### PR TITLE
Daemon emission of tool_executed and skill_loaded telemetry events

### DIFF
--- a/assistant/src/__tests__/conversation-app-control-instantiation.test.ts
+++ b/assistant/src/__tests__/conversation-app-control-instantiation.test.ts
@@ -193,6 +193,19 @@ mock.module("../skills/version-hash.js", () => ({
   },
 }));
 
+// Mock the skill_loaded telemetry dependencies of conversation-skill-tools so
+// their heavy transitive imports (catalog-install → CLI program, sqlite) stay
+// out of this import-light test.
+mock.module("../skills/catalog-cache.js", () => ({
+  getCachedCatalogSync: () => [],
+}));
+mock.module("../skills/install-meta.js", () => ({
+  readInstallMeta: () => null,
+}));
+mock.module("../memory/skill-loaded-events-store.js", () => ({
+  recordSkillLoadedEvent: () => {},
+}));
+
 // ---------------------------------------------------------------------------
 // Imports under test (after mocks)
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/conversation-skill-tools.test.ts
+++ b/assistant/src/__tests__/conversation-skill-tools.test.ts
@@ -2,6 +2,7 @@ import * as realFs from "node:fs";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { SkillSummary, SkillToolManifest } from "../config/skills.js";
+import type { SkillLoadedEventRecord } from "../memory/skill-loaded-events-store.js";
 import { RiskLevel } from "../permissions/types.js";
 import type {
   Message,
@@ -9,7 +10,9 @@ import type {
   ToolResultContent,
   ToolUseContent,
 } from "../providers/types.js";
+import type { SkillInstallMeta } from "../skills/install-meta.js";
 import type { Tool } from "../tools/types.js";
+import type { UsageAttributionSnapshot } from "../usage/attribution.js";
 import { buildSkillLoadHistory } from "./test-support/browser-skill-harness.js";
 
 // ---------------------------------------------------------------------------
@@ -25,6 +28,14 @@ let mockSkillRefCount: Map<string, number> = new Map();
 let mockVersionHashes: Record<string, string> = {};
 /** Skill IDs for which computeSkillVersionHash should throw (simulates unreadable directories). */
 let mockVersionHashErrors: Set<string> = new Set();
+/** Install metadata by skill id (readInstallMeta derives the id from the directory path). */
+let mockInstallMetas: Record<string, SkillInstallMeta | null> = {};
+/** Merged catalog entries returned by getCachedCatalogSync. */
+let mockCachedCatalog: Array<{ id: string; updatedAt?: string }> = [];
+/** skill_loaded events captured by the mocked store. */
+let recordedSkillLoadedEvents: SkillLoadedEventRecord[] = [];
+/** When true, recordSkillLoadedEvent throws (simulates a store failure). */
+let mockRecordSkillLoadedFailure = false;
 
 // ---------------------------------------------------------------------------
 // Mocks — must be set up before importing the module under test
@@ -227,6 +238,27 @@ mock.module("../config/skill-state.js", () => ({
     skill.featureFlag || undefined,
 }));
 
+mock.module("../skills/install-meta.js", () => ({
+  readInstallMeta: (skillDir: string) => {
+    const parts = skillDir.split("/");
+    const skillId = parts[parts.length - 1];
+    return mockInstallMetas[skillId] ?? null;
+  },
+}));
+
+mock.module("../skills/catalog-cache.js", () => ({
+  getCachedCatalogSync: () => mockCachedCatalog,
+}));
+
+mock.module("../memory/skill-loaded-events-store.js", () => ({
+  recordSkillLoadedEvent: (record: SkillLoadedEventRecord) => {
+    if (mockRecordSkillLoadedFailure) {
+      throw new Error("Mock: skill_loaded store failure");
+    }
+    recordedSkillLoadedEvents.push(record);
+  },
+}));
+
 // ---------------------------------------------------------------------------
 // Import module under test (after mocks)
 // ---------------------------------------------------------------------------
@@ -238,7 +270,11 @@ const { projectSkillTools, resetSkillToolProjection } =
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeSkill(id: string, dir?: string): SkillSummary {
+function makeSkill(
+  id: string,
+  dir?: string,
+  source: SkillSummary["source"] = "managed",
+): SkillSummary {
   return {
     id,
     name: id,
@@ -247,7 +283,7 @@ function makeSkill(id: string, dir?: string): SkillSummary {
     directoryPath: dir ?? `/skills/${id}`,
     skillFilePath: `/skills/${id}/SKILL.md`,
 
-    source: "managed",
+    source,
   };
 }
 
@@ -706,6 +742,264 @@ describe("projectSkillTools", () => {
     resetSkillToolProjection(sessionB);
     expect(mockRegisteredTools.has("deploy")).toBe(false);
     expect(mockSkillRefCount.has("deploy")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// skill_loaded telemetry recording
+// ---------------------------------------------------------------------------
+
+describe("skill_loaded telemetry recording", () => {
+  let sessionState: Map<string, string>;
+
+  function makeAttribution(): UsageAttributionSnapshot {
+    return {
+      callSite: "mainAgent",
+      activeProfile: "balanced",
+      overrideProfile: null,
+      callSiteProfile: null,
+      appliedProfile: "balanced",
+      profileSource: "active",
+      resolvedProvider: "test-provider",
+      resolvedModel: "test-model",
+      resolvedMixArm: null,
+    };
+  }
+
+  function makeTelemetry() {
+    return { conversationId: "conv-xyz", attribution: makeAttribution() };
+  }
+
+  beforeEach(() => {
+    mockCatalog = [];
+    mockManifests = {};
+    mockRegisteredTools = new Map();
+    mockUnregisteredSkillIds = [];
+    mockSkillRefCount = new Map();
+    mockVersionHashes = {};
+    mockVersionHashErrors = new Set();
+    mockInstallMetas = {};
+    mockCachedCatalog = [];
+    recordedSkillLoadedEvents = [];
+    mockRecordSkillLoadedFailure = false;
+    sessionState = new Map<string, string>();
+  });
+
+  test("bundled skill activation records an event with attribution and catalog updatedAt", () => {
+    mockCatalog = [makeSkill("notes", undefined, "bundled")];
+    mockManifests = { notes: makeManifest(["notes_add"]) };
+    mockCachedCatalog = [{ id: "notes", updatedAt: "2026-01-02T03:04:05Z" }];
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="notes" />'),
+    ];
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+
+    expect(recordedSkillLoadedEvents).toHaveLength(1);
+    expect(recordedSkillLoadedEvents[0]).toEqual({
+      conversationId: "conv-xyz",
+      skillName: "notes",
+      skillUpdatedAt: "2026-01-02T03:04:05Z",
+      provider: "test-provider",
+      model: "test-model",
+      inferenceProfile: "balanced",
+      inferenceProfileSource: "active",
+    });
+  });
+
+  test("managed skill with vellum install origin records an event", () => {
+    mockCatalog = [makeSkill("deploy")];
+    mockManifests = { deploy: makeManifest(["deploy_run"]) };
+    mockInstallMetas = {
+      deploy: { origin: "vellum", installedAt: "2026-01-01T00:00:00Z" },
+    };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="deploy" />'),
+    ];
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+
+    expect(recordedSkillLoadedEvents).toHaveLength(1);
+    expect(recordedSkillLoadedEvents[0].skillName).toBe("deploy");
+  });
+
+  test("managed skill with clawhub or custom origin does NOT record", () => {
+    mockCatalog = [makeSkill("third-party"), makeSkill("homemade")];
+    mockManifests = {
+      "third-party": makeManifest(["tp_run"]),
+      homemade: makeManifest(["hm_run"]),
+    };
+    mockInstallMetas = {
+      "third-party": {
+        origin: "clawhub",
+        installedAt: "2026-01-01T00:00:00Z",
+      },
+      homemade: { origin: "custom", installedAt: "2026-01-01T00:00:00Z" },
+    };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="third-party" />'),
+      ...skillLoadMessages('<loaded_skill id="homemade" />'),
+    ];
+    const result = projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+
+    expect(recordedSkillLoadedEvents).toHaveLength(0);
+    // Tool projection itself is unaffected
+    expect(result.allowedToolNames).toEqual(new Set(["tp_run", "hm_run"]));
+  });
+
+  test("managed skill without install metadata does NOT record", () => {
+    mockCatalog = [makeSkill("deploy")];
+    mockManifests = { deploy: makeManifest(["deploy_run"]) };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="deploy" />'),
+    ];
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+
+    expect(recordedSkillLoadedEvents).toHaveLength(0);
+  });
+
+  test("workspace skill does NOT record", () => {
+    mockCatalog = [makeSkill("local-helper", undefined, "workspace")];
+    mockManifests = { "local-helper": makeManifest(["lh_run"]) };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="local-helper" />'),
+    ];
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+
+    expect(recordedSkillLoadedEvents).toHaveLength(0);
+  });
+
+  test("second turn with the skill still active does NOT re-record", () => {
+    mockCatalog = [makeSkill("notes", undefined, "bundled")];
+    mockManifests = { notes: makeManifest(["notes_add"]) };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="notes" />'),
+    ];
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+
+    expect(recordedSkillLoadedEvents).toHaveLength(1);
+  });
+
+  test("version-hash change that re-registers counts as a new load", () => {
+    mockCatalog = [makeSkill("notes", undefined, "bundled")];
+    mockManifests = { notes: makeManifest(["notes_add"]) };
+    mockVersionHashes = { notes: "v1:hash-aaa" };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="notes" />'),
+    ];
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+
+    mockVersionHashes = { notes: "v1:hash-bbb" };
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+
+    expect(recordedSkillLoadedEvents).toHaveLength(2);
+  });
+
+  test("catalog miss yields undefined skillUpdatedAt (persisted as null)", () => {
+    mockCatalog = [makeSkill("notes", undefined, "bundled")];
+    mockManifests = { notes: makeManifest(["notes_add"]) };
+    mockCachedCatalog = []; // no merged-catalog entry for "notes"
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="notes" />'),
+    ];
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+
+    expect(recordedSkillLoadedEvents).toHaveLength(1);
+    expect(recordedSkillLoadedEvents[0].skillUpdatedAt).toBeUndefined();
+  });
+
+  test("null attribution records the event without model fields", () => {
+    mockCatalog = [makeSkill("notes", undefined, "bundled")];
+    mockManifests = { notes: makeManifest(["notes_add"]) };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="notes" />'),
+    ];
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: { conversationId: "conv-xyz", attribution: null },
+    });
+
+    expect(recordedSkillLoadedEvents).toHaveLength(1);
+    expect(recordedSkillLoadedEvents[0]).toEqual({
+      conversationId: "conv-xyz",
+      skillName: "notes",
+      skillUpdatedAt: undefined,
+      provider: undefined,
+      model: undefined,
+      inferenceProfile: undefined,
+      inferenceProfileSource: undefined,
+    });
+  });
+
+  test("store failure does not throw out of projectSkillTools", () => {
+    mockCatalog = [makeSkill("notes", undefined, "bundled")];
+    mockManifests = { notes: makeManifest(["notes_add"]) };
+    mockRecordSkillLoadedFailure = true;
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="notes" />'),
+    ];
+    const result = projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+
+    // Tool projection behavior is unchanged when recording fails
+    expect(result.allowedToolNames.has("notes_add")).toBe(true);
+    expect(sessionState.has("notes")).toBe(true);
+  });
+
+  test("absent telemetry context disables recording entirely", () => {
+    mockCatalog = [makeSkill("notes", undefined, "bundled")];
+    mockManifests = { notes: makeManifest(["notes_add"]) };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="notes" />'),
+    ];
+    const result = projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+    });
+
+    expect(recordedSkillLoadedEvents).toHaveLength(0);
+    expect(result.allowedToolNames.has("notes_add")).toBe(true);
   });
 });
 

--- a/assistant/src/__tests__/conversation-skill-tools.test.ts
+++ b/assistant/src/__tests__/conversation-skill-tools.test.ts
@@ -579,34 +579,6 @@ describe("projectSkillTools", () => {
     expect(mockSkillRefCount.get("deploy")).toBe(1);
   });
 
-  test("registration failure is contained and the skill is retried on the next turn", () => {
-    mockCatalog = [makeSkill("deploy")];
-    mockManifests = { deploy: makeManifest(["deploy_run"]) };
-    mockRegisterFailures = new Set(["deploy"]);
-
-    const history: Message[] = [
-      ...skillLoadMessages('<loaded_skill id="deploy" />'),
-    ];
-
-    // Turn 1: registerSkillTools throws — projection continues without the
-    // skill, leaves it untracked, and never touches unregisterSkillTools.
-    const result1 = projectSkillTools(history, {
-      previouslyActiveSkillIds: sessionState,
-    });
-    expect(result1.allowedToolNames.size).toBe(0);
-    expect(sessionState.has("deploy")).toBe(false);
-    expect(mockUnregisteredSkillIds).toEqual([]);
-
-    // Turn 2: registration recovers — registered with a balanced refcount.
-    mockRegisterFailures = new Set();
-    const result2 = projectSkillTools(history, {
-      previouslyActiveSkillIds: sessionState,
-    });
-    expect(result2.allowedToolNames.has("deploy_run")).toBe(true);
-    expect(sessionState.has("deploy")).toBe(true);
-    expect(mockSkillRefCount.get("deploy")).toBe(1);
-  });
-
   test("skill version hash change triggers unregister and re-register", () => {
     mockCatalog = [makeSkill("deploy")];
     mockManifests = { deploy: makeManifest(["deploy_run"]) };
@@ -994,6 +966,7 @@ describe("skill_loaded telemetry recording", () => {
     expect(recordedSkillLoadedEvents).toHaveLength(1);
     expect(recordedSkillLoadedEvents[0].skillName).toBe("notes");
     expect(result2.allowedToolNames.has("notes_add")).toBe(true);
+    expect(sessionState.has("notes")).toBe(true);
     expect(mockSkillRefCount.get("notes")).toBe(1);
   });
 

--- a/assistant/src/__tests__/conversation-skill-tools.test.ts
+++ b/assistant/src/__tests__/conversation-skill-tools.test.ts
@@ -521,7 +521,9 @@ describe("projectSkillTools", () => {
       previouslyActiveSkillIds: sessionState,
     });
     expect(result1.toolDefinitions).toEqual([]);
-    expect(sessionState.has("deploy")).toBe(false);
+    // Tracked as a manifest-less activation — no tools registered yet.
+    expect(sessionState.has("deploy")).toBe(true);
+    expect(mockRegisteredTools.has("deploy")).toBe(false);
 
     // Turn 2: manifest now available
     mockManifests = { deploy: makeManifest(["deploy_run"]) };
@@ -548,11 +550,12 @@ describe("projectSkillTools", () => {
     expect(sessionState.has("deploy")).toBe(true);
     expect(mockSkillRefCount.get("deploy")).toBe(1);
 
-    // Turn 2: manifest transiently fails — skill should be unregistered
+    // Turn 2: manifest transiently fails — tools should be unregistered
+    // (the skill stays tracked as a manifest-less activation)
     mockManifests = {};
     mockUnregisteredSkillIds = [];
     projectSkillTools(history, { previouslyActiveSkillIds: sessionState });
-    expect(sessionState.has("deploy")).toBe(false);
+    expect(sessionState.has("deploy")).toBe(true);
     expect(mockUnregisteredSkillIds).toContain("deploy");
     // Ref count should be 0 (properly decremented)
     expect(mockSkillRefCount.has("deploy")).toBe(false);
@@ -985,6 +988,115 @@ describe("skill_loaded telemetry recording", () => {
     // Tool projection behavior is unchanged when recording fails
     expect(result.allowedToolNames.has("notes_add")).toBe(true);
     expect(sessionState.has("notes")).toBe(true);
+  });
+
+  test("instruction-only bundled skill (no TOOLS.json) records exactly one event", () => {
+    mockCatalog = [makeSkill("guides", undefined, "bundled")];
+    // No manifest registered for "guides" — instruction-only skill.
+    mockCachedCatalog = [{ id: "guides", updatedAt: "2026-02-03T04:05:06Z" }];
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="guides" />'),
+    ];
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+
+    expect(recordedSkillLoadedEvents).toHaveLength(1);
+    expect(recordedSkillLoadedEvents[0]).toEqual({
+      conversationId: "conv-xyz",
+      skillName: "guides",
+      skillUpdatedAt: "2026-02-03T04:05:06Z",
+      provider: "test-provider",
+      model: "test-model",
+      inferenceProfile: "balanced",
+      inferenceProfileSource: "active",
+    });
+
+    // Still active next turn — no re-record.
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+    expect(recordedSkillLoadedEvents).toHaveLength(1);
+  });
+
+  test("instruction-only managed skill with vellum origin records exactly one event", () => {
+    mockCatalog = [makeSkill("catalog-skill")];
+    // No manifest — mirrors installSkillLocally output for catalog skills.
+    mockInstallMetas = {
+      "catalog-skill": {
+        origin: "vellum",
+        installedAt: "2026-01-01T00:00:00Z",
+      },
+    };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="catalog-skill" />'),
+    ];
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+
+    expect(recordedSkillLoadedEvents).toHaveLength(1);
+    expect(recordedSkillLoadedEvents[0].skillName).toBe("catalog-skill");
+  });
+
+  test("instruction-only non-Vellum skills never record", () => {
+    mockCatalog = [
+      makeSkill("local-notes", undefined, "workspace"),
+      makeSkill("homemade"),
+    ];
+    // No manifests for either skill.
+    mockInstallMetas = {
+      homemade: { origin: "custom", installedAt: "2026-01-01T00:00:00Z" },
+    };
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="local-notes" />'),
+      ...skillLoadMessages('<loaded_skill id="homemade" />'),
+    ];
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+
+    expect(recordedSkillLoadedEvents).toHaveLength(0);
+  });
+
+  test("instruction-only skill re-records after deactivation and reactivation, without touching the registry", () => {
+    mockCatalog = [makeSkill("guides", undefined, "bundled")];
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="guides" />'),
+    ];
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+    expect(recordedSkillLoadedEvents).toHaveLength(1);
+
+    // Deactivated: marker gone. No tools were ever registered for it, so the
+    // registry must not be touched (refcounts belong to other conversations).
+    mockUnregisteredSkillIds = [];
+    projectSkillTools([], {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+    expect(mockUnregisteredSkillIds).not.toContain("guides");
+
+    // Reactivated: a fresh activation is a new load.
+    projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+    expect(recordedSkillLoadedEvents).toHaveLength(2);
   });
 
   test("absent telemetry context disables recording entirely", () => {
@@ -2306,6 +2418,27 @@ describe("resetSkillToolProjection", () => {
 
     expect(mockUnregisteredSkillIds).toContain("deploy");
     expect(mockUnregisteredSkillIds).toContain("oncall");
+    expect(trackedIds.size).toBe(0);
+  });
+
+  test("manifest-less tracked skills are cleared without touching the registry", () => {
+    mockCatalog = [makeSkill("deploy"), makeSkill("guides")];
+    // Only deploy has tools; guides is instruction-only.
+    mockManifests = { deploy: makeManifest(["deploy_run"]) };
+
+    const trackedIds = new Map<string, string>();
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="deploy" />'),
+      ...skillLoadMessages('<loaded_skill id="guides" />'),
+    ];
+    projectSkillTools(history, { previouslyActiveSkillIds: trackedIds });
+    expect(trackedIds.size).toBe(2);
+
+    mockUnregisteredSkillIds = [];
+    resetSkillToolProjection(trackedIds);
+
+    expect(mockUnregisteredSkillIds).toContain("deploy");
+    expect(mockUnregisteredSkillIds).not.toContain("guides");
     expect(trackedIds.size).toBe(0);
   });
 

--- a/assistant/src/__tests__/conversation-skill-tools.test.ts
+++ b/assistant/src/__tests__/conversation-skill-tools.test.ts
@@ -36,6 +36,8 @@ let mockCachedCatalog: Array<{ id: string; updatedAt?: string }> = [];
 let recordedSkillLoadedEvents: SkillLoadedEventRecord[] = [];
 /** When true, recordSkillLoadedEvent throws (simulates a store failure). */
 let mockRecordSkillLoadedFailure = false;
+/** Skill IDs for which registerSkillTools throws (simulates a different-owner tool name collision). */
+let mockRegisterFailures: Set<string> = new Set();
 
 // ---------------------------------------------------------------------------
 // Mocks — must be set up before importing the module under test
@@ -128,6 +130,9 @@ mock.module("../tools/registry.js", () => ({
   // skillId comes from the caller (conversation-skill-tools) and is the
   // sole source of truth for ownership.
   registerSkillTools: (skillId: string, tools: Tool[]) => {
+    if (mockRegisterFailures.has(skillId)) {
+      throw new Error(`Mock: tool name collision for skill "${skillId}"`);
+    }
     const existing = mockRegisteredTools.get(skillId) ?? [];
     existing.push(...tools);
     mockRegisteredTools.set(skillId, existing);
@@ -342,6 +347,7 @@ describe("projectSkillTools", () => {
     mockSkillRefCount = new Map();
     mockVersionHashes = {};
     mockVersionHashErrors = new Set();
+    mockRegisterFailures = new Set();
     sessionState = new Map<string, string>();
   });
 
@@ -573,6 +579,34 @@ describe("projectSkillTools", () => {
     expect(mockSkillRefCount.get("deploy")).toBe(1);
   });
 
+  test("registration failure is contained and the skill is retried on the next turn", () => {
+    mockCatalog = [makeSkill("deploy")];
+    mockManifests = { deploy: makeManifest(["deploy_run"]) };
+    mockRegisterFailures = new Set(["deploy"]);
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="deploy" />'),
+    ];
+
+    // Turn 1: registerSkillTools throws — projection continues without the
+    // skill, leaves it untracked, and never touches unregisterSkillTools.
+    const result1 = projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+    });
+    expect(result1.allowedToolNames.size).toBe(0);
+    expect(sessionState.has("deploy")).toBe(false);
+    expect(mockUnregisteredSkillIds).toEqual([]);
+
+    // Turn 2: registration recovers — registered with a balanced refcount.
+    mockRegisterFailures = new Set();
+    const result2 = projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+    });
+    expect(result2.allowedToolNames.has("deploy_run")).toBe(true);
+    expect(sessionState.has("deploy")).toBe(true);
+    expect(mockSkillRefCount.get("deploy")).toBe(1);
+  });
+
   test("skill version hash change triggers unregister and re-register", () => {
     mockCatalog = [makeSkill("deploy")];
     mockManifests = { deploy: makeManifest(["deploy_run"]) };
@@ -785,6 +819,7 @@ describe("skill_loaded telemetry recording", () => {
     mockCachedCatalog = [];
     recordedSkillLoadedEvents = [];
     mockRecordSkillLoadedFailure = false;
+    mockRegisterFailures = new Set();
     sessionState = new Map<string, string>();
   });
 
@@ -931,6 +966,57 @@ describe("skill_loaded telemetry recording", () => {
     expect(recordedSkillLoadedEvents).toHaveLength(2);
   });
 
+  test("registration that throws on turn 1 and succeeds on turn 2 records exactly one row total", () => {
+    mockCatalog = [makeSkill("notes", undefined, "bundled")];
+    mockManifests = { notes: makeManifest(["notes_add"]) };
+    mockRegisterFailures = new Set(["notes"]);
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="notes" />'),
+    ];
+
+    // Turn 1: registration throws — no row, no tracking, registry untouched.
+    const result1 = projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+    expect(recordedSkillLoadedEvents).toHaveLength(0);
+    expect(result1.allowedToolNames.size).toBe(0);
+    expect(sessionState.has("notes")).toBe(false);
+    expect(mockUnregisteredSkillIds).toEqual([]);
+
+    // Turn 2: registration succeeds — the load is recorded exactly once.
+    mockRegisterFailures = new Set();
+    const result2 = projectSkillTools(history, {
+      previouslyActiveSkillIds: sessionState,
+      telemetry: makeTelemetry(),
+    });
+    expect(recordedSkillLoadedEvents).toHaveLength(1);
+    expect(recordedSkillLoadedEvents[0].skillName).toBe("notes");
+    expect(result2.allowedToolNames.has("notes_add")).toBe(true);
+    expect(mockSkillRefCount.get("notes")).toBe(1);
+  });
+
+  test("persistently failing registration never duplicates skill_loaded rows across turns", () => {
+    mockCatalog = [makeSkill("notes", undefined, "bundled")];
+    mockManifests = { notes: makeManifest(["notes_add"]) };
+    mockRegisterFailures = new Set(["notes"]);
+
+    const history: Message[] = [
+      ...skillLoadMessages('<loaded_skill id="notes" />'),
+    ];
+
+    for (let turn = 1; turn <= 3; turn++) {
+      projectSkillTools(history, {
+        previouslyActiveSkillIds: sessionState,
+        telemetry: makeTelemetry(),
+      });
+    }
+
+    expect(recordedSkillLoadedEvents).toHaveLength(0);
+    expect(mockUnregisteredSkillIds).toEqual([]);
+  });
+
   test("catalog miss yields undefined skillUpdatedAt (persisted as null)", () => {
     mockCatalog = [makeSkill("notes", undefined, "bundled")];
     mockManifests = { notes: makeManifest(["notes_add"]) };
@@ -965,10 +1051,10 @@ describe("skill_loaded telemetry recording", () => {
       conversationId: "conv-xyz",
       skillName: "notes",
       skillUpdatedAt: undefined,
-      provider: undefined,
-      model: undefined,
-      inferenceProfile: undefined,
-      inferenceProfileSource: undefined,
+      provider: null,
+      model: null,
+      inferenceProfile: null,
+      inferenceProfileSource: null,
     });
   });
 

--- a/assistant/src/__tests__/conversation-store.test.ts
+++ b/assistant/src/__tests__/conversation-store.test.ts
@@ -17,6 +17,7 @@ import {
   addMessage,
   clearAll,
   createConversation,
+  deleteConversation,
   deleteLastExchange,
   getConversation,
   getMessages,
@@ -24,6 +25,7 @@ import {
 import { isLastUserMessageToolResult } from "../memory/conversation-queries.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
+import { skillLoadedEvents } from "../memory/schema.js";
 // Initialize db once before all tests
 initializeDb();
 
@@ -349,6 +351,78 @@ describe("attachment orphan cleanup", () => {
       .get() as { c: number };
     expect(attachmentCount.c).toBe(0);
     expect(linkCount.c).toBe(0);
+  });
+
+  test("clearAll removes skill_loaded_events", async () => {
+    // Privacy posture: Clear All wins over unflushed telemetry — the
+    // skill_loaded_events rows (conversation id, skill name, model
+    // attribution) must not survive the wipe and ship later.
+    getDb().delete(skillLoadedEvents).run();
+    const conv = createConversation("test");
+    getDb()
+      .insert(skillLoadedEvents)
+      .values([
+        {
+          id: "sle-clear-1",
+          createdAt: 1000,
+          conversationId: conv.id,
+          skillName: "web-research",
+        },
+        // Rows without a conversation are wiped too.
+        { id: "sle-clear-2", createdAt: 2000, skillName: "tasks" },
+      ])
+      .run();
+
+    await clearAll();
+
+    expect(getDb().select().from(skillLoadedEvents).all()).toHaveLength(0);
+  });
+
+  test("deleteConversation removes that conversation's skill_loaded_events", async () => {
+    getDb().delete(skillLoadedEvents).run();
+    const conv = createConversation("doomed");
+    await addMessage(conv.id, "user", "hello");
+    const other = createConversation("kept");
+    getDb()
+      .insert(skillLoadedEvents)
+      .values([
+        {
+          id: "sle-del-1",
+          createdAt: 1000,
+          conversationId: conv.id,
+          skillName: "web-research",
+        },
+        {
+          id: "sle-del-2",
+          createdAt: 2000,
+          conversationId: other.id,
+          skillName: "tasks",
+        },
+      ])
+      .run();
+
+    deleteConversation(conv.id);
+
+    const remaining = getDb().select().from(skillLoadedEvents).all();
+    expect(remaining.map((r) => r.id)).toEqual(["sle-del-2"]);
+  });
+
+  test("deleteConversation removes skill_loaded_events when the conversation has no messages", () => {
+    getDb().delete(skillLoadedEvents).run();
+    const conv = createConversation("empty");
+    getDb()
+      .insert(skillLoadedEvents)
+      .values({
+        id: "sle-del-empty",
+        createdAt: 1000,
+        conversationId: conv.id,
+        skillName: "web-research",
+      })
+      .run();
+
+    deleteConversation(conv.id);
+
+    expect(getDb().select().from(skillLoadedEvents).all()).toHaveLength(0);
   });
 
   test("deleteLastExchange does not delete unlinked user uploads", async () => {

--- a/assistant/src/__tests__/conversation-tool-setup-attribution.test.ts
+++ b/assistant/src/__tests__/conversation-tool-setup-attribution.test.ts
@@ -1,0 +1,382 @@
+/**
+ * Tests for conversation model attribution threading in
+ * conversation-tool-setup.ts: `resolveConversationAttribution` must mirror
+ * the agent-loop usage path (the current turn's call site — defaulting to
+ * mainAgent — plus the per-turn override profile), `createToolExecutor`
+ * must stamp the snapshot onto the ToolContext handed to the executor, and
+ * attribution resolution failures must never break tool execution.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { ToolSetupContext } from "../daemon/conversation-tool-setup.js";
+import type { SurfaceData, SurfaceType } from "../daemon/message-protocol.js";
+import type { PermissionPrompter } from "../permissions/prompter.js";
+import type { SecretPrompter } from "../permissions/secret-prompter.js";
+import type { ToolExecutor } from "../tools/executor.js";
+import type { ToolContext, ToolExecutionResult } from "../tools/types.js";
+
+// ---------------------------------------------------------------------------
+// Module mocks (must precede the import of the module under test)
+// ---------------------------------------------------------------------------
+
+let mockLlmConfig: Record<string, unknown> = {};
+let configThrows = false;
+
+// Non-llm fields used by other conversation-tool-setup consumers (e.g.
+// createResolveToolsCallback reads `tools.exclude`), so test files sharing
+// this process keep working against the mocked loader.
+const baseConfig = {
+  tools: { exclude: [] as string[] },
+  timeouts: {
+    shellDefaultTimeoutSec: 120,
+    shellMaxTimeoutSec: 600,
+    permissionTimeoutSec: 300,
+    toolExecutionTimeoutSec: 600,
+  },
+  services: {},
+};
+
+function mockGetConfig() {
+  if (configThrows) throw new Error("config unavailable");
+  return { ...baseConfig, llm: mockLlmConfig };
+}
+
+mock.module("../config/loader.js", () => ({
+  getConfig: mockGetConfig,
+  loadConfig: mockGetConfig,
+  invalidateConfigCache: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+}));
+
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  broadcastMessage: mock(() => {}),
+}));
+
+mock.module("../daemon/conversation-surfaces.js", () => ({
+  refreshSurfacesForApp: mock(() => {}),
+  surfaceProxyResolver: mock(() =>
+    Promise.resolve({ content: "", isError: false }),
+  ),
+}));
+
+mock.module("../services/published-app-updater.js", () => ({
+  updatePublishedAppDeployment: mock(() => Promise.resolve()),
+}));
+
+mock.module("../tools/browser/browser-screencast.js", () => ({
+  registerConversationSender: mock(() => {}),
+}));
+
+mock.module("../memory/app-store.js", () => ({
+  getApp: mock(() => null),
+  getAppDirPath: mock(() => "/tmp/test-apps/dummy"),
+  isMultifileApp: mock(() => false),
+  getAppsDir: mock(() => "/tmp/test-apps"),
+  resolveAppIdByDirName: mock(() => null),
+  resolveAppIdFromPath: mock(() => null),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks are in place
+// ---------------------------------------------------------------------------
+
+import { LLMSchema } from "../config/schemas/llm.js";
+import {
+  createToolExecutor,
+  resolveConversationAttribution,
+} from "../daemon/conversation-tool-setup.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setLlmConfig(raw: unknown): void {
+  mockLlmConfig = LLMSchema.parse(raw) as Record<string, unknown>;
+}
+
+/** Build a minimal ToolSetupContext stub. */
+function makeCtx(overrides: Partial<ToolSetupContext> = {}): ToolSetupContext {
+  return {
+    conversationId: "conv-test",
+    currentRequestId: "req-1",
+    workingDir: "/tmp/test",
+    abortController: null,
+    traceEmitter: { emit: () => {} },
+    sendToClient: mock(() => {}),
+    pendingSurfaceActions: new Map(),
+    lastSurfaceAction: new Map(),
+    surfaceState: new Map<
+      string,
+      { surfaceType: SurfaceType; data: SurfaceData; title?: string }
+    >(),
+    surfaceUndoStacks: new Map(),
+    accumulatedSurfaceState: new Map(),
+    surfaceActionRequestIds: new Set<string>(),
+    currentTurnSurfaces: [],
+    isProcessing: () => false,
+    enqueueMessage: () => ({ queued: false, requestId: "r" }),
+    getQueueDepth: () => 0,
+    processMessage: async () => "",
+    withSurface: async <T>(_id: string, fn: () => T | Promise<T>) => fn(),
+    ...overrides,
+  };
+}
+
+/** Fake ToolExecutor that captures the context of each execute() call. */
+function makeCapturingExecutor() {
+  const calls: Array<{ name: string; context: ToolContext }> = [];
+  const executor = {
+    execute: async (
+      name: string,
+      _input: Record<string, unknown>,
+      context: ToolContext,
+    ): Promise<ToolExecutionResult> => {
+      calls.push({ name, context });
+      return { content: "ok", isError: false };
+    },
+  };
+  return { executor: executor as unknown as ToolExecutor, calls };
+}
+
+const noopPrompter = {
+  prompt: mock(async () => ({ decision: "allow" as const })),
+} as unknown as PermissionPrompter;
+const noopSecretPrompter = {
+  prompt: mock(async () => ({ cancelled: true })),
+} as unknown as SecretPrompter;
+
+function makeToolFn(executor: ToolExecutor, ctx: ToolSetupContext) {
+  return createToolExecutor(
+    executor,
+    noopPrompter,
+    noopSecretPrompter,
+    ctx,
+    () => {},
+  );
+}
+
+// The module mock outlives this file when multiple test files share a
+// process, so leave the config in a working (non-throwing) state.
+afterEach(() => {
+  configThrows = false;
+});
+
+beforeEach(() => {
+  configThrows = false;
+  setLlmConfig({
+    default: { provider: "anthropic", model: "model-default" },
+    profiles: {
+      active: { provider: "openai", model: "model-active" },
+      pinned: { provider: "gemini", model: "model-pinned" },
+    },
+    activeProfile: "active",
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("resolveConversationAttribution", () => {
+  test("attributes the conversation's override profile like the main-loop usage path", () => {
+    const snapshot = resolveConversationAttribution({
+      conversationId: "conv-test",
+      currentTurnOverrideProfile: "pinned",
+    });
+
+    expect(snapshot).toMatchObject({
+      callSite: "mainAgent",
+      activeProfile: "active",
+      overrideProfile: "pinned",
+      appliedProfile: "pinned",
+      profileSource: "conversation",
+      resolvedProvider: "gemini",
+      resolvedModel: "model-pinned",
+    });
+  });
+
+  test("falls back to the workspace active profile when no override is set", () => {
+    const snapshot = resolveConversationAttribution({
+      conversationId: "conv-test",
+    });
+
+    expect(snapshot).toMatchObject({
+      callSite: "mainAgent",
+      overrideProfile: null,
+      appliedProfile: "active",
+      profileSource: "active",
+      resolvedProvider: "openai",
+      resolvedModel: "model-active",
+    });
+  });
+
+  test("attributes non-main turns to the turn call site like the usage path (voice callAgent)", () => {
+    setLlmConfig({
+      default: { provider: "anthropic", model: "model-default" },
+      profiles: {
+        active: { provider: "openai", model: "model-active" },
+        pinned: { provider: "gemini", model: "model-pinned" },
+      },
+      activeProfile: "active",
+      callSites: { callAgent: { profile: "pinned" } },
+    });
+
+    const snapshot = resolveConversationAttribution({
+      conversationId: "conv-test",
+      currentCallSite: "callAgent",
+    });
+
+    // Matches resolveUsageAttribution semantics for non-main call sites:
+    // the call-site profile wins (profileSource "call_site"), not the
+    // workspace active profile the mainAgent path would report.
+    expect(snapshot).toMatchObject({
+      callSite: "callAgent",
+      activeProfile: "active",
+      callSiteProfile: "pinned",
+      appliedProfile: "pinned",
+      profileSource: "call_site",
+      resolvedProvider: "gemini",
+      resolvedModel: "model-pinned",
+    });
+  });
+
+  test("non-main call sites prefer the call-site profile over the conversation override", () => {
+    setLlmConfig({
+      default: { provider: "anthropic", model: "model-default" },
+      profiles: {
+        active: { provider: "openai", model: "model-active" },
+        pinned: { provider: "gemini", model: "model-pinned" },
+      },
+      activeProfile: "active",
+      callSites: { callAgent: { profile: "pinned" } },
+    });
+
+    const snapshot = resolveConversationAttribution({
+      conversationId: "conv-test",
+      currentCallSite: "callAgent",
+      currentTurnOverrideProfile: "active",
+    });
+
+    expect(snapshot).toMatchObject({
+      callSite: "callAgent",
+      overrideProfile: "active",
+      callSiteProfile: "pinned",
+      appliedProfile: "pinned",
+      profileSource: "call_site",
+      resolvedProvider: "gemini",
+      resolvedModel: "model-pinned",
+    });
+  });
+
+  test("resolves profileSource default when no profiles apply", () => {
+    setLlmConfig({
+      default: { provider: "anthropic", model: "model-default" },
+    });
+
+    const snapshot = resolveConversationAttribution({
+      conversationId: "conv-test",
+    });
+
+    expect(snapshot).toMatchObject({
+      appliedProfile: null,
+      profileSource: "default",
+      resolvedProvider: "anthropic",
+      resolvedModel: "model-default",
+    });
+  });
+
+  test("returns null instead of throwing when resolution fails", () => {
+    configThrows = true;
+
+    expect(
+      resolveConversationAttribution({ conversationId: "conv-test" }),
+    ).toBeNull();
+  });
+});
+
+describe("createToolExecutor attribution threading", () => {
+  test("stamps the attribution snapshot onto the ToolContext for direct tool calls", async () => {
+    const { executor, calls } = makeCapturingExecutor();
+    const toolFn = makeToolFn(
+      executor,
+      makeCtx({ currentTurnOverrideProfile: "pinned" }),
+    );
+
+    const result = await toolFn("file_read", { path: "/tmp/a" });
+
+    expect(result).toMatchObject({ content: "ok", isError: false });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].context.attribution).toMatchObject({
+      callSite: "mainAgent",
+      appliedProfile: "pinned",
+      profileSource: "conversation",
+      resolvedProvider: "gemini",
+      resolvedModel: "model-pinned",
+    });
+  });
+
+  test("threads a non-main turn call site (voice callAgent) into the snapshot", async () => {
+    setLlmConfig({
+      default: { provider: "anthropic", model: "model-default" },
+      profiles: {
+        active: { provider: "openai", model: "model-active" },
+        pinned: { provider: "gemini", model: "model-pinned" },
+      },
+      activeProfile: "active",
+      callSites: { callAgent: { profile: "pinned" } },
+    });
+
+    const { executor, calls } = makeCapturingExecutor();
+    const toolFn = makeToolFn(
+      executor,
+      makeCtx({ currentCallSite: "callAgent" }),
+    );
+
+    await toolFn("file_read", { path: "/tmp/a" });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].context.attribution).toMatchObject({
+      callSite: "callAgent",
+      appliedProfile: "pinned",
+      profileSource: "call_site",
+      resolvedProvider: "gemini",
+      resolvedModel: "model-pinned",
+    });
+  });
+
+  test("stamps the attribution snapshot onto skill_execute dispatches", async () => {
+    const { executor, calls } = makeCapturingExecutor();
+    const toolFn = makeToolFn(executor, makeCtx());
+
+    await toolFn("skill_execute", {
+      tool: "file_read",
+      input: { path: "/tmp/a" },
+      activity: "testing",
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].name).toBe("file_read");
+    expect(calls[0].context.attribution).toMatchObject({
+      callSite: "mainAgent",
+      appliedProfile: "active",
+      profileSource: "active",
+    });
+  });
+
+  test("attribution resolution failure yields null and does not break tool execution", async () => {
+    configThrows = true;
+
+    const { executor, calls } = makeCapturingExecutor();
+    const toolFn = makeToolFn(executor, makeCtx());
+
+    const result = await toolFn("file_read", { path: "/tmp/a" });
+
+    expect(result).toMatchObject({ content: "ok", isError: false });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].context.attribution).toBeNull();
+  });
+});

--- a/assistant/src/__tests__/conversation-tool-setup-attribution.test.ts
+++ b/assistant/src/__tests__/conversation-tool-setup-attribution.test.ts
@@ -181,24 +181,10 @@ beforeEach(() => {
 // Tests
 // ---------------------------------------------------------------------------
 
+// Precedence semantics (override/active/call-site/default) are owned by
+// resolveUsageAttribution and covered in usage-attribution.test.ts; the
+// tests here only exercise what the wrapper adds on top.
 describe("resolveConversationAttribution", () => {
-  test("attributes the conversation's override profile like the main-loop usage path", () => {
-    const snapshot = resolveConversationAttribution({
-      conversationId: "conv-test",
-      currentTurnOverrideProfile: "pinned",
-    });
-
-    expect(snapshot).toMatchObject({
-      callSite: "mainAgent",
-      activeProfile: "active",
-      overrideProfile: "pinned",
-      appliedProfile: "pinned",
-      profileSource: "conversation",
-      resolvedProvider: "gemini",
-      resolvedModel: "model-pinned",
-    });
-  });
-
   test("falls back to the workspace active profile when no override is set", () => {
     const snapshot = resolveConversationAttribution({
       conversationId: "conv-test",
@@ -241,51 +227,6 @@ describe("resolveConversationAttribution", () => {
       profileSource: "call_site",
       resolvedProvider: "gemini",
       resolvedModel: "model-pinned",
-    });
-  });
-
-  test("non-main call sites prefer the call-site profile over the conversation override", () => {
-    setLlmConfig({
-      default: { provider: "anthropic", model: "model-default" },
-      profiles: {
-        active: { provider: "openai", model: "model-active" },
-        pinned: { provider: "gemini", model: "model-pinned" },
-      },
-      activeProfile: "active",
-      callSites: { callAgent: { profile: "pinned" } },
-    });
-
-    const snapshot = resolveConversationAttribution({
-      conversationId: "conv-test",
-      currentCallSite: "callAgent",
-      currentTurnOverrideProfile: "active",
-    });
-
-    expect(snapshot).toMatchObject({
-      callSite: "callAgent",
-      overrideProfile: "active",
-      callSiteProfile: "pinned",
-      appliedProfile: "pinned",
-      profileSource: "call_site",
-      resolvedProvider: "gemini",
-      resolvedModel: "model-pinned",
-    });
-  });
-
-  test("resolves profileSource default when no profiles apply", () => {
-    setLlmConfig({
-      default: { provider: "anthropic", model: "model-default" },
-    });
-
-    const snapshot = resolveConversationAttribution({
-      conversationId: "conv-test",
-    });
-
-    expect(snapshot).toMatchObject({
-      appliedProfile: null,
-      profileSource: "default",
-      resolvedProvider: "anthropic",
-      resolvedModel: "model-default",
     });
   });
 

--- a/assistant/src/__tests__/prune-old-conversations-job.test.ts
+++ b/assistant/src/__tests__/prune-old-conversations-job.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Silence the logger.
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import type { AssistantConfig } from "../config/schema.js";
+import { getDb } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
+import { pruneOldConversationsJob } from "../memory/job-handlers/cleanup.js";
+import type { MemoryJob } from "../memory/jobs-store.js";
+import {
+  conversations,
+  skillLoadedEvents,
+  toolInvocations,
+} from "../memory/schema.js";
+
+initializeDb();
+
+const STALE_ID = "conv-prune-job-stale";
+const FRESH_ID = "conv-prune-job-fresh";
+
+const JOB = { payload: {} } as unknown as MemoryJob;
+const CONFIG = {
+  memory: { cleanup: { conversationRetentionDays: 30 } },
+} as unknown as AssistantConfig;
+
+function seedConversation(id: string, updatedAt: number): void {
+  const db = getDb();
+  db.insert(conversations)
+    .values({ id, title: "test", createdAt: updatedAt, updatedAt })
+    .run();
+  db.insert(toolInvocations)
+    .values({
+      id: `ti-${id}`,
+      conversationId: id,
+      toolName: "calendar_list_events",
+      input: "{}",
+      result: "{}",
+      decision: "allow",
+      riskLevel: "low",
+      durationMs: 12,
+      createdAt: updatedAt,
+    })
+    .run();
+  db.insert(skillLoadedEvents)
+    .values({
+      id: `sl-${id}`,
+      createdAt: updatedAt,
+      conversationId: id,
+      skillName: "test-skill",
+    })
+    .run();
+}
+
+function countRows(conversationId: string): {
+  invocations: number;
+  skillLoads: number;
+} {
+  const db = getDb();
+  return {
+    invocations: db
+      .select()
+      .from(toolInvocations)
+      .all()
+      .filter((r) => r.conversationId === conversationId).length,
+    skillLoads: db
+      .select()
+      .from(skillLoadedEvents)
+      .all()
+      .filter((r) => r.conversationId === conversationId).length,
+  };
+}
+
+describe("pruneOldConversationsJob", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.delete(skillLoadedEvents).run();
+    db.delete(toolInvocations).run();
+    db.delete(conversations).run();
+  });
+
+  test("deletes non-cascading rows — including skill_loaded_events — for pruned conversations only", () => {
+    const staleUpdatedAt = Date.now() - 60 * 86_400_000;
+    seedConversation(STALE_ID, staleUpdatedAt);
+    seedConversation(FRESH_ID, Date.now());
+
+    pruneOldConversationsJob(JOB, CONFIG);
+
+    expect(countRows(STALE_ID)).toEqual({ invocations: 0, skillLoads: 0 });
+    expect(countRows(FRESH_ID)).toEqual({ invocations: 1, skillLoads: 1 });
+    const remaining = getDb().select().from(conversations).all();
+    expect(remaining.map((c) => c.id)).toEqual([FRESH_ID]);
+  });
+});

--- a/assistant/src/__tests__/skill-projection-feature-flag.test.ts
+++ b/assistant/src/__tests__/skill-projection-feature-flag.test.ts
@@ -222,6 +222,19 @@ mock.module("../util/logger.js", () => ({
   }),
 }));
 
+// Mock the skill_loaded telemetry dependencies of conversation-skill-tools so
+// their heavy transitive imports (catalog-install → CLI program, sqlite) stay
+// out of this import-light test.
+mock.module("../skills/catalog-cache.js", () => ({
+  getCachedCatalogSync: () => [],
+}));
+mock.module("../skills/install-meta.js", () => ({
+  readInstallMeta: () => null,
+}));
+mock.module("../memory/skill-loaded-events-store.js", () => ({
+  recordSkillLoadedEvent: () => {},
+}));
+
 // ---------------------------------------------------------------------------
 // Import module under test (after mocks)
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/skill-projection.benchmark.test.ts
+++ b/assistant/src/__tests__/skill-projection.benchmark.test.ts
@@ -96,6 +96,19 @@ mock.module("../skills/version-hash.js", () => ({
   computeSkillVersionHash: () => "v1:deadbeef",
 }));
 
+// Mock the skill_loaded telemetry dependencies of conversation-skill-tools so
+// their heavy transitive imports (catalog-install → CLI program, sqlite) stay
+// out of this import-light test.
+mock.module("../skills/catalog-cache.js", () => ({
+  getCachedCatalogSync: () => [],
+}));
+mock.module("../skills/install-meta.js", () => ({
+  readInstallMeta: () => null,
+}));
+mock.module("../memory/skill-loaded-events-store.js", () => ({
+  recordSkillLoadedEvent: () => {},
+}));
+
 // Mock createSkillToolsFromManifest to return lightweight Tool-like objects
 mock.module("../tools/skills/skill-tool-factory.js", () => ({
   createSkillToolsFromManifest: (
@@ -153,22 +166,27 @@ mock.module("node:fs", () => ({
   Stats: class {},
 }));
 
-const benchmarkRegistry = new Map<string, unknown>();
+// Mirrors the current registry contract: ownership is recorded from the
+// `registerSkillTools(skillId, tools)` call and reported via `getToolOwner`.
+const benchmarkRegistry = new Map<string, { tool: unknown; skillId: string }>();
 mock.module("../tools/registry.js", () => ({
   registerSkillTools: (
+    skillId: string,
     tools: Array<{ name: string; [k: string]: unknown }>,
   ) => {
-    for (const t of tools) benchmarkRegistry.set(t.name, t);
+    for (const t of tools) benchmarkRegistry.set(t.name, { tool: t, skillId });
     return tools;
   },
   unregisterSkillTools: (skillId: string) => {
-    for (const [name, t] of benchmarkRegistry) {
-      const owner = (t as { owner?: { kind: string; id: string } }).owner;
-      if (owner?.kind === "skill" && owner.id === skillId)
-        benchmarkRegistry.delete(name);
+    for (const [name, entry] of benchmarkRegistry) {
+      if (entry.skillId === skillId) benchmarkRegistry.delete(name);
     }
   },
-  getTool: (name: string) => benchmarkRegistry.get(name),
+  getTool: (name: string) => benchmarkRegistry.get(name)?.tool,
+  getToolOwner: (name: string) => {
+    const entry = benchmarkRegistry.get(name);
+    return entry ? { kind: "skill" as const, id: entry.skillId } : undefined;
+  },
 }));
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/test-support/tool-invocation-seed.ts
+++ b/assistant/src/__tests__/test-support/tool-invocation-seed.ts
@@ -1,0 +1,63 @@
+import { getDb } from "../../memory/db-connection.js";
+import { conversations, toolInvocations } from "../../memory/schema.js";
+
+/**
+ * Sentinel embedded in the seeded raw input/result payloads. Tests assert it
+ * never appears in any projection or wire payload — raw tool args/outputs
+ * must never leave the device.
+ */
+export const TOOL_INVOCATION_PII_SENTINEL = "must never leave the device";
+
+export interface ToolInvocationSeedSpec {
+  id: string;
+  createdAt: number;
+  conversationId: string;
+  toolName?: string;
+  decision?: string;
+  durationMs?: number;
+  argBytes?: number | null;
+  resultBytes?: number | null;
+  provider?: string | null;
+  model?: string | null;
+  inferenceProfile?: string | null;
+  inferenceProfileSource?: string | null;
+}
+
+/**
+ * Seed a `tool_invocations` row (plus its FK conversation) for telemetry
+ * projection tests. Byte sizes default to non-null — post-migration writer
+ * paths always compute them; pass an explicit null to seed a legacy
+ * pre-migration-278 row.
+ */
+export function seedToolInvocation(spec: ToolInvocationSeedSpec): void {
+  const db = getDb();
+  // tool_invocations has an enforced FK to conversations.
+  db.insert(conversations)
+    .values({
+      id: spec.conversationId,
+      title: "test",
+      createdAt: 1000,
+      updatedAt: 1000,
+    })
+    .onConflictDoNothing()
+    .run();
+  db.insert(toolInvocations)
+    .values({
+      id: spec.id,
+      conversationId: spec.conversationId,
+      toolName: spec.toolName ?? "calendar_list_events",
+      input: `{"secret":"raw tool args — ${TOOL_INVOCATION_PII_SENTINEL}"}`,
+      result: `{"secret":"raw tool output — ${TOOL_INVOCATION_PII_SENTINEL}"}`,
+      decision: spec.decision ?? "allow",
+      riskLevel: "low",
+      durationMs: spec.durationMs ?? 12,
+      createdAt: spec.createdAt,
+      argBytes: spec.argBytes !== undefined ? spec.argBytes : 2,
+      resultBytes: spec.resultBytes !== undefined ? spec.resultBytes : 9,
+      provider: spec.provider ?? null,
+      model: spec.model ?? null,
+      inferenceProfile: spec.inferenceProfile ?? null,
+      inferenceProfileSource: spec.inferenceProfileSource ?? null,
+    })
+    .run();
+}

--- a/assistant/src/__tests__/test-support/tool-invocation-seed.ts
+++ b/assistant/src/__tests__/test-support/tool-invocation-seed.ts
@@ -1,5 +1,10 @@
-import { getDb } from "../../memory/db-connection.js";
-import { conversations, toolInvocations } from "../../memory/schema.js";
+// Per the test-machinery isolation rule in assistant/AGENTS.md, this shared
+// helper has no runtime imports from src/ — the importing test files (which
+// may import production modules like any normal consumer) pass the db handle
+// and table objects in. The imports below are type-only and fully erased at
+// compile time, so loading this module has no side effects.
+import type { getDb } from "../../memory/db-connection.js";
+import type { conversations, toolInvocations } from "../../memory/schema.js";
 
 /**
  * Sentinel embedded in the seeded raw input/result payloads. Tests assert it
@@ -7,6 +12,13 @@ import { conversations, toolInvocations } from "../../memory/schema.js";
  * must never leave the device.
  */
 export const TOOL_INVOCATION_PII_SENTINEL = "must never leave the device";
+
+/** Production handles supplied by the importing test file. */
+export interface ToolInvocationSeedDeps {
+  db: ReturnType<typeof getDb>;
+  conversations: typeof conversations;
+  toolInvocations: typeof toolInvocations;
+}
 
 export interface ToolInvocationSeedSpec {
   id: string;
@@ -29,10 +41,13 @@ export interface ToolInvocationSeedSpec {
  * paths always compute them; pass an explicit null to seed a legacy
  * pre-migration-278 row.
  */
-export function seedToolInvocation(spec: ToolInvocationSeedSpec): void {
-  const db = getDb();
+export function seedToolInvocation(
+  deps: ToolInvocationSeedDeps,
+  spec: ToolInvocationSeedSpec,
+): void {
   // tool_invocations has an enforced FK to conversations.
-  db.insert(conversations)
+  deps.db
+    .insert(deps.conversations)
     .values({
       id: spec.conversationId,
       title: "test",
@@ -41,7 +56,8 @@ export function seedToolInvocation(spec: ToolInvocationSeedSpec): void {
     })
     .onConflictDoNothing()
     .run();
-  db.insert(toolInvocations)
+  deps.db
+    .insert(deps.toolInvocations)
     .values({
       id: spec.id,
       conversationId: spec.conversationId,

--- a/assistant/src/__tests__/tool-audit-listener.test.ts
+++ b/assistant/src/__tests__/tool-audit-listener.test.ts
@@ -232,28 +232,6 @@ describe("tool audit listener", () => {
     }
   });
 
-  test("falls back to sizing the event input when inputBytes is absent, keeping argBytes non-null", () => {
-    const records: ToolInvocationRecord[] = [];
-    const listener = createToolAuditListener((record) => records.push(record));
-
-    listener({
-      type: "executed",
-      toolName: "file_read",
-      input: { path: "/tmp/a" },
-      workingDir: "/tmp",
-      conversationId: "conv-fallback",
-      riskLevel: "low",
-      decision: "allow",
-      durationMs: 4,
-      result: { content: "ok", isError: false },
-    });
-
-    expect(records).toHaveLength(1);
-    expect(records[0].argBytes).toBe(
-      Buffer.byteLength(JSON.stringify({ path: "/tmp/a" }), "utf8"),
-    );
-  });
-
   test("maps attribution onto executed records and leaves denied records null", () => {
     const records: ToolInvocationRecord[] = [];
     const listener = createToolAuditListener((record) => records.push(record));

--- a/assistant/src/__tests__/tool-audit-listener.test.ts
+++ b/assistant/src/__tests__/tool-audit-listener.test.ts
@@ -152,5 +152,104 @@ describe("tool audit listener", () => {
     expect(records).toHaveLength(1);
     expect(records[0].result).toBe("error: boom");
     expect(records[0].decision).toBe("error");
+    expect(records[0].argBytes).toBe(
+      Buffer.byteLength(JSON.stringify({ path: "/tmp/secret" }), "utf8"),
+    );
+    expect(records[0].resultBytes).toBe(Buffer.byteLength("error: boom"));
+  });
+
+  test("records byte sizes from the full payloads, before truncation and redaction", () => {
+    const records: ToolInvocationRecord[] = [];
+    const listener = createToolAuditListener((record) => records.push(record));
+
+    listener({
+      type: "executed",
+      toolName: "file_read",
+      input: { path: "/tmp/a" },
+      workingDir: "/tmp",
+      conversationId: "conv-bytes",
+      riskLevel: "low",
+      decision: "allow",
+      durationMs: 12,
+      // 1200 chars: the stored result is capped at 1000 but the size must
+      // reflect the full payload. "é" is 1 char / 2 utf8 bytes, proving
+      // byte (not char) accounting.
+      result: { content: "é".repeat(1200), isError: false },
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].result).toHaveLength(1000);
+    expect(records[0].argBytes).toBe(
+      Buffer.byteLength(JSON.stringify({ path: "/tmp/a" }), "utf8"),
+    );
+    expect(records[0].resultBytes).toBe(2400);
+  });
+
+  test("maps attribution onto executed records and leaves denied records null", () => {
+    const records: ToolInvocationRecord[] = [];
+    const listener = createToolAuditListener((record) => records.push(record));
+
+    listener({
+      type: "executed",
+      toolName: "file_read",
+      input: { path: "/tmp/a" },
+      workingDir: "/tmp",
+      conversationId: "conv-attr",
+      riskLevel: "low",
+      decision: "allow",
+      durationMs: 12,
+      result: { content: "ok", isError: false },
+      attribution: {
+        callSite: "mainAgent",
+        activeProfile: "balanced",
+        overrideProfile: null,
+        callSiteProfile: null,
+        appliedProfile: "balanced",
+        profileSource: "active",
+        resolvedProvider: "anthropic",
+        resolvedModel: "model-a",
+        resolvedMixArm: null,
+      },
+    });
+    listener({
+      type: "executed",
+      toolName: "file_read",
+      input: { path: "/tmp/b" },
+      workingDir: "/tmp",
+      conversationId: "conv-attr",
+      riskLevel: "low",
+      decision: "allow",
+      durationMs: 3,
+      result: { content: "ok", isError: false },
+      attribution: null,
+    });
+    listener({
+      type: "permission_denied",
+      toolName: "bash",
+      input: { command: "rm -rf /tmp" },
+      workingDir: "/tmp",
+      conversationId: "conv-attr",
+      riskLevel: "high",
+      decision: "deny",
+      reason: "Permission denied by user",
+      durationMs: 1,
+    });
+
+    expect(records).toHaveLength(3);
+    expect(records[0]).toMatchObject({
+      provider: "anthropic",
+      model: "model-a",
+      inferenceProfile: "balanced",
+      inferenceProfileSource: "active",
+    });
+    expect(records[1]).toMatchObject({
+      provider: null,
+      model: null,
+      inferenceProfile: null,
+      inferenceProfileSource: null,
+    });
+    expect(records[2].provider).toBeUndefined();
+    expect(records[2].argBytes).toBeUndefined();
+    expect(records[2].resultBytes).toBeUndefined();
   });
 });

--- a/assistant/src/__tests__/tool-audit-listener.test.ts
+++ b/assistant/src/__tests__/tool-audit-listener.test.ts
@@ -185,6 +185,75 @@ describe("tool audit listener", () => {
     expect(records[0].resultBytes).toBe(2400);
   });
 
+  test("prefers the executor-stamped raw inputBytes over sizing the (sanitized) event input", () => {
+    const records: ToolInvocationRecord[] = [];
+    const listener = createToolAuditListener((record) => records.push(record));
+
+    // The executor sanitizes event.input before listeners run and stamps
+    // inputBytes from the RAW input — the listener must report that size,
+    // not the redacted payload's.
+    const rawInput = { path: "/tmp/a", token: "t-1" };
+    const rawSize = Buffer.byteLength(JSON.stringify(rawInput), "utf8");
+    const sanitizedInput = { path: "/tmp/a", token: "<redacted />" };
+
+    listener({
+      type: "executed",
+      toolName: "file_read",
+      input: sanitizedInput,
+      inputBytes: rawSize,
+      workingDir: "/tmp",
+      conversationId: "conv-raw-bytes",
+      riskLevel: "low",
+      decision: "allow",
+      durationMs: 4,
+      result: { content: "ok", isError: false },
+    });
+    listener({
+      type: "error",
+      toolName: "file_read",
+      input: sanitizedInput,
+      inputBytes: rawSize,
+      workingDir: "/tmp",
+      conversationId: "conv-raw-bytes",
+      riskLevel: "low",
+      decision: "error",
+      durationMs: 4,
+      errorMessage: "boom",
+      isExpected: false,
+      errorCategory: "tool_failure",
+    });
+
+    expect(records).toHaveLength(2);
+    for (const record of records) {
+      expect(record.argBytes).toBe(rawSize);
+      expect(record.argBytes).not.toBe(
+        Buffer.byteLength(JSON.stringify(sanitizedInput), "utf8"),
+      );
+    }
+  });
+
+  test("falls back to sizing the event input when inputBytes is absent, keeping argBytes non-null", () => {
+    const records: ToolInvocationRecord[] = [];
+    const listener = createToolAuditListener((record) => records.push(record));
+
+    listener({
+      type: "executed",
+      toolName: "file_read",
+      input: { path: "/tmp/a" },
+      workingDir: "/tmp",
+      conversationId: "conv-fallback",
+      riskLevel: "low",
+      decision: "allow",
+      durationMs: 4,
+      result: { content: "ok", isError: false },
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].argBytes).toBe(
+      Buffer.byteLength(JSON.stringify({ path: "/tmp/a" }), "utf8"),
+    );
+  });
+
   test("maps attribution onto executed records and leaves denied records null", () => {
     const records: ToolInvocationRecord[] = [];
     const listener = createToolAuditListener((record) => records.push(record));

--- a/assistant/src/__tests__/tool-audit-listener.test.ts
+++ b/assistant/src/__tests__/tool-audit-listener.test.ts
@@ -1,9 +1,21 @@
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Toggle for the collectUsageData opt-out gate the listener consults when
+// populating the telemetry columns.
+let collectUsageData = true;
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({ collectUsageData }),
+}));
 
 import { createToolAuditListener } from "../events/tool-audit-listener.js";
 import type { ToolInvocationRecord } from "../memory/tool-usage-store.js";
 
 describe("tool audit listener", () => {
+  beforeEach(() => {
+    collectUsageData = true;
+  });
+
   test("records executed events with truncated output", () => {
     const records: ToolInvocationRecord[] = [];
     const listener = createToolAuditListener((record) => records.push(record));
@@ -230,6 +242,111 @@ describe("tool audit listener", () => {
         Buffer.byteLength(JSON.stringify(sanitizedInput), "utf8"),
       );
     }
+  });
+
+  test("prefers the executor-stamped raw resultBytes over sizing the (sanitized) event result", () => {
+    const records: ToolInvocationRecord[] = [];
+    const listener = createToolAuditListener((record) => records.push(record));
+
+    // For sensitive-output tools, the executor sanitizes result.content
+    // before listeners run and stamps resultBytes from the RAW content —
+    // the listener must report that size, not the placeholder-rewritten
+    // payload's.
+    const sanitizedContent = "code: VELLUM_ASSISTANT_INVITE_CODE_AB12CD34";
+    const rawSize = 4096;
+
+    listener({
+      type: "executed",
+      toolName: "create_invite",
+      input: { count: 1 },
+      workingDir: "/tmp",
+      conversationId: "conv-raw-result-bytes",
+      riskLevel: "low",
+      decision: "allow",
+      durationMs: 4,
+      result: { content: sanitizedContent, isError: false },
+      resultBytes: rawSize,
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].resultBytes).toBe(rawSize);
+    expect(records[0].resultBytes).not.toBe(
+      Buffer.byteLength(sanitizedContent, "utf8"),
+    );
+  });
+
+  test("persists NULL telemetry columns when usage data collection is opted out", () => {
+    collectUsageData = false;
+    const records: ToolInvocationRecord[] = [];
+    const listener = createToolAuditListener((record) => records.push(record));
+
+    const attribution = {
+      callSite: "mainAgent" as const,
+      activeProfile: "balanced",
+      overrideProfile: null,
+      callSiteProfile: null,
+      appliedProfile: "balanced",
+      profileSource: "active" as const,
+      resolvedProvider: "anthropic",
+      resolvedModel: "model-a",
+      resolvedMixArm: null,
+    };
+    listener({
+      type: "executed",
+      toolName: "file_read",
+      input: { path: "/tmp/a" },
+      inputBytes: 42,
+      resultBytes: 99,
+      workingDir: "/tmp",
+      conversationId: "conv-opt-out",
+      riskLevel: "low",
+      decision: "allow",
+      durationMs: 12,
+      result: { content: "ok", isError: false },
+      attribution,
+    });
+    listener({
+      type: "error",
+      toolName: "file_read",
+      input: { path: "/tmp/b" },
+      inputBytes: 42,
+      workingDir: "/tmp",
+      conversationId: "conv-opt-out",
+      riskLevel: "low",
+      decision: "error",
+      durationMs: 9,
+      errorMessage: "boom",
+      isExpected: false,
+      errorCategory: "tool_failure",
+      attribution,
+    });
+
+    // Telemetry columns are NULL — the tool_executed projection's
+    // arg_bytes IS NOT NULL filter makes these rows permanently
+    // unreportable, even from a zero watermark.
+    expect(records).toHaveLength(2);
+    for (const record of records) {
+      expect(record.argBytes).toBeNull();
+      expect(record.resultBytes).toBeNull();
+      expect(record.provider).toBeNull();
+      expect(record.model).toBeNull();
+      expect(record.inferenceProfile).toBeNull();
+      expect(record.inferenceProfileSource).toBeNull();
+    }
+    // The audit row itself is unaffected by the opt-out.
+    expect(records[0]).toMatchObject({
+      conversationId: "conv-opt-out",
+      toolName: "file_read",
+      input: JSON.stringify({ path: "/tmp/a" }),
+      result: "ok",
+      decision: "allow",
+      durationMs: 12,
+    });
+    expect(records[1]).toMatchObject({
+      result: "error: boom",
+      decision: "error",
+      durationMs: 9,
+    });
   });
 
   test("maps attribution onto executed records and leaves denied records null", () => {

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -652,6 +652,73 @@ describe("ToolExecutor lifecycle events", () => {
     expect(errorEvent.attribution).toEqual(testAttribution);
   });
 
+  // ── raw input byte sizing tests ───────────────────────────
+
+  test("stamps inputBytes from the raw input even when sanitization redacts fields", async () => {
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    const rawInput = { path: "README.md", token: "t-1" };
+    const rawSize = Buffer.byteLength(JSON.stringify(rawInput), "utf8");
+
+    await executor.execute("file_read", rawInput, makeContext(events));
+
+    const executed = events.find((event) => event.type === "executed");
+    if (executed?.type !== "executed")
+      throw new Error("Expected executed event");
+    // The event input is sanitized, but the size reflects the raw payload.
+    expect(executed.input.token).toBe("<redacted />");
+    expect(executed.inputBytes).toBe(rawSize);
+    expect(executed.inputBytes).not.toBe(
+      Buffer.byteLength(JSON.stringify(executed.input), "utf8"),
+    );
+  });
+
+  test("stamps inputBytes from the raw input on error events", async () => {
+    toolThrow = new Error("boom");
+
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    const rawInput = { path: "README.md", api_key: "k-1" };
+
+    await executor.execute("file_read", rawInput, makeContext(events));
+
+    const errorEvent = events.find((event) => event.type === "error");
+    if (errorEvent?.type !== "error") throw new Error("Expected error event");
+    expect(errorEvent.input.api_key).toBe("<redacted />");
+    expect(errorEvent.inputBytes).toBe(
+      Buffer.byteLength(JSON.stringify(rawInput), "utf8"),
+    );
+  });
+
+  test("audit listener records arg_bytes equal to the raw serialized input size", async () => {
+    // End-to-end: executor sanitization must not shrink the recorded
+    // arg_bytes — the audit row sizes the raw pre-redaction input.
+    const { createToolAuditListener } =
+      await import("../events/tool-audit-listener.js");
+    const records: Array<{ argBytes?: number | null; input: string }> = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    const rawInput = { path: "README.md", token: "t-1" };
+
+    await executor.execute("file_read", rawInput, {
+      workingDir: "/tmp/project",
+      conversationId: "conversation-1",
+      trustClass: "guardian" as const,
+      onToolLifecycleEvent: createToolAuditListener((record) =>
+        records.push(record),
+      ),
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].argBytes).toBe(
+      Buffer.byteLength(JSON.stringify(rawInput), "utf8"),
+    );
+    // The stored input column is still the redacted payload.
+    expect(records[0].input).not.toContain("t-1");
+  });
+
   test("skill tool with sandbox execution_target resolves to sandbox executionTarget", async () => {
     const events: ToolLifecycleEvent[] = [];
     const executor = new ToolExecutor(makePrompter());

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -4,6 +4,7 @@ import type {
   ToolExecutionResult,
   ToolLifecycleEvent,
 } from "../tools/types.js";
+import type { UsageAttributionSnapshot } from "../usage/attribution.js";
 
 const mockConfig = {
   provider: "anthropic",
@@ -513,6 +514,142 @@ describe("ToolExecutor lifecycle events", () => {
     if (executed.type !== "executed")
       throw new Error("Expected executed event");
     expect(executed.executionTarget).toBe("sandbox");
+  });
+
+  // ── attribution forwarding tests ──────────────────────────
+
+  // Uses a non-main call site (voice turn) so these tests also prove the
+  // executor forwards the snapshot verbatim — non-main turns must not be
+  // rewritten to the main agent's attribution.
+  const testAttribution: UsageAttributionSnapshot = {
+    callSite: "callAgent",
+    activeProfile: "balanced",
+    overrideProfile: null,
+    callSiteProfile: "voice-profile",
+    appliedProfile: "voice-profile",
+    profileSource: "call_site",
+    resolvedProvider: "anthropic",
+    resolvedModel: "test-model",
+    resolvedMixArm: null,
+  };
+
+  test("forwards context.attribution into the executed lifecycle event", async () => {
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    await executor.execute(
+      "file_read",
+      { path: "README.md" },
+      makeContext(events, { attribution: testAttribution }),
+    );
+
+    const executed = events.find((event) => event.type === "executed");
+    if (executed?.type !== "executed")
+      throw new Error("Expected executed event");
+    expect(executed.attribution).toEqual(testAttribution);
+  });
+
+  test("forwards context.attribution into the error lifecycle event", async () => {
+    toolThrow = new Error("boom");
+
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    await executor.execute(
+      "file_read",
+      {},
+      makeContext(events, { attribution: testAttribution }),
+    );
+
+    const errorEvent = events.find((event) => event.type === "error");
+    if (errorEvent?.type !== "error") throw new Error("Expected error event");
+    expect(errorEvent.attribution).toEqual(testAttribution);
+  });
+
+  test("missing context.attribution yields null on the executed event without throwing", async () => {
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    const result = await executor.execute(
+      "file_read",
+      { path: "README.md" },
+      makeContext(events),
+    );
+
+    expect(result).toMatchObject({ content: "ok", isError: false });
+    const executed = events.find((event) => event.type === "executed");
+    if (executed?.type !== "executed")
+      throw new Error("Expected executed event");
+    expect(executed.attribution).toBeNull();
+  });
+
+  test("missing context.attribution yields null on the error event without throwing", async () => {
+    toolThrow = new Error("boom");
+
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    const result = await executor.execute("file_read", {}, makeContext(events));
+
+    expect(result.isError).toBe(true);
+    const errorEvent = events.find((event) => event.type === "error");
+    if (errorEvent?.type !== "error") throw new Error("Expected error event");
+    expect(errorEvent.attribution).toBeNull();
+  });
+
+  test("stamps attribution on pre-execution gate error events (unknown tool)", async () => {
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    const result = await executor.execute(
+      "unknown_tool",
+      { test: true },
+      makeContext(events, { attribution: testAttribution }),
+    );
+
+    expect(result.isError).toBe(true);
+    const errorEvent = events.find((event) => event.type === "error");
+    if (errorEvent?.type !== "error") throw new Error("Expected error event");
+    expect(errorEvent.errorMessage).toContain("Unknown tool: unknown_tool");
+    expect(errorEvent.attribution).toEqual(testAttribution);
+  });
+
+  test("missing attribution yields null on pre-execution gate error events", async () => {
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    const result = await executor.execute(
+      "unknown_tool",
+      { test: true },
+      makeContext(events),
+    );
+
+    expect(result.isError).toBe(true);
+    const errorEvent = events.find((event) => event.type === "error");
+    if (errorEvent?.type !== "error") throw new Error("Expected error event");
+    expect(errorEvent.attribution).toBeNull();
+  });
+
+  test("stamps attribution on the aborted pre-execution gate error event", async () => {
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await executor.execute(
+      "file_read",
+      { path: "README.md" },
+      makeContext(events, {
+        attribution: testAttribution,
+        signal: controller.signal,
+      }),
+    );
+
+    expect(result).toEqual({ content: "Cancelled", isError: true });
+    const errorEvent = events.find((event) => event.type === "error");
+    if (errorEvent?.type !== "error") throw new Error("Expected error event");
+    expect(errorEvent.errorMessage).toBe("Cancelled");
+    expect(errorEvent.attribution).toEqual(testAttribution);
   });
 
   test("skill tool with sandbox execution_target resolves to sandbox executionTarget", async () => {

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -34,6 +34,9 @@ const mockConfig = {
   permissions: {
     mode: "workspace" as const,
   },
+  // The audit listener nulls the telemetry columns when this is false; the
+  // end-to-end listener tests below assert the opted-in sizing behavior.
+  collectUsageData: true,
 };
 
 let checkerDecision: "allow" | "prompt" | "deny" = "allow";
@@ -690,6 +693,72 @@ describe("ToolExecutor lifecycle events", () => {
     expect(errorEvent.inputBytes).toBe(
       Buffer.byteLength(JSON.stringify(rawInput), "utf8"),
     );
+  });
+
+  test("stamps resultBytes from the raw content before sensitive-output sanitization", async () => {
+    // Directive stripping + placeholder substitution shrink the content the
+    // lifecycle event carries; the stamped size must reflect the raw output.
+    const rawContent =
+      'Your invite: <vellum-sensitive-output kind="invite_code" value="SECRET-CODE-123" /> use SECRET-CODE-123';
+    fakeToolResult = { content: rawContent, isError: false };
+
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    await executor.execute("file_read", { path: "a" }, makeContext(events));
+
+    const executed = events.find((event) => event.type === "executed");
+    if (executed?.type !== "executed")
+      throw new Error("Expected executed event");
+    // The event carries the sanitized content...
+    expect(executed.result.content).not.toContain("SECRET-CODE-123");
+    // ...but the stamped size is the raw pre-sanitization byte length.
+    expect(executed.resultBytes).toBe(Buffer.byteLength(rawContent, "utf8"));
+    expect(executed.resultBytes).not.toBe(
+      Buffer.byteLength(executed.result.content, "utf8"),
+    );
+  });
+
+  test("stamps resultBytes for non-sensitive results too (raw equals emitted content)", async () => {
+    const events: ToolLifecycleEvent[] = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    await executor.execute("file_read", { path: "a" }, makeContext(events));
+
+    const executed = events.find((event) => event.type === "executed");
+    if (executed?.type !== "executed")
+      throw new Error("Expected executed event");
+    expect(executed.result.content).toBe("ok");
+    expect(executed.resultBytes).toBe(Buffer.byteLength("ok", "utf8"));
+  });
+
+  test("audit listener records result_bytes from the raw pre-sanitization output", async () => {
+    const { createToolAuditListener } =
+      await import("../events/tool-audit-listener.js");
+    const records: Array<{ resultBytes?: number | null; result: string }> = [];
+    const executor = new ToolExecutor(makePrompter());
+
+    const rawContent =
+      'Code: <vellum-sensitive-output kind="invite_code" value="SECRET-CODE-456" />SECRET-CODE-456';
+    fakeToolResult = { content: rawContent, isError: false };
+
+    await executor.execute(
+      "file_read",
+      { path: "a" },
+      {
+        workingDir: "/tmp/project",
+        conversationId: "conversation-1",
+        trustClass: "guardian" as const,
+        onToolLifecycleEvent: createToolAuditListener((record) =>
+          records.push(record),
+        ),
+      },
+    );
+
+    expect(records).toHaveLength(1);
+    expect(records[0].resultBytes).toBe(Buffer.byteLength(rawContent, "utf8"));
+    // The stored result column is still the sanitized payload.
+    expect(records[0].result).not.toContain("SECRET-CODE-456");
   });
 
   test("audit listener records arg_bytes equal to the raw serialized input size", async () => {

--- a/assistant/src/daemon/conversation-skill-tools.ts
+++ b/assistant/src/daemon/conversation-skill-tools.ts
@@ -32,9 +32,20 @@ import {
 } from "../tools/registry.js";
 import { createSkillToolsFromManifest } from "../tools/skills/skill-tool-factory.js";
 import type { UsageAttributionSnapshot } from "../usage/attribution.js";
+import { toAttributionColumns } from "../usage/attribution.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("conversation-skill-tools");
+
+/**
+ * Sentinel "version hash" stored in the previously-active map for skills that
+ * are active without a loadable TOOLS.json (instruction-only skills — the
+ * common case for catalog installs — or skills whose manifest failed to
+ * parse). These entries registered no tools, so teardown paths must skip
+ * `unregisterSkillTools` for them to avoid decrementing refcounts held by
+ * other conversations.
+ */
+const NO_TOOLS_VERSION = "__no_tools__";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -78,7 +89,8 @@ export interface ProjectSkillToolsOptions {
   preactivatedSkillIds?: string[];
   /**
    * Conversation-scoped tracking map of previously active skill IDs to their
-   * version hashes. Each conversation should own its own map to prevent
+   * version hashes (or the no-tools sentinel for active skills without a
+   * loadable manifest). Each conversation should own its own map to prevent
    * cross-conversation state bleed when the daemon serves multiple concurrent
    * conversations. When a skill's hash changes between turns, its tools are
    * unregistered and re-registered with the updated definitions.
@@ -155,15 +167,15 @@ function recordSkillLoadedTelemetry(
   try {
     if (!isVellumProducedSkill(skill)) return;
     const catalogEntry = getCachedCatalogSync().find((s) => s.id === skill.id);
-    const attribution = telemetry.attribution;
+    const columns = toAttributionColumns(telemetry.attribution);
     recordSkillLoadedEvent({
       conversationId: telemetry.conversationId ?? undefined,
       skillName: skill.id,
       skillUpdatedAt: catalogEntry?.updatedAt,
-      provider: attribution?.resolvedProvider,
-      model: attribution?.resolvedModel,
-      inferenceProfile: attribution?.appliedProfile ?? undefined,
-      inferenceProfileSource: attribution?.profileSource,
+      provider: columns.provider ?? undefined,
+      model: columns.model ?? undefined,
+      inferenceProfile: columns.inferenceProfile ?? undefined,
+      inferenceProfileSource: columns.inferenceProfileSource ?? undefined,
     });
   } catch (err) {
     log.debug(
@@ -325,8 +337,11 @@ export function projectSkillTools(
     }
   }
 
-  // Unregister tools for skills that are no longer active
+  // Unregister tools for skills that are no longer active. Skills tracked
+  // with the no-tools sentinel never registered anything — skip them so we
+  // don't decrement refcounts held by other conversations.
   for (const id of removedIds) {
+    if (prevActive.get(id) === NO_TOOLS_VERSION) continue;
     log.info({ skillId: id }, "Unregistering tools for deactivated skill");
     unregisterSkillTools(id);
   }
@@ -351,8 +366,34 @@ export function projectSkillTools(
       continue;
     }
 
+    // A skill that newly became active counts as one `skill_loaded`, whether
+    // or not it ships a TOOLS.json — instruction-only skills (the common case
+    // for catalog installs) must be counted too, so this runs before the
+    // manifest gate. The once-per-activation guard (`prevActive`) is
+    // in-memory per-conversation state: after conversation disposal or a
+    // daemon restart, re-projection re-emits skill_loaded for already-active
+    // skills. That is intentional — a re-load after restart is a load.
+    // Downstream consumers that need activation-level uniqueness dedup on
+    // (conversation_id, skill_name).
+    if (!prevActive.has(skillId)) {
+      recordSkillLoadedTelemetry(skill, options?.telemetry);
+    }
+
     const manifest = loadManifestForSkill(skill);
     if (!manifest) {
+      // No loadable manifest — nothing to register, but keep tracking the
+      // activation so it isn't re-recorded every turn. If tools were
+      // registered on a previous turn (manifest removed or corrupted since),
+      // tear them down like the transiently-failed path would.
+      const prevHash = prevActive.get(skillId);
+      if (prevHash !== undefined && prevHash !== NO_TOOLS_VERSION) {
+        log.info(
+          { skillId },
+          "Unregistering tools for skill whose manifest is no longer loadable",
+        );
+        unregisterSkillTools(skillId);
+      }
+      successfulEntries.set(skillId, NO_TOOLS_VERSION);
       continue;
     }
 
@@ -379,10 +420,17 @@ export function projectSkillTools(
     if (tools.length > 0) {
       let accepted = tools;
       const prevHash = prevActive.get(skillId);
-      if (prevHash === undefined) {
-        // Newly active skill — register for the first time
+      if (prevHash === undefined || prevHash === NO_TOOLS_VERSION) {
+        // Newly active skill (already recorded above), or a previously
+        // manifest-less activation whose TOOLS.json has since appeared —
+        // register for the first time. There is nothing to unregister in the
+        // sentinel case: no tools were ever registered for it.
         accepted = registerSkillTools(skillId, tools);
-        recordSkillLoadedTelemetry(skill, options?.telemetry);
+        if (prevHash === NO_TOOLS_VERSION) {
+          // Gaining a manifest re-registers the skill — like a version-hash
+          // change, that counts as a new load.
+          recordSkillLoadedTelemetry(skill, options?.telemetry);
+        }
       } else if (prevHash !== currentHash) {
         // Hash changed — unregister stale tools, then re-register with new definitions
         log.info(
@@ -432,7 +480,9 @@ export function projectSkillTools(
     if (
       activeIds.has(id) &&
       !successfulEntries.has(id) &&
-      !alreadyUnregistered.has(id)
+      !alreadyUnregistered.has(id) &&
+      // Sentinel entries registered no tools — nothing to unregister.
+      prevActive.get(id) !== NO_TOOLS_VERSION
     ) {
       log.info(
         { skillId: id },
@@ -463,7 +513,11 @@ export function resetSkillToolProjection(
   trackedIds?: Map<string, string>,
 ): void {
   if (trackedIds) {
-    for (const id of trackedIds.keys()) {
+    for (const [id, hash] of trackedIds) {
+      // Sentinel entries (active skills without a manifest) registered no
+      // tools — skip them so we don't decrement refcounts held by other
+      // conversations.
+      if (hash === NO_TOOLS_VERSION) continue;
       unregisterSkillTools(id);
     }
     trackedIds.clear();

--- a/assistant/src/daemon/conversation-skill-tools.ts
+++ b/assistant/src/daemon/conversation-skill-tools.ts
@@ -47,6 +47,18 @@ const log = getLogger("conversation-skill-tools");
  */
 const NO_TOOLS_VERSION = "__no_tools__";
 
+/**
+ * Whether a tracked version-hash entry corresponds to tools that were actually
+ * registered. Absent entries and the no-tools sentinel registered nothing, so
+ * every teardown path must consult this before calling `unregisterSkillTools`
+ * — the registry refcounts, and a spurious unregister would decrement counts
+ * held by other conversations. This helper is the single owner of the
+ * sentinel check; do not compare against `NO_TOOLS_VERSION` elsewhere.
+ */
+function hasRegisteredTools(trackedHash: string | undefined): boolean {
+  return trackedHash !== undefined && trackedHash !== NO_TOOLS_VERSION;
+}
+
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
@@ -104,7 +116,7 @@ export interface ProjectSkillToolsOptions {
   cache?: SkillProjectionCache;
   /** Telemetry context for skill_loaded events; absent disables recording. */
   telemetry?: {
-    conversationId: string | null;
+    conversationId: string;
     attribution: UsageAttributionSnapshot | null;
   };
 }
@@ -167,15 +179,11 @@ function recordSkillLoadedTelemetry(
   try {
     if (!isVellumProducedSkill(skill)) return;
     const catalogEntry = getCachedCatalogSync().find((s) => s.id === skill.id);
-    const columns = toAttributionColumns(telemetry.attribution);
     recordSkillLoadedEvent({
-      conversationId: telemetry.conversationId ?? undefined,
+      conversationId: telemetry.conversationId,
       skillName: skill.id,
       skillUpdatedAt: catalogEntry?.updatedAt,
-      provider: columns.provider ?? undefined,
-      model: columns.model ?? undefined,
-      inferenceProfile: columns.inferenceProfile ?? undefined,
-      inferenceProfileSource: columns.inferenceProfileSource ?? undefined,
+      ...toAttributionColumns(telemetry.attribution),
     });
   } catch (err) {
     log.debug(
@@ -341,7 +349,7 @@ export function projectSkillTools(
   // with the no-tools sentinel never registered anything — skip them so we
   // don't decrement refcounts held by other conversations.
   for (const id of removedIds) {
-    if (prevActive.get(id) === NO_TOOLS_VERSION) continue;
+    if (!hasRegisteredTools(prevActive.get(id))) continue;
     log.info({ skillId: id }, "Unregistering tools for deactivated skill");
     unregisterSkillTools(id);
   }
@@ -368,16 +376,16 @@ export function projectSkillTools(
 
     // A skill that newly became active counts as one `skill_loaded`, whether
     // or not it ships a TOOLS.json — instruction-only skills (the common case
-    // for catalog installs) must be counted too, so this runs before the
-    // manifest gate. The once-per-activation guard (`prevActive`) is
+    // for catalog installs) must be counted too. The event is recorded only
+    // once the skill lands in `successfulEntries`, so a failed registration
+    // is retried (and counted) on a later turn instead of emitting one row
+    // per failing turn. The once-per-activation guard (`prevActive`) is
     // in-memory per-conversation state: after conversation disposal or a
     // daemon restart, re-projection re-emits skill_loaded for already-active
     // skills. That is intentional — a re-load after restart is a load.
     // Downstream consumers that need activation-level uniqueness dedup on
     // (conversation_id, skill_name).
-    if (!prevActive.has(skillId)) {
-      recordSkillLoadedTelemetry(skill, options?.telemetry);
-    }
+    const prevHash = prevActive.get(skillId);
 
     const manifest = loadManifestForSkill(skill);
     if (!manifest) {
@@ -385,8 +393,7 @@ export function projectSkillTools(
       // activation so it isn't re-recorded every turn. If tools were
       // registered on a previous turn (manifest removed or corrupted since),
       // tear them down like the transiently-failed path would.
-      const prevHash = prevActive.get(skillId);
-      if (prevHash !== undefined && prevHash !== NO_TOOLS_VERSION) {
+      if (hasRegisteredTools(prevHash)) {
         log.info(
           { skillId },
           "Unregistering tools for skill whose manifest is no longer loadable",
@@ -394,6 +401,9 @@ export function projectSkillTools(
         unregisterSkillTools(skillId);
       }
       successfulEntries.set(skillId, NO_TOOLS_VERSION);
+      if (prevHash === undefined) {
+        recordSkillLoadedTelemetry(skill, options?.telemetry);
+      }
       continue;
     }
 
@@ -419,18 +429,23 @@ export function projectSkillTools(
 
     if (tools.length > 0) {
       let accepted = tools;
-      const prevHash = prevActive.get(skillId);
-      if (prevHash === undefined || prevHash === NO_TOOLS_VERSION) {
-        // Newly active skill (already recorded above), or a previously
-        // manifest-less activation whose TOOLS.json has since appeared —
-        // register for the first time. There is nothing to unregister in the
-        // sentinel case: no tools were ever registered for it.
-        accepted = registerSkillTools(skillId, tools);
-        if (prevHash === NO_TOOLS_VERSION) {
-          // Gaining a manifest re-registers the skill — like a version-hash
-          // change, that counts as a new load.
-          recordSkillLoadedTelemetry(skill, options?.telemetry);
+      if (!hasRegisteredTools(prevHash)) {
+        // Newly active skill, or a previously manifest-less activation whose
+        // TOOLS.json has since appeared — register for the first time. There
+        // is nothing to unregister in the sentinel case: no tools were ever
+        // registered for it.
+        try {
+          accepted = registerSkillTools(skillId, tools);
+        } catch (err) {
+          log.error({ err, skillId }, "Failed to register skill tools");
+          // Not added to successfulEntries — registration (and the
+          // skill_loaded record below) is retried next turn.
+          continue;
         }
+        // A first successful registration counts as the load; a manifest-less
+        // activation gaining a TOOLS.json re-registers, which — like a
+        // version-hash change — counts as a new load.
+        recordSkillLoadedTelemetry(skill, options?.telemetry);
       } else if (prevHash !== currentHash) {
         // Hash changed — unregister stale tools, then re-register with new definitions
         log.info(
@@ -482,7 +497,7 @@ export function projectSkillTools(
       !successfulEntries.has(id) &&
       !alreadyUnregistered.has(id) &&
       // Sentinel entries registered no tools — nothing to unregister.
-      prevActive.get(id) !== NO_TOOLS_VERSION
+      hasRegisteredTools(prevActive.get(id))
     ) {
       log.info(
         { skillId: id },
@@ -517,7 +532,7 @@ export function resetSkillToolProjection(
       // Sentinel entries (active skills without a manifest) registered no
       // tools — skip them so we don't decrement refcounts held by other
       // conversations.
-      if (hash === NO_TOOLS_VERSION) continue;
+      if (!hasRegisteredTools(hash)) continue;
       unregisterSkillTools(id);
     }
     trackedIds.clear();

--- a/assistant/src/daemon/conversation-skill-tools.ts
+++ b/assistant/src/daemon/conversation-skill-tools.ts
@@ -16,9 +16,12 @@ import { getConfig } from "../config/loader.js";
 import { skillFlagKey } from "../config/skill-state.js";
 import type { SkillSummary, SkillToolManifest } from "../config/skills.js";
 import { loadSkillCatalog } from "../config/skills.js";
+import { recordSkillLoadedEvent } from "../memory/skill-loaded-events-store.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
 import type { ActiveSkillEntry } from "../skills/active-skill-tools.js";
 import { deriveActiveSkills } from "../skills/active-skill-tools.js";
+import { getCachedCatalogSync } from "../skills/catalog-cache.js";
+import { readInstallMeta } from "../skills/install-meta.js";
 import { parseToolManifestFile } from "../skills/tool-manifest.js";
 import { computeSkillVersionHash } from "../skills/version-hash.js";
 import {
@@ -28,6 +31,7 @@ import {
   unregisterSkillTools,
 } from "../tools/registry.js";
 import { createSkillToolsFromManifest } from "../tools/skills/skill-tool-factory.js";
+import type { UsageAttributionSnapshot } from "../usage/attribution.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("conversation-skill-tools");
@@ -86,6 +90,11 @@ export interface ProjectSkillToolsOptions {
    * reads across agent turns.
    */
   cache?: SkillProjectionCache;
+  /** Telemetry context for skill_loaded events; absent disables recording. */
+  telemetry?: {
+    conversationId: string | null;
+    attribution: UsageAttributionSnapshot | null;
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -113,6 +122,54 @@ function loadManifestForSkill(skill: SkillSummary): SkillToolManifest | null {
       "Failed to parse TOOLS.json for skill",
     );
     return null;
+  }
+}
+
+/**
+ * Whether a skill is Vellum-produced for `skill_loaded` telemetry purposes:
+ * bundled skills always are; managed skills only when their install metadata
+ * records a `vellum` origin (legacy version.json installs are inferred as
+ * vellum by `readInstallMeta`). All other sources (workspace, extra, plugin)
+ * never emit.
+ */
+function isVellumProducedSkill(skill: SkillSummary): boolean {
+  if (skill.source === "bundled") return true;
+  if (skill.source === "managed") {
+    return readInstallMeta(skill.directoryPath)?.origin === "vellum";
+  }
+  return false;
+}
+
+/**
+ * Record a `skill_loaded` telemetry event for a newly-activated Vellum-produced
+ * skill. Metadata only — never skill output or conversation content.
+ * `skill_updated_at` comes from the cached merged catalog (sync accessor —
+ * this runs on the hot tool-projection path). Failures are swallowed at
+ * debug level: recording must never break tool projection.
+ */
+function recordSkillLoadedTelemetry(
+  skill: SkillSummary,
+  telemetry: ProjectSkillToolsOptions["telemetry"],
+): void {
+  if (!telemetry) return;
+  try {
+    if (!isVellumProducedSkill(skill)) return;
+    const catalogEntry = getCachedCatalogSync().find((s) => s.id === skill.id);
+    const attribution = telemetry.attribution;
+    recordSkillLoadedEvent({
+      conversationId: telemetry.conversationId ?? undefined,
+      skillName: skill.id,
+      skillUpdatedAt: catalogEntry?.updatedAt,
+      provider: attribution?.resolvedProvider,
+      model: attribution?.resolvedModel,
+      inferenceProfile: attribution?.appliedProfile ?? undefined,
+      inferenceProfileSource: attribution?.profileSource,
+    });
+  } catch (err) {
+    log.debug(
+      { err, skillId: skill.id },
+      "Failed to record skill_loaded telemetry event (non-fatal)",
+    );
   }
 }
 
@@ -325,6 +382,7 @@ export function projectSkillTools(
       if (prevHash === undefined) {
         // Newly active skill — register for the first time
         accepted = registerSkillTools(skillId, tools);
+        recordSkillLoadedTelemetry(skill, options?.telemetry);
       } else if (prevHash !== currentHash) {
         // Hash changed — unregister stale tools, then re-register with new definitions
         log.info(
@@ -343,6 +401,8 @@ export function projectSkillTools(
           // Don't add to successfulEntries — will be cleaned up as transiently-failed
           continue;
         }
+        // A version change that re-registers counts as a new skill load.
+        recordSkillLoadedTelemetry(skill, options?.telemetry);
       } else {
         // Hash unchanged — filter to only tools that are actually registered
         // for this skill. Some tools may have been skipped during initial

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -13,6 +13,7 @@ import {
 } from "../channels/types.js";
 import { getIsPlatform } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
+import type { LLMCallSite } from "../config/schemas/llm.js";
 import { getBindingByConversation } from "../memory/external-conversation-store.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
@@ -375,6 +376,17 @@ export interface SkillProjectionContext {
   readonly transportInterface?: InterfaceId;
   /** Per-turn override profile, read by the switch_inference_profile tool injection. */
   currentTurnOverrideProfile?: string;
+  /**
+   * Conversation id for `skill_loaded` telemetry. Absent (e.g. minimal test
+   * contexts) disables telemetry recording in the skill projection.
+   */
+  readonly conversationId?: string;
+  /**
+   * The LLM call site driving the current turn (see
+   * {@link ToolSetupContext.currentCallSite}) — read per turn so skill_loaded
+   * telemetry attributes the provider/model/profile the turn actually ran on.
+   */
+  currentCallSite?: LLMCallSite;
 }
 
 // ── Conditional tool sets ────────────────────────────────────────────
@@ -641,6 +653,19 @@ export function createResolveToolsCallback(
       preactivatedSkillIds: effectivePreactivated,
       previouslyActiveSkillIds: ctx.skillProjectionState,
       cache: ctx.skillProjectionCache,
+      // skill_loaded telemetry context — resolved per turn so attribution
+      // reflects the call site/profile the current turn actually runs on.
+      telemetry:
+        ctx.conversationId !== undefined
+          ? {
+              conversationId: ctx.conversationId,
+              attribution: resolveConversationAttribution({
+                conversationId: ctx.conversationId,
+                currentCallSite: ctx.currentCallSite,
+                currentTurnOverrideProfile: ctx.currentTurnOverrideProfile,
+              }),
+            }
+          : undefined,
     });
     const turnAllowed = new Set(allBaseDefs.map((d) => d.name));
     for (const name of projection.allowedToolNames) {

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -34,6 +34,10 @@ import {
   type ToolExecutionResult,
   type ToolLifecycleEventHandler,
 } from "../tools/types.js";
+import {
+  resolveUsageAttribution,
+  type UsageAttributionSnapshot,
+} from "../usage/attribution.js";
 import { getLogger } from "../util/logger.js";
 import {
   projectSkillTools,
@@ -58,6 +62,45 @@ import {
 } from "./switch-inference-profile-tool.js";
 import type { ToolSetupContext } from "./tool-setup-types.js";
 export type { ToolSetupContext } from "./tool-setup-types.js";
+
+// ── resolveConversationAttribution ───────────────────────────────────
+
+/**
+ * Resolve the model attribution snapshot for the conversation at invocation
+ * time (provider/model/profile that issued the current turn). Mirrors how
+ * the agent-loop usage path builds its `UsageAttributionInput` — the
+ * current turn's call site (`runAgentLoopImpl` sets `ctx.currentCallSite`
+ * from `options.callSite`, defaulting to `mainAgent`) plus the
+ * conversation's per-turn override profile — so `profileSource` resolves
+ * to `call_site`/`conversation`/`active`/`default` exactly as `llm_usage`
+ * records do for the same turn (non-main turns like voice `callAgent` or
+ * `filingAgent` attribute their own call-site config, not the main
+ * agent's). The conversation id is threaded as the mix selection seed so
+ * mix-profile arms match what the dispatch path actually ran.
+ *
+ * Returns `null` on any failure: attribution is telemetry-only and must
+ * never break tool execution (or skill loads, which reuse this helper).
+ */
+export function resolveConversationAttribution(
+  ctx: Pick<
+    ToolSetupContext,
+    "conversationId" | "currentCallSite" | "currentTurnOverrideProfile"
+  >,
+): UsageAttributionSnapshot | null {
+  try {
+    return resolveUsageAttribution({
+      callSite: ctx.currentCallSite ?? "mainAgent",
+      overrideProfile: ctx.currentTurnOverrideProfile ?? null,
+      selectionSeed: ctx.conversationId,
+    });
+  } catch (err) {
+    log.debug(
+      { err, conversationId: ctx.conversationId },
+      "Failed to resolve conversation attribution for telemetry (non-fatal)",
+    );
+    return null;
+  }
+}
 
 // ── createToolExecutor ───────────────────────────────────────────────
 
@@ -130,6 +173,7 @@ export function createToolExecutor(
       isPlatformHosted: getIsPlatform(),
       transportInterface: ctx.transportInterface,
       overrideProfile: ctx.currentTurnOverrideProfile,
+      attribution: resolveConversationAttribution(ctx),
       onToolLifecycleEvent: handleToolLifecycleEvent,
       sendToClient: (msg) => {
         // Tool context's sendToClient uses a loose { type: string; [key: string]: unknown }

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -647,10 +647,13 @@ export async function runDaemon(): Promise<void> {
     // Construct and start the reporter even when usage collection is disabled:
     // flush() re-checks collectUsageData each cycle and, when opted out, sends
     // nothing but advances all watermarks (including the final flush in
-    // stop()). That keeps the watermarks ahead of the always-on
-    // tool_invocations audit rows across opted-out sessions, so a later opt-in
-    // — runtime or via restart — never retroactively ships events recorded
-    // during the opt-out window. Deliberately NOT gated on dbReady: getDb()
+    // stop()). New opted-out tool_invocations rows are already unreportable by
+    // construction — the audit listener persists NULL telemetry columns for
+    // them, which the tool_executed projection filters out — so the opted-out
+    // flushes are defense in depth there (covering rows recorded under builds
+    // that predate that write-time gate) and remain the primary guard for the
+    // always-on tables without a write-time gate (llm_usage, turn events).
+    // Deliberately NOT gated on dbReady: getDb()
     // can still work when initializeDb() failed mid-migration, in which case
     // the audit listener keeps writing rows that the opt-out branch must keep
     // covered. The reporter is degraded-mode safe — its constructor and

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -635,21 +635,35 @@ export async function runDaemon(): Promise<void> {
     }
 
     // Privacy gating: Sentry crash/error reporting is gated by sendDiagnostics,
-    // while the usage telemetry reporter is gated by collectUsageData. Both are
-    // disabled in dev mode. Early-startup crashes before this point are still captured.
+    // while the usage telemetry reporter re-checks collectUsageData on every
+    // flush. Both are disabled in dev mode. Early-startup crashes before this
+    // point are still captured.
     const isDevMode = process.env.VELLUM_DEV === "1";
     const sendDiagnostics = !isDevMode && config.sendDiagnostics;
-    const collectUsageData = !isDevMode && config.collectUsageData;
     if (!sendDiagnostics) {
       await closeSentry();
     }
 
+    // Construct and start the reporter even when usage collection is disabled:
+    // flush() re-checks collectUsageData each cycle and, when opted out, sends
+    // nothing but advances all watermarks (including the final flush in
+    // stop()). That keeps the watermarks ahead of the always-on
+    // tool_invocations audit rows across opted-out sessions, so a later opt-in
+    // — runtime or via restart — never retroactively ships events recorded
+    // during the opt-out window. Deliberately NOT gated on dbReady: getDb()
+    // can still work when initializeDb() failed mid-migration, in which case
+    // the audit listener keeps writing rows that the opt-out branch must keep
+    // covered. The reporter is degraded-mode safe — its constructor and
+    // flush() treat DB errors as non-fatal.
     let telemetryReporter: UsageTelemetryReporter | null = null;
-    if (collectUsageData) {
+    if (!isDevMode) {
       telemetryReporter = new UsageTelemetryReporter();
       setUsageTelemetryReporter(telemetryReporter);
       telemetryReporter.start();
-      log.info("Usage telemetry reporter started");
+      log.info(
+        { collectUsageData: config.collectUsageData },
+        "Usage telemetry reporter started",
+      );
     }
 
     // CES lifecycle — kick off early so CES handshake runs concurrently with

--- a/assistant/src/daemon/tool-setup-types.ts
+++ b/assistant/src/daemon/tool-setup-types.ts
@@ -4,6 +4,7 @@
  */
 
 import type { InterfaceId } from "../channels/types.js";
+import type { LLMCallSite } from "../config/schemas/llm.js";
 import type { SurfaceConversationContext } from "./conversation-surfaces.js";
 import type { TrustContext } from "./trust-context.js";
 
@@ -46,6 +47,14 @@ export interface ToolSetupContext extends SurfaceConversationContext {
    * trust rules auto-executing side-effect tools in non-interactive contexts.
    */
   forcePromptSideEffects?: boolean;
+  /**
+   * The LLM call site driving the current turn, set by `runAgentLoopImpl`
+   * (`options.callSite ?? "mainAgent"`). Non-main turns (voice `callAgent`,
+   * `filingAgent`, …) resolve different provider/model/profile config, so
+   * tool telemetry attribution must use this rather than assuming
+   * `mainAgent`. Absent before the first turn starts.
+   */
+  currentCallSite?: LLMCallSite;
   /**
    * Per-turn snapshot of the resolved inference-profile override, set by
    * `runAgentLoopImpl`. Propagated into `ToolContext.overrideProfile` so

--- a/assistant/src/events/tool-audit-listener.ts
+++ b/assistant/src/events/tool-audit-listener.ts
@@ -1,3 +1,4 @@
+import { getConfig } from "../config/loader.js";
 import {
   recordToolInvocation,
   type ToolInvocationRecord,
@@ -8,7 +9,10 @@ import {
   type ToolLifecycleEvent,
   type ToolLifecycleEventHandler,
 } from "../tools/types.js";
-import { toAttributionColumns } from "../usage/attribution.js";
+import {
+  toAttributionColumns,
+  type UsageAttributionColumns,
+} from "../usage/attribution.js";
 import { getLogger } from "../util/logger.js";
 
 const RESULT_PREVIEW_LIMIT = 1000;
@@ -52,11 +56,16 @@ function toInvocationRecord(
         riskLevel: event.riskLevel,
         matchedTrustRuleId: event.matchedTrustRuleId,
         durationMs: event.durationMs,
-        // The fallback keeps argBytes non-null, which the tool_executed
-        // projection's legacy-row filter relies on.
-        argBytes: event.inputBytes ?? Buffer.byteLength(input, "utf8"),
-        resultBytes: Buffer.byteLength(event.result.content, "utf8"),
-        ...toAttributionColumns(event.attribution),
+        // Prefer the executor-stamped raw pre-sanitization size: by the
+        // time listeners run, sensitive-output extraction has already
+        // rewritten `result.content`, so sizing it here would undercount
+        // for sensitive-output tools. The fallback covers emitters that
+        // don't stamp.
+        ...telemetryColumns(
+          event,
+          input,
+          event.resultBytes ?? Buffer.byteLength(event.result.content, "utf8"),
+        ),
       };
     }
     case "error": {
@@ -71,10 +80,10 @@ function toInvocationRecord(
         riskLevel: event.riskLevel,
         matchedTrustRuleId: event.matchedTrustRuleId,
         durationMs: event.durationMs,
-        // Same sizing contract as the "executed" case above.
-        argBytes: event.inputBytes ?? Buffer.byteLength(input, "utf8"),
-        resultBytes: Buffer.byteLength(result, "utf8"),
-        ...toAttributionColumns(event.attribution),
+        // The error result string is built right here and never goes
+        // through sensitive-output sanitization, so sizing it directly is
+        // already raw — no executor stamp exists or is needed.
+        ...telemetryColumns(event, input, Buffer.byteLength(result, "utf8")),
       };
     }
     case "permission_denied":
@@ -94,6 +103,46 @@ function toInvocationRecord(
     case "permission_prompt":
       return null;
   }
+}
+
+type TelemetryColumns = Pick<ToolInvocationRecord, "argBytes" | "resultBytes"> &
+  UsageAttributionColumns;
+
+const NULL_TELEMETRY_COLUMNS: TelemetryColumns = {
+  argBytes: null,
+  resultBytes: null,
+  provider: null,
+  model: null,
+  inferenceProfile: null,
+  inferenceProfileSource: null,
+};
+
+/**
+ * Telemetry-only columns (payload sizes + model attribution) for an
+ * executed/error audit row. This is the single write-time privacy gate for
+ * `tool_executed` telemetry: when usage data collection is disabled, the
+ * columns persist as NULL, which the projection's `arg_bytes IS NOT NULL`
+ * filter excludes permanently — the same mechanism that excludes legacy
+ * pre-migration rows (see tool-executed-events-store.ts). That makes
+ * opted-out rows unreportable by construction: no later opt-in, crash, or
+ * watermark race can ship them. The audit fields themselves (tool name,
+ * decision, input/result previews, duration) are unaffected —
+ * `tool_invocations` is a local always-on audit log.
+ *
+ * When opted in, the non-null sizing keeps `argBytes` populated, which the
+ * projection's legacy-row filter relies on.
+ */
+function telemetryColumns(
+  event: Extract<ToolLifecycleEvent, { type: "executed" | "error" }>,
+  input: string,
+  resultBytes: number,
+): TelemetryColumns {
+  if (!getConfig().collectUsageData) return NULL_TELEMETRY_COLUMNS;
+  return {
+    argBytes: event.inputBytes ?? Buffer.byteLength(input, "utf8"),
+    resultBytes,
+    ...toAttributionColumns(event.attribution),
+  };
 }
 
 function formatDeniedResult(reason: string): string {

--- a/assistant/src/events/tool-audit-listener.ts
+++ b/assistant/src/events/tool-audit-listener.ts
@@ -7,6 +7,7 @@ import type {
   ToolLifecycleEvent,
   ToolLifecycleEventHandler,
 } from "../tools/types.js";
+import type { UsageAttributionSnapshot } from "../usage/attribution.js";
 import { getLogger } from "../util/logger.js";
 
 const RESULT_PREVIEW_LIMIT = 1000;
@@ -36,11 +37,12 @@ function toInvocationRecord(
   event: ToolLifecycleEvent,
 ): ToolInvocationRecord | null {
   switch (event.type) {
-    case "executed":
+    case "executed": {
+      const input = stringifyInput(event.input);
       return {
         conversationId: event.conversationId,
         toolName: event.toolName,
-        input: stringifyInput(event.input),
+        input,
         result: redactSecrets(event.result.content).slice(
           0,
           RESULT_PREVIEW_LIMIT,
@@ -49,19 +51,34 @@ function toInvocationRecord(
         riskLevel: event.riskLevel,
         matchedTrustRuleId: event.matchedTrustRuleId,
         durationMs: event.durationMs,
+        // Byte sizes are computed here from the raw payloads — the stored
+        // `result` column is truncated and redacted above, so sizing at
+        // query time would undercount. Only the sizes leave the device.
+        argBytes: Buffer.byteLength(input, "utf8"),
+        resultBytes: Buffer.byteLength(event.result.content, "utf8"),
+        ...toAttributionFields(event.attribution),
       };
-    case "error":
+    }
+    case "error": {
+      const input = stringifyInput(event.input);
+      const result = `error: ${event.errorMessage}`;
       return {
         conversationId: event.conversationId,
         toolName: event.toolName,
-        input: stringifyInput(event.input),
-        result: `error: ${event.errorMessage}`,
+        input,
+        result,
         decision: "error",
         riskLevel: event.riskLevel,
         matchedTrustRuleId: event.matchedTrustRuleId,
         durationMs: event.durationMs,
+        argBytes: Buffer.byteLength(input, "utf8"),
+        resultBytes: Buffer.byteLength(result, "utf8"),
+        ...toAttributionFields(event.attribution),
       };
+    }
     case "permission_denied":
+      // No telemetry fields: the tool never executed, and denied rows are
+      // filtered out of the tool_executed projection anyway.
       return {
         conversationId: event.conversationId,
         toolName: event.toolName,
@@ -76,6 +93,25 @@ function toInvocationRecord(
     case "permission_prompt":
       return null;
   }
+}
+
+/**
+ * Maps an attribution snapshot to the tool_invocations telemetry columns —
+ * the same mapping `llm_usage` reporting uses (`appliedProfile` →
+ * inference_profile, `profileSource` → inference_profile_source).
+ */
+function toAttributionFields(
+  attribution: UsageAttributionSnapshot | null | undefined,
+): Pick<
+  ToolInvocationRecord,
+  "provider" | "model" | "inferenceProfile" | "inferenceProfileSource"
+> {
+  return {
+    provider: attribution?.resolvedProvider ?? null,
+    model: attribution?.resolvedModel ?? null,
+    inferenceProfile: attribution?.appliedProfile ?? null,
+    inferenceProfileSource: attribution?.profileSource ?? null,
+  };
 }
 
 function stringifyInput(input: Record<string, unknown>): string {

--- a/assistant/src/events/tool-audit-listener.ts
+++ b/assistant/src/events/tool-audit-listener.ts
@@ -52,13 +52,8 @@ function toInvocationRecord(
         riskLevel: event.riskLevel,
         matchedTrustRuleId: event.matchedTrustRuleId,
         durationMs: event.durationMs,
-        // Byte sizes reflect the full raw payloads — only the sizes leave
-        // the device. The arg size prefers `event.inputBytes`, stamped by
-        // the executor BEFORE input sanitization; the fallback sizes the
-        // (sanitized) event input so argBytes stays non-null, which the
-        // tool_executed projection's legacy-row filter relies on. The
-        // result size is computed before the stored `result` column is
-        // truncated and redacted above.
+        // The fallback keeps argBytes non-null, which the tool_executed
+        // projection's legacy-row filter relies on.
         argBytes: event.inputBytes ?? Buffer.byteLength(input, "utf8"),
         resultBytes: Buffer.byteLength(event.result.content, "utf8"),
         ...toAttributionColumns(event.attribution),

--- a/assistant/src/events/tool-audit-listener.ts
+++ b/assistant/src/events/tool-audit-listener.ts
@@ -7,7 +7,7 @@ import type {
   ToolLifecycleEvent,
   ToolLifecycleEventHandler,
 } from "../tools/types.js";
-import type { UsageAttributionSnapshot } from "../usage/attribution.js";
+import { toAttributionColumns } from "../usage/attribution.js";
 import { getLogger } from "../util/logger.js";
 
 const RESULT_PREVIEW_LIMIT = 1000;
@@ -56,7 +56,7 @@ function toInvocationRecord(
         // query time would undercount. Only the sizes leave the device.
         argBytes: Buffer.byteLength(input, "utf8"),
         resultBytes: Buffer.byteLength(event.result.content, "utf8"),
-        ...toAttributionFields(event.attribution),
+        ...toAttributionColumns(event.attribution),
       };
     }
     case "error": {
@@ -73,7 +73,7 @@ function toInvocationRecord(
         durationMs: event.durationMs,
         argBytes: Buffer.byteLength(input, "utf8"),
         resultBytes: Buffer.byteLength(result, "utf8"),
-        ...toAttributionFields(event.attribution),
+        ...toAttributionColumns(event.attribution),
       };
     }
     case "permission_denied":
@@ -93,25 +93,6 @@ function toInvocationRecord(
     case "permission_prompt":
       return null;
   }
-}
-
-/**
- * Maps an attribution snapshot to the tool_invocations telemetry columns —
- * the same mapping `llm_usage` reporting uses (`appliedProfile` →
- * inference_profile, `profileSource` → inference_profile_source).
- */
-function toAttributionFields(
-  attribution: UsageAttributionSnapshot | null | undefined,
-): Pick<
-  ToolInvocationRecord,
-  "provider" | "model" | "inferenceProfile" | "inferenceProfileSource"
-> {
-  return {
-    provider: attribution?.resolvedProvider ?? null,
-    model: attribution?.resolvedModel ?? null,
-    inferenceProfile: attribution?.appliedProfile ?? null,
-    inferenceProfileSource: attribution?.profileSource ?? null,
-  };
 }
 
 function stringifyInput(input: Record<string, unknown>): string {

--- a/assistant/src/events/tool-audit-listener.ts
+++ b/assistant/src/events/tool-audit-listener.ts
@@ -3,9 +3,10 @@ import {
   type ToolInvocationRecord,
 } from "../memory/tool-usage-store.js";
 import { redactSecrets } from "../security/secret-scanner.js";
-import type {
-  ToolLifecycleEvent,
-  ToolLifecycleEventHandler,
+import {
+  stringifyToolInput,
+  type ToolLifecycleEvent,
+  type ToolLifecycleEventHandler,
 } from "../tools/types.js";
 import { toAttributionColumns } from "../usage/attribution.js";
 import { getLogger } from "../util/logger.js";
@@ -38,7 +39,7 @@ function toInvocationRecord(
 ): ToolInvocationRecord | null {
   switch (event.type) {
     case "executed": {
-      const input = stringifyInput(event.input);
+      const input = stringifyToolInput(event.input);
       return {
         conversationId: event.conversationId,
         toolName: event.toolName,
@@ -51,16 +52,20 @@ function toInvocationRecord(
         riskLevel: event.riskLevel,
         matchedTrustRuleId: event.matchedTrustRuleId,
         durationMs: event.durationMs,
-        // Byte sizes are computed here from the raw payloads — the stored
-        // `result` column is truncated and redacted above, so sizing at
-        // query time would undercount. Only the sizes leave the device.
-        argBytes: Buffer.byteLength(input, "utf8"),
+        // Byte sizes reflect the full raw payloads — only the sizes leave
+        // the device. The arg size prefers `event.inputBytes`, stamped by
+        // the executor BEFORE input sanitization; the fallback sizes the
+        // (sanitized) event input so argBytes stays non-null, which the
+        // tool_executed projection's legacy-row filter relies on. The
+        // result size is computed before the stored `result` column is
+        // truncated and redacted above.
+        argBytes: event.inputBytes ?? Buffer.byteLength(input, "utf8"),
         resultBytes: Buffer.byteLength(event.result.content, "utf8"),
         ...toAttributionColumns(event.attribution),
       };
     }
     case "error": {
-      const input = stringifyInput(event.input);
+      const input = stringifyToolInput(event.input);
       const result = `error: ${event.errorMessage}`;
       return {
         conversationId: event.conversationId,
@@ -71,7 +76,8 @@ function toInvocationRecord(
         riskLevel: event.riskLevel,
         matchedTrustRuleId: event.matchedTrustRuleId,
         durationMs: event.durationMs,
-        argBytes: Buffer.byteLength(input, "utf8"),
+        // Same sizing contract as the "executed" case above.
+        argBytes: event.inputBytes ?? Buffer.byteLength(input, "utf8"),
         resultBytes: Buffer.byteLength(result, "utf8"),
         ...toAttributionColumns(event.attribution),
       };
@@ -82,7 +88,7 @@ function toInvocationRecord(
       return {
         conversationId: event.conversationId,
         toolName: event.toolName,
-        input: stringifyInput(event.input),
+        input: stringifyToolInput(event.input),
         result: formatDeniedResult(event.reason),
         decision: "denied",
         riskLevel: event.riskLevel,
@@ -92,14 +98,6 @@ function toInvocationRecord(
     case "start":
     case "permission_prompt":
       return null;
-  }
-}
-
-function stringifyInput(input: Record<string, unknown>): string {
-  try {
-    return JSON.stringify(input);
-  } catch {
-    return "[unserializable-input]";
   }
 }
 

--- a/assistant/src/events/tool-metrics-listener.ts
+++ b/assistant/src/events/tool-metrics-listener.ts
@@ -1,3 +1,4 @@
+import { stringifyToolInput } from "../tools/types.js";
 import { getLogger, truncateForLog } from "../util/logger.js";
 import type { EventBus, Subscription } from "./bus.js";
 import type { AssistantDomainEvents } from "./domain-events.js";
@@ -129,9 +130,5 @@ function formatInputForLog(
   input: Record<string, unknown>,
   truncate: (value: string, maxLen: number) => string,
 ): string {
-  try {
-    return truncate(JSON.stringify(input), INPUT_PREVIEW_LIMIT);
-  } catch {
-    return "[unserializable-input]";
-  }
+  return truncate(stringifyToolInput(input), INPUT_PREVIEW_LIMIT);
 }

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -72,6 +72,7 @@ import {
   memorySummaries,
   messageAttachments,
   messages,
+  skillLoadedEvents,
   toolInvocations,
 } from "./schema.js";
 import { cancelPendingJobsForConversation } from "./task-memory-cleanup.js";
@@ -1185,6 +1186,9 @@ export function deleteConversation(id: string): DeletedMemoryIds {
       tx.delete(toolInvocations)
         .where(eq(toolInvocations.conversationId, id))
         .run();
+      tx.delete(skillLoadedEvents)
+        .where(eq(skillLoadedEvents.conversationId, id))
+        .run();
       // Cascade deletes memory_segments, message_attachments.
       tx.delete(messages).where(eq(messages.conversationId, id)).run();
 
@@ -1206,6 +1210,9 @@ export function deleteConversation(id: string): DeletedMemoryIds {
         .run();
       tx.delete(toolInvocations)
         .where(eq(toolInvocations.conversationId, id))
+        .run();
+      tx.delete(skillLoadedEvents)
+        .where(eq(skillLoadedEvents.conversationId, id))
         .run();
     }
 
@@ -1264,7 +1271,7 @@ export function wipeConversation(id: string): WipeConversationResult {
 
   // Step D — Delegate to deleteConversation which handles messages (cascade
   // segments, attachments), llmRequestLogs, toolInvocations,
-  // embeddings, and the conversation row.
+  // skillLoadedEvents, embeddings, and the conversation row.
   const deletedMemoryIds = deleteConversation(id);
 
   // Step E — Return the combined result.
@@ -2105,6 +2112,7 @@ export async function clearAll(): Promise<{
   await runOrThrow("DELETE FROM message_attachments");
   await runOrThrow("DELETE FROM attachments");
   await runOrThrow("DELETE FROM tool_invocations");
+  await runOrThrow("DELETE FROM skill_loaded_events");
   let messagesFtsCorrupted = false;
   const ftsResult = await runAsyncSqlite("DELETE FROM messages_fts");
   if (!ftsResult.ok) {

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -206,6 +206,7 @@ import {
   migrateToolInvocationsCreatedAtIdIndex,
   migrateToolInvocationsMatchedRuleId,
   migrateToolInvocationsSkillId,
+  migrateToolInvocationsTelemetryColumns,
   migrateTraceEventsCreatedAtIndex,
   migrateUsageDashboardIndexes,
   migrateUsageLlmCallCount,
@@ -491,6 +492,7 @@ export function initializeDb(): void {
     migrateToolInvocationsSkillId,
     migrateToolInvocationsCreatedAtIdIndex,
     migrateAddMemoryV3EverInjected,
+    migrateToolInvocationsTelemetryColumns,
     createSkillLoadedEventsTable,
   ];
 

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -37,6 +37,7 @@ import {
   createOnboardingEventsTable,
   createScopedApprovalGrantsTable,
   createSequenceTables,
+  createSkillLoadedEventsTable,
   createTasksAndWorkItemsTables,
   createWatchersAndLogsTables,
   migrate230AcpSessionHistory,
@@ -490,6 +491,7 @@ export function initializeDb(): void {
     migrateToolInvocationsSkillId,
     migrateToolInvocationsCreatedAtIdIndex,
     migrateAddMemoryV3EverInjected,
+    createSkillLoadedEventsTable,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/job-handlers/cleanup.ts
+++ b/assistant/src/memory/job-handlers/cleanup.ts
@@ -164,7 +164,8 @@ function parseDeletedCount(stdout: string | undefined): number {
  * conversation_keys, channel_inbound_events, message_runs, call_sessions,
  * external_conversation_bindings, assistant_inbox_conversation_state) are handled
  * automatically. Tables without cascade (messages, tool_invocations,
- * llm_request_logs) are deleted explicitly before removing the conversation row.
+ * llm_request_logs, skill_loaded_events) are deleted explicitly before
+ * removing the conversation row.
  */
 export function pruneOldConversationsJob(
   job: MemoryJob,
@@ -206,6 +207,7 @@ export function pruneOldConversationsJob(
       rawRun(`DELETE FROM llm_request_logs WHERE conversation_id = ?`, id);
       rawRun(`DELETE FROM tool_invocations WHERE conversation_id = ?`, id);
       rawRun(`DELETE FROM messages WHERE conversation_id = ?`, id);
+      rawRun(`DELETE FROM skill_loaded_events WHERE conversation_id = ?`, id);
       // Conversation row deletion cascades to remaining dependent tables
       rawRun(`DELETE FROM conversations WHERE id = ?`, id);
       pruned++;

--- a/assistant/src/memory/migrations/278-tool-invocations-telemetry-columns.test.ts
+++ b/assistant/src/memory/migrations/278-tool-invocations-telemetry-columns.test.ts
@@ -1,0 +1,96 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import * as schema from "../schema.js";
+import { migrateToolInvocationsTelemetryColumns } from "./278-tool-invocations-telemetry-columns.js";
+
+const NEW_COLUMNS = [
+  "arg_bytes",
+  "result_bytes",
+  "provider",
+  "model",
+  "inference_profile",
+  "inference_profile_source",
+];
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  // Pre-278 shape: skill_id exists (275), telemetry columns do not.
+  sqlite.exec(/*sql*/ `
+    CREATE TABLE tool_invocations (
+      id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL,
+      tool_name TEXT NOT NULL,
+      input TEXT NOT NULL,
+      result TEXT NOT NULL,
+      decision TEXT NOT NULL,
+      risk_level TEXT NOT NULL,
+      matched_trust_rule_id TEXT,
+      duration_ms INTEGER NOT NULL,
+      created_at INTEGER NOT NULL,
+      skill_id TEXT
+    )
+  `);
+  return { sqlite, db: drizzle(sqlite, { schema }) };
+}
+
+function tableInfo(sqlite: Database) {
+  return sqlite.query("PRAGMA table_info(tool_invocations)").all() as Array<{
+    name: string;
+    notnull: number;
+  }>;
+}
+
+describe("migration 278: tool_invocations telemetry columns", () => {
+  test("adds the nullable telemetry columns", () => {
+    const { sqlite, db } = createTestDb();
+    const before = tableInfo(sqlite).map((c) => c.name);
+    for (const name of NEW_COLUMNS) {
+      expect(before).not.toContain(name);
+    }
+
+    migrateToolInvocationsTelemetryColumns(db);
+
+    const after = tableInfo(sqlite);
+    for (const name of NEW_COLUMNS) {
+      const column = after.find((c) => c.name === name);
+      expect(column).toBeDefined();
+      expect(column?.notnull).toBe(0);
+    }
+  });
+
+  test("existing rows read back with null telemetry columns", () => {
+    const { sqlite, db } = createTestDb();
+    sqlite.exec(/*sql*/ `
+      INSERT INTO tool_invocations
+        (id, conversation_id, tool_name, input, result, decision, risk_level, duration_ms, created_at)
+      VALUES
+        ('ti-1', 'conv-1', 'bash', '{}', 'ok', 'allow', 'low', 5, 1000)
+    `);
+
+    migrateToolInvocationsTelemetryColumns(db);
+
+    const row = sqlite
+      .query(
+        `SELECT ${NEW_COLUMNS.join(", ")} FROM tool_invocations WHERE id = 'ti-1'`,
+      )
+      .get() as Record<string, unknown>;
+    for (const name of NEW_COLUMNS) {
+      expect(row[name]).toBeNull();
+    }
+  });
+
+  test("is idempotent — re-run is a no-op", () => {
+    const { sqlite, db } = createTestDb();
+
+    migrateToolInvocationsTelemetryColumns(db);
+    expect(() => migrateToolInvocationsTelemetryColumns(db)).not.toThrow();
+
+    const names = tableInfo(sqlite).map((c) => c.name);
+    for (const name of NEW_COLUMNS) {
+      expect(names.filter((n) => n === name)).toHaveLength(1);
+    }
+  });
+});

--- a/assistant/src/memory/migrations/278-tool-invocations-telemetry-columns.ts
+++ b/assistant/src/memory/migrations/278-tool-invocations-telemetry-columns.ts
@@ -12,21 +12,14 @@ const COLUMNS: Array<{ name: string; type: string }> = [
 
 /**
  * Add nullable telemetry columns to `tool_invocations` for the
- * `tool_executed` telemetry projection.
+ * `tool_executed` telemetry projection: serialized payload sizes (only the
+ * sizes leave the device, never the payloads) and the conversation's model
+ * attribution at invocation time. Nullable so pre-migration and
+ * permission-denied rows stay NULL (see the legacy-row filter in
+ * tool-executed-events-store.ts).
  *
- * `arg_bytes` / `result_bytes` record the serialized payload sizes computed
- * by the audit listener BEFORE the stored `result` column is truncated and
- * redacted — only the sizes leave the device, never the payloads. The
- * `provider` / `model` / `inference_profile` / `inference_profile_source`
- * columns snapshot the conversation's model attribution at invocation time
- * (same mapping the `llm_usage` events use).
- *
- * All columns are nullable — `NULL` for rows persisted before this migration
- * ran and for permission-denied rows (the tool never executed; they are
- * filtered out of the telemetry projection).
- *
- * Idempotent — re-running is a no-op once the columns exist. Pure DDL with a
- * PRAGMA guard, no registry entry needed (matches the 273 / 275 pattern).
+ * Idempotent pure DDL with a PRAGMA guard, no registry entry needed
+ * (matches the 273 / 275 pattern).
  */
 export function migrateToolInvocationsTelemetryColumns(
   database: DrizzleDb,

--- a/assistant/src/memory/migrations/278-tool-invocations-telemetry-columns.ts
+++ b/assistant/src/memory/migrations/278-tool-invocations-telemetry-columns.ts
@@ -1,0 +1,46 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+
+const TABLE = "tool_invocations";
+const COLUMNS: Array<{ name: string; type: string }> = [
+  { name: "arg_bytes", type: "INTEGER" },
+  { name: "result_bytes", type: "INTEGER" },
+  { name: "provider", type: "TEXT" },
+  { name: "model", type: "TEXT" },
+  { name: "inference_profile", type: "TEXT" },
+  { name: "inference_profile_source", type: "TEXT" },
+];
+
+/**
+ * Add nullable telemetry columns to `tool_invocations` for the
+ * `tool_executed` telemetry projection.
+ *
+ * `arg_bytes` / `result_bytes` record the serialized payload sizes computed
+ * by the audit listener BEFORE the stored `result` column is truncated and
+ * redacted — only the sizes leave the device, never the payloads. The
+ * `provider` / `model` / `inference_profile` / `inference_profile_source`
+ * columns snapshot the conversation's model attribution at invocation time
+ * (same mapping the `llm_usage` events use).
+ *
+ * All columns are nullable — `NULL` for rows persisted before this migration
+ * ran and for permission-denied rows (the tool never executed; they are
+ * filtered out of the telemetry projection).
+ *
+ * Idempotent — re-running is a no-op once the columns exist. Pure DDL with a
+ * PRAGMA guard, no registry entry needed (matches the 273 / 275 pattern).
+ */
+export function migrateToolInvocationsTelemetryColumns(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  const columns = raw.query(`PRAGMA table_info(${TABLE})`).all() as Array<{
+    name: string;
+  }>;
+  const columnNames = new Set(columns.map((c) => c.name));
+
+  for (const { name, type } of COLUMNS) {
+    if (!columnNames.has(name)) {
+      raw.exec(`ALTER TABLE ${TABLE} ADD COLUMN ${name} ${type}`);
+    }
+  }
+}

--- a/assistant/src/memory/migrations/279-create-skill-loaded-events.test.ts
+++ b/assistant/src/memory/migrations/279-create-skill-loaded-events.test.ts
@@ -1,0 +1,84 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import * as schema from "../schema.js";
+import { createSkillLoadedEventsTable } from "./279-create-skill-loaded-events.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  return { sqlite, db: drizzle(sqlite, { schema }) };
+}
+
+function columnNames(sqlite: Database): string[] {
+  return (
+    sqlite.query("PRAGMA table_info(skill_loaded_events)").all() as Array<{
+      name: string;
+    }>
+  ).map((c) => c.name);
+}
+
+function indexNames(sqlite: Database): string[] {
+  return (
+    sqlite.query("PRAGMA index_list(skill_loaded_events)").all() as Array<{
+      name: string;
+    }>
+  ).map((i) => i.name);
+}
+
+describe("migration 279: skill_loaded_events table", () => {
+  test("creates the table with the expected columns", () => {
+    const { sqlite, db } = createTestDb();
+
+    createSkillLoadedEventsTable(db);
+
+    expect(columnNames(sqlite)).toEqual([
+      "id",
+      "created_at",
+      "conversation_id",
+      "skill_name",
+      "skill_updated_at",
+      "provider",
+      "model",
+      "inference_profile",
+      "inference_profile_source",
+    ]);
+  });
+
+  test("creates the (created_at, id) cursor index", () => {
+    const { sqlite, db } = createTestDb();
+
+    createSkillLoadedEventsTable(db);
+
+    expect(indexNames(sqlite)).toContain(
+      "idx_skill_loaded_events_created_at_id",
+    );
+    const columns = (
+      sqlite
+        .query("PRAGMA index_info(idx_skill_loaded_events_created_at_id)")
+        .all() as Array<{ name: string }>
+    ).map((c) => c.name);
+    expect(columns).toEqual(["created_at", "id"]);
+  });
+
+  test("is idempotent — re-run is a no-op and preserves existing rows", () => {
+    const { sqlite, db } = createTestDb();
+
+    createSkillLoadedEventsTable(db);
+    sqlite.exec(/*sql*/ `
+      INSERT INTO skill_loaded_events (id, created_at, skill_name)
+      VALUES ('sle-1', 1000, 'web-research')
+    `);
+
+    expect(() => createSkillLoadedEventsTable(db)).not.toThrow();
+
+    const rows = sqlite.query("SELECT id FROM skill_loaded_events").all();
+    expect(rows).toEqual([{ id: "sle-1" }]);
+    expect(
+      indexNames(sqlite).filter(
+        (name) => name === "idx_skill_loaded_events_created_at_id",
+      ),
+    ).toHaveLength(1);
+  });
+});

--- a/assistant/src/memory/migrations/279-create-skill-loaded-events.ts
+++ b/assistant/src/memory/migrations/279-create-skill-loaded-events.ts
@@ -1,0 +1,27 @@
+import type { DrizzleDb } from "../db-connection.js";
+
+/**
+ * Create the skill_loaded_events table for `skill_loaded` telemetry events.
+ * One row per activation of a Vellum-produced skill — metadata only, never
+ * skill output or conversation content. Rows are flushed to the platform
+ * telemetry endpoint by the usage telemetry reporter, which seeks with a
+ * compound `(created_at, id)` watermark cursor backed by the index below.
+ */
+export function createSkillLoadedEventsTable(database: DrizzleDb): void {
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS skill_loaded_events (
+      id TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL,
+      conversation_id TEXT,
+      skill_name TEXT NOT NULL,
+      skill_updated_at TEXT,
+      provider TEXT,
+      model TEXT,
+      inference_profile TEXT,
+      inference_profile_source TEXT
+    )
+  `);
+  database.run(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_skill_loaded_events_created_at_id ON skill_loaded_events (created_at, id)`,
+  );
+}

--- a/assistant/src/memory/migrations/279-create-skill-loaded-events.ts
+++ b/assistant/src/memory/migrations/279-create-skill-loaded-events.ts
@@ -1,11 +1,10 @@
 import type { DrizzleDb } from "../db-connection.js";
 
 /**
- * Create the skill_loaded_events table for `skill_loaded` telemetry events.
- * One row per activation of a Vellum-produced skill — metadata only, never
- * skill output or conversation content. Rows are flushed to the platform
- * telemetry endpoint by the usage telemetry reporter, which seeks with a
- * compound `(created_at, id)` watermark cursor backed by the index below.
+ * Create the skill_loaded_events table for `skill_loaded` telemetry events —
+ * one row per activation of a Vellum-produced skill (see
+ * skill-loaded-events-store.ts for the data contract). The index backs the
+ * telemetry reporter's compound `(created_at, id)` watermark cursor.
  */
 export function createSkillLoadedEventsTable(database: DrizzleDb): void {
   database.run(/*sql*/ `

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -265,6 +265,7 @@ export { createActivationSessionsTable } from "./274-create-activation-sessions.
 export { migrateToolInvocationsSkillId } from "./275-tool-invocations-add-skill-id.js";
 export { migrateToolInvocationsCreatedAtIdIndex } from "./276-tool-invocations-created-at-id-index.js";
 export { migrateAddMemoryV3EverInjected } from "./277-add-memory-v3-ever-injected.js";
+export { createSkillLoadedEventsTable } from "./279-create-skill-loaded-events.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -265,6 +265,7 @@ export { createActivationSessionsTable } from "./274-create-activation-sessions.
 export { migrateToolInvocationsSkillId } from "./275-tool-invocations-add-skill-id.js";
 export { migrateToolInvocationsCreatedAtIdIndex } from "./276-tool-invocations-created-at-id-index.js";
 export { migrateAddMemoryV3EverInjected } from "./277-add-memory-v3-ever-injected.js";
+export { migrateToolInvocationsTelemetryColumns } from "./278-tool-invocations-telemetry-columns.js";
 export { createSkillLoadedEventsTable } from "./279-create-skill-loaded-events.js";
 export {
   MIGRATION_REGISTRY,

--- a/assistant/src/memory/schema/conversations.ts
+++ b/assistant/src/memory/schema/conversations.ts
@@ -93,6 +93,14 @@ export const toolInvocations = sqliteTable(
     matchedTrustRuleId: text("matched_trust_rule_id"),
     durationMs: integer("duration_ms").notNull(),
     createdAt: integer("created_at").notNull(),
+    /** Serialized input size in bytes, computed before any redaction. Null pre-migration-278. */
+    argBytes: integer("arg_bytes"),
+    /** Full serialized result size in bytes, computed before truncation/redaction. Null pre-migration-278 and for denied rows. */
+    resultBytes: integer("result_bytes"),
+    provider: text("provider"),
+    model: text("model"),
+    inferenceProfile: text("inference_profile"),
+    inferenceProfileSource: text("inference_profile_source"),
   },
   (table) => [
     index("idx_tool_invocations_conversation_id").on(table.conversationId),

--- a/assistant/src/memory/schema/infrastructure.ts
+++ b/assistant/src/memory/schema/infrastructure.ts
@@ -308,9 +308,8 @@ export const activationSessions = sqliteTable("activation_sessions", {
 });
 
 // One row per `skill_loaded` telemetry event, emitted when a Vellum-produced
-// skill is activated in a conversation. Metadata only — never skill output or
-// conversation content. Flushed to the platform telemetry endpoint by the
-// usage telemetry reporter via a compound (created_at, id) watermark cursor.
+// skill is activated in a conversation — see skill-loaded-events-store.ts for
+// the data contract. Flushed by the usage telemetry reporter.
 export const skillLoadedEvents = sqliteTable(
   "skill_loaded_events",
   {

--- a/assistant/src/memory/schema/infrastructure.ts
+++ b/assistant/src/memory/schema/infrastructure.ts
@@ -307,6 +307,32 @@ export const activationSessions = sqliteTable("activation_sessions", {
   createdAt: integer("created_at").notNull(),
 });
 
+// One row per `skill_loaded` telemetry event, emitted when a Vellum-produced
+// skill is activated in a conversation. Metadata only — never skill output or
+// conversation content. Flushed to the platform telemetry endpoint by the
+// usage telemetry reporter via a compound (created_at, id) watermark cursor.
+export const skillLoadedEvents = sqliteTable(
+  "skill_loaded_events",
+  {
+    id: text("id").primaryKey(),
+    createdAt: integer("created_at").notNull(),
+    conversationId: text("conversation_id"),
+    skillName: text("skill_name").notNull(),
+    // ISO 8601 timestamp from the merged skill catalog, when known.
+    skillUpdatedAt: text("skill_updated_at"),
+    provider: text("provider"),
+    model: text("model"),
+    inferenceProfile: text("inference_profile"),
+    inferenceProfileSource: text("inference_profile_source"),
+  },
+  (table) => [
+    index("idx_skill_loaded_events_created_at_id").on(
+      table.createdAt,
+      table.id,
+    ),
+  ],
+);
+
 export const traceEvents = sqliteTable(
   "trace_events",
   {

--- a/assistant/src/memory/skill-loaded-events-store.test.ts
+++ b/assistant/src/memory/skill-loaded-events-store.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Silence the logger.
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { getDb } from "./db-connection.js";
+import { initializeDb } from "./db-init.js";
+import { skillLoadedEvents } from "./schema.js";
+import {
+  queryUnreportedSkillLoadedEvents,
+  recordSkillLoadedEvent,
+} from "./skill-loaded-events-store.js";
+
+initializeDb();
+
+function insertEvent(
+  id: string,
+  createdAt: number,
+  skillName = "web-research",
+): void {
+  getDb().insert(skillLoadedEvents).values({ id, createdAt, skillName }).run();
+}
+
+describe("skill-loaded-events-store", () => {
+  beforeEach(() => {
+    getDb().delete(skillLoadedEvents).run();
+  });
+
+  test("record + query round-trips all fields", () => {
+    recordSkillLoadedEvent({
+      conversationId: "conv-xyz",
+      skillName: "web-research",
+      skillUpdatedAt: "2026-06-01T00:00:00.000Z",
+      provider: "anthropic",
+      model: "model-a",
+      inferenceProfile: "balanced",
+      inferenceProfileSource: "active-profile",
+    });
+
+    const rows = queryUnreportedSkillLoadedEvents(0, undefined, 10);
+    expect(rows).toHaveLength(1);
+    const row = rows[0]!;
+    expect(row.id).toBeString();
+    expect(row.createdAt).toBeGreaterThan(0);
+    expect(row).toMatchObject({
+      conversationId: "conv-xyz",
+      skillName: "web-research",
+      skillUpdatedAt: "2026-06-01T00:00:00.000Z",
+      provider: "anthropic",
+      model: "model-a",
+      inferenceProfile: "balanced",
+      inferenceProfileSource: "active-profile",
+    });
+  });
+
+  test("optional fields persist as null", () => {
+    recordSkillLoadedEvent({ skillName: "tasks" });
+
+    const rows = queryUnreportedSkillLoadedEvents(0, undefined, 10);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      skillName: "tasks",
+      conversationId: null,
+      skillUpdatedAt: null,
+      provider: null,
+      model: null,
+      inferenceProfile: null,
+      inferenceProfileSource: null,
+    });
+  });
+
+  test("returns rows in (createdAt, id) order", () => {
+    insertEvent("sle-b", 2000);
+    insertEvent("sle-a", 1000);
+
+    const rows = queryUnreportedSkillLoadedEvents(0, undefined, 100);
+    expect(rows.map((r) => r.id)).toEqual(["sle-a", "sle-b"]);
+  });
+
+  test("query advances past the compound (createdAt, id) cursor", () => {
+    // Two rows in the same millisecond: pagination must use the id
+    // tiebreaker to make forward progress, not loop.
+    insertEvent("sle-1", 5000);
+    insertEvent("sle-2", 5000);
+    insertEvent("sle-3", 6000);
+
+    const first = queryUnreportedSkillLoadedEvents(0, undefined, 1);
+    expect(first.map((r) => r.id)).toEqual(["sle-1"]);
+
+    const second = queryUnreportedSkillLoadedEvents(
+      first[0]!.createdAt,
+      first[0]!.id,
+      100,
+    );
+    expect(second.map((r) => r.id)).toEqual(["sle-2", "sle-3"]);
+
+    // Without an id cursor the timestamp-only branch is used.
+    expect(
+      queryUnreportedSkillLoadedEvents(5000, undefined, 100).map((r) => r.id),
+    ).toEqual(["sle-3"]);
+
+    // Cursor past the last row returns nothing.
+    const last = second[second.length - 1]!;
+    expect(
+      queryUnreportedSkillLoadedEvents(last.createdAt, last.id, 100).length,
+    ).toBe(0);
+  });
+
+  test("resumes from a persisted watermark without re-reporting", () => {
+    insertEvent("sle-w1", 1000);
+    insertEvent("sle-w2", 2000);
+
+    const batch = queryUnreportedSkillLoadedEvents(0, undefined, 100);
+    const watermark = batch[batch.length - 1]!;
+
+    insertEvent("sle-w3", 3000);
+
+    const resumed = queryUnreportedSkillLoadedEvents(
+      watermark.createdAt,
+      watermark.id,
+      100,
+    );
+    expect(resumed.map((r) => r.id)).toEqual(["sle-w3"]);
+  });
+
+  test("honors the limit", () => {
+    insertEvent("sle-l1", 1000);
+    insertEvent("sle-l2", 2000);
+    insertEvent("sle-l3", 3000);
+
+    const rows = queryUnreportedSkillLoadedEvents(0, undefined, 2);
+    expect(rows.map((r) => r.id)).toEqual(["sle-l1", "sle-l2"]);
+  });
+});

--- a/assistant/src/memory/skill-loaded-events-store.test.ts
+++ b/assistant/src/memory/skill-loaded-events-store.test.ts
@@ -8,6 +8,20 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+let collectUsageData = true;
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    rateLimit: { maxRequestsPerMinute: 0 },
+    secretDetection: { enabled: false },
+    collectUsageData,
+  }),
+}));
+
 import { getDb } from "./db-connection.js";
 import { initializeDb } from "./db-init.js";
 import { skillLoadedEvents } from "./schema.js";
@@ -28,7 +42,14 @@ function insertEvent(
 
 describe("skill-loaded-events-store", () => {
   beforeEach(() => {
+    collectUsageData = true;
     getDb().delete(skillLoadedEvents).run();
+  });
+
+  test("honors the collectUsageData opt-out (records nothing)", () => {
+    collectUsageData = false;
+    recordSkillLoadedEvent({ skillName: "web-research" });
+    expect(queryUnreportedSkillLoadedEvents(0, undefined, 10)).toHaveLength(0);
   });
 
   test("record + query round-trips all fields", () => {

--- a/assistant/src/memory/skill-loaded-events-store.ts
+++ b/assistant/src/memory/skill-loaded-events-store.ts
@@ -1,0 +1,90 @@
+import { and, asc, eq, gt, or } from "drizzle-orm";
+import { v4 as uuid } from "uuid";
+
+import { getDb } from "./db-connection.js";
+import { skillLoadedEvents } from "./schema.js";
+
+/**
+ * Input for one `skill_loaded` telemetry event. Metadata only — never skill
+ * output or conversation content.
+ */
+export interface SkillLoadedEventRecord {
+  conversationId?: string;
+  skillName: string;
+  /** ISO 8601 timestamp from the merged skill catalog, when known. */
+  skillUpdatedAt?: string;
+  provider?: string;
+  model?: string;
+  inferenceProfile?: string;
+  inferenceProfileSource?: string;
+}
+
+/** A persisted skill_loaded event row. */
+export interface SkillLoadedEvent {
+  id: string;
+  createdAt: number;
+  conversationId: string | null;
+  skillName: string;
+  skillUpdatedAt: string | null;
+  provider: string | null;
+  model: string | null;
+  inferenceProfile: string | null;
+  inferenceProfileSource: string | null;
+}
+
+/** Record a `skill_loaded` telemetry event for a skill activation. */
+export function recordSkillLoadedEvent(record: SkillLoadedEventRecord): void {
+  const db = getDb();
+  db.insert(skillLoadedEvents)
+    .values({
+      id: uuid(),
+      createdAt: Date.now(),
+      conversationId: record.conversationId,
+      skillName: record.skillName,
+      skillUpdatedAt: record.skillUpdatedAt,
+      provider: record.provider,
+      model: record.model,
+      inferenceProfile: record.inferenceProfile,
+      inferenceProfileSource: record.inferenceProfileSource,
+    })
+    .run();
+}
+
+/**
+ * Query skill_loaded events that haven't been reported to telemetry yet.
+ * Uses a compound cursor (createdAt + id) for reliable watermarking.
+ */
+export function queryUnreportedSkillLoadedEvents(
+  afterCreatedAt: number,
+  afterId: string | undefined,
+  limit: number,
+): SkillLoadedEvent[] {
+  const db = getDb();
+  return db
+    .select({
+      id: skillLoadedEvents.id,
+      createdAt: skillLoadedEvents.createdAt,
+      conversationId: skillLoadedEvents.conversationId,
+      skillName: skillLoadedEvents.skillName,
+      skillUpdatedAt: skillLoadedEvents.skillUpdatedAt,
+      provider: skillLoadedEvents.provider,
+      model: skillLoadedEvents.model,
+      inferenceProfile: skillLoadedEvents.inferenceProfile,
+      inferenceProfileSource: skillLoadedEvents.inferenceProfileSource,
+    })
+    .from(skillLoadedEvents)
+    .where(
+      afterId
+        ? or(
+            gt(skillLoadedEvents.createdAt, afterCreatedAt),
+            and(
+              eq(skillLoadedEvents.createdAt, afterCreatedAt),
+              gt(skillLoadedEvents.id, afterId),
+            ),
+          )
+        : gt(skillLoadedEvents.createdAt, afterCreatedAt),
+    )
+    .orderBy(asc(skillLoadedEvents.createdAt), asc(skillLoadedEvents.id))
+    .limit(limit)
+    .all();
+}

--- a/assistant/src/memory/skill-loaded-events-store.ts
+++ b/assistant/src/memory/skill-loaded-events-store.ts
@@ -1,6 +1,7 @@
 import { and, asc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
+import { getConfig } from "../config/loader.js";
 import { getDb } from "./db-connection.js";
 import { skillLoadedEvents } from "./schema.js";
 
@@ -32,8 +33,13 @@ export interface SkillLoadedEvent {
   inferenceProfileSource: string | null;
 }
 
-/** Record a `skill_loaded` telemetry event for a skill activation. */
+/**
+ * Record a `skill_loaded` telemetry event for a skill activation. No-ops when
+ * usage data collection is disabled (the event is dropped to honor the
+ * opt-out, matching the rest of telemetry).
+ */
 export function recordSkillLoadedEvent(record: SkillLoadedEventRecord): void {
+  if (!getConfig().collectUsageData) return;
   const db = getDb();
   db.insert(skillLoadedEvents)
     .values({

--- a/assistant/src/memory/skill-loaded-events-store.ts
+++ b/assistant/src/memory/skill-loaded-events-store.ts
@@ -2,22 +2,21 @@ import { and, asc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getConfig } from "../config/loader.js";
+import type { UsageAttributionColumns } from "../usage/attribution.js";
 import { getDb } from "./db-connection.js";
 import { skillLoadedEvents } from "./schema.js";
 
 /**
  * Input for one `skill_loaded` telemetry event. Metadata only — never skill
- * output or conversation content.
+ * output or conversation content. The attribution columns reuse the shared
+ * nullable shape from `toAttributionColumns` so producers can spread it
+ * directly; null and absent both persist as NULL.
  */
-export interface SkillLoadedEventRecord {
+export interface SkillLoadedEventRecord extends Partial<UsageAttributionColumns> {
   conversationId?: string;
   skillName: string;
   /** ISO 8601 timestamp from the merged skill catalog, when known. */
   skillUpdatedAt?: string;
-  provider?: string;
-  model?: string;
-  inferenceProfile?: string;
-  inferenceProfileSource?: string;
 }
 
 /** A persisted skill_loaded event row. */

--- a/assistant/src/memory/tool-executed-events-store.test.ts
+++ b/assistant/src/memory/tool-executed-events-store.test.ts
@@ -8,70 +8,24 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+import {
+  seedToolInvocation,
+  TOOL_INVOCATION_PII_SENTINEL as PII_SENTINEL,
+  type ToolInvocationSeedSpec,
+} from "../__tests__/test-support/tool-invocation-seed.js";
 import { getDb } from "./db-connection.js";
 import { initializeDb } from "./db-init.js";
-import { conversations, toolInvocations } from "./schema.js";
+import { toolInvocations } from "./schema.js";
 import { queryUnreportedToolExecutedEvents } from "./tool-executed-events-store.js";
 
 initializeDb();
 
 const CONVERSATION_ID = "conv-tool-executed-store-test";
 
-/**
- * Sentinel embedded in the seeded raw input/result payloads. Asserted to
- * never appear in any projection — raw tool args/outputs must never leave
- * the device.
- */
-const PII_SENTINEL = "must never leave the device";
-
-interface SeedSpec {
-  id: string;
-  createdAt: number;
-  toolName?: string;
-  decision?: string;
-  durationMs?: number;
-  argBytes?: number | null;
-  resultBytes?: number | null;
-  provider?: string | null;
-  model?: string | null;
-  inferenceProfile?: string | null;
-  inferenceProfileSource?: string | null;
-}
-
-function insertInvocation(spec: SeedSpec): void {
-  const db = getDb();
-  // tool_invocations has an enforced FK to conversations.
-  db.insert(conversations)
-    .values({
-      id: CONVERSATION_ID,
-      title: "test",
-      createdAt: 1000,
-      updatedAt: 1000,
-    })
-    .onConflictDoNothing()
-    .run();
-  db.insert(toolInvocations)
-    .values({
-      id: spec.id,
-      conversationId: CONVERSATION_ID,
-      toolName: spec.toolName ?? "calendar_list_events",
-      input: `{"secret":"raw tool args — ${PII_SENTINEL}"}`,
-      result: `{"secret":"raw tool output — ${PII_SENTINEL}"}`,
-      decision: spec.decision ?? "allow",
-      riskLevel: "low",
-      durationMs: spec.durationMs ?? 12,
-      createdAt: spec.createdAt,
-      // Post-migration writer paths always compute byte sizes (legacy
-      // pre-migration rows are the only null-argBytes rows), so the seed
-      // defaults to non-null. Pass an explicit null to seed a legacy row.
-      argBytes: spec.argBytes !== undefined ? spec.argBytes : 2,
-      resultBytes: spec.resultBytes !== undefined ? spec.resultBytes : 9,
-      provider: spec.provider ?? null,
-      model: spec.model ?? null,
-      inferenceProfile: spec.inferenceProfile ?? null,
-      inferenceProfileSource: spec.inferenceProfileSource ?? null,
-    })
-    .run();
+function insertInvocation(
+  spec: Omit<ToolInvocationSeedSpec, "conversationId">,
+): void {
+  seedToolInvocation({ ...spec, conversationId: CONVERSATION_ID });
 }
 
 describe("tool-executed-events-store", () => {
@@ -134,9 +88,8 @@ describe("tool-executed-events-store", () => {
   });
 
   test("excludes legacy pre-migration rows (null arg_bytes)", () => {
-    // Pre-migration-278 rows were already shipped under the since-reverted
-    // tool_execution event type — they must never be projected, even from
-    // a zero watermark.
+    // Already shipped under the reverted tool_execution type — never
+    // projected, even from a zero watermark.
     insertInvocation({
       id: "ti-legacy",
       createdAt: 1000,

--- a/assistant/src/memory/tool-executed-events-store.test.ts
+++ b/assistant/src/memory/tool-executed-events-store.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Silence the logger.
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { getDb } from "./db-connection.js";
+import { initializeDb } from "./db-init.js";
+import { conversations, toolInvocations } from "./schema.js";
+import { queryUnreportedToolExecutedEvents } from "./tool-executed-events-store.js";
+
+initializeDb();
+
+const CONVERSATION_ID = "conv-tool-executed-store-test";
+
+/**
+ * Sentinel embedded in the seeded raw input/result payloads. Asserted to
+ * never appear in any projection — raw tool args/outputs must never leave
+ * the device.
+ */
+const PII_SENTINEL = "must never leave the device";
+
+interface SeedSpec {
+  id: string;
+  createdAt: number;
+  toolName?: string;
+  decision?: string;
+  durationMs?: number;
+  argBytes?: number | null;
+  resultBytes?: number | null;
+  provider?: string | null;
+  model?: string | null;
+  inferenceProfile?: string | null;
+  inferenceProfileSource?: string | null;
+}
+
+function insertInvocation(spec: SeedSpec): void {
+  const db = getDb();
+  // tool_invocations has an enforced FK to conversations.
+  db.insert(conversations)
+    .values({
+      id: CONVERSATION_ID,
+      title: "test",
+      createdAt: 1000,
+      updatedAt: 1000,
+    })
+    .onConflictDoNothing()
+    .run();
+  db.insert(toolInvocations)
+    .values({
+      id: spec.id,
+      conversationId: CONVERSATION_ID,
+      toolName: spec.toolName ?? "calendar_list_events",
+      input: `{"secret":"raw tool args — ${PII_SENTINEL}"}`,
+      result: `{"secret":"raw tool output — ${PII_SENTINEL}"}`,
+      decision: spec.decision ?? "allow",
+      riskLevel: "low",
+      durationMs: spec.durationMs ?? 12,
+      createdAt: spec.createdAt,
+      argBytes: spec.argBytes ?? null,
+      resultBytes: spec.resultBytes ?? null,
+      provider: spec.provider ?? null,
+      model: spec.model ?? null,
+      inferenceProfile: spec.inferenceProfile ?? null,
+      inferenceProfileSource: spec.inferenceProfileSource ?? null,
+    })
+    .run();
+}
+
+describe("tool-executed-events-store", () => {
+  beforeEach(() => {
+    getDb().delete(toolInvocations).run();
+  });
+
+  test("projects telemetry fields in (createdAt, id) order without input/result", () => {
+    insertInvocation({
+      id: "ti-b",
+      createdAt: 2000,
+      toolName: "web_search",
+      decision: "error",
+      durationMs: 7,
+    });
+    insertInvocation({
+      id: "ti-a",
+      createdAt: 1000,
+      argBytes: 42,
+      resultBytes: 9001,
+      provider: "anthropic",
+      model: "model-a",
+      inferenceProfile: "balanced",
+      inferenceProfileSource: "active",
+    });
+
+    const rows = queryUnreportedToolExecutedEvents(0, undefined, 100);
+    expect(rows.map((r) => r.id)).toEqual(["ti-a", "ti-b"]);
+    expect(rows[0]).toEqual({
+      id: "ti-a",
+      toolName: "calendar_list_events",
+      decision: "allow",
+      durationMs: 12,
+      argBytes: 42,
+      resultBytes: 9001,
+      provider: "anthropic",
+      model: "model-a",
+      inferenceProfile: "balanced",
+      inferenceProfileSource: "active",
+      conversationId: CONVERSATION_ID,
+      createdAt: 1000,
+    });
+    expect(rows[1]).toMatchObject({
+      toolName: "web_search",
+      decision: "error",
+      durationMs: 7,
+    });
+    // Raw tool args/outputs are potentially PII — the projection must
+    // never include them.
+    expect(JSON.stringify(rows)).not.toContain(PII_SENTINEL);
+  });
+
+  test("excludes permission-denied rows", () => {
+    insertInvocation({ id: "ti-denied", createdAt: 1000, decision: "denied" });
+    insertInvocation({ id: "ti-allow", createdAt: 2000 });
+    insertInvocation({ id: "ti-error", createdAt: 3000, decision: "error" });
+
+    const rows = queryUnreportedToolExecutedEvents(0, undefined, 100);
+    expect(rows.map((r) => r.id)).toEqual(["ti-allow", "ti-error"]);
+  });
+
+  test("pre-migration rows project with null telemetry columns", () => {
+    insertInvocation({ id: "ti-old", createdAt: 1000 });
+
+    const rows = queryUnreportedToolExecutedEvents(0, undefined, 100);
+    expect(rows[0]).toMatchObject({
+      argBytes: null,
+      resultBytes: null,
+      provider: null,
+      model: null,
+      inferenceProfile: null,
+      inferenceProfileSource: null,
+    });
+  });
+
+  test("query advances past the compound (createdAt, id) cursor", () => {
+    // Two rows in the same millisecond: pagination must use the id
+    // tiebreaker to make forward progress, not loop.
+    insertInvocation({ id: "ti-1", createdAt: 5000 });
+    insertInvocation({ id: "ti-2", createdAt: 5000 });
+    insertInvocation({ id: "ti-3", createdAt: 6000 });
+
+    const first = queryUnreportedToolExecutedEvents(0, undefined, 1);
+    expect(first.map((r) => r.id)).toEqual(["ti-1"]);
+
+    const second = queryUnreportedToolExecutedEvents(
+      first[0]!.createdAt,
+      first[0]!.id,
+      100,
+    );
+    expect(second.map((r) => r.id)).toEqual(["ti-2", "ti-3"]);
+
+    // Without an id cursor the timestamp-only branch is used.
+    expect(
+      queryUnreportedToolExecutedEvents(5000, undefined, 100).map((r) => r.id),
+    ).toEqual(["ti-3"]);
+
+    // Cursor past the last row returns nothing.
+    const last = second[second.length - 1]!;
+    expect(
+      queryUnreportedToolExecutedEvents(last.createdAt, last.id, 100).length,
+    ).toBe(0);
+  });
+
+  test("honors the limit", () => {
+    insertInvocation({ id: "ti-l1", createdAt: 1000 });
+    insertInvocation({ id: "ti-l2", createdAt: 2000 });
+    insertInvocation({ id: "ti-l3", createdAt: 3000 });
+
+    const rows = queryUnreportedToolExecutedEvents(0, undefined, 2);
+    expect(rows.map((r) => r.id)).toEqual(["ti-l1", "ti-l2"]);
+  });
+});

--- a/assistant/src/memory/tool-executed-events-store.test.ts
+++ b/assistant/src/memory/tool-executed-events-store.test.ts
@@ -8,11 +8,21 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+// Toggle for the collectUsageData opt-out gate the audit listener consults
+// when populating the telemetry columns.
+let collectUsageData = true;
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({ collectUsageData }),
+}));
+
 import {
   seedToolInvocation,
   TOOL_INVOCATION_PII_SENTINEL as PII_SENTINEL,
   type ToolInvocationSeedSpec,
 } from "../__tests__/test-support/tool-invocation-seed.js";
+import { createToolAuditListener } from "../events/tool-audit-listener.js";
+import type { ToolLifecycleEvent } from "../tools/types.js";
 import { getDb } from "./db-connection.js";
 import { initializeDb } from "./db-init.js";
 import { toolInvocations } from "./schema.js";
@@ -30,6 +40,7 @@ function insertInvocation(
 
 describe("tool-executed-events-store", () => {
   beforeEach(() => {
+    collectUsageData = true;
     getDb().delete(toolInvocations).run();
   });
 
@@ -100,6 +111,55 @@ describe("tool-executed-events-store", () => {
 
     const rows = queryUnreportedToolExecutedEvents(0, undefined, 100);
     expect(rows.map((r) => r.id)).toEqual(["ti-new"]);
+  });
+
+  test("rows recorded while opted out are never projected, even from a zero watermark", () => {
+    // End-to-end through the real audit listener: the write-time opt-out
+    // gate persists NULL telemetry columns, which the arg_bytes IS NOT NULL
+    // filter excludes permanently — the same mechanism as legacy rows. No
+    // watermark state is involved, so no later opt-in can ship these rows.
+    const listener = createToolAuditListener();
+    const executedEvent = (toolName: string): ToolLifecycleEvent => ({
+      type: "executed",
+      toolName,
+      input: { path: "/tmp/a" },
+      workingDir: "/tmp",
+      conversationId: CONVERSATION_ID,
+      riskLevel: "low",
+      decision: "allow",
+      durationMs: 5,
+      result: { content: "ok", isError: false },
+    });
+
+    listener(executedEvent("t-opted-in-before"));
+
+    collectUsageData = false;
+    listener(executedEvent("t-opted-out"));
+
+    collectUsageData = true;
+    listener(executedEvent("t-opted-in-after"));
+
+    // Mid-session opt-out flip: only rows recorded while opted in project.
+    const rows = queryUnreportedToolExecutedEvents(0, undefined, 100);
+    expect(rows.map((r) => r.toolName).sort()).toEqual([
+      "t-opted-in-after",
+      "t-opted-in-before",
+    ]);
+
+    // The audit row itself is still recorded — only its telemetry columns
+    // are NULL.
+    const auditRows = getDb().select().from(toolInvocations).all();
+    expect(auditRows).toHaveLength(3);
+    const optedOut = auditRows.find((r) => r.toolName === "t-opted-out");
+    expect(optedOut).toMatchObject({
+      decision: "allow",
+      argBytes: null,
+      resultBytes: null,
+      provider: null,
+      model: null,
+      inferenceProfile: null,
+      inferenceProfileSource: null,
+    });
   });
 
   test("post-migration rows project with null attribution columns", () => {

--- a/assistant/src/memory/tool-executed-events-store.test.ts
+++ b/assistant/src/memory/tool-executed-events-store.test.ts
@@ -25,7 +25,7 @@ import { createToolAuditListener } from "../events/tool-audit-listener.js";
 import type { ToolLifecycleEvent } from "../tools/types.js";
 import { getDb } from "./db-connection.js";
 import { initializeDb } from "./db-init.js";
-import { toolInvocations } from "./schema.js";
+import { conversations, toolInvocations } from "./schema.js";
 import { queryUnreportedToolExecutedEvents } from "./tool-executed-events-store.js";
 
 initializeDb();
@@ -35,7 +35,10 @@ const CONVERSATION_ID = "conv-tool-executed-store-test";
 function insertInvocation(
   spec: Omit<ToolInvocationSeedSpec, "conversationId">,
 ): void {
-  seedToolInvocation({ ...spec, conversationId: CONVERSATION_ID });
+  seedToolInvocation(
+    { db: getDb(), conversations, toolInvocations },
+    { ...spec, conversationId: CONVERSATION_ID },
+  );
 }
 
 describe("tool-executed-events-store", () => {

--- a/assistant/src/memory/tool-executed-events-store.test.ts
+++ b/assistant/src/memory/tool-executed-events-store.test.ts
@@ -61,8 +61,11 @@ function insertInvocation(spec: SeedSpec): void {
       riskLevel: "low",
       durationMs: spec.durationMs ?? 12,
       createdAt: spec.createdAt,
-      argBytes: spec.argBytes ?? null,
-      resultBytes: spec.resultBytes ?? null,
+      // Post-migration writer paths always compute byte sizes (legacy
+      // pre-migration rows are the only null-argBytes rows), so the seed
+      // defaults to non-null. Pass an explicit null to seed a legacy row.
+      argBytes: spec.argBytes !== undefined ? spec.argBytes : 2,
+      resultBytes: spec.resultBytes !== undefined ? spec.resultBytes : 9,
       provider: spec.provider ?? null,
       model: spec.model ?? null,
       inferenceProfile: spec.inferenceProfile ?? null,
@@ -130,13 +133,29 @@ describe("tool-executed-events-store", () => {
     expect(rows.map((r) => r.id)).toEqual(["ti-allow", "ti-error"]);
   });
 
-  test("pre-migration rows project with null telemetry columns", () => {
-    insertInvocation({ id: "ti-old", createdAt: 1000 });
+  test("excludes legacy pre-migration rows (null arg_bytes)", () => {
+    // Pre-migration-278 rows were already shipped under the since-reverted
+    // tool_execution event type — they must never be projected, even from
+    // a zero watermark.
+    insertInvocation({
+      id: "ti-legacy",
+      createdAt: 1000,
+      argBytes: null,
+      resultBytes: null,
+    });
+    insertInvocation({ id: "ti-new", createdAt: 2000 });
+
+    const rows = queryUnreportedToolExecutedEvents(0, undefined, 100);
+    expect(rows.map((r) => r.id)).toEqual(["ti-new"]);
+  });
+
+  test("post-migration rows project with null attribution columns", () => {
+    insertInvocation({ id: "ti-no-attr", createdAt: 1000 });
 
     const rows = queryUnreportedToolExecutedEvents(0, undefined, 100);
     expect(rows[0]).toMatchObject({
-      argBytes: null,
-      resultBytes: null,
+      argBytes: 2,
+      resultBytes: 9,
       provider: null,
       model: null,
       inferenceProfile: null,

--- a/assistant/src/memory/tool-executed-events-store.ts
+++ b/assistant/src/memory/tool-executed-events-store.ts
@@ -1,0 +1,83 @@
+import { and, asc, eq, gt, ne, or } from "drizzle-orm";
+
+import { getDb } from "./db-connection.js";
+import { toolInvocations } from "./schema.js";
+
+/**
+ * A `tool_invocations` audit row projected for `tool_executed` telemetry
+ * reporting.
+ *
+ * Deliberately excludes the `input` / `result` columns — raw tool
+ * args/outputs are potentially PII and must never leave the device. Only the
+ * payload SIZES (`argBytes` / `resultBytes`) are projected.
+ */
+export interface UnreportedToolExecutedEvent {
+  id: string;
+  toolName: string;
+  /** `"allow"`-style decisions or `"error"`; never `"denied"` (filtered out). */
+  decision: string;
+  durationMs: number;
+  /** Serialized input size in bytes. Null for rows persisted before migration 278. */
+  argBytes: number | null;
+  /** Full serialized result size in bytes. Null for rows persisted before migration 278. */
+  resultBytes: number | null;
+  provider: string | null;
+  model: string | null;
+  inferenceProfile: string | null;
+  inferenceProfileSource: string | null;
+  conversationId: string;
+  createdAt: number;
+}
+
+/**
+ * Query tool invocations that haven't been reported to telemetry yet.
+ * Uses a compound cursor (createdAt + id) for reliable watermarking.
+ *
+ * Permission-denied rows are excluded — the tool never executed, so no
+ * `tool_executed` event is emitted for them.
+ *
+ * Rows are written by the tool audit listener
+ * (`events/tool-audit-listener.ts`) — there is no record function here.
+ *
+ * Reporting is best-effort: `rotateToolInvocations` purges rows by
+ * `created_at` alone, so rows older than the configured
+ * `auditLog.retentionDays` window may be rotated away before they are
+ * reported (e.g. if the daemon is offline or failing for longer than
+ * the retention window).
+ */
+export function queryUnreportedToolExecutedEvents(
+  afterCreatedAt: number,
+  afterId: string | undefined,
+  limit: number,
+): UnreportedToolExecutedEvent[] {
+  const db = getDb();
+  const cursorPredicate = afterId
+    ? or(
+        gt(toolInvocations.createdAt, afterCreatedAt),
+        and(
+          eq(toolInvocations.createdAt, afterCreatedAt),
+          gt(toolInvocations.id, afterId),
+        ),
+      )
+    : gt(toolInvocations.createdAt, afterCreatedAt);
+  return db
+    .select({
+      id: toolInvocations.id,
+      toolName: toolInvocations.toolName,
+      decision: toolInvocations.decision,
+      durationMs: toolInvocations.durationMs,
+      argBytes: toolInvocations.argBytes,
+      resultBytes: toolInvocations.resultBytes,
+      provider: toolInvocations.provider,
+      model: toolInvocations.model,
+      inferenceProfile: toolInvocations.inferenceProfile,
+      inferenceProfileSource: toolInvocations.inferenceProfileSource,
+      conversationId: toolInvocations.conversationId,
+      createdAt: toolInvocations.createdAt,
+    })
+    .from(toolInvocations)
+    .where(and(ne(toolInvocations.decision, "denied"), cursorPredicate))
+    .orderBy(asc(toolInvocations.createdAt), asc(toolInvocations.id))
+    .limit(limit)
+    .all();
+}

--- a/assistant/src/memory/tool-executed-events-store.ts
+++ b/assistant/src/memory/tool-executed-events-store.ts
@@ -44,8 +44,8 @@ export interface UnreportedToolExecutedEvent {
  *   excluded by the decision filter), making `arg_bytes IS NOT NULL` a
  *   reliable legacy-row discriminator. It only guards pre-migration rows —
  *   rows recorded while telemetry is opted out are guarded separately by
- *   the reporter's construction-time watermark initialization (see
- *   usage-telemetry-reporter.ts).
+ *   the reporter's opt-out flush branch, which advances watermarks without
+ *   sending (see usage-telemetry-reporter.ts).
  *
  * Reporting is best-effort: `rotateToolInvocations` purges by `created_at`
  * alone, so rows older than `auditLog.retentionDays` may rotate away before

--- a/assistant/src/memory/tool-executed-events-store.ts
+++ b/assistant/src/memory/tool-executed-events-store.ts
@@ -17,17 +17,9 @@ export interface UnreportedToolExecutedEvent {
   /** `"allow"`-style decisions or `"error"`; never `"denied"` (filtered out). */
   decision: string;
   durationMs: number;
-  /**
-   * Serialized input size in bytes. Non-null in practice: legacy rows
-   * persisted before migration 278 have `arg_bytes IS NULL` and are excluded
-   * from the projection entirely (see the query's legacy-row filter).
-   */
+  /** Serialized raw input size in bytes. Non-null on projected rows (the legacy-row filter excludes null). */
   argBytes: number | null;
-  /**
-   * Full serialized result size in bytes. The audit listener writes it
-   * together with `argBytes`, so it is non-null on every projected row in
-   * practice.
-   */
+  /** Full serialized result size in bytes, computed before truncation/redaction. */
   resultBytes: number | null;
   provider: string | null;
   model: string | null;
@@ -40,30 +32,22 @@ export interface UnreportedToolExecutedEvent {
 /**
  * Query tool invocations that haven't been reported to telemetry yet.
  * Uses a compound cursor (createdAt + id) for reliable watermarking.
- *
- * Permission-denied rows are excluded — the tool never executed, so no
- * `tool_executed` event is emitted for them.
- *
- * Legacy rows persisted before migration 278 (null `arg_bytes`) are also
- * excluded: they were already shipped under the since-reverted
- * `tool_execution` event type and lack the size/attribution columns, so
- * re-shipping them as `tool_executed` would double-count with null
- * attribution. Every post-migration writer path (tool-audit-listener.ts
- * "executed" and "error" events) always computes a non-null `arg_bytes`;
- * the only path that leaves it null ("permission_denied") is already
- * excluded by the decision filter. This makes `arg_bytes IS NOT NULL` a
- * reliable legacy-row discriminator, which in turn lets the telemetry
- * reporter use the standard 0 watermark default without dropping rows
- * recorded before its first flush.
- *
  * Rows are written by the tool audit listener
  * (`events/tool-audit-listener.ts`) — there is no record function here.
  *
- * Reporting is best-effort: `rotateToolInvocations` purges rows by
- * `created_at` alone, so rows older than the configured
- * `auditLog.retentionDays` window may be rotated away before they are
- * reported (e.g. if the daemon is offline or failing for longer than
- * the retention window).
+ * Two row classes are excluded:
+ * - Permission-denied rows: the tool never executed.
+ * - Legacy pre-migration-278 rows (null `arg_bytes`): already shipped under
+ *   the since-reverted `tool_execution` event type and lacking the
+ *   size/attribution columns. Every post-migration writer path computes a
+ *   non-null `arg_bytes` (the only null writer, "permission_denied", is
+ *   excluded by the decision filter), making `arg_bytes IS NOT NULL` a
+ *   reliable legacy-row discriminator — which lets the reporter keep the
+ *   standard 0 watermark default without dropping pre-first-flush rows.
+ *
+ * Reporting is best-effort: `rotateToolInvocations` purges by `created_at`
+ * alone, so rows older than `auditLog.retentionDays` may rotate away before
+ * they are reported.
  */
 export function queryUnreportedToolExecutedEvents(
   afterCreatedAt: number,

--- a/assistant/src/memory/tool-executed-events-store.ts
+++ b/assistant/src/memory/tool-executed-events-store.ts
@@ -42,8 +42,10 @@ export interface UnreportedToolExecutedEvent {
  *   size/attribution columns. Every post-migration writer path computes a
  *   non-null `arg_bytes` (the only null writer, "permission_denied", is
  *   excluded by the decision filter), making `arg_bytes IS NOT NULL` a
- *   reliable legacy-row discriminator — which lets the reporter keep the
- *   standard 0 watermark default without dropping pre-first-flush rows.
+ *   reliable legacy-row discriminator. It only guards pre-migration rows —
+ *   rows recorded while telemetry is opted out are guarded separately by
+ *   the reporter's construction-time watermark initialization (see
+ *   usage-telemetry-reporter.ts).
  *
  * Reporting is best-effort: `rotateToolInvocations` purges by `created_at`
  * alone, so rows older than `auditLog.retentionDays` may rotate away before

--- a/assistant/src/memory/tool-executed-events-store.ts
+++ b/assistant/src/memory/tool-executed-events-store.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, gt, ne, or } from "drizzle-orm";
+import { and, asc, eq, gt, isNotNull, ne, or } from "drizzle-orm";
 
 import { getDb } from "./db-connection.js";
 import { toolInvocations } from "./schema.js";
@@ -17,9 +17,17 @@ export interface UnreportedToolExecutedEvent {
   /** `"allow"`-style decisions or `"error"`; never `"denied"` (filtered out). */
   decision: string;
   durationMs: number;
-  /** Serialized input size in bytes. Null for rows persisted before migration 278. */
+  /**
+   * Serialized input size in bytes. Non-null in practice: legacy rows
+   * persisted before migration 278 have `arg_bytes IS NULL` and are excluded
+   * from the projection entirely (see the query's legacy-row filter).
+   */
   argBytes: number | null;
-  /** Full serialized result size in bytes. Null for rows persisted before migration 278. */
+  /**
+   * Full serialized result size in bytes. The audit listener writes it
+   * together with `argBytes`, so it is non-null on every projected row in
+   * practice.
+   */
   resultBytes: number | null;
   provider: string | null;
   model: string | null;
@@ -35,6 +43,18 @@ export interface UnreportedToolExecutedEvent {
  *
  * Permission-denied rows are excluded — the tool never executed, so no
  * `tool_executed` event is emitted for them.
+ *
+ * Legacy rows persisted before migration 278 (null `arg_bytes`) are also
+ * excluded: they were already shipped under the since-reverted
+ * `tool_execution` event type and lack the size/attribution columns, so
+ * re-shipping them as `tool_executed` would double-count with null
+ * attribution. Every post-migration writer path (tool-audit-listener.ts
+ * "executed" and "error" events) always computes a non-null `arg_bytes`;
+ * the only path that leaves it null ("permission_denied") is already
+ * excluded by the decision filter. This makes `arg_bytes IS NOT NULL` a
+ * reliable legacy-row discriminator, which in turn lets the telemetry
+ * reporter use the standard 0 watermark default without dropping rows
+ * recorded before its first flush.
  *
  * Rows are written by the tool audit listener
  * (`events/tool-audit-listener.ts`) — there is no record function here.
@@ -76,7 +96,14 @@ export function queryUnreportedToolExecutedEvents(
       createdAt: toolInvocations.createdAt,
     })
     .from(toolInvocations)
-    .where(and(ne(toolInvocations.decision, "denied"), cursorPredicate))
+    .where(
+      and(
+        ne(toolInvocations.decision, "denied"),
+        // Legacy pre-migration-278 rows — see the doc comment above.
+        isNotNull(toolInvocations.argBytes),
+        cursorPredicate,
+      ),
+    )
     .orderBy(asc(toolInvocations.createdAt), asc(toolInvocations.id))
     .limit(limit)
     .all();

--- a/assistant/src/memory/tool-executed-events-store.ts
+++ b/assistant/src/memory/tool-executed-events-store.ts
@@ -17,9 +17,9 @@ export interface UnreportedToolExecutedEvent {
   /** `"allow"`-style decisions or `"error"`; never `"denied"` (filtered out). */
   decision: string;
   durationMs: number;
-  /** Serialized raw input size in bytes. Non-null on projected rows (the legacy-row filter excludes null). */
+  /** Serialized raw input size in bytes. Non-null on projected rows (the null-arg-bytes filter excludes legacy and opted-out rows). */
   argBytes: number | null;
-  /** Full serialized result size in bytes, computed before truncation/redaction. */
+  /** Raw result size in bytes, computed before truncation/redaction and sensitive-output sanitization. */
   resultBytes: number | null;
   provider: string | null;
   model: string | null;
@@ -37,13 +37,19 @@ export interface UnreportedToolExecutedEvent {
  *
  * Two row classes are excluded:
  * - Permission-denied rows: the tool never executed.
- * - Legacy pre-migration-278 rows (null `arg_bytes`): already shipped under
- *   the since-reverted `tool_execution` event type and lacking the
- *   size/attribution columns. Every post-migration writer path computes a
- *   non-null `arg_bytes` (the only null writer, "permission_denied", is
+ * - Rows with null `arg_bytes`, which covers two populations:
+ *   - Legacy pre-migration-278 rows: already shipped under the
+ *     since-reverted `tool_execution` event type and lacking the
+ *     size/attribution columns.
+ *   - Rows recorded while usage data collection was opted out: the audit
+ *     listener (`events/tool-audit-listener.ts`) persists NULL telemetry
+ *     columns for them at write time, making them unreportable by
+ *     construction — no later opt-in or watermark race can ship them.
+ *   Every opted-in post-migration writer path computes a non-null
+ *   `arg_bytes` (the only other null writer, "permission_denied", is
  *   excluded by the decision filter), making `arg_bytes IS NOT NULL` a
- *   reliable legacy-row discriminator. It only guards pre-migration rows —
- *   rows recorded while telemetry is opted out are guarded separately by
+ *   reliable discriminator. Opted-out rows recorded under builds that
+ *   predate the write-time gate carry non-null columns and are guarded by
  *   the reporter's opt-out flush branch, which advances watermarks without
  *   sending (see usage-telemetry-reporter.ts).
  *

--- a/assistant/src/memory/tool-usage-store.ts
+++ b/assistant/src/memory/tool-usage-store.ts
@@ -15,6 +15,14 @@ export interface ToolInvocationRecord {
   riskLevel: string;
   matchedTrustRuleId?: string;
   durationMs: number;
+  /** Serialized input size in bytes, computed before any redaction. */
+  argBytes?: number | null;
+  /** Full serialized result size in bytes, computed before truncation/redaction. */
+  resultBytes?: number | null;
+  provider?: string | null;
+  model?: string | null;
+  inferenceProfile?: string | null;
+  inferenceProfileSource?: string | null;
 }
 
 export function recordToolInvocation(record: ToolInvocationRecord): void {
@@ -31,6 +39,12 @@ export function recordToolInvocation(record: ToolInvocationRecord): void {
       matchedTrustRuleId: record.matchedTrustRuleId,
       durationMs: record.durationMs,
       createdAt: Date.now(),
+      argBytes: record.argBytes,
+      resultBytes: record.resultBytes,
+      provider: record.provider,
+      model: record.model,
+      inferenceProfile: record.inferenceProfile,
+      inferenceProfileSource: record.inferenceProfileSource,
     })
     .run();
 }

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -34,6 +34,27 @@ export interface TelemetryEventBase {
   assistant_version: string | null;
 }
 
+/**
+ * Base for telemetry events that occur in the context of a model call.
+ * Standardizes model attribution across event types — field names/shapes
+ * mirror the existing llm_usage event so downstream consumers (dbt, admin
+ * charts) can join/group consistently.
+ *
+ * `provider`/`model` are nullable on the wire because rows persisted before
+ * the attribution columns existed, and rows whose attribution resolution
+ * failed, must still ship; the platform serializer accepts null.
+ */
+export interface ModelTelemetryEventBase extends TelemetryEventBase {
+  /** Provider serving the call, e.g. "anthropic", "fireworks". */
+  provider: string | null;
+  /** Model id active for the call, e.g. "claude-fable-5". */
+  model: string | null;
+  /** Inference profile slug. Null when no profile applied. */
+  inference_profile: string | null;
+  /** How the profile was attributed (same enum as llm_usage). */
+  inference_profile_source: UsageAttributionProfileSource | null;
+}
+
 /** LLM usage event — one per provider API call. */
 export interface LlmUsageTelemetryEvent extends TelemetryEventBase {
   type: "llm_usage";
@@ -225,10 +246,48 @@ export interface AuthFallbackTelemetryEvent extends TelemetryEventBase {
   window_end: number;
 }
 
+/**
+ * Tool-executed event — one per tool invocation. Carries NO tool
+ * args/inputs or result contents (customer PII per ToS) — payload sizes
+ * and metadata only; no raw error messages. Identity/attribution come
+ * from the upload envelope per the per-event-wins contract. Distinct
+ * from the `tool_execution` permission-audit event, which it
+ * complements, not replaces.
+ */
+export interface ToolExecutedTelemetryEvent extends ModelTelemetryEventBase {
+  type: "tool_executed";
+  tool_name: string;
+  status: "fulfilled" | "errored";
+  duration_ms: number;
+  /** Serialized tool-argument size in bytes. Null when unknown. */
+  arg_bytes: number | null;
+  /** Serialized tool-result size in bytes. Null when unknown. */
+  result_bytes: number | null;
+  conversation_id: string | null;
+}
+
+/**
+ * Skill-loaded event — one per skill load. Emitted only for
+ * Vellum-produced skills (bundled, or managed with vellum origin).
+ * Metadata only — no skill output or conversation content.
+ */
+export interface SkillLoadedTelemetryEvent extends ModelTelemetryEventBase {
+  type: "skill_loaded";
+  skill_name: string;
+  /**
+   * ISO 8601 timestamp — the catalog's `updatedAt`, effectively the
+   * skill version. Null when the catalog carries no timestamp.
+   */
+  skill_updated_at: string | null;
+  conversation_id: string | null;
+}
+
 /** Discriminated union of all telemetry event types. */
 export type TelemetryEvent =
   | LlmUsageTelemetryEvent
   | TurnTelemetryEvent
   | LifecycleTelemetryEvent
   | OnboardingTelemetryEvent
-  | AuthFallbackTelemetryEvent;
+  | AuthFallbackTelemetryEvent
+  | ToolExecutedTelemetryEvent
+  | SkillLoadedTelemetryEvent;

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -250,13 +250,19 @@ export interface AuthFallbackTelemetryEvent extends TelemetryEventBase {
  * Tool-executed event — one per tool invocation. Carries NO tool
  * args/inputs or result contents (customer PII per ToS) — payload sizes
  * and metadata only; no raw error messages. Identity/attribution come
- * from the upload envelope per the per-event-wins contract. Distinct
- * from the `tool_execution` permission-audit event, which it
- * complements, not replaces.
+ * from the upload envelope per the per-event-wins contract. Not to be
+ * confused with the since-reverted `tool_execution` permission-audit
+ * event, which no longer exists on the wire.
  */
 export interface ToolExecutedTelemetryEvent extends ModelTelemetryEventBase {
   type: "tool_executed";
   tool_name: string;
+  /**
+   * `"errored"` means the invocation failed at the execution layer — a
+   * thrown error / infra failure (audit decision `"error"`). A tool that
+   * runs to completion but returns an `isError` result payload still
+   * counts as `"fulfilled"`: it executed.
+   */
   status: "fulfilled" | "errored";
   duration_ms: number;
   /** Serialized tool-argument size in bytes. Null when unknown. */

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -163,6 +163,7 @@ import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import {
   authFallbackEvents,
+  conversations,
   skillLoadedEvents,
   toolInvocations,
 } from "../memory/schema.js";
@@ -254,7 +255,10 @@ const TOOL_CONVERSATION_ID = "conv-reporter-tool-executed";
 function seedToolInvocation(
   spec: Omit<ToolInvocationSeedSpec, "conversationId">,
 ): void {
-  seedToolInvocationRow({ ...spec, conversationId: TOOL_CONVERSATION_ID });
+  seedToolInvocationRow(
+    { db: getDb(), conversations, toolInvocations },
+    { ...spec, conversationId: TOOL_CONVERSATION_ID },
+  );
 }
 
 /**

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -143,10 +143,11 @@ mock.module("../memory/onboarding-events-store.js", () => ({
   queryUnreportedOnboardingEvents: mockQueryUnreportedOnboardingEvents,
 }));
 
-// The auth-fallback store is intentionally NOT mocked — it has its own
-// DB-backed tests, and Bun's `mock.module` is process-global, so mocking it
-// here would leak into those tests when files share an invocation. We seed the
-// real DB instead so every auth-fallback test stays order-independent.
+// The auth-fallback, tool-executed, and skill-loaded stores are intentionally
+// NOT mocked — they have their own DB-backed tests, and Bun's `mock.module`
+// is process-global, so mocking them here would leak into those tests when
+// files share an invocation. We seed the real DB instead so every test stays
+// order-independent.
 
 // ---------------------------------------------------------------------------
 // Production import (after mocks)
@@ -155,7 +156,13 @@ mock.module("../memory/onboarding-events-store.js", () => ({
 import { recordAuthFallbackCounts } from "../memory/auth-fallback-events-store.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
-import { authFallbackEvents } from "../memory/schema.js";
+import {
+  authFallbackEvents,
+  conversations,
+  skillLoadedEvents,
+  toolInvocations,
+} from "../memory/schema.js";
+import { recordSkillLoadedEvent } from "../memory/skill-loaded-events-store.js";
 import type { UsageEvent } from "../usage/types.js";
 import {
   ACTIVATION_FUNNEL_VERSION,
@@ -238,6 +245,63 @@ function makeOnboardingEvent(
   };
 }
 
+const TOOL_CONVERSATION_ID = "conv-reporter-tool-executed";
+
+/**
+ * Sentinel embedded in the seeded raw input/result payloads. Asserted to
+ * never appear on the wire — raw tool args/outputs must never leave the
+ * device.
+ */
+const TOOL_PII_SENTINEL = "must never leave the device";
+
+function seedToolInvocation(spec: {
+  id: string;
+  createdAt: number;
+  toolName?: string;
+  decision?: string;
+  durationMs?: number;
+  argBytes?: number | null;
+  resultBytes?: number | null;
+  provider?: string | null;
+  model?: string | null;
+  inferenceProfile?: string | null;
+  inferenceProfileSource?: string | null;
+}): void {
+  const db = getDb();
+  // tool_invocations has an enforced FK to conversations.
+  db.insert(conversations)
+    .values({
+      id: TOOL_CONVERSATION_ID,
+      title: "test",
+      createdAt: 1000,
+      updatedAt: 1000,
+    })
+    .onConflictDoNothing()
+    .run();
+  db.insert(toolInvocations)
+    .values({
+      id: spec.id,
+      conversationId: TOOL_CONVERSATION_ID,
+      toolName: spec.toolName ?? "calendar_list_events",
+      input: `{"secret":"raw tool args — ${TOOL_PII_SENTINEL}"}`,
+      result: `{"secret":"raw tool output — ${TOOL_PII_SENTINEL}"}`,
+      decision: spec.decision ?? "allow",
+      riskLevel: "low",
+      durationMs: spec.durationMs ?? 12,
+      createdAt: spec.createdAt,
+      // Post-migration writer paths always compute byte sizes (legacy
+      // pre-migration rows are the only null-argBytes rows), so the seed
+      // defaults to non-null. Pass an explicit null to seed a legacy row.
+      argBytes: spec.argBytes !== undefined ? spec.argBytes : 2,
+      resultBytes: spec.resultBytes !== undefined ? spec.resultBytes : 9,
+      provider: spec.provider ?? null,
+      model: spec.model ?? null,
+      inferenceProfile: spec.inferenceProfile ?? null,
+      inferenceProfileSource: spec.inferenceProfileSource ?? null,
+    })
+    .run();
+}
+
 const originalFetch = globalThis.fetch;
 let mockFetch: ReturnType<typeof mock>;
 
@@ -258,6 +322,8 @@ beforeEach(() => {
   mockQueryUnreportedOnboardingEvents.mockReset();
   mockQueryUnreportedOnboardingEvents.mockReturnValue([]);
   getDb().delete(authFallbackEvents).run();
+  getDb().delete(toolInvocations).run();
+  getDb().delete(skillLoadedEvents).run();
   mockPlatformClient = null;
   mockGetPlatformBaseUrl.mockReset();
   mockGetDeviceId.mockReset();
@@ -966,9 +1032,9 @@ describe("UsageTelemetryReporter", () => {
     // No HTTP call should have been made
     expect(mockFetch).not.toHaveBeenCalled();
 
-    // All 5 timestamp watermarks should have been advanced (IDs left untouched
+    // All 7 timestamp watermarks should have been advanced (IDs left untouched
     // so the compound-cursor branch stays active)
-    expect(mockSetMemoryCheckpoint).toHaveBeenCalledTimes(5);
+    expect(mockSetMemoryCheckpoint).toHaveBeenCalledTimes(7);
 
     const calls = mockSetMemoryCheckpoint.mock.calls;
     const keys = calls.map((c) => c[0]);
@@ -977,6 +1043,8 @@ describe("UsageTelemetryReporter", () => {
     expect(keys).toContain("telemetry:lifecycle:last_reported_at");
     expect(keys).toContain("telemetry:onboarding:last_reported_at");
     expect(keys).toContain("telemetry:auth_fallback:last_reported_at");
+    expect(keys).toContain("telemetry:tool_executed:last_reported_at");
+    expect(keys).toContain("telemetry:skill_loaded:last_reported_at");
   });
 
   test("events sent normally after re-enabling collectUsageData", async () => {
@@ -1337,5 +1405,317 @@ describe("UsageTelemetryReporter", () => {
     expect(e.step_index).toBeUndefined();
     expect(e.completed_at).toBeUndefined();
     expect(e.funnel_version).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Tool-executed events
+  // -------------------------------------------------------------------------
+
+  test("tool_executed events project decision to status and never carry raw args/results", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    seedToolInvocation({
+      id: "ti-ok",
+      createdAt: 1700000001000,
+      toolName: "calendar_list_events",
+      decision: "allow",
+      durationMs: 12,
+      argBytes: 42,
+      resultBytes: 9001,
+      provider: "anthropic",
+      model: "model-a",
+      inferenceProfile: "balanced",
+      inferenceProfileSource: "active",
+    });
+    // Errored invocation without LLM attribution — the attribution columns
+    // are null and must pass through as null.
+    seedToolInvocation({
+      id: "ti-err",
+      createdAt: 1700000002000,
+      toolName: "web_search",
+      decision: "error",
+      durationMs: 7,
+      argBytes: 17,
+      resultBytes: 33,
+    });
+    // Permission-denied rows are filtered in the store and must never ship.
+    seedToolInvocation({
+      id: "ti-denied",
+      createdAt: 1700000003000,
+      decision: "denied",
+    });
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":2}', { status: 200 })),
+    );
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const rawBody = (mockFetch.mock.calls[0] as [string, RequestInit])[1]
+      .body as string;
+    // ToS/PII contract: raw tool args/outputs never leave the device.
+    expect(rawBody).not.toContain(TOOL_PII_SENTINEL);
+
+    const body = JSON.parse(rawBody);
+    expect(body.events.length).toBe(2);
+
+    const byId: Record<string, Record<string, unknown>> = {};
+    for (const e of body.events as Array<{ daemon_event_id: string }>) {
+      byId[e.daemon_event_id] = e;
+    }
+
+    expect(byId["ti-ok"]).toEqual({
+      type: "tool_executed",
+      daemon_event_id: "ti-ok",
+      recorded_at: 1700000001000,
+      tool_name: "calendar_list_events",
+      status: "fulfilled",
+      duration_ms: 12,
+      arg_bytes: 42,
+      result_bytes: 9001,
+      conversation_id: TOOL_CONVERSATION_ID,
+      provider: "anthropic",
+      model: "model-a",
+      inference_profile: "balanced",
+      inference_profile_source: "active",
+      assistant_version: "1.2.3-test",
+    });
+    expect(byId["ti-err"]).toMatchObject({
+      type: "tool_executed",
+      tool_name: "web_search",
+      status: "errored",
+      duration_ms: 7,
+      arg_bytes: 17,
+      result_bytes: 33,
+      provider: null,
+      model: null,
+      inference_profile: null,
+      inference_profile_source: null,
+    });
+    expect(byId["ti-denied"]).toBeUndefined();
+  });
+
+  test("tool_executed watermark advances to the last reported row on success", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    seedToolInvocation({ id: "ti-w1", createdAt: 1700000001000 });
+    seedToolInvocation({ id: "ti-w2", createdAt: 1700000002000 });
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":2}', { status: 200 })),
+    );
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    const watermarkCalls = mockSetMemoryCheckpoint.mock.calls.filter(
+      (c) => c[0] === "telemetry:tool_executed:last_reported_at",
+    );
+    expect(watermarkCalls.length).toBeGreaterThanOrEqual(1);
+    expect(watermarkCalls[watermarkCalls.length - 1][1]).toBe(
+      String(1700000002000),
+    );
+
+    const idCalls = mockSetMemoryCheckpoint.mock.calls.filter(
+      (c) => c[0] === "telemetry:tool_executed:last_reported_id",
+    );
+    expect(idCalls.length).toBeGreaterThanOrEqual(1);
+    expect(idCalls[idCalls.length - 1][1]).toBe("ti-w2");
+  });
+
+  test("tool_executed resumes from a stored watermark — reported rows are not re-shipped", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    seedToolInvocation({ id: "ti-r1", createdAt: 1700000001000 });
+    seedToolInvocation({ id: "ti-r2", createdAt: 1700000002000 });
+    // A previous flush already reported ti-r1.
+    mockGetMemoryCheckpoint.mockImplementation((key) => {
+      if (key === "telemetry:tool_executed:last_reported_at") {
+        return String(1700000001000);
+      }
+      if (key === "telemetry:tool_executed:last_reported_id") return "ti-r1";
+      return null;
+    });
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
+    );
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(
+      body.events.map((e: { daemon_event_id: string }) => e.daemon_event_id),
+    ).toEqual(["ti-r2"]);
+  });
+
+  test("legacy pre-migration rows (null arg_bytes) are never shipped", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    // Default mock: every checkpoint is absent (first run after upgrade),
+    // so the watermark is 0 and the query scans the whole table. The
+    // tool_invocations table holds a pre-upgrade row; it was already
+    // shipped under the since-reverted tool_execution type, lacks the
+    // migration-278 telemetry columns, and must NOT be re-shipped as
+    // tool_executed.
+    seedToolInvocation({
+      id: "ti-historical",
+      createdAt: 1700000001000,
+      argBytes: null,
+      resultBytes: null,
+    });
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    // Nothing to report — the legacy row is excluded at the query level.
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test("rows recorded before the first flush are shipped (no now-initialized watermark)", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    // Regression coverage for the review finding: the reporter delays its
+    // first flush, so a tool used right after install/upgrade is recorded
+    // BEFORE any tool_executed checkpoint exists. A watermark initialized
+    // to Date.now() would silently drop it; the legacy-row discriminator
+    // (null arg_bytes) plus the standard 0 default must ship it.
+    seedToolInvocation({ id: "ti-pre-first-flush", createdAt: 1700000001000 });
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(body.events.length).toBe(1);
+    expect(body.events[0]).toMatchObject({
+      type: "tool_executed",
+      daemon_event_id: "ti-pre-first-flush",
+      recorded_at: 1700000001000,
+    });
+
+    // The watermark advances to the shipped row, so the next flush resumes
+    // after it instead of re-shipping.
+    const watermarkCalls = mockSetMemoryCheckpoint.mock.calls.filter(
+      (c) => c[0] === "telemetry:tool_executed:last_reported_at",
+    );
+    expect(watermarkCalls.length).toBe(1);
+    expect(watermarkCalls[0][1]).toBe(String(1700000001000));
+  });
+
+  // -------------------------------------------------------------------------
+  // Skill-loaded events
+  // -------------------------------------------------------------------------
+
+  test("skill_loaded events ship metadata with attribution and null passthrough", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    recordSkillLoadedEvent({
+      conversationId: "conv-skill",
+      skillName: "web-research",
+      skillUpdatedAt: "2026-06-01T00:00:00.000Z",
+      provider: "anthropic",
+      model: "model-a",
+      inferenceProfile: "balanced",
+      inferenceProfileSource: "active",
+    });
+    // Minimal record — optional fields persist as null and ship as null.
+    recordSkillLoadedEvent({ skillName: "tasks" });
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":2}', { status: 200 })),
+    );
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(body.events.length).toBe(2);
+
+    const byName: Record<string, Record<string, unknown>> = {};
+    for (const e of body.events as Array<{ skill_name: string }>) {
+      byName[e.skill_name] = e;
+    }
+
+    expect(byName["web-research"]).toMatchObject({
+      type: "skill_loaded",
+      skill_name: "web-research",
+      skill_updated_at: "2026-06-01T00:00:00.000Z",
+      conversation_id: "conv-skill",
+      provider: "anthropic",
+      model: "model-a",
+      inference_profile: "balanced",
+      inference_profile_source: "active",
+      assistant_version: "1.2.3-test",
+    });
+    expect(typeof byName["web-research"].daemon_event_id).toBe("string");
+    expect(typeof byName["web-research"].recorded_at).toBe("number");
+    expect(byName["tasks"]).toMatchObject({
+      type: "skill_loaded",
+      skill_name: "tasks",
+      skill_updated_at: null,
+      conversation_id: null,
+      provider: null,
+      model: null,
+      inference_profile: null,
+      inference_profile_source: null,
+    });
+  });
+
+  test("skill_loaded watermark advances to the last reported row on success", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    recordSkillLoadedEvent({ skillName: "web-research" });
+    recordSkillLoadedEvent({ skillName: "tasks" });
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":2}', { status: 200 })),
+    );
+
+    // The last row by the reporter's (createdAt, id) cursor order is the one
+    // whose watermark should be persisted after a successful upload.
+    const rows = getDb()
+      .select()
+      .from(skillLoadedEvents)
+      .orderBy(skillLoadedEvents.createdAt, skillLoadedEvents.id)
+      .all();
+    const lastRow = rows[rows.length - 1];
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    const watermarkCalls = mockSetMemoryCheckpoint.mock.calls.filter(
+      (c) => c[0] === "telemetry:skill_loaded:last_reported_at",
+    );
+    expect(watermarkCalls.length).toBeGreaterThanOrEqual(1);
+    expect(watermarkCalls[watermarkCalls.length - 1][1]).toBe(
+      String(lastRow.createdAt),
+    );
+
+    const idCalls = mockSetMemoryCheckpoint.mock.calls.filter(
+      (c) => c[0] === "telemetry:skill_loaded:last_reported_id",
+    );
+    expect(idCalls.length).toBeGreaterThanOrEqual(1);
+    expect(idCalls[idCalls.length - 1][1]).toBe(lastRow.id);
+  });
+
+  test("batch recursion when skill_loaded returns a full batch, capped at 10", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    // Exactly BATCH_SIZE rows; the mocked checkpoints never persist, so each
+    // recursion re-reads the same full batch until the cap.
+    const fullBatch = Array.from({ length: 500 }, (_, i) => ({
+      id: `sle-batch-${String(i).padStart(3, "0")}`,
+      createdAt: 1700000000000 + i,
+      skillName: "web-research",
+    }));
+    getDb().insert(skillLoadedEvents).values(fullBatch).run();
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":500}', { status: 200 })),
+    );
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    // MAX_CONSECUTIVE_BATCHES = 10
+    expect(mockFetch).toHaveBeenCalledTimes(10);
   });
 });

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -1526,24 +1526,6 @@ describe("UsageTelemetryReporter", () => {
     ).toEqual(["ti-r2"]);
   });
 
-  test("legacy pre-migration rows (null arg_bytes) are never shipped", async () => {
-    mockQueryUnreportedUsageEvents.mockReturnValue([]);
-    // No checkpoints (zero watermark, whole-table scan): a legacy null-
-    // arg_bytes row must still not be re-shipped as tool_executed.
-    seedToolInvocation({
-      id: "ti-historical",
-      createdAt: 1700000001000,
-      argBytes: null,
-      resultBytes: null,
-    });
-
-    const reporter = new UsageTelemetryReporter();
-    await reporter.flush();
-
-    // Nothing to report — the legacy row is excluded at the query level.
-    expect(mockFetch).not.toHaveBeenCalled();
-  });
-
   test("rows recorded after construction but before the first flush are shipped", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
     // Regression coverage for the review finding: the reporter delays its

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -257,6 +257,25 @@ function seedToolInvocation(
   seedToolInvocationRow({ ...spec, conversationId: TOOL_CONVERSATION_ID });
 }
 
+/**
+ * Replace the default null-returning checkpoint mocks with a Map-backed
+ * implementation so values persisted by the reporter (e.g. the
+ * construction-time tool_executed watermark init) are visible to later
+ * reads within the same test.
+ */
+function useStatefulCheckpoints(
+  seed: Record<string, string> = {},
+): Map<string, string> {
+  const checkpoints = new Map(Object.entries(seed));
+  mockGetMemoryCheckpoint.mockImplementation(
+    (key) => checkpoints.get(key) ?? null,
+  );
+  mockSetMemoryCheckpoint.mockImplementation((key, value) => {
+    checkpoints.set(key, value);
+  });
+  return checkpoints;
+}
+
 const originalFetch = globalThis.fetch;
 let mockFetch: ReturnType<typeof mock>;
 
@@ -982,6 +1001,9 @@ describe("UsageTelemetryReporter", () => {
     );
 
     const reporter = new UsageTelemetryReporter();
+    // Construction initializes the absent tool_executed watermark; clear that
+    // call so the count below covers only the flush's advancement.
+    mockSetMemoryCheckpoint.mockClear();
     await reporter.flush();
 
     // No HTTP call should have been made
@@ -1522,13 +1544,21 @@ describe("UsageTelemetryReporter", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  test("rows recorded before the first flush are shipped (no now-initialized watermark)", async () => {
+  test("rows recorded after construction but before the first flush are shipped", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
-    // A row recorded before any tool_executed checkpoint exists must ship —
-    // a now-initialized watermark would silently drop it.
-    seedToolInvocation({ id: "ti-pre-first-flush", createdAt: 1700000001000 });
+    // Regression coverage for the review finding: the reporter delays its
+    // first flush by 30s+, so a tool used right after daemon startup is
+    // recorded before any flush has run. The construction-time watermark
+    // init must not drop it — only rows from before construction (the
+    // opt-out window) stay behind the watermark.
+    const checkpoints = useStatefulCheckpoints();
 
     const reporter = new UsageTelemetryReporter();
+    const rowCreatedAt =
+      Number(checkpoints.get("telemetry:tool_executed:last_reported_at")) +
+      1000;
+    seedToolInvocation({ id: "ti-pre-first-flush", createdAt: rowCreatedAt });
+
     await reporter.flush();
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -1539,16 +1569,82 @@ describe("UsageTelemetryReporter", () => {
     expect(body.events[0]).toMatchObject({
       type: "tool_executed",
       daemon_event_id: "ti-pre-first-flush",
-      recorded_at: 1700000001000,
+      recorded_at: rowCreatedAt,
     });
 
     // The watermark advances to the shipped row, so the next flush resumes
     // after it instead of re-shipping.
-    const watermarkCalls = mockSetMemoryCheckpoint.mock.calls.filter(
-      (c) => c[0] === "telemetry:tool_executed:last_reported_at",
+    expect(checkpoints.get("telemetry:tool_executed:last_reported_at")).toBe(
+      String(rowCreatedAt),
     );
-    expect(watermarkCalls.length).toBe(1);
-    expect(watermarkCalls[0][1]).toBe(String(1700000001000));
+  });
+
+  test("absent tool_executed checkpoint is initialized at construction — opt-out-window rows never ship", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    const checkpoints = useStatefulCheckpoints();
+
+    // Rows accumulated while telemetry was opted out: the reporter is never
+    // constructed then, but the always-on audit listener keeps writing.
+    seedToolInvocation({
+      id: "ti-opt-out-window",
+      createdAt: Date.now() - 60_000,
+    });
+
+    const reporter = new UsageTelemetryReporter();
+
+    // The checkpoint is persisted immediately at construction so a crash
+    // before the first flush can't re-initialize later.
+    const initialized = checkpoints.get(
+      "telemetry:tool_executed:last_reported_at",
+    );
+    expect(initialized).toBeDefined();
+
+    // A tool that runs after construction ships normally.
+    seedToolInvocation({
+      id: "ti-post-construction",
+      createdAt: Number(initialized) + 1000,
+    });
+
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(
+      body.events.map((e: { daemon_event_id: string }) => e.daemon_event_id),
+    ).toEqual(["ti-post-construction"]);
+  });
+
+  test("existing tool_executed checkpoint is respected — construction does not re-initialize", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    const checkpoints = useStatefulCheckpoints({
+      "telemetry:tool_executed:last_reported_at": String(1700000001000),
+      "telemetry:tool_executed:last_reported_id": "ti-already-reported",
+    });
+
+    seedToolInvocation({
+      id: "ti-already-reported",
+      createdAt: 1700000001000,
+    });
+    // Legitimate backlog past the stored watermark — a re-initialization to
+    // Date.now() at construction would silently drop it.
+    seedToolInvocation({ id: "ti-backlog", createdAt: 1700000002000 });
+
+    const reporter = new UsageTelemetryReporter();
+    expect(checkpoints.get("telemetry:tool_executed:last_reported_at")).toBe(
+      String(1700000001000),
+    );
+
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(
+      body.events.map((e: { daemon_event_id: string }) => e.daemon_event_id),
+    ).toEqual(["ti-backlog"]);
   });
 
   // -------------------------------------------------------------------------

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -1579,12 +1579,14 @@ describe("UsageTelemetryReporter", () => {
     );
   });
 
-  test("absent tool_executed checkpoint is initialized at construction — opt-out-window rows never ship", async () => {
+  test("absent tool_executed checkpoint is initialized at construction — rows predating the reporter never ship", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
     const checkpoints = useStatefulCheckpoints();
 
-    // Rows accumulated while telemetry was opted out: the reporter is never
-    // constructed then, but the always-on audit listener keeps writing.
+    // Rows accumulated before any flush ever advanced the watermark — e.g.
+    // an opt-out period under an older build that gated reporter
+    // construction on collectUsageData while the always-on audit listener
+    // kept writing.
     seedToolInvocation({
       id: "ti-opt-out-window",
       createdAt: Date.now() - 60_000,
@@ -1628,7 +1630,11 @@ describe("UsageTelemetryReporter", () => {
       createdAt: 1700000001000,
     });
     // Legitimate backlog past the stored watermark — a re-initialization to
-    // Date.now() at construction would silently drop it.
+    // Date.now() at construction would silently drop it. Rows past the
+    // watermark are always legitimately shippable: opted-out sessions keep
+    // the watermark advancing via the opt-out flush branch (the reporter
+    // runs even when collection is disabled), so the backlog can only hold
+    // opted-in rows.
     seedToolInvocation({ id: "ti-backlog", createdAt: 1700000002000 });
 
     const reporter = new UsageTelemetryReporter();
@@ -1645,6 +1651,65 @@ describe("UsageTelemetryReporter", () => {
     expect(
       body.events.map((e: { daemon_event_id: string }) => e.daemon_event_id),
     ).toEqual(["ti-backlog"]);
+  });
+
+  test("opt-out window never ships across restarts — opted-out flushes keep the watermark ahead of audit rows", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    // A previous opted-in session shipped through this watermark.
+    const checkpoints = useStatefulCheckpoints({
+      "telemetry:tool_executed:last_reported_at": String(1700000001000),
+      "telemetry:tool_executed:last_reported_id": "ti-shipped-opted-in",
+    });
+
+    // Session 1: the user opted out and restarted. The daemon still
+    // constructs and runs the reporter; the always-on audit listener keeps
+    // writing rows. Every opted-out flush (5-minute cycle plus the final
+    // flush in stop()) advances the watermark past them without sending.
+    mockCollectUsageData = false;
+    const optOutRowCreatedAt = Date.now() - 5_000;
+    seedToolInvocation({
+      id: "ti-opt-out-window",
+      createdAt: optOutRowCreatedAt,
+    });
+    const optedOutReporter = new UsageTelemetryReporter();
+    await optedOutReporter.stop(); // shutdown path: runs the final flush
+    expect(mockFetch).not.toHaveBeenCalled();
+    const advanced = Number(
+      checkpoints.get("telemetry:tool_executed:last_reported_at"),
+    );
+    expect(advanced).toBeGreaterThan(optOutRowCreatedAt);
+
+    // Session 2: the user opts back in and restarts. Only rows recorded
+    // after the opt-out epoch ship — the opt-out-window row never does.
+    mockCollectUsageData = true;
+    seedToolInvocation({ id: "ti-after-opt-in", createdAt: advanced + 1000 });
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(
+      body.events.map((e: { daemon_event_id: string }) => e.daemon_event_id),
+    ).toEqual(["ti-after-opt-in"]);
+  });
+
+  test("checkpoint store failure during construction is non-fatal — degraded-DB daemons still start", () => {
+    // initializeDb() failures are tolerated at daemon startup (degraded
+    // mode), so the constructor's checkpoint init must never throw out of
+    // the constructor and abort the daemon.
+    mockGetMemoryCheckpoint.mockImplementation(() => {
+      throw new Error("database disk image is malformed");
+    });
+    expect(() => new UsageTelemetryReporter()).not.toThrow();
+
+    // The write path failing is equally non-fatal.
+    mockGetMemoryCheckpoint.mockImplementation(() => null);
+    mockSetMemoryCheckpoint.mockImplementation(() => {
+      throw new Error("database disk image is malformed");
+    });
+    expect(() => new UsageTelemetryReporter()).not.toThrow();
   });
 
   // -------------------------------------------------------------------------

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -153,12 +153,16 @@ mock.module("../memory/onboarding-events-store.js", () => ({
 // Production import (after mocks)
 // ---------------------------------------------------------------------------
 
+import {
+  seedToolInvocation as seedToolInvocationRow,
+  TOOL_INVOCATION_PII_SENTINEL as TOOL_PII_SENTINEL,
+  type ToolInvocationSeedSpec,
+} from "../__tests__/test-support/tool-invocation-seed.js";
 import { recordAuthFallbackCounts } from "../memory/auth-fallback-events-store.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import {
   authFallbackEvents,
-  conversations,
   skillLoadedEvents,
   toolInvocations,
 } from "../memory/schema.js";
@@ -247,59 +251,10 @@ function makeOnboardingEvent(
 
 const TOOL_CONVERSATION_ID = "conv-reporter-tool-executed";
 
-/**
- * Sentinel embedded in the seeded raw input/result payloads. Asserted to
- * never appear on the wire — raw tool args/outputs must never leave the
- * device.
- */
-const TOOL_PII_SENTINEL = "must never leave the device";
-
-function seedToolInvocation(spec: {
-  id: string;
-  createdAt: number;
-  toolName?: string;
-  decision?: string;
-  durationMs?: number;
-  argBytes?: number | null;
-  resultBytes?: number | null;
-  provider?: string | null;
-  model?: string | null;
-  inferenceProfile?: string | null;
-  inferenceProfileSource?: string | null;
-}): void {
-  const db = getDb();
-  // tool_invocations has an enforced FK to conversations.
-  db.insert(conversations)
-    .values({
-      id: TOOL_CONVERSATION_ID,
-      title: "test",
-      createdAt: 1000,
-      updatedAt: 1000,
-    })
-    .onConflictDoNothing()
-    .run();
-  db.insert(toolInvocations)
-    .values({
-      id: spec.id,
-      conversationId: TOOL_CONVERSATION_ID,
-      toolName: spec.toolName ?? "calendar_list_events",
-      input: `{"secret":"raw tool args — ${TOOL_PII_SENTINEL}"}`,
-      result: `{"secret":"raw tool output — ${TOOL_PII_SENTINEL}"}`,
-      decision: spec.decision ?? "allow",
-      riskLevel: "low",
-      durationMs: spec.durationMs ?? 12,
-      createdAt: spec.createdAt,
-      // Post-migration writer paths always compute byte sizes (legacy
-      // pre-migration rows are the only null-argBytes rows), so the seed
-      // defaults to non-null. Pass an explicit null to seed a legacy row.
-      argBytes: spec.argBytes !== undefined ? spec.argBytes : 2,
-      resultBytes: spec.resultBytes !== undefined ? spec.resultBytes : 9,
-      provider: spec.provider ?? null,
-      model: spec.model ?? null,
-      inferenceProfile: spec.inferenceProfile ?? null,
-      inferenceProfileSource: spec.inferenceProfileSource ?? null,
-    })
-    .run();
+function seedToolInvocation(
+  spec: Omit<ToolInvocationSeedSpec, "conversationId">,
+): void {
+  seedToolInvocationRow({ ...spec, conversationId: TOOL_CONVERSATION_ID });
 }
 
 const originalFetch = globalThis.fetch;
@@ -1551,12 +1506,8 @@ describe("UsageTelemetryReporter", () => {
 
   test("legacy pre-migration rows (null arg_bytes) are never shipped", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
-    // Default mock: every checkpoint is absent (first run after upgrade),
-    // so the watermark is 0 and the query scans the whole table. The
-    // tool_invocations table holds a pre-upgrade row; it was already
-    // shipped under the since-reverted tool_execution type, lacks the
-    // migration-278 telemetry columns, and must NOT be re-shipped as
-    // tool_executed.
+    // No checkpoints (zero watermark, whole-table scan): a legacy null-
+    // arg_bytes row must still not be re-shipped as tool_executed.
     seedToolInvocation({
       id: "ti-historical",
       createdAt: 1700000001000,
@@ -1573,11 +1524,8 @@ describe("UsageTelemetryReporter", () => {
 
   test("rows recorded before the first flush are shipped (no now-initialized watermark)", async () => {
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
-    // Regression coverage for the review finding: the reporter delays its
-    // first flush, so a tool used right after install/upgrade is recorded
-    // BEFORE any tool_executed checkpoint exists. A watermark initialized
-    // to Date.now() would silently drop it; the legacy-row discriminator
-    // (null arg_bytes) plus the standard 0 default must ship it.
+    // A row recorded before any tool_executed checkpoint exists must ship —
+    // a now-initialized watermark would silently drop it.
     seedToolInvocation({ id: "ti-pre-first-flush", createdAt: 1700000001000 });
 
     const reporter = new UsageTelemetryReporter();

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -1009,19 +1009,30 @@ describe("UsageTelemetryReporter", () => {
     // No HTTP call should have been made
     expect(mockFetch).not.toHaveBeenCalled();
 
-    // All 7 timestamp watermarks should have been advanced (IDs left untouched
-    // so the compound-cursor branch stays active)
-    expect(mockSetMemoryCheckpoint).toHaveBeenCalledTimes(7);
+    // All 7 timestamp watermarks should have been advanced, and all 7 ID
+    // watermarks pinned to the high-sorting sentinel (a truthy value keeps
+    // the compound-cursor branch active while closing its same-millisecond
+    // arm against opt-out rows).
+    expect(mockSetMemoryCheckpoint).toHaveBeenCalledTimes(14);
 
     const calls = mockSetMemoryCheckpoint.mock.calls;
     const keys = calls.map((c) => c[0]);
-    expect(keys).toContain("telemetry:usage:last_reported_at");
-    expect(keys).toContain("telemetry:turns:last_reported_at");
-    expect(keys).toContain("telemetry:lifecycle:last_reported_at");
-    expect(keys).toContain("telemetry:onboarding:last_reported_at");
-    expect(keys).toContain("telemetry:auth_fallback:last_reported_at");
-    expect(keys).toContain("telemetry:tool_executed:last_reported_at");
-    expect(keys).toContain("telemetry:skill_loaded:last_reported_at");
+    const eventTypes = [
+      "usage",
+      "turns",
+      "lifecycle",
+      "onboarding",
+      "auth_fallback",
+      "tool_executed",
+      "skill_loaded",
+    ];
+    for (const eventType of eventTypes) {
+      expect(keys).toContain(`telemetry:${eventType}:last_reported_at`);
+      const idCall = calls.find(
+        (c) => c[0] === `telemetry:${eventType}:last_reported_id`,
+      );
+      expect(idCall?.[1]).toBe("ffffffff-ffff-ffff-ffff-ffffffffffff");
+    }
   });
 
   test("events sent normally after re-enabling collectUsageData", async () => {
@@ -1531,8 +1542,8 @@ describe("UsageTelemetryReporter", () => {
     // Regression coverage for the review finding: the reporter delays its
     // first flush by 30s+, so a tool used right after daemon startup is
     // recorded before any flush has run. The construction-time watermark
-    // init must not drop it — only rows from before construction (the
-    // opt-out window) stay behind the watermark.
+    // init must not drop it — only rows from before construction (rows
+    // predating the reporter) stay behind the watermark.
     const checkpoints = useStatefulCheckpoints();
 
     const reporter = new UsageTelemetryReporter();
@@ -1665,6 +1676,49 @@ describe("UsageTelemetryReporter", () => {
     // after the opt-out epoch ship — the opt-out-window row never does.
     mockCollectUsageData = true;
     seedToolInvocation({ id: "ti-after-opt-in", createdAt: advanced + 1000 });
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(
+      body.events.map((e: { daemon_event_id: string }) => e.daemon_event_id),
+    ).toEqual(["ti-after-opt-in"]);
+  });
+
+  test("opt-out row written in the same millisecond as the opt-out flush never ships after re-opt-in", async () => {
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    // A previous opted-in session left a low-sorting ID watermark behind.
+    const checkpoints = useStatefulCheckpoints({
+      "telemetry:tool_executed:last_reported_at": String(1700000001000),
+      "telemetry:tool_executed:last_reported_id":
+        "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    });
+
+    // Opted-out flush: advances the timestamp watermark to Date.now() and
+    // must also pin the ID watermark to the high-sorting sentinel.
+    mockCollectUsageData = false;
+    const optedOutReporter = new UsageTelemetryReporter();
+    await optedOutReporter.flush();
+    expect(mockFetch).not.toHaveBeenCalled();
+    const watermark = Number(
+      checkpoints.get("telemetry:tool_executed:last_reported_at"),
+    );
+
+    // An audit row written in the SAME millisecond as the opt-out flush's
+    // Date.now(), with a UUID sorting above the stale pre-opt-out ID
+    // watermark. With only the timestamp watermark advanced, the compound
+    // cursor's `createdAt == watermark AND id > afterId` arm would match it.
+    seedToolInvocation({
+      id: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+      createdAt: watermark,
+    });
+
+    // Re-opt-in: only rows strictly after the opt-out epoch ship.
+    mockCollectUsageData = true;
+    seedToolInvocation({ id: "ti-after-opt-in", createdAt: watermark + 1000 });
     const reporter = new UsageTelemetryReporter();
     await reporter.flush();
 

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -99,21 +99,36 @@ export class UsageTelemetryReporter {
   private activeFlush: Promise<void> | null = null;
 
   constructor() {
-    // `tool_invocations` is an always-on audit table: while telemetry is
-    // opted out the reporter is never constructed, but the audit listener
-    // keeps writing rows. Initialize an absent watermark to "now" at
-    // construction so a later opt-in doesn't retroactively ship the opt-out
-    // window. Construction happens during daemon startup before any tool
-    // runs, so no legitimate row falls behind the watermark — initializing
-    // at first FLUSH instead would drop tools used during the 30s+ flush
-    // delay. The checkpoint is persisted immediately so a crash before the
-    // first flush can't leave it absent and re-initialize later.
+    // `tool_invocations` is an always-on audit table that predates this
+    // reporter shipping its rows: an absent watermark means no flush (opted
+    // in or out) has ever advanced it, so rows recorded before this build —
+    // including any opted-out period under older builds that gated the
+    // reporter on collectUsageData — would otherwise ship retroactively.
+    // Initialize an absent watermark to "now" at construction. Construction
+    // happens during daemon startup before any tool runs, so no legitimate
+    // row falls behind the watermark — initializing at first FLUSH instead
+    // would drop tools used during the 30s+ flush delay. The checkpoint is
+    // persisted immediately so a crash before the first flush can't leave it
+    // absent and re-initialize later. An EXISTING watermark is never touched:
+    // opted-out sessions keep it advancing via the opt-out flush branch, and
+    // overwriting it here would drop a legitimate unshipped backlog.
     // `skill_loaded` needs no init: recording is gated on collectUsageData,
     // so opt-out rows never exist and its standard 0 default is safe.
-    if (getMemoryCheckpoint(CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK) == null) {
-      setMemoryCheckpoint(
-        CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK,
-        String(Date.now()),
+    //
+    // Best-effort: DB init failures are tolerated at daemon startup (degraded
+    // mode), so this must never throw out of the constructor — matching
+    // flush(), which treats DB errors as non-fatal.
+    try {
+      if (getMemoryCheckpoint(CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK) == null) {
+        setMemoryCheckpoint(
+          CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK,
+          String(Date.now()),
+        );
+      }
+    } catch (err) {
+      log.warn(
+        { err },
+        "tool_executed watermark init failed at construction — non-fatal; a later construction with a working DB re-runs the absent-checkpoint init",
       );
     }
   }
@@ -165,9 +180,13 @@ export class UsageTelemetryReporter {
     try {
       if (batchCount >= MAX_CONSECUTIVE_BATCHES) return;
 
-      // Respect runtime opt-out: if the user has disabled usage data collection,
-      // skip the flush and advance watermarks so events recorded during the
-      // opt-out window are never sent retroactively.
+      // Respect opt-out: if the user has disabled usage data collection, skip
+      // the flush and advance watermarks so events recorded during the
+      // opt-out window are never sent retroactively. The daemon runs the
+      // reporter even when opted out specifically so this branch keeps
+      // executing — every cycle plus the final flush in stop() — which is
+      // what lets a later opt-in (runtime or via restart) resume from a
+      // watermark that already covers the opt-out window.
       if (!getConfig().collectUsageData) {
         // Advance only the timestamp watermarks. Leave the ID watermarks
         // untouched so the compound-cursor branch stays active — setting them

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -98,6 +98,26 @@ export class UsageTelemetryReporter {
   private timer: ReturnType<typeof setInterval> | null = null;
   private activeFlush: Promise<void> | null = null;
 
+  constructor() {
+    // `tool_invocations` is an always-on audit table: while telemetry is
+    // opted out the reporter is never constructed, but the audit listener
+    // keeps writing rows. Initialize an absent watermark to "now" at
+    // construction so a later opt-in doesn't retroactively ship the opt-out
+    // window. Construction happens during daemon startup before any tool
+    // runs, so no legitimate row falls behind the watermark — initializing
+    // at first FLUSH instead would drop tools used during the 30s+ flush
+    // delay. The checkpoint is persisted immediately so a crash before the
+    // first flush can't leave it absent and re-initialize later.
+    // `skill_loaded` needs no init: recording is gated on collectUsageData,
+    // so opt-out rows never exist and its standard 0 default is safe.
+    if (getMemoryCheckpoint(CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK) == null) {
+      setMemoryCheckpoint(
+        CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK,
+        String(Date.now()),
+      );
+    }
+  }
+
   start(): void {
     // Delay the first flush to allow the credential infrastructure (CES
     // handshake) to complete. Without this delay, VellumPlatformClient.create()
@@ -203,9 +223,10 @@ export class UsageTelemetryReporter {
         undefined;
 
       // Read tool-executed watermark (compound cursor: createdAt + id).
-      // The 0 default is safe despite the pre-existing audit table: legacy
-      // rows are excluded at the query level (see
-      // queryUnreportedToolExecutedEvents).
+      // An absent checkpoint was initialized to construction time (see the
+      // constructor), guarding opt-out windows; the 0 fallback here is a
+      // defensive default matching the other event types. Legacy rows are
+      // excluded at the query level (see queryUnreportedToolExecutedEvents).
       const toolExecutedWatermark = Number(
         getMemoryCheckpoint(CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK) ?? "0",
       );

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -214,7 +214,12 @@ export class UsageTelemetryReporter {
       // watermark that already covers the opt-out window. One caveat: a
       // RUNTIME false→true flip can still ship up to one flush interval
       // (≤5 min) of pre-toggle rows recorded since the last opted-out flush;
-      // the restart path is fully covered by the final flush in stop().
+      // the restart path is fully covered by the final flush in stop(). The
+      // caveat applies to the always-on tables without a write-time opt-out
+      // gate (llm_usage, turn events) and to tool_invocations rows recorded
+      // under builds predating the audit listener's write-time gate — new
+      // opted-out tool_invocations rows persist NULL telemetry columns and
+      // are unreportable by construction regardless of watermark timing.
       if (!getConfig().collectUsageData) {
         // Advance the timestamp watermarks and pin the ID watermarks to a
         // sentinel that sorts above any real UUID. The sentinel (rather than

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -203,14 +203,9 @@ export class UsageTelemetryReporter {
         undefined;
 
       // Read tool-executed watermark (compound cursor: createdAt + id).
-      // The standard 0 default is safe even though `tool_invocations` is a
-      // pre-existing audit table: legacy rows — already shipped under the
-      // since-reverted `tool_execution` event type and lacking the
-      // arg_bytes/result_bytes/attribution columns — are excluded at the
-      // query level via the null `arg_bytes` discriminator (see
-      // queryUnreportedToolExecutedEvents), so they are never backfilled.
-      // Rows recorded after migration 278 but before the first flush ARE
-      // picked up, which a now-initialized watermark would have dropped.
+      // The 0 default is safe despite the pre-existing audit table: legacy
+      // rows are excluded at the query level (see
+      // queryUnreportedToolExecutedEvents).
       const toolExecutedWatermark = Number(
         getMemoryCheckpoint(CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK) ?? "0",
       );

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -67,6 +67,31 @@ const CHECKPOINT_KEY_SKILL_LOADED_WATERMARK =
   "telemetry:skill_loaded:last_reported_at";
 const CHECKPOINT_KEY_SKILL_LOADED_WATERMARK_ID =
   "telemetry:skill_loaded:last_reported_id";
+// Written into the `*_id` watermark checkpoints by the opt-out flush branch.
+// Sorts lexicographically above every real row ID (all event stores generate
+// lowercase v4 UUIDs), so the compound cursor's same-millisecond arm
+// (`createdAt == watermark AND id > afterId`) can never match an opt-out row.
+const OPT_OUT_WATERMARK_ID_SENTINEL = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+// (timestamp, id) checkpoint-key pairs for every event type's compound
+// cursor — keep in sync when adding an event type.
+const WATERMARK_KEY_PAIRS: ReadonlyArray<readonly [string, string]> = [
+  [CHECKPOINT_KEY_WATERMARK, CHECKPOINT_KEY_WATERMARK_ID],
+  [CHECKPOINT_KEY_TURN_WATERMARK, CHECKPOINT_KEY_TURN_WATERMARK_ID],
+  [CHECKPOINT_KEY_LIFECYCLE_WATERMARK, CHECKPOINT_KEY_LIFECYCLE_WATERMARK_ID],
+  [CHECKPOINT_KEY_ONBOARDING_WATERMARK, CHECKPOINT_KEY_ONBOARDING_WATERMARK_ID],
+  [
+    CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK,
+    CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK_ID,
+  ],
+  [
+    CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK,
+    CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK_ID,
+  ],
+  [
+    CHECKPOINT_KEY_SKILL_LOADED_WATERMARK,
+    CHECKPOINT_KEY_SKILL_LOADED_WATERMARK_ID,
+  ],
+];
 const REPORT_INTERVAL_MS = 5 * 60 * 1000;
 const INITIAL_FLUSH_DELAY_MS = 30_000; // Delay first flush to let CES handshake complete
 const BATCH_SIZE = 500;
@@ -186,21 +211,24 @@ export class UsageTelemetryReporter {
       // reporter even when opted out specifically so this branch keeps
       // executing — every cycle plus the final flush in stop() — which is
       // what lets a later opt-in (runtime or via restart) resume from a
-      // watermark that already covers the opt-out window.
+      // watermark that already covers the opt-out window. One caveat: a
+      // RUNTIME false→true flip can still ship up to one flush interval
+      // (≤5 min) of pre-toggle rows recorded since the last opted-out flush;
+      // the restart path is fully covered by the final flush in stop().
       if (!getConfig().collectUsageData) {
-        // Advance only the timestamp watermarks. Leave the ID watermarks
-        // untouched so the compound-cursor branch stays active — setting them
-        // to "" would make the truthy check fail, falling back to a
-        // timestamp-only `gt(createdAt, watermark)` query that silently drops
-        // events created in the same millisecond as the opt-out watermark.
+        // Advance the timestamp watermarks and pin the ID watermarks to a
+        // sentinel that sorts above any real UUID. The sentinel (rather than
+        // "") keeps the compound-cursor branch active — a falsy ID would
+        // downgrade the query to a timestamp-only `gt(createdAt, watermark)`
+        // — while making its same-millisecond arm unsatisfiable, so a row
+        // written in the same millisecond as this flush's Date.now() can
+        // never ship after a later opt-in. The next opted-in flush that
+        // ships events overwrites the sentinel with a real row ID.
         const now = String(Date.now());
-        setMemoryCheckpoint(CHECKPOINT_KEY_WATERMARK, now);
-        setMemoryCheckpoint(CHECKPOINT_KEY_TURN_WATERMARK, now);
-        setMemoryCheckpoint(CHECKPOINT_KEY_LIFECYCLE_WATERMARK, now);
-        setMemoryCheckpoint(CHECKPOINT_KEY_ONBOARDING_WATERMARK, now);
-        setMemoryCheckpoint(CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK, now);
-        setMemoryCheckpoint(CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK, now);
-        setMemoryCheckpoint(CHECKPOINT_KEY_SKILL_LOADED_WATERMARK, now);
+        for (const [timestampKey, idKey] of WATERMARK_KEY_PAIRS) {
+          setMemoryCheckpoint(timestampKey, now);
+          setMemoryCheckpoint(idKey, OPT_OUT_WATERMARK_ID_SENTINEL);
+        }
         return;
       }
 

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -23,8 +23,11 @@ import {
 import { queryUnreportedLifecycleEvents } from "../memory/lifecycle-events-store.js";
 import { queryUnreportedUsageEvents } from "../memory/llm-usage-store.js";
 import { queryUnreportedOnboardingEvents } from "../memory/onboarding-events-store.js";
+import { queryUnreportedSkillLoadedEvents } from "../memory/skill-loaded-events-store.js";
+import { queryUnreportedToolExecutedEvents } from "../memory/tool-executed-events-store.js";
 import { queryUnreportedTurnEvents } from "../memory/turn-events-store.js";
 import { VellumPlatformClient } from "../platform/client.js";
+import type { UsageAttributionProfileSource } from "../usage/types.js";
 import { getDeviceId } from "../util/device-id.js";
 import { getLogger } from "../util/logger.js";
 import { APP_VERSION } from "../version.js";
@@ -56,6 +59,14 @@ const CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK =
   "telemetry:auth_fallback:last_reported_at";
 const CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK_ID =
   "telemetry:auth_fallback:last_reported_id";
+const CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK =
+  "telemetry:tool_executed:last_reported_at";
+const CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK_ID =
+  "telemetry:tool_executed:last_reported_id";
+const CHECKPOINT_KEY_SKILL_LOADED_WATERMARK =
+  "telemetry:skill_loaded:last_reported_at";
+const CHECKPOINT_KEY_SKILL_LOADED_WATERMARK_ID =
+  "telemetry:skill_loaded:last_reported_id";
 const REPORT_INTERVAL_MS = 5 * 60 * 1000;
 const INITIAL_FLUSH_DELAY_MS = 30_000; // Delay first flush to let CES handshake complete
 const BATCH_SIZE = 500;
@@ -149,6 +160,8 @@ export class UsageTelemetryReporter {
         setMemoryCheckpoint(CHECKPOINT_KEY_LIFECYCLE_WATERMARK, now);
         setMemoryCheckpoint(CHECKPOINT_KEY_ONBOARDING_WATERMARK, now);
         setMemoryCheckpoint(CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK, now);
+        setMemoryCheckpoint(CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK, now);
+        setMemoryCheckpoint(CHECKPOINT_KEY_SKILL_LOADED_WATERMARK, now);
         return;
       }
 
@@ -189,6 +202,31 @@ export class UsageTelemetryReporter {
         getMemoryCheckpoint(CHECKPOINT_KEY_AUTH_FALLBACK_WATERMARK_ID) ??
         undefined;
 
+      // Read tool-executed watermark (compound cursor: createdAt + id).
+      // The standard 0 default is safe even though `tool_invocations` is a
+      // pre-existing audit table: legacy rows — already shipped under the
+      // since-reverted `tool_execution` event type and lacking the
+      // arg_bytes/result_bytes/attribution columns — are excluded at the
+      // query level via the null `arg_bytes` discriminator (see
+      // queryUnreportedToolExecutedEvents), so they are never backfilled.
+      // Rows recorded after migration 278 but before the first flush ARE
+      // picked up, which a now-initialized watermark would have dropped.
+      const toolExecutedWatermark = Number(
+        getMemoryCheckpoint(CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK) ?? "0",
+      );
+      const toolExecutedWatermarkId =
+        getMemoryCheckpoint(CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK_ID) ??
+        undefined;
+
+      // Read skill-loaded watermark (compound cursor: createdAt + id).
+      // Brand-new table, so the standard 0 default is safe.
+      const skillLoadedWatermark = Number(
+        getMemoryCheckpoint(CHECKPOINT_KEY_SKILL_LOADED_WATERMARK) ?? "0",
+      );
+      const skillLoadedWatermarkId =
+        getMemoryCheckpoint(CHECKPOINT_KEY_SKILL_LOADED_WATERMARK_ID) ??
+        undefined;
+
       // Query unreported events
       const events = queryUnreportedUsageEvents(
         watermark,
@@ -215,13 +253,25 @@ export class UsageTelemetryReporter {
         authFallbackWatermarkId,
         BATCH_SIZE,
       );
+      const toolExecutedEvents = queryUnreportedToolExecutedEvents(
+        toolExecutedWatermark,
+        toolExecutedWatermarkId,
+        BATCH_SIZE,
+      );
+      const skillLoadedEvents = queryUnreportedSkillLoadedEvents(
+        skillLoadedWatermark,
+        skillLoadedWatermarkId,
+        BATCH_SIZE,
+      );
 
       if (
         events.length === 0 &&
         turnEvents.length === 0 &&
         lifecycleEvents.length === 0 &&
         onboardingEvents.length === 0 &&
-        authFallbackEvents.length === 0
+        authFallbackEvents.length === 0 &&
+        toolExecutedEvents.length === 0 &&
+        skillLoadedEvents.length === 0
       )
         return;
 
@@ -236,6 +286,8 @@ export class UsageTelemetryReporter {
           lifecycleCount: lifecycleEvents.length,
           onboardingCount: onboardingEvents.length,
           authFallbackCount: authFallbackEvents.length,
+          toolExecutedCount: toolExecutedEvents.length,
+          skillLoadedCount: skillLoadedEvents.length,
         },
         "Telemetry flush: resolved auth context",
       );
@@ -402,6 +454,50 @@ export class UsageTelemetryReporter {
             assistant_version: APP_VERSION,
           }),
         ),
+        ...toolExecutedEvents.map(
+          (e): TelemetryEvent => ({
+            type: "tool_executed",
+            daemon_event_id: e.id,
+            recorded_at: e.createdAt,
+            tool_name: e.toolName,
+            // The store filters out permission-denied rows, so the only
+            // non-success decision that reaches here is "error".
+            status: e.decision === "error" ? "errored" : "fulfilled",
+            duration_ms: e.durationMs,
+            arg_bytes: e.argBytes,
+            result_bytes: e.resultBytes,
+            conversation_id: e.conversationId,
+            provider: e.provider,
+            model: e.model,
+            inference_profile: e.inferenceProfile,
+            inference_profile_source:
+              e.inferenceProfileSource as UsageAttributionProfileSource | null,
+            // `tool_invocations` has no record-time version column — stamp
+            // the running binary's `APP_VERSION` so the wire value is
+            // concrete rather than an explicit null that would override the
+            // envelope under the platform's per-event-wins contract.
+            assistant_version: APP_VERSION,
+          }),
+        ),
+        ...skillLoadedEvents.map(
+          (e): TelemetryEvent => ({
+            type: "skill_loaded",
+            daemon_event_id: e.id,
+            recorded_at: e.createdAt,
+            skill_name: e.skillName,
+            skill_updated_at: e.skillUpdatedAt,
+            conversation_id: e.conversationId,
+            provider: e.provider,
+            model: e.model,
+            inference_profile: e.inferenceProfile,
+            inference_profile_source:
+              e.inferenceProfileSource as UsageAttributionProfileSource | null,
+            // `skill_loaded_events` has no record-time version column — same
+            // upload-time APP_VERSION stamping as the other non-llm_usage
+            // event types.
+            assistant_version: APP_VERSION,
+          }),
+        ),
       ];
 
       const organizationId = getPlatformOrganizationId() || undefined;
@@ -501,13 +597,42 @@ export class UsageTelemetryReporter {
         );
       }
 
+      // Advance tool-executed watermark (compound cursor)
+      if (toolExecutedEvents.length > 0) {
+        const lastToolExecuted =
+          toolExecutedEvents[toolExecutedEvents.length - 1];
+        setMemoryCheckpoint(
+          CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK,
+          String(lastToolExecuted.createdAt),
+        );
+        setMemoryCheckpoint(
+          CHECKPOINT_KEY_TOOL_EXECUTED_WATERMARK_ID,
+          lastToolExecuted.id,
+        );
+      }
+
+      // Advance skill-loaded watermark (compound cursor)
+      if (skillLoadedEvents.length > 0) {
+        const lastSkillLoaded = skillLoadedEvents[skillLoadedEvents.length - 1];
+        setMemoryCheckpoint(
+          CHECKPOINT_KEY_SKILL_LOADED_WATERMARK,
+          String(lastSkillLoaded.createdAt),
+        );
+        setMemoryCheckpoint(
+          CHECKPOINT_KEY_SKILL_LOADED_WATERMARK_ID,
+          lastSkillLoaded.id,
+        );
+      }
+
       // If we got a full batch of any type, there may be more — recurse
       if (
         events.length === BATCH_SIZE ||
         turnEvents.length === BATCH_SIZE ||
         lifecycleEvents.length === BATCH_SIZE ||
         onboardingEvents.length === BATCH_SIZE ||
-        authFallbackEvents.length === BATCH_SIZE
+        authFallbackEvents.length === BATCH_SIZE ||
+        toolExecutedEvents.length === BATCH_SIZE ||
+        skillLoadedEvents.length === BATCH_SIZE
       ) {
         await this._doFlush(batchCount + 1);
       }

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -493,6 +493,15 @@ function emitLifecycleEvent(
     input: sanitizeToolInput(event.toolName, event.input),
   };
 
+  // Stamp model attribution centrally so every executed/error event carries
+  // it — including the pre-execution gate failures (aborted, disk pressure,
+  // unknown/inactive tool) emitted from checkPreExecutionGates(), whose
+  // emission sites don't have to remember to copy it.
+  if (sanitizedEvent.type === "executed" || sanitizedEvent.type === "error") {
+    sanitizedEvent.attribution =
+      sanitizedEvent.attribution ?? context.attribution ?? null;
+  }
+
   try {
     const maybePromise = handler(sanitizedEvent as ToolLifecycleEvent);
     if (maybePromise) {

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -311,6 +311,15 @@ export class ToolExecutor {
         }
       }
 
+      // Sized from the RAW pre-sanitization result — sensitive-output
+      // extraction below strips directives and swaps raw values for
+      // placeholders, which changes the content length, and telemetry must
+      // report the true payload size. Only the size leaves the device,
+      // never the payload. Stamped here (not centrally in
+      // emitLifecycleEvent) because only this site sees the content before
+      // extractAndSanitize() rewrites it.
+      const rawResultBytes = Buffer.byteLength(execResult.content, "utf8");
+
       // Sensitive output extraction: strip directives, replace raw values
       // with placeholders, and attach bindings for agent-loop substitution.
       const { sanitizedContent, bindings } = extractAndSanitize(
@@ -342,6 +351,7 @@ export class ToolExecutor {
         decision,
         durationMs,
         result: safeResult,
+        resultBytes: rawResultBytes,
       });
 
       // Merge risk metadata from the classifier assessment cache onto the
@@ -498,7 +508,10 @@ function emitLifecycleEvent(
   // them — including the pre-execution gate failures (aborted, disk
   // pressure, unknown/inactive tool) emitted from checkPreExecutionGates(),
   // whose emission sites don't have to remember to copy them. This is the
-  // sole writer of both fields.
+  // sole writer of both fields. (`resultBytes` is the exception: it is
+  // stamped at the executed emission site in executeInternal, the only
+  // place that sees the result content before sensitive-output extraction
+  // rewrites it; the spread above passes it through untouched.)
   if (sanitizedEvent.type === "executed" || sanitizedEvent.type === "error") {
     sanitizedEvent.attribution = context.attribution ?? null;
     // Sized from the RAW pre-sanitization input — redaction changes the

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -22,10 +22,11 @@ import { sandboxPolicy } from "./shared/filesystem/path-policy.js";
 import { MAX_FILE_SIZE_BYTES } from "./shared/filesystem/size-guard.js";
 import { ToolApprovalHandler } from "./tool-approval-handler.js";
 import { resolveToolInvocationAlias } from "./tool-name-aliases.js";
-import type {
-  ToolContext,
-  ToolExecutionResult,
-  ToolLifecycleEvent,
+import {
+  stringifyToolInput,
+  type ToolContext,
+  type ToolExecutionResult,
+  type ToolLifecycleEvent,
 } from "./types.js";
 
 const log = getLogger("tool-executor");
@@ -493,13 +494,20 @@ function emitLifecycleEvent(
     input: sanitizeToolInput(event.toolName, event.input),
   };
 
-  // Stamp model attribution centrally so every executed/error event carries
-  // it — including the pre-execution gate failures (aborted, disk pressure,
-  // unknown/inactive tool) emitted from checkPreExecutionGates(), whose
-  // emission sites don't have to remember to copy it.
+  // Stamp telemetry fields centrally so every executed/error event carries
+  // them — including the pre-execution gate failures (aborted, disk
+  // pressure, unknown/inactive tool) emitted from checkPreExecutionGates(),
+  // whose emission sites don't have to remember to copy them. This is the
+  // sole writer of both fields.
   if (sanitizedEvent.type === "executed" || sanitizedEvent.type === "error") {
-    sanitizedEvent.attribution =
-      sanitizedEvent.attribution ?? context.attribution ?? null;
+    sanitizedEvent.attribution = context.attribution ?? null;
+    // Sized from the RAW pre-sanitization input — redaction changes the
+    // serialized length, and telemetry must report the true payload size.
+    // Only the size leaves the device, never the payload.
+    sanitizedEvent.inputBytes = Buffer.byteLength(
+      stringifyToolInput(event.input),
+      "utf8",
+    );
   }
 
   try {

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -162,12 +162,31 @@ export type ProxyToolResolver = (
 ) => Promise<ToolExecutionResult>;
 
 /**
+ * Telemetry fields stamped centrally by the executor's `emitLifecycleEvent`
+ * on terminal (executed/error) lifecycle events.
+ */
+export interface ExecutorTelemetryStamp {
+  /**
+   * Model attribution snapshot for the conversation at invocation time.
+   * Copied from {@link ToolContext.attribution} by the executor; `null` when
+   * resolution failed or no attribution was available.
+   */
+  attribution?: UsageAttributionSnapshot | null;
+  /**
+   * Serialized byte size of the RAW tool input, stamped by the executor
+   * before sensitive-field sanitization rewrites `input`. Only the size
+   * leaves the device, never the payload.
+   */
+  inputBytes?: number | null;
+}
+
+/**
  * `ToolExecutedEvent` carries a `result: ToolExecutionResult` field, so
  * the assistant re-declares it here to reference the assistant-side
  * `ToolExecutionResult` (which narrows `contentBlocks` to `ContentBlock[]`
  * and `cesApprovalRequired` to `ApprovalRequired`).
  */
-export interface ToolExecutedEvent {
+export interface ToolExecutedEvent extends ExecutorTelemetryStamp {
   type: "executed";
   toolName: string;
   input: Record<string, unknown>;
@@ -185,38 +204,14 @@ export interface ToolExecutedEvent {
   decision: string;
   durationMs: number;
   result: ToolExecutionResult;
-  /**
-   * Model attribution snapshot for the conversation at invocation time.
-   * Copied from {@link ToolContext.attribution} by the executor; `null` when
-   * resolution failed or no attribution was available.
-   */
-  attribution?: UsageAttributionSnapshot | null;
-  /**
-   * Serialized byte size of the RAW tool input, stamped by the executor
-   * before sensitive-field sanitization rewrites `input`. Only the size
-   * leaves the device, never the payload.
-   */
-  inputBytes?: number | null;
 }
 
 /**
  * Extends the contracts declaration with the assistant-side telemetry
  * fields stamped centrally by the executor's `emitLifecycleEvent`.
  */
-export interface ToolExecutionErrorEvent extends ContractsToolExecutionErrorEvent {
-  /**
-   * Model attribution snapshot for the conversation at invocation time.
-   * Copied from {@link ToolContext.attribution} by the executor; `null` when
-   * resolution failed or no attribution was available.
-   */
-  attribution?: UsageAttributionSnapshot | null;
-  /**
-   * Serialized byte size of the RAW tool input, stamped by the executor
-   * before sensitive-field sanitization rewrites `input`. Only the size
-   * leaves the device, never the payload.
-   */
-  inputBytes?: number | null;
-}
+export interface ToolExecutionErrorEvent
+  extends ContractsToolExecutionErrorEvent, ExecutorTelemetryStamp {}
 
 export type ToolLifecycleEvent =
   | ToolExecutionStartEvent

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -1,10 +1,10 @@
 import type { ApprovalRequired } from "@vellumai/service-contracts/credential-rpc";
 import type {
   DiffInfo,
-  ErrorCategory,
   ExecutionTarget,
   ProxyApprovalCallback,
   SensitiveOutputBinding,
+  ToolExecutionErrorEvent as ContractsToolExecutionErrorEvent,
   ToolExecutionStartEvent,
   ToolPermissionDeniedEvent,
   ToolPermissionPromptEvent,
@@ -44,8 +44,7 @@ export function isDiskPressureCleanupToolName(name: string): boolean {
 // Pure re-exports below cover types the contracts package could declare
 // without any assistant-side references. The remaining interfaces (`Tool`,
 // `ToolContext`, `ToolExecutionResult`, `ToolExecutedEvent`,
-// `ToolExecutionErrorEvent`, `ToolLifecycleEvent`,
-// `ToolLifecycleEventHandler`, `ProxyToolResolver`)
+// `ToolLifecycleEvent`, `ToolLifecycleEventHandler`, `ProxyToolResolver`)
 // reference daemon-internal types (CES client, host-proxy classes,
 // `ContentBlock`, `ApprovalRequired`, `TrustClass`, `InterfaceId`,
 // `SecretPromptResult`, `UsageAttributionSnapshot`) that can't move into a
@@ -55,6 +54,9 @@ export function isDiskPressureCleanupToolName(name: string): boolean {
 // concrete types. The two sides are structurally independent — no
 // inheritance, no intersection — which avoids TypeScript's contravariance
 // mismatches on lifecycle-event handlers.
+// `ToolExecutionErrorEvent` is the exception: its contracts fields are all
+// concrete, so the assistant overlay simply extends it with the
+// daemon-internal telemetry fields.
 // ---------------------------------------------------------------------------
 
 export type {
@@ -189,39 +191,31 @@ export interface ToolExecutedEvent {
    * resolution failed or no attribution was available.
    */
   attribution?: UsageAttributionSnapshot | null;
+  /**
+   * Serialized byte size of the RAW tool input, stamped by the executor
+   * before sensitive-field sanitization rewrites `input`. Only the size
+   * leaves the device, never the payload.
+   */
+  inputBytes?: number | null;
 }
 
 /**
- * `ToolExecutionErrorEvent` is redeclared here (rather than re-exported from
- * the contracts package) so it can carry the assistant-side `attribution`
- * snapshot, which references the daemon-internal `UsageAttributionSnapshot`
- * type. All other fields mirror the contracts declaration.
+ * Extends the contracts declaration with the assistant-side telemetry
+ * fields stamped centrally by the executor's `emitLifecycleEvent`.
  */
-export interface ToolExecutionErrorEvent {
-  type: "error";
-  toolName: string;
-  input: Record<string, unknown>;
-  workingDir: string;
-  conversationId: string;
-  requestId?: string;
-  executionTarget?: ExecutionTarget;
-  riskLevel: string;
-  /** ID of the trust rule that matched this invocation (if any). */
-  matchedTrustRuleId?: string;
-  decision: string;
-  durationMs: number;
-  errorMessage: string;
-  isExpected: boolean;
-  /** Classifies the error for downstream consumers (audit, alerting, monitoring). */
-  errorCategory: ErrorCategory;
-  errorName?: string;
-  errorStack?: string;
+export interface ToolExecutionErrorEvent extends ContractsToolExecutionErrorEvent {
   /**
    * Model attribution snapshot for the conversation at invocation time.
    * Copied from {@link ToolContext.attribution} by the executor; `null` when
    * resolution failed or no attribution was available.
    */
   attribution?: UsageAttributionSnapshot | null;
+  /**
+   * Serialized byte size of the RAW tool input, stamped by the executor
+   * before sensitive-field sanitization rewrites `input`. Only the size
+   * leaves the device, never the payload.
+   */
+  inputBytes?: number | null;
 }
 
 export type ToolLifecycleEvent =
@@ -234,6 +228,20 @@ export type ToolLifecycleEvent =
 export type ToolLifecycleEventHandler = (
   event: ToolLifecycleEvent,
 ) => void | Promise<void>;
+
+/**
+ * Canonical serialization used for tool-input byte sizing. Shared by the
+ * executor (raw pre-sanitization sizing) and the audit listener (stored
+ * `input` column + fallback sizing) so the two always measure the same
+ * serialization.
+ */
+export function stringifyToolInput(input: Record<string, unknown>): string {
+  try {
+    return JSON.stringify(input);
+  } catch {
+    return "[unserializable-input]";
+  }
+}
 
 export interface ToolContext {
   /** Identifier of the conversation this tool invocation belongs to. */

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -1,10 +1,10 @@
 import type { ApprovalRequired } from "@vellumai/service-contracts/credential-rpc";
 import type {
   DiffInfo,
+  ErrorCategory,
   ExecutionTarget,
   ProxyApprovalCallback,
   SensitiveOutputBinding,
-  ToolExecutionErrorEvent,
   ToolExecutionStartEvent,
   ToolPermissionDeniedEvent,
   ToolPermissionPromptEvent,
@@ -17,6 +17,7 @@ import type { ToolActivityMetadata } from "../daemon/message-types/web-activity.
 import type { SecretPromptResult } from "../permissions/secret-prompter.js";
 import type { ContentBlock } from "../providers/types.js";
 import type { TrustClass } from "../runtime/actor-trust-resolver.js";
+import type { UsageAttributionSnapshot } from "../usage/attribution.js";
 
 export const DISK_PRESSURE_CLEANUP_TOOL_NAMES: ReadonlySet<string> = new Set([
   "bash",
@@ -43,10 +44,12 @@ export function isDiskPressureCleanupToolName(name: string): boolean {
 // Pure re-exports below cover types the contracts package could declare
 // without any assistant-side references. The remaining interfaces (`Tool`,
 // `ToolContext`, `ToolExecutionResult`, `ToolExecutedEvent`,
-// `ToolLifecycleEvent`, `ToolLifecycleEventHandler`, `ProxyToolResolver`)
+// `ToolExecutionErrorEvent`, `ToolLifecycleEvent`,
+// `ToolLifecycleEventHandler`, `ProxyToolResolver`)
 // reference daemon-internal types (CES client, host-proxy classes,
 // `ContentBlock`, `ApprovalRequired`, `TrustClass`, `InterfaceId`,
-// `SecretPromptResult`) that can't move into a neutral package. For those,
+// `SecretPromptResult`, `UsageAttributionSnapshot`) that can't move into a
+// neutral package. For those,
 // the contracts version uses opaque placeholders (`unknown`, broadened
 // `string`) and the assistant redeclares the interface here with the
 // concrete types. The two sides are structurally independent — no
@@ -63,7 +66,6 @@ export type {
   ProxyEnvVars,
   SensitiveOutputBinding,
   SensitiveOutputKind,
-  ToolExecutionErrorEvent,
   ToolExecutionStartEvent,
   ToolPermissionDeniedEvent,
   ToolPermissionPromptEvent,
@@ -181,6 +183,45 @@ export interface ToolExecutedEvent {
   decision: string;
   durationMs: number;
   result: ToolExecutionResult;
+  /**
+   * Model attribution snapshot for the conversation at invocation time.
+   * Copied from {@link ToolContext.attribution} by the executor; `null` when
+   * resolution failed or no attribution was available.
+   */
+  attribution?: UsageAttributionSnapshot | null;
+}
+
+/**
+ * `ToolExecutionErrorEvent` is redeclared here (rather than re-exported from
+ * the contracts package) so it can carry the assistant-side `attribution`
+ * snapshot, which references the daemon-internal `UsageAttributionSnapshot`
+ * type. All other fields mirror the contracts declaration.
+ */
+export interface ToolExecutionErrorEvent {
+  type: "error";
+  toolName: string;
+  input: Record<string, unknown>;
+  workingDir: string;
+  conversationId: string;
+  requestId?: string;
+  executionTarget?: ExecutionTarget;
+  riskLevel: string;
+  /** ID of the trust rule that matched this invocation (if any). */
+  matchedTrustRuleId?: string;
+  decision: string;
+  durationMs: number;
+  errorMessage: string;
+  isExpected: boolean;
+  /** Classifies the error for downstream consumers (audit, alerting, monitoring). */
+  errorCategory: ErrorCategory;
+  errorName?: string;
+  errorStack?: string;
+  /**
+   * Model attribution snapshot for the conversation at invocation time.
+   * Copied from {@link ToolContext.attribution} by the executor; `null` when
+   * resolution failed or no attribution was available.
+   */
+  attribution?: UsageAttributionSnapshot | null;
 }
 
 export type ToolLifecycleEvent =
@@ -209,6 +250,12 @@ export interface ToolContext {
   assistantId?: string;
   /** When set, the tool execution is part of a task run. Used to retrieve ephemeral permission rules. */
   taskRunId?: string;
+  /**
+   * Model attribution snapshot for the conversation at invocation time
+   * (provider/model/profile that issued this tool call). Used by tool
+   * telemetry; never sent to the tool itself.
+   */
+  attribution?: UsageAttributionSnapshot | null;
   /** Optional callback for tool lifecycle events (start/prompt/deny/execute/error). */
   onToolLifecycleEvent?: ToolLifecycleEventHandler;
   /** Optional resolver for proxy tools - delegates execution to an external client. */

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -178,6 +178,15 @@ export interface ExecutorTelemetryStamp {
    * leaves the device, never the payload.
    */
   inputBytes?: number | null;
+  /**
+   * Byte size of the RAW tool result content, stamped by the executor
+   * before sensitive-output extraction rewrites `result.content`. Only
+   * stamped on `executed` events: error events carry no executor-side
+   * result — the audit listener sizes the error string it builds itself,
+   * which never goes through sanitization, so it is already raw. Only the
+   * size leaves the device, never the payload.
+   */
+  resultBytes?: number | null;
 }
 
 /**

--- a/assistant/src/usage/attribution.ts
+++ b/assistant/src/usage/attribution.ts
@@ -43,6 +43,34 @@ export interface UsageAttributionSnapshot {
 }
 
 /**
+ * The four nullable attribution columns shared by telemetry event rows
+ * (`tool_invocations`, `skill_loaded_events`).
+ */
+export interface UsageAttributionColumns {
+  provider: string | null;
+  model: string | null;
+  inferenceProfile: string | null;
+  inferenceProfileSource: string | null;
+}
+
+/**
+ * Maps an attribution snapshot to the shared telemetry columns — the same
+ * mapping `llm_usage` reporting uses (`appliedProfile` → inference_profile,
+ * `profileSource` → inference_profile_source). Accepts a missing snapshot so
+ * producers that resolve attribution best-effort can pass it through as-is.
+ */
+export function toAttributionColumns(
+  snapshot: UsageAttributionSnapshot | null | undefined,
+): UsageAttributionColumns {
+  return {
+    provider: snapshot?.resolvedProvider ?? null,
+    model: snapshot?.resolvedModel ?? null,
+    inferenceProfile: snapshot?.appliedProfile ?? null,
+    inferenceProfileSource: snapshot?.profileSource ?? null,
+  };
+}
+
+/**
  * Sanitizes values before they are copied into external metadata surfaces.
  * Empty strings and control-character-bearing strings are dropped, and long
  * values are capped so later forwarding cannot create unbounded headers.


### PR DESCRIPTION
## Summary
Adds two new daemon telemetry event types: `tool_executed` (one per tool invocation — status, duration, payload byte sizes, model attribution; no content) and `skill_loaded` (one per Vellum-produced skill load), flowing through the existing SQLite → usage-telemetry-reporter → `POST /v1/telemetry/ingest/` pipeline. Model attribution (provider/model/inference_profile/source) resolves from the conversation's active model at event time via a shared `ModelTelemetryEventBase`, matching `llm_usage` semantics. ToS/PII contract upheld end-to-end: byte sizes and metadata only — no tool args, results, raw error messages, or skill output leave the device.

## Self-review result
GAPS FOUND → fixed: 4 review rounds, 11 gaps fixed across 7 fix PRs (notable: instruction-only Vellum skills now record skill_loaded; opt-out windows never ship retroactively, including same-millisecond edge; skill_loaded_events wiped on clearAll/deleteConversation; arg_bytes sized from raw pre-sanitization input; degraded-DB daemon startup preserved). Final round: PASS on all passes.

## PRs merged into feature branch
- #34343: Add ModelTelemetryEventBase + tool_executed/skill_loaded telemetry wire types
- #34347: Thread conversation model attribution into ToolContext and tool lifecycle events
- #34346: Add skill_loaded_events table and store
- #34375: Capture payload sizes and model attribution on tool_invocations; add tool_executed projection store
- #34380: Record skill_loaded events for Vellum-produced skills at skill activation
- #34391: Ship tool_executed and skill_loaded events through the telemetry reporter

### Fix PRs
- #34394: skill_loaded coverage for instruction-only skills + shared attribution mapping
- #34395: raw arg_bytes sizing + type/test dedup + telemetry doc cleanups
- #34396: skill_loaded_events privacy wipes + telemetry opt-out gaps
- #34397: telemetry opt-out watermark leak + degraded-mode-safe reporter init
- #34398: shared ExecutorTelemetryStamp interface + test dedup
- #34408: skill_loaded registration-failure dedup + telemetry typing cleanups
- #34412: opt-out ID watermark sentinel + comment/test cleanup

**Cross-repo note:** the platform serializer PR (separate plan in vellum-assistant-platform) should merge before the daemon release that ships this, otherwise the new events are logged and skipped at ingest (lossy, not breaking).

Part of plan: tool-skill-telemetry.md