### PR TITLE
Plumb frontmatter category into skills API; categorize bundled skills

### DIFF
--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -10,6 +10,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
 import { parse as parseYaml } from "yaml";
 
 const TEST_DIR = process.env.VELLUM_WORKSPACE_DIR!;

--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -10,6 +10,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { parse as parseYaml } from "yaml";
 
 const TEST_DIR = process.env.VELLUM_WORKSPACE_DIR!;
 
@@ -634,6 +635,83 @@ describe("includes frontmatter parsing", () => {
     const catalog = loadUserSkillCatalog();
     const skill = catalog.find((s) => s.id === "no-includes");
     expect(skill!.includes).toBeUndefined();
+  });
+});
+
+describe("category frontmatter parsing", () => {
+  beforeEach(() => {
+    mkdirSync(join(TEST_DIR, "skills"), { recursive: true });
+  });
+
+  afterEach(() => {
+    const skillsDir = join(TEST_DIR, "skills");
+    if (existsSync(skillsDir))
+      rmSync(skillsDir, { recursive: true, force: true });
+  });
+
+  function writeSkillWithCategory(skillId: string, category: string): void {
+    const skillDir = join(TEST_DIR, "skills", skillId);
+    mkdirSync(skillDir, { recursive: true });
+    const metadata = `{"vellum":{"category":${category}}}`;
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      `---\nname: "${skillId}"\ndescription: "test"\nmetadata: ${metadata}\n---\n\nBody.\n`,
+    );
+  }
+
+  test("parses category from metadata.vellum", () => {
+    writeSkillWithCategory("categorized", '"productivity"');
+    const skill = loadUserSkillCatalog().find((s) => s.id === "categorized");
+    expect(skill!.category).toBe("productivity");
+  });
+
+  test("trims whitespace in category", () => {
+    writeSkillWithCategory("padded", '"  email  "');
+    const skill = loadUserSkillCatalog().find((s) => s.id === "padded");
+    expect(skill!.category).toBe("email");
+  });
+
+  test("returns undefined for empty category", () => {
+    writeSkillWithCategory("empty", '"  "');
+    const skill = loadUserSkillCatalog().find((s) => s.id === "empty");
+    expect(skill!.category).toBeUndefined();
+  });
+
+  test("returns undefined for non-string category", () => {
+    writeSkillWithCategory("numeric", "42");
+    const skill = loadUserSkillCatalog().find((s) => s.id === "numeric");
+    expect(skill!.category).toBeUndefined();
+  });
+
+  test("skill without category has undefined category", () => {
+    writeSkill("no-category", "No Category", "Test");
+    const skill = loadUserSkillCatalog().find((s) => s.id === "no-category");
+    expect(skill!.category).toBeUndefined();
+  });
+});
+
+describe("bundled skill categories", () => {
+  test("every bundled skill declares a valid category slug", () => {
+    const yamlPath = join(
+      import.meta.dir,
+      "..",
+      "..",
+      "..",
+      "skills",
+      "skill-categories-catalog.yaml",
+    );
+    const parsed = parseYaml(readFileSync(yamlPath, "utf-8")) as {
+      categories: { slug: string }[];
+    };
+    const validSlugs = new Set(parsed.categories.map((c) => c.slug));
+    expect(validSlugs.size).toBeGreaterThan(0);
+
+    const bundled = loadSkillCatalog().filter((s) => s.bundled);
+    expect(bundled.length).toBeGreaterThan(0);
+    const invalid = bundled
+      .filter((s) => !s.category || !validSlugs.has(s.category))
+      .map((s) => `${s.id}: ${s.category ?? "(missing)"}`);
+    expect(invalid).toEqual([]);
   });
 });
 

--- a/assistant/src/__tests__/slim-skill-category.test.ts
+++ b/assistant/src/__tests__/slim-skill-category.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Category precedence in toSlimSkillResponse (via listSkills):
+ * catalog entry > SKILL.md frontmatter > "system" fallback.
+ */
+import { join } from "node:path";
+import { describe, expect, mock, test } from "bun:test";
+
+import type { SkillSummary } from "../config/skills.js";
+import type { CatalogSkill } from "../skills/catalog-install.js";
+
+let mockSummaries: SkillSummary[] = [];
+let mockCachedCatalog: CatalogSkill[] = [];
+
+// ---------------------------------------------------------------------------
+// Module mocks — must be declared before importing the module under test
+// ---------------------------------------------------------------------------
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({}),
+  invalidateConfigCache: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+}));
+
+mock.module("../config/skills.js", () => ({
+  loadSkillCatalog: () => mockSummaries,
+}));
+
+mock.module("../config/skill-state.js", () => ({
+  resolveSkillStates: (catalog: SkillSummary[]) =>
+    catalog.map((summary) => ({ summary, state: "enabled" })),
+  skillFlagKey: () => null,
+}));
+
+mock.module("../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: () => true,
+}));
+
+mock.module("../skills/install-meta.js", () => ({
+  readInstallMeta: () => null,
+}));
+
+mock.module("../skills/catalog-cache.js", () => ({
+  getCatalog: async () => mockCachedCatalog,
+  getCachedCatalogSync: () => mockCachedCatalog,
+}));
+
+mock.module("../skills/catalog-files.js", () => ({
+  catalogSkillToSlim: () => ({}),
+  createVellumCatalogProvider: () => ({}),
+  hasHiddenOrSkippedSegment: () => false,
+  readCatalogSkillFiles: async () => null,
+  readCatalogSkillFileContent: async () => null,
+  sanitizeRelativePath: (p: string) => p,
+  SKIP_DIRS: new Set(["node_modules", "__pycache__", ".git"]),
+}));
+
+mock.module("../skills/skillssh-files.js", () => ({
+  createSkillsShProvider: () => ({}),
+}));
+
+mock.module("../skills/clawhub-files.js", () => ({
+  createClawhubProvider: () => ({}),
+}));
+
+mock.module("../skills/catalog-install.js", () => ({
+  installSkillLocally: async () => {},
+}));
+
+mock.module("../skills/catalog-search.js", () => ({
+  filterByQuery: () => [],
+}));
+
+mock.module("../skills/clawhub.js", () => ({
+  clawhubCheckUpdates: async () => [],
+  clawhubInspect: async () => ({}),
+  clawhubInstall: async () => ({ success: true }),
+  clawhubSearch: async () => ({ skills: [] }),
+  clawhubUpdate: async () => ({ success: true }),
+}));
+
+mock.module("../skills/skillssh-registry.js", () => ({
+  fetchSkillAudits: async () => [],
+  installExternalSkill: async () => {},
+  resolveSkillSource: () => ({ owner: "", repo: "", skillSlug: "" }),
+  searchSkillsRegistry: async () => [],
+}));
+
+mock.module("../skills/managed-store.js", () => ({
+  createManagedSkill: () => ({ created: true }),
+  deleteManagedSkill: () => ({ deleted: true }),
+  validateManagedSkillId: () => null,
+}));
+
+mock.module("../memory/graph/capability-seed.js", () => ({
+  deleteSkillCapabilityNode: () => {},
+  seedSkillGraphNodes: () => {},
+  seedUninstalledCatalogSkillMemories: async () => {},
+}));
+
+mock.module("../providers/provider-send-message.js", () => ({
+  createTimeout: () => ({
+    signal: AbortSignal.timeout(1000),
+    cleanup: () => {},
+  }),
+  extractText: () => "",
+  getConfiguredProvider: async () => null,
+  userMessage: () => ({}),
+}));
+
+mock.module("../util/platform.js", () => ({
+  getWorkspaceSkillsDir: () => "/tmp/test-skills-category",
+}));
+
+mock.module("../daemon/handlers/shared.js", () => ({
+  CONFIG_RELOAD_DEBOUNCE_MS: 100,
+  ensureSkillEntry: () => ({ enabled: false }),
+  log: {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import { listSkills } from "../daemon/handlers/skills.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSummary(overrides: Partial<SkillSummary>): SkillSummary {
+  const directoryPath = overrides.directoryPath ?? "/tmp/nonexistent-skill-dir";
+  return {
+    id: overrides.id ?? "summary-id",
+    name: overrides.id ?? "summary-id",
+    displayName: overrides.displayName ?? "Summary",
+    description: "",
+    directoryPath,
+    skillFilePath: join(directoryPath, "SKILL.md"),
+    source: overrides.source ?? "bundled",
+    bundled: overrides.source !== "managed",
+    category: overrides.category,
+  };
+}
+
+function makeCatalogSkill(id: string, category: string): CatalogSkill {
+  return {
+    id,
+    name: id,
+    description: "",
+    metadata: { vellum: { category } },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("listSkills — category precedence", () => {
+  test("catalog category wins over frontmatter category", () => {
+    mockSummaries = [makeSummary({ id: "gmail", category: "messaging" })];
+    mockCachedCatalog = [makeCatalogSkill("gmail", "email")];
+
+    const [skill] = listSkills();
+    expect(skill.category).toBe("email");
+  });
+
+  test("frontmatter category used when skill is not in the catalog", () => {
+    mockSummaries = [makeSummary({ id: "schedule", category: "productivity" })];
+    mockCachedCatalog = [];
+
+    const [skill] = listSkills();
+    expect(skill.category).toBe("productivity");
+  });
+
+  test("falls back to system when neither catalog nor frontmatter declare a category", () => {
+    mockSummaries = [makeSummary({ id: "mystery" })];
+    mockCachedCatalog = [];
+
+    const [skill] = listSkills();
+    expect(skill.category).toBe("system");
+  });
+});

--- a/assistant/src/config/bundled-skills/acp/SKILL.md
+++ b/assistant/src/config/bundled-skills/acp/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "🔗"
   vellum:
     display-name: "ACP"
+    category: "development"
     activation-hints:
       - "User asks to use Claude Code, Codex, or Gemini to do something"
       - "User wants to delegate a coding task to Claude Code, Codex, Gemini, or another ACP agent"

--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -5,6 +5,7 @@ metadata:
   emoji: "🛠️"
   vellum:
     display-name: "App Builder"
+    category: "development"
     activation-hints:
       - "User asks to build a dashboard, tracker, calculator, data visualization, chart, simple landing page, or slide deck for their own use"
       - "User asks to visualize something, make a chart, or build an artifact — build a real persistent app here, never a ui_show dynamic_page"

--- a/assistant/src/config/bundled-skills/app-control/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-control/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "🎯"
   vellum:
     display-name: "App Control"
+    category: "system"
     feature-flag: "app-control"
     activation-hints:
       - "User explicitly directs the assistant to drive a specific named app via raw input (emulator, game, OpenGL canvas, custom-rendered Electron app)"

--- a/assistant/src/config/bundled-skills/computer-use/SKILL.md
+++ b/assistant/src/config/bundled-skills/computer-use/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "🖥️"
   vellum:
     display-name: "Computer Use"
+    category: "system"
     activation-hints:
       - "User asks the assistant to click, type, drag, or interact with the macOS GUI directly"
       - "User wants control of a desktop app with no CLI or API alternative (games, design tools, visual workflows)"

--- a/assistant/src/config/bundled-skills/contacts/SKILL.md
+++ b/assistant/src/config/bundled-skills/contacts/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "👥"
   vellum:
     display-name: "Contacts"
+    category: "productivity"
     activation-hints:
       - "Look up contact info before asking the user for email addresses or phone numbers"
       - "User wants to manage who can message the assistant, or create/revoke invite links"

--- a/assistant/src/config/bundled-skills/document-editor/SKILL.md
+++ b/assistant/src/config/bundled-skills/document-editor/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "✍️"
   vellum:
     display-name: "Document Writer"
+    category: "content"
     activation-hints:
       - "User asks to write, draft, or compose an article, blog post, essay, report, story, or any long-form content — always create it in the document editor, not as a chat reply"
       - "User wants written content they will iterate on, review, or export — use the editor instead of inline markdown"

--- a/assistant/src/config/bundled-skills/followups/SKILL.md
+++ b/assistant/src/config/bundled-skills/followups/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "📨"
   vellum:
     display-name: "Followups"
+    category: "messaging"
 ---
 
 Track messages sent on external channels (email, Slack, WhatsApp, etc.) that are awaiting a response.

--- a/assistant/src/config/bundled-skills/image-studio/SKILL.md
+++ b/assistant/src/config/bundled-skills/image-studio/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "🎨"
   vellum:
     display-name: "Image Studio"
+    category: "content"
     activation-hints:
       - "User asks to generate, draw, or create an image from a text prompt"
       - "User wants to edit an existing image — background removal, in-painting, style change, retouching"

--- a/assistant/src/config/bundled-skills/media-processing/SKILL.md
+++ b/assistant/src/config/bundled-skills/media-processing/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "🎬"
   vellum:
     display-name: "Media Processing"
+    category: "content"
     activation-hints:
       - "User wants to ingest, process, or analyze a local video, audio, or image file"
       - "User wants to ask natural-language questions about a video's content (e.g. 'what happens at 3:14', 'find all the goals', 'who appears in this footage')"

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "\U0001F4AC"
   vellum:
     display-name: "Messaging"
+    category: "messaging"
     activation-hints:
       - "Email, messaging, inbox management, read/send/search on any platform"
       - "Handles credential flows -- do not improvise setup instructions"

--- a/assistant/src/config/bundled-skills/phone-calls/SKILL.md
+++ b/assistant/src/config/bundled-skills/phone-calls/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "📞"
   vellum:
     display-name: "Phone Calls"
+    category: "voice"
     includes:
       - "twilio-setup"
       - "public-ingress"

--- a/assistant/src/config/bundled-skills/playbooks/SKILL.md
+++ b/assistant/src/config/bundled-skills/playbooks/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "📖"
   vellum:
     display-name: "Playbooks"
+    category: "productivity"
 ---
 
 Playbooks are trigger-action automation rules that tell the assistant how to handle incoming messages matching a pattern.

--- a/assistant/src/config/bundled-skills/schedule/SKILL.md
+++ b/assistant/src/config/bundled-skills/schedule/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "📅"
   vellum:
     display-name: "Schedule"
+    category: "productivity"
     activation-hints:
       - "User wants to set a reminder for a future time (e.g. 'remind me at 9am tomorrow', 'remind me to take meds at 8pm')"
       - "User wants to schedule a recurring task or automation (e.g. 'every weekday at 9am', 'every Monday at noon')"

--- a/assistant/src/config/bundled-skills/sequences/SKILL.md
+++ b/assistant/src/config/bundled-skills/sequences/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "📧"
   vellum:
     display-name: "Email Sequences"
+    category: "email"
 ---
 
 You are an email sequence assistant. Use the sequence tools to help users create and manage automated multi-step email drip campaigns.

--- a/assistant/src/config/bundled-skills/settings/SKILL.md
+++ b/assistant/src/config/bundled-skills/settings/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "\u2699\uFE0F"
   vellum:
     display-name: "Settings"
+    category: "system"
     activation-hints:
       - "User wants to change the assistant's voice, TTS provider, or speech output"
       - "User wants to rebind the push-to-talk key or adjust microphone / conversation timeout"

--- a/assistant/src/config/bundled-skills/skill-management/SKILL.md
+++ b/assistant/src/config/bundled-skills/skill-management/SKILL.md
@@ -5,6 +5,7 @@ metadata:
   emoji: "\U0001F9E9"
   vellum:
     display-name: "Skill Management"
+    category: "system"
     activation-hints:
       - "User wants to scaffold a new managed skill in their workspace from a description"
       - "User wants to delete or list the custom skills they have defined"

--- a/assistant/src/config/bundled-skills/subagent/SKILL.md
+++ b/assistant/src/config/bundled-skills/subagent/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "🤖"
   vellum:
     display-name: "Subagent"
+    category: "system"
     activation-hints:
       - "Spawn a background worker that runs in parallel with the main turn"
       - "Delegate a self-contained research or implementation task off the main thread"

--- a/assistant/src/config/bundled-skills/transcribe/SKILL.md
+++ b/assistant/src/config/bundled-skills/transcribe/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   emoji: "🎙️"
   vellum:
     display-name: "Transcribe"
+    category: "voice"
     activation-hints:
       - "User has an audio or video file on disk they want converted to text"
       - "User wants speech-to-text on a recording, voice memo, podcast, or meeting capture"

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -46,6 +46,7 @@ const VellumMetadataSchema = z
     "feature-flag": z.string().optional(),
     "activation-hints": z.array(z.string()).optional(),
     "avoid-when": z.array(z.string()).optional(),
+    category: z.string().optional(),
   })
   .passthrough();
 
@@ -106,6 +107,8 @@ export interface SkillSummary {
   activationHints?: string[];
   /** Conditions under which this skill should NOT be loaded. */
   avoidWhen?: string[];
+  /** Category slug declared in frontmatter, used as a fallback when the skill is not in the Vellum catalog. */
+  category?: string;
   /** Parsed inline command expansion descriptors (`!\`command\``) found in the skill body. */
   inlineCommandExpansions?: InlineCommandExpansion[];
 }
@@ -223,6 +226,7 @@ interface ParsedFrontmatter {
   featureFlag?: string;
   activationHints?: string[];
   avoidWhen?: string[];
+  category?: string;
   inlineCommandExpansions?: InlineCommandExpansion[];
 }
 
@@ -333,6 +337,11 @@ function parseFrontmatter(
   const activationHints = normalizeStringArray(vellum?.["activation-hints"]);
   const avoidWhen = normalizeStringArray(vellum?.["avoid-when"]);
 
+  const category =
+    typeof vellum?.category === "string" && vellum.category.trim().length > 0
+      ? vellum.category.trim()
+      : undefined;
+
   const strippedBody = stripCommentLines(body);
 
   // Parse inline command expansions from the body (after frontmatter/comment stripping)
@@ -356,6 +365,7 @@ function parseFrontmatter(
     featureFlag,
     activationHints,
     avoidWhen,
+    category,
     inlineCommandExpansions,
   };
 }
@@ -512,6 +522,7 @@ function readSkillFromDirectory(
       featureFlag: parsed.featureFlag,
       activationHints: parsed.activationHints,
       avoidWhen: parsed.avoidWhen,
+      category: parsed.category,
       inlineCommandExpansions: parsed.inlineCommandExpansions,
     };
   } catch (err) {
@@ -564,6 +575,7 @@ function readBundledSkillFromDirectory(
       featureFlag: parsed.featureFlag,
       activationHints: parsed.activationHints,
       avoidWhen: parsed.avoidWhen,
+      category: parsed.category,
       inlineCommandExpansions: parsed.inlineCommandExpansions,
     };
   } catch (err) {
@@ -624,6 +636,7 @@ function loadBundledSkills(): SkillSummary[] {
       featureFlag: skill.featureFlag,
       activationHints: skill.activationHints,
       avoidWhen: skill.avoidWhen,
+      category: skill.category,
       inlineCommandExpansions: skill.inlineCommandExpansions,
     });
   }
@@ -750,6 +763,7 @@ function skillSummaryFromDefinition(
     featureFlag: skill.featureFlag,
     activationHints: skill.activationHints,
     avoidWhen: skill.avoidWhen,
+    category: skill.category,
     inlineCommandExpansions: skill.inlineCommandExpansions,
   };
 }
@@ -803,6 +817,7 @@ export function loadSkillCatalog(
             featureFlag: parsed.featureFlag,
             activationHints: parsed.activationHints,
             avoidWhen: parsed.avoidWhen,
+            category: parsed.category,
             inlineCommandExpansions: parsed.inlineCommandExpansions,
           });
         } catch (err) {
@@ -938,6 +953,7 @@ export function loadSkillCatalog(
           featureFlag: parsed.featureFlag,
           activationHints: parsed.activationHints,
           avoidWhen: parsed.avoidWhen,
+          category: parsed.category,
           inlineCommandExpansions: parsed.inlineCommandExpansions,
         };
 

--- a/assistant/src/daemon/handlers/skills.ts
+++ b/assistant/src/daemon/handlers/skills.ts
@@ -351,7 +351,8 @@ function toSlimSkillResponse(
   const origin = deriveOrigin(kind, summary.directoryPath, installMeta);
   const status: SlimSkillResponse["status"] = state;
 
-  const category = getCatalogCategoryMap().get(summary.id) ?? "system";
+  const category =
+    getCatalogCategoryMap().get(summary.id) ?? summary.category ?? "system";
   const base = {
     id: summary.id,
     name: summary.displayName,


### PR DESCRIPTION
## Summary
- Parse `metadata.vellum.category` from SKILL.md frontmatter into `SkillSummary` (all five skill sources flow through the shared `parseFrontmatter()` helper) and use it in `toSlimSkillResponse` as a fallback between the catalog lookup and the `"system"` default: catalog > frontmatter > system.
- Assign category slugs to all 18 bundled skills, which were previously always bucketed under System because they are never in the Vellum catalog and frontmatter categories were silently dropped (messaging/followups → messaging, phone-calls/transcribe → voice, schedule/playbooks/contacts → productivity, document-editor/image-studio/media-processing → content, acp/app-builder → development, sequences → email; settings, computer-use, skill-management, subagent, app-control stay system).
- Add tests: frontmatter category parsing (trim/empty/non-string handling), a regression test that every bundled skill declares a slug from `skills/skill-categories-catalog.yaml`, and category-precedence coverage for `listSkills()`.

## Original prompt
While investigating why all skills were showing a category of "system", we found the daemon resolves category exclusively from the Vellum catalog id lookup with a `"system"` fallback — a skill's own `metadata.vellum.category` frontmatter was never parsed. The catalog-side half was fixed in #34234, but bundled skills (never in the catalog) still always rendered as System. The user asked to fix this remaining gap: plumb frontmatter category through `SkillSummary` to the skills API and assign real categories to the bundled skills.