### PR TITLE
fix(assistant): memory-graph zod validation + background-job LLM timeouts (M3)

### DIFF
--- a/assistant/src/memory/graph/consolidation.test.ts
+++ b/assistant/src/memory/graph/consolidation.test.ts
@@ -1,0 +1,187 @@
+// ---------------------------------------------------------------------------
+// consolidation.test.ts — timeout-degradation coverage for `runConsolidation`.
+//
+// Focus (M3 review follow-up): the dupe-scan LLM call (`identifyDuplicateGroups`)
+// has a graceful-degradation contract — provider unavailable returns []. The
+// M3 timeout wraps `sendMessage`, so a 60s abort (DOMException AbortError) must
+// also degrade to "no dupes found" rather than propagating out and abandoning
+// the whole consolidation partition. This test drives the public
+// `runConsolidation` entry point with a provider stub whose dupe-scan call
+// rejects (simulating the timeout abort) while the chunk-consolidation call
+// succeeds — proving the partition survives the dupe-scan failure and still
+// runs the singleton fidelity/narrative pass.
+//
+// Only the provider boundary is mocked; SQLite/store run unmocked against the
+// in-process test DB so the assertions reflect real graph state.
+// ---------------------------------------------------------------------------
+
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+  ToolUseContent,
+} from "../../providers/types.js";
+
+// Provider stub — each test sets `providerStub`; `null` simulates "no provider".
+let providerStub: Provider | null = null;
+// Tool names the stub was asked to produce, in call order. Lets a test assert
+// the singleton consolidation pass ran AFTER the dupe-scan call aborted.
+let toolCalls: string[] = [];
+
+// `runConsolidation` imports `getConfiguredProvider`, `userMessage`,
+// `extractToolUse`, and `createTimeout` from this module — the mock must export
+// all four. `createTimeout` keeps its real shape (real abort timer) so the
+// finally-cleanup path is exercised; the timeout itself is simulated by having
+// `sendMessage` reject for the dupe-scan call.
+mock.module("../../providers/provider-send-message.js", () => ({
+  getConfiguredProvider: async () => providerStub,
+  userMessage: (text: string) => ({
+    role: "user" as const,
+    content: [{ type: "text" as const, text }],
+  }),
+  extractToolUse: (response: ProviderResponse) =>
+    response.content.find((b): b is ToolUseContent => b.type === "tool_use"),
+  createTimeout: (ms: number) => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), ms);
+    return { signal: controller.signal, cleanup: () => clearTimeout(timer) };
+  },
+}));
+
+import { resetDbForTesting } from "../../__tests__/db-test-helpers.js";
+import { DEFAULT_CONFIG } from "../../config/defaults.js";
+import { initializeDb } from "../db-init.js";
+import { runConsolidation } from "./consolidation.js";
+import { createNode } from "./store.js";
+import type { NewNode } from "./types.js";
+
+const SCOPE = "consolidation-timeout-test";
+
+/** Build a recent narrative node so it lands in the "recent" partition. */
+function makeNode(content: string): NewNode {
+  const now = Date.now();
+  return {
+    content,
+    type: "narrative",
+    created: now,
+    lastAccessed: now,
+    lastConsolidated: now,
+    eventDate: null,
+    emotionalCharge: {
+      valence: 0,
+      intensity: 0.3,
+      decayCurve: "linear",
+      decayRate: 0.05,
+      originalIntensity: 0.3,
+    },
+    fidelity: "clear",
+    confidence: 0.7,
+    significance: 0.5,
+    stability: 14,
+    reinforcementCount: 0,
+    lastReinforced: now,
+    sourceConversations: [],
+    sourceType: "observed",
+    narrativeRole: null,
+    partOfStory: null,
+    imageRefs: null,
+    scopeId: SCOPE,
+  };
+}
+
+function seedNodes(count: number): void {
+  for (let i = 0; i < count; i++) {
+    createNode(
+      makeNode(`Distinct memory ${i}: an unrelated fact about topic ${i}.`),
+    );
+  }
+}
+
+/**
+ * Provider stub that aborts the dupe-scan call and succeeds (empty diff) on the
+ * chunk-consolidation call. Branches on the forced `tool_choice.name`.
+ */
+function makeTimeoutOnDupeScanProvider(): Provider {
+  return {
+    name: "stub",
+    sendMessage: async (
+      _msgs: Message[],
+      opts?: SendMessageOptions,
+    ): Promise<ProviderResponse> => {
+      // `tool_choice` lives under SendMessageConfig's index signature, so it
+      // reads back as `unknown`; narrow it to pull the forced tool name.
+      const choice = opts?.config?.tool_choice;
+      const toolName =
+        choice != null &&
+        typeof choice === "object" &&
+        "name" in choice &&
+        typeof (choice as { name?: unknown }).name === "string"
+          ? (choice as { name: string }).name
+          : "<auto>";
+      toolCalls.push(toolName);
+
+      if (toolName === "report_duplicate_groups") {
+        // Simulate the 60s timeout firing: an aborted request rejects with a
+        // DOMException AbortError. `identifyDuplicateGroups` must catch this and
+        // degrade to [] rather than letting it crash the partition.
+        const err = new DOMException(
+          "The operation was aborted.",
+          "AbortError",
+        );
+        throw err;
+      }
+
+      // consolidate_diff: return a well-formed empty diff (no-op). Reaching this
+      // call proves the partition continued past the dupe-scan abort into the
+      // singleton consolidation pass.
+      return {
+        model: "stub-model",
+        stopReason: "tool_use",
+        usage: { inputTokens: 0, outputTokens: 0 },
+        content: [
+          {
+            type: "tool_use",
+            id: "tu-1",
+            name: "consolidate_diff",
+            input: { updates: [], delete_ids: [], merge_edges: [] },
+          },
+        ],
+      };
+    },
+  } as Provider;
+}
+
+describe("runConsolidation — dupe-scan timeout degradation", () => {
+  beforeAll(() => {
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    resetDbForTesting();
+    initializeDb();
+    providerStub = null;
+    toolCalls = [];
+  });
+
+  test("a dupe-scan timeout degrades to [] and the partition still runs the singleton pass", async () => {
+    // Need ≥2 nodes so the dupe-scan runs, and enough singletons so the
+    // singleton consolidation pass (chunked at ≥2) is reached.
+    seedNodes(4);
+    providerStub = makeTimeoutOnDupeScanProvider();
+
+    // Must NOT throw — a transient dupe-scan timeout degrades to "no dupes",
+    // letting the partition continue rather than crashing the consolidation.
+    const result = await runConsolidation(SCOPE, DEFAULT_CONFIG);
+
+    // The dupe-scan call was attempted (and aborted).
+    expect(toolCalls).toContain("report_duplicate_groups");
+    // The singleton consolidation pass ran AFTER the dupe-scan abort — proving
+    // graceful degradation rather than partition abandonment.
+    expect(toolCalls).toContain("consolidate_diff");
+    // No nodes were lost; the empty diff is a no-op.
+    expect(result.totalDeleted).toBe(0);
+  });
+});

--- a/assistant/src/memory/graph/consolidation.test.ts
+++ b/assistant/src/memory/graph/consolidation.test.ts
@@ -1,15 +1,22 @@
 // ---------------------------------------------------------------------------
-// consolidation.test.ts — timeout-degradation coverage for `runConsolidation`.
+// consolidation.test.ts — timeout-handling coverage for `runConsolidation`.
 //
-// Focus (M3 review follow-up): the dupe-scan LLM call (`identifyDuplicateGroups`)
-// has a graceful-degradation contract — provider unavailable returns []. The
-// M3 timeout wraps `sendMessage`, so a 60s abort (DOMException AbortError) must
-// also degrade to "no dupes found" rather than propagating out and abandoning
-// the whole consolidation partition. This test drives the public
-// `runConsolidation` entry point with a provider stub whose dupe-scan call
-// rejects (simulating the timeout abort) while the chunk-consolidation call
-// succeeds — proving the partition survives the dupe-scan failure and still
-// runs the singleton fidelity/narrative pass.
+// Two distinct timeout contracts are exercised:
+//
+//   1. Dupe-scan degradation (`identifyDuplicateGroups`): provider unavailable
+//      returns []. The M3 timeout wraps `sendMessage`, so a 60s abort
+//      (DOMException AbortError) must also degrade to "no dupes found" rather
+//      than propagating out and abandoning the whole consolidation partition.
+//      The first test proves the partition survives the dupe-scan failure and
+//      still runs the singleton fidelity/narrative pass.
+//
+//   2. Chunk-consolidation re-throw (round-3 review follow-up): a chunk-level
+//      timeout (`consolidateChunk`) is a backend OUTAGE that affects every
+//      partition, not a single bad partition. `consolidateChunk` translates the
+//      abort to `BackendUnavailableError`, and `runConsolidation`'s per-partition
+//      catch must RE-THROW it (not degrade to a zero-result partition) so the
+//      job worker can defer/retry instead of silently completing the job. The
+//      second test proves the error propagates out of `runConsolidation`.
 //
 // Only the provider boundary is mocked; SQLite/store run unmocked against the
 // in-process test DB so the assertions reflect real graph state.
@@ -44,15 +51,20 @@ mock.module("../../providers/provider-send-message.js", () => ({
   }),
   extractToolUse: (response: ProviderResponse) =>
     response.content.find((b): b is ToolUseContent => b.type === "tool_use"),
+  // Cap the fuse at 100ms so the chunk-timeout test aborts quickly instead of
+  // waiting the real 120s `CONSOLIDATE_CHUNK_TIMEOUT_MS`. The dupe-scan and
+  // empty-diff stubs resolve/throw synchronously on the next microtask, well
+  // before 100ms, so the cap never trips them.
   createTimeout: (ms: number) => {
     const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), ms);
+    const timer = setTimeout(() => controller.abort(), Math.min(ms, 100));
     return { signal: controller.signal, cleanup: () => clearTimeout(timer) };
   },
 }));
 
 import { resetDbForTesting } from "../../__tests__/db-test-helpers.js";
 import { DEFAULT_CONFIG } from "../../config/defaults.js";
+import { BackendUnavailableError } from "../../util/errors.js";
 import { initializeDb } from "../db-init.js";
 import { runConsolidation } from "./consolidation.js";
 import { createNode } from "./store.js";
@@ -154,6 +166,65 @@ function makeTimeoutOnDupeScanProvider(): Provider {
   } as Provider;
 }
 
+/**
+ * Provider stub where the dupe-scan call returns "no dupes" (so the partition
+ * proceeds to the singleton consolidation pass) and the chunk-consolidation call
+ * stalls until its abort signal fires — simulating a chunk-level timeout. The
+ * resulting `BackendUnavailableError` from `consolidateChunk` must propagate out
+ * of `runConsolidation`'s per-partition catch (not degrade to a zero-result
+ * partition), so the job worker can defer/retry the whole consolidation.
+ */
+function makeTimeoutOnConsolidateChunkProvider(): Provider {
+  return {
+    name: "stub",
+    sendMessage: (
+      _msgs: Message[],
+      opts?: SendMessageOptions,
+    ): Promise<ProviderResponse> => {
+      const choice = opts?.config?.tool_choice;
+      const toolName =
+        choice != null &&
+        typeof choice === "object" &&
+        "name" in choice &&
+        typeof (choice as { name?: unknown }).name === "string"
+          ? (choice as { name: string }).name
+          : "<auto>";
+      toolCalls.push(toolName);
+
+      if (toolName === "report_duplicate_groups") {
+        // No dupes — lets the partition advance to the singleton chunk pass.
+        return Promise.resolve({
+          model: "stub-model",
+          stopReason: "tool_use",
+          usage: { inputTokens: 0, outputTokens: 0 },
+          content: [
+            {
+              type: "tool_use",
+              id: "tu-dupe",
+              name: "report_duplicate_groups",
+              input: { groups: [] },
+            },
+          ],
+        });
+      }
+
+      // consolidate_diff: stall until the timeout aborts the signal, then reject
+      // with an AbortError. `consolidateChunk` sees `signal.aborted` and throws
+      // `BackendUnavailableError`, which the partition catch must re-throw.
+      return new Promise<ProviderResponse>((_resolve, reject) => {
+        const signal = opts?.signal;
+        if (signal?.aborted) {
+          reject(new DOMException("Aborted", "AbortError"));
+          return;
+        }
+        signal?.addEventListener("abort", () => {
+          reject(new DOMException("Aborted", "AbortError"));
+        });
+      });
+    },
+  } as Provider;
+}
+
 describe("runConsolidation — dupe-scan timeout degradation", () => {
   beforeAll(() => {
     initializeDb();
@@ -183,5 +254,28 @@ describe("runConsolidation — dupe-scan timeout degradation", () => {
     expect(toolCalls).toContain("consolidate_diff");
     // No nodes were lost; the empty diff is a no-op.
     expect(result.totalDeleted).toBe(0);
+  });
+
+  test("a chunk-consolidation timeout re-throws BackendUnavailableError so the job worker defers/retries", async () => {
+    // ≥2 nodes so the singleton consolidation chunk pass runs and can time out.
+    seedNodes(4);
+    providerStub = makeTimeoutOnConsolidateChunkProvider();
+
+    // The chunk timeout surfaces as `BackendUnavailableError` from
+    // `consolidateChunk`. A backend outage affects every partition, so the
+    // per-partition catch must RE-THROW it rather than degrading to a
+    // zero-result partition — otherwise `graphConsolidateJob` returns normally,
+    // `completeMemoryJob()` marks the job done, and consolidation is silently
+    // skipped for a full interval. Re-throwing lets `handleJobError` /
+    // `classifyError` defer/retry the job.
+    await expect(
+      runConsolidation(SCOPE, DEFAULT_CONFIG),
+    ).rejects.toBeInstanceOf(BackendUnavailableError);
+
+    // The dupe-scan ran (no dupes) and the chunk-consolidation call was reached
+    // before the timeout fired — proving the re-throw came from the chunk pass,
+    // not an earlier failure.
+    expect(toolCalls).toContain("report_duplicate_groups");
+    expect(toolCalls).toContain("consolidate_diff");
   });
 });

--- a/assistant/src/memory/graph/consolidation.ts
+++ b/assistant/src/memory/graph/consolidation.ts
@@ -345,6 +345,22 @@ async function identifyDuplicateGroups(
       },
       signal,
     });
+  } catch (err) {
+    // Graceful degradation: this function's contract is "best-effort dupe scan
+    // — return [] on any failure" (see the no-provider early return above).
+    // A timeout (AbortError) or transient provider error must NOT propagate,
+    // because the only caller (`consolidatePartition`) has no try/catch around
+    // this call — a throw here would abandon the whole partition (losing the
+    // singleton fidelity/narrative pass too). Treat as "no dupes found".
+    log.warn(
+      {
+        callSite: "memoryConsolidation",
+        aborted: signal.aborted,
+        err: err instanceof Error ? err.message : String(err),
+      },
+      "Duplicate-scan LLM call failed (timeout or error); treating as no dupes",
+    );
+    return [];
   } finally {
     cleanup();
   }
@@ -536,6 +552,21 @@ async function consolidateChunk(
         signal,
       },
     );
+  } catch (err) {
+    // Required-job semantics: this chunk MUST surface as a failed/retryable
+    // job (it already throws BackendUnavailableError on no-provider above, and
+    // `runConsolidation` wraps each partition so the partition is dropped, not
+    // the whole job). A bare timeout aborts with a DOMException AbortError,
+    // which `classifyError` (memory/job-utils.ts) would otherwise treat as
+    // fatal → no retry. Translate the abort into BackendUnavailableError so the
+    // existing handler defers/retries it like any other transient backend
+    // outage. Non-abort errors keep their own classification.
+    if (signal.aborted) {
+      throw new BackendUnavailableError(
+        "Consolidation chunk LLM call timed out",
+      );
+    }
+    throw err;
   } finally {
     cleanup();
   }

--- a/assistant/src/memory/graph/consolidation.ts
+++ b/assistant/src/memory/graph/consolidation.ts
@@ -797,6 +797,23 @@ export async function runConsolidation(
         "Partition consolidation complete",
       );
     } catch (err) {
+      // A backend outage (no provider, or a chunk-level timeout translated to
+      // `BackendUnavailableError` in `consolidateChunk`) is different in kind
+      // from a single bad partition: it will affect every partition, and the
+      // job worker (`graphConsolidateJob` → `completeMemoryJob()`) treats a
+      // normal return as success and advances the maintenance checkpoint. If we
+      // degraded this to a zero-result partition, a stalled provider would
+      // silently skip consolidation for a full interval. Re-throw so
+      // `classifyError` routes it to defer/retry. Other per-partition errors
+      // keep the established "contain one bad partition" contract below — they
+      // degrade to a zero-result partition so the rest of the job proceeds.
+      if (err instanceof BackendUnavailableError) {
+        log.warn(
+          { partition: partition.name, err: err.message },
+          "Partition consolidation hit a backend outage; failing the job for retry",
+        );
+        throw err;
+      }
       log.warn(
         {
           partition: partition.name,

--- a/assistant/src/memory/graph/consolidation.ts
+++ b/assistant/src/memory/graph/consolidation.ts
@@ -10,8 +10,11 @@
 // (same format as extraction) that is applied to the graph.
 // ---------------------------------------------------------------------------
 
+import { z } from "zod";
+
 import type { AssistantConfig } from "../../config/types.js";
 import {
+  createTimeout,
   extractToolUse,
   getConfiguredProvider,
   userMessage,
@@ -228,6 +231,57 @@ function getRandomSample(scopeId: string, n: number = 30): MemoryNode[] {
 
 const CHUNK_SIZE = 25;
 
+/**
+ * Generous timeouts for the consolidation background batch calls. Both the
+ * fast duplicate-scan pass and the full per-chunk consolidation run inside the
+ * daily consolidation job, where a stalled provider connection would otherwise
+ * wedge the worker. The dupe-scan compares one-line previews, so it gets a
+ * shorter budget than the full chunk pass that reasons over complete prose.
+ */
+const DUPE_SCAN_TIMEOUT_MS = 60_000;
+const CONSOLIDATE_CHUNK_TIMEOUT_MS = 120_000;
+
+/**
+ * Tool input for `report_duplicate_groups`. Mirrors the prior
+ * `{ groups?: string[][] }` cast; `groups` stays optional so an absent list
+ * degrades to "no duplicate groups" exactly as before.
+ */
+const DuplicateGroupsSchema = z.object({
+  groups: z.array(z.array(z.string())).optional(),
+});
+
+/**
+ * Per-item update schema for `consolidate_diff`. Encodes what the prior cast
+ * assumed AND validates the two previously-unchecked fields: `fidelity` is the
+ * exact node-fidelity enum, and `event_date` is `number | null`. A single
+ * update whose `fidelity`/`event_date` fails validation is skipped (with a
+ * warn) rather than failing the whole batch — matching how the loop already
+ * tolerates missing optional fields. The top-level `delete_ids` / `merge_edges`
+ * arrays are validated as a whole since their elements have no
+ * partially-tolerable fields.
+ */
+const ConsolidateUpdateSchema = z.object({
+  id: z.string(),
+  content: z.string().optional(),
+  fidelity: z.enum(["vivid", "clear", "faded", "gist", "gone"]).optional(),
+  narrativeRole: z.string().optional(),
+  partOfStory: z.string().optional(),
+  event_date: z.number().nullable().optional(),
+});
+
+const ConsolidateDiffSchema = z.object({
+  // `updates` elements are validated per-item in the loop (via
+  // `ConsolidateUpdateSchema`) so a single malformed update is skipped rather
+  // than failing the whole batch — only the array-of-objects shape is checked
+  // here. `delete_ids` / `merge_edges` have no partially-tolerable fields, so
+  // they're validated strictly as a whole.
+  updates: z.array(z.record(z.string(), z.unknown())).optional(),
+  delete_ids: z.array(z.string()).optional(),
+  merge_edges: z
+    .array(z.object({ survivor_id: z.string(), deleted_id: z.string() }))
+    .optional(),
+});
+
 // ---------------------------------------------------------------------------
 // Duplicate detection — fast LLM call on compact listings
 // ---------------------------------------------------------------------------
@@ -279,24 +333,38 @@ async function identifyDuplicateGroups(
 
   const systemPrompt = `You are scanning a list of memory nodes for DUPLICATES — nodes that describe the exact same specific event or fact. Group duplicates together. Two nodes are duplicates ONLY if they describe the same underlying thing with substantially the same details. Be conservative — nodes about the same person or topic but with different details, timestamps, or context are NOT duplicates. Only include nodes that have at least one true duplicate.`;
 
-  const response = await provider.sendMessage([userMessage(listing)], {
-    tools: [DUPE_DETECT_TOOL],
-    systemPrompt,
-    config: {
-      callSite: "memoryConsolidation" as const,
-      tool_choice: { type: "tool" as const, name: "report_duplicate_groups" },
-    },
-  });
+  const { signal, cleanup } = createTimeout(DUPE_SCAN_TIMEOUT_MS);
+  let response;
+  try {
+    response = await provider.sendMessage([userMessage(listing)], {
+      tools: [DUPE_DETECT_TOOL],
+      systemPrompt,
+      config: {
+        callSite: "memoryConsolidation" as const,
+        tool_choice: { type: "tool" as const, name: "report_duplicate_groups" },
+      },
+      signal,
+    });
+  } finally {
+    cleanup();
+  }
 
   const toolBlock = extractToolUse(response);
   if (!toolBlock) return [];
 
-  const input = toolBlock.input as { groups?: string[][] };
-  if (!input.groups) return [];
+  const parsed = DuplicateGroupsSchema.safeParse(toolBlock.input);
+  if (!parsed.success) {
+    log.warn(
+      { callSite: "memoryConsolidation", error: parsed.error.message },
+      "Duplicate-group tool input did not match schema; treating as no dupes",
+    );
+    return [];
+  }
+  if (!parsed.data.groups) return [];
 
   const nodeMap = new Map(nodes.map((n) => [n.id, n]));
 
-  return (input.groups ?? [])
+  return parsed.data.groups
     .map((ids) =>
       ids.filter((id) => nodeMap.has(id)).map((id) => nodeMap.get(id)!),
     )
@@ -449,21 +517,28 @@ async function consolidateChunk(
     dedupedEdges,
   );
 
-  const response = await provider.sendMessage(
-    [
-      userMessage(
-        "Consolidate this partition. Focus on merging duplicates and fading old memories.",
-      ),
-    ],
-    {
-      tools: [CONSOLIDATE_TOOL_SCHEMA],
-      systemPrompt,
-      config: {
-        callSite: "memoryConsolidation" as const,
-        tool_choice: { type: "tool" as const, name: "consolidate_diff" },
+  const { signal, cleanup } = createTimeout(CONSOLIDATE_CHUNK_TIMEOUT_MS);
+  let response;
+  try {
+    response = await provider.sendMessage(
+      [
+        userMessage(
+          "Consolidate this partition. Focus on merging duplicates and fading old memories.",
+        ),
+      ],
+      {
+        tools: [CONSOLIDATE_TOOL_SCHEMA],
+        systemPrompt,
+        config: {
+          callSite: "memoryConsolidation" as const,
+          tool_choice: { type: "tool" as const, name: "consolidate_diff" },
+        },
+        signal,
       },
-    },
-  );
+    );
+  } finally {
+    cleanup();
+  }
 
   const toolBlock = extractToolUse(response);
   if (!toolBlock) {
@@ -471,31 +546,41 @@ async function consolidateChunk(
     return result;
   }
 
-  const input = toolBlock.input as {
-    updates?: Array<{
-      id: string;
-      content?: string;
-      fidelity?: string;
-      narrativeRole?: string;
-      partOfStory?: string;
-      event_date?: number | null;
-    }>;
-    delete_ids?: string[];
-    merge_edges?: Array<{ survivor_id: string; deleted_id: string }>;
-  };
+  const parsed = ConsolidateDiffSchema.safeParse(toolBlock.input);
+  if (!parsed.success) {
+    log.warn(
+      { callSite: "memoryConsolidation", error: parsed.error.message },
+      "Consolidation diff did not match schema; skipping chunk",
+    );
+    return result;
+  }
+  const input = parsed.data;
 
   // Build nodeMap once upfront; patch entries after each updateNode() so
   // later iterations always read fresh in-memory state.
   const nodeMap = new Map(nodes.map((n) => [n.id, n]));
 
   // Apply updates
-  for (const update of input.updates ?? []) {
+  for (const rawUpdate of input.updates ?? []) {
+    // Per-item strict validation: a single update whose `id`/`fidelity`/
+    // `event_date` is malformed is skipped with a warn rather than failing the
+    // whole chunk — the loop already tolerates missing optional fields, so a
+    // bad field on one item shouldn't lose the other items' valid rewrites.
+    const updateParse = ConsolidateUpdateSchema.safeParse(rawUpdate);
+    if (!updateParse.success) {
+      log.warn(
+        { callSite: "memoryConsolidation", error: updateParse.error.message },
+        "Consolidation update item failed validation; skipping item",
+      );
+      continue;
+    }
+    const update = updateParse.data;
+
     if (!nodeIds.has(update.id)) continue; // safety: only update nodes in this partition
 
     const changes: Partial<MemoryNode> = {};
     if (update.content) changes.content = update.content;
-    if (update.fidelity)
-      changes.fidelity = update.fidelity as MemoryNode["fidelity"];
+    if (update.fidelity) changes.fidelity = update.fidelity;
     if (update.narrativeRole !== undefined)
       changes.narrativeRole = update.narrativeRole || null;
     if (update.partOfStory !== undefined)

--- a/assistant/src/memory/graph/extraction.ts
+++ b/assistant/src/memory/graph/extraction.ts
@@ -14,6 +14,7 @@ import { and, asc, desc, eq, gt } from "drizzle-orm";
 import type { AssistantConfig } from "../../config/types.js";
 import { buildCoreIdentityContext } from "../../prompts/system-prompt.js";
 import {
+  createTimeout,
   extractToolUse,
   getConfiguredProvider,
   userMessage,
@@ -49,6 +50,14 @@ import type {
 } from "./types.js";
 
 const log = getLogger("graph-extraction");
+
+/**
+ * Generous timeout for the extraction LLM call. Extraction processes a whole
+ * conversation transcript (the largest single input of any memory background
+ * job), so it gets the longest budget — but it must still be bounded so a
+ * stalled provider connection can't wedge the memory worker indefinitely.
+ */
+const EXTRACTION_TIMEOUT_MS = 120_000;
 
 // ---------------------------------------------------------------------------
 // Extraction system prompt
@@ -1071,14 +1080,21 @@ export async function runGraphExtraction(
         ),
       ];
 
-  const response = await provider.sendMessage(extractionMessages, {
-    tools: [EXTRACT_TOOL_SCHEMA],
-    systemPrompt,
-    config: {
-      callSite: "memoryExtraction" as const,
-      tool_choice: { type: "tool" as const, name: "extract_graph_diff" },
-    },
-  });
+  const { signal, cleanup } = createTimeout(EXTRACTION_TIMEOUT_MS);
+  let response;
+  try {
+    response = await provider.sendMessage(extractionMessages, {
+      tools: [EXTRACT_TOOL_SCHEMA],
+      systemPrompt,
+      config: {
+        callSite: "memoryExtraction" as const,
+        tool_choice: { type: "tool" as const, name: "extract_graph_diff" },
+      },
+      signal,
+    });
+  } finally {
+    cleanup();
+  }
 
   const toolBlock = extractToolUse(response);
   if (!toolBlock) {

--- a/assistant/src/memory/graph/extraction.ts
+++ b/assistant/src/memory/graph/extraction.ts
@@ -1092,6 +1092,19 @@ export async function runGraphExtraction(
       },
       signal,
     });
+  } catch (err) {
+    // Required-job semantics: extraction already throws BackendUnavailableError
+    // on no-provider above, and `graphExtractJob` re-throws so the worker can
+    // observe the failure. A bare timeout aborts with a DOMException AbortError
+    // that `classifyError` (memory/job-utils.ts) would treat as fatal → no
+    // retry. Translate the abort into BackendUnavailableError so the worker
+    // defers/retries it like any other transient backend outage; bootstrap's
+    // per-conversation catch already tolerates the throw. Non-abort errors keep
+    // their own classification.
+    if (signal.aborted) {
+      throw new BackendUnavailableError("Graph extraction LLM call timed out");
+    }
+    throw err;
   } finally {
     cleanup();
   }

--- a/assistant/src/memory/graph/narrative.ts
+++ b/assistant/src/memory/graph/narrative.ts
@@ -14,6 +14,7 @@ import { z } from "zod";
 import type { AssistantConfig } from "../../config/types.js";
 import { runOneShotLLM } from "../../providers/one-shot-llm.js";
 import { userMessage } from "../../providers/provider-send-message.js";
+import { BackendUnavailableError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
 import { queryNodes, updateNode } from "./store.js";
 import type { MemoryNode } from "./types.js";
@@ -211,9 +212,8 @@ export async function runNarrativeRefinement(
     })),
   );
 
-  // `onUnavailable: "throw"` preserves the prior BackendUnavailableError.
-  // A missing tool_use or schema mismatch degrades to "no updates" — the same
-  // empty result the old `!toolBlock` path produced.
+  // `onUnavailable: "throw"` preserves the prior BackendUnavailableError for
+  // the no-provider case.
   const llmResult = await runOneShotLLM(
     "narrativeRefinement",
     [
@@ -232,6 +232,25 @@ export async function runNarrativeRefinement(
   );
 
   if (llmResult.status !== "ok") {
+    // Required-job semantics (mirrors pattern-scan): narrative refinement runs
+    // as a memory maintenance job whose worker calls `completeMemoryJob()` when
+    // this returns normally, and the checkpoint has already advanced at enqueue
+    // time. A transient transport failure (timeout / provider error) must
+    // re-throw BackendUnavailableError so `classifyError` routes it to
+    // defer/retry — otherwise the weekly refinement is silently skipped for a
+    // full interval. Malformed model output (`tool_use_missing` /
+    // `schema_mismatch`) is not transient, so it keeps degrading to "no
+    // updates" — the same empty result the old `!toolBlock` path produced.
+    if (
+      llmResult.status === "failure" &&
+      (llmResult.reason === "timeout" || llmResult.reason === "provider_error")
+    ) {
+      throw llmResult.error instanceof BackendUnavailableError
+        ? llmResult.error
+        : new BackendUnavailableError(
+            `Narrative refinement LLM call failed (${llmResult.reason})`,
+          );
+    }
     log.warn(
       { reason: llmResult.status === "failure" ? llmResult.reason : undefined },
       "Narrative refinement produced no usable tool output",

--- a/assistant/src/memory/graph/narrative.ts
+++ b/assistant/src/memory/graph/narrative.ts
@@ -235,21 +235,35 @@ export async function runNarrativeRefinement(
     // Required-job semantics (mirrors pattern-scan): narrative refinement runs
     // as a memory maintenance job whose worker calls `completeMemoryJob()` when
     // this returns normally, and the checkpoint has already advanced at enqueue
-    // time. A transient transport failure (timeout / provider error) must
-    // re-throw BackendUnavailableError so `classifyError` routes it to
-    // defer/retry — otherwise the weekly refinement is silently skipped for a
-    // full interval. Malformed model output (`tool_use_missing` /
-    // `schema_mismatch`) is not transient, so it keeps degrading to "no
-    // updates" — the same empty result the old `!toolBlock` path produced.
+    // time. A transient transport failure must throw so `classifyError` routes
+    // it to defer/retry — otherwise the weekly refinement is silently skipped
+    // for a full interval. We preserve the error's fatal-vs-transient shape
+    // rather than blanket-wrapping in `BackendUnavailableError`:
+    //  - `timeout`: a stalled provider IS transient → throw
+    //    `BackendUnavailableError` (classified retryable).
+    //  - `provider_error`: re-throw the ORIGINAL provider error on
+    //    `llmResult.error` so `classifyError` can fail fast on a fatal 4xx
+    //    instead of treating it as a transient outage. Already-
+    //    `BackendUnavailableError` errors re-throw as-is; a missing error
+    //    falls back to `BackendUnavailableError`.
+    // Malformed model output (`tool_use_missing` / `schema_mismatch`) is not
+    // transient, so it keeps degrading to "no updates" — the same empty result
+    // the old `!toolBlock` path produced.
+    if (llmResult.status === "failure" && llmResult.reason === "timeout") {
+      throw new BackendUnavailableError(
+        "Narrative refinement LLM call timed out",
+      );
+    }
     if (
       llmResult.status === "failure" &&
-      (llmResult.reason === "timeout" || llmResult.reason === "provider_error")
+      llmResult.reason === "provider_error"
     ) {
-      throw llmResult.error instanceof BackendUnavailableError
-        ? llmResult.error
-        : new BackendUnavailableError(
-            `Narrative refinement LLM call failed (${llmResult.reason})`,
-          );
+      if (llmResult.error !== undefined) {
+        throw llmResult.error;
+      }
+      throw new BackendUnavailableError(
+        "Narrative refinement LLM provider call failed",
+      );
     }
     log.warn(
       { reason: llmResult.status === "failure" ? llmResult.reason : undefined },

--- a/assistant/src/memory/graph/narrative.ts
+++ b/assistant/src/memory/graph/narrative.ts
@@ -9,18 +9,50 @@
 // high-significance nodes to re-evaluate arc assignments.
 // ---------------------------------------------------------------------------
 
+import { z } from "zod";
+
 import type { AssistantConfig } from "../../config/types.js";
-import {
-  extractToolUse,
-  getConfiguredProvider,
-  userMessage,
-} from "../../providers/provider-send-message.js";
-import { BackendUnavailableError } from "../../util/errors.js";
+import { runOneShotLLM } from "../../providers/one-shot-llm.js";
+import { userMessage } from "../../providers/provider-send-message.js";
 import { getLogger } from "../../util/logger.js";
 import { queryNodes, updateNode } from "./store.js";
 import type { MemoryNode } from "./types.js";
 
 const log = getLogger("graph-narrative");
+
+/**
+ * Tool input for `refine_narratives`. Encodes what the previous
+ * `toolBlock.input as {...}` cast assumed AND supplies the null guards the old
+ * code lacked: `updates` and `arcs_summary` default to `[]` so the iteration
+ * sites can no longer crash on a missing array. `narrativeRole`/`partOfStory`
+ * are nullable strings (the model returns `null` to clear a role).
+ */
+const RefineNarrativesSchema = z.object({
+  updates: z
+    .array(
+      z.object({
+        id: z.string(),
+        narrativeRole: z.string().nullish(),
+        partOfStory: z.string().nullish(),
+      }),
+    )
+    .default([]),
+  arcs_summary: z
+    .array(
+      z.object({
+        name: z.string(),
+        description: z.string(),
+        node_count: z.number(),
+      }),
+    )
+    .default([]),
+});
+
+/**
+ * Generous timeout for the narrative-refinement background batch call (runs
+ * monthly over up to 150 nodes).
+ */
+const NARRATIVE_TIMEOUT_MS = 60_000;
 
 // ---------------------------------------------------------------------------
 // Narrative refinement prompt
@@ -165,13 +197,6 @@ export async function runNarrativeRefinement(
     .sort((a, b) => b.significance - a.significance)
     .slice(0, 150);
 
-  const provider = await getConfiguredProvider("narrativeRefinement");
-  if (!provider) {
-    throw new BackendUnavailableError(
-      "Provider unavailable for narrative refinement",
-    );
-  }
-
   const candidateIds = new Set(candidates.map((n) => n.id));
 
   const systemPrompt = buildNarrativePrompt(
@@ -186,7 +211,11 @@ export async function runNarrativeRefinement(
     })),
   );
 
-  const response = await provider.sendMessage(
+  // `onUnavailable: "throw"` preserves the prior BackendUnavailableError.
+  // A missing tool_use or schema mismatch degrades to "no updates" — the same
+  // empty result the old `!toolBlock` path produced.
+  const llmResult = await runOneShotLLM(
+    "narrativeRefinement",
     [
       userMessage(
         "Review and refine the narrative structure of these memories. Identify story arcs and assign roles with the benefit of hindsight.",
@@ -194,36 +223,27 @@ export async function runNarrativeRefinement(
     ],
     {
       tools: [NARRATIVE_TOOL_SCHEMA],
+      toolChoice: "refine_narratives",
+      schema: RefineNarrativesSchema,
       systemPrompt,
-      config: {
-        callSite: "narrativeRefinement" as const,
-        tool_choice: { type: "tool" as const, name: "refine_narratives" },
-      },
+      timeoutMs: NARRATIVE_TIMEOUT_MS,
+      onUnavailable: "throw",
     },
   );
 
-  const toolBlock = extractToolUse(response);
-  if (!toolBlock) {
-    log.warn("No tool_use block in narrative refinement response");
+  if (llmResult.status !== "ok") {
+    log.warn(
+      { reason: llmResult.status === "failure" ? llmResult.reason : undefined },
+      "Narrative refinement produced no usable tool output",
+    );
     result.latencyMs = Date.now() - start;
     return result;
   }
 
-  const input = toolBlock.input as {
-    updates?: Array<{
-      id: string;
-      narrativeRole?: string | null;
-      partOfStory?: string | null;
-    }>;
-    arcs_summary?: Array<{
-      name: string;
-      description: string;
-      node_count: number;
-    }>;
-  };
+  const input = llmResult.data;
 
   // Apply updates
-  for (const update of input.updates ?? []) {
+  for (const update of input.updates) {
     if (!candidateIds.has(update.id)) continue;
 
     const changes: Partial<MemoryNode> = { lastConsolidated: Date.now() };
@@ -245,7 +265,7 @@ export async function runNarrativeRefinement(
   }
 
   // Record arc summaries
-  result.arcs = (input.arcs_summary ?? []).map((a) => ({
+  result.arcs = input.arcs_summary.map((a) => ({
     name: a.name,
     description: a.description,
     nodeCount: a.node_count,

--- a/assistant/src/memory/graph/pattern-scan.test.ts
+++ b/assistant/src/memory/graph/pattern-scan.test.ts
@@ -38,15 +38,20 @@ mock.module("../../providers/provider-send-message.js", () => ({
   extractToolUse: (response: ProviderResponse) =>
     response.content.find((b): b is ToolUseContent => b.type === "tool_use"),
   extractAllText: () => "",
+  // Cap the fuse at 100ms so the timeout-path test aborts quickly instead of
+  // waiting the scan's real 60s `PATTERN_SCAN_TIMEOUT_MS`. Providers in the
+  // other tests resolve on the next microtask, well before 100ms, so the cap
+  // never trips them.
   createTimeout: (ms: number) => {
     const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), ms);
+    const timer = setTimeout(() => controller.abort(), Math.min(ms, 100));
     return { signal: controller.signal, cleanup: () => clearTimeout(timer) };
   },
 }));
 
 import { resetDbForTesting } from "../../__tests__/db-test-helpers.js";
 import { DEFAULT_CONFIG } from "../../config/defaults.js";
+import { BackendUnavailableError } from "../../util/errors.js";
 import { initializeDb } from "../db-init.js";
 import { runPatternScan } from "./pattern-scan.js";
 import { createNode, queryNodes } from "./store.js";
@@ -103,6 +108,38 @@ function makeToolProvider(input: unknown): Provider {
         },
       ],
     }),
+  } as Provider;
+}
+
+/** Provider stub whose `sendMessage` throws — simulates `provider_error`. */
+function makeThrowingProvider(err: unknown): Provider {
+  return {
+    name: "stub",
+    sendMessage: async () => {
+      throw err;
+    },
+  } as Provider;
+}
+
+/**
+ * Provider stub that rejects with an AbortError once its abort signal fires —
+ * simulates the timeout path. `runOneShotLLM` sees `signal.aborted` and reports
+ * `reason: "timeout"`. Pair with a small `createTimeout` so the abort is fast.
+ */
+function makeAbortAwaitingProvider(): Provider {
+  return {
+    name: "stub",
+    sendMessage: (_msgs: Message[], opts?: SendMessageOptions) =>
+      new Promise<ProviderResponse>((_resolve, reject) => {
+        const signal = opts?.signal;
+        if (signal?.aborted) {
+          reject(new DOMException("Aborted", "AbortError"));
+          return;
+        }
+        signal?.addEventListener("abort", () => {
+          reject(new DOMException("Aborted", "AbortError"));
+        });
+      }),
   } as Provider;
 }
 
@@ -175,6 +212,35 @@ describe("runPatternScan — schema validation + degradation", () => {
     providerStub = null;
 
     await expect(runPatternScan(SCOPE, DEFAULT_CONFIG)).rejects.toThrow();
+  });
+
+  test("re-throws BackendUnavailableError on a provider error (transient) so the worker retries", async () => {
+    seedNodes(12);
+    const before = queryNodes({ scopeId: SCOPE }).length;
+    // A transport failure (provider.sendMessage throws, signal NOT aborted)
+    // surfaces as `reason: "provider_error"`. The pattern-scan job must re-throw
+    // BackendUnavailableError so `classifyError` defers/retries instead of
+    // marking the job COMPLETED and skipping the scan for a full interval.
+    providerStub = makeThrowingProvider(new Error("upstream 503"));
+
+    await expect(runPatternScan(SCOPE, DEFAULT_CONFIG)).rejects.toBeInstanceOf(
+      BackendUnavailableError,
+    );
+    // No graph writes on a failed scan.
+    expect(queryNodes({ scopeId: SCOPE }).length).toBe(before);
+  });
+
+  test("re-throws BackendUnavailableError on a timeout (transient) so the worker retries", async () => {
+    seedNodes(12);
+    // A stalled provider connection that hits the timeout aborts the request;
+    // `runOneShotLLM` reports `reason: "timeout"`, which the job must re-throw
+    // as BackendUnavailableError (the established transient-backend signal). The
+    // mocked `createTimeout` caps the fuse at 100ms, so the abort fires fast.
+    providerStub = makeAbortAwaitingProvider();
+
+    await expect(runPatternScan(SCOPE, DEFAULT_CONFIG)).rejects.toBeInstanceOf(
+      BackendUnavailableError,
+    );
   });
 
   test("returns an empty result without an LLM call for too-few nodes", async () => {

--- a/assistant/src/memory/graph/pattern-scan.test.ts
+++ b/assistant/src/memory/graph/pattern-scan.test.ts
@@ -8,6 +8,14 @@
 // partially iterated. The no-provider path still throws
 // BackendUnavailableError.
 //
+// Round-3 review follow-up — error fidelity at the job boundary:
+//   - `timeout` (stalled provider): throws BackendUnavailableError (transient →
+//     defer/retry).
+//   - `provider_error`: re-throws the ORIGINAL provider error so `classifyError`
+//     can fail fast on a fatal 4xx instead of wrapping every failure in a
+//     "transient" BackendUnavailableError. An already-BackendUnavailableError
+//     re-throws as-is.
+//
 // Only the provider boundary is mocked; SQLite/store run unmocked against the
 // in-process test DB so the assertions reflect real graph state.
 // ---------------------------------------------------------------------------
@@ -214,20 +222,41 @@ describe("runPatternScan — schema validation + degradation", () => {
     await expect(runPatternScan(SCOPE, DEFAULT_CONFIG)).rejects.toThrow();
   });
 
-  test("re-throws BackendUnavailableError on a provider error (transient) so the worker retries", async () => {
+  test("re-throws the ORIGINAL provider error so classifyError can fail fast on a fatal 4xx", async () => {
     seedNodes(12);
     const before = queryNodes({ scopeId: SCOPE }).length;
-    // A transport failure (provider.sendMessage throws, signal NOT aborted)
-    // surfaces as `reason: "provider_error"`. The pattern-scan job must re-throw
-    // BackendUnavailableError so `classifyError` defers/retries instead of
-    // marking the job COMPLETED and skipping the scan for a full interval.
-    providerStub = makeThrowingProvider(new Error("upstream 503"));
+    // A non-retryable provider error (e.g. a 400 bad-request / 401 auth error
+    // from the forced-tool call) surfaces as `reason: "provider_error"` with the
+    // original error preserved on `llmResult.error`. The job must re-throw that
+    // ORIGINAL error — NOT a BackendUnavailableError wrapper — so `classifyError`
+    // inspects its 4xx status and fails the job fast instead of deferring/retrying
+    // a doomed request for the full backoff window.
+    const fatalError = Object.assign(new Error("bad request"), { status: 400 });
+    providerStub = makeThrowingProvider(fatalError);
 
-    await expect(runPatternScan(SCOPE, DEFAULT_CONFIG)).rejects.toBeInstanceOf(
-      BackendUnavailableError,
+    await expect(runPatternScan(SCOPE, DEFAULT_CONFIG)).rejects.toBe(
+      fatalError,
     );
+    // The original error propagates, not a BackendUnavailableError wrapper.
+    await expect(
+      runPatternScan(SCOPE, DEFAULT_CONFIG),
+    ).rejects.not.toBeInstanceOf(BackendUnavailableError);
     // No graph writes on a failed scan.
     expect(queryNodes({ scopeId: SCOPE }).length).toBe(before);
+  });
+
+  test("re-throws an already-BackendUnavailableError provider error as-is (transient)", async () => {
+    seedNodes(12);
+    // When the provider itself throws a BackendUnavailableError (e.g. a backend
+    // that classifies its own outage), `reason: "provider_error"` carries it on
+    // `llmResult.error` and the job re-throws it unchanged — still transient, so
+    // `classifyError` / `handleJobError` defers and retries.
+    const backendErr = new BackendUnavailableError("provider backend down");
+    providerStub = makeThrowingProvider(backendErr);
+
+    await expect(runPatternScan(SCOPE, DEFAULT_CONFIG)).rejects.toBe(
+      backendErr,
+    );
   });
 
   test("re-throws BackendUnavailableError on a timeout (transient) so the worker retries", async () => {

--- a/assistant/src/memory/graph/pattern-scan.test.ts
+++ b/assistant/src/memory/graph/pattern-scan.test.ts
@@ -1,0 +1,188 @@
+// ---------------------------------------------------------------------------
+// pattern-scan.test.ts — schema-validation + degradation coverage for
+// `runPatternScan`.
+//
+// Focus (M3): the pattern-scan tool input is now validated with a zod schema
+// via `runOneShotLLM`. A malformed tool input must degrade to "no patterns
+// detected" (empty result, no throw, no graph writes) instead of being
+// partially iterated. The no-provider path still throws
+// BackendUnavailableError.
+//
+// Only the provider boundary is mocked; SQLite/store run unmocked against the
+// in-process test DB so the assertions reflect real graph state.
+// ---------------------------------------------------------------------------
+
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+  ToolUseContent,
+} from "../../providers/types.js";
+
+// Provider stub — each test sets `providerStub` to control the tool response;
+// `null` simulates "no configured provider".
+let providerStub: Provider | null = null;
+
+// `runPatternScan` routes through `runOneShotLLM`, which imports
+// `getConfiguredProvider`, `userMessage`, `extractToolUse`, `createTimeout`,
+// and `extractAllText` from this module — the mock must export all five.
+mock.module("../../providers/provider-send-message.js", () => ({
+  getConfiguredProvider: async () => providerStub,
+  userMessage: (text: string) => ({
+    role: "user" as const,
+    content: [{ type: "text" as const, text }],
+  }),
+  extractToolUse: (response: ProviderResponse) =>
+    response.content.find((b): b is ToolUseContent => b.type === "tool_use"),
+  extractAllText: () => "",
+  createTimeout: (ms: number) => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), ms);
+    return { signal: controller.signal, cleanup: () => clearTimeout(timer) };
+  },
+}));
+
+import { resetDbForTesting } from "../../__tests__/db-test-helpers.js";
+import { DEFAULT_CONFIG } from "../../config/defaults.js";
+import { initializeDb } from "../db-init.js";
+import { runPatternScan } from "./pattern-scan.js";
+import { createNode, queryNodes } from "./store.js";
+import type { NewNode } from "./types.js";
+
+const SCOPE = "pattern-scan-test";
+
+/** Build a plain narrative node so `runPatternScan`'s ≥10-node gate clears. */
+function makeNode(content: string): NewNode {
+  const now = Date.now();
+  return {
+    content,
+    type: "narrative",
+    created: now,
+    lastAccessed: now,
+    lastConsolidated: now,
+    eventDate: null,
+    emotionalCharge: {
+      valence: 0,
+      intensity: 0.3,
+      decayCurve: "linear",
+      decayRate: 0.05,
+      originalIntensity: 0.3,
+    },
+    fidelity: "clear",
+    confidence: 0.7,
+    significance: 0.5,
+    stability: 14,
+    reinforcementCount: 0,
+    lastReinforced: now,
+    sourceConversations: [],
+    sourceType: "observed",
+    narrativeRole: null,
+    partOfStory: null,
+    imageRefs: null,
+    scopeId: SCOPE,
+  };
+}
+
+/** Provider stub returning a single `detect_patterns` tool_use with `input`. */
+function makeToolProvider(input: unknown): Provider {
+  return {
+    name: "stub",
+    sendMessage: async (_msgs: Message[], _opts?: SendMessageOptions) => ({
+      model: "stub-model",
+      stopReason: "tool_use",
+      usage: { inputTokens: 0, outputTokens: 0 },
+      content: [
+        {
+          type: "tool_use",
+          id: "tu-1",
+          name: "detect_patterns",
+          input: input as Record<string, unknown>,
+        },
+      ],
+    }),
+  } as Provider;
+}
+
+function seedNodes(count: number): string[] {
+  const ids: string[] = [];
+  for (let i = 0; i < count; i++) {
+    ids.push(createNode(makeNode(`Memory number ${i} about being tired.`)).id);
+  }
+  return ids;
+}
+
+describe("runPatternScan — schema validation + degradation", () => {
+  beforeAll(() => {
+    initializeDb();
+  });
+
+  beforeEach(() => {
+    resetDbForTesting();
+    initializeDb();
+    providerStub = null;
+  });
+
+  test("creates pattern nodes + edges on a well-formed tool response", async () => {
+    const ids = seedNodes(12);
+    providerStub = makeToolProvider({
+      patterns: [
+        {
+          content: "I notice the user keeps mentioning being tired.",
+          type: "narrative",
+          significance: 0.6,
+          source_node_ids: ids.slice(0, 4),
+        },
+      ],
+    });
+
+    const result = await runPatternScan(SCOPE, DEFAULT_CONFIG);
+
+    expect(result.patternsDetected).toBe(1);
+    expect(result.edgesCreated).toBe(4);
+  });
+
+  test("degrades to an empty result (no throw, no writes) on a schema mismatch", async () => {
+    seedNodes(12);
+    const before = queryNodes({ scopeId: SCOPE }).length;
+
+    // `patterns[].significance` is a string, not a number — the zod schema
+    // rejects the whole input, so the scan must degrade rather than partially
+    // iterate a malformed shape.
+    providerStub = makeToolProvider({
+      patterns: [
+        {
+          content: "malformed",
+          type: "narrative",
+          significance: "high",
+          source_node_ids: ["x", "y", "z"],
+        },
+      ],
+    });
+
+    const result = await runPatternScan(SCOPE, DEFAULT_CONFIG);
+
+    expect(result.patternsDetected).toBe(0);
+    expect(result.edgesCreated).toBe(0);
+    // No new nodes were written despite the malformed response.
+    expect(queryNodes({ scopeId: SCOPE }).length).toBe(before);
+  });
+
+  test("throws BackendUnavailableError when no provider is configured", async () => {
+    seedNodes(12);
+    providerStub = null;
+
+    await expect(runPatternScan(SCOPE, DEFAULT_CONFIG)).rejects.toThrow();
+  });
+
+  test("returns an empty result without an LLM call for too-few nodes", async () => {
+    seedNodes(5);
+    providerStub = makeToolProvider({ patterns: [] });
+
+    const result = await runPatternScan(SCOPE, DEFAULT_CONFIG);
+
+    expect(result.patternsDetected).toBe(0);
+  });
+});

--- a/assistant/src/memory/graph/pattern-scan.ts
+++ b/assistant/src/memory/graph/pattern-scan.ts
@@ -8,17 +8,39 @@
 // Also detects behavioral patterns in the assistant's own actions.
 // ---------------------------------------------------------------------------
 
+import { z } from "zod";
+
 import type { AssistantConfig } from "../../config/types.js";
-import {
-  extractToolUse,
-  getConfiguredProvider,
-  userMessage,
-} from "../../providers/provider-send-message.js";
-import { BackendUnavailableError } from "../../util/errors.js";
+import { runOneShotLLM } from "../../providers/one-shot-llm.js";
+import { userMessage } from "../../providers/provider-send-message.js";
 import { getLogger } from "../../util/logger.js";
 import { createEdge, createNode, queryNodes } from "./store.js";
 
 const log = getLogger("graph-pattern-scan");
+
+/**
+ * Pattern-scan tool input. Encodes what the previous manual
+ * `toolBlock.input as {...}` cast assumed. `patterns` is the array the loop
+ * iterates; each element is dropped (`continue`) downstream if it has fewer
+ * than 3 valid source nodes, so the schema only needs to guarantee the
+ * iterated fields exist with the right types. `partOfStory` stays optional.
+ */
+const PatternScanResultSchema = z.object({
+  patterns: z
+    .array(
+      z.object({
+        content: z.string(),
+        type: z.string(),
+        significance: z.number(),
+        source_node_ids: z.array(z.string()),
+        partOfStory: z.string().optional(),
+      }),
+    )
+    .optional(),
+});
+
+/** Generous timeout for the pattern-scan background batch call. */
+const PATTERN_SCAN_TIMEOUT_MS = 60_000;
 
 // ---------------------------------------------------------------------------
 // Pattern scan prompt
@@ -141,11 +163,6 @@ export async function runPatternScan(
     return result;
   }
 
-  const provider = await getConfiguredProvider("patternScan");
-  if (!provider) {
-    throw new BackendUnavailableError("Provider unavailable for pattern scan");
-  }
-
   const systemPrompt = buildPatternScanPrompt(
     allNodes.map((n) => ({
       id: n.id,
@@ -155,7 +172,11 @@ export async function runPatternScan(
     })),
   );
 
-  const response = await provider.sendMessage(
+  // `onUnavailable: "throw"` preserves the prior BackendUnavailableError
+  // semantics. A schema mismatch or missing tool_use degrades to "no patterns
+  // detected" — the same empty result the old `!toolBlock` path produced.
+  const llmResult = await runOneShotLLM(
+    "patternScan",
     [
       userMessage(
         "Analyze this memory sample for recurring patterns. Only report patterns you're confident about.",
@@ -163,30 +184,24 @@ export async function runPatternScan(
     ],
     {
       tools: [PATTERN_TOOL_SCHEMA],
+      toolChoice: "detect_patterns",
+      schema: PatternScanResultSchema,
       systemPrompt,
-      config: {
-        callSite: "patternScan" as const,
-        tool_choice: { type: "tool" as const, name: "detect_patterns" },
-      },
+      timeoutMs: PATTERN_SCAN_TIMEOUT_MS,
+      onUnavailable: "throw",
     },
   );
 
-  const toolBlock = extractToolUse(response);
-  if (!toolBlock) {
-    log.warn("No tool_use block in pattern scan response");
+  if (llmResult.status !== "ok") {
+    log.warn(
+      { reason: llmResult.status === "failure" ? llmResult.reason : undefined },
+      "Pattern scan produced no usable tool output",
+    );
     result.latencyMs = Date.now() - start;
     return result;
   }
 
-  const input = toolBlock.input as {
-    patterns?: Array<{
-      content: string;
-      type: string;
-      significance: number;
-      source_node_ids: string[];
-      partOfStory?: string;
-    }>;
-  };
+  const input = llmResult.data;
 
   const existingIds = new Set(allNodes.map((n) => n.id));
   const now = Date.now();

--- a/assistant/src/memory/graph/pattern-scan.ts
+++ b/assistant/src/memory/graph/pattern-scan.ts
@@ -196,24 +196,41 @@ export async function runPatternScan(
     // Required-job semantics: pattern scan runs as the `graph_pattern_scan`
     // memory job, and `jobs-worker.ts` calls `completeMemoryJob()` when this
     // returns normally — the maintenance checkpoint has already advanced at
-    // enqueue time. A transient transport failure (timeout / provider error)
-    // must NOT return an empty result, or the worker marks the job COMPLETED
-    // and the scan is silently skipped for a full interval. Re-throw
-    // BackendUnavailableError so `classifyError` (memory/job-utils.ts) routes
-    // it to defer/retry, matching `consolidateChunk` / `runGraphExtraction`
-    // and the sweep job. Malformed model output (`tool_use_missing` /
-    // `schema_mismatch`) is NOT transient — retrying won't help — so it keeps
-    // degrading to "no patterns detected", the same empty result the old
-    // `!toolBlock` path produced.
+    // enqueue time. A transient transport failure must NOT return an empty
+    // result, or the worker marks the job COMPLETED and the scan is silently
+    // skipped for a full interval. We throw so `classifyError`
+    // (memory/job-utils.ts) routes the failure to defer/retry.
+    //
+    // Critically, we preserve the error's fatal-vs-transient shape rather than
+    // blanket-wrapping every failure in `BackendUnavailableError`:
+    //  - `timeout`: a stalled provider connection IS transient, so we throw
+    //    `BackendUnavailableError` (classified retryable). The abort error in
+    //    `llmResult.error` carries no status, so wrapping it gives the worker
+    //    the right signal.
+    //  - `provider_error`: re-throw the ORIGINAL provider error preserved on
+    //    `llmResult.error`. `classifyError` inspects its HTTP status / message,
+    //    so a fatal 4xx (auth / bad request from the forced-tool call) fails
+    //    fast instead of being wrapped into a "transient" outage that retries
+    //    for the full backoff window. If the original is already a
+    //    `BackendUnavailableError`, re-throw as-is; if it's somehow missing,
+    //    fall back to `BackendUnavailableError`.
+    //
+    // Malformed model output (`tool_use_missing` / `schema_mismatch`) is NOT
+    // transient — retrying won't help — so it keeps degrading to "no patterns
+    // detected", the same empty result the old `!toolBlock` path produced.
+    if (llmResult.status === "failure" && llmResult.reason === "timeout") {
+      throw new BackendUnavailableError("Pattern scan LLM call timed out");
+    }
     if (
       llmResult.status === "failure" &&
-      (llmResult.reason === "timeout" || llmResult.reason === "provider_error")
+      llmResult.reason === "provider_error"
     ) {
-      throw llmResult.error instanceof BackendUnavailableError
-        ? llmResult.error
-        : new BackendUnavailableError(
-            `Pattern scan LLM call failed (${llmResult.reason})`,
-          );
+      if (llmResult.error !== undefined) {
+        throw llmResult.error;
+      }
+      throw new BackendUnavailableError(
+        "Pattern scan LLM provider call failed",
+      );
     }
     log.warn(
       { reason: llmResult.status === "failure" ? llmResult.reason : undefined },

--- a/assistant/src/memory/graph/pattern-scan.ts
+++ b/assistant/src/memory/graph/pattern-scan.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 import type { AssistantConfig } from "../../config/types.js";
 import { runOneShotLLM } from "../../providers/one-shot-llm.js";
 import { userMessage } from "../../providers/provider-send-message.js";
+import { BackendUnavailableError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
 import { createEdge, createNode, queryNodes } from "./store.js";
 
@@ -173,8 +174,7 @@ export async function runPatternScan(
   );
 
   // `onUnavailable: "throw"` preserves the prior BackendUnavailableError
-  // semantics. A schema mismatch or missing tool_use degrades to "no patterns
-  // detected" — the same empty result the old `!toolBlock` path produced.
+  // semantics for the no-provider case.
   const llmResult = await runOneShotLLM(
     "patternScan",
     [
@@ -193,6 +193,28 @@ export async function runPatternScan(
   );
 
   if (llmResult.status !== "ok") {
+    // Required-job semantics: pattern scan runs as the `graph_pattern_scan`
+    // memory job, and `jobs-worker.ts` calls `completeMemoryJob()` when this
+    // returns normally — the maintenance checkpoint has already advanced at
+    // enqueue time. A transient transport failure (timeout / provider error)
+    // must NOT return an empty result, or the worker marks the job COMPLETED
+    // and the scan is silently skipped for a full interval. Re-throw
+    // BackendUnavailableError so `classifyError` (memory/job-utils.ts) routes
+    // it to defer/retry, matching `consolidateChunk` / `runGraphExtraction`
+    // and the sweep job. Malformed model output (`tool_use_missing` /
+    // `schema_mismatch`) is NOT transient — retrying won't help — so it keeps
+    // degrading to "no patterns detected", the same empty result the old
+    // `!toolBlock` path produced.
+    if (
+      llmResult.status === "failure" &&
+      (llmResult.reason === "timeout" || llmResult.reason === "provider_error")
+    ) {
+      throw llmResult.error instanceof BackendUnavailableError
+        ? llmResult.error
+        : new BackendUnavailableError(
+            `Pattern scan LLM call failed (${llmResult.reason})`,
+          );
+    }
     log.warn(
       { reason: llmResult.status === "failure" ? llmResult.reason : undefined },
       "Pattern scan produced no usable tool output",

--- a/assistant/src/memory/graph/retriever.test.ts
+++ b/assistant/src/memory/graph/retriever.test.ts
@@ -59,9 +59,11 @@ mock.module("./graph-search.js", () => ({
   },
 }));
 
-// Returning `null` from getConfiguredProvider causes rerankAndDedup and
-// dedupCrossCategory to fall back to the candidate list without calling an
-// LLM, keeping these tests fully offline.
+// Returning `null` from getConfiguredProvider causes rerankAndDedup,
+// dedupForTurn, and dedupCrossCategory (now routed through `runOneShotLLM`) to
+// resolve `{ status: "unavailable" }` and fall back to the candidate list
+// without calling an LLM, keeping these tests fully offline. The helper also
+// imports `createTimeout` and `extractAllText`, so the mock must export them.
 mock.module("../../providers/provider-send-message.js", () => ({
   getConfiguredProvider: async () => null,
   userMessage: (text: string) => ({
@@ -69,6 +71,12 @@ mock.module("../../providers/provider-send-message.js", () => ({
     content: [{ type: "text" as const, text }],
   }),
   extractToolUse: () => null,
+  extractAllText: () => "",
+  createTimeout: (ms: number) => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), ms);
+    return { signal: controller.signal, cleanup: () => clearTimeout(timer) };
+  },
 }));
 
 import { resetDbForTesting } from "../../__tests__/db-test-helpers.js";

--- a/assistant/src/memory/graph/retriever.ts
+++ b/assistant/src/memory/graph/retriever.ts
@@ -6,12 +6,11 @@
 // 2. Per-turn injection — lightweight embedding search for new memories
 // ---------------------------------------------------------------------------
 
+import { z } from "zod";
+
 import type { AssistantConfig } from "../../config/types.js";
-import {
-  extractToolUse,
-  getConfiguredProvider,
-  userMessage,
-} from "../../providers/provider-send-message.js";
+import { runOneShotLLM } from "../../providers/one-shot-llm.js";
+import { userMessage } from "../../providers/provider-send-message.js";
 import type { ContentBlock, ImageContent } from "../../providers/types.js";
 import { getLogger } from "../../util/logger.js";
 import { embedWithRetry } from "../embed.js";
@@ -66,6 +65,33 @@ function extractCapabilityId(node: MemoryNode): string | null {
 // LLM re-ranking + deduplication
 // ---------------------------------------------------------------------------
 
+/**
+ * Generous timeout for the retrieval rerank/dedup background calls. These run
+ * inside the context-load / per-turn pipelines, but all three degrade to a
+ * deterministic score-based slice on failure, so a stalled provider can't
+ * wedge retrieval — the timeout just bounds how long it waits before falling
+ * back.
+ */
+const RERANK_TIMEOUT_MS = 60_000;
+
+/**
+ * Tool input for the `select_memories` rerank pass. Encodes what the previous
+ * `toolBlock.input as { selected?: number[] }` cast assumed; `selected` stays
+ * optional so an absent/empty list degrades to the scored slice exactly as
+ * before.
+ */
+const SelectMemoriesSchema = z.object({
+  selected: z.array(z.number()).optional(),
+});
+
+/**
+ * Tool input for the `select_items` dedup passes (per-turn and cross-category).
+ * Mirrors the prior `{ items?: number[] }` cast.
+ */
+const SelectItemsSchema = z.object({
+  items: z.array(z.number()).optional(),
+});
+
 const RERANK_TOOL = {
   name: "select_memories",
   description:
@@ -97,9 +123,6 @@ async function rerankAndDedup(
   if (candidates.length <= maxNodes) return candidates;
 
   try {
-    const provider = await getConfiguredProvider("memoryRetrieval");
-    if (!provider) return candidates.slice(0, maxNodes);
-
     // Numbered listing for the LLM: index + age + full content
     const now = Date.now();
     const listing = candidates
@@ -113,9 +136,16 @@ async function rerankAndDedup(
       })
       .join("\n");
 
-    const response = await provider.sendMessage([userMessage(listing)], {
-      tools: [RERANK_TOOL],
-      systemPrompt: `You are selecting memories for an AI assistant's context at conversation start. You see ${candidates.length} candidate memories ranked by algorithmic score.
+    // `onUnavailable: "null"` keeps the prior "no provider → scored slice"
+    // degradation; any non-`ok` status falls through to the same fallback.
+    const llmResult = await runOneShotLLM(
+      "memoryRetrieval",
+      [userMessage(listing)],
+      {
+        tools: [RERANK_TOOL],
+        toolChoice: "select_memories",
+        schema: SelectMemoriesSchema,
+        systemPrompt: `You are selecting memories for an AI assistant's context at conversation start. You see ${candidates.length} candidate memories ranked by algorithmic score.
 
 Your job:
 1. REMOVE DUPLICATES: If multiple entries describe the same event/fact/topic, keep ONLY the most complete version. Be aggressive — even partial overlaps should be deduplicated.
@@ -124,18 +154,14 @@ Your job:
    - Diversity (don't load 5 memories about the same topic)
    - Importance (key relationship moments, active commitments, identity-defining events)
 3. Return the IDs in order of importance (most important first).`,
-      config: {
-        callSite: "memoryRetrieval" as const,
-        tool_choice: { type: "tool" as const, name: "select_memories" },
-        thinking: { type: "disabled" },
-        temperature: 0,
+        timeoutMs: RERANK_TIMEOUT_MS,
+        config: { thinking: { type: "disabled" }, temperature: 0 },
       },
-    });
+    );
 
-    const toolBlock = extractToolUse(response);
-    if (!toolBlock) return candidates.slice(0, maxNodes);
+    if (llmResult.status !== "ok") return candidates.slice(0, maxNodes);
 
-    const input = toolBlock.input as { selected?: number[] };
+    const input = llmResult.data;
     if (!input.selected?.length) return candidates.slice(0, maxNodes);
 
     // Rebuild scored list in the LLM's chosen order (1-indexed → 0-indexed)
@@ -193,10 +219,6 @@ async function dedupForTurn(
   query: string,
 ): Promise<{ nodes: ScoredNode[]; llmApplied: boolean }> {
   try {
-    const provider = await getConfiguredProvider("memoryRetrieval");
-    if (!provider)
-      return { nodes: candidates.slice(0, maxNodes), llmApplied: false };
-
     const now = Date.now();
     const listing = candidates
       .map((s, i) => {
@@ -209,25 +231,23 @@ async function dedupForTurn(
       })
       .join("\n");
 
-    const response = await provider.sendMessage(
+    const llmResult = await runOneShotLLM(
+      "memoryRetrieval",
       [userMessage(`query:\n${query}\n\nitems:\n\n${listing}`)],
       {
         tools: [SELECT_ITEMS_TOOL],
+        toolChoice: "select_items",
+        schema: SelectItemsSchema,
         systemPrompt: `Dedupe + rerank the following numbered items. Pick the most relevant items to the query. Call the select_items tool.\n\nBe aggressive on dedup — when multiple items describe the same event, fact, or status, keep ONLY the richest version. But be generous on relevance — only cut items that are completely irrelevant to the query. If it's even tangentially related, keep it.`,
-        config: {
-          callSite: "memoryRetrieval" as const,
-          tool_choice: { type: "tool" as const, name: "select_items" },
-          thinking: { type: "disabled" },
-          temperature: 0,
-        },
+        timeoutMs: RERANK_TIMEOUT_MS,
+        config: { thinking: { type: "disabled" }, temperature: 0 },
       },
     );
 
-    const toolBlock = extractToolUse(response);
-    if (!toolBlock)
+    if (llmResult.status !== "ok")
       return { nodes: candidates.slice(0, maxNodes), llmApplied: false };
 
-    const input = toolBlock.input as { items?: number[] };
+    const input = llmResult.data;
     if (!input.items?.length)
       return { nodes: candidates.slice(0, maxNodes), llmApplied: false };
 
@@ -286,9 +306,6 @@ async function dedupCrossCategory(
   maxNodes: number,
 ): Promise<ScoredNode[]> {
   try {
-    const provider = await getConfiguredProvider("memoryRetrieval");
-    if (!provider) return candidates.slice(0, maxNodes);
-
     const now = Date.now();
     const listing = candidates
       .map((s, i) => {
@@ -301,21 +318,22 @@ async function dedupCrossCategory(
       })
       .join("\n");
 
-    const response = await provider.sendMessage([userMessage(listing)], {
-      tools: [DEDUP_ITEMS_TOOL],
-      systemPrompt: `Deduplicate the following numbered items. When multiple items describe the same event, fact, or status, keep ONLY the richest version. Keep ALL items that are not duplicates — do not filter by relevance or topic. Call the select_items tool with every item that survives dedup.`,
-      config: {
-        callSite: "memoryRetrieval" as const,
-        tool_choice: { type: "tool" as const, name: "select_items" },
-        thinking: { type: "disabled" },
-        temperature: 0,
+    const llmResult = await runOneShotLLM(
+      "memoryRetrieval",
+      [userMessage(listing)],
+      {
+        tools: [DEDUP_ITEMS_TOOL],
+        toolChoice: "select_items",
+        schema: SelectItemsSchema,
+        systemPrompt: `Deduplicate the following numbered items. When multiple items describe the same event, fact, or status, keep ONLY the richest version. Keep ALL items that are not duplicates — do not filter by relevance or topic. Call the select_items tool with every item that survives dedup.`,
+        timeoutMs: RERANK_TIMEOUT_MS,
+        config: { thinking: { type: "disabled" }, temperature: 0 },
       },
-    });
+    );
 
-    const toolBlock = extractToolUse(response);
-    if (!toolBlock) return candidates.slice(0, maxNodes);
+    if (llmResult.status !== "ok") return candidates.slice(0, maxNodes);
 
-    const input = toolBlock.input as { items?: number[] };
+    const input = llmResult.data;
     if (!input.items?.length) return candidates.slice(0, maxNodes);
 
     const reranked: ScoredNode[] = [];

--- a/assistant/src/memory/v2/__tests__/sweep-job.test.ts
+++ b/assistant/src/memory/v2/__tests__/sweep-job.test.ts
@@ -54,6 +54,12 @@ const providerCalls: Array<{
   userText: string;
 }> = [];
 
+// The sweep now routes through `runOneShotLLM`, which imports
+// `getConfiguredProvider`, `userMessage`, `extractToolUse`, `createTimeout`,
+// and `extractAllText` from this module — so the mock must export all five.
+// `createTimeout` returns a real (never-firing) timer so the helper's
+// finally-cleanup runs without a network call; `extractAllText` is only used
+// on the text path (not the sweep's tool path) but must exist as an export.
 mock.module("../../../providers/provider-send-message.js", () => ({
   getConfiguredProvider: async () => providerStub,
   userMessage: (text: string) => ({
@@ -62,6 +68,16 @@ mock.module("../../../providers/provider-send-message.js", () => ({
   }),
   extractToolUse: (response: ProviderResponse) =>
     response.content.find((b): b is ToolUseContent => b.type === "tool_use"),
+  extractAllText: (response: ProviderResponse) =>
+    response.content
+      .filter((b): b is { type: "text"; text: string } => b.type === "text")
+      .map((b) => b.text)
+      .join(" "),
+  createTimeout: (ms: number) => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), ms);
+    return { signal: controller.signal, cleanup: () => clearTimeout(timer) };
+  },
 }));
 
 // emitNotificationSignal spy — captures every notification the sweep emits

--- a/assistant/src/memory/v2/sweep-job.ts
+++ b/assistant/src/memory/v2/sweep-job.ts
@@ -31,11 +31,8 @@ import {
   resolveUserName,
 } from "../../daemon/identity-helpers.js";
 import { emitNotificationSignal } from "../../notifications/emit-signal.js";
-import {
-  extractToolUse,
-  getConfiguredProvider,
-  userMessage,
-} from "../../providers/provider-send-message.js";
+import { runOneShotLLM } from "../../providers/one-shot-llm.js";
+import { userMessage } from "../../providers/provider-send-message.js";
 import type { ToolDefinition } from "../../providers/types.js";
 import { getLogger } from "../../util/logger.js";
 import { getWorkspaceDir } from "../../util/platform.js";
@@ -99,6 +96,13 @@ const SweepResultSchema = z.object({
 });
 
 /**
+ * Generous timeout for the sweep's single forced-tool call. The sweep is a
+ * background batch job, so a stalled provider connection must not wedge the
+ * memory worker indefinitely.
+ */
+const SWEEP_TIMEOUT_MS = 60_000;
+
+/**
  * Job handler. Reads recent messages + buffer, asks the configured provider
  * for additional remember-able entries, and appends each entry to
  * `memory/buffer.md` + `memory/archive/<today>.md` via the same helper
@@ -140,12 +144,6 @@ export async function memoryV2SweepJob(
 
     const existingBuffer = readBufferText(memoryDir);
 
-    const provider = await getConfiguredProvider("memoryV2Sweep");
-    if (!provider) {
-      log.warn("memoryV2Sweep provider unavailable; sweep skipped");
-      return 0;
-    }
-
     const systemPrompt = renderSweepPrompt({
       assistantName: getAssistantName(),
       userName: resolveUserName(workspaceDir),
@@ -154,30 +152,47 @@ export async function memoryV2SweepJob(
       `## existingBuffer\n\n${existingBuffer || "(empty)"}\n\n` +
       `## recentMessages\n\n${recentText}`;
 
-    const response = await provider.sendMessage([userMessage(userText)], {
-      tools: [SWEEP_TOOL],
-      systemPrompt,
-      config: {
-        callSite: "memoryV2Sweep" as const,
-        tool_choice: { type: "tool" as const, name: SWEEP_TOOL_NAME },
+    // `onUnavailable: "null"` preserves the prior "no provider → return 0"
+    // contract. Schema validation and the timeout now live in the helper; any
+    // non-`ok` status (unavailable, timeout, tool_use_missing, schema_mismatch)
+    // degrades to returning 0 without writes, matching the old behavior.
+    const llmResult = await runOneShotLLM(
+      "memoryV2Sweep",
+      [userMessage(userText)],
+      {
+        tools: [SWEEP_TOOL],
+        toolChoice: SWEEP_TOOL_NAME,
+        schema: SweepResultSchema,
+        systemPrompt,
+        timeoutMs: SWEEP_TIMEOUT_MS,
+        onUnavailable: "null",
       },
-    });
+    );
 
-    const toolBlock = extractToolUse(response);
-    if (!toolBlock || toolBlock.name !== SWEEP_TOOL_NAME) {
-      log.debug("Sweep model returned no tool_use block");
-      return 0;
-    }
-    const parsed = SweepResultSchema.safeParse(toolBlock.input);
-    if (!parsed.success) {
-      log.warn(
-        { error: parsed.error.message },
-        "Sweep tool input did not match schema",
+    if (llmResult.status !== "ok") {
+      // Preserve the prior failure contract: a provider exception (or a
+      // stalled connection that hit the timeout) must surface via the
+      // `activity.failed` notification, so re-throw into the outer catch. The
+      // "model responded but the output was unusable" cases (no provider,
+      // missing tool_use, schema mismatch) return 0 silently — matching the
+      // old `!toolBlock` / bad-shape / no-provider paths.
+      if (
+        llmResult.status === "failure" &&
+        (llmResult.reason === "provider_error" ||
+          llmResult.reason === "timeout")
+      ) {
+        throw llmResult.error instanceof Error
+          ? llmResult.error
+          : new Error(`memory v2 sweep LLM call failed: ${llmResult.reason}`);
+      }
+      log.debug(
+        { status: llmResult.status },
+        "Sweep produced no usable tool output; nothing written",
       );
       return 0;
     }
 
-    const written = appendEntries(memoryDir, parsed.data.entries);
+    const written = appendEntries(memoryDir, llmResult.data.entries);
     if (written > 0) {
       log.info({ written }, "Memory v2 sweep wrote new buffer entries");
     }

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/live-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/live-integration.test.ts
@@ -52,6 +52,11 @@ mock.module("../../../../providers/provider-send-message.js", () => ({
   getConfiguredProvider: async () => providerStub,
   extractToolUse: (response: ProviderResponse) =>
     response.content.find((b) => b.type === "tool_use"),
+  createTimeout: (ms: number) => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), ms);
+    return { signal: controller.signal, cleanup: () => clearTimeout(timer) };
+  },
 }));
 
 mock.module("../../../../util/logger.js", () => ({

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
@@ -42,6 +42,11 @@ mock.module("../../../../providers/provider-send-message.js", () => ({
   getConfiguredProvider: async () => providerStub,
   extractToolUse: (response: ProviderResponse) =>
     response.content.find((b) => b.type === "tool_use"),
+  createTimeout: (ms: number) => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), ms);
+    return { signal: controller.signal, cleanup: () => clearTimeout(timer) };
+  },
 }));
 
 mock.module("../../../../util/logger.js", () => ({

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/pool-select.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/pool-select.test.ts
@@ -48,10 +48,18 @@ interface ProviderCall {
 }
 const providerCalls: ProviderCall[] = [];
 
+// pool-select now imports `createTimeout` for its per-attempt timeout, so the
+// mock exports a real (never-firing in tests) timer alongside the existing
+// provider helpers.
 mock.module("../../../../providers/provider-send-message.js", () => ({
   getConfiguredProvider: async () => providerStub,
   extractToolUse: (response: ProviderResponse) =>
     response.content.find((b): b is ToolUseContent => b.type === "tool_use"),
+  createTimeout: (ms: number) => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), ms);
+    return { signal: controller.signal, cleanup: () => clearTimeout(timer) };
+  },
 }));
 
 mock.module("../../../../util/logger.js", () => ({

--- a/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
@@ -45,6 +45,7 @@ import { z } from "zod";
 
 import { cachedTextBlock } from "../../../providers/cache-control.js";
 import {
+  createTimeout,
   extractToolUse,
   getConfiguredProvider,
 } from "../../../providers/provider-send-message.js";
@@ -91,6 +92,15 @@ export interface SelectorPool {
 
 /** Tool name forced via `tool_choice`. Shared constant so tests can match it. */
 const SELECT_PAGES_TOOL_NAME = "select_pages";
+
+/**
+ * Per-attempt timeout for the selector's forced-tool call. The selector runs
+ * in the per-turn routing path and degrades to deterministic lanes on failure,
+ * but a stalled provider connection must still be bounded — each
+ * `retryForResult` attempt gets a fresh timeout. The selector reasons over a
+ * compact candidate pool, so a 60s budget is generous.
+ */
+const SELECT_TIMEOUT_MS = 60_000;
 
 /** Finder-line snippets are truncated to keep the dynamic tail compact. */
 const SNIPPET_MAX_CHARS = 300;
@@ -239,19 +249,29 @@ export async function selectPool(
   // we give up. `null` from an attempt means "unusable, retry"; the provider
   // layer already backs off transient throws, so this loop adds no delay.
   const parsed = await retryForResult(async () => {
-    const response = await provider.sendMessage([userMsg], {
-      tools: [SELECT_PAGES_TOOL],
-      systemPrompt: SYSTEM_PROMPT,
-      config: {
-        callSite: "memoryV3SelectL2" as const,
-        tool_choice: { type: "tool" as const, name: SELECT_PAGES_TOOL_NAME },
-        // The last block of this one-shot message varies every turn; the
-        // provider's auto-applied turn-start breakpoint would land on it and
-        // pay cache_creation with no future hit. The stable-prefix block
-        // above carries its own breakpoint instead.
-        disableTurnStartCache: true,
-      },
-    });
+    // Fresh timeout per attempt — a stalled attempt aborts and `retryForResult`
+    // re-prompts (or, on the final attempt, surfaces null → deterministic
+    // lanes). The provider layer already backs off transient throws.
+    const { signal, cleanup } = createTimeout(SELECT_TIMEOUT_MS);
+    let response;
+    try {
+      response = await provider.sendMessage([userMsg], {
+        tools: [SELECT_PAGES_TOOL],
+        systemPrompt: SYSTEM_PROMPT,
+        config: {
+          callSite: "memoryV3SelectL2" as const,
+          tool_choice: { type: "tool" as const, name: SELECT_PAGES_TOOL_NAME },
+          // The last block of this one-shot message varies every turn; the
+          // provider's auto-applied turn-start breakpoint would land on it and
+          // pay cache_creation with no future hit. The stable-prefix block
+          // above carries its own breakpoint instead.
+          disableTurnStartCache: true,
+        },
+        signal,
+      });
+    } finally {
+      cleanup();
+    }
     const toolBlock = extractToolUse(response);
     if (!toolBlock || toolBlock.name !== SELECT_PAGES_TOOL_NAME) return null;
     const result = SelectPagesSchema.safeParse(toolBlock.input);


### PR DESCRIPTION
Part of #34399. Closes #34402. Adds zod safeParse validation to the unvalidated memory-graph tool-input casts (pattern-scan, retriever, consolidation, narrative) and timeouts to all untimed background-job LLM calls (extraction, sweep, consolidation, narrative, pool-select), migrating plain call shapes onto the shared runOneShotLLM helper.