### PR TITLE
feat(cli): support local assistants in `vellum upgrade`

### DIFF
--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -32,6 +32,7 @@ import {
   restoreBackup,
 } from "../lib/backup-ops.js";
 import { emitCliError, categorizeUpgradeError } from "../lib/cli-error.js";
+import { upgradeLocal } from "../lib/local-upgrade.js";
 import { exec } from "../lib/step-runner.js";
 import {
   broadcastUpgradeEvent,
@@ -72,6 +73,13 @@ function parseArgs(): UpgradeArgs {
       console.log("Upgrade an assistant to a newer version.");
       console.log("To roll back to a previous version, use `vellum rollback`.");
       console.log("");
+      console.log(
+        "Local assistants run the CLI's embedded runtime; upgrading restarts",
+      );
+      console.log(
+        "them on the current CLI — use --latest to update the CLI first.",
+      );
+      console.log("");
       console.log("Arguments:");
       console.log(
         "  <name>               Name of the assistant to upgrade (default: active or only assistant)",
@@ -103,6 +111,9 @@ function parseArgs(): UpgradeArgs {
       );
       console.log(
         "  vellum upgrade my-assistant --version v1.2.3 # Upgrade to a specific version",
+      );
+      console.log(
+        "  vellum upgrade --latest                     # On a local assistant: update the CLI, then restart on it",
       );
       process.exit(0);
     } else if (arg === "--version") {
@@ -929,6 +940,13 @@ export async function upgrade(): Promise<void> {
   const { name, version, latest, prepare, finalize } = parseArgs();
   const entry = resolveTargetAssistant(name);
 
+  if ((prepare || finalize) && resolveCloud(entry) === "local") {
+    const msg = "--prepare/--finalize are not supported for local assistants";
+    console.error(`Error: ${msg}.`);
+    emitCliError("UNSUPPORTED_TOPOLOGY", msg);
+    process.exit(1);
+  }
+
   if (prepare) {
     await upgradePrepare(entry, version);
     return;
@@ -960,6 +978,11 @@ export async function upgrade(): Promise<void> {
       await upgradePlatform(entry, effectiveVersion);
       return;
     }
+
+    if (cloud === "local") {
+      await upgradeLocal(entry, effectiveVersion, cliPkg.version);
+      return;
+    }
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
     console.error(`\n❌ Upgrade failed: ${detail}`);
@@ -975,7 +998,7 @@ export async function upgrade(): Promise<void> {
     process.exit(1);
   }
 
-  const msg = `Error: Upgrade is not supported for '${cloud}' assistants. Only 'docker' and 'vellum' assistants can be upgraded via the CLI.`;
+  const msg = `Error: Upgrade is not supported for '${cloud}' assistants. Only 'docker', 'vellum', and 'local' assistants can be upgraded via the CLI.`;
   console.error(msg);
   emitCliError("UNSUPPORTED_TOPOLOGY", msg);
   process.exit(1);

--- a/cli/src/lib/__tests__/local-upgrade.test.ts
+++ b/cli/src/lib/__tests__/local-upgrade.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveLocalUpgradeTarget } from "../local-upgrade.js";
+
+describe("resolveLocalUpgradeTarget", () => {
+  test("null requested version resolves to the CLI's own tag", () => {
+    expect(resolveLocalUpgradeTarget(null, "0.8.10")).toEqual({
+      ok: true,
+      tag: "v0.8.10",
+    });
+  });
+
+  test("matching version with v prefix is accepted", () => {
+    expect(resolveLocalUpgradeTarget("v0.8.10", "0.8.10")).toEqual({
+      ok: true,
+      tag: "v0.8.10",
+    });
+  });
+
+  test("matching version without v prefix is accepted", () => {
+    expect(resolveLocalUpgradeTarget("0.8.10", "0.8.10")).toEqual({
+      ok: true,
+      tag: "v0.8.10",
+    });
+  });
+
+  test("older explicit version is rejected with --latest guidance", () => {
+    const result = resolveLocalUpgradeTarget("v0.0.1", "0.8.10");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("v0.8.10");
+      expect(result.reason).toContain("v0.0.1");
+      expect(result.reason).toContain("--latest");
+    }
+  });
+
+  test("newer explicit version is rejected with --latest guidance", () => {
+    const result = resolveLocalUpgradeTarget("v9.9.9", "0.8.10");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("--latest");
+    }
+  });
+});

--- a/cli/src/lib/__tests__/local-upgrade.test.ts
+++ b/cli/src/lib/__tests__/local-upgrade.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { resolveLocalUpgradeTarget } from "../local-upgrade.js";
+import {
+  resolveLocalProbeUrl,
+  resolveLocalUpgradeTarget,
+} from "../local-upgrade.js";
 
 describe("resolveLocalUpgradeTarget", () => {
   test("null requested version resolves to the CLI's own tag", () => {
@@ -40,5 +43,22 @@ describe("resolveLocalUpgradeTarget", () => {
     if (!result.ok) {
       expect(result.reason).toContain("--latest");
     }
+  });
+});
+
+describe("resolveLocalProbeUrl", () => {
+  test("prefers localUrl when present", () => {
+    expect(
+      resolveLocalProbeUrl({
+        localUrl: "http://127.0.0.1:18300",
+        runtimeUrl: "https://my-assistant.example.com",
+      }),
+    ).toBe("http://127.0.0.1:18300");
+  });
+
+  test("falls back to runtimeUrl when localUrl is absent", () => {
+    expect(
+      resolveLocalProbeUrl({ runtimeUrl: "http://127.0.0.1:18300" }),
+    ).toBe("http://127.0.0.1:18300");
   });
 });

--- a/cli/src/lib/__tests__/local-upgrade.test.ts
+++ b/cli/src/lib/__tests__/local-upgrade.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  checkLocalVersionDirection,
   resolveLocalProbeUrl,
   resolveLocalUpgradeTarget,
 } from "../local-upgrade.js";
@@ -43,6 +44,45 @@ describe("resolveLocalUpgradeTarget", () => {
     if (!result.ok) {
       expect(result.reason).toContain("--latest");
     }
+  });
+});
+
+describe("checkLocalVersionDirection", () => {
+  test("downgrade (running runtime newer than CLI) is rejected", () => {
+    const result = checkLocalVersionDirection("v0.8.10", "v0.9.0");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("v0.9.0");
+      expect(result.reason).toContain("v0.8.10");
+      expect(result.reason).toContain("vellum upgrade --latest");
+      expect(result.reason).not.toContain("rollback");
+    }
+  });
+
+  test("equal versions are allowed", () => {
+    expect(checkLocalVersionDirection("v0.8.10", "v0.8.10")).toEqual({
+      ok: true,
+    });
+  });
+
+  test("newer target is allowed", () => {
+    expect(checkLocalVersionDirection("v0.9.0", "v0.8.10")).toEqual({
+      ok: true,
+    });
+  });
+
+  test("unknown current version proceeds with a warning (Docker parity)", () => {
+    const result = checkLocalVersionDirection("v0.8.10", undefined);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.warning).toContain("skipping version-direction check");
+    }
+  });
+
+  test("unparseable current version proceeds without warning (Docker parity)", () => {
+    expect(checkLocalVersionDirection("v0.8.10", "not-a-version")).toEqual({
+      ok: true,
+    });
   });
 });
 

--- a/cli/src/lib/local-upgrade.ts
+++ b/cli/src/lib/local-upgrade.ts
@@ -1,0 +1,123 @@
+import type { AssistantEntry } from "./assistant-config.js";
+import { emitCliError } from "./cli-error.js";
+import {
+  getBlockingCallLeases,
+  sleepLocalAssistant,
+  wakeLocalAssistant,
+} from "./local-lifecycle.js";
+import {
+  broadcastUpgradeEvent,
+  buildCompleteEvent,
+  buildStartingEvent,
+  waitForReady,
+} from "./upgrade-lifecycle.js";
+import { compareVersions } from "./version-compat.js";
+
+function toTag(version: string): string {
+  return version.startsWith("v") ? version : `v${version}`;
+}
+
+/**
+ * Resolve the version tag a local upgrade restarts onto. Local assistants run
+ * the installed CLI's embedded runtime, so the only valid target is the CLI's
+ * own version — any other explicit version is rejected with guidance.
+ */
+export function resolveLocalUpgradeTarget(
+  requestedVersion: string | null,
+  cliVersion: string,
+): { ok: true; tag: string } | { ok: false; reason: string } {
+  const cliTag = toTag(cliVersion);
+  if (requestedVersion === null) {
+    return { ok: true, tag: cliTag };
+  }
+
+  const requestedTag = toTag(requestedVersion);
+  if (compareVersions(requestedTag, cliTag) === 0) {
+    return { ok: true, tag: cliTag };
+  }
+
+  return {
+    ok: false,
+    reason:
+      `Local assistants always run the installed CLI's embedded runtime (currently ${cliTag}), ` +
+      `so they cannot be upgraded to ${requestedTag} directly. ` +
+      `The only way to change versions is to change the CLI itself — run \`vellum upgrade --latest\` ` +
+      `to update the CLI and restart the assistant on it.`,
+  };
+}
+
+/**
+ * "Upgrade" a local assistant: restart its daemon/gateway processes so they
+ * pick up the installed CLI's embedded runtime. The actual version change
+ * happens when the CLI itself is updated (see `vellum upgrade --latest`).
+ */
+export async function upgradeLocal(
+  entry: AssistantEntry,
+  requestedVersion: string | null,
+  cliVersion: string,
+): Promise<void> {
+  const target = resolveLocalUpgradeTarget(requestedVersion, cliVersion);
+  if (!target.ok) {
+    console.error(`Error: ${target.reason}`);
+    emitCliError("VERSION_DIRECTION", target.reason);
+    process.exit(1);
+  }
+  const { tag } = target;
+
+  // Check call leases BEFORE stopping anything or broadcasting.
+  const blockingCallIds = getBlockingCallLeases(entry);
+  if (blockingCallIds.length > 0) {
+    const msg = `assistant is staying awake for active phone calls (${blockingCallIds.join(
+      ", ",
+    )}). Retry the upgrade after the call ends.`;
+    console.error(`Error: ${msg}`);
+    emitCliError("UNKNOWN", msg);
+    process.exit(1);
+  }
+
+  console.log(
+    `🔄 Restarting local assistant '${entry.assistantId}' on ${tag}...\n`,
+  );
+
+  // Best-effort client notification (broadcastUpgradeEvent never throws).
+  await broadcastUpgradeEvent(
+    entry.runtimeUrl,
+    entry.assistantId,
+    buildStartingEvent(tag, 30),
+  );
+
+  try {
+    await sleepLocalAssistant(entry, { force: false });
+  } catch (err) {
+    // A call lease may have appeared between the check above and the sleep.
+    const detail = err instanceof Error ? err.message : String(err);
+    console.error(`Error: ${detail}`);
+    emitCliError("UNKNOWN", detail);
+    process.exit(1);
+  }
+
+  await wakeLocalAssistant(entry, { watch: false, foreground: false });
+
+  console.log("Waiting for assistant to become ready...");
+  const ready = await waitForReady(entry.runtimeUrl);
+  if (!ready) {
+    console.error("\n❌ Assistant failed to become ready within the timeout.");
+    await broadcastUpgradeEvent(
+      entry.runtimeUrl,
+      entry.assistantId,
+      buildCompleteEvent(tag, false),
+    );
+    emitCliError(
+      "READINESS_TIMEOUT",
+      `Local assistant '${entry.assistantId}' did not become ready after restart. Check 'vellum logs' for details.`,
+    );
+    process.exit(1);
+  }
+
+  await broadcastUpgradeEvent(
+    entry.runtimeUrl,
+    entry.assistantId,
+    buildCompleteEvent(tag, true),
+  );
+  console.log(`\n✅ '${entry.assistantId}' restarted on ${tag}.`);
+}

--- a/cli/src/lib/local-upgrade.ts
+++ b/cli/src/lib/local-upgrade.ts
@@ -1,4 +1,6 @@
 import type { AssistantEntry } from "./assistant-config.js";
+import { findAssistantByName, saveAssistantEntry } from "./assistant-config.js";
+import { createBackup, pruneOldBackups } from "./backup-ops.js";
 import { emitCliError } from "./cli-error.js";
 import {
   getBlockingCallLeases,
@@ -47,6 +49,17 @@ export function resolveLocalUpgradeTarget(
 }
 
 /**
+ * Same-machine probe URL for a local assistant. `runtimeUrl` may be an
+ * external/public address (e.g. a tunnel), while `localUrl` is persisted
+ * specifically for loopback health checks.
+ */
+export function resolveLocalProbeUrl(
+  entry: Pick<AssistantEntry, "localUrl" | "runtimeUrl">,
+): string {
+  return entry.localUrl ?? entry.runtimeUrl;
+}
+
+/**
  * "Upgrade" a local assistant: restart its daemon/gateway processes so they
  * pick up the installed CLI's embedded runtime. The actual version change
  * happens when the CLI itself is updated (see `vellum upgrade --latest`).
@@ -79,6 +92,34 @@ export async function upgradeLocal(
     `🔄 Restarting local assistant '${entry.assistantId}' on ${tag}...\n`,
   );
 
+  const probeUrl = resolveLocalProbeUrl(entry);
+
+  // Pre-upgrade backup before anything is stopped (best-effort, mirrors the
+  // Docker upgrade path — the restarted runtime may run migrations).
+  console.log("📦 Creating pre-upgrade backup...");
+  const backupPath = await createBackup(probeUrl, entry.assistantId, {
+    prefix: `${entry.assistantId}-pre-upgrade`,
+    description: `Pre-upgrade snapshot before local restart on ${tag}`,
+  });
+  if (backupPath) {
+    console.log(`   Backup saved: ${backupPath}\n`);
+    pruneOldBackups(entry.assistantId, 3);
+  } else {
+    console.warn("⚠️  Pre-upgrade backup failed (continuing with upgrade)\n");
+  }
+
+  // Persist the backup path so restores target this attempt's snapshot,
+  // never a stale backup from a prior cycle.
+  {
+    const current = findAssistantByName(entry.assistantId);
+    if (current) {
+      saveAssistantEntry({
+        ...current,
+        preUpgradeBackupPath: backupPath ?? undefined,
+      });
+    }
+  }
+
   // Best-effort client notification (broadcastUpgradeEvent never throws).
   await broadcastUpgradeEvent(
     entry.runtimeUrl,
@@ -99,7 +140,7 @@ export async function upgradeLocal(
   await wakeLocalAssistant(entry, { watch: false, foreground: false });
 
   console.log("Waiting for assistant to become ready...");
-  const ready = await waitForReady(entry.runtimeUrl);
+  const ready = await waitForReady(probeUrl);
   if (!ready) {
     console.error("\n❌ Assistant failed to become ready within the timeout.");
     await broadcastUpgradeEvent(

--- a/cli/src/lib/local-upgrade.ts
+++ b/cli/src/lib/local-upgrade.ts
@@ -11,6 +11,7 @@ import {
   broadcastUpgradeEvent,
   buildCompleteEvent,
   buildStartingEvent,
+  fetchCurrentVersion,
   waitForReady,
 } from "./upgrade-lifecycle.js";
 import { compareVersions } from "./version-compat.js";
@@ -46,6 +47,36 @@ export function resolveLocalUpgradeTarget(
       `The only way to change versions is to change the CLI itself — run \`vellum upgrade --latest\` ` +
       `to update the CLI and restart the assistant on it.`,
   };
+}
+
+/**
+ * Decide whether a local restart onto `tag` is a downgrade relative to the
+ * currently running runtime. Mirrors the Docker upgrade guard: an unknown or
+ * unparseable current version proceeds (with a warning when unknown); only a
+ * strictly older target is rejected.
+ */
+export function checkLocalVersionDirection(
+  tag: string,
+  currentVersion: string | undefined,
+): { ok: true; warning?: string } | { ok: false; reason: string } {
+  if (!currentVersion) {
+    return {
+      ok: true,
+      warning:
+        "Could not determine current version from health endpoint — skipping version-direction check.",
+    };
+  }
+  const cmp = compareVersions(tag, currentVersion);
+  if (cmp !== null && cmp < 0) {
+    return {
+      ok: false,
+      reason:
+        `The local assistant is running ${currentVersion}, which is newer than this CLI's ` +
+        `embedded runtime (${tag}). Restarting it now would downgrade the assistant onto an ` +
+        `older runtime. Update the CLI instead — run \`vellum upgrade --latest\` — and retry.`,
+    };
+  }
+  return { ok: true };
 }
 
 /**
@@ -88,11 +119,26 @@ export async function upgradeLocal(
     process.exit(1);
   }
 
+  const probeUrl = resolveLocalProbeUrl(entry);
+
+  // Refuse downgrades BEFORE stopping anything — the running runtime may be
+  // newer than this CLI (e.g. upgraded independently).
+  const direction = checkLocalVersionDirection(
+    tag,
+    await fetchCurrentVersion(probeUrl),
+  );
+  if (!direction.ok) {
+    console.error(`Error: ${direction.reason}`);
+    emitCliError("VERSION_DIRECTION", direction.reason);
+    process.exit(1);
+  }
+  if (direction.warning) {
+    console.warn(`⚠️  ${direction.warning}\n`);
+  }
+
   console.log(
     `🔄 Restarting local assistant '${entry.assistantId}' on ${tag}...\n`,
   );
-
-  const probeUrl = resolveLocalProbeUrl(entry);
 
   // Pre-upgrade backup before anything is stopped (best-effort, mirrors the
   // Docker upgrade path — the restarted runtime may run migrations).

--- a/cli/src/lib/local-upgrade.ts
+++ b/cli/src/lib/local-upgrade.ts
@@ -177,8 +177,15 @@ export async function upgradeLocal(
     await sleepLocalAssistant(entry, { force: false });
   } catch (err) {
     // A call lease may have appeared between the check above and the sleep.
+    // The `starting` event already went out, so close the update UI on
+    // connected clients before exiting.
     const detail = err instanceof Error ? err.message : String(err);
     console.error(`Error: ${detail}`);
+    await broadcastUpgradeEvent(
+      entry.runtimeUrl,
+      entry.assistantId,
+      buildCompleteEvent(tag, false),
+    );
     emitCliError("UNKNOWN", detail);
     process.exit(1);
   }


### PR DESCRIPTION
## Summary
- New cli/src/lib/local-upgrade.ts: upgradeLocal() restarts a local assistant on the current CLI's embedded runtime (lease check → broadcast starting → sleep → wake → waitForReady → broadcast complete)
- upgrade.ts dispatch gains a 'local' branch; --prepare/--finalize guarded; help text updated
- Explicit --version mismatching the CLI errors with guidance toward --latest

Part of plan: vellum-upgrade-local.md (PR 3 of 5)