### PR TITLE
CLI: disable fetch keepalive for loopback platform URLs

### DIFF
--- a/cli/src/lib/health-check.ts
+++ b/cli/src/lib/health-check.ts
@@ -1,3 +1,5 @@
+import { loopbackSafeFetch } from "./loopback-fetch.js";
+
 export const HEALTH_CHECK_TIMEOUT_MS = 1500;
 
 interface HealthResponse {
@@ -44,7 +46,7 @@ export async function checkManagedHealth(
       HEALTH_CHECK_TIMEOUT_MS,
     );
 
-    const response = await fetch(url, {
+    const response = await loopbackSafeFetch(url, {
       signal: controller.signal,
       headers,
     });
@@ -105,7 +107,7 @@ export async function fetchManagedPs(
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 5000);
 
-    const response = await fetch(psUrl, {
+    const response = await loopbackSafeFetch(psUrl, {
       signal: controller.signal,
       headers,
     });
@@ -144,7 +146,7 @@ async function fetchLegacyConnectionStatus(
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 5000);
 
-    const response = await fetch(url, {
+    const response = await loopbackSafeFetch(url, {
       method: "POST",
       signal: controller.signal,
       headers,
@@ -188,7 +190,7 @@ export async function checkHealth(
       headers["Authorization"] = `Bearer ${bearerToken}`;
     }
 
-    const response = await fetch(url, {
+    const response = await loopbackSafeFetch(url, {
       signal: controller.signal,
       headers,
     });

--- a/cli/src/lib/loopback-fetch.ts
+++ b/cli/src/lib/loopback-fetch.ts
@@ -1,0 +1,28 @@
+/**
+ * Bun's fetch pools sockets even when the server responds `Connection:
+ * close` (e.g. the Werkzeug dev platform on localhost), so the next request
+ * to the same origin is written to a dead socket and hangs until its abort
+ * timeout fires. Disable keepalive for loopback targets to force a fresh
+ * connection per request; remote hosts are unaffected.
+ */
+
+function isLoopbackUrl(url: string): boolean {
+  try {
+    // WHATWG URL canonicalizes hostnames, so IPv6 loopback is always "[::1]".
+    const h = new URL(url).hostname;
+    return (
+      h === "localhost" || h === "[::1]" || /^127(?:\.\d{1,3}){3}$/.test(h)
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function loopbackSafeFetch(
+  url: string,
+  init?: RequestInit,
+): Promise<Response> {
+  return isLoopbackUrl(url)
+    ? fetch(url, { ...init, keepalive: false })
+    : fetch(url, init);
+}

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -11,6 +11,7 @@ import { join, dirname } from "path";
 import { getLockfilePlatformBaseUrl } from "./assistant-config.js";
 import { getConfigDir } from "./environments/paths.js";
 import { getCurrentEnvironment } from "./environments/resolve.js";
+import { loopbackSafeFetch } from "./loopback-fetch.js";
 
 function getPlatformTokenPath(): string {
   return join(getConfigDir(getCurrentEnvironment()), "platform-token");
@@ -229,7 +230,7 @@ export async function ensureSelfHostedLocalRegistration(
     body.public_ingress_url = publicBaseUrl;
   }
 
-  const response = await fetch(
+  const response = await loopbackSafeFetch(
     `${resolvedUrl}/v1/assistants/self-hosted-local/ensure-registration/`,
     {
       method: "POST",
@@ -292,7 +293,7 @@ export async function reprovisionAssistantApiKey(
     body.assistant_version = assistantVersion;
   }
 
-  const response = await fetch(
+  const response = await loopbackSafeFetch(
     `${resolvedUrl}/v1/assistants/self-hosted-local/reprovision-api-key/`,
     {
       method: "POST",
@@ -358,7 +359,7 @@ export async function readGatewayCredential(
       headers["Authorization"] = `Bearer ${bearerToken}`;
     }
 
-    const response = await fetch(`${gatewayUrl}/v1/secrets/read`, {
+    const response = await loopbackSafeFetch(`${gatewayUrl}/v1/secrets/read`, {
       method: "POST",
       headers,
       body: JSON.stringify({ type: "credential", name, reveal: true }),
@@ -416,7 +417,7 @@ async function injectGatewayCredential(
     headers["Authorization"] = `Bearer ${bearerToken}`;
   }
 
-  const response = await fetch(`${gatewayUrl}/v1/secrets`, {
+  const response = await loopbackSafeFetch(`${gatewayUrl}/v1/secrets`, {
     method: "POST",
     headers,
     body: JSON.stringify({ type: "credential", name, value }),
@@ -486,7 +487,7 @@ export async function hatchAssistant(
   const resolvedUrl = platformUrl || getPlatformUrl();
   const url = `${resolvedUrl}/v1/assistants/hatch/`;
 
-  const response = await fetch(url, {
+  const response = await loopbackSafeFetch(url, {
     method: "POST",
     headers: await authHeaders(token, platformUrl),
     body: JSON.stringify({}),
@@ -545,7 +546,7 @@ export async function checkExistingPlatformAssistant(
   );
 
   try {
-    const response = await fetch(url, {
+    const response = await loopbackSafeFetch(url, {
       signal: controller.signal,
       headers: await authHeaders(token, platformUrl),
     });
@@ -583,7 +584,7 @@ export async function fetchPlatformAssistants(
   );
 
   try {
-    const response = await fetch(url, {
+    const response = await loopbackSafeFetch(url, {
       signal: controller.signal,
       headers: await authHeaders(token, platformUrl),
     });
@@ -624,7 +625,7 @@ export async function fetchOrganizationId(
   );
 
   try {
-    const response = await fetch(url, {
+    const response = await loopbackSafeFetch(url, {
       signal: controller.signal,
       headers: { ...tokenAuthHeader(token) },
     });
@@ -671,7 +672,7 @@ export async function fetchCurrentUser(
   );
 
   try {
-    const response = await fetch(url, {
+    const response = await loopbackSafeFetch(url, {
       signal: controller.signal,
       headers: { "X-Session-Token": token },
     });
@@ -706,11 +707,14 @@ export async function rollbackPlatformAssistant(
   platformUrl?: string,
 ): Promise<{ detail: string; version: string | null }> {
   const resolvedUrl = platformUrl || getPlatformUrl();
-  const response = await fetch(`${resolvedUrl}/v1/assistants/rollback/`, {
-    method: "POST",
-    headers: await authHeaders(token, platformUrl),
-    body: JSON.stringify(version ? { version } : {}),
-  });
+  const response = await loopbackSafeFetch(
+    `${resolvedUrl}/v1/assistants/rollback/`,
+    {
+      method: "POST",
+      headers: await authHeaders(token, platformUrl),
+      body: JSON.stringify(version ? { version } : {}),
+    },
+  );
 
   const body = (await response.json().catch(() => ({}))) as {
     detail?: string;
@@ -744,7 +748,7 @@ export async function platformUploadToSignedUrl(
   uploadUrl: string,
   bundleData: Uint8Array<ArrayBuffer>,
 ): Promise<void> {
-  const response = await fetch(uploadUrl, {
+  const response = await loopbackSafeFetch(uploadUrl, {
     method: "PUT",
     headers: {
       "Content-Type": "application/octet-stream",
@@ -766,7 +770,7 @@ export async function platformImportPreflightFromGcs(
   platformUrl?: string,
 ): Promise<{ statusCode: number; body: Record<string, unknown> }> {
   const resolvedUrl = platformUrl || getPlatformUrl();
-  const response = await fetch(
+  const response = await loopbackSafeFetch(
     `${resolvedUrl}/v1/migrations/import-preflight-from-gcs/`,
     {
       method: "POST",
@@ -789,7 +793,7 @@ export async function platformImportBundleFromGcs(
   platformUrl?: string,
 ): Promise<{ statusCode: number; body: Record<string, unknown> }> {
   const resolvedUrl = platformUrl || getPlatformUrl();
-  const response = await fetch(
+  const response = await loopbackSafeFetch(
     `${resolvedUrl}/v1/migrations/import-from-gcs/`,
     {
       method: "POST",
@@ -970,7 +974,7 @@ export async function platformRequestSignedUrl(
   }
 
   const doRequest = async (): Promise<Response> =>
-    fetch(`${resolvedUrl}/v1/migrations/signed-url/`, {
+    loopbackSafeFetch(`${resolvedUrl}/v1/migrations/signed-url/`, {
       method: "POST",
       headers: await authHeaders(token, platformUrl),
       body: JSON.stringify(body),
@@ -1040,9 +1044,12 @@ export async function platformPollJobStatus(
   platformUrl?: string,
 ): Promise<UnifiedJobStatus> {
   const resolvedUrl = platformUrl || getPlatformUrl();
-  const response = await fetch(`${resolvedUrl}/v1/migrations/jobs/${jobId}/`, {
-    headers: await authHeaders(token, platformUrl),
-  });
+  const response = await loopbackSafeFetch(
+    `${resolvedUrl}/v1/migrations/jobs/${jobId}/`,
+    {
+      headers: await authHeaders(token, platformUrl),
+    },
+  );
 
   if (response.status === 404) {
     throw new Error("Migration job not found");


### PR DESCRIPTION
## Summary
- Add `cli/src/lib/loopback-fetch.ts`: a drop-in `fetch` wrapper that sets `keepalive: false` when the target host is loopback (`localhost`, `127.0.0.0/8`, `[::1]`); remote hosts are untouched.
- Route all platform/gateway fetches in `platform-client.ts` and `health-check.ts` through the wrapper.
- Fixes `vellum ps` taking ~10s against a local platform: Bun's fetch keeps sockets from `Connection: close` responses (Werkzeug dev server) in its keep-alive pool, so every other request to the same origin was written to a dead socket and hung until the 10s abort timeout. Verified locally: `vellum ps` went from 10.1s to 0.08s.

## Original prompt
While investigating why `vellum ps` took ~10 seconds in the local environment, we traced the delay to Bun's fetch reusing dead pooled connections against the Werkzeug dev platform (which responds `Connection: close`): the first request succeeds instantly, the next one hangs until `PLATFORM_FETCH_TIMEOUT_MS` aborts it. The user asked to apply the verified workaround — disable fetch keepalive, scoped to localhost URLs only — so production keep-alive behavior is unchanged.