### PR TITLE
Local Assistant Hatch Hardening

### DIFF
--- a/apps/macos/src/main/bundle-flow.test.ts
+++ b/apps/macos/src/main/bundle-flow.test.ts
@@ -45,6 +45,7 @@ mock.module("@vellumai/local-mode", () => ({
   getLockfileData: getLockfileDataMock,
   resolveLockfilePaths: resolveLockfilePathsMock,
   resolveConfigDir: resolveConfigDirMock,
+  resolveEnvironmentName: mock((_env: NodeJS.ProcessEnv) => "production"),
   getGuardianAccessToken: getGuardianAccessTokenMock,
   replacePlatformAssistants: mock(() => ({ ok: false, error: "unused" })),
   upsertLockfileAssistant: mock(() => ({ ok: false, error: "unused" })),

--- a/apps/macos/src/main/local-mode.ts
+++ b/apps/macos/src/main/local-mode.ts
@@ -8,6 +8,7 @@ import {
   getLockfileData,
   replacePlatformAssistants,
   resolveConfigDir,
+  resolveEnvironmentName,
   resolveLockfilePaths,
   runHatch,
   runRetire,
@@ -156,6 +157,13 @@ export const installLocalMode = (): void => {
 
   const lockfilePaths = resolveLockfilePaths(process.env);
   const configDir = resolveConfigDir(process.env);
+  // Pin the environment the guardian-token CLI subprocess (refresh/lease) sees
+  // to the same one `configDir` was resolved from, so the token is always read
+  // and written under the same env dir. Overlaid on `process.env` by the host
+  // seam, so PATH etc. are preserved.
+  const guardianTokenEnv = {
+    VELLUM_ENVIRONMENT: resolveEnvironmentName(process.env),
+  };
 
   // `species` is optional on the wire so an empty/omitted request
   // falls back to the default rather than being rejected.
@@ -226,7 +234,13 @@ export const installLocalMode = (): void => {
       } catch (err) {
         return { ok: false, status: 500, error: (err as Error).message };
       }
-      return getGuardianAccessToken(assistantId, configDir, invocation, true);
+      return getGuardianAccessToken(
+        assistantId,
+        configDir,
+        invocation,
+        true,
+        guardianTokenEnv,
+      );
     },
   );
 };

--- a/apps/web/src/assistant/sse-service.test.ts
+++ b/apps/web/src/assistant/sse-service.test.ts
@@ -132,6 +132,9 @@ describe("sseService.attach — connection lifecycle", () => {
 
   test("publishes sse.opened with cause=watchdog when stream reconnects after a watchdog stall", () => {
     sseService.attach("asst-1");
+    // The stream must have genuinely established first — a reconnect only
+    // reconciles when there was a live connection to recover.
+    activeOnStreamOpen!();
     publishSpy.mockClear();
 
     activeOnReconnect!("watchdog");
@@ -140,6 +143,22 @@ describe("sseService.attach — connection lifecycle", () => {
       assistantId: "asst-1",
       cause: "watchdog",
     });
+  });
+
+  test("does NOT publish sse.opened on reconnect when the stream never established (502 loop)", () => {
+    sseService.attach("asst-1");
+    publishSpy.mockClear();
+
+    // Stream never opened (onStreamOpen never fired), then the transport
+    // retries. Firing sse.opened here would trigger a full reconcile/refetch
+    // with nothing to recover — the source of the request storm.
+    activeOnReconnect!("error");
+    activeOnReconnect!("error");
+
+    const openedCalls = publishSpy.mock.calls.filter(
+      ([name]) => name === "sse.opened",
+    );
+    expect(openedCalls).toHaveLength(0);
   });
 
   test("publishes sse.closed on transport error", () => {

--- a/apps/web/src/assistant/sse-service.ts
+++ b/apps/web/src/assistant/sse-service.ts
@@ -111,6 +111,15 @@ export const sseService: SseService = {
       if (cancelled || current) return;
       const causeAtOpen = nextOpenCause;
       nextOpenCause = "resume";
+      // Did THIS stream ever genuinely establish (a frame arrived)? A transport
+      // reconnect only triggers a reconcile when we'd actually been connected
+      // before. Otherwise a stream that never opens — e.g. a 502 loop against
+      // the gateway proxy — would publish `sse.opened` on every failed attempt,
+      // and each one fans out to a full reconcile/refetch across domains
+      // (conversations, messages, identity, flags…), storming the daemon's
+      // request limiter. Reconciling has nothing to recover when we never went
+      // live, so suppress it until the stream proves established.
+      let everOpened = false;
       const stream = subscribeEvents(
         assistantId,
         (envelope) => {
@@ -128,9 +137,14 @@ export const sseService: SseService = {
         },
         {
           onReconnect: (cause) => {
-            publish("sse.opened", { assistantId, cause });
+            if (everOpened) {
+              publish("sse.opened", { assistantId, cause });
+            }
           },
-          onStreamOpen: () => setConnected(true),
+          onStreamOpen: () => {
+            everOpened = true;
+            setConnected(true);
+          },
           onStreamClose: () => setConnected(false),
         },
       );

--- a/apps/web/src/components/providers.tsx
+++ b/apps/web/src/components/providers.tsx
@@ -28,12 +28,18 @@ import { useState, type ReactNode } from "react";
 import { ProfileQuickAddProvider } from "@/components/profile-quick-add-provider";
 import { useAuthStore, useIsAuthenticated } from "@/stores/auth-store";
 import { useOrganizationStore } from "@/stores/organization-store";
+import { queryRetryDelay, shouldRetryQuery } from "@/utils/query-retry";
 
 function createQueryClient(): QueryClient {
   return new QueryClient({
     defaultOptions: {
       queries: {
         staleTime: 10_000,
+        // Never retry 429/4xx — retrying a rate-limited request turns a
+        // transient burst into a self-sustaining storm against the daemon's
+        // request limiter. Per-query `retry` options still override this.
+        retry: shouldRetryQuery,
+        retryDelay: queryRetryDelay,
       },
     },
   });

--- a/apps/web/src/utils/query-retry.test.ts
+++ b/apps/web/src/utils/query-retry.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+
+const { httpStatusFromError, shouldRetryQuery, queryRetryDelay } = await import(
+  "@/utils/query-retry"
+);
+const { ApiError } = await import("@/utils/api-errors");
+
+describe("httpStatusFromError", () => {
+  test("reads ApiError.status", () => {
+    expect(httpStatusFromError(new ApiError(429, "rate limited"))).toBe(429);
+  });
+
+  test("reads a numeric status field", () => {
+    expect(httpStatusFromError({ status: 503 })).toBe(503);
+  });
+
+  test("reads response.status", () => {
+    expect(httpStatusFromError({ response: { status: 502 } })).toBe(502);
+  });
+
+  test("returns undefined for network/non-HTTP errors", () => {
+    expect(httpStatusFromError(new TypeError("Failed to fetch"))).toBeUndefined();
+    expect(httpStatusFromError("boom")).toBeUndefined();
+  });
+});
+
+describe("shouldRetryQuery", () => {
+  test("never retries 429 (the storm trigger)", () => {
+    expect(shouldRetryQuery(0, new ApiError(429, "rate limited"))).toBe(false);
+  });
+
+  test("never retries other 4xx client errors", () => {
+    expect(shouldRetryQuery(0, new ApiError(401, "unauthorized"))).toBe(false);
+    expect(shouldRetryQuery(0, new ApiError(404, "not found"))).toBe(false);
+  });
+
+  test("retries transient 5xx", () => {
+    expect(shouldRetryQuery(0, new ApiError(503, "starting"))).toBe(true);
+    expect(shouldRetryQuery(2, new ApiError(502, "bad gateway"))).toBe(true);
+  });
+
+  test("retries network errors (no status)", () => {
+    expect(shouldRetryQuery(0, new TypeError("Failed to fetch"))).toBe(true);
+  });
+
+  test("stops after 3 failures regardless of error", () => {
+    expect(shouldRetryQuery(3, new ApiError(503, "starting"))).toBe(false);
+    expect(shouldRetryQuery(3, new TypeError("Failed to fetch"))).toBe(false);
+  });
+});
+
+describe("queryRetryDelay", () => {
+  test("capped exponential backoff", () => {
+    expect(queryRetryDelay(0)).toBe(1000);
+    expect(queryRetryDelay(1)).toBe(2000);
+    expect(queryRetryDelay(2)).toBe(4000);
+    expect(queryRetryDelay(10)).toBe(30_000); // capped
+  });
+});

--- a/apps/web/src/utils/query-retry.ts
+++ b/apps/web/src/utils/query-retry.ts
@@ -1,0 +1,58 @@
+/**
+ * Global TanStack Query retry policy.
+ *
+ * The default react-query behaviour retries every failed query 3× — including
+ * `429 Too Many Requests`. Against the daemon's 300 req/min limiter that is
+ * self-defeating: once a burst (window-focus refetch, reconnect, many queries
+ * at once) crosses the limit, retrying the 429s keeps the request rate pinned
+ * above the limit so it never recovers — a sustained 429 storm. This predicate
+ * never retries rate-limited (429) or other 4xx client errors (they don't
+ * self-heal), and retries only transient server (5xx) and network errors.
+ *
+ * Per-query `retry` options still override this default, so queries that opt
+ * into `shouldRetryDaemonError` (401 auth-race, 503 startup) or `retry: false`
+ * keep their own behaviour.
+ *
+ * Reference: https://tanstack.com/query/latest/docs/framework/react/guides/query-retries
+ */
+
+import { ApiError } from "@/utils/api-errors";
+
+const MAX_RETRIES = 3;
+
+/**
+ * Best-effort HTTP status extraction across the error shapes our query
+ * functions throw: {@link ApiError} (carries `status`), HeyAPI client errors
+ * (a `status` field), and `Response`-shaped errors (`response.status`).
+ * Returns `undefined` for network errors / non-HTTP failures.
+ */
+export function httpStatusFromError(error: unknown): number | undefined {
+  if (error instanceof ApiError) return error.status;
+  if (error && typeof error === "object") {
+    const e = error as { status?: unknown; response?: { status?: unknown } };
+    if (typeof e.status === "number") return e.status;
+    if (e.response && typeof e.response.status === "number") {
+      return e.response.status;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Default retry predicate: never retry a 4xx (especially 429), retry transient
+ * 5xx / network errors up to {@link MAX_RETRIES}.
+ */
+export function shouldRetryQuery(
+  failureCount: number,
+  error: unknown,
+): boolean {
+  if (failureCount >= MAX_RETRIES) return false;
+  const status = httpStatusFromError(error);
+  if (status !== undefined && status >= 400 && status < 500) return false;
+  return true;
+}
+
+/** Capped exponential backoff: 1s, 2s, 4s, … capped at 30s. */
+export function queryRetryDelay(attempt: number): number {
+  return Math.min(1000 * 2 ** attempt, 30_000);
+}

--- a/apps/web/vite-plugin-local-mode.ts
+++ b/apps/web/vite-plugin-local-mode.ts
@@ -475,7 +475,15 @@ function gatewayProxyMiddleware(
     };
 
     const proxyReq = http.request(proxyOptions, (proxyRes) => {
-      res.writeHead(proxyRes.statusCode ?? 502, proxyRes.headers);
+      // Drop the upstream's `transfer-encoding` before re-emitting: Node's http
+      // server sets its own when we pipe the streamed body, so copying the
+      // gateway's `chunked` too yields a duplicate ("too many transfer
+      // encodings"). A strict downstream proxy (the `vel up` Caddy edge)
+      // rejects that with 502 — fatal for the SSE `/events` stream, whose
+      // failure drives a client reconnect + full-refetch loop.
+      const headers = { ...proxyRes.headers };
+      delete headers["transfer-encoding"];
+      res.writeHead(proxyRes.statusCode ?? 502, headers);
       proxyRes.pipe(res);
     });
 

--- a/cli/src/__tests__/guardian-token.test.ts
+++ b/cli/src/__tests__/guardian-token.test.ts
@@ -11,6 +11,8 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
+import { guardianTokenPath, resolveConfigDir } from "@vellumai/local-mode";
+
 import {
   getOrCreatePersistedDeviceId,
   guardianTokenDueForRenewal,
@@ -20,6 +22,8 @@ import {
   seedGuardianTokenFromSiblingEnv,
   type GuardianTokenData,
 } from "../lib/guardian-token.js";
+import { getConfigDir } from "../lib/environments/paths.js";
+import { getCurrentEnvironment } from "../lib/environments/resolve.js";
 
 function makeTokenData(suffix: string): GuardianTokenData {
   const now = new Date().toISOString();
@@ -471,5 +475,80 @@ describe("guardianTokenDueForRenewal", () => {
         token({ refreshAfter: "not-a-date", accessTokenExpiresAt: "nope" }),
       ),
     ).toBe(false);
+  });
+});
+
+// Drift guard between the guardian-token WRITE path (CLI: getGuardianTokenPath
+// → getConfigDir(getCurrentEnvironment())) and the READ path used by every
+// host-seam reader (getGuardianAccessToken → resolveConfigDir(env) from
+// @vellumai/local-mode). A divergence here writes a freshly leased token where
+// the connect can't read it, bricking local-assistant connect. saveGuardianToken
+// already resolves through the shared resolver; this asserts the two resolvers
+// stay in lockstep so a future change to either can't silently relocate tokens.
+describe("guardian-token path resolver parity (CLI ↔ shared)", () => {
+  let tempHome: string;
+  let savedXdg: string | undefined;
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    savedXdg = process.env.XDG_CONFIG_HOME;
+    savedEnv = process.env.VELLUM_ENVIRONMENT;
+    tempHome = mkdtempSync(join(tmpdir(), "cli-guardian-parity-test-"));
+    process.env.XDG_CONFIG_HOME = tempHome;
+    delete process.env.VELLUM_ENVIRONMENT;
+  });
+
+  afterEach(() => {
+    if (savedXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = savedXdg;
+    if (savedEnv === undefined) delete process.env.VELLUM_ENVIRONMENT;
+    else process.env.VELLUM_ENVIRONMENT = savedEnv;
+    rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  // The CLI's own resolver and the shared @vellumai/local-mode resolver must
+  // agree on the config dir for every environment source.
+  const expectResolversAgree = () => {
+    expect(getConfigDir(getCurrentEnvironment())).toBe(
+      resolveConfigDir(process.env),
+    );
+  };
+
+  test("unset → production: resolvers agree and saveGuardianToken lands there", () => {
+    expectResolversAgree();
+    saveGuardianToken("alpha", makeTokenData("prod"));
+    expect(
+      existsSync(guardianTokenPath(resolveConfigDir(process.env), "alpha")),
+    ).toBe(true);
+  });
+
+  test("VELLUM_ENVIRONMENT=dev: resolvers agree and token lands there", () => {
+    process.env.VELLUM_ENVIRONMENT = "dev";
+    expectResolversAgree();
+    saveGuardianToken("alpha", makeTokenData("dev"));
+    expect(
+      existsSync(guardianTokenPath(resolveConfigDir(process.env), "alpha")),
+    ).toBe(true);
+  });
+
+  test("VELLUM_ENVIRONMENT=local: resolvers agree and token lands there", () => {
+    process.env.VELLUM_ENVIRONMENT = "local";
+    expectResolversAgree();
+    saveGuardianToken("alpha", makeTokenData("local"));
+    expect(
+      existsSync(guardianTokenPath(resolveConfigDir(process.env), "alpha")),
+    ).toBe(true);
+  });
+
+  test("persisted default env file (no VELLUM_ENVIRONMENT): resolvers agree", () => {
+    // Mirror `vellum env set dev`: the default-env file lives at the fixed,
+    // env-agnostic path $XDG_CONFIG_HOME/vellum/environment.
+    mkdirSync(join(tempHome, "vellum"), { recursive: true });
+    writeFileSync(join(tempHome, "vellum", "environment"), "dev\n");
+    expectResolversAgree();
+    saveGuardianToken("alpha", makeTokenData("default-dev"));
+    expect(
+      existsSync(guardianTokenPath(resolveConfigDir(process.env), "alpha")),
+    ).toBe(true);
   });
 });

--- a/cli/src/__tests__/wake.test.ts
+++ b/cli/src/__tests__/wake.test.ts
@@ -240,7 +240,8 @@ describe("vellum wake", () => {
     );
   });
 
-  test("re-provisions the guardian token when it is missing after sibling seeding", async () => {
+  test("re-provisions the guardian token when missing and --repair-guardian is passed", async () => {
+    process.argv = ["bun", "vellum", "wake", "--repair-guardian", "local-assistant"];
     loadGuardianTokenMock.mockReturnValue(null);
 
     await wake();
@@ -258,7 +259,21 @@ describe("vellum wake", () => {
     );
   });
 
+  test("does NOT re-provision without --repair-guardian, even when the token is missing", async () => {
+    // The automatic connect-repair path spawns `wake <id>` with no flags. A
+    // re-lease here would revoke other device-bound tokens (other tabs / local
+    // clients), so it must never run from auto-repair.
+    process.argv = ["bun", "vellum", "wake", "local-assistant"];
+    loadGuardianTokenMock.mockReturnValue(null);
+
+    await wake();
+
+    expect(resetGuardianBootstrapMock).not.toHaveBeenCalled();
+    expect(leaseGuardianTokenMock).not.toHaveBeenCalled();
+  });
+
   test("skips re-provision when a guardian token already exists", async () => {
+    process.argv = ["bun", "vellum", "wake", "--repair-guardian", "local-assistant"];
     // loadGuardianToken returns a token by default — recovery must not run.
     await wake();
 

--- a/cli/src/__tests__/wake.test.ts
+++ b/cli/src/__tests__/wake.test.ts
@@ -58,10 +58,27 @@ mock.module("../lib/docker.js", () => ({
 const seedGuardianTokenFromSiblingEnvMock = mock<
   typeof guardianToken.seedGuardianTokenFromSiblingEnv
 >(() => false);
+// Default: a token exists, so the re-provision recovery path is skipped. Tests
+// that exercise recovery override loadGuardianToken to return null.
+const loadGuardianTokenMock = mock<typeof guardianToken.loadGuardianToken>(
+  () => ({ accessToken: "existing" }) as ReturnType<
+    typeof guardianToken.loadGuardianToken
+  >,
+);
+const resetGuardianBootstrapMock = mock<
+  typeof guardianToken.resetGuardianBootstrap
+>(async () => {});
+const leaseGuardianTokenMock = mock<typeof guardianToken.leaseGuardianToken>(
+  async () =>
+    ({}) as Awaited<ReturnType<typeof guardianToken.leaseGuardianToken>>,
+);
 
 mock.module("../lib/guardian-token.js", () => ({
   ...realGuardianToken,
   seedGuardianTokenFromSiblingEnv: seedGuardianTokenFromSiblingEnvMock,
+  loadGuardianToken: loadGuardianTokenMock,
+  resetGuardianBootstrap: resetGuardianBootstrapMock,
+  leaseGuardianToken: leaseGuardianTokenMock,
 }));
 
 const resolveProcessStateMock = mock<typeof processLib.resolveProcessState>(
@@ -169,6 +186,16 @@ beforeEach(() => {
   startGatewayMock.mockResolvedValue("http://127.0.0.1:7830");
   seedGuardianTokenFromSiblingEnvMock.mockReset();
   seedGuardianTokenFromSiblingEnvMock.mockReturnValue(false);
+  loadGuardianTokenMock.mockReset();
+  loadGuardianTokenMock.mockReturnValue({ accessToken: "existing" } as ReturnType<
+    typeof guardianToken.loadGuardianToken
+  >);
+  resetGuardianBootstrapMock.mockReset();
+  resetGuardianBootstrapMock.mockResolvedValue(undefined);
+  leaseGuardianTokenMock.mockReset();
+  leaseGuardianTokenMock.mockResolvedValue(
+    {} as Awaited<ReturnType<typeof guardianToken.leaseGuardianToken>>,
+  );
   maybeStartNgrokTunnelMock.mockReset();
   maybeStartNgrokTunnelMock.mockResolvedValue(null);
 });
@@ -211,5 +238,31 @@ describe("vellum wake", () => {
         bootstrapSecret: "generated-bootstrap-secret",
       },
     );
+  });
+
+  test("re-provisions the guardian token when it is missing after sibling seeding", async () => {
+    loadGuardianTokenMock.mockReturnValue(null);
+
+    await wake();
+
+    // Resets the gateway's spent bootstrap state, then re-leases against the
+    // loopback gateway with the lockfile's bootstrap secret.
+    expect(resetGuardianBootstrapMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:7830",
+      "generated-bootstrap-secret",
+    );
+    expect(leaseGuardianTokenMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:7830",
+      "local-assistant",
+      "generated-bootstrap-secret",
+    );
+  });
+
+  test("skips re-provision when a guardian token already exists", async () => {
+    // loadGuardianToken returns a token by default — recovery must not run.
+    await wake();
+
+    expect(resetGuardianBootstrapMock).not.toHaveBeenCalled();
+    expect(leaseGuardianTokenMock).not.toHaveBeenCalled();
   });
 });

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -42,11 +42,23 @@ export async function wake(): Promise<void> {
     console.log(
       "  --foreground   Run assistant in foreground with logs printed to terminal",
     );
+    console.log(
+      "  --repair-guardian  Re-provision the guardian token if missing (resets the\n" +
+        "                     gateway bootstrap and re-leases — REVOKES other device-bound\n" +
+        "                     tokens, so only use deliberately, never from auto-repair)",
+    );
     process.exit(0);
   }
 
   const watch = args.includes("--watch");
   const foreground = args.includes("--foreground");
+  // Re-leasing the guardian token calls guardian/init, which revokes every
+  // other device-bound token (other tabs, other local clients on this machine).
+  // Gate it behind an explicit flag so the automatic connect-repair path
+  // (`runWake` spawns `wake <id>` with no flags) can never revoke a live session
+  // — it only ever restarts + sibling-seeds. A genuine spent-bootstrap brick is
+  // recovered deliberately via `vellum wake <id> --repair-guardian`.
+  const repairGuardian = args.includes("--repair-guardian");
   const nameArg = args.find((a) => !a.startsWith("-"));
   const entry = resolveTargetAssistant(nameArg);
 
@@ -226,15 +238,17 @@ export async function wake(): Promise<void> {
     console.log("   Seeded guardian token from sibling environment.");
   }
 
-  // Last-resort recovery: if no guardian token exists for this env even after
-  // sibling seeding, re-provision one. The single-use bootstrap secret may
-  // already be spent — a prior connect can lease a token that's then lost, or
-  // the gateway marks the secret consumed before the client persists the token
-  // — which otherwise bricks connect into a 401 → auth-rate-limit → 429
-  // cascade with no path back short of retire+hatch. Reset the gateway's
-  // bootstrap lock+consumed state (loopback-only, authorized by the lockfile
-  // secret — mirrors the macOS client's forceReBootstrap), then re-lease.
-  if (!loadGuardianToken(entry.assistantId)) {
+  // Last-resort recovery (explicit `--repair-guardian` only): if no guardian
+  // token exists for this env even after sibling seeding, re-provision one. The
+  // single-use bootstrap secret may already be spent — a prior connect can
+  // lease a token that's then lost, or the gateway marks the secret consumed
+  // before the client persists it — which otherwise bricks connect into a
+  // 401 → auth-rate-limit → 429 cascade with no path back short of retire+hatch.
+  // Reset the gateway's bootstrap lock+consumed state (loopback-only, authorized
+  // by the lockfile secret — mirrors the macOS client's forceReBootstrap), then
+  // re-lease. Gated behind the flag because the re-lease revokes other
+  // device-bound tokens; it must never run from the automatic repair path.
+  if (repairGuardian && !loadGuardianToken(entry.assistantId)) {
     const loopbackUrl = `http://127.0.0.1:${resources.gatewayPort}`;
     const maxAttempts = 3;
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -7,7 +7,12 @@ import {
   saveAssistantEntry,
 } from "../lib/assistant-config.js";
 import { dockerResourceNames, wakeContainers } from "../lib/docker.js";
-import { seedGuardianTokenFromSiblingEnv } from "../lib/guardian-token.js";
+import {
+  leaseGuardianToken,
+  loadGuardianToken,
+  resetGuardianBootstrap,
+  seedGuardianTokenFromSiblingEnv,
+} from "../lib/guardian-token.js";
 import { resolveProcessState, stopProcessByPidFile } from "../lib/process";
 import {
   generateLocalSigningKey,
@@ -219,6 +224,35 @@ export async function wake(): Promise<void> {
   // and strictly additive.
   if (seedGuardianTokenFromSiblingEnv(entry.assistantId)) {
     console.log("   Seeded guardian token from sibling environment.");
+  }
+
+  // Last-resort recovery: if no guardian token exists for this env even after
+  // sibling seeding, re-provision one. The single-use bootstrap secret may
+  // already be spent — a prior connect can lease a token that's then lost, or
+  // the gateway marks the secret consumed before the client persists the token
+  // — which otherwise bricks connect into a 401 → auth-rate-limit → 429
+  // cascade with no path back short of retire+hatch. Reset the gateway's
+  // bootstrap lock+consumed state (loopback-only, authorized by the lockfile
+  // secret — mirrors the macOS client's forceReBootstrap), then re-lease.
+  if (!loadGuardianToken(entry.assistantId)) {
+    const loopbackUrl = `http://127.0.0.1:${resources.gatewayPort}`;
+    const maxAttempts = 3;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        await resetGuardianBootstrap(loopbackUrl, bootstrapSecret);
+        await leaseGuardianToken(loopbackUrl, entry.assistantId, bootstrapSecret);
+        console.log("   Re-provisioned guardian token.");
+        break;
+      } catch (err) {
+        if (attempt < maxAttempts) {
+          await new Promise((r) => setTimeout(r, 2000 * 2 ** (attempt - 1)));
+        } else {
+          console.warn(
+            `   Guardian token re-provision failed after ${maxAttempts} attempts: ${err}`,
+          );
+        }
+      }
+    }
   }
 
   // Auto-start ngrok if webhook integrations (e.g. Telegram) are configured.

--- a/cli/src/lib/guardian-token.ts
+++ b/cli/src/lib/guardian-token.ts
@@ -17,6 +17,10 @@ import { platform } from "os";
 import { dirname, join } from "path";
 
 import { SEEDS } from "@vellumai/environments";
+import {
+  guardianTokenPath,
+  resolveConfigDir,
+} from "@vellumai/local-mode";
 
 import { getConfigDir } from "./environments/paths.js";
 import { getCurrentEnvironment } from "./environments/resolve.js";
@@ -38,12 +42,12 @@ export interface GuardianTokenData {
 }
 
 function getGuardianTokenPath(assistantId: string): string {
-  return join(
-    getConfigDir(getCurrentEnvironment()),
-    "assistants",
-    assistantId,
-    "guardian-token.json",
-  );
+  // Resolve via the shared @vellumai/local-mode resolver — the same one every
+  // host-seam reader (`getGuardianAccessToken`) uses — so the token is always
+  // written where it's read. Must stay in lockstep with `getConfigDir(
+  // getCurrentEnvironment())`; the parity test in guardian-token.test.ts guards
+  // against drift.
+  return guardianTokenPath(resolveConfigDir(process.env), assistantId);
 }
 
 /**
@@ -428,6 +432,37 @@ export async function leaseGuardianToken(
 
   saveGuardianToken(assistantId, tokenData);
   return tokenData;
+}
+
+/**
+ * Clear the gateway's guardian-init lock + consumed-secret state via
+ * `POST /v1/guardian/reset-bootstrap`, so a spent single-use bootstrap secret
+ * can be used again by a subsequent `leaseGuardianToken`. Loopback-only on the
+ * gateway; when bootstrap secrets are configured the gateway requires a
+ * matching `x-bootstrap-secret`. Mirrors the macOS client's `forceReBootstrap`
+ * recovery. Throws on a non-OK response.
+ */
+export async function resetGuardianBootstrap(
+  gatewayUrl: string,
+  bootstrapSecret?: string,
+): Promise<void> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (bootstrapSecret) {
+    headers["x-bootstrap-secret"] = bootstrapSecret;
+  }
+  const response = await fetch(`${gatewayUrl}/v1/guardian/reset-bootstrap`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({}),
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `guardian/reset-bootstrap failed (${response.status}): ${body}`,
+    );
+  }
 }
 
 /**

--- a/packages/local-mode/src/config.ts
+++ b/packages/local-mode/src/config.ts
@@ -64,3 +64,16 @@ export function resolveConfigDir(
   }
   return path.join(xdgConfigHome, `vellum-${vellumEnv}`);
 }
+
+/**
+ * The on-disk location of an assistant's guardian token, given an already
+ * resolved config dir. The single source of truth for this path so the CLI
+ * writer and every host-seam reader agree — a divergence here is what leaves a
+ * freshly leased token unreadable and bricks the connect.
+ */
+export function guardianTokenPath(
+  configDir: string,
+  assistantId: string,
+): string {
+  return path.join(configDir, "assistants", assistantId, "guardian-token.json");
+}

--- a/packages/local-mode/src/guardian-token.ts
+++ b/packages/local-mode/src/guardian-token.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import fs from "node:fs";
-import path from "node:path";
 
+import { guardianTokenPath } from "./config";
 import type { CliInvocation } from "./util";
 
 const GUARDIAN_TOKEN_REFRESH_TIMEOUT_MS = 15_000;
@@ -40,7 +40,7 @@ export function getGuardianAccessToken(
     return Promise.resolve({ ok: false, status: 403, error: "Forbidden" });
   }
 
-  const tokenPath = path.join(configDir, "assistants", assistantId, "guardian-token.json");
+  const tokenPath = guardianTokenPath(configDir, assistantId);
 
   let raw: string;
   try {

--- a/packages/local-mode/src/index.ts
+++ b/packages/local-mode/src/index.ts
@@ -14,7 +14,7 @@ export {
   resolveDevCliInvocation,
 } from "./util";
 export type { CliInvocation } from "./util";
-export { resolveLocalConfigFromEnv, resolveLockfilePaths, resolveConfigDir } from "./config";
+export { resolveLocalConfigFromEnv, resolveLockfilePaths, resolveConfigDir, guardianTokenPath } from "./config";
 export type { LocalEndpointConfig } from "./config";
 export { defaultEnvironmentFilePath, readDefaultEnvironment, resolveEnvironmentName } from "./environment";
 export {


### PR DESCRIPTION
## Summary

Hardens the local-assistant hatch → connect → conversation path on `vel up` web/Electron dev. Fixes a fresh local hatch that couldn't connect (401/429), and a subsequent request storm that melted the daemon. **None of these were regressions from #34370 / the device-id PRs** — they're pre-existing issues in the guardian-token provisioning and the local-mode SSE proxy, surfaced by exercising the flow end-to-end.

## What was broken & fixed

**1. Guardian-token written where it isn't read (couldn't connect).** The CLI write path (`getGuardianTokenPath`) and the host-seam readers (`getGuardianAccessToken`) resolved the config dir through two parallel resolvers, so a hatch could persist `guardian-token.json` under one env dir while the connect read another → 404 → repair loop → spent bootstrap → 401.
- Consolidate to one resolver: extract `guardianTokenPath()` in `@vellumai/local-mode`; point the CLI write path at the shared `resolveConfigDir(process.env)`. Parity test guards against future drift.
- Pin `VELLUM_ENVIRONMENT` on the Electron guardian-token seam so the refresh/lease subprocess and the reader always agree.

**2. No recovery from a spent bootstrap.** A single-use bootstrap secret consumed without a persisted token bricked the assistant. Added an opt-in `vellum wake <id> --repair-guardian` that resets the gateway bootstrap state and re-leases (mirrors the macOS client's `forceReBootstrap`). **Gated behind the flag** so the automatic connect-repair path can never run it — re-leasing revokes other device-bound tokens, which must be deliberate.

**3. SSE `/events` 502 → request storm (the big one).** The local-mode gateway proxy copied the upstream's `transfer-encoding: chunked` while Node added its own, producing a duplicate header that the `vel up` Caddy edge rejects with **502**. The dead SSE stream made the client reconnect in a loop, each reopen re-fetching everything → 471-request storm hitting the daemon's 300 req/min limiter.
- Strip `transfer-encoding` before re-emitting the proxied response (`vite-plugin-local-mode.ts`). Verified: SSE 502 → 200 through Caddy.

**4. Client robustness (defense-in-depth).** So a failing SSE degrades gracefully instead of storming:
- Global TanStack Query retry policy: never retry 429/4xx (retrying a rate-limited request self-sustains the storm) + capped backoff.
- `sse.opened` (which fans out to 6 reconcile/refetch subscribers) now fires only on **genuine stream establishment**, not on every failed reconnect attempt — a never-opening stream triggers zero reconciles.

## Test plan
- `packages/local-mode` (67), `cli` guardian-token/wake/device-id (37), `apps/web` sse-service/query-retry/reconcile-on-reopen (60) — all pass.
- `tsc --noEmit` clean in `packages/local-mode`, `cli`, `apps/web`, `apps/macos`.
- Manual: fresh local hatch connects first-try; SSE streams (200) through Caddy; conversation no longer storms the daemon.

## Notes
- Feature branch — not for auto-merge; for manual review/merge.
- 5 commits; recommend **squash-merge** (the intermediate state briefly has the wake re-provision before it's flag-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)