### PR TITLE
CLI: route all remaining loopback-able fetches through loopbackSafeFetch

### DIFF
--- a/cli/src/commands/backup.ts
+++ b/cli/src/commands/backup.ts
@@ -16,6 +16,7 @@ import {
   platformRequestSignedUrl,
   readPlatformToken,
 } from "../lib/platform-client.js";
+import { loopbackSafeFetch } from "../lib/loopback-fetch.js";
 
 export async function backup(): Promise<void> {
   const args = process.argv.slice(3);
@@ -112,7 +113,7 @@ export async function backup(): Promise<void> {
   // Call the export endpoint
   let response: Response;
   try {
-    response = await fetch(`${entry.runtimeUrl}/v1/migrations/export`, {
+    response = await loopbackSafeFetch(`${entry.runtimeUrl}/v1/migrations/export`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${accessToken}`,
@@ -138,7 +139,7 @@ export async function backup(): Promise<void> {
       }
       if (refreshedToken) {
         accessToken = refreshedToken;
-        response = await fetch(`${entry.runtimeUrl}/v1/migrations/export`, {
+        response = await loopbackSafeFetch(`${entry.runtimeUrl}/v1/migrations/export`, {
           method: "POST",
           headers: {
             Authorization: `Bearer ${accessToken}`,

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -56,6 +56,7 @@ import {
   readPlatformToken,
 } from "../lib/platform-client";
 import { tuiLog } from "../lib/tui-log";
+import { loopbackSafeFetch } from "../lib/loopback-fetch.js";
 
 const SUPPORTED_INTERFACES = ["cli", "web"] as const;
 type SupportedInterface = (typeof SUPPORTED_INTERFACES)[number];
@@ -619,7 +620,7 @@ async function handleLocalEndpoints(
 
     try {
       const hasBody = req.method !== "GET" && req.method !== "HEAD";
-      const proxyRes = await fetch(targetUrl, {
+      const proxyRes = await loopbackSafeFetch(targetUrl, {
         method: req.method,
         headers,
         body: hasBody ? req.body : undefined,
@@ -760,7 +761,7 @@ async function runWebInterface(
         try {
           const hasBody = req.method !== "GET" && req.method !== "HEAD";
           const body = hasBody ? await req.arrayBuffer() : undefined;
-          const proxyRes = await fetch(target.toString(), {
+          const proxyRes = await loopbackSafeFetch(target.toString(), {
             method: req.method,
             headers,
             body,

--- a/cli/src/commands/devices.ts
+++ b/cli/src/commands/devices.ts
@@ -28,6 +28,7 @@ import {
   canPromptForConfirmation,
   confirmAction,
 } from "../lib/confirm-action.js";
+import { loopbackSafeFetch } from "../lib/loopback-fetch.js";
 
 interface DeviceRecord {
   hashedDeviceId: string;
@@ -108,7 +109,7 @@ async function listDevices(entry: AssistantEntry, base: string): Promise<void> {
 
   let response: Response;
   try {
-    response = await fetch(`${base}/v1/devices`, {
+    response = await loopbackSafeFetch(`${base}/v1/devices`, {
       method: "GET",
       headers: getClientRegistrationHeaders(CLI_INTERFACE_ID),
     });
@@ -186,7 +187,7 @@ async function revokeDevice(
 
   let response: Response;
   try {
-    response = await fetch(`${base}/v1/devices/revoke`, {
+    response = await loopbackSafeFetch(`${base}/v1/devices/revoke`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -26,6 +26,7 @@ import {
 } from "../lib/client-identity.js";
 import { GATEWAY_PORT } from "../lib/constants.js";
 import { getLocalLanIPv4 } from "../lib/local.js";
+import { loopbackSafeFetch } from "../lib/loopback-fetch.js";
 
 function isLoopbackHost(url: string): boolean {
   try {
@@ -154,7 +155,7 @@ export async function pair(): Promise<void> {
 
   let response: Response;
   try {
-    response = await fetch(`${mintUrl}/v1/pair`, {
+    response = await loopbackSafeFetch(`${mintUrl}/v1/pair`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/cli/src/commands/restore.ts
+++ b/cli/src/commands/restore.ts
@@ -16,6 +16,7 @@ import {
   platformPollJobStatus,
 } from "../lib/platform-client.js";
 import { performDockerRollback } from "../lib/upgrade-lifecycle.js";
+import { loopbackSafeFetch } from "../lib/loopback-fetch.js";
 
 function printUsage(): void {
   console.log(
@@ -588,7 +589,7 @@ export async function restore(): Promise<void> {
 
     let response: Response;
     try {
-      response = await fetch(
+      response = await loopbackSafeFetch(
         `${entry.runtimeUrl}/v1/migrations/import-preflight`,
         {
           method: "POST",
@@ -694,7 +695,7 @@ export async function restore(): Promise<void> {
 
     let response: Response;
     try {
-      response = await fetch(`${entry.runtimeUrl}/v1/migrations/import`, {
+      response = await loopbackSafeFetch(`${entry.runtimeUrl}/v1/migrations/import`, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${accessToken}`,

--- a/cli/src/commands/retire.ts
+++ b/cli/src/commands/retire.ts
@@ -36,6 +36,7 @@ import {
   resetLogFile,
   writeToLogFile,
 } from "../lib/xdg-log.js";
+import { loopbackSafeFetch } from "../lib/loopback-fetch.js";
 
 export { retireLocal };
 
@@ -96,7 +97,7 @@ async function retireVellum(
 
   const platformUrl = runtimeUrl || getPlatformUrl();
   const url = `${platformUrl}/v1/assistants/${encodeURIComponent(assistantId)}/retire/`;
-  const response = await fetch(url, {
+  const response = await loopbackSafeFetch(url, {
     method: "DELETE",
     headers: await authHeaders(token, runtimeUrl),
   });

--- a/cli/src/commands/roadmap.ts
+++ b/cli/src/commands/roadmap.ts
@@ -1,4 +1,5 @@
 import { readPlatformToken, getWebUrl } from "../lib/platform-client.js";
+import { loopbackSafeFetch } from "../lib/loopback-fetch.js";
 
 function printUsage(): void {
   console.log("Usage: vellum roadmap <subcommand>");
@@ -88,7 +89,7 @@ async function apiFetch(
   if (options.token) headers["X-Session-Token"] = options.token;
   if (options.body) headers["Content-Type"] = "application/json";
 
-  return fetch(url, {
+  return loopbackSafeFetch(url, {
     method: options.method ?? "GET",
     headers,
     body: options.body ? JSON.stringify(options.body) : undefined,

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -47,6 +47,7 @@ import {
   waitForReady,
 } from "../lib/upgrade-lifecycle.js";
 import { compareVersions } from "../lib/version-compat.js";
+import { loopbackSafeFetch } from "../lib/loopback-fetch.js";
 
 interface UpgradeArgs {
   name: string | null;
@@ -230,7 +231,7 @@ async function upgradeDocker(
     lastWorkspaceMigrationId?: string;
   } = {};
   try {
-    const healthResp = await fetch(
+    const healthResp = await loopbackSafeFetch(
       `${entry.runtimeUrl}/healthz?include=migrations`,
       {
         signal: AbortSignal.timeout(5000),
@@ -695,7 +696,7 @@ async function upgradePlatform(
     body.version = version;
   }
 
-  const response = await fetch(url, {
+  const response = await loopbackSafeFetch(url, {
     method: "POST",
     headers,
     body: JSON.stringify(body),

--- a/cli/src/lib/assistant-client.ts
+++ b/cli/src/lib/assistant-client.ts
@@ -19,6 +19,7 @@ import {
   refreshGuardianToken,
   guardianTokenDueForRenewal,
 } from "./guardian-token.js";
+import { loopbackSafeFetch } from "./loopback-fetch.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const FALLBACK_RUNTIME_URL = `http://127.0.0.1:${GATEWAY_PORT}`;
@@ -203,7 +204,7 @@ export class AssistantClient {
     const doFetch = (): Promise<Response> => {
       const headers = buildHeaders();
       if (opts?.signal) {
-        return fetch(url, {
+        return loopbackSafeFetch(url, {
           method,
           headers,
           body: jsonBody,
@@ -213,7 +214,7 @@ export class AssistantClient {
       const timeout = opts?.timeout ?? DEFAULT_TIMEOUT_MS;
       const controller = new AbortController();
       const timeoutId = setTimeout(() => controller.abort(), timeout);
-      return fetch(url, {
+      return loopbackSafeFetch(url, {
         method,
         headers,
         body: jsonBody,

--- a/cli/src/lib/backup-ops.ts
+++ b/cli/src/lib/backup-ops.ts
@@ -13,6 +13,7 @@ import {
   loadGuardianToken,
   refreshGuardianToken,
 } from "./guardian-token.js";
+import { loopbackSafeFetch } from "./loopback-fetch.js";
 
 /** Default backup directory following XDG convention */
 export function getBackupsDir(): string {
@@ -66,7 +67,7 @@ export async function createBackup(
       return null;
     }
 
-    let response = await fetch(`${runtimeUrl}/v1/migrations/export`, {
+    let response = await loopbackSafeFetch(`${runtimeUrl}/v1/migrations/export`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${accessToken}`,
@@ -87,7 +88,7 @@ export async function createBackup(
         return null;
       }
       accessToken = refreshed.accessToken;
-      response = await fetch(`${runtimeUrl}/v1/migrations/export`, {
+      response = await loopbackSafeFetch(`${runtimeUrl}/v1/migrations/export`, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${accessToken}`,
@@ -152,7 +153,7 @@ export async function restoreBackup(
       return false;
     }
 
-    let response = await fetch(`${runtimeUrl}/v1/migrations/import`, {
+    let response = await loopbackSafeFetch(`${runtimeUrl}/v1/migrations/import`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${accessToken}`,
@@ -171,7 +172,7 @@ export async function restoreBackup(
         return false;
       }
       accessToken = refreshed.accessToken;
-      response = await fetch(`${runtimeUrl}/v1/migrations/import`, {
+      response = await loopbackSafeFetch(`${runtimeUrl}/v1/migrations/import`, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${accessToken}`,

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -67,6 +67,7 @@ export {
   ASSISTANT_INTERNAL_PORT,
   GATEWAY_INTERNAL_PORT,
 } from "./environments/paths.js";
+import { loopbackSafeFetch } from "./loopback-fetch.js";
 
 /** Max time to wait for the assistant container to emit the readiness sentinel. */
 export const DOCKER_READY_TIMEOUT_MS = 5 * 60 * 1000;
@@ -1530,7 +1531,7 @@ async function waitForGatewayAndLease(opts: {
 
   while (Date.now() - start < DOCKER_READY_TIMEOUT_MS) {
     try {
-      const resp = await fetch(readyUrl, {
+      const resp = await loopbackSafeFetch(readyUrl, {
         signal: AbortSignal.timeout(5000),
       });
       if (resp.ok) {

--- a/cli/src/lib/guardian-token.ts
+++ b/cli/src/lib/guardian-token.ts
@@ -24,6 +24,7 @@ import {
 
 import { getConfigDir } from "./environments/paths.js";
 import { getCurrentEnvironment } from "./environments/resolve.js";
+import { loopbackSafeFetch } from "./loopback-fetch.js";
 
 const DEVICE_ID_SALT = "vellum-assistant-host-id";
 
@@ -346,7 +347,7 @@ export async function refreshGuardianToken(
 
     const tokenData = current ?? before;
 
-    const response = await fetch(`${gatewayUrl}/v1/guardian/refresh`, {
+    const response = await loopbackSafeFetch(`${gatewayUrl}/v1/guardian/refresh`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -406,7 +407,7 @@ export async function leaseGuardianToken(
   if (bootstrapSecret) {
     headers["x-bootstrap-secret"] = bootstrapSecret;
   }
-  const response = await fetch(`${gatewayUrl}/v1/guardian/init`, {
+  const response = await loopbackSafeFetch(`${gatewayUrl}/v1/guardian/init`, {
     method: "POST",
     headers,
     body: JSON.stringify({ platform: "cli", deviceId }),

--- a/cli/src/lib/hatch-local.ts
+++ b/cli/src/lib/hatch-local.ts
@@ -44,6 +44,7 @@ import {
 } from "./provider-secrets.js";
 import { logHatchNextSteps } from "./hatch-next-steps.js";
 import { checkProviderApiKey } from "./api-key-check.js";
+import { loopbackSafeFetch } from "./loopback-fetch.js";
 
 /**
  * Attempts to place a symlink at the given path pointing to cliBinary.
@@ -358,7 +359,7 @@ export async function hatchLocal(
     while (true) {
       await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
       try {
-        const res = await fetch(healthUrl, {
+        const res = await loopbackSafeFetch(healthUrl, {
           signal: AbortSignal.timeout(3000),
         });
         if (res.ok) {

--- a/cli/src/lib/http-client.ts
+++ b/cli/src/lib/http-client.ts
@@ -1,3 +1,5 @@
+import { loopbackSafeFetch } from "./loopback-fetch.js";
+
 /**
  * Build the base URL for the daemon HTTP server.
  */
@@ -15,7 +17,7 @@ export async function httpHealthCheck(
 ): Promise<boolean> {
   try {
     const url = `${buildDaemonUrl(port)}/healthz`;
-    const response = await fetch(url, {
+    const response = await loopbackSafeFetch(url, {
       signal: AbortSignal.timeout(timeoutMs),
     });
     return response.ok;

--- a/cli/src/lib/local-runtime-client.ts
+++ b/cli/src/lib/local-runtime-client.ts
@@ -9,6 +9,7 @@ import {
   resolveRuntimeMigrationUrl,
   resolveRuntimeUrl,
 } from "./runtime-url.js";
+import { loopbackSafeFetch } from "./loopback-fetch.js";
 
 /**
  * Thrown when the local runtime returns 409 for an export/import request
@@ -122,7 +123,7 @@ export async function localRuntimeExportToGcs(
     body.description = params.description;
   }
 
-  const response = await fetch(
+  const response = await loopbackSafeFetch(
     resolveRuntimeMigrationUrl(entry, "export-to-gcs"),
     {
       method: "POST",
@@ -166,7 +167,7 @@ export async function localRuntimeImportFromGcs(
   token: string,
   params: { bundleUrl: string },
 ): Promise<{ jobId: string }> {
-  const response = await fetch(
+  const response = await loopbackSafeFetch(
     resolveRuntimeMigrationUrl(entry, "import-from-gcs"),
     {
       method: "POST",
@@ -211,7 +212,7 @@ export async function localRuntimePollJobStatus(
   token: string,
   jobId: string,
 ): Promise<UnifiedJobStatus> {
-  const response = await fetch(
+  const response = await loopbackSafeFetch(
     resolveRuntimeMigrationUrl(entry, `jobs/${jobId}`),
     {
       headers: await migrationRequestHeaders(entry, token),
@@ -285,7 +286,7 @@ export async function localRuntimeIdentity(
 ): Promise<RuntimeIdentity> {
   const url = resolveRuntimeUrl(entry, "health");
   const doRequest = async (): Promise<Response> =>
-    fetch(url, {
+    loopbackSafeFetch(url, {
       method: "GET",
       headers: await migrationRequestHeaders(entry, token),
     });

--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -11,6 +11,7 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
 import { GATEWAY_PORT } from "./constants";
+import { loopbackSafeFetch } from "./loopback-fetch.js";
 
 function getDefaultWorkspaceDir(): string {
   return (
@@ -78,7 +79,7 @@ export function getNgrokVersion(): string | null {
  */
 async function queryNgrokTunnels(): Promise<NgrokTunnel[] | null> {
   try {
-    const res = await fetch(NGROK_API_URL, {
+    const res = await loopbackSafeFetch(NGROK_API_URL, {
       signal: AbortSignal.timeout(2_000),
     });
     if (!res.ok) return null;

--- a/cli/src/lib/platform-releases.ts
+++ b/cli/src/lib/platform-releases.ts
@@ -1,6 +1,7 @@
 import { getPlatformUrl } from "./platform-client.js";
 import { DOCKERHUB_IMAGES } from "./docker.js";
 import type { ServiceName } from "./docker.js";
+import { loopbackSafeFetch } from "./loopback-fetch.js";
 
 export interface ResolvedImageRefs {
   imageTags: Record<ServiceName, string>;
@@ -15,7 +16,7 @@ export interface ResolvedImageRefs {
 export async function fetchLatestStableVersion(): Promise<string | null> {
   try {
     const platformUrl = getPlatformUrl();
-    const response = await fetch(`${platformUrl}/v1/releases/?stable=true`, {
+    const response = await loopbackSafeFetch(`${platformUrl}/v1/releases/?stable=true`, {
       signal: AbortSignal.timeout(10_000),
     });
     if (!response.ok) return null;
@@ -80,7 +81,7 @@ async function fetchPlatformImageRefs(
 
     log?.(`Fetching releases from ${url}`);
 
-    const response = await fetch(url, {
+    const response = await loopbackSafeFetch(url, {
       signal: AbortSignal.timeout(10_000),
     });
 

--- a/cli/src/lib/terminal-client.ts
+++ b/cli/src/lib/terminal-client.ts
@@ -7,6 +7,7 @@
  */
 
 import { authHeaders, getPlatformUrl } from "./platform-client.js";
+import { loopbackSafeFetch } from "./loopback-fetch.js";
 
 // ---------------------------------------------------------------------------
 // Create / Close
@@ -25,7 +26,7 @@ export async function createTerminalSession(
   if (service) {
     body.service = service;
   }
-  const response = await fetch(
+  const response = await loopbackSafeFetch(
     `${baseUrl}/v1/assistants/${assistantId}/terminal/sessions/`,
     {
       method: "POST",
@@ -49,7 +50,7 @@ export async function closeTerminalSession(
   platformUrl?: string,
 ): Promise<void> {
   const baseUrl = platformUrl || getPlatformUrl();
-  const response = await fetch(
+  const response = await loopbackSafeFetch(
     `${baseUrl}/v1/assistants/${assistantId}/terminal/sessions/${sessionId}/`,
     {
       method: "DELETE",
@@ -76,7 +77,7 @@ export async function sendTerminalInput(
   platformUrl?: string,
 ): Promise<void> {
   const baseUrl = platformUrl || getPlatformUrl();
-  const response = await fetch(
+  const response = await loopbackSafeFetch(
     `${baseUrl}/v1/assistants/${assistantId}/terminal/sessions/${sessionId}/input/`,
     {
       method: "POST",
@@ -100,7 +101,7 @@ export async function resizeTerminalSession(
   platformUrl?: string,
 ): Promise<void> {
   const baseUrl = platformUrl || getPlatformUrl();
-  const response = await fetch(
+  const response = await loopbackSafeFetch(
     `${baseUrl}/v1/assistants/${assistantId}/terminal/sessions/${sessionId}/resize/`,
     {
       method: "POST",
@@ -137,7 +138,7 @@ export async function* subscribeTerminalEvents(
   signal?: AbortSignal,
 ): AsyncGenerator<TerminalOutputEvent> {
   const baseUrl = platformUrl || getPlatformUrl();
-  const response = await fetch(
+  const response = await loopbackSafeFetch(
     `${baseUrl}/v1/assistants/${assistantId}/terminal/sessions/${sessionId}/events/`,
     {
       headers: await authHeaders(token, platformUrl),

--- a/cli/src/lib/upgrade-lifecycle.ts
+++ b/cli/src/lib/upgrade-lifecycle.ts
@@ -27,6 +27,7 @@ import {
 } from "./statefulset.js";
 import { exec, execOutput } from "./step-runner.js";
 import { compareVersions } from "./version-compat.js";
+import { loopbackSafeFetch } from "./loopback-fetch.js";
 
 // ---------------------------------------------------------------------------
 // Failure log capture
@@ -274,7 +275,7 @@ export async function fetchCurrentVersion(
   runtimeUrl: string,
 ): Promise<string | undefined> {
   try {
-    const resp = await fetch(`${runtimeUrl}/healthz`, {
+    const resp = await loopbackSafeFetch(`${runtimeUrl}/healthz`, {
       signal: AbortSignal.timeout(5000),
     });
     if (resp.ok) {
@@ -299,7 +300,7 @@ export async function fetchAssistantIngressUrl(
 ): Promise<string | undefined> {
   if (!bearerToken) return undefined;
   try {
-    const resp = await fetch(`${runtimeUrl}/integrations/ingress/config`, {
+    const resp = await loopbackSafeFetch(`${runtimeUrl}/integrations/ingress/config`, {
       headers: { Authorization: `Bearer ${bearerToken}` },
       signal: AbortSignal.timeout(5000),
     });
@@ -341,7 +342,7 @@ export async function fetchPreviousVersion(
   try {
     const { getPlatformUrl } = await import("./platform-client.js");
     const platformUrl = getPlatformUrl();
-    const resp = await fetch(`${platformUrl}/v1/releases/?stable=true`, {
+    const resp = await loopbackSafeFetch(`${platformUrl}/v1/releases/?stable=true`, {
       signal: AbortSignal.timeout(10_000),
     });
     if (!resp.ok) return undefined;
@@ -373,7 +374,7 @@ export async function waitForReady(runtimeUrl: string): Promise<boolean> {
 
   while (Date.now() - start < DOCKER_READY_TIMEOUT_MS) {
     try {
-      const resp = await fetch(readyUrl, {
+      const resp = await loopbackSafeFetch(readyUrl, {
         signal: AbortSignal.timeout(5000),
       });
       if (resp.ok) {
@@ -419,7 +420,7 @@ export async function broadcastUpgradeEvent(
     if (token?.accessToken) {
       headers["Authorization"] = `Bearer ${token.accessToken}`;
     }
-    await fetch(`${gatewayUrl}/v1/admin/upgrade-broadcast`, {
+    await loopbackSafeFetch(`${gatewayUrl}/v1/admin/upgrade-broadcast`, {
       method: "POST",
       headers,
       body: JSON.stringify(event),
@@ -448,7 +449,7 @@ export async function commitWorkspaceViaGateway(
     if (token?.accessToken) {
       headers["Authorization"] = `Bearer ${token.accessToken}`;
     }
-    await fetch(`${gatewayUrl}/v1/admin/workspace-commit`, {
+    await loopbackSafeFetch(`${gatewayUrl}/v1/admin/workspace-commit`, {
       method: "POST",
       headers,
       body: JSON.stringify({ message }),
@@ -491,7 +492,7 @@ export async function rollbackMigrations(
       body.targetWorkspaceMigrationId = targetWorkspaceMigrationId;
     if (rollbackToRegistryCeiling) body.rollbackToRegistryCeiling = true;
 
-    const resp = await fetch(`${gatewayUrl}/v1/admin/rollback-migrations`, {
+    const resp = await loopbackSafeFetch(`${gatewayUrl}/v1/admin/rollback-migrations`, {
       method: "POST",
       headers,
       body: JSON.stringify(body),
@@ -572,7 +573,7 @@ export async function performDockerRollback(
     lastWorkspaceMigrationId?: string;
   } = {};
   try {
-    const healthResp = await fetch(
+    const healthResp = await loopbackSafeFetch(
       `${entry.runtimeUrl}/healthz?include=migrations`,
       { signal: AbortSignal.timeout(5000) },
     );


### PR DESCRIPTION
## Summary
- Follow-up to #34421: route every remaining CLI `fetch` that can target a loopback URL (platform, runtime, gateway, daemon, ngrok local API) through `loopbackSafeFetch`, which disables Bun's keep-alive socket pooling for loopback hosts only.
- Covers commands (`retire`, `backup`, `restore`, `devices`, `pair`, `upgrade`, `client` proxies, `roadmap`) and libs (`backup-ops`, `upgrade-lifecycle`, `platform-releases`, `hatch-local`, `assistant-client`, `local-runtime-client`, `terminal-client`, `guardian-token`, `http-client`, docker readiness probe, `ngrok`).
- Deliberately excluded (fixed external endpoints where loopback is impossible): cloud metadata lookups in `local.ts` (169.254.169.254), the GitHub Lima release check in `docker.ts`, and the GCS signed bundle download in `backup.ts`.

## Original prompt
While diagnosing why `vellum ps` took ~10s against the local (Werkzeug) platform, we found Bun's fetch reuses sockets from `Connection: close` responses, hanging every other request to the same origin until its abort timeout. #34421 fixed `platform-client.ts` and `health-check.ts`; the user then noticed `vellum retire` (whose platform DELETE in `retire.ts` was still a raw fetch with no abort signal) was also affected and asked to extend `loopbackSafeFetch` to all other relevant API calls in the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)