### PR TITLE
GA dynamic empty-state greetings

### DIFF
--- a/apps/web/src/domains/chat/hooks/use-empty-state-greeting.test.tsx
+++ b/apps/web/src/domains/chat/hooks/use-empty-state-greeting.test.tsx
@@ -168,9 +168,15 @@ describe("useEmptyStateGreeting", () => {
       refreshing: false,
     });
     expect(identityIntroCalls).toHaveLength(1);
-    expect(
-      (identityIntroCalls[0] as { path: { assistant_id: string } }).path
-    ).toEqual({ assistant_id: "asst-1" });
+    const call = identityIntroCalls[0] as {
+      path: { assistant_id: string };
+      query?: { localHour?: number; localMinute?: number };
+    };
+    expect(call.path).toEqual({ assistant_id: "asst-1" });
+    expect(call.query?.localHour).toBeGreaterThanOrEqual(0);
+    expect(call.query?.localHour).toBeLessThanOrEqual(23);
+    expect(call.query?.localMinute).toBeGreaterThanOrEqual(0);
+    expect(call.query?.localMinute).toBeLessThanOrEqual(59);
   });
 
   test("queryFn falls back to legacy text when greetings are absent", async () => {

--- a/apps/web/src/domains/chat/hooks/use-empty-state-greeting.ts
+++ b/apps/web/src/domains/chat/hooks/use-empty-state-greeting.ts
@@ -7,8 +7,8 @@
  * {@link DEFAULT_EMPTY_STATE_GREETING} when the assistant ID is missing, the
  * daemon is unreachable, or the response is empty.
  *
- * The query has a long `staleTime` (5 minutes) since the intro text only
- * changes when the assistant's identity or soul prompt changes.
+ * The query has a long `staleTime` (5 minutes) since the intro text is cached
+ * server-side and refreshed in the background.
  */
 
 import { useMemo } from "react";
@@ -41,6 +41,7 @@ async function fetchIdentityIntro(
   try {
     const { data, error, response } = await identityIntroGet({
       path: { assistant_id: assistantId },
+      query: buildLocalTimeQuery(),
       throwOnError: false,
     });
     assertHasResponse(response, error, "Failed to fetch identity intro");
@@ -61,6 +62,16 @@ async function fetchIdentityIntro(
   } catch {
     return null;
   }
+}
+
+function buildLocalTimeQuery(date: Date = new Date()): {
+  localHour: number;
+  localMinute: number;
+} {
+  return {
+    localHour: date.getHours(),
+    localMinute: date.getMinutes(),
+  };
 }
 
 function normalizeIdentityIntroCandidates(

--- a/apps/web/src/lib/feature-flags/feature-flag-catalog.test.ts
+++ b/apps/web/src/lib/feature-flags/feature-flag-catalog.test.ts
@@ -33,8 +33,8 @@ describe("feature flag catalog", () => {
     );
   });
 
-  test("exposes dynamic empty-state greetings as an assistant flag", () => {
-    expect(ASSISTANT_FLAG_DEFAULTS.emptyStateDynamicGreetings).toBe(false);
+  test("does not expose GA empty-state greetings as a feature flag", () => {
+    expect("emptyStateDynamicGreetings" in ASSISTANT_FLAG_DEFAULTS).toBe(false);
     expect("emptyStateDynamicGreetings" in CLIENT_FLAG_DEFAULTS).toBe(false);
   });
 });

--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -404,14 +404,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "empty-state-dynamic-greetings",
-      "scope": "assistant",
-      "key": "empty-state-dynamic-greetings",
-      "label": "Dynamic Empty-State Greetings",
-      "description": "Enable the empty new-chat screen to refresh cached greeting options via the empty-state greeting LLM call site. When off, the assistant serves workspace-authored greetings or static fallbacks only.",
-      "defaultEnabled": false
-    },
-    {
       "id": "self-intro-greeting",
       "scope": "both",
       "key": "self-intro-greeting",

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -12893,6 +12893,23 @@ paths:
                   - source
                   - refreshing
                 additionalProperties: false
+      parameters:
+        - name: localHour
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 23
+          description: Optional client-local hour of day used only when refreshing generated greetings.
+        - name: localMinute
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 59
+          description: Optional client-local minute used only when refreshing generated greetings.
   /v1/image-generation/generate:
     post:
       operationId: imagegeneration_generate_post

--- a/assistant/src/__tests__/btw-routes.test.ts
+++ b/assistant/src/__tests__/btw-routes.test.ts
@@ -8,7 +8,7 @@
 
 import { rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 
 // ---------------------------------------------------------------------------
 // Mocks — must be defined before importing the module under test
@@ -22,7 +22,11 @@ mock.module("../util/logger.js", () => ({
 }));
 
 const mockGetConversationByKey = mock(
-  (_key: string): { conversationId: string } | null => ({
+  (
+    _key: string,
+  ): {
+    conversationId: string;
+  } | null => ({
     conversationId: "conv-test-123",
   }),
 );
@@ -78,13 +82,6 @@ mock.module("../runtime/routes/identity-intro-cache.js", () => ({
   getCachedIntro: () => null,
   readWorkspaceIdentityIntro: () => null,
   setCachedIntro: () => {},
-}));
-
-const assistantFeatureFlags: Record<string, boolean> = {};
-
-mock.module("../config/assistant-feature-flags.js", () => ({
-  isAssistantFeatureFlagEnabled: (key: string) =>
-    assistantFeatureFlags[key] ?? false,
 }));
 
 // Mock getOrCreateConversation from conversation-store so the handler
@@ -184,12 +181,6 @@ function makeMockSession(
 
 const route = ROUTES.find((r) => r.endpoint === "btw" && r.method === "POST");
 if (!route) throw new Error("btw route not found in ROUTES");
-
-beforeEach(() => {
-  for (const key of Object.keys(assistantFeatureFlags)) {
-    delete assistantFeatureFlags[key];
-  }
-});
 
 async function callHandler(
   body: Record<string, unknown>,
@@ -338,25 +329,7 @@ describe("POST /v1/btw", () => {
     expect(options!.config!.modelIntent).toBeUndefined();
   });
 
-  test("greeting requests return static fallback when the dynamic greetings flag is off", async () => {
-    mockGetOrCreateConversation.mockClear();
-
-    const { result } = await callHandler({
-      conversationKey: "greeting",
-      content: "Generate a greeting",
-    });
-    const text = await readStream(result as ReadableStream<Uint8Array>);
-
-    expect(text).toContain(
-      `event: btw_text_delta\ndata: {"text":"What are we working on?"}`,
-    );
-    expect(text).toContain("event: btw_complete\ndata: {}");
-    expect(mockGetOrCreateConversation).not.toHaveBeenCalled();
-  });
-
-  test("greeting requests pass callSite: 'emptyStateGreeting' when the dynamic greetings flag is on", async () => {
-    assistantFeatureFlags["empty-state-dynamic-greetings"] = true;
-
+  test("greeting requests pass callSite: 'emptyStateGreeting'", async () => {
     const provider = makeMockProvider();
     const session = makeMockSession(provider);
     mockGetOrCreateConversation.mockImplementationOnce(async () => session);

--- a/assistant/src/__tests__/identity-intro-cache.test.ts
+++ b/assistant/src/__tests__/identity-intro-cache.test.ts
@@ -119,19 +119,26 @@ describe("identity intro cache", () => {
 
     setCachedIntro(["Hello!"]);
 
-    const fortyNineHoursAgo = String(Date.now() - 49 * 60 * 60 * 1000);
-    checkpointStore.set("identity:intro:cached_at", fortyNineHoursAgo);
+    const fourHoursAndOneMinuteAgo = String(
+      Date.now() - (4 * 60 + 1) * 60 * 1000,
+    );
+    checkpointStore.set("identity:intro:cached_at", fourHoursAndOneMinuteAgo);
 
     expect(getCachedIntro()).toBeNull();
   });
 
-  test("returns cached greetings when within TTL (47 hours ago)", () => {
+  test("returns cached greetings when within TTL (3 hours 59 minutes ago)", () => {
     workspaceFiles["IDENTITY.md"] = "- **Name:** Atlas";
 
     setCachedIntro(["Hello!"]);
 
-    const fortySevenHoursAgo = String(Date.now() - 47 * 60 * 60 * 1000);
-    checkpointStore.set("identity:intro:cached_at", fortySevenHoursAgo);
+    const threeHoursAndFiftyNineMinutesAgo = String(
+      Date.now() - (3 * 60 + 59) * 60 * 1000,
+    );
+    checkpointStore.set(
+      "identity:intro:cached_at",
+      threeHoursAndFiftyNineMinutesAgo,
+    );
 
     const cached = getCachedIntro();
     expect(cached).not.toBeNull();

--- a/assistant/src/__tests__/identity-routes.test.ts
+++ b/assistant/src/__tests__/identity-routes.test.ts
@@ -73,13 +73,6 @@ mock.module("../runtime/btw-sidechain.js", () => ({
   }),
 }));
 
-const assistantFeatureFlags: Record<string, boolean> = {};
-
-mock.module("../config/assistant-feature-flags.js", () => ({
-  isAssistantFeatureFlagEnabled: (key: string) =>
-    assistantFeatureFlags[key] ?? false,
-}));
-
 import {
   handleDetailedHealth,
   handleReadyz,
@@ -206,9 +199,6 @@ beforeEach(() => {
   sidechainCalls.length = 0;
   sidechainText = "";
   sidechainResultPromise = null;
-  for (const key of Object.keys(assistantFeatureFlags)) {
-    delete assistantFeatureFlags[key];
-  }
 });
 
 afterEach(() => {
@@ -575,53 +565,7 @@ describe("identity routes — createdAt selection", () => {
 });
 
 describe("identity routes — intro greetings", () => {
-  test("returns static fallback and does not generate when the dynamic greetings flag is off", async () => {
-    const workspaceDir = getWorkspaceDir();
-    writeFileSync(
-      join(workspaceDir, "IDENTITY.md"),
-      "# Identity\n\n- **Name:** Example Assistant\n",
-      "utf-8",
-    );
-    writeFileSync(
-      join(workspaceDir, "SOUL.md"),
-      "# Soul\n\nNo explicit greetings section here.\n",
-      "utf-8",
-    );
-
-    const route = ROUTES.find(
-      (candidate) => candidate.operationId === "identity_intro",
-    );
-    expect(route).toBeDefined();
-
-    const body = route!.handler({}) as {
-      greetings: string[];
-      text: string;
-      source: string;
-      refreshing: boolean;
-    };
-
-    expect(body).toEqual({
-      greetings: [
-        "What are we working on?",
-        "I'm here whenever you need me.",
-        "What's on your mind?",
-        "Ready when you are.",
-      ],
-      text: "What are we working on?",
-      source: "fallback",
-      refreshing: false,
-    });
-
-    await Promise.resolve();
-    await Promise.resolve();
-
-    expect(getConfiguredProviderCalls).toEqual([]);
-    expect(sidechainCalls).toEqual([]);
-  });
-
   test("returns fallback immediately, generates personalized greetings in the background, then reuses the cache", async () => {
-    assistantFeatureFlags["empty-state-dynamic-greetings"] = true;
-
     const workspaceDir = getWorkspaceDir();
     writeFileSync(
       join(workspaceDir, "IDENTITY.md"),
@@ -682,6 +626,9 @@ describe("identity routes — intro greetings", () => {
     expect(sidechainCalls).toHaveLength(1);
     expect(sidechainCalls[0]?.callSite).toBe("emptyStateGreeting");
     expect(sidechainCalls[0]?.tools).toEqual([]);
+    expect(sidechainCalls[0]?.content).toContain("Generate 5 short");
+    expect(sidechainCalls[0]?.content).toContain("Current time of day:");
+    expect(sidechainCalls[0]?.content).toMatch(/Current time of day: .+\.$/);
     expect(sidechainCalls[0]?.content).toContain("JSON array");
     expect(sidechainCalls[0]?.systemPrompt).toContain(
       "Identity sentinel: chartreuse compass.",
@@ -694,6 +641,8 @@ describe("identity routes — intro greetings", () => {
         "Charting the next useful thing?",
         "I brought the compass. Where to?",
         "Ready to make this lighter.",
+        "Morning momentum?",
+        "Five options, one good start.",
       ]),
       hadTextDeltas: false,
       response: { content: [] },
@@ -717,6 +666,8 @@ describe("identity routes — intro greetings", () => {
         "Charting the next useful thing?",
         "I brought the compass. Where to?",
         "Ready to make this lighter.",
+        "Morning momentum?",
+        "Five options, one good start.",
       ],
       text: "Charting the next useful thing?",
       source: "cache",

--- a/assistant/src/__tests__/identity-routes.test.ts
+++ b/assistant/src/__tests__/identity-routes.test.ts
@@ -598,7 +598,9 @@ describe("identity routes — intro greetings", () => {
     );
     expect(route).toBeDefined();
 
-    const body = route!.handler({}) as {
+    const body = route!.handler({
+      queryParams: { localHour: "8", localMinute: "15" },
+    }) as {
       greetings: string[];
       text: string;
       source: string;
@@ -627,8 +629,10 @@ describe("identity routes — intro greetings", () => {
     expect(sidechainCalls[0]?.callSite).toBe("emptyStateGreeting");
     expect(sidechainCalls[0]?.tools).toEqual([]);
     expect(sidechainCalls[0]?.content).toContain("Generate 5 short");
-    expect(sidechainCalls[0]?.content).toContain("Current time of day:");
-    expect(sidechainCalls[0]?.content).toMatch(/Current time of day: .+\.$/);
+    expect(sidechainCalls[0]?.content).not.toContain("Current time of day:");
+    expect(sidechainCalls[0]?.content).toMatch(
+      /Current user-local time: morning \(08:15\)\.$/,
+    );
     expect(sidechainCalls[0]?.content).toContain("JSON array");
     expect(sidechainCalls[0]?.systemPrompt).toContain(
       "Identity sentinel: chartreuse compass.",

--- a/assistant/src/__tests__/identity-routes.test.ts
+++ b/assistant/src/__tests__/identity-routes.test.ts
@@ -630,8 +630,11 @@ describe("identity routes — intro greetings", () => {
     expect(sidechainCalls[0]?.tools).toEqual([]);
     expect(sidechainCalls[0]?.content).toContain("Generate 5 short");
     expect(sidechainCalls[0]?.content).not.toContain("Current time of day:");
+    expect(sidechainCalls[0]?.content).toContain(
+      "do not mention the current time",
+    );
     expect(sidechainCalls[0]?.content).toMatch(
-      /Current user-local time: morning \(08:15\)\.$/,
+      /Current user-local time for subtle tone only: morning \(08:15\)\.$/,
     );
     expect(sidechainCalls[0]?.content).toContain("JSON array");
     expect(sidechainCalls[0]?.systemPrompt).toContain(
@@ -647,6 +650,7 @@ describe("identity routes — intro greetings", () => {
         "Ready to make this lighter.",
         "Morning momentum?",
         "Five options, one good start.",
+        "A useful next step?",
       ]),
       hadTextDeltas: false,
       response: { content: [] },
@@ -670,8 +674,8 @@ describe("identity routes — intro greetings", () => {
         "Charting the next useful thing?",
         "I brought the compass. Where to?",
         "Ready to make this lighter.",
-        "Morning momentum?",
         "Five options, one good start.",
+        "A useful next step?",
       ],
       text: "Charting the next useful thing?",
       source: "cache",

--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -20,6 +20,8 @@ SSE handlers built on `ReadableStream` shed slow subscribers when `controller.de
 
 GET handlers must be safe and side-effect-free — they must not enqueue background jobs, mutate database state, or trigger writes. If a feature needs server-initiated work in response to a client request, use an explicit POST endpoint or a push-based flow (SSE event → client refetch). See [RFC 9110 §9.2.1 — Safe Methods](https://httpwg.org/specs/rfc9110.html#safe.methods).
 
+Accepted exception: `GET /v1/identity/intro` may enqueue a bounded background refresh of the generated greeting cache when no fresh greeting cache exists. The handler must still return immediately with existing workspace/fallback copy, and the background prompt may only depend on static identity/soul context plus caller-supplied local hour/minute.
+
 ### Approvals (confirmations, secrets, trust rules)
 
 Approvals are **orthogonal to message sending**. The assistant asks for approval whenever it needs one — this is a separate concern from how a message enters the system.

--- a/assistant/src/runtime/routes/btw-routes.ts
+++ b/assistant/src/runtime/routes/btw-routes.ts
@@ -14,7 +14,6 @@
 
 import { z } from "zod";
 
-import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { getConfig } from "../../config/loader.js";
 import { getOrCreateConversation } from "../../daemon/conversation-store.js";
 import { readNowScratchpad } from "../../daemon/now-scratchpad.js";
@@ -34,9 +33,6 @@ const IDENTITY_INTRO_KEY = "identity-intro";
 
 /** Conversation key used by the client for empty-state greeting generation. */
 const GREETING_KEY = "greeting";
-const EMPTY_STATE_DYNAMIC_GREETINGS_FLAG =
-  "empty-state-dynamic-greetings" as const;
-const STATIC_EMPTY_STATE_GREETING = "What are we working on?";
 
 // ---------------------------------------------------------------------------
 // SSE helpers
@@ -67,16 +63,6 @@ async function handleBtw({
   }
 
   const trimmedContent = content.trim();
-
-  if (
-    conversationKey === GREETING_KEY &&
-    !isAssistantFeatureFlagEnabled(
-      EMPTY_STATE_DYNAMIC_GREETINGS_FLAG,
-      getConfig(),
-    )
-  ) {
-    return streamText(STATIC_EMPTY_STATE_GREETING);
-  }
 
   // ----- Cached identity intro fast-path -----
   if (conversationKey === IDENTITY_INTRO_KEY) {

--- a/assistant/src/runtime/routes/identity-intro-cache.ts
+++ b/assistant/src/runtime/routes/identity-intro-cache.ts
@@ -25,7 +25,7 @@ import { getWorkspacePromptPath } from "../../util/platform.js";
 // Constants
 // ---------------------------------------------------------------------------
 
-const CACHE_TTL_MS = 2 * 24 * 60 * 60 * 1000; // 2 days
+const CACHE_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
 
 const CHECKPOINT_KEY_GREETINGS = "identity:intro:greetings";
 const CHECKPOINT_KEY_TIMESTAMP = "identity:intro:cached_at";

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -35,7 +35,7 @@ import {
   readWorkspaceIdentityIntro,
   setCachedIntro,
 } from "./identity-intro-cache.js";
-import type { RouteDefinition } from "./types.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 interface MemoryInfo {
   currentMb: number;
@@ -439,7 +439,11 @@ function identityIntroResponse(
   };
 }
 
-function getIdentityIntro(): IdentityIntroResponse {
+function getIdentityIntro({
+  queryParams = {},
+}: RouteHandlerArgs = {}): IdentityIntroResponse {
+  const localTimeContext = buildLocalTimeContext(queryParams);
+
   // 1. User-defined greetings from SOUL.md `## Greetings`
   const workspaceGreetings = readWorkspaceGreetings();
   if (workspaceGreetings) {
@@ -458,7 +462,7 @@ function getIdentityIntro(): IdentityIntroResponse {
   if (identityIntro) {
     // Still trigger background generation so the next request gets
     // LLM-generated greetings instead of the static tagline.
-    const refreshing = triggerEmptyStateGreetingGeneration();
+    const refreshing = triggerEmptyStateGreetingGeneration(localTimeContext);
     return identityIntroResponse(
       [identityIntro, ...FALLBACK_GREETINGS],
       "workspace",
@@ -467,13 +471,50 @@ function getIdentityIntro(): IdentityIntroResponse {
   }
 
   // 4. Trigger fresh generation without blocking the empty-state UI.
-  const refreshing = triggerEmptyStateGreetingGeneration();
+  const refreshing = triggerEmptyStateGreetingGeneration(localTimeContext);
 
   // 5. Generic fallback only when generation is unavailable.
   return identityIntroResponse(FALLBACK_GREETINGS, "fallback", refreshing);
 }
 
-function triggerEmptyStateGreetingGeneration(): boolean {
+function buildLocalTimeContext(
+  queryParams: Record<string, string>,
+): string | null {
+  const rawHour = queryParams.localHour;
+  const rawMinute = queryParams.localMinute;
+  if (rawHour === undefined || rawMinute === undefined) {
+    return null;
+  }
+
+  const hour = Number(rawHour);
+  const minute = Number(rawMinute);
+  if (
+    !Number.isInteger(hour) ||
+    !Number.isInteger(minute) ||
+    hour < 0 ||
+    hour > 23 ||
+    minute < 0 ||
+    minute > 59
+  ) {
+    return null;
+  }
+
+  const period =
+    hour >= 5 && hour < 12
+      ? "morning"
+      : hour >= 12 && hour < 17
+        ? "afternoon"
+        : hour >= 17 && hour < 21
+          ? "evening"
+          : "late night";
+  const paddedHour = String(hour).padStart(2, "0");
+  const paddedMinute = String(minute).padStart(2, "0");
+  return `${period} (${paddedHour}:${paddedMinute})`;
+}
+
+function triggerEmptyStateGreetingGeneration(
+  localTimeContext: string | null,
+): boolean {
   if (greetingGenerationInFlight) {
     return true;
   }
@@ -488,7 +529,7 @@ function triggerEmptyStateGreetingGeneration(): boolean {
 
   greetingGenerationInFlight = new Promise<void>((resolve) => {
     queueMicrotask(() => {
-      void generateEmptyStateGreetings()
+      void generateEmptyStateGreetings(localTimeContext)
         .then((greetings) => {
           lastGreetingGenerationFailureAt = greetings === null ? Date.now() : 0;
         })
@@ -502,7 +543,9 @@ function triggerEmptyStateGreetingGeneration(): boolean {
   return true;
 }
 
-async function generateEmptyStateGreetings(): Promise<string[] | null> {
+async function generateEmptyStateGreetings(
+  localTimeContext: string | null,
+): Promise<string[] | null> {
   try {
     const provider = await getConfiguredProvider(EMPTY_STATE_GREETING_CALLSITE);
     if (!provider) {
@@ -517,14 +560,17 @@ async function generateEmptyStateGreetings(): Promise<string[] | null> {
       excludeBootstrap: true,
       excludeCustomPrefix: true,
     });
-    const timeOfDay = formatEmptyStateGreetingTimeOfDay(new Date());
+    const localTimeInstruction = localTimeContext
+      ? ` Current user-local time: ${localTimeContext}.`
+      : "";
     const result = await runBtwSidechain({
       content:
         `Generate ${GENERATED_GREETING_LIMIT} short first-person greeting options for the empty new-chat screen. ` +
         "Use the assistant identity, voice, and relationship guidance from IDENTITY.md and SOUL.md. " +
         "Each greeting should feel personal and inviting, not like a generic assistant introduction. " +
         "Return only a JSON array of strings. No markdown, keys, or explanation. " +
-        `Current time of day: ${timeOfDay}.`,
+        "Keep any time-sensitive phrasing appropriate for the user's local time." +
+        localTimeInstruction,
       provider,
       systemPrompt,
       messages: [],
@@ -548,23 +594,6 @@ async function generateEmptyStateGreetings(): Promise<string[] | null> {
     );
     return null;
   }
-}
-
-function formatEmptyStateGreetingTimeOfDay(date: Date): string {
-  const hour = date.getHours();
-  const period =
-    hour >= 5 && hour < 12
-      ? "morning"
-      : hour >= 12 && hour < 17
-        ? "afternoon"
-        : hour >= 17 && hour < 21
-          ? "evening"
-          : "late night";
-  const time = new Intl.DateTimeFormat(undefined, {
-    hour: "numeric",
-    minute: "2-digit",
-  }).format(date);
-  return `${period} (${time})`;
 }
 
 function parseGeneratedGreetings(text: string): string[] {
@@ -759,6 +788,20 @@ export const ROUTES: RouteDefinition[] = [
     description:
       "Returns greetings sourced from SOUL.md, the generated cache, or generic fallbacks while background generation refreshes the cache.",
     tags: ["identity"],
+    queryParams: [
+      {
+        name: "localHour",
+        schema: { type: "integer", minimum: 0, maximum: 23 },
+        description:
+          "Optional client-local hour of day used only when refreshing generated greetings.",
+      },
+      {
+        name: "localMinute",
+        schema: { type: "integer", minimum: 0, maximum: 59 },
+        description:
+          "Optional client-local minute used only when refreshing generated greetings.",
+      },
+    ],
     responseBody: z.object({
       greetings: z.array(z.string()),
       text: z.string(),

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -413,6 +413,8 @@ const GENERATED_GREETING_LIMIT = 5;
 const GREETING_GENERATION_TIMEOUT_MS = 10_000;
 const GREETING_GENERATION_FAILURE_COOLDOWN_MS = 60_000;
 const EMPTY_STATE_GREETING_CALLSITE = "emptyStateGreeting" as const;
+const EXPLICIT_TIME_OF_DAY_PATTERN =
+  /\b(?:morning|afternoon|evening|tonight|midnight|noon|sunrise|sunset)\b/i;
 
 type IdentityIntroSource = "workspace" | "cache" | "fallback";
 
@@ -561,7 +563,7 @@ async function generateEmptyStateGreetings(
       excludeCustomPrefix: true,
     });
     const localTimeInstruction = localTimeContext
-      ? ` Current user-local time: ${localTimeContext}.`
+      ? ` Current user-local time for subtle tone only: ${localTimeContext}.`
       : "";
     const result = await runBtwSidechain({
       content:
@@ -569,7 +571,8 @@ async function generateEmptyStateGreetings(
         "Use the assistant identity, voice, and relationship guidance from IDENTITY.md and SOUL.md. " +
         "Each greeting should feel personal and inviting, not like a generic assistant introduction. " +
         "Return only a JSON array of strings. No markdown, keys, or explanation. " +
-        "Keep any time-sensitive phrasing appropriate for the user's local time." +
+        "Generated greetings are cached for 4 hours, so do not mention the current time " +
+        "or use explicit time-of-day words like morning, afternoon, evening, or tonight." +
         localTimeInstruction,
       provider,
       systemPrompt,
@@ -636,6 +639,7 @@ function normalizeGeneratedGreetings(values: unknown[]): string[] {
       .replace(/^["'`]+|["'`]+$/g, "")
       .trim();
     if (!greeting) continue;
+    if (EXPLICIT_TIME_OF_DAY_PATTERN.test(greeting)) continue;
 
     const key = greeting.toLowerCase();
     if (seen.has(key)) continue;

--- a/assistant/src/runtime/routes/identity-routes.ts
+++ b/assistant/src/runtime/routes/identity-routes.ts
@@ -7,7 +7,6 @@ import { availableParallelism, cpus, totalmem } from "node:os";
 
 import { z } from "zod";
 
-import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
 import { getCpuLimit, getIsPlatform } from "../../config/env-registry.js";
 import { resolveCallSiteConfig } from "../../config/llm-resolver.js";
 import { getConfig } from "../../config/loader.js";
@@ -410,12 +409,10 @@ const FALLBACK_GREETINGS = [
   "Ready when you are.",
 ];
 
-const GENERATED_GREETING_LIMIT = 4;
+const GENERATED_GREETING_LIMIT = 5;
 const GREETING_GENERATION_TIMEOUT_MS = 10_000;
 const GREETING_GENERATION_FAILURE_COOLDOWN_MS = 60_000;
 const EMPTY_STATE_GREETING_CALLSITE = "emptyStateGreeting" as const;
-const EMPTY_STATE_DYNAMIC_GREETINGS_FLAG =
-  "empty-state-dynamic-greetings" as const;
 
 type IdentityIntroSource = "workspace" | "cache" | "fallback";
 
@@ -449,14 +446,7 @@ function getIdentityIntro(): IdentityIntroResponse {
     return identityIntroResponse(workspaceGreetings, "workspace");
   }
 
-  const config = getConfig();
-  if (
-    !isAssistantFeatureFlagEnabled(EMPTY_STATE_DYNAMIC_GREETINGS_FLAG, config)
-  ) {
-    return identityIntroResponse(FALLBACK_GREETINGS, "fallback");
-  }
-
-  // 2. Cached LLM-generated greetings (populated by background refresh)
+  // 2. Cached LLM-generated greetings
   const cached = getCachedIntro();
   if (cached) {
     return identityIntroResponse(cached.greetings, "cache");
@@ -527,12 +517,14 @@ async function generateEmptyStateGreetings(): Promise<string[] | null> {
       excludeBootstrap: true,
       excludeCustomPrefix: true,
     });
+    const timeOfDay = formatEmptyStateGreetingTimeOfDay(new Date());
     const result = await runBtwSidechain({
       content:
         `Generate ${GENERATED_GREETING_LIMIT} short first-person greeting options for the empty new-chat screen. ` +
         "Use the assistant identity, voice, and relationship guidance from IDENTITY.md and SOUL.md. " +
         "Each greeting should feel personal and inviting, not like a generic assistant introduction. " +
-        "Return only a JSON array of strings. No markdown, keys, or explanation.",
+        "Return only a JSON array of strings. No markdown, keys, or explanation. " +
+        `Current time of day: ${timeOfDay}.`,
       provider,
       systemPrompt,
       messages: [],
@@ -556,6 +548,23 @@ async function generateEmptyStateGreetings(): Promise<string[] | null> {
     );
     return null;
   }
+}
+
+function formatEmptyStateGreetingTimeOfDay(date: Date): string {
+  const hour = date.getHours();
+  const period =
+    hour >= 5 && hour < 12
+      ? "morning"
+      : hour >= 12 && hour < 17
+        ? "afternoon"
+        : hour >= 17 && hour < 21
+          ? "evening"
+          : "late night";
+  const time = new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(date);
+  return `${period} (${time})`;
 }
 
 function parseGeneratedGreetings(text: string): string[] {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -404,14 +404,6 @@
       "defaultEnabled": false
     },
     {
-      "id": "empty-state-dynamic-greetings",
-      "scope": "assistant",
-      "key": "empty-state-dynamic-greetings",
-      "label": "Dynamic Empty-State Greetings",
-      "description": "Enable the empty new-chat screen to refresh cached greeting options via the empty-state greeting LLM call site. When off, the assistant serves workspace-authored greetings or static fallbacks only.",
-      "defaultEnabled": false
-    },
-    {
       "id": "self-intro-greeting",
       "scope": "both",
       "key": "self-intro-greeting",


### PR DESCRIPTION
## Summary
- Remove the default-off feature flag gate for dynamic empty-state greetings.
- Refresh generated greeting caches every 4 hours instead of every 2 days.
- Generate up to 5 greeting options and include a time-of-day hint at the end of the generation prompt.
- Remove the empty-state dynamic greetings flag from the assistant/web registry copies.

## Merge order
- Merge this assistant PR first.
- Then merge the platform Terraform removal PR: https://github.com/vellum-ai/vellum-assistant-platform/pull/8367

## Testing
- `cd assistant && bun test src/__tests__/identity-routes.test.ts --grep "identity routes — intro greetings"`
- `cd assistant && bun test src/__tests__/identity-intro-cache.test.ts`
- `cd assistant && bun test src/__tests__/btw-routes.test.ts`
- `cd apps/web && bun test src/domains/chat/hooks/use-empty-state-greeting.test.tsx src/lib/feature-flags/feature-flag-catalog.test.ts`
- `cd assistant && bunx tsc --noEmit`
- `cd apps/web && bunx tsc --noEmit`