### PR TITLE
Collapse per-org selected-assistant map into one unified selection

### DIFF
--- a/apps/web/src/assistant/lifecycle-service.ts
+++ b/apps/web/src/assistant/lifecycle-service.ts
@@ -215,13 +215,7 @@ class AssistantLifecycleService {
       // stale selection and retry without an ID so the lifecycle
       // falls back to the default first-listed assistant.
       if (selectedId && !result.ok && result.status === 404) {
-        const store = useResolvedAssistantsStore.getState();
-        const byOrg = store.selectedPlatformAssistantByOrg;
-        for (const orgId of Object.keys(byOrg)) {
-          if (byOrg[orgId] === selectedId) {
-            store.setSelectedPlatformAssistant(orgId, null);
-          }
-        }
+        useResolvedAssistantsStore.getState().setSelectedAssistant(null);
         result = await this.inputs.queryClient.fetchQuery({
           queryKey: ASSISTANT_QUERY_KEY,
           queryFn: () => getAssistant(),

--- a/apps/web/src/assistant/select-platform-assistant.test.ts
+++ b/apps/web/src/assistant/select-platform-assistant.test.ts
@@ -1,57 +1,42 @@
 /**
  * Unit tests for `selectPlatformAssistant` — the single primitive both the
- * settings picker and (later) the tray use to switch the active platform
- * assistant. It records the per-org selection (the source the lifecycle
- * re-resolves from) and mirrors it into the lockfile for the tray/CLI/native.
+ * settings picker and (later) the tray use to switch the active assistant. It
+ * records the one selection (the source the lifecycle re-resolves from) and
+ * mirrors it into the lockfile for the tray/CLI/native.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-let orgId: string | null = "org-1";
-
-const setSelectedPlatformAssistantMock = mock((_orgId: string, _id: string | null) => {});
+const setSelectedAssistantMock = mock((_id: string | null) => {});
 const setActiveLockfileAssistantMock = mock(async (_id: string) => {});
 
 mock.module("@/lib/local-mode", () => ({
   setActiveLockfileAssistant: setActiveLockfileAssistantMock,
-  getTabLocalSelectedAssistantId: () => null,
   getActiveAssistant: () => undefined,
 }));
 mock.module("@/stores/resolved-assistants-store", () => ({
   assistantsValidForOrg: () => [],
   useResolvedAssistantsStore: {
     getState: () => ({
-      setSelectedPlatformAssistant: setSelectedPlatformAssistantMock,
+      setSelectedAssistant: setSelectedAssistantMock,
       assistants: [],
-      selectedPlatformAssistantByOrg: {},
+      selectedAssistantId: null,
+      assistantsHydrated: true,
     }),
-  },
-}));
-mock.module("@/stores/organization-store", () => ({
-  useOrganizationStore: {
-    getState: () => ({ currentOrganizationId: orgId }),
   },
 }));
 
 const { selectPlatformAssistant } = await import("./select-platform-assistant");
 
 beforeEach(() => {
-  orgId = "org-1";
-  setSelectedPlatformAssistantMock.mockClear();
+  setSelectedAssistantMock.mockClear();
   setActiveLockfileAssistantMock.mockClear();
 });
 
 describe("selectPlatformAssistant", () => {
-  test("records the per-org selection and mirrors it into the lockfile", async () => {
+  test("records the selection and mirrors it into the lockfile", async () => {
     await selectPlatformAssistant("ast-2");
-    expect(setSelectedPlatformAssistantMock).toHaveBeenCalledWith("org-1", "ast-2");
-    expect(setActiveLockfileAssistantMock).toHaveBeenCalledWith("ast-2");
-  });
-
-  test("skips the per-org write when there is no current org but still mirrors the lockfile", async () => {
-    orgId = null;
-    await selectPlatformAssistant("ast-2");
-    expect(setSelectedPlatformAssistantMock).not.toHaveBeenCalled();
+    expect(setSelectedAssistantMock).toHaveBeenCalledWith("ast-2");
     expect(setActiveLockfileAssistantMock).toHaveBeenCalledWith("ast-2");
   });
 });

--- a/apps/web/src/assistant/select-platform-assistant.ts
+++ b/apps/web/src/assistant/select-platform-assistant.ts
@@ -4,8 +4,9 @@ import { setSelectedAssistant } from "@/assistant/selection";
  * Switch the active platform assistant.
  *
  * Thin alias over the unified `setSelectedAssistant` write path so all writes
- * (per-org cache + lockfile `activeAssistant` mirror) go through one place. The
- * name/signature is kept for existing callers (e.g. `assistant-picker.tsx`).
+ * (the selection slice/key + lockfile `activeAssistant` mirror) go through one
+ * place. The name/signature is kept for existing callers (e.g.
+ * `assistant-picker.tsx`).
  */
 export async function selectPlatformAssistant(
   assistantId: string,

--- a/apps/web/src/assistant/selected-assistant-storage.test.ts
+++ b/apps/web/src/assistant/selected-assistant-storage.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  SELECTED_ASSISTANT_STORAGE_KEY,
+  clearSelectedAssistantId,
+  readSelectedAssistantId,
+  writeSelectedAssistantId,
+} from "@/assistant/selected-assistant-storage";
+
+afterEach(() => {
+  localStorage.removeItem(SELECTED_ASSISTANT_STORAGE_KEY);
+});
+
+describe("selected-assistant-storage", () => {
+  test("round-trips a written id", () => {
+    writeSelectedAssistantId("asst-1");
+    expect(localStorage.getItem(SELECTED_ASSISTANT_STORAGE_KEY)).toBe("asst-1");
+    expect(readSelectedAssistantId()).toBe("asst-1");
+  });
+
+  test("reads null when unset", () => {
+    expect(readSelectedAssistantId()).toBeNull();
+  });
+
+  test("reads null for an empty-string value", () => {
+    localStorage.setItem(SELECTED_ASSISTANT_STORAGE_KEY, "");
+    expect(readSelectedAssistantId()).toBeNull();
+  });
+
+  test("clear removes the key", () => {
+    writeSelectedAssistantId("asst-1");
+    clearSelectedAssistantId();
+    expect(readSelectedAssistantId()).toBeNull();
+    expect(localStorage.getItem(SELECTED_ASSISTANT_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/apps/web/src/assistant/selected-assistant-storage.ts
+++ b/apps/web/src/assistant/selected-assistant-storage.ts
@@ -1,0 +1,33 @@
+/**
+ * Raw persistence for the single selected-assistant id.
+ *
+ * Deliberately dependency-free (only `@/utils/local-settings`) so it can be
+ * imported by BOTH `resolved-assistants-store.ts` (the reactive owner) and
+ * `lib/local-mode.ts` (the lockfile-resolving getters) without an import
+ * cycle — the store already imports `local-mode`, so `local-mode` can't import
+ * the store. `setLocalSetting` fires the same-tab `vellum:pref-changed` event,
+ * so writes are observable cross-tab (native `storage`) and same-tab.
+ *
+ * The reactive `selectedAssistantId` slice in the store is the source of truth
+ * consumers subscribe to; this module is the raw key access both sides agree on.
+ */
+
+import {
+  getLocalSetting,
+  removeLocalSetting,
+  setLocalSetting,
+} from "@/utils/local-settings";
+
+export const SELECTED_ASSISTANT_STORAGE_KEY = "vellum:selectedAssistantId";
+
+export function readSelectedAssistantId(): string | null {
+  return getLocalSetting(SELECTED_ASSISTANT_STORAGE_KEY, "") || null;
+}
+
+export function writeSelectedAssistantId(id: string): void {
+  setLocalSetting(SELECTED_ASSISTANT_STORAGE_KEY, id);
+}
+
+export function clearSelectedAssistantId(): void {
+  removeLocalSetting(SELECTED_ASSISTANT_STORAGE_KEY);
+}

--- a/apps/web/src/assistant/selection.test.ts
+++ b/apps/web/src/assistant/selection.test.ts
@@ -1,8 +1,9 @@
 /**
  * Unit tests for `resolveSelectedAssistantId` — the unified read path shared by
- * platform and local selection. Covers the resolution order: valid per-org
- * cache hit → drop wrong-org → lockfile activeAssistant → first valid → unknown
- * id pass-through.
+ * platform and local selection. There is ONE selection; the org is a read-time
+ * filter. Covers the resolution order: valid selected id → drop wrong-org →
+ * lockfile activeAssistant → first valid, plus the hydration-gated pass-through
+ * for an unknown id.
  *
  * bun's `mock.module` is process-global, so this file must run on its own.
  */
@@ -18,23 +19,19 @@ const ORG_B = "org-b";
 
 // Mutable fixtures the mocks read so each test can stage its own world.
 let assistants: ResolvedAssistant[] = [];
-let selectedPlatformAssistantByOrg: Record<string, string> = {};
-let tabLocalId: string | null = null;
+let selectedAssistantId: string | null = null;
+let assistantsHydrated = true;
 let activeLocal: LockfileAssistant | undefined;
 
 mock.module("@/stores/resolved-assistants-store", () => ({
   assistantsValidForOrg,
   useResolvedAssistantsStore: {
-    getState: () => ({ assistants, selectedPlatformAssistantByOrg }),
+    getState: () => ({ assistants, selectedAssistantId, assistantsHydrated }),
   },
 }));
 mock.module("@/lib/local-mode", () => ({
-  getTabLocalSelectedAssistantId: () => tabLocalId,
   getActiveAssistant: () => activeLocal,
   setActiveLockfileAssistant: async () => {},
-}));
-mock.module("@/stores/organization-store", () => ({
-  useOrganizationStore: { getState: () => ({ currentOrganizationId: ORG_A }) },
 }));
 
 const { resolveSelectedAssistantId } = await import("./selection");
@@ -57,60 +54,63 @@ function lockfileAssistant(assistantId: string): LockfileAssistant {
 
 beforeEach(() => {
   assistants = [];
-  selectedPlatformAssistantByOrg = {};
-  tabLocalId = null;
+  selectedAssistantId = null;
+  assistantsHydrated = true;
   activeLocal = undefined;
 });
 
 describe("resolveSelectedAssistantId", () => {
-  test("valid cached per-org selection passes through", () => {
+  test("valid selected id passes through", () => {
     assistants = [platformAssistant("asst-1", ORG_A)];
-    selectedPlatformAssistantByOrg = { [ORG_A]: "asst-1" };
+    selectedAssistantId = "asst-1";
     expect(resolveSelectedAssistantId(ORG_A)).toBe("asst-1");
   });
 
-  test("wrong-org cached selection is dropped and falls back", () => {
+  test("wrong-org selection is dropped and falls back", () => {
     // asst-b is owned by ORG_B; asst-a is the only valid one for ORG_A.
     assistants = [
       platformAssistant("asst-b", ORG_B),
       platformAssistant("asst-a", ORG_A),
     ];
-    selectedPlatformAssistantByOrg = { [ORG_A]: "asst-b" };
+    selectedAssistantId = "asst-b";
     expect(resolveSelectedAssistantId(ORG_A)).toBe("asst-a");
   });
 
-  test("empty cache falls back to lockfile activeAssistant when valid", () => {
+  test("empty selection falls back to lockfile activeAssistant when valid", () => {
     assistants = [platformAssistant("asst-1", ORG_A)];
     activeLocal = lockfileAssistant("asst-1");
     expect(resolveSelectedAssistantId(ORG_A)).toBe("asst-1");
   });
 
-  test("empty cache + stale active falls back to first valid assistant", () => {
+  test("empty selection + stale active falls back to first valid assistant", () => {
     assistants = [platformAssistant("asst-1", ORG_A)];
     // active id no longer resolves to a valid entry for this org.
     activeLocal = lockfileAssistant("asst-stale");
     expect(resolveSelectedAssistantId(ORG_A)).toBe("asst-1");
   });
 
-  test("unknown PER-ORG candidate passes through (404 net clears that store)", () => {
-    assistants = [platformAssistant("asst-1", ORG_A)];
-    selectedPlatformAssistantByOrg = { [ORG_A]: "asst-unknown" };
+  test("unknown selected id passes through while NOT hydrated (pre-load)", () => {
+    // The list may simply not have arrived yet, so don't drop the selection.
+    assistantsHydrated = false;
+    assistants = [];
+    selectedAssistantId = "asst-unknown";
     expect(resolveSelectedAssistantId(ORG_A)).toBe("asst-unknown");
   });
 
-  test("an unknown TAB-LOCAL candidate is NOT passed through", () => {
-    // Regression: the 404 net only clears selectedPlatformAssistantByOrg, not
-    // the tab-local key, so a stale tab-local id must fall to a valid one
-    // rather than loop on the platform retrieve endpoint.
+  test("unknown selected id is a ghost once hydrated and falls through", () => {
+    // Regression for the ghost bug: a hydrated list that doesn't contain the
+    // selection means it's genuinely gone — fall through, never return it.
+    assistantsHydrated = true;
     assistants = [platformAssistant("asst-1", ORG_A)];
-    tabLocalId = "asst-stale-tab";
+    selectedAssistantId = "asst-unknown";
     expect(resolveSelectedAssistantId(ORG_A)).toBe("asst-1");
   });
 
-  test("a tab-local pick is used when it resolves to a valid assistant", () => {
-    assistants = [platformAssistant("asst-1", ORG_A)];
-    tabLocalId = "asst-1";
-    expect(resolveSelectedAssistantId(ORG_A)).toBe("asst-1");
+  test("hydrated unknown selection with no valid assistants resolves to null", () => {
+    assistantsHydrated = true;
+    assistants = [];
+    selectedAssistantId = "asst-unknown";
+    expect(resolveSelectedAssistantId(ORG_A)).toBeNull();
   });
 
   test("a stale lockfile active with no resolved entry is NOT passed through", () => {

--- a/apps/web/src/assistant/selection.ts
+++ b/apps/web/src/assistant/selection.ts
@@ -2,63 +2,51 @@
  * The single read/write path for the selected assistant, shared by platform
  * and local flows so the two stop diverging.
  *
- * Read: `resolveSelectedAssistantId` resolves a per-org cache hit (or a
- * tab-local pick) down to a valid id for the active org, falling back to the
- * lockfile `activeAssistant` and finally the first valid assistant.
+ * Read: `resolveSelectedAssistantId` validates the one selected id for the
+ * active org, falling back to the lockfile `activeAssistant` and finally the
+ * first valid assistant.
  *
- * Write: `setSelectedAssistant` records the per-org cache selection AND mirrors
- * it into the lockfile `activeAssistant`, so the macOS tray, the CLI, and the
- * native client agree.
+ * Write: `setSelectedAssistant` records the selection AND mirrors it into the
+ * lockfile `activeAssistant`, so the macOS tray, the CLI, and the native
+ * client agree.
  */
 
 import {
   getActiveAssistant,
-  getTabLocalSelectedAssistantId,
   setActiveLockfileAssistant,
 } from "@/lib/local-mode";
 import {
   assistantsValidForOrg,
   useResolvedAssistantsStore,
 } from "@/stores/resolved-assistants-store";
-import { useOrganizationStore } from "@/stores/organization-store";
 
 /**
- * Resolve the selected assistant id for the active org.
+ * Resolve the selected assistant id for the active org. There is one selection;
+ * the org is only a read-time filter.
  *
  * Order:
- *   1. Candidate from the cache — the per-org platform selection, or the raw
- *      tab-local pick. NOT the lockfile `activeAssistant`: that is only reached
- *      via the validated fallback (step 3), so a stale active id can't slip
- *      through the unknown-id pass-through and 404-loop forever.
- *   2. Keep the candidate only if it is valid for the org. An unknown id (no
- *      resolved entry yet) passes through unchanged — the lifecycle 404 net
- *      covers ids the client can't see.
- *   3. Else the lockfile `activeAssistant`, if valid for the org.
- *   4. Else the first valid assistant for the org, or null.
+ *   1. The selected id, if valid for the org. An UNKNOWN id (no resolved entry)
+ *      passes through only until the list is hydrated — pre-load the list may
+ *      simply not have arrived yet. Once hydrated an unknown id is a ghost and
+ *      falls through (the store also reconciles it away on lockfile load).
+ *   2. Else the lockfile `activeAssistant`, if valid for the org.
+ *   3. Else the first valid assistant for the org, or null.
  */
 export function resolveSelectedAssistantId(
   activeOrgId: string | null,
 ): string | null {
-  const { assistants, selectedPlatformAssistantByOrg } =
+  const { assistants, selectedAssistantId, assistantsHydrated } =
     useResolvedAssistantsStore.getState();
   const valid = assistantsValidForOrg(assistants, activeOrgId);
   const isValid = (id: string): boolean => valid.some((a) => a.id === id);
 
-  // Per-org platform selection: an unknown id passes through — the lifecycle
-  // 404 net clears `selectedPlatformAssistantByOrg`, so a stale one self-heals.
-  const perOrg = activeOrgId
-    ? (selectedPlatformAssistantByOrg[activeOrgId] ?? null)
-    : null;
-  if (perOrg !== null) {
-    const known = assistants.some((a) => a.id === perOrg);
-    if (!known || isValid(perOrg)) return perOrg;
+  if (selectedAssistantId !== null) {
+    const known = assistants.some((a) => a.id === selectedAssistantId);
+    if (isValid(selectedAssistantId)) return selectedAssistantId;
+    // Unknown id: pass through only pre-hydration. Once the list is
+    // authoritative, an id absent from it is a ghost — fall through.
+    if (!known && !assistantsHydrated) return selectedAssistantId;
   }
-
-  // Tab-local pick: only when it resolves to a VALID assistant. No unknown
-  // pass-through here — the 404 net doesn't clear the tab-local key, so a stale
-  // id would loop (reconcileSelectedAssistant clears it on lockfile commit).
-  const tabLocal = getTabLocalSelectedAssistantId();
-  if (tabLocal !== null && isValid(tabLocal)) return tabLocal;
 
   // Lockfile active, then first valid — both validated.
   const active = getActiveAssistant()?.assistantId ?? null;
@@ -69,13 +57,10 @@ export function resolveSelectedAssistantId(
 
 /**
  * The single write path for switching the selected assistant. Records the
- * per-org cache selection and mirrors it into the lockfile `activeAssistant`
- * (a no-op in the browser, where there is no lockfile host).
+ * selection (reactive slice + persisted key) and mirrors it into the lockfile
+ * `activeAssistant` (a no-op in the browser, where there is no lockfile host).
  */
 export async function setSelectedAssistant(id: string): Promise<void> {
-  const orgId = useOrganizationStore.getState().currentOrganizationId;
-  if (orgId) {
-    useResolvedAssistantsStore.getState().setSelectedPlatformAssistant(orgId, id);
-  }
+  useResolvedAssistantsStore.getState().setSelectedAssistant(id);
   await setActiveLockfileAssistant(id);
 }

--- a/apps/web/src/assistant/use-lifecycle.ts
+++ b/apps/web/src/assistant/use-lifecycle.ts
@@ -55,13 +55,13 @@ export function useAssistantLifecycle({
   // Which platform assistant the user has selected, gated by the
   // multi-platform-assistant flag. When the flag is off this stays null,
   // so the resolution falls back to the default first-listed assistant —
-  // identical to the pre-multi-assistant behavior. Subscribe to the cache
+  // identical to the pre-multi-assistant behavior. Subscribe to the selection
   // and resolved list so the hook re-renders when either changes, then
-  // resolve through the unified resolver (per-org cache → validate for org
+  // resolve through the unified resolver (selected id → validate for org
   // → lockfile activeAssistant → first valid).
   const multiAssistantEnabled =
     useClientFeatureFlagStore.use.multiPlatformAssistant();
-  useResolvedAssistantsStore.use.selectedPlatformAssistantByOrg();
+  useResolvedAssistantsStore.use.selectedAssistantId();
   // Subscribe so the hook re-renders (and the lockfile-local check below
   // re-evaluates) when the resolved list / lockfile change.
   useResolvedAssistantsStore.use.assistants();
@@ -73,8 +73,7 @@ export function useAssistantLifecycle({
   // they're gateway-based, never registered on the platform, so getAssistant(id)
   // 404s. Managed AND platform self-hosted (API `is_local`) assistants ARE valid
   // there — the lifecycle's projectSelfHosted handles the self-hosted response —
-  // and unknown ids (only ever the per-org platform cache) pass through for the
-  // 404 net.
+  // and a pre-hydration unknown id passes through for the 404 net.
   const selectedPlatformAssistantId =
     resolvedSelectionId &&
     !getLocalAssistants().some((a) => a.assistantId === resolvedSelectionId)

--- a/apps/web/src/components/command-palette/command-palette-window-page.test.tsx
+++ b/apps/web/src/components/command-palette/command-palette-window-page.test.tsx
@@ -16,7 +16,8 @@ const resolvedRef = {
     },
   ],
   activeAssistantId: "assistant-1" as string | null,
-  selectedPlatformAssistantByOrg: {} as Record<string, string>,
+  selectedAssistantId: null as string | null,
+  assistantsHydrated: true,
 };
 const orgRef = {
   currentOrganizationId: "org-1" as string | null,
@@ -55,14 +56,12 @@ mock.module("@/hooks/conversation-queries", () => ({
 const localSelectedRef = {
   value: null as { assistantId: string; name?: string } | null,
 };
-const tabLocalSelectedRef = { value: null as string | null };
 mock.module("@/lib/local-mode", () => ({
   getSelectedAssistant: () => localSelectedRef.value,
   getActiveAssistant: () =>
     resolvedRef.activeAssistantId
       ? { assistantId: resolvedRef.activeAssistantId }
       : undefined,
-  getTabLocalSelectedAssistantId: () => tabLocalSelectedRef.value,
   setActiveLockfileAssistant: async () => undefined,
 }));
 
@@ -104,12 +103,12 @@ mock.module("@/stores/resolved-assistants-store", () => {
   useResolvedAssistantsStore.use = {
     assistants: () => resolvedRef.assistants,
     activeAssistantId: () => resolvedRef.activeAssistantId,
-    selectedPlatformAssistantByOrg: () =>
-      resolvedRef.selectedPlatformAssistantByOrg,
+    selectedAssistantId: () => resolvedRef.selectedAssistantId,
   };
   useResolvedAssistantsStore.getState = () => ({
     assistants: resolvedRef.assistants,
-    selectedPlatformAssistantByOrg: resolvedRef.selectedPlatformAssistantByOrg,
+    selectedAssistantId: resolvedRef.selectedAssistantId,
+    assistantsHydrated: resolvedRef.assistantsHydrated,
   });
   return {
     useResolvedAssistantsStore,
@@ -165,7 +164,8 @@ beforeEach(() => {
     },
   ];
   resolvedRef.activeAssistantId = "assistant-1";
-  resolvedRef.selectedPlatformAssistantByOrg = {};
+  resolvedRef.selectedAssistantId = null;
+  resolvedRef.assistantsHydrated = true;
   orgRef.currentOrganizationId = "org-1";
   localSelectedRef.value = null;
 
@@ -210,7 +210,7 @@ describe("CommandPaletteWindowPage", () => {
       },
     ];
     resolvedRef.activeAssistantId = null;
-    resolvedRef.selectedPlatformAssistantByOrg = { "org-1": "assistant-2" };
+    resolvedRef.selectedAssistantId = "assistant-2";
 
     render(<CommandPaletteWindowPage />);
 

--- a/apps/web/src/components/command-palette/command-palette-window-page.tsx
+++ b/apps/web/src/components/command-palette/command-palette-window-page.tsx
@@ -86,17 +86,17 @@ export function CommandPaletteWindowPage() {
 
   const assistants = useResolvedAssistantsStore.use.assistants();
   const activeAssistantId = useResolvedAssistantsStore.use.activeAssistantId();
-  const selectedPlatformAssistantByOrg =
-    useResolvedAssistantsStore.use.selectedPlatformAssistantByOrg();
+  const selectedAssistantId =
+    useResolvedAssistantsStore.use.selectedAssistantId();
   const currentOrganizationId =
     useOrganizationStore.use.currentOrganizationId();
   const multiAssistantEnabled =
     useClientFeatureFlagStore.use.multiPlatformAssistant();
-  // Mirror use-lifecycle's gating: only resolve the per-org cache when the
+  // Mirror use-lifecycle's gating: only resolve the selection when the
   // multi-assistant flag is on; otherwise track the lifecycle's active id, so
-  // the palette never binds to a stale cached selection the lifecycle ignored.
-  // The resolver reads selectedPlatformAssistantByOrg via getState() (non-
-  // reactive), so that slice stays in the dep array as the recompute signal.
+  // the palette never binds to a stale selection the lifecycle ignored. The
+  // resolver reads selectedAssistantId via getState() (non-reactive), so that
+  // slice stays in the dep array as the recompute signal.
   const selectedAssistant = useMemo(
     () => {
       const selectedId =
@@ -113,7 +113,7 @@ export function CommandPaletteWindowPage() {
       activeAssistantId,
       assistants,
       currentOrganizationId,
-      selectedPlatformAssistantByOrg,
+      selectedAssistantId,
     ],
   );
   const assistantId = selectedAssistant?.id ?? null;

--- a/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -207,7 +207,6 @@ mock.module("@/lib/local-mode", () => ({
   getPlatformRuntimeUrl: () => "https://platform.vellum.ai",
   getSelectedAssistant: () => undefined,
   loadLockfile: async () => ({ assistants: [], activeAssistant: null }),
-  setSelectedAssistantId: () => {},
   setActiveLockfileAssistant: async () => {},
   saveLockfileAssistant: async () => {},
   primeLocalGatewayConnection: async () => {},
@@ -227,13 +226,16 @@ mock.module("@/stores/resolved-assistants-store", () => ({
     getState: () => ({
       assistants: [],
       activeAssistantId: null,
+      selectedAssistantId: null,
+      assistantsHydrated: true,
       upsertFromApi: () => {},
       setActiveAssistantId: () => {},
+      setSelectedAssistant: () => {},
     }),
     use: {
       assistants: () => [],
       activeAssistantId: () => null,
-      selectedPlatformAssistantByOrg: () => ({}),
+      selectedAssistantId: () => null,
     },
   },
 }));

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -19,7 +19,7 @@ import {
     writeSelectedVersion,
 } from "@/domains/onboarding/prefs";
 import { applyPendingProviderKey } from "@/domains/onboarding/provider-key";
-import { getLocalGatewayUrl, getPlatformRuntimeUrl, isLocalMode, loadLockfile, primeLocalGatewayConnection, saveLockfileAssistant, setSelectedAssistantId } from "@/lib/local-mode";
+import { getLocalGatewayUrl, getPlatformRuntimeUrl, isLocalMode, loadLockfile, primeLocalGatewayConnection, saveLockfileAssistant } from "@/lib/local-mode";
 import { clearGatewayToken } from "@/lib/auth/gateway-session";
 import { avatarQueryKey } from "@/lib/sync/query-tags";
 import { resolveNavigation } from "@/lib/navigation/navigation-resolver";
@@ -304,7 +304,9 @@ export function HatchingScreen() {
           }
           await loadLockfile();
           if (result.assistantId) {
-            setSelectedAssistantId(result.assistantId);
+            useResolvedAssistantsStore
+              .getState()
+              .setSelectedAssistant(result.assistantId);
           }
 
           // Wait for the gateway + daemon to be fully ready before proceeding.

--- a/apps/web/src/lib/auth/session-cleanup.test.ts
+++ b/apps/web/src/lib/auth/session-cleanup.test.ts
@@ -27,7 +27,7 @@ describe("clearUserScopedStorage", () => {
     localStorage.setItem("vellum:lastViewedConversation:asst-1", "conv-1");
     localStorage.setItem("vellum:sidebar-open-categories:asst-1", "{}");
     localStorage.setItem("vellum:sidebar-open-custom-groups:asst-1", "{}");
-    localStorage.setItem("vellum:currentAssistantId:org-1", "asst-1");
+    localStorage.setItem("vellum:selectedAssistantId", "asst-1");
     localStorage.setItem("vellum:nudge-prefs", "{}");
     localStorage.setItem("vellum:chatDrafts:asst-1", '{"text":"hi"}');
     localStorage.setItem("vellum:ctxwindow:asst-1", "4096");

--- a/apps/web/src/lib/local-mode.test.ts
+++ b/apps/web/src/lib/local-mode.test.ts
@@ -26,14 +26,17 @@ import {
   isLocalAssistant,
   isPlatformAssistant,
   reconcileSelectedAssistant,
-  setSelectedAssistantId,
   syncPlatformAssistantsToLockfile,
 } from "@/lib/local-mode";
+import { SELECTED_ASSISTANT_STORAGE_KEY } from "@/assistant/selected-assistant-storage";
 import type { Lockfile, LockfileAssistant } from "@/runtime/local-mode-host";
 import { useLockfileStore } from "@/stores/lockfile-store";
 
 const LOCKFILE_STORAGE_KEY = "vellum:local:lockfile";
-const SELECTED_ASSISTANT_STORAGE_KEY = "vellum:local:selectedAssistantId";
+
+function setSelected(id: string): void {
+  localStorage.setItem(SELECTED_ASSISTANT_STORAGE_KEY, id);
+}
 
 const localA: LockfileAssistant = {
   assistantId: "local-a",
@@ -138,7 +141,7 @@ describe("getActiveAssistant", () => {
 describe("reconcileSelectedAssistant", () => {
   test("clears a stale selection whose id is absent from the lockfile", () => {
     setLockfile({ assistants: [localA], activeAssistant: "local-a" });
-    setSelectedAssistantId("local-b");
+    setSelected("local-b");
 
     reconcileSelectedAssistant();
 
@@ -150,7 +153,7 @@ describe("reconcileSelectedAssistant", () => {
 
   test("preserves a selection that is still present in the lockfile", () => {
     setLockfile({ assistants: [localA, localB], activeAssistant: "local-a" });
-    setSelectedAssistantId("local-b");
+    setSelected("local-b");
 
     reconcileSelectedAssistant();
 
@@ -172,7 +175,7 @@ describe("reconcileSelectedAssistant", () => {
     // No cached lockfile and nothing persisted → getLockfile() hits its empty
     // fallback (setCachedLockfile), which must NOT reconcile. Otherwise a boot/
     // read failure would wrongly drop a still-valid selection.
-    setSelectedAssistantId("local-a");
+    setSelected("local-a");
 
     getLockfile();
 

--- a/apps/web/src/lib/local-mode.ts
+++ b/apps/web/src/lib/local-mode.ts
@@ -1,8 +1,8 @@
+import { getLocalSetting, setLocalSetting } from "@/utils/local-settings";
 import {
-  getLocalSetting,
-  removeLocalSetting,
-  setLocalSetting,
-} from "@/utils/local-settings";
+  clearSelectedAssistantId,
+  readSelectedAssistantId,
+} from "@/assistant/selected-assistant-storage";
 import {
   clearGatewayToken,
   ensureGatewayToken,
@@ -56,7 +56,6 @@ const setCachedLockfile = (data: Lockfile): void =>
 const EMPTY_LOCKFILE: Lockfile = { assistants: [], activeAssistant: null };
 
 const LOCKFILE_STORAGE_KEY = "vellum:local:lockfile";
-const SELECTED_ASSISTANT_STORAGE_KEY = "vellum:local:selectedAssistantId";
 
 export function getPlatformRuntimeUrl(): string {
   const injected = (
@@ -233,7 +232,9 @@ export async function retireLocalAssistant(
 ): Promise<LocalRetireResult> {
   const result = await retireLocalAssistantHost(assistantId);
   if (result.ok) {
-    clearSelectedAssistant();
+    // Clear the raw key directly (no store import here — that would cycle); the
+    // reactive slice reconciles via the `loadLockfile` below → `setFromLockfile`.
+    clearSelectedAssistantId();
     clearGatewayToken();
     setSelfHostedConnection(null);
     await loadLockfile();
@@ -287,7 +288,7 @@ export function getActiveAssistant(): LockfileAssistant | undefined {
 }
 
 export function getSelectedAssistant(): LockfileAssistant | undefined {
-  const selectedId = getLocalSetting(SELECTED_ASSISTANT_STORAGE_KEY, "");
+  const selectedId = readSelectedAssistantId();
   if (selectedId) {
     const found = getLockfile().assistants.find(
       (a) => a.assistantId === selectedId,
@@ -298,36 +299,19 @@ export function getSelectedAssistant(): LockfileAssistant | undefined {
 }
 
 /**
- * The raw tab-local selection id, or null — without the `activeAssistant`
- * fallback that `getSelectedAssistant` folds in. Callers that resolve the
- * lockfile active through their own validation must use this so a stale active
- * id isn't mistaken for a deliberate tab pick.
- */
-export function getTabLocalSelectedAssistantId(): string | null {
-  return getLocalSetting(SELECTED_ASSISTANT_STORAGE_KEY, "") || null;
-}
-
-export function setSelectedAssistantId(id: string): void {
-  setLocalSetting(SELECTED_ASSISTANT_STORAGE_KEY, id);
-}
-
-export function clearSelectedAssistant(): void {
-  removeLocalSetting(SELECTED_ASSISTANT_STORAGE_KEY);
-}
-
-/**
- * Reconcile the tab-local selection cache against the lockfile registry: if the
- * selected id no longer names a lockfile entry, clear it so `getSelectedAssistant`
- * falls back to `getActiveAssistant`. No-op when there is no tab-local selection —
- * resolution is left to `getActiveAssistant`.
+ * Reconcile the selection key against the lockfile registry: if the selected id
+ * no longer names a lockfile entry, clear it so `getSelectedAssistant` falls
+ * back to `getActiveAssistant`. The store's own reconcile (on `setFromLockfile`)
+ * covers the reactive slice; this keeps the raw key honest on the synchronous
+ * `commitLockfile` path, including the pre-React-mount gateway-auth boot.
  */
 export function reconcileSelectedAssistant(): void {
-  const selectedId = getLocalSetting(SELECTED_ASSISTANT_STORAGE_KEY, "");
+  const selectedId = readSelectedAssistantId();
   if (!selectedId) return;
   const present = getLockfile().assistants.some(
     (a) => a.assistantId === selectedId,
   );
-  if (!present) clearSelectedAssistant();
+  if (!present) clearSelectedAssistantId();
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/stores/auth-store.test.ts
+++ b/apps/web/src/stores/auth-store.test.ts
@@ -18,7 +18,8 @@ let mockIsGatewayAuth = false;
 let mockIsLocalMode = false;
 let mockPlatformAssistants: unknown[] = [];
 let mockPrimeError: Error | null = null;
-const setSelectedAssistantIdMock = mock((_id: string) => {});
+const setSelectedAssistantMock = mock((_id: string | null) => {});
+const setFromApiMock = mock((_assistants: unknown) => {});
 const primeLocalGatewayConnectionMock = mock(async () => {
   if (mockPrimeError) throw mockPrimeError;
 });
@@ -91,8 +92,6 @@ mock.module("@/lib/local-mode", () => ({
   isPlatformAssistant: (a: { cloud?: string }) => a.cloud === "vellum",
   getPlatformAssistants: () => mockPlatformAssistants,
   getLocalAssistants: () => [],
-  clearSelectedAssistant: () => {},
-  setSelectedAssistantId: setSelectedAssistantIdMock,
   primeLocalGatewayConnection: primeLocalGatewayConnectionMock,
   primeLocalGatewayConnectionWithRepair:
     primeLocalGatewayConnectionWithRepairMock,
@@ -141,6 +140,15 @@ mock.module("@/domains/onboarding/onboarding-store", () => ({
 
 mock.module("@/lib/auth/session-cleanup", () => ({
   clearUserScopedStorage: clearUserScopedStorageMock,
+}));
+
+mock.module("@/stores/resolved-assistants-store", () => ({
+  useResolvedAssistantsStore: {
+    getState: () => ({
+      setSelectedAssistant: setSelectedAssistantMock,
+      setFromApi: setFromApiMock,
+    }),
+  },
 }));
 
 mock.module("@/stores/organization-store", () => ({
@@ -197,7 +205,8 @@ beforeEach(() => {
   mockIsBiometricEnabled = false;
   mockBiometricToken = null;
   mockPrimeError = null;
-  setSelectedAssistantIdMock.mockClear();
+  setSelectedAssistantMock.mockClear();
+  setFromApiMock.mockClear();
   primeLocalGatewayConnectionMock.mockClear();
   primeLocalGatewayConnectionWithRepairMock.mockClear();
   restoreConsentForUserMock.mockClear();
@@ -501,7 +510,7 @@ describe("connectLocalAssistant", () => {
 
     await useAuthStore.getState().connectLocalAssistant("local-a");
 
-    expect(setSelectedAssistantIdMock).toHaveBeenCalledWith("local-a");
+    expect(setSelectedAssistantMock).toHaveBeenCalledWith("local-a");
     expect(primeLocalGatewayConnectionWithRepairMock).toHaveBeenCalledTimes(1);
     expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
     expect(useAuthStore.getState().user?.id).toBe("gateway-local");
@@ -518,7 +527,7 @@ describe("connectLocalAssistant", () => {
       useAuthStore.getState().connectLocalAssistant("local-a"),
     ).rejects.toThrow("Guardian token not found");
 
-    expect(setSelectedAssistantIdMock).toHaveBeenCalledWith("local-a");
+    expect(setSelectedAssistantMock).toHaveBeenCalledWith("local-a");
     expect(useAuthStore.getState().sessionStatus).not.toBe("authenticated");
   });
 });

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -38,8 +38,6 @@ import {
   isLocalMode,
   getPlatformAssistants,
   getLocalAssistants,
-  clearSelectedAssistant,
-  setSelectedAssistantId,
   primeLocalGatewayConnection,
   primeLocalGatewayConnectionWithRepair,
   syncPlatformAssistantsToLockfile,
@@ -485,14 +483,14 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
    * stays on the plain primitive so app launch never spawns daemon processes.
    */
   connectLocalAssistant: async (assistantId: string) => {
-    setSelectedAssistantId(assistantId);
+    useResolvedAssistantsStore.getState().setSelectedAssistant(assistantId);
     await primeLocalGatewayConnectionWithRepair();
     set(authenticatedLocalUser());
     probePlatformSessionIfReachable(set);
   },
 
   connectPlatformAssistant: async (assistantId: string) => {
-    setSelectedAssistantId(assistantId);
+    useResolvedAssistantsStore.getState().setSelectedAssistant(assistantId);
     const result = await getSession();
     if (!result.ok || !result.data.user) {
       throw new Error("Platform authentication required");
@@ -555,7 +553,7 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
 
   logout: async () => {
     if (isGatewayAuthMode()) {
-      clearSelectedAssistant();
+      useResolvedAssistantsStore.getState().setSelectedAssistant(null);
       clearGatewayToken();
       clearOrganization();
       clearUserScopedStorage();

--- a/apps/web/src/stores/resolved-assistants-store.test.ts
+++ b/apps/web/src/stores/resolved-assistants-store.test.ts
@@ -5,6 +5,7 @@ import {
   useResolvedAssistantsStore,
   type ResolvedAssistant,
 } from "@/stores/resolved-assistants-store";
+import { SELECTED_ASSISTANT_STORAGE_KEY } from "@/assistant/selected-assistant-storage";
 import type { Lockfile, LockfileAssistant } from "@/runtime/local-mode-host";
 
 // A platform entry is identified by `cloud === "vellum"` and carries an
@@ -24,7 +25,12 @@ const localAssistant: LockfileAssistant = {
 };
 
 beforeEach(() => {
-  useResolvedAssistantsStore.setState({ assistants: [] });
+  localStorage.removeItem(SELECTED_ASSISTANT_STORAGE_KEY);
+  useResolvedAssistantsStore.setState({
+    assistants: [],
+    selectedAssistantId: null,
+    assistantsHydrated: false,
+  });
 });
 
 describe("setFromLockfile", () => {
@@ -119,5 +125,61 @@ describe("assistantsValidForOrg", () => {
 
   it("drops cross-org platform entries", () => {
     expect(assistantsValidForOrg([otherOrg], "org-1")).toEqual([]);
+  });
+});
+
+describe("setSelectedAssistant", () => {
+  it("moves the reactive slice and the persisted key together", () => {
+    useResolvedAssistantsStore.getState().setSelectedAssistant("asst-1");
+    expect(useResolvedAssistantsStore.getState().selectedAssistantId).toBe(
+      "asst-1",
+    );
+    expect(localStorage.getItem(SELECTED_ASSISTANT_STORAGE_KEY)).toBe("asst-1");
+
+    useResolvedAssistantsStore.getState().setSelectedAssistant(null);
+    expect(useResolvedAssistantsStore.getState().selectedAssistantId).toBeNull();
+    expect(localStorage.getItem(SELECTED_ASSISTANT_STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe("selection reconcile on hydration", () => {
+  it("clears a selection absent from the lockfile (the ghost case)", () => {
+    useResolvedAssistantsStore.getState().setSelectedAssistant("asst-ghost");
+    useResolvedAssistantsStore.getState().setFromLockfile({
+      assistants: [localAssistant],
+      activeAssistant: null,
+    });
+    expect(useResolvedAssistantsStore.getState().selectedAssistantId).toBeNull();
+    expect(localStorage.getItem(SELECTED_ASSISTANT_STORAGE_KEY)).toBeNull();
+  });
+
+  it("preserves a selection still present in the lockfile", () => {
+    useResolvedAssistantsStore.getState().setSelectedAssistant("asst-local");
+    useResolvedAssistantsStore.getState().setFromLockfile({
+      assistants: [localAssistant],
+      activeAssistant: null,
+    });
+    expect(useResolvedAssistantsStore.getState().selectedAssistantId).toBe(
+      "asst-local",
+    );
+  });
+
+  it("does NOT clear a cross-org selection on the org-scoped API list", () => {
+    // setFromApi reflects only the active org's assistants; a selection for a
+    // different org must survive (it's filtered on read, never deleted here).
+    useResolvedAssistantsStore.getState().setSelectedAssistant("asst-other-org");
+    useResolvedAssistantsStore.getState().setFromApi([
+      {
+        id: "asst-active-org",
+        name: "Active",
+        created: "2026-01-01T00:00:00Z",
+        is_local: false,
+      } as Parameters<
+        ReturnType<typeof useResolvedAssistantsStore.getState>["setFromApi"]
+      >[0],
+    ]);
+    expect(useResolvedAssistantsStore.getState().selectedAssistantId).toBe(
+      "asst-other-org",
+    );
   });
 });

--- a/apps/web/src/stores/resolved-assistants-store.test.ts
+++ b/apps/web/src/stores/resolved-assistants-store.test.ts
@@ -167,17 +167,16 @@ describe("selection reconcile on hydration", () => {
   it("does NOT clear a cross-org selection on the org-scoped API list", () => {
     // setFromApi reflects only the active org's assistants; a selection for a
     // different org must survive (it's filtered on read, never deleted here).
+    const apiEntry = {
+      id: "asst-active-org",
+      name: "Active",
+      created: "2026-01-01T00:00:00Z",
+      is_local: false,
+    } as Parameters<
+      ReturnType<typeof useResolvedAssistantsStore.getState>["upsertFromApi"]
+    >[0];
     useResolvedAssistantsStore.getState().setSelectedAssistant("asst-other-org");
-    useResolvedAssistantsStore.getState().setFromApi([
-      {
-        id: "asst-active-org",
-        name: "Active",
-        created: "2026-01-01T00:00:00Z",
-        is_local: false,
-      } as Parameters<
-        ReturnType<typeof useResolvedAssistantsStore.getState>["setFromApi"]
-      >[0],
-    ]);
+    useResolvedAssistantsStore.getState().setFromApi([apiEntry]);
     expect(useResolvedAssistantsStore.getState().selectedAssistantId).toBe(
       "asst-other-org",
     );

--- a/apps/web/src/stores/resolved-assistants-store.ts
+++ b/apps/web/src/stores/resolved-assistants-store.ts
@@ -4,9 +4,10 @@
  *  1. **What assistants exist** — `assistants: ResolvedAssistant[]`
  *  2. **Which is active** — `activeAssistantId` (output of the lifecycle
  *     state machine, written exclusively by `lifecycle-service.ts`)
- *  3. **Which platform assistant the user selected** —
- *     `selectedPlatformAssistantByOrg` (per-org input to the lifecycle,
- *     persisted to localStorage)
+ *  3. **Which assistant the user selected** — `selectedAssistantId` (input to
+ *     the lifecycle, persisted to a single localStorage key). The active org is
+ *     a read-time *filter* (see `resolveSelectedAssistantId`), never a storage
+ *     key — there is one selection, validated for whichever org is active.
  *
  * Population:
  *  - Local mode: assistant list auto-syncs with the lockfile store via
@@ -29,6 +30,12 @@ import {
   isLocalAssistant,
   isPlatformAssistant,
 } from "@/lib/local-mode";
+import {
+  SELECTED_ASSISTANT_STORAGE_KEY,
+  clearSelectedAssistantId,
+  readSelectedAssistantId,
+  writeSelectedAssistantId,
+} from "@/assistant/selected-assistant-storage";
 import { useLockfileStore } from "@/stores/lockfile-store";
 import type { Lockfile } from "@/runtime/local-mode-host";
 import type { Assistant } from "@/generated/api/types.gen";
@@ -60,65 +67,20 @@ export function assistantsValidForOrg(
 }
 
 // ---------------------------------------------------------------------------
-// Per-org platform selection persistence (localStorage)
-// ---------------------------------------------------------------------------
-
-export const PLATFORM_ASSISTANT_STORAGE_PREFIX =
-  "vellum:currentAssistantId:";
-
-function storageKeyForOrg(orgId: string): string {
-  return `${PLATFORM_ASSISTANT_STORAGE_PREFIX}${orgId}`;
-}
-
-function readByOrgFromLocalStorage(): Record<string, string> {
-  if (typeof window === "undefined") return {};
-  const byOrg: Record<string, string> = {};
-  try {
-    for (let i = 0; i < window.localStorage.length; i++) {
-      const key = window.localStorage.key(i);
-      if (key && key.startsWith(PLATFORM_ASSISTANT_STORAGE_PREFIX)) {
-        const orgId = key.slice(PLATFORM_ASSISTANT_STORAGE_PREFIX.length);
-        const value = window.localStorage.getItem(key);
-        if (value != null) byOrg[orgId] = value;
-      }
-    }
-  } catch {
-    // ignore storage failures
-  }
-  return byOrg;
-}
-
-function persistByOrgToLocalStorage(byOrg: Record<string, string>): void {
-  if (typeof window === "undefined") return;
-  try {
-    for (const [orgId, id] of Object.entries(byOrg)) {
-      const key = storageKeyForOrg(orgId);
-      if (window.localStorage.getItem(key) !== id) {
-        window.localStorage.setItem(key, id);
-      }
-    }
-  } catch {
-    // ignore storage failures
-  }
-}
-
-function removeStoredAssistantId(orgId: string): void {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.removeItem(storageKeyForOrg(orgId));
-  } catch {
-    // ignore storage failures
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Store definition
 // ---------------------------------------------------------------------------
 
 interface ResolvedAssistantsState {
   assistants: ResolvedAssistant[];
   activeAssistantId: string | null;
-  selectedPlatformAssistantByOrg: Record<string, string>;
+  selectedAssistantId: string | null;
+  /**
+   * Whether the resolved list reflects at least one authoritative load
+   * (`setFromApi` / `setFromLockfile`). Until then an unknown selection is
+   * passed through on read (the list may simply not have loaded yet); once
+   * hydrated, an unknown id is a ghost and is reconciled away.
+   */
+  assistantsHydrated: boolean;
 }
 
 interface ResolvedAssistantsActions {
@@ -128,35 +90,42 @@ interface ResolvedAssistantsActions {
   remove: (assistantId: string) => void;
   clear: () => void;
   setActiveAssistantId: (assistantId: string | null) => void;
-  setSelectedPlatformAssistant: (orgId: string, id: string | null) => void;
+  setSelectedAssistant: (id: string | null) => void;
 }
 
 type ResolvedAssistantsStore = ResolvedAssistantsState &
   ResolvedAssistantsActions;
 
 const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
-  (set) => ({
+  (set, get) => ({
     assistants: [],
     activeAssistantId: null,
-    selectedPlatformAssistantByOrg: readByOrgFromLocalStorage(),
+    selectedAssistantId: readSelectedAssistantId(),
+    assistantsHydrated: false,
 
-    setFromLockfile: (lockfile) =>
-      set({
-        assistants: lockfile.assistants.map((a) => ({
-          id: a.assistantId,
-          name: a.name,
-          hatchedAt: a.hatchedAt,
-          isLocal: isLocalAssistant(a),
-          isPlatformHosted: isPlatformAssistant(a),
-          organizationId: a.organizationId,
-        })),
-      }),
+    setFromLockfile: (lockfile) => {
+      const assistants = lockfile.assistants.map((a) => ({
+        id: a.assistantId,
+        name: a.name,
+        hatchedAt: a.hatchedAt,
+        isLocal: isLocalAssistant(a),
+        isPlatformHosted: isPlatformAssistant(a),
+        organizationId: a.organizationId,
+      }));
+      set({ assistants, assistantsHydrated: true });
+      // The lockfile carries every org's entries, so an id absent from it is
+      // genuinely gone — safe to prune. (The API list is org-scoped, so
+      // `setFromApi` deliberately does NOT reconcile; a cross-org selection
+      // there is filtered out on read, not deleted.)
+      reconcileSelection(get, set);
+    },
 
     // The platform `Assistant` API carries no org field, so API-sourced
     // entries intentionally leave `organizationId` undefined (unlike
     // `setFromLockfile`). Don't "fix" this by inventing an org here.
     setFromApi: (assistants) =>
       set({
+        assistantsHydrated: true,
         assistants: assistants.map((a) => ({
           id: a.id,
           name: a.name,
@@ -196,23 +165,37 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
     setActiveAssistantId: (assistantId) =>
       set({ activeAssistantId: assistantId }),
 
-    setSelectedPlatformAssistant: (orgId, id) => {
+    // The single write path for the selected id: the reactive slice and the
+    // persisted key move together. All callers (selection.ts, connect/hatch
+    // flows, the lifecycle 404 net) go through here so same-tab consumers
+    // re-render and the key never drifts from the slice.
+    setSelectedAssistant: (id) => {
       if (id == null) {
-        removeStoredAssistantId(orgId);
+        clearSelectedAssistantId();
+      } else {
+        writeSelectedAssistantId(id);
       }
-      set((state) => {
-        const next = { ...state.selectedPlatformAssistantByOrg };
-        if (id == null) {
-          delete next[orgId];
-        } else {
-          next[orgId] = id;
-        }
-        persistByOrgToLocalStorage(next);
-        return { selectedPlatformAssistantByOrg: next };
-      });
+      set({ selectedAssistantId: id });
     },
   }),
 );
+
+/**
+ * Drop the selected id once it's provably a ghost: hydrated AND not present in
+ * the resolved list. Only `setFromLockfile` calls this (the lockfile is the
+ * cross-org universe); the org-scoped API list must not delete a valid
+ * cross-org selection.
+ */
+function reconcileSelection(
+  get: () => ResolvedAssistantsStore,
+  set: (partial: Partial<ResolvedAssistantsState>) => void,
+): void {
+  const { assistants, selectedAssistantId, assistantsHydrated } = get();
+  if (!assistantsHydrated || selectedAssistantId == null) return;
+  if (assistants.some((a) => a.id === selectedAssistantId)) return;
+  clearSelectedAssistantId();
+  set({ selectedAssistantId: null });
+}
 
 export const useResolvedAssistantsStore = createSelectors(
   useResolvedAssistantsStoreBase,
@@ -231,15 +214,14 @@ if (isLocalMode()) {
   });
 }
 
-// Cross-tab sync: pick up per-org selection changes from other tabs.
+// Cross-tab sync: pick up selection changes from other tabs. The native
+// `storage` event only fires in *other* tabs; same-tab writes update the slice
+// directly via `setSelectedAssistant`. `event.key === null` covers `clear()`.
 if (typeof window !== "undefined") {
   window.addEventListener("storage", (event) => {
-    if (
-      event.key === null ||
-      event.key.startsWith(PLATFORM_ASSISTANT_STORAGE_PREFIX)
-    ) {
+    if (event.key === null || event.key === SELECTED_ASSISTANT_STORAGE_KEY) {
       useResolvedAssistantsStoreBase.setState({
-        selectedPlatformAssistantByOrg: readByOrgFromLocalStorage(),
+        selectedAssistantId: readSelectedAssistantId(),
       });
     }
   });

--- a/apps/web/src/utils/storage-migration.test.ts
+++ b/apps/web/src/utils/storage-migration.test.ts
@@ -4,10 +4,12 @@ import { migrateKey, migratePrefix, migrateValue, removeKey, runStorageMigration
 
 beforeEach(() => {
   localStorage.clear();
+  sessionStorage.clear();
 });
 
 afterEach(() => {
   localStorage.clear();
+  sessionStorage.clear();
 });
 
 describe("removeKey", () => {
@@ -259,6 +261,20 @@ describe("runStorageMigrations", () => {
     expect(localStorage.getItem("vellum:currentAssistantId:org-1")).toBeNull();
     expect(localStorage.getItem("vellum:currentAssistantId:org-2")).toBeNull();
     expect(localStorage.getItem("vellum_current_assistant_id__org-1")).toBeNull();
+  });
+
+  test("collapse prefers the persisted active org's per-org selection", () => {
+    // Active org is org-2 even though org-1 sorts first; the active org's pick
+    // must win so a multi-org user keeps their current selection on upgrade.
+    sessionStorage.setItem("vellum_active_organization_id", "org-2");
+    localStorage.setItem("vellum:currentAssistantId:org-1", "asst-1");
+    localStorage.setItem("vellum:currentAssistantId:org-2", "asst-2");
+
+    runStorageMigrations();
+
+    expect(localStorage.getItem("vellum:selectedAssistantId")).toBe("asst-2");
+    expect(localStorage.getItem("vellum:currentAssistantId:org-1")).toBeNull();
+    expect(localStorage.getItem("vellum:currentAssistantId:org-2")).toBeNull();
   });
 
   test("collapse prefers the tab-local key and is idempotent", () => {

--- a/apps/web/src/utils/storage-migration.test.ts
+++ b/apps/web/src/utils/storage-migration.test.ts
@@ -227,7 +227,10 @@ describe("runStorageMigrations", () => {
     expect(localStorage.getItem("vellum:gw:expiresAt")).toBe("1700000000");
     expect(localStorage.getItem("vellum:gw:tokenSource")).toBe("/auth/token");
     expect(localStorage.getItem("vellum:local:lockfile")).toBe("{}");
-    expect(localStorage.getItem("vellum:local:selectedAssistantId")).toBe("asst-1");
+    // local:selectedAssistantId is canonicalized then collapsed into the single
+    // vellum:selectedAssistantId, so the intermediate key no longer survives.
+    expect(localStorage.getItem("vellum:selectedAssistantId")).toBe("asst-1");
+    expect(localStorage.getItem("vellum:local:selectedAssistantId")).toBeNull();
     expect(localStorage.getItem("gw:token")).toBeNull();
     expect(localStorage.getItem("local:lockfile")).toBeNull();
   });
@@ -243,15 +246,33 @@ describe("runStorageMigrations", () => {
     expect(localStorage.getItem("disk-pressure-warning-dismissed-asst-1")).toBeNull();
   });
 
-  test("migrates vellum_current_assistant_id__ prefix", () => {
-    localStorage.setItem("vellum_current_assistant_id__org-1", "asst-a");
+  test("collapses the legacy per-org assistant map into one key", () => {
+    // Canonicalized first (vellum_current_assistant_id__ → vellum:currentAssistantId:),
+    // then collapsed into the single vellum:selectedAssistantId. With no current
+    // org at migration time, the lexicographically-smallest org suffix wins.
     localStorage.setItem("vellum_current_assistant_id__org-2", "asst-b");
+    localStorage.setItem("vellum_current_assistant_id__org-1", "asst-a");
 
     runStorageMigrations();
 
-    expect(localStorage.getItem("vellum:currentAssistantId:org-1")).toBe("asst-a");
-    expect(localStorage.getItem("vellum:currentAssistantId:org-2")).toBe("asst-b");
+    expect(localStorage.getItem("vellum:selectedAssistantId")).toBe("asst-a");
+    expect(localStorage.getItem("vellum:currentAssistantId:org-1")).toBeNull();
+    expect(localStorage.getItem("vellum:currentAssistantId:org-2")).toBeNull();
     expect(localStorage.getItem("vellum_current_assistant_id__org-1")).toBeNull();
+  });
+
+  test("collapse prefers the tab-local key and is idempotent", () => {
+    localStorage.setItem("vellum:local:selectedAssistantId", "tab-local");
+    localStorage.setItem("vellum:currentAssistantId:org-1", "per-org");
+
+    runStorageMigrations();
+    expect(localStorage.getItem("vellum:selectedAssistantId")).toBe("tab-local");
+    expect(localStorage.getItem("vellum:local:selectedAssistantId")).toBeNull();
+    expect(localStorage.getItem("vellum:currentAssistantId:org-1")).toBeNull();
+
+    // Re-running leaves the collapsed value untouched and removes nothing new.
+    runStorageMigrations();
+    expect(localStorage.getItem("vellum:selectedAssistantId")).toBe("tab-local");
   });
 
   test("migrates vellumDebug key", () => {

--- a/apps/web/src/utils/storage-migration.ts
+++ b/apps/web/src/utils/storage-migration.ts
@@ -91,6 +91,59 @@ export function migratePrefix(oldPrefix: string, newPrefix: string): void {
 }
 
 /**
+ * Remove every key matching `prefix`. Snapshots keys first to avoid mutating
+ * during iteration. Caller is responsible for the try/catch.
+ */
+function removeAllWithPrefix(prefix: string): void {
+  const keys: string[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key && key.startsWith(prefix)) keys.push(key);
+  }
+  for (const key of keys) localStorage.removeItem(key);
+}
+
+/**
+ * Collapse the two legacy selection schemes — the tab-local
+ * `vellum:local:selectedAssistantId` and the per-org
+ * `vellum:currentAssistantId:<org>` map — into the single
+ * `vellum:selectedAssistantId` key.
+ *
+ * No "current org" exists at migration time (this runs synchronously before
+ * stores hydrate), so when only per-org entries exist the winner is the
+ * lexicographically-smallest org suffix — deterministic and idempotent. A
+ * non-ideal pick self-heals on read: `resolveSelectedAssistantId` validates the
+ * id against the active org and drops it if it doesn't belong. Idempotent via
+ * the target-exists short-circuit plus unconditional legacy removal.
+ */
+export function collapseSelectedAssistantKeys(): void {
+  if (typeof window === "undefined") return;
+  const target = "vellum:selectedAssistantId";
+  const tabLocalKey = "vellum:local:selectedAssistantId";
+  const perOrgPrefix = "vellum:currentAssistantId:";
+  try {
+    if (localStorage.getItem(target) === null) {
+      let candidate = localStorage.getItem(tabLocalKey);
+      if (candidate === null) {
+        let smallestKey: string | null = null;
+        for (let i = 0; i < localStorage.length; i++) {
+          const key = localStorage.key(i);
+          if (key && key.startsWith(perOrgPrefix)) {
+            if (smallestKey === null || key < smallestKey) smallestKey = key;
+          }
+        }
+        if (smallestKey !== null) candidate = localStorage.getItem(smallestKey);
+      }
+      if (candidate) localStorage.setItem(target, candidate);
+    }
+    localStorage.removeItem(tabLocalKey);
+    removeAllWithPrefix(perOrgPrefix);
+  } catch {
+    // Storage unavailable — migration retries on next load.
+  }
+}
+
+/**
  * Run all pending storage key migrations. Called from
  * `run-storage-migrations.ts` (side-effect import at the top of
  * `main.tsx`), after `migrateDeviceSettings()` — device keys must
@@ -171,6 +224,11 @@ export function runStorageMigrations(): void {
 
   // vellum_ per-org → vellum:
   migratePrefix("vellum_current_assistant_id__", "vellum:currentAssistantId:");
+
+  // Collapse the canonicalized legacy selection keys (tab-local + per-org map)
+  // into the single `vellum:selectedAssistantId`. Must run AFTER the renames
+  // above so it sees the canonical key names.
+  collapseSelectedAssistantKeys();
 
   // -- Value format migrations ---------------------------------------------
   // Skills tip was stored as "1"; getLocalBool expects "true".

--- a/apps/web/src/utils/storage-migration.ts
+++ b/apps/web/src/utils/storage-migration.ts
@@ -109,12 +109,13 @@ function removeAllWithPrefix(prefix: string): void {
  * `vellum:currentAssistantId:<org>` map — into the single
  * `vellum:selectedAssistantId` key.
  *
- * No "current org" exists at migration time (this runs synchronously before
- * stores hydrate), so when only per-org entries exist the winner is the
- * lexicographically-smallest org suffix — deterministic and idempotent. A
- * non-ideal pick self-heals on read: `resolveSelectedAssistantId` validates the
- * id against the active org and drops it if it doesn't belong. Idempotent via
- * the target-exists short-circuit plus unconditional legacy removal.
+ * Among per-org entries, prefer the persisted active org's selection (the org
+ * store records it in sessionStorage as `vellum_active_organization_id`) so a
+ * multi-org user keeps their current org's pick. Only when that's absent does
+ * the lexicographically-smallest org suffix win — deterministic and idempotent.
+ * A non-ideal pick self-heals on read: `resolveSelectedAssistantId` validates
+ * the id against the active org and drops it if it doesn't belong. Idempotent
+ * via the target-exists short-circuit plus unconditional legacy removal.
  */
 export function collapseSelectedAssistantKeys(): void {
   if (typeof window === "undefined") return;
@@ -124,6 +125,7 @@ export function collapseSelectedAssistantKeys(): void {
   try {
     if (localStorage.getItem(target) === null) {
       let candidate = localStorage.getItem(tabLocalKey);
+      if (candidate === null) candidate = activeOrgSelection(perOrgPrefix);
       if (candidate === null) {
         let smallestKey: string | null = null;
         for (let i = 0; i < localStorage.length; i++) {
@@ -141,6 +143,18 @@ export function collapseSelectedAssistantKeys(): void {
   } catch {
     // Storage unavailable — migration retries on next load.
   }
+}
+
+/** The per-org selection for the persisted active org, or null. */
+function activeOrgSelection(perOrgPrefix: string): string | null {
+  let activeOrg: string | null = null;
+  try {
+    activeOrg = sessionStorage.getItem("vellum_active_organization_id");
+  } catch {
+    return null;
+  }
+  if (!activeOrg) return null;
+  return localStorage.getItem(`${perOrgPrefix}${activeOrg}`);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace the per-org `selectedPlatformAssistantByOrg` map (`vellum:currentAssistantId:<org>`) **and** the tab-local `vellum:local:selectedAssistantId` key with a single reactive `selectedAssistantId` persisted to one key (`vellum:selectedAssistantId`). The active org becomes a read-time validation filter only — there is no in-app org switcher, so per-org keying bought nothing and `assistantsValidForOrg` already enforces cross-org safety.
- Fix the ghost-selection bug at its root: a new `assistantsHydrated` flag lets the resolver stop returning an unknown id once the list is authoritative, and `setFromLockfile` reconciles the selection against the resolved list. Previously the per-org map's *only* cleanup was the lifecycle 404 net (`lifecycle-service.ts`), which short-circuits in gateway-auth/local mode — so stale `vellum:currentAssistantId:<org>` entries lived forever and made the app try to load assistants that exist in neither the lockfile nor the platform API.
- Pruning runs on `setFromLockfile` (the cross-org universe) but **not** `setFromApi` (org-scoped, no org field), so a valid cross-org selection is never wrongly deleted — it's filtered on read. Add a dependency-free `selected-assistant-storage` module so the store and `local-mode` share raw key access without an import cycle, plus a one-time migration that collapses the legacy keys.

## Original prompt
While debugging local-assistant hatch issues, Noa found `vellum:currentAssistantId:<org>` entries in localStorage pointing at assistants present in neither the lockfile nor the platform API, causing the app to "load an assistant that doesn't exist." Investigation showed the per-org selection map is a second, redundant selection store whose only cleanup path doesn't run in local/gateway-auth mode, and that the per-org keying is vestigial (no org switcher is wired up). Noa chose to collapse and simplify: unify to a single validated selection and reconcile stale ids on load. Planned in plan mode; this implements that plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)