### PR TITLE
Clarify schedule usage stat labels

### DIFF
--- a/apps/web/src/domains/settings/components/schedule-shared-ui.tsx
+++ b/apps/web/src/domains/settings/components/schedule-shared-ui.tsx
@@ -41,10 +41,10 @@ export function ScheduleUsageStats({
     return (
       <div
         aria-label="Loading schedule usage"
-        className="flex w-[136px] shrink-0 items-center justify-end gap-3"
+        className="flex w-[156px] shrink-0 items-center justify-end gap-3"
       >
-        <span className="h-8 w-14 animate-pulse rounded bg-[var(--surface-muted)]" />
-        <span className="h-8 w-14 animate-pulse rounded bg-[var(--surface-muted)]" />
+        <span className="h-8 w-16 animate-pulse rounded bg-[var(--surface-muted)]" />
+        <span className="h-8 w-16 animate-pulse rounded bg-[var(--surface-muted)]" />
       </div>
     );
   }
@@ -58,16 +58,16 @@ export function ScheduleUsageStats({
     : formatScheduleRunCount(usage.summary.runCount);
 
   return (
-    <div className="flex w-[136px] shrink-0 items-center justify-end gap-3 text-right">
+    <div className="flex w-[156px] shrink-0 items-center justify-end gap-3 text-right">
       {onOpenUsage ? (
         <button
           type="button"
           onClick={onOpenUsage}
           aria-label={`View usage for ${scheduleName}`}
-          className="min-w-[54px] cursor-pointer rounded px-1 py-0.5 text-right transition-colors hover:bg-[var(--surface-hover)]"
+          className="min-w-[64px] cursor-pointer rounded px-1 py-0.5 text-right transition-colors hover:bg-[var(--surface-hover)]"
         >
           <span className="block text-label-small-default text-[var(--content-tertiary)]">
-            Cost
+            Cost (7d)
           </span>
           <span className="block text-body-small-default text-[var(--content-default)]">
             {cost}
@@ -76,10 +76,10 @@ export function ScheduleUsageStats({
       ) : (
         <span
           aria-label={`Cost for ${scheduleName} in the last 7 days: ${cost}`}
-          className="block min-w-[54px] px-1 py-0.5"
+          className="block min-w-[64px] px-1 py-0.5"
         >
           <span className="block text-label-small-default text-[var(--content-tertiary)]">
-            Cost
+            Cost (7d)
           </span>
           <span className="block text-body-small-default text-[var(--content-default)]">
             {cost}
@@ -88,10 +88,10 @@ export function ScheduleUsageStats({
       )}
       <span
         aria-label={`Runs for ${scheduleName} in the last 7 days: ${runs}`}
-        className="block min-w-[54px] px-1 py-0.5"
+        className="block min-w-[64px] px-1 py-0.5"
       >
         <span className="block text-label-small-default text-[var(--content-tertiary)]">
-          Runs
+          Runs (7d)
         </span>
         <span className="block text-body-small-default text-[var(--content-default)]">
           {runs}

--- a/apps/web/src/domains/settings/pages/schedules-page.test.ts
+++ b/apps/web/src/domains/settings/pages/schedules-page.test.ts
@@ -536,9 +536,9 @@ describe("SystemTaskRow", () => {
 
     expect(screen.queryByRole("button", { name: /Run now/i })).toBeNull();
     expect(screen.getByLabelText("enabled")).toBeTruthy();
-    expect(screen.getByText("Cost")).toBeTruthy();
+    expect(screen.getByText("Cost (7d)")).toBeTruthy();
     expect(screen.getByText("$0.42")).toBeTruthy();
-    expect(screen.getByText("Runs")).toBeTruthy();
+    expect(screen.getByText("Runs (7d)")).toBeTruthy();
     expect(screen.getByText("2 runs")).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- Change schedule row stat labels from `Cost` / `Runs` to `Cost (7d)` / `Runs (7d)`
- Slightly widen the stat columns and loading placeholders so the longer labels have room
- Update the focused schedules page test assertions

## 7-day query confirmation
- The Schedules page calls `scheduleUsageSummaryQueryOptions(...)`, which calls `resolveScheduleUsageWindow(tz)` before fetching summaries.
- `resolveScheduleUsageWindow(...)` delegates to `resolveUsageRangeWindow("7d", tz, now)`, matching the Usage page 7-day calendar-window semantics.
- The assistant `schedules/usage-summary` route requires `from` and `to`, then applies that range to both `cron_runs.started_at` and `llm_usage_events.created_at` when computing run counts and costs.

## Verification
- `cd apps/web && bun test src/domains/settings/pages/schedules-page.test.ts src/domains/settings/utils/schedule-usage-window.test.ts`
- `cd apps/web && bun run lint src/domains/settings/components/schedule-shared-ui.tsx src/domains/settings/pages/schedules-page.test.ts src/domains/settings/utils/schedule-usage-window.test.ts`
- `cd apps/web && bun run postinstall`
- `cd apps/web && bun run typecheck`
- `git diff --check`