### PR TITLE
Clean up schedule list row metadata

### DIFF
--- a/apps/web/src/domains/settings/components/schedule-row.tsx
+++ b/apps/web/src/domains/settings/components/schedule-row.tsx
@@ -6,10 +6,8 @@ import {
 } from "@/domains/settings/components/schedule-shared-ui";
 import {
   formatTimestamp,
-  MODE_TONE,
   type ScheduleRowUsage,
 } from "@/domains/settings/utils/schedule-formatters";
-import { Tag } from "@vellumai/design-library/components/tag";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 
 import type { Schedule } from "@/domains/settings/types/schedules";
@@ -38,9 +36,6 @@ export function ScheduleRow({
           <span className="truncate text-body-medium-default text-[var(--content-default)]">
             {schedule.name}
           </span>
-          <Tag tone={MODE_TONE[schedule.mode] ?? "neutral"}>
-            {schedule.mode}
-          </Tag>
         </div>
         <div className="mt-0.5 flex items-center gap-3 text-body-small-default text-[var(--content-tertiary)]">
           <span className="truncate">{schedule.description}</span>

--- a/apps/web/src/domains/settings/components/schedule-row.tsx
+++ b/apps/web/src/domains/settings/components/schedule-row.tsx
@@ -1,9 +1,6 @@
 import { ChevronRight } from "lucide-react";
 
-import {
-  ScheduleUsageStats,
-  StatusDot,
-} from "@/domains/settings/components/schedule-shared-ui";
+import { ScheduleUsageStats } from "@/domains/settings/components/schedule-shared-ui";
 import {
   formatTimestamp,
   type ScheduleRowUsage,
@@ -25,6 +22,8 @@ export function ScheduleRow({
   onToggle: (enabled: boolean) => void;
   onOpenUsage: () => void;
 }) {
+  const displayRunAt = schedule.lastRunAt ?? schedule.nextRunAt;
+
   return (
     <div className="flex flex-wrap items-center gap-3 rounded-md px-2 py-3 transition-colors hover:bg-[var(--surface-hover)] [&+&]:border-t [&+&]:border-[var(--border-base)]">
       <button
@@ -39,12 +38,9 @@ export function ScheduleRow({
         </div>
         <div className="mt-0.5 flex items-center gap-3 text-body-small-default text-[var(--content-tertiary)]">
           <span className="truncate">{schedule.description}</span>
-          {schedule.lastRunAt && (
-            <span className="flex shrink-0 items-center gap-1">
-              <StatusDot status={schedule.lastStatus} />
-              {formatTimestamp(schedule.lastRunAt)}
-            </span>
-          )}
+          {displayRunAt ? (
+            <span className="shrink-0">{formatTimestamp(displayRunAt)}</span>
+          ) : null}
         </div>
       </button>
       <div className="flex shrink-0 items-center gap-3">

--- a/apps/web/src/domains/settings/components/schedule-shared-ui.tsx
+++ b/apps/web/src/domains/settings/components/schedule-shared-ui.tsx
@@ -66,7 +66,7 @@ export function ScheduleUsageStats({
           aria-label={`View usage for ${scheduleName}`}
           className="min-w-[64px] cursor-pointer rounded px-1 py-0.5 text-right transition-colors hover:bg-[var(--surface-hover)]"
         >
-          <span className="block text-label-small-default text-[var(--content-tertiary)]">
+          <span className="mb-0.5 block text-label-small-default text-[var(--content-tertiary)]">
             Cost (7d)
           </span>
           <span className="block text-body-small-default text-[var(--content-default)]">
@@ -78,7 +78,7 @@ export function ScheduleUsageStats({
           aria-label={`Cost for ${scheduleName} in the last 7 days: ${cost}`}
           className="block min-w-[64px] px-1 py-0.5"
         >
-          <span className="block text-label-small-default text-[var(--content-tertiary)]">
+          <span className="mb-0.5 block text-label-small-default text-[var(--content-tertiary)]">
             Cost (7d)
           </span>
           <span className="block text-body-small-default text-[var(--content-default)]">
@@ -90,7 +90,7 @@ export function ScheduleUsageStats({
         aria-label={`Runs for ${scheduleName} in the last 7 days: ${runs}`}
         className="block min-w-[64px] px-1 py-0.5"
       >
-        <span className="block text-label-small-default text-[var(--content-tertiary)]">
+        <span className="mb-0.5 block text-label-small-default text-[var(--content-tertiary)]">
           Runs (7d)
         </span>
         <span className="block text-body-small-default text-[var(--content-default)]">

--- a/apps/web/src/domains/settings/components/system-tasks-section.tsx
+++ b/apps/web/src/domains/settings/components/system-tasks-section.tsx
@@ -9,7 +9,6 @@ import {
   type ScheduleRowUsage,
 } from "@/domains/settings/utils/schedule-formatters";
 import { Notice } from "@vellumai/design-library/components/notice";
-import { Tag } from "@vellumai/design-library/components/tag";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 
 import type {
@@ -57,7 +56,6 @@ export function SystemTaskRow({
             <span className="truncate text-body-medium-default text-[var(--content-default)]">
               {name}
             </span>
-            <Tag tone="neutral">system</Tag>
           </div>
           <div className="mt-0.5 text-body-small-default text-[var(--content-tertiary)]">
             {subtitle}
@@ -205,5 +203,4 @@ export function SystemTasksSection({
     </DetailCard>
   );
 }
-
 

--- a/apps/web/src/domains/settings/pages/schedules-page.test.ts
+++ b/apps/web/src/domains/settings/pages/schedules-page.test.ts
@@ -70,6 +70,7 @@ const {
   canOpenScheduleRunConversation,
   canOpenScheduleSourceConversation,
   formatScheduleCost,
+  formatTimestamp,
   shouldShowSystemTaskToggles,
 } = await import("@/domains/settings/utils/schedule-formatters");
 const { RecentRunsCard } = await import(
@@ -432,6 +433,61 @@ describe("ScheduleRow", () => {
     expect(usageClicks).toBe(0);
     expect(detailClicks).toBe(0);
     expect(screen.queryByText("execute")).toBeNull();
+  });
+
+  test("renders the last run timestamp without a status dot", () => {
+    const lastRunAt = 1_761_792_000_000;
+
+    render(
+      createElement(ScheduleRow, {
+        schedule: rowSchedule({
+          lastRunAt,
+          lastStatus: "ok",
+        }),
+        usage: {
+          status: "ready",
+          summary: {
+            scheduleId: "schedule-123",
+            runCount: 1,
+            totalEstimatedCostUsd: 0.03,
+            eventCount: 1,
+          },
+        },
+        onClick: () => {},
+        onToggle: () => {},
+        onOpenUsage: () => {},
+      }),
+    );
+
+    expect(screen.getByText(formatTimestamp(lastRunAt))).toBeTruthy();
+    expect(screen.queryByLabelText("ok")).toBeNull();
+  });
+
+  test("renders the next run timestamp before a schedule has run", () => {
+    const nextRunAt = 1_761_795_600_000;
+
+    render(
+      createElement(ScheduleRow, {
+        schedule: rowSchedule({
+          nextRunAt,
+          lastRunAt: null,
+        }),
+        usage: {
+          status: "ready",
+          summary: {
+            scheduleId: "schedule-123",
+            runCount: 0,
+            totalEstimatedCostUsd: 0,
+            eventCount: 0,
+          },
+        },
+        onClick: () => {},
+        onToggle: () => {},
+        onOpenUsage: () => {},
+      }),
+    );
+
+    expect(screen.getByText(formatTimestamp(nextRunAt))).toBeTruthy();
   });
 
   test("one-time rows use the shared clickable row affordance", () => {

--- a/apps/web/src/domains/settings/pages/schedules-page.test.ts
+++ b/apps/web/src/domains/settings/pages/schedules-page.test.ts
@@ -431,6 +431,7 @@ describe("ScheduleRow", () => {
 
     expect(usageClicks).toBe(0);
     expect(detailClicks).toBe(0);
+    expect(screen.queryByText("execute")).toBeNull();
   });
 
   test("one-time rows use the shared clickable row affordance", () => {
@@ -535,6 +536,7 @@ describe("SystemTaskRow", () => {
     );
 
     expect(screen.queryByRole("button", { name: /Run now/i })).toBeNull();
+    expect(screen.queryByText("system")).toBeNull();
     expect(screen.getByLabelText("enabled")).toBeTruthy();
     expect(screen.getByText("Cost (7d)")).toBeTruthy();
     expect(screen.getByText("$0.42")).toBeTruthy();


### PR DESCRIPTION
## Summary
- Remove the visible `notify` / `execute` / mode chips from regular schedule list rows
- Remove the visible `system` chips from system schedule list rows
- Remove the status dot next to regular schedule row timestamps
- Show a plain timestamp using the last run time when present, falling back to the next run time before the schedule has run
- Add a small amount of spacing between schedule stat labels and values
- Keep schedule detail page chips and run-history status dots unchanged; this PR is scoped to the list rows shown on the Schedules page

## Verification
- `cd apps/web && bun test src/domains/settings/pages/schedules-page.test.ts`
- `cd apps/web && bun run lint src/domains/settings/components/schedule-row.tsx src/domains/settings/components/system-tasks-section.tsx src/domains/settings/components/schedule-shared-ui.tsx src/domains/settings/pages/schedules-page.test.ts`
- `cd apps/web && bun run typecheck`
- `git diff --check`