### PR TITLE
refactor(assistant): guardian double-wrap resolution (M6)

### DIFF
--- a/assistant/src/config/call-site-defaults.ts
+++ b/assistant/src/config/call-site-defaults.ts
@@ -95,6 +95,7 @@ export const CALL_SITE_DEFAULTS: Record<LLMCallSite, CallSiteDefaultConfig> = {
   },
   guardianQuestionCopy: {
     profile: "cost-optimized",
+    maxTokens: 200,
     effort: "low",
     thinking: { enabled: false },
   },

--- a/assistant/src/daemon/guardian-action-generators.ts
+++ b/assistant/src/daemon/guardian-action-generators.ts
@@ -1,10 +1,7 @@
-import { loadConfig } from "../config/loader.js";
-import { wrapWithCallSiteRouting } from "../providers/call-site-routing.js";
-import { getConfiguredProvider } from "../providers/provider-send-message.js";
+import { runOneShotLLM } from "../providers/one-shot-llm.js";
 import {
   buildGuardianActionGenerationPrompt,
   getGuardianActionFallbackMessage,
-  GUARDIAN_ACTION_COPY_MAX_TOKENS,
   GUARDIAN_ACTION_COPY_SYSTEM_PROMPT,
   GUARDIAN_ACTION_COPY_TIMEOUT_MS,
   includesRequiredKeywords,
@@ -12,25 +9,17 @@ import {
 import type { GuardianActionCopyGenerator } from "../runtime/http-types.js";
 
 /**
- * Create the daemon-owned guardian action copy generator that resolves
- * providers and calls `provider.sendMessage` to generate guardian action
- * copy text. Uses the `guardianQuestionCopy` call site so model selection
- * tracks the unified `llm.callSites` configuration.
+ * Create the daemon-owned guardian action copy generator that resolves a
+ * provider and runs a one-shot LLM call to generate guardian action copy
+ * text. Uses the `guardianQuestionCopy` call site so model selection,
+ * provider/connection routing, and tuning all track the unified
+ * `llm.callSites` configuration.
  *
  * This keeps all provider awareness in the daemon lifecycle, away from
  * the runtime composer.
  */
 export function createGuardianActionCopyGenerator(): GuardianActionCopyGenerator {
   return async (context, options = {}) => {
-    const baseProvider = await getConfiguredProvider("guardianQuestionCopy");
-    if (!baseProvider) return null;
-    // Wrap so the per-call `callSite` can route to a different provider
-    // transport when `llm.callSites.guardianQuestionCopy.provider` overrides
-    // the default. Connection-aware: when the resolved profile names a
-    // `provider_connection`, that connection's auth wins over the legacy
-    // registry lookup. See `wrapWithCallSiteRouting`.
-    const provider = wrapWithCallSiteRouting(baseProvider, loadConfig());
-
     const fallbackText =
       options.fallbackText?.trim() || getGuardianActionFallbackMessage(context);
     const requiredKeywords = options.requiredKeywords
@@ -42,25 +31,27 @@ export function createGuardianActionCopyGenerator(): GuardianActionCopyGenerator
       requiredKeywords,
     );
 
-    const response = await provider.sendMessage(
+    const result = await runOneShotLLM(
+      "guardianQuestionCopy",
       [{ role: "user", content: [{ type: "text", text: prompt }] }],
       {
-        tools: [],
         systemPrompt: GUARDIAN_ACTION_COPY_SYSTEM_PROMPT,
-        config: {
-          max_tokens: options.maxTokens ?? GUARDIAN_ACTION_COPY_MAX_TOKENS,
-          callSite: "guardianQuestionCopy",
-        },
-        signal: AbortSignal.timeout(
-          options.timeoutMs ?? GUARDIAN_ACTION_COPY_TIMEOUT_MS,
-        ),
+        timeoutMs: options.timeoutMs ?? GUARDIAN_ACTION_COPY_TIMEOUT_MS,
+        // No provider configured → unavailable; any non-`ok` status below
+        // returns null so the caller falls back to deterministic template copy.
+        onUnavailable: "null",
+        // Runtime per-call override only. When `options.maxTokens` is
+        // undefined the resolved CALL_SITE_DEFAULTS.guardianQuestionCopy cap
+        // (200) auto-flows to the wire via retry.ts — do not hardcode it here.
+        ...(options.maxTokens !== undefined
+          ? // call-site-tuning:allow — reason: runtime caller override, not a static default
+            { config: { max_tokens: options.maxTokens } }
+          : {}),
       },
     );
 
-    const block = response.content.find((entry) => entry.type === "text");
-    const text = block && "text" in block ? block.text.trim() : "";
-    if (!text) return null;
-    const cleaned = text
+    if (result.status !== "ok") return null;
+    const cleaned = result.data
       .replace(/^["'`]+/, "")
       .replace(/["'`]+$/, "")
       .trim();

--- a/assistant/src/runtime/guardian-action-message-composer.ts
+++ b/assistant/src/runtime/guardian-action-message-composer.ts
@@ -28,7 +28,9 @@ const log = getLogger("guardian-action-message-composer");
 // ---------------------------------------------------------------------------
 
 export const GUARDIAN_ACTION_COPY_TIMEOUT_MS = 4_000;
-export const GUARDIAN_ACTION_COPY_MAX_TOKENS = 200;
+// Per-call-site max-tokens cap lives in CALL_SITE_DEFAULTS.guardianQuestionCopy
+// (config/call-site-defaults.ts) so operator/user `llm.callSites` tuning is
+// honored; the resolved value auto-flows to the wire via retry.ts.
 export const GUARDIAN_ACTION_COPY_SYSTEM_PROMPT =
   "You are an assistant writing one user-facing message about a guardian action in a voice call scenario. " +
   "Keep it concise, natural, and conversational. Preserve factual details exactly. " +


### PR DESCRIPTION
Part of #34399. Closes #34405.

## Double-wrap investigation: VERDICT — redundant, removed

`createGuardianActionCopyGenerator` resolved its provider via `getConfiguredProvider("guardianQuestionCopy")` and then re-wrapped it with `wrapWithCallSiteRouting(baseProvider, loadConfig())`. That second wrap was dead weight for THIS call site.

**Evidence:**
- The wrap was added in #26466 (Apr 2026). At that time `getConfiguredProvider` returned a provider whose HTTP transport was bound to the *default* — the per-call `callSite` only stamped request metadata, so the routing wrapper was genuinely needed to re-route the transport.
- #30198 ("route dispatch through provider_connection") then changed `resolveConfiguredProvider` (provider-send-message.ts): it now calls `resolveCallSiteConfig(callSite, config.llm, opts)` itself, resolves `provider_connection` for that call site, and returns a `CallSiteConfiguredProvider` already bound to the connection-resolved transport.
- `CallSiteRoutingProvider.selectProvider` re-runs the *identical* resolution: `resolveCallSiteConfig("guardianQuestionCopy", ...)` → same `provider_connection` → same `tryResolveProviderForConnectionName(connectionName, config, provider, model)`. Same inputs, same transport, every `sendMessage`.
- Because this is a one-shot path that calls `getConfiguredProvider("guardianQuestionCopy")` fresh per generation with a fixed call site, the routing wrapper can never re-route to a *different* call site's transport (its sole reason to exist). Confirmed: `getConfiguredProvider("guardianQuestionCopy")` alone already honors `llm.callSites.guardianQuestionCopy.provider`/`.provider_connection`.

**Not a general resolver gap.** The other `wrapWithCallSiteRouting` users (conversation-store.ts, approval-generators.ts, subagent/manager.ts, agent-wake.ts) build the provider ONCE at conversation/agent start via `resolveDefaultProvider` and then route per-call across many call sites within a long-lived loop — the wrapper is load-bearing there. Only this generator double-resolved by combining the call-site-aware `getConfiguredProvider` with the routing wrapper.

Removed the wrap and the now-unused `loadConfig()` import.

## Other changes (canonical-pattern alignment)
- Migrated the LLM call to `runOneShotLLM("guardianQuestionCopy", …)` text mode — replaces the bare `AbortSignal.timeout(...)` (no timer cleanup) and the hand-rolled first-text-block extraction. Behavior preserved: null on no provider (`onUnavailable: "null"`), null on empty/keyword-failing text, quote-stripping post-processing, `options.timeoutMs` override, required-keywords validation.
- Moved `GUARDIAN_ACTION_COPY_MAX_TOKENS` (200) into `CALL_SITE_DEFAULTS.guardianQuestionCopy` (M4 pattern; resolved value auto-flows to the wire). The runtime `options.maxTokens` override still wins: passed inline only when provided, otherwise the resolved default flows. The dynamic inline pass-through carries a `call-site-tuning:allow` suppression comment. Removed the now-unused exported constant from the composer.

## Verification
- `bunx tsc --noEmit` clean
- `bun run lint` clean
- Tests: guardian-action-copy-generator, call-site-tuning-guard, guardian-action-no-hardcoded-copy, llm-callsite-catalog, llm-resolver, retry-callsite, call-site-routing-provider — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)