### PR TITLE
fix(assistant): null-provider policy + route/IPC timeout fixes (M5)

### DIFF
--- a/assistant/docs/error-handling.md
+++ b/assistant/docs/error-handling.md
@@ -25,6 +25,18 @@ throw new AssistantError(
 );
 ```
 
+### Null-provider policy (LLM backend unavailable)
+
+`getConfiguredProvider(callSite)` returns `null` when no LLM provider is configured for the call site. How to handle that null depends on where the call originates — pick by context, not by convenience:
+
+| Context                     | Action                                                                                                                                                                                                                                                                                                                                                                                 |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| HTTP / IPC route handler    | Throw the appropriate `RouteError` subclass (`assistant/src/runtime/routes/errors.ts`) — `ServiceUnavailableError` (503) for "LLM backend unavailable", `BadRequestError` (400) when the caller can fix it (e.g. `inference/send` tells the user to configure a provider). Skill IPC handlers throw a plain `Error` whose message the IPC server serializes as the wire `error` field. |
+| Optional background feature | Log a warning and skip / fall back to a safe default (e.g. the meet consent monitor assumes "no objection"). Never crash a background job over a missing provider.                                                                                                                                                                                                                     |
+| Hard-required job           | Throw `BackendUnavailableError` (`util/errors.ts`) so the job aborts with a structured code.                                                                                                                                                                                                                                                                                           |
+
+The shared `runOneShotLLM` helper (`providers/one-shot-llm.ts`) centralizes this: `onUnavailable: "null"` returns `{ status: "unavailable" }` for optional callers to branch on; `onUnavailable: "throw"` raises `BackendUnavailableError` for hard-required callers.
+
 ## 2. Result objects for operations that can fail in expected ways
 
 Return a discriminated union or result object when:

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -13872,6 +13872,10 @@ paths:
                   type: integer
                   exclusiveMinimum: 0
                   maximum: 9007199254740991
+                timeoutMs:
+                  type: integer
+                  exclusiveMinimum: 0
+                  maximum: 9007199254740991
               required:
                 - message
               additionalProperties: false

--- a/assistant/src/cli/commands/__tests__/inference-send.test.ts
+++ b/assistant/src/cli/commands/__tests__/inference-send.test.ts
@@ -283,7 +283,7 @@ describe("--max-tokens", () => {
 // ---------------------------------------------------------------------------
 
 describe("--timeout-seconds", () => {
-  test("uses a long default IPC timeout for inference calls", async () => {
+  test("uses a long default timeout in body and a slightly larger IPC budget", async () => {
     const { exitCode, stdout } = await runCommand([
       "inference",
       "send",
@@ -294,10 +294,14 @@ describe("--timeout-seconds", () => {
     expect(exitCode).toBe(0);
     expect(JSON.parse(stdout).ok).toBe(true);
     expect(lastIpcCall!.method).toBe("inference_send");
-    expect(lastIpcCall!.options!.timeoutMs).toBe(32 * 60 * 1000);
+    // Body deadline matches the documented 32-minute default.
+    const body = lastIpcCall!.params!.body as { timeoutMs?: number };
+    expect(body.timeoutMs).toBe(32 * 60 * 1000);
+    // IPC budget is larger than the body deadline so the server aborts first.
+    expect(lastIpcCall!.options!.timeoutMs).toBe(32 * 60 * 1000 + 30 * 1000);
   });
 
-  test("passes custom timeout to IPC call", async () => {
+  test("passes custom timeout to both the body and IPC budget", async () => {
     const { exitCode } = await runCommand([
       "llm",
       "send",
@@ -308,7 +312,9 @@ describe("--timeout-seconds", () => {
 
     expect(exitCode).toBe(0);
     expect(lastIpcCall!.method).toBe("inference_send");
-    expect(lastIpcCall!.options!.timeoutMs).toBe(300_000);
+    const body = lastIpcCall!.params!.body as { timeoutMs?: number };
+    expect(body.timeoutMs).toBe(300_000);
+    expect(lastIpcCall!.options!.timeoutMs).toBe(300_000 + 30 * 1000);
   });
 
   test("errors on invalid timeout value", async () => {

--- a/assistant/src/cli/commands/inference.ts
+++ b/assistant/src/cli/commands/inference.ts
@@ -30,9 +30,17 @@ interface InferenceSendResult {
   };
 }
 
-const DEFAULT_INFERENCE_IPC_TIMEOUT_MS = 32 * 60 * 1000;
+const DEFAULT_INFERENCE_TIMEOUT_MS = 32 * 60 * 1000;
 const MAX_TIMER_TIMEOUT_MS = 2_147_483_647;
 const MAX_INFERENCE_TIMEOUT_SECONDS = Math.floor(MAX_TIMER_TIMEOUT_MS / 1000);
+
+/**
+ * Margin added to the body deadline to derive the IPC wait budget. Keeping the
+ * IPC budget slightly larger than the server-side provider timeout ensures the
+ * server's clean abort fires first and returns a structured error rather than
+ * the IPC layer timing out the call.
+ */
+const IPC_TIMEOUT_MARGIN_MS = 30 * 1000;
 
 function parsePositiveIntegerOption(
   raw: string | undefined,
@@ -158,10 +166,14 @@ Examples:
         }
 
         const maxTokens = parsedMaxTokens.value;
+        // Provider deadline the daemon enforces (passed in the route body).
         const timeoutMs =
           parsedTimeoutSeconds.value !== undefined
             ? parsedTimeoutSeconds.value * 1000
-            : DEFAULT_INFERENCE_IPC_TIMEOUT_MS;
+            : DEFAULT_INFERENCE_TIMEOUT_MS;
+        // IPC wait budget: a margin above the body deadline so the server's
+        // clean abort fires before the IPC layer times out the call.
+        const ipcTimeoutMs = timeoutMs + IPC_TIMEOUT_MARGIN_MS;
 
         // Determine user message: positional args or stdin.
         let messageText = messageParts.length > 0 ? messageParts.join(" ") : "";
@@ -182,7 +194,10 @@ Examples:
         }
 
         // Build IPC body
-        const body: Record<string, unknown> = { message: messageText };
+        const body: Record<string, unknown> = {
+          message: messageText,
+          timeoutMs,
+        };
         if (systemPrompt) body.systemPrompt = systemPrompt;
         if (model) body.model = model;
         if (profile) body.profile = profile;
@@ -191,7 +206,7 @@ Examples:
         const ipcResult = await cliIpcCall<InferenceSendResult>(
           "inference_send",
           { body },
-          { timeoutMs },
+          { timeoutMs: ipcTimeoutMs },
         );
 
         if (!ipcResult.ok) {

--- a/assistant/src/ipc/skill-routes/__tests__/providers.test.ts
+++ b/assistant/src/ipc/skill-routes/__tests__/providers.test.ts
@@ -168,6 +168,44 @@ describe("host.providers.llm.complete", () => {
       }),
     ).rejects.toThrow(/no provider configured/);
   });
+
+  test("passes an abort signal to sendMessage so the call is time-bounded", async () => {
+    await providersLlmCompleteRoute.handler({
+      callSite: "mainAgent",
+      messages: [],
+    });
+
+    const call = sendMessageSpy.mock.calls[0] as unknown as [
+      unknown[],
+      { signal?: AbortSignal },
+    ];
+    expect(call[1]?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  test("accepts a caller-supplied timeoutMs", async () => {
+    await providersLlmCompleteRoute.handler({
+      callSite: "mainAgent",
+      messages: [],
+      timeoutMs: 5_000,
+    });
+
+    expect(sendMessageSpy).toHaveBeenCalledTimes(1);
+    const call = sendMessageSpy.mock.calls[0] as unknown as [
+      unknown[],
+      { signal?: AbortSignal },
+    ];
+    expect(call[1]?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  test("rejects a non-positive timeoutMs", async () => {
+    await expect(
+      providersLlmCompleteRoute.handler({
+        callSite: "mainAgent",
+        messages: [],
+        timeoutMs: 0,
+      }),
+    ).rejects.toThrow();
+  });
 });
 
 describe("host.providers.stt.listProviderIds", () => {

--- a/assistant/src/ipc/skill-routes/__tests__/providers.test.ts
+++ b/assistant/src/ipc/skill-routes/__tests__/providers.test.ts
@@ -25,6 +25,14 @@ const stubProvider: unknown = {
 const getConfiguredProviderSpy = mock(async () => stubProvider);
 mock.module("../../../providers/provider-send-message.js", () => ({
   getConfiguredProvider: getConfiguredProviderSpy,
+  // The handler calls createTimeout for the abort signal; provide a real
+  // implementation so the signal it passes to sendMessage is a genuine
+  // AbortSignal (asserted by the time-bound tests below).
+  createTimeout: (ms: number) => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), ms);
+    return { signal: controller.signal, cleanup: () => clearTimeout(timer) };
+  },
 }));
 
 const sttListProviderIdsSpy = mock(() => ["openai-whisper", "deepgram"]);

--- a/assistant/src/ipc/skill-routes/providers.ts
+++ b/assistant/src/ipc/skill-routes/providers.ts
@@ -20,7 +20,10 @@ import { z } from "zod";
 
 import { getConfig } from "../../config/loader.js";
 import { LLMCallSiteEnum } from "../../config/schemas/llm.js";
-import { getConfiguredProvider } from "../../providers/provider-send-message.js";
+import {
+  createTimeout,
+  getConfiguredProvider,
+} from "../../providers/provider-send-message.js";
 import {
   listProviderIds as sttListProviderIds,
   supportsBoundary as sttSupportsBoundary,
@@ -38,10 +41,20 @@ import type { SkillIpcRoute } from "../skill-ipc-types.js";
 // -- Param schemas --------------------------------------------------------
 
 /**
+ * Default timeout for a skill LLM completion when the caller supplies none.
+ * Generous (120s) because first-party skills — the meet-join consent monitor
+ * and chat-opportunity detector — flow through this route and pass their own
+ * tighter `timeoutMs`. Without any bound a stalled provider call would block
+ * the skill IPC channel indefinitely.
+ */
+const DEFAULT_LLM_COMPLETE_TIMEOUT_MS = 120_000;
+
+/**
  * LLM completion request. The IPC surface only accepts the serializable
  * subset of `Provider.sendMessage(messages, options?)`.
- * Non-serializable fields (`onEvent`, `signal`) are intentionally omitted —
- * streaming deltas and per-call cancellation belong on future streaming
+ * The non-serializable `signal` is replaced by a serializable `timeoutMs`:
+ * callers express cancellation as a deadline the daemon enforces locally via
+ * `createTimeout`. Streaming deltas (`onEvent`) belong on future streaming
  * routes, not this one-shot RPC.
  */
 const ProvidersLlmCompleteParams = z.object({
@@ -50,6 +63,8 @@ const ProvidersLlmCompleteParams = z.object({
   tools: z.array(z.unknown()).optional(),
   systemPrompt: z.string().optional(),
   config: z.record(z.string(), z.unknown()).optional(),
+  /** Caller-supplied deadline in ms. Defaults to 120s when omitted. */
+  timeoutMs: z.number().int().positive().optional(),
 });
 
 const ProvidersSttSupportsBoundaryParams = z.object({
@@ -68,19 +83,30 @@ const ProvidersSecureKeysGetParams = z.object({
 // -- Handlers -------------------------------------------------------------
 
 async function handleLlmComplete(params?: Record<string, unknown>) {
-  const { callSite, messages, tools, systemPrompt, config } =
+  const { callSite, messages, tools, systemPrompt, config, timeoutMs } =
     ProvidersLlmCompleteParams.parse(params);
   const provider = await getConfiguredProvider(callSite);
   if (!provider) {
+    // The skill IPC server serializes a thrown Error's message as the wire
+    // `error` field, so a plain Error is the structured error convention here
+    // (matching sibling skill-route handlers).
     throw new Error(
       `host.providers.llm.complete: no provider configured for callSite '${callSite}'`,
     );
   }
-  return provider.sendMessage(messages as Message[], {
-    tools: tools as ToolDefinition[] | undefined,
-    systemPrompt,
-    config: { ...((config as SendMessageConfig) ?? {}), callSite },
-  });
+  const { signal, cleanup } = createTimeout(
+    timeoutMs ?? DEFAULT_LLM_COMPLETE_TIMEOUT_MS,
+  );
+  try {
+    return await provider.sendMessage(messages as Message[], {
+      tools: tools as ToolDefinition[] | undefined,
+      systemPrompt,
+      config: { ...((config as SendMessageConfig) ?? {}), callSite },
+      signal,
+    });
+  } finally {
+    cleanup();
+  }
 }
 
 function handleSttListProviderIds(): string[] {

--- a/assistant/src/runtime/routes/__tests__/inference-send-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-send-routes.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for the one-shot inference send route (`POST /v1/inference/send`).
+ *
+ * Focus: the provider call's timeout budget. The handler must honor a
+ * caller-supplied `timeoutMs` (the CLI's `--timeout-seconds`), clamp it to a
+ * sane ceiling, and fall back to a generous default that matches the CLI's
+ * documented 32-minute wait — not the old hard-coded 60s.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Module mocks (must come before imports) ──────────────────────────────────
+
+mock.module("../../../config/loader.js", () => ({
+  getConfigReadOnly: () => ({ llm: { profiles: {} } }),
+}));
+
+// Capture the ms passed to createTimeout so we can assert the resolved budget.
+let lastCreateTimeoutMs: number | undefined;
+const sendMessageSpy = mock(async () => ({
+  content: [{ type: "text", text: "hello" }],
+  model: "stub-model",
+  usage: { inputTokens: 1, outputTokens: 2 },
+  stopReason: "end_turn",
+}));
+const getConfiguredProviderSpy = mock(async () => ({
+  name: "stub-provider",
+  sendMessage: sendMessageSpy,
+}));
+mock.module("../../../providers/provider-send-message.js", () => ({
+  getConfiguredProvider: getConfiguredProviderSpy,
+  extractAllText: () => "hello",
+  userMessage: (text: string) => ({
+    role: "user",
+    content: [{ type: "text", text }],
+  }),
+  createTimeout: (ms: number) => {
+    lastCreateTimeoutMs = ms;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), ms);
+    return { signal: controller.signal, cleanup: () => clearTimeout(timer) };
+  },
+}));
+
+// ── Real imports (after mocks) ────────────────────────────────────────────────
+
+import { ROUTES } from "../inference-send-routes.js";
+import type { RouteDefinition, RouteHandlerArgs } from "../types.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const DEFAULT_INFERENCE_TIMEOUT_MS = 32 * 60 * 1000;
+const MAX_INFERENCE_TIMEOUT_MS = 35 * 60 * 1000;
+
+function findHandler(operationId: string): RouteDefinition["handler"] {
+  const route = ROUTES.find((r) => r.operationId === operationId);
+  if (!route) throw new Error(`Route ${operationId} not found`);
+  return route.handler;
+}
+
+async function send(body: Record<string, unknown>): Promise<unknown> {
+  return await findHandler("inference_send")({ body } as RouteHandlerArgs);
+}
+
+beforeEach(() => {
+  lastCreateTimeoutMs = undefined;
+  sendMessageSpy.mockClear();
+  getConfiguredProviderSpy.mockClear();
+});
+
+// ── Timeout budget ──────────────────────────────────────────────────────────
+
+describe("inference_send timeout budget", () => {
+  test("applies the CLI-matching default when no timeout is supplied", async () => {
+    await send({ message: "hi" });
+    expect(lastCreateTimeoutMs).toBe(DEFAULT_INFERENCE_TIMEOUT_MS);
+  });
+
+  test("honors a caller-supplied timeoutMs under the ceiling", async () => {
+    await send({ message: "hi", timeoutMs: 300_000 });
+    expect(lastCreateTimeoutMs).toBe(300_000);
+  });
+
+  test("clamps a caller-supplied timeoutMs to the ceiling", async () => {
+    await send({ message: "hi", timeoutMs: 60 * 60 * 1000 });
+    expect(lastCreateTimeoutMs).toBe(MAX_INFERENCE_TIMEOUT_MS);
+  });
+
+  test("passes the resulting abort signal to the provider", async () => {
+    await send({ message: "hi", timeoutMs: 5_000 });
+    expect(sendMessageSpy).toHaveBeenCalledTimes(1);
+    const call = sendMessageSpy.mock.calls[0] as unknown as [
+      unknown[],
+      { signal?: AbortSignal },
+    ];
+    expect(call[1]?.signal).toBeInstanceOf(AbortSignal);
+  });
+});

--- a/assistant/src/runtime/routes/__tests__/suggest-trust-rule-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/suggest-trust-rule-routes.test.ts
@@ -1,14 +1,18 @@
 /**
- * Unit tests for the suggest_trust_rule IPC route handler.
+ * Unit tests for the suggest_trust_rule route handler.
  *
- * Covers:
- * - Happy path: provider returns tool_use block → correct SuggestTrustRuleResponse
- * - No provider: getConfiguredProvider returns null → throws
- * - No tool block: provider returns non-tool response → throws
+ * The handler delegates to the shared `runOneShotLLM` helper (tool mode +
+ * zod schema + timeout). These tests mock that helper to exercise the
+ * handler's result-status → RouteError mapping and response shaping:
+ * - ok: validated tool input → correct SuggestTrustRuleResponse
+ * - unavailable: no provider → ServiceUnavailableError (503)
+ * - failure: unusable output → BadGatewayError (502)
  * - directoryScopeOptions is optional: passes through correctly when absent
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { BadGatewayError, ServiceUnavailableError } from "../errors.js";
 
 // ---------------------------------------------------------------------------
 // Mocks — must be defined before importing the module under test
@@ -21,48 +25,29 @@ mock.module("../../../util/logger.js", () => ({
     }),
 }));
 
-let mockSendMessage = mock(async () => ({
-  content: [
-    {
-      type: "tool_use",
-      id: "tu_1",
-      name: "suggest_trust_rule",
-      input: {
-        pattern: "rm -rf *",
-        risk: "high",
-        scope: "/workspace/myproject/*",
-        description: "Any recursive removal",
-      },
-    },
-  ],
-  model: "test-model",
-  usage: { inputTokens: 10, outputTokens: 20 },
-  stopReason: "tool_use",
-}));
+type OneShotResult =
+  | { status: "ok"; data: Record<string, unknown>; response: unknown }
+  | { status: "unavailable" }
+  | { status: "failure"; reason: string; response?: unknown };
 
-let mockProvider: { sendMessage: typeof mockSendMessage } | null = {
-  sendMessage: mockSendMessage,
-};
-
-let mockExtractToolUseResult: unknown = {
-  type: "tool_use",
-  id: "tu_1",
-  name: "suggest_trust_rule",
-  input: {
+let mockResult: OneShotResult = {
+  status: "ok",
+  data: {
     pattern: "rm -rf *",
     risk: "high",
     scope: "/workspace/myproject/*",
     description: "Any recursive removal",
   },
+  response: { model: "test-model" },
 };
 
+const runOneShotLLMSpy = mock(async () => mockResult);
+
+mock.module("../../../providers/one-shot-llm.js", () => ({
+  runOneShotLLM: runOneShotLLMSpy,
+}));
+
 mock.module("../../../providers/provider-send-message.js", () => ({
-  getConfiguredProvider: async () => mockProvider,
-  createTimeout: () => ({
-    signal: new AbortController().signal,
-    cleanup: () => {},
-  }),
-  extractToolUse: () => mockExtractToolUseResult,
   userMessage: (text: string) => ({ role: "user", content: text }),
 }));
 
@@ -110,35 +95,16 @@ const baseRequest = {
 
 describe("suggestTrustRuleRoute", () => {
   beforeEach(() => {
-    mockSendMessage = mock(async () => ({
-      content: [
-        {
-          type: "tool_use",
-          id: "tu_1",
-          name: "suggest_trust_rule",
-          input: {
-            pattern: "rm -rf *",
-            risk: "high",
-            scope: "/workspace/myproject/*",
-            description: "Any recursive removal",
-          },
-        },
-      ],
-      model: "test-model",
-      usage: { inputTokens: 10, outputTokens: 20 },
-      stopReason: "tool_use",
-    }));
-    mockProvider = { sendMessage: mockSendMessage };
-    mockExtractToolUseResult = {
-      type: "tool_use",
-      id: "tu_1",
-      name: "suggest_trust_rule",
-      input: {
+    runOneShotLLMSpy.mockClear();
+    mockResult = {
+      status: "ok",
+      data: {
         pattern: "rm -rf *",
         risk: "high",
         scope: "/workspace/myproject/*",
         description: "Any recursive removal",
       },
+      response: { model: "test-model" },
     };
   });
 
@@ -162,48 +128,50 @@ describe("suggestTrustRuleRoute", () => {
       });
     });
 
-    test("passes callSite 'trustRuleSuggestion' and tool_choice to provider", async () => {
+    test("invokes runOneShotLLM with the trustRuleSuggestion call site and forced tool", async () => {
       await suggestTrustRuleRoute.handler({
         body: baseRequest as unknown as Record<string, unknown>,
       });
 
-      expect(mockSendMessage).toHaveBeenCalledTimes(1);
-      const callArgs = mockSendMessage.mock.calls[0] as unknown[];
-      const options = callArgs[1] as {
-        config: {
-          callSite: string;
-          tool_choice: { type: string; name: string };
-        };
+      expect(runOneShotLLMSpy).toHaveBeenCalledTimes(1);
+      const callArgs = runOneShotLLMSpy.mock.calls[0] as unknown[];
+      expect(callArgs[0]).toBe("trustRuleSuggestion");
+      const opts = callArgs[2] as {
+        tools: { name: string }[];
+        toolChoice: string;
+        schema: unknown;
       };
-      expect(options.config.callSite).toBe("trustRuleSuggestion");
-      expect(options.config.tool_choice).toEqual({
-        type: "tool",
-        name: "suggest_trust_rule",
-      });
+      expect(opts.toolChoice).toBe("suggest_trust_rule");
+      expect(opts.tools[0]?.name).toBe("suggest_trust_rule");
+      expect(opts.schema).toBeDefined();
     });
   });
 
   describe("no provider", () => {
-    test("throws when getConfiguredProvider returns null", async () => {
-      mockProvider = null;
+    test("throws ServiceUnavailableError (503) when the helper reports unavailable", async () => {
+      mockResult = { status: "unavailable" };
 
-      await expect(
-        suggestTrustRuleRoute.handler({
-          body: baseRequest as unknown as Record<string, unknown>,
-        }),
-      ).rejects.toThrow("No LLM provider configured for trustRuleSuggestion");
+      const promise = suggestTrustRuleRoute.handler({
+        body: baseRequest as unknown as Record<string, unknown>,
+      });
+      await expect(promise).rejects.toBeInstanceOf(ServiceUnavailableError);
+      await expect(promise).rejects.toMatchObject({ statusCode: 503 });
     });
   });
 
-  describe("no tool block", () => {
-    test("throws when extractToolUse returns undefined", async () => {
-      mockExtractToolUseResult = undefined;
+  describe("unusable LLM output", () => {
+    test("throws BadGatewayError (502) when the helper reports a failure", async () => {
+      mockResult = {
+        status: "failure",
+        reason: "tool_use_missing",
+        response: { model: "test-model" },
+      };
 
-      await expect(
-        suggestTrustRuleRoute.handler({
-          body: baseRequest as unknown as Record<string, unknown>,
-        }),
-      ).rejects.toThrow("No tool_use block in trust rule suggestion response");
+      const promise = suggestTrustRuleRoute.handler({
+        body: baseRequest as unknown as Record<string, unknown>,
+      });
+      await expect(promise).rejects.toBeInstanceOf(BadGatewayError);
+      await expect(promise).rejects.toMatchObject({ statusCode: 502 });
     });
   });
 

--- a/assistant/src/runtime/routes/inference-send-routes.ts
+++ b/assistant/src/runtime/routes/inference-send-routes.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 
 import { getConfigReadOnly } from "../../config/loader.js";
 import {
+  createTimeout,
   extractAllText,
   getConfiguredProvider,
   userMessage,
@@ -16,6 +17,9 @@ import {
 import { LOCAL_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+/** Timeout for this user-facing one-shot inference endpoint. */
+const INFERENCE_TIMEOUT_MS = 60_000;
 
 // ---------------------------------------------------------------------------
 // Handler
@@ -56,25 +60,29 @@ async function handleInferenceSend({ body = {} }: RouteHandlerArgs) {
     );
   }
 
-  const response = await provider.sendMessage([userMessage(message)], {
-    systemPrompt,
-    config: {
-      callSite: "inference",
-      max_tokens: maxTokens,
-      model,
-    },
-  });
+  const { signal, cleanup } = createTimeout(INFERENCE_TIMEOUT_MS);
+  try {
+    const response = await provider.sendMessage([userMessage(message)], {
+      systemPrompt,
+      config: {
+        callSite: "inference",
+        max_tokens: maxTokens,
+        model,
+      },
+      signal,
+    });
 
-  const text = extractAllText(response);
-
-  return {
-    response: text,
-    model: response.model,
-    usage: {
-      inputTokens: response.usage.inputTokens,
-      outputTokens: response.usage.outputTokens,
-    },
-  };
+    return {
+      response: extractAllText(response),
+      model: response.model,
+      usage: {
+        inputTokens: response.usage.inputTokens,
+        outputTokens: response.usage.outputTokens,
+      },
+    };
+  } finally {
+    cleanup();
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/routes/inference-send-routes.ts
+++ b/assistant/src/runtime/routes/inference-send-routes.ts
@@ -18,8 +18,20 @@ import { LOCAL_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
-/** Timeout for this user-facing one-shot inference endpoint. */
-const INFERENCE_TIMEOUT_MS = 60_000;
+/**
+ * Default provider timeout for this user-facing one-shot inference endpoint
+ * when the caller supplies none. Matches the CLI's documented default wait
+ * (`assistant inference send` waits up to 32 minutes), so long-running prompts
+ * are not server-cancelled before the CLI's IPC budget elapses.
+ */
+const DEFAULT_INFERENCE_TIMEOUT_MS = 32 * 60 * 1000;
+
+/**
+ * Hard ceiling on the caller-supplied `timeoutMs`. A small margin above the
+ * 32-minute default keeps a misbehaving or unbounded client from pinning a
+ * provider connection open indefinitely.
+ */
+const MAX_INFERENCE_TIMEOUT_MS = 35 * 60 * 1000;
 
 // ---------------------------------------------------------------------------
 // Handler
@@ -35,6 +47,15 @@ async function handleInferenceSend({ body = {} }: RouteHandlerArgs) {
   const model = body.model as string | undefined;
   const profile = body.profile as string | undefined;
   const maxTokens = body.maxTokens as number | undefined;
+  const requestedTimeoutMs = body.timeoutMs as number | undefined;
+
+  // Honor the caller's deadline (the CLI's `--timeout-seconds`), clamped to a
+  // sane ceiling. Defaults to the CLI's documented 32-minute wait so long
+  // inferences are not server-cancelled before the client's IPC budget.
+  const timeoutMs =
+    requestedTimeoutMs !== undefined
+      ? Math.min(requestedTimeoutMs, MAX_INFERENCE_TIMEOUT_MS)
+      : DEFAULT_INFERENCE_TIMEOUT_MS;
 
   // Validate --profile against the configured profile catalog.
   if (profile !== undefined) {
@@ -60,7 +81,7 @@ async function handleInferenceSend({ body = {} }: RouteHandlerArgs) {
     );
   }
 
-  const { signal, cleanup } = createTimeout(INFERENCE_TIMEOUT_MS);
+  const { signal, cleanup } = createTimeout(timeoutMs);
   try {
     const response = await provider.sendMessage([userMessage(message)], {
       systemPrompt,
@@ -109,6 +130,11 @@ export const ROUTES: RouteDefinition[] = [
       model: z.string().optional(),
       profile: z.string().optional(),
       maxTokens: z.number().int().positive().optional(),
+      /**
+       * Caller-supplied provider deadline in ms. Clamped server-side to a
+       * 35-minute ceiling; defaults to the CLI's 32-minute wait when omitted.
+       */
+      timeoutMs: z.number().int().positive().optional(),
     }),
     responseBody: z.object({
       response: z.string(),

--- a/assistant/src/runtime/routes/suggest-trust-rule-routes.ts
+++ b/assistant/src/runtime/routes/suggest-trust-rule-routes.ts
@@ -8,13 +8,10 @@
 
 import { z } from "zod";
 
-import {
-  createTimeout,
-  extractToolUse,
-  getConfiguredProvider,
-  userMessage,
-} from "../../providers/provider-send-message.js";
+import { runOneShotLLM } from "../../providers/one-shot-llm.js";
+import { userMessage } from "../../providers/provider-send-message.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import { BadGatewayError, ServiceUnavailableError } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 // ── Request / response shapes ─────────────────────────────────────────
@@ -88,6 +85,14 @@ const SUGGEST_RULE_TOOL = {
     required: ["pattern", "risk", "description"],
   },
 };
+
+/** Zod schema validating the `suggest_trust_rule` tool input. */
+const SuggestRuleToolInputSchema = z.object({
+  pattern: z.string(),
+  risk: z.enum(["low", "medium", "high"]),
+  scope: z.string().optional(),
+  description: z.string(),
+});
 
 // ── System prompt ────────────────────────────────────────────────────
 
@@ -175,44 +180,38 @@ async function handleSuggestTrustRule({
 }: RouteHandlerArgs): Promise<SuggestTrustRuleResponse> {
   const req = body as unknown as SuggestTrustRuleRequest;
 
-  const provider = await getConfiguredProvider("trustRuleSuggestion");
-  if (!provider) {
-    throw new Error("No LLM provider configured for trustRuleSuggestion");
-  }
+  const result = await runOneShotLLM(
+    "trustRuleSuggestion",
+    [userMessage(buildUserMessage(req))],
+    {
+      systemPrompt: SYSTEM_PROMPT,
+      tools: [SUGGEST_RULE_TOOL],
+      toolChoice: "suggest_trust_rule",
+      schema: SuggestRuleToolInputSchema,
+    },
+  );
 
-  const { signal, cleanup } = createTimeout(30_000);
-  try {
-    const response = await provider.sendMessage(
-      [userMessage(buildUserMessage(req))],
-      {
-        tools: [SUGGEST_RULE_TOOL],
-        systemPrompt: SYSTEM_PROMPT,
-        config: {
-          callSite: "trustRuleSuggestion",
-          tool_choice: { type: "tool" as const, name: "suggest_trust_rule" },
-        },
-        signal,
-      },
+  if (result.status === "unavailable") {
+    throw new ServiceUnavailableError(
+      "LLM backend unavailable: no provider configured for trust rule suggestion",
     );
-    cleanup();
-
-    const toolBlock = extractToolUse(response);
-    if (!toolBlock) {
-      throw new Error("No tool_use block in trust rule suggestion response");
-    }
-
-    const input = toolBlock.input as Record<string, unknown>;
-    return {
-      pattern: input.pattern as string,
-      risk: input.risk as string,
-      scope: input.scope as string | undefined,
-      description: input.description as string,
-      scopeOptions: req.scopeOptions,
-      directoryScopeOptions: req.directoryScopeOptions,
-    };
-  } finally {
-    cleanup();
   }
+  if (result.status === "failure") {
+    // The provider responded but produced no usable suggestion (timeout,
+    // missing tool_use block, or schema mismatch) — an upstream-output
+    // failure, not a client error.
+    throw new BadGatewayError(`Trust rule suggestion failed: ${result.reason}`);
+  }
+
+  const input = result.data;
+  return {
+    pattern: input.pattern,
+    risk: input.risk,
+    scope: input.scope,
+    description: input.description,
+    scopeOptions: req.scopeOptions,
+    directoryScopeOptions: req.directoryScopeOptions,
+  };
 }
 
 // ── Zod schemas for OpenAPI ──────────────────────────────────────────


### PR DESCRIPTION
Part of #34399. Closes #34404. Documents the null-provider policy, replaces bare Error throws with RouteError subclasses in suggest-trust-rule routes, adds a timeout + structured error to the skill IPC provider route (meet-join compatible), and adds a timeout to the inference send route.