### PR TITLE
feat(web): friendly cadence builder for the Create-schedule modal

### DIFF
--- a/apps/web/src/domains/settings/components/create-schedule-modal.tsx
+++ b/apps/web/src/domains/settings/components/create-schedule-modal.tsx
@@ -58,13 +58,16 @@ const MINUTE_OPTIONS: DropdownOption<string>[] = Array.from(
   },
 );
 
-const DAY_OF_MONTH_OPTIONS: DropdownOption<string>[] = Array.from(
-  { length: 31 },
-  (_, i) => {
+// Only days that exist in every month (1–28) plus an explicit "Last day", so a
+// monthly schedule never silently skips short months. The 29th–31st (which skip
+// February etc.) remain available through the Advanced cron field.
+const DAY_OF_MONTH_OPTIONS: DropdownOption<string>[] = [
+  ...Array.from({ length: 28 }, (_, i) => {
     const day = i + 1;
     return { value: String(day), label: formatOrdinal(day) };
-  },
-);
+  }),
+  { value: "last", label: "Last day" },
+];
 
 const PERIOD_ITEMS: SegmentControlItem<"AM" | "PM">[] = [
   { value: "AM", label: "AM" },
@@ -336,12 +339,15 @@ function CadenceBuilder({
         <SubField label="On day">
           <Dropdown
             options={DAY_OF_MONTH_OPTIONS}
-            value={String(cadence.dayOfMonth)}
+            value={cadence.dayOfMonth === "last" ? "last" : String(cadence.dayOfMonth)}
             onChange={(value) =>
-              onChange({ ...cadence, dayOfMonth: Number(value) })
+              onChange({
+                ...cadence,
+                dayOfMonth: value === "last" ? "last" : Number(value),
+              })
             }
             aria-label="Day of month"
-            className="w-28"
+            className="w-32"
           />
         </SubField>
       ) : null}

--- a/apps/web/src/domains/settings/components/create-schedule-modal.tsx
+++ b/apps/web/src/domains/settings/components/create-schedule-modal.tsx
@@ -1,30 +1,98 @@
-import { useState, type FormEvent } from "react";
+import { Clock } from "lucide-react";
+import { useMemo, useState, type FormEvent, type ReactNode } from "react";
 
 import {
-    createSchedule,
-    type CreateSchedulePayload,
+  createSchedule,
+  type CreateSchedulePayload,
 } from "@/domains/settings/api/schedules";
+import {
+  buildCronExpression,
+  type Cadence,
+  describeCadence,
+  DEFAULT_CADENCE,
+  formatOrdinal,
+  type ScheduleFrequency,
+  WEEKDAYS,
+} from "@/domains/settings/utils/cron-builder";
+import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
+import { cn } from "@vellumai/design-library";
 import { Button } from "@vellumai/design-library/components/button";
+import {
+  Dropdown,
+  type DropdownOption,
+} from "@vellumai/design-library/components/dropdown";
 import { Input, Textarea } from "@vellumai/design-library/components/input";
 import { Modal } from "@vellumai/design-library/components/modal";
+import {
+  SegmentControl,
+  type SegmentControlItem,
+} from "@vellumai/design-library/components/segment-control";
 
 // ---------------------------------------------------------------------------
-// Cron presets — cover the most common cases without forcing users to learn
-// cron syntax. Free-form expression is still accepted for advanced cases.
+// Static option lists for the cadence builder
 // ---------------------------------------------------------------------------
 
-interface CronPreset {
-  readonly label: string;
-  readonly expression: string;
+const FREQUENCY_ITEMS: SegmentControlItem<ScheduleFrequency>[] = [
+  { value: "hourly", label: "Hourly" },
+  { value: "daily", label: "Daily" },
+  { value: "weekly", label: "Weekly" },
+  { value: "monthly", label: "Monthly" },
+];
+
+const HOUR12_OPTIONS: DropdownOption<string>[] = Array.from(
+  { length: 12 },
+  (_, i) => {
+    const hour = i + 1;
+    return { value: String(hour), label: String(hour) };
+  },
+);
+
+// Five-minute granularity keeps the menu short while covering the times people
+// actually schedule.
+const MINUTE_OPTIONS: DropdownOption<string>[] = Array.from(
+  { length: 12 },
+  (_, i) => {
+    const minute = i * 5;
+    const padded = String(minute).padStart(2, "0");
+    return { value: padded, label: padded };
+  },
+);
+
+const DAY_OF_MONTH_OPTIONS: DropdownOption<string>[] = Array.from(
+  { length: 31 },
+  (_, i) => {
+    const day = i + 1;
+    return { value: String(day), label: formatOrdinal(day) };
+  },
+);
+
+const PERIOD_ITEMS: SegmentControlItem<"AM" | "PM">[] = [
+  { value: "AM", label: "AM" },
+  { value: "PM", label: "PM" },
+];
+
+function to24Hour(hour12: number, period: "AM" | "PM"): number {
+  const base = hour12 % 12;
+  return period === "PM" ? base + 12 : base;
 }
 
-const CRON_PRESETS: readonly CronPreset[] = [
-  { label: "Every hour", expression: "0 * * * *" },
-  { label: "Every day at 9am", expression: "0 9 * * *" },
-  { label: "Every weekday at 9am", expression: "0 9 * * 1-5" },
-  { label: "Every Monday at 9am", expression: "0 9 * * 1" },
-  { label: "Every 1st of month, 9am", expression: "0 9 1 * *" },
-];
+/** Friendly timezone label, e.g. "America/New_York · EDT". */
+function describeTimezone(timezone: string): string {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      timeZoneName: "short",
+    }).formatToParts(new Date());
+    const abbreviation = parts.find(
+      (part) => part.type === "timeZoneName",
+    )?.value;
+    return abbreviation && abbreviation !== timezone
+      ? `${timezone} · ${abbreviation}`
+      : timezone;
+  } catch {
+    return timezone;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Props
@@ -74,20 +142,36 @@ function CreateScheduleModalInner({
   onClose: () => void;
   onCreated: () => void;
 }) {
+  const timezone = useEffectiveTimezone();
+
   const [name, setName] = useState("");
-  const [expression, setExpression] = useState("");
   const [message, setMessage] = useState("");
-  const [timezone, setTimezone] = useState("");
+  const [mode, setMode] = useState<"simple" | "advanced">("simple");
+  const [cadence, setCadence] = useState<Cadence>(DEFAULT_CADENCE);
+  const [rawExpression, setRawExpression] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
   const trimmedName = name.trim();
-  const trimmedExpression = expression.trim();
   const trimmedMessage = message.trim();
+  const trimmedRaw = rawExpression.trim();
+
+  const expression = useMemo(
+    () => (mode === "simple" ? buildCronExpression(cadence) : trimmedRaw),
+    [mode, cadence, trimmedRaw],
+  );
+
+  const summary = useMemo(() => {
+    if (mode === "simple") return describeCadence(cadence);
+    return trimmedRaw ? trimmedRaw : "Enter a cron expression to continue.";
+  }, [mode, cadence, trimmedRaw]);
+
+  const timezoneLabel = useMemo(() => describeTimezone(timezone), [timezone]);
+
   const canSubmit =
     trimmedName.length > 0 &&
-    trimmedExpression.length > 0 &&
     trimmedMessage.length > 0 &&
+    expression.length > 0 &&
     !submitting;
 
   const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
@@ -98,22 +182,29 @@ function CreateScheduleModalInner({
     try {
       const payload: CreateSchedulePayload = {
         name: trimmedName,
-        expression: trimmedExpression,
+        expression,
         message: trimmedMessage,
+        // Schedules always run in the user's current timezone — inferred here
+        // rather than asked for, so the time the user picked means what they
+        // expect.
+        timezone,
       };
-      const tz = timezone.trim();
-      if (tz) payload.timezone = tz;
       await createSchedule(assistantId, payload);
       setSubmitting(false);
       onCreated();
     } catch (err) {
       setSubmitError(
-        err instanceof Error
-          ? err.message
-          : "Failed to create schedule.",
+        err instanceof Error ? err.message : "Failed to create schedule.",
       );
       setSubmitting(false);
     }
+  };
+
+  const switchToAdvanced = () => {
+    // Seed the raw field with the equivalent cron so power users start from
+    // what they had configured rather than a blank box.
+    setRawExpression((prev) => prev || buildCronExpression(cadence));
+    setMode("advanced");
   };
 
   return (
@@ -121,15 +212,14 @@ function CreateScheduleModalInner({
       <Modal.Header>
         <Modal.Title>Create schedule</Modal.Title>
         <Modal.Description>
-          Schedule a recurring instruction for your assistant. Runs in
-          execute mode — the message is delivered to the assistant on each
-          fire.
+          Schedule a recurring instruction for your assistant. Runs in execute
+          mode — the message is delivered to the assistant on each fire.
         </Modal.Description>
       </Modal.Header>
 
       <form onSubmit={onSubmit}>
         <Modal.Body>
-          <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-5">
             <Input
               label="Name"
               placeholder="Morning briefing"
@@ -140,39 +230,33 @@ function CreateScheduleModalInner({
               fullWidth
             />
 
-            <div className="flex flex-col gap-1.5">
-              <Input
-                label="Cron expression"
-                placeholder="0 9 * * *"
-                value={expression}
-                onChange={(e) => setExpression(e.target.value)}
-                required
-                fullWidth
-                helperText="Standard 5-field cron (minute hour day month weekday). RRULE expressions are also accepted."
-              />
-              <div className="flex flex-wrap gap-1.5">
-                {CRON_PRESETS.map((preset) => (
-                  <Button
-                    key={preset.expression}
-                    variant="outlined"
-                    size="compact"
-                    type="button"
-                    onClick={() => setExpression(preset.expression)}
-                  >
-                    {preset.label}
-                  </Button>
-                ))}
-              </div>
-            </div>
+            <Field label="Repeat">
+              {mode === "simple" ? (
+                <CadenceBuilder cadence={cadence} onChange={setCadence} />
+              ) : (
+                <AdvancedCron
+                  value={rawExpression}
+                  onChange={setRawExpression}
+                  onUseSimple={() => setMode("simple")}
+                />
+              )}
+            </Field>
 
-            <Input
-              label="Timezone (optional)"
-              placeholder="America/New_York"
-              value={timezone}
-              onChange={(e) => setTimezone(e.target.value)}
-              fullWidth
-              helperText="IANA timezone name. Leave blank to use UTC."
+            <ScheduleSummary
+              summary={summary}
+              mono={mode === "advanced" && trimmedRaw.length > 0}
+              timezoneLabel={timezoneLabel}
             />
+
+            {mode === "simple" ? (
+              <button
+                type="button"
+                onClick={switchToAdvanced}
+                className="self-start text-body-small-default text-[var(--content-tertiary)] underline-offset-2 transition-colors hover:text-[var(--content-default)] hover:underline"
+              >
+                Advanced — write a cron expression
+              </button>
+            ) : null}
 
             <Textarea
               label="Message"
@@ -202,5 +286,262 @@ function CreateScheduleModalInner({
         </Modal.Footer>
       </form>
     </Modal.Content>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Cadence builder (simple mode)
+// ---------------------------------------------------------------------------
+
+function CadenceBuilder({
+  cadence,
+  onChange,
+}: {
+  cadence: Cadence;
+  onChange: (next: Cadence) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <SegmentControl
+        items={FREQUENCY_ITEMS}
+        value={cadence.frequency}
+        onChange={(frequency) => onChange({ ...cadence, frequency })}
+        ariaLabel="How often the schedule runs"
+      />
+
+      {cadence.frequency === "hourly" ? (
+        <SubField label="At minute">
+          <Dropdown
+            options={MINUTE_OPTIONS}
+            value={String(cadence.minute).padStart(2, "0")}
+            onChange={(value) =>
+              onChange({ ...cadence, minute: Number(value) })
+            }
+            aria-label="Minute"
+            className="w-24"
+          />
+        </SubField>
+      ) : null}
+
+      {cadence.frequency === "weekly" ? (
+        <SubField label="On these days">
+          <WeekdayPicker
+            value={cadence.weekdays}
+            onChange={(weekdays) => onChange({ ...cadence, weekdays })}
+          />
+        </SubField>
+      ) : null}
+
+      {cadence.frequency === "monthly" ? (
+        <SubField label="On day">
+          <Dropdown
+            options={DAY_OF_MONTH_OPTIONS}
+            value={String(cadence.dayOfMonth)}
+            onChange={(value) =>
+              onChange({ ...cadence, dayOfMonth: Number(value) })
+            }
+            aria-label="Day of month"
+            className="w-28"
+          />
+        </SubField>
+      ) : null}
+
+      {cadence.frequency !== "hourly" ? (
+        <SubField label="At time">
+          <TimeFields
+            hour24={cadence.hour24}
+            minute={cadence.minute}
+            onChange={(hour24, minute) =>
+              onChange({ ...cadence, hour24, minute })
+            }
+          />
+        </SubField>
+      ) : null}
+    </div>
+  );
+}
+
+function TimeFields({
+  hour24,
+  minute,
+  onChange,
+}: {
+  hour24: number;
+  minute: number;
+  onChange: (hour24: number, minute: number) => void;
+}) {
+  const period: "AM" | "PM" = hour24 < 12 ? "AM" : "PM";
+  const hour12 = hour24 % 12 === 0 ? 12 : hour24 % 12;
+
+  return (
+    <div className="flex items-center gap-2">
+      <Dropdown
+        options={HOUR12_OPTIONS}
+        value={String(hour12)}
+        onChange={(value) => onChange(to24Hour(Number(value), period), minute)}
+        aria-label="Hour"
+        className="w-[72px]"
+      />
+      <span className="text-body-medium-default text-[var(--content-tertiary)]">
+        :
+      </span>
+      <Dropdown
+        options={MINUTE_OPTIONS}
+        value={String(minute).padStart(2, "0")}
+        onChange={(value) => onChange(hour24, Number(value))}
+        aria-label="Minute"
+        className="w-[72px]"
+      />
+      <div className="w-[112px]">
+        <SegmentControl
+          items={PERIOD_ITEMS}
+          value={period}
+          onChange={(nextPeriod) =>
+            onChange(to24Hour(hour12, nextPeriod), minute)
+          }
+          ariaLabel="AM or PM"
+        />
+      </div>
+    </div>
+  );
+}
+
+function WeekdayPicker({
+  value,
+  onChange,
+}: {
+  value: readonly number[];
+  onChange: (next: number[]) => void;
+}) {
+  const selected = new Set(value);
+
+  const toggle = (day: number) => {
+    const next = new Set(selected);
+    if (next.has(day)) {
+      // Keep at least one day selected — an empty set can't be scheduled.
+      if (next.size > 1) next.delete(day);
+    } else {
+      next.add(day);
+    }
+    onChange([...next].sort((a, b) => a - b));
+  };
+
+  return (
+    <div className="flex gap-1.5">
+      {WEEKDAYS.map((weekday) => {
+        const isActive = selected.has(weekday.value);
+        return (
+          <button
+            key={weekday.value}
+            type="button"
+            onClick={() => toggle(weekday.value)}
+            aria-pressed={isActive}
+            aria-label={weekday.full}
+            title={weekday.full}
+            className={cn(
+              "flex h-9 w-9 items-center justify-center rounded-md border text-body-medium-default transition-colors",
+              isActive
+                ? "border-[var(--border-active)] bg-[var(--surface-active)] text-[var(--content-emphasised)]"
+                : "border-[var(--field-border)] text-[var(--content-tertiary)] hover:border-[var(--border-active)] hover:text-[var(--content-default)]",
+            )}
+          >
+            {weekday.letter}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Advanced cron mode
+// ---------------------------------------------------------------------------
+
+function AdvancedCron({
+  value,
+  onChange,
+  onUseSimple,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+  onUseSimple: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <Input
+        placeholder="0 9 * * *"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        fullWidth
+        className="font-mono"
+        aria-label="Cron expression"
+        helperText="Standard 5-field cron (minute hour day month weekday). RRULE expressions are also accepted."
+      />
+      <button
+        type="button"
+        onClick={onUseSimple}
+        className="self-start text-body-small-default text-[var(--content-tertiary)] underline-offset-2 transition-colors hover:text-[var(--content-default)] hover:underline"
+      >
+        ← Back to the simple builder
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Shared presentational helpers
+// ---------------------------------------------------------------------------
+
+function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="text-body-small-default text-[var(--content-secondary)]">
+        {label}
+      </span>
+      {children}
+    </div>
+  );
+}
+
+function SubField({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5">
+      <span className="min-w-[88px] text-body-small-default text-[var(--content-tertiary)]">
+        {label}
+      </span>
+      {children}
+    </div>
+  );
+}
+
+function ScheduleSummary({
+  summary,
+  mono,
+  timezoneLabel,
+}: {
+  summary: string;
+  mono: boolean;
+  timezoneLabel: string;
+}) {
+  return (
+    <div className="flex items-start gap-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-lift)] px-3.5 py-3">
+      <Clock
+        className="mt-0.5 h-4 w-4 shrink-0 text-[var(--content-tertiary)]"
+        aria-hidden
+      />
+      <div className="min-w-0">
+        <p
+          className={cn(
+            "text-body-medium-default text-[var(--content-default)]",
+            mono && "break-all font-mono",
+          )}
+        >
+          {summary}
+        </p>
+        <p className="mt-0.5 text-body-small-default text-[var(--content-tertiary)]">
+          Times use your timezone — {timezoneLabel}.
+        </p>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/domains/settings/utils/cron-builder.test.ts
+++ b/apps/web/src/domains/settings/utils/cron-builder.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildCronExpression,
+  type Cadence,
+  describeCadence,
+  DEFAULT_CADENCE,
+  formatTimeOfDay,
+  normalizeWeekdays,
+} from "@/domains/settings/utils/cron-builder";
+
+function cadence(overrides: Partial<Cadence>): Cadence {
+  return { ...DEFAULT_CADENCE, ...overrides };
+}
+
+describe("buildCronExpression", () => {
+  test("hourly fires at the chosen minute of every hour", () => {
+    expect(buildCronExpression(cadence({ frequency: "hourly", minute: 30 }))).toBe(
+      "30 * * * *",
+    );
+  });
+
+  test("daily fires at the chosen time", () => {
+    expect(
+      buildCronExpression(
+        cadence({ frequency: "daily", hour24: 9, minute: 0 }),
+      ),
+    ).toBe("0 9 * * *");
+  });
+
+  test("weekly joins selected weekdays in cron order", () => {
+    expect(
+      buildCronExpression(
+        cadence({
+          frequency: "weekly",
+          hour24: 9,
+          minute: 0,
+          weekdays: [5, 1, 3],
+        }),
+      ),
+    ).toBe("0 9 * * 1,3,5");
+  });
+
+  test("monthly fires on the chosen day of month", () => {
+    expect(
+      buildCronExpression(
+        cadence({
+          frequency: "monthly",
+          hour24: 14,
+          minute: 0,
+          dayOfMonth: 15,
+        }),
+      ),
+    ).toBe("0 14 15 * *");
+  });
+
+  test("clamps out-of-range values into valid cron fields", () => {
+    expect(
+      buildCronExpression(
+        cadence({ frequency: "monthly", hour24: 99, minute: -5, dayOfMonth: 99 }),
+      ),
+    ).toBe("0 23 31 * *");
+  });
+});
+
+describe("normalizeWeekdays", () => {
+  test("dedupes, sorts, and defaults to Monday when empty", () => {
+    expect(normalizeWeekdays([3, 1, 3])).toEqual([1, 3]);
+    expect(normalizeWeekdays([])).toEqual([1]);
+  });
+});
+
+describe("formatTimeOfDay", () => {
+  test("formats 12-hour clock with AM/PM", () => {
+    expect(formatTimeOfDay(0, 0)).toBe("12:00 AM");
+    expect(formatTimeOfDay(9, 5)).toBe("9:05 AM");
+    expect(formatTimeOfDay(12, 30)).toBe("12:30 PM");
+    expect(formatTimeOfDay(13, 0)).toBe("1:00 PM");
+  });
+});
+
+describe("describeCadence", () => {
+  test("hourly", () => {
+    expect(describeCadence(cadence({ frequency: "hourly", minute: 0 }))).toBe(
+      "Runs every hour at :00",
+    );
+  });
+
+  test("daily", () => {
+    expect(
+      describeCadence(cadence({ frequency: "daily", hour24: 9, minute: 0 })),
+    ).toBe("Runs every day at 9:00 AM");
+  });
+
+  test("weekly collapses Mon–Fri to 'every weekday'", () => {
+    expect(
+      describeCadence(
+        cadence({ frequency: "weekly", weekdays: [1, 2, 3, 4, 5] }),
+      ),
+    ).toBe("Runs every weekday at 9:00 AM");
+  });
+
+  test("weekly collapses the full week to 'every day'", () => {
+    expect(
+      describeCadence(
+        cadence({ frequency: "weekly", weekdays: [0, 1, 2, 3, 4, 5, 6] }),
+      ),
+    ).toBe("Runs every day at 9:00 AM");
+  });
+
+  test("weekly collapses Sat+Sun to 'every weekend'", () => {
+    expect(
+      describeCadence(cadence({ frequency: "weekly", weekdays: [0, 6] })),
+    ).toBe("Runs every weekend at 9:00 AM");
+  });
+
+  test("weekly lists an arbitrary set of days", () => {
+    expect(
+      describeCadence(cadence({ frequency: "weekly", weekdays: [1, 3, 5] })),
+    ).toBe("Runs every Mon, Wed & Fri at 9:00 AM");
+  });
+
+  test("monthly uses an ordinal day", () => {
+    expect(
+      describeCadence(
+        cadence({ frequency: "monthly", dayOfMonth: 1, hour24: 9, minute: 0 }),
+      ),
+    ).toBe("Runs on the 1st of every month at 9:00 AM");
+    expect(
+      describeCadence(
+        cadence({ frequency: "monthly", dayOfMonth: 22, hour24: 9, minute: 0 }),
+      ),
+    ).toBe("Runs on the 22nd of every month at 9:00 AM");
+  });
+});

--- a/apps/web/src/domains/settings/utils/cron-builder.test.ts
+++ b/apps/web/src/domains/settings/utils/cron-builder.test.ts
@@ -54,12 +54,27 @@ describe("buildCronExpression", () => {
     ).toBe("0 14 15 * *");
   });
 
+  test("monthly 'last' maps to cron L so short months are never skipped", () => {
+    expect(
+      buildCronExpression(
+        cadence({
+          frequency: "monthly",
+          hour24: 9,
+          minute: 0,
+          dayOfMonth: "last",
+        }),
+      ),
+    ).toBe("0 9 L * *");
+  });
+
   test("clamps out-of-range values into valid cron fields", () => {
+    // dayOfMonth caps at 28 — the simple builder never targets 29–31, which
+    // would skip months that lack those dates.
     expect(
       buildCronExpression(
         cadence({ frequency: "monthly", hour24: 99, minute: -5, dayOfMonth: 99 }),
       ),
-    ).toBe("0 23 31 * *");
+    ).toBe("0 23 28 * *");
   });
 });
 
@@ -131,5 +146,18 @@ describe("describeCadence", () => {
         cadence({ frequency: "monthly", dayOfMonth: 22, hour24: 9, minute: 0 }),
       ),
     ).toBe("Runs on the 22nd of every month at 9:00 AM");
+  });
+
+  test("monthly 'last' reads as the last day", () => {
+    expect(
+      describeCadence(
+        cadence({
+          frequency: "monthly",
+          dayOfMonth: "last",
+          hour24: 9,
+          minute: 0,
+        }),
+      ),
+    ).toBe("Runs on the last day of every month at 9:00 AM");
   });
 });

--- a/apps/web/src/domains/settings/utils/cron-builder.ts
+++ b/apps/web/src/domains/settings/utils/cron-builder.ts
@@ -18,8 +18,13 @@ export interface Cadence {
   readonly hour24: number;
   /** Selected weekdays, 0 = Sunday … 6 = Saturday. Used by weekly. */
   readonly weekdays: readonly number[];
-  /** Day of month, 1–31. Used by monthly. */
-  readonly dayOfMonth: number;
+  /**
+   * Day of month for the monthly cadence: 1–28 (days that exist in every
+   * month) or "last" for the final day. We deliberately omit 29–31 from the
+   * simple builder so a monthly schedule never silently skips short months —
+   * those cases remain reachable via the Advanced cron field.
+   */
+  readonly dayOfMonth: number | "last";
 }
 
 /** Sensible starting point: every day at 9:00 AM. */
@@ -84,7 +89,10 @@ export function buildCronExpression(cadence: Cadence): string {
     case "weekly":
       return `${minute} ${hour} * * ${normalizeWeekdays(cadence.weekdays).join(",")}`;
     case "monthly": {
-      const dayOfMonth = clampInt(cadence.dayOfMonth, 1, 31);
+      if (cadence.dayOfMonth === "last") {
+        return `${minute} ${hour} L * *`;
+      }
+      const dayOfMonth = clampInt(cadence.dayOfMonth, 1, 28);
       return `${minute} ${hour} ${dayOfMonth} * *`;
     }
   }
@@ -141,6 +149,8 @@ export function describeCadence(cadence: Cadence): string {
     case "weekly":
       return `Runs ${describeWeekdays(cadence.weekdays)} at ${time}`;
     case "monthly":
-      return `Runs on the ${formatOrdinal(clampInt(cadence.dayOfMonth, 1, 31))} of every month at ${time}`;
+      return cadence.dayOfMonth === "last"
+        ? `Runs on the last day of every month at ${time}`
+        : `Runs on the ${formatOrdinal(clampInt(cadence.dayOfMonth, 1, 28))} of every month at ${time}`;
   }
 }

--- a/apps/web/src/domains/settings/utils/cron-builder.ts
+++ b/apps/web/src/domains/settings/utils/cron-builder.ts
@@ -1,0 +1,146 @@
+/**
+ * Pure helpers that translate a structured "cadence" (a friendly frequency +
+ * time) into a standard 5-field cron expression and a human-readable summary.
+ *
+ * The Create-schedule modal builds schedules from approachable controls instead
+ * of forcing users to write cron by hand. These functions are the single source
+ * of truth for that translation and are kept pure so they can be unit-tested
+ * without a DOM.
+ */
+
+export type ScheduleFrequency = "hourly" | "daily" | "weekly" | "monthly";
+
+export interface Cadence {
+  readonly frequency: ScheduleFrequency;
+  /** Minute within the hour, 0–59. Used by every frequency. */
+  readonly minute: number;
+  /** Hour of day, 0–23. Ignored for hourly. */
+  readonly hour24: number;
+  /** Selected weekdays, 0 = Sunday … 6 = Saturday. Used by weekly. */
+  readonly weekdays: readonly number[];
+  /** Day of month, 1–31. Used by monthly. */
+  readonly dayOfMonth: number;
+}
+
+/** Sensible starting point: every day at 9:00 AM. */
+export const DEFAULT_CADENCE: Cadence = {
+  frequency: "daily",
+  minute: 0,
+  hour24: 9,
+  weekdays: [1], // Monday
+  dayOfMonth: 1,
+};
+
+export interface WeekdayMeta {
+  /** Cron day-of-week value (0 = Sunday … 6 = Saturday). */
+  readonly value: number;
+  /** Single-letter label for compact chips. */
+  readonly letter: string;
+  /** Abbreviated label, e.g. "Mon". */
+  readonly short: string;
+  /** Full label, e.g. "Monday". */
+  readonly full: string;
+}
+
+export const WEEKDAYS: readonly WeekdayMeta[] = [
+  { value: 0, letter: "S", short: "Sun", full: "Sunday" },
+  { value: 1, letter: "M", short: "Mon", full: "Monday" },
+  { value: 2, letter: "T", short: "Tue", full: "Tuesday" },
+  { value: 3, letter: "W", short: "Wed", full: "Wednesday" },
+  { value: 4, letter: "T", short: "Thu", full: "Thursday" },
+  { value: 5, letter: "F", short: "Fri", full: "Friday" },
+  { value: 6, letter: "S", short: "Sat", full: "Saturday" },
+];
+
+const MONDAY_TO_FRIDAY = [1, 2, 3, 4, 5];
+
+function clampInt(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(max, Math.max(min, Math.round(value)));
+}
+
+/** Unique, sorted weekday list; falls back to Monday when empty. */
+export function normalizeWeekdays(weekdays: readonly number[]): number[] {
+  const unique = Array.from(
+    new Set(
+      weekdays
+        .map((d) => clampInt(d, 0, 6))
+        .filter((d) => Number.isInteger(d)),
+    ),
+  ).sort((a, b) => a - b);
+  return unique.length > 0 ? unique : [1];
+}
+
+/** Build a standard 5-field cron expression (minute hour dom month dow). */
+export function buildCronExpression(cadence: Cadence): string {
+  const minute = clampInt(cadence.minute, 0, 59);
+  const hour = clampInt(cadence.hour24, 0, 23);
+
+  switch (cadence.frequency) {
+    case "hourly":
+      return `${minute} * * * *`;
+    case "daily":
+      return `${minute} ${hour} * * *`;
+    case "weekly":
+      return `${minute} ${hour} * * ${normalizeWeekdays(cadence.weekdays).join(",")}`;
+    case "monthly": {
+      const dayOfMonth = clampInt(cadence.dayOfMonth, 1, 31);
+      return `${minute} ${hour} ${dayOfMonth} * *`;
+    }
+  }
+}
+
+/** Format a 24-hour time as a 12-hour clock string, e.g. "9:05 AM". */
+export function formatTimeOfDay(hour24: number, minute: number): string {
+  const hour = clampInt(hour24, 0, 23);
+  const min = clampInt(minute, 0, 59);
+  const period = hour < 12 ? "AM" : "PM";
+  const hour12 = hour % 12 === 0 ? 12 : hour % 12;
+  return `${hour12}:${String(min).padStart(2, "0")} ${period}`;
+}
+
+/** Format a number with its English ordinal suffix, e.g. 1 → "1st", 22 → "22nd". */
+export function formatOrdinal(n: number): string {
+  const suffixes = ["th", "st", "nd", "rd"];
+  const v = n % 100;
+  return `${n}${suffixes[(v - 20) % 10] ?? suffixes[v] ?? suffixes[0]}`;
+}
+
+function describeWeekdays(weekdays: readonly number[]): string {
+  const days = normalizeWeekdays(weekdays);
+  const set = new Set(days);
+
+  if (days.length === 7) return "every day";
+  if (days.length === 5 && MONDAY_TO_FRIDAY.every((d) => set.has(d))) {
+    return "every weekday";
+  }
+  if (days.length === 2 && set.has(0) && set.has(6)) return "every weekend";
+  if (days.length === 1) {
+    return `every ${WEEKDAYS[days[0]]?.full ?? "day"}`;
+  }
+
+  const names = days.map((d) => WEEKDAYS[d]?.short ?? "");
+  const last = names.pop();
+  return `every ${names.join(", ")} & ${last}`;
+}
+
+/**
+ * Plain-language description of when a cadence fires, e.g.
+ * "Runs every weekday at 9:00 AM".
+ */
+export function describeCadence(cadence: Cadence): string {
+  const time = formatTimeOfDay(cadence.hour24, cadence.minute);
+
+  switch (cadence.frequency) {
+    case "hourly": {
+      const minute = clampInt(cadence.minute, 0, 59);
+      return `Runs every hour at :${String(minute).padStart(2, "0")}`;
+    }
+    case "daily":
+      return `Runs every day at ${time}`;
+    case "weekly":
+      return `Runs ${describeWeekdays(cadence.weekdays)} at ${time}`;
+    case "monthly":
+      return `Runs on the ${formatOrdinal(clampInt(cadence.dayOfMonth, 1, 31))} of every month at ${time}`;
+  }
+}


### PR DESCRIPTION
## Summary
- Replace the raw `cron expression` field with a **cadence builder** — a Hourly / Daily / Weekly / Monthly segment control plus contextual pickers (a 12-hour time picker, weekday chips, day-of-month). Writing cron by hand is now an opt-in **Advanced** mode that's pre-seeded with the equivalent expression.
- Remove the manual **Timezone** field. Schedules now infer the user's effective timezone (`useEffectiveTimezone`) and always submit it, so the time you pick means what you expect.
- Add a **summary card** that states what the schedule will do in plain language (e.g. "Runs every weekday at 9:00 AM") and names the inferred timezone ("Times use your timezone — America/New_York · EDT").
- Extract a pure `cron-builder` util (cron-string construction + human-readable summary) with unit tests.

## Original prompt
Polish the Create-schedule modal into a genuinely good UX. The raw cron-expression field is too unfriendly to be the primary control, so demote it to an advanced option and build an approachable way to configure how often a schedule runs. Drop the timezone field entirely and infer the user's timezone instead, and make it clear somewhere in the modal what the schedule will actually do (including which timezone it runs in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)