### PR TITLE
Expose Authored Descriptions In Schedule Routes

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -20298,9 +20298,9 @@ paths:
                             - type: number
                             - type: "null"
                         description:
-                          anyOf:
-                            - type: string
-                            - type: "null"
+                          type: string
+                        cadenceDescription:
+                          type: string
                         mode:
                           type: string
                           enum:
@@ -20350,6 +20350,7 @@ paths:
                         - createdFromConversationExists
                         - createdFromConversationArchivedAt
                         - description
+                        - cadenceDescription
                         - mode
                         - status
                         - routingIntent
@@ -20447,9 +20448,9 @@ paths:
                             - type: number
                             - type: "null"
                         description:
-                          anyOf:
-                            - type: string
-                            - type: "null"
+                          type: string
+                        cadenceDescription:
+                          type: string
                         mode:
                           type: string
                           enum:
@@ -20499,6 +20500,7 @@ paths:
                         - createdFromConversationExists
                         - createdFromConversationArchivedAt
                         - description
+                        - cadenceDescription
                         - mode
                         - status
                         - routingIntent
@@ -20520,6 +20522,9 @@ paths:
                 name:
                   type: string
                   description: Display name
+                description:
+                  type: string
+                  description: Authored schedule description
                 expression:
                   type: string
                   description: Cron or RRULE expression
@@ -20539,6 +20544,7 @@ paths:
                   description: Currently must be 'execute'
               required:
                 - name
+                - description
                 - expression
                 - message
               additionalProperties: false
@@ -20622,9 +20628,9 @@ paths:
                             - type: number
                             - type: "null"
                         description:
-                          anyOf:
-                            - type: string
-                            - type: "null"
+                          type: string
+                        cadenceDescription:
+                          type: string
                         mode:
                           type: string
                           enum:
@@ -20674,6 +20680,7 @@ paths:
                         - createdFromConversationExists
                         - createdFromConversationArchivedAt
                         - description
+                        - cadenceDescription
                         - mode
                         - status
                         - routingIntent
@@ -20770,9 +20777,9 @@ paths:
                             - type: number
                             - type: "null"
                         description:
-                          anyOf:
-                            - type: string
-                            - type: "null"
+                          type: string
+                        cadenceDescription:
+                          type: string
                         mode:
                           type: string
                           enum:
@@ -20822,6 +20829,7 @@ paths:
                         - createdFromConversationExists
                         - createdFromConversationArchivedAt
                         - description
+                        - cadenceDescription
                         - mode
                         - status
                         - routingIntent
@@ -20847,6 +20855,8 @@ paths:
               type: object
               properties:
                 name:
+                  type: string
+                description:
                   type: string
                 expression:
                   type: string
@@ -20961,9 +20971,9 @@ paths:
                             - type: number
                             - type: "null"
                         description:
-                          anyOf:
-                            - type: string
-                            - type: "null"
+                          type: string
+                        cadenceDescription:
+                          type: string
                         mode:
                           type: string
                           enum:
@@ -21013,6 +21023,7 @@ paths:
                         - createdFromConversationExists
                         - createdFromConversationArchivedAt
                         - description
+                        - cadenceDescription
                         - mode
                         - status
                         - routingIntent
@@ -21110,9 +21121,9 @@ paths:
                             - type: number
                             - type: "null"
                         description:
-                          anyOf:
-                            - type: string
-                            - type: "null"
+                          type: string
+                        cadenceDescription:
+                          type: string
                         mode:
                           type: string
                           enum:
@@ -21162,6 +21173,7 @@ paths:
                         - createdFromConversationExists
                         - createdFromConversationArchivedAt
                         - description
+                        - cadenceDescription
                         - mode
                         - status
                         - routingIntent
@@ -21348,9 +21360,9 @@ paths:
                             - type: number
                             - type: "null"
                         description:
-                          anyOf:
-                            - type: string
-                            - type: "null"
+                          type: string
+                        cadenceDescription:
+                          type: string
                         mode:
                           type: string
                           enum:
@@ -21400,6 +21412,7 @@ paths:
                         - createdFromConversationExists
                         - createdFromConversationArchivedAt
                         - description
+                        - cadenceDescription
                         - mode
                         - status
                         - routingIntent

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -441,6 +441,32 @@ describe("GET /schedules — default defer exclusion", () => {
     expect(noSource.createdFromConversationArchivedAt).toBeNull();
   });
 
+  test("returns authored descriptions separately from cadence descriptions", () => {
+    createSchedule({
+      name: "Described schedule",
+      description: "Review the morning queue",
+      cronExpression: "0 9 * * *",
+      message: "review queue",
+      syntax: "cron",
+    });
+
+    const route = findRoute("schedules", "GET");
+    const result = route.handler({}) as {
+      schedules: Array<{
+        name: string;
+        description: string;
+        cadenceDescription: string;
+      }>;
+    };
+
+    expect(result.schedules).toHaveLength(1);
+    expect(result.schedules[0]).toMatchObject({
+      name: "Described schedule",
+      description: "Review the morning queue",
+      cadenceDescription: "Every day at 9:00 AM",
+    });
+  });
+
   test("mutation responses also exclude deferred wakes", () => {
     createSchedule({
       name: "Agent schedule",
@@ -997,6 +1023,7 @@ describe("POST /schedules — create", () => {
   test("creates a recurring execute schedule with defaults", () => {
     const result = postCreate({
       name: "Morning ping",
+      description: "Start the morning workflow",
       expression: "0 9 * * *",
       message: "good morning",
     });
@@ -1006,6 +1033,7 @@ describe("POST /schedules — create", () => {
     expect(job.mode).toBe("execute");
     expect(job.expression).toBe("0 9 * * *");
     expect(job.syntax).toBe("cron");
+    expect(job.description).toBe("Start the morning workflow");
     expect(job.enabled).toBe(true);
     expect(job.timezone).toBeNull();
   });
@@ -1013,12 +1041,14 @@ describe("POST /schedules — create", () => {
   test("trims whitespace and accepts an explicit timezone", () => {
     postCreate({
       name: "  Trimmed  ",
+      description: "  Trimmed description  ",
       expression: "  0 9 * * *  ",
       message: "hi",
       timezone: " America/New_York ",
     });
     const job = listSchedules()[0];
     expect(job.name).toBe("Trimmed");
+    expect(job.description).toBe("Trimmed description");
     expect(job.expression).toBe("0 9 * * *");
     expect(job.timezone).toBe("America/New_York");
   });
@@ -1027,6 +1057,7 @@ describe("POST /schedules — create", () => {
     const expression = "DTSTART:20260101T000000Z\nRRULE:FREQ=WEEKLY;BYDAY=MO";
     postCreate({
       name: "Weekly",
+      description: "Weekly wake",
       expression,
       message: "monday wake",
     });
@@ -1045,12 +1076,24 @@ describe("POST /schedules — create", () => {
     expect(() => postCreate({ name: "x", expression: "* * * * *" })).toThrow(
       "message is required",
     );
+    expect(() =>
+      postCreate({ name: "x", expression: "* * * * *", message: "hi" }),
+    ).toThrow("description is required");
+    expect(() =>
+      postCreate({
+        name: "x",
+        description: "   ",
+        expression: "* * * * *",
+        message: "hi",
+      }),
+    ).toThrow("description is required");
   });
 
   test("rejects non-execute modes", () => {
     expect(() =>
       postCreate({
         name: "x",
+        description: "Run the thing",
         expression: "* * * * *",
         message: "hi",
         mode: "notify",
@@ -1060,7 +1103,12 @@ describe("POST /schedules — create", () => {
 
   test("rejects an unparseable expression", () => {
     expect(() =>
-      postCreate({ name: "x", expression: "not-a-cron", message: "hi" }),
+      postCreate({
+        name: "x",
+        description: "Run the thing",
+        expression: "not-a-cron",
+        message: "hi",
+      }),
     ).toThrow("could not be parsed");
   });
 
@@ -1068,6 +1116,7 @@ describe("POST /schedules — create", () => {
     expect(() =>
       postCreate({
         name: "x",
+        description: "Run the thing",
         expression: "99 99 99 99 99",
         message: "hi",
       }),
@@ -1077,12 +1126,45 @@ describe("POST /schedules — create", () => {
   test("respects enabled=false", () => {
     postCreate({
       name: "Off",
+      description: "Disabled schedule",
       expression: "0 9 * * *",
       message: "hi",
       enabled: false,
     });
     const job = listSchedules()[0];
     expect(job.enabled).toBe(false);
+  });
+});
+
+// ── PATCH /schedules/:id — description ───────────────────────────────────
+
+describe("PATCH /schedules/:id — description", () => {
+  beforeEach(() => {
+    clearTables();
+  });
+
+  test("updates authored descriptions", () => {
+    const schedule = createSchedule({
+      name: "Description update",
+      description: "Original description",
+      cronExpression: "0 9 * * *",
+      message: "hi",
+      syntax: "cron",
+    });
+
+    const route = findRoute("schedules/:id", "PATCH");
+    const result = route.handler({
+      pathParams: { id: schedule.id },
+      body: { description: "Updated description" },
+    }) as {
+      schedules: Array<{ id: string; description: string }>;
+    };
+
+    expect(result.schedules[0]).toMatchObject({
+      id: schedule.id,
+      description: "Updated description",
+    });
+    expect(listSchedules()[0].description).toBe("Updated description");
   });
 });
 

--- a/assistant/src/daemon/message-types/schedules.ts
+++ b/assistant/src/daemon/message-types/schedules.ts
@@ -80,6 +80,7 @@ export interface SchedulesListResponse {
     lastRunAt: number | null;
     lastStatus: string | null;
     description: string;
+    cadenceDescription: string;
     mode: string;
     status: string;
     routingIntent: string;

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -28,8 +28,8 @@ import {
   getSchedule,
   getScheduleRuns,
   listSchedules,
-  setScheduleRunConversationId,
   type ScheduleJob,
+  setScheduleRunConversationId,
   updateSchedule,
 } from "../../schedule/schedule-store.js";
 import { getScheduleUsageSummaries } from "../../schedule/schedule-usage-store.js";

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -29,6 +29,7 @@ import {
   getScheduleRuns,
   listSchedules,
   setScheduleRunConversationId,
+  type ScheduleJob,
   updateSchedule,
 } from "../../schedule/schedule-store.js";
 import { getScheduleUsageSummaries } from "../../schedule/schedule-usage-store.js";
@@ -64,7 +65,8 @@ const scheduleSchema = z.object({
   createdFromConversationId: z.string().nullable(),
   createdFromConversationExists: z.boolean(),
   createdFromConversationArchivedAt: z.number().nullable(),
-  description: z.string().nullable(),
+  description: z.string(),
+  cadenceDescription: z.string(),
   mode: z.enum(["notify", "execute", "script", "wake"]),
   status: z.enum(["active", "firing", "fired", "cancelled"]),
   routingIntent: z.enum(["single_channel", "multi_channel", "all_channels"]),
@@ -125,6 +127,15 @@ function getCreatedFromConversationState(
   return state;
 }
 
+function getCadenceDescription(
+  job: Pick<ScheduleJob, "syntax" | "cronExpression" | "expression">,
+): string {
+  if (job.syntax === "cron") {
+    return describeCronExpression(job.cronExpression);
+  }
+  return job.expression ?? "";
+}
+
 function handleListSchedules(queryParams: Record<string, string>) {
   const includeAll = queryParams.include_all === "true";
   const jobs = listSchedules();
@@ -161,10 +172,8 @@ function handleListSchedules(queryParams: Record<string, string>) {
         createdFromConversationId: j.createdFromConversationId,
         createdFromConversationExists: sourceConversation.exists,
         createdFromConversationArchivedAt: sourceConversation.archivedAt,
-        description:
-          j.syntax === "cron"
-            ? describeCronExpression(j.cronExpression)
-            : j.expression,
+        description: j.description,
+        cadenceDescription: getCadenceDescription(j),
         mode: j.mode,
         status: j.status,
         routingIntent: j.routingIntent,
@@ -180,6 +189,8 @@ function handleCreateSchedule(body: Record<string, unknown>) {
   const name = typeof body.name === "string" ? body.name.trim() : "";
   const expression =
     typeof body.expression === "string" ? body.expression.trim() : "";
+  const description =
+    typeof body.description === "string" ? body.description.trim() : "";
   const message = typeof body.message === "string" ? body.message : "";
   const timezoneRaw =
     typeof body.timezone === "string" ? body.timezone.trim() : "";
@@ -190,6 +201,7 @@ function handleCreateSchedule(body: Record<string, unknown>) {
   if (!name) throw new BadRequestError("name is required");
   if (!expression) throw new BadRequestError("expression is required");
   if (!message) throw new BadRequestError("message is required");
+  if (!description) throw new BadRequestError("description is required");
 
   // The settings UI only exposes execute mode for now. Other modes
   // remain reachable via the schedule_create LLM tool.
@@ -209,6 +221,7 @@ function handleCreateSchedule(body: Record<string, unknown>) {
   try {
     const job = createSchedule({
       name,
+      description,
       message,
       mode: "execute",
       enabled,
@@ -302,6 +315,15 @@ function handleUpdateSchedule(id: string, body: Record<string, unknown>) {
     if (key in body) {
       updates[key] = body[key];
     }
+  }
+
+  if ("description" in body) {
+    const description =
+      typeof body.description === "string" ? body.description.trim() : "";
+    if (!description) {
+      throw new BadRequestError("description is required");
+    }
+    updates.description = description;
   }
 
   if (updates.timeoutMs != null) {
@@ -460,6 +482,7 @@ export const ROUTES: RouteDefinition[] = [
     tags: ["schedules"],
     requestBody: z.object({
       name: z.string().describe("Display name"),
+      description: z.string().describe("Authored schedule description"),
       expression: z.string().describe("Cron or RRULE expression"),
       message: z.string().describe("Message body to execute on each fire"),
       timezone: z
@@ -552,6 +575,7 @@ export const ROUTES: RouteDefinition[] = [
     tags: ["schedules"],
     requestBody: z.object({
       name: z.string().optional(),
+      description: z.string().optional(),
       expression: z.string().optional(),
       timezone: z.string().optional(),
       message: z.string().optional(),


### PR DESCRIPTION
## Summary
- Returns authored schedule descriptions from runtime schedule list responses.
- Adds cadenceDescription for generated timing labels.
- Validates and updates descriptions through schedule routes.

Part of plan: schedule-description-fields.md (PR 2 of 6)