### PR TITLE
[codex] Promote run conversations to recents on send

### DIFF
--- a/apps/web/src/domains/chat/api/messages.ts
+++ b/apps/web/src/domains/chat/api/messages.ts
@@ -337,6 +337,7 @@ export type PostMessageResult =
        *  id, on the legacy flow it's the resolved/echoed id. */
       conversationId: string;
       messageId: string;
+      movedToGroupId?: string;
     }
   | {
       ok: true;
@@ -348,6 +349,7 @@ export type PostMessageResult =
        *  id, on the legacy flow it's the resolved/echoed id. */
       conversationId: string;
       requestId?: string;
+      movedToGroupId?: string;
     }
   | { ok: false; status: number; error: { code?: string; detail?: string } };
 
@@ -613,6 +615,10 @@ export async function postChatMessage(
       queued: true,
       assistantId,
       conversationId: resolvedConversationId,
+      movedToGroupId:
+        typeof sendData.movedToGroupId === "string"
+          ? sendData.movedToGroupId
+          : undefined,
       requestId:
         typeof sendData.requestId === "string" ? sendData.requestId : undefined,
     };
@@ -631,6 +637,10 @@ export async function postChatMessage(
     assistantId,
     conversationId: resolvedConversationId,
     messageId: sendData.messageId,
+    movedToGroupId:
+      typeof sendData.movedToGroupId === "string"
+        ? sendData.movedToGroupId
+        : undefined,
   };
 }
 

--- a/apps/web/src/domains/chat/hooks/use-send-message.ts
+++ b/apps/web/src/domains/chat/hooks/use-send-message.ts
@@ -39,6 +39,7 @@ import { endTurn } from "@/domains/chat/turn-coordinator";
 import { useInteractionStore } from "@/domains/chat/interaction-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import {
+  moveConversationToGroup,
   prependConversation,
   removeConversation,
   resolveDraftKey,
@@ -286,6 +287,14 @@ export function useSendMessage({
           },
         };
       }
+      if (postResult.movedToGroupId) {
+        moveConversationToGroup(
+          queryClient,
+          postResult.assistantId,
+          postResult.conversationId,
+          postResult.movedToGroupId,
+        );
+      }
       // Success — drain the ref so subsequent messages omit the field.
       pendingOnboardingContextRef.current = null;
       if (onboardingDraftConversationIdRef.current === activeConversationId) {
@@ -462,7 +471,7 @@ export function useSendMessage({
         resolvedConversationId: postResult.conversationId,
       };
     },
-    [activeConversationId, assistantId, startReconciliationLoop],
+    [activeConversationId, assistantId, queryClient, startReconciliationLoop],
   );
 
   // -------------------------------------------------------------------------
@@ -557,6 +566,14 @@ export function useSendMessage({
             );
             setError({ message: detail, code: postResult.error.code ?? undefined });
             return;
+          }
+          if (postResult.movedToGroupId) {
+            moveConversationToGroup(
+              queryClient,
+              assistantId,
+              postResult.conversationId,
+              postResult.movedToGroupId,
+            );
           }
           if (!postResult.queued) {
             // The daemon processed the message directly (turn finished

--- a/apps/web/src/domains/chat/utils/group-conversations.test.ts
+++ b/apps/web/src/domains/chat/utils/group-conversations.test.ts
@@ -60,6 +60,28 @@ describe("groupConversations · bucket routing", () => {
     expect(result.recents).toEqual([]);
   });
 
+  test("routes promoted scheduled conversations into recents when groupId is system:all", () => {
+    const result = groupConversations([
+      makeConversation({
+        conversationId: "promoted-scheduled",
+        conversationType: "scheduled",
+        groupId: "system:all",
+      }),
+      makeConversation({
+        conversationId: "promoted-background",
+        conversationType: "background",
+        groupId: "system:all",
+      }),
+    ]);
+
+    expect(result.recents.map((c) => c.conversationId).sort()).toEqual([
+      "promoted-background",
+      "promoted-scheduled",
+    ]);
+    expect(result.scheduled).toEqual([]);
+    expect(result.background).toEqual([]);
+  });
+
   test("routes conversationType=background into background bucket", () => {
     const result = groupConversations([
       makeConversation({

--- a/apps/web/src/domains/chat/utils/group-conversations.ts
+++ b/apps/web/src/domains/chat/utils/group-conversations.ts
@@ -55,8 +55,10 @@ export function isConversationPinned(c: Conversation): boolean {
 }
 
 function isBackground(c: Conversation): boolean {
+  if (c.groupId === "system:all") return false;
   return (
-    c.conversationType === "background" || c.groupId === "system:background"
+    c.groupId === "system:background" ||
+    (c.groupId == null && c.conversationType === "background")
   );
 }
 
@@ -86,6 +88,7 @@ function shouldBucketInSlackSection(c: Conversation): boolean {
 export function getEffectiveGroupId(c: Conversation): string {
   if (isConversationPinned(c)) return "system:pinned";
   if (c.groupId && !c.groupId.startsWith("system:")) return c.groupId;
+  if (c.groupId === "system:all") return "system:all";
   if (shouldBucketInSlackSection(c)) return "system:slack";
   if (isScheduledConversation(c)) return "system:scheduled";
   if (isBackground(c)) return "system:background";

--- a/apps/web/src/utils/conversation-cache-mutations.test.ts
+++ b/apps/web/src/utils/conversation-cache-mutations.test.ts
@@ -15,6 +15,7 @@ import {
   markConversationSeenLocal,
   prependConversation,
   removeConversation,
+  moveConversationToGroup,
   resolveDraftKey,
   appendGroup,
   patchGroup,
@@ -273,6 +274,62 @@ describe("removeConversation", () => {
     seedForeground(qc, original);
 
     removeConversation(qc, ASSISTANT_ID, "nonexistent");
+
+    expect(getForeground(qc)).toBe(original);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// moveConversationToGroup
+// ---------------------------------------------------------------------------
+
+describe("moveConversationToGroup", () => {
+  test("moves a scheduled conversation from scheduled cache to foreground recents", () => {
+    seedForeground(qc, [makeConversation({ conversationId: "existing" })]);
+    seedScheduled(qc, [
+      makeConversation({
+        conversationId: "run-1",
+        conversationType: "scheduled",
+        groupId: "system:scheduled",
+        lastMessageAt: 3000,
+      }),
+    ]);
+
+    moveConversationToGroup(qc, ASSISTANT_ID, "run-1", "system:all");
+
+    expect(getScheduled(qc)).toEqual([]);
+    expect(getForeground(qc).map((c) => [c.conversationId, c.groupId])).toEqual([
+      ["run-1", "system:all"],
+      ["existing", undefined],
+    ]);
+  });
+
+  test("moves a background conversation from background cache to foreground recents", () => {
+    seedForeground(qc, []);
+    seedBackground(qc, [
+      makeConversation({
+        conversationId: "run-1",
+        conversationType: "background",
+        groupId: "system:background",
+      }),
+    ]);
+
+    moveConversationToGroup(qc, ASSISTANT_ID, "run-1", "system:all");
+
+    expect(getBackground(qc)).toEqual([]);
+    expect(getForeground(qc)[0]).toMatchObject({
+      conversationId: "run-1",
+      groupId: "system:all",
+    });
+  });
+
+  test("no-ops when the conversation is already in the target group", () => {
+    const original = [
+      makeConversation({ conversationId: "run-1", groupId: "system:all" }),
+    ];
+    seedForeground(qc, original);
+
+    moveConversationToGroup(qc, ASSISTANT_ID, "run-1", "system:all");
 
     expect(getForeground(qc)).toBe(original);
   });

--- a/apps/web/src/utils/conversation-cache-mutations.ts
+++ b/apps/web/src/utils/conversation-cache-mutations.ts
@@ -19,6 +19,7 @@ import {
 } from "@/utils/conversation-predicates";
 import {
   findConversation,
+  updateArchivedConversationsCache,
   updateAllConversationCaches,
   updateBackgroundConversationsCache,
   updateConversationsCache,
@@ -88,6 +89,55 @@ export function removeConversation(
     return filtered.length === conversations.length ? conversations : filtered;
   };
   updateAllConversationCaches(queryClient, assistantId, drop);
+}
+
+export function moveConversationToGroup(
+  queryClient: QueryClient,
+  assistantId: string | null,
+  conversationId: string,
+  groupId: string,
+): void {
+  const existing = findConversation(queryClient, assistantId, conversationId);
+  if (!existing || existing.groupId === groupId) return;
+
+  const moved: Conversation = {
+    ...existing,
+    groupId,
+    isPinned: groupId === "system:pinned",
+    displayOrder: undefined,
+  };
+  const drop = (conversations: Conversation[]) => {
+    const next = conversations.filter((c) => c.conversationId !== conversationId);
+    return next.length === conversations.length ? conversations : next;
+  };
+
+  updateAllConversationCaches(queryClient, assistantId, drop);
+
+  if (moved.archivedAt != null) {
+    updateArchivedConversationsCache(queryClient, assistantId, (conversations) => [
+      moved,
+      ...conversations,
+    ]);
+    return;
+  }
+  if (isScheduledConversation(moved)) {
+    updateScheduledConversationsCache(queryClient, assistantId, (conversations) => [
+      moved,
+      ...conversations,
+    ]);
+    return;
+  }
+  if (isBackgroundConversation(moved)) {
+    updateBackgroundConversationsCache(queryClient, assistantId, (conversations) => [
+      moved,
+      ...conversations,
+    ]);
+    return;
+  }
+  updateConversationsCache(queryClient, assistantId, (conversations) => [
+    moved,
+    ...conversations,
+  ]);
 }
 
 /**

--- a/apps/web/src/utils/conversation-predicates.ts
+++ b/apps/web/src/utils/conversation-predicates.ts
@@ -8,11 +8,13 @@
 import type { Conversation } from "@/types/conversation-types";
 
 export function isBackgroundConversation(conversation: Conversation): boolean {
+  if (conversation.groupId === "system:all") return false;
   return (
-    conversation.conversationType === "background" ||
-    conversation.conversationType === "scheduled" ||
     conversation.groupId === "system:background" ||
-    conversation.groupId === "system:scheduled"
+    conversation.groupId === "system:scheduled" ||
+    (conversation.groupId == null &&
+      (conversation.conversationType === "background" ||
+        conversation.conversationType === "scheduled"))
   );
 }
 
@@ -24,9 +26,11 @@ export function isBackgroundConversation(conversation: Conversation): boolean {
  * filtered through `!isScheduledConversation` before it is cached.
  */
 export function isScheduledConversation(conversation: Conversation): boolean {
+  if (conversation.groupId === "system:all") return false;
   return (
-    conversation.conversationType === "scheduled" ||
-    conversation.groupId === "system:scheduled"
+    conversation.groupId === "system:scheduled" ||
+    (conversation.groupId == null &&
+      conversation.conversationType === "scheduled")
   );
 }
 

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -16879,6 +16879,8 @@ paths:
                     type: boolean
                   requestId:
                     type: string
+                  movedToGroupId:
+                    type: string
                 required:
                   - accepted
                 additionalProperties: false

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -20,6 +20,7 @@ import {
   getConversationByKey,
   getOrCreateConversation,
 } from "../memory/conversation-key-store.js";
+import { createConversation } from "../memory/conversation-crud.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
 
 mock.module("../util/logger.js", () => ({
@@ -122,6 +123,7 @@ mock.module("../runtime/local-actor-identity.js", () => ({
 
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
+import { rawGet } from "../memory/raw-query.js";
 import type { AssistantEvent } from "../runtime/assistant-event.js";
 import { RuntimeHttpServer } from "../runtime/http-server.js";
 import type { ApprovalConversationGenerator } from "../runtime/http-types.js";
@@ -404,6 +406,82 @@ describe("POST /v1/messages — queue-if-busy and hub publishing", () => {
     expect(body.messageId).toBeDefined();
     expect(typeof body.conversationId).toBe("string");
     expect(body.conversationId.length).toBeGreaterThan(0);
+
+    await stopServer();
+  });
+
+  test("promotes interactive scheduled runs to recents on send", async () => {
+    const runConversation = createConversation({
+      title: "scheduled run",
+      conversationType: "scheduled",
+      source: "schedule",
+      groupId: "system:scheduled",
+    });
+    await startServer(() => makeCompletingConversation());
+
+    const res = await fetch(messagesUrl(), {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+      body: JSON.stringify({
+        conversationKey: runConversation.id,
+        content: "Follow up",
+        sourceChannel: "vellum",
+        interface: "macos",
+      }),
+    });
+    const body = (await res.json()) as {
+      accepted: boolean;
+      messageId: string;
+      conversationId: string;
+      movedToGroupId?: string;
+    };
+
+    expect(res.status).toBe(202);
+    expect(body.accepted).toBe(true);
+    expect(body.conversationId).toBe(runConversation.id);
+    expect(body.movedToGroupId).toBe("system:all");
+    const row = rawGet<{ group_id: string | null }>(
+      "SELECT group_id FROM conversations WHERE id = ?",
+      runConversation.id,
+    );
+    expect(row?.group_id).toBe("system:all");
+
+    await stopServer();
+  });
+
+  test("does not promote automated scheduled run messages", async () => {
+    const runConversation = createConversation({
+      title: "automated scheduled run",
+      conversationType: "scheduled",
+      source: "schedule",
+      groupId: "system:scheduled",
+    });
+    await startServer(() => makeCompletingConversation());
+
+    const res = await fetch(messagesUrl(), {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+      body: JSON.stringify({
+        conversationKey: runConversation.id,
+        content: "Automated update",
+        sourceChannel: "vellum",
+        interface: "macos",
+        automated: true,
+      }),
+    });
+    const body = (await res.json()) as {
+      accepted: boolean;
+      movedToGroupId?: string;
+    };
+
+    expect(res.status).toBe(202);
+    expect(body.accepted).toBe(true);
+    expect(body.movedToGroupId).toBeUndefined();
+    const row = rawGet<{ group_id: string | null }>(
+      "SELECT group_id FROM conversations WHERE id = ?",
+      runConversation.id,
+    );
+    expect(row?.group_id).toBe("system:scheduled");
 
     await stopServer();
   });

--- a/assistant/src/memory/__tests__/conversation-queries.test.ts
+++ b/assistant/src/memory/__tests__/conversation-queries.test.ts
@@ -367,6 +367,31 @@ describe("listConversations", () => {
     expect(scheduledList).toHaveLength(0);
   });
 
+  test("foreground fetch includes promoted scheduled rows by display group", () => {
+    // GIVEN a scheduled run conversation whose display group was promoted to Recents
+    createConversation({
+      title: "promoted-schedule",
+      conversationType: "scheduled",
+      source: "schedule",
+      groupId: "system:scheduled",
+    });
+    rawRun(
+      "UPDATE conversations SET group_id = 'system:all' WHERE title = ?",
+      "promoted-schedule",
+    );
+
+    // WHEN listing foreground conversations
+    const foreground = listConversations(100, "standard");
+
+    // THEN it appears in Recents even though its provenance remains scheduled
+    expect(foreground.map((c) => c.title)).toContain("promoted-schedule");
+    expect(countConversations("standard")).toBe(1);
+
+    // AND it no longer appears in the Scheduled / Background sidebar buckets
+    expect(listConversations(100, "scheduled")).toHaveLength(0);
+    expect(listConversations(100, "background")).toHaveLength(0);
+  });
+
   describe("archiveStatus", () => {
     test("defaults to active — archived rows are excluded", () => {
       // GIVEN a live conversation and an archived one

--- a/assistant/src/memory/__tests__/conversation-recents-promotion.test.ts
+++ b/assistant/src/memory/__tests__/conversation-recents-promotion.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import {
+  createConversation,
+  promoteConversationToRecentsIfNeeded,
+} from "../conversation-crud.js";
+import { ensureGroupMigration } from "../conversation-group-migration.js";
+import { getDb } from "../db-connection.js";
+import { initializeDb } from "../db-init.js";
+import { createGroup } from "../group-crud.js";
+import { rawGet, rawRun } from "../raw-query.js";
+
+initializeDb();
+
+function resetTables(): void {
+  ensureGroupMigration();
+  const db = getDb();
+  db.run(`DELETE FROM messages`);
+  db.run(`DELETE FROM conversations`);
+  db.run(`DELETE FROM conversation_groups WHERE is_system_group = 0`);
+}
+
+function readConversationDisplay(id: string): {
+  conversation_type: string;
+  source: string | null;
+  schedule_job_id: string | null;
+  group_id: string | null;
+  is_pinned: number | null;
+  display_order: number | null;
+} {
+  const row = rawGet<{
+    conversation_type: string;
+    source: string | null;
+    schedule_job_id: string | null;
+    group_id: string | null;
+    is_pinned: number | null;
+    display_order: number | null;
+  }>(
+    `SELECT conversation_type, source, schedule_job_id, group_id, is_pinned, display_order
+       FROM conversations
+      WHERE id = ?`,
+    id,
+  );
+  if (!row) throw new Error(`missing conversation ${id}`);
+  return row;
+}
+
+describe("promoteConversationToRecentsIfNeeded", () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test("moves scheduled display rows to Recents while preserving provenance", () => {
+    const conversation = createConversation({
+      title: "scheduled run",
+      conversationType: "scheduled",
+      source: "schedule",
+      scheduleJobId: "job-123",
+      groupId: "system:scheduled",
+    });
+    rawRun(
+      "UPDATE conversations SET display_order = ?, is_pinned = 1 WHERE id = ?",
+      42,
+      conversation.id,
+    );
+
+    const moved = promoteConversationToRecentsIfNeeded(conversation.id);
+
+    expect(moved).toBe(true);
+    expect(readConversationDisplay(conversation.id)).toEqual({
+      conversation_type: "scheduled",
+      source: "schedule",
+      schedule_job_id: "job-123",
+      group_id: "system:all",
+      is_pinned: 0,
+      display_order: null,
+    });
+  });
+
+  test("moves background display rows to Recents", () => {
+    const conversation = createConversation({
+      title: "heartbeat run",
+      conversationType: "background",
+      source: "heartbeat",
+      groupId: "system:background",
+    });
+
+    const moved = promoteConversationToRecentsIfNeeded(conversation.id);
+
+    expect(moved).toBe(true);
+    expect(readConversationDisplay(conversation.id).group_id).toBe("system:all");
+  });
+
+  test("does not write rows that are already displayed in Recents", () => {
+    const conversation = createConversation({
+      title: "already recent",
+      conversationType: "scheduled",
+      source: "schedule",
+      groupId: "system:all",
+    });
+
+    const moved = promoteConversationToRecentsIfNeeded(conversation.id);
+
+    expect(moved).toBe(false);
+    expect(readConversationDisplay(conversation.id).group_id).toBe("system:all");
+  });
+
+  test("does not move pinned or custom grouped conversations", () => {
+    const pinned = createConversation({
+      title: "pinned run",
+      conversationType: "scheduled",
+      groupId: "system:pinned",
+    });
+    const group = createGroup("Runs");
+    const custom = createConversation({
+      title: "custom run",
+      conversationType: "background",
+      groupId: group.id,
+    });
+
+    expect(promoteConversationToRecentsIfNeeded(pinned.id)).toBe(false);
+    expect(promoteConversationToRecentsIfNeeded(custom.id)).toBe(false);
+    expect(readConversationDisplay(pinned.id).group_id).toBe("system:pinned");
+    expect(readConversationDisplay(custom.id).group_id).toBe(group.id);
+  });
+});

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -552,7 +552,13 @@ export function createConversation(
   const conversationType: ConversationCreateType =
     requestedConversationType ?? "standard";
   const source = opts.source ?? "user";
-  const groupId = opts.groupId;
+  const groupId =
+    opts.groupId ??
+    (conversationType === "scheduled"
+      ? "system:scheduled"
+      : conversationType === "background"
+        ? "system:background"
+        : "system:all");
   const id = uuid();
   const memoryScopeId = "default";
 
@@ -615,7 +621,7 @@ export function createConversation(
   // Set via raw SQL after the INSERT succeeds.
   // Always set group_id — default to "system:all" when none provided.
   {
-    const effectiveGroupId = groupId ?? "system:all";
+    const effectiveGroupId = groupId;
     for (let attempt = 0; ; attempt++) {
       try {
         rawRun(
@@ -671,6 +677,35 @@ export function countConversationsByScheduleJobId(
       "SELECT COUNT(*) AS c FROM conversations WHERE schedule_job_id = ?",
       scheduleJobId,
     )?.c ?? 0
+  );
+}
+
+export function promoteConversationToRecentsIfNeeded(
+  conversationId: string,
+): boolean {
+  ensureGroupMigration();
+  ensureDisplayOrderMigration();
+  const row = rawGet<{ group_id: string | null }>(
+    "SELECT group_id FROM conversations WHERE id = ?",
+    conversationId,
+  );
+  if (
+    row?.group_id !== "system:scheduled" &&
+    row?.group_id !== "system:background"
+  ) {
+    return false;
+  }
+
+  return (
+    rawRun(
+      `UPDATE conversations
+          SET group_id = 'system:all',
+              is_pinned = 0,
+              display_order = NULL
+        WHERE id = ?
+          AND group_id IN ('system:scheduled', 'system:background')`,
+      conversationId,
+    ) > 0
   );
 }
 

--- a/assistant/src/memory/conversation-queries.ts
+++ b/assistant/src/memory/conversation-queries.ts
@@ -73,6 +73,17 @@ function archiveStatusClause(status: ArchiveStatusFilter) {
   }
 }
 
+function displayGroupExpr() {
+  return sql`COALESCE(
+    group_id,
+    CASE
+      WHEN ${conversations.conversationType} = 'scheduled' THEN 'system:scheduled'
+      WHEN ${conversations.conversationType} = 'background' THEN 'system:background'
+      ELSE 'system:all'
+    END
+  )`;
+}
+
 /**
  * SQL predicate selecting which bucket {@link listConversations} and
  * {@link countConversations} return, keyed by the canonical
@@ -99,13 +110,14 @@ function archiveStatusClause(status: ArchiveStatusFilter) {
  */
 function conversationTypeClause(type: ConversationType) {
   const notSubagent = sql`(${conversations.source} IS NULL OR ${conversations.source} != 'subagent')`;
+  const displayGroup = displayGroupExpr();
   switch (type) {
     case "standard":
-      return sql`${conversations.conversationType} NOT IN ('background', 'scheduled', 'private') AND COALESCE(group_id, 'system:all') NOT IN ('system:background', 'system:scheduled')`;
+      return sql`${conversations.conversationType} != 'private' AND ${displayGroup} NOT IN ('system:background', 'system:scheduled') AND ${notSubagent}`;
     case "background":
-      return sql`(${conversations.conversationType} IN ('background', 'scheduled') OR group_id IN ('system:background', 'system:scheduled')) AND ${notSubagent}`;
+      return sql`${displayGroup} IN ('system:background', 'system:scheduled') AND ${notSubagent}`;
     case "scheduled":
-      return sql`(${conversations.conversationType} = 'scheduled' OR group_id = 'system:scheduled') AND ${notSubagent}`;
+      return sql`${displayGroup} = 'system:scheduled' AND ${notSubagent}`;
   }
 }
 
@@ -233,8 +245,9 @@ export function listPinnedConversations(
     .from(conversations)
     .where(
       and(
-        sql`${conversations.conversationType} NOT IN ('background', 'scheduled', 'private')`,
+        sql`${conversations.conversationType} != 'private'`,
         sql`is_pinned = 1`,
+        sql`${conversations.source} IS NULL OR ${conversations.source} != 'subagent'`,
         ...(archiveCond ? [archiveCond] : []),
       ),
     )
@@ -417,7 +430,18 @@ export function searchConversations(
         FROM messages_fts f
         JOIN messages m ON m.id = f.message_id
         JOIN conversations c ON c.id = m.conversation_id
-        WHERE messages_fts MATCH ? AND c.conversation_type NOT IN ('background', 'scheduled', 'private') AND COALESCE(c.group_id, 'system:all') NOT IN ('system:background', 'system:scheduled') AND c.archived_at IS NULL
+        WHERE messages_fts MATCH ?
+          AND c.conversation_type != 'private'
+          AND COALESCE(
+            c.group_id,
+            CASE
+              WHEN c.conversation_type = 'scheduled' THEN 'system:scheduled'
+              WHEN c.conversation_type = 'background' THEN 'system:background'
+              ELSE 'system:all'
+            END
+          ) NOT IN ('system:background', 'system:scheduled')
+          AND (c.source IS NULL OR c.source != 'subagent')
+          AND c.archived_at IS NULL
         LIMIT 1000
       `,
         ftsMatch,
@@ -442,7 +466,18 @@ export function searchConversations(
       SELECT DISTINCT m.conversation_id
       FROM messages m
       JOIN conversations c ON c.id = m.conversation_id
-      WHERE m.content LIKE ? ESCAPE '\\' AND c.conversation_type NOT IN ('background', 'scheduled', 'private') AND COALESCE(c.group_id, 'system:all') NOT IN ('system:background', 'system:scheduled') AND c.archived_at IS NULL
+      WHERE m.content LIKE ? ESCAPE '\\'
+        AND c.conversation_type != 'private'
+        AND COALESCE(
+          c.group_id,
+          CASE
+            WHEN c.conversation_type = 'scheduled' THEN 'system:scheduled'
+            WHEN c.conversation_type = 'background' THEN 'system:background'
+            ELSE 'system:all'
+          END
+        ) NOT IN ('system:background', 'system:scheduled')
+        AND (c.source IS NULL OR c.source != 'subagent')
+        AND c.archived_at IS NULL
       LIMIT 1000
     `,
       likePattern,
@@ -456,8 +491,9 @@ export function searchConversations(
     .from(conversations)
     .where(
       and(
-        sql`${conversations.conversationType} NOT IN ('background', 'scheduled', 'private')`,
-        sql`COALESCE(group_id, 'system:all') NOT IN ('system:background', 'system:scheduled')`,
+        sql`${conversations.conversationType} != 'private'`,
+        sql`${displayGroupExpr()} NOT IN ('system:background', 'system:scheduled')`,
+        sql`${conversations.source} IS NULL OR ${conversations.source} != 'subagent'`,
         sql`${conversations.title} LIKE ${titlePattern} ESCAPE '\\'`,
         sql`${conversations.archivedAt} IS NULL`,
       ),

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -90,6 +90,7 @@ import {
   hasMessages,
   type MessageRow,
   provenanceFromTrustContext,
+  promoteConversationToRecentsIfNeeded,
   setConversationInferenceProfile,
 } from "../../memory/conversation-crud.js";
 import {
@@ -1320,6 +1321,16 @@ export async function handleSendMessage(
   }
 
   const smDeps = deps.sendMessageDeps;
+  const shouldPromoteInteractiveRunConversation =
+    body.automated !== true &&
+    sourceChannel === "vellum" &&
+    isInteractiveInterface(sourceInterface);
+  const movedToGroupId =
+    shouldPromoteInteractiveRunConversation &&
+    promoteConversationToRecentsIfNeeded(mapping.conversationId)
+      ? "system:all"
+      : undefined;
+  const movedResponseFields = movedToGroupId ? { movedToGroupId } : {};
 
   // Notify all connected clients that the conversation list changed when
   // this is the first message in a standard conversation, so sidebars on
@@ -1337,6 +1348,13 @@ export async function handleSendMessage(
         originClientId,
       );
     }
+  }
+  if (movedToGroupId) {
+    publishConversationListAndMetadataChanged(
+      "reordered",
+      mapping.conversationId,
+      originClientId,
+    );
   }
 
   // Build transport metadata from the request so the daemon can inject
@@ -1592,6 +1610,7 @@ export async function handleSendMessage(
         accepted: true,
         messageId: persisted.id,
         conversationId,
+        ...movedResponseFields,
       };
 
       if (isFirstOnboarding) {
@@ -1713,6 +1732,7 @@ export async function handleSendMessage(
       return {
         accepted: true,
         conversationId: mapping.conversationId,
+        ...movedResponseFields,
         ...(inlineReplyResult.messageId
           ? { messageId: inlineReplyResult.messageId }
           : {}),
@@ -1800,6 +1820,7 @@ export async function handleSendMessage(
       queued: true,
       conversationId: mapping.conversationId,
       requestId,
+      ...movedResponseFields,
     };
   }
 
@@ -1884,6 +1905,7 @@ export async function handleSendMessage(
           accepted: true,
           messageId: persisted.id,
           conversationId: mapping.conversationId,
+          ...movedResponseFields,
         };
       }
 
@@ -1909,6 +1931,7 @@ export async function handleSendMessage(
         accepted: true,
         messageId: persisted.id,
         conversationId: mapping.conversationId,
+        ...movedResponseFields,
       };
 
       // Defer event publishing to next tick so the HTTP response reaches the
@@ -1991,6 +2014,7 @@ export async function handleSendMessage(
         accepted: true,
         messageId: persisted.id,
         conversationId: mapping.conversationId,
+        ...movedResponseFields,
       };
     }
 
@@ -2063,6 +2087,7 @@ export async function handleSendMessage(
       accepted: true,
       messageId: persisted.id,
       conversationId,
+      ...movedResponseFields,
     };
   }
 
@@ -2092,6 +2117,7 @@ export async function handleSendMessage(
           accepted: true,
           messageId: persisted.id,
           conversationId,
+          ...movedResponseFields,
         };
       }
 
@@ -2151,6 +2177,7 @@ export async function handleSendMessage(
         accepted: true,
         messageId: persisted.id,
         conversationId,
+        ...movedResponseFields,
       };
     } finally {
       conversation.setProcessing(false);
@@ -2176,6 +2203,7 @@ export async function handleSendMessage(
       accepted: true,
       messageId,
       conversationId: mapping.conversationId,
+      ...movedResponseFields,
     };
   }
 
@@ -2207,6 +2235,7 @@ export async function handleSendMessage(
     accepted: true,
     messageId,
     conversationId: mapping.conversationId,
+    ...movedResponseFields,
   };
 }
 
@@ -2713,6 +2742,7 @@ export const ROUTES: RouteDefinition[] = [
       messageId: z.string().optional(),
       queued: z.boolean().optional(),
       requestId: z.string().optional(),
+      movedToGroupId: z.string().optional(),
     }),
     handler: async (args) =>
       handleSendMessage(args, {


### PR DESCRIPTION
## Summary

Promote scheduled/background run conversations into Recents when the user sends an interactive Vellum message from that conversation.

## What changed

- Added `movedToGroupId?: string` to `POST /v1/messages` responses so clients can update local sidebar caches immediately.
- Added `promoteConversationToRecentsIfNeeded()` to move only conversations currently displayed in `system:scheduled` or `system:background` to `system:all`.
- Kept provenance intact (`conversationType`, `source`, schedule metadata) while changing only display group fields.
- Updated list/search/sidebar classification to treat `groupId` as the display source of truth, with legacy `conversationType` fallback for null group rows.
- Updated web send-message UX to move the conversation from Scheduled/Background caches into foreground Recents when the response says it moved.

## DB write behavior

The send route only attempts promotion for interactive Vellum sends (`automated !== true` plus interactive interface). The helper reads the current `group_id` and only writes when it is `system:scheduled` or `system:background`; ordinary Recents messages do not get an update write.

## Validation

- `cd assistant && bun test src/memory/__tests__/conversation-recents-promotion.test.ts src/memory/__tests__/conversation-queries.test.ts src/__tests__/send-endpoint-busy.test.ts`
- `cd apps/web && bun test src/domains/chat/utils/group-conversations.test.ts src/utils/conversation-cache-mutations.test.ts`
- `cd assistant && bunx tsc --noEmit`
- `cd apps/web && bun run typecheck`
- `cd apps/web && bun run openapi-ts`
- `cd assistant && bun run generate:openapi`