### PR TITLE
[codex] Disable consolidation when memory is off

### DIFF
--- a/assistant/src/memory/__tests__/jobs-worker-v2-schedule.test.ts
+++ b/assistant/src/memory/__tests__/jobs-worker-v2-schedule.test.ts
@@ -71,11 +71,15 @@ const { maybeEnqueueGraphMaintenanceJobs } = await import("../jobs-worker.js");
 const CONSOLIDATE_CHECKPOINT_KEY = "memory_v2_consolidate_last_run";
 
 function buildConfig(overrides: {
+  memoryEnabled?: boolean;
   v2Enabled?: boolean;
   intervalHours?: number;
   maxBufferLines?: number | null;
 }) {
   const partial = applyNestedDefaults({});
+  if (overrides.memoryEnabled !== undefined) {
+    partial.memory.enabled = overrides.memoryEnabled;
+  }
   if (overrides.v2Enabled !== undefined) {
     partial.memory.v2.enabled = overrides.v2Enabled;
   }
@@ -154,6 +158,20 @@ describe("maybeEnqueueGraphMaintenanceJobs — memory v2 consolidation", () => {
     expect(countPendingJobs("graph_consolidate")).toBe(0);
     expect(countPendingJobs("graph_pattern_scan")).toBe(0);
     expect(countPendingJobs("graph_narrative_refine")).toBe(0);
+  });
+
+  test("does not enqueue consolidate when global memory is disabled", () => {
+    const config = buildConfig({
+      memoryEnabled: false,
+      v2Enabled: true,
+      intervalHours: 1,
+    });
+    writeBuffer(15);
+
+    maybeEnqueueGraphMaintenanceJobs(config, Date.now());
+
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(0);
+    expect(countPendingJobs("graph_consolidate")).toBe(0);
   });
 
   test("does not enqueue consolidate before the interval has elapsed", () => {
@@ -246,7 +264,6 @@ describe("maybeEnqueueGraphMaintenanceJobs — memory v2 consolidation", () => {
     expect(countPendingJobs("graph_narrative_refine")).toBe(1);
     expect(countPendingJobs("memory_v2_consolidate")).toBe(0);
   });
-
 });
 
 describe("maybeEnqueueGraphMaintenanceJobs — buffer-size trigger", () => {
@@ -386,6 +403,20 @@ describe("maybeEnqueueGraphMaintenanceJobs — buffer-size trigger", () => {
     expect(countPendingJobs("memory_v2_consolidate")).toBe(0);
   });
 
+  test("size trigger inert when global memory is disabled", () => {
+    const config = buildConfig({
+      memoryEnabled: false,
+      v2Enabled: true,
+      intervalHours: 1,
+      maxBufferLines: 1,
+    });
+
+    writeBuffer(100);
+
+    maybeEnqueueGraphMaintenanceJobs(config, Date.now());
+
+    expect(countPendingJobs("memory_v2_consolidate")).toBe(0);
+  });
 });
 
 describe("maybeEnqueueGraphMaintenanceJobs — min buffer lines noop", () => {

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -748,6 +748,9 @@ export function maybeEnqueueGraphMaintenanceJobs(
   config: AssistantConfig,
   nowMs = Date.now(),
 ): void {
+  const memoryEnabled = config.memory.enabled !== false;
+  if (!memoryEnabled) return;
+
   const v2Active = config.memory.v2.enabled;
 
   // The single buffer-drainer entry for the v2-active branch. Referenced again

--- a/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
+++ b/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
@@ -140,14 +140,26 @@ const { memoryV2ConsolidateJob } = await import("../consolidation-job.js");
 const { CUTOFF_PLACEHOLDER, CONSOLIDATION_PROMPT } =
   await import("../prompts/consolidation.js");
 
-// The resolver only reads `config.memory.v2.enabled` and
-// `config.memory.v2.consolidation_prompt_path`, so a minimal stand-in
-// covers both call sites without materializing the full default config.
+// The handler only reads `config.memory.enabled`, `config.memory.v2.enabled`,
+// and `config.memory.v2.consolidation_prompt_path`, so a minimal stand-in
+// covers those call sites without materializing the full default config.
 const CONFIG = {
-  memory: { v2: { enabled: true, consolidation_prompt_path: null } },
+  memory: {
+    enabled: true,
+    v2: { enabled: true, consolidation_prompt_path: null },
+  },
 } as Parameters<typeof memoryV2ConsolidateJob>[1];
 const CONFIG_DISABLED = {
-  memory: { v2: { enabled: false, consolidation_prompt_path: null } },
+  memory: {
+    enabled: true,
+    v2: { enabled: false, consolidation_prompt_path: null },
+  },
+} as Parameters<typeof memoryV2ConsolidateJob>[1];
+const CONFIG_MEMORY_DISABLED = {
+  memory: {
+    enabled: false,
+    v2: { enabled: true, consolidation_prompt_path: null },
+  },
 } as Parameters<typeof memoryV2ConsolidateJob>[1];
 
 function makeJob(): Parameters<typeof memoryV2ConsolidateJob>[0] {
@@ -194,6 +206,22 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("memoryV2ConsolidateJob — v2 disabled", () => {
+  test("returns disabled without invoking the runner when memory.enabled is false", async () => {
+    writeFileSync(bufferPath(), "- [Apr 27, 9:00 AM] Alice prefers VS Code.\n");
+
+    const result = await memoryV2ConsolidateJob(
+      makeJob(),
+      CONFIG_MEMORY_DISABLED,
+    );
+
+    expect(result).toEqual({ kind: "disabled" });
+    expect(runnerCalls).toBe(0);
+    expect(enqueuedJobs).toHaveLength(0);
+    // Lock must NOT linger on the disabled path — the handler bailed before
+    // the lock was acquired.
+    expect(existsSync(lockPath())).toBe(false);
+  });
+
   test("returns disabled without invoking the runner when memory.v2.enabled is false", async () => {
     writeFileSync(bufferPath(), "- [Apr 27, 9:00 AM] Alice prefers VS Code.\n");
 

--- a/assistant/src/memory/v2/consolidation-job.ts
+++ b/assistant/src/memory/v2/consolidation-job.ts
@@ -15,8 +15,9 @@
  * substitute in.
  *
  * Lifecycle:
- *   1. Bail if `config.memory.v2.enabled` is false (the worker may have
- *      claimed a stale row from before v2 was disabled).
+ *   1. Bail if `config.memory.enabled` or `config.memory.v2.enabled` is false
+ *      (the worker may have claimed a stale row from before memory was
+ *      disabled).
  *   2. Acquire a single-process lock at `memory/.v2-state/consolidation.lock`
  *      so two overlapping schedule windows can't fight over the same files.
  *      The lock contains the holder's PID + timestamp so a crashed run leaves
@@ -150,6 +151,11 @@ export async function memoryV2ConsolidateJob(
   _job: MemoryJob,
   config: AssistantConfig,
 ): Promise<ConsolidationOutcome> {
+  if (config.memory.enabled === false) {
+    log.debug("memory.enabled is false; consolidation skipped");
+    return { kind: "disabled" };
+  }
+
   if (!config.memory.v2.enabled) {
     log.debug("memory.v2.enabled is false; consolidation skipped");
     return { kind: "disabled" };


### PR DESCRIPTION
## Summary
- Gate periodic memory maintenance scheduling on global `memory.enabled`
- Make already-queued memory v2 consolidation jobs no-op when `memory.enabled` is false
- Add regression coverage for interval, size-triggered, and stale claimed consolidation jobs

## Why
After the Memory opt-out PR merged, consolidation config/manual routes were gated by global Memory, but the automatic background scheduler and claimed job handler could still run when `memory.enabled=false`.

## Validation
- `cd assistant && bun test src/memory/__tests__/jobs-worker-v2-schedule.test.ts`
- `cd assistant && bun test src/memory/v2/__tests__/consolidation-job.test.ts`
- `cd assistant && bunx tsc --noEmit`
- `cd assistant && bun run lint src/memory/jobs-worker.ts src/memory/v2/consolidation-job.ts src/memory/__tests__/jobs-worker-v2-schedule.test.ts src/memory/v2/__tests__/consolidation-job.test.ts`
- `git diff --check`