### PR TITLE
Require Descriptions In Schedule Tools

### DIFF
--- a/assistant/src/__tests__/intent-routing.test.ts
+++ b/assistant/src/__tests__/intent-routing.test.ts
@@ -83,6 +83,13 @@ describe("schedule_create tool description", () => {
     expect(scheduleCreateDef.description).toContain("cron");
   });
 
+  test("requires an authored description", () => {
+    expect(scheduleCreateDef.input_schema.required).toContain("description");
+    expect(
+      scheduleCreateDef.input_schema.properties.description.description,
+    ).toContain("what it does and why");
+  });
+
   test('warns against using for "add to my tasks" requests', () => {
     expect(scheduleCreateDef.description).toContain(
       'Do NOT use this for "add to my tasks"',

--- a/assistant/src/__tests__/schedule-tools.test.ts
+++ b/assistant/src/__tests__/schedule-tools.test.ts
@@ -18,7 +18,7 @@ import type { Database } from "bun:sqlite";
 
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
-import { executeScheduleCreate } from "../tools/schedule/create.js";
+import { executeScheduleCreate as rawExecuteScheduleCreate } from "../tools/schedule/create.js";
 import { executeScheduleDelete } from "../tools/schedule/delete.js";
 import { executeScheduleList } from "../tools/schedule/list.js";
 import { executeScheduleUpdate } from "../tools/schedule/update.js";
@@ -41,6 +41,16 @@ const trustedCtx: ToolContext = {
   trustClass: "trusted_contact",
 };
 
+function executeScheduleCreate(
+  input: Record<string, unknown>,
+  context: ToolContext,
+) {
+  return rawExecuteScheduleCreate(
+    { description: "Test schedule description", ...input },
+    context,
+  );
+}
+
 // ── schedule_create ─────────────────────────────────────────────────
 
 describe("schedule_create tool", () => {
@@ -53,6 +63,7 @@ describe("schedule_create tool", () => {
     const result = await executeScheduleCreate(
       {
         name: "Daily standup",
+        description: "Remind the team to join the daily standup.",
         expression: "0 9 * * 1-5",
         message: "Time for standup!",
       },
@@ -62,8 +73,16 @@ describe("schedule_create tool", () => {
     expect(result.isError).toBe(false);
     expect(result.content).toContain("schedule created successfully");
     expect(result.content).toContain("Daily standup");
+    expect(result.content).toContain(
+      "Description: Remind the team to join the daily standup.",
+    );
     expect(result.content).toContain("Every weekday at 9:00 AM");
     expect(result.content).toContain("Enabled: true");
+
+    const row = getRawDb()
+      .query("SELECT description FROM cron_jobs LIMIT 1")
+      .get() as { description: string };
+    expect(row.description).toBe("Remind the team to join the daily standup.");
   });
 
   test("persists the creating conversation for recurring schedules", async () => {
@@ -124,6 +143,35 @@ describe("schedule_create tool", () => {
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain("name is required");
+  });
+
+  test("rejects missing description", async () => {
+    const result = await rawExecuteScheduleCreate(
+      {
+        name: "No description",
+        expression: "0 9 * * *",
+        message: "test",
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("description is required");
+  });
+
+  test("rejects blank description", async () => {
+    const result = await rawExecuteScheduleCreate(
+      {
+        name: "Blank description",
+        description: "   ",
+        expression: "0 9 * * *",
+        message: "test",
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("description is required");
   });
 
   test("rejects missing expression when no fire_at", async () => {
@@ -195,6 +243,7 @@ describe("schedule_create with fire_at (one-shot)", () => {
     const result = await executeScheduleCreate(
       {
         name: "One-time reminder",
+        description: "Remind the user about a one-time event.",
         fire_at: futureDate,
         message: "Don't forget!",
       },
@@ -206,7 +255,15 @@ describe("schedule_create with fire_at (one-shot)", () => {
     expect(result.content).toContain("Type: one-shot");
     expect(result.content).toContain("Mode: execute");
     expect(result.content).toContain("One-time reminder");
+    expect(result.content).toContain(
+      "Description: Remind the user about a one-time event.",
+    );
     expect(result.content).toContain("Status: active");
+
+    const row = getRawDb()
+      .query("SELECT description FROM cron_jobs LIMIT 1")
+      .get() as { description: string };
+    expect(row.description).toBe("Remind the user about a one-time event.");
   });
 
   test("persists the creating conversation for one-shot schedules", async () => {
@@ -547,6 +604,7 @@ describe("schedule_list tool", () => {
     await executeScheduleCreate(
       {
         name: "Detail Job",
+        description: "Describe the detail job purpose.",
         expression: "30 14 * * *",
         message: "Afternoon check",
       },
@@ -561,6 +619,9 @@ describe("schedule_list tool", () => {
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain("Schedule: Detail Job");
+    expect(result.content).toContain(
+      "Description: Describe the detail job purpose.",
+    );
     expect(result.content).toContain("Every day at 2:30 PM");
     expect(result.content).toContain("Message: Afternoon check");
     expect(result.content).toContain("Enabled: true");
@@ -598,6 +659,7 @@ describe("schedule_list with one-shot schedules", () => {
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain("One-shot Event");
+    expect(result.content).toContain("Test schedule description");
     expect(result.content).toContain("one-shot");
     expect(result.content).toContain("fire at:");
     expect(result.content).toContain("active");
@@ -717,6 +779,37 @@ describe("schedule_update tool", () => {
     expect(result.isError).toBe(false);
     expect(result.content).toContain("Schedule updated successfully");
     expect(result.content).toContain("New Name");
+  });
+
+  test("updates the description of a schedule", async () => {
+    await executeScheduleCreate(
+      {
+        name: "Description update",
+        description: "Original purpose.",
+        expression: "0 9 * * *",
+        message: "test",
+      },
+      ctx,
+    );
+
+    const row = getRawDb().query("SELECT id FROM cron_jobs LIMIT 1").get() as {
+      id: string;
+    };
+    const result = await executeScheduleUpdate(
+      {
+        job_id: row.id,
+        description: "Updated purpose.",
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Description: Updated purpose.");
+
+    const dbRow = getRawDb()
+      .query("SELECT description FROM cron_jobs WHERE id = ?")
+      .get(row.id) as { description: string };
+    expect(dbRow.description).toBe("Updated purpose.");
   });
 
   test("updates the cron expression", async () => {

--- a/assistant/src/config/bundled-skills/schedule/TOOLS.json
+++ b/assistant/src/config/bundled-skills/schedule/TOOLS.json
@@ -3,7 +3,7 @@
   "tools": [
     {
       "name": "schedule_create",
-      "description": "Create a scheduled automation. For recurring: provide expression (cron/RRULE). For one-time: provide fire_at (ISO 8601 timestamp). ONLY use this when the user explicitly wants something to run on a schedule (e.g. \"every day at 9am\", \"remind me tomorrow at 3pm\", \"weekly on Mondays\"). Do NOT use this for \"add to my tasks\" or \"add to my queue\" - use task_list_add for those requests instead.",
+      "description": "Create a scheduled automation. Always provide a concise description of what the schedule does and why. For recurring: provide expression (cron/RRULE). For one-time: provide fire_at (ISO 8601 timestamp). ONLY use this when the user explicitly wants something to run on a schedule (e.g. \"every day at 9am\", \"remind me tomorrow at 3pm\", \"weekly on Mondays\"). Do NOT use this for \"add to my tasks\" or \"add to my queue\" - use task_list_add for those requests instead.",
       "category": "schedule",
       "risk": "medium",
       "input_schema": {
@@ -12,6 +12,10 @@
           "name": {
             "type": "string",
             "description": "A human-readable name for the scheduled task"
+          },
+          "description": {
+            "type": "string",
+            "description": "Required concise authored description of what it does and why. Keep this distinct from the timing/cadence."
           },
           "syntax": {
             "type": "string",
@@ -77,7 +81,7 @@
             "description": "For script mode: maximum time in milliseconds the shell command may run before it is killed. Defaults to 60000 (60s). Allowed range: 1000 to 1800000."
           }
         },
-        "required": ["name"]
+        "required": ["name", "description"]
       },
       "executor": "tools/schedule-create.ts",
       "execution_target": "host"
@@ -106,7 +110,7 @@
     },
     {
       "name": "schedule_update",
-      "description": "Update an existing scheduled automation (expression, syntax, message, name, enabled state, mode, or routing)",
+      "description": "Update an existing scheduled automation (expression, syntax, message, name, description, enabled state, mode, or routing)",
       "category": "schedule",
       "risk": "medium",
       "input_schema": {
@@ -119,6 +123,10 @@
           "name": {
             "type": "string",
             "description": "New name for the job"
+          },
+          "description": {
+            "type": "string",
+            "description": "New concise authored description of what the schedule does and why. Keep this distinct from the timing/cadence."
           },
           "syntax": {
             "type": "string",

--- a/assistant/src/tools/schedule/create.ts
+++ b/assistant/src/tools/schedule/create.ts
@@ -33,6 +33,7 @@ export async function executeScheduleCreate(
     };
   }
   const name = input.name as string;
+  const description = input.description as string | undefined;
   const timezone = (input.timezone as string) ?? null;
   const message = (input.message as string) ?? "";
   const script = (input.script as string) ?? null;
@@ -59,6 +60,17 @@ export async function executeScheduleCreate(
   if (!name || typeof name !== "string") {
     return {
       content: "Error: name is required and must be a string",
+      isError: true,
+    };
+  }
+
+  if (
+    !description ||
+    typeof description !== "string" ||
+    description.trim().length === 0
+  ) {
+    return {
+      content: "Error: description is required and must be a non-empty string",
       isError: true,
     };
   }
@@ -128,6 +140,7 @@ export async function executeScheduleCreate(
     try {
       const job = createSchedule({
         name,
+        description,
         cronExpression: null,
         timezone,
         message,
@@ -154,6 +167,7 @@ export async function executeScheduleCreate(
           `One-shot schedule created successfully.`,
           `  ID: ${job.id}`,
           `  Name: ${job.name}`,
+          `  Description: ${job.description}`,
           `  Type: one-shot`,
           `  Mode: ${job.mode}`,
           `  Fire at: ${fireDate}`,
@@ -211,6 +225,7 @@ export async function executeScheduleCreate(
   try {
     const job = createSchedule({
       name,
+      description,
       cronExpression: resolved.expression,
       timezone,
       message,
@@ -243,6 +258,7 @@ export async function executeScheduleCreate(
         `Recurring schedule created successfully.`,
         `  ID: ${job.id}`,
         `  Name: ${job.name}`,
+        `  Description: ${job.description}`,
         `  Syntax: ${job.syntax}`,
         `  Mode: ${job.mode}`,
         `  Schedule: ${scheduleDescription}${

--- a/assistant/src/tools/schedule/list.ts
+++ b/assistant/src/tools/schedule/list.ts
@@ -25,6 +25,10 @@ function isOneShot(job: { expression: string | null }): boolean {
   return job.expression == null;
 }
 
+function describeAuthoredPurpose(job: { description: string }): string {
+  return job.description || "(none)";
+}
+
 export async function executeScheduleList(
   input: Record<string, unknown>,
   _context: ToolContext,
@@ -48,6 +52,7 @@ export async function executeScheduleList(
       `  Type: ${oneShot ? "one-shot" : "recurring"}`,
       `  Mode: ${job.mode}`,
       `  Status: ${job.status}`,
+      `  Description: ${describeAuthoredPurpose(job)}`,
     ];
 
     if (oneShot) {
@@ -118,14 +123,17 @@ export async function executeScheduleList(
     if (oneShot) {
       const fireTime = formatLocalDate(job.nextRunAt);
       lines.push(
-        `  - [${status}] ${job.name} (id: ${job.id}) (one-shot, ${job.mode}) - fire at: ${fireTime} [${job.status}]`,
+        `  - [${status}] ${job.name} (id: ${job.id}) (one-shot, ${job.mode}) [${job.status}]`,
+        `    Description: ${describeAuthoredPurpose(job)}`,
+        `    fire at: ${fireTime}`,
       );
     } else {
       const next = job.enabled ? formatLocalDate(job.nextRunAt) : "n/a";
       lines.push(
-        `  - [${status}] ${job.name} (id: ${job.id}) ([${
-          job.syntax
-        }] ${describeSchedule(job)}, ${job.mode}) - next: ${next}`,
+        `  - [${status}] ${job.name} (id: ${job.id}) (${job.mode})`,
+        `    Description: ${describeAuthoredPurpose(job)}`,
+        `    Schedule: [${job.syntax}] ${describeSchedule(job)}`,
+        `    Next: ${next}`,
       );
     }
   }

--- a/assistant/src/tools/schedule/update.ts
+++ b/assistant/src/tools/schedule/update.ts
@@ -65,6 +65,16 @@ export async function executeScheduleUpdate(
 
   const updates: Record<string, unknown> = {};
   if (input.name !== undefined) updates.name = input.name;
+  if (input.description !== undefined) {
+    const description = input.description as string;
+    if (typeof description !== "string" || description.trim().length === 0) {
+      return {
+        content: "Error: description must be a non-empty string when provided",
+        isError: true,
+      };
+    }
+    updates.description = description;
+  }
   if (input.timezone !== undefined) updates.timezone = input.timezone;
   if (input.message !== undefined) updates.message = input.message;
   if (input.script !== undefined) updates.script = input.script;
@@ -184,6 +194,7 @@ export async function executeScheduleUpdate(
       jobId,
       updates as {
         name?: string;
+        description?: string;
         cronExpression?: string;
         timezone?: string | null;
         message?: string;
@@ -217,6 +228,7 @@ export async function executeScheduleUpdate(
       content: [
         `Schedule updated successfully.`,
         `  Name: ${job.name}`,
+        `  Description: ${job.description}`,
         `  Syntax: ${job.syntax}`,
         `  Mode: ${job.mode}`,
         `  Schedule: ${scheduleDescription}${job.timezone ? ` (${job.timezone})` : ""}`,


### PR DESCRIPTION
## Summary
- Requires authored descriptions when creating schedules through LLM tools.
- Allows schedule_update to change descriptions.
- Shows descriptions in schedule tool output while preserving schedule timing details.

Part of plan: schedule-description-fields.md (PR 3 of 6)