### PR TITLE
Clean up consolidation Memory UI on schedules and advanced settings

### DIFF
--- a/apps/web/src/domains/settings/components/system-task-detail-view.tsx
+++ b/apps/web/src/domains/settings/components/system-task-detail-view.tsx
@@ -41,8 +41,16 @@ export function SystemTaskDetailView({
   onRunNow,
   onOpenMemorySettings,
 }: SystemTaskDetailViewProps) {
-  const isConsolidationPaused = kind === "consolidation" && !enabled;
+  const isConsolidation = kind === "consolidation";
+  const isConsolidationPaused = isConsolidation && !enabled;
   const runNowDisabled = isRunning || isConsolidationPaused;
+  const statusValue = isConsolidation
+    ? enabled
+      ? "On · Managed by Memory"
+      : "Paused"
+    : enabled
+      ? "Enabled"
+      : "Disabled";
 
   const { data: runs, isLoading } = useQuery({
     queryKey: ["system-task-runs", assistantId, kind],
@@ -70,7 +78,7 @@ export function SystemTaskDetailView({
         accessory={
           <div className="flex items-center gap-2">
             <Tag tone="neutral">system</Tag>
-            {kind === "consolidation" && onOpenMemorySettings ? (
+            {isConsolidation && enabled && onOpenMemorySettings ? (
               <Button
                 variant="outlined"
                 size="compact"
@@ -93,11 +101,7 @@ export function SystemTaskDetailView({
               onClick={onRunNow}
               disabled={runNowDisabled}
             >
-              {isRunning
-                ? "Running…"
-                : isConsolidationPaused
-                  ? "Paused"
-                  : "Run now"}
+              {isRunning ? "Running…" : "Run now"}
             </Button>
           </div>
         }
@@ -105,7 +109,7 @@ export function SystemTaskDetailView({
         <div className="space-y-2 text-body-medium-lighter">
           <div className="flex items-center justify-between">
             <span className="text-[var(--content-secondary)]">Status</span>
-            <span>{enabled ? "Enabled" : "Disabled"}</span>
+            <span>{statusValue}</span>
           </div>
           <div className="flex items-center justify-between">
             <span className="text-[var(--content-secondary)]">Next run</span>
@@ -116,11 +120,24 @@ export function SystemTaskDetailView({
             <span>{formatTimestamp(lastRunAt)}</span>
           </div>
         </div>
-        {kind === "consolidation" ? (
-          <Notice tone={enabled ? "info" : "warning"} className="mt-4">
-            {enabled
-              ? "Consolidation is managed by Memory. To turn off consolidation, disable Memory as a whole."
-              : "Memory is off, so consolidation is paused. Turn Memory back on to resume consolidation."}
+        {isConsolidationPaused ? (
+          <Notice
+            tone="warning"
+            className="mt-4"
+            actions={
+              onOpenMemorySettings ? (
+                <Button
+                  variant="outlined"
+                  size="compact"
+                  onClick={onOpenMemorySettings}
+                >
+                  Turn on Memory
+                </Button>
+              ) : undefined
+            }
+          >
+            Memory is off, so consolidation is paused. Turn Memory back on to
+            resume consolidation.
           </Notice>
         ) : null}
       </DetailCard>

--- a/apps/web/src/domains/settings/components/system-tasks-section.tsx
+++ b/apps/web/src/domains/settings/components/system-tasks-section.tsx
@@ -190,17 +190,15 @@ export function SystemTasksSection({
               enabled={consolidationConfig.enabled}
               helperText={
                 consolidationConfig.enabled
-                  ? "Consolidation is part of Memory. Disable Memory to stop it."
+                  ? undefined
                   : "Memory is off, so consolidation is paused."
               }
               nextRunAt={consolidationConfig.nextRunAt}
               lastRunAt={consolidationConfig.lastRunAt}
               usage={consolidationUsage}
               showToggle={false}
-              statusLabel={
-                consolidationConfig.enabled ? "Managed by Memory" : "Paused"
-              }
-              statusTone={consolidationConfig.enabled ? "neutral" : "warning"}
+              statusLabel={consolidationConfig.enabled ? undefined : "Paused"}
+              statusTone="warning"
               onClick={onSelectConsolidation}
             />
           ) : null}

--- a/apps/web/src/domains/settings/pages/advanced-page.tsx
+++ b/apps/web/src/domains/settings/pages/advanced-page.tsx
@@ -32,21 +32,6 @@ export function AdvancedPage() {
 
   return (
     <div className="space-y-4">
-      {showMemoryOptOut ? (
-        <DetailCard
-          title="Memory"
-          subtitle="Opt out of long-term memory."
-          accessory={
-            <Toggle
-              checked={memoryEnabled}
-              onChange={(enabled) => void handleMemoryToggle(enabled)}
-              aria-label="Enable memory"
-              disabled={configMutation.isPending}
-            />
-          }
-          compactAccessory
-        />
-      ) : null}
       {infraGate === "full" && platformAssistant && (
         <DetailCard
           title="Update Window"
@@ -65,6 +50,21 @@ export function AdvancedPage() {
           </Notice>
         </DetailCard>
       )}
+      {showMemoryOptOut ? (
+        <DetailCard
+          title="Memory"
+          subtitle="Let your assistant remember information from past conversations. Turning this off also pauses memory consolidation."
+          accessory={
+            <Toggle
+              checked={memoryEnabled}
+              onChange={(enabled) => void handleMemoryToggle(enabled)}
+              aria-label="Enable memory"
+              disabled={configMutation.isPending}
+            />
+          }
+          compactAccessory
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/domains/settings/pages/schedules-page.test.ts
+++ b/apps/web/src/domains/settings/pages/schedules-page.test.ts
@@ -259,6 +259,10 @@ describe("SystemTaskDetailView", () => {
       expect(document.body.textContent).toContain("$0.12"),
     );
     expect(screen.getByRole("button", { name: /Run now/i })).toBeTruthy();
+    expect(document.body.textContent).toContain("On · Managed by Memory");
+    expect(document.body.textContent).not.toContain(
+      "Memory is off, so consolidation is paused.",
+    );
     expect(document.body.textContent).not.toContain(
       "Run history is not available",
     );
@@ -299,12 +303,15 @@ describe("SystemTaskDetailView", () => {
       "Memory is off, so consolidation is paused.",
     );
     expect(
-      (screen.getByRole("button", { name: "Paused" }) as HTMLButtonElement)
+      (screen.getByRole("button", { name: /Run now/i }) as HTMLButtonElement)
         .disabled,
     ).toBe(true);
+    expect(
+      screen.queryByRole("button", { name: /Memory settings/i }),
+    ).toBeNull();
 
     fireEvent.click(
-      screen.getByRole("button", { name: /Memory settings/i }),
+      screen.getByRole("button", { name: /Turn on Memory/i }),
     );
 
     expect(memorySettingsClicks).toBe(1);
@@ -698,8 +705,11 @@ describe("system task toggles", () => {
     expect(screen.queryByLabelText("Toggle Consolidation")).toBeNull();
     expect(toggleCalls).toEqual([]);
     expect(screen.queryByRole("button", { name: /run now/i })).toBeNull();
-    expect(screen.getByText("Managed by Memory")).toBeTruthy();
-    expect(document.body.textContent).toContain(
+    // Enabled consolidation reads like any other healthy system row: a status
+    // dot, no management tag or helper copy (the detail page explains it).
+    expect(screen.getByLabelText("enabled")).toBeTruthy();
+    expect(screen.queryByText("Managed by Memory")).toBeNull();
+    expect(document.body.textContent).not.toContain(
       "Consolidation is part of Memory.",
     );
   });


### PR DESCRIPTION
## Summary

Follow-up UI/UX cleanup to the memory opt-out setting (#34321). The consolidation surfaces over-explained the Memory relationship in the steady state and under-served the paused state.

**Schedules list (`/settings/schedules`)**
- A healthy Consolidation row now looks like any other system row: green status dot, no "Managed by Memory" tag, no helper sentence.
- Only the unusual paused state gets attention: a warning "Paused" tag plus one line — "Memory is off, so consolidation is paused."

**Consolidation detail (`/settings/schedules/system-consolidation`)**
- Removed the permanent info banner ("Consolidation is managed by Memory…"). The Status row now reads **"On · Managed by Memory"** instead.
- Paused state is actionable: a warning notice with a **"Turn on Memory"** button (uses the Notice `actions` slot).
- The header "Memory settings" button only shows while consolidation is running, so each state has exactly one Memory affordance.
- The Run now button stays labeled "Run now" (disabled when paused) rather than relabeling itself "Paused".

**Advanced settings (`/settings/advanced`)**
- Moved the Memory card below the Update Window section.
- Replaced the ambiguous subtitle "Opt out of long-term memory." (unclear which toggle direction meant opted out) with: "Let your assistant remember information from past conversations. Turning this off also pauses memory consolidation."

## Testing

- `bunx tsc --noEmit` in `apps/web` — clean
- `bun test src/domains/settings/pages/schedules-page.test.ts src/domains/settings/pages/advanced-page.test.tsx` — 25 pass, 0 fail
- Tests updated to pin the new behavior: paused-state routing goes through the notice's "Turn on Memory" action, and the enabled row asserts no management tag/helper copy renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)