### PR TITLE
Add CLI Schedule Description Support

### DIFF
--- a/apps/web/src/domains/settings/api/schedules.ts
+++ b/apps/web/src/domains/settings/api/schedules.ts
@@ -45,6 +45,7 @@ export { ApiError };
 
 export interface CreateSchedulePayload {
   name: string;
+  description: string;
   expression: string;
   message: string;
   timezone?: string | null;

--- a/apps/web/src/domains/settings/components/create-schedule-modal.tsx
+++ b/apps/web/src/domains/settings/components/create-schedule-modal.tsx
@@ -75,6 +75,7 @@ function CreateScheduleModalInner({
   onCreated: () => void;
 }) {
   const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
   const [expression, setExpression] = useState("");
   const [message, setMessage] = useState("");
   const [timezone, setTimezone] = useState("");
@@ -82,10 +83,12 @@ function CreateScheduleModalInner({
   const [submitError, setSubmitError] = useState<string | null>(null);
 
   const trimmedName = name.trim();
+  const trimmedDescription = description.trim();
   const trimmedExpression = expression.trim();
   const trimmedMessage = message.trim();
   const canSubmit =
     trimmedName.length > 0 &&
+    trimmedDescription.length > 0 &&
     trimmedExpression.length > 0 &&
     trimmedMessage.length > 0 &&
     !submitting;
@@ -98,6 +101,7 @@ function CreateScheduleModalInner({
     try {
       const payload: CreateSchedulePayload = {
         name: trimmedName,
+        description: trimmedDescription,
         expression: trimmedExpression,
         message: trimmedMessage,
       };
@@ -138,6 +142,16 @@ function CreateScheduleModalInner({
               required
               autoFocus
               fullWidth
+            />
+
+            <Textarea
+              label="Description"
+              placeholder="What is this schedule for?"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              required
+              fullWidth
+              rows={2}
             />
 
             <div className="flex flex-col gap-1.5">

--- a/apps/web/src/domains/settings/components/schedule-detail-view.tsx
+++ b/apps/web/src/domains/settings/components/schedule-detail-view.tsx
@@ -284,6 +284,14 @@ export function ScheduleDetailView({
               onUpdated={onUpdated}
             />
           )}
+          {schedule.cadenceDescription ? (
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-[var(--content-secondary)]">Cadence</span>
+              <span className="min-w-0 text-right">
+                {schedule.cadenceDescription}
+              </span>
+            </div>
+          ) : null}
           <div className="flex items-center justify-between">
             <span className="text-[var(--content-secondary)]">Status</span>
             <span>{schedule.enabled ? "Enabled" : "Disabled"}</span>

--- a/apps/web/src/domains/settings/components/schedule-row.tsx
+++ b/apps/web/src/domains/settings/components/schedule-row.tsx
@@ -9,6 +9,14 @@ import { Toggle } from "@vellumai/design-library/components/toggle";
 
 import type { Schedule } from "@/domains/settings/types/schedules";
 
+function cadenceTextForRow(schedule: Schedule): string | null {
+  const cadence = schedule.cadenceDescription.trim();
+  if (!cadence) return null;
+  if (schedule.isOneShot) return null;
+  if (cadence === schedule.description.trim()) return null;
+  return cadence;
+}
+
 export function ScheduleRow({
   schedule,
   usage,
@@ -23,6 +31,7 @@ export function ScheduleRow({
   onOpenUsage: () => void;
 }) {
   const displayRunAt = schedule.lastRunAt ?? schedule.nextRunAt;
+  const cadenceText = cadenceTextForRow(schedule);
 
   return (
     <div className="flex flex-wrap items-center gap-3 rounded-md px-2 py-3 transition-colors hover:bg-[var(--surface-hover)] [&+&]:border-t [&+&]:border-[var(--border-base)]">
@@ -36,8 +45,15 @@ export function ScheduleRow({
             {schedule.name}
           </span>
         </div>
-        <div className="mt-0.5 flex items-center gap-3 text-body-small-default text-[var(--content-tertiary)]">
-          <span className="truncate">{schedule.description}</span>
+        <div className="mt-0.5 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-body-small-default text-[var(--content-tertiary)]">
+          <span className="min-w-[12rem] max-w-full flex-1 truncate">
+            {schedule.description}
+          </span>
+          {cadenceText ? (
+            <span className="shrink-0 text-[var(--content-secondary)]">
+              {cadenceText}
+            </span>
+          ) : null}
           {displayRunAt ? (
             <span className="shrink-0">{formatTimestamp(displayRunAt)}</span>
           ) : null}

--- a/apps/web/src/domains/settings/types/schedules.ts
+++ b/apps/web/src/domains/settings/types/schedules.ts
@@ -5,6 +5,8 @@ import type {
 } from "@/generated/daemon/types.gen";
 
 export type Schedule = SchedulesGetResponse["schedules"][number] & {
+  description: string;
+  cadenceDescription: string;
   createdFromConversationId?: string | null;
   createdFromConversationExists?: boolean;
   createdFromConversationArchivedAt?: number | null;


### PR DESCRIPTION
## Summary
- Requires descriptions when creating schedules from the CLI.
- Sends authored descriptions in schedule create requests.
- Uses cadenceDescription for generated schedule timing labels in CLI output.

Part of plan: schedule-description-fields.md (PR 4 of 6)