### PR TITLE
Add CLI Schedule Description Support

### DIFF
--- a/assistant/src/cli/commands/__tests__/schedules.test.ts
+++ b/assistant/src/cli/commands/__tests__/schedules.test.ts
@@ -151,7 +151,8 @@ describe("schedules list", () => {
             retryCount: 0,
             maxRetries: 3,
             retryBackoffMs: 60_000,
-            description: "Every 30 minutes",
+            description: "Authored heartbeat check",
+            cadenceDescription: "Every 30 minutes",
             mode: "execute",
             status: "active",
             routingIntent: "all_channels",
@@ -175,6 +176,8 @@ describe("schedules list", () => {
         expect.objectContaining({
           id: "schedule-1",
           name: "Heartbeat",
+          description: "Authored heartbeat check",
+          cadenceDescription: "Every 30 minutes",
         }),
       ],
     });
@@ -201,7 +204,8 @@ describe("schedules list", () => {
             retryCount: 0,
             maxRetries: 3,
             retryBackoffMs: 60_000,
-            description: "Every 30 minutes",
+            description: "Authored heartbeat check",
+            cadenceDescription: "Every 30 minutes",
             mode: "execute",
             status: "active",
             routingIntent: "all_channels",
@@ -219,6 +223,7 @@ describe("schedules list", () => {
     expect(logLines.join("\n")).toContain("ID");
     expect(logLines.join("\n")).toContain("Heartbeat");
     expect(logLines.join("\n")).toContain("Every 30 minutes (UTC)");
+    expect(logLines.join("\n")).not.toContain("Authored heartbeat check");
   });
 
   test("sets exit code on IPC failure", async () => {
@@ -376,6 +381,8 @@ describe("schedules create", () => {
       "Heartbeat",
       "--expression",
       "*/30 * * * *",
+      "--description",
+      "Checks service heartbeat",
       "--message",
       "run heartbeat",
     ]);
@@ -388,6 +395,7 @@ describe("schedules create", () => {
           body: {
             name: "Heartbeat",
             expression: "*/30 * * * *",
+            description: "Checks service heartbeat",
             message: "run heartbeat",
             enabled: true,
           },
@@ -395,6 +403,39 @@ describe("schedules create", () => {
       },
     ]);
     expect(logLines).toEqual(["Created schedule: Heartbeat"]);
+  });
+
+  test("requires a description", async () => {
+    const { exitCode } = await runCommand([
+      "schedules",
+      "create",
+      "Heartbeat",
+      "--expression",
+      "*/30 * * * *",
+      "--message",
+      "run heartbeat",
+    ]);
+
+    expect(exitCode).not.toBe(0);
+    expect(ipcCalls).toEqual([]);
+  });
+
+  test("rejects an empty description", async () => {
+    const { exitCode } = await runCommand([
+      "schedules",
+      "create",
+      "Heartbeat",
+      "--expression",
+      "*/30 * * * *",
+      "--description",
+      "   ",
+      "--message",
+      "run heartbeat",
+    ]);
+
+    expect(exitCode).not.toBe(0);
+    expect(ipcCalls).toEqual([]);
+    expect(errorLines).toEqual(["description is required"]);
   });
 
   test("passes --timezone through to the request body", async () => {
@@ -408,6 +449,8 @@ describe("schedules create", () => {
       "0 9 * * MON-FRI",
       "--message",
       "morning summary",
+      "--description",
+      "Summarizes weekday mornings",
       "--timezone",
       "America/New_York",
     ]);
@@ -421,6 +464,7 @@ describe("schedules create", () => {
             name: "Morning",
             expression: "0 9 * * MON-FRI",
             message: "morning summary",
+            description: "Summarizes weekday mornings",
             enabled: true,
             timezone: "America/New_York",
           },
@@ -440,6 +484,8 @@ describe("schedules create", () => {
       "0 0 * * *",
       "--message",
       "placeholder",
+      "--description",
+      "Draft schedule",
       "--no-enabled",
     ]);
 
@@ -452,6 +498,7 @@ describe("schedules create", () => {
             name: "Drafted",
             expression: "0 0 * * *",
             message: "placeholder",
+            description: "Draft schedule",
             enabled: false,
           },
         },
@@ -480,7 +527,8 @@ describe("schedules create", () => {
             retryCount: 0,
             maxRetries: 3,
             retryBackoffMs: 60_000,
-            description: "Every 30 minutes",
+            description: "Checks service heartbeat",
+            cadenceDescription: "Every 30 minutes",
             mode: "execute",
             status: "active",
             routingIntent: "all_channels",
@@ -500,12 +548,20 @@ describe("schedules create", () => {
       "*/30 * * * *",
       "--message",
       "run heartbeat",
+      "--description",
+      "Checks service heartbeat",
       "--json",
     ]);
 
     expect(exitCode).toBe(0);
     expect(JSON.parse(stdout)).toEqual({
-      schedules: [expect.objectContaining({ id: "new-schedule-id" })],
+      schedules: [
+        expect.objectContaining({
+          id: "new-schedule-id",
+          description: "Checks service heartbeat",
+          cadenceDescription: "Every 30 minutes",
+        }),
+      ],
     });
     expect(logLines).toEqual([]);
   });
@@ -524,6 +580,8 @@ describe("schedules create", () => {
       "not-a-cron",
       "--message",
       "noop",
+      "--description",
+      "Invalid test schedule",
     ]);
 
     expect(exitCode).toBe(10);

--- a/assistant/src/cli/commands/schedules.ts
+++ b/assistant/src/cli/commands/schedules.ts
@@ -23,6 +23,7 @@ interface ScheduleRecord {
   maxRetries: number;
   retryBackoffMs: number;
   description: string | null;
+  cadenceDescription: string | null;
   mode: string;
   status: string;
   routingIntent: string;
@@ -64,9 +65,9 @@ export function registerSchedulesCommand(program: Command): void {
 Schedules are recurring or one-shot jobs run by the assistant.
 
 This CLI namespace is intentionally landing incrementally. Today it supports
-listing schedules, viewing recent run history, enabling/disabling schedules,
-manually executing a schedule one time, and cancelling pending one-shot schedules;
-create, delete, and run inspection will follow as separate slices.
+creating schedules, listing schedules, viewing recent run history,
+enabling/disabling schedules, manually executing a schedule one time, cancelling
+pending one-shot schedules, and deleting schedules.
 
 Examples:
   $ assistant schedules list
@@ -319,6 +320,10 @@ Examples:
           "Cron or RRULE expression that schedules the fire times",
         )
         .requiredOption(
+          "-d, --description <text>",
+          "Authored description explaining what the schedule is for",
+        )
+        .requiredOption(
           "-m, --message <text>",
           "Message body sent to the assistant on each fire",
         )
@@ -333,6 +338,7 @@ Examples:
           `
 Options:
   -e, --expression <expr>   Cron (e.g. '*/30 * * * *') or RRULE expression.
+  -d, --description <text>  Authored description explaining what the schedule is for.
   -m, --message <text>      Message body sent on each fire.
   -t, --timezone <tz>       IANA timezone applied to the expression.
   --no-enabled              Create the schedule disabled. Defaults to enabled.
@@ -349,13 +355,16 @@ Behavior:
 Examples:
   $ assistant schedules create "Heartbeat" \\
       --expression '*/30 * * * *' \\
+      --description 'Checks service heartbeat every 30 minutes' \\
       --message 'run heartbeat'
   $ assistant schedules create "Morning summary" \\
       --expression '0 9 * * MON-FRI' \\
+      --description 'Summarizes weekday activity' \\
       --timezone America/New_York \\
       --message 'write the morning summary'
   $ assistant schedules create "Drafted" \\
       --expression '0 0 * * *' \\
+      --description 'Placeholder daily schedule' \\
       --message 'placeholder' \\
       --no-enabled --json`,
         )
@@ -364,6 +373,7 @@ Examples:
             name: string,
             opts: {
               expression: string;
+              description: string;
               message: string;
               timezone?: string;
               enabled: boolean;
@@ -383,9 +393,22 @@ Examples:
               return;
             }
 
+            const description = opts.description.trim();
+            if (!description) {
+              const error = "description is required";
+              if (opts.json) {
+                writeOutput(cmd, { ok: false, error });
+              } else {
+                log.error(error);
+              }
+              process.exitCode = 1;
+              return;
+            }
+
             const body: Record<string, unknown> = {
               name: scheduleName,
               expression: opts.expression,
+              description,
               message: opts.message,
               enabled: opts.enabled,
             };
@@ -662,7 +685,7 @@ async function toggleScheduleEnabled(
 
 function describeSchedule(schedule: ScheduleRecord): string {
   if (schedule.isOneShot) return "one-shot";
-  const expression = schedule.description ?? schedule.expression ?? "—";
+  const expression = schedule.cadenceDescription ?? schedule.expression ?? "—";
   return schedule.timezone
     ? `${expression} (${schedule.timezone})`
     : expression;


### PR DESCRIPTION
## Summary
- Requires descriptions when creating schedules from the CLI.
- Sends authored descriptions in schedule create requests.
- Uses cadenceDescription for generated schedule timing labels in CLI output.

Part of plan: schedule-description-fields.md (PR 4 of 6)