### PR TITLE
Render Descriptions In Web Settings UI

### DIFF
--- a/apps/web/src/domains/settings/api/schedules.ts
+++ b/apps/web/src/domains/settings/api/schedules.ts
@@ -45,6 +45,7 @@ export { ApiError };
 
 export interface CreateSchedulePayload {
   name: string;
+  description: string;
   expression: string;
   message: string;
   timezone?: string | null;

--- a/apps/web/src/domains/settings/components/create-schedule-modal.tsx
+++ b/apps/web/src/domains/settings/components/create-schedule-modal.tsx
@@ -75,6 +75,7 @@ function CreateScheduleModalInner({
   onCreated: () => void;
 }) {
   const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
   const [expression, setExpression] = useState("");
   const [message, setMessage] = useState("");
   const [timezone, setTimezone] = useState("");
@@ -82,10 +83,12 @@ function CreateScheduleModalInner({
   const [submitError, setSubmitError] = useState<string | null>(null);
 
   const trimmedName = name.trim();
+  const trimmedDescription = description.trim();
   const trimmedExpression = expression.trim();
   const trimmedMessage = message.trim();
   const canSubmit =
     trimmedName.length > 0 &&
+    trimmedDescription.length > 0 &&
     trimmedExpression.length > 0 &&
     trimmedMessage.length > 0 &&
     !submitting;
@@ -98,6 +101,7 @@ function CreateScheduleModalInner({
     try {
       const payload: CreateSchedulePayload = {
         name: trimmedName,
+        description: trimmedDescription,
         expression: trimmedExpression,
         message: trimmedMessage,
       };
@@ -138,6 +142,16 @@ function CreateScheduleModalInner({
               required
               autoFocus
               fullWidth
+            />
+
+            <Textarea
+              label="Description"
+              placeholder="What is this schedule for?"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              required
+              fullWidth
+              rows={2}
             />
 
             <div className="flex flex-col gap-1.5">

--- a/apps/web/src/domains/settings/components/schedule-detail-view.tsx
+++ b/apps/web/src/domains/settings/components/schedule-detail-view.tsx
@@ -218,7 +218,7 @@ export function ScheduleDetailView({
 
       <DetailCard
         title={schedule.name}
-        subtitle={schedule.description ?? undefined}
+        subtitle={schedule.description}
         accessory={
           <div className="flex items-center gap-2">
             <Tag tone={MODE_TONE[schedule.mode] ?? "neutral"}>
@@ -284,6 +284,14 @@ export function ScheduleDetailView({
               onUpdated={onUpdated}
             />
           )}
+          {schedule.cadenceDescription ? (
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-[var(--content-secondary)]">Cadence</span>
+              <span className="min-w-0 text-right">
+                {schedule.cadenceDescription}
+              </span>
+            </div>
+          ) : null}
           <div className="flex items-center justify-between">
             <span className="text-[var(--content-secondary)]">Status</span>
             <span>{schedule.enabled ? "Enabled" : "Disabled"}</span>

--- a/apps/web/src/domains/settings/components/schedule-row.tsx
+++ b/apps/web/src/domains/settings/components/schedule-row.tsx
@@ -9,6 +9,14 @@ import { Toggle } from "@vellumai/design-library/components/toggle";
 
 import type { Schedule } from "@/domains/settings/types/schedules";
 
+function cadenceTextForRow(schedule: Schedule): string | null {
+  const cadence = schedule.cadenceDescription.trim();
+  if (!cadence) return null;
+  if (schedule.isOneShot) return null;
+  if (cadence === schedule.description.trim()) return null;
+  return cadence;
+}
+
 export function ScheduleRow({
   schedule,
   usage,
@@ -23,6 +31,7 @@ export function ScheduleRow({
   onOpenUsage: () => void;
 }) {
   const displayRunAt = schedule.lastRunAt ?? schedule.nextRunAt;
+  const cadenceText = cadenceTextForRow(schedule);
 
   return (
     <div className="flex flex-wrap items-center gap-3 rounded-md px-2 py-3 transition-colors hover:bg-[var(--surface-hover)] [&+&]:border-t [&+&]:border-[var(--border-base)]">
@@ -36,8 +45,15 @@ export function ScheduleRow({
             {schedule.name}
           </span>
         </div>
-        <div className="mt-0.5 flex items-center gap-3 text-body-small-default text-[var(--content-tertiary)]">
-          <span className="truncate">{schedule.description}</span>
+        <div className="mt-0.5 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-body-small-default text-[var(--content-tertiary)]">
+          <span className="min-w-[12rem] max-w-full flex-1 truncate">
+            {schedule.description}
+          </span>
+          {cadenceText ? (
+            <span className="shrink-0 text-[var(--content-secondary)]">
+              {cadenceText}
+            </span>
+          ) : null}
           {displayRunAt ? (
             <span className="shrink-0">{formatTimestamp(displayRunAt)}</span>
           ) : null}

--- a/apps/web/src/domains/settings/pages/schedules-page.test.ts
+++ b/apps/web/src/domains/settings/pages/schedules-page.test.ts
@@ -57,11 +57,22 @@ const fetchConsolidationRunsMock = mock(
     },
   ],
 );
+const fetchScheduleRunsMock = mock(
+  async (_assistantId: string, _scheduleId: string): Promise<ScheduleRun[]> => [],
+);
+const createScheduleMock = mock(
+  async (
+    _assistantId: string,
+    _payload: schedulesApi.CreateSchedulePayload,
+  ): Promise<void> => {},
+);
 let nowSpy: ReturnType<typeof spyOn> | null = null;
 
 mock.module("@/domains/settings/api/schedules", () => ({
   ...schedulesApi,
+  createSchedule: createScheduleMock,
   fetchConsolidationRuns: fetchConsolidationRunsMock,
+  fetchScheduleRuns: fetchScheduleRunsMock,
   fetchScheduleUsageSummary: fetchScheduleUsageSummaryMock,
 }));
 
@@ -76,6 +87,12 @@ const {
 const { RecentRunsCard } = await import(
   "@/domains/settings/components/recent-runs-card"
 );
+const { CreateScheduleModal } = await import(
+  "@/domains/settings/components/create-schedule-modal"
+);
+const { ScheduleDetailView } = await import(
+  "@/domains/settings/components/schedule-detail-view"
+);
 const { ScheduleRow } = await import(
   "@/domains/settings/components/schedule-row"
 );
@@ -89,7 +106,9 @@ const { SystemTaskDetailView } = await import(
 afterEach(() => {
   cleanup();
   navigateCalls.length = 0;
+  createScheduleMock.mockClear();
   fetchConsolidationRunsMock.mockClear();
+  fetchScheduleRunsMock.mockClear();
   fetchScheduleUsageSummaryMock.mockClear();
   nowSpy?.mockRestore();
   nowSpy = null;
@@ -361,6 +380,7 @@ describe("ScheduleRow", () => {
       id: "schedule-123",
       name: "Daily summary",
       description: "Summarize the day",
+      cadenceDescription: "Every day at 9am",
       mode: "execute",
       enabled: true,
       lastRunAt: null,
@@ -490,11 +510,38 @@ describe("ScheduleRow", () => {
     expect(screen.getByText(formatTimestamp(nextRunAt))).toBeTruthy();
   });
 
-  test("one-time rows use the shared clickable row affordance", () => {
+  test("renders authored description and recurring cadence as separate row text", () => {
+    render(
+      createElement(ScheduleRow, {
+        schedule: rowSchedule({
+          description: "Summarize customer updates",
+          cadenceDescription: "Every weekday at 9am",
+        }),
+        usage: {
+          status: "ready",
+          summary: {
+            scheduleId: "schedule-123",
+            runCount: 0,
+            totalEstimatedCostUsd: 0,
+            eventCount: 0,
+          },
+        },
+        onClick: () => {},
+        onToggle: () => {},
+        onOpenUsage: () => {},
+      }),
+    );
+
+    expect(screen.getByText("Summarize customer updates")).toBeTruthy();
+    expect(screen.getByText("Every weekday at 9am")).toBeTruthy();
+  });
+
+  test("one-time rows show authored descriptions and omit the generated one-time label", () => {
     const { container } = render(
       createElement(ScheduleRow, {
         schedule: rowSchedule({
-          description: "One-time",
+          description: "Send the launch reminder",
+          cadenceDescription: "One-time",
           isOneShot: true,
         }),
         usage: {
@@ -511,6 +558,9 @@ describe("ScheduleRow", () => {
         onOpenUsage: () => {},
       }),
     );
+
+    expect(screen.getByText("Send the launch reminder")).toBeTruthy();
+    expect(screen.queryByText("One-time")).toBeNull();
 
     const row = container.firstElementChild;
     expect(row?.className).toContain("rounded-md");
@@ -547,6 +597,88 @@ describe("ScheduleRow", () => {
     );
 
     expect(screen.getAllByText("--")).toHaveLength(2);
+  });
+});
+
+describe("CreateScheduleModal", () => {
+  test("requires a description and sends the trimmed value in the create payload", async () => {
+    render(
+      createElement(CreateScheduleModal, {
+        isOpen: true,
+        assistantId: "assistant-1",
+        onClose: () => {},
+        onCreated: () => {},
+      }),
+    );
+
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: " Morning briefing " },
+    });
+    fireEvent.change(screen.getByLabelText("Cron expression"), {
+      target: { value: " 0 9 * * * " },
+    });
+    fireEvent.change(screen.getByLabelText("Message"), {
+      target: { value: " Report on overnight updates " },
+    });
+
+    expect(
+      screen.getByRole<HTMLButtonElement>("button", { name: "Create schedule" })
+        .disabled,
+    ).toBe(true);
+
+    fireEvent.change(screen.getByLabelText("Description"), {
+      target: { value: " Start the day with the most important changes " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create schedule" }));
+
+    await waitFor(() =>
+      expect(createScheduleMock.mock.calls).toEqual([
+        [
+          "assistant-1",
+          {
+            name: "Morning briefing",
+            description: "Start the day with the most important changes",
+            expression: "0 9 * * *",
+            message: "Report on overnight updates",
+          },
+        ],
+      ]),
+    );
+  });
+});
+
+describe("ScheduleDetailView", () => {
+  test("uses authored description as the subtitle and shows cadence in metadata", async () => {
+    renderWithQueryClient(
+      createElement(ScheduleDetailView, {
+        schedule: schedule({
+          id: "schedule-123",
+          name: "Launch reminder",
+          description: "Send the launch reminder",
+          cadenceDescription: "One-time",
+          mode: "execute",
+          enabled: true,
+          nextRunAt: 1_761_792_000_000,
+          lastRunAt: null,
+          lastStatus: null,
+        }),
+        assistantId: "assistant-1",
+        onBack: () => {},
+        onDeleted: () => {},
+        onUpdated: () => {},
+      }),
+    );
+
+    expect(screen.getByText("Launch reminder")).toBeTruthy();
+    expect(screen.getByText("Send the launch reminder")).toBeTruthy();
+    expect(screen.getByText("Cadence")).toBeTruthy();
+    expect(screen.getByText("One-time")).toBeTruthy();
+
+    await waitFor(() =>
+      expect(fetchScheduleRunsMock.mock.calls).toEqual([
+        ["assistant-1", "schedule-123"],
+      ]),
+    );
   });
 });
 

--- a/apps/web/src/domains/settings/types/schedules.ts
+++ b/apps/web/src/domains/settings/types/schedules.ts
@@ -5,6 +5,8 @@ import type {
 } from "@/generated/daemon/types.gen";
 
 export type Schedule = SchedulesGetResponse["schedules"][number] & {
+  description: string;
+  cadenceDescription: string;
   createdFromConversationId?: string | null;
   createdFromConversationExists?: boolean;
   createdFromConversationArchivedAt?: number | null;


### PR DESCRIPTION
## Summary
- Adds required schedule descriptions to the web create modal.
- Renders authored descriptions in schedule rows and details.
- Moves generated cadence text into metadata so one-time rows stop repeating the type label.

Part of plan: schedule-description-fields.md (PR 5 of 6)