### PR TITLE
Link system schedule costs to usage

### DIFF
--- a/apps/web/src/domains/logs/components/usage-tab.test.tsx
+++ b/apps/web/src/domains/logs/components/usage-tab.test.tsx
@@ -38,8 +38,36 @@ const fetchUsageTotalsMock = mock(
 const fetchUsageBreakdownMock = mock(
   async (
     _assistantId: string,
-    params: { scheduleId?: string },
+    params: { groupBy?: string; scheduleId?: string },
   ): Promise<UsageBreakdownResponse> => {
+    if (params.groupBy === "task") {
+      return {
+        breakdown: [
+          {
+            group: "heartbeatAgent",
+            groupId: "heartbeatAgent",
+            groupKey: "heartbeatAgent",
+            totalInputTokens: 120,
+            totalOutputTokens: 80,
+            totalCacheCreationTokens: 0,
+            totalCacheReadTokens: 0,
+            totalEstimatedCostUsd: 0.03,
+            eventCount: 2,
+          },
+          {
+            group: "mainAgent",
+            groupId: "mainAgent",
+            groupKey: "mainAgent",
+            totalInputTokens: 40,
+            totalOutputTokens: 20,
+            totalCacheCreationTokens: 0,
+            totalCacheReadTokens: 0,
+            totalEstimatedCostUsd: 0.01,
+            eventCount: 1,
+          },
+        ],
+      };
+    }
     const selectedScheduleId = params.scheduleId ?? "schedule-123";
     const selectedSchedule = defaultSchedules.find(
       (schedule) => schedule.id === selectedScheduleId,
@@ -64,8 +92,41 @@ const fetchUsageBreakdownMock = mock(
 const fetchUsageSeriesMock = mock(
   async (
     _assistantId: string,
-    params: { scheduleId?: string },
+    params: { groupBy?: string; scheduleId?: string },
   ): Promise<UsageSeriesResponse> => {
+    if (params.groupBy === "task") {
+      return {
+        buckets: [
+          {
+            bucketId: "2026-06-01",
+            date: "2026-06-01",
+            displayLabel: "Jun 1",
+            totalInputTokens: 160,
+            totalOutputTokens: 100,
+            totalEstimatedCostUsd: 0.04,
+            eventCount: 3,
+            groups: {
+              [usageSeriesKeyForGroupValue("heartbeatAgent", "task")]: {
+                group: "heartbeatAgent",
+                groupKey: "heartbeatAgent",
+                totalInputTokens: 120,
+                totalOutputTokens: 80,
+                totalEstimatedCostUsd: 0.03,
+                eventCount: 2,
+              },
+              [usageSeriesKeyForGroupValue("mainAgent", "task")]: {
+                group: "mainAgent",
+                groupKey: "mainAgent",
+                totalInputTokens: 40,
+                totalOutputTokens: 20,
+                totalEstimatedCostUsd: 0.01,
+                eventCount: 1,
+              },
+            },
+          },
+        ],
+      };
+    }
     const selectedScheduleId = params.scheduleId ?? "schedule-123";
     const selectedSeriesKey = usageSeriesKeyForGroupValue(
       selectedScheduleId,
@@ -100,6 +161,23 @@ const fetchUsageSeriesMock = mock(
   },
 );
 const fetchUsageDailyMock = mock(async () => ({ buckets: [] }));
+const fetchUsageCallSiteCatalogMock = mock(async () => ({
+  domains: [{ id: "agentLoop", displayName: "Agent Loop" }],
+  callSites: [
+    {
+      id: "heartbeatAgent",
+      displayName: "Heartbeat Agent",
+      description: "Runs background tasks and proactive checks.",
+      domain: "agentLoop",
+    },
+    {
+      id: "mainAgent",
+      displayName: "Main Agent",
+      description: "Handles user messages.",
+      domain: "agentLoop",
+    },
+  ],
+}));
 class UsageRequestError extends Error {
   status: number;
 
@@ -123,6 +201,25 @@ mock.module("@/domains/logs/usage-api", () => ({
   fetchUsageSeries: fetchUsageSeriesMock,
   fetchUsageTotals: fetchUsageTotalsMock,
 }));
+mock.module("@/domains/logs/call-site-metadata", () => ({
+  buildCallSiteMetadataMap: (
+    catalog: {
+      callSites: Array<{
+        id: string;
+        displayName: string;
+        description: string;
+        domain: string;
+      }>;
+    } | null | undefined,
+  ) =>
+    Object.fromEntries(
+      (catalog?.callSites ?? []).map((callSite) => [
+        callSite.id,
+        callSite,
+      ]),
+    ),
+  fetchUsageCallSiteCatalog: fetchUsageCallSiteCatalogMock,
+}));
 
 const { UsageTab } = await import("./usage-tab");
 
@@ -134,6 +231,7 @@ afterEach(() => {
   fetchUsageBreakdownMock.mockClear();
   fetchUsageSeriesMock.mockClear();
   fetchUsageDailyMock.mockClear();
+  fetchUsageCallSiteCatalogMock.mockClear();
 });
 
 function renderUsageTab(initialEntry: string) {
@@ -226,6 +324,31 @@ describe("UsageTab", () => {
     expect(legendItems.map((item) => item.label.textContent)).toEqual([
       "Unknown schedule (schedule-deleted)",
       "Evening digest",
+    ]);
+    expect(legendItems.map((item) => item.state)).toEqual([
+      "active",
+      "inactive",
+    ]);
+  });
+
+  test("renders URL-selected task usage as an active legend item", async () => {
+    const { container } = renderUsageTab(
+      "/assistant/logs/usage?range=7d&groupBy=task&selectedGroup=heartbeatAgent",
+    );
+
+    await waitFor(() =>
+      expect(fetchUsageSeriesMock.mock.calls).toHaveLength(1),
+    );
+
+    expect(screen.getByText("Daily Trend by Action")).toBeTruthy();
+    expect(fetchUsageTotalsMock.mock.calls[0]?.[1]?.scheduleId).toBeUndefined();
+    expect(fetchUsageBreakdownMock.mock.calls[0]?.[1]?.scheduleId).toBeUndefined();
+    expect(fetchUsageSeriesMock.mock.calls[0]?.[1]?.scheduleId).toBeUndefined();
+
+    const legendItems = readLegendItems(container);
+    expect(legendItems.map((item) => item.label.textContent)).toEqual([
+      "Heartbeat Agent",
+      "Main Agent",
     ]);
     expect(legendItems.map((item) => item.state)).toEqual([
       "active",

--- a/apps/web/src/domains/logs/components/usage-tab.test.tsx
+++ b/apps/web/src/domains/logs/components/usage-tab.test.tsx
@@ -35,12 +35,17 @@ const fetchUsageTotalsMock = mock(
     unpricedEventCount: 0,
   }),
 );
+let taskGroupingUnsupported = false;
 const fetchUsageBreakdownMock = mock(
   async (
     _assistantId: string,
     params: { groupBy?: string; scheduleId?: string },
   ): Promise<UsageBreakdownResponse> => {
     if (params.groupBy === "task") {
+      if (taskGroupingUnsupported) {
+        throw new UsageRequestError(400, "Unsupported groupBy");
+      }
+
       return {
         breakdown: [
           {
@@ -58,6 +63,34 @@ const fetchUsageBreakdownMock = mock(
             group: "mainAgent",
             groupId: "mainAgent",
             groupKey: "mainAgent",
+            totalInputTokens: 40,
+            totalOutputTokens: 20,
+            totalCacheCreationTokens: 0,
+            totalCacheReadTokens: 0,
+            totalEstimatedCostUsd: 0.01,
+            eventCount: 1,
+          },
+        ],
+      };
+    }
+    if (params.groupBy === "model") {
+      return {
+        breakdown: [
+          {
+            group: "gpt-5.4-mini",
+            groupId: "gpt-5.4-mini",
+            groupKey: "gpt-5.4-mini",
+            totalInputTokens: 120,
+            totalOutputTokens: 80,
+            totalCacheCreationTokens: 0,
+            totalCacheReadTokens: 0,
+            totalEstimatedCostUsd: 0.03,
+            eventCount: 2,
+          },
+          {
+            group: "gpt-5.4",
+            groupId: "gpt-5.4",
+            groupKey: "gpt-5.4",
             totalInputTokens: 40,
             totalOutputTokens: 20,
             totalCacheCreationTokens: 0,
@@ -117,6 +150,39 @@ const fetchUsageSeriesMock = mock(
               [usageSeriesKeyForGroupValue("mainAgent", "task")]: {
                 group: "mainAgent",
                 groupKey: "mainAgent",
+                totalInputTokens: 40,
+                totalOutputTokens: 20,
+                totalEstimatedCostUsd: 0.01,
+                eventCount: 1,
+              },
+            },
+          },
+        ],
+      };
+    }
+    if (params.groupBy === "model") {
+      return {
+        buckets: [
+          {
+            bucketId: "2026-06-01",
+            date: "2026-06-01",
+            displayLabel: "Jun 1",
+            totalInputTokens: 160,
+            totalOutputTokens: 100,
+            totalEstimatedCostUsd: 0.04,
+            eventCount: 3,
+            groups: {
+              [usageSeriesKeyForGroupValue("gpt-5.4-mini", "model")]: {
+                group: "gpt-5.4-mini",
+                groupKey: "gpt-5.4-mini",
+                totalInputTokens: 120,
+                totalOutputTokens: 80,
+                totalEstimatedCostUsd: 0.03,
+                eventCount: 2,
+              },
+              [usageSeriesKeyForGroupValue("gpt-5.4", "model")]: {
+                group: "gpt-5.4",
+                groupKey: "gpt-5.4",
                 totalInputTokens: 40,
                 totalOutputTokens: 20,
                 totalEstimatedCostUsd: 0.01,
@@ -226,6 +292,7 @@ const { UsageTab } = await import("./usage-tab");
 afterEach(() => {
   cleanup();
   schedulesResponse = [...defaultSchedules];
+  taskGroupingUnsupported = false;
   fetchSchedulesMock.mockClear();
   fetchUsageTotalsMock.mockClear();
   fetchUsageBreakdownMock.mockClear();
@@ -354,5 +421,42 @@ describe("UsageTab", () => {
       "active",
       "inactive",
     ]);
+  });
+
+  test("ignores a selected task when task usage falls back to model grouping", async () => {
+    taskGroupingUnsupported = true;
+    const { container } = renderUsageTab(
+      "/assistant/logs/usage?range=7d&groupBy=task&selectedGroup=heartbeatAgent",
+    );
+
+    await waitFor(() =>
+      expect(
+        fetchUsageSeriesMock.mock.calls.some(
+          (call) => call[1]?.groupBy === "model",
+        ),
+      ).toBe(true),
+    );
+
+    expect(screen.getByText("Daily Trend by Model")).toBeTruthy();
+    expect(fetchUsageBreakdownMock.mock.calls[0]?.[1]?.groupBy).toBe("task");
+    expect(fetchUsageBreakdownMock.mock.calls[1]?.[1]?.groupBy).toBe("model");
+
+    const legendItems = readLegendItems(container);
+    expect(legendItems.map((item) => item.label.textContent)).toEqual([
+      "gpt-5.4-mini",
+      "gpt-5.4",
+    ]);
+    expect(legendItems.map((item) => item.state)).toEqual([
+      "active",
+      "active",
+    ]);
+    expect(
+      container.querySelector(
+        `[data-usage-series-segment="${usageSeriesKeyForGroupValue(
+          "heartbeatAgent",
+          "model",
+        )}"]`,
+      ),
+    ).toBeNull();
   });
 });

--- a/apps/web/src/domains/logs/components/usage-tab.test.tsx
+++ b/apps/web/src/domains/logs/components/usage-tab.test.tsx
@@ -23,7 +23,7 @@ const fetchSchedulesMock = mock(
 const fetchUsageTotalsMock = mock(
   async (
     _assistantId: string,
-    _params: { scheduleId?: string },
+    _params: { scheduleId?: string; callSite?: string },
   ): Promise<UsageTotals> => ({
     totalInputTokens: 120,
     totalOutputTokens: 80,
@@ -39,38 +39,41 @@ let taskGroupingUnsupported = false;
 const fetchUsageBreakdownMock = mock(
   async (
     _assistantId: string,
-    params: { groupBy?: string; scheduleId?: string },
+    params: { groupBy?: string; scheduleId?: string; callSite?: string },
   ): Promise<UsageBreakdownResponse> => {
     if (params.groupBy === "task") {
       if (taskGroupingUnsupported) {
         throw new UsageRequestError(400, "Unsupported groupBy");
       }
 
+      const breakdown = [
+        {
+          group: "heartbeatAgent",
+          groupId: "heartbeatAgent",
+          groupKey: "heartbeatAgent",
+          totalInputTokens: 120,
+          totalOutputTokens: 80,
+          totalCacheCreationTokens: 0,
+          totalCacheReadTokens: 0,
+          totalEstimatedCostUsd: 0.03,
+          eventCount: 2,
+        },
+        {
+          group: "mainAgent",
+          groupId: "mainAgent",
+          groupKey: "mainAgent",
+          totalInputTokens: 40,
+          totalOutputTokens: 20,
+          totalCacheCreationTokens: 0,
+          totalCacheReadTokens: 0,
+          totalEstimatedCostUsd: 0.01,
+          eventCount: 1,
+        },
+      ];
       return {
-        breakdown: [
-          {
-            group: "heartbeatAgent",
-            groupId: "heartbeatAgent",
-            groupKey: "heartbeatAgent",
-            totalInputTokens: 120,
-            totalOutputTokens: 80,
-            totalCacheCreationTokens: 0,
-            totalCacheReadTokens: 0,
-            totalEstimatedCostUsd: 0.03,
-            eventCount: 2,
-          },
-          {
-            group: "mainAgent",
-            groupId: "mainAgent",
-            groupKey: "mainAgent",
-            totalInputTokens: 40,
-            totalOutputTokens: 20,
-            totalCacheCreationTokens: 0,
-            totalCacheReadTokens: 0,
-            totalEstimatedCostUsd: 0.01,
-            eventCount: 1,
-          },
-        ],
+        breakdown: params.callSite
+          ? breakdown.filter((row) => row.groupKey === params.callSite)
+          : breakdown,
       };
     }
     if (params.groupBy === "model") {
@@ -125,9 +128,35 @@ const fetchUsageBreakdownMock = mock(
 const fetchUsageSeriesMock = mock(
   async (
     _assistantId: string,
-    params: { groupBy?: string; scheduleId?: string },
+    params: { groupBy?: string; scheduleId?: string; callSite?: string },
   ): Promise<UsageSeriesResponse> => {
     if (params.groupBy === "task") {
+      if (params.callSite === "heartbeatAgent") {
+        return {
+          buckets: [
+            {
+              bucketId: "2026-06-01",
+              date: "2026-06-01",
+              displayLabel: "Jun 1",
+              totalInputTokens: 120,
+              totalOutputTokens: 80,
+              totalEstimatedCostUsd: 0.03,
+              eventCount: 2,
+              groups: {
+                [usageSeriesKeyForGroupValue("heartbeatAgent", "task")]: {
+                  group: "heartbeatAgent",
+                  groupKey: "heartbeatAgent",
+                  totalInputTokens: 120,
+                  totalOutputTokens: 80,
+                  totalEstimatedCostUsd: 0.03,
+                  eventCount: 2,
+                },
+              },
+            },
+          ],
+        };
+      }
+
       return {
         buckets: [
           {
@@ -409,18 +438,23 @@ describe("UsageTab", () => {
 
     expect(screen.getByText("Daily Trend by Action")).toBeTruthy();
     expect(fetchUsageTotalsMock.mock.calls[0]?.[1]?.scheduleId).toBeUndefined();
+    expect(fetchUsageTotalsMock.mock.calls[0]?.[1]?.callSite).toBe(
+      "heartbeatAgent",
+    );
     expect(fetchUsageBreakdownMock.mock.calls[0]?.[1]?.scheduleId).toBeUndefined();
+    expect(fetchUsageBreakdownMock.mock.calls[0]?.[1]?.callSite).toBe(
+      "heartbeatAgent",
+    );
     expect(fetchUsageSeriesMock.mock.calls[0]?.[1]?.scheduleId).toBeUndefined();
+    expect(fetchUsageSeriesMock.mock.calls[0]?.[1]?.callSite).toBe(
+      "heartbeatAgent",
+    );
 
     const legendItems = readLegendItems(container);
     expect(legendItems.map((item) => item.label.textContent)).toEqual([
       "Heartbeat Agent",
-      "Main Agent",
     ]);
-    expect(legendItems.map((item) => item.state)).toEqual([
-      "active",
-      "inactive",
-    ]);
+    expect(legendItems.map((item) => item.state)).toEqual(["active"]);
   });
 
   test("ignores a selected task when task usage falls back to model grouping", async () => {
@@ -439,7 +473,13 @@ describe("UsageTab", () => {
 
     expect(screen.getByText("Daily Trend by Model")).toBeTruthy();
     expect(fetchUsageBreakdownMock.mock.calls[0]?.[1]?.groupBy).toBe("task");
+    expect(fetchUsageBreakdownMock.mock.calls[0]?.[1]?.callSite).toBe(
+      "heartbeatAgent",
+    );
     expect(fetchUsageBreakdownMock.mock.calls[1]?.[1]?.groupBy).toBe("model");
+    expect(fetchUsageBreakdownMock.mock.calls[1]?.[1]?.callSite).toBe(
+      "heartbeatAgent",
+    );
 
     const legendItems = readLegendItems(container);
     expect(legendItems.map((item) => item.label.textContent)).toEqual([

--- a/apps/web/src/domains/logs/components/usage-tab.tsx
+++ b/apps/web/src/domains/logs/components/usage-tab.tsx
@@ -15,7 +15,11 @@ import {
     type UsageTrendChartLegendItem,
 } from "@/domains/logs/components/usage-trend-chart";
 import { formatCost, formatTokens } from "@/domains/logs/format";
-import { decorateUsageBreakdownGroups } from "@/domains/logs/group-labels";
+import {
+    decorateUsageBreakdownGroups,
+    resolveUsageGroupLabel,
+    type UsageGroupLabelMetadata,
+} from "@/domains/logs/group-labels";
 import { fetchUsageProfileMetadata } from "@/domains/logs/profile-metadata";
 import {
     fetchUsageBreakdown,
@@ -28,6 +32,7 @@ import {
     formatBreakdownTokensShort,
 } from "@/domains/logs/usage-breakdown-format";
 import {
+    buildUsageSeriesLegend,
     decorateUsageSeriesGroups,
     seriesFromDailyBuckets,
     usageSeriesKeyForGroupValue,
@@ -50,6 +55,8 @@ import type {
     UsageBreakdownResponse,
     UsageGroupBreakdown,
     UsageGroupBy,
+    UsageSeriesBucket,
+    UsageSeriesGroupBy,
     UsageTimeRange,
     UsageTotals,
 } from "@/domains/logs/usage-types";
@@ -93,7 +100,7 @@ const COST_OPTIMIZATION_PROMPT = [
 export function UsageTab({ assistantId }: UsageTabProps) {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
-  const { range, groupBy, scheduleId } = useMemo(
+  const { range, groupBy, scheduleId, selectedGroupKey } = useMemo(
     () => readUsageUrlState(searchParams),
     [searchParams],
   );
@@ -364,6 +371,24 @@ export function UsageTab({ assistantId }: UsageTabProps) {
 
     return buildSelectedScheduleLegendItems(schedulesQuery.data, scheduleId);
   }, [effectiveGroupBy, scheduleId, schedulesQuery.data]);
+  const selectedGroupLegendItems = useMemo(() => {
+    if (!selectedGroupKey || !seriesGroupBy || effectiveGroupBy === "schedule") {
+      return undefined;
+    }
+
+    return buildSelectedGroupLegendItems(
+      decoratedSeriesBuckets,
+      seriesGroupBy,
+      selectedGroupKey,
+      usageGroupMetadata,
+    );
+  }, [
+    decoratedSeriesBuckets,
+    effectiveGroupBy,
+    selectedGroupKey,
+    seriesGroupBy,
+    usageGroupMetadata,
+  ]);
 
   const handleGroupByChange = (nextGroupBy: UsageGroupBy) => {
     if (nextGroupBy === groupBy && effectiveGroupBy !== groupBy) {
@@ -373,6 +398,7 @@ export function UsageTab({ assistantId }: UsageTabProps) {
     updateUsageSearchParams({
       groupBy: nextGroupBy,
       scheduleId: nextGroupBy === "schedule" ? undefined : null,
+      selectedGroupKey: null,
     });
   };
 
@@ -421,7 +447,9 @@ export function UsageTab({ assistantId }: UsageTabProps) {
               <UsageTrendChart
                 buckets={buckets}
                 isHourly={isHourly}
-                legendItems={selectedScheduleLegendItems}
+                legendItems={
+                  selectedScheduleLegendItems ?? selectedGroupLegendItems
+                }
               />
             )}
           />
@@ -474,6 +502,60 @@ function buildSelectedScheduleLegendItems(
 
 function unknownScheduleLabel(scheduleId: string) {
   return `Unknown schedule (${scheduleId})`;
+}
+
+function buildSelectedGroupLegendItems(
+  buckets: readonly UsageSeriesBucket[] | undefined,
+  groupBy: UsageSeriesGroupBy,
+  selectedGroupKey: string,
+  metadata: UsageGroupLabelMetadata,
+): UsageTrendChartLegendItem[] {
+  const selectedSeriesKey = usageSeriesKeyForGroupValue(
+    selectedGroupKey,
+    groupBy,
+  );
+  const bucketLegend = buildUsageSeriesLegend(buckets ?? []);
+  const hasSelectedGroup = bucketLegend.items.some(
+    (item) => item.seriesKey === selectedSeriesKey,
+  );
+  const items = hasSelectedGroup
+    ? bucketLegend.items
+    : [
+        {
+          seriesKey: selectedSeriesKey,
+          label: selectedGroupLabel(groupBy, selectedGroupKey, metadata),
+        },
+        ...bucketLegend.items,
+      ];
+
+  return items.map((item, colorIndex) => ({
+    seriesKey: item.seriesKey,
+    label: item.label,
+    colorIndex,
+    state: item.seriesKey === selectedSeriesKey ? "active" : "inactive",
+  }));
+}
+
+function selectedGroupLabel(
+  groupBy: UsageGroupBy,
+  selectedGroupKey: string,
+  metadata: UsageGroupLabelMetadata,
+) {
+  return resolveUsageGroupLabel(
+    groupBy,
+    {
+      group: selectedGroupKey,
+      groupId: selectedGroupKey,
+      groupKey: selectedGroupKey,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalCacheCreationTokens: 0,
+      totalCacheReadTokens: 0,
+      totalEstimatedCostUsd: 0,
+      eventCount: 0,
+    },
+    metadata,
+  );
 }
 
 function CostAssistantSection({

--- a/apps/web/src/domains/logs/components/usage-tab.tsx
+++ b/apps/web/src/domains/logs/components/usage-tab.tsx
@@ -372,7 +372,12 @@ export function UsageTab({ assistantId }: UsageTabProps) {
     return buildSelectedScheduleLegendItems(schedulesQuery.data, scheduleId);
   }, [effectiveGroupBy, scheduleId, schedulesQuery.data]);
   const selectedGroupLegendItems = useMemo(() => {
-    if (!selectedGroupKey || !seriesGroupBy || effectiveGroupBy === "schedule") {
+    if (
+      !selectedGroupKey ||
+      !seriesGroupBy ||
+      effectiveGroupBy === "schedule" ||
+      effectiveGroupBy !== groupBy
+    ) {
       return undefined;
     }
 
@@ -385,6 +390,7 @@ export function UsageTab({ assistantId }: UsageTabProps) {
   }, [
     decoratedSeriesBuckets,
     effectiveGroupBy,
+    groupBy,
     selectedGroupKey,
     seriesGroupBy,
     usageGroupMetadata,

--- a/apps/web/src/domains/logs/components/usage-tab.tsx
+++ b/apps/web/src/domains/logs/components/usage-tab.tsx
@@ -100,10 +100,10 @@ const COST_OPTIMIZATION_PROMPT = [
 export function UsageTab({ assistantId }: UsageTabProps) {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
-  const { range, groupBy, scheduleId, selectedGroupKey } = useMemo(
-    () => readUsageUrlState(searchParams),
-    [searchParams],
-  );
+  const { range, groupBy, scheduleId, callSiteFilter, selectedGroupKey } =
+    useMemo(() => readUsageUrlState(searchParams), [searchParams]);
+  const taskCallSiteFilter =
+    groupBy === "task" ? (callSiteFilter ?? selectedGroupKey) : undefined;
   const timezone = useEffectiveTimezone();
   const updateUsageSearchParams = useCallback(
     (update: UsageSearchParamsUpdate) => {
@@ -150,12 +150,14 @@ export function UsageTab({ assistantId }: UsageTabProps) {
       rangeWindow.from,
       rangeWindow.to,
       scheduleId ?? null,
+      taskCallSiteFilter ?? null,
     ],
     queryFn: () =>
       fetchUsageTotals(assistantId, {
         from: rangeWindow.from,
         to: rangeWindow.to,
         scheduleId,
+        callSite: taskCallSiteFilter,
       }),
   });
 
@@ -167,6 +169,7 @@ export function UsageTab({ assistantId }: UsageTabProps) {
       rangeWindow.to,
       groupBy,
       scheduleId ?? null,
+      taskCallSiteFilter ?? null,
     ],
     queryFn: async () => {
       try {
@@ -177,6 +180,7 @@ export function UsageTab({ assistantId }: UsageTabProps) {
             to: rangeWindow.to,
             groupBy,
             scheduleId,
+            callSite: taskCallSiteFilter,
           }),
         };
       } catch (error) {
@@ -191,6 +195,7 @@ export function UsageTab({ assistantId }: UsageTabProps) {
             to: rangeWindow.to,
             groupBy: FALLBACK_USAGE_GROUP_BY,
             scheduleId,
+            callSite: taskCallSiteFilter,
           }),
         };
       }
@@ -213,6 +218,7 @@ export function UsageTab({ assistantId }: UsageTabProps) {
       timezone,
       effectiveGroupBy,
       scheduleId ?? null,
+      taskCallSiteFilter ?? null,
     ],
     queryFn: () => {
       if (!seriesGroupBy) {
@@ -226,6 +232,7 @@ export function UsageTab({ assistantId }: UsageTabProps) {
         groupBy: seriesGroupBy,
         tz: timezone,
         scheduleId,
+        callSite: taskCallSiteFilter,
       });
     },
     enabled: Boolean(seriesGroupBy),
@@ -241,6 +248,7 @@ export function UsageTab({ assistantId }: UsageTabProps) {
       granularity,
       timezone,
       scheduleId ?? null,
+      taskCallSiteFilter ?? null,
     ],
     queryFn: () =>
       fetchUsageDaily(assistantId, {
@@ -249,6 +257,7 @@ export function UsageTab({ assistantId }: UsageTabProps) {
         granularity,
         tz: timezone,
         scheduleId,
+        callSite: taskCallSiteFilter,
       }),
     enabled: !seriesGroupBy || seriesQuery.isError,
   });
@@ -404,6 +413,7 @@ export function UsageTab({ assistantId }: UsageTabProps) {
     updateUsageSearchParams({
       groupBy: nextGroupBy,
       scheduleId: nextGroupBy === "schedule" ? undefined : null,
+      callSiteFilter: null,
       selectedGroupKey: null,
     });
   };

--- a/apps/web/src/domains/logs/usage-api.test.ts
+++ b/apps/web/src/domains/logs/usage-api.test.ts
@@ -14,11 +14,13 @@ describe("usage API query builders", () => {
         from: 100,
         to: 200,
         scheduleId: "schedule-123",
+        callSite: "heartbeatAgent",
       }),
     ).toEqual({
       from: 100,
       to: 200,
       scheduleId: "schedule-123",
+      callSite: "heartbeatAgent",
     });
   });
 
@@ -30,6 +32,7 @@ describe("usage API query builders", () => {
         granularity: "hourly",
         tz: "America/New_York",
         scheduleId: "schedule-123",
+        callSite: "heartbeatAgent",
       }),
     ).toEqual({
       from: 100,
@@ -37,6 +40,7 @@ describe("usage API query builders", () => {
       granularity: "hourly",
       tz: "America/New_York",
       scheduleId: "schedule-123",
+      callSite: "heartbeatAgent",
     });
   });
 
@@ -46,11 +50,13 @@ describe("usage API query builders", () => {
         from: 100,
         to: 200,
         groupBy: "task",
+        callSite: "heartbeatAgent",
       }),
     ).toEqual({
       from: 100,
       to: 200,
       groupBy: "call_site",
+      callSite: "heartbeatAgent",
     });
 
     expect(

--- a/apps/web/src/domains/logs/usage-api.ts
+++ b/apps/web/src/domains/logs/usage-api.ts
@@ -52,6 +52,7 @@ export interface FetchUsageTotalsParams {
   from: number;
   to: number;
   scheduleId?: string;
+  callSite?: string;
 }
 
 export interface FetchUsageDailyParams {
@@ -60,6 +61,7 @@ export interface FetchUsageDailyParams {
   granularity?: UsageGranularity;
   tz?: string;
   scheduleId?: string;
+  callSite?: string;
 }
 
 export interface FetchUsageBreakdownParams {
@@ -67,6 +69,7 @@ export interface FetchUsageBreakdownParams {
   to: number;
   groupBy: UsageGroupBy;
   scheduleId?: string;
+  callSite?: string;
 }
 
 export interface FetchUsageSeriesParams {
@@ -76,6 +79,7 @@ export interface FetchUsageSeriesParams {
   groupBy: UsageSeriesGroupBy;
   tz?: string;
   scheduleId?: string;
+  callSite?: string;
 }
 
 export type UsageTotalsQuery = NonNullable<UsageTotalsGetData["query"]>;
@@ -94,7 +98,7 @@ export function buildUsageTotalsQuery(
     from: params.from,
     to: params.to,
   };
-  return withScheduleId(query, params.scheduleId);
+  return withUsageFilters(query, params);
 }
 
 export function buildUsageDailyQuery(
@@ -106,7 +110,7 @@ export function buildUsageDailyQuery(
     ...(params.granularity ? { granularity: params.granularity } : {}),
     ...(params.tz ? { tz: params.tz } : {}),
   };
-  return withScheduleId(query, params.scheduleId);
+  return withUsageFilters(query, params);
 }
 
 export function buildUsageBreakdownQuery(
@@ -117,7 +121,7 @@ export function buildUsageBreakdownQuery(
     to: params.to,
     groupBy: toUsageGroupByQueryValue(params.groupBy),
   };
-  return withScheduleId(query, params.scheduleId);
+  return withUsageFilters(query, params);
 }
 
 export function buildUsageSeriesQuery(
@@ -130,14 +134,18 @@ export function buildUsageSeriesQuery(
     groupBy: toUsageGroupByQueryValue(params.groupBy),
     ...(params.tz ? { tz: params.tz } : {}),
   };
-  return withScheduleId(query, params.scheduleId);
+  return withUsageFilters(query, params);
 }
 
-function withScheduleId<T extends { scheduleId?: string }>(
+function withUsageFilters<T extends { scheduleId?: string; callSite?: string }>(
   query: T,
-  scheduleId: string | undefined,
+  params: { scheduleId?: string; callSite?: string },
 ): T {
-  return scheduleId ? { ...query, scheduleId } : query;
+  return {
+    ...query,
+    ...(params.scheduleId ? { scheduleId: params.scheduleId } : {}),
+    ...(params.callSite ? { callSite: params.callSite } : {}),
+  };
 }
 
 async function throwOnBadResponse(

--- a/apps/web/src/domains/logs/usage-tab-state.test.ts
+++ b/apps/web/src/domains/logs/usage-tab-state.test.ts
@@ -146,11 +146,26 @@ describe("usage URL state", () => {
       range: "today",
       groupBy: "schedule",
       scheduleId: "schedule-123",
+      callSiteFilter: undefined,
       selectedGroupKey: undefined,
     });
   });
 
-  test("reads a selected grouped usage value outside schedule filtering", () => {
+  test("reads a selected task value and task call-site filter", () => {
+    const params = new URLSearchParams(
+      "range=7d&groupBy=task&selectedGroup=heartbeatAgent&callSite=heartbeatAgent",
+    );
+
+    expect(readUsageUrlState(params)).toEqual({
+      range: "7d",
+      groupBy: "task",
+      scheduleId: undefined,
+      callSiteFilter: "heartbeatAgent",
+      selectedGroupKey: "heartbeatAgent",
+    });
+  });
+
+  test("keeps legacy selected task URLs selected without explicit call-site filters", () => {
     const params = new URLSearchParams(
       "range=7d&groupBy=task&selectedGroup=heartbeatAgent",
     );
@@ -159,6 +174,7 @@ describe("usage URL state", () => {
       range: "7d",
       groupBy: "task",
       scheduleId: undefined,
+      callSiteFilter: undefined,
       selectedGroupKey: "heartbeatAgent",
     });
   });
@@ -172,6 +188,7 @@ describe("usage URL state", () => {
       range: "7d",
       groupBy: "task",
       scheduleId: undefined,
+      callSiteFilter: undefined,
       selectedGroupKey: undefined,
     });
   });
@@ -185,6 +202,7 @@ describe("usage URL state", () => {
       range: "7d",
       groupBy: "task",
       scheduleId: undefined,
+      callSiteFilter: undefined,
       selectedGroupKey: undefined,
     });
   });
@@ -196,6 +214,7 @@ describe("usage URL state", () => {
       range: "7d",
       groupBy: "task",
       scheduleId: undefined,
+      callSiteFilter: undefined,
       selectedGroupKey: undefined,
     });
   });
@@ -225,7 +244,7 @@ describe("usage URL state", () => {
   test("updates group-by to schedule without dropping a schedule filter", () => {
     const params = buildUsageSearchParams(
       new URLSearchParams(
-        "range=90d&groupBy=task&scheduleId=schedule-123&selectedGroup=heartbeatAgent",
+        "range=90d&groupBy=task&scheduleId=schedule-123&selectedGroup=heartbeatAgent&callSite=heartbeatAgent",
       ),
       { groupBy: "schedule" },
     );
@@ -247,14 +266,18 @@ describe("usage URL state", () => {
   test("sets and clears a selected grouped usage value", () => {
     const withSelection = buildUsageSearchParams(
       new URLSearchParams("range=7d&groupBy=task"),
-      { selectedGroupKey: "memoryV2Consolidation" },
+      {
+        selectedGroupKey: "memoryV2Consolidation",
+        callSiteFilter: "memoryV2Consolidation",
+      },
     );
     expect(withSelection.toString()).toBe(
-      "range=7d&groupBy=task&selectedGroup=memoryV2Consolidation",
+      "range=7d&groupBy=task&callSite=memoryV2Consolidation&selectedGroup=memoryV2Consolidation",
     );
 
     const cleared = buildUsageSearchParams(withSelection, {
       selectedGroupKey: null,
+      callSiteFilter: null,
     });
     expect(cleared.toString()).toBe("range=7d&groupBy=task");
   });

--- a/apps/web/src/domains/logs/usage-tab-state.test.ts
+++ b/apps/web/src/domains/logs/usage-tab-state.test.ts
@@ -146,6 +146,20 @@ describe("usage URL state", () => {
       range: "today",
       groupBy: "schedule",
       scheduleId: "schedule-123",
+      selectedGroupKey: undefined,
+    });
+  });
+
+  test("reads a selected grouped usage value outside schedule filtering", () => {
+    const params = new URLSearchParams(
+      "range=7d&groupBy=task&selectedGroup=heartbeatAgent",
+    );
+
+    expect(readUsageUrlState(params)).toEqual({
+      range: "7d",
+      groupBy: "task",
+      scheduleId: undefined,
+      selectedGroupKey: "heartbeatAgent",
     });
   });
 
@@ -158,6 +172,7 @@ describe("usage URL state", () => {
       range: "7d",
       groupBy: "task",
       scheduleId: undefined,
+      selectedGroupKey: undefined,
     });
   });
 
@@ -170,6 +185,18 @@ describe("usage URL state", () => {
       range: "7d",
       groupBy: "task",
       scheduleId: undefined,
+      selectedGroupKey: undefined,
+    });
+  });
+
+  test("ignores blank selected group params", () => {
+    const params = new URLSearchParams("range=7d&groupBy=task&selectedGroup=");
+
+    expect(readUsageUrlState(params)).toEqual({
+      range: "7d",
+      groupBy: "task",
+      scheduleId: undefined,
+      selectedGroupKey: undefined,
     });
   });
 
@@ -197,7 +224,9 @@ describe("usage URL state", () => {
 
   test("updates group-by to schedule without dropping a schedule filter", () => {
     const params = buildUsageSearchParams(
-      new URLSearchParams("range=90d&groupBy=task&scheduleId=schedule-123"),
+      new URLSearchParams(
+        "range=90d&groupBy=task&scheduleId=schedule-123&selectedGroup=heartbeatAgent",
+      ),
       { groupBy: "schedule" },
     );
 
@@ -213,5 +242,20 @@ describe("usage URL state", () => {
     );
 
     expect(params.toString()).toBe("range=90d&groupBy=schedule");
+  });
+
+  test("sets and clears a selected grouped usage value", () => {
+    const withSelection = buildUsageSearchParams(
+      new URLSearchParams("range=7d&groupBy=task"),
+      { selectedGroupKey: "memoryV2Consolidation" },
+    );
+    expect(withSelection.toString()).toBe(
+      "range=7d&groupBy=task&selectedGroup=memoryV2Consolidation",
+    );
+
+    const cleared = buildUsageSearchParams(withSelection, {
+      selectedGroupKey: null,
+    });
+    expect(cleared.toString()).toBe("range=7d&groupBy=task");
   });
 });

--- a/apps/web/src/domains/logs/usage-tab-state.ts
+++ b/apps/web/src/domains/logs/usage-tab-state.ts
@@ -57,6 +57,7 @@ export interface UsageUrlState {
   range: UsageTimeRange;
   groupBy: UsageGroupBy;
   scheduleId: string | undefined;
+  callSiteFilter: string | undefined;
   selectedGroupKey: string | undefined;
 }
 
@@ -64,6 +65,7 @@ export interface UsageSearchParamsUpdate {
   range?: UsageTimeRange;
   groupBy?: UsageGroupBy;
   scheduleId?: string | null;
+  callSiteFilter?: string | null;
   selectedGroupKey?: string | null;
 }
 
@@ -75,13 +77,19 @@ export function readUsageUrlState(
   const groupBy = isUsageGroupBy(rawGroupBy)
     ? rawGroupBy
     : DEFAULT_USAGE_GROUP_BY;
+  const callSiteFilter =
+    groupBy === "task" ? readCallSiteFilter(searchParams) : undefined;
+  const selectedGroupKey =
+    groupBy === "schedule"
+      ? undefined
+      : (readSelectedGroupKey(searchParams) ?? callSiteFilter);
   return {
     range: isUsageTimeRange(range) ? range : DEFAULT_USAGE_RANGE,
     groupBy,
     scheduleId:
       groupBy === "schedule" ? readUsageScheduleId(searchParams) : undefined,
-    selectedGroupKey:
-      groupBy === "schedule" ? undefined : readSelectedGroupKey(searchParams),
+    callSiteFilter,
+    selectedGroupKey,
   };
 }
 
@@ -105,6 +113,14 @@ function readSelectedGroupKey(
   return selectedGroup;
 }
 
+function readCallSiteFilter(searchParams: URLSearchParams): string | undefined {
+  const callSite = searchParams.get("callSite");
+  if (!callSite || callSite.trim().length === 0) {
+    return undefined;
+  }
+  return callSite;
+}
+
 export function buildUsageSearchParams(
   searchParams: URLSearchParams,
   update: UsageSearchParamsUpdate,
@@ -124,6 +140,16 @@ export function buildUsageSearchParams(
       next.set("scheduleId", update.scheduleId);
     }
   }
+  if (update.callSiteFilter !== undefined) {
+    if (
+      update.callSiteFilter === null ||
+      update.callSiteFilter.trim().length === 0
+    ) {
+      next.delete("callSite");
+    } else {
+      next.set("callSite", update.callSiteFilter);
+    }
+  }
   if (update.selectedGroupKey !== undefined) {
     if (
       update.selectedGroupKey === null ||
@@ -136,6 +162,9 @@ export function buildUsageSearchParams(
   }
   if (next.get("groupBy") !== "schedule") {
     next.delete("scheduleId");
+  }
+  if (next.get("groupBy") !== "task") {
+    next.delete("callSite");
   }
   if (next.get("groupBy") === "schedule") {
     next.delete("selectedGroup");

--- a/apps/web/src/domains/logs/usage-tab-state.ts
+++ b/apps/web/src/domains/logs/usage-tab-state.ts
@@ -57,12 +57,14 @@ export interface UsageUrlState {
   range: UsageTimeRange;
   groupBy: UsageGroupBy;
   scheduleId: string | undefined;
+  selectedGroupKey: string | undefined;
 }
 
 export interface UsageSearchParamsUpdate {
   range?: UsageTimeRange;
   groupBy?: UsageGroupBy;
   scheduleId?: string | null;
+  selectedGroupKey?: string | null;
 }
 
 export function readUsageUrlState(
@@ -78,6 +80,8 @@ export function readUsageUrlState(
     groupBy,
     scheduleId:
       groupBy === "schedule" ? readUsageScheduleId(searchParams) : undefined,
+    selectedGroupKey:
+      groupBy === "schedule" ? undefined : readSelectedGroupKey(searchParams),
   };
 }
 
@@ -89,6 +93,16 @@ export function readUsageScheduleId(
     return undefined;
   }
   return scheduleId;
+}
+
+function readSelectedGroupKey(
+  searchParams: URLSearchParams,
+): string | undefined {
+  const selectedGroup = searchParams.get("selectedGroup");
+  if (!selectedGroup || selectedGroup.trim().length === 0) {
+    return undefined;
+  }
+  return selectedGroup;
 }
 
 export function buildUsageSearchParams(
@@ -110,8 +124,21 @@ export function buildUsageSearchParams(
       next.set("scheduleId", update.scheduleId);
     }
   }
+  if (update.selectedGroupKey !== undefined) {
+    if (
+      update.selectedGroupKey === null ||
+      update.selectedGroupKey.trim().length === 0
+    ) {
+      next.delete("selectedGroup");
+    } else {
+      next.set("selectedGroup", update.selectedGroupKey);
+    }
+  }
   if (next.get("groupBy") !== "schedule") {
     next.delete("scheduleId");
+  }
+  if (next.get("groupBy") === "schedule") {
+    next.delete("selectedGroup");
   }
 
   return next;

--- a/apps/web/src/domains/settings/components/system-tasks-section.tsx
+++ b/apps/web/src/domains/settings/components/system-tasks-section.tsx
@@ -33,6 +33,7 @@ interface SystemTaskRowProps {
   statusLabel?: string;
   statusTone?: TagTone;
   onClick: () => void;
+  onOpenUsage?: () => void;
   onToggle?: (enabled: boolean) => void;
 }
 
@@ -48,6 +49,7 @@ export function SystemTaskRow({
   statusLabel,
   statusTone = "neutral",
   onClick,
+  onOpenUsage,
   onToggle,
 }: SystemTaskRowProps) {
   return (
@@ -56,49 +58,54 @@ export function SystemTaskRow({
         type="button"
         onClick={onClick}
         aria-label={`Open ${name}`}
-        className="flex min-w-0 flex-1 cursor-pointer flex-wrap items-center gap-3 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+        className="min-w-0 flex-1 cursor-pointer text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
       >
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <span className="truncate text-body-medium-default text-[var(--content-default)]">
-              {name}
-            </span>
-          </div>
-          <div className="mt-0.5 text-body-small-default text-[var(--content-tertiary)]">
-            {subtitle}
-          </div>
-          {helperText ? (
-            <div className="mt-0.5 text-body-small-default text-[var(--content-secondary)]">
-              {helperText}
-            </div>
-          ) : null}
-          <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-body-small-default text-[var(--content-tertiary)]">
-            {nextRunAt ? (
-              <span>Next: {formatTimestamp(nextRunAt)}</span>
-            ) : null}
-            {lastRunAt ? (
-              <span>Last: {formatTimestamp(lastRunAt)}</span>
-            ) : null}
-          </div>
+        <div className="flex items-center gap-2">
+          <span className="truncate text-body-medium-default text-[var(--content-default)]">
+            {name}
+          </span>
         </div>
-        <div className="flex shrink-0 flex-wrap items-center justify-end gap-3">
-          <ScheduleUsageStats scheduleName={name} usage={usage} />
-          {showToggle ? null : statusLabel ? (
-            <Tag tone={statusTone}>{statusLabel}</Tag>
-          ) : (
-            <span
-              className="h-2 w-2 rounded-full"
-              style={{
-                backgroundColor: enabled
-                  ? "var(--system-positive-strong)"
-                  : "var(--content-disabled)",
-              }}
-              aria-label={enabled ? "enabled" : "disabled"}
-            />
-          )}
-          <ChevronRight className="h-4 w-4 text-[var(--content-tertiary)]" />
+        <div className="mt-0.5 text-body-small-default text-[var(--content-tertiary)]">
+          {subtitle}
+        </div>
+        {helperText ? (
+          <div className="mt-0.5 text-body-small-default text-[var(--content-secondary)]">
+            {helperText}
+          </div>
+        ) : null}
+        <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-body-small-default text-[var(--content-tertiary)]">
+          {nextRunAt ? <span>Next: {formatTimestamp(nextRunAt)}</span> : null}
+          {lastRunAt ? <span>Last: {formatTimestamp(lastRunAt)}</span> : null}
         </div>
       </button>
+      <div className="flex shrink-0 flex-wrap items-center justify-end gap-3">
+        <ScheduleUsageStats
+          scheduleName={name}
+          usage={usage}
+          onOpenUsage={onOpenUsage}
+        />
+        {showToggle ? null : statusLabel ? (
+          <Tag tone={statusTone}>{statusLabel}</Tag>
+        ) : (
+          <span
+            className="h-2 w-2 rounded-full"
+            style={{
+              backgroundColor: enabled
+                ? "var(--system-positive-strong)"
+                : "var(--content-disabled)",
+            }}
+            aria-label={enabled ? "enabled" : "disabled"}
+          />
+        )}
+        <button
+          type="button"
+          onClick={onClick}
+          aria-label={`Open ${name} details`}
+          className="flex h-7 w-7 cursor-pointer items-center justify-center rounded text-[var(--content-tertiary)] transition-colors hover:bg-[var(--surface-hover)]"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </button>
+      </div>
       {showToggle && onToggle ? (
         <Toggle
           checked={enabled}
@@ -124,6 +131,8 @@ interface SystemTasksSectionProps {
   onRetry: () => void;
   onSelectHeartbeat: () => void;
   onSelectConsolidation: () => void;
+  onOpenHeartbeatUsage: () => void;
+  onOpenConsolidationUsage: () => void;
   showSystemTaskToggles: boolean;
   onToggleHeartbeat: (enabled: boolean) => void;
 }
@@ -138,6 +147,8 @@ export function SystemTasksSection({
   onRetry,
   onSelectHeartbeat,
   onSelectConsolidation,
+  onOpenHeartbeatUsage,
+  onOpenConsolidationUsage,
   showSystemTaskToggles,
   onToggleHeartbeat,
 }: SystemTasksSectionProps) {
@@ -180,6 +191,7 @@ export function SystemTasksSection({
               usage={heartbeatUsage}
               showToggle={showSystemTaskToggles}
               onClick={onSelectHeartbeat}
+              onOpenUsage={onOpenHeartbeatUsage}
               onToggle={onToggleHeartbeat}
             />
           ) : null}
@@ -202,6 +214,7 @@ export function SystemTasksSection({
               }
               statusTone={consolidationConfig.enabled ? "neutral" : "warning"}
               onClick={onSelectConsolidation}
+              onOpenUsage={onOpenConsolidationUsage}
             />
           ) : null}
           {hasError ? (

--- a/apps/web/src/domains/settings/pages/schedules-page.test.ts
+++ b/apps/web/src/domains/settings/pages/schedules-page.test.ts
@@ -616,6 +616,35 @@ describe("SystemTaskRow", () => {
     expect(detailClicks).toBe(1);
   });
 
+  test("cost metric opens usage without opening system task details", () => {
+    let detailClicks = 0;
+    let usageClicks = 0;
+
+    render(
+      createElement(SystemTaskRow, {
+        name: "Heartbeat",
+        subtitle: "Every 5 min",
+        enabled: true,
+        nextRunAt: 1_761_792_000_000,
+        lastRunAt: 1_761_792_003_000,
+        usage: readySystemTaskUsage,
+        onClick: () => {
+          detailClicks += 1;
+        },
+        onOpenUsage: () => {
+          usageClicks += 1;
+        },
+        showToggle: false,
+        onToggle: () => {},
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /view usage/i }));
+
+    expect(usageClicks).toBe(1);
+    expect(detailClicks).toBe(0);
+  });
+
   test("omits list-level run now while keeping status and usage content", () => {
     render(
       createElement(SystemTaskRow, {
@@ -688,6 +717,8 @@ describe("system task toggles", () => {
         onRetry: () => {},
         onSelectHeartbeat: () => {},
         onSelectConsolidation: () => {},
+        onOpenHeartbeatUsage: () => {},
+        onOpenConsolidationUsage: () => {},
         showSystemTaskToggles: true,
         onToggleHeartbeat: (enabled: boolean) => {
           toggleCalls.push(enabled);

--- a/apps/web/src/domains/settings/pages/schedules-page.tsx
+++ b/apps/web/src/domains/settings/pages/schedules-page.tsx
@@ -19,6 +19,7 @@ import {
   scheduleUsageSummaryQueryOptions,
   shouldShowSystemTaskToggles,
   sortSchedules,
+  SYSTEM_TASK_USAGE_TASK_KEYS,
   SYSTEM_TASK_URL_IDS,
   systemTaskKindFromUrlId,
   type ScheduleRowUsage,
@@ -403,6 +404,14 @@ export function SchedulesPage() {
         }
         onSelectConsolidation={() =>
           navigateToSchedule(SYSTEM_TASK_URL_IDS.consolidation)
+        }
+        onOpenHeartbeatUsage={() =>
+          navigate(routes.logs.usageForTask(SYSTEM_TASK_USAGE_TASK_KEYS.heartbeat))
+        }
+        onOpenConsolidationUsage={() =>
+          navigate(
+            routes.logs.usageForTask(SYSTEM_TASK_USAGE_TASK_KEYS.consolidation),
+          )
         }
         showSystemTaskToggles={showSystemTaskToggles}
         onToggleHeartbeat={(enabled) =>

--- a/apps/web/src/domains/settings/utils/schedule-formatters.ts
+++ b/apps/web/src/domains/settings/utils/schedule-formatters.ts
@@ -109,6 +109,11 @@ export const SYSTEM_TASK_URL_IDS = {
   consolidation: "system-consolidation",
 } as const satisfies Record<SystemTaskKind, string>;
 
+export const SYSTEM_TASK_USAGE_TASK_KEYS = {
+  heartbeat: "heartbeatAgent",
+  consolidation: "memoryV2Consolidation",
+} as const satisfies Record<SystemTaskKind, string>;
+
 export const SYSTEM_TASK_STATS_RUN_LIMIT = 100;
 
 export function shouldShowSystemTaskToggles(

--- a/apps/web/src/utils/routes.test.ts
+++ b/apps/web/src/utils/routes.test.ts
@@ -36,7 +36,7 @@ describe("routes", () => {
 
   test("builds task-selected usage URLs", () => {
     expect(routes.logs.usageForTask("memoryV2Consolidation")).toBe(
-      "/assistant/logs/usage?range=7d&groupBy=task&selectedGroup=memoryV2Consolidation",
+      "/assistant/logs/usage?range=7d&groupBy=task&callSite=memoryV2Consolidation&selectedGroup=memoryV2Consolidation",
     );
   });
 });

--- a/apps/web/src/utils/routes.test.ts
+++ b/apps/web/src/utils/routes.test.ts
@@ -33,4 +33,10 @@ describe("routes", () => {
       "/assistant/logs/usage?range=7d&groupBy=schedule&scheduleId=schedule+with+spaces",
     );
   });
+
+  test("builds task-selected usage URLs", () => {
+    expect(routes.logs.usageForTask("memoryV2Consolidation")).toBe(
+      "/assistant/logs/usage?range=7d&groupBy=task&selectedGroup=memoryV2Consolidation",
+    );
+  });
 });

--- a/apps/web/src/utils/routes.ts
+++ b/apps/web/src/utils/routes.ts
@@ -62,6 +62,14 @@ export const routes = {
       });
       return `${LOGS_USAGE_PATH}?${params.toString()}`;
     },
+    usageForTask: (taskKey: string) => {
+      const params = new URLSearchParams({
+        range: "7d",
+        groupBy: "task",
+        selectedGroup: taskKey,
+      });
+      return `${LOGS_USAGE_PATH}?${params.toString()}`;
+    },
     emails: r("/assistant/logs/emails"),
     systemEvents: r("/assistant/logs/system-events"),
   },

--- a/apps/web/src/utils/routes.ts
+++ b/apps/web/src/utils/routes.ts
@@ -66,6 +66,7 @@ export const routes = {
       const params = new URLSearchParams({
         range: "7d",
         groupBy: "task",
+        callSite: taskKey,
         selectedGroup: taskKey,
       });
       return `${LOGS_USAGE_PATH}?${params.toString()}`;

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -25377,6 +25377,12 @@ paths:
           schema:
             type: string
           description: Optional schedule id. When set, usage is attributed by cron run windows for that schedule.
+        - name: callSite
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Optional call site/task key. When set, only usage attributed to that task is included.
   /v1/usage/daily:
     get:
       operationId: usage_daily_get
@@ -25459,6 +25465,12 @@ paths:
           schema:
             type: string
           description: Optional schedule id. When set, usage is attributed by cron run windows for that schedule.
+        - name: callSite
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Optional call site/task key. When set, only usage attributed to that task is included.
   /v1/usage/series:
     get:
       operationId: usage_series_get
@@ -25577,6 +25589,12 @@ paths:
           schema:
             type: string
           description: Optional schedule id. When set, usage is attributed by cron run windows for that schedule.
+        - name: callSite
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Optional call site/task key. When set, only usage attributed to that task is included.
   /v1/usage/totals:
     get:
       operationId: usage_totals_get
@@ -25637,6 +25655,12 @@ paths:
           schema:
             type: string
           description: Optional schedule id. When set, usage is attributed by cron run windows for that schedule.
+        - name: callSite
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Optional call site/task key. When set, only usage attributed to that task is included.
   /v1/user-routes/inspect:
     post:
       operationId: userroutes_inspect_post

--- a/assistant/src/__tests__/usage-routes.test.ts
+++ b/assistant/src/__tests__/usage-routes.test.ts
@@ -330,6 +330,22 @@ describe("usage routes", () => {
       expect(body.totalCacheReadTokens).toBe(100);
     });
 
+    test("filters totals by trimmed callSite", () => {
+      const { day1, day2 } = seedEvents();
+      const from = day1 - 1000;
+      const to = day2 + 1000;
+
+      const body = dispatch(
+        "GET",
+        `usage/totals?from=${from}&to=${to}&callSite=%20mainAgent%20`,
+      ) as Record<string, number>;
+
+      expect(body.eventCount).toBe(1);
+      expect(body.totalInputTokens).toBe(850);
+      expect(body.totalOutputTokens).toBe(200);
+      expect(body.totalEstimatedCostUsd).toBeCloseTo(0.005);
+    });
+
     test("filters by trimmed scheduleId using schedule run windows", () => {
       seedScheduleRouteEvents();
 
@@ -392,6 +408,29 @@ describe("usage routes", () => {
       expect(body.buckets[1].date).toBe("2025-01-16");
       expect(body.buckets[1].totalInputTokens).toBe(2000);
       expect(body.buckets[1].eventCount).toBe(1);
+    });
+
+    test("filters daily buckets by callSite", () => {
+      const { day1, day2 } = seedEvents();
+      const from = day1 - 1000;
+      const to = day2 + 1000;
+
+      const body = dispatch(
+        "GET",
+        `usage/daily?from=${from}&to=${to}&callSite=mainAgent`,
+      ) as {
+        buckets: Array<{ totalInputTokens: number; eventCount: number }>;
+      };
+
+      expect(body.buckets).toHaveLength(2);
+      expect(body.buckets[0]).toMatchObject({
+        totalInputTokens: 850,
+        eventCount: 1,
+      });
+      expect(body.buckets[1]).toMatchObject({
+        totalInputTokens: 0,
+        eventCount: 0,
+      });
     });
 
     test("filters daily buckets by scheduleId", () => {
@@ -524,6 +563,30 @@ describe("usage routes", () => {
       expect(
         body.breakdown.find((row) => row.groupKey === null)?.totalInputTokens,
       ).toBe(2000);
+    });
+
+    test("filters breakdown by callSite", () => {
+      const { day1, day2 } = seedEvents();
+      const from = day1 - 1000;
+      const to = day2 + 1000;
+
+      const body = dispatch(
+        "GET",
+        `usage/breakdown?from=${from}&to=${to}&groupBy=provider&callSite=mainAgent`,
+      ) as {
+        breakdown: Array<{
+          group: string;
+          totalInputTokens: number;
+          eventCount: number;
+        }>;
+      };
+
+      expect(body.breakdown).toHaveLength(1);
+      expect(body.breakdown[0]).toMatchObject({
+        group: "anthropic",
+        totalInputTokens: 850,
+        eventCount: 1,
+      });
     });
 
     test("groups by inference profile with unset rows", () => {
@@ -666,6 +729,32 @@ describe("usage routes", () => {
         groupKey: null,
         totalInputTokens: 2000,
       });
+    });
+
+    test("filters grouped series by callSite", () => {
+      const { day1, day2 } = seedEvents();
+      const from = day1 - 1000;
+      const to = day2 + 1000;
+
+      const body = dispatch(
+        "GET",
+        `usage/series?from=${from}&to=${to}&groupBy=call_site&granularity=daily&callSite=mainAgent`,
+      ) as {
+        buckets: Array<{
+          totalInputTokens: number;
+          groups: Record<string, { groupKey: string | null; totalInputTokens: number }>;
+        }>;
+      };
+
+      expect(body.buckets).toHaveLength(2);
+      expect(body.buckets[0].totalInputTokens).toBe(850);
+      expect(body.buckets[0].groups["value:mainAgent"]).toMatchObject({
+        groupKey: "mainAgent",
+        totalInputTokens: 850,
+      });
+      expect(body.buckets[0].groups["value:compactionAgent"]).toBeUndefined();
+      expect(body.buckets[1].totalInputTokens).toBe(0);
+      expect(body.buckets[1].groups).toEqual({});
     });
 
     test("returns grouped inference-profile series buckets", () => {

--- a/assistant/src/memory/llm-usage-store.ts
+++ b/assistant/src/memory/llm-usage-store.ts
@@ -289,7 +289,9 @@ export interface UsageTimeRange {
   to: number;
 }
 
-export type UsageAggregationFilter = ScheduleAttributionFilter;
+export interface UsageAggregationFilter extends ScheduleAttributionFilter {
+  callSite?: string;
+}
 
 /** Aggregate totals across a time range. */
 export interface UsageTotals {
@@ -391,7 +393,12 @@ type UsageQueryParam = ScheduleAttributionSqlParam;
 function normalizeUsageAggregationFilter(
   filter?: UsageAggregationFilter,
 ): UsageAggregationFilter {
-  return normalizeScheduleAttributionFilter(filter);
+  const scheduleFilter = normalizeScheduleAttributionFilter(filter);
+  const callSite = filter?.callSite?.trim();
+  return {
+    ...scheduleFilter,
+    ...(callSite ? { callSite } : {}),
+  };
 }
 
 function buildUsageAggregationWhere(
@@ -414,6 +421,10 @@ function buildUsageAggregationWhere(
     });
     clauses.push(exists.sql);
     params.push(...exists.params);
+  }
+  if (normalized.callSite) {
+    clauses.push(`${eventTable}.call_site = ?`);
+    params.push(normalized.callSite);
   }
 
   return { sql: clauses.join(" AND "), params };

--- a/assistant/src/runtime/routes/usage-routes.ts
+++ b/assistant/src/runtime/routes/usage-routes.ts
@@ -1,10 +1,10 @@
 /**
  * Route handlers for usage and cost summary endpoints.
  *
- * GET /v1/usage/totals?from=&to=&scheduleId=  — aggregate totals for a time range
- * GET /v1/usage/daily?from=&to=&scheduleId=   — per-day buckets for a time range
- * GET /v1/usage/breakdown?from=&to=&groupBy=&scheduleId=  — grouped breakdown
- * GET /v1/usage/series?from=&to=&granularity=&groupBy=&scheduleId= — grouped time-series buckets
+ * GET /v1/usage/totals?from=&to=&scheduleId=&callSite=  — aggregate totals for a time range
+ * GET /v1/usage/daily?from=&to=&scheduleId=&callSite=   — per-day buckets for a time range
+ * GET /v1/usage/breakdown?from=&to=&groupBy=&scheduleId=&callSite=  — grouped breakdown
+ * GET /v1/usage/series?from=&to=&granularity=&groupBy=&scheduleId=&callSite= — grouped time-series buckets
  */
 
 import { z } from "zod";
@@ -33,6 +33,8 @@ const GROUP_BY_DESCRIPTION = USAGE_GROUP_BY_DIMENSIONS.join(", ");
 const SERIES_GROUP_BY_DESCRIPTION = USAGE_SERIES_GROUP_BY_DIMENSIONS.join(", ");
 const SCHEDULE_ID_FILTER_DESCRIPTION =
   "Optional schedule id. When set, usage is attributed by cron run windows for that schedule.";
+const CALL_SITE_FILTER_DESCRIPTION =
+  "Optional call site/task key. When set, only usage attributed to that task is included.";
 
 const usageTotalsSchema = z.object({
   totalInputTokens: z.number(),
@@ -94,7 +96,11 @@ function parseUsageAggregationFilter(
   queryParams: Record<string, string>,
 ): UsageAggregationFilter {
   const scheduleId = queryParams.scheduleId?.trim();
-  return scheduleId ? { scheduleId } : {};
+  const callSite = queryParams.callSite?.trim();
+  return {
+    ...(scheduleId ? { scheduleId } : {}),
+    ...(callSite ? { callSite } : {}),
+  };
 }
 
 function handleUsageTotals({ queryParams }: RouteHandlerArgs) {
@@ -209,6 +215,10 @@ export const ROUTES: RouteDefinition[] = [
         name: "scheduleId",
         description: SCHEDULE_ID_FILTER_DESCRIPTION,
       },
+      {
+        name: "callSite",
+        description: CALL_SITE_FILTER_DESCRIPTION,
+      },
     ],
     responseBody: usageTotalsSchema,
     handler: handleUsageTotals,
@@ -249,6 +259,10 @@ export const ROUTES: RouteDefinition[] = [
         name: "scheduleId",
         description: SCHEDULE_ID_FILTER_DESCRIPTION,
       },
+      {
+        name: "callSite",
+        description: CALL_SITE_FILTER_DESCRIPTION,
+      },
     ],
     responseBody: z.object({
       buckets: z.array(usageDayBucketSchema).describe("Usage bucket objects"),
@@ -285,6 +299,10 @@ export const ROUTES: RouteDefinition[] = [
       {
         name: "scheduleId",
         description: SCHEDULE_ID_FILTER_DESCRIPTION,
+      },
+      {
+        name: "callSite",
+        description: CALL_SITE_FILTER_DESCRIPTION,
       },
     ],
     responseBody: z.object({
@@ -334,6 +352,10 @@ export const ROUTES: RouteDefinition[] = [
       {
         name: "scheduleId",
         description: SCHEDULE_ID_FILTER_DESCRIPTION,
+      },
+      {
+        name: "callSite",
+        description: CALL_SITE_FILTER_DESCRIPTION,
       },
     ],
     responseBody: z.object({


### PR DESCRIPTION
## Summary
- Make System schedule cost cells clickable with the existing Cost (7d) usage affordance.
- Add task-selected usage URLs so heartbeat/consolidation open the 7-day Actions usage view with the matching series selected.
- Preserve the existing schedule-details chevron behavior while making only the cost cells navigate.

## Validation
- cd apps/web && export PATH="$HOME/.bun/bin:$PATH"; bun test src/domains/logs/usage-tab-state.test.ts src/domains/logs/components/usage-tab.test.tsx src/domains/settings/pages/schedules-page.test.ts src/utils/routes.test.ts
- cd apps/web && export PATH="$HOME/.bun/bin:$PATH"; bun run typecheck
- cd apps/web && export PATH="$HOME/.bun/bin:$PATH"; bun run lint (0 errors, 19 existing react-hooks/exhaustive-deps warnings)
- git diff --check

## Notes
- Local Vite smoke check could not start because vite.config.ts failed to load with ResolveMessage {}; direct vite invocation failed the same way before page load.