### PR TITLE
Fix Schedule Description Rollout Gaps

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -20524,7 +20524,7 @@ paths:
                   description: Display name
                 description:
                   type: string
-                  description: Authored schedule description
+                  description: Authored schedule description. Defaults to the schedule name when omitted for backward compatibility.
                 expression:
                   type: string
                   description: Cron or RRULE expression
@@ -20544,7 +20544,6 @@ paths:
                   description: Currently must be 'execute'
               required:
                 - name
-                - description
                 - expression
                 - message
               additionalProperties: false

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -467,6 +467,31 @@ describe("GET /schedules — default defer exclusion", () => {
     });
   });
 
+  test("returns One-time as the cadence description for one-shot schedules", () => {
+    createSchedule({
+      name: "One-shot schedule",
+      description: "Send a one-time reminder",
+      cronExpression: null,
+      nextRunAt: Date.now() + 60_000,
+      message: "remember this",
+    });
+
+    const route = findRoute("schedules", "GET");
+    const result = route.handler({}) as {
+      schedules: Array<{
+        name: string;
+        description: string;
+        cadenceDescription: string;
+      }>;
+    };
+
+    expect(result.schedules[0]).toMatchObject({
+      name: "One-shot schedule",
+      description: "Send a one-time reminder",
+      cadenceDescription: "One-time",
+    });
+  });
+
   test("mutation responses also exclude deferred wakes", () => {
     createSchedule({
       name: "Agent schedule",
@@ -1077,9 +1102,6 @@ describe("POST /schedules — create", () => {
       "message is required",
     );
     expect(() =>
-      postCreate({ name: "x", expression: "* * * * *", message: "hi" }),
-    ).toThrow("description is required");
-    expect(() =>
       postCreate({
         name: "x",
         description: "   ",
@@ -1087,6 +1109,17 @@ describe("POST /schedules — create", () => {
         message: "hi",
       }),
     ).toThrow("description is required");
+  });
+
+  test("defaults omitted create descriptions for backward compatibility", () => {
+    postCreate({
+      name: "Description fallback",
+      expression: "0 9 * * *",
+      message: "hi",
+    });
+
+    const job = listSchedules()[0];
+    expect(job.description).toBe("Description fallback");
   });
 
   test("rejects non-execute modes", () => {

--- a/assistant/src/__tests__/schedule-store.test.ts
+++ b/assistant/src/__tests__/schedule-store.test.ts
@@ -160,6 +160,7 @@ describe("createSchedule (cron)", () => {
     expect(job.syntax).toBe("cron");
     expect(job.expression).toBe("0 9 * * *");
     expect(job.cronExpression).toBe("0 9 * * *");
+    expect(job.description).toBe("Morning ping");
     expect(job.nextRunAt).toBeGreaterThan(Date.now() - 1000);
     expect(job.enabled).toBe(true);
   });

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -130,6 +130,9 @@ function getCreatedFromConversationState(
 function getCadenceDescription(
   job: Pick<ScheduleJob, "syntax" | "cronExpression" | "expression">,
 ): string {
+  if (job.cronExpression === null) {
+    return describeCronExpression(job.cronExpression);
+  }
   if (job.syntax === "cron") {
     return describeCronExpression(job.cronExpression);
   }
@@ -190,7 +193,11 @@ function handleCreateSchedule(body: Record<string, unknown>) {
   const expression =
     typeof body.expression === "string" ? body.expression.trim() : "";
   const description =
-    typeof body.description === "string" ? body.description.trim() : "";
+    body.description === undefined
+      ? undefined
+      : typeof body.description === "string"
+        ? body.description.trim()
+        : "";
   const message = typeof body.message === "string" ? body.message : "";
   const timezoneRaw =
     typeof body.timezone === "string" ? body.timezone.trim() : "";
@@ -201,7 +208,9 @@ function handleCreateSchedule(body: Record<string, unknown>) {
   if (!name) throw new BadRequestError("name is required");
   if (!expression) throw new BadRequestError("expression is required");
   if (!message) throw new BadRequestError("message is required");
-  if (!description) throw new BadRequestError("description is required");
+  if (description === "") {
+    throw new BadRequestError("description is required");
+  }
 
   // The settings UI only exposes execute mode for now. Other modes
   // remain reachable via the schedule_create LLM tool.
@@ -482,7 +491,12 @@ export const ROUTES: RouteDefinition[] = [
     tags: ["schedules"],
     requestBody: z.object({
       name: z.string().describe("Display name"),
-      description: z.string().describe("Authored schedule description"),
+      description: z
+        .string()
+        .describe(
+          "Authored schedule description. Defaults to the schedule name when omitted for backward compatibility.",
+        )
+        .optional(),
       expression: z.string().describe("Cron or RRULE expression"),
       message: z.string().describe("Message body to execute on each fire"),
       timezone: z

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -143,7 +143,10 @@ export function createSchedule(params: {
   const retryBackoffMs = params.retryBackoffMs ?? 60000;
   const timeoutMs = params.timeoutMs ?? null;
   const createdFromConversationId = params.createdFromConversationId ?? null;
-  const description = normalizeDescription(params.description);
+  const description = normalizeDescription(
+    params.description,
+    params.createdBy === "defer" ? "" : params.name,
+  );
 
   let nextRunAt: number;
   if (isOneShot) {
@@ -1016,8 +1019,12 @@ function parseJobRow(row: typeof scheduleJobs.$inferSelect): ScheduleJob {
   };
 }
 
-function normalizeDescription(value: string | undefined): string {
-  return value?.trim() ?? "";
+function normalizeDescription(
+  value: string | undefined,
+  fallback = "",
+): string {
+  const normalized = value?.trim() ?? "";
+  return normalized || fallback;
 }
 
 function safeParseJson(

--- a/clients/macos/vellum-assistant/Features/Settings/SettingsSchedulesTab.swift
+++ b/clients/macos/vellum-assistant/Features/Settings/SettingsSchedulesTab.swift
@@ -568,7 +568,12 @@ struct SettingsSchedulesTab: View {
     private func saveEdits(_ schedule: ScheduleItem) {
         var updates: [String: Any] = [:]
         if editName != schedule.name { updates["name"] = editName }
-        if editDescription != schedule.description { updates["description"] = editDescription }
+        let trimmedDescription = editDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedDescription.isEmpty {
+            loadError = "Description is required."
+            return
+        }
+        if trimmedDescription != schedule.description { updates["description"] = trimmedDescription }
         let originalExpression = schedule.expression ?? schedule.cronExpression ?? ""
         if editExpression != originalExpression { updates["expression"] = editExpression }
         if editMessage != schedule.message { updates["message"] = editMessage }

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -3386,6 +3386,26 @@ public struct SchedulesListResponseSchedule: Codable, Sendable {
     public let routingIntent: String
     public let isOneShot: Bool
 
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case enabled
+        case syntax
+        case expression
+        case cronExpression
+        case timezone
+        case message
+        case nextRunAt
+        case lastRunAt
+        case lastStatus
+        case description
+        case cadenceDescription
+        case mode
+        case status
+        case routingIntent
+        case isOneShot
+    }
+
     public init(id: String, name: String, enabled: Bool, syntax: String, expression: String?, cronExpression: String?, timezone: String?, message: String, nextRunAt: Int, lastRunAt: Int?, lastStatus: String?, description: String, cadenceDescription: String, mode: String, status: String, routingIntent: String, isOneShot: Bool) {
         self.id = id
         self.name = name
@@ -3404,6 +3424,33 @@ public struct SchedulesListResponseSchedule: Codable, Sendable {
         self.status = status
         self.routingIntent = routingIntent
         self.isOneShot = isOneShot
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        enabled = try container.decode(Bool.self, forKey: .enabled)
+        syntax = try container.decode(String.self, forKey: .syntax)
+        expression = try container.decodeIfPresent(String.self, forKey: .expression)
+        cronExpression = try container.decodeIfPresent(String.self, forKey: .cronExpression)
+        timezone = try container.decodeIfPresent(String.self, forKey: .timezone)
+        message = try container.decode(String.self, forKey: .message)
+        nextRunAt = try container.decode(Int.self, forKey: .nextRunAt)
+        lastRunAt = try container.decodeIfPresent(Int.self, forKey: .lastRunAt)
+        lastStatus = try container.decodeIfPresent(String.self, forKey: .lastStatus)
+        let rawDescription = try container.decodeIfPresent(String.self, forKey: .description) ?? ""
+        if let cadence = try container.decodeIfPresent(String.self, forKey: .cadenceDescription) {
+            description = rawDescription
+            cadenceDescription = cadence
+        } else {
+            description = ""
+            cadenceDescription = rawDescription
+        }
+        mode = try container.decode(String.self, forKey: .mode)
+        status = try container.decode(String.self, forKey: .status)
+        routingIntent = try container.decode(String.self, forKey: .routingIntent)
+        isOneShot = try container.decode(Bool.self, forKey: .isOneShot)
     }
 }
 

--- a/clients/shared/Tests/MessageTypesTests.swift
+++ b/clients/shared/Tests/MessageTypesTests.swift
@@ -201,6 +201,47 @@ final class MessageTypesTests: XCTestCase {
         XCTAssertEqual(schedule.cadenceDescription, "Every day at 9:00 AM")
     }
 
+    func testDecodesSchedulesListResponseWithoutCadenceDescription() throws {
+        let json = Data(
+            """
+            {
+              "type": "schedules_list_response",
+              "schedules": [
+                {
+                  "id": "schedule-123",
+                  "name": "Morning brief",
+                  "enabled": true,
+                  "syntax": "cron",
+                  "expression": "0 9 * * *",
+                  "cronExpression": "0 9 * * *",
+                  "timezone": "America/Denver",
+                  "message": "Send the morning brief",
+                  "nextRunAt": 1781000000000,
+                  "lastRunAt": null,
+                  "lastStatus": null,
+                  "description": "Every day at 9:00 AM",
+                  "mode": "notify",
+                  "status": "active",
+                  "routingIntent": "new",
+                  "isOneShot": false
+                }
+              ]
+            }
+            """.utf8
+        )
+
+        let message = try decoder.decode(ServerMessage.self, from: json)
+
+        guard case .schedulesListResponse(let response) = message else {
+            XCTFail("Expected .schedulesListResponse, got \(message)")
+            return
+        }
+
+        let schedule = try XCTUnwrap(response.schedules.first)
+        XCTAssertEqual(schedule.description, "")
+        XCTAssertEqual(schedule.cadenceDescription, "Every day at 9:00 AM")
+    }
+
     // MARK: - host_browser_request
 
     func testDecodes_hostBrowserRequest_withAllFields() throws {


### PR DESCRIPTION
## Summary

- Keep schedule creation backward-compatible by defaulting omitted descriptions to the schedule name.
- Restore one-shot cadence descriptions while preserving authored descriptions.
- Make native schedule decoding and edit validation tolerant of version skew and blank edits.

## Test plan

- `cd assistant && bun run generate:openapi`
- `cd assistant && bun test src/__tests__/schedule-store.test.ts src/__tests__/schedule-routes.test.ts`
- `cd assistant && bunx tsc --noEmit`
- `cd clients && DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter VellumAssistantSharedTests.MessageTypesTests`
- `cd clients && DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build`