### PR TITLE
[codex] Surface run conversations after user sends

### DIFF
--- a/apps/web/src/domains/chat/api/conversations.ts
+++ b/apps/web/src/domains/chat/api/conversations.ts
@@ -1,0 +1,35 @@
+import { conversationsByIdSurfacePost } from "@/generated/daemon/sdk.gen";
+import {
+  ApiError,
+  assertHasResponse,
+  extractErrorMessage,
+} from "@/utils/api-errors";
+
+export async function surfaceConversation(
+  assistantId: string,
+  conversationId: string,
+): Promise<number> {
+  const { data, error, response } = await conversationsByIdSurfacePost({
+    path: { assistant_id: assistantId, id: conversationId },
+    body: { surfaced: true },
+    throwOnError: false,
+  });
+
+  assertHasResponse(response, error, "Failed to surface conversation.");
+  if (!response.ok) {
+    const msg = extractErrorMessage(
+      error,
+      response,
+      "Failed to surface conversation.",
+    );
+    throw new ApiError(response.status, msg);
+  }
+  if (typeof data?.surfacedAt !== "number") {
+    const bodyPreview = JSON.stringify(data ?? null).slice(0, 200);
+    throw new ApiError(
+      response.status,
+      `Surface conversation payload was malformed (status=${response.status}, body=${bodyPreview}).`,
+    );
+  }
+  return data.surfacedAt;
+}

--- a/apps/web/src/domains/chat/hooks/use-send-message.ts
+++ b/apps/web/src/domains/chat/hooks/use-send-message.ts
@@ -42,6 +42,8 @@ import {
   prependConversation,
   removeConversation,
   resolveDraftKey,
+  shouldSurfaceConversationOnUserSend,
+  surfaceConversationInCaches,
 } from "@/utils/conversation-cache-mutations";
 import { findConversation, patchConversation } from "@/utils/conversation-cache";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
@@ -73,8 +75,13 @@ import {
   postChatMessage,
   pollForResponse,
 } from "@/domains/chat/api/messages";
+import { surfaceConversation } from "@/domains/chat/api/conversations";
 import type { ConversationMessage } from "@vellumai/assistant-api";
 import { supportsServerMintedConversation } from "@/lib/backwards-compat/server-minted-conversation";
+import {
+  CONVERSATION_NOT_FOUND,
+  fetchConversationDetail,
+} from "@/utils/fetch-conversation-detail";
 
 // ---------------------------------------------------------------------------
 // Stream send result
@@ -163,6 +170,7 @@ export function useSendMessage({
   // Cleared after the POST resolves or rejects. The draft-id check on
   // clear guards against re-mounts overwriting a newer mint.
   const pendingDraftMintRef = useRef<string | null>(null);
+  const surfacingConversationIdsRef = useRef<Set<string>>(new Set());
 
   // -------------------------------------------------------------------------
   // Queue management (delegated to useMessageQueue)
@@ -201,6 +209,43 @@ export function useSendMessage({
       }
     },
     [],
+  );
+
+  const surfaceConversationAfterUserSend = useCallback(
+    async (conversationId: string) => {
+      if (!assistantId) return;
+      if (surfacingConversationIdsRef.current.has(conversationId)) return;
+
+      let conversation = findConversation(
+        queryClient,
+        assistantId,
+        conversationId,
+      );
+      if (!conversation) {
+        const detail = await fetchConversationDetail(
+          assistantId,
+          conversationId,
+        );
+        if (detail === CONVERSATION_NOT_FOUND) return;
+        conversation = detail;
+      }
+
+      if (!shouldSurfaceConversationOnUserSend(conversation)) return;
+
+      surfacingConversationIdsRef.current.add(conversationId);
+      try {
+        const surfacedAt = await surfaceConversation(assistantId, conversationId);
+        surfaceConversationInCaches(
+          queryClient,
+          assistantId,
+          conversation,
+          surfacedAt,
+        );
+      } finally {
+        surfacingConversationIdsRef.current.delete(conversationId);
+      }
+    },
+    [assistantId, queryClient],
   );
 
   // -------------------------------------------------------------------------
@@ -318,6 +363,12 @@ export function useSendMessage({
           resolvedConversationId: postResult.conversationId,
         };
       }
+
+      void surfaceConversationAfterUserSend(effectiveConversationId).catch(
+        (err) => {
+          captureError(err, { context: "surface_conversation_after_send" });
+        },
+      );
 
       const streamState = useStreamStore.getState();
       const existingStreamContext = streamState.streamContext;
@@ -462,7 +513,12 @@ export function useSendMessage({
         resolvedConversationId: postResult.conversationId,
       };
     },
-    [activeConversationId, assistantId, startReconciliationLoop],
+    [
+      activeConversationId,
+      assistantId,
+      startReconciliationLoop,
+      surfaceConversationAfterUserSend,
+    ],
   );
 
   // -------------------------------------------------------------------------
@@ -558,6 +614,13 @@ export function useSendMessage({
             setError({ message: detail, code: postResult.error.code ?? undefined });
             return;
           }
+          void surfaceConversationAfterUserSend(postResult.conversationId).catch(
+            (err) => {
+              captureError(err, {
+                context: "surface_queued_conversation_after_send",
+              });
+            },
+          );
           if (!postResult.queued) {
             // The daemon processed the message directly (turn finished
             // between the client-side isSending check and the POST
@@ -729,6 +792,7 @@ export function useSendMessage({
       revertQueuedMessage,
       persistDismissedSurfaces,
       queryClient,
+      surfaceConversationAfterUserSend,
     ],
   );
 

--- a/apps/web/src/utils/conversation-cache-mutations.test.ts
+++ b/apps/web/src/utils/conversation-cache-mutations.test.ts
@@ -15,6 +15,8 @@ import {
   markConversationSeenLocal,
   prependConversation,
   removeConversation,
+  shouldSurfaceConversationOnUserSend,
+  surfaceConversationInCaches,
   resolveDraftKey,
   appendGroup,
   patchGroup,
@@ -275,6 +277,166 @@ describe("removeConversation", () => {
     removeConversation(qc, ASSISTANT_ID, "nonexistent");
 
     expect(getForeground(qc)).toBe(original);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// surfaceConversationInCaches
+// ---------------------------------------------------------------------------
+
+describe("shouldSurfaceConversationOnUserSend", () => {
+  test("allows unsurfaced scheduled and background conversations", () => {
+    expect(
+      shouldSurfaceConversationOnUserSend(
+        makeConversation({
+          conversationId: "scheduled-1",
+          conversationType: "scheduled",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldSurfaceConversationOnUserSend(
+        makeConversation({
+          conversationId: "background-1",
+          conversationType: "background",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldSurfaceConversationOnUserSend(
+        makeConversation({
+          conversationId: "legacy-scheduled-1",
+          groupId: "system:scheduled",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  test("skips conversations already displayed outside run buckets", () => {
+    expect(
+      shouldSurfaceConversationOnUserSend(
+        makeConversation({ conversationId: "standard-1" }),
+      ),
+    ).toBe(false);
+    expect(
+      shouldSurfaceConversationOnUserSend(
+        makeConversation({
+          conversationId: "surfaced-1",
+          conversationType: "scheduled",
+          surfacedAt: 9000,
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      shouldSurfaceConversationOnUserSend(
+        makeConversation({
+          conversationId: "pinned-1",
+          conversationType: "background",
+          isPinned: true,
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      shouldSurfaceConversationOnUserSend(
+        makeConversation({
+          conversationId: "custom-1",
+          conversationType: "scheduled",
+          groupId: "group-custom",
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      shouldSurfaceConversationOnUserSend(
+        makeConversation({
+          conversationId: "archived-1",
+          conversationType: "background",
+          archivedAt: 7000,
+        }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("surfaceConversationInCaches", () => {
+  test("prepends a scheduled conversation to foreground Recents and patches its existing cache row", () => {
+    seedForeground(qc, [makeConversation({ conversationId: "existing" })]);
+    seedScheduled(qc, [
+      makeConversation({
+        conversationId: "run-1",
+        conversationType: "scheduled",
+        groupId: "system:scheduled",
+        lastMessageAt: 3000,
+      }),
+    ]);
+
+    surfaceConversationInCaches(
+      qc,
+      ASSISTANT_ID,
+      getScheduled(qc)[0]!,
+      9000,
+      8000,
+    );
+
+    expect(getForeground(qc).map((c) => c.conversationId)).toEqual([
+      "run-1",
+      "existing",
+    ]);
+    expect(getForeground(qc)[0]).toMatchObject({
+      conversationId: "run-1",
+      groupId: "system:all",
+      surfacedAt: 9000,
+      lastMessageAt: 8000,
+    });
+    expect(getScheduled(qc)[0]).toMatchObject({
+      conversationId: "run-1",
+      groupId: "system:all",
+      surfacedAt: 9000,
+    });
+  });
+
+  test("prepends the fetched conversation when no lazy run cache has loaded", () => {
+    seedForeground(qc, [makeConversation({ conversationId: "existing" })]);
+    const runConversation = makeConversation({
+      conversationId: "run-1",
+      conversationType: "background",
+      groupId: "system:background",
+    });
+
+    surfaceConversationInCaches(
+      qc,
+      ASSISTANT_ID,
+      runConversation,
+      9000,
+      8500,
+    );
+
+    expect(getForeground(qc)[0]).toMatchObject({
+      conversationId: "run-1",
+      groupId: "system:all",
+      surfacedAt: 9000,
+      lastMessageAt: 8500,
+    });
+    expect(getBackground(qc)).toEqual([]);
+  });
+
+  test("keeps the newer existing lastMessageAt when the caller timestamp is older", () => {
+    seedBackground(qc, [
+      makeConversation({
+        conversationId: "run-1",
+        conversationType: "background",
+        lastMessageAt: 9500,
+      }),
+    ]);
+
+    surfaceConversationInCaches(
+      qc,
+      ASSISTANT_ID,
+      getBackground(qc)[0]!,
+      9000,
+      8500,
+    );
+
+    expect(getForeground(qc)[0]?.lastMessageAt).toBe(9500);
   });
 });
 

--- a/apps/web/src/utils/conversation-cache-mutations.ts
+++ b/apps/web/src/utils/conversation-cache-mutations.ts
@@ -90,6 +90,57 @@ export function removeConversation(
   updateAllConversationCaches(queryClient, assistantId, drop);
 }
 
+export function shouldSurfaceConversationOnUserSend(
+  conversation: Conversation,
+): boolean {
+  if (conversation.archivedAt != null) return false;
+  if (conversation.surfacedAt != null) return false;
+  if (conversation.isPinned === true || conversation.groupId === "system:pinned") {
+    return false;
+  }
+  if (conversation.groupId && !conversation.groupId.startsWith("system:")) {
+    return false;
+  }
+  return (
+    isScheduledConversation(conversation) ||
+    isBackgroundConversation(conversation)
+  );
+}
+
+export function surfaceConversationInCaches(
+  queryClient: QueryClient,
+  assistantId: string | null,
+  conversation: Conversation,
+  surfacedAt: number,
+  lastMessageAt = Date.now(),
+): void {
+  const surfacedConversation: Conversation = {
+    ...conversation,
+    groupId: "system:all",
+    surfacedAt,
+    lastMessageAt: Math.max(conversation.lastMessageAt ?? 0, lastMessageAt),
+  };
+
+  updateAllConversationCaches(queryClient, assistantId, (conversations) => {
+    let changed = false;
+    const next = conversations.map((c) => {
+      if (c.conversationId !== conversation.conversationId) {
+        return c;
+      }
+      changed = true;
+      return surfacedConversation;
+    });
+    return changed ? next : conversations;
+  });
+
+  updateConversationsCache(queryClient, assistantId, (conversations) => [
+    surfacedConversation,
+    ...conversations.filter(
+      (c) => c.conversationId !== conversation.conversationId,
+    ),
+  ]);
+}
+
 /**
  * Refresh a single conversation row in the cached sidebar list by
  * fetching `GET /v1/conversations/:id` and patching the cache in place.


### PR DESCRIPTION
## Summary

Completes the send-time UX on top of #34222's explicit `surfaced_at` API:

- after a successful user send, surface unsurfaced scheduled/background run conversations into Recents
- fetch a single conversation detail when the run was opened from Settings and is not in the lazy sidebar caches yet
- update the foreground conversation cache immediately so the row appears at the top of Recents
- avoid unnecessary writes by skipping standard, already-surfaced, pinned, custom-grouped, and archived conversations, with an in-flight guard per conversation

This supersedes #34436's older `group_id -> system:all` promotion approach while keeping #34222's cleaner provenance-preserving `surfaced_at` model.

## Validation

- `cd apps/web && bun test src/utils/conversation-cache-mutations.test.ts`
- `cd apps/web && bun run typecheck`
- `cd apps/web && bun test src/domains/chat/utils/group-conversations.test.ts src/utils/conversation-predicates.test.ts src/domains/chat/utils/conversation-selection.test.ts`
- `cd apps/web && bun run lint src/domains/chat/hooks/use-send-message.ts src/domains/chat/api/conversations.ts src/utils/conversation-cache-mutations.ts src/utils/conversation-cache-mutations.test.ts` (existing hook dependency warnings only; no errors)
- `git diff --check`
