### PR TITLE
Preserve legacy schedule description cadence

### DIFF
--- a/apps/web/src/domains/settings/api/schedules.test.ts
+++ b/apps/web/src/domains/settings/api/schedules.test.ts
@@ -68,7 +68,7 @@ afterEach(() => {
 });
 
 describe("fetchSchedules", () => {
-  test("falls back to description when older assistants omit cadenceDescription", async () => {
+  test("treats older assistants' description as cadence when cadenceDescription is omitted", async () => {
     scheduleRows = [
       {
         id: "schedule-123",
@@ -108,7 +108,49 @@ describe("fetchSchedules", () => {
         throwOnError: false,
       },
     ]);
-    expect(result[0]?.description).toBe("Every day at 9:00 AM");
+    expect(result[0]?.description).toBe("");
+    expect(result[0]?.cadenceDescription).toBe("Every day at 9:00 AM");
+  });
+
+  test("uses authoredDescription when newer assistants preserve legacy description cadence", async () => {
+    scheduleRows = [
+      {
+        id: "schedule-123",
+        name: "Morning brief",
+        enabled: true,
+        syntax: "cron",
+        expression: "0 9 * * *",
+        cronExpression: "0 9 * * *",
+        timezone: "UTC",
+        message: "Send the morning brief",
+        script: null,
+        nextRunAt: 1_761_792_000_000,
+        lastRunAt: null,
+        lastStatus: null,
+        retryCount: 0,
+        maxRetries: 0,
+        retryBackoffMs: 60_000,
+        timeoutMs: null,
+        createdFromConversationId: null,
+        createdFromConversationExists: false,
+        createdFromConversationArchivedAt: null,
+        description: "Every day at 9:00 AM",
+        authoredDescription: "Send the morning brief before work starts",
+        cadenceDescription: "Every day at 9:00 AM",
+        mode: "execute",
+        status: "active",
+        routingIntent: "all_channels",
+        reuseConversation: true,
+        wakeConversationId: null,
+        isOneShot: false,
+      },
+    ] as unknown as SchedulesGetResponse["schedules"];
+
+    const result = await fetchSchedules("assistant-1");
+
+    expect(result[0]?.description).toBe(
+      "Send the morning brief before work starts",
+    );
     expect(result[0]?.cadenceDescription).toBe("Every day at 9:00 AM");
   });
 });

--- a/apps/web/src/domains/settings/api/schedules.test.ts
+++ b/apps/web/src/domains/settings/api/schedules.test.ts
@@ -168,7 +168,7 @@ afterEach(() => {
 });
 
 describe("fetchSchedules", () => {
-  test("falls back to description when older assistants omit cadenceDescription", async () => {
+  test("treats older assistants' description as cadence when cadenceDescription is omitted", async () => {
     scheduleRows = [
       {
         id: "schedule-123",
@@ -208,7 +208,49 @@ describe("fetchSchedules", () => {
         throwOnError: false,
       },
     ]);
-    expect(result[0]?.description).toBe("Every day at 9:00 AM");
+    expect(result[0]?.description).toBe("");
+    expect(result[0]?.cadenceDescription).toBe("Every day at 9:00 AM");
+  });
+
+  test("uses authoredDescription when newer assistants preserve legacy description cadence", async () => {
+    scheduleRows = [
+      {
+        id: "schedule-123",
+        name: "Morning brief",
+        enabled: true,
+        syntax: "cron",
+        expression: "0 9 * * *",
+        cronExpression: "0 9 * * *",
+        timezone: "UTC",
+        message: "Send the morning brief",
+        script: null,
+        nextRunAt: 1_761_792_000_000,
+        lastRunAt: null,
+        lastStatus: null,
+        retryCount: 0,
+        maxRetries: 0,
+        retryBackoffMs: 60_000,
+        timeoutMs: null,
+        createdFromConversationId: null,
+        createdFromConversationExists: false,
+        createdFromConversationArchivedAt: null,
+        description: "Every day at 9:00 AM",
+        authoredDescription: "Send the morning brief before work starts",
+        cadenceDescription: "Every day at 9:00 AM",
+        mode: "execute",
+        status: "active",
+        routingIntent: "all_channels",
+        reuseConversation: true,
+        wakeConversationId: null,
+        isOneShot: false,
+      },
+    ] as unknown as SchedulesGetResponse["schedules"];
+
+    const result = await fetchSchedules("assistant-1");
+
+    expect(result[0]?.description).toBe(
+      "Send the morning brief before work starts",
+    );
     expect(result[0]?.cadenceDescription).toBe("Every day at 9:00 AM");
   });
 });

--- a/apps/web/src/utils/schedules.ts
+++ b/apps/web/src/utils/schedules.ts
@@ -10,14 +10,20 @@ export type AssistantSchedule = SchedulesGetResponse["schedules"][number];
 
 function normalizeSchedule(schedule: AssistantSchedule): AssistantSchedule {
   const raw = schedule as AssistantSchedule & {
+    authoredDescription?: string;
     cadenceDescription?: string;
     description?: string;
   };
-  const description = raw.description ?? "";
+  const legacyDescription = raw.description ?? "";
+  const cadenceDescription = raw.cadenceDescription ?? legacyDescription;
+  const authoredDescription =
+    raw.authoredDescription ??
+    (raw.cadenceDescription === undefined ? "" : legacyDescription);
   return {
     ...schedule,
-    description,
-    cadenceDescription: raw.cadenceDescription ?? description,
+    description: authoredDescription,
+    authoredDescription,
+    cadenceDescription,
   };
 }
 

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -20687,6 +20687,8 @@ paths:
                             - type: "null"
                         description:
                           type: string
+                        authoredDescription:
+                          type: string
                         cadenceDescription:
                           type: string
                         mode:
@@ -20744,6 +20746,7 @@ paths:
                         - createdFromConversationExists
                         - createdFromConversationArchivedAt
                         - description
+                        - authoredDescription
                         - cadenceDescription
                         - mode
                         - status
@@ -20888,6 +20891,8 @@ paths:
                             - type: "null"
                         description:
                           type: string
+                        authoredDescription:
+                          type: string
                         cadenceDescription:
                           type: string
                         mode:
@@ -20945,6 +20950,7 @@ paths:
                         - createdFromConversationExists
                         - createdFromConversationArchivedAt
                         - description
+                        - authoredDescription
                         - cadenceDescription
                         - mode
                         - status
@@ -21049,6 +21055,8 @@ paths:
                             - type: "null"
                         description:
                           type: string
+                        authoredDescription:
+                          type: string
                         cadenceDescription:
                           type: string
                         mode:
@@ -21106,6 +21114,7 @@ paths:
                         - createdFromConversationExists
                         - createdFromConversationArchivedAt
                         - description
+                        - authoredDescription
                         - cadenceDescription
                         - mode
                         - status
@@ -21207,6 +21216,8 @@ paths:
                           - type: "null"
                       description:
                         type: string
+                      authoredDescription:
+                        type: string
                       cadenceDescription:
                         type: string
                       mode:
@@ -21264,6 +21275,7 @@ paths:
                       - createdFromConversationExists
                       - createdFromConversationArchivedAt
                       - description
+                      - authoredDescription
                       - cadenceDescription
                       - mode
                       - status
@@ -21424,6 +21436,8 @@ paths:
                             - type: "null"
                         description:
                           type: string
+                        authoredDescription:
+                          type: string
                         cadenceDescription:
                           type: string
                         mode:
@@ -21481,6 +21495,7 @@ paths:
                         - createdFromConversationExists
                         - createdFromConversationArchivedAt
                         - description
+                        - authoredDescription
                         - cadenceDescription
                         - mode
                         - status
@@ -21585,6 +21600,8 @@ paths:
                             - type: "null"
                         description:
                           type: string
+                        authoredDescription:
+                          type: string
                         cadenceDescription:
                           type: string
                         mode:
@@ -21642,6 +21659,7 @@ paths:
                         - createdFromConversationExists
                         - createdFromConversationArchivedAt
                         - description
+                        - authoredDescription
                         - cadenceDescription
                         - mode
                         - status
@@ -21746,6 +21764,8 @@ paths:
                             - type: "null"
                         description:
                           type: string
+                        authoredDescription:
+                          type: string
                         cadenceDescription:
                           type: string
                         mode:
@@ -21803,6 +21823,7 @@ paths:
                         - createdFromConversationExists
                         - createdFromConversationArchivedAt
                         - description
+                        - authoredDescription
                         - cadenceDescription
                         - mode
                         - status
@@ -22020,6 +22041,8 @@ paths:
                             - type: "null"
                         description:
                           type: string
+                        authoredDescription:
+                          type: string
                         cadenceDescription:
                           type: string
                         mode:
@@ -22077,6 +22100,7 @@ paths:
                         - createdFromConversationExists
                         - createdFromConversationArchivedAt
                         - description
+                        - authoredDescription
                         - cadenceDescription
                         - mode
                         - status

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -20326,6 +20326,8 @@ paths:
                             - type: "null"
                         description:
                           type: string
+                        authoredDescription:
+                          type: string
                         cadenceDescription:
                           type: string
                         mode:
@@ -20377,6 +20379,7 @@ paths:
                         - createdFromConversationExists
                         - createdFromConversationArchivedAt
                         - description
+                        - authoredDescription
                         - cadenceDescription
                         - mode
                         - status
@@ -20476,6 +20479,8 @@ paths:
                             - type: "null"
                         description:
                           type: string
+                        authoredDescription:
+                          type: string
                         cadenceDescription:
                           type: string
                         mode:
@@ -20527,6 +20532,7 @@ paths:
                         - createdFromConversationExists
                         - createdFromConversationArchivedAt
                         - description
+                        - authoredDescription
                         - cadenceDescription
                         - mode
                         - status
@@ -20655,6 +20661,8 @@ paths:
                             - type: "null"
                         description:
                           type: string
+                        authoredDescription:
+                          type: string
                         cadenceDescription:
                           type: string
                         mode:
@@ -20706,6 +20714,7 @@ paths:
                         - createdFromConversationExists
                         - createdFromConversationArchivedAt
                         - description
+                        - authoredDescription
                         - cadenceDescription
                         - mode
                         - status
@@ -20804,6 +20813,8 @@ paths:
                             - type: "null"
                         description:
                           type: string
+                        authoredDescription:
+                          type: string
                         cadenceDescription:
                           type: string
                         mode:
@@ -20855,6 +20866,7 @@ paths:
                         - createdFromConversationExists
                         - createdFromConversationArchivedAt
                         - description
+                        - authoredDescription
                         - cadenceDescription
                         - mode
                         - status
@@ -20998,6 +21010,8 @@ paths:
                             - type: "null"
                         description:
                           type: string
+                        authoredDescription:
+                          type: string
                         cadenceDescription:
                           type: string
                         mode:
@@ -21049,6 +21063,7 @@ paths:
                         - createdFromConversationExists
                         - createdFromConversationArchivedAt
                         - description
+                        - authoredDescription
                         - cadenceDescription
                         - mode
                         - status
@@ -21148,6 +21163,8 @@ paths:
                             - type: "null"
                         description:
                           type: string
+                        authoredDescription:
+                          type: string
                         cadenceDescription:
                           type: string
                         mode:
@@ -21199,6 +21216,7 @@ paths:
                         - createdFromConversationExists
                         - createdFromConversationArchivedAt
                         - description
+                        - authoredDescription
                         - cadenceDescription
                         - mode
                         - status
@@ -21387,6 +21405,8 @@ paths:
                             - type: "null"
                         description:
                           type: string
+                        authoredDescription:
+                          type: string
                         cadenceDescription:
                           type: string
                         mode:
@@ -21438,6 +21458,7 @@ paths:
                         - createdFromConversationExists
                         - createdFromConversationArchivedAt
                         - description
+                        - authoredDescription
                         - cadenceDescription
                         - mode
                         - status

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -449,7 +449,7 @@ describe("GET /schedules — default defer exclusion", () => {
     expect(noSource.createdFromConversationArchivedAt).toBeNull();
   });
 
-  test("returns authored descriptions separately from cadence descriptions", () => {
+  test("keeps legacy descriptions as cadence and returns authored descriptions separately", () => {
     createSchedule({
       name: "Described schedule",
       description: "Review the morning queue",
@@ -463,6 +463,7 @@ describe("GET /schedules — default defer exclusion", () => {
       schedules: Array<{
         name: string;
         description: string;
+        authoredDescription: string;
         cadenceDescription: string;
       }>;
     };
@@ -470,7 +471,8 @@ describe("GET /schedules — default defer exclusion", () => {
     expect(result.schedules).toHaveLength(1);
     expect(result.schedules[0]).toMatchObject({
       name: "Described schedule",
-      description: "Review the morning queue",
+      description: "Every day at 9:00 AM",
+      authoredDescription: "Review the morning queue",
       cadenceDescription: "Every day at 9:00 AM",
     });
   });
@@ -489,13 +491,15 @@ describe("GET /schedules — default defer exclusion", () => {
       schedules: Array<{
         name: string;
         description: string;
+        authoredDescription: string;
         cadenceDescription: string;
       }>;
     };
 
     expect(result.schedules[0]).toMatchObject({
       name: "One-shot schedule",
-      description: "Send a one-time reminder",
+      description: "One-time",
+      authoredDescription: "Send a one-time reminder",
       cadenceDescription: "One-time",
     });
   });
@@ -621,7 +625,8 @@ describe("GET /schedules/:id", () => {
     expect(result.schedule).toMatchObject({
       id: schedule.id,
       name: "Single schedule",
-      description: "Fetch me by ID",
+      description: "Every day at 9:00 AM",
+      authoredDescription: "Fetch me by ID",
       cadenceDescription: "Every day at 9:00 AM",
       message: "review queue",
       mode: "execute",
@@ -1407,12 +1412,17 @@ describe("PATCH /schedules/:id — description", () => {
       pathParams: { id: schedule.id },
       body: { description: "Updated description" },
     }) as {
-      schedules: Array<{ id: string; description: string }>;
+      schedules: Array<{
+        id: string;
+        description: string;
+        authoredDescription: string;
+      }>;
     };
 
     expect(result.schedules[0]).toMatchObject({
       id: schedule.id,
-      description: "Updated description",
+      description: "Every day at 9:00 AM",
+      authoredDescription: "Updated description",
     });
     expect(listSchedules()[0].description).toBe("Updated description");
   });

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -441,7 +441,7 @@ describe("GET /schedules — default defer exclusion", () => {
     expect(noSource.createdFromConversationArchivedAt).toBeNull();
   });
 
-  test("returns authored descriptions separately from cadence descriptions", () => {
+  test("keeps legacy descriptions as cadence and returns authored descriptions separately", () => {
     createSchedule({
       name: "Described schedule",
       description: "Review the morning queue",
@@ -455,6 +455,7 @@ describe("GET /schedules — default defer exclusion", () => {
       schedules: Array<{
         name: string;
         description: string;
+        authoredDescription: string;
         cadenceDescription: string;
       }>;
     };
@@ -462,7 +463,8 @@ describe("GET /schedules — default defer exclusion", () => {
     expect(result.schedules).toHaveLength(1);
     expect(result.schedules[0]).toMatchObject({
       name: "Described schedule",
-      description: "Review the morning queue",
+      description: "Every day at 9:00 AM",
+      authoredDescription: "Review the morning queue",
       cadenceDescription: "Every day at 9:00 AM",
     });
   });
@@ -481,13 +483,15 @@ describe("GET /schedules — default defer exclusion", () => {
       schedules: Array<{
         name: string;
         description: string;
+        authoredDescription: string;
         cadenceDescription: string;
       }>;
     };
 
     expect(result.schedules[0]).toMatchObject({
       name: "One-shot schedule",
-      description: "Send a one-time reminder",
+      description: "One-time",
+      authoredDescription: "Send a one-time reminder",
       cadenceDescription: "One-time",
     });
   });
@@ -1190,12 +1194,17 @@ describe("PATCH /schedules/:id — description", () => {
       pathParams: { id: schedule.id },
       body: { description: "Updated description" },
     }) as {
-      schedules: Array<{ id: string; description: string }>;
+      schedules: Array<{
+        id: string;
+        description: string;
+        authoredDescription: string;
+      }>;
     };
 
     expect(result.schedules[0]).toMatchObject({
       id: schedule.id,
-      description: "Updated description",
+      description: "Every day at 9:00 AM",
+      authoredDescription: "Updated description",
     });
     expect(listSchedules()[0].description).toBe("Updated description");
   });

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -89,6 +89,7 @@ const scheduleSchema = z.object({
   createdFromConversationExists: z.boolean(),
   createdFromConversationArchivedAt: z.number().nullable(),
   description: z.string(),
+  authoredDescription: z.string(),
   cadenceDescription: z.string(),
   mode: z.enum(["notify", "execute", "script", "wake", "workflow"]),
   status: z.enum(["active", "firing", "fired", "cancelled"]),
@@ -184,6 +185,7 @@ function serializeSchedule(
     j.createdFromConversationId,
     sourceConversationCache,
   );
+  const cadenceDescription = getCadenceDescription(j);
   return {
     id: j.id,
     name: j.name,
@@ -205,8 +207,9 @@ function serializeSchedule(
     createdFromConversationId: j.createdFromConversationId,
     createdFromConversationExists: sourceConversation.exists,
     createdFromConversationArchivedAt: sourceConversation.archivedAt,
-    description: j.description,
-    cadenceDescription: getCadenceDescription(j),
+    description: cadenceDescription,
+    authoredDescription: j.description,
+    cadenceDescription,
     mode: j.mode,
     status: j.status,
     routingIntent: j.routingIntent,

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -66,6 +66,7 @@ const scheduleSchema = z.object({
   createdFromConversationExists: z.boolean(),
   createdFromConversationArchivedAt: z.number().nullable(),
   description: z.string(),
+  authoredDescription: z.string(),
   cadenceDescription: z.string(),
   mode: z.enum(["notify", "execute", "script", "wake"]),
   status: z.enum(["active", "firing", "fired", "cancelled"]),
@@ -155,6 +156,7 @@ function handleListSchedules(queryParams: Record<string, string>) {
         j.createdFromConversationId,
         sourceConversationCache,
       );
+      const cadenceDescription = getCadenceDescription(j);
       return {
         id: j.id,
         name: j.name,
@@ -175,8 +177,9 @@ function handleListSchedules(queryParams: Record<string, string>) {
         createdFromConversationId: j.createdFromConversationId,
         createdFromConversationExists: sourceConversation.exists,
         createdFromConversationArchivedAt: sourceConversation.archivedAt,
-        description: j.description,
-        cadenceDescription: getCadenceDescription(j),
+        description: cadenceDescription,
+        authoredDescription: j.description,
+        cadenceDescription,
         mode: j.mode,
         status: j.status,
         routingIntent: j.routingIntent,

--- a/clients/shared/Network/Generated/GeneratedAPITypes.swift
+++ b/clients/shared/Network/Generated/GeneratedAPITypes.swift
@@ -3380,6 +3380,7 @@ public struct SchedulesListResponseSchedule: Codable, Sendable {
     public let lastRunAt: Int?
     public let lastStatus: String?
     public let description: String
+    public let authoredDescription: String
     public let cadenceDescription: String
     public let mode: String
     public let status: String
@@ -3399,6 +3400,7 @@ public struct SchedulesListResponseSchedule: Codable, Sendable {
         case lastRunAt
         case lastStatus
         case description
+        case authoredDescription
         case cadenceDescription
         case mode
         case status
@@ -3406,7 +3408,7 @@ public struct SchedulesListResponseSchedule: Codable, Sendable {
         case isOneShot
     }
 
-    public init(id: String, name: String, enabled: Bool, syntax: String, expression: String?, cronExpression: String?, timezone: String?, message: String, nextRunAt: Int, lastRunAt: Int?, lastStatus: String?, description: String, cadenceDescription: String, mode: String, status: String, routingIntent: String, isOneShot: Bool) {
+    public init(id: String, name: String, enabled: Bool, syntax: String, expression: String?, cronExpression: String?, timezone: String?, message: String, nextRunAt: Int, lastRunAt: Int?, lastStatus: String?, description: String, authoredDescription: String? = nil, cadenceDescription: String, mode: String, status: String, routingIntent: String, isOneShot: Bool) {
         self.id = id
         self.name = name
         self.enabled = enabled
@@ -3419,6 +3421,7 @@ public struct SchedulesListResponseSchedule: Codable, Sendable {
         self.lastRunAt = lastRunAt
         self.lastStatus = lastStatus
         self.description = description
+        self.authoredDescription = authoredDescription ?? description
         self.cadenceDescription = cadenceDescription
         self.mode = mode
         self.status = status
@@ -3440,11 +3443,19 @@ public struct SchedulesListResponseSchedule: Codable, Sendable {
         lastRunAt = try container.decodeIfPresent(Int.self, forKey: .lastRunAt)
         lastStatus = try container.decodeIfPresent(String.self, forKey: .lastStatus)
         let rawDescription = try container.decodeIfPresent(String.self, forKey: .description) ?? ""
-        if let cadence = try container.decodeIfPresent(String.self, forKey: .cadenceDescription) {
+        if let authored = try container.decodeIfPresent(String.self, forKey: .authoredDescription) {
+            description = authored
+            authoredDescription = authored
+            cadenceDescription =
+                try container.decodeIfPresent(String.self, forKey: .cadenceDescription)
+                ?? rawDescription
+        } else if let cadence = try container.decodeIfPresent(String.self, forKey: .cadenceDescription) {
             description = rawDescription
+            authoredDescription = rawDescription
             cadenceDescription = cadence
         } else {
             description = ""
+            authoredDescription = ""
             cadenceDescription = rawDescription
         }
         mode = try container.decode(String.self, forKey: .mode)

--- a/clients/shared/Tests/MessageTypesTests.swift
+++ b/clients/shared/Tests/MessageTypesTests.swift
@@ -198,6 +198,51 @@ final class MessageTypesTests: XCTestCase {
 
         let schedule = try XCTUnwrap(response.schedules.first)
         XCTAssertEqual(schedule.description, "A useful authored summary")
+        XCTAssertEqual(schedule.authoredDescription, "A useful authored summary")
+        XCTAssertEqual(schedule.cadenceDescription, "Every day at 9:00 AM")
+    }
+
+    func testDecodesSchedulesListResponseWithLegacyDescriptionAndAuthoredDescription() throws {
+        let json = Data(
+            """
+            {
+              "type": "schedules_list_response",
+              "schedules": [
+                {
+                  "id": "schedule-123",
+                  "name": "Morning brief",
+                  "enabled": true,
+                  "syntax": "rrule",
+                  "expression": "FREQ=DAILY;BYHOUR=9;BYMINUTE=0",
+                  "cronExpression": null,
+                  "timezone": "America/Denver",
+                  "message": "Send the morning brief",
+                  "nextRunAt": 1781000000000,
+                  "lastRunAt": null,
+                  "lastStatus": null,
+                  "description": "Every day at 9:00 AM",
+                  "authoredDescription": "A useful authored summary",
+                  "cadenceDescription": "Every day at 9:00 AM",
+                  "mode": "notify",
+                  "status": "active",
+                  "routingIntent": "new",
+                  "isOneShot": false
+                }
+              ]
+            }
+            """.utf8
+        )
+
+        let message = try decoder.decode(ServerMessage.self, from: json)
+
+        guard case .schedulesListResponse(let response) = message else {
+            XCTFail("Expected .schedulesListResponse, got \(message)")
+            return
+        }
+
+        let schedule = try XCTUnwrap(response.schedules.first)
+        XCTAssertEqual(schedule.description, "A useful authored summary")
+        XCTAssertEqual(schedule.authoredDescription, "A useful authored summary")
         XCTAssertEqual(schedule.cadenceDescription, "Every day at 9:00 AM")
     }
 
@@ -239,6 +284,7 @@ final class MessageTypesTests: XCTestCase {
 
         let schedule = try XCTUnwrap(response.schedules.first)
         XCTAssertEqual(schedule.description, "")
+        XCTAssertEqual(schedule.authoredDescription, "")
         XCTAssertEqual(schedule.cadenceDescription, "Every day at 9:00 AM")
     }
 


### PR DESCRIPTION
## Summary
- Preserve the schedules list response `description` field as the legacy cadence text for older clients.
- Add `authoredDescription` so updated web/native clients can keep showing the new authored schedule purpose.
- Normalize web and Swift decoding across older assistant responses, the #34442 response shape, and this compatibility shape.

## Why
Follow-up to #34442. A post-merge Codex review correctly flagged that pre-#34442 clients read `description` as cadence. Returning authored text there would make older settings UIs lose timing/cadence information during version-skewed rollout.

## Test plan
- `cd assistant && bun test src/__tests__/schedule-routes.test.ts`
- `cd apps/web && bun test src/domains/settings/api/schedules.test.ts src/domains/settings/pages/schedules-page.test.ts`
- `cd assistant && bunx tsc --noEmit`
- `cd apps/web && bunx tsc --noEmit`
- `cd clients && swift test --filter MessageTypesTests`
- `git diff --check`

Related to #34442.