### PR TITLE
fix(web): web-search activity header hugs its content instead of full width

### DIFF
--- a/apps/web/src/domains/chat/components/single-activity/single-activity.test.tsx
+++ b/apps/web/src/domains/chat/components/single-activity/single-activity.test.tsx
@@ -296,6 +296,11 @@ describe("SingleActivity — web variant", () => {
     );
     expect(getByTestId("inline-web-link")).toBeTruthy();
     expect(getByText("Web Search")).toBeTruthy();
+    // The flex-col wrapper uses items-start so the header button hugs its
+    // content width rather than stretching to fill the row.
+    expect(getByTestId("inline-web-link").parentElement?.className).toContain(
+      "items-start",
+    );
   });
 
   test("rotates the WebsiteCarousel in the info slot while loading", () => {

--- a/apps/web/src/domains/chat/components/single-activity/single-activity.tsx
+++ b/apps/web/src/domains/chat/components/single-activity/single-activity.tsx
@@ -125,7 +125,7 @@ export function SingleActivity(props: SingleActivityProps) {
     const isError = state === "error";
     const ExpandChevron = expanded ? ChevronUp : ChevronDown;
     return (
-      <div className="flex flex-col">
+      <div className="flex flex-col items-start">
         <button
           type="button"
           data-testid="inline-web-link"


### PR DESCRIPTION
## Summary
- Add `items-start` to the web variant's flex-col wrapper so the header button no longer stretches to full container width; its hover highlight now hugs the content.

Part of plan: web-search-ui.md (PR 1 of 4)