### PR TITLE
fix(web): cap web-search result pill width so multiple fit per row

### DIFF
--- a/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.stories.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.stories.tsx
@@ -141,6 +141,45 @@ export const Web: Story = {
   },
 };
 
+/**
+ * Several web pills laid out the way `WebSearchStepRow` renders them — a
+ * `flex flex-wrap` row. The 240px per-pill cap (with truncation) lets 2–3
+ * pills sit on each row instead of one-per-row even with long page titles.
+ */
+export const WebResults: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () => (
+    <div className="flex max-w-[600px] flex-wrap gap-1">
+      <ToolStepPill
+        variant="web"
+        label="Toronto - Wikipedia, the free encyclopedia"
+        url="https://en.wikipedia.org/wiki/Toronto"
+        domain="en.wikipedia.org"
+      />
+      <ToolStepPill
+        variant="web"
+        label="Toronto travel guide: the best things to do in the city"
+        url="https://www.timeout.com/toronto"
+        domain="timeout.com"
+      />
+      <ToolStepPill
+        variant="web"
+        label="Visit Toronto — official tourism site for the city of Toronto"
+        url="https://www.destinationtoronto.com"
+        domain="destinationtoronto.com"
+      />
+      <ToolStepPill
+        variant="web"
+        label="Weather in Toronto — 7 day forecast and conditions"
+        url="https://weather.gc.ca/city/pages/on-143_metric_e.html"
+        domain="weather.gc.ca"
+      />
+    </div>
+  ),
+};
+
 export const AllVariants: Story = {
   parameters: {
     controls: { disable: true },

--- a/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.tsx
@@ -80,7 +80,7 @@ export type ToolStepPillProps = ToolStepPillToolProps | ToolStepPillWebProps;
  * enough that descenders ("g", "p", "y") get clipped without extra leading.
  */
 const BASE_CLASSES =
-  "inline-flex min-w-0 max-w-full items-center gap-1 self-start rounded-full px-2 py-1 text-left leading-normal";
+  "inline-flex min-w-0 items-center gap-1 self-start rounded-full px-2 py-1 text-left leading-normal";
 
 /** Cursor / transition / focus-ring affordances when the pill is a button. */
 const INTERACTIVE_BASE =
@@ -152,7 +152,7 @@ function WebStepPill({
       data-testid="tool-step-pill"
       data-variant="web"
       aria-label={ariaLabel ?? `Open ${label}`}
-      className={`${BASE_CLASSES} ${INTERACTIVE_BASE} no-underline hover:bg-[var(--surface-active)] ${idleColorClasses(tone)}`}
+      className={`${BASE_CLASSES} ${INTERACTIVE_BASE} max-w-[240px] no-underline hover:bg-[var(--surface-active)] ${idleColorClasses(tone)}`}
     >
       <PillFavicon faviconUrl={faviconUrl} domain={domain} label={label} />
       <Typography
@@ -242,7 +242,7 @@ export function ToolStepPill(props: ToolStepPillProps) {
           aria-label={ariaLabel ?? `View details: ${label}`}
           onClick={onClick}
           onKeyDown={handleKeyDown}
-          className={`${BASE_CLASSES} ${INTERACTIVE_BASE} ${hoverClass} ${colorClasses}`}
+          className={`${BASE_CLASSES} ${INTERACTIVE_BASE} max-w-full ${hoverClass} ${colorClasses}`}
         >
           {labelContent}
           <RiskBadge level={riskLevel} onClick={onRiskBadgeClick} />
@@ -258,7 +258,7 @@ export function ToolStepPill(props: ToolStepPillProps) {
         aria-pressed={active}
         aria-label={ariaLabel ?? `View details: ${label}`}
         onClick={onClick}
-        className={`${BASE_CLASSES} ${INTERACTIVE_BASE} ${hoverClass} ${colorClasses}`}
+        className={`${BASE_CLASSES} ${INTERACTIVE_BASE} max-w-full ${hoverClass} ${colorClasses}`}
       >
         {labelContent}
         <RiskBadge level={riskLevel} />
@@ -269,7 +269,7 @@ export function ToolStepPill(props: ToolStepPillProps) {
   return (
     <span
       data-testid="tool-step-pill"
-      className={`${BASE_CLASSES} ${colorClasses}`}
+      className={`${BASE_CLASSES} max-w-full ${colorClasses}`}
     >
       {labelContent}
       <RiskBadge level={riskLevel} />


### PR DESCRIPTION
## Summary
- Drop `max-w-full` from the shared pill BASE_CLASSES and re-apply it per call site, capping web-variant pills at `max-w-[240px]` so 2–3 result pills fit per row while tool pills stay unchanged.

Part of plan: web-search-ui.md (PR 2 of 4)