### PR TITLE
fix(web): web-search carousel walks to the latest searched site with a 0.5s dwell

### DIFF
--- a/apps/web/src/domains/chat/components/web-search/website-carousel.test.tsx
+++ b/apps/web/src/domains/chat/components/web-search/website-carousel.test.tsx
@@ -2,9 +2,11 @@
  * Tests for `WebsiteCarousel`.
  *
  * bun:test doesn't ship a `vi.useFakeTimers()` equivalent, so we drive the
- * carousel's `setInterval` manually by monkey-patching the global. Each test
- * captures the callback the component registers, then invokes it from `act()`
- * to advance the rotation without real-time delays.
+ * carousel's `setTimeout` manually by monkey-patching the global. Each timeout
+ * the component schedules is captured, then fired from `act()` to advance the
+ * walk without real-time delays. This lets us assert that an advance only
+ * happens once the `minDwellMs` timeout fires (the 0.5s floor) and that the
+ * carousel walks toward the latest item and then holds — never wrapping back.
  *
  * The reduced-motion path is verified by stubbing `motion/react` so that
  * `useReducedMotion()` returns `true` and `motion.div` resolves to a plain
@@ -20,63 +22,74 @@ import { cleanup, render } from "@testing-library/react";
 import { WebsiteCarousel } from "@/domains/chat/components/web-search/website-carousel";
 
 // ---------------------------------------------------------------------------
-// setInterval harness
+// setTimeout harness
 // ---------------------------------------------------------------------------
 
-interface IntervalHandle {
+interface TimeoutHandle {
   id: number;
   fn: () => void;
   ms: number;
   cleared: boolean;
 }
 
-let intervals: IntervalHandle[] = [];
-let nextIntervalId = 1;
-let setIntervalCallCount = 0;
-let originalSetInterval: typeof globalThis.setInterval;
-let originalClearInterval: typeof globalThis.clearInterval;
+let timeouts: TimeoutHandle[] = [];
+let nextTimeoutId = 1;
+let setTimeoutCallCount = 0;
+let originalSetTimeout: typeof globalThis.setTimeout;
+let originalClearTimeout: typeof globalThis.clearTimeout;
 
 beforeEach(() => {
-  intervals = [];
-  nextIntervalId = 1;
-  setIntervalCallCount = 0;
-  originalSetInterval = globalThis.setInterval;
-  originalClearInterval = globalThis.clearInterval;
-  globalThis.setInterval = ((
+  timeouts = [];
+  nextTimeoutId = 1;
+  setTimeoutCallCount = 0;
+  originalSetTimeout = globalThis.setTimeout;
+  originalClearTimeout = globalThis.clearTimeout;
+  globalThis.setTimeout = ((
     fn: (...args: unknown[]) => void,
     ms?: number,
   ) => {
-    setIntervalCallCount += 1;
-    const handle: IntervalHandle = {
-      id: nextIntervalId++,
+    setTimeoutCallCount += 1;
+    const handle: TimeoutHandle = {
+      id: nextTimeoutId++,
       fn: () => fn(),
       ms: ms ?? 0,
       cleared: false,
     };
-    intervals.push(handle);
-    return handle.id as unknown as ReturnType<typeof globalThis.setInterval>;
-  }) as typeof globalThis.setInterval;
-  globalThis.clearInterval = ((id: number) => {
-    const handle = intervals.find((h) => h.id === id);
+    timeouts.push(handle);
+    return handle.id as unknown as ReturnType<typeof globalThis.setTimeout>;
+  }) as typeof globalThis.setTimeout;
+  globalThis.clearTimeout = ((id?: number) => {
+    const handle = timeouts.find((h) => h.id === id);
     if (handle) handle.cleared = true;
-  }) as typeof globalThis.clearInterval;
+  }) as typeof globalThis.clearTimeout;
 });
 
 afterEach(() => {
-  globalThis.setInterval = originalSetInterval;
-  globalThis.clearInterval = originalClearInterval;
+  globalThis.setTimeout = originalSetTimeout;
+  globalThis.clearTimeout = originalClearTimeout;
   cleanup();
 });
 
-/** Fire every pending (non-cleared) interval one tick. */
-function advanceOneTick() {
-  for (const handle of intervals) {
+/**
+ * Fire every currently-pending (non-cleared) timeout once. The component
+ * schedules at most one timeout per render, so this advances the walk by a
+ * single step. After firing, the timeout is marked cleared so it isn't
+ * re-fired on the next call.
+ */
+function fireDwellTimer() {
+  for (const handle of timeouts) {
     if (!handle.cleared) {
+      handle.cleared = true;
       act(() => {
         handle.fn();
       });
     }
   }
+}
+
+/** Count of timeouts that are still pending (scheduled and not yet fired/cleared). */
+function pendingTimeouts() {
+  return timeouts.filter((h) => !h.cleared);
 }
 
 // ---------------------------------------------------------------------------
@@ -89,63 +102,94 @@ const ITEMS = [
   { faviconUrl: "https://c.test/favicon.ico", title: "Charlie", domain: "c.test" },
 ];
 
-describe("WebsiteCarousel — rotation", () => {
-  test("advances to the next item after the interval fires", () => {
+describe("WebsiteCarousel — walk to latest", () => {
+  test("advances one step per dwell tick toward the last item, then holds", () => {
     const { getByText } = render(
-      <WebsiteCarousel items={ITEMS} intervalMs={1000} />,
+      <WebsiteCarousel items={ITEMS} minDwellMs={1000} />,
     );
     // Initial frame shows the first item.
     expect(getByText("Alpha")).toBeTruthy();
-    // After one interval tick → second item visible.
-    advanceOneTick();
+    // After one dwell tick → second item visible.
+    fireDwellTimer();
     expect(getByText("Bravo")).toBeTruthy();
-    // After two ticks → third item visible (interval * 2 worth of progress).
+    // After another tick → the last (latest) item is visible.
     // Note: `AnimatePresence mode="popLayout"` retains the previous element
     // during its exit animation, so we only assert that the new entry is in
     // the tree — the old one may still be there mid-fade.
-    advanceOneTick();
+    fireDwellTimer();
+    expect(getByText("Charlie")).toBeTruthy();
+    // Once caught up to the latest, the walk holds: no further timer is
+    // scheduled, and it does NOT wrap back to the first item.
+    expect(pendingTimeouts()).toHaveLength(0);
     expect(getByText("Charlie")).toBeTruthy();
   });
 
-  test("wraps back to the first item after the last", () => {
+  test("does not advance before the dwell timeout fires (honours the floor)", () => {
     const { getByText } = render(
-      <WebsiteCarousel items={ITEMS} intervalMs={500} />,
+      <WebsiteCarousel items={ITEMS} minDwellMs={500} />,
     );
-    advanceOneTick(); // Bravo
-    advanceOneTick(); // Charlie
-    advanceOneTick(); // Alpha again
+    // A timer is scheduled but not yet fired — still on the first item.
     expect(getByText("Alpha")).toBeTruthy();
+    expect(pendingTimeouts()).toHaveLength(1);
+    expect(pendingTimeouts()[0]!.ms).toBe(500);
   });
 
-  test("uses the supplied intervalMs when scheduling", () => {
-    render(<WebsiteCarousel items={ITEMS} intervalMs={1234} />);
-    expect(intervals).toHaveLength(1);
-    expect(intervals[0]!.ms).toBe(1234);
+  test("resumes the walk when a newer item is appended", () => {
+    const { getByText, rerender } = render(
+      <WebsiteCarousel items={ITEMS} minDwellMs={500} />,
+    );
+    // Walk to the current latest item.
+    fireDwellTimer(); // Bravo
+    fireDwellTimer(); // Charlie
+    expect(getByText("Charlie")).toBeTruthy();
+    expect(pendingTimeouts()).toHaveLength(0);
+
+    // Parent appends a newer searched site — the target grows and the walk
+    // resumes toward it.
+    const moreItems = [
+      ...ITEMS,
+      {
+        faviconUrl: "https://d.test/favicon.ico",
+        title: "Delta",
+        domain: "d.test",
+      },
+    ];
+    rerender(<WebsiteCarousel items={moreItems} minDwellMs={500} />);
+    expect(pendingTimeouts()).toHaveLength(1);
+    fireDwellTimer();
+    expect(getByText("Delta")).toBeTruthy();
+    expect(pendingTimeouts()).toHaveLength(0);
+  });
+
+  test("defaults minDwellMs to 500", () => {
+    render(<WebsiteCarousel items={ITEMS} />);
+    expect(pendingTimeouts()).toHaveLength(1);
+    expect(pendingTimeouts()[0]!.ms).toBe(500);
   });
 });
 
 describe("WebsiteCarousel — degenerate cases", () => {
-  test("with one item: renders it statically and never schedules an interval", () => {
+  test("with one item: renders it statically and never schedules a timer", () => {
     const { getByText } = render(
-      <WebsiteCarousel items={[ITEMS[0]!]} intervalMs={500} />,
+      <WebsiteCarousel items={[ITEMS[0]!]} minDwellMs={500} />,
     );
     expect(getByText("Alpha")).toBeTruthy();
-    expect(setIntervalCallCount).toBe(0);
+    expect(setTimeoutCallCount).toBe(0);
   });
 
-  test("with zero items: renders nothing and never schedules an interval", () => {
+  test("with zero items: renders nothing and never schedules a timer", () => {
     const { container } = render(<WebsiteCarousel items={[]} />);
     expect(container.firstChild).toBeNull();
-    expect(setIntervalCallCount).toBe(0);
+    expect(setTimeoutCallCount).toBe(0);
   });
 
-  test("clears its interval on unmount", () => {
+  test("clears its pending timer on unmount", () => {
     const { unmount } = render(
-      <WebsiteCarousel items={ITEMS} intervalMs={500} />,
+      <WebsiteCarousel items={ITEMS} minDwellMs={500} />,
     );
-    expect(intervals).toHaveLength(1);
+    expect(pendingTimeouts()).toHaveLength(1);
     unmount();
-    expect(intervals[0]!.cleared).toBe(true);
+    expect(pendingTimeouts()).toHaveLength(0);
   });
 });
 
@@ -215,7 +259,7 @@ describe("WebsiteCarousel — reduced motion", () => {
     const { WebsiteCarousel: PatchedCarousel } = await import(
       "./website-carousel"
     );
-    render(<PatchedCarousel items={ITEMS} intervalMs={500} />);
+    render(<PatchedCarousel items={ITEMS} minDwellMs={500} />);
 
     // At least one motion.div should have been rendered.
     expect(motionDivCalls.length).toBeGreaterThan(0);

--- a/apps/web/src/domains/chat/components/web-search/website-carousel.tsx
+++ b/apps/web/src/domains/chat/components/web-search/website-carousel.tsx
@@ -19,14 +19,24 @@ export interface WebsiteCarouselItem {
 
 export interface WebsiteCarouselProps {
   items: WebsiteCarouselItem[];
-  /** Time between transitions in ms. Defaults to 2500ms. */
-  intervalMs?: number;
+  /**
+   * Minimum time each site is shown before advancing toward the latest, in ms.
+   * Defaults to 500.
+   */
+  minDwellMs?: number;
 }
 
 /**
- * Top-down rotating ticker that cycles through `items`, sliding each new entry
- * in from above and the previous one out the bottom. Used by the collapsed
- * "Searching the web" header to show the websites currently being searched.
+ * Top-down ticker that walks toward the latest searched site, sliding each new
+ * entry in from above and the previous one out the bottom. Used by the
+ * collapsed "Searching the web" header to show the websites being searched.
+ *
+ * The parent appends a new item as each site is searched, so the most recent
+ * result is always the last entry. Rather than round-robining stale results,
+ * the carousel advances `currentIndex` forward one step at a time toward
+ * `items.length - 1` and then holds there. Every step is gated by a
+ * `setTimeout(…, minDwellMs)` so each intermediate site is shown for at least
+ * `minDwellMs` and rapid bursts of new results don't flash by.
  *
  * Mirrors the motion vocabulary used by `surfaces/card-surface.tsx`
  * (`InProgressDetail`) — `AnimatePresence` with `mode="popLayout"`, a per-entry
@@ -37,26 +47,32 @@ export interface WebsiteCarouselProps {
  *
  * Edge cases:
  * - 0 items → renders nothing.
- * - 1 item → renders that single chip statically, never schedules an interval.
+ * - 1 item → renders that single chip statically, never schedules a timer.
  */
 export function WebsiteCarousel({
   items,
-  intervalMs = 2500,
+  minDwellMs = 500,
 }: WebsiteCarouselProps) {
   const reduce = useReducedMotion();
   const [currentIndex, setCurrentIndex] = useState(0);
 
-  // Schedule the interval only when there's something to rotate through. A
-  // single-item carousel is intentionally static — no timer churn. The
-  // modulo guards against `items.length` shrinking out from under us between
-  // ticks (e.g. when the parent updates the list mid-rotation).
+  // The display target is always the latest item. Clamp to 0 so an empty list
+  // yields a non-negative target.
+  const target = Math.max(items.length - 1, 0);
+
+  // Walk `currentIndex` toward the latest item one step at a time, each step
+  // gated by `minDwellMs` so every intermediate site stays visible long enough.
+  // When the parent appends a newer result `target` grows, this effect re-runs,
+  // and the walk resumes — always converging on (and then holding) the most
+  // recently searched site. Once caught up we hold and schedule nothing.
   useEffect(() => {
-    if (items.length <= 1) return;
-    const id = setInterval(() => {
-      setCurrentIndex((prev) => (prev + 1) % items.length);
-    }, intervalMs);
-    return () => clearInterval(id);
-  }, [items.length, intervalMs]);
+    if (currentIndex >= target) return;
+    const id = setTimeout(
+      () => setCurrentIndex((i) => Math.min(i + 1, target)),
+      minDwellMs,
+    );
+    return () => clearTimeout(id);
+  }, [currentIndex, target, minDwellMs]);
 
   if (items.length === 0) return null;
 
@@ -67,7 +83,7 @@ export function WebsiteCarousel({
   const animate = reduce ? { opacity: 1 } : { y: 0, opacity: 1 };
   const exit = reduce ? { opacity: 0 } : { y: 28, opacity: 0 };
 
-  // Single-item branch: no AnimatePresence, no interval — render the chip
+  // Single-item branch: no AnimatePresence, no timer — render the chip
   // directly so the wrapper still has the same height for layout stability.
   if (items.length === 1) {
     const item = items[0]!;
@@ -84,7 +100,8 @@ export function WebsiteCarousel({
     );
   }
 
-  const safeIndex = currentIndex % items.length;
+  // Clamp to the latest item so a shrinking list can't index out of bounds.
+  const safeIndex = Math.min(currentIndex, target);
   const current = items[safeIndex]!;
   // Compose a stable per-cycle key from domain/title plus the index so back-to-
   // back duplicates still trigger the slide animation.


### PR DESCRIPTION
## Summary
- Replace the round-robin carousel loop with a forward walk toward the latest searched site, gated by a `minDwellMs` (default 500ms) setTimeout so each site shows for at least 0.5s before advancing and the carousel holds on the most recent result.

Part of plan: web-search-ui.md (PR 4 of 4)