### PR TITLE
feat(web): show the site favicon in the settled web-search header

### DIFF
--- a/apps/web/src/domains/chat/components/single-activity/single-activity.test.tsx
+++ b/apps/web/src/domains/chat/components/single-activity/single-activity.test.tsx
@@ -338,8 +338,56 @@ describe("SingleActivity — web variant", () => {
     expect(container.querySelector(".h-\\[28px\\]")).toBeNull();
   });
 
-  test("shows the static info text when carouselItems is empty", () => {
-    const { getByText, container } = render(
+  test("renders the latest page's favicon (or monogram) beside the settled title", () => {
+    const { getByTestId, getByText } = render(
+      <SingleActivity
+        variant="web"
+        info="Visit Toronto — Official Tourism"
+        carouselItems={RESULTS}
+        state="complete"
+        step={WEB_STEP}
+        expanded={false}
+        onExpandChange={() => {}}
+      />,
+    );
+    // The favicon for the LAST result (carouselItems.at(-1)) sits beside the
+    // title. RESULTS' last item has no faviconUrl, so the monogram of its
+    // domain ("destinationtoronto.com" → "D") renders inside the slot.
+    const slot = getByTestId("site-favicon");
+    expect(slot).toBeTruthy();
+    expect(slot.textContent).toBe("D");
+    expect(getByText("Visit Toronto — Official Tourism")).toBeTruthy();
+  });
+
+  test("renders the favicon <img> when the latest result has a faviconUrl", () => {
+    const withFavicon: WebSearchResultItem[] = [
+      makeResult({
+        rank: 1,
+        title: "Toronto Travel",
+        domain: "destinationtoronto.com",
+        faviconUrl: "https://destinationtoronto.com/favicon.ico",
+      }),
+    ];
+    const { container } = render(
+      <SingleActivity
+        variant="web"
+        info="Toronto Travel"
+        carouselItems={withFavicon}
+        state="complete"
+        step={WEB_STEP}
+        expanded={false}
+        onExpandChange={() => {}}
+      />,
+    );
+    const img = container.querySelector('[data-testid="site-favicon"] img');
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute("src")).toBe(
+      "https://destinationtoronto.com/favicon.ico",
+    );
+  });
+
+  test("shows the static info text (no favicon) when carouselItems is empty", () => {
+    const { getByText, queryByTestId, container } = render(
       <SingleActivity
         variant="web"
         info="en.wikipedia.org"
@@ -351,6 +399,8 @@ describe("SingleActivity — web variant", () => {
       />,
     );
     expect(getByText("en.wikipedia.org")).toBeTruthy();
+    // No latest result → no favicon rendered next to the title.
+    expect(queryByTestId("site-favicon")).toBeNull();
     // No carousel ticker wrapper when there are no items.
     expect(container.querySelector(".h-\\[28px\\]")).toBeNull();
   });

--- a/apps/web/src/domains/chat/components/single-activity/single-activity.tsx
+++ b/apps/web/src/domains/chat/components/single-activity/single-activity.tsx
@@ -55,6 +55,7 @@ import {
   WebSearchStepRow,
 } from "@/domains/chat/components/web-search/web-search-step-row";
 import { WebsiteCarousel } from "@/domains/chat/components/web-search/website-carousel";
+import { SiteFavicon } from "@/domains/chat/components/web-search/site-favicon";
 import { useViewerStore } from "@/stores/viewer-store";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { WebSearchResultItem } from "@/assistant/web-activity-types";
@@ -121,8 +122,12 @@ export function SingleActivity(props: SingleActivityProps) {
   );
 
   if (props.variant === "web") {
-    const { info, state, step, expanded, onExpandChange } = props;
+    const { info, carouselItems, state, step, expanded, onExpandChange } =
+      props;
     const isError = state === "error";
+    // The settled header shows the LAST result's title (`info`); pull the
+    // matching result so we can render its favicon immediately left of it.
+    const latest = carouselItems.at(-1);
     const ExpandChevron = expanded ? ChevronUp : ChevronDown;
     return (
       <div className="flex flex-col items-start">
@@ -166,6 +171,19 @@ export function SingleActivity(props: SingleActivityProps) {
           {state === "loading" && carouselNode ? (
             <span className="inline-flex w-[220px] min-w-0 items-center">
               {carouselNode}
+            </span>
+          ) : latest &&
+            (latest.faviconUrl || latest.domain || latest.title) ? (
+            <span className="inline-flex min-w-0 items-center gap-1.5">
+              <SiteFavicon
+                faviconUrl={latest.faviconUrl}
+                domain={latest.domain}
+                title={info}
+                className="shrink-0"
+              />
+              <span className="min-w-0 max-w-[280px] truncate text-[var(--content-default)]">
+                {info}
+              </span>
             </span>
           ) : (
             <span className="min-w-0 max-w-[280px] truncate text-[var(--content-default)]">

--- a/apps/web/src/domains/chat/components/web-search/site-favicon.test.tsx
+++ b/apps/web/src/domains/chat/components/web-search/site-favicon.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * Tests for the chrome-less `SiteFavicon` primitive.
+ *
+ * Uses react-testing-library + bun:test so we can fire a real `error` event on
+ * the `<img>` to exercise the `useState`-driven monogram fallback. Mirrors the
+ * FaviconChip test style — no jest-dom matchers, just className / DOM assertions.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { SiteFavicon } from "@/domains/chat/components/web-search/site-favicon";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SiteFavicon", () => {
+  test("renders an <img> with the supplied faviconUrl", () => {
+    const { container } = render(
+      <SiteFavicon
+        faviconUrl="https://example.com/favicon.ico"
+        domain="example.com"
+        title="Example"
+      />,
+    );
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute("src")).toBe("https://example.com/favicon.ico");
+    expect(img!.getAttribute("loading")).toBe("lazy");
+    expect(img!.getAttribute("referrerpolicy")).toBe("no-referrer");
+  });
+
+  test("renders the monogram (first letter of domain) when faviconUrl is absent", () => {
+    const { container, getByText } = render(
+      <SiteFavicon domain="example.com" title="Some Article" />,
+    );
+    expect(container.querySelector("img")).toBeNull();
+    expect(getByText("E")).toBeTruthy();
+  });
+
+  test("falls back to the first letter of title when domain is omitted", () => {
+    const { getByText } = render(<SiteFavicon title="zenith report" />);
+    expect(getByText("Z")).toBeTruthy();
+  });
+
+  test("swaps the <img> for the monogram when onError fires", () => {
+    const { container, getByText, queryByText } = render(
+      <SiteFavicon
+        faviconUrl="https://example.com/favicon.ico"
+        domain="example.com"
+        title="Example"
+      />,
+    );
+    expect(queryByText("E")).toBeNull();
+    fireEvent.error(container.querySelector("img")!);
+    expect(container.querySelector("img")).toBeNull();
+    expect(getByText("E")).toBeTruthy();
+  });
+
+  test("merges a supplied className onto the outer span", () => {
+    const { getByTestId } = render(
+      <SiteFavicon title="Example" className="shrink-0" />,
+    );
+    expect(getByTestId("site-favicon").className).toContain("shrink-0");
+  });
+});

--- a/apps/web/src/domains/chat/components/web-search/site-favicon.tsx
+++ b/apps/web/src/domains/chat/components/web-search/site-favicon.tsx
@@ -1,0 +1,72 @@
+/**
+ * Chrome-less 14×14 site favicon with a monogram fallback.
+ *
+ * Renders the bare favicon `<img>` (no pill / surface chrome) so callers that
+ * already supply their own container — e.g. the settled web-search header,
+ * which sits a favicon immediately left of the page title — can drop it inline
+ * without inheriting the {@link FaviconChip} pill geometry. On a missing or
+ * failed favicon it falls back to the uppercased first letter of `domain`
+ * (then `title`) as a monogram, mirroring the favicon+fallback pattern used by
+ * `tool-step-pill`'s `PillFavicon` and `web-search-step-row`'s
+ * `OverflowSourceLink`.
+ */
+
+import { useEffect, useState } from "react";
+
+import { cn } from "@/utils/misc";
+
+interface SiteFaviconProps {
+  /** Site favicon URL; falls back to a monogram on absence / load error. */
+  faviconUrl?: string;
+  /** Site domain — supplies the monogram fallback letter. */
+  domain?: string;
+  /** Page title — monogram source when `domain` is empty. */
+  title: string;
+  /** Extra classes merged onto the outer span. */
+  className?: string;
+}
+
+export function SiteFavicon({
+  faviconUrl,
+  domain,
+  title,
+  className,
+}: SiteFaviconProps) {
+  const [imageFailed, setImageFailed] = useState(false);
+  // Reset the failed flag when the URL changes so a swapped favicon re-attempts
+  // loading rather than staying stuck on the monogram.
+  useEffect(() => {
+    setImageFailed(false);
+  }, [faviconUrl]);
+
+  const hasFavicon = Boolean(faviconUrl) && !imageFailed;
+  const source = domain && domain.length > 0 ? domain : title;
+  const letter = source.charAt(0).toUpperCase();
+
+  return (
+    <span
+      aria-hidden="true"
+      data-testid="site-favicon"
+      className={cn(
+        "inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center overflow-hidden rounded-[var(--radius-sm)]",
+        className,
+      )}
+    >
+      {hasFavicon ? (
+        <img
+          src={faviconUrl}
+          alt=""
+          loading="lazy"
+          referrerPolicy="no-referrer"
+          className="h-full w-full object-contain"
+          onError={() => setImageFailed(true)}
+        />
+      ) : (
+        // typography: off-scale — 10px monogram inside the 14px favicon slot
+        <span className="text-[10px] font-medium leading-none text-[var(--content-tertiary)]">
+          {letter}
+        </span>
+      )}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a chrome-less `SiteFavicon` component (favicon img + monogram fallback) and render it before the latest page title in the settled web-search header, derived from `carouselItems.at(-1)`.

Part of plan: web-search-ui.md (PR 3 of 4)