### PR TITLE
Fix web search activity UI inconsistencies

### DIFF
--- a/apps/web/src/domains/chat/components/single-activity/single-activity.test.tsx
+++ b/apps/web/src/domains/chat/components/single-activity/single-activity.test.tsx
@@ -338,8 +338,56 @@ describe("SingleActivity — web variant", () => {
     expect(container.querySelector(".h-\\[28px\\]")).toBeNull();
   });
 
-  test("shows the static info text when carouselItems is empty", () => {
-    const { getByText, container } = render(
+  test("renders the latest page's favicon (or monogram) beside the settled title", () => {
+    const { getByTestId, getByText } = render(
+      <SingleActivity
+        variant="web"
+        info="Visit Toronto — Official Tourism"
+        carouselItems={RESULTS}
+        state="complete"
+        step={WEB_STEP}
+        expanded={false}
+        onExpandChange={() => {}}
+      />,
+    );
+    // The favicon for the LAST result (carouselItems.at(-1)) sits beside the
+    // title. RESULTS' last item has no faviconUrl, so the monogram of its
+    // domain ("destinationtoronto.com" → "D") renders inside the slot.
+    const slot = getByTestId("site-favicon");
+    expect(slot).toBeTruthy();
+    expect(slot.textContent).toBe("D");
+    expect(getByText("Visit Toronto — Official Tourism")).toBeTruthy();
+  });
+
+  test("renders the favicon <img> when the latest result has a faviconUrl", () => {
+    const withFavicon: WebSearchResultItem[] = [
+      makeResult({
+        rank: 1,
+        title: "Toronto Travel",
+        domain: "destinationtoronto.com",
+        faviconUrl: "https://destinationtoronto.com/favicon.ico",
+      }),
+    ];
+    const { container } = render(
+      <SingleActivity
+        variant="web"
+        info="Toronto Travel"
+        carouselItems={withFavicon}
+        state="complete"
+        step={WEB_STEP}
+        expanded={false}
+        onExpandChange={() => {}}
+      />,
+    );
+    const img = container.querySelector('[data-testid="site-favicon"] img');
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute("src")).toBe(
+      "https://destinationtoronto.com/favicon.ico",
+    );
+  });
+
+  test("shows the static info text (no favicon) when carouselItems is empty", () => {
+    const { getByText, queryByTestId, container } = render(
       <SingleActivity
         variant="web"
         info="en.wikipedia.org"
@@ -351,6 +399,8 @@ describe("SingleActivity — web variant", () => {
       />,
     );
     expect(getByText("en.wikipedia.org")).toBeTruthy();
+    // No latest result → no favicon rendered next to the title.
+    expect(queryByTestId("site-favicon")).toBeNull();
     // No carousel ticker wrapper when there are no items.
     expect(container.querySelector(".h-\\[28px\\]")).toBeNull();
   });

--- a/apps/web/src/domains/chat/components/single-activity/single-activity.test.tsx
+++ b/apps/web/src/domains/chat/components/single-activity/single-activity.test.tsx
@@ -296,6 +296,11 @@ describe("SingleActivity — web variant", () => {
     );
     expect(getByTestId("inline-web-link")).toBeTruthy();
     expect(getByText("Web Search")).toBeTruthy();
+    // The flex-col wrapper uses items-start so the header button hugs its
+    // content width rather than stretching to fill the row.
+    expect(getByTestId("inline-web-link").parentElement?.className).toContain(
+      "items-start",
+    );
   });
 
   test("rotates the WebsiteCarousel in the info slot while loading", () => {

--- a/apps/web/src/domains/chat/components/single-activity/single-activity.tsx
+++ b/apps/web/src/domains/chat/components/single-activity/single-activity.tsx
@@ -125,7 +125,7 @@ export function SingleActivity(props: SingleActivityProps) {
     const isError = state === "error";
     const ExpandChevron = expanded ? ChevronUp : ChevronDown;
     return (
-      <div className="flex flex-col">
+      <div className="flex flex-col items-start">
         <button
           type="button"
           data-testid="inline-web-link"

--- a/apps/web/src/domains/chat/components/single-activity/single-activity.tsx
+++ b/apps/web/src/domains/chat/components/single-activity/single-activity.tsx
@@ -55,6 +55,7 @@ import {
   WebSearchStepRow,
 } from "@/domains/chat/components/web-search/web-search-step-row";
 import { WebsiteCarousel } from "@/domains/chat/components/web-search/website-carousel";
+import { SiteFavicon } from "@/domains/chat/components/web-search/site-favicon";
 import { useViewerStore } from "@/stores/viewer-store";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { WebSearchResultItem } from "@/assistant/web-activity-types";
@@ -121,8 +122,12 @@ export function SingleActivity(props: SingleActivityProps) {
   );
 
   if (props.variant === "web") {
-    const { info, state, step, expanded, onExpandChange } = props;
+    const { info, carouselItems, state, step, expanded, onExpandChange } =
+      props;
     const isError = state === "error";
+    // The settled header shows the LAST result's title (`info`); pull the
+    // matching result so we can render its favicon immediately left of it.
+    const latest = carouselItems.at(-1);
     const ExpandChevron = expanded ? ChevronUp : ChevronDown;
     return (
       <div className="flex flex-col items-start">
@@ -166,6 +171,19 @@ export function SingleActivity(props: SingleActivityProps) {
           {state === "loading" && carouselNode ? (
             <span className="inline-flex w-[220px] min-w-0 items-center">
               {carouselNode}
+            </span>
+          ) : latest &&
+            (latest.faviconUrl || latest.domain || latest.title) ? (
+            <span className="inline-flex min-w-0 items-center gap-1.5">
+              <SiteFavicon
+                faviconUrl={latest.faviconUrl}
+                domain={latest.domain}
+                title={info}
+                className="shrink-0"
+              />
+              <span className="min-w-0 max-w-[280px] truncate text-[var(--content-default)]">
+                {info}
+              </span>
             </span>
           ) : (
             <span className="min-w-0 max-w-[280px] truncate text-[var(--content-default)]">

--- a/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.stories.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.stories.tsx
@@ -141,6 +141,45 @@ export const Web: Story = {
   },
 };
 
+/**
+ * Several web pills laid out the way `WebSearchStepRow` renders them — a
+ * `flex flex-wrap` row. The 240px per-pill cap (with truncation) lets 2–3
+ * pills sit on each row instead of one-per-row even with long page titles.
+ */
+export const WebResults: Story = {
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () => (
+    <div className="flex max-w-[600px] flex-wrap gap-1">
+      <ToolStepPill
+        variant="web"
+        label="Toronto - Wikipedia, the free encyclopedia"
+        url="https://en.wikipedia.org/wiki/Toronto"
+        domain="en.wikipedia.org"
+      />
+      <ToolStepPill
+        variant="web"
+        label="Toronto travel guide: the best things to do in the city"
+        url="https://www.timeout.com/toronto"
+        domain="timeout.com"
+      />
+      <ToolStepPill
+        variant="web"
+        label="Visit Toronto — official tourism site for the city of Toronto"
+        url="https://www.destinationtoronto.com"
+        domain="destinationtoronto.com"
+      />
+      <ToolStepPill
+        variant="web"
+        label="Weather in Toronto — 7 day forecast and conditions"
+        url="https://weather.gc.ca/city/pages/on-143_metric_e.html"
+        domain="weather.gc.ca"
+      />
+    </div>
+  ),
+};
+
 export const AllVariants: Story = {
   parameters: {
     controls: { disable: true },

--- a/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.tsx
+++ b/apps/web/src/domains/chat/components/tool-progress-card/tool-step-pill.tsx
@@ -80,7 +80,7 @@ export type ToolStepPillProps = ToolStepPillToolProps | ToolStepPillWebProps;
  * enough that descenders ("g", "p", "y") get clipped without extra leading.
  */
 const BASE_CLASSES =
-  "inline-flex min-w-0 max-w-full items-center gap-1 self-start rounded-full px-2 py-1 text-left leading-normal";
+  "inline-flex min-w-0 items-center gap-1 self-start rounded-full px-2 py-1 text-left leading-normal";
 
 /** Cursor / transition / focus-ring affordances when the pill is a button. */
 const INTERACTIVE_BASE =
@@ -152,7 +152,7 @@ function WebStepPill({
       data-testid="tool-step-pill"
       data-variant="web"
       aria-label={ariaLabel ?? `Open ${label}`}
-      className={`${BASE_CLASSES} ${INTERACTIVE_BASE} no-underline hover:bg-[var(--surface-active)] ${idleColorClasses(tone)}`}
+      className={`${BASE_CLASSES} ${INTERACTIVE_BASE} max-w-[240px] no-underline hover:bg-[var(--surface-active)] ${idleColorClasses(tone)}`}
     >
       <PillFavicon faviconUrl={faviconUrl} domain={domain} label={label} />
       <Typography
@@ -242,7 +242,7 @@ export function ToolStepPill(props: ToolStepPillProps) {
           aria-label={ariaLabel ?? `View details: ${label}`}
           onClick={onClick}
           onKeyDown={handleKeyDown}
-          className={`${BASE_CLASSES} ${INTERACTIVE_BASE} ${hoverClass} ${colorClasses}`}
+          className={`${BASE_CLASSES} ${INTERACTIVE_BASE} max-w-full ${hoverClass} ${colorClasses}`}
         >
           {labelContent}
           <RiskBadge level={riskLevel} onClick={onRiskBadgeClick} />
@@ -258,7 +258,7 @@ export function ToolStepPill(props: ToolStepPillProps) {
         aria-pressed={active}
         aria-label={ariaLabel ?? `View details: ${label}`}
         onClick={onClick}
-        className={`${BASE_CLASSES} ${INTERACTIVE_BASE} ${hoverClass} ${colorClasses}`}
+        className={`${BASE_CLASSES} ${INTERACTIVE_BASE} max-w-full ${hoverClass} ${colorClasses}`}
       >
         {labelContent}
         <RiskBadge level={riskLevel} />
@@ -269,7 +269,7 @@ export function ToolStepPill(props: ToolStepPillProps) {
   return (
     <span
       data-testid="tool-step-pill"
-      className={`${BASE_CLASSES} ${colorClasses}`}
+      className={`${BASE_CLASSES} max-w-full ${colorClasses}`}
     >
       {labelContent}
       <RiskBadge level={riskLevel} />

--- a/apps/web/src/domains/chat/components/web-search/site-favicon.test.tsx
+++ b/apps/web/src/domains/chat/components/web-search/site-favicon.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * Tests for the chrome-less `SiteFavicon` primitive.
+ *
+ * Uses react-testing-library + bun:test so we can fire a real `error` event on
+ * the `<img>` to exercise the `useState`-driven monogram fallback. Mirrors the
+ * FaviconChip test style — no jest-dom matchers, just className / DOM assertions.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { SiteFavicon } from "@/domains/chat/components/web-search/site-favicon";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SiteFavicon", () => {
+  test("renders an <img> with the supplied faviconUrl", () => {
+    const { container } = render(
+      <SiteFavicon
+        faviconUrl="https://example.com/favicon.ico"
+        domain="example.com"
+        title="Example"
+      />,
+    );
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute("src")).toBe("https://example.com/favicon.ico");
+    expect(img!.getAttribute("loading")).toBe("lazy");
+    expect(img!.getAttribute("referrerpolicy")).toBe("no-referrer");
+  });
+
+  test("renders the monogram (first letter of domain) when faviconUrl is absent", () => {
+    const { container, getByText } = render(
+      <SiteFavicon domain="example.com" title="Some Article" />,
+    );
+    expect(container.querySelector("img")).toBeNull();
+    expect(getByText("E")).toBeTruthy();
+  });
+
+  test("falls back to the first letter of title when domain is omitted", () => {
+    const { getByText } = render(<SiteFavicon title="zenith report" />);
+    expect(getByText("Z")).toBeTruthy();
+  });
+
+  test("swaps the <img> for the monogram when onError fires", () => {
+    const { container, getByText, queryByText } = render(
+      <SiteFavicon
+        faviconUrl="https://example.com/favicon.ico"
+        domain="example.com"
+        title="Example"
+      />,
+    );
+    expect(queryByText("E")).toBeNull();
+    fireEvent.error(container.querySelector("img")!);
+    expect(container.querySelector("img")).toBeNull();
+    expect(getByText("E")).toBeTruthy();
+  });
+
+  test("merges a supplied className onto the outer span", () => {
+    const { getByTestId } = render(
+      <SiteFavicon title="Example" className="shrink-0" />,
+    );
+    expect(getByTestId("site-favicon").className).toContain("shrink-0");
+  });
+});

--- a/apps/web/src/domains/chat/components/web-search/site-favicon.tsx
+++ b/apps/web/src/domains/chat/components/web-search/site-favicon.tsx
@@ -1,0 +1,72 @@
+/**
+ * Chrome-less 14×14 site favicon with a monogram fallback.
+ *
+ * Renders the bare favicon `<img>` (no pill / surface chrome) so callers that
+ * already supply their own container — e.g. the settled web-search header,
+ * which sits a favicon immediately left of the page title — can drop it inline
+ * without inheriting the {@link FaviconChip} pill geometry. On a missing or
+ * failed favicon it falls back to the uppercased first letter of `domain`
+ * (then `title`) as a monogram, mirroring the favicon+fallback pattern used by
+ * `tool-step-pill`'s `PillFavicon` and `web-search-step-row`'s
+ * `OverflowSourceLink`.
+ */
+
+import { useEffect, useState } from "react";
+
+import { cn } from "@/utils/misc";
+
+interface SiteFaviconProps {
+  /** Site favicon URL; falls back to a monogram on absence / load error. */
+  faviconUrl?: string;
+  /** Site domain — supplies the monogram fallback letter. */
+  domain?: string;
+  /** Page title — monogram source when `domain` is empty. */
+  title: string;
+  /** Extra classes merged onto the outer span. */
+  className?: string;
+}
+
+export function SiteFavicon({
+  faviconUrl,
+  domain,
+  title,
+  className,
+}: SiteFaviconProps) {
+  const [imageFailed, setImageFailed] = useState(false);
+  // Reset the failed flag when the URL changes so a swapped favicon re-attempts
+  // loading rather than staying stuck on the monogram.
+  useEffect(() => {
+    setImageFailed(false);
+  }, [faviconUrl]);
+
+  const hasFavicon = Boolean(faviconUrl) && !imageFailed;
+  const source = domain && domain.length > 0 ? domain : title;
+  const letter = source.charAt(0).toUpperCase();
+
+  return (
+    <span
+      aria-hidden="true"
+      data-testid="site-favicon"
+      className={cn(
+        "inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center overflow-hidden rounded-[var(--radius-sm)]",
+        className,
+      )}
+    >
+      {hasFavicon ? (
+        <img
+          src={faviconUrl}
+          alt=""
+          loading="lazy"
+          referrerPolicy="no-referrer"
+          className="h-full w-full object-contain"
+          onError={() => setImageFailed(true)}
+        />
+      ) : (
+        // typography: off-scale — 10px monogram inside the 14px favicon slot
+        <span className="text-[10px] font-medium leading-none text-[var(--content-tertiary)]">
+          {letter}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/apps/web/src/domains/chat/components/web-search/website-carousel.test.tsx
+++ b/apps/web/src/domains/chat/components/web-search/website-carousel.test.tsx
@@ -2,9 +2,11 @@
  * Tests for `WebsiteCarousel`.
  *
  * bun:test doesn't ship a `vi.useFakeTimers()` equivalent, so we drive the
- * carousel's `setInterval` manually by monkey-patching the global. Each test
- * captures the callback the component registers, then invokes it from `act()`
- * to advance the rotation without real-time delays.
+ * carousel's `setTimeout` manually by monkey-patching the global. Each timeout
+ * the component schedules is captured, then fired from `act()` to advance the
+ * walk without real-time delays. This lets us assert that an advance only
+ * happens once the `minDwellMs` timeout fires (the 0.5s floor) and that the
+ * carousel walks toward the latest item and then holds — never wrapping back.
  *
  * The reduced-motion path is verified by stubbing `motion/react` so that
  * `useReducedMotion()` returns `true` and `motion.div` resolves to a plain
@@ -20,63 +22,74 @@ import { cleanup, render } from "@testing-library/react";
 import { WebsiteCarousel } from "@/domains/chat/components/web-search/website-carousel";
 
 // ---------------------------------------------------------------------------
-// setInterval harness
+// setTimeout harness
 // ---------------------------------------------------------------------------
 
-interface IntervalHandle {
+interface TimeoutHandle {
   id: number;
   fn: () => void;
   ms: number;
   cleared: boolean;
 }
 
-let intervals: IntervalHandle[] = [];
-let nextIntervalId = 1;
-let setIntervalCallCount = 0;
-let originalSetInterval: typeof globalThis.setInterval;
-let originalClearInterval: typeof globalThis.clearInterval;
+let timeouts: TimeoutHandle[] = [];
+let nextTimeoutId = 1;
+let setTimeoutCallCount = 0;
+let originalSetTimeout: typeof globalThis.setTimeout;
+let originalClearTimeout: typeof globalThis.clearTimeout;
 
 beforeEach(() => {
-  intervals = [];
-  nextIntervalId = 1;
-  setIntervalCallCount = 0;
-  originalSetInterval = globalThis.setInterval;
-  originalClearInterval = globalThis.clearInterval;
-  globalThis.setInterval = ((
+  timeouts = [];
+  nextTimeoutId = 1;
+  setTimeoutCallCount = 0;
+  originalSetTimeout = globalThis.setTimeout;
+  originalClearTimeout = globalThis.clearTimeout;
+  globalThis.setTimeout = ((
     fn: (...args: unknown[]) => void,
     ms?: number,
   ) => {
-    setIntervalCallCount += 1;
-    const handle: IntervalHandle = {
-      id: nextIntervalId++,
+    setTimeoutCallCount += 1;
+    const handle: TimeoutHandle = {
+      id: nextTimeoutId++,
       fn: () => fn(),
       ms: ms ?? 0,
       cleared: false,
     };
-    intervals.push(handle);
-    return handle.id as unknown as ReturnType<typeof globalThis.setInterval>;
-  }) as typeof globalThis.setInterval;
-  globalThis.clearInterval = ((id: number) => {
-    const handle = intervals.find((h) => h.id === id);
+    timeouts.push(handle);
+    return handle.id as unknown as ReturnType<typeof globalThis.setTimeout>;
+  }) as typeof globalThis.setTimeout;
+  globalThis.clearTimeout = ((id?: number) => {
+    const handle = timeouts.find((h) => h.id === id);
     if (handle) handle.cleared = true;
-  }) as typeof globalThis.clearInterval;
+  }) as typeof globalThis.clearTimeout;
 });
 
 afterEach(() => {
-  globalThis.setInterval = originalSetInterval;
-  globalThis.clearInterval = originalClearInterval;
+  globalThis.setTimeout = originalSetTimeout;
+  globalThis.clearTimeout = originalClearTimeout;
   cleanup();
 });
 
-/** Fire every pending (non-cleared) interval one tick. */
-function advanceOneTick() {
-  for (const handle of intervals) {
+/**
+ * Fire every currently-pending (non-cleared) timeout once. The component
+ * schedules at most one timeout per render, so this advances the walk by a
+ * single step. After firing, the timeout is marked cleared so it isn't
+ * re-fired on the next call.
+ */
+function fireDwellTimer() {
+  for (const handle of timeouts) {
     if (!handle.cleared) {
+      handle.cleared = true;
       act(() => {
         handle.fn();
       });
     }
   }
+}
+
+/** Count of timeouts that are still pending (scheduled and not yet fired/cleared). */
+function pendingTimeouts() {
+  return timeouts.filter((h) => !h.cleared);
 }
 
 // ---------------------------------------------------------------------------
@@ -89,63 +102,94 @@ const ITEMS = [
   { faviconUrl: "https://c.test/favicon.ico", title: "Charlie", domain: "c.test" },
 ];
 
-describe("WebsiteCarousel — rotation", () => {
-  test("advances to the next item after the interval fires", () => {
+describe("WebsiteCarousel — walk to latest", () => {
+  test("advances one step per dwell tick toward the last item, then holds", () => {
     const { getByText } = render(
-      <WebsiteCarousel items={ITEMS} intervalMs={1000} />,
+      <WebsiteCarousel items={ITEMS} minDwellMs={1000} />,
     );
     // Initial frame shows the first item.
     expect(getByText("Alpha")).toBeTruthy();
-    // After one interval tick → second item visible.
-    advanceOneTick();
+    // After one dwell tick → second item visible.
+    fireDwellTimer();
     expect(getByText("Bravo")).toBeTruthy();
-    // After two ticks → third item visible (interval * 2 worth of progress).
+    // After another tick → the last (latest) item is visible.
     // Note: `AnimatePresence mode="popLayout"` retains the previous element
     // during its exit animation, so we only assert that the new entry is in
     // the tree — the old one may still be there mid-fade.
-    advanceOneTick();
+    fireDwellTimer();
+    expect(getByText("Charlie")).toBeTruthy();
+    // Once caught up to the latest, the walk holds: no further timer is
+    // scheduled, and it does NOT wrap back to the first item.
+    expect(pendingTimeouts()).toHaveLength(0);
     expect(getByText("Charlie")).toBeTruthy();
   });
 
-  test("wraps back to the first item after the last", () => {
+  test("does not advance before the dwell timeout fires (honours the floor)", () => {
     const { getByText } = render(
-      <WebsiteCarousel items={ITEMS} intervalMs={500} />,
+      <WebsiteCarousel items={ITEMS} minDwellMs={500} />,
     );
-    advanceOneTick(); // Bravo
-    advanceOneTick(); // Charlie
-    advanceOneTick(); // Alpha again
+    // A timer is scheduled but not yet fired — still on the first item.
     expect(getByText("Alpha")).toBeTruthy();
+    expect(pendingTimeouts()).toHaveLength(1);
+    expect(pendingTimeouts()[0]!.ms).toBe(500);
   });
 
-  test("uses the supplied intervalMs when scheduling", () => {
-    render(<WebsiteCarousel items={ITEMS} intervalMs={1234} />);
-    expect(intervals).toHaveLength(1);
-    expect(intervals[0]!.ms).toBe(1234);
+  test("resumes the walk when a newer item is appended", () => {
+    const { getByText, rerender } = render(
+      <WebsiteCarousel items={ITEMS} minDwellMs={500} />,
+    );
+    // Walk to the current latest item.
+    fireDwellTimer(); // Bravo
+    fireDwellTimer(); // Charlie
+    expect(getByText("Charlie")).toBeTruthy();
+    expect(pendingTimeouts()).toHaveLength(0);
+
+    // Parent appends a newer searched site — the target grows and the walk
+    // resumes toward it.
+    const moreItems = [
+      ...ITEMS,
+      {
+        faviconUrl: "https://d.test/favicon.ico",
+        title: "Delta",
+        domain: "d.test",
+      },
+    ];
+    rerender(<WebsiteCarousel items={moreItems} minDwellMs={500} />);
+    expect(pendingTimeouts()).toHaveLength(1);
+    fireDwellTimer();
+    expect(getByText("Delta")).toBeTruthy();
+    expect(pendingTimeouts()).toHaveLength(0);
+  });
+
+  test("defaults minDwellMs to 500", () => {
+    render(<WebsiteCarousel items={ITEMS} />);
+    expect(pendingTimeouts()).toHaveLength(1);
+    expect(pendingTimeouts()[0]!.ms).toBe(500);
   });
 });
 
 describe("WebsiteCarousel — degenerate cases", () => {
-  test("with one item: renders it statically and never schedules an interval", () => {
+  test("with one item: renders it statically and never schedules a timer", () => {
     const { getByText } = render(
-      <WebsiteCarousel items={[ITEMS[0]!]} intervalMs={500} />,
+      <WebsiteCarousel items={[ITEMS[0]!]} minDwellMs={500} />,
     );
     expect(getByText("Alpha")).toBeTruthy();
-    expect(setIntervalCallCount).toBe(0);
+    expect(setTimeoutCallCount).toBe(0);
   });
 
-  test("with zero items: renders nothing and never schedules an interval", () => {
+  test("with zero items: renders nothing and never schedules a timer", () => {
     const { container } = render(<WebsiteCarousel items={[]} />);
     expect(container.firstChild).toBeNull();
-    expect(setIntervalCallCount).toBe(0);
+    expect(setTimeoutCallCount).toBe(0);
   });
 
-  test("clears its interval on unmount", () => {
+  test("clears its pending timer on unmount", () => {
     const { unmount } = render(
-      <WebsiteCarousel items={ITEMS} intervalMs={500} />,
+      <WebsiteCarousel items={ITEMS} minDwellMs={500} />,
     );
-    expect(intervals).toHaveLength(1);
+    expect(pendingTimeouts()).toHaveLength(1);
     unmount();
-    expect(intervals[0]!.cleared).toBe(true);
+    expect(pendingTimeouts()).toHaveLength(0);
   });
 });
 
@@ -215,7 +259,7 @@ describe("WebsiteCarousel — reduced motion", () => {
     const { WebsiteCarousel: PatchedCarousel } = await import(
       "./website-carousel"
     );
-    render(<PatchedCarousel items={ITEMS} intervalMs={500} />);
+    render(<PatchedCarousel items={ITEMS} minDwellMs={500} />);
 
     // At least one motion.div should have been rendered.
     expect(motionDivCalls.length).toBeGreaterThan(0);

--- a/apps/web/src/domains/chat/components/web-search/website-carousel.tsx
+++ b/apps/web/src/domains/chat/components/web-search/website-carousel.tsx
@@ -19,14 +19,24 @@ export interface WebsiteCarouselItem {
 
 export interface WebsiteCarouselProps {
   items: WebsiteCarouselItem[];
-  /** Time between transitions in ms. Defaults to 2500ms. */
-  intervalMs?: number;
+  /**
+   * Minimum time each site is shown before advancing toward the latest, in ms.
+   * Defaults to 500.
+   */
+  minDwellMs?: number;
 }
 
 /**
- * Top-down rotating ticker that cycles through `items`, sliding each new entry
- * in from above and the previous one out the bottom. Used by the collapsed
- * "Searching the web" header to show the websites currently being searched.
+ * Top-down ticker that walks toward the latest searched site, sliding each new
+ * entry in from above and the previous one out the bottom. Used by the
+ * collapsed "Searching the web" header to show the websites being searched.
+ *
+ * The parent appends a new item as each site is searched, so the most recent
+ * result is always the last entry. Rather than round-robining stale results,
+ * the carousel advances `currentIndex` forward one step at a time toward
+ * `items.length - 1` and then holds there. Every step is gated by a
+ * `setTimeout(…, minDwellMs)` so each intermediate site is shown for at least
+ * `minDwellMs` and rapid bursts of new results don't flash by.
  *
  * Mirrors the motion vocabulary used by `surfaces/card-surface.tsx`
  * (`InProgressDetail`) — `AnimatePresence` with `mode="popLayout"`, a per-entry
@@ -37,26 +47,32 @@ export interface WebsiteCarouselProps {
  *
  * Edge cases:
  * - 0 items → renders nothing.
- * - 1 item → renders that single chip statically, never schedules an interval.
+ * - 1 item → renders that single chip statically, never schedules a timer.
  */
 export function WebsiteCarousel({
   items,
-  intervalMs = 2500,
+  minDwellMs = 500,
 }: WebsiteCarouselProps) {
   const reduce = useReducedMotion();
   const [currentIndex, setCurrentIndex] = useState(0);
 
-  // Schedule the interval only when there's something to rotate through. A
-  // single-item carousel is intentionally static — no timer churn. The
-  // modulo guards against `items.length` shrinking out from under us between
-  // ticks (e.g. when the parent updates the list mid-rotation).
+  // The display target is always the latest item. Clamp to 0 so an empty list
+  // yields a non-negative target.
+  const target = Math.max(items.length - 1, 0);
+
+  // Walk `currentIndex` toward the latest item one step at a time, each step
+  // gated by `minDwellMs` so every intermediate site stays visible long enough.
+  // When the parent appends a newer result `target` grows, this effect re-runs,
+  // and the walk resumes — always converging on (and then holding) the most
+  // recently searched site. Once caught up we hold and schedule nothing.
   useEffect(() => {
-    if (items.length <= 1) return;
-    const id = setInterval(() => {
-      setCurrentIndex((prev) => (prev + 1) % items.length);
-    }, intervalMs);
-    return () => clearInterval(id);
-  }, [items.length, intervalMs]);
+    if (currentIndex >= target) return;
+    const id = setTimeout(
+      () => setCurrentIndex((i) => Math.min(i + 1, target)),
+      minDwellMs,
+    );
+    return () => clearTimeout(id);
+  }, [currentIndex, target, minDwellMs]);
 
   if (items.length === 0) return null;
 
@@ -67,7 +83,7 @@ export function WebsiteCarousel({
   const animate = reduce ? { opacity: 1 } : { y: 0, opacity: 1 };
   const exit = reduce ? { opacity: 0 } : { y: 28, opacity: 0 };
 
-  // Single-item branch: no AnimatePresence, no interval — render the chip
+  // Single-item branch: no AnimatePresence, no timer — render the chip
   // directly so the wrapper still has the same height for layout stability.
   if (items.length === 1) {
     const item = items[0]!;
@@ -84,7 +100,8 @@ export function WebsiteCarousel({
     );
   }
 
-  const safeIndex = currentIndex % items.length;
+  // Clamp to the latest item so a shrinking list can't index out of bounds.
+  const safeIndex = Math.min(currentIndex, target);
   const current = items[safeIndex]!;
   // Compose a stable per-cycle key from domain/title plus the index so back-to-
   // back duplicates still trigger the slide animation.


### PR DESCRIPTION
## Summary
Polish the inline web-search activity with four small fixes:
- **Header width** (#34459): the "Web Search | …" header no longer stretches full width; its hover highlight hugs the content.
- **Pill width** (#34460): web result pills are capped at 240px so 2–3 fit per row instead of one-per-row.
- **Carousel timing** (#34461): the streaming header carousel walks forward to the latest searched site (holding each ≥0.5s) instead of round-robining old results.
- **Header favicon** (#34462): the settled header shows the latest page's favicon before its title, with a monogram fallback.

## Self-review result
Skipped per request (per-PR review gates and final self-review both skipped).

## PRs merged into feature branch
- #34459: fix(web): web-search header hugs its content instead of full width
- #34460: fix(web): cap web-search result pill width so multiple fit per row
- #34461: fix(web): web-search carousel walks to the latest searched site with a 0.5s dwell
- #34462: feat(web): show the site favicon in the settled web-search header

Part of plan: web-search-ui.md