### PR TITLE
fix(onboarding): bottom-pin prechat footer buttons on Electron

### DIFF
--- a/apps/web/src/domains/onboarding/screens/google-connect-screen.tsx
+++ b/apps/web/src/domains/onboarding/screens/google-connect-screen.tsx
@@ -375,7 +375,7 @@ export function GoogleConnectScreen({
 
   return (
     <OnboardingLayout showCreatureFooter={false}>
-      <div className={`mx-auto flex w-full max-w-md flex-col items-center ${electron ? "min-h-full px-8 pt-7 pb-4 electron-prechat-type" : "px-6 pt-12 pb-40"} text-[var(--content-default)]`}>
+      <div className={`mx-auto flex w-full max-w-md flex-col items-center ${electron ? "min-h-full px-8 pt-11 pb-4 electron-prechat-type" : "px-6 pt-12 pb-40"} text-[var(--content-default)]`}>
         <div
           className="grid w-full grid-cols-[auto_1fr_auto] items-center"
           style={{ animation: "fadeInUp 0.3s ease-out 0.1s both" }}

--- a/apps/web/src/domains/onboarding/screens/google-connect-screen.tsx
+++ b/apps/web/src/domains/onboarding/screens/google-connect-screen.tsx
@@ -375,7 +375,7 @@ export function GoogleConnectScreen({
 
   return (
     <OnboardingLayout showCreatureFooter={false}>
-      <div className={`mx-auto flex w-full max-w-md flex-col items-center ${electron ? "px-8 pt-7 pb-4 electron-prechat-type" : "px-6 pt-12 pb-40"} text-[var(--content-default)]`}>
+      <div className={`mx-auto flex w-full max-w-md flex-col items-center ${electron ? "min-h-full px-8 pt-7 pb-4 electron-prechat-type" : "px-6 pt-12 pb-40"} text-[var(--content-default)]`}>
         <div
           className="grid w-full grid-cols-[auto_1fr_auto] items-center"
           style={{ animation: "fadeInUp 0.3s ease-out 0.1s both" }}
@@ -433,7 +433,7 @@ export function GoogleConnectScreen({
         </p>
 
         <div
-          className="mt-8 flex w-full flex-col gap-2"
+          className={`${electron ? "mt-auto" : "mt-8"} flex w-full flex-col gap-2`}
           style={{ animation: "fadeInUp 0.3s ease-out 0.35s both" }}
         >
           <Button

--- a/apps/web/src/domains/onboarding/screens/name-exchange-screen.tsx
+++ b/apps/web/src/domains/onboarding/screens/name-exchange-screen.tsx
@@ -39,7 +39,7 @@ export function NameExchangeScreen({
   return (
     <OnboardingLayout showCreatureFooter={false}>
       <div
-        className={`mx-auto flex w-full max-w-md flex-col items-center ${electron ? "px-8 pt-11 pb-4 electron-prechat-type" : "px-6 pt-12 pb-40"} text-[var(--content-default)]`}
+        className={`mx-auto flex w-full max-w-md flex-col items-center ${electron ? "min-h-full px-8 pt-11 pb-4 electron-prechat-type" : "px-6 pt-12 pb-40"} text-[var(--content-default)]`}
       >
         <div
           className={`grid w-full items-center ${onBack ? "grid-cols-[auto_1fr_auto]" : ""}`}
@@ -136,7 +136,7 @@ export function NameExchangeScreen({
         </div>
 
         <div
-          className="mt-8 flex w-full flex-col gap-2"
+          className={`${electron ? "mt-auto" : "mt-8"} flex w-full flex-col gap-2`}
           style={{ animation: "fadeInUp 0.3s ease-out 0.3s both" }}
         >
           <Button

--- a/apps/web/src/domains/onboarding/screens/prior-assistant-selection-screen.tsx
+++ b/apps/web/src/domains/onboarding/screens/prior-assistant-selection-screen.tsx
@@ -94,7 +94,7 @@ export function PriorAssistantSelectionScreen({
 
   return (
     <OnboardingLayout showCreatureFooter={false}>
-      <div className={`mx-auto flex w-full max-w-2xl flex-col items-center ${electron ? "min-h-full px-8 pt-7 pb-4 electron-prechat-type" : "px-6 pt-12 pb-40"} text-[var(--content-default)]`}>
+      <div className={`mx-auto flex w-full max-w-2xl flex-col items-center ${electron ? "min-h-full px-8 pt-11 pb-4 electron-prechat-type" : "px-6 pt-12 pb-40"} text-[var(--content-default)]`}>
         <div
           className="grid w-full items-center grid-cols-[auto_1fr_auto]"
           style={{ animation: "fadeInUp 0.3s ease-out 0.1s both" }}

--- a/apps/web/src/domains/onboarding/screens/prior-assistant-selection-screen.tsx
+++ b/apps/web/src/domains/onboarding/screens/prior-assistant-selection-screen.tsx
@@ -94,7 +94,7 @@ export function PriorAssistantSelectionScreen({
 
   return (
     <OnboardingLayout showCreatureFooter={false}>
-      <div className={`mx-auto flex w-full max-w-2xl flex-col items-center ${electron ? "px-8 pt-7 pb-4 electron-prechat-type" : "px-6 pt-12 pb-40"} text-[var(--content-default)]`}>
+      <div className={`mx-auto flex w-full max-w-2xl flex-col items-center ${electron ? "min-h-full px-8 pt-7 pb-4 electron-prechat-type" : "px-6 pt-12 pb-40"} text-[var(--content-default)]`}>
         <div
           className="grid w-full items-center grid-cols-[auto_1fr_auto]"
           style={{ animation: "fadeInUp 0.3s ease-out 0.1s both" }}
@@ -188,7 +188,7 @@ export function PriorAssistantSelectionScreen({
         ) : null}
 
         <div
-          className={`${electron ? "mt-6" : "mt-8"} flex w-full flex-col gap-2`}
+          className={`${electron ? "mt-auto" : "mt-8"} flex w-full flex-col gap-2`}
           style={{ animation: "fadeInUp 0.3s ease-out 0.3s both" }}
         >
           <Button

--- a/apps/web/src/domains/onboarding/screens/task-tone-selection-screen.tsx
+++ b/apps/web/src/domains/onboarding/screens/task-tone-selection-screen.tsx
@@ -35,7 +35,7 @@ export function TaskToneSelectionScreen({
 
   return (
     <OnboardingLayout showCreatureFooter={false}>
-      <div className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-7 pb-4 electron-prechat-type" : "px-6 pt-12 pb-40"} text-[var(--content-default)]`}>
+      <div className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-11 pb-4 electron-prechat-type" : "px-6 pt-12 pb-40"} text-[var(--content-default)]`}>
         <div
           className="grid w-full grid-cols-[auto_1fr_auto] items-center"
           style={{ animation: "fadeInUp 0.3s ease-out 0.1s both" }}

--- a/apps/web/src/domains/onboarding/screens/task-tone-selection-screen.tsx
+++ b/apps/web/src/domains/onboarding/screens/task-tone-selection-screen.tsx
@@ -35,7 +35,7 @@ export function TaskToneSelectionScreen({
 
   return (
     <OnboardingLayout showCreatureFooter={false}>
-      <div className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "px-8 pt-7 pb-4 electron-prechat-type" : "px-6 pt-12 pb-40"} text-[var(--content-default)]`}>
+      <div className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-7 pb-4 electron-prechat-type" : "px-6 pt-12 pb-40"} text-[var(--content-default)]`}>
         <div
           className="grid w-full grid-cols-[auto_1fr_auto] items-center"
           style={{ animation: "fadeInUp 0.3s ease-out 0.1s both" }}
@@ -110,7 +110,7 @@ export function TaskToneSelectionScreen({
         </div>
 
         <div
-          className={`${electron ? "mt-6" : "mt-8"} flex w-full flex-col gap-2`}
+          className={`${electron ? "mt-auto" : "mt-8"} flex w-full flex-col gap-2`}
           style={{ animation: "fadeInUp 0.3s ease-out 0.3s both" }}
         >
           <Button

--- a/apps/web/src/domains/onboarding/screens/tool-selection-screen.tsx
+++ b/apps/web/src/domains/onboarding/screens/tool-selection-screen.tsx
@@ -94,7 +94,7 @@ export function ToolSelectionScreen({
 
   return (
     <OnboardingLayout showCreatureFooter={false}>
-      <div className={`mx-auto flex w-full max-w-2xl flex-col items-center ${electron ? "min-h-full px-8 pt-7 pb-4 electron-prechat-type" : "px-6 pt-12 pb-40"} text-[var(--content-default)]`}>
+      <div className={`mx-auto flex w-full max-w-2xl flex-col items-center ${electron ? "min-h-full px-8 pt-11 pb-4 electron-prechat-type" : "px-6 pt-12 pb-40"} text-[var(--content-default)]`}>
         <div
           className={`grid w-full items-center ${onBack ? "grid-cols-[auto_1fr_auto]" : ""}`}
           style={{ animation: "fadeInUp 0.3s ease-out 0.1s both" }}

--- a/apps/web/src/domains/onboarding/screens/tool-selection-screen.tsx
+++ b/apps/web/src/domains/onboarding/screens/tool-selection-screen.tsx
@@ -94,7 +94,7 @@ export function ToolSelectionScreen({
 
   return (
     <OnboardingLayout showCreatureFooter={false}>
-      <div className={`mx-auto flex w-full max-w-2xl flex-col items-center ${electron ? "px-8 pt-7 pb-4 electron-prechat-type" : "px-6 pt-12 pb-40"} text-[var(--content-default)]`}>
+      <div className={`mx-auto flex w-full max-w-2xl flex-col items-center ${electron ? "min-h-full px-8 pt-7 pb-4 electron-prechat-type" : "px-6 pt-12 pb-40"} text-[var(--content-default)]`}>
         <div
           className={`grid w-full items-center ${onBack ? "grid-cols-[auto_1fr_auto]" : ""}`}
           style={{ animation: "fadeInUp 0.3s ease-out 0.1s both" }}
@@ -194,7 +194,7 @@ export function ToolSelectionScreen({
         ) : null}
 
         <div
-          className={`${electron ? "mt-6" : "mt-8"} flex w-full flex-col gap-2`}
+          className={`${electron ? "mt-auto" : "mt-8"} flex w-full flex-col gap-2`}
           style={{ animation: "fadeInUp 0.3s ease-out 0.3s both" }}
         >
           <Button


### PR DESCRIPTION
## Summary

Bottom-pins the footer buttons (primary + ghost) on the **Electron** prechat onboarding funnel so they match the native Swift macOS client, which anchors them to the bottom of the window. Before this, the Electron funnel screens laid their footer out top-flowing — directly under the content — so the button placement drifted between the two clients.

## Change

Gated behind the existing `electron` flag (web/iOS are unchanged):

- Add `min-h-full` to each screen's outer column so it fills the scroll container.
- Switch each footer's top margin to `mt-auto`, which absorbs the free space and pins the buttons to the bottom. When content overflows, `mt-auto` collapses and the screen scrolls normally — the same pattern the already-bottom-pinned `vibe-step` / `name-step` screens use.

### Screens touched
- `name-exchange-screen`
- `task-tone-selection-screen`
- `tool-selection-screen`
- `prior-assistant-selection-screen`
- `google-connect-screen`

Left alone: `vibe-step` / `name-step` (already bottom-pinned via a `flex-1` spacer) and the vertically-centered, iOS-only `get-ios-app` screen.

## Test plan

- Pure Tailwind className changes (10 lines); web/iOS branches untouched.
- Merges cleanly into `main` — these files are untouched on main since the branch base.
- Manual: on the Electron app, walk the prechat funnel and confirm the footer buttons sit at the bottom of each step, matching the native client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
