### PR TITLE
fix(web): unify selected-assistant writers and republish activeAssistantId on selection change

### DIFF
--- a/apps/web/src/assistant/lifecycle-service.test.ts
+++ b/apps/web/src/assistant/lifecycle-service.test.ts
@@ -45,12 +45,16 @@ mock.module("@/lib/auth/gateway-session", () => ({
 }));
 
 const isLocalModeMock = mock(() => false);
+const getSelectedAssistantMock = mock(
+  (): { assistantId: string } | undefined => undefined,
+);
+const getLocalGatewayUrlMock = mock((): string | undefined => undefined);
 mock.module("@/lib/local-mode", () => ({
   isLocalMode: isLocalModeMock,
   isLocalAssistant: () => false,
   isPlatformAssistant: () => false,
-  getSelectedAssistant: () => null,
-  getLocalGatewayUrl: () => null,
+  getSelectedAssistant: getSelectedAssistantMock,
+  getLocalGatewayUrl: getLocalGatewayUrlMock,
 }));
 
 // Sentry is a side-effect-only dep here; silence it.
@@ -110,9 +114,20 @@ beforeEach(() => {
   // tests will silently inherit the previous test's stub.
   isGatewayAuthModeMock.mockImplementation(() => false);
   isLocalModeMock.mockImplementation(() => false);
+  getSelectedAssistantMock.mockImplementation(() => undefined);
+  getLocalGatewayUrlMock.mockImplementation(() => undefined);
   getAssistantMock.mockImplementation(async () => ({ ok: false, status: 404 }));
   getAssistantHealthzMock.mockImplementation(async () => ({ ok: true }));
   lifecycleService.__resetForTesting();
+  // Deterministic baseline for the selection subscription's diff. Reset
+  // AFTER __resetForTesting (state is `loading`, gateway mode is false)
+  // so the write itself can't republish.
+  useResolvedAssistantsStore.setState({
+    assistants: [],
+    assistantsHydrated: false,
+    selectedAssistantId: null,
+  });
+  localStorage.removeItem("vellum:selectedAssistantId");
 });
 
 afterEach(() => {
@@ -695,5 +710,145 @@ describe("lifecycleService — reachability probe", () => {
     expect(useAssistantLifecycleStore.getState().assistantState.kind).toBe(
       "loading",
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Selection subscription — gateway-mode republish
+//
+// The service subscribes to the resolved-assistants store's
+// `selectedAssistantId` slice (real store here, so the store action
+// exercises the subscription directly): any selection write while
+// gateway-auth mode is on and the lifecycle is past `loading`
+// re-runs the gateway short-circuit, republishing `activeAssistantId`
+// and the self-hosted connection.
+// ---------------------------------------------------------------------------
+
+describe("lifecycleService — selection subscription", () => {
+  /** Drive the service into the gateway-auth active state. */
+  async function driveGatewayActive(assistantId: string): Promise<void> {
+    isGatewayAuthModeMock.mockImplementation(() => true);
+    getLocalGatewayUrlMock.mockImplementation(
+      () => "/assistant/__gateway/1111",
+    );
+    getSelectedAssistantMock.mockImplementation(() => ({ assistantId }));
+    lifecycleService.setInputs({
+      ...baseInputs,
+      queryClient: makeQueryClient(),
+    });
+    await lifecycleService.respondToInputs();
+    expect(
+      useResolvedAssistantsStore.getState().activeAssistantId,
+    ).toBe(assistantId);
+  }
+
+  test("selection write republishes activeAssistantId and the connection", async () => {
+    await driveGatewayActive("asst-a");
+    getLocalGatewayUrlMock.mockImplementation(
+      () => "/assistant/__gateway/2222",
+    );
+    getSelectedAssistantMock.mockImplementation(() => ({
+      assistantId: "asst-b",
+    }));
+    setSelfHostedConnectionMock.mockClear();
+
+    useResolvedAssistantsStore.getState().setSelectedAssistant("asst-b");
+
+    expect(
+      useResolvedAssistantsStore.getState().activeAssistantId,
+    ).toBe("asst-b");
+    expect(setSelfHostedConnectionMock).toHaveBeenCalledTimes(1);
+    const arg = setSelfHostedConnectionMock.mock.calls[0]![0] as {
+      url: string;
+    };
+    expect(arg.url).toContain("/assistant/__gateway/2222");
+  });
+
+  test("no republish while the lifecycle is still loading", () => {
+    isGatewayAuthModeMock.mockImplementation(() => true);
+
+    useResolvedAssistantsStore.getState().setSelectedAssistant("asst-early");
+
+    expect(
+      useResolvedAssistantsStore.getState().activeAssistantId,
+    ).toBeNull();
+    expect(useAssistantLifecycleStore.getState().assistantState.kind).toBe(
+      "loading",
+    );
+    expect(setSelfHostedConnectionMock).not.toHaveBeenCalled();
+  });
+
+  test("no republish outside gateway-auth mode", async () => {
+    // Drive to active via the platform path.
+    getAssistantMock.mockImplementationOnce(async () => ({
+      ok: true,
+      status: 200,
+      data: {
+        id: "asst-platform",
+        status: "active",
+        is_local: false,
+        maintenance_mode: { enabled: false },
+      },
+    }));
+    lifecycleService.setInputs({
+      ...baseInputs,
+      queryClient: makeQueryClient(),
+    });
+    await lifecycleService.checkAssistant();
+    setSelfHostedConnectionMock.mockClear();
+
+    useResolvedAssistantsStore.getState().setSelectedAssistant("asst-other");
+
+    expect(
+      useResolvedAssistantsStore.getState().activeAssistantId,
+    ).toBe("asst-platform");
+    expect(setSelfHostedConnectionMock).not.toHaveBeenCalled();
+  });
+
+  test("same-id write does not republish", async () => {
+    await driveGatewayActive("asst-a");
+    useResolvedAssistantsStore.getState().setSelectedAssistant("asst-a");
+    setSelfHostedConnectionMock.mockClear();
+
+    useResolvedAssistantsStore.getState().setSelectedAssistant("asst-a");
+
+    expect(setSelfHostedConnectionMock).not.toHaveBeenCalled();
+  });
+
+  test("reconcile-driven clear republishes the fallback assistant", async () => {
+    await driveGatewayActive("asst-gone");
+    useResolvedAssistantsStore.getState().setSelectedAssistant("asst-gone");
+    // After the ghost is reconciled away, the lockfile fallback wins.
+    getSelectedAssistantMock.mockImplementation(() => ({
+      assistantId: "asst-fallback",
+    }));
+
+    // Lockfile load without the selected id → reconcile clears the slice
+    // → subscription republishes from the lockfile fallback.
+    useResolvedAssistantsStore
+      .getState()
+      .setFromLockfile({ assistants: [], activeAssistant: null });
+
+    expect(
+      useResolvedAssistantsStore.getState().selectedAssistantId,
+    ).toBeNull();
+    expect(
+      useResolvedAssistantsStore.getState().activeAssistantId,
+    ).toBe("asst-fallback");
+  });
+
+  test("selection clear after resetForLogout does not resurrect an active state", async () => {
+    await driveGatewayActive("asst-a");
+    useResolvedAssistantsStore.getState().setSelectedAssistant("asst-a");
+
+    lifecycleService.resetForLogout();
+    useResolvedAssistantsStore.getState().setSelectedAssistant(null);
+
+    expect(
+      useResolvedAssistantsStore.getState().activeAssistantId,
+    ).toBeNull();
+    expect(useAssistantLifecycleStore.getState().assistantState).toEqual({
+      kind: "loading",
+    });
   });
 });

--- a/apps/web/src/assistant/lifecycle-service.ts
+++ b/apps/web/src/assistant/lifecycle-service.ts
@@ -103,6 +103,21 @@ class AssistantLifecycleService {
 
   constructor() {
     subscribeAssistantUnreachable(() => this.onUnreachable());
+    // Republish `activeAssistantId` whenever the selection changes, at the
+    // store funnel so every writer (and future ones) is covered — gateway-auth
+    // mode has no other republish path while connected (the React effect's
+    // deps pin the resolved selection to null there). The `loading` guard
+    // keeps the initial publish owned by `respondToInputs` and prevents a
+    // mid-logout clear from resurrecting an active state (`resetForLogout`
+    // runs before the clear). Fires synchronously inside the write, bypassing
+    // the `ready` guard — must not read `this.inputs`. Platform mode is
+    // deliberately not handled here: its resolver-fed effect path already
+    // re-checks, and acting on it would double-fetch with stale inputs.
+    useResolvedAssistantsStore.subscribe((state, prevState) => {
+      if (state.selectedAssistantId === prevState.selectedAssistantId) return;
+      if (!isGatewayAuthMode() || this.state.kind === "loading") return;
+      this.applyGatewayAuthShortCircuit();
+    });
   }
 
   // ---------------------------------------------------------------------------

--- a/apps/web/src/assistant/selection.test.ts
+++ b/apps/web/src/assistant/selection.test.ts
@@ -23,18 +23,27 @@ let selectedAssistantId: string | null = null;
 let assistantsHydrated = true;
 let activeLocal: LockfileAssistant | undefined;
 
+const storeSetSelectedAssistantMock = mock((_id: string | null) => {});
 mock.module("@/stores/resolved-assistants-store", () => ({
   assistantsValidForOrg,
   useResolvedAssistantsStore: {
-    getState: () => ({ assistants, selectedAssistantId, assistantsHydrated }),
+    getState: () => ({
+      assistants,
+      selectedAssistantId,
+      assistantsHydrated,
+      setSelectedAssistant: storeSetSelectedAssistantMock,
+    }),
   },
 }));
+const setActiveLockfileAssistantMock = mock(async (_id: string) => {});
 mock.module("@/lib/local-mode", () => ({
   getActiveAssistant: () => activeLocal,
-  setActiveLockfileAssistant: async () => {},
+  setActiveLockfileAssistant: setActiveLockfileAssistantMock,
 }));
 
-const { resolveSelectedAssistantId } = await import("./selection");
+const { resolveSelectedAssistantId, setSelectedAssistant } = await import(
+  "./selection"
+);
 
 function platformAssistant(
   id: string,
@@ -57,6 +66,8 @@ beforeEach(() => {
   selectedAssistantId = null;
   assistantsHydrated = true;
   activeLocal = undefined;
+  storeSetSelectedAssistantMock.mockClear();
+  setActiveLockfileAssistantMock.mockClear();
 });
 
 describe("resolveSelectedAssistantId", () => {
@@ -119,5 +130,21 @@ describe("resolveSelectedAssistantId", () => {
     assistants = [platformAssistant("asst-1", ORG_A)];
     activeLocal = lockfileAssistant("asst-stale");
     expect(resolveSelectedAssistantId(ORG_A)).toBe("asst-1");
+  });
+});
+
+describe("setSelectedAssistant", () => {
+  test("an id records the selection and mirrors it into the lockfile", async () => {
+    await setSelectedAssistant("asst-1");
+
+    expect(storeSetSelectedAssistantMock).toHaveBeenCalledWith("asst-1");
+    expect(setActiveLockfileAssistantMock).toHaveBeenCalledWith("asst-1");
+  });
+
+  test("null clears the selection and skips the lockfile mirror", async () => {
+    await setSelectedAssistant(null);
+
+    expect(storeSetSelectedAssistantMock).toHaveBeenCalledWith(null);
+    expect(setActiveLockfileAssistantMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/assistant/selection.ts
+++ b/apps/web/src/assistant/selection.ts
@@ -56,11 +56,23 @@ export function resolveSelectedAssistantId(
 }
 
 /**
- * The single write path for switching the selected assistant. Records the
- * selection (reactive slice + persisted key) and mirrors it into the lockfile
- * `activeAssistant` (a no-op in the browser, where there is no lockfile host).
+ * The single public write path for switching the selected assistant. Records
+ * the selection (reactive slice + persisted key) and mirrors it into the
+ * lockfile `activeAssistant` (a no-op in the browser, where there is no
+ * lockfile host). The store action it wraps is internal plumbing — every
+ * other caller goes through here.
+ *
+ * `null` clears the selection but skips the lockfile mirror: the host API has
+ * no clear operation, and `activeAssistant` is machine-level tray/CLI state,
+ * not session state.
+ *
+ * Selecting a LOCAL assistant must go through `connectLocalAssistant`, which
+ * primes a gateway token for the new gateway — the bare write would leave the
+ * lifecycle pointing at it with a token minted for a different gateway.
  */
-export async function setSelectedAssistant(id: string): Promise<void> {
+export async function setSelectedAssistant(id: string | null): Promise<void> {
   useResolvedAssistantsStore.getState().setSelectedAssistant(id);
-  await setActiveLockfileAssistant(id);
+  if (id !== null) {
+    await setActiveLockfileAssistant(id);
+  }
 }

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -304,9 +304,11 @@ export function HatchingScreen() {
           }
           await loadLockfile();
           if (result.assistantId) {
-            useResolvedAssistantsStore
-              .getState()
-              .setSelectedAssistant(result.assistantId);
+            // The selection key is written synchronously, so the /readyz loop
+            // below resolves the new assistant's gateway URL. The lifecycle's
+            // selection subscription may briefly point at the not-yet-ready
+            // gateway; the re-prime below converges it.
+            void setSelectedAssistant(result.assistantId);
           }
 
           // Wait for the gateway + daemon to be fully ready before proceeding.

--- a/apps/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -2,11 +2,12 @@ import { Check, Cloud, Laptop } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
-import { setSelectedAssistant } from "@/assistant/selection";
+import { resolveSelectedAssistantId } from "@/assistant/selection";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
 import { formatRelativeDate } from "@/utils/format-date";
 import { useOnboardingLogin } from "@/hooks/use-onboarding-login";
 import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
+import { useOrganizationStore } from "@/stores/organization-store";
 import {
   useResolvedAssistantsStore,
   type ResolvedAssistant,
@@ -31,6 +32,8 @@ export function SelectAssistantScreen() {
   const fromSettings = searchParams.get("fromSettings") === "1";
   const hasPlatformSession = useHasPlatformSession();
   const assistants = useResolvedAssistantsStore.use.assistants();
+  const currentOrganizationId =
+    useOrganizationStore.use.currentOrganizationId();
   const {
     loading: loginLoading,
     error: loginError,
@@ -51,12 +54,14 @@ export function SelectAssistantScreen() {
   const [autoSkipping, setAutoSkipping] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Default selection to first accessible assistant
+  // Default selection: the app's known selected assistant when accessible,
+  // else the first accessible assistant.
   useEffect(() => {
-    if (selected == null && accessibleAssistants.length > 0) {
-      setSelected(accessibleAssistants[0].id);
-    }
-  }, [selected, accessibleAssistants]);
+    if (selected != null || accessibleAssistants.length === 0) return;
+    const resolved = resolveSelectedAssistantId(currentOrganizationId);
+    const match = accessibleAssistants.find((a) => a.id === resolved);
+    setSelected(match?.id ?? accessibleAssistants[0].id);
+  }, [selected, accessibleAssistants, currentOrganizationId]);
 
   const handleConnect = async (assistant: ResolvedAssistant) => {
     setConnecting(true);
@@ -65,7 +70,6 @@ export function SelectAssistantScreen() {
       if (assistant.isLocal) {
         await useAuthStore.getState().connectLocalAssistant(assistant.id);
       } else {
-        await setSelectedAssistant(assistant.id);
         await useAuthStore.getState().connectPlatformAssistant(assistant.id);
       }
       void navigate(routes.assistant, { replace: true });

--- a/apps/web/src/lib/auth/gateway-session.ts
+++ b/apps/web/src/lib/auth/gateway-session.ts
@@ -2,6 +2,7 @@ import {
   isLocalMode,
   getLocalGatewayUrl,
 } from "@/lib/local-mode";
+import type { LockfileAssistant } from "@/runtime/local-mode-host";
 
 const LS_TOKEN_KEY = "vellum:gw:token";
 const LS_EXPIRES_KEY = "vellum:gw:expiresAt";
@@ -96,8 +97,10 @@ export async function ensureGatewayToken(tokenUrl?: string, guardianToken?: stri
   return acquireGatewayToken(tokenUrl, guardianToken);
 }
 
-export function getLocalTokenUrl(): string | undefined {
-  const gatewayUrl = getLocalGatewayUrl();
+export function getLocalTokenUrl(
+  assistant?: LockfileAssistant,
+): string | undefined {
+  const gatewayUrl = getLocalGatewayUrl(assistant);
   if (!gatewayUrl) return undefined;
   return `${gatewayUrl}/auth/token`;
 }

--- a/apps/web/src/lib/local-mode.ts
+++ b/apps/web/src/lib/local-mode.ts
@@ -7,7 +7,6 @@ import {
   clearGatewayToken,
   ensureGatewayToken,
   getGatewayToken,
-  getLocalTokenUrl,
 } from "@/lib/auth/gateway-session";
 import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
 import { useLockfileStore } from "@/stores/lockfile-store";
@@ -323,12 +322,14 @@ export function gatewayProxyUrl(port: number): string {
 }
 
 /**
- * Return the local gateway proxy URL for the selected assistant, or
- * `undefined` when not in local mode / no local assistant is selected.
+ * Return the local gateway proxy URL for the given assistant (default: the
+ * selected one), or `undefined` when not in local mode / not a local
+ * assistant.
  */
-export function getLocalGatewayUrl(): string | undefined {
+export function getLocalGatewayUrl(
+  assistant: LockfileAssistant | undefined = getSelectedAssistant(),
+): string | undefined {
   if (!isLocalMode()) return undefined;
-  const assistant = getSelectedAssistant();
   if (!assistant || !isLocalAssistant(assistant)) return undefined;
   return gatewayProxyUrl(assistant.resources!.gatewayPort);
 }
@@ -338,20 +339,22 @@ export function getLocalGatewayUrl(): string | undefined {
 // ---------------------------------------------------------------------------
 
 /**
- * Acquire a gateway token and prime the self-hosted connection for the
- * selected local assistant. The guardian token and gateway exchange both ride
- * the host's local-mode transport, so this stays host-agnostic.
+ * Acquire a gateway token and prime the self-hosted connection for the given
+ * local assistant (default: the selected one). The guardian token and gateway
+ * exchange both ride the host's local-mode transport, so this stays
+ * host-agnostic. Passing `target` lets connect flows prime the NEW assistant's
+ * gateway before the selection write becomes observable, so the lifecycle's
+ * selection subscription never publishes a connection with a token minted for
+ * a different gateway.
  */
-export async function primeLocalGatewayConnection(): Promise<void> {
-  const tokenUrl = getLocalTokenUrl();
-  if (!tokenUrl) return;
-  const assistant = getSelectedAssistant();
-  const guardianToken = assistant
-    ? await fetchGuardianTokenHost(assistant.assistantId)
-    : undefined;
-  await ensureGatewayToken(tokenUrl, guardianToken);
-  const localGateway = getLocalGatewayUrl();
-  if (!localGateway) return;
+export async function primeLocalGatewayConnection(
+  target?: LockfileAssistant,
+): Promise<void> {
+  const assistant = target ?? getSelectedAssistant();
+  const localGateway = getLocalGatewayUrl(assistant);
+  if (!assistant || !localGateway) return;
+  const guardianToken = await fetchGuardianTokenHost(assistant.assistantId);
+  await ensureGatewayToken(`${localGateway}/auth/token`, guardianToken);
   setSelfHostedConnection({
     url: `${window.location.origin}${localGateway}`,
     token: getGatewayToken(),
@@ -382,16 +385,18 @@ function isRepairableConnectError(error: unknown): boolean {
  * a wake that itself fails, or a still-failing retry propagate the original
  * error so the existing connect-error UI surfaces it unchanged.
  */
-export async function primeLocalGatewayConnectionWithRepair(): Promise<void> {
+export async function primeLocalGatewayConnectionWithRepair(
+  target?: LockfileAssistant,
+): Promise<void> {
   try {
-    await primeLocalGatewayConnection();
+    await primeLocalGatewayConnection(target);
     return;
   } catch (error) {
     if (!isRepairableConnectError(error)) throw error;
-    const assistantId = getSelectedAssistant()?.assistantId;
+    const assistantId = (target ?? getSelectedAssistant())?.assistantId;
     if (!assistantId) throw error;
     const repair = await wakeLocalAssistantHost(assistantId);
     if (!repair.ok) throw error;
-    await primeLocalGatewayConnection();
+    await primeLocalGatewayConnection(target);
   }
 }

--- a/apps/web/src/lib/local-mode.ts
+++ b/apps/web/src/lib/local-mode.ts
@@ -7,6 +7,7 @@ import {
   clearGatewayToken,
   ensureGatewayToken,
   getGatewayToken,
+  getLocalTokenUrl,
 } from "@/lib/auth/gateway-session";
 import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
 import { useLockfileStore } from "@/stores/lockfile-store";
@@ -351,10 +352,14 @@ export async function primeLocalGatewayConnection(
   target?: LockfileAssistant,
 ): Promise<void> {
   const assistant = target ?? getSelectedAssistant();
+  const tokenUrl = getLocalTokenUrl(assistant);
+  if (!tokenUrl) return;
+  const guardianToken = assistant
+    ? await fetchGuardianTokenHost(assistant.assistantId)
+    : undefined;
+  await ensureGatewayToken(tokenUrl, guardianToken);
   const localGateway = getLocalGatewayUrl(assistant);
-  if (!assistant || !localGateway) return;
-  const guardianToken = await fetchGuardianTokenHost(assistant.assistantId);
-  await ensureGatewayToken(`${localGateway}/auth/token`, guardianToken);
+  if (!localGateway) return;
   setSelfHostedConnection({
     url: `${window.location.origin}${localGateway}`,
     token: getGatewayToken(),

--- a/apps/web/src/stores/auth-store.test.ts
+++ b/apps/web/src/stores/auth-store.test.ts
@@ -545,14 +545,25 @@ describe("biometric session recovery", () => {
 });
 
 describe("connectLocalAssistant", () => {
-  test("selects the assistant, primes the connection, and logs in", async () => {
+  test("primes the connection BEFORE selecting the assistant, then logs in", async () => {
     mockIsLocalMode = true;
     mockPlatformAssistants = [];
+    // Prime must complete before the selection write becomes observable —
+    // the lifecycle's selection subscription republishes the connection
+    // synchronously on the write, with whatever token is cached.
+    const order: string[] = [];
+    primeLocalGatewayConnectionWithRepairMock.mockImplementationOnce(
+      async () => {
+        order.push("prime");
+      },
+    );
+    setSelectedAssistantMock.mockImplementationOnce(async (id) => {
+      order.push(`select:${String(id)}`);
+    });
 
     await useAuthStore.getState().connectLocalAssistant("local-a");
 
-    expect(setSelectedAssistantMock).toHaveBeenCalledWith("local-a");
-    expect(primeLocalGatewayConnectionWithRepairMock).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(["prime", "select:local-a"]);
     expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
     expect(useAuthStore.getState().user?.id).toBe("gateway-local");
     // No platform assistants — nothing to probe, so the status settles
@@ -560,7 +571,7 @@ describe("connectLocalAssistant", () => {
     expect(useAuthStore.getState().platformSession).toBe("absent");
   });
 
-  test("rethrows the prime failure without marking the session logged in", async () => {
+  test("rethrows the prime failure without selecting or marking the session logged in", async () => {
     mockIsLocalMode = true;
     mockPrimeError = new Error("Guardian token not found");
 
@@ -568,7 +579,8 @@ describe("connectLocalAssistant", () => {
       useAuthStore.getState().connectLocalAssistant("local-a"),
     ).rejects.toThrow("Guardian token not found");
 
-    expect(setSelectedAssistantMock).toHaveBeenCalledWith("local-a");
+    // A failed connect leaves the previous selection in place.
+    expect(setSelectedAssistantMock).not.toHaveBeenCalled();
     expect(useAuthStore.getState().sessionStatus).not.toBe("authenticated");
   });
 });

--- a/apps/web/src/stores/auth-store.test.ts
+++ b/apps/web/src/stores/auth-store.test.ts
@@ -18,7 +18,7 @@ let mockIsGatewayAuth = false;
 let mockIsLocalMode = false;
 let mockPlatformAssistants: unknown[] = [];
 let mockPrimeError: Error | null = null;
-const setSelectedAssistantMock = mock((_id: string | null) => {});
+const setSelectedAssistantMock = mock(async (_id: string | null) => {});
 const setFromApiMock = mock((_assistants: unknown) => {});
 const primeLocalGatewayConnectionMock = mock(async () => {
   if (mockPrimeError) throw mockPrimeError;
@@ -145,10 +145,16 @@ mock.module("@/lib/auth/session-cleanup", () => ({
 mock.module("@/stores/resolved-assistants-store", () => ({
   useResolvedAssistantsStore: {
     getState: () => ({
-      setSelectedAssistant: setSelectedAssistantMock,
       setFromApi: setFromApiMock,
     }),
   },
+}));
+
+// Auth-store writes the selection through the public wrapper, not the store
+// action — mock the wrapper module so the real one (and its local-mode deps)
+// never loads.
+mock.module("@/assistant/selection", () => ({
+  setSelectedAssistant: setSelectedAssistantMock,
 }));
 
 mock.module("@/stores/organization-store", () => ({
@@ -388,6 +394,41 @@ describe("session cleanup on logout", () => {
     expect(lifecycleResetForLogoutMock).toHaveBeenCalledTimes(1);
     expect(statusAtResetTime).toBe("authenticated");
     expect(useAuthStore.getState().sessionStatus).toBe("unauthenticated");
+  });
+
+  // The lifecycle reset must run BEFORE the selection clear in both branches:
+  // the lifecycle's selection subscription skips writes while the state is
+  // `loading`, so this order is what prevents the clear from resurrecting an
+  // active state mid-logout.
+  test("gateway logout resets the lifecycle before clearing the selection", async () => {
+    mockIsGatewayAuth = true;
+    useAuthStore.setState({ sessionStatus: "authenticated" });
+    const order: string[] = [];
+    lifecycleResetForLogoutMock.mockImplementationOnce(() => {
+      order.push("reset");
+    });
+    setSelectedAssistantMock.mockImplementationOnce(async (id) => {
+      order.push(`clear:${String(id)}`);
+    });
+
+    await useAuthStore.getState().logout();
+
+    expect(order).toEqual(["reset", "clear:null"]);
+    expect(useAuthStore.getState().sessionStatus).toBe("unauthenticated");
+  });
+
+  test("non-gateway logout clears the selection slice after the lifecycle reset", async () => {
+    const order: string[] = [];
+    lifecycleResetForLogoutMock.mockImplementationOnce(() => {
+      order.push("reset");
+    });
+    setSelectedAssistantMock.mockImplementationOnce(async (id) => {
+      order.push(`clear:${String(id)}`);
+    });
+
+    await useAuthStore.getState().logout();
+
+    expect(order).toEqual(["reset", "clear:null"]);
   });
 });
 

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -14,6 +14,7 @@
 import { create } from "zustand";
 
 import { lifecycleService } from "@/assistant/lifecycle-service";
+import { setSelectedAssistant } from "@/assistant/selection";
 import { createSelectors } from "@/utils/create-selectors";
 import {
   isAuthenticated,
@@ -483,14 +484,14 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
    * stays on the plain primitive so app launch never spawns daemon processes.
    */
   connectLocalAssistant: async (assistantId: string) => {
-    useResolvedAssistantsStore.getState().setSelectedAssistant(assistantId);
+    await setSelectedAssistant(assistantId);
     await primeLocalGatewayConnectionWithRepair();
     set(authenticatedLocalUser());
     probePlatformSessionIfReachable(set);
   },
 
   connectPlatformAssistant: async (assistantId: string) => {
-    useResolvedAssistantsStore.getState().setSelectedAssistant(assistantId);
+    await setSelectedAssistant(assistantId);
     const result = await getSession();
     if (!result.ok || !result.data.user) {
       throw new Error("Platform authentication required");
@@ -553,15 +554,18 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
 
   logout: async () => {
     if (isGatewayAuthMode()) {
-      useResolvedAssistantsStore.getState().setSelectedAssistant(null);
+      // Clear lifecycle state BEFORE `sessionStatus` leaves `authenticated`
+      // so the assistant sync hooks don't observe a stale assistant id in
+      // their first re-render, and BEFORE the selection clear so the
+      // lifecycle's selection subscription (guarded on `loading`) doesn't
+      // resurrect an active state mid-logout. The `respondToInputs`
+      // not-authenticated branch is the safety net for token-expiry-style
+      // flips.
+      lifecycleService.resetForLogout();
+      await setSelectedAssistant(null);
       clearGatewayToken();
       clearOrganization();
       clearUserScopedStorage();
-      // Clear lifecycle state BEFORE `sessionStatus` leaves `authenticated`
-      // so the assistant sync hooks don't observe a stale assistant id in
-      // their first re-render. The `respondToInputs` not-authenticated
-      // branch is the safety net for token-expiry-style flips.
-      lifecycleService.resetForLogout();
       set(sessionEnded());
       broadcastAuthChange();
       return;
@@ -580,6 +584,10 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
       clearOrganization();
       clearUserScopedStorage();
       lifecycleService.resetForLogout();
+      // Clear the selection slice too — `clearUserScopedStorage` already
+      // removed the persisted key, and a surviving slice would resolve the
+      // previous user's assistant after re-login.
+      await setSelectedAssistant(null);
       set(sessionEnded());
       broadcastAuthChange();
     }

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -471,8 +471,13 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
 
   /**
    * Connect to a specific local assistant from an interactive surface (the
-   * login picker / auto-connect). Selects the assistant, primes its gateway
-   * connection, and marks the session logged in.
+   * login picker / auto-connect). Primes its gateway connection, selects the
+   * assistant, and marks the session logged in.
+   *
+   * Priming runs BEFORE the selection write: the lifecycle's selection
+   * subscription republishes the connection synchronously on the write, so
+   * the token must already be minted for the new gateway — and a failed
+   * connect leaves the previous selection in place.
    *
    * Unlike {@link AuthActions.initSession}, which is the best-effort boot
    * probe and swallows failures, this rethrows so the caller can surface the
@@ -484,8 +489,11 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
    * stays on the plain primitive so app launch never spawns daemon processes.
    */
   connectLocalAssistant: async (assistantId: string) => {
+    const target = getLocalAssistants().find(
+      (a) => a.assistantId === assistantId,
+    );
+    await primeLocalGatewayConnectionWithRepair(target);
     await setSelectedAssistant(assistantId);
-    await primeLocalGatewayConnectionWithRepair();
     set(authenticatedLocalUser());
     probePlatformSessionIfReachable(set);
   },

--- a/apps/web/src/stores/resolved-assistants-store.ts
+++ b/apps/web/src/stores/resolved-assistants-store.ts
@@ -165,10 +165,11 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
     setActiveAssistantId: (assistantId) =>
       set({ activeAssistantId: assistantId }),
 
-    // The single write path for the selected id: the reactive slice and the
-    // persisted key move together. All callers (selection.ts, connect/hatch
-    // flows, the lifecycle 404 net) go through here so same-tab consumers
-    // re-render and the key never drifts from the slice.
+    // Internal plumbing for the selected id: the reactive slice and the
+    // persisted key move together. Callers go through the public wrapper in
+    // selection.ts (which adds the lockfile mirror); only that wrapper and
+    // the lifecycle 404 net call this directly. The lifecycle service
+    // subscribes to the slice, so every write republishes in gateway mode.
     setSelectedAssistant: (id) => {
       if (id == null) {
         clearSelectedAssistantId();


### PR DESCRIPTION
## Summary
- Fix: in gateway-auth (desktop) mode, switching assistants while connected never updated `activeAssistantId` — the gateway short-circuit only re-ran on `use-lifecycle` effect-dep changes, and gateway mode pins the resolved selection to `null`. The lifecycle service now subscribes to the store's `selectedAssistantId` slice and re-runs `applyGatewayAuthShortCircuit()` on any selection change (synchronous, at the store funnel, guarded to gateway mode + past `loading` so boot publish stays owned by `respondToInputs` and a mid-logout clear can't resurrect an active state).
- Unify all selection writers behind `selection.ts::setSelectedAssistant` (now `string | null`): the connect flows, both logout branches, and the last hatching-screen holdout previously used the raw store action and skipped the lockfile `activeAssistant` mirror the macOS tray/CLI read. `null` clears the selection but skips the mirror (no host clear API; it's machine-level, not session state). The 404 net stays on the store action by design (internal plumbing). Also fixes a non-gateway-logout drift where the persisted key was swept but the slice survived, resolving the previous user's assistant after re-login.
- The Choose an Assistant screen now preselects the app's known selected assistant (via `resolveSelectedAssistantId`) when accessible, falling back to the first accessible assistant.

## Original prompt
Noa reported that on the Choose an Assistant screen, selecting a different assistant and clicking Continue didn't actually switch the active assistant. Root-causing showed the gateway-auth republish path never re-fires on selection changes, and that selection writers were split across two inconsistently-used layers (the documented wrapper vs the raw store action). Rather than patching the Continue button imperatively, Noa asked to unify the writers so all of them work correctly without relying solely on React reactivity — plus, as added scope, have the screen default its card to the known selected assistant when one exists, keeping the existing first-accessible fallback otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)