### PR TITLE
feat(settings): add schedule usage cost aggregation helpers

### DIFF
--- a/apps/web/src/domains/settings/utils/schedule-formatters.test.ts
+++ b/apps/web/src/domains/settings/utils/schedule-formatters.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ScheduleUsageSummary } from "@/domains/settings/types/schedules";
+
+import { systemTaskUsageCost, totalUsageCost } from "./schedule-formatters";
+
+function summary(
+  scheduleId: string,
+  totalEstimatedCostUsd: number,
+): ScheduleUsageSummary {
+  return {
+    scheduleId,
+    runCount: 1,
+    totalEstimatedCostUsd,
+    eventCount: 0,
+  };
+}
+
+describe("totalUsageCost", () => {
+  test("returns 0 for an empty array", () => {
+    expect(totalUsageCost([])).toBe(0);
+  });
+
+  test("returns 0 for undefined", () => {
+    expect(totalUsageCost(undefined)).toBe(0);
+  });
+
+  test("sums totalEstimatedCostUsd across multiple summaries", () => {
+    expect(
+      totalUsageCost([summary("a", 1.25), summary("b", 2.5), summary("c", 0)]),
+    ).toBeCloseTo(3.75);
+  });
+
+  test("skips non-finite cost entries", () => {
+    expect(
+      totalUsageCost([
+        summary("a", 1),
+        summary("b", Number.NaN),
+        summary("c", Infinity),
+        summary("d", -Infinity),
+        summary("e", 2),
+      ]),
+    ).toBe(3);
+  });
+});
+
+describe("systemTaskUsageCost", () => {
+  test("returns 0 while loading", () => {
+    expect(systemTaskUsageCost({ status: "loading" })).toBe(0);
+  });
+
+  test("returns 0 on error", () => {
+    expect(systemTaskUsageCost({ status: "error" })).toBe(0);
+  });
+
+  test("returns the summary cost when ready", () => {
+    expect(
+      systemTaskUsageCost({ status: "ready", summary: summary("a", 4.5) }),
+    ).toBe(4.5);
+  });
+
+  test("returns 0 when ready summary cost is falsy", () => {
+    expect(
+      systemTaskUsageCost({ status: "ready", summary: summary("a", 0) }),
+    ).toBe(0);
+  });
+});

--- a/apps/web/src/domains/settings/utils/schedule-formatters.ts
+++ b/apps/web/src/domains/settings/utils/schedule-formatters.ts
@@ -260,3 +260,18 @@ export function summarizeRunsForUsage(
     eventCount: 0,
   };
 }
+
+export function totalUsageCost(
+  summaries: ScheduleUsageSummary[] | undefined,
+): number {
+  return (summaries ?? []).reduce((total, summary) => {
+    const cost = summary.totalEstimatedCostUsd;
+    return Number.isFinite(cost) ? total + cost : total;
+  }, 0);
+}
+
+export function systemTaskUsageCost(usage: ScheduleRowUsage): number {
+  return usage.status === "ready"
+    ? usage.summary.totalEstimatedCostUsd || 0
+    : 0;
+}


### PR DESCRIPTION
## Summary
- Add pure totalUsageCost + systemTaskUsageCost helpers for 7-day cost aggregation
- Unit tests covering empty/undefined/non-finite/ready/loading/error cases

Part of plan: homepage-schedules-dashboard.md (PR 1 of 5)