### PR TITLE
feat(home): add collapsible ScheduleSummaryCard shell

### DIFF
--- a/apps/web/src/domains/home/components/schedule-summary-card.test.tsx
+++ b/apps/web/src/domains/home/components/schedule-summary-card.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * Tests for the presentational ScheduleSummaryCard shell:
+ *  - Collapsed renders title/subtitle/costLabel and hides children; clicking the
+ *    card toggles expand.
+ *  - Expanded renders children and a minimize button; clicking minimize toggles.
+ *  - Cost loading renders a skeleton; cost error renders an em dash.
+ *
+ * Uses @testing-library/react (happy-dom is registered via the test preload) so
+ * we can drive clicks and assert presence/absence of body content.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { ScheduleSummaryCard } from "./schedule-summary-card";
+
+afterEach(cleanup);
+
+const BASE_PROPS = {
+  title: "Schedules",
+  subtitle: "3 active",
+  costLabel: "$4.29",
+  costStatus: "ready" as const,
+  isExpanded: false,
+  onToggleExpand: () => {},
+};
+
+describe("ScheduleSummaryCard", () => {
+  test("collapsed renders title/subtitle/costLabel and hides children", () => {
+    const { getByText, queryByText } = render(
+      <ScheduleSummaryCard {...BASE_PROPS}>
+        <div>hidden child</div>
+      </ScheduleSummaryCard>,
+    );
+
+    expect(getByText("Schedules")).toBeTruthy();
+    expect(getByText("3 active")).toBeTruthy();
+    expect(getByText("$4.29")).toBeTruthy();
+    expect(queryByText("hidden child")).toBeNull();
+  });
+
+  test("clicking the collapsed card calls onToggleExpand", () => {
+    const onToggleExpand = mock(() => {});
+    const { getByRole } = render(
+      <ScheduleSummaryCard {...BASE_PROPS} onToggleExpand={onToggleExpand} />,
+    );
+
+    fireEvent.click(getByRole("button"));
+    expect(onToggleExpand).toHaveBeenCalledTimes(1);
+  });
+
+  test("collapsed loading cost renders a skeleton, not the cost label", () => {
+    const { getByLabelText, queryByText } = render(
+      <ScheduleSummaryCard {...BASE_PROPS} costStatus="loading" />,
+    );
+
+    expect(getByLabelText("Loading cost")).toBeTruthy();
+    expect(queryByText("$4.29")).toBeNull();
+  });
+
+  test("collapsed error cost renders an em dash", () => {
+    const { getByText, queryByText } = render(
+      <ScheduleSummaryCard {...BASE_PROPS} costStatus="error" />,
+    );
+
+    expect(getByText("—")).toBeTruthy();
+    expect(queryByText("$4.29")).toBeNull();
+  });
+
+  test("expanded renders children and a minimize button", () => {
+    const { getByText, getByLabelText } = render(
+      <ScheduleSummaryCard {...BASE_PROPS} isExpanded>
+        <div>visible child</div>
+      </ScheduleSummaryCard>,
+    );
+
+    expect(getByText("visible child")).toBeTruthy();
+    expect(getByLabelText("Minimize Schedules")).toBeTruthy();
+  });
+
+  test("clicking minimize calls onToggleExpand", () => {
+    const onToggleExpand = mock(() => {});
+    const { getByLabelText } = render(
+      <ScheduleSummaryCard
+        {...BASE_PROPS}
+        isExpanded
+        onToggleExpand={onToggleExpand}
+      >
+        <div>visible child</div>
+      </ScheduleSummaryCard>,
+    );
+
+    fireEvent.click(getByLabelText("Minimize Schedules"));
+    expect(onToggleExpand).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/domains/home/components/schedule-summary-card.tsx
+++ b/apps/web/src/domains/home/components/schedule-summary-card.tsx
@@ -1,0 +1,102 @@
+import type { ReactNode } from "react";
+
+import { Maximize2, Minimize2 } from "lucide-react";
+
+import { DetailCard } from "@/components/detail-card";
+import { Card } from "@vellumai/design-library";
+
+export interface ScheduleSummaryCardProps {
+  title: string;
+  subtitle: string;
+  /** Pre-formatted cost string, e.g. "$4.29". */
+  costLabel: string;
+  costStatus: "loading" | "error" | "ready";
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+  /** Rendered inside the card body only when expanded. */
+  children?: ReactNode;
+}
+
+function CostDisplay({
+  costLabel,
+  costStatus,
+}: {
+  costLabel: string;
+  costStatus: ScheduleSummaryCardProps["costStatus"];
+}) {
+  return (
+    <div className="flex shrink-0 flex-col items-end text-right">
+      <span className="mb-0.5 text-label-small-default text-[var(--content-tertiary)]">
+        Cost (7d)
+      </span>
+      {costStatus === "loading" ? (
+        <span
+          aria-label="Loading cost"
+          className="h-5 w-16 animate-pulse rounded bg-[var(--surface-muted)]"
+        />
+      ) : (
+        <span className="text-body-medium-default text-[var(--content-default)]">
+          {costStatus === "error" ? "—" : costLabel}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export function ScheduleSummaryCard({
+  title,
+  subtitle,
+  costLabel,
+  costStatus,
+  isExpanded,
+  onToggleExpand,
+  children,
+}: ScheduleSummaryCardProps) {
+  if (isExpanded) {
+    return (
+      <DetailCard
+        title={title}
+        subtitle={subtitle}
+        compactAccessory
+        accessory={
+          <button
+            type="button"
+            onClick={onToggleExpand}
+            aria-label={`Minimize ${title}`}
+            className="flex h-7 w-7 cursor-pointer items-center justify-center rounded text-[var(--content-tertiary)] transition-colors hover:bg-[var(--surface-hover)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+          >
+            <Minimize2 className="h-4 w-4" />
+          </button>
+        }
+      >
+        {children}
+      </DetailCard>
+    );
+  }
+
+  return (
+    <Card asChild>
+      <button
+        type="button"
+        onClick={onToggleExpand}
+        className="group relative flex w-full cursor-pointer items-start justify-between gap-4 text-left transition-colors hover:bg-[var(--surface-hover)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]"
+      >
+        <div className="flex min-w-0 flex-col gap-2">
+          <span className="text-title-medium text-[var(--content-emphasised)]">
+            {title}
+          </span>
+          <span className="text-body-medium-default text-[var(--content-tertiary)]">
+            {subtitle}
+          </span>
+        </div>
+        <CostDisplay costLabel={costLabel} costStatus={costStatus} />
+        <span
+          aria-label={`Expand ${title}`}
+          className="absolute right-2 top-2 text-[var(--content-tertiary)] opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
+        >
+          <Maximize2 className="h-4 w-4" />
+        </span>
+      </button>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- Add presentational ScheduleSummaryCard with collapsed (hover expand icon) and expanded (minimize icon) states
- Component tests for both states and cost loading/error rendering

Part of plan: homepage-schedules-dashboard.md (PR 2 of 5)