### PR TITLE
feat(home): surface schedules dashboard at top of homepage

### DIFF
--- a/apps/web/src/domains/home/home-page.tsx
+++ b/apps/web/src/domains/home/home-page.tsx
@@ -8,6 +8,7 @@ import type {
     SuggestedPrompt,
 } from "@vellumai/assistant-api";
 import { ResizablePanel } from "@vellumai/design-library";
+import { HomeSchedulesPanel } from "./components/home-schedules-panel";
 import { HomeDetailPanel } from "./detail-panel/home-detail-panel";
 import { HomeFeedList } from "./home-feed-list";
 import { HomeGreetingHeader } from "./home-greeting-header";
@@ -131,6 +132,7 @@ export function HomePage({
     <HomePageSkeleton />
   ) : (
     <>
+      <HomeSchedulesPanel assistantId={assistantId} />
       <HomeGreetingHeader
         avatarComponents={avatar.components}
         avatarTraits={avatar.traits}


### PR DESCRIPTION
## Summary
- Mount HomeSchedulesPanel at the top of the homepage feed content (above the greeting), covering all three layout branches
- Panel self-hides when the assistant has no schedules/system tasks

Part of plan: homepage-schedules-dashboard.md (PR 5 of 5)