### PR TITLE
feat: upgrade Quality profile to Claude Fable 5

### DIFF
--- a/assistant/src/__tests__/model-intents.test.ts
+++ b/assistant/src/__tests__/model-intents.test.ts
@@ -20,7 +20,7 @@ describe("model intents", () => {
       "claude-haiku-4-5-20251001",
     );
     expect(resolveModelIntent("anthropic", "quality-optimized")).toBe(
-      "claude-opus-4-8",
+      "claude-fable-5",
     );
     expect(resolveModelIntent("anthropic", "vision-optimized")).toBe(
       "claude-opus-4-6",

--- a/assistant/src/providers/model-intents.ts
+++ b/assistant/src/providers/model-intents.ts
@@ -13,7 +13,7 @@ const PROVIDER_MODEL_INTENTS: Record<string, Record<ModelIntent, string>> = {
   anthropic: {
     balanced: "claude-sonnet-4-6",
     "latency-optimized": "claude-haiku-4-5-20251001",
-    "quality-optimized": "claude-opus-4-8",
+    "quality-optimized": "claude-fable-5",
     "vision-optimized": "claude-opus-4-6",
   },
   openai: {

--- a/assistant/src/providers/model-intents.ts
+++ b/assistant/src/providers/model-intents.ts
@@ -43,7 +43,7 @@ const PROVIDER_MODEL_INTENTS: Record<string, Record<ModelIntent, string>> = {
   openrouter: {
     balanced: "anthropic/claude-sonnet-4.6",
     "latency-optimized": "anthropic/claude-haiku-4.5",
-    "quality-optimized": "anthropic/claude-opus-4.8",
+    "quality-optimized": "anthropic/claude-fable-5",
     "vision-optimized": "anthropic/claude-opus-4.6",
   },
 };


### PR DESCRIPTION
## Summary
- Swap the `anthropic` `quality-optimized` model intent from `claude-opus-4-8` to `claude-fable-5` in `assistant/src/providers/model-intents.ts`, so the managed Quality profile (and hatch-time `custom-quality-optimized`) resolves to Fable 5.
- Update the corresponding assertion in `model-intents.test.ts`.
- No other changes needed: `claude-fable-5` is already in `PROVIDER_CATALOG` (load-time intent validation passes), and the request path already normalizes thinking config for adaptive-only models. Managed profiles are reseeded on every daemon boot, so existing off-platform installs pick up the new model automatically.

## Original prompt
Update our Quality default LLM profile to use Fable 5 instead of Opus. The Quality profile's model is resolved from the `quality-optimized` model intent, so the change lands in the intent mapping rather than the profile template.