### PR TITLE
fix(export): redact acp.agents env values in the sanitized config snapshot

### DIFF
--- a/assistant/src/__tests__/log-export-workspace.test.ts
+++ b/assistant/src/__tests__/log-export-workspace.test.ts
@@ -98,10 +98,25 @@ async function extractArchive(res: Response): Promise<string> {
 // Seed test data
 // ---------------------------------------------------------------------------
 
-// config.json at workspace root — needed for config-snapshot test
+// config.json at workspace root — needed for config-snapshot tests. The
+// acp.agents env values are obviously-synthetic secrets that must be redacted
+// from the exported snapshot.
+const SYNTHETIC_ACP_API_KEY = "sk-proj-synthetic-test-key-000000";
 writeFileSync(
   join(testWorkspaceDir, "config.json"),
-  JSON.stringify({ provider: "anthropic" }),
+  JSON.stringify({
+    provider: "anthropic",
+    acp: {
+      agents: {
+        codex: {
+          env: {
+            OPENAI_API_KEY: SYNTHETIC_ACP_API_KEY,
+            PATH: "/data/.bun/bin",
+          },
+        },
+      },
+    },
+  }),
 );
 
 // Conversation directories — used for workspace allowlist tests
@@ -197,6 +212,26 @@ describe("POST /v1/export — tar.gz archive", () => {
       );
       const parsed = JSON.parse(configContent);
       expect(parsed.provider).toBe("anthropic");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("config-snapshot.json redacts acp.agents env values", async () => {
+    const res = await callExport();
+    const dir = await extractArchive(res);
+    try {
+      const configContent = readFileSync(
+        join(dir, "config-snapshot.json"),
+        "utf-8",
+      );
+      const parsed = JSON.parse(configContent);
+      const env = parsed.acp.agents.codex.env as Record<string, string>;
+      expect(Object.keys(env).sort()).toEqual(["OPENAI_API_KEY", "PATH"]);
+      for (const value of Object.values(env)) {
+        expect(value).toBe("(set)");
+      }
+      expect(configContent).not.toContain(SYNTHETIC_ACP_API_KEY);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -432,6 +432,27 @@ function readSanitizedConfig(): Record<string, unknown> | undefined {
       config.twilio = twilio;
     }
 
+    if (config.acp && typeof config.acp === "object") {
+      const acp = config.acp as Record<string, unknown>;
+      if (acp.agents && typeof acp.agents === "object") {
+        const agents = acp.agents as Record<string, unknown>;
+        for (const name of Object.keys(agents)) {
+          const agent = agents[name];
+          if (agent && typeof agent === "object") {
+            const a = agent as Record<string, unknown>;
+            if (a.env && typeof a.env === "object") {
+              // Agent env is an arbitrary user-supplied map (often API keys);
+              // redact every value and keep only the key names.
+              const env = a.env as Record<string, unknown>;
+              a.env = Object.fromEntries(
+                Object.keys(env).map((k) => [k, redactStringValue(env[k])]),
+              );
+            }
+          }
+        }
+      }
+    }
+
     if (config.mcp && typeof config.mcp === "object") {
       const mcp = config.mcp as Record<string, unknown>;
       if (mcp.servers && typeof mcp.servers === "object") {


### PR DESCRIPTION
## Summary
- readSanitizedConfig now replaces every acp.agents.*.env value with presence flags ((set)/(empty)), matching the existing mcp/skills sanitization
- Closes the config-snapshot.json plaintext API key leak observed in an exported bug report

Part of plan: acp-codex-auth-export-redaction.md (PR 4 of 7)