### PR TITLE
feat(acp): inject OPENAI_API_KEY/CODEX_API_KEY for codex-acp from the credential vault

### DIFF
--- a/assistant/src/acp/__tests__/prepare-agent-env.test.ts
+++ b/assistant/src/acp/__tests__/prepare-agent-env.test.ts
@@ -47,8 +47,7 @@ mock.module("../../tools/credentials/metadata-store.js", () => ({
     const existing = metadataStore.get(key);
     metadataStore.set(key, {
       allowedTools: policy?.allowedTools ?? existing?.allowedTools ?? [],
-      usageDescription:
-        policy?.usageDescription ?? existing?.usageDescription,
+      usageDescription: policy?.usageDescription ?? existing?.usageDescription,
     });
     return {
       credentialId: `cred-${key}`,
@@ -331,16 +330,91 @@ describe("prepareAgentEnv - gemini gating", () => {
   });
 });
 
-describe("prepareAgentEnv — non-claude commands", () => {
-  test("returns the config unchanged for codex-acp (no required env vars today)", async () => {
+describe("prepareAgentEnv - codex-acp gating", () => {
+  function seedVaultOpenaiKey(key: string): void {
+    vaultStore.set("acp/openai_api_key", key);
+  }
+
+  function seedVaultCodexKey(key: string): void {
+    vaultStore.set("acp/codex_api_key", key);
+  }
+
+  test("injects OPENAI_API_KEY from the vault via the broker when agent.env has no override", async () => {
+    seedVaultOpenaiKey("vault-fake-openai-AAA");
+
     const prepared = await prepareAgentEnv({
       command: "codex-acp",
       args: [],
     });
 
-    expect(prepared.env).toEqual({});
+    expect(prepared.env?.OPENAI_API_KEY).toBe("vault-fake-openai-AAA");
   });
 
+  test("agent.env override wins over the vault entry and skips the broker (precedence pin)", async () => {
+    // Seed a vault value but no metadata: if the override path consulted the
+    // broker anyway, ensureAcpCredentialPolicy would create metadata here.
+    seedVaultOpenaiKey("vault-fake-openai-BBB");
+
+    const prepared = await prepareAgentEnv({
+      command: "codex-acp",
+      args: [],
+      env: { OPENAI_API_KEY: "config-fake-openai-CCC" },
+    });
+
+    expect(prepared.env?.OPENAI_API_KEY).toBe("config-fake-openai-CCC");
+    expect(metadataStore.has("acp/openai_api_key")).toBe(false);
+  });
+
+  test("a vault miss for both fields does NOT throw and spawns with env unchanged (keys are optional)", async () => {
+    const prepared = await prepareAgentEnv({
+      command: "codex-acp",
+      args: [],
+      env: { NO_COLOR: "1" },
+    });
+
+    expect(prepared.env).toEqual({ NO_COLOR: "1" });
+    expect(prepared.env).not.toHaveProperty("OPENAI_API_KEY");
+    expect(prepared.env).not.toHaveProperty("CODEX_API_KEY");
+  });
+
+  test("injects CODEX_API_KEY independently of OPENAI_API_KEY", async () => {
+    seedVaultCodexKey("vault-fake-codex-DDD");
+
+    const prepared = await prepareAgentEnv({
+      command: "codex-acp",
+      args: [],
+    });
+
+    expect(prepared.env?.CODEX_API_KEY).toBe("vault-fake-codex-DDD");
+    expect(prepared.env).not.toHaveProperty("OPENAI_API_KEY");
+  });
+
+  test("injects both keys when both vault fields are present", async () => {
+    seedVaultOpenaiKey("vault-fake-openai-EEE");
+    seedVaultCodexKey("vault-fake-codex-FFF");
+
+    const prepared = await prepareAgentEnv({
+      command: "codex-acp",
+      args: [],
+    });
+
+    expect(prepared.env?.OPENAI_API_KEY).toBe("vault-fake-openai-EEE");
+    expect(prepared.env?.CODEX_API_KEY).toBe("vault-fake-codex-FFF");
+  });
+
+  test("gates on the resolved command BASENAME (custom agent id with full path still gets injection)", async () => {
+    seedVaultOpenaiKey("vault-fake-openai-GGG");
+
+    const prepared = await prepareAgentEnv({
+      command: "/data/.bun/bin/codex-acp",
+      args: [],
+    });
+
+    expect(prepared.env?.OPENAI_API_KEY).toBe("vault-fake-openai-GGG");
+  });
+});
+
+describe("prepareAgentEnv — non-claude commands", () => {
   test("returns the config unchanged for an unrecognized command basename", async () => {
     seedVaultToken("vault-HHH");
 

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -94,6 +94,32 @@ async function injectCredential(
 }
 
 /**
+ * Inject an OPTIONAL credential: skip when the env var is already set
+ * (config.json override wins), and treat a vault miss as non-fatal — the
+ * adapter has its own login fallback, so spawning without the key is fine.
+ */
+async function injectOptionalCredential(
+  env: Record<string, string>,
+  field: string,
+  envVar: string,
+  usageDescription: string,
+): Promise<void> {
+  if (env[envVar]) return;
+  const missReason = await injectCredential(
+    env,
+    field,
+    envVar,
+    usageDescription,
+  );
+  if (missReason !== undefined) {
+    log.debug(
+      { reason: missReason },
+      `${envVar} unavailable from the vault; spawning without it`,
+    );
+  }
+}
+
+/**
  * Returns a NEW config with any required credentials merged into `env`.
  * Does NOT mutate the input. Throws `FailedDependencyError` if a required
  * credential is missing from both the user-supplied env override and the
@@ -123,6 +149,13 @@ async function injectCredential(
  * ways (config.json override wins, vault field `gemini_api_key` second),
  * but it is OPTIONAL: the Gemini CLI supports its own OAuth login, so a
  * vault miss proceeds without the key instead of failing the spawn.
+ *
+ * For `codex-acp` the env vars are `OPENAI_API_KEY` (vault field
+ * `acp/openai_api_key`) and `CODEX_API_KEY` (vault field
+ * `acp/codex_api_key`), provisioned the same two ways (config.json
+ * override wins, vault second). Both are OPTIONAL: codex also supports
+ * ChatGPT login (`codex login` pre-seeding `auth.json` in the workspace),
+ * so a vault miss proceeds without the key instead of failing the spawn.
  */
 export async function prepareAgentEnv(
   agentConfig: AcpAgentConfig,
@@ -150,22 +183,25 @@ export async function prepareAgentEnv(
       );
     }
   } else if (adapterCommand === "gemini") {
-    if (!env.GEMINI_API_KEY) {
-      const missReason = await injectCredential(
-        env,
-        "gemini_api_key",
-        "GEMINI_API_KEY",
-        "Gemini API key for ACP agent authentication",
-      );
-      if (missReason !== undefined) {
-        // Optional credential: Gemini CLI can authenticate via its own
-        // OAuth login, so a vault miss must not fail the spawn.
-        log.debug(
-          { reason: missReason },
-          "Gemini API key unavailable from the vault; spawning without GEMINI_API_KEY",
-        );
-      }
-    }
+    await injectOptionalCredential(
+      env,
+      "gemini_api_key",
+      "GEMINI_API_KEY",
+      "Gemini API key for ACP agent authentication",
+    );
+  } else if (adapterCommand === "codex-acp") {
+    await injectOptionalCredential(
+      env,
+      "openai_api_key",
+      "OPENAI_API_KEY",
+      "OpenAI API key for Codex ACP agent authentication",
+    );
+    await injectOptionalCredential(
+      env,
+      "codex_api_key",
+      "CODEX_API_KEY",
+      "Codex API key for Codex ACP agent authentication",
+    );
   }
 
   return { ...agentConfig, env };


### PR DESCRIPTION
## Summary
- prepareAgentEnv now optionally injects OPENAI_API_KEY (vault field acp/openai_api_key) and CODEX_API_KEY (acp/codex_api_key) for the codex-acp adapter, mirroring the gemini optional pattern
- config.json acp.agents.<id>.env values still win; vault misses are non-fatal (ChatGPT login remains a valid auth path)

Part of plan: acp-codex-auth-export-redaction.md (PR 2 of 7)