### PR TITLE
fix(security): redact secrets in tool-invocation inputs before they reach the audit store

### DIFF
--- a/assistant/src/__tests__/tool-audit-listener.test.ts
+++ b/assistant/src/__tests__/tool-audit-listener.test.ts
@@ -101,6 +101,86 @@ describe("tool audit listener", () => {
     expect(records[0].result).toContain("<redacted");
   });
 
+  test("redacts known-pattern secrets in tool inputs before recording", () => {
+    const records: ToolInvocationRecord[] = [];
+    const listener = createToolAuditListener((record) => records.push(record));
+
+    // OpenAI Project Key pattern requires 40+ base64url chars after
+    // "sk-proj-"; value chosen to dodge the scanner's placeholder filtering
+    // (no test/fake/example markers, not same-char or x-runs).
+    const openaiKey =
+      "sk-proj-Ab3dEf6hIj9kLm2nOp5qRs8tUv1wXy4zAb7cDe0fGh3iJk6l";
+    const input = { command: `export OPENAI_API_KEY="${openaiKey}"` };
+
+    listener({
+      type: "executed",
+      toolName: "bash",
+      input,
+      workingDir: "/tmp",
+      conversationId: "conv-input-redact",
+      riskLevel: "low",
+      decision: "allow",
+      durationMs: 5,
+      result: { content: "ok", isError: false },
+    });
+    listener({
+      type: "error",
+      toolName: "bash",
+      input,
+      workingDir: "/tmp",
+      conversationId: "conv-input-redact",
+      riskLevel: "low",
+      decision: "error",
+      durationMs: 5,
+      errorMessage: "boom",
+      isExpected: false,
+      errorCategory: "tool_failure",
+    });
+    listener({
+      type: "permission_denied",
+      toolName: "bash",
+      input,
+      workingDir: "/tmp",
+      conversationId: "conv-input-redact",
+      riskLevel: "high",
+      decision: "deny",
+      reason: "Permission denied by user",
+      durationMs: 5,
+    });
+
+    expect(records).toHaveLength(3);
+    for (const record of records) {
+      expect(record.input).toContain('<redacted type="OpenAI Project Key" />');
+      expect(record.input).not.toContain(openaiKey);
+    }
+  });
+
+  test("benign inputs round-trip byte-identical (no false-positive mangling)", () => {
+    const records: ToolInvocationRecord[] = [];
+    const listener = createToolAuditListener((record) => records.push(record));
+
+    const input = {
+      command: "git log --oneline -5 && echo done",
+      cwd: "/tmp/project",
+      env: { LANG: "en_US.UTF-8" },
+    };
+
+    listener({
+      type: "executed",
+      toolName: "bash",
+      input,
+      workingDir: "/tmp",
+      conversationId: "conv-benign-input",
+      riskLevel: "low",
+      decision: "allow",
+      durationMs: 2,
+      result: { content: "ok", isError: false },
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].input).toBe(JSON.stringify(input));
+  });
+
   test("does not redact non-secret content like UUIDs or hashes", () => {
     const records: ToolInvocationRecord[] = [];
     const listener = createToolAuditListener((record) => records.push(record));

--- a/assistant/src/events/tool-audit-listener.ts
+++ b/assistant/src/events/tool-audit-listener.ts
@@ -43,11 +43,14 @@ function toInvocationRecord(
 ): ToolInvocationRecord | null {
   switch (event.type) {
     case "executed": {
-      const input = stringifyToolInput(event.input);
+      const rawInput = stringifyToolInput(event.input);
       return {
         conversationId: event.conversationId,
         toolName: event.toolName,
-        input,
+        // Inputs can carry secrets the model typed verbatim (e.g.
+        // `export OPENAI_API_KEY=...` in a bash command) — redact before
+        // the row reaches the audit store, like results below.
+        input: redactSecrets(rawInput),
         result: redactSecrets(event.result.content).slice(
           0,
           RESULT_PREVIEW_LIMIT,
@@ -63,18 +66,18 @@ function toInvocationRecord(
         // don't stamp.
         ...telemetryColumns(
           event,
-          input,
+          rawInput,
           event.resultBytes ?? Buffer.byteLength(event.result.content, "utf8"),
         ),
       };
     }
     case "error": {
-      const input = stringifyToolInput(event.input);
+      const rawInput = stringifyToolInput(event.input);
       const result = `error: ${event.errorMessage}`;
       return {
         conversationId: event.conversationId,
         toolName: event.toolName,
-        input,
+        input: redactSecrets(rawInput),
         result,
         decision: "error",
         riskLevel: event.riskLevel,
@@ -83,7 +86,7 @@ function toInvocationRecord(
         // The error result string is built right here and never goes
         // through sensitive-output sanitization, so sizing it directly is
         // already raw — no executor stamp exists or is needed.
-        ...telemetryColumns(event, input, Buffer.byteLength(result, "utf8")),
+        ...telemetryColumns(event, rawInput, Buffer.byteLength(result, "utf8")),
       };
     }
     case "permission_denied":
@@ -92,7 +95,7 @@ function toInvocationRecord(
       return {
         conversationId: event.conversationId,
         toolName: event.toolName,
-        input: stringifyToolInput(event.input),
+        input: redactSecrets(stringifyToolInput(event.input)),
         result: formatDeniedResult(event.reason),
         decision: "denied",
         riskLevel: event.riskLevel,
@@ -134,12 +137,12 @@ const NULL_TELEMETRY_COLUMNS: TelemetryColumns = {
  */
 function telemetryColumns(
   event: Extract<ToolLifecycleEvent, { type: "executed" | "error" }>,
-  input: string,
+  rawInput: string,
   resultBytes: number,
 ): TelemetryColumns {
   if (!getConfig().collectUsageData) return NULL_TELEMETRY_COLUMNS;
   return {
-    argBytes: event.inputBytes ?? Buffer.byteLength(input, "utf8"),
+    argBytes: event.inputBytes ?? Buffer.byteLength(rawInput, "utf8"),
     resultBytes,
     ...toAttributionColumns(event.attribution),
   };


### PR DESCRIPTION
## Summary
- Tool-invocation inputs are now passed through redactSecrets before being written to the toolInvocations audit store (results were already redacted; inputs were stored raw)
- Closes the leak where secrets typed into bash commands (e.g. export OPENAI_API_KEY=...) landed in plaintext in exported audit-data.json

Part of plan: acp-codex-auth-export-redaction.md (PR 3 of 7)