### PR TITLE
fix(acp): authenticate via advertised env_var auth methods when agents return auth_required

### DIFF
--- a/assistant/src/acp/__tests__/agent-process.test.ts
+++ b/assistant/src/acp/__tests__/agent-process.test.ts
@@ -6,9 +6,9 @@
  * connection is stubbed directly so no child process is spawned.
  */
 
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 
-import type { InitializeResponse } from "@agentclientprotocol/sdk";
+import type { AuthMethod, InitializeResponse } from "@agentclientprotocol/sdk";
 
 import { AcpAgentProcess } from "../agent-process.js";
 
@@ -157,5 +157,219 @@ describe("AcpAgentProcess loadSession/resumeSession", () => {
     await expect(
       proc.resumeSession("session-1", "/tmp/project"),
     ).rejects.toThrow('ACP agent "test-agent" is not spawned');
+  });
+});
+
+describe("AcpAgentProcess auth_required retry", () => {
+  // The merged child env includes process.env, so the advertised var names use
+  // a VELLUM_TEST_ prefix guaranteed absent from the test process env. The
+  // structure mirrors codex-acp's real advertisement: an agent-driven browser
+  // login (no `type`, must never be auto-selected) followed by two env_var
+  // methods, in that order.
+  const CODEX_VAR = "VELLUM_TEST_FAKE_CODEX_API_KEY";
+  const OPENAI_VAR = "VELLUM_TEST_FAKE_OPENAI_API_KEY";
+
+  const codexLikeAuthMethods: AuthMethod[] = [
+    { id: "chatgpt", name: "Login with ChatGPT" },
+    {
+      type: "env_var",
+      id: "codex-api-key",
+      name: "Use CODEX_API_KEY",
+      vars: [{ name: CODEX_VAR }],
+    },
+    {
+      type: "env_var",
+      id: "openai-api-key",
+      name: "Use OPENAI_API_KEY",
+      vars: [{ name: OPENAI_VAR }],
+    },
+  ];
+
+  const authRequiredError = { code: -32000, message: "Authentication required" };
+
+  /**
+   * Creates a process whose connection is stubbed with mocks, then runs
+   * initialize() so the advertised authMethods are captured.
+   */
+  async function setupAuthProcess(options: {
+    env?: Record<string, string>;
+    authMethods?: AuthMethod[];
+    /** Rejections to throw from successive newSession calls before succeeding. */
+    newSessionRejections?: unknown[];
+    loadSessionRejections?: unknown[];
+    resumeSessionRejections?: unknown[];
+  }) {
+    const proc = new AcpAgentProcess(
+      "codex",
+      { command: "echo", args: [], env: options.env },
+      () => {
+        throw new Error("client factory should not be called in this test");
+      },
+    );
+
+    function failThenSucceed(rejections: unknown[], result: unknown) {
+      let calls = 0;
+      return mock(() => {
+        const rejection = rejections[calls];
+        calls += 1;
+        return rejection != null
+          ? Promise.reject(rejection)
+          : Promise.resolve(result);
+      });
+    }
+
+    const newSession = failThenSucceed(options.newSessionRejections ?? [], {
+      sessionId: "session-1",
+    });
+    const loadSession = failThenSucceed(options.loadSessionRejections ?? [], {});
+    const resumeSession = failThenSucceed(
+      options.resumeSessionRejections ?? [],
+      {},
+    );
+    const authenticate = mock(() => Promise.resolve({}));
+
+    (proc as unknown as { connection: unknown }).connection = {
+      initialize: () =>
+        Promise.resolve({
+          protocolVersion: 1,
+          authMethods: options.authMethods ?? codexLikeAuthMethods,
+        }),
+      newSession,
+      loadSession,
+      resumeSession,
+      authenticate,
+    };
+
+    await proc.initialize();
+
+    return { proc, newSession, loadSession, resumeSession, authenticate };
+  }
+
+  test("createSession does not authenticate when newSession succeeds", async () => {
+    const { proc, newSession, authenticate } = await setupAuthProcess({
+      env: { [OPENAI_VAR]: "sk-test" },
+    });
+
+    const sessionId = await proc.createSession("/tmp/project");
+
+    expect(sessionId).toBe("session-1");
+    expect(newSession).toHaveBeenCalledTimes(1);
+    expect(authenticate).not.toHaveBeenCalled();
+  });
+
+  test("auth_required with OPENAI-style key authenticates and retries once", async () => {
+    const { proc, newSession, authenticate } = await setupAuthProcess({
+      env: { [OPENAI_VAR]: "sk-test" },
+      newSessionRejections: [authRequiredError],
+    });
+
+    const sessionId = await proc.createSession("/tmp/project");
+
+    expect(sessionId).toBe("session-1");
+    expect(authenticate).toHaveBeenCalledTimes(1);
+    expect(authenticate).toHaveBeenCalledWith({ methodId: "openai-api-key" });
+    expect(newSession).toHaveBeenCalledTimes(2);
+  });
+
+  test("auth_required with CODEX-style key selects the earlier advertised method", async () => {
+    const { proc, authenticate } = await setupAuthProcess({
+      env: { [CODEX_VAR]: "sk-codex" },
+      newSessionRejections: [authRequiredError],
+    });
+
+    await proc.createSession("/tmp/project");
+
+    expect(authenticate).toHaveBeenCalledTimes(1);
+    expect(authenticate).toHaveBeenCalledWith({ methodId: "codex-api-key" });
+  });
+
+  test("auth_required with no satisfiable env_var method throws an actionable error", async () => {
+    const { proc, newSession, authenticate } = await setupAuthProcess({
+      env: {},
+      newSessionRejections: [authRequiredError],
+    });
+
+    const promise = proc.createSession("/tmp/project");
+
+    await expect(promise).rejects.toThrow(
+      'ACP agent "codex" requires authentication',
+    );
+    await expect(promise).rejects.toThrow("Login with ChatGPT");
+    await expect(promise).rejects.toThrow(CODEX_VAR);
+    await expect(promise).rejects.toThrow(OPENAI_VAR);
+    expect(authenticate).not.toHaveBeenCalled();
+    expect(newSession).toHaveBeenCalledTimes(1);
+  });
+
+  test("a second auth_required after authenticating propagates without a retry loop", async () => {
+    const { proc, newSession, authenticate } = await setupAuthProcess({
+      env: { [OPENAI_VAR]: "sk-test" },
+      newSessionRejections: [authRequiredError, authRequiredError],
+    });
+
+    await expect(proc.createSession("/tmp/project")).rejects.toMatchObject({
+      code: -32000,
+    });
+    expect(authenticate).toHaveBeenCalledTimes(1);
+    expect(newSession).toHaveBeenCalledTimes(2);
+  });
+
+  test("an absent optional var does not block satisfiability", async () => {
+    const { proc, authenticate } = await setupAuthProcess({
+      env: { [OPENAI_VAR]: "sk-test" },
+      authMethods: [
+        {
+          type: "env_var",
+          id: "openai-api-key",
+          name: "Use OPENAI_API_KEY",
+          vars: [
+            { name: OPENAI_VAR },
+            { name: "VELLUM_TEST_FAKE_OPTIONAL_VAR", optional: true },
+          ],
+        },
+      ],
+      newSessionRejections: [authRequiredError],
+    });
+
+    await proc.createSession("/tmp/project");
+
+    expect(authenticate).toHaveBeenCalledWith({ methodId: "openai-api-key" });
+  });
+
+  test("loadSession authenticates and retries on auth_required", async () => {
+    const { proc, loadSession, authenticate } = await setupAuthProcess({
+      env: { [OPENAI_VAR]: "sk-test" },
+      loadSessionRejections: [authRequiredError],
+    });
+
+    await proc.loadSession("session-1", "/tmp/project");
+
+    expect(authenticate).toHaveBeenCalledWith({ methodId: "openai-api-key" });
+    expect(loadSession).toHaveBeenCalledTimes(2);
+  });
+
+  test("resumeSession authenticates and retries on auth_required", async () => {
+    const { proc, resumeSession, authenticate } = await setupAuthProcess({
+      env: { [OPENAI_VAR]: "sk-test" },
+      resumeSessionRejections: [authRequiredError],
+    });
+
+    await proc.resumeSession("session-1", "/tmp/project");
+
+    expect(authenticate).toHaveBeenCalledWith({ methodId: "openai-api-key" });
+    expect(resumeSession).toHaveBeenCalledTimes(2);
+  });
+
+  test("a non-auth error propagates without authenticating", async () => {
+    const { proc, newSession, authenticate } = await setupAuthProcess({
+      env: { [OPENAI_VAR]: "sk-test" },
+      newSessionRejections: [{ code: -32603, message: "Internal error" }],
+    });
+
+    await expect(proc.createSession("/tmp/project")).rejects.toMatchObject({
+      code: -32603,
+    });
+    expect(authenticate).not.toHaveBeenCalled();
+    expect(newSession).toHaveBeenCalledTimes(1);
   });
 });

--- a/assistant/src/acp/agent-process.ts
+++ b/assistant/src/acp/agent-process.ts
@@ -10,6 +10,8 @@ import { Readable, Writable } from "node:stream";
 
 import type {
   Agent,
+  AuthMethod,
+  AuthMethodEnvVar,
   Client,
   InitializeResponse,
   NewSessionResponse,
@@ -21,6 +23,31 @@ import { getLogger } from "../util/logger.js";
 import type { AcpAgentConfig } from "./types.js";
 
 const log = getLogger("acp");
+
+/**
+ * JSON-RPC error code agents use to signal that authentication is required
+ * (matches the SDK's RequestError.authRequired()).
+ */
+const AUTH_REQUIRED_CODE = -32000;
+
+/**
+ * Detects the ACP auth-required error. Checks the `code` property rather than
+ * `instanceof acp.RequestError` so plain JSON-RPC error objects are also
+ * recognized.
+ */
+function isAuthRequiredError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { code?: unknown }).code === AUTH_REQUIRED_CODE
+  );
+}
+
+function isEnvVarMethod(
+  method: AuthMethod,
+): method is AuthMethodEnvVar & { type: "env_var" } {
+  return "type" in method && method.type === "env_var";
+}
 
 /**
  * Factory function type for creating ACP client handlers.
@@ -54,7 +81,7 @@ export class AcpAgentProcess {
     this.proc = spawn(this.config.command, this.config.args, {
       cwd,
       stdio: ["pipe", "pipe", "pipe"],
-      env: { ...process.env, ...this.config.env },
+      env: this.childEnv(),
     });
 
     const stream = acp.ndJsonStream(
@@ -133,6 +160,105 @@ export class AcpAgentProcess {
   }
 
   /**
+   * Authentication methods the agent advertised at initialize.
+   * Returns an empty array before initialize() resolves.
+   */
+  get authMethods(): AuthMethod[] {
+    return this.initializeResponse?.authMethods ?? [];
+  }
+
+  /**
+   * Authenticates with the agent using one of its advertised auth methods.
+   */
+  async authenticate(methodId: string): Promise<void> {
+    if (!this.connection) {
+      throw new Error(`ACP agent "${this.agentId}" is not spawned`);
+    }
+
+    log.info({ agentId: this.agentId, methodId }, "Authenticating ACP agent");
+
+    await this.connection.authenticate({ methodId });
+  }
+
+  /**
+   * Selects the first advertised env_var auth method whose required variables
+   * are all present (non-empty) in the env the agent process was spawned with.
+   *
+   * Terminal-type and agent-driven (untyped) methods are never selected:
+   * auto-triggering an interactive login would hang the headless daemon.
+   */
+  private selectEnvVarAuthMethod(): AuthMethod | undefined {
+    const env = this.childEnv();
+
+    return this.authMethods.find((method) => {
+      if (!isEnvVarMethod(method)) return false;
+
+      const requiredVars = method.vars.filter((v) => !v.optional);
+      if (requiredVars.length === 0) return false;
+
+      return requiredVars.every((v) => {
+        const value = env[v.name];
+        return typeof value === "string" && value.length > 0;
+      });
+    });
+  }
+
+  /** The environment the agent child process is spawned with. */
+  private childEnv(): NodeJS.ProcessEnv {
+    return { ...process.env, ...this.config.env };
+  }
+
+  /**
+   * Runs an operation, and if the agent rejects with the ACP auth-required
+   * error, authenticates via a satisfiable env_var auth method and retries
+   * the operation exactly once.
+   */
+  private async withAuthRetry<T>(op: () => Promise<T>): Promise<T> {
+    try {
+      return await op();
+    } catch (err) {
+      if (!isAuthRequiredError(err)) throw err;
+
+      const method = this.selectEnvVarAuthMethod();
+      if (!method) {
+        throw new Error(
+          `ACP agent "${this.agentId}" requires authentication. ` +
+            `Advertised methods: ${this.describeAuthMethods()}. ` +
+            "Set the required env var under acp.agents.<id>.env in config.json, " +
+            "store it via 'assistant credentials set --service acp --field <field>', " +
+            "or complete the agent's own login flow in the workspace.",
+        );
+      }
+
+      log.info(
+        { agentId: this.agentId, methodId: method.id },
+        "ACP agent returned auth_required; authenticating with env_var method",
+      );
+
+      await this.authenticate(method.id);
+      return await op();
+    }
+  }
+
+  /**
+   * Renders the agent's advertised auth methods for error messages, e.g.
+   * `"Login with ChatGPT" (chatgpt), "Use OPENAI_API_KEY" (env var OPENAI_API_KEY)`.
+   */
+  private describeAuthMethods(): string {
+    if (this.authMethods.length === 0) return "none";
+
+    return this.authMethods
+      .map((method) => {
+        if (isEnvVarMethod(method)) {
+          const varNames = method.vars.map((v) => v.name).join(", ");
+          return `"${method.name}" (env var ${varNames})`;
+        }
+        return `"${method.name}" (${method.id})`;
+      })
+      .join(", ");
+  }
+
+  /**
    * Creates a new ACP session in the specified working directory.
    * Returns the session ID.
    */
@@ -143,10 +269,9 @@ export class AcpAgentProcess {
 
     log.info({ agentId: this.agentId, cwd }, "Creating ACP session");
 
-    const result: NewSessionResponse = await this.connection.newSession({
-      cwd,
-      mcpServers: [],
-    });
+    const result: NewSessionResponse = await this.withAuthRetry(() =>
+      this.connection!.newSession({ cwd, mcpServers: [] }),
+    );
 
     return result.sessionId;
   }
@@ -166,7 +291,9 @@ export class AcpAgentProcess {
 
     log.info({ agentId: this.agentId, sessionId, cwd }, "Loading ACP session");
 
-    await this.connection.loadSession({ sessionId, cwd, mcpServers: [] });
+    await this.withAuthRetry(() =>
+      this.connection!.loadSession({ sessionId, cwd, mcpServers: [] }),
+    );
   }
 
   /**
@@ -183,7 +310,9 @@ export class AcpAgentProcess {
 
     log.info({ agentId: this.agentId, sessionId, cwd }, "Resuming ACP session");
 
-    await this.connection.resumeSession({ sessionId, cwd, mcpServers: [] });
+    await this.withAuthRetry(() =>
+      this.connection!.resumeSession({ sessionId, cwd, mcpServers: [] }),
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary
- AcpAgentProcess now handles the ACP auth_required error (-32000): it selects the first satisfiable advertised env_var auth method, calls authenticate, and retries session establishment once
- Fixes codex-acp spawns failing with 'Failed to spawn ACP agent: Authentication required' even when OPENAI_API_KEY/CODEX_API_KEY are configured
- Unsatisfiable auth now fails with an actionable error listing the agent's advertised methods

Part of plan: acp-codex-auth-export-redaction.md (PR 1 of 7)