### PR TITLE
fix(macos): redact acp.agents env values in the client-side config snapshot fallback

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -1163,8 +1163,22 @@ enum LogExporter {
     /// Fetches the workspace config from the daemon and writes a sanitized copy
     /// with sensitive values replaced by presence flags.
     private nonisolated static func writeSanitizedWorkspaceConfig(to url: URL) async {
-        var config = await SettingsClient().fetchConfig() ?? [:]
+        let config = await SettingsClient().fetchConfig() ?? [:]
         guard !config.isEmpty else { return }
+
+        let sanitized = sanitizeWorkspaceConfig(config)
+
+        guard let data = try? JSONSerialization.data(
+            withJSONObject: sanitized,
+            options: [.prettyPrinted, .sortedKeys]
+        ) else { return }
+        try? data.write(to: url)
+    }
+
+    /// Returns a copy of the workspace config with sensitive values replaced
+    /// by presence flags ("(set)" / "(empty)").
+    nonisolated static func sanitizeWorkspaceConfig(_ config: [String: Any]) -> [String: Any] {
+        var config = config
 
         // Strip API key values — preserve which providers have keys configured
         if var apiKeys = config["apiKeys"] as? [String: Any] {
@@ -1234,11 +1248,24 @@ enum LogExporter {
             config["mcp"] = mcp
         }
 
-        guard let data = try? JSONSerialization.data(
-            withJSONObject: config,
-            options: [.prettyPrinted, .sortedKeys]
-        ) else { return }
-        try? data.write(to: url)
+        // Strip ACP agent env vars
+        if var acp = config["acp"] as? [String: Any],
+           var agents = acp["agents"] as? [String: [String: Any]] {
+            for name in agents.keys {
+                var agent = agents[name]!
+                if var env = agent["env"] as? [String: Any] {
+                    for key in env.keys {
+                        env[key] = redactValue(env[key])
+                    }
+                    agent["env"] = env
+                }
+                agents[name] = agent
+            }
+            acp["agents"] = agents
+            config["acp"] = acp
+        }
+
+        return config
     }
 
     /// Writes a human-readable error log file for a failed export API call.

--- a/clients/macos/vellum-assistantTests/LogExporterClientArtifactsTests.swift
+++ b/clients/macos/vellum-assistantTests/LogExporterClientArtifactsTests.swift
@@ -29,6 +29,91 @@ struct LogExporterClientArtifactsTests {
         }
     }
 
+    // MARK: - Workspace Config Sanitization
+
+    @Test
+    func sanitizeWorkspaceConfigRedactsAcpAgentEnvValues() throws {
+        let config: [String: Any] = [
+            "acp": [
+                "agents": [
+                    "codex": [
+                        "command": "codex",
+                        "args": ["acp"],
+                        "env": [
+                            "OPENAI_API_KEY": "sk-proj-synthetic-test-value-1234567890",
+                            "EMPTY_VAR": ""
+                        ]
+                    ]
+                ]
+            ],
+            "apiKeys": [
+                "anthropic": "sk-ant-synthetic-test-value"
+            ],
+            "model": "some-model"
+        ]
+
+        let sanitized = LogExporter.sanitizeWorkspaceConfig(config)
+
+        guard let acp = sanitized["acp"] as? [String: Any],
+              let agents = acp["agents"] as? [String: [String: Any]],
+              let codex = agents["codex"],
+              let env = codex["env"] as? [String: Any] else {
+            Issue.record("Expected sanitized acp.agents.codex.env")
+            return
+        }
+
+        // Env keys are preserved, values become presence flags
+        #expect(env["OPENAI_API_KEY"] as? String == "(set)")
+        #expect(env["EMPTY_VAR"] as? String == "(empty)")
+
+        // Non-sensitive agent fields round-trip unchanged
+        #expect(codex["command"] as? String == "codex")
+        #expect(codex["args"] as? [String] == ["acp"])
+
+        // Already-covered path (apiKeys) is still redacted
+        guard let apiKeys = sanitized["apiKeys"] as? [String: Any] else {
+            Issue.record("Expected sanitized apiKeys")
+            return
+        }
+        #expect(apiKeys["anthropic"] as? String == "(set)")
+
+        // Untouched sections round-trip unchanged
+        #expect(sanitized["model"] as? String == "some-model")
+
+        // No plaintext secrets anywhere in the serialized output
+        let data = try JSONSerialization.data(withJSONObject: sanitized)
+        let json = String(decoding: data, as: UTF8.self)
+        #expect(!json.contains("sk-proj-synthetic-test-value-1234567890"))
+        #expect(!json.contains("sk-ant-synthetic-test-value"))
+    }
+
+    @Test
+    func sanitizeWorkspaceConfigPassesThroughAgentsWithoutEnv() throws {
+        let config: [String: Any] = [
+            "model": "some-model",
+            "acp": [
+                "agents": [
+                    "codex": [
+                        "command": "codex"
+                    ]
+                ]
+            ]
+        ]
+
+        let sanitized = LogExporter.sanitizeWorkspaceConfig(config)
+
+        // Agents without env blocks pass through unchanged
+        guard let acp = sanitized["acp"] as? [String: Any],
+              let agents = acp["agents"] as? [String: [String: Any]],
+              let codex = agents["codex"] else {
+            Issue.record("Expected acp.agents.codex to round-trip")
+            return
+        }
+        #expect(codex["command"] as? String == "codex")
+        #expect(codex["env"] == nil)
+        #expect(sanitized["model"] as? String == "some-model")
+    }
+
     // MARK: - All Artifacts Present
 
     @Test


### PR DESCRIPTION
## Summary
- Extracts LogExporter's config sanitization into a testable sanitizeWorkspaceConfig helper and adds acp.agents.*.env redaction (presence flags), mirroring the existing mcp.servers handling
- Closes the client-side fallback config-snapshot.json plaintext API key leak

Part of plan: acp-codex-auth-export-redaction.md (PR 6 of 7)