### PR TITLE
fix(export): run a secret-redaction sweep over every staged text file before archiving

### DIFF
--- a/assistant/src/__tests__/log-export-workspace.test.ts
+++ b/assistant/src/__tests__/log-export-workspace.test.ts
@@ -36,9 +36,12 @@ mock.module("../util/secure-keys.js", () => ({
   getSecureKeyAsync: async () => undefined,
 }));
 
+import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
+import { conversations, toolInvocations } from "../memory/schema.js";
 import { RouteError } from "../runtime/routes/errors.js";
 import { ROUTES } from "../runtime/routes/log-export-routes.js";
+import { redactStagedExportFiles } from "../runtime/routes/redact-staged-export.js";
 
 initializeDb();
 
@@ -472,6 +475,123 @@ describe("POST /v1/export — workspace allowlist", () => {
       expect(entries).toContain("2025-01-15T00-00-00.000Z_conv-jan15");
       expect(entries).toContain("2025-01-20T00-00-00.000Z_conv-jan20");
       expect(entries).toContain("2025-01-25T00-00-00.000Z_conv-jan25");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Export-time secret sweep
+// ---------------------------------------------------------------------------
+
+// A synthetic OpenAI project key that matches the scanner's
+// `sk-proj-[A-Za-z0-9\-_]{40,}` pattern while deliberately dodging its
+// placeholder filtering: no "test"/"example"/"xxxx"-style segments, not a
+// repeated character, and it ends with an alphanumeric so the trailing `\b`
+// boundary holds.
+const RAW_OPENAI_PROJECT_KEY =
+  "sk-proj-Ab1Cd2Ef3Gh4Ij5Kl6Mn7Op8Qr9St0Uv1Wx2Yz3Ab4Cd5Ef6Gh";
+const REDACTION_MARKER = '<redacted type="OpenAI Project Key" />';
+
+// NOTE: these tests intentionally run after every other describe block in
+// this file — they seed a workspace conversation and an audit DB row that
+// contain a raw secret, which would otherwise leak into the exports made by
+// the earlier (clean-state) tests.
+describe("POST /v1/export — staged-file secret sweep", () => {
+  test("clean staged files are left byte-identical and report filesRedacted: 0", () => {
+    const staging = mkdtempSync(join(tmpdir(), "redact-staged-clean-"));
+    try {
+      mkdirSync(join(staging, "daemon-logs"), { recursive: true });
+      const seeded: Record<string, string> = {
+        "audit-data.json": JSON.stringify(
+          [{ id: "ti-1", toolName: "bash", input: "{}" }],
+          null,
+          2,
+        ),
+        "daemon-logs/assistant-2025-01-10.log": "log entry from Jan 10\n",
+        "notes.md": "# clean notes\n",
+      };
+      for (const [rel, content] of Object.entries(seeded)) {
+        writeFileSync(join(staging, rel), content, "utf-8");
+      }
+
+      const result = redactStagedExportFiles(staging);
+
+      expect(result).toEqual({ filesScanned: 3, filesRedacted: 0 });
+      for (const [rel, content] of Object.entries(seeded)) {
+        expect(readFileSync(join(staging, rel), "utf-8")).toBe(content);
+      }
+    } finally {
+      rmSync(staging, { recursive: true, force: true });
+    }
+  });
+
+  test("redacts raw keys from workspace conversation files in the archive", async () => {
+    seedConversation(
+      "2025-01-30T00-00-00.000Z_conv-secret",
+      JSON.stringify({
+        role: "user",
+        content: `export OPENAI_API_KEY="${RAW_OPENAI_PROJECT_KEY}"`,
+      }) + "\n",
+    );
+
+    const res = await callExport();
+    const dir = await extractArchive(res);
+    try {
+      const content = readFileSync(
+        join(
+          dir,
+          "workspace",
+          "conversations",
+          "2025-01-30T00-00-00.000Z_conv-secret",
+          "messages.jsonl",
+        ),
+        "utf-8",
+      );
+      expect(content).toContain(REDACTION_MARKER);
+      expect(content).not.toContain(RAW_OPENAI_PROJECT_KEY);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("redacts legacy audit rows and keeps audit-data.json valid JSON", async () => {
+    // Simulate a row written before write-time input redaction shipped: the
+    // raw key sits in the persisted `input` column, where no structural
+    // sanitizer can retroactively fix it.
+    const db = getDb();
+    const now = Date.now();
+    db.insert(conversations)
+      .values({ id: "conv-legacy-audit", createdAt: now, updatedAt: now })
+      .run();
+    db.insert(toolInvocations)
+      .values({
+        id: "ti-legacy-audit",
+        conversationId: "conv-legacy-audit",
+        toolName: "bash",
+        input: JSON.stringify({
+          command: `export OPENAI_API_KEY="${RAW_OPENAI_PROJECT_KEY}"`,
+        }),
+        result: "{}",
+        decision: "allow",
+        riskLevel: "low",
+        durationMs: 5,
+        createdAt: now,
+      })
+      .run();
+
+    const res = await callExport();
+    const dir = await extractArchive(res);
+    try {
+      const content = readFileSync(join(dir, "audit-data.json"), "utf-8");
+      expect(content).not.toContain(RAW_OPENAI_PROJECT_KEY);
+      // The sweep must keep the file parseable — redaction goes through a
+      // JSON-aware path rather than splicing quoted markers into raw JSON.
+      const rows = JSON.parse(content) as Array<{ id: string; input: string }>;
+      const row = rows.find((r) => r.id === "ti-legacy-audit");
+      expect(row).toBeDefined();
+      expect(row!.input).toContain(REDACTION_MARKER);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -41,6 +41,7 @@ import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { createTarGz } from "./archive-utils.js";
 import { InternalError } from "./errors.js";
 import { collectWorkspaceData } from "./log-export/workspace-allowlist.js";
+import { redactStagedExportFiles } from "./redact-staged-export.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("log-export-routes");
@@ -343,6 +344,13 @@ async function handleExport({
       "utf-8",
     );
 
+    // --- Secret-redaction sweep over every staged text file ---
+    // Belt-and-suspenders over the structural sanitizers above: catches
+    // legacy audit rows persisted with plaintext inputs (written before
+    // write-time redaction existed) and secrets sitting in copied workspace
+    // conversation files.
+    const redactionResult = redactStagedExportFiles(staging);
+
     log.info(
       {
         auditCount: auditRows.length,
@@ -353,6 +361,8 @@ async function handleExport({
         full: full ?? false,
         workspaceEntries: workspaceResult.entries.length,
         workspaceBytes: workspaceResult.totalBytes,
+        redactionScanned: redactionResult.filesScanned,
+        redactionRedacted: redactionResult.filesRedacted,
       },
       "Export collected, creating tar.gz archive",
     );

--- a/assistant/src/runtime/routes/redact-staged-export.ts
+++ b/assistant/src/runtime/routes/redact-staged-export.ts
@@ -1,0 +1,165 @@
+/**
+ * Export-time secret sweep for the log export staging directory.
+ *
+ * `POST /v1/export` stages audit DB rows, daemon logs, a sanitized config
+ * snapshot, and allowlisted workspace files before archiving them. The
+ * structural sanitizers (write-time audit-input redaction, config snapshot
+ * env scrubbing) only protect data written after they shipped — legacy audit
+ * rows already persisted with plaintext inputs, and free-form workspace
+ * conversation logs, can still carry raw secrets. This module is the final
+ * belt: a pattern-based `redactSecrets()` pass over every staged text file
+ * immediately before the tar.gz is created.
+ */
+
+import type { Dirent } from "node:fs";
+import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { extname, join } from "node:path";
+
+import { redactSecrets } from "../../security/secret-scanner.js";
+import { getLogger } from "../../util/logger.js";
+
+const log = getLogger("redact-staged-export");
+
+/**
+ * Extensions eligible for the sweep. Covers everything the export stages as
+ * text today: `audit-data.json`, `messages.json`, `config-snapshot.json`,
+ * daemon `.log` files, `conversation-filtered.jsonl`, and the workspace
+ * copies (`conversations/**\/messages.jsonl`, `.tool-results/*.txt`).
+ */
+const REDACTABLE_EXTENSIONS = new Set([
+  ".json",
+  ".jsonl",
+  ".txt",
+  ".log",
+  ".md",
+]);
+
+/**
+ * Files larger than this are skipped to bound memory — the sweep reads each
+ * file fully into memory. Today's largest staged file is ~1–3 MB, so 32 MiB
+ * leaves ample headroom.
+ */
+const MAX_SWEEP_FILE_BYTES = 32 * 1024 * 1024;
+
+interface RedactionState {
+  changed: boolean;
+}
+
+function redactString(value: string, state: RedactionState): string {
+  const redacted = redactSecrets(value);
+  if (redacted !== value) state.changed = true;
+  return redacted;
+}
+
+/**
+ * Redact secrets in a parsed JSON value, walking every string leaf (keys
+ * included). Sets `state.changed` when any redaction fired.
+ */
+function redactJsonValue(value: unknown, state: RedactionState): unknown {
+  if (typeof value === "string") {
+    return redactString(value, state);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactJsonValue(item, state));
+  }
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(
+        ([key, val]) =>
+          [redactString(key, state), redactJsonValue(val, state)] as const,
+      ),
+    );
+  }
+  return value;
+}
+
+/**
+ * Redact a `.json` file's content while preserving JSON validity. The
+ * redaction marker (`<redacted type="..." />`) contains double quotes, so
+ * splicing it into serialized JSON would corrupt any string it lands inside.
+ * Parse, redact every string leaf, and re-stringify instead. Falls back to
+ * plain-text redaction when the content isn't valid JSON — the file is
+ * already malformed, so there is no validity to preserve.
+ */
+function redactJsonContent(content: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return redactSecrets(content);
+  }
+  const state = { changed: false };
+  const redacted = redactJsonValue(parsed, state);
+  return state.changed ? JSON.stringify(redacted, null, 2) : content;
+}
+
+/**
+ * Run a secret-redaction sweep over every staged text file under
+ * `stagingDir`, rewriting in place any file where `redactSecrets()` found a
+ * match. Unchanged files are left byte-identical (no gratuitous rewrites).
+ *
+ * Per-file failures are logged and skipped — a single unreadable file must
+ * never fail the export (degraded mode beats no archive at all).
+ */
+export function redactStagedExportFiles(stagingDir: string): {
+  filesScanned: number;
+  filesRedacted: number;
+} {
+  let filesScanned = 0;
+  let filesRedacted = 0;
+
+  const stack: string[] = [stagingDir];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch (err) {
+      log.warn(
+        { err, dir },
+        "Failed to read staged export directory during secret sweep; skipping",
+      );
+      continue;
+    }
+    for (const entry of entries) {
+      const filePath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(filePath);
+        continue;
+      }
+      // Dirent type checks use lstat semantics, so symlinks are neither
+      // files nor directories here — they are skipped, never followed.
+      if (!entry.isFile()) continue;
+      const ext = extname(entry.name).toLowerCase();
+      if (!REDACTABLE_EXTENSIONS.has(ext)) continue;
+
+      try {
+        const { size } = statSync(filePath);
+        if (size > MAX_SWEEP_FILE_BYTES) {
+          log.warn(
+            { file: filePath, size },
+            "Staged export file exceeds secret sweep size cap; skipping",
+          );
+          continue;
+        }
+        const content = readFileSync(filePath, "utf-8");
+        filesScanned++;
+        const redacted =
+          ext === ".json"
+            ? redactJsonContent(content)
+            : redactSecrets(content);
+        if (redacted !== content) {
+          writeFileSync(filePath, redacted, "utf-8");
+          filesRedacted++;
+        }
+      } catch (err) {
+        log.warn(
+          { err, file: filePath },
+          "Failed to sweep staged export file for secrets; continuing",
+        );
+      }
+    }
+  }
+
+  return { filesScanned, filesRedacted };
+}


### PR DESCRIPTION
## Summary
- New redactStagedExportFiles helper walks the export staging dir and runs redactSecrets over every staged .json/.jsonl/.txt/.log/.md file before the tar.gz is created
- Catches secrets the structural sanitizers can't: legacy audit rows written before write-time input redaction, and workspace conversation logs
- Per-file failures degrade gracefully; scanned/redacted counts are logged

Part of plan: acp-codex-auth-export-redaction.md (PR 5 of 7)