### PR TITLE
fix(web): isolate recharts so a chart-dep failure can't blank Billing

### DIFF
--- a/apps/web/src/domains/settings/components/billing-usage/billing-usage-panel.tsx
+++ b/apps/web/src/domains/settings/components/billing-usage/billing-usage-panel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { lazy, useMemo, useState } from "react";
 
 import { ArrowLeft, Coins, Loader2, Target } from "lucide-react";
 
@@ -22,13 +22,31 @@ import {
     type LlmUsageDimension,
 } from "@/utils/llm-dimension";
 
-import { BillingUsageChart, type ChartMetric } from "@/domains/settings/components/billing-usage/billing-usage-chart";
+import { LazyBoundary } from "@/components/lazy-boundary";
+import type { ChartMetric } from "@/domains/settings/components/billing-usage/billing-usage-chart";
 import {
     type BillingUsageSourceFilter,
     getDefaultDateRange,
     useBillingUsageData,
 } from "@/domains/settings/components/billing-usage/use-billing-usage-data";
 import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
+
+/**
+ * recharts (~100 kB) is the only hard dependency on the billing surface
+ * that can fail to *evaluate* — e.g. a corrupted Vite dep pre-bundle in
+ * dev. As a static import it sat in the eager `billing-page` module
+ * graph, so any recharts failure blanked the entire Billing tab with no
+ * error surfaced. `React.lazy` splits it into its own chunk (loaded only
+ * when the chart renders) so the page is robust to a chart-dep failure,
+ * and `LazyBoundary` degrades the chart area gracefully if that chunk
+ * ever fails to load. The `ChartMetric` type stays a static `import
+ * type` — it's erased at build time and pulls in no runtime code.
+ */
+const BillingUsageChart = lazy(() =>
+  import(
+    "@/domains/settings/components/billing-usage/billing-usage-chart"
+  ).then((m) => ({ default: m.BillingUsageChart })),
+);
 
 const METRIC_ITEMS: SegmentControlItem<ChartMetric>[] = [
   { value: "spend", label: "Spend ($)" },
@@ -237,11 +255,24 @@ export function BillingUsagePanel() {
           </div>
         ) : series ? (
           <div className="rounded-xl bg-[var(--surface-base)] p-3">
-            <BillingUsageChart
-              buckets={series.buckets}
-              metric={metric}
-              onBarClick={handleBarClick}
-            />
+            <LazyBoundary
+              fallback={
+                <div className="flex h-[345px] items-center justify-center">
+                  <Loader2 className="h-6 w-6 animate-spin text-[var(--content-tertiary)]" />
+                </div>
+              }
+              errorFallback={
+                <div className="flex h-[345px] items-center justify-center text-body-medium-lighter text-[var(--content-tertiary)]">
+                  Couldn&apos;t load the usage chart. Reload to try again.
+                </div>
+              }
+            >
+              <BillingUsageChart
+                buckets={series.buckets}
+                metric={metric}
+                onBarClick={handleBarClick}
+              />
+            </LazyBoundary>
           </div>
         ) : null}
       </div>


### PR DESCRIPTION
## Problem

The Settings → **Billing** tab rendered a **fully blank page** — no settings shell, no error boundary, no network calls, never resolving. General (and every other settings tab) worked fine.

## Root cause

`billing-page` → `BillingUsagePanel` → `BillingUsageChart` **statically imports recharts**, pulling it into billing-page's eager lazy-route module graph. recharts 3.8.1 depends on **es-toolkit**, whose `compat/*` helpers ship CJS-only, and **Vite 8's Rolldown dep-optimizer mis-bundles that circular CJS** — emitting a `require_isUnsafeProperty` wrapper called before assignment (`require_isUnsafeProperty is not a function`) at module-eval time. recharts throws while React Router's object-style `lazy: { Component }` resolves the route, so the route **mounts nothing, silently** (an eval failure, not a caught error → no error boundary fires).

Verified prod is **not** affected: the full Rolldown production build bundles recharts cleanly (no `require_isUnsafeProperty`), so the chart renders in prod.

## Fix

`React.lazy`-split `BillingUsageChart` behind `LazyBoundary` — the same convention already used for `TiptapDocumentEditor` / `WeatherForecastDisplay` (`docs/CONVENTIONS.md`):

- recharts leaves billing-page's eager module graph, so a recharts failure **can no longer blank the page** — it degrades to the chart's `errorFallback` ("Couldn't load the usage chart").
- recharts is code-split into its own on-demand chunk: **billing-page chunk 423 kB → 89 kB**.
- `ChartMetric` is kept as a type-only import so no runtime recharts code re-enters the eager graph.

## Verification

- ✅ Typecheck clean (changed files), ESLint clean, prod build exits 0.
- ✅ Prod billing-page chunk: 0 `isUnsafeProperty` refs (recharts fully split out).
- ✅ Manually confirmed in dev: Billing now renders fully; chart area shows the graceful fallback instead of blanking the window.

## Known follow-up (out of scope)

In **dev only**, recharts itself still fails to evaluate due to the Vite 8 (Rolldown) + es-toolkit CJS-`compat` incompatibility. Every `optimizeDeps` workaround just relocates the same circular-CJS error, so none are included here. With this change that failure degrades gracefully instead of blanking Billing. A real dev-chart fix needs a recharts/es-toolkit/Rolldown version bump — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)