### PR TITLE
feat(agent): stub oversized tool results at result time without breaking the prompt cache

### DIFF
--- a/assistant/src/__tests__/conversation-history-web-search.test.ts
+++ b/assistant/src/__tests__/conversation-history-web-search.test.ts
@@ -755,6 +755,7 @@ describe("web_search_tool_result structural guard", () => {
     // (array of web_search_result objects) and is not truncated this way.
     "context/tool-result-truncation.ts",
     "context/post-turn-tool-result-truncation.ts",
+    "context/tool-result-spool.ts",
 
     // Anthropic provider type guards define API-specific discriminants.
     // It has a separate isWebSearchToolResultBlock for the other type.

--- a/assistant/src/__tests__/tool-result-spool.test.ts
+++ b/assistant/src/__tests__/tool-result-spool.test.ts
@@ -9,8 +9,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { AgentLoop } from "../agent/loop.js";
 import type { AgentEvent } from "../agent/loop.js";
+import { AgentLoop } from "../agent/loop.js";
 import {
   getToolResultFilePath,
   postTurnTruncateToolResults,

--- a/assistant/src/__tests__/tool-result-spool.test.ts
+++ b/assistant/src/__tests__/tool-result-spool.test.ts
@@ -1,0 +1,306 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { AgentLoop } from "../agent/loop.js";
+import type { AgentEvent } from "../agent/loop.js";
+import {
+  getToolResultFilePath,
+  postTurnTruncateToolResults,
+  THRESHOLD_CHARS,
+  TOOL_RESULT_DIR,
+  TRUNCATION_MARKER,
+} from "../context/post-turn-tool-result-truncation.js";
+import { spoolAndStubOversizedToolResults } from "../context/tool-result-spool.js";
+import { resetPluginRegistryAndRegisterDefaults } from "../plugins/defaults/index.js";
+import type {
+  ContentBlock,
+  Message,
+  ToolDefinition,
+} from "../providers/types.js";
+import {
+  createMockProvider,
+  textResponse,
+  toolUseResponse,
+} from "./helpers/mock-provider.js";
+
+function makeToolResult(
+  content: string,
+  toolUseId = "tool_use_1",
+  is_error = false,
+): ContentBlock {
+  return {
+    type: "tool_result" as const,
+    tool_use_id: toolUseId,
+    content,
+    ...(is_error ? { is_error: true } : {}),
+  };
+}
+
+const LONG = "x".repeat(THRESHOLD_CHARS + 100);
+const SHORT = "y".repeat(100);
+
+describe("spoolAndStubOversizedToolResults", () => {
+  let convDir: string;
+  const noName = () => undefined;
+
+  beforeEach(() => {
+    convDir = mkdtempSync(join(tmpdir(), "tool-result-spool-"));
+  });
+
+  afterEach(() => {
+    rmSync(convDir, { recursive: true, force: true });
+  });
+
+  test("spools an oversized result and swaps in the stub", () => {
+    const blocks = [makeToolResult(LONG, "tu_big")];
+
+    const count = spoolAndStubOversizedToolResults(blocks, {
+      conversationDir: convDir,
+      toolNameById: noName,
+    });
+
+    expect(count).toBe(1);
+    const filePath = getToolResultFilePath(convDir, "tu_big");
+    expect(existsSync(filePath)).toBe(true);
+    expect(readFileSync(filePath, "utf-8")).toBe(LONG);
+    const stubbed = blocks[0] as { content: string };
+    expect(stubbed.content).toContain(TRUNCATION_MARKER);
+    expect(stubbed.content).toContain(filePath);
+    expect(stubbed.content.length).toBeLessThan(LONG.length);
+  });
+
+  test("stub is byte-identical to the post-turn truncation stub", () => {
+    const blocks = [makeToolResult(LONG, "tu_big")];
+    spoolAndStubOversizedToolResults(blocks, {
+      conversationDir: convDir,
+      toolNameById: noName,
+    });
+
+    const { messages: postTurn } = postTurnTruncateToolResults(
+      [{ role: "user", content: [makeToolResult(LONG, "tu_big")] }],
+      { conversationDir: convDir },
+    );
+
+    expect((blocks[0] as { content: string }).content).toBe(
+      (postTurn[0].content[0] as { content: string }).content,
+    );
+  });
+
+  test("post-turn pass is a no-op on result-time stubs", () => {
+    const blocks = [makeToolResult(LONG, "tu_big")];
+    spoolAndStubOversizedToolResults(blocks, {
+      conversationDir: convDir,
+      toolNameById: noName,
+    });
+
+    const history: Message[] = [{ role: "user", content: [...blocks] }];
+    const { messages, truncatedCount } = postTurnTruncateToolResults(history, {
+      conversationDir: convDir,
+    });
+
+    expect(truncatedCount).toBe(0);
+    expect(messages).toBe(history);
+  });
+
+  test("skips below-threshold, error, exempt, file_read, marked, and ax-tree results", () => {
+    const blocks = [
+      makeToolResult(SHORT, "tu_short"),
+      makeToolResult(LONG, "tu_err", true),
+      makeToolResult(LONG, "tu_skill"),
+      makeToolResult(LONG, "tu_read"),
+      makeToolResult(`${LONG}${TRUNCATION_MARKER}`, "tu_marked"),
+      makeToolResult(`<ax-tree>${LONG}</ax-tree>`, "tu_ax"),
+      { type: "text" as const, text: LONG },
+    ];
+    const originals = blocks.map((b) => b);
+
+    const count = spoolAndStubOversizedToolResults(blocks, {
+      conversationDir: convDir,
+      toolNameById: (id) => {
+        if (id === "tu_skill") return "skill_load";
+        if (id === "tu_read") return "file_read";
+        return undefined;
+      },
+    });
+
+    expect(count).toBe(0);
+    expect(blocks).toEqual(originals);
+    expect(existsSync(join(convDir, TOOL_RESULT_DIR))).toBe(false);
+  });
+
+  test("spools each eligible block in a mixed batch", () => {
+    const blocks = [
+      makeToolResult(LONG, "tu_a"),
+      makeToolResult(SHORT, "tu_b"),
+      makeToolResult(LONG, "tu_c"),
+    ];
+
+    const count = spoolAndStubOversizedToolResults(blocks, {
+      conversationDir: convDir,
+      toolNameById: noName,
+    });
+
+    expect(count).toBe(2);
+    expect(existsSync(getToolResultFilePath(convDir, "tu_a"))).toBe(true);
+    expect(existsSync(getToolResultFilePath(convDir, "tu_b"))).toBe(false);
+    expect(existsSync(getToolResultFilePath(convDir, "tu_c"))).toBe(true);
+    expect((blocks[0] as { content: string }).content).toContain(
+      TRUNCATION_MARKER,
+    );
+    expect((blocks[1] as { content: string }).content).toBe(SHORT);
+    expect((blocks[2] as { content: string }).content).toContain(
+      TRUNCATION_MARKER,
+    );
+  });
+
+  test("keeps full content when the spool directory cannot be created", () => {
+    // A regular file at the conversation-dir path makes mkdir throw, so no
+    // stub can be written; the block must keep its full content (a stub must
+    // never exist without its file on disk).
+    const fileAsDir = join(convDir, "not-a-dir");
+    writeFileSync(fileAsDir, "occupied", "utf-8");
+    const blocks = [makeToolResult(LONG, "tu_big")];
+
+    expect(() =>
+      spoolAndStubOversizedToolResults(blocks, {
+        conversationDir: fileAsDir,
+        toolNameById: noName,
+      }),
+    ).toThrow();
+    expect((blocks[0] as { content: string }).content).toBe(LONG);
+  });
+});
+
+describe("AgentLoop result-time spooling", () => {
+  let convDir: string;
+
+  const dummyTools: ToolDefinition[] = [
+    {
+      name: "fetch_transcript",
+      description: "Fetch a transcript",
+      input_schema: { type: "object", properties: {} },
+    },
+  ];
+
+  const userMessage: Message = {
+    role: "user",
+    content: [{ type: "text", text: "Import the transcripts" }],
+  };
+
+  beforeEach(() => {
+    resetPluginRegistryAndRegisterDefaults();
+    convDir = mkdtempSync(join(tmpdir(), "tool-result-spool-loop-"));
+  });
+
+  afterEach(() => {
+    rmSync(convDir, { recursive: true, force: true });
+  });
+
+  test("oversized result enters history as the stub; full content is never sent to the provider", async () => {
+    const { provider, calls } = createMockProvider([
+      toolUseResponse("tu_1", "fetch_transcript", {}),
+      textResponse("Done."),
+    ]);
+    const loop = new AgentLoop({
+      provider,
+      systemPrompt: "system",
+      conversationId: "test-conversation",
+      tools: dummyTools,
+      toolExecutor: async () => ({ content: LONG, isError: false }),
+      resolveConversationDir: () => convDir,
+    });
+
+    const events: AgentEvent[] = [];
+    const { history } = await loop.run({
+      requestId: "test-request",
+      messages: [userMessage],
+      onEvent: (e) => {
+        events.push(e);
+      },
+      trust: { sourceChannel: "vellum", trustClass: "unknown" },
+    });
+
+    const filePath = getToolResultFilePath(convDir, "tu_1");
+    expect(readFileSync(filePath, "utf-8")).toBe(LONG);
+
+    // The second provider call carries the stub, not the full content.
+    const sentResult = calls[1].messages[2].content[0] as { content: string };
+    expect(sentResult.content).toContain(TRUNCATION_MARKER);
+    expect(sentResult.content).toContain(filePath);
+    expect(JSON.stringify(calls.map((c) => c.messages))).not.toContain(LONG);
+
+    // Durable history and the emitted tool_result event match what was sent.
+    const historyResult = history[2].content[0] as { content: string };
+    expect(historyResult.content).toBe(sentResult.content);
+    const resultEvent = events.find((e) => e.type === "tool_result") as {
+      content: string;
+    };
+    expect(resultEvent.content).toBe(sentResult.content);
+  });
+
+  test("outbound payloads stay append-only across calls (prompt-cache prefix invariant)", async () => {
+    const { provider, calls } = createMockProvider([
+      toolUseResponse("tu_1", "fetch_transcript", {}),
+      toolUseResponse("tu_2", "fetch_transcript", {}),
+      textResponse("Done."),
+    ]);
+    const loop = new AgentLoop({
+      provider,
+      systemPrompt: "system",
+      conversationId: "test-conversation",
+      tools: dummyTools,
+      toolExecutor: async () => ({ content: LONG, isError: false }),
+      resolveConversationDir: () => convDir,
+    });
+
+    await loop.run({
+      requestId: "test-request",
+      messages: [userMessage],
+      onEvent: () => {},
+      trust: { sourceChannel: "vellum", trustClass: "unknown" },
+    });
+
+    expect(calls).toHaveLength(3);
+    // Each call's payload extends the previous call's payload without
+    // rewriting it — the property that keeps the provider's prompt-cache
+    // prefix valid across the turn's iterations.
+    for (let i = 1; i < calls.length; i++) {
+      expect(calls[i].messages.slice(0, calls[i - 1].messages.length)).toEqual(
+        calls[i - 1].messages,
+      );
+    }
+  });
+
+  test("without resolveConversationDir the full content is sent and post-turn handles it", async () => {
+    const { provider, calls } = createMockProvider([
+      toolUseResponse("tu_1", "fetch_transcript", {}),
+      textResponse("Done."),
+    ]);
+    const loop = new AgentLoop({
+      provider,
+      systemPrompt: "system",
+      conversationId: "test-conversation",
+      tools: dummyTools,
+      toolExecutor: async () => ({ content: LONG, isError: false }),
+    });
+
+    await loop.run({
+      requestId: "test-request",
+      messages: [userMessage],
+      onEvent: () => {},
+      trust: { sourceChannel: "vellum", trustClass: "unknown" },
+    });
+
+    const sentResult = calls[1].messages[2].content[0] as { content: string };
+    expect(sentResult.content).toBe(LONG);
+    expect(existsSync(join(convDir, TOOL_RESULT_DIR))).toBe(false);
+  });
+});

--- a/assistant/src/__tests__/tool-result-spool.test.ts
+++ b/assistant/src/__tests__/tool-result-spool.test.ts
@@ -279,6 +279,37 @@ describe("AgentLoop result-time spooling", () => {
     }
   });
 
+  test("spools the raw output even when it exceeds the post-tool-use truncation budget", async () => {
+    // maxInputTokens of 10k gives the default truncate plugin a 12k-char
+    // budget (0.3 share × 4 chars/token). The spool must run before that
+    // hook, so the file holds all 20k chars of raw output rather than the
+    // hook's tail-dropped copy — otherwise the omitted tail is unrecoverable.
+    const HUGE = "z".repeat(20_000);
+    const { provider } = createMockProvider([
+      toolUseResponse("tu_1", "fetch_transcript", {}),
+      textResponse("Done."),
+    ]);
+    const loop = new AgentLoop({
+      provider,
+      systemPrompt: "system",
+      conversationId: "test-conversation",
+      config: { maxInputTokens: 10_000 },
+      tools: dummyTools,
+      toolExecutor: async () => ({ content: HUGE, isError: false }),
+      resolveConversationDir: () => convDir,
+    });
+
+    await loop.run({
+      requestId: "test-request",
+      messages: [userMessage],
+      onEvent: () => {},
+      trust: { sourceChannel: "vellum", trustClass: "unknown" },
+    });
+
+    const filePath = getToolResultFilePath(convDir, "tu_1");
+    expect(readFileSync(filePath, "utf-8")).toBe(HUGE);
+  });
+
   test("without resolveConversationDir the full content is sent and post-turn handles it", async () => {
     const { provider, calls } = createMockProvider([
       toolUseResponse("tu_1", "fetch_transcript", {}),

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -11,6 +11,7 @@ import {
   estimateToolsTokens,
   getCalibrationProviderKey,
 } from "../context/token-estimator.js";
+import { spoolAndStubOversizedToolResults } from "../context/tool-result-spool.js";
 import type { ToolActivityMetadata } from "../daemon/message-types/web-activity.js";
 import { parseActualTokensFromError } from "../daemon/parse-actual-tokens-from-error.js";
 import type { TrustContext } from "../daemon/trust-context.js";
@@ -595,6 +596,16 @@ export interface AgentLoopConstructorOptions {
    * post-compaction re-injection resolve the live conversation through.
    */
   conversationId: string;
+  /**
+   * Resolve the conversation's on-disk directory, used to spool oversized
+   * tool results to `.tool-results/` and swap the inline copy for the
+   * post-turn pass's stub at result time — before the result joins history,
+   * so the provider-bound prefix stays append-only for prompt caching.
+   * Returns `null` while the directory cannot be resolved (e.g. the
+   * conversation row is not yet persisted); the loop then skips the
+   * result-time pass and the post-turn truncation covers the turn instead.
+   */
+  resolveConversationDir?: () => string | null;
 }
 
 export class AgentLoop {
@@ -616,6 +627,9 @@ export class AgentLoop {
    */
   private readonly conversationId: string;
 
+  /** See {@link AgentLoopConstructorOptions.resolveConversationDir}. */
+  private readonly resolveConversationDir: (() => string | null) | null;
+
   /**
    * Loop-held compaction circuit breaker. The loop has a 1:1 lifetime with its
    * conversation, so it is the source of truth for the cross-turn failure
@@ -635,6 +649,7 @@ export class AgentLoop {
       resolveTools,
       resolveSystemPrompt,
       conversationId,
+      resolveConversationDir,
     } = options;
     this.provider = provider;
     this.systemPrompt = systemPrompt;
@@ -644,6 +659,7 @@ export class AgentLoop {
     this.resolveSystemPrompt = resolveSystemPrompt ?? null;
     this.toolExecutor = toolExecutor ?? null;
     this.conversationId = conversationId;
+    this.resolveConversationDir = resolveConversationDir ?? null;
     this.compactionCircuit = new CompactionCircuit(this.conversationId);
   }
 
@@ -885,6 +901,19 @@ export class AgentLoop {
     let overflowLadderExhausted = false;
     let overflowAutoCompressApplied = false;
     const rlog = log.child({ requestId });
+
+    // Conversation directory for the result-time tool-result spool/stub pass.
+    // Resolved once per run; `null` disables the pass for this run and the
+    // post-turn truncation covers the turn instead.
+    let conversationDir: string | null = null;
+    try {
+      conversationDir = this.resolveConversationDir?.() ?? null;
+    } catch (err) {
+      rlog.warn(
+        { err },
+        "Resolving conversation dir for tool-result spooling failed (non-fatal)",
+      );
+    }
 
     // Resolve the inference-profile override that applies right now. The
     // optional resolver lets a turn observe a confirmed mid-turn profile switch
@@ -1756,6 +1785,29 @@ export class AgentLoop {
               type: "text",
               text: finalCtx.additionalContext,
             });
+          }
+        }
+
+        // Spool oversized results to `.tool-results/` and swap the inline
+        // copy for the post-turn pass's stub now — before the results are
+        // emitted or join history — so the full content is on disk for the
+        // model to read back within this turn while the provider-bound
+        // history stays append-only (rewriting an earlier message between
+        // calls would invalidate the prompt-cache prefix on every iteration).
+        if (conversationDir) {
+          const toolNameByUseId = new Map(
+            toolUseBlocks.map((tu) => [tu.id, tu.name]),
+          );
+          try {
+            spoolAndStubOversizedToolResults(resultBlocks, {
+              conversationDir,
+              toolNameById: (id) => toolNameByUseId.get(id),
+            });
+          } catch (err) {
+            rlog.warn(
+              { err, turn: toolUseTurns },
+              "Spooling oversized tool results to disk failed (non-fatal)",
+            );
           }
         }
 

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -1753,11 +1753,39 @@ export class AgentLoop {
           }),
         );
 
+        // Spool oversized results to `.tool-results/` and swap the inline
+        // copy for the post-turn pass's stub now — on the raw blocks, before
+        // the post-tool-use hooks, event emission, and history append. Running
+        // ahead of the hooks means the spooled file holds the tool's full
+        // output rather than the truncate plugin's tail-dropped copy, and the
+        // hooks then see the stub. Stubbing before the first send keeps the
+        // provider-bound history strictly append-only (rewriting an earlier
+        // message between calls would invalidate the prompt-cache prefix on
+        // every iteration).
+        if (conversationDir) {
+          const toolNameByUseId = new Map(
+            toolUseBlocks.map((tu) => [tu.id, tu.name]),
+          );
+          try {
+            spoolAndStubOversizedToolResults(rawResultBlocks, {
+              conversationDir,
+              toolNameById: (id) => toolNameByUseId.get(id),
+            });
+          } catch (err) {
+            rlog.warn(
+              { err, turn: toolUseTurns },
+              "Spooling oversized tool results to disk failed (non-fatal)",
+            );
+          }
+        }
+
         // Run the `post-tool-use` hook once per tool result, after the tool
         // returns and before the result joins the provider-bound history.
         // The default tool-result-truncate plugin tail-drops oversized output
-        // to fit the context window; user hooks can swap in a smarter strategy
-        // (e.g. a summariser) or observe results for side effects.
+        // to fit the context window (spool-stubbed results are already tiny;
+        // spool-exempt ones still rely on it); user hooks can swap in a
+        // smarter strategy (e.g. a summariser) or observe results for side
+        // effects.
         const contextWindowTokens =
           resolveContextWindow?.().maxInputTokens ??
           this.config.maxInputTokens ??
@@ -1785,29 +1813,6 @@ export class AgentLoop {
               type: "text",
               text: finalCtx.additionalContext,
             });
-          }
-        }
-
-        // Spool oversized results to `.tool-results/` and swap the inline
-        // copy for the post-turn pass's stub now — before the results are
-        // emitted or join history — so the full content is on disk for the
-        // model to read back within this turn while the provider-bound
-        // history stays append-only (rewriting an earlier message between
-        // calls would invalidate the prompt-cache prefix on every iteration).
-        if (conversationDir) {
-          const toolNameByUseId = new Map(
-            toolUseBlocks.map((tu) => [tu.id, tu.name]),
-          );
-          try {
-            spoolAndStubOversizedToolResults(resultBlocks, {
-              conversationDir,
-              toolNameById: (id) => toolNameByUseId.get(id),
-            });
-          } catch (err) {
-            rlog.warn(
-              { err, turn: toolUseTurns },
-              "Spooling oversized tool results to disk failed (non-fatal)",
-            );
           }
         }
 

--- a/assistant/src/context/post-turn-tool-result-truncation.ts
+++ b/assistant/src/context/post-turn-tool-result-truncation.ts
@@ -51,6 +51,27 @@ function buildToolNameById(messages: Message[]): Map<string, string> {
 }
 
 /**
+ * Shared eligibility rules for replacing an oversized tool result with the
+ * on-disk stub: string content over the size threshold, not an error result,
+ * not from an exempt tool (durable instructions like skill bodies), and not
+ * already truncated (idempotency marker). Used by both the post-turn pass and
+ * the result-time spool pass so the two converge on the same results.
+ */
+export function isTruncationEligible(
+  tr: ToolResultContent,
+  toolName: string | undefined,
+): boolean {
+  if (typeof tr.content !== "string") return false;
+  if (tr.content.length <= THRESHOLD_CHARS) return false;
+  if (tr.is_error) return false;
+  if (toolName !== undefined && TRUNCATION_EXEMPT_TOOLS.has(toolName)) {
+    return false;
+  }
+  if (tr.content.includes(TRUNCATION_MARKER)) return false;
+  return true;
+}
+
+/**
  * Deterministic file path for a tool result's full content on disk.
  * Uses the first 12 hex chars of the SHA-256 of the tool_use_id.
  */
@@ -58,7 +79,10 @@ export function getToolResultFilePath(
   conversationDir: string,
   toolUseId: string,
 ): string {
-  const hash = createHash("sha256").update(toolUseId).digest("hex").slice(0, 12);
+  const hash = createHash("sha256")
+    .update(toolUseId)
+    .digest("hex")
+    .slice(0, 12);
   return join(conversationDir, TOOL_RESULT_DIR, `${hash}.txt`);
 }
 
@@ -73,7 +97,11 @@ export function buildTruncatedContent(
 ): string {
   const half = Math.floor(TARGET_CHARS / 2);
   const prefix = safeStringSlice(original, 0, half);
-  const suffix = safeStringSlice(original, original.length - half, original.length);
+  const suffix = safeStringSlice(
+    original,
+    original.length - half,
+    original.length,
+  );
   const omittedChars = original.length - TARGET_CHARS;
   const estimatedTokens = Math.round(omittedChars / 4);
   return `${prefix}\n\n...(${estimatedTokens} tokens omitted ${TRUNCATION_MARKER} ${filePath})\n\n${suffix}`;
@@ -86,9 +114,7 @@ export function buildTruncatedContent(
  * - The full content is persisted to a deterministic file path on disk.
  * - The in-context content is replaced with a prefix/suffix stub.
  *
- * Results are skipped if they are below threshold, are error results,
- * have already been truncated (contain `TRUNCATION_MARKER`), or were produced
- * by a tool in `TRUNCATION_EXEMPT_TOOLS` (durable instructions like skill bodies).
+ * Results are skipped unless {@link isTruncationEligible} allows them.
  *
  * Returns a shallow-copied messages array (only modified messages are cloned)
  * and the count of results that were truncated.
@@ -107,21 +133,9 @@ export function postTurnTruncateToolResults(
       if (block.type !== "tool_result") return block;
       const tr = block as ToolResultContent;
 
-      // Skip short results.
-      if (tr.content.length <= THRESHOLD_CHARS) return block;
-
-      // Skip error results.
-      if (tr.is_error) return block;
-
-      // Skip results from tools whose output is durable operating instructions
-      // (e.g. skill_load); middle-truncating them strips the workflow.
-      const toolName = toolNameById.get(tr.tool_use_id);
-      if (toolName !== undefined && TRUNCATION_EXEMPT_TOOLS.has(toolName)) {
+      if (!isTruncationEligible(tr, toolNameById.get(tr.tool_use_id))) {
         return block;
       }
-
-      // Skip already-truncated results (idempotency).
-      if (tr.content.includes(TRUNCATION_MARKER)) return block;
 
       const filePath = getToolResultFilePath(
         options.conversationDir,

--- a/assistant/src/context/tool-result-spool.ts
+++ b/assistant/src/context/tool-result-spool.ts
@@ -1,0 +1,104 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { ContentBlock, ToolResultContent } from "../providers/types.js";
+import {
+  buildTruncatedContent,
+  getToolResultFilePath,
+  isTruncationEligible,
+  TOOL_RESULT_DIR,
+} from "./post-turn-tool-result-truncation.js";
+
+/**
+ * AX-tree snapshots have their own dedicated history compactor
+ * (`compactAxTreeHistory`) with placeholder semantics tuned for computer-use
+ * sessions, and the model needs the freshest tree inline to act on it, so the
+ * result-time pass leaves them alone.
+ */
+const AX_TREE_TAG = "<ax-tree>";
+
+/**
+ * Tools whose results keep their full content at result time even when
+ * oversized. `file_read` is the model's only way to page spooled content back
+ * into context: stubbing a read of a `.tool-results/` file would spool a
+ * fresh copy and hand back another stub, so oversized content could never be
+ * read at all. Explicit reads are therefore honored in full; the post-turn
+ * pass still truncates them at turn end, after the model has consumed the
+ * content.
+ */
+const RESULT_TIME_STUB_EXEMPT_TOOLS = new Set<string>(["file_read"]);
+
+/**
+ * Whether a tool result is eligible for the result-time spool/stub pass:
+ * the post-turn pass's shared rules plus the AX-tree and `file_read`
+ * exemptions above.
+ */
+function isSpoolEligible(
+  tr: ToolResultContent,
+  toolName: string | undefined,
+): boolean {
+  if (!isTruncationEligible(tr, toolName)) return false;
+  if (toolName !== undefined && RESULT_TIME_STUB_EXEMPT_TOOLS.has(toolName)) {
+    return false;
+  }
+  if (tr.content.includes(AX_TREE_TAG)) return false;
+  return true;
+}
+
+/**
+ * Spool every oversized tool result in `blocks` to its deterministic
+ * `.tool-results/` file and replace the inline content with the post-turn
+ * pass's prefix/suffix stub — at result time, before the blocks join history.
+ *
+ * Because the swap happens before the content is ever sent, the
+ * provider-bound history stays strictly append-only across the turn's model
+ * calls, which is what keeps the provider's prompt-cache prefix valid:
+ * rewriting an earlier message between calls would invalidate the cache from
+ * that point on every iteration. The model still gets the head/tail preview
+ * plus the on-disk path, so it can page the full content back in with
+ * `file_read` (whose results are exempt from this pass) when it actually
+ * needs it.
+ *
+ * Uses the same file paths, stub bytes, and eligibility rules as
+ * `postTurnTruncateToolResults`, whose `TRUNCATION_MARKER` guard then skips
+ * these results at turn end. Eligible elements of `blocks` are replaced in
+ * place (the block objects themselves are not mutated). A result is only
+ * stubbed after its file is written, so a stub never points at a missing
+ * file; on filesystem errors the remaining blocks keep their full content and
+ * the post-turn pass covers them.
+ *
+ * Returns the number of results spooled and stubbed.
+ */
+export function spoolAndStubOversizedToolResults(
+  blocks: ContentBlock[],
+  options: {
+    conversationDir: string;
+    toolNameById: (toolUseId: string) => string | undefined;
+  },
+): number {
+  let stubbedCount = 0;
+  for (let i = 0; i < blocks.length; i++) {
+    const block = blocks[i];
+    if (block.type !== "tool_result") continue;
+    if (!isSpoolEligible(block, options.toolNameById(block.tool_use_id))) {
+      continue;
+    }
+
+    if (stubbedCount === 0) {
+      mkdirSync(join(options.conversationDir, TOOL_RESULT_DIR), {
+        recursive: true,
+      });
+    }
+    const filePath = getToolResultFilePath(
+      options.conversationDir,
+      block.tool_use_id,
+    );
+    writeFileSync(filePath, block.content, "utf-8");
+    blocks[i] = {
+      ...block,
+      content: buildTruncatedContent(block.content, filePath),
+    };
+    stubbedCount++;
+  }
+  return stubbedCount;
+}

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -51,6 +51,7 @@ import {
   resolveOverrideProfile,
   setConversationHistoryStrippedAt,
 } from "../memory/conversation-crud.js";
+import { getResolvedConversationDirPath } from "../memory/conversation-directories.js";
 import { ConversationGraphMemory } from "../memory/graph/conversation-graph-memory.js";
 import { unwrapMemoryBlock, wrapMemoryBlock } from "../memory/memory-marker.js";
 import { PermissionPrompter } from "../permissions/prompter.js";
@@ -638,6 +639,14 @@ export class Conversation {
       toolExecutor: toolDefs.length > 0 ? toolExecutor : undefined,
       resolveTools,
       resolveSystemPrompt: resolveSystemPromptCallback,
+      resolveConversationDir: () => {
+        const conv = getConversation(this.conversationId);
+        if (!conv) return null;
+        return getResolvedConversationDirPath(
+          this.conversationId,
+          conv.createdAt,
+        );
+      },
     });
     createContextWindowManager({
       provider,


### PR DESCRIPTION
## Summary

- Oversized tool results (>8k chars) are now spooled to their deterministic `.tool-results/` file and swapped for the post-turn pass's prefix/suffix stub **at result time** — before they are emitted or join history — so the full content is never sent to the provider and the model immediately sees the on-disk path (new `src/context/tool-result-spool.ts`, wired through an optional `resolveConversationDir` on `AgentLoop`).
- Unlike the per-call outbound stubbing in #34283 (which this PR replaces), the provider-bound history stays strictly append-only across a turn's model calls, so the Anthropic prompt-cache prefix (advancing-tail breakpoint) remains valid on every iteration; a regression test asserts each call's payload extends the previous call's payload.
- `file_read` results are exempt at result time — stubbing a read of a spool file would hand back another stub forever, making oversized content unreachable; the model pages spooled content back in with `offset`/`limit`. Eligibility rules are shared with the post-turn pass via a new exported `isTruncationEligible`, and the byte-identical stub means the post-turn pass's `TRUNCATION_MARKER` guard skips result-time stubs at turn end.

## Original prompt

Review of PR #34283 (result-time spool + per-provider-call stale-result stubbing, addressing the JARVIS-1025 bulk-import cost incident) found that its `stubStaleOversizedToolResults` projection rewrites the second-most-recent tool-result batch on every model call, which invalidates the prompt-cache prefix each iteration: every advancing-tail cache write is wasted and the whole turn span re-processes uncached, per call. The user asked for a design that does not break the prompt cache; the verified replacement moves the full→stub swap to the only cache-safe moment before turn end — result time, before the content is ever sent. Approach, 8k threshold parity with the post-turn pass, and byte-identical stub format were confirmed with the user before implementation. #34283 should be closed in favor of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)