### PR TITLE
fix(web): hide assistant handle section for self-hosted assistants

### DIFF
--- a/apps/web/src/domains/intelligence/plugin-detail-page.test.tsx
+++ b/apps/web/src/domains/intelligence/plugin-detail-page.test.tsx
@@ -79,6 +79,7 @@ describe("PluginDetailPage", () => {
       source: { kind: "github", repo: "example-org/caveman", ref: "v1.8.2" },
       readme: "# Caveman\n\nMakes the agent speak in grunts.",
       ref: "v1.8.2",
+      artifact: null,
     });
 
     // README markdown is rendered.
@@ -104,6 +105,7 @@ describe("PluginDetailPage", () => {
       source: null,
       readme: null,
       ref: "main",
+      artifact: null,
     });
 
     expect(html).toContain("Remove");

--- a/apps/web/src/domains/settings/pages/general-page.tsx
+++ b/apps/web/src/domains/settings/pages/general-page.tsx
@@ -274,7 +274,10 @@ export function GeneralPage() {
         />
       </DetailCard>
 
-      {isAuthenticated && platformGate === "full" && <ProfileCard assistant={platformAssistant} />}
+      {isAuthenticated && platformGate === "full" && (
+        // Handles are platform-only — withhold the prop for self-hosted assistants.
+        <ProfileCard assistant={isPlatformHosted ? platformAssistant : null} />
+      )}
 
       {infraGate === "full" && assistant && (
         <ResizeCard


### PR DESCRIPTION
## Summary
- Gate the "Assistant handle" section of the settings Profile card on the active assistant being platform-hosted: the `ProfileCard` call site in `general-page.tsx` now withholds the `assistant` prop (passes `null`) unless `useActiveAssistantIsPlatformHosted()` is true.
- `ProfileCard` already hides the assistant-handle section when the prop is null (covered by existing tests); this fixes the call site, which previously passed the assistant through in local mode even when it was self-hosted. The user-handle section remains visible.

## Original prompt
The "Assistant handle" section on the settings Profile card (screenshot showed the empty claim-a-handle state) should be gated and hidden for self-hosted assistants, since assistant handles are a platform concept with no meaning for a self-hosted assistant.