### PR TITLE
fix(web): pin es-toolkit to 1.46.1 so the billing usage chart evaluates again

### DIFF
--- a/apps/web/bun.lock
+++ b/apps/web/bun.lock
@@ -99,6 +99,9 @@
       },
     },
   },
+  "overrides": {
+    "es-toolkit": "1.46.1",
+  },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
 
@@ -1046,7 +1049,7 @@
 
     "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
 
-    "es-toolkit": ["es-toolkit@1.47.0", "", {}, "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw=="],
+    "es-toolkit": ["es-toolkit@1.46.1", "", {}, "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ=="],
 
     "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -119,5 +119,8 @@
     "typescript": "5.9.3",
     "typescript-eslint": "8.58.1",
     "vite": "8.0.11"
+  },
+  "overrides": {
+    "es-toolkit": "1.46.1"
   }
 }


### PR DESCRIPTION
## Summary

- Pin transitive dep `es-toolkit` to 1.46.1 via bun `overrides` in `apps/web/package.json` (it reaches us through recharts 3.8.1).
- es-toolkit 1.47.0's CJS dist names its module-scope require bindings `require_isUnsafeProperty` etc., which collides with Rolldown's (Vite 8) own CJS-wrapper helper naming. The deconflicted output emits self-shadowing `var t = t()` in the wrapped `compat/get` module, throwing `TypeError: t is not a function` at module evaluation.
- This was the root cause of the blank black page at `/assistant/settings/billing` — **including in prod**: importing the deployed `billing-page-DKHEIITH.js` on www.vellum.ai rejects with exactly this error (contrary to #34508's "prod not affected" note, which appears to have been verified against a pre-#34477 install). #34508 stops the page from blanking, but the split-out recharts chunk still fails to evaluate, leaving the usage chart stuck on its error fallback. With this pin, both `billing-page` and `billing-usage-chart` prod chunks evaluate cleanly (verified by serving `dist/` and dynamic-importing the chunks in a browser; the rebuilt chart chunk has no `var t=t()` self-shadowing near `isUnsafeProperty`).

The bump to 1.47.0 came in via #34477's lockfile refresh. Revisit this pin once es-toolkit ships a stable release fixing the `require_`-prefixed naming in its CJS dist (only `-dev` builds exist after 1.47.0 as of 2026-06-11), or once Rolldown fixes the deconflicting collision.

## Original prompt

Investigating why /assistant/settings/billing rendered a blank black page in dev and prod. Diagnosis traced it to the es-toolkit 1.46.1 → 1.47.0 transitive bump breaking Rolldown's CJS wrapping of recharts' es-toolkit compat imports. #34508 (merged) contains the blast radius so a chart failure can't blank the page; this PR pins es-toolkit back so the chart actually works again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)