### PR TITLE
fix(web): add missing artifact field to plugin-detail-page test fixtures

### DIFF
--- a/apps/web/src/domains/intelligence/plugin-detail-page.test.tsx
+++ b/apps/web/src/domains/intelligence/plugin-detail-page.test.tsx
@@ -79,6 +79,7 @@ describe("PluginDetailPage", () => {
       source: { kind: "github", repo: "example-org/caveman", ref: "v1.8.2" },
       readme: "# Caveman\n\nMakes the agent speak in grunts.",
       ref: "v1.8.2",
+      artifact: null,
     });
 
     // README markdown is rendered.
@@ -104,6 +105,7 @@ describe("PluginDetailPage", () => {
       source: null,
       readme: null,
       ref: "main",
+      artifact: null,
     });
 
     expect(html).toContain("Remove");


### PR DESCRIPTION
## Summary

- Adds `artifact: null` to the two `renderDetail` fixtures in `plugin-detail-page.test.tsx`.
- #34469 made `artifact` a required field on the plugin detail payload but didn't update these test fixtures, so the Web **Type Check** job has been failing on main since (first red run: #34487's merge). This unblocks CI for every PR stacked on current main, including #34512 (the es-toolkit pin for the billing chart).
- `bunx tsc --noEmit` is clean with this change; the tests themselves already pass in CI (the Test job is green — only typecheck was broken).

## Original prompt

While shipping the es-toolkit 1.46.1 pin (#34512) for the blank billing page incident, its CI failed on a pre-existing main breakage: plugin-detail-page test fixtures missing the newly-required `artifact` property. This PR fixes that breakage separately so the incident fix isn't muddied with unrelated changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)