### PR TITLE
fix: release note 098 leads with credential vault and shows an executable command

### DIFF
--- a/assistant/src/workspace/migrations/098-release-notes-acp-codex-auth.ts
+++ b/assistant/src/workspace/migrations/098-release-notes-acp-codex-auth.ts
@@ -21,10 +21,11 @@ Codex ACP sessions no longer fail with a bare "Authentication required"
 error. When Codex asks for authentication, the assistant now authenticates
 it automatically using your API key and retries.
 
-- Provide a key by setting \`OPENAI_API_KEY\` (or \`CODEX_API_KEY\`) under
-  \`acp.agents.codex.env\` in config.json, or store it in the credential
-  vault with \`assistant credentials set --service acp --field
-  openai_api_key\` (config.json wins if both are set).
+- Store your key in the credential vault with \`assistant credentials set
+  --service acp --field openai_api_key <key>\` (use \`--field codex_api_key\`
+  for \`CODEX_API_KEY\`). If you already set \`OPENAI_API_KEY\` or
+  \`CODEX_API_KEY\` under \`acp.agents.codex.env\` in config.json, those
+  explicit values take precedence.
 - If you sign in with ChatGPT instead, nothing changes: \`codex login\` in
   the workspace keeps working.
 - When no usable key is available, spawn failures now list the auth


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for acp-codex-auth-export-redaction.md (Codex review P1/P2 on #34506).

**Gap:** release note recommended storing API keys in workspace config.json (contradicts the repo secrets invariant) and quoted a credentials command missing its required positional
**Fix:** note now leads with the credential vault using verified CLI syntax; config.json demoted to a precedence note