### PR TITLE
fix: trim unused public ACP auth surface and parallelize codex vault reads

### DIFF
--- a/assistant/src/acp/agent-process.ts
+++ b/assistant/src/acp/agent-process.ts
@@ -163,21 +163,8 @@ export class AcpAgentProcess {
    * Authentication methods the agent advertised at initialize.
    * Returns an empty array before initialize() resolves.
    */
-  get authMethods(): AuthMethod[] {
+  private get authMethods(): AuthMethod[] {
     return this.initializeResponse?.authMethods ?? [];
-  }
-
-  /**
-   * Authenticates with the agent using one of its advertised auth methods.
-   */
-  async authenticate(methodId: string): Promise<void> {
-    if (!this.connection) {
-      throw new Error(`ACP agent "${this.agentId}" is not spawned`);
-    }
-
-    log.info({ agentId: this.agentId, methodId }, "Authenticating ACP agent");
-
-    await this.connection.authenticate({ methodId });
   }
 
   /**
@@ -235,7 +222,7 @@ export class AcpAgentProcess {
         "ACP agent returned auth_required; authenticating with env_var method",
       );
 
-      await this.authenticate(method.id);
+      await this.connection!.authenticate({ methodId: method.id });
       return await op();
     }
   }

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -190,18 +190,22 @@ export async function prepareAgentEnv(
       "Gemini API key for ACP agent authentication",
     );
   } else if (adapterCommand === "codex-acp") {
-    await injectOptionalCredential(
-      env,
-      "openai_api_key",
-      "OPENAI_API_KEY",
-      "OpenAI API key for Codex ACP agent authentication",
-    );
-    await injectOptionalCredential(
-      env,
-      "codex_api_key",
-      "CODEX_API_KEY",
-      "Codex API key for Codex ACP agent authentication",
-    );
+    // The two reads target independent vault fields and write disjoint env
+    // keys, so running them concurrently is safe.
+    await Promise.all([
+      injectOptionalCredential(
+        env,
+        "openai_api_key",
+        "OPENAI_API_KEY",
+        "OpenAI API key for Codex ACP agent authentication",
+      ),
+      injectOptionalCredential(
+        env,
+        "codex_api_key",
+        "CODEX_API_KEY",
+        "Codex API key for Codex ACP agent authentication",
+      ),
+    ]);
   }
 
   return { ...agentConfig, env };


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for acp-codex-auth-export-redaction.md.

- AcpAgentProcess auth members demoted from speculative public API (no external consumers)
- The two independent codex vault credential reads now run concurrently