### PR TITLE
fix: JSON-safe redaction for jsonl/audit inputs and fail-closed export sweep coverage

### DIFF
--- a/assistant/src/__tests__/log-export-workspace.test.ts
+++ b/assistant/src/__tests__/log-export-workspace.test.ts
@@ -41,7 +41,15 @@ import { initializeDb } from "../memory/db-init.js";
 import { conversations, toolInvocations } from "../memory/schema.js";
 import { RouteError } from "../runtime/routes/errors.js";
 import { ROUTES } from "../runtime/routes/log-export-routes.js";
-import { redactStagedExportFiles } from "../runtime/routes/redact-staged-export.js";
+import {
+  MAX_SWEEP_FILE_BYTES,
+  OVERSIZED_FILE_NOTE,
+  redactStagedExportFiles,
+} from "../runtime/routes/redact-staged-export.js";
+import {
+  OPENAI_PROJECT_KEY_REDACTION_MARKER,
+  SYNTHETIC_OPENAI_PROJECT_KEY,
+} from "./secret-fixtures.js";
 
 initializeDb();
 
@@ -485,15 +493,6 @@ describe("POST /v1/export — workspace allowlist", () => {
 // Export-time secret sweep
 // ---------------------------------------------------------------------------
 
-// A synthetic OpenAI project key that matches the scanner's
-// `sk-proj-[A-Za-z0-9\-_]{40,}` pattern while deliberately dodging its
-// placeholder filtering: no "test"/"example"/"xxxx"-style segments, not a
-// repeated character, and it ends with an alphanumeric so the trailing `\b`
-// boundary holds.
-const RAW_OPENAI_PROJECT_KEY =
-  "sk-proj-Ab1Cd2Ef3Gh4Ij5Kl6Mn7Op8Qr9St0Uv1Wx2Yz3Ab4Cd5Ef6Gh";
-const REDACTION_MARKER = '<redacted type="OpenAI Project Key" />';
-
 // NOTE: these tests intentionally run after every other describe block in
 // this file — they seed a workspace conversation and an audit DB row that
 // contain a raw secret, which would otherwise leak into the exports made by
@@ -527,12 +526,142 @@ describe("POST /v1/export — staged-file secret sweep", () => {
     }
   });
 
+  test("clean export round-trip ships staged files byte-identical (no gratuitous rewrites)", async () => {
+    // Route-level variant of the byte-identical property above: every clean
+    // seeded source file must come out of the archive exactly as it went in,
+    // proving the sweep does no gratuitous rewrites end-to-end.
+    const res = await callExport();
+    const dir = await extractArchive(res);
+    try {
+      for (const logFile of ["assistant-2025-01-10.log", "vellum.log"]) {
+        expect(readFileSync(join(dir, "daemon-logs", logFile), "utf-8")).toBe(
+          readFileSync(join(logsDir, logFile), "utf-8"),
+        );
+      }
+      for (const name of [
+        "2025-01-10T00-00-00.000Z_conv-jan10",
+        "2025-01-15T00-00-00.000Z_conv-jan15",
+      ]) {
+        const srcDir = join(conversationsDir, name);
+        const outDir = join(dir, "workspace", "conversations", name);
+        for (const file of readdirSync(srcDir)) {
+          expect(readFileSync(join(outDir, file), "utf-8")).toBe(
+            readFileSync(join(srcDir, file), "utf-8"),
+          );
+        }
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("redacts .jsonl files line-wise, keeping each valid line parseable", () => {
+    const staging = mkdtempSync(join(tmpdir(), "redact-staged-jsonl-"));
+    try {
+      const filePath = join(staging, "conversation-filtered.jsonl");
+      const validLine = JSON.stringify({
+        msg: `token ${SYNTHETIC_OPENAI_PROJECT_KEY}`,
+      });
+      const malformedLine = `not json but carries ${SYNTHETIC_OPENAI_PROJECT_KEY}`;
+      const cleanLine = JSON.stringify({ msg: "clean" });
+      writeFileSync(
+        filePath,
+        `${validLine}\n${malformedLine}\n${cleanLine}\n`,
+        "utf-8",
+      );
+
+      const result = redactStagedExportFiles(staging);
+      expect(result).toEqual({ filesScanned: 1, filesRedacted: 1 });
+
+      const lines = readFileSync(filePath, "utf-8").split("\n");
+      expect(lines[0]).not.toContain(SYNTHETIC_OPENAI_PROJECT_KEY);
+      // The valid line stays valid JSON, marker stored as a string value.
+      const parsed = JSON.parse(lines[0]) as { msg: string };
+      expect(parsed.msg).toContain(OPENAI_PROJECT_KEY_REDACTION_MARKER);
+      // The unparseable line falls back to plain-text redaction.
+      expect(lines[1]).toBe(
+        `not json but carries ${OPENAI_PROJECT_KEY_REDACTION_MARKER}`,
+      );
+      // The clean line is untouched.
+      expect(lines[2]).toBe(cleanLine);
+    } finally {
+      rmSync(staging, { recursive: true, force: true });
+    }
+  });
+
+  test("sweeps non-allowlisted staged files that sniff as text; leaves binary files untouched", () => {
+    const staging = mkdtempSync(join(tmpdir(), "redact-staged-sniff-"));
+    try {
+      // Conversation attachments are staged wholesale with arbitrary user
+      // extensions — they bypass the extension allowlist but must still be
+      // swept when they sniff as text.
+      const attachmentsDir = join(
+        staging,
+        "workspace",
+        "conversations",
+        "2025-01-10T00-00-00.000Z_conv-jan10",
+        "attachments",
+      );
+      mkdirSync(attachmentsDir, { recursive: true });
+      writeFileSync(
+        join(attachmentsDir, "creds.env"),
+        `OPENAI_API_KEY=${SYNTHETIC_OPENAI_PROJECT_KEY}\n`,
+        "utf-8",
+      );
+      writeFileSync(
+        join(attachmentsDir, "no-extension"),
+        `key: ${SYNTHETIC_OPENAI_PROJECT_KEY}\n`,
+        "utf-8",
+      );
+      // Binary sniff: a NUL byte in the head exempts the file from the
+      // sweep even though scanner-matching bytes appear later in it.
+      const binary = Buffer.concat([
+        Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0x01]),
+        Buffer.from(SYNTHETIC_OPENAI_PROJECT_KEY, "utf-8"),
+      ]);
+      writeFileSync(join(attachmentsDir, "image.png"), binary);
+
+      const result = redactStagedExportFiles(staging);
+
+      expect(result).toEqual({ filesScanned: 2, filesRedacted: 2 });
+      for (const file of ["creds.env", "no-extension"]) {
+        const content = readFileSync(join(attachmentsDir, file), "utf-8");
+        expect(content).toContain(OPENAI_PROJECT_KEY_REDACTION_MARKER);
+        expect(content).not.toContain(SYNTHETIC_OPENAI_PROJECT_KEY);
+      }
+      expect(readFileSync(join(attachmentsDir, "image.png"))).toEqual(binary);
+    } finally {
+      rmSync(staging, { recursive: true, force: true });
+    }
+  });
+
+  test("replaces oversized sweep-eligible files with an omission note (fail closed)", () => {
+    const staging = mkdtempSync(join(tmpdir(), "redact-staged-oversize-"));
+    try {
+      // One byte over the cap. The content must never ship unswept — it is
+      // replaced wholesale with the omission note.
+      writeFileSync(
+        join(staging, "messages.json"),
+        Buffer.alloc(MAX_SWEEP_FILE_BYTES + 1, 0x61),
+      );
+
+      const result = redactStagedExportFiles(staging);
+
+      expect(result).toEqual({ filesScanned: 1, filesRedacted: 1 });
+      expect(readFileSync(join(staging, "messages.json"), "utf-8")).toBe(
+        OVERSIZED_FILE_NOTE,
+      );
+    } finally {
+      rmSync(staging, { recursive: true, force: true });
+    }
+  });
+
   test("redacts raw keys from workspace conversation files in the archive", async () => {
     seedConversation(
       "2025-01-30T00-00-00.000Z_conv-secret",
       JSON.stringify({
         role: "user",
-        content: `export OPENAI_API_KEY="${RAW_OPENAI_PROJECT_KEY}"`,
+        content: `export OPENAI_API_KEY="${SYNTHETIC_OPENAI_PROJECT_KEY}"`,
       }) + "\n",
     );
 
@@ -549,8 +678,20 @@ describe("POST /v1/export — staged-file secret sweep", () => {
         ),
         "utf-8",
       );
-      expect(content).toContain(REDACTION_MARKER);
-      expect(content).not.toContain(RAW_OPENAI_PROJECT_KEY);
+      expect(content).not.toContain(SYNTHETIC_OPENAI_PROJECT_KEY);
+      // Line-wise JSON-aware redaction: every redacted line must still
+      // JSON.parse, with the marker stored as a proper JSON string value
+      // (its quotes are escaped on serialization).
+      const lines = content.split("\n").filter((line) => line.trim() !== "");
+      expect(lines.length).toBeGreaterThan(0);
+      const parsedLines = lines.map(
+        (line) => JSON.parse(line) as { content?: string },
+      );
+      expect(
+        parsedLines.some((record) =>
+          record.content?.includes(OPENAI_PROJECT_KEY_REDACTION_MARKER),
+        ),
+      ).toBe(true);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -571,7 +712,7 @@ describe("POST /v1/export — staged-file secret sweep", () => {
         conversationId: "conv-legacy-audit",
         toolName: "bash",
         input: JSON.stringify({
-          command: `export OPENAI_API_KEY="${RAW_OPENAI_PROJECT_KEY}"`,
+          command: `export OPENAI_API_KEY="${SYNTHETIC_OPENAI_PROJECT_KEY}"`,
         }),
         result: "{}",
         decision: "allow",
@@ -585,13 +726,13 @@ describe("POST /v1/export — staged-file secret sweep", () => {
     const dir = await extractArchive(res);
     try {
       const content = readFileSync(join(dir, "audit-data.json"), "utf-8");
-      expect(content).not.toContain(RAW_OPENAI_PROJECT_KEY);
+      expect(content).not.toContain(SYNTHETIC_OPENAI_PROJECT_KEY);
       // The sweep must keep the file parseable — redaction goes through a
       // JSON-aware path rather than splicing quoted markers into raw JSON.
       const rows = JSON.parse(content) as Array<{ id: string; input: string }>;
       const row = rows.find((r) => r.id === "ti-legacy-audit");
       expect(row).toBeDefined();
-      expect(row!.input).toContain(REDACTION_MARKER);
+      expect(row!.input).toContain(OPENAI_PROJECT_KEY_REDACTION_MARKER);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/assistant/src/__tests__/secret-fixtures.ts
+++ b/assistant/src/__tests__/secret-fixtures.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared synthetic-secret fixtures for redaction tests.
+ *
+ * Constants only — per the test machinery isolation rule, shared helpers in
+ * `src/__tests__/` must not import from `src/`.
+ */
+
+/**
+ * A synthetic OpenAI project key that matches the scanner's
+ * `sk-proj-[A-Za-z0-9\-_]{40,}` pattern while deliberately dodging its
+ * placeholder filtering: no "test"/"example"/"xxxx"-style segments, not a
+ * repeated character, and it ends with an alphanumeric so the trailing `\b`
+ * boundary holds.
+ */
+export const SYNTHETIC_OPENAI_PROJECT_KEY =
+  "sk-proj-Ab1Cd2Ef3Gh4Ij5Kl6Mn7Op8Qr9St0Uv1Wx2Yz3Ab4Cd5Ef6Gh";
+
+/** The marker `redactSecrets()` substitutes for the key above. */
+export const OPENAI_PROJECT_KEY_REDACTION_MARKER =
+  '<redacted type="OpenAI Project Key" />';

--- a/assistant/src/__tests__/tool-audit-listener.test.ts
+++ b/assistant/src/__tests__/tool-audit-listener.test.ts
@@ -10,6 +10,10 @@ mock.module("../config/loader.js", () => ({
 
 import { createToolAuditListener } from "../events/tool-audit-listener.js";
 import type { ToolInvocationRecord } from "../memory/tool-usage-store.js";
+import {
+  OPENAI_PROJECT_KEY_REDACTION_MARKER,
+  SYNTHETIC_OPENAI_PROJECT_KEY,
+} from "./secret-fixtures.js";
 
 describe("tool audit listener", () => {
   beforeEach(() => {
@@ -105,12 +109,9 @@ describe("tool audit listener", () => {
     const records: ToolInvocationRecord[] = [];
     const listener = createToolAuditListener((record) => records.push(record));
 
-    // OpenAI Project Key pattern requires 40+ base64url chars after
-    // "sk-proj-"; value chosen to dodge the scanner's placeholder filtering
-    // (no test/fake/example markers, not same-char or x-runs).
-    const openaiKey =
-      "sk-proj-Ab3dEf6hIj9kLm2nOp5qRs8tUv1wXy4zAb7cDe0fGh3iJk6l";
-    const input = { command: `export OPENAI_API_KEY="${openaiKey}"` };
+    const input = {
+      command: `export OPENAI_API_KEY="${SYNTHETIC_OPENAI_PROJECT_KEY}"`,
+    };
 
     listener({
       type: "executed",
@@ -150,8 +151,13 @@ describe("tool audit listener", () => {
 
     expect(records).toHaveLength(3);
     for (const record of records) {
-      expect(record.input).toContain('<redacted type="OpenAI Project Key" />');
-      expect(record.input).not.toContain(openaiKey);
+      expect(record.input).not.toContain(SYNTHETIC_OPENAI_PROJECT_KEY);
+      // The stored input must remain parseable JSON: string leaves are
+      // redacted before stringification, so the marker lands inside a JSON
+      // string value (its quotes escaped) instead of corrupting the
+      // serialized form.
+      const parsed = JSON.parse(record.input) as { command: string };
+      expect(parsed.command).toContain(OPENAI_PROJECT_KEY_REDACTION_MARKER);
     }
   });
 

--- a/assistant/src/events/tool-audit-listener.ts
+++ b/assistant/src/events/tool-audit-listener.ts
@@ -3,6 +3,7 @@ import {
   recordToolInvocation,
   type ToolInvocationRecord,
 } from "../memory/tool-usage-store.js";
+import { redactJsonStringLeaves } from "../security/redact-json.js";
 import { redactSecrets } from "../security/secret-scanner.js";
 import {
   stringifyToolInput,
@@ -50,7 +51,7 @@ function toInvocationRecord(
         // Inputs can carry secrets the model typed verbatim (e.g.
         // `export OPENAI_API_KEY=...` in a bash command) — redact before
         // the row reaches the audit store, like results below.
-        input: redactSecrets(rawInput),
+        input: redactToolInput(event.input, rawInput),
         result: redactSecrets(event.result.content).slice(
           0,
           RESULT_PREVIEW_LIMIT,
@@ -77,7 +78,7 @@ function toInvocationRecord(
       return {
         conversationId: event.conversationId,
         toolName: event.toolName,
-        input: redactSecrets(rawInput),
+        input: redactToolInput(event.input, rawInput),
         result,
         decision: "error",
         riskLevel: event.riskLevel,
@@ -95,7 +96,7 @@ function toInvocationRecord(
       return {
         conversationId: event.conversationId,
         toolName: event.toolName,
-        input: redactSecrets(stringifyToolInput(event.input)),
+        input: redactToolInput(event.input, stringifyToolInput(event.input)),
         result: formatDeniedResult(event.reason),
         decision: "denied",
         riskLevel: event.riskLevel,
@@ -105,6 +106,33 @@ function toInvocationRecord(
     case "start":
     case "permission_prompt":
       return null;
+  }
+}
+
+/**
+ * Redact secrets from a tool input while keeping the stored audit string
+ * parseable JSON. The redaction marker (`<redacted type="..." />`) contains
+ * double quotes, so redacting the serialized string would corrupt it —
+ * instead, walk the input's string leaves BEFORE stringification so the
+ * marker lands inside a JSON string value (with its quotes escaped).
+ *
+ * `rawInput` is the canonical pre-redaction serialization (also used for
+ * the `argBytes` telemetry fallback — byte sizes must reflect the full
+ * payload before truncation and redaction). It is returned untouched when
+ * nothing matched, keeping benign inputs byte-identical, and is redacted as
+ * plain text if the input can't be walked or re-serialized (e.g. cyclic
+ * structures).
+ */
+function redactToolInput(
+  input: Record<string, unknown>,
+  rawInput: string,
+): string {
+  try {
+    const { value, changed } = redactJsonStringLeaves(input);
+    if (!changed) return rawInput;
+    return JSON.stringify(value);
+  } catch {
+    return redactSecrets(rawInput);
   }
 }
 

--- a/assistant/src/runtime/routes/redact-staged-export.ts
+++ b/assistant/src/runtime/routes/redact-staged-export.ts
@@ -7,24 +7,45 @@
  * env scrubbing) only protect data written after they shipped — legacy audit
  * rows already persisted with plaintext inputs, and free-form workspace
  * conversation logs, can still carry raw secrets. This module is the final
- * belt: a pattern-based `redactSecrets()` pass over every staged text file
- * immediately before the tar.gz is created.
+ * belt: a pattern-based `redactSecrets()` pass over staged files immediately
+ * before the tar.gz is created.
+ *
+ * Coverage: every staged file with an allowlisted text extension
+ * (`REDACTABLE_EXTENSIONS`), plus any other staged file that sniffs as text
+ * (no NUL byte in its first 8 KiB) — e.g. conversation `attachments/` with
+ * arbitrary user extensions (`.env`, `.csv`, extensionless). Files that
+ * sniff as binary are left untouched. Serialized-JSON formats (`.json`,
+ * `.jsonl`) are redacted via a parse → redact-string-leaves → re-stringify
+ * path so the quoted redaction marker cannot corrupt them. Files above the
+ * size cap are NOT shipped unswept: their content is replaced with a short
+ * omission note (fail closed).
  */
 
 import type { Dirent } from "node:fs";
-import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import {
+  closeSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  readSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { extname, join } from "node:path";
 
+import { redactJsonStringLeaves } from "../../security/redact-json.js";
 import { redactSecrets } from "../../security/secret-scanner.js";
 import { getLogger } from "../../util/logger.js";
 
 const log = getLogger("redact-staged-export");
 
 /**
- * Extensions eligible for the sweep. Covers everything the export stages as
- * text today: `audit-data.json`, `messages.json`, `config-snapshot.json`,
- * daemon `.log` files, `conversation-filtered.jsonl`, and the workspace
- * copies (`conversations/**\/messages.jsonl`, `.tool-results/*.txt`).
+ * Extensions always eligible for the sweep, no sniffing needed. Covers
+ * everything the export stages as text today: `audit-data.json`,
+ * `messages.json`, `config-snapshot.json`, daemon `.log` files,
+ * `conversation-filtered.jsonl`, and the workspace copies
+ * (`conversations/**\/messages.jsonl`, `.tool-results/*.txt`). Files with
+ * other extensions are still swept when they sniff as text (see module doc).
  */
 const REDACTABLE_EXTENSIONS = new Set([
   ".json",
@@ -35,62 +56,88 @@ const REDACTABLE_EXTENSIONS = new Set([
 ]);
 
 /**
- * Files larger than this are skipped to bound memory — the sweep reads each
- * file fully into memory. Today's largest staged file is ~1–3 MB, so 32 MiB
- * leaves ample headroom.
+ * Files larger than this are not read into memory — the sweep reads each
+ * file fully to redact it. Today's largest staged file is ~1–3 MB, so 32 MiB
+ * leaves ample headroom. Oversized sweep-eligible files fail closed: their
+ * content is replaced with `OVERSIZED_FILE_NOTE` so legacy plaintext secrets
+ * can never ship unswept (e.g. an unbounded `messages.json` on `full: true`
+ * exports).
  */
-const MAX_SWEEP_FILE_BYTES = 32 * 1024 * 1024;
+export const MAX_SWEEP_FILE_BYTES = 32 * 1024 * 1024;
 
-interface RedactionState {
-  changed: boolean;
-}
+/** Replacement content for files that exceed `MAX_SWEEP_FILE_BYTES`. */
+export const OVERSIZED_FILE_NOTE = `[content omitted from export: file exceeded the ${
+  MAX_SWEEP_FILE_BYTES / (1024 * 1024)
+} MiB secret-redaction cap]\n`;
 
-function redactString(value: string, state: RedactionState): string {
-  const redacted = redactSecrets(value);
-  if (redacted !== value) state.changed = true;
-  return redacted;
+/**
+ * Bytes read from the head of a non-allowlisted-extension file to classify
+ * it as text (sweep it) or binary (leave it untouched).
+ */
+const TEXT_SNIFF_BYTES = 8 * 1024;
+
+/**
+ * Heuristic text check: a file is treated as text when its first
+ * `TEXT_SNIFF_BYTES` contain no NUL byte. Binary formats (images, archives,
+ * SQLite, …) virtually always carry a NUL early; redacting them as text
+ * would corrupt them for no benefit.
+ */
+function sniffsAsText(filePath: string): boolean {
+  const fd = openSync(filePath, "r");
+  try {
+    const buffer = Buffer.alloc(TEXT_SNIFF_BYTES);
+    const bytesRead = readSync(fd, buffer, 0, buffer.length, 0);
+    return !buffer.subarray(0, bytesRead).includes(0);
+  } finally {
+    closeSync(fd);
+  }
 }
 
 /**
- * Redact secrets in a parsed JSON value, walking every string leaf (keys
- * included). Sets `state.changed` when any redaction fired.
+ * Redact a serialized-JSON document while preserving its validity: parse,
+ * redact every string leaf, and re-stringify (unchanged text is returned
+ * byte-identical). Falls back to plain-text redaction when the text isn't
+ * valid JSON — it is already malformed, so there is no validity to preserve.
  */
-function redactJsonValue(value: unknown, state: RedactionState): unknown {
-  if (typeof value === "string") {
-    return redactString(value, state);
-  }
-  if (Array.isArray(value)) {
-    return value.map((item) => redactJsonValue(item, state));
-  }
-  if (value !== null && typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value).map(
-        ([key, val]) =>
-          [redactString(key, state), redactJsonValue(val, state)] as const,
-      ),
-    );
-  }
-  return value;
-}
-
-/**
- * Redact a `.json` file's content while preserving JSON validity. The
- * redaction marker (`<redacted type="..." />`) contains double quotes, so
- * splicing it into serialized JSON would corrupt any string it lands inside.
- * Parse, redact every string leaf, and re-stringify instead. Falls back to
- * plain-text redaction when the content isn't valid JSON — the file is
- * already malformed, so there is no validity to preserve.
- */
-function redactJsonContent(content: string): string {
+function redactSerializedJson(
+  text: string,
+  stringify: (value: unknown) => string,
+): string {
   let parsed: unknown;
   try {
-    parsed = JSON.parse(content);
+    parsed = JSON.parse(text);
   } catch {
-    return redactSecrets(content);
+    return redactSecrets(text);
   }
-  const state = { changed: false };
-  const redacted = redactJsonValue(parsed, state);
-  return state.changed ? JSON.stringify(redacted, null, 2) : content;
+  const { value, changed } = redactJsonStringLeaves(parsed);
+  return changed ? stringify(value) : text;
+}
+
+/**
+ * Redact a `.jsonl` file's content line by line, preserving each line's
+ * JSON validity (compact re-stringify, no pretty-printing).
+ */
+function redactJsonlContent(content: string): string {
+  let changed = false;
+  const lines = content.split("\n").map((line) => {
+    if (line.trim() === "") return line;
+    const redacted = redactSerializedJson(line, (value) =>
+      JSON.stringify(value),
+    );
+    if (redacted !== line) changed = true;
+    return redacted;
+  });
+  return changed ? lines.join("\n") : content;
+}
+
+function redactContent(content: string, ext: string): string {
+  if (ext === ".json") {
+    return redactSerializedJson(content, (value) =>
+      JSON.stringify(value, null, 2),
+    );
+  }
+  if (ext === ".jsonl") return redactJsonlContent(content);
+  return redactSecrets(content);
 }
 
 /**
@@ -131,23 +178,31 @@ export function redactStagedExportFiles(stagingDir: string): {
       // files nor directories here — they are skipped, never followed.
       if (!entry.isFile()) continue;
       const ext = extname(entry.name).toLowerCase();
-      if (!REDACTABLE_EXTENSIONS.has(ext)) continue;
 
       try {
+        // Files outside the extension allowlist (e.g. staged conversation
+        // attachments) are still swept when they sniff as text; only
+        // binary-looking files are exempt.
+        if (!REDACTABLE_EXTENSIONS.has(ext) && !sniffsAsText(filePath)) {
+          continue;
+        }
         const { size } = statSync(filePath);
         if (size > MAX_SWEEP_FILE_BYTES) {
+          // Fail closed: an oversized sweep-eligible file must not ship
+          // unswept — it may carry legacy plaintext secrets the sweep
+          // exists to catch. Replace its content with a short note.
           log.warn(
             { file: filePath, size },
-            "Staged export file exceeds secret sweep size cap; skipping",
+            "Staged export file exceeds secret sweep size cap; replacing content with omission note",
           );
+          writeFileSync(filePath, OVERSIZED_FILE_NOTE, "utf-8");
+          filesScanned++;
+          filesRedacted++;
           continue;
         }
         const content = readFileSync(filePath, "utf-8");
         filesScanned++;
-        const redacted =
-          ext === ".json"
-            ? redactJsonContent(content)
-            : redactSecrets(content);
+        const redacted = redactContent(content, ext);
         if (redacted !== content) {
           writeFileSync(filePath, redacted, "utf-8");
           filesRedacted++;

--- a/assistant/src/security/redact-json.ts
+++ b/assistant/src/security/redact-json.ts
@@ -1,0 +1,61 @@
+/**
+ * JSON-aware secret redaction: walk a parsed JSON value and run
+ * `redactSecrets()` over every string leaf (object keys included).
+ *
+ * The redaction marker (`<redacted type="..." />`) contains double quotes,
+ * so splicing it into an already-serialized JSON document corrupts any
+ * string it lands inside. Callers that need to keep serialized JSON valid
+ * must redact the string leaves of the parsed value and re-stringify,
+ * rather than redacting the serialized text.
+ *
+ * Shared by the export-time staged-file sweep (`redact-staged-export.ts`)
+ * and the tool-audit listener (`tool-audit-listener.ts`). The hot-path pino
+ * log serializer (`util/log-redact.ts`) intentionally does not use this
+ * module.
+ */
+
+import { redactSecrets } from "./secret-scanner.js";
+
+export interface RedactedJsonValue {
+  /** Redacted copy of the input (the input itself is never mutated). */
+  value: unknown;
+  /** True when at least one string leaf was changed by redaction. */
+  changed: boolean;
+}
+
+interface RedactionState {
+  changed: boolean;
+}
+
+/**
+ * Redact secrets in every string leaf (keys included) of a parsed JSON
+ * value. Returns the redacted copy plus a `changed` flag so callers can
+ * keep unchanged content byte-identical (no gratuitous re-serialization).
+ */
+export function redactJsonStringLeaves(value: unknown): RedactedJsonValue {
+  const state: RedactionState = { changed: false };
+  return { value: walk(value, state), changed: state.changed };
+}
+
+function walk(value: unknown, state: RedactionState): unknown {
+  if (typeof value === "string") {
+    return redactString(value, state);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => walk(item, state));
+  }
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(
+        ([key, val]) => [redactString(key, state), walk(val, state)] as const,
+      ),
+    );
+  }
+  return value;
+}
+
+function redactString(value: string, state: RedactionState): string {
+  const redacted = redactSecrets(value);
+  if (redacted !== value) state.changed = true;
+  return redacted;
+}


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for acp-codex-auth-export-redaction.md (and Codex review comments on #34502/#34507).

- .jsonl files now get line-wise JSON-aware redaction (marker quotes no longer corrupt JSONL)
- Audit tool inputs are redacted on string leaves before stringification, keeping stored input parseable (argBytes telemetry unchanged)
- Shared string-leaf redaction walker extracted; shared synthetic-key test fixture
- Export sweep now fails closed on oversized files and sniffs non-allowlisted text files (attachments) instead of shipping them unswept