### PR TITLE
fix(web): harden lockfile fallback paths against assistant-list and selection wipes

### DIFF
--- a/apps/web/src/lib/local-mode.test.ts
+++ b/apps/web/src/lib/local-mode.test.ts
@@ -12,9 +12,14 @@ const replacePlatformAssistantsHost = mock(
   }),
 );
 
+const loadLockfileHost = mock(async () => {
+  throw new Error("host down");
+});
+
 mock.module("@/runtime/local-mode-host", () => ({
   ...localModeHost,
   replacePlatformAssistantsHost,
+  loadLockfileHost,
 }));
 
 import {
@@ -25,6 +30,7 @@ import {
   getSelectedAssistant,
   isLocalAssistant,
   isPlatformAssistant,
+  loadLockfile,
   reconcileSelectedAssistant,
   syncPlatformAssistantsToLockfile,
 } from "@/lib/local-mode";
@@ -60,7 +66,7 @@ function setLockfile(lockfile: Lockfile): void {
 }
 
 afterEach(() => {
-  useLockfileStore.setState({ lockfile: null });
+  useLockfileStore.setState({ lockfile: null, committed: false });
   localStorage.removeItem(LOCKFILE_STORAGE_KEY);
   localStorage.removeItem(SELECTED_ASSISTANT_STORAGE_KEY);
   replacePlatformAssistantsHost.mockClear();
@@ -90,6 +96,62 @@ describe("syncPlatformAssistantsToLockfile", () => {
     expect(entries).toEqual([
       expect.objectContaining({ assistantId: "platform-a", organizationId: "org-1" }),
     ]);
+  });
+
+  test("backs out before the host replace when shouldApply is false", async () => {
+    await syncPlatformAssistantsToLockfile([remote], "org-1", () => false);
+
+    expect(replacePlatformAssistantsHost).not.toHaveBeenCalled();
+  });
+
+  test("skips the commit when shouldApply flips false during the replace", async () => {
+    let fresh = true;
+    replacePlatformAssistantsHost.mockImplementationOnce(async () => {
+      fresh = false;
+      return {
+        ok: true as const,
+        lockfile: { assistants: [], activeAssistant: null },
+      };
+    });
+
+    await syncPlatformAssistantsToLockfile([remote], "org-1", () => fresh);
+
+    expect(replacePlatformAssistantsHost).toHaveBeenCalledTimes(1);
+    expect(useLockfileStore.getState().lockfile).toBeNull();
+    expect(localStorage.getItem(LOCKFILE_STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe("loadLockfile host-failure fallback", () => {
+  test("keeps the cached lockfile instead of clobbering it with empty", async () => {
+    useLockfileStore
+      .getState()
+      .setLockfile({ assistants: [localA], activeAssistant: "local-a" });
+
+    const result = await loadLockfile();
+
+    expect(result.assistants).toEqual([localA]);
+    expect(useLockfileStore.getState().lockfile?.assistants).toEqual([localA]);
+    expect(useLockfileStore.getState().committed).toBe(true);
+  });
+
+  test("falls back to the persisted mirror when nothing is cached", async () => {
+    localStorage.setItem(
+      LOCKFILE_STORAGE_KEY,
+      JSON.stringify({ assistants: [localA], activeAssistant: null }),
+    );
+
+    const result = await loadLockfile();
+
+    expect(result.assistants.map((a) => a.assistantId)).toEqual(["local-a"]);
+    expect(useLockfileStore.getState().committed).toBe(true);
+  });
+
+  test("records the empty fallback as not committed", async () => {
+    const result = await loadLockfile();
+
+    expect(result.assistants).toEqual([]);
+    expect(useLockfileStore.getState().committed).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/local-mode.ts
+++ b/apps/web/src/lib/local-mode.ts
@@ -50,8 +50,8 @@ export type {
 // changes; this module owns the transport and is the only writer.
 const getCachedLockfile = (): Lockfile | null =>
   useLockfileStore.getState().lockfile;
-const setCachedLockfile = (data: Lockfile): void =>
-  useLockfileStore.getState().setLockfile(data);
+const setCachedLockfile = (data: Lockfile, committed = true): void =>
+  useLockfileStore.getState().setLockfile(data, committed);
 
 const EMPTY_LOCKFILE: Lockfile = { assistants: [], activeAssistant: null };
 
@@ -73,8 +73,8 @@ const commitLockfile = (data: Lockfile): void => {
   setCachedLockfile(data);
   setLocalSetting(LOCKFILE_STORAGE_KEY, JSON.stringify(data));
   // Only reconcile against a lockfile from a successful host read/write — never
-  // the transient empty fallback in `loadLockfile`/`getLockfile`, which would
-  // wrongly drop a valid selection on a boot/read failure.
+  // the transient empty fallback in `getLockfile`, which would wrongly drop a
+  // valid selection on a boot/read failure.
   reconcileSelectedAssistant();
 };
 
@@ -113,9 +113,10 @@ export async function loadLockfile(): Promise<Lockfile> {
     commitLockfile(data);
     return data;
   } catch {
-    const empty = { ...EMPTY_LOCKFILE };
-    setCachedLockfile(empty);
-    return empty;
+    // Host read failed — keep whatever we already have (the in-memory cache,
+    // then the persisted mirror) rather than clobbering it with an empty
+    // lockfile that subscribers would mistake for "no assistants".
+    return getLockfile();
   }
 }
 
@@ -135,8 +136,10 @@ export function getLockfile(): Lockfile {
     }
   }
 
+  // Not committed: this is a "nothing loaded yet" placeholder, not evidence
+  // that the assistants are gone — reconciling subscribers must ignore it.
   const empty = { ...EMPTY_LOCKFILE };
-  setCachedLockfile(empty);
+  setCachedLockfile(empty, false);
   return empty;
 }
 
@@ -193,10 +196,14 @@ export async function setActiveLockfileAssistant(
 export async function syncPlatformAssistantsToLockfile(
   assistants: Array<{ id: string; name?: string; is_local: boolean; created: string }>,
   organizationId?: string,
+  shouldApply: () => boolean = () => true,
 ): Promise<void> {
   // Without a resolved org we can't scope the replace; a full wipe here would
   // drop other orgs' platform entries. Skip — a later sync re-runs with the org.
   if (organizationId == null) return;
+  // `shouldApply` lets a superseded caller (e.g. an out-of-date session probe)
+  // back out before the host replace, and again before committing the result.
+  if (!shouldApply()) return;
 
   const platformAssistants = assistants
     .filter((a) => !a.is_local)
@@ -213,7 +220,7 @@ export async function syncPlatformAssistantsToLockfile(
     platformAssistants,
     organizationId,
   );
-  if (result.ok) {
+  if (result.ok && shouldApply()) {
     commitLockfile(result.lockfile);
   }
 }

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -267,24 +267,32 @@ function probePlatformSession(
         // The whole sequence (org fetch, list, host replace) is bounded
         // to 3s so a hanging call can't block the probe from settling —
         // the middleware's 5s timeout would loop indefinitely otherwise.
-        // `!isStale()` keeps a superseded probe from committing an
-        // out-of-date lockfile.
+        // The race does not cancel the inner branch, so the guard also
+        // checks `timedOut`: once the probe settles without the sync, a
+        // late commit must not land after routing decisions were made on
+        // the un-synced lockfile. `!isStale()` likewise keeps a
+        // superseded probe from committing an out-of-date lockfile.
         if (isLocalMode()) {
+          let timedOut = false;
+          const syncIsCurrent = (): boolean => !timedOut && !isStale();
           try {
             await Promise.race([
               (async () => {
                 await useOrganizationStore.getState().fetchOrganizations();
                 const apiAssistants = await listAssistants();
-                if (!isStale() && apiAssistants.ok) {
+                if (syncIsCurrent() && apiAssistants.ok) {
                   await syncPlatformAssistantsToLockfile(
                     apiAssistants.data,
                     useOrganizationStore.getState().currentOrganizationId ?? undefined,
-                    () => !isStale(),
+                    syncIsCurrent,
                   );
                 }
               })(),
               new Promise<never>((_, reject) =>
-                setTimeout(() => reject(new Error("sync timeout")), 3_000),
+                setTimeout(() => {
+                  timedOut = true;
+                  reject(new Error("sync timeout"));
+                }, 3_000),
               ),
             ]);
           } catch {

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -264,24 +264,29 @@ function probePlatformSession(
         // platformSession to "present". The auth middleware unblocks on
         // `platformSession !== "unknown"`, and hasAssistants() must
         // already reflect synced platform assistants at that point.
-        // Bounded to 3s so a hanging list call can't block the probe
-        // from settling — the middleware's 5s timeout would loop
-        // indefinitely otherwise.
+        // The whole sequence (org fetch, list, host replace) is bounded
+        // to 3s so a hanging call can't block the probe from settling —
+        // the middleware's 5s timeout would loop indefinitely otherwise.
+        // `!isStale()` keeps a superseded probe from committing an
+        // out-of-date lockfile.
         if (isLocalMode()) {
           try {
-            await useOrganizationStore.getState().fetchOrganizations();
-            const apiAssistants = await Promise.race([
-              listAssistants(),
+            await Promise.race([
+              (async () => {
+                await useOrganizationStore.getState().fetchOrganizations();
+                const apiAssistants = await listAssistants();
+                if (!isStale() && apiAssistants.ok) {
+                  await syncPlatformAssistantsToLockfile(
+                    apiAssistants.data,
+                    useOrganizationStore.getState().currentOrganizationId ?? undefined,
+                    () => !isStale(),
+                  );
+                }
+              })(),
               new Promise<never>((_, reject) =>
                 setTimeout(() => reject(new Error("sync timeout")), 3_000),
               ),
             ]);
-            if (!isStale() && apiAssistants.ok) {
-              await syncPlatformAssistantsToLockfile(
-                apiAssistants.data,
-                useOrganizationStore.getState().currentOrganizationId ?? undefined,
-              );
-            }
           } catch {
             // Sync failed or timed out — continue with cached lockfile data
           }
@@ -391,10 +396,6 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
                   apiAssistants.data,
                   useOrganizationStore.getState().currentOrganizationId ?? undefined,
                 );
-                if (getPlatformAssistants().length === 0 && getLocalAssistants().length === 0) {
-                  set(authenticatedPlatformUser(user));
-                  return;
-                }
               }
             } catch {
               // Sync failed — continue with cached data

--- a/apps/web/src/stores/lockfile-store.ts
+++ b/apps/web/src/stores/lockfile-store.ts
@@ -26,17 +26,25 @@ import type { Lockfile } from "@/runtime/local-mode-host";
 
 interface LockfileState {
   lockfile: Lockfile | null;
+  /**
+   * Whether `lockfile` reflects authoritative data (a host read/write or its
+   * persisted mirror) rather than a transient empty fallback written when
+   * nothing has loaded. Subscribers that reconcile state away — e.g. the
+   * resolved-assistants sync — must ignore non-committed writes.
+   */
+  committed: boolean;
 }
 
 interface LockfileActions {
-  setLockfile: (lockfile: Lockfile) => void;
+  setLockfile: (lockfile: Lockfile, committed?: boolean) => void;
 }
 
 type LockfileStore = LockfileState & LockfileActions;
 
 const useLockfileStoreBase = create<LockfileStore>((set) => ({
   lockfile: null,
-  setLockfile: (lockfile) => set({ lockfile }),
+  committed: false,
+  setLockfile: (lockfile, committed = true) => set({ lockfile, committed }),
 }));
 
 export const useLockfileStore = createSelectors(useLockfileStoreBase);

--- a/apps/web/src/stores/resolved-assistants-store.test.ts
+++ b/apps/web/src/stores/resolved-assistants-store.test.ts
@@ -6,6 +6,7 @@ import {
   type ResolvedAssistant,
 } from "@/stores/resolved-assistants-store";
 import { SELECTED_ASSISTANT_STORAGE_KEY } from "@/assistant/selected-assistant-storage";
+import { useLockfileStore } from "@/stores/lockfile-store";
 import type { Lockfile, LockfileAssistant } from "@/runtime/local-mode-host";
 
 // A platform entry is identified by `cloud === "vellum"` and carries an
@@ -26,6 +27,7 @@ const localAssistant: LockfileAssistant = {
 
 beforeEach(() => {
   localStorage.removeItem(SELECTED_ASSISTANT_STORAGE_KEY);
+  useLockfileStore.setState({ lockfile: null, committed: false });
   useResolvedAssistantsStore.setState({
     assistants: [],
     selectedAssistantId: null,
@@ -81,6 +83,28 @@ describe("upsertFromApi", () => {
     const entry = useResolvedAssistantsStore.getState().assistants[0];
     expect(entry.id).toBe("asst-platform");
     expect(entry.name).toBe("Platform (refreshed)");
+    expect(entry.organizationId).toBe("org-1");
+  });
+
+  it("seeds organizationId from the lockfile cache when inserting a new entry", () => {
+    // A lifecycle refresh can land before the lockfile subscription has seeded
+    // the resolved list; the insert must still pick up the org the lockfile knows.
+    useLockfileStore.getState().setLockfile({
+      assistants: [platformAssistant],
+      activeAssistant: null,
+    });
+
+    useResolvedAssistantsStore.getState().upsertFromApi({
+      id: "asst-platform",
+      name: "Platform",
+      created: "2026-01-01T00:00:00Z",
+      is_local: false,
+    } as Parameters<
+      ReturnType<typeof useResolvedAssistantsStore.getState>["upsertFromApi"]
+    >[0]);
+
+    const entry = useResolvedAssistantsStore.getState().assistants[0];
+    expect(entry.id).toBe("asst-platform");
     expect(entry.organizationId).toBe("org-1");
   });
 });

--- a/apps/web/src/stores/resolved-assistants-store.ts
+++ b/apps/web/src/stores/resolved-assistants-store.ts
@@ -152,7 +152,20 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
           next[idx] = { ...entry, organizationId: next[idx]!.organizationId };
           return { assistants: next };
         }
-        return { assistants: [...state.assistants, entry] };
+        // New entry: the API payload has no org field, but the lockfile may
+        // already know it (a lifecycle refresh can land before the lockfile
+        // subscription seeds the list).
+        const lockfileOrg = useLockfileStore
+          .getState()
+          .lockfile?.assistants.find(
+            (a) => a.assistantId === assistant.id,
+          )?.organizationId;
+        return {
+          assistants: [
+            ...state.assistants,
+            { ...entry, organizationId: lockfileOrg },
+          ],
+        };
       }),
 
     remove: (assistantId) =>
@@ -206,10 +219,13 @@ export const useResolvedAssistantsStore = createSelectors(
 // Subscriptions
 // ---------------------------------------------------------------------------
 
-// In local mode, keep the resolved list in sync with the lockfile.
+// In local mode, keep the resolved list in sync with the lockfile. Only
+// committed lockfiles count: the empty placeholder written when nothing has
+// loaded (e.g. a failed host read at boot) must not mark the list hydrated
+// and reconcile away a still-valid selection.
 if (isLocalMode()) {
   useLockfileStore.subscribe((state) => {
-    if (state.lockfile) {
+    if (state.lockfile && state.committed) {
       useResolvedAssistantsStoreBase.getState().setFromLockfile(state.lockfile);
     }
   });


### PR DESCRIPTION
## Summary
- Add a `committed` flag to the lockfile store so the resolved-assistants subscription ignores transient empty fallbacks: a failed host read at boot no longer wipes the assistant list or permanently clears the persisted selection. `loadLockfile` now falls back to the in-memory cache / persisted mirror instead of clobbering them with an empty lockfile.
- Bound the entire platform-assistant sync in `probePlatformSession` (org fetch + list + host replace) by the existing 3s race — previously only `listAssistants` was bounded — and pass a `shouldApply` staleness guard so a superseded probe can't commit an out-of-date lockfile.
- Remove a dead branch in `initSession` (identical to the unconditional code right after it) and seed `organizationId` from the lockfile cache when `upsertFromApi` inserts a new entry, closing the window where a lifecycle refresh landing before the lockfile sync left a platform assistant org-less.

## Original prompt
While tracing how the resolved-assistants store hydrates from the local lockfile, a review of the surrounding code surfaced several issues — most notably that the transient empty-lockfile fallback written on a failed host read flowed through the lockfile-store subscription, marked the resolved list hydrated, and reconciled away a still-valid persisted selection (assistants vanish after a flaky boot). The user asked to ship fixes for all issues identified in that review: the fallback wipe, the incomplete 3s probe bound, stale probes committing the lockfile, a dead branch in initSession, and the upsert org-seeding gap.