### PR TITLE
fix(macos): per-entry tolerant acp.agents sanitization so one malformed agent can't fail open

### DIFF
--- a/clients/macos/vellum-assistant/Logging/LogExporter.swift
+++ b/clients/macos/vellum-assistant/Logging/LogExporter.swift
@@ -1241,11 +1241,13 @@ enum LogExporter {
             config["mcp"] = mcp
         }
 
-        // Strip ACP agent env vars
+        // Strip ACP agent env vars. Sanitize per-entry (mirroring the daemon-side
+        // sanitizer) so a single malformed agent value can't skip redaction for
+        // every well-formed agent.
         if var acp = config["acp"] as? [String: Any],
-           var agents = acp["agents"] as? [String: [String: Any]] {
-            for name in agents.keys {
-                var agent = agents[name]!
+           var agents = acp["agents"] as? [String: Any] {
+            for (name, value) in agents {
+                guard var agent = value as? [String: Any] else { continue }
                 if let env = agent["env"] as? [String: Any] {
                     agent["env"] = redactAllValues(env)
                 }

--- a/clients/macos/vellum-assistantTests/LogExporterClientArtifactsTests.swift
+++ b/clients/macos/vellum-assistantTests/LogExporterClientArtifactsTests.swift
@@ -114,6 +114,45 @@ struct LogExporterClientArtifactsTests {
         #expect(sanitized["model"] as? String == "some-model")
     }
 
+    @Test
+    func sanitizeWorkspaceConfigRedactsWellFormedAgentsDespiteMalformedSibling() throws {
+        let config: [String: Any] = [
+            "acp": [
+                "agents": [
+                    "broken": "not-a-dictionary",
+                    "codex": [
+                        "command": "codex",
+                        "env": [
+                            "OPENAI_API_KEY": "sk-proj-synthetic-test-value-1234567890"
+                        ]
+                    ]
+                ]
+            ]
+        ]
+
+        let sanitized = LogExporter.sanitizeWorkspaceConfig(config)
+
+        guard let acp = sanitized["acp"] as? [String: Any],
+              let agents = acp["agents"] as? [String: Any],
+              let codex = agents["codex"] as? [String: Any],
+              let env = codex["env"] as? [String: Any] else {
+            Issue.record("Expected sanitized acp.agents.codex.env")
+            return
+        }
+
+        // The well-formed agent's env is still redacted despite the malformed sibling
+        #expect(env["OPENAI_API_KEY"] as? String == "(set)")
+        #expect(codex["command"] as? String == "codex")
+
+        // The malformed entry passes through unchanged
+        #expect(agents["broken"] as? String == "not-a-dictionary")
+
+        // No plaintext secrets anywhere in the serialized output
+        let data = try JSONSerialization.data(withJSONObject: sanitized)
+        let json = String(decoding: data, as: UTF8.self)
+        #expect(!json.contains("sk-proj-synthetic-test-value-1234567890"))
+    }
+
     // MARK: - All Artifacts Present
 
     @Test


### PR DESCRIPTION
## Summary
Round-2 review fix for acp-codex-auth-export-redaction.md.

- sanitizeWorkspaceConfig now sanitizes acp agents per-entry (mirroring the daemon-side sanitizer) so a single malformed agent entry no longer skips redaction for all agents