### PR TITLE
fix(acp): guard connection in auth retry, capture spawn env once, pin auth-method ordering test

### DIFF
--- a/assistant/src/acp/__tests__/agent-process.test.ts
+++ b/assistant/src/acp/__tests__/agent-process.test.ts
@@ -161,11 +161,12 @@ describe("AcpAgentProcess loadSession/resumeSession", () => {
 });
 
 describe("AcpAgentProcess auth_required retry", () => {
-  // The merged child env includes process.env, so the advertised var names use
-  // a VELLUM_TEST_ prefix guaranteed absent from the test process env. The
-  // structure mirrors codex-acp's real advertisement: an agent-driven browser
-  // login (no `type`, must never be auto-selected) followed by two env_var
-  // methods, in that order.
+  // spawnedEnv is injected the way spawn() builds it ({ ...process.env,
+  // ...config.env }), so the advertised var names use a VELLUM_TEST_ prefix
+  // guaranteed absent from the test process env. The structure mirrors
+  // codex-acp's real advertisement: an agent-driven browser login (no `type`,
+  // must never be auto-selected) followed by two env_var methods, in that
+  // order.
   const CODEX_VAR = "VELLUM_TEST_FAKE_CODEX_API_KEY";
   const OPENAI_VAR = "VELLUM_TEST_FAKE_OPENAI_API_KEY";
 
@@ -185,7 +186,10 @@ describe("AcpAgentProcess auth_required retry", () => {
     },
   ];
 
-  const authRequiredError = { code: -32000, message: "Authentication required" };
+  const authRequiredError = {
+    code: -32000,
+    message: "Authentication required",
+  };
 
   /**
    * Creates a process whose connection is stubbed with mocks, then runs
@@ -221,14 +225,21 @@ describe("AcpAgentProcess auth_required retry", () => {
     const newSession = failThenSucceed(options.newSessionRejections ?? [], {
       sessionId: "session-1",
     });
-    const loadSession = failThenSucceed(options.loadSessionRejections ?? [], {});
+    const loadSession = failThenSucceed(
+      options.loadSessionRejections ?? [],
+      {},
+    );
     const resumeSession = failThenSucceed(
       options.resumeSessionRejections ?? [],
       {},
     );
     const authenticate = mock(() => Promise.resolve({}));
 
-    (proc as unknown as { connection: unknown }).connection = {
+    const internals = proc as unknown as {
+      connection: unknown;
+      spawnedEnv: NodeJS.ProcessEnv;
+    };
+    internals.connection = {
       initialize: () =>
         Promise.resolve({
           protocolVersion: 1,
@@ -239,10 +250,18 @@ describe("AcpAgentProcess auth_required retry", () => {
       resumeSession,
       authenticate,
     };
+    internals.spawnedEnv = { ...process.env, ...options.env };
 
     await proc.initialize();
 
-    return { proc, newSession, loadSession, resumeSession, authenticate };
+    return {
+      proc,
+      newSession,
+      loadSession,
+      resumeSession,
+      authenticate,
+      internals,
+    };
   }
 
   test("createSession does not authenticate when newSession succeeds", async () => {
@@ -271,9 +290,11 @@ describe("AcpAgentProcess auth_required retry", () => {
     expect(newSession).toHaveBeenCalledTimes(2);
   });
 
-  test("auth_required with CODEX-style key selects the earlier advertised method", async () => {
+  test("auth_required with both keys present selects the earlier advertised method", async () => {
+    // Both methods are satisfiable, so this pins advertised-order selection
+    // rather than only-satisfiable selection.
     const { proc, authenticate } = await setupAuthProcess({
-      env: { [CODEX_VAR]: "sk-codex" },
+      env: { [CODEX_VAR]: "sk-codex", [OPENAI_VAR]: "sk-openai" },
       newSessionRejections: [authRequiredError],
     });
 
@@ -371,5 +392,45 @@ describe("AcpAgentProcess auth_required retry", () => {
     });
     expect(authenticate).not.toHaveBeenCalled();
     expect(newSession).toHaveBeenCalledTimes(1);
+  });
+
+  test("auth_required after the agent process exits throws the not-spawned error", async () => {
+    const { proc, authenticate, internals } = await setupAuthProcess({
+      env: { [OPENAI_VAR]: "sk-test" },
+    });
+
+    // Simulate handleProcessExit racing the auth retry: the agent dies as it
+    // rejects with auth_required, nulling the connection before the retry
+    // path runs. spawnedEnv stays satisfiable so only the connection guard
+    // can produce the failure.
+    (internals.connection as { newSession: unknown }).newSession = () => {
+      internals.connection = null;
+      return Promise.reject(authRequiredError);
+    };
+
+    await expect(proc.createSession("/tmp/project")).rejects.toThrow(
+      'ACP agent "codex" is not spawned',
+    );
+    expect(authenticate).not.toHaveBeenCalled();
+  });
+
+  test("satisfiability uses the env captured at spawn, not live process.env", async () => {
+    const { proc, authenticate } = await setupAuthProcess({
+      env: { [OPENAI_VAR]: "sk-test" },
+      newSessionRejections: [authRequiredError],
+    });
+
+    // Drift process.env after "spawn": the earlier-advertised codex var
+    // appears, but the spawned child never saw it, so the openai method
+    // must still be selected.
+    process.env[CODEX_VAR] = "sk-codex-late";
+    try {
+      await proc.createSession("/tmp/project");
+    } finally {
+      delete process.env[CODEX_VAR];
+    }
+
+    expect(authenticate).toHaveBeenCalledTimes(1);
+    expect(authenticate).toHaveBeenCalledWith({ methodId: "openai-api-key" });
   });
 });

--- a/assistant/src/acp/agent-process.ts
+++ b/assistant/src/acp/agent-process.ts
@@ -62,6 +62,12 @@ export class AcpAgentProcess {
   private proc: ChildProcess | null = null;
   private connection: acp.ClientSideConnection | null = null;
   private initializeResponse: InitializeResponse | null = null;
+  /**
+   * Merged env captured at spawn() so auth satisfiability checks match the
+   * env the child process actually received, even if process.env changes
+   * afterwards.
+   */
+  private spawnedEnv: NodeJS.ProcessEnv | null = null;
 
   constructor(
     public readonly agentId: string,
@@ -78,10 +84,11 @@ export class AcpAgentProcess {
       "Spawning ACP agent process",
     );
 
+    this.spawnedEnv = { ...process.env, ...this.config.env };
     this.proc = spawn(this.config.command, this.config.args, {
       cwd,
       stdio: ["pipe", "pipe", "pipe"],
-      env: this.childEnv(),
+      env: this.spawnedEnv,
     });
 
     const stream = acp.ndJsonStream(
@@ -121,13 +128,11 @@ export class AcpAgentProcess {
    * Initializes the ACP connection by negotiating protocol version and capabilities.
    */
   async initialize(): Promise<InitializeResponse> {
-    if (!this.connection) {
-      throw new Error(`ACP agent "${this.agentId}" is not spawned`);
-    }
+    const connection = this.requireConnection();
 
     log.info({ agentId: this.agentId }, "Initializing ACP connection");
 
-    const response = await this.connection.initialize({
+    const response = await connection.initialize({
       protocolVersion: acp.PROTOCOL_VERSION,
       clientInfo: { name: "vellum", version: "1.0.0" },
       clientCapabilities: {
@@ -175,7 +180,8 @@ export class AcpAgentProcess {
    * auto-triggering an interactive login would hang the headless daemon.
    */
   private selectEnvVarAuthMethod(): AuthMethod | undefined {
-    const env = this.childEnv();
+    const env = this.spawnedEnv;
+    if (!env) return undefined;
 
     return this.authMethods.find((method) => {
       if (!isEnvVarMethod(method)) return false;
@@ -190,9 +196,15 @@ export class AcpAgentProcess {
     });
   }
 
-  /** The environment the agent child process is spawned with. */
-  private childEnv(): NodeJS.ProcessEnv {
-    return { ...process.env, ...this.config.env };
+  /**
+   * Returns the live connection, throwing the standard not-spawned error if
+   * the agent was never spawned or its process has since exited.
+   */
+  private requireConnection(): acp.ClientSideConnection {
+    if (!this.connection) {
+      throw new Error(`ACP agent "${this.agentId}" is not spawned`);
+    }
+    return this.connection;
   }
 
   /**
@@ -205,6 +217,10 @@ export class AcpAgentProcess {
       return await op();
     } catch (err) {
       if (!isAuthRequiredError(err)) throw err;
+
+      // The agent may have exited between the auth_required rejection and
+      // this retry path; fail with the standard not-spawned error.
+      const connection = this.requireConnection();
 
       const method = this.selectEnvVarAuthMethod();
       if (!method) {
@@ -222,7 +238,7 @@ export class AcpAgentProcess {
         "ACP agent returned auth_required; authenticating with env_var method",
       );
 
-      await this.connection!.authenticate({ methodId: method.id });
+      await connection.authenticate({ methodId: method.id });
       return await op();
     }
   }
@@ -250,14 +266,12 @@ export class AcpAgentProcess {
    * Returns the session ID.
    */
   async createSession(cwd: string): Promise<string> {
-    if (!this.connection) {
-      throw new Error(`ACP agent "${this.agentId}" is not spawned`);
-    }
+    this.requireConnection();
 
     log.info({ agentId: this.agentId, cwd }, "Creating ACP session");
 
     const result: NewSessionResponse = await this.withAuthRetry(() =>
-      this.connection!.newSession({ cwd, mcpServers: [] }),
+      this.requireConnection().newSession({ cwd, mcpServers: [] }),
     );
 
     return result.sessionId;
@@ -272,14 +286,12 @@ export class AcpAgentProcess {
    * VellumAcpClientHandler.beginReplaySuppression).
    */
   async loadSession(sessionId: string, cwd: string): Promise<void> {
-    if (!this.connection) {
-      throw new Error(`ACP agent "${this.agentId}" is not spawned`);
-    }
+    this.requireConnection();
 
     log.info({ agentId: this.agentId, sessionId, cwd }, "Loading ACP session");
 
     await this.withAuthRetry(() =>
-      this.connection!.loadSession({ sessionId, cwd, mcpServers: [] }),
+      this.requireConnection().loadSession({ sessionId, cwd, mcpServers: [] }),
     );
   }
 
@@ -291,14 +303,16 @@ export class AcpAgentProcess {
    * (see supportsSessionResume).
    */
   async resumeSession(sessionId: string, cwd: string): Promise<void> {
-    if (!this.connection) {
-      throw new Error(`ACP agent "${this.agentId}" is not spawned`);
-    }
+    this.requireConnection();
 
     log.info({ agentId: this.agentId, sessionId, cwd }, "Resuming ACP session");
 
     await this.withAuthRetry(() =>
-      this.connection!.resumeSession({ sessionId, cwd, mcpServers: [] }),
+      this.requireConnection().resumeSession({
+        sessionId,
+        cwd,
+        mcpServers: [],
+      }),
     );
   }
 
@@ -307,16 +321,14 @@ export class AcpAgentProcess {
    * Returns the prompt response (includes stopReason).
    */
   async prompt(sessionId: string, text: string): Promise<PromptResponse> {
-    if (!this.connection) {
-      throw new Error(`ACP agent "${this.agentId}" is not spawned`);
-    }
+    const connection = this.requireConnection();
 
     log.info(
       { agentId: this.agentId, sessionId },
       "Sending prompt to ACP agent",
     );
 
-    return this.connection.prompt({
+    return connection.prompt({
       sessionId,
       prompt: [{ type: "text", text }],
     });
@@ -326,16 +338,14 @@ export class AcpAgentProcess {
    * Cancels an ongoing prompt in the specified session.
    */
   async cancel(sessionId: string): Promise<void> {
-    if (!this.connection) {
-      throw new Error(`ACP agent "${this.agentId}" is not spawned`);
-    }
+    const connection = this.requireConnection();
 
     log.info(
       { agentId: this.agentId, sessionId },
       "Cancelling ACP session prompt",
     );
 
-    await this.connection.cancel({ sessionId });
+    await connection.cancel({ sessionId });
   }
 
   /**
@@ -350,6 +360,7 @@ export class AcpAgentProcess {
     }
     this.connection = null;
     this.initializeResponse = null;
+    this.spawnedEnv = null;
   }
 
   /**
@@ -381,5 +392,6 @@ export class AcpAgentProcess {
     this.proc = null;
     this.connection = null;
     this.initializeResponse = null;
+    this.spawnedEnv = null;
   }
 }


### PR DESCRIPTION
## Summary
Round-2 review fixes for acp-codex-auth-export-redaction.md.

- withAuthRetry now fails with the standard not-spawned error if the agent dies mid-retry instead of a TypeError
- Merged child env captured once at spawn so auth satisfiability can't drift from the env the child actually got
- Ordering test now sets both env vars, genuinely pinning advertised-order selection