### PR TITLE
fix: bound full-export DB dumps, simplify sweep classification, BOM-safe JSON redaction

### DIFF
--- a/assistant/src/__tests__/log-export-workspace.test.ts
+++ b/assistant/src/__tests__/log-export-workspace.test.ts
@@ -9,6 +9,7 @@
 
 import { spawnSync } from "node:child_process";
 import {
+  chmodSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
@@ -110,9 +111,13 @@ async function extractArchive(res: Response): Promise<string> {
 // ---------------------------------------------------------------------------
 
 // config.json at workspace root — needed for config-snapshot tests. The
-// acp.agents env values are obviously-synthetic secrets that must be redacted
-// from the exported snapshot.
-const SYNTHETIC_ACP_API_KEY = "sk-proj-synthetic-test-key-000000";
+// acp.agents env value is a synthetic secret that must be redacted from the
+// exported snapshot. Unlike the shared `SYNTHETIC_OPENAI_PROJECT_KEY`, it is
+// deliberately below the secret scanner's 40-char minimum, so the export-time
+// sweep cannot see it — only the config snapshot's structural env redaction
+// can keep it out of the archive, meaning a sanitizer regression cannot be
+// masked by the sweep.
+const SWEEP_INVISIBLE_SYNTHETIC_KEY = "sk-proj-synthetic-test-key-000000";
 writeFileSync(
   join(testWorkspaceDir, "config.json"),
   JSON.stringify({
@@ -121,7 +126,7 @@ writeFileSync(
       agents: {
         codex: {
           env: {
-            OPENAI_API_KEY: SYNTHETIC_ACP_API_KEY,
+            OPENAI_API_KEY: SWEEP_INVISIBLE_SYNTHETIC_KEY,
             PATH: "/data/.bun/bin",
           },
         },
@@ -242,7 +247,7 @@ describe("POST /v1/export — tar.gz archive", () => {
       for (const value of Object.values(env)) {
         expect(value).toBe("(set)");
       }
-      expect(configContent).not.toContain(SYNTHETIC_ACP_API_KEY);
+      expect(configContent).not.toContain(SWEEP_INVISIBLE_SYNTHETIC_KEY);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -449,6 +454,13 @@ describe("POST /v1/export — workspace allowlist", () => {
       );
       const content = readFileSync(messagesPath, "utf-8");
       expect(content).toBe('{"role":"user","content":"jan 15"}\n');
+      // Clean daemon log files must also ship byte-identical — the secret
+      // sweep does no gratuitous rewrites.
+      for (const logFile of ["assistant-2025-01-10.log", "vellum.log"]) {
+        expect(readFileSync(join(dir, "daemon-logs", logFile), "utf-8")).toBe(
+          readFileSync(join(logsDir, logFile), "utf-8"),
+        );
+      }
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -517,41 +529,16 @@ describe("POST /v1/export — staged-file secret sweep", () => {
 
       const result = redactStagedExportFiles(staging);
 
-      expect(result).toEqual({ filesScanned: 3, filesRedacted: 0 });
+      expect(result).toEqual({
+        filesScanned: 3,
+        filesRedacted: 0,
+        filesOmitted: 0,
+      });
       for (const [rel, content] of Object.entries(seeded)) {
         expect(readFileSync(join(staging, rel), "utf-8")).toBe(content);
       }
     } finally {
       rmSync(staging, { recursive: true, force: true });
-    }
-  });
-
-  test("clean export round-trip ships staged files byte-identical (no gratuitous rewrites)", async () => {
-    // Route-level variant of the byte-identical property above: every clean
-    // seeded source file must come out of the archive exactly as it went in,
-    // proving the sweep does no gratuitous rewrites end-to-end.
-    const res = await callExport();
-    const dir = await extractArchive(res);
-    try {
-      for (const logFile of ["assistant-2025-01-10.log", "vellum.log"]) {
-        expect(readFileSync(join(dir, "daemon-logs", logFile), "utf-8")).toBe(
-          readFileSync(join(logsDir, logFile), "utf-8"),
-        );
-      }
-      for (const name of [
-        "2025-01-10T00-00-00.000Z_conv-jan10",
-        "2025-01-15T00-00-00.000Z_conv-jan15",
-      ]) {
-        const srcDir = join(conversationsDir, name);
-        const outDir = join(dir, "workspace", "conversations", name);
-        for (const file of readdirSync(srcDir)) {
-          expect(readFileSync(join(outDir, file), "utf-8")).toBe(
-            readFileSync(join(srcDir, file), "utf-8"),
-          );
-        }
-      }
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
     }
   });
 
@@ -571,7 +558,11 @@ describe("POST /v1/export — staged-file secret sweep", () => {
       );
 
       const result = redactStagedExportFiles(staging);
-      expect(result).toEqual({ filesScanned: 1, filesRedacted: 1 });
+      expect(result).toEqual({
+        filesScanned: 1,
+        filesRedacted: 1,
+        filesOmitted: 0,
+      });
 
       const lines = readFileSync(filePath, "utf-8").split("\n");
       expect(lines[0]).not.toContain(SYNTHETIC_OPENAI_PROJECT_KEY);
@@ -623,7 +614,11 @@ describe("POST /v1/export — staged-file secret sweep", () => {
 
       const result = redactStagedExportFiles(staging);
 
-      expect(result).toEqual({ filesScanned: 2, filesRedacted: 2 });
+      expect(result).toEqual({
+        filesScanned: 2,
+        filesRedacted: 2,
+        filesOmitted: 0,
+      });
       for (const file of ["creds.env", "no-extension"]) {
         const content = readFileSync(join(attachmentsDir, file), "utf-8");
         expect(content).toContain(OPENAI_PROJECT_KEY_REDACTION_MARKER);
@@ -639,7 +634,8 @@ describe("POST /v1/export — staged-file secret sweep", () => {
     const staging = mkdtempSync(join(tmpdir(), "redact-staged-oversize-"));
     try {
       // One byte over the cap. The content must never ship unswept — it is
-      // replaced wholesale with the omission note.
+      // replaced wholesale with the omission note. An omitted file was never
+      // actually scanned or redacted, so it only counts as omitted.
       writeFileSync(
         join(staging, "messages.json"),
         Buffer.alloc(MAX_SWEEP_FILE_BYTES + 1, 0x61),
@@ -647,7 +643,11 @@ describe("POST /v1/export — staged-file secret sweep", () => {
 
       const result = redactStagedExportFiles(staging);
 
-      expect(result).toEqual({ filesScanned: 1, filesRedacted: 1 });
+      expect(result).toEqual({
+        filesScanned: 0,
+        filesRedacted: 0,
+        filesOmitted: 1,
+      });
       expect(readFileSync(join(staging, "messages.json"), "utf-8")).toBe(
         OVERSIZED_FILE_NOTE,
       );
@@ -655,6 +655,75 @@ describe("POST /v1/export — staged-file secret sweep", () => {
       rmSync(staging, { recursive: true, force: true });
     }
   });
+
+  test("redacts BOM-prefixed .json files via the JSON-aware path, preserving the BOM", () => {
+    const staging = mkdtempSync(join(tmpdir(), "redact-staged-bom-"));
+    try {
+      // A UTF-8 BOM (common in user attachments) makes JSON.parse throw, so
+      // without BOM handling the file would take the plain-text fallback and
+      // the quoted marker would corrupt the JSON string it lands in.
+      const filePath = join(staging, "attachment.json");
+      writeFileSync(
+        filePath,
+        "\uFEFF" +
+          JSON.stringify({ key: SYNTHETIC_OPENAI_PROJECT_KEY }, null, 2),
+        "utf-8",
+      );
+
+      const result = redactStagedExportFiles(staging);
+      expect(result).toEqual({
+        filesScanned: 1,
+        filesRedacted: 1,
+        filesOmitted: 0,
+      });
+
+      const content = readFileSync(filePath, "utf-8");
+      expect(content.startsWith("\uFEFF")).toBe(true);
+      expect(content).not.toContain(SYNTHETIC_OPENAI_PROJECT_KEY);
+      // Stripping the preserved BOM yields valid JSON with the marker stored
+      // as a proper string value.
+      const parsed = JSON.parse(content.slice(1)) as { key: string };
+      expect(parsed.key).toContain(OPENAI_PROJECT_KEY_REDACTION_MARKER);
+    } finally {
+      rmSync(staging, { recursive: true, force: true });
+    }
+  });
+
+  // Root bypasses file permission checks, so chmod 0o000 cannot make the
+  // file unreadable — skip rather than assert a degraded path that cannot
+  // be exercised.
+  test.skipIf(process.getuid?.() === 0)(
+    "sweep continues past an unreadable staged file (degraded, not failed)",
+    () => {
+      const staging = mkdtempSync(join(tmpdir(), "redact-staged-unreadable-"));
+      const unreadablePath = join(staging, "unreadable.log");
+      try {
+        writeFileSync(
+          join(staging, "readable.log"),
+          `key ${SYNTHETIC_OPENAI_PROJECT_KEY}\n`,
+          "utf-8",
+        );
+        writeFileSync(unreadablePath, "any content\n", "utf-8");
+        chmodSync(unreadablePath, 0o000);
+
+        // Must return normally: the unreadable file is logged and skipped,
+        // and every other staged file is still swept.
+        const result = redactStagedExportFiles(staging);
+
+        expect(result).toEqual({
+          filesScanned: 1,
+          filesRedacted: 1,
+          filesOmitted: 0,
+        });
+        const content = readFileSync(join(staging, "readable.log"), "utf-8");
+        expect(content).toContain(OPENAI_PROJECT_KEY_REDACTION_MARKER);
+        expect(content).not.toContain(SYNTHETIC_OPENAI_PROJECT_KEY);
+      } finally {
+        chmodSync(unreadablePath, 0o600);
+        rmSync(staging, { recursive: true, force: true });
+      }
+    },
+  );
 
   test("redacts raw keys from workspace conversation files in the archive", async () => {
     seedConversation(

--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -49,6 +49,20 @@ const log = getLogger("log-export-routes");
 /** Maximum total payload size for log file contents (10 MB). */
 const MAX_LOG_PAYLOAD_BYTES = 10 * 1024 * 1024;
 
+/**
+ * Row caps for the conversation-data table dumps (`messages.json`,
+ * `llm-request-logs.json`, `llm-usage-events.json`). Without them, a
+ * `full: true` export dumps entire tables — for long-tenured users the only
+ * realistic way to blow past the sweep's `MAX_SWEEP_FILE_BYTES` cap, which
+ * fails closed by replacing the whole file with an omission note. Bounding
+ * at the source keeps the most recent (and most useful) rows instead,
+ * mirroring the `auditLimit` pattern: order by createdAt desc, newest rows
+ * first. Truncated sections are logged and surfaced in the export log line.
+ */
+const MAX_EXPORT_MESSAGE_ROWS = 10_000;
+const MAX_EXPORT_LLM_REQUEST_LOG_ROWS = 2_000;
+const MAX_EXPORT_LLM_USAGE_EVENT_ROWS = 10_000;
+
 interface ExportRequestBody {
   auditLimit?: number;
   conversationId?: string;
@@ -103,23 +117,43 @@ async function handleExport({
     );
 
     // --- Conversation data tables ---
+    // Sections truncated by a row cap, surfaced in the export log line.
+    const truncatedSections: string[] = [];
+    /**
+     * Keep the newest `limit` rows of a section dump. Callers fetch
+     * `limit + 1` rows so truncation is detectable without a COUNT query.
+     */
+    const capRows = <T>(rows: T[], limit: number, section: string): T[] => {
+      if (rows.length <= limit) return rows;
+      truncatedSections.push(section);
+      log.warn(
+        { section, limit },
+        "Export section exceeded its row cap; keeping only the most recent rows",
+      );
+      return rows.slice(0, limit);
+    };
     if (conversationId || full) {
       const conversationFilter = conversationId
         ? [eq(messages.conversationId, conversationId)]
         : [];
 
-      const messageRows = db
-        .select()
-        .from(messages)
-        .where(
-          and(
-            ...conversationFilter,
-            startTime ? gte(messages.createdAt, startTime) : undefined,
-            endTime ? lte(messages.createdAt, endTime) : undefined,
-          ),
-        )
-        .orderBy(messages.createdAt)
-        .all();
+      const messageRows = capRows(
+        db
+          .select()
+          .from(messages)
+          .where(
+            and(
+              ...conversationFilter,
+              startTime ? gte(messages.createdAt, startTime) : undefined,
+              endTime ? lte(messages.createdAt, endTime) : undefined,
+            ),
+          )
+          .orderBy(desc(messages.createdAt))
+          .limit(MAX_EXPORT_MESSAGE_ROWS + 1)
+          .all(),
+        MAX_EXPORT_MESSAGE_ROWS,
+        "messages",
+      );
       writeFileSync(
         join(staging, "messages.json"),
         JSON.stringify(messageRows, null, 2),
@@ -130,18 +164,23 @@ async function handleExport({
         ? [eq(llmRequestLogs.conversationId, conversationId)]
         : [];
 
-      const llmLogRows = db
-        .select()
-        .from(llmRequestLogs)
-        .where(
-          and(
-            ...llmConversationFilter,
-            startTime ? gte(llmRequestLogs.createdAt, startTime) : undefined,
-            endTime ? lte(llmRequestLogs.createdAt, endTime) : undefined,
-          ),
-        )
-        .orderBy(llmRequestLogs.createdAt)
-        .all();
+      const llmLogRows = capRows(
+        db
+          .select()
+          .from(llmRequestLogs)
+          .where(
+            and(
+              ...llmConversationFilter,
+              startTime ? gte(llmRequestLogs.createdAt, startTime) : undefined,
+              endTime ? lte(llmRequestLogs.createdAt, endTime) : undefined,
+            ),
+          )
+          .orderBy(desc(llmRequestLogs.createdAt))
+          .limit(MAX_EXPORT_LLM_REQUEST_LOG_ROWS + 1)
+          .all(),
+        MAX_EXPORT_LLM_REQUEST_LOG_ROWS,
+        "llm-request-logs",
+      );
       writeFileSync(
         join(staging, "llm-request-logs.json"),
         JSON.stringify(llmLogRows, null, 2),
@@ -152,18 +191,23 @@ async function handleExport({
         ? [eq(llmUsageEvents.conversationId, conversationId)]
         : [];
 
-      const usageRows = db
-        .select()
-        .from(llmUsageEvents)
-        .where(
-          and(
-            ...usageConversationFilter,
-            startTime ? gte(llmUsageEvents.createdAt, startTime) : undefined,
-            endTime ? lte(llmUsageEvents.createdAt, endTime) : undefined,
-          ),
-        )
-        .orderBy(llmUsageEvents.createdAt)
-        .all();
+      const usageRows = capRows(
+        db
+          .select()
+          .from(llmUsageEvents)
+          .where(
+            and(
+              ...usageConversationFilter,
+              startTime ? gte(llmUsageEvents.createdAt, startTime) : undefined,
+              endTime ? lte(llmUsageEvents.createdAt, endTime) : undefined,
+            ),
+          )
+          .orderBy(desc(llmUsageEvents.createdAt))
+          .limit(MAX_EXPORT_LLM_USAGE_EVENT_ROWS + 1)
+          .all(),
+        MAX_EXPORT_LLM_USAGE_EVENT_ROWS,
+        "llm-usage-events",
+      );
       writeFileSync(
         join(staging, "llm-usage-events.json"),
         JSON.stringify(usageRows, null, 2),
@@ -361,8 +405,10 @@ async function handleExport({
         full: full ?? false,
         workspaceEntries: workspaceResult.entries.length,
         workspaceBytes: workspaceResult.totalBytes,
+        truncatedSections,
         redactionScanned: redactionResult.filesScanned,
         redactionRedacted: redactionResult.filesRedacted,
+        redactionOmitted: redactionResult.filesOmitted,
       },
       "Export collected, creating tar.gz archive",
     );
@@ -396,7 +442,12 @@ function redactStringValue(val: unknown): string {
   return val ? "(set)" : "(empty)";
 }
 
-/** Narrow an unknown value to a mutable record, or undefined if not an object. */
+/**
+ * Narrow an unknown value to a mutable record, or undefined if not an object.
+ * Deliberately looser than `isPlainObject` (`util/object.ts`): arrays are
+ * admitted on purpose so sanitization stays fail-closed — a malformed config
+ * shape must redact more, never less.
+ */
 function asRecord(v: unknown): Record<string, unknown> | undefined {
   return v && typeof v === "object"
     ? (v as Record<string, unknown>)

--- a/assistant/src/runtime/routes/redact-staged-export.ts
+++ b/assistant/src/runtime/routes/redact-staged-export.ts
@@ -10,15 +10,18 @@
  * belt: a pattern-based `redactSecrets()` pass over staged files immediately
  * before the tar.gz is created.
  *
- * Coverage: every staged file with an allowlisted text extension
- * (`REDACTABLE_EXTENSIONS`), plus any other staged file that sniffs as text
- * (no NUL byte in its first 8 KiB) — e.g. conversation `attachments/` with
- * arbitrary user extensions (`.env`, `.csv`, extensionless). Files that
- * sniff as binary are left untouched. Serialized-JSON formats (`.json`,
- * `.jsonl`) are redacted via a parse → redact-string-leaves → re-stringify
- * path so the quoted redaction marker cannot corrupt them. Files above the
- * size cap are NOT shipped unswept: their content is replaced with a short
- * omission note (fail closed).
+ * Coverage: every staged file that sniffs as text (no NUL byte in its first
+ * 8 KiB) is swept; files that sniff as binary are left untouched. That
+ * single check covers everything the export stages as text today —
+ * `audit-data.json`, `messages.json`, `config-snapshot.json`, daemon `.log`
+ * files, `conversation-filtered.jsonl`, workspace copies
+ * (`conversations/**\/messages.jsonl`, `.tool-results/*.txt`) — plus
+ * conversation `attachments/` with arbitrary user extensions (`.env`,
+ * `.csv`, extensionless). Serialized-JSON formats (`.json`, `.jsonl`) are
+ * redacted via a parse → redact-string-leaves → re-stringify path so the
+ * quoted redaction marker cannot corrupt them. Files above the size cap are
+ * NOT shipped unswept: their content is replaced with a short omission note
+ * (fail closed).
  */
 
 import type { Dirent } from "node:fs";
@@ -40,28 +43,12 @@ import { getLogger } from "../../util/logger.js";
 const log = getLogger("redact-staged-export");
 
 /**
- * Extensions always eligible for the sweep, no sniffing needed. Covers
- * everything the export stages as text today: `audit-data.json`,
- * `messages.json`, `config-snapshot.json`, daemon `.log` files,
- * `conversation-filtered.jsonl`, and the workspace copies
- * (`conversations/**\/messages.jsonl`, `.tool-results/*.txt`). Files with
- * other extensions are still swept when they sniff as text (see module doc).
- */
-const REDACTABLE_EXTENSIONS = new Set([
-  ".json",
-  ".jsonl",
-  ".txt",
-  ".log",
-  ".md",
-]);
-
-/**
  * Files larger than this are not read into memory — the sweep reads each
- * file fully to redact it. Today's largest staged file is ~1–3 MB, so 32 MiB
- * leaves ample headroom. Oversized sweep-eligible files fail closed: their
- * content is replaced with `OVERSIZED_FILE_NOTE` so legacy plaintext secrets
- * can never ship unswept (e.g. an unbounded `messages.json` on `full: true`
- * exports).
+ * file fully to redact it. Every staged section is bounded at the source
+ * (row-capped DB dumps, the daemon-log payload cap, workspace copy caps), so
+ * staged files sit well below this. Oversized sweep-eligible files fail
+ * closed: their content is replaced with `OVERSIZED_FILE_NOTE` so legacy
+ * plaintext secrets can never ship unswept.
  */
 export const MAX_SWEEP_FILE_BYTES = 32 * 1024 * 1024;
 
@@ -71,8 +58,8 @@ export const OVERSIZED_FILE_NOTE = `[content omitted from export: file exceeded 
 } MiB secret-redaction cap]\n`;
 
 /**
- * Bytes read from the head of a non-allowlisted-extension file to classify
- * it as text (sweep it) or binary (leave it untouched).
+ * Bytes read from the head of each staged file to classify it as text
+ * (sweep it) or binary (leave it untouched).
  */
 const TEXT_SNIFF_BYTES = 8 * 1024;
 
@@ -95,47 +82,39 @@ function sniffsAsText(filePath: string): boolean {
 
 /**
  * Redact a serialized-JSON document while preserving its validity: parse,
- * redact every string leaf, and re-stringify (unchanged text is returned
- * byte-identical). Falls back to plain-text redaction when the text isn't
- * valid JSON — it is already malformed, so there is no validity to preserve.
+ * redact every string leaf, and re-stringify with `indent` (unchanged text
+ * is returned byte-identical). A leading UTF-8 BOM — common in user
+ * attachments — would make `JSON.parse` throw, so it is stripped for parsing
+ * and re-prepended on changed output to keep the content faithful. Falls
+ * back to plain-text redaction when the text isn't valid JSON — it is
+ * already malformed, so there is no validity to preserve.
  */
-function redactSerializedJson(
-  text: string,
-  stringify: (value: unknown) => string,
-): string {
+function redactSerializedJson(text: string, indent?: number): string {
+  const bom = text.startsWith("\uFEFF") ? "\uFEFF" : "";
   let parsed: unknown;
   try {
-    parsed = JSON.parse(text);
+    parsed = JSON.parse(bom ? text.slice(1) : text);
   } catch {
     return redactSecrets(text);
   }
   const { value, changed } = redactJsonStringLeaves(parsed);
-  return changed ? stringify(value) : text;
+  return changed ? bom + JSON.stringify(value, null, indent) : text;
 }
 
 /**
  * Redact a `.jsonl` file's content line by line, preserving each line's
- * JSON validity (compact re-stringify, no pretty-printing).
+ * JSON validity (compact re-stringify, no pretty-printing). Unchanged lines
+ * map to themselves, so split/join leaves clean content byte-identical.
  */
 function redactJsonlContent(content: string): string {
-  let changed = false;
-  const lines = content.split("\n").map((line) => {
-    if (line.trim() === "") return line;
-    const redacted = redactSerializedJson(line, (value) =>
-      JSON.stringify(value),
-    );
-    if (redacted !== line) changed = true;
-    return redacted;
-  });
-  return changed ? lines.join("\n") : content;
+  return content
+    .split("\n")
+    .map((line) => (line.trim() === "" ? line : redactSerializedJson(line)))
+    .join("\n");
 }
 
 function redactContent(content: string, ext: string): string {
-  if (ext === ".json") {
-    return redactSerializedJson(content, (value) =>
-      JSON.stringify(value, null, 2),
-    );
-  }
+  if (ext === ".json") return redactSerializedJson(content, 2);
   if (ext === ".jsonl") return redactJsonlContent(content);
   return redactSecrets(content);
 }
@@ -147,13 +126,19 @@ function redactContent(content: string, ext: string): string {
  *
  * Per-file failures are logged and skipped — a single unreadable file must
  * never fail the export (degraded mode beats no archive at all).
+ *
+ * `filesOmitted` counts oversized files whose content was replaced with the
+ * omission note — they are never read, so they are not counted as scanned
+ * or redacted.
  */
 export function redactStagedExportFiles(stagingDir: string): {
   filesScanned: number;
   filesRedacted: number;
+  filesOmitted: number;
 } {
   let filesScanned = 0;
   let filesRedacted = 0;
+  let filesOmitted = 0;
 
   const stack: string[] = [stagingDir];
   while (stack.length > 0) {
@@ -180,24 +165,22 @@ export function redactStagedExportFiles(stagingDir: string): {
       const ext = extname(entry.name).toLowerCase();
 
       try {
-        // Files outside the extension allowlist (e.g. staged conversation
-        // attachments) are still swept when they sniff as text; only
-        // binary-looking files are exempt.
-        if (!REDACTABLE_EXTENSIONS.has(ext) && !sniffsAsText(filePath)) {
-          continue;
-        }
+        if (!sniffsAsText(filePath)) continue;
         const { size } = statSync(filePath);
         if (size > MAX_SWEEP_FILE_BYTES) {
           // Fail closed: an oversized sweep-eligible file must not ship
           // unswept — it may carry legacy plaintext secrets the sweep
           // exists to catch. Replace its content with a short note.
+          // Normally unreachable now that every staged section is bounded
+          // at the source; retained as the final belt so assumption drift
+          // (a future unbounded section) can't silently ship unswept
+          // secrets.
           log.warn(
             { file: filePath, size },
             "Staged export file exceeds secret sweep size cap; replacing content with omission note",
           );
           writeFileSync(filePath, OVERSIZED_FILE_NOTE, "utf-8");
-          filesScanned++;
-          filesRedacted++;
+          filesOmitted++;
           continue;
         }
         const content = readFileSync(filePath, "utf-8");
@@ -216,5 +199,5 @@ export function redactStagedExportFiles(stagingDir: string): {
     }
   }
 
-  return { filesScanned, filesRedacted };
+  return { filesScanned, filesRedacted, filesOmitted };
 }


### PR DESCRIPTION
## Summary
Round-2 review fixes for acp-codex-auth-export-redaction.md.

- full:true DB dumps now bounded at the source (mirroring auditLimit); oversize fail-closed note kept as a documented belt with honest filesOmitted accounting
- Sweep classifies by text-sniff alone (extension allowlist dropped); BOM'd JSON no longer falls back to corrupting plain-text redaction
- Redundant clean-round-trip test dropped; unreadable-file degraded test added; deliberate asRecord/fixture choices documented