### PR TITLE
fix: surface export row-cap truncation in the manifest; minor ACP/test cleanups

### DIFF
--- a/assistant/src/__tests__/log-export-workspace.test.ts
+++ b/assistant/src/__tests__/log-export-workspace.test.ts
@@ -39,9 +39,16 @@ mock.module("../util/secure-keys.js", () => ({
 
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
-import { conversations, toolInvocations } from "../memory/schema.js";
+import {
+  conversations,
+  llmRequestLogs,
+  toolInvocations,
+} from "../memory/schema.js";
 import { RouteError } from "../runtime/routes/errors.js";
-import { ROUTES } from "../runtime/routes/log-export-routes.js";
+import {
+  MAX_EXPORT_LLM_REQUEST_LOG_ROWS,
+  ROUTES,
+} from "../runtime/routes/log-export-routes.js";
 import {
   MAX_SWEEP_FILE_BYTES,
   OVERSIZED_FILE_NOTE,
@@ -502,6 +509,61 @@ describe("POST /v1/export — workspace allowlist", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Export manifest row-cap truncation
+// ---------------------------------------------------------------------------
+
+describe("POST /v1/export — manifest truncatedSections", () => {
+  async function readManifest(
+    body: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const res = await callExport(body);
+    const dir = await extractArchive(res);
+    try {
+      return JSON.parse(
+        readFileSync(join(dir, "export-manifest.json"), "utf-8"),
+      ) as Record<string, unknown>;
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  test("omits truncatedSections when no section hits its row cap", async () => {
+    const manifest = await readManifest({ full: true });
+    expect(manifest.type).toBe("full-export");
+    expect(manifest).not.toHaveProperty("truncatedSections");
+  });
+
+  test("surfaces truncatedSections when a full-export dump exceeds its row cap", async () => {
+    // Seed limit + 1 rows for the cheapest capped section (llm-request-logs)
+    // so capRows detects truncation without a COUNT query.
+    const db = getDb();
+    const now = Date.now();
+    db.insert(conversations)
+      .values({ id: "conv-cap-test", createdAt: now, updatedAt: now })
+      .run();
+    const rows = Array.from(
+      { length: MAX_EXPORT_LLM_REQUEST_LOG_ROWS + 1 },
+      (_, i) => ({
+        id: `llm-log-cap-${i}`,
+        conversationId: "conv-cap-test",
+        requestPayload: "{}",
+        responsePayload: "{}",
+        createdAt: now + i,
+      }),
+    );
+    // Chunked inserts keep each statement under SQLite's bind-variable limit.
+    for (let i = 0; i < rows.length; i += 500) {
+      db.insert(llmRequestLogs)
+        .values(rows.slice(i, i + 500))
+        .run();
+    }
+
+    const manifest = await readManifest({ full: true });
+    expect(manifest.truncatedSections).toEqual(["llm-request-logs"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Export-time secret sweep
 // ---------------------------------------------------------------------------
 
@@ -580,12 +642,12 @@ describe("POST /v1/export — staged-file secret sweep", () => {
     }
   });
 
-  test("sweeps non-allowlisted staged files that sniff as text; leaves binary files untouched", () => {
+  test("sweeps arbitrary-extension staged files that sniff as text; leaves binary files untouched", () => {
     const staging = mkdtempSync(join(tmpdir(), "redact-staged-sniff-"));
     try {
       // Conversation attachments are staged wholesale with arbitrary user
-      // extensions — they bypass the extension allowlist but must still be
-      // swept when they sniff as text.
+      // extensions — sweep eligibility is decided by content sniffing, not
+      // file extension, so they must still be swept when they sniff as text.
       const attachmentsDir = join(
         staging,
         "workspace",

--- a/assistant/src/acp/agent-process.ts
+++ b/assistant/src/acp/agent-process.ts
@@ -186,7 +186,10 @@ export class AcpAgentProcess {
     return this.authMethods.find((method) => {
       if (!isEnvVarMethod(method)) return false;
 
-      const requiredVars = method.vars.filter((v) => !v.optional);
+      // `vars` is required by the SDK type, but agent responses aren't
+      // runtime-validated — tolerate an out-of-spec agent omitting it so the
+      // caller gets the friendly auth error instead of a TypeError.
+      const requiredVars = (method.vars ?? []).filter((v) => !v.optional);
       if (requiredVars.length === 0) return false;
 
       return requiredVars.every((v) => {
@@ -252,11 +255,15 @@ export class AcpAgentProcess {
 
     return this.authMethods
       .map((method) => {
-        if (isEnvVarMethod(method)) {
-          const varNames = method.vars.map((v) => v.name).join(", ");
-          return `"${method.name}" (env var ${varNames})`;
-        }
-        return `"${method.name}" (${method.id})`;
+        // `vars ?? []`: tolerate out-of-spec agents omitting the field —
+        // this renders inside the friendly auth error, which must not
+        // itself throw a TypeError.
+        const varNames = isEnvVarMethod(method)
+          ? (method.vars ?? []).map((v) => v.name).join(", ")
+          : "";
+        return varNames
+          ? `"${method.name}" (env var ${varNames})`
+          : `"${method.name}" (${method.id})`;
       })
       .join(", ");
   }
@@ -266,8 +273,6 @@ export class AcpAgentProcess {
    * Returns the session ID.
    */
   async createSession(cwd: string): Promise<string> {
-    this.requireConnection();
-
     log.info({ agentId: this.agentId, cwd }, "Creating ACP session");
 
     const result: NewSessionResponse = await this.withAuthRetry(() =>
@@ -286,8 +291,6 @@ export class AcpAgentProcess {
    * VellumAcpClientHandler.beginReplaySuppression).
    */
   async loadSession(sessionId: string, cwd: string): Promise<void> {
-    this.requireConnection();
-
     log.info({ agentId: this.agentId, sessionId, cwd }, "Loading ACP session");
 
     await this.withAuthRetry(() =>
@@ -303,8 +306,6 @@ export class AcpAgentProcess {
    * (see supportsSessionResume).
    */
   async resumeSession(sessionId: string, cwd: string): Promise<void> {
-    this.requireConnection();
-
     log.info({ agentId: this.agentId, sessionId, cwd }, "Resuming ACP session");
 
     await this.withAuthRetry(() =>

--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -57,10 +57,12 @@ const MAX_LOG_PAYLOAD_BYTES = 10 * 1024 * 1024;
  * fails closed by replacing the whole file with an omission note. Bounding
  * at the source keeps the most recent (and most useful) rows instead,
  * mirroring the `auditLimit` pattern: order by createdAt desc, newest rows
- * first. Truncated sections are logged and surfaced in the export log line.
+ * first. Truncated sections are logged and surfaced in both the export log
+ * line and `export-manifest.json` (`truncatedSections`), so a capped bundle
+ * is distinguishable from a complete one.
  */
 const MAX_EXPORT_MESSAGE_ROWS = 10_000;
-const MAX_EXPORT_LLM_REQUEST_LOG_ROWS = 2_000;
+export const MAX_EXPORT_LLM_REQUEST_LOG_ROWS = 2_000;
 const MAX_EXPORT_LLM_USAGE_EVENT_ROWS = 10_000;
 
 interface ExportRequestBody {
@@ -117,7 +119,8 @@ async function handleExport({
     );
 
     // --- Conversation data tables ---
-    // Sections truncated by a row cap, surfaced in the export log line.
+    // Sections truncated by a row cap, surfaced in the export log line and
+    // the export manifest.
     const truncatedSections: string[] = [];
     /**
      * Keep the newest `limit` rows of a section dump. Callers fetch
@@ -380,6 +383,7 @@ async function handleExport({
       commitSha: COMMIT_SHA,
       ...(startTime !== undefined ? { startTime } : {}),
       ...(endTime !== undefined ? { endTime } : {}),
+      ...(truncatedSections.length > 0 ? { truncatedSections } : {}),
       exportedAt: new Date().toISOString(),
     };
     writeFileSync(


### PR DESCRIPTION
## Summary
Round-3 review fixes for acp-codex-auth-export-redaction.md (Codex P2 on #34525).

- export-manifest.json now carries truncatedSections when full-export DB dumps hit their row caps, so capped bundles are distinguishable from complete ones
- Stale allowlist references removed from sweep test naming; redundant connection guards dropped; out-of-spec agents missing authMethod vars now get the friendly auth error