### PR TITLE
feat(providers): add MiniMax M3 to the standalone MiniMax provider catalog

### DIFF
--- a/assistant/src/__tests__/llm-catalog-parity.test.ts
+++ b/assistant/src/__tests__/llm-catalog-parity.test.ts
@@ -309,6 +309,22 @@ describe("LLM catalog parity: daemon vs client", () => {
     });
   });
 
+  test("MiniMax catalog includes MiniMax M3", () => {
+    const minimax = PROVIDER_CATALOG.find((entry) => entry.id === "minimax");
+    expect(
+      minimax?.models.find((model) => model.id === "MiniMax-M3"),
+    ).toMatchObject({
+      displayName: "MiniMax M3",
+      contextWindowTokens: 1000000,
+      defaultContextWindowTokens: 200000,
+      maxOutputTokens: 512000,
+      longContextMode: "native-model",
+      supportsThinking: true,
+      supportsVision: true,
+      supportsToolUse: true,
+    });
+  });
+
   // -----------------------------------------------------------------------
   // pricing.ts ↔ model-catalog.ts parity
   //

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -1242,6 +1242,16 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     },
     models: [
       {
+        id: "MiniMax-M3",
+        displayName: "MiniMax M3",
+        contextWindowTokens: 1000000,
+        maxOutputTokens: 512000,
+        supportsThinking: true,
+        supportsCaching: true,
+        supportsVision: true,
+        supportsToolUse: true,
+      },
+      {
         id: "MiniMax-M2.7",
         displayName: "MiniMax M2.7",
         contextWindowTokens: 200000,

--- a/clients/shared/Resources/llm-provider-catalog.json
+++ b/clients/shared/Resources/llm-provider-catalog.json
@@ -1311,6 +1311,18 @@
       "defaultModel": "MiniMax-M2.7",
       "models": [
         {
+          "id": "MiniMax-M3",
+          "displayName": "MiniMax M3",
+          "contextWindowTokens": 1000000,
+          "maxOutputTokens": 512000,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true
+        },
+        {
           "id": "MiniMax-M2.7",
           "displayName": "MiniMax M2.7",
           "contextWindowTokens": 200000,

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -1311,6 +1311,18 @@
       "defaultModel": "MiniMax-M2.7",
       "models": [
         {
+          "id": "MiniMax-M3",
+          "displayName": "MiniMax M3",
+          "contextWindowTokens": 1000000,
+          "maxOutputTokens": 512000,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true
+        },
+        {
           "id": "MiniMax-M2.7",
           "displayName": "MiniMax M2.7",
           "contextWindowTokens": 200000,


### PR DESCRIPTION
## Summary
- Add MiniMax-M3 (1M context, 512k max output, thinking/vision/tool-use) to the standalone minimax provider in the daemon catalog
- Regenerate meta/ and clients/shared/Resources/ llm-provider-catalog.json via bun run sync:llm-catalog
- Add targeted parity-test assertion for the new model

Specs: https://platform.minimax.io/docs/guides/text-generation (model ID, 1M context, multimodal/tool/thinking) and https://openrouter.ai/minimax/minimax-m3 (512k max output).

Part of plan: minimax-m3-provider-catalog.md (PR 1 of 4)