### PR TITLE
fix: replace speculative chunked insert with a single statement in truncation test

### DIFF
--- a/assistant/src/__tests__/log-export-workspace.test.ts
+++ b/assistant/src/__tests__/log-export-workspace.test.ts
@@ -551,12 +551,7 @@ describe("POST /v1/export — manifest truncatedSections", () => {
         createdAt: now + i,
       }),
     );
-    // Chunked inserts keep each statement under SQLite's bind-variable limit.
-    for (let i = 0; i < rows.length; i += 500) {
-      db.insert(llmRequestLogs)
-        .values(rows.slice(i, i + 500))
-        .run();
-    }
+    db.insert(llmRequestLogs).values(rows).run();
 
     const manifest = await readManifest({ full: true });
     expect(manifest.truncatedSections).toEqual(["llm-request-logs"]);


### PR DESCRIPTION
## Summary
Round-4 review fix for acp-codex-auth-export-redaction.md: the chunked-insert loop in the row-cap truncation test guarded against no real SQLite configuration (single 2,001-row insert binds ~10k variables, well under bun:sqlite's 32,766 limit); replaced with one insert statement.