### PR TITLE
fix(web): explain empty model lists in the profile editor instead of showing a silent empty dropdown

### DIFF
--- a/apps/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -312,6 +312,27 @@ describe("ProfileEditorModal create mode — provider-first", () => {
     expect(optionLabels).toEqual(["+ Create new provider"]);
   });
 
+  test("a provider unknown to the catalog shows an explicit empty-model state", () => {
+    // "acme-llm" isn't in the static web catalog — `getModelsForProvider`
+    // returns [] for unknown ids — reproducing the drift scenario where a
+    // connection exists for a provider this app version doesn't know about.
+    renderCreate([makeConnection("acme-llm-personal", "acme-llm")]);
+
+    selectProvider("acme-llm");
+
+    // The Model dropdown trigger explains the empty list instead of showing
+    // a bare "Select a model" placeholder over zero options...
+    const triggerLabels = dropdownTriggers().map((t) => t.textContent?.trim());
+    expect(triggerLabels).toContain("No models available");
+    expect(triggerLabels).not.toContain("Select a model");
+
+    // ...and the hint below spells out why and what to do about it.
+    expect(document.body.textContent).toContain(
+      "No models are available for this provider in this app version. " +
+        "Update the app, or use an OpenAI-compatible connection to enter a custom model.",
+    );
+  });
+
   test("+ Create new provider mounts ProviderCreateForm; successful create selects it and Save enables after a model", async () => {
     renderCreate([]);
 

--- a/apps/web/src/domains/settings/ai/profile-editor-provider-section.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-provider-section.tsx
@@ -290,8 +290,10 @@ export function ProfileEditorProviderSection({
               value: "",
               label: !provider
                 ? "Select a provider first"
-                : provider === OPENAI_COMPATIBLE_PROVIDER && availableModels.length === 0
-                  ? "Configure models on connection"
+                : availableModels.length === 0
+                  ? provider === OPENAI_COMPATIBLE_PROVIDER
+                    ? "Configure models on connection"
+                    : "No models available"
                   : "Select a model",
             },
             ...availableModels.map((m) => ({
@@ -306,8 +308,10 @@ export function ProfileEditorProviderSection({
             as="p"
             className="text-(--system-negative-strong)"
           >
-            {provider === OPENAI_COMPATIBLE_PROVIDER && availableModels.length === 0
-              ? "No models available. Configure models on the provider connection first."
+            {availableModels.length === 0
+              ? provider === OPENAI_COMPATIBLE_PROVIDER
+                ? "No models available. Configure models on the provider connection first."
+                : "No models are available for this provider in this app version. Update the app, or use an OpenAI-compatible connection to enter a custom model."
               : "Select a model."}
           </Typography>
         ) : null}


### PR DESCRIPTION
## Summary
- Show an explicit 'No models available' placeholder + hint in the profile editor Model dropdown for ANY provider with an empty model list, not just openai-compatible
- Add a regression test for the empty-catalog provider case

Part of plan: minimax-m3-provider-catalog.md (PR 3 of 4)