### PR TITLE
fix(web): add minimax models to the web LLM catalog so the profile editor can list them

### DIFF
--- a/apps/web/src/assistant/llm-model-catalog.test.ts
+++ b/apps/web/src/assistant/llm-model-catalog.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Targeted assertions for the web LLM model catalog: the minimax provider
+ * mirrors the daemon catalog, and every provider's default model exists in
+ * its models list (the web mirror of the daemon catalog invariant).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  DEFAULT_MODEL_BY_PROVIDER,
+  MODELS_BY_PROVIDER,
+  getModelsForProvider,
+  type LlmProviderId,
+} from "./llm-model-catalog";
+
+describe("llm-model-catalog", () => {
+  test("minimax provider lists MiniMax M3 then MiniMax M2.7", () => {
+    expect(getModelsForProvider("minimax").map((model) => model.id)).toEqual([
+      "MiniMax-M3",
+      "MiniMax-M2.7",
+    ]);
+  });
+
+  test("every provider's default model exists in its models list", () => {
+    for (const [provider, models] of Object.entries(MODELS_BY_PROVIDER)) {
+      // openai-compatible is a free-form escape hatch: models are configured
+      // per-connection, so it has no catalog entries or default model.
+      if (provider === "openai-compatible") continue;
+      const defaultModel = DEFAULT_MODEL_BY_PROVIDER[provider as LlmProviderId];
+      const modelIds: string[] = models.map((model) => model.id);
+      expect(modelIds).toContain(defaultModel);
+    }
+  });
+});

--- a/apps/web/src/assistant/llm-model-catalog.ts
+++ b/apps/web/src/assistant/llm-model-catalog.ts
@@ -521,6 +521,24 @@ export const MODELS_BY_PROVIDER = {
       maxOutputTokens: 5_000,
     },
   ],
+  minimax: [
+    {
+      id: "MiniMax-M3",
+      displayName: "MiniMax M3",
+      contextWindowTokens: 1_000_000,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 512_000,
+      supportsThinking: true,
+    },
+    {
+      id: "MiniMax-M2.7",
+      displayName: "MiniMax M2.7",
+      contextWindowTokens: 200_000,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 16_384,
+      supportsThinking: true,
+    },
+  ],
   "openai-compatible": [
   ],
 } as const satisfies Record<string, readonly LlmCatalogModel[]>;
@@ -533,6 +551,7 @@ export const DEFAULT_MODEL_BY_PROVIDER: Record<LlmProviderId, string> = {
   gemini: "gemini-2.5-flash",
   fireworks: "accounts/fireworks/models/kimi-k2p5",
   openrouter: "x-ai/grok-4.20-beta",
+  minimax: "MiniMax-M2.7",
   "openai-compatible": "",
 };
 


### PR DESCRIPTION
## Summary
- Add the minimax provider (MiniMax M3 + MiniMax M2.7) to MODELS_BY_PROVIDER in the web LLM catalog — fixes the empty Model dropdown when creating a profile with a MiniMax connection
- Add minimax to DEFAULT_MODEL_BY_PROVIDER (compiler-enforced)
- Add llm-model-catalog.test.ts with targeted assertions

Part of plan: minimax-m3-provider-catalog.md (PR 2 of 4)