### PR TITLE
feat: plumb assistant release version through lockfile and resolved assistants store

### DIFF
--- a/apps/web/src/lib/local-mode.ts
+++ b/apps/web/src/lib/local-mode.ts
@@ -194,7 +194,13 @@ export async function setActiveLockfileAssistant(
  * in `assistants` belongs to that org.
  */
 export async function syncPlatformAssistantsToLockfile(
-  assistants: Array<{ id: string; name?: string; is_local: boolean; created: string }>,
+  assistants: Array<{
+    id: string;
+    name?: string;
+    is_local: boolean;
+    created: string;
+    current_release_version?: string | null;
+  }>,
   organizationId?: string,
   shouldApply: () => boolean = () => true,
 ): Promise<void> {
@@ -213,6 +219,9 @@ export async function syncPlatformAssistantsToLockfile(
       cloud: "vellum",
       runtimeUrl: getPlatformRuntimeUrl(),
       hatchedAt: a.created,
+      ...(a.current_release_version != null && {
+        version: a.current_release_version.replace(/^v/, ""),
+      }),
       ...(organizationId != null && { organizationId }),
     }));
 

--- a/apps/web/src/stores/resolved-assistants-store.test.ts
+++ b/apps/web/src/stores/resolved-assistants-store.test.ts
@@ -49,6 +49,18 @@ describe("setFromLockfile", () => {
     expect(entry.organizationId).toBe("org-1");
   });
 
+  it("copies version from lockfile entries", () => {
+    const lockfile: Lockfile = {
+      assistants: [{ ...localAssistant, version: "0.7.0" }],
+      activeAssistant: null,
+    };
+    useResolvedAssistantsStore.getState().setFromLockfile(lockfile);
+
+    expect(useResolvedAssistantsStore.getState().assistants[0].version).toBe(
+      "0.7.0",
+    );
+  });
+
   it("leaves organizationId undefined for local entries", () => {
     const lockfile: Lockfile = {
       assistants: [localAssistant],
@@ -76,6 +88,7 @@ describe("upsertFromApi", () => {
       name: "Platform (refreshed)",
       created: "2026-01-01T00:00:00Z",
       is_local: false,
+      current_release_version: "0.7.0",
     } as Parameters<
       ReturnType<typeof useResolvedAssistantsStore.getState>["upsertFromApi"]
     >[0]);
@@ -84,6 +97,7 @@ describe("upsertFromApi", () => {
     expect(entry.id).toBe("asst-platform");
     expect(entry.name).toBe("Platform (refreshed)");
     expect(entry.organizationId).toBe("org-1");
+    expect(entry.version).toBe("0.7.0");
   });
 
   it("seeds organizationId from the lockfile cache when inserting a new entry", () => {

--- a/apps/web/src/stores/resolved-assistants-store.ts
+++ b/apps/web/src/stores/resolved-assistants-store.ts
@@ -44,6 +44,9 @@ export interface ResolvedAssistant {
   id: string;
   name?: string;
   hatchedAt?: string;
+  /** Installed release version — `version` from the lockfile or
+   *  `current_release_version` from the API. */
+  version?: string;
   isLocal: boolean;
   isPlatformHosted: boolean;
   /** Owning org for platform entries; only the lockfile carries it, so
@@ -108,6 +111,7 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
         id: a.assistantId,
         name: a.name,
         hatchedAt: a.hatchedAt,
+        version: a.version,
         isLocal: isLocalAssistant(a),
         isPlatformHosted: isPlatformAssistant(a),
         organizationId: a.organizationId,
@@ -130,6 +134,7 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
           id: a.id,
           name: a.name,
           hatchedAt: a.created,
+          version: a.current_release_version ?? undefined,
           isLocal: a.is_local,
           isPlatformHosted: !a.is_local,
         })),
@@ -141,6 +146,7 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
           id: assistant.id,
           name: assistant.name,
           hatchedAt: assistant.created,
+          version: assistant.current_release_version ?? undefined,
           isLocal: assistant.is_local,
           isPlatformHosted: !assistant.is_local,
         };

--- a/cli/src/__tests__/assistant-config.test.ts
+++ b/cli/src/__tests__/assistant-config.test.ts
@@ -75,11 +75,12 @@ describe("assistant-config", () => {
   });
 
   test("saveAssistantEntry and loadAllAssistants round-trip", () => {
-    const entry = makeEntry("test-1");
+    const entry = makeEntry("test-1", undefined, { version: "0.7.0" });
     saveAssistantEntry(entry);
     const all = loadAllAssistants();
     expect(all).toHaveLength(1);
     expect(all[0].assistantId).toBe("test-1");
+    expect(all[0].version).toBe("0.7.0");
   });
 
   test("findAssistantByName returns matching entry", () => {

--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -5,6 +5,7 @@ import cliPkg from "../../package.json";
 
 import { buildOpenclawStartupScript } from "../adapters/openclaw";
 import {
+  normalizeVersion,
   saveAssistantEntry,
   setActiveAssistant,
 } from "../lib/assistant-config";
@@ -638,6 +639,9 @@ async function hatchVellumPlatform(): Promise<void> {
     cloud: "vellum",
     species: "vellum",
     hatchedAt: new Date().toISOString(),
+    ...(result.current_release_version != null && {
+      version: normalizeVersion(result.current_release_version),
+    }),
   });
   setActiveAssistant(result.id);
 

--- a/cli/src/commands/rollback.ts
+++ b/cli/src/commands/rollback.ts
@@ -2,6 +2,7 @@ import {
   findAssistantByName,
   getActiveAssistant,
   loadAllAssistants,
+  normalizeVersion,
   resolveCloud,
   saveAssistantEntry,
   type AssistantEntry,
@@ -402,6 +403,11 @@ export async function rollback(): Promise<void> {
           networkName: res.network,
         },
         previousContainerInfo: entry.containerInfo,
+        // Cleared (not preserved) when the rolled-back-to version is unknown
+        version:
+          previousVersion !== "unknown"
+            ? normalizeVersion(previousVersion)
+            : undefined,
         // Clear the backup path — it belonged to the upgrade we just rolled back
         preUpgradeBackupPath: undefined,
         previousDbMigrationVersion: undefined,

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -6,6 +6,7 @@ import {
   findAssistantByName,
   getActiveAssistant,
   loadAllAssistants,
+  normalizeVersion,
   resolveCloud,
   saveAssistantEntry,
   type AssistantEntry,
@@ -435,6 +436,7 @@ async function upgradeDocker(
       previousContainerInfo: entry.containerInfo,
       previousDbMigrationVersion: preMigrationState.dbVersion,
       previousWorkspaceMigrationId: preMigrationState.lastWorkspaceMigrationId,
+      version: normalizeVersion(versionTag),
       // Preserve the backup path so `vellum rollback` can restore it later
       preUpgradeBackupPath: backupPath ?? undefined,
     };

--- a/cli/src/lib/assistant-config.ts
+++ b/cli/src/lib/assistant-config.ts
@@ -97,6 +97,8 @@ export interface AssistantEntry {
   sshUser?: string;
   zone?: string;
   hatchedAt?: string;
+  /** Installed service-group release version (no `v` prefix), written at hatch/upgrade/rollback. */
+  version?: string;
   /** Per-instance resource config. Present for local entries in multi-instance setups. */
   resources?: LocalInstanceResources;
   /** PID of the file watcher process for docker instances hatched with --watch. */
@@ -582,6 +584,11 @@ export function extractHostFromUrl(url: string): string {
   } catch {
     return url.replace(/^https?:\/\//, "").split(":")[0];
   }
+}
+
+/** Strip a leading `v` so stored versions match the healthz `version` format. */
+export function normalizeVersion(version: string): string {
+  return version.replace(/^v/, "");
 }
 
 export function saveAssistantEntry(entry: AssistantEntry): void {

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -15,6 +15,7 @@ import cliPkg from "../../package.json";
 
 import {
   findAssistantByName,
+  normalizeVersion,
   saveAssistantEntry,
   setActiveAssistant,
 } from "./assistant-config";
@@ -1151,6 +1152,8 @@ export async function hatchDocker(
       log("✅ Docker images built");
     }
 
+    let releaseVersion: string | undefined;
+
     if (!mode.build || !repoRoot) {
       emitProgress(2, 6, "Pulling images...");
 
@@ -1186,6 +1189,9 @@ export async function hatchDocker(
           log(
             `⚠️  Platform releases unavailable; falling back to CLI version ${versionTag}`,
           );
+        }
+        if (versionTag !== "latest") {
+          releaseVersion = normalizeVersion(versionTag);
         }
         log("🔍 Resolving image references...");
         const resolved = await resolveImageRefs(versionTag, log);
@@ -1364,6 +1370,7 @@ export async function hatchDocker(
       cloud: "docker",
       species,
       hatchedAt: new Date().toISOString(),
+      version: releaseVersion,
       guardianBootstrapSecret: ownSecret,
       containerInfo: {
         assistantImage: imageTags.assistant,

--- a/cli/src/lib/hatch-local.ts
+++ b/cli/src/lib/hatch-local.ts
@@ -290,6 +290,7 @@ export async function hatchLocal(
     cloud: "local",
     species,
     hatchedAt: new Date().toISOString(),
+    version: cliPkg.version,
     resources: { ...resources, signingKey },
     guardianBootstrapSecret: bootstrapSecret,
   };

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -177,6 +177,7 @@ export interface HatchedAssistant {
   id: string;
   name: string;
   status: string;
+  current_release_version?: string | null;
 }
 
 export interface HatchAssistantResult {

--- a/cli/src/lib/sync-cloud-assistants.ts
+++ b/cli/src/lib/sync-cloud-assistants.ts
@@ -15,6 +15,7 @@
 
 import {
   loadAllAssistants,
+  normalizeVersion,
   removeAssistantEntry,
   saveAssistantEntry,
 } from "./assistant-config.js";
@@ -22,6 +23,7 @@ import {
   fetchCurrentUser,
   fetchPlatformAssistants,
   getPlatformUrl,
+  type HatchedAssistant,
 } from "./platform-client.js";
 
 export type SyncLogger = (message: string) => void;
@@ -82,7 +84,7 @@ export async function syncCloudAssistants(
     }
   }
 
-  let platformAssistants: { id: string; name: string; status: string }[];
+  let platformAssistants: HatchedAssistant[];
   try {
     log?.("Fetching platform assistants…");
     platformAssistants = await fetchPlatformAssistants(token);
@@ -126,22 +128,32 @@ export async function syncCloudAssistants(
     const existing = existingCloudById.get(pa.id);
     const assistantName = pa.name.trim();
     const nameFields = assistantName ? { name: assistantName } : {};
+    const version =
+      pa.current_release_version != null
+        ? normalizeVersion(pa.current_release_version)
+        : undefined;
+    const versionFields = version ? { version } : {};
     if (!existing) {
       log?.(`Adding ${pa.name || pa.id} to lockfile`);
       saveAssistantEntry({
         assistantId: pa.id,
         ...nameFields,
+        ...versionFields,
         runtimeUrl: getPlatformUrl(),
         cloud: "vellum",
         species: "vellum",
         hatchedAt: new Date().toISOString(),
       });
       added++;
-    } else if (assistantName && existing.name !== assistantName) {
-      log?.(`Updating ${pa.id} name to ${assistantName}`);
+    } else if (
+      (assistantName && existing.name !== assistantName) ||
+      (version && existing.version !== version)
+    ) {
+      log?.(`Updating ${pa.id} from platform`);
       saveAssistantEntry({
         ...existing,
-        name: assistantName,
+        ...nameFields,
+        ...versionFields,
       });
       updated++;
     }

--- a/cli/src/lib/sync-cloud-assistants.ts
+++ b/cli/src/lib/sync-cloud-assistants.ts
@@ -128,17 +128,18 @@ export async function syncCloudAssistants(
     const existing = existingCloudById.get(pa.id);
     const assistantName = pa.name.trim();
     const nameFields = assistantName ? { name: assistantName } : {};
+    // undefined when the platform reports no release — written through on
+    // update so a stale cached version is cleared, not preserved.
     const version =
       pa.current_release_version != null
         ? normalizeVersion(pa.current_release_version)
         : undefined;
-    const versionFields = version ? { version } : {};
     if (!existing) {
       log?.(`Adding ${pa.name || pa.id} to lockfile`);
       saveAssistantEntry({
         assistantId: pa.id,
         ...nameFields,
-        ...versionFields,
+        ...(version && { version }),
         runtimeUrl: getPlatformUrl(),
         cloud: "vellum",
         species: "vellum",
@@ -147,13 +148,13 @@ export async function syncCloudAssistants(
       added++;
     } else if (
       (assistantName && existing.name !== assistantName) ||
-      (version && existing.version !== version)
+      existing.version !== version
     ) {
       log?.(`Updating ${pa.id} from platform`);
       saveAssistantEntry({
         ...existing,
         ...nameFields,
-        ...versionFields,
+        version,
       });
       updated++;
     }

--- a/cli/src/lib/upgrade-lifecycle.ts
+++ b/cli/src/lib/upgrade-lifecycle.ts
@@ -4,7 +4,7 @@ import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { join } from "path";
 
 import type { AssistantEntry } from "./assistant-config.js";
-import { saveAssistantEntry } from "./assistant-config.js";
+import { normalizeVersion, saveAssistantEntry } from "./assistant-config.js";
 import { createBackup, pruneOldBackups, restoreBackup } from "./backup-ops.js";
 import { emitCliError } from "./cli-error.js";
 import { getOrCreateHostDeviceId } from "./device-id.js";
@@ -788,6 +788,7 @@ export async function performDockerRollback(
       previousContainerInfo: entry.containerInfo,
       previousDbMigrationVersion: preMigrationState.dbVersion,
       previousWorkspaceMigrationId: preMigrationState.lastWorkspaceMigrationId,
+      version: normalizeVersion(targetVersion),
       preUpgradeBackupPath: undefined,
     };
     saveAssistantEntry(updatedEntry);

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -334,6 +334,7 @@ export interface LockfileAssistant {
   runtimeUrl?: string;
   species?: string;
   hatchedAt?: string;
+  version?: string;
   organizationId?: string;
   resources?: LocalAssistantResources;
 }

--- a/packages/local-mode/src/lockfile-contract.test.ts
+++ b/packages/local-mode/src/lockfile-contract.test.ts
@@ -14,6 +14,7 @@ describe("parseLockfile", () => {
           runtimeUrl: "http://127.0.0.1:7777",
           species: "vellum",
           hatchedAt: "2026-01-01T00:00:00.000Z",
+          version: "0.7.0",
           organizationId: "org_1",
           resources: { gatewayPort: 7777, daemonPort: 7778 },
         },
@@ -166,6 +167,20 @@ describe("parseLockfile", () => {
       { assistantId: "asst_1", cloud: "vellum", organizationId: "org_1" },
       { assistantId: "asst_2", cloud: "vellum" },
       { assistantId: "asst_3", cloud: "local" },
+    ]);
+  });
+
+  test("keeps version when a string and drops it when mistyped", () => {
+    const raw = {
+      assistants: [
+        { assistantId: "asst_1", cloud: "docker", version: "0.7.0" },
+        { assistantId: "asst_2", cloud: "docker", version: 7 }, // mistyped
+      ],
+      activeAssistant: null,
+    };
+    expect(parseLockfile(raw).assistants).toEqual([
+      { assistantId: "asst_1", cloud: "docker", version: "0.7.0" },
+      { assistantId: "asst_2", cloud: "docker" },
     ]);
   });
 

--- a/packages/local-mode/src/lockfile-contract.ts
+++ b/packages/local-mode/src/lockfile-contract.ts
@@ -42,6 +42,8 @@ export interface LockfileAssistant {
   runtimeUrl?: string;
   species?: string;
   hatchedAt?: string;
+  /** Installed release version (no `v` prefix), written by the CLI at hatch/upgrade. */
+  version?: string;
   /** Owning org for platform assistants; absent for local ones. */
   organizationId?: string;
   resources?: LocalAssistantResources;
@@ -89,6 +91,7 @@ function parseAssistant(value: unknown): LockfileAssistant | null {
   if (typeof value.runtimeUrl === "string") assistant.runtimeUrl = value.runtimeUrl;
   if (typeof value.species === "string") assistant.species = value.species;
   if (typeof value.hatchedAt === "string") assistant.hatchedAt = value.hatchedAt;
+  if (typeof value.version === "string") assistant.version = value.version;
   if (typeof value.organizationId === "string") assistant.organizationId = value.organizationId;
   const resources = parseResources(value.resources);
   if (resources) assistant.resources = resources;


### PR DESCRIPTION
## Summary
- CLI writes a `version` field (installed release, no `v` prefix) to lockfile assistant entries on `hatch` (local/docker/platform), `upgrade`, `rollback`, and cloud sync, via a new `normalizeVersion` helper
- Lockfile contract models `version?: string` in `packages/local-mode` (parser included) and the duplicate `LockfileAssistant` in `packages/ipc-contract`
- Web `ResolvedAssistant` gains `version`, populated from the lockfile (`version`) and from the platform API (`current_release_version`) in `setFromLockfile`/`setFromApi`/`upsertFromApi`; the platform→lockfile mirror sync also stamps it

## Original prompt
The resolved assistants store had no assistant version: the platform list API already returns `current_release_version` but the store's mapper dropped it, and local assistants had no version recorded anywhere (the lockfile only carried a pre-upgrade `previousVersion` rollback snapshot). The user asked to (1) update the CLI to write the version at hatch and upgrade, (2) update the lockfile schema/contract, and (3) update the web contract so the resolved store exposes the version for all assistants.