### PR TITLE
test(web): enforce web LLM catalog parity with meta/llm-provider-catalog.json

### DIFF
--- a/apps/web/src/assistant/llm-model-catalog.test.ts
+++ b/apps/web/src/assistant/llm-model-catalog.test.ts
@@ -2,8 +2,15 @@
  * Targeted assertions for the web LLM model catalog: the minimax provider
  * mirrors the daemon catalog, and every provider's default model exists in
  * its models list (the web mirror of the daemon catalog invariant).
+ *
+ * Also enforces full parity with `meta/llm-provider-catalog.json` (the
+ * canonical catalog generated from the daemon's
+ * `assistant/src/providers/model-catalog.ts`) so this hand-maintained
+ * mirror can never silently drift again.
  */
 
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
 import {
@@ -31,4 +38,113 @@ describe("llm-model-catalog", () => {
       expect(modelIds).toContain(defaultModel);
     }
   });
+});
+
+// ---------------------------------------------------------------------------
+// Parity with meta/llm-provider-catalog.json
+// ---------------------------------------------------------------------------
+
+interface MetaCatalogModel {
+  id: string;
+  displayName: string;
+  contextWindowTokens?: number;
+  maxOutputTokens?: number;
+  defaultContextWindowTokens?: number;
+  longContextPricingThresholdTokens?: number;
+  supportsThinking?: boolean;
+}
+
+interface MetaCatalogProvider {
+  id: string;
+  defaultModel: string;
+  models: MetaCatalogModel[];
+}
+
+interface MetaCatalog {
+  version: number;
+  providers: MetaCatalogProvider[];
+}
+
+// bun:test runs in Bun, so direct filesystem access works here — same
+// technique as the daemon's assistant/src/__tests__/llm-catalog-parity.test.ts.
+const META_CATALOG_PATH = join(
+  import.meta.dir,
+  "../../../../meta/llm-provider-catalog.json",
+);
+
+/**
+ * Project a model down to the fields the web UI uses. The web mirror omits
+ * capability fields the UI doesn't render (vision/caching/toolUse/pricing),
+ * so only the shared subset is compared. `supportsThinking` is normalized to
+ * a boolean because the web mirror omits it when false while the meta JSON
+ * carries an explicit `false`.
+ */
+function comparableModel(model: MetaCatalogModel) {
+  return {
+    id: model.id,
+    displayName: model.displayName,
+    contextWindowTokens: model.contextWindowTokens,
+    maxOutputTokens: model.maxOutputTokens,
+    defaultContextWindowTokens: model.defaultContextWindowTokens,
+    longContextPricingThresholdTokens: model.longContextPricingThresholdTokens,
+    supportsThinking: model.supportsThinking === true,
+  };
+}
+
+describe("parity with meta/llm-provider-catalog.json", () => {
+  // Intentional asymmetries between the web mirror and the meta catalog:
+  // - the web mirror omits daemon-only providers (ollama);
+  // - openai-compatible has a per-connection model list, so its (empty)
+  //   catalog entry is excluded from model/default comparisons.
+  // Field parity therefore iterates web keys, not meta providers; the
+  // coverage test below guards the reverse direction.
+  const DAEMON_ONLY_PROVIDERS = new Set(["ollama"]);
+
+  const metaCatalog: MetaCatalog = JSON.parse(
+    readFileSync(META_CATALOG_PATH, "utf-8"),
+  );
+  const metaProvidersById = new Map(
+    metaCatalog.providers.map((provider) => [provider.id, provider]),
+  );
+  const webProviderIds = (
+    Object.keys(MODELS_BY_PROVIDER) as LlmProviderId[]
+  ).filter((id) => id !== "openai-compatible");
+
+  test("every meta provider except daemon-only ones exists in the web mirror", () => {
+    // This is the original MiniMax bug: a provider added to the daemon
+    // catalog but never mirrored here, leaving an empty Model dropdown.
+    const webKeys = new Set<string>(Object.keys(MODELS_BY_PROVIDER));
+    for (const provider of metaCatalog.providers) {
+      if (DAEMON_ONLY_PROVIDERS.has(provider.id)) continue;
+      expect(
+        webKeys.has(provider.id),
+        `meta provider "${provider.id}" is missing from MODELS_BY_PROVIDER`,
+      ).toBe(true);
+    }
+  });
+
+  for (const providerId of webProviderIds) {
+    describe(providerId, () => {
+      const metaProvider = metaProvidersById.get(providerId);
+
+      test("exists in the meta catalog", () => {
+        expect(
+          metaProvider,
+          `web provider "${providerId}" has no meta catalog entry`,
+        ).toBeDefined();
+      });
+
+      test("models match the meta catalog (ids, order, and shared fields)", () => {
+        expect(getModelsForProvider(providerId).map(comparableModel)).toEqual(
+          (metaProvider?.models ?? []).map(comparableModel),
+        );
+      });
+
+      test("default model matches the meta catalog", () => {
+        expect(metaProvider?.defaultModel).toBe(
+          DEFAULT_MODEL_BY_PROVIDER[providerId],
+        );
+      });
+    });
+  }
 });

--- a/apps/web/src/assistant/llm-model-catalog.ts
+++ b/apps/web/src/assistant/llm-model-catalog.ts
@@ -1,13 +1,13 @@
-// AUTO-GENERATED FILE. Do not edit by hand.
+// Hand-maintained mirror of the LLM provider/model catalog for the web app.
 //
-// Source:    web/src/lib/generated/llm-provider-catalog.json
-//            (vendored from vellum-ai/vellum-assistant meta/llm-provider-catalog.json)
-// Generator: web/scripts/sync-llm-model-catalog.ts
-// Run:       bun run sync:llm-model-catalog
+// Source of truth: assistant/src/providers/model-catalog.ts, which
+// generates meta/llm-provider-catalog.json via
+//   cd assistant && bun run sync:llm-catalog
+// This file mirrors the subset the web UI needs (no ollama, no
+// pricing/vision/caching fields).
 //
-// To change a model or provider, update the upstream catalog in the
-// vellum-assistant repo first, then refresh the vendored JSON here and
-// re-run the generator.
+// Parity is enforced by llm-model-catalog.test.ts: update the daemon
+// catalog first, run the sync, then mirror the change here.
 
 export interface LlmCatalogModel {
   id: string;
@@ -148,6 +148,14 @@ export const MODELS_BY_PROVIDER = {
   ],
   gemini: [
     {
+      id: "gemini-3.5-flash",
+      displayName: "Gemini 3.5 Flash",
+      contextWindowTokens: 1_048_576,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 65_536,
+      supportsThinking: true,
+    },
+    {
       id: "gemini-3.1-pro-preview",
       displayName: "Gemini 3.1 Pro Preview",
       contextWindowTokens: 1_048_576,
@@ -215,6 +223,14 @@ export const MODELS_BY_PROVIDER = {
     },
   ],
   fireworks: [
+    {
+      id: "accounts/fireworks/models/kimi-k2p6",
+      displayName: "Kimi K2.6",
+      contextWindowTokens: 262_144,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 32_768,
+      supportsThinking: true,
+    },
     {
       id: "accounts/fireworks/models/kimi-k2p5",
       displayName: "Kimi K2.5",
@@ -320,6 +336,14 @@ export const MODELS_BY_PROVIDER = {
       id: "x-ai/grok-4.20-beta",
       displayName: "Grok 4.20 Beta",
       contextWindowTokens: 256_000,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 16_000,
+      supportsThinking: true,
+    },
+    {
+      id: "x-ai/grok-4.3",
+      displayName: "Grok 4.3",
+      contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 16_000,
       supportsThinking: true,
@@ -520,6 +544,13 @@ export const MODELS_BY_PROVIDER = {
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 5_000,
     },
+    {
+      id: "openrouter/owl-alpha",
+      displayName: "Owl Alpha",
+      contextWindowTokens: 1_048_576,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 262_144,
+    },
   ],
   minimax: [
     {
@@ -546,7 +577,7 @@ export const MODELS_BY_PROVIDER = {
 export type LlmProviderId = keyof typeof MODELS_BY_PROVIDER;
 
 export const DEFAULT_MODEL_BY_PROVIDER: Record<LlmProviderId, string> = {
-  anthropic: "claude-sonnet-4-6",
+  anthropic: "claude-opus-4-8",
   openai: "gpt-5.5",
   gemini: "gemini-2.5-flash",
   fireworks: "accounts/fireworks/models/kimi-k2p5",


### PR DESCRIPTION
## Summary
- Add a parity suite to llm-model-catalog.test.ts comparing the web catalog against meta/llm-provider-catalog.json (model ids, order, display names, token limits, thinking flags, default models)
- Replace the stale AUTO-GENERATED header in llm-model-catalog.ts with truthful hand-maintained-mirror guidance

The original bug (empty MiniMax model dropdown) was silent drift between the daemon catalog and this file; this guard makes that class of bug fail CI.

## Pre-existing drift uncovered and fixed

Running the new guard surfaced drift in the web mirror beyond minimax, fixed here by updating llm-model-catalog.ts to match meta (all mechanical, additive mirrors of existing meta entries):

- **gemini**: missing `gemini-3.5-flash` (first entry)
- **fireworks**: missing `accounts/fireworks/models/kimi-k2p6` (Kimi K2.6, first entry)
- **openrouter**: missing `x-ai/grok-4.3` and `openrouter/owl-alpha`
- **anthropic default**: web preselected `claude-sonnet-4-6` while the daemon defaults to `claude-opus-4-8` — behavior change: provider default-model prefill (call-site override UIs) now matches the daemon

Sanity check performed: temporarily deleting the `minimax` key made the guard fail with `meta provider "minimax" is missing from MODELS_BY_PROVIDER` (restored afterwards) — the original bug can no longer happen silently.

Part of plan: minimax-m3-provider-catalog.md (PR 4 of 4)

## ⚠️ Behavior change (drift fix)
The anthropic entry in `DEFAULT_MODEL_BY_PROVIDER` changed from `claude-sonnet-4-6` to `claude-opus-4-8` to match the daemon catalog's `defaultModel`. The runtime consumers are the call-site-overrides UIs: toggling an override on with no profile seed, or selecting Custom/switching provider, now pre-seeds `claude-opus-4-8` (a more expensive model) instead of `claude-sonnet-4-6`. This restores parity with what the daemon/macOS clients already advertise; flagging explicitly since it changes the default cost profile of that flow.