### PR TITLE
refactor(web): declutter schedules page — unified list, collapsed past one-times, buried system jobs

### DIFF
--- a/apps/web/src/domains/settings/components/schedule-row.tsx
+++ b/apps/web/src/domains/settings/components/schedule-row.tsx
@@ -3,8 +3,10 @@ import { ChevronRight } from "lucide-react";
 import { ScheduleUsageStats } from "@/domains/settings/components/schedule-shared-ui";
 import {
   formatTimestamp,
+  type PastOneTimeStatus,
   type ScheduleRowUsage,
 } from "@/domains/settings/utils/schedule-formatters";
+import { Tag } from "@vellumai/design-library/components/tag";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 
 import type { Schedule } from "@/domains/settings/types/schedules";
@@ -17,21 +19,49 @@ function cadenceTextForRow(schedule: Schedule): string | null {
   return cadence;
 }
 
+function descriptionTextForRow(schedule: Schedule): string | null {
+  const description = schedule.description.trim();
+  if (!description) return null;
+  if (description.toLowerCase() === schedule.name.trim().toLowerCase()) {
+    return null;
+  }
+  return description;
+}
+
+function timestampTextForRow(
+  schedule: Schedule,
+  isPast: boolean,
+): string | null {
+  if (schedule.lastRunAt != null) {
+    return `Last ${formatTimestamp(schedule.lastRunAt)}`;
+  }
+  if (schedule.nextRunAt != null) {
+    return isPast
+      ? `Scheduled ${formatTimestamp(schedule.nextRunAt)}`
+      : `Next ${formatTimestamp(schedule.nextRunAt)}`;
+  }
+  return null;
+}
+
 export function ScheduleRow({
   schedule,
   usage,
   onClick,
   onToggle,
   onOpenUsage,
+  pastStatus,
 }: {
   schedule: Schedule;
   usage: ScheduleRowUsage;
   onClick: () => void;
-  onToggle: (enabled: boolean) => void;
+  onToggle?: (enabled: boolean) => void;
   onOpenUsage: () => void;
+  /** When set, the row is an elapsed one-shot: status tag instead of toggle. */
+  pastStatus?: PastOneTimeStatus;
 }) {
-  const displayRunAt = schedule.lastRunAt ?? schedule.nextRunAt;
   const cadenceText = cadenceTextForRow(schedule);
+  const descriptionText = descriptionTextForRow(schedule);
+  const timestampText = timestampTextForRow(schedule, pastStatus != null);
 
   return (
     <div className="flex flex-wrap items-center gap-3 rounded-md px-2 py-3 transition-colors hover:bg-[var(--surface-hover)] [&+&]:border-t [&+&]:border-[var(--border-base)]">
@@ -46,16 +76,18 @@ export function ScheduleRow({
           </span>
         </div>
         <div className="mt-0.5 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-body-small-default text-[var(--content-tertiary)]">
-          <span className="min-w-[12rem] max-w-full flex-1 truncate">
-            {schedule.description}
-          </span>
+          {descriptionText ? (
+            <span className="min-w-[12rem] max-w-full flex-1 truncate">
+              {descriptionText}
+            </span>
+          ) : null}
           {cadenceText ? (
             <span className="shrink-0 text-[var(--content-secondary)]">
               {cadenceText}
             </span>
           ) : null}
-          {displayRunAt ? (
-            <span className="shrink-0">{formatTimestamp(displayRunAt)}</span>
+          {timestampText ? (
+            <span className="shrink-0">{timestampText}</span>
           ) : null}
         </div>
       </button>
@@ -65,11 +97,15 @@ export function ScheduleRow({
           usage={usage}
           onOpenUsage={onOpenUsage}
         />
-        <Toggle
-          checked={schedule.enabled}
-          onChange={onToggle}
-          aria-label={`Toggle ${schedule.name}`}
-        />
+        {pastStatus ? (
+          <Tag tone={pastStatus.tone}>{pastStatus.label}</Tag>
+        ) : (
+          <Toggle
+            checked={schedule.enabled}
+            onChange={(enabled) => onToggle?.(enabled)}
+            aria-label={`Toggle ${schedule.name}`}
+          />
+        )}
         <button
           type="button"
           onClick={onClick}

--- a/apps/web/src/domains/settings/components/schedule-shared-ui.tsx
+++ b/apps/web/src/domains/settings/components/schedule-shared-ui.tsx
@@ -28,6 +28,10 @@ export function StatusDot({ status }: { status: string | null }) {
 // ScheduleUsageStats — cost + run count display for schedule rows
 // ---------------------------------------------------------------------------
 
+// Column labels live once in ScheduleListColumnsHeader; rows render bare
+// values. Zero values are dimmed so the eye lands on rows that actually
+// cost or ran something.
+
 export function ScheduleUsageStats({
   scheduleName,
   usage,
@@ -43,8 +47,8 @@ export function ScheduleUsageStats({
         aria-label="Loading schedule usage"
         className="flex w-[156px] shrink-0 items-center justify-end gap-3"
       >
-        <span className="h-8 w-16 animate-pulse rounded bg-[var(--surface-muted)]" />
-        <span className="h-8 w-16 animate-pulse rounded bg-[var(--surface-muted)]" />
+        <span className="h-5 w-16 animate-pulse rounded bg-[var(--surface-muted)]" />
+        <span className="h-5 w-16 animate-pulse rounded bg-[var(--surface-muted)]" />
       </div>
     );
   }
@@ -56,47 +60,66 @@ export function ScheduleUsageStats({
   const runs = isUnavailable
     ? "--"
     : formatScheduleRunCount(usage.summary.runCount);
+  const costIsZero =
+    usage.status === "ready" && !(usage.summary.totalEstimatedCostUsd > 0);
+  const runsIsZero = usage.status === "ready" && usage.summary.runCount === 0;
+
+  const costClass = costIsZero
+    ? "text-[var(--content-tertiary)]"
+    : "text-[var(--content-default)]";
+  const runsClass = runsIsZero
+    ? "text-[var(--content-tertiary)]"
+    : "text-[var(--content-default)]";
 
   return (
-    <div className="flex w-[156px] shrink-0 items-center justify-end gap-3 text-right">
+    <div className="flex w-[156px] shrink-0 items-center justify-end gap-3 text-right text-body-small-default">
       {onOpenUsage ? (
         <button
           type="button"
           onClick={onOpenUsage}
           aria-label={`View usage for ${scheduleName}`}
-          className="min-w-[64px] cursor-pointer rounded px-1 py-0.5 text-right transition-colors hover:bg-[var(--surface-hover)]"
+          className={`min-w-[64px] cursor-pointer rounded px-1 py-0.5 text-right transition-colors hover:bg-[var(--surface-hover)] ${costClass}`}
         >
-          <span className="mb-0.5 block text-label-small-default text-[var(--content-tertiary)]">
-            Cost (7d)
-          </span>
-          <span className="block text-body-small-default text-[var(--content-default)]">
-            {cost}
-          </span>
+          {cost}
         </button>
       ) : (
         <span
           aria-label={`Cost for ${scheduleName} in the last 7 days: ${cost}`}
-          className="block min-w-[64px] px-1 py-0.5"
+          className={`block min-w-[64px] px-1 py-0.5 ${costClass}`}
         >
-          <span className="mb-0.5 block text-label-small-default text-[var(--content-tertiary)]">
-            Cost (7d)
-          </span>
-          <span className="block text-body-small-default text-[var(--content-default)]">
-            {cost}
-          </span>
+          {cost}
         </span>
       )}
       <span
         aria-label={`Runs for ${scheduleName} in the last 7 days: ${runs}`}
-        className="block min-w-[64px] px-1 py-0.5"
+        className={`block min-w-[64px] px-1 py-0.5 ${runsClass}`}
       >
-        <span className="mb-0.5 block text-label-small-default text-[var(--content-tertiary)]">
-          Runs (7d)
-        </span>
-        <span className="block text-body-small-default text-[var(--content-default)]">
-          {runs}
-        </span>
+        {runs}
       </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ScheduleListColumnsHeader — one-time column labels for the schedule list
+// ---------------------------------------------------------------------------
+
+/**
+ * Mirrors ScheduleRow's right-side layout (stats block + toggle + chevron)
+ * so the labels line up over the value columns.
+ */
+export function ScheduleListColumnsHeader() {
+  return (
+    <div aria-hidden="true" className="flex items-center gap-3 px-2 pb-1">
+      <div className="min-w-0 flex-1" />
+      <div className="flex shrink-0 items-center gap-3">
+        <div className="flex w-[156px] items-center justify-end gap-3 text-right text-label-small-default text-[var(--content-tertiary)]">
+          <span className="block min-w-[64px] px-1">Cost (7d)</span>
+          <span className="block min-w-[64px] px-1">Runs (7d)</span>
+        </div>
+        <span className="block w-9" />
+        <span className="block w-7" />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/domains/settings/components/system-tasks-section.tsx
+++ b/apps/web/src/domains/settings/components/system-tasks-section.tsx
@@ -1,13 +1,15 @@
-import { ChevronRight, Loader2 } from "lucide-react";
+import { ChevronDown, ChevronRight, Loader2 } from "lucide-react";
 
 import { DetailCard } from "@/components/detail-card";
 import { ScheduleUsageStats } from "@/domains/settings/components/schedule-shared-ui";
 import {
   consolidationSubtitle,
+  formatScheduleCost,
   formatTimestamp,
   heartbeatSubtitle,
   type ScheduleRowUsage,
 } from "@/domains/settings/utils/schedule-formatters";
+import { Collapsible } from "@vellumai/design-library/components/collapsible";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { Tag, type TagTone } from "@vellumai/design-library/components/tag";
 import { Toggle } from "@vellumai/design-library/components/toggle";
@@ -148,76 +150,108 @@ export function SystemTasksSection({
     return null;
   }
 
+  const readyUsages = [heartbeatUsage, consolidationUsage].filter(
+    (usage): usage is Extract<ScheduleRowUsage, { status: "ready" }> =>
+      usage.status === "ready",
+  );
+  const totalCost = readyUsages.reduce(
+    (sum, usage) => sum + (usage.summary.totalEstimatedCostUsd ?? 0),
+    0,
+  );
+
+  const body = isLoading ? (
+    <div className="flex items-center justify-center py-8">
+      <Loader2 className="h-5 w-5 animate-spin text-stone-400" />
+    </div>
+  ) : hasError && !showHeartbeat && !showConsolidation ? (
+    <Notice tone="error">
+      Failed to load system jobs.{" "}
+      <button
+        type="button"
+        onClick={onRetry}
+        className="cursor-pointer underline hover:no-underline"
+      >
+        Retry
+      </button>
+    </Notice>
+  ) : (
+    <div>
+      {showHeartbeat ? (
+        <SystemTaskRow
+          name="Heartbeat"
+          subtitle={heartbeatSubtitle(heartbeatConfig)}
+          enabled={heartbeatConfig.enabled}
+          nextRunAt={heartbeatConfig.nextRunAt}
+          lastRunAt={heartbeatConfig.lastRunAt}
+          usage={heartbeatUsage}
+          showToggle={showSystemTaskToggles}
+          onClick={onSelectHeartbeat}
+          onToggle={onToggleHeartbeat}
+        />
+      ) : null}
+      {showConsolidation ? (
+        <SystemTaskRow
+          name="Consolidation"
+          subtitle={consolidationSubtitle(consolidationConfig)}
+          enabled={consolidationConfig.enabled}
+          helperText={
+            consolidationConfig.enabled
+              ? undefined
+              : "Memory is off, so consolidation is paused."
+          }
+          nextRunAt={consolidationConfig.nextRunAt}
+          lastRunAt={consolidationConfig.lastRunAt}
+          usage={consolidationUsage}
+          showToggle={false}
+          statusLabel={consolidationConfig.enabled ? undefined : "Paused"}
+          statusTone="warning"
+          onClick={onSelectConsolidation}
+        />
+      ) : null}
+      {hasError ? (
+        <div className="pt-3 first:pt-0">
+          <Notice tone="error">
+            Some system jobs failed to load.{" "}
+            <button
+              type="button"
+              onClick={onRetry}
+              className="cursor-pointer underline hover:no-underline"
+            >
+              Retry
+            </button>
+          </Notice>
+        </div>
+      ) : null}
+    </div>
+  );
+
   return (
-    <DetailCard
-      title="System"
-      subtitle="Built-in jobs managed by the assistant runtime."
-    >
-      {isLoading ? (
-        <div className="flex items-center justify-center py-8">
-          <Loader2 className="h-5 w-5 animate-spin text-stone-400" />
-        </div>
-      ) : hasError && !showHeartbeat && !showConsolidation ? (
-        <Notice tone="error">
-          Failed to load system jobs.{" "}
-          <button
-            type="button"
-            onClick={onRetry}
-            className="cursor-pointer underline hover:no-underline"
-          >
-            Retry
-          </button>
-        </Notice>
-      ) : (
-        <div>
-          {showHeartbeat ? (
-            <SystemTaskRow
-              name="Heartbeat"
-              subtitle={heartbeatSubtitle(heartbeatConfig)}
-              enabled={heartbeatConfig.enabled}
-              nextRunAt={heartbeatConfig.nextRunAt}
-              lastRunAt={heartbeatConfig.lastRunAt}
-              usage={heartbeatUsage}
-              showToggle={showSystemTaskToggles}
-              onClick={onSelectHeartbeat}
-              onToggle={onToggleHeartbeat}
-            />
-          ) : null}
-          {showConsolidation ? (
-            <SystemTaskRow
-              name="Consolidation"
-              subtitle={consolidationSubtitle(consolidationConfig)}
-              enabled={consolidationConfig.enabled}
-              helperText={
-                consolidationConfig.enabled
-                  ? undefined
-                  : "Memory is off, so consolidation is paused."
-              }
-              nextRunAt={consolidationConfig.nextRunAt}
-              lastRunAt={consolidationConfig.lastRunAt}
-              usage={consolidationUsage}
-              showToggle={false}
-              statusLabel={consolidationConfig.enabled ? undefined : "Paused"}
-              statusTone="warning"
-              onClick={onSelectConsolidation}
-            />
-          ) : null}
-          {hasError ? (
-            <div className="pt-3 first:pt-0">
-              <Notice tone="error">
-                Some system jobs failed to load.{" "}
-                <button
-                  type="button"
-                  onClick={onRetry}
-                  className="cursor-pointer underline hover:no-underline"
-                >
-                  Retry
-                </button>
-              </Notice>
-            </div>
-          ) : null}
-        </div>
-      )}
+    <DetailCard>
+      <Collapsible.Root type="multiple">
+        <Collapsible.Item value="system-jobs">
+          <Collapsible.Trigger className="group justify-between gap-3">
+            <span className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-1 text-left">
+              <span className="text-body-medium-default text-[var(--content-secondary)]">
+                System
+              </span>
+              <span className="text-body-small-default text-[var(--content-tertiary)]">
+                Built-in jobs managed by the assistant runtime
+              </span>
+            </span>
+            <span className="flex shrink-0 items-center gap-3">
+              {readyUsages.length > 0 ? (
+                <span className="text-body-small-default text-[var(--content-tertiary)]">
+                  {formatScheduleCost(totalCost)} (7d)
+                </span>
+              ) : null}
+              <ChevronDown className="h-4 w-4 shrink-0 text-[var(--content-tertiary)] transition-transform group-data-[state=open]:rotate-180" />
+            </span>
+          </Collapsible.Trigger>
+          <Collapsible.Content>
+            <div className="mt-3">{body}</div>
+          </Collapsible.Content>
+        </Collapsible.Item>
+      </Collapsible.Root>
     </DetailCard>
   );
 }

--- a/apps/web/src/domains/settings/components/system-tasks-section.tsx
+++ b/apps/web/src/domains/settings/components/system-tasks-section.tsx
@@ -150,7 +150,12 @@ export function SystemTasksSection({
     return null;
   }
 
-  const readyUsages = [heartbeatUsage, consolidationUsage].filter(
+  // Aggregate only the visible jobs — a hidden job's query can still hold
+  // cached usage (e.g. consolidation after memory is turned off).
+  const readyUsages = [
+    ...(showHeartbeat ? [heartbeatUsage] : []),
+    ...(showConsolidation ? [consolidationUsage] : []),
+  ].filter(
     (usage): usage is Extract<ScheduleRowUsage, { status: "ready" }> =>
       usage.status === "ready",
   );

--- a/apps/web/src/domains/settings/hooks/use-system-tasks.ts
+++ b/apps/web/src/domains/settings/hooks/use-system-tasks.ts
@@ -270,8 +270,6 @@ export function useSystemTasks(assistantId: string | undefined, tz: string) {
     consolidationUsage,
     isLoading: isHeartbeatLoading || isConsolidationLoading,
     hasError: isHeartbeatError || isConsolidationError,
-    hasAnySystemTask:
-      heartbeatConfig != null || consolidationConfig?.available === true,
     isHeartbeatRunning,
     isConsolidationRunning,
     isHeartbeatLoading,

--- a/apps/web/src/domains/settings/pages/schedules-page.test.ts
+++ b/apps/web/src/domains/settings/pages/schedules-page.test.ts
@@ -243,6 +243,21 @@ describe("groupSchedules", () => {
     expect(grouped.pastOneTime.map((s) => s.id)).toEqual(["p1", "p2"]);
   });
 
+  test("a failed one-shot awaiting retry stays upcoming", () => {
+    const retrying = schedule({
+      id: "retry-1",
+      isOneShot: true,
+      lastRunAt: now - 60_000,
+      lastStatus: "error",
+      nextRunAt: now + 60_000,
+    });
+
+    const grouped = groupSchedules([retrying], now);
+
+    expect(grouped.upcomingOneTime.map((s) => s.id)).toEqual(["retry-1"]);
+    expect(grouped.pastOneTime).toEqual([]);
+  });
+
   test("orders upcoming one-shots soonest first", () => {
     const later = schedule({
       id: "later",

--- a/apps/web/src/domains/settings/pages/schedules-page.test.ts
+++ b/apps/web/src/domains/settings/pages/schedules-page.test.ts
@@ -1041,5 +1041,8 @@ describe("system task toggles", () => {
     expect(document.body.textContent).not.toContain(
       "Consolidation is part of Memory.",
     );
+    // Heartbeat is hidden here, so its cached usage must not inflate the
+    // aggregate cost on the collapsed trigger ($0.42, not $0.84).
+    expect(document.body.textContent).toContain("$0.42 (7d)");
   });
 });

--- a/apps/web/src/domains/settings/pages/schedules-page.test.ts
+++ b/apps/web/src/domains/settings/pages/schedules-page.test.ts
@@ -217,24 +217,30 @@ describe("groupSchedules", () => {
     const upcoming = schedule({
       id: "u1",
       isOneShot: true,
+      status: "active",
+      enabled: true,
       lastRunAt: null,
       nextRunAt: now + 60_000,
     });
-    const elapsed = schedule({
+    const expired = schedule({
       id: "p1",
       isOneShot: true,
+      status: "active",
+      enabled: false,
       lastRunAt: null,
       nextRunAt: now - 60_000,
     });
     const completed = schedule({
       id: "p2",
       isOneShot: true,
+      status: "fired",
+      enabled: true,
       lastRunAt: now - 120_000,
       nextRunAt: now - 120_000,
     });
 
     const grouped = groupSchedules(
-      [completed, recurring, upcoming, elapsed],
+      [completed, recurring, upcoming, expired],
       now,
     );
 
@@ -247,6 +253,8 @@ describe("groupSchedules", () => {
     const retrying = schedule({
       id: "retry-1",
       isOneShot: true,
+      status: "active",
+      enabled: true,
       lastRunAt: now - 60_000,
       lastStatus: "error",
       nextRunAt: now + 60_000,
@@ -256,6 +264,33 @@ describe("groupSchedules", () => {
 
     expect(grouped.upcomingOneTime.map((s) => s.id)).toEqual(["retry-1"]);
     expect(grouped.pastOneTime).toEqual([]);
+  });
+
+  test("in-flight and overdue-but-enabled one-shots stay out of the past bucket", () => {
+    const firing = schedule({
+      id: "firing-1",
+      isOneShot: true,
+      status: "firing",
+      enabled: true,
+      lastRunAt: now - 1_000,
+      nextRunAt: now - 1_000,
+    });
+    const overdue = schedule({
+      id: "overdue-1",
+      isOneShot: true,
+      status: "active",
+      enabled: true,
+      lastRunAt: null,
+      nextRunAt: now - 60_000,
+    });
+
+    const grouped = groupSchedules([firing, overdue], now);
+
+    expect(grouped.pastOneTime).toEqual([]);
+    expect(grouped.upcomingOneTime.map((s) => s.id)).toEqual([
+      "overdue-1",
+      "firing-1",
+    ]);
   });
 
   test("orders upcoming one-shots soonest first", () => {
@@ -296,6 +331,11 @@ describe("pastOneTimeStatus", () => {
     expect(
       pastOneTimeStatus(schedule({ lastRunAt: null, nextRunAt: 1 })),
     ).toEqual({ label: "Expired", tone: "neutral" });
+    expect(
+      pastOneTimeStatus(
+        schedule({ status: "cancelled", lastRunAt: 1_761_792_000_000 }),
+      ),
+    ).toEqual({ label: "Cancelled", tone: "neutral" });
   });
 });
 

--- a/apps/web/src/domains/settings/pages/schedules-page.test.ts
+++ b/apps/web/src/domains/settings/pages/schedules-page.test.ts
@@ -336,6 +336,16 @@ describe("pastOneTimeStatus", () => {
         schedule({ status: "cancelled", lastRunAt: 1_761_792_000_000 }),
       ),
     ).toEqual({ label: "Cancelled", tone: "neutral" });
+    // failOneShotPermanently: retry cap exhausted → cancelled + error.
+    expect(
+      pastOneTimeStatus(
+        schedule({
+          status: "cancelled",
+          lastStatus: "error",
+          lastRunAt: 1_761_792_000_000,
+        }),
+      ),
+    ).toEqual({ label: "Failed", tone: "negative" });
   });
 });
 

--- a/apps/web/src/domains/settings/pages/schedules-page.test.ts
+++ b/apps/web/src/domains/settings/pages/schedules-page.test.ts
@@ -82,6 +82,8 @@ const {
   canOpenScheduleSourceConversation,
   formatScheduleCost,
   formatTimestamp,
+  groupSchedules,
+  pastOneTimeStatus,
   shouldShowSystemTaskToggles,
 } = await import("@/domains/settings/utils/schedule-formatters");
 const { RecentRunsCard } = await import(
@@ -204,6 +206,81 @@ describe("formatScheduleCost", () => {
   test("falls back when cost is missing or invalid", () => {
     expect(formatScheduleCost(null)).toBe("—");
     expect(formatScheduleCost(Number.NaN)).toBe("—");
+  });
+});
+
+describe("groupSchedules", () => {
+  const now = 1_761_792_000_000;
+
+  test("splits one-shots into upcoming and past", () => {
+    const recurring = schedule({ id: "r1", isOneShot: false });
+    const upcoming = schedule({
+      id: "u1",
+      isOneShot: true,
+      lastRunAt: null,
+      nextRunAt: now + 60_000,
+    });
+    const elapsed = schedule({
+      id: "p1",
+      isOneShot: true,
+      lastRunAt: null,
+      nextRunAt: now - 60_000,
+    });
+    const completed = schedule({
+      id: "p2",
+      isOneShot: true,
+      lastRunAt: now - 120_000,
+      nextRunAt: now - 120_000,
+    });
+
+    const grouped = groupSchedules(
+      [completed, recurring, upcoming, elapsed],
+      now,
+    );
+
+    expect(grouped.recurring.map((s) => s.id)).toEqual(["r1"]);
+    expect(grouped.upcomingOneTime.map((s) => s.id)).toEqual(["u1"]);
+    expect(grouped.pastOneTime.map((s) => s.id)).toEqual(["p1", "p2"]);
+  });
+
+  test("orders upcoming one-shots soonest first", () => {
+    const later = schedule({
+      id: "later",
+      isOneShot: true,
+      lastRunAt: null,
+      nextRunAt: now + 120_000,
+    });
+    const sooner = schedule({
+      id: "sooner",
+      isOneShot: true,
+      lastRunAt: null,
+      nextRunAt: now + 60_000,
+    });
+
+    const grouped = groupSchedules([later, sooner], now);
+
+    expect(grouped.upcomingOneTime.map((s) => s.id)).toEqual([
+      "sooner",
+      "later",
+    ]);
+  });
+});
+
+describe("pastOneTimeStatus", () => {
+  test("labels completed, failed, and expired one-shots", () => {
+    expect(
+      pastOneTimeStatus(
+        schedule({ lastRunAt: 1_761_792_000_000, lastStatus: "ok" }),
+      ),
+    ).toEqual({ label: "Completed", tone: "positive" });
+    expect(
+      pastOneTimeStatus(
+        schedule({ lastRunAt: 1_761_792_000_000, lastStatus: "error" }),
+      ),
+    ).toEqual({ label: "Failed", tone: "negative" });
+    expect(
+      pastOneTimeStatus(schedule({ lastRunAt: null, nextRunAt: 1 })),
+    ).toEqual({ label: "Expired", tone: "neutral" });
   });
 });
 
@@ -526,7 +603,7 @@ describe("ScheduleRow", () => {
       }),
     );
 
-    expect(screen.getByText(formatTimestamp(lastRunAt))).toBeTruthy();
+    expect(screen.getByText(`Last ${formatTimestamp(lastRunAt)}`)).toBeTruthy();
     expect(screen.queryByLabelText("ok")).toBeNull();
   });
 
@@ -554,7 +631,60 @@ describe("ScheduleRow", () => {
       }),
     );
 
-    expect(screen.getByText(formatTimestamp(nextRunAt))).toBeTruthy();
+    expect(screen.getByText(`Next ${formatTimestamp(nextRunAt)}`)).toBeTruthy();
+  });
+
+  test("hides the description when it duplicates the name", () => {
+    render(
+      createElement(ScheduleRow, {
+        schedule: rowSchedule({
+          name: "fill water",
+          description: "fill water",
+        }),
+        usage: {
+          status: "ready",
+          summary: {
+            scheduleId: "schedule-123",
+            runCount: 0,
+            totalEstimatedCostUsd: 0,
+            eventCount: 0,
+          },
+        },
+        onClick: () => {},
+        onToggle: () => {},
+        onOpenUsage: () => {},
+      }),
+    );
+
+    expect(screen.getAllByText("fill water")).toHaveLength(1);
+  });
+
+  test("past one-shot rows show a status tag instead of a toggle", () => {
+    render(
+      createElement(ScheduleRow, {
+        schedule: rowSchedule({
+          isOneShot: true,
+          lastRunAt: 1_761_792_000_000,
+          lastStatus: "ok",
+        }),
+        usage: {
+          status: "ready",
+          summary: {
+            scheduleId: "schedule-123",
+            runCount: 1,
+            totalEstimatedCostUsd: 0.01,
+            eventCount: 1,
+          },
+        },
+        onClick: () => {},
+        onToggle: () => {},
+        onOpenUsage: () => {},
+        pastStatus: { label: "Completed", tone: "positive" },
+      }),
+    );
+
+    expect(screen.getByText("Completed")).toBeTruthy();
+    expect(screen.queryByLabelText("Toggle Daily summary")).toBeNull();
   });
 
   test("renders authored description and recurring cadence as separate row text", () => {
@@ -771,9 +901,10 @@ describe("SystemTaskRow", () => {
     expect(screen.queryByRole("button", { name: /Run now/i })).toBeNull();
     expect(screen.queryByText("system")).toBeNull();
     expect(screen.getByLabelText("enabled")).toBeTruthy();
-    expect(screen.getByText("Cost (7d)")).toBeTruthy();
+    // Column labels live in the shared list header now, not in each row.
+    expect(screen.queryByText("Cost (7d)")).toBeNull();
     expect(screen.getByText("$0.42")).toBeTruthy();
-    expect(screen.getByText("Runs (7d)")).toBeTruthy();
+    expect(screen.queryByText("Runs (7d)")).toBeNull();
     expect(screen.getByText("2 runs")).toBeTruthy();
   });
 });
@@ -831,6 +962,9 @@ describe("system task toggles", () => {
         },
       }),
     );
+
+    // System jobs are collapsed by default — expand the disclosure first.
+    fireEvent.click(screen.getByRole("button", { name: /System/i }));
 
     expect(screen.queryByLabelText("Toggle Consolidation")).toBeNull();
     expect(toggleCalls).toEqual([]);

--- a/apps/web/src/domains/settings/pages/schedules-page.tsx
+++ b/apps/web/src/domains/settings/pages/schedules-page.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
-import { ArrowLeft, Calendar, Loader2, Plus } from "lucide-react";
+import { ArrowLeft, Calendar, ChevronDown, Loader2, Plus } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
+import type { ReactNode } from "react";
 import { useNavigate, useParams } from "react-router";
 
 import { DetailCard } from "@/components/detail-card";
@@ -10,26 +11,30 @@ import { fetchSchedules, toggleSchedule } from "@/domains/settings/api/schedules
 import { CreateScheduleModal } from "@/domains/settings/components/create-schedule-modal";
 import { ScheduleDetailView } from "@/domains/settings/components/schedule-detail-view";
 import { ScheduleRow } from "@/domains/settings/components/schedule-row";
+import { ScheduleListColumnsHeader } from "@/domains/settings/components/schedule-shared-ui";
 import { SystemTaskDetailView } from "@/domains/settings/components/system-task-detail-view";
 import { SystemTasksSection } from "@/domains/settings/components/system-tasks-section";
 import { useSystemTasks } from "@/domains/settings/hooks/use-system-tasks";
 import {
   consolidationSubtitle,
+  groupSchedules,
   heartbeatSubtitle,
+  pastOneTimeStatus,
   scheduleUsageSummaryQueryOptions,
   shouldShowSystemTaskToggles,
-  sortSchedules,
   SYSTEM_TASK_URL_IDS,
   systemTaskKindFromUrlId,
   type ScheduleRowUsage,
   zeroScheduleUsageSummary,
 } from "@/domains/settings/utils/schedule-formatters";
 import { captureError } from "@/lib/sentry/capture-error";
+import type { Schedule } from "@/domains/settings/types/schedules";
 import { assistantSchedulesQueryKey } from "@/lib/sync/query-tags";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { routes } from "@/utils/routes";
 import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
 import { Button } from "@vellumai/design-library/components/button";
+import { Collapsible } from "@vellumai/design-library/components/collapsible";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { toast } from "@vellumai/design-library/components/toast";
 
@@ -56,6 +61,23 @@ function EmptyState({ onCreate }: { onCreate: () => void }) {
           Create schedule
         </Button>
       </div>
+    </div>
+  );
+}
+
+function ScheduleGroup({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="[&+&]:mt-4">
+      <div className="px-2 pb-1 text-label-medium-default uppercase tracking-wider text-[var(--content-tertiary)]">
+        {label}
+      </div>
+      <div>{children}</div>
     </div>
   );
 }
@@ -329,38 +351,36 @@ export function SchedulesPage() {
     return <UnknownScheduleState onBack={navigateToSchedules} />;
   }
 
-  if (
-    !schedules ||
-    (schedules.length === 0 &&
-      !systemTasks.hasAnySystemTask &&
-      !systemTasks.isLoading &&
-      !systemTasks.hasError)
-  ) {
-    return (
-      <div className="w-full">
-        <EmptyState onCreate={() => setCreateOpen(true)} />
-        {assistantId ? (
-          <CreateScheduleModal
-            isOpen={createOpen}
-            assistantId={assistantId}
-            onClose={() => setCreateOpen(false)}
-            onCreated={handleCreated}
-          />
-        ) : null}
-      </div>
-    );
-  }
+  const scheduleList = schedules ?? [];
+  const { recurring, upcomingOneTime, pastOneTime } = groupSchedules(
+    scheduleList,
+    Date.now(),
+  );
+  const hasActiveSchedules =
+    recurring.length > 0 || upcomingOneTime.length > 0;
 
-  const { recurring, oneTime } = sortSchedules(schedules);
+  const renderRow = (schedule: Schedule, past = false) => (
+    <ScheduleRow
+      key={schedule.id}
+      schedule={schedule}
+      usage={usageForSchedule(schedule.id)}
+      onClick={() => navigateToSchedule(schedule.id)}
+      onToggle={(enabled) => void handleToggle(schedule.id, enabled)}
+      onOpenUsage={() => navigate(routes.logs.usageForSchedule(schedule.id))}
+      pastStatus={past ? pastOneTimeStatus(schedule) : undefined}
+    />
+  );
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-end">
-        <Button variant="primary" onClick={() => setCreateOpen(true)}>
-          <Plus className="h-4 w-4" />
-          New schedule
-        </Button>
-      </div>
+      {scheduleList.length > 0 ? (
+        <div className="flex items-center justify-end">
+          <Button variant="primary" onClick={() => setCreateOpen(true)}>
+            <Plus className="h-4 w-4" />
+            New schedule
+          </Button>
+        </div>
+      ) : null}
 
       {isUsageSummaryError ? (
         <Notice tone="warning" className="py-2 text-body-small-default">
@@ -368,24 +388,45 @@ export function SchedulesPage() {
         </Notice>
       ) : null}
 
-      {recurring.length > 0 && (
-        <DetailCard
-          title="Schedules"
-          subtitle="Recurring automations managed by your assistant."
-        >
+      {scheduleList.length === 0 ? (
+        <EmptyState onCreate={() => setCreateOpen(true)} />
+      ) : (
+        <DetailCard title="Schedules">
           <div>
-            {recurring.map((schedule) => (
-              <ScheduleRow
-                key={schedule.id}
-                schedule={schedule}
-                usage={usageForSchedule(schedule.id)}
-                onClick={() => navigateToSchedule(schedule.id)}
-                onToggle={(enabled) => void handleToggle(schedule.id, enabled)}
-                onOpenUsage={() =>
-                  navigate(routes.logs.usageForSchedule(schedule.id))
-                }
-              />
-            ))}
+            <ScheduleListColumnsHeader />
+            {recurring.length > 0 && (
+              <ScheduleGroup label="Recurring">
+                {recurring.map((schedule) => renderRow(schedule))}
+              </ScheduleGroup>
+            )}
+            {upcomingOneTime.length > 0 && (
+              <ScheduleGroup label="One-time">
+                {upcomingOneTime.map((schedule) => renderRow(schedule))}
+              </ScheduleGroup>
+            )}
+            {!hasActiveSchedules && (
+              <p className="px-2 py-3 text-body-small-default text-[var(--content-tertiary)]">
+                No upcoming schedules.
+              </p>
+            )}
+            {pastOneTime.length > 0 && (
+              <Collapsible.Root
+                type="multiple"
+                className="mt-3 border-t border-[var(--border-base)] pt-1"
+              >
+                <Collapsible.Item value="past-one-time">
+                  <Collapsible.Trigger className="group gap-2 rounded-md px-2 py-2 text-body-small-default text-[var(--content-tertiary)] transition-colors hover:bg-[var(--surface-hover)]">
+                    <ChevronDown className="h-4 w-4 shrink-0 transition-transform group-data-[state=open]:rotate-180" />
+                    Past one-time ({pastOneTime.length})
+                  </Collapsible.Trigger>
+                  <Collapsible.Content>
+                    <div>
+                      {pastOneTime.map((schedule) => renderRow(schedule, true))}
+                    </div>
+                  </Collapsible.Content>
+                </Collapsible.Item>
+              </Collapsible.Root>
+            )}
           </div>
         </DetailCard>
       )}
@@ -409,28 +450,6 @@ export function SchedulesPage() {
           void systemTasks.handleToggle("heartbeat", enabled)
         }
       />
-
-      {oneTime.length > 0 && (
-        <DetailCard
-          title="One-time"
-          subtitle="One-shot automations that run once at a scheduled time."
-        >
-          <div>
-            {oneTime.map((schedule) => (
-              <ScheduleRow
-                key={schedule.id}
-                schedule={schedule}
-                usage={usageForSchedule(schedule.id)}
-                onClick={() => navigateToSchedule(schedule.id)}
-                onToggle={(enabled) => void handleToggle(schedule.id, enabled)}
-                onOpenUsage={() =>
-                  navigate(routes.logs.usageForSchedule(schedule.id))
-                }
-              />
-            ))}
-          </div>
-        </DetailCard>
-      )}
 
       {assistantId ? (
         <CreateScheduleModal

--- a/apps/web/src/domains/settings/pages/schedules-page.tsx
+++ b/apps/web/src/domains/settings/pages/schedules-page.tsx
@@ -163,6 +163,9 @@ export function SchedulesPage() {
 
   const selectedSystemTask = systemTaskKindFromUrlId(scheduleId);
   const [createOpen, setCreateOpen] = useState(false);
+  // Mount-time snapshot (impure calls are not allowed during render); the
+  // upcoming/past one-shot boundary doesn't need to move while the page is up.
+  const [now] = useState(() => Date.now());
 
   const selectedSchedule = useMemo(
     () =>
@@ -354,7 +357,7 @@ export function SchedulesPage() {
   const scheduleList = schedules ?? [];
   const { recurring, upcomingOneTime, pastOneTime } = groupSchedules(
     scheduleList,
-    Date.now(),
+    now,
   );
   const hasActiveSchedules =
     recurring.length > 0 || upcomingOneTime.length > 0;

--- a/apps/web/src/domains/settings/utils/schedule-formatters.ts
+++ b/apps/web/src/domains/settings/utils/schedule-formatters.ts
@@ -174,11 +174,20 @@ export interface GroupedSchedules {
   pastOneTime: Schedule[];
 }
 
-// A one-shot with a future nextRunAt is upcoming even when lastRunAt is set:
-// a failed attempt with retries left keeps lastRunAt while the backend
-// schedules the retry in the future.
+// Keyed on the lifecycle status, not lastRunAt/nextRunAt alone: a failed
+// attempt awaiting retry keeps lastRunAt set, and an in-flight run is
+// `firing` with nextRunAt already due — both are still live, not past.
 function isPastOneTime(schedule: Schedule, now: number): boolean {
-  return schedule.nextRunAt == null || schedule.nextRunAt <= now;
+  if (schedule.status === "fired" || schedule.status === "cancelled") {
+    return true;
+  }
+  if (schedule.status === "firing") return false;
+  // active: an enabled one-shot still fires on the next daemon wake even if
+  // overdue; a disabled one whose time has passed never will.
+  return (
+    schedule.nextRunAt == null ||
+    (!schedule.enabled && schedule.nextRunAt <= now)
+  );
 }
 
 export function groupSchedules(
@@ -223,6 +232,9 @@ export interface PastOneTimeStatus {
 }
 
 export function pastOneTimeStatus(schedule: Schedule): PastOneTimeStatus {
+  if (schedule.status === "cancelled") {
+    return { label: "Cancelled", tone: "neutral" };
+  }
   if (schedule.lastRunAt != null) {
     return schedule.lastStatus === "error" || schedule.lastStatus === "failed"
       ? { label: "Failed", tone: "negative" }

--- a/apps/web/src/domains/settings/utils/schedule-formatters.ts
+++ b/apps/web/src/domains/settings/utils/schedule-formatters.ts
@@ -174,12 +174,11 @@ export interface GroupedSchedules {
   pastOneTime: Schedule[];
 }
 
+// A one-shot with a future nextRunAt is upcoming even when lastRunAt is set:
+// a failed attempt with retries left keeps lastRunAt while the backend
+// schedules the retry in the future.
 function isPastOneTime(schedule: Schedule, now: number): boolean {
-  return (
-    schedule.lastRunAt != null ||
-    schedule.nextRunAt == null ||
-    schedule.nextRunAt <= now
-  );
+  return schedule.nextRunAt == null || schedule.nextRunAt <= now;
 }
 
 export function groupSchedules(

--- a/apps/web/src/domains/settings/utils/schedule-formatters.ts
+++ b/apps/web/src/domains/settings/utils/schedule-formatters.ts
@@ -165,21 +165,38 @@ export const MIN_SCRIPT_TIMEOUT_SECONDS = 1;
 export const MAX_SCRIPT_TIMEOUT_SECONDS = 30 * 60;
 
 // ---------------------------------------------------------------------------
-// Sorting
+// Grouping
 // ---------------------------------------------------------------------------
 
-export function sortSchedules(schedules: Schedule[]): {
+export interface GroupedSchedules {
   recurring: Schedule[];
-  oneTime: Schedule[];
-} {
+  upcomingOneTime: Schedule[];
+  pastOneTime: Schedule[];
+}
+
+function isPastOneTime(schedule: Schedule, now: number): boolean {
+  return (
+    schedule.lastRunAt != null ||
+    schedule.nextRunAt == null ||
+    schedule.nextRunAt <= now
+  );
+}
+
+export function groupSchedules(
+  schedules: Schedule[],
+  now: number,
+): GroupedSchedules {
   const recurring: Schedule[] = [];
-  const oneTime: Schedule[] = [];
+  const upcomingOneTime: Schedule[] = [];
+  const pastOneTime: Schedule[] = [];
 
   for (const s of schedules) {
-    if (s.isOneShot) {
-      oneTime.push(s);
-    } else {
+    if (!s.isOneShot) {
       recurring.push(s);
+    } else if (isPastOneTime(s, now)) {
+      pastOneTime.push(s);
+    } else {
+      upcomingOneTime.push(s);
     }
   }
 
@@ -188,13 +205,31 @@ export function sortSchedules(schedules: Schedule[]): {
     return (a.nextRunAt ?? Infinity) - (b.nextRunAt ?? Infinity);
   });
 
-  oneTime.sort((a, b) => {
+  upcomingOneTime.sort(
+    (a, b) => (a.nextRunAt ?? Infinity) - (b.nextRunAt ?? Infinity),
+  );
+
+  pastOneTime.sort((a, b) => {
     const aTime = a.lastRunAt ?? a.nextRunAt ?? 0;
     const bTime = b.lastRunAt ?? b.nextRunAt ?? 0;
     return bTime - aTime;
   });
 
-  return { recurring, oneTime };
+  return { recurring, upcomingOneTime, pastOneTime };
+}
+
+export interface PastOneTimeStatus {
+  label: string;
+  tone: TagTone;
+}
+
+export function pastOneTimeStatus(schedule: Schedule): PastOneTimeStatus {
+  if (schedule.lastRunAt != null) {
+    return schedule.lastStatus === "error" || schedule.lastStatus === "failed"
+      ? { label: "Failed", tone: "negative" }
+      : { label: "Completed", tone: "positive" };
+  }
+  return { label: "Expired", tone: "neutral" };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/domains/settings/utils/schedule-formatters.ts
+++ b/apps/web/src/domains/settings/utils/schedule-formatters.ts
@@ -232,13 +232,16 @@ export interface PastOneTimeStatus {
 }
 
 export function pastOneTimeStatus(schedule: Schedule): PastOneTimeStatus {
+  // Failure wins over cancellation: failOneShotPermanently (retry cap
+  // exhausted) records status "cancelled" with lastStatus "error".
+  if (schedule.lastStatus === "error" || schedule.lastStatus === "failed") {
+    return { label: "Failed", tone: "negative" };
+  }
   if (schedule.status === "cancelled") {
     return { label: "Cancelled", tone: "neutral" };
   }
   if (schedule.lastRunAt != null) {
-    return schedule.lastStatus === "error" || schedule.lastStatus === "failed"
-      ? { label: "Failed", tone: "negative" }
-      : { label: "Completed", tone: "positive" };
+    return { label: "Completed", tone: "positive" };
   }
   return { label: "Expired", tone: "neutral" };
 }


### PR DESCRIPTION
## Summary
- Merge the three stacked cards (Schedules / System / One-time) into a single **Schedules** card with slim uppercase group headers (Recurring / One-time) and a single column-header row for Cost (7d) / Runs (7d) — the per-row stat labels are removed and zero values are dimmed so non-zero cost stands out
- Elapsed one-shots auto-demote into a collapsed **Past one-time (N)** disclosure with a Completed / Failed / Expired status tag instead of a meaningless toggle; row metadata is tightened (description hidden when it duplicates the name, timestamps prefixed Next / Last / Scheduled)
- System jobs (Heartbeat, Consolidation) move to the bottom of the page under a collapsed disclosure that still surfaces aggregate 7-day cost while collapsed

## Original prompt
The schedules settings page felt cluttered: three full-height cards each repeating per-row "Cost (7d)" / "Runs (7d)" labels, month-old one-time schedules rendered at full prominence with toggles that no longer mean anything, and built-in system jobs occupying a full card between user schedules. Aaron asked to implement the pitched cleanup (unified list, shared column header, deduped descriptions, demoted past one-times) and additionally to bury the system jobs either at the bottom of the page or under a collapsed/advanced dropdown — this PR does both: bottom of the page, collapsed by default.