### PR TITLE
ci: run web tests when meta/llm-provider-catalog.json changes

### DIFF
--- a/.github/workflows/ci-main-web.yaml
+++ b/.github/workflows/ci-main-web.yaml
@@ -9,6 +9,9 @@ on:
       - 'packages/design-library/**'
       - 'packages/local-mode/**'
       - 'packages/environments/**'
+      # The web LLM catalog parity test reads this file, so daemon-side catalog
+      # regenerations must run the web tests too.
+      - 'meta/llm-provider-catalog.json'
       - '.github/workflows/ci-main-web.yaml'
       - '.github/actions/install-shared-packages/**'
       # The deploy/publish logic lives in this reusable workflow, so a change to

--- a/.github/workflows/pr-web.yaml
+++ b/.github/workflows/pr-web.yaml
@@ -8,6 +8,9 @@ on:
       - 'packages/design-library/**'
       - 'packages/local-mode/**'
       - 'packages/environments/**'
+      # The web LLM catalog parity test reads this file, so daemon-side catalog
+      # regenerations must run the web tests on the PR that introduces drift.
+      - 'meta/llm-provider-catalog.json'
       - '.github/workflows/pr-web.yaml'
       - '.github/actions/install-shared-packages/**'
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for minimax-m3-provider-catalog.md.

**Gap:** web CI path filters exclude meta/, so the new web↔meta catalog parity test never runs on the daemon-side PRs that cause drift
**What was expected:** drift fails CI on the PR that introduces it
**What was found:** pr-web.yaml and ci-main-web.yaml trigger only on apps/web/** and packages/**