### PR TITLE
refactor(web): dedupe profile editor empty-state logic; fix stale codegen note

### DIFF
--- a/apps/web/src/domains/settings/ai/profile-editor-provider-section.tsx
+++ b/apps/web/src/domains/settings/ai/profile-editor-provider-section.tsx
@@ -28,6 +28,26 @@ function connectionModelsToCatalog(models: ConnectionModel[] | null | undefined)
   }));
 }
 
+/**
+ * Copy for the Model field's empty states, keyed by the `modelEmptyState`
+ * discriminator. The "no-provider" hint is `null` because the hint only
+ * renders once a provider is selected.
+ */
+const MODEL_EMPTY_STATE_COPY = {
+  "no-provider": {
+    placeholder: "Select a provider first",
+    hint: null,
+  },
+  "configure-connection": {
+    placeholder: "Configure models on connection",
+    hint: "No models available. Configure models on the provider connection first.",
+  },
+  "unknown-to-catalog": {
+    placeholder: "No models available",
+    hint: "No models are available for this provider in this app version. Update the app, or use an OpenAI-compatible connection to enter a custom model.",
+  },
+} as const;
+
 // ---------------------------------------------------------------------------
 // Props
 // ---------------------------------------------------------------------------
@@ -167,6 +187,20 @@ export function ProfileEditorProviderSection({
     availableConnectionsForProvider,
   ]);
 
+  // Single discriminator for the Model field's empty states — the dropdown
+  // placeholder and the hint below both derive from it so the two can't
+  // drift apart.
+  const modelEmptyState = !provider
+    ? "no-provider"
+    : availableModels.length === 0
+      ? provider === OPENAI_COMPATIBLE_PROVIDER
+        ? "configure-connection"
+        : "unknown-to-catalog"
+      : null;
+  const modelEmptyStateCopy = modelEmptyState
+    ? MODEL_EMPTY_STATE_COPY[modelEmptyState]
+    : null;
+
   // Auto-clear model when it's no longer in the available list (e.g. after
   // switching connections for openai-compatible providers).
   useEffect(() => {
@@ -288,13 +322,7 @@ export function ProfileEditorProviderSection({
           options={[
             {
               value: "",
-              label: !provider
-                ? "Select a provider first"
-                : availableModels.length === 0
-                  ? provider === OPENAI_COMPATIBLE_PROVIDER
-                    ? "Configure models on connection"
-                    : "No models available"
-                  : "Select a model",
+              label: modelEmptyStateCopy?.placeholder ?? "Select a model",
             },
             ...availableModels.map((m) => ({
               value: m.id,
@@ -308,11 +336,7 @@ export function ProfileEditorProviderSection({
             as="p"
             className="text-(--system-negative-strong)"
           >
-            {availableModels.length === 0
-              ? provider === OPENAI_COMPATIBLE_PROVIDER
-                ? "No models available. Configure models on the provider connection first."
-                : "No models are available for this provider in this app version. Update the app, or use an OpenAI-compatible connection to enter a custom model."
-              : "Select a model."}
+            {modelEmptyStateCopy?.hint ?? "Select a model."}
           </Typography>
         ) : null}
       </div>

--- a/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
+++ b/apps/web/src/domains/settings/ai/provider-editor-modal.tsx
@@ -35,11 +35,14 @@ import { secretPlaceholder } from "@/domains/settings/ai/secret-placeholder";
 import { useLabelKeySync } from "@/domains/settings/ai/use-label-key-sync";
 import { useProviderCredentialsList } from "@/domains/settings/ai/use-provider-credentials-list";
 
-// NOTE: The set of providers that support `platform` auth is sourced from
-// the catalog via `providerSupportsPlatformAuth()` — it's derived from the
-// daemon's `PLATFORM_PROVIDER_META` table at catalog build time so the UI
-// gate and the proxy routing table cannot drift. See
-// `web/scripts/sync-llm-model-catalog.ts` + `web/src/lib/llm-model-catalog.ts`.
+// NOTE: The `platform` auth gate is `providerSupportsPlatformAuth()`. The
+// daemon derives `supportsPlatformAuth` from `PLATFORM_PROVIDER_META`
+// (assistant/src/providers/platform-proxy/constants.ts) into
+// meta/llm-provider-catalog.json via `cd assistant && bun run
+// sync:llm-catalog`; the web mirrors it in the hand-maintained
+// `PROVIDER_SUPPORTS_PLATFORM_AUTH` map in
+// apps/web/src/assistant/llm-model-catalog.ts, with parity tests guarding
+// drift against the meta catalog.
 
 // ---------------------------------------------------------------------------
 // ProviderEditorContent


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for minimax-m3-provider-catalog.md.

**Gap:** duplicated empty-state decision tree in profile-editor-provider-section.tsx; stale reference to nonexistent web/scripts/sync-llm-model-catalog.ts in provider-editor-modal.tsx
**What was expected:** single source for the empty-state discriminator; truthful comments
**What was found:** identical nested ternary duplicated for label and hint; NOTE pointing at files that don't exist in this monorepo