### PR TITLE
fix(web): make catalog model lookups case-insensitive for mixed-case ids

### DIFF
--- a/apps/web/src/assistant/model-capabilities.ts
+++ b/apps/web/src/assistant/model-capabilities.ts
@@ -7,7 +7,7 @@
  * provider or model is absent.
  */
 
-import { getModelsForProvider } from "@/assistant/llm-model-catalog";
+import { getModelsForProvider, type LlmCatalogModel } from "@/assistant/llm-model-catalog";
 
 export interface ProfileParamVisibility {
   maxTokens: boolean;
@@ -48,8 +48,19 @@ function knownOpenRouterReasoningModel(modelId: string): boolean {
   );
 }
 
+/**
+ * Case-insensitive exact-id catalog lookup. `resolveProfileParamVisibility`
+ * lowercases the model id for its prefix/substring heuristics, but catalog
+ * ids can be mixed-case (e.g. minimax's "MiniMax-M3"), so an exact `===`
+ * find would never match those entries.
+ */
+function findCatalogModel(provider: string, modelId: string): LlmCatalogModel | undefined {
+  const id = modelId.toLowerCase();
+  return getModelsForProvider(provider).find((m) => m.id.toLowerCase() === id);
+}
+
 function modelSupportsThinking(provider: string, modelId: string): boolean {
-  const entry = getModelsForProvider(provider).find((m) => m.id === modelId);
+  const entry = findCatalogModel(provider, modelId);
   if (entry?.supportsThinking !== undefined) return entry.supportsThinking;
 
   if (provider === "anthropic") return true;

--- a/apps/web/src/domains/settings/ai/profile-param-visibility.test.ts
+++ b/apps/web/src/domains/settings/ai/profile-param-visibility.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   geminiThinkingLevels,
+  modelSupportsThinking,
   resolveProfileParamVisibility,
   VISIBILITY_NONE,
 } from "@/domains/settings/ai/profile-param-visibility";
@@ -76,6 +77,18 @@ describe("resolveProfileParamVisibility", () => {
     expect(vis.temperature).toBe(false);
     expect(vis.thinking).toBe(false);
     expect(vis.thinkingLevel).toBe(false);
+  });
+});
+
+describe("modelSupportsThinking", () => {
+  test("matches mixed-case catalog ids case-insensitively (minimax)", () => {
+    // The web catalog stores minimax ids mixed-case ("MiniMax-M3") while
+    // resolveProfileParamVisibility lowercases the model id before the
+    // catalog lookup, so the exact-id find must be case-insensitive or the
+    // minimax entries are unreachable.
+    expect(modelSupportsThinking("minimax", "minimax-m3")).toBe(true);
+    expect(modelSupportsThinking("minimax", "MiniMax-M2.7")).toBe(true);
+    expect(modelSupportsThinking("minimax", "minimax-unknown")).toBe(false);
   });
 });
 

--- a/apps/web/src/domains/settings/ai/profile-param-visibility.ts
+++ b/apps/web/src/domains/settings/ai/profile-param-visibility.ts
@@ -3,7 +3,7 @@
  * based on the selected provider and model.
  */
 
-import { getModelsForProvider } from "@/assistant/llm-model-catalog";
+import { getModelsForProvider, type LlmCatalogModel } from "@/assistant/llm-model-catalog";
 
 export interface ProfileParamVisibility {
   maxTokens: boolean;
@@ -38,6 +38,17 @@ function isOpenRouterAnthropicModel(modelId: string): boolean {
 }
 
 /**
+ * Case-insensitive exact-id catalog lookup. `resolveProfileParamVisibility`
+ * lowercases the model id for its prefix/substring heuristics, but catalog
+ * ids can be mixed-case (e.g. minimax's "MiniMax-M3"), so an exact `===`
+ * find would never match those entries.
+ */
+function findCatalogModel(provider: string, modelId: string): LlmCatalogModel | undefined {
+  const id = modelId.toLowerCase();
+  return getModelsForProvider(provider).find((m) => m.id.toLowerCase() === id);
+}
+
+/**
  * Models flagged `adaptiveThinkingOnly` in the catalog always reason with
  * adaptive (always-on) thinking and reject an explicit "disable thinking"
  * request, so the enable/disable toggle must not be shown — effort stays
@@ -45,10 +56,7 @@ function isOpenRouterAnthropicModel(modelId: string): boolean {
  * `assistant/src/providers/model-catalog.ts`.
  */
 function isAdaptiveThinkingOnlyModel(provider: string, modelId: string): boolean {
-  return (
-    getModelsForProvider(provider).find((m) => m.id === modelId)
-      ?.adaptiveThinkingOnly === true
-  );
+  return findCatalogModel(provider, modelId)?.adaptiveThinkingOnly === true;
 }
 
 function knownOpenRouterReasoningModel(modelId: string): boolean {
@@ -85,8 +93,13 @@ export function geminiThinkingLevels(modelId: string): readonly string[] {
     : GEMINI_THINKING_LEVELS_FULL;
 }
 
-function modelSupportsThinking(provider: string, modelId: string): boolean {
-  const entry = getModelsForProvider(provider).find((m) => m.id === modelId);
+/**
+ * Whether a model supports extended thinking, preferring the catalog's
+ * `supportsThinking` flag over per-provider heuristics. `provider` must be a
+ * lowercase provider id. Exported for tests.
+ */
+export function modelSupportsThinking(provider: string, modelId: string): boolean {
+  const entry = findCatalogModel(provider, modelId);
   if (entry?.supportsThinking !== undefined) return entry.supportsThinking;
 
   if (provider === "anthropic") return true;


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for minimax-m3-provider-catalog.md.

**Gap:** lowercased capability lookups can't match mixed-case catalog ids
**What was expected:** catalog capability data for MiniMax-M3/MiniMax-M2.7 reachable via all lookup paths
**What was found:** profile-param-visibility.ts and model-capabilities.ts lowercase the model id before an exact-match find, so mixed-case minimax entries never match