### PR TITLE
ci: run assistant tests when llm provider catalog JSONs change

### DIFF
--- a/.github/workflows/ci-main-assistant.yaml
+++ b/.github/workflows/ci-main-assistant.yaml
@@ -10,6 +10,10 @@ on:
       - 'packages/**'
       - 'skills/meet-join/contracts/**'
       - 'meta/feature-flags/**'
+      # The daemon LLM catalog parity test reads these files, so hand edits to
+      # either catalog JSON must run the assistant tests too.
+      - 'meta/llm-provider-catalog.json'
+      - 'clients/shared/Resources/llm-provider-catalog.json'
       - '.github/workflows/ci-main-assistant.yaml'
       - '.github/actions/install-shared-packages/**'
 

--- a/.github/workflows/pr-assistant.yaml
+++ b/.github/workflows/pr-assistant.yaml
@@ -11,6 +11,11 @@ on:
       - 'skills/meet-join/contracts/**'
       - 'scripts/skills/**'
       - 'meta/feature-flags/**'
+      # The daemon LLM catalog parity test reads these files, so hand edits to
+      # either catalog JSON must run the assistant tests on the PR that
+      # introduces drift.
+      - 'meta/llm-provider-catalog.json'
+      - 'clients/shared/Resources/llm-provider-catalog.json'
       - '.github/workflows/pr-assistant.yaml'
       - '.github/actions/install-shared-packages/**'
 


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for minimax-m3-provider-catalog.md.

**Gap:** assistant CI workflows don't trigger on meta/clients catalog JSON changes, so the daemon parity suite can't catch hand-edited drift on the PR that introduces it
**What was expected:** catalog JSON edits run the full daemon parity suite (per-field TS↔meta + meta↔clients byte mirror)
**What was found:** only the web workflows gained the meta path in #34539; pr-assistant.yaml and the main-branch assistant workflow have no catalog JSON entries