### PR TITLE
test(web): guard CONNECTION_PROVIDERS against meta catalog drift

### DIFF
--- a/apps/web/src/assistant/llm-model-catalog.test.ts
+++ b/apps/web/src/assistant/llm-model-catalog.test.ts
@@ -6,8 +6,9 @@
  *
  * Covers every catalog surface the web UI consumes: per-model fields
  * (ids, order, display names, token limits, thinking flags), per-provider
- * default models, the provider display-name and platform-auth maps, and the
- * INFERENCE_PROVIDERS picker list in ai-types.ts.
+ * default models, the provider display-name and platform-auth maps, the
+ * INFERENCE_PROVIDERS picker list in ai-types.ts, and the
+ * CONNECTION_PROVIDERS picker list in provider-editor-constants.ts.
  */
 
 import { readFileSync } from "node:fs";
@@ -15,6 +16,7 @@ import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
 import { INFERENCE_PROVIDERS } from "@/domains/settings/ai/ai-types";
+import { CONNECTION_PROVIDERS } from "@/domains/settings/ai/provider-editor-constants";
 
 import {
   DEFAULT_MODEL_BY_PROVIDER,
@@ -144,6 +146,20 @@ describe("parity with meta/llm-provider-catalog.json", () => {
     // picker's display order (a UI choice, with index 0 as the default
     // fallback), not the catalog's.
     expect([...INFERENCE_PROVIDERS].sort()).toEqual([...webProviderIds].sort());
+  });
+
+  test("CONNECTION_PROVIDERS covers every meta catalog provider", () => {
+    // The connection-creation picker is driven by CONNECTION_PROVIDERS in
+    // provider-editor-constants.ts. Unlike INFERENCE_PROVIDERS, it
+    // intentionally includes daemon-only providers (ollama) and the
+    // free-form openai-compatible escape hatch — any daemon provider can
+    // back a connection — so it must list exactly the meta catalog's
+    // provider ids or a provider becomes un-creatable as a connection.
+    // Order is not asserted: the list's order is the picker's display order.
+    const connectionProviderIds: string[] = [...CONNECTION_PROVIDERS];
+    expect(connectionProviderIds.sort()).toEqual(
+      metaCatalog.providers.map((provider) => provider.id).sort(),
+    );
   });
 
   for (const providerId of webProviderIds) {

--- a/apps/web/src/domains/settings/ai/provider-editor-constants.ts
+++ b/apps/web/src/domains/settings/ai/provider-editor-constants.ts
@@ -10,6 +10,13 @@ export type AuthType = "api_key" | "platform" | "none" | "oauth_subscription";
 // Constants
 // ---------------------------------------------------------------------------
 
+/**
+ * Providers that can be selected when creating a provider connection. Must
+ * list exactly the meta/llm-provider-catalog.json provider ids (including
+ * daemon-only ones like ollama and the openai-compatible escape hatch);
+ * parity is enforced by llm-model-catalog.test.ts. Array order is the
+ * picker's display order.
+ */
 export const CONNECTION_PROVIDERS: ConnectionProvider[] = [
   "anthropic",
   "openai",


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for minimax-m3-provider-catalog.md.

**Gap:** CONNECTION_PROVIDERS (connection-creation provider picker) is the last unguarded hand-maintained provider mirror
**What was expected:** every web provider list is parity-guarded against meta/llm-provider-catalog.json
**What was found:** the hardened parity suite covers MODELS_BY_PROVIDER, display names, platform-auth, and INFERENCE_PROVIDERS — but not CONNECTION_PROVIDERS