### PR TITLE
Add Log Out control to Settings → General page

### DIFF
--- a/apps/web/src/domains/settings/components/logout-section.test.tsx
+++ b/apps/web/src/domains/settings/components/logout-section.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * Tests for `LogOutSection`.
+ *
+ * Uses `renderToStaticMarkup` (SSR) to assert the visibility gate that the
+ * Preferences popover previously owned: the Log Out card shows whenever we
+ * are not in pure local mode, and is hidden in local mode without a platform
+ * session.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const isLocalModeRef = { value: false };
+const hasPlatformSessionRef = { value: false };
+
+mock.module("react-router", () => ({
+  useNavigate: () => () => {},
+}));
+
+mock.module("@/lib/local-mode", () => ({
+  isLocalMode: () => isLocalModeRef.value,
+}));
+
+mock.module("@/stores/auth-store", () => ({
+  useHasPlatformSession: () => hasPlatformSessionRef.value,
+}));
+
+mock.module("@/lib/auth/handle-logout", () => ({
+  handleLogout: async () => {},
+}));
+
+import { LogOutSection } from "@/domains/settings/components/logout-section";
+
+beforeEach(() => {
+  isLocalModeRef.value = false;
+  hasPlatformSessionRef.value = false;
+});
+
+describe("LogOutSection", () => {
+  test("renders the Log Out card when not in local mode", () => {
+    isLocalModeRef.value = false;
+    const html = renderToStaticMarkup(createElement(LogOutSection));
+    expect(html).toContain("Log Out");
+  });
+
+  test("renders nothing in pure local mode without a platform session", () => {
+    isLocalModeRef.value = true;
+    hasPlatformSessionRef.value = false;
+    const html = renderToStaticMarkup(createElement(LogOutSection));
+    expect(html).toBe("");
+  });
+
+  test("renders the Log Out card in local mode when a platform session exists", () => {
+    isLocalModeRef.value = true;
+    hasPlatformSessionRef.value = true;
+    const html = renderToStaticMarkup(createElement(LogOutSection));
+    expect(html).toContain("Log Out");
+  });
+});

--- a/apps/web/src/domains/settings/components/logout-section.tsx
+++ b/apps/web/src/domains/settings/components/logout-section.tsx
@@ -1,0 +1,34 @@
+import { useNavigate } from "react-router";
+
+import { DetailCard } from "@/components/detail-card";
+import { handleLogout } from "@/lib/auth/handle-logout";
+import { isLocalMode } from "@/lib/local-mode";
+import { useHasPlatformSession } from "@/stores/auth-store";
+import { Button } from "@vellumai/design-library/components/button";
+
+export function LogOutSection() {
+  const navigate = useNavigate();
+  // Mirror the Preferences popover's prior visibility gate so behavior is
+  // preserved now that logout lives here (see `showLogout` in
+  // `preferences-menu.tsx`): hide in pure local mode unless a platform
+  // session exists.
+  const hasPlatformSession = useHasPlatformSession();
+  const showLogout = !isLocalMode() || hasPlatformSession;
+
+  if (!showLogout) return null;
+
+  return (
+    <DetailCard
+      title="Log Out"
+      subtitle="Sign out of your Vellum account on this device."
+    >
+      <Button
+        variant="outlined"
+        onClick={() => void handleLogout(navigate)}
+        className="self-start"
+      >
+        Log Out
+      </Button>
+    </DetailCard>
+  );
+}

--- a/apps/web/src/domains/settings/pages/general-page.tsx
+++ b/apps/web/src/domains/settings/pages/general-page.tsx
@@ -16,6 +16,7 @@ import { AssistantUpgrades } from "@/domains/settings/components/assistant-upgra
 import { DeleteAccountSection } from "@/domains/settings/components/delete-account-section";
 import { IOSAppCard } from "@/domains/settings/components/ios-app-card";
 import { LaunchAtLoginCard } from "@/domains/settings/components/launch-at-login-card";
+import { LogOutSection } from "@/domains/settings/components/logout-section";
 import { MediaEmbedsCard } from "@/domains/settings/components/media-embeds-card";
 import { PreviewReleaseChannel } from "@/domains/settings/components/preview-release-channel";
 import { ResizeCard } from "@/domains/settings/components/resize-card";
@@ -382,6 +383,8 @@ export function GeneralPage() {
           </Notice>
         </DetailCard>
       )}
+
+      <LogOutSection />
 
       <DeleteAccountSection />
     </div>


### PR DESCRIPTION
## Summary
- Add a LogOutSection card to Settings → General, gated by the same showLogout condition the Preferences popover used
- Positioned just above Delete Account; calls handleLogout
- SSR test for visibility + gating

Part of plan: move-settings-popover.md (PR 1 of 2)