### PR TITLE
fix: keep Log Out reachable when assistant lifecycle is unresolved

### DIFF
--- a/apps/web/src/components/layout/active-assistant-gate.tsx
+++ b/apps/web/src/components/layout/active-assistant-gate.tsx
@@ -1,9 +1,13 @@
 import { Loader2 } from "lucide-react";
-import { Outlet } from "react-router";
+import { Outlet, useNavigate } from "react-router";
 
 import { Typography } from "@vellumai/design-library";
+import { Button } from "@vellumai/design-library/components/button";
 
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
+import { handleLogout } from "@/lib/auth/handle-logout";
+import { isLocalMode } from "@/lib/local-mode";
+import { useHasPlatformSession } from "@/stores/auth-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 
 /**
@@ -42,6 +46,12 @@ export function ActiveAssistantGate() {
 }
 
 function ActiveAssistantPlaceholder() {
+  const navigate = useNavigate();
+  // Keep an escape hatch reachable while the assistant lifecycle is
+  // unresolved: hide in pure local mode unless a platform session exists.
+  const hasPlatformSession = useHasPlatformSession();
+  const showLogout = !isLocalMode() || hasPlatformSession;
+
   return (
     <div
       className="flex min-h-0 flex-1 flex-col items-center justify-center gap-[var(--app-spacing-md)] text-[var(--content-tertiary)]"
@@ -52,6 +62,11 @@ function ActiveAssistantPlaceholder() {
       <Typography variant="body-medium-default">
         Connecting to your assistant…
       </Typography>
+      {showLogout && (
+        <Button variant="ghost" onClick={() => void handleLogout(navigate)}>
+          Log Out
+        </Button>
+      )}
     </div>
   );
 }

--- a/apps/web/src/domains/settings/components/logout-section.test.tsx
+++ b/apps/web/src/domains/settings/components/logout-section.test.tsx
@@ -1,10 +1,9 @@
 /**
  * Tests for `LogOutSection`.
  *
- * Uses `renderToStaticMarkup` (SSR) to assert the visibility gate that the
- * Preferences popover previously owned: the Log Out card shows whenever we
- * are not in pure local mode, and is hidden in local mode without a platform
- * session.
+ * Uses `renderToStaticMarkup` (SSR) to assert the visibility gate: the Log Out
+ * card shows whenever we are not in pure local mode, and is hidden in local
+ * mode without a platform session.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";

--- a/apps/web/src/domains/settings/components/logout-section.tsx
+++ b/apps/web/src/domains/settings/components/logout-section.tsx
@@ -8,10 +8,7 @@ import { Button } from "@vellumai/design-library/components/button";
 
 export function LogOutSection() {
   const navigate = useNavigate();
-  // Mirror the Preferences popover's prior visibility gate so behavior is
-  // preserved now that logout lives here (see `showLogout` in
-  // `preferences-menu.tsx`): hide in pure local mode unless a platform
-  // session exists.
+  // Hide in pure local mode unless a platform session exists.
   const hasPlatformSession = useHasPlatformSession();
   const showLogout = !isLocalMode() || hasPlatformSession;
 


### PR DESCRIPTION
## Summary
Fixes gaps found during plan review for move-settings-popover.md.

- Gap 1: the Preferences popover (ungated) lost its Log Out item, but the new Settings → General logout sits behind ActiveAssistantGate — so a stuck/unresolved-assistant user had no discoverable logout. Add a gated Log Out escape hatch to ActiveAssistantPlaceholder.
- Gap 2: trim stale showLogout/preferences-menu back-reference in logout-section comment + test docstring.