### PR TITLE
fix(providers): request split reasoning from MiniMax so <think> tags stop leaking into responses

### DIFF
--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -1364,6 +1364,40 @@ describe("custom baseURL initialization", () => {
       timeout: DEFAULT_SDK_TIMEOUT_MS,
     });
   });
+
+  test("MinimaxProvider sends reasoning_split so reasoning never leaks into content as <think> tags", async () => {
+    fakeChunks = [textChunk("hello", "stop"), usageChunk(10, 5)];
+    const provider = new MinimaxProvider("mm-user-key", "MiniMax-M3");
+
+    await provider.sendMessage([userMsg("hi")]);
+
+    expect(lastCreateParams!.reasoning_split).toBe(true);
+  });
+
+  test("MinimaxProvider replays prior assistant thinking via reasoning_content", async () => {
+    fakeChunks = [textChunk("done", "stop"), usageChunk(10, 5)];
+    const provider = new MinimaxProvider("mm-user-key", "MiniMax-M3");
+
+    await provider.sendMessage([
+      userMsg("question"),
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "prior reasoning", signature: "" },
+          { type: "text", text: "prior answer" },
+        ],
+      },
+      userMsg("follow-up"),
+    ]);
+
+    const sent = lastCreateParams!.messages as Array<Record<string, unknown>>;
+    const assistantTurn = sent.find((m) => m.role === "assistant");
+    expect(assistantTurn).toEqual({
+      role: "assistant",
+      content: "prior answer",
+      reasoning_content: "prior reasoning",
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/providers/minimax/client.ts
+++ b/assistant/src/providers/minimax/client.ts
@@ -101,6 +101,15 @@ export class MinimaxProvider extends OpenAIChatCompletionsProvider {
       providerName: "minimax",
       providerLabel: "MiniMax",
       streamTimeoutMs: options.streamTimeoutMs,
+      // Without reasoning_split, MiniMax embeds reasoning in `content`
+      // wrapped in <think>...</think> tags (and also mirrors it into
+      // reasoning deltas), so raw tags leak into user-visible text. With it,
+      // reasoning arrives only via `reasoning_content`/`reasoning_details`,
+      // which the base provider already parses into thinking blocks.
+      extraCreateParams: { reasoning_split: true },
+      // MiniMax models reason between tool calls (interleaved thinking) and
+      // expect prior-turn reasoning replayed on multi-turn requests.
+      assistantReasoningField: "reasoning_content",
     });
   }
 }


### PR DESCRIPTION
## Problem

Users on the MiniMax M3 profile see the model's reasoning rendered twice in every response: once as a proper collapsed "Thinking" block, and again as raw `<think>...</think>` markup in the visible assistant text.

Root cause (from user feedback-bundle logs): MiniMax's OpenAI-compatible endpoint, without the `reasoning_split` parameter, embeds reasoning in the `content` stream wrapped in `<think>` tags **and** mirrors the same reasoning into reasoning deltas. Our generic chat-completions handler turns the delta copy into a thinking block, but the minimax adapter never enabled `parseThinkTags`, so the tagged copy streamed through as plain `assistant_text_delta`s and persisted as a text block. Captured conversations show every assistant message carrying both a `thinking` block and an identical `<think>`-tagged text block.

(Per-profile `thinking`/`effort` config can't help here — `minimax` is not in `EFFORT_SUPPORTED_PROVIDERS`/`THINKING_AWARE_PROVIDERS`, so the retry layer strips those before the wire.)

## Fix

- Send `reasoning_split: true` ([MiniMax docs](https://platform.minimax.io/docs/api-reference/text-openai-api)) so reasoning arrives only via `reasoning_content`/`reasoning_details`, which the base provider already parses into thinking blocks. Content stays clean — nothing to leak.
- Set `assistantReasoningField: "reasoning_content"` so prior-turn reasoning is replayed on multi-turn requests (MiniMax models reason between tool calls and expect it back), matching the Fireworks adapter. Previously the reasoning was only "replayed" by accident, as part of the leaked text block.

Deliberately **not** enabling `parseThinkTags` instead: with both wire channels active, the tag parser and the reasoning-delta handler would each append to the thinking accumulator, interleaving/duplicating the thinking block.

## Notes for review

- Risk: MiniMax must accept `reasoning_split` on both `api.minimax.io` and the `api.minimaxi.com` fallback; it is documented API surface, but worth a smoke test with a real key before release.
- Already-persisted conversations keep their `<think>`-tagged text blocks (they replay into history and may nudge the model to imitate the format in its visible answer). If that proves noisy in practice, a display-time strip or cleanup can follow in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)