### PR TITLE
feat(cli): pre-flight checks and completion polling for vellum upgrade

### DIFF
--- a/cli/src/__tests__/platform-client.test.ts
+++ b/cli/src/__tests__/platform-client.test.ts
@@ -9,8 +9,12 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { mock } from "bun:test";
+
 import {
   clearPlatformToken,
+  fetchAssistantDetail,
+  fetchUpgradeInProgress,
   getPlatformUrl,
   readPlatformToken,
   savePlatformToken,
@@ -200,5 +204,108 @@ describe("getPlatformUrl resolution order", () => {
   test("trims whitespace from VELLUM_PLATFORM_URL", () => {
     process.env.VELLUM_PLATFORM_URL = "  https://trimmed.vellum.ai  ";
     expect(getPlatformUrl()).toBe("https://trimmed.vellum.ai");
+  });
+});
+
+describe("fetchAssistantDetail / fetchUpgradeInProgress", () => {
+  // vak_ token → authHeaders skips the org-ID fetch, so the single mocked
+  // fetch call is the endpoint under test.
+  const TOKEN = "vak_test_token";
+  const ASSISTANT_ID = "11111111-2222-3333-4444-555555555555";
+  const PLATFORM_URL = "https://platform.test";
+
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function mockFetchJson(body: unknown, status = 200) {
+    const fetchMock = mock(
+      async (_url: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(JSON.stringify(body), { status }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+    return fetchMock;
+  }
+
+  function mockFetchNetworkError() {
+    globalThis.fetch = mock(async () => {
+      throw new TypeError("fetch failed");
+    }) as unknown as typeof globalThis.fetch;
+  }
+
+  test("fetchAssistantDetail maps fields", async () => {
+    const fetchMock = mockFetchJson({
+      current_release_version: "0.7.0",
+      release_channel: "preview",
+    });
+    const detail = await fetchAssistantDetail(TOKEN, ASSISTANT_ID, PLATFORM_URL);
+    expect(detail).toEqual({
+      currentReleaseVersion: "0.7.0",
+      releaseChannel: "preview",
+    });
+    const url = String(fetchMock.mock.calls[0][0]);
+    expect(url).toBe(`${PLATFORM_URL}/v1/assistants/${ASSISTANT_ID}/`);
+  });
+
+  test("fetchAssistantDetail defaults missing fields", async () => {
+    mockFetchJson({});
+    const detail = await fetchAssistantDetail(TOKEN, ASSISTANT_ID, PLATFORM_URL);
+    expect(detail).toEqual({
+      currentReleaseVersion: null,
+      releaseChannel: "stable",
+    });
+  });
+
+  test("fetchAssistantDetail returns null on non-OK", async () => {
+    mockFetchJson({ detail: "not found" }, 404);
+    expect(
+      await fetchAssistantDetail(TOKEN, ASSISTANT_ID, PLATFORM_URL),
+    ).toBeNull();
+  });
+
+  test("fetchAssistantDetail returns null on network error", async () => {
+    mockFetchNetworkError();
+    expect(
+      await fetchAssistantDetail(TOKEN, ASSISTANT_ID, PLATFORM_URL),
+    ).toBeNull();
+  });
+
+  test("fetchUpgradeInProgress returns the boolean", async () => {
+    const fetchMock = mockFetchJson({ in_progress: true });
+    expect(
+      await fetchUpgradeInProgress(TOKEN, ASSISTANT_ID, PLATFORM_URL),
+    ).toBe(true);
+    const url = String(fetchMock.mock.calls[0][0]);
+    expect(url).toBe(
+      `${PLATFORM_URL}/v1/assistants/${ASSISTANT_ID}/upgrade-status/`,
+    );
+
+    mockFetchJson({ in_progress: false });
+    expect(
+      await fetchUpgradeInProgress(TOKEN, ASSISTANT_ID, PLATFORM_URL),
+    ).toBe(false);
+  });
+
+  test("fetchUpgradeInProgress returns null on 404 (older platform)", async () => {
+    mockFetchJson({ detail: "not found" }, 404);
+    expect(
+      await fetchUpgradeInProgress(TOKEN, ASSISTANT_ID, PLATFORM_URL),
+    ).toBeNull();
+  });
+
+  test("fetchUpgradeInProgress returns null on network error", async () => {
+    mockFetchNetworkError();
+    expect(
+      await fetchUpgradeInProgress(TOKEN, ASSISTANT_ID, PLATFORM_URL),
+    ).toBeNull();
+  });
+
+  test("fetchUpgradeInProgress returns null on a malformed body", async () => {
+    mockFetchJson({ something_else: 1 });
+    expect(
+      await fetchUpgradeInProgress(TOKEN, ASSISTANT_ID, PLATFORM_URL),
+    ).toBeNull();
   });
 });

--- a/cli/src/__tests__/platform-releases.test.ts
+++ b/cli/src/__tests__/platform-releases.test.ts
@@ -56,6 +56,13 @@ describe("fetchReleases", () => {
     expect(url).toContain("limit=100");
   });
 
+  test("uses the platformUrl override over the resolved default", async () => {
+    const fetchMock = mockFetchJson([RELEASE]);
+    await fetchReleases({ platformUrl: "https://other-platform.test" });
+    const url = String(fetchMock.mock.calls[0][0]);
+    expect(url).toContain("https://other-platform.test/v1/releases/");
+  });
+
   test("returns null on non-OK response", async () => {
     mockFetchJson({ detail: "nope" }, 500);
     expect(await fetchReleases()).toBeNull();

--- a/cli/src/__tests__/platform-releases.test.ts
+++ b/cli/src/__tests__/platform-releases.test.ts
@@ -45,6 +45,7 @@ describe("fetchReleases", () => {
     expect(releases).toEqual([RELEASE]);
     const url = String(fetchMock.mock.calls[0][0]);
     expect(url).toContain("/v1/releases/?stable=true");
+    expect(url).toContain("limit=100");
   });
 
   test("passes the channel param when given", async () => {
@@ -52,6 +53,7 @@ describe("fetchReleases", () => {
     await fetchReleases({ channel: "preview" });
     const url = String(fetchMock.mock.calls[0][0]);
     expect(url).toContain("/v1/releases/?channel=preview");
+    expect(url).toContain("limit=100");
   });
 
   test("returns null on non-OK response", async () => {

--- a/cli/src/__tests__/platform-releases.test.ts
+++ b/cli/src/__tests__/platform-releases.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  fetchReleases,
+  resolveImageRefsDetailed,
+} from "../lib/platform-releases.js";
+
+const originalFetch = globalThis.fetch;
+
+function mockFetchJson(body: unknown, status = 200) {
+  const fetchMock = mock(
+    async (_url: RequestInfo | URL, _init?: RequestInit) =>
+      new Response(JSON.stringify(body), { status }),
+  );
+  globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+  return fetchMock;
+}
+
+function mockFetchError() {
+  globalThis.fetch = mock(async () => {
+    throw new TypeError("fetch failed");
+  }) as unknown as typeof globalThis.fetch;
+}
+
+beforeEach(() => {
+  process.env.VELLUM_PLATFORM_URL = "https://platform.test";
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  delete process.env.VELLUM_PLATFORM_URL;
+});
+
+const RELEASE = {
+  version: "0.7.0",
+  assistant_image_ref: "gcr.io/vellum/assistant@sha256:aaa",
+  gateway_image_ref: "gcr.io/vellum/gateway@sha256:bbb",
+  credential_executor_image_ref: "gcr.io/vellum/ces@sha256:ccc",
+};
+
+describe("fetchReleases", () => {
+  test("defaults to stable=true and returns the list", async () => {
+    const fetchMock = mockFetchJson([RELEASE]);
+    const releases = await fetchReleases();
+    expect(releases).toEqual([RELEASE]);
+    const url = String(fetchMock.mock.calls[0][0]);
+    expect(url).toContain("/v1/releases/?stable=true");
+  });
+
+  test("passes the channel param when given", async () => {
+    const fetchMock = mockFetchJson([RELEASE]);
+    await fetchReleases({ channel: "preview" });
+    const url = String(fetchMock.mock.calls[0][0]);
+    expect(url).toContain("/v1/releases/?channel=preview");
+  });
+
+  test("returns null on non-OK response", async () => {
+    mockFetchJson({ detail: "nope" }, 500);
+    expect(await fetchReleases()).toBeNull();
+  });
+
+  test("returns null on network error", async () => {
+    mockFetchError();
+    expect(await fetchReleases()).toBeNull();
+  });
+});
+
+describe("resolveImageRefsDetailed", () => {
+  test("returns platform refs when the version is found", async () => {
+    mockFetchJson([RELEASE]);
+    const result = await resolveImageRefsDetailed("v0.7.0");
+    expect(result.status).toBe("platform");
+    if (result.status === "platform") {
+      expect(result.imageTags.assistant).toBe(RELEASE.assistant_image_ref);
+      expect(result.imageTags.gateway).toBe(RELEASE.gateway_image_ref);
+    }
+  });
+
+  test("falls back to DockerHub for a null credential-executor ref", async () => {
+    mockFetchJson([{ ...RELEASE, credential_executor_image_ref: null }]);
+    const result = await resolveImageRefsDetailed("0.7.0");
+    expect(result.status).toBe("platform");
+    if (result.status === "platform") {
+      expect(result.imageTags["credential-executor"]).toContain(":0.7.0");
+    }
+  });
+
+  test("returns version-not-found when the platform list lacks the version", async () => {
+    mockFetchJson([RELEASE]);
+    const result = await resolveImageRefsDetailed("v9.9.9");
+    expect(result.status).toBe("version-not-found");
+  });
+
+  test("returns dockerhub-fallback when the platform is unreachable", async () => {
+    mockFetchError();
+    const result = await resolveImageRefsDetailed("v0.7.0");
+    expect(result.status).toBe("dockerhub-fallback");
+    if (result.status === "dockerhub-fallback") {
+      expect(result.imageTags.assistant).toContain(":v0.7.0");
+    }
+  });
+
+  test("returns dockerhub-fallback when required refs are missing", async () => {
+    mockFetchJson([{ ...RELEASE, assistant_image_ref: null }]);
+    const result = await resolveImageRefsDetailed("0.7.0");
+    expect(result.status).toBe("dockerhub-fallback");
+  });
+});

--- a/cli/src/__tests__/upgrade-preflight.test.ts
+++ b/cli/src/__tests__/upgrade-preflight.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  evaluateUpgradePoll,
+  resolveUpgradeTarget,
+} from "../lib/upgrade-preflight.js";
+
+const RELEASES = [
+  { version: "0.8.0", is_stable: false },
+  { version: "0.7.0" },
+  { version: "0.6.0" },
+];
+
+describe("resolveUpgradeTarget", () => {
+  test("explicit version present in releases resolves ok", () => {
+    const result = resolveUpgradeTarget({
+      explicitVersion: "v0.7.0",
+      releases: RELEASES,
+      currentVersion: "0.6.0",
+    });
+    expect(result.kind).toBe("ok");
+    expect(result.target).toBe("v0.7.0");
+    expect(result.isNoOp).toBe(false);
+    expect(result.isDowngrade).toBe(false);
+  });
+
+  test("explicit version absent from releases is version-not-found", () => {
+    const result = resolveUpgradeTarget({
+      explicitVersion: "v9.9.9",
+      releases: RELEASES,
+      currentVersion: "0.6.0",
+    });
+    expect(result.kind).toBe("version-not-found");
+    expect(result.target).toBeNull();
+  });
+
+  test("explicit version is trusted when releases are unavailable", () => {
+    const result = resolveUpgradeTarget({
+      explicitVersion: "v0.7.0",
+      releases: null,
+      currentVersion: "0.6.0",
+    });
+    expect(result.kind).toBe("ok");
+    expect(result.target).toBe("v0.7.0");
+  });
+
+  test("default target skips non-stable heads", () => {
+    const result = resolveUpgradeTarget({
+      explicitVersion: null,
+      releases: RELEASES,
+      currentVersion: "0.6.0",
+    });
+    expect(result.kind).toBe("ok");
+    expect(result.target).toBe("0.7.0");
+  });
+
+  test("default target falls back to first release when none are stable", () => {
+    const result = resolveUpgradeTarget({
+      explicitVersion: null,
+      releases: [{ version: "0.8.0", is_stable: false }],
+      currentVersion: "0.6.0",
+    });
+    expect(result.target).toBe("0.8.0");
+  });
+
+  test("no explicit version with unreachable releases is no-releases", () => {
+    const result = resolveUpgradeTarget({
+      explicitVersion: null,
+      releases: null,
+      currentVersion: "0.6.0",
+    });
+    expect(result.kind).toBe("no-releases");
+    expect(result.target).toBeNull();
+  });
+
+  test("no explicit version with empty releases is no-releases", () => {
+    const result = resolveUpgradeTarget({
+      explicitVersion: null,
+      releases: [],
+      currentVersion: "0.6.0",
+    });
+    expect(result.kind).toBe("no-releases");
+  });
+
+  test("detects no-op across v prefix", () => {
+    const result = resolveUpgradeTarget({
+      explicitVersion: "v0.7.0",
+      releases: RELEASES,
+      currentVersion: "0.7.0",
+    });
+    expect(result.isNoOp).toBe(true);
+    expect(result.isDowngrade).toBe(false);
+  });
+
+  test("detects downgrade", () => {
+    const result = resolveUpgradeTarget({
+      explicitVersion: "v0.6.0",
+      releases: RELEASES,
+      currentVersion: "0.7.0",
+    });
+    expect(result.isDowngrade).toBe(true);
+    expect(result.isNoOp).toBe(false);
+  });
+
+  test("unknown current version yields no flags", () => {
+    const result = resolveUpgradeTarget({
+      explicitVersion: "v0.7.0",
+      releases: RELEASES,
+      currentVersion: undefined,
+    });
+    expect(result.comparison).toBeNull();
+    expect(result.isNoOp).toBe(false);
+    expect(result.isDowngrade).toBe(false);
+  });
+});
+
+describe("evaluateUpgradePoll", () => {
+  test("known target completes on version match", () => {
+    expect(
+      evaluateUpgradePoll({
+        targetVersion: "v0.7.0",
+        initialVersion: "0.6.0",
+        observedVersion: "0.7.0",
+        inProgress: null,
+        sawInProgress: false,
+      }),
+    ).toBe("complete");
+  });
+
+  test("known target pends until the version matches", () => {
+    expect(
+      evaluateUpgradePoll({
+        targetVersion: "0.7.0",
+        initialVersion: "0.6.0",
+        observedVersion: "0.6.0",
+        inProgress: false,
+        sawInProgress: false,
+      }),
+    ).toBe("pending");
+  });
+
+  test("unknown target completes when the in-progress lock releases", () => {
+    expect(
+      evaluateUpgradePoll({
+        targetVersion: null,
+        initialVersion: "0.6.0",
+        observedVersion: "0.6.0",
+        inProgress: false,
+        sawInProgress: true,
+      }),
+    ).toBe("complete");
+  });
+
+  test("unknown target pends while the lock was never observed", () => {
+    expect(
+      evaluateUpgradePoll({
+        targetVersion: null,
+        initialVersion: "0.6.0",
+        observedVersion: "0.6.0",
+        inProgress: false,
+        sawInProgress: false,
+      }),
+    ).toBe("pending");
+  });
+
+  test("unknown target without upgrade-status completes on version change", () => {
+    expect(
+      evaluateUpgradePoll({
+        targetVersion: null,
+        initialVersion: "0.6.0",
+        observedVersion: "0.7.0",
+        inProgress: null,
+        sawInProgress: false,
+      }),
+    ).toBe("complete");
+  });
+
+  test("unknown target without upgrade-status pends while the version is unchanged", () => {
+    expect(
+      evaluateUpgradePoll({
+        targetVersion: null,
+        initialVersion: "0.6.0",
+        observedVersion: "v0.6.0",
+        inProgress: null,
+        sawInProgress: false,
+      }),
+    ).toBe("pending");
+  });
+});

--- a/cli/src/__tests__/upgrade-preflight.test.ts
+++ b/cli/src/__tests__/upgrade-preflight.test.ts
@@ -175,6 +175,20 @@ describe("evaluateUpgradePoll", () => {
     ).toBe("complete");
   });
 
+  test("unknown target completes on version change even when the lock was never observed", () => {
+    // Upgrade finished before the first poll: in_progress already false,
+    // sawInProgress never set — the version change alone must complete.
+    expect(
+      evaluateUpgradePoll({
+        targetVersion: null,
+        initialVersion: "0.6.0",
+        observedVersion: "0.7.0",
+        inProgress: false,
+        sawInProgress: false,
+      }),
+    ).toBe("complete");
+  });
+
   test("unknown target without upgrade-status pends while the version is unchanged", () => {
     expect(
       evaluateUpgradePoll({

--- a/cli/src/__tests__/version-compat.test.ts
+++ b/cli/src/__tests__/version-compat.test.ts
@@ -4,6 +4,8 @@ import {
   parseVersion,
   compareVersions,
   isVersionCompatible,
+  stripVersionPrefix,
+  versionsEqual,
 } from "../lib/version-compat.js";
 
 describe("parseVersion", () => {
@@ -202,5 +204,34 @@ describe("isVersionCompatible", () => {
 
   test("returns false for unparseable input", () => {
     expect(isVersionCompatible("bad", "1.0.0")).toBe(false);
+  });
+});
+
+describe("stripVersionPrefix", () => {
+  test("strips v prefix", () => {
+    expect(stripVersionPrefix("v0.7.0")).toBe("0.7.0");
+  });
+
+  test("strips V prefix", () => {
+    expect(stripVersionPrefix("V0.7.0")).toBe("0.7.0");
+  });
+
+  test("leaves unprefixed versions unchanged", () => {
+    expect(stripVersionPrefix("0.7.0")).toBe("0.7.0");
+  });
+});
+
+describe("versionsEqual", () => {
+  test("equal across v prefix", () => {
+    expect(versionsEqual("v0.7.0", "0.7.0")).toBe(true);
+  });
+
+  test("different versions are not equal", () => {
+    expect(versionsEqual("0.7.0", "0.7.1")).toBe(false);
+  });
+
+  test("unparseable falls back to prefix-stripped string equality", () => {
+    expect(versionsEqual("vweird-build", "weird-build")).toBe(true);
+    expect(versionsEqual("weird-build", "other-build")).toBe(false);
   });
 });

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -864,7 +864,12 @@ async function upgradePlatform(
     health.version ?? assistantDetail?.currentReleaseVersion ?? undefined;
 
   const releaseChannel = assistantDetail?.releaseChannel ?? "stable";
-  const releases = await fetchReleases({ channel: releaseChannel });
+  // Target the same platform as the detail/health/POST calls — the entry's
+  // platform may differ from the active lockfile default.
+  const releases = await fetchReleases({
+    channel: releaseChannel,
+    platformUrl: entry.runtimeUrl,
+  });
 
   const resolution = resolveUpgradeTarget({
     explicitVersion: version,

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -1114,6 +1114,7 @@ async function upgradeFinalize(
  */
 async function resolveLatestAndMaybeSelfUpdate(
   name: string | null,
+  flags: { noWait: boolean; force: boolean },
 ): Promise<string> {
   console.log("🔍 Fetching latest stable release...");
   const latestVersion = await fetchLatestStableVersion();
@@ -1156,10 +1157,13 @@ async function resolveLatestAndMaybeSelfUpdate(
     console.log(`✅ CLI updated to ${latestTag}\n`);
 
     // Re-exec with the updated CLI. Pass --version instead of --latest
-    // to avoid re-fetching and to prevent infinite re-exec loops.
+    // to avoid re-fetching and to prevent infinite re-exec loops; forward
+    // the other flags so the re-exec keeps the requested semantics.
     const reexecArgs = ["upgrade"];
     if (name) reexecArgs.push(name);
     reexecArgs.push("--version", latestTag);
+    if (flags.noWait) reexecArgs.push("--no-wait");
+    if (flags.force) reexecArgs.push("--force");
 
     console.log(`🚀 Re-running upgrade with updated CLI...\n`);
     const reexecResult = spawnSync("vellum", reexecArgs, {
@@ -1195,7 +1199,10 @@ export async function upgrade(): Promise<void> {
   // as the explicit target for the rest of the upgrade flow.
   let effectiveVersion = version;
   if (latest) {
-    const latestTag = await resolveLatestAndMaybeSelfUpdate(name);
+    const latestTag = await resolveLatestAndMaybeSelfUpdate(name, {
+      noWait,
+      force,
+    });
     effectiveVersion = latestTag;
   }
 

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -19,13 +19,21 @@ import {
 } from "../lib/docker";
 import {
   fetchLatestStableVersion,
-  resolveImageRefs,
+  fetchReleases,
+  resolveImageRefsDetailed,
 } from "../lib/platform-releases";
 import {
   authHeaders,
+  fetchAssistantDetail,
+  fetchUpgradeInProgress,
   getPlatformUrl,
   readPlatformToken,
 } from "../lib/platform-client";
+import { checkManagedHealth } from "../lib/health-check.js";
+import {
+  evaluateUpgradePoll,
+  resolveUpgradeTarget,
+} from "../lib/upgrade-preflight.js";
 import {
   createBackup,
   pruneOldBackups,
@@ -46,7 +54,11 @@ import {
   UPGRADE_PROGRESS,
   waitForReady,
 } from "../lib/upgrade-lifecycle.js";
-import { compareVersions } from "../lib/version-compat.js";
+import {
+  compareVersions,
+  stripVersionPrefix,
+  versionsEqual,
+} from "../lib/version-compat.js";
 import { loopbackSafeFetch } from "../lib/loopback-fetch.js";
 
 interface UpgradeArgs {
@@ -55,6 +67,8 @@ interface UpgradeArgs {
   latest: boolean;
   prepare: boolean;
   finalize: boolean;
+  noWait: boolean;
+  force: boolean;
 }
 
 function parseArgs(): UpgradeArgs {
@@ -64,6 +78,8 @@ function parseArgs(): UpgradeArgs {
   let latest = false;
   let prepare = false;
   let finalize = false;
+  let noWait = false;
+  let force = false;
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -90,6 +106,12 @@ function parseArgs(): UpgradeArgs {
       );
       console.log(
         "  --finalize           Run post-upgrade steps only (broadcast complete, workspace commit)",
+      );
+      console.log(
+        "  --no-wait            Platform assistants only: return after the upgrade request is accepted instead of waiting for completion",
+      );
+      console.log(
+        "  --force              Docker assistants only: reinstall even when already on the target version",
       );
       console.log("");
       console.log("Examples:");
@@ -121,6 +143,10 @@ function parseArgs(): UpgradeArgs {
       prepare = true;
     } else if (arg === "--finalize") {
       finalize = true;
+    } else if (arg === "--no-wait") {
+      noWait = true;
+    } else if (arg === "--force") {
+      force = true;
     } else if (!arg.startsWith("-")) {
       name = arg;
     } else {
@@ -142,7 +168,18 @@ function parseArgs(): UpgradeArgs {
     process.exit(1);
   }
 
-  return { name, version, latest, prepare, finalize };
+  if (noWait && (prepare || finalize)) {
+    console.error(
+      "Error: --no-wait cannot be combined with --prepare or --finalize.",
+    );
+    emitCliError(
+      "UNKNOWN",
+      "--no-wait cannot be combined with --prepare or --finalize",
+    );
+    process.exit(1);
+  }
+
+  return { name, version, latest, prepare, finalize, noWait, force };
 }
 
 /**
@@ -190,6 +227,7 @@ function resolveTargetAssistant(nameArg: string | null): AssistantEntry {
 async function upgradeDocker(
   entry: AssistantEntry,
   version: string | null,
+  force: boolean,
 ): Promise<void> {
   const instanceName = entry.assistantId;
   const res = dockerResourceNames(instanceName);
@@ -197,35 +235,10 @@ async function upgradeDocker(
   const versionTag =
     version ?? (cliPkg.version ? `v${cliPkg.version}` : "latest");
 
-  // Fetch the current running version from the health endpoint.
-  // This is used for logging, commit messages, and version-direction guards.
+  // Capture current migration state and running version for rollback targeting
+  // and version guards. Must happen while the daemon is still running (before
+  // containers are stopped).
   let currentVersion: string | undefined;
-
-  console.log("🔍 Resolving image references...");
-  const { imageTags } = await resolveImageRefs(versionTag);
-
-  console.log(
-    `🔄 Upgrading Docker assistant '${instanceName}' to ${versionTag}...\n`,
-  );
-
-  // Capture rollback state from existing containers BEFORE pulling new
-  // images or stopping anything.  captureImageRefs uses the immutable
-  // image digest ({{.Image}}), but capturing first keeps the intent
-  // explicit and avoids relying on container-inspect ordering subtleties.
-  console.log("📸 Capturing current image references for rollback...");
-  const previousImageRefs = await captureImageRefs(res);
-  if (previousImageRefs) {
-    console.log(
-      `   Captured refs for ${Object.keys(previousImageRefs).length} service(s)\n`,
-    );
-  } else {
-    console.log(
-      "   Could not capture all container refs (fresh install or partial deployment)\n",
-    );
-  }
-
-  // Capture current migration state and running version for rollback targeting.
-  // Must happen while daemon is still running (before containers are stopped).
   let preMigrationState: {
     dbVersion?: number;
     lastWorkspaceMigrationId?: string;
@@ -264,6 +277,53 @@ async function upgradeDocker(
       emitCliError("VERSION_DIRECTION", msg);
       process.exit(1);
     }
+  }
+
+  // No-op guard: skip the full stop/start cycle (real downtime) when already
+  // on the target version. --force allows an intentional reinstall/repair.
+  if (currentVersion && versionsEqual(versionTag, currentVersion)) {
+    if (!force) {
+      console.log(
+        `✅ Already on ${versionTag}. Nothing to do. Pass --force to reinstall.`,
+      );
+      return;
+    }
+    console.log(`🔁 Reinstalling ${versionTag} (--force)...\n`);
+  }
+
+  console.log("🔍 Resolving image references...");
+  const resolution = await resolveImageRefsDetailed(versionTag);
+  if (resolution.status === "version-not-found") {
+    const msg = `Version ${versionTag} not found in platform releases.`;
+    console.error(msg);
+    emitCliError("MISSING_VERSION", msg);
+    process.exit(1);
+  }
+  if (resolution.status === "dockerhub-fallback") {
+    console.warn(
+      `⚠️  Platform unreachable — falling back to DockerHub tags for ${versionTag}.`,
+    );
+  }
+  const { imageTags } = resolution;
+
+  console.log(
+    `🔄 Upgrading Docker assistant '${instanceName}' to ${versionTag}...\n`,
+  );
+
+  // Capture rollback state from existing containers BEFORE pulling new
+  // images or stopping anything.  captureImageRefs uses the immutable
+  // image digest ({{.Image}}), but capturing first keeps the intent
+  // explicit and avoids relying on container-inspect ordering subtleties.
+  console.log("📸 Capturing current image references for rollback...");
+  const previousImageRefs = await captureImageRefs(res);
+  if (previousImageRefs) {
+    console.log(
+      `   Captured refs for ${Object.keys(previousImageRefs).length} service(s)\n`,
+    );
+  } else {
+    console.log(
+      "   Could not capture all container refs (fresh install or partial deployment)\n",
+    );
   }
 
   // Persist rollback state to lockfile BEFORE any destructive changes.
@@ -669,9 +729,112 @@ interface UpgradeApiResponse {
   version: string | null;
 }
 
+const PLATFORM_POLL_INTERVAL_MS = 3_000;
+const PLATFORM_POLL_HEARTBEAT_MS = 30_000;
+const PLATFORM_HEALTH_CONFIRM_TIMEOUT_MS = 120_000;
+const PLATFORM_HEALTH_CONFIRM_INTERVAL_MS = 5_000;
+
+const UPGRADE_IN_PROGRESS_MSG =
+  "An upgrade is already in progress for this assistant. Check `vellum ps`.";
+
+function platformUpgradeTimeoutMs(): number {
+  const override = process.env.VELLUM_PLATFORM_UPGRADE_TIMEOUT_MS;
+  if (override) {
+    const parsed = parseInt(override, 10);
+    if (!isNaN(parsed) && parsed > 0) return parsed;
+  }
+  return 600_000;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * Poll the platform until the upgrade completes, then confirm health.
+ * Mirrors the web UI's Software Updates flow (poll the DB-backed
+ * `current_release_version` rather than the gateway, which bounces while
+ * the service group restarts).
+ */
+async function waitForPlatformUpgrade(
+  entry: AssistantEntry,
+  token: string,
+  pollTarget: string | null,
+  initialVersion: string | null,
+): Promise<void> {
+  const timeoutMs = platformUpgradeTimeoutMs();
+  const start = Date.now();
+  let sawInProgress = false;
+  let lastHeartbeat = start;
+  let observedVersion: string | null = initialVersion;
+
+  console.log(
+    pollTarget
+      ? `⏳ Waiting for the upgrade to ${pollTarget} to complete...`
+      : "⏳ Waiting for the upgrade to complete...",
+  );
+
+  while (Date.now() - start < timeoutMs) {
+    await sleep(PLATFORM_POLL_INTERVAL_MS);
+
+    // The in-progress lock is only needed when we don't know the target
+    // version (server resolved "latest" without reporting it).
+    const [detail, inProgress] = await Promise.all([
+      fetchAssistantDetail(token, entry.assistantId, entry.runtimeUrl),
+      pollTarget
+        ? Promise.resolve(null)
+        : fetchUpgradeInProgress(token, entry.assistantId, entry.runtimeUrl),
+    ]);
+    if (detail) observedVersion = detail.currentReleaseVersion;
+    if (inProgress === true) sawInProgress = true;
+
+    const verdict = evaluateUpgradePoll({
+      targetVersion: pollTarget,
+      initialVersion,
+      observedVersion,
+      inProgress,
+      sawInProgress,
+    });
+
+    if (verdict === "complete") {
+      const finalVersion = observedVersion ?? pollTarget ?? "unknown";
+      const healthDeadline = Date.now() + PLATFORM_HEALTH_CONFIRM_TIMEOUT_MS;
+      while (Date.now() < healthDeadline) {
+        const health = await checkManagedHealth(
+          entry.runtimeUrl || getPlatformUrl(),
+          entry.assistantId,
+        );
+        if (health.status === "healthy") {
+          console.log(
+            `✅ Upgraded to ${finalVersion} — assistant is healthy.`,
+          );
+          return;
+        }
+        await sleep(PLATFORM_HEALTH_CONFIRM_INTERVAL_MS);
+      }
+      console.warn(
+        `⚠️  Upgraded to ${finalVersion}, but the health check did not confirm. Check \`vellum ps\`.`,
+      );
+      return;
+    }
+
+    if (Date.now() - lastHeartbeat >= PLATFORM_POLL_HEARTBEAT_MS) {
+      const elapsedSec = Math.round((Date.now() - start) / 1000);
+      console.log(`   Still upgrading... (${elapsedSec}s elapsed)`);
+      lastHeartbeat = Date.now();
+    }
+  }
+
+  const timeoutMin = Math.round(timeoutMs / 60_000);
+  console.warn(
+    `⚠️  Upgrade request was accepted but completion was not confirmed within ${timeoutMin} minutes. The platform may still be working — check \`vellum ps\` or the web settings page.`,
+  );
+}
+
 async function upgradePlatform(
   entry: AssistantEntry,
   version: string | null,
+  wait: boolean,
 ): Promise<void> {
   console.log(
     `🔄 Upgrading platform-hosted assistant '${entry.assistantId}'...\n`,
@@ -686,12 +849,73 @@ async function upgradePlatform(
     process.exit(1);
   }
 
+  // Pre-flight (all best-effort except an explicit version that the
+  // platform doesn't know about): resolve the target, detect no-ops and
+  // downgrades before POSTing, and bail if an upgrade is already running.
+  const [assistantDetail, health] = await Promise.all([
+    fetchAssistantDetail(token, entry.assistantId, entry.runtimeUrl),
+    checkManagedHealth(
+      entry.runtimeUrl || getPlatformUrl(),
+      entry.assistantId,
+    ),
+  ]);
+  // Health probe first, DB-backed field as the sleeping-assistant fallback.
+  const currentVersion =
+    health.version ?? assistantDetail?.currentReleaseVersion ?? undefined;
+
+  const releaseChannel = assistantDetail?.releaseChannel ?? "stable";
+  const releases = await fetchReleases({ channel: releaseChannel });
+
+  const resolution = resolveUpgradeTarget({
+    explicitVersion: version,
+    releases,
+    currentVersion,
+  });
+
+  if (resolution.kind === "version-not-found") {
+    const msg = `Version ${version} not found in platform releases (channel: ${releaseChannel}).`;
+    console.error(msg);
+    emitCliError("MISSING_VERSION", msg);
+    process.exit(1);
+  }
+
+  if (resolution.isNoOp && resolution.target) {
+    console.log(`✅ Already on ${resolution.target}. Nothing to do.`);
+    return;
+  }
+
+  if (resolution.isDowngrade && resolution.target && currentVersion) {
+    const msg = `Cannot upgrade to an older version (${resolution.target} < ${currentVersion}). Use \`vellum rollback --version ${resolution.target}\` instead.`;
+    console.error(msg);
+    emitCliError("VERSION_DIRECTION", msg);
+    process.exit(1);
+  }
+
+  if (resolution.kind === "no-releases") {
+    console.warn(
+      "⚠️  Platform releases unavailable — requesting latest from server.",
+    );
+  }
+
+  const inProgress = await fetchUpgradeInProgress(
+    token,
+    entry.assistantId,
+    entry.runtimeUrl,
+  );
+  if (inProgress === true) {
+    console.error(UPGRADE_IN_PROGRESS_MSG);
+    emitCliError("PLATFORM_API_ERROR", UPGRADE_IN_PROGRESS_MSG);
+    process.exit(1);
+  }
+
+  if (currentVersion && resolution.target) {
+    console.log(`   ${currentVersion} → ${resolution.target}\n`);
+  }
+
   const headers = await authHeaders(token, entry.runtimeUrl);
 
-  const url = `${entry.runtimeUrl || getPlatformUrl()}/v1/assistants/upgrade/`;
-  const body: { assistant_id?: string; version?: string } = {
-    assistant_id: entry.assistantId,
-  };
+  const url = `${entry.runtimeUrl || getPlatformUrl()}/v1/assistants/${encodeURIComponent(entry.assistantId)}/upgrade/`;
+  const body: { version?: string } = {};
   if (version) {
     body.version = version;
   }
@@ -720,6 +944,13 @@ async function upgradePlatform(
     process.exit(1);
   }
 
+  if (response.status === 409) {
+    const text = await response.text();
+    console.error(UPGRADE_IN_PROGRESS_MSG);
+    emitCliError("PLATFORM_API_ERROR", UPGRADE_IN_PROGRESS_MSG, text);
+    process.exit(1);
+  }
+
   if (!response.ok) {
     const text = await response.text();
     console.error(
@@ -744,6 +975,13 @@ async function upgradePlatform(
 
   const result = (await response.json()) as UpgradeApiResponse;
 
+  // The server resolves "latest" itself; a no-op response means nothing was
+  // actually kicked off, so don't poll for a completion that will never come.
+  if (result.detail?.includes("Already on the latest")) {
+    console.warn(`⚠️  ${result.detail}`);
+    return;
+  }
+
   // NOTE: We intentionally do NOT broadcast a "complete" event here.
   // The platform API returning 200 only means "upgrade request accepted" —
   // the service group has not yet restarted with the new version.  The
@@ -755,6 +993,17 @@ async function upgradePlatform(
   if (result.version) {
     console.log(`   Version: ${result.version}`);
   }
+
+  if (!wait) {
+    return;
+  }
+
+  await waitForPlatformUpgrade(
+    entry,
+    token,
+    result.version ?? resolution.target,
+    currentVersion ?? null,
+  );
 }
 
 /**
@@ -893,7 +1142,7 @@ async function resolveLatestAndMaybeSelfUpdate(
     console.log(`🔄 Updating CLI to ${latestTag}...`);
     const installResult = spawnSync(
       "bun",
-      ["install", "-g", `vellum@${latestVersion}`],
+      ["install", "-g", `vellum@${stripVersionPrefix(latestVersion)}`],
       { stdio: "inherit" },
     );
     if (installResult.error || installResult.status !== 0) {
@@ -927,7 +1176,8 @@ async function resolveLatestAndMaybeSelfUpdate(
 }
 
 export async function upgrade(): Promise<void> {
-  const { name, version, latest, prepare, finalize } = parseArgs();
+  const { name, version, latest, prepare, finalize, noWait, force } =
+    parseArgs();
   const entry = resolveTargetAssistant(name);
 
   if (prepare) {
@@ -953,12 +1203,12 @@ export async function upgrade(): Promise<void> {
 
   try {
     if (cloud === "docker") {
-      await upgradeDocker(entry, effectiveVersion);
+      await upgradeDocker(entry, effectiveVersion, force);
       return;
     }
 
     if (cloud === "vellum") {
-      await upgradePlatform(entry, effectiveVersion);
+      await upgradePlatform(entry, effectiveVersion, !noWait);
       return;
     }
   } catch (err) {

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -601,6 +601,74 @@ export async function fetchPlatformAssistants(
   }
 }
 
+export interface PlatformAssistantDetail {
+  currentReleaseVersion: string | null;
+  releaseChannel: "stable" | "preview";
+}
+
+/**
+ * Fetch a single assistant's upgrade-relevant fields from
+ * `GET /v1/assistants/{id}/`. Returns null on any failure (best-effort
+ * pre-flight / polling helper — never throws).
+ */
+export async function fetchAssistantDetail(
+  token: string,
+  assistantId: string,
+  platformUrl?: string,
+): Promise<PlatformAssistantDetail | null> {
+  const resolvedUrl = platformUrl || getPlatformUrl();
+  const url = `${resolvedUrl}/v1/assistants/${encodeURIComponent(assistantId)}/`;
+
+  try {
+    const response = await loopbackSafeFetch(url, {
+      signal: AbortSignal.timeout(PLATFORM_FETCH_TIMEOUT_MS),
+      headers: await authHeaders(token, platformUrl),
+    });
+
+    if (!response.ok) return null;
+
+    const body = (await response.json()) as {
+      current_release_version?: string | null;
+      release_channel?: string;
+    };
+    return {
+      currentReleaseVersion: body.current_release_version ?? null,
+      releaseChannel: body.release_channel === "preview" ? "preview" : "stable",
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check whether the platform reports an upgrade in progress for the
+ * assistant via `GET /v1/assistants/{id}/upgrade-status/`. Returns null
+ * when the endpoint is unavailable (404 on older platforms, network
+ * error) so callers can skip the check. Never throws.
+ */
+export async function fetchUpgradeInProgress(
+  token: string,
+  assistantId: string,
+  platformUrl?: string,
+): Promise<boolean | null> {
+  const resolvedUrl = platformUrl || getPlatformUrl();
+  const url = `${resolvedUrl}/v1/assistants/${encodeURIComponent(assistantId)}/upgrade-status/`;
+
+  try {
+    const response = await loopbackSafeFetch(url, {
+      signal: AbortSignal.timeout(PLATFORM_FETCH_TIMEOUT_MS),
+      headers: await authHeaders(token, platformUrl),
+    });
+
+    if (!response.ok) return null;
+
+    const body = (await response.json()) as { in_progress?: boolean };
+    return typeof body.in_progress === "boolean" ? body.in_progress : null;
+  } catch {
+    return null;
+  }
+}
+
 export interface PlatformUser {
   id: string;
   email: string;

--- a/cli/src/lib/platform-releases.ts
+++ b/cli/src/lib/platform-releases.ts
@@ -18,6 +18,13 @@ export interface ReleaseListItem {
 }
 
 /**
+ * The endpoint defaults `limit` to 10, which is too few to validate an
+ * explicit --version against ("absent from the list" is treated as a hard
+ * error) — always request the documented maximum.
+ */
+const RELEASES_FETCH_LIMIT = 100;
+
+/**
  * Fetch the releases list from the platform API, optionally filtered by
  * channel (the `channel` param takes precedence over `stable` server-side).
  * Returns `null` when the platform is unreachable or responds non-OK —
@@ -28,9 +35,9 @@ export async function fetchReleases(opts?: {
 }): Promise<ReleaseListItem[] | null> {
   try {
     const platformUrl = getPlatformUrl();
-    const query = opts?.channel ? `channel=${opts.channel}` : "stable=true";
+    const filter = opts?.channel ? `channel=${opts.channel}` : "stable=true";
     const response = await loopbackSafeFetch(
-      `${platformUrl}/v1/releases/?${query}`,
+      `${platformUrl}/v1/releases/?${filter}&limit=${RELEASES_FETCH_LIMIT}`,
       { signal: AbortSignal.timeout(10_000) },
     );
     if (!response.ok) return null;

--- a/cli/src/lib/platform-releases.ts
+++ b/cli/src/lib/platform-releases.ts
@@ -27,14 +27,17 @@ const RELEASES_FETCH_LIMIT = 100;
 /**
  * Fetch the releases list from the platform API, optionally filtered by
  * channel (the `channel` param takes precedence over `stable` server-side).
+ * `platformUrl` overrides the lockfile/env-resolved default — pass the
+ * target assistant's platform URL when it may differ from the active one.
  * Returns `null` when the platform is unreachable or responds non-OK —
  * distinct from `[]` (platform answered, no releases).
  */
 export async function fetchReleases(opts?: {
   channel?: "stable" | "preview";
+  platformUrl?: string;
 }): Promise<ReleaseListItem[] | null> {
   try {
-    const platformUrl = getPlatformUrl();
+    const platformUrl = opts?.platformUrl || getPlatformUrl();
     const filter = opts?.channel ? `channel=${opts.channel}` : "stable=true";
     const response = await loopbackSafeFetch(
       `${platformUrl}/v1/releases/?${filter}&limit=${RELEASES_FETCH_LIMIT}`,

--- a/cli/src/lib/platform-releases.ts
+++ b/cli/src/lib/platform-releases.ts
@@ -2,10 +2,42 @@ import { getPlatformUrl } from "./platform-client.js";
 import { DOCKERHUB_IMAGES } from "./docker.js";
 import type { ServiceName } from "./docker.js";
 import { loopbackSafeFetch } from "./loopback-fetch.js";
+import { stripVersionPrefix } from "./version-compat.js";
 
 export interface ResolvedImageRefs {
   imageTags: Record<ServiceName, string>;
   source: "platform" | "dockerhub";
+}
+
+export interface ReleaseListItem {
+  version: string;
+  is_stable?: boolean;
+  assistant_image_ref?: string | null;
+  gateway_image_ref?: string | null;
+  credential_executor_image_ref?: string | null;
+}
+
+/**
+ * Fetch the releases list from the platform API, optionally filtered by
+ * channel (the `channel` param takes precedence over `stable` server-side).
+ * Returns `null` when the platform is unreachable or responds non-OK —
+ * distinct from `[]` (platform answered, no releases).
+ */
+export async function fetchReleases(opts?: {
+  channel?: "stable" | "preview";
+}): Promise<ReleaseListItem[] | null> {
+  try {
+    const platformUrl = getPlatformUrl();
+    const query = opts?.channel ? `channel=${opts.channel}` : "stable=true";
+    const response = await loopbackSafeFetch(
+      `${platformUrl}/v1/releases/?${query}`,
+      { signal: AbortSignal.timeout(10_000) },
+    );
+    if (!response.ok) return null;
+    return (await response.json()) as ReleaseListItem[];
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -14,130 +46,110 @@ export interface ResolvedImageRefs {
  * The releases endpoint returns entries ordered newest-first.
  */
 export async function fetchLatestStableVersion(): Promise<string | null> {
-  try {
-    const platformUrl = getPlatformUrl();
-    const response = await loopbackSafeFetch(`${platformUrl}/v1/releases/?stable=true`, {
-      signal: AbortSignal.timeout(10_000),
-    });
-    if (!response.ok) return null;
+  const releases = await fetchReleases();
+  return releases?.[0]?.version ?? null;
+}
 
-    const releases = (await response.json()) as Array<{
-      version?: string;
-    }>;
-    const first = releases[0];
-    return first?.version ?? null;
-  } catch {
-    return null;
+export type ImageRefResolution =
+  | { status: "platform"; imageTags: Record<ServiceName, string> }
+  | { status: "dockerhub-fallback"; imageTags: Record<ServiceName, string> }
+  | { status: "version-not-found" };
+
+function dockerhubImageTags(version: string): Record<ServiceName, string> {
+  return {
+    assistant: `${DOCKERHUB_IMAGES.assistant}:${version}`,
+    "credential-executor": `${DOCKERHUB_IMAGES["credential-executor"]}:${version}`,
+    gateway: `${DOCKERHUB_IMAGES.gateway}:${version}`,
+  };
+}
+
+/**
+ * Resolve image references for a given version, distinguishing why the
+ * platform refs were unavailable:
+ *
+ *   - `platform` — release found; GCR digest-based refs (credential-executor
+ *     falls back to DockerHub per-service when its ref is null).
+ *   - `dockerhub-fallback` — platform unreachable or responded non-OK;
+ *     tag-based DockerHub refs.
+ *   - `version-not-found` — the platform answered but the version is absent
+ *     from the releases list (likely a typo'd --version).
+ */
+export async function resolveImageRefsDetailed(
+  version: string,
+  log?: (msg: string) => void,
+): Promise<ImageRefResolution> {
+  log?.("Resolving image references...");
+
+  const releases = await fetchReleases();
+  if (releases === null) {
+    log?.("Platform unreachable — falling back to DockerHub tags");
+    return {
+      status: "dockerhub-fallback",
+      imageTags: dockerhubImageTags(version),
+    };
   }
+
+  const normalizedVersion = stripVersionPrefix(version);
+  const release = releases.find(
+    (r) => stripVersionPrefix(r.version ?? "") === normalizedVersion,
+  );
+
+  if (!release) {
+    log?.(`Version ${version} not found in platform releases`);
+    return { status: "version-not-found" };
+  }
+
+  const assistantImage = release.assistant_image_ref;
+  const gatewayImage = release.gateway_image_ref;
+  let credentialExecutorImage = release.credential_executor_image_ref;
+
+  // Assistant and gateway images are required; a release missing them is a
+  // platform data gap, not a user typo — fall back to DockerHub tags.
+  if (!assistantImage || !gatewayImage) {
+    log?.("Platform release missing required image refs");
+    return {
+      status: "dockerhub-fallback",
+      imageTags: dockerhubImageTags(version),
+    };
+  }
+
+  if (!credentialExecutorImage) {
+    credentialExecutorImage = `${DOCKERHUB_IMAGES["credential-executor"]}:${version}`;
+    log?.(
+      "credential-executor image not in platform release, using DockerHub fallback",
+    );
+  }
+
+  return {
+    status: "platform",
+    imageTags: {
+      assistant: assistantImage,
+      "credential-executor": credentialExecutorImage,
+      gateway: gatewayImage,
+    },
+  };
 }
 
 /**
  * Resolve image references for a given version.
  *
- * Tries the platform API first (returns GCR digest-based refs when available),
- * then falls back to DockerHub tag-based refs when the platform is unreachable
- * or the version is not found.
+ * Lenient wrapper around {@link resolveImageRefsDetailed}: maps
+ * `version-not-found` to the DockerHub fallback so existing callers
+ * (start flows, docker rollback) keep their permissive behavior. The
+ * upgrade command uses the detailed variant to fail fast on typos.
  */
 export async function resolveImageRefs(
   version: string,
   log?: (msg: string) => void,
 ): Promise<ResolvedImageRefs> {
-  log?.("Resolving image references...");
-
-  const platformRefs = await fetchPlatformImageRefs(version, log);
-  if (platformRefs) {
+  const resolution = await resolveImageRefsDetailed(version, log);
+  if (resolution.status === "platform") {
     log?.("Resolved image refs from platform API");
-    return {
-      imageTags: platformRefs.imageTags,
-      source: "platform",
-    };
+    return { imageTags: resolution.imageTags, source: "platform" };
   }
-
-  log?.("Falling back to DockerHub tags");
-  const imageTags: Record<ServiceName, string> = {
-    assistant: `${DOCKERHUB_IMAGES.assistant}:${version}`,
-    "credential-executor": `${DOCKERHUB_IMAGES["credential-executor"]}:${version}`,
-    gateway: `${DOCKERHUB_IMAGES.gateway}:${version}`,
-  };
-  return { imageTags, source: "dockerhub" };
-}
-
-/**
- * Fetch image references from the platform releases API.
- *
- * Returns a record of service name to image ref (GCR digest-based) for the
- * given version, or null if the platform is unreachable, the version is not
- * found, or any error occurs.
- */
-async function fetchPlatformImageRefs(
-  version: string,
-  log?: (msg: string) => void,
-): Promise<{
-  imageTags: Record<ServiceName, string>;
-} | null> {
-  try {
-    const platformUrl = getPlatformUrl();
-    const url = `${platformUrl}/v1/releases/?stable=true`;
-
-    log?.(`Fetching releases from ${url}`);
-
-    const response = await loopbackSafeFetch(url, {
-      signal: AbortSignal.timeout(10_000),
-    });
-
-    if (!response.ok) {
-      log?.(`Platform API returned ${response.status}`);
-      return null;
-    }
-
-    const releases = (await response.json()) as Array<{
-      version?: string;
-      assistant_image_ref?: string | null;
-      gateway_image_ref?: string | null;
-      credential_executor_image_ref?: string | null;
-    }>;
-
-    // Strip leading "v" from the requested version for matching
-    const normalizedVersion = version.replace(/^v/, "");
-
-    const release = releases.find((r) => {
-      const releaseVersion = (r.version ?? "").replace(/^v/, "");
-      return releaseVersion === normalizedVersion;
-    });
-
-    if (!release) {
-      log?.(`Version ${version} not found in platform releases`);
-      return null;
-    }
-
-    const assistantImage = release.assistant_image_ref;
-    const gatewayImage = release.gateway_image_ref;
-    let credentialExecutorImage = release.credential_executor_image_ref;
-
-    // Assistant and gateway images are required; credential-executor falls back to DockerHub
-    if (!assistantImage || !gatewayImage) {
-      log?.("Platform release missing required image refs");
-      return null;
-    }
-
-    // Fall back to DockerHub for credential-executor if its image ref is null
-    if (!credentialExecutorImage) {
-      credentialExecutorImage = `${DOCKERHUB_IMAGES["credential-executor"]}:${version}`;
-      log?.(
-        "credential-executor image not in platform release, using DockerHub fallback",
-      );
-    }
-
-    return {
-      imageTags: {
-        assistant: assistantImage,
-        "credential-executor": credentialExecutorImage,
-        gateway: gatewayImage,
-      },
-    };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    log?.(`Platform image ref resolution failed: ${message}`);
-    return null;
+  if (resolution.status === "version-not-found") {
+    log?.("Falling back to DockerHub tags");
+    return { imageTags: dockerhubImageTags(version), source: "dockerhub" };
   }
+  return { imageTags: resolution.imageTags, source: "dockerhub" };
 }

--- a/cli/src/lib/upgrade-lifecycle.ts
+++ b/cli/src/lib/upgrade-lifecycle.ts
@@ -19,14 +19,14 @@ import {
 import { getStateDir } from "./environments/paths.js";
 import { getCurrentEnvironment } from "./environments/resolve.js";
 import { loadGuardianToken } from "./guardian-token.js";
-import { resolveImageRefs } from "./platform-releases.js";
+import { fetchReleases, resolveImageRefs } from "./platform-releases.js";
 import {
   getBuilderManagedEnvKeys,
   type DockerStatefulSetSpec,
   type ServiceName,
 } from "./statefulset.js";
 import { exec, execOutput } from "./step-runner.js";
-import { compareVersions } from "./version-compat.js";
+import { compareVersions, stripVersionPrefix } from "./version-compat.js";
 import { loopbackSafeFetch } from "./loopback-fetch.js";
 
 // ---------------------------------------------------------------------------
@@ -339,27 +339,18 @@ export async function fetchPreviousVersion(
 
   // 2. Derive from releases list
   if (!currentVersion) return undefined;
-  try {
-    const { getPlatformUrl } = await import("./platform-client.js");
-    const platformUrl = getPlatformUrl();
-    const resp = await loopbackSafeFetch(`${platformUrl}/v1/releases/?stable=true`, {
-      signal: AbortSignal.timeout(10_000),
-    });
-    if (!resp.ok) return undefined;
+  const releases = await fetchReleases();
+  if (!releases) return undefined;
 
-    const releases = (await resp.json()) as Array<{ version?: string }>;
-    const normalizedCurrent = currentVersion.replace(/^v/, "");
+  const normalizedCurrent = stripVersionPrefix(currentVersion);
 
-    // Releases are ordered newest-first; find the entry right after the
-    // current version (i.e. the one that was running before the upgrade).
-    const idx = releases.findIndex(
-      (r) => (r.version ?? "").replace(/^v/, "") === normalizedCurrent,
-    );
-    if (idx >= 0 && idx + 1 < releases.length) {
-      return releases[idx + 1].version;
-    }
-  } catch {
-    // Best-effort
+  // Releases are ordered newest-first; find the entry right after the
+  // current version (i.e. the one that was running before the upgrade).
+  const idx = releases.findIndex(
+    (r) => stripVersionPrefix(r.version ?? "") === normalizedCurrent,
+  );
+  if (idx >= 0 && idx + 1 < releases.length) {
+    return releases[idx + 1].version;
   }
   return undefined;
 }

--- a/cli/src/lib/upgrade-preflight.ts
+++ b/cli/src/lib/upgrade-preflight.ts
@@ -108,19 +108,20 @@ export function evaluateUpgradePoll(
       : "pending";
   }
 
-  // Target unknown: rely on the in-progress lock releasing...
-  if (sawInProgress && inProgress === false) return "complete";
-
-  // ...or, when upgrade-status is unavailable (older platform), on the
-  // observed version changing from its pre-upgrade value.
+  // Target unknown: a version change from the pre-upgrade value is
+  // definitive on its own — the upgrade can finish before the first poll,
+  // leaving in_progress false without sawInProgress ever being set.
   if (
-    inProgress === null &&
     observedVersion &&
     initialVersion &&
     !versionsEqual(observedVersion, initialVersion)
   ) {
     return "complete";
   }
+
+  // Otherwise rely on the in-progress lock releasing (e.g. when the
+  // pre-upgrade version was unknown).
+  if (sawInProgress && inProgress === false) return "complete";
 
   return "pending";
 }

--- a/cli/src/lib/upgrade-preflight.ts
+++ b/cli/src/lib/upgrade-preflight.ts
@@ -1,0 +1,126 @@
+import type { ReleaseListItem } from "./platform-releases.js";
+import { compareVersions, versionsEqual } from "./version-compat.js";
+
+export interface UpgradeTargetResolution {
+  kind: "ok" | "version-not-found" | "no-releases";
+  /** Resolved target version (kind "ok" only). */
+  target: string | null;
+  /** compareVersions(target, current); null when either side is unknown/unparseable. */
+  comparison: number | null;
+  isNoOp: boolean;
+  isDowngrade: boolean;
+}
+
+/**
+ * Resolve the upgrade target version from the releases list and compare it
+ * against the running version. Pure — callers fetch releases/current first.
+ *
+ * - An explicit version is validated against the releases list when one is
+ *   available (`releases !== null`); absent from the list → "version-not-found".
+ * - No explicit version → latest release, skipping non-stable heads
+ *   (mirrors the web UI: `releases.find(r => r.is_stable !== false) ?? releases[0]`).
+ * - `releases === null` (platform unreachable) with an explicit version
+ *   trusts the explicit version; without one → "no-releases".
+ */
+export function resolveUpgradeTarget(args: {
+  explicitVersion: string | null;
+  releases: ReleaseListItem[] | null;
+  currentVersion: string | undefined;
+}): UpgradeTargetResolution {
+  const { explicitVersion, releases, currentVersion } = args;
+
+  let target: string | null = null;
+  if (explicitVersion) {
+    if (releases !== null) {
+      const found = releases.find((r) =>
+        versionsEqual(r.version ?? "", explicitVersion),
+      );
+      if (!found) {
+        return {
+          kind: "version-not-found",
+          target: null,
+          comparison: null,
+          isNoOp: false,
+          isDowngrade: false,
+        };
+      }
+    }
+    target = explicitVersion;
+  } else {
+    if (releases === null || releases.length === 0) {
+      return {
+        kind: "no-releases",
+        target: null,
+        comparison: null,
+        isNoOp: false,
+        isDowngrade: false,
+      };
+    }
+    target =
+      (releases.find((r) => r.is_stable !== false) ?? releases[0]).version;
+  }
+
+  const comparison = currentVersion
+    ? compareVersions(target, currentVersion)
+    : null;
+  const isNoOp = currentVersion
+    ? versionsEqual(target, currentVersion)
+    : false;
+
+  return {
+    kind: "ok",
+    target,
+    comparison,
+    isNoOp,
+    isDowngrade: comparison !== null && comparison < 0,
+  };
+}
+
+export interface UpgradePollState {
+  /** Resolved target; null when the server resolved "latest" without reporting it. */
+  targetVersion: string | null;
+  /** Version observed before the upgrade was triggered. */
+  initialVersion: string | null;
+  /** Latest current_release_version from the assistant detail endpoint. */
+  observedVersion: string | null;
+  /** Latest upgrade-status in_progress; null when the endpoint is unavailable. */
+  inProgress: boolean | null;
+  /** Whether in_progress === true was ever observed during this poll. */
+  sawInProgress: boolean;
+}
+
+/**
+ * Completion predicate for the platform upgrade poll loop. Pure.
+ *
+ * The primary signal is the DB-backed `current_release_version` (works while
+ * the service group restarts or the assistant sleeps); the upgrade-status
+ * lock is secondary, used only when the target version is unknown.
+ */
+export function evaluateUpgradePoll(
+  state: UpgradePollState,
+): "pending" | "complete" {
+  const { targetVersion, initialVersion, observedVersion, inProgress, sawInProgress } =
+    state;
+
+  if (targetVersion) {
+    return observedVersion && versionsEqual(observedVersion, targetVersion)
+      ? "complete"
+      : "pending";
+  }
+
+  // Target unknown: rely on the in-progress lock releasing...
+  if (sawInProgress && inProgress === false) return "complete";
+
+  // ...or, when upgrade-status is unavailable (older platform), on the
+  // observed version changing from its pre-upgrade value.
+  if (
+    inProgress === null &&
+    observedVersion &&
+    initialVersion &&
+    !versionsEqual(observedVersion, initialVersion)
+  ) {
+    return "complete";
+  }
+
+  return "pending";
+}

--- a/cli/src/lib/version-compat.ts
+++ b/cli/src/lib/version-compat.ts
@@ -87,6 +87,24 @@ export function compareVersions(a: string, b: string): number | null {
 }
 
 /**
+ * Strip an optional leading `v`/`V` prefix: "v0.7.0" → "0.7.0".
+ */
+export function stripVersionPrefix(version: string): string {
+  return version.replace(/^[vV]/, "");
+}
+
+/**
+ * Check whether two version strings refer to the same version.
+ * Compares via semver when both parse; falls back to prefix-stripped
+ * string equality when either is unparseable.
+ */
+export function versionsEqual(a: string, b: string): boolean {
+  const cmp = compareVersions(a, b);
+  if (cmp !== null) return cmp === 0;
+  return stripVersionPrefix(a) === stripVersionPrefix(b);
+}
+
+/**
  * Check whether two version strings are compatible.
  * Compatibility requires matching major AND minor versions.
  * Patch differences are allowed.


### PR DESCRIPTION
## Summary
- **Platform (vellum) path** is no longer fire-and-forget: it now resolves the target version from the channel-aware `/v1/releases/` list, detects no-ops ("Already on vX", exit 0 without POSTing), rejects downgrades with a `vellum rollback` suggestion, bails early when `upgrade-status` reports an upgrade already in progress (plus a 409 handler), POSTs to the detail endpoint `/v1/assistants/{id}/upgrade/`, and then polls the DB-backed `current_release_version` every 3s (10 min cap) followed by a health confirmation — mirroring the web app's Software Updates flow. `--no-wait` preserves the old return-on-accept behavior.
- **Docker path**: skips the full stop/start cycle when already on the target version (new `--force` flag for intentional reinstalls), and a typo'd `--version` now fails fast with `MISSING_VERSION` before any broadcast or lockfile mutation — previously it silently fell back to DockerHub tags and died later at `docker pull` with "manifest unknown". A genuine platform outage still falls back to DockerHub, now with a visible warning.
- **Shared plumbing**: `stripVersionPrefix`/`versionsEqual` centralize the v-prefix normalization that was re-implemented in three places; new pure `upgrade-preflight.ts` (target resolution + poll predicate) and `fetchReleases`/`resolveImageRefsDetailed`/`fetchAssistantDetail`/`fetchUpgradeInProgress` helpers, all unit-tested.

## Original prompt
Starting from an exploration of how the web app's Software Updates settings section gates and calls the platform upgrade APIs, we compared it against the `vellum upgrade` CLI and found the platform path was a fire-and-forget POST with no pre-flight or completion tracking, while the docker path restarted containers for no-op upgrades and validated targets too leniently. The user asked for the best parts of both to be combined: bring the web UI's pre-flight version resolution, no-op/direction checks, and completion polling into the CLI platform path, and tighten the docker path along the way. Confirmed scope: cloud (vellum) + docker topologies only — no `--prepare`/`--finalize` (Sparkle), apple-container, or release-channel changes — with wait-for-completion as the platform default and a `--no-wait` escape hatch. The macOS app needed no changes since it only invokes the CLI for docker upgrades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)