### PR TITLE
Remove onboarding system permissions card

### DIFF
--- a/apps/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -4,7 +4,6 @@ import { useNavigate, useSearchParams } from "react-router";
 
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
 import { StepIndicatorDots } from "@/domains/onboarding/components/step-indicator-dots";
-import { SystemPermissionsCard } from "@/components/system-permissions-card";
 import {
     emitOnboardingFunnelStepCompleted,
     getOnboardingFunnelSessionId,
@@ -225,15 +224,6 @@ export function PrivacyScreen() {
             </div>
           </div>
         </Card>
-
-        {electron && (
-          <div
-            className="mt-4 w-full"
-            style={{ animation: "fadeInUp 0.5s ease-out 0.45s both" }}
-          >
-            <SystemPermissionsCard compact />
-          </div>
-        )}
 
         <div
           className={`flex w-full items-start ${electron ? "mt-4" : "mt-6"}`}


### PR DESCRIPTION
## Summary
- Removed the unified System Permissions card from the onboarding privacy screen.
- Kept the shared System Permissions card available on the Settings privacy page.

## Original prompt
The request was to remove the unified system permissions UI from the onboarding flow while keeping the work isolated from the local branch. This PR keeps the change tightly scoped to onboarding by removing the Electron-only permissions card from the privacy step without deleting the shared settings UI.