### PR TITLE
refactor(workspace): move adaptive thinking repair out of migration 097

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -98,8 +98,8 @@ import {
   listWorkItems,
   updateWorkItem,
 } from "../work-items/work-item-store.js";
+import { repairAdaptiveThinkingOnManagedProfiles } from "../workspace/adaptive-thinking-repair.js";
 import { WorkspaceHeartbeatService } from "../workspace/heartbeat-service.js";
-import { repairAdaptiveThinkingOnManagedProfiles } from "../workspace/migrations/097-enable-adaptive-thinking-managed-profiles.js";
 import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
 import { runWorkspaceMigrations } from "../workspace/migrations/runner.js";
 import {

--- a/assistant/src/workspace/adaptive-thinking-repair.ts
+++ b/assistant/src/workspace/adaptive-thinking-repair.ts
@@ -1,0 +1,103 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Enable adaptive thinking on the managed "balanced" and "quality-optimized"
+// profiles.
+//
+// The assistant-side seed defaults (MANAGED_PROFILE_TEMPLATES in
+// seed-inference-profiles.ts) already ship thinking: { enabled: true,
+// streamThinking: true } for both profiles, which normalizes to
+// { type: "adaptive" } on the wire. Off-platform (BYOK) instances pick this
+// up on every boot because the seeder overwrites managed profiles. On-platform
+// instances preserve existing profiles (the platform overlay is authoritative),
+// so instances that were hatched before thinking was enabled in the templates
+// are stuck with thinking disabled or absent.
+//
+// Workspace migration 097 patches the on-disk config once, but it runs before
+// mergeDefaultWorkspaceConfig() which can overwrite the fix with overlay
+// profiles that have thinking disabled or absent. lifecycle.ts calls this
+// repair again after the overlay merge + profile seeding so the fix sticks.
+// The migration keeps its own frozen copy of this logic (migration files are
+// self-contained snapshots and must not be imported from).
+//
+// The repair patches both profiles, adding thinking: { enabled: true,
+// streamThinking: true } where it's missing or explicitly disabled. It skips
+// profiles that:
+//   - Don't exist (no profile to patch)
+//   - Already have thinking enabled (idempotent)
+//   - Are source: "user" (user-created profiles are untouched)
+//   - Have a non-managed, non-absent source (unknown origin)
+//   - Use a non-Anthropic provider (adaptive thinking is Anthropic-specific)
+
+const ADAPTIVE_THINKING = { enabled: true, streamThinking: true } as const;
+const TARGET_PROFILES = ["balanced", "quality-optimized"] as const;
+
+/**
+ * Patch managed Anthropic profiles that are missing adaptive thinking.
+ *
+ * Idempotent: profiles that already have thinking enabled are skipped.
+ */
+export function repairAdaptiveThinkingOnManagedProfiles(
+  workspaceDir: string,
+): void {
+  const configPath = join(workspaceDir, "config.json");
+  if (!existsSync(configPath)) return;
+
+  let config: Record<string, unknown>;
+  try {
+    const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+    config = raw as Record<string, unknown>;
+  } catch {
+    return;
+  }
+
+  const llm = readObject(config.llm);
+  if (llm === null) return;
+
+  const profiles = readObject(llm.profiles);
+  if (profiles === null) return;
+
+  let changed = false;
+
+  for (const name of TARGET_PROFILES) {
+    const profile = readObject(profiles[name]);
+    if (profile === null) continue;
+
+    // Only patch managed Anthropic profiles.
+    // Legacy profiles created before the `source` metadata field was introduced
+    // have source=undefined. Treat these as managed when the profile name is one
+    // of the canonical managed names (which TARGET_PROFILES already guarantees)
+    // and the provider is Anthropic (or absent). Explicit `source: "user"`
+    // profiles are always skipped.
+    if (profile.source === "user") continue;
+    if (profile.source !== undefined && profile.source !== "managed") continue;
+    if (
+      typeof profile.provider === "string" &&
+      profile.provider !== "anthropic"
+    ) {
+      continue;
+    }
+
+    // Skip if thinking is already enabled.
+    const thinking = readObject(profile.thinking);
+    if (thinking !== null && thinking.enabled === true) continue;
+
+    profile.thinking = { ...ADAPTIVE_THINKING };
+    profiles[name] = profile;
+    changed = true;
+  }
+
+  if (changed) {
+    llm.profiles = profiles;
+    config.llm = llm;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  }
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}

--- a/assistant/src/workspace/migrations/097-enable-adaptive-thinking-managed-profiles.ts
+++ b/assistant/src/workspace/migrations/097-enable-adaptive-thinking-managed-profiles.ts
@@ -23,78 +23,14 @@ import type { WorkspaceMigration } from "./types.js";
 //   - Are source: "user" (user-created profiles are untouched)
 //   - Have a non-managed, non-absent source (unknown origin)
 //   - Use a non-Anthropic provider (adaptive thinking is Anthropic-specific)
+//
+// Note: the live startup path re-runs the same repair after the platform
+// overlay merge — see assistant/src/workspace/adaptive-thinking-repair.ts.
+// This file keeps its own frozen copy of the logic because migration modules
+// are self-contained snapshots and must never be imported by other code.
 
 const ADAPTIVE_THINKING = { enabled: true, streamThinking: true } as const;
 const TARGET_PROFILES = ["balanced", "quality-optimized"] as const;
-
-/**
- * Patch managed Anthropic profiles that are missing adaptive thinking.
- *
- * Exported so lifecycle.ts can re-run the repair after mergeDefaultWorkspaceConfig()
- * and seedInferenceProfiles(). On-platform instances with a config overlay have their
- * profiles overwritten by the overlay merge (which runs after workspace migrations),
- * so the migration alone is insufficient — the post-overlay call ensures the repair
- * sticks even when the overlay supplies profiles without thinking enabled.
- *
- * The function is idempotent: profiles that already have thinking enabled are skipped.
- */
-export function repairAdaptiveThinkingOnManagedProfiles(
-  workspaceDir: string,
-): void {
-  const configPath = join(workspaceDir, "config.json");
-  if (!existsSync(configPath)) return;
-
-  let config: Record<string, unknown>;
-  try {
-    const raw = JSON.parse(readFileSync(configPath, "utf-8"));
-    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
-    config = raw as Record<string, unknown>;
-  } catch {
-    return;
-  }
-
-  const llm = readObject(config.llm);
-  if (llm === null) return;
-
-  const profiles = readObject(llm.profiles);
-  if (profiles === null) return;
-
-  let changed = false;
-
-  for (const name of TARGET_PROFILES) {
-    const profile = readObject(profiles[name]);
-    if (profile === null) continue;
-
-    // Only patch managed Anthropic profiles.
-    // Legacy profiles created before the `source` metadata field was introduced
-    // have source=undefined. Treat these as managed when the profile name is one
-    // of the canonical managed names (which TARGET_PROFILES already guarantees)
-    // and the provider is Anthropic (or absent). Explicit `source: "user"`
-    // profiles are always skipped.
-    if (profile.source === "user") continue;
-    if (profile.source !== undefined && profile.source !== "managed") continue;
-    if (
-      typeof profile.provider === "string" &&
-      profile.provider !== "anthropic"
-    ) {
-      continue;
-    }
-
-    // Skip if thinking is already enabled.
-    const thinking = readObject(profile.thinking);
-    if (thinking !== null && thinking.enabled === true) continue;
-
-    profile.thinking = { ...ADAPTIVE_THINKING };
-    profiles[name] = profile;
-    changed = true;
-  }
-
-  if (changed) {
-    llm.profiles = profiles;
-    config.llm = llm;
-    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
-  }
-}
 
 export const enableAdaptiveThinkingManagedProfilesMigration: WorkspaceMigration =
   {
@@ -102,7 +38,61 @@ export const enableAdaptiveThinkingManagedProfilesMigration: WorkspaceMigration 
     description:
       "Enable adaptive thinking on managed balanced and quality-optimized profiles",
     run(workspaceDir: string): void {
-      repairAdaptiveThinkingOnManagedProfiles(workspaceDir);
+      const configPath = join(workspaceDir, "config.json");
+      if (!existsSync(configPath)) return;
+
+      let config: Record<string, unknown>;
+      try {
+        const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+        if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+        config = raw as Record<string, unknown>;
+      } catch {
+        return;
+      }
+
+      const llm = readObject(config.llm);
+      if (llm === null) return;
+
+      const profiles = readObject(llm.profiles);
+      if (profiles === null) return;
+
+      let changed = false;
+
+      for (const name of TARGET_PROFILES) {
+        const profile = readObject(profiles[name]);
+        if (profile === null) continue;
+
+        // Only patch managed Anthropic profiles.
+        // Legacy profiles created before the `source` metadata field was
+        // introduced have source=undefined. Treat these as managed when the
+        // profile name is one of the canonical managed names (which
+        // TARGET_PROFILES already guarantees) and the provider is Anthropic
+        // (or absent). Explicit `source: "user"` profiles are always skipped.
+        if (profile.source === "user") continue;
+        if (profile.source !== undefined && profile.source !== "managed") {
+          continue;
+        }
+        if (
+          typeof profile.provider === "string" &&
+          profile.provider !== "anthropic"
+        ) {
+          continue;
+        }
+
+        // Skip if thinking is already enabled.
+        const thinking = readObject(profile.thinking);
+        if (thinking !== null && thinking.enabled === true) continue;
+
+        profile.thinking = { ...ADAPTIVE_THINKING };
+        profiles[name] = profile;
+        changed = true;
+      }
+
+      if (changed) {
+        llm.profiles = profiles;
+        config.llm = llm;
+        writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+      }
     },
     down(_workspaceDir: string): void {
       // Forward-only.


### PR DESCRIPTION
## Summary

Follow-up to #33676, addressing Codex review feedback ("Keep startup code out of migration modules").

PR #33676 made migration 097 export `repairAdaptiveThinkingOnManagedProfiles()`, which `daemon/lifecycle.ts` imported and called after the platform overlay merge. That violates `assistant/src/workspace/migrations/AGENTS.md`: migration files must be fully self-contained, export only the single `WorkspaceMigration` object, and never be imported by other code.

## Changes

- New `assistant/src/workspace/adaptive-thinking-repair.ts` hosts the reusable repair function for the live startup path.
- `assistant/src/daemon/lifecycle.ts` now imports the repair from the new module instead of from the migration file.
- Migration 097 is self-contained again: it exports only the `WorkspaceMigration` object and inlines its own frozen copy of the repair logic (duplication between a migration and live code is explicitly acceptable per the migrations AGENTS.md).

Pure code move — no behavior change. Both copies preserve the current guard semantics from #33677 (skip explicit `source: "user"`, treat `source === undefined` as managed, allow absent provider).

🤖 Generated with [Claude Code](https://claude.com/claude-code)