### PR TITLE
fix(tools): reject tool calls whose arguments failed JSON parsing

### DIFF
--- a/assistant/src/__tests__/tool-approval-handler.test.ts
+++ b/assistant/src/__tests__/tool-approval-handler.test.ts
@@ -532,6 +532,91 @@ describe("ToolApprovalHandler / pre-exec gate grant check", () => {
   });
 });
 
+describe("ToolApprovalHandler / unparseable tool args gate", () => {
+  const handler = new ToolApprovalHandler();
+  const events: ToolLifecycleEvent[] = [];
+  const emitLifecycleEvent = (event: ToolLifecycleEvent) => {
+    events.push(event);
+  };
+
+  beforeEach(() => {
+    clearTables();
+    events.length = 0;
+  });
+
+  test("input wrapped as { _raw } is rejected without executing", async () => {
+    const result = await handler.checkPreExecutionGates(
+      "bash",
+      { _raw: '{"command": "ls -' },
+      makeContext({ trustClass: "guardian" }),
+      "sandbox",
+      "low",
+      Date.now(),
+      emitLifecycleEvent,
+    );
+
+    expect(result.allowed).toBe(false);
+    if (result.allowed) return;
+    expect(result.result.isError).toBe(true);
+    expect(result.result.content).toContain("were not valid JSON");
+    expect(result.result.content).toContain('{"command": "ls -');
+    expect(result.result.content).toContain("Retry");
+
+    const errorEvents = events.filter((e) => e.type === "error");
+    expect(errorEvents).toHaveLength(1);
+    if (errorEvents[0].type === "error") {
+      expect(errorEvents[0].isExpected).toBe(true);
+      expect(errorEvents[0].errorCategory).toBe("tool_failure");
+    }
+  });
+
+  test("long raw args are truncated in the error message", async () => {
+    const raw = `{"data": "${"x".repeat(500)}`;
+    const result = await handler.checkPreExecutionGates(
+      "bash",
+      { _raw: raw },
+      makeContext({ trustClass: "guardian" }),
+      "sandbox",
+      "low",
+      Date.now(),
+      emitLifecycleEvent,
+    );
+
+    expect(result.allowed).toBe(false);
+    if (result.allowed) return;
+    expect(result.result.content).not.toContain(raw);
+    expect(result.result.content).toContain("…");
+  });
+
+  test("legitimate input containing a _raw field among others is not rejected", async () => {
+    const result = await handler.checkPreExecutionGates(
+      "bash",
+      { _raw: "something", command: "ls" },
+      makeContext({ trustClass: "guardian" }),
+      "sandbox",
+      "low",
+      Date.now(),
+      emitLifecycleEvent,
+    );
+
+    expect(result.allowed).toBe(true);
+  });
+
+  test("non-string _raw value is not treated as the marker", async () => {
+    const result = await handler.checkPreExecutionGates(
+      "bash",
+      { _raw: 42 },
+      makeContext({ trustClass: "guardian" }),
+      "sandbox",
+      "low",
+      Date.now(),
+      emitLifecycleEvent,
+    );
+
+    expect(result.allowed).toBe(true);
+  });
+});
+
 afterAll(() => {
   mock.restore();
 });

--- a/assistant/src/providers/__tests__/unparseable-tool-args.test.ts
+++ b/assistant/src/providers/__tests__/unparseable-tool-args.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isUnparseableToolArgs,
+  unparseableToolArgsMessage,
+  wrapUnparseableToolArgs,
+} from "../unparseable-tool-args.js";
+
+describe("unparseable tool args marker", () => {
+  test("wrap/detect roundtrip", () => {
+    const wrapped = wrapUnparseableToolArgs(
+      '{"surface_type": "card", "data": ',
+    );
+    expect(isUnparseableToolArgs(wrapped)).toBe(true);
+  });
+
+  test("detects empty raw string", () => {
+    expect(isUnparseableToolArgs(wrapUnparseableToolArgs(""))).toBe(true);
+  });
+
+  test("does not match input with additional keys", () => {
+    expect(isUnparseableToolArgs({ _raw: "x", other: 1 })).toBe(false);
+  });
+
+  test("does not match non-string _raw", () => {
+    expect(isUnparseableToolArgs({ _raw: { nested: true } })).toBe(false);
+  });
+
+  test("does not match ordinary tool input", () => {
+    expect(isUnparseableToolArgs({ command: "ls" })).toBe(false);
+    expect(isUnparseableToolArgs({})).toBe(false);
+  });
+
+  test("message includes tool name, raw preview, and retry instruction", () => {
+    const msg = unparseableToolArgsMessage("ui_show", '{"surface_type": ');
+    expect(msg).toContain('"ui_show"');
+    expect(msg).toContain('{"surface_type": ');
+    expect(msg).toContain("NOT executed");
+    expect(msg).toContain("Retry");
+  });
+
+  test("message truncates long raw args", () => {
+    const raw = "a".repeat(1000);
+    const msg = unparseableToolArgsMessage("bash", raw);
+    expect(msg).not.toContain(raw);
+    expect(msg).toContain("a".repeat(200) + "…");
+  });
+
+  test("message handles empty raw args", () => {
+    const msg = unparseableToolArgsMessage("bash", "");
+    expect(msg).toContain("(empty)");
+  });
+});

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -17,6 +17,7 @@ import {
   ContextOverflowError,
   extractOverflowTokensFromMessage,
 } from "../types.js";
+import { wrapUnparseableToolArgs } from "../unparseable-tool-args.js";
 
 /**
  * Detect OpenAI-compatible context-overflow signals on an `OpenAI.APIError`.
@@ -634,7 +635,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
         try {
           input = JSON.parse(tc.args);
         } catch {
-          input = { _raw: tc.args };
+          input = wrapUnparseableToolArgs(tc.args);
         }
         content.push({
           type: "tool_use",

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -14,6 +14,7 @@ import type {
   SendMessageOptions,
 } from "../types.js";
 import { ContextOverflowError } from "../types.js";
+import { wrapUnparseableToolArgs } from "../unparseable-tool-args.js";
 import { detectOpenAICompatibleContextOverflow } from "./chat-completions-provider.js";
 
 const log = getLogger("openai-responses");
@@ -461,7 +462,7 @@ export class OpenAIResponsesProvider implements Provider {
         try {
           input = JSON.parse(tc.args);
         } catch {
-          input = { _raw: tc.args };
+          input = wrapUnparseableToolArgs(tc.args);
         }
         content.push({
           type: "tool_use",

--- a/assistant/src/providers/unparseable-tool-args.ts
+++ b/assistant/src/providers/unparseable-tool-args.ts
@@ -1,0 +1,56 @@
+/**
+ * Marker shape for tool-call arguments that failed JSON parsing.
+ *
+ * Streaming providers accumulate tool-call argument deltas as a string and
+ * parse the result once the stream completes. Some models/gateways emit
+ * truncated or malformed argument JSON (e.g. MiniMax M3 via OpenRouter cutting
+ * the stream mid-object). The provider cannot drop the tool_use block — the
+ * protocol requires a paired tool_result for every tool_use id — so it wraps
+ * the raw string under this marker key instead.
+ *
+ * The tool execution layer detects the marker and rejects the invocation with
+ * an error tool result, so the model sees the failure and can retry, instead
+ * of a tool executing with garbage input.
+ */
+const UNPARSEABLE_TOOL_ARGS_KEY = "_raw";
+
+/** Wrap raw, unparseable tool-call argument text in the marker shape. */
+export function wrapUnparseableToolArgs(raw: string): Record<string, unknown> {
+  return { [UNPARSEABLE_TOOL_ARGS_KEY]: raw };
+}
+
+/**
+ * Detect input produced by {@link wrapUnparseableToolArgs}: exactly one key,
+ * the marker key, holding the raw argument string. The exact-shape check
+ * avoids false positives on hypothetical legitimate inputs that merely
+ * contain a `_raw` field among others.
+ */
+export function isUnparseableToolArgs(
+  input: Record<string, unknown>,
+): input is { _raw: string } {
+  const keys = Object.keys(input);
+  return (
+    keys.length === 1 &&
+    keys[0] === UNPARSEABLE_TOOL_ARGS_KEY &&
+    typeof input[UNPARSEABLE_TOOL_ARGS_KEY] === "string"
+  );
+}
+
+/**
+ * Build the error message returned to the model when it sends unparseable
+ * tool arguments. Includes a bounded prefix of what was received so the model
+ * can see where its output was cut off or malformed.
+ */
+export function unparseableToolArgsMessage(
+  toolName: string,
+  raw: string,
+): string {
+  const PREVIEW_LIMIT = 200;
+  const preview =
+    raw.length > PREVIEW_LIMIT ? `${raw.slice(0, PREVIEW_LIMIT)}…` : raw;
+  return (
+    `Error: the arguments for "${toolName}" were not valid JSON — the argument stream was malformed or truncated, so the tool was NOT executed. ` +
+    `Received: ${preview || "(empty)"}\n` +
+    `Retry the call with complete, valid JSON arguments.`
+  );
+}

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -5,6 +5,10 @@ import {
   getCanonicalGuardianRequest,
   updateCanonicalGuardianRequest,
 } from "../memory/canonical-guardian-store.js";
+import {
+  isUnparseableToolArgs,
+  unparseableToolArgsMessage,
+} from "../providers/unparseable-tool-args.js";
 import { isUntrustedTrustClass } from "../runtime/actor-trust-resolver.js";
 import { createOrReuseToolGrantRequest } from "../runtime/tool-grant-request-helper.js";
 import { redactSecrets } from "../security/secret-scanner.js";
@@ -239,6 +243,33 @@ export class ToolApprovalHandler {
         allowed: false,
         result: { content: "Cancelled", isError: true },
       };
+    }
+
+    // Reject tool calls whose arguments failed JSON parsing in the provider
+    // layer (wrapped under the `_raw` marker). Executing with the marker
+    // object would feed garbage input to the tool — and worse, a tool that
+    // tolerates missing fields can "succeed" (e.g. ui_show creating a
+    // typeless surface), so the model never learns its arguments were
+    // mangled. Fail loudly instead so the model retries.
+    if (isUnparseableToolArgs(input)) {
+      const msg = unparseableToolArgsMessage(name, input._raw);
+      const durationMs = Date.now() - startTime;
+      emitLifecycleEvent({
+        type: "error",
+        toolName: name,
+        executionTarget,
+        input,
+        workingDir: context.workingDir,
+        conversationId: context.conversationId,
+        requestId: context.requestId,
+        riskLevel,
+        decision: "error",
+        durationMs,
+        errorMessage: msg,
+        isExpected: true,
+        errorCategory: "tool_failure",
+      });
+      return { allowed: false, result: { content: msg, isError: true } };
     }
 
     // Reject tool invocations targeting guardian control-plane endpoints from non-guardian actors.


### PR DESCRIPTION
## Problem

When a model streams malformed or truncated tool-call argument JSON, the OpenAI-compatible providers wrap the raw string as `{ _raw: "..." }` (they can't drop the `tool_use` block — the protocol requires a paired `tool_result` for every tool_use id). Nothing downstream checked for that marker, so tools executed with garbage input.

Observed in production with MiniMax M3 via OpenRouter: two `ui_show` calls arrived with arguments truncated mid-object (`{"surface_type": "card", "data": `). The tool executed anyway, created surfaces with no `surface_type` — which render as permanent **"Unknown surface"** cards in the web client — and returned a success result with a surfaceId, so the model believed the calls succeeded and never retried.

## Fix

- New `assistant/src/providers/unparseable-tool-args.ts` centralizes the marker shape: `wrapUnparseableToolArgs()` (used by both OpenAI-compatible providers) and `isUnparseableToolArgs()` / `unparseableToolArgsMessage()`.
- `ToolApprovalHandler.checkPreExecutionGates` gains an early gate: when the input is the marker shape, the invocation is rejected with an error tool result that includes a bounded preview of the raw arguments and tells the model to retry with valid JSON. The tool never executes.
- The detection requires the exact wrapped shape (single `_raw` key holding a string) so legitimate inputs that happen to contain a `_raw` field are unaffected.

## Tests

- `assistant/src/providers/__tests__/unparseable-tool-args.test.ts` — marker wrap/detect/message unit tests.
- `assistant/src/__tests__/tool-approval-handler.test.ts` — gate rejects marker input with an error lifecycle event, truncates long previews, and does not false-positive on inputs that merely contain `_raw`.

Part of the MiniMax M3 tool-arg mangling investigation (companion UI PR makes the `task_progress` card degrade sanely when steps data is malformed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)