### PR TITLE
fix(web): don't render a 0/0 progress bar for malformed task_progress cards

### DIFF
--- a/apps/web/src/domains/chat/components/surfaces/card-surface.test.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/card-surface.test.tsx
@@ -129,4 +129,71 @@ describe("CardSurface", () => {
 
     expect(rendered).toContain("lucide-circle-x");
   });
+
+  test("renders the counter progress bar when templateData has usable counters", () => {
+    const rendered = renderToStaticMarkup(
+      <CardSurface
+        surface={surface({
+          data: {
+            title: "Processing files",
+            body: "",
+            template: "task_progress",
+            templateData: { completed: 2, total: 5 },
+          },
+        })}
+        onAction={() => undefined}
+      />,
+    );
+
+    expect(rendered).toContain("2 / 5 tasks");
+    expect(rendered).toContain("40%");
+  });
+
+  test("degrades to the plain card body when task_progress steps is not an array", () => {
+    // Shape observed from MiniMax M3: arrays wrapped as { item: [...] }.
+    // This fails isTaskProgressSurface, and there are no counters either —
+    // the card must not render a meaningless "0 / 0 tasks" bar.
+    const rendered = renderToStaticMarkup(
+      <CardSurface
+        surface={surface({
+          title: "Building slide deck",
+          data: {
+            body: "Working on it.",
+            template: "task_progress",
+            templateData: {
+              title: "Slide Deck",
+              status: "in_progress",
+              steps: { item: [{ label: "Research", status: "in_progress" }] },
+            },
+          },
+        })}
+        onAction={() => undefined}
+      />,
+    );
+
+    expect(rendered).not.toContain("0 / 0 tasks");
+    expect(rendered).not.toContain("tasks");
+    expect(rendered).toContain("Building slide deck");
+    expect(rendered).toContain("Working on it.");
+  });
+
+  test("does not render a counter bar when task_progress has neither steps nor counters", () => {
+    const rendered = renderToStaticMarkup(
+      <CardSurface
+        surface={surface({
+          data: {
+            title: "Task",
+            body: "Details",
+            template: "task_progress",
+            templateData: { title: "Task", status: "in_progress" },
+          },
+        })}
+        onAction={() => undefined}
+      />,
+    );
+
+    expect(rendered).not.toContain("tasks");
+    expect(rendered).not.toContain("%");
+    expect(rendered).toContain("Details");
+  });
 });

--- a/apps/web/src/domains/chat/components/surfaces/card-surface.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/card-surface.tsx
@@ -116,6 +116,21 @@ function StepIcon({ status }: { status: string | undefined }) {
 // Task progress template
 // ---------------------------------------------------------------------------
 
+/**
+ * The counter-style task_progress fallback only makes sense when the template
+ * data actually carries usable `{ completed, total }` counters. Malformed
+ * template data — e.g. a model emitting `steps` as an object instead of an
+ * array, which fails `isTaskProgressSurface` — must not fall through to a
+ * meaningless "0 / 0 tasks · 0%" bar; the card degrades to its plain body
+ * instead. `completed` may be absent (treated as 0 by the bar), `total` must
+ * coerce to a finite positive number.
+ */
+function hasUsableProgressCounters(templateData: Record<string, unknown>): boolean {
+  const completed = Number(templateData.completed ?? 0);
+  const total = Number(templateData.total ?? NaN);
+  return Number.isFinite(completed) && Number.isFinite(total) && total > 0;
+}
+
 function TaskProgressBar({ templateData }: { templateData: Record<string, unknown> }) {
   const completed = Number(templateData.completed ?? 0);
   const total = Number(templateData.total ?? 0);
@@ -193,7 +208,10 @@ function TaskStepList({
 export function CardSurface({ surface, onAction }: CardSurfaceProps) {
   const data = surface.data as unknown as CardSurfaceData;
   const isWeather = data.template === "weather_forecast" && data.templateData;
-  const isTaskProgress = data.template === "task_progress" && data.templateData;
+  const isTaskProgress =
+    data.template === "task_progress" &&
+    !!data.templateData &&
+    hasUsableProgressCounters(data.templateData);
   // Shared predicate so this render-detection and the activity-summary
   // hoist-detection in transcript-message-body cannot drift.
   const hasSteps = isTaskProgressSurface(surface);


### PR DESCRIPTION
## Problem

When a model emits `task_progress` card template data whose `steps` field is not an array — observed with MiniMax M3, which wrapped the array as `{"steps": {"item": [...]}}` — the card fails `isTaskProgressSurface()` (which requires a non-empty array) and falls through to the generic branch. That branch still matched on `template === "task_progress"` and rendered the counter-style `TaskProgressBar`, which reads `templateData.completed`/`total` — fields that don't exist in the steps-shaped payload — producing a useless **"0 / 0 tasks · 0%"** bar.

## Fix

Gate the counter bar on the template data actually carrying usable counters: `completed` must coerce to a finite number (absent is fine — the bar treats it as 0) and `total` to a finite positive number. When neither valid steps nor usable counters are present, the card degrades to its plain title/body.

Cards with a valid `steps` array (the documented shape) and cards with genuine `{ completed, total }` counters render exactly as before.

## Tests

`card-surface.test.tsx`:
- valid counters still render the bar (`2 / 5 tasks`, `40%`)
- the MiniMax `{ item: [...] }` steps shape renders no bar and falls back to title/body
- `task_progress` with neither steps nor counters renders no bar

Companion to #34574, which rejects tool calls whose arguments failed JSON parsing entirely (this PR covers the case where the JSON parsed but the shape is wrong).

🤖 Generated with [Claude Code](https://claude.com/claude-code)