### PR TITLE
fix(assistant): stop leaking raw RRULE text into schedule clients, treat COUNT=1 rrules as one-shots

### DIFF
--- a/assistant/src/__tests__/recurrence-engine.test.ts
+++ b/assistant/src/__tests__/recurrence-engine.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 
 import {
   computeNextRunAt,
+  describeRRuleExpression,
+  isSingleFireRRule,
   isValidScheduleExpression,
 } from "../schedule/recurrence-engine.js";
 
@@ -115,5 +117,48 @@ describe("recurrence engine — rrule", () => {
     // Should skip the excluded date and return January 2
     const jan2 = new Date("2099-01-02T09:00:00Z").getTime();
     expect(next).toBe(jan2);
+  });
+});
+
+describe("recurrence engine — rrule display helpers", () => {
+  const SINGLE_FIRE = "DTSTART:20990612T080000\nRRULE:FREQ=DAILY;COUNT=1";
+  const WEEKLY = "DTSTART:20990612T080000\nRRULE:FREQ=WEEKLY;BYDAY=MO,WE";
+
+  test("isSingleFireRRule detects COUNT=1 rules", () => {
+    expect(isSingleFireRRule(SINGLE_FIRE)).toBe(true);
+    expect(isSingleFireRRule(WEEKLY)).toBe(false);
+    expect(
+      isSingleFireRRule("DTSTART:20990612T080000\nRRULE:FREQ=DAILY;COUNT=2"),
+    ).toBe(false);
+    expect(isSingleFireRRule("not an rrule")).toBe(false);
+  });
+
+  test("isSingleFireRRule is false for set constructs", () => {
+    expect(
+      isSingleFireRRule(
+        "DTSTART:20990612T080000\nRRULE:FREQ=DAILY;COUNT=1\nRDATE:20990613T080000",
+      ),
+    ).toBe(false);
+  });
+
+  test("describeRRuleExpression humanizes rules", () => {
+    expect(describeRRuleExpression(SINGLE_FIRE)).toBe("One-time");
+    expect(describeRRuleExpression(WEEKLY)).toBe(
+      "Every week on Monday, Wednesday",
+    );
+    expect(
+      describeRRuleExpression(
+        "DTSTART:20990612T080000\nRRULE:FREQ=DAILY;COUNT=3",
+      ),
+    ).toBe("Every day for 3 times");
+  });
+
+  test("describeRRuleExpression falls back instead of leaking raw text", () => {
+    expect(
+      describeRRuleExpression(
+        "DTSTART:20990612T080000\nRRULE:FREQ=DAILY\nEXDATE:20990613T080000",
+      ),
+    ).toBe("Custom recurrence");
+    expect(describeRRuleExpression("garbage")).toBe("Custom recurrence");
   });
 });

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -492,6 +492,40 @@ describe("GET /schedules — default defer exclusion", () => {
     });
   });
 
+  test("humanizes rrule cadences and flags single-fire rrules as one-shot", () => {
+    createSchedule({
+      name: "RRule single fire",
+      cronExpression: "DTSTART:20990612T080000\nRRULE:FREQ=DAILY;COUNT=1",
+      syntax: "rrule",
+      message: "brush teeth",
+    });
+    createSchedule({
+      name: "RRule weekly",
+      cronExpression: "DTSTART:20990612T080000\nRRULE:FREQ=WEEKLY;BYDAY=MO,WE",
+      syntax: "rrule",
+      message: "standup",
+    });
+
+    const route = findRoute("schedules", "GET");
+    const result = route.handler({}) as {
+      schedules: Array<{
+        name: string;
+        cadenceDescription: string;
+        isOneShot: boolean;
+      }>;
+    };
+    const byName = new Map(result.schedules.map((s) => [s.name, s]));
+
+    expect(byName.get("RRule single fire")).toMatchObject({
+      cadenceDescription: "One-time",
+      isOneShot: true,
+    });
+    expect(byName.get("RRule weekly")).toMatchObject({
+      cadenceDescription: "Every week on Monday, Wednesday",
+      isOneShot: false,
+    });
+  });
+
   test("mutation responses also exclude deferred wakes", () => {
     createSchedule({
       name: "Agent schedule",

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -12,6 +12,10 @@ import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../../daemon/trust-context.js";
 import { bootstrapConversation } from "../../memory/conversation-bootstrap.js";
 import { getConversation } from "../../memory/conversation-crud.js";
 import { getUsageCostForConversationWindow } from "../../memory/llm-usage-store.js";
+import {
+  describeRRuleExpression,
+  isSingleFireRRule,
+} from "../../schedule/recurrence-engine.js";
 import { normalizeScheduleSyntax } from "../../schedule/recurrence-types.js";
 import {
   runScript,
@@ -136,7 +140,20 @@ function getCadenceDescription(
   if (job.syntax === "cron") {
     return describeCronExpression(job.cronExpression);
   }
-  return job.expression ?? "";
+  return describeRRuleExpression(job.cronExpression);
+}
+
+/**
+ * Presentation-layer one-shot flag. A COUNT=1 rrule fires exactly once and
+ * should read as one-time in clients, even though the scheduler internally
+ * treats expression-backed jobs as recurring (retry policy, conversation
+ * reuse). Do not feed this back into scheduler logic.
+ */
+function isOneShotForDisplay(
+  job: Pick<ScheduleJob, "syntax" | "cronExpression">,
+): boolean {
+  if (job.cronExpression == null) return true;
+  return job.syntax === "rrule" && isSingleFireRRule(job.cronExpression);
 }
 
 function handleListSchedules(queryParams: Record<string, string>) {
@@ -182,7 +199,7 @@ function handleListSchedules(queryParams: Record<string, string>) {
         routingIntent: j.routingIntent,
         reuseConversation: j.reuseConversation,
         wakeConversationId: j.wakeConversationId,
-        isOneShot: j.cronExpression == null,
+        isOneShot: isOneShotForDisplay(j),
       };
     }),
   };

--- a/assistant/src/schedule/recurrence-engine.ts
+++ b/assistant/src/schedule/recurrence-engine.ts
@@ -136,6 +136,40 @@ export function isValidScheduleExpression(spec: ScheduleSpec): boolean {
 }
 
 /**
+ * Detect whether an RRULE expression fires exactly once — a single RRULE
+ * with COUNT=1 and no set constructs. Such schedules are semantically
+ * one-shots even though they carry a recurrence expression.
+ */
+export function isSingleFireRRule(expression: string): boolean {
+  try {
+    const normalized = normalizeRruleExpression(expression);
+    if (hasSetConstructs(normalized)) return false;
+    const rule = rrulestr(normalized);
+    return !(rule instanceof RRuleSet) && rule.options.count === 1;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Human-readable description of an RRULE expression for display surfaces.
+ * Single-fire rules read as "One-time"; rules the library cannot express
+ * fall back to "Custom recurrence" rather than leaking raw iCalendar text.
+ */
+export function describeRRuleExpression(expression: string): string {
+  if (isSingleFireRRule(expression)) return "One-time";
+  try {
+    const normalized = normalizeRruleExpression(expression);
+    if (hasSetConstructs(normalized)) return "Custom recurrence";
+    const text = rrulestr(normalized).toText();
+    if (!text) return "Custom recurrence";
+    return text.charAt(0).toUpperCase() + text.slice(1);
+  } catch {
+    return "Custom recurrence";
+  }
+}
+
+/**
  * Compute the next run timestamp (epoch ms) for a schedule expression.
  * Throws if no future runs exist.
  */


### PR DESCRIPTION
## Summary
- The schedules API (`getCadenceDescription` in `schedule-routes.ts`) returned the raw stored expression for rrule-syntax schedules, so clients rendered literal `DTSTART:...RRULE:FREQ=DAILY;COUNT=1` strings. New `describeRRuleExpression()` in the recurrence engine humanizes via the rrule library's `toText()` ("Every week on Monday, Wednesday"), reads single-fire rules as "One-time", and falls back to "Custom recurrence" for set constructs or unparseable input instead of leaking iCalendar text.
- `isOneShot` in the list response was `cronExpression == null`, so a `COUNT=1` rrule — which fires exactly once — was presented as recurring. New `isSingleFireRRule()` flags those, and the response now uses a presentation-only `isOneShotForDisplay()` so the web UI's Recurring/One-time/Past grouping places them correctly. Scheduler-internal one-shot semantics (retry policy, conversation reuse) are deliberately untouched.
- The CLI consumes the same `cadenceDescription` field, so both web and CLI are fixed by this route-layer change. Assistant-facing schedule tools intentionally keep raw RRULE text (the model needs precision).

## Original prompt
After the schedules-page UI consolidation (#34536) merged, Aaron noticed two presentation problems on the page: assistant-created reminders showed raw iCalendar junk (`DTSTART:20260612T080000 RRULE:FREQ=DAILY;COUNT=1`) as their cadence text, and those same COUNT=1 single-fire rrule schedules were grouped under "Recurring" even though they run exactly once. Both trace to the daemon's schedule routes: rrule expressions were never humanized (only cron was) and the isOneShot flag only checked for a null expression. He asked to fix both at the API layer.