### PR TITLE
fix(tests): poll for terminal stopped state in idle-timeout proxy session test

### DIFF
--- a/assistant/src/__tests__/script-proxy-conversation-manager.test.ts
+++ b/assistant/src/__tests__/script-proxy-conversation-manager.test.ts
@@ -247,13 +247,18 @@ describe("session-manager", () => {
       await startSession(session.id);
       expect(getActiveSession(CONV_ID)).toBeDefined();
 
-      // Wait for the idle timeout to fire
-      await new Promise((r) => setTimeout(r, 200));
+      // Wait for the idle timeout to fire and the async stop to finish.
+      // The session passes through "stopping" while the server closes, so
+      // poll for the terminal state rather than sleeping a fixed interval.
+      const deadline = Date.now() + 5000;
+      const findSession = () =>
+        getSessionsForConversation(CONV_ID).find((x) => x.id === session.id);
+      while (findSession()?.status !== "stopped" && Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 20));
+      }
 
       expect(getActiveSession(CONV_ID)).toBeUndefined();
-      const all = getSessionsForConversation(CONV_ID);
-      const s = all.find((x) => x.id === session.id);
-      expect(s?.status).toBe("stopped");
+      expect(findSession()?.status).toBe("stopped");
     });
   });
 


### PR DESCRIPTION
## Summary
- Fixes the flaky `session-manager > idle timeout > auto-stops session after idle timeout` failure that broke main CI ([run 27382778028](https://github.com/vellum-ai/vellum-assistant/actions/runs/27382778028)).
- The idle timer flips the session to `stopping`; the terminal `stopped` state only lands after the async `server.close()` completes, which can outlast the test's fixed 200ms sleep under CI load.
- Replace the fixed sleep with a bounded poll (5s deadline, 20ms interval) for the terminal `stopped` state.

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/27382778028

🤖 Generated with [Claude Code](https://claude.com/claude-code)