### PR TITLE
fix(schedules): center-align cadence/timestamp with cost and runs columns

### DIFF
--- a/apps/web/src/domains/settings/components/schedule-row.tsx
+++ b/apps/web/src/domains/settings/components/schedule-row.tsx
@@ -76,11 +76,9 @@ export function ScheduleRow({
           </span>
         </div>
         {descriptionText ? (
-          <div className="mt-0.5 text-body-small-default text-[var(--content-tertiary)]">
-            <span className="min-w-[12rem] max-w-full truncate">
-              {descriptionText}
-            </span>
-          </div>
+          <p className="mt-0.5 truncate text-body-small-default text-[var(--content-tertiary)]">
+            {descriptionText}
+          </p>
         ) : null}
       </button>
       {(cadenceText || timestampText) && (

--- a/apps/web/src/domains/settings/components/schedule-row.tsx
+++ b/apps/web/src/domains/settings/components/schedule-row.tsx
@@ -75,12 +75,16 @@ export function ScheduleRow({
             {schedule.name}
           </span>
         </div>
-        <div className="mt-0.5 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 text-body-small-default text-[var(--content-tertiary)]">
-          {descriptionText ? (
-            <span className="min-w-[12rem] max-w-full flex-1 truncate">
+        {descriptionText ? (
+          <div className="mt-0.5 text-body-small-default text-[var(--content-tertiary)]">
+            <span className="min-w-[12rem] max-w-full truncate">
               {descriptionText}
             </span>
-          ) : null}
+          </div>
+        ) : null}
+      </button>
+      {(cadenceText || timestampText) && (
+        <div className="flex shrink-0 items-center gap-3 text-body-small-default text-[var(--content-tertiary)]">
           {cadenceText ? (
             <span className="shrink-0 text-[var(--content-secondary)]">
               {cadenceText}
@@ -90,7 +94,7 @@ export function ScheduleRow({
             <span className="shrink-0">{timestampText}</span>
           ) : null}
         </div>
-      </button>
+      )}
       <div className="flex shrink-0 items-center gap-3">
         <ScheduleUsageStats
           scheduleName={schedule.name}


### PR DESCRIPTION
## Summary
- Moved cadence text ("Every hour") and last-run timestamp out of the button's subtitle line and into their own `shrink-0` flex div at the same level as the stats
- Since the outer row uses `items-center`, all three sections (name/description, cadence/timestamp, cost/runs/toggle) now share the same vertical center
- Added a guard so the cadence/timestamp div only renders when there is content to show

## Original prompt
The Schedules page row was visually misaligned: the "Every hour" cadence text and the "Last Jun 11, 2:00 PM" timestamp appeared in the second line of the clickable button element (below the schedule name), while the Cost and Runs stats were vertically centered in the right-side flex div. Because the button was taller (two stacked lines) than the stats area, the cadence/timestamp sat below the visual center — misaligned with Cost ($0.00) and Runs (1 run). The fix moves cadence and timestamp into a dedicated `shrink-0` sibling div so all elements center-align together.