### PR TITLE
Replace <no_response/> sentinel with a no_response turn-control tool

### DIFF
--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -32,7 +32,10 @@
       "label": "Pre-chat Onboarding Experiment 2026-06-06",
       "description": "Pre-chat onboarding experiment with control and variant-a arms. Control shows the full funnel; variant-a shows the condensed pared-down flow.",
       "defaultEnabled": "control",
-      "values": ["control", "variant-a"]
+      "values": [
+        "control",
+        "variant-a"
+      ]
     },
     {
       "id": "experiment-activation-flow-2026-06-03",
@@ -41,7 +44,10 @@
       "label": "Activation Flow Experiment 2026-06-03",
       "description": "Multivariate activation-flow experiment. control = standard flow; variant-a = activation rail. Targeted via LaunchDarkly.",
       "defaultEnabled": "control",
-      "values": ["control", "variant-a"]
+      "values": [
+        "control",
+        "variant-a"
+      ]
     },
     {
       "id": "local-docker-enabled",
@@ -410,6 +416,14 @@
       "label": "Self-intro first message",
       "description": "On the first conversation, send a natural self-introduction (e.g. \"Hi Vela, I'm alex. Nice to meet you.\") on the user's behalf and route it through real LLM inference, instead of serving the canned first greeting. Names come from the onboarding context; falls back to the canned greeting when no name is known. Exposed to clients so pre-hatch onboarding can compute the source-of-truth initial message, and to the assistant so older clients can still be gated server-side. See assistant/src/daemon/first-greeting.ts (buildSelfIntroMessage).",
       "defaultEnabled": false
+    },
+    {
+      "id": "no-response-tool",
+      "scope": "assistant",
+      "key": "no-response-tool",
+      "label": "No-response turn-control tool",
+      "description": "Signal channel-thread silence via the no_response tool (ends the turn with no reply posted). When disabled, the turn context falls back to prompting the legacy <no_response/> text sentinel and the tool is hidden.",
+      "defaultEnabled": true
     }
   ]
 }

--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -697,6 +697,102 @@ describe("channel-reply-delivery", () => {
     expect(deliveryCalls[0].payload.text).toBe("Real response.");
   });
 
+  it("strips an inline <no_response/> wrapped in other text instead of leaking it", async () => {
+    await deliverRenderedReplyViaCallback({
+      callbackUrl: "http://gateway/deliver/slack",
+      chatId: "chat-wrapped",
+      textSegments: ["Sure thing! <no_response/>"],
+      interSegmentDelayMs: 0,
+    });
+
+    expect(deliveryCalls).toHaveLength(1);
+    expect(deliveryCalls[0].payload.text).toBe("Sure thing!");
+  });
+
+  it("suppresses delivery for case-variant sentinels", async () => {
+    await deliverRenderedReplyViaCallback({
+      callbackUrl: "http://gateway/deliver/slack",
+      chatId: "chat-case",
+      textSegments: ["<No_Response/>"],
+      fallbackText: "Fallback text",
+      interSegmentDelayMs: 0,
+    });
+
+    expect(deliveryCalls).toHaveLength(0);
+  });
+
+  it("suppresses all delivery when the no_response tool was invoked", async () => {
+    await deliverRenderedReplyViaCallback({
+      callbackUrl: "http://gateway/deliver/slack",
+      chatId: "chat-tool-silent",
+      textSegments: [],
+      fallbackText: "Fallback text",
+      noResponseToolInvoked: true,
+      attachments: [
+        {
+          id: "att-tool-silent",
+          filename: "notes.txt",
+          mimeType: "text/plain",
+          sizeBytes: 10,
+          kind: "uploaded",
+        },
+      ],
+      interSegmentDelayMs: 0,
+    });
+
+    expect(deliveryCalls).toHaveLength(0);
+  });
+
+  it("delivers real text segments even when the no_response tool was invoked", async () => {
+    await deliverRenderedReplyViaCallback({
+      callbackUrl: "http://gateway/deliver/slack",
+      chatId: "chat-tool-mixed",
+      textSegments: ["Real response."],
+      noResponseToolInvoked: true,
+      interSegmentDelayMs: 0,
+    });
+
+    expect(deliveryCalls).toHaveLength(1);
+    expect(deliveryCalls[0].payload.text).toBe("Real response.");
+  });
+
+  it("treats a current-turn no_response tool call as terminal instead of falling back", async () => {
+    conversationMessages.push(
+      { id: "msg-current-user", role: "user", content: "current prompt" },
+      {
+        id: "msg-current-text",
+        role: "assistant",
+        content: '[{"type":"text","text":"current answer"}]',
+      },
+      {
+        id: "msg-current-tool-silent",
+        role: "assistant",
+        content:
+          '[{"type":"tool_use","id":"tu-nr","name":"no_response","input":{}}]',
+      },
+    );
+    const silentRendered = {
+      text: "",
+      textSegments: [],
+      toolCalls: [{ name: "no_response", input: {} }],
+      toolCallsBeforeText: true,
+      contentOrder: ["tool:0"],
+      surfaces: [],
+      thinkingSegments: [],
+    };
+    renderedHistoryContentQueue.push(silentRendered, silentRendered);
+
+    await deliverReplyViaCallback(
+      "conv-1",
+      "chat-current",
+      "http://gateway/deliver/slack",
+      "assistant-current",
+      { sinceMessageId: "msg-current-user" },
+    );
+
+    expect(deliveryCalls).toHaveLength(0);
+  });
+
   it("passes startFromSegment through deliverReplyViaCallback options", async () => {
     conversationMessages.push(
       { id: "msg-u", role: "user", content: "hi" },

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -1727,9 +1727,33 @@ describe("buildUnifiedTurnContextBlock", () => {
     expect(vellumText).not.toContain("response_discretion:");
     expect(telegramText).toContain("response_discretion:");
     expect(telegramText).toContain("no_response tool");
-    // The literal sentinel must never be prompted — models leaked it into
-    // channel replies; silence is signaled via the no_response tool instead.
+    // The literal sentinel must never be prompted by default — models leaked
+    // it into channel replies; silence is signaled via the no_response tool.
     expect(telegramText).not.toContain("<no_response/>");
+  });
+
+  test("response discretion falls back to the sentinel when the no-response-tool flag is off", () => {
+    const baseOptions: UnifiedTurnContextOptions = {
+      timestamp: "2026-04-02T12:00:00Z",
+      interfaceName: "telegram",
+      channelName: "telegram",
+    };
+
+    const flagOffText = buildUnifiedTurnContextBlock({
+      ...baseOptions,
+      noResponseToolEnabled: false,
+    });
+    const flagOnText = buildUnifiedTurnContextBlock({
+      ...baseOptions,
+      noResponseToolEnabled: true,
+    });
+
+    expect(flagOffText).toContain("response_discretion:");
+    expect(flagOffText).toContain("<no_response/>");
+    expect(flagOffText).not.toContain("no_response tool");
+
+    expect(flagOnText).toContain("no_response tool");
+    expect(flagOnText).not.toContain("<no_response/>");
   });
 
   test("adds task_progress hint only for Slack turns", () => {

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -1726,7 +1726,10 @@ describe("buildUnifiedTurnContextBlock", () => {
 
     expect(vellumText).not.toContain("response_discretion:");
     expect(telegramText).toContain("response_discretion:");
-    expect(telegramText).toContain("<no_response/>");
+    expect(telegramText).toContain("no_response tool");
+    // The literal sentinel must never be prompted — models leaked it into
+    // channel replies; silence is signaled via the no_response tool instead.
+    expect(telegramText).not.toContain("<no_response/>");
   });
 
   test("adds task_progress hint only for Slack turns", () => {

--- a/assistant/src/channels/permission-profiles.ts
+++ b/assistant/src/channels/permission-profiles.ts
@@ -12,6 +12,7 @@
  */
 
 import { getConfig } from "../config/loader.js";
+import { NO_RESPONSE_TOOL_NAME } from "../tools/no-response.js";
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -66,6 +67,11 @@ export function isToolAllowedInChannel(
   toolName: string,
   toolCategory?: string,
 ): boolean {
+  // The no_response turn-control tool is a silence signal, not a capability.
+  // Blocking it cannot protect anything and would force the model to post a
+  // reply in threads it should stay out of, so it bypasses channel profiles.
+  if (toolName === NO_RESPONSE_TOOL_NAME) return true;
+
   const profile = getChannelPermissionProfile(channelId);
   if (!profile) return true;
 

--- a/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
@@ -29,6 +29,8 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { setOverridesForTesting } from "../../__tests__/feature-flag-test-helpers.js";
+
 // ── Module-level mocks ─────────────────────────────────────────────
 
 // Control how many capable clients the hub reports per capability.
@@ -97,6 +99,20 @@ describe("isToolActiveForContext — no_response channel gating", () => {
 
   test("no_response is hidden when channel capabilities are unresolved", () => {
     expect(isToolActiveForContext("no_response", makeCtx())).toBe(false);
+  });
+
+  test("no_response is hidden when the no-response-tool flag is disabled", () => {
+    const ctx = makeCtx({
+      hasNoClient: true,
+      channelCapabilities: { channel: "slack", supportsDynamicUi: false },
+    });
+    setOverridesForTesting({ "no-response-tool": false });
+    try {
+      expect(isToolActiveForContext("no_response", ctx)).toBe(false);
+    } finally {
+      setOverridesForTesting({});
+    }
+    expect(isToolActiveForContext("no_response", ctx)).toBe(true);
   });
 });
 

--- a/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
@@ -72,6 +72,34 @@ beforeEach(() => {
   mockClientCountByCapability.clear();
 });
 
+describe("isToolActiveForContext — no_response channel gating", () => {
+  test("no_response is active for external channel turns", () => {
+    for (const channel of ["slack", "telegram"]) {
+      const ctx = makeCtx({
+        hasNoClient: true,
+        channelCapabilities: { channel, supportsDynamicUi: false },
+      });
+      expect(isToolActiveForContext("no_response", ctx)).toBe(true);
+    }
+  });
+
+  test("no_response is hidden on vellum-native surfaces", () => {
+    expect(
+      isToolActiveForContext(
+        "no_response",
+        makeCtx({
+          hasNoClient: false,
+          channelCapabilities: { channel: "vellum", supportsDynamicUi: true },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test("no_response is hidden when channel capabilities are unresolved", () => {
+    expect(isToolActiveForContext("no_response", makeCtx())).toBe(false);
+  });
+});
+
 describe("isToolActiveForContext — Slack task_progress UI exception", () => {
   test("ui_show and ui_update are active for Slack task_progress turns", () => {
     const ctx = makeCtx({

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -21,6 +21,7 @@ import type { Message, ToolDefinition } from "../providers/types.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { registerConversationSender } from "../tools/browser/browser-screencast.js";
 import type { ToolExecutor } from "../tools/executor.js";
+import { NO_RESPONSE_TOOL_NAME } from "../tools/no-response.js";
 import { getMcpToolDefinitions } from "../tools/registry.js";
 import {
   ACTIVITY_SKIP_SET,
@@ -504,6 +505,15 @@ export function isToolActiveForContext(
     } catch {
       return true;
     }
+  }
+  if (name === NO_RESPONSE_TOOL_NAME) {
+    // Staying silent is only meaningful on external channel threads (Slack,
+    // Telegram, ...) where not every message is directed at the assistant.
+    // Vellum-native surfaces always expect a reply, so the tool is hidden
+    // there. Mirrors the `response_discretion` turn-context gate in
+    // unified-turn-context.ts.
+    const channel = ctx.channelCapabilities?.channel;
+    return channel !== undefined && channel !== "vellum";
   }
   if (UI_SURFACE_TOOL_NAMES.has(name)) {
     if (

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -21,7 +21,10 @@ import type { Message, ToolDefinition } from "../providers/types.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { registerConversationSender } from "../tools/browser/browser-screencast.js";
 import type { ToolExecutor } from "../tools/executor.js";
-import { NO_RESPONSE_TOOL_NAME } from "../tools/no-response.js";
+import {
+  isNoResponseToolEnabled,
+  NO_RESPONSE_TOOL_NAME,
+} from "../tools/no-response.js";
 import { getMcpToolDefinitions } from "../tools/registry.js";
 import {
   ACTIVITY_SKIP_SET,
@@ -511,7 +514,10 @@ export function isToolActiveForContext(
     // Telegram, ...) where not every message is directed at the assistant.
     // Vellum-native surfaces always expect a reply, so the tool is hidden
     // there. Mirrors the `response_discretion` turn-context gate in
-    // unified-turn-context.ts.
+    // unified-turn-context.ts, including the kill-switch flag (when off,
+    // the prompt reverts to the legacy sentinel and the tool must be hidden
+    // so prompt and tool list stay consistent).
+    if (!isNoResponseToolEnabled()) return false;
     const channel = ctx.channelCapabilities?.channel;
     return channel !== undefined && channel !== "vellum";
   }

--- a/assistant/src/plugins/defaults/memory-retrieval/injectors.ts
+++ b/assistant/src/plugins/defaults/memory-retrieval/injectors.ts
@@ -64,6 +64,7 @@ import { searchPkbFiles } from "../../../memory/pkb/pkb-search.js";
 import { getPkbRoot, PKB_WORKSPACE_SCOPE } from "../../../memory/pkb/types.js";
 import { readMemoryV2StaticContent } from "../../../memory/v2/static-context.js";
 import type { Message } from "../../../providers/types.js";
+import { isNoResponseToolEnabled } from "../../../tools/no-response.js";
 import { getLogger } from "../../../util/logger.js";
 import { getSandboxWorkingDir } from "../../../util/platform.js";
 import {
@@ -268,6 +269,7 @@ const unifiedTurnContextInjector: Injector = {
       detectedTimezone: ctx.detectedTimezone,
       timeSinceLastMessage: ctx.timeSinceLastMessage,
       modelProfile: ctx.modelProfile,
+      noResponseToolEnabled: isNoResponseToolEnabled(),
     });
     return {
       id: "unified-turn-context",

--- a/assistant/src/plugins/defaults/memory-retrieval/unified-turn-context.ts
+++ b/assistant/src/plugins/defaults/memory-retrieval/unified-turn-context.ts
@@ -35,6 +35,14 @@ export interface UnifiedTurnContextOptions {
    * paying per-turn token cost.
    */
   modelProfile?: string | null;
+  /**
+   * Whether the `no_response` turn-control tool is available this turn
+   * (`no-response-tool` feature flag). Selects the response_discretion
+   * wording: tool instruction when true (default), legacy `<no_response/>`
+   * sentinel instruction when false. Must match the tool-exposure gate in
+   * conversation-tool-setup.ts so the prompt never references a hidden tool.
+   */
+  noResponseToolEnabled?: boolean;
 }
 
 /**
@@ -210,8 +218,12 @@ export function buildUnifiedTurnContextBlock(
 
   // Response discretion for non-vellum channels.
   if (options.channelName && options.channelName !== "vellum") {
+    const silenceInstruction =
+      options.noResponseToolEnabled !== false
+        ? "call the no_response tool — with no reply text — to stay silent."
+        : "output exactly <no_response/> as your entire reply to stay silent.";
     lines.push(
-      `response_discretion: Not every message in a channel thread requires your response. If a message is clearly not directed at you (e.g. people talking among themselves, acknowledgements, reactions), call the no_response tool — with no reply text — to stay silent.`,
+      `response_discretion: Not every message in a channel thread requires your response. If a message is clearly not directed at you (e.g. people talking among themselves, acknowledgements, reactions), ${silenceInstruction}`,
     );
     if (options.channelName === "slack") {
       lines.push("if you are going to do work, use task_progress");

--- a/assistant/src/plugins/defaults/memory-retrieval/unified-turn-context.ts
+++ b/assistant/src/plugins/defaults/memory-retrieval/unified-turn-context.ts
@@ -211,7 +211,7 @@ export function buildUnifiedTurnContextBlock(
   // Response discretion for non-vellum channels.
   if (options.channelName && options.channelName !== "vellum") {
     lines.push(
-      `response_discretion: Not every message in a channel thread requires your response. If a message is clearly not directed at you (e.g. people talking among themselves, acknowledgements, reactions), output exactly <no_response/> as your entire reply to stay silent.`,
+      `response_discretion: Not every message in a channel thread requires your response. If a message is clearly not directed at you (e.g. people talking among themselves, acknowledgements, reactions), call the no_response tool — with no reply text — to stay silent.`,
     );
     if (options.channelName === "slack") {
       lines.push("if you are going to do work, use task_progress");

--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -1,4 +1,7 @@
-import type { RenderedHistoryContent } from "../daemon/handlers/shared.js";
+import type {
+  HistoryToolCall,
+  RenderedHistoryContent,
+} from "../daemon/handlers/shared.js";
 import { renderHistoryContent } from "../daemon/handlers/shared.js";
 import { getAttachmentMetadataForMessage } from "../memory/attachments-store.js";
 import {
@@ -7,6 +10,7 @@ import {
   updateMessageMetadata,
 } from "../memory/conversation-crud.js";
 import { readSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
+import { NO_RESPONSE_TOOL_NAME } from "../tools/no-response.js";
 import { getLogger } from "../util/logger.js";
 import type { ChannelDeliveryResult } from "./gateway-client.js";
 import { deliverChannelReply } from "./gateway-client.js";
@@ -47,32 +51,60 @@ type DeliverRenderedReplyParams = {
   /** Called with the ts of the delivered/updated message so callers
    *  can use it for subsequent updates. */
   onMessageTs?: (ts: string) => void;
+  /**
+   * True when the source assistant message invoked the `no_response`
+   * turn-control tool. Treated like a `<no_response/>` sentinel: with no
+   * deliverable text remaining, all delivery (including attachments) is
+   * suppressed and fallbackText is never used.
+   */
+  noResponseToolInvoked?: boolean;
 };
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-const NO_RESPONSE_RE = /^\s*<no_response\s*\/?>\s*$/;
+// Presence check (non-global so `.test` is stateless) and global strip form.
+// Case-insensitive to match the Slack DM live-delivery and messages-API
+// handling of the sentinel.
+const NO_RESPONSE_PRESENT_RE = /<no_response\s*\/?>/i;
+const NO_RESPONSE_INLINE_RE = /<no_response\s*\/?>/gi;
 
-/** Returns true when any segment is a `<no_response/>` sentinel. */
+/**
+ * Returns true when any segment contains a `<no_response/>` sentinel —
+ * exact or embedded in other text (models sometimes wrap the sentinel in
+ * artifacts like timestamps or lead-in phrases).
+ */
 function hasNoResponseMarker(textSegments: string[]): boolean {
-  return textSegments.some((s) => NO_RESPONSE_RE.test(s));
+  return textSegments.some((s) => NO_RESPONSE_PRESENT_RE.test(s));
+}
+
+/** Returns true when the message invoked the `no_response` turn-control tool. */
+function hasNoResponseToolCall(toolCalls: HistoryToolCall[]): boolean {
+  return toolCalls.some((c) => c.name === NO_RESPONSE_TOOL_NAME);
+}
+
+function stripNoResponseSentinel(text: string): string {
+  return text.replace(NO_RESPONSE_INLINE_RE, "").trim();
 }
 
 function toDeliverableTextSegments(
   textSegments: string[],
   fallbackText?: string,
+  noResponseToolInvoked?: boolean,
 ): string[] {
-  const nonEmptySegments = textSegments.filter(
-    (segment) => segment.trim().length > 0 && !NO_RESPONSE_RE.test(segment),
-  );
-  if (nonEmptySegments.length > 0) return nonEmptySegments;
-  // If the only text was <no_response/>, treat as intentional silence —
-  // do not fall back to fallbackText.
-  if (hasNoResponseMarker(textSegments)) return [];
-  if (typeof fallbackText === "string" && fallbackText.trim().length > 0) {
-    return [fallbackText];
+  // Strip sentinels inline so a wrapped marker (e.g. "Sure! <no_response/>")
+  // never reaches the channel verbatim.
+  const strippedSegments = textSegments
+    .map(stripNoResponseSentinel)
+    .filter((segment) => segment.length > 0);
+  if (strippedSegments.length > 0) return strippedSegments;
+  // Intentional silence — sentinel-only text or a no_response tool call —
+  // must not fall back to fallbackText.
+  if (noResponseToolInvoked || hasNoResponseMarker(textSegments)) return [];
+  if (typeof fallbackText === "string") {
+    const strippedFallback = stripNoResponseSentinel(fallbackText);
+    if (strippedFallback.length > 0) return [strippedFallback];
   }
   return [];
 }
@@ -81,11 +113,16 @@ function hasDeliverableReply(
   rendered: RenderedHistoryContent,
   attachments: RuntimeAttachmentMetadata[],
 ): boolean {
+  const noResponseToolInvoked = hasNoResponseToolCall(rendered.toolCalls);
   return (
-    toDeliverableTextSegments(rendered.textSegments, rendered.text).length >
-      0 ||
+    toDeliverableTextSegments(
+      rendered.textSegments,
+      rendered.text,
+      noResponseToolInvoked,
+    ).length > 0 ||
     attachments.length > 0 ||
-    hasNoResponseMarker(rendered.textSegments)
+    hasNoResponseMarker(rendered.textSegments) ||
+    noResponseToolInvoked
   );
 }
 
@@ -106,18 +143,24 @@ export async function deliverRenderedReplyViaCallback(
     user,
     messageTs,
     onMessageTs,
+    noResponseToolInvoked,
   } = params;
 
   const deliverableSegments = toDeliverableTextSegments(
     textSegments,
     fallbackText,
+    noResponseToolInvoked,
   );
   const replyAttachments =
     attachments && attachments.length > 0 ? attachments : undefined;
 
-  // If the model output <no_response/> and no other deliverable text remains,
-  // suppress all delivery — including attachments — so nothing is posted.
-  if (deliverableSegments.length === 0 && hasNoResponseMarker(textSegments)) {
+  // If the model signaled silence — via the no_response tool or the
+  // <no_response/> sentinel — and no other deliverable text remains,
+  // suppress all delivery (including attachments) so nothing is posted.
+  if (
+    deliverableSegments.length === 0 &&
+    (noResponseToolInvoked || hasNoResponseMarker(textSegments))
+  ) {
     return;
   }
 
@@ -331,6 +374,7 @@ async function deliverPersistedAssistantMessageViaCallback(
     chatId: externalChatId,
     textSegments: rendered.textSegments,
     fallbackText: rendered.text,
+    noResponseToolInvoked: hasNoResponseToolCall(rendered.toolCalls),
     attachments: replyAttachments,
     assistantId,
     startFromSegment: options?.startFromSegment,

--- a/assistant/src/tools/__tests__/no-response.test.ts
+++ b/assistant/src/tools/__tests__/no-response.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+
+import { isToolAllowedInChannel } from "../../channels/permission-profiles.js";
+import { NO_RESPONSE_TOOL_NAME, noResponseTool } from "../no-response.js";
+import type { ToolContext } from "../types.js";
+
+const context = {
+  conversationId: "conv-123",
+  workingDir: "/tmp",
+  trustClass: "guardian",
+} as ToolContext;
+
+describe("noResponseTool", () => {
+  test("yields the turn back to the user so no follow-up LLM call happens", async () => {
+    const result = await noResponseTool.execute({}, context);
+
+    expect(result.isError).toBe(false);
+    expect(result.yieldToUser).toBe(true);
+  });
+
+  test("accepts an optional reason without changing the outcome", async () => {
+    const result = await noResponseTool.execute(
+      { reason: "thread chatter not directed at the assistant" },
+      context,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.yieldToUser).toBe(true);
+  });
+
+  test("bypasses channel permission profiles — silence must never be blocked", () => {
+    // No profile configured for this channel id, and the name-based exemption
+    // short-circuits before any profile lookup regardless.
+    expect(
+      isToolAllowedInChannel(
+        "channel-restricted",
+        NO_RESPONSE_TOOL_NAME,
+        noResponseTool.category,
+      ),
+    ).toBe(true);
+  });
+});

--- a/assistant/src/tools/__tests__/no-response.test.ts
+++ b/assistant/src/tools/__tests__/no-response.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
+import { setOverridesForTesting } from "../../__tests__/feature-flag-test-helpers.js";
 import { isToolAllowedInChannel } from "../../channels/permission-profiles.js";
-import { NO_RESPONSE_TOOL_NAME, noResponseTool } from "../no-response.js";
+import {
+  isNoResponseToolEnabled,
+  NO_RESPONSE_TOOL_NAME,
+  noResponseTool,
+} from "../no-response.js";
 import type { ToolContext } from "../types.js";
 
 const context = {
@@ -26,6 +31,18 @@ describe("noResponseTool", () => {
 
     expect(result.isError).toBe(false);
     expect(result.yieldToUser).toBe(true);
+  });
+
+  test("is enabled by default and disabled via the no-response-tool flag", () => {
+    expect(isNoResponseToolEnabled()).toBe(true);
+
+    setOverridesForTesting({ "no-response-tool": false });
+    try {
+      expect(isNoResponseToolEnabled()).toBe(false);
+    } finally {
+      setOverridesForTesting({});
+    }
+    expect(isNoResponseToolEnabled()).toBe(true);
   });
 
   test("bypasses channel permission profiles — silence must never be blocked", () => {

--- a/assistant/src/tools/no-response.ts
+++ b/assistant/src/tools/no-response.ts
@@ -1,0 +1,65 @@
+import { RiskLevel } from "../permissions/types.js";
+import { getLogger } from "../util/logger.js";
+import type {
+  ToolContext,
+  ToolDefinition,
+  ToolExecutionResult,
+} from "./types.js";
+
+const log = getLogger("no-response-tool");
+
+export const NO_RESPONSE_TOOL_NAME = "no_response";
+
+/**
+ * Turn-control tool for channel conversations: the model calls it to end the
+ * turn without posting any reply. The result sets `yieldToUser`, so the agent
+ * loop pushes the tool_result into history (keeping the provider's
+ * tool_use/tool_result pairing valid) and stops without another LLM call —
+ * the model never gets a follow-up inference in which it could talk itself
+ * into replying anyway.
+ *
+ * Exposed only on channel conversations (Slack, Telegram, ...) — see the
+ * gate in `conversation-tool-setup.ts`. Vellum-native surfaces always reply.
+ */
+export const noResponseTool = {
+  name: NO_RESPONSE_TOOL_NAME,
+  description:
+    "End the current turn WITHOUT sending any reply to the channel. Use this " +
+    "when the latest message does not call for a response from you — e.g. " +
+    "people talking among themselves, simple acknowledgements ('thanks', " +
+    "'+1', 'sounds good'), reactions, or thread chatter that is not directed " +
+    "at you. Call this tool on its own, without writing any reply text. " +
+    "After it runs, your turn ends immediately and nothing is posted.",
+  category: "conversation",
+  executionTarget: "sandbox",
+  defaultRiskLevel: RiskLevel.Low,
+  input_schema: {
+    type: "object",
+    properties: {
+      reason: {
+        type: "string",
+        description:
+          "Optional one-line note on why no reply is needed (recorded in logs only; never shown in the channel).",
+      },
+    },
+    required: [],
+  },
+
+  async execute(
+    input: Record<string, unknown>,
+    context: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    log.info(
+      {
+        conversationId: context.conversationId,
+        reason: typeof input.reason === "string" ? input.reason : undefined,
+      },
+      "Model elected to stay silent for this turn",
+    );
+    return {
+      content: "Acknowledged — no reply will be posted for this turn.",
+      isError: false,
+      yieldToUser: true,
+    };
+  },
+} satisfies ToolDefinition;

--- a/assistant/src/tools/no-response.ts
+++ b/assistant/src/tools/no-response.ts
@@ -1,3 +1,6 @@
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { getConfig } from "../config/loader.js";
+import type { AssistantConfig } from "../config/types.js";
 import { RiskLevel } from "../permissions/types.js";
 import { getLogger } from "../util/logger.js";
 import type {
@@ -9,6 +12,29 @@ import type {
 const log = getLogger("no-response-tool");
 
 export const NO_RESPONSE_TOOL_NAME = "no_response";
+
+const NO_RESPONSE_TOOL_FLAG = "no-response-tool" as const;
+
+/**
+ * Kill switch for the tool-based silence signal. Default-enabled; when the
+ * flag is off, the tool is hidden from channel turns and the turn context
+ * falls back to prompting the legacy `<no_response/>` text sentinel
+ * (delivery-side sentinel handling is always active, so the off state is
+ * exactly the pre-tool behavior).
+ *
+ * Tolerates an unloaded config (e.g. isolated tests): flag resolution reads
+ * only the override cache and the registry default, so an empty config is
+ * safe and keeps the kill switch effective even before config load.
+ */
+export function isNoResponseToolEnabled(): boolean {
+  let config: AssistantConfig;
+  try {
+    config = getConfig();
+  } catch {
+    config = {} as AssistantConfig;
+  }
+  return isAssistantFeatureFlagEnabled(NO_RESPONSE_TOOL_FLAG, config);
+}
 
 /**
  * Turn-control tool for channel conversations: the model calls it to end the

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -23,6 +23,7 @@ import { fileWriteTool } from "./filesystem/write.js";
 import { recallTool, rememberTool } from "./memory/register.js";
 import { webFetchTool } from "./network/web-fetch.js";
 import { webSearchTool } from "./network/web-search.js";
+import { noResponseTool } from "./no-response.js";
 import { skillExecuteTool } from "./skills/execute.js";
 import { skillLoadTool } from "./skills/load.js";
 import { notifyParentTool } from "./subagent/notify-parent.js";
@@ -93,6 +94,7 @@ export const explicitTools: ToolDefinition[] = [
   credentialStoreTool,
   notifyParentTool,
   askQuestionTool,
+  noResponseTool,
   // NOTE: external skill tools (registered via registerExternalTools in
   // registry.ts) are intentionally NOT included here. `explicitTools` is a
   // module-level const whose value is fixed at first evaluation, so

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -32,7 +32,10 @@
       "label": "Pre-chat Onboarding Experiment 2026-06-06",
       "description": "Pre-chat onboarding experiment with control and variant-a arms. Control shows the full funnel; variant-a shows the condensed pared-down flow.",
       "defaultEnabled": "control",
-      "values": ["control", "variant-a"]
+      "values": [
+        "control",
+        "variant-a"
+      ]
     },
     {
       "id": "experiment-activation-flow-2026-06-03",
@@ -41,7 +44,10 @@
       "label": "Activation Flow Experiment 2026-06-03",
       "description": "Multivariate activation-flow experiment. control = standard flow; variant-a = activation rail. Targeted via LaunchDarkly.",
       "defaultEnabled": "control",
-      "values": ["control", "variant-a"]
+      "values": [
+        "control",
+        "variant-a"
+      ]
     },
     {
       "id": "local-docker-enabled",
@@ -410,6 +416,14 @@
       "label": "Self-intro first message",
       "description": "On the first conversation, send a natural self-introduction (e.g. \"Hi Vela, I'm alex. Nice to meet you.\") on the user's behalf and route it through real LLM inference, instead of serving the canned first greeting. Names come from the onboarding context; falls back to the canned greeting when no name is known. Exposed to clients so pre-hatch onboarding can compute the source-of-truth initial message, and to the assistant so older clients can still be gated server-side. See assistant/src/daemon/first-greeting.ts (buildSelfIntroMessage).",
       "defaultEnabled": false
+    },
+    {
+      "id": "no-response-tool",
+      "scope": "assistant",
+      "key": "no-response-tool",
+      "label": "No-response turn-control tool",
+      "description": "Signal channel-thread silence via the no_response tool (ends the turn with no reply posted). When disabled, the turn context falls back to prompting the legacy <no_response/> text sentinel and the tool is hidden.",
+      "defaultEnabled": true
     }
   ]
 }


### PR DESCRIPTION
## Problem

The `<no_response/>` text sentinel leaked verbatim into a Slack channel today (Ash). Root cause: `channel-reply-delivery.ts` only recognized the sentinel as an **exact full text segment**, while inline stripping (`/<no_response\s*\/?>/gi`) existed only on the Slack DM live path and the messages API read path. Any model that wraps the sentinel in other text — timestamps, lead-ins, case variants — leaks it straight into the channel. Non-frontier models do this often enough that asking for a literal magic string is structurally fragile.

## Approach: structured silence signal

Silence is now signaled via a `no_response` tool instead of prompted literal text:

- **New `no_response` tool** (`assistant/src/tools/no-response.ts`), exposed only on external channel conversations (`channelCapabilities.channel !== "vellum"`). Optional `reason` input is logged, never posted.
- **The tool ends the turn.** Its result sets `yieldToUser: true`, which the agent loop already honors (`src/agent/loop.ts` — same mechanism as `remember`'s `finish_turn` and interactive surfaces): the tool_result is persisted (keeping the provider's tool_use/tool_result pairing valid) and the loop stops **without another LLM call**. This directly addresses why the prior tool-based approach was abandoned — the model used to get a follow-up inference after the tool and would talk itself into replying anyway. Now it never gets that chance.
- **Delivery treats the tool call as a terminal silence marker** — same semantics as the sentinel: suppresses text, attachments, fallbackText, and stops the backward fallback scan in `findAssistantReplyMessageIdForTurn`.
- **Prompt updated**: `response_discretion` in the turn context now instructs calling the tool; the literal sentinel is no longer prompted anywhere.
- **`no_response` bypasses channel permission profiles** (`isToolAllowedInChannel`) — it is a turn-control signal, not a capability; blocking it can only force unwanted replies.

## Defense-in-depth leak fix (the actual bug today)

Sentinel detection is kept for older histories and prompt-cache tail, and hardened in `channel-reply-delivery.ts`:

- Inline/wrapped sentinels (`"Sure thing! <no_response/>"`) are now **stripped** before delivery instead of posted verbatim.
- Detection is case-insensitive (matching the DM path), covering `<No_Response/>` variants.
- Sentinel-only and tool-only replies suppress fallbackText and attachments as before.

## Feature flag (kill switch)

The tool rollout is gated behind a new `no-response-tool` assistant-scope flag, **default ON**. Turning it off hides the tool from channel turns and reverts the `response_discretion` prompt to the legacy `<no_response/>` sentinel instruction — a true revert to old behavior, since sentinel handling was retained everywhere. Only the two model-facing decision points are gated (tool exposure + prompt wording, resolved at the same predicate so they stay consistent per turn); delivery suppression and the inline-stripping leak fix stay unconditional because they also protect the sentinel path.

Companion Terraform PR (LaunchDarkly provisioning): vellum-ai/vellum-assistant-platform#8433

## New tool registration — approval context

`assistant/src/tools/AGENTS.md` discourages new non-skill tools; this one was explicitly requested by Aaron to fix the production sentinel leak. It cannot be a skill: it must be present in every channel turn's tool list with zero activation latency, and its semantics (terminating the agent loop via `yieldToUser`) are loop-internal. The pre-commit new-tool gate was bypassed per the documented flow. If approved as a permanent exception, `tools/AGENTS.md` can be updated in a follow-up.

## Tests

- `channel-reply-delivery.test.ts`: tool-call suppression (text/attachments/fallback), terminal no-fallback scan, inline-wrapped sentinel stripping (leak regression), case-variant suppression, mixed text+tool delivery parity.
- `conversation-tool-setup.test.ts`: tool exposed on slack/telegram, hidden on vellum and when channel is unresolved.
- `no-response.test.ts`: `yieldToUser` contract, channel-profile bypass.
- `conversation-runtime-assembly.test.ts`: prompt asserts the tool instruction and that the literal sentinel is never prompted.

`bunx tsc --noEmit` clean; lint clean. (Note: `channel-reply-delivery.test.ts` + `conversation-tool-setup.test.ts` fail when run in the same bun process due to pre-existing `mock.module` cross-file pollution — reproduced identically on `main`; each file passes alone.)

## Rollout note

Old conversations whose history contains sentinel text remain handled (stripping is retained at all four pipeline layers). Once tool adoption is verified in production, a follow-up can consider removing the prompt-era sentinel paths from the live delivery controllers — the persisted-history strippers should stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
