### PR TITLE
Move heartbeat pause toggle from the list row to the detail page

### DIFF
--- a/apps/web/src/domains/settings/components/system-task-detail-view.tsx
+++ b/apps/web/src/domains/settings/components/system-task-detail-view.tsx
@@ -11,6 +11,7 @@ import { formatTimestamp } from "@/domains/settings/utils/schedule-formatters";
 import { Button } from "@vellumai/design-library/components/button";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { Tag } from "@vellumai/design-library/components/tag";
+import { Toggle } from "@vellumai/design-library/components/toggle";
 
 import type { SystemTaskKind } from "@/domains/settings/types/schedules";
 
@@ -25,6 +26,8 @@ interface SystemTaskDetailViewProps {
   isRunning: boolean;
   onBack: () => void;
   onRunNow: () => void;
+  /** Pauses/resumes automatic runs. Manual Run now stays available. */
+  onToggleEnabled?: (enabled: boolean) => void;
   onOpenMemorySettings?: () => void;
 }
 
@@ -39,6 +42,7 @@ export function SystemTaskDetailView({
   isRunning,
   onBack,
   onRunNow,
+  onToggleEnabled,
   onOpenMemorySettings,
 }: SystemTaskDetailViewProps) {
   const isConsolidation = kind === "consolidation";
@@ -109,7 +113,16 @@ export function SystemTaskDetailView({
         <div className="space-y-2 text-body-medium-lighter">
           <div className="flex items-center justify-between">
             <span className="text-[var(--content-secondary)]">Status</span>
-            <span>{statusValue}</span>
+            <span className="flex items-center gap-2">
+              <span>{statusValue}</span>
+              {!isConsolidation && onToggleEnabled ? (
+                <Toggle
+                  checked={enabled}
+                  onChange={onToggleEnabled}
+                  aria-label={`Toggle ${name}`}
+                />
+              ) : null}
+            </span>
           </div>
           <div className="flex items-center justify-between">
             <span className="text-[var(--content-secondary)]">Next run</span>

--- a/apps/web/src/domains/settings/components/system-tasks-section.tsx
+++ b/apps/web/src/domains/settings/components/system-tasks-section.tsx
@@ -12,7 +12,6 @@ import {
 import { Collapsible } from "@vellumai/design-library/components/collapsible";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { Tag, type TagTone } from "@vellumai/design-library/components/tag";
-import { Toggle } from "@vellumai/design-library/components/toggle";
 
 import type {
   ConsolidationConfigGetResponse,
@@ -34,8 +33,6 @@ interface SystemTaskRowProps {
   statusLabel?: string;
   statusTone?: TagTone;
   onClick: () => void;
-  /** When provided, the row shows a toggle instead of a status dot/tag. */
-  onToggle?: (enabled: boolean) => void;
 }
 
 export function SystemTaskRow({
@@ -49,7 +46,6 @@ export function SystemTaskRow({
   statusLabel,
   statusTone = "neutral",
   onClick,
-  onToggle,
 }: SystemTaskRowProps) {
   return (
     <div className="flex flex-wrap items-center gap-3 rounded-md px-2 py-3 transition-colors hover:bg-[var(--surface-hover)] [&+&]:border-t [&+&]:border-[var(--border-base)]">
@@ -84,7 +80,7 @@ export function SystemTaskRow({
         </div>
         <div className="flex shrink-0 flex-wrap items-center justify-end gap-3">
           <ScheduleUsageStats scheduleName={name} usage={usage} />
-          {onToggle ? null : statusLabel ? (
+          {statusLabel ? (
             <Tag tone={statusTone}>{statusLabel}</Tag>
           ) : (
             <span
@@ -100,13 +96,6 @@ export function SystemTaskRow({
           <ChevronRight className="h-4 w-4 text-[var(--content-tertiary)]" />
         </div>
       </button>
-      {onToggle ? (
-        <Toggle
-          checked={enabled}
-          onChange={onToggle}
-          aria-label={`Toggle ${name}`}
-        />
-      ) : null}
     </div>
   );
 }
@@ -125,7 +114,6 @@ interface SystemTasksSectionProps {
   onRetry: () => void;
   onSelectHeartbeat: () => void;
   onSelectConsolidation: () => void;
-  onToggleHeartbeat: (enabled: boolean) => void;
 }
 
 export function SystemTasksSection({
@@ -138,7 +126,6 @@ export function SystemTasksSection({
   onRetry,
   onSelectHeartbeat,
   onSelectConsolidation,
-  onToggleHeartbeat,
 }: SystemTasksSectionProps) {
   const showHeartbeat = heartbeatConfig != null;
   const showConsolidation = consolidationConfig?.available === true;
@@ -187,7 +174,6 @@ export function SystemTasksSection({
           lastRunAt={heartbeatConfig.lastRunAt}
           usage={heartbeatUsage}
           onClick={onSelectHeartbeat}
-          onToggle={onToggleHeartbeat}
         />
       ) : null}
       {showConsolidation ? (

--- a/apps/web/src/domains/settings/pages/schedules-page.test.ts
+++ b/apps/web/src/domains/settings/pages/schedules-page.test.ts
@@ -57,6 +57,9 @@ const fetchConsolidationRunsMock = mock(
     },
   ],
 );
+const fetchHeartbeatRunsMock = mock(
+  async (_assistantId: string): Promise<ScheduleRun[]> => [],
+);
 const fetchScheduleRunsMock = mock(
   async (_assistantId: string, _scheduleId: string): Promise<ScheduleRun[]> => [],
 );
@@ -72,6 +75,7 @@ mock.module("@/domains/settings/api/schedules", () => ({
   ...schedulesApi,
   createSchedule: createScheduleMock,
   fetchConsolidationRuns: fetchConsolidationRunsMock,
+  fetchHeartbeatRuns: fetchHeartbeatRunsMock,
   fetchScheduleRuns: fetchScheduleRunsMock,
   fetchScheduleUsageSummary: fetchScheduleUsageSummaryMock,
 }));
@@ -109,6 +113,7 @@ afterEach(() => {
   navigateCalls.length = 0;
   createScheduleMock.mockClear();
   fetchConsolidationRunsMock.mockClear();
+  fetchHeartbeatRunsMock.mockClear();
   fetchScheduleRunsMock.mockClear();
   fetchScheduleUsageSummaryMock.mockClear();
   nowSpy?.mockRestore();
@@ -970,9 +975,7 @@ describe("SystemTaskRow", () => {
 });
 
 describe("system task toggles", () => {
-  test("heartbeat row always renders a toggle that reports the new state", () => {
-    const toggleCalls: boolean[] = [];
-
+  test("heartbeat list row shows a status dot; the toggle lives on the detail page", () => {
     render(
       createElement(SystemTasksSection, {
         heartbeatConfig: {
@@ -994,24 +997,54 @@ describe("system task toggles", () => {
         onRetry: () => {},
         onSelectHeartbeat: () => {},
         onSelectConsolidation: () => {},
-        onToggleHeartbeat: (enabled: boolean) => {
-          toggleCalls.push(enabled);
-        },
       }),
     );
 
     // System jobs are collapsed by default — expand the disclosure first.
     fireEvent.click(screen.getByRole("button", { name: /System/i }));
 
-    const toggle = screen.getByLabelText("Toggle Heartbeat");
-    fireEvent.click(toggle);
+    expect(screen.queryByLabelText("Toggle Heartbeat")).toBeNull();
+    expect(screen.getByLabelText("enabled")).toBeTruthy();
+  });
 
-    expect(toggleCalls).toEqual([false]);
+  test("heartbeat detail page toggle reports the new state and keeps Run now available", async () => {
+    const toggleCalls: boolean[] = [];
+
+    renderWithQueryClient(
+      createElement(SystemTaskDetailView, {
+        kind: "heartbeat",
+        assistantId: "assistant-1",
+        name: "Heartbeat",
+        subtitle: "Every 1 hr",
+        enabled: false,
+        nextRunAt: null,
+        lastRunAt: null,
+        isRunning: false,
+        onBack: () => {},
+        onRunNow: () => {},
+        onToggleEnabled: (enabled: boolean) => {
+          toggleCalls.push(enabled);
+        },
+      }),
+    );
+
+    await waitFor(() =>
+      expect(fetchHeartbeatRunsMock.mock.calls).toEqual([["assistant-1"]]),
+    );
+
+    expect(document.body.textContent).toContain("Disabled");
+    // Disabling only pauses automatic runs — manual runs stay available.
+    expect(
+      (screen.getByRole("button", { name: /Run now/i }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(false);
+
+    fireEvent.click(screen.getByLabelText("Toggle Heartbeat"));
+
+    expect(toggleCalls).toEqual([true]);
   });
 
   test("consolidation never renders an automatic-run toggle", () => {
-    const toggleCalls: boolean[] = [];
-
     render(
       createElement(SystemTasksSection, {
         heartbeatConfig: undefined,
@@ -1030,9 +1063,6 @@ describe("system task toggles", () => {
         onRetry: () => {},
         onSelectHeartbeat: () => {},
         onSelectConsolidation: () => {},
-        onToggleHeartbeat: (enabled: boolean) => {
-          toggleCalls.push(enabled);
-        },
       }),
     );
 
@@ -1040,7 +1070,6 @@ describe("system task toggles", () => {
     fireEvent.click(screen.getByRole("button", { name: /System/i }));
 
     expect(screen.queryByLabelText("Toggle Consolidation")).toBeNull();
-    expect(toggleCalls).toEqual([]);
     expect(screen.queryByRole("button", { name: /run now/i })).toBeNull();
     // Enabled consolidation reads like any other healthy system row: a status
     // dot, no management tag or helper copy (the detail page explains it).
@@ -1052,5 +1081,30 @@ describe("system task toggles", () => {
     // Heartbeat is hidden here, so its cached usage must not inflate the
     // aggregate cost on the collapsed trigger ($0.42, not $0.84).
     expect(document.body.textContent).toContain("$0.42 (7d)");
+  });
+
+  test("consolidation detail page never renders a toggle even if a handler is passed", async () => {
+    renderWithQueryClient(
+      createElement(SystemTaskDetailView, {
+        kind: "consolidation",
+        assistantId: "assistant-1",
+        name: "Consolidation",
+        subtitle: "Every 4 hr",
+        enabled: true,
+        nextRunAt: null,
+        lastRunAt: null,
+        isRunning: false,
+        onBack: () => {},
+        onRunNow: () => {},
+        onToggleEnabled: () => {},
+      }),
+    );
+
+    await waitFor(() =>
+      expect(fetchConsolidationRunsMock.mock.calls).toEqual([["assistant-1"]]),
+    );
+
+    expect(screen.queryByLabelText("Toggle Consolidation")).toBeNull();
+    expect(document.body.textContent).toContain("On · Managed by Memory");
   });
 });

--- a/apps/web/src/domains/settings/pages/schedules-page.tsx
+++ b/apps/web/src/domains/settings/pages/schedules-page.tsx
@@ -240,6 +240,9 @@ export function SchedulesPage() {
         isRunning={systemTasks.isHeartbeatRunning}
         onBack={navigateToSchedules}
         onRunNow={() => void systemTasks.handleRunNow("heartbeat")}
+        onToggleEnabled={(enabled) =>
+          void systemTasks.handleToggle("heartbeat", enabled)
+        }
       />
     );
   }
@@ -437,9 +440,6 @@ export function SchedulesPage() {
         }
         onSelectConsolidation={() =>
           navigateToSchedule(SYSTEM_TASK_URL_IDS.consolidation)
-        }
-        onToggleHeartbeat={(enabled) =>
-          void systemTasks.handleToggle("heartbeat", enabled)
         }
       />
 


### PR DESCRIPTION
## Summary
- The Heartbeat row in the System section of `/assistant/settings/schedules` shows a status dot again (green enabled / gray disabled), matching the Consolidation row — the row-level Toggle from #34448 crowded the row and sat awkwardly next to the chevron.
- The enable/disable control moves to the heartbeat detail page (`/assistant/settings/schedules/system-heartbeat`): a Toggle on the Status row next to the Enabled/Disabled text, wired to the existing `handleToggle("heartbeat", enabled)` PATCH + query-cache + toast flow. Run now stays available while automatic runs are paused (original #33593 behavior).
- `SystemTaskRow` loses its now-unused `onToggle` prop and toggle rendering; `SystemTasksSection` loses `onToggleHeartbeat`. The detail view's toggle renders only for the heartbeat kind — consolidation remains structurally toggle-free (managed by Memory), with a new guard test.

## Original prompt
Follow-up to #34448 (merged): the user found the list-row toggle UI bad and asked to move the heartbeat disable control onto the heartbeat detail page while restoring the status-dot indicator on the top-level schedules list, mirroring how the Consolidation row presents.

## Testing
- `cd apps/web && bunx tsc --noEmit` — clean
- `bun test src/domains/settings/pages/schedules-page.test.ts` — 33 pass
- New tests: detail-page toggle fires the handler and keeps Run now enabled while disabled; heartbeat row asserts dot-not-toggle; consolidation detail never renders a toggle even if a handler is passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)