### PR TITLE
feat(web): add Open Settings deep-link to the denied-mic composer notice

### DIFF
--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -254,6 +254,7 @@ export function ChatMainPanel({
     handlePrimerContinue,
     handlePrimerCancel,
     handleRetryMicPermission,
+    handleOpenMicSettings,
   } = useVoiceInput({ assistantId, inputRef, setInput });
 
 
@@ -792,6 +793,7 @@ export function ChatMainPanel({
         voiceError={voiceError}
         onClearVoiceError={clearVoiceError}
         onRetryMicPermission={handleRetryMicPermission}
+        onOpenMicSettings={handleOpenMicSettings}
         onOpenTextInsertionSettings={handleOpenTextInsertionSettings}
         textStateNoticesSlot={textStateNoticesJsx}
       />

--- a/apps/web/src/domains/chat/components/composer-notices.tsx
+++ b/apps/web/src/domains/chat/components/composer-notices.tsx
@@ -6,6 +6,7 @@ import { MissingApiKeyBanner } from "@/domains/chat/components/missing-api-key-b
 import {
   formatVoiceError,
   isMicPermissionError,
+  isMicPermissionPermanentError,
   isTextInsertionPermissionError,
 } from "@/domains/chat/utils/chat";
 import { Button, Notice } from "@vellumai/design-library";
@@ -49,6 +50,13 @@ export interface ComposerNoticesProps {
   onClearVoiceError?: () => void;
   /** Mic-permission retry handler. Only shown when {@link voiceError} is a permission error. */
   onRetryMicPermission?: () => void;
+  /**
+   * Opens the OS microphone privacy settings. Only shown when
+   * {@link voiceError} is a permanent (OS-recorded) mic-permission denial,
+   * which macOS never re-prompts for. Omit when no settings deep-link is
+   * available (plain browser).
+   */
+  onOpenMicSettings?: () => void | Promise<void>;
   /** Opens macOS Automation settings for external-app dictation paste. */
   onOpenTextInsertionSettings?: () => void | Promise<void>;
 
@@ -98,6 +106,7 @@ export function ComposerNotices({
   voiceError,
   onClearVoiceError,
   onRetryMicPermission,
+  onOpenMicSettings,
   onOpenTextInsertionSettings,
   diskPressureBanner,
   billingBannerSlot,
@@ -134,6 +143,17 @@ export function ComposerNotices({
                   onClick={onRetryMicPermission}
                 >
                   Allow Microphone
+                </Button>
+              ) : isMicPermissionPermanentError(voiceError) &&
+                onOpenMicSettings ? (
+                <Button
+                  variant="outlined"
+                  size="compact"
+                  onClick={() => {
+                    void onOpenMicSettings();
+                  }}
+                >
+                  Open Settings
                 </Button>
               ) : isTextInsertionPermissionError(voiceError) &&
                 onOpenTextInsertionSettings ? (

--- a/apps/web/src/domains/chat/hooks/use-voice-input.test.tsx
+++ b/apps/web/src/domains/chat/hooks/use-voice-input.test.tsx
@@ -41,6 +41,23 @@ mock.module("@/domains/chat/voice/use-push-to-talk", () => ({
   usePushToTalk: () => undefined,
 }));
 
+let systemPermissionsSupported = false;
+let nextSystemPermissionStatus: "granted" | "denied" | "not-determined" =
+  "denied";
+const openedSettingsKinds: string[] = [];
+
+mock.module("@/runtime/system-permissions", () => ({
+  supportsSystemPermissions: () => systemPermissionsSupported,
+  requestSystemPermission: async (kind: string) => ({
+    kind,
+    status: nextSystemPermissionStatus,
+  }),
+  openSystemPermissionSettings: async (kind: string) => {
+    openedSettingsKinds.push(kind);
+    return null;
+  },
+}));
+
 const { useVoiceInput } = await import("./use-voice-input");
 
 const renderVoiceInput = (assistantId: string | null = null) => {
@@ -74,6 +91,9 @@ afterEach(() => {
   nextTextInsertionStatus = "unavailable";
   nextDictationResult = null;
   insertedTexts.length = 0;
+  systemPermissionsSupported = false;
+  nextSystemPermissionStatus = "denied";
+  openedSettingsKinds.length = 0;
 });
 
 describe("useVoiceInput", () => {
@@ -118,6 +138,35 @@ describe("useVoiceInput", () => {
     expect(getInput()).toBe("open settings please");
     expect(getFocusCount()).toBe(1);
     expect(hook.result.current.voiceError).toBe("dictation-automation-denied");
+  });
+
+  test("omits handleOpenMicSettings when no OS settings deep-link exists", () => {
+    const { hook } = renderVoiceInput();
+
+    expect(hook.result.current.handleOpenMicSettings).toBeUndefined();
+  });
+
+  test("opens the OS microphone settings pane when supported", async () => {
+    systemPermissionsSupported = true;
+    const { hook } = renderVoiceInput();
+
+    await act(async () => {
+      await hook.result.current.handleOpenMicSettings?.();
+    });
+
+    expect(openedSettingsKinds).toEqual(["microphone"]);
+  });
+
+  test("maps a recorded OS denial to not-allowed-permanent on retry", async () => {
+    systemPermissionsSupported = true;
+    nextSystemPermissionStatus = "denied";
+    const { hook } = renderVoiceInput();
+
+    await act(async () => {
+      await hook.result.current.handleRetryMicPermission();
+    });
+
+    expect(hook.result.current.voiceError).toBe("not-allowed-permanent");
   });
 
 });

--- a/apps/web/src/domains/chat/hooks/use-voice-input.ts
+++ b/apps/web/src/domains/chat/hooks/use-voice-input.ts
@@ -1,5 +1,5 @@
 
-import { type Dispatch, type RefObject, type SetStateAction, useCallback, useEffect, useRef, useState } from "react";
+import { type Dispatch, type RefObject, type SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
   type VoiceInputButtonHandle,
@@ -16,6 +16,7 @@ import {
   openTextInsertionSettings,
 } from "@/runtime/text-insertion";
 import {
+  openSystemPermissionSettings,
   requestSystemPermission,
   supportsSystemPermissions,
 } from "@/runtime/system-permissions";
@@ -74,6 +75,14 @@ export interface UseVoiceInputReturn {
    * `not-allowed-permanent`. Otherwise calls `getUserMedia` to re-prompt.
    */
   handleRetryMicPermission: () => Promise<void>;
+  /**
+   * Opens the OS microphone privacy pane (System Settings → Privacy &
+   * Security → Microphone on macOS) for recovering from a recorded TCC
+   * denial, which the OS never re-prompts for. `undefined` when no
+   * settings deep-link is available (plain browser), so callers can hide
+   * the affordance entirely.
+   */
+  handleOpenMicSettings: (() => Promise<void>) | undefined;
 }
 
 /**
@@ -256,6 +265,16 @@ export function useVoiceInput({
     }
   }, []);
 
+  const handleOpenMicSettings = useMemo(
+    () =>
+      supportsSystemPermissions()
+        ? async () => {
+            await openSystemPermissionSettings("microphone");
+          }
+        : undefined,
+    [],
+  );
+
   return {
     voiceInputRef,
     voiceInterim,
@@ -270,5 +289,6 @@ export function useVoiceInput({
     handlePrimerContinue,
     handlePrimerCancel,
     handleRetryMicPermission,
+    handleOpenMicSettings,
   };
 }

--- a/apps/web/src/domains/chat/utils/chat.ts
+++ b/apps/web/src/domains/chat/utils/chat.ts
@@ -174,6 +174,10 @@ export function isMicPermissionError(code: string | null): boolean {
   return code !== null && MIC_PERMISSION_ERROR_CODES.has(code);
 }
 
+export function isMicPermissionPermanentError(code: string | null): boolean {
+  return code === "not-allowed-permanent";
+}
+
 export function isTextInsertionPermissionError(code: string | null): boolean {
   return code === "dictation-automation-denied";
 }


### PR DESCRIPTION
## Summary
- When macOS records a TCC microphone denial, the OS never re-prompts — the composer notice for `not-allowed-permanent` told users to "allow microphone access in system or browser settings" but offered no way to get there. This adds a one-click **Open Settings** button that deep-links to System Settings → Privacy & Security → Microphone via the unified permissions service from #34031 (`openSystemPermissionSettings("microphone")`).
- `useVoiceInput` exposes the handler only when the Electron permissions bridge exists (`supportsSystemPermissions()`), so plain browsers — where no deep-link is possible — keep the existing text-only guidance.
- The retry flow composes with it: "Allow Microphone" on a `not-allowed` error consults TCC state, maps a recorded denial to `not-allowed-permanent`, and the notice then re-renders with the Open Settings affordance instead of a dead-end retry loop.

## Tests
- `use-voice-input.test.tsx`: handler is `undefined` without the bridge; opens the `microphone` pane when supported; recorded OS denial on retry maps to `not-allowed-permanent`.

## Context
Part of LUM-1968. Re-cuts the last remaining piece of #34372 (closed as superseded by #34031) against the new permissions service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)