### PR TITLE
feat(web): offer macOS Native Dictation as an explicit STT provider on Electron

### DIFF
--- a/apps/web/src/domains/chat/components/voice-input-button.test.tsx
+++ b/apps/web/src/domains/chat/components/voice-input-button.test.tsx
@@ -39,8 +39,12 @@ const postSttTranscribeSpy = mock(
     text: "hello world",
   }),
 );
+// Flipped on by the forced-native tests — mirrors the user picking
+// "macOS Native Dictation" as the STT provider in Settings.
+let prefersNativeStt = false;
 mock.module("@/domains/chat/voice/stt-api", () => ({
   postSttTranscribe: postSttTranscribeSpy,
+  prefersMacosNativeStt: () => prefersNativeStt,
 }));
 
 // The daemon stream defaults to unavailable (null) — live interim text from
@@ -428,5 +432,63 @@ describe("VoiceInputButton — native partials fallback", () => {
     await waitFor(() => {
       expect(onTranscript).toHaveBeenCalledWith("stream words");
     });
+  });
+});
+
+describe("VoiceInputButton — forced native provider (macOS Native Dictation)", () => {
+  beforeEach(() => {
+    addBreadcrumbSpy.mockClear();
+    postSttTranscribeSpy.mockClear();
+    prefersNativeStt = true;
+    useVoiceRecordingStore.getState().reset();
+  });
+
+  afterEach(() => {
+    prefersNativeStt = false;
+    nativePartialsImpl = async () => null;
+    transcribeBlobImpl = async () => null;
+    dictationStreamImpl = () => null;
+    cleanup();
+    useVoiceRecordingStore.getState().reset();
+  });
+
+  test("skips batch STT and the daemon stream; native transcript is the authority", async () => {
+    let streamStarted = false;
+    dictationStreamImpl = () => {
+      streamStarted = true;
+      return { isLive: () => true, stop: () => {} };
+    };
+    transcribeBlobImpl = async () => "spoken natively";
+
+    const onTranscript = mock(async (_text: string) => {});
+    await startSession(onTranscript);
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop recording" }));
+
+    await waitFor(() => {
+      expect(onTranscript).toHaveBeenCalledWith("spoken natively");
+    });
+    expect(postSttTranscribeSpy).not.toHaveBeenCalled();
+    expect(streamStarted).toBe(false);
+    expect(lastBreadcrumb().data.outcome).toBe("completed");
+  });
+
+  test("captured audio with no native transcript surfaces the dictation-setup error", async () => {
+    transcribeBlobImpl = async () => null;
+
+    const onTranscript = mock(async (_text: string) => {});
+    await startSession(onTranscript);
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop recording" }));
+
+    await waitFor(() => {
+      expect(useVoiceRecordingStore.getState().phase).toBe("error");
+    });
+    expect(useVoiceRecordingStore.getState().errorCode).toBe(
+      "native-stt-no-transcript",
+    );
+    expect(postSttTranscribeSpy).not.toHaveBeenCalled();
+    expect(onTranscript).not.toHaveBeenCalled();
+    expect(lastBreadcrumb().data.outcome).toBe("error");
   });
 });

--- a/apps/web/src/domains/chat/components/voice-input-button.tsx
+++ b/apps/web/src/domains/chat/components/voice-input-button.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/runtime/native-dictation-partials";
 import {
     postSttTranscribe,
+    prefersMacosNativeStt,
     type SttFailureReason,
 } from "@/domains/chat/voice/stt-api";
 import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
@@ -553,6 +554,10 @@ export const VoiceInputButton = forwardRef<
     cancelledStartRef.current = false;
     discardedRef.current = false;
     const sessionId = ++sessionIdRef.current;
+    // Honor the explicit "macOS Native Dictation" provider choice for the
+    // whole session: no daemon stream, no batch upload — the helper's
+    // recognizer (already running for every session) is the authority.
+    const nativeSttForced = prefersMacosNativeStt();
 
     if (onBeforeStart) {
       let proceed: boolean;
@@ -749,7 +754,7 @@ export const VoiceInputButton = forwardRef<
         let text = "";
         let daemonFailure: SttFailureReason | null = null;
         try {
-          if (audioBlob && assistantId) {
+          if (audioBlob && assistantId && !nativeSttForced) {
             if (typeof navigator !== "undefined" && navigator.onLine === false) {
               // Provably offline — don't burn the provider timeout to learn
               // what we already know.
@@ -801,7 +806,7 @@ export const VoiceInputButton = forwardRef<
 
         // Character counts only — transcript content must never be logged.
         console.info(
-          `dictation: finalize batchChars=${text.length} blobChars=${blobText.length} nativeChars=${nativeText.length} streamChars=${streamText.length} webChars=${fallbackText.length} failure=${daemonFailure ?? "none"}`,
+          `dictation: finalize batchChars=${text.length} blobChars=${blobText.length} nativeChars=${nativeText.length} streamChars=${streamText.length} webChars=${fallbackText.length} failure=${daemonFailure ?? "none"} forcedNative=${nativeSttForced}`,
         );
 
         if (!text && blobText) {
@@ -837,6 +842,15 @@ export const VoiceInputButton = forwardRef<
             const code = errorCodeForReason(daemonFailure);
             onError?.(code);
             vsFail(code);
+            return;
+          } else if (nativeSttForced && audioBlob) {
+            // Audio was captured but the forced-native recognizer produced
+            // nothing — most likely macOS Dictation (and its on-device
+            // model) isn't enabled. Surface that instead of resetting
+            // silently; there is no daemon failure to report here.
+            addDictationSessionBreadcrumb("error", durationMs, 0);
+            onError?.("native-stt-no-transcript");
+            vsFail("native-stt-no-transcript");
             return;
           } else {
             addDictationSessionBreadcrumb("empty", durationMs, 0);
@@ -889,15 +903,19 @@ export const VoiceInputButton = forwardRef<
 
     // Recording is live — open the daemon streaming session for interim
     // transcripts. Null / later failure means no live partials from that
-    // source; the recorder above is untouched either way.
+    // source; the recorder above is untouched either way. A forced-native
+    // session never opens the stream: the helper recognizer below is its
+    // only transcript source.
     stopDictationStream();
     stopNativePartials();
-    dictationStreamRef.current = startDictationStream({
-      onPartial: (text) => {
-        streamTranscriptRef.current = text;
-        publishInterim(text);
-      },
-    });
+    if (!nativeSttForced) {
+      dictationStreamRef.current = startDictationStream({
+        onPartial: (text) => {
+          streamTranscriptRef.current = text;
+          publishInterim(text);
+        },
+      });
+    }
 
     startNativePartials();
   }, [

--- a/apps/web/src/domains/chat/utils/chat.ts
+++ b/apps/web/src/domains/chat/utils/chat.ts
@@ -152,6 +152,8 @@ const VOICE_ERROR_MESSAGES: Readonly<Record<string, string>> = {
   "stt-unavailable":
     "Speech-to-text is temporarily unavailable. Try again in a moment.",
   "stt-timeout": "Transcription took too long. Try a shorter recording.",
+  "native-stt-no-transcript":
+    "macOS dictation didn’t return a transcript. Make sure Dictation is turned on in System Settings → Keyboard → Dictation, then try again.",
   "dictation-automation-denied":
     "Dictation needs Automation permission to paste into other apps.",
   "dictation-paste-blocked":

--- a/apps/web/src/domains/chat/voice/stt-api.test.ts
+++ b/apps/web/src/domains/chat/voice/stt-api.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Tests for `prefersMacosNativeStt` — the forced-native gate must require
+ * BOTH the persisted provider choice and a live helper dictation bridge. A
+ * stale "macos-native" value in a renderer without the bridge (older
+ * Electron preload, web/iOS) must not suppress the daemon STT paths, or
+ * dictation would be left with no transcript source at all.
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+let nativeDictationSupported = false;
+mock.module("@/runtime/native-dictation-partials", () => ({
+  isNativeDictationSupported: () => nativeDictationSupported,
+}));
+
+const { prefersMacosNativeStt } = await import("@/domains/chat/voice/stt-api");
+
+const LS_STT_PROVIDER = "vellum:voice:sttProvider";
+
+describe("prefersMacosNativeStt", () => {
+  afterEach(() => {
+    localStorage.clear();
+    nativeDictationSupported = false;
+  });
+
+  test("false for the default provider even with the bridge available", () => {
+    nativeDictationSupported = true;
+    expect(prefersMacosNativeStt()).toBe(false);
+  });
+
+  test("true when chosen in settings and the helper bridge is available", () => {
+    nativeDictationSupported = true;
+    localStorage.setItem(LS_STT_PROVIDER, "macos-native");
+    expect(prefersMacosNativeStt()).toBe(true);
+  });
+
+  test("a stale native choice without the bridge does not suppress daemon STT", () => {
+    localStorage.setItem(LS_STT_PROVIDER, "macos-native");
+    expect(prefersMacosNativeStt()).toBe(false);
+  });
+});

--- a/apps/web/src/domains/chat/voice/stt-api.ts
+++ b/apps/web/src/domains/chat/voice/stt-api.ts
@@ -3,6 +3,7 @@ import {
   secretsPost,
   sttTranscribePost,
 } from "@/generated/daemon/sdk.gen";
+import { isNativeDictationSupported } from "@/runtime/native-dictation-partials";
 import {
   getLocalSetting,
   removeLocalSetting,
@@ -60,13 +61,19 @@ const MACOS_NATIVE_STT_PROVIDER_ID = "macos-native";
 
 /**
  * True when the user explicitly chose macOS native dictation as the STT
- * provider in Settings → AI. Callers should then skip the daemon streaming
- * and batch STT paths entirely and rely on the helper recognizer.
+ * provider in Settings → AI AND this renderer can honor it (the helper's
+ * dictation bridge is present). Callers should then skip the daemon
+ * streaming and batch STT paths entirely and rely on the helper recognizer.
+ *
+ * The capability gate matters: a persisted choice can outlive the bridge
+ * (older Electron preload, web/iOS) — suppressing the daemon paths there
+ * would leave dictation with no transcript source at all.
  */
 export function prefersMacosNativeStt(): boolean {
   return (
+    isNativeDictationSupported() &&
     getLocalSetting(LS_STT_PROVIDER, DEFAULT_STT_PROVIDER_ID) ===
-    MACOS_NATIVE_STT_PROVIDER_ID
+      MACOS_NATIVE_STT_PROVIDER_ID
   );
 }
 

--- a/apps/web/src/domains/chat/voice/stt-api.ts
+++ b/apps/web/src/domains/chat/voice/stt-api.ts
@@ -48,6 +48,28 @@ const LS_STT_PROVIDER = "vellum:voice:sttProvider";
 const LS_STT_API_KEY_PREFIX = "vellum:voice:sttApiKey:";
 const DEFAULT_STT_PROVIDER_ID = "deepgram";
 
+/**
+ * Provider id for the explicit "macOS Native Dictation" settings choice.
+ * Not a daemon provider: when selected, dictation routes through the mac
+ * helper's `SFSpeechRecognizer` and never calls `/v1/stt/transcribe`.
+ * Mirrors `MACOS_NATIVE_STT_PROVIDER_ID` in
+ * `@/domains/settings/ai/ai-types.ts` — cross-domain constants stay
+ * duplicated here, like the `LS_STT_*` keys above.
+ */
+const MACOS_NATIVE_STT_PROVIDER_ID = "macos-native";
+
+/**
+ * True when the user explicitly chose macOS native dictation as the STT
+ * provider in Settings → AI. Callers should then skip the daemon streaming
+ * and batch STT paths entirely and rely on the helper recognizer.
+ */
+export function prefersMacosNativeStt(): boolean {
+  return (
+    getLocalSetting(LS_STT_PROVIDER, DEFAULT_STT_PROVIDER_ID) ===
+    MACOS_NATIVE_STT_PROVIDER_ID
+  );
+}
+
 function normalizeSttProviderId(provider: string): string {
   if (provider === "openai" || provider === "whisper") return "openai-whisper";
   return provider;

--- a/apps/web/src/domains/settings/ai/ai-types.ts
+++ b/apps/web/src/domains/settings/ai/ai-types.ts
@@ -138,8 +138,20 @@ export interface STTProvider {
   id: string;
   displayName: string;
   subtitle: string;
-  apiKeyPlaceholder: string;
-  credentialsGuide: ProviderCredentialsGuide;
+  /**
+   * Only offered when the renderer can reach the mac helper's
+   * `SFSpeechRecognizer` (the macOS Electron shell) — see
+   * `isNativeDictationSupported()` in `@/runtime/native-dictation-partials`.
+   */
+  requiresNativeDictation?: boolean;
+  /**
+   * Prerequisite the user must complete before the provider works. Shown
+   * below the provider dropdown in place of a credentials guide.
+   */
+  setupWarning?: string;
+  /** Absent for keyless providers (on-device recognition needs no API key). */
+  apiKeyPlaceholder?: string;
+  credentialsGuide?: ProviderCredentialsGuide;
 }
 
 export interface EmailByoProvider {
@@ -245,6 +257,15 @@ export const TTS_PROVIDERS: readonly TTSProvider[] = [
   },
 ];
 
+/**
+ * STT provider id for Apple's on-device recognition. Not a daemon provider:
+ * when selected, dictation routes through the mac helper's recognizer and
+ * never calls `/v1/stt/transcribe`. Duplicated as a literal in
+ * `@/domains/chat/voice/stt-api.ts` (`prefersMacosNativeStt`) — cross-domain
+ * constants stay duplicated there, like the `LS_STT_*` keys.
+ */
+export const MACOS_NATIVE_STT_PROVIDER_ID = "macos-native";
+
 export const STT_PROVIDERS: readonly STTProvider[] = [
   {
     id: "deepgram",
@@ -270,6 +291,15 @@ export const STT_PROVIDERS: readonly STTProvider[] = [
       url: "https://platform.openai.com/api-keys",
       linkLabel: "Open OpenAI API Keys",
     },
+  },
+  {
+    id: MACOS_NATIVE_STT_PROVIDER_ID,
+    displayName: "macOS Native Dictation",
+    subtitle:
+      "Apple's on-device speech recognition, running locally through the macOS helper. Works offline and needs no API key.",
+    requiresNativeDictation: true,
+    setupWarning:
+      "Requires macOS Dictation to be turned on: open System Settings → Keyboard, then enable Dictation. macOS downloads the on-device speech model the first time Dictation is enabled — without it, voice input produces no transcript.",
   },
 ];
 

--- a/apps/web/src/domains/settings/ai/speech-to-text-card.test.tsx
+++ b/apps/web/src/domains/settings/ai/speech-to-text-card.test.tsx
@@ -103,4 +103,14 @@ describe("SpeechToTextCard — macOS Native Dictation option", () => {
     // Save disabled so the user couldn't persist the correction.
     expect(localStorage.getItem(LS_STT_PROVIDER)).toBe("deepgram");
   });
+
+  test("a legacy provider alias is not overwritten by the self-heal", () => {
+    // "whisper" predates the current catalog ids; stt-api's
+    // normalizeSttProviderId() still maps it at transcribe time, so merely
+    // opening Settings must not rewrite it.
+    localStorage.setItem(LS_STT_PROVIDER, "whisper");
+    render(<SpeechToTextCard />);
+
+    expect(localStorage.getItem(LS_STT_PROVIDER)).toBe("whisper");
+  });
 });

--- a/apps/web/src/domains/settings/ai/speech-to-text-card.test.tsx
+++ b/apps/web/src/domains/settings/ai/speech-to-text-card.test.tsx
@@ -98,5 +98,9 @@ describe("SpeechToTextCard — macOS Native Dictation option", () => {
     );
     expect(trigger?.textContent).toContain("Deepgram");
     expect(screen.getByText("API Key")).toBeTruthy();
+    // The fallback must also self-heal the persisted value — leaving
+    // "macos-native" behind would diverge from what the UI shows, with
+    // Save disabled so the user couldn't persist the correction.
+    expect(localStorage.getItem(LS_STT_PROVIDER)).toBe("deepgram");
   });
 });

--- a/apps/web/src/domains/settings/ai/speech-to-text-card.test.tsx
+++ b/apps/web/src/domains/settings/ai/speech-to-text-card.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * Tests for `SpeechToTextCard`'s "macOS Native Dictation" provider option:
+ *
+ *   1. The option only appears when the renderer can reach the mac helper's
+ *      recognizer (the macOS Electron shell) — never on web/iOS.
+ *   2. Selecting it hides the API-key field and shows the System Settings →
+ *      Keyboard → Dictation prerequisite warning; Save persists the choice.
+ *   3. A persisted native choice on a build without the capability falls
+ *      back to the default provider instead of an empty dropdown.
+ *
+ * The native-dictation runtime module is mocked (its real implementation
+ * imports a Vite `?worker&url` asset and probes `window.vellum`); the
+ * design-library Dropdown is real, driven via its combobox trigger like
+ * `provider-create-form.test.tsx`.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+let nativeDictationSupported = false;
+mock.module("@/runtime/native-dictation-partials", () => ({
+  isNativeDictationSupported: () => nativeDictationSupported,
+}));
+
+const { SpeechToTextCard } = await import(
+  "@/domains/settings/ai/speech-to-text-card"
+);
+const { LS_STT_PROVIDER } = await import("@/domains/settings/ai/ai-types");
+
+function openProviderDropdown(): void {
+  const trigger = document.querySelector<HTMLButtonElement>(
+    'button[role="combobox"][aria-label="STT provider"]',
+  );
+  if (!trigger) throw new Error("expected the STT provider dropdown trigger");
+  fireEvent.click(trigger);
+}
+
+function visibleOptions(): string[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).map((o) => o.textContent?.trim() ?? "");
+}
+
+/** Click an option in the already-open listbox (the trigger toggles). */
+function selectOption(label: string): void {
+  const option = Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).find((o) => o.textContent?.trim() === label);
+  if (!option) {
+    throw new Error(
+      `expected option "${label}" — saw: ${visibleOptions().join(", ")}`,
+    );
+  }
+  fireEvent.click(option);
+}
+
+describe("SpeechToTextCard — macOS Native Dictation option", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    nativeDictationSupported = false;
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  test("native option is absent when the helper recognizer is unavailable", () => {
+    render(<SpeechToTextCard />);
+
+    openProviderDropdown();
+    expect(visibleOptions()).not.toContain("macOS Native Dictation");
+  });
+
+  test("selecting the native option hides the API key field and shows the Dictation warning", () => {
+    nativeDictationSupported = true;
+    render(<SpeechToTextCard />);
+
+    openProviderDropdown();
+    expect(visibleOptions()).toContain("macOS Native Dictation");
+
+    selectOption("macOS Native Dictation");
+
+    expect(screen.queryByText("API Key")).toBeNull();
+    expect(
+      screen.getByText(/System Settings → Keyboard, then enable Dictation/),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(localStorage.getItem(LS_STT_PROVIDER)).toBe("macos-native");
+  });
+
+  test("a stored native choice falls back to the default provider off Electron", () => {
+    localStorage.setItem(LS_STT_PROVIDER, "macos-native");
+    render(<SpeechToTextCard />);
+
+    const trigger = document.querySelector<HTMLButtonElement>(
+      'button[role="combobox"][aria-label="STT provider"]',
+    );
+    expect(trigger?.textContent).toContain("Deepgram");
+    expect(screen.getByText("API Key")).toBeTruthy();
+  });
+});

--- a/apps/web/src/domains/settings/ai/speech-to-text-card.tsx
+++ b/apps/web/src/domains/settings/ai/speech-to-text-card.tsx
@@ -16,6 +16,7 @@ import {
 import {
     LS_STT_API_KEY_PREFIX,
     LS_STT_PROVIDER,
+    MACOS_NATIVE_STT_PROVIDER_ID,
     STT_PROVIDERS,
 } from "@/domains/settings/ai/ai-types";
 
@@ -40,14 +41,20 @@ export function SpeechToTextCard() {
   const [apiKeyText, setApiKeyText] = useState("");
   const [providerHasKey, setProviderHasKey] = useState(false);
 
-  // Self-heal a stored choice this build can't honor: the visual fallback
-  // alone would leave localStorage pointing at a provider the renderer
-  // can't use, and since draft and initial both coerce to the fallback,
-  // Save stays disabled and could never persist the correction. Both deps
-  // are set-once, so this runs only on mount.
+  // Self-heal a stored native choice this build can't honor: the visual
+  // fallback alone would leave localStorage pointing at a provider the
+  // renderer can't use, and since draft and initial both coerce to the
+  // fallback, Save stays disabled and could never persist the correction.
+  // ONLY the capability-dependent native id is corrected — legacy aliases
+  // like "whisper" must survive untouched for normalizeSttProviderId() /
+  // migrateLegacyLocalSttSettings() in stt-api.ts to map at transcribe
+  // time. Both deps are set-once, so this runs only on mount.
   useEffect(() => {
     const stored = getLocalSetting(LS_STT_PROVIDER, defaultProviderId);
-    if (!providers.some((p) => p.id === stored)) {
+    if (
+      stored === MACOS_NATIVE_STT_PROVIDER_ID &&
+      !providers.some((p) => p.id === stored)
+    ) {
       setLocalSetting(LS_STT_PROVIDER, defaultProviderId);
     }
   }, [providers, defaultProviderId]);

--- a/apps/web/src/domains/settings/ai/speech-to-text-card.tsx
+++ b/apps/web/src/domains/settings/ai/speech-to-text-card.tsx
@@ -40,6 +40,18 @@ export function SpeechToTextCard() {
   const [apiKeyText, setApiKeyText] = useState("");
   const [providerHasKey, setProviderHasKey] = useState(false);
 
+  // Self-heal a stored choice this build can't honor: the visual fallback
+  // alone would leave localStorage pointing at a provider the renderer
+  // can't use, and since draft and initial both coerce to the fallback,
+  // Save stays disabled and could never persist the correction. Both deps
+  // are set-once, so this runs only on mount.
+  useEffect(() => {
+    const stored = getLocalSetting(LS_STT_PROVIDER, defaultProviderId);
+    if (!providers.some((p) => p.id === stored)) {
+      setLocalSetting(LS_STT_PROVIDER, defaultProviderId);
+    }
+  }, [providers, defaultProviderId]);
+
   const selectedProvider = useMemo(() => {
     return providers.find((p) => p.id === draftProvider) ?? providers[0]!;
   }, [providers, draftProvider]);

--- a/apps/web/src/domains/settings/ai/speech-to-text-card.tsx
+++ b/apps/web/src/domains/settings/ai/speech-to-text-card.tsx
@@ -1,5 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import { TriangleAlert } from "lucide-react";
+
+import { isNativeDictationSupported } from "@/runtime/native-dictation-partials";
 import { getLocalSetting, setLocalSetting } from "@/utils/local-settings";
 import { Dropdown } from "@vellumai/design-library/components/dropdown";
 import { Input } from "@vellumai/design-library/components/input";
@@ -17,19 +20,30 @@ import {
 } from "@/domains/settings/ai/ai-types";
 
 export function SpeechToTextCard() {
-  const defaultProviderId = STT_PROVIDERS[0]?.id ?? "deepgram";
-  const [draftProvider, setDraftProvider] = useState<string>(() =>
-    getLocalSetting(LS_STT_PROVIDER, defaultProviderId),
+  // Capability is fixed for the renderer's lifetime, so compute the offered
+  // list once: the native provider only exists inside the macOS Electron
+  // shell, where the helper's SFSpeechRecognizer bridge is wired.
+  const [providers] = useState(() =>
+    STT_PROVIDERS.filter(
+      (p) => !p.requiresNativeDictation || isNativeDictationSupported(),
+    ),
   );
+  const defaultProviderId = providers[0]?.id ?? "deepgram";
+  const [draftProvider, setDraftProvider] = useState<string>(() => {
+    const stored = getLocalSetting(LS_STT_PROVIDER, defaultProviderId);
+    // A stored choice this build can't honor (e.g. the native provider
+    // outside the Electron shell) falls back to the default instead of
+    // rendering an empty dropdown.
+    return providers.some((p) => p.id === stored) ? stored : defaultProviderId;
+  });
   const [initialProvider, setInitialProvider] = useState<string>(draftProvider);
   const [apiKeyText, setApiKeyText] = useState("");
   const [providerHasKey, setProviderHasKey] = useState(false);
 
   const selectedProvider = useMemo(() => {
-    return (
-      STT_PROVIDERS.find((p) => p.id === draftProvider) ?? STT_PROVIDERS[0]!
-    );
-  }, [draftProvider]);
+    return providers.find((p) => p.id === draftProvider) ?? providers[0]!;
+  }, [providers, draftProvider]);
+  const requiresApiKey = selectedProvider.apiKeyPlaceholder !== undefined;
 
   useEffect(() => {
     const storedKey = getLocalSetting(
@@ -80,7 +94,7 @@ export function SpeechToTextCard() {
           <Dropdown
             value={draftProvider}
             onChange={setDraftProvider}
-            options={STT_PROVIDERS.map((p) => ({
+            options={providers.map((p) => ({
               value: p.id,
               label: p.displayName,
             }))}
@@ -88,20 +102,31 @@ export function SpeechToTextCard() {
           />
         </div>
 
-        <div className="space-y-1">
-          <label className="block text-body-small-default text-[var(--content-tertiary)]">
-            API Key
-          </label>
-          <Input
-            type="password"
-            value={apiKeyText}
-            onChange={(e) => setApiKeyText(e.target.value)}
-            placeholder={apiKeyPlaceholder}
-            fullWidth
-          />
-        </div>
+        {requiresApiKey && (
+          <div className="space-y-1">
+            <label className="block text-body-small-default text-[var(--content-tertiary)]">
+              API Key
+            </label>
+            <Input
+              type="password"
+              value={apiKeyText}
+              onChange={(e) => setApiKeyText(e.target.value)}
+              placeholder={apiKeyPlaceholder}
+              fullWidth
+            />
+          </div>
+        )}
 
-        <CredentialsGuide guide={selectedProvider.credentialsGuide} />
+        {selectedProvider.setupWarning && (
+          <div className="flex items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-sunken)] p-3 text-body-small-default text-[var(--content-tertiary)]">
+            <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--system-mid-strong)]" />
+            <span>{selectedProvider.setupWarning}</span>
+          </div>
+        )}
+
+        {selectedProvider.credentialsGuide && (
+          <CredentialsGuide guide={selectedProvider.credentialsGuide} />
+        )}
 
         <div className="flex items-center justify-end gap-2">
           <SaveButton onClick={handleSave} disabled={!hasChanges} />

--- a/apps/web/src/runtime/native-dictation-partials.ts
+++ b/apps/web/src/runtime/native-dictation-partials.ts
@@ -45,9 +45,15 @@ function dictationBridge() {
  * `SFSpeechRecognizer` — i.e. the macOS Electron shell with a preload new
  * enough to expose the dictation bridge. Settings uses this to decide
  * whether to offer the "macOS Native Dictation" STT provider at all.
+ *
+ * Requires the one-shot `transcribe`/`onTranscribed` surface, not just the
+ * partials methods: those members are optional for version-skew tolerance,
+ * and a forced-native session's transcript authority is the whole-recording
+ * transcribe — partials alone routinely miss short dictations.
  */
 export function isNativeDictationSupported(): boolean {
-  return !!dictationBridge();
+  const dictation = dictationBridge();
+  return !!dictation?.transcribe && !!dictation.onTranscribed;
 }
 
 export interface NativeDictationPartialsOptions {

--- a/apps/web/src/runtime/native-dictation-partials.ts
+++ b/apps/web/src/runtime/native-dictation-partials.ts
@@ -36,6 +36,20 @@ const PUSH_BATCH_SAMPLES = 1600;
 // Mirror of the pcm-downsample worklet's TARGET_SAMPLE_RATE.
 const PUSH_SAMPLE_RATE = 16000;
 
+function dictationBridge() {
+  return isElectron() ? window.vellum?.helper?.dictation : undefined;
+}
+
+/**
+ * True when the renderer can route dictation through the mac helper's
+ * `SFSpeechRecognizer` — i.e. the macOS Electron shell with a preload new
+ * enough to expose the dictation bridge. Settings uses this to decide
+ * whether to offer the "macOS Native Dictation" STT provider at all.
+ */
+export function isNativeDictationSupported(): boolean {
+  return !!dictationBridge();
+}
+
 export interface NativeDictationPartialsOptions {
   /**
    * The live recording stream. When provided (and the shell supports
@@ -139,9 +153,7 @@ const TRANSCRIBED_TIMEOUT_MS = 8000;
 export async function transcribeNativeAudioBlob(
   blob: Blob,
 ): Promise<string | null> {
-  const dictation = isElectron()
-    ? window.vellum?.helper?.dictation
-    : undefined;
+  const dictation = dictationBridge();
   if (!dictation?.transcribe || !dictation.onTranscribed) {
     return null;
   }
@@ -239,9 +251,7 @@ export async function startNativeDictationPartials(
   onPartial: (text: string) => void,
   options?: NativeDictationPartialsOptions,
 ): Promise<StopNativeDictationPartials | null> {
-  const dictation = isElectron()
-    ? window.vellum?.helper?.dictation
-    : undefined;
+  const dictation = dictationBridge();
   if (!dictation) {
     return null;
   }


### PR DESCRIPTION
## Summary
- Add a **macOS Native Dictation** option to the Speech-to-Text provider dropdown in Settings → AI, offered only inside the macOS Electron shell (gated on the mac helper's `SFSpeechRecognizer` dictation bridge via a new `isNativeDictationSupported()`).
- When selected, the API-key field and credentials guide are replaced by a warning that macOS Dictation must be enabled in **System Settings → Keyboard → Dictation** (enabling it downloads the on-device speech model the recognizer depends on).
- Dictation sessions honor the choice end-to-end: the renderer skips the daemon streaming STT WebSocket and the batch `/v1/stt/transcribe` upload, making the helper recognizer the sole transcript authority; captured audio that produces no native transcript surfaces a new `native-stt-no-transcript` error pointing at the System Settings prerequisite instead of resetting silently.

## Original prompt
Following the close-out of LUM-1968 (dictation voice-input pipeline), expose the already-working Apple Speech fallback as an explicit user-selectable STT provider: in the voice options under the AI/model settings, show a macOS-native-dictation choice in the provider dropdown only when running in Electron on macOS, and warn the user below the dropdown that they must enable Dictation in System Settings → Keyboard → Dictation. Selecting it should force dictation through the existing native helper path instead of the daemon streaming/batch providers, following the existing provider definition/persistence patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)