### PR TITLE
feat(dictation): stop button in the Electron dictation overlay, state icon on the right

### DIFF
--- a/apps/macos/src/main/commands.ts
+++ b/apps/macos/src/main/commands.ts
@@ -47,6 +47,7 @@ export const DEFAULT_ACCELERATORS: Record<VellumCommandKind, string> = {
   quickInputSubmit: "",
   cancelActiveAction: "",
   cancelDictation: "",
+  stopDictation: "",
   replayOnboarding: "",
   previewPrechat: "",
   replayHatchFailure: "",

--- a/apps/macos/src/main/dictation-overlay-window.ts
+++ b/apps/macos/src/main/dictation-overlay-window.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, screen } from "electron";
+import { BrowserWindow, screen, type WebContents } from "electron";
 import { z } from "zod";
 
 import type {
@@ -229,13 +229,22 @@ export const installDictationOverlay = (
     /**
      * The user clicked the overlay's stop button. Injected (same reason as
      * above) so main can relay a `stopDictation` command to the renderer
-     * that owns the recording session.
+     * that owns the recording session. `owner` is the WebContents that
+     * published the session's overlay state — the chat composer can live in
+     * the main window or a conversation pop-out — or null when it's already
+     * gone (fall back to the main window).
      */
-    onStopRequested?: () => void;
+    onStopRequested?: (owner: WebContents | null) => void;
   } = {},
 ): void => {
   if (installed) return;
   installed = true;
+
+  // The renderer that published the current session's state. Captured on
+  // every lifecycle message rather than just session start: it's the same
+  // sender throughout a session, and re-capturing keeps it correct without
+  // session-boundary bookkeeping.
+  let sessionOwner: WebContents | null = null;
 
   const controller = createDictationOverlayController({
     showOverlay,
@@ -249,7 +258,8 @@ export const installDictationOverlay = (
   on(
     "vellum:dictationOverlay:setState",
     z.tuple([dictationOverlayMessageSchema]),
-    ([message]) => {
+    ([message], event) => {
+      sessionOwner = event.sender;
       options.onRecordingLifecycle?.(message.kind === "recording");
       controller.handleMessage(message);
     },
@@ -259,7 +269,9 @@ export const installDictationOverlay = (
 
   // Sent by the overlay's own renderer when the stop button is clicked.
   on("vellum:dictationOverlay:requestStop", z.tuple([]), () => {
-    options.onStopRequested?.();
+    options.onStopRequested?.(
+      sessionOwner && !sessionOwner.isDestroyed() ? sessionOwner : null,
+    );
   });
 
   // The overlay window is click-through by default; the overlay renderer

--- a/apps/macos/src/main/dictation-overlay-window.ts
+++ b/apps/macos/src/main/dictation-overlay-window.ts
@@ -24,8 +24,10 @@ import { handle, on } from "./ipc";
  * `apps/web/`, same standalone pattern as Quick Input).
  *
  * `type: "panel"` + `focusable: false` keep the overlay from ever stealing
- * focus from the app being dictated into, and the window is fully
- * click-through — it's a display surface only.
+ * focus from the app being dictated into. The window is click-through by
+ * default; the page flips it interactive while the cursor hovers the pill's
+ * stop button (via `vellum:dictationOverlay:setInteractive`) so the button
+ * is clickable without the transparent canvas swallowing clicks.
  */
 
 const OVERLAY_KIND = "dictation-overlay";
@@ -188,10 +190,25 @@ const showOverlay = (): void => {
   ensureOverlayWindow();
 };
 
+// Whether interactive (clickable, while hovering the stop button) or
+// click-through, the window must keep forwarding mousemove to the page —
+// without `forward: true` the page never sees the mouseenter/mouseleave
+// that drive the toggle.
+const setOverlayInteractive = (
+  win: BrowserWindow,
+  interactive: boolean,
+): void => {
+  win.setIgnoreMouseEvents(!interactive, { forward: true });
+};
+
 const hideOverlay = (): void => {
   latestState = null;
   const win = getFloatingWindow(OVERLAY_KIND);
   if (win) {
+    // A session can end while the cursor is over the stop button, so its
+    // mouseleave (which restores click-through) never fires — re-assert it
+    // here so the next session doesn't start with an interactive canvas.
+    setOverlayInteractive(win, false);
     win.hide();
   }
 };
@@ -209,6 +226,12 @@ export const installDictationOverlay = (
      * recording even when the overlay itself is suppressed.
      */
     onRecordingLifecycle?: (recording: boolean) => void;
+    /**
+     * The user clicked the overlay's stop button. Injected (same reason as
+     * above) so main can relay a `stopDictation` command to the renderer
+     * that owns the recording session.
+     */
+    onStopRequested?: () => void;
   } = {},
 ): void => {
   if (installed) return;
@@ -233,4 +256,24 @@ export const installDictationOverlay = (
   );
 
   handle("vellum:dictationOverlay:getState", z.tuple([]), () => latestState);
+
+  // Sent by the overlay's own renderer when the stop button is clicked.
+  on("vellum:dictationOverlay:requestStop", z.tuple([]), () => {
+    options.onStopRequested?.();
+  });
+
+  // The overlay window is click-through by default; the overlay renderer
+  // flips it interactive while the cursor is over the stop button (the
+  // standard Electron forward-mousemove hover pattern), so clicks on the
+  // transparent canvas around the pill still reach the app underneath.
+  on(
+    "vellum:dictationOverlay:setInteractive",
+    z.tuple([z.boolean()]),
+    ([interactive]) => {
+      const win = getFloatingWindow(OVERLAY_KIND);
+      if (win) {
+        setOverlayInteractive(win, interactive);
+      }
+    },
+  );
 };

--- a/apps/macos/src/main/floating-window.test.ts
+++ b/apps/macos/src/main/floating-window.test.ts
@@ -271,7 +271,9 @@ describe("createFloatingWindow", () => {
       ignoreMouseEvents: true,
     }) as unknown as StubWindow & { __calls: string[] };
 
-    expect(win.setIgnoreMouseEvents.mock.calls).toEqual([[true]]);
+    expect(win.setIgnoreMouseEvents.mock.calls).toEqual([
+      [true, { forward: true }],
+    ]);
     expect(win.__calls).toEqual(["setIgnoreMouseEvents", "showInactive"]);
   });
 

--- a/apps/macos/src/main/floating-window.ts
+++ b/apps/macos/src/main/floating-window.ts
@@ -117,7 +117,10 @@ export const createFloatingWindow = ({
 
   win.setAlwaysOnTop(true, alwaysOnTopLevel);
   if (ignoreMouseEvents) {
-    win.setIgnoreMouseEvents(true);
+    // `forward: true` keeps the window click-through while still delivering
+    // mousemove to the page, so hoverable controls (the dictation overlay's
+    // stop button) can flip interactivity on via mouseenter/mouseleave.
+    win.setIgnoreMouseEvents(true, { forward: true });
   }
   if (visibleOnAllWorkspaces) {
     win.setVisibleOnAllWorkspaces(true, {

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -53,6 +53,7 @@ import { installHostProxyBridge } from "./host-proxy-router";
 import "./executors/host-bash-executor"; // side-effect: registers host_bash executor
 import log from "./logger";
 import {
+  dispatchToMain,
   ensureVisible as ensureMainWindowVisible,
   installMainWindow,
   toggleVisibility as toggleMainWindowVisibility,
@@ -353,7 +354,13 @@ app
     installCommandPaletteWindow();
     installApplicationMenu();
     installQuickInput();
-    installDictationOverlay({ onRecordingLifecycle: setDictationRecording });
+    installDictationOverlay({
+      onRecordingLifecycle: setDictationRecording,
+      // The recording session lives in the main window's renderer (chat
+      // composer or the push-to-talk fallback), so relay the overlay's stop
+      // click there as a command.
+      onStopRequested: () => dispatchToMain({ kind: "stopDictation" }),
+    });
     installPopoutWindows();
     installGlobalShortcuts();
     // Register the avatar channel before the Dock and Tray install so their

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -356,10 +356,17 @@ app
     installQuickInput();
     installDictationOverlay({
       onRecordingLifecycle: setDictationRecording,
-      // The recording session lives in the main window's renderer (chat
-      // composer or the push-to-talk fallback), so relay the overlay's stop
-      // click there as a command.
-      onStopRequested: () => dispatchToMain({ kind: "stopDictation" }),
+      // Relay the overlay's stop click to the renderer that published the
+      // session's overlay state — the chat composer can live in the main
+      // window or a conversation pop-out. Fall back to the main window when
+      // the owning window is already gone.
+      onStopRequested: (owner) => {
+        if (owner) {
+          owner.send("vellum:command", { kind: "stopDictation" });
+        } else {
+          dispatchToMain({ kind: "stopDictation" });
+        }
+      },
     });
     installPopoutWindows();
     installGlobalShortcuts();

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -471,6 +471,12 @@ const bridge: VellumBridge = {
       ipcRenderer.invoke(
         "vellum:dictationOverlay:getState",
       ) as Promise<DictationOverlayState | null>,
+    requestStop: (): void => {
+      ipcRenderer.send("vellum:dictationOverlay:requestStop");
+    },
+    setInteractive: (interactive: boolean): void => {
+      ipcRenderer.send("vellum:dictationOverlay:setInteractive", interactive);
+    },
   },
   popout: {
     open: (conversationId: string): Promise<void> =>

--- a/apps/web/src/components/dictation-overlay-page.tsx
+++ b/apps/web/src/components/dictation-overlay-page.tsx
@@ -1,19 +1,22 @@
-import { Check, Loader2, TriangleAlert } from "lucide-react";
+import { Check, Loader2, Square, TriangleAlert } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import {
   getDictationOverlayState,
+  requestDictationOverlayStop,
+  setDictationOverlayInteractive,
   subscribeToDictationOverlayState,
 } from "@/runtime/dictation-overlay";
 import type { DictationOverlayState } from "@/runtime/is-electron";
 
 /**
  * Live dictation pill rendered inside the Electron dictation overlay
- * BrowserWindow — a click-through, non-activating panel pinned top-center
- * of the active display while the user dictates via push-to-talk into
- * another app. The Electron port of the native Swift client's
- * `DictationOverlayWindow`: a status row (state icon + label), compact
- * audio meter, and optional two-line live transcription.
+ * BrowserWindow — a non-activating panel pinned top-center of the active
+ * display while the user dictates via push-to-talk into another app. The
+ * Electron port of the native Swift client's `DictationOverlayWindow`: a
+ * status row (stop button + label, with the state icon and compact audio
+ * meter on the right edge) and optional two-line live transcription. The
+ * window is click-through except while the cursor hovers the stop button.
  *
  * Standalone (no auth, no RootLayout) like the Quick Input page; the
  * window canvas is transparent, so the page paints only the pill. The
@@ -50,13 +53,16 @@ export function DictationOverlayPage() {
     <div className="flex h-screen w-screen items-start justify-center bg-transparent p-4">
       <div className="flex w-[min(28rem,calc(100vw-2rem))] flex-col gap-1 rounded-xl border border-[var(--border-default)] bg-[var(--surface-base)] px-4 py-2.5 shadow-lg">
         <div className="flex min-w-0 items-center gap-2">
-          <StateIcon state={state} />
+          {(state.kind === "recording" || state.kind === "processing") && (
+            <StopButton processing={state.kind === "processing"} />
+          )}
           <span className="truncate text-[11px] font-medium text-[var(--content-secondary)]">
             {stateLabel(state)}
           </span>
-          {state.kind === "recording" && (
-            <AudioMeter level={audioLevel} />
-          )}
+          <div className="ml-auto flex shrink-0 items-center gap-2">
+            {state.kind === "recording" && <AudioMeter level={audioLevel} />}
+            <StateIcon state={state} />
+          </div>
         </div>
         {transcription && (
           // Bottom-anchored two-line text: the transcript grows as words
@@ -73,14 +79,41 @@ export function DictationOverlayPage() {
   );
 }
 
+/**
+ * Stop control shown while a session can still be ended: during recording
+ * it stops the capture and hands the audio to transcription; during
+ * processing it abandons the in-flight transcription.
+ *
+ * The overlay window is click-through, so the button is only clickable via
+ * the forwarded-mousemove hover pattern: mouseenter flips the window
+ * interactive, mouseleave (or unmount, when the session reaches a terminal
+ * state under the cursor) flips it back.
+ */
+function StopButton({ processing }: { processing: boolean }) {
+  useEffect(() => () => setDictationOverlayInteractive(false), []);
+
+  const label = processing ? "Cancel transcription" : "Stop dictation";
+
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      className="flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-full border border-[var(--border-default)] text-[var(--system-negative-strong)] transition-colors hover:bg-[var(--surface-hover)]"
+      onMouseEnter={() => setDictationOverlayInteractive(true)}
+      onMouseLeave={() => setDictationOverlayInteractive(false)}
+      onClick={() => requestDictationOverlayStop()}
+    >
+      <Square className="size-2 fill-current" aria-hidden />
+    </button>
+  );
+}
+
 function AudioMeter({ level }: { level: number }) {
   const clamped = Math.max(0, Math.min(1, level));
 
   return (
-    <div
-      className="ml-auto flex h-4 w-16 shrink-0 items-end gap-0.5"
-      aria-hidden
-    >
+    <div className="flex h-4 w-16 shrink-0 items-end gap-0.5" aria-hidden>
       {[0.16, 0.32, 0.48, 0.64, 0.8, 0.96].map((threshold, index) => (
         <span
           key={threshold}

--- a/apps/web/src/domains/chat/components/voice-input-button.tsx
+++ b/apps/web/src/domains/chat/components/voice-input-button.tsx
@@ -527,13 +527,21 @@ export const VoiceInputButton = forwardRef<
     },
     // The dictation overlay's stop button. While recording it ends the
     // session the normal way (capture stops, audio goes to STT); while
-    // processing it abandons the transcription outright.
+    // processing it abandons the transcription outright. Both branches
+    // need an ownership guard: two instances are mounted per window (chat
+    // composer + the headless push-to-talk bridge) and the non-owner must
+    // not touch the shared store — its vsReset would flip the phase to
+    // idle before the owner's handler runs, leaving the owner's STT
+    // request alive to insert the transcript anyway. The owner is the
+    // instance holding the recorder (recording, or stopped but onstop
+    // hasn't run) or the in-flight transcribe abort controller.
     stopDictation: () => {
       const { phase } = useVoiceRecordingStore.getState();
       if (phase === "recording") {
         if (!mediaRecorderRef.current) return;
         stopRecording();
       } else if (phase === "processing") {
+        if (!mediaRecorderRef.current && !transcribeAbortRef.current) return;
         abortProcessing();
       }
     },

--- a/apps/web/src/domains/chat/components/voice-input-button.tsx
+++ b/apps/web/src/domains/chat/components/voice-input-button.tsx
@@ -883,6 +883,12 @@ export const VoiceInputButton = forwardRef<
         } finally {
           transcribeAbortRef.current = null;
         }
+        // Re-check after the awaited delivery: a cancel (overlay stop
+        // button) landing while `onTranscript` was in flight bumped the
+        // session id after the guard above. Delivery already started and
+        // can't be retracted, but the cancelled session must not overwrite
+        // the user's reset with a "done" flash.
+        if (sessionIdRef.current !== sessionId) return;
         vsFinalize();
       })();
     };

--- a/apps/web/src/domains/chat/components/voice-input-button.tsx
+++ b/apps/web/src/domains/chat/components/voice-input-button.tsx
@@ -501,6 +501,21 @@ export const VoiceInputButton = forwardRef<
     };
   }, [recording, cancelRecording]);
 
+  /**
+   * Abandon an in-flight transcription (the dictation overlay's stop
+   * button during "Processing…"). Bumping the session id makes the async
+   * STT completion drop its result, the abort cancels the batch POST, and
+   * `discardedRef` covers the window where the store is already
+   * "processing" but `recorder.onstop` hasn't run yet.
+   */
+  const abortProcessing = useCallback(() => {
+    sessionIdRef.current += 1;
+    discardedRef.current = true;
+    transcribeAbortRef.current?.abort();
+    transcribeAbortRef.current = null;
+    vsReset();
+  }, [vsReset]);
+
   // The DOM listener above only sees Escape while a Vellum window has
   // focus. During system-wide push-to-talk dictation into another app the
   // Electron escape monitor owns Escape and relays it as a command; the
@@ -509,6 +524,18 @@ export const VoiceInputButton = forwardRef<
     cancelDictation: () => {
       if (!mediaRecorderRef.current) return;
       cancelRecording();
+    },
+    // The dictation overlay's stop button. While recording it ends the
+    // session the normal way (capture stops, audio goes to STT); while
+    // processing it abandons the transcription outright.
+    stopDictation: () => {
+      const { phase } = useVoiceRecordingStore.getState();
+      if (phase === "recording") {
+        if (!mediaRecorderRef.current) return;
+        stopRecording();
+      } else if (phase === "processing") {
+        abortProcessing();
+      }
     },
   });
 

--- a/apps/web/src/runtime/dictation-overlay.ts
+++ b/apps/web/src/runtime/dictation-overlay.ts
@@ -54,3 +54,24 @@ export async function getDictationOverlayState(): Promise<DictationOverlayState 
   }
   return window.vellum.dictationOverlay.getState();
 }
+
+/**
+ * Ask main to stop the active dictation session — the overlay's stop
+ * button. Main relays it to the recording session's renderer as a
+ * `stopDictation` command.
+ */
+export function requestDictationOverlayStop(): void {
+  if (!isElectron()) return;
+  window.vellum?.dictationOverlay?.requestStop?.();
+}
+
+/**
+ * Toggle the overlay window between click-through (default) and
+ * interactive. The overlay page flips it interactive only while the
+ * cursor is over the stop button, so the transparent canvas around the
+ * pill never swallows clicks meant for the app underneath.
+ */
+export function setDictationOverlayInteractive(interactive: boolean): void {
+  if (!isElectron()) return;
+  window.vellum?.dictationOverlay?.setInteractive?.(interactive);
+}

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -246,6 +246,8 @@ declare global {
           callback: (state: DictationOverlayState) => void,
         ): () => void;
         getState(): Promise<DictationOverlayState | null>;
+        requestStop?(): void;
+        setInteractive?(interactive: boolean): void;
       };
       notifications?: {
         show(

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -206,6 +206,8 @@ export interface VellumBridge {
     setState(state: DictationOverlayMessage): void;
     onState(callback: (state: DictationOverlayState) => void): () => void;
     getState(): Promise<DictationOverlayState | null>;
+    requestStop(): void;
+    setInteractive(interactive: boolean): void;
   };
   popout: {
     open(conversationId: string): Promise<void>;

--- a/packages/ipc-contract/src/channels.ts
+++ b/packages/ipc-contract/src/channels.ts
@@ -120,6 +120,10 @@ export const COMMAND_PALETTE_SELECT = "vellum:commandPalette:select";
 export const DICTATION_OVERLAY_SET_STATE = "vellum:dictationOverlay:setState";
 export const DICTATION_OVERLAY_STATE_EVENT = "vellum:dictationOverlay:state";
 export const DICTATION_OVERLAY_GET_STATE = "vellum:dictationOverlay:getState";
+export const DICTATION_OVERLAY_REQUEST_STOP =
+  "vellum:dictationOverlay:requestStop";
+export const DICTATION_OVERLAY_SET_INTERACTIVE =
+  "vellum:dictationOverlay:setInteractive";
 
 // Popout
 export const POPOUT_OPEN = "vellum:popout:open";

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -55,6 +55,7 @@ export type VellumCommand =
   | { kind: "quickInputSubmit"; message: string }
   | { kind: "cancelActiveAction" }
   | { kind: "cancelDictation" }
+  | { kind: "stopDictation" }
   | { kind: "replayOnboarding" }
   | { kind: "previewPrechat" }
   | { kind: "replayHatchFailure" }


### PR DESCRIPTION
## Summary
- Adds a stop button to the macOS Electron dictation overlay pill, visible during both `Recording…` and `Processing…`. While recording, clicking it stops the capture and sends the audio to transcription (same as the composer's stop button); while processing, it abandons the in-flight transcription and returns to idle — useful when STT hangs.
- The overlay window remains click-through: it now forwards mouse moves (`setIgnoreMouseEvents(true, { forward: true })`) and the page flips the window interactive only while the cursor hovers the stop button, so clicks around the pill still reach the app underneath. New `vellum:dictationOverlay:requestStop`/`setInteractive` IPC channels plus a new `stopDictation` `VellumCommand` relay the click to the renderer that owns the recording session.
- Moves the state icon (red dot / spinner / check / error) to the right edge of the pill next to the audio meter, with the stop button and label on the left.

## Original prompt
When recording in the Electron macOS app, the overlay pill at the top of the screen should have a stop button that displays while recording, and the same button should also appear during the `Processing…` state to just stop/abort it. Additionally, the overlay's state icon should be moved to the right side of the pill.