### PR TITLE
Voice mode: TTS playback with interrupt handling + TTS redaction (LUM-1969)

### DIFF
--- a/apps/macos/.gitignore
+++ b/apps/macos/.gitignore
@@ -6,6 +6,7 @@ resources/bun
 resources/hotkey-helper
 resources/vellum-mac-helper
 resources/vellum-mac-helper.app
+resources/.vellum-mac-helper.source-hash
 resources/web-dist
 native/hotkey-helper/.build/
 native/mac-helper/.build/

--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -65,6 +65,7 @@ import { installPermissionHandler } from "./permissions";
 import { installPermissionsService } from "./permissions-service";
 import { installPowerEvents } from "./power-events";
 import { installConnectivityIpc, installStatusIpc } from "./status";
+import { installVoiceStateIpc } from "./voice-state";
 import { installTextInsertionIpc } from "./textInsertion";
 import { installTray } from "./tray";
 import { hardenedWebPreferences } from "./windows";
@@ -121,6 +122,11 @@ if (app.isPackaged) {
 if (!app.requestSingleInstanceLock()) {
   app.quit();
 }
+
+// Voice-mode TTS playback is triggered by live-voice frames, not a user
+// gesture, so Chromium's autoplay policy would block the AudioContext from
+// starting. Must be set before app.whenReady().
+app.commandLine.appendSwitch("autoplay-policy", "no-user-gesture-required");
 
 // In prod, register `app://` as a "standard" + "secure" scheme so that fetch,
 // service workers, and same-origin policy treat it like https://.
@@ -367,6 +373,7 @@ app
     // initial render reflects any status the renderer publishes during
     // bootstrap rather than briefly showing the default idle dot.
     installStatusIpc();
+    installVoiceStateIpc();
     installEscapeMonitor();
     const lockfilePaths = resolveLockfilePaths(process.env);
     const runProbe = installConnectivityProbe(lockfilePaths);

--- a/apps/macos/src/main/tray.test.ts
+++ b/apps/macos/src/main/tray.test.ts
@@ -167,7 +167,19 @@ mock.module("./status", () => ({
   PULSE_FRAME_INTERVAL_MS: 80,
 }));
 
+// The real `./voice-state` is used (its state machine is the integration
+// under test for the tooltip override); only its `./ipc` boundary is stubbed
+// so importing it never touches `ipcMain`. The stub matches the shape
+// `status.test.ts` leaks when co-run, keeping the registry consistent.
+mock.module("./ipc", () => ({
+  on: () => {},
+  handle: () => {},
+}));
+
 const { installTray, __resetForTesting } = await import("./tray");
+const { setVoiceState, __resetForTesting: resetVoiceState } = await import(
+  "./voice-state"
+);
 
 const handlers = {
   toggleMainWindow: mock(() => undefined),
@@ -194,6 +206,7 @@ beforeEach(() => {
   appQuitMock.mockClear();
   currentStatus = "idle";
   statusListeners.clear();
+  resetVoiceState();
   intervalCallback = null;
   clearIntervalMock.mockClear();
   globalThis.setInterval = ((cb: () => void) => {
@@ -225,6 +238,23 @@ describe("installTray", () => {
     const tray = trays[0];
     // Constructed with the idle frame; tooltip reflects the idle title.
     expect(statusFramesMock).toHaveBeenCalledWith("idle");
+    expect(tray?.setToolTip).toHaveBeenLastCalledWith("title:idle");
+  });
+
+  test("an active voice conversation owns the tooltip until it turns off", () => {
+    installTray(handlers);
+    const tray = trays[0];
+
+    setVoiceState("listening");
+    expect(tray?.setToolTip).toHaveBeenLastCalledWith(
+      "Assistant is listening…",
+    );
+
+    setVoiceState("speaking");
+    expect(tray?.setToolTip).toHaveBeenLastCalledWith("Assistant is speaking…");
+
+    // Voice mode off → the assistant status line takes the tooltip back.
+    setVoiceState("off");
     expect(tray?.setToolTip).toHaveBeenLastCalledWith("title:idle");
   });
 

--- a/apps/macos/src/main/tray.ts
+++ b/apps/macos/src/main/tray.ts
@@ -26,6 +26,7 @@ import {
   type AssistantStatus,
 } from "./status";
 import { invalidateIconCache, statusFrames } from "./status-icon";
+import { getVoiceState, onVoiceStateChange, voiceMenuTitle } from "./voice-state";
 import { readOnboardingActive } from "./window-state";
 
 /**
@@ -119,8 +120,9 @@ const buildTrayMenu = (handlers: TrayHandlers, status: AssistantStatus): Menu =>
   const items: Electron.MenuItemConstructorOptions[] = [
     {
       // Status line, matching the Swift status menu's header. Disabled so
-      // it reads as a label, not an action.
-      label: statusMenuTitle(status),
+      // it reads as a label, not an action. An active voice conversation
+      // takes over the line (listening / thinking / speaking).
+      label: tooltipTitle(status),
       enabled: false,
     },
   ];
@@ -343,12 +345,17 @@ const stopPulse = (): void => {
  * (see `installTray`), so it reflects the current status without rebuilding
  * here on every tick.
  */
+// An active voice conversation owns the tooltip / menu header; otherwise the
+// assistant connection status does.
+const tooltipTitle = (status: AssistantStatus): string =>
+  voiceMenuTitle(getVoiceState()) ?? statusMenuTitle(status);
+
 const applyStatus = (status: AssistantStatus): void => {
   const tray = trayInstance;
   if (!tray) return;
 
   stopPulse();
-  tray.setToolTip(statusMenuTitle(status));
+  tray.setToolTip(tooltipTitle(status));
 
   const frames = statusFrames(status);
   tray.setImage(frames[0]!);
@@ -410,6 +417,11 @@ export const installTray = (handlers: TrayHandlers): void => {
   applyStatus(initialStatus);
   const unsubscribeStatus = onStatusChange(applyStatus);
   const unsubscribeAvatar = onAvatarChange(refreshIcon);
+  // Voice-mode transitions refresh only the tooltip line — going through
+  // applyStatus would needlessly restart the thinking pulse mid-cycle.
+  const unsubscribeVoice = onVoiceStateChange(() => {
+    trayInstance?.setToolTip(tooltipTitle(getStatus()));
+  });
   nativeTheme.on("updated", refreshIcon);
 
   // Explicit destroy on quit. In production the OS releases the
@@ -421,6 +433,7 @@ export const installTray = (handlers: TrayHandlers): void => {
     stopPulse();
     unsubscribeStatus();
     unsubscribeAvatar();
+    unsubscribeVoice();
     nativeTheme.removeListener("updated", refreshIcon);
     trayInstance?.destroy();
     trayInstance = null;

--- a/apps/macos/src/main/voice-state.test.ts
+++ b/apps/macos/src/main/voice-state.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { z } from "zod";
+
+// Capture the channel + schema + handler that `installVoiceStateIpc`
+// registers, without dragging in the real `ipcMain` / sender-origin guard
+// (covered by `ipc.test.ts`). The captured schema is exercised directly so we
+// assert the payload contract the renderer must satisfy.
+type OnRegistration = {
+  channel: string;
+  schema: z.ZodType<unknown[]>;
+  fn: (args: unknown[]) => void;
+};
+const registrations: OnRegistration[] = [];
+const onMock = mock(
+  (channel: string, schema: z.ZodType<unknown[]>, fn: (args: unknown[]) => void) => {
+    registrations.push({ channel, schema, fn });
+  },
+);
+mock.module("./ipc", () => ({ on: onMock }));
+
+const {
+  VOICE_MODE_STATES,
+  getVoiceState,
+  installVoiceStateIpc,
+  onVoiceStateChange,
+  setVoiceState,
+  voiceMenuTitle,
+  __resetForTesting,
+} = await import("./voice-state");
+
+beforeEach(() => {
+  __resetForTesting();
+  registrations.length = 0;
+  onMock.mockClear();
+});
+
+describe("voiceMenuTitle", () => {
+  test("produces a line for every active state and null when off", () => {
+    expect(voiceMenuTitle("off")).toBeNull();
+    expect(voiceMenuTitle("idle")).toBe("Assistant — voice mode ready");
+    expect(voiceMenuTitle("listening")).toBe("Assistant is listening…");
+    expect(voiceMenuTitle("processing")).toBe("Assistant is thinking…");
+    expect(voiceMenuTitle("speaking")).toBe("Assistant is speaking…");
+    expect(voiceMenuTitle("listening", "Vellum")).toBe("Vellum is listening…");
+  });
+});
+
+describe("voice state machine", () => {
+  test("starts off, transitions on set, and notifies listeners once per change", () => {
+    expect(getVoiceState()).toBe("off");
+
+    const seen: string[] = [];
+    const unsubscribe = onVoiceStateChange((state) => seen.push(state));
+
+    setVoiceState("listening");
+    setVoiceState("listening"); // duplicate republish must not re-notify
+    setVoiceState("speaking");
+
+    expect(getVoiceState()).toBe("speaking");
+    expect(seen).toEqual(["listening", "speaking"]);
+
+    unsubscribe();
+    setVoiceState("off");
+    expect(seen).toEqual(["listening", "speaking"]);
+  });
+});
+
+describe("installVoiceStateIpc", () => {
+  test("registers vellum:voice:state once and applies valid payloads", () => {
+    installVoiceStateIpc();
+    installVoiceStateIpc(); // idempotent
+
+    expect(registrations).toHaveLength(1);
+    const registration = registrations[0]!;
+    expect(registration.channel).toBe("vellum:voice:state");
+
+    for (const state of VOICE_MODE_STATES) {
+      expect(registration.schema.safeParse([state]).success).toBe(true);
+    }
+    expect(registration.schema.safeParse(["bogus"]).success).toBe(false);
+    expect(registration.schema.safeParse([]).success).toBe(false);
+
+    registration.fn(["processing"]);
+    expect(getVoiceState()).toBe("processing");
+  });
+});

--- a/apps/macos/src/main/voice-state.ts
+++ b/apps/macos/src/main/voice-state.ts
@@ -1,0 +1,98 @@
+import {
+  VOICE_MODE_STATES,
+  type VoiceModeState,
+  voiceModeStateSchema,
+} from "@vellumai/ipc-contract";
+import { z } from "zod";
+
+import { on } from "./ipc";
+
+/**
+ * Voice mode state published by the renderer over `vellum:voice:state`.
+ *
+ * The renderer owns the voice-mode state machine (it holds the audio context
+ * and the mic input, so transitions fire locally without a main-process round
+ * trip — see the LUM-1969 design); main only mirrors the latest state for
+ * presentation, the same split `status.ts` uses for the assistant connection
+ * status. The tray subscribes to show "listening / thinking / speaking" in
+ * its tooltip and menu header while a voice conversation is active.
+ */
+export { VOICE_MODE_STATES, type VoiceModeState };
+
+/**
+ * Tray tooltip / menu-header line for an active voice conversation, or `null`
+ * when voice mode is inactive (`off`) and the regular assistant status line
+ * should be shown instead. Mirrors the Swift `VoiceModeManager.stateLabel`
+ * wording.
+ */
+export const voiceMenuTitle = (
+  state: VoiceModeState,
+  assistantName?: string,
+): string | null => {
+  const name = assistantName ?? "Assistant";
+  switch (state) {
+    case "off":
+      return null;
+    case "idle":
+      return `${name} — voice mode ready`;
+    case "listening":
+      return `${name} is listening…`;
+    case "processing":
+      return `${name} is thinking…`;
+    case "speaking":
+      return `${name} is speaking…`;
+  }
+};
+
+type VoiceStateListener = (state: VoiceModeState) => void;
+
+let currentVoiceState: VoiceModeState = "off";
+const listeners = new Set<VoiceStateListener>();
+
+export const getVoiceState = (): VoiceModeState => currentVoiceState;
+
+/**
+ * Subscribe to voice-state transitions. Returns an unsubscribe function.
+ * Invoked only on an actual change (the setter de-dupes), so subscribers
+ * never rebuild tray presentation for a no-op republish.
+ */
+export const onVoiceStateChange = (
+  listener: VoiceStateListener,
+): (() => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+export const setVoiceState = (state: VoiceModeState): void => {
+  if (state === currentVoiceState) return;
+  currentVoiceState = state;
+  for (const listener of listeners) listener(state);
+};
+
+const voiceStatePayloadSchema = z.tuple([voiceModeStateSchema]);
+
+/**
+ * Register the `vellum:voice:state` renderer→main channel. Fire-and-forget
+ * (`ipcRenderer.send`), matching `vellum:status:connection`: a state
+ * republish has no return value and a malformed payload drops silently.
+ * Call once from `whenReady`.
+ */
+let installed = false;
+export const installVoiceStateIpc = (): void => {
+  if (installed) return;
+  installed = true;
+
+  on("vellum:voice:state", voiceStatePayloadSchema, ([state]) => {
+    setVoiceState(state);
+  });
+};
+
+// Test seam — exported only for unit-test setup so each test starts from a
+// known state. Production code never calls this.
+export const __resetForTesting = (): void => {
+  installed = false;
+  currentVoiceState = "off";
+  listeners.clear();
+};

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -26,6 +26,7 @@ import type {
   UpdateState,
   VellumBridge,
   VellumCommand,
+  VoiceModeState,
 } from "@vellumai/ipc-contract";
 
 export type {
@@ -53,6 +54,7 @@ export type {
   UpdateState,
   VellumBridge,
   VellumCommand,
+  VoiceModeState,
 };
 
 const notImplemented = (name: string) => (): Promise<never> =>
@@ -252,6 +254,11 @@ const bridge: VellumBridge = {
   status: {
     setConnection: (status: AssistantStatus): void => {
       ipcRenderer.send("vellum:status:connection", status);
+    },
+  },
+  voice: {
+    setState: (state: VoiceModeState): void => {
+      ipcRenderer.send("vellum:voice:state", state);
     },
   },
   icon: {

--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -767,6 +767,27 @@ describe("ChatComposer — live-voice integration", () => {
     expect(voiceModeDeactivateSpy).toHaveBeenCalledTimes(1);
   });
 
+  test("voice conversation keeps the voice controls mounted while a response streams", () => {
+    // GIVEN voice mode is speaking AND the turn pipeline reports a stoppable
+    // response (a voice turn streams through the normal turn events, so
+    // canStopGenerating goes true mid-conversation)
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoiceMode = true;
+    mockVoiceModeState = "speaking";
+    mockLiveVoiceState = "speaking";
+
+    // WHEN the composer renders in the stoppable-generation state
+    const { getByLabelText, queryByLabelText } = renderVoiceComposer({
+      canStopGenerating: true,
+    });
+
+    // THEN the controls are NOT swapped for the stop-generation button —
+    // unmounting LiveVoiceButton would tear down the live session mid-response
+    // and remove the interrupt control exactly while speaking
+    expect(getByLabelText("Interrupt and speak")).toBeTruthy();
+    expect(queryByLabelText("Stop generating")).toBeNull();
+  });
+
   test("flag ON but no transcript content: surface stays empty when idle", () => {
     // GIVEN the flag is on but the session is idle
     useTurnStore.setState(INITIAL_TURN_STATE);

--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -54,24 +54,25 @@ mock.module("@/stores/assistant-feature-flag-store", () => ({
   },
 }));
 
-// Local mirror of the live-voice session phases this test exercises. Kept as a
-// narrow union (not an import from the `voice` domain) so the `chat` test stays
-// free of cross-domain coupling — the composer only ever distinguishes idle
-// from non-idle, so the precise phase taxonomy is irrelevant here.
+// Local mirrors of the live-voice session phases / voice-mode states this
+// test exercises. Kept as narrow unions (not imports from the `voice` domain)
+// so the `chat` test stays free of cross-domain coupling — the composer only
+// ever distinguishes off from non-off, so the precise taxonomy is irrelevant
+// here.
 type MockLiveVoiceState = "idle" | "connecting" | "listening" | "failed";
+type MockVoiceModeState = "off" | "idle" | "listening" | "speaking";
 
 let mockLiveVoiceState: MockLiveVoiceState = "idle";
+let mockVoiceModeState: MockVoiceModeState = "off";
 let mockLivePartial = "";
 let mockLiveFinal = "";
 let mockLiveAssistant = "";
-const liveStartSpy = mock(
-  async (_assistantId: string, _conversationId?: string) => {},
-);
-const liveStopSpy = mock(async () => {});
-// The composer reads session state through the store's per-field selectors
-// (`useLiveVoiceStore.use.state()` etc.), so mock the store rather than the
-// `useLiveVoice` controller. `LiveVoiceButton` is the only `useLiveVoice`
-// consumer, and it is mocked separately below.
+const voiceModeActivateSpy = mock(async () => {});
+const voiceModeDeactivateSpy = mock(async () => {});
+const voiceModeInterruptSpy = mock(() => {});
+// The composer reads transcripts through the session store's per-field
+// selectors and activity through the voice-mode store, so mock both stores.
+// `LiveVoiceButton` consumes the `useVoiceMode` controller, mocked below.
 mock.module("@/domains/chat/voice/live-voice/live-voice-store", () => ({
   useLiveVoiceStore: {
     use: {
@@ -82,16 +83,22 @@ mock.module("@/domains/chat/voice/live-voice/live-voice-store", () => ({
     },
   },
 }));
-mock.module("@/domains/chat/voice/live-voice/use-live-voice", () => ({
-  useLiveVoice: () => ({
-    state: mockLiveVoiceState,
-    partialTranscript: mockLivePartial,
-    finalTranscript: mockLiveFinal,
-    assistantTranscript: mockLiveAssistant,
-    inputAmplitude: 0,
+mock.module("@/domains/chat/voice/live-voice/voice-mode-store", () => ({
+  useVoiceModeStore: {
+    use: {
+      state: () => mockVoiceModeState,
+    },
+  },
+}));
+mock.module("@/domains/chat/voice/live-voice/use-voice-mode", () => ({
+  useVoiceMode: () => ({
+    state: mockVoiceModeState,
     error: null,
-    start: liveStartSpy,
-    stop: liveStopSpy,
+    autoDeactivated: false,
+    inputAmplitude: 0,
+    activate: voiceModeActivateSpy,
+    deactivate: voiceModeDeactivateSpy,
+    interrupt: voiceModeInterruptSpy,
   }),
 }));
 
@@ -130,13 +137,15 @@ function resetLiveVoiceMocks() {
   mockIsElectron = false;
   mockVoiceMode = false;
   mockLiveVoiceState = "idle";
+  mockVoiceModeState = "off";
   mockLivePartial = "";
   mockLiveFinal = "";
   mockLiveAssistant = "";
   mockVoicePhase = "idle";
   setAudioLevelSpy.mockClear();
-  liveStartSpy.mockClear();
-  liveStopSpy.mockClear();
+  voiceModeActivateSpy.mockClear();
+  voiceModeDeactivateSpy.mockClear();
+  voiceModeInterruptSpy.mockClear();
 }
 
 // Imported after the mocks so the component (and its transitive flag-store /
@@ -705,9 +714,10 @@ describe("ChatComposer — live-voice integration", () => {
   });
 
   test("active session disables dictation (mutual exclusion)", () => {
-    // GIVEN a live-voice session is listening
+    // GIVEN voice mode is listening
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
+    mockVoiceModeState = "listening";
     mockLiveVoiceState = "listening";
 
     // WHEN the composer renders
@@ -723,9 +733,10 @@ describe("ChatComposer — live-voice integration", () => {
   });
 
   test("active session surfaces user + assistant transcripts", () => {
-    // GIVEN a listening session with partial speech and a streaming reply
+    // GIVEN a listening conversation with partial speech and a streaming reply
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
+    mockVoiceModeState = "listening";
     mockLiveVoiceState = "listening";
     mockLivePartial = "what is the";
     mockLiveAssistant = "Let me check";
@@ -740,19 +751,20 @@ describe("ChatComposer — live-voice integration", () => {
   });
 
   test("active session stays stoppable even when the composer is busy", () => {
-    // GIVEN a live session AND the composer is otherwise disabled
+    // GIVEN an active voice conversation AND the composer is otherwise disabled
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
+    mockVoiceModeState = "listening";
     mockLiveVoiceState = "listening";
 
     // WHEN the composer renders with typingDisabled raised
     const { getByLabelText } = renderVoiceComposer({ typingDisabled: true });
 
-    // THEN the stop control is still actionable and clicking it stops
+    // THEN the stop control is still actionable and clicking it deactivates
     const stop = getByLabelText("Stop voice mode") as HTMLButtonElement;
     expect(stop.disabled).toBe(false);
     fireEvent.click(stop);
-    expect(liveStopSpy).toHaveBeenCalledTimes(1);
+    expect(voiceModeDeactivateSpy).toHaveBeenCalledTimes(1);
   });
 
   test("flag ON but no transcript content: surface stays empty when idle", () => {
@@ -808,9 +820,11 @@ describe("ChatComposer — live-voice integration", () => {
   });
 
   test("failed live-voice state is inactive: dictation re-enabled, no transcript surface", () => {
-    // GIVEN the flag is on and a live-voice start attempt has failed
+    // GIVEN the flag is on and a voice-mode start attempt has failed (the
+    // mode turned itself off; the session store is left in `failed`)
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockVoiceMode = true;
+    mockVoiceModeState = "off";
     mockLiveVoiceState = "failed";
 
     // WHEN the composer renders (dictation idle)

--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -59,7 +59,12 @@ mock.module("@/stores/assistant-feature-flag-store", () => ({
 // so the `chat` test stays free of cross-domain coupling — the composer only
 // ever distinguishes off from non-off, so the precise taxonomy is irrelevant
 // here.
-type MockLiveVoiceState = "idle" | "connecting" | "listening" | "failed";
+type MockLiveVoiceState =
+  | "idle"
+  | "connecting"
+  | "listening"
+  | "speaking"
+  | "failed";
 type MockVoiceModeState = "off" | "idle" | "listening" | "speaking";
 
 let mockLiveVoiceState: MockLiveVoiceState = "idle";

--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -594,7 +594,15 @@ export function ChatComposer({
                 {contextWindowIndicatorSlot}
               </div>
               <div className="flex items-center gap-1">
-                {canStopGenerating ? (
+                {/* A live voice conversation pins the regular controls: a voice
+                turn streams through the normal turn pipeline, so
+                canStopGenerating goes true mid-conversation — swapping to the
+                stop-generation branch would unmount LiveVoiceButton, whose
+                single useVoiceMode controller tears down the live session on
+                unmount (cutting off the spoken response and removing the
+                interrupt control exactly while speaking). While voice mode is
+                active the voice button is the stop/interrupt affordance. */}
+                {canStopGenerating && !isLiveVoiceActive ? (
                   <>
                     {/* Desktop: always show stop. Mobile: show stop only when user has no input. */}
                     {(!isMobile || (!input.trim() && !canSendAttachments)) && (

--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/domains/chat/components/voice-input-button";
 import { type TurnPhase, useTurnStore } from "@/domains/chat/turn-store";
 import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { useVoiceModeStore } from "@/domains/chat/voice/live-voice/voice-mode-store";
 import { useAudioAmplitude } from "@/domains/chat/voice/use-audio-amplitude";
 import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
 import { useIsMobile } from "@/hooks/use-is-mobile";
@@ -225,19 +226,15 @@ export function ChatComposer({
   // effect); the composer only ever *reads* the projected state, so two
   // controllers with competing teardown effects on the same store would be a
   // footgun. These atomic selectors re-render only on the fields they read.
-  const liveVoiceState = useLiveVoiceStore.use.state();
   const liveVoicePartial = useLiveVoiceStore.use.partialTranscript();
   const liveVoiceFinal = useLiveVoiceStore.use.finalTranscript();
   const liveVoiceAssistant = useLiveVoiceStore.use.assistantTranscript();
-  // Anything but idle/failed counts as an active session; while active the
-  // dictation mic is disabled so the two capture flows never run at once.
-  // `failed` is a retryable/inactive state in `useLiveVoice`/`LiveVoiceButton`,
-  // so we must treat it as inactive — otherwise dictation stays disabled and
-  // the (empty) transcript surface stays mounted after a failed start.
-  const isLiveVoiceActive =
-    liveVoiceEligible &&
-    liveVoiceState !== "idle" &&
-    liveVoiceState !== "failed";
+  // Voice mode (the conversation loop in `useVoiceMode`) is the activity
+  // signal, not the underlying session: the loop briefly tears a session down
+  // between turns (and during retry backoff), and those gaps must not flash
+  // the transcript surface away or re-enable the dictation mic mid-loop.
+  const voiceModeState = useVoiceModeStore.use.state();
+  const isLiveVoiceActive = liveVoiceEligible && voiceModeState !== "off";
 
   const pointerCoarse = useMemo(() => isPointerCoarse(), []);
   const isMobile = useIsMobile();

--- a/apps/web/src/domains/chat/components/live-voice-button.test.tsx
+++ b/apps/web/src/domains/chat/components/live-voice-button.test.tsx
@@ -1,10 +1,12 @@
 /**
  * Tests for `LiveVoiceButton`.
  *
- * The button is gated behind the `voice-mode` assistant flag and toggles a
- * {@link useLiveVoice} session. We mock both so the component renders in
- * isolation: the flag store via a mutable `mockVoiceMode`, and `useLiveVoice`
- * via spies for `start`/`stop` plus a mutable `mockState`/`mockInputAmplitude`.
+ * The button is gated behind the `voice-mode` assistant flag and drives the
+ * {@link useVoiceMode} conversation loop. We mock both so the component
+ * renders in isolation: the flag store via a mutable `mockVoiceModeFlag`, and
+ * `useVoiceMode` via spies for `activate`/`deactivate`/`interrupt` plus a
+ * mutable `mockState`/`mockInputAmplitude`. The session-level store supplies
+ * the `connecting` busy phase.
  *
  * Uses happy-dom via the bun:test preload configured in `web/bunfig.toml`.
  */
@@ -20,31 +22,46 @@ import {
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
 import type { LiveVoiceSessionState } from "@/domains/chat/voice/live-voice/live-voice-store";
+import type { VoiceModeState } from "@/domains/chat/voice/live-voice/voice-mode-store";
 
-let mockVoiceMode = false;
+let mockVoiceModeFlag = false;
 mock.module("@/stores/assistant-feature-flag-store", () => ({
   useAssistantFeatureFlagStore: {
     use: {
-      voiceMode: () => mockVoiceMode,
+      voiceMode: () => mockVoiceModeFlag,
     },
   },
 }));
 
-const startSpy = mock(async (_assistantId: string, _conversationId?: string) => {});
-const stopSpy = mock(async () => {});
-let mockState: LiveVoiceSessionState = "idle";
+const activateSpy = mock(async () => {});
+const deactivateSpy = mock(async () => {});
+const interruptSpy = mock(() => {});
+let mockState: VoiceModeState = "off";
 let mockInputAmplitude = 0;
-mock.module("@/domains/chat/voice/live-voice/use-live-voice", () => ({
-  useLiveVoice: () => ({
-    state: mockState,
-    partialTranscript: "",
-    finalTranscript: "",
-    assistantTranscript: "",
-    inputAmplitude: mockInputAmplitude,
-    error: null,
-    start: startSpy,
-    stop: stopSpy,
-  }),
+let lastVoiceModeOptions: { assistantId: string; conversationId?: string } | null =
+  null;
+mock.module("@/domains/chat/voice/live-voice/use-voice-mode", () => ({
+  useVoiceMode: (options: { assistantId: string; conversationId?: string }) => {
+    lastVoiceModeOptions = options;
+    return {
+      state: mockState,
+      error: null,
+      autoDeactivated: false,
+      inputAmplitude: mockInputAmplitude,
+      activate: activateSpy,
+      deactivate: deactivateSpy,
+      interrupt: interruptSpy,
+    };
+  },
+}));
+
+let mockSessionState: LiveVoiceSessionState = "idle";
+mock.module("@/domains/chat/voice/live-voice/live-voice-store", () => ({
+  useLiveVoiceStore: {
+    use: {
+      state: () => mockSessionState,
+    },
+  },
 }));
 
 // Imported after the mocks so the component picks up the mocked modules.
@@ -53,11 +70,14 @@ const { LiveVoiceButton } = await import(
 );
 
 beforeEach(() => {
-  mockVoiceMode = false;
-  mockState = "idle";
+  mockVoiceModeFlag = false;
+  mockState = "off";
+  mockSessionState = "idle";
   mockInputAmplitude = 0;
-  startSpy.mockClear();
-  stopSpy.mockClear();
+  lastVoiceModeOptions = null;
+  activateSpy.mockClear();
+  deactivateSpy.mockClear();
+  interruptSpy.mockClear();
 });
 
 afterEach(() => {
@@ -66,126 +86,128 @@ afterEach(() => {
 
 describe("LiveVoiceButton", () => {
   test("renders nothing when the voice-mode flag is off", () => {
-    // GIVEN the voice-mode flag is disabled
-    mockVoiceMode = false;
+    mockVoiceModeFlag = false;
 
-    // WHEN the button renders
     const { container } = render(<LiveVoiceButton assistantId="a1" />);
 
-    // THEN nothing is painted
     expect(container.firstChild).toBeNull();
   });
 
-  test("renders a start control when the flag is on and idle", () => {
-    // GIVEN the flag is enabled and no session is active
-    mockVoiceMode = true;
-    mockState = "idle";
+  test("renders a start control when the flag is on and the mode is off", () => {
+    mockVoiceModeFlag = true;
+    mockState = "off";
 
-    // WHEN the button renders
-    const { getByLabelText } = render(<LiveVoiceButton assistantId="a1" />);
-
-    // THEN it offers to start voice mode and is not pressed
-    const button = getByLabelText("Start voice mode");
-    expect(button).toBeTruthy();
-    expect(button.getAttribute("aria-pressed")).toBe("false");
-  });
-
-  test("starts a session on click when idle", () => {
-    // GIVEN an idle, flag-enabled button with a conversation
-    mockVoiceMode = true;
-    mockState = "idle";
     const { getByLabelText } = render(
       <LiveVoiceButton assistantId="a1" conversationId="c1" />,
     );
 
-    // WHEN the user clicks it
-    fireEvent.click(getByLabelText("Start voice mode"));
-
-    // THEN it starts a live-voice session for the assistant + conversation
-    expect(startSpy).toHaveBeenCalledTimes(1);
-    expect(startSpy).toHaveBeenCalledWith("a1", "c1");
-    expect(stopSpy).not.toHaveBeenCalled();
+    const button = getByLabelText("Start voice mode");
+    expect(button).toBeTruthy();
+    expect(button.getAttribute("aria-pressed")).toBe("false");
+    // The conversation loop is parameterized with the composer's identifiers.
+    expect(lastVoiceModeOptions).toEqual({
+      assistantId: "a1",
+      conversationId: "c1",
+    });
   });
 
-  test("stops the session on click when active", () => {
-    // GIVEN an active session (listening)
-    mockVoiceMode = true;
-    mockState = "listening";
+  test("activates the mode on click when off", () => {
+    mockVoiceModeFlag = true;
+    mockState = "off";
     const { getByLabelText } = render(<LiveVoiceButton assistantId="a1" />);
 
-    // THEN the control reflects the live session
+    fireEvent.click(getByLabelText("Start voice mode"));
+
+    expect(activateSpy).toHaveBeenCalledTimes(1);
+    expect(deactivateSpy).not.toHaveBeenCalled();
+    expect(interruptSpy).not.toHaveBeenCalled();
+  });
+
+  test("deactivates on click while listening", () => {
+    mockVoiceModeFlag = true;
+    mockState = "listening";
+    mockSessionState = "listening";
+    const { getByLabelText } = render(<LiveVoiceButton assistantId="a1" />);
+
     const button = getByLabelText("Stop voice mode");
     expect(button.getAttribute("aria-pressed")).toBe("true");
 
-    // WHEN the user clicks it
     fireEvent.click(button);
 
-    // THEN it stops the session
-    expect(stopSpy).toHaveBeenCalledTimes(1);
-    expect(startSpy).not.toHaveBeenCalled();
+    expect(deactivateSpy).toHaveBeenCalledTimes(1);
+    expect(activateSpy).not.toHaveBeenCalled();
+    expect(interruptSpy).not.toHaveBeenCalled();
+  });
+
+  test("interrupts (not stops) on click while speaking", () => {
+    // The LUM-1969 acceptance path: pressing the mic button mid-playback
+    // stops playback and the mode goes back to listening.
+    mockVoiceModeFlag = true;
+    mockState = "speaking";
+    mockSessionState = "speaking";
+    const { getByLabelText } = render(<LiveVoiceButton assistantId="a1" />);
+
+    fireEvent.click(getByLabelText("Interrupt and speak"));
+
+    expect(interruptSpy).toHaveBeenCalledTimes(1);
+    expect(deactivateSpy).not.toHaveBeenCalled();
+    expect(activateSpy).not.toHaveBeenCalled();
   });
 
   test("reflects connecting as a busy, non-toggling state", () => {
-    // GIVEN a session that is still connecting
-    mockVoiceMode = true;
-    mockState = "connecting";
+    mockVoiceModeFlag = true;
+    mockState = "listening"; // mode already on…
+    mockSessionState = "connecting"; // …but the socket is still opening
     const { getByLabelText } = render(<LiveVoiceButton assistantId="a1" />);
 
-    // THEN the control is busy and disabled
-    const button = getByLabelText("Connecting live voice") as HTMLButtonElement;
+    const button = getByLabelText("Connecting voice mode") as HTMLButtonElement;
     expect(button.getAttribute("aria-busy")).toBe("true");
     expect(button.disabled).toBe(true);
 
-    // WHEN the user clicks it, neither start nor stop fire
     fireEvent.click(button);
-    expect(startSpy).not.toHaveBeenCalled();
-    expect(stopSpy).not.toHaveBeenCalled();
+    expect(activateSpy).not.toHaveBeenCalled();
+    expect(deactivateSpy).not.toHaveBeenCalled();
+    expect(interruptSpy).not.toHaveBeenCalled();
   });
 
-  test("stays stoppable when disabled while a session is active", () => {
-    // GIVEN an active session and a parent that has raised `disabled`
-    mockVoiceMode = true;
+  test("stays stoppable when disabled while the mode is on", () => {
+    mockVoiceModeFlag = true;
     mockState = "listening";
+    mockSessionState = "listening";
     const { getByLabelText } = render(
       <LiveVoiceButton assistantId="a1" disabled />,
     );
 
-    // THEN the stop control remains enabled despite the external disabled prop
     const button = getByLabelText("Stop voice mode") as HTMLButtonElement;
     expect(button.disabled).toBe(false);
 
-    // WHEN the user clicks it, the session is stopped
     fireEvent.click(button);
-    expect(stopSpy).toHaveBeenCalledTimes(1);
-    expect(startSpy).not.toHaveBeenCalled();
+    expect(deactivateSpy).toHaveBeenCalledTimes(1);
+    expect(activateSpy).not.toHaveBeenCalled();
   });
 
-  test("prevents starting a session when disabled while idle", () => {
-    // GIVEN an idle, flag-enabled button that the parent has disabled
-    mockVoiceMode = true;
-    mockState = "idle";
+  test("prevents activating when disabled while off", () => {
+    mockVoiceModeFlag = true;
+    mockState = "off";
     const { getByLabelText } = render(
       <LiveVoiceButton assistantId="a1" disabled />,
     );
 
-    // THEN the start control is disabled
     const button = getByLabelText("Start voice mode") as HTMLButtonElement;
     expect(button.disabled).toBe(true);
 
-    // WHEN the user clicks it, no session is started
     fireEvent.click(button);
-    expect(startSpy).not.toHaveBeenCalled();
-    expect(stopSpy).not.toHaveBeenCalled();
+    expect(activateSpy).not.toHaveBeenCalled();
+    expect(deactivateSpy).not.toHaveBeenCalled();
   });
 
   test("scales the icon with live amplitude while active", () => {
-    // GIVEN an active session with non-zero mic amplitude
-    mockVoiceMode = true;
+    mockVoiceModeFlag = true;
     mockState = "listening";
+    mockSessionState = "listening";
     mockInputAmplitude = 1;
     const { getByLabelText } = render(<LiveVoiceButton assistantId="a1" />);
 
-    // THEN the control carries an amplitude-driven transform
     const button = getByLabelText("Stop voice mode");
     expect(button.style.transform).toContain("scale(");
   });

--- a/apps/web/src/domains/chat/components/live-voice-button.test.tsx
+++ b/apps/web/src/domains/chat/components/live-voice-button.test.tsx
@@ -211,4 +211,20 @@ describe("LiveVoiceButton", () => {
     const button = getByLabelText("Stop voice mode");
     expect(button.style.transform).toContain("scale(");
   });
+
+  test("flag turning off mid-conversation deactivates the mode", () => {
+    // GIVEN an active conversation whose voice-mode flag has just dropped
+    // (flag refresh / dev toggle) — the component renders nothing, so the
+    // user has no stop control left
+    mockVoiceModeFlag = false;
+    mockState = "listening";
+    mockSessionState = "listening";
+
+    // WHEN the button renders in that state
+    const { container } = render(<LiveVoiceButton assistantId="a1" />);
+
+    // THEN it ends the conversation rather than stranding the loop + mic
+    expect(container.firstChild).toBeNull();
+    expect(deactivateSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/web/src/domains/chat/components/live-voice-button.tsx
+++ b/apps/web/src/domains/chat/components/live-voice-button.tsx
@@ -21,7 +21,7 @@
  */
 
 import { Loader2, Mic, StopCircle } from "lucide-react";
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 
 import { Button } from "@vellumai/design-library";
 
@@ -74,6 +74,14 @@ export function LiveVoiceButton({
     if (disabled) return;
     void activate();
   }, [active, connecting, deactivate, disabled, interrupt, activate, speaking]);
+
+  // If the voice-mode flag turns off while a conversation is active (flag
+  // refresh / dev toggle), this component stops rendering the only
+  // stop/interrupt control while the controller above keeps the loop and mic
+  // running — end the conversation instead of stranding it.
+  useEffect(() => {
+    if (!voiceModeFlag && active) void deactivate();
+  }, [voiceModeFlag, active, deactivate]);
 
   if (!voiceModeFlag) return null;
 

--- a/apps/web/src/domains/chat/components/live-voice-button.tsx
+++ b/apps/web/src/domains/chat/components/live-voice-button.tsx
@@ -1,20 +1,23 @@
 /**
- * `LiveVoiceButton` — composer control that toggles a live-voice conversation.
+ * `LiveVoiceButton` — composer control that toggles voice mode.
  *
  * Distinct from the dictation {@link import("./voice-input-button").VoiceInputButton}:
  * that one records a single utterance and drops a transcript into the composer,
- * while this one opens a full-duplex live-voice session via {@link useLiveVoice}
- * (mic streaming + TTS playback + barge-in). The button is gated behind the
- * `voice-mode` assistant flag and renders nothing when the flag is off.
+ * while this one runs the voice-mode conversation loop via {@link useVoiceMode}
+ * (mic streaming + TTS playback + barge-in + auto-listen between turns). The
+ * button is gated behind the `voice-mode` assistant flag and renders nothing
+ * when the flag is off.
  *
- * Appearance reflects the {@link useLiveVoice} session phase:
- *   - `idle`/`failed`     → mic icon, click to start
- *   - `connecting`        → spinning loader, disabled (token mint / socket open)
- *   - any other (active)  → stop-circle icon, click to stop; the live
- *                           `inputAmplitude` drives a subtle pulse so the user
- *                           sees the mic is hearing them.
+ * Appearance / click behavior follow the mode state:
+ *   - `off`          → mic icon, click activates the mode (idle → listening)
+ *   - `speaking`     → mic icon, click interrupts the response and listens
+ *                      again (the LUM-1969 "mic button mid-playback" path)
+ *   - any other      → stop-circle icon, click turns the mode off; while
+ *                      listening the live `inputAmplitude` drives a subtle
+ *                      pulse so the user sees the mic is hearing them.
  *
- * Wiring into the composer happens in a later PR; this is the standalone control.
+ * The session-level `connecting` phase (sub-second token mint / socket open)
+ * shows a spinner so a click can't race the handshake.
  */
 
 import { Loader2, Mic, StopCircle } from "lucide-react";
@@ -22,13 +25,14 @@ import { useCallback } from "react";
 
 import { Button } from "@vellumai/design-library";
 
-import { useLiveVoice } from "@/domains/chat/voice/live-voice/use-live-voice";
+import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { useVoiceMode } from "@/domains/chat/voice/live-voice/use-voice-mode";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
 interface LiveVoiceButtonProps {
-  /** Assistant whose live-voice channel the session attaches to. */
+  /** Assistant whose live-voice channel the conversation attaches to. */
   assistantId: string;
-  /** Optional conversation to continue inside the session. */
+  /** Optional conversation to continue inside the voice conversation. */
   conversationId?: string;
   /** Disable the control (e.g. while the composer is otherwise busy). */
   disabled?: boolean;
@@ -39,36 +43,47 @@ export function LiveVoiceButton({
   conversationId,
   disabled = false,
 }: LiveVoiceButtonProps) {
-  const voiceMode = useAssistantFeatureFlagStore.use.voiceMode();
-  const { state, inputAmplitude, start, stop } = useLiveVoice();
+  const voiceModeFlag = useAssistantFeatureFlagStore.use.voiceMode();
+  const { state, inputAmplitude, activate, deactivate, interrupt } =
+    useVoiceMode({ assistantId, conversationId });
 
-  const connecting = state === "connecting";
-  // Anything past connecting (listening/transcribing/thinking/speaking/ending)
-  // means a session is live and the button acts as a stop control.
-  const active =
-    state !== "idle" && state !== "failed" && state !== "connecting";
+  // The session-level connecting phase is the only window where a click has
+  // nothing meaningful to do (the mode is on but the socket isn't up yet).
+  const sessionState = useLiveVoiceStore.use.state();
+  const connecting = state !== "off" && sessionState === "connecting";
+
+  const active = state !== "off";
+  const speaking = state === "speaking";
 
   const handleClick = useCallback(() => {
     if (connecting) return;
-    if (active) {
-      // An active session must always be stoppable, even if the parent has
-      // raised `disabled` in the meantime — otherwise the user is stuck with a
-      // live mic/socket until some automatic teardown.
-      void stop();
-    } else {
-      // Only the start path honours the external `disabled` prop.
-      if (disabled) return;
-      void start(assistantId, conversationId);
+    if (speaking) {
+      // Mid-playback the mic button is the interrupt: playback stops and the
+      // mode goes straight back to listening.
+      interrupt();
+      return;
     }
-  }, [active, connecting, disabled, start, stop, assistantId, conversationId]);
+    if (active) {
+      // An active mode must always be stoppable, even if the parent has
+      // raised `disabled` in the meantime — otherwise the user is stuck with
+      // a live mic until some automatic teardown.
+      void deactivate();
+      return;
+    }
+    // Only the start path honours the external `disabled` prop.
+    if (disabled) return;
+    void activate();
+  }, [active, connecting, deactivate, disabled, interrupt, activate, speaking]);
 
-  if (!voiceMode) return null;
+  if (!voiceModeFlag) return null;
 
   const label = connecting
-    ? "Connecting live voice"
-    : active
-      ? "Stop voice mode"
-      : "Start voice mode";
+    ? "Connecting voice mode"
+    : speaking
+      ? "Interrupt and speak"
+      : active
+        ? "Stop voice mode"
+        : "Start voice mode";
 
   return (
     <Button
@@ -76,14 +91,14 @@ export function LiveVoiceButton({
       iconOnly={
         connecting ? (
           <Loader2 className="animate-spin" strokeWidth={2} />
-        ) : active ? (
+        ) : active && !speaking ? (
           <StopCircle strokeWidth={2} />
         ) : (
           <Mic strokeWidth={2} />
         )
       }
       onClick={handleClick}
-      // An active session is always stoppable; the external `disabled` prop
+      // An active mode is always stoppable; the external `disabled` prop
       // only gates the start path. `connecting` stays disabled/busy.
       disabled={connecting || (!active && disabled)}
       aria-label={label}

--- a/apps/web/src/domains/chat/voice/live-voice/test-fakes.ts
+++ b/apps/web/src/domains/chat/voice/live-voice/test-fakes.ts
@@ -1,0 +1,166 @@
+/**
+ * Hand-rolled fakes for the three live-voice primitives — client, capture,
+ * player — injected through `useLiveVoice`/`useVoiceMode` factory options so
+ * tests never touch a WebSocket, microphone, or AudioContext. Each fake
+ * exposes drivers (`emit`, `pushChunk`, `pushAmplitude`, `finishPlayback`)
+ * so a test can puppet a full conversation turn.
+ *
+ * Shared by `use-live-voice.test.ts` and `use-voice-mode.test.ts`; not a
+ * `.test.ts` file itself, so the test runner never collects it.
+ */
+
+import type {
+  LiveVoiceClientEventMap,
+  LiveVoiceClientEventName,
+} from "@/domains/chat/voice/live-voice/live-voice-client";
+import type {
+  LiveVoiceAudioCaptureOptions,
+  LiveVoiceCaptureResult,
+} from "@/domains/chat/voice/live-voice/pcm-capture";
+
+export class FakeClient {
+  connectArgs: { assistantId: string; conversationId?: string } | null = null;
+  sentAudio: ArrayBuffer[] = [];
+  pttReleaseCount = 0;
+  interruptCount = 0;
+  ended = false;
+  closed = false;
+
+  private handlers = new Map<
+    LiveVoiceClientEventName,
+    Set<(payload: never) => void>
+  >();
+
+  on<E extends LiveVoiceClientEventName>(
+    event: E,
+    handler: (payload: LiveVoiceClientEventMap[E]) => void,
+  ): () => void {
+    let set = this.handlers.get(event);
+    if (!set) {
+      set = new Set();
+      this.handlers.set(event, set);
+    }
+    set.add(handler as (payload: never) => void);
+    return () => set?.delete(handler as (payload: never) => void);
+  }
+
+  async connect(args: {
+    assistantId: string;
+    conversationId?: string;
+  }): Promise<void> {
+    this.connectArgs = args;
+  }
+
+  sendAudio(pcm: ArrayBuffer): void {
+    this.sentAudio.push(pcm);
+  }
+  pttRelease(): void {
+    this.pttReleaseCount++;
+  }
+  interrupt(): void {
+    this.interruptCount++;
+  }
+  end(): void {
+    this.ended = true;
+  }
+  close(): void {
+    this.closed = true;
+  }
+
+  /** Drive a server event to the controller's subscribed handlers. */
+  emit<E extends LiveVoiceClientEventName>(
+    event: E,
+    payload: LiveVoiceClientEventMap[E],
+  ): void {
+    for (const handler of this.handlers.get(event) ?? []) {
+      (handler as (payload: LiveVoiceClientEventMap[E]) => void)(payload);
+    }
+  }
+}
+
+export class FakeCapture {
+  readonly onChunk: (buf: ArrayBuffer) => void;
+  readonly onAmplitude?: (amplitude: number) => void;
+
+  startCount = 0;
+  stopCount = 0;
+  shutdownCount = 0;
+  startResult: LiveVoiceCaptureResult = { ok: true };
+
+  constructor(options: LiveVoiceAudioCaptureOptions) {
+    this.onChunk = options.onChunk;
+    this.onAmplitude = options.onAmplitude;
+  }
+
+  async start(): Promise<LiveVoiceCaptureResult> {
+    this.startCount++;
+    return this.startResult;
+  }
+  async stop(): Promise<void> {
+    this.stopCount++;
+  }
+  async shutdown(): Promise<void> {
+    this.shutdownCount++;
+  }
+
+  /** Feed a captured PCM chunk to the controller. */
+  pushChunk(buf: ArrayBuffer): void {
+    this.onChunk(buf);
+  }
+  /** Feed an amplitude reading to the controller. */
+  pushAmplitude(amplitude: number): void {
+    this.onAmplitude?.(amplitude);
+  }
+}
+
+export class FakePlayer {
+  enqueued: unknown[] = [];
+  stopCount = 0;
+  disposeCount = 0;
+  isPlaying = false;
+  volume: number | null = null;
+  muted: boolean | null = null;
+  private drainResolvers: Array<() => void> = [];
+
+  setVolume(volume: number): void {
+    this.volume = volume;
+  }
+  setMuted(muted: boolean): void {
+    this.muted = muted;
+  }
+
+  enqueue(chunk: unknown): void {
+    this.enqueued.push(chunk);
+    this.isPlaying = true;
+  }
+  stop(): void {
+    this.stopCount++;
+    this.isPlaying = false;
+    this.resolveDrain();
+  }
+  async dispose(): Promise<void> {
+    this.disposeCount++;
+    this.stop();
+  }
+  async waitUntilDrained(): Promise<void> {
+    if (!this.isPlaying) return;
+    await new Promise<void>((resolve) => this.drainResolvers.push(resolve));
+  }
+
+  /** Simulate playback finishing naturally. */
+  finishPlayback(): void {
+    this.isPlaying = false;
+    this.resolveDrain();
+  }
+  private resolveDrain(): void {
+    const resolvers = this.drainResolvers;
+    this.drainResolvers = [];
+    for (const resolve of resolvers) resolve();
+  }
+}
+
+/** A PCM chunk of `ms` milliseconds at 16 kHz mono Int16. */
+export function pcmChunk(ms: number): ArrayBuffer {
+  const samples = Math.round((16000 * ms) / 1000);
+  return new Int16Array(samples).buffer;
+}

--- a/apps/web/src/domains/chat/voice/live-voice/tts-playback.test.ts
+++ b/apps/web/src/domains/chat/voice/live-voice/tts-playback.test.ts
@@ -2,8 +2,10 @@ import { beforeEach, describe, expect, test } from "bun:test";
 
 import {
   LiveVoiceAudioPlayer,
+  STOP_FADE_OUT_SECONDS,
   decodePcm16Base64,
   type AudioContextLike,
+  type GainNodeLike,
 } from "@/domains/chat/voice/live-voice/tts-playback";
 
 // ---------------------------------------------------------------------------
@@ -18,16 +20,55 @@ interface MockSource {
   buffer: AudioBuffer | null;
   startedAt: number | null;
   stopped: boolean;
+  /** Time passed to stop(when), or currentTime for a bare stop(). */
+  stoppedAt: number | null;
   disconnected: boolean;
+  /** Node the source was connected to (the master gain, normally). */
+  connectedTo: unknown;
   onended: (() => void) | null;
   /** Fire the ended handler as the engine would when the buffer finishes. */
   finish(): void;
+}
+
+/** A single scheduled AudioParam automation call, in call order. */
+interface MockParamEvent {
+  method: "setValueAtTime" | "linearRampToValueAtTime" | "cancelScheduledValues";
+  value?: number;
+  time: number;
+}
+
+class MockGainNode implements GainNodeLike {
+  connectedTo: unknown = null;
+  readonly events: MockParamEvent[] = [];
+  readonly gain = {
+    value: 1,
+    setValueAtTime: (value: number, time: number) => {
+      this.events.push({ method: "setValueAtTime", value, time });
+      this.gain.value = value;
+    },
+    linearRampToValueAtTime: (value: number, time: number) => {
+      this.events.push({ method: "linearRampToValueAtTime", value, time });
+      this.gain.value = value;
+    },
+    cancelScheduledValues: (time: number) => {
+      this.events.push({ method: "cancelScheduledValues", time });
+    },
+  };
+
+  connect(destination: AudioNode): void {
+    this.connectedTo = destination;
+  }
+
+  disconnect(): void {
+    this.connectedTo = null;
+  }
 }
 
 class MockAudioContext {
   currentTime = 0;
   closed = false;
   readonly sources: MockSource[] = [];
+  readonly gains: MockGainNode[] = [];
 
   /** ArrayBuffers passed to decodeAudioData, in call order. */
   readonly decodedInputs: ArrayBuffer[] = [];
@@ -68,7 +109,9 @@ class MockAudioContext {
       buffer: null,
       startedAt: null,
       stopped: false,
+      stoppedAt: null,
       disconnected: false,
+      connectedTo: null,
       onended: null,
       finish() {
         this.stopped = true;
@@ -88,19 +131,34 @@ class MockAudioContext {
       set onended(cb: (() => void) | null) {
         source.onended = cb;
       },
-      connect() {},
+      connect(destination: unknown) {
+        source.connectedTo = destination;
+      },
       disconnect() {
         source.disconnected = true;
       },
       start(when?: number) {
         source.startedAt = when ?? getCurrentTime();
       },
-      stop() {
+      stop(when?: number) {
         source.stopped = true;
+        source.stoppedAt = when ?? getCurrentTime();
       },
     } as unknown as AudioBufferSourceNode;
     this.sources.push(source);
     return node;
+  }
+
+  createGain(): GainNodeLike {
+    const gain = new MockGainNode();
+    this.gains.push(gain);
+    return gain;
+  }
+
+  /** The master gain node the player created (lazily, with the context). */
+  get masterGain(): MockGainNode {
+    if (!this.gains[0]) throw new Error("no gain node created yet");
+    return this.gains[0];
   }
 
   async close(): Promise<void> {
@@ -230,15 +288,57 @@ describe("LiveVoiceAudioPlayer", () => {
     expect(player.isPlaying).toBe(false);
   });
 
-  test("stop() halts every source immediately and clears the queue", () => {
+  test("stop() halts every source at the end of the fade and clears the queue", () => {
     player.enqueue(chunk(new Array(24000).fill(1)));
     player.enqueue(chunk(new Array(24000).fill(1)));
 
     player.stop();
 
+    // Sources are scheduled to halt when the 20ms gain fade completes — an
+    // immediate stop would produce an audible click.
     expect(ctx.sources.every((s) => s.stopped)).toBe(true);
-    expect(ctx.sources.every((s) => s.disconnected)).toBe(true);
+    expect(
+      ctx.sources.every((s) => s.stoppedAt === STOP_FADE_OUT_SECONDS),
+    ).toBe(true);
     expect(player.isPlaying).toBe(false);
+  });
+
+  test("stop() ramps the master gain to silence over the fade window", () => {
+    player.enqueue(chunk(new Array(24000).fill(1)));
+    ctx.currentTime = 0.5;
+
+    player.stop();
+
+    const ramp = ctx.masterGain.events.find(
+      (e) => e.method === "linearRampToValueAtTime",
+    );
+    expect(ramp).toEqual({
+      method: "linearRampToValueAtTime",
+      value: 0,
+      time: 0.5 + STOP_FADE_OUT_SECONDS,
+    });
+  });
+
+  test("enqueue after stop() restores the gain to the user's level", () => {
+    player.setVolume(0.4);
+    player.enqueue(chunk(new Array(24000).fill(1)));
+    player.stop();
+    expect(ctx.masterGain.gain.value).toBe(0);
+
+    player.enqueue(chunk(new Array(24000).fill(1)));
+    expect(ctx.masterGain.gain.value).toBe(0.4);
+  });
+
+  test("stop() without active sources leaves the gain untouched", () => {
+    player.enqueue(chunk(new Array(12000).fill(1)));
+    ctx.sources[0]!.finish();
+
+    player.stop();
+
+    const ramp = ctx.masterGain.events.find(
+      (e) => e.method === "linearRampToValueAtTime",
+    );
+    expect(ramp).toBeUndefined();
   });
 
   test("playhead resets after stop so the next enqueue starts fresh", () => {
@@ -283,6 +383,57 @@ describe("LiveVoiceAudioPlayer", () => {
     player.enqueue(chunk([]));
     expect(ctx.sources.length).toBe(0);
     expect(player.isPlaying).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // master gain: routing, volume, mute
+  // -------------------------------------------------------------------------
+
+  test("sources play through the master gain, which feeds the destination", () => {
+    player.enqueue(chunk(new Array(24000).fill(1)));
+
+    expect(ctx.gains.length).toBe(1);
+    expect(ctx.masterGain.connectedTo).toBe(ctx.destination);
+    expect(ctx.sources[0]!.connectedTo).toBe(ctx.masterGain);
+  });
+
+  test("constructor volume/muted seed the master gain", () => {
+    const seeded = new LiveVoiceAudioPlayer({
+      audioContextFactory: () => ctx as unknown as AudioContextLike,
+      volume: 0.6,
+      muted: true,
+    });
+    seeded.enqueue(chunk(new Array(24000).fill(1)));
+
+    // Muted wins: the gain starts silent even with a non-zero volume.
+    expect(ctx.masterGain.gain.value).toBe(0);
+
+    seeded.setMuted(false);
+    expect(ctx.masterGain.gain.value).toBe(0.6);
+  });
+
+  test("setVolume applies live to playing audio and clamps to [0, 1]", () => {
+    player.enqueue(chunk(new Array(24000).fill(1)));
+
+    player.setVolume(0.25);
+    expect(ctx.masterGain.gain.value).toBe(0.25);
+
+    player.setVolume(7);
+    expect(ctx.masterGain.gain.value).toBe(1);
+
+    player.setVolume(-3);
+    expect(ctx.masterGain.gain.value).toBe(0);
+  });
+
+  test("setMuted silences and restores without touching the volume", () => {
+    player.setVolume(0.8);
+    player.enqueue(chunk(new Array(24000).fill(1)));
+
+    player.setMuted(true);
+    expect(ctx.masterGain.gain.value).toBe(0);
+
+    player.setMuted(false);
+    expect(ctx.masterGain.gain.value).toBe(0.8);
   });
 
   // -------------------------------------------------------------------------

--- a/apps/web/src/domains/chat/voice/live-voice/tts-playback.ts
+++ b/apps/web/src/domains/chat/voice/live-voice/tts-playback.ts
@@ -26,9 +26,15 @@
  * previous buffer finishes — rather than relying on `onended` callbacks, which
  * fire too late to avoid audible gaps between buffers.
  *
- * {@link LiveVoiceAudioPlayer.stop} flushes the queue immediately for
- * barge-in/interrupt: it stops every scheduled source, drops queued chunks, and
- * resets the playhead so the next `enqueue` starts fresh.
+ * {@link LiveVoiceAudioPlayer.stop} flushes the queue for barge-in/interrupt:
+ * it fades the master gain to silence over {@link STOP_FADE_OUT_SECONDS} (a
+ * hard cut produces an audible click), schedules every source to halt at the
+ * end of the fade, drops queued chunks, and resets the playhead so the next
+ * `enqueue` starts fresh.
+ *
+ * All sources play through a single master {@link GainNodeLike} which also
+ * carries the user's TTS volume/mute preference
+ * ({@link LiveVoiceAudioPlayer.setVolume} / {@link LiveVoiceAudioPlayer.setMuted}).
  *
  * No audio playback infrastructure exists elsewhere in `apps/web`; this module
  * owns its own `AudioContext` lifecycle.
@@ -70,6 +76,12 @@ function normalizeMimeType(mimeType: string): string {
   return mimeType.split(";", 1)[0]?.trim().toLowerCase() ?? "";
 }
 
+/** Clamp a volume preference into the valid [0, 1] gain range. */
+function clampVolume(volume: number): number {
+  if (!Number.isFinite(volume)) return 1;
+  return Math.min(1, Math.max(0, volume));
+}
+
 /** Decode a base64 string into a fresh `ArrayBuffer` of its raw bytes. */
 function base64ToArrayBuffer(dataBase64: string): ArrayBuffer {
   const binary = atob(dataBase64);
@@ -78,6 +90,28 @@ function base64ToArrayBuffer(dataBase64: string): ArrayBuffer {
     bytes[i] = binary.charCodeAt(i);
   }
   return bytes.buffer;
+}
+
+/**
+ * Duration of the gain ramp applied on {@link LiveVoiceAudioPlayer.stop}. An
+ * immediate cut produces an audible click; 20ms is short enough that an
+ * interrupt still feels instant.
+ */
+export const STOP_FADE_OUT_SECONDS = 0.02;
+
+/** Minimal structural type for the `AudioParam` surface the player drives. */
+export interface AudioParamLike {
+  value: number;
+  setValueAtTime(value: number, startTime: number): unknown;
+  linearRampToValueAtTime(value: number, endTime: number): unknown;
+  cancelScheduledValues(startTime: number): unknown;
+}
+
+/** Minimal structural type for the master `GainNode`. */
+export interface GainNodeLike {
+  readonly gain: AudioParamLike;
+  connect(destination: AudioNode): unknown;
+  disconnect(): unknown;
 }
 
 /**
@@ -95,6 +129,7 @@ export interface AudioContextLike {
     sampleRate: number,
   ): AudioBuffer;
   createBufferSource(): AudioBufferSourceNode;
+  createGain(): GainNodeLike;
   /**
    * Decode an encoded container (wav/mp3/opus) into an `AudioBuffer`, deriving
    * sample rate and channel layout from the container header.
@@ -138,6 +173,28 @@ export class LiveVoiceAudioPlayer {
   private readonly createContext: AudioContextFactory;
   private context: AudioContextLike | null = null;
 
+  /** Master gain between every source and the destination (volume/mute/fade). */
+  private gainNode: GainNodeLike | null = null;
+
+  /** User TTS volume preference in [0, 1]; applied through the master gain. */
+  private volume: number;
+
+  /** User TTS mute preference; mutes the master gain without pausing playback. */
+  private muted: boolean;
+
+  /**
+   * Set when {@link stop} ramped the gain to silence; the next scheduled
+   * buffer restores the gain to the user's level before starting.
+   */
+  private fadePending = false;
+
+  /**
+   * Wall-clock time (ms) at which the stop-fade finishes. {@link dispose}
+   * waits this out before closing the context so an interrupt's fade is
+   * actually heard instead of being cut by the context teardown.
+   */
+  private fadeEndsAtMs = 0;
+
   /** Sources currently scheduled (playing or pending). */
   private activeSources = new Set<AudioBufferSourceNode>();
 
@@ -177,13 +234,50 @@ export class LiveVoiceAudioPlayer {
    */
   private containerDecodeChain: Promise<void> = Promise.resolve();
 
-  constructor(options?: { audioContextFactory?: AudioContextFactory }) {
+  constructor(options?: {
+    audioContextFactory?: AudioContextFactory;
+    /** Initial TTS volume in [0, 1]. Defaults to full volume. */
+    volume?: number;
+    /** Initial mute state. Defaults to unmuted. */
+    muted?: boolean;
+  }) {
     this.createContext = options?.audioContextFactory ?? defaultAudioContextFactory;
+    this.volume = clampVolume(options?.volume ?? 1);
+    this.muted = options?.muted ?? false;
   }
 
   /** Whether any audio is scheduled, playing, or still decoding. */
   get isPlaying(): boolean {
     return this.playingState || this.pendingContainerDecodes > 0;
+  }
+
+  /** Gain the master node should sit at outside of a stop-fade. */
+  private get effectiveGain(): number {
+    return this.muted ? 0 : this.volume;
+  }
+
+  /** Set the TTS volume (clamped to [0, 1]); applies live to playing audio. */
+  setVolume(volume: number): void {
+    this.volume = clampVolume(volume);
+    this.applyGain();
+  }
+
+  /** Mute/unmute TTS output without pausing the scheduled timeline. */
+  setMuted(muted: boolean): void {
+    this.muted = muted;
+    this.applyGain();
+  }
+
+  /**
+   * Snap the master gain to the user's level. A pending stop-fade is left
+   * untouched — cancelling its ramp would un-silence sources that are about
+   * to halt — the new level lands when the next buffer is scheduled.
+   */
+  private applyGain(): void {
+    if (!this.context || !this.gainNode || this.fadePending) return;
+    const now = this.context.currentTime;
+    this.gainNode.gain.cancelScheduledValues(now);
+    this.gainNode.gain.setValueAtTime(this.effectiveGain, now);
   }
 
   /**
@@ -292,11 +386,18 @@ export class LiveVoiceAudioPlayer {
     });
   }
 
-  /** Connect a decoded buffer to the destination and start it gaplessly. */
+  /** Connect a decoded buffer through the master gain and start it gaplessly. */
   private scheduleBuffer(context: AudioContextLike, buffer: AudioBuffer): void {
     const source = context.createBufferSource();
     source.buffer = buffer;
-    source.connect(context.destination);
+    source.connect(this.gainNode as unknown as AudioNode);
+
+    // A previous stop() faded the gain to silence; bring it back to the
+    // user's level for the new utterance.
+    if (this.fadePending) {
+      this.fadePending = false;
+      this.applyGain();
+    }
 
     // Chain start time from the running playhead. Never schedule in the past:
     // if the queue drained the playhead may lag behind currentTime.
@@ -313,10 +414,14 @@ export class LiveVoiceAudioPlayer {
   }
 
   /**
-   * Immediately halt playback and clear the queue (barge-in / interrupt).
+   * Halt playback and clear the queue (barge-in / interrupt).
    *
-   * Stops every scheduled source, drops the playhead, and resolves any pending
-   * `waitUntilDrained()` callers — a flushed queue counts as drained.
+   * The master gain ramps to silence over {@link STOP_FADE_OUT_SECONDS} and
+   * every scheduled source is halted at the end of the ramp — an immediate
+   * `stop()`/`disconnect()` produces an audible click. Sources whose start
+   * time lies beyond the fade window simply never sound. The queue is
+   * dropped, the playhead reset, and any pending `waitUntilDrained()` callers
+   * resolve — a flushed queue counts as drained.
    *
    * Bumping {@link generation} invalidates any in-flight container decode so a
    * later-resolving `decodeAudioData` is discarded instead of scheduling the
@@ -326,16 +431,28 @@ export class LiveVoiceAudioPlayer {
    */
   stop(): void {
     this.generation += 1;
-    for (const source of this.activeSources) {
-      // Detach the handler first so stop() doesn't re-enter handleSourceEnded
-      // mid-iteration as we mutate the set.
-      source.onended = null;
-      try {
-        source.stop();
-      } catch {
-        // Already stopped or never started — safe to ignore.
+    const context = this.context;
+    if (context && this.gainNode && this.activeSources.size > 0) {
+      const now = context.currentTime;
+      const stopAt = now + STOP_FADE_OUT_SECONDS;
+      const gain = this.gainNode.gain;
+      // Pin the ramp's start value first — linearRampToValueAtTime ramps from
+      // the previous scheduled event, which may be far in the past.
+      gain.cancelScheduledValues(now);
+      gain.setValueAtTime(this.effectiveGain, now);
+      gain.linearRampToValueAtTime(0, stopAt);
+      this.fadePending = true;
+      this.fadeEndsAtMs = Date.now() + STOP_FADE_OUT_SECONDS * 1000;
+      for (const source of this.activeSources) {
+        // Detach the handler first so stop() doesn't re-enter
+        // handleSourceEnded mid-iteration as we mutate the set.
+        source.onended = null;
+        try {
+          source.stop(stopAt);
+        } catch {
+          // Already stopped or never started — safe to ignore.
+        }
       }
-      source.disconnect();
     }
     this.activeSources.clear();
     this.pendingContainerDecodes = 0;
@@ -362,6 +479,10 @@ export class LiveVoiceAudioPlayer {
   /**
    * Release the underlying `AudioContext`. Implicitly stops playback first.
    *
+   * If a stop-fade is still in flight, closing is deferred until it finishes —
+   * closing the context hard-cuts output, which is exactly the click the fade
+   * exists to avoid.
+   *
    * Idempotent and safe to call when the context was never created or is
    * already closed: only a context this player owns is closed, and the field is
    * cleared before awaiting so re-entrant/repeat calls are no-ops. The player
@@ -371,13 +492,25 @@ export class LiveVoiceAudioPlayer {
     this.stop();
     const context = this.context;
     this.context = null;
-    if (context) await context.close();
+    this.gainNode = null;
+    this.fadePending = false;
+    if (!context) return;
+    const fadeRemainingMs = this.fadeEndsAtMs - Date.now();
+    if (fadeRemainingMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, fadeRemainingMs));
+    }
+    await context.close();
   }
 
   private ensureContext(): AudioContextLike {
     if (!this.context) {
       this.context = this.createContext();
       this.playheadTime = 0;
+      this.fadePending = false;
+      const gainNode = this.context.createGain();
+      gainNode.gain.value = this.effectiveGain;
+      gainNode.connect(this.context.destination);
+      this.gainNode = gainNode;
     }
     return this.context;
   }

--- a/apps/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/apps/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -492,6 +492,26 @@ describe("onSessionEnd", () => {
     expect(ends).toEqual([{ reason: "completed", conversationId: "conv-1" }]);
   });
 
+  test("a silent turn (tts_done without tts_audio) still completes the session", async () => {
+    // The server sends tts_done even when a turn produced no speakable text
+    // (or the TTS stream yielded zero chunks), so the session never reaches
+    // `speaking`. The turn must still end — and report `completed` so the
+    // voice-mode loop opens the next listening session instead of hanging in
+    // processing.
+    const { h, ends } = recordingEnds();
+    await startListening(h);
+
+    await act(async () => {
+      h.client.emit("thinking", { type: "thinking", seq: 2, turnId: "t1" });
+      h.client.emit("ttsDone", { type: "tts_done", seq: 3, turnId: "t1" });
+      await Promise.resolve();
+    });
+
+    expect(h.view.result.current.state).toBe("idle");
+    expect(h.client.closed).toBe(true);
+    expect(ends).toEqual([{ reason: "completed", conversationId: "conv-1" }]);
+  });
+
   test("the server-issued conversation id from `ready` is reported when start() had none", async () => {
     const { h, ends } = recordingEnds();
     await act(async () => {

--- a/apps/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/apps/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -25,15 +25,15 @@ mock.module("@/domains/chat/voice/live-voice/connection", () => ({
 import type {
   LiveVoiceChannelClient,
   LiveVoiceClientError,
-  LiveVoiceClientEventMap,
-  LiveVoiceClientEventName,
 } from "@/domains/chat/voice/live-voice/live-voice-client";
-import type {
-  LiveVoiceAudioCapture,
-  LiveVoiceAudioCaptureOptions,
-  LiveVoiceCaptureResult,
-} from "@/domains/chat/voice/live-voice/pcm-capture";
+import type { LiveVoiceAudioCapture } from "@/domains/chat/voice/live-voice/pcm-capture";
 import type { LiveVoiceAudioPlayer } from "@/domains/chat/voice/live-voice/tts-playback";
+import {
+  FakeCapture,
+  FakeClient,
+  FakePlayer,
+  pcmChunk,
+} from "@/domains/chat/voice/live-voice/test-fakes";
 
 // Import the controller + store *after* the connection mock is registered, so
 // the real connection.ts (which imports the generated SDK) never enters the
@@ -46,158 +46,23 @@ const { useLiveVoiceStore } = await import(
 );
 
 // ---------------------------------------------------------------------------
-// Fakes
-// ---------------------------------------------------------------------------
-
-class FakeClient {
-  connectArgs: { assistantId: string; conversationId?: string } | null = null;
-  sentAudio: ArrayBuffer[] = [];
-  pttReleaseCount = 0;
-  interruptCount = 0;
-  ended = false;
-  closed = false;
-
-  private handlers = new Map<
-    LiveVoiceClientEventName,
-    Set<(payload: never) => void>
-  >();
-
-  on<E extends LiveVoiceClientEventName>(
-    event: E,
-    handler: (payload: LiveVoiceClientEventMap[E]) => void,
-  ): () => void {
-    let set = this.handlers.get(event);
-    if (!set) {
-      set = new Set();
-      this.handlers.set(event, set);
-    }
-    set.add(handler as (payload: never) => void);
-    return () => set?.delete(handler as (payload: never) => void);
-  }
-
-  async connect(args: {
-    assistantId: string;
-    conversationId?: string;
-  }): Promise<void> {
-    this.connectArgs = args;
-  }
-
-  sendAudio(pcm: ArrayBuffer): void {
-    this.sentAudio.push(pcm);
-  }
-  pttRelease(): void {
-    this.pttReleaseCount++;
-  }
-  interrupt(): void {
-    this.interruptCount++;
-  }
-  end(): void {
-    this.ended = true;
-  }
-  close(): void {
-    this.closed = true;
-  }
-
-  /** Drive a server event to the controller's subscribed handlers. */
-  emit<E extends LiveVoiceClientEventName>(
-    event: E,
-    payload: LiveVoiceClientEventMap[E],
-  ): void {
-    for (const handler of this.handlers.get(event) ?? []) {
-      (handler as (payload: LiveVoiceClientEventMap[E]) => void)(payload);
-    }
-  }
-}
-
-class FakeCapture {
-  readonly onChunk: (buf: ArrayBuffer) => void;
-  readonly onAmplitude?: (amplitude: number) => void;
-
-  startCount = 0;
-  stopCount = 0;
-  shutdownCount = 0;
-  startResult: LiveVoiceCaptureResult = { ok: true };
-
-  constructor(options: LiveVoiceAudioCaptureOptions) {
-    this.onChunk = options.onChunk;
-    this.onAmplitude = options.onAmplitude;
-  }
-
-  async start(): Promise<LiveVoiceCaptureResult> {
-    this.startCount++;
-    return this.startResult;
-  }
-  async stop(): Promise<void> {
-    this.stopCount++;
-  }
-  async shutdown(): Promise<void> {
-    this.shutdownCount++;
-  }
-
-  /** Feed a captured PCM chunk to the controller. */
-  pushChunk(buf: ArrayBuffer): void {
-    this.onChunk(buf);
-  }
-  /** Feed an amplitude reading to the controller. */
-  pushAmplitude(amplitude: number): void {
-    this.onAmplitude?.(amplitude);
-  }
-}
-
-class FakePlayer {
-  enqueued: unknown[] = [];
-  stopCount = 0;
-  disposeCount = 0;
-  isPlaying = false;
-  private drainResolvers: Array<() => void> = [];
-
-  enqueue(chunk: unknown): void {
-    this.enqueued.push(chunk);
-    this.isPlaying = true;
-  }
-  stop(): void {
-    this.stopCount++;
-    this.isPlaying = false;
-    this.resolveDrain();
-  }
-  async dispose(): Promise<void> {
-    this.disposeCount++;
-    this.stop();
-  }
-  async waitUntilDrained(): Promise<void> {
-    if (!this.isPlaying) return;
-    await new Promise<void>((resolve) => this.drainResolvers.push(resolve));
-  }
-
-  /** Simulate playback finishing naturally. */
-  finishPlayback(): void {
-    this.isPlaying = false;
-    this.resolveDrain();
-  }
-  private resolveDrain(): void {
-    const resolvers = this.drainResolvers;
-    this.drainResolvers = [];
-    for (const resolve of resolvers) resolve();
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Harness
 // ---------------------------------------------------------------------------
 
-/** A PCM chunk of `ms` milliseconds at 16 kHz mono Int16. */
-function pcmChunk(ms: number): ArrayBuffer {
-  const samples = Math.round((16000 * ms) / 1000);
-  return new Int16Array(samples).buffer;
-}
 
-function renderController() {
+function renderController(
+  extraOptions: Omit<
+    Parameters<typeof useLiveVoice>[0] & object,
+    "createClient" | "createPlayer" | "createCapture"
+  > = {},
+) {
   const client = new FakeClient();
   const player = new FakePlayer();
   let capture!: FakeCapture;
 
   const view = renderHook(() =>
     useLiveVoice({
+      ...extraOptions,
       createClient: () => client as unknown as LiveVoiceChannelClient,
       createPlayer: () => player as unknown as LiveVoiceAudioPlayer,
       createCapture: (options) => {
@@ -589,5 +454,106 @@ describe("teardown", () => {
       await h.view.result.current.stop();
     });
     expect(h.view.result.current.state).toBe("idle");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session end reporting (consumed by the voice-mode conversation loop)
+// ---------------------------------------------------------------------------
+
+describe("onSessionEnd", () => {
+  function recordingEnds() {
+    const ends: Array<{ reason: string; conversationId: string | null }> = [];
+    const h = renderController({
+      onSessionEnd: (reason, info) =>
+        ends.push({ reason, conversationId: info.conversationId }),
+    });
+    return { h, ends };
+  }
+
+  test("a completed turn reports 'completed' with the session's conversation", async () => {
+    const { h, ends } = recordingEnds();
+    await startListening(h);
+
+    await act(async () => {
+      h.client.emit("thinking", { type: "thinking", seq: 2, turnId: "t1" });
+      h.client.emit("ttsAudio", {
+        type: "tts_audio",
+        seq: 3,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        dataBase64: "AAAA",
+      });
+      h.client.emit("ttsDone", { type: "tts_done", seq: 4, turnId: "t1" });
+      h.player.finishPlayback();
+      await Promise.resolve();
+    });
+
+    expect(ends).toEqual([{ reason: "completed", conversationId: "conv-1" }]);
+  });
+
+  test("the server-issued conversation id from `ready` is reported when start() had none", async () => {
+    const { h, ends } = recordingEnds();
+    await act(async () => {
+      await h.view.result.current.start("assistant-1");
+    });
+    await act(async () => {
+      h.client.emit("ready", {
+        type: "ready",
+        seq: 1,
+        sessionId: "s1",
+        conversationId: "conv-from-server",
+      });
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await h.view.result.current.stop();
+    });
+    expect(ends).toEqual([
+      { reason: "stopped", conversationId: "conv-from-server" },
+    ]);
+  });
+
+  test("barge-in reports 'interrupted' exactly once", async () => {
+    const { h, ends } = recordingEnds();
+    await startListening(h);
+
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 2, turnId: "t1" });
+      h.client.emit("ttsAudio", {
+        type: "tts_audio",
+        seq: 3,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        dataBase64: "AAAA",
+      });
+      h.getCapture().pushAmplitude(0.2);
+    });
+
+    expect(ends).toEqual([{ reason: "interrupted", conversationId: "conv-1" }]);
+  });
+
+  test("a server error reports 'failed'", async () => {
+    const { h, ends } = recordingEnds();
+    await startListening(h);
+
+    act(() => {
+      h.client.emit("error", {
+        code: "stt_unavailable",
+        message: "no STT provider",
+      } as LiveVoiceClientError);
+    });
+
+    expect(ends).toEqual([{ reason: "failed", conversationId: "conv-1" }]);
+  });
+
+  test("unmount mid-session does not report an end", async () => {
+    const { h, ends } = recordingEnds();
+    await startListening(h);
+
+    h.view.unmount();
+
+    expect(ends).toEqual([]);
   });
 });

--- a/apps/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/apps/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -18,9 +18,12 @@
  * (and the macOS reference) treat `ptt_release` as terminal: once released, the
  * session never re-accepts audio (sending more yields `invalid_audio_payload`).
  * So this controller does NOT keep one socket open across turns — after the
- * assistant finishes speaking it ends the session (→ idle), and the user starts
- * a fresh one for the next turn. Barge-in is the one case that reconnects
- * automatically (see below).
+ * assistant finishes speaking it ends the session (→ idle), and the user (or a
+ * higher-level controller) starts a fresh one for the next turn. Every ended
+ * session is reported through {@link UseLiveVoiceOptions.onSessionEnd} with a
+ * reason and the server-issued conversation id, which is how the voice-mode
+ * conversation loop (`useVoiceMode`) chains turns and reconnects after a
+ * barge-in.
  *
  * ## State transitions (one session = one turn)
  * `idle → connecting` (start) → `listening` (ready + capture started) →
@@ -39,10 +42,11 @@
  *
  * ## Barge-in
  * While `speaking`, a captured amplitude over {@link BARGE_IN_AMPLITUDE_THRESHOLD}
- * stops playback, sends `interrupt` (once per response), and ends the session
- * (→ idle) — the interrupted session is terminal on the runtime, so the user
- * starts a fresh session to respond. (Seamless reconnect-on-barge-in is a
- * follow-up.)
+ * stops playback (20ms fade), sends `interrupt` (once per response), and ends
+ * the session (→ idle) — the interrupted session is terminal on the runtime, so
+ * a fresh session is needed to respond. The end is reported as
+ * `onSessionEnd("interrupted", …)`; voice mode uses that to immediately open
+ * the next session so `speaking → listening` feels seamless.
  *
  * ## Automatic push-to-talk release
  * While `listening`, sustained speech (≥ {@link MINIMUM_SPEECH_DURATION_BEFORE_RELEASE_MS})
@@ -68,6 +72,11 @@ import {
   useLiveVoiceStore,
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
+import {
+  getTtsMuted,
+  getTtsVolume,
+  watchTtsOutputSettings,
+} from "@/utils/tts-output-settings";
 
 // ---------------------------------------------------------------------------
 // Thresholds (mirror the macOS LiveVoiceChannelManager defaults)
@@ -89,6 +98,30 @@ const MINIMUM_SPEECH_DURATION_BEFORE_RELEASE_MS = 120;
 // Public API
 // ---------------------------------------------------------------------------
 
+/**
+ * Why a live-voice session ended. Lets a higher-level controller (voice mode)
+ * decide whether to chain a follow-up session:
+ *
+ * - `completed` — the assistant finished speaking and playback drained.
+ * - `interrupted` — barge-in stopped playback and interrupted the server.
+ * - `stopped` — the consumer called `stop()`.
+ * - `failed` — an error, `busy`, or unexpected transport close ended it.
+ */
+export type LiveVoiceSessionEndReason =
+  | "completed"
+  | "interrupted"
+  | "stopped"
+  | "failed";
+
+export interface LiveVoiceSessionEndInfo {
+  /**
+   * Conversation the session was attached to (from the server `ready` /
+   * `archived` frames), so a follow-up session can continue the same
+   * conversation. `null` when the session never reached `ready`.
+   */
+  conversationId: string | null;
+}
+
 export interface UseLiveVoiceResult {
   /** Current session phase. */
   state: LiveVoiceSessionState;
@@ -106,6 +139,12 @@ export interface UseLiveVoiceResult {
   start: (assistantId: string, conversationId?: string) => Promise<void>;
   /** End the session and release the mic, socket, and audio context. */
   stop: () => Promise<void>;
+  /**
+   * Interrupt the assistant mid-`speaking` (button-triggered barge-in): same
+   * path as the amplitude trigger — stop playback, send `interrupt`, end the
+   * session, report `onSessionEnd("interrupted")`. No-op outside `speaking`.
+   */
+  interrupt: () => void;
 }
 
 /** Injectable factories so tests can supply mock primitives. */
@@ -115,6 +154,15 @@ export interface UseLiveVoiceOptions {
     options: ConstructorParameters<typeof LiveVoiceAudioCapture>[0],
   ) => LiveVoiceAudioCapture;
   createPlayer?: () => LiveVoiceAudioPlayer;
+  /**
+   * Invoked exactly once per session, after the session's primitives are torn
+   * down, with the reason it ended. Read fresh from the latest options at
+   * fire time, so consumers may pass an inline function.
+   */
+  onSessionEnd?: (
+    reason: LiveVoiceSessionEndReason,
+    info: LiveVoiceSessionEndInfo,
+  ) => void;
 }
 
 /**
@@ -151,6 +199,16 @@ interface SessionContext {
   speechMs: number;
   /** Accumulated trailing silence (ms) after speech in the current utterance. */
   silenceMs: number;
+  /** Conversation id from the server `ready`/`archived` frames, if any. */
+  conversationId: string | null;
+  /**
+   * Report why this session ended to the consumer's `onSessionEnd`. At most
+   * one report fires per session (teardown paths can overlap, e.g. an
+   * interrupt racing a transport close).
+   */
+  notifySessionEnd: (reason: LiveVoiceSessionEndReason) => void;
+  /** Whether `notifySessionEnd` already fired for this session. */
+  endNotified: boolean;
 }
 
 /** Number of bytes per Int16 PCM sample. */
@@ -225,6 +283,7 @@ export function useLiveVoice(
     await session.player.dispose();
     await session.capture.shutdown();
     useLiveVoiceStore.getState().reset();
+    session.notifySessionEnd("stopped");
   }, []);
 
   const start = useCallback(
@@ -241,7 +300,16 @@ export function useLiveVoice(
 
       const opts = optionsRef.current;
       const client = (opts.createClient ?? (() => new LiveVoiceChannelClient()))();
-      const player = (opts.createPlayer ?? (() => new LiveVoiceAudioPlayer()))();
+      // The default player starts at the user's persisted TTS output
+      // preference; the watcher below keeps it live for the session.
+      const player = (
+        opts.createPlayer ??
+        (() =>
+          new LiveVoiceAudioPlayer({
+            volume: getTtsVolume(),
+            muted: getTtsMuted(),
+          }))
+      )();
 
       const session: SessionContext = {
         client,
@@ -256,7 +324,24 @@ export function useLiveVoice(
         releaseInFlight: false,
         speechMs: 0,
         silenceMs: 0,
+        conversationId: conversationId ?? null,
+        endNotified: false,
+        notifySessionEnd: (reason) => {
+          if (session.endNotified) return;
+          session.endNotified = true;
+          // Read the callback fresh so inline option objects stay current.
+          optionsRef.current.onSessionEnd?.(reason, {
+            conversationId: session.conversationId,
+          });
+        },
       };
+
+      session.unsubscribes.push(
+        watchTtsOutputSettings(() => {
+          player.setVolume(getTtsVolume());
+          player.setMuted(getTtsMuted());
+        }),
+      );
 
       const capture = (opts.createCapture ?? ((o) => new LiveVoiceAudioCapture(o)))({
         onChunk: (buf) => handleChunk(session, buf),
@@ -270,8 +355,11 @@ export function useLiveVoice(
         sessionRef.current === session && session.generation === generation;
 
       session.unsubscribes.push(
-        client.on("ready", () => {
+        client.on("ready", (frame) => {
           if (!live()) return;
+          // Capture the conversation the server attached/created so a
+          // follow-up session (voice mode's next turn) can continue it.
+          session.conversationId = frame.conversationId || session.conversationId;
           void startCapture(session, teardown);
         }),
         client.on("sttPartial", (frame) => {
@@ -324,9 +412,10 @@ export function useLiveVoice(
           if (!live()) return;
           void finishResponseAfterPlayback(session, teardown);
         }),
-        client.on("archived", () => {
+        client.on("archived", (frame) => {
           if (!live()) return;
-          // Persisted; nothing user-visible to do here.
+          // Persisted; keep the conversation id current for follow-up turns.
+          session.conversationId = frame.conversationId || session.conversationId;
         }),
         client.on("busy", () => {
           if (!live()) return;
@@ -342,6 +431,7 @@ export function useLiveVoice(
           // resets the store to idle.
           if (!live()) return;
           teardown();
+          session.notifySessionEnd("failed");
         }),
       );
 
@@ -349,6 +439,12 @@ export function useLiveVoice(
     },
     [teardown],
   );
+
+  const interrupt = useCallback(() => {
+    const session = sessionRef.current;
+    if (!session) return;
+    interruptIfSpeaking(session, teardown);
+  }, [teardown]);
 
   // Release everything if the consumer unmounts mid-session. teardown() also
   // resets the store to idle so a mid-session unmount doesn't strand it in a
@@ -364,6 +460,7 @@ export function useLiveVoice(
     error,
     start,
     stop,
+    interrupt,
   };
 }
 
@@ -487,6 +584,7 @@ function interruptIfSpeaking(
   session.player.stop();
   session.client.interrupt();
   teardown();
+  session.notifySessionEnd("interrupted");
 }
 
 /** First TTS frame of a response: reset playback flags for the new utterance. */
@@ -522,6 +620,7 @@ async function finishResponseAfterPlayback(
   // A barge-in mid-drain already reconnected a fresh session; don't tear it down.
   if (useLiveVoiceStore.getState().state !== "speaking") return;
   teardown();
+  session.notifySessionEnd("completed");
 }
 
 /** Fail the session: tear down primitives and surface the message. */
@@ -532,4 +631,5 @@ function finishWithError(
 ): void {
   teardown();
   useLiveVoiceStore.getState().fail(message);
+  session.notifySessionEnd("failed");
 }

--- a/apps/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/apps/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -602,9 +602,17 @@ function beginAssistantAudioIfNeeded(session: SessionContext): void {
  * socket — we tear the session down and the user starts a fresh one for the next
  * turn (mirrors the macOS `closeCompletedUtteranceSessionAfterPlayback`).
  * Forwarding is suspended during the drain so playback audio captured by the
- * (still-open) mic isn't streamed back. A barge-in during the drain already
- * tore this session down and reconnected (generation bumped / state no longer
- * `speaking`), so we leave that fresh session alone.
+ * (still-open) mic isn't streamed back. Any teardown that raced the drain —
+ * barge-in (which reconnects a fresh session), stop(), unmount — bumped the
+ * generation, so the stale-session guard below covers all of them.
+ *
+ * Runs for silent turns too: `tts_done` can arrive without any prior
+ * `tts_audio` (no speakable text, or a zero-chunk TTS stream), in which case
+ * the session never reached `speaking` (it is still `thinking`). The drain
+ * resolves immediately and the turn must still complete — and report
+ * `completed` so the voice-mode loop opens the next listening session — the
+ * same way the macOS `syncLiveVoiceState` restarts the loop when a turn lands
+ * on `idle` without speaking.
  */
 async function finishResponseAfterPlayback(
   session: SessionContext,
@@ -617,8 +625,6 @@ async function finishResponseAfterPlayback(
   await session.player.waitUntilDrained();
   if (session.generation !== generation) return;
 
-  // A barge-in mid-drain already reconnected a fresh session; don't tear it down.
-  if (useLiveVoiceStore.getState().state !== "speaking") return;
   teardown();
   session.notifySessionEnd("completed");
 }

--- a/apps/web/src/domains/chat/voice/live-voice/use-voice-mode.test.ts
+++ b/apps/web/src/domains/chat/voice/live-voice/use-voice-mode.test.ts
@@ -1,0 +1,371 @@
+/**
+ * Tests for the `useVoiceMode` conversation loop.
+ *
+ * The live-voice primitives are replaced with the shared fakes; each session
+ * the loop opens creates a fresh client/capture/player triple, so the arrays
+ * record the loop's reconnects. The Electron bridge is stubbed on `window`
+ * to capture published voice states.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+// Keep the generated SDK out of the import graph (see use-live-voice.test.ts).
+mock.module("@/domains/chat/voice/live-voice/connection", () => ({
+  resolveLiveVoiceWsUrl: mock(
+    async () => "wss://velay.vellum.ai/a/v1/live-voice",
+  ),
+}));
+
+import type { LiveVoiceChannelClient } from "@/domains/chat/voice/live-voice/live-voice-client";
+import type { LiveVoiceAudioCapture } from "@/domains/chat/voice/live-voice/pcm-capture";
+import type { LiveVoiceAudioPlayer } from "@/domains/chat/voice/live-voice/tts-playback";
+import {
+  FakeCapture,
+  FakeClient,
+  FakePlayer,
+} from "@/domains/chat/voice/live-voice/test-fakes";
+import { LS_CONVERSATION_TIMEOUT } from "@/utils/voice-conversation-timeout";
+
+const { useVoiceMode } = await import(
+  "@/domains/chat/voice/live-voice/use-voice-mode"
+);
+const { useVoiceModeStore } = await import(
+  "@/domains/chat/voice/live-voice/voice-mode-store"
+);
+const { useLiveVoiceStore } = await import(
+  "@/domains/chat/voice/live-voice/live-voice-store"
+);
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+const publishedStates: string[] = [];
+
+function renderVoiceMode(options: { conversationId?: string } = {}) {
+  const clients: FakeClient[] = [];
+  const captures: FakeCapture[] = [];
+  const players: FakePlayer[] = [];
+
+  const view = renderHook(() =>
+    useVoiceMode({
+      assistantId: "assistant-1",
+      conversationId: options.conversationId,
+      liveVoice: {
+        createClient: () => {
+          const client = new FakeClient();
+          clients.push(client);
+          return client as unknown as LiveVoiceChannelClient;
+        },
+        createCapture: (captureOptions) => {
+          const capture = new FakeCapture(captureOptions);
+          captures.push(capture);
+          return capture as unknown as LiveVoiceAudioCapture;
+        },
+        createPlayer: () => {
+          const player = new FakePlayer();
+          players.push(player);
+          return player as unknown as LiveVoiceAudioPlayer;
+        },
+      },
+    }),
+  );
+
+  return {
+    view,
+    clients,
+    captures,
+    players,
+    client: () => clients[clients.length - 1]!,
+    capture: () => captures[captures.length - 1]!,
+    player: () => players[players.length - 1]!,
+  };
+}
+
+type Harness = ReturnType<typeof renderVoiceMode>;
+
+/** Activate the mode and drive the newest session to `listening`. */
+async function activateToListening(h: Harness, conversationId = "conv-1") {
+  await act(async () => {
+    await h.view.result.current.activate();
+  });
+  await emitReady(h, conversationId);
+}
+
+/** Emit `ready` on the newest session and settle capture start. */
+async function emitReady(h: Harness, conversationId = "conv-1") {
+  await act(async () => {
+    h.client().emit("ready", {
+      type: "ready",
+      seq: 1,
+      sessionId: `s${h.clients.length}`,
+      conversationId,
+    });
+    await Promise.resolve();
+  });
+}
+
+/** Drive the newest session into `speaking` (thinking + first TTS frame). */
+function startSpeaking(h: Harness) {
+  act(() => {
+    h.client().emit("thinking", { type: "thinking", seq: 2, turnId: "t1" });
+    h.client().emit("ttsAudio", {
+      type: "tts_audio",
+      seq: 3,
+      mimeType: "audio/pcm",
+      sampleRate: 24000,
+      dataBase64: "AAAA",
+    });
+  });
+}
+
+beforeEach(() => {
+  useLiveVoiceStore.getState().reset();
+  useVoiceModeStore.getState().reset();
+  publishedStates.length = 0;
+  localStorage.removeItem(LS_CONVERSATION_TIMEOUT);
+  (window as { vellum?: unknown }).vellum = {
+    platform: "electron",
+    voice: {
+      setState: (state: string) => {
+        publishedStates.push(state);
+      },
+    },
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  useLiveVoiceStore.getState().reset();
+  useVoiceModeStore.getState().reset();
+  localStorage.removeItem(LS_CONVERSATION_TIMEOUT);
+  delete (window as { vellum?: unknown }).vellum;
+});
+
+// ---------------------------------------------------------------------------
+// Activation & state projection
+// ---------------------------------------------------------------------------
+
+describe("activation", () => {
+  test("activate opens a session and the mode reaches listening", async () => {
+    const h = renderVoiceMode({ conversationId: "conv-init" });
+
+    expect(h.view.result.current.state).toBe("off");
+
+    await activateToListening(h, "conv-init");
+
+    expect(h.clients).toHaveLength(1);
+    expect(h.client().connectArgs).toEqual({
+      assistantId: "assistant-1",
+      conversationId: "conv-init",
+    });
+    expect(h.view.result.current.state).toBe("listening");
+    expect(publishedStates).toContain("listening");
+  });
+
+  test("session phases project to coarse mode states", async () => {
+    const h = renderVoiceMode();
+    await activateToListening(h);
+
+    act(() => {
+      h.client().emit("thinking", { type: "thinking", seq: 2, turnId: "t1" });
+    });
+    expect(h.view.result.current.state).toBe("processing");
+
+    startSpeaking(h);
+    expect(h.view.result.current.state).toBe("speaking");
+    expect(publishedStates).toContain("processing");
+    expect(publishedStates).toContain("speaking");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The conversation loop
+// ---------------------------------------------------------------------------
+
+describe("conversation loop", () => {
+  test("a completed response auto-starts the next turn on the same conversation", async () => {
+    const h = renderVoiceMode();
+    await activateToListening(h, "conv-from-server");
+    startSpeaking(h);
+
+    await act(async () => {
+      h.client().emit("ttsDone", { type: "tts_done", seq: 4, turnId: "t1" });
+      h.player().finishPlayback();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // A fresh session was opened automatically, attached to the conversation
+    // the server issued for the first one.
+    expect(h.clients).toHaveLength(2);
+    expect(h.client().connectArgs).toEqual({
+      assistantId: "assistant-1",
+      conversationId: "conv-from-server",
+    });
+
+    await emitReady(h, "conv-from-server");
+    expect(h.view.result.current.state).toBe("listening");
+  });
+
+  test("voice barge-in while speaking interrupts and resumes listening", async () => {
+    const h = renderVoiceMode();
+    await activateToListening(h);
+    startSpeaking(h);
+
+    const speakingClient = h.clients[0]!;
+    await act(async () => {
+      h.captures[0]!.pushAmplitude(0.2); // over the barge-in threshold
+      await Promise.resolve();
+    });
+
+    // The interrupted session sent `interrupt` and a replacement session
+    // opened immediately — speaking → listening without user action.
+    expect(speakingClient.interruptCount).toBe(1);
+    expect(h.players[0]!.isPlaying).toBe(false);
+    expect(h.clients).toHaveLength(2);
+
+    await emitReady(h);
+    expect(h.view.result.current.state).toBe("listening");
+  });
+
+  test("interrupt() (mic button mid-playback) behaves like voice barge-in", async () => {
+    const h = renderVoiceMode();
+    await activateToListening(h);
+    startSpeaking(h);
+
+    await act(async () => {
+      h.view.result.current.interrupt();
+      await Promise.resolve();
+    });
+
+    expect(h.clients[0]!.interruptCount).toBe(1);
+    expect(h.clients).toHaveLength(2);
+
+    await emitReady(h);
+    expect(h.view.result.current.state).toBe("listening");
+  });
+
+  test("interrupt() outside speaking is a no-op", async () => {
+    const h = renderVoiceMode();
+    await activateToListening(h);
+
+    act(() => {
+      h.view.result.current.interrupt();
+    });
+
+    expect(h.clients).toHaveLength(1);
+    expect(h.client().interruptCount).toBe(0);
+    expect(h.view.result.current.state).toBe("listening");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Deactivation
+// ---------------------------------------------------------------------------
+
+describe("deactivation", () => {
+  test("deactivate turns the mode off and ends the session", async () => {
+    const h = renderVoiceMode();
+    await activateToListening(h);
+
+    await act(async () => {
+      await h.view.result.current.deactivate();
+    });
+
+    expect(h.view.result.current.state).toBe("off");
+    expect(h.view.result.current.autoDeactivated).toBe(false);
+    expect(h.client().ended).toBe(true);
+    // No replacement session: the loop is off.
+    expect(h.clients).toHaveLength(1);
+    expect(publishedStates[publishedStates.length - 1]).toBe("off");
+  });
+
+  test("listening with no speech for the conversation timeout auto-deactivates", async () => {
+    localStorage.setItem(LS_CONVERSATION_TIMEOUT, "0.05"); // 50ms
+    const h = renderVoiceMode();
+    await activateToListening(h);
+    expect(h.view.result.current.state).toBe("listening");
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 120));
+    });
+
+    expect(h.view.result.current.state).toBe("off");
+    expect(h.view.result.current.autoDeactivated).toBe(true);
+    expect(h.clients).toHaveLength(1);
+  });
+
+  test("recognized speech keeps the conversation timeout from firing", async () => {
+    localStorage.setItem(LS_CONVERSATION_TIMEOUT, "0.08"); // 80ms
+    const h = renderVoiceMode();
+    await activateToListening(h);
+
+    // Speech arrives before the window elapses; the partial transcript
+    // disarms the timer while it is non-empty.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 40));
+      h.client().emit("sttPartial", { type: "stt_partial", seq: 2, text: "he" });
+      await new Promise((resolve) => setTimeout(resolve, 60));
+    });
+
+    expect(h.view.result.current.state).toBe("listening");
+  });
+
+  test("unmount mid-conversation resets the mode and publishes off", async () => {
+    const h = renderVoiceMode();
+    await activateToListening(h);
+
+    h.view.unmount();
+
+    expect(useVoiceModeStore.getState().state).toBe("off");
+    expect(publishedStates[publishedStates.length - 1]).toBe("off");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Failure handling
+// ---------------------------------------------------------------------------
+
+describe("failure handling", () => {
+  test("failed sessions are retried, then the mode turns off with the error", async () => {
+    const h = renderVoiceMode();
+    await activateToListening(h);
+
+    const failCurrentSession = async () => {
+      await act(async () => {
+        h.client().emit("error", {
+          reason: "protocol-error",
+          code: "stt_unavailable",
+          message: "no STT provider",
+        });
+        await Promise.resolve();
+      });
+    };
+
+    const awaitRetry = async () => {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 450));
+      });
+    };
+
+    await failCurrentSession();
+    expect(h.view.result.current.state).not.toBe("off");
+    await awaitRetry();
+    expect(h.clients).toHaveLength(2);
+
+    await emitReady(h);
+    await failCurrentSession();
+    await awaitRetry();
+    expect(h.clients).toHaveLength(3);
+
+    await emitReady(h);
+    await failCurrentSession();
+
+    // Third consecutive failure exhausts the retries.
+    expect(h.view.result.current.state).toBe("off");
+    expect(h.view.result.current.error).toBe("no STT provider");
+    expect(h.clients).toHaveLength(3);
+  });
+});

--- a/apps/web/src/domains/chat/voice/live-voice/use-voice-mode.test.ts
+++ b/apps/web/src/domains/chat/voice/live-voice/use-voice-mode.test.ts
@@ -209,6 +209,25 @@ describe("conversation loop", () => {
     expect(h.view.result.current.state).toBe("listening");
   });
 
+  test("a silent (no-TTS) response still advances the loop to the next turn", async () => {
+    // tts_done with no tts_audio: the session never reaches `speaking`, but
+    // the loop must re-listen anyway (mirrors the macOS idle auto-restart)
+    // rather than hanging in `processing` until the user stops it.
+    const h = renderVoiceMode();
+    await activateToListening(h);
+
+    await act(async () => {
+      h.client().emit("thinking", { type: "thinking", seq: 2, turnId: "t1" });
+      h.client().emit("ttsDone", { type: "tts_done", seq: 3, turnId: "t1" });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(h.clients).toHaveLength(2);
+    await emitReady(h);
+    expect(h.view.result.current.state).toBe("listening");
+  });
+
   test("voice barge-in while speaking interrupts and resumes listening", async () => {
     const h = renderVoiceMode();
     await activateToListening(h);

--- a/apps/web/src/domains/chat/voice/live-voice/use-voice-mode.test.ts
+++ b/apps/web/src/domains/chat/voice/live-voice/use-voice-mode.test.ts
@@ -341,6 +341,17 @@ describe("deactivation", () => {
     expect(useVoiceModeStore.getState().state).toBe("off");
     expect(publishedStates[publishedStates.length - 1]).toBe("off");
   });
+
+  test("a controller that never activated publishes nothing (multi-window tray safety)", () => {
+    // Each Electron window has its own renderer/store; an idle window's
+    // composer mounting or unmounting must not publish its local `off` over
+    // another window's live conversation in the main-process tray state.
+    const h = renderVoiceMode();
+    expect(publishedStates).toEqual([]);
+
+    h.view.unmount();
+    expect(publishedStates).toEqual([]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/domains/chat/voice/live-voice/use-voice-mode.ts
+++ b/apps/web/src/domains/chat/voice/live-voice/use-voice-mode.ts
@@ -1,0 +1,321 @@
+/**
+ * `useVoiceMode()` — the voice-mode conversation loop (LUM-1969).
+ *
+ * Web-app counterpart to the macOS `VoiceModeManager`
+ * (`clients/macos/.../VoiceModeManager.swift`). A live-voice session is
+ * single-utterance (one user turn → one spoken response — see
+ * {@link useLiveVoice}); voice *mode* is the persistent layer above it that
+ * keeps a conversation going:
+ *
+ * - `off ⇄ idle` — {@link UseVoiceModeResult.activate} /
+ *   {@link UseVoiceModeResult.deactivate} (button press).
+ * - `idle → listening` — activation immediately opens a session.
+ * - `listening → processing` — the user stops talking (automatic
+ *   push-to-talk release inside the session).
+ * - `processing → speaking` — first TTS chunk arrives.
+ * - `speaking → listening` — the user interrupts (voice barge-in over the
+ *   amplitude threshold, or the mic button via
+ *   {@link UseVoiceModeResult.interrupt}): the terminated session is
+ *   replaced with a fresh one attached to the same conversation.
+ * - `speaking → idle → listening` — TTS completes and playback drains; the
+ *   loop auto-listens for the next turn (matching the macOS auto-resume).
+ *
+ * The coarse mode state lives in {@link useVoiceModeStore} for UI
+ * affordances and is published to the Electron main process
+ * ({@link publishVoiceModeState}) so the tray can show
+ * listening / thinking / speaking. Fine-grained session state (transcripts,
+ * amplitude) stays in `useLiveVoiceStore`.
+ *
+ * ## Conversation continuity
+ * The first session may create a conversation server-side; its id arrives in
+ * the `ready` frame and is carried through {@link UseLiveVoiceOptions.onSessionEnd}
+ * into the next session, so every turn of one voice-mode activation shares a
+ * conversation.
+ *
+ * ## Conversation timeout
+ * Listening with no recognized speech for the user's configured timeout
+ * (`vellum:voice:conversationTimeoutSeconds`, default 30s — same setting the
+ * Voice settings page edits) deactivates the mode, mirroring the macOS
+ * conversation timeout. The store's `autoDeactivated` flag tells the UI the
+ * mode ended itself.
+ *
+ * ## Failure handling
+ * A failed session (transport error, `busy` after a barge-in reconnect, …)
+ * is retried up to {@link MAX_RESTART_ATTEMPTS} times with a short delay;
+ * after that the mode turns off and surfaces the live-voice error.
+ */
+
+import { useCallback, useEffect, useRef } from "react";
+
+import {
+  useLiveVoice,
+  type LiveVoiceSessionEndInfo,
+  type LiveVoiceSessionEndReason,
+  type UseLiveVoiceOptions,
+} from "@/domains/chat/voice/live-voice/use-live-voice";
+import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
+import {
+  useVoiceModeStore,
+  type VoiceModeState,
+} from "@/domains/chat/voice/live-voice/voice-mode-store";
+import { getConversationTimeoutMs } from "@/utils/voice-conversation-timeout";
+import { publishVoiceModeState } from "@/runtime/voice-state";
+
+/** Delay before retrying after a failed session while the mode is on. */
+const RESTART_RETRY_DELAY_MS = 400;
+
+/** Consecutive failed sessions tolerated before the mode gives up. */
+const MAX_RESTART_ATTEMPTS = 2;
+
+export interface UseVoiceModeOptions {
+  /** Assistant whose live-voice channel the conversation runs on. */
+  assistantId: string;
+  /** Conversation to continue; omitted → the first session creates one. */
+  conversationId?: string;
+  /** Injectable live-voice primitives (tests). */
+  liveVoice?: Pick<
+    UseLiveVoiceOptions,
+    "createClient" | "createCapture" | "createPlayer"
+  >;
+}
+
+export interface UseVoiceModeResult {
+  /** Coarse voice-mode state (`off`/`idle`/`listening`/`processing`/`speaking`). */
+  state: VoiceModeState;
+  /** Failure that ended the mode, if any (cleared on next activation). */
+  error: string | null;
+  /** Whether the mode turned itself off (timeout / repeated failures). */
+  autoDeactivated: boolean;
+  /** Smoothed mic amplitude in [0, 1] (for the button pulse). */
+  inputAmplitude: number;
+  /** Turn the mode on and start listening. No-op while already on. */
+  activate: () => Promise<void>;
+  /** Turn the mode off and end any active session. */
+  deactivate: () => Promise<void>;
+  /** Skip the rest of the spoken response and listen again (mid-`speaking`). */
+  interrupt: () => void;
+}
+
+/**
+ * Coarse mode state for a live session phase, or `null` for transient phases
+ * (`ending`, `failed`) that the session-end handler resolves instead.
+ */
+function mapSessionStateToMode(
+  sessionState: ReturnType<typeof useLiveVoiceStore.getState>["state"],
+): VoiceModeState | null {
+  switch (sessionState) {
+    case "connecting":
+    case "listening":
+      return "listening";
+    case "transcribing":
+    case "thinking":
+      return "processing";
+    case "speaking":
+      return "speaking";
+    case "idle":
+      return "idle";
+    case "ending":
+    case "failed":
+      return null;
+  }
+}
+
+export function useVoiceMode(options: UseVoiceModeOptions): UseVoiceModeResult {
+  const state = useVoiceModeStore.use.state();
+  const error = useVoiceModeStore.use.error();
+  const autoDeactivated = useVoiceModeStore.use.autoDeactivated();
+
+  const sessionState = useLiveVoiceStore.use.state();
+  const partialTranscript = useLiveVoiceStore.use.partialTranscript();
+
+  // Mode bookkeeping that must not re-render: whether the loop is on, the
+  // conversation threading through its sessions, retry accounting, timers.
+  const modeOnRef = useRef(false);
+  const conversationRef = useRef<string | null>(null);
+  const restartAttemptsRef = useRef(0);
+  const restartTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const idleTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const optionsRef = useRef(options);
+  useEffect(() => {
+    optionsRef.current = options;
+  });
+
+  const clearRestartTimer = useCallback(() => {
+    if (restartTimerRef.current === null) return;
+    clearTimeout(restartTimerRef.current);
+    restartTimerRef.current = null;
+  }, []);
+
+  /**
+   * Turn the mode off locally (state, timers, flags). Ending the live
+   * session is the caller's responsibility — the paths differ (user stop vs
+   * already-ended session vs failure).
+   */
+  const turnOff = useCallback(
+    (result: { auto: boolean } | { failure: string }) => {
+      modeOnRef.current = false;
+      clearRestartTimer();
+      const store = useVoiceModeStore.getState();
+      if ("failure" in result) store.fail(result.failure);
+      else store.turnOff({ auto: result.auto });
+    },
+    [clearRestartTimer],
+  );
+
+  /**
+   * Open the next session of the loop against the threaded conversation.
+   * A `connect()` rejection (transport-level; server-reported failures come
+   * through `onSessionEnd("failed")` instead) ends the mode with the error.
+   */
+  const startTurnRef = useRef<() => Promise<void>>(async () => {});
+
+  const handleSessionEnd = useCallback(
+    (reason: LiveVoiceSessionEndReason, info: LiveVoiceSessionEndInfo) => {
+      if (info.conversationId) conversationRef.current = info.conversationId;
+      if (!modeOnRef.current) return;
+
+      switch (reason) {
+        case "completed":
+        case "interrupted":
+          // The conversation loop: a finished response auto-listens for the
+          // next turn; an interrupt resumes listening immediately
+          // (speaking → listening).
+          restartAttemptsRef.current = 0;
+          void startTurnRef.current();
+          break;
+        case "stopped":
+          // The session was stopped underneath the mode (e.g. another
+          // consumer) — treat as a deactivation.
+          turnOff({ auto: false });
+          break;
+        case "failed":
+          restartAttemptsRef.current += 1;
+          if (restartAttemptsRef.current <= MAX_RESTART_ATTEMPTS) {
+            clearRestartTimer();
+            restartTimerRef.current = setTimeout(() => {
+              restartTimerRef.current = null;
+              if (modeOnRef.current) void startTurnRef.current();
+            }, RESTART_RETRY_DELAY_MS);
+          } else {
+            turnOff({
+              failure:
+                useLiveVoiceStore.getState().error ??
+                "Voice conversation failed.",
+            });
+          }
+          break;
+      }
+    },
+    [clearRestartTimer, turnOff],
+  );
+
+  const live = useLiveVoice({
+    ...options.liveVoice,
+    onSessionEnd: handleSessionEnd,
+  });
+
+  const liveStart = live.start;
+  const liveStop = live.stop;
+
+  useEffect(() => {
+    startTurnRef.current = async () => {
+      if (!modeOnRef.current) return;
+      try {
+        await liveStart(
+          optionsRef.current.assistantId,
+          conversationRef.current ?? undefined,
+        );
+      } catch (err) {
+        turnOff({
+          failure:
+            err instanceof Error ? err.message : "Voice conversation failed.",
+        });
+        await liveStop();
+      }
+    };
+  }, [liveStart, liveStop, turnOff]);
+
+  const activate = useCallback(async () => {
+    if (modeOnRef.current) return;
+    useVoiceModeStore.getState().reset();
+    modeOnRef.current = true;
+    restartAttemptsRef.current = 0;
+    conversationRef.current = optionsRef.current.conversationId ?? null;
+    useVoiceModeStore.getState().setState("idle");
+    await startTurnRef.current();
+  }, []);
+
+  const deactivate = useCallback(async () => {
+    if (!modeOnRef.current) return;
+    turnOff({ auto: false });
+    // Fires onSessionEnd("stopped"), which the handler ignores now that the
+    // mode is off.
+    await liveStop();
+  }, [liveStop, turnOff]);
+
+  // Project the session phase into the coarse mode state while the mode is
+  // on. Terminal phases (`failed`) and gaps between sessions are resolved by
+  // the session-end handler instead, so a transient `idle` between turns
+  // can't flicker the UI off.
+  useEffect(() => {
+    if (!modeOnRef.current) return;
+    const mapped = mapSessionStateToMode(sessionState);
+    if (mapped !== null) useVoiceModeStore.getState().setState(mapped);
+  }, [sessionState]);
+
+  // Conversation timeout: listening with no recognized speech for the
+  // configured duration deactivates the mode (auto). Recognized speech
+  // (a partial transcript) or leaving `listening` clears/re-arms the timer.
+  useEffect(() => {
+    if (state !== "listening" || partialTranscript !== "") {
+      if (idleTimeoutRef.current !== null) {
+        clearTimeout(idleTimeoutRef.current);
+        idleTimeoutRef.current = null;
+      }
+      return;
+    }
+    const timer = setTimeout(() => {
+      idleTimeoutRef.current = null;
+      if (!modeOnRef.current) return;
+      turnOff({ auto: true });
+      void liveStop();
+    }, getConversationTimeoutMs());
+    idleTimeoutRef.current = timer;
+    return () => {
+      clearTimeout(timer);
+      if (idleTimeoutRef.current === timer) idleTimeoutRef.current = null;
+    };
+  }, [state, partialTranscript, liveStop, turnOff]);
+
+  // Mirror every mode transition to the Electron main process (tray).
+  useEffect(() => {
+    publishVoiceModeState(state);
+  }, [state]);
+
+  // Unmount: the mode can't outlive its controller. useLiveVoice's own
+  // unmount cleanup tears down the session; this resets the mode store and
+  // tells main the conversation is over.
+  useEffect(
+    () => () => {
+      modeOnRef.current = false;
+      if (restartTimerRef.current !== null) {
+        clearTimeout(restartTimerRef.current);
+        restartTimerRef.current = null;
+      }
+      useVoiceModeStore.getState().reset();
+      publishVoiceModeState("off");
+    },
+    [],
+  );
+
+  return {
+    state,
+    error,
+    autoDeactivated,
+    inputAmplitude: live.inputAmplitude,
+    activate,
+    deactivate,
+    interrupt: live.interrupt,
+  };
+}

--- a/apps/web/src/domains/chat/voice/live-voice/use-voice-mode.ts
+++ b/apps/web/src/domains/chat/voice/live-voice/use-voice-mode.ts
@@ -288,14 +288,25 @@ export function useVoiceMode(options: UseVoiceModeOptions): UseVoiceModeResult {
     };
   }, [state, partialTranscript, liveStop, turnOff]);
 
-  // Mirror every mode transition to the Electron main process (tray).
+  // Mirror mode transitions to the Electron main process (tray) — but only
+  // from a controller that has actually been active. Each Electron window is
+  // its own renderer with its own store, and more than one can mount a
+  // composer (main chat + pop-out); an idle window publishing its local
+  // `off` on mount/unmount would overwrite the tray state of another
+  // window's live conversation. Gating on the last published value means an
+  // always-off controller never publishes at all, while the owning window
+  // still publishes its final `off`.
+  const lastPublishedStateRef = useRef<VoiceModeState>("off");
   useEffect(() => {
+    if (state === "off" && lastPublishedStateRef.current === "off") return;
+    lastPublishedStateRef.current = state;
     publishVoiceModeState(state);
   }, [state]);
 
   // Unmount: the mode can't outlive its controller. useLiveVoice's own
   // unmount cleanup tears down the session; this resets the mode store and
-  // tells main the conversation is over.
+  // — when this controller owned an active conversation — tells main it is
+  // over.
   useEffect(
     () => () => {
       modeOnRef.current = false;
@@ -304,7 +315,10 @@ export function useVoiceMode(options: UseVoiceModeOptions): UseVoiceModeResult {
         restartTimerRef.current = null;
       }
       useVoiceModeStore.getState().reset();
-      publishVoiceModeState("off");
+      if (lastPublishedStateRef.current !== "off") {
+        lastPublishedStateRef.current = "off";
+        publishVoiceModeState("off");
+      }
     },
     [],
   );

--- a/apps/web/src/domains/chat/voice/live-voice/voice-mode-store.ts
+++ b/apps/web/src/domains/chat/voice/live-voice/voice-mode-store.ts
@@ -1,0 +1,69 @@
+/**
+ * Zustand store holding the observable voice-mode state.
+ *
+ * Voice mode is the *conversation loop* layered over single-utterance
+ * live-voice sessions: while the mode is on, finishing a turn automatically
+ * starts listening for the next one, and a barge-in reconnects straight into
+ * listening. Web-app counterpart to the macOS `VoiceModeManager`
+ * (`clients/macos/.../VoiceModeManager.swift`) — same five states.
+ *
+ * The {@link useVoiceMode} controller owns the loop and writes here through
+ * the actions; UI subscribes via per-field selectors. The session-level
+ * machine (connecting/transcribing/thinking/…) stays in `useLiveVoiceStore`;
+ * this store is the coarser, user-facing mode: `off → idle → listening →
+ * processing → speaking` (ticket LUM-1969).
+ */
+
+import { create } from "zustand";
+
+import type { VoiceModeState } from "@/runtime/voice-state";
+
+import { createSelectors } from "@/utils/create-selectors";
+
+export type { VoiceModeState };
+
+export interface VoiceModeStoreState {
+  /** Current voice-mode phase; `off` when the mode is inactive. */
+  state: VoiceModeState;
+  /**
+   * Failure that ended voice mode, surfaced after the mode turns off.
+   * Cleared on the next activation.
+   */
+  error: string | null;
+  /**
+   * True when the mode turned itself off (conversation timeout or repeated
+   * session failures) rather than by a user action — lets the UI hint why
+   * the conversation stopped. Cleared on the next activation.
+   */
+  autoDeactivated: boolean;
+}
+
+export interface VoiceModeActions {
+  setState: (state: VoiceModeState) => void;
+  /** Turn off with a surfaced failure message. */
+  fail: (message: string) => void;
+  /** Turn off, marking whether the mode deactivated itself. */
+  turnOff: (options?: { auto?: boolean }) => void;
+  /** Reset to a clean `off` (clears error/autoDeactivated). */
+  reset: () => void;
+}
+
+export type VoiceModeStore = VoiceModeStoreState & VoiceModeActions;
+
+const INITIAL_STATE: VoiceModeStoreState = {
+  state: "off",
+  error: null,
+  autoDeactivated: false,
+};
+
+const useVoiceModeStoreBase = create<VoiceModeStore>()((set) => ({
+  ...INITIAL_STATE,
+
+  setState: (state) => set({ state }),
+  fail: (message) => set({ state: "off", error: message }),
+  turnOff: (options) =>
+    set({ state: "off", autoDeactivated: options?.auto ?? false }),
+  reset: () => set({ ...INITIAL_STATE }),
+}));
+
+export const useVoiceModeStore = createSelectors(useVoiceModeStoreBase);

--- a/apps/web/src/domains/settings/pages/voice-page.tsx
+++ b/apps/web/src/domains/settings/pages/voice-page.tsx
@@ -38,8 +38,13 @@ import {
     getPreferredInputDeviceId,
 } from "@/utils/voice-input-device";
 import { canConfigureFnPushToTalk } from "@/runtime/hotkey";
-
-const LS_CONVERSATION_TIMEOUT = "vellum:voice:conversationTimeoutSeconds";
+import { LS_CONVERSATION_TIMEOUT } from "@/utils/voice-conversation-timeout";
+import {
+    getTtsMuted,
+    getTtsVolume,
+    setTtsMuted,
+    setTtsVolume,
+} from "@/utils/tts-output-settings";
 
 const PTT_PRESETS: ReadonlyArray<{ label: string; activator: PTTActivator }> = [
   {
@@ -82,6 +87,7 @@ export function VoicePage() {
     <div className="flex flex-col gap-6">
       <SpeechServicesBanner />
       <MicrophoneCard />
+      <SpeechOutputCard />
       <PushToTalkCard />
       <ConversationTimeoutCard />
     </div>
@@ -216,6 +222,54 @@ function MicrophoneCard() {
             </span>
           </div>
         )}
+      </div>
+    </DetailCard>
+  );
+}
+
+function SpeechOutputCard() {
+  const [volume, setVolume] = useState<number>(() => getTtsVolume());
+  const [muted, setMuted] = useState<boolean>(() => getTtsMuted());
+
+  // Writes go through the shared setters so an active voice conversation
+  // hears the change live (the playback path watches these keys).
+  const handleVolumeChange = useCallback((next: number) => {
+    setVolume(next);
+    setTtsVolume(next);
+  }, []);
+
+  const handleMutedChange = useCallback((next: boolean) => {
+    setMuted(next);
+    setTtsMuted(next);
+  }, []);
+
+  return (
+    <DetailCard
+      title="Speech Output"
+      subtitle="Volume of the assistant's spoken responses in voice conversations."
+    >
+      <div className="flex flex-col gap-3">
+        <div className="flex items-center gap-3">
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.05}
+            value={volume}
+            onChange={(e) => handleVolumeChange(parseFloat(e.target.value))}
+            className="h-1 w-48 cursor-pointer"
+            disabled={muted}
+            aria-label="Speech output volume"
+          />
+          <span className="tabular-nums text-body-small-default text-[var(--content-tertiary)]">
+            {Math.round(volume * 100)}%
+          </span>
+        </div>
+        <Toggle
+          checked={muted}
+          onChange={handleMutedChange}
+          label="Mute spoken responses"
+        />
       </div>
     </DetailCard>
   );

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -43,6 +43,7 @@ import type {
   UpdateState,
   UpdateStatus,
   VellumCommand,
+  VoiceModeState,
 } from "@vellumai/ipc-contract";
 
 export type {
@@ -72,6 +73,7 @@ export type {
   UpdateState,
   UpdateStatus,
   VellumCommand,
+  VoiceModeState,
 };
 
 // Legacy aliases — existing consumers import these `Electron`-prefixed names.
@@ -158,6 +160,9 @@ declare global {
       };
       status?: {
         setConnection(status: AssistantStatus): void;
+      };
+      voice?: {
+        setState(state: VoiceModeState): void;
       };
       icon?: {
         setAvatar(png: Uint8Array | null): void;

--- a/apps/web/src/runtime/voice-state.ts
+++ b/apps/web/src/runtime/voice-state.ts
@@ -1,0 +1,22 @@
+import { isElectron, type VoiceModeState } from "@/runtime/is-electron";
+
+export type { VoiceModeState };
+
+/**
+ * Per-capability wrapper for publishing the voice-mode state to the Electron
+ * host. Matches the `runtime/status.ts` pattern: the renderer never touches
+ * `window.vellum.*` directly — feature code calls this named function and the
+ * cross-platform branch lives here.
+ *
+ * The renderer owns the voice-mode state machine (it holds the audio context
+ * and the mic, so transitions fire locally without a main-process round
+ * trip); main mirrors the state to drive the tray tooltip / menu header
+ * while a voice conversation is active. Fire-and-forget — no acknowledgement.
+ *
+ * Safe to call from any host — no-op off Electron, and tolerant of an older
+ * preload that predates the `voice` surface.
+ */
+export function publishVoiceModeState(state: VoiceModeState): void {
+  if (!isElectron()) return;
+  window.vellum?.voice?.setState(state);
+}

--- a/apps/web/src/utils/tts-output-settings.ts
+++ b/apps/web/src/utils/tts-output-settings.ts
@@ -1,0 +1,51 @@
+/**
+ * User preferences for TTS (voice mode) audio output: volume and mute.
+ *
+ * Persisted through the shared localStorage settings helpers so the Voice
+ * settings page and the live-voice playback path read the same values, and
+ * changes apply live to an in-flight session via {@link watchTtsOutputSettings}.
+ */
+
+import {
+  getLocalBool,
+  getLocalNumber,
+  setLocalBool,
+  setLocalNumber,
+  watchSetting,
+} from "@/utils/local-settings";
+
+export const LS_TTS_VOLUME = "vellum:voice:ttsVolume";
+export const LS_TTS_MUTED = "vellum:voice:ttsMuted";
+
+export const DEFAULT_TTS_VOLUME = 1;
+
+/** Stored TTS volume in [0, 1]; out-of-range persisted values are clamped. */
+export function getTtsVolume(): number {
+  const raw = getLocalNumber(LS_TTS_VOLUME, DEFAULT_TTS_VOLUME);
+  return Math.min(1, Math.max(0, raw));
+}
+
+export function setTtsVolume(volume: number): void {
+  setLocalNumber(LS_TTS_VOLUME, Math.min(1, Math.max(0, volume)));
+}
+
+export function getTtsMuted(): boolean {
+  return getLocalBool(LS_TTS_MUTED, false);
+}
+
+export function setTtsMuted(muted: boolean): void {
+  setLocalBool(LS_TTS_MUTED, muted);
+}
+
+/**
+ * Invoke `callback` whenever either TTS output preference changes (same-tab
+ * or cross-tab). Returns an unsubscribe function.
+ */
+export function watchTtsOutputSettings(callback: () => void): () => void {
+  const unwatchVolume = watchSetting(LS_TTS_VOLUME, callback);
+  const unwatchMuted = watchSetting(LS_TTS_MUTED, callback);
+  return () => {
+    unwatchVolume();
+    unwatchMuted();
+  };
+}

--- a/apps/web/src/utils/voice-conversation-timeout.ts
+++ b/apps/web/src/utils/voice-conversation-timeout.ts
@@ -1,0 +1,28 @@
+/**
+ * Voice-conversation idle timeout preference.
+ *
+ * How long voice mode waits (while listening, with no speech) before
+ * deactivating itself — the web counterpart of the Swift
+ * `voiceConversationTimeoutSeconds` UserDefault. Written by the Voice
+ * settings page; read by the voice-mode conversation loop.
+ */
+
+import { getLocalNumber } from "@/utils/local-settings";
+
+export const LS_CONVERSATION_TIMEOUT =
+  "vellum:voice:conversationTimeoutSeconds";
+
+export const DEFAULT_CONVERSATION_TIMEOUT_SECONDS = 30;
+
+/** Idle-listening duration (ms) after which voice mode turns itself off. */
+export function getConversationTimeoutMs(): number {
+  const seconds = getLocalNumber(
+    LS_CONVERSATION_TIMEOUT,
+    DEFAULT_CONVERSATION_TIMEOUT_SECONDS,
+  );
+  const effective =
+    Number.isFinite(seconds) && seconds > 0
+      ? seconds
+      : DEFAULT_CONVERSATION_TIMEOUT_SECONDS;
+  return effective * 1000;
+}

--- a/assistant/src/live-voice/__tests__/tts-redactor.test.ts
+++ b/assistant/src/live-voice/__tests__/tts-redactor.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+
+import { redactTextForTts } from "../tts-redactor.js";
+
+describe("redactTextForTts", () => {
+  test("redacts Anthropic API keys with the specific placeholder", () => {
+    const text = `Your key is sk-ant-api03-${"a".repeat(40)} — keep it safe.`;
+    expect(redactTextForTts(text)).toBe(
+      "Your key is a redacted Anthropic key — keep it safe.",
+    );
+  });
+
+  test("redacts OpenAI project keys before the generic sk- rule", () => {
+    const text = `Use sk-proj-${"B".repeat(24)} for the project.`;
+    expect(redactTextForTts(text)).toBe(
+      "Use a redacted API key for the project.",
+    );
+  });
+
+  test("redacts generic OpenAI keys", () => {
+    const text = `sk-${"x1".repeat(12)} is your secret`;
+    expect(redactTextForTts(text)).toBe("a redacted API key is your secret");
+  });
+
+  test("redacts GitHub fine-grained PATs", () => {
+    const text = `token: github_pat_${"A".repeat(82)}`;
+    expect(redactTextForTts(text)).toBe("token: a redacted GitHub token");
+  });
+
+  test("redacts GitHub classic tokens", () => {
+    const text = `ghp_${"a1B2".repeat(9)} expires tomorrow`;
+    expect(redactTextForTts(text)).toBe(
+      "a redacted GitHub token expires tomorrow",
+    );
+  });
+
+  test("redacts JWTs", () => {
+    const jwt = `eyJ${"a".repeat(12)}.${"b".repeat(12)}.${"c".repeat(12)}`;
+    expect(redactTextForTts(`The session token is ${jwt}.`)).toBe(
+      "The session token is a redacted token.",
+    );
+  });
+
+  test("redacts Bearer tokens case-insensitively", () => {
+    const text = `Authorization: bearer ${"t0k3n".repeat(5)}`;
+    expect(redactTextForTts(text)).toBe(
+      "Authorization: a redacted bearer token",
+    );
+  });
+
+  test("redacts email addresses", () => {
+    expect(
+      redactTextForTts("Reach me at jane.doe+test@mail.example.co.uk now"),
+    ).toBe("Reach me at a redacted email address now");
+  });
+
+  test("redacts 16-digit card numbers with and without separators", () => {
+    expect(redactTextForTts("Card 4111 1111 1111 1111 on file.")).toBe(
+      "Card a redacted card number on file.",
+    );
+    expect(redactTextForTts("Card 4111-1111-1111-1111 on file.")).toBe(
+      "Card a redacted card number on file.",
+    );
+    expect(redactTextForTts("Card 4111111111111111 on file.")).toBe(
+      "Card a redacted card number on file.",
+    );
+  });
+
+  test("redacts 15-digit Amex-style card numbers", () => {
+    expect(redactTextForTts("Amex 3782 822463 10005 charged.")).toBe(
+      "Amex a redacted card number charged.",
+    );
+  });
+
+  test("redacts phone numbers in common formats", () => {
+    expect(redactTextForTts("Call (415) 555-0123 today")).toBe(
+      "Call a redacted phone number today",
+    );
+    expect(redactTextForTts("Call +1 415-555-0123 today")).toBe(
+      "Call a redacted phone number today",
+    );
+    expect(redactTextForTts("Call 415.555.0199 today")).toBe(
+      "Call a redacted phone number today",
+    );
+  });
+
+  test("redacts 32-char alphanumeric credentials", () => {
+    const key = "Ab3dEf6hIj9kLm2nOp5qRs8tUv1wXy4z";
+    expect(redactTextForTts(`ElevenLabs key ${key} works`)).toBe(
+      "ElevenLabs key a redacted key works",
+    );
+  });
+
+  test("redacts long hex strings", () => {
+    const sha = "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3";
+    expect(redactTextForTts(`Commit ${sha} merged`)).toBe(
+      "Commit a redacted hash merged",
+    );
+  });
+
+  test("replaces every occurrence, not just the first", () => {
+    const text = "Emails: a@example.com and b@example.org";
+    expect(redactTextForTts(text)).toBe(
+      "Emails: a redacted email address and a redacted email address",
+    );
+  });
+
+  test("leaves ordinary prose untouched", () => {
+    const text =
+      "The meeting is at 3pm on June 14, 2026 — room 1234 has 16 seats.";
+    expect(redactTextForTts(text)).toBe(text);
+  });
+});

--- a/assistant/src/live-voice/live-voice-tts.ts
+++ b/assistant/src/live-voice/live-voice-tts.ts
@@ -6,6 +6,7 @@ import type {
   TtsSynthesisRequest,
   TtsUseCase,
 } from "../tts/types.js";
+import { redactTextForTts } from "./tts-redactor.js";
 
 export const DEFAULT_LIVE_VOICE_TTS_SAMPLE_RATE = 24_000;
 
@@ -98,7 +99,9 @@ export async function streamLiveVoiceTtsAudio(
   try {
     const result = await provider.synthesizeStream!(
       {
-        text: options.text,
+        // Strip credentials/PII before the text leaves the runtime — the TTS
+        // backend must never receive (or speak) unredacted secrets.
+        text: redactTextForTts(options.text),
         useCase: options.useCase ?? "phone-call",
         voiceId: options.voiceId,
         signal: options.signal,

--- a/assistant/src/live-voice/tts-redactor.ts
+++ b/assistant/src/live-voice/tts-redactor.ts
@@ -1,0 +1,76 @@
+/**
+ * Redacts credential-like and PII patterns from assistant text before TTS
+ * synthesis.
+ *
+ * Port of the Swift `TTSRedactor`
+ * (`clients/macos/vellum-assistant/Features/Voice/TTSRedactor.swift`): secrets
+ * that appear in spoken text (API keys echoed back, tokens mentioned in tool
+ * output, etc.) must not be read aloud. Each matched pattern is replaced with
+ * a short, naturally spoken placeholder. On top of the Swift secret rules,
+ * this port also strips PII shapes (email, credit card, phone number) so they
+ * never reach the TTS provider.
+ *
+ * Deliberately independent of `security/secret-patterns.ts`: that list feeds
+ * log redaction / ingress blocking with `[REDACTED]`-style tags, while these
+ * rules must stay 1:1 with the Swift client (parity) and produce placeholders
+ * that sound natural when spoken.
+ */
+
+// Each entry is (regex, spoken replacement). Patterns are ordered from most
+// specific to most general so that a more-specific rule wins when multiple
+// patterns could match. All regexes carry the `g` flag so every occurrence in
+// the text is replaced.
+const RULES: ReadonlyArray<readonly [RegExp, string]> = [
+  // Anthropic API keys (sk-ant-...)
+  [/sk-ant-[A-Za-z0-9\-_]{20,}/g, "a redacted Anthropic key"],
+  // OpenAI project API keys (sk-proj-...)
+  [/sk-proj-[A-Za-z0-9\-_]{20,}/g, "a redacted API key"],
+  // Generic OpenAI API keys (sk-...)
+  [/sk-[A-Za-z0-9]{20,}/g, "a redacted API key"],
+  // GitHub fine-grained PATs
+  [/github_pat_[A-Za-z0-9_]{82}/g, "a redacted GitHub token"],
+  // GitHub classic tokens (ghp_, ghs_, gho_, ghr_)
+  [/gh[phsor]_[A-Za-z0-9]{36}/g, "a redacted GitHub token"],
+  // JWT: three base64url segments separated by dots
+  [
+    /eyJ[A-Za-z0-9\-_]{10,}\.[A-Za-z0-9\-_]{10,}\.[A-Za-z0-9\-_]{10,}/g,
+    "a redacted token",
+  ],
+  // Bearer tokens (Authorization header value); case-insensitive
+  [/Bearer [A-Za-z0-9\-_.]{20,}/gi, "a redacted bearer token"],
+  // Email addresses
+  [
+    /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g,
+    "a redacted email address",
+  ],
+  // Payment card numbers: 16 digits in 4-groups (Visa/MC/Discover) or the
+  // 4-6-5 Amex grouping, with optional space/dash separators. Digit
+  // lookarounds keep the match from biting into longer digit runs.
+  [
+    /(?<!\d)(?:\d{4}[ -]?){3}\d{4}(?!\d)|(?<!\d)\d{4}[ -]\d{6}[ -]\d{5}(?!\d)/g,
+    "a redacted card number",
+  ],
+  // Phone numbers: optional +country code, then 10 digits with common
+  // separators. Requires at least one separator or a leading + so plain
+  // 10-digit IDs aren't swallowed unless formatted like a phone number.
+  [
+    /(?<!\d)(?:\+\d{1,3}[ .-]?)?\(?\d{3}\)?[ .-]\d{3}[ .-]?\d{4}(?!\d)/g,
+    "a redacted phone number",
+  ],
+  // 32-char alphanumeric credentials — ElevenLabs keys and similar (not just hex)
+  [/\b[A-Za-z0-9]{32}\b/g, "a redacted key"],
+  // Long hex strings (40+ chars) — SHA-1/SHA-256 hashes and token IDs
+  [/\b[0-9a-f]{40,}\b/g, "a redacted hash"],
+];
+
+/**
+ * Returns `text` with all detected credential/PII patterns replaced by spoken
+ * placeholders.
+ */
+export function redactTextForTts(text: string): string {
+  let result = text;
+  for (const [regex, replacement] of RULES) {
+    result = result.replace(regex, replacement);
+  }
+  return result;
+}

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -39,6 +39,7 @@ import type {
   TextInsertionResult,
   UpdateState,
   VellumCommand,
+  VoiceModeState,
 } from "./types";
 
 export interface VellumBridge {
@@ -125,6 +126,9 @@ export interface VellumBridge {
   };
   status: {
     setConnection(status: AssistantStatus): void;
+  };
+  voice: {
+    setState(state: VoiceModeState): void;
   };
   icon: {
     setAvatar(png: Uint8Array | null): void;

--- a/packages/ipc-contract/src/channels.ts
+++ b/packages/ipc-contract/src/channels.ts
@@ -51,6 +51,9 @@ export const COMMAND_EVENT = "vellum:command";
 // Status
 export const STATUS_CONNECTION = "vellum:status:connection";
 
+// Voice mode
+export const VOICE_SET_STATE = "vellum:voice:state";
+
 // Icon / avatar
 export const ICON_SET_AVATAR = "vellum:icon:setAvatar";
 

--- a/packages/ipc-contract/src/schemas.ts
+++ b/packages/ipc-contract/src/schemas.ts
@@ -15,13 +15,23 @@
  */
 import { z } from "zod";
 
-import { ASSISTANT_STATUSES, NOTIFICATION_CATEGORIES } from "./types";
+import {
+  ASSISTANT_STATUSES,
+  NOTIFICATION_CATEGORIES,
+  VOICE_MODE_STATES,
+} from "./types";
 
 // ---------------------------------------------------------------------------
 // Status
 // ---------------------------------------------------------------------------
 
 export const assistantStatusSchema = z.enum(ASSISTANT_STATUSES);
+
+// ---------------------------------------------------------------------------
+// Voice mode
+// ---------------------------------------------------------------------------
+
+export const voiceModeStateSchema = z.enum(VOICE_MODE_STATES);
 
 // ---------------------------------------------------------------------------
 // Notifications

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -169,6 +169,23 @@ export const CONNECTIVITY_STATES = [
 
 export type ConnectivityState = (typeof CONNECTIVITY_STATES)[number];
 
+/**
+ * Voice mode (live-voice conversation) state, published renderer → main so
+ * the tray can reflect an active voice conversation. Mirrors the Swift app's
+ * `VoiceModeManager.State` enum: `off` (mode disabled), `idle` (mode on,
+ * between turns), `listening` (mic streaming), `processing` (transcribing /
+ * assistant thinking), `speaking` (TTS playing).
+ */
+export const VOICE_MODE_STATES = [
+  "off",
+  "idle",
+  "listening",
+  "processing",
+  "speaking",
+] as const;
+
+export type VoiceModeState = (typeof VOICE_MODE_STATES)[number];
+
 // ---------------------------------------------------------------------------
 // Power events
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add a voice-mode conversation loop (`useVoiceMode` + `voice-mode-store`) over the existing single-utterance live-voice sessions, porting the Swift `VoiceModeManager` state machine (`off → idle → listening → processing → speaking`): finished responses auto-listen for the next turn on the same conversation, barge-in (RMS threshold or mic-button press mid-playback) interrupts and reconnects straight into `listening`, repeated failures retry then surface, and an idle-listening conversation timeout auto-deactivates the mode.
- Upgrade the TTS playback queue with a master gain node: 20ms linear fade-out on interrupt (a hard stop clicks), plus live volume/mute controls persisted via the settings store (new Speech Output card in Voice settings) and applied mid-session.
- Publish renderer voice state to main over a new `vellum:voice:state` IPC channel (tray tooltip/menu header show listening/thinking/speaking), set `autoplay-policy=no-user-gesture-required` so frame-triggered playback isn't blocked, and redact secrets/PII (Swift `TTSRedactor` patterns 1:1 plus email/phone/credit-card, spoken placeholders) in `streamLiveVoiceTtsAudio` before text reaches any TTS provider.

## Original prompt
Implement Linear ticket [LUM-1969](https://linear.app/vellum/issue/LUM-1969/dictation-voice-mode-tts-playback-with-interrupt-handling) — "[Dictation] Voice mode + TTS playback with interrupt handling": Vellum talks back in voice mode with streaming low-latency TTS playback, a voice-mode state machine the renderer owns (published to main for tray affordances), interrupt handling that flushes playback and resumes listening, volume/mute in the settings store, and TTS redaction matching the native app. The native macOS Swift app (`clients/macos/vellum-assistant/Features/Voice/` — `VoiceModeManager`, `LiveVoiceAudioPlayer`, `TTSRedactor`, `OpenAIVoiceService`) served as the reference implementation to port; the existing Electron live-voice channel (full-duplex WebSocket, PCM capture, gapless playback) was the foundation this builds on.