### PR TITLE
feat(assistant): add modification-recency fresh-set lane to memory-v3

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v3.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v3.test.ts
@@ -8,6 +8,7 @@ describe("MemoryV3ConfigSchema", () => {
     expect(parsed).toEqual({
       prune: { maxResidentBytes: 393216, targetResidentBytes: 262144 },
       hotSet: { k: 40, halfLifeDays: 14 },
+      freshSet: { k: 50 },
       spotlight: { n: 6, windowTurns: 2 },
       needleK: 100,
       denseK: 100,

--- a/assistant/src/config/schemas/memory-v3.ts
+++ b/assistant/src/config/schemas/memory-v3.ts
@@ -64,6 +64,26 @@ export const MemoryV3HotSetSchema = z
   .describe("Memory v3 hot-set lane (decayed selection frequency) tuning.");
 
 /**
+ * Fresh-set lane tuning: the top-K pages by most-recent on-disk modification
+ * folded into the candidate pool as a stable-prefix lane. Recency covers the
+ * window before the other lanes can reach a just-written page (no selection
+ * history for the hot set; nothing lexical for the finders on summary-shaped
+ * messages).
+ */
+export const MemoryV3FreshSetSchema = z
+  .object({
+    k: z
+      .number({ error: "memory.v3.freshSet.k must be a number" })
+      .int("memory.v3.freshSet.k must be an integer")
+      .nonnegative("memory.v3.freshSet.k must be a non-negative integer")
+      .default(50)
+      .describe(
+        "Number of most-recently-modified pages included in the fresh-set lane (0 disables the lane). Sized to cover roughly the last day or two of page writes — the recency window conversations reference most.",
+      ),
+  })
+  .describe("Memory v3 fresh-set lane (page-modification recency) tuning.");
+
+/**
  * Ephemeral section-spotlight tuning: how many of the current turn's selected
  * finder hits render their matched section into the `<memory_spotlight>`
  * block, and how many previous turns' spotlight entries are carried along
@@ -142,6 +162,7 @@ export const MemoryV3ConfigSchema = z
   .object({
     prune: MemoryV3PruneSchema.default(MemoryV3PruneSchema.parse({})),
     hotSet: MemoryV3HotSetSchema.default(MemoryV3HotSetSchema.parse({})),
+    freshSet: MemoryV3FreshSetSchema.default(MemoryV3FreshSetSchema.parse({})),
     spotlight: MemoryV3SpotlightSchema.default(
       MemoryV3SpotlightSchema.parse({}),
     ),

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/carry-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/carry-integration.test.ts
@@ -255,6 +255,7 @@ async function scriptedObserveTurn(conversationId: string, turnIndex: number) {
       edgeGraph: lanes.edgeGraph,
       coreSlugs: lanes.coreSlugs,
       hotSlugs: lanes.hotSlugs,
+      freshSlugs: [],
       prefixCards: lanes.prefixCards,
     },
   );

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/fresh-set.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/fresh-set.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+
+import { computeFreshSet } from "../fresh-set.js";
+
+const entry = (slug: string, modifiedAt: number) => ({ slug, modifiedAt });
+
+describe("computeFreshSet", () => {
+  test("ranks by modification time, newest first", () => {
+    const slugs = computeFreshSet(
+      [entry("old", 1000), entry("newest", 3000), entry("mid", 2000)],
+      { k: 3, excludeSlugs: new Set() },
+    );
+    expect(slugs).toEqual(["newest", "mid", "old"]);
+  });
+
+  test("cuts to k after exclusions", () => {
+    const slugs = computeFreshSet(
+      [entry("a", 4000), entry("b", 3000), entry("c", 2000), entry("d", 1000)],
+      { k: 2, excludeSlugs: new Set(["a"]) },
+    );
+    // "a" is excluded BEFORE the cut, so the two slots go to the next-newest.
+    expect(slugs).toEqual(["b", "c"]);
+  });
+
+  test("skips synthetic entries (modifiedAt 0)", () => {
+    const slugs = computeFreshSet(
+      [entry("skills/oura", 0), entry("real-page", 500)],
+      { k: 5, excludeSlugs: new Set() },
+    );
+    expect(slugs).toEqual(["real-page"]);
+  });
+
+  test("k = 0 disables the lane", () => {
+    expect(
+      computeFreshSet([entry("a", 1000)], { k: 0, excludeSlugs: new Set() }),
+    ).toEqual([]);
+  });
+
+  test("breaks modification-time ties by slug, ascending", () => {
+    const slugs = computeFreshSet(
+      [entry("zebra", 1000), entry("apple", 1000), entry("mango", 1000)],
+      { k: 3, excludeSlugs: new Set() },
+    );
+    expect(slugs).toEqual(["apple", "mango", "zebra"]);
+  });
+
+  test("does not mutate the input array", () => {
+    const entries = [entry("b", 1000), entry("a", 2000)];
+    computeFreshSet(entries, { k: 2, excludeSlugs: new Set() });
+    expect(entries.map((e) => e.slug)).toEqual(["b", "a"]);
+  });
+});

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/injection.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/injection.test.ts
@@ -215,6 +215,7 @@ function result(
     lanes: {
       core: [],
       hot: [],
+      fresh: [],
       finder: matched.map(([slug]) => ({
         slug,
         descriptor: "",

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/live-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/live-integration.test.ts
@@ -235,6 +235,7 @@ async function runTurn(
     edgeGraph: deps.lanes.edgeGraph,
     coreSlugs: [],
     hotSlugs: [],
+    freshSlugs: [],
     prefixCards: new Map(),
   });
   const active = getActiveSlugs(conversationId);

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
@@ -127,8 +127,9 @@ function depsOf(
 ): OrchestrateDeps {
   const coreSlugs = overrides.coreSlugs ?? [];
   const hotSlugs = overrides.hotSlugs ?? [];
+  const freshSlugs = overrides.freshSlugs ?? [];
   const prefixCards = new Map<Slug, string>(
-    [...coreSlugs, ...hotSlugs].map((slug) => [
+    [...coreSlugs, ...hotSlugs, ...freshSlugs].map((slug) => [
       slug,
       renderCard(slug, RAW[slug] ?? ""),
     ]),
@@ -140,6 +141,7 @@ function depsOf(
     edgeGraph: lanes.edgeGraph,
     coreSlugs,
     hotSlugs,
+    freshSlugs,
     prefixCards,
     ...overrides,
   };
@@ -369,6 +371,26 @@ describe("orchestrate — cache-ordered pool (core + hot + finders)", () => {
       "topic-a",
       "topic-b",
     ]);
+  });
+
+  test("fresh follows hot in the pool and dedups against core/hot", async () => {
+    const lanes = await buildLanes();
+    denseHits = [];
+    providerStub = selectProvider([]);
+
+    const result = await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, {
+        coreSlugs: ["topic-c"],
+        hotSlugs: ["topic-d"],
+        // topic-c (core) and topic-d (hot) are defensively dropped; only
+        // topic-b earns a fresh slot.
+        freshSlugs: ["topic-c", "topic-d", "topic-b"],
+      }),
+    );
+
+    expect(lastPool).toEqual(["topic-c", "topic-d", "topic-b", "topic-a"]);
+    expect(result.lanes.fresh).toEqual(["topic-b"]);
   });
 
   test("the rendered stable prefix is byte-identical across turns with different queries", async () => {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/selection-log-store.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/selection-log-store.test.ts
@@ -202,6 +202,7 @@ describe("summarizeSelections", () => {
     expect(summary.bySource).toEqual({
       core: 0,
       hot: 0,
+      fresh: 0,
       needle: 2,
       dense: 0,
       edge: 2,
@@ -216,6 +217,7 @@ describe("summarizeSelections", () => {
       bySource: {
         core: 0,
         hot: 0,
+        fresh: 0,
         needle: 0,
         dense: 0,
         edge: 0,

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-integration.test.ts
@@ -310,6 +310,7 @@ async function runTurn(
     edgeGraph: deps.lanes.edgeGraph,
     coreSlugs: deps.core ?? [],
     hotSlugs: deps.hot ?? [],
+    freshSlugs: [],
     // Mirrors lane init: every stable-prefix slug gets a pre-rendered card.
     prefixCards: new Map(
       stableSlugs.map((slug) => [slug, renderCard(slug, RAW[slug] ?? "")]),
@@ -476,6 +477,7 @@ describe("memory-v3 shadow integration — selection-log readout", () => {
       bySource: {
         core: 0,
         hot: 0,
+        fresh: 0,
         needle: 0,
         dense: 0,
         edge: 0,

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
@@ -88,8 +88,9 @@ const CAPABILITY_SLUG = "skills/example";
 const CAPABILITY_CONTENT = "use the kumquat skill to do the thing";
 
 // The orchestrate result the spy returns. `lanes` records where each pooled
-// slug lived: page-core in the core lane, page-hot in the hot lane, and the
-// finder entries page-1 → "needle", page-2 → "dense", page-3 → "edge";
+// slug lived: page-core in the core lane, page-hot in the hot lane, page-fresh
+// in the fresh lane, and the finder entries page-1 → "needle", page-2 → "dense",
+// page-3 → "edge";
 // `attributeSelections` reads it directly. `matchedSections` carries the
 // matched section for the slugs that had one (page-1/page-2) — consumed by the
 // live injector's progressive disclosure, independent of source attribution.
@@ -98,6 +99,7 @@ const orchestrateSpy = mock(
     selections: [
       { slug: "page-core", pinned: false },
       { slug: "page-hot", pinned: false },
+      { slug: "page-fresh", pinned: false },
       { slug: "page-1", pinned: true },
       { slug: "page-2", pinned: false },
       { slug: "page-3", pinned: false },
@@ -109,6 +111,7 @@ const orchestrateSpy = mock(
     lanes: {
       core: ["page-core"],
       hot: ["page-hot"],
+      fresh: ["page-fresh"],
       finder: [
         { slug: "page-1", descriptor: "", lane: "needle" },
         { slug: "page-2", descriptor: "", lane: "dense" },
@@ -180,6 +183,7 @@ mock.module("../../../../config/loader.js", () => ({
       enabled: memoryEnabled,
       v3: {
         hotSet: { k: 40, halfLifeDays: 14 },
+        freshSet: { k: 50 },
         spotlight: { n: 6, windowTurns: 2 },
         needleK: 100,
         denseK: 100,
@@ -463,8 +467,10 @@ describe("memory-v3 shadow plugin", () => {
       { slug: "page-2", source: "dense", pinned: 0 },
       // page-3 was surfaced by the edge lane → "edge".
       { slug: "page-3", source: "edge", pinned: 0 },
-      // page-core / page-hot sit in the stable prefix → "core" / "hot".
+      // page-core / page-hot / page-fresh sit in the stable prefix →
+      // "core" / "hot" / "fresh".
       { slug: "page-core", source: "core", pinned: 0 },
+      { slug: "page-fresh", source: "fresh", pinned: 0 },
       { slug: "page-hot", source: "hot", pinned: 0 },
     ]);
   });
@@ -476,6 +482,7 @@ describe("memory-v3 shadow plugin", () => {
       lanes: {
         core: ["page-core"],
         hot: [],
+        fresh: [],
         // The needle also hit the core page this turn — the row still logs
         // "core" because that is where the candidate lived in the pool.
         finder: [{ slug: "page-core", descriptor: "", lane: "needle" }],
@@ -598,7 +605,7 @@ describe("memory-v3 shadow plugin", () => {
     orchestrateSpy.mockImplementationOnce(async () => ({
       selections: [],
       matchedSections: new Map(),
-      lanes: { core: [], hot: [], finder: [] },
+      lanes: { core: [], hot: [], fresh: [], finder: [] },
     }));
     const block = await produce("conv-1", 0);
     expect(block).toBeNull();

--- a/assistant/src/plugins/defaults/memory-v3-shadow/fresh-set.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/fresh-set.ts
@@ -1,0 +1,59 @@
+/**
+ * Recency fresh-set lane.
+ *
+ * Returns the top-K page slugs by most-recent on-disk modification
+ * (`PageIndexEntry.modifiedAt`). The fresh set keeps *just-written* pages in
+ * the candidate pool during the window before the other lanes can reach them:
+ * a page consolidated minutes ago has no selection history (so frecency can't
+ * rank it into the hot set) and a "what happened today?"-shaped message gives
+ * the finder lanes nothing lexical to match it on. Recency is exactly the
+ * signal those lanes are missing, so it gets its own lane.
+ *
+ * Like core and hot, the fresh set is a stable-prefix lane: it is computed at
+ * lane init and recomputed only on lane invalidation (the consolidation
+ * cadence), so its membership — and therefore the selector's cache-stable
+ * prefix — never changes mid-window. Page mtimes move on every consolidation
+ * write, which is the same event that invalidates the lanes, so recompute
+ * lag is bounded by the consolidation interval.
+ *
+ * Slugs in `excludeSlugs` (core + hot members) are dropped before the K cut —
+ * those pages already sit in the stable prefix, so re-listing them would only
+ * spend fresh slots on duplicates. Synthetic capability entries carry
+ * `modifiedAt: 0` and are skipped: they have no on-disk write to be fresh by.
+ */
+
+import type { Slug } from "./types.js";
+
+/** The slice of a page-index entry the fresh lane ranks on. */
+export interface FreshSetEntry {
+  slug: Slug;
+  /** File mtime in epoch ms; `0` for synthetic entries (skills, CLI commands). */
+  modifiedAt: number;
+}
+
+export interface FreshSetOptions {
+  /** Maximum number of slugs returned; `0` disables the lane. */
+  k: number;
+  /** Slugs excluded from the result (core + hot — fresh never duplicates the
+   *  rest of the stable prefix). */
+  excludeSlugs: Set<string>;
+}
+
+/**
+ * Compute the top-`k` fresh slugs by file modification time, newest first.
+ *
+ * Deterministic for fixed inputs: ties break `modifiedAt` desc, then slug asc.
+ */
+export function computeFreshSet(
+  entries: readonly FreshSetEntry[],
+  opts: FreshSetOptions,
+): Slug[] {
+  const { k, excludeSlugs } = opts;
+  if (k <= 0) return [];
+
+  return entries
+    .filter((entry) => entry.modifiedAt > 0 && !excludeSlugs.has(entry.slug))
+    .sort((a, b) => b.modifiedAt - a.modifiedAt || (a.slug < b.slug ? -1 : 1))
+    .slice(0, k)
+    .map((entry) => entry.slug);
+}

--- a/assistant/src/plugins/defaults/memory-v3-shadow/injector.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/injector.ts
@@ -301,14 +301,16 @@ export const memoryV3Injector: Injector = {
       // `produce()` would let a never-attached turn (non-user tail) claim
       // cards in the store, suppressing them until compaction. The valve is
       // scheduled after `recordInjected` so the resident accounting includes
-      // this turn's cards; core/hot lane members are exempt — the selector's
-      // stable prefix must never be pruned out from under it.
+      // this turn's cards; stable-prefix lane members (core/hot/fresh) are
+      // exempt — the selector's stable prefix must never be pruned out from
+      // under it.
       const commit = (): void => {
         recordInjected(ctx.conversationId, entries);
         schedulePruneValve(ctx.conversationId, {
           exemptSlugs: new Set<Slug>([
             ...result.lanes.core,
             ...result.lanes.hot,
+            ...result.lanes.fresh,
           ]),
         });
       };

--- a/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
@@ -10,13 +10,13 @@
  *      Each lane only ever ADDS candidates, so the pool is recall-safe by
  *      construction.
  *   2. Build the candidate pool in CACHE ORDER: the stable prefix —
- *      `[...core (file order), ...hot (score order)]`, both computed at lane
- *      init — followed by the finder candidates (needle → dense → edge
- *      surfacing order). The stable prefix is identical across consecutive
- *      turns while the lanes are unchanged (lane invalidation at consolidation
- *      is the recompute cadence), so the selector input's leading segment
- *      rides the provider KV cache (the cache breakpoint itself lives in
- *      `pool-select.ts`).
+ *      `[...core (file order), ...hot (score order), ...fresh (recency
+ *      order)]`, all computed at lane init — followed by the finder
+ *      candidates (needle → dense → edge surfacing order). The stable prefix
+ *      is identical across consecutive turns while the lanes are unchanged
+ *      (lane invalidation at consolidation is the recompute cadence), so the
+ *      selector input's leading segment rides the provider KV cache (the
+ *      cache breakpoint itself lives in `pool-select.ts`).
  *
  *      Stable-prefix candidates render as FULL CARDS (`renderCard` — head
  *      section + TOC), pre-rendered at lane init (`prefixCards`) so the
@@ -71,10 +71,13 @@ export interface OrchestrateDeps {
   /** The frecency hot set in score order (computed at lane init with the core
    *  set excluded). Follows core in the stable prefix. */
   hotSlugs: Slug[];
+  /** The modification-recency fresh set in recency order (computed at lane
+   *  init with core and hot excluded). Follows hot in the stable prefix. */
+  freshSlugs: Slug[];
   /** Pre-rendered FULL cards for the stable-prefix slugs, keyed by slug.
    *  Rendered ONCE at lane init so the selector's stable prefix is
-   *  byte-identical across turns (the cache contract). Every core/hot slug
-   *  MUST have an entry — a missing card is a lane-init bug and throws
+   *  byte-identical across turns (the cache contract). Every core/hot/fresh
+   *  slug MUST have an entry — a missing card is a lane-init bug and throws
    *  (silently degrading would violate the byte-stable-prefix contract). */
   prefixCards: ReadonlyMap<Slug, string>;
   /** Number of BM25 needle articles. Defaults to {@link DEFAULT_NEEDLE_K}. */
@@ -101,16 +104,19 @@ export interface FinderCandidate {
 }
 
 /**
- * The three candidate lanes in cache order. `core` and `hot` are the stable
- * prefix (byte-identical across turns while lanes are unchanged); `finder` is
- * the dynamic tail and MAY repeat a stable-prefix slug (a finder hit on a
- * core/hot page is kept so its current relevance stays visible downstream).
+ * The candidate lanes in cache order. `core`, `hot`, and `fresh` are the
+ * stable prefix (byte-identical across turns while lanes are unchanged);
+ * `finder` is the dynamic tail and MAY repeat a stable-prefix slug (a finder
+ * hit on a stable-prefix page is kept so its current relevance stays visible
+ * downstream).
  */
 export interface OrchestrateLanes {
   /** Curated core set, file order. */
   core: Slug[];
   /** Frecency hot set, score order (never overlaps core). */
   hot: Slug[];
+  /** Modification-recency fresh set, recency order (never overlaps core/hot). */
+  fresh: Slug[];
   /** Finder candidates in surfacing order, deduped among themselves only. */
   finder: FinderCandidate[];
 }
@@ -144,12 +150,15 @@ export async function orchestrate(
   const denseK = deps.denseK ?? DEFAULT_DENSE_K;
   const { sections } = deps.sectionIndex;
 
-  // The stable prefix: core (file order) then hot (score order). Hot is
-  // computed with core excluded at lane init; the filter here is a cheap
-  // defensive dedup so a misbehaving lane can never double-list a slug.
+  // The stable prefix: core (file order), hot (score order), fresh (recency
+  // order). Hot is computed with core excluded at lane init, fresh with both
+  // excluded; the filters here are a cheap defensive dedup so a misbehaving
+  // lane can never double-list a slug.
   const core = deps.coreSlugs;
   const hot = deps.hotSlugs.filter((slug) => !core.includes(slug));
-  const stablePrefix = new Set<Slug>([...core, ...hot]);
+  const coreHot = new Set<Slug>([...core, ...hot]);
+  const fresh = deps.freshSlugs.filter((slug) => !coreHot.has(slug));
+  const stablePrefix = new Set<Slug>([...coreHot, ...fresh]);
 
   // Step 1: needle (sync BM25) and dense (async embed + Qdrant) lanes run in
   // parallel. Both return distinct articles each tagged with their best-scoring
@@ -246,7 +255,7 @@ export async function orchestrate(
   }
 
   // Step 2: assemble the selector pool in cache order — the stable prefix
-  // (core then hot) as FULL CARDS, then the finder tail. Cards are
+  // (core, hot, fresh) as FULL CARDS, then the finder tail. Cards are
   // pre-rendered at lane init (`prefixCards`): query- AND
   // conversation-state-INDEPENDENT by design, so the rendered prefix is
   // byte-identical across turns while the lanes are unchanged. The tail is
@@ -254,7 +263,7 @@ export async function orchestrate(
   // its own snippet line so its CURRENT relevance stays visible; `selectPool`
   // dedupes selections by slug. Finder candidates with no match text fall
   // back to the page's lead-section snippet.
-  const stable: StableCandidate[] = [...core, ...hot].map((slug) => {
+  const stable: StableCandidate[] = [...core, ...hot, ...fresh].map((slug) => {
     const card = deps.prefixCards.get(slug);
     if (card === undefined) {
       // Lane init renders a card for every core/hot slug; a hole here means
@@ -283,7 +292,7 @@ export async function orchestrate(
   return {
     selections,
     matchedSections,
-    lanes: { core, hot, finder },
+    lanes: { core, hot, fresh, finder },
   };
 }
 

--- a/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
@@ -50,6 +50,7 @@ import { renderCard } from "./card.js";
 import { loadCoreSet } from "./core-set.js";
 import type { EdgeGraph } from "./edge.js";
 import { buildEdgeGraph } from "./edge.js";
+import { computeFreshSet } from "./fresh-set.js";
 import { computeHotSet } from "./hot-set.js";
 import type { OrchestrateResult } from "./orchestrate.js";
 import { orchestrate } from "./orchestrate.js";
@@ -92,8 +93,11 @@ export interface ShadowLanes {
   /** Frecency hot set in score order: core excluded, filtered to pages in the
    *  section index. */
   hotSlugs: string[];
-  /** Pre-rendered FULL cards for the stable-prefix (core+hot) slugs, keyed by
-   *  slug. Frozen at lane build so the selector's stable prefix is
+  /** Modification-recency fresh set in recency order: core and hot excluded,
+   *  filtered to pages in the section index. */
+  freshSlugs: string[];
+  /** Pre-rendered FULL cards for the stable-prefix (core+hot+fresh) slugs,
+   *  keyed by slug. Frozen at lane build so the selector's stable prefix is
    *  byte-identical across turns until the next invalidation. */
   prefixCards: Map<Slug, string>;
 }
@@ -189,6 +193,15 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
     .map((entry) => entry.slug)
     .filter((slug) => sectionIndex.byArticle.has(slug));
 
+  // Fresh is the modification-recency top-K over the page index with core and
+  // hot excluded (fresh never duplicates the rest of the prefix). Page mtimes
+  // move at consolidation — the same event that invalidates the lanes — so the
+  // set is recomputed exactly when it can have changed.
+  const freshSlugs = computeFreshSet(pageIndex.entries, {
+    k: config.memory.v3.freshSet.k,
+    excludeSlugs: new Set([...coreSlugs, ...hotSlugs]),
+  }).filter((slug) => sectionIndex.byArticle.has(slug));
+
   // Pre-render the stable-prefix cards ONCE per lane build: the selector's
   // stable prefix must be byte-identical across turns to ride the provider KV
   // cache, so the cards are frozen here (lane invalidation at consolidation is
@@ -196,7 +209,7 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
   // render their capability content; disk pages render raw (frontmatter +
   // body) so `kind: index` pages surface their `links:` map in the card TOC.
   const prefixCards = new Map<Slug, string>();
-  for (const slug of [...coreSlugs, ...hotSlugs]) {
+  for (const slug of [...coreSlugs, ...hotSlugs, ...freshSlugs]) {
     const raw = await capabilityOrDiskBody(
       slug,
       async (s) => (await loadPage(s))?.raw ?? "",
@@ -230,6 +243,7 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
     edgeGraph,
     coreSlugs,
     hotSlugs,
+    freshSlugs,
     prefixCards,
   };
 }
@@ -325,17 +339,18 @@ interface SelectionRow {
 /**
  * Map an orchestrate result onto telemetry rows with per-lane source
  * attribution, by pool position: a selection of a stable-prefix page is
- * attributed `"core"` / `"hot"` (the lane that placed it in the pool), and any
- * other selection is attributed the finder lane that FIRST surfaced it
- * (`"needle"` / `"dense"` / `"edge"`, recorded at pool-build time). A finder
- * hit on a core/hot page therefore still logs as core/hot — the prefix is
- * where the candidate lived. (`"needle"` is the fallback if a selected slug is
- * somehow absent from every lane, which should not happen since every pooled
- * candidate comes from one.)
+ * attributed `"core"` / `"hot"` / `"fresh"` (the lane that placed it in the
+ * pool), and any other selection is attributed the finder lane that FIRST
+ * surfaced it (`"needle"` / `"dense"` / `"edge"`, recorded at pool-build
+ * time). A finder hit on a stable-prefix page therefore still logs as its
+ * prefix lane — the prefix is where the candidate lived. (`"needle"` is the
+ * fallback if a selected slug is somehow absent from every lane, which should
+ * not happen since every pooled candidate comes from one.)
  */
 export function attributeSelections(result: OrchestrateResult): SelectionRow[] {
   const core = new Set<Slug>(result.lanes.core);
   const hot = new Set<Slug>(result.lanes.hot);
+  const fresh = new Set<Slug>(result.lanes.fresh);
   const finderLane = new Map(
     result.lanes.finder.map((c) => [c.slug, c.lane] as const),
   );
@@ -345,7 +360,9 @@ export function attributeSelections(result: OrchestrateResult): SelectionRow[] {
       ? ("core" as const)
       : hot.has(sel.slug)
         ? ("hot" as const)
-        : (finderLane.get(sel.slug) ?? "needle"),
+        : fresh.has(sel.slug)
+          ? ("fresh" as const)
+          : (finderLane.get(sel.slug) ?? "needle"),
     pinned: sel.pinned ? 1 : 0,
   }));
 }
@@ -396,6 +413,7 @@ export async function observeTurn(
       edgeGraph: lanes.edgeGraph,
       coreSlugs: lanes.coreSlugs,
       hotSlugs: lanes.hotSlugs,
+      freshSlugs: lanes.freshSlugs,
       prefixCards: lanes.prefixCards,
       needleK: v3.needleK,
       denseK: v3.denseK,
@@ -403,6 +421,22 @@ export async function observeTurn(
       edgePerSeed: v3.edge.perSeed,
       edgeCap: v3.edge.cap,
     });
+
+    // A zero-selection turn over a non-trivial pool is unusual enough to be
+    // worth a breadcrumb (observed on meta-prompt-shaped system turns): the
+    // turn itself proceeds normally — cards already in context still serve it.
+    if (result.selections.length === 0) {
+      log.info(
+        {
+          conversationId,
+          core: result.lanes.core.length,
+          hot: result.lanes.hot.length,
+          fresh: result.lanes.fresh.length,
+          finder: result.lanes.finder.length,
+        },
+        "memory-v3: selector returned zero selections",
+      );
+    }
 
     const rows = attributeSelections(result);
     writeSelections(conversationId, turnIndex, rows);

--- a/assistant/src/plugins/defaults/memory-v3-shadow/types.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/types.ts
@@ -81,8 +81,9 @@ export interface MemoryRoutingTurn {
  * exactly one place and the runtime list (used for telemetry roll-ups and
  * source validation) can never drift from the type.
  *
- * `core` / `hot` are the stable-prefix lanes (curated core set, frecency hot
- * set); `needle` / `dense` / `edge` are the per-turn finder lanes.
+ * `core` / `hot` / `fresh` are the stable-prefix lanes (curated core set,
+ * frecency hot set, modification-recency fresh set); `needle` / `dense` /
+ * `edge` are the per-turn finder lanes.
  *
  * The `memory_v3_selections.source` column is free-text, so tightening this set
  * needs no migration: any historical rows with retired labels (e.g. the old
@@ -92,6 +93,7 @@ export interface MemoryRoutingTurn {
 export const SELECTION_SOURCES = [
   "core",
   "hot",
+  "fresh",
   "needle",
   "dense",
   "edge",
@@ -101,9 +103,9 @@ export type SelectionSource = (typeof SELECTION_SOURCES)[number];
 
 /**
  * The per-turn finder lanes — the strict subset of {@link SelectionSource} a
- * finder candidate can be tagged with at pool-build time. (`core` / `hot` are
- * assigned by stable-prefix membership, not by a finder.) Defined via
- * `Exclude` so it can never drift from {@link SELECTION_SOURCES}: adding a
+ * finder candidate can be tagged with at pool-build time. (`core` / `hot` /
+ * `fresh` are assigned by stable-prefix membership, not by a finder.) Defined
+ * via `Exclude` so it can never drift from {@link SELECTION_SOURCES}: adding a
  * finder lane there widens this automatically.
  */
-export type FinderLane = Exclude<SelectionSource, "core" | "hot">;
+export type FinderLane = Exclude<SelectionSource, "core" | "hot" | "fresh">;


### PR DESCRIPTION
## Summary
- New `fresh` stable-prefix lane in the memory-v3 candidate pool: top-K pages by file modification recency (default `memory.v3.freshSet.k` = 50, 0 disables), excluded against core/hot, full-card rendered, recomputed at lane invalidation — same cache posture as the hot lane (no new cache-bust class).
- Rationale: a page consolidated minutes ago has no selection history (frecency can't reach it) and daily-summary-shaped messages give the lexical/dense lanes nothing to match; recency is precisely the missing signal. Eval evidence showed same-day pages were the dominant miss class on briefing-style turns. K is deliberately over-provisioned: the most recent day or two of writes dominate conversational reference in this workload.
- Selections attribute `source: "fresh"` for telemetry; fresh joins the prune valve's stable-prefix exemption; adds an info log when the selector selects nothing over a non-trivial pool (observed on meta-prompt system turns; aids production diagnosis).

## Original prompt
Part of the pre-deploy memory-v3 improvement push: ship the fresh lane with K=50 (maintainer chose over-provisioning since the most recent days are the most-referenced window), including recently modified pages — not just newly created ones — because consolidation is merge-biased and most same-day content lands as edits to existing pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)