### PR TITLE
feat(assistant): add reply-query finder pass to memory-v3

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v3.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v3.test.ts
@@ -12,6 +12,7 @@ describe("MemoryV3ConfigSchema", () => {
       spotlight: { n: 6, windowTurns: 2 },
       needleK: 100,
       denseK: 100,
+      replyQueryK: 12,
       edge: { hubDegree: 30, seedCount: 18, perSeed: 6, cap: 45 },
     });
   });

--- a/assistant/src/config/schemas/memory-v3.ts
+++ b/assistant/src/config/schemas/memory-v3.ts
@@ -182,6 +182,14 @@ export const MemoryV3ConfigSchema = z
       .describe(
         "Number of dense-lane articles folded into the candidate pool each turn.",
       ),
+    replyQueryK: z
+      .number({ error: "memory.v3.replyQueryK must be a number" })
+      .int("memory.v3.replyQueryK must be an integer")
+      .nonnegative("memory.v3.replyQueryK must be a non-negative integer")
+      .default(12)
+      .describe(
+        "Per-lane article budget for the reply-query finder pass: needle and dense each re-run over the assistant's previous message as separate queries (never concatenated with the user's message). 0 disables the pass. Deliberately small next to needleK/denseK — the pass adds the assistant-side retrieval signal, not a second full sweep.",
+      ),
     edge: MemoryV3EdgeSchema.default(MemoryV3EdgeSchema.parse({})),
   })
   .describe("Memory v3 — section-grain lane retrieval");

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
@@ -150,12 +150,14 @@ function depsOf(
 function makeTurn(
   turnNumber: number,
   currentMessage: string,
+  previousAssistantMessage?: string,
 ): MemoryRoutingTurn {
   return {
     conversationId: "conv-xyz",
     turnNumber,
     currentMessage,
     recentContext: "prior context",
+    previousAssistantMessage,
   };
 }
 
@@ -391,6 +393,68 @@ describe("orchestrate — cache-ordered pool (core + hot + finders)", () => {
 
     expect(lastPool).toEqual(["topic-c", "topic-d", "topic-b", "topic-a"]);
     expect(result.lanes.fresh).toEqual(["topic-b"]);
+  });
+
+  test('reply-query hits join the finder tail tagged "reply", after primary lanes and before edge', async () => {
+    const lanes = await buildLanes();
+    denseHits = [];
+    providerStub = selectProvider([]);
+
+    // Primary query matches topic-a; the previous reply matches topic-b. The
+    // edge lane expands topic-a's curated link to topic-d.
+    const result = await orchestrate(
+      makeTurn(1, "apple", "cherry date"),
+      depsOf(lanes, { replyQueryK: 5 }),
+    );
+
+    expect(result.lanes.finder.map((c) => [c.slug, c.lane])).toEqual([
+      ["topic-a", "needle"],
+      ["topic-b", "reply"],
+      ["topic-d", "edge"],
+    ]);
+    // The reply-matched section is recorded for injection/spotlight.
+    expect(result.matchedSections.has("topic-b")).toBe(true);
+  });
+
+  test("a slug both queries surface keeps its primary-lane attribution", async () => {
+    const lanes = await buildLanes();
+    denseHits = [];
+    providerStub = selectProvider([]);
+
+    const result = await orchestrate(
+      makeTurn(1, "apple", "apple banana"),
+      depsOf(lanes, { replyQueryK: 5 }),
+    );
+
+    const topicA = result.lanes.finder.filter((c) => c.slug === "topic-a");
+    expect(topicA).toHaveLength(1);
+    expect(topicA[0]!.lane).toBe("needle");
+  });
+
+  test("no previous assistant message → no reply-lane candidates", async () => {
+    const lanes = await buildLanes();
+    denseHits = [];
+    providerStub = selectProvider([]);
+
+    const result = await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, { replyQueryK: 5 }),
+    );
+
+    expect(result.lanes.finder.some((c) => c.lane === "reply")).toBe(false);
+  });
+
+  test("replyQueryK = 0 disables the pass even with a previous reply", async () => {
+    const lanes = await buildLanes();
+    denseHits = [];
+    providerStub = selectProvider([]);
+
+    const result = await orchestrate(
+      makeTurn(1, "apple", "cherry date"),
+      depsOf(lanes, { replyQueryK: 0 }),
+    );
+
+    expect(result.lanes.finder.some((c) => c.lane === "reply")).toBe(false);
   });
 
   test("the rendered stable prefix is byte-identical across turns with different queries", async () => {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/selection-log-store.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/selection-log-store.test.ts
@@ -206,6 +206,7 @@ describe("summarizeSelections", () => {
       needle: 2,
       dense: 0,
       edge: 2,
+      reply: 0,
     });
     expect(summary.turns).toBe(2);
     // page-1 and page-2 — distinct across the two turns.
@@ -221,6 +222,7 @@ describe("summarizeSelections", () => {
         needle: 0,
         dense: 0,
         edge: 0,
+        reply: 0,
       },
       turns: 0,
       distinctSlugs: 0,

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-integration.test.ts
@@ -481,6 +481,7 @@ describe("memory-v3 shadow integration — selection-log readout", () => {
         needle: 0,
         dense: 0,
         edge: 0,
+        reply: 0,
       },
       turns: 0,
       distinctSlugs: 0,

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
@@ -34,6 +34,7 @@ import type { HotSetEntry, HotSetOptions } from "../hot-set.js";
 import type { OrchestrateResult } from "../orchestrate.js";
 import {
   MEMORY_V3_COMMIT_META_KEY,
+  type MemoryRoutingTurn,
   type SectionIndex,
   type SelectionSource,
 } from "../types.js";
@@ -103,6 +104,7 @@ const orchestrateSpy = mock(
       { slug: "page-1", pinned: true },
       { slug: "page-2", pinned: false },
       { slug: "page-3", pinned: false },
+      { slug: "page-4", pinned: false },
     ],
     matchedSections: new Map([
       ["page-1", { article: "page-1", title: "", text: "x", ordinal: 0 }],
@@ -116,6 +118,7 @@ const orchestrateSpy = mock(
         { slug: "page-1", descriptor: "", lane: "needle" },
         { slug: "page-2", descriptor: "", lane: "dense" },
         { slug: "page-3", descriptor: "", lane: "edge" },
+        { slug: "page-4", descriptor: "", lane: "reply" },
       ],
     },
   }),
@@ -187,6 +190,7 @@ mock.module("../../../../config/loader.js", () => ({
         spotlight: { n: 6, windowTurns: 2 },
         needleK: 100,
         denseK: 100,
+        replyQueryK: 12,
         edge: { hubDegree: 30, seedCount: 18, perSeed: 6, cap: 45 },
       },
       qdrant: { vectorSize: 8, onDisk: false },
@@ -467,12 +471,53 @@ describe("memory-v3 shadow plugin", () => {
       { slug: "page-2", source: "dense", pinned: 0 },
       // page-3 was surfaced by the edge lane → "edge".
       { slug: "page-3", source: "edge", pinned: 0 },
+      // page-4 was first surfaced by the reply-query pass → "reply".
+      { slug: "page-4", source: "reply", pinned: 0 },
       // page-core / page-hot / page-fresh sit in the stable prefix →
       // "core" / "hot" / "fresh".
       { slug: "page-core", source: "core", pinned: 0 },
       { slug: "page-fresh", source: "fresh", pinned: 0 },
       { slug: "page-hot", source: "hot", pinned: 0 },
     ]);
+  });
+
+  test("the turn carries the tail of the previous assistant reply for the reply-query pass", async () => {
+    shadowEnabled = true;
+    messages = [
+      {
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "first question" }]),
+      },
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          { type: "text", text: "the thread continues from my last reply" },
+        ]),
+      },
+      {
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "and now this" }]),
+      },
+    ];
+    await runShadowObservation("conv-1", 1);
+
+    const turn = (
+      orchestrateSpy.mock.calls as unknown as unknown[][]
+    )[0]![0] as MemoryRoutingTurn;
+    expect(turn.currentMessage).toBe("and now this");
+    expect(turn.previousAssistantMessage).toBe(
+      "the thread continues from my last reply",
+    );
+  });
+
+  test("a conversation-opening turn has no previous assistant message", async () => {
+    shadowEnabled = true;
+    await runShadowObservation("conv-1", 0);
+
+    const turn = (
+      orchestrateSpy.mock.calls as unknown as unknown[][]
+    )[0]![0] as MemoryRoutingTurn;
+    expect(turn.previousAssistantMessage).toBeUndefined();
   });
 
   test("a selection of a core page a finder also hit attributes to core (pool position wins)", () => {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
@@ -2,11 +2,16 @@
  * Memory v3 — orchestrator composing the candidate lanes into one turn.
  *
  * Each turn runs:
- *   1. Candidate generation over three deterministic finder lanes:
+ *   1. Candidate generation over the deterministic finder lanes:
  *        - the section-grain BM25 needle (`SectionNeedle.query`, KB articles),
- *        - the dense lane (`denseLane`, KD articles), and
- *        - link-graph edge expansion (`edgeExpand`) over the top needle+dense
- *          article seeds.
+ *        - the dense lane (`denseLane`, KD articles),
+ *        - the reply-query pass — needle + dense re-run over the assistant's
+ *          PREVIOUS message as separate queries at a smaller budget
+ *          (`replyQueryK` per lane), surfacing the threads the assistant is
+ *          actively developing that the user's message references without
+ *          naming — and
+ *        - link-graph edge expansion (`edgeExpand`) over the top
+ *          user-message needle+dense article seeds.
  *      Each lane only ever ADDS candidates, so the pool is recall-safe by
  *      construction.
  *   2. Build the candidate pool in CACHE ORDER: the stable prefix —
@@ -84,6 +89,10 @@ export interface OrchestrateDeps {
   needleK?: number;
   /** Number of dense-lane articles. Defaults to {@link DEFAULT_DENSE_K}. */
   denseK?: number;
+  /** Per-lane article budget for the reply-query pass (needle + dense re-run
+   *  over `turn.previousAssistantMessage` as separate queries). `0` or
+   *  omitted disables the pass (canonical value: `memory.v3.replyQueryK`). */
+  replyQueryK?: number;
   /** Number of top needle+dense seeds expanded. When omitted, the edge lane's
    *  own default applies (canonical value: `memory.v3.edge.seedCount`). */
   edgeSeeds?: number;
@@ -162,10 +171,22 @@ export async function orchestrate(
 
   // Step 1: needle (sync BM25) and dense (async embed + Qdrant) lanes run in
   // parallel. Both return distinct articles each tagged with their best-scoring
-  // section index/ordinal.
-  const [needled, densed] = await Promise.all([
+  // section index/ordinal. The reply-query pass re-runs both lanes over the
+  // assistant's previous message as SEPARATE queries (concatenating the two
+  // speakers would average their retrieval intents into a vector that matches
+  // neither) at its own, smaller budget; it runs in the same parallel batch.
+  const replyK = deps.replyQueryK ?? 0;
+  const replyQuery =
+    replyK > 0 ? (turn.previousAssistantMessage ?? "").trim() : "";
+  const [needled, densed, replyNeedled, replyDensed] = await Promise.all([
     Promise.resolve(deps.needle.query(turn.currentMessage, needleK)),
     denseLane(deps.denseConfig, turn.currentMessage, denseK),
+    Promise.resolve(
+      replyQuery.length > 0 ? deps.needle.query(replyQuery, replyK) : [],
+    ),
+    replyQuery.length > 0
+      ? denseLane(deps.denseConfig, replyQuery, replyK)
+      : Promise.resolve([]),
   ]);
 
   // `matchedSections` records the matched `Section` (when one is known) for
@@ -217,6 +238,24 @@ export async function orchestrate(
       sectionByOrdinal(deps.sectionIndex, hit.article, hit.section),
       undefined,
       "dense",
+    );
+  }
+
+  // Step 1b': reply-query hits — candidates the user-message lanes already
+  // surfaced keep their primary attribution (`addFinder`'s first-lane-wins
+  // dedup); only genuinely reply-surfaced articles tag `"reply"`. Matched
+  // sections are recorded the same way as the primary lanes', so injection
+  // and the spotlight render the reply-matched section.
+  for (const hit of replyNeedled) {
+    addFinder(hit.article, sections[hit.section], undefined, "reply");
+  }
+  for (const hit of replyDensed) {
+    if (!deps.sectionIndex.byArticle.has(hit.article)) continue;
+    addFinder(
+      hit.article,
+      sectionByOrdinal(deps.sectionIndex, hit.article, hit.section),
+      undefined,
+      "reply",
     );
   }
 

--- a/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
@@ -73,6 +73,10 @@ const log = getLogger("memory-v3-shadow");
 /** How many recent messages to fold into the shadow `recentContext` string. */
 const RECENT_CONTEXT_MESSAGES = 6;
 
+/** How many trailing characters of the previous assistant reply feed the
+ *  reply-query finder pass. */
+const REPLY_QUERY_TAIL_CHARS = 2500;
+
 /**
  * The lazily-built, process-lifetime v3 lanes. The core and hot sets are
  * computed here (not per turn) because they are the candidate pool's STABLE
@@ -294,10 +298,12 @@ function buildSituationalContext(): string {
 
 /**
  * Build a v3 {@link MemoryRoutingTurn} from the conversation's persisted messages.
- * `currentMessage` is the latest user message; `recentContext` is the tail of
- * the recent transcript; `situationalContext` carries the current date and the
- * live NOW.md scratchpad. Returns `null` when there is no user message to route
- * on (nothing to shadow this turn).
+ * `currentMessage` is the latest user message; `previousAssistantMessage` is
+ * the tail of the last assistant reply BEFORE that message (the reply-query
+ * pass's input — absent on a conversation's first turn); `recentContext` is
+ * the tail of the recent transcript; `situationalContext` carries the current
+ * date and the live NOW.md scratchpad. Returns `null` when there is no user
+ * message to route on (nothing to shadow this turn).
  */
 function buildShadowTurn(
   conversationId: string,
@@ -307,13 +313,30 @@ function buildShadowTurn(
   if (rows.length === 0) return null;
 
   let currentMessage = "";
+  let currentIndex = -1;
   for (let i = rows.length - 1; i >= 0; i--) {
     if (rows[i]!.role === "user") {
       currentMessage = stringifyMessageContent(rows[i]!.content);
-      if (currentMessage.length > 0) break;
+      if (currentMessage.length > 0) {
+        currentIndex = i;
+        break;
+      }
     }
   }
   if (currentMessage.length === 0) return null;
+
+  // The last assistant reply before the routed user message. Only the tail is
+  // kept: replies run long, and the live threads — what the lanes should
+  // retrieve on — concentrate at the end.
+  let previousAssistantMessage: string | undefined;
+  for (let i = currentIndex - 1; i >= 0; i--) {
+    if (rows[i]!.role !== "assistant") continue;
+    const text = stringifyMessageContent(rows[i]!.content);
+    if (text.length > 0) {
+      previousAssistantMessage = text.slice(-REPLY_QUERY_TAIL_CHARS);
+      break;
+    }
+  }
 
   const recentContext = rows
     .slice(-RECENT_CONTEXT_MESSAGES)
@@ -327,6 +350,7 @@ function buildShadowTurn(
     currentMessage,
     recentContext,
     situationalContext: buildSituationalContext(),
+    previousAssistantMessage,
   };
 }
 
@@ -417,6 +441,7 @@ export async function observeTurn(
       prefixCards: lanes.prefixCards,
       needleK: v3.needleK,
       denseK: v3.denseK,
+      replyQueryK: v3.replyQueryK,
       edgeSeeds: v3.edge.seedCount,
       edgePerSeed: v3.edge.perSeed,
       edgeCap: v3.edge.cap,

--- a/assistant/src/plugins/defaults/memory-v3-shadow/types.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/types.ts
@@ -73,6 +73,17 @@ export interface MemoryRoutingTurn {
    * render nothing for an undefined value.
    */
   situationalContext?: string;
+  /**
+   * Tail of the assistant's previous reply (the message before
+   * `currentMessage`), fed to the reply-query finder pass as its OWN needle +
+   * dense queries — never concatenated onto `currentMessage`, which would
+   * average two speakers' retrieval intents into a vector that matches
+   * neither. The assistant's prose carries the threads it is actively
+   * developing, which the user's next message often references without
+   * naming. Omitted on a conversation's first turn (no prior reply) or when
+   * the reply lane is disabled.
+   */
+  previousAssistantMessage?: string;
 }
 
 /**
@@ -83,7 +94,9 @@ export interface MemoryRoutingTurn {
  *
  * `core` / `hot` / `fresh` are the stable-prefix lanes (curated core set,
  * frecency hot set, modification-recency fresh set); `needle` / `dense` /
- * `edge` are the per-turn finder lanes.
+ * `edge` are the per-turn finder lanes over the user's message; `reply` marks
+ * finder candidates first surfaced by the reply-query pass (needle + dense
+ * re-run over the assistant's previous message).
  *
  * The `memory_v3_selections.source` column is free-text, so tightening this set
  * needs no migration: any historical rows with retired labels (e.g. the old
@@ -97,6 +110,7 @@ export const SELECTION_SOURCES = [
   "needle",
   "dense",
   "edge",
+  "reply",
 ] as const;
 
 export type SelectionSource = (typeof SELECTION_SOURCES)[number];


### PR DESCRIPTION
## Summary
- New reply-query finder pass: needle + dense re-run over the last ~2.5K chars of the assistant's previous message as separate queries at `memory.v3.replyQueryK` = 12 per lane (0 disables), unioned into the finder tail with primary-query precedence; edge expansion remains seeded by the user-message lanes only.
- Rationale: the finder lanes previously fired on the user's message alone — the assistant-side retrieval signal was entirely absent. Pool-level evaluation on real turns showed the pass adds relevant reach on every applicable turn (it cannot fire on conversation openers), and that separate queries beat concatenation (two speakers' intents average into a vector that matches neither).
- Reply-surfaced candidates attribute `source: "reply"` for telemetry, so the lane's post-deploy selection rate is directly measurable; candidates the primary lanes already surfaced keep their primary attribution.

## Original prompt
Second item in the pre-deploy memory-v3 improvement push (after the fresh-set lane): wire the assistant's previous reply into candidate generation as its own small-budget query pass, with distinct source attribution for measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)