### PR TITLE
fix(macos): add camera usage description and entitlements to Swift and Electron apps

### DIFF
--- a/apps/macos/electron-builder.config.cjs
+++ b/apps/macos/electron-builder.config.cjs
@@ -65,6 +65,8 @@ module.exports = {
       CFBundleIconName: "AppIcon",
       NSMicrophoneUsageDescription:
         "Vellum uses the microphone to record voice input for chat.",
+      NSCameraUsageDescription:
+        "Vellum uses the camera to capture photos when you ask your assistant to use the camera.",
       NSSpeechRecognitionUsageDescription:
         "Vellum uses speech recognition to transcribe dictated voice input.",
       NSAppleEventsUsageDescription:

--- a/apps/macos/scripts/entitlements/app.plist
+++ b/apps/macos/scripts/entitlements/app.plist
@@ -14,5 +14,7 @@
     <true/>
     <key>com.apple.security.device.audio-input</key>
     <true/>
+    <key>com.apple.security.device.camera</key>
+    <true/>
 </dict>
 </plist>

--- a/apps/macos/scripts/entitlements/bun.plist
+++ b/apps/macos/scripts/entitlements/bun.plist
@@ -12,5 +12,7 @@
     <true/>
     <key>com.apple.security.network.server</key>
     <true/>
+    <key>com.apple.security.device.camera</key>
+    <true/>
 </dict>
 </plist>

--- a/clients/macos/AGENTS.md
+++ b/clients/macos/AGENTS.md
@@ -395,10 +395,10 @@ When adding a new keyboard shortcut to the macOS app, you **must** also add a co
 
 ### Entitlements and Sandboxing
 - The app is **not sandboxed** — it requires direct access to accessibility APIs, CGEvent injection, and file system paths outside the sandbox container.
-- The main app binary is signed with `app-entitlements.plist` ([`com.apple.security.device.audio-input`](https://developer.apple.com/documentation/BundleResources/Entitlements/com.apple.security.device.audio-input) — required for microphone access under [Hardened Runtime](https://developer.apple.com/documentation/xcode/configuring-the-hardened-runtime)).
-- The embedded daemon binary is signed with `daemon-entitlements.plist` (JIT, unsigned executable memory, network client).
+- The main app binary is signed with `app-entitlements.plist` ([`com.apple.security.device.audio-input`](https://developer.apple.com/documentation/BundleResources/Entitlements/com.apple.security.device.audio-input) and [`com.apple.security.device.camera`](https://developer.apple.com/documentation/BundleResources/Entitlements/com.apple.security.device.camera) — required for microphone/camera access under [Hardened Runtime](https://developer.apple.com/documentation/xcode/configuring-the-hardened-runtime)).
+- The embedded daemon binary is signed with `daemon-entitlements.plist` (JIT, unsigned executable memory, network client, camera — shell commands the assistant runs, e.g. an ffmpeg webcam capture, attribute their TCC camera request to the daemon as the responsible process).
 - All Bun-compiled binaries (`vellum-cli`, `vellum-gateway`, `credential-executor`) must be signed with daemon entitlements — hardened runtime blocks JIT by default, and these are JavaScript executables. See [`allow-jit`](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_cs_allow-jit).
-- If new hardware access is needed (e.g., camera), add the corresponding hardened runtime entitlement to `app-entitlements.plist`.
+- If new hardware access is needed, add the corresponding hardened runtime entitlement to `app-entitlements.plist` (and to `daemon-entitlements.plist` when assistant-run shell commands need the device), plus the matching `NS*UsageDescription` string in **both** the `build.sh` Info.plist heredoc (authoritative for built bundles) and `vellum-assistant/Resources/Info.plist`. Without a usage description, macOS denies the TCC request silently — no consent prompt ever appears.
 - Never add `com.apple.security.app-sandbox` — it would break core functionality.
 
 ### Code Signing

--- a/clients/macos/app-entitlements.plist
+++ b/clients/macos/app-entitlements.plist
@@ -4,6 +4,8 @@
 <dict>
     <key>com.apple.security.device.audio-input</key>
     <true/>
+    <key>com.apple.security.device.camera</key>
+    <true/>
     <key>com.apple.security.virtualization</key>
     <true/>
 </dict>

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -1729,6 +1729,8 @@ cat > "$CONTENTS/Info.plist" <<PLIST
     <string>Vellum needs Screen Recording access to see what's on your screen during computer use tasks.</string>
     <key>NSMicrophoneUsageDescription</key>
     <string>Vellum needs microphone access to transcribe voice commands.</string>
+    <key>NSCameraUsageDescription</key>
+    <string>Vellum needs camera access to capture photos when you ask your assistant to use the camera.</string>
     <key>NSSpeechRecognitionUsageDescription</key>
     <string>Vellum uses speech recognition to convert voice commands into tasks.</string>
     <key>SUFeedURL</key>

--- a/clients/macos/daemon-entitlements.plist
+++ b/clients/macos/daemon-entitlements.plist
@@ -8,5 +8,7 @@
     <true/>
     <key>com.apple.security.network.client</key>
     <true/>
+    <key>com.apple.security.device.camera</key>
+    <true/>
 </dict>
 </plist>

--- a/clients/macos/vellum-assistant/Resources/Info.plist
+++ b/clients/macos/vellum-assistant/Resources/Info.plist
@@ -6,6 +6,8 @@
     <string>Vellum needs Screen Recording access to see what's on your screen during computer use tasks.</string>
     <key>NSMicrophoneUsageDescription</key>
     <string>Vellum needs microphone access to transcribe voice commands.</string>
+    <key>NSCameraUsageDescription</key>
+    <string>Vellum needs camera access to capture photos when you ask your assistant to use the camera.</string>
     <key>NSSpeechRecognitionUsageDescription</key>
     <string>Vellum uses speech recognition to convert voice commands into tasks.</string>
     <key>CFBundleURLTypes</key>


### PR DESCRIPTION
## Summary
- Add `NSCameraUsageDescription` to the Swift app — both the `build.sh` Info.plist heredoc (authoritative for built bundles) and `vellum-assistant/Resources/Info.plist` — and to the Electron app's `extendInfo`, so macOS can show a camera consent prompt instead of silently denying.
- Add `com.apple.security.device.camera` to the hardened-runtime entitlements in both apps: Swift `app-entitlements.plist` + `daemon-entitlements.plist`, Electron `app.plist` + `bun.plist`. The daemon-side binaries are the TCC responsible process for assistant-run shell commands (e.g. `ffmpeg -f avfoundation` webcam capture), so they need the entitlement too.
- Update `clients/macos/AGENTS.md` to document the new entitlements and the dual-Info.plist gotcha (usage strings must land in the heredoc, not just the Resources plist).

## Original prompt
While debugging why an assistant-run `ffmpeg -f avfoundation` webcam capture hung until the tool timeout (the same command worked from a user terminal), we traced it to macOS TCC: the daemon's process tree had no camera grant and could not even request one — the app bundles ship no camera usage description or entitlement, so macOS denies without ever showing a consent dialog. The user asked to add the camera usage description and entitlement to both the Swift app (`clients/macos/`) and the Electron app (`apps/macos/`).