### PR TITLE
Remove device id from pairing refresh flow

### DIFF
--- a/cli/src/__tests__/connect-import.test.ts
+++ b/cli/src/__tests__/connect-import.test.ts
@@ -32,10 +32,15 @@ function bundleFor(overrides: Record<string, unknown> = {}): string {
     gatewayUrl: "http://10.0.0.5:7830",
     assistantId: "self",
     token: "test-token",
-    deviceId: "dev-aaa",
     ...overrides,
   };
   return Buffer.from(JSON.stringify(obj)).toString("base64");
+}
+
+function importedIdsFromLogs(logs: string[]): string[] {
+  return [...logs.join("\n").matchAll(/paired assistant '([^']+)'/g)].map(
+    (m) => m[1],
+  );
 }
 
 describe("connect import", () => {
@@ -59,20 +64,29 @@ describe("connect import", () => {
 
   test("writes a lockfile entry + guardian token from a valid bundle", async () => {
     process.argv = ["bun", "vellum", "connect", "import", bundleFor()];
-    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+    const logs: string[] = [];
+    const logSpy = spyOn(console, "log").mockImplementation(
+      (...a: unknown[]) => {
+        logs.push(a.join(" "));
+      },
+    );
     try {
       await connectImport();
     } finally {
       logSpy.mockRestore();
     }
 
-    const entry = findAssistantByName("paired-dev-aaa");
+    const [localId] = importedIdsFromLogs(logs);
+    expect(localId).toBeDefined();
+    const id = localId!;
+    expect(id).toMatch(/^paired-/);
+    const entry = findAssistantByName(id);
     expect(entry).not.toBeNull();
     expect(entry!.runtimeUrl).toBe("http://10.0.0.5:7830");
     expect(entry!.cloud).toBe("paired");
-    expect(loadGuardianToken("paired-dev-aaa")?.accessToken).toBe("test-token");
+    expect(loadGuardianToken(id)?.accessToken).toBe("test-token");
     // Back-compat: a bundle without refresh fields imports access-only.
-    expect(loadGuardianToken("paired-dev-aaa")?.refreshToken).toBe("");
+    expect(loadGuardianToken(id)?.refreshToken).toBe("");
   });
 
   test("persists the refresh credential when the bundle carries one", async () => {
@@ -82,12 +96,13 @@ describe("connect import", () => {
       "connect",
       "import",
       bundleFor({
-        deviceId: "dev-refresh",
         token: "acc-tok",
         refreshToken: "refresh-tok",
         refreshTokenExpiresAt: "2027-01-01T00:00:00.000Z",
         refreshAfter: "2026-07-01T00:00:00.000Z",
       }),
+      "--name",
+      "refresh-box",
     ];
     const logSpy = spyOn(console, "log").mockImplementation(() => {});
     try {
@@ -96,7 +111,7 @@ describe("connect import", () => {
       logSpy.mockRestore();
     }
 
-    const tok = loadGuardianToken("paired-dev-refresh");
+    const tok = loadGuardianToken("refresh-box");
     expect(tok?.accessToken).toBe("acc-tok");
     expect(tok?.refreshToken).toBe("refresh-tok");
     expect(tok?.refreshTokenExpiresAt).toBe("2027-01-01T00:00:00.000Z");
@@ -113,10 +128,11 @@ describe("connect import", () => {
       "connect",
       "import",
       bundleFor({
-        deviceId: "dev-num",
         refreshToken: "refresh-tok",
         refreshTokenExpiresAt: expiresMs,
       }),
+      "--name",
+      "num-box",
     ];
     const logSpy = spyOn(console, "log").mockImplementation(() => {});
     try {
@@ -125,9 +141,7 @@ describe("connect import", () => {
       logSpy.mockRestore();
     }
 
-    expect(loadGuardianToken("paired-dev-num")?.refreshTokenExpiresAt).toBe(
-      expiresMs,
-    );
+    expect(loadGuardianToken("num-box")?.refreshTokenExpiresAt).toBe(expiresMs);
   });
 
   test("two different bundles (both assistantId 'self') do not collide", async () => {
@@ -136,9 +150,14 @@ describe("connect import", () => {
       "vellum",
       "connect",
       "import",
-      bundleFor({ deviceId: "dev-one", token: "tok1" }),
+      bundleFor({ token: "tok1" }),
     ];
-    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+    const logs: string[] = [];
+    const logSpy = spyOn(console, "log").mockImplementation(
+      (...a: unknown[]) => {
+        logs.push(a.join(" "));
+      },
+    );
     try {
       await connectImport();
       process.argv = [
@@ -146,17 +165,22 @@ describe("connect import", () => {
         "vellum",
         "connect",
         "import",
-        bundleFor({ deviceId: "dev-two", token: "tok2" }),
+        bundleFor({ token: "tok2" }),
       ];
       await connectImport();
     } finally {
       logSpy.mockRestore();
     }
 
-    expect(findAssistantByName("paired-dev-one")).not.toBeNull();
-    expect(findAssistantByName("paired-dev-two")).not.toBeNull();
-    expect(loadGuardianToken("paired-dev-one")?.accessToken).toBe("tok1");
-    expect(loadGuardianToken("paired-dev-two")?.accessToken).toBe("tok2");
+    const ids = importedIdsFromLogs(logs);
+    expect(ids).toHaveLength(2);
+    const firstId = ids[0]!;
+    const secondId = ids[1]!;
+    expect(firstId).not.toBe(secondId);
+    expect(findAssistantByName(firstId)).not.toBeNull();
+    expect(findAssistantByName(secondId)).not.toBeNull();
+    expect(loadGuardianToken(firstId)?.accessToken).toBe("tok1");
+    expect(loadGuardianToken(secondId)?.accessToken).toBe("tok2");
   });
 
   test("--name registers the entry under that name", async () => {
@@ -165,7 +189,7 @@ describe("connect import", () => {
       "vellum",
       "connect",
       "import",
-      bundleFor({ deviceId: "dev-named" }),
+      bundleFor(),
       "--name",
       "Desk Box",
     ];
@@ -179,7 +203,7 @@ describe("connect import", () => {
     expect(findAssistantByName("desk-box")).not.toBeNull();
   });
 
-  test("sanitizes a malicious bundle deviceId (no path traversal in the local id)", async () => {
+  test("ignores a legacy bundle deviceId when choosing the generated local id", async () => {
     process.argv = [
       "bun",
       "vellum",
@@ -199,13 +223,13 @@ describe("connect import", () => {
       logSpy.mockRestore();
     }
 
-    // The registered id must contain no path separators or `..`.
-    const m = logs.join("\n").match(/paired assistant '([^']+)'/);
-    expect(m).not.toBeNull();
-    const id = m![1];
-    expect(id).not.toContain("/");
-    expect(id).not.toContain("..");
-    expect(loadGuardianToken(id)?.accessToken).toBe("tokX");
+    const [id] = importedIdsFromLogs(logs);
+    expect(id).toBeDefined();
+    const localId = id!;
+    expect(localId).toMatch(/^paired-/);
+    expect(localId).not.toContain("/");
+    expect(localId).not.toContain("..");
+    expect(loadGuardianToken(localId)?.accessToken).toBe("tokX");
   });
 
   test("does not overwrite an existing non-paired assistant", async () => {
@@ -221,7 +245,7 @@ describe("connect import", () => {
       "vellum",
       "connect",
       "import",
-      bundleFor({ deviceId: "dx" }),
+      bundleFor(),
       "--name",
       "desk",
     ];
@@ -245,7 +269,7 @@ describe("connect import", () => {
     expect(e!.paired).toBeUndefined();
   });
 
-  test("re-importing the same pairing updates in place", async () => {
+  test("re-importing with the same --name updates in place", async () => {
     const logSpy = spyOn(console, "log").mockImplementation(() => {});
     try {
       process.argv = [
@@ -253,7 +277,9 @@ describe("connect import", () => {
         "vellum",
         "connect",
         "import",
-        bundleFor({ deviceId: "dev-re", token: "t1" }),
+        bundleFor({ token: "t1" }),
+        "--name",
+        "remote-desk",
       ];
       await connectImport();
       process.argv = [
@@ -261,13 +287,15 @@ describe("connect import", () => {
         "vellum",
         "connect",
         "import",
-        bundleFor({ deviceId: "dev-re", token: "t2" }),
+        bundleFor({ token: "t2" }),
+        "--name",
+        "remote-desk",
       ];
       await connectImport();
     } finally {
       logSpy.mockRestore();
     }
-    expect(loadGuardianToken("paired-dev-re")?.accessToken).toBe("t2");
+    expect(loadGuardianToken("remote-desk")?.accessToken).toBe("t2");
   });
 
   test("rejects a bundle whose gatewayUrl is not http(s)", async () => {
@@ -276,7 +304,9 @@ describe("connect import", () => {
       "vellum",
       "connect",
       "import",
-      bundleFor({ gatewayUrl: "ftp://nope", deviceId: "dz" }),
+      bundleFor({ gatewayUrl: "ftp://nope" }),
+      "--name",
+      "bad-url",
     ];
     const errSpy = spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = spyOn(process, "exit").mockImplementation(((c?: number) => {
@@ -292,7 +322,7 @@ describe("connect import", () => {
       exitSpy.mockRestore();
     }
     expect(exited).toBe(true);
-    expect(findAssistantByName("paired-dz")).toBeNull();
+    expect(findAssistantByName("bad-url")).toBeNull();
   });
 
   test("a malformed bundle exits 1 and registers nothing", async () => {
@@ -311,7 +341,7 @@ describe("connect import", () => {
       exitSpy.mockRestore();
     }
     expect(exited).toBe(true);
-    // A malformed bundle has no deviceId, so no `paired-*` entry is created.
+    // A malformed bundle has no generated id, so no `paired-*` entry is created.
     expect(findAssistantByName("paired-")).toBeNull();
   });
 });

--- a/cli/src/__tests__/guardian-token.test.ts
+++ b/cli/src/__tests__/guardian-token.test.ts
@@ -284,8 +284,13 @@ describe("refreshGuardianToken", () => {
   test("refreshes, persists the rotated token, sends an abort signal, releases the lock", async () => {
     seed(future());
     let sawSignal = false;
+    let refreshBody: Record<string, unknown> | undefined;
     globalThis.fetch = (async (_url: unknown, init?: RequestInit) => {
       sawSignal = init?.signal instanceof AbortSignal;
+      refreshBody =
+        typeof init?.body === "string"
+          ? (JSON.parse(init.body) as Record<string, unknown>)
+          : undefined;
       return new Response(
         JSON.stringify({
           accessToken: "new-acc",
@@ -303,6 +308,7 @@ describe("refreshGuardianToken", () => {
     expect(result?.accessToken).toBe("new-acc");
     expect(loadGuardianToken("px")?.accessToken).toBe("new-acc");
     expect(sawSignal).toBe(true); // fetch carries a timeout AbortSignal
+    expect(refreshBody).toEqual({ refreshToken: "old-ref" });
     expect(existsSync(lockPath("px"))).toBe(false); // lock released
   });
 

--- a/cli/src/__tests__/pair.test.ts
+++ b/cli/src/__tests__/pair.test.ts
@@ -57,7 +57,7 @@ describe("pair command", () => {
     delete process.env.VELLUM_LOCKFILE_DIR;
   });
 
-  test("POSTs a cli device-bound pair request and prints a decodable bundle", async () => {
+  test("POSTs a cli pair request without deviceId and prints a decodable bundle", async () => {
     const calls: Array<[string, RequestInit]> = [];
     const origFetch = globalThis.fetch;
     globalThis.fetch = (async (url: string, init: RequestInit) => {
@@ -101,8 +101,7 @@ describe("pair command", () => {
     );
     expect(headers["x-vellum-interface-id"]).toBe("cli");
     const body = JSON.parse(init.body as string);
-    expect(typeof body.deviceId).toBe("string");
-    expect(body.deviceId.length).toBeGreaterThan(0);
+    expect(body.deviceId).toBeUndefined();
     expect(body.platform).toBe("cli");
 
     // The bundle advertises the REACHABLE runtime URL, not loopback.
@@ -110,7 +109,7 @@ describe("pair command", () => {
     expect(out.gatewayUrl).toBe(RUNTIME_URL);
     expect(out.assistantId).toBe("self");
     expect(out.token).toBe("test-access-token");
-    expect(out.deviceId).toBe(body.deviceId);
+    expect(out.deviceId).toBeUndefined();
   });
 
   test("resolves an unquoted multi-word display name", async () => {

--- a/cli/src/__tests__/tui-midsession-refresh.test.ts
+++ b/cli/src/__tests__/tui-midsession-refresh.test.ts
@@ -115,7 +115,7 @@ describe("maybeRefreshAuthHeaders", () => {
   test("does NOT refresh against an overridden/poisoned baseUrl (no credential leak)", async () => {
     // The CLI lets --url override the runtime URL while still using the stored
     // paired guardian token. A 401 from that attacker origin must NOT cause us
-    // to POST the refreshToken + deviceId there.
+    // to POST the refreshToken there.
     seedEntry("paired"); // persisted runtimeUrl = RUNTIME
     seedToken("old-acc", "ref");
     const refresh = stubRefresh(true);

--- a/cli/src/commands/connect/import.ts
+++ b/cli/src/commands/connect/import.ts
@@ -5,12 +5,13 @@
  * register it locally so `vellum client`/`message`/`events <name>` work against
  * the remote assistant.
  *
- * The bundle is base64(JSON.stringify({ gatewayUrl, assistantId, token,
- * deviceId })). We store the entry under a UNIQUE LOCAL id (not the bundle's
- * assistantId, which is typically "self" and would collide across hosts). This
- * is safe because the gateway's runtime proxy strips the `/v1/assistants/<id>/`
- * segment before forwarding, so the local id never has to match the remote one
- * — the token (validated by signature/audience) is what authorizes requests.
+ * The bundle is base64(JSON.stringify({ gatewayUrl, assistantId, token, ... })).
+ * We store the entry under a UNIQUE LOCAL id (not the bundle's assistantId,
+ * which is typically "self" and would collide across hosts). This is safe
+ * because the gateway's runtime proxy strips the `/v1/assistants/<id>/`
+ * segment before forwarding, so the local id never has to match the remote
+ * one — the token (validated by signature/audience) is what authorizes
+ * requests.
  */
 
 import { nanoid } from "nanoid";
@@ -33,7 +34,7 @@ ARGUMENTS:
 
 OPTIONS:
     --name <name>   Local name to register the assistant under
-                    (default: paired-<deviceId>)
+                    (default: paired-<generated-id>)
 
 EXAMPLES:
     vellum connect import eyJnYXRld2F5...
@@ -45,9 +46,8 @@ interface PairBundle {
   gatewayUrl: string;
   token: string;
   assistantId?: string;
-  deviceId?: string;
   // Optional refresh credential. Present when the host's gateway issued a
-  // device-bound token pair; absent for older access-only bundles (which remain
+  // refreshable token pair; absent for older access-only bundles (which remain
   // importable, just without auto-renewal). `refreshTokenExpiresAt` mirrors
   // GuardianTokenData (ISO string OR epoch-ms number) so a numeric expiry isn't
   // silently dropped on import.
@@ -84,7 +84,6 @@ function decodeBundle(blob: string): PairBundle | null {
     gatewayUrl: b.gatewayUrl,
     token: b.token,
     assistantId: typeof b.assistantId === "string" ? b.assistantId : undefined,
-    deviceId: typeof b.deviceId === "string" ? b.deviceId : undefined,
     refreshToken:
       typeof b.refreshToken === "string" ? b.refreshToken : undefined,
     refreshTokenExpiresAt:
@@ -144,14 +143,9 @@ export async function connectImport(): Promise<void> {
     process.exit(1);
   }
 
-  // Unique local id: a --name slug, or paired-<deviceId> (deviceId is unique
-  // per pairing). Never the bundle's "self" assistantId — that would collide.
-  // The deviceId comes from an untrusted bundle and is used as a path component
-  // by saveGuardianToken, so it MUST be slugified (no `../` traversal); fall
-  // back to a random id if it sanitizes to empty.
-  const localId = nameFlag
-    ? slugify(nameFlag)
-    : `paired-${slugify(bundle.deviceId ?? "") || nanoid()}`;
+  // Unique local id: a --name slug, or a generated paired-* id. Never the
+  // bundle's "self" assistantId — that would collide across remote hosts.
+  const localId = nameFlag ? slugify(nameFlag) : `paired-${nanoid()}`;
   if (!localId) {
     console.error(
       "Error: --name must contain at least one alphanumeric character.",
@@ -199,7 +193,6 @@ export async function connectImport(): Promise<void> {
     refreshTokenExpiresAt: bundle.refreshTokenExpiresAt ?? 0,
     refreshAfter: bundle.refreshAfter ?? "",
     isNew: false,
-    deviceId: bundle.deviceId ?? "",
     leasedAt: new Date(now).toISOString(),
   });
 

--- a/cli/src/commands/pair.ts
+++ b/cli/src/commands/pair.ts
@@ -1,16 +1,12 @@
 /**
  * `vellum pair [assistant] [--label <name>]`
  *
- * Mint a device-scoped token for another machine and print a pairing bundle.
+ * Mint a refreshable token for another machine and print a pairing bundle.
  * Runs on the machine hosting the assistant: it calls the local gateway's
- * loopback-only `POST /v1/pair` (cli interface) with a freshly generated
- * deviceId, then prints the credentials to hand to a second device.
- *
- * Each invocation generates a NEW random deviceId, so each pairing is an
- * independent, separately-revocable device (see `vellum unpair`, forthcoming).
+ * loopback-only `POST /v1/pair` (cli interface), then prints the credentials
+ * to hand to a second device. The gateway creates the revocation binding
+ * internally; the bundle only carries the token material needed by the client.
  */
-
-import { nanoid } from "nanoid";
 
 import { extractFlag } from "../lib/arg-utils.js";
 import { parseAssistantTargetArg } from "../lib/assistant-target-args.js";
@@ -38,7 +34,7 @@ function isLoopbackHost(url: string): boolean {
 }
 
 function printUsage(): void {
-  console.log(`vellum pair [beta] - Mint a device-scoped token for another machine
+  console.log(`vellum pair [beta] - Mint a refreshable token for another machine
 
 USAGE:
     vellum pair [assistant] [options]
@@ -65,7 +61,7 @@ interface PairResponse {
   expiresAt: string;
   guardianId: string;
   assistantId: string;
-  // Present on the device-bound path: a long-lived refresh credential the
+  // Present on refreshable responses: a long-lived refresh credential the
   // imported client uses to renew its access token (ISO-8601 strings).
   refreshToken?: string;
   refreshTokenExpiresAt?: string;
@@ -149,10 +145,6 @@ export async function pair(): Promise<void> {
     process.exit(1);
   }
 
-  // Fresh per-pairing device identity — each `vellum pair` is independently
-  // revocable.
-  const deviceId = nanoid();
-
   let response: Response;
   try {
     response = await loopbackSafeFetch(`${mintUrl}/v1/pair`, {
@@ -161,7 +153,7 @@ export async function pair(): Promise<void> {
         "Content-Type": "application/json",
         ...getClientRegistrationHeaders(CLI_INTERFACE_ID),
       },
-      body: JSON.stringify({ deviceId, platform: "cli" }),
+      body: JSON.stringify({ platform: "cli" }),
     });
   } catch (err) {
     console.error(
@@ -188,7 +180,6 @@ export async function pair(): Promise<void> {
     gatewayUrl: advertisedUrl,
     assistantId: result.assistantId,
     token: result.token,
-    deviceId,
     // Carry the refresh credential through when the gateway issued one, so the
     // imported client can renew without re-pairing. Omitted entirely for an
     // access-only (older gateway) response so the bundle stays clean.

--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -203,7 +203,7 @@ function friendlyErrorMessage(status: number, body: string): string {
  * `vellum client` lets `--url`/`-u` override the runtime URL while still using
  * the selected paired entry's stored guardian token, so a victim pointed at an
  * attacker-controlled (or poisoned/redirected) URL that returns 401 must NOT
- * cause us to POST the long-lived refreshToken + deviceId to that origin. We
+ * cause us to POST the long-lived refresh token to that origin. We
  * therefore (a) refuse to refresh unless `baseUrl` normalizes to one of the
  * entry's persisted URLs, and (b) send the refresh to the persisted URL rather
  * than the caller-supplied `baseUrl` — defense in depth if the gate is ever

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -101,7 +101,7 @@ function printHelp(): void {
   console.log("  logout   Log out of the Vellum platform");
   console.log("  message  Send a message to a running assistant");
   console.log(
-    "  pair     Mint a device-scoped token to connect another machine [beta]",
+    "  pair     Mint a refreshable token to connect another machine [beta]",
   );
   console.log(
     "  ps       List assistants (or processes for a specific assistant)",

--- a/cli/src/lib/guardian-token.ts
+++ b/cli/src/lib/guardian-token.ts
@@ -17,10 +17,7 @@ import { platform } from "os";
 import { dirname, join } from "path";
 
 import { SEEDS } from "@vellumai/environments";
-import {
-  guardianTokenPath,
-  resolveConfigDir,
-} from "@vellumai/local-mode";
+import { guardianTokenPath, resolveConfigDir } from "@vellumai/local-mode";
 
 import { getConfigDir } from "./environments/paths.js";
 import { getCurrentEnvironment } from "./environments/resolve.js";
@@ -38,7 +35,7 @@ export interface GuardianTokenData {
   refreshTokenExpiresAt: string | number;
   refreshAfter: string;
   isNew: boolean;
-  deviceId: string;
+  deviceId?: string;
   leasedAt: string;
 }
 
@@ -347,21 +344,20 @@ export async function refreshGuardianToken(
 
     const tokenData = current ?? before;
 
-    const response = await loopbackSafeFetch(`${gatewayUrl}/v1/guardian/refresh`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${tokenData.accessToken}`,
+    const response = await loopbackSafeFetch(
+      `${gatewayUrl}/v1/guardian/refresh`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${tokenData.accessToken}`,
+        },
+        body: JSON.stringify({
+          refreshToken: tokenData.refreshToken,
+        }),
+        signal: AbortSignal.timeout(REFRESH_FETCH_TIMEOUT_MS),
       },
-      body: JSON.stringify({
-        refreshToken: tokenData.refreshToken,
-        // The refresh token is device-bound; send the device id used at init
-        // (falling back to a fresh computation for tokens persisted before the
-        // field was stored) so the gateway can verify the binding.
-        deviceId: tokenData.deviceId || computeDeviceId(),
-      }),
-      signal: AbortSignal.timeout(REFRESH_FETCH_TIMEOUT_MS),
-    });
+    );
     if (!response.ok) return null;
 
     const json = (await response.json()) as Record<string, unknown>;
@@ -378,7 +374,7 @@ export async function refreshGuardianToken(
         tokenData.refreshTokenExpiresAt,
       refreshAfter: (json.refreshAfter as string) ?? tokenData.refreshAfter,
       isNew: false,
-      deviceId: tokenData.deviceId,
+      ...(tokenData.deviceId ? { deviceId: tokenData.deviceId } : {}),
       leasedAt: new Date().toISOString(),
     };
     saveGuardianToken(assistantId, refreshed);

--- a/cli/src/lib/runtime-url.ts
+++ b/cli/src/lib/runtime-url.ts
@@ -111,7 +111,7 @@ export function normalizeRuntimeUrl(url: string): string {
  * `vellum client` lets `--url`/`-u` override the runtime URL while still reusing
  * the selected entry's stored guardian token, so a victim pointed at an
  * attacker-controlled (or poisoned/redirected) URL must NOT cause us to POST the
- * long-lived refreshToken + deviceId there. Refresh is permitted only when
+ * long-lived refresh token there. Refresh is permitted only when
  * `candidateUrl` normalizes to one of the entry's persisted URLs (`localUrl`,
  * which the CLI prefers when present, or `runtimeUrl`).
  *

--- a/clients/shared/App/Auth/ActorCredentialRefresher.swift
+++ b/clients/shared/App/Auth/ActorCredentialRefresher.swift
@@ -77,7 +77,7 @@ public class ActorCredentialRefresher {
             // "refresh_unauthorized" from the 401 status check below.
             if let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
                let error = json["error"] as? String {
-                let terminalErrors = ["refresh_reuse_detected", "revoked", "device_binding_mismatch", "refresh_invalid", "refresh_expired"]
+                let terminalErrors = ["refresh_reuse_detected", "revoked", "principal_mismatch", "device_binding_mismatch", "refresh_invalid", "refresh_expired"]
                 if terminalErrors.contains(error) {
                     return .terminalError(reason: error)
                 }

--- a/clients/shared/App/Auth/GuardianTokenFileReader.swift
+++ b/clients/shared/App/Auth/GuardianTokenFileReader.swift
@@ -27,7 +27,7 @@ public enum GuardianTokenFileReader {
         let refreshTokenExpiresAt: StringOrNumber
         let refreshAfter: StringOrNumber
         let isNew: Bool
-        let deviceId: String
+        let deviceId: String?
         let leasedAt: String
     }
 

--- a/gateway/src/__tests__/pair-device-bound.test.ts
+++ b/gateway/src/__tests__/pair-device-bound.test.ts
@@ -1,7 +1,6 @@
 /**
- * Tests for device-scoped /v1/pair minting: when a request supplies a deviceId,
- * pair mints a DB-recorded, revocable, refreshable token pair (instead of the
- * legacy stateless token).
+ * Tests for refreshable /v1/pair minting: pair can mint a DB-recorded,
+ * revocable, refreshable token pair instead of the legacy stateless token.
  */
 import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
@@ -15,7 +14,7 @@ import { initSigningKey } from "../auth/token-service.js";
 initSigningKey(Buffer.from("test-signing-key-at-least-32-bytes-long-xx"));
 
 // pair.ts → resolveLocalGuardianPrincipalId() queries the assistant DB; mock it
-// to return a stable principal. The device-bound token records live in the
+// to return a stable principal. The credential-bound token records live in the
 // (real) gateway DB initialized below.
 const mockQuery = mock();
 mock.module("../db/assistant-db-proxy.js", () => ({
@@ -80,8 +79,8 @@ afterEach(() => {
   }
 });
 
-describe("/v1/pair device-bound minting", () => {
-  test("records a device-bound access token AND a refresh token", async () => {
+describe("/v1/pair refreshable minting", () => {
+  test("records an access token AND a refresh token when a deviceId is supplied", async () => {
     const res = await handlePair(
       makePairRequest({ deviceId: "device-A", platform: "web" }),
       LOOPBACK_IP,
@@ -90,7 +89,7 @@ describe("/v1/pair device-bound minting", () => {
     const body = (await res.json()) as Record<string, unknown>;
 
     expect(typeof body.token).toBe("string");
-    // A device-scoped refresh token is now issued so the client can renew
+    // A refresh token is now issued so the client can renew
     // without re-pairing (safe now that hot-path revocation is enforced).
     expect(typeof body.refreshToken).toBe("string");
     expect((body.refreshToken as string).length).toBeGreaterThan(0);
@@ -124,7 +123,7 @@ describe("/v1/pair device-bound minting", () => {
 
     const rotated = rotateCredentials({
       refreshToken: body.refreshToken,
-      hashedDeviceId: hashToken("device-A"),
+      authorizedGuardianPrincipalId: GUARDIAN_ID,
     });
     expect(rotated.ok).toBe(true);
     if (rotated.ok) {
@@ -142,7 +141,7 @@ describe("/v1/pair device-bound minting", () => {
 
     const DAY_MS = 24 * 60 * 60 * 1000;
     const [token] = activeTokens();
-    // The device-bound access token uses the standard ~30-day TTL (NOT a short
+    // The refreshable access token uses the standard ~30-day TTL (NOT a short
     // pair-specific TTL): a refresh token + hot-path revocation bound a leaked
     // token's reach, and the TTL stays consistent with what /v1/guardian/refresh
     // mints on rotation (rather than 24h at mint then 30d after the first
@@ -198,9 +197,9 @@ describe("/v1/pair cli interface", () => {
     });
   }
 
-  test("mints a device-bound token pair (no Origin header required)", async () => {
+  test("mints a credential-bound token pair without a client deviceId", async () => {
     const res = await handlePair(
-      makeCliRequest({ deviceId: "device-cli" }),
+      makeCliRequest({ platform: "cli" }),
       LOOPBACK_IP,
     );
     expect(res.status).toBe(200);
@@ -213,19 +212,20 @@ describe("/v1/pair cli interface", () => {
 
     const tokens = activeTokens();
     expect(tokens).toHaveLength(1);
-    expect(tokens[0].hashedDeviceId).toBe(hashToken("device-cli"));
+    expect(tokens[0].hashedDeviceId).toMatch(/^[0-9a-f]{64}$/);
+    expect(tokens[0].hashedDeviceId).not.toBe(hashToken("device-cli"));
     expect(tokens[0].platform).toBe("cli");
   });
 
-  test("rejects a cli pair request without a deviceId (400)", async () => {
+  test("accepts a cli pair request without a body", async () => {
     const res = await handlePair(makeCliRequest(), LOOPBACK_IP);
-    expect(res.status).toBe(400);
-    expect(activeTokens()).toHaveLength(0);
+    expect(res.status).toBe(200);
+    expect(activeTokens()).toHaveLength(1);
   });
 
   test("still rejects non-loopback cli callers", async () => {
     const res = await handlePair(
-      makeCliRequest({ deviceId: "device-cli" }),
+      makeCliRequest({ platform: "cli" }),
       "8.8.8.8",
     );
     expect(res.status).toBe(403);
@@ -246,7 +246,7 @@ describe("/v1/pair cli interface", () => {
         "x-vellum-interface-id": "cli",
         origin: "https://app.vellum.local",
       },
-      body: JSON.stringify({ deviceId: "device-cli", platform: "webview" }),
+      body: JSON.stringify({ platform: "webview" }),
     });
     const res = await handlePair(req, LOOPBACK_IP);
     expect(res.status).toBe(403);

--- a/gateway/src/__tests__/pair-device-bound.test.ts
+++ b/gateway/src/__tests__/pair-device-bound.test.ts
@@ -14,7 +14,7 @@ import { initSigningKey } from "../auth/token-service.js";
 initSigningKey(Buffer.from("test-signing-key-at-least-32-bytes-long-xx"));
 
 // pair.ts → resolveLocalGuardianPrincipalId() queries the assistant DB; mock it
-// to return a stable principal. The credential-bound token records live in the
+// to return a stable principal. The device-bound token records live in the
 // (real) gateway DB initialized below.
 const mockQuery = mock();
 mock.module("../db/assistant-db-proxy.js", () => ({
@@ -197,7 +197,7 @@ describe("/v1/pair cli interface", () => {
     });
   }
 
-  test("mints a credential-bound token pair without a client deviceId", async () => {
+  test("mints a device-bound token pair without a client deviceId", async () => {
     const res = await handlePair(
       makeCliRequest({ platform: "cli" }),
       LOOPBACK_IP,

--- a/gateway/src/__tests__/refresh-device-binding.test.ts
+++ b/gateway/src/__tests__/refresh-device-binding.test.ts
@@ -1,6 +1,6 @@
 /**
  * Tests for guardian credential rotation: a refresh token record owns the
- * stored credential binding used for revocation/minting, while the bearer
+ * stored device binding used for revocation/minting, while the bearer
  * actor principal must match before rotation side effects are allowed.
  */
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";

--- a/gateway/src/__tests__/refresh-device-binding.test.ts
+++ b/gateway/src/__tests__/refresh-device-binding.test.ts
@@ -1,8 +1,7 @@
 /**
- * Tests for device binding on guardian credential rotation: a refresh token
- * is bound to the device it was issued to, so a leaked refresh token cannot be
- * redeemed from a different device. The binding is verified before any side
- * effects so a wrong-device request cannot disturb the legitimate token family.
+ * Tests for guardian credential rotation: a refresh token record owns the
+ * stored credential binding used for revocation/minting, while the bearer
+ * actor principal must match before rotation side effects are allowed.
  */
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
@@ -21,7 +20,7 @@ const { rotateCredentials } = await import("../auth/guardian-refresh.js");
 
 const PRINCIPAL = "guardian-001";
 const DEVICE_A = "device-A";
-const DEVICE_B = "device-B";
+const OTHER_PRINCIPAL = "guardian-002";
 const FAMILY = "family-001";
 
 let testRoot: string;
@@ -75,53 +74,53 @@ afterEach(() => {
   }
 });
 
-describe("rotateCredentials device binding", () => {
-  test("rotates when the device id matches the record's binding", () => {
+describe("rotateCredentials principal authorization", () => {
+  test("rotates when the bearer principal matches the record", () => {
     insertRefreshRecord("rt-match", DEVICE_A);
     const result = rotateCredentials({
       refreshToken: "rt-match",
-      hashedDeviceId: hashToken(DEVICE_A),
+      authorizedGuardianPrincipalId: PRINCIPAL,
     });
     expect(result.ok).toBe(true);
     // Old token is consumed (rotated), proving the happy path ran end-to-end.
     expect(recordStatus("rt-match")).toBe("rotated");
   });
 
-  test("rejects with device_binding_mismatch from a different device", () => {
+  test("rejects with principal_mismatch from a different bearer principal", () => {
     insertRefreshRecord("rt-leaked", DEVICE_A);
     const result = rotateCredentials({
       refreshToken: "rt-leaked",
-      hashedDeviceId: hashToken(DEVICE_B),
+      authorizedGuardianPrincipalId: OTHER_PRINCIPAL,
     });
-    expect(result).toEqual({ ok: false, error: "device_binding_mismatch" });
+    expect(result).toEqual({ ok: false, error: "principal_mismatch" });
   });
 
-  test("a wrong-device request has no side effects on the token family", () => {
+  test("a wrong-principal request has no side effects on the token family", () => {
     insertRefreshRecord("rt-leaked", DEVICE_A);
     rotateCredentials({
       refreshToken: "rt-leaked",
-      hashedDeviceId: hashToken(DEVICE_B),
+      authorizedGuardianPrincipalId: OTHER_PRINCIPAL,
     });
     // The legitimate token must remain active and usable.
     expect(recordStatus("rt-leaked")).toBe("active");
     const legit = rotateCredentials({
       refreshToken: "rt-leaked",
-      hashedDeviceId: hashToken(DEVICE_A),
+      authorizedGuardianPrincipalId: PRINCIPAL,
     });
     expect(legit.ok).toBe(true);
   });
 
-  test("device binding is checked before reuse detection (no family revocation from wrong device)", () => {
-    // A previously-rotated token presented from the wrong device must not
+  test("principal binding is checked before reuse detection (no family revocation from wrong principal)", () => {
+    // A previously-rotated token presented by the wrong principal must not
     // trigger the reuse-detection family revocation — that would let an
     // attacker with a leaked, already-spent token DoS the real user.
     insertRefreshRecord("rt-active", DEVICE_A, "active");
     insertRefreshRecord("rt-spent", DEVICE_A, "rotated");
     const result = rotateCredentials({
       refreshToken: "rt-spent",
-      hashedDeviceId: hashToken(DEVICE_B),
+      authorizedGuardianPrincipalId: OTHER_PRINCIPAL,
     });
-    expect(result).toEqual({ ok: false, error: "device_binding_mismatch" });
+    expect(result).toEqual({ ok: false, error: "principal_mismatch" });
     // The still-active sibling token in the same family is untouched.
     expect(recordStatus("rt-active")).toBe("active");
   });
@@ -129,7 +128,7 @@ describe("rotateCredentials device binding", () => {
   test("still returns refresh_invalid for an unknown token regardless of device", () => {
     const result = rotateCredentials({
       refreshToken: "rt-unknown",
-      hashedDeviceId: hashToken(DEVICE_A),
+      authorizedGuardianPrincipalId: PRINCIPAL,
     });
     expect(result).toEqual({ ok: false, error: "refresh_invalid" });
   });

--- a/gateway/src/auth/guardian-refresh.ts
+++ b/gateway/src/auth/guardian-refresh.ts
@@ -32,7 +32,7 @@ export type RefreshErrorCode =
   | "refresh_invalid"
   | "refresh_expired"
   | "refresh_reuse_detected"
-  | "device_binding_mismatch"
+  | "principal_mismatch"
   | "revoked";
 
 export interface RotateResult {
@@ -215,16 +215,15 @@ function mintRefreshTokenInFamily(params: {
  *
  * All token operations run against the gateway's SQLite database.
  *
- * The refresh token is bound to the device it was issued to: the caller must
- * supply the hashed device id, and it must match the record's stored binding.
- * This ensures a leaked refresh token cannot be redeemed from a different
- * device. The binding is checked before any side effects (rotation, family
- * revocation) so a request from a non-matching device cannot disturb the
- * legitimate token family.
+ * The refresh token record owns its credential binding. Callers no longer
+ * supply a raw device id during refresh; after auth principal validation, the
+ * stored binding is reused to revoke the old access token and mint the next
+ * credential pair. Principal validation happens before side effects so a
+ * mismatched bearer token cannot disturb the legitimate token family.
  */
 export function rotateCredentials(params: {
   refreshToken: string;
-  hashedDeviceId: string;
+  authorizedGuardianPrincipalId: string;
 }):
   | { ok: true; result: RotateResult }
   | { ok: false; error: RefreshErrorCode } {
@@ -236,12 +235,12 @@ export function rotateCredentials(params: {
     return { ok: false, error: "refresh_invalid" };
   }
 
-  if (record.hashedDeviceId !== params.hashedDeviceId) {
+  if (record.guardianPrincipalId !== params.authorizedGuardianPrincipalId) {
     log.warn(
       { familyId: record.familyId },
-      "Refresh rejected — device binding mismatch",
+      "Refresh rejected — bearer principal mismatch",
     );
-    return { ok: false, error: "device_binding_mismatch" };
+    return { ok: false, error: "principal_mismatch" };
   }
 
   if (record.status === "rotated") {

--- a/gateway/src/http/routes/channel-verification-session-proxy.ts
+++ b/gateway/src/http/routes/channel-verification-session-proxy.ts
@@ -10,7 +10,7 @@ import { join } from "node:path";
 
 import { proxyForwardToResponse } from "@vellumai/assistant-client";
 
-import { bootstrapGuardian, hashToken } from "../../auth/guardian-bootstrap.js";
+import { bootstrapGuardian } from "../../auth/guardian-bootstrap.js";
 import { rotateCredentials } from "../../auth/guardian-refresh.js";
 import { mintServiceToken } from "../../auth/token-exchange.js";
 import type { GatewayConfig } from "../../config.js";
@@ -420,12 +420,14 @@ export function createChannelVerificationSessionProxyHandler(
       }
     },
 
-    async handleGuardianRefresh(req: Request): Promise<Response> {
+    async handleGuardianRefresh(
+      req: Request,
+      auth: { guardianPrincipalId: string },
+    ): Promise<Response> {
       try {
         const body = (await req.json()) as Record<string, unknown>;
         const refreshToken =
           typeof body.refreshToken === "string" ? body.refreshToken : "";
-        const deviceId = typeof body.deviceId === "string" ? body.deviceId : "";
 
         if (!refreshToken) {
           return Response.json(
@@ -439,32 +441,17 @@ export function createChannelVerificationSessionProxyHandler(
           );
         }
 
-        // The refresh token is bound to the device it was issued to. Require
-        // the caller to prove the device so a leaked refresh token cannot be
-        // redeemed from a different device.
-        if (!deviceId) {
-          return Response.json(
-            {
-              error: {
-                code: "BAD_REQUEST",
-                message: "Missing required field: deviceId",
-              },
-            },
-            { status: 400 },
-          );
-        }
-
         const result = rotateCredentials({
           refreshToken,
-          hashedDeviceId: hashToken(deviceId),
+          authorizedGuardianPrincipalId: auth.guardianPrincipalId,
         });
 
         if (!result.ok) {
           // 403 for tokens that are valid-but-forbidden (revoked, reused, or
-          // presented from the wrong device); 401 for invalid/expired tokens.
+          // presented by the wrong principal); 401 for invalid/expired tokens.
           const forbidden: Array<typeof result.error> = [
             "refresh_reuse_detected",
-            "device_binding_mismatch",
+            "principal_mismatch",
             "revoked",
           ];
           const statusCode = forbidden.includes(result.error) ? 403 : 401;
@@ -523,7 +510,7 @@ export function createChannelVerificationSessionProxyHandler(
       }
 
       // Refuse while an init request is awaiting an upstream response —
-      // bootstrapGuardian revokes existing device-bound tokens before
+      // bootstrapGuardian revokes existing binding-scoped tokens before
       // minting, so allowing a concurrent init would invalidate whatever
       // the in-flight one returns.
       if (guardianInitPending) {

--- a/gateway/src/http/routes/pair.ts
+++ b/gateway/src/http/routes/pair.ts
@@ -21,10 +21,10 @@
  * as a gateway edge token — send it as `Authorization: Bearer <token>` on
  * subsequent runtime requests.
  *
- * Response body: `{ token, expiresAt, guardianId, assistantId }`. The
- * device-bound path (a `deviceId` is supplied) additionally returns
- * `{ refreshToken, refreshTokenExpiresAt, refreshAfter }` so the client can
- * renew via `/v1/guardian/refresh` instead of re-pairing.
+ * Response body: `{ token, expiresAt, guardianId, assistantId }`. Refreshable
+ * pairings additionally return `{ refreshToken, refreshTokenExpiresAt,
+ * refreshAfter }` so the client can renew via `/v1/guardian/refresh` instead
+ * of re-pairing.
  */
 
 import { mintAndRecordDeviceBoundTokenPair } from "../../auth/guardian-bootstrap.js";
@@ -217,10 +217,9 @@ export async function handlePair(
   const guardianPrincipalId = await resolveLocalGuardianPrincipalId();
   const assistantId = getExternalAssistantId();
 
-  // Optionally, a client may supply a deviceId to receive a device-bound,
-  // DB-recorded, refreshable token pair (revocable per device) instead of the
-  // legacy stateless token. The body is optional — a malformed or absent body
-  // simply leaves deviceId undefined and preserves the stateless path.
+  // Chrome extension clients may still supply a deviceId to receive a
+  // DB-recorded, refreshable token pair. CLI pairings are always refreshable
+  // and use a server-generated credential binding instead.
   let deviceId: string | undefined;
   let bodyPlatform: string | undefined;
   if ((req.headers.get("content-type") ?? "").includes("json")) {
@@ -265,12 +264,12 @@ export async function handlePair(
       );
     }
 
-    // Device-bound path: mint a recorded, per-device-revocable access token.
+    // Client-supplied binding path: mint a recorded, refreshable access token.
     if (deviceId) {
-      return mintDeviceBoundPairResponse({
+      return mintCredentialBoundPairResponse({
         guardianPrincipalId,
         assistantId,
-        deviceId,
+        credentialBindingId: deviceId,
         platform: bodyPlatform ?? interfaceId,
         interfaceId,
         clientId,
@@ -301,9 +300,10 @@ export async function handlePair(
   }
 
   // CLI pairing (e.g. `vellum pair`): a loopback-local caller mints a
-  // device-bound token for another machine. The loopback / X-Forwarded-For /
-  // edge-marker guards above are the boundary. A deviceId is required — CLI
-  // pairing is always device-scoped (and thus revocable).
+  // refreshable credential for another machine. The loopback /
+  // X-Forwarded-For / edge-marker guards above are the boundary. The gateway
+  // generates the credential binding internally so the pairing bundle only
+  // contains the token material the remote client actually needs.
   if (interfaceId === "cli") {
     // A real `vellum pair` is a terminal process and never sends an Origin
     // header; any Origin means a browser/WebView is calling (e.g. dynamic
@@ -317,17 +317,9 @@ export async function handlePair(
       auditDeny(req, clientIp, "cli_browser_origin", { origin });
       return errorResponse("FORBIDDEN", "endpoint is local-only", 403);
     }
-    if (!deviceId) {
-      return errorResponse(
-        "BAD_REQUEST",
-        "cli interface requires a deviceId",
-        400,
-      );
-    }
-    return mintDeviceBoundPairResponse({
+    return mintCredentialBoundPairResponse({
       guardianPrincipalId,
       assistantId,
-      deviceId,
       platform: bodyPlatform ?? "cli",
       interfaceId,
       clientId,
@@ -343,30 +335,29 @@ export async function handlePair(
 }
 
 /**
- * Mint a device-bound, recorded, per-device-revocable credential and build the
- * pair response. Shared by the chrome-extension (deviceId) and cli pairing
- * paths.
+ * Mint a recorded refreshable credential and build the pair response. Shared
+ * by the chrome-extension (client-supplied binding) and cli pairing
+ * (server-generated binding) paths.
  *
- * Issues the standard access + long-lived device-scoped refresh token pair, so
- * a paired client renews via `/v1/guardian/refresh` instead of re-pairing.
- * Both are revocable per device on the hot path (actor-token revocation is
- * enforced on live requests), and the refresh endpoint rejects revoked/rotated
- * tokens — so revocation, not a short TTL, bounds a leaked token's reach. The
- * access TTL matches what `/v1/guardian/refresh` mints on rotation, so it stays
- * consistent across the token's life (rather than 24h at mint then 30d after
- * the first refresh).
+ * Issues the standard access + long-lived refresh token pair, so a paired
+ * client renews via `/v1/guardian/refresh` instead of re-pairing. Tokens remain
+ * revocable through the stored credential binding, and the refresh endpoint
+ * rejects revoked/rotated tokens — so revocation, not a short TTL, bounds a
+ * leaked token's reach. The access TTL matches what `/v1/guardian/refresh`
+ * mints on rotation, so it stays consistent across the token's life.
  */
-function mintDeviceBoundPairResponse(opts: {
+function mintCredentialBoundPairResponse(opts: {
   guardianPrincipalId: string;
   assistantId: string;
-  deviceId: string;
+  credentialBindingId?: string;
   platform: string;
   interfaceId: string;
   clientId: string | null;
 }): Response {
+  const credentialBindingId = opts.credentialBindingId ?? crypto.randomUUID();
   const pair = mintAndRecordDeviceBoundTokenPair({
     guardianPrincipalId: opts.guardianPrincipalId,
-    deviceId: opts.deviceId,
+    deviceId: credentialBindingId,
     platform: opts.platform,
   });
 
@@ -377,7 +368,7 @@ function mintDeviceBoundPairResponse(opts: {
       guardianPrincipalId: opts.guardianPrincipalId,
       platform: opts.platform,
     },
-    "Client paired successfully via loopback (device-bound)",
+    "Client paired successfully via loopback (credential-bound)",
   );
 
   return Response.json({

--- a/gateway/src/http/routes/pair.ts
+++ b/gateway/src/http/routes/pair.ts
@@ -219,7 +219,8 @@ export async function handlePair(
 
   // Chrome extension clients may still supply a deviceId to receive a
   // DB-recorded, refreshable token pair. CLI pairings are always refreshable
-  // and use a server-generated credential binding instead.
+  // and use a server-generated deviceId instead of requiring one from the
+  // client.
   let deviceId: string | undefined;
   let bodyPlatform: string | undefined;
   if ((req.headers.get("content-type") ?? "").includes("json")) {
@@ -264,12 +265,12 @@ export async function handlePair(
       );
     }
 
-    // Client-supplied binding path: mint a recorded, refreshable access token.
+    // Device-bound path: mint a recorded, refreshable access token.
     if (deviceId) {
-      return mintCredentialBoundPairResponse({
+      return mintDeviceBoundPairResponse({
         guardianPrincipalId,
         assistantId,
-        credentialBindingId: deviceId,
+        deviceId,
         platform: bodyPlatform ?? interfaceId,
         interfaceId,
         clientId,
@@ -301,9 +302,9 @@ export async function handlePair(
 
   // CLI pairing (e.g. `vellum pair`): a loopback-local caller mints a
   // refreshable credential for another machine. The loopback /
-  // X-Forwarded-For / edge-marker guards above are the boundary. The gateway
-  // generates the credential binding internally so the pairing bundle only
-  // contains the token material the remote client actually needs.
+  // X-Forwarded-For / edge-marker guards above are the boundary. The gateway now
+  // generates the deviceId internally so the pairing bundle only contains the
+  // token material the remote client actually needs.
   if (interfaceId === "cli") {
     // A real `vellum pair` is a terminal process and never sends an Origin
     // header; any Origin means a browser/WebView is calling (e.g. dynamic
@@ -317,7 +318,7 @@ export async function handlePair(
       auditDeny(req, clientIp, "cli_browser_origin", { origin });
       return errorResponse("FORBIDDEN", "endpoint is local-only", 403);
     }
-    return mintCredentialBoundPairResponse({
+    return mintDeviceBoundPairResponse({
       guardianPrincipalId,
       assistantId,
       platform: bodyPlatform ?? "cli",
@@ -335,29 +336,29 @@ export async function handlePair(
 }
 
 /**
- * Mint a recorded refreshable credential and build the pair response. Shared
- * by the chrome-extension (client-supplied binding) and cli pairing
- * (server-generated binding) paths.
+ * Mint a device-bound, recorded, refreshable credential and build the pair
+ * response. Shared by the chrome-extension (client-supplied deviceId) and cli
+ * pairing (server-generated deviceId) paths.
  *
  * Issues the standard access + long-lived refresh token pair, so a paired
  * client renews via `/v1/guardian/refresh` instead of re-pairing. Tokens remain
- * revocable through the stored credential binding, and the refresh endpoint
+ * revocable through the stored device binding, and the refresh endpoint
  * rejects revoked/rotated tokens — so revocation, not a short TTL, bounds a
  * leaked token's reach. The access TTL matches what `/v1/guardian/refresh`
  * mints on rotation, so it stays consistent across the token's life.
  */
-function mintCredentialBoundPairResponse(opts: {
+function mintDeviceBoundPairResponse(opts: {
   guardianPrincipalId: string;
   assistantId: string;
-  credentialBindingId?: string;
+  deviceId?: string;
   platform: string;
   interfaceId: string;
   clientId: string | null;
 }): Response {
-  const credentialBindingId = opts.credentialBindingId ?? crypto.randomUUID();
+  const deviceId = opts.deviceId ?? crypto.randomUUID();
   const pair = mintAndRecordDeviceBoundTokenPair({
     guardianPrincipalId: opts.guardianPrincipalId,
-    deviceId: credentialBindingId,
+    deviceId,
     platform: opts.platform,
   });
 
@@ -368,7 +369,7 @@ function mintCredentialBoundPairResponse(opts: {
       guardianPrincipalId: opts.guardianPrincipalId,
       platform: opts.platform,
     },
-    "Client paired successfully via loopback (credential-bound)",
+    "Client paired successfully via loopback (device-bound)",
   );
 
   return Response.json({

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -16,7 +16,9 @@ import {
   initSigningKey,
 } from "./auth/token-service.js";
 import { validateEdgeToken, mintServiceToken } from "./auth/token-exchange.js";
+import { isActorTokenRevoked } from "./auth/actor-token-revocation.js";
 import { findGuardianForChannelActor } from "./auth/guardian-bootstrap.js";
+import { parseSub } from "./auth/subject.js";
 import { AuthFallbackReporter } from "./auth-fallback-reporter.js";
 import { loopbackFallbackCountTracker } from "./http/middleware/auth.js";
 import { ConfigFileCache } from "./config-file-cache.js";
@@ -931,7 +933,44 @@ async function main() {
           );
           return Response.json({ error: "Unauthorized" }, { status: 401 });
         }
-        return channelVerificationSessionProxy.handleGuardianRefresh(req);
+        if (result.claims.scope_profile !== "actor_client_v1") {
+          authRateLimiter.recordFailure(getClientIp());
+          log.warn(
+            {
+              path: new URL(req.url).pathname,
+              scope: result.claims.scope_profile,
+            },
+            "Guardian refresh auth rejected: insufficient scope",
+          );
+          return Response.json({ error: "Unauthorized" }, { status: 401 });
+        }
+        const parsedSub = parseSub(result.claims.sub);
+        if (
+          !parsedSub.ok ||
+          parsedSub.principalType !== "actor" ||
+          !parsedSub.actorPrincipalId
+        ) {
+          authRateLimiter.recordFailure(getClientIp());
+          log.warn(
+            {
+              path: new URL(req.url).pathname,
+              reason: parsedSub.ok ? "non_actor_sub" : parsedSub.reason,
+            },
+            "Guardian refresh auth rejected: non-actor token",
+          );
+          return Response.json({ error: "Unauthorized" }, { status: 401 });
+        }
+        if (isActorTokenRevoked(token, result.claims)) {
+          authRateLimiter.recordFailure(getClientIp());
+          log.warn(
+            { path: new URL(req.url).pathname },
+            "Guardian refresh auth rejected: actor token revoked",
+          );
+          return Response.json({ error: "Unauthorized" }, { status: 401 });
+        }
+        return channelVerificationSessionProxy.handleGuardianRefresh(req, {
+          guardianPrincipalId: parsedSub.actorPrincipalId,
+        });
       },
     },
 

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1981,7 +1981,7 @@ export function buildSchema(): Record<string, unknown> {
         post: {
           summary: "Refresh guardian access token",
           description:
-            "Refreshes an expired guardian access token. Accepts expired JWTs (signature, audience, and policy epoch are still verified — only the expiration check is relaxed). Requires `refreshToken`; the refresh token record's stored credential binding is reused when rotating credentials.",
+            "Refreshes an expired guardian access token. Accepts expired JWTs (signature, audience, and policy epoch are still verified — only the expiration check is relaxed). Requires `refreshToken`; the refresh token record's stored device binding is reused when rotating credentials.",
           operationId: "guardianRefresh",
           security: [{ BearerAuth: [] }],
           requestBody: {

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1981,7 +1981,7 @@ export function buildSchema(): Record<string, unknown> {
         post: {
           summary: "Refresh guardian access token",
           description:
-            "Refreshes an expired guardian access token. Accepts expired JWTs (signature, audience, and policy epoch are still verified — only the expiration check is relaxed). Requires `refreshToken` and the `deviceId` the token was issued to; the refresh token is device-bound and is rejected if the device does not match.",
+            "Refreshes an expired guardian access token. Accepts expired JWTs (signature, audience, and policy epoch are still verified — only the expiration check is relaxed). Requires `refreshToken`; the refresh token record's stored credential binding is reused when rotating credentials.",
           operationId: "guardianRefresh",
           security: [{ BearerAuth: [] }],
           requestBody: {
@@ -1995,12 +1995,12 @@ export function buildSchema(): Record<string, unknown> {
           responses: {
             "200": { description: "New access token returned" },
             "400": {
-              description: "Missing required field (refreshToken or deviceId)",
+              description: "Missing required field (refreshToken)",
             },
             "401": { description: "Unauthorized — invalid token" },
             "403": {
               description:
-                "Refresh token revoked, reused, or presented from a non-matching device",
+                "Refresh token revoked, reused, or presented by a non-matching principal",
             },
             "502": { description: "Failed to reach assistant runtime" },
           },


### PR DESCRIPTION
## Summary
- Remove client-provided device IDs from `vellum pair` bundles and `connect import`
- Let CLI pairings use gateway-generated credential bindings and refresh with only the refresh token
- Tighten guardian refresh auth by binding rotation to the authenticated actor principal

## Original prompt
The user asked to remove `deviceId` from the bearer pairing secret because it is stored with the refresh token and does not add meaningful security for the pair/import flow.