### PR TITLE
feat(workflows): add workflowLeaf LLM call site

### DIFF
--- a/assistant/src/__tests__/llm-resolver.test.ts
+++ b/assistant/src/__tests__/llm-resolver.test.ts
@@ -579,6 +579,30 @@ describe("resolveCallSiteConfig", () => {
     expect(resolved.effort).toBe("medium");
   });
 
+  test("workflowLeaf defaults to the cost-optimized profile", () => {
+    const llm = LLMSchema.parse({
+      default: fullDefault,
+      profiles: {
+        balanced: {
+          model: "claude-sonnet-4-7",
+          effort: "medium",
+        },
+        "cost-optimized": {
+          model: "claude-haiku-4-5-20251001",
+          effort: "low",
+        },
+      },
+    });
+
+    expect(resolveDefaultProfileKey("workflowLeaf", llm)).toBe(
+      "cost-optimized",
+    );
+    const resolved = resolveCallSiteConfig("workflowLeaf", llm);
+    expect(resolved.model).toBe("claude-haiku-4-5-20251001");
+    expect(resolved.effort).toBe("low");
+    expect(resolved.thinking.enabled).toBe(false);
+  });
+
   test("explicit callSites config overrides CALL_SITE_DEFAULTS", () => {
     const llm = LLMSchema.parse({
       default: fullDefault,

--- a/assistant/src/config/call-site-defaults.ts
+++ b/assistant/src/config/call-site-defaults.ts
@@ -114,4 +114,9 @@ export const CALL_SITE_DEFAULTS: Record<LLMCallSite, CallSiteDefaultConfig> = {
     effort: "low",
     thinking: { enabled: false },
   },
+  workflowLeaf: {
+    profile: "cost-optimized",
+    effort: "low",
+    thinking: { enabled: false },
+  },
 };

--- a/assistant/src/config/schemas/call-site-catalog.ts
+++ b/assistant/src/config/schemas/call-site-catalog.ts
@@ -82,6 +82,13 @@ const CATALOG_RECORD: CatalogRecord = {
     description: "Handles voice call conversations.",
     domain: "agentLoop",
   },
+  workflowLeaf: {
+    id: "workflowLeaf",
+    displayName: "Workflow Leaf",
+    description:
+      "Runs an ephemeral leaf agent fanned out by the workflow orchestration engine.",
+    domain: "agentLoop",
+  },
 
   // memory
   memoryExtraction: {

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -78,6 +78,7 @@ export const LLMCallSiteEnum = z.enum([
   "trustRuleSuggestion",
   "homeGreeting",
   "homeSuggestedPrompts",
+  "workflowLeaf",
 ]);
 export type LLMCallSite = z.infer<typeof LLMCallSiteEnum>;
 


### PR DESCRIPTION
## Summary
- Add the `workflowLeaf` call site mapped to the cost-optimized profile (low effort, thinking off) for ephemeral leaf agents.

Part of plan: workflow-engine.md (PR 5 of 17)