### PR TITLE
feat(workflows): workflow run tables and journal store

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -214,6 +214,7 @@ import {
   migrateUsageLlmCallCount,
   migrateVoiceInviteColumns,
   migrateVoiceInviteDisplayMetadata,
+  migrateWorkflowRuns,
   recoverCrashedMigrations,
   runComplexMigrations,
   runLateMigrations,
@@ -498,6 +499,7 @@ export function initializeDb(): void {
     migrateToolInvocationsTelemetryColumns,
     createSkillLoadedEventsTable,
     migrateConversationsSurfacedAt,
+    migrateWorkflowRuns,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/281-workflow-runs.ts
+++ b/assistant/src/memory/migrations/281-workflow-runs.ts
@@ -1,0 +1,51 @@
+import type { DrizzleDb } from "../db-connection.js";
+
+/**
+ * Create the workflow-engine persistence tables.
+ *
+ * `workflow_runs` is one row per orchestration run (a sandboxed script that
+ * spawns parallel leaf agents). `workflow_journal` is an append-only log of
+ * every leaf call (agent / host function / nested workflow) keyed by
+ * `(run_id, seq)`, so a run can RESUME after a daemon restart by replaying
+ * cached results for the unchanged call prefix.
+ *
+ * Idempotent — re-running is a no-op once the tables and index exist.
+ */
+export function migrateWorkflowRuns(database: DrizzleDb): void {
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS workflow_runs (
+      id TEXT PRIMARY KEY,
+      name TEXT,
+      script_source TEXT NOT NULL,
+      script_hash TEXT NOT NULL,
+      args_json TEXT,
+      capabilities_json TEXT,
+      status TEXT NOT NULL,
+      conversation_id TEXT,
+      agents_spawned INTEGER NOT NULL DEFAULT 0,
+      input_tokens INTEGER NOT NULL DEFAULT 0,
+      output_tokens INTEGER NOT NULL DEFAULT 0,
+      result_json TEXT,
+      error TEXT,
+      created_at INTEGER,
+      updated_at INTEGER,
+      finished_at INTEGER
+    )
+  `);
+  database.run(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_workflow_runs_status_created_at ON workflow_runs (status, created_at)`,
+  );
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS workflow_journal (
+      run_id TEXT NOT NULL,
+      seq INTEGER NOT NULL,
+      call_hash TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      request_json TEXT,
+      result_json TEXT,
+      status TEXT NOT NULL,
+      created_at INTEGER,
+      PRIMARY KEY (run_id, seq)
+    )
+  `);
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -272,6 +272,7 @@ export { migrateAddMemoryV3EverInjected } from "./277-add-memory-v3-ever-injecte
 export { migrateToolInvocationsTelemetryColumns } from "./278-tool-invocations-telemetry-columns.js";
 export { createSkillLoadedEventsTable } from "./279-create-skill-loaded-events.js";
 export { migrateConversationsSurfacedAt } from "./280-conversations-surfaced-at.js";
+export { migrateWorkflowRuns } from "./281-workflow-runs.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/workflows/journal-store.test.ts
+++ b/assistant/src/workflows/journal-store.test.ts
@@ -1,0 +1,280 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Silence the logger.
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { getDb, getSqlite } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
+import { migrateWorkflowRuns } from "../memory/migrations/281-workflow-runs.js";
+import {
+  appendJournalEntry,
+  createRun,
+  finishRun,
+  getJournal,
+  getRun,
+  listRuns,
+  pruneRuns,
+  updateRun,
+} from "./journal-store.js";
+
+initializeDb();
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function resetTables(): void {
+  getSqlite().exec("DELETE FROM workflow_journal");
+  getSqlite().exec("DELETE FROM workflow_runs");
+}
+
+describe("workflow journal store", () => {
+  beforeEach(() => {
+    resetTables();
+  });
+
+  test("the migration is idempotent (re-running is a no-op)", () => {
+    // initializeDb (called at module load) already ran the migration once.
+    // Running it directly a second and third time must not throw and must
+    // leave the tables intact and usable.
+    expect(() => migrateWorkflowRuns(getDb())).not.toThrow();
+    expect(() => migrateWorkflowRuns(getDb())).not.toThrow();
+
+    createRun({
+      id: "wf-idem",
+      scriptSource: "console.log(1)",
+      scriptHash: "h1",
+    });
+    expect(getRun("wf-idem")?.id).toBe("wf-idem");
+  });
+
+  test("createRun round-trips all fields with sane defaults", () => {
+    const run = createRun({
+      id: "wf-1",
+      name: "nightly digest",
+      scriptSource: "await agent('x')",
+      scriptHash: "hash-abc",
+      args: { topic: "ai" },
+      capabilities: ["search", "email"],
+      conversationId: "conv-xyz",
+    });
+
+    expect(run).toMatchObject({
+      id: "wf-1",
+      name: "nightly digest",
+      scriptSource: "await agent('x')",
+      scriptHash: "hash-abc",
+      args: { topic: "ai" },
+      capabilities: ["search", "email"],
+      status: "running",
+      conversationId: "conv-xyz",
+      agentsSpawned: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      result: null,
+      error: null,
+      finishedAt: null,
+    });
+    expect(run.createdAt).toBeGreaterThan(0);
+    expect(run.updatedAt).toBeGreaterThan(0);
+
+    expect(getRun("wf-1")).toEqual(run);
+  });
+
+  test("optional fields default to null", () => {
+    const run = createRun({
+      id: "wf-min",
+      scriptSource: "noop",
+      scriptHash: "h",
+    });
+    expect(run).toMatchObject({
+      name: null,
+      args: null,
+      capabilities: null,
+      conversationId: null,
+    });
+  });
+
+  test("updateRun patches only provided fields and bumps updated_at", () => {
+    const created = createRun({
+      id: "wf-2",
+      scriptSource: "s",
+      scriptHash: "h",
+    });
+
+    const updated = updateRun("wf-2", {
+      status: "running",
+      agentsSpawned: 3,
+      inputTokens: 100,
+      outputTokens: 50,
+      conversationId: "conv-new",
+    });
+
+    expect(updated).toMatchObject({
+      agentsSpawned: 3,
+      inputTokens: 100,
+      outputTokens: 50,
+      conversationId: "conv-new",
+      // Untouched fields preserved.
+      scriptSource: "s",
+      scriptHash: "h",
+    });
+    expect(updated!.updatedAt!).toBeGreaterThanOrEqual(created.updatedAt!);
+  });
+
+  test("updateRun returns null for an unknown run", () => {
+    expect(updateRun("nope", { status: "failed" })).toBeNull();
+  });
+
+  test("finishRun stamps terminal status, result, and finished_at", () => {
+    createRun({ id: "wf-3", scriptSource: "s", scriptHash: "h" });
+
+    const finished = finishRun("wf-3", {
+      status: "completed",
+      result: { ok: true, count: 2 },
+    });
+
+    expect(finished).toMatchObject({
+      status: "completed",
+      result: { ok: true, count: 2 },
+      error: null,
+    });
+    expect(finished!.finishedAt).toBeGreaterThan(0);
+  });
+
+  test("finishRun records failure error text", () => {
+    createRun({ id: "wf-fail", scriptSource: "s", scriptHash: "h" });
+    const finished = finishRun("wf-fail", {
+      status: "failed",
+      error: "boom",
+    });
+    expect(finished).toMatchObject({ status: "failed", error: "boom" });
+  });
+
+  test("appendJournalEntry + getJournal round-trips in seq order", () => {
+    createRun({ id: "wf-j", scriptSource: "s", scriptHash: "h" });
+
+    appendJournalEntry({
+      runId: "wf-j",
+      seq: 1,
+      callHash: "c1",
+      kind: "agent",
+      request: { prompt: "a" },
+      result: { text: "ra" },
+      status: "completed",
+    });
+    appendJournalEntry({
+      runId: "wf-j",
+      seq: 0,
+      callHash: "c0",
+      kind: "hostFn",
+      request: { fn: "now" },
+      result: 123,
+      status: "completed",
+    });
+
+    const journal = getJournal("wf-j");
+    expect(journal.map((e) => e.seq)).toEqual([0, 1]);
+    expect(journal[0]).toMatchObject({
+      runId: "wf-j",
+      seq: 0,
+      callHash: "c0",
+      kind: "hostFn",
+      request: { fn: "now" },
+      result: 123,
+      status: "completed",
+    });
+    expect(journal[1]).toMatchObject({
+      kind: "agent",
+      request: { prompt: "a" },
+      result: { text: "ra" },
+    });
+  });
+
+  test("appendJournalEntry is idempotent on (run_id, seq)", () => {
+    createRun({ id: "wf-dup", scriptSource: "s", scriptHash: "h" });
+
+    appendJournalEntry({
+      runId: "wf-dup",
+      seq: 0,
+      callHash: "c0",
+      kind: "agent",
+      status: "completed",
+    });
+    // Replayed append for the same seq must not double-insert.
+    appendJournalEntry({
+      runId: "wf-dup",
+      seq: 0,
+      callHash: "c0",
+      kind: "agent",
+      status: "completed",
+    });
+
+    expect(getJournal("wf-dup")).toHaveLength(1);
+  });
+
+  test("listRuns returns newest-first and honors limit + status filter", () => {
+    // created_at is wall-clock; force distinct ordering via direct timestamps.
+    createRun({ id: "old", scriptSource: "s", scriptHash: "h" });
+    getSqlite().exec(
+      "UPDATE workflow_runs SET created_at = 1000 WHERE id = 'old'",
+    );
+    createRun({ id: "mid", scriptSource: "s", scriptHash: "h" });
+    getSqlite().exec(
+      "UPDATE workflow_runs SET created_at = 2000 WHERE id = 'mid'",
+    );
+    createRun({ id: "new", scriptSource: "s", scriptHash: "h" });
+    getSqlite().exec(
+      "UPDATE workflow_runs SET created_at = 3000 WHERE id = 'new'",
+    );
+    finishRun("new", { status: "completed" });
+
+    expect(listRuns({ limit: 10 }).map((r) => r.id)).toEqual([
+      "new",
+      "mid",
+      "old",
+    ]);
+    expect(listRuns({ limit: 1 }).map((r) => r.id)).toEqual(["new"]);
+    expect(
+      listRuns({ limit: 10, status: "completed" }).map((r) => r.id),
+    ).toEqual(["new"]);
+  });
+
+  test("pruneRuns deletes finished runs past retention but keeps running ones", () => {
+    const now = Date.now();
+
+    // Old finished run — should be pruned.
+    createRun({ id: "old-done", scriptSource: "s", scriptHash: "h" });
+    finishRun("old-done", { status: "completed" });
+    appendJournalEntry({
+      runId: "old-done",
+      seq: 0,
+      callHash: "c",
+      kind: "agent",
+      status: "completed",
+    });
+    getSqlite().exec(
+      `UPDATE workflow_runs SET created_at = ${now - 10 * DAY_MS} WHERE id = 'old-done'`,
+    );
+
+    // Old but still running — must be kept.
+    createRun({ id: "old-running", scriptSource: "s", scriptHash: "h" });
+    getSqlite().exec(
+      `UPDATE workflow_runs SET created_at = ${now - 10 * DAY_MS} WHERE id = 'old-running'`,
+    );
+
+    // Recent finished run — within retention, kept.
+    createRun({ id: "recent-done", scriptSource: "s", scriptHash: "h" });
+    finishRun("recent-done", { status: "completed" });
+
+    const deleted = pruneRuns(7);
+    expect(deleted).toBe(1);
+    expect(getRun("old-done")).toBeNull();
+    expect(getJournal("old-done")).toHaveLength(0);
+    expect(getRun("old-running")).not.toBeNull();
+    expect(getRun("recent-done")).not.toBeNull();
+  });
+});

--- a/assistant/src/workflows/journal-store.ts
+++ b/assistant/src/workflows/journal-store.ts
@@ -1,0 +1,388 @@
+/**
+ * Typed persistence for the workflow orchestration engine.
+ *
+ * Two tables (created by migration 281):
+ *
+ * - `workflow_runs` — one row per orchestration run (a sandboxed script that
+ *   spawns parallel leaf agents), tracking lifecycle status and token usage.
+ * - `workflow_journal` — append-only `(run_id, seq)` log of every leaf call
+ *   (agent / host function / nested workflow). On resume after a daemon
+ *   restart, the engine replays cached results for the unchanged call prefix
+ *   instead of re-spawning agents.
+ *
+ * This module is pure persistence — no `workflows` feature-flag logic. Callers
+ * (the engine, a later PR) own gating.
+ */
+
+import { rawAll, rawGet, rawRun } from "../memory/raw-query.js";
+
+export type WorkflowRunStatus =
+  | "running"
+  | "completed"
+  | "failed"
+  | "aborted"
+  | "cap_exceeded";
+
+export type WorkflowJournalKind = "agent" | "hostFn" | "workflow";
+
+/** A persisted workflow run row, with JSON columns parsed into values. */
+export interface WorkflowRun {
+  id: string;
+  name: string | null;
+  scriptSource: string;
+  scriptHash: string;
+  args: unknown;
+  capabilities: unknown;
+  status: WorkflowRunStatus;
+  conversationId: string | null;
+  agentsSpawned: number;
+  inputTokens: number;
+  outputTokens: number;
+  result: unknown;
+  error: string | null;
+  createdAt: number | null;
+  updatedAt: number | null;
+  finishedAt: number | null;
+}
+
+/** A persisted journal entry, with JSON columns parsed into values. */
+export interface WorkflowJournalEntry {
+  runId: string;
+  seq: number;
+  callHash: string;
+  kind: WorkflowJournalKind;
+  request: unknown;
+  result: unknown;
+  status: string;
+  createdAt: number | null;
+}
+
+export interface CreateRunInput {
+  id: string;
+  name?: string | null;
+  scriptSource: string;
+  scriptHash: string;
+  args?: unknown;
+  capabilities?: unknown;
+  status?: WorkflowRunStatus;
+  conversationId?: string | null;
+}
+
+export interface UpdateRunInput {
+  status?: WorkflowRunStatus;
+  agentsSpawned?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  conversationId?: string | null;
+}
+
+export interface FinishRunInput {
+  status: WorkflowRunStatus;
+  result?: unknown;
+  error?: string | null;
+}
+
+export interface AppendJournalEntryInput {
+  runId: string;
+  seq: number;
+  callHash: string;
+  kind: WorkflowJournalKind;
+  request?: unknown;
+  result?: unknown;
+  status: string;
+}
+
+// ---------------------------------------------------------------------------
+// Row shapes + mappers
+// ---------------------------------------------------------------------------
+
+interface WorkflowRunRow {
+  id: string;
+  name: string | null;
+  script_source: string;
+  script_hash: string;
+  args_json: string | null;
+  capabilities_json: string | null;
+  status: string;
+  conversation_id: string | null;
+  agents_spawned: number;
+  input_tokens: number;
+  output_tokens: number;
+  result_json: string | null;
+  error: string | null;
+  created_at: number | null;
+  updated_at: number | null;
+  finished_at: number | null;
+}
+
+interface WorkflowJournalRow {
+  run_id: string;
+  seq: number;
+  call_hash: string;
+  kind: string;
+  request_json: string | null;
+  result_json: string | null;
+  status: string;
+  created_at: number | null;
+}
+
+/** Parse a nullable JSON column; malformed values collapse to null. */
+function parseJsonColumn(value: string | null): unknown {
+  if (value === null) return null;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+/** Serialize a value for a nullable JSON column. `undefined` stores as null. */
+function serializeJsonColumn(value: unknown): string | null {
+  return value === undefined || value === null ? null : JSON.stringify(value);
+}
+
+function rowToRun(row: WorkflowRunRow): WorkflowRun {
+  return {
+    id: row.id,
+    name: row.name,
+    scriptSource: row.script_source,
+    scriptHash: row.script_hash,
+    args: parseJsonColumn(row.args_json),
+    capabilities: parseJsonColumn(row.capabilities_json),
+    status: row.status as WorkflowRunStatus,
+    conversationId: row.conversation_id,
+    agentsSpawned: row.agents_spawned,
+    inputTokens: row.input_tokens,
+    outputTokens: row.output_tokens,
+    result: parseJsonColumn(row.result_json),
+    error: row.error,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    finishedAt: row.finished_at,
+  };
+}
+
+function rowToJournalEntry(row: WorkflowJournalRow): WorkflowJournalEntry {
+  return {
+    runId: row.run_id,
+    seq: row.seq,
+    callHash: row.call_hash,
+    kind: row.kind as WorkflowJournalKind,
+    request: parseJsonColumn(row.request_json),
+    result: parseJsonColumn(row.result_json),
+    status: row.status,
+    createdAt: row.created_at,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Runs — write
+// ---------------------------------------------------------------------------
+
+/** Insert a new workflow run. Defaults status to `running`. */
+export function createRun(input: CreateRunInput): WorkflowRun {
+  const now = Date.now();
+  const status = input.status ?? "running";
+  rawRun(
+    /*sql*/ `
+    INSERT INTO workflow_runs (
+      id, name, script_source, script_hash, args_json, capabilities_json,
+      status, conversation_id, agents_spawned, input_tokens, output_tokens,
+      result_json, error, created_at, updated_at, finished_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 0, NULL, NULL, ?, ?, NULL)
+    `,
+    input.id,
+    input.name ?? null,
+    input.scriptSource,
+    input.scriptHash,
+    serializeJsonColumn(input.args),
+    serializeJsonColumn(input.capabilities),
+    status,
+    input.conversationId ?? null,
+    now,
+    now,
+  );
+  return getRun(input.id)!;
+}
+
+/**
+ * Patch mutable fields on a run and bump `updated_at`. Only the fields present
+ * in `input` are written. Returns the updated run, or null if it doesn't exist.
+ */
+export function updateRun(
+  runId: string,
+  input: UpdateRunInput,
+): WorkflowRun | null {
+  const sets: string[] = [];
+  const params: (string | number | null)[] = [];
+
+  if (input.status !== undefined) {
+    sets.push("status = ?");
+    params.push(input.status);
+  }
+  if (input.agentsSpawned !== undefined) {
+    sets.push("agents_spawned = ?");
+    params.push(input.agentsSpawned);
+  }
+  if (input.inputTokens !== undefined) {
+    sets.push("input_tokens = ?");
+    params.push(input.inputTokens);
+  }
+  if (input.outputTokens !== undefined) {
+    sets.push("output_tokens = ?");
+    params.push(input.outputTokens);
+  }
+  if (input.conversationId !== undefined) {
+    sets.push("conversation_id = ?");
+    params.push(input.conversationId);
+  }
+
+  sets.push("updated_at = ?");
+  params.push(Date.now());
+  params.push(runId);
+
+  rawRun(`UPDATE workflow_runs SET ${sets.join(", ")} WHERE id = ?`, ...params);
+  return getRun(runId);
+}
+
+/**
+ * Mark a run terminal: set its final status, result/error payload, and stamp
+ * both `updated_at` and `finished_at`. Returns the updated run, or null if it
+ * doesn't exist.
+ */
+export function finishRun(
+  runId: string,
+  input: FinishRunInput,
+): WorkflowRun | null {
+  const now = Date.now();
+  rawRun(
+    /*sql*/ `
+    UPDATE workflow_runs
+    SET status = ?, result_json = ?, error = ?, updated_at = ?, finished_at = ?
+    WHERE id = ?
+    `,
+    input.status,
+    serializeJsonColumn(input.result),
+    input.error ?? null,
+    now,
+    now,
+    runId,
+  );
+  return getRun(runId);
+}
+
+// ---------------------------------------------------------------------------
+// Journal — write
+// ---------------------------------------------------------------------------
+
+/**
+ * Append a leaf-call entry to a run's journal. Idempotent on `(run_id, seq)`:
+ * a replayed append for an existing sequence number is ignored, so a crash
+ * between the call and its journal write can't double-insert on resume.
+ */
+export function appendJournalEntry(
+  input: AppendJournalEntryInput,
+): WorkflowJournalEntry {
+  rawRun(
+    /*sql*/ `
+    INSERT OR IGNORE INTO workflow_journal (
+      run_id, seq, call_hash, kind, request_json, result_json, status, created_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `,
+    input.runId,
+    input.seq,
+    input.callHash,
+    input.kind,
+    serializeJsonColumn(input.request),
+    serializeJsonColumn(input.result),
+    input.status,
+    Date.now(),
+  );
+  return getJournalEntry(input.runId, input.seq)!;
+}
+
+// ---------------------------------------------------------------------------
+// Runs + journal — read
+// ---------------------------------------------------------------------------
+
+/** Fetch a single run by id, or null if it doesn't exist. */
+export function getRun(runId: string): WorkflowRun | null {
+  const row = rawGet<WorkflowRunRow>(
+    `SELECT * FROM workflow_runs WHERE id = ?`,
+    runId,
+  );
+  return row ? rowToRun(row) : null;
+}
+
+/** Fetch a run's full journal in sequence order for resume replay. */
+export function getJournal(runId: string): WorkflowJournalEntry[] {
+  const rows = rawAll<WorkflowJournalRow>(
+    `SELECT * FROM workflow_journal WHERE run_id = ? ORDER BY seq ASC`,
+    runId,
+  );
+  return rows.map(rowToJournalEntry);
+}
+
+/** Fetch a single journal entry by its `(run_id, seq)` key, or null. */
+export function getJournalEntry(
+  runId: string,
+  seq: number,
+): WorkflowJournalEntry | null {
+  const row = rawGet<WorkflowJournalRow>(
+    `SELECT * FROM workflow_journal WHERE run_id = ? AND seq = ?`,
+    runId,
+    seq,
+  );
+  return row ? rowToJournalEntry(row) : null;
+}
+
+export interface ListRunsOptions {
+  limit: number;
+  status?: WorkflowRunStatus;
+}
+
+/** List runs newest-first, optionally filtered by status. */
+export function listRuns(options: ListRunsOptions): WorkflowRun[] {
+  const rows = options.status
+    ? rawAll<WorkflowRunRow>(
+        `SELECT * FROM workflow_runs WHERE status = ? ORDER BY created_at DESC LIMIT ?`,
+        options.status,
+        options.limit,
+      )
+    : rawAll<WorkflowRunRow>(
+        `SELECT * FROM workflow_runs ORDER BY created_at DESC LIMIT ?`,
+        options.limit,
+      );
+  return rows.map(rowToRun);
+}
+
+// ---------------------------------------------------------------------------
+// Retention
+// ---------------------------------------------------------------------------
+
+/**
+ * Delete finished runs older than `retentionDays` (by `created_at`) and their
+ * journal entries. Running (un-finished) runs are never pruned, regardless of
+ * age, so an in-flight long run can't be reaped out from under the engine.
+ * Returns the number of runs deleted.
+ */
+export function pruneRuns(retentionDays: number): number {
+  const cutoff = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+  rawRun(
+    /*sql*/ `
+    DELETE FROM workflow_journal
+    WHERE run_id IN (
+      SELECT id FROM workflow_runs
+      WHERE status != 'running' AND created_at IS NOT NULL AND created_at < ?
+    )
+    `,
+    cutoff,
+  );
+  return rawRun(
+    /*sql*/ `
+    DELETE FROM workflow_runs
+    WHERE status != 'running' AND created_at IS NOT NULL AND created_at < ?
+    `,
+    cutoff,
+  );
+}


### PR DESCRIPTION
## Summary
- Add workflow_runs + workflow_journal tables (idempotent migration, registered last) and a typed journal store for run lifecycle + resume replay.

Part of plan: workflow-engine.md (PR 4 of 17)