### PR TITLE
feat(workflows): workflow engine with caps, concurrency, and journaled resume

### DIFF
--- a/assistant/src/workflows/engine.test.ts
+++ b/assistant/src/workflows/engine.test.ts
@@ -1,0 +1,379 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Silence the logger.
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import type { WorkflowsConfig } from "../config/schemas/workflows.js";
+import type { TrustContext } from "../daemon/trust-context.js";
+import { getSqlite } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
+import type { ResolvedCapabilities } from "./capabilities.js";
+import { executeWorkflow, extractWorkflowMeta } from "./engine.js";
+import * as journalStore from "./journal-store.js";
+import type { LeafResult, RunLeafOptions } from "./leaf-runner.js";
+
+initializeDb();
+
+function resetTables(): void {
+  getSqlite().exec("DELETE FROM workflow_journal");
+  getSqlite().exec("DELETE FROM workflow_runs");
+}
+
+const TRUST: TrustContext = { sourceChannel: "vellum", trustClass: "guardian" };
+
+const CAPABILITIES: ResolvedCapabilities = {
+  tools: [],
+  hostFunctions: [],
+  persona: false,
+};
+
+function configWith(overrides: Partial<WorkflowsConfig> = {}): WorkflowsConfig {
+  return {
+    maxAgentsPerRun: 500,
+    maxConcurrentLeaves: 6,
+    maxConcurrentRuns: 3,
+    journalRetentionDays: 30,
+    ...overrides,
+  };
+}
+
+/**
+ * Fake leaf runner. Records every prompt it is called with, tracks the
+ * concurrency high-water mark (so a test can assert the cap), and returns a
+ * deterministic echo output with fixed token usage. An optional `failOn`
+ * predicate makes a leaf throw.
+ */
+function makeFakeRunner(opts?: {
+  delayMs?: number;
+  failOn?: (prompt: string) => boolean;
+  onCall?: (prompt: string) => void;
+}) {
+  const prompts: string[] = [];
+  let inFlight = 0;
+  let highWater = 0;
+
+  const runner = async (leafOpts: RunLeafOptions): Promise<LeafResult> => {
+    prompts.push(leafOpts.prompt);
+    opts?.onCall?.(leafOpts.prompt);
+    inFlight += 1;
+    highWater = Math.max(highWater, inFlight);
+    try {
+      if (opts?.delayMs) {
+        await new Promise((r) => setTimeout(r, opts.delayMs));
+      } else {
+        await Promise.resolve();
+      }
+      if (opts?.failOn?.(leafOpts.prompt)) {
+        throw new Error(`leaf failed: ${leafOpts.prompt}`);
+      }
+      return {
+        output: `out:${leafOpts.prompt}`,
+        inputTokens: 10,
+        outputTokens: 5,
+        toolCallCount: 0,
+      };
+    } finally {
+      inFlight -= 1;
+    }
+  };
+
+  return {
+    runner: runner as unknown as typeof import("./leaf-runner.js").runLeaf,
+    prompts,
+    get highWater() {
+      return highWater;
+    },
+  };
+}
+
+const META = `export const meta = { name: "test-wf", description: "a test workflow" };\n`;
+
+function execute(
+  runId: string,
+  scriptSource: string,
+  runner: typeof import("./leaf-runner.js").runLeaf,
+  config: WorkflowsConfig = configWith(),
+  args: unknown = null,
+) {
+  return executeWorkflow({
+    runId,
+    scriptSource: META + scriptSource,
+    args,
+    capabilities: CAPABILITIES,
+    config,
+    journal: journalStore,
+    leafRunner: runner,
+    trustContext: TRUST,
+  });
+}
+
+describe("extractWorkflowMeta", () => {
+  test("extracts a pure-literal meta", () => {
+    expect(
+      extractWorkflowMeta(
+        `export const meta = { name: "n", description: "d" };`,
+      ),
+    ).toEqual({ name: "n", description: "d" });
+  });
+
+  test("rejects a missing meta", () => {
+    expect(() => extractWorkflowMeta(`const x = 1;`)).toThrow();
+  });
+
+  test("rejects a non-string name/description", () => {
+    expect(() =>
+      extractWorkflowMeta(`export const meta = { name: 1, description: "d" };`),
+    ).toThrow();
+  });
+
+  test("accepts single-quoted and unquoted-key literals", () => {
+    expect(
+      extractWorkflowMeta(
+        `export const meta = { name: 'n', description: 'd', };`,
+      ),
+    ).toEqual({ name: "n", description: "d" });
+  });
+
+  test("rejects a computed meta without executing it (no host eval)", () => {
+    // A function call in the literal must NOT run in the host process — it
+    // simply fails to JSON-parse and is rejected.
+    (globalThis as Record<string, unknown>).__pwned = false;
+    expect(() =>
+      extractWorkflowMeta(
+        `export const meta = { name: (((globalThis).__pwned = true), "n"), description: "d" };`,
+      ),
+    ).toThrow();
+    expect((globalThis as Record<string, unknown>).__pwned).toBe(false);
+    delete (globalThis as Record<string, unknown>).__pwned;
+  });
+});
+
+describe("executeWorkflow — fan-out & aggregation", () => {
+  beforeEach(resetTables);
+
+  test("map/parallel aggregates results and respects the concurrency cap", async () => {
+    const fake = makeFakeRunner({ delayMs: 8 });
+    const items = Array.from({ length: 20 }, (_, i) => `item-${i}`);
+
+    const res = await execute(
+      "wf-map",
+      `const results = map(args.items, (it) => leaf("task:" + it));
+       return results;`,
+      fake.runner,
+      configWith({ maxConcurrentLeaves: 4 }),
+      { items },
+    );
+
+    expect(res.status).toBe("completed");
+    expect(res.result).toEqual(items.map((it) => `out:task:${it}`));
+    expect(res.agentsSpawned).toBe(20);
+    expect(res.inputTokens).toBe(200);
+    expect(res.outputTokens).toBe(100);
+    // Concurrency high-water never exceeds the cap.
+    expect(fake.highWater).toBeLessThanOrEqual(4);
+    expect(fake.highWater).toBeGreaterThan(1);
+  });
+
+  test("parallel results stay in spec-array order despite completion order", async () => {
+    // Earlier items take longer, so completion order is reversed.
+    const fake = makeFakeRunner();
+    const res = await execute(
+      "wf-order",
+      `return parallel([leaf("a"), leaf("b"), leaf("c")]);`,
+      fake.runner,
+    );
+    expect(res.result).toEqual(["out:a", "out:b", "out:c"]);
+  });
+
+  test("a failed leaf inside parallel yields null (never throws)", async () => {
+    const fake = makeFakeRunner({ failOn: (p) => p === "boom" });
+    const res = await execute(
+      "wf-fail",
+      `return parallel([leaf("ok1"), leaf("boom"), leaf("ok2")]);`,
+      fake.runner,
+    );
+    expect(res.status).toBe("completed");
+    expect(res.result).toEqual(["out:ok1", null, "out:ok2"]);
+  });
+
+  test("agent() runs one sequential leaf and returns its output", async () => {
+    const fake = makeFakeRunner();
+    const res = await execute(
+      "wf-agent",
+      `const a = agent("first");
+       const b = agent("second");
+       return [a, b];`,
+      fake.runner,
+    );
+    expect(res.result).toEqual(["out:first", "out:second"]);
+    expect(fake.prompts).toEqual(["first", "second"]);
+  });
+
+  test("usage() reflects accumulated agents/tokens mid-script", async () => {
+    const fake = makeFakeRunner();
+    const res = await execute(
+      "wf-usage",
+      `agent("one");
+       const u = usage();
+       return u;`,
+      fake.runner,
+    );
+    expect(res.result).toEqual({
+      agentsSpawned: 1,
+      inputTokens: 10,
+      outputTokens: 5,
+    });
+  });
+});
+
+describe("executeWorkflow — pipeline", () => {
+  beforeEach(resetTables);
+
+  test("pipeline advances across stages with a per-stage barrier", async () => {
+    const order: string[] = [];
+    const fake = makeFakeRunner({ onCall: (p) => order.push(p) });
+
+    const res = await execute(
+      "wf-pipeline",
+      `return pipeline(
+         args.items,
+         (it) => leaf("s1:" + it),
+         (prev) => leaf("s2:" + prev),
+       );`,
+      fake.runner,
+      configWith(),
+      { items: ["x", "y"] },
+    );
+
+    // Stage 1 output feeds stage 2's input.
+    expect(res.result).toEqual(["out:s2:out:s1:x", "out:s2:out:s1:y"]);
+    // Per-stage barrier: BOTH stage-1 calls precede ANY stage-2 call.
+    const firstStage2 = order.findIndex((p) => p.startsWith("s2:"));
+    const stage1AfterStage2 = order
+      .slice(firstStage2)
+      .some((p) => p.startsWith("s1:"));
+    expect(stage1AfterStage2).toBe(false);
+  });
+});
+
+describe("executeWorkflow — resume", () => {
+  beforeEach(resetTables);
+
+  test("re-running the same runId replays the unchanged prefix (zero duplicate calls)", async () => {
+    const script = `const a = agent("alpha");
+       const b = agent("beta");
+       return [a, b];`;
+
+    const first = makeFakeRunner();
+    const res1 = await execute("wf-resume", script, first.runner);
+    expect(res1.result).toEqual(["out:alpha", "out:beta"]);
+    expect(first.prompts).toEqual(["alpha", "beta"]);
+
+    // Re-run with the SAME runId against the SAME DB. The journal replays both
+    // cached calls — the runner must NOT be invoked at all.
+    const second = makeFakeRunner();
+    const res2 = await execute("wf-resume", script, second.runner);
+    expect(res2.result).toEqual(["out:alpha", "out:beta"]);
+    expect(second.prompts).toEqual([]);
+  });
+
+  test("a changed call breaks the replay prefix and re-runs from there", async () => {
+    const first = makeFakeRunner();
+    await execute(
+      "wf-resume2",
+      `agent("alpha"); return agent("beta");`,
+      first.runner,
+    );
+    expect(first.prompts).toEqual(["alpha", "beta"]);
+
+    // Second run: seq 0 ("alpha") is unchanged → replayed; seq 1 changes
+    // ("beta" → "gamma") → hash mismatch → re-run.
+    const second = makeFakeRunner();
+    const res = await execute(
+      "wf-resume2",
+      `agent("alpha"); return agent("gamma");`,
+      second.runner,
+    );
+    expect(res.result).toBe("out:gamma");
+    expect(second.prompts).toEqual(["gamma"]);
+  });
+
+  test("deterministic seq + call_hash are stable across two runs", async () => {
+    const script = `return parallel([leaf("p0"), leaf("p1"), leaf("p2")]);`;
+
+    const first = makeFakeRunner();
+    await execute("wf-hash", script, first.runner);
+    const journalA = journalStore.getJournal("wf-hash");
+
+    resetTables();
+
+    const second = makeFakeRunner();
+    await execute("wf-hash", script, second.runner);
+    const journalB = journalStore.getJournal("wf-hash");
+
+    expect(journalA.map((e) => [e.seq, e.callHash])).toEqual(
+      journalB.map((e) => [e.seq, e.callHash]),
+    );
+    expect(journalA.map((e) => e.seq)).toEqual([0, 1, 2]);
+  });
+});
+
+describe("executeWorkflow — agent cap", () => {
+  beforeEach(resetTables);
+
+  test("exceeding maxAgentsPerRun aborts with cap_exceeded and persists partials", async () => {
+    const fake = makeFakeRunner();
+    const items = Array.from({ length: 10 }, (_, i) => `i${i}`);
+
+    const res = await execute(
+      "wf-cap",
+      `const a = map(args.items, (it) => leaf(it));
+       return a;`,
+      fake.runner,
+      configWith({ maxAgentsPerRun: 3, maxConcurrentLeaves: 1 }),
+      { items },
+    );
+
+    expect(res.status).toBe("cap_exceeded");
+    // Exactly the cap's worth of leaves ran before the run aborted.
+    expect(res.agentsSpawned).toBe(3);
+    expect(fake.prompts.length).toBe(3);
+
+    // Partials are persisted: the run row reflects cap_exceeded + 3 agents, and
+    // 3 journal entries exist.
+    const run = journalStore.getRun("wf-cap");
+    expect(run?.status).toBe("cap_exceeded");
+    expect(run?.agentsSpawned).toBe(3);
+    expect(journalStore.getJournal("wf-cap").length).toBe(3);
+  });
+
+  test("the cap counts only NEW leaves; replayed leaves do not consume it", async () => {
+    // First run journals 2 leaves with a generous cap.
+    const first = makeFakeRunner();
+    await execute(
+      "wf-cap-replay",
+      `agent("a"); agent("b"); return agent("c");`,
+      first.runner,
+      configWith({ maxAgentsPerRun: 500 }),
+    );
+    expect(first.prompts).toEqual(["a", "b", "c"]);
+
+    // Re-run with cap=1: a/b/c all replay from the journal (hash match), so the
+    // cap (which only counts NEW spawns) is never tripped.
+    const second = makeFakeRunner();
+    const res = await execute(
+      "wf-cap-replay",
+      `agent("a"); agent("b"); return agent("c");`,
+      second.runner,
+      configWith({ maxAgentsPerRun: 1 }),
+    );
+    expect(res.status).toBe("completed");
+    expect(res.result).toBe("out:c");
+    expect(second.prompts).toEqual([]);
+  });
+});

--- a/assistant/src/workflows/engine.ts
+++ b/assistant/src/workflows/engine.ts
@@ -1,0 +1,602 @@
+/**
+ * Workflow orchestration engine — `executeWorkflow`.
+ *
+ * Runs an assistant-authored workflow script in the QuickJS sandbox
+ * ({@link createWorkflowSandbox}) and fans it out to many parallel ephemeral
+ * leaf agents ({@link runLeaf}). The engine ties together four already-merged
+ * building blocks:
+ *
+ *  - **sandbox** (`sandbox.ts`) — runs the script SYNCHRONOUSLY. Host functions
+ *    are asyncified: a host fn may return a promise, the VM suspends until it
+ *    settles, and the script gets the value back directly (authors write
+ *    `const r = agent(...)`, never `await agent(...)`). The VM is single-
+ *    threaded: it is never inside two script callbacks at once, and a host
+ *    function CANNOT synchronously re-enter the VM to invoke a script callback
+ *    while it is itself suspended in asyncify. This is why `map`/`pipeline` are
+ *    JS prelude helpers (built on `parallel` purely in the VM), not host fns.
+ *  - **journal-store** (`journal-store.ts`) — `(runId, seq)` append-only log of
+ *    every leaf call, for crash-resume replay.
+ *  - **capabilities** (`capabilities.ts`) — the resolved tools/persona/
+ *    host-function grants for the run (the single consent point).
+ *  - **leaf-runner** (`leaf-runner.ts`) — the single-leaf primitive. Injected as
+ *    a dependency so tests can pass a fake.
+ *
+ * ### Host API exposed to the script (synchronous from the script's view)
+ *
+ *  - `agent(prompt, opts?) -> result` — runs ONE leaf and returns its output.
+ *  - `leaf(prompt, opts?) -> Spec` — a tagged descriptor (runs nothing); used
+ *    inside `parallel`/`map` fan-out callbacks.
+ *  - `parallel(specs) -> results[]` — runs the specs concurrently, capped at
+ *    `config.maxConcurrentLeaves`, results in spec-array order; a failed leaf
+ *    yields `null` (never throws). The core fan-out primitive.
+ *  - `map(items, build) -> results[]` and
+ *    `pipeline(items, ...stages) -> results[]` — JS prelude helpers over
+ *    `parallel`. `pipeline` has a PER-STAGE BARRIER in v1: all of stage N
+ *    completes before stage N+1 is built (the single-threaded VM cannot stream
+ *    across stages).
+ *  - `phase(title)`, `log(msg)` — forwarded to `onProgress`.
+ *  - `args` — the verbatim run input.
+ *  - `usage() -> { agentsSpawned, inputTokens, outputTokens }` — a read-only
+ *    snapshot so scripts can self-moderate.
+ *
+ * Declared host functions from the manifest are injected by name; undeclared
+ * ones are absent.
+ *
+ * ### Determinism & resume
+ *
+ * Each leaf call is assigned a `seq` from a monotonic counter incremented in
+ * deterministic call order. For `parallel`, seqs are assigned across the spec
+ * array in array order BEFORE any concurrency is launched, so completion order
+ * cannot perturb seq. The `call_hash = sha256(deterministicStringify({ prompt,
+ * opts }))`. On resume, a journal entry whose `(runId, seq)` is present and
+ * whose `call_hash` matches is replayed from cache WITHOUT calling the leaf
+ * runner (longest-unchanged-prefix replay).
+ */
+
+import { createHash } from "node:crypto";
+
+import type { WorkflowsConfig } from "../config/schemas/workflows.js";
+import type { TrustContext } from "../daemon/trust-context.js";
+import { getLogger } from "../util/logger.js";
+import type { ResolvedCapabilities } from "./capabilities.js";
+import type * as JournalStore from "./journal-store.js";
+import type { WorkflowRunStatus } from "./journal-store.js";
+import type { runLeaf } from "./leaf-runner.js";
+import { createWorkflowSandbox, WorkflowScriptError } from "./sandbox.js";
+
+const log = getLogger("workflow-engine");
+
+/** A progress event forwarded from the script's `phase`/`log` host calls. */
+export type WorkflowProgressEvent =
+  | { type: "phase"; title: string }
+  | { type: "log"; message: string };
+
+/** The journal-store surface the engine depends on (injectable for tests). */
+export interface WorkflowJournal {
+  appendJournalEntry: typeof JournalStore.appendJournalEntry;
+  getJournalEntry: typeof JournalStore.getJournalEntry;
+  getRun: typeof JournalStore.getRun;
+  createRun: typeof JournalStore.createRun;
+  updateRun: typeof JournalStore.updateRun;
+  finishRun: typeof JournalStore.finishRun;
+}
+
+/** Static `meta` extracted from a workflow script. */
+export interface WorkflowMeta {
+  name: string;
+  description: string;
+}
+
+export interface ExecuteWorkflowOptions {
+  /** Stable run id; also the journal/resume key. */
+  runId: string;
+  /** The workflow script source (JS or TS). */
+  scriptSource: string;
+  /** Verbatim run input, exposed to the script as `args`. */
+  args: unknown;
+  /** Resolved capabilities (tools/persona/host fns) — the single consent point. */
+  capabilities: ResolvedCapabilities;
+  /** Engine caps and concurrency knobs. */
+  config: WorkflowsConfig;
+  /** Journal-store functions (injected so tests use a real store + temp DB). */
+  journal: WorkflowJournal;
+  /** Leaf runner (injected so tests pass a fake — no real provider call). */
+  leafRunner: typeof runLeaf;
+  /** Trust/auth context forwarded to every leaf. */
+  trustContext: TrustContext;
+  /** Receives `phase`/`log` progress events from the script. */
+  onProgress?: (event: WorkflowProgressEvent) => void;
+  /** Cooperative cancellation for the whole run. */
+  signal?: AbortSignal;
+}
+
+export interface ExecuteWorkflowResult {
+  status: WorkflowRunStatus;
+  result: unknown;
+  agentsSpawned: number;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+/** Options passed by a script to `agent(...)` / `leaf(...)`. */
+interface LeafCallOptions {
+  schema?: unknown;
+  label?: string;
+  profile?: string;
+  persona?: boolean;
+  phase?: string;
+}
+
+/** Tagged descriptor returned by `leaf(...)` — runs nothing on its own. */
+interface LeafSpec {
+  __workflowSpec: true;
+  prompt: string;
+  opts: LeafCallOptions;
+}
+
+/** Sentinel thrown internally to unwind the script when the agent cap trips. */
+class CapExceededSignal extends Error {
+  constructor() {
+    super("Workflow agent cap exceeded");
+    this.name = "CapExceededSignal";
+  }
+}
+
+/** Sentinel thrown internally to unwind the script on abort. */
+class AbortedSignal extends Error {
+  constructor() {
+    super("Workflow aborted");
+    this.name = "AbortedSignal";
+  }
+}
+
+/**
+ * Prelude evaluated in the VM before the user script. `map` and `pipeline` are
+ * pure script-side helpers over the `parallel` host function — the VM is
+ * single-threaded and a host fn cannot re-enter it mid-asyncify, so these
+ * cannot be host functions. `pipeline` reduces over its stages with one
+ * `parallel` per stage; because each `parallel` fully settles before the next
+ * stage is built, v1 pipelining has a PER-STAGE BARRIER (no cross-stage
+ * streaming). Each helper is wrapped in a getter-free assignment so a script
+ * cannot accidentally shadow it before use.
+ */
+const SCRIPT_PRELUDE = `
+const map = (items, build) => parallel(items.map((it, i) => __toSpec(build(it, i))));
+const pipeline = (items, ...stages) =>
+  stages.reduce(
+    (acc, stage) => parallel(acc.map((it, i) => __toSpec(stage(it, i)))),
+    items,
+  );
+`;
+
+/**
+ * Normalize what a `map`/`pipeline` build callback returns into a leaf spec.
+ * A build callback may return either a {@link LeafSpec} (from calling
+ * `leaf(...)` itself, idiomatic) or a bare prompt string (sugar). `parallel`
+ * accepts both, but normalizing here keeps the spec array uniform.
+ */
+const SCRIPT_PRELUDE_HELPERS = `
+const __toSpec = (v) =>
+  (v && typeof v === "object" && v.__workflowSpec === true) ? v : leaf(v);
+`;
+
+/**
+ * Strip leading `export` keywords from top-level declarations. The sandbox runs
+ * the script inside a synchronous function body where a top-level `export` is a
+ * syntax error; an authored `export const meta = ...` (and any other top-level
+ * `export const/let/var/function/class`) must become a plain local. Only matches
+ * `export` at the start of a line (after optional indentation), so the word
+ * "export" inside a string or expression is untouched.
+ */
+function stripTopLevelExports(scriptSource: string): string {
+  return scriptSource.replace(
+    /^(\s*)export\s+(const|let|var|function|class|async\s+function)\b/gm,
+    "$1$2",
+  );
+}
+
+/** Stable, sorted-key JSON stringify so hashes are insertion-order-independent. */
+function deterministicStringify(value: unknown): string {
+  return JSON.stringify(sortValue(value)) ?? "null";
+}
+
+function sortValue(value: unknown): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map(sortValue);
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+    out[key] = sortValue((value as Record<string, unknown>)[key]);
+  }
+  return out;
+}
+
+function callHashOf(prompt: string, opts: LeafCallOptions): string {
+  return createHash("sha256")
+    .update(deterministicStringify({ prompt, opts }))
+    .digest("hex");
+}
+
+/**
+ * Extract the pure-literal `export const meta = { name, description }` from a
+ * script. Rejects a computed/missing meta. The literal is parsed via
+ * {@link JSON.parse} after light normalization — NOT `eval`/`Function` — so an
+ * author cannot run code in the host process at extraction time (the script
+ * source is untrusted; only the QuickJS sandbox may execute it). Anything that
+ * isn't a plain `{ "name": "...", "description": "..." }` literal (template
+ * strings, identifiers, function calls) fails to JSON-parse and is rejected.
+ */
+export function extractWorkflowMeta(scriptSource: string): WorkflowMeta {
+  const match = scriptSource.match(
+    /export\s+const\s+meta\s*=\s*(\{[\s\S]*?\})\s*;?/,
+  );
+  if (!match) {
+    throw new WorkflowScriptError(
+      "Workflow script must begin with a literal `export const meta = { name, description }`.",
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(literalToJson(match[1]!));
+  } catch {
+    throw new WorkflowScriptError(
+      "Workflow script `meta` must be a plain object literal with string " +
+        "`name` and `description` (no computed values, template strings, or calls).",
+    );
+  }
+
+  if (
+    !parsed ||
+    typeof parsed !== "object" ||
+    typeof (parsed as Record<string, unknown>).name !== "string" ||
+    typeof (parsed as Record<string, unknown>).description !== "string"
+  ) {
+    throw new WorkflowScriptError(
+      "Workflow script `meta` must have string `name` and `description` fields.",
+    );
+  }
+  const m = parsed as Record<string, unknown>;
+  return { name: m.name as string, description: m.description as string };
+}
+
+/**
+ * Normalize a restricted JS object literal into strict JSON without executing
+ * it: convert single-quoted strings to double-quoted, quote bare identifier
+ * keys, and drop a trailing comma. Any construct outside this grammar (a call,
+ * a template literal, an identifier value) survives normalization as invalid
+ * JSON and makes the subsequent `JSON.parse` throw — which is the rejection
+ * path. This is a deliberately narrow normalizer, not a JS parser.
+ */
+function literalToJson(literal: string): string {
+  return literal
+    .replace(/'((?:[^'\\]|\\.)*)'/g, (_m, body: string) => {
+      // Re-encode the unescaped string body as a JSON string literal.
+      return JSON.stringify(body.replace(/\\'/g, "'"));
+    })
+    .replace(/([{,]\s*)([A-Za-z_$][\w$]*)\s*:/g, '$1"$2":')
+    .replace(/,(\s*})/g, "$1");
+}
+
+/**
+ * Run a workflow script and fan it out to parallel leaf agents, with journaled
+ * resume and an agent cap. See the module doc for the host API and invariants.
+ */
+export async function executeWorkflow(
+  opts: ExecuteWorkflowOptions,
+): Promise<ExecuteWorkflowResult> {
+  const {
+    runId,
+    scriptSource,
+    args,
+    capabilities,
+    config,
+    journal,
+    leafRunner,
+    trustContext,
+    onProgress,
+    signal,
+  } = opts;
+
+  const meta = extractWorkflowMeta(scriptSource);
+  const scriptHash = createHash("sha256").update(scriptSource).digest("hex");
+
+  // Idempotent run row: createRun on first execution, reuse on resume.
+  const existing = journal.getRun(runId);
+  if (!existing) {
+    journal.createRun({
+      id: runId,
+      name: meta.name,
+      scriptSource,
+      scriptHash,
+      args,
+      capabilities,
+      status: "running",
+    });
+  } else {
+    // Re-running: re-open the row as running and reset terminal fields.
+    journal.updateRun(runId, { status: "running" });
+  }
+
+  // --- Run-scoped mutable accounting ---------------------------------------
+  let nextSeq = 0;
+  let agentsSpawned = 0;
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let capExceeded = false;
+
+  /** Persist live counters so `getRun` reports them mid-flight. */
+  const flushCounters = (): void => {
+    journal.updateRun(runId, { agentsSpawned, inputTokens, outputTokens });
+  };
+
+  /**
+   * Run (or replay) a single leaf at a pre-assigned `seq`. Returns the leaf
+   * output. On the agent cap or an abort, throws the corresponding sentinel to
+   * unwind the whole script. A leaf-runner failure does NOT throw here — the
+   * caller (`agent`/`parallel`) decides whether to surface or null it.
+   */
+  const runLeafAtSeq = async (
+    seq: number,
+    prompt: string,
+    leafOpts: LeafCallOptions,
+  ): Promise<{ output: unknown; failed: boolean }> => {
+    if (signal?.aborted) throw new AbortedSignal();
+
+    const hash = callHashOf(prompt, leafOpts);
+
+    // Resume: replay a cached entry whose hash matches. Failures are journaled
+    // with status "failed", so they are re-run rather than replayed as a hit.
+    const cached = journal.getJournalEntry(runId, seq);
+    if (cached && cached.callHash === hash && cached.status === "completed") {
+      return { output: cached.result, failed: false };
+    }
+
+    // Agent cap: trip BEFORE launching, abort the whole run.
+    if (agentsSpawned >= config.maxAgentsPerRun) {
+      capExceeded = true;
+      throw new CapExceededSignal();
+    }
+    agentsSpawned += 1;
+
+    try {
+      const result = await leafRunner({
+        prompt,
+        ...(leafOpts.label !== undefined ? { label: leafOpts.label } : {}),
+        ...(leafOpts.schema !== undefined
+          ? { schema: leafOpts.schema as never }
+          : {}),
+        ...(leafOpts.profile !== undefined
+          ? { profile: leafOpts.profile }
+          : {}),
+        tools: capabilities.tools,
+        trustContext,
+        ...(signal ? { signal } : {}),
+      });
+      inputTokens += result.inputTokens;
+      outputTokens += result.outputTokens;
+      flushCounters();
+      journal.appendJournalEntry({
+        runId,
+        seq,
+        callHash: hash,
+        kind: "agent",
+        request: { prompt, opts: leafOpts },
+        result: result.output,
+        status: "completed",
+      });
+      return { output: result.output, failed: false };
+    } catch (err) {
+      // A leaf failure is journaled as failed (so it is NOT replayed as a hit)
+      // and surfaced to the caller, which decides to null or rethrow it.
+      journal.appendJournalEntry({
+        runId,
+        seq,
+        callHash: hash,
+        kind: "agent",
+        request: { prompt, opts: leafOpts },
+        result: { error: err instanceof Error ? err.message : String(err) },
+        status: "failed",
+      });
+      log.warn(
+        { err, runId, seq, label: leafOpts.label },
+        "Workflow leaf failed",
+      );
+      return { output: null, failed: true };
+    }
+  };
+
+  // --- Host functions ------------------------------------------------------
+  // `agent` runs one sequential leaf and surfaces failures (throws into the
+  // script). `parallel` is the fan-out primitive: it null-coalesces failures.
+
+  const hostAgent = async (
+    promptArg: unknown,
+    optsArg?: unknown,
+  ): Promise<unknown> => {
+    const prompt = String(promptArg);
+    const leafOpts = normalizeLeafOpts(optsArg);
+    const seq = nextSeq++;
+    const { output, failed } = await runLeafAtSeq(seq, prompt, leafOpts);
+    if (failed) {
+      throw new WorkflowScriptError(
+        `Workflow agent leaf${leafOpts.label ? ` "${leafOpts.label}"` : ""} failed.`,
+      );
+    }
+    return output;
+  };
+
+  const hostLeaf = (promptArg: unknown, optsArg?: unknown): LeafSpec => ({
+    __workflowSpec: true,
+    prompt: String(promptArg),
+    opts: normalizeLeafOpts(optsArg),
+  });
+
+  const hostParallel = async (specsArg: unknown): Promise<unknown[]> => {
+    const specs = toSpecArray(specsArg);
+    // Assign seqs in array order BEFORE launching concurrency, so completion
+    // order cannot perturb the deterministic seq mapping.
+    const assigned = specs.map((spec) => ({ spec, seq: nextSeq++ }));
+    return runWithConcurrency(
+      assigned,
+      config.maxConcurrentLeaves,
+      async ({ spec, seq }) => {
+        const { output } = await runLeafAtSeq(seq, spec.prompt, spec.opts);
+        // `parallel` never throws on a single leaf failure — it yields null.
+        return output;
+      },
+    );
+  };
+
+  const hostPhase = (titleArg: unknown): void => {
+    onProgress?.({ type: "phase", title: String(titleArg) });
+  };
+  const hostLog = (msgArg: unknown): void => {
+    onProgress?.({ type: "log", message: String(msgArg) });
+  };
+  const hostUsage = (): {
+    agentsSpawned: number;
+    inputTokens: number;
+    outputTokens: number;
+  } => ({ agentsSpawned, inputTokens, outputTokens });
+
+  // Always-available host functions.
+  const hostFunctions: Record<
+    string,
+    (...a: unknown[]) => unknown | Promise<unknown>
+  > = {
+    agent: (p, o) => hostAgent(p, o),
+    leaf: (p, o) => hostLeaf(p, o),
+    parallel: (s) => hostParallel(s),
+    phase: (t) => hostPhase(t),
+    log: (m) => hostLog(m),
+    usage: () => hostUsage(),
+  };
+
+  // Manifest-declared host functions are injected by name as no-op-safe stubs
+  // only when explicitly granted. (Their concrete impls are bound by later PRs;
+  // here we expose the names so an undeclared call is a ReferenceError and a
+  // declared-but-unbound call fails loudly rather than silently.)
+  for (const name of capabilities.hostFunctions) {
+    if (name in hostFunctions) continue;
+    hostFunctions[name] = () => {
+      throw new WorkflowScriptError(
+        `Host function "${name}" is declared but not bound in this engine build.`,
+      );
+    };
+  }
+
+  // The prelude defines `map`/`pipeline` over `parallel`; prepend it so the
+  // user script can call them. The sandbox runs the script as a SYNCHRONOUS
+  // function body, where a top-level `export` is a syntax error — strip the
+  // `export` keyword(s) so `export const meta = ...` becomes a plain local.
+  const fullScript = `${SCRIPT_PRELUDE_HELPERS}${SCRIPT_PRELUDE}\n${stripTopLevelExports(scriptSource)}`;
+
+  const sandbox = createWorkflowSandbox({
+    hostFunctions,
+    ...(onProgress
+      ? { onLog: (m) => onProgress({ type: "log", message: m }) }
+      : {}),
+    ...(signal ? { signal } : {}),
+  });
+
+  let status: WorkflowRunStatus;
+  let result: unknown = null;
+
+  try {
+    result = await sandbox.run(fullScript, args);
+    status = "completed";
+  } catch (err) {
+    if (capExceeded || err instanceof CapExceededSignal) {
+      status = "cap_exceeded";
+    } else if (signal?.aborted || err instanceof AbortedSignal) {
+      status = "aborted";
+    } else {
+      status = "failed";
+    }
+    if (status === "failed") {
+      log.warn({ err, runId }, "Workflow run failed");
+    }
+  }
+
+  flushCounters();
+  journal.finishRun(runId, {
+    status,
+    result: status === "completed" ? result : null,
+    error:
+      status === "failed"
+        ? "Workflow script error"
+        : status === "cap_exceeded"
+          ? `Agent cap of ${config.maxAgentsPerRun} exceeded`
+          : null,
+  });
+
+  return {
+    status,
+    result: status === "completed" ? result : null,
+    agentsSpawned,
+    inputTokens,
+    outputTokens,
+  };
+}
+
+function normalizeLeafOpts(optsArg: unknown): LeafCallOptions {
+  if (!optsArg || typeof optsArg !== "object") return {};
+  const o = optsArg as Record<string, unknown>;
+  const out: LeafCallOptions = {};
+  if (o.schema !== undefined) out.schema = o.schema;
+  if (typeof o.label === "string") out.label = o.label;
+  if (typeof o.profile === "string") out.profile = o.profile;
+  if (typeof o.persona === "boolean") out.persona = o.persona;
+  if (typeof o.phase === "string") out.phase = o.phase;
+  return out;
+}
+
+function toSpecArray(specsArg: unknown): LeafSpec[] {
+  if (!Array.isArray(specsArg)) {
+    throw new WorkflowScriptError(
+      "parallel(specs) requires an array of leaf specs.",
+    );
+  }
+  return specsArg.map((spec, i) => {
+    if (
+      spec &&
+      typeof spec === "object" &&
+      (spec as Record<string, unknown>).__workflowSpec === true
+    ) {
+      return spec as LeafSpec;
+    }
+    // Sugar: a bare string is treated as a prompt-only spec.
+    if (typeof spec === "string") {
+      return { __workflowSpec: true, prompt: spec, opts: {} };
+    }
+    throw new WorkflowScriptError(
+      `parallel(specs)[${i}] must be a leaf(...) spec or a prompt string.`,
+    );
+  });
+}
+
+/**
+ * Run `tasks` with at most `limit` in flight, preserving INPUT ORDER in the
+ * returned results array. A simple index-cursor worker pool: each worker pulls
+ * the next index, runs it, and writes the result back at that index.
+ */
+async function runWithConcurrency<T, R>(
+  tasks: T[],
+  limit: number,
+  run: (task: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(tasks.length);
+  let cursor = 0;
+  const width = Math.max(1, Math.min(limit, tasks.length || 1));
+
+  const worker = async (): Promise<void> => {
+    for (;;) {
+      const index = cursor++;
+      if (index >= tasks.length) return;
+      results[index] = await run(tasks[index]!);
+    }
+  };
+
+  await Promise.all(Array.from({ length: width }, () => worker()));
+  return results;
+}


### PR DESCRIPTION
## Summary
- Add executeWorkflow: synchronous-script host API (agent/leaf/parallel/map/pipeline/phase/log/usage), journaled resume, agent cap, concurrency cap.

Part of plan: workflow-engine.md (PR 8 of 17)