### PR TITLE
feat(workflows): workflow run manager with progress events

### DIFF
--- a/assistant/src/daemon/message-protocol.ts
+++ b/assistant/src/daemon/message-protocol.ts
@@ -46,6 +46,7 @@ export * from "./message-types/sync.js";
 export * from "./message-types/upgrades.js";
 export * from "./message-types/web-activity.js";
 export * from "./message-types/work-items.js";
+export * from "./message-types/workflows.js";
 export * from "./message-types/workspace.js";
 
 // Import domain-level union aliases for composition
@@ -135,6 +136,7 @@ import type {
   _WorkItemsClientMessages,
   _WorkItemsServerMessages,
 } from "./message-types/work-items.js";
+import type { _WorkflowsServerMessages } from "./message-types/workflows.js";
 import type {
   _WorkspaceClientMessages,
   _WorkspaceServerMessages,
@@ -208,6 +210,7 @@ export type ServerMessage =
   | _UpgradesServerMessages
   | _AcpServerMessages
   | _BookmarksServerMessages
+  | _WorkflowsServerMessages
   | DiskPressureStatusChangedEvent
   | SubagentEvent;
 

--- a/assistant/src/daemon/message-types/workflows.ts
+++ b/assistant/src/daemon/message-types/workflows.ts
@@ -1,0 +1,49 @@
+// Workflow orchestration run lifecycle events.
+//
+// Emitted by the `WorkflowRunManager` (run-manager.ts) as a workflow run
+// progresses and completes. These are server → client push events only — the
+// run is launched via the workflow tool / scheduler / routes (later PRs), not
+// via a client message in this union.
+
+import type { WorkflowRunStatus } from "../../workflows/journal-store.js";
+
+// === Server → Client ===
+
+/**
+ * Progress push for an in-flight workflow run. Maps the engine's
+ * `onProgress` (`phase`/`log`) callback plus the current usage snapshot into a
+ * single wire event. `phase` carries the latest `phase(title)`; `message`
+ * carries the latest `log(msg)`; only one is set per emission.
+ */
+export interface WorkflowProgress {
+  type: "workflow_progress";
+  runId: string;
+  /** Latest phase title, when this emission came from a `phase(...)` call. */
+  phase?: string;
+  /** Run label (the workflow's `meta.name`), for client display. */
+  label?: string;
+  /** Live agent count at emission time. */
+  agentsSpawned: number;
+  /** Latest log line, when this emission came from a `log(...)` call. */
+  message?: string;
+}
+
+/**
+ * Terminal push for a workflow run. Carries the final status, counts, token
+ * usage, and a human-readable result/error summary the originating
+ * conversation also receives via an agent wake.
+ */
+export interface WorkflowCompleted {
+  type: "workflow_completed";
+  runId: string;
+  status: WorkflowRunStatus;
+  agentsSpawned: number;
+  inputTokens: number;
+  outputTokens: number;
+  /** Human-readable result-or-error summary. */
+  summary?: string;
+}
+
+// --- Domain-level union aliases (consumed by the barrel file) ---
+
+export type _WorkflowsServerMessages = WorkflowProgress | WorkflowCompleted;

--- a/assistant/src/workflows/run-manager.test.ts
+++ b/assistant/src/workflows/run-manager.test.ts
@@ -1,0 +1,405 @@
+import { describe, expect, mock, test } from "bun:test";
+
+// Silence the logger.
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import type { AssistantConfig } from "../config/schema.js";
+import type { TrustContext } from "../daemon/trust-context.js";
+import type { ExecuteWorkflowOptions } from "./engine.js";
+import type {
+  CreateRunInput,
+  WorkflowRun,
+  WorkflowRunStatus,
+} from "./journal-store.js";
+import {
+  WorkflowRunCapError,
+  WorkflowRunManager,
+  type WorkflowRunManagerDeps,
+  WorkflowsDisabledError,
+} from "./run-manager.js";
+
+const TRUST: TrustContext = {
+  sourceChannel: "vellum",
+  trustClass: "guardian",
+};
+
+/** Minimal config exposing only the fields the manager reads. */
+function makeConfig(maxConcurrentRuns = 3): AssistantConfig {
+  return {
+    workflows: {
+      maxAgentsPerRun: 500,
+      maxConcurrentLeaves: 6,
+      maxConcurrentRuns,
+      journalRetentionDays: 30,
+    },
+  } as unknown as AssistantConfig;
+}
+
+/**
+ * In-memory journal store standing in for `./journal-store.js`. Implements only
+ * the surface the manager touches (`createRun`, `getRun`, `listRuns`) plus the
+ * engine's surface (unused here since we also fake the engine).
+ */
+function makeFakeJournal() {
+  const rows = new Map<string, WorkflowRun>();
+  const setStats = (id: string, patch: Partial<WorkflowRun>): void => {
+    const existing = rows.get(id);
+    if (existing) rows.set(id, { ...existing, ...patch });
+  };
+  return {
+    rows,
+    setStats,
+    journal: {
+      createRun: (input: CreateRunInput): WorkflowRun => {
+        const run: WorkflowRun = {
+          id: input.id,
+          name: input.name ?? null,
+          scriptSource: input.scriptSource,
+          scriptHash: input.scriptHash,
+          args: input.args ?? null,
+          capabilities: input.capabilities ?? null,
+          status: input.status ?? "running",
+          conversationId: input.conversationId ?? null,
+          agentsSpawned: 0,
+          inputTokens: 0,
+          outputTokens: 0,
+          result: null,
+          error: null,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+          finishedAt: null,
+        };
+        rows.set(input.id, run);
+        return run;
+      },
+      getRun: (id: string): WorkflowRun | null => rows.get(id) ?? null,
+      listRuns: ({
+        limit,
+        status,
+      }: {
+        limit: number;
+        status?: WorkflowRunStatus;
+      }): WorkflowRun[] => {
+        const all = [...rows.values()].sort(
+          (a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0),
+        );
+        return (status ? all.filter((r) => r.status === status) : all).slice(
+          0,
+          limit,
+        );
+      },
+    } as unknown as WorkflowRunManagerDeps["journal"],
+  };
+}
+
+interface ManagerHarness {
+  manager: WorkflowRunManager;
+  executeCalls: ExecuteWorkflowOptions[];
+  broadcasts: Array<{ type: string; [k: string]: unknown }>;
+  wakes: Array<{ conversationId: string; hint: string; source: string }>;
+  fake: ReturnType<typeof makeFakeJournal>;
+  /** Resolve the latest in-flight engine run with a given result. */
+  resolveLatest: (result: EngineResult) => Promise<void>;
+}
+
+interface EngineResult {
+  status: WorkflowRunStatus;
+  result: unknown;
+  agentsSpawned: number;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+/**
+ * Build a manager with a fully-injected, provider-free seam: a fake engine that
+ * surfaces a resolver hook (so a test can drive progress/abort/completion
+ * deterministically), an in-memory journal, and spies for broadcast + wake.
+ */
+function makeHarness(opts?: {
+  flagEnabled?: boolean;
+  maxConcurrentRuns?: number;
+  /** Custom engine impl; defaults to the deferred-resolver fake. */
+  engine?: WorkflowRunManagerDeps["executeWorkflow"];
+}): ManagerHarness {
+  const fake = makeFakeJournal();
+  const executeCalls: ExecuteWorkflowOptions[] = [];
+  const broadcasts: ManagerHarness["broadcasts"] = [];
+  const wakes: ManagerHarness["wakes"] = [];
+
+  // Deferred-resolution engine: capture each invocation and let the test settle
+  // it. Tracks the resolver so `resolveLatest` can fire completion on demand.
+  const resolvers: Array<(r: EngineResult) => void> = [];
+  const defaultEngine: WorkflowRunManagerDeps["executeWorkflow"] = (
+    options,
+  ) => {
+    executeCalls.push(options);
+    // Reflect the engine's count-flushing so `getRun` mirrors mid-flight state.
+    return new Promise<EngineResult>((resolve) => {
+      resolvers.push((r) => {
+        fake.setStats(options.runId, {
+          status: r.status,
+          agentsSpawned: r.agentsSpawned,
+          inputTokens: r.inputTokens,
+          outputTokens: r.outputTokens,
+          result: r.status === "completed" ? r.result : null,
+          error:
+            r.status === "completed"
+              ? null
+              : `Workflow ended with status ${r.status}`,
+          finishedAt: Date.now(),
+        });
+        resolve(r);
+      });
+    }) as ReturnType<WorkflowRunManagerDeps["executeWorkflow"]>;
+  };
+
+  const deps: Partial<WorkflowRunManagerDeps> = {
+    executeWorkflow: opts?.engine ?? defaultEngine,
+    leafRunner: (() => {
+      throw new Error("leafRunner must not be called in run-manager tests");
+    }) as unknown as WorkflowRunManagerDeps["leafRunner"],
+    journal: fake.journal,
+    getConfig: () => makeConfig(opts?.maxConcurrentRuns),
+    isFlagEnabled: () => opts?.flagEnabled ?? true,
+    wake: (async (wakeOpts) => {
+      wakes.push({
+        conversationId: wakeOpts.conversationId,
+        hint: wakeOpts.hint,
+        source: wakeOpts.source,
+      });
+      return { invoked: true, producedToolCalls: false };
+    }) as WorkflowRunManagerDeps["wake"],
+    broadcast: ((msg) => {
+      broadcasts.push(msg as { type: string });
+    }) as WorkflowRunManagerDeps["broadcast"],
+    newRunId: (() => {
+      let n = 0;
+      return () => `run-${++n}`;
+    })(),
+  };
+
+  const manager = new WorkflowRunManager(deps);
+
+  return {
+    manager,
+    executeCalls,
+    broadcasts,
+    wakes,
+    fake,
+    resolveLatest: async (result) => {
+      const resolve = resolvers[resolvers.length - 1];
+      if (!resolve) throw new Error("no in-flight engine run to resolve");
+      resolve(result);
+      // Let the manager's post-completion microtasks (broadcast + wake) settle.
+      await new Promise((r) => setTimeout(r, 0));
+    },
+  };
+}
+
+describe("WorkflowRunManager.start — flag gate", () => {
+  test("flag off → start throws and the engine is never invoked", () => {
+    const h = makeHarness({ flagEnabled: false });
+    expect(() =>
+      h.manager.start({
+        scriptSource: "export const meta = { name: 'x', description: 'y' }",
+        args: {},
+        manifest: { tools: [], hostFunctions: [], persona: false },
+        trustContext: TRUST,
+      }),
+    ).toThrow(WorkflowsDisabledError);
+    expect(h.executeCalls).toHaveLength(0);
+    expect(h.fake.rows.size).toBe(0);
+  });
+});
+
+describe("WorkflowRunManager.start — concurrent-run cap", () => {
+  test("the (N+1)th concurrent start is rejected", () => {
+    const h = makeHarness({ maxConcurrentRuns: 2 });
+    const startOne = () =>
+      h.manager.start({
+        scriptSource: "export const meta = { name: 'x', description: 'y' }",
+        args: {},
+        manifest: { tools: [], hostFunctions: [], persona: false },
+        trustContext: TRUST,
+      });
+
+    startOne();
+    startOne();
+    expect(h.manager.inflightCount()).toBe(2);
+    expect(() => startOne()).toThrow(WorkflowRunCapError);
+    // The rejected start created no extra run row.
+    expect(h.fake.rows.size).toBe(2);
+  });
+
+  test("a finished run frees a cap slot", async () => {
+    const h = makeHarness({ maxConcurrentRuns: 1 });
+    const start = () =>
+      h.manager.start({
+        scriptSource: "export const meta = { name: 'x', description: 'y' }",
+        args: {},
+        manifest: { tools: [], hostFunctions: [], persona: false },
+        trustContext: TRUST,
+      });
+
+    start();
+    expect(() => start()).toThrow(WorkflowRunCapError);
+
+    await h.resolveLatest({
+      status: "completed",
+      result: "ok",
+      agentsSpawned: 1,
+      inputTokens: 10,
+      outputTokens: 5,
+    });
+
+    expect(h.manager.inflightCount()).toBe(0);
+    // Slot freed: a second run now starts without throwing.
+    expect(() => start()).not.toThrow();
+  });
+});
+
+describe("WorkflowRunManager.abort", () => {
+  test("abort signals the engine's AbortController", () => {
+    const h = makeHarness();
+    const { runId } = h.manager.start({
+      scriptSource: "export const meta = { name: 'x', description: 'y' }",
+      args: {},
+      manifest: { tools: [], hostFunctions: [], persona: false },
+      trustContext: TRUST,
+    });
+
+    const passedSignal = h.executeCalls[0]!.signal!;
+    expect(passedSignal.aborted).toBe(false);
+    h.manager.abort(runId);
+    expect(passedSignal.aborted).toBe(true);
+  });
+
+  test("an aborted run resolves with status 'aborted' and persists it", async () => {
+    const h = makeHarness();
+    const { runId } = h.manager.start({
+      scriptSource: "export const meta = { name: 'x', description: 'y' }",
+      args: {},
+      manifest: { tools: [], hostFunctions: [], persona: false },
+      trustContext: TRUST,
+    });
+
+    h.manager.abort(runId);
+    // The (faked) engine observes the abort and reports the terminal status.
+    await h.resolveLatest({
+      status: "aborted",
+      result: null,
+      agentsSpawned: 2,
+      inputTokens: 0,
+      outputTokens: 0,
+    });
+
+    expect(h.manager.status(runId)?.status).toBe("aborted");
+    const completed = h.broadcasts.find((b) => b.type === "workflow_completed");
+    expect(completed?.status).toBe("aborted");
+  });
+});
+
+describe("WorkflowRunManager — progress events", () => {
+  test("onProgress phase/log are republished as workflow_progress", async () => {
+    const h = makeHarness();
+    h.manager.start({
+      scriptSource: "export const meta = { name: 'x', description: 'y' }",
+      args: {},
+      manifest: { tools: [], hostFunctions: [], persona: false },
+      label: "My Flow",
+      trustContext: TRUST,
+    });
+
+    const onProgress = h.executeCalls[0]!.onProgress!;
+    onProgress({ type: "phase", title: "Gathering" });
+    onProgress({ type: "log", message: "step done" });
+
+    const progress = h.broadcasts.filter((b) => b.type === "workflow_progress");
+    expect(progress).toHaveLength(2);
+    expect(progress[0]).toMatchObject({
+      type: "workflow_progress",
+      label: "My Flow",
+      phase: "Gathering",
+    });
+    expect(progress[1]).toMatchObject({
+      type: "workflow_progress",
+      message: "step done",
+    });
+  });
+});
+
+describe("WorkflowRunManager — completion", () => {
+  test("completion publishes workflow_completed and injects into the conversation", async () => {
+    const h = makeHarness();
+    const { runId } = h.manager.start({
+      scriptSource: "export const meta = { name: 'x', description: 'y' }",
+      args: {},
+      manifest: { tools: [], hostFunctions: [], persona: false },
+      conversationId: "conv-1",
+      label: "Digest",
+      trustContext: TRUST,
+    });
+
+    await h.resolveLatest({
+      status: "completed",
+      result: { summary: "all good" },
+      agentsSpawned: 4,
+      inputTokens: 100,
+      outputTokens: 50,
+    });
+
+    const completed = h.broadcasts.find((b) => b.type === "workflow_completed");
+    expect(completed).toMatchObject({
+      type: "workflow_completed",
+      runId,
+      status: "completed",
+      agentsSpawned: 4,
+      inputTokens: 100,
+      outputTokens: 50,
+    });
+    expect(typeof completed?.summary).toBe("string");
+
+    // Completion summary surfaced to the originating conversation via a wake.
+    expect(h.wakes).toHaveLength(1);
+    expect(h.wakes[0]).toMatchObject({
+      conversationId: "conv-1",
+      source: "workflow_completed",
+    });
+    expect(h.wakes[0]!.hint).toContain("completed");
+
+    // Final stats persisted to the run row.
+    const run = h.manager.status(runId);
+    expect(run?.status).toBe("completed");
+    expect(run?.agentsSpawned).toBe(4);
+    expect(run?.inputTokens).toBe(100);
+    expect(run?.outputTokens).toBe(50);
+  });
+
+  test("no conversationId → completion events fire but no wake", async () => {
+    const h = makeHarness();
+    h.manager.start({
+      scriptSource: "export const meta = { name: 'x', description: 'y' }",
+      args: {},
+      manifest: { tools: [], hostFunctions: [], persona: false },
+      trustContext: TRUST,
+    });
+
+    await h.resolveLatest({
+      status: "completed",
+      result: "x",
+      agentsSpawned: 1,
+      inputTokens: 1,
+      outputTokens: 1,
+    });
+
+    expect(h.broadcasts.some((b) => b.type === "workflow_completed")).toBe(
+      true,
+    );
+    expect(h.wakes).toHaveLength(0);
+  });
+});

--- a/assistant/src/workflows/run-manager.ts
+++ b/assistant/src/workflows/run-manager.ts
@@ -1,0 +1,354 @@
+/**
+ * Lifecycle layer for the workflow orchestration engine.
+ *
+ * The {@link WorkflowRunManager} is the surface the workflow tool, scheduler,
+ * and routes (later PRs) drive. It owns everything the raw {@link executeWorkflow}
+ * engine deliberately does NOT:
+ *
+ *  - **Feature-flag gate.** `start` hard-fails with {@link WorkflowsDisabledError}
+ *    when the `workflows` flag is off, BEFORE any engine code path is reachable.
+ *  - **Concurrent-run cap.** At most `config.workflows.maxConcurrentRuns` runs
+ *    may be in flight; the (N+1)th `start` throws {@link WorkflowRunCapError}.
+ *  - **Async launch.** `start` resolves capabilities, creates the journal run
+ *    row, kicks off {@link executeWorkflow} WITHOUT awaiting it, and returns the
+ *    `runId` immediately. Progress and completion are surfaced out-of-band.
+ *  - **Progress + completion events.** The engine's `onProgress` callback is
+ *    republished as `workflow_progress` server messages; on completion a
+ *    `workflow_completed` message is published. Both go through the shared
+ *    `broadcastMessage` / event hub.
+ *  - **Completion injection.** On completion, a human-readable summary is
+ *    surfaced back into the originating conversation via
+ *    {@link wakeAgentForOpportunity} — the same mechanism scheduled tasks and
+ *    background shell jobs use to report finished background work to a
+ *    conversation.
+ *
+ * `status` and `list` are thin reads over the journal store (the engine flushes
+ * live counts to the run row, so `getRun` is the single source of truth).
+ */
+
+import { createHash, randomUUID } from "node:crypto";
+
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import { getConfig } from "../config/loader.js";
+import type { AssistantConfig } from "../config/schema.js";
+import type { TrustContext } from "../daemon/trust-context.js";
+import { wakeAgentForOpportunity } from "../runtime/agent-wake.js";
+import { broadcastMessage } from "../runtime/assistant-event-hub.js";
+import { getLogger } from "../util/logger.js";
+import type { CapabilityManifest } from "./capabilities.js";
+import { resolveCapabilities } from "./capabilities.js";
+import { executeWorkflow, extractWorkflowMeta } from "./engine.js";
+import type { WorkflowRun } from "./journal-store.js";
+import * as journalStore from "./journal-store.js";
+import { runLeaf } from "./leaf-runner.js";
+
+const log = getLogger("workflow-run-manager");
+
+/** Source tag for the completion wake (shows up in the wake's structured log). */
+const WORKFLOW_WAKE_SOURCE = "workflow_completed";
+
+/** Thrown by `start` when the `workflows` feature flag is disabled. */
+export class WorkflowsDisabledError extends Error {
+  readonly code = "workflows_disabled" as const;
+  constructor() {
+    super("Workflows are not enabled.");
+    this.name = "WorkflowsDisabledError";
+  }
+}
+
+/** Thrown by `start` when the concurrent-run cap is already reached. */
+export class WorkflowRunCapError extends Error {
+  readonly code = "workflow_run_cap_exceeded" as const;
+  constructor(readonly limit: number) {
+    super(
+      `Cannot start workflow run: ${limit} run(s) are already in flight ` +
+        `(maxConcurrentRuns).`,
+    );
+    this.name = "WorkflowRunCapError";
+  }
+}
+
+export interface StartWorkflowOptions {
+  /** The workflow script source (JS or TS). */
+  scriptSource: string;
+  /** Verbatim run input, exposed to the script as `args`. */
+  args: unknown;
+  /** Per-run capability declaration (the single consent point). */
+  manifest: CapabilityManifest;
+  /**
+   * Conversation that originated the run; receives the completion summary via
+   * an agent wake. Omit for runs with no originating conversation (e.g. a
+   * scheduled run with no chat surface) — the summary is then events-only.
+   */
+  conversationId?: string;
+  /** Human-readable label for display; defaults to the run id. */
+  label?: string;
+  /** Trust/auth context forwarded to every leaf. */
+  trustContext: TrustContext;
+}
+
+/**
+ * Dependencies injected for testing. Production callers omit this entirely and
+ * rely on the real engine, leaf runner, journal store, config, and wake.
+ */
+export interface WorkflowRunManagerDeps {
+  executeWorkflow: typeof executeWorkflow;
+  leafRunner: typeof runLeaf;
+  journal: typeof journalStore;
+  getConfig: () => AssistantConfig;
+  isFlagEnabled: (config: AssistantConfig) => boolean;
+  wake: typeof wakeAgentForOpportunity;
+  broadcast: typeof broadcastMessage;
+  newRunId: () => string;
+}
+
+function defaultDeps(): WorkflowRunManagerDeps {
+  return {
+    executeWorkflow,
+    leafRunner: runLeaf,
+    journal: journalStore,
+    getConfig,
+    isFlagEnabled: (config) =>
+      isAssistantFeatureFlagEnabled("workflows", config),
+    wake: wakeAgentForOpportunity,
+    broadcast: broadcastMessage,
+    newRunId: () => randomUUID(),
+  };
+}
+
+/**
+ * Owns the lifecycle of workflow runs. One instance per daemon (see
+ * {@link getWorkflowRunManager}); tests construct their own with injected deps.
+ */
+export class WorkflowRunManager {
+  private readonly deps: WorkflowRunManagerDeps;
+  /** runId → AbortController for every currently in-flight run. */
+  private readonly inflight = new Map<string, AbortController>();
+
+  constructor(deps?: Partial<WorkflowRunManagerDeps>) {
+    this.deps = { ...defaultDeps(), ...deps };
+  }
+
+  /**
+   * Launch a workflow run. Gates on the `workflows` flag and the concurrent-run
+   * cap (both throw before any engine code is reachable), resolves capabilities,
+   * creates the journal run row, and kicks off {@link executeWorkflow}
+   * asynchronously. Returns the `runId` immediately — completion is surfaced via
+   * events and a conversation wake.
+   */
+  start(opts: StartWorkflowOptions): { runId: string } {
+    const config = this.deps.getConfig();
+    if (!this.deps.isFlagEnabled(config)) {
+      throw new WorkflowsDisabledError();
+    }
+
+    const limit = config.workflows.maxConcurrentRuns;
+    if (this.inflight.size >= limit) {
+      throw new WorkflowRunCapError(limit);
+    }
+
+    // Resolve capabilities and extract meta BEFORE creating the run row so a
+    // manifest authoring error (unknown/forbidden tool) or a malformed script
+    // `meta` surfaces synchronously to the caller and leaves no orphaned
+    // `running` row behind.
+    const capabilities = resolveCapabilities(opts.manifest);
+    const meta = extractWorkflowMeta(opts.scriptSource);
+
+    const runId = this.deps.newRunId();
+    const label = opts.label ?? meta.name;
+
+    // Create the row up front (so `status`/`list` see it immediately) with the
+    // same name + script hash the engine would compute, so its idempotent
+    // re-open of the existing row is a true no-op rather than a divergent
+    // overwrite.
+    this.deps.journal.createRun({
+      id: runId,
+      name: meta.name,
+      scriptSource: opts.scriptSource,
+      scriptHash: createHash("sha256").update(opts.scriptSource).digest("hex"),
+      args: opts.args,
+      capabilities,
+      status: "running",
+      conversationId: opts.conversationId ?? null,
+    });
+
+    const controller = new AbortController();
+    this.inflight.set(runId, controller);
+
+    // Fire-and-forget: the engine owns its own try/catch and always finishes
+    // the run row. We never await it — `start` must return synchronously.
+    void this.runToCompletion(runId, label, opts, capabilities, controller);
+
+    return { runId };
+  }
+
+  /** Abort an in-flight run by signalling its {@link AbortController}. No-op for unknown/finished runs. */
+  abort(runId: string): void {
+    this.inflight.get(runId)?.abort();
+  }
+
+  /** Read the current run row (live counts + status), or null if unknown. */
+  status(runId: string): WorkflowRun | null {
+    return this.deps.journal.getRun(runId);
+  }
+
+  /** List runs newest-first, optionally filtered by status. */
+  list(options?: {
+    limit?: number;
+    status?: WorkflowRun["status"];
+  }): WorkflowRun[] {
+    return this.deps.journal.listRuns({
+      limit: options?.limit ?? 50,
+      ...(options?.status ? { status: options.status } : {}),
+    });
+  }
+
+  /** Number of currently in-flight runs (for tests / diagnostics). */
+  inflightCount(): number {
+    return this.inflight.size;
+  }
+
+  /**
+   * Drive a single run to completion: stream progress events, await the engine,
+   * publish completion, and inject the summary into the originating
+   * conversation. Always clears the in-flight slot in a finally block so a cap
+   * slot is never leaked even if the engine throws (it shouldn't — it owns its
+   * own error handling — but defense in depth).
+   */
+  private async runToCompletion(
+    runId: string,
+    label: string,
+    opts: StartWorkflowOptions,
+    capabilities: ReturnType<typeof resolveCapabilities>,
+    controller: AbortController,
+  ): Promise<void> {
+    const config = this.deps.getConfig();
+    try {
+      const result = await this.deps.executeWorkflow({
+        runId,
+        scriptSource: opts.scriptSource,
+        args: opts.args,
+        capabilities,
+        config: config.workflows,
+        journal: this.deps.journal,
+        leafRunner: this.deps.leafRunner,
+        trustContext: opts.trustContext,
+        signal: controller.signal,
+        onProgress: (event) => {
+          const run = this.deps.journal.getRun(runId);
+          const agentsSpawned = run?.agentsSpawned ?? 0;
+          this.deps.broadcast({
+            type: "workflow_progress",
+            runId,
+            label,
+            agentsSpawned,
+            ...(event.type === "phase"
+              ? { phase: event.title }
+              : { message: event.message }),
+          });
+        },
+      });
+
+      const summary = buildCompletionSummary(
+        runId,
+        label,
+        result,
+        this.deps.journal.getRun(runId),
+      );
+
+      this.deps.broadcast({
+        type: "workflow_completed",
+        runId,
+        status: result.status,
+        agentsSpawned: result.agentsSpawned,
+        inputTokens: result.inputTokens,
+        outputTokens: result.outputTokens,
+        summary,
+      });
+
+      await this.injectCompletionSummary(opts, summary);
+    } catch (err) {
+      // The engine finishes the run row even on internal errors, so this only
+      // fires for an unexpected throw (e.g. a bug in the manager glue). Log and
+      // move on — the in-flight slot is released in finally.
+      log.error({ err, runId }, "Workflow run manager: run threw unexpectedly");
+    } finally {
+      this.inflight.delete(runId);
+    }
+  }
+
+  /**
+   * Surface the completion summary back into the originating conversation,
+   * REUSING {@link wakeAgentForOpportunity} — the canonical "background job
+   * finished, tell this conversation" path (shared with scheduled tasks and
+   * background shell tools). Best-effort: a wake failure is logged, never
+   * thrown (the run already completed; events already fired).
+   */
+  private async injectCompletionSummary(
+    opts: StartWorkflowOptions,
+    summary: string,
+  ): Promise<void> {
+    if (!opts.conversationId) return;
+    try {
+      await this.deps.wake({
+        conversationId: opts.conversationId,
+        hint: summary,
+        source: WORKFLOW_WAKE_SOURCE,
+        trustContext: opts.trustContext,
+      });
+    } catch (err) {
+      log.warn(
+        { err, conversationId: opts.conversationId },
+        "Workflow run manager: completion wake failed (non-fatal)",
+      );
+    }
+  }
+}
+
+/**
+ * Build the human-readable completion summary injected into the originating
+ * conversation and carried on the `workflow_completed` event. Reports the run's
+ * terminal status, agent/token counts, and a result-or-error tail.
+ */
+function buildCompletionSummary(
+  runId: string,
+  label: string,
+  result: Awaited<ReturnType<typeof executeWorkflow>>,
+  run: WorkflowRun | null,
+): string {
+  const lines = [
+    `[workflow "${label}" ${result.status}]`,
+    `Run ${runId} finished with status: ${result.status}.`,
+    `Agents spawned: ${result.agentsSpawned}. ` +
+      `Tokens: ${result.inputTokens} in / ${result.outputTokens} out.`,
+  ];
+  if (result.status === "completed") {
+    lines.push(`Result: ${stringifyResult(result.result)}`);
+  } else {
+    lines.push(`Outcome: ${run?.error ?? result.status}`);
+  }
+  return lines.join("\n");
+}
+
+/** Compact a workflow result for the summary — JSON for objects, string otherwise. */
+function stringifyResult(value: unknown): string {
+  if (value == null) return "(no result)";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+// ── Process-level singleton ───────────────────────────────────────────────
+
+let _instance: WorkflowRunManager | null = null;
+
+/** Singleton {@link WorkflowRunManager} shared across the daemon. */
+export function getWorkflowRunManager(): WorkflowRunManager {
+  if (!_instance) {
+    _instance = new WorkflowRunManager();
+  }
+  return _instance;
+}


### PR DESCRIPTION
## Summary
- Add WorkflowRunManager: flag-gated start/abort/status/list, concurrent-run cap, async executeWorkflow launch, progress+completion events, completion injection into the originating conversation.

Part of plan: workflow-engine.md (PR 10 of 17)