### PR TITLE
fix(workflows): schema-path marshaling + journal resume upsert

### DIFF
--- a/assistant/src/workflows/engine-integration.test.ts
+++ b/assistant/src/workflows/engine-integration.test.ts
@@ -9,20 +9,24 @@
  * sandbox↔host JSON marshaling, the leaf runner's real agent-loop path, and
  * journal DB round-trips on resume.
  *
- * Leaves run the REAL **tool path**: the engine forwards `capabilities.tools`
+ * Most leaves run the REAL **tool path**: the engine forwards `capabilities.tools`
  * to every leaf, the leaf runner spins up an `AgentLoop`, and the mocked
  * provider returns a single `end_turn` message whose text echoes the prompt
  * (so each leaf's `output` is distinguishable and order-checkable). A leaf with
- * an empty toolset would route to the leaf runner's SCHEMA path, which requires
- * an in-process Zod schema and so cannot be driven from a sandboxed script —
- * see the `test.todo` at the end of this file (a known engine↔leaf-runner gap).
+ * an empty toolset routes to the leaf runner's SCHEMA path; a sandboxed script
+ * passes a JSON Schema object (it can't hold a host-side Zod object), which the
+ * leaf runner duck-types — see the schema-path test below.
  *
  * Covered:
  *  - `map`/`parallel` fan-out: each leaf returns its echoed output, aggregated
  *    in spec-array order through the real sandbox + leaf runner + agent loop.
+ *  - Schema path: a script-provided JSON Schema drives the forced-tool call and
+ *    its validated structured object is returned and journaled.
  *  - In-process resume: re-running the SAME runId against the SAME DB replays
  *    the unchanged prefix from the journal — ZERO duplicate provider calls —
  *    and only the changed/new tail re-runs the provider.
+ *  - Resume journal rewrite: a changed-input leaf re-runs and its journal row is
+ *    upserted (new hash + result) rather than left stale.
  *  - Cap abort: a low `maxAgentsPerRun` aborts with status `cap_exceeded` and
  *    the partial counters are persisted on the run row.
  *  - Concurrency high-water: the provider mock records in-flight concurrency
@@ -77,10 +81,19 @@ function lastUserPrompt(
   return "";
 }
 
+interface SendOptionsFull extends SendOptions {
+  config?: { tool_choice?: { type: string; name: string } };
+}
+
 /**
- * The leaf's real `AgentLoop` calls the provider; we return a single `end_turn`
- * message whose text echoes the prompt, so the loop terminates in one turn and
- * the leaf's `output` is `processed:<prompt>`.
+ * The leaf's real `AgentLoop` (tool path) calls the provider; we return a single
+ * `end_turn` message whose text echoes the prompt, so the loop terminates in one
+ * turn and the leaf's `output` is `processed:<prompt>`.
+ *
+ * The SCHEMA path forces a `tool_choice` on the synthetic `emit_result` tool;
+ * we detect that and instead return a `tool_use` block whose input echoes the
+ * prompt under the schema's `answer` field, so the leaf's structured `output`
+ * is `{ answer: "processed:<prompt>" }`.
  */
 const sendMessage = mock(
   async (
@@ -88,9 +101,14 @@ const sendMessage = mock(
       role: string;
       content: Array<{ type: string; text?: string }>;
     }>,
-    options: SendOptions,
+    options: SendOptionsFull,
   ): Promise<{
-    content: Array<{ type: string; text: string }>;
+    content: Array<{
+      type: string;
+      text?: string;
+      name?: string;
+      input?: unknown;
+    }>;
     model: string;
     usage: { inputTokens: number; outputTokens: number };
     stopReason: string;
@@ -104,6 +122,21 @@ const sendMessage = mock(
       }
       if (options.signal?.aborted) {
         throw new DOMException("Aborted", "AbortError");
+      }
+      const forcedTool = options.config?.tool_choice;
+      if (forcedTool?.type === "tool") {
+        return {
+          content: [
+            {
+              type: "tool_use",
+              name: forcedTool.name,
+              input: { answer: `processed:${lastUserPrompt(messages)}` },
+            },
+          ],
+          model: "test-model",
+          usage: { inputTokens: 7, outputTokens: 3 },
+          stopReason: "tool_use",
+        };
       }
       return {
         content: [
@@ -186,6 +219,17 @@ const capabilities = resolveCapabilities({
   persona: false,
 });
 
+/**
+ * Capabilities with NO tools. A schema leaf must route to the leaf runner's
+ * SCHEMA path, which requires an empty toolset (a schema + tools is a hard
+ * error in `runLeaf`). Used by the schema-path integration test.
+ */
+const schemaCapabilities = resolveCapabilities({
+  tools: [],
+  hostFunctions: [],
+  persona: false,
+});
+
 /** Build a `WorkflowsConfig` from schema defaults with optional overrides. */
 function makeConfig(
   overrides: Partial<{
@@ -200,12 +244,16 @@ function makeConfig(
  * Base options shared by every `executeWorkflow` call: the REAL journal store,
  * the REAL leaf runner, real capabilities, real trust context.
  */
-function baseOptions(runId: string, scriptSource: string) {
+function baseOptions(
+  runId: string,
+  scriptSource: string,
+  caps: typeof capabilities = capabilities,
+) {
   return {
     runId,
     scriptSource,
     args: {},
-    capabilities,
+    capabilities: caps,
     journal: journalStore,
     leafRunner: runLeaf,
     trustContext,
@@ -421,39 +469,103 @@ return { results, tail };
   });
 
   // ---------------------------------------------------------------------------
-  // KNOWN ENGINE↔LEAF-RUNNER GAP (flagged for a follow-up product fix).
+  // FIXED ENGINE↔LEAF-RUNNER GAP (schema-path marshaling).
   //
-  // A workflow script can declare a per-leaf output `schema` via
-  // `leaf(prompt, { schema })`, but that schema crosses the QuickJS sandbox
-  // boundary as a JSON-marshaled plain object. The leaf runner's schema path
-  // (`runSchemaLeaf`) requires an in-process Zod schema — it calls
-  // `z.toJSONSchema(schema)` and `schema.safeParse(...)` — so a marshaled
-  // schema throws `undefined is not an object (evaluating 'schema._zod.def')`
-  // and the leaf fails. The engine needs to reconstruct a Zod schema (e.g. via
-  // `z.fromJSONSchema`) from the marshaled JSON Schema before invoking the leaf
-  // runner. Converted to `test()` once the engine bridges the schema path.
+  // A workflow script declares a per-leaf output `schema` via
+  // `leaf(prompt, { schema })`. That schema crosses the QuickJS sandbox boundary
+  // as a JSON-marshaled plain object (a JSON Schema). The leaf runner's schema
+  // path now duck-types its input: a plain JSON Schema object is used directly as
+  // the forced-tool `input_schema` and validated via `z.fromJSONSchema`, while a
+  // host-side Zod schema keeps the original behavior. A schema leaf must route to
+  // the schema path, which requires an empty toolset (`schemaCapabilities`).
   // ---------------------------------------------------------------------------
-  test.todo(
-    "schema-path leaves: script-provided JSON Schema is reconstructed to Zod before runLeaf",
-    () => {},
-  );
+  test("schema-path leaves: a script-provided JSON Schema drives the forced-tool path", async () => {
+    // The script passes a JSON Schema OBJECT LITERAL (the only shape a sandbox
+    // script can produce — Zod is host-side). It marshals across the boundary
+    // and reaches the leaf runner verbatim.
+    const scriptSource = `
+export const meta = { name: "schema", description: "structured leaf output" };
+const schema = {
+  type: "object",
+  properties: { answer: { type: "string" } },
+  required: ["answer"],
+  additionalProperties: false,
+};
+const items = args.items;
+const results = map(items, (it) => leaf("item-" + it, { schema }));
+return results;
+`;
+    const result = await executeWorkflow({
+      ...baseOptions("wf-schema", scriptSource, schemaCapabilities),
+      args: { items: ["a", "b"] },
+      config: makeConfig(),
+    });
+
+    expect(result.status).toBe("completed");
+    // Each leaf returned the validated structured object (forced-tool path),
+    // NOT the tool-path's plain echoed text.
+    expect(result.result).toEqual([
+      { answer: "processed:item-a" },
+      { answer: "processed:item-b" },
+    ]);
+    expect(result.agentsSpawned).toBe(2);
+    expect(sendCallCount).toBe(2);
+
+    // The journal persisted the structured outputs.
+    const journal = getJournal("wf-schema");
+    expect(journal.map((e) => e.result)).toEqual([
+      { answer: "processed:item-a" },
+      { answer: "processed:item-b" },
+    ]);
+  });
 
   // ---------------------------------------------------------------------------
-  // KNOWN RESUME JOURNAL-STALENESS GAP (flagged for a follow-up product fix).
+  // FIXED RESUME JOURNAL-STALENESS GAP.
   //
-  // On resume, a leaf whose input CHANGED (new `call_hash`) correctly re-runs
-  // and the engine returns the new value. But its journal row is never
-  // rewritten: `journalStore.appendJournalEntry` uses `INSERT OR IGNORE` keyed
-  // on `(run_id, seq)`, so the stale first-run row (old hash, old result)
-  // survives and the persisted journal disagrees with the value the engine
-  // actually returned. The crash-idempotency the `INSERT OR IGNORE` was meant
-  // to provide should be narrowed to genuine duplicate (same-hash) re-appends;
-  // a changed-hash re-run at the same seq must overwrite (e.g. upsert keyed on
-  // `(run_id, seq)`). Converted to `test()` once the journal upserts a changed
-  // seq on resume.
+  // On resume, a leaf whose input CHANGED (new `call_hash`) re-runs and the
+  // engine returns the new value. `appendJournalEntry` now UPSERTs on
+  // `(run_id, seq)`, so the stale first-run row is rewritten with the new hash
+  // and result — the persisted journal agrees with the engine's returned value.
   // ---------------------------------------------------------------------------
-  test.todo(
-    "resume rewrites a changed leaf's journal entry (hash + result) instead of keeping the stale row",
-    () => {},
-  );
+  test("resume rewrites a changed leaf's journal entry (hash + result) instead of keeping the stale row", async () => {
+    const scriptSource = `
+export const meta = { name: "resume-rewrite", description: "sequential agents" };
+const a = agent("step-1");
+const b = agent(args.tail);
+return [a, b];
+`;
+    // First run: 2 fresh leaves.
+    await executeWorkflow({
+      ...baseOptions("wf-resume-rewrite", scriptSource),
+      args: { tail: "step-2" },
+      config: makeConfig(),
+    });
+    const firstJournal = getJournal("wf-resume-rewrite");
+    expect(firstJournal.map((e) => e.seq)).toEqual([0, 1]);
+    const seq1HashBefore = firstJournal[1]!.callHash;
+    expect(firstJournal[1]!.result).toBe("processed:step-2");
+
+    sendCallCount = 0;
+    sendMessage.mockClear();
+
+    // Resume: seq 1's input changes, so it re-runs; seq 0 replays from journal.
+    const second = await executeWorkflow({
+      ...baseOptions("wf-resume-rewrite", scriptSource),
+      args: { tail: "step-2-CHANGED" },
+      config: makeConfig(),
+    });
+    expect(second.status).toBe("completed");
+    expect(sendCallCount).toBe(1);
+
+    // The persisted journal row for seq 1 was REWRITTEN (new hash + result),
+    // agreeing with the value the engine returned — not the stale first-run row.
+    const secondJournal = getJournal("wf-resume-rewrite");
+    expect(secondJournal.map((e) => e.seq)).toEqual([0, 1]);
+    expect(secondJournal[1]!.callHash).not.toBe(seq1HashBefore);
+    expect(secondJournal[1]!.result).toBe("processed:step-2-CHANGED");
+    expect(second.result).toEqual([
+      "processed:step-1",
+      "processed:step-2-CHANGED",
+    ]);
+  });
 });

--- a/assistant/src/workflows/journal-store.test.ts
+++ b/assistant/src/workflows/journal-store.test.ts
@@ -216,6 +216,44 @@ describe("workflow journal store", () => {
     expect(getJournal("wf-dup")).toHaveLength(1);
   });
 
+  test("appendJournalEntry upserts a changed-hash re-run at the same seq", () => {
+    createRun({ id: "wf-resume", scriptSource: "s", scriptHash: "h" });
+
+    // First run: leaf at seq 0 produces one (hash, result).
+    appendJournalEntry({
+      runId: "wf-resume",
+      seq: 0,
+      callHash: "hash-old",
+      kind: "agent",
+      request: { prompt: "old" },
+      result: { text: "old-result" },
+      status: "completed",
+    });
+
+    // Resume: the leaf's input CHANGED, so it re-runs and re-appends a new
+    // (hash, result) at the SAME seq. The stale row must be overwritten.
+    appendJournalEntry({
+      runId: "wf-resume",
+      seq: 0,
+      callHash: "hash-new",
+      kind: "agent",
+      request: { prompt: "new" },
+      result: { text: "new-result" },
+      status: "completed",
+    });
+
+    const journal = getJournal("wf-resume");
+    // Still exactly one row at seq 0 (no duplicate).
+    expect(journal).toHaveLength(1);
+    expect(journal[0]).toMatchObject({
+      seq: 0,
+      callHash: "hash-new",
+      request: { prompt: "new" },
+      result: { text: "new-result" },
+      status: "completed",
+    });
+  });
+
   test("listRuns returns newest-first and honors limit + status filter", () => {
     // created_at is wall-clock; force distinct ordering via direct timestamps.
     createRun({ id: "old", scriptSource: "s", scriptHash: "h" });

--- a/assistant/src/workflows/journal-store.ts
+++ b/assistant/src/workflows/journal-store.ts
@@ -276,18 +276,32 @@ export function finishRun(
 // ---------------------------------------------------------------------------
 
 /**
- * Append a leaf-call entry to a run's journal. Idempotent on `(run_id, seq)`:
- * a replayed append for an existing sequence number is ignored, so a crash
- * between the call and its journal write can't double-insert on resume.
+ * Append a leaf-call entry to a run's journal, upserting on `(run_id, seq)`.
+ *
+ * A genuine duplicate re-append (same hash/result — the crash-recovery case
+ * where a write replays after a crash between the call and its journal write)
+ * is idempotent: the conflicting row is overwritten with identical values.
+ *
+ * On resume, a leaf whose input CHANGED re-runs and produces a new
+ * hash/result/status at the same `seq`; the UPSERT rewrites the stale first-run
+ * row so the persisted journal agrees with the value the engine returned (and
+ * the call doesn't re-run on every future resume). `created_at` is left at its
+ * original value on conflict so the row keeps its first-write timestamp.
  */
 export function appendJournalEntry(
   input: AppendJournalEntryInput,
 ): WorkflowJournalEntry {
   rawRun(
     /*sql*/ `
-    INSERT OR IGNORE INTO workflow_journal (
+    INSERT INTO workflow_journal (
       run_id, seq, call_hash, kind, request_json, result_json, status, created_at
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(run_id, seq) DO UPDATE SET
+      call_hash = excluded.call_hash,
+      kind = excluded.kind,
+      request_json = excluded.request_json,
+      result_json = excluded.result_json,
+      status = excluded.status
     `,
     input.runId,
     input.seq,

--- a/assistant/src/workflows/leaf-runner.test.ts
+++ b/assistant/src/workflows/leaf-runner.test.ts
@@ -220,6 +220,77 @@ describe("runLeaf — schema path", () => {
     expect(countConversations()).toBe(before);
   });
 
+  test("accepts a plain JSON Schema object (sandbox-marshaled) directly", async () => {
+    // A workflow script can't hold a Zod object, so its `schema` reaches
+    // runLeaf as a JSON-marshaled JSON Schema object. The runner duck-types it,
+    // uses it directly as the forced-tool input_schema, and validates the
+    // returned input via z.fromJSONSchema.
+    const jsonSchema = {
+      type: "object",
+      properties: { answer: { type: "string" }, score: { type: "number" } },
+      required: ["answer", "score"],
+      additionalProperties: false,
+    };
+    responseQueue = [
+      {
+        content: [
+          {
+            type: "tool_use",
+            name: "emit_result",
+            id: "tu-json",
+            input: { answer: "yes", score: 7 },
+          },
+        ],
+        model: "test",
+        usage: { inputTokens: 5, outputTokens: 2 },
+        stopReason: "tool_use",
+      },
+    ];
+
+    const result = await runLeaf({
+      prompt: "Answer the question.",
+      schema: jsonSchema,
+      trustContext,
+    });
+
+    expect(result.output).toEqual({ answer: "yes", score: 7 });
+    // The JSON Schema is used verbatim as the synthetic tool's input_schema.
+    const tool = lastSendCall?.options.tools?.[0];
+    expect(tool?.name).toBe("emit_result");
+    expect(tool?.input_schema).toMatchObject({
+      type: "object",
+      properties: { answer: { type: "string" }, score: { type: "number" } },
+    });
+  });
+
+  test("throws when JSON-Schema-path output fails validation", async () => {
+    const jsonSchema = {
+      type: "object",
+      properties: { answer: { type: "string" } },
+      required: ["answer"],
+      additionalProperties: false,
+    };
+    responseQueue = [
+      {
+        content: [
+          {
+            type: "tool_use",
+            name: "emit_result",
+            id: "tu-json-bad",
+            input: { answer: 5 },
+          },
+        ],
+        model: "test",
+        usage: { inputTokens: 1, outputTokens: 1 },
+        stopReason: "tool_use",
+      },
+    ];
+
+    await expect(
+      runLeaf({ prompt: "x", schema: jsonSchema, trustContext }),
+    ).rejects.toThrow(/schema validation/i);
+  });
+
   test("throws when provider output fails schema validation", async () => {
     const schema = z.object({ answer: z.string() });
     responseQueue = [

--- a/assistant/src/workflows/leaf-runner.ts
+++ b/assistant/src/workflows/leaf-runner.ts
@@ -175,8 +175,14 @@ export interface RunLeafOptions {
    * When provided (and `tools` is absent), runs the schema path: a single
    * forced-tool-choice call whose returned input is validated against this
    * schema and returned as `output`.
+   *
+   * Accepts EITHER a host-side Zod schema (host callers) OR a plain JSON Schema
+   * object. A workflow script runs inside the QuickJS sandbox and cannot hold a
+   * Zod object (Zod is host-side), so a script's `leaf(prompt, { schema })`
+   * crosses the sandbox→host boundary as a JSON-marshaled JSON Schema. The
+   * runner duck-types the input and handles both shapes (see {@link runSchemaLeaf}).
    */
-  schema?: z.ZodType;
+  schema?: z.ZodType | Record<string, unknown>;
   /**
    * When provided (and `schema` is absent), runs the tool path: an agent loop
    * restricted to exactly these registry tools. These are the resolved
@@ -299,7 +305,7 @@ async function runSchemaLeaf(
   opts: RunLeafOptions,
   overrideProfile: string | undefined,
 ): Promise<LeafResult> {
-  const schema = opts.schema as z.ZodType;
+  const schema = opts.schema as z.ZodType | Record<string, unknown>;
 
   const { systemPrompt, messages } = await resolveLeafContext(opts);
 
@@ -317,7 +323,7 @@ async function runSchemaLeaf(
     description:
       "Return the result for this task. Call this tool exactly once with the " +
       "structured result.",
-    input_schema: zodToInputSchema(schema),
+    input_schema: schemaToInputSchema(schema),
   };
 
   const response = await provider.sendMessage(messages, {
@@ -338,7 +344,7 @@ async function runSchemaLeaf(
     );
   }
 
-  const parsed = schema.safeParse(toolBlock.input);
+  const parsed = validateSchemaOutput(schema, toolBlock.input);
   if (!parsed.success) {
     throw new Error(
       `Workflow leaf "${opts.label ?? "schema"}" output failed schema ` +
@@ -498,14 +504,49 @@ function finalAssistantText(history: Message[]): string {
 }
 
 /**
- * Convert a Zod schema into a JSON-schema `input_schema` object for a synthetic
- * tool. Uses Zod 4's native `z.toJSONSchema` (mirrors `scripts/generate-openapi.ts`)
- * and strips the `$schema` key, which tool definitions don't carry.
+ * A leaf's structured-output schema is EITHER a host-side Zod schema (passed by
+ * a host caller) or a plain JSON Schema object (a script's `leaf(prompt,
+ * { schema })` is JSON-marshaled across the sandbox→host boundary, since the
+ * sandbox can't hold a Zod object). Duck-type the input: a Zod schema exposes a
+ * `safeParse` method (and the internal `_zod` marker), a JSON Schema object does
+ * not.
  */
-function zodToInputSchema(schema: z.ZodType): Record<string, unknown> {
-  const converted = z.toJSONSchema(schema, {
-    unrepresentable: "any",
-  }) as Record<string, unknown>;
+function isZodSchema(
+  schema: z.ZodType | Record<string, unknown>,
+): schema is z.ZodType {
+  return typeof (schema as { safeParse?: unknown }).safeParse === "function";
+}
+
+/**
+ * Build the synthetic forced-tool's `input_schema` from the leaf's schema. A Zod
+ * schema is converted via Zod 4's native `z.toJSONSchema` (mirrors
+ * `scripts/generate-openapi.ts`), stripping the `$schema` key tool definitions
+ * don't carry. A plain JSON Schema object is used directly (same `$schema`
+ * strip for parity).
+ */
+function schemaToInputSchema(
+  schema: z.ZodType | Record<string, unknown>,
+): Record<string, unknown> {
+  const converted = isZodSchema(schema)
+    ? (z.toJSONSchema(schema, { unrepresentable: "any" }) as Record<
+        string,
+        unknown
+      >)
+    : schema;
   const { $schema: _dropped, ...rest } = converted;
   return rest;
+}
+
+/**
+ * Validate the model's returned tool input against the leaf's schema. A Zod
+ * schema validates directly; a plain JSON Schema object is reconstructed into a
+ * Zod schema via `z.fromJSONSchema` first. Returns Zod's native `safeParse`
+ * result so callers handle both shapes uniformly.
+ */
+function validateSchemaOutput(
+  schema: z.ZodType | Record<string, unknown>,
+  input: unknown,
+) {
+  const zodSchema = isZodSchema(schema) ? schema : z.fromJSONSchema(schema);
+  return zodSchema.safeParse(input);
 }


### PR DESCRIPTION
## Summary
- Leaf schema path now accepts a JSON Schema object (from sandbox scripts) as well as a Zod schema (host callers).
- appendJournalEntry upserts on (run_id, seq) so changed-input resume rewrites stale rows.
- Converts two engine-integration test.todos (surfaced these bugs) into real passing tests.

Part of plan: workflow-engine.md (fix for PRs 6/8 surfaced by PR 16)