### PR TITLE
fix(workflows): don't forward tools to schema leaves

### DIFF
--- a/assistant/src/workflows/engine-integration.test.ts
+++ b/assistant/src/workflows/engine-integration.test.ts
@@ -10,12 +10,14 @@
  * journal DB round-trips on resume.
  *
  * Most leaves run the REAL **tool path**: the engine forwards `capabilities.tools`
- * to every leaf, the leaf runner spins up an `AgentLoop`, and the mocked
+ * to tool leaves, the leaf runner spins up an `AgentLoop`, and the mocked
  * provider returns a single `end_turn` message whose text echoes the prompt
- * (so each leaf's `output` is distinguishable and order-checkable). A leaf with
- * an empty toolset routes to the leaf runner's SCHEMA path; a sandboxed script
- * passes a JSON Schema object (it can't hold a host-side Zod object), which the
- * leaf runner duck-types — see the schema-path test below.
+ * (so each leaf's `output` is distinguishable and order-checkable). A leaf that
+ * declares a `schema` routes to the leaf runner's SCHEMA path; the engine omits
+ * `tools` for it (a schema + tools is a hard error in `runLeaf`), so the schema
+ * path works even when the run carries the read-only baseline. A sandboxed
+ * script passes a JSON Schema object (it can't hold a host-side Zod object),
+ * which the leaf runner duck-types — see the schema-path test below.
  *
  * Covered:
  *  - `map`/`parallel` fan-out: each leaf returns its echoed output, aggregated
@@ -215,17 +217,6 @@ registerTool({
 
 const capabilities = resolveCapabilities({
   tools: [ECHO_TOOL_NAME],
-  hostFunctions: [],
-  persona: false,
-});
-
-/**
- * Capabilities with NO tools. A schema leaf must route to the leaf runner's
- * SCHEMA path, which requires an empty toolset (a schema + tools is a hard
- * error in `runLeaf`). Used by the schema-path integration test.
- */
-const schemaCapabilities = resolveCapabilities({
-  tools: [],
   hostFunctions: [],
   persona: false,
 });
@@ -469,17 +460,22 @@ return { results, tail };
   });
 
   // ---------------------------------------------------------------------------
-  // FIXED ENGINE↔LEAF-RUNNER GAP (schema-path marshaling).
+  // FIXED ENGINE↔LEAF-RUNNER GAP (schema-path marshaling + tool forwarding).
   //
   // A workflow script declares a per-leaf output `schema` via
   // `leaf(prompt, { schema })`. That schema crosses the QuickJS sandbox boundary
   // as a JSON-marshaled plain object (a JSON Schema). The leaf runner's schema
   // path now duck-types its input: a plain JSON Schema object is used directly as
   // the forced-tool `input_schema` and validated via `z.fromJSONSchema`, while a
-  // host-side Zod schema keeps the original behavior. A schema leaf must route to
-  // the schema path, which requires an empty toolset (`schemaCapabilities`).
+  // host-side Zod schema keeps the original behavior.
+  //
+  // This run uses the FULL capability set (non-empty `capabilities.tools`, which
+  // every real run carries via the read-only baseline). A schema leaf must NOT
+  // receive those tools — `runLeaf` hard-errors on `schema` + non-empty `tools`.
+  // The engine now omits `tools` for schema leaves, so the structured-output path
+  // works end-to-end even when the run carries baseline tools (the real case).
   // ---------------------------------------------------------------------------
-  test("schema-path leaves: a script-provided JSON Schema drives the forced-tool path", async () => {
+  test("schema-path leaves run with the read-only baseline present (tools not forwarded)", async () => {
     // The script passes a JSON Schema OBJECT LITERAL (the only shape a sandbox
     // script can produce — Zod is host-side). It marshals across the boundary
     // and reaches the leaf runner verbatim.
@@ -495,8 +491,12 @@ const items = args.items;
 const results = map(items, (it) => leaf("item-" + it, { schema }));
 return results;
 `;
+    // `capabilities` carries a non-empty toolset (the echo tool); a real run's
+    // resolved baseline is likewise non-empty. The schema leaf still succeeds,
+    // proving the engine omits `tools` on the schema path.
+    expect(capabilities.tools.length).toBeGreaterThan(0);
     const result = await executeWorkflow({
-      ...baseOptions("wf-schema", scriptSource, schemaCapabilities),
+      ...baseOptions("wf-schema", scriptSource, capabilities),
       args: { items: ["a", "b"] },
       config: makeConfig(),
     });

--- a/assistant/src/workflows/engine.test.ts
+++ b/assistant/src/workflows/engine.test.ts
@@ -54,11 +54,13 @@ function makeFakeRunner(opts?: {
   onCall?: (prompt: string) => void;
 }) {
   const prompts: string[] = [];
+  const calls: RunLeafOptions[] = [];
   let inFlight = 0;
   let highWater = 0;
 
   const runner = async (leafOpts: RunLeafOptions): Promise<LeafResult> => {
     prompts.push(leafOpts.prompt);
+    calls.push(leafOpts);
     opts?.onCall?.(leafOpts.prompt);
     inFlight += 1;
     highWater = Math.max(highWater, inFlight);
@@ -85,6 +87,7 @@ function makeFakeRunner(opts?: {
   return {
     runner: runner as unknown as typeof import("./leaf-runner.js").runLeaf,
     prompts,
+    calls,
     get highWater() {
       return highWater;
     },
@@ -99,12 +102,13 @@ function execute(
   runner: typeof import("./leaf-runner.js").runLeaf,
   config: WorkflowsConfig = configWith(),
   args: unknown = null,
+  capabilities: ResolvedCapabilities = CAPABILITIES,
 ) {
   return executeWorkflow({
     runId,
     scriptSource: META + scriptSource,
     args,
-    capabilities: CAPABILITIES,
+    capabilities,
     config,
     journal: journalStore,
     leafRunner: runner,
@@ -320,6 +324,45 @@ describe("executeWorkflow — resume", () => {
       journalB.map((e) => [e.seq, e.callHash]),
     );
     expect(journalA.map((e) => e.seq)).toEqual([0, 1, 2]);
+  });
+});
+
+describe("executeWorkflow — schema vs tool leaf tool forwarding", () => {
+  beforeEach(resetTables);
+
+  // A non-empty capability set, mirroring a real run (which always carries the
+  // read-only baseline). The engine must forward these tools ONLY to tool leaves.
+  const toolsCapabilities: ResolvedCapabilities = {
+    tools: [{ name: "file_read" } as ResolvedCapabilities["tools"][number]],
+    hostFunctions: [],
+    persona: false,
+  };
+
+  test("a schema leaf is called with NO tools; a plain tool leaf gets capabilities.tools", async () => {
+    const fake = makeFakeRunner();
+    // The schema crosses the (here-bypassed) sandbox as a plain JSON Schema
+    // object; the engine forwards it verbatim. The plain leaf has no schema.
+    const res = await execute(
+      "wf-tool-forward",
+      `const schemaLeaf = agent("structured", { schema: { type: "object" } });
+       const toolLeaf = agent("freeform");
+       return [schemaLeaf, toolLeaf];`,
+      fake.runner,
+      configWith(),
+      null,
+      toolsCapabilities,
+    );
+
+    expect(res.status).toBe("completed");
+    expect(fake.prompts).toEqual(["structured", "freeform"]);
+
+    const [schemaCall, toolCall] = fake.calls;
+    // Schema leaf: schema present, NO tools forwarded.
+    expect(schemaCall!.schema).toEqual({ type: "object" });
+    expect(schemaCall!.tools ?? []).toEqual([]);
+    // Tool leaf: no schema, capabilities.tools forwarded.
+    expect(toolCall!.schema).toBeUndefined();
+    expect(toolCall!.tools).toBe(toolsCapabilities.tools);
   });
 });
 

--- a/assistant/src/workflows/engine.ts
+++ b/assistant/src/workflows/engine.ts
@@ -359,16 +359,20 @@ export async function executeWorkflow(
     agentsSpawned += 1;
 
     try {
+      // A leaf is EITHER a schema leaf (structured output via forced
+      // tool-choice — `schema` set, no tools) OR a tool leaf (free-form with
+      // tools — no schema). `runLeaf` hard-errors if BOTH are passed. The
+      // resolved capabilities always include a non-empty read-only baseline, so
+      // forward `tools` only on the tool-leaf path; a schema leaf runs with none.
+      const isSchemaLeaf = leafOpts.schema !== undefined;
       const result = await leafRunner({
         prompt,
         ...(leafOpts.label !== undefined ? { label: leafOpts.label } : {}),
-        ...(leafOpts.schema !== undefined
-          ? { schema: leafOpts.schema as never }
-          : {}),
+        ...(isSchemaLeaf ? { schema: leafOpts.schema as never } : {}),
         ...(leafOpts.profile !== undefined
           ? { profile: leafOpts.profile }
           : {}),
-        tools: capabilities.tools,
+        ...(isSchemaLeaf ? {} : { tools: capabilities.tools }),
         trustContext,
         ...(signal ? { signal } : {}),
       });


### PR DESCRIPTION
## Summary
- Engine now forwards capabilities.tools only to tool-leaves; schema leaves run with no tools, so the structured-output path works in runs that carry the read-only baseline.

Part of plan: workflow-engine.md (engine fix surfaced during integration testing)