### PR TITLE
feat(workflows): saved workflow library and one-level nesting

### DIFF
--- a/assistant/src/workflows/engine.test.ts
+++ b/assistant/src/workflows/engine.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 // Silence the logger.
 mock.module("../util/logger.js", () => ({
@@ -418,5 +421,148 @@ describe("executeWorkflow — agent cap", () => {
     expect(res.status).toBe("completed");
     expect(res.result).toBe("out:c");
     expect(second.prompts).toEqual([]);
+  });
+});
+
+describe("executeWorkflow — nested workflow()", () => {
+  // Saved workflows live at `<workspace>/workflows/*.workflow.ts`; point the
+  // workspace at a temp dir so `workflow(name)` resolves a fixture we control.
+  let workspaceDir: string;
+  let prevOverride: string | undefined;
+
+  beforeEach(() => {
+    resetTables();
+    workspaceDir = mkdtempSync(join(tmpdir(), "wf-nest-"));
+    prevOverride = process.env.VELLUM_WORKSPACE_DIR;
+    process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+  });
+
+  afterEach(() => {
+    if (prevOverride === undefined) delete process.env.VELLUM_WORKSPACE_DIR;
+    else process.env.VELLUM_WORKSPACE_DIR = prevOverride;
+    rmSync(workspaceDir, { recursive: true, force: true });
+  });
+
+  function writeSaved(file: string, source: string): void {
+    const dir = join(workspaceDir, "workflows");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, file), source, "utf8");
+  }
+
+  test("workflow() runs a saved child inline and returns its result", async () => {
+    writeSaved(
+      "child.workflow.ts",
+      `export const meta = { name: "child", description: "c" };
+       return agent("child-task");`,
+    );
+
+    const fake = makeFakeRunner();
+    const res = await execute(
+      "wf-nest-basic",
+      `const c = workflow("child", {});
+       const p = agent("parent-task");
+       return [c, p];`,
+      fake.runner,
+    );
+
+    expect(res.status).toBe("completed");
+    // The child's agent() result threads back into the parent script.
+    expect(res.result).toEqual(["out:child-task", "out:parent-task"]);
+    // Child leaf ran before the parent's own leaf (inline, same run).
+    expect(fake.prompts).toEqual(["child-task", "parent-task"]);
+  });
+
+  test("nested leaves draw seq from the SAME run-scoped counter", async () => {
+    writeSaved(
+      "child.workflow.ts",
+      `export const meta = { name: "child", description: "c" };
+       return parallel([leaf("c0"), leaf("c1")]);`,
+    );
+
+    const fake = makeFakeRunner();
+    await execute(
+      "wf-nest-seq",
+      `agent("p0");
+       workflow("child", {});
+       return agent("p2");`,
+      fake.runner,
+    );
+
+    // One contiguous seq sequence across the parent + child boundary.
+    const journal = journalStore.getJournal("wf-nest-seq");
+    expect(journal.map((e) => e.seq)).toEqual([0, 1, 2, 3]);
+    // Child leaf labels are attributed to the child workflow.
+    const childEntries = journal.filter((e) =>
+      ["c0", "c1"].includes((e.request as { prompt: string }).prompt),
+    );
+    expect(
+      childEntries.map(
+        (e) => (e.request as { opts: { label?: string } }).opts.label,
+      ),
+    ).toEqual(["child", "child"]);
+  });
+
+  test("parent + child spawns share the agent cap (counted together)", async () => {
+    // Child spawns 2 leaves; parent spawns 2 before + would spawn more after.
+    // With cap=3, the run trips while running the child's second leaf.
+    writeSaved(
+      "child.workflow.ts",
+      `export const meta = { name: "child", description: "c" };
+       return parallel([leaf("c0"), leaf("c1")]);`,
+    );
+
+    const fake = makeFakeRunner();
+    const res = await execute(
+      "wf-nest-cap",
+      `agent("p0");
+       agent("p1");
+       workflow("child", {});
+       return agent("never");`,
+      fake.runner,
+      configWith({ maxAgentsPerRun: 3, maxConcurrentLeaves: 1 }),
+    );
+
+    expect(res.status).toBe("cap_exceeded");
+    // Exactly the cap's worth ran across BOTH levels: p0, p1, then the child's
+    // first leaf — the child's second leaf trips the shared cap.
+    expect(res.agentsSpawned).toBe(3);
+    expect(fake.prompts).toEqual(["p0", "p1", "c0"]);
+  });
+
+  test("calling workflow() from inside a child throws (depth-1 only)", async () => {
+    writeSaved(
+      "grandchild.workflow.ts",
+      `export const meta = { name: "grandchild", description: "g" };
+       return agent("gc");`,
+    );
+    // The child illegally nests another workflow() — depth would be 2.
+    writeSaved(
+      "child.workflow.ts",
+      `export const meta = { name: "child", description: "c" };
+       return workflow("grandchild", {});`,
+    );
+
+    const fake = makeFakeRunner();
+    const res = await execute(
+      "wf-nest-depth",
+      `return workflow("child", {});`,
+      fake.runner,
+    );
+
+    // The depth guard fires inside the child; uncaught, it fails the run.
+    expect(res.status).toBe("failed");
+    // The grandchild never ran.
+    expect(fake.prompts).toEqual([]);
+  });
+
+  test("workflow() with an unknown name fails the run", async () => {
+    const fake = makeFakeRunner();
+    const res = await execute(
+      "wf-nest-missing",
+      `return workflow("ghost", {});`,
+      fake.runner,
+    );
+    expect(res.status).toBe("failed");
+    expect(fake.prompts).toEqual([]);
   });
 });

--- a/assistant/src/workflows/engine.ts
+++ b/assistant/src/workflows/engine.ts
@@ -62,6 +62,7 @@ import type { ResolvedCapabilities } from "./capabilities.js";
 import type * as JournalStore from "./journal-store.js";
 import type { WorkflowRunStatus } from "./journal-store.js";
 import type { runLeaf } from "./leaf-runner.js";
+import * as library from "./library.js";
 import { createWorkflowSandbox, WorkflowScriptError } from "./sandbox.js";
 
 const log = getLogger("workflow-engine");
@@ -147,6 +148,32 @@ class AbortedSignal extends Error {
   constructor() {
     super("Workflow aborted");
     this.name = "AbortedSignal";
+  }
+}
+
+/**
+ * Thrown into the script when `workflow(name)` references a saved workflow that
+ * does not exist in the library. Surfaces as a catchable VM exception (or, if
+ * uncaught, fails the run).
+ */
+export class WorkflowNotFoundError extends Error {
+  readonly code = "workflow_not_found" as const;
+  constructor(readonly name: string) {
+    super(`No saved workflow named "${name}".`);
+    this.name = "WorkflowNotFoundError";
+  }
+}
+
+/**
+ * Thrown into the script when `workflow()` is called from inside a nested
+ * workflow. Nesting is limited to ONE level: a top-level script may call
+ * `workflow()`, but a child workflow may not.
+ */
+export class WorkflowNestingDepthError extends Error {
+  readonly code = "workflow_nesting_too_deep" as const;
+  constructor() {
+    super("workflow() may only be called from a top-level workflow (depth 1).");
+    this.name = "WorkflowNestingDepthError";
   }
 }
 
@@ -412,102 +439,179 @@ export async function executeWorkflow(
   // --- Host functions ------------------------------------------------------
   // `agent` runs one sequential leaf and surfaces failures (throws into the
   // script). `parallel` is the fan-out primitive: it null-coalesces failures.
+  //
+  // The host API is built by a FACTORY so it can be re-bound for a nested
+  // `workflow()` child: the child reuses the SAME shared run-state (seq counter,
+  // agent cap, journal, signal, capabilities) but applies a `labelPrefix` so its
+  // leaf labels are attributed to the child workflow. The single-level nesting
+  // guard lives in the `workflow()` host fn, gated on `depth`.
 
-  const hostAgent = async (
-    promptArg: unknown,
-    optsArg?: unknown,
-  ): Promise<unknown> => {
-    const prompt = String(promptArg);
-    const leafOpts = normalizeLeafOpts(optsArg);
-    const seq = nextSeq++;
-    const { output, failed } = await runLeafAtSeq(seq, prompt, leafOpts);
-    if (failed) {
-      throw new WorkflowScriptError(
-        `Workflow agent leaf${leafOpts.label ? ` "${leafOpts.label}"` : ""} failed.`,
+  /** Prefix a leaf label with the (optional) nested-workflow attribution. */
+  const withLabelPrefix = (
+    labelPrefix: string,
+    leafOpts: LeafCallOptions,
+  ): LeafCallOptions => {
+    if (!labelPrefix) return leafOpts;
+    const base = leafOpts.label ?? "";
+    return {
+      ...leafOpts,
+      label: base ? `${labelPrefix}/${base}` : labelPrefix,
+    };
+  };
+
+  /**
+   * Build the host API bound to the shared run-state. `labelPrefix` attributes a
+   * nested child's leaves; `depth` (0 = top-level, 1 = nested) gates `workflow()`.
+   */
+  const buildHostFunctions = (
+    labelPrefix: string,
+    depth: number,
+  ): Record<string, (...a: unknown[]) => unknown | Promise<unknown>> => {
+    const hostAgent = async (
+      promptArg: unknown,
+      optsArg?: unknown,
+    ): Promise<unknown> => {
+      const prompt = String(promptArg);
+      const leafOpts = withLabelPrefix(labelPrefix, normalizeLeafOpts(optsArg));
+      const seq = nextSeq++;
+      const { output, failed } = await runLeafAtSeq(seq, prompt, leafOpts);
+      if (failed) {
+        throw new WorkflowScriptError(
+          `Workflow agent leaf${leafOpts.label ? ` "${leafOpts.label}"` : ""} failed.`,
+        );
+      }
+      return output;
+    };
+
+    const hostLeaf = (promptArg: unknown, optsArg?: unknown): LeafSpec => ({
+      __workflowSpec: true,
+      prompt: String(promptArg),
+      opts: withLabelPrefix(labelPrefix, normalizeLeafOpts(optsArg)),
+    });
+
+    const hostParallel = async (specsArg: unknown): Promise<unknown[]> => {
+      // A spec built by `leaf()` already carries the child label prefix; a
+      // bare-string spec (sugar) bypassed `leaf()`, so prefix it here. Either
+      // way the prefix is applied EXACTLY once.
+      const specs = toSpecArray(specsArg).map((spec, i) =>
+        typeof (specsArg as unknown[])[i] === "string"
+          ? { ...spec, opts: withLabelPrefix(labelPrefix, spec.opts) }
+          : spec,
       );
-    }
-    return output;
-  };
-
-  const hostLeaf = (promptArg: unknown, optsArg?: unknown): LeafSpec => ({
-    __workflowSpec: true,
-    prompt: String(promptArg),
-    opts: normalizeLeafOpts(optsArg),
-  });
-
-  const hostParallel = async (specsArg: unknown): Promise<unknown[]> => {
-    const specs = toSpecArray(specsArg);
-    // Assign seqs in array order BEFORE launching concurrency, so completion
-    // order cannot perturb the deterministic seq mapping.
-    const assigned = specs.map((spec) => ({ spec, seq: nextSeq++ }));
-    return runWithConcurrency(
-      assigned,
-      config.maxConcurrentLeaves,
-      async ({ spec, seq }) => {
-        const { output } = await runLeafAtSeq(seq, spec.prompt, spec.opts);
-        // `parallel` never throws on a single leaf failure — it yields null.
-        return output;
-      },
-    );
-  };
-
-  const hostPhase = (titleArg: unknown): void => {
-    onProgress?.({ type: "phase", title: String(titleArg) });
-  };
-  const hostLog = (msgArg: unknown): void => {
-    onProgress?.({ type: "log", message: String(msgArg) });
-  };
-  const hostUsage = (): {
-    agentsSpawned: number;
-    inputTokens: number;
-    outputTokens: number;
-  } => ({ agentsSpawned, inputTokens, outputTokens });
-
-  // Always-available host functions.
-  const hostFunctions: Record<
-    string,
-    (...a: unknown[]) => unknown | Promise<unknown>
-  > = {
-    agent: (p, o) => hostAgent(p, o),
-    leaf: (p, o) => hostLeaf(p, o),
-    parallel: (s) => hostParallel(s),
-    phase: (t) => hostPhase(t),
-    log: (m) => hostLog(m),
-    usage: () => hostUsage(),
-  };
-
-  // Manifest-declared host functions are injected by name as no-op-safe stubs
-  // only when explicitly granted. (Their concrete impls are bound by later PRs;
-  // here we expose the names so an undeclared call is a ReferenceError and a
-  // declared-but-unbound call fails loudly rather than silently.)
-  for (const name of capabilities.hostFunctions) {
-    if (name in hostFunctions) continue;
-    hostFunctions[name] = () => {
-      throw new WorkflowScriptError(
-        `Host function "${name}" is declared but not bound in this engine build.`,
+      // Assign seqs in array order BEFORE launching concurrency, so completion
+      // order cannot perturb the deterministic seq mapping.
+      const assigned = specs.map((spec) => ({ spec, seq: nextSeq++ }));
+      return runWithConcurrency(
+        assigned,
+        config.maxConcurrentLeaves,
+        async ({ spec, seq }) => {
+          const { output } = await runLeafAtSeq(seq, spec.prompt, spec.opts);
+          // `parallel` never throws on a single leaf failure — it yields null.
+          return output;
+        },
       );
     };
-  }
 
-  // The prelude defines `map`/`pipeline` over `parallel`; prepend it so the
-  // user script can call them. The sandbox runs the script as a SYNCHRONOUS
-  // function body, where a top-level `export` is a syntax error — strip the
-  // `export` keyword(s) so `export const meta = ...` becomes a plain local.
-  const fullScript = `${SCRIPT_PRELUDE_HELPERS}${SCRIPT_PRELUDE}\n${stripTopLevelExports(scriptSource)}`;
+    const hostPhase = (titleArg: unknown): void => {
+      onProgress?.({ type: "phase", title: String(titleArg) });
+    };
+    const hostLog = (msgArg: unknown): void => {
+      onProgress?.({ type: "log", message: String(msgArg) });
+    };
+    const hostUsage = (): {
+      agentsSpawned: number;
+      inputTokens: number;
+      outputTokens: number;
+    } => ({ agentsSpawned, inputTokens, outputTokens });
 
-  const sandbox = createWorkflowSandbox({
-    hostFunctions,
-    ...(onProgress
-      ? { onLog: (m) => onProgress({ type: "log", message: m }) }
-      : {}),
-    ...(signal ? { signal } : {}),
-  });
+    /**
+     * Run a saved workflow by name INLINE as part of this run: the child draws
+     * `seq` from the same counter, counts against the same agent cap, and shares
+     * the same journal/signal/leaf-runner — so determinism and journaled resume
+     * carry across the nesting boundary. Nesting is depth-1 only: a `workflow()`
+     * call from inside a child throws {@link WorkflowNestingDepthError}.
+     */
+    const hostWorkflow = async (
+      nameArg: unknown,
+      childArgs?: unknown,
+    ): Promise<unknown> => {
+      if (depth >= 1) throw new WorkflowNestingDepthError();
+      if (signal?.aborted) throw new AbortedSignal();
+      const childName = String(nameArg);
+      const saved = library.getWorkflow(childName);
+      if (!saved) throw new WorkflowNotFoundError(childName);
+      // The child runs in its OWN sandbox VM (the parent VM is suspended in
+      // asyncify and cannot be re-entered), but with host functions bound to the
+      // SAME shared run-state and a child label prefix, at depth 1.
+      const childHostFns = buildHostFunctions(childName, depth + 1);
+      return runScriptInSandbox(saved.source, childArgs ?? null, childHostFns);
+    };
+
+    // Always-available host functions.
+    const hostFunctions: Record<
+      string,
+      (...a: unknown[]) => unknown | Promise<unknown>
+    > = {
+      agent: (p, o) => hostAgent(p, o),
+      leaf: (p, o) => hostLeaf(p, o),
+      parallel: (s) => hostParallel(s),
+      workflow: (n, a) => hostWorkflow(n, a),
+      phase: (t) => hostPhase(t),
+      log: (m) => hostLog(m),
+      usage: () => hostUsage(),
+    };
+
+    // Manifest-declared host functions are injected by name as no-op-safe stubs
+    // only when explicitly granted. (Their concrete impls are bound by later
+    // PRs; here we expose the names so an undeclared call is a ReferenceError and
+    // a declared-but-unbound call fails loudly rather than silently.)
+    for (const name of capabilities.hostFunctions) {
+      if (name in hostFunctions) continue;
+      hostFunctions[name] = () => {
+        throw new WorkflowScriptError(
+          `Host function "${name}" is declared but not bound in this engine build.`,
+        );
+      };
+    }
+    return hostFunctions;
+  };
+
+  /**
+   * Run one workflow script source in a fresh sandbox VM, wired to the given
+   * host functions. Shared by the top-level run and every nested `workflow()`
+   * child. The prelude defines `map`/`pipeline` over `parallel`; prepend it so
+   * the script can call them. The sandbox runs the script as a SYNCHRONOUS
+   * function body, where a top-level `export` is a syntax error — strip the
+   * `export` keyword(s) so `export const meta = ...` becomes a plain local.
+   */
+  const runScriptInSandbox = (
+    source: string,
+    scriptArgs: unknown,
+    hostFunctions: Record<
+      string,
+      (...a: unknown[]) => unknown | Promise<unknown>
+    >,
+  ): Promise<unknown> => {
+    const fullScript = `${SCRIPT_PRELUDE_HELPERS}${SCRIPT_PRELUDE}\n${stripTopLevelExports(source)}`;
+    const sandbox = createWorkflowSandbox({
+      hostFunctions,
+      ...(onProgress
+        ? { onLog: (m) => onProgress({ type: "log", message: m }) }
+        : {}),
+      ...(signal ? { signal } : {}),
+    });
+    return sandbox.run(fullScript, scriptArgs);
+  };
 
   let status: WorkflowRunStatus;
   let result: unknown = null;
 
   try {
-    result = await sandbox.run(fullScript, args);
+    result = await runScriptInSandbox(
+      scriptSource,
+      args,
+      buildHostFunctions("", 0),
+    );
     status = "completed";
   } catch (err) {
     if (capExceeded || err instanceof CapExceededSignal) {

--- a/assistant/src/workflows/library.test.ts
+++ b/assistant/src/workflows/library.test.ts
@@ -1,0 +1,134 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Silence the logger so a skipped-file warning doesn't spam the test output.
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { getWorkflow, listWorkflows } from "./library.js";
+
+// Each test points VELLUM_WORKSPACE_DIR at a fresh temp dir, so `getWorkspaceDir`
+// resolves there and saved workflows live at `<temp>/workflows/*.workflow.ts`.
+let workspaceDir: string;
+let prevOverride: string | undefined;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "wf-library-"));
+  prevOverride = process.env.VELLUM_WORKSPACE_DIR;
+  process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+});
+
+afterEach(() => {
+  if (prevOverride === undefined) delete process.env.VELLUM_WORKSPACE_DIR;
+  else process.env.VELLUM_WORKSPACE_DIR = prevOverride;
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+/** Write `<workspace>/workflows/<file>` with `source` (creating the dir). */
+function writeWorkflow(file: string, source: string): void {
+  const dir = join(workspaceDir, "workflows");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, file), source, "utf8");
+}
+
+describe("listWorkflows", () => {
+  test("returns [] and does not create the dir when none exists", () => {
+    expect(listWorkflows()).toEqual([]);
+    // A second call still sees no dir — listing never creates it eagerly.
+    expect(getWorkflow("anything")).toBeNull();
+  });
+
+  test("lists workflows with a statically-extractable meta", () => {
+    writeWorkflow(
+      "digest.workflow.ts",
+      `export const meta = { name: "daily-digest", description: "Summarize the day" };\nreturn agent("go");`,
+    );
+    writeWorkflow(
+      "research.workflow.ts",
+      `export const meta = { name: "research", description: "Research a topic" };\nreturn agent("go");`,
+    );
+
+    const entries = listWorkflows().sort((a, b) =>
+      a.name.localeCompare(b.name),
+    );
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({
+      name: "daily-digest",
+      description: "Summarize the day",
+    });
+    expect(entries[0]!.path).toContain("digest.workflow.ts");
+    expect(entries[1]).toMatchObject({
+      name: "research",
+      description: "Research a topic",
+    });
+  });
+
+  test("ignores non-`.workflow.ts` files", () => {
+    writeWorkflow(
+      "real.workflow.ts",
+      `export const meta = { name: "real", description: "d" };\nreturn 1;`,
+    );
+    writeWorkflow(
+      "notes.ts",
+      `export const meta = { name: "x", description: "y" };`,
+    );
+    writeWorkflow("README.md", `# not a workflow`);
+
+    const entries = listWorkflows();
+    expect(entries.map((e) => e.name)).toEqual(["real"]);
+  });
+
+  test("skips a file whose meta is computed/non-literal (cannot be statically extracted)", () => {
+    writeWorkflow(
+      "ok.workflow.ts",
+      `export const meta = { name: "ok", description: "fine" };\nreturn 1;`,
+    );
+    // Computed meta: a call expression cannot be statically extracted and the
+    // file is skipped rather than failing the whole listing.
+    writeWorkflow(
+      "computed.workflow.ts",
+      `const make = () => ({ name: "nope", description: "d" });\nexport const meta = make();\nreturn 1;`,
+    );
+    // Missing meta entirely.
+    writeWorkflow("nometa.workflow.ts", `return agent("go");`);
+
+    const entries = listWorkflows();
+    expect(entries.map((e) => e.name)).toEqual(["ok"]);
+  });
+});
+
+describe("getWorkflow", () => {
+  test("resolves by meta.name", () => {
+    const source = `export const meta = { name: "daily-digest", description: "d" };\nreturn agent("go");`;
+    writeWorkflow("digest.workflow.ts", source);
+
+    const resolved = getWorkflow("daily-digest");
+    expect(resolved).not.toBeNull();
+    expect(resolved!.source).toBe(source);
+    expect(resolved!.path).toContain("digest.workflow.ts");
+  });
+
+  test("falls back to the filename base when no meta.name matches", () => {
+    // meta.name is "canonical" but the caller asks by the file base "byfile".
+    const source = `export const meta = { name: "canonical", description: "d" };\nreturn 1;`;
+    writeWorkflow("byfile.workflow.ts", source);
+
+    expect(getWorkflow("byfile")!.source).toBe(source);
+    // The canonical meta.name also resolves.
+    expect(getWorkflow("canonical")!.source).toBe(source);
+  });
+
+  test("returns null for an unknown name", () => {
+    writeWorkflow(
+      "real.workflow.ts",
+      `export const meta = { name: "real", description: "d" };\nreturn 1;`,
+    );
+    expect(getWorkflow("ghost")).toBeNull();
+  });
+});

--- a/assistant/src/workflows/library.ts
+++ b/assistant/src/workflows/library.ts
@@ -1,0 +1,124 @@
+/**
+ * Saved-workflow LIBRARY — named workflows the assistant can invoke by name and
+ * the scheduler can trigger.
+ *
+ * Saved workflows live at `<workspace>/workflows/*.workflow.ts`. Each file is a
+ * normal workflow script: a leading literal `export const meta = { name,
+ * description }` followed by the script body. The library only reads the STATIC
+ * `meta` (via {@link extractWorkflowMeta}, a pure-literal extractor that never
+ * executes the untrusted source — only the QuickJS sandbox may run it) and the
+ * raw source. Resolution to an actual run goes through {@link executeWorkflow} /
+ * {@link WorkflowRunManager}, which run the source in the sandbox.
+ *
+ * The directory is read lazily and is NOT created eagerly: if it does not exist,
+ * {@link listWorkflows} returns `[]` and {@link getWorkflow} returns `null`.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { getLogger } from "../util/logger.js";
+import { getWorkspaceDir } from "../util/platform.js";
+import { extractWorkflowMeta } from "./engine.js";
+
+const log = getLogger("workflow-library");
+
+/** File suffix every saved workflow uses. */
+const WORKFLOW_SUFFIX = ".workflow.ts";
+
+/** A saved workflow surfaced by {@link listWorkflows}. */
+export interface SavedWorkflowEntry {
+  /** The workflow's `meta.name`. */
+  name: string;
+  /** The workflow's `meta.description`. */
+  description: string;
+  /** Absolute path to the `*.workflow.ts` file. */
+  path: string;
+}
+
+/** The source + path of a resolved saved workflow. */
+export interface SavedWorkflowSource {
+  /** The raw script source (TS). */
+  source: string;
+  /** Absolute path to the `*.workflow.ts` file. */
+  path: string;
+}
+
+/** Absolute path to the saved-workflows directory (`<workspace>/workflows`). */
+function workflowsDir(): string {
+  return join(getWorkspaceDir(), "workflows");
+}
+
+/** The filename (sans `.workflow.ts`) for `<workspace>/workflows/<base>.workflow.ts`. */
+function fileBaseName(file: string): string {
+  return file.slice(0, -WORKFLOW_SUFFIX.length);
+}
+
+/** A `*.workflow.ts` file read off disk, before meta extraction. */
+interface RawWorkflowFile {
+  file: string;
+  path: string;
+  source: string;
+}
+
+/**
+ * Yield every readable `*.workflow.ts` file in the workflows directory (each read
+ * once). Returns nothing if the directory does not exist — it is never created.
+ * An unreadable file is skipped with a logged warning.
+ */
+function* readWorkflowFiles(): Generator<RawWorkflowFile> {
+  const dir = workflowsDir();
+  if (!existsSync(dir)) return;
+  for (const file of readdirSync(dir)) {
+    if (!file.endsWith(WORKFLOW_SUFFIX)) continue;
+    const path = join(dir, file);
+    try {
+      yield { file, path, source: readFileSync(path, "utf8") };
+    } catch (err) {
+      log.warn({ err, path }, "Failed to read saved workflow; skipping");
+    }
+  }
+}
+
+/**
+ * List every saved workflow with a statically-extractable `meta`. A file whose
+ * `meta` cannot be statically extracted (computed/missing/malformed) is SKIPPED
+ * with a logged warning rather than failing the whole listing.
+ */
+export function listWorkflows(): SavedWorkflowEntry[] {
+  const entries: SavedWorkflowEntry[] = [];
+  for (const { path, source } of readWorkflowFiles()) {
+    try {
+      const meta = extractWorkflowMeta(source);
+      entries.push({ name: meta.name, description: meta.description, path });
+    } catch (err) {
+      log.warn(
+        { err, path },
+        "Saved workflow has no statically-extractable meta; skipping",
+      );
+    }
+  }
+  return entries;
+}
+
+/**
+ * Resolve a saved workflow by name. Matches against the workflow's `meta.name`
+ * first, then falls back to the filename base (`<base>.workflow.ts`). Returns the
+ * source + path, or `null` if no saved workflow matches.
+ */
+export function getWorkflow(name: string): SavedWorkflowSource | null {
+  let fileMatch: SavedWorkflowSource | null = null;
+  for (const { file, path, source } of readWorkflowFiles()) {
+    // Prefer a `meta.name` match — it is the canonical identity.
+    try {
+      if (extractWorkflowMeta(source).name === name) return { source, path };
+    } catch {
+      // Fall through: a file with non-extractable meta can still match by name.
+    }
+    // Remember the first filename-base match as a fallback.
+    if (fileMatch === null && fileBaseName(file) === name) {
+      fileMatch = { source, path };
+    }
+  }
+  return fileMatch;
+}

--- a/assistant/src/workflows/run-manager.test.ts
+++ b/assistant/src/workflows/run-manager.test.ts
@@ -11,6 +11,7 @@ mock.module("../util/logger.js", () => ({
 import type { AssistantConfig } from "../config/schema.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import type { ExecuteWorkflowOptions } from "./engine.js";
+import { WorkflowNotFoundError } from "./engine.js";
 import type {
   CreateRunInput,
   WorkflowRun,
@@ -125,6 +126,8 @@ function makeHarness(opts?: {
   maxConcurrentRuns?: number;
   /** Custom engine impl; defaults to the deferred-resolver fake. */
   engine?: WorkflowRunManagerDeps["executeWorkflow"];
+  /** Saved-workflow resolver for the `start({ name })` path. */
+  getWorkflow?: WorkflowRunManagerDeps["getWorkflow"];
 }): ManagerHarness {
   const fake = makeFakeJournal();
   const executeCalls: ExecuteWorkflowOptions[] = [];
@@ -181,6 +184,7 @@ function makeHarness(opts?: {
       let n = 0;
       return () => `run-${++n}`;
     })(),
+    ...(opts?.getWorkflow ? { getWorkflow: opts.getWorkflow } : {}),
   };
 
   const manager = new WorkflowRunManager(deps);
@@ -401,5 +405,47 @@ describe("WorkflowRunManager — completion", () => {
       true,
     );
     expect(h.wakes).toHaveLength(0);
+  });
+});
+
+describe("WorkflowRunManager.start — saved-workflow name resolution", () => {
+  const SAVED_SOURCE =
+    "export const meta = { name: 'saved-flow', description: 'd' }";
+
+  test("start({ name }) resolves the library source and runs it", () => {
+    const h = makeHarness({
+      getWorkflow: (name) =>
+        name === "saved-flow"
+          ? { source: SAVED_SOURCE, path: "/ws/workflows/saved.workflow.ts" }
+          : null,
+    });
+
+    const { runId } = h.manager.start({
+      name: "saved-flow",
+      args: { x: 1 },
+      manifest: { tools: [], hostFunctions: [], persona: false },
+      trustContext: TRUST,
+    });
+
+    // The run row + engine call carry the RESOLVED source, not the name.
+    expect(h.fake.rows.get(runId)?.scriptSource).toBe(SAVED_SOURCE);
+    expect(h.executeCalls).toHaveLength(1);
+    expect(h.executeCalls[0]!.scriptSource).toBe(SAVED_SOURCE);
+    // meta.name is extracted from the resolved source.
+    expect(h.fake.rows.get(runId)?.name).toBe("saved-flow");
+  });
+
+  test("start({ name }) with an unknown name throws and creates no run row", () => {
+    const h = makeHarness({ getWorkflow: () => null });
+    expect(() =>
+      h.manager.start({
+        name: "ghost",
+        args: {},
+        manifest: { tools: [], hostFunctions: [], persona: false },
+        trustContext: TRUST,
+      }),
+    ).toThrow(WorkflowNotFoundError);
+    expect(h.executeCalls).toHaveLength(0);
+    expect(h.fake.rows.size).toBe(0);
   });
 });

--- a/assistant/src/workflows/run-manager.ts
+++ b/assistant/src/workflows/run-manager.ts
@@ -37,10 +37,15 @@ import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { getLogger } from "../util/logger.js";
 import type { CapabilityManifest } from "./capabilities.js";
 import { resolveCapabilities } from "./capabilities.js";
-import { executeWorkflow, extractWorkflowMeta } from "./engine.js";
+import {
+  executeWorkflow,
+  extractWorkflowMeta,
+  WorkflowNotFoundError,
+} from "./engine.js";
 import type { WorkflowRun } from "./journal-store.js";
 import * as journalStore from "./journal-store.js";
 import { runLeaf } from "./leaf-runner.js";
+import * as library from "./library.js";
 
 const log = getLogger("workflow-run-manager");
 
@@ -68,9 +73,18 @@ export class WorkflowRunCapError extends Error {
   }
 }
 
-export interface StartWorkflowOptions {
-  /** The workflow script source (JS or TS). */
-  scriptSource: string;
+/**
+ * Start a run from EITHER an inline `scriptSource` OR a saved workflow `name`
+ * (exactly one). When `name` is given the source is resolved from the saved
+ * workflow library; an unknown name throws {@link WorkflowNotFoundError}.
+ */
+export type StartWorkflowOptions = StartWorkflowCommon &
+  (
+    | { scriptSource: string; name?: undefined }
+    | { name: string; scriptSource?: undefined }
+  );
+
+interface StartWorkflowCommon {
   /** Verbatim run input, exposed to the script as `args`. */
   args: unknown;
   /** Per-run capability declaration (the single consent point). */
@@ -100,6 +114,8 @@ export interface WorkflowRunManagerDeps {
   wake: typeof wakeAgentForOpportunity;
   broadcast: typeof broadcastMessage;
   newRunId: () => string;
+  /** Resolve a saved workflow's source by name (for `start({ name })`). */
+  getWorkflow: typeof library.getWorkflow;
 }
 
 function defaultDeps(): WorkflowRunManagerDeps {
@@ -113,6 +129,7 @@ function defaultDeps(): WorkflowRunManagerDeps {
     wake: wakeAgentForOpportunity,
     broadcast: broadcastMessage,
     newRunId: () => randomUUID(),
+    getWorkflow: library.getWorkflow,
   };
 }
 
@@ -147,12 +164,17 @@ export class WorkflowRunManager {
       throw new WorkflowRunCapError(limit);
     }
 
+    // Resolve the script source: either inline (`scriptSource`) or by name from
+    // the saved-workflow library (`name`). An unknown saved name throws
+    // synchronously, leaving no orphaned `running` row behind.
+    const scriptSource = this.resolveScriptSource(opts);
+
     // Resolve capabilities and extract meta BEFORE creating the run row so a
     // manifest authoring error (unknown/forbidden tool) or a malformed script
     // `meta` surfaces synchronously to the caller and leaves no orphaned
     // `running` row behind.
     const capabilities = resolveCapabilities(opts.manifest);
-    const meta = extractWorkflowMeta(opts.scriptSource);
+    const meta = extractWorkflowMeta(scriptSource);
 
     const runId = this.deps.newRunId();
     const label = opts.label ?? meta.name;
@@ -164,8 +186,8 @@ export class WorkflowRunManager {
     this.deps.journal.createRun({
       id: runId,
       name: meta.name,
-      scriptSource: opts.scriptSource,
-      scriptHash: createHash("sha256").update(opts.scriptSource).digest("hex"),
+      scriptSource,
+      scriptHash: createHash("sha256").update(scriptSource).digest("hex"),
       args: opts.args,
       capabilities,
       status: "running",
@@ -177,9 +199,29 @@ export class WorkflowRunManager {
 
     // Fire-and-forget: the engine owns its own try/catch and always finishes
     // the run row. We never await it — `start` must return synchronously.
-    void this.runToCompletion(runId, label, opts, capabilities, controller);
+    void this.runToCompletion(
+      runId,
+      label,
+      scriptSource,
+      opts,
+      capabilities,
+      controller,
+    );
 
     return { runId };
+  }
+
+  /**
+   * Resolve the run's script source from `StartWorkflowOptions`: returns
+   * `opts.scriptSource` verbatim, or — when `name` is given — the source of the
+   * matching saved workflow. Throws {@link WorkflowNotFoundError} if the name
+   * does not resolve.
+   */
+  private resolveScriptSource(opts: StartWorkflowOptions): string {
+    if (opts.scriptSource !== undefined) return opts.scriptSource;
+    const saved = this.deps.getWorkflow(opts.name);
+    if (!saved) throw new WorkflowNotFoundError(opts.name);
+    return saved.source;
   }
 
   /** Abort an in-flight run by signalling its {@link AbortController}. No-op for unknown/finished runs. */
@@ -218,6 +260,7 @@ export class WorkflowRunManager {
   private async runToCompletion(
     runId: string,
     label: string,
+    scriptSource: string,
     opts: StartWorkflowOptions,
     capabilities: ReturnType<typeof resolveCapabilities>,
     controller: AbortController,
@@ -226,7 +269,7 @@ export class WorkflowRunManager {
     try {
       const result = await this.deps.executeWorkflow({
         runId,
-        scriptSource: opts.scriptSource,
+        scriptSource,
         args: opts.args,
         capabilities,
         config: config.workflows,


### PR DESCRIPTION
## Summary
- Add the saved-workflow library (<workspace>/workflows/*.workflow.ts), start() name resolution, and a depth-1 nested workflow() host function sharing the parent run's seq/cap/journal.

Part of plan: workflow-engine.md (PR 12 of 17)