### PR TITLE
feat(workflows): schedule saved workflows

### DIFF
--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -1156,7 +1156,7 @@ describe("POST /schedules — create", () => {
     expect(job.description).toBe("Description fallback");
   });
 
-  test("rejects non-execute modes", () => {
+  test("rejects modes other than execute/workflow", () => {
     expect(() =>
       postCreate({
         name: "x",
@@ -1165,7 +1165,37 @@ describe("POST /schedules — create", () => {
         message: "hi",
         mode: "notify",
       }),
-    ).toThrow("Only 'execute' mode is supported");
+    ).toThrow("Only 'execute' and 'workflow' modes are supported");
+  });
+
+  test("rejects workflow-mode creation when the workflows flag is off", () => {
+    // The mocked getConfig returns no feature flags, so `workflows` is off.
+    expect(() =>
+      postCreate({
+        name: "Triage",
+        description: "Triage the inbox every morning",
+        expression: "0 9 * * *",
+        message: "triage inbox",
+        mode: "workflow",
+        workflowName: "triage-inbox",
+      }),
+    ).toThrow("Workflows are not enabled");
+  });
+
+  test("rejects PATCH switching to workflow mode when the flag is off", () => {
+    const schedule = createSchedule({
+      name: "Plain execute",
+      cronExpression: "0 9 * * *",
+      message: "hi",
+      syntax: "cron",
+    });
+    const patch = findRoute("schedules/:id", "PATCH");
+    expect(() =>
+      patch.handler({
+        pathParams: { id: schedule.id },
+        body: { mode: "workflow", workflowName: "triage-inbox" },
+      }),
+    ).toThrow("Workflows are not enabled");
   });
 
   test("rejects an unparseable expression", () => {
@@ -1188,6 +1218,38 @@ describe("POST /schedules — create", () => {
         message: "hi",
       }),
     ).toThrow();
+  });
+
+  test("persists and round-trips workflowName/workflowArgs in the list response", () => {
+    // Store-level round trip: the create route is flag-gated (and the mocked
+    // config disables it), so exercise persistence directly via the store.
+    createSchedule({
+      name: "Workflow schedule",
+      cronExpression: "0 9 * * *",
+      message: "trigger",
+      syntax: "cron",
+      mode: "workflow",
+      workflowName: "triage-inbox",
+      workflowArgs: { folder: "primary", limit: 10 },
+    });
+
+    const route = findRoute("schedules", "GET");
+    const result = route.handler({}) as {
+      schedules: Array<{
+        name: string;
+        mode: string;
+        workflowName: string | null;
+      }>;
+    };
+    const job = result.schedules.find((s) => s.name === "Workflow schedule");
+    expect(job).toBeDefined();
+    expect(job!.mode).toBe("workflow");
+    expect(job!.workflowName).toBe("triage-inbox");
+
+    // workflowArgs is not in the list projection; assert it round-trips at the
+    // store layer (this is what the scheduler reads).
+    const stored = listSchedules().find((s) => s.name === "Workflow schedule")!;
+    expect(stored.workflowArgs).toEqual({ folder: "primary", limit: 10 });
   });
 
   test("respects enabled=false", () => {

--- a/assistant/src/__tests__/task-scheduler.test.ts
+++ b/assistant/src/__tests__/task-scheduler.test.ts
@@ -44,6 +44,22 @@ mock.module("../runtime/background-job-runner.js", () => ({
   },
 }));
 
+// Capture workflow-mode dispatch. The scheduler's `workflow` branch calls
+// `getWorkflowRunManager().start(...)`; we stub the singleton so each trigger
+// is observable without spinning up the real engine.
+const workflowStartCalls: Array<Record<string, unknown>> = [];
+let workflowStartImpl: (opts: Record<string, unknown>) => { runId: string } = (
+  opts,
+) => {
+  workflowStartCalls.push(opts);
+  return { runId: "wf-run-1" };
+};
+mock.module("../workflows/run-manager.js", () => ({
+  getWorkflowRunManager: () => ({
+    start: (opts: Record<string, unknown>) => workflowStartImpl(opts),
+  }),
+}));
+
 // Capture `emitNotificationSignal` calls so tests can assert that scheduled
 // task failures surface via the notification pipeline (home feed + native).
 const emitNotificationCalls: Array<Record<string, unknown>> = [];
@@ -458,5 +474,117 @@ describe("scheduler run_task detection", () => {
       totalEstimatedCostUsd: 0.1,
       eventCount: 1,
     });
+  });
+});
+
+// ── Workflow mode dispatch ──────────────────────────────────────────
+
+describe("scheduler workflow mode", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run("DELETE FROM cron_runs");
+    db.run("DELETE FROM cron_jobs");
+    workflowStartCalls.length = 0;
+    workflowStartImpl = (opts) => {
+      workflowStartCalls.push(opts);
+      return { runId: "wf-run-1" };
+    };
+  });
+
+  test("a due workflow-mode job triggers the run manager with name/args", async () => {
+    const schedule = createSchedule({
+      name: "Triage inbox",
+      cronExpression: "0 9 * * *",
+      message: "triage",
+      syntax: "cron",
+      mode: "workflow",
+      workflowName: "triage-inbox",
+      workflowArgs: { folder: "primary" },
+      wakeConversationId: "conv-origin",
+    });
+    forceScheduleDue(schedule.id);
+
+    const result = await runScheduleDueWorkOnce(
+      async () => {},
+      () => {},
+    );
+
+    expect(result.completed).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(workflowStartCalls).toHaveLength(1);
+    expect(workflowStartCalls[0]).toMatchObject({
+      name: "triage-inbox",
+      args: { folder: "primary" },
+      conversationId: "conv-origin",
+      manifest: { tools: [], hostFunctions: [], persona: false },
+    });
+
+    const runs = getScheduleRuns(schedule.id);
+    expect(runs).toHaveLength(1);
+    expect(runs[0].status).toBe("ok");
+  });
+
+  test("defaults workflowArgs to {} when unset", async () => {
+    const schedule = createSchedule({
+      name: "No-args workflow",
+      cronExpression: "0 9 * * *",
+      message: "go",
+      syntax: "cron",
+      mode: "workflow",
+      workflowName: "nightly",
+    });
+    forceScheduleDue(schedule.id);
+
+    await runScheduleDueWorkOnce(
+      async () => {},
+      () => {},
+    );
+
+    expect(workflowStartCalls).toHaveLength(1);
+    expect(workflowStartCalls[0].args).toEqual({});
+  });
+
+  test("records an error and skips when start() throws", async () => {
+    workflowStartImpl = () => {
+      throw new Error("workflows disabled");
+    };
+    const schedule = createSchedule({
+      name: "Failing workflow",
+      cronExpression: "0 9 * * *",
+      message: "go",
+      syntax: "cron",
+      mode: "workflow",
+      workflowName: "broken",
+    });
+    forceScheduleDue(schedule.id);
+
+    const result = await runScheduleDueWorkOnce(
+      async () => {},
+      () => {},
+    );
+
+    expect(result.failed).toBe(1);
+    const runs = getScheduleRuns(schedule.id);
+    expect(runs[0].status).toBe("error");
+    expect(runs[0].error).toContain("workflows disabled");
+  });
+
+  test("skips a workflow-mode job with no workflowName", async () => {
+    const schedule = createSchedule({
+      name: "Nameless workflow",
+      cronExpression: "0 9 * * *",
+      message: "go",
+      syntax: "cron",
+      mode: "workflow",
+    });
+    forceScheduleDue(schedule.id);
+
+    const result = await runScheduleDueWorkOnce(
+      async () => {},
+      () => {},
+    );
+
+    expect(result.skipped).toBe(1);
+    expect(workflowStartCalls).toHaveLength(0);
   });
 });

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -198,6 +198,7 @@ import {
   migrateScheduleScriptTimeout,
   migrateScheduleSourceConversation,
   migrateScheduleWakeConversationId,
+  migrateScheduleWorkflowMode,
   migrateSchemaIndexesAndColumns,
   migrateScrubCorruptedImageAttachments,
   migrateSlackCompactionWatermark,
@@ -500,6 +501,7 @@ export function initializeDb(): void {
     createSkillLoadedEventsTable,
     migrateConversationsSurfacedAt,
     migrateWorkflowRuns,
+    migrateScheduleWorkflowMode,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/282-schedule-workflow-mode.ts
+++ b/assistant/src/memory/migrations/282-schedule-workflow-mode.ts
@@ -1,0 +1,26 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Add `workflow_name` + `workflow_args_json` columns to `cron_jobs`.
+ *
+ * These back the new `workflow` schedule mode, which triggers a saved
+ * workflow by name on a schedule. Both are nullable and only populated for
+ * `mode = 'workflow'` rows; existing schedules stay NULL and unchanged.
+ *
+ * Idempotent — each ALTER is wrapped so a re-run (column already present)
+ * is a no-op.
+ */
+export function migrateScheduleWorkflowMode(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  try {
+    raw.exec(`ALTER TABLE cron_jobs ADD COLUMN workflow_name TEXT`);
+  } catch {
+    /* Column already exists */
+  }
+  try {
+    raw.exec(`ALTER TABLE cron_jobs ADD COLUMN workflow_args_json TEXT`);
+  } catch {
+    /* Column already exists */
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -273,6 +273,7 @@ export { migrateToolInvocationsTelemetryColumns } from "./278-tool-invocations-t
 export { createSkillLoadedEventsTable } from "./279-create-skill-loaded-events.js";
 export { migrateConversationsSurfacedAt } from "./280-conversations-surfaced-at.js";
 export { migrateWorkflowRuns } from "./281-workflow-runs.js";
+export { migrateScheduleWorkflowMode } from "./282-schedule-workflow-mode.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/infrastructure.ts
+++ b/assistant/src/memory/schema/infrastructure.ts
@@ -35,6 +35,8 @@ export const cronJobs = sqliteTable("cron_jobs", {
     .default(false), // reuse the same conversation across runs
   script: text("script"), // shell command for script mode (nullable, only used when mode = 'script')
   wakeConversationId: text("wake_conversation_id"), // target conversation for wake mode (nullable)
+  workflowName: text("workflow_name"), // saved workflow to trigger (nullable, only used when mode = 'workflow')
+  workflowArgsJson: text("workflow_args_json"), // JSON-encoded args passed to the workflow run (nullable)
   createdAt: integer("created_at").notNull(),
   updatedAt: integer("updated_at").notNull(),
 });

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -7,6 +7,8 @@
 
 import { z } from "zod";
 
+import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
+import { getConfig } from "../../config/loader.js";
 import { getOrCreateConversation } from "../../daemon/conversation-store.js";
 import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../../daemon/trust-context.js";
 import { bootstrapConversation } from "../../memory/conversation-bootstrap.js";
@@ -71,11 +73,12 @@ const scheduleSchema = z.object({
   createdFromConversationArchivedAt: z.number().nullable(),
   description: z.string(),
   cadenceDescription: z.string(),
-  mode: z.enum(["notify", "execute", "script", "wake"]),
+  mode: z.enum(["notify", "execute", "script", "wake", "workflow"]),
   status: z.enum(["active", "firing", "fired", "cancelled"]),
   routingIntent: z.enum(["single_channel", "multi_channel", "all_channels"]),
   reuseConversation: z.boolean(),
   wakeConversationId: z.string().nullable(),
+  workflowName: z.string().nullable(),
   isOneShot: z.boolean(),
 });
 
@@ -199,6 +202,7 @@ function handleListSchedules(queryParams: Record<string, string>) {
         routingIntent: j.routingIntent,
         reuseConversation: j.reuseConversation,
         wakeConversationId: j.wakeConversationId,
+        workflowName: j.workflowName,
         isOneShot: isOneShotForDisplay(j),
       };
     }),
@@ -229,11 +233,12 @@ function handleCreateSchedule(body: Record<string, unknown>) {
     throw new BadRequestError("description is required");
   }
 
-  // The settings UI only exposes execute mode for now. Other modes
-  // remain reachable via the schedule_create LLM tool.
-  if (mode !== "execute") {
+  // The settings UI only exposes execute mode; `workflow` mode is reachable
+  // here (flag-gated) and via the schedule_create LLM tool. All other modes
+  // remain tool-only.
+  if (mode !== "execute" && mode !== "workflow") {
     throw new BadRequestError(
-      "Only 'execute' mode is supported by this endpoint",
+      "Only 'execute' and 'workflow' modes are supported by this endpoint",
     );
   }
 
@@ -242,6 +247,39 @@ function handleCreateSchedule(body: Record<string, unknown>) {
     throw new BadRequestError(
       "expression could not be parsed as cron or rrule",
     );
+  }
+
+  if (mode === "workflow") {
+    assertWorkflowsEnabled();
+    const workflowName =
+      typeof body.workflowName === "string" ? body.workflowName.trim() : "";
+    if (!workflowName) {
+      throw new BadRequestError(
+        "workflowName is required for workflow-mode schedules",
+      );
+    }
+    try {
+      const job = createSchedule({
+        name,
+        description,
+        message,
+        mode: "workflow",
+        workflowName,
+        workflowArgs: body.workflowArgs,
+        enabled,
+        timezone,
+        expression: normalized.expression,
+        syntax: normalized.syntax,
+      });
+      log.info(
+        { id: job.id, name: job.name, workflowName },
+        "Workflow schedule created",
+      );
+    } catch (err) {
+      if (err instanceof Error) throw new BadRequestError(err.message);
+      throw err;
+    }
+    return handleListSchedules({});
   }
 
   try {
@@ -261,6 +299,17 @@ function handleCreateSchedule(body: Record<string, unknown>) {
     throw err;
   }
   return handleListSchedules({});
+}
+
+/**
+ * Reject workflow-mode schedule operations when the `workflows` feature flag
+ * is off. Scheduled workflow runs would fail at trigger time (the run manager
+ * hard-fails with WorkflowsDisabledError), so we fail fast at the route.
+ */
+function assertWorkflowsEnabled(): void {
+  if (!isAssistantFeatureFlagEnabled("workflows", getConfig())) {
+    throw new BadRequestError("Workflows are not enabled.");
+  }
 }
 
 function handleToggleSchedule(id: string, body: Record<string, unknown>) {
@@ -295,7 +344,13 @@ function handleCancelSchedule(id: string) {
   return handleListSchedules({});
 }
 
-const VALID_MODES = ["notify", "execute", "script", "wake"] as const;
+const VALID_MODES = [
+  "notify",
+  "execute",
+  "script",
+  "wake",
+  "workflow",
+] as const;
 const VALID_ROUTING_INTENTS = [
   "single_channel",
   "multi_channel",
@@ -322,6 +377,11 @@ function handleUpdateSchedule(id: string, body: Record<string, unknown>) {
     );
   }
 
+  // Switching a schedule into workflow mode requires the workflows flag.
+  if (body.mode === "workflow") {
+    assertWorkflowsEnabled();
+  }
+
   const updates: Record<string, unknown> = {};
   for (const key of [
     "name",
@@ -334,6 +394,8 @@ function handleUpdateSchedule(id: string, body: Record<string, unknown>) {
     "quiet",
     "reuseConversation",
     "wakeConversationId",
+    "workflowName",
+    "workflowArgs",
     "maxRetries",
     "retryBackoffMs",
     "timeoutMs",
@@ -525,7 +587,18 @@ export const ROUTES: RouteDefinition[] = [
         .boolean()
         .describe("Whether the schedule starts active (default true)")
         .optional(),
-      mode: z.string().describe("Currently must be 'execute'").optional(),
+      mode: z
+        .string()
+        .describe("'execute' (default) or 'workflow' (flag-gated)")
+        .optional(),
+      workflowName: z
+        .string()
+        .describe("Saved workflow to trigger (required for workflow mode)")
+        .optional(),
+      workflowArgs: z
+        .unknown()
+        .describe("Args passed to the workflow run (workflow mode)")
+        .optional(),
     }),
     responseBody: z.object({
       schedules: z.array(scheduleSchema).describe("Updated schedule list"),
@@ -615,7 +688,19 @@ export const ROUTES: RouteDefinition[] = [
         .nullable()
         .describe("Shell command for script mode")
         .optional(),
-      mode: z.string().describe("notify, execute, or script").optional(),
+      mode: z
+        .string()
+        .describe("notify, execute, script, wake, or workflow")
+        .optional(),
+      workflowName: z
+        .string()
+        .nullable()
+        .describe("Saved workflow to trigger (workflow mode)")
+        .optional(),
+      workflowArgs: z
+        .unknown()
+        .describe("Args passed to the workflow run (workflow mode)")
+        .optional(),
       routingIntent: z
         .string()
         .describe("single_channel, multi_channel, or all_channels")

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -26,7 +26,12 @@ function notifySchedulesChanged(): void {
     );
 }
 
-export type ScheduleMode = "notify" | "execute" | "script" | "wake";
+export type ScheduleMode =
+  | "notify"
+  | "execute"
+  | "script"
+  | "wake"
+  | "workflow";
 export type RoutingIntent = "single_channel" | "multi_channel" | "all_channels";
 export type ScheduleStatus = "active" | "firing" | "fired" | "cancelled";
 
@@ -42,6 +47,10 @@ export interface ScheduleJob {
   message: string;
   script: string | null;
   wakeConversationId: string | null;
+  /** Saved workflow to trigger; only used when mode = 'workflow'. */
+  workflowName: string | null;
+  /** Args passed verbatim to the workflow run; only used when mode = 'workflow'. */
+  workflowArgs: unknown;
   nextRunAt: number;
   lastRunAt: number | null;
   lastStatus: string | null;
@@ -92,6 +101,8 @@ export function createSchedule(params: {
   message: string;
   script?: string | null;
   wakeConversationId?: string | null;
+  workflowName?: string | null;
+  workflowArgs?: unknown;
   enabled?: boolean;
   createdBy?: string;
   syntax?: ScheduleSyntax;
@@ -168,6 +179,11 @@ export function createSchedule(params: {
     message: params.message,
     script: params.script ?? null,
     wakeConversationId: params.wakeConversationId ?? null,
+    workflowName: params.workflowName ?? null,
+    workflowArgsJson:
+      params.workflowArgs === undefined
+        ? null
+        : JSON.stringify(params.workflowArgs),
     nextRunAt,
     lastRunAt: null as number | null,
     lastStatus: null as string | null,
@@ -273,6 +289,8 @@ export function updateSchedule(
     quiet?: boolean;
     reuseConversation?: boolean;
     wakeConversationId?: string | null;
+    workflowName?: string | null;
+    workflowArgs?: unknown;
     maxRetries?: number;
     retryBackoffMs?: number;
     timeoutMs?: number | null;
@@ -340,6 +358,15 @@ export function updateSchedule(
     set.reuseConversation = updates.reuseConversation;
   if (updates.wakeConversationId !== undefined)
     set.wakeConversationId = updates.wakeConversationId;
+  if (updates.workflowName !== undefined)
+    set.workflowName = updates.workflowName;
+  // `workflowArgs` may legitimately be any JSON value (including null), so
+  // detect presence by key rather than `!== undefined`.
+  if ("workflowArgs" in updates)
+    set.workflowArgsJson =
+      updates.workflowArgs === undefined
+        ? null
+        : JSON.stringify(updates.workflowArgs);
   if (updates.maxRetries !== undefined) set.maxRetries = updates.maxRetries;
   if (updates.retryBackoffMs !== undefined)
     set.retryBackoffMs = updates.retryBackoffMs;
@@ -999,6 +1026,8 @@ function parseJobRow(row: typeof scheduleJobs.$inferSelect): ScheduleJob {
     message: row.message,
     script: row.script ?? null,
     wakeConversationId: row.wakeConversationId ?? null,
+    workflowName: row.workflowName ?? null,
+    workflowArgs: parseOptionalJson(row.workflowArgsJson),
     nextRunAt: row.nextRunAt,
     lastRunAt: row.lastRunAt,
     lastStatus: row.lastStatus,
@@ -1035,6 +1064,20 @@ function safeParseJson(
     return JSON.parse(json) as Record<string, unknown>;
   } catch {
     return {};
+  }
+}
+
+/**
+ * Parse a nullable JSON column into an arbitrary value. Unlike
+ * {@link safeParseJson}, the result is not coerced to an object — workflow
+ * args may be any JSON value — and an absent/unparseable column yields null.
+ */
+function parseOptionalJson(json: string | null | undefined): unknown {
+  if (json == null) return null;
+  try {
+    return JSON.parse(json);
+  } catch {
+    return null;
   }
 }
 

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -3,6 +3,7 @@ import {
   diskPressureBackgroundSkipLogFields,
   shouldLogDiskPressureBackgroundSkip,
 } from "../daemon/disk-pressure-background-gate.js";
+import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../daemon/trust-context.js";
 import { bootstrapConversation } from "../memory/conversation-bootstrap.js";
 import { getConversation } from "../memory/conversation-crud.js";
 import { invalidateAssistantInferredItemsForConversation } from "../memory/task-memory-cleanup.js";
@@ -12,6 +13,7 @@ import { runBackgroundJob } from "../runtime/background-job-runner.js";
 import { runSequencesOnce } from "../sequence/engine.js";
 import { getLogger } from "../util/logger.js";
 import { runWatchersOnce, type WatcherNotifier } from "../watcher/engine.js";
+import { getWorkflowRunManager } from "../workflows/run-manager.js";
 import { hasSetConstructs } from "./recurrence-engine.js";
 import { applyRetryDecision, decideRetry } from "./retry-policy.js";
 import { runScript, type ScriptResult } from "./run-script.js";
@@ -426,6 +428,61 @@ export async function runScheduleDueWorkOnce(
           status: "error",
           error: errorMsg,
         });
+        handleExecutionFailure({ job, errorMsg, isOneShot });
+        failed = true;
+      }
+      mark(failed ? "failed" : "completed");
+      continue;
+    }
+
+    // ── Workflow mode (trigger a saved workflow by name) ────────────
+    if (job.mode === "workflow") {
+      if (!job.workflowName) {
+        log.warn(
+          { jobId: job.id, name: job.name },
+          "Workflow schedule has no workflowName — skipping",
+        );
+        mark("skipped");
+        continue;
+      }
+      const runId = createScheduleRun(job.id, `workflow:${job.id}`);
+      let failed = false;
+      try {
+        log.info(
+          {
+            jobId: job.id,
+            name: job.name,
+            workflowName: job.workflowName,
+            isOneShot,
+          },
+          "Triggering workflow schedule",
+        );
+        // V1 LIMITATION: scheduled workflows run with the read-only baseline
+        // manifest only (no tools / host functions / persona). The schedule
+        // record carries no capability manifest, so declaring side-effecting
+        // tools for scheduled runs is a future enhancement.
+        const { runId: workflowRunId } = getWorkflowRunManager().start({
+          name: job.workflowName,
+          args: job.workflowArgs ?? {},
+          conversationId: job.wakeConversationId ?? undefined,
+          manifest: { tools: [], hostFunctions: [], persona: false },
+          trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT,
+        });
+        // `start` launches the run fire-and-forget and returns synchronously;
+        // a successful trigger is recorded as ok. Workflow completion/failure
+        // is surfaced out-of-band via workflow events and the completion wake.
+        completeScheduleRun(runId, {
+          status: "ok",
+          output: `workflow run ${workflowRunId} started`,
+        });
+        if (isOneShot) completeOneShot(job.id);
+      } catch (err) {
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        log.warn(
+          { err, jobId: job.id, name: job.name, isOneShot },
+          "Workflow schedule trigger failed",
+        );
+        completeScheduleRun(runId, { status: "error", error: errorMsg });
         handleExecutionFailure({ job, errorMsg, isOneShot });
         failed = true;
       }


### PR DESCRIPTION
## Summary
- Add a 'workflow' schedule mode that triggers a saved workflow by name via WorkflowRunManager (read-only baseline manifest in v1). Flag-gated at the route.

Part of plan: workflow-engine.md (PR 13 of 17)