### PR TITLE
docs(workflows): authoring guide and architecture updates

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -22,6 +22,9 @@ This file is the cross-system architecture index. Detailed designs live in domai
 | Multi-local instance isolation              | [Multi-Local Instance Isolation](#multi-local-instance-isolation) (this file)                      |
 | Docker volume architecture                  | [Docker Volume Architecture](#docker-volume-architecture) (this file)                              |
 | Web search failure normalization            | [Web Search Failure Normalization](#web-search-failure-normalization) (this file)                  |
+| Workflow orchestration engine               | [Workflow Orchestration Engine](#workflow-orchestration-engine) (this file)                        |
+| Workflow authoring guide                    | [`assistant/docs/workflows.md`](assistant/docs/workflows.md)                                       |
+| Workflow manual testing runbook             | [`assistant/docs/workflows-testing.md`](assistant/docs/workflows-testing.md)                       |
 | Service communication matrix                | [`docs/service-communication-matrix.md`](docs/service-communication-matrix.md)                     |
 
 ## Cross-Cutting Invariants
@@ -47,6 +50,7 @@ This file is the cross-system architecture index. Detailed designs live in domai
 - **Assistant feature flags** control skill availability at runtime. The canonical key format is simple kebab-case (e.g., `browser`, `ces-tools`); the legacy `feature_flags.<id>.enabled` and `skills.<id>.enabled` formats are no longer supported. All declared flags live in the unified registry at `meta/feature-flags/feature-flag-registry.json`, scoped by `scope` (`assistant` or `client`). Labels come from the registry. Bundled copies exist at `assistant/src/config/feature-flag-registry.json` and `gateway/src/feature-flag-registry.json`. The gateway owns the `/v1/feature-flags` REST API and the IPC `get_feature_flags` method (see [`gateway/ARCHITECTURE.md`](gateway/ARCHITECTURE.md)); the assistant resolves effective flag state via IPC to the gateway socket (`gateway.sock`) — see [`assistant/ARCHITECTURE.md`](assistant/ARCHITECTURE.md). When a flag is OFF, the corresponding skill is excluded from all exposure surfaces: client skill lists, system prompt catalog, `skill_load`, runtime tool projection, and included child skills. Guard tests enforce that all flag keys in code use the canonical format and that all referenced flags are declared in the unified registry.
 - **Safe storage limits** protect the workspace volume. When workspace disk usage reaches the critical 95% threshold, the assistant enters storage cleanup mode: background work is skipped, remote ingress including trusted-contact messages is blocked, local guardian turns get cleanup-specific runtime instructions, and clients must show acknowledgement/status UI until enough space is freed or the guardian explicitly overrides the lock. See [Safe Storage Limits](#safe-storage-limits).
 - **Permission controls v2** removes deterministic tool-by-tool approval friction for assistant-owned actions. Under `permission-controls-v2`, the only built-in deterministic approval surface is conversation-scoped host computer access for `host_*` / host-target tools. All other assistant-owned tool usage relies on model-mediated consent, not temporary approvals, wildcard scopes, per-tool persistence, or network/side-effect approval cards. Cross-principal identity checks (for example unknown actors) still fail closed deterministically.
+- **Workflow orchestration** (gated by the `workflows` flag, default off): the assistant authors JS/TS scripts that run in a QuickJS-WASM sandbox and fan out to parallel ephemeral leaf agents. Scripts get **hooks only** — no filesystem, network, process, or ambient capabilities — because a script may be authored after the assistant has read untrusted content. The per-run **capability declaration is the single consent point** (no per-call approval prompts inside a run), and the only runaway guard is the per-run **agent cap** (`maxAgentsPerRun`, default 500) — there is no dollar kill-switch by design. Scripts must be deterministic (no `Date.now`/`Math.random`/argless `new Date()`) so a journaled run can resume after a restart by replaying the unchanged call prefix. See [Workflow Orchestration Engine](#workflow-orchestration-engine) and [`assistant/docs/workflows.md`](assistant/docs/workflows.md).
 - **Context overflow resilience**: The session loop implements a deterministic overflow convergence pipeline that recovers from context-too-large failures without surfacing errors to users. A preflight budget check catches overflow before provider calls; a tiered reducer (forced compaction, tool-result truncation, media stubbing, injection downgrade) iteratively shrinks the payload; and when all tiers are exhausted the overflow policy resolver auto-compresses the latest turn with no user prompt — this applies equally to interactive and non-interactive sessions. Setting `contextWindow.overflowRecovery.interactiveLatestTurnCompression` to `"drop"` opts interactive sessions out, and `contextWindow.overflowRecovery.nonInteractiveLatestTurnCompression: "drop"` opts non-interactive/background sessions out independently — either short-circuits to a graceful failure for that session type; setting `contextWindow.overflowRecovery.enabled: false` also yields a graceful failure. Config lives under `contextWindow.overflowRecovery`. See [`assistant/ARCHITECTURE.md`](assistant/ARCHITECTURE.md#context-overflow-recovery) for the full design and [`assistant/docs/architecture/memory.md`](assistant/docs/architecture/memory.md#context-compaction-and-overflow-recovery-interaction) for compaction interaction details.
 
 ## Environment and Data Layout
@@ -648,6 +652,60 @@ Every `web_search` failure path funnels through a single classification layer so
 - **No conflation with `web_fetch`.** The normalization layer keys exclusively on `web_search` (native server-tool web_search and the app-side search tool). It never inspects `WebFetchMetadata`, so a `web_fetch` DNS failure (e.g. an unresolved host) keeps its own `webFetch.errorMessage` and is never rewritten to the search backend copy.
 
 End-to-end coverage lives in `assistant/src/__tests__/web-search-backend-failure.test.ts`.
+
+## Workflow Orchestration Engine
+
+The workflow engine lets the assistant author a short JS/TS script that runs in a sandbox and fans work out across many parallel, ephemeral **leaf agents** — for example: score every option in a list in parallel, then synthesize the winner. It is gated by the `workflows` feature flag (default off) and lives under `assistant/src/workflows/` with the launching tools at `assistant/src/tools/workflows/`. The authoring guide and a manual e2e runbook are at [`assistant/docs/workflows.md`](assistant/docs/workflows.md) and [`assistant/docs/workflows-testing.md`](assistant/docs/workflows-testing.md).
+
+### Modules
+
+- **`run-manager.ts`** (`WorkflowRunManager`) — the lifecycle surface the tool, scheduler, and routes drive. Gates on the feature flag and the concurrent-run cap, resolves the capability manifest, creates the journal run row, launches `executeWorkflow` **without awaiting it** (returns the `runId` immediately), and republishes engine progress/completion as `workflow_progress` / `workflow_completed` events. On completion it wakes the originating conversation with a human-readable summary via the same `wakeAgentForOpportunity` path scheduled tasks and background shell jobs use.
+- **`engine.ts`** (`executeWorkflow`) — runs the script in the sandbox and owns the host API (`agent`, `leaf`, `parallel`, `map`, `pipeline`, `phase`, `log`, `usage`, `workflow`, `args`), the deterministic `seq` assignment, the agent cap, and journaled resume. `map`/`pipeline` are JS-prelude helpers over the `parallel` host function (the single-threaded VM cannot re-enter itself mid-call); `pipeline` has a per-stage barrier.
+- **`sandbox.ts`** (`createWorkflowSandbox`) — a fresh QuickJS-WASM VM per run with **no** `fetch`/`process`/`Bun`/`require`/network/filesystem and a banned `Date.now`/`Math.random`/argless `new Date()`. Host functions are *asyncified*: a host call suspends the whole VM until its promise settles, so from the script's view host calls are **synchronous** (authors write `const r = agent(...)`, never `await`). An interrupt handler enforces a CPU deadline and cooperative abort.
+- **`capabilities.ts`** (`resolveCapabilities`) — resolves the per-run manifest into the concrete allow-set: a read-only baseline (`file_read`, `file_list`, `recall`, `web_search`, `web_fetch`) unioned with declared `tools`, with a forbidden set always denied. This is the single consent point; the leaf runner hard-denies anything outside it.
+- **`leaf-runner.ts`** (`runLeaf`) — the single-leaf primitive. A *schema* leaf makes one forced-`tool_choice` provider call returning structured output (no tools); a *tool* leaf runs a restricted agent loop. Leaves are anonymous by default (minimal task prompt, no identity, no memory); `persona: true` injects the assistant identity + memory pipeline. No leaf ever creates a conversation row, jsonl mirror, title job, or turn broadcast. Every leaf call resolves through the `workflowLeaf` call site (cost-optimized profile by default).
+- **`journal-store.ts`** — typed persistence over the `workflow_runs` and `workflow_journal` tables (migration 281). The journal is an append-only `(run_id, seq)` log; on resume the engine replays cached results for the unchanged call prefix instead of re-spawning agents.
+- **`library.ts`** — saved workflows at `<workspace>/workflows/*.workflow.ts`, resolvable by name (by `meta.name`, then filename base) for `run_workflow({ name })`, `workflow(name)`, and the scheduler's `workflow` mode.
+
+### Data flow
+
+```mermaid
+graph TB
+    TOOL["run_workflow tool<br/>(flag-gated)"]
+    SCHED["Scheduler<br/>(workflow mode)"]
+    RM["WorkflowRunManager<br/>flag + run-cap gate<br/>async launch"]
+    CAPS["resolveCapabilities<br/>baseline ∪ declared − forbidden"]
+    ENGINE["executeWorkflow<br/>host API + seq + agent cap"]
+    SANDBOX["QuickJS-WASM sandbox<br/>synchronous host calls<br/>no fs/net/process"]
+    LEAVES["Leaf agents (parallel)<br/>schema | tool · anon | persona"]
+    JOURNAL["workflow_runs +<br/>workflow_journal<br/>(journaled resume)"]
+    USAGE["llm_usage_events<br/>call_site = workflowLeaf"]
+    HUB["assistant event hub<br/>workflow_progress / _completed"]
+    WAKE["Conversation wake<br/>completion summary"]
+    ROUTES["GET /v1/workflows*<br/>+ vellum workflows CLI"]
+
+    TOOL --> RM
+    SCHED --> RM
+    RM --> CAPS
+    CAPS --> ENGINE
+    RM --> ENGINE
+    ENGINE --> SANDBOX
+    SANDBOX -->|"agent / parallel / map / pipeline"| LEAVES
+    LEAVES -->|"results back into the VM"| SANDBOX
+    ENGINE --> JOURNAL
+    LEAVES --> USAGE
+    ENGINE -->|"phase / log"| HUB
+    RM --> HUB
+    RM --> WAKE
+    JOURNAL --> ROUTES
+```
+
+### Tables, routes, and CLI
+
+- **Tables** (migration 281): `workflow_runs` (one row per run — status, agent/token counts, script source/hash, capabilities, originating conversation) and `workflow_journal` (append-only `(run_id, seq)` leaf-call log). Leaf cost is attributed in `llm_usage_events` under `call_site = 'workflowLeaf'`.
+- **Routes** (read/abort surfaces, all 404 when the flag is off): `GET /v1/workflows`, `GET /v1/workflows/runs`, `GET /v1/workflows/runs/:id`, `POST /v1/workflows/runs/:id/abort`.
+- **CLI**: `vellum workflows list | runs | show <id> | abort <id>`.
+- **Config** (`workflows.*`): `maxAgentsPerRun` (500), `maxConcurrentLeaves` (6), `maxConcurrentRuns` (3), `journalRetentionDays` (30).
 
 ## Maintenance Rule
 

--- a/assistant/docs/workflows-testing.md
+++ b/assistant/docs/workflows-testing.md
@@ -1,0 +1,204 @@
+# Workflows — Manual e2e / Live-Verification Runbook
+
+This runbook covers the parts of the workflow engine that automated tests do not:
+real provider calls, real journaled resume across a restart, capability
+containment under a live model, flag-off inertness, and persona-leaf voice. Unit
+and integration coverage lives under `assistant/src/workflows/*.test.ts` and
+`assistant/src/__tests__/`; this is the human-in-the-loop pass that runs **last**,
+on throwaway instances first, and only touches a real inbox or a production
+instance at the very end.
+
+Work through the steps in order. The `workflows` flag is **off by default**, so
+every step that exercises the engine first enables it on a throwaway instance.
+
+> **Safety rule:** Nothing in this runbook touches a real inbox, a real workspace,
+> or a production instance until every throwaway-instance step has passed. The
+> production/persona instance is the **last** step.
+
+---
+
+## 1. Hatch a throwaway instance and enable the flag
+
+Hatch a disposable Docker instance built from local source:
+
+```
+vellum hatch --remote docker --source .
+```
+
+Note the instance name it prints (e.g. `vellum-<adjective>-<animal>`). Use it as
+`--assistant <name>` for everything below, or set it active.
+
+Enable the `workflows` flag via that instance's feature-flag override file. The
+override lives in the instance's `protected/feature-flags.json` (overrides here
+win over the registry default — see the feature-flag-overrides gotcha):
+
+```jsonc
+// .../<instance>/protected/feature-flags.json
+{ "workflows": true }
+```
+
+Restart the instance so it re-reads the override, then confirm it is up:
+
+```
+vellum ps
+```
+
+Sanity-check that the surface is now live: `vellum workflows runs --assistant <name>`
+should return an (empty) table rather than a 404.
+
+---
+
+## 2. Synthetic-corpus run (no Gmail/Slack dependency)
+
+Drive a `run_workflow` over a **fixture item list passed as `args`** — no external
+integration. Ask the assistant (via `vellum events`-visible conversation, the app,
+or a CLI message) to run a small workflow such as the triage example from
+[`workflows.md`](./workflows.md), passing a dozen synthetic items in `args.items`.
+
+Watch the run:
+
+```
+vellum workflows runs  --assistant <name>          # find the runId
+vellum workflows show  <run-id> --assistant <name>  # status + agent/token counts
+vellum events          --assistant <name>           # workflow_progress / workflow_completed
+```
+
+Confirm:
+
+- The run reaches `completed`.
+- `agentsSpawned` matches the number of leaves the script should have launched.
+- A completion summary is injected back into the originating conversation.
+
+---
+
+## 3. Inspect the evidence
+
+Query the instance's database directly (the live DB is under the instance's
+`workspace/data/db/assistant.db`).
+
+**Leaf cost attribution** — confirm leaves ran on the cost-optimized model and
+tally spend:
+
+```sql
+SELECT model, COUNT(*) AS calls,
+       SUM(input_tokens)  AS in_tok,
+       SUM(output_tokens) AS out_tok,
+       SUM(estimated_cost_usd) AS usd
+FROM llm_usage_events
+WHERE call_site = 'workflowLeaf'
+GROUP BY model;
+```
+
+**Request shape** — confirm the schema path forced a tool and used a cheap model;
+for persona leaves, confirm identity + memory were injected:
+
+```sql
+SELECT id, created_at
+FROM llm_request_logs
+ORDER BY created_at DESC
+LIMIT 20;
+```
+
+Inspect a few `request_payload` bodies:
+
+- A **schema** leaf request carries `tool_choice` forcing the synthetic
+  `emit_result` tool and a cheap model id.
+- A **persona** leaf request's system prompt carries the assistant identity and a
+  `<memory>` block; an **anonymous** leaf's does not.
+
+---
+
+## 4. Restart-resume (journal replay)
+
+Start a **long** synthetic run (enough leaves that it is still in flight for a few
+seconds). While it is running, restart the assistant with **SIGTERM**:
+
+> **Never SIGKILL the assistant.** SIGKILL leaves WAL pages unmerged and forces a
+> costly recovery on the next start (and can corrupt an in-flight run). Use a
+> graceful stop / `vellum sleep` / SIGTERM with grace.
+
+After restart, re-invoke the **same `runId`** (re-run the same workflow with the
+same run id). Then assert journal replay:
+
+- Re-running does **not** double the `agentsSpawned` count or the
+  `llm_usage_events` rows for `call_site = 'workflowLeaf'` — the completed prefix
+  replays from the journal rather than re-spawning leaves.
+- Only leaves that had not completed before the restart produce new usage rows.
+
+```sql
+-- Before and after the re-invoke, this count should not grow for already-done leaves.
+SELECT COUNT(*) FROM llm_usage_events WHERE call_site = 'workflowLeaf';
+
+-- The journal holds one row per completed (run_id, seq); re-running does not duplicate them.
+SELECT run_id, COUNT(*) FROM workflow_journal GROUP BY run_id;
+```
+
+---
+
+## 5. Capability containment
+
+Author a workflow whose leaf tries to use a **side-effecting tool that is absent
+from its manifest** (e.g. a leaf prompt that pushes the model toward `file_write`
+or a send tool, with `capabilities.tools` left empty). Run it and confirm:
+
+- The forbidden tool invocation is **hard-denied** inside the leaf — it never
+  executes. The leaf gets an error result, not a permission prompt (there are no
+  per-call prompts inside a run).
+- Declaring a **forbidden** tool (`subagent_spawn`, `run_workflow`,
+  `manage_workflows`, `manage_secure_command_tool`) in `capabilities.tools` fails
+  the run synchronously at start — `run_workflow` returns an error and **no**
+  `running` row is created.
+
+---
+
+## 6. Flag-off inertness
+
+On a **default** instance (no `workflows` override, or set back to `false` and
+restart), confirm the whole surface is gone:
+
+- `run_workflow` and `manage_workflows` are **absent** from the tool set (the
+  assistant cannot call them).
+- The routes 404:
+
+  ```
+  vellum workflows runs --assistant <default-instance>   # request fails (404)
+  ```
+
+- A scheduler `workflow`-mode job is **rejected** (the engine gate throws before
+  any run is launched).
+
+---
+
+## 7. Real-data smoke (throwaway TEST account)
+
+Only after steps 1–6 pass: run the full path against a **throwaway TEST Google or
+Slack account** with about a dozen messages — never a real account. Drive the
+end-to-end flow:
+
+1. The assistant enumerates the relevant skill (e.g. `gmail`).
+2. It authors and launches a `run_workflow` over the real messages.
+3. Leaves synthesize results.
+4. Any side-effecting action (label, draft, reply) goes through the declared
+   capability manifest and the normal audited-action path.
+
+Confirm the run completes, the evidence queries from step 3 look right against
+real content, and every side effect was one the manifest declared.
+
+---
+
+## 8. Production / persona instance — LAST
+
+Flip the `workflows` flag on a real (e.g. persona) instance **only after** the
+throwaway instances above pass, and only after the instance is on current code:
+
+1. `git pull` and **restart** the instance so it runs the merged code (a restart
+   alone re-runs stale code — see the deploy gotcha).
+2. Enable the flag and restart.
+3. Start with the **smallest real slice** — a few items, dry-run actions where the
+   tool supports it — before any larger or side-effecting run.
+4. **Human-eval the persona-leaf voice**: read a persona leaf's output and confirm
+   it reads as the assistant, not as a generic worker.
+
+Stop and reassess if any run's `agentsSpawned` approaches `maxAgentsPerRun`, if
+spend (step 3 query) is higher than expected, or if any side effect was not one
+the manifest declared.

--- a/assistant/docs/workflows.md
+++ b/assistant/docs/workflows.md
@@ -1,0 +1,443 @@
+# Workflows — Authoring Guide
+
+The workflow engine lets the assistant author a short JS/TS script that runs in a
+sandbox and fans work out across many parallel, ephemeral **leaf agents**. A
+workflow is the right tool when a task decomposes into a lot of similar small
+sub-tasks that can run concurrently — score every item in a list, extract a field
+from each of a hundred documents, draft-then-verify a batch — and you want the
+results orchestrated deterministically and reported back when the whole run
+finishes.
+
+Workflows are gated behind the `workflows` feature flag (default **off**). When it
+is off, the `run_workflow` / `manage_workflows` tools are absent, the management
+routes 404, and the scheduler rejects `workflow`-mode jobs.
+
+- Engine code: `assistant/src/workflows/`
+- Launching tools: `assistant/src/tools/workflows/`
+- Architecture overview: [`ARCHITECTURE.md` § Workflow Orchestration Engine](../../ARCHITECTURE.md#workflow-orchestration-engine)
+- Manual e2e runbook: [`workflows-testing.md`](./workflows-testing.md)
+
+---
+
+## Why it works this way (design rationale)
+
+### The sandbox is hooks-only because scripts may be authored from untrusted input
+
+A workflow script can be written by the assistant **after** it has read untrusted
+content — a hostile email, a web page, a shared document. The script must
+therefore be unable to do anything on its own. It runs in a fresh QuickJS-WASM VM
+per run with **no** `fetch`, `XMLHttpRequest`, `WebSocket`, `process`, `Bun`,
+`require`, no dynamic `import()`, no timers, no filesystem, and no network. The
+only way a script affects the outside world is through the host functions the
+engine injects (`agent`, `parallel`, …). There are no ambient capabilities to
+escalate, and the sandbox stops the script from reaching around its declared
+capabilities.
+
+### The capability declaration is the single consent point
+
+A run declares **once**, up front, which side-effecting tools and host functions
+its leaves may use and whether they may speak in the assistant's persona. That
+declaration is the only place consent is given for the whole run — there are **no
+per-call permission prompts inside a running workflow**. This is deliberate: a
+run may spawn hundreds of leaves, and prompting per call would be unworkable and
+would defeat the point of unattended fan-out. Leaves always get a curated
+read-only baseline for free; anything that writes, sends, or executes must be
+named in the manifest.
+
+### The runaway guard is the agent cap — by design, no dollar kill-switch
+
+The only structural limit on a run is the **agent cap** (`maxAgentsPerRun`,
+default 500): the total number of leaves a single run may spawn. There is
+intentionally **no spend/dollar kill-switch**. The cap bounds the blast radius in
+a way that is deterministic and resume-safe (it counts agents, not wall-clock or
+cost), and leaves default to a cost-optimized model. Concurrency is separately
+bounded by `maxConcurrentLeaves` (default 6).
+
+### Scripts must be deterministic so runs can resume
+
+Every leaf call is journaled by a deterministic sequence number and an input
+hash. If the assistant restarts mid-run, re-invoking the same `runId` **replays
+the unchanged prefix from the journal** instead of re-spawning agents — so a
+long run survives a deploy or crash without redoing (or re-paying for) completed
+work. That guarantee only holds if the script is deterministic, so `Date.now()`,
+`Math.random()`, and argless `new Date()` **throw**. Pass any timestamps or seeds
+in through `args`.
+
+---
+
+## The script model
+
+### Scripts are SYNCHRONOUS — never use `await`
+
+This is the single most important authoring fact. Host functions are _asyncified_:
+calling one suspends the entire VM until the host-side promise settles, then
+resumes the VM with the value. From the script's perspective every host call is
+**synchronous** — you call it and the result comes back directly:
+
+```js
+const r = agent("Summarize this thread."); // r is the result, right here
+```
+
+Do **not** write `await agent(...)`, and do **not** make the script `async`.
+Asyncify can only suspend the main evaluation stack, never a promise
+continuation, so an `async`/`await` script would deadlock on its second host
+call. Write plain straight-line code.
+
+### Every script starts with a literal `meta`
+
+The first thing in a script must be a pure-literal export — no computed values,
+template strings, or concatenation:
+
+```js
+export const meta = {
+  name: "triage-inbox",
+  description: "Triage and label inbox messages",
+};
+```
+
+`meta` is extracted **statically**, without executing the script (the source is
+untrusted), so it must be a plain object literal with string `name` and
+`description`. The `name` is how a saved workflow is referenced by `workflow(name)`
+and the scheduler.
+
+The script's final expression is its result. End with the value you want
+returned:
+
+```js
+const result = agent(`Write the final summary: ${JSON.stringify(parts)}`);
+result; // returned as the run result
+```
+
+---
+
+## Host API reference
+
+All functions are synchronous from the script's perspective.
+
+| Function                     | Returns                                        | Notes                                                                                                                                                          |
+| ---------------------------- | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent(prompt, opts?)`       | the leaf's result                              | Runs ONE leaf. **Throws** on leaf failure.                                                                                                                     |
+| `leaf(prompt, opts?)`        | a leaf descriptor                              | Runs nothing on its own; used inside `parallel`/`map`/`pipeline`.                                                                                              |
+| `parallel(specs)`            | `results[]`                                    | Runs an array of `leaf(...)` descriptors concurrently (capped at `maxConcurrentLeaves`), results in input order. A failed leaf becomes `null` (never throws).  |
+| `map(items, build)`          | `results[]`                                    | `build(item, i)` returns a `leaf(...)` descriptor (or a bare prompt string) per item; runs them like `parallel`.                                               |
+| `pipeline(items, ...stages)` | `results[]`                                    | Each `stage(prev, i)` returns a `leaf(...)` descriptor or a plain value, where `prev` is the prior stage's result at index `i`. Per-stage barrier (see below). |
+| `phase(title)`               | —                                              | Marks a named phase; surfaced as a progress event.                                                                                                             |
+| `log(msg)`                   | —                                              | Emits a progress log line.                                                                                                                                     |
+| `usage()`                    | `{ agentsSpawned, inputTokens, outputTokens }` | Live snapshot so a script can self-moderate.                                                                                                                   |
+| `workflow(name, args?)`      | the child's result                             | Runs a SAVED workflow inline, depth 1 only (see Nesting).                                                                                                      |
+| `args`                       | the run input                                  | The `args` object passed to `run_workflow`.                                                                                                                    |
+
+### `agent` vs `parallel` failure semantics
+
+`agent(...)` is for a single sequential leaf and **throws** if that leaf fails —
+an unhandled throw fails the whole run. `parallel(...)` is the fan-out primitive
+and **never throws on a single leaf**: a failed leaf is `null` in the results
+array, so a batch survives a few bad items. `map` and `pipeline` are built on
+`parallel` and share that null-on-failure behavior.
+
+### `pipeline` has a per-stage barrier
+
+`pipeline(items, stageA, stageB)` runs `stageA` across all items in parallel,
+**waits for all of stage A to finish**, then runs `stageB` across stage A's
+results. There is no cross-stage streaming in v1 — item _n_ does not advance to
+stage B early just because its stage A finished first. Each `stage(prev, i)`
+callback receives the prior stage's result for index `i`. This barrier is a
+consequence of the single-threaded VM and is honest about its cost: a pipeline is
+only as fast as the slowest leaf in each stage.
+
+### Leaf options (`opts` for `agent` / `leaf`)
+
+| Option    | Type                       | Effect                                                                                  |
+| --------- | -------------------------- | --------------------------------------------------------------------------------------- |
+| `schema`  | JSON Schema object literal | Forces structured output via a tool. A schema leaf runs with **no tools**.              |
+| `label`   | string                     | Short display/diagnostic label for the leaf.                                            |
+| `profile` | string                     | Overrides the model profile. Must exist in `llm.profiles` or the leaf throws.           |
+| `persona` | boolean                    | `true` makes the leaf speak as the assistant (identity + memory). Default is anonymous. |
+
+#### `schema` is a JSON Schema literal, not Zod
+
+A script runs in the sandbox and cannot hold a host-side Zod object, so a leaf's
+`schema` is a plain **JSON Schema object literal**. The engine builds a forced
+`tool_choice` call whose synthetic tool input is that schema, validates the
+model's output against it, and returns the structured object. A leaf with a
+`schema` is a pure judge/extractor — it gets **no tools**:
+
+```js
+leaf(`Score this option 0-10 for fit: ${opt}`, {
+  schema: {
+    type: "object",
+    properties: { score: { type: "number" } },
+    required: ["score"],
+  },
+});
+```
+
+#### `persona` vs anonymous leaves, and profile resolution
+
+By default a leaf is **anonymous**: a minimal task-scoped system prompt, no
+assistant identity, no memory pipeline. Use anonymous leaves for impartial
+judging, scoring, and extraction of input — the bulk of fan-out work.
+
+`persona: true` opts the leaf into **persona mode**: it carries the assistant's
+identity system prompt and runs the same memory-injection pipeline a normal turn
+uses, so its output is authentically the assistant's voice (e.g. drafting a reply
+to be sent). This is the costly path — use it for the small number of leaves whose
+output is meant to be _in the assistant's voice_, not for bulk judging.
+
+Model profile resolution:
+
+- An explicit `profile` always wins and is validated up front — an unknown
+  profile throws (a deliberate, loud failure rather than a silent downgrade).
+- With no explicit `profile`, a **persona** leaf mirrors the main agent: the
+  workspace `activeProfile` floats above the call-site default (a deleted/stale
+  active profile degrades gracefully to the default).
+- With no explicit `profile`, an **anonymous** leaf uses the shipped
+  `workflowLeaf` call-site default (cost-optimized).
+
+No leaf — anonymous or persona — ever creates a conversation row, jsonl mirror,
+title job, or turn broadcast. Leaves are ephemeral.
+
+---
+
+## Capability manifest semantics
+
+The `capabilities` argument to `run_workflow` is the single consent point:
+
+```jsonc
+{
+  "tools": ["file_write", "gmail_send"], // side-effecting tools granted to leaves
+  "hostFunctions": [], // host-function names the run may invoke
+  "persona": true, // grant leaves persona (identity + memory) access
+}
+```
+
+Resolution: the leaf tool set is the **read-only baseline ∪ declared `tools`**,
+minus a forbidden set.
+
+- **Read-only baseline** (always available, no declaration needed): `file_read`,
+  `file_list`, `recall`, `web_search`, `web_fetch`.
+- **Declared tools** must exist in the tool registry — an unknown name is a hard
+  authoring error, not a silent drop.
+- **Forbidden tools** can never be granted, even if declared (declaring one is a
+  hard error): `subagent_spawn`, `run_workflow`, `manage_workflows`,
+  `manage_secure_command_tool`. These are recursion vectors or human-in-the-loop
+  install paths that must not be delegated to an unattended leaf.
+
+Side-effecting tools (`file_write`, sends, shell, …) and `persona` are **not** in
+the baseline; a run must declare them. Once declared, every leaf may use them with
+no further prompting.
+
+---
+
+## Worked examples
+
+### Triage a list with `map`
+
+Score and label each inbox item in parallel (anonymous schema leaves), then write
+one summary in the assistant's voice (a single persona leaf). The item list is
+passed in via `args` — never fetched inside the script.
+
+```js
+export const meta = {
+  name: "triage-inbox",
+  description: "Score and summarize inbox items",
+};
+
+phase("score");
+const scored = map(args.items, (item) =>
+  leaf(
+    `Rate this message's urgency 0-10 and give a one-line reason:\n${item.subject}\n${item.body}`,
+    {
+      label: `score:${item.id}`,
+      schema: {
+        type: "object",
+        properties: {
+          urgency: { type: "number" },
+          reason: { type: "string" },
+        },
+        required: ["urgency", "reason"],
+      },
+    },
+  ),
+);
+
+phase("summarize");
+const summary = agent(
+  `Here are scored inbox items. Write a short triage summary for the user, ` +
+    `highlighting anything urgent:\n${JSON.stringify(scored)}`,
+  { persona: true },
+);
+summary;
+```
+
+A failed scoring leaf shows up as `null` in `scored`; the run continues.
+
+### Find, then verify, with `pipeline`
+
+A two-stage pipeline with a barrier: stage 1 extracts a candidate answer from each
+document; stage 2 verifies each candidate. Stage 2 only starts once all of stage 1
+has finished.
+
+```js
+export const meta = {
+  name: "find-and-verify",
+  description: "Extract then verify a fact per document",
+};
+
+const verified = pipeline(
+  args.documents,
+
+  // Stage 1: extract a candidate from each document.
+  (doc) =>
+    leaf(
+      `Extract the contract end date from this document, or "unknown":\n${doc.text}`,
+      {
+        label: `extract:${doc.id}`,
+        schema: {
+          type: "object",
+          properties: { endDate: { type: "string" } },
+          required: ["endDate"],
+        },
+      },
+    ),
+
+  // Stage 2: `prev` is stage 1's result for this index.
+  (prev, i) =>
+    leaf(
+      `A prior pass extracted end date "${prev?.endDate}" from document ` +
+        `"${args.documents[i].id}". Confirm or correct it, and rate your confidence 0-1.`,
+      {
+        label: `verify:${args.documents[i].id}`,
+        schema: {
+          type: "object",
+          properties: {
+            endDate: { type: "string" },
+            confidence: { type: "number" },
+          },
+          required: ["endDate", "confidence"],
+        },
+      },
+    ),
+);
+
+verified;
+```
+
+### Granting a side-effecting tool
+
+To let leaves write files, declare the tool in the manifest passed to
+`run_workflow`:
+
+```jsonc
+{
+  "script": "...",
+  "args": {
+    "items": [
+      /* ... */
+    ],
+  },
+  "capabilities": { "tools": ["file_write"] },
+}
+```
+
+Inside the script, a leaf that needs to write gets `file_write` automatically (no
+schema, so it runs the tool path):
+
+```js
+agent(`Write a per-item report file for: ${JSON.stringify(item)}`, {
+  label: `report:${item.id}`,
+});
+```
+
+---
+
+## Saved workflows (library) and the scheduler
+
+### Saving and invoking by name
+
+A saved workflow is a normal script at `<workspace>/workflows/<name>.workflow.ts`.
+It is resolved by its `meta.name` first, then by filename base. Invoke it by name
+instead of an inline script:
+
+- From the tool: `run_workflow({ name: "triage-inbox", args: { … } })`.
+- Inline from another script: `workflow("triage-inbox", { … })`.
+
+### Nesting is depth-1 only
+
+A top-level script may call `workflow(name, args)` to run a saved workflow inline;
+the child draws from the **same** seq counter, agent cap, journal, and signal, so
+determinism and resume carry across the boundary. A child workflow may **not**
+call `workflow()` — nesting deeper than one level throws.
+
+### Scheduler `workflow` mode
+
+A scheduled job can trigger a saved workflow by name (e.g. "triage the inbox every
+morning"). In v1 the scheduler runs the workflow with **only the read-only
+baseline** — a scheduled run cannot be granted side-effecting tools. The trigger
+records success once the run starts; completion/failure is surfaced out-of-band
+via workflow events and the completion wake.
+
+---
+
+## Tools, routes, and CLI
+
+### Tools (flag-gated)
+
+- **`run_workflow`** — `{ script?, name?, args?, capabilities?, label? }` (exactly
+  one of `script`/`name`). Returns `{ runId }` immediately; the run is
+  asynchronous and you are notified in the conversation when it completes. **Do
+  not poll.**
+- **`manage_workflows`** — `{ action: "status" | "abort" | "list_runs", run_id? }`.
+  `status`/`abort` require `run_id`.
+
+### Routes (read/abort, all 404 when the flag is off)
+
+| Method | Path                           | Purpose                                               |
+| ------ | ------------------------------ | ----------------------------------------------------- |
+| `GET`  | `/v1/workflows`                | List saved (named) workflows.                         |
+| `GET`  | `/v1/workflows/runs`           | List recent runs (newest first); `?limit`, `?status`. |
+| `GET`  | `/v1/workflows/runs/:id`       | Get one run.                                          |
+| `POST` | `/v1/workflows/runs/:id/abort` | Signal an in-flight run to abort.                     |
+
+### CLI
+
+```
+vellum workflows list              # saved (named) workflows
+vellum workflows runs              # recent runs  (--limit, --status)
+vellum workflows show <run-id>     # one run's status + counts
+vellum workflows abort <run-id>    # abort an in-flight run
+```
+
+All subcommands accept `--assistant <name>` to target a specific instance.
+
+---
+
+## Configuration
+
+Engine caps live under `workflows.*` in assistant config:
+
+| Key                    | Default | Meaning                                                       |
+| ---------------------- | ------- | ------------------------------------------------------------- |
+| `maxAgentsPerRun`      | 500     | Total leaves a single run may spawn (the runaway guard).      |
+| `maxConcurrentLeaves`  | 6       | Max leaves in flight within one run.                          |
+| `maxConcurrentRuns`    | 3       | Max workflow runs in flight at once.                          |
+| `journalRetentionDays` | 30      | How long finished runs' journals are retained before pruning. |
+
+---
+
+## Persistence and resume
+
+Run state lives in two tables (migration 281):
+
+- **`workflow_runs`** — one row per run: status (`running` / `completed` /
+  `failed` / `aborted` / `cap_exceeded`), agent/token counts, script source +
+  hash, capabilities, and the originating conversation.
+- **`workflow_journal`** — append-only `(run_id, seq)` log of every leaf call.
+
+Leaf cost is attributed in `llm_usage_events` under `call_site = 'workflowLeaf'`,
+so a run's spend is queryable after the fact.
+
+On resume (re-invoking the same `runId`), a journal entry whose `(run_id, seq)`
+and input hash match a completed prior call is replayed from cache without
+re-spawning the leaf — the longest-unchanged-prefix replays, and only changed or
+not-yet-run leaves execute.


### PR DESCRIPTION
## Summary
- Add the workflows authoring guide (synchronous script API, capability model, resume, persona), an ARCHITECTURE.md entry, and a manual e2e testing runbook.

Part of plan: workflow-engine.md (PR 15 of 17)