### PR TITLE
feat(assistant): raise memory-v3 fresh-set default K to 100

### DIFF
--- a/assistant/src/config/schemas/__tests__/memory-v3.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v3.test.ts
@@ -8,7 +8,7 @@ describe("MemoryV3ConfigSchema", () => {
     expect(parsed).toEqual({
       prune: { maxResidentBytes: 393216, targetResidentBytes: 262144 },
       hotSet: { k: 40, halfLifeDays: 14 },
-      freshSet: { k: 50 },
+      freshSet: { k: 100 },
       learnedEdges: {
         halfLifeDays: 30,
         minCount: 3,

--- a/assistant/src/config/schemas/memory-v3.ts
+++ b/assistant/src/config/schemas/memory-v3.ts
@@ -76,7 +76,7 @@ export const MemoryV3FreshSetSchema = z
       .number({ error: "memory.v3.freshSet.k must be a number" })
       .int("memory.v3.freshSet.k must be an integer")
       .nonnegative("memory.v3.freshSet.k must be a non-negative integer")
-      .default(50)
+      .default(100)
       .describe(
         "Number of most-recently-modified pages included in the fresh-set lane (0 disables the lane). Sized to cover roughly the last day or two of page writes — the recency window conversations reference most.",
       ),


### PR DESCRIPTION
## Summary
- Raise `memory.v3.freshSet.k` shipped default from 50 to 100 (schema default + defaults-assertion test).
- At K=50 the lane saturates on busy 48h write windows (~100 modified pages), dropping in-window pages ranked 51+; an injection-loss autopsy found task-relevant pages cut at ranks 67–79. The fresh lane is the only path to just-written pages when the message has no lexical/semantic anchor, so it should over-provision.

## Original prompt
While auditing memory-v3 retrieval losses on state-enumeration turns ("what's on my plate"-style briefing messages), the maintainer found the fresh lane's top-50 cutoff dropping recently-modified task pages during heavy write windows and asked to raise the default K to 100.