### PR TITLE
fix(workflows): sandbox interrupt should bound CPU, not total wall-clock

### DIFF
--- a/assistant/src/workflows/sandbox-escape.test.ts
+++ b/assistant/src/workflows/sandbox-escape.test.ts
@@ -191,6 +191,59 @@ describe("sandbox containment — determinism bans", () => {
 });
 
 describe("sandbox containment — resource guards", () => {
+  test("cumulative host-call latency beyond the deadline does NOT abort the run", async () => {
+    // Regression guard for a production-killing bug: the interrupt deadline used
+    // to bound TOTAL run wall-clock, which includes time the VM is suspended in
+    // asyncify awaiting host promises. Real workflows make many `agent()` host
+    // calls each costing seconds of LLM latency, so after a couple of leaves the
+    // run tripped the deadline and aborted on latency alone.
+    //
+    // Here three host calls each sleep ~250ms (cumulative ~750ms) under a 400ms
+    // deadline. Because the deadline measures CONTIGUOUS script CPU between host
+    // calls — reset around each host-call boundary — the suspended latency must
+    // NOT count, and the run must complete successfully.
+    const sb = createWorkflowSandbox({
+      hostFunctions: {
+        slow: async (n: unknown) => {
+          await new Promise((r) => setTimeout(r, 250));
+          return (n as number) + 1;
+        },
+      },
+      interruptDeadlineMs: 400,
+    });
+
+    const result = await sb.run(
+      `let n = 0;
+       for (let i = 0; i < 3; i++) {
+         n = slow(n); // each call sleeps ~250ms; cumulative ~750ms > 400ms deadline
+       }
+       return n;`,
+      null,
+    );
+    // slow(n) = n + 1, applied three times starting from 0 -> 3.
+    expect(result).toBe(3);
+  }, 20_000);
+
+  test("a tight CPU loop with no host calls is still interrupted (spin guard)", async () => {
+    // Companion to the latency test above: a genuine spin that never yields to a
+    // host call must STILL trip the deadline. Short deadline keeps the test fast.
+    const sb = createWorkflowSandbox({
+      hostFunctions: {},
+      interruptDeadlineMs: 200,
+    });
+    const start = Date.now();
+    let caught: unknown;
+    try {
+      await sb.run(`while (true) {}`, null);
+    } catch (e) {
+      caught = e;
+    }
+    const elapsed = Date.now() - start;
+    expect(caught).toBeInstanceOf(WorkflowResourceError);
+    // 200ms deadline; allow generous slack but assert it is bounded.
+    expect(elapsed).toBeLessThan(10_000);
+  }, 20_000);
+
   test("an infinite loop is interrupted within a bounded time", async () => {
     const start = Date.now();
     let caught: unknown;

--- a/assistant/src/workflows/sandbox.ts
+++ b/assistant/src/workflows/sandbox.ts
@@ -28,9 +28,16 @@ import {
 const DEFAULT_MEMORY_LIMIT_BYTES = 256 * 1024 * 1024;
 
 /**
- * Wall-clock budget for a single run. The interrupt handler — invoked
- * periodically by the VM as it executes — returns `true` once this elapses, so
- * a pure `while(true){}` is interrupted well before the daemon is starved.
+ * CPU budget for a single *contiguous* stretch of script execution between host
+ * calls. The interrupt handler — invoked periodically by the VM as it executes —
+ * returns `true` once this elapses, so a pure `while(true){}` (which never yields
+ * to a host call) is interrupted well before the daemon is starved.
+ *
+ * Crucially this bounds uninterrupted SCRIPT CPU, not total run wall-clock. The
+ * deadline is reset around every host-call boundary (see {@link installNativeBridge}),
+ * so seconds spent suspended in asyncify awaiting a host promise (each `agent()`
+ * leaf is a multi-second LLM round-trip) do NOT count against it. Total-runtime
+ * limits are the caller's responsibility via {@link CreateWorkflowSandboxOptions.signal}.
  */
 const INTERRUPT_DEADLINE_MS = 5_000;
 
@@ -78,6 +85,14 @@ export interface CreateWorkflowSandboxOptions {
   signal?: AbortSignal;
   /** Runtime memory ceiling. Defaults to 256 MiB. */
   memoryLimitBytes?: number;
+  /**
+   * CPU budget, in milliseconds, for a single contiguous stretch of script
+   * execution between host calls. Reset around every host-call boundary, so it
+   * never counts time suspended awaiting a host promise. Defaults to 5000.
+   * Primarily a test seam for exercising the interrupt guard with short delays;
+   * production should use the default.
+   */
+  interruptDeadlineMs?: number;
 }
 
 export interface WorkflowSandbox {
@@ -211,6 +226,7 @@ export function createWorkflowSandbox(
 ): WorkflowSandbox {
   const transpiler = new Bun.Transpiler({ loader: "ts" });
   const memoryLimitBytes = opts.memoryLimitBytes ?? DEFAULT_MEMORY_LIMIT_BYTES;
+  const interruptDeadlineMs = opts.interruptDeadlineMs ?? INTERRUPT_DEADLINE_MS;
   const hostFunctionNames = Object.keys(opts.hostFunctions);
 
   return {
@@ -238,14 +254,21 @@ export function createWorkflowSandbox(
       const runtime = vm.runtime;
       runtime.setMemoryLimit(memoryLimitBytes);
 
-      const deadline = Date.now() + INTERRUPT_DEADLINE_MS;
+      // The deadline bounds CONTIGUOUS script CPU between host calls, not total
+      // run wall-clock. It is held in a one-element box so the native bridge can
+      // reset it around each host-call boundary (where the VM is suspended in
+      // asyncify awaiting a host promise — time that must not count against the
+      // CPU guard). `signal.aborted` remains the hard, total-runtime stop.
+      const deadline = { at: Date.now() + interruptDeadlineMs };
       runtime.setInterruptHandler(() => {
         if (opts.signal?.aborted) return true;
-        return Date.now() > deadline;
+        return Date.now() > deadline.at;
       });
 
       try {
-        installNativeBridge(vm, opts);
+        installNativeBridge(vm, opts, () => {
+          deadline.at = Date.now() + interruptDeadlineMs;
+        });
         seedArgs(vm, args);
 
         // Bootstrap: strip capabilities, install bans, wire host fns.
@@ -278,6 +301,7 @@ export function createWorkflowSandbox(
 function installNativeBridge(
   vm: QuickJSAsyncContext,
   opts: CreateWorkflowSandboxOptions,
+  resetDeadline: () => void,
 ): void {
   // Single asyncified bridge for all host functions. Suspends the VM while the
   // host promise settles, then resumes with a JSON string (or undefined).
@@ -296,6 +320,11 @@ function installNativeBridge(
       // A host throw/rejection propagates as a VM exception the script can
       // catch, or — if uncaught — as a WorkflowScriptError to the caller.
       const result = await fn(...parsedArgs);
+      // The VM is about to resume script execution. Reset the CPU budget so the
+      // (possibly multi-second) host-call latency we just awaited does not count
+      // against the interrupt deadline — that guards contiguous script CPU only,
+      // not cumulative host-call wall-clock. `signal` remains the hard stop.
+      resetDeadline();
       // `undefined` JSON-stringifies to `undefined`; map it to the VM's
       // undefined so the sync wrapper returns `undefined` rather than NaN.
       if (result === undefined) return vm.undefined;


### PR DESCRIPTION
## Summary
- The QuickJS interrupt deadline now measures contiguous script CPU between host calls (reset around each asyncified host call), so cumulative LLM latency no longer aborts real runs. CPU-spin guard and signal-abort preserved. Adds a cumulative-latency regression test.

Part of plan: workflow-engine.md (critical fix surfaced during self-review)