### PR TITLE
fix(workflows): persona forwarding + resume counter seeding

### DIFF
--- a/assistant/src/workflows/engine-integration.test.ts
+++ b/assistant/src/workflows/engine-integration.test.ts
@@ -520,6 +520,31 @@ return results;
   });
 
   // ---------------------------------------------------------------------------
+  // PERSONA MANIFEST GATE (consent-gated, like tools).
+  //
+  // A leaf may request `persona: true` only if the run's capability manifest
+  // declared `persona`. An undeclared request fails the run loudly through the
+  // real engine + sandbox stack — it must NOT silently downgrade to anonymous.
+  // ---------------------------------------------------------------------------
+  test("a persona leaf in a run WITHOUT declared persona fails the run", async () => {
+    const scriptSource = `
+export const meta = { name: "persona-denied", description: "undeclared persona" };
+return agent("draft in voice", { persona: true });
+`;
+    // `capabilities` (the shared fixture) declares persona:false.
+    expect(capabilities.persona).toBe(false);
+    const result = await executeWorkflow({
+      ...baseOptions("wf-persona-denied", scriptSource),
+      config: makeConfig(),
+    });
+
+    expect(result.status).toBe("failed");
+    // The gate trips before any provider call — nothing was spawned.
+    expect(sendCallCount).toBe(0);
+    expect(result.agentsSpawned).toBe(0);
+  });
+
+  // ---------------------------------------------------------------------------
   // FIXED RESUME JOURNAL-STALENESS GAP.
   //
   // On resume, a leaf whose input CHANGED (new `call_hash`) re-runs and the

--- a/assistant/src/workflows/engine.test.ts
+++ b/assistant/src/workflows/engine.test.ts
@@ -289,6 +289,68 @@ describe("executeWorkflow — resume", () => {
     expect(second.prompts).toEqual([]);
   });
 
+  test("resume carries agentsSpawned/tokens forward from the persisted run row (not reset to 0)", async () => {
+    // First run journals 2 leaves → persisted agents_spawned = 2.
+    const first = makeFakeRunner();
+    await execute(
+      "wf-resume-count",
+      `agent("a"); return agent("b");`,
+      first.runner,
+    );
+    const afterFirst = journalStore.getRun("wf-resume-count");
+    expect(afterFirst?.agentsSpawned).toBe(2);
+    expect(afterFirst?.inputTokens).toBe(20);
+
+    // Resume with one ADDED leaf: a/b replay (no re-count), the new leaf spawns.
+    const second = makeFakeRunner();
+    const res = await execute(
+      "wf-resume-count",
+      `agent("a"); agent("b"); return agent("c");`,
+      second.runner,
+    );
+    expect(res.status).toBe("completed");
+    expect(second.prompts).toEqual(["c"]);
+    // Carried forward: persisted 2 + 1 newly spawned = 3 (NOT reset to 1).
+    expect(res.agentsSpawned).toBe(3);
+    expect(res.inputTokens).toBe(30);
+
+    // The persisted agents_spawned is not regressed downward by the resume.
+    const afterSecond = journalStore.getRun("wf-resume-count");
+    expect(afterSecond?.agentsSpawned).toBe(3);
+    expect(afterSecond!.agentsSpawned).toBeGreaterThanOrEqual(
+      afterFirst!.agentsSpawned,
+    );
+  });
+
+  test("resume enforces the agent cap against the carried-over total (no fresh budget)", async () => {
+    // First run spawns 3 leaves under a generous cap → persisted at 3.
+    const first = makeFakeRunner();
+    await execute(
+      "wf-resume-cap",
+      `agent("a"); agent("b"); return agent("c");`,
+      first.runner,
+      configWith({ maxAgentsPerRun: 500 }),
+    );
+    expect(journalStore.getRun("wf-resume-cap")?.agentsSpawned).toBe(3);
+
+    // Resume with cap=3 and one NEW leaf. Were the counter reset to 0, the new
+    // leaf would fit a fresh budget; seeded from the persisted 3, the cap is
+    // already met, so the new leaf trips it.
+    const second = makeFakeRunner();
+    const res = await execute(
+      "wf-resume-cap",
+      `agent("a"); agent("b"); agent("c"); return agent("d");`,
+      second.runner,
+      configWith({ maxAgentsPerRun: 3 }),
+    );
+
+    expect(res.status).toBe("cap_exceeded");
+    // The new leaf never ran; the carried total stays at the cap.
+    expect(second.prompts).toEqual([]);
+    expect(res.agentsSpawned).toBe(3);
+    expect(journalStore.getRun("wf-resume-cap")?.agentsSpawned).toBe(3);
+  });
+
   test("a changed call breaks the replay prefix and re-runs from there", async () => {
     const first = makeFakeRunner();
     await execute(
@@ -366,6 +428,60 @@ describe("executeWorkflow — schema vs tool leaf tool forwarding", () => {
     // Tool leaf: no schema, capabilities.tools forwarded.
     expect(toolCall!.schema).toBeUndefined();
     expect(toolCall!.tools).toBe(toolsCapabilities.tools);
+  });
+});
+
+describe("executeWorkflow — persona gating", () => {
+  beforeEach(resetTables);
+
+  const personaCapabilities: ResolvedCapabilities = {
+    tools: [],
+    hostFunctions: [],
+    persona: true,
+  };
+
+  test("a persona leaf forwards persona:true to the runner when the run declared persona", async () => {
+    const fake = makeFakeRunner();
+    const res = await execute(
+      "wf-persona-ok",
+      `return agent("draft a reply", { persona: true });`,
+      fake.runner,
+      configWith(),
+      null,
+      personaCapabilities,
+    );
+
+    expect(res.status).toBe("completed");
+    expect(fake.calls).toHaveLength(1);
+    expect(fake.calls[0]!.persona).toBe(true);
+  });
+
+  test("a non-persona leaf does NOT forward persona", async () => {
+    const fake = makeFakeRunner();
+    await execute(
+      "wf-persona-anon",
+      `return agent("plain task");`,
+      fake.runner,
+      configWith(),
+      null,
+      personaCapabilities,
+    );
+    expect(fake.calls[0]!.persona).toBeUndefined();
+  });
+
+  test("a persona leaf in a run WITHOUT declared persona fails the run (loud, never silent)", async () => {
+    const fake = makeFakeRunner();
+    // Default CAPABILITIES has persona:false.
+    const res = await execute(
+      "wf-persona-denied",
+      `return agent("draft a reply", { persona: true });`,
+      fake.runner,
+    );
+
+    expect(res.status).toBe("failed");
+    // The leaf runner is never invoked — the gate trips before the spawn.
+    expect(fake.calls).toHaveLength(0);
+    expect(res.agentsSpawned).toBe(0);
   });
 });
 

--- a/assistant/src/workflows/engine.ts
+++ b/assistant/src/workflows/engine.ts
@@ -165,6 +165,24 @@ export class WorkflowNotFoundError extends Error {
 }
 
 /**
+ * Thrown into the script when a leaf requests `persona: true` but the run's
+ * capability manifest did not declare `persona`. Persona access — like tool
+ * access — is consent-gated at the manifest (the single consent point); a leaf
+ * cannot opt itself in. Surfaces as a catchable VM exception (or, uncaught,
+ * fails the run), matching the tool-denial model: be loud, never silently
+ * downgrade to anonymous.
+ */
+export class WorkflowPersonaNotDeclaredError extends Error {
+  readonly code = "persona_not_declared" as const;
+  constructor() {
+    super(
+      "persona leaves require declaring `persona` in the workflow capabilities.",
+    );
+    this.name = "WorkflowPersonaNotDeclaredError";
+  }
+}
+
+/**
  * Thrown into the script when `workflow()` is called from inside a nested
  * workflow. Nesting is limited to ONE level: a top-level script may call
  * `workflow()`, but a child workflow may not.
@@ -345,10 +363,25 @@ export async function executeWorkflow(
   }
 
   // --- Run-scoped mutable accounting ---------------------------------------
+  // On a RESUME (an existing run row from a prior, crashed execution), SEED the
+  // ACCOUNTING counters from persisted state so the agent cap and token/agent
+  // totals carry across the restart instead of resetting to zero. Without this,
+  // replayed leaves return at the journal short-circuit BEFORE the
+  // `agentsSpawned += 1` increment, so the fresh-from-0 counter would exclude
+  // everything spawned before the crash — and the first `flushCounters()` would
+  // overwrite the persisted total with that smaller value, handing a resumed
+  // run a full fresh cap budget and defeating the runaway guard.
+  //
+  // The `seq` counter is DELIBERATELY NOT seeded: it must restart at 0 on every
+  // execution. The script re-runs from the top and re-derives the SAME
+  // deterministic seq sequence (0, 1, 2, …); replay matches a journaled entry
+  // by `(runId, seq)`, so a `seq` that did not restart at 0 would miss every
+  // cached entry and re-run the whole prefix. The persisted `agentsSpawned`
+  // carries the real spawn total; `seq` is purely the in-execution call index.
   let nextSeq = 0;
-  let agentsSpawned = 0;
-  let inputTokens = 0;
-  let outputTokens = 0;
+  let agentsSpawned = existing ? existing.agentsSpawned : 0;
+  let inputTokens = existing ? existing.inputTokens : 0;
+  let outputTokens = existing ? existing.outputTokens : 0;
   let capExceeded = false;
 
   /** Persist live counters so `getRun` reports them mid-flight. */
@@ -378,6 +411,14 @@ export async function executeWorkflow(
       return { output: cached.result, failed: false };
     }
 
+    // Persona is consent-gated by the manifest, exactly like tools: a leaf may
+    // opt into persona ONLY if the run declared `persona`. An undeclared
+    // request fails loudly (never silently downgrades to anonymous), matching
+    // the tool-denial model.
+    if (leafOpts.persona && !capabilities.persona) {
+      throw new WorkflowPersonaNotDeclaredError();
+    }
+
     // Agent cap: trip BEFORE launching, abort the whole run.
     if (agentsSpawned >= config.maxAgentsPerRun) {
       capExceeded = true;
@@ -400,6 +441,7 @@ export async function executeWorkflow(
           ? { profile: leafOpts.profile }
           : {}),
         ...(isSchemaLeaf ? {} : { tools: capabilities.tools }),
+        ...(leafOpts.persona ? { persona: true } : {}),
         trustContext,
         ...(signal ? { signal } : {}),
       });


### PR DESCRIPTION
## Summary
- Engine now forwards per-leaf persona to the leaf runner, gated on capabilities.persona (consent), so persona leaves actually run.
- On resume, seed agentsSpawned/inputTokens/outputTokens from persisted run so the agent cap and counts carry across a restart instead of resetting.

Part of plan: workflow-engine.md (correctness fixes surfaced during self-review)