### PR TITLE
feat(workflows): reachable journaled resume

### DIFF
--- a/assistant/docs/workflows-testing.md
+++ b/assistant/docs/workflows-testing.md
@@ -117,19 +117,36 @@ seconds). While it is running, restart the assistant with **SIGTERM**:
 > costly recovery on the next start (and can corrupt an in-flight run). Use a
 > graceful stop / `vellum sleep` / SIGTERM with grace.
 
-After restart, re-invoke the **same `runId`** (re-run the same workflow with the
-same run id). Then assert journal replay:
+After restart, the run that was in flight when the process stopped is no longer
+`running` — at startup the assistant reconciles every orphaned `running` row to
+`interrupted` (status only; the accounting counters are preserved). Resume is
+**not automatic**. Confirm the run shows up as interrupted, then trigger an
+explicit resume:
 
-- Re-running does **not** double the `agentsSpawned` count or the
+```bash
+# The crashed run is now interrupted, not running.
+vellum workflows runs --status interrupted
+
+# Trigger the resume (or: manage_workflows with action="resume" from chat).
+vellum workflows resume <run-id>
+```
+
+Resuming re-invokes the engine with the **same `runId`**, so the completed prefix
+replays from the journal. Assert:
+
+- Resuming does **not** double the `agentsSpawned` count or the
   `llm_usage_events` rows for `call_site = 'workflowLeaf'` — the completed prefix
-  replays from the journal rather than re-spawning leaves.
+  replays from the journal rather than re-spawning leaves. The agent count
+  **carries** across the restart (it seeds from the persisted run row) instead of
+  resetting to zero.
 - Only leaves that had not completed before the restart produce new usage rows.
+- The run transitions `interrupted` → `running` → a terminal status.
 
 ```sql
--- Before and after the re-invoke, this count should not grow for already-done leaves.
+-- Before and after the resume, this count should not grow for already-done leaves.
 SELECT COUNT(*) FROM llm_usage_events WHERE call_site = 'workflowLeaf';
 
--- The journal holds one row per completed (run_id, seq); re-running does not duplicate them.
+-- The journal holds one row per completed (run_id, seq); resuming does not duplicate them.
 SELECT run_id, COUNT(*) FROM workflow_journal GROUP BY run_id;
 ```
 

--- a/assistant/docs/workflows.md
+++ b/assistant/docs/workflows.md
@@ -56,12 +56,13 @@ bounded by `maxConcurrentLeaves` (default 6).
 ### Scripts must be deterministic so runs can resume
 
 Every leaf call is journaled by a deterministic sequence number and an input
-hash. If the assistant restarts mid-run, re-invoking the same `runId` **replays
+hash. If the assistant restarts mid-run, resuming the same `runId` **replays
 the unchanged prefix from the journal** instead of re-spawning agents — so a
 long run survives a deploy or crash without redoing (or re-paying for) completed
-work. That guarantee only holds if the script is deterministic, so `Date.now()`,
-`Math.random()`, and argless `new Date()` **throw**. Pass any timestamps or seeds
-in through `args`.
+work. (Resume is explicit, not automatic — see
+[Recovering a crashed run](#recovering-a-crashed-run).) That guarantee only
+holds if the script is deterministic, so `Date.now()`, `Math.random()`, and
+argless `new Date()` **throw**. Pass any timestamps or seeds in through `args`.
 
 ---
 
@@ -430,8 +431,8 @@ Engine caps live under `workflows.*` in assistant config:
 Run state lives in two tables (migration 281):
 
 - **`workflow_runs`** — one row per run: status (`running` / `completed` /
-  `failed` / `aborted` / `cap_exceeded`), agent/token counts, script source +
-  hash, capabilities, and the originating conversation.
+  `failed` / `aborted` / `cap_exceeded` / `interrupted`), agent/token counts,
+  script source + hash, capability manifest, and the originating conversation.
 - **`workflow_journal`** — append-only `(run_id, seq)` log of every leaf call.
 
 Leaf cost is attributed in `llm_usage_events` under `call_site = 'workflowLeaf'`,
@@ -441,3 +442,21 @@ On resume (re-invoking the same `runId`), a journal entry whose `(run_id, seq)`
 and input hash match a completed prior call is replayed from cache without
 re-spawning the leaf — the longest-unchanged-prefix replays, and only changed or
 not-yet-run leaves execute.
+
+### Recovering a crashed run
+
+Resume is **not automatic**. If the assistant restarts mid-run, the run row is
+left `running`; at startup the assistant reconciles every such orphaned row to
+`interrupted` (status only — the agent/token accounting is preserved so the agent
+cap still carries across the restart). An `interrupted` run sits there until you
+explicitly resume it:
+
+- **From the assistant**: `manage_workflows` with `action: "resume"` and the
+  `run_id`.
+- **From the CLI**: `vellum workflows resume <run-id>`.
+
+Resuming re-invokes the engine with the same `runId`: it replays the completed
+prefix from the journal and continues from the first unfinished leaf, under the
+run's originally-declared capabilities and the same structural agent cap. Only
+`interrupted` runs are resumable; a `completed` / `failed` / `aborted` run is
+terminal.

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -20457,6 +20457,7 @@ paths:
                             - execute
                             - script
                             - wake
+                            - workflow
                         status:
                           type: string
                           enum:
@@ -20473,6 +20474,10 @@ paths:
                         reuseConversation:
                           type: boolean
                         wakeConversationId:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        workflowName:
                           anyOf:
                             - type: string
                             - type: "null"
@@ -20505,6 +20510,7 @@ paths:
                         - routingIntent
                         - reuseConversation
                         - wakeConversationId
+                        - workflowName
                         - isOneShot
                       additionalProperties: false
                     description: Schedule objects
@@ -20607,6 +20613,7 @@ paths:
                             - execute
                             - script
                             - wake
+                            - workflow
                         status:
                           type: string
                           enum:
@@ -20623,6 +20630,10 @@ paths:
                         reuseConversation:
                           type: boolean
                         wakeConversationId:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        workflowName:
                           anyOf:
                             - type: string
                             - type: "null"
@@ -20655,6 +20666,7 @@ paths:
                         - routingIntent
                         - reuseConversation
                         - wakeConversationId
+                        - workflowName
                         - isOneShot
                       additionalProperties: false
                     description: Updated schedule list
@@ -20690,7 +20702,12 @@ paths:
                   description: Whether the schedule starts active (default true)
                 mode:
                   type: string
-                  description: Currently must be 'execute'
+                  description: "'execute' (default) or 'workflow' (flag-gated)"
+                workflowName:
+                  type: string
+                  description: Saved workflow to trigger (required for workflow mode)
+                workflowArgs:
+                  description: Args passed to the workflow run (workflow mode)
               required:
                 - name
                 - expression
@@ -20786,6 +20803,7 @@ paths:
                             - execute
                             - script
                             - wake
+                            - workflow
                         status:
                           type: string
                           enum:
@@ -20802,6 +20820,10 @@ paths:
                         reuseConversation:
                           type: boolean
                         wakeConversationId:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        workflowName:
                           anyOf:
                             - type: string
                             - type: "null"
@@ -20834,6 +20856,7 @@ paths:
                         - routingIntent
                         - reuseConversation
                         - wakeConversationId
+                        - workflowName
                         - isOneShot
                       additionalProperties: false
                     description: Updated schedule list
@@ -20935,6 +20958,7 @@ paths:
                             - execute
                             - script
                             - wake
+                            - workflow
                         status:
                           type: string
                           enum:
@@ -20951,6 +20975,10 @@ paths:
                         reuseConversation:
                           type: boolean
                         wakeConversationId:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        workflowName:
                           anyOf:
                             - type: string
                             - type: "null"
@@ -20983,6 +21011,7 @@ paths:
                         - routingIntent
                         - reuseConversation
                         - wakeConversationId
+                        - workflowName
                         - isOneShot
                       additionalProperties: false
                     description: Updated schedule list
@@ -21019,7 +21048,14 @@ paths:
                   description: Shell command for script mode
                 mode:
                   type: string
-                  description: notify, execute, or script
+                  description: notify, execute, script, wake, or workflow
+                workflowName:
+                  anyOf:
+                    - type: string
+                    - type: "null"
+                  description: Saved workflow to trigger (workflow mode)
+                workflowArgs:
+                  description: Args passed to the workflow run (workflow mode)
                 routingIntent:
                   type: string
                   description: single_channel, multi_channel, or all_channels
@@ -21129,6 +21165,7 @@ paths:
                             - execute
                             - script
                             - wake
+                            - workflow
                         status:
                           type: string
                           enum:
@@ -21145,6 +21182,10 @@ paths:
                         reuseConversation:
                           type: boolean
                         wakeConversationId:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        workflowName:
                           anyOf:
                             - type: string
                             - type: "null"
@@ -21177,6 +21218,7 @@ paths:
                         - routingIntent
                         - reuseConversation
                         - wakeConversationId
+                        - workflowName
                         - isOneShot
                       additionalProperties: false
                     description: Updated schedule list
@@ -21279,6 +21321,7 @@ paths:
                             - execute
                             - script
                             - wake
+                            - workflow
                         status:
                           type: string
                           enum:
@@ -21295,6 +21338,10 @@ paths:
                         reuseConversation:
                           type: boolean
                         wakeConversationId:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        workflowName:
                           anyOf:
                             - type: string
                             - type: "null"
@@ -21327,6 +21374,7 @@ paths:
                         - routingIntent
                         - reuseConversation
                         - wakeConversationId
+                        - workflowName
                         - isOneShot
                       additionalProperties: false
                     description: Updated schedule list
@@ -21518,6 +21566,7 @@ paths:
                             - execute
                             - script
                             - wake
+                            - workflow
                         status:
                           type: string
                           enum:
@@ -21534,6 +21583,10 @@ paths:
                         reuseConversation:
                           type: boolean
                         wakeConversationId:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        workflowName:
                           anyOf:
                             - type: string
                             - type: "null"
@@ -21566,6 +21619,7 @@ paths:
                         - routingIntent
                         - reuseConversation
                         - wakeConversationId
+                        - workflowName
                         - isOneShot
                       additionalProperties: false
                     description: Updated schedule list
@@ -26626,6 +26680,283 @@ paths:
           description: Work item or associated task not found
         "409":
           description: Work item is already running or not runnable
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/workflows:
+    get:
+      operationId: workflows_get
+      summary: List saved workflows
+      description: Return the saved (named) workflows the assistant can run.
+      tags:
+        - workflows
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  workflows:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        description:
+                          type: string
+                        path:
+                          type: string
+                      required:
+                        - name
+                        - description
+                        - path
+                      additionalProperties: false
+                    description: Saved workflow entries
+                required:
+                  - workflows
+                additionalProperties: false
+  /v1/workflows/runs:
+    get:
+      operationId: workflows_runs_get
+      summary: List workflow runs
+      description: Return recent workflow runs, newest first.
+      tags:
+        - workflows
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  runs:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        name:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        scriptHash:
+                          type: string
+                        status:
+                          type: string
+                          enum:
+                            - running
+                            - completed
+                            - failed
+                            - aborted
+                            - cap_exceeded
+                            - interrupted
+                        conversationId:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        agentsSpawned:
+                          type: number
+                        inputTokens:
+                          type: number
+                        outputTokens:
+                          type: number
+                        error:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        createdAt:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                        updatedAt:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                        finishedAt:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                      required:
+                        - id
+                        - name
+                        - scriptHash
+                        - status
+                        - conversationId
+                        - agentsSpawned
+                        - inputTokens
+                        - outputTokens
+                        - error
+                        - createdAt
+                        - updatedAt
+                        - finishedAt
+                      additionalProperties: false
+                    description: Workflow run objects
+                required:
+                  - runs
+                additionalProperties: false
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: Max runs to return (default 50, max 200)
+        - name: status
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Filter by run status (running, completed, failed, aborted, cap_exceeded, interrupted).
+  /v1/workflows/runs/{id}:
+    get:
+      operationId: workflows_runs_by_id_get
+      summary: Get workflow run
+      description: Return a single workflow run by ID.
+      tags:
+        - workflows
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  name:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                  scriptHash:
+                    type: string
+                  status:
+                    type: string
+                    enum:
+                      - running
+                      - completed
+                      - failed
+                      - aborted
+                      - cap_exceeded
+                      - interrupted
+                  conversationId:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                  agentsSpawned:
+                    type: number
+                  inputTokens:
+                    type: number
+                  outputTokens:
+                    type: number
+                  error:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                  createdAt:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  updatedAt:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  finishedAt:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                required:
+                  - id
+                  - name
+                  - scriptHash
+                  - status
+                  - conversationId
+                  - agentsSpawned
+                  - inputTokens
+                  - outputTokens
+                  - error
+                  - createdAt
+                  - updatedAt
+                  - finishedAt
+                additionalProperties: false
+        "404":
+          description: Run not found
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/workflows/runs/{id}/abort:
+    post:
+      operationId: workflows_runs_by_id_abort_post
+      summary: Abort workflow run
+      description: Signal an in-flight workflow run to abort.
+      tags:
+        - workflows
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  runId:
+                    type: string
+                required:
+                  - ok
+                  - runId
+                additionalProperties: false
+        "404":
+          description: Run not found
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /v1/workflows/runs/{id}/resume:
+    post:
+      operationId: workflows_runs_by_id_resume_post
+      summary: Resume workflow run
+      description:
+        Resume an interrupted workflow run (one orphaned by an assistant restart), replaying its journaled prefix
+        and continuing from the first unfinished step.
+      tags:
+        - workflows
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  runId:
+                    type: string
+                required:
+                  - ok
+                  - runId
+                additionalProperties: false
+        "404":
+          description: Run not found
+        "409":
+          description: Run is not resumable (not interrupted)
+        "429":
+          description: Concurrent-run cap reached
       parameters:
         - name: id
           in: path

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -98,6 +98,7 @@ import {
   listWorkItems,
   updateWorkItem,
 } from "../work-items/work-item-store.js";
+import { getWorkflowRunManager } from "../workflows/run-manager.js";
 import { repairAdaptiveThinkingOnManagedProfiles } from "../workspace/adaptive-thinking-repair.js";
 import { WorkspaceHeartbeatService } from "../workspace/heartbeat-service.js";
 import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
@@ -968,6 +969,26 @@ export async function runDaemon(): Promise<void> {
       recoverStaleSchedules();
     } catch (err) {
       log.error({ err }, "Schedule recovery failed — continuing startup");
+    }
+
+    // Reconcile workflow runs orphaned by a crash: any row still `running` was
+    // in flight when the process died (the engine always finishes its row on
+    // exit), so flip it to `interrupted` to make it eligible for an explicit
+    // resume. Status only — accounting counters are preserved. Never blocks
+    // startup on failure.
+    try {
+      const reconciled = getWorkflowRunManager().reconcileOrphanedRuns();
+      if (reconciled > 0) {
+        log.info(
+          { reconciled },
+          "Reconciled orphaned workflow runs to interrupted",
+        );
+      }
+    } catch (err) {
+      log.error(
+        { err },
+        "Workflow run reconciliation failed — continuing startup",
+      );
     }
 
     const scheduler = startScheduler(

--- a/assistant/src/runtime/routes/workflow-routes.test.ts
+++ b/assistant/src/runtime/routes/workflow-routes.test.ts
@@ -3,7 +3,15 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { AssistantConfig } from "../../config/schema.js";
 import type { WorkflowRun } from "../../workflows/journal-store.js";
 import type { SavedWorkflowEntry } from "../../workflows/library.js";
-import { NotFoundError } from "./errors.js";
+import {
+  WorkflowResumeNotPossibleError,
+  WorkflowRunCapError,
+} from "../../workflows/run-manager.js";
+import {
+  ConflictError,
+  NotFoundError,
+  TooManyRequestsError,
+} from "./errors.js";
 import type { RouteDefinition } from "./types.js";
 import { __setWorkflowRoutesDeps, ROUTES } from "./workflow-routes.js";
 
@@ -46,18 +54,23 @@ interface FakeManager {
   }) => WorkflowRun[];
   status: (id: string) => WorkflowRun | null;
   abort: (id: string) => void;
+  resume: (id: string) => { runId: string };
 }
 
 function setup(opts: {
   flagEnabled?: boolean;
   runs?: WorkflowRun[];
   saved?: SavedWorkflowEntry[];
+  /** Custom resume impl; defaults to a success that records the id. */
+  resume?: (id: string) => { runId: string };
 }): {
   aborted: string[];
+  resumed: string[];
   listCalls: Array<{ limit?: number; status?: string }>;
 } {
   const runs = opts.runs ?? [];
   const aborted: string[] = [];
+  const resumed: string[] = [];
   const listCalls: Array<{ limit?: number; status?: string }> = [];
   const manager: FakeManager = {
     list: (o) => {
@@ -71,6 +84,12 @@ function setup(opts: {
     abort: (id) => {
       aborted.push(id);
     },
+    resume:
+      opts.resume ??
+      ((id) => {
+        resumed.push(id);
+        return { runId: id };
+      }),
   };
   __setWorkflowRoutesDeps({
     getManager: () => manager,
@@ -78,7 +97,7 @@ function setup(opts: {
     getConfig: () => ({}) as AssistantConfig,
     isFlagEnabled: () => opts.flagEnabled ?? true,
   });
-  return { aborted, listCalls };
+  return { aborted, resumed, listCalls };
 }
 
 afterEach(() => {
@@ -149,6 +168,48 @@ describe("workflow routes (flag on)", () => {
     expect(aborted).toEqual(["run-1"]);
   });
 
+  test("resumeWorkflowRun resumes an interrupted run", async () => {
+    const { resumed } = setup({
+      flagEnabled: true,
+      runs: [makeRun({ id: "run-1", status: "interrupted" })],
+    });
+    const result = (await route("resumeWorkflowRun").handler({
+      pathParams: { id: "run-1" },
+    })) as { ok: boolean; runId: string };
+    expect(result).toEqual({ ok: true, runId: "run-1" });
+    expect(resumed).toEqual(["run-1"]);
+  });
+
+  test("resumeWorkflowRun maps a non-interrupted run to a 409 ConflictError", () => {
+    setup({
+      flagEnabled: true,
+      runs: [makeRun({ id: "run-1", status: "completed" })],
+      resume: (id) => {
+        throw new WorkflowResumeNotPossibleError(
+          id,
+          "not_interrupted",
+          "completed",
+        );
+      },
+    });
+    expect(() =>
+      route("resumeWorkflowRun").handler({ pathParams: { id: "run-1" } }),
+    ).toThrow(ConflictError);
+  });
+
+  test("resumeWorkflowRun maps a cap error to a 429 TooManyRequestsError", () => {
+    setup({
+      flagEnabled: true,
+      runs: [makeRun({ id: "run-1", status: "interrupted" })],
+      resume: () => {
+        throw new WorkflowRunCapError(3);
+      },
+    });
+    expect(() =>
+      route("resumeWorkflowRun").handler({ pathParams: { id: "run-1" } }),
+    ).toThrow(TooManyRequestsError);
+  });
+
   test("listSavedWorkflows returns saved entries", async () => {
     const result = (await route("listSavedWorkflows").handler({})) as {
       workflows: SavedWorkflowEntry[];
@@ -182,6 +243,14 @@ describe("workflow routes (unknown run)", () => {
     ).toThrow(NotFoundError);
     expect(aborted).toEqual([]);
   });
+
+  test("resumeWorkflowRun throws NotFoundError for an unknown id", () => {
+    const { resumed } = setup({ flagEnabled: true, runs: [] });
+    expect(() =>
+      route("resumeWorkflowRun").handler({ pathParams: { id: "nope" } }),
+    ).toThrow(NotFoundError);
+    expect(resumed).toEqual([]);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -197,6 +266,7 @@ describe("workflow routes (flag off)", () => {
     ["listWorkflowRuns", { queryParams: {} }],
     ["getWorkflowRun", { pathParams: { id: "run-1" } }],
     ["abortWorkflowRun", { pathParams: { id: "run-1" } }],
+    ["resumeWorkflowRun", { pathParams: { id: "run-1" } }],
     ["listSavedWorkflows", {}],
   ] as const)("%s throws NotFoundError when the flag is off", (op, args) => {
     expect(() => route(op).handler(args)).toThrow(NotFoundError);

--- a/assistant/src/runtime/routes/workflow-routes.ts
+++ b/assistant/src/runtime/routes/workflow-routes.ts
@@ -20,10 +20,16 @@ import type { WorkflowRun } from "../../workflows/journal-store.js";
 import { listWorkflows } from "../../workflows/library.js";
 import {
   getWorkflowRunManager,
+  WorkflowResumeNotPossibleError,
+  WorkflowRunCapError,
   type WorkflowRunManager,
 } from "../../workflows/run-manager.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
-import { NotFoundError } from "./errors.js";
+import {
+  ConflictError,
+  NotFoundError,
+  TooManyRequestsError,
+} from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 // ---------------------------------------------------------------------------
@@ -31,7 +37,10 @@ import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 // ---------------------------------------------------------------------------
 
 export interface WorkflowRoutesDeps {
-  getManager: () => Pick<WorkflowRunManager, "list" | "status" | "abort">;
+  getManager: () => Pick<
+    WorkflowRunManager,
+    "list" | "status" | "abort" | "resume"
+  >;
   listWorkflows: typeof listWorkflows;
   getConfig: () => AssistantConfig;
   isFlagEnabled: (config: AssistantConfig) => boolean;
@@ -66,6 +75,7 @@ const VALID_RUN_STATUSES = [
   "failed",
   "aborted",
   "cap_exceeded",
+  "interrupted",
 ] as const;
 
 const workflowRunSchema = z.object({
@@ -170,6 +180,33 @@ function handleAbortRun(id: string) {
   return { ok: true, runId: id };
 }
 
+function handleResumeRun(id: string) {
+  assertFlagEnabled();
+  const manager = deps.getManager();
+  // status() is the source of truth for existence, so 404 an unknown id here
+  // (matching abort) rather than letting resume's "not_found" reach the client
+  // as a 409.
+  if (!manager.status(id)) {
+    throw new NotFoundError(`Workflow run ${id} not found`);
+  }
+  try {
+    const { runId } = manager.resume(id);
+    return { ok: true, runId };
+  } catch (err) {
+    if (err instanceof WorkflowResumeNotPossibleError) {
+      if (err.reason === "not_found") {
+        throw new NotFoundError(`Workflow run ${id} not found`);
+      }
+      // not_interrupted / in_flight — the run exists but isn't resumable now.
+      throw new ConflictError(err.message);
+    }
+    if (err instanceof WorkflowRunCapError) {
+      throw new TooManyRequestsError(err.message);
+    }
+    throw err;
+  }
+}
+
 function handleListSavedWorkflows() {
   assertFlagEnabled();
   return { workflows: deps.listWorkflows() };
@@ -201,7 +238,7 @@ export const ROUTES: RouteDefinition[] = [
         name: "status",
         schema: { type: "string" },
         description:
-          "Filter by run status (running, completed, failed, aborted, cap_exceeded).",
+          "Filter by run status (running, completed, failed, aborted, cap_exceeded, interrupted).",
       },
     ],
     responseBody: z.object({
@@ -243,6 +280,30 @@ export const ROUTES: RouteDefinition[] = [
     additionalResponses: { "404": { description: "Run not found" } },
     handler: ({ pathParams }: RouteHandlerArgs) =>
       handleAbortRun(pathParams!.id),
+  },
+  {
+    operationId: "resumeWorkflowRun",
+    endpoint: "workflows/runs/:id/resume",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Resume workflow run",
+    description:
+      "Resume an interrupted workflow run (one orphaned by an assistant restart), replaying its journaled prefix and continuing from the first unfinished step.",
+    tags: ["workflows"],
+    responseBody: z.object({
+      ok: z.boolean(),
+      runId: z.string(),
+    }),
+    additionalResponses: {
+      "404": { description: "Run not found" },
+      "409": { description: "Run is not resumable (not interrupted)" },
+      "429": { description: "Concurrent-run cap reached" },
+    },
+    handler: ({ pathParams }: RouteHandlerArgs) =>
+      handleResumeRun(pathParams!.id),
   },
   {
     operationId: "listSavedWorkflows",

--- a/assistant/src/tools/workflows/manage-workflows.ts
+++ b/assistant/src/tools/workflows/manage-workflows.ts
@@ -24,11 +24,17 @@ async function executeManageWorkflows(
   switch (action) {
     case "status": {
       if (!runId) {
-        return { content: '"run_id" is required for action "status".', isError: true };
+        return {
+          content: '"run_id" is required for action "status".',
+          isError: true,
+        };
       }
       const run = manager.status(runId);
       if (!run) {
-        return { content: JSON.stringify({ runId, found: false }), isError: false };
+        return {
+          content: JSON.stringify({ runId, found: false }),
+          isError: false,
+        };
       }
       return {
         content: JSON.stringify({
@@ -45,7 +51,10 @@ async function executeManageWorkflows(
     }
     case "abort": {
       if (!runId) {
-        return { content: '"run_id" is required for action "abort".', isError: true };
+        return {
+          content: '"run_id" is required for action "abort".',
+          isError: true,
+        };
       }
       manager.abort(runId);
       return {
@@ -55,6 +64,29 @@ async function executeManageWorkflows(
         }),
         isError: false,
       };
+    }
+    case "resume": {
+      if (!runId) {
+        return {
+          content: '"run_id" is required for action "resume".',
+          isError: true,
+        };
+      }
+      try {
+        const { runId: resumedId } = manager.resume(runId);
+        return {
+          content: JSON.stringify({
+            runId: resumedId,
+            status: "running",
+            message:
+              "Workflow resumed. The completed prefix is replayed from the journal and the run continues from the first unfinished step. You will be notified in this conversation when it completes — do NOT poll.",
+          }),
+          isError: false,
+        };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return { content: `Failed to resume workflow: ${msg}`, isError: true };
+      }
     }
     case "list_runs": {
       const runs = manager.list();
@@ -72,7 +104,8 @@ async function executeManageWorkflows(
     }
     default:
       return {
-        content: 'Unknown action. Use one of: "status", "abort", "list_runs".',
+        content:
+          'Unknown action. Use one of: "status", "abort", "resume", "list_runs".',
         isError: true,
       };
   }
@@ -81,21 +114,24 @@ async function executeManageWorkflows(
 export const manageWorkflowsTool = {
   name: "manage_workflows",
   description:
-    'Inspect or control workflow runs started by run_workflow. action="status" (requires run_id) returns a run\'s status and counts; action="abort" (requires run_id) signals an in-flight run to stop; action="list_runs" returns recent runs newest-first.',
+    'Inspect or control workflow runs started by run_workflow. action="status" (requires run_id) returns a run\'s status and counts; action="abort" (requires run_id) signals an in-flight run to stop; action="resume" (requires run_id) restarts an interrupted run (one orphaned by an assistant restart), replaying its journaled prefix and continuing from the first unfinished step; action="list_runs" returns recent runs newest-first.',
   // Low risk: status/list are pure reads; abort only signals an existing run to
-  // stop and can never spawn work or cause side effects.
+  // stop; resume replays a journaled prefix and continues a previously-consented
+  // run under the same structural agent cap — none can introduce new unbounded
+  // work or side effects beyond what the run already declared.
   defaultRiskLevel: RiskLevel.Low,
   input_schema: {
     type: "object",
     properties: {
       action: {
         type: "string",
-        enum: ["status", "abort", "list_runs"],
+        enum: ["status", "abort", "resume", "list_runs"],
         description: "What to do.",
       },
       run_id: {
         type: "string",
-        description: 'Target run id (required for "status" and "abort").',
+        description:
+          'Target run id (required for "status", "abort", and "resume").',
       },
     },
     required: ["action"],

--- a/assistant/src/tools/workflows/run-workflow.test.ts
+++ b/assistant/src/tools/workflows/run-workflow.test.ts
@@ -52,6 +52,11 @@ const startMock = mock((opts: Record<string, unknown>) => {
 const statusMock = mock(() => null as unknown);
 const abortMock = mock(() => {});
 const listMock = mock(() => [] as unknown[]);
+let resumeThrows: Error | null = null;
+const resumeMock = mock((runId: string) => {
+  if (resumeThrows) throw resumeThrows;
+  return { runId };
+});
 
 mock.module("../../workflows/run-manager.js", () => ({
   getWorkflowRunManager: () => ({
@@ -59,6 +64,7 @@ mock.module("../../workflows/run-manager.js", () => ({
     status: statusMock,
     abort: abortMock,
     list: listMock,
+    resume: resumeMock,
   }),
 }));
 
@@ -81,10 +87,12 @@ beforeEach(() => {
   configThrows = false;
   startThrows = null;
   lastStartArgs = null;
+  resumeThrows = null;
   startMock.mockClear();
   statusMock.mockClear();
   abortMock.mockClear();
   listMock.mockClear();
+  resumeMock.mockClear();
 });
 
 describe("workflow tool registration gating", () => {
@@ -147,7 +155,9 @@ describe("run_workflow launch", () => {
       manifest: { tools: ["file_write"], hostFunctions: [], persona: true },
     });
     // Trust context falls back to the tool context's trust class.
-    expect((lastStartArgs as Record<string, unknown>).trustContext).toMatchObject({
+    expect(
+      (lastStartArgs as Record<string, unknown>).trustContext,
+    ).toMatchObject({
       trustClass: "guardian",
     });
   });
@@ -158,7 +168,9 @@ describe("run_workflow launch", () => {
       name: "saved-flow",
       manifest: { tools: [], hostFunctions: [], persona: false },
     });
-    expect((lastStartArgs as Record<string, unknown>).scriptSource).toBeUndefined();
+    expect(
+      (lastStartArgs as Record<string, unknown>).scriptSource,
+    ).toBeUndefined();
   });
 
   test("surfaces a run-manager start error as a tool error", async () => {
@@ -220,6 +232,35 @@ describe("manage_workflows", () => {
     );
     expect(res.isError).toBe(false);
     expect(JSON.parse(res.content).found).toBe(false);
+  });
+
+  test("resume requires run_id and delegates to resume()", async () => {
+    const missing = await manageWorkflowsTool.execute(
+      { action: "resume" },
+      makeContext(),
+    );
+    expect(missing.isError).toBe(true);
+    expect(resumeMock).not.toHaveBeenCalled();
+
+    const ok = await manageWorkflowsTool.execute(
+      { action: "resume", run_id: "r9" },
+      makeContext(),
+    );
+    expect(ok.isError).toBe(false);
+    expect(resumeMock).toHaveBeenCalledWith("r9");
+    expect(JSON.parse(ok.content).runId).toBe("r9");
+  });
+
+  test("resume surfaces a run-manager error as a tool error", async () => {
+    resumeThrows = new Error(
+      "Workflow run r9 is not resumable (status: completed).",
+    );
+    const res = await manageWorkflowsTool.execute(
+      { action: "resume", run_id: "r9" },
+      makeContext(),
+    );
+    expect(res.isError).toBe(true);
+    expect(res.content).toContain("not resumable");
   });
 
   test("rejects an unknown action", async () => {

--- a/assistant/src/workflows/engine-integration.test.ts
+++ b/assistant/src/workflows/engine-integration.test.ts
@@ -179,7 +179,11 @@ import type { ToolContext, ToolExecutionResult } from "../tools/types.js";
 import { resolveCapabilities } from "./capabilities.js";
 import { executeWorkflow } from "./engine.js";
 import * as journalStore from "./journal-store.js";
-import { getJournal, getRun } from "./journal-store.js";
+import {
+  getJournal,
+  getRun,
+  markRunningAsInterrupted,
+} from "./journal-store.js";
 import { runLeaf } from "./leaf-runner.js";
 
 initializeDb();
@@ -373,6 +377,62 @@ return [a, b, c];
     // `resume rewrites a changed leaf's journal entry` test.todo below for the
     // known `INSERT OR IGNORE` staleness bug. The engine's returned value
     // (asserted above) is correct; only the persisted journal row is stale.
+  });
+
+  test("restart→reconcile→resume: an interrupted run replays its prefix and carries accounting", async () => {
+    // Stage 1 — a first pass that journals a 2-leaf prefix, mirroring a run that
+    // got partway before the process died.
+    const scriptSource = `
+export const meta = { name: "reconcile-resume", description: "sequential agents" };
+const a = agent("step-1");
+const b = agent("step-2");
+const c = agent(args.tail);
+return [a, b, c];
+`;
+    const first = await executeWorkflow({
+      ...baseOptions("wf-reconcile", scriptSource),
+      args: { tail: "step-3" },
+      config: makeConfig(),
+    });
+    expect(first.status).toBe("completed");
+    expect(first.agentsSpawned).toBe(3);
+    const agentsBefore = getRun("wf-reconcile")!.agentsSpawned;
+    expect(agentsBefore).toBe(3);
+
+    // Simulate a crash: force the persisted row back to `running` (the state a
+    // mid-flight run leaves on disk), then run startup reconciliation.
+    journalStore.updateRun("wf-reconcile", { status: "running" });
+    const reconciled = markRunningAsInterrupted();
+    expect(reconciled).toBeGreaterThanOrEqual(1);
+    const interrupted = getRun("wf-reconcile")!;
+    expect(interrupted.status).toBe("interrupted");
+    // Reconciliation is STATUS ONLY — the accounting total is untouched.
+    expect(interrupted.agentsSpawned).toBe(agentsBefore);
+
+    sendCallCount = 0;
+    sendMessage.mockClear();
+
+    // Stage 2 — resume re-invokes the engine with the SAME runId. The unchanged
+    // prefix (seq 0,1) replays from the journal with ZERO provider calls; only
+    // the changed tail re-runs. Accounting SEEDS from the persisted total (3)
+    // and grows — it does not reset to 0.
+    const resumed = await executeWorkflow({
+      ...baseOptions("wf-reconcile", scriptSource),
+      args: { tail: "step-3-CHANGED" },
+      config: makeConfig(),
+    });
+
+    expect(resumed.status).toBe("completed");
+    // Only the changed tail hit the provider — the prefix replayed.
+    expect(sendCallCount).toBe(1);
+    expect(resumed.result).toEqual([
+      "processed:step-1",
+      "processed:step-2",
+      "processed:step-3-CHANGED",
+    ]);
+    // Accounting carried: seeded from 3, the single re-run tail makes it 4.
+    expect(resumed.agentsSpawned).toBe(4);
+    expect(getRun("wf-reconcile")!.agentsSpawned).toBe(4);
   });
 
   test("cap abort: a low maxAgentsPerRun yields cap_exceeded with partials persisted", async () => {

--- a/assistant/src/workflows/journal-store.ts
+++ b/assistant/src/workflows/journal-store.ts
@@ -21,7 +21,8 @@ export type WorkflowRunStatus =
   | "completed"
   | "failed"
   | "aborted"
-  | "cap_exceeded";
+  | "cap_exceeded"
+  | "interrupted";
 
 export type WorkflowJournalKind = "agent" | "hostFn" | "workflow";
 
@@ -368,6 +369,29 @@ export function listRuns(options: ListRunsOptions): WorkflowRun[] {
         options.limit,
       );
   return rows.map(rowToRun);
+}
+
+// ---------------------------------------------------------------------------
+// Startup reconciliation
+// ---------------------------------------------------------------------------
+
+/**
+ * Flip every `running` run to `interrupted`. Called once at daemon startup: a
+ * row left in `running` means the process died mid-run (nothing else can leave
+ * a row `running` after the engine exits, which always finishes it). Marking it
+ * `interrupted` makes it eligible for an explicit resume.
+ *
+ * STATUS ONLY — `agents_spawned`/`input_tokens`/`output_tokens` are NOT touched.
+ * The run row is the source of truth for ACCOUNTING (it seeds the resumed run's
+ * cap counters) while the journal is the source of truth for REPLAY; rewriting
+ * the counters here would drift the cap accounting. Returns the number of rows
+ * reconciled.
+ */
+export function markRunningAsInterrupted(): number {
+  return rawRun(
+    /*sql*/ `UPDATE workflow_runs SET status = 'interrupted', updated_at = ? WHERE status = 'running'`,
+    Date.now(),
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/workflows/run-manager.test.ts
+++ b/assistant/src/workflows/run-manager.test.ts
@@ -18,6 +18,7 @@ import type {
   WorkflowRunStatus,
 } from "./journal-store.js";
 import {
+  WorkflowResumeNotPossibleError,
   WorkflowRunCapError,
   WorkflowRunManager,
   type WorkflowRunManagerDeps,
@@ -79,6 +80,26 @@ function makeFakeJournal() {
         return run;
       },
       getRun: (id: string): WorkflowRun | null => rows.get(id) ?? null,
+      updateRun: (
+        id: string,
+        patch: Partial<WorkflowRun>,
+      ): WorkflowRun | null => {
+        const existing = rows.get(id);
+        if (!existing) return null;
+        const updated = { ...existing, ...patch, updatedAt: Date.now() };
+        rows.set(id, updated);
+        return updated;
+      },
+      markRunningAsInterrupted: (): number => {
+        let n = 0;
+        for (const [id, run] of rows) {
+          if (run.status === "running") {
+            rows.set(id, { ...run, status: "interrupted" });
+            n += 1;
+          }
+        }
+        return n;
+      },
       listRuns: ({
         limit,
         status,
@@ -128,6 +149,8 @@ function makeHarness(opts?: {
   engine?: WorkflowRunManagerDeps["executeWorkflow"];
   /** Saved-workflow resolver for the `start({ name })` path. */
   getWorkflow?: WorkflowRunManagerDeps["getWorkflow"];
+  /** Live-conversation lookup for the `resume` trust reconstruction path. */
+  findConversation?: WorkflowRunManagerDeps["findConversation"];
 }): ManagerHarness {
   const fake = makeFakeJournal();
   const executeCalls: ExecuteWorkflowOptions[] = [];
@@ -185,6 +208,9 @@ function makeHarness(opts?: {
       return () => `run-${++n}`;
     })(),
     ...(opts?.getWorkflow ? { getWorkflow: opts.getWorkflow } : {}),
+    findConversation:
+      opts?.findConversation ??
+      ((() => undefined) as WorkflowRunManagerDeps["findConversation"]),
   };
 
   const manager = new WorkflowRunManager(deps);
@@ -447,5 +473,140 @@ describe("WorkflowRunManager.start — saved-workflow name resolution", () => {
     ).toThrow(WorkflowNotFoundError);
     expect(h.executeCalls).toHaveLength(0);
     expect(h.fake.rows.size).toBe(0);
+  });
+});
+
+// Seed a run row directly into the fake journal (bypassing `start`), so resume
+// tests can stand up a pre-existing `interrupted`/other-status row.
+function seedRun(
+  h: ManagerHarness,
+  overrides: Partial<WorkflowRun> & { id: string },
+): WorkflowRun {
+  const run: WorkflowRun = {
+    name: "seeded",
+    scriptSource: "export const meta = { name: 'seeded', description: 'd' }",
+    scriptHash: "hash",
+    args: { k: "v" },
+    capabilities: { tools: [], hostFunctions: [], persona: false },
+    status: "interrupted",
+    conversationId: null,
+    agentsSpawned: 3,
+    inputTokens: 100,
+    outputTokens: 50,
+    result: null,
+    error: null,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    finishedAt: null,
+    ...overrides,
+  };
+  h.fake.rows.set(run.id, run);
+  return run;
+}
+
+describe("WorkflowRunManager.reconcileOrphanedRuns", () => {
+  test("flips running rows to interrupted, leaving counters untouched", () => {
+    const h = makeHarness({});
+    seedRun(h, { id: "r-run", status: "running", agentsSpawned: 7 });
+    seedRun(h, { id: "r-done", status: "completed", agentsSpawned: 2 });
+
+    const n = h.manager.reconcileOrphanedRuns();
+
+    expect(n).toBe(1);
+    const reconciled = h.fake.rows.get("r-run")!;
+    expect(reconciled.status).toBe("interrupted");
+    // Accounting preserved — reconciliation is status-only.
+    expect(reconciled.agentsSpawned).toBe(7);
+    expect(reconciled.inputTokens).toBe(100);
+    expect(reconciled.outputTokens).toBe(50);
+    // A completed run is untouched.
+    expect(h.fake.rows.get("r-done")!.status).toBe("completed");
+  });
+});
+
+describe("WorkflowRunManager.resume", () => {
+  test("an interrupted run re-invokes the engine with the SAME runId and carries accounting", async () => {
+    const h = makeHarness({});
+    seedRun(h, {
+      id: "run-x",
+      status: "interrupted",
+      args: { foo: 1 },
+      agentsSpawned: 4,
+    });
+
+    const { runId } = h.manager.resume("run-x");
+    expect(runId).toBe("run-x");
+
+    // Engine invoked with the same runId + reconstructed args; no NEW row.
+    expect(h.executeCalls).toHaveLength(1);
+    expect(h.executeCalls[0]!.runId).toBe("run-x");
+    expect(h.executeCalls[0]!.args).toEqual({ foo: 1 });
+
+    // Status transitions interrupted → running before launch.
+    expect(h.fake.rows.get("run-x")!.status).toBe("running");
+
+    // The engine reports the carried-forward accounting (seed: 4 agents) plus
+    // newly spawned work — the count carries, it does NOT reset.
+    await h.resolveLatest({
+      status: "completed",
+      result: "done",
+      agentsSpawned: 6,
+      inputTokens: 200,
+      outputTokens: 90,
+    });
+
+    const run = h.manager.status("run-x");
+    expect(run?.status).toBe("completed");
+    expect(run?.agentsSpawned).toBe(6);
+    expect(h.manager.inflightCount()).toBe(0);
+  });
+
+  test("resume falls back to the internal guardian trust context when no conversation", () => {
+    const h = makeHarness({});
+    seedRun(h, { id: "run-x", status: "interrupted", conversationId: null });
+
+    h.manager.resume("run-x");
+
+    expect(h.executeCalls[0]!.trustContext.trustClass).toBe("guardian");
+  });
+
+  test("a non-interrupted run throws WorkflowResumeNotPossibleError and does not invoke the engine", () => {
+    const h = makeHarness({});
+    seedRun(h, { id: "run-done", status: "completed" });
+
+    expect(() => h.manager.resume("run-done")).toThrow(
+      WorkflowResumeNotPossibleError,
+    );
+    expect(h.executeCalls).toHaveLength(0);
+    // The row is untouched (still completed).
+    expect(h.fake.rows.get("run-done")!.status).toBe("completed");
+  });
+
+  test("an unknown run throws WorkflowResumeNotPossibleError", () => {
+    const h = makeHarness({});
+    expect(() => h.manager.resume("ghost")).toThrow(
+      WorkflowResumeNotPossibleError,
+    );
+    expect(h.executeCalls).toHaveLength(0);
+  });
+
+  test("resume respects the concurrent-run cap", () => {
+    const h = makeHarness({ maxConcurrentRuns: 1 });
+    // Occupy the single slot with a live run.
+    h.manager.start({
+      scriptSource: "export const meta = { name: 'x', description: 'y' }",
+      args: {},
+      manifest: { tools: [], hostFunctions: [], persona: false },
+      trustContext: TRUST,
+    });
+    seedRun(h, { id: "run-x", status: "interrupted" });
+
+    expect(() => h.manager.resume("run-x")).toThrow(WorkflowRunCapError);
+  });
+
+  test("resume is rejected when the flag is off", () => {
+    const h = makeHarness({ flagEnabled: false });
+    seedRun(h, { id: "run-x", status: "interrupted" });
+    expect(() => h.manager.resume("run-x")).toThrow(WorkflowsDisabledError);
   });
 });

--- a/assistant/src/workflows/run-manager.ts
+++ b/assistant/src/workflows/run-manager.ts
@@ -31,7 +31,11 @@ import { createHash, randomUUID } from "node:crypto";
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
 import type { AssistantConfig } from "../config/schema.js";
-import type { TrustContext } from "../daemon/trust-context.js";
+import { findConversation } from "../daemon/conversation-registry.js";
+import {
+  INTERNAL_GUARDIAN_TRUST_CONTEXT,
+  type TrustContext,
+} from "../daemon/trust-context.js";
 import { wakeAgentForOpportunity } from "../runtime/agent-wake.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { getLogger } from "../util/logger.js";
@@ -70,6 +74,31 @@ export class WorkflowRunCapError extends Error {
         `(maxConcurrentRuns).`,
     );
     this.name = "WorkflowRunCapError";
+  }
+}
+
+/**
+ * Thrown by `resume` when the target run cannot be resumed: it does not exist,
+ * is already in a terminal-but-not-resumable state, or is currently in flight.
+ * Only an `interrupted` run (a `running` row reconciled at startup after a
+ * crash) is resumable.
+ */
+export class WorkflowResumeNotPossibleError extends Error {
+  readonly code = "workflow_resume_not_possible" as const;
+  constructor(
+    readonly runId: string,
+    readonly reason: "not_found" | "not_interrupted" | "in_flight",
+    readonly status?: WorkflowRun["status"],
+  ) {
+    super(
+      reason === "not_found"
+        ? `Workflow run ${runId} not found.`
+        : reason === "in_flight"
+          ? `Workflow run ${runId} is already in flight.`
+          : `Workflow run ${runId} is not resumable (status: ${status}). ` +
+            `Only interrupted runs can be resumed.`,
+    );
+    this.name = "WorkflowResumeNotPossibleError";
   }
 }
 
@@ -116,6 +145,8 @@ export interface WorkflowRunManagerDeps {
   newRunId: () => string;
   /** Resolve a saved workflow's source by name (for `start({ name })`). */
   getWorkflow: typeof library.getWorkflow;
+  /** Look up a live conversation (for `resume` trust reconstruction). */
+  findConversation: typeof findConversation;
 }
 
 function defaultDeps(): WorkflowRunManagerDeps {
@@ -130,6 +161,7 @@ function defaultDeps(): WorkflowRunManagerDeps {
     broadcast: broadcastMessage,
     newRunId: () => randomUUID(),
     getWorkflow: library.getWorkflow,
+    findConversation,
   };
 }
 
@@ -182,14 +214,16 @@ export class WorkflowRunManager {
     // Create the row up front (so `status`/`list` see it immediately) with the
     // same name + script hash the engine would compute, so its idempotent
     // re-open of the existing row is a true no-op rather than a divergent
-    // overwrite.
+    // overwrite. We persist the MANIFEST (a plain serializable grant), not the
+    // resolved capabilities (which carry live Tool objects that don't survive a
+    // round-trip), so a later `resume` can re-resolve it deterministically.
     this.deps.journal.createRun({
       id: runId,
       name: meta.name,
       scriptSource,
       scriptHash: createHash("sha256").update(scriptSource).digest("hex"),
       args: opts.args,
-      capabilities,
+      capabilities: opts.manifest,
       status: "running",
       conversationId: opts.conversationId ?? null,
     });
@@ -203,12 +237,124 @@ export class WorkflowRunManager {
       runId,
       label,
       scriptSource,
-      opts,
       capabilities,
       controller,
+      {
+        args: opts.args,
+        conversationId: opts.conversationId,
+        trustContext: opts.trustContext,
+      },
     );
 
     return { runId };
+  }
+
+  /**
+   * Mark every `running` run `interrupted` at daemon startup. A row left in
+   * `running` means the process died mid-run (the engine always finishes its
+   * row on exit, so nothing else leaves one `running`). This makes the run
+   * eligible for an explicit {@link resume}; it does NOT auto-resume (that would
+   * be surprising and possibly unsafe). STATUS ONLY — accounting counters are
+   * never touched (see {@link journalStore.markRunningAsInterrupted}). Returns
+   * the number of runs reconciled.
+   */
+  reconcileOrphanedRuns(): number {
+    return this.deps.journal.markRunningAsInterrupted();
+  }
+
+  /**
+   * Resume an `interrupted` run with the SAME `runId`, re-invoking the engine so
+   * it replays the journaled prefix and continues from the first changed/new
+   * leaf. Reconstructs the run's inputs from the persisted row (script source,
+   * args, capability manifest, conversation) and re-derives the trust context
+   * from the originating conversation (falling back to the internal guardian
+   * context). Enforces the `workflows` flag and the concurrent-run cap (a resume
+   * occupies a run slot). Returns the `runId` immediately — completion is
+   * surfaced via events and a conversation wake exactly like {@link start}.
+   *
+   * Throws {@link WorkflowResumeNotPossibleError} when the run is missing, not
+   * `interrupted`, or already in flight.
+   */
+  resume(runId: string): { runId: string } {
+    const config = this.deps.getConfig();
+    if (!this.deps.isFlagEnabled(config)) {
+      throw new WorkflowsDisabledError();
+    }
+
+    if (this.inflight.has(runId)) {
+      throw new WorkflowResumeNotPossibleError(runId, "in_flight");
+    }
+
+    const run = this.deps.journal.getRun(runId);
+    if (!run) {
+      throw new WorkflowResumeNotPossibleError(runId, "not_found");
+    }
+    // Gate to `interrupted`: only a startup-reconciled crash leaves a resumable
+    // row. A `running` row that is NOT in our in-flight map is a stale row from
+    // a still-booting/other process — refuse rather than racing it.
+    if (run.status !== "interrupted") {
+      throw new WorkflowResumeNotPossibleError(
+        runId,
+        "not_interrupted",
+        run.status,
+      );
+    }
+
+    const limit = config.workflows.maxConcurrentRuns;
+    if (this.inflight.size >= limit) {
+      throw new WorkflowRunCapError(limit);
+    }
+
+    // Re-resolve capabilities from the persisted manifest (re-resolution throws
+    // synchronously on an unknown/forbidden tool, leaving the row interrupted).
+    // The engine re-validates the script's `meta` on re-invoke, so we don't
+    // re-extract it here — the persisted `name` is the display label.
+    const capabilities = resolveCapabilities(
+      manifestFromStored(run.capabilities),
+    );
+    const label = run.name ?? runId;
+    const trustContext = this.resolveResumeTrustContext(run.conversationId);
+
+    // Flip back to `running` before launching so `status`/`list` reflect the
+    // in-flight resume; the engine re-opens the same row idempotently.
+    this.deps.journal.updateRun(runId, { status: "running" });
+
+    const controller = new AbortController();
+    this.inflight.set(runId, controller);
+
+    void this.runToCompletion(
+      runId,
+      label,
+      run.scriptSource,
+      capabilities,
+      controller,
+      {
+        args: run.args,
+        conversationId: run.conversationId ?? undefined,
+        trustContext,
+      },
+    );
+
+    return { runId };
+  }
+
+  /**
+   * Reconstruct the trust context for a resumed run: prefer the originating
+   * conversation's resolved/per-turn trust (the context it ran under), falling
+   * back to the internal guardian context when the conversation is gone (it was
+   * a self-maintenance/background run, or the conversation evicted on restart).
+   */
+  private resolveResumeTrustContext(
+    conversationId: string | null,
+  ): TrustContext {
+    const conversation = this.deps.findConversation(
+      conversationId ?? undefined,
+    );
+    return (
+      conversation?.currentTurnTrustContext ??
+      conversation?.trustContext ??
+      INTERNAL_GUARDIAN_TRUST_CONTEXT
+    );
   }
 
   /**
@@ -261,21 +407,21 @@ export class WorkflowRunManager {
     runId: string,
     label: string,
     scriptSource: string,
-    opts: StartWorkflowOptions,
     capabilities: ReturnType<typeof resolveCapabilities>,
     controller: AbortController,
+    ctx: RunContext,
   ): Promise<void> {
     const config = this.deps.getConfig();
     try {
       const result = await this.deps.executeWorkflow({
         runId,
         scriptSource,
-        args: opts.args,
+        args: ctx.args,
         capabilities,
         config: config.workflows,
         journal: this.deps.journal,
         leafRunner: this.deps.leafRunner,
-        trustContext: opts.trustContext,
+        trustContext: ctx.trustContext,
         signal: controller.signal,
         onProgress: (event) => {
           const run = this.deps.journal.getRun(runId);
@@ -309,7 +455,7 @@ export class WorkflowRunManager {
         summary,
       });
 
-      await this.injectCompletionSummary(opts, summary);
+      await this.injectCompletionSummary(ctx, summary);
     } catch (err) {
       // The engine finishes the run row even on internal errors, so this only
       // fires for an unexpected throw (e.g. a bug in the manager glue). Log and
@@ -328,24 +474,72 @@ export class WorkflowRunManager {
    * thrown (the run already completed; events already fired).
    */
   private async injectCompletionSummary(
-    opts: StartWorkflowOptions,
+    ctx: RunContext,
     summary: string,
   ): Promise<void> {
-    if (!opts.conversationId) return;
+    if (!ctx.conversationId) return;
     try {
       await this.deps.wake({
-        conversationId: opts.conversationId,
+        conversationId: ctx.conversationId,
         hint: summary,
         source: WORKFLOW_WAKE_SOURCE,
-        trustContext: opts.trustContext,
+        trustContext: ctx.trustContext,
       });
     } catch (err) {
       log.warn(
-        { err, conversationId: opts.conversationId },
+        { err, conversationId: ctx.conversationId },
         "Workflow run manager: completion wake failed (non-fatal)",
       );
     }
   }
+}
+
+/**
+ * The per-run inputs `runToCompletion` needs, decoupled from how the run was
+ * launched. Both {@link WorkflowRunManager.start} (from `StartWorkflowOptions`)
+ * and {@link WorkflowRunManager.resume} (from the persisted run row) build one.
+ */
+interface RunContext {
+  args: unknown;
+  conversationId: string | undefined;
+  trustContext: TrustContext;
+}
+
+/**
+ * Normalize a run row's persisted `capabilities` back into a
+ * {@link CapabilityManifest} for re-resolution on resume.
+ *
+ * New rows persist the manifest verbatim (`tools`/`hostFunctions` as
+ * string arrays). Older rows persisted the RESOLVED set, whose `tools` are Tool
+ * objects (their functions dropped on JSON round-trip) — for those we recover
+ * the declared tool names from the objects' `name` fields. Either way the
+ * resulting manifest is fed back through `resolveCapabilities`, which re-unions
+ * the read-only baseline and re-validates every name.
+ */
+function manifestFromStored(stored: unknown): CapabilityManifest {
+  const obj =
+    stored && typeof stored === "object"
+      ? (stored as Record<string, unknown>)
+      : {};
+  const toolNames = Array.isArray(obj.tools)
+    ? obj.tools
+        .map((t) =>
+          typeof t === "string"
+            ? t
+            : t && typeof t === "object"
+              ? ((t as Record<string, unknown>).name as string | undefined)
+              : undefined,
+        )
+        .filter((n): n is string => typeof n === "string")
+    : [];
+  const hostFunctions = Array.isArray(obj.hostFunctions)
+    ? obj.hostFunctions.filter((n): n is string => typeof n === "string")
+    : [];
+  return {
+    tools: toolNames,
+    hostFunctions,
+    persona: obj.persona === true,
+  };
 }
 
 /**

--- a/cli/src/commands/workflows.ts
+++ b/cli/src/commands/workflows.ts
@@ -90,6 +90,9 @@ function printHelp(): void {
   console.log("  runs              List recent workflow runs");
   console.log("  show <run-id>     Show details for a single run");
   console.log("  abort <run-id>    Abort an in-flight run");
+  console.log(
+    "  resume <run-id>   Resume an interrupted run (orphaned by a restart)",
+  );
   console.log("");
   console.log("Options:");
   console.log(
@@ -218,6 +221,18 @@ async function abortRun(runId: string, assistantName?: string): Promise<void> {
   console.log(`Abort signalled for workflow run ${runId}.`);
 }
 
+async function resumeRun(runId: string, assistantName?: string): Promise<void> {
+  const client = createClient(assistantName);
+  await requestJson<{ ok: boolean; runId: string }>(
+    client,
+    "post",
+    `/workflows/runs/${runId}/resume`,
+  );
+  console.log(
+    `Resumed workflow run ${runId}. It replays its completed steps and continues from where it was interrupted.`,
+  );
+}
+
 /**
  * Strip `--assistant <name>` from argv and return the captured value.
  * Mutates the input array so downstream positional parsing is clean.
@@ -291,6 +306,16 @@ export async function workflows(): Promise<void> {
       process.exit(1);
     }
     await abortRun(runId, assistantName);
+    return;
+  }
+
+  if (subcommand === "resume") {
+    const runId = args[1];
+    if (!runId) {
+      console.error("Usage: vellum workflows resume <run-id>");
+      process.exit(1);
+    }
+    await resumeRun(runId, assistantName);
     return;
   }
 


### PR DESCRIPTION
## Summary
- Add the resume surface: 'interrupted' run status, daemon-startup reconciliation of orphaned running rows, WorkflowRunManager.resume(runId) re-invoking the engine with the same runId, a manage_workflows 'resume' action, a resume route + 'vellum workflows resume' CLI, and docs alignment. Reconciliation is status-only (preserves accounting/replay invariants).

Part of plan: workflow-engine.md (completes journaled resume; surfaced during self-review)