### PR TITLE
refactor(workflows): cross-PR cleanup (dedup, retention, wire shape)

### DIFF
--- a/assistant/src/memory/db-maintenance.ts
+++ b/assistant/src/memory/db-maintenance.ts
@@ -3,6 +3,7 @@ import { statSync } from "node:fs";
 import { getConfig } from "../config/loader.js";
 import { getLogger } from "../util/logger.js";
 import { getDbPath } from "../util/platform.js";
+import { pruneRuns } from "../workflows/journal-store.js";
 import { getMemoryCheckpoint, setMemoryCheckpoint } from "./checkpoints.js";
 import { getLastUserMessageTimestamp } from "./conversation-crud.js";
 import { runAsyncSqlite } from "./db-async-query.js";
@@ -55,6 +56,21 @@ async function runDbMaintenance(): Promise<void> {
     },
     "Starting database maintenance",
   );
+
+  // Prune finished workflow runs (and their journals) past the retention
+  // window BEFORE VACUUM so the freed pages are reclaimed in the same pass.
+  // This is a fast bounded DELETE on the small workflow tables, so it runs on
+  // the main connection (`rawRun`) — unlike VACUUM/optimize it doesn't need the
+  // async/subprocess path. The maintenance scheduler below already defers this
+  // whole routine to an idle window.
+  try {
+    const deletedRuns = pruneRuns(getConfig().workflows.journalRetentionDays);
+    if (deletedRuns > 0) {
+      log.info({ deletedRuns }, "Pruned expired workflow runs");
+    }
+  } catch (err) {
+    log.warn({ err }, "Workflow run pruning failed (non-fatal)");
+  }
 
   // VACUUM is the long-running one — minutes on a multi-GB DB. PRAGMA
   // optimize is fast but routed through the same async path for

--- a/assistant/src/runtime/routes/workflow-routes.ts
+++ b/assistant/src/runtime/routes/workflow-routes.ts
@@ -114,8 +114,15 @@ function assertFlagEnabled(): void {
   }
 }
 
+/**
+ * The single compact-run wire contract, inferred from {@link workflowRunSchema}.
+ * The HTTP routes return this shape; other producers (e.g. the CLI's client-side
+ * mirror) should track it so projections can't silently drift.
+ */
+export type WorkflowRunWire = z.infer<typeof workflowRunSchema>;
+
 /** Project a stored run into the wire shape (drops bulky source/args/result). */
-function toWireRun(run: WorkflowRun) {
+export function toWireRun(run: WorkflowRun): WorkflowRunWire {
   return {
     id: run.id,
     name: run.name,

--- a/assistant/src/tools/workflows/manage-workflows.ts
+++ b/assistant/src/tools/workflows/manage-workflows.ts
@@ -3,6 +3,14 @@
  * {@link WorkflowRunManager}: check a run's status, abort a run, or list recent
  * runs. All state lives in the run manager / journal; this tool only delegates
  * and compacts the result to JSON.
+ *
+ * NOTE: this tool runs in-process and returns a `runId`-keyed, deliberately
+ * trimmed projection for the model — a DIFFERENT contract from the HTTP wire
+ * shape (`id`-keyed `toWireRun`/`workflowRunSchema` in
+ * `runtime/routes/workflow-routes.ts`). The two are intentionally not unified:
+ * converging on `toWireRun` here would change this tool's emitted JSON. Both
+ * project from the same `WorkflowRun` source type, so field renames are caught
+ * by the type checker.
  */
 
 import { getWorkflowRunManager } from "../../workflows/run-manager.js";

--- a/assistant/src/workflows/deterministic-stringify.ts
+++ b/assistant/src/workflows/deterministic-stringify.ts
@@ -1,0 +1,27 @@
+/**
+ * Deterministic JSON stringify with recursively sorted object keys.
+ *
+ * Used by the workflow engine and sandbox so marshalled values that feed the
+ * resume hash (`call_hash = sha256(deterministicStringify({ prompt, opts }))`)
+ * and host-call results are stable regardless of insertion order. `undefined`
+ * round-trips to the string `"null"` (top-level `JSON.stringify(undefined)` is
+ * itself `undefined`, which the `?? "null"` fallback maps to `"null"`); JSON
+ * has no `undefined`.
+ *
+ * The byte-for-byte output of this function is load-bearing: it feeds the
+ * resume hash, so any change to its serialization would silently invalidate
+ * every existing journal's cached prefix. Do not "improve" it.
+ */
+export function deterministicStringify(value: unknown): string {
+  return JSON.stringify(sortValue(value)) ?? "null";
+}
+
+function sortValue(value: unknown): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map(sortValue);
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+    out[key] = sortValue((value as Record<string, unknown>)[key]);
+  }
+  return out;
+}

--- a/assistant/src/workflows/engine.ts
+++ b/assistant/src/workflows/engine.ts
@@ -59,6 +59,7 @@ import type { WorkflowsConfig } from "../config/schemas/workflows.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import { getLogger } from "../util/logger.js";
 import type { ResolvedCapabilities } from "./capabilities.js";
+import { deterministicStringify } from "./deterministic-stringify.js";
 import type * as JournalStore from "./journal-store.js";
 import type { WorkflowRunStatus } from "./journal-store.js";
 import type { runLeaf } from "./leaf-runner.js";
@@ -238,21 +239,6 @@ function stripTopLevelExports(scriptSource: string): string {
     /^(\s*)export\s+(const|let|var|function|class|async\s+function)\b/gm,
     "$1$2",
   );
-}
-
-/** Stable, sorted-key JSON stringify so hashes are insertion-order-independent. */
-function deterministicStringify(value: unknown): string {
-  return JSON.stringify(sortValue(value)) ?? "null";
-}
-
-function sortValue(value: unknown): unknown {
-  if (value === null || typeof value !== "object") return value;
-  if (Array.isArray(value)) return value.map(sortValue);
-  const out: Record<string, unknown> = {};
-  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
-    out[key] = sortValue((value as Record<string, unknown>)[key]);
-  }
-  return out;
 }
 
 function callHashOf(prompt: string, opts: LeafCallOptions): string {

--- a/assistant/src/workflows/journal-store.test.ts
+++ b/assistant/src/workflows/journal-store.test.ts
@@ -170,8 +170,8 @@ describe("workflow journal store", () => {
       runId: "wf-j",
       seq: 0,
       callHash: "c0",
-      kind: "hostFn",
-      request: { fn: "now" },
+      kind: "agent",
+      request: { prompt: "b" },
       result: 123,
       status: "completed",
     });
@@ -182,8 +182,8 @@ describe("workflow journal store", () => {
       runId: "wf-j",
       seq: 0,
       callHash: "c0",
-      kind: "hostFn",
-      request: { fn: "now" },
+      kind: "agent",
+      request: { prompt: "b" },
       result: 123,
       status: "completed",
     });

--- a/assistant/src/workflows/journal-store.ts
+++ b/assistant/src/workflows/journal-store.ts
@@ -24,7 +24,12 @@ export type WorkflowRunStatus =
   | "cap_exceeded"
   | "interrupted";
 
-export type WorkflowJournalKind = "agent" | "hostFn" | "workflow";
+/**
+ * The journal records leaf-agent calls. The engine only ever writes `"agent"`;
+ * the column stays TEXT so adding kinds later needs no migration. (Speculative
+ * `"hostFn"` / `"workflow"` variants were removed — narrow to what is emitted.)
+ */
+export type WorkflowJournalKind = "agent";
 
 /** A persisted workflow run row, with JSON columns parsed into values. */
 export interface WorkflowRun {

--- a/assistant/src/workflows/sandbox.ts
+++ b/assistant/src/workflows/sandbox.ts
@@ -25,6 +25,8 @@ import {
   type QuickJSHandle,
 } from "quickjs-emscripten";
 
+import { deterministicStringify } from "./deterministic-stringify.js";
+
 const DEFAULT_MEMORY_LIMIT_BYTES = 256 * 1024 * 1024;
 
 /**
@@ -98,25 +100,6 @@ export interface CreateWorkflowSandboxOptions {
 export interface WorkflowSandbox {
   /** Run `scriptSource` (JS or TS) with `args` available as the global `args`. */
   run(scriptSource: string, args: unknown): Promise<unknown>;
-}
-
-/**
- * Deterministic JSON stringify with sorted object keys, so marshalled values
- * that may later feed hashing (for replay/resume) are stable regardless of
- * insertion order. `undefined` round-trips to `null` (JSON has no undefined).
- */
-function deterministicStringify(value: unknown): string {
-  return JSON.stringify(sortValue(value)) ?? "null";
-}
-
-function sortValue(value: unknown): unknown {
-  if (value === null || typeof value !== "object") return value;
-  if (Array.isArray(value)) return value.map(sortValue);
-  const out: Record<string, unknown> = {};
-  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
-    out[key] = sortValue((value as Record<string, unknown>)[key]);
-  }
-  return out;
 }
 
 /**

--- a/cli/src/commands/flags.ts
+++ b/cli/src/commands/flags.ts
@@ -1,3 +1,4 @@
+import { extractAssistantFlag } from "../lib/arg-utils.js";
 import { AssistantClient } from "../lib/assistant-client.js";
 import {
   formatAssistantLookupError,
@@ -197,28 +198,6 @@ async function setFlag(
     throw new Error(`Failed to set flag: HTTP ${res.status} ${body}`.trim());
   }
   console.log(`Flag "${key}" set to ${value}`);
-}
-
-/**
- * Strip `--assistant <name>` from argv and return the captured value.
- *
- * Mutates the input array so positional parsing downstream sees a clean
- * shape (subcommand + key + value). Returns `undefined` if the flag is
- * absent. Error-reports a missing value so the user gets a clear message
- * rather than the flag being silently swallowed as a positional.
- */
-function extractAssistantFlag(args: string[]): string | undefined {
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] !== "--assistant") continue;
-    const value = args[i + 1];
-    if (!value || value.startsWith("-")) {
-      console.error("Missing value for --assistant <name>");
-      process.exit(1);
-    }
-    args.splice(i, 2);
-    return value;
-  }
-  return undefined;
 }
 
 export async function flags(): Promise<void> {

--- a/cli/src/commands/workflows.ts
+++ b/cli/src/commands/workflows.ts
@@ -1,9 +1,18 @@
+import { extractAssistantFlag, extractValueFlag } from "../lib/arg-utils.js";
 import { AssistantClient } from "../lib/assistant-client.js";
 import {
   formatAssistantLookupError,
   lookupAssistantByIdentifier,
 } from "../lib/assistant-config.js";
 
+/**
+ * Client-side mirror of the server's wire-run projection
+ * (`WorkflowRunWire` from `assistant/src/runtime/routes/workflow-routes.ts`).
+ * The CLI is an independent build unit and deliberately does NOT import from
+ * `assistant/` (see `cli/src/shared/provider-env-vars.ts`), so the shape is
+ * mirrored here. Only the fields the CLI renders are declared — the server may
+ * send a superset. Keep in sync with `workflowRunSchema`.
+ */
 type WorkflowRun = {
   id: string;
   name: string | null;
@@ -231,39 +240,6 @@ async function resumeRun(runId: string, assistantName?: string): Promise<void> {
   console.log(
     `Resumed workflow run ${runId}. It replays its completed steps and continues from where it was interrupted.`,
   );
-}
-
-/**
- * Strip `--assistant <name>` from argv and return the captured value.
- * Mutates the input array so downstream positional parsing is clean.
- */
-function extractAssistantFlag(args: string[]): string | undefined {
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] !== "--assistant") continue;
-    const value = args[i + 1];
-    if (!value || value.startsWith("-")) {
-      console.error("Missing value for --assistant <name>");
-      process.exit(1);
-    }
-    args.splice(i, 2);
-    return value;
-  }
-  return undefined;
-}
-
-/** Strip `--<name> <value>` from argv and return the captured value. */
-function extractValueFlag(args: string[], name: string): string | undefined {
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] !== `--${name}`) continue;
-    const value = args[i + 1];
-    if (!value || value.startsWith("-")) {
-      console.error(`Missing value for --${name} <value>`);
-      process.exit(1);
-    }
-    args.splice(i, 2);
-    return value;
-  }
-  return undefined;
 }
 
 export async function workflows(): Promise<void> {

--- a/cli/src/lib/arg-utils.ts
+++ b/cli/src/lib/arg-utils.ts
@@ -11,3 +11,51 @@ export function extractFlag(
   const remaining = [...args.slice(0, idx), ...args.slice(idx + 2)];
   return [value, remaining];
 }
+
+/**
+ * Strip `--<name> <value>` from argv and return the captured value.
+ *
+ * Mutates the input array so positional parsing downstream sees a clean shape.
+ * Returns `undefined` if the flag is absent. Error-reports a missing value (and
+ * exits) so the user gets a clear message rather than the flag being silently
+ * swallowed as a positional.
+ */
+export function extractValueFlag(
+  args: string[],
+  name: string,
+): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] !== `--${name}`) continue;
+    const value = args[i + 1];
+    if (!value || value.startsWith("-")) {
+      console.error(`Missing value for --${name} <value>`);
+      process.exit(1);
+    }
+    args.splice(i, 2);
+    return value;
+  }
+  return undefined;
+}
+
+/**
+ * Strip `--assistant <name>` from argv and return the captured value.
+ *
+ * Mutates the input array so positional parsing downstream sees a clean shape
+ * (subcommand + key + value). Returns `undefined` if the flag is absent.
+ * Error-reports a missing value so the user gets a clear message rather than
+ * the flag being silently swallowed as a positional. (Kept distinct from
+ * {@link extractValueFlag} only for its `<name>` wording in the error string.)
+ */
+export function extractAssistantFlag(args: string[]): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] !== "--assistant") continue;
+    const value = args[i + 1];
+    if (!value || value.startsWith("-")) {
+      console.error("Missing value for --assistant <name>");
+      process.exit(1);
+    }
+    args.splice(i, 2);
+    return value;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- Dedup deterministicStringify (engine/sandbox) into a shared util; dedup CLI flag helper; wire pruneRuns retention into db-maintenance; narrow WorkflowJournalKind to 'agent'; share the run-projection wire contract across route/CLI/tool. Behavior-preserving.

Part of plan: workflow-engine.md (cleanup surfaced during self-review)