### PR TITLE
feat(assistant): lane-annotated selector candidates + task-state selector guidance

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/card.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/card.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for `card.ts` — the compact card renderer. Focused on the annotation
+ * line: it must sit directly under the header (the always-rendered card
+ * surface) and leave the card untouched when absent.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { renderCard } from "../card.js";
+
+const PAGE = `---
+title: Page A
+---
+
+Lead paragraph for page a.
+
+## Alpha
+
+Body text.
+`;
+
+describe("renderCard — annotation line", () => {
+  test("renders the annotation directly under the header, before the head", () => {
+    const card = renderCard(
+      "page-a",
+      PAGE,
+      "[lane: fresh · updated 2026-06-10 14:23 UTC]",
+    );
+    expect(
+      card.startsWith(
+        "# memory/concepts/page-a.md\n[lane: fresh · updated 2026-06-10 14:23 UTC]\nLead paragraph for page a.",
+      ),
+    ).toBe(true);
+    expect(card).toContain("[sections: §Alpha]");
+  });
+
+  test("an absent or empty annotation leaves the card unchanged", () => {
+    const bare = renderCard("page-a", PAGE);
+    expect(renderCard("page-a", PAGE, "")).toBe(bare);
+    expect(bare).not.toContain("[lane:");
+    expect(
+      bare.startsWith(
+        "# memory/concepts/page-a.md\nLead paragraph for page a.",
+      ),
+    ).toBe(true);
+  });
+
+  test("annotates a page with no head section without a dangling blank line", () => {
+    const card = renderCard(
+      "page-b",
+      "## Only Section\n\nBody.",
+      "[lane: core]",
+    );
+    expect(card.startsWith("# memory/concepts/page-b.md\n[lane: core]")).toBe(
+      true,
+    );
+  });
+});

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/carry-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/carry-integration.test.ts
@@ -488,7 +488,7 @@ function candidateSlugs(messages: Message[]): Slug[] {
       );
       if (finder) {
         for (const line of finder[1].split("\n")) {
-          const m = /^\[(\d+)\] (\S+)(?: — |$)/.exec(line);
+          const m = /^\[(\d+)\] (?:\([^)]*\) )?(\S+)(?: — |$)/.exec(line);
           if (m) entries.push({ id: Number(m[1]), slug: m[2]! });
         }
       }

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/live-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/live-integration.test.ts
@@ -189,7 +189,7 @@ function candidateSlugs(messages: Message[]): Slug[] {
       );
       if (finder) {
         for (const line of finder[1].split("\n")) {
-          const m = /^\[(\d+)\] (\S+)(?: — |$)/.exec(line);
+          const m = /^\[(\d+)\] (?:\([^)]*\) )?(\S+)(?: — |$)/.exec(line);
           if (m) entries.push({ id: Number(m[1]), slug: m[2]! });
         }
       }

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
@@ -203,7 +203,7 @@ function parsePool(messages: Message[]): {
       );
       if (finder) {
         for (const line of finder[1].split("\n")) {
-          const m = /^\[(\d+)\] (\S+)(?: — |$)/.exec(line);
+          const m = /^\[(\d+)\] (?:\([^)]*\) )?(\S+)(?: — |$)/.exec(line);
           if (m) entries.push({ id: Number(m[1]), slug: m[2]!, line });
         }
       }

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/pool-select.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/pool-select.test.ts
@@ -316,6 +316,23 @@ describe("selectPool — request shape", () => {
     expect(tail.text).not.toContain("<candidate_cards>");
   });
 
+  test("finder lines render the surfacing lane tag when one is supplied", async () => {
+    providerStub = makeProvider(toolUseResponse({ ids: [] }));
+    const pool = makePool();
+    pool.finder = [
+      { slug: "topic-x", descriptor: "section: about topic x", lane: "needle" },
+      { slug: "page-a", descriptor: "", lane: "learned" },
+    ];
+    await selectPool(pool, makeTurn("rollout?"));
+
+    const [, tail] = sentBlocks();
+    expect(tail.text).toContain(
+      "[3] (needle) topic-x — section: about topic x",
+    );
+    // Empty descriptor: lane tag still renders, dash omitted.
+    expect(tail.text).toContain("[4] (learned) page-a");
+  });
+
   test("the rendered prefix is byte-identical across turns; only the tail varies", async () => {
     providerStub = makeProvider(toolUseResponse({ ids: [1] }));
     await selectPool(makePool(), makeTurn("first question"));

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-integration.test.ts
@@ -237,7 +237,7 @@ function candidateSlugs(messages: Message[]): Slug[] {
       );
       if (finder) {
         for (const line of finder[1].split("\n")) {
-          const m = /^\[(\d+)\] (\S+)(?: — |$)/.exec(line);
+          const m = /^\[(\d+)\] (?:\([^)]*\) )?(\S+)(?: — |$)/.exec(line);
           if (m) entries.push({ id: Number(m[1]), slug: m[2]! });
         }
       }

--- a/assistant/src/plugins/defaults/memory-v3-shadow/card.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/card.ts
@@ -73,21 +73,32 @@ function renderTocLine(
 }
 
 /**
- * Render a page's compact card: header marker, head section (uncapped — the
- * corpus's rare long leads inject whole; a length cap is a deliberate
- * non-feature), and one-line TOC.
+ * Render a page's compact card: header marker, optional annotation line, head
+ * section (uncapped — the corpus's rare long leads inject whole; a length cap
+ * is a deliberate non-feature), and one-line TOC.
  *
  * ```
  * # memory/concepts/<slug>.md
+ * [lane: fresh · updated 2026-06-10 14:23]
  * <head section verbatim>
  *
  * [sections: §… · §…]
  * ```
  *
+ * The annotation renders directly under the header: selector-visible metadata
+ * must sit on the always-rendered card surface (section-grain rendering can
+ * hide anything that lives only inside page content). Annotations must derive
+ * only from lane-init state (lane membership, page mtime) so the card stays
+ * byte-identical across turns between lane recomputes.
+ *
  * The TOC line is omitted when the page has no `## ` sections and no usable
- * `links:`. Deterministic for a given (slug, rawPageText).
+ * `links:`. Deterministic for a given (slug, rawPageText, annotation).
  */
-export function renderCard(slug: Slug, rawPageText: string): string {
+export function renderCard(
+  slug: Slug,
+  rawPageText: string,
+  annotation?: string,
+): string {
   const parsed = parseFrontmatterFields(rawPageText);
   // `parseFrontmatterFields` returns null both for "no frontmatter block" and
   // "block present but YAML failed to parse" — strip the block either way so a
@@ -101,6 +112,9 @@ export function renderCard(slug: Slug, rawPageText: string): string {
   const head = (firstHeading ? body.slice(0, firstHeading.index) : body).trim();
 
   let card = injectedConceptHeader(slug);
+  if (annotation !== undefined && annotation.length > 0) {
+    card += `\n${annotation}`;
+  }
   if (head.length > 0) card += `\n${head}`;
 
   const toc = renderTocLine(body, fields);

--- a/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
@@ -357,6 +357,7 @@ export async function orchestrate(
   });
   const finderTail: PoolCandidate[] = finder.map((c) => ({
     slug: c.slug,
+    lane: c.lane,
     descriptor:
       c.descriptor.trim().length > 0
         ? c.descriptor

--- a/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
@@ -62,10 +62,12 @@ const log = getLogger("memory-v3-pool-select");
 
 /** A dynamic-tail (finder) candidate: the slug plus the descriptor that
  *  justifies it — a matched section for a needle/dense hit, or a curated link
- *  description for an edge page. Rendered as a one-line snippet. */
+ *  description for an edge page. Rendered as a one-line snippet, prefixed
+ *  with the surfacing lane when one is supplied. */
 export interface PoolCandidate {
   slug: Slug;
   descriptor: string;
+  lane?: string;
 }
 
 /** A stable-prefix candidate: the slug plus its pre-rendered FULL card
@@ -127,13 +129,13 @@ const SELECT_PAGES_TOOL: ToolDefinition = {
   },
 };
 
-const SYSTEM_PROMPT = `You are given the candidate memory pages for an assistant's next reply, in two segments that share one numbering: full page cards first (the curated core and recently-recurring pages, shown every turn), then this turn's search hits as one-line snippets.
+const SYSTEM_PROMPT = `You are given the candidate memory pages for an assistant's next reply, in two segments that share one numbering: full page cards first (the curated core, recently-recurring, and recently-modified pages, shown every turn), then this turn's search hits as one-line snippets. Cards carry a \`[lane: …]\` annotation — core is curated, hot recurs by selection frequency, fresh was recently modified (with its last-update time) — and search hits are tagged with the lane that surfaced them.
 
-Select EVERY candidate whose content the upcoming reply would draw on. That includes facts the reply needs, but equally register, established framing, calibration rules, and relationship/person/project texture — pages that shape HOW to reply, not only what to say. There is no limit on how many you may select; recall matters more than precision, so when a candidate could plausibly inform the reply, keep it. For a list or an "all of X" request, keep EVERY candidate that belongs to X rather than guessing a representative subset.
+Select EVERY candidate whose content the upcoming reply would draw on. That includes facts the reply needs, current task and event state (open items, deadlines, schedules, recent activity), and equally register, established framing, calibration rules, and relationship/person/project texture — pages that shape HOW to reply, not only what to say. There is no limit on how many you may select; recall matters more than precision, so when a candidate could plausibly inform the reply, keep it. For a list or an "all of X" request, keep EVERY candidate that belongs to X rather than guessing a representative subset.
 
 Pages you select persist in the conversation automatically, and re-selecting a page that is already in context is harmless (duplicates are removed downstream) — so never withhold a candidate because it might have been selected before. Judge each candidate only by whether the upcoming reply would draw on it.
 
-A page can be relevant because of the current situation — the date or the live scratchpad — not only the message: keep a page the situation makes pertinent (e.g. a person whose anniversary is today).
+A page can be relevant because of the current situation — the date or the live scratchpad — not only the message: keep a page the situation makes pertinent (e.g. a person whose anniversary is today). When the message asks about status, plans, schedule, or what's pending, treat pages carrying current task/event state — especially recently-updated (fresh) ones — as first-class candidates.
 
 If the conversation is centrally ABOUT a page (rather than only peripherally relevant to it), mark that page as pinned. Call \`select_pages\` with the chosen IDs. Omit \`ids\` only as a recall-safe fallback when you cannot judge the pool (keeps every candidate); return \`[]\` when candidates are present but none are relevant.`;
 
@@ -153,17 +155,19 @@ function renderCardSegment(stable: StableCandidate[]): string {
 }
 
 /**
- * Render the finder tail: one `[m+i] slug — snippet` line per candidate,
- * numbered continuing after the `offset` stable-prefix cards. A candidate
- * with an empty descriptor renders without the dash.
+ * Render the finder tail: one `[m+i] (lane) slug — snippet` line per
+ * candidate, numbered continuing after the `offset` stable-prefix cards. The
+ * lane tag is omitted for a candidate without one; a candidate with an empty
+ * descriptor renders without the dash.
  */
 function renderFinderSegment(finder: PoolCandidate[], offset: number): string {
   const lines = finder.map((c, i) => {
     const snippet = renderSnippet(c.descriptor);
     const id = offset + i + 1;
+    const lane = c.lane !== undefined ? `(${c.lane}) ` : "";
     return snippet.length > 0
-      ? `[${id}] ${c.slug} — ${snippet}`
-      : `[${id}] ${c.slug}`;
+      ? `[${id}] ${lane}${c.slug} — ${snippet}`
+      : `[${id}] ${lane}${c.slug}`;
   });
   return `<candidates>\n${lines.join("\n")}\n</candidates>`;
 }

--- a/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
@@ -221,13 +221,41 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
   // the recompute point) instead of being re-read per turn. Capability slugs
   // render their capability content; disk pages render raw (frontmatter +
   // body) so `kind: index` pages surface their `links:` map in the card TOC.
+  // Each card carries its lane annotation; fresh cards additionally carry the
+  // page's last-modified time (an absolute stamp — it only changes when the
+  // page does, so the card stays byte-stable between lane recomputes).
+  const modifiedAtBySlug = new Map(
+    pageIndex.entries.map((entry) => [entry.slug, entry.modifiedAt]),
+  );
+  const laneAnnotation = (slug: Slug, lane: "core" | "hot" | "fresh") => {
+    if (lane !== "fresh") return `[lane: ${lane}]`;
+    const modifiedAt = modifiedAtBySlug.get(slug);
+    if (
+      modifiedAt === undefined ||
+      !Number.isFinite(modifiedAt) ||
+      modifiedAt <= 0
+    ) {
+      return "[lane: fresh]";
+    }
+    const stamp = new Date(modifiedAt)
+      .toISOString()
+      .slice(0, 16)
+      .replace("T", " ");
+    return `[lane: fresh · updated ${stamp} UTC]`;
+  };
   const prefixCards = new Map<Slug, string>();
-  for (const slug of [...coreSlugs, ...hotSlugs, ...freshSlugs]) {
-    const raw = await capabilityOrDiskBody(
-      slug,
-      async (s) => (await loadPage(s))?.raw ?? "",
-    );
-    prefixCards.set(slug, renderCard(slug, raw));
+  for (const [lane, slugs] of [
+    ["core", coreSlugs],
+    ["hot", hotSlugs],
+    ["fresh", freshSlugs],
+  ] as const) {
+    for (const slug of slugs) {
+      const raw = await capabilityOrDiskBody(
+        slug,
+        async (s) => (await loadPage(s))?.raw ?? "",
+      );
+      prefixCards.set(slug, renderCard(slug, raw, laneAnnotation(slug, lane)));
+    }
   }
 
   const edgeGraph = await buildEdgeGraph(pageIndex.entries, pageRaw, {


### PR DESCRIPTION
## Summary
- Annotate memory-v3 stable-prefix cards with their lane (`[lane: core]` / `[lane: hot]` / `[lane: fresh · updated <UTC stamp>]`) on the always-rendered card surface, and tag finder-tail lines with their surfacing lane.
- Extend the pool-selector system prompt: current task/event state (open items, deadlines, schedules, recent activity) is a named selection category, and status/plans/schedule asks treat state-carrying and recently-modified pages as first-class.
- Annotations derive only from lane-init state (lane membership, page mtime), so the stable prefix stays byte-identical between lane recomputes — the KV-cache contract is unchanged. Sibling integration-test pool parsers updated for the optional lane tag.

## Original prompt
An injection-loss autopsy found the v3 selector systematically passing over operational pages on state-enumeration turns ("what's on my plate"-style briefings) even though they were in the pool — across nine runs the misses never varied with temperature. A controlled mock experiment showed selector-visible state annotations on the card surface flip those picks from ~2/10 to ~9/10, and a 3-run/30-turn eval of exactly this bundle (lane tags + fresh-date stamps + task-state prompt category) raised working-set gold coverage with zero per-turn regressions. The maintainer approved shipping the bundle.