### PR TITLE
fix(memory-v3): allow lane tag in orchestrate finder-line test assertion

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
@@ -587,9 +587,9 @@ describe("orchestrate — cache-ordered pool (core + hot + finders)", () => {
     expect(lastPool.filter((s) => s === "topic-a")).toHaveLength(2);
     expect(lastPool[0]).toBe("topic-a");
     // The finder line shows the matched-section snippet.
-    expect(lastPoolLines.find((l) => /^\[2\] topic-a — /.test(l))).toContain(
-      "apple",
-    );
+    expect(
+      lastPoolLines.find((l) => /^\[2\] (?:\([^)]*\) )?topic-a — /.test(l)),
+    ).toContain("apple");
     // Selecting both ids still yields ONE selection (slug dedup), the finder
     // lane records the hit, and the matched section survives downstream.
     expect(result.selections).toEqual([{ slug: "topic-a", pinned: false }]);


### PR DESCRIPTION
## Summary
- Fixes the `orchestrate.test.ts` failure on main ([CI Main Assistant Checks run](https://github.com/vellum-ai/vellum-assistant/actions/runs/27397421163/job/80967576322)): the lane-annotated selector candidates change made finder lines render as `[id] (lane) slug — snippet`, but the test "a finder hit on a core page repeats as a finder line and dedupes on selection" still anchored on `^\[2\] topic-a — ` with no lane tag, so `.find()` returned `undefined` and `toContain` threw.
- Allows an optional lane group with the same `(?:\([^)]*\) )?` idiom the test's own `parsePool` uses, keeping the assertion pinned to pool id + slug + snippet without coupling it to lane semantics (covered by the lane-provenance tests).

## Original prompt
Fix the specific CI issue in this failing job only: https://github.com/vellum-ai/vellum-assistant/actions/runs/27397421163/job/80967576322