### PR TITLE
fix(workflows): resume trust escalation + prune interrupted runs

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -216,6 +216,7 @@ import {
   migrateVoiceInviteColumns,
   migrateVoiceInviteDisplayMetadata,
   migrateWorkflowRuns,
+  migrateWorkflowRunTrust,
   recoverCrashedMigrations,
   runComplexMigrations,
   runLateMigrations,
@@ -502,6 +503,7 @@ export function initializeDb(): void {
     migrateConversationsSurfacedAt,
     migrateWorkflowRuns,
     migrateScheduleWorkflowMode,
+    migrateWorkflowRunTrust,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/283-workflow-run-trust.ts
+++ b/assistant/src/memory/migrations/283-workflow-run-trust.ts
@@ -1,0 +1,27 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Add a `trust_json` column to `workflow_runs`.
+ *
+ * Persists the originating {@link TrustContext} (trust metadata — NOT secret
+ * material) so a crash-orphaned run can reconstruct the exact trust class it
+ * started under when it is resumed after a restart. Without this, resume could
+ * only fall back to a default, and the previous fallback was the internal
+ * guardian context — a privilege escalation, since a run started by a low-trust
+ * actor would resume with the side-effect approval gate cleared.
+ *
+ * Nullable — legacy rows written before this column stay NULL and resume at the
+ * low-trust fallback (never guardian).
+ *
+ * Idempotent — the ALTER is wrapped so a re-run (column already present) is a
+ * no-op.
+ */
+export function migrateWorkflowRunTrust(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+  try {
+    raw.exec(`ALTER TABLE workflow_runs ADD COLUMN trust_json TEXT`);
+  } catch {
+    /* Column already exists */
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -274,6 +274,7 @@ export { createSkillLoadedEventsTable } from "./279-create-skill-loaded-events.j
 export { migrateConversationsSurfacedAt } from "./280-conversations-surfaced-at.js";
 export { migrateWorkflowRuns } from "./281-workflow-runs.js";
 export { migrateScheduleWorkflowMode } from "./282-schedule-workflow-mode.js";
+export { migrateWorkflowRunTrust } from "./283-workflow-run-trust.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/runtime/routes/workflow-routes.test.ts
+++ b/assistant/src/runtime/routes/workflow-routes.test.ts
@@ -35,6 +35,7 @@ function makeRun(overrides: Partial<WorkflowRun> = {}): WorkflowRun {
     capabilities: null,
     status: "running",
     conversationId: null,
+    trust: null,
     agentsSpawned: 2,
     inputTokens: 10,
     outputTokens: 5,

--- a/assistant/src/workflows/journal-store.test.ts
+++ b/assistant/src/workflows/journal-store.test.ts
@@ -60,6 +60,7 @@ describe("workflow journal store", () => {
       args: { topic: "ai" },
       capabilities: ["search", "email"],
       conversationId: "conv-xyz",
+      trust: { sourceChannel: "slack", trustClass: "unknown" },
     });
 
     expect(run).toMatchObject({
@@ -71,6 +72,7 @@ describe("workflow journal store", () => {
       capabilities: ["search", "email"],
       status: "running",
       conversationId: "conv-xyz",
+      trust: { sourceChannel: "slack", trustClass: "unknown" },
       agentsSpawned: 0,
       inputTokens: 0,
       outputTokens: 0,
@@ -95,6 +97,7 @@ describe("workflow journal store", () => {
       args: null,
       capabilities: null,
       conversationId: null,
+      trust: null,
     });
   });
 
@@ -314,5 +317,53 @@ describe("workflow journal store", () => {
     expect(getJournal("old-done")).toHaveLength(0);
     expect(getRun("old-running")).not.toBeNull();
     expect(getRun("recent-done")).not.toBeNull();
+  });
+
+  test("pruneRuns never reaps a resumable 'interrupted' run, even past retention", () => {
+    const now = Date.now();
+
+    // Old interrupted run (crash-orphaned, awaiting resume) with a journal —
+    // pruning it would destroy resumability, so it MUST be kept.
+    createRun({ id: "old-interrupted", scriptSource: "s", scriptHash: "h" });
+    updateRun("old-interrupted", { status: "interrupted" });
+    appendJournalEntry({
+      runId: "old-interrupted",
+      seq: 0,
+      callHash: "c",
+      kind: "agent",
+      status: "completed",
+    });
+    getSqlite().exec(
+      `UPDATE workflow_runs SET created_at = ${now - 100 * DAY_MS} WHERE id = 'old-interrupted'`,
+    );
+
+    const deleted = pruneRuns(7);
+    expect(deleted).toBe(0);
+    expect(getRun("old-interrupted")).not.toBeNull();
+    // Its journal survives too, so resume can still replay.
+    expect(getJournal("old-interrupted")).toHaveLength(1);
+  });
+
+  test("pruneRuns reaps every TERMINAL status past retention", () => {
+    const now = Date.now();
+    const terminal = [
+      "completed",
+      "failed",
+      "aborted",
+      "cap_exceeded",
+    ] as const;
+    for (const status of terminal) {
+      createRun({ id: `old-${status}`, scriptSource: "s", scriptHash: "h" });
+      finishRun(`old-${status}`, { status });
+      getSqlite().exec(
+        `UPDATE workflow_runs SET created_at = ${now - 10 * DAY_MS} WHERE id = 'old-${status}'`,
+      );
+    }
+
+    const deleted = pruneRuns(7);
+    expect(deleted).toBe(terminal.length);
+    for (const status of terminal) {
+      expect(getRun(`old-${status}`)).toBeNull();
+    }
   });
 });

--- a/assistant/src/workflows/journal-store.ts
+++ b/assistant/src/workflows/journal-store.ts
@@ -41,6 +41,12 @@ export interface WorkflowRun {
   capabilities: unknown;
   status: WorkflowRunStatus;
   conversationId: string | null;
+  /**
+   * Originating trust context (parsed), or null for legacy rows written before
+   * the column existed. Reconstructed on resume so a run never resumes with more
+   * trust than it started under — see {@link CreateRunInput.trust}.
+   */
+  trust: unknown;
   agentsSpawned: number;
   inputTokens: number;
   outputTokens: number;
@@ -72,6 +78,13 @@ export interface CreateRunInput {
   capabilities?: unknown;
   status?: WorkflowRunStatus;
   conversationId?: string | null;
+  /**
+   * Originating trust context (trust metadata — `{ sourceChannel, trustClass,
+   * ... }`, no secret material), serialized so a crash-orphaned run can
+   * reconstruct the exact trust class it started under when resumed. Omit on
+   * legacy callers; resume then falls back to low trust, never guardian.
+   */
+  trust?: unknown;
 }
 
 export interface UpdateRunInput {
@@ -111,6 +124,7 @@ interface WorkflowRunRow {
   capabilities_json: string | null;
   status: string;
   conversation_id: string | null;
+  trust_json: string | null;
   agents_spawned: number;
   input_tokens: number;
   output_tokens: number;
@@ -157,6 +171,7 @@ function rowToRun(row: WorkflowRunRow): WorkflowRun {
     capabilities: parseJsonColumn(row.capabilities_json),
     status: row.status as WorkflowRunStatus,
     conversationId: row.conversation_id,
+    trust: parseJsonColumn(row.trust_json),
     agentsSpawned: row.agents_spawned,
     inputTokens: row.input_tokens,
     outputTokens: row.output_tokens,
@@ -193,9 +208,9 @@ export function createRun(input: CreateRunInput): WorkflowRun {
     /*sql*/ `
     INSERT INTO workflow_runs (
       id, name, script_source, script_hash, args_json, capabilities_json,
-      status, conversation_id, agents_spawned, input_tokens, output_tokens,
-      result_json, error, created_at, updated_at, finished_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 0, NULL, NULL, ?, ?, NULL)
+      status, conversation_id, trust_json, agents_spawned, input_tokens,
+      output_tokens, result_json, error, created_at, updated_at, finished_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 0, NULL, NULL, ?, ?, NULL)
     `,
     input.id,
     input.name ?? null,
@@ -205,6 +220,7 @@ export function createRun(input: CreateRunInput): WorkflowRun {
     serializeJsonColumn(input.capabilities),
     status,
     input.conversationId ?? null,
+    serializeJsonColumn(input.trust),
     now,
     now,
   );
@@ -404,10 +420,29 @@ export function markRunningAsInterrupted(): number {
 // ---------------------------------------------------------------------------
 
 /**
- * Delete finished runs older than `retentionDays` (by `created_at`) and their
- * journal entries. Running (un-finished) runs are never pruned, regardless of
- * age, so an in-flight long run can't be reaped out from under the engine.
- * Returns the number of runs deleted.
+ * Set of genuinely TERMINAL run statuses — the only rows `pruneRuns` may reap.
+ * A run is non-terminal (and therefore retained regardless of age) when it is
+ * still `running` OR `interrupted`: an `interrupted` run is a crash-orphaned
+ * row awaiting an explicit resume, so pruning it would destroy resumability.
+ */
+const TERMINAL_RUN_STATUSES: readonly WorkflowRunStatus[] = [
+  "completed",
+  "failed",
+  "aborted",
+  "cap_exceeded",
+];
+
+/** SQL list literal of the terminal statuses, e.g. `'completed','failed',...`. */
+const TERMINAL_RUN_STATUS_SQL = TERMINAL_RUN_STATUSES.map((s) => `'${s}'`).join(
+  ", ",
+);
+
+/**
+ * Delete TERMINAL runs older than `retentionDays` (by `created_at`) and their
+ * journal entries. Non-terminal runs are never pruned, regardless of age:
+ * `running` rows could be reaped out from under the engine, and `interrupted`
+ * rows are crash-orphaned and still resumable — deleting either would destroy
+ * an in-flight or resumable run. Returns the number of runs deleted.
  */
 export function pruneRuns(retentionDays: number): number {
   const cutoff = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
@@ -416,7 +451,8 @@ export function pruneRuns(retentionDays: number): number {
     DELETE FROM workflow_journal
     WHERE run_id IN (
       SELECT id FROM workflow_runs
-      WHERE status != 'running' AND created_at IS NOT NULL AND created_at < ?
+      WHERE status IN (${TERMINAL_RUN_STATUS_SQL})
+        AND created_at IS NOT NULL AND created_at < ?
     )
     `,
     cutoff,
@@ -424,7 +460,8 @@ export function pruneRuns(retentionDays: number): number {
   return rawRun(
     /*sql*/ `
     DELETE FROM workflow_runs
-    WHERE status != 'running' AND created_at IS NOT NULL AND created_at < ?
+    WHERE status IN (${TERMINAL_RUN_STATUS_SQL})
+      AND created_at IS NOT NULL AND created_at < ?
     `,
     cutoff,
   );

--- a/assistant/src/workflows/run-manager.test.ts
+++ b/assistant/src/workflows/run-manager.test.ts
@@ -67,6 +67,7 @@ function makeFakeJournal() {
           capabilities: input.capabilities ?? null,
           status: input.status ?? "running",
           conversationId: input.conversationId ?? null,
+          trust: input.trust ?? null,
           agentsSpawned: 0,
           inputTokens: 0,
           outputTokens: 0,
@@ -149,8 +150,6 @@ function makeHarness(opts?: {
   engine?: WorkflowRunManagerDeps["executeWorkflow"];
   /** Saved-workflow resolver for the `start({ name })` path. */
   getWorkflow?: WorkflowRunManagerDeps["getWorkflow"];
-  /** Live-conversation lookup for the `resume` trust reconstruction path. */
-  findConversation?: WorkflowRunManagerDeps["findConversation"];
 }): ManagerHarness {
   const fake = makeFakeJournal();
   const executeCalls: ExecuteWorkflowOptions[] = [];
@@ -208,9 +207,6 @@ function makeHarness(opts?: {
       return () => `run-${++n}`;
     })(),
     ...(opts?.getWorkflow ? { getWorkflow: opts.getWorkflow } : {}),
-    findConversation:
-      opts?.findConversation ??
-      ((() => undefined) as WorkflowRunManagerDeps["findConversation"]),
   };
 
   const manager = new WorkflowRunManager(deps);
@@ -490,6 +486,7 @@ function seedRun(
     capabilities: { tools: [], hostFunctions: [], persona: false },
     status: "interrupted",
     conversationId: null,
+    trust: null,
     agentsSpawned: 3,
     inputTokens: 100,
     outputTokens: 50,
@@ -561,13 +558,84 @@ describe("WorkflowRunManager.resume", () => {
     expect(h.manager.inflightCount()).toBe(0);
   });
 
-  test("resume falls back to the internal guardian trust context when no conversation", () => {
+  test("resume replays the SAME (non-guardian) trust the run started under — never escalates", () => {
     const h = makeHarness({});
-    seedRun(h, { id: "run-x", status: "interrupted", conversationId: null });
+    // A run started by a low-trust actor: persisted trust is NOT guardian.
+    const lowTrust: TrustContext = {
+      sourceChannel: "slack",
+      trustClass: "unknown",
+      requesterIdentifier: "@someone",
+    };
+    seedRun(h, {
+      id: "run-x",
+      status: "interrupted",
+      conversationId: null,
+      trust: lowTrust,
+    });
 
     h.manager.resume("run-x");
 
-    expect(h.executeCalls[0]!.trustContext.trustClass).toBe("guardian");
+    const replayed = h.executeCalls[0]!.trustContext;
+    // SECURITY: resume must reconstruct the exact trust the run started under,
+    // never elevate to guardian (which would clear the side-effect gate).
+    expect(replayed.trustClass).toBe("unknown");
+    expect(replayed.trustClass).not.toBe("guardian");
+    expect(replayed.sourceChannel).toBe("slack");
+  });
+
+  test("resume of a trusted_contact run keeps trusted_contact (no escalation)", () => {
+    const h = makeHarness({});
+    seedRun(h, {
+      id: "run-tc",
+      status: "interrupted",
+      trust: { sourceChannel: "slack", trustClass: "trusted_contact" },
+    });
+
+    h.manager.resume("run-tc");
+
+    expect(h.executeCalls[0]!.trustContext.trustClass).toBe("trusted_contact");
+  });
+
+  test("SECURITY: a legacy run row with no persisted trust resumes at LOW trust, never guardian", () => {
+    const h = makeHarness({});
+    // Legacy row: written before the trust_json column existed → trust is null.
+    seedRun(h, { id: "run-legacy", status: "interrupted", trust: null });
+
+    h.manager.resume("run-legacy");
+
+    const replayed = h.executeCalls[0]!.trustContext;
+    expect(replayed.trustClass).toBe("unknown");
+    expect(replayed.trustClass).not.toBe("guardian");
+  });
+
+  test("a persisted trust with an unrecognized trustClass falls back to LOW trust", () => {
+    const h = makeHarness({});
+    seedRun(h, {
+      id: "run-bad",
+      status: "interrupted",
+      // Corrupt/forward-incompatible snapshot: not a known trust class.
+      trust: { sourceChannel: "slack", trustClass: "superuser" },
+    });
+
+    h.manager.resume("run-bad");
+
+    expect(h.executeCalls[0]!.trustContext.trustClass).toBe("unknown");
+  });
+
+  test("start persists the originating trust context on the run row", () => {
+    const h = makeHarness({});
+    const startTrust: TrustContext = {
+      sourceChannel: "slack",
+      trustClass: "unknown",
+    };
+    const { runId } = h.manager.start({
+      scriptSource: "export const meta = { name: 'x', description: 'y' }",
+      args: {},
+      manifest: { tools: [], hostFunctions: [], persona: false },
+      trustContext: startTrust,
+    });
+
+    expect(h.fake.rows.get(runId)?.trust).toEqual(startTrust);
   });
 
   test("a non-interrupted run throws WorkflowResumeNotPossibleError and does not invoke the engine", () => {

--- a/assistant/src/workflows/run-manager.ts
+++ b/assistant/src/workflows/run-manager.ts
@@ -31,9 +31,8 @@ import { createHash, randomUUID } from "node:crypto";
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
 import type { AssistantConfig } from "../config/schema.js";
-import { findConversation } from "../daemon/conversation-registry.js";
 import {
-  INTERNAL_GUARDIAN_TRUST_CONTEXT,
+  FALLBACK_TURN_TRUST,
   type TrustContext,
 } from "../daemon/trust-context.js";
 import { wakeAgentForOpportunity } from "../runtime/agent-wake.js";
@@ -145,8 +144,6 @@ export interface WorkflowRunManagerDeps {
   newRunId: () => string;
   /** Resolve a saved workflow's source by name (for `start({ name })`). */
   getWorkflow: typeof library.getWorkflow;
-  /** Look up a live conversation (for `resume` trust reconstruction). */
-  findConversation: typeof findConversation;
 }
 
 function defaultDeps(): WorkflowRunManagerDeps {
@@ -161,7 +158,6 @@ function defaultDeps(): WorkflowRunManagerDeps {
     broadcast: broadcastMessage,
     newRunId: () => randomUUID(),
     getWorkflow: library.getWorkflow,
-    findConversation,
   };
 }
 
@@ -216,7 +212,10 @@ export class WorkflowRunManager {
     // re-open of the existing row is a true no-op rather than a divergent
     // overwrite. We persist the MANIFEST (a plain serializable grant), not the
     // resolved capabilities (which carry live Tool objects that don't survive a
-    // round-trip), so a later `resume` can re-resolve it deterministically.
+    // round-trip), so a later `resume` can re-resolve it deterministically. We
+    // also persist the originating TRUST CONTEXT (trust metadata, no secret
+    // material) so a crash-orphaned `resume` reconstructs the exact trust class
+    // the run started under — NEVER escalating to guardian on resume.
     this.deps.journal.createRun({
       id: runId,
       name: meta.name,
@@ -226,6 +225,7 @@ export class WorkflowRunManager {
       capabilities: opts.manifest,
       status: "running",
       conversationId: opts.conversationId ?? null,
+      trust: opts.trustContext,
     });
 
     const controller = new AbortController();
@@ -266,11 +266,13 @@ export class WorkflowRunManager {
    * Resume an `interrupted` run with the SAME `runId`, re-invoking the engine so
    * it replays the journaled prefix and continues from the first changed/new
    * leaf. Reconstructs the run's inputs from the persisted row (script source,
-   * args, capability manifest, conversation) and re-derives the trust context
-   * from the originating conversation (falling back to the internal guardian
-   * context). Enforces the `workflows` flag and the concurrent-run cap (a resume
-   * occupies a run slot). Returns the `runId` immediately — completion is
-   * surfaced via events and a conversation wake exactly like {@link start}.
+   * args, capability manifest, conversation) and the trust context from the
+   * persisted `trust` snapshot — so a resumed run NEVER runs with more trust
+   * than it started under. Legacy rows with no persisted trust fall back to the
+   * low-trust {@link FALLBACK_TURN_TRUST} (never guardian). Enforces the
+   * `workflows` flag and the concurrent-run cap (a resume occupies a run slot).
+   * Returns the `runId` immediately — completion is surfaced via events and a
+   * conversation wake exactly like {@link start}.
    *
    * Throws {@link WorkflowResumeNotPossibleError} when the run is missing, not
    * `interrupted`, or already in flight.
@@ -313,7 +315,7 @@ export class WorkflowRunManager {
       manifestFromStored(run.capabilities),
     );
     const label = run.name ?? runId;
-    const trustContext = this.resolveResumeTrustContext(run.conversationId);
+    const trustContext = reconstructResumeTrustContext(run.trust);
 
     // Flip back to `running` before launching so `status`/`list` reflect the
     // in-flight resume; the engine re-opens the same row idempotently.
@@ -336,25 +338,6 @@ export class WorkflowRunManager {
     );
 
     return { runId };
-  }
-
-  /**
-   * Reconstruct the trust context for a resumed run: prefer the originating
-   * conversation's resolved/per-turn trust (the context it ran under), falling
-   * back to the internal guardian context when the conversation is gone (it was
-   * a self-maintenance/background run, or the conversation evicted on restart).
-   */
-  private resolveResumeTrustContext(
-    conversationId: string | null,
-  ): TrustContext {
-    const conversation = this.deps.findConversation(
-      conversationId ?? undefined,
-    );
-    return (
-      conversation?.currentTurnTrustContext ??
-      conversation?.trustContext ??
-      INTERNAL_GUARDIAN_TRUST_CONTEXT
-    );
   }
 
   /**
@@ -503,6 +486,37 @@ interface RunContext {
   args: unknown;
   conversationId: string | undefined;
   trustContext: TrustContext;
+}
+
+/** The trust classes a persisted trust snapshot may legitimately carry. */
+const VALID_TRUST_CLASSES: ReadonlySet<TrustContext["trustClass"]> = new Set([
+  "guardian",
+  "trusted_contact",
+  "unknown",
+]);
+
+/**
+ * Reconstruct the {@link TrustContext} for a resumed run from its persisted
+ * `trust` snapshot. This is the security boundary on resume: a run must NEVER
+ * resume with more trust than it started under. When the snapshot is absent
+ * (legacy rows written before the `trust_json` column existed) or unusable
+ * (unparseable JSON, or a missing/unrecognized `trustClass`), we fall back to
+ * the low-trust {@link FALLBACK_TURN_TRUST} — biased to `unknown` — matching the
+ * start path's no-elevation discipline. We deliberately do NOT fall back to the
+ * internal guardian context, which would clear the side-effect approval gate.
+ */
+function reconstructResumeTrustContext(persisted: unknown): TrustContext {
+  if (persisted && typeof persisted === "object") {
+    const candidate = persisted as Partial<TrustContext>;
+    if (
+      typeof candidate.trustClass === "string" &&
+      VALID_TRUST_CLASSES.has(candidate.trustClass)
+    ) {
+      // The snapshot is a well-formed trust context — replay it verbatim.
+      return candidate as TrustContext;
+    }
+  }
+  return FALLBACK_TURN_TRUST;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Persist the originating trust on the run row and reconstruct it on resume (low-trust fallback, never guardian) — fixes a privilege escalation where a resumed orphaned run gained guardian trust.
- pruneRuns now only reaps terminal runs, never resumable 'interrupted' (or 'running') rows.

Part of plan: workflow-engine.md (security + correctness fixes surfaced during re-review)