### PR TITLE
feat(assistant): card-surface `current:` page state for memory-v3 selection

### DIFF
--- a/assistant/src/memory/v2/prompts/consolidation.ts
+++ b/assistant/src/memory/v2/prompts/consolidation.ts
@@ -571,6 +571,7 @@ Bullets where a list is genuinely a list.
 - **\`links\`** are directed see-also references, each annotated: \`"target-slug — why"\`. The annotation is for future-you deciding whether to follow it. Directed means listing B here pulls B toward A's readers — it does not link back.
 - **\`tags\`** are flat labels for the cluster(s) this touches. Index pages also carry \`kind: index\`.
 - **No \`summary:\` field.** The lead is the summary. Writing a good lead IS writing the retrieval surface.
+- **\`current:\`** — optional ONE-LINE live state of the page's subject: open items, deadlines, what's owed or pending, with an as-of date in the text (\`current: "bridge check owed before thursday's dry-run (as of jun 10)"\`). Retrieval renders it on the card, so status-shaped questions ("what's on my plate", "what's pending") can find the page. Maintain it like state, not prose: update it when the state moves, DELETE the field the moment nothing is live — a stale \`current:\` is worse than none. Most pages never carry one. \`threads.md\` remains the cross-page commitments list; \`current:\` is per-page state, not a second threads file.
 
 ## The card budget (the economic principle)
 

--- a/assistant/src/memory/v2/types.ts
+++ b/assistant/src/memory/v2/types.ts
@@ -62,6 +62,11 @@ export const ConceptPageFrontmatterSchema = z
     main: z.string().optional(),
     kind: z.string().optional(),
     status: z.string().optional(),
+    // One-line live state of the page's subject (open items, deadlines,
+    // what's pending), as-of dated by convention. Memory-v3 renders it on the
+    // card surface so state-shaped questions can select the page. Distinct
+    // from `status:` (the article-model draft marker, e.g. "cc-draft").
+    current: z.string().optional(),
   })
   .strict();
 

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/card.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/card.test.ts
@@ -45,6 +45,40 @@ describe("renderCard — annotation line", () => {
     ).toBe(true);
   });
 
+  test("renders a `current:` frontmatter line first, before the lane annotation", () => {
+    const page = `---
+title: Page A
+current: "bridge check owed before thursday's dry-run (as of jun 10)"
+---
+
+Lead paragraph for page a.
+`;
+    const card = renderCard("page-a", page, "[lane: fresh]");
+    expect(
+      card.startsWith(
+        "# memory/concepts/page-a.md\n[current: bridge check owed before thursday's dry-run (as of jun 10)]\n[lane: fresh]\nLead paragraph for page a.",
+      ),
+    ).toBe(true);
+  });
+
+  test("collapses whitespace and caps a runaway `current:` value", () => {
+    const long = `a  line  with   breaks ${"x".repeat(400)}`;
+    const card = renderCard(
+      "page-a",
+      `---\ncurrent: "${long}"\n---\n\nLead.\n`,
+    );
+    const line = card.split("\n")[1]!;
+    expect(line.startsWith("[current: a line with breaks x")).toBe(true);
+    expect(line.endsWith("…]")).toBe(true);
+    expect(line.length).toBeLessThan(300);
+  });
+
+  test("the `status:` draft marker does NOT render as a card line", () => {
+    const card = renderCard("page-a", `---\nstatus: cc-draft\n---\n\nLead.\n`);
+    expect(card).not.toContain("cc-draft");
+    expect(card).not.toContain("[current:");
+  });
+
   test("annotates a page with no head section without a dangling blank line", () => {
     const card = renderCard(
       "page-b",

--- a/assistant/src/plugins/defaults/memory-v3-shadow/card.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/card.ts
@@ -72,6 +72,28 @@ function renderTocLine(
   return `[sections: ${headings.map((h) => `§${h}`).join(" · ")}]`;
 }
 
+/** Max characters of a `current:` line carried onto the card. A `current:` is
+ * one line by contract; the cap keeps a runaway value from bloating every
+ * render of the card. */
+const CURRENT_MAX_CHARS = 280;
+
+/**
+ * Render a page's `current:` frontmatter (one-line live state) as a card
+ * annotation, or `null` when the page has none. Whitespace-collapsed and
+ * capped at {@link CURRENT_MAX_CHARS}.
+ */
+function renderCurrentLine(fields: Record<string, unknown>): string | null {
+  const current = fields.current;
+  if (typeof current !== "string") return null;
+  const collapsed = current.replace(/\s+/g, " ").trim();
+  if (collapsed.length === 0) return null;
+  const capped =
+    collapsed.length > CURRENT_MAX_CHARS
+      ? `${collapsed.slice(0, CURRENT_MAX_CHARS).trimEnd()}…`
+      : collapsed;
+  return `[current: ${capped}]`;
+}
+
 /**
  * Render a page's compact card: header marker, optional annotation line, head
  * section (uncapped — the corpus's rare long leads inject whole; a length cap
@@ -90,6 +112,12 @@ function renderTocLine(
  * hide anything that lives only inside page content). Annotations must derive
  * only from lane-init state (lane membership, page mtime) so the card stays
  * byte-identical across turns between lane recomputes.
+ *
+ * A page's `current:` frontmatter (one-line live state — open items,
+ * deadlines, what's pending) renders the same way, first: it exists so
+ * state-shaped questions can select the page, which only works if the
+ * selector can see it on every card render. It changes only when the page is
+ * edited (consolidation), so it shares the lane annotation's cache story.
  *
  * The TOC line is omitted when the page has no `## ` sections and no usable
  * `links:`. Deterministic for a given (slug, rawPageText, annotation).
@@ -112,6 +140,8 @@ export function renderCard(
   const head = (firstHeading ? body.slice(0, firstHeading.index) : body).trim();
 
   let card = injectedConceptHeader(slug);
+  const current = renderCurrentLine(fields);
+  if (current !== null) card += `\n${current}`;
   if (annotation !== undefined && annotation.length > 0) {
     card += `\n${annotation}`;
   }


### PR DESCRIPTION
## Summary
- Add an optional `current:` field to the concept-page frontmatter schema (one-line live state of the page's subject — open items, deadlines, pending work — as-of dated by convention; distinct from the `status:` draft marker).
- Render it as a `[current: …]` annotation directly under the card header (whitespace-collapsed, capped), ahead of the lane annotation — on the always-rendered card surface so the selector can see it regardless of which section matched.
- Teach the V3 consolidation prompt the field: write it only while live state exists, update when state moves, delete when stale; `threads.md` remains the cross-page commitments list.

## Original prompt
A retrieval-loss autopsy found memory-v3's selector passing over in-pool operational pages on briefing-style turns because nothing card-visible marks a page as carrying live state. A mock experiment (status lines stamped onto the card surface) flipped selection of those pages from ~2/10 to ~9/10. The maintainer approved landing the engine half now — schema field + card rendering + default-prompt instruction — inert until consolidation begins writing the field.