### PR TITLE
Skip the memory v2 router LLM call when the page index is saturated

### DIFF
--- a/assistant/src/memory/v2/__tests__/injection.test.ts
+++ b/assistant/src/memory/v2/__tests__/injection.test.ts
@@ -1872,6 +1872,76 @@ describe("injectMemoryV2Block", () => {
       expect(aliceRow!.ownActivation).toBe(0);
     });
 
+    test("flag-on: saturated index (every page already injected) skips the router LLM call", async () => {
+      // Turn 1 — normal router path injects alice.
+      routerState.nextResult = {
+        selectedSlugs: ["alice-vscode"],
+        failureReason: null,
+      };
+      await injectMemoryV2Block({
+        database: db,
+        conversationId: "conv-router-saturated",
+        currentTurn: 1,
+        recentTurnPairs: [
+          { assistantMessage: "", userMessage: "Tell me about Alice" },
+        ],
+        nowText: "Now",
+        messageId: "msg-1",
+        config: makeConfig({ router: { enabled: true } }),
+      });
+
+      // Mark every page in the index as already injected — the state a
+      // small workspace reaches a few turns into any conversation.
+      const { getPageIndex } = await import("../page-index.js");
+      const index = await getPageIndex(tmpWorkspace);
+      const seeded = await hydrate(db, "conv-router-saturated");
+      await save(db, "conv-router-saturated", {
+        ...seeded!,
+        everInjected: index.entries.map((e) => ({ slug: e.slug, turn: 1 })),
+      });
+
+      // Turn 2 — the router must not be called: any selection would dedupe
+      // against everInjected and render nothing.
+      const callsBefore = routerState.callCount;
+      routerState.nextResult = {
+        selectedSlugs: ["bob-coffee"],
+        failureReason: null,
+      };
+      const result = await injectMemoryV2Block({
+        database: db,
+        conversationId: "conv-router-saturated",
+        currentTurn: 2,
+        recentTurnPairs: [{ assistantMessage: "ok", userMessage: "and Bob?" }],
+        nowText: "Now",
+        messageId: "msg-2",
+        config: makeConfig({ router: { enabled: true } }),
+      });
+
+      expect(routerState.callCount).toBe(callsBefore);
+      expect(result.block).toBeNull();
+      expect(result.toInject).toEqual([]);
+
+      // State still advanced; everInjected preserved for future dedupe.
+      const persisted = await hydrate(db, "conv-router-saturated");
+      expect(persisted!.currentTurn).toBe(2);
+      expect(persisted!.messageId).toBe("msg-2");
+      expect(persisted!.everInjected.length).toBe(index.entries.length);
+
+      // Telemetry row stays in router mode with every slug carried over.
+      const row = telemetryState.recordCalls.at(-1) as {
+        mode: string;
+        concepts: Array<{ source: string; status: string }>;
+      };
+      expect(row.mode).toBe("router");
+      expect(row.concepts.length).toBe(index.entries.length);
+      for (const concept of row.concepts) {
+        expect(concept.source).toBe("carry_over");
+        // `finalizeInjection` rewrites the placeholder status: slugs already
+        // in everInjected are reported as in_context.
+        expect(concept.status).toBe("in_context");
+      }
+    });
+
     test("flag-on: router failure logs warn, writes mode:`errored` telemetry, returns null block", async () => {
       routerState.nextResult = {
         selectedSlugs: [],

--- a/assistant/src/memory/v2/injection.ts
+++ b/assistant/src/memory/v2/injection.ts
@@ -44,6 +44,7 @@ import {
 } from "./cli-command-store.js";
 import { getEdgeIndex } from "./edge-index.js";
 import { recordInjectionEvents } from "./injection-events.js";
+import { getPageIndex } from "./page-index.js";
 import { readPage, renderPageContent } from "./page-store.js";
 import { type RouterTurnPair, runRouter } from "./router.js";
 import { getSkillCapability, isSkillSlug } from "./skill-store.js";
@@ -552,6 +553,58 @@ async function injectViaRouter(args: {
 
   const priorEverInjected: readonly EverInjectedEntry[] =
     priorState?.everInjected ?? [];
+
+  // Saturated-index bypass: when every page in the index has already been
+  // injected on a prior turn of this conversation, the router LLM call is
+  // provably useless — whatever it selected would be deduped against
+  // `priorEverInjected` below and render nothing. Small workspaces reach
+  // this state within the first few turns, after which the per-message
+  // router call is pure cost. Skip the call and finalize directly with
+  // carry-over telemetry, mirroring the success path's "all selections
+  // already injected" outcome. (Trade-off: re-pick EMA events are not
+  // recorded from this state; with the whole index attached, injection-
+  // score ranking has nothing left to decide for this conversation.)
+  const everInjectedSlugSet = new Set(priorEverInjected.map((e) => e.slug));
+  const pageIndexForBypass = await getPageIndex(workspaceDir);
+  if (
+    pageIndexForBypass.entries.length > 0 &&
+    pageIndexForBypass.entries.every((e) => everInjectedSlugSet.has(e.slug))
+  ) {
+    log.info(
+      {
+        conversationId,
+        indexSize: pageIndexForBypass.entries.length,
+      },
+      "memory v2 router skipped — every index page already injected",
+    );
+    return finalizeInjection({
+      workspaceDir,
+      database,
+      conversationId,
+      mode: "router",
+      currentTurn,
+      messageId,
+      priorEverInjected,
+      slugsToRender: [],
+      telemetryRows: priorEverInjected.map((entry) => ({
+        slug: entry.slug,
+        finalActivation: 0,
+        ownActivation: 0,
+        priorActivation: 0,
+        simUser: 0,
+        simAssistant: 0,
+        simNow: 0,
+        simUserRerankBoost: 0,
+        simAssistantRerankBoost: 0,
+        inRerankPool: false,
+        spreadContribution: 0,
+        source: "carry_over",
+        status: "not_injected",
+      })),
+      config,
+      nextStateMap: {},
+    });
+  }
 
   const routerResult = await runRouter({
     workspaceDir,


### PR DESCRIPTION
## Summary
- `injectViaRouter` now bypasses the router LLM call when every page in the index is already in the conversation's `everInjected` set — any selection would dedupe to nothing, so the call cannot produce work.
- The bypass finalizes through the existing `finalizeInjection` path (mode `router`, all slugs `carry_over`), so activation state still advances and telemetry rows stay consistent with the "router selected only already-injected pages" outcome.
- Regression test covers the saturated path: router not called, state advanced, `everInjected` preserved, carry-over telemetry emitted.

## Original prompt
Cost-reduction follow-up from a cache-hit-ratio audit: memoryRouter made 45,775 LLM calls in 7 days (more than the main agent's 36,850) at ~8.8k tokens per call, firing on every user message. The ask was a "memory router diet"; this PR implements the provably-safe lever — small workspaces saturate their page index a few turns into any conversation, after which every per-message router call is wasted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)