### PR TITLE
Bound memory v2 consolidation runs with a per-run buffer entry cap

### DIFF
--- a/assistant/src/__tests__/memory-v2-static-injector.test.ts
+++ b/assistant/src/__tests__/memory-v2-static-injector.test.ts
@@ -74,6 +74,12 @@ function seedThreads(body: string): void {
   writeFileSync(path, body, "utf-8");
 }
 
+function seedBuffer(body: string): void {
+  const path = getWorkspacePromptPath("memory/buffer.md");
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, body, "utf-8");
+}
+
 function clearV2StaticFiles(): void {
   for (const file of [
     "memory/essentials.md",
@@ -114,6 +120,22 @@ describe("memory-v2-static injector", () => {
     expect(block!.text).toBe(
       "<info>\n## Essentials\n\nAlice prefers VS Code.\n\n## Threads\n\nOpen: ship PR.\n</info>",
     );
+  });
+
+  test("suppresses the Buffer section on memoryV2Consolidation turns", async () => {
+    seedEssentials("Alice prefers VS Code.");
+    seedBuffer("- [Apr 27, 9:00 AM] backlog entry");
+
+    const consolidationBlock = await memoryV2StaticInjector.produce(
+      makeContext({ callSite: "memoryV2Consolidation" }),
+    );
+    expect(consolidationBlock).not.toBeNull();
+    expect(consolidationBlock!.text).toContain("## Essentials");
+    expect(consolidationBlock!.text).not.toContain("## Buffer");
+
+    // Other call sites (and untagged turns) keep the buffer section.
+    const mainBlock = await memoryV2StaticInjector.produce(makeContext());
+    expect(mainBlock!.text).toContain("## Buffer");
   });
 
   test("escapes inner </info> closing tags so the wrapper cannot be broken out of", async () => {

--- a/assistant/src/config/schemas/__tests__/memory-v2.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v2.test.ts
@@ -24,6 +24,7 @@ describe("MemoryV2ConfigSchema", () => {
       bm25_b: 0.4,
       consolidation_interval_hours: 4,
       consolidation_max_buffer_lines: 100,
+      consolidation_max_entries_per_run: 150,
       max_page_chars: 5000,
       consolidation_prompt_path: null,
       rerank: {

--- a/assistant/src/config/schemas/memory-v2.ts
+++ b/assistant/src/config/schemas/memory-v2.ts
@@ -207,6 +207,19 @@ export const MemoryV2ConfigSchema = z
       .describe(
         "Size-based trigger for consolidation. When `memory/buffer.md` reaches this many non-empty lines, consolidation runs even if the time-based interval hasn't elapsed. Defaults to 100. Set to `null` to disable the size trigger and rely solely on `consolidation_interval_hours`.",
       ),
+    consolidation_max_entries_per_run: z
+      .number({
+        error: "memory.v2.consolidation_max_entries_per_run must be a number",
+      })
+      .int("memory.v2.consolidation_max_entries_per_run must be an integer")
+      .positive(
+        "memory.v2.consolidation_max_entries_per_run must be a positive integer",
+      )
+      .nullable()
+      .default(150)
+      .describe(
+        "Upper bound on buffer entries one consolidation run may process. When the buffer holds more, the run's cutoff is moved back to the first over-cap entry's timestamp so the overflow is deferred to a follow-up pass (the `consolidation_max_buffer_lines` size trigger re-fires while the remainder stays over threshold). Bounds the context a single agentic run must read after a backlog. Set to `null` to always process the full buffer.",
+      ),
     max_page_chars: z
       .number({ error: "memory.v2.max_page_chars must be a number" })
       .int("memory.v2.max_page_chars must be an integer")

--- a/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
+++ b/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
@@ -141,14 +141,32 @@ const { CUTOFF_PLACEHOLDER, CONSOLIDATION_PROMPT } =
   await import("../prompts/consolidation.js");
 
 // The handler only reads `config.memory.enabled`, `config.memory.v2.enabled`,
-// and `config.memory.v2.consolidation_prompt_path`, so a minimal stand-in
-// covers those call sites without materializing the full default config.
+// `config.memory.v2.consolidation_prompt_path`, and
+// `config.memory.v2.consolidation_max_entries_per_run`, so a minimal
+// stand-in covers those call sites without materializing the full default
+// config.
 const CONFIG = {
   memory: {
     enabled: true,
     v2: { enabled: true, consolidation_prompt_path: null },
   },
 } as Parameters<typeof memoryV2ConsolidateJob>[1];
+
+/** CONFIG plus a per-run entry cap for the chunked-cutoff tests. */
+function configWithMaxEntries(
+  maxEntries: number | null,
+): Parameters<typeof memoryV2ConsolidateJob>[1] {
+  return {
+    memory: {
+      enabled: true,
+      v2: {
+        enabled: true,
+        consolidation_prompt_path: null,
+        consolidation_max_entries_per_run: maxEntries,
+      },
+    },
+  } as Parameters<typeof memoryV2ConsolidateJob>[1];
+}
 const CONFIG_DISABLED = {
   memory: {
     enabled: true,
@@ -204,6 +222,92 @@ beforeEach(() => {
 });
 
 // ---------------------------------------------------------------------------
+
+describe("memoryV2ConsolidateJob — chunked cutoff (consolidation_max_entries_per_run)", () => {
+  const FIVE_ENTRIES = [
+    "- [Apr 27, 9:00 AM] Alice prefers VS Code.",
+    "- [Apr 27, 9:01 AM] Bob takes his coffee black.",
+    "- [Apr 27, 9:02 AM] Carol loves jazz.",
+    "- [Apr 27, 9:03 AM] Dave runs marathons.",
+    "- [Apr 27, 9:04 AM] Erin paints watercolors.",
+  ].join("\n");
+
+  test("buffer over the cap → cutoff is the first over-cap entry's timestamp; overflow deferred", async () => {
+    writeFileSync(bufferPath(), FIVE_ENTRIES + "\n");
+
+    const outcome = await memoryV2ConsolidateJob(
+      makeJob(),
+      configWithMaxEntries(3),
+    );
+
+    expect(outcome.kind).toBe("invoked");
+    if (outcome.kind !== "invoked") throw new Error("unreachable");
+    expect(outcome.cutoff).toBe("Apr 27, 9:03 AM");
+    expect(outcome.deferredEntries).toBe(2);
+    expect(runnerCalls).toBe(1);
+    expect(runnerLastArgs!.prompt as string).toContain("Apr 27, 9:03 AM");
+  });
+
+  test("buffer at or under the cap → full-buffer cutoff, nothing deferred", async () => {
+    writeFileSync(bufferPath(), FIVE_ENTRIES + "\n");
+
+    const outcome = await memoryV2ConsolidateJob(
+      makeJob(),
+      configWithMaxEntries(5),
+    );
+
+    expect(outcome.kind).toBe("invoked");
+    if (outcome.kind !== "invoked") throw new Error("unreachable");
+    expect(outcome.deferredEntries).toBe(0);
+    // Cutoff is the run-start timestamp, not any buffer entry's.
+    expect(outcome.cutoff).not.toBe("Apr 27, 9:03 AM");
+  });
+
+  test("null cap → full buffer processed regardless of size", async () => {
+    writeFileSync(bufferPath(), FIVE_ENTRIES + "\n");
+
+    const outcome = await memoryV2ConsolidateJob(
+      makeJob(),
+      configWithMaxEntries(null),
+    );
+
+    expect(outcome.kind).toBe("invoked");
+    if (outcome.kind !== "invoked") throw new Error("unreachable");
+    expect(outcome.deferredEntries).toBe(0);
+  });
+
+  test("cap absent from config (hand-crafted stand-in) → full buffer processed", async () => {
+    writeFileSync(bufferPath(), FIVE_ENTRIES + "\n");
+
+    const outcome = await memoryV2ConsolidateJob(makeJob(), CONFIG);
+
+    expect(outcome.kind).toBe("invoked");
+    if (outcome.kind !== "invoked") throw new Error("unreachable");
+    expect(outcome.deferredEntries).toBe(0);
+  });
+
+  test("over-cap line without a bracketed timestamp → falls back to the full-buffer cutoff", async () => {
+    writeFileSync(
+      bufferPath(),
+      [
+        "- [Apr 27, 9:00 AM] Alice prefers VS Code.",
+        "- [Apr 27, 9:01 AM] Bob takes his coffee black.",
+        "a stray unstructured line with no timestamp",
+        "- [Apr 27, 9:03 AM] Dave runs marathons.",
+      ].join("\n") + "\n",
+    );
+
+    const outcome = await memoryV2ConsolidateJob(
+      makeJob(),
+      configWithMaxEntries(2),
+    );
+
+    expect(outcome.kind).toBe("invoked");
+    if (outcome.kind !== "invoked") throw new Error("unreachable");
+    expect(outcome.deferredEntries).toBe(0);
+    expect(outcome.cutoff).not.toBe("Apr 27, 9:03 AM");
+  });
+});
 
 describe("memoryV2ConsolidateJob — v2 disabled", () => {
   test("returns disabled without invoking the runner when memory.enabled is false", async () => {

--- a/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
+++ b/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
@@ -336,6 +336,33 @@ describe("memoryV2ConsolidateJob — chunked cutoff (consolidation_max_entries_p
     expect(outcome.deferredEntries).toBe(1);
   });
 
+  test("bracketed continuation lines (checklists, wikilinks) are not counted as entries", async () => {
+    // Continuation lines that START with "- [" but don't carry the
+    // formatBufferTimestamp shape must not count toward the cap or become
+    // the cutoff — "- [ ] task" would otherwise yield a blank-string cutoff.
+    writeFileSync(
+      bufferPath(),
+      [
+        "- [Apr 27, 9:00 AM] Alice's project plan:",
+        "- [ ] follow up with Bob",
+        "- [[meeting-notes]] referenced doc",
+        "- [Apr 27, 9:01 AM] Carol loves jazz.",
+      ].join("\n") + "\n",
+    );
+
+    const outcome = await memoryV2ConsolidateJob(
+      makeJob(),
+      configWithMaxEntries(2),
+    );
+
+    expect(outcome.kind).toBe("invoked");
+    if (outcome.kind !== "invoked") throw new Error("unreachable");
+    // Two real entries, cap 2 → no chunking, full-buffer cutoff.
+    expect(outcome.deferredEntries).toBe(0);
+    expect(outcome.cutoff).not.toBe(" ");
+    expect(outcome.cutoff).not.toBe("[meeting-notes]");
+  });
+
   test("multi-line entries under the cap → full-buffer cutoff even when raw line count exceeds it", async () => {
     writeFileSync(
       bufferPath(),

--- a/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
+++ b/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
@@ -310,13 +310,17 @@ describe("memoryV2ConsolidateJob — chunked cutoff (consolidation_max_entries_p
     );
   });
 
-  test("over-cap line without a bracketed timestamp → falls back to the full-buffer cutoff", async () => {
+  test("continuation lines (multi-line entries) don't count as entries or break the cutoff", async () => {
+    // The second entry carries embedded newlines: its continuation lines
+    // belong to that entry, so the buffer holds 3 entries, not 5 lines.
+    // With a cap of 2, the cutoff is the THIRD entry's timestamp.
     writeFileSync(
       bufferPath(),
       [
         "- [Apr 27, 9:00 AM] Alice prefers VS Code.",
-        "- [Apr 27, 9:01 AM] Bob takes his coffee black.",
-        "a stray unstructured line with no timestamp",
+        "- [Apr 27, 9:01 AM] Bob shared a snippet:",
+        "  line two of Bob's multi-line memory",
+        "  line three of Bob's multi-line memory",
         "- [Apr 27, 9:03 AM] Dave runs marathons.",
       ].join("\n") + "\n",
     );
@@ -328,8 +332,30 @@ describe("memoryV2ConsolidateJob — chunked cutoff (consolidation_max_entries_p
 
     expect(outcome.kind).toBe("invoked");
     if (outcome.kind !== "invoked") throw new Error("unreachable");
+    expect(outcome.cutoff).toBe("Apr 27, 9:03 AM");
+    expect(outcome.deferredEntries).toBe(1);
+  });
+
+  test("multi-line entries under the cap → full-buffer cutoff even when raw line count exceeds it", async () => {
+    writeFileSync(
+      bufferPath(),
+      [
+        "- [Apr 27, 9:00 AM] Alice shared a snippet:",
+        "  continuation one",
+        "  continuation two",
+        "- [Apr 27, 9:01 AM] Bob takes his coffee black.",
+      ].join("\n") + "\n",
+    );
+
+    const outcome = await memoryV2ConsolidateJob(
+      makeJob(),
+      configWithMaxEntries(2),
+    );
+
+    expect(outcome.kind).toBe("invoked");
+    if (outcome.kind !== "invoked") throw new Error("unreachable");
     expect(outcome.deferredEntries).toBe(0);
-    expect(outcome.cutoff).not.toBe("Apr 27, 9:03 AM");
+    expect(outcome.cutoff).not.toBe("Apr 27, 9:01 AM");
   });
 });
 

--- a/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
+++ b/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
@@ -286,6 +286,30 @@ describe("memoryV2ConsolidateJob — chunked cutoff (consolidation_max_entries_p
     expect(outcome.deferredEntries).toBe(0);
   });
 
+  test("same-minute burst (every entry shares the over-cap timestamp) → full-buffer cutoff, no wedge", () => {
+    // A sweep that wrote >cap entries within one minute: a pulled-back
+    // cutoff would defer ALL of them ("timestamp >= cutoff stays") and the
+    // size trigger would requeue an identical no-op run forever.
+    writeFileSync(
+      bufferPath(),
+      [
+        "- [Apr 27, 9:00 AM] Alice prefers VS Code.",
+        "- [Apr 27, 9:00 AM] Bob takes his coffee black.",
+        "- [Apr 27, 9:00 AM] Carol loves jazz.",
+        "- [Apr 27, 9:00 AM] Dave runs marathons.",
+      ].join("\n") + "\n",
+    );
+
+    return memoryV2ConsolidateJob(makeJob(), configWithMaxEntries(2)).then(
+      (outcome) => {
+        expect(outcome.kind).toBe("invoked");
+        if (outcome.kind !== "invoked") throw new Error("unreachable");
+        expect(outcome.deferredEntries).toBe(0);
+        expect(outcome.cutoff).not.toBe("Apr 27, 9:00 AM");
+      },
+    );
+  });
+
   test("over-cap line without a bracketed timestamp → falls back to the full-buffer cutoff", async () => {
     writeFileSync(
       bufferPath(),

--- a/assistant/src/memory/v2/__tests__/static-context.test.ts
+++ b/assistant/src/memory/v2/__tests__/static-context.test.ts
@@ -126,6 +126,18 @@ describe("readMemoryV2StaticContent", () => {
     expect(text.indexOf("## Recent")).toBeLessThan(text.indexOf("## Buffer"));
   });
 
+  test("excludeBuffer drops the Buffer section but keeps the other three", () => {
+    for (const file of MEMORY_FILES) writeMemoryFile(file, `Content ${file}`);
+
+    const result = readMemoryV2StaticContent({ excludeBuffer: true });
+    expect(result).not.toBeNull();
+    expect(result!).toContain("## Essentials");
+    expect(result!).toContain("## Threads");
+    expect(result!).toContain("## Recent");
+    expect(result!).not.toContain("## Buffer");
+    expect(result!).not.toContain("Content buffer.md");
+  });
+
   test("omits empty files but keeps populated ones", () => {
     writeMemoryFile("essentials.md", "Alice prefers VS Code.");
     writeMemoryFile("threads.md", "");

--- a/assistant/src/memory/v2/consolidation-job.ts
+++ b/assistant/src/memory/v2/consolidation-job.ts
@@ -216,7 +216,23 @@ export async function memoryV2ConsolidateJob(
         const overflowTimestamp = extractBufferEntryTimestamp(
           entryLines[maxEntries],
         );
-        if (overflowTimestamp !== null) {
+        // Same-minute burst guard: timestamps have minute precision, so when
+        // even the FIRST entry shares the over-cap entry's timestamp, a
+        // pulled-back cutoff would tell the agent to defer every entry
+        // ("timestamp ≥ cutoff stays") — zero progress, and the size trigger
+        // would requeue the identical run forever. Fall back to the
+        // full-buffer cutoff in that case; partial same-minute runs (some
+        // earlier entries have older timestamps) still make progress.
+        const firstTimestamp = extractBufferEntryTimestamp(entryLines[0]);
+        if (
+          overflowTimestamp !== null &&
+          firstTimestamp === overflowTimestamp
+        ) {
+          log.warn(
+            { bufferEntries: entryLines.length, maxEntries, overflowTimestamp },
+            "consolidation: entire over-cap prefix shares one minute timestamp; processing full buffer to guarantee progress",
+          );
+        } else if (overflowTimestamp !== null) {
           cutoff = overflowTimestamp;
           deferredEntries = entryLines.length - maxEntries;
           log.info(

--- a/assistant/src/memory/v2/consolidation-job.ts
+++ b/assistant/src/memory/v2/consolidation-job.ts
@@ -144,6 +144,12 @@ export type ConsolidationOutcome =
       kind: "invoked";
       conversationId: string;
       cutoff: string;
+      /**
+       * Buffer entries beyond `consolidation_max_entries_per_run` left for a
+       * follow-up pass via the pulled-back cutoff. `0` when the whole buffer
+       * fit in one run.
+       */
+      deferredEntries: number;
       followUpJobIds: string[];
     };
 
@@ -174,20 +180,61 @@ export async function memoryV2ConsolidateJob(
   }
 
   try {
-    // Step 2: capture cutoff. Formatted to match `buffer.md` entry timestamps
-    // (`Mon D, h:mm AM/PM`, see `formatBufferTimestamp`) so the agent's
-    // "timestamp ≥ cutoff" check compares like-with-like at minute precision.
-    // Same-minute entries land on the next pass — conservative but loss-free.
-    // Captured here (not at enqueue time) so late-claimed rows get a fresh
-    // cutoff.
-    const cutoff = formatBufferTimestamp(new Date());
-
-    // Step 3: bail on empty buffer. Nothing for the agent to consolidate.
+    // Step 2: bail on empty buffer. Nothing for the agent to consolidate.
     // The lock is released in finally below.
     const bufferContent = readBufferContent(bufferPath);
     if (bufferContent.trim().length === 0) {
       log.debug("buffer.md empty; consolidation skipped");
       return { kind: "empty_buffer" };
+    }
+
+    // Step 3: capture cutoff. Formatted to match `buffer.md` entry timestamps
+    // (`Mon D, h:mm AM/PM`, see `formatBufferTimestamp`) so the agent's
+    // "timestamp ≥ cutoff" check compares like-with-like at minute precision.
+    // Same-minute entries land on the next pass — conservative but loss-free.
+    // Captured here (not at enqueue time) so late-claimed rows get a fresh
+    // cutoff.
+    //
+    // Chunking: when the buffer holds more than
+    // `consolidation_max_entries_per_run` entries (a backlog from missed or
+    // failed runs), pull the cutoff back to the first over-cap entry's
+    // timestamp. The agent's existing "≥ cutoff stays" rule then defers the
+    // overflow loss-free, and the `consolidation_max_buffer_lines` size
+    // trigger re-fires while the remainder stays over threshold — so one run
+    // never has to read an unbounded backlog into context. Entries sharing
+    // the over-cap entry's minute are also deferred (conservative). A line
+    // whose timestamp can't be extracted falls back to the full-buffer
+    // cutoff — today's behavior.
+    let cutoff = formatBufferTimestamp(new Date());
+    let deferredEntries = 0;
+    const maxEntries = config.memory.v2.consolidation_max_entries_per_run;
+    if (maxEntries != null) {
+      const entryLines = bufferContent
+        .split("\n")
+        .filter((line) => line.trim().length > 0);
+      if (entryLines.length > maxEntries) {
+        const overflowTimestamp = extractBufferEntryTimestamp(
+          entryLines[maxEntries],
+        );
+        if (overflowTimestamp !== null) {
+          cutoff = overflowTimestamp;
+          deferredEntries = entryLines.length - maxEntries;
+          log.info(
+            {
+              bufferEntries: entryLines.length,
+              maxEntries,
+              deferredEntries,
+              cutoff,
+            },
+            "consolidation chunked: buffer over per-run cap, overflow deferred to next pass",
+          );
+        } else {
+          log.warn(
+            { line: entryLines[maxEntries].slice(0, 80) },
+            "consolidation: could not extract timestamp from over-cap buffer entry; processing full buffer",
+          );
+        }
+      }
     }
 
     // Step 4: hand off to the centralized background-job runner. The runner
@@ -272,6 +319,7 @@ export async function memoryV2ConsolidateJob(
       {
         conversationId: runResult.conversationId,
         cutoff,
+        deferredEntries,
         followUpJobIds,
       },
       "consolidation invoked",
@@ -280,6 +328,7 @@ export async function memoryV2ConsolidateJob(
       kind: "invoked",
       conversationId: runResult.conversationId,
       cutoff,
+      deferredEntries,
       followUpJobIds,
     };
   } finally {
@@ -298,6 +347,18 @@ function readBufferContent(bufferPath: string): string {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return "";
     throw err;
   }
+}
+
+/**
+ * Extract the bracketed timestamp from a `buffer.md` entry line
+ * (`- [Mon D, h:mm AM/PM] …`, see `formatBufferEntry`). Returned verbatim so
+ * it can serve directly as a consolidation cutoff — both sides of the agent's
+ * "timestamp ≥ cutoff" comparison then share the exact `formatBufferTimestamp`
+ * shape. Returns `null` for lines that don't carry the bracketed prefix.
+ */
+function extractBufferEntryTimestamp(line: string): string | null {
+  const match = /^\s*-\s*\[([^\]]+)\]/.exec(line);
+  return match ? match[1] : null;
 }
 
 /**

--- a/assistant/src/memory/v2/consolidation-job.ts
+++ b/assistant/src/memory/v2/consolidation-job.ts
@@ -202,20 +202,22 @@ export async function memoryV2ConsolidateJob(
     // overflow loss-free, and the `consolidation_max_buffer_lines` size
     // trigger re-fires while the remainder stays over threshold — so one run
     // never has to read an unbounded backlog into context. Entries sharing
-    // the over-cap entry's minute are also deferred (conservative). A line
-    // whose timestamp can't be extracted falls back to the full-buffer
-    // cutoff — today's behavior.
+    // the over-cap entry's minute are also deferred (conservative).
+    //
+    // Entries are counted by their timestamped bullet-start lines
+    // (`- [Mon D, h:mm AM/PM] …`) rather than raw non-empty lines: a
+    // remembered fact can carry embedded newlines, and its continuation
+    // lines belong to the preceding entry, not the count.
     let cutoff = formatBufferTimestamp(new Date());
     let deferredEntries = 0;
     const maxEntries = config.memory.v2.consolidation_max_entries_per_run;
     if (maxEntries != null) {
-      const entryLines = bufferContent
+      const entryTimestamps = bufferContent
         .split("\n")
-        .filter((line) => line.trim().length > 0);
-      if (entryLines.length > maxEntries) {
-        const overflowTimestamp = extractBufferEntryTimestamp(
-          entryLines[maxEntries],
-        );
+        .map(extractBufferEntryTimestamp)
+        .filter((timestamp): timestamp is string => timestamp !== null);
+      if (entryTimestamps.length > maxEntries) {
+        const overflowTimestamp = entryTimestamps[maxEntries];
         // Same-minute burst guard: timestamps have minute precision, so when
         // even the FIRST entry shares the over-cap entry's timestamp, a
         // pulled-back cutoff would tell the agent to defer every entry
@@ -223,31 +225,26 @@ export async function memoryV2ConsolidateJob(
         // would requeue the identical run forever. Fall back to the
         // full-buffer cutoff in that case; partial same-minute runs (some
         // earlier entries have older timestamps) still make progress.
-        const firstTimestamp = extractBufferEntryTimestamp(entryLines[0]);
-        if (
-          overflowTimestamp !== null &&
-          firstTimestamp === overflowTimestamp
-        ) {
+        if (entryTimestamps[0] === overflowTimestamp) {
           log.warn(
-            { bufferEntries: entryLines.length, maxEntries, overflowTimestamp },
+            {
+              bufferEntries: entryTimestamps.length,
+              maxEntries,
+              overflowTimestamp,
+            },
             "consolidation: entire over-cap prefix shares one minute timestamp; processing full buffer to guarantee progress",
           );
-        } else if (overflowTimestamp !== null) {
+        } else {
           cutoff = overflowTimestamp;
-          deferredEntries = entryLines.length - maxEntries;
+          deferredEntries = entryTimestamps.length - maxEntries;
           log.info(
             {
-              bufferEntries: entryLines.length,
+              bufferEntries: entryTimestamps.length,
               maxEntries,
               deferredEntries,
               cutoff,
             },
             "consolidation chunked: buffer over per-run cap, overflow deferred to next pass",
-          );
-        } else {
-          log.warn(
-            { line: entryLines[maxEntries].slice(0, 80) },
-            "consolidation: could not extract timestamp from over-cap buffer entry; processing full buffer",
           );
         }
       }

--- a/assistant/src/memory/v2/consolidation-job.ts
+++ b/assistant/src/memory/v2/consolidation-job.ts
@@ -367,10 +367,19 @@ function readBufferContent(bufferPath: string): string {
  * (`- [Mon D, h:mm AM/PM] …`, see `formatBufferEntry`). Returned verbatim so
  * it can serve directly as a consolidation cutoff — both sides of the agent's
  * "timestamp ≥ cutoff" comparison then share the exact `formatBufferTimestamp`
- * shape. Returns `null` for lines that don't carry the bracketed prefix.
+ * shape.
+ *
+ * The bracket contents must match that shape exactly: a remembered fact's
+ * continuation lines can themselves start with `- [` (markdown checklists
+ * `- [ ] …`, wikilink bullets `- [[…]]`), and counting those as entries
+ * would inflate the per-run budget — or worse, hand the agent a garbage
+ * cutoff like a blank string. Returns `null` for anything that isn't a real
+ * timestamped entry start.
  */
 function extractBufferEntryTimestamp(line: string): string | null {
-  const match = /^\s*-\s*\[([^\]]+)\]/.exec(line);
+  const match = /^\s*-\s*\[([A-Z][a-z]{2} \d{1,2}, \d{1,2}:\d{2} [AP]M)\]/.exec(
+    line,
+  );
   return match ? match[1] : null;
 }
 

--- a/assistant/src/memory/v2/static-context.ts
+++ b/assistant/src/memory/v2/static-context.ts
@@ -38,8 +38,17 @@ const MEMORY_V2_STATIC_BLOCKS: readonly MemoryV2StaticBlock[] = [
  * Build the v2 static memory block, gated on `config.memory.enabled` and
  * `config.memory.v2.enabled`. Empty/missing files are skipped; returns `null`
  * when either gate is off or every file is empty.
+ *
+ * `excludeBuffer` drops the `## Buffer` section. The consolidation run sets
+ * it: the agent's contract there is the `memory/buffer.md` FILE — it reads,
+ * routes, and rewrites it through file tools — so injecting a static snapshot
+ * of the same content would duplicate the entire (potentially unbounded)
+ * backlog into the turn's context and go stale the moment the agent edits
+ * the file.
  */
-export function readMemoryV2StaticContent(): string | null {
+export function readMemoryV2StaticContent(
+  options: { excludeBuffer?: boolean } = {},
+): string | null {
   let config;
   try {
     config = loadConfig();
@@ -52,6 +61,9 @@ export function readMemoryV2StaticContent(): string | null {
 
   const sections: string[] = [];
   for (const { heading, file } of MEMORY_V2_STATIC_BLOCKS) {
+    if (options.excludeBuffer === true && file === "memory/buffer.md") {
+      continue;
+    }
     const content = readPromptFile(getWorkspacePromptPath(file));
     if (!content) continue;
     sections.push(`${heading}\n\n${content}`);

--- a/assistant/src/plugins/defaults/memory-retrieval/injectors.ts
+++ b/assistant/src/plugins/defaults/memory-retrieval/injectors.ts
@@ -389,9 +389,17 @@ function readGatedNowScratchpad(trust: TrustContext): string | null {
  * otherwise `null`. {@link readMemoryV2StaticContent} self-gates on the v2
  * flag + config, so the `memory-v2-static` injector owns its input rather than
  * having it threaded in from the agent loop.
+ *
+ * `excludeBuffer` is forwarded for consolidation turns, whose contract is the
+ * buffer FILE itself — see {@link readMemoryV2StaticContent}.
  */
-function readGatedMemoryV2Static(trust: TrustContext): string | null {
-  return isPersonalMemoryAllowed(trust) ? readMemoryV2StaticContent() : null;
+function readGatedMemoryV2Static(
+  trust: TrustContext,
+  options: { excludeBuffer?: boolean } = {},
+): string | null {
+  return isPersonalMemoryAllowed(trust)
+    ? readMemoryV2StaticContent(options)
+    : null;
 }
 
 /**
@@ -629,7 +637,12 @@ const memoryV2StaticInjector: Injector = {
   ): Promise<InjectionBlock | null> {
     const mode = ctx.mode ?? "full";
     if (mode !== "full") return null;
-    const content = readGatedMemoryV2Static(ctx.trust);
+    // The consolidation agent reads and rewrites memory/buffer.md through
+    // file tools; injecting the buffer section here would duplicate the
+    // entire backlog into its context (and go stale as it edits the file).
+    const content = readGatedMemoryV2Static(ctx.trust, {
+      excludeBuffer: ctx.callSite === "memoryV2Consolidation",
+    });
     if (!content) return null;
     if (hasInjectedUserTextBlock(runMessages, MEMORY_V2_STATIC_BLOCK_MATCHERS))
       return null;


### PR DESCRIPTION
## Summary
- New `memory.v2.consolidation_max_entries_per_run` config knob (default 150, `null` disables). When `buffer.md` holds more entries, the run's cutoff is pulled back to the first over-cap entry's bracketed timestamp — both sides of the agent's `timestamp ≥ cutoff` rule share the exact `formatBufferTimestamp` shape, so the overflow defers loss-free with no parsing or ordering.
- The existing `consolidation_max_buffer_lines` size trigger (default 100) re-fires while the deferred remainder stays over threshold, so backlogs drain in bounded chunks on consecutive worker ticks rather than as one unbounded ~300k-token run.
- The `invoked` outcome and log line now report `deferredEntries`; lines without an extractable timestamp fall back to today's full-buffer behavior.

## Original prompt
Cost-reduction follow-up from a cache-hit-ratio audit: memoryV2Consolidation averaged ~302k tokens per LLM call (870M tokens over 2,878 calls in 7 days) because a single agentic run reads the entire buffer backlog plus the memory tree. The ask: bound the context a single consolidation run must process by chunking the buffer per run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)