### PR TITLE
feat(assistant): add clock time to the memory-v3 selector's situation anchor

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
@@ -346,7 +346,13 @@ function readNowContext(): string | null {
  */
 function buildSituationalContext(): string {
   const now = readNowContext();
-  const today = `Today is ${new Date().toDateString()}.`;
+  const at = new Date();
+  // Clock time matters, not just the date: fresh cards carry absolute
+  // `updated <time>` stamps, and hour-grain windows ("while I was asleep",
+  // "this morning") are only computable against a current-time anchor —
+  // measured on a state-recall turn, the anchor alone moved selection more
+  // than prompt steering did.
+  const today = `Today is ${at.toDateString()}, ${at.toISOString().slice(11, 16)} UTC.`;
   return now ? `${today}\n\n${now}` : today;
 }
 


### PR DESCRIPTION
## Summary
- `buildSituationalContext()` now renders `Today is <date>, <HH:MM> UTC.` instead of the date alone.
- Fresh cards carry absolute `updated <time>` stamps; without a current-time anchor the selector cannot place them in windows like "while I was away" or "this morning". A paired single-turn experiment (3 runs/arm) showed the anchor alone lifting gold-page selection avg 6.7 → 10.3 (of 58), more than a recency steering sentence did, which added only noise on top of the anchor.
- The situation block is part of the selector's uncached per-turn tail — no cache-contract change.

## Original prompt
While auditing memory-v3 retrieval losses on "what did you do recently"-style turns, the maintainer asked whether the selector sees the current time alongside the pages' last-modified stamps. It did not (date only), and the harness modeled no anchor at all; fixing the instrument and A/B-ing the anchor showed it to be the binding signal. The maintainer's question directly motivated this change.