### PR TITLE
fix(vbundle): keep legacy bundles with prompts/UPDATES.md restorable

### DIFF
--- a/assistant/src/runtime/migrations/__tests__/vbundle-legacy-user-md.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-legacy-user-md.test.ts
@@ -388,6 +388,49 @@ describe("commitImport for legacy prompts/USER.md", () => {
     expect(existsSync(join(USERS_DIR, "USER.md"))).toBe(false);
   });
 
+  test("retired prompts/UPDATES.md skips silently — no warning, nothing written", () => {
+    const resolver = new DefaultPathResolver(
+      WORKSPACE_ROOT,
+      undefined,
+      () => null,
+    );
+
+    const { archive } = buildVBundle({
+      files: [
+        {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
+        {
+          path: "prompts/UPDATES.md",
+          data: new TextEncoder().encode("## Old release notes\n"),
+        },
+      ],
+      ...defaultV1Options(),
+    });
+
+    const result = commitImport({
+      archiveData: archive,
+      pathResolver: resolver,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.report.success).toBe(true);
+      expect(
+        result.report.files.find((f) => f.path === "prompts/UPDATES.md")
+          ?.action,
+      ).toBe("skipped");
+      // Silent skip: the commit report must agree with preflight, which
+      // raises neither a conflict nor a warning for retired paths.
+      expect(
+        result.report.warnings.some((w) => w.includes("prompts/UPDATES.md")),
+      ).toBe(false);
+    }
+
+    expect(existsSync(join(WORKSPACE_ROOT, "UPDATES.md"))).toBe(false);
+  });
+
   test("does NOT overwrite a customized users/<slug>.md", () => {
     const slug = "captain.md";
     const guardianPath = join(USERS_DIR, slug);

--- a/assistant/src/runtime/migrations/__tests__/vbundle-legacy-user-md.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-legacy-user-md.test.ts
@@ -227,6 +227,39 @@ describe("analyzeImport for legacy prompts/USER.md", () => {
     const userMd = report.files.find((f) => f.path === "prompts/USER.md");
     expect(userMd!.action).toBe("skip");
   });
+
+  test("retired prompts/UPDATES.md in a legacy bundle is a non-blocking skip", () => {
+    const resolver = new DefaultPathResolver(
+      WORKSPACE_ROOT,
+      undefined,
+      () => null,
+    );
+
+    const { manifest } = buildVBundle({
+      files: [
+        {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
+        {
+          path: "prompts/UPDATES.md",
+          data: new TextEncoder().encode("## Old release notes\n"),
+        },
+      ],
+      ...defaultV1Options(),
+    });
+
+    const report = analyzeImport({ manifest, pathResolver: resolver });
+
+    // Bundles exported while the update-bulletin feature existed must stay
+    // restorable — the retired file is dropped, never written back, and
+    // must not register an UNKNOWN_ARCHIVE_PATH conflict.
+    expect(report.can_import).toBe(true);
+    expect(report.conflicts).toHaveLength(0);
+    const updatesMd = report.files.find((f) => f.path === "prompts/UPDATES.md");
+    expect(updatesMd).toBeDefined();
+    expect(updatesMd!.action).toBe("skip");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/migrations/__tests__/vbundle-legacy-user-md.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-legacy-user-md.test.ts
@@ -228,6 +228,38 @@ describe("analyzeImport for legacy prompts/USER.md", () => {
     expect(userMd!.action).toBe("skip");
   });
 
+  test("retired workspace/UPDATES.md (current format) is a non-blocking skip", () => {
+    const resolver = new DefaultPathResolver(
+      WORKSPACE_ROOT,
+      undefined,
+      () => null,
+    );
+
+    const { manifest } = buildVBundle({
+      files: [
+        {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
+        {
+          path: "workspace/UPDATES.md",
+          data: new TextEncoder().encode("## Old release notes\n"),
+        },
+      ],
+      ...defaultV1Options(),
+    });
+
+    const report = analyzeImport({ manifest, pathResolver: resolver });
+
+    expect(report.can_import).toBe(true);
+    expect(report.conflicts).toHaveLength(0);
+    const updatesMd = report.files.find(
+      (f) => f.path === "workspace/UPDATES.md",
+    );
+    expect(updatesMd).toBeDefined();
+    expect(updatesMd!.action).toBe("skip");
+  });
+
   test("retired prompts/UPDATES.md in a legacy bundle is a non-blocking skip", () => {
     const resolver = new DefaultPathResolver(
       WORKSPACE_ROOT,
@@ -386,6 +418,48 @@ describe("commitImport for legacy prompts/USER.md", () => {
 
     // No stray file was written anywhere in users/.
     expect(existsSync(join(USERS_DIR, "USER.md"))).toBe(false);
+  });
+
+  test("retired workspace/UPDATES.md (current format) is never written back", () => {
+    const resolver = new DefaultPathResolver(
+      WORKSPACE_ROOT,
+      undefined,
+      () => null,
+    );
+
+    const { archive } = buildVBundle({
+      files: [
+        {
+          path: "data/db/assistant.db",
+          data: new Uint8Array(),
+        },
+        {
+          path: "workspace/UPDATES.md",
+          data: new TextEncoder().encode("## Old release notes\n"),
+        },
+      ],
+      ...defaultV1Options(),
+    });
+
+    const result = commitImport({
+      archiveData: archive,
+      pathResolver: resolver,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.report.success).toBe(true);
+      expect(
+        result.report.files.find((f) => f.path === "workspace/UPDATES.md")
+          ?.action,
+      ).toBe("skipped");
+      expect(result.report.warnings.some((w) => w.includes("UPDATES.md"))).toBe(
+        false,
+      );
+    }
+
+    // The retired bulletin file must not be resurrected in the workspace.
+    expect(existsSync(join(WORKSPACE_ROOT, "UPDATES.md"))).toBe(false);
   });
 
   test("retired prompts/UPDATES.md skips silently — no warning, nothing written", () => {

--- a/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
+++ b/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
@@ -19,6 +19,7 @@ import { join, resolve } from "node:path";
 
 import { resolveGuardianPersonaPath } from "../../prompts/persona-resolver.js";
 import { getLogger } from "../../util/logger.js";
+import { isRetiredArchivePath } from "./vbundle-import-policy.js";
 import type { ManifestType } from "./vbundle-validator.js";
 
 const log = getLogger("vbundle-import-analyzer");
@@ -34,14 +35,6 @@ const ALLOWED_PROMPT_FILENAMES = new Set(["IDENTITY.md", "SOUL.md", "USER.md"]);
 
 /** Archive path for the legacy guardian user persona file. */
 const LEGACY_USER_MD_ARCHIVE_PATH = "prompts/USER.md";
-
-/**
- * Archive path for the retired update-bulletin file. Legacy bundles exported
- * while the feature existed contain this entry; it must remain importable as
- * a non-blocking skip so old backups stay restorable, but the file is never
- * written back to the workspace.
- */
-const RETIRED_UPDATES_MD_ARCHIVE_PATH = "prompts/UPDATES.md";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -291,13 +284,13 @@ export function analyzeImport(
         continue;
       }
 
-      // Retired update-bulletin file from a legacy bundle: nothing consumes
-      // it anymore, so drop it silently instead of blocking the restore with
+      // Retired-feature file from a legacy bundle: nothing consumes it
+      // anymore, so drop it silently instead of blocking the restore with
       // an UNKNOWN_ARCHIVE_PATH conflict.
-      if (fileEntry.path === RETIRED_UPDATES_MD_ARCHIVE_PATH) {
+      if (isRetiredArchivePath(fileEntry.path)) {
         log.info(
           { path: fileEntry.path },
-          "Retired prompts/UPDATES.md in legacy bundle — will be skipped on import",
+          "Retired archive path in legacy bundle — will be skipped on import",
         );
         files.push({
           path: fileEntry.path,

--- a/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
+++ b/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
@@ -35,6 +35,14 @@ const ALLOWED_PROMPT_FILENAMES = new Set(["IDENTITY.md", "SOUL.md", "USER.md"]);
 /** Archive path for the legacy guardian user persona file. */
 const LEGACY_USER_MD_ARCHIVE_PATH = "prompts/USER.md";
 
+/**
+ * Archive path for the retired update-bulletin file. Legacy bundles exported
+ * while the feature existed contain this entry; it must remain importable as
+ * a non-blocking skip so old backups stay restorable, but the file is never
+ * written back to the workspace.
+ */
+const RETIRED_UPDATES_MD_ARCHIVE_PATH = "prompts/UPDATES.md";
+
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
@@ -271,6 +279,25 @@ export function analyzeImport(
         log.warn(
           { path: fileEntry.path },
           "Legacy prompts/USER.md has no guardian target — will be skipped on import",
+        );
+        files.push({
+          path: fileEntry.path,
+          action: "skip",
+          bundle_size: fileEntry.size_bytes,
+          bundle_sha256: fileEntry.sha256,
+          current_size: null,
+          current_sha256: null,
+        });
+        continue;
+      }
+
+      // Retired update-bulletin file from a legacy bundle: nothing consumes
+      // it anymore, so drop it silently instead of blocking the restore with
+      // an UNKNOWN_ARCHIVE_PATH conflict.
+      if (fileEntry.path === RETIRED_UPDATES_MD_ARCHIVE_PATH) {
+        log.info(
+          { path: fileEntry.path },
+          "Retired prompts/UPDATES.md in legacy bundle — will be skipped on import",
         );
         files.push({
           path: fileEntry.path,

--- a/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
+++ b/assistant/src/runtime/migrations/vbundle-import-analyzer.ts
@@ -119,6 +119,14 @@ export class DefaultPathResolver implements PathResolver {
       return null;
     }
 
+    // Retired-feature files (both legacy and workspace-format spellings)
+    // must never resolve to a disk target — resolving would write them
+    // back into the workspace on import. The analyzer and both importers
+    // turn the resulting null into a silent non-blocking skip.
+    if (isRetiredArchivePath(archivePath)) {
+      return null;
+    }
+
     // New format: workspace/ prefix — maps directly into the workspace dir
     if (archivePath.startsWith("workspace/") && this.workspaceDir) {
       const relPath = archivePath.slice("workspace/".length);

--- a/assistant/src/runtime/migrations/vbundle-import-policy.ts
+++ b/assistant/src/runtime/migrations/vbundle-import-policy.ts
@@ -35,16 +35,22 @@ export function isLegacyPersonaArchivePath(archivePath: string): boolean {
 }
 
 /**
- * Archive paths for retired features. Legacy bundles exported while those
- * features existed still contain these entries; preflight and both importers
- * must treat them as silent non-blocking skips (no conflict, no warning) so
- * old backups stay restorable without noise, and the files are never written
+ * Archive paths for retired features. Bundles exported while those features
+ * existed still contain these entries; preflight and both importers must
+ * treat them as silent non-blocking skips (no conflict, no warning) so old
+ * backups stay restorable without noise, and the files are never written
  * back to the workspace.
  *
- * `prompts/UPDATES.md` carried the retired update-bulletin release notes.
+ * `UPDATES.md` carried the retired update-bulletin release notes. Legacy
+ * bundles archived it as `prompts/UPDATES.md`; current-format bundles walk
+ * the workspace dir, so it appears as `workspace/UPDATES.md`. Both spellings
+ * must be retired — `DefaultPathResolver.resolve()` short-circuits them to
+ * `null` before any prefix handling so the workspace-format entry cannot
+ * resolve normally and recreate the file on import.
  */
 export const RETIRED_ARCHIVE_PATHS: ReadonlySet<string> = new Set([
   "prompts/UPDATES.md",
+  "workspace/UPDATES.md",
 ]);
 
 export function isRetiredArchivePath(archivePath: string): boolean {

--- a/assistant/src/runtime/migrations/vbundle-import-policy.ts
+++ b/assistant/src/runtime/migrations/vbundle-import-policy.ts
@@ -34,6 +34,23 @@ export function isLegacyPersonaArchivePath(archivePath: string): boolean {
   return archivePath === LEGACY_USER_MD_ARCHIVE_PATH;
 }
 
+/**
+ * Archive paths for retired features. Legacy bundles exported while those
+ * features existed still contain these entries; preflight and both importers
+ * must treat them as silent non-blocking skips (no conflict, no warning) so
+ * old backups stay restorable without noise, and the files are never written
+ * back to the workspace.
+ *
+ * `prompts/UPDATES.md` carried the retired update-bulletin release notes.
+ */
+export const RETIRED_ARCHIVE_PATHS: ReadonlySet<string> = new Set([
+  "prompts/UPDATES.md",
+]);
+
+export function isRetiredArchivePath(archivePath: string): boolean {
+  return RETIRED_ARCHIVE_PATHS.has(archivePath);
+}
+
 export function isConfigArchivePath(archivePath: string): boolean {
   return CONFIG_ARCHIVE_PATHS.has(archivePath);
 }

--- a/assistant/src/runtime/migrations/vbundle-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-importer.ts
@@ -322,7 +322,10 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
     const diskPath = pathResolver.resolve(fileEntry.path);
 
     if (!diskPath) {
-      // Unknown archive path — skip it
+      // Unknown archive path — skip it. Retired-feature paths (see
+      // `policy.RETIRED_ARCHIVE_PATHS`) are expected in legacy bundles and
+      // skip silently so the import report matches preflight; anything else
+      // unresolvable earns a warning.
       importedFiles.push({
         path: fileEntry.path,
         disk_path: "",
@@ -331,9 +334,11 @@ export function commitImport(options: ImportCommitOptions): ImportCommitResult {
         sha256: fileEntry.sha256,
         backup_path: null,
       });
-      warnings.push(
-        `Skipped "${fileEntry.path}": no known disk target for this archive path`,
-      );
+      if (!policy.isRetiredArchivePath(fileEntry.path)) {
+        warnings.push(
+          `Skipped "${fileEntry.path}": no known disk target for this archive path`,
+        );
+      }
       continue;
     }
 

--- a/assistant/src/runtime/migrations/vbundle-streaming-importer.ts
+++ b/assistant/src/runtime/migrations/vbundle-streaming-importer.ts
@@ -695,9 +695,14 @@ export async function streamCommitImport(
           sha256: expectedEntry.sha256,
           backup_path: null,
         });
-        warnings.push(
-          `Skipped "${archivePath}": no known disk target for this archive path`,
-        );
+        // Retired-feature paths (see `policy.RETIRED_ARCHIVE_PATHS`) are
+        // expected in legacy bundles and skip silently so the import report
+        // matches preflight; anything else unresolvable earns a warning.
+        if (!policy.isRetiredArchivePath(archivePath)) {
+          warnings.push(
+            `Skipped "${archivePath}": no known disk target for this archive path`,
+          );
+        }
         seen.add(archivePath);
         onProgress?.({
           archivePath,


### PR DESCRIPTION
## Summary

Addresses [Codex's P1 on #34636](https://github.com/vellum-ai/vellum-assistant/pull/34636#discussion_r3401282302), which was flagged but not addressed before that PR merged.

#34636 removed `UPDATES.md` from `ALLOWED_PROMPT_FILENAMES`, which made `DefaultPathResolver.resolve()` return `null` for `prompts/UPDATES.md` entries in legacy `.vbundle` archives. The preflight analyzer then registered an `UNKNOWN_ARCHIVE_PATH` conflict and returned `can_import: false` — **blocking the entire restore of any backup exported while the update-bulletin feature existed**.

## Fix

`analyzeImport()` now special-cases the retired `prompts/UPDATES.md` path as a non-blocking skip (no conflict, `action: "skip"`), mirroring the existing legacy `prompts/USER.md` handling. The commit-time importer already skipped unresolvable paths non-blockingly, so preflight and commit now agree: the retired file is dropped on import and never written back to the workspace.

## Testing

- New regression test in `vbundle-legacy-user-md.test.ts`: a legacy bundle containing `prompts/UPDATES.md` reports `can_import: true`, zero conflicts, `action: "skip"`.
- `bunx tsc --noEmit` and `bun run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)