### PR TITLE
feat(macos): add WorkOS app-held PKCE module

### DIFF
--- a/apps/macos/src/main/workos-pkce.test.ts
+++ b/apps/macos/src/main/workos-pkce.test.ts
@@ -1,0 +1,270 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+// net.fetch routes by URL so each WorkOS/platform call can be asserted.
+let fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
+let fetchResponses: Record<string, () => Response> = {};
+
+mock.module("electron", () => ({
+  net: {
+    fetch: (url: string, init?: RequestInit) => {
+      fetchCalls.push({ url, init });
+      const match = Object.entries(fetchResponses).find(([prefix]) =>
+        url.includes(prefix),
+      );
+      if (!match) throw new Error(`Unexpected fetch: ${url}`);
+      return Promise.resolve(match[1]());
+    },
+  },
+}));
+
+const {
+  buildAuthorizeUrl,
+  exchangeAccessTokenForSession,
+  exchangeCodeWithWorkos,
+  fetchWorkosClientId,
+  generatePkcePair,
+  selectWorkosClientId,
+  startLoopbackListener,
+} = await import("./workos-pkce");
+
+afterEach(() => {
+  fetchCalls = [];
+  fetchResponses = {};
+});
+
+describe("generatePkcePair", () => {
+  test("challenge is the base64url sha256 of the verifier", async () => {
+    const { verifier, challenge } = generatePkcePair();
+    const digest = await crypto.subtle.digest(
+      "SHA-256",
+      new TextEncoder().encode(verifier),
+    );
+    const expected = Buffer.from(digest).toString("base64url");
+    expect(challenge).toBe(expected);
+  });
+
+  test("verifiers are unique", () => {
+    expect(generatePkcePair().verifier).not.toBe(generatePkcePair().verifier);
+  });
+});
+
+describe("buildAuthorizeUrl", () => {
+  const base = {
+    clientId: "client_123",
+    redirectUri: "http://127.0.0.1:4242/auth/callback",
+    challenge: "chal",
+    state: "st",
+  };
+
+  test("targets user_management/authorize with PKCE and authkit defaults", () => {
+    const url = new URL(buildAuthorizeUrl(base));
+    expect(url.origin).toBe("https://api.workos.com");
+    expect(url.pathname).toBe("/user_management/authorize");
+    expect(url.searchParams.get("client_id")).toBe("client_123");
+    expect(url.searchParams.get("redirect_uri")).toBe(base.redirectUri);
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("code_challenge")).toBe("chal");
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(url.searchParams.get("state")).toBe("st");
+    expect(url.searchParams.get("provider")).toBe("authkit");
+    expect(url.searchParams.get("scope")).toBe("openid profile email");
+    // Session reuse: never force a fresh IdP login.
+    expect(url.searchParams.has("prompt")).toBe(false);
+  });
+
+  test("provider hint replaces authkit", () => {
+    const url = new URL(buildAuthorizeUrl({ ...base, providerHint: "GoogleOAuth" }));
+    expect(url.searchParams.get("provider")).toBe("GoogleOAuth");
+  });
+
+  test("signup intent maps to screen_hint", () => {
+    const url = new URL(buildAuthorizeUrl({ ...base, intent: "signup" }));
+    expect(url.searchParams.get("screen_hint")).toBe("sign-up");
+
+    const noIntent = new URL(buildAuthorizeUrl(base));
+    expect(noIntent.searchParams.has("screen_hint")).toBe(false);
+  });
+
+  test("login hint is forwarded", () => {
+    const url = new URL(buildAuthorizeUrl({ ...base, loginHint: "a@b.co" }));
+    expect(url.searchParams.get("login_hint")).toBe("a@b.co");
+  });
+});
+
+describe("selectWorkosClientId", () => {
+  // During coexistence the platform lists two providers that share the
+  // "workos-oidc" id; only the OAuth2 one (no discovery URL) is usable.
+  const legacy = {
+    id: "workos-oidc",
+    name: "WorkOS OIDC",
+    client_id: "client_connect",
+    flows: ["provider_redirect", "provider_token"],
+    openid_configuration_url: "https://x.authkit.app/.well-known/openid-configuration",
+  };
+  const modern = {
+    id: "workos-oidc",
+    name: "WorkOS",
+    client_id: "client_um",
+    flows: ["provider_redirect", "provider_token"],
+  };
+
+  test("picks the OAuth2 entry during coexistence", () => {
+    expect(selectWorkosClientId([legacy, modern])).toBe("client_um");
+    expect(selectWorkosClientId([modern, legacy])).toBe("client_um");
+  });
+
+  test("returns null when the platform lacks token auth", () => {
+    const preTokenAuth = { ...modern, flows: ["provider_redirect"] };
+    expect(selectWorkosClientId([legacy, preTokenAuth])).toBeNull();
+    expect(selectWorkosClientId([])).toBeNull();
+  });
+});
+
+describe("fetchWorkosClientId", () => {
+  test("resolves the client id from the headless config", async () => {
+    fetchResponses["/_allauth/app/v1/config"] = () =>
+      new Response(
+        JSON.stringify({
+          data: {
+            socialaccount: {
+              providers: [
+                { id: "workos-oidc", client_id: "client_um", flows: ["provider_token"] },
+              ],
+            },
+          },
+        }),
+        { status: 200 },
+      );
+
+    expect(await fetchWorkosClientId("https://platform.example")).toBe("client_um");
+    expect(fetchCalls[0]!.url).toBe("https://platform.example/_allauth/app/v1/config");
+  });
+
+  test("throws a clear error when no token-auth provider is advertised", async () => {
+    fetchResponses["/_allauth/app/v1/config"] = () =>
+      new Response(JSON.stringify({ data: { socialaccount: { providers: [] } } }), {
+        status: 200,
+      });
+
+    await expect(fetchWorkosClientId("https://platform.example")).rejects.toThrow(
+      /does not advertise/,
+    );
+  });
+});
+
+describe("startLoopbackListener", () => {
+  test("delivers the code for a state-matched callback and ignores noise", async () => {
+    const listener = await startLoopbackListener("expected-state");
+    try {
+      // Noise: wrong path, wrong state — must not settle the promise.
+      const noise1 = await fetch(listener.redirectUri.replace("/auth/callback", "/favicon.ico"));
+      expect(noise1.status).toBe(404);
+      const noise2 = await fetch(`${listener.redirectUri}?code=evil&state=wrong`);
+      expect(noise2.status).toBe(404);
+
+      const ok = await fetch(`${listener.redirectUri}?code=good-code&state=expected-state`);
+      expect(ok.status).toBe(200);
+      expect(await ok.text()).toContain("Signed in");
+      expect(await listener.waitForCode).toBe("good-code");
+    } finally {
+      listener.close();
+    }
+  });
+
+  test("rejects on an error callback", async () => {
+    const listener = await startLoopbackListener("st");
+    try {
+      // Attach a handler before triggering so the rejection is never
+      // momentarily unhandled (bun reports those as test errors).
+      const settled = listener.waitForCode.then(
+        () => null,
+        (err: Error) => err,
+      );
+      const res = await fetch(`${listener.redirectUri}?error=access_denied&state=st`);
+      expect(res.status).toBe(200);
+      const err = await settled;
+      expect(err?.message).toMatch(/access_denied/);
+    } finally {
+      listener.close();
+    }
+  });
+
+  test("close rejects pending waiters with the given reason", async () => {
+    const listener = await startLoopbackListener("st");
+    const settled = listener.waitForCode.then(
+      () => null,
+      (err: Error) => err,
+    );
+    listener.close("Sign-in timed out.");
+    const err = await settled;
+    expect(err?.message).toMatch(/timed out/);
+  });
+});
+
+describe("exchangeCodeWithWorkos", () => {
+  test("posts a public-client PKCE exchange and returns the access token", async () => {
+    fetchResponses["/user_management/authenticate"] = () =>
+      new Response(JSON.stringify({ access_token: "at_1", user: {} }), { status: 200 });
+
+    const token = await exchangeCodeWithWorkos({
+      clientId: "client_um",
+      code: "c",
+      verifier: "v",
+    });
+
+    expect(token).toBe("at_1");
+    const body = JSON.parse(String(fetchCalls[0]!.init?.body));
+    expect(body).toEqual({
+      client_id: "client_um",
+      grant_type: "authorization_code",
+      code: "c",
+      code_verifier: "v",
+    });
+  });
+
+  test("throws with upstream detail on failure", async () => {
+    fetchResponses["/user_management/authenticate"] = () =>
+      new Response(JSON.stringify({ error: "invalid_grant" }), { status: 400 });
+
+    await expect(
+      exchangeCodeWithWorkos({ clientId: "c", code: "x", verifier: "v" }),
+    ).rejects.toThrow(/400/);
+  });
+});
+
+describe("exchangeAccessTokenForSession", () => {
+  test("posts the headless token payload and returns the session token", async () => {
+    fetchResponses["/_allauth/app/v1/auth/provider/token"] = () =>
+      new Response(JSON.stringify({ meta: { session_token: "sess_1" } }), {
+        status: 200,
+      });
+
+    const token = await exchangeAccessTokenForSession(
+      "https://platform.example",
+      "client_um",
+      "at_1",
+    );
+
+    expect(token).toBe("sess_1");
+    expect(fetchCalls[0]!.url).toBe(
+      "https://platform.example/_allauth/app/v1/auth/provider/token",
+    );
+    const body = JSON.parse(String(fetchCalls[0]!.init?.body));
+    expect(body).toEqual({
+      provider: "workos",
+      process: "login",
+      token: { client_id: "client_um", access_token: "at_1" },
+    });
+  });
+
+  test("throws on a rejected token", async () => {
+    fetchResponses["/_allauth/app/v1/auth/provider/token"] = () =>
+      new Response(JSON.stringify({ errors: [{ code: "invalid_token" }] }), {
+        status: 400,
+      });
+
+    await expect(
+      exchangeAccessTokenForSession("https://platform.example", "c", "bad"),
+    ).rejects.toThrow(/400/);
+  });
+});

--- a/apps/macos/src/main/workos-pkce.ts
+++ b/apps/macos/src/main/workos-pkce.ts
@@ -1,0 +1,223 @@
+/**
+ * App-held PKCE login against WorkOS User Management (RFC 8252 loopback):
+ * authorize in the system browser, receive the code on an ephemeral
+ * 127.0.0.1 listener, exchange it as a public client, then swap the access
+ * token for a platform session token via allauth's headless token endpoint.
+ */
+
+import { net } from "electron";
+import crypto from "node:crypto";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+const WORKOS_API_BASE_URL = "https://api.workos.com";
+const PROVIDER_ID = "workos";
+const SCOPE = "openid profile email";
+
+export interface PkcePair {
+  verifier: string;
+  challenge: string;
+}
+
+export function generatePkcePair(): PkcePair {
+  const verifier = crypto.randomBytes(32).toString("base64url");
+  const challenge = crypto
+    .createHash("sha256")
+    .update(verifier)
+    .digest("base64url");
+  return { verifier, challenge };
+}
+
+export interface AuthorizeUrlOptions {
+  clientId: string;
+  redirectUri: string;
+  challenge: string;
+  state: string;
+  loginHint?: string;
+  providerHint?: string;
+  intent?: string;
+}
+
+export function buildAuthorizeUrl(options: AuthorizeUrlOptions): string {
+  const url = new URL("/user_management/authorize", WORKOS_API_BASE_URL);
+  url.searchParams.set("client_id", options.clientId);
+  url.searchParams.set("redirect_uri", options.redirectUri);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("scope", SCOPE);
+  url.searchParams.set("code_challenge", options.challenge);
+  url.searchParams.set("code_challenge_method", "S256");
+  url.searchParams.set("state", options.state);
+  // No `prompt`: lets the browser's existing IdP session be reused.
+  url.searchParams.set("provider", options.providerHint || "authkit");
+  if (options.loginHint) url.searchParams.set("login_hint", options.loginHint);
+  if (options.intent === "signup") url.searchParams.set("screen_hint", "sign-up");
+  return url.toString();
+}
+
+interface HeadlessProviderEntry {
+  id: string;
+  name?: string;
+  client_id?: string;
+  flows?: string[];
+  openid_configuration_url?: string;
+}
+
+/**
+ * Pick the first-class WorkOS OAuth2 provider out of the headless config.
+ *
+ * During the coexistence window the platform lists two entries
+ * with the same "workos-oidc" provider ID.
+ * The OAuth2 one is distinguished by having no OIDC discovery URL.
+ * Returns null when the platform doesn't support token auth yet - 
+ * callers should surface that as a clear error.
+ */
+export function selectWorkosClientId(
+  providers: HeadlessProviderEntry[],
+): string | null {
+  const entry = providers.find(
+    (p) =>
+      !p.openid_configuration_url &&
+      (p.flows ?? []).includes("provider_token") &&
+      typeof p.client_id === "string",
+  );
+  return entry?.client_id ?? null;
+}
+
+export async function fetchWorkosClientId(platformUrl: string): Promise<string> {
+  const url = `${new URL(platformUrl).origin}/_allauth/app/v1/config`;
+  const response = await net.fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch auth config (${response.status})`);
+  }
+  const body = (await response.json()) as {
+    data?: { socialaccount?: { providers?: HeadlessProviderEntry[] } };
+  };
+  const clientId = selectWorkosClientId(
+    body.data?.socialaccount?.providers ?? [],
+  );
+  if (!clientId) {
+    throw new Error(
+      "Platform does not advertise a token-auth WorkOS provider; cannot start PKCE login.",
+    );
+  }
+  return clientId;
+}
+
+// Mirrors the native apps' legacy deep-link path ({scheme}://auth/callback).
+const CALLBACK_PATH = "/auth/callback";
+
+const SUCCESS_HTML = `<!doctype html><html><head><meta charset="utf-8"><title>Signed in</title></head>
+<body style="font-family:system-ui;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">
+<p>Signed in — you can close this tab and return to Vellum.</p></body></html>`;
+
+const ERROR_HTML = `<!doctype html><html><head><meta charset="utf-8"><title>Sign-in failed</title></head>
+<body style="font-family:system-ui;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">
+<p>Sign-in failed — you can close this tab and try again from Vellum.</p></body></html>`;
+
+export interface LoopbackListener {
+  redirectUri: string;
+  /** Resolves with the authorization code once the browser hits the callback. */
+  waitForCode: Promise<string>;
+  close: (reason?: string) => void;
+}
+
+/** Bind an ephemeral loopback listener and wait for the OAuth redirect. */
+export function startLoopbackListener(expectedState: string): Promise<LoopbackListener> {
+  return new Promise((resolveListener, rejectListener) => {
+    let settle: { resolve: (code: string) => void; reject: (err: Error) => void };
+    const waitForCode = new Promise<string>((resolve, reject) => {
+      settle = { resolve, reject };
+    });
+
+    const server = http.createServer((req, res) => {
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      if (url.pathname !== CALLBACK_PATH || url.searchParams.get("state") !== expectedState) {
+        res.writeHead(404).end();
+        return;
+      }
+      const error = url.searchParams.get("error");
+      const code = url.searchParams.get("code");
+      if (error || !code) {
+        res.writeHead(200, { "Content-Type": "text/html" }).end(ERROR_HTML);
+        settle.reject(
+          new Error(`Authentication failed: ${error ?? "no authorization code received"}`),
+        );
+        return;
+      }
+      res.writeHead(200, { "Content-Type": "text/html" }).end(SUCCESS_HTML);
+      settle.resolve(code);
+    });
+
+    server.on("error", rejectListener);
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as AddressInfo;
+      resolveListener({
+        redirectUri: `http://127.0.0.1:${port}${CALLBACK_PATH}`,
+        waitForCode,
+        close: (reason?: string) => {
+          server.close();
+          settle.reject(new Error(reason ?? "Auth flow cancelled."));
+        },
+      });
+    });
+  });
+}
+
+/** Exchange the authorization code at WorkOS as a public client. */
+export async function exchangeCodeWithWorkos(options: {
+  clientId: string;
+  code: string;
+  verifier: string;
+}): Promise<string> {
+  const response = await net.fetch(
+    `${WORKOS_API_BASE_URL}/user_management/authenticate`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        client_id: options.clientId,
+        grant_type: "authorization_code",
+        code: options.code,
+        code_verifier: options.verifier,
+      }),
+    },
+  );
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`WorkOS code exchange failed (${response.status}): ${body}`);
+  }
+  const data = (await response.json()) as { access_token?: string };
+  if (!data.access_token) {
+    throw new Error("WorkOS code exchange returned no access token.");
+  }
+  return data.access_token;
+}
+
+/** Exchange the WorkOS access token for a platform session token. */
+export async function exchangeAccessTokenForSession(
+  platformUrl: string,
+  clientId: string,
+  accessToken: string,
+): Promise<string> {
+  const url = `${new URL(platformUrl).origin}/_allauth/app/v1/auth/provider/token`;
+  const response = await net.fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      provider: PROVIDER_ID,
+      process: "login",
+      token: { client_id: clientId, access_token: accessToken },
+    }),
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Session exchange failed (${response.status}): ${body}`);
+  }
+  const data = (await response.json()) as {
+    meta?: { session_token?: string };
+  };
+  if (!data.meta?.session_token) {
+    throw new Error("Session exchange returned no session token.");
+  }
+  return data.meta.session_token;
+}


### PR DESCRIPTION
RFC 8252 loopback PKCE for platform login, module only (no wire-up — that follows in a stacked PR; `startOAuth` still uses the legacy flow).

- S256 PKCE + authorize URL against `user_management/authorize` (hints supported; no `prompt`, so existing IdP sessions are reused)
- Ephemeral `127.0.0.1` listener at `/auth/callback` (registered in WorkOS as `http://127.0.0.1:*/auth/callback`); only a state-matched callback settles — any local process can connect, so the state check is load-bearing
- Public-client code exchange (no secret), then access-token → session-token via `/_allauth/app/v1/auth/provider/token`
- Client id discovered from `/_allauth/app/v1/config` (app variant lists only token-auth providers); selector disambiguates the coexistence window where two entries share the `workos-oidc` id, and fails clearly against servers without token auth

17 tests incl. a real loopback round-trip. Requires platform PR #8401 deployed to be usable; verified e2e against it locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)