### PR TITLE
feat(macos): add --environment and --open flags to pack.sh, default env to local

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1903,9 +1903,8 @@ jobs:
 
       - name: Build and package Electron app
         env:
-          VELLUM_ENVIRONMENT: dev
           CSC_NAME: Developer ID Application
-        run: bun run pack
+        run: bun run pack --environment dev
 
       - name: Rename DMG for release
         id: dmg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2808,9 +2808,8 @@ jobs:
 
       - name: Build and package Electron app
         env:
-          VELLUM_ENVIRONMENT: ${{ needs.extract-version.outputs.is_staging == 'true' && 'staging' || 'production' }}
           CSC_NAME: Developer ID Application
-        run: bun run pack
+        run: bun run pack --environment "${{ needs.extract-version.outputs.is_staging == 'true' && 'staging' || 'production' }}"
 
       - name: Rename DMG for release
         id: dmg

--- a/apps/macos/electron-builder.config.cjs
+++ b/apps/macos/electron-builder.config.cjs
@@ -1,6 +1,6 @@
 // @ts-check
 
-const env = process.env.VELLUM_ENVIRONMENT || "production";
+const env = process.env.VELLUM_ENVIRONMENT || "local";
 const bucketEnv = env === "production" ? "prod" : env;
 const targetArch = process.env.ELECTRON_TARGET_ARCH || "arm64";
 

--- a/apps/macos/electron.vite.config.ts
+++ b/apps/macos/electron.vite.config.ts
@@ -47,7 +47,7 @@ const resolveBuildSha = (): string => {
 const BUILD_DEFINES = {
   __VELLUM_BUILD_SHA__: JSON.stringify(resolveBuildSha()),
   __VELLUM_ENVIRONMENT__: JSON.stringify(
-    process.env.VELLUM_ENVIRONMENT || "production",
+    process.env.VELLUM_ENVIRONMENT || "local",
   ),
   __VELLUM_ENABLE_CHROME_DEVTOOLS__: JSON.stringify(
     process.env.VELLUM_ENABLE_CHROME_DEVTOOLS === "true" ||

--- a/apps/macos/scripts/dev.ts
+++ b/apps/macos/scripts/dev.ts
@@ -53,14 +53,12 @@ async function isVelUp(): Promise<boolean> {
 const velRunning = await isVelUp();
 const downstreamScript = velRunning ? "dev:electron-only" : "dev:standalone";
 
-// Match the native Swift app's default of "local" when vel up is running.
-const env: NodeJS.ProcessEnv = velRunning
-  ? {
-      ...process.env,
-      VELLUM_DEV_URL: VEL_RENDERER_URL,
-      VELLUM_ENVIRONMENT: process.env.VELLUM_ENVIRONMENT || "local",
-    }
-  : process.env;
+// Match the native Swift app's default of "local".
+const env: NodeJS.ProcessEnv = {
+  ...process.env,
+  VELLUM_ENVIRONMENT: process.env.VELLUM_ENVIRONMENT || "local",
+  ...(velRunning ? { VELLUM_DEV_URL: VEL_RENDERER_URL } : {}),
+};
 
 if (velRunning) {
   console.log(

--- a/apps/macos/scripts/generate-icon.sh
+++ b/apps/macos/scripts/generate-icon.sh
@@ -2,14 +2,14 @@
 set -euo pipefail
 
 # Generate a per-environment AppIcon.icns for the Electron build.
-# Reads VELLUM_ENVIRONMENT (default: dev) and renders the matching icon from
+# Reads VELLUM_ENVIRONMENT (default: local) and renders the matching icon from
 # clients/macos/build-resources/icons/{env}/ into build/icon.icns.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_ROOT="$(cd "$APP_DIR/../.." && pwd)"
 
-VELLUM_ENVIRONMENT="${VELLUM_ENVIRONMENT:-dev}"
+VELLUM_ENVIRONMENT="${VELLUM_ENVIRONMENT:-local}"
 ICONS_DIR="$REPO_ROOT/clients/macos/build-resources/icons"
 
 if [ -d "$ICONS_DIR/$VELLUM_ENVIRONMENT" ]; then

--- a/apps/macos/scripts/pack.sh
+++ b/apps/macos/scripts/pack.sh
@@ -1,16 +1,25 @@
 #!/usr/bin/env bash
 # pack.sh — Build and package the Electron app for the target architecture.
-#
-# Reads ELECTRON_TARGET_ARCH (arm64 | x64, default arm64) and maps it to
-# the correct --arch value for fetch-bun.sh.
-#
-# Flags:
-#   --environment, --env <name>  Set VELLUM_ENVIRONMENT (default: local)
-#   --open                       Launch the built .app when done
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+usage() {
+  cat <<'EOF'
+Usage: pack.sh [flags]
+
+Build and package the Electron app for the target architecture.
+
+Flags:
+  --environment, --env <name>  Set VELLUM_ENVIRONMENT (default: local)
+  --open                       Launch the built .app when done
+  --help, -h                   Show this help
+
+Environment:
+  ELECTRON_TARGET_ARCH         arm64 | x64 (default: arm64)
+EOF
+}
 
 OPEN_AFTER_BUILD=false
 while [ $# -gt 0 ]; do
@@ -28,8 +37,13 @@ while [ $# -gt 0 ]; do
       OPEN_AFTER_BUILD=true
       shift
       ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
     *)
       echo "ERROR: unknown argument: $1" >&2
+      usage >&2
       exit 1
       ;;
   esac

--- a/apps/macos/scripts/pack.sh
+++ b/apps/macos/scripts/pack.sh
@@ -3,10 +3,39 @@
 #
 # Reads ELECTRON_TARGET_ARCH (arm64 | x64, default arm64) and maps it to
 # the correct --arch value for fetch-bun.sh.
+#
+# Flags:
+#   --environment, --env <name>  Set VELLUM_ENVIRONMENT (default: local)
+#   --open                       Launch the built .app when done
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+OPEN_AFTER_BUILD=false
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --environment|--env)
+      [ $# -ge 2 ] || { echo "ERROR: $1 requires a value" >&2; exit 1; }
+      export VELLUM_ENVIRONMENT="$2"
+      shift 2
+      ;;
+    --environment=*|--env=*)
+      export VELLUM_ENVIRONMENT="${1#*=}"
+      shift
+      ;;
+    --open)
+      OPEN_AFTER_BUILD=true
+      shift
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+export VELLUM_ENVIRONMENT="${VELLUM_ENVIRONMENT:-local}"
 
 ARCH="${ELECTRON_TARGET_ARCH:-arm64}"
 case "$ARCH" in
@@ -27,3 +56,15 @@ bun run build:web
 bash scripts/generate-cli-lockfile.sh
 electron-vite build
 electron-builder --config electron-builder.config.cjs --publish always
+
+if [ "$OPEN_AFTER_BUILD" = true ]; then
+  # Newest .app wins — dist/ may hold stale apps from prior envs.
+  APP_PATH="$(ls -dt "$APP_DIR"/dist/mac*/*.app 2>/dev/null | head -n 1 || true)"
+  if [ -n "$APP_PATH" ]; then
+    echo "Launching $APP_PATH"
+    open "$APP_PATH"
+  else
+    echo "ERROR: no .app found under $APP_DIR/dist" >&2
+    exit 1
+  fi
+fi


### PR DESCRIPTION
## Summary

- `apps/macos/scripts/pack.sh` now accepts flags:
  - `--environment` / `--env <name>` — sets `VELLUM_ENVIRONMENT` for the whole pack pipeline (icon generation, the compiled-in `__VELLUM_ENVIRONMENT__` define, and the electron-builder config)
  - `--open` — launches the built `.app` after packaging (picks the newest `.app` under `dist/`, since stale apps from prior envs can coexist there)
  - `--help` / `-h` — prints usage; unknown args now print usage to stderr too
- **`local` is now the default environment for all dev/build entry points.** Previously the defaults were scattered and inconsistent (`electron-builder.config.cjs` and `electron.vite.config.ts` defaulted to `production`, `generate-icon.sh` to `dev`, `scripts/dev.ts` only defaulted when vel up was detected). Now `pack.sh`, `dev.ts` (both vel-up and standalone paths), `electron.vite.config.ts`, `electron-builder.config.cjs`, and `generate-icon.sh` all agree on `local` when `VELLUM_ENVIRONMENT` is unset.
- **Runtime fallbacks intentionally stay `production`** (`about.ts`, `auto-update.ts`, `resolveEnvironmentName` in `packages/local-mode`): in any real build the compile-time define exists, and the safe failure mode for a packaged app is to behave as production — especially `auto-update.ts`, which derives its update bucket from it. `resolveEnvironmentName` is also shared with the CLI and runs on end-user machines.
- The release workflows now pass the environment explicitly via the flag (`--environment dev` in `dev-release.yaml`, the staging/production expression in `release.yml`) instead of a step-level env var, so CI is unaffected by the new local default.

This makes the local dev loop a one-liner for a proper packaged app with no hot reload:

```bash
bun run pack:debug --open
```

## Test plan

- `bunx tsc --noEmit` clean; `bash -n` on both shell scripts; `electron-builder.config.cjs` loads under node
- Verified flag error paths: unknown flags and valueless `--env` exit 1 with usage; `--help`/`-h` exit 0
- Verified `clients/macos/build-resources/icons/local/` exists so the default env gets the correct icon
- Full `bun run pack:debug` exercised locally (dist/ contains a fresh `Vellum Local` build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
