### PR TITLE
feat(macos): wire login to app-held PKCE

### DIFF
--- a/apps/macos/src/main/native-auth.test.ts
+++ b/apps/macos/src/main/native-auth.test.ts
@@ -28,12 +28,37 @@ const cookieRemoveCalls: Array<{ url: string; name: string }> = [];
 mock.module("electron", () => ({
   app: { getVersion: () => "9.9.9", getPath: () => "/tmp" },
   net: {
-    fetch: () =>
-      Promise.resolve(
-        new Response(JSON.stringify({ session_token: "sess-tok-123" }), {
-          status: 200,
-        }),
-      ),
+    // Routed by URL: serves the real workos-pkce module's three network
+    // legs (config discovery, WorkOS code exchange, session exchange) and
+    // the legacy /accounts/native/exchange.
+    fetch: (url: string) => {
+      let body: unknown;
+      if (url.includes("/_allauth/app/v1/config")) {
+        body = {
+          data: {
+            socialaccount: {
+              providers: [
+                {
+                  id: "workos-oidc",
+                  name: "WorkOS",
+                  client_id: "client_um_test",
+                  flows: ["provider_redirect", "provider_token"],
+                },
+              ],
+            },
+          },
+        };
+      } else if (url.includes("/user_management/authenticate")) {
+        body = { access_token: "access-token-abc", user: {} };
+      } else if (url.includes("/_allauth/app/v1/auth/provider/token")) {
+        body = { meta: { session_token: "sess-tok-123" } };
+      } else {
+        body = { session_token: "sess-tok-123" };
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify(body), { status: 200 }),
+      );
+    },
   },
   session: {
     defaultSession: {
@@ -139,7 +164,7 @@ describe("buildStartUrl", () => {
 });
 
 describe("installNativeAuth — session-token wiring", () => {
-  test("persists the exchanged token on successful login", async () => {
+  test("persists the exchanged token on successful PKCE login", async () => {
     installNativeAuth();
 
     const startOAuth = ipcHandlers["vellum:auth:startOAuth"];
@@ -147,16 +172,31 @@ describe("installNativeAuth — session-token wiring", () => {
 
     const pending = startOAuth([{}]) as Promise<{ sessionToken: string }>;
 
-    // openExternal ran synchronously in the flow's executor, so the start URL
-    // (with the state) is already captured.
-    const state = new URL(lastOpenedUrl).searchParams.get("state");
-    expect(state).toBeTruthy();
+    // Wait for the async setup (config fetch + listener bind) to open the
+    // browser at the WorkOS authorize URL.
+    while (!lastOpenedUrl) await Bun.sleep(1);
+    const opened = new URL(lastOpenedUrl);
+    expect(opened.pathname).toBe("/user_management/authorize");
+    expect(opened.searchParams.get("client_id")).toBe("client_um_test");
+    expect(opened.searchParams.get("code_challenge_method")).toBe("S256");
 
-    await handleAuthCallback(state!, "auth-code-xyz");
+    // Play the browser: hit the real loopback listener with the code.
+    const redirectUri = opened.searchParams.get("redirect_uri")!;
+    const state = opened.searchParams.get("state")!;
+    expect(redirectUri).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/auth\/callback$/);
+    const res = await fetch(`${redirectUri}?code=auth-code-xyz&state=${state}`);
+    expect(res.status).toBe(200);
+
     const result = await pending;
-
     expect(result.sessionToken).toBe("sess-tok-123");
     expect(store.saved).toContain("sess-tok-123");
+  });
+
+  test("legacy deep-link callbacks are ignored by the PKCE flow", async () => {
+    installNativeAuth();
+    // No pending legacy flow exists; a stray deep link must be a no-op.
+    await handleAuthCallback("unknown-state", "auth-code-xyz");
+    expect(store.saved).toHaveLength(0);
   });
 
   test("evicts both legacy session cookies on install", () => {

--- a/apps/macos/src/main/native-auth.ts
+++ b/apps/macos/src/main/native-auth.ts
@@ -1,4 +1,4 @@
-import { app, net, session, shell } from "electron";
+import { net, session, shell } from "electron";
 import crypto from "node:crypto";
 import { z } from "zod";
 
@@ -10,6 +10,14 @@ import {
     getSessionToken,
     saveSessionToken,
 } from "./session-token-store";
+import {
+    buildAuthorizeUrl,
+    exchangeAccessTokenForSession,
+    exchangeCodeWithWorkos,
+    fetchWorkosClientId,
+    generatePkcePair,
+    startLoopbackListener,
+} from "./workos-pkce";
 
 const AUTH_FLOW_TIMEOUT_MS = 5 * 60_000;
 
@@ -94,35 +102,64 @@ function resolveProxyPlatformUrl(): string {
   return resolveLocalConfigFromEnv(process.env).platformUrl;
 }
 
+let activePkceCancel: ((reason?: string) => void) | null = null;
+
+/**
+ * App-held PKCE login (workos-pkce.ts). Replaces the server-mediated flow
+ * (`/accounts/native/start` → deep link → `/accounts/native/exchange`);
+ * older builds keep using those legacy endpoints.
+ */
 async function startOAuth(options: {
   providerHint?: string;
   loginHint?: string;
   intent?: string;
 }): Promise<{ sessionToken: string }> {
   cancelPendingFlows();
+  activePkceCancel?.();
 
+  const platformUrl = resolveProxyPlatformUrl();
+  const clientId = await fetchWorkosClientId(platformUrl);
   const state = generateState();
-  const authPlatformUrl = resolveAuthPlatformUrl();
-  const clientVersion = app.getVersion();
+  const { verifier, challenge } = generatePkcePair();
+  const listener = await startLoopbackListener(state);
 
-  const url = buildStartUrl(authPlatformUrl, state, {
-    providerHint: options.providerHint,
-    loginHint: options.loginHint,
-    clientVersion,
-  });
+  const timer = setTimeout(
+    () => listener.close("Sign-in timed out. Please try again."),
+    AUTH_FLOW_TIMEOUT_MS,
+  );
+  activePkceCancel = listener.close;
 
-  const sessionToken = await new Promise<string>((resolve, reject) => {
-    const timer = setTimeout(() => {
-      pendingFlows.delete(state);
-      reject(new Error("Sign-in timed out. Please try again."));
-    }, AUTH_FLOW_TIMEOUT_MS);
+  try {
+    const authorizeUrl = buildAuthorizeUrl({
+      clientId,
+      redirectUri: listener.redirectUri,
+      challenge,
+      state,
+      loginHint: options.loginHint,
+      providerHint: options.providerHint,
+      intent: options.intent,
+    });
+    void shell.openExternal(authorizeUrl);
 
-    pendingFlows.set(state, { resolve, reject, timer });
-    void shell.openExternal(url);
-  });
+    const code = await listener.waitForCode;
+    const accessToken = await exchangeCodeWithWorkos({
+      clientId,
+      code,
+      verifier,
+    });
+    const sessionToken = await exchangeAccessTokenForSession(
+      platformUrl,
+      clientId,
+      accessToken,
+    );
 
-  saveSessionToken(sessionToken);
-  return { sessionToken };
+    saveSessionToken(sessionToken);
+    return { sessionToken };
+  } finally {
+    clearTimeout(timer);
+    listener.close();
+    activePkceCancel = null;
+  }
 }
 
 export async function handleAuthCallback(
@@ -180,6 +217,7 @@ export const installNativeAuth = (): void => {
 
   handle("vellum:auth:cancelOAuth", z.tuple([]), () => {
     cancelPendingFlows();
+    activePkceCancel?.();
   });
 
   handle("vellum:auth:signOut", z.tuple([]), () => {


### PR DESCRIPTION
Wires `startOAuth` to the loopback PKCE module (merged in #34654), replacing the server-mediated native flow.

- `startOAuth` runs PKCE in the main process: discover client id → authorize in system browser → loopback code → public-client exchange → session-token swap. IPC contract unchanged, so the renderer is untouched; cancel and the 5-min timeout close the listener.
- Legacy deep-link path (`handleAuthCallback`/`buildStartUrl`/`exchangeCode`) kept for older builds — now dead for flows this build starts (a stray deep link finds no pending flow). Removal rides the platform's legacy-endpoint EOL.

Requires platform #8401 deployed to be usable; verified e2e locally. Tests: 27 pass (native-auth + workos-pkce), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)