### PR TITLE
refactor(macos): remove legacy native-auth path

### DIFF
--- a/apps/macos/src/main/deep-links.test.ts
+++ b/apps/macos/src/main/deep-links.test.ts
@@ -67,12 +67,6 @@ mock.module("./main-window", () => ({
   ensureVisible: ensureMainWindowVisibleMock,
 }));
 
-// `./native-auth` is called from `handleDeepLink` for auth callbacks.
-const handleAuthCallbackMock = mock(async () => undefined);
-mock.module("./native-auth", () => ({
-  handleAuthCallback: handleAuthCallbackMock,
-}));
-
 const {
   __resetForTesting,
   extractDeepLinkFromArgv,
@@ -108,7 +102,6 @@ beforeEach(() => {
   ipcHandleMock.mockClear();
   ipcOnMock.mockClear();
   ensureMainWindowVisibleMock.mockClear();
-  handleAuthCallbackMock.mockClear();
   windows = [];
   appIsReady = true;
 });
@@ -199,50 +192,6 @@ describe("parseVellumUrl", () => {
     expect(parseVellumUrl("vellum://garbage")).toEqual({
       kind: "unknown",
       url: "vellum://garbage",
-    });
-  });
-
-  test("vellum-assistant://auth/callback?code=abc&state=xyz → authCallback", () => {
-    expect(
-      parseVellumUrl("vellum-assistant://auth/callback?code=abc&state=xyz"),
-    ).toEqual({
-      kind: "authCallback",
-      state: "xyz",
-      code: "abc",
-      error: undefined,
-    });
-  });
-
-  test("auth callback with error and no code", () => {
-    expect(
-      parseVellumUrl(
-        "vellum-assistant://auth/callback?state=xyz&error=signup_closed",
-      ),
-    ).toEqual({
-      kind: "authCallback",
-      state: "xyz",
-      code: undefined,
-      error: "signup_closed",
-    });
-  });
-
-  test("auth callback without state → unknown", () => {
-    expect(
-      parseVellumUrl("vellum-assistant://auth/callback?code=abc"),
-    ).toEqual({
-      kind: "unknown",
-      url: "vellum-assistant://auth/callback?code=abc",
-    });
-  });
-
-  test("auth callback works with vellum:// scheme too", () => {
-    expect(
-      parseVellumUrl("vellum://auth/callback?code=abc&state=xyz"),
-    ).toEqual({
-      kind: "authCallback",
-      state: "xyz",
-      code: "abc",
-      error: undefined,
     });
   });
 
@@ -612,45 +561,5 @@ describe("resolveAcceptedSchemes", () => {
     expect(accepted).toContain("vellum-assistant:");
     expect(accepted).toContain("vellum-assistant-local:");
     expect(accepted).toHaveLength(3);
-  });
-});
-
-describe("handleDeepLink — auth callback", () => {
-  test("routes auth callbacks to native-auth instead of broadcasting", () => {
-    const w = makeWindow();
-    windows = [w];
-
-    handleDeepLink("vellum-assistant://auth/callback?code=abc&state=xyz");
-
-    expect(handleAuthCallbackMock).toHaveBeenCalledWith("xyz", "abc", undefined);
-    expect(w.webContents.send).not.toHaveBeenCalled();
-  });
-
-  test("auth callbacks with errors are forwarded to native-auth", () => {
-    handleDeepLink(
-      "vellum-assistant://auth/callback?state=xyz&error=signup_closed",
-    );
-
-    expect(handleAuthCallbackMock).toHaveBeenCalledWith(
-      "xyz",
-      undefined,
-      "signup_closed",
-    );
-  });
-
-  test("auth callbacks bring the main window forward", () => {
-    handleDeepLink("vellum-assistant://auth/callback?code=abc&state=xyz");
-    expect(ensureMainWindowVisibleMock).toHaveBeenCalledTimes(1);
-  });
-
-  test("auth callbacks are not buffered for the renderer", () => {
-    installDeepLinks();
-    const drainHandler = ipcHandleMock.mock.calls.find(
-      (c) => c[0] === "vellum:deepLinks:drain",
-    )![1] as (event: unknown) => unknown[];
-
-    handleDeepLink("vellum-assistant://auth/callback?code=abc&state=xyz");
-
-    expect(drainHandler(allowedEvent)).toEqual([]);
   });
 });

--- a/apps/macos/src/main/deep-links.test.ts
+++ b/apps/macos/src/main/deep-links.test.ts
@@ -195,6 +195,17 @@ describe("parseVellumUrl", () => {
     });
   });
 
+  test("legacy auth/callback → unknown with query stripped (no code leak)", () => {
+    // The legacy code must not survive into the URL the renderer logs as
+    // a `deeplink.unknown` Sentry breadcrumb.
+    expect(
+      parseVellumUrl("vellum://auth/callback?code=secret&state=xyz"),
+    ).toEqual({ kind: "unknown", url: "vellum://auth/callback" });
+    expect(
+      parseVellumUrl("vellum-assistant://auth/callback?code=secret"),
+    ).toEqual({ kind: "unknown", url: "vellum-assistant://auth/callback" });
+  });
+
   test("env-specific scheme for a foreign environment is rejected as unknown", () => {
     // A scheme that doesn't match any known environment is always
     // rejected, regardless of which env this test suite runs under.

--- a/apps/macos/src/main/deep-links.ts
+++ b/apps/macos/src/main/deep-links.ts
@@ -6,7 +6,6 @@ import { resolveEnvironmentName } from "@vellumai/local-mode";
 
 import { handle, on } from "./ipc";
 import { ensureVisible as ensureMainWindowVisible } from "./main-window";
-import { handleAuthCallback } from "./native-auth";
 
 /**
  * Inbound deep links — `vellum://` and `vellum-assistant://` URL
@@ -49,15 +48,6 @@ import { handleAuthCallback } from "./native-auth";
  *   - https://www.electronjs.org/docs/latest/api/app#event-will-finish-launching
  *   - https://www.electronjs.org/docs/latest/api/app#appsetasdefaultprotocolclientprotocol-path-args
  */
-
-/**
- * Superset of the shared `DeepLink` — adds `authCallback`, which is
- * intercepted in main before reaching the bridge and therefore absent
- * from the contract's renderer-visible union.
- */
-export type MainDeepLink =
-  | DeepLink
-  | { kind: "authCallback"; state: string; code?: string; error?: string };
 
 export type { DeepLink };
 
@@ -107,7 +97,7 @@ const ACCEPTED_SCHEMES = resolveAcceptedSchemes(currentEnv);
  *   - Malformed URL (unparseable, percent-encoding throws) →
  *     `kind: "unknown"`.
  */
-export const parseVellumUrl = (input: string): MainDeepLink => {
+export const parseVellumUrl = (input: string): DeepLink => {
   let url: URL;
   try {
     url = new URL(input);
@@ -124,13 +114,6 @@ export const parseVellumUrl = (input: string): MainDeepLink => {
     const threadId = url.pathname.replace(/^\/+/, "").split("/")[0] ?? "";
     if (threadId) return { kind: "openThread", threadId };
     return { kind: "unknown", url: input };
-  }
-  if (url.host === "auth" && url.pathname.startsWith("/callback")) {
-    const state = url.searchParams.get("state");
-    if (!state) return { kind: "unknown", url: input };
-    const code = url.searchParams.get("code") ?? undefined;
-    const error = url.searchParams.get("error") ?? undefined;
-    return { kind: "authCallback", state, code, error };
   }
   return { kind: "unknown", url: input };
 };
@@ -200,20 +183,7 @@ const broadcast = (link: DeepLink): void => {
  * on an already-visible main window.
  */
 export const handleDeepLink = (input: string): void => {
-  const parsed = parseVellumUrl(input);
-
-  // Auth callbacks are a main-process concern — the renderer doesn't
-  // need to see them. Route directly to the native-auth module and
-  // bring the window forward so the user sees the result.
-  if (parsed.kind === "authCallback") {
-    void handleAuthCallback(parsed.state, parsed.code, parsed.error);
-    if (app.isReady()) void ensureMainWindowVisible();
-    return;
-  }
-
-  // After filtering out authCallback, the remaining variants satisfy
-  // the renderer-visible DeepLink union.
-  const link: DeepLink = parsed;
+  const link = parseVellumUrl(input);
 
   if (subscribers.size === 0) pending.push(link);
   broadcast(link);

--- a/apps/macos/src/main/deep-links.ts
+++ b/apps/macos/src/main/deep-links.ts
@@ -115,6 +115,11 @@ export const parseVellumUrl = (input: string): DeepLink => {
     if (threadId) return { kind: "openThread", threadId };
     return { kind: "unknown", url: input };
   }
+  if (url.host === "auth" && url.pathname.startsWith("/callback")) {
+    // The deprecated `/accounts/native/*` flow returns its auth code here.
+    // Strip the sensitive code from the query so it doesn't get captured downstream.
+    return { kind: "unknown", url: `${url.protocol}//${url.host}${url.pathname}` };
+  }
   return { kind: "unknown", url: input };
 };
 

--- a/apps/macos/src/main/native-auth.test.ts
+++ b/apps/macos/src/main/native-auth.test.ts
@@ -101,13 +101,9 @@ mock.module("./session-token-store", () => ({
   getSessionToken: () => store.saved.at(-1) ?? null,
 }));
 
-const {
-  buildStartUrl,
-  generateState,
-  handleAuthCallback,
-  installNativeAuth,
-  __resetForTesting,
-} = await import("./native-auth");
+const { generateState, installNativeAuth, __resetForTesting } = await import(
+  "./native-auth"
+);
 
 afterEach(() => {
   __resetForTesting();
@@ -130,36 +126,6 @@ describe("generateState", () => {
     const a = generateState();
     const b = generateState();
     expect(a).not.toBe(b);
-  });
-});
-
-describe("buildStartUrl", () => {
-  test("builds URL with required state param", () => {
-    const url = buildStartUrl("https://platform.vellum.ai", "abc123", {});
-    expect(url).toBe(
-      "https://platform.vellum.ai/accounts/native/start?state=abc123",
-    );
-  });
-
-  test("includes optional params when provided", () => {
-    const url = buildStartUrl("https://platform.vellum.ai", "abc123", {
-      providerHint: "GoogleOAuth",
-      loginHint: "user@example.com",
-      clientVersion: "1.0.0",
-    });
-    const parsed = new URL(url);
-    expect(parsed.searchParams.get("state")).toBe("abc123");
-    expect(parsed.searchParams.get("provider_hint")).toBe("GoogleOAuth");
-    expect(parsed.searchParams.get("login_hint")).toBe("user@example.com");
-    expect(parsed.searchParams.get("client_version")).toBe("1.0.0");
-  });
-
-  test("omits optional params when not provided", () => {
-    const url = buildStartUrl("https://platform.vellum.ai", "abc123", {});
-    const parsed = new URL(url);
-    expect(parsed.searchParams.has("provider_hint")).toBe(false);
-    expect(parsed.searchParams.has("login_hint")).toBe(false);
-    expect(parsed.searchParams.has("client_version")).toBe(false);
   });
 });
 
@@ -190,13 +156,6 @@ describe("installNativeAuth — session-token wiring", () => {
     const result = await pending;
     expect(result.sessionToken).toBe("sess-tok-123");
     expect(store.saved).toContain("sess-tok-123");
-  });
-
-  test("legacy deep-link callbacks are ignored by the PKCE flow", async () => {
-    installNativeAuth();
-    // No pending legacy flow exists; a stray deep link must be a no-op.
-    await handleAuthCallback("unknown-state", "auth-code-xyz");
-    expect(store.saved).toHaveLength(0);
   });
 
   test("evicts both legacy session cookies on install", () => {

--- a/apps/macos/src/main/native-auth.ts
+++ b/apps/macos/src/main/native-auth.ts
@@ -1,4 +1,4 @@
-import { net, session, shell } from "electron";
+import { session, shell } from "electron";
 import crypto from "node:crypto";
 import { z } from "zod";
 
@@ -21,51 +21,8 @@ import {
 
 const AUTH_FLOW_TIMEOUT_MS = 5 * 60_000;
 
-interface PendingFlow {
-  resolve: (sessionToken: string) => void;
-  reject: (err: Error) => void;
-  timer: ReturnType<typeof setTimeout>;
-}
-
-const pendingFlows = new Map<string, PendingFlow>();
-
 export function generateState(): string {
   return crypto.randomBytes(32).toString("base64url");
-}
-
-export function buildStartUrl(
-  platformUrl: string,
-  state: string,
-  options: {
-    providerHint?: string;
-    loginHint?: string;
-    clientVersion?: string;
-  },
-): string {
-  const url = new URL("/accounts/native/start", platformUrl);
-  url.searchParams.set("state", state);
-  if (options.providerHint) url.searchParams.set("provider_hint", options.providerHint);
-  if (options.loginHint) url.searchParams.set("login_hint", options.loginHint);
-  if (options.clientVersion) url.searchParams.set("client_version", options.clientVersion);
-  return url.toString();
-}
-
-async function exchangeCode(
-  platformUrl: string,
-  code: string,
-): Promise<string> {
-  const url = `${new URL(platformUrl).origin}/accounts/native/exchange`;
-  const response = await net.fetch(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ code }),
-  });
-  if (!response.ok) {
-    const body = await response.text();
-    throw new Error(`Code exchange failed (${response.status}): ${body}`);
-  }
-  const data = (await response.json()) as { session_token: string };
-  return data.session_token;
 }
 
 // Evict the session cookies installed by prior builds, so that
@@ -80,23 +37,6 @@ async function clearLegacySessionCookies(): Promise<void> {
   );
 }
 
-function cancelPendingFlows(): void {
-  for (const flow of pendingFlows.values()) {
-    clearTimeout(flow.timer);
-    flow.reject(new Error("Auth flow cancelled — a new flow was started."));
-  }
-  pendingFlows.clear();
-}
-
-// The OAuth start/exchange endpoints must go through the web origin (not
-// the platform origin) because WorkOS redirect URIs are registered against
-// the web domain (e.g. dev-assistant.vellum.ai, localhost:3000). The web
-// server proxies /accounts/* to Django, so Django sees the web host and
-// builds a matching callback URL.
-function resolveAuthPlatformUrl(): string {
-  return resolveLocalConfigFromEnv(process.env).webUrl;
-}
-
 // The platform URL the renderer's proxy talks to.
 function resolveProxyPlatformUrl(): string {
   return resolveLocalConfigFromEnv(process.env).platformUrl;
@@ -105,16 +45,14 @@ function resolveProxyPlatformUrl(): string {
 let activePkceCancel: ((reason?: string) => void) | null = null;
 
 /**
- * App-held PKCE login (workos-pkce.ts). Replaces the server-mediated flow
- * (`/accounts/native/start` → deep link → `/accounts/native/exchange`);
- * older builds keep using those legacy endpoints.
+ * App-held PKCE login (workos-pkce.ts). Drives the WorkOS OAuth flow in
+ * the main process; the renderer is uninvolved beyond the IPC result.
  */
 async function startOAuth(options: {
   providerHint?: string;
   loginHint?: string;
   intent?: string;
 }): Promise<{ sessionToken: string }> {
-  cancelPendingFlows();
   activePkceCancel?.();
 
   const platformUrl = resolveProxyPlatformUrl();
@@ -162,35 +100,6 @@ async function startOAuth(options: {
   }
 }
 
-export async function handleAuthCallback(
-  state: string,
-  code?: string,
-  error?: string,
-): Promise<void> {
-  const flow = pendingFlows.get(state);
-  if (!flow) return;
-
-  pendingFlows.delete(state);
-  clearTimeout(flow.timer);
-
-  if (error) {
-    flow.reject(new Error(`Authentication failed: ${error}`));
-    return;
-  }
-
-  if (!code) {
-    flow.reject(new Error("Authentication failed: no authorization code received."));
-    return;
-  }
-
-  try {
-    const sessionToken = await exchangeCode(resolveAuthPlatformUrl(), code);
-    flow.resolve(sessionToken);
-  } catch (err) {
-    flow.reject(err instanceof Error ? err : new Error(String(err)));
-  }
-}
-
 const startOAuthSchema = z.tuple([
   z.object({
     providerHint: z.string().optional(),
@@ -216,7 +125,6 @@ export const installNativeAuth = (): void => {
   );
 
   handle("vellum:auth:cancelOAuth", z.tuple([]), () => {
-    cancelPendingFlows();
     activePkceCancel?.();
   });
 
@@ -229,5 +137,5 @@ export const installNativeAuth = (): void => {
 
 export const __resetForTesting = (): void => {
   installed = false;
-  cancelPendingFlows();
+  activePkceCancel?.();
 };


### PR DESCRIPTION
ref: ATL-842

Now that Electron login runs app-held PKCE (#34659), the server-mediated native flow's client code is dead in the build and can go. It was never a backwards-compat shim — `native-auth.ts` is bundled per Electron build, so old builds run their own copy; this code was kept only to keep the wire-up PR scoped.

Two bisectable commits:
1. **deep-links**: drop the `vellum://auth/callback` parse branch, `MainDeepLink` superset type, and the routing to native-auth. A stray such link now parses to `unknown` and is ignored.
2. **native-auth**: delete `buildStartUrl`, `exchangeCode`, `handleAuthCallback`, the `pendingFlows` bookkeeping, and `resolveAuthPlatformUrl`; cancellation collapses to the single PKCE listener. `generateState` stays (PKCE uses it).

Net −263 lines. Each commit typechecks independently.

Not touched (gated on old native builds aging out): the server `/accounts/native/*` endpoints, which old builds still call.

Tests: native-auth (6), workos-pkce (17), deep-links (43) all pass in isolation; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)