### PR TITLE
image-studio: dynamic model registry with tier aliases

### DIFF
--- a/assistant/src/__tests__/media-generate-image.test.ts
+++ b/assistant/src/__tests__/media-generate-image.test.ts
@@ -474,11 +474,11 @@ describe("image-studio TOOLS.json manifest", () => {
     expect(props.mode.enum).toEqual(["generate", "edit"]);
     expect(props.source_paths.type).toBe("array");
     expect(props.attachment_ids).toBeUndefined();
-    expect(props.model.enum).toEqual([
-      "gemini-3.1-flash-image-preview",
-      "gemini-3-pro-image-preview",
-      "gpt-image-2",
-    ]);
+    // No enum by design: model accepts tier aliases or concrete IDs, and is
+    // validated at runtime against the registry so the schema never goes
+    // stale when models change.
+    expect(props.model.type).toBe("string");
+    expect(props.model.enum).toBeUndefined();
     expect(props.variants.type).toBe("number");
   });
 });

--- a/assistant/src/__tests__/media-generate-image.test.ts
+++ b/assistant/src/__tests__/media-generate-image.test.ts
@@ -322,7 +322,13 @@ describe("image-studio skill script wrapper", () => {
     expect(result.isError).toBe(true);
     expect(result.content).toContain("Mock Gemini error: API failure");
     expect(result.content).toContain(
-      "Do not change service configuration (mode, provider, or model) to try to fix it",
+      "Failed model: gemini-3.1-flash-image-preview",
+    );
+    expect(result.content).toContain(
+      "Do not change service configuration (managed/your-own mode or default provider/model settings)",
+    );
+    expect(result.content).toContain(
+      "Retrying this call once with a different model parameter is allowed",
     );
   });
 
@@ -335,7 +341,10 @@ describe("image-studio skill script wrapper", () => {
     expect(result.isError).toBe(true);
     expect(result.content).toContain("Mock OpenAI error: openai failure");
     expect(result.content).toContain(
-      "Do not change service configuration (mode, provider, or model) to try to fix it",
+      "Do not change service configuration (managed/your-own mode or default provider/model settings)",
+    );
+    expect(result.content).toContain(
+      "Retrying this call once with a different model parameter is allowed",
     );
   });
 
@@ -346,8 +355,9 @@ describe("image-studio skill script wrapper", () => {
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain("No Gemini API key");
+    expect(result.content).toContain("Report this error to the user as-is");
     expect(result.content).toContain(
-      "Do not change service configuration (mode, provider, or model) to try to fix it",
+      "Do not change service configuration (managed/your-own mode or default provider/model settings)",
     );
   });
 
@@ -359,8 +369,9 @@ describe("image-studio skill script wrapper", () => {
 
     expect(result.isError).toBe(true);
     expect(result.content).toContain("Managed proxy is not available");
+    expect(result.content).toContain("Report this error to the user as-is");
     expect(result.content).toContain(
-      "Do not change service configuration (mode, provider, or model) to try to fix it",
+      "Do not change service configuration (managed/your-own mode or default provider/model settings)",
     );
   });
 

--- a/assistant/src/cli/commands/image-generation.ts
+++ b/assistant/src/cli/commands/image-generation.ts
@@ -66,7 +66,7 @@ Modes:
   managed    — Uses platform-managed credentials (requires login to Vellum).
   your-own   — Uses your own Gemini or OpenAI API key depending on the configured model.
 
-Supported models: pass a tier alias, the daemon resolves it to the
+Supported models: pass a tier alias, the assistant resolves it to the
 current model for that tier.
   fast     (default) quickest, good quality
   quality  higher fidelity, slower

--- a/assistant/src/cli/commands/image-generation.ts
+++ b/assistant/src/cli/commands/image-generation.ts
@@ -66,10 +66,13 @@ Modes:
   managed    — Uses platform-managed credentials (requires login to Vellum).
   your-own   — Uses your own Gemini or OpenAI API key depending on the configured model.
 
-Supported models:
-  gemini-3.1-flash-image-preview (default)
-  gemini-3-pro-image-preview
-  gpt-image-2
+Supported models: pass a tier alias, the daemon resolves it to the
+current model for that tier.
+  fast     (default) quickest, good quality
+  quality  higher fidelity, slower
+  openai   OpenAI's model
+A concrete model ID is also accepted; unknown values return an error
+listing the currently available models.
 
 Examples:
   $ assistant image-generation generate --prompt "A sunset over the ocean"
@@ -113,8 +116,8 @@ Examples:
   $ assistant image-generation generate --prompt "A mountain landscape at dawn"
   $ assistant image-generation generate --prompt "Make it darker" --mode edit --source input.png
   $ assistant image-generation generate --prompt "Logo variations" --variants 4 --output-dir ./logos
-  $ assistant image-generation generate --prompt "A robot" --model gemini-3-pro-image-preview --json
-  $ assistant image-generation generate --prompt "A robot" --model gpt-image-2 --json`,
+  $ assistant image-generation generate --prompt "A robot" --model quality --json
+  $ assistant image-generation generate --prompt "A robot" --model openai --json`,
       );
 
       generate.action(async (opts) => {
@@ -166,7 +169,10 @@ Examples:
                 file.type !== "application/octet-stream"
                   ? file.type
                   : mimeForExtension(filePath);
-              validImages.push({ mimeType, dataBase64: buffer.toString("base64") });
+              validImages.push({
+                mimeType,
+                dataBase64: buffer.toString("base64"),
+              });
             } catch (err) {
               errors.push(
                 `Could not read ${filePath}: ${(err as Error).message}`,
@@ -191,7 +197,11 @@ Examples:
 
         // Call daemon via IPC
         const r = await cliIpcCall<{
-          images: Array<{ mimeType: string; dataBase64: string; title?: string }>;
+          images: Array<{
+            mimeType: string;
+            dataBase64: string;
+            title?: string;
+          }>;
           text?: string;
           resolvedModel: string;
         }>("image_generation_generate", {
@@ -204,7 +214,11 @@ Examples:
           },
         });
 
-        if (!r.ok) return exitFromIpcResult({ ok: false, error: r.error, statusCode: r.statusCode }, generate);
+        if (!r.ok)
+          return exitFromIpcResult(
+            { ok: false, error: r.error, statusCode: r.statusCode },
+            generate,
+          );
 
         // Write images to disk (stays in CLI)
         if (!existsSync(outputDir)) {

--- a/assistant/src/config/bundled-skills/image-studio/SKILL.md
+++ b/assistant/src/config/bundled-skills/image-studio/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: image-studio
-description: Generate and edit images using AI
+description: Create images from a text description, or edit photos and graphics the user provides (remove backgrounds or watermarks, retouch, restyle, in-paint). Can produce multiple variants when the user wants options to choose from.
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🎨"
@@ -9,36 +9,79 @@ metadata:
     category: "content"
     activation-hints:
       - "User asks to generate, draw, or create an image from a text prompt"
-      - "User wants to edit an existing image — background removal, in-painting, style change, retouching"
+      - "User wants to edit an existing image: background removal, watermark removal, in-painting, style change, retouching"
       - "User wants multiple variations of a visual (logo concepts, mood boards, illustration options)"
 ---
 
-You are an image generation assistant. When the user asks you to create or edit images, use the `media_generate_image` tool.
-
-## Usage
-
-- **Text-to-image**: "Generate an image of a sunset over the ocean"
-- **Image editing**: "Remove the background from this image" (requires providing source image file paths)
-- **Multiple variants**: "Generate 3 variations of a logo for a coffee shop"
+Use the `media_generate_image` tool via `skill_execute` to create or edit images.
 
 ## Modes
 
 - **generate** (default): Create a new image from a text prompt.
-- **edit**: Modify an existing image based on a text prompt. Requires one or more source images via `source_paths` (file paths on disk).
+- **edit**: Modify an existing image. Requires one or more source images via `source_paths`.
 
 ## Models
 
-- `gemini-3.1-flash-image-preview` (default) - Nano Banana 2, fast, good quality
-- `gemini-3-pro-image-preview` - Nano Banana Pro, higher quality, slower
-- `gpt-image-2` - OpenAI GPT Image 2, high fidelity, slower
+Do not pass the `model` parameter unless you need a specific tier. Omitting it uses the configured default, which is correct for most requests.
 
-## Tips
+When you do need to choose, use an alias, not a concrete model ID. Aliases always resolve to the current model for that tier:
 
-- Be descriptive in your prompts for better results. Include details about style, composition, lighting, and mood.
-- When editing images, clearly describe what changes you want made to the source image.
-- Use the `variants` parameter (1-4) to generate multiple options and pick the best one.
-- If no API key is configured for the selected model's provider (Gemini or OpenAI), the tool will return an error - ask the user to set one up.
+- `fast`: quickest, good quality (default tier)
+- `quality`: higher fidelity, slower
+- `openai`: OpenAI's model; most permissive on photo edits
+
+Pass a concrete model ID only if the user names one explicitly. If the tool rejects an unknown model ID, the error lists the currently available models and aliases.
+
+## Example calls
+
+Generate (no model parameter, default is correct):
+
+```json
+{ "tool": "media_generate_image", "input": { "prompt": "A sunset over the ocean, golden hour, soft haze, 35mm photo style", "variants": 2 } }
+```
+
+Edit:
+
+```json
+{ "tool": "media_generate_image", "input": { "prompt": "Remove the watermark text from the background. Keep the subject, framing, lighting, and colors exactly identical. Change nothing else.", "mode": "edit", "source_paths": ["conversations/<conv-id>/attachments/photo.jpeg"], "model": "openai" } }
+```
+
+`source_paths` is a flat array of file path strings. Do NOT pass objects:
+
+- Wrong: `"source_paths": [{ "path": "img.jpeg" }]` → schema validation error
+- Right: `"source_paths": ["img.jpeg"]`
+
+## Source images for edit mode
+
+- Paths resolve inside the workspace. Conversation attachments live under `conversations/<conversation-id>/attachments/`; prefer that path for images the user attached.
+- Host paths (e.g. `~/Desktop/photo.jpg`) only work if the file arrived as an attachment; the tool falls back to the stored workspace copy. If the user references a host file that was never attached, pull it into the workspace first, then pass the workspace path.
+
+## Prompting
+
+- Generate: describe style, composition, lighting, and mood, not just the subject.
+- Edit: name the change AND what must stay the same. Models re-render the whole image, so without preservation language ("keep subject, framing, and lighting identical; only change X") they drift on crop and color.
+- Aspect ratio and size have no parameter today. State them in the prompt ("16:9 widescreen banner") and verify the output.
+- Use `variants` (1 to 4) when the user wants options or when an edit is risky; pick or present the best.
+
+## Output handling
+
+Images return as inline content blocks in the tool result; they are not written to disk automatically.
+
+- If the user just wants to see the image, the inline result is enough.
+- If the user wants a file or you need to iterate on the result, save it to disk and deliver it through the conversation's attachment mechanism.
 
 ## Error handling
 
-When image generation fails, report the error to the user as-is. **Do not** attempt to fix the error by changing service configuration (e.g. switching between "managed" and "your-own" mode, or changing the provider/model). Service configuration changes should only be made at the user's explicit request via Settings.
+Two kinds of failure. Treat them differently:
+
+1. **Configuration errors** (missing API key, provider not set up): report the error to the user as-is. Do NOT change service configuration (managed vs your-own mode, default provider, or default model in Settings). Configuration changes happen only at the user's explicit request.
+2. **Generation failures** (any other error: "invalid", content policy, safety rejection, provider error). Do not diagnose the cause; switch providers. The error message names the model that failed:
+   - If the error names a `gemini-*` model (or no model) → retry ONCE with `model: "openai"`.
+   - If the error names `gpt-image-2` or another `gpt-*` model → retry ONCE with `model: "quality"`.
+   - If the retry also fails → stop and report both errors to the user.
+
+Do NOT rephrase the prompt and retry on the same model, even if the error suggests checking the prompt. One provider switch, then stop.
+
+## Complete when
+
+The tool has returned at least one image and the user can see it: either the inline result in chat or an attached saved file. An error report counts as complete only after the retry path in Error handling has been exhausted.

--- a/assistant/src/config/bundled-skills/image-studio/SKILL.md
+++ b/assistant/src/config/bundled-skills/image-studio/SKILL.md
@@ -61,7 +61,11 @@ Edit:
 - Generate: describe style, composition, lighting, and mood, not just the subject.
 - Edit: name the change AND what must stay the same. Models re-render the whole image, so without preservation language ("keep subject, framing, and lighting identical; only change X") they drift on crop and color.
 - Aspect ratio and size have no parameter today. State them in the prompt ("16:9 widescreen banner") and verify the output.
-- Use `variants` (1 to 4) when the user wants options or when an edit is risky; pick or present the best.
+- Use `variants` (1 to 4) when the user wants options. In **edit mode always use `variants: 1`**: edits run 60-90 seconds per variant, and two variants can exceed the tool execution timeout (`timeouts.toolExecutionTimeoutSec`, default 120s). If the user wants multiple edit options, make separate sequential calls.
+
+## Timing
+
+Edits on large photos are slow (1 to 2 minutes). If the tool reports a timeout ("timed out after Ns"), the result is lost; do not wait for it to appear. Retry with `variants: 1`, or if it already was 1, fall back to the CLI which writes files to disk: `assistant image-generation generate --prompt "..." --mode edit --source <path> --model openai --output-dir <dir>`.
 
 ## Output handling
 

--- a/assistant/src/config/bundled-skills/image-studio/TOOLS.json
+++ b/assistant/src/config/bundled-skills/image-studio/TOOLS.json
@@ -27,12 +27,7 @@
           },
           "model": {
             "type": "string",
-            "enum": [
-              "gemini-3.1-flash-image-preview",
-              "gemini-3-pro-image-preview",
-              "gpt-image-2"
-            ],
-            "description": "Which model to use for generation. If omitted, uses the user's configured preference."
+            "description": "Model tier alias (fast | quality | openai) or a concrete model ID. If omitted, uses the user's configured preference. Unknown values return an error listing currently available models."
           },
           "variants": {
             "type": "number",

--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -1,6 +1,10 @@
 import { getConfig } from "../../../../config/loader.js";
 import { resolveImageGenCredentials } from "../../../../media/image-credentials.js";
 import {
+  describeImageModels,
+  resolveImageModel,
+} from "../../../../media/image-models.js";
+import {
   generateImage,
   mapImageGenError,
   providerForModel,
@@ -19,7 +23,20 @@ export async function run(
 ): Promise<ToolExecutionResult> {
   const config = getConfig();
   const svc = config.services["image-generation"];
-  const modelOverride = input.model;
+  let modelOverride = input.model;
+  // Resolve tier aliases (fast, quality, openai) to concrete model IDs via
+  // the registry. Unknown values get an error listing the current catalog so
+  // callers can self-correct without a stale schema enum.
+  if (typeof modelOverride === "string" && modelOverride) {
+    const entry = resolveImageModel(modelOverride);
+    if (!entry) {
+      return {
+        content: `Unknown model "${modelOverride}". Available models and aliases:\n${describeImageModels()}\n\nRetry with one of the aliases above, or omit the model parameter to use the configured default.`,
+        isError: true,
+      };
+    }
+    modelOverride = entry.id;
+  }
   // Derive provider from the explicit model when supplied so that requesting
   // e.g. `gpt-image-2` while config.provider === "gemini" routes to OpenAI
   // instead of silently falling back to the Gemini default model.
@@ -130,8 +147,10 @@ export async function run(
       contentBlocks,
     };
   } catch (error) {
+    // Echo the model that failed so callers (including the skill's retry
+    // branch) can key off the error text instead of remembering their input.
     return {
-      content: `${mapImageGenError(provider, error)}\n\nReport this error to the user. Do not change service configuration (mode, provider, or model) to try to fix it.`,
+      content: `${mapImageGenError(provider, error)}\n\nFailed model: ${model}\n\nReport this error to the user. Do not change service configuration (mode, provider, or model) to try to fix it.`,
       isError: true,
     };
   }

--- a/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
+++ b/assistant/src/config/bundled-skills/image-studio/tools/media-generate-image.ts
@@ -47,7 +47,7 @@ export async function run(
   });
   if (!credentials) {
     return {
-      content: `${errorHint ?? "Image generation is not configured."}\n\nReport this error to the user. Do not change service configuration (mode, provider, or model) to try to fix it.`,
+      content: `${errorHint ?? "Image generation is not configured."}\n\nReport this error to the user as-is. Do not change service configuration (managed/your-own mode or default provider/model settings) to try to fix it.`,
       isError: true,
     };
   }
@@ -150,7 +150,7 @@ export async function run(
     // Echo the model that failed so callers (including the skill's retry
     // branch) can key off the error text instead of remembering their input.
     return {
-      content: `${mapImageGenError(provider, error)}\n\nFailed model: ${model}\n\nReport this error to the user. Do not change service configuration (mode, provider, or model) to try to fix it.`,
+      content: `${mapImageGenError(provider, error)}\n\nFailed model: ${model}\n\nDo not change service configuration (managed/your-own mode or default provider/model settings) to try to fix it. Retrying this call once with a different model parameter is allowed; follow the skill's error handling instructions.`,
       isError: true,
     };
   }

--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { DEFAULT_IMAGE_MODEL } from "../../media/image-models.js";
 import { SEARCH_PROVIDER_IDS } from "../../providers/search-provider-catalog.js";
 import { SttServiceSchema } from "./stt.js";
 import { TtsServiceSchema } from "./tts.js";
@@ -42,7 +43,7 @@ const InferenceServiceSchema = z.object({});
 
 const ImageGenerationServiceSchema = BaseServiceSchema.extend({
   provider: z.enum(VALID_IMAGE_GEN_PROVIDERS).default("gemini"),
-  model: z.string().default("gemini-3.1-flash-image-preview"),
+  model: z.string().default(DEFAULT_IMAGE_MODEL),
 });
 
 const WebSearchServiceSchema = BaseServiceSchema.extend({

--- a/assistant/src/media/__tests__/image-models.test.ts
+++ b/assistant/src/media/__tests__/image-models.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  DEFAULT_IMAGE_MODEL,
+  describeImageModels,
+  IMAGE_MODELS,
+  resolveImageModel,
+} from "../image-models.js";
+import { providerForModel } from "../image-service.js";
+
+describe("image model registry", () => {
+  test("aliases resolve to concrete model IDs", () => {
+    expect(resolveImageModel("fast")?.id).toBe(
+      "gemini-3.1-flash-image-preview",
+    );
+    expect(resolveImageModel("quality")?.id).toBe("gemini-3-pro-image-preview");
+    expect(resolveImageModel("openai")?.id).toBe("gpt-image-2");
+  });
+
+  test("concrete IDs resolve to themselves", () => {
+    for (const entry of IMAGE_MODELS) {
+      expect(resolveImageModel(entry.id)?.id).toBe(entry.id);
+    }
+  });
+
+  test("unknown values return undefined", () => {
+    expect(resolveImageModel("gpt-image-3")).toBeUndefined();
+    expect(resolveImageModel("")).toBeUndefined();
+  });
+
+  test("aliases are unique and never collide with model IDs", () => {
+    const aliases = IMAGE_MODELS.map((m) => m.alias);
+    expect(new Set(aliases).size).toBe(aliases.length);
+    const ids = new Set(IMAGE_MODELS.map((m) => m.id));
+    for (const alias of aliases) {
+      expect(ids.has(alias)).toBe(false);
+    }
+  });
+
+  test("default model is the first registry entry", () => {
+    expect(DEFAULT_IMAGE_MODEL).toBe(IMAGE_MODELS[0].id);
+  });
+
+  test("every registry entry routes to its own provider via prefix dispatch", () => {
+    for (const entry of IMAGE_MODELS) {
+      expect(providerForModel(entry.id, "gemini")).toBe(entry.provider);
+    }
+  });
+
+  test("describeImageModels lists every alias and ID", () => {
+    const text = describeImageModels();
+    for (const entry of IMAGE_MODELS) {
+      expect(text).toContain(entry.alias);
+      expect(text).toContain(entry.id);
+    }
+  });
+});

--- a/assistant/src/media/image-models.ts
+++ b/assistant/src/media/image-models.ts
@@ -1,0 +1,66 @@
+/**
+ * Single source of truth for the image generation model catalog.
+ *
+ * Concrete model IDs change as providers ship new versions. Everything that
+ * needs a model name (config schema default, skill executor, CLI help text)
+ * imports from here so a version bump is a one-line change. User-facing
+ * surfaces (SKILL.md, tool descriptions) reference the stable tier aliases
+ * instead of concrete IDs.
+ *
+ * This module is intentionally dependency-free so the config schema layer
+ * can import it without cycles.
+ */
+
+export type ImageModelProvider = "gemini" | "openai";
+
+export interface ImageModelEntry {
+  /** Concrete provider model ID sent on the API request. */
+  id: string;
+  provider: ImageModelProvider;
+  /** Stable tier alias referenced by SKILL.md and tool callers. */
+  alias: string;
+  /** Human-readable label for help text and error messages. */
+  label: string;
+}
+
+export const IMAGE_MODELS: readonly ImageModelEntry[] = [
+  {
+    id: "gemini-3.1-flash-image-preview",
+    provider: "gemini",
+    alias: "fast",
+    label: "Nano Banana 2",
+  },
+  {
+    id: "gemini-3-pro-image-preview",
+    provider: "gemini",
+    alias: "quality",
+    label: "Nano Banana Pro",
+  },
+  {
+    id: "gpt-image-2",
+    provider: "openai",
+    alias: "openai",
+    label: "GPT Image 2",
+  },
+] as const;
+
+export const DEFAULT_IMAGE_MODEL = IMAGE_MODELS[0].id;
+
+/**
+ * Resolve a model input (tier alias or concrete ID) to a registry entry.
+ * Returns undefined for unknown values so callers can produce an error that
+ * lists the currently available models.
+ */
+export function resolveImageModel(model: string): ImageModelEntry | undefined {
+  return IMAGE_MODELS.find((m) => m.alias === model || m.id === model);
+}
+
+/**
+ * One line per model: "alias -> id (label)". Used in CLI help text and in
+ * unknown-model error messages so the available set is always current.
+ */
+export function describeImageModels(): string {
+  return IMAGE_MODELS.map((m) => `  ${m.alias} -> ${m.id} (${m.label})`).join(
+    "\n",
+  );
+}

--- a/assistant/src/runtime/routes/image-generation-routes.ts
+++ b/assistant/src/runtime/routes/image-generation-routes.ts
@@ -3,6 +3,10 @@ import { z } from "zod";
 import { getConfig } from "../../config/loader.js";
 import { resolveImageGenCredentials } from "../../media/image-credentials.js";
 import {
+  describeImageModels,
+  resolveImageModel,
+} from "../../media/image-models.js";
+import {
   generateImage,
   mapImageGenError,
   providerForModel,
@@ -77,8 +81,22 @@ async function handleImageGenerationGenerate(
   const config = getConfig();
   const svc = config.services["image-generation"];
 
+  // Resolve tier aliases (fast, quality, openai) to concrete model IDs via
+  // the registry; reject unknown values with the current catalog so the
+  // error is self-describing rather than a stale enum.
+  let resolvedModel = model as string | undefined;
+  if (typeof resolvedModel === "string" && resolvedModel) {
+    const entry = resolveImageModel(resolvedModel);
+    if (!entry) {
+      throw new BadRequestError(
+        `Unknown model "${resolvedModel}". Available models and aliases:\n${describeImageModels()}`,
+      );
+    }
+    resolvedModel = entry.id;
+  }
+
   // Derive provider from explicit model override when supplied
-  const provider = providerForModel(model, svc.provider);
+  const provider = providerForModel(resolvedModel, svc.provider);
 
   // Resolve credentials
   const { credentials, errorHint } = await resolveImageGenCredentials({
@@ -103,7 +121,7 @@ async function handleImageGenerationGenerate(
       sourceImages: sourceImages as
         | Array<{ mimeType: string; dataBase64: string }>
         | undefined,
-      model: (model as string | undefined) ?? svc.model,
+      model: resolvedModel ?? svc.model,
       variants: clampedVariants,
     });
 


### PR DESCRIPTION
## Problem

Image model IDs were hardcoded in four unsynchronized places: SKILL.md prose, the TOOLS.json `model` enum, the config schema default, and CLI help text. Shipping a new model meant touching all four, and the TOOLS.json enum hard-rejected any model the prefix-routing layer (`providerForModel`) could already handle.

## Change

- **New `src/media/image-models.ts` registry.** Single source of truth mapping stable tier aliases (`fast`, `quality`, `openai`) to concrete model IDs. A model version bump is now a one-line change.
- **Alias resolution in the skill executor and the IPC route.** Unknown values get an error listing the current catalog, so the error is self-describing instead of a stale schema enum.
- **Generation errors echo the failed model** (`Failed model: X`), so retry logic can key off error text instead of relying on the caller remembering its own input. Matters for weaker models.
- **SKILL.md rewritten** around the alias layer: no version strings anywhere, verbatim example calls (including a wrong-vs-right `source_paths` shape pair), source-path resolution rules for edit mode, an explicit provider-switch retry branch with named defaults, and completion criteria bound to actual tool output.
- **TOOLS.json enum dropped** in favor of a plain string validated at runtime against the registry.
- **CLI help references aliases only.** The `cli/no-daemon-internals` rule correctly keeps the registry out of the thin wrapper; resolution happens daemon-side.

## Testing

- New `image-models.test.ts`: alias resolution, ID passthrough, unknown rejection, alias/ID collision guard, default = first entry, provider prefix-routing consistency. 7 pass.
- Existing image generation suites: 9 pass. Typecheck and lint clean.
- Skill body exercised live against a running assistant before this PR: generate, alias resolution, unknown-model recovery, edit mode with attachments, variants, malformed source_paths, and the provider-switch retry branch (which fired for real, see note below).

## Note: possible Gemini image path issue

During live testing, all Gemini image requests (both models, managed credentials, trivially safe prompts like a coffee cup and a red circle) returned a blanket "The image request was invalid". gpt-image-2 succeeded with identical prompts. Filing separately; this PR's provider-switch retry branch mitigates it from the skill side.