### PR TITLE
feat(local-mode): support --repair-guardian in runWake

### DIFF
--- a/packages/local-mode/src/__tests__/wake.test.ts
+++ b/packages/local-mode/src/__tests__/wake.test.ts
@@ -41,6 +41,25 @@ describe("runWake", () => {
     expect(spawnArgs[0]).toEqual(["bun", ["run", "cli", "wake", "asst-42"]]);
   });
 
+  test("repairGuardian: true appends --repair-guardian to the CLI args", async () => {
+    const pending = runWake(invocation, "asst-42", { repairGuardian: true });
+    lastChild.emit("close", 0);
+
+    expect(await pending).toEqual({ ok: true });
+    expect(spawnArgs[0]).toEqual([
+      "bun",
+      ["run", "cli", "wake", "asst-42", "--repair-guardian"],
+    ]);
+  });
+
+  test("repairGuardian: false omits the flag", async () => {
+    const pending = runWake(invocation, "asst-42", { repairGuardian: false });
+    lastChild.emit("close", 0);
+
+    expect(await pending).toEqual({ ok: true });
+    expect(spawnArgs[0]).toEqual(["bun", ["run", "cli", "wake", "asst-42"]]);
+  });
+
   test("a non-zero exit resolves to a failure carrying the CLI's output", async () => {
     const pending = runWake(invocation, "asst-42");
     lastChild.stderr.emit("data", Buffer.from("no sibling environment to seed from"));

--- a/packages/local-mode/src/index.ts
+++ b/packages/local-mode/src/index.ts
@@ -36,7 +36,7 @@ export type { HatchResult } from "./hatch";
 export { runRetire } from "./retire";
 export type { RetireResult } from "./retire";
 export { runWake } from "./wake";
-export type { WakeResult } from "./wake";
+export type { WakeOptions, WakeResult } from "./wake";
 export { getGuardianAccessToken } from "./guardian-token";
 export type { TokenResult } from "./guardian-token";
 export {

--- a/packages/local-mode/src/wake.ts
+++ b/packages/local-mode/src/wake.ts
@@ -14,6 +14,11 @@ export type WakeResult =
   | { ok: true }
   | { ok: false; status: number; error: string };
 
+export interface WakeOptions {
+  /** Pass --repair-guardian to re-provision a missing/expired guardian token. Revokes the assistant's other device-bound tokens, so callers must gate this behind explicit user confirmation. */
+  repairGuardian?: boolean;
+}
+
 /**
  * Start (or restart) a local assistant's daemon and gateway via the CLI's
  * `wake`, which also re-seeds the guardian token from a sibling environment.
@@ -27,11 +32,17 @@ export type WakeResult =
 export function runWake(
   invocation: CliInvocation,
   assistantId: string,
+  options?: WakeOptions,
 ): Promise<WakeResult> {
   return new Promise((resolve) => {
     const child = spawn(
       invocation.command,
-      [...invocation.baseArgs, "wake", assistantId],
+      [
+        ...invocation.baseArgs,
+        "wake",
+        assistantId,
+        ...(options?.repairGuardian ? ["--repair-guardian"] : []),
+      ],
       { stdio: ["ignore", "pipe", "pipe"] },
     );
 


### PR DESCRIPTION
## Summary
- Add optional `WakeOptions` with `repairGuardian` to `runWake`, appending `--repair-guardian` to the spawned CLI command
- Re-export `WakeOptions` from the package index
- Tests assert the flag is appended only when explicitly enabled

Part of plan: guardian-token-recovery-modal.md (PR 1 of 5)