### PR TITLE
feat(web): plumb repairGuardian through wakeLocalAssistantHost

### DIFF
--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -185,7 +185,10 @@ declare global {
           organizationId?: string,
         ): Promise<LockfileWriteResult>;
         retire(assistantId: string): Promise<{ ok: boolean; error?: string }>;
-        wake?(assistantId: string): Promise<{ ok: boolean; error?: string }>;
+        wake?(
+          assistantId: string,
+          options?: { repairGuardian?: boolean },
+        ): Promise<{ ok: boolean; error?: string }>;
         guardianToken(
           assistantId: string,
         ): Promise<

--- a/apps/web/src/runtime/local-mode-host.test.ts
+++ b/apps/web/src/runtime/local-mode-host.test.ts
@@ -254,7 +254,23 @@ describe("wakeLocalAssistantHost", () => {
     const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
     expect(url).toBe("/assistant/__local/wake");
     expect(init.method).toBe("POST");
-    expect(JSON.parse(init.body as string)).toEqual({ assistantId: "a-1" });
+    expect(JSON.parse(init.body as string)).toEqual({
+      assistantId: "a-1",
+      repairGuardian: false,
+    });
+  });
+
+  test("web/dev host forwards repairGuardian when the caller opts in", async () => {
+    const fetchMock = mock(async () => ({ json: async () => ({ ok: true }) }));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await wakeLocalAssistantHost("a-1", { repairGuardian: true });
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({
+      assistantId: "a-1",
+      repairGuardian: true,
+    });
   });
 
   test("Electron host wakes through the bridge and never touches fetch", async () => {
@@ -266,7 +282,22 @@ describe("wakeLocalAssistantHost", () => {
     setElectronBridge({ wake });
 
     expect(await wakeLocalAssistantHost("a-1")).toEqual({ ok: true });
-    expect(wake).toHaveBeenCalledWith("a-1");
+    expect(wake).toHaveBeenCalledWith("a-1", undefined);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("Electron host forwards repairGuardian to the bridge", async () => {
+    const wake = mock(async () => ({ ok: true }));
+    const fetchMock = mock(async () => {
+      throw new Error("fetch must not run on the Electron branch");
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    setElectronBridge({ wake });
+
+    expect(
+      await wakeLocalAssistantHost("a-1", { repairGuardian: true }),
+    ).toEqual({ ok: true });
+    expect(wake).toHaveBeenCalledWith("a-1", { repairGuardian: true });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/runtime/local-mode-host.ts
+++ b/apps/web/src/runtime/local-mode-host.ts
@@ -206,25 +206,35 @@ export async function retireLocalAssistantHost(
  * This is the non-destructive repair primitive: it revives a stopped or
  * mis-seeded assistant in place without touching its data or identity, the
  * counterpart to {@link retireLocalAssistantHost}'s destructive removal.
+ * A plain wake (no options) is the safe auto-repair primitive. Passing
+ * `repairGuardian: true` re-provisions the guardian token and revokes the
+ * assistant's other device-bound tokens, so it must only be passed from
+ * explicitly user-confirmed flows — never from silent auto-repair paths.
  * Older Electron hosts that predate this IPC channel resolve `wake` as
  * `undefined`; callers treat that as a no-op repair and fall through to the
- * underlying connect error.
+ * underlying connect error. Older preloads whose `wake` takes one parameter
+ * silently ignore the extra options argument at the JS level, so a plain
+ * wake still succeeds — the same graceful degradation for version skew.
  */
 export async function wakeLocalAssistantHost(
   assistantId: string,
+  options?: { repairGuardian?: boolean },
 ): Promise<LocalWakeResult> {
   if (isElectron()) {
     const wake = window.vellum!.localMode.wake;
     if (!wake) {
       return { ok: false, error: "Wake is not supported by this app version" };
     }
-    return wake(assistantId);
+    return wake(assistantId, options);
   }
 
   const res = await fetch("/assistant/__local/wake", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ assistantId }),
+    body: JSON.stringify({
+      assistantId,
+      repairGuardian: options?.repairGuardian ?? false,
+    }),
   });
   return res.json() as Promise<LocalWakeResult>;
 }


### PR DESCRIPTION
## Summary
- `wakeLocalAssistantHost` accepts `{ repairGuardian }` and forwards it on both the Electron bridge and dev-server fetch paths
- Updated the `window.vellum.localMode.wake` type declaration
- Auto-repair call sites are unchanged and never pass the flag

Part of plan: guardian-token-recovery-modal.md (PR 4 of 5)