### PR TITLE
feat(web): accept repairGuardian in the dev wake middleware

### DIFF
--- a/apps/web/vite-plugin-local-mode.ts
+++ b/apps/web/vite-plugin-local-mode.ts
@@ -345,12 +345,15 @@ function wakeMiddleware(baseDir: string): Connect.NextHandleFunction {
     req.on("data", (chunk: Buffer) => chunks.push(chunk));
     req.on("end", () => {
       let assistantId: string | undefined;
+      let repairGuardian = false;
       if (chunks.length > 0) {
         try {
           const body = JSON.parse(Buffer.concat(chunks).toString()) as {
             assistantId?: string;
+            repairGuardian?: boolean;
           };
           assistantId = body.assistantId;
+          repairGuardian = body.repairGuardian === true;
         } catch {
           res.statusCode = 400;
           res.setHeader("Content-Type", "application/json");
@@ -381,7 +384,7 @@ function wakeMiddleware(baseDir: string): Connect.NextHandleFunction {
         return;
       }
 
-      runWake(invocation, assistantId).then((result) => {
+      runWake(invocation, assistantId, { repairGuardian }).then((result) => {
         res.statusCode = result.ok ? 200 : result.status;
         res.setHeader("Content-Type", "application/json");
         res.end(


### PR DESCRIPTION
## Summary
- The dev-server wake middleware parses an optional `repairGuardian` boolean from the POST body
- Forwards it to `runWake` with an exact `=== true` coercion so malformed values can't enable the destructive flag

Part of plan: guardian-token-recovery-modal.md (PR 3 of 5)