### PR TITLE
feat(macos): accept repairGuardian option on the localMode wake IPC

### DIFF
--- a/apps/macos/src/main/local-mode.test.ts
+++ b/apps/macos/src/main/local-mode.test.ts
@@ -316,6 +316,12 @@ const replacePlatformAssistants = (platformAssistants: unknown): WriteResult =>
   ) as WriteResult;
 const retire = (assistantId?: unknown): Promise<unknown> =>
   handlers["vellum:localMode:retire"](allowedEvent, assistantId) as Promise<unknown>;
+const wake = (assistantId?: unknown, options?: unknown): Promise<unknown> =>
+  handlers["vellum:localMode:wake"](
+    allowedEvent,
+    assistantId,
+    options,
+  ) as Promise<unknown>;
 
 describe("lockfile IPC handlers", () => {
   beforeEach(() => {
@@ -486,6 +492,52 @@ describe("vellum:localMode:retire handler", () => {
     const result = (await retire("asst-1")) as { ok: boolean; error: string };
     expect(result.ok).toBe(false);
     expect(result.error).toBe("disk full");
+    expect(spawnArgs).toHaveLength(0);
+  });
+});
+
+describe("vellum:localMode:wake handler", () => {
+  test("forwards repairGuardian to runWake, appending --repair-guardian", async () => {
+    const pending = wake("asst-1", { repairGuardian: true });
+    await tick();
+    expect(spawnArgs[0]).toEqual([
+      "bun",
+      [
+        "run",
+        path.join("/repo", "cli", "src", "index.ts"),
+        "wake",
+        "asst-1",
+        "--repair-guardian",
+      ],
+    ]);
+    lastChild.emit("close", 0);
+    expect(await pending).toEqual({ ok: true });
+  });
+
+  test("a single-argument invoke still resolves ok with no options forwarded", async () => {
+    const pending = handlers["vellum:localMode:wake"](
+      allowedEvent,
+      "asst-1",
+    ) as Promise<unknown>;
+    await tick();
+    expect(spawnArgs[0]).toEqual([
+      "bun",
+      ["run", path.join("/repo", "cli", "src", "index.ts"), "wake", "asst-1"],
+    ]);
+    lastChild.emit("close", 0);
+    expect(await pending).toEqual({ ok: true });
+  });
+
+  test("rejects malformed options without spawning", async () => {
+    expect(() => wake("asst-1", "repair-please")).toThrow();
+    expect(spawnArgs).toHaveLength(0);
+  });
+
+  test("rejects a missing assistant id without spawning", async () => {
+    expect(await wake(undefined, { repairGuardian: true })).toEqual({
+      ok: false,
+      error: "Missing assistantId",
+    });
     expect(spawnArgs).toHaveLength(0);
   });
 });

--- a/apps/macos/src/main/local-mode.ts
+++ b/apps/macos/src/main/local-mode.ts
@@ -17,6 +17,7 @@ import {
   type CliInvocation,
   type LockfileWriteResult,
   type TokenResult,
+  type WakeOptions,
 } from "@vellumai/local-mode";
 import { handle } from "./ipc";
 
@@ -122,14 +123,17 @@ async function retire(assistantId: string): Promise<RetireResult> {
  * guardian token. The non-destructive repair primitive. Mirrors `hatch`'s
  * never-reject contract.
  */
-async function wake(assistantId: string): Promise<WakeResult> {
+async function wake(
+  assistantId: string,
+  options?: WakeOptions,
+): Promise<WakeResult> {
   let invocation: CliInvocation;
   try {
     invocation = await resolveCliInvocation();
   } catch (err) {
     return { ok: false, error: (err as Error).message };
   }
-  const result = await runWake(invocation, assistantId);
+  const result = await runWake(invocation, assistantId, options);
   return result.ok ? { ok: true } : { ok: false, error: result.error };
 }
 
@@ -144,6 +148,14 @@ const assistantRecord = z.record(z.string(), z.unknown());
 // renderer renders, rather than rejecting the invoke. The id is therefore
 // optional on the wire and validated in the body.
 const assistantIdArgs = z.tuple([z.string().optional()]);
+
+// `wake` additionally takes an options object so a user-confirmed repair can
+// pass `repairGuardian` through to the CLI's `--repair-guardian` flag. Both
+// members stay optional so older renderers' single-argument invokes parse.
+const wakeArgs = z.tuple([
+  z.string().optional(),
+  z.object({ repairGuardian: z.boolean().optional() }).optional(),
+]);
 
 let installed = false;
 
@@ -216,9 +228,9 @@ export const installLocalMode = (): void => {
     return retire(assistantId);
   });
 
-  handle("vellum:localMode:wake", assistantIdArgs, ([assistantId]) => {
+  handle("vellum:localMode:wake", wakeArgs, ([assistantId, options]) => {
     if (!assistantId) return { ok: false, error: "Missing assistantId" };
-    return wake(assistantId);
+    return wake(assistantId, options);
   });
 
   handle(

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -294,8 +294,8 @@ const bridge: VellumBridge = {
         platformAssistants,
         organizationId,
       ) as Promise<LockfileWriteResult>,
-    wake: (assistantId: string) =>
-      ipcRenderer.invoke("vellum:localMode:wake", assistantId) as Promise<{
+    wake: (assistantId: string, options?: { repairGuardian?: boolean }) =>
+      ipcRenderer.invoke("vellum:localMode:wake", assistantId, options) as Promise<{
         ok: boolean;
         error?: string;
       }>,

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -148,7 +148,10 @@ export interface VellumBridge {
       organizationId?: string,
     ): Promise<LockfileWriteResult>;
     retire(assistantId: string): Promise<{ ok: boolean; error?: string }>;
-    wake(assistantId: string): Promise<{ ok: boolean; error?: string }>;
+    wake(
+      assistantId: string,
+      options?: { repairGuardian?: boolean },
+    ): Promise<{ ok: boolean; error?: string }>;
     guardianToken(
       assistantId: string,
     ): Promise<


### PR DESCRIPTION
## Summary
- Wake IPC handler accepts an optional `{ repairGuardian }` options object and forwards it to `runWake`
- Preload bridge passes the options through `window.vellum.localMode.wake`
- Single-argument invokes keep working for backward compatibility

Part of plan: guardian-token-recovery-modal.md (PR 2 of 5)