### PR TITLE
feat(web): guardian-token recovery dialog on the assistant chooser

### DIFF
--- a/apps/web/src/domains/onboarding/components/connect-recovery-dialog.test.tsx
+++ b/apps/web/src/domains/onboarding/components/connect-recovery-dialog.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * Tests for `ConnectRecoveryDialog`.
+ *
+ * The component composes `@vellumai/design-library`'s `Modal` and
+ * `ConfirmDialog` (Radix Dialog under the hood), mounted via
+ * `@testing-library/react` on happy-dom — same approach as
+ * `rename-conversation-dialog.test.tsx`. The real library components are
+ * rendered so the destructive styling and `isPending` behavior asserted
+ * here are the actual shipped behavior, not a mock's.
+ *
+ * What matters: the step machine. `onRepair`/`onRetire` must only ever
+ * fire from their nested confirmation steps, never from the menu.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { ConnectRecoveryDialog } from "@/domains/onboarding/components/connect-recovery-dialog";
+
+afterEach(cleanup);
+
+function getButton(label: string): HTMLButtonElement {
+  // Modals portal into document.body, so query the document rather than
+  // the render container.
+  const buttons = Array.from(
+    document.querySelectorAll<HTMLButtonElement>("button"),
+  );
+  const match = buttons.find((b) => b.textContent?.trim() === label);
+  if (!match) {
+    throw new Error(
+      `expected to find a "${label}" button — saw: ${buttons
+        .map((b) => `"${b.textContent?.trim()}"`)
+        .join(", ")}`,
+    );
+  }
+  return match;
+}
+
+function renderDialog(
+  overrides: Partial<Parameters<typeof ConnectRecoveryDialog>[0]> = {},
+) {
+  const onCancel = mock(() => {});
+  const onRepair = mock(() => {});
+  const onRetire = mock(() => {});
+  const props = {
+    open: true,
+    assistantName: "Local Assistant",
+    isPending: false,
+    onCancel,
+    onRepair,
+    onRetire,
+    ...overrides,
+  };
+  const { rerender } = render(<ConnectRecoveryDialog {...props} />);
+  return {
+    onCancel,
+    onRepair,
+    onRetire,
+    rerender: (next: Partial<Parameters<typeof ConnectRecoveryDialog>[0]>) =>
+      rerender(<ConnectRecoveryDialog {...props} {...next} />),
+  };
+}
+
+describe("Menu step", () => {
+  test("renders the title, assistant name, and all three actions", () => {
+    renderDialog();
+    expect(document.body.textContent).toContain(
+      "Can’t Authenticate Assistant",
+    );
+    expect(document.body.textContent).toContain(
+      "The authentication token for Local Assistant",
+    );
+    expect(getButton("Wake & Repair")).toBeTruthy();
+    expect(getButton("Retire Assistant")).toBeTruthy();
+    expect(getButton("Cancel")).toBeTruthy();
+  });
+
+  test("renders nothing when open=false", () => {
+    renderDialog({ open: false });
+    expect(document.querySelector("button")).toBeNull();
+  });
+
+  test("Cancel fires onCancel without firing onRepair or onRetire", () => {
+    const { onCancel, onRepair, onRetire } = renderDialog();
+    fireEvent.click(getButton("Cancel"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onRepair).not.toHaveBeenCalled();
+    expect(onRetire).not.toHaveBeenCalled();
+  });
+});
+
+describe("Repair confirmation", () => {
+  test("Wake & Repair advances to the confirmation instead of firing onRepair", () => {
+    const { onRepair } = renderDialog();
+    fireEvent.click(getButton("Wake & Repair"));
+    expect(onRepair).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain("Repair Assistant?");
+    // The confirmation states the real side effect.
+    expect(document.body.textContent).toContain(
+      "signed out and need to reconnect",
+    );
+  });
+
+  test("confirming fires onRepair", () => {
+    const { onRepair } = renderDialog();
+    fireEvent.click(getButton("Wake & Repair"));
+    fireEvent.click(getButton("Repair"));
+    expect(onRepair).toHaveBeenCalledTimes(1);
+  });
+
+  test("canceling the confirmation returns to the menu without firing callbacks", () => {
+    const { onRepair, onCancel } = renderDialog();
+    fireEvent.click(getButton("Wake & Repair"));
+    fireEvent.click(getButton("Cancel"));
+    expect(document.body.textContent).toContain(
+      "Can’t Authenticate Assistant",
+    );
+    expect(onRepair).not.toHaveBeenCalled();
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  test("isPending disables the confirm button", () => {
+    const { rerender, onRepair } = renderDialog();
+    fireEvent.click(getButton("Wake & Repair"));
+    rerender({ isPending: true });
+    const repair = getButton("Repair");
+    expect(repair.disabled).toBe(true);
+    fireEvent.click(repair);
+    expect(onRepair).not.toHaveBeenCalled();
+  });
+});
+
+describe("Retire confirmation", () => {
+  test("Retire Assistant advances to a destructive confirmation instead of firing onRetire", () => {
+    const { onRetire } = renderDialog();
+    fireEvent.click(getButton("Retire Assistant"));
+    expect(onRetire).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain(
+      "This will permanently retire this assistant and all of its data.",
+    );
+    // ConfirmDialog's destructive variant styles the confirm as a danger
+    // button.
+    expect(getButton("Retire").className).toContain(
+      "bg-[var(--system-negative-strong)]",
+    );
+  });
+
+  test("confirming fires onRetire; canceling returns to the menu", () => {
+    const { onRetire } = renderDialog();
+    fireEvent.click(getButton("Retire Assistant"));
+    fireEvent.click(getButton("Cancel"));
+    expect(getButton("Wake & Repair")).toBeTruthy();
+    expect(onRetire).not.toHaveBeenCalled();
+
+    fireEvent.click(getButton("Retire Assistant"));
+    fireEvent.click(getButton("Retire"));
+    expect(onRetire).toHaveBeenCalledTimes(1);
+  });
+
+  test("isPending disables the confirm button", () => {
+    const { rerender, onRetire } = renderDialog();
+    fireEvent.click(getButton("Retire Assistant"));
+    rerender({ isPending: true });
+    const retire = getButton("Retire");
+    expect(retire.disabled).toBe(true);
+    fireEvent.click(retire);
+    expect(onRetire).not.toHaveBeenCalled();
+  });
+});
+
+describe("Error display", () => {
+  test("errorMessage renders in the menu step", () => {
+    renderDialog({ errorMessage: "Repair failed. Please try again." });
+    expect(document.body.textContent).toContain(
+      "Repair failed. Please try again.",
+    );
+  });
+
+  test("errorMessage renders inside the active confirmation step", () => {
+    const { rerender } = renderDialog();
+    fireEvent.click(getButton("Wake & Repair"));
+    rerender({ errorMessage: "Repair failed. Please try again." });
+    // Still on the confirmation step, with the failure shown inline.
+    expect(document.body.textContent).toContain("Repair Assistant?");
+    expect(document.body.textContent).toContain(
+      "Repair failed. Please try again.",
+    );
+  });
+});
+
+describe("Reset on reopen", () => {
+  test("reopening lands on the menu even if closed mid-confirmation", () => {
+    const { rerender } = renderDialog();
+    fireEvent.click(getButton("Wake & Repair"));
+    expect(document.body.textContent).toContain("Repair Assistant?");
+
+    rerender({ open: false });
+    rerender({ open: true });
+    expect(document.body.textContent).toContain(
+      "Can’t Authenticate Assistant",
+    );
+    expect(getButton("Wake & Repair")).toBeTruthy();
+  });
+});

--- a/apps/web/src/domains/onboarding/components/connect-recovery-dialog.tsx
+++ b/apps/web/src/domains/onboarding/components/connect-recovery-dialog.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useState } from "react";
+
+import { Button } from "@vellumai/design-library/components/button";
+import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
+import { Modal } from "@vellumai/design-library/components/modal";
+
+type RecoveryStep = "menu" | "confirm-repair" | "confirm-retire";
+
+interface ConnectRecoveryDialogProps {
+  open: boolean;
+  /** Display label of the assistant that failed to connect. */
+  assistantName: string;
+  /** A repair or retire is in flight. */
+  isPending: boolean;
+  /** Failure from a repair/retire attempt, shown inline. */
+  errorMessage?: string;
+  onCancel: () => void;
+  /** Fired only after the nested repair confirmation. */
+  onRepair: () => void;
+  /** Fired only after the nested retire confirmation. */
+  onRetire: () => void;
+}
+
+/**
+ * Recovery dialog for a local assistant whose guardian token is missing or
+ * can no longer be refreshed. Offers three paths: cancel back to the chooser,
+ * wake-and-repair (re-provisions the token — revokes the assistant's other
+ * device-bound tokens, so it sits behind an explicit confirmation), or retire
+ * (destructive, also confirmed).
+ */
+function ConnectRecoveryDialog({
+  open,
+  assistantName,
+  isPending,
+  errorMessage,
+  onCancel,
+  onRepair,
+  onRetire,
+}: ConnectRecoveryDialogProps) {
+  const [step, setStep] = useState<RecoveryStep>("menu");
+
+  useEffect(() => {
+    if (open) setStep("menu");
+  }, [open]);
+
+  // A span (not <p>) so it can nest inside ConfirmDialog's <p> description.
+  const errorLine = errorMessage ? (
+    <span className="mt-3 block text-body-small-default text-[var(--system-negative-strong)]">
+      {errorMessage}
+    </span>
+  ) : null;
+
+  if (step === "confirm-repair") {
+    return (
+      <ConfirmDialog
+        open={open}
+        title="Repair Assistant?"
+        message={
+          <>
+            Repairing re-provisions this assistant&rsquo;s authentication
+            token. Any other devices or browser sessions connected to it will
+            be signed out and need to reconnect.
+            {errorLine}
+          </>
+        }
+        confirmLabel="Repair"
+        isPending={isPending}
+        onConfirm={onRepair}
+        onCancel={() => setStep("menu")}
+      />
+    );
+  }
+
+  if (step === "confirm-retire") {
+    return (
+      <ConfirmDialog
+        open={open}
+        title="Retire Assistant"
+        message={
+          <>
+            This will permanently retire this assistant and all of its data.
+            You will need to go through the onboarding flow again to create a
+            new one. This action cannot be undone.
+            {errorLine}
+          </>
+        }
+        confirmLabel="Retire"
+        destructive
+        isPending={isPending}
+        onConfirm={onRetire}
+        onCancel={() => setStep("menu")}
+      />
+    );
+  }
+
+  return (
+    <Modal.Root
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && !isPending) onCancel();
+      }}
+    >
+      <Modal.Content
+        size="sm"
+        hideCloseButton
+        onEscapeKeyDown={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          if (!isPending) onCancel();
+        }}
+      >
+        <Modal.Header>
+          <Modal.Title>Can&rsquo;t Authenticate Assistant</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Modal.Description>
+            The authentication token for {assistantName} is missing or can no
+            longer be refreshed, so this assistant can&rsquo;t be connected.
+            You can repair it, retire it, or pick a different assistant.
+          </Modal.Description>
+          {errorLine}
+          <div className="mt-5 flex w-full flex-col gap-2">
+            <Button
+              variant="primary"
+              fullWidth
+              disabled={isPending}
+              onClick={() => setStep("confirm-repair")}
+            >
+              Wake &amp; Repair
+            </Button>
+            <Button
+              variant="dangerOutline"
+              fullWidth
+              disabled={isPending}
+              onClick={() => setStep("confirm-retire")}
+            >
+              Retire Assistant
+            </Button>
+            <Button
+              variant="outlined"
+              fullWidth
+              disabled={isPending}
+              onClick={onCancel}
+            >
+              Cancel
+            </Button>
+          </div>
+        </Modal.Body>
+      </Modal.Content>
+    </Modal.Root>
+  );
+}
+
+export { ConnectRecoveryDialog };
+export type { ConnectRecoveryDialogProps };

--- a/apps/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -110,6 +110,10 @@ export function SelectAssistantScreen() {
     setRecoveryAssistant(null);
     setRecoveryPending(false);
     setRecoveryError(null);
+    // If recovery interrupted an auto-skip, dismissing it must land on the
+    // chooser — leaving autoSkipping set would re-render the indefinite
+    // "Connecting…" screen with no way out.
+    setAutoSkipping(false);
   };
 
   const handleRecoveryRepair = async () => {

--- a/apps/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -3,10 +3,16 @@ import { useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
 import { resolveSelectedAssistantId } from "@/assistant/selection";
+import { retireAssistant } from "@/assistant/retire-service";
+import { ConnectRecoveryDialog } from "@/domains/onboarding/components/connect-recovery-dialog";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
 import { formatRelativeDate } from "@/utils/format-date";
 import { useOnboardingLogin } from "@/hooks/use-onboarding-login";
 import { isElectron } from "@/runtime/is-electron";
+import {
+  GuardianTokenError,
+  wakeLocalAssistantHost,
+} from "@/runtime/local-mode-host";
 import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
 import { useOrganizationStore } from "@/stores/organization-store";
 import {
@@ -55,6 +61,12 @@ export function SelectAssistantScreen() {
   const [connecting, setConnecting] = useState(false);
   const [autoSkipping, setAutoSkipping] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // A local assistant whose guardian token is missing/unrefreshable; opens
+  // the recovery dialog instead of the generic connect error.
+  const [recoveryAssistant, setRecoveryAssistant] =
+    useState<ResolvedAssistant | null>(null);
+  const [recoveryPending, setRecoveryPending] = useState(false);
+  const [recoveryError, setRecoveryError] = useState<string | null>(null);
 
   // Default selection: the app's known selected assistant when accessible,
   // else the first accessible assistant.
@@ -75,9 +87,58 @@ export function SelectAssistantScreen() {
         await useAuthStore.getState().connectPlatformAssistant(assistant.id);
       }
       void navigate(routes.assistant, { replace: true });
-    } catch {
-      setError("Failed to connect. Please try again.");
+    } catch (err) {
+      console.error("selectAssistant.handleConnect failed", err);
+      // A missing (404) or expired-and-unrefreshable (401) guardian token
+      // can only be fixed by re-provisioning, so offer the recovery dialog.
+      // 403 (refused loopback boundary) and transient failures keep the
+      // generic message — repair can't help those.
+      if (
+        assistant.isLocal &&
+        err instanceof GuardianTokenError &&
+        (err.status === 404 || err.status === 401)
+      ) {
+        setRecoveryAssistant(assistant);
+      } else {
+        setError("Failed to connect. Please try again.");
+      }
       setConnecting(false);
+    }
+  };
+
+  const clearRecoveryState = () => {
+    setRecoveryAssistant(null);
+    setRecoveryPending(false);
+    setRecoveryError(null);
+  };
+
+  const handleRecoveryRepair = async () => {
+    if (!recoveryAssistant) return;
+    setRecoveryPending(true);
+    setRecoveryError(null);
+    const result = await wakeLocalAssistantHost(recoveryAssistant.id, {
+      repairGuardian: true,
+    });
+    if (result.ok) {
+      clearRecoveryState();
+      void handleConnect(recoveryAssistant);
+    } else {
+      setRecoveryError(result.error || "Repair failed. Please try again.");
+      setRecoveryPending(false);
+    }
+  };
+
+  const handleRecoveryRetire = async () => {
+    if (!recoveryAssistant) return;
+    setRecoveryPending(true);
+    setRecoveryError(null);
+    const outcome = await retireAssistant(recoveryAssistant.id);
+    if (outcome.ok) {
+      clearRecoveryState();
+      void navigate(outcome.nextRoute, { replace: true });
+    } else {
+      setRecoveryError(outcome.error);
+      setRecoveryPending(false);
     }
   };
 
@@ -107,8 +168,9 @@ export function SelectAssistantScreen() {
 
   const displayError = loginError ?? error;
 
-  // Loading state during auto-skip
-  if (autoSkipping && !displayError) {
+  // Loading state during auto-skip. A pending recovery falls through to the
+  // chooser so the dialog can render.
+  if (autoSkipping && !displayError && !recoveryAssistant) {
     return (
       <OnboardingLayout>
         <div className="mx-auto flex min-h-screen w-full max-w-xl flex-col items-center justify-center px-6 text-[var(--content-default)]">
@@ -217,6 +279,15 @@ export function SelectAssistantScreen() {
           </Button>
         </div>
       </div>
+      <ConnectRecoveryDialog
+        open={recoveryAssistant != null}
+        assistantName={recoveryAssistant ? assistantLabel(recoveryAssistant) : ""}
+        isPending={recoveryPending}
+        errorMessage={recoveryError ?? undefined}
+        onCancel={clearRecoveryState}
+        onRepair={() => void handleRecoveryRepair()}
+        onRetire={() => void handleRecoveryRetire()}
+      />
     </OnboardingLayout>
   );
 }


### PR DESCRIPTION
## Summary
- Detect `GuardianTokenError` 404/401 on local-assistant connect and open a recovery dialog instead of the generic error
- Dialog offers Cancel / Wake & Repair (confirmed; states the token-revocation side effect; auto-retries connect on success) / Retire (destructive confirmation; navigates via the retire service)
- Other failure classes keep the existing generic message

Part of plan: guardian-token-recovery-modal.md (PR 5 of 5)