### PR TITLE
fix: guard recovery repair/retire handlers against re-entry

### DIFF
--- a/apps/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -117,7 +117,9 @@ export function SelectAssistantScreen() {
   };
 
   const handleRecoveryRepair = async () => {
-    if (!recoveryAssistant) return;
+    // recoveryPending also guards re-entry: a second click can land before
+    // React flushes the pending state into the dialog's disabled buttons.
+    if (!recoveryAssistant || recoveryPending) return;
     setRecoveryPending(true);
     setRecoveryError(null);
     const result = await wakeLocalAssistantHost(recoveryAssistant.id, {
@@ -133,7 +135,7 @@ export function SelectAssistantScreen() {
   };
 
   const handleRecoveryRetire = async () => {
-    if (!recoveryAssistant) return;
+    if (!recoveryAssistant || recoveryPending) return;
     setRecoveryPending(true);
     setRecoveryError(null);
     const outcome = await retireAssistant(recoveryAssistant.id);


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for guardian-token-recovery-modal.md.

**Gap:** Repair retry allows double-connect via stale pending state
**What was expected:** A second click on Repair/Retire before React flushes the pending state must not start a concurrent repair/retire chain
**What was found:** `handleRecoveryRepair`/`handleRecoveryRetire` only relied on the dialog's `isPending`-disabled buttons, which lag one render behind the first click