### PR TITLE
docs(feature-flags): correct memory-retrospective-fork description

### DIFF
--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -14,7 +14,7 @@
       "scope": "assistant",
       "key": "memory-retrospective-fork",
       "label": "Fork-based memory retrospective",
-      "description": "Fork the source conversation through its latest message for memory retrospectives, instead of rendering the slice into a transcript and waking an empty background conversation. Lets the retrospective hit the provider prompt cache and read compaction summary + tail messages natively.",
+      "description": "Fork the source conversation through its latest message for memory retrospectives, instead of rendering the slice into a transcript and waking an empty background conversation. The retrospective reads the conversation natively, including any inherited compaction summary and tail messages. Provider prompt-cache reuse additionally requires memory.retrospective.matchConversationProfile.",
       "defaultEnabled": false
     },
     {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -14,7 +14,7 @@
       "scope": "assistant",
       "key": "memory-retrospective-fork",
       "label": "Fork-based memory retrospective",
-      "description": "Fork the source conversation through its latest message for memory retrospectives, instead of rendering the slice into a transcript and waking an empty background conversation. Lets the retrospective hit the provider prompt cache and read compaction summary + tail messages natively.",
+      "description": "Fork the source conversation through its latest message for memory retrospectives, instead of rendering the slice into a transcript and waking an empty background conversation. The retrospective reads the conversation natively, including any inherited compaction summary and tail messages. Provider prompt-cache reuse additionally requires memory.retrospective.matchConversationProfile.",
       "defaultEnabled": false
     },
     {


### PR DESCRIPTION
## Summary
- The flag description claimed provider prompt-cache reuse, which is not true as shipped (different model/tools/system than the cached prefix)
- Reworded to the accurate benefit (native conversation reading incl. compaction summary) and noted cache reuse requires the matchConversationProfile option

Part of plan: memory-retrospective-fork-hardening.md (PR L of 12)