### PR TITLE
fix(memory): exclude retrospective conversations from auto-analysis

### DIFF
--- a/assistant/src/memory/__tests__/auto-analysis-enqueue.test.ts
+++ b/assistant/src/memory/__tests__/auto-analysis-enqueue.test.ts
@@ -13,6 +13,7 @@ mock.module("../../util/logger.js", () => ({
 
 let flagEnabled = true;
 let isAuto = false;
+let isRetrospective = false;
 let configValue: { analysis?: { idleTimeoutMs?: number } } = {
   analysis: { idleTimeoutMs: 600_000 },
 };
@@ -44,6 +45,11 @@ mock.module("../../config/assistant-feature-flags.js", () => ({
 mock.module("../auto-analysis-guard.js", () => ({
   AUTO_ANALYSIS_SOURCE: "auto-analysis",
   isAutoAnalysisConversation: (_conversationId: string) => isAuto,
+}));
+
+mock.module("../memory-retrospective-enqueue.js", () => ({
+  isMemoryRetrospectiveConversation: (_conversationId: string) =>
+    isRetrospective,
 }));
 
 mock.module("../jobs-store.js", () => ({
@@ -90,6 +96,7 @@ describe("enqueueAutoAnalysisIfEnabled", () => {
   beforeEach(() => {
     flagEnabled = true;
     isAuto = false;
+    isRetrospective = false;
     getConfigThrows = false;
     configValue = { analysis: { idleTimeoutMs: 600_000 } };
     enqueueCalls.length = 0;
@@ -191,6 +198,27 @@ describe("enqueueAutoAnalysisIfEnabled", () => {
     expect(debouncedCalls).toHaveLength(0);
   });
 
+  test("flag on, source is a memory-retrospective conversation — no job is enqueued", () => {
+    // Fork-kind retrospective conversations carry a full copy of the source
+    // conversation's history; auto-analyzing one would re-process the entire
+    // source conversation and double-write memory.
+    isRetrospective = true;
+
+    enqueueAutoAnalysisIfEnabled({ conversationId: "c1", trigger: "batch" });
+    enqueueAutoAnalysisIfEnabled({ conversationId: "c1", trigger: "idle" });
+    enqueueAutoAnalysisIfEnabled({
+      conversationId: "c1",
+      trigger: "lifecycle",
+    });
+    enqueueAutoAnalysisIfEnabled({
+      conversationId: "c1",
+      trigger: "compaction",
+    });
+
+    expect(enqueueCalls).toHaveLength(0);
+    expect(debouncedCalls).toHaveLength(0);
+  });
+
   test("getConfig throws — skips silently without enqueueing", () => {
     getConfigThrows = true;
 
@@ -262,6 +290,7 @@ describe("enqueueAutoAnalysisOnCompaction", () => {
   beforeEach(() => {
     flagEnabled = true;
     isAuto = false;
+    isRetrospective = false;
     getConfigThrows = false;
     configValue = { analysis: { idleTimeoutMs: 600_000 } };
     enqueueCalls.length = 0;
@@ -323,6 +352,15 @@ describe("enqueueAutoAnalysisOnCompaction", () => {
 
   test("guardian trust but source is auto-analysis — helper skips via recursion guard", () => {
     isAuto = true;
+
+    enqueueAutoAnalysisOnCompaction("c1", "guardian");
+
+    expect(enqueueCalls).toHaveLength(0);
+    expect(debouncedCalls).toHaveLength(0);
+  });
+
+  test("guardian trust but source is a memory-retrospective conversation — helper skips", () => {
+    isRetrospective = true;
 
     enqueueAutoAnalysisOnCompaction("c1", "guardian");
 

--- a/assistant/src/memory/auto-analysis-enqueue.ts
+++ b/assistant/src/memory/auto-analysis-enqueue.ts
@@ -7,6 +7,7 @@ import {
 import { getLogger } from "../util/logger.js";
 import { isAutoAnalysisConversation } from "./auto-analysis-guard.js";
 import { isMemoryEnabled, upsertAutoAnalysisJob } from "./jobs-store.js";
+import { isMemoryRetrospectiveConversation } from "./memory-retrospective-enqueue.js";
 
 const log = getLogger("auto-analysis-enqueue");
 
@@ -31,7 +32,11 @@ export type AutoAnalysisTrigger = "batch" | "idle" | "lifecycle" | "compaction";
  * conversation. Skips silently when:
  *   - the `auto-analyze` feature flag is disabled, OR
  *   - the source conversation is itself an auto-analysis conversation
- *     (recursion guard — we never analyze our own analysis output).
+ *     (recursion guard — we never analyze our own analysis output), OR
+ *   - the source conversation is a memory-retrospective conversation.
+ *     Fork-kind retrospectives carry a full copy of the source
+ *     conversation's history, so auto-analyzing one would re-process the
+ *     entire source conversation and double-write memory.
  *
  * Immediate triggers (`"batch"`, `"compaction"`) and debounced triggers
  * (`"idle"`, `"lifecycle"`) are written to separate rows keyed by a
@@ -69,6 +74,14 @@ export function enqueueAutoAnalysisIfEnabled(args: {
     log.debug(
       { conversationId, trigger },
       "Skipping auto-analysis enqueue: source is an auto-analysis conversation",
+    );
+    return;
+  }
+
+  if (isMemoryRetrospectiveConversation(conversationId)) {
+    log.debug(
+      { conversationId, trigger },
+      "Skipping auto-analysis enqueue: source is a memory-retrospective conversation",
     );
     return;
   }

--- a/assistant/src/runtime/services/__tests__/analyze-conversation.test.ts
+++ b/assistant/src/runtime/services/__tests__/analyze-conversation.test.ts
@@ -365,6 +365,44 @@ describe("analyzeConversation", () => {
     expect(mockAddMessage).not.toHaveBeenCalled();
   });
 
+  test.each(["memory-retrospective", "memory-retrospective-fork"])(
+    "auto: rejects when the source conversation is a %s conversation",
+    async (source) => {
+      // Fork-kind retrospective conversations carry a full copy of the
+      // source conversation's history; auto-analyzing one would re-process
+      // the entire source conversation and double-write memory.
+      mockGetConversationSource.mockImplementation(() => source);
+
+      const result = await analyzeConversation("conv-1", {
+        trigger: "auto",
+      });
+
+      expect("error" in result).toBe(true);
+      if (!("error" in result)) throw new Error("expected error");
+      expect(result.error.kind).toBe("BAD_REQUEST");
+      expect(result.error.status).toBe(400);
+
+      // Nothing downstream of the guard should have fired.
+      expect(mockFindAnalysisConversationFor).not.toHaveBeenCalled();
+      expect(mockCreateConversation).not.toHaveBeenCalled();
+      expect(mockAddMessage).not.toHaveBeenCalled();
+    },
+  );
+
+  test("manual: does NOT reject a memory-retrospective conversation (guard is auto-only)", async () => {
+    mockGetConversationSource.mockImplementation(
+      () => "memory-retrospective-fork",
+    );
+
+    const result = await analyzeConversation("conv-1", {
+      trigger: "manual",
+    });
+
+    expect("error" in result).toBe(false);
+    if ("error" in result) throw new Error("expected success");
+    expect(result.analysisConversationId).toBe("analysis-new");
+  });
+
   test("auto: routes the agent loop through callSite: 'analyzeConversation'", async () => {
     await analyzeConversation("conv-1", { trigger: "auto" });
 

--- a/assistant/src/runtime/services/analyze-conversation.ts
+++ b/assistant/src/runtime/services/analyze-conversation.ts
@@ -34,6 +34,7 @@ import {
   getMessages,
 } from "../../memory/conversation-crud.js";
 import { resolveConversationId } from "../../memory/conversation-key-store.js";
+import { MEMORY_RETROSPECTIVE_SOURCES } from "../../memory/memory-retrospective-constants.js";
 import { getLogger } from "../../util/logger.js";
 import { assistantEventHub, broadcastMessage } from "../assistant-event-hub.js";
 import {
@@ -118,19 +119,31 @@ export async function analyzeConversation(
 
   // e. Defense-in-depth recursion guard for auto mode: refuse to
   // auto-analyze a conversation that is itself an auto-analysis
-  // conversation. Prevents job-handler bugs from triggering runaway
-  // self-analysis loops.
-  if (
-    opts.trigger === "auto" &&
-    getConversationSource(resolvedId) === AUTO_ANALYSIS_SOURCE
-  ) {
-    return {
-      error: {
-        kind: "BAD_REQUEST",
-        status: 400,
-        message: "Cannot auto-analyze an auto-analysis conversation",
-      },
-    };
+  // conversation (prevents job-handler bugs from triggering runaway
+  // self-analysis loops) or a memory-retrospective conversation
+  // (fork-kind retrospectives carry a full copy of the source history,
+  // so auto-analyzing one would re-process the entire source
+  // conversation and double-write memory).
+  if (opts.trigger === "auto") {
+    const source = getConversationSource(resolvedId);
+    if (source === AUTO_ANALYSIS_SOURCE) {
+      return {
+        error: {
+          kind: "BAD_REQUEST",
+          status: 400,
+          message: "Cannot auto-analyze an auto-analysis conversation",
+        },
+      };
+    }
+    if (source !== null && MEMORY_RETROSPECTIVE_SOURCES.includes(source)) {
+      return {
+        error: {
+          kind: "BAD_REQUEST",
+          status: 400,
+          message: "Cannot auto-analyze a memory-retrospective conversation",
+        },
+      };
+    }
   }
 
   // f. Build the analysis transcript


### PR DESCRIPTION
## Summary
- Skip auto-analysis enqueue for conversations whose source is a memory-retrospective sentinel
- Add the same defense-in-depth rejection to analyzeConversation's auto mode
- Prevents O(history) auto-analysis passes over fork-kind retrospective conversations (full history copies)

Part of plan: memory-retrospective-fork-hardening.md (PR C of 12)