### PR TITLE
feat(watcher): add usage telemetry via lifecycle events

### DIFF
--- a/assistant/src/watcher/__tests__/engine.test.ts
+++ b/assistant/src/watcher/__tests__/engine.test.ts
@@ -105,6 +105,21 @@ mock.module("../../runtime/background-job-runner.js", () => ({
   },
 }));
 
+const inventoryCalls: number[] = [];
+const llmProcessedCalls: Array<{
+  providerId: string;
+  conversationId: string;
+}> = [];
+
+mock.module("../telemetry.js", () => ({
+  recordWatcherInventoryIfDue: (now: number) => {
+    inventoryCalls.push(now);
+  },
+  recordWatcherLlmProcessed: (providerId: string, conversationId: string) => {
+    llmProcessedCalls.push({ providerId, conversationId });
+  },
+}));
+
 // Import after mocks are in place.
 const { runWatchersOnce } = await import("../engine.js");
 
@@ -156,6 +171,8 @@ beforeEach(() => {
   setConvCalls.length = 0;
   dispositionCalls.length = 0;
   runJobCalls.length = 0;
+  inventoryCalls.length = 0;
+  llmProcessedCalls.length = 0;
   runJobImpl = async () => ({ conversationId: "conv-stub", ok: true });
 });
 
@@ -223,6 +240,9 @@ describe("runWatchersOnce — Phase 2 runBackgroundJob integration", () => {
     expect(setConvCalls).toEqual([
       { watcherId: "watcher-1", conversationId: "conv-success" },
     ]);
+    expect(llmProcessedCalls).toEqual([
+      { providerId: "linear", conversationId: "conv-success" },
+    ]);
     expect(dispositionCalls).toHaveLength(2);
     for (const call of dispositionCalls) {
       expect(call.disposition).toBe("silent");
@@ -267,6 +287,8 @@ describe("runWatchersOnce — Phase 2 runBackgroundJob integration", () => {
     // Critical: we must NOT have called setWatcherConversationId with "",
     // which would clobber a valid prior conversation id in the DB.
     expect(setConvCalls).toEqual([]);
+    // No conversation was bootstrapped, so no usage breadcrumb either.
+    expect(llmProcessedCalls).toEqual([]);
     // Failure path still updates event dispositions.
     expect(dispositionCalls).toHaveLength(1);
     expect(dispositionCalls[0].disposition).toBe("error");
@@ -280,6 +302,8 @@ describe("runWatchersOnce — Phase 2 runBackgroundJob integration", () => {
 
     expect(runJobCalls).toHaveLength(0);
     expect(setConvCalls).toHaveLength(0);
+    // Inventory telemetry runs on every tick regardless of pending work.
+    expect(inventoryCalls).toHaveLength(1);
   });
 
   test("malicious payload reaches the runner only inside assistant-role sandwich.content", async () => {

--- a/assistant/src/watcher/__tests__/telemetry.test.ts
+++ b/assistant/src/watcher/__tests__/telemetry.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for watcher usage telemetry.
+ *
+ * Strategy: stub the checkpoint store, lifecycle-event store, and
+ * watcher store via `mock.module()` so we can drive the inventory
+ * throttle and event naming without touching the DB.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const checkpoints = new Map<string, string>();
+const recordedEvents: string[] = [];
+let fakeEnabledWatchers: Array<{ providerId: string }> = [];
+let recordImpl: (name: string) => void = (name) => {
+  recordedEvents.push(name);
+};
+
+mock.module("../../memory/checkpoints.js", () => ({
+  getMemoryCheckpoint: (key: string) => checkpoints.get(key) ?? null,
+  setMemoryCheckpoint: (key: string, value: string) => {
+    checkpoints.set(key, value);
+  },
+}));
+
+mock.module("../../memory/lifecycle-events-store.js", () => ({
+  recordLifecycleEvent: (name: string) => {
+    recordImpl(name);
+    return null;
+  },
+}));
+
+mock.module("../watcher-store.js", () => ({
+  listWatchers: () => fakeEnabledWatchers,
+}));
+
+const {
+  recordWatcherInventoryIfDue,
+  recordWatcherLlmProcessed,
+  WATCHER_INVENTORY_INTERVAL_MS,
+} = await import("../telemetry.js");
+
+const INVENTORY_KEY = "telemetry:watchers:inventory_last_recorded";
+// Realistic epoch base: an absent checkpoint reads as 0, so `now` must be
+// at least one interval past the epoch for the inventory to be due.
+const BASE = 1_700_000_000_000;
+
+beforeEach(() => {
+  checkpoints.clear();
+  recordedEvents.length = 0;
+  fakeEnabledWatchers = [];
+  recordImpl = (name) => {
+    recordedEvents.push(name);
+  };
+});
+
+describe("recordWatcherInventoryIfDue", () => {
+  test("records one event per enabled watcher when due", () => {
+    fakeEnabledWatchers = [
+      { providerId: "gmail" },
+      { providerId: "linear" },
+      { providerId: "gmail" },
+    ];
+
+    recordWatcherInventoryIfDue(BASE);
+
+    expect(recordedEvents).toEqual([
+      "watcher_enabled:gmail",
+      "watcher_enabled:linear",
+      "watcher_enabled:gmail",
+    ]);
+    expect(checkpoints.get(INVENTORY_KEY)).toBe(String(BASE));
+  });
+
+  test("skips when the last inventory is within the interval", () => {
+    fakeEnabledWatchers = [{ providerId: "gmail" }];
+    checkpoints.set(INVENTORY_KEY, String(BASE));
+
+    recordWatcherInventoryIfDue(BASE + WATCHER_INVENTORY_INTERVAL_MS - 1);
+
+    expect(recordedEvents).toEqual([]);
+    expect(checkpoints.get(INVENTORY_KEY)).toBe(String(BASE));
+  });
+
+  test("records again once the interval has elapsed", () => {
+    fakeEnabledWatchers = [{ providerId: "github" }];
+    checkpoints.set(INVENTORY_KEY, String(BASE));
+
+    recordWatcherInventoryIfDue(BASE + WATCHER_INVENTORY_INTERVAL_MS);
+
+    expect(recordedEvents).toEqual(["watcher_enabled:github"]);
+  });
+
+  test("advances the checkpoint even when no watchers are enabled", () => {
+    recordWatcherInventoryIfDue(BASE + 1);
+
+    expect(recordedEvents).toEqual([]);
+    expect(checkpoints.get(INVENTORY_KEY)).toBe(String(BASE + 1));
+  });
+
+  test("swallows storage errors", () => {
+    fakeEnabledWatchers = [{ providerId: "gmail" }];
+    recordImpl = () => {
+      throw new Error("db unavailable");
+    };
+
+    expect(() => recordWatcherInventoryIfDue(BASE + 2)).not.toThrow();
+  });
+});
+
+describe("recordWatcherLlmProcessed", () => {
+  test("embeds provider and conversation id in the event name", () => {
+    recordWatcherLlmProcessed("linear", "conv-123");
+
+    expect(recordedEvents).toEqual(["watcher_llm_processed:linear:conv-123"]);
+  });
+
+  test("swallows storage errors", () => {
+    recordImpl = () => {
+      throw new Error("db unavailable");
+    };
+
+    expect(() => recordWatcherLlmProcessed("gmail", "conv-456")).not.toThrow();
+  });
+});

--- a/assistant/src/watcher/__tests__/telemetry.test.ts
+++ b/assistant/src/watcher/__tests__/telemetry.test.ts
@@ -97,13 +97,24 @@ describe("recordWatcherInventoryIfDue", () => {
     expect(checkpoints.get(INVENTORY_KEY)).toBe(String(BASE + 1));
   });
 
-  test("swallows storage errors", () => {
+  test("swallows storage errors and leaves the checkpoint for retry", () => {
     fakeEnabledWatchers = [{ providerId: "gmail" }];
     recordImpl = () => {
       throw new Error("db unavailable");
     };
 
     expect(() => recordWatcherInventoryIfDue(BASE + 2)).not.toThrow();
+    // Checkpoint must not advance on failure: the next tick retries
+    // instead of skipping a day of inventory.
+    expect(checkpoints.get(INVENTORY_KEY)).toBeUndefined();
+
+    recordImpl = (name) => {
+      recordedEvents.push(name);
+    };
+    recordWatcherInventoryIfDue(BASE + 3);
+
+    expect(recordedEvents).toEqual(["watcher_enabled:gmail"]);
+    expect(checkpoints.get(INVENTORY_KEY)).toBe(String(BASE + 3));
   });
 });
 

--- a/assistant/src/watcher/engine.ts
+++ b/assistant/src/watcher/engine.ts
@@ -13,6 +13,10 @@ import { getLogger } from "../util/logger.js";
 import { MAX_CONSECUTIVE_ERRORS, WATCHER_JOB_TIMEOUT_MS } from "./constants.js";
 import { getWatcherProvider } from "./provider-registry.js";
 import {
+  recordWatcherInventoryIfDue,
+  recordWatcherLlmProcessed,
+} from "./telemetry.js";
+import {
   claimDueWatchers,
   completeWatcherPoll,
   disableWatcher,
@@ -68,6 +72,8 @@ export async function runWatchersOnce(
 ): Promise<number> {
   const now = Date.now();
   let processed = 0;
+
+  recordWatcherInventoryIfDue(now);
 
   // ── Phase 1: Poll providers for new events ──────────────────────
   const claimed = claimDueWatchers(now);
@@ -269,6 +275,7 @@ export async function runWatchersOnce(
     // is empty) — otherwise we'd overwrite a valid prior id with "".
     if (result.conversationId !== "") {
       setWatcherConversationId(watcher.id, result.conversationId);
+      recordWatcherLlmProcessed(watcher.providerId, result.conversationId);
     }
 
     if (result.ok) {

--- a/assistant/src/watcher/telemetry.ts
+++ b/assistant/src/watcher/telemetry.ts
@@ -1,0 +1,71 @@
+/**
+ * Watcher usage telemetry — lifecycle-event breadcrumbs that let fleet
+ * analytics answer "is anyone using watchers, and what do they cost?"
+ * ahead of the planned watcher → skills-and-schedules migration.
+ *
+ * Both event shapes ship through the existing lifecycle-event telemetry
+ * pipeline, so they inherit its `collectUsageData` opt-out gate and need
+ * no wire-contract or platform-side changes:
+ *
+ * - `watcher_enabled:<providerId>` — one per enabled watcher, at most
+ *   once per 24h per daemon. Counts devices that have watchers
+ *   configured, including ones whose providers rarely produce events.
+ * - `watcher_llm_processed:<providerId>:<conversationId>` — one per
+ *   watcher tick that ran an LLM background job. The conversation id is
+ *   embedded so analytics can join against `llm_usage` events for exact
+ *   cost attribution.
+ *
+ * Telemetry must never break the polling loop, so every entry point
+ * swallows storage errors.
+ */
+
+import {
+  getMemoryCheckpoint,
+  setMemoryCheckpoint,
+} from "../memory/checkpoints.js";
+import { recordLifecycleEvent } from "../memory/lifecycle-events-store.js";
+import { getLogger } from "../util/logger.js";
+import { listWatchers } from "./watcher-store.js";
+
+const log = getLogger("watcher-telemetry");
+
+const INVENTORY_CHECKPOINT_KEY = "telemetry:watchers:inventory_last_recorded";
+export const WATCHER_INVENTORY_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Record one `watcher_enabled:<providerId>` lifecycle event per enabled
+ * watcher, at most once per 24h. Called from every watcher tick; the
+ * checkpoint advances even when no watchers are enabled so the inventory
+ * query runs once per interval rather than every tick.
+ */
+export function recordWatcherInventoryIfDue(now: number): void {
+  try {
+    const last = Number(getMemoryCheckpoint(INVENTORY_CHECKPOINT_KEY) ?? "0");
+    if (now - last < WATCHER_INVENTORY_INTERVAL_MS) return;
+    setMemoryCheckpoint(INVENTORY_CHECKPOINT_KEY, String(now));
+    for (const watcher of listWatchers({ enabledOnly: true })) {
+      recordLifecycleEvent(`watcher_enabled:${watcher.providerId}`);
+    }
+  } catch (err) {
+    log.warn({ err }, "Failed to record watcher inventory telemetry");
+  }
+}
+
+/**
+ * Record a `watcher_llm_processed:<providerId>:<conversationId>`
+ * lifecycle event for a watcher tick that bootstrapped an LLM background
+ * job. Recorded whenever a conversation was created — even if the job
+ * later failed — because tokens may already have been spent.
+ */
+export function recordWatcherLlmProcessed(
+  providerId: string,
+  conversationId: string,
+): void {
+  try {
+    recordLifecycleEvent(
+      `watcher_llm_processed:${providerId}:${conversationId}`,
+    );
+  } catch (err) {
+    log.warn({ err }, "Failed to record watcher LLM-processed telemetry");
+  }
+}

--- a/assistant/src/watcher/telemetry.ts
+++ b/assistant/src/watcher/telemetry.ts
@@ -35,17 +35,20 @@ export const WATCHER_INVENTORY_INTERVAL_MS = 24 * 60 * 60 * 1000;
 /**
  * Record one `watcher_enabled:<providerId>` lifecycle event per enabled
  * watcher, at most once per 24h. Called from every watcher tick; the
- * checkpoint advances even when no watchers are enabled so the inventory
- * query runs once per interval rather than every tick.
+ * checkpoint advances only after the events are recorded, so a transient
+ * storage failure retries on the next tick instead of skipping a day.
+ * Retries can duplicate events for watchers recorded before the failure
+ * point — an acceptable overcount for best-effort telemetry, where losing
+ * a full day's inventory would not be.
  */
 export function recordWatcherInventoryIfDue(now: number): void {
   try {
     const last = Number(getMemoryCheckpoint(INVENTORY_CHECKPOINT_KEY) ?? "0");
     if (now - last < WATCHER_INVENTORY_INTERVAL_MS) return;
-    setMemoryCheckpoint(INVENTORY_CHECKPOINT_KEY, String(now));
     for (const watcher of listWatchers({ enabledOnly: true })) {
       recordLifecycleEvent(`watcher_enabled:${watcher.providerId}`);
     }
+    setMemoryCheckpoint(INVENTORY_CHECKPOINT_KEY, String(now));
   } catch (err) {
     log.warn({ err }, "Failed to record watcher inventory telemetry");
   }


### PR DESCRIPTION
## What

Adds fleet-visible usage tracking for watchers, via two lifecycle-event breadcrumbs recorded by the watcher engine:

- **`watcher_enabled:<providerId>`** — one per enabled watcher, throttled to once per 24h per daemon (memory-checkpoint watermark). Counts devices that have watchers configured, including ones whose providers rarely produce events.
- **`watcher_llm_processed:<providerId>:<conversationId>`** — one per watcher tick that bootstrapped an LLM background job (recorded even when the job later fails, since tokens may already be spent). The embedded conversation id lets analytics join against `llm_usage` telemetry events for exact cost attribution.

## Why

Watchers run LLM background jobs that cost users money in the background (this is generating support email), but their usage is currently invisible fleet-side: watcher conversations carry `conversation_type: "background"`, indistinguishable from other background work on the telemetry wire. We're deciding whether watchers get removed outright or refactored into skills + tokenless schedules — that decision needs data on who actually uses them. Came out of today's Watchers/Background-Tasks discussion (Noa/Aaron/Barry).

## Design notes

- Lifecycle events were chosen deliberately: they're free-form pass-through strings (precedent: `permission_prompt:<toolName>`), so this ships with **zero platform-side or wire-contract changes** and inherits the `collectUsageData` opt-out gate in `recordLifecycleEvent`.
- Explicitly did **not** add a `'watcher'` value to `conversation_type`: that column is load-bearing in conversation-list filters (`NOT IN ('background', 'scheduled', 'private')`), and a new value would leak watcher conversations into user-facing lists.
- Telemetry never breaks the polling loop — both entry points swallow storage errors.

## Testing

- New `src/watcher/__tests__/telemetry.test.ts` (7 tests): per-watcher inventory events, 24h throttle, checkpoint advance on empty inventory, error swallowing, event-name shape.
- Extended `src/watcher/__tests__/engine.test.ts` (6 tests): breadcrumb recorded on success, skipped on bootstrap failure, inventory called per tick.
- `bunx tsc --noEmit` clean, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)