### PR TITLE
feat(cli): add get and update subcommands to assistant schedules CLI

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -21353,6 +21353,153 @@ paths:
           required: true
           schema:
             type: string
+    get:
+      operationId: schedules_by_id_get
+      summary: Get schedule
+      description: Return a single schedule by ID.
+      tags:
+        - schedules
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  schedule:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      name:
+                        type: string
+                      enabled:
+                        type: boolean
+                      syntax:
+                        type: string
+                        enum:
+                          - cron
+                          - rrule
+                      expression:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      cronExpression:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      timezone:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      message:
+                        type: string
+                      script:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      nextRunAt:
+                        type: number
+                      lastRunAt:
+                        anyOf:
+                          - type: number
+                          - type: "null"
+                      lastStatus:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      retryCount:
+                        type: number
+                      maxRetries:
+                        type: number
+                      retryBackoffMs:
+                        type: number
+                      timeoutMs:
+                        anyOf:
+                          - type: number
+                          - type: "null"
+                      createdFromConversationId:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      createdFromConversationExists:
+                        type: boolean
+                      createdFromConversationArchivedAt:
+                        anyOf:
+                          - type: number
+                          - type: "null"
+                      description:
+                        type: string
+                      cadenceDescription:
+                        type: string
+                      mode:
+                        type: string
+                        enum:
+                          - notify
+                          - execute
+                          - script
+                          - wake
+                      status:
+                        type: string
+                        enum:
+                          - active
+                          - firing
+                          - fired
+                          - cancelled
+                      routingIntent:
+                        type: string
+                        enum:
+                          - single_channel
+                          - multi_channel
+                          - all_channels
+                      reuseConversation:
+                        type: boolean
+                      wakeConversationId:
+                        anyOf:
+                          - type: string
+                          - type: "null"
+                      isOneShot:
+                        type: boolean
+                    required:
+                      - id
+                      - name
+                      - enabled
+                      - syntax
+                      - expression
+                      - cronExpression
+                      - timezone
+                      - message
+                      - script
+                      - nextRunAt
+                      - lastRunAt
+                      - lastStatus
+                      - retryCount
+                      - maxRetries
+                      - retryBackoffMs
+                      - timeoutMs
+                      - createdFromConversationId
+                      - createdFromConversationExists
+                      - createdFromConversationArchivedAt
+                      - description
+                      - cadenceDescription
+                      - mode
+                      - status
+                      - routingIntent
+                      - reuseConversation
+                      - wakeConversationId
+                      - isOneShot
+                    additionalProperties: false
+                    description: Schedule object
+                required:
+                  - schedule
+                additionalProperties: false
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
     patch:
       operationId: schedules_by_id_patch
       summary: Update schedule

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -76,7 +76,7 @@ import { recordUsageEvent } from "../memory/llm-usage-store.js";
 import { rawRun } from "../memory/raw-query.js";
 import type { AssistantEvent } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
-import { BadRequestError } from "../runtime/routes/errors.js";
+import { BadRequestError, NotFoundError } from "../runtime/routes/errors.js";
 import { ROUTES as HEARTBEAT_ROUTES } from "../runtime/routes/heartbeat-routes.js";
 import { ROUTES as SCHEDULE_ROUTES } from "../runtime/routes/schedule-routes.js";
 import type { RouteDefinition } from "../runtime/routes/types.js";
@@ -584,6 +584,71 @@ describe("GET /schedules — default defer exclusion", () => {
     } finally {
       subscription.dispose();
     }
+  });
+});
+
+// ── GET /schedules/:id ────────────────────────────────────────────────────
+
+describe("GET /schedules/:id", () => {
+  beforeEach(() => {
+    clearTables();
+  });
+
+  test("returns the full schedule by ID", () => {
+    const source = createConversation("Schedule source");
+    const schedule = createSchedule({
+      name: "Single schedule",
+      description: "Fetch me by ID",
+      cronExpression: "0 9 * * *",
+      message: "review queue",
+      syntax: "cron",
+      createdFromConversationId: source.id,
+    });
+
+    const route = findRoute("schedules/:id", "GET");
+    const result = route.handler({ pathParams: { id: schedule.id } }) as {
+      schedule: Record<string, unknown>;
+    };
+
+    expect(result.schedule).toMatchObject({
+      id: schedule.id,
+      name: "Single schedule",
+      description: "Fetch me by ID",
+      cadenceDescription: "Every day at 9:00 AM",
+      message: "review queue",
+      mode: "execute",
+      enabled: true,
+      isOneShot: false,
+      createdFromConversationId: source.id,
+      createdFromConversationExists: true,
+      createdFromConversationArchivedAt: null,
+    });
+  });
+
+  test("returns deferred schedules that the list hides by default", () => {
+    const deferred = createSchedule({
+      name: "Deferred wake",
+      cronExpression: "0 9 * * *",
+      message: "wake up",
+      syntax: "cron",
+      createdBy: "defer",
+    });
+
+    const route = findRoute("schedules/:id", "GET");
+    const result = route.handler({ pathParams: { id: deferred.id } }) as {
+      schedule: { id: string };
+    };
+    expect(result.schedule.id).toBe(deferred.id);
+  });
+
+  test("throws NotFoundError for a missing schedule", () => {
+    const route = findRoute("schedules/:id", "GET");
+    expect(() =>
+      route.handler({ pathParams: { id: "missing-schedule" } }),
+    ).toThrow(NotFoundError);
+    expect(() =>
+      route.handler({ pathParams: { id: "missing-schedule" } }),
+    ).toThrow("Schedule not found");
   });
 });
 

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -1298,6 +1298,45 @@ describe("PATCH /schedules/:id — description", () => {
     });
     expect(listSchedules()[0].description).toBe("Updated description");
   });
+
+  test("re-derives syntax when the expression switches cron to rrule", () => {
+    const schedule = createSchedule({
+      name: "Syntax switch",
+      description: "Cron schedule",
+      cronExpression: "0 9 * * *",
+      message: "hi",
+      syntax: "cron",
+    });
+
+    const route = findRoute("schedules/:id", "PATCH");
+    const rrule = "DTSTART:20260101T000000Z\nRRULE:FREQ=WEEKLY;BYDAY=MO";
+    route.handler({
+      pathParams: { id: schedule.id },
+      body: { expression: rrule },
+    });
+
+    const updated = listSchedules()[0];
+    expect(updated.syntax).toBe("rrule");
+    expect(updated.cronExpression).toBe(rrule);
+  });
+
+  test("rejects an expression that parses as neither cron nor rrule", () => {
+    const schedule = createSchedule({
+      name: "Bad expression",
+      description: "Cron schedule",
+      cronExpression: "0 9 * * *",
+      message: "hi",
+      syntax: "cron",
+    });
+
+    const route = findRoute("schedules/:id", "PATCH");
+    expect(() =>
+      route.handler({
+        pathParams: { id: schedule.id },
+        body: { expression: "not a schedule" },
+      }),
+    ).toThrow(BadRequestError);
+  });
 });
 
 // ── Wake mode support ─────────────────────────────────────────────────────

--- a/assistant/src/cli/AGENTS.md
+++ b/assistant/src/cli/AGENTS.md
@@ -14,6 +14,10 @@ For commands that manage the **lifecycle of assistant instances** (create, start
 
 Examples: `config`, `contacts`, `memory`, `autonomy`, `conversations` belong here. `hatch`, `wake`, `sleep`, `retire`, `ps`, `ssh` belong in `cli/`.
 
+## Full CRUD for Resource Namespaces
+
+Every namespace that manages a resource (schedules, contacts, tasks, …) must expose the full CRUD surface — create, get/list, update, delete — each wired to a daemon route. Intentional exceptions (e.g. create restricted to one mode) must be documented inline in the namespace help text so agents know the gap is deliberate. Partial surfaces are not a smaller scope, they are a hazard: when a CRUD verb is missing, the model bypasses the CLI and hand-writes SQLite rows instead.
+
 ## Conventions
 
 - Commands use [Commander.js](https://github.com/tj/commander.js) and follow the `registerXCommand(program: Command)` pattern.

--- a/assistant/src/cli/commands/__tests__/schedules.test.ts
+++ b/assistant/src/cli/commands/__tests__/schedules.test.ts
@@ -813,6 +813,58 @@ describe("schedules update", () => {
     expect(errorLines.join("\n")).toContain("mutually exclusive");
   });
 
+  test("rejects --mode wake when the schedule has no wake conversation target", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: { schedule: { wakeConversationId: null } },
+    };
+
+    const { exitCode } = await runCommand([
+      "schedules",
+      "update",
+      "schedule-1",
+      "--mode",
+      "wake",
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(ipcCalls).toEqual([
+      { method: "getSchedule", params: { pathParams: { id: "schedule-1" } } },
+    ]);
+    expect(errorLines.join("\n")).toContain("wake conversation target");
+  });
+
+  test("allows --mode wake when the schedule already has a wake target", async () => {
+    // The shared mock returns one shape for both IPC calls; satisfy the
+    // getSchedule guard and the update response renderer simultaneously.
+    mockIpcResult = {
+      ok: true,
+      result: {
+        schedule: { wakeConversationId: "conv-1" },
+        schedules: [],
+      },
+    };
+
+    const { exitCode } = await runCommand([
+      "schedules",
+      "update",
+      "schedule-1",
+      "--mode",
+      "wake",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(ipcCalls).toHaveLength(2);
+    expect(ipcCalls[0].method).toBe("getSchedule");
+    expect(ipcCalls[1]).toEqual({
+      method: "updateSchedule",
+      params: {
+        pathParams: { id: "schedule-1" },
+        body: { mode: "wake" },
+      },
+    });
+  });
+
   test("sends boolean false for negated flags", async () => {
     mockIpcResult = { ok: true, result: { schedules: [] } };
 

--- a/assistant/src/cli/commands/__tests__/schedules.test.ts
+++ b/assistant/src/cli/commands/__tests__/schedules.test.ts
@@ -98,8 +98,10 @@ describe("schedules command", () => {
     expect(schedules).toBeDefined();
     expect(schedules!.commands.map((command) => command.name())).toEqual([
       "list",
+      "get",
       "runs",
       "create",
+      "update",
       "enable",
       "disable",
       "cancel",
@@ -249,6 +251,102 @@ describe("schedules list", () => {
       ok: false,
       error: "daemon unavailable",
     });
+  });
+});
+
+describe("schedules get", () => {
+  const scheduleFixture = {
+    id: "schedule-1",
+    name: "Heartbeat",
+    enabled: true,
+    syntax: "cron",
+    expression: "*/30 * * * *",
+    cronExpression: "*/30 * * * *",
+    timezone: "UTC",
+    message: "run heartbeat",
+    script: null,
+    nextRunAt: 1_778_800_000_000,
+    lastRunAt: 1_778_799_000_000,
+    lastStatus: "ok",
+    retryCount: 0,
+    maxRetries: 3,
+    retryBackoffMs: 60_000,
+    timeoutMs: null,
+    createdFromConversationId: "conv-abc",
+    description: "Authored heartbeat check",
+    cadenceDescription: "Every 30 minutes",
+    mode: "execute",
+    status: "active",
+    routingIntent: "all_channels",
+    reuseConversation: false,
+    wakeConversationId: null,
+    isOneShot: false,
+  };
+
+  test("calls getSchedule with the schedule ID path param", async () => {
+    mockIpcResult = { ok: true, result: { schedule: scheduleFixture } };
+
+    const { exitCode } = await runCommand(["schedules", "get", "schedule-1"]);
+
+    expect(exitCode).toBe(0);
+    expect(ipcCalls).toEqual([
+      {
+        method: "getSchedule",
+        params: { pathParams: { id: "schedule-1" } },
+      },
+    ]);
+  });
+
+  test("renders a detail view for human output", async () => {
+    mockIpcResult = { ok: true, result: { schedule: scheduleFixture } };
+
+    const { exitCode } = await runCommand(["schedules", "get", "schedule-1"]);
+
+    expect(exitCode).toBe(0);
+    const output = logLines.join("\n");
+    expect(output).toContain("ID:");
+    expect(output).toContain("schedule-1");
+    expect(output).toContain("Heartbeat");
+    expect(output).toContain("Authored heartbeat check");
+    expect(output).toContain("Every 30 minutes (UTC)");
+    expect(output).toContain("run heartbeat");
+    expect(output).toContain("all_channels");
+    expect(output).toContain("conv-abc");
+  });
+
+  test("emits JSON result when --json is set", async () => {
+    mockIpcResult = { ok: true, result: { schedule: scheduleFixture } };
+
+    const { stdout, exitCode } = await runCommand([
+      "schedules",
+      "get",
+      "schedule-1",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout)).toEqual({
+      schedule: expect.objectContaining({
+        id: "schedule-1",
+        name: "Heartbeat",
+        description: "Authored heartbeat check",
+      }),
+    });
+    expect(logLines).toEqual([]);
+  });
+
+  test("routes IPC failure through exitFromIpcResult", async () => {
+    mockIpcResult = { ok: false, error: "Schedule not found" };
+
+    const { exitCode } = await runCommand([
+      "schedules",
+      "get",
+      "missing-schedule",
+    ]);
+
+    expect(exitCode).toBe(10);
+    expect(exitFromIpcResultCalls).toEqual([mockIpcResult]);
+    expect(errorLines).toEqual([]);
   });
 });
 
@@ -582,6 +680,223 @@ describe("schedules create", () => {
       "noop",
       "--description",
       "Invalid test schedule",
+    ]);
+
+    expect(exitCode).toBe(10);
+    expect(exitFromIpcResultCalls).toEqual([mockIpcResult]);
+    expect(errorLines).toEqual([]);
+  });
+});
+
+describe("schedules update", () => {
+  test("calls updateSchedule with only the provided flags", async () => {
+    mockIpcResult = { ok: true, result: { schedules: [] } };
+
+    const { exitCode } = await runCommand([
+      "schedules",
+      "update",
+      "schedule-1",
+      "--name",
+      "Renamed",
+      "--expression",
+      "0 9 * * MON-FRI",
+      "--timezone",
+      "America/New_York",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(ipcCalls).toEqual([
+      {
+        method: "updateSchedule",
+        params: {
+          pathParams: { id: "schedule-1" },
+          body: {
+            name: "Renamed",
+            expression: "0 9 * * MON-FRI",
+            timezone: "America/New_York",
+          },
+        },
+      },
+    ]);
+    expect(logLines).toEqual(["Updated schedule: schedule-1"]);
+  });
+
+  test("errors when no update flags are provided", async () => {
+    const { exitCode } = await runCommand([
+      "schedules",
+      "update",
+      "schedule-1",
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(ipcCalls).toEqual([]);
+    expect(errorLines.join("\n")).toContain(
+      "At least one update flag is required",
+    );
+  });
+
+  test("parses numeric retry and timeout flags into numbers", async () => {
+    mockIpcResult = { ok: true, result: { schedules: [] } };
+
+    const { exitCode } = await runCommand([
+      "schedules",
+      "update",
+      "schedule-1",
+      "--max-retries",
+      "5",
+      "--retry-backoff-ms",
+      "30000",
+      "--timeout-ms",
+      "5000",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(ipcCalls).toEqual([
+      {
+        method: "updateSchedule",
+        params: {
+          pathParams: { id: "schedule-1" },
+          body: { maxRetries: 5, retryBackoffMs: 30_000, timeoutMs: 5000 },
+        },
+      },
+    ]);
+  });
+
+  test("rejects a non-integer --max-retries", async () => {
+    const { exitCode } = await runCommand([
+      "schedules",
+      "update",
+      "schedule-1",
+      "--max-retries",
+      "lots",
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(ipcCalls).toEqual([]);
+    expect(errorLines.join("\n")).toContain("--max-retries must be an integer");
+  });
+
+  test("sends timeoutMs null with --clear-timeout", async () => {
+    mockIpcResult = { ok: true, result: { schedules: [] } };
+
+    const { exitCode } = await runCommand([
+      "schedules",
+      "update",
+      "schedule-1",
+      "--clear-timeout",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(ipcCalls).toEqual([
+      {
+        method: "updateSchedule",
+        params: {
+          pathParams: { id: "schedule-1" },
+          body: { timeoutMs: null },
+        },
+      },
+    ]);
+  });
+
+  test("rejects --timeout-ms combined with --clear-timeout", async () => {
+    const { exitCode } = await runCommand([
+      "schedules",
+      "update",
+      "schedule-1",
+      "--timeout-ms",
+      "5000",
+      "--clear-timeout",
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(ipcCalls).toEqual([]);
+    expect(errorLines.join("\n")).toContain("mutually exclusive");
+  });
+
+  test("sends boolean false for negated flags", async () => {
+    mockIpcResult = { ok: true, result: { schedules: [] } };
+
+    const { exitCode } = await runCommand([
+      "schedules",
+      "update",
+      "schedule-1",
+      "--no-quiet",
+      "--no-reuse-conversation",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(ipcCalls).toEqual([
+      {
+        method: "updateSchedule",
+        params: {
+          pathParams: { id: "schedule-1" },
+          body: { quiet: false, reuseConversation: false },
+        },
+      },
+    ]);
+  });
+
+  test("emits JSON result when --json is set", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: {
+        schedules: [
+          {
+            id: "schedule-1",
+            name: "Renamed",
+            enabled: true,
+            syntax: "cron",
+            expression: "0 9 * * MON-FRI",
+            cronExpression: "0 9 * * MON-FRI",
+            timezone: "America/New_York",
+            message: "run heartbeat",
+            script: null,
+            nextRunAt: 1_778_800_000_000,
+            lastRunAt: null,
+            lastStatus: "ok",
+            retryCount: 0,
+            maxRetries: 3,
+            retryBackoffMs: 60_000,
+            description: "Authored heartbeat check",
+            cadenceDescription: "At 9:00 AM, Monday through Friday",
+            mode: "execute",
+            status: "active",
+            routingIntent: "all_channels",
+            reuseConversation: false,
+            wakeConversationId: null,
+            isOneShot: false,
+          },
+        ],
+      },
+    };
+
+    const { stdout, exitCode } = await runCommand([
+      "schedules",
+      "update",
+      "schedule-1",
+      "--name",
+      "Renamed",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout)).toEqual({
+      schedules: [
+        expect.objectContaining({ id: "schedule-1", name: "Renamed" }),
+      ],
+    });
+    expect(logLines).toEqual([]);
+  });
+
+  test("routes IPC failure through exitFromIpcResult", async () => {
+    mockIpcResult = { ok: false, error: "Schedule not found" };
+
+    const { exitCode } = await runCommand([
+      "schedules",
+      "update",
+      "missing-schedule",
+      "--name",
+      "Renamed",
     ]);
 
     expect(exitCode).toBe(10);

--- a/assistant/src/cli/commands/schedules.ts
+++ b/assistant/src/cli/commands/schedules.ts
@@ -22,6 +22,8 @@ interface ScheduleRecord {
   retryCount: number;
   maxRetries: number;
   retryBackoffMs: number;
+  timeoutMs: number | null;
+  createdFromConversationId: string | null;
   description: string | null;
   cadenceDescription: string | null;
   mode: string;
@@ -34,6 +36,10 @@ interface ScheduleRecord {
 
 interface ListSchedulesResponse {
   schedules: ScheduleRecord[];
+}
+
+interface GetScheduleResponse {
+  schedule: ScheduleRecord;
 }
 
 interface ScheduleRunRecord {
@@ -64,19 +70,17 @@ export function registerSchedulesCommand(program: Command): void {
         `
 Schedules are recurring or one-shot jobs run by the assistant.
 
-This CLI namespace is intentionally landing incrementally. Today it supports
-creating schedules, listing schedules, viewing recent run history,
-enabling/disabling schedules, manually executing a schedule one time, cancelling
-pending one-shot schedules, and deleting schedules.
+This namespace exposes full CRUD against the assistant's schedule store:
+create, list, get, update, enable/disable, cancel, delete, plus run history
+and manual one-time execution. One documented exception: 'create' is limited
+to 'execute' mode — notify/script/wake schedules are created via the
+in-assistant schedule_create tool, but can be inspected and updated here.
 
 Examples:
   $ assistant schedules list
-  $ assistant schedules list --all
-  $ assistant schedules runs <schedule-id>
+  $ assistant schedules get <schedule-id>
+  $ assistant schedules update <schedule-id> --expression '0 9 * * *'
   $ assistant schedules runs <schedule-id> --limit 25 --json
-  $ assistant schedules disable <schedule-id>
-  $ assistant schedules enable <schedule-id>
-  $ assistant schedules cancel <schedule-id>
   $ assistant schedules execute <schedule-id>`,
       );
 
@@ -198,6 +202,86 @@ Examples:
             }
           },
         );
+
+      schedules
+        .command("get <id>")
+        .description("Show full details for a single schedule")
+        .option("--json", "Machine-readable compact JSON output")
+        .addHelpText(
+          "after",
+          `
+Options:
+  --json   Output the raw schedule object as compact JSON.
+
+Arguments:
+  <id>   Schedule ID (UUID) — run 'assistant schedules list --all' to find it.
+
+Behavior:
+  Prints every stored field of the schedule: name, description, mode,
+  expression/syntax, timezone, enabled state, status, next/last run times,
+  message or script body, routing intent, and retry policy. Works for
+  deferred schedules that 'assistant schedules list' hides by default.
+
+Examples:
+  $ assistant schedules get 9f2c4f3a-3f1a-41e4-88e7-abc123
+  $ assistant schedules get 9f2c4f3a-3f1a-41e4-88e7-abc123 --json`,
+        )
+        .action(async (id: string, opts: { json?: boolean }, cmd: Command) => {
+          const scheduleId = id.trim();
+          const result = await cliIpcCall<GetScheduleResponse>("getSchedule", {
+            pathParams: { id: scheduleId },
+          });
+
+          if (!result.ok) return exitFromIpcResult(result, cmd);
+
+          const schedule = result.result?.schedule;
+          if (!schedule) {
+            const error = `Schedule "${scheduleId}" not found. Run 'assistant schedules list --all' to see available schedules.`;
+            if (opts.json) {
+              writeOutput(cmd, { ok: false, error });
+            } else {
+              log.error(error);
+            }
+            process.exitCode = 1;
+            return;
+          }
+
+          if (opts.json) {
+            writeOutput(cmd, { schedule });
+            return;
+          }
+
+          const fields: Array<[string, string]> = [
+            ["ID", schedule.id],
+            ["Name", schedule.name],
+            ["Description", schedule.description ?? "—"],
+            ["Enabled", schedule.enabled ? "enabled" : "disabled"],
+            ["Status", schedule.status],
+            ["Mode", schedule.mode],
+            ["Syntax", schedule.syntax],
+            ["Expression", schedule.expression ?? "—"],
+            ["Cadence", describeSchedule(schedule)],
+            ["Timezone", schedule.timezone ?? "—"],
+            ["Next run", formatTimestamp(schedule.nextRunAt)],
+            ["Last run", formatNullableTimestamp(schedule.lastRunAt)],
+            ["Last status", schedule.lastStatus ?? "—"],
+            ["One-shot", schedule.isOneShot ? "yes" : "no"],
+            ["Message", schedule.message || "—"],
+            ["Script", schedule.script ?? "—"],
+            ["Routing intent", schedule.routingIntent],
+            ["Reuse conversation", schedule.reuseConversation ? "yes" : "no"],
+            ["Wake conversation", schedule.wakeConversationId ?? "—"],
+            ["Retry count", String(schedule.retryCount)],
+            ["Max retries", String(schedule.maxRetries)],
+            ["Retry backoff", formatDuration(schedule.retryBackoffMs)],
+            ["Timeout", formatDuration(schedule.timeoutMs)],
+            ["Source conversation", schedule.createdFromConversationId ?? "—"],
+          ];
+          const labelWidth = Math.max(...fields.map(([label]) => label.length));
+          for (const [label, value] of fields) {
+            log.info(`${`${label}:`.padEnd(labelWidth + 2)}${value}`);
+          }
+        });
 
       schedules
         .command("runs <id>")
@@ -428,6 +512,205 @@ Examples:
             }
 
             log.info(`Created schedule: ${scheduleName}`);
+          },
+        );
+
+      schedules
+        .command("update <id>")
+        .description("Update fields on an existing schedule")
+        .option("--name <text>", "New display name")
+        .option(
+          "-d, --description <text>",
+          "New authored description explaining what the schedule is for",
+        )
+        .option(
+          "-e, --expression <expr>",
+          "New cron or RRULE expression for the fire times",
+        )
+        .option(
+          "-t, --timezone <tz>",
+          "IANA timezone for the expression (e.g. America/New_York)",
+        )
+        .option(
+          "-m, --message <text>",
+          "New message body sent to the assistant on each fire",
+        )
+        .option("--script <command>", "Shell command for script-mode schedules")
+        .option("--mode <mode>", "One of: notify, execute, script, wake")
+        .option(
+          "--routing-intent <intent>",
+          "One of: single_channel, multi_channel, all_channels",
+        )
+        .option("--quiet", "Suppress notifications for this schedule")
+        .option("--no-quiet", "Re-enable notifications for this schedule")
+        .option(
+          "--reuse-conversation",
+          "Reuse one conversation across recurring fires",
+        )
+        .option(
+          "--no-reuse-conversation",
+          "Start a fresh conversation on each fire",
+        )
+        .option("--max-retries <count>", "Maximum retry attempts (integer)")
+        .option(
+          "--retry-backoff-ms <ms>",
+          "Retry backoff in milliseconds (integer)",
+        )
+        .option(
+          "--timeout-ms <ms>",
+          "Script-mode execution timeout in milliseconds (integer)",
+        )
+        .option(
+          "--clear-timeout",
+          "Clear the script timeout override and use the assistant default",
+        )
+        .option("--json", "Machine-readable compact JSON output")
+        .addHelpText(
+          "after",
+          `
+Options:
+  --name <text>             New display name.
+  -d, --description <text>  New authored description (must be non-empty).
+  -e, --expression <expr>   Cron (e.g. '*/30 * * * *') or RRULE expression.
+  -t, --timezone <tz>       IANA timezone applied to the expression.
+  -m, --message <text>      New message body sent on each fire.
+  --script <command>        Shell command for script-mode schedules.
+  --mode <mode>             notify, execute, script, or wake.
+  --routing-intent <intent> single_channel, multi_channel, or all_channels.
+  --quiet / --no-quiet      Toggle notification suppression.
+  --reuse-conversation / --no-reuse-conversation
+                            Toggle conversation reuse across recurring fires.
+  --max-retries <count>     Maximum retry attempts.
+  --retry-backoff-ms <ms>   Retry backoff in milliseconds.
+  --timeout-ms <ms>         Script-mode execution timeout in milliseconds.
+  --clear-timeout           Remove the timeout override (mutually exclusive
+                            with --timeout-ms).
+  --json                    Output the updated schedule list as compact JSON.
+
+Arguments:
+  <id>   Schedule ID (UUID) — run 'assistant schedules list --all' to find it.
+
+Behavior:
+  Partially updates the schedule: only fields for flags you pass are changed,
+  everything else is preserved. At least one update flag is required. To
+  enable or disable a schedule, use 'assistant schedules enable <id>' or
+  'assistant schedules disable <id>' instead.
+
+Examples:
+  $ assistant schedules update 9f2c4f3a-3f1a-41e4-88e7-abc123 \\
+      --expression '0 9 * * MON-FRI' --timezone America/New_York
+  $ assistant schedules update 9f2c4f3a-3f1a-41e4-88e7-abc123 \\
+      --name "Morning summary" --message 'write the morning summary'
+  $ assistant schedules update 9f2c4f3a-3f1a-41e4-88e7-abc123 \\
+      --max-retries 5 --retry-backoff-ms 30000 --json`,
+        )
+        .action(
+          async (
+            id: string,
+            opts: {
+              name?: string;
+              description?: string;
+              expression?: string;
+              timezone?: string;
+              message?: string;
+              script?: string;
+              mode?: string;
+              routingIntent?: string;
+              quiet?: boolean;
+              reuseConversation?: boolean;
+              maxRetries?: string;
+              retryBackoffMs?: string;
+              timeoutMs?: string;
+              clearTimeout?: boolean;
+              json?: boolean;
+            },
+            cmd: Command,
+          ) => {
+            const scheduleId = id.trim();
+            const fail = (error: string) => {
+              if (opts.json) {
+                writeOutput(cmd, { ok: false, error });
+              } else {
+                log.error(error);
+              }
+              process.exitCode = 1;
+            };
+
+            const parseInteger = (
+              flag: string,
+              value: string,
+            ): number | null => {
+              const parsed = Number(value);
+              if (!Number.isInteger(parsed)) {
+                fail(`${flag} must be an integer, got "${value}"`);
+                return null;
+              }
+              return parsed;
+            };
+
+            if (opts.clearTimeout && opts.timeoutMs != null) {
+              fail(
+                "--timeout-ms and --clear-timeout are mutually exclusive; pass --timeout-ms to set a timeout or --clear-timeout to remove it",
+              );
+              return;
+            }
+
+            const body: Record<string, unknown> = {};
+            if (opts.name != null) body.name = opts.name;
+            if (opts.description != null) body.description = opts.description;
+            if (opts.expression != null) body.expression = opts.expression;
+            if (opts.timezone != null) body.timezone = opts.timezone;
+            if (opts.message != null) body.message = opts.message;
+            if (opts.script != null) body.script = opts.script;
+            if (opts.mode != null) body.mode = opts.mode;
+            if (opts.routingIntent != null) {
+              body.routingIntent = opts.routingIntent;
+            }
+            if (opts.quiet != null) body.quiet = opts.quiet;
+            if (opts.reuseConversation != null) {
+              body.reuseConversation = opts.reuseConversation;
+            }
+            if (opts.maxRetries != null) {
+              const parsed = parseInteger("--max-retries", opts.maxRetries);
+              if (parsed == null) return;
+              body.maxRetries = parsed;
+            }
+            if (opts.retryBackoffMs != null) {
+              const parsed = parseInteger(
+                "--retry-backoff-ms",
+                opts.retryBackoffMs,
+              );
+              if (parsed == null) return;
+              body.retryBackoffMs = parsed;
+            }
+            if (opts.timeoutMs != null) {
+              const parsed = parseInteger("--timeout-ms", opts.timeoutMs);
+              if (parsed == null) return;
+              body.timeoutMs = parsed;
+            }
+            if (opts.clearTimeout) body.timeoutMs = null;
+
+            if (Object.keys(body).length === 0) {
+              fail(
+                "At least one update flag is required. Run 'assistant schedules update --help' for the available flags.",
+              );
+              return;
+            }
+
+            const result = await cliIpcCall<ListSchedulesResponse>(
+              "updateSchedule",
+              { pathParams: { id: scheduleId }, body },
+            );
+
+            if (!result.ok) return exitFromIpcResult(result, cmd);
+
+            const response = result.result ?? { schedules: [] };
+            if (opts.json) {
+              writeOutput(cmd, response);
+              return;
+            }
+
+            log.info(`Updated schedule: ${scheduleId}`);
           },
         );
 

--- a/assistant/src/cli/commands/schedules.ts
+++ b/assistant/src/cli/commands/schedules.ts
@@ -536,7 +536,10 @@ Examples:
           "New message body sent to the assistant on each fire",
         )
         .option("--script <command>", "Shell command for script-mode schedules")
-        .option("--mode <mode>", "One of: notify, execute, script, wake")
+        .option(
+          "--mode <mode>",
+          "One of: notify, execute, script, wake (wake only when the schedule already has a wake conversation target)",
+        )
         .option(
           "--routing-intent <intent>",
           "One of: single_channel, multi_channel, all_channels",
@@ -653,6 +656,24 @@ Examples:
                 "--timeout-ms and --clear-timeout are mutually exclusive; pass --timeout-ms to set a timeout or --clear-timeout to remove it",
               );
               return;
+            }
+
+            // Wake mode requires a wake conversation target, which this CLI
+            // cannot set. Allow `--mode wake` only when the schedule already
+            // has one — otherwise the scheduler would skip every fire as a
+            // no-op.
+            if (opts.mode === "wake") {
+              const existing = await cliIpcCall<GetScheduleResponse>(
+                "getSchedule",
+                { pathParams: { id: scheduleId } },
+              );
+              if (!existing.ok) return exitFromIpcResult(existing, cmd);
+              if (!existing.result?.schedule.wakeConversationId) {
+                fail(
+                  "--mode wake requires the schedule to already have a wake conversation target; this CLI cannot set one. Create wake schedules with the schedule tool instead.",
+                );
+                return;
+              }
             }
 
             const body: Record<string, unknown> = {};

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -358,6 +358,21 @@ function handleUpdateSchedule(id: string, body: Record<string, unknown>) {
     }
   }
 
+  // Re-derive syntax whenever the expression changes, mirroring the create
+  // handler. Without this, switching an expression between cron and rrule
+  // would validate the new expression against the schedule's old syntax.
+  if (typeof updates.expression === "string") {
+    const normalized = normalizeScheduleSyntax({
+      expression: updates.expression,
+    });
+    if (!normalized) {
+      throw new BadRequestError(
+        "expression could not be parsed as cron or rrule",
+      );
+    }
+    updates.syntax = normalized.syntax;
+  }
+
   if ("description" in body) {
     const description =
       typeof body.description === "string" ? body.description.trim() : "";

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -156,6 +156,45 @@ function isOneShotForDisplay(
   return job.syntax === "rrule" && isSingleFireRRule(job.cronExpression);
 }
 
+function serializeSchedule(
+  j: ScheduleJob,
+  sourceConversationCache: Map<string, CreatedFromConversationState>,
+) {
+  const sourceConversation = getCreatedFromConversationState(
+    j.createdFromConversationId,
+    sourceConversationCache,
+  );
+  return {
+    id: j.id,
+    name: j.name,
+    enabled: j.enabled,
+    syntax: j.syntax,
+    expression: j.expression,
+    cronExpression: j.cronExpression,
+    timezone: j.timezone,
+    message: j.message,
+    script: j.script,
+    nextRunAt: j.nextRunAt,
+    lastRunAt: j.lastRunAt,
+    lastStatus: j.lastStatus,
+    retryCount: j.retryCount,
+    maxRetries: j.maxRetries,
+    retryBackoffMs: j.retryBackoffMs,
+    timeoutMs: j.timeoutMs,
+    createdFromConversationId: j.createdFromConversationId,
+    createdFromConversationExists: sourceConversation.exists,
+    createdFromConversationArchivedAt: sourceConversation.archivedAt,
+    description: j.description,
+    cadenceDescription: getCadenceDescription(j),
+    mode: j.mode,
+    status: j.status,
+    routingIntent: j.routingIntent,
+    reuseConversation: j.reuseConversation,
+    wakeConversationId: j.wakeConversationId,
+    isOneShot: isOneShotForDisplay(j),
+  };
+}
+
 function handleListSchedules(queryParams: Record<string, string>) {
   const includeAll = queryParams.include_all === "true";
   const jobs = listSchedules();
@@ -167,42 +206,18 @@ function handleListSchedules(queryParams: Record<string, string>) {
     CreatedFromConversationState
   >();
   return {
-    schedules: filtered.map((j) => {
-      const sourceConversation = getCreatedFromConversationState(
-        j.createdFromConversationId,
-        sourceConversationCache,
-      );
-      return {
-        id: j.id,
-        name: j.name,
-        enabled: j.enabled,
-        syntax: j.syntax,
-        expression: j.expression,
-        cronExpression: j.cronExpression,
-        timezone: j.timezone,
-        message: j.message,
-        script: j.script,
-        nextRunAt: j.nextRunAt,
-        lastRunAt: j.lastRunAt,
-        lastStatus: j.lastStatus,
-        retryCount: j.retryCount,
-        maxRetries: j.maxRetries,
-        retryBackoffMs: j.retryBackoffMs,
-        timeoutMs: j.timeoutMs,
-        createdFromConversationId: j.createdFromConversationId,
-        createdFromConversationExists: sourceConversation.exists,
-        createdFromConversationArchivedAt: sourceConversation.archivedAt,
-        description: j.description,
-        cadenceDescription: getCadenceDescription(j),
-        mode: j.mode,
-        status: j.status,
-        routingIntent: j.routingIntent,
-        reuseConversation: j.reuseConversation,
-        wakeConversationId: j.wakeConversationId,
-        isOneShot: isOneShotForDisplay(j),
-      };
-    }),
+    schedules: filtered.map((j) =>
+      serializeSchedule(j, sourceConversationCache),
+    ),
   };
+}
+
+function handleGetSchedule(id: string) {
+  const job = getSchedule(id);
+  if (!job) {
+    throw new NotFoundError("Schedule not found");
+  }
+  return { schedule: serializeSchedule(job, new Map()) };
 }
 
 function handleCreateSchedule(body: Record<string, unknown>) {
@@ -493,6 +508,25 @@ export const ROUTES: RouteDefinition[] = [
     }),
     handler: ({ queryParams }: RouteHandlerArgs) =>
       handleScheduleUsageSummary(queryParams ?? {}),
+  },
+  // Must stay after literal `schedules/*` GET siblings (e.g. usage-summary):
+  // the router matches in declaration order and `:id` would shadow them.
+  {
+    operationId: "getSchedule",
+    endpoint: "schedules/:id",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Get schedule",
+    description: "Return a single schedule by ID.",
+    tags: ["schedules"],
+    responseBody: z.object({
+      schedule: scheduleSchema.describe("Schedule object"),
+    }),
+    handler: ({ pathParams }: RouteHandlerArgs) =>
+      handleGetSchedule(pathParams!.id),
   },
   {
     operationId: "createSchedule",

--- a/gateway/src/risk/command-registry.test.ts
+++ b/gateway/src/risk/command-registry.test.ts
@@ -598,8 +598,10 @@ describe("command-registry", () => {
       expect(getAssistantPath("inference session close").baseRisk).toBe("low");
       expect(getAssistantPath("inference session list").baseRisk).toBe("low");
       expect(getAssistantPath("schedules list").baseRisk).toBe("low");
+      expect(getAssistantPath("schedules get").baseRisk).toBe("low");
       expect(getAssistantPath("schedules runs").baseRisk).toBe("low");
       expect(getAssistantPath("schedules create").baseRisk).toBe("medium");
+      expect(getAssistantPath("schedules update").baseRisk).toBe("medium");
       expect(getAssistantPath("schedules enable").baseRisk).toBe("medium");
       expect(getAssistantPath("schedules disable").baseRisk).toBe("medium");
       expect(getAssistantPath("schedules cancel").baseRisk).toBe("medium");
@@ -610,6 +612,23 @@ describe("command-registry", () => {
       expect(getAssistantPath("plugins install").baseRisk).toBe("high");
       expect(getAssistantPath("plugins upgrade").baseRisk).toBe("high");
       expect(getAssistantPath("plugins uninstall").baseRisk).toBe("medium");
+    });
+
+    test("assistant schedules update escalates to high for script payloads", () => {
+      const updateSpec = getAssistantPath("schedules update");
+      expect(updateSpec.argRules).toBeDefined();
+
+      const scriptRule = updateSpec.argRules!.find((r) =>
+        r.flags?.includes("--script"),
+      );
+      expect(scriptRule).toBeDefined();
+      expect(scriptRule!.risk).toBe("high");
+
+      const modeRule = updateSpec.argRules!.find(
+        (r) => r.flags?.includes("--mode") && r.valuePattern === "^script$",
+      );
+      expect(modeRule).toBeDefined();
+      expect(modeRule!.risk).toBe("high");
     });
   });
 

--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -659,4 +659,30 @@ const assistantBashArgRules: ArgRule[] = [
 ];
 getExistingPath(spec, "bash").argRules = assistantBashArgRules;
 
+// `schedules update` is medium-risk as a state mutation, but updates that
+// install or switch to a script payload persist host shell execution for a
+// later schedule fire — classify those as high like `bash`.
+const scheduleUpdateArgRules: ArgRule[] = [
+  {
+    id: "assistant-schedules-update:script",
+    flags: ["--script"],
+    risk: "high",
+    reason:
+      "Persists an arbitrary shell command that the schedule executes on fire",
+  },
+  {
+    id: "assistant-schedules-update:mode-script",
+    flags: ["--mode"],
+    valuePattern: "^script$",
+    risk: "high",
+    reason:
+      "Switches the schedule to script mode (host shell execution on fire)",
+  },
+];
+const scheduleUpdateNode = getExistingPath(spec, "schedules update");
+scheduleUpdateNode.argRules = scheduleUpdateArgRules;
+// Both rule flags consume the next token as a value; declare them so the
+// arg parser pairs `--mode script` / `--script <cmd>` correctly.
+scheduleUpdateNode.argSchema = { valueFlags: ["--mode", "--script"] };
+
 export default spec;

--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -200,8 +200,10 @@ const ASSISTANT_SUPPORTED_COMMAND_PATHS = [
   "routes inspect",
   "schedules",
   "schedules list",
+  "schedules get",
   "schedules runs",
   "schedules create",
+  "schedules update",
   "schedules enable",
   "schedules disable",
   "schedules cancel",
@@ -541,6 +543,12 @@ const riskOverrides: AssistantRiskOverride[] = [
     risk: "medium",
     reason:
       "Creates a new recurring schedule that fires assistant-side messages",
+  },
+  {
+    path: "schedules update",
+    risk: "medium",
+    reason:
+      "Updates schedule fields (expression, message, mode, script) and mutates assistant schedule state",
   },
   {
     path: "schedules enable",


### PR DESCRIPTION
## Summary

Out of the Watchers/Background-Tasks discussion: the assistant self-CLI's `schedules` namespace was missing `get` and `update`, and assistants were observed bypassing the CLI and hand-writing SQLite rows to fill the gap. This PR completes the CRUD surface and codifies the rule so it doesn't regress in other namespaces.

### New route

- **`GET /schedules/:id`** (operationId `getSchedule`) in `assistant/src/runtime/routes/schedule-routes.ts`, served over both HTTP and IPC via the shared ROUTES array. Returns the full serialized schedule (extracted a shared `serializeSchedule()` helper from the list handler); throws `NotFoundError` when missing. Placed after the literal `schedules/usage-summary` sibling since the router matches in declaration order. `assistant/openapi.yaml` regenerated via `bun run generate:openapi`.

### New CLI subcommands

- **`assistant schedules get <id>`** — human-readable detail view of every stored field (name, description, mode, expression/syntax, timezone, enabled, status, next/last run, message/script, routing intent, retry policy, timeout, source conversation), plus `--json` for the raw object. Also surfaces deferred schedules that `list` hides by default.
- **`assistant schedules update <id>`** — exposes the existing `PATCH /schedules/:id` route. Flags map 1:1 to the route's accepted body schema (name, description, expression, timezone, message, script, mode, routing-intent, quiet, reuse-conversation, max-retries, retry-backoff-ms, timeout-ms / clear-timeout); no new route capability added. Errors unless at least one update flag is provided. `--json` supported.
- Namespace help text updated to describe the full CRUD surface and document the one deliberate exception: `create` remains execute-mode-only (expanding create modes is intentionally out of scope for this PR).
- Gateway bash risk registry (`gateway/src/risk/command-registry/commands/assistant.ts`) updated with the two new subcommand paths and a medium-risk override for `schedules update`.

### AGENTS.md rule

Added a "Full CRUD for Resource Namespaces" section to `assistant/src/cli/AGENTS.md`: every resource-managing namespace must expose create/get/list/update/delete wired to daemon routes, with intentional exceptions documented inline in the namespace help text — partial surfaces push the model around the CLI and into direct SQLite writes.

## Testing

- `bun test src/cli/commands/__tests__/schedules.test.ts` — 48 pass (registration, IPC dispatch, JSON/human output, flag parsing, tri-state booleans, mutually-exclusive timeout flags, failure paths)
- `bun test src/__tests__/schedule-routes.test.ts` — 44 pass (new GET route: found incl. source-conversation metadata, deferred schedules, NotFoundError)
- `bunx tsc --noEmit` clean (assistant + gateway)
- `bun run lint` clean
- `gateway: bun test src/risk/command-registry.test.ts` — 50 pass

Note: running both test files in a single `bun test` invocation fails due to pre-existing cross-file `mock.module` contamination (reproduced at the base commit); files pass individually, matching CI's behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)