### PR TITLE
fix(app-compiler): strip source-file script tags before injecting main.js

### DIFF
--- a/assistant/src/bundler/app-compiler.ts
+++ b/assistant/src/bundler/app-compiler.ts
@@ -454,6 +454,14 @@ async function runCompile(appDir: string): Promise<CompileResult> {
   if (existsSync(htmlSrc)) {
     let html = await readFile(htmlSrc, "utf-8");
 
+    // Strip source-file script tags (e.g. <script src="/src/main.tsx">) that
+    // models often write in Vite style; browsers cannot load raw TSX/TS/JSX.
+    // The compiled main.js tag is injected below instead.
+    html = html.replace(
+      /<script\b[^>]*\bsrc=["'][^"']*\.(?:tsx|ts|jsx)["'][^>]*>\s*<\/script>\s*/gi,
+      "",
+    );
+
     // Check if CSS output was produced
     const distFiles = await readdir(distDir);
     const hasCss = distFiles.some((f) => f.endsWith(".css"));


### PR DESCRIPTION
## Problem

Models often author `index.html` Vite-style with `<script type="module" src="/src/main.tsx"></script>`. The compiler copies the HTML and injects the compiled `main.js` tag, but leaves the raw TSX tag in place. The browser then tries to load uncompiled source and the app preview breaks. This has been a consistent failure mode for app-builder previews since the index.html authoring path became common (#33106, #33919).

## Fix

Strip script tags pointing at `.tsx` / `.ts` / `.jsx` during the HTML copy step in `compileApp()`, before the `main.js` injection check. The regex handles single/double quotes, attributes in any order, and `./` or `/src/` paths. Compiled `.js` tags and external script URLs are untouched.

Existing `app-compiler.test.ts` suite passes (27/27). Lint, typecheck, and formatting clean.