### PR TITLE
fix(runtime): wire suppressAutoCompaction through to the agent loop

### DIFF
--- a/assistant/src/__tests__/agent-wake-disk-pressure-callsite.test.ts
+++ b/assistant/src/__tests__/agent-wake-disk-pressure-callsite.test.ts
@@ -89,6 +89,8 @@ function makeTarget(): Conversation {
     getTurnChannelContext: () => null,
     getTurnInterfaceContext: () => null,
     drainQueue: async () => {},
+    // Pre-run auto-compaction gate — no-op for these tests.
+    maybeCompact: async () => null,
   };
   return target as unknown as Conversation;
 }

--- a/assistant/src/__tests__/agent-wake-override-profile.test.ts
+++ b/assistant/src/__tests__/agent-wake-override-profile.test.ts
@@ -101,6 +101,8 @@ function makeTarget(): {
     getTurnChannelContext: () => null,
     getTurnInterfaceContext: () => null,
     drainQueue: async () => {},
+    // Pre-run auto-compaction gate — no-op for these tests.
+    maybeCompact: async () => null,
   };
   return { target: target as unknown as Conversation, runArgs };
 }

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -1503,6 +1503,34 @@ export class Conversation {
   }
 
   async forceCompact(): Promise<ContextWindowResult> {
+    return this.runCompaction(true);
+  }
+
+  /**
+   * Auto-threshold compaction gate. Runs the same durable compaction
+   * pipeline as {@link forceCompact} (summary call, circuit-breaker
+   * accounting, Slack provenance, in-memory + DB commit) but honors the
+   * `compaction.autoThreshold` check — an under-threshold history is a
+   * cheap no-op — and the compaction circuit breaker, returning `null`
+   * without estimating anything while the breaker is open. Used by the
+   * agent-wake path (`runtime/agent-wake.ts`), which bypasses the daemon
+   * orchestrator's in-loop budget gate and needs an equivalent turn-start
+   * compaction before snapshotting its run input.
+   */
+  async maybeCompact(): Promise<ContextWindowResult | null> {
+    if (await this.agentLoop.compactionCircuit.isOpen()) {
+      return null;
+    }
+    return this.runCompaction(false);
+  }
+
+  /**
+   * Shared compaction pipeline behind {@link forceCompact} and
+   * {@link maybeCompact}. `force` skips the auto-threshold check inside the
+   * context-window manager (user-initiated `/compact`); without it the
+   * manager no-ops below the threshold.
+   */
+  private async runCompaction(force: boolean): Promise<ContextWindowResult> {
     const overrideProfile = resolveOverrideProfile(this) ?? null;
     const config = getConfig();
     const effectiveContextWindow = resolveEffectiveContextWindow({
@@ -1538,15 +1566,17 @@ export class Conversation {
       conversationId: this.conversationId,
       messages: messagesToCompact,
       signal: this.abortController?.signal ?? undefined,
-      force: true,
+      force,
       overrideProfile,
       actorTrustClass: this.trustContext?.trustClass,
     });
-    // Track circuit-breaker state for user-initiated `/compact` and other
-    // forced paths so a successful forced compaction clears a stuck counter
-    // and a run of forced failures still trips the breaker. `summaryFailed`
-    // is `undefined` on early-return paths (no eligible messages, disabled,
-    // etc.) — skip those so they don't silently reset the counter.
+    // Track circuit-breaker state for every compaction that ran a summary
+    // call — user-initiated `/compact`, other forced paths, and the wake's
+    // auto gate — so a success clears a stuck counter and a run of failures
+    // still trips the breaker. `summaryFailed` is `undefined` on
+    // early-return paths (no eligible messages, disabled, below the auto
+    // threshold, etc.) — skip those so they don't silently reset the
+    // counter.
     if (result.summaryFailed !== undefined) {
       await this.agentLoop.compactionCircuit.recordOutcome(
         result.summaryFailed,

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -7,7 +7,8 @@
  * double typed as `Conversation` (`makeWakeConversation`) that stubs only the
  * handful of members the wake touches — `getMessages`, `messages.push`,
  * `isProcessing`/`setProcessing`, `setTrustContext`, `setSubagentAllowedTools`,
- * `drainQueue`, and a scripted `agentLoop.run()`.
+ * `drainQueue`, `maybeCompact`, `contextWindowManager.estimateInputTokens`,
+ * and a scripted `agentLoop.run()`.
  *
  * The wake's side effects flow through the daemon boundary, so the
  * instrumentation is captured at that boundary: event emission and the
@@ -78,6 +79,12 @@ interface WakeConversationProbe {
   setTrustContextCalls: Array<{ ctx: unknown; order: number }>;
   /** Number of persisted tail messages at the moment each frame emitted. */
   persistedAtEachEmit: number[];
+  /**
+   * `conversation.maybeCompact()` invocations (the wake's pre-run
+   * auto-compaction gate), tagged with the same monotonic order counter as
+   * `runCalls` so tests can prove the gate ran before the agent loop.
+   */
+  maybeCompactOrders: number[];
 }
 
 const wakeConvRegistry = new Map<string, WakeConversationProbe>();
@@ -236,7 +243,7 @@ import type {
   AgentLoopRunResult,
 } from "../../agent/loop.js";
 import type { Conversation } from "../../daemon/conversation.js";
-import type { Message } from "../../providers/types.js";
+import { ContextOverflowError, type Message } from "../../providers/types.js";
 import {
   __resetWakeChainForTests,
   wakeAgentForOpportunity,
@@ -276,6 +283,13 @@ function makeWakeConversation(options: {
   initialAllowedTools?: Set<string>;
   /** Replaces the default scripted `agentLoop.run` body entirely. */
   runImpl?: ScriptedRun;
+  /**
+   * Token estimate returned by the double's
+   * `contextWindowManager.estimateInputTokens` (consumed by the wake's
+   * over-window pre-flight on compaction-suppressed wakes). Defaults to 0
+   * (always under the mocked 200k window).
+   */
+  estimatedInputTokens?: number;
 }): WakeConversation {
   const conversationId = options.conversationId ?? "conv-test";
   const probe: WakeConversationProbe = {
@@ -291,6 +305,7 @@ function makeWakeConversation(options: {
     allowedToolSnapshots: [],
     setTrustContextCalls: [],
     persistedAtEachEmit: [],
+    maybeCompactOrders: [],
   };
   wakeConvRegistry.set(conversationId, probe);
 
@@ -382,6 +397,17 @@ function makeWakeConversation(options: {
     },
     setTrustContext: (ctx: unknown) => {
       probe.setTrustContextCalls.push({ ctx, order: order++ });
+    },
+    // Pre-run auto-compaction gate. The double only records the call —
+    // compaction side effects are exercised in the Conversation tests.
+    maybeCompact: async () => {
+      probe.maybeCompactOrders.push(order++);
+      probe.callSequence.push("maybeCompact");
+      return null;
+    },
+    // Consumed by the wake's over-window pre-flight (suppressed wakes only).
+    contextWindowManager: {
+      estimateInputTokens: () => options.estimatedInputTokens ?? 0,
     },
     getTurnChannelContext: () => null,
     getTurnInterfaceContext: () => null,
@@ -1233,11 +1259,13 @@ describe("wakeAgentForOpportunity", () => {
         { resolveTarget: async () => conversation },
       );
 
-      // Full call sequence: processing toggled true → 3 pushes →
-      // 3 persists → processing toggled false → drain. Specifically,
-      // every push and every persist must precede the single drain.
+      // Full call sequence: processing toggled true → compaction gate →
+      // 3 pushes → 3 persists → processing toggled false → drain.
+      // Specifically, every push and every persist must precede the
+      // single drain.
       expect(conversation.callSequence).toEqual([
         "processing:true",
+        "maybeCompact",
         "push",
         "push",
         "push",
@@ -1294,9 +1322,11 @@ describe("wakeAgentForOpportunity", () => {
       expect(conversation.emittedEvents).toHaveLength(0);
 
       // But drain still ran exactly once, after processing flipped to
-      // false. Sequence: toggle true → toggle false → drain.
+      // false. Sequence: toggle true → compaction gate → toggle false →
+      // drain.
       expect(conversation.callSequence).toEqual([
         "processing:true",
+        "maybeCompact",
         "processing:false",
         "drain",
       ]);
@@ -1773,5 +1803,176 @@ describe("wakeAgentForOpportunity", () => {
         expect(conversation.surfaceBroadcasts).toHaveLength(0);
       },
     );
+  });
+
+  describe("suppressAutoCompaction + over-window policy", () => {
+    const reply: Message = {
+      role: "assistant",
+      content: [{ type: "text", text: "done" }],
+    };
+
+    test("default wake runs the pre-run compaction gate before the agent loop", async () => {
+      const conversation = makeWakeConversation({
+        scriptedAssistant: reply,
+      });
+
+      const result = await wakeAgentForOpportunity(
+        {
+          conversationId: conversation.conversationId,
+          hint: "do work",
+          source: "unit-test",
+        },
+        { resolveTarget: async () => conversation },
+      );
+
+      expect(result.invoked).toBe(true);
+      expect(conversation.maybeCompactOrders).toHaveLength(1);
+      expect(conversation.runCalls).toHaveLength(1);
+      // The gate fired strictly before agentLoop.run (shared order counter).
+      expect(conversation.maybeCompactOrders[0]!).toBeLessThan(
+        conversation.runCalls[0]!.order,
+      );
+      // And under the processing marker, so a racing user send queues
+      // instead of starting a concurrent turn during the summary call.
+      expect(conversation.callSequence.indexOf("maybeCompact")).toBeGreaterThan(
+        conversation.callSequence.indexOf("processing:true"),
+      );
+    });
+
+    test("suppressAutoCompaction: true skips the compaction gate on an otherwise identical wake", async () => {
+      const conversation = makeWakeConversation({
+        scriptedAssistant: reply,
+      });
+
+      const result = await wakeAgentForOpportunity(
+        {
+          conversationId: conversation.conversationId,
+          hint: "do work",
+          source: "unit-test",
+          suppressAutoCompaction: true,
+        },
+        { resolveTarget: async () => conversation },
+      );
+
+      expect(result.invoked).toBe(true);
+      expect(conversation.maybeCompactOrders).toHaveLength(0);
+      expect(conversation.runCalls).toHaveLength(1);
+    });
+
+    test("over-window suppressed wake fails fast without invoking the loop or compacting", async () => {
+      const conversation = makeWakeConversation({
+        scriptedAssistant: reply,
+        // Mocked resolveEffectiveContextWindow yields maxInputTokens 200k.
+        estimatedInputTokens: 250_000,
+      });
+
+      const result = await wakeAgentForOpportunity(
+        {
+          conversationId: conversation.conversationId,
+          hint: "do work",
+          source: "unit-test",
+          suppressAutoCompaction: true,
+        },
+        { resolveTarget: async () => conversation },
+      );
+
+      expect(result).toEqual({
+        invoked: false,
+        producedToolCalls: false,
+        reason: "context_overflow",
+      });
+      expect(conversation.runCalls).toHaveLength(0);
+      expect(conversation.maybeCompactOrders).toHaveLength(0);
+      // The processing marker is released and the queue drained despite the
+      // early failure.
+      expect(conversation.processingToggles).toEqual([true, false]);
+      expect(conversation.isProcessing()).toBe(false);
+      expect(conversation.drainQueueCalls).toBe(1);
+    });
+
+    test("identical over-window wake without suppression compacts and runs instead of failing", async () => {
+      const conversation = makeWakeConversation({
+        scriptedAssistant: reply,
+        estimatedInputTokens: 250_000,
+      });
+
+      const result = await wakeAgentForOpportunity(
+        {
+          conversationId: conversation.conversationId,
+          hint: "do work",
+          source: "unit-test",
+        },
+        { resolveTarget: async () => conversation },
+      );
+
+      expect(result.invoked).toBe(true);
+      expect(conversation.maybeCompactOrders).toHaveLength(1);
+      expect(conversation.runCalls).toHaveLength(1);
+    });
+
+    test("suppressed wake maps a provider context-overflow rejection to a failed result", async () => {
+      // The estimator under-counted (pre-flight passed) but the provider
+      // still rejected the call as over-window. The loop swallows provider
+      // errors into a graceful no-output stop, which without the mapping
+      // would read as a successful silent no-op.
+      const conversation = makeWakeConversation({
+        estimatedInputTokens: 0,
+        runImpl: async (input, onEvent) => {
+          await onEvent({
+            type: "error",
+            error: new ContextOverflowError(
+              "prompt is too long: 250000 tokens > 200000 maximum",
+              "test-provider",
+            ),
+          });
+          return runResult([...input]);
+        },
+      });
+
+      const result = await wakeAgentForOpportunity(
+        {
+          conversationId: conversation.conversationId,
+          hint: "do work",
+          source: "unit-test",
+          suppressAutoCompaction: true,
+        },
+        { resolveTarget: async () => conversation },
+      );
+
+      expect(result).toEqual({
+        invoked: false,
+        producedToolCalls: false,
+        reason: "context_overflow",
+      });
+      // Cleanup still ran.
+      expect(conversation.processingToggles).toEqual([true, false]);
+      expect(conversation.drainQueueCalls).toBe(1);
+    });
+
+    test("non-suppressed wake treats a provider context-overflow rejection as a silent no-op (existing behavior)", async () => {
+      const conversation = makeWakeConversation({
+        runImpl: async (input, onEvent) => {
+          await onEvent({
+            type: "error",
+            error: new ContextOverflowError(
+              "prompt is too long: 250000 tokens > 200000 maximum",
+              "test-provider",
+            ),
+          });
+          return runResult([...input]);
+        },
+      });
+
+      const result = await wakeAgentForOpportunity(
+        {
+          conversationId: conversation.conversationId,
+          hint: "do work",
+          source: "unit-test",
+        },
+        { resolveTarget: async () => conversation },
+      );
+
+      expect(result).toEqual({ invoked: true, producedToolCalls: false });
+    });
   });
 });

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -7,6 +7,13 @@
  *
  * Semantics:
  *   - Resolves the conversation context exactly as a normal user turn.
+ *   - Runs the conversation's auto-threshold compaction gate
+ *     (`conversation.maybeCompact()`) before snapshotting the history —
+ *     the wake bypasses the orchestrator's in-loop compaction, so this is
+ *     its turn-start equivalent. Callers can pass
+ *     `suppressAutoCompaction: true` to skip it; a suppressed wake whose
+ *     input exceeds the effective context window fails deterministically
+ *     with `reason: "context_overflow"` instead of compacting.
  *   - Appends `hint` as a non-persisted assistant message sandwiched
  *     between two static user messages — never shows up in the transcript
  *     or SSE feed. The assistant role prevents prompt injection (LLMs
@@ -73,7 +80,7 @@ import {
   recordRequestLog,
   setAgentLoopExitReasonOnLatestLog,
 } from "../memory/llm-request-log-store.js";
-import type { Message } from "../providers/types.js";
+import { isContextOverflowError, type Message } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("agent-wake");
@@ -124,22 +131,25 @@ export interface WakeOptions {
    */
   hintRole?: "assistant" | "user";
   /**
-   * Documented intent: this wake must not trigger auto-threshold compaction.
+   * Skip the wake's pre-run auto-threshold compaction gate and refuse to
+   * run over-window instead of compacting.
    *
-   * Today this is automatically satisfied because the wake invokes
-   * `conversation.agentLoop.run()` directly, bypassing the daemon orchestrator
-   * (`conversation-agent-loop.ts`) where the compaction pipeline lives. The
-   * flag is recorded in the wake's structured log line so operators can
-   * verify the contract holds across refactors. If compaction is ever moved
-   * into `AgentLoop.run` or invoked from the wake path, callers that pass
-   * `true` here MUST be updated to suppress it; callers that pass `false`
-   * (or omit it) MUST tolerate compaction firing.
+   * By default the wake runs `conversation.maybeCompact()` before
+   * snapshotting the history — the wake invokes `conversation.agentLoop.run()`
+   * directly with the loop's in-loop budget gate disabled, so this pre-run
+   * gate is the wake path's equivalent of the turn-start compaction the
+   * daemon orchestrator (`conversation-agent-loop.ts`) performs for user
+   * turns. Passing `true` skips the gate entirely; if the wake input would
+   * then exceed the effective context window, the wake fails fast with
+   * `reason: "context_overflow"` instead of compacting, and a provider
+   * context-overflow rejection mid-run is mapped to the same failure.
    *
    * Used by fork-based memory retrospectives: the wake operates on a
-   * freshly-forked conversation that may already be near (or past) the
-   * source's auto-threshold, but the goal is to operate on that exact
-   * context — running a compaction LLM call before the wake's own first
-   * call would waste tokens and defeat prompt-cache reuse.
+   * freshly-forked throwaway conversation that may already be near (or
+   * past) the source's auto-threshold, but the goal is to operate on that
+   * exact context — running a compaction LLM call before the wake's own
+   * first call would waste tokens, defeat prompt-cache reuse, and fire
+   * compaction side-effects on a fork that is deleted afterwards.
    */
   suppressAutoCompaction?: boolean;
   /**
@@ -177,7 +187,14 @@ export type WakeSkipReason =
   | "archived"
   | "timeout"
   | "no_resolver"
-  | "disk_pressure";
+  | "disk_pressure"
+  /**
+   * The wake input exceeds the effective context window and the caller
+   * suppressed auto-compaction (`suppressAutoCompaction: true`), so the
+   * run cannot proceed without the compaction it was told not to perform.
+   * Only possible on suppressed wakes.
+   */
+  | "context_overflow";
 
 export interface WakeResult {
   invoked: boolean;
@@ -331,10 +348,12 @@ function classifyWakeDiskPressurePolicy(opts: WakeOptions): {
 }
 
 /**
- * Trust snapshot the wake hands to the agent loop. A wake has no compaction
- * path (it runs with overflow recovery disabled), so this snapshot is unread
- * except on the disk-pressure cleanup-mode path, whose guardian value scopes
- * the compactor's image manifest if cleanup ever compacts. Other wakes pass an
+ * Trust snapshot the wake hands to the agent loop. The wake's loop run has
+ * no in-loop compaction path (it runs with overflow recovery disabled; the
+ * wake compacts via the pre-run gate instead, which resolves trust from the
+ * conversation's own trust context), so this snapshot is unread except on
+ * the disk-pressure cleanup-mode path, whose guardian value scopes the
+ * compactor's image manifest if cleanup ever compacts. Other wakes pass an
  * `unknown`-class snapshot so a missing actor cannot grant elevated trust.
  */
 function buildWakeTrust(
@@ -420,6 +439,7 @@ export async function wakeAgentForOpportunity(
   deps?: WakeDeps,
 ): Promise<WakeResult> {
   const { conversationId, hint, source } = opts;
+  const suppressAutoCompaction = opts.suppressAutoCompaction === true;
   const resolveTarget = deps?.resolveTarget ?? defaultResolveTarget;
   const nowFn = deps?.now ?? Date.now;
   const startedAt = nowFn();
@@ -484,6 +504,54 @@ export async function wakeAgentForOpportunity(
     // declare guardian trust so side-effect tools clear the approval gate.
     if (opts.trustContext) {
       conversation.setTrustContext(opts.trustContext);
+    }
+
+    // Honor the conversation's pinned inference-profile override (if any).
+    // Without this, scheduled-task wakes and other opportunity wakes bypass
+    // `runAgentLoopImpl` entirely and execute under workspace defaults,
+    // silently violating the user's pinned preference. Resolve the effective
+    // context budget here as well because wakes bypass the normal user-turn
+    // path that computes it for tool-result truncation. Read before
+    // `setProcessing(true)` so a thrown DB/config read can't strand the
+    // processing flag.
+    const overrideProfile = getConversationOverrideProfile(conversationId);
+    const callSite = opts.callSite ?? "mainAgent";
+    const config = getConfig();
+    const effectiveContextWindow = resolveEffectiveContextWindow({
+      llm: config.llm,
+      callSite,
+      overrideProfile,
+    });
+
+    // Mark processing for the duration of the wake — including the pre-run
+    // compaction gate below, whose summary LLM call must not race a user
+    // send into a concurrent agent loop on the same conversation. A user
+    // message arriving while the flag is set is queued by `enqueueMessage()`
+    // and drained after the wake's tail is pushed + persisted. This happens
+    // before applying a wake-scoped tool allowlist so a concurrent user turn
+    // cannot start under the wake's restricted tool set.
+    conversation.setProcessing(true);
+
+    // ── Pre-run auto-compaction gate ──────────────────────────────────
+    // The wake invokes `conversation.agentLoop.run()` with the loop's
+    // in-loop budget gate disabled (see `resolveContextWindow` below), so
+    // the orchestrator's turn-start compaction never fires for wakes.
+    // Mirror it here: run the conversation's auto-threshold compaction
+    // before snapshotting the baseline — a successful compaction replaces
+    // `conversation.messages`, so it must precede the snapshot. Callers
+    // like fork-based memory retrospectives suppress this gate: the fork
+    // is throwaway and a summarization LLM call on it is wasted spend.
+    // Failure is non-fatal — the wake proceeds on the uncompacted history
+    // exactly as it would have before the gate existed.
+    if (!suppressAutoCompaction) {
+      try {
+        await conversation.maybeCompact();
+      } catch (err) {
+        log.warn(
+          { conversationId, source, err },
+          "agent-wake: pre-run auto-compaction failed; continuing with the uncompacted history",
+        );
+      }
     }
 
     const baseline = conversation.getMessages();
@@ -564,6 +632,14 @@ export async function wakeAgentForOpportunity(
     // so the latest-row lookup in `setAgentLoopExitReasonOnLatestLog`
     // can see the freshly-persisted final usage row.
     let pendingExitReason: string | null = null;
+    // Set when the provider rejects a call as context-too-large while
+    // auto-compaction is suppressed. The loop has no recovery ladder to
+    // drive (overflow recovery is disabled for wakes), so it swallows the
+    // rejection into a graceful no-output stop — which would read as a
+    // *successful* silent no-op to callers like the memory-retrospective
+    // job. Capture the signal here so the wake can fail deterministically
+    // instead (`reason: "context_overflow"`).
+    let suppressedContextOverflow = false;
     const persistLog = (record: PendingLog): void => {
       try {
         recordRequestLog(
@@ -657,6 +733,17 @@ export async function wakeAgentForOpportunity(
         } else {
           persistExitReason(event.reason);
         }
+      }
+      // Detect an over-window rejection on a compaction-suppressed wake.
+      // `provider_error` fires at the provider-call site; `error` fires from
+      // the loop's generic catch — check both so a rewrapping retry layer
+      // can't hide the signal.
+      if (
+        suppressAutoCompaction &&
+        (event.type === "provider_error" || event.type === "error") &&
+        isContextOverflowError(event.error)
+      ) {
+        suppressedContextOverflow = true;
       }
       if (mode === "buffering") {
         buffered.push(event);
@@ -758,23 +845,6 @@ export async function wakeAgentForOpportunity(
       persistedTailIndex += newMessages.length;
     };
 
-    // Honor the conversation's pinned inference-profile override (if any).
-    // Without this, scheduled-task wakes and other opportunity wakes bypass
-    // `runAgentLoopImpl` entirely and execute under workspace defaults,
-    // silently violating the user's pinned preference. Resolve the effective
-    // context budget here as well because wakes bypass the normal user-turn
-    // path that computes it for tool-result truncation. Read before
-    // `setProcessing(true)` so a thrown DB/config read can't strand the
-    // processing flag.
-    const overrideProfile = getConversationOverrideProfile(conversationId);
-    const callSite = opts.callSite ?? "mainAgent";
-    const config = getConfig();
-    const effectiveContextWindow = resolveEffectiveContextWindow({
-      llm: config.llm,
-      callSite,
-      overrideProfile,
-    });
-
     let wakeToolScopeRestored = false;
     let restoreWakeToolScope: (() => void) | null = null;
     const restoreWakeAllowedTools = (): void => {
@@ -807,14 +877,6 @@ export async function wakeAgentForOpportunity(
       }
     };
 
-    // Mark processing for the duration of the run so a concurrent user
-    // send is queued by `enqueueMessage()` rather than spawning a second
-    // concurrent agent loop on the same conversation (which would
-    // interleave writes to `conversation.messages`). This happens before
-    // applying a wake-scoped tool allowlist so a concurrent user turn cannot
-    // start under the wake's restricted tool set.
-    conversation.setProcessing(true);
-
     // Fires after each tool-execution turn finalizes (assistant message
     // + matching tool_result user message both in history). A single
     // tool turn is unambiguous evidence of output — promote to live
@@ -834,7 +896,70 @@ export async function wakeAgentForOpportunity(
     let toolUseNames: string[] = [];
     let tailMessageCount = 0;
     let drainedInTry = false;
+    // Set when the wake fails with `reason: "context_overflow"`. The finally
+    // block skips its generic outcome log for this path — the failure
+    // already logged its own dedicated warn line.
+    let failedContextOverflow = false;
+    // Shared failure path for a provider over-window rejection on a
+    // compaction-suppressed wake (reached from the run's catch when the
+    // rejection escaped as a throw, or post-run when the loop swallowed it
+    // into a graceful no-output stop and only the event capture saw it).
+    const failSuppressedContextOverflow = (err?: unknown): WakeResult => {
+      failedContextOverflow = true;
+      log.warn(
+        { conversationId, source, ...(err === undefined ? {} : { err }) },
+        "agent-wake: provider rejected the input as over-window with auto-compaction suppressed; failing the wake",
+      );
+      return {
+        invoked: false,
+        producedToolCalls: false,
+        reason: "context_overflow" as const,
+      };
+    };
     try {
+      // ── Over-window policy under suppressed auto-compaction ─────────
+      // The pre-run gate above is the wake's only compaction path (the
+      // loop's in-loop budget gate stays disabled), so when the caller
+      // suppressed it an over-window input has no recovery. Fail fast and
+      // deterministically — before spending any LLM call — instead of
+      // letting the provider reject the run into a silent no-op. Estimated
+      // with the same estimator the auto-compaction pre-check uses; an
+      // estimator failure proceeds fail-open (the reactive
+      // `suppressedContextOverflow` capture below still maps a provider
+      // rejection to the same failure).
+      if (suppressAutoCompaction) {
+        let estimatedInputTokens: number | null = null;
+        try {
+          estimatedInputTokens =
+            conversation.contextWindowManager.estimateInputTokens(runInput);
+        } catch (err) {
+          log.warn(
+            { conversationId, source, err },
+            "agent-wake: over-window pre-flight estimate failed; proceeding without it",
+          );
+        }
+        if (
+          estimatedInputTokens !== null &&
+          estimatedInputTokens > effectiveContextWindow.maxInputTokens
+        ) {
+          failedContextOverflow = true;
+          log.warn(
+            {
+              conversationId,
+              source,
+              estimatedInputTokens,
+              maxInputTokens: effectiveContextWindow.maxInputTokens,
+            },
+            "agent-wake: input exceeds the effective context window and auto-compaction is suppressed; failing fast",
+          );
+          return {
+            invoked: false,
+            producedToolCalls: false,
+            reason: "context_overflow" as const,
+          };
+        }
+      }
+
       if (!applyWakeAllowedTools()) {
         return {
           invoked: false,
@@ -859,22 +984,43 @@ export async function wakeAgentForOpportunity(
           callSite,
           trust: wakeTrust,
           overrideProfile,
-          // Wake runs have no orchestrator-side mid-loop compaction path,
-          // so the budget gate stays disabled (`overflowRecovery.enabled =
-          // false`); `maxInputTokens` is still supplied for tool-result
-          // truncation.
+          // The wake's compaction lives in the pre-run gate above
+          // (`conversation.maybeCompact()`), never in the loop: the in-loop
+          // budget gate and overflow-recovery ladder stay disabled because
+          // the wake's tail accounting holds external indexes into the
+          // returned history (`baselineLength` + hint count), which an
+          // in-loop compaction rebase would invalidate. `maxInputTokens` is
+          // still supplied for tool-result truncation.
           resolveContextWindow: () => ({
             maxInputTokens: effectiveContextWindow.maxInputTokens,
             overflowRecovery: { enabled: false, safetyMarginRatio: 0 },
           }),
         }));
       } catch (err) {
+        // An over-window throw on a compaction-suppressed wake is the
+        // suppression contract's failure mode, not a generic loop error —
+        // surface it as a deterministic failed result.
+        if (
+          suppressedContextOverflow ||
+          (suppressAutoCompaction && isContextOverflowError(err))
+        ) {
+          return failSuppressedContextOverflow(err);
+        }
         // Capture the error for post-finally logging, then short-circuit
         // the rest of the try body — no tail to push/persist when the
         // run threw mid-flight. The outer finally still runs to release
         // `processing` and drain the queue.
         runError = err instanceof Error ? err : new Error(String(err));
         return { invoked: true, producedToolCalls: false };
+      }
+
+      // The loop swallows provider rejections into a graceful no-output
+      // stop, so an over-window rejection on a compaction-suppressed wake
+      // surfaces only through the event stream (captured into
+      // `suppressedContextOverflow` by `onEvent`). Map it to a deterministic
+      // failure instead of the silent no-op it would otherwise read as.
+      if (suppressedContextOverflow) {
+        return failSuppressedContextOverflow();
       }
 
       // Run completed cleanly. The canonical user-turn pattern
@@ -971,9 +1117,12 @@ export async function wakeAgentForOpportunity(
       }
 
       const durationMs = nowFn() - startedAt;
-      const suppressAutoCompaction = opts.suppressAutoCompaction === true;
       const suppressWakeSurface = opts.suppressWakeSurface === true;
-      if (runError) {
+      if (failedContextOverflow) {
+        // Already logged its own dedicated warn line at the failure site;
+        // a generic "silent no-op" line here would misclassify a failed
+        // wake as a successful empty one.
+      } else if (runError) {
         log.error(
           {
             conversationId,


### PR DESCRIPTION
## Summary
- Thread the wake's suppressAutoCompaction option into the agent loop so compaction is actually skipped (it was declared and logged but consumed nowhere)
- Over-window behavior with suppression on: fail the wake deterministically instead of compacting a throwaway conversation

Part of plan: memory-retrospective-fork-hardening.md (PR D of 12)