### PR TITLE
feat(memory): GC superseded retrospective runs (configurable)

### DIFF
--- a/assistant/src/config/schemas/memory-retrospective.ts
+++ b/assistant/src/config/schemas/memory-retrospective.ts
@@ -38,6 +38,15 @@ export const MemoryRetrospectiveConfigSchema = z
       .describe(
         "Minimum milliseconds between attempts (success or failure). Prevents tight retry loops across trigger types. Pre-compaction bypasses this gate.",
       ),
+
+    keepSupersededRuns: z
+      .boolean({
+        error: "memory.retrospective.keepSupersededRuns must be a boolean",
+      })
+      .default(false)
+      .describe(
+        "When false (default), superseded retrospective conversations are deleted once a newer run succeeds — dedup only ever reads the most recent run via findMostRecentRetrospectiveFor, so older runs are dead weight (fork-based runs each carry a full copy of the source conversation's messages). Operators who want to retain the full run history set this to true; retained runs also skip the startup orphan sweep so they survive restarts.",
+      ),
   })
   .describe(
     "Controls the memory-retrospective background pass. Model selection lives under llm.callSites.memoryRetrospective.",

--- a/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
@@ -47,6 +47,7 @@ let wakeCalls: Array<{
 let bootstrappedConversationId = "bg-conv-new";
 let bootstrapCalls: Array<{ forkParentConversationId?: string }> = [];
 let deletedConversationIds: string[] = [];
+let deleteConversationThrowsFor: string | null = null;
 
 // Fork-path mocks. Flag off by default so legacy-path tests stay untouched.
 let forkFlagEnabled = false;
@@ -148,6 +149,9 @@ mock.module("../conversation-crud.js", () => ({
     addMessageCalls.push({ conversationId, role, content, options });
   },
   deleteConversation: (id: string) => {
+    if (deleteConversationThrowsFor === id) {
+      throw new Error(`delete failed for ${id}`);
+    }
     deletedConversationIds.push(id);
   },
   reserveMessage: mock(async () => ({ id: "msg-reserve" })),
@@ -231,10 +235,19 @@ import type { MemoryJob } from "../jobs-store.js";
 import { memoryRetrospectiveJob } from "../memory-retrospective-job.js";
 
 function makeConfig(
-  overrides: { userTimezone?: string; detectedTimezone?: string } = {},
+  overrides: {
+    userTimezone?: string;
+    detectedTimezone?: string;
+    keepSupersededRuns?: boolean;
+  } = {},
 ): Parameters<typeof memoryRetrospectiveJob>[1] {
   return {
-    memory: { v2: { enabled: true } },
+    memory: {
+      v2: { enabled: true },
+      retrospective: {
+        keepSupersededRuns: overrides.keepSupersededRuns ?? false,
+      },
+    },
     ui: {
       userTimezone: overrides.userTimezone,
       detectedTimezone: overrides.detectedTimezone,
@@ -307,6 +320,7 @@ describe("memoryRetrospectiveJob", () => {
     bootstrappedConversationId = "bg-conv-new";
     bootstrapCalls = [];
     deletedConversationIds = [];
+    deleteConversationThrowsFor = null;
     transcriptFormatterCalls = [];
     mockAssistantName = "Bob";
     mockUserName = "Alice";
@@ -822,5 +836,92 @@ describe("memoryRetrospectiveJob", () => {
       "fail closed: review only the most recent visible messages after the summary",
     );
     expect(instructionText).toContain("behind the compaction summary");
+  });
+
+  // -------------------------------------------------------------------------
+  // GC of superseded prior retrospectives (memory.retrospective.keepSupersededRuns)
+  // -------------------------------------------------------------------------
+
+  test("legacy path: success deletes the superseded prior retrospective", async () => {
+    priorRetroId = "prior-retro-conv-1";
+    priorRetroMessages = [priorRetroMessage(["an old save"])];
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("invoked");
+    expect(deletedConversationIds).toEqual(["prior-retro-conv-1"]);
+  });
+
+  test("fork path: success deletes the superseded prior retrospective", async () => {
+    forkFlagEnabled = true;
+    priorRetroId = "prior-retro-conv-1";
+    priorRetroMessages = [priorRetroMessage(["an old save"])];
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("invoked");
+    expect(deletedConversationIds).toEqual(["prior-retro-conv-1"]);
+  });
+
+  test("success with no prior retrospective deletes nothing", async () => {
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("invoked");
+    expect(deletedConversationIds).toEqual([]);
+  });
+
+  test("legacy path: wake failure does NOT delete the prior retrospective (dedup chain survives)", async () => {
+    priorRetroId = "prior-retro-conv-1";
+    priorRetroMessages = [priorRetroMessage(["an old save"])];
+    mockWakeResult = { invoked: false, reason: "timeout" };
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("wake_failed");
+    // Only the orphan background conversation is cleaned up — the prior
+    // remains the most-recent retrospective for the retry's dedup lookup.
+    expect(deletedConversationIds).toEqual(["bg-conv-new"]);
+  });
+
+  test("fork path: wake failure does NOT delete the prior retrospective (dedup chain survives)", async () => {
+    forkFlagEnabled = true;
+    priorRetroId = "prior-retro-conv-1";
+    priorRetroMessages = [priorRetroMessage(["an old save"])];
+    mockWakeResult = { invoked: false, reason: "timeout" };
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("wake_failed");
+    expect(deletedConversationIds).toEqual(["fork-conv-1"]);
+  });
+
+  test("keepSupersededRuns=true retains the prior retrospective on success (both kinds)", async () => {
+    const config = makeConfig({ keepSupersededRuns: true });
+    priorRetroId = "prior-retro-conv-1";
+    priorRetroMessages = [priorRetroMessage(["an old save"])];
+
+    // Legacy kind.
+    let outcome = await memoryRetrospectiveJob(makeJob(), config);
+    expect(outcome.kind).toBe("invoked");
+    expect(deletedConversationIds).toEqual([]);
+
+    // Fork kind.
+    forkFlagEnabled = true;
+    outcome = await memoryRetrospectiveJob(makeJob(), config);
+    expect(outcome.kind).toBe("invoked");
+    expect(deletedConversationIds).toEqual([]);
+  });
+
+  test("failure to delete the superseded prior is non-fatal — job still reports invoked with state advanced", async () => {
+    priorRetroId = "prior-retro-conv-1";
+    priorRetroMessages = [priorRetroMessage(["an old save"])];
+    deleteConversationThrowsFor = "prior-retro-conv-1";
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("invoked");
+    expect(stateUpserts).toHaveLength(1);
+    expect(stateUpserts[0]!.lastProcessedMessageId).toBe("m3");
+    expect(deletedConversationIds).toEqual([]);
   });
 });

--- a/assistant/src/memory/__tests__/memory-retrospective-startup-cleanup.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-startup-cleanup.test.ts
@@ -102,6 +102,15 @@ mock.module("../db-connection.js", () => ({
 
 let activeJobSourceConvIds = new Set<string>();
 let injectedNowMinusOrphanAgeMs = 0;
+let mockKeepSupersededRuns = false;
+
+mock.module("../../config/loader.js", () => ({
+  getConfig: () => ({
+    memory: {
+      retrospective: { keepSupersededRuns: mockKeepSupersededRuns },
+    },
+  }),
+}));
 
 mock.module("../conversation-crud.js", () => ({
   deleteConversation: (id: string) => {
@@ -142,6 +151,7 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
     deletedIds = [];
     activeJobSourceConvIds = new Set();
     injectedNowMinusOrphanAgeMs = 0;
+    mockKeepSupersededRuns = false;
   });
 
   afterEach(() => {
@@ -313,6 +323,37 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
 
   test("running across an empty workspace returns swept=0 without errors", () => {
     const result = sweepOrphanMemoryRetrospectiveConversations();
+    expect(result.swept).toBe(0);
+    expect(deletedIds).toEqual([]);
+  });
+
+  test("keepSupersededRuns=true skips the sweep entirely — sweepable orphans are retained", () => {
+    mockKeepSupersededRuns = true;
+    const now = Date.now();
+    injectedNowMinusOrphanAgeMs = now - ORPHAN_AGE_MS;
+    // Same shape as the first test's sweepable orphan — with the flag off
+    // this would be swept (older retro superseded by a newer one for the
+    // same source).
+    mockConversations = [
+      {
+        id: "old-orphan",
+        source: "memory-retrospective",
+        last_message_at: now - 2 * ORPHAN_AGE_MS,
+        fork_parent_conversation_id: "source-A",
+        created_at: now - 3 * ORPHAN_AGE_MS,
+      },
+      {
+        id: "newer-retro",
+        source: "memory-retrospective",
+        last_message_at: now - 90 * 60 * 1000,
+        fork_parent_conversation_id: "source-A",
+        created_at: now - 2 * ORPHAN_AGE_MS,
+      },
+    ];
+    rebuildActiveJobSet();
+
+    const result = sweepOrphanMemoryRetrospectiveConversations(now);
+
     expect(result.swept).toBe(0);
     expect(deletedIds).toEqual([]);
   });

--- a/assistant/src/memory/memory-retrospective-job.ts
+++ b/assistant/src/memory/memory-retrospective-job.ts
@@ -161,11 +161,13 @@ async function runLegacyRetrospective(
   }
   const cutoffMessageId = cutoffMessage.id;
 
-  // 3. Pull the most recent prior retrospective's `remember` calls.
-  // Done BEFORE bootstrapping the new background conversation so the lookup
-  // doesn't accidentally include this run's own conversation.
-  const priorRemembers =
-    collectPriorRetrospectiveRemembers(sourceConversationId);
+  // 3. Locate the most recent prior retrospective and pull its `remember`
+  // calls. Done BEFORE bootstrapping the new background conversation so the
+  // lookup doesn't accidentally include this run's own conversation. The
+  // prior's id is kept so the success path can GC it once this run
+  // supersedes it.
+  const prior = findMostRecentRetrospectiveFor(sourceConversationId);
+  const priorRemembers = collectPriorRetrospectiveRemembers(prior);
 
   // 4. Build prompt. Render message timestamps in the user's clock, not UTC,
   // so the assistant's reasoning about relative times in the slice
@@ -235,6 +237,8 @@ async function runLegacyRetrospective(
       lastProcessedMessageId: cutoffMessageId,
       lastRunAt: Date.now(),
     });
+
+    deleteSupersededPriorRetrospective(config, prior);
 
     const followUpJobIds = enqueueFollowUpJobs();
 
@@ -343,10 +347,12 @@ async function runForkBasedRetrospective(
       timezoneContext.effectiveTimezone,
     );
 
-  // Pull prior `remember` calls BEFORE forking — otherwise
-  // `findMostRecentRetrospectiveFor` could locate this run's own fork.
-  const priorRemembers =
-    collectPriorRetrospectiveRemembers(sourceConversationId);
+  // Locate the prior retrospective and pull its `remember` calls BEFORE
+  // forking — otherwise `findMostRecentRetrospectiveFor` could locate this
+  // run's own fork. The prior's id is kept so the success path can GC it
+  // once this run supersedes it.
+  const prior = findMostRecentRetrospectiveFor(sourceConversationId);
+  const priorRemembers = collectPriorRetrospectiveRemembers(prior);
 
   // Pin the fork to `cutoffMessageId` so messages arriving between the slice
   // read above and this call don't sneak into the fork. Without
@@ -445,6 +451,8 @@ async function runForkBasedRetrospective(
       lastRunAt: Date.now(),
     });
 
+    deleteSupersededPriorRetrospective(config, prior);
+
     const followUpJobIds = enqueueFollowUpJobs();
 
     log.info(
@@ -509,6 +517,37 @@ function safeDeleteForkOnFailure(forkId: string): void {
 }
 
 /**
+ * GC the prior retrospective conversation once a newer run has succeeded.
+ * Dedup only ever reads the most recent retrospective per source
+ * (`findMostRecentRetrospectiveFor`), so the superseded run is dead weight —
+ * and fork-kind runs each materialize a full copy of the source
+ * conversation's message rows, so without GC a long-lived daemon accumulates
+ * one full-history copy per retrospective interval per active conversation.
+ *
+ * Called only AFTER `upsertRetrospectiveState` on the success path: deleting
+ * on failure would break the dedup chain (the failed run's conversation is
+ * cleaned up separately and the prior must remain the most-recent
+ * retrospective for the retry). Best-effort — deletion failure is logged and
+ * never fails the job. Operators opt out of GC entirely via
+ * `memory.retrospective.keepSupersededRuns`.
+ */
+function deleteSupersededPriorRetrospective(
+  config: AssistantConfig,
+  prior: { id: string } | null,
+): void {
+  if (!prior) return;
+  if (config.memory.retrospective.keepSupersededRuns) return;
+  try {
+    deleteConversation(prior.id);
+  } catch (err) {
+    log.warn(
+      { err, priorConversationId: prior.id },
+      "memory-retrospective: failed to delete superseded prior retrospective conversation; continuing",
+    );
+  }
+}
+
+/**
  * Walk the slice and return the `<turn_context>` `current_time:` value from
  * the first user message that carries one. Injected blocks like
  * `<turn_context>` are NOT persisted in message content — they live in
@@ -550,9 +589,11 @@ function findFirstTurnContextTimestamp(
 
 /**
  * Pull the `content` strings out of every `remember` tool call made in the
- * most recent prior retrospective conversation rooted at this source. Empty
- * array on first run (no prior retrospective) or when the prior run had no
- * `remember` calls (it found nothing to save).
+ * given prior retrospective conversation (located by the caller via
+ * `findMostRecentRetrospectiveFor` — the caller keeps the id so it can GC
+ * the prior run after success). Empty array on first run (no prior
+ * retrospective) or when the prior run had no `remember` calls (it found
+ * nothing to save).
  *
  * Two artifact shapes exist depending on which path produced the prior
  * retrospective:
@@ -573,9 +614,8 @@ function findFirstTurnContextTimestamp(
  * retrospective dedups against the one before it.
  */
 function collectPriorRetrospectiveRemembers(
-  sourceConversationId: string,
+  prior: { id: string } | null,
 ): string[] {
-  const prior = findMostRecentRetrospectiveFor(sourceConversationId);
   if (!prior) return [];
   let messages: ReturnType<typeof getMessages>;
   try {

--- a/assistant/src/memory/memory-retrospective-startup-cleanup.ts
+++ b/assistant/src/memory/memory-retrospective-startup-cleanup.ts
@@ -29,6 +29,9 @@
 //     retro via `findMostRecentRetrospectiveFor` to seed its
 //     `<already_remembered>` dedup block; sweeping it would force the
 //     next run to re-save facts the prior pass already captured.
+//
+// The sweep is skipped entirely when `memory.retrospective.keepSupersededRuns`
+// is true — see the comment inside the function.
 
 import {
   and,
@@ -42,6 +45,7 @@ import {
   sql,
 } from "drizzle-orm";
 
+import { getConfig } from "../config/loader.js";
 import { getLogger } from "../util/logger.js";
 import { deleteConversation } from "./conversation-crud.js";
 import { getDb } from "./db-connection.js";
@@ -65,6 +69,16 @@ export interface CleanupResult {
 export function sweepOrphanMemoryRetrospectiveConversations(
   now: number = Date.now(),
 ): CleanupResult {
+  // When the operator opted into retaining superseded retrospective runs
+  // (`memory.retrospective.keepSupersededRuns`), skip the sweep entirely —
+  // retained runs must survive restarts, and the sweep cannot distinguish a
+  // retained superseded run from a crash orphan. Tradeoff: under this opt-in,
+  // genuine crash orphans persist too. That's acceptable — the operator asked
+  // for full run history, and an orphan is just one more retained conversation.
+  if (getConfig().memory?.retrospective?.keepSupersededRuns === true) {
+    return { swept: 0 };
+  }
+
   const cutoff = now - ORPHAN_AGE_MS;
   const db = getDb();
 


### PR DESCRIPTION
## Summary
- Add memory.retrospective.keepSupersededRuns (default false = GC on)
- On successful retrospective (fork + legacy), best-effort delete the superseded prior run — dedup only ever reads the most recent
- keepSupersededRuns=true retains all runs and skips the startup sweep so they survive restarts

Part of plan: memory-retrospective-fork-hardening.md (PR B of 12)