### PR TITLE
fix(memory): startup sweep prefers dedup baselines with post-fork output

### DIFF
--- a/assistant/src/memory/__tests__/memory-retrospective-startup-cleanup.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-startup-cleanup.test.ts
@@ -23,10 +23,22 @@ type JobRow = {
   status: string;
   payload: string;
 };
+type MessageRow = {
+  role: string;
+  createdAt: number;
+  metadata: string | null;
+};
 
 let mockConversations: ConvRow[] = [];
 let mockJobs: JobRow[] = [];
+let mockMessages: Record<string, MessageRow[]> = {};
 let deletedIds: string[] = [];
+
+const RETRO_SOURCES = ["memory-retrospective", "memory-retrospective-fork"];
+
+function isRetroSource(source: string | null): boolean {
+  return source !== null && RETRO_SOURCES.includes(source);
+}
 
 mock.module("../db-connection.js", () => ({
   getDb: () => ({
@@ -60,18 +72,20 @@ mock.module("../db-connection.js", () => ({
                   return { conversationId: convId };
                 });
             }
-            // The "all retros" query (used to compute most-recent-per-source
-            // preservation) requests id + forkParentConversationId + createdAt
-            // with only the source + isNotNull(forkParent) predicate.
+            // The "all retros" query (used to compute the preserved
+            // dedup-baseline per source) requests id + source +
+            // forkParentConversationId + createdAt with only the source +
+            // isNotNull(forkParent) predicate.
             if (
               colKeys.includes("forkParentConversationId") &&
               colKeys.includes("createdAt")
             ) {
               return mockConversations
-                .filter((c) => c.source === "memory-retrospective")
+                .filter((c) => isRetroSource(c.source))
                 .filter((c) => c.fork_parent_conversation_id !== null)
                 .map((c) => ({
                   id: c.id,
+                  source: c.source,
                   forkParentConversationId: c.fork_parent_conversation_id,
                   createdAt: c.created_at,
                 }));
@@ -81,7 +95,7 @@ mock.module("../db-connection.js", () => ({
             // encoded on the background conversation row) against the set
             // of source IDs extracted from active jobs.
             return mockConversations
-              .filter((c) => c.source === "memory-retrospective")
+              .filter((c) => isRetroSource(c.source))
               .filter(
                 (c) =>
                   c.last_message_at !== null &&
@@ -117,6 +131,7 @@ mock.module("../conversation-crud.js", () => ({
     deletedIds.push(id);
     mockConversations = mockConversations.filter((c) => c.id !== id);
   },
+  getMessages: (conversationId: string) => mockMessages[conversationId] ?? [],
   reserveMessage: mock(async () => ({ id: "msg-reserve" })),
 }));
 
@@ -148,6 +163,7 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
   beforeEach(() => {
     mockConversations = [];
     mockJobs = [];
+    mockMessages = {};
     deletedIds = [];
     activeJobSourceConvIds = new Set();
     injectedNowMinusOrphanAgeMs = 0;
@@ -157,6 +173,7 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
   afterEach(() => {
     mockConversations = [];
     mockJobs = [];
+    mockMessages = {};
   });
 
   test("sweeps an old memory-retrospective orphan that has been superseded by a newer retro for the same source", () => {
@@ -356,5 +373,169 @@ describe("sweepOrphanMemoryRetrospectiveConversations", () => {
 
     expect(result.swept).toBe(0);
     expect(deletedIds).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------------
+  // Dedup-baseline selection: prefer rows that actually produced output.
+  // -------------------------------------------------------------------------
+
+  /**
+   * Build a fork-kind retrospective's message rows: a copied source prefix
+   * (stamped with `forkSourceMessageId`, ending in an assistant turn AT the
+   * boundary — exercising the strictly-greater check), the post-fork
+   * user-role instruction, and optionally the retrospective's own assistant
+   * output after the boundary.
+   */
+  function forkKindMessages(opts: {
+    boundaryAt: number;
+    withOutput: boolean;
+  }): MessageRow[] {
+    const rows: MessageRow[] = [
+      {
+        role: "user",
+        createdAt: opts.boundaryAt - 1000,
+        metadata: JSON.stringify({ forkSourceMessageId: "src-msg-1" }),
+      },
+      {
+        role: "assistant",
+        createdAt: opts.boundaryAt,
+        metadata: JSON.stringify({ forkSourceMessageId: "src-msg-2" }),
+      },
+      {
+        role: "user",
+        createdAt: opts.boundaryAt + 500,
+        metadata: JSON.stringify({ kind: "memory_retrospective_instruction" }),
+      },
+    ];
+    if (opts.withOutput) {
+      rows.push({
+        role: "assistant",
+        createdAt: opts.boundaryAt + 1000,
+        metadata: null,
+      });
+    }
+    return rows;
+  }
+
+  test("sweeps an orphan MOST-RECENT fork-kind row (no post-fork output) and preserves an older row WITH output as the dedup baseline", () => {
+    const now = Date.now();
+    injectedNowMinusOrphanAgeMs = now - ORPHAN_AGE_MS;
+    mockConversations = [
+      {
+        id: "fork-with-output",
+        source: "memory-retrospective-fork",
+        last_message_at: now - 3 * ORPHAN_AGE_MS,
+        fork_parent_conversation_id: "source-A",
+        created_at: now - 3 * ORPHAN_AGE_MS,
+      },
+      // Most recent for source-A, but a crash orphan: its only post-fork
+      // message is the instruction — no assistant output after the boundary.
+      // The copied prefix DOES contain an assistant turn (at the boundary),
+      // which must not count.
+      {
+        id: "fork-orphan",
+        source: "memory-retrospective-fork",
+        last_message_at: now - 2 * ORPHAN_AGE_MS,
+        fork_parent_conversation_id: "source-A",
+        created_at: now - 2 * ORPHAN_AGE_MS,
+      },
+    ];
+    mockMessages = {
+      "fork-with-output": forkKindMessages({
+        boundaryAt: now - 3 * ORPHAN_AGE_MS,
+        withOutput: true,
+      }),
+      "fork-orphan": forkKindMessages({
+        boundaryAt: now - 2 * ORPHAN_AGE_MS,
+        withOutput: false,
+      }),
+    };
+    rebuildActiveJobSet();
+
+    const result = sweepOrphanMemoryRetrospectiveConversations(now);
+
+    expect(result.swept).toBe(1);
+    expect(deletedIds).toEqual(["fork-orphan"]);
+  });
+
+  test("falls back to preserving the plain most-recent row when EVERY row is an orphan", () => {
+    const now = Date.now();
+    injectedNowMinusOrphanAgeMs = now - ORPHAN_AGE_MS;
+    mockConversations = [
+      {
+        id: "older-orphan",
+        source: "memory-retrospective-fork",
+        last_message_at: now - 3 * ORPHAN_AGE_MS,
+        fork_parent_conversation_id: "source-A",
+        created_at: now - 3 * ORPHAN_AGE_MS,
+      },
+      {
+        id: "newest-orphan",
+        source: "memory-retrospective-fork",
+        last_message_at: now - 2 * ORPHAN_AGE_MS,
+        fork_parent_conversation_id: "source-A",
+        created_at: now - 2 * ORPHAN_AGE_MS,
+      },
+    ];
+    mockMessages = {
+      "older-orphan": forkKindMessages({
+        boundaryAt: now - 3 * ORPHAN_AGE_MS,
+        withOutput: false,
+      }),
+      "newest-orphan": forkKindMessages({
+        boundaryAt: now - 2 * ORPHAN_AGE_MS,
+        withOutput: false,
+      }),
+    };
+    rebuildActiveJobSet();
+
+    const result = sweepOrphanMemoryRetrospectiveConversations(now);
+
+    // Current behavior preserved: the most-recent row survives even though
+    // it has no output; the older orphan is swept.
+    expect(result.swept).toBe(1);
+    expect(deletedIds).toEqual(["older-orphan"]);
+  });
+
+  test("legacy-kind selection: ANY assistant message counts as output (no fork boundary required)", () => {
+    const now = Date.now();
+    injectedNowMinusOrphanAgeMs = now - ORPHAN_AGE_MS;
+    mockConversations = [
+      // Older legacy retro that produced output — preserved.
+      {
+        id: "legacy-with-output",
+        source: "memory-retrospective",
+        last_message_at: now - 3 * ORPHAN_AGE_MS,
+        fork_parent_conversation_id: "source-A",
+        created_at: now - 3 * ORPHAN_AGE_MS,
+      },
+      // Most-recent legacy retro with no assistant message — a wake that
+      // never produced output. Swept.
+      {
+        id: "legacy-orphan",
+        source: "memory-retrospective",
+        last_message_at: now - 2 * ORPHAN_AGE_MS,
+        fork_parent_conversation_id: "source-A",
+        created_at: now - 2 * ORPHAN_AGE_MS,
+      },
+    ];
+    mockMessages = {
+      "legacy-with-output": [
+        // Legacy rows carry no forkSourceMessageId stamps — any assistant
+        // message qualifies.
+        {
+          role: "assistant",
+          createdAt: now - 3 * ORPHAN_AGE_MS,
+          metadata: null,
+        },
+      ],
+      "legacy-orphan": [],
+    };
+    rebuildActiveJobSet();
+
+    const result = sweepOrphanMemoryRetrospectiveConversations(now);
+
+    expect(result.swept).toBe(1);
+    expect(deletedIds).toEqual(["legacy-orphan"]);
   });
 });

--- a/assistant/src/memory/memory-retrospective-fork-boundary.ts
+++ b/assistant/src/memory/memory-retrospective-fork-boundary.ts
@@ -1,0 +1,43 @@
+// ---------------------------------------------------------------------------
+// Memory retrospective — fork-boundary detection.
+// ---------------------------------------------------------------------------
+//
+// Shared between the retrospective job (scoping prior-`remember` dedup to the
+// post-fork tail) and the startup orphan sweep (deciding whether a fork-kind
+// retrospective row produced any post-fork output worth preserving as the
+// next run's dedup baseline). Lives in its own module so the sweep doesn't
+// have to import the job handler's full dependency graph.
+
+/**
+ * Locate the boundary timestamp between a fork-kind retrospective's copied
+ * prefix and its post-fork tail. Scans from the end for the last message
+ * whose metadata carries a `forkSourceMessageId` stamp (the last copied
+ * source message); its `createdAt` is the boundary. The stamp's value may
+ * point at any ancestor when the source was itself a fork
+ * (`cloneForkMessageMetadata` preserves pre-existing values), so we only
+ * check for presence, not equality. Returns `null` only if no copied
+ * messages remain (corrupted fork metadata or empty fork — caller logs +
+ * degrades).
+ */
+export function findForkBoundaryCreatedAt(
+  forkMessages: Array<{
+    createdAt: number;
+    metadata: string | null;
+  }>,
+): number | null {
+  for (let i = forkMessages.length - 1; i >= 0; i--) {
+    const row = forkMessages[i]!;
+    if (!row.metadata) continue;
+    try {
+      const parsed = JSON.parse(row.metadata) as {
+        forkSourceMessageId?: unknown;
+      };
+      if (typeof parsed.forkSourceMessageId === "string") {
+        return row.createdAt;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}

--- a/assistant/src/memory/memory-retrospective-job.ts
+++ b/assistant/src/memory/memory-retrospective-job.ts
@@ -69,6 +69,7 @@ import {
   MEMORY_RETROSPECTIVE_INSTRUCTION_KIND,
   MEMORY_RETROSPECTIVE_SOURCE,
 } from "./memory-retrospective-constants.js";
+import { findForkBoundaryCreatedAt } from "./memory-retrospective-fork-boundary.js";
 import {
   bumpRetrospectiveLastRunAt,
   getRetrospectiveState,
@@ -652,40 +653,6 @@ function collectPriorRetrospectiveRemembers(
   }
 
   return extractRememberContents(messages);
-}
-
-/**
- * Locate the boundary timestamp between the fork's prefix and its post-fork
- * tail. Scans from the end for the last message whose metadata carries a
- * `forkSourceMessageId` stamp (the last copied source message); its
- * `createdAt` is the boundary. The stamp's value may point at any ancestor
- * when the source was itself a fork (`cloneForkMessageMetadata` preserves
- * pre-existing values), so we only check for presence, not equality.
- * Returns `null` only if no copied messages remain (corrupted fork metadata
- * or empty fork — caller logs + degrades).
- */
-function findForkBoundaryCreatedAt(
-  forkMessages: Array<{
-    id: string;
-    createdAt: number;
-    metadata: string | null;
-  }>,
-): number | null {
-  for (let i = forkMessages.length - 1; i >= 0; i--) {
-    const row = forkMessages[i]!;
-    if (!row.metadata) continue;
-    try {
-      const parsed = JSON.parse(row.metadata) as {
-        forkSourceMessageId?: unknown;
-      };
-      if (typeof parsed.forkSourceMessageId === "string") {
-        return row.createdAt;
-      }
-    } catch {
-      continue;
-    }
-  }
-  return null;
 }
 
 interface MessageLike {

--- a/assistant/src/memory/memory-retrospective-startup-cleanup.ts
+++ b/assistant/src/memory/memory-retrospective-startup-cleanup.ts
@@ -24,11 +24,15 @@
 //     conversation might be the active one. We're conservative and only
 //     sweep when no job exists at all, since the worst-case false-positive
 //     is leaving a few extra orphans for the next sweep to catch.)
-//   - AND the row is NOT the most-recent retrospective for its source
+//   - AND the row is NOT the preserved dedup baseline for its source
 //     conversation. The next retrospective run reads the most-recent prior
 //     retro via `findMostRecentRetrospectiveFor` to seed its
 //     `<already_remembered>` dedup block; sweeping it would force the
-//     next run to re-save facts the prior pass already captured.
+//     next run to re-save facts the prior pass already captured. The
+//     baseline is the most recent row that actually produced output (see
+//     `selectPreservedBaseline`) — a crash orphan with no post-fork
+//     assistant message would seed an EMPTY dedup block, so when an older
+//     row with output exists we preserve that one instead.
 //
 // The sweep is skipped entirely when `memory.retrospective.keepSupersededRuns`
 // is true — see the comment inside the function.
@@ -47,14 +51,27 @@ import {
 
 import { getConfig } from "../config/loader.js";
 import { getLogger } from "../util/logger.js";
-import { deleteConversation } from "./conversation-crud.js";
+import { deleteConversation, getMessages } from "./conversation-crud.js";
 import { getDb } from "./db-connection.js";
-import { MEMORY_RETROSPECTIVE_SOURCES } from "./memory-retrospective-constants.js";
+import {
+  MEMORY_RETROSPECTIVE_FORK_SOURCE,
+  MEMORY_RETROSPECTIVE_SOURCES,
+} from "./memory-retrospective-constants.js";
+import { findForkBoundaryCreatedAt } from "./memory-retrospective-fork-boundary.js";
 import { conversations, memoryJobs } from "./schema.js";
 
 const log = getLogger("memory-retrospective-startup-cleanup");
 
 const ORPHAN_AGE_MS = 60 * 60 * 1000;
+
+/**
+ * How many of the newest retrospective rows per source the baseline selector
+ * will load messages for when looking for one with output. Bounds the
+ * per-startup query volume — after GC (`deleteSupersededPriorRetrospective`)
+ * a source normally has 1–2 retro rows, so this only matters for pathological
+ * crash pileups, where the older rows are orphans too.
+ */
+const MAX_BASELINE_CANDIDATES_PER_SOURCE = 3;
 
 export interface CleanupResult {
   swept: number;
@@ -104,13 +121,14 @@ export function sweepOrphanMemoryRetrospectiveConversations(
     .map((row) => row.conversationId)
     .filter((id): id is string => typeof id === "string" && id.length > 0);
 
-  // Compute the most-recent retro per source so we can preserve it.
-  // `findMostRecentRetrospectiveFor` (called by the next retrospective run)
-  // pulls dedup context from this row; sweeping it would re-introduce the
+  // Compute the preserved dedup baseline per source. The next retrospective
+  // run pulls dedup context from the most-recent prior retro (via
+  // `findMostRecentRetrospectiveFor`); sweeping it would re-introduce the
   // unbounded retrospective growth this cleanup exists to prevent.
   const allRetros = db
     .select({
       id: conversations.id,
+      source: conversations.source,
       forkParentConversationId: conversations.forkParentConversationId,
       createdAt: conversations.createdAt,
     })
@@ -122,21 +140,21 @@ export function sweepOrphanMemoryRetrospectiveConversations(
       ),
     )
     .all();
-  const mostRecentPerSource = new Map<
-    string,
-    { id: string; createdAt: number }
-  >();
+  const retrosPerSource = new Map<string, RetroRow[]>();
   for (const row of allRetros) {
     const parent = row.forkParentConversationId;
     if (parent === null) continue;
-    const cur = mostRecentPerSource.get(parent);
-    if (!cur || row.createdAt > cur.createdAt) {
-      mostRecentPerSource.set(parent, { id: row.id, createdAt: row.createdAt });
+    const rows = retrosPerSource.get(parent);
+    if (rows) {
+      rows.push(row);
+    } else {
+      retrosPerSource.set(parent, [row]);
     }
   }
-  const preservedIds = new Set(
-    Array.from(mostRecentPerSource.values(), (v) => v.id),
-  );
+  const preservedIds = new Set<string>();
+  for (const rows of retrosPerSource.values()) {
+    preservedIds.add(selectPreservedBaseline(rows));
+  }
 
   const orphans = db
     .select({ id: conversations.id })
@@ -186,4 +204,67 @@ export function sweepOrphanMemoryRetrospectiveConversations(
     );
   }
   return { swept };
+}
+
+interface RetroRow {
+  id: string;
+  source: string | null;
+  createdAt: number;
+}
+
+/**
+ * Pick which retrospective row to preserve as the source's dedup baseline:
+ * the most recent row that actually produced output (a crash orphan with no
+ * post-fork assistant message would seed the next run with an EMPTY
+ * `<already_remembered>` block and cause re-saves). Falls back to the plain
+ * most-recent row when no candidate qualifies — preserves the previous
+ * behavior when every row is an orphan, and an orphan baseline at least
+ * keeps `findMostRecentRetrospectiveFor` stable until a successful run
+ * supersedes it.
+ *
+ * PR-E's persisted `remembered_log` reduces the impact of preserving a bad
+ * baseline (the next run can fall back to the persisted log), but the log
+ * fallback path still reads the preserved conversation, so the sweep should
+ * keep preferring a row that's actually useful.
+ *
+ * Only loads messages for the newest `MAX_BASELINE_CANDIDATES_PER_SOURCE`
+ * rows — never for every retro row.
+ */
+function selectPreservedBaseline(rows: RetroRow[]): string {
+  const sorted = [...rows].sort((a, b) => b.createdAt - a.createdAt);
+  const withOutput = sorted
+    .slice(0, MAX_BASELINE_CANDIDATES_PER_SOURCE)
+    .find(retrospectiveHasOutput);
+  return (withOutput ?? sorted[0]!).id;
+}
+
+/**
+ * Whether the retrospective row produced any assistant output of its own.
+ * Fork-kind rows carry the full copied source prefix (including the source's
+ * own assistant turns), so only assistant messages strictly after the fork
+ * boundary count; a fork with no detectable boundary contributes nothing to
+ * dedup (`collectPriorRetrospectiveRemembers` treats it as empty), so it
+ * doesn't qualify either. Legacy-kind rows start empty, so any assistant
+ * message counts. Best-effort: a message-load failure disqualifies the row
+ * rather than failing the sweep.
+ */
+function retrospectiveHasOutput(row: RetroRow): boolean {
+  let messages: ReturnType<typeof getMessages>;
+  try {
+    messages = getMessages(row.id);
+  } catch (err) {
+    log.warn(
+      { err, conversationId: row.id },
+      "Failed to load retrospective messages while selecting the preserved dedup baseline; treating row as having no output",
+    );
+    return false;
+  }
+  if (row.source === MEMORY_RETROSPECTIVE_FORK_SOURCE) {
+    const boundaryCreatedAt = findForkBoundaryCreatedAt(messages);
+    if (boundaryCreatedAt == null) return false;
+    return messages.some(
+      (m) => m.role === "assistant" && m.createdAt > boundaryCreatedAt,
+    );
+  }
+  return messages.some((m) => m.role === "assistant");
 }


### PR DESCRIPTION
## Summary
- The startup sweep preserved the most-recent retrospective per source even when it was a crash orphan with no remember output, leaving the next pass an empty dedup baseline
- Now prefers the most recent row with at least one assistant message after the fork boundary (legacy: any assistant message), falling back to the plain most-recent when none qualify

Part of plan: memory-retrospective-fork-hardening.md (PR H of 12)