### PR TITLE
fix(memory): skip fork retrospective while source is mid-turn

### DIFF
--- a/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
@@ -88,6 +88,20 @@ type StubMessage = {
 };
 let messagesByConversationId: Record<string, StubMessage[]> = {};
 
+// In-memory conversation registry stub: id → live processing flag. Ids absent
+// from the map are "unloaded" (findConversation returns undefined), matching
+// the real registry's semantics for conversations not in memory.
+let loadedConversations: Record<string, { processing: boolean }> = {};
+
+mock.module("../../daemon/conversation-registry.js", () => ({
+  findConversation: (id: string | undefined) => {
+    if (!id) return undefined;
+    const entry = loadedConversations[id];
+    if (!entry) return undefined;
+    return { isProcessing: () => entry.processing };
+  },
+}));
+
 mock.module("../memory-retrospective-state.js", () => ({
   getRetrospectiveState: (_id: string) => mockState,
   upsertRetrospectiveState: (args: {
@@ -340,6 +354,7 @@ describe("memoryRetrospectiveJob", () => {
     addMessageCalls = [];
     conversationOverrides = {};
     messagesByConversationId = {};
+    loadedConversations = {};
   });
 
   test("first-run happy path: no state row, no prior retrospective, both pointer fields set on success", async () => {
@@ -609,6 +624,61 @@ describe("memoryRetrospectiveJob", () => {
 
     expect(forkCalls).toHaveLength(1);
     expect(forkCalls[0]!.throughMessageId).toBe("m3");
+  });
+
+  // -------------------------------------------------------------------------
+  // Mid-turn skip gate (fork path only)
+  // -------------------------------------------------------------------------
+
+  test("fork path: source mid-turn → skipped outcome, pointer unchanged, lastRunAt bumped, no fork", async () => {
+    forkFlagEnabled = true;
+    loadedConversations["src-conv-1"] = { processing: true };
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("source_processing");
+    // `lastProcessedMessageId` untouched — only the cooldown timestamp moves.
+    expect(stateUpserts).toHaveLength(0);
+    expect(lastRunAtBumps).toHaveLength(1);
+    expect(lastRunAtBumps[0]!.conversationId).toBe("src-conv-1");
+    // No fork, no instruction, no wake, no cleanup side effects.
+    expect(forkCalls).toHaveLength(0);
+    expect(addMessageCalls).toHaveLength(0);
+    expect(wakeCalls).toHaveLength(0);
+    expect(deletedConversationIds).toEqual([]);
+  });
+
+  test("fork path: source loaded but idle → normal run", async () => {
+    forkFlagEnabled = true;
+    loadedConversations["src-conv-1"] = { processing: false };
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("invoked");
+    expect(forkCalls).toHaveLength(1);
+    expect(lastRunAtBumps).toHaveLength(0);
+    expect(stateUpserts).toHaveLength(1);
+  });
+
+  test("fork path: source unloaded (not in registry) → normal run", async () => {
+    forkFlagEnabled = true;
+    // `loadedConversations` is empty — findConversation returns undefined,
+    // and an unloaded conversation is by definition not processing.
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("invoked");
+    expect(forkCalls).toHaveLength(1);
+    expect(lastRunAtBumps).toHaveLength(0);
+  });
+
+  test("legacy path: source mid-turn still runs (gate is fork-path only)", async () => {
+    loadedConversations["src-conv-1"] = { processing: true };
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("invoked");
+    expect(wakeCalls).toHaveLength(1);
+    expect(lastRunAtBumps).toHaveLength(0);
   });
 
   test("fork path: prior fork-kind retrospective with nested-fork ancestry still surfaces its post-fork remembers in <already_remembered>", async () => {

--- a/assistant/src/memory/memory-retrospective-job.ts
+++ b/assistant/src/memory/memory-retrospective-job.ts
@@ -38,6 +38,7 @@
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import type { AssistantConfig } from "../config/types.js";
 import { extractTurnContextTimestamp } from "../context/compactor.js";
+import { findConversation } from "../daemon/conversation-registry.js";
 import {
   formatLocalTimestamp,
   resolveTurnTimezoneContext,
@@ -103,6 +104,7 @@ const FOLLOW_UP_JOB_TYPES: readonly MemoryJobType[] = [] as const;
 export type MemoryRetrospectiveOutcome =
   | { kind: "disabled" }
   | { kind: "no_new_messages" }
+  | { kind: "source_processing" }
   | { kind: "wake_failed"; reason?: string; conversationId?: string }
   | {
       kind: "invoked";
@@ -327,6 +329,24 @@ async function runForkBasedRetrospective(
       "memory-retrospective (fork): source conversation not found; skipping",
     );
     return { kind: "no_new_messages" };
+  }
+
+  // Forking mid-turn would capture a half-finished display turn — incremental
+  // checkpoint persistence writes complete tool turns to the DB while the
+  // agent loop is still running. Peek the in-memory registry only (an
+  // unloaded conversation is by definition not processing); never load the
+  // conversation just to check. Bump `lastRunAt` so the cooldown gate
+  // applies, leave `lastProcessedMessageId` untouched so the next
+  // interval/message-count trigger re-processes the same messages — nothing
+  // is lost. Returning (not throwing) keeps the jobs-worker from
+  // retry-with-backoff.
+  if (findConversation(sourceConversationId)?.isProcessing()) {
+    bumpRetrospectiveLastRunAt(sourceConversationId, Date.now());
+    log.info(
+      { sourceConversationId },
+      "memory-retrospective (fork): source conversation is mid-turn; skipping",
+    );
+    return { kind: "source_processing" };
   }
 
   const state = getRetrospectiveState(sourceConversationId);


### PR DESCRIPTION
## Summary
- Fork-based retrospectives no longer fork a conversation that is actively processing a turn (a mid-turn fork captures a half-finished display turn)
- Skipped runs bump lastRunAt only; the next trigger re-fires after cooldown and no messages are lost

Part of plan: memory-retrospective-fork-hardening.md (PR G of 12)