### PR TITLE
feat(migrations): upgrade existing quality profiles to Claude Fable 5

### DIFF
--- a/assistant/src/__tests__/workspace-migration-100-upgrade-quality-profile-to-fable-5.test.ts
+++ b/assistant/src/__tests__/workspace-migration-100-upgrade-quality-profile-to-fable-5.test.ts
@@ -1,0 +1,178 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { upgradeQualityProfileToFable5Migration } from "../workspace/migrations/100-upgrade-quality-profile-to-fable-5.js";
+
+let workspaceDir: string;
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+function readProfiles(): Record<string, Record<string, unknown>> {
+  const llm = readConfig().llm as Record<string, unknown>;
+  return llm.profiles as Record<string, Record<string, unknown>>;
+}
+
+beforeEach(() => {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-100-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("100-upgrade-quality-profile-to-fable-5 migration", () => {
+  test("no-op when config.json does not exist", () => {
+    upgradeQualityProfileToFable5Migration.run(workspaceDir);
+    expect(existsSync(join(workspaceDir, "config.json"))).toBe(false);
+  });
+
+  test("no-op when config has no llm.profiles", () => {
+    const original = { llm: { default: { provider: "anthropic" } } };
+    writeConfig(original);
+    upgradeQualityProfileToFable5Migration.run(workspaceDir);
+    expect(readConfig()).toEqual(original);
+  });
+
+  test("gracefully handles invalid JSON", () => {
+    writeFileSync(join(workspaceDir, "config.json"), "not-valid-json");
+    upgradeQualityProfileToFable5Migration.run(workspaceDir);
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+      "not-valid-json",
+    );
+  });
+
+  test("upgrades quality-optimized from claude-opus-4-7", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          "quality-optimized": {
+            provider: "anthropic",
+            model: "claude-opus-4-7",
+            label: "Quality",
+          },
+        },
+      },
+    });
+    upgradeQualityProfileToFable5Migration.run(workspaceDir);
+    const profile = readProfiles()["quality-optimized"]!;
+    expect(profile.model).toBe("claude-fable-5");
+    expect(profile.label).toBe("Quality");
+  });
+
+  test("upgrades both managed and custom profiles from claude-opus-4-8", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          "quality-optimized": {
+            provider: "anthropic",
+            model: "claude-opus-4-8",
+          },
+          "custom-quality-optimized": {
+            provider: "anthropic",
+            model: "claude-opus-4-8",
+          },
+        },
+      },
+    });
+    upgradeQualityProfileToFable5Migration.run(workspaceDir);
+    const profiles = readProfiles();
+    expect(profiles["quality-optimized"]!.model).toBe("claude-fable-5");
+    expect(profiles["custom-quality-optimized"]!.model).toBe("claude-fable-5");
+  });
+
+  test("upgrades OpenRouter-prefixed model ids", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          "quality-optimized": {
+            provider: "openrouter",
+            model: "anthropic/claude-opus-4.8",
+          },
+        },
+      },
+    });
+    upgradeQualityProfileToFable5Migration.run(workspaceDir);
+    expect(readProfiles()["quality-optimized"]!.model).toBe(
+      "anthropic/claude-fable-5",
+    );
+  });
+
+  test("leaves user-customized models untouched", () => {
+    const original = {
+      llm: {
+        profiles: {
+          "quality-optimized": { provider: "openai", model: "gpt-5.4" },
+          "custom-quality-optimized": {
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+          },
+        },
+      },
+    };
+    writeConfig(original);
+    upgradeQualityProfileToFable5Migration.run(workspaceDir);
+    expect(readConfig()).toEqual(original);
+  });
+
+  test("leaves non-quality profiles untouched", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: { provider: "anthropic", model: "claude-opus-4-8" },
+          "quality-optimized": {
+            provider: "anthropic",
+            model: "claude-opus-4-8",
+          },
+        },
+      },
+    });
+    upgradeQualityProfileToFable5Migration.run(workspaceDir);
+    const profiles = readProfiles();
+    expect(profiles["balanced"]!.model).toBe("claude-opus-4-8");
+    expect(profiles["quality-optimized"]!.model).toBe("claude-fable-5");
+  });
+
+  test("idempotency: no-op on already-upgraded config (no writes)", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          "quality-optimized": {
+            provider: "anthropic",
+            model: "claude-fable-5",
+          },
+        },
+      },
+    });
+    const beforeContent = readFileSync(
+      join(workspaceDir, "config.json"),
+      "utf-8",
+    );
+    upgradeQualityProfileToFable5Migration.run(workspaceDir);
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+      beforeContent,
+    );
+  });
+});

--- a/assistant/src/__tests__/workspace-migration-100-upgrade-quality-profile-to-fable-5.test.ts
+++ b/assistant/src/__tests__/workspace-migration-100-upgrade-quality-profile-to-fable-5.test.ts
@@ -82,7 +82,7 @@ describe("100-upgrade-quality-profile-to-fable-5 migration", () => {
     expect(profile.label).toBe("Quality");
   });
 
-  test("upgrades both managed and custom profiles from claude-opus-4-8", () => {
+  test("upgrades the managed profile but not the user-owned custom copy", () => {
     writeConfig({
       llm: {
         profiles: {
@@ -100,7 +100,7 @@ describe("100-upgrade-quality-profile-to-fable-5 migration", () => {
     upgradeQualityProfileToFable5Migration.run(workspaceDir);
     const profiles = readProfiles();
     expect(profiles["quality-optimized"]!.model).toBe("claude-fable-5");
-    expect(profiles["custom-quality-optimized"]!.model).toBe("claude-fable-5");
+    expect(profiles["custom-quality-optimized"]!.model).toBe("claude-opus-4-8");
   });
 
   test("upgrades OpenRouter-prefixed model ids", () => {
@@ -125,10 +125,6 @@ describe("100-upgrade-quality-profile-to-fable-5 migration", () => {
       llm: {
         profiles: {
           "quality-optimized": { provider: "openai", model: "gpt-5.4" },
-          "custom-quality-optimized": {
-            provider: "anthropic",
-            model: "claude-sonnet-4-6",
-          },
         },
       },
     };

--- a/assistant/src/workspace/migrations/100-upgrade-quality-profile-to-fable-5.ts
+++ b/assistant/src/workspace/migrations/100-upgrade-quality-profile-to-fable-5.ts
@@ -14,11 +14,13 @@ import type { WorkspaceMigration } from "./types.js";
 // quality intent pointed at when they hatched (claude-opus-4-7 or
 // claude-opus-4-8) until a migration rewrites it.
 //
-// Only profiles still on a previous quality-intent default are upgraded —
-// matching by model value also covers the OpenRouter-prefixed ids. A profile
-// whose model the user changed to anything else is left untouched.
+// Only the managed quality-optimized profile is touched — the user-owned
+// custom-quality-optimized copy is theirs to manage. Within it, only a model
+// still on a previous quality-intent default is upgraded — matching by model
+// value also covers the OpenRouter-prefixed ids. A profile whose model the
+// user changed to anything else is left untouched.
 
-const TARGET_PROFILES = ["quality-optimized", "custom-quality-optimized"];
+const TARGET_PROFILES = ["quality-optimized"];
 
 const MODEL_UPGRADES: Record<string, string> = {
   "claude-opus-4-7": "claude-fable-5",
@@ -30,7 +32,7 @@ const MODEL_UPGRADES: Record<string, string> = {
 export const upgradeQualityProfileToFable5Migration: WorkspaceMigration = {
   id: "100-upgrade-quality-profile-to-fable-5",
   description:
-    "Upgrade quality-optimized profiles from Opus 4.7/4.8 to Claude Fable 5",
+    "Upgrade the managed quality-optimized profile from Opus 4.7/4.8 to Claude Fable 5",
   run(workspaceDir: string): void {
     const configPath = join(workspaceDir, "config.json");
     if (!existsSync(configPath)) return;

--- a/assistant/src/workspace/migrations/100-upgrade-quality-profile-to-fable-5.ts
+++ b/assistant/src/workspace/migrations/100-upgrade-quality-profile-to-fable-5.ts
@@ -1,0 +1,84 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+// Upgrade quality-optimized profiles to Claude Fable 5.
+//
+// The quality-optimized model intent moved to claude-fable-5 (#34498), but
+// the intent map is only consulted when a profile is seeded: off-platform
+// installs reseed managed profiles on every boot, while on-platform
+// workspaces keep the profile they were hatched with — the seeder skips
+// existing profiles there, and the hatch overlay is consumed exactly once.
+// Existing platform assistants are therefore stuck on whichever model the
+// quality intent pointed at when they hatched (claude-opus-4-7 or
+// claude-opus-4-8) until a migration rewrites it.
+//
+// Only profiles still on a previous quality-intent default are upgraded —
+// matching by model value also covers the OpenRouter-prefixed ids. A profile
+// whose model the user changed to anything else is left untouched.
+
+const TARGET_PROFILES = ["quality-optimized", "custom-quality-optimized"];
+
+const MODEL_UPGRADES: Record<string, string> = {
+  "claude-opus-4-7": "claude-fable-5",
+  "claude-opus-4-8": "claude-fable-5",
+  "anthropic/claude-opus-4.7": "anthropic/claude-fable-5",
+  "anthropic/claude-opus-4.8": "anthropic/claude-fable-5",
+};
+
+export const upgradeQualityProfileToFable5Migration: WorkspaceMigration = {
+  id: "100-upgrade-quality-profile-to-fable-5",
+  description:
+    "Upgrade quality-optimized profiles from Opus 4.7/4.8 to Claude Fable 5",
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const llm = readObject(config.llm);
+    if (llm === null) return;
+
+    const profiles = readObject(llm.profiles);
+    if (profiles === null) return;
+
+    let changed = false;
+
+    for (const name of TARGET_PROFILES) {
+      const profile = readObject(profiles[name]);
+      if (profile === null) continue;
+      if (typeof profile.model !== "string") continue;
+
+      const upgraded = MODEL_UPGRADES[profile.model];
+      if (upgraded === undefined) continue;
+
+      profile.model = upgraded;
+      profiles[name] = profile;
+      changed = true;
+    }
+
+    if (changed) {
+      llm.profiles = profiles;
+      config.llm = llm;
+      writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+    }
+  },
+  down(_workspaceDir: string): void {
+    // Forward-only.
+  },
+};
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -97,6 +97,7 @@ import { reduceQualityProfileEffortMigration } from "./096-reduce-quality-profil
 import { enableAdaptiveThinkingManagedProfilesMigration } from "./097-enable-adaptive-thinking-managed-profiles.js";
 import { removeStaleUpdatesBulletinFileMigration } from "./098-remove-stale-updates-bulletin-file.js";
 import { disableCacheOneShotCallsitesMigration } from "./099-disable-cache-one-shot-callsites.js";
+import { upgradeQualityProfileToFable5Migration } from "./100-upgrade-quality-profile-to-fable-5.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -205,4 +206,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   enableAdaptiveThinkingManagedProfilesMigration,
   removeStaleUpdatesBulletinFileMigration,
   disableCacheOneShotCallsitesMigration,
+  upgradeQualityProfileToFable5Migration,
 ];


### PR DESCRIPTION
## Summary
- Add workspace migration `100-upgrade-quality-profile-to-fable-5`: rewrites the managed `quality-optimized` profile from `claude-opus-4-7`/`claude-opus-4-8` (and the OpenRouter-prefixed equivalents) to `claude-fable-5`, preserving any user-customized model values
- The user-owned `custom-quality-optimized` profile is intentionally NOT touched — it is materialized once at hatch and owned by the user thereafter
- Wire the migration into `WORKSPACE_MIGRATIONS` and add a self-contained test suite (9 tests) covering upgrades, no-op/graceful paths, custom-profile exclusion, and idempotency

## Original prompt
Yesterday's #34498 swapped the quality-optimized model intent to Claude Fable 5, but the intent map is only applied when a profile is seeded: off-platform installs reseed managed profiles every boot, while on-platform workspaces skip existing profiles and consume the hatch overlay exactly once — so existing platform assistants remain stuck on Opus 4.7/4.8 (observed live in the UI). The user asked for the change necessary so existing assistants pick up the Fable 5 quality profile too — scoped to Vellum-managed profiles only — following the precedent of migration 096 which patched quality profiles on existing workspaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
