### PR TITLE
feat(runtime): execution-layer tool gating for cache-parity wakes

### DIFF
--- a/assistant/src/__tests__/subagent-tool-filtering.test.ts
+++ b/assistant/src/__tests__/subagent-tool-filtering.test.ts
@@ -87,6 +87,56 @@ describe("subagent-only tool filtering", () => {
     expect(isToolActiveForContext(TEST_TOOL_NAME, ctx)).toBe(false);
   });
 
+  test("execution gate mode keeps non-allowlisted tools visible (allowlist enforced at execution time)", () => {
+    // `subagentToolGateMode: "execution"` keeps the full tool surface on the
+    // wire for provider prompt-cache parity; the executor callback rejects
+    // non-allowlisted calls instead.
+    const ctx: SkillProjectionContext = {
+      skillProjectionState: new Map(),
+      skillProjectionCache: {},
+      coreToolNames: new Set(),
+      toolsDisabledDepth: 0,
+      hasNoClient: false,
+      subagentAllowedTools: new Set(["remember"]),
+      subagentToolGateMode: "execution",
+    };
+
+    expect(isToolActiveForContext("remember", ctx)).toBe(true);
+    expect(isToolActiveForContext("bash", ctx)).toBe(true);
+  });
+
+  test("explicit wire gate mode filters exactly like the absent default", () => {
+    const ctx: SkillProjectionContext = {
+      skillProjectionState: new Map(),
+      skillProjectionCache: {},
+      coreToolNames: new Set(),
+      toolsDisabledDepth: 0,
+      hasNoClient: false,
+      subagentAllowedTools: new Set(["remember"]),
+      subagentToolGateMode: "wire",
+    };
+
+    expect(isToolActiveForContext("remember", ctx)).toBe(true);
+    expect(isToolActiveForContext("bash", ctx)).toBe(false);
+  });
+
+  test("execution gate mode still applies non-allowlist filters (toolsDisabledDepth)", () => {
+    // The execution gate only bypasses the subagent allowlist's wire filter;
+    // every other visibility rule still applies.
+    const ctx: SkillProjectionContext = {
+      skillProjectionState: new Map(),
+      skillProjectionCache: {},
+      coreToolNames: new Set(),
+      toolsDisabledDepth: 1,
+      hasNoClient: false,
+      subagentAllowedTools: new Set(["remember"]),
+      subagentToolGateMode: "execution",
+    };
+
+    expect(isToolActiveForContext("remember", ctx)).toBe(false);
+    expect(isToolActiveForContext("bash", ctx)).toBe(false);
+  });
+
   test("returns false for every tool when toolsDisabledDepth > 0", () => {
     // `createResolveToolsCallback` returns an empty tool list when tools are
     // disabled; mirror it here so this helper reports the same final tool set.

--- a/assistant/src/__tests__/subagent-tool-gate-mode.test.ts
+++ b/assistant/src/__tests__/subagent-tool-gate-mode.test.ts
@@ -1,0 +1,370 @@
+/**
+ * Tests for `subagentToolGateMode` — the execution-layer tool gating mode
+ * used by cache-parity wakes (fork-based memory retrospectives).
+ *
+ * Covers:
+ * - Resolver (`createResolveToolsCallback`): in `"execution"` mode the
+ *   resolved tool definitions are NOT filtered by the subagent allowlist
+ *   (the wire request keeps the conversation's full tool surface so the
+ *   provider prompt-cache prefix stays byte-identical); in `"wire"` mode /
+ *   absent, the definitions are filtered exactly as before (regression).
+ * - Executor (`createToolExecutor`): in `"execution"` mode a call to a
+ *   non-allowlisted tool returns an error tool_result WITHOUT invoking the
+ *   tool's executor (safety invariant), while allowlisted calls execute
+ *   normally. The gate also covers the `skill_execute` indirection by
+ *   gating the resolved inner tool name.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import type { SkillProjectionCache } from "../daemon/conversation-skill-tools.js";
+import type { SurfaceData, SurfaceType } from "../daemon/message-protocol.js";
+import type { PermissionPrompter } from "../permissions/prompter.js";
+import type { SecretPrompter } from "../permissions/secret-prompter.js";
+import type { Message, ToolDefinition } from "../providers/types.js";
+import type { ToolExecutor } from "../tools/executor.js";
+import type { ToolContext, ToolExecutionResult } from "../tools/types.js";
+
+// ---------------------------------------------------------------------------
+// Module mocks (must precede the import of the module under test)
+// ---------------------------------------------------------------------------
+
+const baseConfig = {
+  tools: { exclude: [] as string[] },
+  timeouts: {
+    shellDefaultTimeoutSec: 120,
+    shellMaxTimeoutSec: 600,
+    permissionTimeoutSec: 300,
+    toolExecutionTimeoutSec: 600,
+  },
+  services: {},
+  llm: {},
+};
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => baseConfig,
+  loadConfig: () => baseConfig,
+  invalidateConfigCache: () => {},
+  loadRawConfig: () => ({}),
+  saveRawConfig: () => {},
+  getNestedValue: () => undefined,
+  setNestedValue: () => {},
+}));
+
+mock.module("../runtime/assistant-event-hub.js", () => ({
+  broadcastMessage: mock(() => {}),
+  assistantEventHub: { listClientsByCapability: () => [] },
+}));
+
+mock.module("../daemon/conversation-surfaces.js", () => ({
+  refreshSurfacesForApp: mock(() => {}),
+  surfaceProxyResolver: mock(() =>
+    Promise.resolve({ content: "", isError: false }),
+  ),
+}));
+
+mock.module("../services/published-app-updater.js", () => ({
+  updatePublishedAppDeployment: mock(() => Promise.resolve()),
+}));
+
+mock.module("../tools/browser/browser-screencast.js", () => ({
+  registerConversationSender: mock(() => {}),
+}));
+
+mock.module("../memory/app-store.js", () => ({
+  getApp: mock(() => null),
+  getAppDirPath: mock(() => "/tmp/test-apps/dummy"),
+  isMultifileApp: mock(() => false),
+  getAppsDir: mock(() => "/tmp/test-apps"),
+  resolveAppIdByDirName: mock(() => null),
+  resolveAppIdFromPath: mock(() => null),
+}));
+
+// Controls the skill tools the projection reports per resolver call.
+let projectedSkillToolNames: string[] = [];
+
+mock.module("../daemon/conversation-skill-tools.js", () => ({
+  projectSkillTools: mock(() => ({
+    allowedToolNames: new Set(projectedSkillToolNames),
+    toolDefinitions: [],
+  })),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks are in place
+// ---------------------------------------------------------------------------
+
+import {
+  createResolveToolsCallback,
+  createToolExecutor,
+  type SkillProjectionContext,
+  type ToolSetupContext,
+} from "../daemon/conversation-tool-setup.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const EMPTY_HISTORY: Message[] = [];
+
+function makeToolDef(name: string): ToolDefinition {
+  return { name, description: `${name} tool`, input_schema: {} };
+}
+
+function makeProjectionCtx(
+  overrides: Partial<SkillProjectionContext> = {},
+): SkillProjectionContext {
+  return {
+    skillProjectionState: new Map(),
+    skillProjectionCache: {} as SkillProjectionCache,
+    coreToolNames: new Set(["remember", "tool_b"]),
+    toolsDisabledDepth: 0,
+    ...overrides,
+  };
+}
+
+function makeSetupCtx(
+  overrides: Partial<ToolSetupContext> = {},
+): ToolSetupContext {
+  return {
+    conversationId: "conv-test",
+    currentRequestId: "req-1",
+    workingDir: "/tmp/test",
+    abortController: null,
+    traceEmitter: { emit: () => {} },
+    sendToClient: mock(() => {}),
+    pendingSurfaceActions: new Map(),
+    lastSurfaceAction: new Map(),
+    surfaceState: new Map<
+      string,
+      { surfaceType: SurfaceType; data: SurfaceData; title?: string }
+    >(),
+    surfaceUndoStacks: new Map(),
+    accumulatedSurfaceState: new Map(),
+    surfaceActionRequestIds: new Set<string>(),
+    currentTurnSurfaces: [],
+    isProcessing: () => false,
+    enqueueMessage: () => ({ queued: false, requestId: "r" }),
+    getQueueDepth: () => 0,
+    processMessage: async () => "",
+    withSurface: async <T>(_id: string, fn: () => T | Promise<T>) => fn(),
+    ...overrides,
+  };
+}
+
+/** Fake ToolExecutor that records every execute() invocation. */
+function makeCapturingExecutor() {
+  const calls: Array<{ name: string; input: Record<string, unknown> }> = [];
+  const executor = {
+    execute: async (
+      name: string,
+      input: Record<string, unknown>,
+      _context: ToolContext,
+    ): Promise<ToolExecutionResult> => {
+      calls.push({ name, input });
+      return { content: "ok", isError: false };
+    },
+  };
+  return { executor: executor as unknown as ToolExecutor, calls };
+}
+
+const noopPrompter = {
+  prompt: mock(async () => ({ decision: "allow" as const })),
+} as unknown as PermissionPrompter;
+const noopSecretPrompter = {
+  prompt: mock(async () => ({ cancelled: true })),
+} as unknown as SecretPrompter;
+
+function makeToolFn(executor: ToolExecutor, ctx: ToolSetupContext) {
+  return createToolExecutor(
+    executor,
+    noopPrompter,
+    noopSecretPrompter,
+    ctx,
+    () => {},
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Resolver — wire vs execution gate mode
+// ---------------------------------------------------------------------------
+
+describe("createResolveToolsCallback — subagentToolGateMode", () => {
+  test("wire mode (default) filters resolved defs to the subagent allowlist (regression)", () => {
+    projectedSkillToolNames = ["skill_tool_x"];
+    const toolDefs = [makeToolDef("remember"), makeToolDef("tool_b")];
+    const ctx = makeProjectionCtx({
+      subagentAllowedTools: new Set(["remember"]),
+    });
+    const resolve = createResolveToolsCallback(toolDefs, ctx)!;
+
+    const tools = resolve(EMPTY_HISTORY);
+
+    expect(tools.map((t) => t.name)).toEqual(["remember"]);
+    expect(ctx.allowedToolNames).toEqual(new Set(["remember"]));
+  });
+
+  test("execution mode keeps the full tool surface on the wire", () => {
+    projectedSkillToolNames = ["skill_tool_x"];
+    const toolDefs = [makeToolDef("remember"), makeToolDef("tool_b")];
+    const ctx = makeProjectionCtx({
+      subagentAllowedTools: new Set(["remember"]),
+      subagentToolGateMode: "execution",
+    });
+    const resolve = createResolveToolsCallback(toolDefs, ctx)!;
+
+    const tools = resolve(EMPTY_HISTORY);
+
+    // Defs are NOT filtered by the allowlist — byte-identical to a turn
+    // without any subagent allowlist.
+    expect(tools.map((t) => t.name).sort()).toEqual(["remember", "tool_b"]);
+    // Skill-projection availability is also not narrowed: the execution-layer
+    // gate in the executor callback owns enforcement.
+    expect(ctx.allowedToolNames).toEqual(
+      new Set(["remember", "tool_b", "skill_tool_x"]),
+    );
+  });
+
+  test("execution mode resolves the same defs as having no allowlist at all", () => {
+    projectedSkillToolNames = [];
+    const toolDefs = [makeToolDef("remember"), makeToolDef("tool_b")];
+
+    const unscoped = createResolveToolsCallback(toolDefs, makeProjectionCtx())!(
+      EMPTY_HISTORY,
+    );
+    const executionScoped = createResolveToolsCallback(
+      toolDefs,
+      makeProjectionCtx({
+        subagentAllowedTools: new Set(["remember"]),
+        subagentToolGateMode: "execution",
+      }),
+    )!(EMPTY_HISTORY);
+
+    expect(executionScoped).toEqual(unscoped);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Executor — execution-layer allowlist gate
+// ---------------------------------------------------------------------------
+
+describe("createToolExecutor — execution-layer allowlist gate", () => {
+  test("execution mode: non-allowlisted call returns an error tool_result and never invokes the executor", async () => {
+    const { executor, calls } = makeCapturingExecutor();
+    const toolFn = makeToolFn(
+      executor,
+      makeSetupCtx({
+        subagentAllowedTools: new Set(["remember"]),
+        subagentToolGateMode: "execution",
+      }),
+    );
+
+    const result = await toolFn("bash", { command: "echo hi" });
+
+    expect(result).toEqual({
+      content: "This background pass may only use: remember.",
+      isError: true,
+    });
+    // Safety invariant: the non-allowlisted tool's executor must never run.
+    expect(calls).toHaveLength(0);
+  });
+
+  test("execution mode: allowlisted call executes normally", async () => {
+    const { executor, calls } = makeCapturingExecutor();
+    const toolFn = makeToolFn(
+      executor,
+      makeSetupCtx({
+        subagentAllowedTools: new Set(["remember"]),
+        subagentToolGateMode: "execution",
+      }),
+    );
+
+    const result = await toolFn("remember", { content: "a fact" });
+
+    expect(result).toEqual({ content: "ok", isError: false });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.name).toBe("remember");
+  });
+
+  test("execution mode: skill_execute gates the resolved inner tool, executor never invoked", async () => {
+    const { executor, calls } = makeCapturingExecutor();
+    const toolFn = makeToolFn(
+      executor,
+      makeSetupCtx({
+        subagentAllowedTools: new Set(["remember"]),
+        subagentToolGateMode: "execution",
+      }),
+    );
+
+    const rejected = await toolFn("skill_execute", {
+      tool: "bash",
+      input: { command: "echo hi" },
+    });
+    expect(rejected).toEqual({
+      content: "This background pass may only use: remember.",
+      isError: true,
+    });
+    expect(calls).toHaveLength(0);
+
+    const allowed = await toolFn("skill_execute", {
+      tool: "remember",
+      input: { content: "a fact" },
+    });
+    expect(allowed).toEqual({ content: "ok", isError: false });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.name).toBe("remember");
+  });
+
+  test("execution mode: multi-entry allowlist renders sorted in the rejection message", async () => {
+    const { executor, calls } = makeCapturingExecutor();
+    const toolFn = makeToolFn(
+      executor,
+      makeSetupCtx({
+        subagentAllowedTools: new Set(["remember", "file_read"]),
+        subagentToolGateMode: "execution",
+      }),
+    );
+
+    const result = await toolFn("bash", {});
+
+    expect(result).toEqual({
+      content: "This background pass may only use: file_read, remember.",
+      isError: true,
+    });
+    expect(calls).toHaveLength(0);
+  });
+
+  test("wire mode (and absent mode) leaves the executor path unchanged (regression)", async () => {
+    // In wire mode the allowlist is enforced by filtering the wire defs (and
+    // by the executor pipeline's own allowedToolNames gate) — the new
+    // execution-layer rejection must stay inert.
+    for (const subagentToolGateMode of ["wire", undefined] as const) {
+      const { executor, calls } = makeCapturingExecutor();
+      const toolFn = makeToolFn(
+        executor,
+        makeSetupCtx({
+          subagentAllowedTools: new Set(["remember"]),
+          subagentToolGateMode,
+        }),
+      );
+
+      const result = await toolFn("bash", { command: "echo hi" });
+
+      expect(result).toEqual({ content: "ok", isError: false });
+      expect(calls).toHaveLength(1);
+    }
+  });
+
+  test("execution mode without an allowlist gates nothing", async () => {
+    const { executor, calls } = makeCapturingExecutor();
+    const toolFn = makeToolFn(
+      executor,
+      makeSetupCtx({ subagentToolGateMode: "execution" }),
+    );
+
+    const result = await toolFn("bash", { command: "echo hi" });
+
+    expect(result).toEqual({ content: "ok", isError: false });
+    expect(calls).toHaveLength(1);
+  });
+});

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -61,8 +61,14 @@ import {
   buildSwitchInferenceProfileToolDef,
   SWITCH_INFERENCE_PROFILE_TOOL_NAME,
 } from "./switch-inference-profile-tool.js";
-import type { ToolSetupContext } from "./tool-setup-types.js";
-export type { ToolSetupContext } from "./tool-setup-types.js";
+import type {
+  SubagentToolGateMode,
+  ToolSetupContext,
+} from "./tool-setup-types.js";
+export type {
+  SubagentToolGateMode,
+  ToolSetupContext,
+} from "./tool-setup-types.js";
 
 // ── resolveConversationAttribution ───────────────────────────────────
 
@@ -127,6 +133,25 @@ export function createToolExecutor(
   registerConversationSender(ctx.conversationId, (msg) =>
     ctx.sendToClient(msg),
   );
+
+  // Execution-layer allowlist gate (`subagentToolGateMode === "execution"`):
+  // the wire request carries the conversation's full tool surface (so the
+  // provider prompt-cache prefix stays byte-identical to normal turns), and
+  // the allowlist is enforced here instead — BEFORE any executor dispatch,
+  // so a non-allowlisted tool's executor never runs. The error tool_result
+  // lets the model continue with an allowlisted tool or finish.
+  const rejectNonAllowlistedTool = (
+    toolName: string,
+  ): ToolExecutionResult | null => {
+    if (ctx.subagentToolGateMode !== "execution") return null;
+    const allowlist = ctx.subagentAllowedTools;
+    if (!allowlist || allowlist.has(toolName)) return null;
+    const allowed = [...allowlist].sort().join(", ");
+    return {
+      content: `This background pass may only use: ${allowed}.`,
+      isError: true,
+    };
+  };
 
   return async (
     name: string,
@@ -280,6 +305,12 @@ export function createToolExecutor(
         };
       }
 
+      // Gate the resolved inner tool, not the skill_execute wrapper — the
+      // wrapper is dispatch indirection, mirroring how wire mode gates the
+      // underlying tool via the executor's allowedToolNames check.
+      const innerRejection = rejectNonAllowlistedTool(toolName);
+      if (innerRejection) return innerRejection;
+
       const result = await executor.execute(toolName, toolInput, toolContext);
       if (toolContext.approvedViaPrompt) {
         ctx.approvedViaPromptThisTurn = true;
@@ -289,6 +320,9 @@ export function createToolExecutor(
 
       return result;
     }
+
+    const rejection = rejectNonAllowlistedTool(executionName);
+    if (rejection) return rejection;
 
     const result = await executor.execute(
       executionName,
@@ -361,6 +395,14 @@ export interface SkillProjectionContext {
   readonly hasNoClient?: boolean;
   /** When set, only tools in this set are included in the resolved tool list (subagent delegation). */
   subagentAllowedTools?: Set<string>;
+  /**
+   * How {@link subagentAllowedTools} is enforced. Absent or `"wire"` filters
+   * the resolved tool definitions (historical behavior); `"execution"` keeps
+   * the full tool surface on the wire — preserving provider prompt-cache
+   * parity — and relies on the executor callback's execution-layer gate to
+   * reject non-allowlisted calls.
+   */
+  subagentToolGateMode?: SubagentToolGateMode;
   /** True when the current turn is restricted to disk-pressure cleanup-safe tools. */
   diskPressureCleanupModeActive?: boolean;
   /** True when this conversation belongs to a subagent spawned by SubagentManager. */
@@ -482,7 +524,13 @@ export function isToolActiveForContext(
   // When the conversation is acting as a subagent, the parent orchestrator
   // restricts the tool list. A tool that isn't on the allowlist is not
   // available for this turn, so short-circuit before any capability checks.
-  if (ctx.subagentAllowedTools && !ctx.subagentAllowedTools.has(name)) {
+  // In execution gate mode the allowlist is enforced at execution time
+  // instead — the full tool surface stays visible on the wire.
+  if (
+    ctx.subagentAllowedTools &&
+    ctx.subagentToolGateMode !== "execution" &&
+    !ctx.subagentAllowedTools.has(name)
+  ) {
     return false;
   }
   // `createResolveToolsCallback` returns an empty tool list when tools are
@@ -628,9 +676,18 @@ export function createResolveToolsCallback(
     );
 
     // When the conversation is acting as a subagent, restrict core tools to
-    // only those explicitly allowed by the parent orchestrator.
-    const scopedCoreDefs = ctx.subagentAllowedTools
-      ? filteredCoreDefs.filter((d) => ctx.subagentAllowedTools!.has(d.name))
+    // only those explicitly allowed by the parent orchestrator. In
+    // `"execution"` gate mode the allowlist is NOT applied to the wire
+    // definitions — the provider request keeps the conversation's full tool
+    // surface (tool definitions lead the provider prompt-cache prefix, so
+    // filtering them would invalidate the cached prefix) and the executor
+    // callback rejects non-allowlisted calls at execution time instead.
+    const wireAllowlist =
+      ctx.subagentToolGateMode === "execution"
+        ? undefined
+        : ctx.subagentAllowedTools;
+    const scopedCoreDefs = wireAllowlist
+      ? filteredCoreDefs.filter((d) => wireAllowlist.has(d.name))
       : filteredCoreDefs;
 
     // Re-read MCP tool definitions from the registry each turn so conversations
@@ -644,8 +701,8 @@ export function createResolveToolsCallback(
       },
       "MCP tools resolved for turn",
     );
-    const scopedMcpDefs = ctx.subagentAllowedTools
-      ? currentMcpDefs.filter((d) => ctx.subagentAllowedTools!.has(d.name))
+    const scopedMcpDefs = wireAllowlist
+      ? currentMcpDefs.filter((d) => wireAllowlist.has(d.name))
       : currentMcpDefs;
     const excluded = new Set(getConfig().tools.exclude);
     const allBaseDefs = [...scopedCoreDefs, ...scopedMcpDefs].filter(
@@ -676,8 +733,10 @@ export function createResolveToolsCallback(
     });
     const turnAllowed = new Set(allBaseDefs.map((d) => d.name));
     for (const name of projection.allowedToolNames) {
-      // When a subagent allowlist is active, exclude skill tools not on it.
-      if (ctx.subagentAllowedTools && !ctx.subagentAllowedTools.has(name)) {
+      // When a wire-gated subagent allowlist is active, exclude skill tools
+      // not on it. (Execution gate mode keeps them available here and
+      // rejects non-allowlisted calls in the executor callback instead.)
+      if (wireAllowlist && !wireAllowlist.has(name)) {
         continue;
       }
       if (excluded.has(name)) continue;

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -146,7 +146,10 @@ import {
   handleSurfaceUndo as handleSurfaceUndoImpl,
   type SurfaceActionResult,
 } from "./conversation-surfaces.js";
-import type { ToolSetupContext } from "./conversation-tool-setup.js";
+import type {
+  SubagentToolGateMode,
+  ToolSetupContext,
+} from "./conversation-tool-setup.js";
 import {
   createResolveToolsCallback,
   createToolExecutor,
@@ -220,6 +223,15 @@ export class Conversation {
   /** @internal */ toolsDisabledDepth = 0;
   /** @internal */ preactivatedSkillIds?: string[];
   /** @internal */ subagentAllowedTools?: Set<string>;
+  /**
+   * How {@link subagentAllowedTools} is enforced — absent/`"wire"` filters
+   * the provider tool definitions (historical behavior); `"execution"`
+   * keeps the full tool surface on the wire for prompt-cache parity and
+   * rejects non-allowlisted calls at execution time. Set and restored
+   * alongside the allowlist by `scopeWakeAllowedTools`.
+   * @internal
+   */
+  subagentToolGateMode?: SubagentToolGateMode;
   /** @internal */ coreToolNames: Set<string>;
   /** @internal */ readonly skillProjectionState = new Map<string, string>();
   /** @internal */ readonly skillProjectionCache: SkillProjectionCache = {};

--- a/assistant/src/daemon/tool-setup-types.ts
+++ b/assistant/src/daemon/tool-setup-types.ts
@@ -9,6 +9,22 @@ import type { SurfaceConversationContext } from "./conversation-surfaces.js";
 import type { TrustContext } from "./trust-context.js";
 
 /**
+ * How a subagent/wake tool allowlist is enforced.
+ *
+ * - `"wire"` (default): filter the tool definitions sent to the provider so
+ *   the model never sees non-allowlisted tools. Smaller request, but the
+ *   tool array no longer byte-matches the conversation's normal turns, so
+ *   the provider prompt-cache prefix (`tools → system → messages`) cannot
+ *   be reused.
+ * - `"execution"`: keep the conversation's full tool surface on the wire
+ *   (preserving cache parity with the source conversation's turns) and
+ *   enforce the allowlist at execution time — a call to a non-allowlisted
+ *   tool returns an error tool_result without ever invoking the tool's
+ *   executor.
+ */
+export type SubagentToolGateMode = "wire" | "execution";
+
+/**
  * Subset of Conversation state that the tool executor callback reads at
  * call time (not construction time). These are captured by the
  * returned closure, so they must be live references.
@@ -21,6 +37,15 @@ export interface ToolSetupContext extends SurfaceConversationContext {
   abortController: AbortController | null;
   /** When set, only tools in this set may execute during the current turn. */
   allowedToolNames?: Set<string>;
+  /** When set, the subagent/wake tool allowlist (see {@link subagentToolGateMode}). */
+  subagentAllowedTools?: Set<string>;
+  /**
+   * How {@link subagentAllowedTools} is enforced. Absent or `"wire"` keeps
+   * the historical behavior (definitions filtered before the provider
+   * request); `"execution"` keeps the full tool surface on the wire and
+   * rejects non-allowlisted calls in the executor callback instead.
+   */
+  subagentToolGateMode?: SubagentToolGateMode;
   /** Turn-scoped disk-pressure cleanup mode flag. */
   diskPressureCleanupModeActive?: boolean;
   /** True when the conversation has no connected client (HTTP-only path). */

--- a/assistant/src/daemon/wake-conversation-ops.ts
+++ b/assistant/src/daemon/wake-conversation-ops.ts
@@ -25,6 +25,7 @@ import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { getLogger } from "../util/logger.js";
 import type { Conversation } from "./conversation.js";
 import type { ServerMessage } from "./message-protocol.js";
+import type { SubagentToolGateMode } from "./tool-setup-types.js";
 
 const log = getLogger("wake-conversation-ops");
 
@@ -256,14 +257,25 @@ export async function persistWakeTailMessage(
  * reusing the conversation's subagent allowlist slot. Returns a restore
  * callback that reinstates the previous allowlist so the wake can release
  * the scope before any queued user turn is drained.
+ *
+ * `gateMode` controls how the allowlist is enforced (see
+ * {@link SubagentToolGateMode}): `"wire"` (default) filters the tool
+ * definitions sent to the provider — the historical behavior — while
+ * `"execution"` keeps the conversation's full tool surface on the wire for
+ * provider prompt-cache parity and rejects non-allowlisted calls at
+ * execution time. The gate mode is restored alongside the allowlist.
  */
 export function scopeWakeAllowedTools(
   conversation: Conversation,
   tools: ReadonlySet<string>,
+  gateMode: SubagentToolGateMode = "wire",
 ): () => void {
   const previous = conversation.subagentAllowedTools;
+  const previousGateMode = conversation.subagentToolGateMode;
   conversation.setSubagentAllowedTools(new Set(tools));
+  conversation.subagentToolGateMode = gateMode;
   return () => {
     conversation.setSubagentAllowedTools(previous);
+    conversation.subagentToolGateMode = previousGateMode;
   };
 }

--- a/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
@@ -719,6 +719,10 @@ describe("memoryRetrospectiveJob", () => {
     expect(wakeCalls[0]!.opts.forceOverrideProfile).toBe("profile-x");
     // Attribution bucket is unchanged — only the resolved profile floats.
     expect(wakeCalls[0]!.opts.callSite).toBe("memoryRetrospective");
+    // Cache parity also requires the conversation's full tool surface on the
+    // wire (tool defs lead the provider cache prefix) — the allowlist is
+    // enforced at execution time instead.
+    expect(wakeCalls[0]!.opts.toolGateMode).toBe("execution");
   });
 
   test("fork path: matchConversationProfile off (default) → wake carries no forceOverrideProfile", async () => {
@@ -735,6 +739,9 @@ describe("memoryRetrospectiveJob", () => {
 
     expect(wakeCalls).toHaveLength(1);
     expect("forceOverrideProfile" in wakeCalls[0]!.opts).toBe(false);
+    // Wire mode (default) when not matching the profile — there is no cache
+    // to preserve, so the smaller filtered request wins.
+    expect("toolGateMode" in wakeCalls[0]!.opts).toBe(false);
   });
 
   test("fork path: matchConversationProfile on but source has no inferenceProfile → wake carries no forceOverrideProfile", async () => {
@@ -747,6 +754,10 @@ describe("memoryRetrospectiveJob", () => {
 
     expect(wakeCalls).toHaveLength(1);
     expect("forceOverrideProfile" in wakeCalls[0]!.opts).toBe(false);
+    // toolGateMode is gated on the config flag, not on a resolved profile:
+    // without a pinned profile the source's turns ran the call-site default,
+    // and keeping the full tool surface still preserves that cached prefix.
+    expect(wakeCalls[0]!.opts.toolGateMode).toBe("execution");
   });
 
   test("fork path: matchConversationProfile on but the profile session expired → wake carries no forceOverrideProfile", async () => {

--- a/assistant/src/memory/memory-retrospective-job.ts
+++ b/assistant/src/memory/memory-retrospective-job.ts
@@ -482,6 +482,16 @@ async function runForkBasedRetrospective(
       trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT,
       callSite: "memoryRetrospective",
       allowedTools: ["remember"],
+      // When matching the source's profile for cache parity, also keep the
+      // source's full tool surface on the wire: the provider cache prefix is
+      // `tools → system → messages`, so wire-filtering the tool array to
+      // ["remember"] would invalidate the cached prefix the profile match
+      // just preserved. The allowlist still holds — non-`remember` calls are
+      // rejected at execution time. Without profile matching there is no
+      // cache to preserve, and the smaller wire-filtered request is cheaper.
+      ...(config.memory.retrospective.matchConversationProfile
+        ? { toolGateMode: "execution" as const }
+        : {}),
       ...(matchedProfile !== undefined
         ? { forceOverrideProfile: matchedProfile }
         : {}),

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -676,6 +676,64 @@ describe("wakeAgentForOpportunity", () => {
     expect(processingFalseIndex).toBeLessThan(drainIndex);
   });
 
+  test("applies toolGateMode: 'execution' alongside the allowlist and restores it after the wake", async () => {
+    let gateModeDuringRun: string | undefined;
+    const conversation = makeWakeConversation({
+      runImpl: async (input) => {
+        gateModeDuringRun = conversation.subagentToolGateMode;
+        return runResult([
+          ...input,
+          { role: "assistant", content: [{ type: "text", text: "Saved." }] },
+        ]);
+      },
+    });
+
+    const result = await wakeAgentForOpportunity(
+      {
+        conversationId: conversation.conversationId,
+        hint: "review for memories",
+        source: "memory-retrospective",
+        allowedTools: ["remember"],
+        toolGateMode: "execution",
+      },
+      { resolveTarget: async () => conversation },
+    );
+
+    expect(result).toEqual({ invoked: true, producedToolCalls: false });
+    // The gate mode is live on the conversation for the duration of the run
+    // (the tool resolver and executor closures read it there)...
+    expect(gateModeDuringRun).toBe("execution");
+    expect(conversation.runCalls[0]!.allowedTools).toEqual(["remember"]);
+    // ...and restored alongside the allowlist after the wake.
+    expect(conversation.subagentToolGateMode).toBeUndefined();
+  });
+
+  test("defaults to the wire gate mode when toolGateMode is absent", async () => {
+    let gateModeDuringRun: string | undefined;
+    const conversation = makeWakeConversation({
+      runImpl: async (input) => {
+        gateModeDuringRun = conversation.subagentToolGateMode;
+        return runResult([
+          ...input,
+          { role: "assistant", content: [{ type: "text", text: "Saved." }] },
+        ]);
+      },
+    });
+
+    await wakeAgentForOpportunity(
+      {
+        conversationId: conversation.conversationId,
+        hint: "review for memories",
+        source: "memory-retrospective",
+        allowedTools: ["remember"],
+      },
+      { resolveTarget: async () => conversation },
+    );
+
+    expect(gateModeDuringRun).toBe("wire");
+    expect(conversation.subagentToolGateMode).toBeUndefined();
+  });
+
   test("restores allowed tools before drain when the wake is a silent no-op", async () => {
     const conversation = makeWakeConversation({
       scriptedAssistant: {

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -184,9 +184,27 @@ export interface WakeOptions {
   /**
    * Optional exact tool allowlist for this wake. Used by internal maintenance
    * jobs that need the assistant's judgment but must not execute arbitrary
-   * side-effect tools.
+   * side-effect tools. Enforcement depends on `toolGateMode`: in `"wire"`
+   * mode (default) the tool definitions sent to the provider are filtered to
+   * the allowlist; in `"execution"` mode the full tool surface stays on the
+   * wire and non-allowlisted calls are rejected with an error tool_result
+   * before their executor runs. Either way, only allowlisted tools can
+   * execute during the wake.
    */
   allowedTools?: readonly string[];
+  /**
+   * How `allowedTools` is enforced. Defaults to `"wire"` — the historical
+   * behavior, byte-identical when absent: the provider request's tool array
+   * is filtered down to the allowlist. Pass `"execution"` to keep the
+   * conversation's full tool surface on the wire and enforce the allowlist
+   * at execution time instead. Provider prompt caches key on the rendered
+   * `tools → system → messages` prefix, so wire-filtering the tool array
+   * invalidates the source conversation's cached prefix; execution mode
+   * preserves it. Used by fork-based memory retrospectives when matching
+   * the source conversation's inference profile. Ignored when
+   * `allowedTools` is absent.
+   */
+  toolGateMode?: "wire" | "execution";
 }
 
 /**
@@ -885,6 +903,7 @@ export async function wakeAgentForOpportunity(
         restoreWakeToolScope = scopeWakeAllowedTools(
           conversation,
           new Set(opts.allowedTools),
+          opts.toolGateMode,
         );
         return true;
       } catch (err) {


### PR DESCRIPTION
## Summary
- New wake toolGateMode: "execution" keeps the conversation's full tool surface on the wire (tool defs are part of the provider cache prefix) and enforces the allowlist at execution time with an error tool_result instead
- Fork retrospectives use execution mode only when matchConversationProfile is on; default wire mode is byte-identical to current behavior
- Second of three cache-parity changes (profile, tools, system prompt)

Part of plan: memory-retrospective-fork-hardening.md (PR J of 12)