### PR TITLE
feat(llm): switch Balanced Economy profile to MiniMax M3 on Fireworks

### DIFF
--- a/apps/web/src/assistant/llm-model-catalog.ts
+++ b/apps/web/src/assistant/llm-model-catalog.ts
@@ -239,6 +239,14 @@ export const MODELS_BY_PROVIDER = {
       maxOutputTokens: 32_768,
     },
     {
+      id: "accounts/fireworks/models/minimax-m3",
+      displayName: "MiniMax M3",
+      contextWindowTokens: 524_288,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 512_000,
+      supportsThinking: true,
+    },
+    {
       id: "accounts/fireworks/models/minimax-m2p7",
       displayName: "MiniMax M2.7",
       contextWindowTokens: 196_608,

--- a/assistant/src/__tests__/workspace-migration-101-upgrade-balanced-economy-to-minimax-m3.test.ts
+++ b/assistant/src/__tests__/workspace-migration-101-upgrade-balanced-economy-to-minimax-m3.test.ts
@@ -1,0 +1,162 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { upgradeBalancedEconomyToMinimaxM3Migration } from "../workspace/migrations/101-upgrade-balanced-economy-to-minimax-m3.js";
+
+let workspaceDir: string;
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+function readProfiles(): Record<string, Record<string, unknown>> {
+  const llm = readConfig().llm as Record<string, unknown>;
+  return llm.profiles as Record<string, Record<string, unknown>>;
+}
+
+beforeEach(() => {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-101-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("101-upgrade-balanced-economy-to-minimax-m3 migration", () => {
+  test("no-op when config.json does not exist", () => {
+    upgradeBalancedEconomyToMinimaxM3Migration.run(workspaceDir);
+    expect(existsSync(join(workspaceDir, "config.json"))).toBe(false);
+  });
+
+  test("no-op when config has no llm.profiles", () => {
+    const original = { llm: { default: { provider: "fireworks" } } };
+    writeConfig(original);
+    upgradeBalancedEconomyToMinimaxM3Migration.run(workspaceDir);
+    expect(readConfig()).toEqual(original);
+  });
+
+  test("gracefully handles invalid JSON", () => {
+    writeFileSync(join(workspaceDir, "config.json"), "not-valid-json");
+    upgradeBalancedEconomyToMinimaxM3Migration.run(workspaceDir);
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+      "not-valid-json",
+    );
+  });
+
+  test("upgrades balanced-economy from Kimi K2.6 and drops the logit-bias preset", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          "balanced-economy": {
+            provider: "fireworks",
+            provider_connection: "fireworks-managed",
+            model: "accounts/fireworks/models/kimi-k2p6",
+            label: "Balanced Economy",
+            description: "Strong open model (Kimi K2.6) at a lower price point",
+            maxTokens: 16000,
+            effort: "high",
+            thinking: { enabled: true, streamThinking: true },
+            contextWindow: { maxInputTokens: 200000 },
+            logitBias: "suppress-cjk",
+          },
+        },
+      },
+    });
+    upgradeBalancedEconomyToMinimaxM3Migration.run(workspaceDir);
+    const profile = readProfiles()["balanced-economy"]!;
+    expect(profile.model).toBe("accounts/fireworks/models/minimax-m3");
+    expect(profile.description).toBe(
+      "Strong open model (MiniMax M3) at a lower price point",
+    );
+    expect(profile.maxTokens).toBe(256000);
+    expect(profile.contextWindow).toEqual({ maxInputTokens: 524288 });
+    expect("logitBias" in profile).toBe(false);
+    expect(profile.label).toBe("Balanced Economy");
+    expect(profile.effort).toBe("high");
+    expect(profile.thinking).toEqual({ enabled: true, streamThinking: true });
+  });
+
+  test("leaves user-customized models untouched", () => {
+    const original = {
+      llm: {
+        profiles: {
+          "balanced-economy": {
+            provider: "fireworks",
+            model: "accounts/fireworks/models/deepseek-v4-pro",
+            logitBias: "suppress-cjk",
+          },
+        },
+      },
+    };
+    writeConfig(original);
+    upgradeBalancedEconomyToMinimaxM3Migration.run(workspaceDir);
+    expect(readConfig()).toEqual(original);
+  });
+
+  test("leaves other profiles untouched", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          "my-kimi": {
+            provider: "fireworks",
+            model: "accounts/fireworks/models/kimi-k2p6",
+          },
+          "balanced-economy": {
+            provider: "fireworks",
+            model: "accounts/fireworks/models/kimi-k2p6",
+          },
+        },
+      },
+    });
+    upgradeBalancedEconomyToMinimaxM3Migration.run(workspaceDir);
+    const profiles = readProfiles();
+    expect(profiles["my-kimi"]!.model).toBe(
+      "accounts/fireworks/models/kimi-k2p6",
+    );
+    expect(profiles["balanced-economy"]!.model).toBe(
+      "accounts/fireworks/models/minimax-m3",
+    );
+  });
+
+  test("idempotency: no-op on already-upgraded config (no writes)", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          "balanced-economy": {
+            provider: "fireworks",
+            model: "accounts/fireworks/models/minimax-m3",
+          },
+        },
+      },
+    });
+    const beforeContent = readFileSync(
+      join(workspaceDir, "config.json"),
+      "utf-8",
+    );
+    upgradeBalancedEconomyToMinimaxM3Migration.run(workspaceDir);
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+      beforeContent,
+    );
+  });
+});

--- a/assistant/src/__tests__/workspace-migration-101-upgrade-balanced-economy-to-minimax-m3.test.ts
+++ b/assistant/src/__tests__/workspace-migration-101-upgrade-balanced-economy-to-minimax-m3.test.ts
@@ -89,8 +89,8 @@ describe("101-upgrade-balanced-economy-to-minimax-m3 migration", () => {
     expect(profile.description).toBe(
       "Strong open model (MiniMax M3) at a lower price point",
     );
-    expect(profile.maxTokens).toBe(256000);
-    expect(profile.contextWindow).toEqual({ maxInputTokens: 524288 });
+    expect(profile.maxTokens).toBe(16000);
+    expect(profile.contextWindow).toEqual({ maxInputTokens: 200000 });
     expect("logitBias" in profile).toBe(false);
     expect(profile.label).toBe("Balanced Economy");
     expect(profile.effort).toBe("high");

--- a/assistant/src/__tests__/workspace-migration-101-upgrade-balanced-economy-to-minimax-m3.test.ts
+++ b/assistant/src/__tests__/workspace-migration-101-upgrade-balanced-economy-to-minimax-m3.test.ts
@@ -89,7 +89,7 @@ describe("101-upgrade-balanced-economy-to-minimax-m3 migration", () => {
     expect(profile.description).toBe(
       "Strong open model (MiniMax M3) at a lower price point",
     );
-    expect(profile.maxTokens).toBe(16000);
+    expect(profile.maxTokens).toBe(32000);
     expect(profile.contextWindow).toEqual({ maxInputTokens: 200000 });
     expect("logitBias" in profile).toBe(false);
     expect(profile.label).toBe("Balanced Economy");

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -83,7 +83,7 @@ const MANAGED_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
     source: "managed",
     label: "Balanced Economy",
     description: "Strong open model (MiniMax M3) at a lower price point",
-    maxTokens: 16000,
+    maxTokens: 32000,
     effort: "high",
     thinking: { enabled: true, streamThinking: true },
     contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -74,23 +74,20 @@ const MANAGED_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
     thinking: { enabled: false, streamThinking: false },
     contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
   },
-  // Open-weight economy option: Kimi K2.6 served by Fireworks via managed
-  // platform inference. Carries the `suppress-cjk` logit-bias preset to
-  // discourage the model from spontaneously emitting Chinese in English
-  // output; the preset is profile-scoped and only forwarded on the Fireworks
-  // path (see `providers/inference/logit-bias.ts`).
+  // Open-weight economy option: MiniMax M3 served by Fireworks via managed
+  // platform inference. The context window is opened to the model's full
+  // 512K (524,288 tokens) rather than the 200K default.
   "balanced-economy": {
     intent: "balanced",
     provider: "fireworks",
     connectionName: "fireworks-managed",
     source: "managed",
     label: "Balanced Economy",
-    description: "Strong open model (Kimi K2.6) at a lower price point",
-    maxTokens: 16000,
+    description: "Strong open model (MiniMax M3) at a lower price point",
+    maxTokens: 256000,
     effort: "high",
     thinking: { enabled: true, streamThinking: true },
-    contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
-    logitBias: "suppress-cjk",
+    contextWindow: { maxInputTokens: 524288 },
   },
 };
 

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -75,8 +75,7 @@ const MANAGED_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
     contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
   },
   // Open-weight economy option: MiniMax M3 served by Fireworks via managed
-  // platform inference. The context window is opened to the model's full
-  // 512K (524,288 tokens) rather than the 200K default.
+  // platform inference.
   "balanced-economy": {
     intent: "balanced",
     provider: "fireworks",
@@ -84,10 +83,10 @@ const MANAGED_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
     source: "managed",
     label: "Balanced Economy",
     description: "Strong open model (MiniMax M3) at a lower price point",
-    maxTokens: 256000,
+    maxTokens: 16000,
     effort: "high",
     thinking: { enabled: true, streamThinking: true },
-    contextWindow: { maxInputTokens: 524288 },
+    contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
   },
 };
 

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -692,6 +692,24 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         },
       },
       {
+        id: "accounts/fireworks/models/minimax-m3",
+        displayName: "MiniMax M3",
+        // The model supports 1M context, but Fireworks serves it with a
+        // 512K (524,288-token) window; advertise the served limit.
+        contextWindowTokens: 524288,
+        maxOutputTokens: 512000,
+        supportsThinking: true,
+        supportsCaching: true,
+        supportsVision: true,
+        supportsToolUse: true,
+        maxEffort: "high",
+        pricing: {
+          inputPer1mTokens: 0.3,
+          outputPer1mTokens: 1.2,
+          cacheReadPer1mTokens: 0.06,
+        },
+      },
+      {
         id: "accounts/fireworks/models/minimax-m2p7",
         displayName: "MiniMax M2.7",
         contextWindowTokens: 196608,

--- a/assistant/src/providers/model-intents.ts
+++ b/assistant/src/providers/model-intents.ts
@@ -35,7 +35,7 @@ const PROVIDER_MODEL_INTENTS: Record<string, Record<ModelIntent, string>> = {
     "vision-optimized": "llama3.2",
   },
   fireworks: {
-    balanced: "accounts/fireworks/models/kimi-k2p6",
+    balanced: "accounts/fireworks/models/minimax-m3",
     "latency-optimized": "accounts/fireworks/models/kimi-k2p5",
     "quality-optimized": "accounts/fireworks/models/kimi-k2p6",
     "vision-optimized": "accounts/fireworks/models/kimi-k2p6",

--- a/assistant/src/workspace/migrations/101-upgrade-balanced-economy-to-minimax-m3.ts
+++ b/assistant/src/workspace/migrations/101-upgrade-balanced-economy-to-minimax-m3.ts
@@ -15,9 +15,8 @@ import type { WorkspaceMigration } from "./types.js";
 //
 // Only the managed balanced-economy profile still pointing at the old
 // default model is touched — a profile whose model the user changed is left
-// alone. The rewrite mirrors the new seed template: MiniMax M3, no
-// logit-bias preset. Token limits are unchanged between the templates, so
-// they are left as-is.
+// alone. The rewrite mirrors the new seed template: MiniMax M3, 32K max
+// output tokens, no logit-bias preset.
 
 const OLD_MODEL = "accounts/fireworks/models/kimi-k2p6";
 const NEW_MODEL = "accounts/fireworks/models/minimax-m3";
@@ -51,6 +50,7 @@ export const upgradeBalancedEconomyToMinimaxM3Migration: WorkspaceMigration = {
     profile.model = NEW_MODEL;
     profile.description =
       "Strong open model (MiniMax M3) at a lower price point";
+    profile.maxTokens = 32000;
     delete profile.logitBias;
     profiles["balanced-economy"] = profile;
     llm.profiles = profiles;

--- a/assistant/src/workspace/migrations/101-upgrade-balanced-economy-to-minimax-m3.ts
+++ b/assistant/src/workspace/migrations/101-upgrade-balanced-economy-to-minimax-m3.ts
@@ -15,9 +15,9 @@ import type { WorkspaceMigration } from "./types.js";
 //
 // Only the managed balanced-economy profile still pointing at the old
 // default model is touched — a profile whose model the user changed is left
-// alone. The rewrite mirrors the new seed template: MiniMax M3, 256K max
-// output tokens, the model's full 512K context window, and no logit-bias
-// preset.
+// alone. The rewrite mirrors the new seed template: MiniMax M3, no
+// logit-bias preset. Token limits are unchanged between the templates, so
+// they are left as-is.
 
 const OLD_MODEL = "accounts/fireworks/models/kimi-k2p6";
 const NEW_MODEL = "accounts/fireworks/models/minimax-m3";
@@ -51,8 +51,6 @@ export const upgradeBalancedEconomyToMinimaxM3Migration: WorkspaceMigration = {
     profile.model = NEW_MODEL;
     profile.description =
       "Strong open model (MiniMax M3) at a lower price point";
-    profile.maxTokens = 256000;
-    profile.contextWindow = { maxInputTokens: 524288 };
     delete profile.logitBias;
     profiles["balanced-economy"] = profile;
     llm.profiles = profiles;

--- a/assistant/src/workspace/migrations/101-upgrade-balanced-economy-to-minimax-m3.ts
+++ b/assistant/src/workspace/migrations/101-upgrade-balanced-economy-to-minimax-m3.ts
@@ -1,0 +1,72 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+// Switch the Balanced Economy profile from Kimi K2.6 to MiniMax M3.
+//
+// The Fireworks balanced model intent moved to MiniMax M3 (#34726), but the
+// intent map is only consulted when a profile is seeded: off-platform
+// installs reseed managed profiles on every boot, while on-platform
+// workspaces keep the profile they were hatched with — the seeder skips
+// existing profiles there. Existing platform assistants would otherwise stay
+// on Kimi K2.6 (including the now-dropped `suppress-cjk` logit-bias preset)
+// until a migration rewrites the profile.
+//
+// Only the managed balanced-economy profile still pointing at the old
+// default model is touched — a profile whose model the user changed is left
+// alone. The rewrite mirrors the new seed template: MiniMax M3, 256K max
+// output tokens, the model's full 512K context window, and no logit-bias
+// preset.
+
+const OLD_MODEL = "accounts/fireworks/models/kimi-k2p6";
+const NEW_MODEL = "accounts/fireworks/models/minimax-m3";
+
+export const upgradeBalancedEconomyToMinimaxM3Migration: WorkspaceMigration = {
+  id: "101-upgrade-balanced-economy-to-minimax-m3",
+  description:
+    "Switch the managed Balanced Economy profile from Kimi K2.6 to MiniMax M3",
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const llm = readObject(config.llm);
+    if (llm === null) return;
+
+    const profiles = readObject(llm.profiles);
+    if (profiles === null) return;
+
+    const profile = readObject(profiles["balanced-economy"]);
+    if (profile === null || profile.model !== OLD_MODEL) return;
+
+    profile.model = NEW_MODEL;
+    profile.description =
+      "Strong open model (MiniMax M3) at a lower price point";
+    profile.maxTokens = 256000;
+    profile.contextWindow = { maxInputTokens: 524288 };
+    delete profile.logitBias;
+    profiles["balanced-economy"] = profile;
+    llm.profiles = profiles;
+    config.llm = llm;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(_workspaceDir: string): void {
+    // Forward-only.
+  },
+};
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -98,6 +98,7 @@ import { enableAdaptiveThinkingManagedProfilesMigration } from "./097-enable-ada
 import { removeStaleUpdatesBulletinFileMigration } from "./098-remove-stale-updates-bulletin-file.js";
 import { disableCacheOneShotCallsitesMigration } from "./099-disable-cache-one-shot-callsites.js";
 import { upgradeQualityProfileToFable5Migration } from "./100-upgrade-quality-profile-to-fable-5.js";
+import { upgradeBalancedEconomyToMinimaxM3Migration } from "./101-upgrade-balanced-economy-to-minimax-m3.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -207,4 +208,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   removeStaleUpdatesBulletinFileMigration,
   disableCacheOneShotCallsitesMigration,
   upgradeQualityProfileToFable5Migration,
+  upgradeBalancedEconomyToMinimaxM3Migration,
 ];

--- a/clients/shared/Resources/llm-provider-catalog.json
+++ b/clients/shared/Resources/llm-provider-catalog.json
@@ -602,6 +602,23 @@
           }
         },
         {
+          "id": "accounts/fireworks/models/minimax-m3",
+          "displayName": "MiniMax M3",
+          "contextWindowTokens": 524288,
+          "maxOutputTokens": 512000,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.3,
+            "outputPer1mTokens": 1.2,
+            "cacheReadPer1mTokens": 0.06
+          }
+        },
+        {
           "id": "accounts/fireworks/models/minimax-m2p7",
           "displayName": "MiniMax M2.7",
           "contextWindowTokens": 196608,

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -602,6 +602,23 @@
           }
         },
         {
+          "id": "accounts/fireworks/models/minimax-m3",
+          "displayName": "MiniMax M3",
+          "contextWindowTokens": 524288,
+          "maxOutputTokens": 512000,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.3,
+            "outputPer1mTokens": 1.2,
+            "cacheReadPer1mTokens": 0.06
+          }
+        },
+        {
           "id": "accounts/fireworks/models/minimax-m2p7",
           "displayName": "MiniMax M2.7",
           "contextWindowTokens": 196608,


### PR DESCRIPTION
## Summary
- Add MiniMax M3 (`accounts/fireworks/models/minimax-m3`) to the Fireworks catalog — daemon catalog, web mirror, and regenerated client JSON: 512K served context window (model is natively 1M), 512K max output, thinking/caching/vision/tool use, $0.30/$1.20 per 1M tokens with $0.06 cached input, `maxEffort: "high"` matching Fireworks' documented `reasoning_effort` range.
- Point the Fireworks `balanced` intent at MiniMax M3 so the managed **Balanced Economy** profile resolves to it. Profile defaults: 32K max output tokens, 200K max input tokens, effort `high`, extended thinking enabled with streamed thinking tokens.
- Drop the Kimi-specific `suppress-cjk` logit-bias preset from the Balanced Economy profile. The preset mechanism itself is unchanged — it self-gates on Kimi-tokenizer models, so user profiles pointing at Kimi keep working.
- Add workspace migration `101-upgrade-balanced-economy-to-minimax-m3` so existing assistants (whose seeded profiles aren't reseeded on platform) get the same rewrite: only a balanced-economy profile still on the old Kimi K2.6 default is updated (model, description, 32K max output tokens, logit-bias removal); user-customized models are left untouched.

## Original prompt
Change the Balanced Economy managed inference profile from Kimi K2.6 to MiniMax M3. The model is available via OpenRouter today but needs to be added to the Fireworks catalog, since the profile will use the managed Fireworks provider (same as Kimi did). The Kimi CJK logit-bias preset should be dropped from the profile as part of the switch. Follow-up direction: add a workspace migration so existing assistants' seeded profiles receive the update, and set profile defaults to 32K max output tokens and 200K max input tokens (the catalog keeps the model's true 512K-context/512K-output maxes). Fireworks model page: https://fireworks.ai/models/fireworks/minimax-m3/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
