### PR TITLE
feat(memory): system-prompt persona parity for fork retrospectives

### DIFF
--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -76,6 +76,7 @@ import { filterPrunedCardSections } from "../plugins/defaults/memory-v3-shadow/p
 import {
   applyBootstrapTemplate,
   buildSystemPrompt,
+  type SystemPromptPersonaOverride,
 } from "../prompts/system-prompt.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 import type { Provider } from "../providers/types.js";
@@ -307,6 +308,18 @@ export class Conversation {
    */
   currentTurnInboundActorContext?: InboundActorContext | null;
   /** @internal */ currentTurnChannelCapabilities?: ChannelCapabilities;
+  /**
+   * Explicit persona/channel slugs for the system-prompt build, set (and
+   * cleared) by `wakeAgentForOpportunity` around a wake's agent-loop run.
+   * Wakes bypass the orchestrator's turn-start snapshots above, so without
+   * this their prompt is built from whatever snapshot the conversation
+   * already holds (for a freshly hydrated conversation: the no-trust-context
+   * persona derivation) regardless of which actor/channel the conversation
+   * belongs to. Takes precedence over the trust-context derivation when set.
+   * Persona selection only — never read for trust/approval decisions.
+   * @internal
+   */
+  wakePersonaOverride?: SystemPromptPersonaOverride;
   /** @internal */ currentTurnOverrideProfile?: string;
   /** @internal */ toolRoutedProfile?: string;
   /** @internal */ authContext?: AuthContext;
@@ -606,6 +619,7 @@ export class Conversation {
               hasNoClient: this.hasNoClient,
               trustContext: this.currentTurnTrustContext,
               channelCapabilities: this.currentTurnChannelCapabilities,
+              personaOverride: this.wakePersonaOverride,
               onboardingContext: this.getOnboardingContext(),
               conversationId: this.conversationId,
             }),
@@ -741,6 +755,7 @@ export class Conversation {
           hasNoClient: this.hasNoClient,
           trustContext: this.currentTurnTrustContext,
           channelCapabilities: this.currentTurnChannelCapabilities,
+          personaOverride: this.wakePersonaOverride,
           onboardingContext: this.getOnboardingContext(),
           conversationId: this.conversationId,
         });

--- a/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
@@ -78,6 +78,7 @@ type ConversationStub = {
   conversationType?: string | null;
   inferenceProfile?: string | null;
   inferenceProfileExpiresAt?: number | null;
+  originChannel?: string | null;
 };
 let conversationOverrides: Record<string, ConversationStub> = {};
 
@@ -263,6 +264,19 @@ mock.module("../../daemon/trust-context.js", () => ({
   INTERNAL_GUARDIAN_TRUST_CONTEXT: { trustClass: "guardian" },
 }));
 
+// Guardian persona slug resolution for the fork wake's persona override.
+// The real resolver reads the contacts table; the stub records the trust
+// context it was handed (the job must pass `undefined` — the live-turn
+// guardian branch) and returns a scripted slug.
+let mockResolvedUserSlug: string | null = "alice";
+let resolveUserSlugCalls: unknown[] = [];
+mock.module("../../prompts/persona-resolver.js", () => ({
+  resolveUserSlug: (trustContext: unknown) => {
+    resolveUserSlugCalls.push(trustContext);
+    return mockResolvedUserSlug;
+  },
+}));
+
 mock.module("../../runtime/agent-wake.js", () => ({
   wakeAgentForOpportunity: async (
     opts: { conversationId: string; hint: string } & Record<string, unknown>,
@@ -383,6 +397,8 @@ describe("memoryRetrospectiveJob", () => {
     conversationOverrides = {};
     messagesByConversationId = {};
     loadedConversations = {};
+    mockResolvedUserSlug = "alice";
+    resolveUserSlugCalls = [];
   });
 
   test("first-run happy path: no state row, no prior retrospective, both pointer fields set on success", async () => {
@@ -778,6 +794,91 @@ describe("memoryRetrospectiveJob", () => {
 
     expect(wakeCalls).toHaveLength(1);
     expect("forceOverrideProfile" in wakeCalls[0]!.opts).toBe(false);
+  });
+
+  test("fork path: local/vellum source → wake carries the guardian persona + vellum channel override", async () => {
+    forkFlagEnabled = true;
+    // Default source stub has no originChannel — a local/desktop conversation.
+    await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(wakeCalls).toHaveLength(1);
+    expect(wakeCalls[0]!.opts.personaOverride).toEqual({
+      userSlug: "alice",
+      channelSlug: "vellum",
+    });
+    // Resolved via the live-turn guardian branch: undefined trust context,
+    // never the wake's internal guardian context.
+    expect(resolveUserSlugCalls).toEqual([undefined]);
+  });
+
+  test("fork path: explicit vellum originChannel → override present", async () => {
+    forkFlagEnabled = true;
+    conversationOverrides["src-conv-1"] = {
+      source: "user",
+      forkParentMessageId: null,
+      title: "Source conversation",
+      originChannel: "vellum",
+    };
+
+    await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(wakeCalls).toHaveLength(1);
+    expect(wakeCalls[0]!.opts.personaOverride).toEqual({
+      userSlug: "alice",
+      channelSlug: "vellum",
+    });
+  });
+
+  test("fork path: channel-routed source → no persona override (identity not recoverable)", async () => {
+    forkFlagEnabled = true;
+    conversationOverrides["src-conv-1"] = {
+      source: "user",
+      forkParentMessageId: null,
+      title: "Source conversation",
+      originChannel: "telegram",
+    };
+
+    await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(wakeCalls).toHaveLength(1);
+    expect("personaOverride" in wakeCalls[0]!.opts).toBe(false);
+    expect(resolveUserSlugCalls).toEqual([]);
+  });
+
+  test("fork path: no guardian resolvable → override falls back to the default persona slug", async () => {
+    forkFlagEnabled = true;
+    mockResolvedUserSlug = null;
+
+    await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(wakeCalls).toHaveLength(1);
+    expect(wakeCalls[0]!.opts.personaOverride).toEqual({
+      userSlug: "default",
+      channelSlug: "vellum",
+    });
+  });
+
+  test("fork path: persona override is not gated on matchConversationProfile", async () => {
+    forkFlagEnabled = true;
+
+    await memoryRetrospectiveJob(
+      makeJob(),
+      makeConfig({ matchConversationProfile: true }),
+    );
+
+    expect(wakeCalls).toHaveLength(1);
+    expect(wakeCalls[0]!.opts.personaOverride).toEqual({
+      userSlug: "alice",
+      channelSlug: "vellum",
+    });
+  });
+
+  test("legacy path: wake carries no persona override", async () => {
+    await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(wakeCalls).toHaveLength(1);
+    expect("personaOverride" in wakeCalls[0]!.opts).toBe(false);
+    expect(resolveUserSlugCalls).toEqual([]);
   });
 
   test("legacy path: source mid-turn still runs (gate is fork-path only)", async () => {

--- a/assistant/src/memory/memory-retrospective-job.ts
+++ b/assistant/src/memory/memory-retrospective-job.ts
@@ -49,12 +49,15 @@ import {
 } from "../daemon/identity-helpers.js";
 import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../daemon/trust-context.js";
 import { formatMessageSliceForTranscript } from "../export/transcript-formatter.js";
+import { resolveUserSlug } from "../prompts/persona-resolver.js";
+import type { SystemPromptPersonaOverride } from "../prompts/system-prompt.js";
 import { wakeAgentForOpportunity } from "../runtime/agent-wake.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir } from "../util/platform.js";
 import { bootstrapConversation } from "./conversation-bootstrap.js";
 import {
   addMessage,
+  type ConversationRow,
   deleteConversation,
   findMostRecentRetrospectiveFor,
   forkConversation,
@@ -469,6 +472,14 @@ async function runForkBasedRetrospective(
     ? resolveOverrideProfile(sourceConversation)
     : undefined;
 
+  // Render the fork's system prompt under the SOURCE conversation's persona
+  // and channel — the same sections its live turns rendered. Passed
+  // unconditionally (not gated on matchConversationProfile): the correct
+  // persona is a review-quality fix on its own; with profile matching it
+  // additionally preserves the source's cached system-prompt prefix.
+  // `undefined` (identity not recoverable) keeps today's behavior.
+  const personaOverride = resolveSourcePersonaOverride(sourceConversation);
+
   // `skipHintInjection: true` because the instruction is already a
   // persisted message — the wake's hint sandwich would only duplicate it.
   let wakeSucceeded = false;
@@ -495,6 +506,7 @@ async function runForkBasedRetrospective(
       ...(matchedProfile !== undefined
         ? { forceOverrideProfile: matchedProfile }
         : {}),
+      ...(personaOverride !== undefined ? { personaOverride } : {}),
       hintRole: "user",
       skipHintInjection: true,
       suppressAutoCompaction: true,
@@ -580,6 +592,37 @@ function enqueueFollowUpJobs(): string[] {
     }
   }
   return followUpJobIds;
+}
+
+/**
+ * Resolve the persona/channel override the fork wake should render — the
+ * same user and channel persona sections a live turn on the SOURCE
+ * conversation rendered.
+ *
+ * Local/desktop sources (`originChannel` null or `"vellum"`): live turns
+ * resolve the guardian contact's userFile — either via the
+ * undefined-trust-context branch of `resolveUserFilename` (desktop/native,
+ * no gateway) or via its guardian-class `findGuardianForChannel("vellum")`
+ * fallback (managed desktop, whose JWT-principal `requesterExternalUserId`
+ * never matches a contact channel row). `resolveUserSlug(undefined)`
+ * reproduces both, falling back to `"default"` exactly as the live prompt
+ * build does when no guardian resolves. Channel persona is `"vellum"`.
+ *
+ * Channel-routed sources: live-turn persona resolution keys off the
+ * requester's `requesterExternalUserId` (contact lookup per actor, possibly
+ * different across turns), which is not stored on the conversation row —
+ * the live-turn result is not recoverable here. Return `undefined` so the
+ * wake keeps today's behavior.
+ */
+function resolveSourcePersonaOverride(
+  source: Pick<ConversationRow, "originChannel">,
+): SystemPromptPersonaOverride | undefined {
+  const channel = source.originChannel;
+  if (channel != null && channel !== "vellum") return undefined;
+  return {
+    userSlug: resolveUserSlug(undefined) ?? "default",
+    channelSlug: "vellum",
+  };
 }
 
 function safeDeleteForkOnFailure(forkId: string): void {

--- a/assistant/src/prompts/__tests__/system-prompt.test.ts
+++ b/assistant/src/prompts/__tests__/system-prompt.test.ts
@@ -6,7 +6,7 @@
  * user-message injection that replaced it.
  */
 
-import { copyFileSync, mkdirSync, readFileSync } from "node:fs";
+import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -70,6 +70,58 @@ describe("buildSystemPrompt — tool routing guidance", () => {
     const result = buildSystemPrompt({});
     expect(result).not.toContain("## Clarifying questions");
     expect(result).not.toContain("ask_question");
+  });
+});
+
+describe("buildSystemPrompt — persona override", () => {
+  const DEFAULT_SENTINEL = "Sentinel: default persona body.";
+  const ALICE_SENTINEL = "Sentinel: alice persona body.";
+  const TELEGRAM_SENTINEL = "Sentinel: telegram channel persona body.";
+
+  beforeEach(() => {
+    mkdirSync(join(TEST_DIR, "users"), { recursive: true });
+    mkdirSync(join(TEST_DIR, "channels"), { recursive: true });
+    writeFileSync(join(TEST_DIR, "users", "default.md"), DEFAULT_SENTINEL);
+    writeFileSync(join(TEST_DIR, "users", "alice.md"), ALICE_SENTINEL);
+    writeFileSync(join(TEST_DIR, "channels", "telegram.md"), TELEGRAM_SENTINEL);
+  });
+
+  test("personaOverride renders the given user + channel persona sections", () => {
+    const result = buildSystemPrompt({
+      personaOverride: { userSlug: "alice", channelSlug: "telegram" },
+    });
+
+    expect(result).toContain(ALICE_SENTINEL);
+    expect(result).toContain(TELEGRAM_SENTINEL);
+    expect(result).not.toContain(DEFAULT_SENTINEL);
+  });
+
+  test("no override → trust-context-derived resolution (default persona, vellum channel)", () => {
+    // No trust context and no resolvable guardian contact in this test env,
+    // so the user persona falls back to users/default.md and the channel
+    // section resolves channels/vellum.md (absent → omitted).
+    const result = buildSystemPrompt({});
+
+    expect(result).toContain(DEFAULT_SENTINEL);
+    expect(result).not.toContain(ALICE_SENTINEL);
+    expect(result).not.toContain(TELEGRAM_SENTINEL);
+  });
+
+  test("partial override: userSlug alone leaves channel resolution untouched", () => {
+    const result = buildSystemPrompt({
+      personaOverride: { userSlug: "alice" },
+    });
+
+    expect(result).toContain(ALICE_SENTINEL);
+    expect(result).not.toContain(TELEGRAM_SENTINEL);
+  });
+
+  test("override userSlug with no matching file falls back to users/default.md", () => {
+    const result = buildSystemPrompt({
+      personaOverride: { userSlug: "missing-user" },
+    });
+
+    expect(result).toContain(DEFAULT_SENTINEL);
   });
 });
 

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -304,6 +304,20 @@ export function applyBootstrapTemplate(
   }
 }
 
+/**
+ * Explicit persona-selection override for prompt builds that run outside the
+ * inbound-turn pipeline (agent wakes). Each slug, when present, takes
+ * precedence over the corresponding trust-context/channel-capabilities
+ * derivation in {@link buildSystemPrompt}. Persona selection only — trust
+ * class and approval semantics are unaffected.
+ */
+export interface SystemPromptPersonaOverride {
+  /** Renders `users/<slug>.md` as the user persona section. */
+  userSlug?: string;
+  /** Renders `channels/<slug>.md` as the channel persona section. */
+  channelSlug?: string;
+}
+
 export interface BuildSystemPromptOptions {
   hasNoClient?: boolean;
   excludeBootstrap?: boolean;
@@ -311,6 +325,15 @@ export interface BuildSystemPromptOptions {
   trustContext?: TrustContext;
   channelCapabilities?: ChannelCapabilities;
   onboardingContext?: OnboardingContext;
+  /**
+   * Explicit persona/channel slugs, taking precedence over the
+   * trust-context-derived `userSlug` and capabilities-derived `channelSlug`.
+   * Used by fork-based memory retrospectives so the fork's prompt renders the
+   * SOURCE conversation's persona sections (review quality + byte-parity with
+   * the source's cached system-prompt prefix) even though the wake itself
+   * carries an internal guardian trust context with no requester identity.
+   */
+  personaOverride?: SystemPromptPersonaOverride;
   /**
    * Conversation this prompt is being built for. Optional because several
    * callers build a prompt outside a conversation (e.g. home greeting,
@@ -344,8 +367,15 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   // `users/<slug>.md → users/default.md` fallback lives in the
   // section's `workspacePath` array.  `channelSlug` is the channel
   // identifier from `channelCapabilities`, defaulting to "vellum".
-  const userSlug = resolveUserSlug(options?.trustContext) ?? "default";
-  const channelSlug = options?.channelCapabilities?.channel ?? "vellum";
+  // An explicit `personaOverride` slug wins over either derivation.
+  const userSlug =
+    options?.personaOverride?.userSlug ??
+    resolveUserSlug(options?.trustContext) ??
+    "default";
+  const channelSlug =
+    options?.personaOverride?.channelSlug ??
+    options?.channelCapabilities?.channel ??
+    "vellum";
 
   // Section render context.  Workspace section frontmatter `enabled:`
   // predicates, `{{key}}` / `{{#flag}}...{{/flag}}` body interpolation,

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -50,6 +50,12 @@ interface WakeConversationProbe {
     requestId?: string;
     trust?: unknown;
     allowedTools?: string[];
+    /**
+     * `conversation.wakePersonaOverride` as observed at run start — the
+     * field the conversation's resolveSystemPrompt callback reads when
+     * building the wake's system prompt.
+     */
+    personaOverride?: unknown;
     order: number;
   }>;
   /** Every `setProcessing` value, in call order. */
@@ -77,6 +83,13 @@ interface WakeConversationProbe {
   allowedToolSnapshots: Array<string[] | undefined>;
   /** `setTrustContext` calls, with the value and a monotonic order tag. */
   setTrustContextCalls: Array<{ ctx: unknown; order: number }>;
+  /**
+   * Every assignment to `conversation.wakePersonaOverride`, in order. A
+   * wake that applies an override records `[override, undefined]` — the
+   * trailing `undefined` proves the wake restored the field before
+   * releasing the conversation.
+   */
+  personaOverrideSets: unknown[];
   /** Number of persisted tail messages at the moment each frame emitted. */
   persistedAtEachEmit: number[];
   /**
@@ -307,6 +320,7 @@ function makeWakeConversation(options: {
     processingDuringDrain: [],
     allowedToolSnapshots: [],
     setTrustContextCalls: [],
+    personaOverrideSets: [],
     persistedAtEachEmit: [],
     maybeCompactOrders: [],
   };
@@ -315,6 +329,7 @@ function makeWakeConversation(options: {
   let processing = options.isProcessing ?? false;
   let order = 0;
   let activeAllowedTools = options.initialAllowedTools;
+  let wakePersonaOverride: unknown;
   const snapshotAllowedTools = (): string[] | undefined =>
     activeAllowedTools ? [...activeAllowedTools].sort() : undefined;
 
@@ -377,6 +392,13 @@ function makeWakeConversation(options: {
         `tools:${snapshotAllowedTools()?.join(",") ?? "all"}`,
       );
     },
+    get wakePersonaOverride() {
+      return wakePersonaOverride;
+    },
+    set wakePersonaOverride(value: unknown) {
+      wakePersonaOverride = value;
+      probe.personaOverrideSets.push(value);
+    },
     agentLoop: {
       run: async (options: AgentLoopRunOptions) => {
         const { messages: input, onEvent } = options;
@@ -385,6 +407,7 @@ function makeWakeConversation(options: {
           requestId: options.requestId,
           trust: options.trust,
           allowedTools: snapshotAllowedTools(),
+          personaOverride: wakePersonaOverride,
           order: order++,
         });
         return runBody(input, onEvent, options);
@@ -580,6 +603,78 @@ describe("wakeAgentForOpportunity", () => {
       sourceChannel: "vellum",
       trustClass: "guardian",
     });
+  });
+
+  test("personaOverride is applied to the conversation for the run and restored after", async () => {
+    const conversation = makeWakeConversation({
+      scriptedAssistant: {
+        role: "assistant",
+        content: [{ type: "text", text: "reviewed." }],
+      },
+    });
+    const override = { userSlug: "alice", channelSlug: "telegram" };
+
+    const result = await wakeAgentForOpportunity(
+      {
+        conversationId: conversation.conversationId,
+        hint: "retrospective pass",
+        source: "memory-retrospective",
+        trustContext: { sourceChannel: "vellum", trustClass: "guardian" },
+        personaOverride: override,
+      },
+      { resolveTarget: async () => conversation },
+    );
+
+    expect(result.invoked).toBe(true);
+    // The override was live on the conversation when the loop ran — the
+    // resolveSystemPrompt callback reads this field at prompt-build time.
+    expect(conversation.runCalls[0]!.personaOverride).toEqual(override);
+    // Applied exactly once and cleared before the wake released the
+    // conversation, so a queued user turn can't build under it.
+    expect(conversation.personaOverrideSets).toEqual([override, undefined]);
+  });
+
+  test("personaOverride is cleared even when the agent loop throws", async () => {
+    const conversation = makeWakeConversation({
+      runImpl: async () => {
+        throw new Error("loop exploded");
+      },
+    });
+    const override = { userSlug: "alice" };
+
+    const result = await wakeAgentForOpportunity(
+      {
+        conversationId: conversation.conversationId,
+        hint: "retrospective pass",
+        source: "memory-retrospective",
+        personaOverride: override,
+      },
+      { resolveTarget: async () => conversation },
+    );
+
+    expect(result).toEqual({ invoked: true, producedToolCalls: false });
+    expect(conversation.personaOverrideSets).toEqual([override, undefined]);
+  });
+
+  test("no personaOverride → the conversation's persona field is never touched", async () => {
+    const conversation = makeWakeConversation({
+      scriptedAssistant: {
+        role: "assistant",
+        content: [{ type: "text", text: "hello" }],
+      },
+    });
+
+    await wakeAgentForOpportunity(
+      {
+        conversationId: conversation.conversationId,
+        hint: "plain wake",
+        source: "background-tool",
+      },
+      { resolveTarget: async () => conversation },
+    );
+
+    expect(conversation.runCalls[0]!.personaOverride).toBeUndefined();
+    expect(conversation.personaOverrideSets).toEqual([]);
   });
 
   test("silent no-op when agent produces no tool calls and no text", async () => {

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -80,6 +80,7 @@ import {
   recordRequestLog,
   setAgentLoopExitReasonOnLatestLog,
 } from "../memory/llm-request-log-store.js";
+import type { SystemPromptPersonaOverride } from "../prompts/system-prompt.js";
 import { isContextOverflowError, type Message } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
 
@@ -205,6 +206,21 @@ export interface WakeOptions {
    * `allowedTools` is absent.
    */
   toolGateMode?: "wire" | "execution";
+  /**
+   * Explicit persona/channel slugs for the wake's system-prompt build,
+   * applied to the conversation for the duration of the run and restored
+   * afterwards. Wakes bypass the orchestrator's turn-start persona snapshot,
+   * so their prompt is otherwise built from whatever snapshot the
+   * conversation already holds — for a freshly hydrated conversation (the
+   * fork-retrospective case) that is the no-trust-context derivation
+   * (guardian persona + "vellum" channel) regardless of which actor/channel
+   * the conversation belongs to. Used by fork-based memory retrospectives to
+   * render the SOURCE conversation's persona sections — both for review
+   * quality and for byte-parity with the source's cached system-prompt
+   * prefix. Persona selection only; trust class and approval semantics are
+   * governed solely by `trustContext`.
+   */
+  personaOverride?: SystemPromptPersonaOverride;
 }
 
 /**
@@ -536,6 +552,20 @@ export async function wakeAgentForOpportunity(
     if (opts.trustContext) {
       conversation.setTrustContext(opts.trustContext);
     }
+
+    // Apply the caller's persona override for the duration of the run. The
+    // wake's agent loop builds the system prompt through the conversation's
+    // resolveSystemPrompt callback, which reads this field; cleared (below,
+    // before drainQueue) so a queued user turn never builds its prompt under
+    // the wake's override.
+    if (opts.personaOverride) {
+      conversation.wakePersonaOverride = opts.personaOverride;
+    }
+    const clearWakePersonaOverride = (): void => {
+      if (opts.personaOverride) {
+        conversation.wakePersonaOverride = undefined;
+      }
+    };
 
     // Honor the conversation's pinned inference-profile override (if any).
     // Without this, scheduled-task wakes and other opportunity wakes bypass
@@ -1110,6 +1140,7 @@ export async function wakeAgentForOpportunity(
       // processing to already be false). The finally block handles the
       // error/early-return paths where no tail was produced.
       restoreWakeAllowedTools();
+      clearWakePersonaOverride();
       try {
         conversation.setProcessing(false);
       } catch (err) {
@@ -1137,6 +1168,7 @@ export async function wakeAgentForOpportunity(
       // `drainedInTry` is still false.
       if (!drainedInTry) {
         restoreWakeAllowedTools();
+        clearWakePersonaOverride();
         try {
           conversation.setProcessing(false);
         } catch (err) {


### PR DESCRIPTION
## Summary
- Fork-retrospective wakes previously fell through to the default persona and vellum channel (guardian trust context carries no requester identity), reviewing conversations under the wrong persona and breaking system-prompt cache parity
- Wakes can now carry explicit persona/channel overrides, threaded to buildSystemPrompt; the retrospective job resolves them from the source conversation; trust/approval semantics unchanged
- Third of three cache-parity changes (profile, tools, system prompt)

Part of plan: memory-retrospective-fork-hardening.md (PR K of 12)