### PR TITLE
fix(web): recover from a gateway /auth/token 401, not just a missing guardian token

### DIFF
--- a/apps/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -4,7 +4,10 @@ import { useNavigate, useSearchParams } from "react-router";
 
 import { resolveSelectedAssistantId } from "@/assistant/selection";
 import { retireAssistant } from "@/assistant/retire-service";
-import { clearGatewayToken } from "@/lib/auth/gateway-session";
+import {
+  clearGatewayToken,
+  isRepairableGatewayTokenError,
+} from "@/lib/auth/gateway-session";
 import { isGuardianRepairable } from "@/lib/local-mode";
 import { ConnectRecoveryDialog } from "@/domains/onboarding/components/connect-recovery-dialog";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
@@ -91,12 +94,14 @@ export function SelectAssistantScreen() {
       void navigate(routes.assistant, { replace: true });
     } catch (err) {
       console.error("selectAssistant.handleConnect failed", err);
-      // A token that's gone for good can only be fixed by re-provisioning,
-      // so offer the recovery dialog; every other failure keeps the generic
-      // message — repair can't help those.
+      // Offer recovery when a guardian re-provision can fix it: the token is
+      // gone/unrefreshable on disk, or the gateway rejected it at the
+      // /auth/token mint (a 401 from a signing-key mismatch). Otherwise keep
+      // the generic message — repair can't help.
       if (
         assistant.isLocal &&
-        requiresGuardianReprovision(err) &&
+        (requiresGuardianReprovision(err) ||
+          isRepairableGatewayTokenError(err)) &&
         isGuardianRepairable(assistant.id)
       ) {
         setRecoveryAssistant(assistant);

--- a/apps/web/src/lib/auth/gateway-session.test.ts
+++ b/apps/web/src/lib/auth/gateway-session.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  GatewayTokenError,
+  clearGatewayToken,
+  ensureGatewayToken,
+  isRepairableGatewayTokenError,
+} from "@/lib/auth/gateway-session";
+
+const realFetch = globalThis.fetch;
+
+beforeEach(() => {
+  // The token cache is module-level; start every test with no cached token so
+  // `ensureGatewayToken` always reaches the mint.
+  clearGatewayToken();
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  clearGatewayToken();
+});
+
+describe("ensureGatewayToken mint failure", () => {
+  test("throws a GatewayTokenError carrying the response status on a 401", async () => {
+    globalThis.fetch = mock(async () => ({
+      ok: false,
+      status: 401,
+    })) as unknown as typeof fetch;
+
+    const err = await ensureGatewayToken(
+      "/assistant/__gateway/20100/auth/token",
+      "guardian-token",
+    ).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(GatewayTokenError);
+    expect((err as GatewayTokenError).status).toBe(401);
+  });
+
+  test("preserves a non-401 status (e.g. 403 boundary refusal)", async () => {
+    globalThis.fetch = mock(async () => ({
+      ok: false,
+      status: 403,
+    })) as unknown as typeof fetch;
+
+    const err = await ensureGatewayToken(
+      "/assistant/__gateway/20100/auth/token",
+      "guardian-token",
+    ).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(GatewayTokenError);
+    expect((err as GatewayTokenError).status).toBe(403);
+  });
+
+  test("returns the minted token on success", async () => {
+    globalThis.fetch = mock(async () => ({
+      ok: true,
+      json: async () => ({ token: "minted", expiresAt: 9_999_999_999 }),
+    })) as unknown as typeof fetch;
+
+    const token = await ensureGatewayToken(
+      "/assistant/__gateway/20100/auth/token",
+      "guardian-token",
+    );
+    expect(token).toBe("minted");
+  });
+});
+
+describe("isRepairableGatewayTokenError", () => {
+  test("true only for a 401 GatewayTokenError", () => {
+    expect(isRepairableGatewayTokenError(new GatewayTokenError(401, "x"))).toBe(
+      true,
+    );
+  });
+
+  test("false for a 403 (boundary refusal) and 5xx (transient)", () => {
+    expect(isRepairableGatewayTokenError(new GatewayTokenError(403, "x"))).toBe(
+      false,
+    );
+    expect(isRepairableGatewayTokenError(new GatewayTokenError(500, "x"))).toBe(
+      false,
+    );
+  });
+
+  test("false for a plain Error or a non-error value", () => {
+    expect(isRepairableGatewayTokenError(new Error("nope"))).toBe(false);
+    expect(isRepairableGatewayTokenError(undefined)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/auth/gateway-session.ts
+++ b/apps/web/src/lib/auth/gateway-session.ts
@@ -4,6 +4,39 @@ import {
 } from "@/lib/local-mode";
 import type { LockfileAssistant } from "@/runtime/local-mode-host";
 
+/**
+ * Thrown when the gateway `/auth/token` mint rejects the request, carrying the
+ * response `status` so callers can branch on the failure class. A `401` means
+ * the gateway refused the guardian token itself — most often an
+ * `invalid_signature` after the gateway restarted with a different signing key
+ * than the on-disk guardian token was leased against — which a guardian
+ * re-provision (`wake --repair-guardian`) fixes by re-leasing against the
+ * running gateway. A `403` is a loopback/Origin boundary refusal that repair
+ * can't change, and `5xx`/network failures are transient.
+ *
+ * Distinct from {@link GuardianTokenError} (thrown by `fetchGuardianTokenHost`
+ * when the guardian token is missing/unrefreshable on disk): this is the
+ * downstream mint rejecting a token that read back fine.
+ */
+export class GatewayTokenError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "GatewayTokenError";
+    this.status = status;
+  }
+}
+
+/**
+ * True when a connect failure is the gateway rejecting the guardian token at
+ * the `/auth/token` mint (a `401`), which a guardian re-provision can recover.
+ * `403` (boundary refusal) and `5xx`/network failures are not re-provisionable.
+ */
+export function isRepairableGatewayTokenError(error: unknown): boolean {
+  return error instanceof GatewayTokenError && error.status === 401;
+}
+
 const LS_TOKEN_KEY = "vellum:gw:token";
 const LS_EXPIRES_KEY = "vellum:gw:expiresAt";
 const LS_TOKEN_SOURCE_KEY = "vellum:gw:tokenSource";
@@ -64,7 +97,10 @@ async function acquireGatewayToken(tokenUrl?: string, guardianToken?: string): P
   }
   const res = await fetch(url, { method: "POST", headers });
   if (!res.ok) {
-    throw new Error(`Gateway token request failed: ${res.status}`);
+    throw new GatewayTokenError(
+      res.status,
+      `Gateway token request failed: ${res.status}`,
+    );
   }
   const { token, expiresAt } = (await res.json()) as {
     token: string;


### PR DESCRIPTION
## Summary
- The assistant chooser's recovery dialog previously only opened when the guardian token was missing/unrefreshable on disk (`GuardianTokenError` 404/401 from the host fetch). A guardian token that reads back fine but is rejected by the gateway at the `POST /auth/token` mint (a 401 — typically `invalid_signature` after the gateway restarts with a different signing key) threw a plain `Error`, so `requiresGuardianReprovision()` returned false and the user just saw the generic "Failed to connect."
- `acquireGatewayToken` now throws a typed `GatewayTokenError` carrying the response status, and a new `isRepairableGatewayTokenError()` predicate treats a 401 as repair-eligible. The chooser composes it with `requiresGuardianReprovision()`, so the recovery dialog ("Wake & Repair" → `wake --repair-guardian`) now opens for this case too — which is exactly what re-leases the guardian token against the running gateway and fixes the 401.
- Scoped to the connect-time mint 401. A revoked-but-locally-cached gateway token (no error at connect, 401s later on API calls) is a separate, downstream case left as a follow-up.

## Original prompt
While manually testing the guardian-token recovery flow, clicking "Continue" on the Choose an Assistant screen produced a 401 against `…/__gateway/20100/auth/token` (gateway log: `invalid_signature`) because the on-disk guardian token was leased against a gateway signing key that changed on a later gateway restart. The recovery dialog didn't open for this because the failure surfaced at the gateway-token mint rather than the guardian-token fetch. The ask was to extend the recovery dialog to also catch and offer repair for this gateway-rejection 401, since `wake --repair-guardian` resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)