### PR TITLE
feat(chrome-extension): app-held WorkOS PKCE login

### DIFF
--- a/clients/chrome-extension/README.md
+++ b/clients/chrome-extension/README.md
@@ -111,6 +111,31 @@ Chrome assigns each extension a unique 32-character ID. Non-production builds in
 
 Each environment also gets its own icon set (under `icons/<env>/`), making it easy to distinguish side-by-side installs at a glance.
 
+## WorkOS redirect URIs (REQUIRED dashboard step)
+
+Cloud sign-in uses app-held PKCE against WorkOS User Management. The extension
+authorizes via `chrome.identity.launchWebAuthFlow` and WorkOS redirects back to
+a fixed `chromiumapp.org` URL — `https://<extension-id>.chromiumapp.org/cloud-auth`.
+
+**Each of these exact URLs MUST be registered as a redirect on the WorkOS User
+Management application for its environment.** Sign-in fails at the WorkOS
+authorize step (`redirect_uri` not allowed) until the URL is registered. The
+extension id is fixed per environment (deterministic `key` in
+[`extension-environments.json`](./extension-environments.json) for non-prod; the
+CWS signing key for production):
+
+| Environment | Extension ID | Redirect URI to register |
+|---|---|---|
+| production | `hphbdmpffeigpcdjkckleobjmhhokpne` | `https://hphbdmpffeigpcdjkckleobjmhhokpne.chromiumapp.org/cloud-auth` |
+| staging | `idpcnibfinmkdhlpenkglianflkbhfim` | `https://idpcnibfinmkdhlpenkglianflkbhfim.chromiumapp.org/cloud-auth` |
+| dev | `kajfcoaefacmjgdaloeafnpcfaeahcio` | `https://kajfcoaefacmjgdaloeafnpcfaeahcio.chromiumapp.org/cloud-auth` |
+| local | `gfcldmjjhcginboeldmknclbjilohcbn` | `https://gfcldmjjhcginboeldmknclbjilohcbn.chromiumapp.org/cloud-auth` |
+
+Register each redirect on the WorkOS UM app that backs the corresponding
+platform environment (production WorkOS app for `production`, etc.). The
+production extension id is assigned by the Chrome Web Store; if it ever changes,
+update the production row above and re-register.
+
 ## Troubleshooting
 
 | Error | Cause / Fix |

--- a/clients/chrome-extension/background/__tests__/workos-pkce.test.ts
+++ b/clients/chrome-extension/background/__tests__/workos-pkce.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Tests for the WorkOS app-held PKCE helpers used by the Chrome extension's
+ * cloud login flow.
+ *
+ * Covers the pure / transport-agnostic surface:
+ *   - generatePkcePair: format + S256 challenge correctness
+ *   - generateState: format + uniqueness
+ *   - buildAuthorizeUrl: WorkOS authorize URL contract
+ *   - parseRedirectUrl: code/state extraction, error + CSRF handling
+ *   - selectWorkosClientId: coexistence-window provider selection
+ */
+
+import { describe, test, expect } from 'bun:test';
+
+import {
+  generatePkcePair,
+  generateState,
+  buildAuthorizeUrl,
+  parseRedirectUrl,
+  selectWorkosClientId,
+  type HeadlessProviderEntry,
+} from '../workos-pkce.js';
+
+const BASE64URL_RE = /^[A-Za-z0-9_-]+$/;
+
+// ── generatePkcePair ────────────────────────────────────────────────
+
+describe('generatePkcePair', () => {
+  test('verifier is 32 random bytes base64url-encoded (no padding)', async () => {
+    const { verifier } = await generatePkcePair();
+    expect(verifier).toMatch(BASE64URL_RE);
+    // 32 bytes base64url → 43 chars, no padding.
+    expect(verifier.length).toBe(43);
+    expect(verifier).not.toContain('=');
+    expect(verifier).not.toContain('+');
+    expect(verifier).not.toContain('/');
+  });
+
+  test('challenge is base64url(sha256(verifier))', async () => {
+    const { verifier, challenge } = await generatePkcePair();
+    expect(challenge).toMatch(BASE64URL_RE);
+    // SHA-256 digest is 32 bytes → 43 chars base64url, no padding.
+    expect(challenge.length).toBe(43);
+
+    // Recompute the expected challenge from the verifier and compare.
+    const digest = await crypto.subtle.digest(
+      'SHA-256',
+      new TextEncoder().encode(verifier),
+    );
+    const bytes = new Uint8Array(digest);
+    let binary = '';
+    for (const b of bytes) binary += String.fromCharCode(b);
+    const expected = btoa(binary)
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+    expect(challenge).toBe(expected);
+  });
+
+  test('produces a different pair each call', async () => {
+    const a = await generatePkcePair();
+    const b = await generatePkcePair();
+    expect(a.verifier).not.toBe(b.verifier);
+    expect(a.challenge).not.toBe(b.challenge);
+  });
+});
+
+// ── generateState ───────────────────────────────────────────────────
+
+describe('generateState', () => {
+  test('is a non-empty base64url string', () => {
+    const state = generateState();
+    expect(state).toMatch(BASE64URL_RE);
+    expect(state.length).toBeGreaterThan(0);
+  });
+
+  test('is unique across calls', () => {
+    expect(generateState()).not.toBe(generateState());
+  });
+});
+
+// ── buildAuthorizeUrl ───────────────────────────────────────────────
+
+describe('buildAuthorizeUrl', () => {
+  const baseOptions = {
+    clientId: 'client_abc123',
+    redirectUri: 'https://ext-id.chromiumapp.org/cloud-auth',
+    challenge: 'challenge-value',
+    state: 'state-value',
+  };
+
+  test('targets the WorkOS user_management authorize endpoint', () => {
+    const url = new URL(buildAuthorizeUrl(baseOptions));
+    expect(url.origin).toBe('https://api.workos.com');
+    expect(url.pathname).toBe('/user_management/authorize');
+  });
+
+  test('sets the required PKCE + OAuth params', () => {
+    const url = new URL(buildAuthorizeUrl(baseOptions));
+    const p = url.searchParams;
+    expect(p.get('client_id')).toBe('client_abc123');
+    expect(p.get('redirect_uri')).toBe(
+      'https://ext-id.chromiumapp.org/cloud-auth',
+    );
+    expect(p.get('response_type')).toBe('code');
+    expect(p.get('scope')).toBe('openid profile email');
+    expect(p.get('code_challenge')).toBe('challenge-value');
+    expect(p.get('code_challenge_method')).toBe('S256');
+    expect(p.get('state')).toBe('state-value');
+    expect(p.get('provider')).toBe('authkit');
+  });
+
+  test('does not set a prompt param (reuse existing IdP session)', () => {
+    const url = new URL(buildAuthorizeUrl(baseOptions));
+    expect(url.searchParams.has('prompt')).toBe(false);
+  });
+
+  test('omits login_hint and screen_hint by default', () => {
+    const url = new URL(buildAuthorizeUrl(baseOptions));
+    expect(url.searchParams.has('login_hint')).toBe(false);
+    expect(url.searchParams.has('screen_hint')).toBe(false);
+  });
+
+  test('passes login_hint and signup screen_hint when provided', () => {
+    const url = new URL(
+      buildAuthorizeUrl({
+        ...baseOptions,
+        loginHint: 'user@example.com',
+        intent: 'signup',
+      }),
+    );
+    expect(url.searchParams.get('login_hint')).toBe('user@example.com');
+    expect(url.searchParams.get('screen_hint')).toBe('sign-up');
+  });
+
+  test('honors a custom provider hint', () => {
+    const url = new URL(
+      buildAuthorizeUrl({ ...baseOptions, providerHint: 'GoogleOAuth' }),
+    );
+    expect(url.searchParams.get('provider')).toBe('GoogleOAuth');
+  });
+});
+
+// ── parseRedirectUrl ────────────────────────────────────────────────
+
+describe('parseRedirectUrl', () => {
+  test('extracts code + state from a matching redirect', () => {
+    const result = parseRedirectUrl(
+      'https://ext-id.chromiumapp.org/cloud-auth?code=abc&state=xyz',
+      'xyz',
+    );
+    expect(result).toEqual({ code: 'abc', state: 'xyz' });
+  });
+
+  test('throws on a WorkOS error param with description', () => {
+    expect(() =>
+      parseRedirectUrl(
+        'https://ext-id.chromiumapp.org/cloud-auth?error=access_denied&error_description=User+declined',
+        'xyz',
+      ),
+    ).toThrow('User declined');
+  });
+
+  test('throws on a WorkOS error param without description', () => {
+    expect(() =>
+      parseRedirectUrl(
+        'https://ext-id.chromiumapp.org/cloud-auth?error=server_error',
+        'xyz',
+      ),
+    ).toThrow('server_error');
+  });
+
+  test('throws when no code is present', () => {
+    expect(() =>
+      parseRedirectUrl(
+        'https://ext-id.chromiumapp.org/cloud-auth?state=xyz',
+        'xyz',
+      ),
+    ).toThrow('no authorization code');
+  });
+
+  test('throws on a state mismatch (CSRF)', () => {
+    expect(() =>
+      parseRedirectUrl(
+        'https://ext-id.chromiumapp.org/cloud-auth?code=abc&state=wrong',
+        'xyz',
+      ),
+    ).toThrow('state mismatch');
+  });
+
+  test('throws when state is missing entirely', () => {
+    expect(() =>
+      parseRedirectUrl(
+        'https://ext-id.chromiumapp.org/cloud-auth?code=abc',
+        'xyz',
+      ),
+    ).toThrow('state mismatch');
+  });
+});
+
+// ── selectWorkosClientId ────────────────────────────────────────────
+
+describe('selectWorkosClientId', () => {
+  test('returns null when no providers are advertised', () => {
+    expect(selectWorkosClientId([])).toBeNull();
+  });
+
+  test('picks the OAuth2 (no OIDC discovery URL) provider during coexistence', () => {
+    // Two entries share the same id; the OIDC one has a discovery URL and must
+    // be skipped in favor of the OAuth2 one.
+    const providers: HeadlessProviderEntry[] = [
+      {
+        id: 'workos-oidc',
+        client_id: 'client_oidc',
+        flows: ['provider_token'],
+        openid_configuration_url: 'https://api.workos.com/.well-known/openid',
+      },
+      {
+        id: 'workos-oidc',
+        client_id: 'client_oauth2',
+        flows: ['provider_token'],
+      },
+    ];
+    expect(selectWorkosClientId(providers)).toBe('client_oauth2');
+  });
+
+  test('requires the provider_token flow', () => {
+    const providers: HeadlessProviderEntry[] = [
+      { id: 'workos-oidc', client_id: 'client_x', flows: ['authorization_code'] },
+    ];
+    expect(selectWorkosClientId(providers)).toBeNull();
+  });
+
+  test('requires a client_id string', () => {
+    const providers: HeadlessProviderEntry[] = [
+      { id: 'workos-oidc', flows: ['provider_token'] },
+    ];
+    expect(selectWorkosClientId(providers)).toBeNull();
+  });
+
+  test('returns the single valid OAuth2 provider', () => {
+    const providers: HeadlessProviderEntry[] = [
+      { id: 'workos-oidc', client_id: 'client_only', flows: ['provider_token'] },
+    ];
+    expect(selectWorkosClientId(providers)).toBe('client_only');
+  });
+});

--- a/clients/chrome-extension/background/cloud-auth.ts
+++ b/clients/chrome-extension/background/cloud-auth.ts
@@ -1,30 +1,65 @@
 /**
  * Cloud authentication for the Vellum Chrome extension.
  *
- * Handles WorkOS-based sign-in via `chrome.identity.launchWebAuthFlow`.
- * The flow opens a browser tab to the Vellum Chrome extension login
- * endpoint; after the user authenticates, the platform redirects back
- * to a `chromiumapp.org` callback URL that Chrome intercepts, returning
- * the final URL (with token fragment) to the extension.
+ * Handles WorkOS sign-in via app-held PKCE, mirroring the macOS app. The
+ * extension drives WorkOS User Management directly:
  *
- * The existing Django endpoint at `/accounts/chrome-extension/start`
- * handles the full flow: login → assistant ownership check → guardian
- * token mint → redirect with token. However, it requires an
- * `assistant_id` upfront, so the login flow is two-phase:
+ *   1. Discover the public WorkOS client id from the platform's headless
+ *      allauth config (`/_allauth/app/v1/config`).
+ *   2. Generate an S256 PKCE pair with Web Crypto.
+ *   3. Authorize via `chrome.identity.launchWebAuthFlow`, which terminates on
+ *      a `chromiumapp.org` redirect URL that Chrome intercepts and returns to
+ *      the extension.
+ *   4. Exchange the authorization code at WorkOS as a public client.
+ *   5. Swap the WorkOS access token for a platform session token via allauth's
+ *      headless provider-token endpoint (`meta.session_token`, the Django
+ *      session key).
  *
- *   1. Fetch assistants via the headless allauth session API
- *   2. User picks an assistant in the popup
- *   3. `launchWebAuthFlow` with the selected assistant_id
+ * The resulting session token is stored in `chrome.storage.local` and sent as
+ * `X-Session-Token` on platform API calls (SameSite=Lax prevents session
+ * cookies from being sent cross-site from the extension service worker).
  *
- * For now, we use a simpler approach: `launchWebAuthFlow` opens the
- * platform login page. After auth completes, the extension's session
- * cookie grants access to the assistants API. The popup then shows the
- * assistant picker.
+ * The legacy `/accounts/chrome-extension/start` Django endpoint is no longer
+ * used by this client; it remains alive server-side for older extension
+ * versions.
  */
 
 import { fetchOrganizationId } from './cloud-api.js';
 import type { ExtensionEnvironment } from './extension-environment.js';
 import { cloudUrlsForEnvironment } from './extension-environment.js';
+import {
+  buildAuthorizeUrl,
+  exchangeAccessTokenForSession,
+  exchangeCodeWithWorkos,
+  fetchWorkosClientId,
+  generatePkcePair,
+  generateState,
+  parseRedirectUrl,
+} from './workos-pkce.js';
+
+/**
+ * Path component of the `chromiumapp.org` redirect URI.
+ *
+ * Resolves to `https://<extension-id>.chromiumapp.org/cloud-auth`. This exact
+ * URL MUST be registered as a redirect on the WorkOS User Management app per
+ * environment — see this package's README "WorkOS redirect URIs" section.
+ */
+const REDIRECT_PATH = 'cloud-auth';
+
+/**
+ * Thrown when the user dismisses the auth window. `launchWebAuthFlow`'s
+ * promise rejects (rather than resolving undefined) on cancel; callers
+ * should treat this as a no-op rather than a login failure.
+ */
+export class CloudLoginCancelledError extends Error {
+  constructor() {
+    super('Login cancelled.');
+    this.name = 'CloudLoginCancelledError';
+  }
+}
+
+/** launchWebAuthFlow rejection messages that mean "user dismissed the window". */
+const CANCEL_PATTERN = /did not approve|cancell?ed|closed the window/i;
 
 // ── Storage keys ────────────────────────────────────────────────────
 
@@ -40,10 +75,11 @@ export interface CloudSession {
   /** The user's active organization ID (first org from the API). */
   organizationId: string | null;
   /**
-   * Allauth session token (= Django session key) returned by the OAuth
-   * callback in the URL fragment.  Sent as X-Session-Token on platform API
-   * calls because SameSite=Lax prevents session cookies from being sent
-   * cross-site from the extension service worker.
+   * Allauth session token (= Django session key) obtained by exchanging the
+   * WorkOS access token at the headless provider-token endpoint.  Sent as
+   * X-Session-Token on platform API calls because SameSite=Lax prevents
+   * session cookies from being sent cross-site from the extension service
+   * worker.
    */
   sessionToken?: string;
   /** Timestamp when the session was created. */
@@ -116,77 +152,86 @@ export async function clearSelectedAssistant(): Promise<void> {
 // ── Login flow ──────────────────────────────────────────────────────
 
 /**
- * Initiate WorkOS login via `chrome.identity.launchWebAuthFlow`.
+ * Initiate WorkOS sign-in via app-held PKCE.
  *
- * Uses the existing `/accounts/chrome-extension/start` Django endpoint
- * which handles: login_required → WorkOS OAuth → session → redirect
- * back to the chromiumapp.org callback URL with auth result.
+ * Discovers the public WorkOS client id, runs the PKCE authorize flow through
+ * `chrome.identity.launchWebAuthFlow`, exchanges the code at WorkOS as a public
+ * client, then swaps the access token for a platform session token. The session
+ * token is stored and used as `X-Session-Token` on platform API calls.
  *
- * We pass `redirect_uri` and `client_id` as required by the endpoint.
- * Since we don't have an `assistant_id` yet (user hasn't picked one),
- * we omit it — the endpoint will return an error fragment, but the
- * important thing is the user's Django session is now authenticated.
- * We catch the error and proceed to fetch assistants.
+ * Mirrors the macOS app's `workos-pkce` flow; the redirect transport is a
+ * `chromiumapp.org` URL Chrome intercepts rather than a loopback listener.
  */
 export async function startCloudLogin(
   environment: ExtensionEnvironment,
 ): Promise<CloudSession> {
   const { apiBaseUrl } = cloudUrlsForEnvironment(environment);
 
-  // The redirect URI that Chrome intercepts after the flow completes.
-  const redirectUri = chrome.identity.getRedirectURL('cloud-auth');
+  // The redirect URI Chrome intercepts when WorkOS redirects back. This exact
+  // URL must be registered on the WorkOS UM app for `environment` — see README.
+  const redirectUri = chrome.identity.getRedirectURL(REDIRECT_PATH);
 
-  // Build the login URL using the Django chrome-extension start endpoint.
-  // The endpoint lives on the API host (Django), not the web frontend.
-  // Flow: Django @login_required → WorkOS OAuth → redirect back → validate
-  //       → redirect to chromiumapp.org callback URL.
-  const loginUrl = new URL('/accounts/chrome-extension/start', apiBaseUrl);
-  loginUrl.searchParams.set('redirect_uri', redirectUri);
-  loginUrl.searchParams.set('client_id', 'vellum-chrome-extension');
+  // 1. Discover the public WorkOS client id from the platform's headless config.
+  const clientId = await fetchWorkosClientId(apiBaseUrl);
+
+  // 2. Generate the PKCE pair and CSRF state.
+  const { verifier, challenge } = await generatePkcePair();
+  const state = generateState();
+
+  // 3. Authorize via WorkOS in the browser; Chrome returns the redirect URL.
+  const authorizeUrl = buildAuthorizeUrl({
+    clientId,
+    redirectUri,
+    challenge,
+    state,
+  });
 
   let resultUrl: string | undefined;
   try {
     resultUrl = await chrome.identity.launchWebAuthFlow({
-      url: loginUrl.toString(),
+      url: authorizeUrl,
       interactive: true,
     });
   } catch (err) {
-    throw new Error(
-      `Login failed: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    // The promise form rejects on cancel/error (it never resolves
+    // undefined — that's the callback form). Surface a user-initiated
+    // cancel distinctly so the caller treats it as a no-op.
+    const message = err instanceof Error ? err.message : String(err);
+    if (CANCEL_PATTERN.test(message)) {
+      throw new CloudLoginCancelledError();
+    }
+    throw new Error(`Login failed: ${message}`);
   }
 
+  // The promise form resolves a string on success; the typed signature
+  // still permits undefined, so narrow it (and treat that as a cancel).
   if (!resultUrl) {
-    throw new Error('Login was cancelled.');
+    throw new CloudLoginCancelledError();
   }
 
-  // The result URL may contain an error fragment (e.g. missing_assistant_id)
-  // because we didn't pass assistant_id. That's fine — the user's session
-  // is now authenticated. Parse the session token and email from the fragment.
-  const fragment = new URL(resultUrl).hash.slice(1);
-  const fragmentParams = new URLSearchParams(fragment);
+  // 4. Parse + verify the authorization code (state CSRF check inside).
+  const { code } = parseRedirectUrl(resultUrl, state);
 
-  // Check for auth-level errors (not missing_assistant_id, which is expected)
-  const error = fragmentParams.get('error');
-  if (error && error !== 'missing_assistant_id') {
-    const desc = fragmentParams.get('error_description') ?? error;
-    throw new Error(`Login failed: ${desc}`);
-  }
+  // 5. Exchange the code at WorkOS as a public client → access token.
+  const accessToken = await exchangeCodeWithWorkos({ clientId, code, verifier });
 
-  // The OAuth callback returns the allauth session token and user email in
-  // the fragment.  The token is required because SameSite=Lax session cookies
-  // are not sent cross-site from the extension service worker.
-  const sessionToken = fragmentParams.get('session_token') ?? undefined;
-  let email = fragmentParams.get('email') ?? 'signed in';
+  // 6. Swap the WorkOS access token for a platform session token.
+  const { sessionToken, email: exchangedEmail } =
+    await exchangeAccessTokenForSession(apiBaseUrl, clientId, accessToken);
 
-  // Fall back to the allauth session API if the fragment didn't include an
-  // email (e.g. against older platform deployments).
+  let email = exchangedEmail ?? 'signed in';
+
+  // Fall back to the allauth session API if the token exchange didn't include
+  // an email (e.g. against older platform deployments).
   if (email === 'signed in') {
     try {
-      const sessionResponse = await fetch(`${apiBaseUrl}/_allauth/browser/v1/auth/session`, {
-        credentials: 'include',
-        headers: { Accept: 'application/json' },
-      });
+      const sessionResponse = await fetch(
+        `${apiBaseUrl}/_allauth/browser/v1/auth/session`,
+        {
+          credentials: 'include',
+          headers: { Accept: 'application/json' },
+        },
+      );
       if (sessionResponse.ok) {
         const sessionData = (await sessionResponse.json()) as {
           data?: { user?: { email?: string } };

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -45,6 +45,7 @@ import { appendEvent, clearEventLog, getEventLog, getOperations, getOperationByI
 import { getClientId } from "./client-identity.js";
 import {
   startCloudLogin,
+  CloudLoginCancelledError,
   getStoredSession,
   clearSession,
   getSelectedAssistant,
@@ -1365,12 +1366,17 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
         assistants,
         assistantsError,
       });
-    })().catch((err) =>
+    })().catch((err) => {
+      // User dismissed the auth window — not an error, just a no-op.
+      if (err instanceof CloudLoginCancelledError) {
+        sendResponseFn({ ok: false, cancelled: true });
+        return;
+      }
       sendResponseFn({
         ok: false,
         error: err instanceof Error ? err.message : String(err),
-      }),
-    );
+      });
+    });
     return true; // async
   }
 

--- a/clients/chrome-extension/background/workos-pkce.ts
+++ b/clients/chrome-extension/background/workos-pkce.ts
@@ -1,0 +1,237 @@
+/**
+ * App-held PKCE login against WorkOS User Management for the Chrome extension.
+ * Mirrors Electron + CLI implementations, with two adaptations for the
+ * extension service worker:
+ *   - PKCE hashing uses Web Crypto (`crypto.subtle`), not Node's `crypto`.
+ *   - The redirect is captured by `chrome.identity.launchWebAuthFlow`,
+ *     not a loopback HTTP server.
+ */
+
+const WORKOS_API_BASE_URL = 'https://api.workos.com';
+const PROVIDER_ID = 'workos';
+const SCOPE = 'openid profile email';
+
+// ── PKCE ────────────────────────────────────────────────────────────
+
+export interface PkcePair {
+  verifier: string;
+  challenge: string;
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/** S256 PKCE pair via Web Crypto */
+export async function generatePkcePair(): Promise<PkcePair> {
+  const verifierBytes = new Uint8Array(32);
+  crypto.getRandomValues(verifierBytes);
+  const verifier = base64UrlEncode(verifierBytes);
+
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(verifier),
+  );
+  const challenge = base64UrlEncode(new Uint8Array(digest));
+
+  return { verifier, challenge };
+}
+
+/** Generate a random URL-safe state token for CSRF protection. */
+export function generateState(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return base64UrlEncode(bytes);
+}
+
+// ── Authorize URL ───────────────────────────────────────────────────
+
+export interface AuthorizeUrlOptions {
+  clientId: string;
+  redirectUri: string;
+  challenge: string;
+  state: string;
+  loginHint?: string;
+  providerHint?: string;
+  intent?: string;
+}
+
+export function buildAuthorizeUrl(options: AuthorizeUrlOptions): string {
+  const url = new URL('/user_management/authorize', WORKOS_API_BASE_URL);
+  url.searchParams.set('client_id', options.clientId);
+  url.searchParams.set('redirect_uri', options.redirectUri);
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set('scope', SCOPE);
+  url.searchParams.set('code_challenge', options.challenge);
+  url.searchParams.set('code_challenge_method', 'S256');
+  url.searchParams.set('state', options.state);
+  // No `prompt`: lets the browser's existing IdP session be reused.
+  url.searchParams.set('provider', options.providerHint || 'authkit');
+  if (options.loginHint) url.searchParams.set('login_hint', options.loginHint);
+  if (options.intent === 'signup') url.searchParams.set('screen_hint', 'sign-up');
+  return url.toString();
+}
+
+// ── Redirect parsing ────────────────────────────────────────────────
+
+export interface ParsedRedirect {
+  code: string;
+  state: string;
+}
+
+export function parseRedirectUrl(
+  redirectUrl: string,
+  expectedState: string,
+): ParsedRedirect {
+  const url = new URL(redirectUrl);
+  // WorkOS returns params in the query string of the redirect URL.
+  const params = url.searchParams;
+
+  const error = params.get('error');
+  if (error) {
+    const description = params.get('error_description') ?? error;
+    throw new Error(`Authentication failed: ${description}`);
+  }
+
+  const code = params.get('code');
+  const state = params.get('state');
+  if (!code) {
+    throw new Error('Authentication failed: no authorization code received.');
+  }
+  if (!state || state !== expectedState) {
+    throw new Error('Authentication failed: state mismatch (possible CSRF).');
+  }
+
+  return { code, state };
+}
+
+// ── Headless config discovery ───────────────────────────────────────
+
+export interface HeadlessProviderEntry {
+  id: string;
+  name?: string;
+  client_id?: string;
+  flows?: string[];
+  openid_configuration_url?: string;
+}
+
+/**
+ * Pick the OAuth2 WorkOS provider from the headless config. During the
+ * coexistence window two entries share the "workos-oidc" id; the usable one
+ * has token auth and no OIDC discovery URL. Null if none.
+ */
+export function selectWorkosClientId(
+  providers: HeadlessProviderEntry[],
+): string | null {
+  const entry = providers.find(
+    (p) =>
+      !p.openid_configuration_url &&
+      (p.flows ?? []).includes('provider_token') &&
+      typeof p.client_id === 'string',
+  );
+  return entry?.client_id ?? null;
+}
+
+export async function fetchWorkosClientId(platformUrl: string): Promise<string> {
+  const url = `${new URL(platformUrl).origin}/_allauth/app/v1/config`;
+  const response = await fetch(url, { headers: { Accept: 'application/json' } });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch auth config (${response.status}).`);
+  }
+  const body = (await response.json()) as {
+    data?: { socialaccount?: { providers?: HeadlessProviderEntry[] } };
+  };
+  const clientId = selectWorkosClientId(
+    body.data?.socialaccount?.providers ?? [],
+  );
+  if (!clientId) {
+    throw new Error(
+      'Platform does not advertise a token-auth WorkOS provider; cannot start PKCE login.',
+    );
+  }
+  return clientId;
+}
+
+// ── Code exchange (WorkOS, public client) ───────────────────────────
+
+/** Exchange the authorization code at WorkOS as a public client. */
+export async function exchangeCodeWithWorkos(options: {
+  clientId: string;
+  code: string;
+  verifier: string;
+}): Promise<string> {
+  const response = await fetch(
+    `${WORKOS_API_BASE_URL}/user_management/authenticate`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({
+        client_id: options.clientId,
+        grant_type: 'authorization_code',
+        code: options.code,
+        code_verifier: options.verifier,
+      }),
+    },
+  );
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`WorkOS code exchange failed (${response.status}): ${body}`);
+  }
+  const data = (await response.json()) as { access_token?: string };
+  if (!data.access_token) {
+    throw new Error('WorkOS code exchange returned no access token.');
+  }
+  return data.access_token;
+}
+
+// ── Session exchange (platform allauth headless token endpoint) ─────
+
+export interface SessionExchangeResult {
+  /** Platform session token. */
+  sessionToken: string;
+  /** The user's email, if the platform returned it. */
+  email?: string;
+}
+
+/** Exchange the WorkOS access token for a platform session token (+ email if present). */
+export async function exchangeAccessTokenForSession(
+  platformUrl: string,
+  clientId: string,
+  accessToken: string,
+): Promise<SessionExchangeResult> {
+  const url = `${new URL(platformUrl).origin}/_allauth/app/v1/auth/provider/token`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify({
+      provider: PROVIDER_ID,
+      process: 'login',
+      token: { client_id: clientId, access_token: accessToken },
+    }),
+  });
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`Session exchange failed (${response.status}): ${body}`);
+  }
+  const data = (await response.json()) as {
+    meta?: { session_token?: string };
+    data?: { user?: { email?: string } };
+  };
+  if (!data.meta?.session_token) {
+    throw new Error('Session exchange returned no session token.');
+  }
+  return {
+    sessionToken: data.meta.session_token,
+    email: data.data?.user?.email,
+  };
+}

--- a/clients/chrome-extension/popup/App.tsx
+++ b/clients/chrome-extension/popup/App.tsx
@@ -119,10 +119,15 @@ export function App() {
       assistants?: CloudAssistant[];
       assistantsError?: string;
       error?: string;
+      cancelled?: boolean;
     }>({ type: 'cloud-login' }).then((response) => {
       setSigningIn(false);
 
       if (!response?.ok) {
+        // User dismissed the auth window — return to the idle state quietly.
+        if (response?.cancelled) {
+          return;
+        }
         setSignInError(response?.error ?? 'Sign-in failed. Please try again.');
         return;
       }

--- a/clients/chrome-extension/types/bun-test-shim.d.ts
+++ b/clients/chrome-extension/types/bun-test-shim.d.ts
@@ -52,6 +52,7 @@ declare module 'bun:test' {
     toBeLessThan(expected: number): R;
     toBeLessThanOrEqual(expected: number): R;
     toBeString(): R;
+    toMatch(expected: string | RegExp): R;
     toContain(expected: unknown): R;
     toHaveProperty(path: string, value?: unknown): R;
     not: Matchers<R>;


### PR DESCRIPTION
ref: ATL-842

Migrates the extension's cloud login from the server-mediated `/accounts/chrome-extension/start` flow to app-held WorkOS PKCE, mirroring the Electron/CLI clients.

- New `workos-pkce.ts` (pure: PKCE via Web Crypto, authorize URL, redirect parse with state/CSRF check, config discovery, code + session exchanges). `cloud-auth.ts` drives it through `chrome.identity.launchWebAuthFlow` (Chrome intercepts the `chromiumapp.org` redirect) and stores the session token unchanged in `chrome.storage.local` (`vellum.cloudSession`, sent as `X-Session-Token`).
- User-dismissed auth window is treated as a no-op (not an error toast).

**Requires** (WorkOS UM app, per env): register `https://<ext-id>.chromiumapp.org/cloud-auth` — prod `hphbdmpff…`, staging `idpcnibf…`, dev `kajfcoae…`, local `gfcldmjj…`. Login fails at authorize until registered. **Depends on** #8401 (live).

**Checks:** typecheck + eslint clean; 180 background tests pass (22 new). End-to-end not exercised here — manual QA: load unpacked, sign in, confirm authorize hits `api.workos.com/user_management/authorize` and the session lands. Server `/accounts/chrome-extension/start` untouched for old versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)