### PR TITLE
refactor(flags): rename activation-flow personal-page arm to a semantic value

### DIFF
--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -39,9 +39,9 @@
       "scope": "both",
       "key": "experiment-activation-flow-2026-06-03",
       "label": "Activation Flow Experiment 2026-06-03",
-      "description": "Multivariate activation-flow experiment. control = standard flow; variant-a = activation rail; variant-b = preseeded personal-page app (read by the daemon, hence scope \"both\"). Targeted via LaunchDarkly.",
+      "description": "Multivariate activation-flow experiment. control = standard flow; variant-a = activation rail; personal-page = preseeded personal-page app (read by the daemon, hence scope \"both\"). Targeted via LaunchDarkly.",
       "defaultEnabled": "control",
-      "values": ["control", "variant-a", "variant-b"]
+      "values": ["control", "variant-a", "personal-page"]
     },
     {
       "id": "local-docker-enabled",

--- a/assistant/src/memory/preloaded-apps.ts
+++ b/assistant/src/memory/preloaded-apps.ts
@@ -42,7 +42,7 @@ export const PERSONAL_PAGE_APP_ID = "personal-page";
 export const ACTIVATION_FLOW_FLAG = "experiment-activation-flow-2026-06-03";
 
 /** Arm of the activation-flow experiment that gets the preseeded page. */
-export const PERSONAL_PAGE_ARM = "variant-b";
+export const PERSONAL_PAGE_ARM = "personal-page";
 
 export async function seedPreloadedApps(
   config: AssistantConfig,

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -39,9 +39,9 @@
       "scope": "both",
       "key": "experiment-activation-flow-2026-06-03",
       "label": "Activation Flow Experiment 2026-06-03",
-      "description": "Multivariate activation-flow experiment. control = standard flow; variant-a = activation rail; variant-b = preseeded personal-page app (read by the daemon, hence scope \"both\"). Targeted via LaunchDarkly.",
+      "description": "Multivariate activation-flow experiment. control = standard flow; variant-a = activation rail; personal-page = preseeded personal-page app (read by the daemon, hence scope \"both\"). Targeted via LaunchDarkly.",
       "defaultEnabled": "control",
-      "values": ["control", "variant-a", "variant-b"]
+      "values": ["control", "variant-a", "personal-page"]
     },
     {
       "id": "local-docker-enabled",


### PR DESCRIPTION
Part of JARVIS-1167 — follow-up to #34549.

The new activation-flow arm was named `variant-b` per the letter-sequence convention of the existing arms. The variation doesn't exist in LaunchDarkly yet and nothing live reads the value, so this renames it to **`personal-page`** while the rename is still free — semantic arm values are self-documenting in dashboards, telemetry queries (`flag_assignment_raw`), and code.

- `PERSONAL_PAGE_ARM` constant in the seeder: `"variant-b"` → `"personal-page"`
- Registry `values` + description updated; bundled copies re-synced via `meta/feature-flags/sync-bundled-copies.ts`
- The live `variant-a` arm keeps its name (web code compares the literal; renaming it would break experiment continuity)

When creating the variation in the LaunchDarkly dashboard, use `personal-page`.

## Testing

- `preloaded-apps`, registry guard, and bundled-copy tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)