### PR TITLE
fix(memory): retrospective review fixes — GC ownership, gate alignment, consolidation

### DIFF
--- a/assistant/src/config/schemas/memory-retrospective.ts
+++ b/assistant/src/config/schemas/memory-retrospective.ts
@@ -45,7 +45,7 @@ export const MemoryRetrospectiveConfigSchema = z
       })
       .default(false)
       .describe(
-        "When false (default), superseded retrospective conversations are deleted once a newer run succeeds — dedup only ever reads the most recent run via findMostRecentRetrospectiveFor, so older runs are dead weight (fork-based runs each carry a full copy of the source conversation's messages). Operators who want to retain the full run history set this to true; retained runs also skip the startup orphan sweep so they survive restarts.",
+        "When false (default), superseded retrospective conversations are deleted once a newer run succeeds — the persisted remembered_log on memory_retrospective_state is the dedup baseline (the most recent run is scanned only as a fallback for state rows that predate the log column), so older runs are dead weight (fork-based runs each carry a full copy of the source conversation's messages). Operators who want to retain the full run history set this to true; retained runs also skip the startup orphan sweep so they survive restarts.",
       ),
 
     matchConversationProfile: z

--- a/assistant/src/memory/__tests__/find-most-recent-retrospective-for.test.ts
+++ b/assistant/src/memory/__tests__/find-most-recent-retrospective-for.test.ts
@@ -66,7 +66,10 @@ describe("findMostRecentRetrospectiveFor", () => {
     const conv = createConversation("conv");
     const retro = createRetro(conv.id, 1_000);
 
-    expect(findMostRecentRetrospectiveFor(conv.id)).toEqual({ id: retro.id });
+    expect(findMostRecentRetrospectiveFor(conv.id)).toEqual({
+      id: retro.id,
+      forkParentConversationId: conv.id,
+    });
   });
 
   test("returns the most recently created retrospective when multiple exist at the same level", () => {
@@ -75,7 +78,10 @@ describe("findMostRecentRetrospectiveFor", () => {
     const newer = createRetro(conv.id, 2_000);
     createRetro(conv.id, 500);
 
-    expect(findMostRecentRetrospectiveFor(conv.id)).toEqual({ id: newer.id });
+    expect(findMostRecentRetrospectiveFor(conv.id)).toEqual({
+      id: newer.id,
+      forkParentConversationId: conv.id,
+    });
   });
 
   test("walks up the fork chain when the current conversation has no retros", () => {
@@ -87,6 +93,8 @@ describe("findMostRecentRetrospectiveFor", () => {
 
     expect(findMostRecentRetrospectiveFor(fork.id)).toEqual({
       id: parentRetro.id,
+      // Owned by the PARENT — callers must not GC it on the fork's behalf.
+      forkParentConversationId: parent.id,
     });
   });
 
@@ -100,6 +108,7 @@ describe("findMostRecentRetrospectiveFor", () => {
 
     expect(findMostRecentRetrospectiveFor(fork.id)).toEqual({
       id: forkRetro.id,
+      forkParentConversationId: fork.id,
     });
   });
 
@@ -115,6 +124,7 @@ describe("findMostRecentRetrospectiveFor", () => {
 
     expect(findMostRecentRetrospectiveFor(fork.id)).toEqual({
       id: grandparentRetro.id,
+      forkParentConversationId: grandparent.id,
     });
   });
 

--- a/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
@@ -35,8 +35,13 @@ let newMessages: Array<{
   metadata?: string | null;
 }> = [];
 
-// Prior retrospective conversation + messages.
+// Prior retrospective conversation + messages. `priorRetroOwnerId` is the
+// fork-chain conversation the prior is rooted at — `findMostRecentRetrospectiveFor`
+// returns it so the GC ownership check can tell "this source's own prior"
+// (default: the job's source conversation) from an ANCESTOR's preserved
+// baseline reached by the chain walk.
 let priorRetroId: string | null = null;
+let priorRetroOwnerId = "src-conv-1";
 let priorRetroMessages: Array<{ role: string; content: string }> = [];
 
 let mockWakeResult: { invoked: boolean; reason?: string } = { invoked: true };
@@ -136,7 +141,9 @@ mock.module("../conversation-crud.js", () => ({
     return [];
   },
   findMostRecentRetrospectiveFor: (_id: string) =>
-    priorRetroId ? { id: priorRetroId } : null,
+    priorRetroId
+      ? { id: priorRetroId, forkParentConversationId: priorRetroOwnerId }
+      : null,
   // The fork path calls `getConversation(sourceConversationId)` to read the
   // source's title for the fork title. `collectPriorRetrospectiveRemembers`
   // also calls it with the prior retro id to discriminate legacy vs fork
@@ -379,6 +386,7 @@ describe("memoryRetrospectiveJob", () => {
       { id: "m3", createdAt: Date.parse("2026-05-11T10:10:00Z") },
     ];
     priorRetroId = null;
+    priorRetroOwnerId = "src-conv-1";
     priorRetroMessages = [];
     mockWakeResult = { invoked: true };
     mockWakeThrows = null;
@@ -760,7 +768,7 @@ describe("memoryRetrospectiveJob", () => {
     expect("toolGateMode" in wakeCalls[0]!.opts).toBe(false);
   });
 
-  test("fork path: matchConversationProfile on but source has no inferenceProfile → wake carries no forceOverrideProfile", async () => {
+  test("fork path: matchConversationProfile on but source has no inferenceProfile → wire mode, no forceOverrideProfile", async () => {
     forkFlagEnabled = true;
 
     await memoryRetrospectiveJob(
@@ -770,13 +778,15 @@ describe("memoryRetrospectiveJob", () => {
 
     expect(wakeCalls).toHaveLength(1);
     expect("forceOverrideProfile" in wakeCalls[0]!.opts).toBe(false);
-    // toolGateMode is gated on the config flag, not on a resolved profile:
-    // without a pinned profile the source's turns ran the call-site default,
-    // and keeping the full tool surface still preserves that cached prefix.
-    expect(wakeCalls[0]!.opts.toolGateMode).toBe("execution");
+    // toolGateMode keys on the RESOLVED profile match, not the bare config
+    // flag: with no pinned profile the wake runs the call-site default
+    // model, so there is no source cache to preserve — shipping the full
+    // tool surface would pay wire cost for nothing. Wire mode (absent
+    // toolGateMode) keeps the smaller filtered request.
+    expect("toolGateMode" in wakeCalls[0]!.opts).toBe(false);
   });
 
-  test("fork path: matchConversationProfile on but the profile session expired → wake carries no forceOverrideProfile", async () => {
+  test("fork path: matchConversationProfile on but the profile session expired → wire mode, no forceOverrideProfile", async () => {
     forkFlagEnabled = true;
     conversationOverrides["src-conv-1"] = {
       source: "user",
@@ -794,6 +804,7 @@ describe("memoryRetrospectiveJob", () => {
 
     expect(wakeCalls).toHaveLength(1);
     expect("forceOverrideProfile" in wakeCalls[0]!.opts).toBe(false);
+    expect("toolGateMode" in wakeCalls[0]!.opts).toBe(false);
   });
 
   test("fork path: local/vellum source → wake carries the guardian persona + vellum channel override", async () => {
@@ -1183,6 +1194,32 @@ describe("memoryRetrospectiveJob", () => {
 
     expect(outcome.kind).toBe("wake_failed");
     expect(deletedConversationIds).toEqual(["fork-conv-1"]);
+  });
+
+  // Regression test: `findMostRecentRetrospectiveFor` walks up the fork
+  // chain, so when the source is a user-created fork with no retrospectives
+  // of its own, the prior resolves to the PARENT conversation's most-recent
+  // retrospective. GC must not delete it — it is the parent's preserved
+  // dedup baseline, and destroying it would force the parent's next
+  // retrospective to re-save everything.
+  test("success does NOT delete a prior owned by an ancestor conversation, but still seeds dedup from it (both kinds)", async () => {
+    priorRetroId = "parent-retro-conv-1";
+    priorRetroOwnerId = "parent-conv-0"; // not the job's source ("src-conv-1")
+    priorRetroMessages = [priorRetroMessage(["parent's preserved save"])];
+
+    // Legacy kind.
+    let outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+    expect(outcome.kind).toBe("invoked");
+    expect(deletedConversationIds).toEqual([]);
+    // Dedup still seeds from the ancestor's retro.
+    expect(wakeCalls[0]!.hint).toContain("- parent's preserved save");
+
+    // Fork kind.
+    forkFlagEnabled = true;
+    outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+    expect(outcome.kind).toBe("invoked");
+    expect(deletedConversationIds).toEqual([]);
+    expect(persistedInstructionText()).toContain("- parent's preserved save");
   });
 
   test("keepSupersededRuns=true retains the prior retrospective on success (both kinds)", async () => {

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -731,6 +731,13 @@ export function findAnalysisConversationFor(
  * Once the fork accumulates its own retros, those are found at the first
  * iteration and we never walk up.
  *
+ * The returned `forkParentConversationId` is the conversation the
+ * retrospective row is rooted at — `parentConversationId` itself when it has
+ * its own retros, or an ancestor when the chain walk found the row higher
+ * up. Callers that mutate the prior (e.g. GC of superseded runs) must check
+ * it against the source conversation: an ancestor's row is that ancestor's
+ * dedup baseline, not the caller's to delete.
+ *
  * Returns `null` when no prior retrospective exists anywhere in the fork
  * chain (true first-run case).
  *
@@ -741,7 +748,7 @@ const MAX_FORK_CHAIN_DEPTH = 16;
 
 export function findMostRecentRetrospectiveFor(
   parentConversationId: string,
-): { id: string } | null {
+): { id: string; forkParentConversationId: string } | null {
   const db = getDb();
   let currentId: string | null = parentConversationId;
   for (let depth = 0; depth < MAX_FORK_CHAIN_DEPTH && currentId; depth++) {
@@ -757,7 +764,7 @@ export function findMostRecentRetrospectiveFor(
       .orderBy(desc(conversations.createdAt))
       .limit(1)
       .get();
-    if (row) return { id: row.id };
+    if (row) return { id: row.id, forkParentConversationId: currentId };
 
     const parent = db
       .select({

--- a/assistant/src/memory/memory-retrospective-constants.ts
+++ b/assistant/src/memory/memory-retrospective-constants.ts
@@ -25,6 +25,15 @@ export const MEMORY_RETROSPECTIVE_SOURCES: readonly string[] = [
 ];
 
 /**
+ * Whether a conversation `source` value marks a memory-retrospective
+ * background conversation (either kind). Shared predicate for the recursion
+ * and auto-analysis guards.
+ */
+export function isMemoryRetrospectiveSource(source: string): boolean {
+  return MEMORY_RETROSPECTIVE_SOURCES.includes(source);
+}
+
+/**
  * Dedicated `group_id` value for memory-retrospective background
  * conversations. Placed under `system:background` alongside auto-analysis,
  * heartbeat, and filing conversations.

--- a/assistant/src/memory/memory-retrospective-enqueue.ts
+++ b/assistant/src/memory/memory-retrospective-enqueue.ts
@@ -19,11 +19,8 @@ import {
 } from "../runtime/actor-trust-resolver.js";
 import { getLogger } from "../util/logger.js";
 import { getConversationSource } from "./conversation-crud.js";
-import {
-  isMemoryEnabled,
-  upsertMemoryRetrospectiveJob,
-} from "./jobs-store.js";
-import { MEMORY_RETROSPECTIVE_SOURCES } from "./memory-retrospective-constants.js";
+import { isMemoryEnabled, upsertMemoryRetrospectiveJob } from "./jobs-store.js";
+import { isMemoryRetrospectiveSource } from "./memory-retrospective-constants.js";
 
 const log = getLogger("memory-retrospective-enqueue");
 
@@ -75,7 +72,7 @@ export function isMemoryRetrospectiveConversation(
   conversationId: string,
 ): boolean {
   const source = getConversationSource(conversationId);
-  return source !== null && MEMORY_RETROSPECTIVE_SOURCES.includes(source);
+  return source !== null && isMemoryRetrospectiveSource(source);
 }
 
 /**

--- a/assistant/src/memory/memory-retrospective-fork-boundary.ts
+++ b/assistant/src/memory/memory-retrospective-fork-boundary.ts
@@ -8,6 +8,12 @@
 // next run's dedup baseline). Lives in its own module so the sweep doesn't
 // have to import the job handler's full dependency graph.
 
+import { getLogger } from "../util/logger.js";
+import { getMessages } from "./conversation-crud.js";
+import { MEMORY_RETROSPECTIVE_FORK_SOURCE } from "./memory-retrospective-constants.js";
+
+const log = getLogger("memory-retrospective-fork-boundary");
+
 /**
  * Locate the boundary timestamp between a fork-kind retrospective's copied
  * prefix and its post-fork tail. Scans from the end for the last message
@@ -40,4 +46,49 @@ export function findForkBoundaryCreatedAt(
     }
   }
   return null;
+}
+
+/**
+ * Load the messages a retrospective run produced itself, given the
+ * retrospective conversation's `source` kind:
+ *
+ *   - **Fork-kind** rows carry the full copied source prefix, so only the
+ *     post-fork tail (messages strictly after the fork boundary) counts —
+ *     scanning the whole row would attribute the source conversation's own
+ *     turns to the retrospective.
+ *   - **Legacy-kind** rows start empty, so every message is the run's own.
+ *
+ * Returns `null` when the run's output cannot be determined — message load
+ * failure, or a fork-kind row with no detectable boundary (corrupted fork
+ * metadata) — so callers degrade (empty dedup baseline / "no output").
+ * Best-effort: failures are logged, never thrown.
+ */
+export function loadRetrospectiveRunMessages(
+  conversationId: string,
+  source: string | null | undefined,
+): ReturnType<typeof getMessages> | null {
+  let messages: ReturnType<typeof getMessages>;
+  try {
+    messages = getMessages(conversationId);
+  } catch (err) {
+    log.warn(
+      { err, retrospectiveConversationId: conversationId },
+      "memory-retrospective: failed to load retrospective messages; treating run as having produced none",
+    );
+    return null;
+  }
+
+  if (source === MEMORY_RETROSPECTIVE_FORK_SOURCE) {
+    const boundaryCreatedAt = findForkBoundaryCreatedAt(messages);
+    if (boundaryCreatedAt == null) {
+      log.warn(
+        { retrospectiveConversationId: conversationId },
+        "memory-retrospective: fork-kind retrospective has no message with forkSourceMessageId metadata; treating run as having produced none",
+      );
+      return null;
+    }
+    return messages.filter((m) => m.createdAt > boundaryCreatedAt);
+  }
+
+  return messages;
 }

--- a/assistant/src/memory/memory-retrospective-job.ts
+++ b/assistant/src/memory/memory-retrospective-job.ts
@@ -62,7 +62,6 @@ import {
   findMostRecentRetrospectiveFor,
   forkConversation,
   getConversation,
-  getMessages,
   getMessagesAfter,
   resolveOverrideProfile,
 } from "./conversation-crud.js";
@@ -77,7 +76,7 @@ import {
   MEMORY_RETROSPECTIVE_INSTRUCTION_KIND,
   MEMORY_RETROSPECTIVE_SOURCE,
 } from "./memory-retrospective-constants.js";
-import { findForkBoundaryCreatedAt } from "./memory-retrospective-fork-boundary.js";
+import { loadRetrospectiveRunMessages } from "./memory-retrospective-fork-boundary.js";
 import {
   appendToRememberedLog,
   bumpRetrospectiveLastRunAt,
@@ -90,9 +89,12 @@ import {
  * transcript-based path (renders the new-message slice into a `<transcript>`
  * block and wakes an empty background conversation) and the new fork-based
  * path (forks the source through its latest message, persists a user-role
- * instruction, and wakes the fork). The fork path lets the retrospective hit
- * the provider prompt cache and read compaction summary + tail messages
- * natively.
+ * instruction, and wakes the fork). The fork path reads the conversation
+ * natively — including any inherited compaction summary + tail messages —
+ * instead of a lossy transcript render. Provider prompt-cache reuse
+ * additionally requires `memory.retrospective.matchConversationProfile`
+ * (cache parity: same model/thinking/tools/system as the source's own
+ * turns).
  */
 const MEMORY_RETROSPECTIVE_FORK_FLAG = "memory-retrospective-fork" as const;
 
@@ -173,13 +175,10 @@ async function runLegacyRetrospective(
   const cutoffMessageId = cutoffMessage.id;
 
   // 3. Locate the most recent prior retrospective and assemble the dedup
-  // baseline (persisted cumulative log, falling back to scanning the prior).
-  // Done BEFORE bootstrapping the new background conversation so the lookup
-  // doesn't accidentally include this run's own conversation. The prior's id
-  // is kept so the success path can GC it once this run supersedes it.
-  const prior = findMostRecentRetrospectiveFor(sourceConversationId);
-  const priorRemembers = collectPriorRetrospectiveRemembers(
-    prior,
+  // baseline. Done BEFORE bootstrapping the new background conversation so
+  // the lookup doesn't accidentally include this run's own conversation.
+  const { prior, priorRemembers } = resolvePriorRetrospective(
+    sourceConversationId,
     state?.rememberedLog ?? [],
   );
 
@@ -244,61 +243,28 @@ async function runLegacyRetrospective(
     );
   }
 
-  // 6. Update pointers. Extract this run's saves from its own background
-  // conversation FIRST — the wake's tail (including `remember` tool_use
-  // blocks) is persisted by the time `wakeAgentForOpportunity` returns, and
-  // extraction must precede any cleanup. `priorRemembers` (cumulative log,
-  // or the prior-conversation scan that seeds it) is the base so the prior's
-  // saves survive its GC below.
+  // 6. Update pointers + shared success bookkeeping.
   if (wakeSucceeded) {
-    const runRemembers = extractRetrospectiveRunRemembers(
-      backgroundConversation.id,
-    );
-    upsertRetrospectiveState({
-      conversationId: sourceConversationId,
-      lastProcessedMessageId: cutoffMessageId,
-      lastRunAt: Date.now(),
-      rememberedLog: appendToRememberedLog(priorRemembers, runRemembers),
-    });
-
-    deleteSupersededPriorRetrospective(config, prior);
-
-    const followUpJobIds = enqueueFollowUpJobs();
-
-    log.info(
-      {
-        sourceConversationId,
-        backgroundConversationId: backgroundConversation.id,
-        cutoffMessageId,
-        newMessageCount: newMessages.length,
-        priorRememberCount: priorRemembers.length,
-        kind: "legacy",
-      },
-      "memory-retrospective invoked",
-    );
-    return {
-      kind: "invoked",
-      backgroundConversationId: backgroundConversation.id,
+    return finalizeSuccessfulRetrospective({
+      config,
+      sourceConversationId,
+      retrospectiveConversationId: backgroundConversation.id,
       cutoffMessageId,
       newMessageCount: newMessages.length,
-      followUpJobIds,
-    };
+      prior,
+      priorRemembers,
+      logFields: { kind: "legacy" },
+    });
   }
 
   // Wake failed. Bump `lastRunAt` only so the cooldown gate applies, leave
   // `lastProcessedMessageId` alone so the next attempt re-processes the
-  // same messages.
+  // same messages. Then clean up the orphan background conversation.
   bumpRetrospectiveLastRunAt(sourceConversationId, Date.now());
-
-  // Clean up the orphan background conversation. Best-effort.
-  try {
-    deleteConversation(backgroundConversation.id);
-  } catch (err) {
-    log.warn(
-      { err, conversationId: backgroundConversation.id },
-      "memory-retrospective: failed to delete orphan background conversation; continuing",
-    );
-  }
+  safeDeleteRetrospectiveConversation(
+    backgroundConversation.id,
+    "memory-retrospective: failed to delete orphan background conversation; continuing",
+  );
 
   if (threw !== undefined) {
     // Rethrow for jobs-worker retry-with-backoff. `lastRunAt` is already
@@ -318,8 +284,11 @@ async function runLegacyRetrospective(
 // Fork-based path — fork the source through its latest message, persist a
 // user-role retrospective instruction at the tail, and wake the fork. The
 // fork inherits compaction state (summary + tail messages) via the existing
-// `forkConversation` machinery, and its prefix matches the source's prefix
-// so provider prompt caching hits.
+// `forkConversation` machinery, so the agent reads the conversation
+// natively. Provider prompt-cache reuse of the source's prefix additionally
+// requires `memory.retrospective.matchConversationProfile` — without it the
+// wake resolves the call-site default model, which never shares a cache with
+// the source's turns.
 // ---------------------------------------------------------------------------
 
 async function runForkBasedRetrospective(
@@ -388,14 +357,11 @@ async function runForkBasedRetrospective(
       timezoneContext.effectiveTimezone,
     );
 
-  // Locate the prior retrospective and assemble the dedup baseline
-  // (persisted cumulative log, falling back to scanning the prior) BEFORE
+  // Locate the prior retrospective and assemble the dedup baseline BEFORE
   // forking — otherwise `findMostRecentRetrospectiveFor` could locate this
-  // run's own fork. The prior's id is kept so the success path can GC it
-  // once this run supersedes it.
-  const prior = findMostRecentRetrospectiveFor(sourceConversationId);
-  const priorRemembers = collectPriorRetrospectiveRemembers(
-    prior,
+  // run's own fork.
+  const { prior, priorRemembers } = resolvePriorRetrospective(
+    sourceConversationId,
     state?.rememberedLog ?? [],
   );
 
@@ -452,7 +418,7 @@ async function runForkBasedRetrospective(
       { err, forkId, sourceConversationId },
       "memory-retrospective (fork): failed to persist instruction message",
     );
-    safeDeleteForkOnFailure(forkId);
+    safeDeleteRetrospectiveConversation(forkId, FORK_DELETE_FAILURE_WARNING);
     bumpRetrospectiveLastRunAt(sourceConversationId, Date.now());
     throw err;
   }
@@ -493,18 +459,21 @@ async function runForkBasedRetrospective(
       trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT,
       callSite: "memoryRetrospective",
       allowedTools: ["remember"],
-      // When matching the source's profile for cache parity, also keep the
-      // source's full tool surface on the wire: the provider cache prefix is
-      // `tools → system → messages`, so wire-filtering the tool array to
-      // ["remember"] would invalidate the cached prefix the profile match
-      // just preserved. The allowlist still holds — non-`remember` calls are
-      // rejected at execution time. Without profile matching there is no
-      // cache to preserve, and the smaller wire-filtered request is cheaper.
-      ...(config.memory.retrospective.matchConversationProfile
-        ? { toolGateMode: "execution" as const }
-        : {}),
+      // When the profile match actually resolved (cache parity is in play),
+      // also keep the source's full tool surface on the wire: the provider
+      // cache prefix is `tools → system → messages`, so wire-filtering the
+      // tool array to ["remember"] would invalidate the cached prefix the
+      // profile match just preserved. The allowlist still holds —
+      // non-`remember` calls are rejected at execution time. When the match
+      // resolves to nothing (no pinned profile / expired session) the wake
+      // runs the call-site default model, so there is no source cache to
+      // preserve and the smaller wire-filtered request is cheaper — keyed on
+      // `matchedProfile`, not the bare config flag.
       ...(matchedProfile !== undefined
-        ? { forceOverrideProfile: matchedProfile }
+        ? {
+            toolGateMode: "execution" as const,
+            forceOverrideProfile: matchedProfile,
+          }
         : {}),
       ...(personaOverride !== undefined ? { personaOverride } : {}),
       hintRole: "user",
@@ -527,46 +496,23 @@ async function runForkBasedRetrospective(
   }
 
   if (wakeSucceeded) {
-    // Extract this run's saves from the fork's post-fork tail FIRST — the
-    // wake's tail messages are persisted by the time `wakeAgentForOpportunity`
-    // returns, and extraction must precede any cleanup. `priorRemembers`
-    // (cumulative log, or the prior-conversation scan that seeds it) is the
-    // base so the prior's saves survive its GC below.
-    const runRemembers = extractRetrospectiveRunRemembers(forkId);
-    upsertRetrospectiveState({
-      conversationId: sourceConversationId,
-      lastProcessedMessageId: cutoffMessageId,
-      lastRunAt: Date.now(),
-      rememberedLog: appendToRememberedLog(priorRemembers, runRemembers),
-    });
-
-    deleteSupersededPriorRetrospective(config, prior);
-
-    const followUpJobIds = enqueueFollowUpJobs();
-
-    log.info(
-      {
-        sourceConversationId,
-        backgroundConversationId: forkId,
-        cutoffMessageId,
-        newMessageCount: newMessages.length,
-        priorRememberCount: priorRemembers.length,
-        windowStartTimestamp,
-        kind: "fork",
-      },
-      "memory-retrospective invoked",
-    );
-    return {
-      kind: "invoked",
-      backgroundConversationId: forkId,
+    return finalizeSuccessfulRetrospective({
+      config,
+      sourceConversationId,
+      retrospectiveConversationId: forkId,
       cutoffMessageId,
       newMessageCount: newMessages.length,
-      followUpJobIds,
-    };
+      prior,
+      priorRemembers,
+      logFields: { kind: "fork", windowStartTimestamp },
+    });
   }
 
+  // Wake failed. Bump `lastRunAt` only so the cooldown gate applies, leave
+  // `lastProcessedMessageId` alone so the next attempt re-processes the
+  // same messages. Then clean up the orphan fork.
   bumpRetrospectiveLastRunAt(sourceConversationId, Date.now());
-  safeDeleteForkOnFailure(forkId);
+  safeDeleteRetrospectiveConversation(forkId, FORK_DELETE_FAILURE_WARNING);
 
   if (threw !== undefined) {
     throw threw;
@@ -625,24 +571,128 @@ function resolveSourcePersonaOverride(
   };
 }
 
-function safeDeleteForkOnFailure(forkId: string): void {
+type PriorRetrospective = NonNullable<
+  ReturnType<typeof findMostRecentRetrospectiveFor>
+>;
+
+/**
+ * Locate the most recent prior retrospective and assemble the
+ * `<already_remembered>` dedup baseline (persisted cumulative log, falling
+ * back to scanning the prior). Callers must invoke this BEFORE creating this
+ * run's own retrospective conversation — otherwise the lookup could locate
+ * it. The prior row is returned so the success path can GC it once this run
+ * supersedes it.
+ */
+function resolvePriorRetrospective(
+  sourceConversationId: string,
+  rememberedLog: string[],
+): { prior: PriorRetrospective | null; priorRemembers: string[] } {
+  const prior = findMostRecentRetrospectiveFor(sourceConversationId);
+  return {
+    prior,
+    priorRemembers: collectPriorRetrospectiveRemembers(prior, rememberedLog),
+  };
+}
+
+/**
+ * Success bookkeeping shared by both handlers. Extracts this run's saves
+ * from its own retrospective conversation FIRST — the wake's tail (including
+ * `remember` tool_use blocks) is persisted by the time
+ * `wakeAgentForOpportunity` returns, and extraction must precede any
+ * cleanup. `priorRemembers` (cumulative log, or the prior-conversation scan
+ * that seeds it) is the base so the prior's saves survive its GC below.
+ */
+function finalizeSuccessfulRetrospective(args: {
+  config: AssistantConfig;
+  sourceConversationId: string;
+  retrospectiveConversationId: string;
+  cutoffMessageId: string;
+  newMessageCount: number;
+  prior: PriorRetrospective | null;
+  priorRemembers: string[];
+  /** Per-kind extras for the success log line (e.g. `kind`, fork anchor). */
+  logFields: Record<string, unknown>;
+}): MemoryRetrospectiveOutcome {
+  const {
+    config,
+    sourceConversationId,
+    retrospectiveConversationId,
+    cutoffMessageId,
+    newMessageCount,
+    prior,
+    priorRemembers,
+    logFields,
+  } = args;
+
+  const runRemembers = extractRetrospectiveRunRemembers(
+    retrospectiveConversationId,
+  );
+  upsertRetrospectiveState({
+    conversationId: sourceConversationId,
+    lastProcessedMessageId: cutoffMessageId,
+    lastRunAt: Date.now(),
+    rememberedLog: appendToRememberedLog(priorRemembers, runRemembers),
+  });
+
+  deleteSupersededPriorRetrospective(config, prior, sourceConversationId);
+
+  const followUpJobIds = enqueueFollowUpJobs();
+
+  log.info(
+    {
+      sourceConversationId,
+      backgroundConversationId: retrospectiveConversationId,
+      cutoffMessageId,
+      newMessageCount,
+      priorRememberCount: priorRemembers.length,
+      ...logFields,
+    },
+    "memory-retrospective invoked",
+  );
+  return {
+    kind: "invoked",
+    backgroundConversationId: retrospectiveConversationId,
+    cutoffMessageId,
+    newMessageCount,
+    followUpJobIds,
+  };
+}
+
+const FORK_DELETE_FAILURE_WARNING =
+  "memory-retrospective (fork): failed to delete fork on failure; continuing";
+
+/**
+ * Best-effort cleanup of this run's own retrospective conversation on a
+ * failure path. Deletion failure is logged with the caller-supplied warning
+ * and never escalates.
+ */
+function safeDeleteRetrospectiveConversation(
+  conversationId: string,
+  warnMessage: string,
+): void {
   try {
-    deleteConversation(forkId);
+    deleteConversation(conversationId);
   } catch (err) {
-    log.warn(
-      { err, forkId },
-      "memory-retrospective (fork): failed to delete fork on wake failure; continuing",
-    );
+    log.warn({ err, conversationId }, warnMessage);
   }
 }
 
 /**
  * GC the prior retrospective conversation once a newer run has succeeded.
- * Dedup only ever reads the most recent retrospective per source
- * (`findMostRecentRetrospectiveFor`), so the superseded run is dead weight —
- * and fork-kind runs each materialize a full copy of the source
+ * The persisted `remembered_log` on `memory_retrospective_state` is the
+ * dedup baseline (the most-recent run is scanned only as a fallback for
+ * state rows that predate the log column), and the success path has already
+ * folded the prior's saves into the log — so the superseded run is dead
+ * weight. Fork-kind runs each materialize a full copy of the source
  * conversation's message rows, so without GC a long-lived daemon accumulates
  * one full-history copy per retrospective interval per active conversation.
+ *
+ * Only deletes a prior the source conversation actually owns:
+ * `findMostRecentRetrospectiveFor` walks up the fork chain, so when the
+ * source is a user-created fork with no retrospectives of its own, the prior
+ * belongs to an ANCESTOR conversation. That row is the ancestor's preserved
+ * dedup-baseline fallback — deleting it could force the ancestor's next
+ * retrospective to re-save facts its prior passes already captured.
  *
  * Called only AFTER `upsertRetrospectiveState` on the success path: deleting
  * on failure would break the dedup chain (the failed run's conversation is
@@ -653,10 +703,12 @@ function safeDeleteForkOnFailure(forkId: string): void {
  */
 function deleteSupersededPriorRetrospective(
   config: AssistantConfig,
-  prior: { id: string } | null,
+  prior: PriorRetrospective | null,
+  sourceConversationId: string,
 ): void {
   if (!prior) return;
   if (config.memory.retrospective.keepSupersededRuns) return;
+  if (prior.forkParentConversationId !== sourceConversationId) return;
   try {
     deleteConversation(prior.id);
   } catch (err) {
@@ -730,60 +782,20 @@ function collectPriorRetrospectiveRemembers(
 /**
  * Pull the `content` strings out of every `remember` tool call made by a
  * retrospective run's own work in the given retrospective conversation.
- * Empty array when the run had no `remember` calls (it found nothing to
- * save) or on load failure (logged, never fatal).
- *
- * Two artifact shapes exist depending on which path produced the
- * retrospective:
- *
- *   - **Legacy** (`source === MEMORY_RETROSPECTIVE_SOURCE`): empty bg
- *     conversation containing only the wake's tail (`remember` tool_use
- *     blocks). Scan everything.
- *   - **Fork** (`source === MEMORY_RETROSPECTIVE_FORK_SOURCE`): full source
- *     prefix forked in, followed by the retrospective's post-fork tail.
- *     The forked prefix contains the source conversation's own inline
- *     `remember` calls — scanning the whole row would dump source-inline
- *     saves into the dedup baseline and inflate it dramatically. Restrict
- *     to messages created **after** `forkParentMessageId` (the last copied
- *     message); only messages after that boundary came from this
- *     retrospective's own work.
+ * `loadRetrospectiveRunMessages` scopes fork-kind rows to the post-fork tail
+ * (the copied prefix contains the source conversation's own inline
+ * `remember` calls, which must not pollute the dedup baseline) and returns
+ * `null` on load failure or an undetectable fork boundary (logged, never
+ * fatal) — treated here as "the run saved nothing".
  */
 function extractRetrospectiveRunRemembers(conversationId: string): string[] {
-  let messages: ReturnType<typeof getMessages>;
-  try {
-    messages = getMessages(conversationId);
-  } catch (err) {
-    log.warn(
-      { err, retrospectiveConversationId: conversationId },
-      "memory-retrospective: failed to load retrospective messages; treating as empty",
-    );
-    return [];
-  }
-
   const conv = getConversation(conversationId);
-  if (conv?.source === MEMORY_RETROSPECTIVE_FORK_SOURCE) {
-    // For fork-kind rows, the run's `remember` calls live in the post-fork
-    // tail. `cloneForkMessageMetadata` stamps every copied message with
-    // `forkSourceMessageId` (preserving any existing value when the source
-    // was itself a fork), so the LAST message in the fork carrying
-    // `forkSourceMessageId` is the boundary — its value can point to any
-    // ancestor when the source was a nested fork, so we can't match it
-    // against `forkParentMessageId`. Everything strictly past that
-    // timestamp is post-fork.
-    const boundaryCreatedAt = findForkBoundaryCreatedAt(messages);
-    if (boundaryCreatedAt == null) {
-      log.warn(
-        { retrospectiveConversationId: conversationId },
-        "memory-retrospective: fork-kind retrospective has no message with forkSourceMessageId metadata; treating remembers as empty",
-      );
-      return [];
-    }
-    return extractRememberContents(
-      messages.filter((m) => m.createdAt > boundaryCreatedAt),
-    );
-  }
-
-  return extractRememberContents(messages);
+  const runMessages = loadRetrospectiveRunMessages(
+    conversationId,
+    conv?.source ?? null,
+  );
+  if (runMessages == null) return [];
+  return extractRememberContents(runMessages);
 }
 
 interface MessageLike {

--- a/assistant/src/memory/memory-retrospective-startup-cleanup.ts
+++ b/assistant/src/memory/memory-retrospective-startup-cleanup.ts
@@ -25,11 +25,13 @@
 //     sweep when no job exists at all, since the worst-case false-positive
 //     is leaving a few extra orphans for the next sweep to catch.)
 //   - AND the row is NOT the preserved dedup baseline for its source
-//     conversation. The next retrospective run reads the most-recent prior
-//     retro via `findMostRecentRetrospectiveFor` to seed its
-//     `<already_remembered>` dedup block; sweeping it would force the
-//     next run to re-save facts the prior pass already captured. The
-//     baseline is the most recent row that actually produced output (see
+//     conversation. The primary dedup baseline is the persisted
+//     `remembered_log` on `memory_retrospective_state`, but state rows that
+//     predate the log column fall back to scanning the most-recent prior
+//     retro (via `findMostRecentRetrospectiveFor`) to seed their
+//     `<already_remembered>` dedup block; sweeping it would force such a
+//     run to re-save facts the prior pass already captured. The baseline is
+//     the most recent row that actually produced output (see
 //     `selectPreservedBaseline`) — a crash orphan with no post-fork
 //     assistant message would seed an EMPTY dedup block, so when an older
 //     row with output exists we preserve that one instead.
@@ -51,13 +53,10 @@ import {
 
 import { getConfig } from "../config/loader.js";
 import { getLogger } from "../util/logger.js";
-import { deleteConversation, getMessages } from "./conversation-crud.js";
+import { deleteConversation } from "./conversation-crud.js";
 import { getDb } from "./db-connection.js";
-import {
-  MEMORY_RETROSPECTIVE_FORK_SOURCE,
-  MEMORY_RETROSPECTIVE_SOURCES,
-} from "./memory-retrospective-constants.js";
-import { findForkBoundaryCreatedAt } from "./memory-retrospective-fork-boundary.js";
+import { MEMORY_RETROSPECTIVE_SOURCES } from "./memory-retrospective-constants.js";
+import { loadRetrospectiveRunMessages } from "./memory-retrospective-fork-boundary.js";
 import { conversations, memoryJobs } from "./schema.js";
 
 const log = getLogger("memory-retrospective-startup-cleanup");
@@ -121,10 +120,10 @@ export function sweepOrphanMemoryRetrospectiveConversations(
     .map((row) => row.conversationId)
     .filter((id): id is string => typeof id === "string" && id.length > 0);
 
-  // Compute the preserved dedup baseline per source. The next retrospective
-  // run pulls dedup context from the most-recent prior retro (via
-  // `findMostRecentRetrospectiveFor`); sweeping it would re-introduce the
-  // unbounded retrospective growth this cleanup exists to prevent.
+  // Compute the preserved dedup baseline per source. Runs whose state row
+  // predates the persisted `remembered_log` pull dedup context by scanning
+  // the most-recent prior retro (via `findMostRecentRetrospectiveFor`);
+  // sweeping it would leave those runs with no baseline at all.
   const allRetros = db
     .select({
       id: conversations.id,
@@ -240,31 +239,15 @@ function selectPreservedBaseline(rows: RetroRow[]): string {
 
 /**
  * Whether the retrospective row produced any assistant output of its own.
- * Fork-kind rows carry the full copied source prefix (including the source's
- * own assistant turns), so only assistant messages strictly after the fork
- * boundary count; a fork with no detectable boundary contributes nothing to
- * dedup (`collectPriorRetrospectiveRemembers` treats it as empty), so it
- * doesn't qualify either. Legacy-kind rows start empty, so any assistant
- * message counts. Best-effort: a message-load failure disqualifies the row
- * rather than failing the sweep.
+ * `loadRetrospectiveRunMessages` scopes fork-kind rows to the post-fork tail
+ * (the copied source prefix contains the source's own assistant turns) and
+ * returns `null` for rows whose output cannot be determined (load failure or
+ * no detectable fork boundary) — those rows contribute nothing to dedup
+ * (`collectPriorRetrospectiveRemembers` treats them as empty), so they don't
+ * qualify. Legacy-kind rows start empty, so any assistant message counts.
  */
 function retrospectiveHasOutput(row: RetroRow): boolean {
-  let messages: ReturnType<typeof getMessages>;
-  try {
-    messages = getMessages(row.id);
-  } catch (err) {
-    log.warn(
-      { err, conversationId: row.id },
-      "Failed to load retrospective messages while selecting the preserved dedup baseline; treating row as having no output",
-    );
-    return false;
-  }
-  if (row.source === MEMORY_RETROSPECTIVE_FORK_SOURCE) {
-    const boundaryCreatedAt = findForkBoundaryCreatedAt(messages);
-    if (boundaryCreatedAt == null) return false;
-    return messages.some(
-      (m) => m.role === "assistant" && m.createdAt > boundaryCreatedAt,
-    );
-  }
-  return messages.some((m) => m.role === "assistant");
+  const runMessages = loadRetrospectiveRunMessages(row.id, row.source);
+  if (runMessages == null) return false;
+  return runMessages.some((m) => m.role === "assistant");
 }

--- a/assistant/src/runtime/services/analyze-conversation.ts
+++ b/assistant/src/runtime/services/analyze-conversation.ts
@@ -34,7 +34,7 @@ import {
   getMessages,
 } from "../../memory/conversation-crud.js";
 import { resolveConversationId } from "../../memory/conversation-key-store.js";
-import { MEMORY_RETROSPECTIVE_SOURCES } from "../../memory/memory-retrospective-constants.js";
+import { isMemoryRetrospectiveSource } from "../../memory/memory-retrospective-constants.js";
 import { getLogger } from "../../util/logger.js";
 import { assistantEventHub, broadcastMessage } from "../assistant-event-hub.js";
 import {
@@ -135,7 +135,7 @@ export async function analyzeConversation(
         },
       };
     }
-    if (source !== null && MEMORY_RETROSPECTIVE_SOURCES.includes(source)) {
+    if (source !== null && isMemoryRetrospectiveSource(source)) {
       return {
         error: {
           kind: "BAD_REQUEST",


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for memory-retrospective-fork-hardening.md:
- GC no longer deletes an ancestor conversation's baseline retrospective (fork-chain ownership check + regression test)
- Execution tool-gate mode keys on the resolved profile match, not the bare config flag
- Consolidated duplicated success/failure blocks, fork-tail extraction, and the retrospective-source predicate
- Synced stale comments with the shipped dedup (remembered_log) and cache-parity semantics