### PR TITLE
fix(runtime): wake-path review fixes for retrospective parity

### DIFF
--- a/assistant/src/__tests__/compaction-events.test.ts
+++ b/assistant/src/__tests__/compaction-events.test.ts
@@ -74,7 +74,14 @@ mock.module("../config/loader.js", () => ({
         },
       },
       profiles: {},
-      callSites: {},
+      callSites: {
+        // Resolves a SMALLER window than mainAgent (which inherits
+        // llm.default's 100000) — exercised by the maybeCompact gate-sizing
+        // tests below.
+        memoryRetrospective: {
+          contextWindow: { maxInputTokens: 50000 },
+        },
+      },
       pricingOverrides: [],
     },
     rateLimit: { maxRequestsPerMinute: 0 },
@@ -182,11 +189,18 @@ let mockCompactResult: ContextWindowResult = {
   summaryText: "",
 };
 
+// Config payloads handed to the manager's updateConfig — runCompaction calls
+// it with the (possibly sizing-threaded) resolved context-window config
+// before delegating to the manager.
+const updateConfigCalls: Array<{ maxInputTokens?: number }> = [];
+
 mock.module("../plugins/defaults/compaction/window-manager.js", () => ({
   ContextWindowManager: class {
     nonPersistedPrefixCount = 0;
     constructor() {}
-    updateConfig() {}
+    updateConfig(cfg: { maxInputTokens?: number }) {
+      updateConfigCalls.push(cfg);
+    }
     shouldCompact() {
       return { needed: false, estimatedTokens: 0 };
     }
@@ -425,6 +439,53 @@ describe("forceCompact event emission", () => {
       0,
     );
     expect(collected.filter((m) => m.type === "usage_update").length).toBe(0);
+  });
+});
+
+describe("maybeCompact gate sizing", () => {
+  test("default sizing resolves mainAgent's window; wake sizing resolves the wake's call-site window", async () => {
+    // The auto-threshold gate derives its trip point from the
+    // context-window config pushed via updateConfig. Sized against
+    // mainAgent (100k here), a wake whose call site resolves a smaller
+    // window (memoryRetrospective → 50k) would pass the gate un-compacted
+    // and then overflow at the provider — threading the sizing makes the
+    // gate see the 50k window instead.
+    mockCompactResult = {
+      messages: [],
+      compacted: false,
+      previousEstimatedInputTokens: 0,
+      estimatedInputTokens: 0,
+      maxInputTokens: 0,
+      thresholdTokens: 0,
+      compactedMessages: 0,
+      compactedPersistedMessages: 0,
+      summaryCalls: 0,
+      summaryInputTokens: 0,
+      summaryOutputTokens: 0,
+      summaryModel: "",
+      summaryText: "",
+    };
+    const conversation = makeConversation([], "conv-compact-sizing");
+
+    updateConfigCalls.length = 0;
+    await conversation.maybeCompact();
+    await conversation.maybeCompact({ callSite: "memoryRetrospective" });
+
+    expect(updateConfigCalls.map((cfg) => cfg.maxInputTokens)).toEqual([
+      100000, 50000,
+    ]);
+  });
+
+  test("forceCompact keeps mainAgent sizing", async () => {
+    mockCompactResult = { ...mockCompactResult, compacted: false };
+    const conversation = makeConversation([], "conv-compact-force-sizing");
+
+    updateConfigCalls.length = 0;
+    await conversation.forceCompact();
+
+    expect(updateConfigCalls.map((cfg) => cfg.maxInputTokens)).toEqual([
+      100000,
+    ]);
   });
 });
 

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -181,6 +181,26 @@ export interface CleanResult {
   preservedMessages: number;
 }
 
+/**
+ * Optional context-window sizing inputs for {@link Conversation.maybeCompact}.
+ *
+ * The auto-threshold gate sizes its window against `mainAgent` by default,
+ * but an agent wake can run under a different call site (and a forced
+ * override profile) that resolves a SMALLER effective window — sized against
+ * `mainAgent`, such a wake passes the gate un-compacted and then overflows at
+ * the provider. Wakes thread their already-resolved inputs here so the gate's
+ * threshold matches the window the wake's calls actually get. Sizing only:
+ * the compaction execution (summary call profile) is unchanged.
+ */
+export interface CompactionSizing {
+  /** Call site the upcoming run resolves its context window against. */
+  callSite: LLMCallSite;
+  /** Inference profile the run resolves under, if any. */
+  overrideProfile?: string;
+  /** Float `overrideProfile` above the call-site layers (resolver escape hatch). */
+  forceOverrideProfile?: boolean;
+}
+
 export { findLastUndoableUserMessageIndex } from "./conversation-history.js";
 export type {
   QueueDrainReason,
@@ -1543,12 +1563,18 @@ export class Conversation {
    * agent-wake path (`runtime/agent-wake.ts`), which bypasses the daemon
    * orchestrator's in-loop budget gate and needs an equivalent turn-start
    * compaction before snapshotting its run input.
+   *
+   * `sizing` lets a wake thread its own call-site/profile resolution into
+   * the gate's context-window sizing — see {@link CompactionSizing}. Absent,
+   * the gate sizes against `mainAgent` (the live-turn behavior).
    */
-  async maybeCompact(): Promise<ContextWindowResult | null> {
+  async maybeCompact(
+    sizing?: CompactionSizing,
+  ): Promise<ContextWindowResult | null> {
     if (await this.agentLoop.compactionCircuit.isOpen()) {
       return null;
     }
-    return this.runCompaction(false);
+    return this.runCompaction(false, sizing);
   }
 
   /**
@@ -1557,18 +1583,32 @@ export class Conversation {
    * context-window manager (user-initiated `/compact`); without it the
    * manager no-ops below the threshold.
    */
-  private async runCompaction(force: boolean): Promise<ContextWindowResult> {
+  private async runCompaction(
+    force: boolean,
+    sizing?: CompactionSizing,
+  ): Promise<ContextWindowResult> {
     const overrideProfile = resolveOverrideProfile(this) ?? null;
     const config = getConfig();
+    // Threshold/window sizing. The default (`mainAgent` + the conversation's
+    // own pinned profile) matches live turns; caller-supplied `sizing` makes
+    // the gate's threshold reflect the window the caller's run will actually
+    // resolve. Sizing only — the summary call below still runs under the
+    // conversation's own profile.
+    const sizingCallSite = sizing?.callSite ?? "mainAgent";
+    const sizingOverrideProfile = sizing
+      ? sizing.overrideProfile
+      : (overrideProfile ?? undefined);
     const effectiveContextWindow = resolveEffectiveContextWindow({
       llm: config.llm,
-      callSite: "mainAgent",
-      overrideProfile: overrideProfile ?? undefined,
+      callSite: sizingCallSite,
+      overrideProfile: sizingOverrideProfile,
+      forceOverrideProfile: sizing?.forceOverrideProfile,
     });
     this.contextWindowManager.updateConfig(
       contextWindowConfigFromEffective(
-        resolveCallSiteConfig("mainAgent", config.llm, {
-          overrideProfile: overrideProfile ?? undefined,
+        resolveCallSiteConfig(sizingCallSite, config.llm, {
+          overrideProfile: sizingOverrideProfile,
+          forceOverrideProfile: sizing?.forceOverrideProfile,
         }).contextWindow,
         effectiveContextWindow,
       ),

--- a/assistant/src/daemon/parse-actual-tokens-from-error.test.ts
+++ b/assistant/src/daemon/parse-actual-tokens-from-error.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import { ContextOverflowError } from "../providers/types.js";
-import { parseActualTokensFromError } from "./parse-actual-tokens-from-error.js";
+import {
+  looksLikeContextOverflowError,
+  parseActualTokensFromError,
+} from "./parse-actual-tokens-from-error.js";
 
 describe("parseActualTokensFromError", () => {
   test("returns null for null input", () => {
@@ -123,5 +126,63 @@ describe("parseActualTokensFromError", () => {
       { actualTokens: 0 },
     );
     expect(parseActualTokensFromError(err)).toBe(242201);
+  });
+});
+
+describe("looksLikeContextOverflowError", () => {
+  test("matches the typed ContextOverflowError even without a parseable message", () => {
+    const err = new ContextOverflowError("context window exceeded", "openai");
+    expect(looksLikeContextOverflowError(err)).toBe(true);
+  });
+
+  test("matches a REWRAPPED plain Error carrying an Anthropic-style message", () => {
+    // Managed-proxy/adapter paths rewrap overflow rejections into untyped
+    // errors — the heuristic must still recognize them.
+    const err = new Error(
+      "Provider API error (400): prompt is too long: 250000 tokens > 200000 maximum",
+    );
+    expect(looksLikeContextOverflowError(err)).toBe(true);
+  });
+
+  test("matches a rewrapped OpenAI-style message", () => {
+    expect(
+      looksLikeContextOverflowError(
+        new Error("too many input tokens: 150000 > 128000"),
+      ),
+    ).toBe(true);
+  });
+
+  test("matches context_length_exceeded / maximum-context-length phrasings", () => {
+    expect(
+      looksLikeContextOverflowError(new Error("context_length_exceeded")),
+    ).toBe(true);
+    expect(
+      looksLikeContextOverflowError(
+        new Error("This model's maximum context length is 128000 tokens"),
+      ),
+    ).toBe(true);
+  });
+
+  test("accepts a raw string message", () => {
+    expect(
+      looksLikeContextOverflowError(
+        "prompt is too long: 242201 tokens > 200000 maximum",
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects unrelated errors, strings, and nullish input", () => {
+    expect(looksLikeContextOverflowError(new Error("socket hang up"))).toBe(
+      false,
+    );
+    expect(looksLikeContextOverflowError("something went wrong")).toBe(false);
+    expect(looksLikeContextOverflowError(null)).toBe(false);
+    expect(looksLikeContextOverflowError(undefined)).toBe(false);
+  });
+
+  test("does not misread arbitrary numeric comparisons as overflow", () => {
+    expect(
+      looksLikeContextOverflowError(new Error("retry budget: 5 > 3 attempts")),
+    ).toBe(false);
   });
 });

--- a/assistant/src/daemon/parse-actual-tokens-from-error.ts
+++ b/assistant/src/daemon/parse-actual-tokens-from-error.ts
@@ -30,13 +30,52 @@ export function parseActualTokensFromError(
   }
 
   // Untyped path — accept either an Error or a string.
+  return parseFromMessage(extractMessage(errorOrMessage));
+}
+
+/**
+ * Message patterns that identify a provider context-overflow rejection.
+ * Covers the typed wrapper's source patterns plus common provider phrasings
+ * that adapter paths (e.g. managed-proxy rewrappers) surface as untyped
+ * errors:
+ *   "prompt is too long: 242201 tokens > 200000 maximum"   (Anthropic)
+ *   "too many input tokens: 242201 > 200000"                (OpenAI)
+ *   "context_length_exceeded" / "maximum context length"    (OpenAI-compat)
+ */
+const OVERFLOW_MESSAGE_PATTERNS: readonly RegExp[] = [
+  /prompt is too long/i,
+  /too many (?:input )?tokens/i,
+  /context[_\s-]?length[_\s-]?exceeded/i,
+  /maximum context length/i,
+  /\d[\d,]*\s*tokens?\s*[>≥]\s*\d/i,
+];
+
+/**
+ * Heuristic context-overflow check that also catches REWRAPPED provider
+ * errors. `isContextOverflowError` only matches the typed
+ * `ContextOverflowError` wrapper; adapter layers (managed-proxy rewrappers,
+ * retry shims) can re-throw the same rejection as a plain `Error`, hiding the
+ * typed signal. Callers that must not misread an overflow as a clean
+ * no-output stop (e.g. the suppressed-compaction agent-wake path) should use
+ * this instead of the bare typed check.
+ *
+ * Accepts the same inputs as {@link parseActualTokensFromError}: a typed
+ * error, a plain `Error`/object with a `message`, or a raw string.
+ */
+export function looksLikeContextOverflowError(err: unknown): boolean {
+  if (isContextOverflowError(err)) return true;
+  const message = extractMessage(err);
+  if (message === null) return false;
+  return OVERFLOW_MESSAGE_PATTERNS.some((pattern) => pattern.test(message));
+}
+
+/** Pull a message string out of an untyped error-ish value, if possible. */
+function extractMessage(errorOrMessage: unknown): string | null {
   if (errorOrMessage == null) return null;
-  if (typeof errorOrMessage === "string") {
-    return parseFromMessage(errorOrMessage);
-  }
+  if (typeof errorOrMessage === "string") return errorOrMessage;
   if (typeof errorOrMessage === "object" && "message" in errorOrMessage) {
     const msg = (errorOrMessage as { message?: unknown }).message;
-    if (typeof msg === "string") return parseFromMessage(msg);
+    if (typeof msg === "string") return msg;
   }
   return null;
 }

--- a/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
@@ -805,6 +805,7 @@ describe("memoryRetrospectiveJob", () => {
     expect(wakeCalls[0]!.opts.personaOverride).toEqual({
       userSlug: "alice",
       channelSlug: "vellum",
+      hasNoClient: false,
     });
     // Resolved via the live-turn guardian branch: undefined trust context,
     // never the wake's internal guardian context.
@@ -826,10 +827,11 @@ describe("memoryRetrospectiveJob", () => {
     expect(wakeCalls[0]!.opts.personaOverride).toEqual({
       userSlug: "alice",
       channelSlug: "vellum",
+      hasNoClient: false,
     });
   });
 
-  test("fork path: channel-routed source → no persona override (identity not recoverable)", async () => {
+  test("fork path: channel-routed source → no persona slugs (identity not recoverable), hasNoClient still pinned", async () => {
     forkFlagEnabled = true;
     conversationOverrides["src-conv-1"] = {
       source: "user",
@@ -841,7 +843,10 @@ describe("memoryRetrospectiveJob", () => {
     await memoryRetrospectiveJob(makeJob(), stubConfig);
 
     expect(wakeCalls).toHaveLength(1);
-    expect("personaOverride" in wakeCalls[0]!.opts).toBe(false);
+    // The slugs are unrecoverable for a channel-routed source, but the
+    // hasNoClient pin is unconditional: the fork hydrates clientless while
+    // the source's live turns ran with hasNoClient = false.
+    expect(wakeCalls[0]!.opts.personaOverride).toEqual({ hasNoClient: false });
     expect(resolveUserSlugCalls).toEqual([]);
   });
 
@@ -855,6 +860,7 @@ describe("memoryRetrospectiveJob", () => {
     expect(wakeCalls[0]!.opts.personaOverride).toEqual({
       userSlug: "default",
       channelSlug: "vellum",
+      hasNoClient: false,
     });
   });
 
@@ -870,6 +876,7 @@ describe("memoryRetrospectiveJob", () => {
     expect(wakeCalls[0]!.opts.personaOverride).toEqual({
       userSlug: "alice",
       channelSlug: "vellum",
+      hasNoClient: false,
     });
   });
 

--- a/assistant/src/memory/memory-retrospective-job.ts
+++ b/assistant/src/memory/memory-retrospective-job.ts
@@ -477,8 +477,17 @@ async function runForkBasedRetrospective(
   // unconditionally (not gated on matchConversationProfile): the correct
   // persona is a review-quality fix on its own; with profile matching it
   // additionally preserves the source's cached system-prompt prefix.
-  // `undefined` (identity not recoverable) keeps today's behavior.
-  const personaOverride = resolveSourcePersonaOverride(sourceConversation);
+  // An empty slug resolution (identity not recoverable) keeps today's
+  // persona behavior. `hasNoClient` is pinned to the live-turn value
+  // unconditionally: the fork is hydrated clientless
+  // (`getOrCreateConversation` → `updateClient(_, true)`), but the source's
+  // live turns ran with `hasNoClient = false`, and the prompt's
+  // `05-access-preference` section renders different text under the flag —
+  // early enough to break byte-parity with the source's cached prefix.
+  const personaOverride: SystemPromptPersonaOverride = {
+    ...resolveSourcePersonaOverride(sourceConversation),
+    hasNoClient: false,
+  };
 
   // `skipHintInjection: true` because the instruction is already a
   // persisted message — the wake's hint sandwich would only duplicate it.
@@ -506,7 +515,7 @@ async function runForkBasedRetrospective(
       ...(matchedProfile !== undefined
         ? { forceOverrideProfile: matchedProfile }
         : {}),
-      ...(personaOverride !== undefined ? { personaOverride } : {}),
+      personaOverride,
       hintRole: "user",
       skipHintInjection: true,
       suppressAutoCompaction: true,

--- a/assistant/src/prompts/__tests__/system-prompt.test.ts
+++ b/assistant/src/prompts/__tests__/system-prompt.test.ts
@@ -125,6 +125,53 @@ describe("buildSystemPrompt — persona override", () => {
   });
 });
 
+describe("buildSystemPrompt — hasNoClient pin", () => {
+  // Marker unique to the `{{^hasNoClient}}` branch of 05-access-preference:
+  // host fallbacks only render when a client is connected.
+  const WITH_CLIENT_MARKER = "`host_bash` with CLIs";
+
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  test("hasNoClient renders divergent access-preference text", () => {
+    expect(buildSystemPrompt({ hasNoClient: false })).toContain(
+      WITH_CLIENT_MARKER,
+    );
+    expect(buildSystemPrompt({ hasNoClient: true })).not.toContain(
+      WITH_CLIENT_MARKER,
+    );
+  });
+
+  test("personaOverride.hasNoClient pins the flag over the conversation-derived option", () => {
+    // Fork-retrospective case: the fork is hydrated clientless
+    // (hasNoClient: true) but pins the source's live-turn value (false) so
+    // the prompt byte-matches the source's cached prefix.
+    expect(
+      buildSystemPrompt({
+        hasNoClient: true,
+        personaOverride: { hasNoClient: false },
+      }),
+    ).toContain(WITH_CLIENT_MARKER);
+    // And the pin wins in the other direction too.
+    expect(
+      buildSystemPrompt({
+        hasNoClient: false,
+        personaOverride: { hasNoClient: true },
+      }),
+    ).not.toContain(WITH_CLIENT_MARKER);
+  });
+
+  test("a personaOverride without the pin leaves the conversation-derived flag untouched", () => {
+    expect(
+      buildSystemPrompt({ hasNoClient: true, personaOverride: {} }),
+    ).not.toContain(WITH_CLIENT_MARKER);
+    expect(
+      buildSystemPrompt({ hasNoClient: false, personaOverride: {} }),
+    ).toContain(WITH_CLIENT_MARKER);
+  });
+});
+
 describe("maybeReseedBootstrap — content-automation template", () => {
   const templatesDir = join(import.meta.dirname!, "..", "templates");
 

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -305,17 +305,28 @@ export function applyBootstrapTemplate(
 }
 
 /**
- * Explicit persona-selection override for prompt builds that run outside the
- * inbound-turn pipeline (agent wakes). Each slug, when present, takes
- * precedence over the corresponding trust-context/channel-capabilities
- * derivation in {@link buildSystemPrompt}. Persona selection only — trust
- * class and approval semantics are unaffected.
+ * Explicit prompt-build override for builds that run outside the
+ * inbound-turn pipeline (agent wakes). Each field, when present, takes
+ * precedence over the corresponding derivation in {@link buildSystemPrompt}.
+ * Prompt-build selection only — trust class and approval semantics are
+ * unaffected.
  */
 export interface SystemPromptPersonaOverride {
   /** Renders `users/<slug>.md` as the user persona section. */
   userSlug?: string;
   /** Renders `channels/<slug>.md` as the channel persona section. */
   channelSlug?: string;
+  /**
+   * Pins the `hasNoClient` flag for the prompt build, taking precedence over
+   * the top-level `BuildSystemPromptOptions.hasNoClient` (which mirrors the
+   * conversation's live client state). The `05-access-preference` section
+   * renders different text under the flag — early in the prompt, so a
+   * mismatch breaks byte-parity with a cached prefix even when persona and
+   * profile match. Used by fork-based memory retrospectives: the fork is
+   * hydrated clientless (`hasNoClient = true`) while the source's live turns
+   * ran with `hasNoClient = false`.
+   */
+  hasNoClient?: boolean;
 }
 
 export interface BuildSystemPromptOptions {
@@ -376,6 +387,11 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
     options?.personaOverride?.channelSlug ??
     options?.channelCapabilities?.channel ??
     "vellum";
+  // The override's `hasNoClient` pin wins over the conversation-derived
+  // top-level option (see the interface doc); placed after the `...options`
+  // spread below so it overrides the spread-in value.
+  const hasNoClient =
+    options?.personaOverride?.hasNoClient ?? options?.hasNoClient;
 
   // Section render context.  Workspace section frontmatter `enabled:`
   // predicates, `{{key}}` / `{{#flag}}...{{/flag}}` body interpolation,
@@ -388,6 +404,7 @@ export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {
   // no explicit normalization needed; `...options` is enough.
   const ctx = {
     ...options,
+    hasNoClient,
     isContainerized: getIsContainerized(),
     workspaceDir: getWorkspaceDir(),
     userSlug,

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -98,6 +98,12 @@ interface WakeConversationProbe {
    * `runCalls` so tests can prove the gate ran before the agent loop.
    */
   maybeCompactOrders: number[];
+  /**
+   * The sizing argument passed to each `conversation.maybeCompact()` call —
+   * the wake threads its resolved callSite/profile so the gate's threshold
+   * sizes against the wake's window instead of mainAgent's.
+   */
+  maybeCompactSizings: unknown[];
 }
 
 const wakeConvRegistry = new Map<string, WakeConversationProbe>();
@@ -109,8 +115,15 @@ const wakeConvRegistry = new Map<string, WakeConversationProbe>();
 // `persistWakeTailMessage` (createdAt for the disk-view sync). `addMessage`
 // is the persistence boundary the wake's tail persistence flows through —
 // it records into the originating conversation's probe.
+// Overridable per test (e.g. to simulate a throwing DB read); reset in
+// beforeEach.
+let mockGetConversationOverrideProfile: (
+  conversationId: string,
+) => string | undefined = () => undefined;
+
 mock.module("../../memory/conversation-crud.js", () => ({
-  getConversationOverrideProfile: () => undefined,
+  getConversationOverrideProfile: (conversationId: string) =>
+    mockGetConversationOverrideProfile(conversationId),
   getConversation: () => ({
     archivedAt: null,
     createdAt: "2026-01-01T00:00:00.000Z",
@@ -323,6 +336,7 @@ function makeWakeConversation(options: {
     personaOverrideSets: [],
     persistedAtEachEmit: [],
     maybeCompactOrders: [],
+    maybeCompactSizings: [],
   };
   wakeConvRegistry.set(conversationId, probe);
 
@@ -424,10 +438,12 @@ function makeWakeConversation(options: {
     setTrustContext: (ctx: unknown) => {
       probe.setTrustContextCalls.push({ ctx, order: order++ });
     },
-    // Pre-run auto-compaction gate. The double only records the call —
-    // compaction side effects are exercised in the Conversation tests.
-    maybeCompact: async () => {
+    // Pre-run auto-compaction gate. The double only records the call (and
+    // the sizing argument) — compaction side effects are exercised in the
+    // Conversation tests.
+    maybeCompact: async (sizing?: unknown) => {
       probe.maybeCompactOrders.push(order++);
+      probe.maybeCompactSizings.push(sizing);
       probe.callSequence.push("maybeCompact");
       return null;
     },
@@ -450,6 +466,7 @@ beforeEach(() => {
   recordRequestLogCalls.length = 0;
   mockGetOrCreateConversationCalls.length = 0;
   mockResolverTarget = null;
+  mockGetConversationOverrideProfile = () => undefined;
   mockDiskPressureStatus = {
     enabled: false,
     state: "disabled",
@@ -654,6 +671,44 @@ describe("wakeAgentForOpportunity", () => {
 
     expect(result).toEqual({ invoked: true, producedToolCalls: false });
     expect(conversation.personaOverrideSets).toEqual([override, undefined]);
+  });
+
+  test("a throwing profile read never strands the persona override on the conversation", async () => {
+    // The override-profile lookup (and the config/window reads next to it)
+    // run BEFORE the try/finally that clears the wake's persona override. If
+    // the override were assigned before those reads, a throw there would
+    // strand it on the cached Conversation and corrupt every later prompt
+    // build. The wake must assign the override only after the reads succeed.
+    const conversation = makeWakeConversation({
+      scriptedAssistant: {
+        role: "assistant",
+        content: [{ type: "text", text: "never reached" }],
+      },
+    });
+    mockGetConversationOverrideProfile = () => {
+      throw new Error("profile read failed");
+    };
+
+    await expect(
+      wakeAgentForOpportunity(
+        {
+          conversationId: conversation.conversationId,
+          hint: "retrospective pass",
+          source: "memory-retrospective",
+          personaOverride: { userSlug: "alice" },
+        },
+        { resolveTarget: async () => conversation },
+      ),
+    ).rejects.toThrow("profile read failed");
+
+    // The override was never assigned (not assigned-then-cleared) and the
+    // conversation field is clean for the next turn's prompt build.
+    expect(conversation.personaOverrideSets).toEqual([]);
+    expect(conversation.wakePersonaOverride).toBeUndefined();
+    // The processing flag was never stranded either — the reads run before
+    // setProcessing(true).
+    expect(conversation.processingToggles).toEqual([]);
+    expect(conversation.runCalls).toHaveLength(0);
   });
 
   test("no personaOverride → the conversation's persona field is never touched", async () => {
@@ -2142,6 +2197,142 @@ describe("wakeAgentForOpportunity", () => {
       // Cleanup still ran.
       expect(conversation.processingToggles).toEqual([true, false]);
       expect(conversation.drainQueueCalls).toBe(1);
+    });
+
+    test("suppressed wake maps a REWRAPPED (untyped) provider overflow error to a failed result", async () => {
+      // Managed-proxy/adapter paths rewrap provider overflow rejections into
+      // plain Errors, defeating the typed `instanceof` check. The wake's
+      // capture must fall back to the message-level heuristic — otherwise
+      // the overflow reads as a successful silent no-op and the
+      // fork-retrospective job advances `lastProcessedMessageId` past a
+      // slice that was never reviewed.
+      const conversation = makeWakeConversation({
+        estimatedInputTokens: 0,
+        runImpl: async (input, onEvent) => {
+          await onEvent({
+            type: "error",
+            error: new Error(
+              "Provider API error (400): prompt is too long: 250000 tokens > 200000 maximum",
+            ),
+          });
+          return runResult([...input]);
+        },
+      });
+
+      const result = await wakeAgentForOpportunity(
+        {
+          conversationId: conversation.conversationId,
+          hint: "do work",
+          source: "unit-test",
+          suppressAutoCompaction: true,
+        },
+        { resolveTarget: async () => conversation },
+      );
+
+      expect(result).toEqual({
+        invoked: false,
+        producedToolCalls: false,
+        reason: "context_overflow",
+      });
+    });
+
+    test("suppressed wake maps a rewrapped overflow THROW to a failed result", async () => {
+      const conversation = makeWakeConversation({
+        estimatedInputTokens: 0,
+        runImpl: async () => {
+          throw new Error("too many input tokens: 250000 > 200000");
+        },
+      });
+
+      const result = await wakeAgentForOpportunity(
+        {
+          conversationId: conversation.conversationId,
+          hint: "do work",
+          source: "unit-test",
+          suppressAutoCompaction: true,
+        },
+        { resolveTarget: async () => conversation },
+      );
+
+      expect(result).toEqual({
+        invoked: false,
+        producedToolCalls: false,
+        reason: "context_overflow",
+      });
+      // Cleanup still ran.
+      expect(conversation.processingToggles).toEqual([true, false]);
+      expect(conversation.drainQueueCalls).toBe(1);
+    });
+
+    test("suppressed wake treats an unrelated rewrapped error as a generic no-op, not an overflow", async () => {
+      const conversation = makeWakeConversation({
+        estimatedInputTokens: 0,
+        runImpl: async () => {
+          throw new Error("socket hang up");
+        },
+      });
+
+      const result = await wakeAgentForOpportunity(
+        {
+          conversationId: conversation.conversationId,
+          hint: "do work",
+          source: "unit-test",
+          suppressAutoCompaction: true,
+        },
+        { resolveTarget: async () => conversation },
+      );
+
+      expect(result).toEqual({ invoked: true, producedToolCalls: false });
+    });
+
+    test("the compaction gate is sized with the wake's call site and forced profile", async () => {
+      const conversation = makeWakeConversation({
+        scriptedAssistant: reply,
+      });
+
+      await wakeAgentForOpportunity(
+        {
+          conversationId: conversation.conversationId,
+          hint: "do work",
+          source: "memory-retrospective",
+          callSite: "memoryRetrospective",
+          forceOverrideProfile: "forced",
+        },
+        { resolveTarget: async () => conversation },
+      );
+
+      // The wake threads its own resolution inputs so the gate's threshold
+      // sizes against the wake's window instead of mainAgent's.
+      expect(conversation.maybeCompactSizings).toEqual([
+        {
+          callSite: "memoryRetrospective",
+          overrideProfile: "forced",
+          forceOverrideProfile: true,
+        },
+      ]);
+    });
+
+    test("a default wake sizes the compaction gate against mainAgent with no forced profile", async () => {
+      const conversation = makeWakeConversation({
+        scriptedAssistant: reply,
+      });
+
+      await wakeAgentForOpportunity(
+        {
+          conversationId: conversation.conversationId,
+          hint: "do work",
+          source: "unit-test",
+        },
+        { resolveTarget: async () => conversation },
+      );
+
+      expect(conversation.maybeCompactSizings).toEqual([
+        {
+          callSite: "mainAgent",
+          overrideProfile: undefined,
+          forceOverrideProfile: false,
+        },
+      ]);
     });
 
     test("non-suppressed wake treats a provider context-overflow rejection as a silent no-op (existing behavior)", async () => {

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -63,6 +63,8 @@ import {
   classifyDiskPressureTurnPolicy,
   type DiskPressureTurnPolicyDecision,
 } from "../daemon/disk-pressure-policy.js";
+import { looksLikeContextOverflowError } from "../daemon/parse-actual-tokens-from-error.js";
+import type { SubagentToolGateMode } from "../daemon/tool-setup-types.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import {
   broadcastWakeSurface,
@@ -81,7 +83,7 @@ import {
   setAgentLoopExitReasonOnLatestLog,
 } from "../memory/llm-request-log-store.js";
 import type { SystemPromptPersonaOverride } from "../prompts/system-prompt.js";
-import { isContextOverflowError, type Message } from "../providers/types.js";
+import type { Message } from "../providers/types.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("agent-wake");
@@ -93,6 +95,14 @@ const WAKE_PREAMBLE =
 /** Static postamble user message — ends conversation on a user turn. */
 const WAKE_POSTAMBLE =
   "[system] End of message from external system, continue the conversation.";
+
+/**
+ * Warn line shared by the two reactive over-window failure sites (provider
+ * rejection escaped as a throw / swallowed into a no-output stop). The
+ * pre-flight estimate site logs its own distinct message.
+ */
+const OVER_WINDOW_REJECTION_LOG_MESSAGE =
+  "agent-wake: provider rejected the input as over-window with auto-compaction suppressed; failing the wake";
 
 export interface WakeOptions {
   conversationId: string;
@@ -194,18 +204,12 @@ export interface WakeOptions {
    */
   allowedTools?: readonly string[];
   /**
-   * How `allowedTools` is enforced. Defaults to `"wire"` — the historical
-   * behavior, byte-identical when absent: the provider request's tool array
-   * is filtered down to the allowlist. Pass `"execution"` to keep the
-   * conversation's full tool surface on the wire and enforce the allowlist
-   * at execution time instead. Provider prompt caches key on the rendered
-   * `tools → system → messages` prefix, so wire-filtering the tool array
-   * invalidates the source conversation's cached prefix; execution mode
-   * preserves it. Used by fork-based memory retrospectives when matching
-   * the source conversation's inference profile. Ignored when
-   * `allowedTools` is absent.
+   * How `allowedTools` is enforced — see {@link SubagentToolGateMode} for the
+   * wire-vs-execution semantics and cache-parity rationale. Defaults to
+   * `"wire"` (the historical behavior, byte-identical when absent). Ignored
+   * when `allowedTools` is absent.
    */
-  toolGateMode?: "wire" | "execution";
+  toolGateMode?: SubagentToolGateMode;
   /**
    * Explicit persona/channel slugs for the wake's system-prompt build,
    * applied to the conversation for the duration of the run and restored
@@ -217,8 +221,9 @@ export interface WakeOptions {
    * the conversation belongs to. Used by fork-based memory retrospectives to
    * render the SOURCE conversation's persona sections — both for review
    * quality and for byte-parity with the source's cached system-prompt
-   * prefix. Persona selection only; trust class and approval semantics are
-   * governed solely by `trustContext`.
+   * prefix. May also pin `hasNoClient` for the prompt build (see
+   * {@link SystemPromptPersonaOverride}). Prompt-build selection only; trust
+   * class and approval semantics are governed solely by `trustContext`.
    */
   personaOverride?: SystemPromptPersonaOverride;
 }
@@ -553,20 +558,6 @@ export async function wakeAgentForOpportunity(
       conversation.setTrustContext(opts.trustContext);
     }
 
-    // Apply the caller's persona override for the duration of the run. The
-    // wake's agent loop builds the system prompt through the conversation's
-    // resolveSystemPrompt callback, which reads this field; cleared (below,
-    // before drainQueue) so a queued user turn never builds its prompt under
-    // the wake's override.
-    if (opts.personaOverride) {
-      conversation.wakePersonaOverride = opts.personaOverride;
-    }
-    const clearWakePersonaOverride = (): void => {
-      if (opts.personaOverride) {
-        conversation.wakePersonaOverride = undefined;
-      }
-    };
-
     // Honor the conversation's pinned inference-profile override (if any).
     // Without this, scheduled-task wakes and other opportunity wakes bypass
     // `runAgentLoopImpl` entirely and execute under workspace defaults,
@@ -590,6 +581,23 @@ export async function wakeAgentForOpportunity(
       forceOverrideProfile,
     });
 
+    // Apply the caller's persona override for the duration of the run. The
+    // wake's agent loop builds the system prompt through the conversation's
+    // resolveSystemPrompt callback, which reads this field; cleared (below,
+    // before drainQueue) so a queued user turn never builds its prompt under
+    // the wake's override. Assigned only AFTER the profile/config reads above
+    // — those can throw, and they run before the try/finally that clears the
+    // override, so an earlier assignment would strand the override on the
+    // cached Conversation and corrupt every later prompt build on it.
+    if (opts.personaOverride) {
+      conversation.wakePersonaOverride = opts.personaOverride;
+    }
+    const clearWakePersonaOverride = (): void => {
+      if (opts.personaOverride) {
+        conversation.wakePersonaOverride = undefined;
+      }
+    };
+
     // Mark processing for the duration of the wake — including the pre-run
     // compaction gate below, whose summary LLM call must not race a user
     // send into a concurrent agent loop on the same conversation. A user
@@ -609,10 +617,18 @@ export async function wakeAgentForOpportunity(
     // like fork-based memory retrospectives suppress this gate: the fork
     // is throwaway and a summarization LLM call on it is wasted spend.
     // Failure is non-fatal — the wake proceeds on the uncompacted history
-    // exactly as it would have before the gate existed.
+    // exactly as it would have before the gate existed. The gate's window
+    // sizing is threaded from the wake's own call-site resolution above —
+    // without it, `maybeCompact` sizes the threshold against `mainAgent`,
+    // which can pass un-compacted a wake whose call site resolves a smaller
+    // window (and then overflow at the provider).
     if (!suppressAutoCompaction) {
       try {
-        await conversation.maybeCompact();
+        await conversation.maybeCompact({
+          callSite,
+          overrideProfile,
+          forceOverrideProfile,
+        });
       } catch (err) {
         log.warn(
           { conversationId, source, err },
@@ -804,11 +820,13 @@ export async function wakeAgentForOpportunity(
       // Detect an over-window rejection on a compaction-suppressed wake.
       // `provider_error` fires at the provider-call site; `error` fires from
       // the loop's generic catch — check both so a rewrapping retry layer
-      // can't hide the signal.
+      // can't hide the signal. The heuristic check also catches adapter
+      // paths (e.g. managed-proxy rewrappers) that surface the overflow as
+      // an untyped error the typed `instanceof` check would miss.
       if (
         suppressAutoCompaction &&
         (event.type === "provider_error" || event.type === "error") &&
-        isContextOverflowError(event.error)
+        looksLikeContextOverflowError(event.error)
       ) {
         suppressedContextOverflow = true;
       }
@@ -968,16 +986,18 @@ export async function wakeAgentForOpportunity(
     // block skips its generic outcome log for this path — the failure
     // already logged its own dedicated warn line.
     let failedContextOverflow = false;
-    // Shared failure path for a provider over-window rejection on a
-    // compaction-suppressed wake (reached from the run's catch when the
-    // rejection escaped as a throw, or post-run when the loop swallowed it
-    // into a graceful no-output stop and only the event capture saw it).
-    const failSuppressedContextOverflow = (err?: unknown): WakeResult => {
+    // Shared failure path for an over-window condition on a
+    // compaction-suppressed wake (reached from the pre-flight estimate, from
+    // the run's catch when the rejection escaped as a throw, or post-run when
+    // the loop swallowed it into a graceful no-output stop and only the event
+    // capture saw it). `extraLogFields` is spread into the warn line so each
+    // site can attach its own context (err, token estimates).
+    const failSuppressedContextOverflow = (
+      logMessage: string,
+      extraLogFields: Record<string, unknown> = {},
+    ): WakeResult => {
       failedContextOverflow = true;
-      log.warn(
-        { conversationId, source, ...(err === undefined ? {} : { err }) },
-        "agent-wake: provider rejected the input as over-window with auto-compaction suppressed; failing the wake",
-      );
+      log.warn({ conversationId, source, ...extraLogFields }, logMessage);
       return {
         invoked: false,
         producedToolCalls: false,
@@ -1010,21 +1030,13 @@ export async function wakeAgentForOpportunity(
           estimatedInputTokens !== null &&
           estimatedInputTokens > effectiveContextWindow.maxInputTokens
         ) {
-          failedContextOverflow = true;
-          log.warn(
+          return failSuppressedContextOverflow(
+            "agent-wake: input exceeds the effective context window and auto-compaction is suppressed; failing fast",
             {
-              conversationId,
-              source,
               estimatedInputTokens,
               maxInputTokens: effectiveContextWindow.maxInputTokens,
             },
-            "agent-wake: input exceeds the effective context window and auto-compaction is suppressed; failing fast",
           );
-          return {
-            invoked: false,
-            producedToolCalls: false,
-            reason: "context_overflow" as const,
-          };
         }
       }
 
@@ -1068,12 +1080,16 @@ export async function wakeAgentForOpportunity(
       } catch (err) {
         // An over-window throw on a compaction-suppressed wake is the
         // suppression contract's failure mode, not a generic loop error —
-        // surface it as a deterministic failed result.
+        // surface it as a deterministic failed result. The heuristic check
+        // also catches rewrapped (untyped) provider overflow errors.
         if (
           suppressedContextOverflow ||
-          (suppressAutoCompaction && isContextOverflowError(err))
+          (suppressAutoCompaction && looksLikeContextOverflowError(err))
         ) {
-          return failSuppressedContextOverflow(err);
+          return failSuppressedContextOverflow(
+            OVER_WINDOW_REJECTION_LOG_MESSAGE,
+            { err },
+          );
         }
         // Capture the error for post-finally logging, then short-circuit
         // the rest of the try body — no tail to push/persist when the
@@ -1089,7 +1105,7 @@ export async function wakeAgentForOpportunity(
       // `suppressedContextOverflow` by `onEvent`). Map it to a deterministic
       // failure instead of the silent no-op it would otherwise read as.
       if (suppressedContextOverflow) {
-        return failSuppressedContextOverflow();
+        return failSuppressedContextOverflow(OVER_WINDOW_REJECTION_LOG_MESSAGE);
       }
 
       // Run completed cleanly. The canonical user-turn pattern


### PR DESCRIPTION
## Summary
Fixes gaps from the memory-retrospective-fork-hardening plan review:
- Fork wakes can pin hasNoClient so the system prompt byte-matches the source's live turns
- wakePersonaOverride can no longer leak when config/profile reads throw
- Suppressed-wake overflow detection also catches rewrapped (untyped) provider overflow errors, so retrospectives can't advance past an unreviewed slice
- Wake compaction gate sizes against the wake's call site/window, not mainAgent
- Deduplicated the suppressed-overflow failure path; shared SubagentToolGateMode type