### PR TITLE
fix(electron): auto-recover from wake-time network errors (LUM-2402)

### DIFF
--- a/apps/macos/src/main/index.ts
+++ b/apps/macos/src/main/index.ts
@@ -23,7 +23,10 @@ import { handleSync } from "./ipc";
 import { resolveAppProtocolPath } from "./app-protocol";
 import { registerVellumAppProtocol } from "./vellumapp-protocol";
 import { planGatewayForward } from "./gateway-forward";
-import { planPlatformForward } from "./platform-forward";
+import {
+  fetchForwardPlanWithRetry,
+  planPlatformForward,
+} from "./platform-forward";
 import {
   extractDeepLinkFromArgv,
   handleDeepLink,
@@ -291,22 +294,33 @@ const forwardPlatformRequest = async (
     return new Response(plan.message, { status: plan.status });
   }
 
-  try {
-    return await net.fetch(plan.url, {
-      method: plan.method,
-      headers: plan.headers,
-      body: plan.hasBody ? request.body : undefined,
-      ...(plan.hasBody ? { duplex: "half" } : {}),
-      redirect: "manual",
-      // Auth is header-based (X-Session-Token), not cookie-based.
-      // Omit credentials so stale session cookies in the main process's
-      // default session store never shadow the renderer's token header.
-      credentials: "omit",
-    });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "Platform unreachable";
-    return new Response(message, { status: 502 });
-  }
+  // Transient net-stack failures (e.g. ERR_NETWORK_CHANGED while Wi-Fi
+  // reassociates after sleep) retry in-proxy for GET/HEAD; whatever still
+  // fails becomes a structured 502 the renderer can classify, never a raw
+  // `net::ERR_*` body (LUM-2402).
+  return fetchForwardPlanWithRetry(
+    plan,
+    () =>
+      net.fetch(plan.url, {
+        method: plan.method,
+        headers: plan.headers,
+        body: plan.hasBody ? request.body : undefined,
+        ...(plan.hasBody ? { duplex: "half" } : {}),
+        redirect: "manual",
+        // Auth is header-based (X-Session-Token), not cookie-based.
+        // Omit credentials so stale session cookies in the main process's
+        // default session store never shadow the renderer's token header.
+        credentials: "omit",
+      }),
+    {
+      onError: (err, attempt) => {
+        console.error(
+          `[platform-forward] net.fetch failed (attempt ${attempt + 1}) for ${plan.method} ${plan.url}:`,
+          err,
+        );
+      },
+    },
+  );
 };
 
 // ---------------------------------------------------------------------------

--- a/apps/macos/src/main/platform-forward.test.ts
+++ b/apps/macos/src/main/platform-forward.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from "bun:test";
 
-import { planPlatformForward } from "./platform-forward";
+import {
+  buildProxyNetworkErrorResponse,
+  fetchForwardPlanWithRetry,
+  isTransientNetworkError,
+  planPlatformForward,
+  PROXY_ERROR_HEADER,
+  PROXY_NETWORK_ERROR_CODE,
+} from "./platform-forward";
 
 const PLATFORM = "https://platform.vellum.ai";
 const ELECTRON_RENDERER_ORIGIN_HEADER = "X-Vellum-Electron-Renderer-Origin";
@@ -284,5 +291,146 @@ describe("planPlatformForward", () => {
     expect(
       planPlatformForward(request("/accountsettings"), PLATFORM),
     ).toEqual({ kind: "pass" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transient-failure retry + structured proxy error (LUM-2402)
+// ---------------------------------------------------------------------------
+
+describe("isTransientNetworkError", () => {
+  test("matches Chromium transient net errors", () => {
+    for (const code of [
+      "ERR_NETWORK_CHANGED",
+      "ERR_INTERNET_DISCONNECTED",
+      "ERR_NAME_NOT_RESOLVED",
+      "ERR_CONNECTION_RESET",
+    ]) {
+      expect(isTransientNetworkError(new Error(`net::${code}`))).toBe(true);
+    }
+  });
+
+  test("rejects other errors and non-Error values", () => {
+    expect(isTransientNetworkError(new Error("net::ERR_CERT_INVALID"))).toBe(
+      false,
+    );
+    expect(isTransientNetworkError(new Error("boom"))).toBe(false);
+    expect(isTransientNetworkError("ERR_NETWORK_CHANGED")).toBe(false);
+    expect(isTransientNetworkError(undefined)).toBe(false);
+  });
+});
+
+describe("buildProxyNetworkErrorResponse", () => {
+  test("returns a structured JSON 502 with the marker header", async () => {
+    const response = buildProxyNetworkErrorResponse();
+    expect(response.status).toBe(502);
+    expect(response.headers.get("content-type")).toBe("application/json");
+    expect(response.headers.get(PROXY_ERROR_HEADER)).toBe("network");
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.code).toBe(PROXY_NETWORK_ERROR_CODE);
+    expect(typeof body.detail).toBe("string");
+    expect(body.detail).not.toContain("net::");
+  });
+});
+
+describe("fetchForwardPlanWithRetry", () => {
+  const noSleep = async () => {};
+  const get = { method: "GET", hasBody: false };
+  const post = { method: "POST", hasBody: true };
+
+  test("retries a GET through a transient failure and returns the eventual success", async () => {
+    let attempts = 0;
+    const sleeps: number[] = [];
+    const response = await fetchForwardPlanWithRetry(
+      get,
+      async () => {
+        attempts += 1;
+        if (attempts === 1) throw new Error("net::ERR_NETWORK_CHANGED");
+        return new Response("ok", { status: 200 });
+      },
+      {
+        sleep: async (ms) => {
+          sleeps.push(ms);
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(attempts).toBe(2);
+    expect(sleeps).toEqual([500]);
+  });
+
+  test("returns the structured 502 after exhausting retries", async () => {
+    let attempts = 0;
+    const response = await fetchForwardPlanWithRetry(
+      get,
+      async () => {
+        attempts += 1;
+        throw new Error("net::ERR_NETWORK_CHANGED");
+      },
+      { retries: 2, sleep: noSleep },
+    );
+
+    expect(attempts).toBe(3);
+    expect(response.status).toBe(502);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.code).toBe(PROXY_NETWORK_ERROR_CODE);
+  });
+
+  test("does not retry requests with a body — their stream is single-use", async () => {
+    let attempts = 0;
+    const response = await fetchForwardPlanWithRetry(
+      post,
+      async () => {
+        attempts += 1;
+        throw new Error("net::ERR_NETWORK_CHANGED");
+      },
+      { sleep: noSleep },
+    );
+
+    expect(attempts).toBe(1);
+    expect(response.status).toBe(502);
+  });
+
+  test("does not retry non-transient failures", async () => {
+    let attempts = 0;
+    const response = await fetchForwardPlanWithRetry(
+      get,
+      async () => {
+        attempts += 1;
+        throw new Error("net::ERR_CERT_AUTHORITY_INVALID");
+      },
+      { sleep: noSleep },
+    );
+
+    expect(attempts).toBe(1);
+    expect(response.status).toBe(502);
+  });
+
+  test("reports every failed attempt to onError", async () => {
+    const seen: number[] = [];
+    await fetchForwardPlanWithRetry(
+      get,
+      async () => {
+        throw new Error("net::ERR_CONNECTION_RESET");
+      },
+      {
+        retries: 1,
+        sleep: noSleep,
+        onError: (_err, attempt) => {
+          seen.push(attempt);
+        },
+      },
+    );
+
+    expect(seen).toEqual([0, 1]);
+  });
+
+  test("a successful response passes through untouched on the first attempt", async () => {
+    const upstream = new Response("hello", { status: 201 });
+    const response = await fetchForwardPlanWithRetry(get, async () => upstream, {
+      sleep: noSleep,
+    });
+    expect(response).toBe(upstream);
   });
 });

--- a/apps/macos/src/main/platform-forward.ts
+++ b/apps/macos/src/main/platform-forward.ts
@@ -177,3 +177,107 @@ export function planPlatformForward(
     hasBody: request.method !== "GET" && request.method !== "HEAD",
   };
 }
+
+/**
+ * Error code carried in the JSON body of a proxy-synthesized 502 so the
+ * renderer can tell "the proxy's own `net.fetch` failed" apart from a real
+ * platform answer. Mirrors `PROXY_NETWORK_ERROR_CODE` in
+ * `apps/web/src/assistant/lifecycle.ts`; the two must stay in sync, but
+ * there is no shared package between the renderer and the Electron main
+ * bundle to host the constant.
+ */
+export const PROXY_NETWORK_ERROR_CODE = "proxy_network_error";
+
+/** Marker header on proxy-synthesized error responses. */
+export const PROXY_ERROR_HEADER = "X-Vellum-Proxy-Error";
+
+const PROXY_NETWORK_ERROR_DETAIL =
+  "Couldn't reach Vellum. Check your internet connection and try again.";
+
+/**
+ * Chromium net-stack failures that resolve on their own within seconds —
+ * the classic case is `ERR_NETWORK_CHANGED` while Wi-Fi reassociates after
+ * sleep/wake (LUM-2402). Worth a quick in-proxy retry before bothering the
+ * renderer.
+ */
+const TRANSIENT_NET_ERROR_CODES = [
+  "ERR_NETWORK_CHANGED",
+  "ERR_INTERNET_DISCONNECTED",
+  "ERR_NAME_NOT_RESOLVED",
+  "ERR_CONNECTION_RESET",
+] as const;
+
+export function isTransientNetworkError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return TRANSIENT_NET_ERROR_CODES.some((code) => err.message.includes(code));
+}
+
+/**
+ * The 502 returned when the proxy's own `net.fetch` rejected. Structured
+ * (JSON `detail` + `code`, marker header) instead of the raw Chromium
+ * message so the renderer never renders `net::ERR_*` strings and can
+ * classify the failure as transport-shaped.
+ */
+export function buildProxyNetworkErrorResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      detail: PROXY_NETWORK_ERROR_DETAIL,
+      code: PROXY_NETWORK_ERROR_CODE,
+    }),
+    {
+      status: 502,
+      headers: {
+        "Content-Type": "application/json",
+        [PROXY_ERROR_HEADER]: "network",
+      },
+    },
+  );
+}
+
+export interface ForwardFetchRetryOptions {
+  /** Extra attempts after the first failure. */
+  retries?: number;
+  retryDelayMs?: number;
+  /** Injectable for tests. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Per-failure observer (logging); receives every rejected attempt. */
+  onError?: (err: unknown, attempt: number) => void;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Run a forward plan's fetch with retry-on-transient-failure semantics.
+ * Only bodiless idempotent requests (GET/HEAD) retry — anything with a
+ * body streams `request.body`, which is single-use, and non-idempotent
+ * methods must not be silently replayed. Exhausted or non-transient
+ * failures collapse into the structured 502 instead of rejecting, so the
+ * protocol handler never propagates a raw error to the renderer.
+ */
+export async function fetchForwardPlanWithRetry(
+  plan: { method: string; hasBody: boolean },
+  doFetch: () => Promise<Response>,
+  options: ForwardFetchRetryOptions = {},
+): Promise<Response> {
+  const {
+    retries = 2,
+    retryDelayMs = 500,
+    sleep = defaultSleep,
+    onError,
+  } = options;
+  const retryable =
+    !plan.hasBody && ["GET", "HEAD"].includes(plan.method.toUpperCase());
+
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await doFetch();
+    } catch (err) {
+      onError?.(err, attempt);
+      const canRetry =
+        retryable && attempt < retries && isTransientNetworkError(err);
+      if (!canRetry) return buildProxyNetworkErrorResponse();
+      await sleep(retryDelayMs);
+    }
+  }
+}

--- a/apps/web/src/assistant/lifecycle-service.test.ts
+++ b/apps/web/src/assistant/lifecycle-service.test.ts
@@ -18,9 +18,15 @@ import type { QueryClient } from "@tanstack/react-query";
 import {
   buildInitializingTimeoutError,
   resolveAssistantLifecycleState,
+  TRANSPORT_ERROR_MESSAGE,
 } from "@/assistant/lifecycle";
+import { publish } from "@/lib/event-bus";
 
 const TEST_INITIALIZING_TIMEOUT_MS = 30;
+// Shrunk transient-error auto-retry delay. Large enough that a timer
+// armed by an unrelated test gets cleared by `afterEach` before it
+// fires; small enough for the recovery tests' `waitFor` budget.
+const TEST_ERROR_RETRY_DELAY_MS = 200;
 
 // --- module mocks --- //
 
@@ -79,6 +85,8 @@ mock.module("@/assistant/lifecycle", () => ({
   buildInitializingTimeoutError,
   INITIALIZING_TIMEOUT_MS: TEST_INITIALIZING_TIMEOUT_MS,
   resolveAssistantLifecycleState,
+  TRANSPORT_ERROR_MESSAGE,
+  errorRetryDelayMs: () => TEST_ERROR_RETRY_DELAY_MS,
 }));
 
 // --- imports under test --- //
@@ -849,6 +857,228 @@ describe("lifecycleService — selection subscription", () => {
     ).toBeNull();
     expect(useAssistantLifecycleStore.getState().assistantState).toEqual({
       kind: "loading",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transport-shaped failures (LUM-2402)
+//
+// A wake-time network flap must not tear down a live chat surface
+// (active → full-screen error) and must never strand the user on a
+// dead error screen: transient errors carry friendly copy and
+// auto-retry with backoff / on network-online signals.
+// ---------------------------------------------------------------------------
+
+describe("lifecycleService — transport-shaped failures", () => {
+  function activeResult(id: string) {
+    return {
+      ok: true as const,
+      status: 200,
+      data: {
+        id,
+        status: "active",
+        is_local: false,
+        maintenance_mode: { enabled: false },
+      },
+    };
+  }
+
+  /** The structured 502 the Electron platform proxy synthesizes. */
+  const proxyNetworkErrorResult = {
+    ok: false as const,
+    status: 502,
+    error: {
+      detail: "Couldn't reach Vellum. Check your internet connection and try again.",
+      code: "proxy_network_error",
+    },
+  };
+
+  async function driveActive(id: string): Promise<void> {
+    getAssistantMock.mockImplementationOnce(async () => activeResult(id));
+    lifecycleService.setInputs({
+      ...baseInputs,
+      queryClient: makeQueryClient(),
+    });
+    await lifecycleService.checkAssistant();
+    expect(useAssistantLifecycleStore.getState().assistantState.kind).toBe(
+      "active",
+    );
+  }
+
+  test("active + thrown re-check degrades to reachable:false instead of tearing down", async () => {
+    await driveActive("asst-live");
+    getAssistantMock.mockImplementationOnce(async () => {
+      throw new Error("Failed to fetch");
+    });
+
+    await lifecycleService.checkAssistant();
+
+    const state = useAssistantLifecycleStore.getState().assistantState;
+    expect(state.kind).toBe("active");
+    if (state.kind === "active") {
+      expect(state.reachable).toBe(false);
+    }
+    // The degraded session keeps its operational-status polling target.
+    expect(
+      useAssistantLifecycleStore.getState().operationalStatusAssistantId,
+    ).toBe("asst-live");
+  });
+
+  test("active + proxy-synthesized network 502 degrades instead of tearing down", async () => {
+    await driveActive("asst-live-2");
+    getAssistantMock.mockImplementationOnce(async () => proxyNetworkErrorResult);
+
+    await lifecycleService.checkAssistant();
+
+    const state = useAssistantLifecycleStore.getState().assistantState;
+    expect(state.kind).toBe("active");
+    if (state.kind === "active") {
+      expect(state.reachable).toBe(false);
+    }
+    expect(
+      useAssistantLifecycleStore.getState().operationalStatusAssistantId,
+    ).toBe("asst-live-2");
+  });
+
+  test("active + genuine server error still tears down to the error screen", async () => {
+    await driveActive("asst-live-3");
+    getAssistantMock.mockImplementationOnce(async () => ({
+      ok: false,
+      status: 500,
+      error: { detail: "Internal server error" },
+    }));
+
+    await lifecycleService.checkAssistant();
+
+    const state = useAssistantLifecycleStore.getState().assistantState;
+    expect(state).toMatchObject({
+      kind: "error",
+      message: "Internal server error",
+    });
+    if (state.kind === "error") {
+      expect(state.transient).toBeUndefined();
+    }
+  });
+
+  test("initializing + transport blip stays initializing (watchdog is the backstop)", async () => {
+    getAssistantMock.mockImplementationOnce(async () =>
+      initializingResult("asst-init-blip"),
+    );
+    lifecycleService.setInputs({
+      ...baseInputs,
+      queryClient: makeQueryClient(),
+    });
+    await lifecycleService.checkAssistant();
+    expect(useAssistantLifecycleStore.getState().assistantState.kind).toBe(
+      "initializing",
+    );
+
+    getAssistantMock.mockImplementationOnce(async () => proxyNetworkErrorResult);
+    await lifecycleService.checkAssistant();
+
+    expect(useAssistantLifecycleStore.getState().assistantState.kind).toBe(
+      "initializing",
+    );
+  });
+
+  test("boot-time transport failure lands on a transient error with friendly copy", async () => {
+    getAssistantMock.mockImplementationOnce(async () => {
+      throw new Error("net::ERR_NETWORK_CHANGED");
+    });
+    lifecycleService.setInputs({
+      ...baseInputs,
+      queryClient: makeQueryClient(),
+    });
+
+    await lifecycleService.checkAssistant();
+
+    expect(useAssistantLifecycleStore.getState().assistantState).toEqual({
+      kind: "error",
+      transient: true,
+      message: TRANSPORT_ERROR_MESSAGE,
+    });
+  });
+
+  test("transient error auto-retries with backoff and recovers to active", async () => {
+    getAssistantMock.mockImplementationOnce(async () => {
+      throw new Error("Failed to fetch");
+    });
+    lifecycleService.setInputs({
+      ...baseInputs,
+      queryClient: makeQueryClient(),
+    });
+    await lifecycleService.checkAssistant();
+    expect(useAssistantLifecycleStore.getState().assistantState.kind).toBe(
+      "error",
+    );
+
+    // Next check (fired by the armed retry timer) succeeds.
+    getAssistantMock.mockImplementationOnce(async () =>
+      activeResult("asst-recovered"),
+    );
+
+    await waitFor(
+      () =>
+        useAssistantLifecycleStore.getState().assistantState.kind === "active",
+      1000,
+    );
+    expect(
+      useResolvedAssistantsStore.getState().activeAssistantId,
+    ).toBe("asst-recovered");
+  });
+
+  test("app.online retries a transient error immediately, ahead of the backoff timer", async () => {
+    getAssistantMock.mockImplementationOnce(async () => {
+      throw new Error("Failed to fetch");
+    });
+    lifecycleService.setInputs({
+      ...baseInputs,
+      queryClient: makeQueryClient(),
+    });
+    await lifecycleService.checkAssistant();
+    expect(useAssistantLifecycleStore.getState().assistantState.kind).toBe(
+      "error",
+    );
+    const callsBefore = getAssistantMock.mock.calls.length;
+    getAssistantMock.mockImplementationOnce(async () =>
+      activeResult("asst-online"),
+    );
+
+    publish("app.online", {});
+
+    // The re-check starts synchronously from the online signal — no
+    // backoff wait involved.
+    expect(getAssistantMock.mock.calls.length).toBe(callsBefore + 1);
+    await waitFor(
+      () =>
+        useAssistantLifecycleStore.getState().assistantState.kind === "active",
+      1000,
+    );
+  });
+
+  test("non-transient error does not auto-retry", async () => {
+    getAssistantMock.mockImplementationOnce(async () => ({
+      ok: false,
+      status: 500,
+      error: { detail: "Internal server error" },
+    }));
+    lifecycleService.setInputs({
+      ...baseInputs,
+      queryClient: makeQueryClient(),
+    });
+    await lifecycleService.checkAssistant();
+    const callsAfterError = getAssistantMock.mock.calls.length;
+
+    // Give a would-be retry timer ample time to fire.
+    await new Promise((resolve) =>
+      setTimeout(resolve, TEST_ERROR_RETRY_DELAY_MS * 2),
+    );
+
+    expect(getAssistantMock.mock.calls.length).toBe(callsAfterError);
+    expect(useAssistantLifecycleStore.getState().assistantState).toMatchObject({
+      kind: "error",
+      message: "Internal server error",
     });
   });
 });

--- a/apps/web/src/assistant/lifecycle-service.ts
+++ b/apps/web/src/assistant/lifecycle-service.ts
@@ -33,9 +33,12 @@ import {
 import { subscribeAssistantUnreachable } from "@/assistant/unreachable-bus";
 import {
   buildInitializingTimeoutError,
+  errorRetryDelayMs,
   INITIALIZING_TIMEOUT_MS,
   resolveAssistantLifecycleState,
+  TRANSPORT_ERROR_MESSAGE,
 } from "@/assistant/lifecycle";
+import { subscribe } from "@/lib/event-bus";
 import {
   ASSISTANT_QUERY_KEY,
   assistantQueryKey,
@@ -100,9 +103,22 @@ class AssistantLifecycleService {
     selectedPlatformAssistantId: null,
   };
   private probeTimer: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * Auto-retry for transient (transport-shaped) error states —
+   * armed by `transition` on entering such a state, cleared on
+   * leaving it. The attempt counter drives the backoff schedule and
+   * resets once the lifecycle leaves `error` entirely.
+   */
+  private errorRetryTimer: ReturnType<typeof setTimeout> | null = null;
+  private errorRetryAttempt = 0;
 
   constructor() {
     subscribeAssistantUnreachable(() => this.onUnreachable());
+    // Network-back signal: retry a transient error immediately (no
+    // point waiting out the backoff once the browser says we're
+    // online) and re-check a degraded-active session so the
+    // "Reconnecting…" banner clears as soon as possible.
+    subscribe("app.online", () => this.onNetworkOnline());
     // Republish `activeAssistantId` whenever the selection changes, at the
     // store funnel so every writer (and future ones) is covered — gateway-auth
     // mode has no other republish path while connected (the React effect's
@@ -243,11 +259,42 @@ class AssistantLifecycleService {
       console.error("Error checking assistant status:", err);
       captureError(err, { context: "check_assistant" });
       if (generation !== this.generation) return;
+      // A thrown fetch is a transport failure (the request never got
+      // an HTTP answer) — same degrade/auto-retry semantics as a
+      // proxy-synthesized network error result.
+      if (this.degradeOnTransportFailure()) return;
       this.transition({
         kind: "error",
-        message: "Network error. Please check your connection and try again.",
+        transient: true,
+        message: TRANSPORT_ERROR_MESSAGE,
       });
     }
+  }
+
+  /**
+   * Shared handling for transport-shaped failures (wake-time network
+   * flap, device offline): a live or in-progress surface must not be
+   * torn down for a connectivity blip (LUM-2402, the post-sleep
+   * `net::ERR_NETWORK_CHANGED` full-screen error).
+   *
+   * Returns true when the failure was absorbed:
+   *   - `active` → degrade to `reachable: false` (existing probe loop
+   *     + "Reconnecting…" banner) and self-heal when the probe lands.
+   *   - `initializing` / `cleaning_up` → stay put; the background
+   *     poll keeps reporting and the stuck-initializing watchdog is
+   *     the backstop for a real outage.
+   * Returns false for `loading`/`error`, where there is no surface to
+   * preserve — the caller transitions to a transient error state,
+   * whose auto-retry takes over.
+   */
+  private degradeOnTransportFailure(): boolean {
+    if (this.state.kind === "active") {
+      this.triggerReachabilityProbe();
+      return true;
+    }
+    return (
+      this.state.kind === "initializing" || this.state.kind === "cleaning_up"
+    );
   }
 
   retryAssistant(): void {
@@ -298,6 +345,55 @@ class AssistantLifecycleService {
     // arrived or be arriving via SSE).
     if (next.kind !== "initializing" && next.kind !== "active") {
       this.clearExpectingFirstMessage();
+    }
+    // Auto-retry edge-trigger: entering a transient (transport-shaped)
+    // error arms the next backoff step — including error → error
+    // re-entries, which are how a failed retry schedules the following
+    // one. Leaving `error` entirely resets the backoff schedule; a
+    // non-transient error stops auto-retrying but keeps the attempt
+    // count (it's terminal until the user or a network signal acts).
+    if (next.kind === "error" && next.transient) {
+      this.armErrorRetry();
+    } else {
+      this.clearErrorRetry(next.kind !== "error");
+    }
+  }
+
+  private clearErrorRetry(resetAttempts: boolean): void {
+    if (this.errorRetryTimer) {
+      clearTimeout(this.errorRetryTimer);
+      this.errorRetryTimer = null;
+    }
+    if (resetAttempts) this.errorRetryAttempt = 0;
+  }
+
+  private armErrorRetry(): void {
+    if (this.errorRetryTimer) clearTimeout(this.errorRetryTimer);
+    const delay = errorRetryDelayMs(this.errorRetryAttempt);
+    this.errorRetryAttempt += 1;
+    this.errorRetryTimer = setTimeout(() => {
+      this.errorRetryTimer = null;
+      void this.checkAssistant();
+    }, delay);
+  }
+
+  /**
+   * `app.online` — the browser observed the network coming back.
+   * Skip the remaining backoff and retry now: a transient error
+   * re-checks the assistant from scratch (backoff reset so a
+   * follow-up flap starts the schedule over), and a degraded-active
+   * session re-checks so its banner clears without waiting for the
+   * probe loop's next tick.
+   */
+  private onNetworkOnline(): void {
+    if (!this.ready) return;
+    if (this.state.kind === "error" && this.state.transient) {
+      this.clearErrorRetry(true);
+      void this.checkAssistant();
+      return;
+    }
+    if (this.state.kind === "active" && this.state.reachable === false) {
+      void this.checkAssistant();
     }
   }
 
@@ -398,6 +494,18 @@ class AssistantLifecycleService {
   ): Promise<void> {
     const generation = this.generation;
     const nextState = resolveAssistantLifecycleState(result);
+
+    // Transport-shaped failure: absorb it before any store writes so
+    // a degraded-active session keeps its operational-status id (the
+    // status banner's polling target) along with its surface.
+    if (
+      nextState.kind === "error" &&
+      nextState.transient &&
+      this.degradeOnTransportFailure()
+    ) {
+      return;
+    }
+
     if (result.ok) {
       this.setOperationalStatusAssistantId(result.data.id);
     } else {
@@ -500,6 +608,7 @@ class AssistantLifecycleService {
       this.initializingTimeout = null;
     }
     this.cancelProbeTimer();
+    this.clearErrorRetry(true);
     this.state = { kind: "loading" };
     this.generation = 0;
     this.ready = false;

--- a/apps/web/src/assistant/lifecycle.test.ts
+++ b/apps/web/src/assistant/lifecycle.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  ERROR_RETRY_BASE_MS,
+  ERROR_RETRY_MAX_MS,
+  errorRetryDelayMs,
+  isTransportShapedError,
+  PROXY_NETWORK_ERROR_CODE,
+  resolveAssistantLifecycleState,
+  TRANSPORT_ERROR_MESSAGE,
+} from "./lifecycle";
+
+describe("resolveAssistantLifecycleState — transport-shaped failures (LUM-2402)", () => {
+  test("proxy-synthesized network 502 resolves to a transient error with friendly copy", () => {
+    expect(
+      resolveAssistantLifecycleState({
+        ok: false,
+        status: 502,
+        error: {
+          detail: "Couldn't reach Vellum.",
+          code: PROXY_NETWORK_ERROR_CODE,
+        },
+      }),
+    ).toEqual({
+      kind: "error",
+      transient: true,
+      message: TRANSPORT_ERROR_MESSAGE,
+    });
+  });
+
+  test("raw Chromium net:: detail (legacy proxy body) is never shown to the user", () => {
+    const state = resolveAssistantLifecycleState({
+      ok: false,
+      status: 502,
+      error: { detail: "net::ERR_NETWORK_CHANGED" },
+    });
+    expect(state).toEqual({
+      kind: "error",
+      transient: true,
+      message: TRANSPORT_ERROR_MESSAGE,
+    });
+  });
+
+  test("genuine server errors stay non-transient with their own message", () => {
+    expect(
+      resolveAssistantLifecycleState({
+        ok: false,
+        status: 500,
+        error: { detail: "Internal server error" },
+      }),
+    ).toEqual({ kind: "error", message: "Internal server error" });
+  });
+
+  test("404 still resolves to auto_hatch, not a transport error", () => {
+    expect(
+      resolveAssistantLifecycleState({ ok: false, status: 404, error: {} }),
+    ).toEqual({ kind: "auto_hatch" });
+  });
+});
+
+describe("isTransportShapedError", () => {
+  test("matches the structured proxy code", () => {
+    expect(
+      isTransportShapedError({ code: PROXY_NETWORK_ERROR_CODE }),
+    ).toBe(true);
+  });
+
+  test("matches a raw net::ERR_* detail", () => {
+    expect(
+      isTransportShapedError({ detail: "net::ERR_INTERNET_DISCONNECTED" }),
+    ).toBe(true);
+  });
+
+  test("does not match ordinary server error payloads", () => {
+    expect(isTransportShapedError({ detail: "Bad Gateway" })).toBe(false);
+    expect(isTransportShapedError({ code: "platform_hosted_disabled" })).toBe(
+      false,
+    );
+    expect(isTransportShapedError({})).toBe(false);
+  });
+});
+
+describe("errorRetryDelayMs", () => {
+  test("doubles from the base and caps at the maximum", () => {
+    expect(errorRetryDelayMs(0)).toBe(ERROR_RETRY_BASE_MS);
+    expect(errorRetryDelayMs(1)).toBe(ERROR_RETRY_BASE_MS * 2);
+    expect(errorRetryDelayMs(2)).toBe(ERROR_RETRY_BASE_MS * 4);
+    expect(errorRetryDelayMs(4)).toBe(ERROR_RETRY_MAX_MS);
+    expect(errorRetryDelayMs(20)).toBe(ERROR_RETRY_MAX_MS);
+  });
+});

--- a/apps/web/src/assistant/lifecycle.ts
+++ b/apps/web/src/assistant/lifecycle.ts
@@ -8,7 +8,40 @@ export type ResolvedAssistantLifecycleState =
   | { kind: "initializing" }
   | { kind: "cleaning_up" }
   | { kind: "auto_hatch" }
-  | { kind: "error"; message: string };
+  | { kind: "error"; message: string; transient?: boolean };
+
+/**
+ * Error code the Electron main process's platform proxy puts in its
+ * synthesized 502 body when `net.fetch` itself failed (the request
+ * never reached the platform — e.g. `net::ERR_NETWORK_CHANGED` while
+ * Wi-Fi reassociates after sleep). Mirrors `PROXY_NETWORK_ERROR_CODE`
+ * in `apps/macos/src/main/platform-forward.ts`; the two must stay in
+ * sync, but there is no shared package between the renderer and the
+ * Electron main bundle to host the constant.
+ */
+export const PROXY_NETWORK_ERROR_CODE = "proxy_network_error";
+
+export const TRANSPORT_ERROR_MESSAGE =
+  "Connection interrupted. Reconnecting…";
+
+/**
+ * Does this failed `/assistant/` result look like a transport failure
+ * (device offline, network flapping on wake) rather than a server
+ * answer? Two signals:
+ *   - the structured code the Electron platform proxy attaches when
+ *     its own `net.fetch` rejected, and
+ *   - a raw Chromium `net::ERR_*` string in the detail (older
+ *     Electron builds forwarded the error message verbatim).
+ * Thrown fetches (the browser path) never reach this — they surface
+ * via `checkAssistant`'s catch instead.
+ */
+export function isTransportShapedError(
+  error: Record<string, unknown>,
+): boolean {
+  if (error.code === PROXY_NETWORK_ERROR_CODE) return true;
+  const detail = typeof error.detail === "string" ? error.detail : "";
+  return detail.includes("net::ERR_");
+}
 
 export function resolveAssistantLifecycleState(
   result: GetAssistantResult,
@@ -34,6 +67,18 @@ export function resolveAssistantLifecycleState(
 
   if (result.status === 404) {
     return { kind: "auto_hatch" };
+  }
+
+  // Transport-shaped failures get friendly copy (never a raw
+  // `net::ERR_*` string) and the `transient` marker that drives the
+  // lifecycle service's degrade-instead-of-error and auto-retry
+  // behavior (LUM-2402).
+  if (isTransportShapedError(result.error)) {
+    return {
+      kind: "error",
+      transient: true,
+      message: TRANSPORT_ERROR_MESSAGE,
+    };
   }
 
   return {
@@ -67,6 +112,20 @@ export function isPlatformHostedDisabled(
 ): boolean {
   if (status !== 503) return false;
   return error?.code === PLATFORM_HOSTED_DISABLED_CODE;
+}
+
+/**
+ * Backoff schedule for auto-retrying a transient (transport-shaped)
+ * error state: 2s, 4s, 8s, … capped at 30s. Wake-time network flaps
+ * usually resolve within a few seconds, so the early retries recover
+ * the session without the user touching anything; the cap keeps a
+ * long outage from polling aggressively forever.
+ */
+export const ERROR_RETRY_BASE_MS = 2_000;
+export const ERROR_RETRY_MAX_MS = 30_000;
+
+export function errorRetryDelayMs(attempt: number): number {
+  return Math.min(ERROR_RETRY_BASE_MS * 2 ** attempt, ERROR_RETRY_MAX_MS);
 }
 
 export const INITIALIZING_TIMEOUT_MS = 300_000;

--- a/apps/web/src/assistant/types.ts
+++ b/apps/web/src/assistant/types.ts
@@ -18,4 +18,11 @@ export type AssistantState =
   | { kind: "cleaning_up" }
   | { kind: "self_hosted" }
   | { kind: "active"; isLocal: boolean; maintenanceMode?: MaintenanceModeInfo; reachable?: boolean }
-  | { kind: "error"; message: string };
+  /**
+   * `transient: true` marks a transport-shaped failure (device offline,
+   * network flapping after sleep/wake) rather than a server-reported
+   * error. The lifecycle service auto-retries these with backoff and
+   * on network-online signals; the chat page renders them with
+   * reconnecting copy instead of a terminal error.
+   */
+  | { kind: "error"; message: string; transient?: boolean };

--- a/apps/web/src/domains/chat/chat-page.tsx
+++ b/apps/web/src/domains/chat/chat-page.tsx
@@ -90,11 +90,13 @@ export function ChatPage() {
   // Lifecycle guards — non-active assistant states
   // -------------------------------------------------------------------------
   if (assistantState.kind === "error") {
+    // Transient (transport-shaped) errors auto-retry in the lifecycle
+    // service; the button is just the impatient-user shortcut.
     return (
       <div className="flex h-full flex-col items-center justify-center gap-4 p-8 text-center">
         <p className="text-[var(--text-secondary)]">{assistantState.message}</p>
         <Button variant="primary" onClick={retryAssistant}>
-          Try again
+          {assistantState.transient ? "Retry now" : "Try again"}
         </Button>
       </div>
     );


### PR DESCRIPTION
## Summary
- **Renderer lifecycle**: a transport-shaped `/assistant/` check failure (thrown fetch, or the Electron proxy's synthesized network 502) no longer tears down a live chat — when `active`, the lifecycle degrades to the existing `reachable: false` probe-loop path ("Reconnecting…" banner over a usable transcript) and self-heals; `initializing`/`cleaning_up` stay put with the watchdog as backstop. Genuine server errors still get the full error screen.
- **Auto-recovering error state**: transport failures that do land on the error screen (e.g. boot while offline) are marked `transient`, render friendly copy ("Connection interrupted. Reconnecting…" — never raw `net::ERR_*` strings) with a "Retry now" button, and auto-retry with capped backoff (2s → 30s) plus an immediate re-check on the browser's `app.online` signal.
- **Electron platform proxy hardening**: `forwardPlatformRequest`'s `net.fetch` failures now retry idempotent GET/HEAD requests up to 2× (500ms apart) on transient Chromium net errors (`ERR_NETWORK_CHANGED`, `ERR_INTERNET_DISCONNECTED`, `ERR_NAME_NOT_RESOLVED`, `ERR_CONNECTION_RESET`), and failures that survive become a structured JSON 502 (`{detail, code: "proxy_network_error"}` + `X-Vellum-Proxy-Error` header) the renderer can classify instead of a raw error-message body.

Fixes [LUM-2402](https://linear.app/vellum/issue/LUM-2402/electron-shows-err-network-changed-after-laptop-sleep).

**Root cause**: on wake, `powerMonitor` resume triggers an immediate `checkAssistant()` while macOS Wi-Fi is still reassociating. The proxy's `net.fetch` rejects with `ERR_NETWORK_CHANGED`, which the old catch converted into a plain-text 502 whose body was the raw error string — so TanStack's retry never saw a rejection (`throwOnError: false` resolves `{ok: false}`), `resolveAssistantLifecycleState` treated it as a terminal error, and ChatPage replaced the whole chat with `net::ERR_NETWORK_CHANGED` + a manual "Try again" button that nothing ever retried automatically.

## Original prompt
Investigation of LUM-2402 (Electron app shows `net::ERR_NETWORK_CHANGED` with a "Try again" prompt after laptop sleep/wake) traced the failure chain from the wake-time `checkAssistant` through the Electron platform proxy's error-laundering 502 to the chat page's full-screen, never-auto-retried error state. The ask was to fix the UX so transient wake-time network blips auto-retry/self-heal instead of stranding the user on a dead error screen, via the three-layer fix above, with unit tests next to the changed modules.