### PR TITLE
fix(web): workspace file delete and rename via row context menu

### DIFF
--- a/apps/web/src/domains/workspace/components/workspace-browser.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-browser.tsx
@@ -66,6 +66,26 @@ export function WorkspaceBrowser({ assistantId }: { assistantId: string }) {
     });
   }, []);
 
+  const handlePathRenamed = useCallback((oldPath: string, newPath: string) => {
+    const remap = (p: string) =>
+      p === oldPath
+        ? newPath
+        : p.startsWith(`${oldPath}/`)
+          ? newPath + p.slice(oldPath.length)
+          : p;
+    setSelectedPath((prev) => (prev === null ? prev : remap(prev)));
+    setExpandedPaths((prev) => {
+      let changed = false;
+      const next = new Set<string>();
+      for (const p of prev) {
+        const mapped = remap(p);
+        if (mapped !== p) changed = true;
+        next.add(mapped);
+      }
+      return changed ? next : prev;
+    });
+  }, []);
+
   const treeProps = {
     assistantId,
     expandedPaths,
@@ -78,6 +98,7 @@ export function WorkspaceBrowser({ assistantId }: { assistantId: string }) {
     onToggleShowHidden: () => setShowHidden((v) => !v),
     onChangeSortMode: setSortMode,
     onPathDeleted: handlePathDeleted,
+    onPathRenamed: handlePathRenamed,
   };
 
   return (

--- a/apps/web/src/domains/workspace/components/workspace-browser.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-browser.tsx
@@ -57,6 +57,15 @@ export function WorkspaceBrowser({ assistantId }: { assistantId: string }) {
     setDrawerOpen(false);
   }, []);
 
+  const handlePathDeleted = useCallback((path: string) => {
+    const isDeleted = (p: string) => p === path || p.startsWith(`${path}/`);
+    setSelectedPath((prev) => (prev !== null && isDeleted(prev) ? null : prev));
+    setExpandedPaths((prev) => {
+      const next = new Set([...prev].filter((p) => !isDeleted(p)));
+      return next.size === prev.size ? prev : next;
+    });
+  }, []);
+
   const treeProps = {
     assistantId,
     expandedPaths,
@@ -68,6 +77,7 @@ export function WorkspaceBrowser({ assistantId }: { assistantId: string }) {
     onSelectPath: handleSelectPath,
     onToggleShowHidden: () => setShowHidden((v) => !v),
     onChangeSortMode: setSortMode,
+    onPathDeleted: handlePathDeleted,
   };
 
   return (

--- a/apps/web/src/domains/workspace/components/workspace-browser.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-browser.tsx
@@ -66,6 +66,11 @@ export function WorkspaceBrowser({ assistantId }: { assistantId: string }) {
     });
   }, []);
 
+  const [lastRename, setLastRename] = useState<{
+    from: string;
+    to: string;
+  } | null>(null);
+
   const handlePathRenamed = useCallback((oldPath: string, newPath: string) => {
     const remap = (p: string) =>
       p === oldPath
@@ -84,6 +89,7 @@ export function WorkspaceBrowser({ assistantId }: { assistantId: string }) {
       }
       return changed ? next : prev;
     });
+    setLastRename({ from: oldPath, to: newPath });
   }, []);
 
   const treeProps = {
@@ -139,6 +145,7 @@ export function WorkspaceBrowser({ assistantId }: { assistantId: string }) {
             viewMode={viewMode}
             onChangeViewMode={setViewMode}
             onBrowse={() => setDrawerOpen(true)}
+            pathRename={lastRename}
           />
         </div>
       </div>

--- a/apps/web/src/domains/workspace/components/workspace-browser.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-browser.tsx
@@ -57,6 +57,8 @@ export function WorkspaceBrowser({ assistantId }: { assistantId: string }) {
     setDrawerOpen(false);
   }, []);
 
+  const [lastDelete, setLastDelete] = useState<{ path: string } | null>(null);
+
   const handlePathDeleted = useCallback((path: string) => {
     const isDeleted = (p: string) => p === path || p.startsWith(`${path}/`);
     setSelectedPath((prev) => (prev !== null && isDeleted(prev) ? null : prev));
@@ -64,6 +66,7 @@ export function WorkspaceBrowser({ assistantId }: { assistantId: string }) {
       const next = new Set([...prev].filter((p) => !isDeleted(p)));
       return next.size === prev.size ? prev : next;
     });
+    setLastDelete({ path });
   }, []);
 
   const [lastRename, setLastRename] = useState<{
@@ -146,6 +149,7 @@ export function WorkspaceBrowser({ assistantId }: { assistantId: string }) {
             onChangeViewMode={setViewMode}
             onBrowse={() => setDrawerOpen(true)}
             pathRename={lastRename}
+            pathDelete={lastDelete}
           />
         </div>
       </div>

--- a/apps/web/src/domains/workspace/components/workspace-file-viewer.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-file-viewer.tsx
@@ -34,6 +34,7 @@ import {
 import { FileMarkdown, isMarkdown } from "@/components/file-markdown";
 import { isJson, prettifyJson } from "@/domains/workspace/utils/file-json";
 import { formatFileSize } from "@/domains/workspace/utils/format-file-size";
+import { isHiddenPath } from "@/domains/workspace/utils/is-hidden-path";
 import {
     workspaceFileContentGet,
     workspaceFileGet,
@@ -256,10 +257,6 @@ function BinaryContentViewer({
   }
 
   return null;
-}
-
-function isHiddenPath(path: string): boolean {
-  return path.split("/").some((segment) => segment.startsWith("."));
 }
 
 function EditFooter({

--- a/apps/web/src/domains/workspace/components/workspace-file-viewer.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-file-viewer.tsx
@@ -457,6 +457,7 @@ export function WorkspaceFileViewer({
   onChangeViewMode,
   onBrowse,
   pathRename,
+  pathDelete,
 }: {
   assistantId: string;
   selectedPath: string | null;
@@ -466,6 +467,8 @@ export function WorkspaceFileViewer({
   onBrowse?: () => void;
   /** Last successful workspace rename, so edit state can follow the file. */
   pathRename?: { from: string; to: string } | null;
+  /** Last successful workspace delete, so drafts for the path are discarded. */
+  pathDelete?: { path: string } | null;
 }) {
   const queryClient = useQueryClient();
   const { data, isLoading } = useQuery({
@@ -499,6 +502,19 @@ export function WorkspaceFileViewer({
       prev == null ? prev : { ...prev, path: remap(prev.path) },
     );
   }, [pathRename]);
+
+  // Discard drafts tied to a deleted file (or one under a deleted folder) so
+  // recreating the same path doesn't resurrect the old contents — and Save
+  // can't write them into the new file.
+  useEffect(() => {
+    if (!pathDelete) return;
+    const { path } = pathDelete;
+    const covers = (p: string) => p === path || p.startsWith(`${path}/`);
+    setEditingPath((prev) => (prev != null && covers(prev) ? null : prev));
+    setEditOverride((prev) =>
+      prev != null && covers(prev.path) ? null : prev,
+    );
+  }, [pathDelete]);
 
   const isEditing = editingPath != null && editingPath === selectedPath;
   const originalContent = data?.content ?? "";

--- a/apps/web/src/domains/workspace/components/workspace-file-viewer.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-file-viewer.tsx
@@ -456,6 +456,7 @@ export function WorkspaceFileViewer({
   viewMode,
   onChangeViewMode,
   onBrowse,
+  pathRename,
 }: {
   assistantId: string;
   selectedPath: string | null;
@@ -463,6 +464,8 @@ export function WorkspaceFileViewer({
   viewMode: WorkspaceViewMode;
   onChangeViewMode: (mode: WorkspaceViewMode) => void;
   onBrowse?: () => void;
+  /** Last successful workspace rename, so edit state can follow the file. */
+  pathRename?: { from: string; to: string } | null;
 }) {
   const queryClient = useQueryClient();
   const { data, isLoading } = useQuery({
@@ -478,6 +481,24 @@ export function WorkspaceFileViewer({
     path: string;
     content: string;
   } | null>(null);
+
+  // Keep an in-progress edit attached to the file when it (or an ancestor
+  // folder) is renamed — otherwise the draft is orphaned under the old path
+  // and silently disappears from the editor.
+  useEffect(() => {
+    if (!pathRename) return;
+    const { from, to } = pathRename;
+    const remap = (p: string) =>
+      p === from
+        ? to
+        : p.startsWith(`${from}/`)
+          ? to + p.slice(from.length)
+          : p;
+    setEditingPath((prev) => (prev == null ? prev : remap(prev)));
+    setEditOverride((prev) =>
+      prev == null ? prev : { ...prev, path: remap(prev.path) },
+    );
+  }, [pathRename]);
 
   const isEditing = editingPath != null && editingPath === selectedPath;
   const originalContent = data?.content ?? "";

--- a/apps/web/src/domains/workspace/components/workspace-tree.test.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-tree.test.tsx
@@ -1,9 +1,10 @@
 /**
  * Tests for `WorkspaceTreeCreateMenu`.
  *
- * Verifies the mobile vs desktop branch — desktop renders a Radix Popover
- * with the New File / New Folder rows; mobile renders a BottomSheet (Radix
- * Dialog). Selecting either row forwards `onSelectKind(kind)` to the parent.
+ * Verifies the mobile vs desktop branch — desktop renders a Radix dropdown
+ * Menu with the New File / New Folder rows; mobile renders a BottomSheet
+ * (Radix Dialog). Selecting either row forwards `onSelectKind(kind)` to the
+ * parent.
  *
  * Uses `renderToStaticMarkup` + `mock.module` for design library compounds
  * (same pattern as conversation-actions-menu.test.tsx).
@@ -35,13 +36,20 @@ mock.module("@vellumai/design-library/components/bottom-sheet", () => ({
   },
 }));
 
-mock.module("@vellumai/design-library/components/popover", () => ({
-  Popover: {
+mock.module("@vellumai/design-library/components/menu", () => ({
+  Menu: {
     Root: passthrough,
     Trigger: ({ children }: Record<string, unknown>) =>
-      createElement("div", { "data-testid": "pop-trigger" }, children as ReactNode),
-    Content: ({ children, role }: Record<string, unknown>) =>
-      createElement("div", { role }, children as ReactNode),
+      createElement("div", { "data-testid": "menu-trigger" }, children as ReactNode),
+    // Mirror the roles the real Radix menu primitives render with.
+    Content: ({ children }: Record<string, unknown>) =>
+      createElement("div", { role: "menu" }, children as ReactNode),
+    Item: ({ children, onSelect, leftIcon: _leftIcon }: Record<string, unknown>) =>
+      createElement(
+        "button",
+        { role: "menuitem", onClick: onSelect as () => void },
+        children as ReactNode,
+      ),
   },
 }));
 
@@ -78,7 +86,7 @@ beforeEach(() => {
 });
 
 describe("WorkspaceTreeCreateMenu", () => {
-  test("desktop branch renders Popover with New File / New Folder items", () => {
+  test("desktop branch renders Menu with New File / New Folder items", () => {
     mockIsMobile = false;
     const html = renderToStaticMarkup(
       createElement(WorkspaceTreeCreateMenu, {

--- a/apps/web/src/domains/workspace/components/workspace-tree.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-tree.tsx
@@ -108,6 +108,25 @@ function workspaceTreeRetrieveOptions(opts: {
   });
 }
 
+/**
+ * The daemon's write and rename endpoints overwrite existing entries
+ * unconditionally, so creating or renaming onto an existing sibling would
+ * silently destroy it. Guard against that here.
+ */
+async function assertNameAvailable(
+  assistantId: string,
+  parentPath: string,
+  name: string,
+) {
+  const { data } = await workspaceTreeGet({
+    path: { assistant_id: assistantId },
+    query: parentPath ? { path: parentPath } : {},
+  });
+  if (data?.entries?.some((entry) => entry.name === name)) {
+    throw new Error(`"${name}" already exists here.`);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Sub-components
 // ---------------------------------------------------------------------------
@@ -527,6 +546,7 @@ export function WorkspaceTree({
       const path = input.parentPath
         ? `${input.parentPath}/${input.name}`
         : input.name;
+      await assertNameAvailable(assistantId, input.parentPath, input.name);
       const { error, response } =
         input.kind === "file"
           ? await workspaceWritePost({
@@ -572,6 +592,7 @@ export function WorkspaceTree({
       const newPath = parentPath
         ? `${parentPath}/${input.newName}`
         : input.newName;
+      await assertNameAvailable(assistantId, parentPath, input.newName);
       const { error, response } = await workspaceRenamePost({
         path: { assistant_id: assistantId },
         body: { oldPath: input.oldPath, newPath },

--- a/apps/web/src/domains/workspace/components/workspace-tree.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-tree.tsx
@@ -246,7 +246,7 @@ function TreeNode({
           <span className="min-w-0 flex-1 truncate">{entryName}</span>
           {entry.size != null && (
             <span
-              className={`shrink-0 text-label-medium-default tabular-nums${canDelete ? " group-hover:invisible group-focus-within:invisible" : ""}`}
+              className={`shrink-0 text-label-medium-default tabular-nums${canDelete ? " max-md:invisible md:group-hover:invisible md:group-focus-within:invisible" : ""}`}
               style={{ color: "var(--content-tertiary)" }}
             >
               {formatFileSize(entry.size)}
@@ -268,7 +268,7 @@ function TreeNode({
             }
             aria-label={`Delete ${entryName}`}
             title="Delete"
-            className="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+            className="absolute right-1 top-1/2 -translate-y-1/2 transition-opacity max-md:opacity-100 md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100"
             tintColor="var(--content-tertiary)"
           />
         )}

--- a/apps/web/src/domains/workspace/components/workspace-tree.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-tree.tsx
@@ -24,6 +24,7 @@ import {
     Image as ImageIcon,
     Plus,
     Search,
+    Trash2,
     Video,
     X,
 } from "lucide-react";
@@ -42,6 +43,7 @@ import {
     type WorkspaceSortMode,
 } from "@/domains/workspace/utils/sort-entries";
 import {
+    workspaceDeletePost,
     workspaceMkdirPost,
     workspaceTreeGet,
     workspaceWritePost,
@@ -50,6 +52,7 @@ import type { WorkspaceTreeGetResponse } from "@/generated/daemon/types.gen";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { BottomSheet } from "@vellumai/design-library/components/bottom-sheet";
 import { Button } from "@vellumai/design-library/components/button";
+import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 import { Input } from "@vellumai/design-library/components/input";
 import { PanelItem } from "@vellumai/design-library/components/panel-item";
 import { Popover } from "@vellumai/design-library/components/popover";
@@ -61,6 +64,12 @@ export type { WorkspaceSortMode };
 // ---------------------------------------------------------------------------
 
 type WorkspaceTreeEntry = WorkspaceTreeGetResponse["entries"][number];
+
+interface DeleteTarget {
+  path: string;
+  name: string;
+  isDirectory: boolean;
+}
 
 function workspaceTreeRetrieveOptions(opts: {
   path: { assistant_id: string };
@@ -135,6 +144,7 @@ function TreeNode({
   searchLower,
   onToggleExpand,
   onSelectPath,
+  onRequestDelete,
   depth,
 }: {
   entry: WorkspaceTreeEntry;
@@ -146,6 +156,7 @@ function TreeNode({
   searchLower: string;
   onToggleExpand: (path: string) => void;
   onSelectPath: (path: string) => void;
+  onRequestDelete: (target: DeleteTarget) => void;
   depth: number;
 }) {
   const entryPath = entry.path ?? "";
@@ -194,49 +205,68 @@ function TreeNode({
 
   return (
     <div>
-      <button
-        onClick={handleClick}
-        className="group flex w-full items-center gap-1.5 px-2 py-1 text-left text-body-medium-lighter transition-colors hover:bg-[var(--surface-hover)]"
-        style={{
-          paddingLeft: `${depth * 14 + 8}px`,
-          paddingRight: "8px",
-          color: isSelected
-            ? "var(--content-default)"
-            : isHidden
-              ? "var(--content-tertiary)"
-              : "var(--content-default)",
-          backgroundColor: isSelected
-            ? "color-mix(in oklab, var(--primary-base) 12%, transparent)"
-            : undefined,
-          opacity: isHidden && !isSelected ? 0.7 : 1,
-        }}
-      >
-        {isDirectory ? (
-          effectivelyExpanded ? (
-            <ChevronDown
-              className="h-3 w-3 shrink-0"
-              style={{ color: "var(--content-tertiary)" }}
-            />
+      <div className="group relative">
+        <button
+          onClick={handleClick}
+          className="flex w-full items-center gap-1.5 px-2 py-1 text-left text-body-medium-lighter transition-colors hover:bg-[var(--surface-hover)]"
+          style={{
+            paddingLeft: `${depth * 14 + 8}px`,
+            paddingRight: "8px",
+            color: isSelected
+              ? "var(--content-default)"
+              : isHidden
+                ? "var(--content-tertiary)"
+                : "var(--content-default)",
+            backgroundColor: isSelected
+              ? "color-mix(in oklab, var(--primary-base) 12%, transparent)"
+              : undefined,
+            opacity: isHidden && !isSelected ? 0.7 : 1,
+          }}
+        >
+          {isDirectory ? (
+            effectivelyExpanded ? (
+              <ChevronDown
+                className="h-3 w-3 shrink-0"
+                style={{ color: "var(--content-tertiary)" }}
+              />
+            ) : (
+              <ChevronRight
+                className="h-3 w-3 shrink-0"
+                style={{ color: "var(--content-tertiary)" }}
+              />
+            )
           ) : (
-            <ChevronRight
-              className="h-3 w-3 shrink-0"
+            <span className="h-3 w-3 shrink-0" />
+          )}
+          <FileIconForEntry entry={entry} />
+          <span className="min-w-0 flex-1 truncate">{entryName}</span>
+          {entry.size != null && (
+            <span
+              className="shrink-0 text-label-medium-default tabular-nums group-hover:invisible group-focus-within:invisible"
               style={{ color: "var(--content-tertiary)" }}
-            />
-          )
-        ) : (
-          <span className="h-3 w-3 shrink-0" />
-        )}
-        <FileIconForEntry entry={entry} />
-        <span className="min-w-0 flex-1 truncate">{entryName}</span>
-        {entry.size != null && (
-          <span
-            className="shrink-0 text-label-medium-default tabular-nums"
-            style={{ color: "var(--content-tertiary)" }}
-          >
-            {formatFileSize(entry.size)}
-          </span>
-        )}
-      </button>
+            >
+              {formatFileSize(entry.size)}
+            </span>
+          )}
+        </button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="compact"
+          iconOnly={<Trash2 aria-hidden />}
+          onClick={() =>
+            onRequestDelete({
+              path: entryPath,
+              name: entryName,
+              isDirectory,
+            })
+          }
+          aria-label={`Delete ${entryName}`}
+          title="Delete"
+          className="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+          tintColor="var(--content-tertiary)"
+        />
+      </div>
       {isDirectory && effectivelyExpanded && children.length > 0 && (
         <div>
           {children.map((child) => (
@@ -251,6 +281,7 @@ function TreeNode({
               searchLower={searchLower}
               onToggleExpand={onToggleExpand}
               onSelectPath={onSelectPath}
+              onRequestDelete={onRequestDelete}
               depth={depth + 1}
             />
           ))}
@@ -363,6 +394,7 @@ export function WorkspaceTree({
   onSelectPath,
   onToggleShowHidden,
   onChangeSortMode,
+  onPathDeleted,
 }: {
   assistantId: string;
   expandedPaths: Set<string>;
@@ -374,6 +406,7 @@ export function WorkspaceTree({
   onSelectPath: (path: string) => void;
   onToggleShowHidden: () => void;
   onChangeSortMode: (next: WorkspaceSortMode) => void;
+  onPathDeleted: (path: string) => void;
 }) {
   const queryClient = useQueryClient();
   const [search, setSearch] = useState("");
@@ -447,6 +480,37 @@ export function WorkspaceTree({
       createMutation.mutate({ kind: dialogKind, name });
     },
     [dialogKind, createMutation],
+  );
+
+  const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
+
+  const deleteMutation = useMutation({
+    mutationFn: async (target: DeleteTarget) => {
+      const { error, response } = await workspaceDeletePost({
+        path: { assistant_id: assistantId },
+        body: { path: target.path },
+        throwOnError: false,
+      });
+      if (error || !response?.ok) {
+        throw new Error(
+          typeof error === "string" ? error : "Failed to delete — try again.",
+        );
+      }
+      return target;
+    },
+    onSuccess: (target) => {
+      setDeleteTarget(null);
+      invalidateTree();
+      onPathDeleted(target.path);
+    },
+  });
+
+  const handleRequestDelete = useCallback(
+    (target: DeleteTarget) => {
+      deleteMutation.reset();
+      setDeleteTarget(target);
+    },
+    [deleteMutation],
   );
 
   return (
@@ -567,6 +631,7 @@ export function WorkspaceTree({
               searchLower={searchLower}
               onToggleExpand={onToggleExpand}
               onSelectPath={onSelectPath}
+              onRequestDelete={handleRequestDelete}
               depth={0}
             />
           ))
@@ -586,6 +651,36 @@ export function WorkspaceTree({
           error={dialogError}
         />
       )}
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title={deleteTarget?.isDirectory ? "Delete Folder" : "Delete File"}
+        message={
+          <>
+            Are you sure you want to delete{" "}
+            <span style={{ color: "var(--content-default)" }}>
+              {deleteTarget?.name}
+            </span>
+            {deleteTarget?.isDirectory ? " and all of its contents" : ""}? This
+            cannot be undone.
+            {deleteMutation.error && (
+              <span
+                className="mt-2 block"
+                style={{ color: "var(--system-negative-strong)" }}
+              >
+                {deleteMutation.error.message}
+              </span>
+            )}
+          </>
+        }
+        confirmLabel={deleteMutation.isPending ? "Deleting…" : "Delete"}
+        destructive
+        isPending={deleteMutation.isPending}
+        onConfirm={() => {
+          if (deleteTarget) deleteMutation.mutate(deleteTarget);
+        }}
+        onCancel={() => setDeleteTarget(null)}
+      />
     </>
   );
 }

--- a/apps/web/src/domains/workspace/components/workspace-tree.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-tree.tsx
@@ -34,12 +34,11 @@ import {
 } from "lucide-react";
 import {
     type FormEvent,
-    type KeyboardEvent,
     useCallback,
     useMemo,
+    useRef,
     useState,
 } from "react";
-import { createPortal } from "react-dom";
 
 import { formatFileSize } from "@/domains/workspace/utils/format-file-size";
 import { isHiddenPath } from "@/domains/workspace/utils/is-hidden-path";
@@ -61,8 +60,9 @@ import { Button } from "@vellumai/design-library/components/button";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 import { ContextMenu } from "@vellumai/design-library/components/context-menu";
 import { Input } from "@vellumai/design-library/components/input";
+import { Menu } from "@vellumai/design-library/components/menu";
+import { Modal } from "@vellumai/design-library/components/modal";
 import { PanelItem } from "@vellumai/design-library/components/panel-item";
-import { Popover } from "@vellumai/design-library/components/popover";
 
 export type { WorkspaceSortMode };
 
@@ -345,7 +345,7 @@ function TreeNode({
 }
 
 // ---------------------------------------------------------------------------
-// Name dialog (create / rename) — portaled to document.body
+// Name dialog (create / rename)
 // ---------------------------------------------------------------------------
 
 interface NameItemDialogProps {
@@ -371,6 +371,7 @@ function NameItemDialog({
   pending,
   error,
 }: NameItemDialogProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
   const [name, setName] = useState(initialName ?? "");
 
   const trimmed = name.trim();
@@ -381,62 +382,69 @@ function NameItemDialog({
     if (canSubmit) onConfirm(trimmed);
   };
 
-  const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === "Escape") onCancel();
-  };
-
-  return createPortal(
-    <div
-      role="dialog"
-      aria-modal="true"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-      onKeyDown={handleKeyDown}
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onCancel();
+  return (
+    <Modal.Root
+      open
+      onOpenChange={(next) => {
+        if (!next && !pending) onCancel();
       }}
     >
-      <form
-        onSubmit={handleSubmit}
-        className="mx-4 w-full max-w-sm rounded-xl border p-5 shadow-xl"
-        style={{
-          backgroundColor: "var(--surface-lift)",
-          borderColor: "var(--border-base)",
+      <Modal.Content
+        size="sm"
+        hideCloseButton
+        aria-describedby={undefined}
+        // Select-all on open so typing replaces a pre-filled name in one
+        // motion; the selection is deferred a frame because iOS Safari
+        // ignores selection APIs called synchronously during focus.
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          const input = inputRef.current;
+          if (input) {
+            input.focus();
+            requestAnimationFrame(() => {
+              input.setSelectionRange(0, input.value.length);
+            });
+          }
+        }}
+        onEscapeKeyDown={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          if (!pending) onCancel();
         }}
       >
-        <h2
-          className="mb-3 text-title-small"
-          style={{ color: "var(--content-default)" }}
-        >
-          {title}
-        </h2>
-        <Input
-          autoFocus
-          type="text"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder={placeholder}
-          errorText={error ?? undefined}
-          fullWidth
-          wrapperClassName="mb-3"
-          autoComplete="off"
-          spellCheck={false}
-        />
-        <div className="flex justify-end gap-2">
-          <Button
-            type="button"
-            variant="outlined"
-            onClick={onCancel}
-            disabled={pending}
-          >
-            Cancel
-          </Button>
-          <Button type="submit" disabled={!canSubmit}>
-            {pending ? pendingLabel : confirmLabel}
-          </Button>
-        </div>
-      </form>
-    </div>,
-    document.body,
+        <form onSubmit={handleSubmit}>
+          <Modal.Header>
+            <Modal.Title>{title}</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <Input
+              ref={inputRef}
+              label="Name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder={placeholder}
+              errorText={error ?? undefined}
+              autoComplete="off"
+              spellCheck={false}
+              fullWidth
+            />
+          </Modal.Body>
+          <Modal.Footer>
+            <Button
+              type="button"
+              variant="outlined"
+              onClick={onCancel}
+              disabled={pending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" variant="primary" disabled={!canSubmit}>
+              {pending ? pendingLabel : confirmLabel}
+            </Button>
+          </Modal.Footer>
+        </form>
+      </Modal.Content>
+    </Modal.Root>
   );
 }
 
@@ -880,8 +888,8 @@ export function WorkspaceTreeCreateMenu({
   }
 
   return (
-    <Popover.Root open={open} onOpenChange={onOpenChange}>
-      <Popover.Trigger asChild>
+    <Menu.Root open={open} onOpenChange={onOpenChange}>
+      <Menu.Trigger asChild>
         <Button
           type="button"
           variant="ghost"
@@ -891,44 +899,21 @@ export function WorkspaceTreeCreateMenu({
           title="New file or folder"
           tintColor="var(--content-tertiary)"
         />
-      </Popover.Trigger>
-      <Popover.Content
-        align="end"
-        sideOffset={4}
-        role="menu"
-        className="w-44 overflow-hidden p-0"
-      >
-        <Button
-          type="button"
-          variant="ghost"
-          onClick={() => onSelectKind("file")}
-          className="w-full justify-start rounded-none"
-          leftIcon={
-            <FilePlus
-              aria-hidden
-              style={{ color: "var(--content-tertiary)" }}
-            />
-          }
-          role="menuitem"
+      </Menu.Trigger>
+      <Menu.Content align="end" sideOffset={4}>
+        <Menu.Item
+          leftIcon={<FilePlus className="h-3.5 w-3.5" />}
+          onSelect={() => onSelectKind("file")}
         >
           New File
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          onClick={() => onSelectKind("folder")}
-          className="w-full justify-start rounded-none"
-          leftIcon={
-            <FolderPlus
-              aria-hidden
-              style={{ color: "var(--content-tertiary)" }}
-            />
-          }
-          role="menuitem"
+        </Menu.Item>
+        <Menu.Item
+          leftIcon={<FolderPlus className="h-3.5 w-3.5" />}
+          onSelect={() => onSelectKind("folder")}
         >
           New Folder
-        </Button>
-      </Popover.Content>
-    </Popover.Root>
+        </Menu.Item>
+      </Menu.Content>
+    </Menu.Root>
   );
 }

--- a/apps/web/src/domains/workspace/components/workspace-tree.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-tree.tsx
@@ -505,10 +505,17 @@ export function WorkspaceTree({
     [data?.entries, sortMode],
   );
 
-  const invalidateTree = useCallback(() => {
-    queryClient.invalidateQueries({
-      queryKey: ["assistantsWorkspaceTreeRetrieve"],
-    });
+  // Invalidate the file metadata/content caches too: deleting or renaming
+  // foo.md and then recreating it must not serve the old file's cached
+  // contents from the viewer.
+  const invalidateWorkspace = useCallback(() => {
+    for (const key of [
+      "assistantsWorkspaceTreeRetrieve",
+      "assistantsWorkspaceFileRetrieve",
+      "assistantsWorkspaceFileContentRetrieve",
+    ]) {
+      queryClient.invalidateQueries({ queryKey: [key] });
+    }
   }, [queryClient]);
 
   const createMutation = useMutation({
@@ -543,7 +550,7 @@ export function WorkspaceTree({
     },
     onSuccess: (input) => {
       closeDialog();
-      invalidateTree();
+      invalidateWorkspace();
       if (input.parentPath) {
         onExpandPath(input.parentPath);
       }
@@ -581,7 +588,7 @@ export function WorkspaceTree({
     },
     onSuccess: ({ oldPath, newPath }) => {
       closeDialog();
-      invalidateTree();
+      invalidateWorkspace();
       onPathRenamed(oldPath, newPath);
     },
     onError: (err: unknown) => {
@@ -620,7 +627,7 @@ export function WorkspaceTree({
     },
     onSuccess: (target) => {
       setDeleteTarget(null);
-      invalidateTree();
+      invalidateWorkspace();
       onPathDeleted(target.path);
     },
   });

--- a/apps/web/src/domains/workspace/components/workspace-tree.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-tree.tsx
@@ -404,7 +404,12 @@ function NameItemDialog({
   const [name, setName] = useState(initialName ?? "");
 
   const trimmed = name.trim();
-  const canSubmit = trimmed.length > 0 && !pending;
+  // Single path segment only — a name like "sub/existing.md" or "../x" would
+  // land outside the parent directory and bypass the sibling conflict check.
+  const invalidName =
+    trimmed.length > 0 &&
+    (/[/\\]/.test(trimmed) || trimmed === "." || trimmed === "..");
+  const canSubmit = trimmed.length > 0 && !invalidName && !pending;
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
@@ -452,7 +457,12 @@ function NameItemDialog({
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder={placeholder}
-              errorText={error ?? undefined}
+              errorText={
+                error ??
+                (invalidName
+                  ? "Enter a single file or folder name without slashes."
+                  : undefined)
+              }
               autoComplete="off"
               spellCheck={false}
               fullWidth

--- a/apps/web/src/domains/workspace/components/workspace-tree.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-tree.tsx
@@ -1,7 +1,10 @@
 /**
  * File tree sidebar for the workspace browser. Fetches the assistant's
  * workspace directory listing, renders a recursive expandable tree, and
- * provides search filtering plus file/folder creation.
+ * provides search filtering plus file/folder creation. Each row carries a
+ * context menu (right-click / long-press) with New File / New Folder (on
+ * directories), Delete, and Rename — mirroring the original native macOS
+ * app's workspace panel.
  */
 
 import {
@@ -22,6 +25,7 @@ import {
     Folder,
     FolderPlus,
     Image as ImageIcon,
+    Pencil,
     Plus,
     Search,
     Trash2,
@@ -46,6 +50,7 @@ import {
 import {
     workspaceDeletePost,
     workspaceMkdirPost,
+    workspaceRenamePost,
     workspaceTreeGet,
     workspaceWritePost,
 } from "@/generated/daemon/sdk.gen";
@@ -54,6 +59,7 @@ import { useIsMobile } from "@/hooks/use-is-mobile";
 import { BottomSheet } from "@vellumai/design-library/components/bottom-sheet";
 import { Button } from "@vellumai/design-library/components/button";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
+import { ContextMenu } from "@vellumai/design-library/components/context-menu";
 import { Input } from "@vellumai/design-library/components/input";
 import { PanelItem } from "@vellumai/design-library/components/panel-item";
 import { Popover } from "@vellumai/design-library/components/popover";
@@ -66,11 +72,15 @@ export type { WorkspaceSortMode };
 
 type WorkspaceTreeEntry = WorkspaceTreeGetResponse["entries"][number];
 
-interface DeleteTarget {
+interface EntryTarget {
   path: string;
   name: string;
   isDirectory: boolean;
 }
+
+type TreeDialog =
+  | { type: "create"; kind: "file" | "folder"; parentPath: string }
+  | { type: "rename"; path: string; name: string };
 
 function workspaceTreeRetrieveOptions(opts: {
   path: { assistant_id: string };
@@ -146,6 +156,8 @@ function TreeNode({
   onToggleExpand,
   onSelectPath,
   onRequestDelete,
+  onRequestRename,
+  onRequestCreate,
   depth,
 }: {
   entry: WorkspaceTreeEntry;
@@ -157,7 +169,12 @@ function TreeNode({
   searchLower: string;
   onToggleExpand: (path: string) => void;
   onSelectPath: (path: string) => void;
-  onRequestDelete: (target: DeleteTarget) => void;
+  onRequestDelete: (target: EntryTarget) => void;
+  onRequestRename: (target: EntryTarget) => void;
+  onRequestCreate: (input: {
+    kind: "file" | "folder";
+    parentPath: string;
+  }) => void;
   depth: number;
 }) {
   const entryPath = entry.path ?? "";
@@ -166,9 +183,9 @@ function TreeNode({
   const isExpanded = expandedPaths.has(entryPath);
   const isSelected = selectedPath === entryPath;
   const isHidden = entryName.startsWith(".");
-  // The daemon rejects deletes on paths with hidden segments, so don't offer
-  // the action for them.
-  const canDelete = !isHiddenPath(entryPath);
+  // The daemon rejects writes, renames, and deletes on paths with hidden
+  // segments, so don't offer the context menu for them.
+  const hasMenu = !isHiddenPath(entryPath);
 
   // Expand directories whose names match during search so their children are visible.
   const effectivelyExpanded =
@@ -207,72 +224,100 @@ function TreeNode({
     }
   };
 
+  const row = (
+    <button
+      onClick={handleClick}
+      className="flex w-full items-center gap-1.5 px-2 py-1 text-left text-body-medium-lighter transition-colors hover:bg-[var(--surface-hover)]"
+      style={{
+        paddingLeft: `${depth * 14 + 8}px`,
+        paddingRight: "8px",
+        color: isSelected
+          ? "var(--content-default)"
+          : isHidden
+            ? "var(--content-tertiary)"
+            : "var(--content-default)",
+        backgroundColor: isSelected
+          ? "color-mix(in oklab, var(--primary-base) 12%, transparent)"
+          : undefined,
+        opacity: isHidden && !isSelected ? 0.7 : 1,
+      }}
+    >
+      {isDirectory ? (
+        effectivelyExpanded ? (
+          <ChevronDown
+            className="h-3 w-3 shrink-0"
+            style={{ color: "var(--content-tertiary)" }}
+          />
+        ) : (
+          <ChevronRight
+            className="h-3 w-3 shrink-0"
+            style={{ color: "var(--content-tertiary)" }}
+          />
+        )
+      ) : (
+        <span className="h-3 w-3 shrink-0" />
+      )}
+      <FileIconForEntry entry={entry} />
+      <span className="min-w-0 flex-1 truncate">{entryName}</span>
+      {entry.size != null && (
+        <span
+          className="shrink-0 text-label-medium-default tabular-nums"
+          style={{ color: "var(--content-tertiary)" }}
+        >
+          {formatFileSize(entry.size)}
+        </span>
+      )}
+    </button>
+  );
+
   return (
     <div>
-      <div className="group relative">
-        <button
-          onClick={handleClick}
-          className="flex w-full items-center gap-1.5 px-2 py-1 text-left text-body-medium-lighter transition-colors hover:bg-[var(--surface-hover)]"
-          style={{
-            paddingLeft: `${depth * 14 + 8}px`,
-            paddingRight: "8px",
-            color: isSelected
-              ? "var(--content-default)"
-              : isHidden
-                ? "var(--content-tertiary)"
-                : "var(--content-default)",
-            backgroundColor: isSelected
-              ? "color-mix(in oklab, var(--primary-base) 12%, transparent)"
-              : undefined,
-            opacity: isHidden && !isSelected ? 0.7 : 1,
-          }}
-        >
-          {isDirectory ? (
-            effectivelyExpanded ? (
-              <ChevronDown
-                className="h-3 w-3 shrink-0"
-                style={{ color: "var(--content-tertiary)" }}
-              />
-            ) : (
-              <ChevronRight
-                className="h-3 w-3 shrink-0"
-                style={{ color: "var(--content-tertiary)" }}
-              />
-            )
-          ) : (
-            <span className="h-3 w-3 shrink-0" />
-          )}
-          <FileIconForEntry entry={entry} />
-          <span className="min-w-0 flex-1 truncate">{entryName}</span>
-          {entry.size != null && (
-            <span
-              className={`shrink-0 text-label-medium-default tabular-nums${canDelete ? " max-md:invisible md:group-hover:invisible md:group-focus-within:invisible" : ""}`}
-              style={{ color: "var(--content-tertiary)" }}
+      {hasMenu ? (
+        <ContextMenu.Root>
+          <ContextMenu.Trigger>{row}</ContextMenu.Trigger>
+          <ContextMenu.Content>
+            {isDirectory && (
+              <>
+                <ContextMenu.Item
+                  leftIcon={<FilePlus className="h-3.5 w-3.5" />}
+                  onSelect={() =>
+                    onRequestCreate({ kind: "file", parentPath: entryPath })
+                  }
+                >
+                  New File
+                </ContextMenu.Item>
+                <ContextMenu.Item
+                  leftIcon={<FolderPlus className="h-3.5 w-3.5" />}
+                  onSelect={() =>
+                    onRequestCreate({ kind: "folder", parentPath: entryPath })
+                  }
+                >
+                  New Folder
+                </ContextMenu.Item>
+                <ContextMenu.Separator />
+              </>
+            )}
+            <ContextMenu.Item
+              leftIcon={<Trash2 className="h-3.5 w-3.5" />}
+              onSelect={() =>
+                onRequestDelete({ path: entryPath, name: entryName, isDirectory })
+              }
             >
-              {formatFileSize(entry.size)}
-            </span>
-          )}
-        </button>
-        {canDelete && (
-          <Button
-            type="button"
-            variant="ghost"
-            size="compact"
-            iconOnly={<Trash2 aria-hidden />}
-            onClick={() =>
-              onRequestDelete({
-                path: entryPath,
-                name: entryName,
-                isDirectory,
-              })
-            }
-            aria-label={`Delete ${entryName}`}
-            title="Delete"
-            className="absolute right-1 top-1/2 -translate-y-1/2 transition-opacity max-md:opacity-100 md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100"
-            tintColor="var(--content-tertiary)"
-          />
-        )}
-      </div>
+              Delete
+            </ContextMenu.Item>
+            <ContextMenu.Item
+              leftIcon={<Pencil className="h-3.5 w-3.5" />}
+              onSelect={() =>
+                onRequestRename({ path: entryPath, name: entryName, isDirectory })
+              }
+            >
+              Rename
+            </ContextMenu.Item>
+          </ContextMenu.Content>
+        </ContextMenu.Root>
+      ) : (
+        row
+      )}
       {isDirectory && effectivelyExpanded && children.length > 0 && (
         <div>
           {children.map((child) => (
@@ -288,6 +333,8 @@ function TreeNode({
               onToggleExpand={onToggleExpand}
               onSelectPath={onSelectPath}
               onRequestDelete={onRequestDelete}
+              onRequestRename={onRequestRename}
+              onRequestCreate={onRequestCreate}
               depth={depth + 1}
             />
           ))}
@@ -298,25 +345,33 @@ function TreeNode({
 }
 
 // ---------------------------------------------------------------------------
-// Create item dialog — portaled to document.body
+// Name dialog (create / rename) — portaled to document.body
 // ---------------------------------------------------------------------------
 
-interface CreateItemDialogProps {
-  kind: "file" | "folder";
+interface NameItemDialogProps {
+  title: string;
+  placeholder: string;
+  confirmLabel: string;
+  pendingLabel: string;
+  initialName?: string;
   onCancel: () => void;
   onConfirm: (name: string) => void;
   pending: boolean;
   error: string | null;
 }
 
-function CreateItemDialog({
-  kind,
+function NameItemDialog({
+  title,
+  placeholder,
+  confirmLabel,
+  pendingLabel,
+  initialName,
   onCancel,
   onConfirm,
   pending,
   error,
-}: CreateItemDialogProps) {
-  const [name, setName] = useState("");
+}: NameItemDialogProps) {
+  const [name, setName] = useState(initialName ?? "");
 
   const trimmed = name.trim();
   const canSubmit = trimmed.length > 0 && !pending;
@@ -352,14 +407,14 @@ function CreateItemDialog({
           className="mb-3 text-title-small"
           style={{ color: "var(--content-default)" }}
         >
-          {kind === "file" ? "New File" : "New Folder"}
+          {title}
         </h2>
         <Input
           autoFocus
           type="text"
           value={name}
           onChange={(e) => setName(e.target.value)}
-          placeholder={kind === "file" ? "filename.md" : "folder-name"}
+          placeholder={placeholder}
           errorText={error ?? undefined}
           fullWidth
           wrapperClassName="mb-3"
@@ -376,7 +431,7 @@ function CreateItemDialog({
             Cancel
           </Button>
           <Button type="submit" disabled={!canSubmit}>
-            {pending ? "Creating…" : "Create"}
+            {pending ? pendingLabel : confirmLabel}
           </Button>
         </div>
       </form>
@@ -401,6 +456,7 @@ export function WorkspaceTree({
   onToggleShowHidden,
   onChangeSortMode,
   onPathDeleted,
+  onPathRenamed,
 }: {
   assistantId: string;
   expandedPaths: Set<string>;
@@ -413,6 +469,7 @@ export function WorkspaceTree({
   onToggleShowHidden: () => void;
   onChangeSortMode: (next: WorkspaceSortMode) => void;
   onPathDeleted: (path: string) => void;
+  onPathRenamed: (oldPath: string, newPath: string) => void;
 }) {
   const queryClient = useQueryClient();
   const [search, setSearch] = useState("");
@@ -420,8 +477,13 @@ export function WorkspaceTree({
 
   const [menuOpen, setMenuOpen] = useState(false);
 
-  const [dialogKind, setDialogKind] = useState<"file" | "folder" | null>(null);
+  const [dialog, setDialog] = useState<TreeDialog | null>(null);
   const [dialogError, setDialogError] = useState<string | null>(null);
+
+  const closeDialog = useCallback(() => {
+    setDialog(null);
+    setDialogError(null);
+  }, []);
 
   const { data, isLoading } = useQuery(
     workspaceTreeRetrieveOptions({
@@ -442,17 +504,24 @@ export function WorkspaceTree({
   }, [queryClient]);
 
   const createMutation = useMutation({
-    mutationFn: async (input: { kind: "file" | "folder"; name: string }) => {
+    mutationFn: async (input: {
+      kind: "file" | "folder";
+      parentPath: string;
+      name: string;
+    }) => {
+      const path = input.parentPath
+        ? `${input.parentPath}/${input.name}`
+        : input.name;
       const { error, response } =
         input.kind === "file"
           ? await workspaceWritePost({
               path: { assistant_id: assistantId },
-              body: { path: input.name, content: "", encoding: "utf8" },
+              body: { path, content: "", encoding: "utf8" },
               throwOnError: false,
             })
           : await workspaceMkdirPost({
               path: { assistant_id: assistantId },
-              body: { path: input.name },
+              body: { path },
               throwOnError: false,
             });
       if (error || !response?.ok) {
@@ -462,16 +531,18 @@ export function WorkspaceTree({
             : "Failed to create — check the name and try again.",
         );
       }
-      return input;
+      return { ...input, path };
     },
     onSuccess: (input) => {
-      setDialogKind(null);
-      setDialogError(null);
+      closeDialog();
       invalidateTree();
+      if (input.parentPath) {
+        onExpandPath(input.parentPath);
+      }
       if (input.kind === "file") {
-        onSelectPath(input.name);
+        onSelectPath(input.path);
       } else {
-        onExpandPath(input.name);
+        onExpandPath(input.path);
       }
     },
     onError: (err: unknown) => {
@@ -479,19 +550,54 @@ export function WorkspaceTree({
     },
   });
 
-  const handleConfirm = useCallback(
-    (name: string) => {
-      if (!dialogKind) return;
-      setDialogError(null);
-      createMutation.mutate({ kind: dialogKind, name });
+  const renameMutation = useMutation({
+    mutationFn: async (input: { oldPath: string; newName: string }) => {
+      const slash = input.oldPath.lastIndexOf("/");
+      const parentPath = slash === -1 ? "" : input.oldPath.slice(0, slash);
+      const newPath = parentPath
+        ? `${parentPath}/${input.newName}`
+        : input.newName;
+      const { error, response } = await workspaceRenamePost({
+        path: { assistant_id: assistantId },
+        body: { oldPath: input.oldPath, newPath },
+        throwOnError: false,
+      });
+      if (error || !response?.ok) {
+        throw new Error(
+          typeof error === "string"
+            ? error
+            : "Failed to rename — check the name and try again.",
+        );
+      }
+      return { oldPath: input.oldPath, newPath };
     },
-    [dialogKind, createMutation],
+    onSuccess: ({ oldPath, newPath }) => {
+      closeDialog();
+      invalidateTree();
+      onPathRenamed(oldPath, newPath);
+    },
+    onError: (err: unknown) => {
+      setDialogError(err instanceof Error ? err.message : "Failed to rename.");
+    },
+  });
+
+  const handleRequestCreate = useCallback(
+    (input: { kind: "file" | "folder"; parentPath: string }) => {
+      setDialogError(null);
+      setDialog({ type: "create", ...input });
+    },
+    [],
   );
 
-  const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
+  const handleRequestRename = useCallback((target: EntryTarget) => {
+    setDialogError(null);
+    setDialog({ type: "rename", path: target.path, name: target.name });
+  }, []);
+
+  const [deleteTarget, setDeleteTarget] = useState<EntryTarget | null>(null);
 
   const deleteMutation = useMutation({
-    mutationFn: async (target: DeleteTarget) => {
+    mutationFn: async (target: EntryTarget) => {
       const { error, response } = await workspaceDeletePost({
         path: { assistant_id: assistantId },
         body: { path: target.path },
@@ -512,7 +618,7 @@ export function WorkspaceTree({
   });
 
   const handleRequestDelete = useCallback(
-    (target: DeleteTarget) => {
+    (target: EntryTarget) => {
       deleteMutation.reset();
       setDeleteTarget(target);
     },
@@ -575,8 +681,7 @@ export function WorkspaceTree({
             onOpenChange={setMenuOpen}
             onSelectKind={(kind) => {
               setMenuOpen(false);
-              setDialogError(null);
-              setDialogKind(kind);
+              handleRequestCreate({ kind, parentPath: "" });
             }}
           />
         </div>
@@ -638,22 +743,53 @@ export function WorkspaceTree({
               onToggleExpand={onToggleExpand}
               onSelectPath={onSelectPath}
               onRequestDelete={handleRequestDelete}
+              onRequestRename={handleRequestRename}
+              onRequestCreate={handleRequestCreate}
               depth={0}
             />
           ))
         )}
       </div>
 
-      {dialogKind !== null && (
-        <CreateItemDialog
-          key={dialogKind}
-          kind={dialogKind}
-          onCancel={() => {
-            setDialogKind(null);
+      {dialog?.type === "create" && (
+        <NameItemDialog
+          key={`create-${dialog.kind}-${dialog.parentPath}`}
+          title={dialog.kind === "file" ? "New File" : "New Folder"}
+          placeholder={dialog.kind === "file" ? "filename.md" : "folder-name"}
+          confirmLabel="Create"
+          pendingLabel="Creating…"
+          onCancel={closeDialog}
+          onConfirm={(name) => {
             setDialogError(null);
+            createMutation.mutate({
+              kind: dialog.kind,
+              parentPath: dialog.parentPath,
+              name,
+            });
           }}
-          onConfirm={handleConfirm}
           pending={createMutation.isPending}
+          error={dialogError}
+        />
+      )}
+
+      {dialog?.type === "rename" && (
+        <NameItemDialog
+          key={`rename-${dialog.path}`}
+          title="Rename"
+          placeholder={dialog.name}
+          confirmLabel="Rename"
+          pendingLabel="Renaming…"
+          initialName={dialog.name}
+          onCancel={closeDialog}
+          onConfirm={(name) => {
+            if (name === dialog.name) {
+              closeDialog();
+              return;
+            }
+            setDialogError(null);
+            renameMutation.mutate({ oldPath: dialog.path, newName: name });
+          }}
+          pending={renameMutation.isPending}
           error={dialogError}
         />
       )}

--- a/apps/web/src/domains/workspace/components/workspace-tree.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-tree.tsx
@@ -111,18 +111,28 @@ function workspaceTreeRetrieveOptions(opts: {
 /**
  * The daemon's write and rename endpoints overwrite existing entries
  * unconditionally, so creating or renaming onto an existing sibling would
- * silently destroy it. Guard against that here.
+ * silently destroy it. Names compare case-insensitively because the default
+ * macOS/iOS filesystems treat Foo.md and foo.md as the same file. Renames
+ * pass `excludeName` (the entry's current name) so a case-only rename of
+ * the same file is still allowed.
  */
 async function assertNameAvailable(
   assistantId: string,
   parentPath: string,
   name: string,
+  excludeName?: string,
 ) {
+  const target = name.toLowerCase();
+  const excluded = excludeName?.toLowerCase();
   const { data } = await workspaceTreeGet({
     path: { assistant_id: assistantId },
     query: parentPath ? { path: parentPath } : {},
   });
-  if (data?.entries?.some((entry) => entry.name === name)) {
+  const conflict = data?.entries?.some((entry) => {
+    const existing = (entry.name ?? "").toLowerCase();
+    return existing === target && existing !== excluded;
+  });
+  if (conflict) {
     throw new Error(`"${name}" already exists here.`);
   }
 }
@@ -589,10 +599,11 @@ export function WorkspaceTree({
     mutationFn: async (input: { oldPath: string; newName: string }) => {
       const slash = input.oldPath.lastIndexOf("/");
       const parentPath = slash === -1 ? "" : input.oldPath.slice(0, slash);
+      const oldName = input.oldPath.slice(slash + 1);
       const newPath = parentPath
         ? `${parentPath}/${input.newName}`
         : input.newName;
-      await assertNameAvailable(assistantId, parentPath, input.newName);
+      await assertNameAvailable(assistantId, parentPath, input.newName, oldName);
       const { error, response } = await workspaceRenamePost({
         path: { assistant_id: assistantId },
         body: { oldPath: input.oldPath, newPath },

--- a/apps/web/src/domains/workspace/components/workspace-tree.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-tree.tsx
@@ -38,6 +38,7 @@ import {
 import { createPortal } from "react-dom";
 
 import { formatFileSize } from "@/domains/workspace/utils/format-file-size";
+import { isHiddenPath } from "@/domains/workspace/utils/is-hidden-path";
 import {
     sortEntries,
     type WorkspaceSortMode,
@@ -165,6 +166,9 @@ function TreeNode({
   const isExpanded = expandedPaths.has(entryPath);
   const isSelected = selectedPath === entryPath;
   const isHidden = entryName.startsWith(".");
+  // The daemon rejects deletes on paths with hidden segments, so don't offer
+  // the action for them.
+  const canDelete = !isHiddenPath(entryPath);
 
   // Expand directories whose names match during search so their children are visible.
   const effectivelyExpanded =
@@ -242,30 +246,32 @@ function TreeNode({
           <span className="min-w-0 flex-1 truncate">{entryName}</span>
           {entry.size != null && (
             <span
-              className="shrink-0 text-label-medium-default tabular-nums group-hover:invisible group-focus-within:invisible"
+              className={`shrink-0 text-label-medium-default tabular-nums${canDelete ? " group-hover:invisible group-focus-within:invisible" : ""}`}
               style={{ color: "var(--content-tertiary)" }}
             >
               {formatFileSize(entry.size)}
             </span>
           )}
         </button>
-        <Button
-          type="button"
-          variant="ghost"
-          size="compact"
-          iconOnly={<Trash2 aria-hidden />}
-          onClick={() =>
-            onRequestDelete({
-              path: entryPath,
-              name: entryName,
-              isDirectory,
-            })
-          }
-          aria-label={`Delete ${entryName}`}
-          title="Delete"
-          className="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
-          tintColor="var(--content-tertiary)"
-        />
+        {canDelete && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="compact"
+            iconOnly={<Trash2 aria-hidden />}
+            onClick={() =>
+              onRequestDelete({
+                path: entryPath,
+                name: entryName,
+                isDirectory,
+              })
+            }
+            aria-label={`Delete ${entryName}`}
+            title="Delete"
+            className="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+            tintColor="var(--content-tertiary)"
+          />
+        )}
       </div>
       {isDirectory && effectivelyExpanded && children.length > 0 && (
         <div>

--- a/apps/web/src/domains/workspace/utils/is-hidden-path.ts
+++ b/apps/web/src/domains/workspace/utils/is-hidden-path.ts
@@ -1,0 +1,8 @@
+/**
+ * True when any segment of the workspace-relative path is dot-prefixed
+ * (e.g. `.env`, `.hidden/notes.md`). Hidden paths are read-only in the
+ * workspace UI — the daemon rejects writes/deletes to them.
+ */
+export function isHiddenPath(path: string): boolean {
+  return path.split("/").some((segment) => segment.startsWith("."));
+}

--- a/assistant/src/runtime/routes/workspace-routes.test.ts
+++ b/assistant/src/runtime/routes/workspace-routes.test.ts
@@ -5,7 +5,13 @@
  * directory listing, file metadata, write/mkdir/rename/delete, and raw
  * content serving with range support (HTTP-only).
  */
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { beforeAll, describe, expect, test } from "bun:test";
 
@@ -674,6 +680,21 @@ describe("POST /v1/workspace/rename", () => {
         body: { oldPath: "hello.txt", newPath: "data.json" },
       }),
     ).toThrow(ConflictError);
+  });
+
+  // On case-insensitive filesystems (macOS default) the destination "exists"
+  // because it resolves to the source itself — must rename, not conflict.
+  test("allows case-only rename of the same file", () => {
+    const srcPath = join(testWorkspaceDir, "CaseFile.txt");
+    writeFileSync(srcPath, "case test");
+
+    const result = handler({
+      body: { oldPath: "CaseFile.txt", newPath: "casefile.txt" },
+    }) as { oldPath: string; newPath: string };
+    expect(result.newPath).toBe("casefile.txt");
+    const names = readdirSync(testWorkspaceDir);
+    expect(names).toContain("casefile.txt");
+    expect(names).not.toContain("CaseFile.txt");
   });
 
   test("rejects path traversal on oldPath", () => {

--- a/assistant/src/runtime/routes/workspace-routes.test.ts
+++ b/assistant/src/runtime/routes/workspace-routes.test.ts
@@ -7,6 +7,7 @@
  */
 import {
   existsSync,
+  linkSync,
   mkdirSync,
   readdirSync,
   readFileSync,
@@ -679,6 +680,23 @@ describe("POST /v1/workspace/rename", () => {
     expect(() =>
       handler({
         body: { oldPath: "hello.txt", newPath: "data.json" },
+      }),
+    ).toThrow(ConflictError);
+  });
+
+  // Hard links share an inode while being distinct entries, and POSIX
+  // rename() between two hard links is a silent no-op — must 409 instead
+  // of reporting a successful rename that never happened.
+  test("throws ConflictError when renaming a hard link over its sibling link", () => {
+    writeFileSync(join(testWorkspaceDir, "hard-a.txt"), "hard");
+    linkSync(
+      join(testWorkspaceDir, "hard-a.txt"),
+      join(testWorkspaceDir, "hard-b.txt"),
+    );
+
+    expect(() =>
+      handler({
+        body: { oldPath: "hard-a.txt", newPath: "hard-b.txt" },
       }),
     ).toThrow(ConflictError);
   });

--- a/assistant/src/runtime/routes/workspace-routes.test.ts
+++ b/assistant/src/runtime/routes/workspace-routes.test.ts
@@ -10,6 +10,7 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
@@ -678,6 +679,26 @@ describe("POST /v1/workspace/rename", () => {
     expect(() =>
       handler({
         body: { oldPath: "hello.txt", newPath: "data.json" },
+      }),
+    ).toThrow(ConflictError);
+  });
+
+  // statSync would follow both links to the shared target and treat them as
+  // the same entry, letting the rename clobber a real, separate symlink.
+  test("throws ConflictError when renaming a symlink over a sibling symlink to the same target", () => {
+    writeFileSync(join(testWorkspaceDir, "link-target.txt"), "target");
+    symlinkSync(
+      join(testWorkspaceDir, "link-target.txt"),
+      join(testWorkspaceDir, "link-a.txt"),
+    );
+    symlinkSync(
+      join(testWorkspaceDir, "link-target.txt"),
+      join(testWorkspaceDir, "link-b.txt"),
+    );
+
+    expect(() =>
+      handler({
+        body: { oldPath: "link-a.txt", newPath: "link-b.txt" },
       }),
     ).toThrow(ConflictError);
   });

--- a/assistant/src/runtime/routes/workspace-routes.ts
+++ b/assistant/src/runtime/routes/workspace-routes.ts
@@ -448,6 +448,22 @@ function handleWorkspaceMkdir({ body, headers }: RouteHandlerArgs) {
 // POST /v1/workspace/rename — rename/move files and directories
 // ---------------------------------------------------------------------------
 
+/**
+ * On case-insensitive filesystems (macOS/iOS defaults) a case-only rename's
+ * destination "exists" because it resolves to the source itself. Compare
+ * dev/inode so that case is treated as a rename of the same file rather
+ * than a conflict.
+ */
+function isSameFsEntry(a: string, b: string): boolean {
+  try {
+    const statA = statSync(a);
+    const statB = statSync(b);
+    return statA.dev === statB.dev && statA.ino === statB.ino;
+  } catch {
+    return false;
+  }
+}
+
 function handleWorkspaceRename({ body, headers }: RouteHandlerArgs) {
   const oldPath = body?.oldPath as string | undefined;
   const newPath = body?.newPath as string | undefined;
@@ -474,7 +490,7 @@ function handleWorkspaceRename({ body, headers }: RouteHandlerArgs) {
     throw new NotFoundError("Source path not found");
   }
 
-  if (existsSync(resolvedNew)) {
+  if (existsSync(resolvedNew) && !isSameFsEntry(resolvedOld, resolvedNew)) {
     throw new ConflictError("Destination already exists");
   }
 

--- a/assistant/src/runtime/routes/workspace-routes.ts
+++ b/assistant/src/runtime/routes/workspace-routes.ts
@@ -10,6 +10,7 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  realpathSync,
   renameSync,
   rmSync,
   statSync,
@@ -451,16 +452,22 @@ function handleWorkspaceMkdir({ body, headers }: RouteHandlerArgs) {
 
 /**
  * On case-insensitive filesystems (macOS/iOS defaults) a case-only rename's
- * destination "exists" because it resolves to the source itself. Compare
- * dev/inode so that case is treated as a rename of the same file rather
- * than a conflict. lstat, not stat: two distinct symlinks to one target
- * must still count as different entries.
+ * destination "exists" because it resolves to the source itself. Treat only
+ * true path aliases of one directory entry as the same file:
+ * - lstat, not stat, so two symlinks to one target stay distinct entries;
+ * - matching inodes alone are not enough — hard links share an inode while
+ *   being distinct entries, and POSIX rename() between two hard links is a
+ *   silent no-op. realpath canonicalizes case/normalization aliases of the
+ *   same entry to one string, while distinct entries keep distinct names.
  */
-function isSameFsEntry(a: string, b: string): boolean {
+function isSamePathAlias(a: string, b: string): boolean {
   try {
     const statA = lstatSync(a);
     const statB = lstatSync(b);
-    return statA.dev === statB.dev && statA.ino === statB.ino;
+    if (statA.dev !== statB.dev || statA.ino !== statB.ino) {
+      return false;
+    }
+    return realpathSync(a) === realpathSync(b);
   } catch {
     return false;
   }
@@ -492,7 +499,7 @@ function handleWorkspaceRename({ body, headers }: RouteHandlerArgs) {
     throw new NotFoundError("Source path not found");
   }
 
-  if (existsSync(resolvedNew) && !isSameFsEntry(resolvedOld, resolvedNew)) {
+  if (existsSync(resolvedNew) && !isSamePathAlias(resolvedOld, resolvedNew)) {
     throw new ConflictError("Destination already exists");
   }
 

--- a/assistant/src/runtime/routes/workspace-routes.ts
+++ b/assistant/src/runtime/routes/workspace-routes.ts
@@ -6,6 +6,7 @@
 import {
   type Dirent,
   existsSync,
+  lstatSync,
   mkdirSync,
   readdirSync,
   readFileSync,
@@ -452,12 +453,13 @@ function handleWorkspaceMkdir({ body, headers }: RouteHandlerArgs) {
  * On case-insensitive filesystems (macOS/iOS defaults) a case-only rename's
  * destination "exists" because it resolves to the source itself. Compare
  * dev/inode so that case is treated as a rename of the same file rather
- * than a conflict.
+ * than a conflict. lstat, not stat: two distinct symlinks to one target
+ * must still count as different entries.
  */
 function isSameFsEntry(a: string, b: string): boolean {
   try {
-    const statA = statSync(a);
-    const statB = statSync(b);
+    const statA = lstatSync(a);
+    const statB = lstatSync(b);
     return statA.dev === statB.dev && statA.ino === statB.ino;
   } catch {
     return false;


### PR DESCRIPTION
## Summary
- Add a right-click / long-press context menu to every workspace tree row — New File / New Folder (on directories), Delete, and Rename — mirroring the original native macOS app's WorkspacePanel, using the design library's `ContextMenu`
- Delete confirms via a destructive `ConfirmDialog` and calls the existing `POST /v1/workspace/delete`; rename prompts with a prefilled name dialog, calls `POST /v1/workspace/rename`, and remaps the viewer selection and expanded folders to the new path
- Hidden paths (dot-prefixed segments) get no context menu, matching both the daemon's read-only policy for hidden paths and the native app's behavior; context-menu creates land inside the right-clicked directory

Fixes [LUM-2398](https://linear.app/vellum/issue/LUM-2398/cannot-manually-delete-files-in-the-workspace)

## Original prompt
Fix Linear ticket LUM-2398 ("Cannot manually delete files in the workspace"): manual file deletion was not working in the Electron app or on web. Investigation showed the daemon's workspace/delete endpoint already worked but the shared workspace browser UI never exposed any delete action. After an initial hover-button implementation, the change was reworked per follow-up direction to match the original native macOS app's UX: a per-row context menu with Delete plus Rename (and contextual New File / New Folder), wired to the existing daemon endpoints.