### PR TITLE
fix(memory): tool-surface and hasNoClient parity pins derived from the source

### DIFF
--- a/assistant/src/__tests__/subagent-tool-gate-mode.test.ts
+++ b/assistant/src/__tests__/subagent-tool-gate-mode.test.ts
@@ -248,6 +248,111 @@ describe("createResolveToolsCallback — subagentToolGateMode", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Resolver — toolContextPin (wire tool-surface parity for execution wakes)
+// ---------------------------------------------------------------------------
+
+describe("createResolveToolsCallback — toolContextPin", () => {
+  // Core defs spanning each client-gated family: host proxy (host_bash),
+  // dynamic UI (ui_show), connected-client (app_open), client-platform
+  // (request_system_permission), plus the always-on remember.
+  const CLIENT_GATED_DEFS = [
+    makeToolDef("remember"),
+    makeToolDef("host_bash"),
+    makeToolDef("ui_show"),
+    makeToolDef("app_open"),
+    makeToolDef("request_system_permission"),
+  ];
+
+  /** Execution-gate ctx shaped like a clientless fork-retrospective wake. */
+  function clientlessExecutionCtx(
+    overrides: Partial<SkillProjectionContext> = {},
+  ): SkillProjectionContext {
+    return makeProjectionCtx({
+      coreToolNames: new Set(CLIENT_GATED_DEFS.map((d) => d.name)),
+      hasNoClient: true,
+      subagentAllowedTools: new Set(["remember"]),
+      subagentToolGateMode: "execution",
+      ...overrides,
+    });
+  }
+
+  test("control: without a pin, a clientless fork drops every client-gated tool from the wire", () => {
+    projectedSkillToolNames = [];
+    const resolve = createResolveToolsCallback(
+      CLIENT_GATED_DEFS,
+      clientlessExecutionCtx(),
+    )!;
+
+    expect(resolve(EMPTY_HISTORY).map((t) => t.name)).toEqual(["remember"]);
+  });
+
+  test("a desktop-source pin restores the host/UI/client tool defs on the wire", () => {
+    projectedSkillToolNames = [];
+    const resolve = createResolveToolsCallback(
+      CLIENT_GATED_DEFS,
+      clientlessExecutionCtx({
+        toolContextPin: { hasNoClient: false, transportInterface: "macos" },
+      }),
+    )!;
+
+    const names = resolve(EMPTY_HISTORY)
+      .map((t) => t.name)
+      .sort();
+    // request_system_permission stays out: it keys on
+    // channelCapabilities.clientOS, which desktop HTTP live turns never set
+    // either — exclusion IS parity there.
+    expect(names).toEqual(["app_open", "host_bash", "remember", "ui_show"]);
+  });
+
+  test("the pin REPLACES the live context — absent pin fields do not fall through", () => {
+    projectedSkillToolNames = [];
+    // Live ctx claims an interactive macOS client; the pin says clientless.
+    // Client-gated tools must drop, proving pinned-undefined beats live.
+    const resolve = createResolveToolsCallback(
+      CLIENT_GATED_DEFS,
+      clientlessExecutionCtx({
+        hasNoClient: false,
+        transportInterface: "macos",
+        toolContextPin: { hasNoClient: true },
+      }),
+    )!;
+
+    expect(resolve(EMPTY_HISTORY).map((t) => t.name)).toEqual(["remember"]);
+  });
+
+  test("invariant: a pinned-in tool is on the wire but can never execute", async () => {
+    projectedSkillToolNames = [];
+    const pin = { hasNoClient: false, transportInterface: "macos" as const };
+    const resolve = createResolveToolsCallback(
+      CLIENT_GATED_DEFS,
+      clientlessExecutionCtx({ toolContextPin: pin }),
+    )!;
+    expect(resolve(EMPTY_HISTORY).map((t) => t.name)).toContain("host_bash");
+
+    // The pin affects tool-DEFINITION resolution only: the executor-level
+    // gate never reads it, so the pinned-in host tool is rejected before
+    // any executor dispatch.
+    const { executor, calls } = makeCapturingExecutor();
+    const toolFn = makeToolFn(
+      executor,
+      makeSetupCtx({
+        hasNoClient: true,
+        subagentAllowedTools: new Set(["remember"]),
+        subagentToolGateMode: "execution",
+      }),
+    );
+
+    const result = await toolFn("host_bash", { command: "echo hi" });
+
+    expect(result).toEqual({
+      content: "This background pass may only use: remember.",
+      isError: true,
+    });
+    expect(calls).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Executor — execution-layer allowlist gate
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -64,10 +64,12 @@ import {
 import type {
   SubagentToolGateMode,
   ToolSetupContext,
+  WakeToolContextPin,
 } from "./tool-setup-types.js";
 export type {
   SubagentToolGateMode,
   ToolSetupContext,
+  WakeToolContextPin,
 } from "./tool-setup-types.js";
 
 // ── resolveConversationAttribution ───────────────────────────────────
@@ -134,12 +136,10 @@ export function createToolExecutor(
     ctx.sendToClient(msg),
   );
 
-  // Execution-layer allowlist gate (`subagentToolGateMode === "execution"`):
-  // the wire request carries the conversation's full tool surface (so the
-  // provider prompt-cache prefix stays byte-identical to normal turns), and
-  // the allowlist is enforced here instead — BEFORE any executor dispatch,
-  // so a non-allowlisted tool's executor never runs. The error tool_result
-  // lets the model continue with an allowlisted tool or finish.
+  // Execution-layer allowlist gate (`subagentToolGateMode === "execution"`,
+  // see {@link SubagentToolGateMode}): rejects non-allowlisted calls BEFORE
+  // any executor dispatch, so a non-allowlisted tool's executor never runs.
+  // The error tool_result lets the model continue or finish.
   const rejectNonAllowlistedTool = (
     toolName: string,
   ): ToolExecutionResult | null => {
@@ -404,13 +404,17 @@ export interface SkillProjectionContext {
   /** When set, only tools in this set are included in the resolved tool list (subagent delegation). */
   subagentAllowedTools?: Set<string>;
   /**
-   * How {@link subagentAllowedTools} is enforced. Absent or `"wire"` filters
-   * the resolved tool definitions (historical behavior); `"execution"` keeps
-   * the full tool surface on the wire — preserving provider prompt-cache
-   * parity — and relies on the executor callback's execution-layer gate to
-   * reject non-allowlisted calls.
+   * How {@link subagentAllowedTools} is enforced — see
+   * {@link SubagentToolGateMode}. Absent means `"wire"`.
    */
   subagentToolGateMode?: SubagentToolGateMode;
+  /**
+   * When set (execution-gate-mode wakes), tool-definition resolution reads
+   * `hasNoClient` / `transportInterface` / `channelCapabilities` exclusively
+   * from this pin instead of the live conversation — see
+   * {@link WakeToolContextPin}.
+   */
+  readonly toolContextPin?: WakeToolContextPin;
   /** True when the current turn is restricted to disk-pressure cleanup-safe tools. */
   diskPressureCleanupModeActive?: boolean;
   /** True when this conversation belongs to a subagent spawned by SubagentManager. */
@@ -529,6 +533,20 @@ export function isToolActiveForContext(
   name: string,
   ctx: SkillProjectionContext,
 ): boolean {
+  // Execution-gate-mode wakes pin the client-context inputs so the wire tool
+  // surface matches the SOURCE conversation's live turns rather than the
+  // fork's clientless hydration (see {@link WakeToolContextPin}). When the
+  // pin is present it replaces all three values — absent pin fields pin
+  // `undefined`, never falling through to live state.
+  const pin = ctx.toolContextPin;
+  const hasNoClient = pin ? pin.hasNoClient : ctx.hasNoClient;
+  const channelCapabilities = pin
+    ? pin.channelCapabilities
+    : ctx.channelCapabilities;
+  const transportInterface = pin
+    ? pin.transportInterface
+    : ctx.transportInterface;
+
   // When the conversation is acting as a subagent, the parent orchestrator
   // restricts the tool list. A tool that isn't on the allowlist is not
   // available for this turn, so short-circuit before any capability checks.
@@ -563,16 +581,16 @@ export function isToolActiveForContext(
   }
   if (UI_SURFACE_TOOL_NAMES.has(name)) {
     if (
-      ctx.channelCapabilities?.channel === "slack" &&
+      channelCapabilities?.channel === "slack" &&
       SLACK_TASK_PROGRESS_UI_TOOL_NAMES.has(name)
     ) {
-      return !ctx.hasNoClient;
+      return !hasNoClient;
     }
-    return ctx.channelCapabilities?.supportsDynamicUi ?? !ctx.hasNoClient;
+    return channelCapabilities?.supportsDynamicUi ?? !hasNoClient;
   }
   if (HOST_TOOL_NAMES.has(name)) {
     const capability = HOST_TOOL_TO_CAPABILITY.get(name);
-    const transport = ctx.transportInterface;
+    const transport = transportInterface;
 
     // Per-capability check is authoritative for structural support: if the
     // transport cannot service this capability, the tool is filtered out.
@@ -591,7 +609,7 @@ export function isToolActiveForContext(
         capability &&
         CROSS_CLIENT_EXPOSED_CAPABILITIES.has(capability) &&
         transport !== "chrome-extension" &&
-        !ctx.hasNoClient &&
+        !hasNoClient &&
         assistantEventHub.listClientsByCapability(capability).length > 0
       ) {
         return true;
@@ -611,23 +629,20 @@ export function isToolActiveForContext(
     // For transports that surface approvals over SSE (macos, backwards-compat
     // fallback), deny when no client is present so the guardian auto-approve
     // path cannot execute host commands unattended.
-    return !ctx.hasNoClient;
+    return !hasNoClient;
   }
   if (CLIENT_CAPABILITY_TOOL_NAMES.has(name)) {
-    if (
-      name === "ask_question" &&
-      ctx.channelCapabilities?.clientOS === "macos"
-    ) {
+    if (name === "ask_question" && channelCapabilities?.clientOS === "macos") {
       // macOS has no UI handler for question_request yet; hiding the tool
       // avoids a 5-minute prompter timeout when the LLM would otherwise call it.
       return false;
     }
-    return !ctx.hasNoClient;
+    return !hasNoClient;
   }
   if (PLATFORM_TOOL_NAMES.has(name)) {
     // Check the *client's* platform, not the daemon's process.platform.
     // In Docker the daemon runs on Linux but the connected client may be macOS.
-    return ctx.channelCapabilities?.clientOS === "macos" && !ctx.hasNoClient;
+    return channelCapabilities?.clientOS === "macos" && !hasNoClient;
   }
   if (SUBAGENT_ONLY_TOOL_NAMES.has(name)) {
     return ctx.isSubagent === true;
@@ -686,10 +701,8 @@ export function createResolveToolsCallback(
     // When the conversation is acting as a subagent, restrict core tools to
     // only those explicitly allowed by the parent orchestrator. In
     // `"execution"` gate mode the allowlist is NOT applied to the wire
-    // definitions — the provider request keeps the conversation's full tool
-    // surface (tool definitions lead the provider prompt-cache prefix, so
-    // filtering them would invalidate the cached prefix) and the executor
-    // callback rejects non-allowlisted calls at execution time instead.
+    // definitions (see {@link SubagentToolGateMode}) — the executor callback
+    // rejects non-allowlisted calls at execution time instead.
     const wireAllowlist =
       ctx.subagentToolGateMode === "execution"
         ? undefined

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -150,6 +150,7 @@ import {
 import type {
   SubagentToolGateMode,
   ToolSetupContext,
+  WakeToolContextPin,
 } from "./conversation-tool-setup.js";
 import {
   createResolveToolsCallback,
@@ -245,14 +246,20 @@ export class Conversation {
   /** @internal */ preactivatedSkillIds?: string[];
   /** @internal */ subagentAllowedTools?: Set<string>;
   /**
-   * How {@link subagentAllowedTools} is enforced — absent/`"wire"` filters
-   * the provider tool definitions (historical behavior); `"execution"`
-   * keeps the full tool surface on the wire for prompt-cache parity and
-   * rejects non-allowlisted calls at execution time. Set and restored
-   * alongside the allowlist by `scopeWakeAllowedTools`.
+   * How {@link subagentAllowedTools} is enforced — see
+   * {@link SubagentToolGateMode}. Set and restored alongside the allowlist
+   * by `scopeWakeAllowedTools`.
    * @internal
    */
   subagentToolGateMode?: SubagentToolGateMode;
+  /**
+   * Client-context pin for execution-gate-mode wakes — see
+   * {@link WakeToolContextPin}. Set and restored alongside the allowlist by
+   * `scopeWakeAllowedTools`; read only by tool-DEFINITION resolution
+   * (`isToolActiveForContext`), never by executor or host-proxy paths.
+   * @internal
+   */
+  toolContextPin?: WakeToolContextPin;
   /** @internal */ coreToolNames: Set<string>;
   /** @internal */ readonly skillProjectionState = new Map<string, string>();
   /** @internal */ readonly skillProjectionCache: SkillProjectionCache = {};

--- a/assistant/src/daemon/tool-setup-types.ts
+++ b/assistant/src/daemon/tool-setup-types.ts
@@ -25,6 +25,45 @@ import type { TrustContext } from "./trust-context.js";
 export type SubagentToolGateMode = "wire" | "execution";
 
 /**
+ * Client-context inputs frozen for tool-DEFINITION resolution during a wake
+ * that runs with `subagentToolGateMode: "execution"`.
+ *
+ * Execution gate mode exists to keep the wire tool array byte-identical to
+ * the source conversation's live turns (see {@link SubagentToolGateMode}),
+ * but the definitions themselves are resolved from the live context: a
+ * fork-retrospective wake hydrates clientless (`hasNoClient = true`, no
+ * transport interface, no channel capabilities), which drops client-gated
+ * tools (`host_*`, `ui_*`, `app_open`, `request_system_permission`) from
+ * the wire definitions and breaks the cache prefix anyway. When this pin is
+ * set on the conversation, `isToolActiveForContext` reads `hasNoClient`,
+ * `transportInterface`, and `channelCapabilities` exclusively from the pin
+ * — an absent optional field pins the value to `undefined`; there is no
+ * fall-through to the live conversation state.
+ *
+ * Tool-definition resolution ONLY. The executor callback and host-proxy
+ * attachment paths never read the pin, so it cannot make a host tool
+ * runnable: in execution gate mode every non-allowlisted call is rejected
+ * before its executor runs, so a pinned-in tool can appear on the wire but
+ * can never execute.
+ */
+export interface WakeToolContextPin {
+  /** The source conversation's live-turn `hasNoClient` value. */
+  hasNoClient: boolean;
+  /** The interface the source's live turns ran on (e.g. `"macos"`). */
+  transportInterface?: InterfaceId;
+  /**
+   * The source's live-turn channel capabilities. Interactive-interface
+   * (desktop/web HTTP) turns never set channel capabilities, so parity for
+   * those sources means leaving this unset.
+   */
+  channelCapabilities?: {
+    channel: string;
+    supportsDynamicUi: boolean;
+    clientOS?: string;
+  };
+}
+
+/**
  * Subset of Conversation state that the tool executor callback reads at
  * call time (not construction time). These are captured by the
  * returned closure, so they must be live references.

--- a/assistant/src/daemon/wake-conversation-ops.ts
+++ b/assistant/src/daemon/wake-conversation-ops.ts
@@ -25,7 +25,10 @@ import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { getLogger } from "../util/logger.js";
 import type { Conversation } from "./conversation.js";
 import type { ServerMessage } from "./message-protocol.js";
-import type { SubagentToolGateMode } from "./tool-setup-types.js";
+import type {
+  SubagentToolGateMode,
+  WakeToolContextPin,
+} from "./tool-setup-types.js";
 
 const log = getLogger("wake-conversation-ops");
 
@@ -258,24 +261,27 @@ export async function persistWakeTailMessage(
  * callback that reinstates the previous allowlist so the wake can release
  * the scope before any queued user turn is drained.
  *
- * `gateMode` controls how the allowlist is enforced (see
- * {@link SubagentToolGateMode}): `"wire"` (default) filters the tool
- * definitions sent to the provider — the historical behavior — while
- * `"execution"` keeps the conversation's full tool surface on the wire for
- * provider prompt-cache parity and rejects non-allowlisted calls at
- * execution time. The gate mode is restored alongside the allowlist.
+ * `gateMode` controls how the allowlist is enforced — see
+ * {@link SubagentToolGateMode}. `toolContextPin`, when provided
+ * (execution-gate-mode cache-parity wakes), freezes the client-context
+ * inputs for tool-definition resolution — see {@link WakeToolContextPin}.
+ * Both are set and restored alongside the allowlist.
  */
 export function scopeWakeAllowedTools(
   conversation: Conversation,
   tools: ReadonlySet<string>,
   gateMode: SubagentToolGateMode = "wire",
+  toolContextPin?: WakeToolContextPin,
 ): () => void {
   const previous = conversation.subagentAllowedTools;
   const previousGateMode = conversation.subagentToolGateMode;
+  const previousToolContextPin = conversation.toolContextPin;
   conversation.setSubagentAllowedTools(new Set(tools));
   conversation.subagentToolGateMode = gateMode;
+  conversation.toolContextPin = toolContextPin;
   return () => {
     conversation.setSubagentAllowedTools(previous);
     conversation.subagentToolGateMode = previousGateMode;
+    conversation.toolContextPin = previousToolContextPin;
   };
 }

--- a/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
@@ -84,6 +84,7 @@ type ConversationStub = {
   inferenceProfile?: string | null;
   inferenceProfileExpiresAt?: number | null;
   originChannel?: string | null;
+  originInterface?: string | null;
 };
 let conversationOverrides: Record<string, ConversationStub> = {};
 
@@ -842,7 +843,7 @@ describe("memoryRetrospectiveJob", () => {
     });
   });
 
-  test("fork path: channel-routed source → no persona slugs (identity not recoverable), hasNoClient still pinned", async () => {
+  test("fork path: channel-routed source → no persona slugs (identity not recoverable), hasNoClient pinned to the live-turn value (true)", async () => {
     forkFlagEnabled = true;
     conversationOverrides["src-conv-1"] = {
       source: "user",
@@ -854,10 +855,12 @@ describe("memoryRetrospectiveJob", () => {
     await memoryRetrospectiveJob(makeJob(), stubConfig);
 
     expect(wakeCalls).toHaveLength(1);
-    // The slugs are unrecoverable for a channel-routed source, but the
-    // hasNoClient pin is unconditional: the fork hydrates clientless while
-    // the source's live turns ran with hasNoClient = false.
-    expect(wakeCalls[0]!.opts.personaOverride).toEqual({ hasNoClient: false });
+    // The slugs are unrecoverable for a channel-routed source, and the
+    // hasNoClient pin mirrors the source's live turns: channel-routed turns
+    // run clientless (process-message never calls updateClient(_, false)),
+    // so the live-turn value is TRUE — pinned explicitly rather than left to
+    // the fork's hydration default.
+    expect(wakeCalls[0]!.opts.personaOverride).toEqual({ hasNoClient: true });
     expect(resolveUserSlugCalls).toEqual([]);
   });
 
@@ -889,6 +892,138 @@ describe("memoryRetrospectiveJob", () => {
       channelSlug: "vellum",
       hasNoClient: false,
     });
+  });
+
+  test("fork path: execution mode → toolContextPin derived from the source (desktop default = web, hasNoClient false)", async () => {
+    forkFlagEnabled = true;
+    conversationOverrides["src-conv-1"] = {
+      source: "user",
+      forkParentMessageId: null,
+      title: "Source conversation",
+      conversationType: "standard",
+      inferenceProfile: "profile-x",
+    };
+
+    await memoryRetrospectiveJob(
+      makeJob(),
+      makeConfig({ matchConversationProfile: true }),
+    );
+
+    expect(wakeCalls).toHaveLength(1);
+    // No slice metadata, no originInterface → the non-channel-routed
+    // terminal fallback is "web" (mirroring resolveTurnInterface).
+    expect(wakeCalls[0]!.opts.toolContextPin).toEqual({
+      hasNoClient: false,
+      transportInterface: "web",
+    });
+  });
+
+  test("fork path: wire mode (no resolved profile) → no toolContextPin on the wake", async () => {
+    forkFlagEnabled = true;
+
+    await memoryRetrospectiveJob(
+      makeJob(),
+      makeConfig({ matchConversationProfile: true }),
+    );
+
+    expect(wakeCalls).toHaveLength(1);
+    // The pin exists purely for wire tool-surface cache parity, which is
+    // only in play in execution gate mode.
+    expect("toolContextPin" in wakeCalls[0]!.opts).toBe(false);
+  });
+
+  test("fork path: toolContextPin recovers the interface from the NEWEST stamped user message in the slice", async () => {
+    forkFlagEnabled = true;
+    conversationOverrides["src-conv-1"] = {
+      source: "user",
+      forkParentMessageId: null,
+      title: "Source conversation",
+      conversationType: "standard",
+      inferenceProfile: "profile-x",
+    };
+    newMessages = [
+      {
+        id: "m1",
+        createdAt: Date.parse("2026-05-11T10:00:00Z"),
+        role: "user",
+        metadata: JSON.stringify({ userMessageInterface: "web" }),
+      },
+      {
+        id: "m2",
+        createdAt: Date.parse("2026-05-11T10:05:00Z"),
+        role: "user",
+        metadata: JSON.stringify({ userMessageInterface: "macos" }),
+      },
+      {
+        id: "m3",
+        createdAt: Date.parse("2026-05-11T10:10:00Z"),
+        role: "assistant",
+        metadata: null,
+      },
+    ];
+
+    await memoryRetrospectiveJob(
+      makeJob(),
+      makeConfig({ matchConversationProfile: true }),
+    );
+
+    expect(wakeCalls).toHaveLength(1);
+    // Newest stamped USER message wins (m2's "macos", not m1's "web"); the
+    // assistant row is skipped.
+    expect(wakeCalls[0]!.opts.toolContextPin).toEqual({
+      hasNoClient: false,
+      transportInterface: "macos",
+    });
+  });
+
+  test("fork path: toolContextPin falls back to the row's originInterface when the slice carries no stamp", async () => {
+    forkFlagEnabled = true;
+    conversationOverrides["src-conv-1"] = {
+      source: "user",
+      forkParentMessageId: null,
+      title: "Source conversation",
+      conversationType: "standard",
+      inferenceProfile: "profile-x",
+      originInterface: "macos",
+    };
+
+    await memoryRetrospectiveJob(
+      makeJob(),
+      makeConfig({ matchConversationProfile: true }),
+    );
+
+    expect(wakeCalls).toHaveLength(1);
+    expect(wakeCalls[0]!.opts.toolContextPin).toEqual({
+      hasNoClient: false,
+      transportInterface: "macos",
+    });
+  });
+
+  test("fork path: channel-routed source → toolContextPin pins clientless with the channel's interface", async () => {
+    forkFlagEnabled = true;
+    conversationOverrides["src-conv-1"] = {
+      source: "user",
+      forkParentMessageId: null,
+      title: "Source conversation",
+      conversationType: "standard",
+      inferenceProfile: "profile-x",
+      originChannel: "telegram",
+    };
+
+    await memoryRetrospectiveJob(
+      makeJob(),
+      makeConfig({ matchConversationProfile: true }),
+    );
+
+    expect(wakeCalls).toHaveLength(1);
+    // Channel-routed live turns ran clientless; the channel id doubles as
+    // the interface id when nothing else is recoverable.
+    expect(wakeCalls[0]!.opts.toolContextPin).toEqual({
+      hasNoClient: true,
+      transportInterface: "telegram",
+    });
+    // The persona pin carries the same live-turn hasNoClient value.
+    expect(wakeCalls[0]!.opts.personaOverride).toEqual({ hasNoClient: true });
   });
 
   test("legacy path: wake carries no persona override", async () => {

--- a/assistant/src/memory/memory-retrospective-job.ts
+++ b/assistant/src/memory/memory-retrospective-job.ts
@@ -35,6 +35,11 @@
 // conversations left by a mid-run crash are swept by
 // `memory-retrospective-startup-cleanup.ts`.
 
+import {
+  type InterfaceId,
+  isInteractiveInterface,
+  parseInterfaceId,
+} from "../channels/types.js";
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import type { AssistantConfig } from "../config/types.js";
 import { extractTurnContextTimestamp } from "../context/compactor.js";
@@ -47,6 +52,7 @@ import {
   getAssistantName,
   resolveUserName,
 } from "../daemon/identity-helpers.js";
+import type { WakeToolContextPin } from "../daemon/tool-setup-types.js";
 import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../daemon/trust-context.js";
 import { formatMessageSliceForTranscript } from "../export/transcript-formatter.js";
 import { resolveUserSlug } from "../prompts/persona-resolver.js";
@@ -438,22 +444,17 @@ async function runForkBasedRetrospective(
     ? resolveOverrideProfile(sourceConversation)
     : undefined;
 
-  // Render the fork's system prompt under the SOURCE conversation's persona
-  // and channel — the same sections its live turns rendered. Passed
-  // unconditionally (not gated on matchConversationProfile): the correct
-  // persona is a review-quality fix on its own; with profile matching it
-  // additionally preserves the source's cached system-prompt prefix.
-  // An empty slug resolution (identity not recoverable) keeps today's
-  // persona behavior. `hasNoClient` is pinned to the live-turn value
-  // unconditionally: the fork is hydrated clientless
-  // (`getOrCreateConversation` → `updateClient(_, true)`), but the source's
-  // live turns ran with `hasNoClient = false`, and the prompt's
-  // `05-access-preference` section renders different text under the flag —
-  // early enough to break byte-parity with the source's cached prefix.
-  const personaOverride: SystemPromptPersonaOverride = {
-    ...resolveSourcePersonaOverride(sourceConversation),
-    hasNoClient: false,
-  };
+  // Persona + tool-context parity pins derived from the source conversation
+  // (see `resolveSourceParityPins`). The persona override is passed
+  // unconditionally — the correct persona is a review-quality fix on its
+  // own; with profile matching it additionally preserves the source's
+  // cached system-prompt prefix. The tool-context pin rides only with
+  // execution gate mode below: it exists purely for wire tool-surface
+  // cache parity.
+  const { personaOverride, toolContextPin } = resolveSourceParityPins(
+    sourceConversation,
+    newMessages,
+  );
 
   // `skipHintInjection: true` because the instruction is already a
   // persisted message — the wake's hint sandwich would only duplicate it.
@@ -468,20 +469,18 @@ async function runForkBasedRetrospective(
       trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT,
       callSite: "memoryRetrospective",
       allowedTools: ["remember"],
-      // When the profile match actually resolved (cache parity is in play),
-      // also keep the source's full tool surface on the wire: the provider
-      // cache prefix is `tools → system → messages`, so wire-filtering the
-      // tool array to ["remember"] would invalidate the cached prefix the
-      // profile match just preserved. The allowlist still holds —
-      // non-`remember` calls are rejected at execution time. When the match
-      // resolves to nothing (no pinned profile / expired session) the wake
-      // runs the call-site default model, so there is no source cache to
-      // preserve and the smaller wire-filtered request is cheaper — keyed on
-      // `matchedProfile`, not the bare config flag.
+      // When the profile match resolved (cache parity is in play), keep the
+      // source's full tool surface on the wire AND resolve it under the
+      // source's client context — see {@link SubagentToolGateMode} and
+      // {@link WakeToolContextPin} for the rationale; the allowlist still
+      // holds at execution time. No match ⇒ no source cache to preserve, so
+      // the smaller wire-filtered request wins (keyed on `matchedProfile`,
+      // not the bare config flag).
       ...(matchedProfile !== undefined
         ? {
             toolGateMode: "execution" as const,
             forceOverrideProfile: matchedProfile,
+            toolContextPin,
           }
         : {}),
       personaOverride,
@@ -550,34 +549,117 @@ function enqueueFollowUpJobs(): string[] {
 }
 
 /**
- * Resolve the persona/channel override the fork wake should render — the
- * same user and channel persona sections a live turn on the SOURCE
- * conversation rendered.
- *
- * Local/desktop sources (`originChannel` null or `"vellum"`): live turns
- * resolve the guardian contact's userFile — either via the
- * undefined-trust-context branch of `resolveUserFilename` (desktop/native,
- * no gateway) or via its guardian-class `findGuardianForChannel("vellum")`
- * fallback (managed desktop, whose JWT-principal `requesterExternalUserId`
- * never matches a contact channel row). `resolveUserSlug(undefined)`
- * reproduces both, falling back to `"default"` exactly as the live prompt
- * build does when no guardian resolves. Channel persona is `"vellum"`.
- *
- * Channel-routed sources: live-turn persona resolution keys off the
- * requester's `requesterExternalUserId` (contact lookup per actor, possibly
- * different across turns), which is not stored on the conversation row —
- * the live-turn result is not recoverable here. Return `undefined` so the
- * wake keeps today's behavior.
+ * The source-derived parity pins the fork wake runs under: the system-prompt
+ * persona override and the tool-resolution context pin. Both exist so the
+ * fork's provider request matches what the SOURCE conversation's live turns
+ * sent (prompt-cache prefix is `tools → system → messages`).
  */
-function resolveSourcePersonaOverride(
-  source: Pick<ConversationRow, "originChannel">,
-): SystemPromptPersonaOverride | undefined {
+interface SourceParityPins {
+  personaOverride: SystemPromptPersonaOverride;
+  toolContextPin: WakeToolContextPin;
+}
+
+/**
+ * Derive the fork wake's parity pins from the source conversation.
+ *
+ * Persona slugs — local/desktop sources (`originChannel` null or
+ * `"vellum"`): live turns resolve the guardian contact's userFile — either
+ * via the undefined-trust-context branch of `resolveUserFilename`
+ * (desktop/native, no gateway) or via its guardian-class
+ * `findGuardianForChannel("vellum")` fallback (managed desktop, whose
+ * JWT-principal `requesterExternalUserId` never matches a contact channel
+ * row). `resolveUserSlug(undefined)` reproduces both, falling back to
+ * `"default"` exactly as the live prompt build does when no guardian
+ * resolves. Channel persona is `"vellum"`. Channel-routed sources: live-turn
+ * persona resolution keys off the requester's `requesterExternalUserId`
+ * (contact lookup per actor, possibly different across turns), which is not
+ * stored on the conversation row — the slugs are omitted so the wake keeps
+ * today's persona derivation for them.
+ *
+ * `hasNoClient` — pinned on BOTH the persona override (the prompt's
+ * `05-access-preference` section renders different text under the flag) and
+ * the tool-context pin, using the live-turn derivation: interactive
+ * interfaces run `updateClient(_, false)` (`hasNoClient = false`), while
+ * channel-routed and chrome-extension turns stay clientless (`true`) — the
+ * exact `isInteractiveInterface` predicate `conversation-routes.ts` /
+ * `process-message.ts` apply. Pinned explicitly even when it matches the
+ * fork's hydrated value (`true`) so the parity contract doesn't depend on
+ * hydration defaults.
+ *
+ * `toolContextPin.transportInterface` — the interface the source's most
+ * recent live turns ran on (see {@link resolveSourceLiveInterface}).
+ * `channelCapabilities` is left unset: desktop/web HTTP turns never set
+ * channel capabilities, and for channel-routed sources (whose live turns do
+ * carry them) every tool gate resolves identically under
+ * `hasNoClient = true` with or without capabilities — so unset is parity
+ * for the former and outcome-equal for the latter.
+ */
+function resolveSourceParityPins(
+  source: Pick<ConversationRow, "originChannel" | "originInterface">,
+  sliceMessages: Array<{ role: string; metadata: string | null }>,
+): SourceParityPins {
   const channel = source.originChannel;
-  if (channel != null && channel !== "vellum") return undefined;
+  const channelRouted = channel != null && channel !== "vellum";
+  const recovered = resolveSourceLiveInterface(source, sliceMessages);
+  // Non-channel-routed sources always have a client-connected interface;
+  // when none is recoverable, default to "web" — the same terminal fallback
+  // `resolveTurnInterface` applies to live turns. Channel-routed sources
+  // with an unmappable channel stay undefined (their live turns were
+  // clientless either way).
+  const transportInterface = recovered ?? (channelRouted ? undefined : "web");
+  const hasNoClient =
+    transportInterface == null || !isInteractiveInterface(transportInterface);
+  const personaOverride: SystemPromptPersonaOverride = channelRouted
+    ? { hasNoClient }
+    : {
+        userSlug: resolveUserSlug(undefined) ?? "default",
+        channelSlug: "vellum",
+        hasNoClient,
+      };
   return {
-    userSlug: resolveUserSlug(undefined) ?? "default",
-    channelSlug: "vellum",
+    personaOverride,
+    toolContextPin: { hasNoClient, transportInterface },
   };
+}
+
+/**
+ * Recover the interface the source conversation's most recent live turns ran
+ * on — the transport whose provider requests the fork wants cache parity
+ * with.
+ *
+ * Scans the new-message slice newest-first for a user message stamped with
+ * `userMessageInterface` (the same per-message metadata live turns persist),
+ * then falls back to the conversation row's `originInterface` (sticky
+ * first-interface column), then to the origin channel id where it doubles as
+ * an interface id (telegram/slack/whatsapp/email/phone; the legacy
+ * `"vellum"` alias maps to `"web"`). Every input is persisted state, so for
+ * a given cutoff the result is deterministic — it cannot flap between
+ * retries of the same slice.
+ */
+function resolveSourceLiveInterface(
+  source: Pick<ConversationRow, "originChannel" | "originInterface">,
+  sliceMessages: Array<{ role: string; metadata: string | null }>,
+): InterfaceId | undefined {
+  for (let i = sliceMessages.length - 1; i >= 0; i--) {
+    const row = sliceMessages[i]!;
+    if (row.role !== "user" || !row.metadata) continue;
+    let meta: unknown;
+    try {
+      meta = JSON.parse(row.metadata);
+    } catch {
+      continue;
+    }
+    if (!meta || typeof meta !== "object") continue;
+    const iface = parseInterfaceId(
+      (meta as Record<string, unknown>).userMessageInterface,
+    );
+    if (iface) return iface;
+  }
+  return (
+    parseInterfaceId(source.originInterface) ??
+    parseInterfaceId(source.originChannel) ??
+    undefined
+  );
 }
 
 type PriorRetrospective = NonNullable<

--- a/assistant/src/prompts/system-prompt.ts
+++ b/assistant/src/prompts/system-prompt.ts
@@ -324,7 +324,9 @@ export interface SystemPromptPersonaOverride {
    * mismatch breaks byte-parity with a cached prefix even when persona and
    * profile match. Used by fork-based memory retrospectives: the fork is
    * hydrated clientless (`hasNoClient = true`) while the source's live turns
-   * ran with `hasNoClient = false`.
+   * ran under the source's own client state (`false` for interactive
+   * interfaces, `true` for channel-routed sources) — the pin carries that
+   * live-turn value.
    */
   hasNoClient?: boolean;
 }

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -858,6 +858,41 @@ describe("wakeAgentForOpportunity", () => {
     expect(conversation.subagentToolGateMode).toBeUndefined();
   });
 
+  test("applies toolContextPin alongside the allowlist and restores it after the wake", async () => {
+    let pinDuringRun: unknown;
+    const conversation = makeWakeConversation({
+      runImpl: async (input) => {
+        pinDuringRun = conversation.toolContextPin;
+        return runResult([
+          ...input,
+          { role: "assistant", content: [{ type: "text", text: "Saved." }] },
+        ]);
+      },
+    });
+
+    const result = await wakeAgentForOpportunity(
+      {
+        conversationId: conversation.conversationId,
+        hint: "review for memories",
+        source: "memory-retrospective",
+        allowedTools: ["remember"],
+        toolGateMode: "execution",
+        toolContextPin: { hasNoClient: false, transportInterface: "macos" },
+      },
+      { resolveTarget: async () => conversation },
+    );
+
+    expect(result).toEqual({ invoked: true, producedToolCalls: false });
+    // The pin is live on the conversation for the duration of the run (the
+    // tool resolver reads it there for wire-definition parity)...
+    expect(pinDuringRun).toEqual({
+      hasNoClient: false,
+      transportInterface: "macos",
+    });
+    // ...and restored alongside the allowlist + gate mode after the wake.
+    expect(conversation.toolContextPin).toBeUndefined();
+  });
+
   test("defaults to the wire gate mode when toolGateMode is absent", async () => {
     let gateModeDuringRun: string | undefined;
     const conversation = makeWakeConversation({

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -64,7 +64,10 @@ import {
   type DiskPressureTurnPolicyDecision,
 } from "../daemon/disk-pressure-policy.js";
 import { looksLikeContextOverflowError } from "../daemon/parse-actual-tokens-from-error.js";
-import type { SubagentToolGateMode } from "../daemon/tool-setup-types.js";
+import type {
+  SubagentToolGateMode,
+  WakeToolContextPin,
+} from "../daemon/tool-setup-types.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import {
   broadcastWakeSurface,
@@ -210,6 +213,17 @@ export interface WakeOptions {
    * when `allowedTools` is absent.
    */
   toolGateMode?: SubagentToolGateMode;
+  /**
+   * Client-context pin applied (and restored) alongside `allowedTools` for
+   * the duration of the wake — see {@link WakeToolContextPin}. Pass only
+   * with `toolGateMode: "execution"`: it exists purely so the wire tool
+   * definitions resolve under the SOURCE conversation's client context
+   * (provider prompt-cache parity) and is pointless when the wire is
+   * allowlist-filtered anyway. Definition resolution only — pinned-in tools
+   * remain execution-rejected by the gate. Ignored when `allowedTools` is
+   * absent.
+   */
+  toolContextPin?: WakeToolContextPin;
   /**
    * Explicit persona/channel slugs for the wake's system-prompt build,
    * applied to the conversation for the duration of the run and restored
@@ -952,6 +966,7 @@ export async function wakeAgentForOpportunity(
           conversation,
           new Set(opts.allowedTools),
           opts.toolGateMode,
+          opts.toolContextPin,
         );
         return true;
       } catch (err) {


### PR DESCRIPTION
## Summary
Round-2 review fixes for memory-retrospective-fork-hardening:
- hasNoClient pin now mirrors the source's live-turn value (channel-routed sources run clientless) instead of being unconditionally false
- New wake tool-context pin: execution-gate-mode wakes resolve wire tool definitions under the source's client context, closing the tools-tier cache divergence for desktop sources; pinned-in tools remain execution-rejected
- Trimmed duplicated cache-parity rationale comments to {@link} references