### PR TITLE
refactor(daemon): drop producer-less WakeToolContextPin.channelCapabilities

### DIFF
--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -536,13 +536,12 @@ export function isToolActiveForContext(
   // Execution-gate-mode wakes pin the client-context inputs so the wire tool
   // surface matches the SOURCE conversation's live turns rather than the
   // fork's clientless hydration (see {@link WakeToolContextPin}). When the
-  // pin is present it replaces all three values — absent pin fields pin
-  // `undefined`, never falling through to live state.
+  // pin is present it replaces all three values — channel capabilities pin
+  // to `undefined` (see the pin's doc for why unset IS parity), never
+  // falling through to live state.
   const pin = ctx.toolContextPin;
   const hasNoClient = pin ? pin.hasNoClient : ctx.hasNoClient;
-  const channelCapabilities = pin
-    ? pin.channelCapabilities
-    : ctx.channelCapabilities;
+  const channelCapabilities = pin ? undefined : ctx.channelCapabilities;
   const transportInterface = pin
     ? pin.transportInterface
     : ctx.transportInterface;

--- a/assistant/src/daemon/tool-setup-types.ts
+++ b/assistant/src/daemon/tool-setup-types.ts
@@ -35,10 +35,13 @@ export type SubagentToolGateMode = "wire" | "execution";
  * transport interface, no channel capabilities), which drops client-gated
  * tools (`host_*`, `ui_*`, `app_open`, `request_system_permission`) from
  * the wire definitions and breaks the cache prefix anyway. When this pin is
- * set on the conversation, `isToolActiveForContext` reads `hasNoClient`,
- * `transportInterface`, and `channelCapabilities` exclusively from the pin
- * — an absent optional field pins the value to `undefined`; there is no
- * fall-through to the live conversation state.
+ * set on the conversation, `isToolActiveForContext` reads `hasNoClient` and
+ * `transportInterface` exclusively from the pin and treats channel
+ * capabilities as unset — an absent optional field pins the value to
+ * `undefined`; there is no fall-through to the live conversation state.
+ * (Interactive-interface turns never set channel capabilities, so unset IS
+ * parity for desktop/web sources; channel-routed sources resolve every tool
+ * gate identically under `hasNoClient: true` with or without them.)
  *
  * Tool-definition resolution ONLY. The executor callback and host-proxy
  * attachment paths never read the pin, so it cannot make a host tool
@@ -51,16 +54,6 @@ export interface WakeToolContextPin {
   hasNoClient: boolean;
   /** The interface the source's live turns ran on (e.g. `"macos"`). */
   transportInterface?: InterfaceId;
-  /**
-   * The source's live-turn channel capabilities. Interactive-interface
-   * (desktop/web HTTP) turns never set channel capabilities, so parity for
-   * those sources means leaving this unset.
-   */
-  channelCapabilities?: {
-    channel: string;
-    supportsDynamicUi: boolean;
-    clientOS?: string;
-  };
 }
 
 /**


### PR DESCRIPTION
## Summary
Final review-round fix for the memory-retrospective-fork-hardening plan: no producer ever set the pin's channelCapabilities field (unset IS parity for every source class, as its own docs argued), so the field is removed and the consumer pins channel capabilities to undefined directly. Replace-semantics and the execution-rejection invariant are unchanged.