### PR TITLE
feat(macos): local builds run the repo CLI source instead of installing from npm

### DIFF
--- a/apps/macos/electron.vite.config.ts
+++ b/apps/macos/electron.vite.config.ts
@@ -1,4 +1,5 @@
 import { execSync } from "node:child_process";
+import path from "node:path";
 
 import { defineConfig, externalizeDepsPlugin } from "electron-vite";
 
@@ -44,11 +45,20 @@ const resolveBuildSha = (): string => {
   }
 };
 
+// Local builds drive the repo CLI source directly instead of installing the
+// published package; release builds bake an empty path and keep the pinned
+// npm install (see getLocalCliEntry in src/main/cli-installer.ts).
+const LOCAL_CLI_ENTRY =
+  (process.env.VELLUM_ENVIRONMENT || "local") === "local"
+    ? path.resolve(__dirname, "../../cli/src/index.ts")
+    : "";
+
 const BUILD_DEFINES = {
   __VELLUM_BUILD_SHA__: JSON.stringify(resolveBuildSha()),
   __VELLUM_ENVIRONMENT__: JSON.stringify(
     process.env.VELLUM_ENVIRONMENT || "local",
   ),
+  __VELLUM_LOCAL_CLI_ENTRY__: JSON.stringify(LOCAL_CLI_ENTRY),
   __VELLUM_ENABLE_CHROME_DEVTOOLS__: JSON.stringify(
     process.env.VELLUM_ENABLE_CHROME_DEVTOOLS === "true" ||
       process.env.VELLUM_ENABLE_CHROME_DEVTOOLS === "1",

--- a/apps/macos/scripts/generate-cli-lockfile.sh
+++ b/apps/macos/scripts/generate-cli-lockfile.sh
@@ -16,6 +16,16 @@ if [ -z "$VERSION" ]; then
   exit 1
 fi
 
+# Local builds drive the repo CLI source directly (see getLocalCliEntry in
+# cli-installer.ts) and never install from npm. Ship an empty seed dir so
+# electron-builder's extraResources mapping still resolves.
+if [ "${VELLUM_ENVIRONMENT:-local}" = "local" ]; then
+  echo "Local build: skipping CLI lockfile (app runs the repo CLI source)"
+  rm -rf "$SEED_DIR"
+  mkdir -p "$SEED_DIR"
+  exit 0
+fi
+
 echo "Generating CLI lockfile for vellum@$VERSION ..."
 
 rm -rf "$SEED_DIR"

--- a/apps/macos/scripts/pack.sh
+++ b/apps/macos/scripts/pack.sh
@@ -63,6 +63,12 @@ esac
 
 cd "$APP_DIR"
 
+# Local builds run the repo CLI source at runtime (see getLocalCliEntry in
+# src/main/cli-installer.ts); install its deps so the checkout is runnable.
+if [ "$VELLUM_ENVIRONMENT" = "local" ]; then
+  (cd "$APP_DIR/../../cli" && bun install)
+fi
+
 bash scripts/fetch-bun.sh --arch "$BUN_ARCH"
 bash scripts/generate-icon.sh
 bash scripts/build-mac-helper.sh

--- a/apps/macos/src/main/cli-installer.ts
+++ b/apps/macos/src/main/cli-installer.ts
@@ -26,9 +26,16 @@ const LOCAL_CLI_ENTRY =
     ? __VELLUM_LOCAL_CLI_ENTRY__
     : "";
 
-/** Repo CLI entry for local builds, when the checkout still exists. */
+/**
+ * Repo CLI entry for local builds, when the checkout is actually runnable:
+ * the entry must exist and the CLI package's deps must be installed
+ * (cli/node_modules is a standalone install, not hoisted). Otherwise local
+ * builds fall back to the pinned install path.
+ */
 export function getLocalCliEntry(): string | null {
-  return LOCAL_CLI_ENTRY !== "" && existsSync(LOCAL_CLI_ENTRY)
+  if (LOCAL_CLI_ENTRY === "" || !existsSync(LOCAL_CLI_ENTRY)) return null;
+  const cliRoot = path.resolve(path.dirname(LOCAL_CLI_ENTRY), "..");
+  return existsSync(path.join(cliRoot, "node_modules"))
     ? LOCAL_CLI_ENTRY
     : null;
 }

--- a/apps/macos/src/main/cli-installer.ts
+++ b/apps/macos/src/main/cli-installer.ts
@@ -18,14 +18,37 @@ import log from "./logger";
 // Auto-stamped by create-release-branch workflow.
 export const PINNED_CLI_VERSION = "0.8.12";
 
+// Baked by electron.vite.config.ts: the repo CLI entry for local builds,
+// empty for release builds (and absent under bun test).
+declare const __VELLUM_LOCAL_CLI_ENTRY__: string;
+const LOCAL_CLI_ENTRY =
+  typeof __VELLUM_LOCAL_CLI_ENTRY__ === "string"
+    ? __VELLUM_LOCAL_CLI_ENTRY__
+    : "";
+
+/** Repo CLI entry for local builds, when the checkout still exists. */
+export function getLocalCliEntry(): string | null {
+  return LOCAL_CLI_ENTRY !== "" && existsSync(LOCAL_CLI_ENTRY)
+    ? LOCAL_CLI_ENTRY
+    : null;
+}
+
 /** Directory where the pinned CLI version is installed. */
 export function getCliInstallDir(): string {
   return path.join(app.getPath("userData"), "cli", PINNED_CLI_VERSION);
 }
 
-/** Absolute path to the installed `vellum` binary. */
+/**
+ * Absolute path of what the bundled bun should execute as the CLI: the repo
+ * source entry in local builds, otherwise the installed `vellum` binary.
+ * Everything downstream (invocation, locator, PATH wrapper) flows through
+ * this, so local builds never touch the npm install path.
+ */
 export function getCliBinPath(): string {
-  return path.join(getCliInstallDir(), "node_modules", ".bin", "vellum");
+  return (
+    getLocalCliEntry() ??
+    path.join(getCliInstallDir(), "node_modules", ".bin", "vellum")
+  );
 }
 
 /** Absolute path to the bun runtime bundled inside the app resources. */


### PR DESCRIPTION
## Problem

`bun run pack` / `pack:debug` resolved `vellum@PINNED_CLI_VERSION` from the live npm registry at build time. On main, the pin is stamped ahead of the npm publish by the release-branch workflow, so local packs fail with `No version matching "X" found` during the window between a release cut and its promotion (e.g. `0.8.12` pinned, only `0.8.12-staging.1` published).

## Change

Local builds (`VELLUM_ENVIRONMENT=local`, the `pack.sh` default) now drive the repo CLI source directly and never touch npm — matching what unpackaged dev mode already does via `resolveCliInvocation()`:

- **`electron.vite.config.ts`** bakes `__VELLUM_LOCAL_CLI_ENTRY__` (absolute path to `<repo>/cli/src/index.ts`) into the main bundle for local builds; release builds bake an empty string.
- **`cli-installer.ts`** adds `getLocalCliEntry()` and prefers it in `getCliBinPath()`. Since the in-app CLI invocation, the locator file, and the `~/.local/bin/vellum` PATH wrapper all flow through `getCliBinPath()`, every path runs the repo source via the bundled bun, and `ensureCliInstalled()` naturally no-ops (`isCliInstalled()` sees the entry). If the checkout is deleted, it degrades to the existing pinned-install path.
- **`generate-cli-lockfile.sh`** skips npm resolution for local builds and ships an empty seed dir.

Release builds are byte-for-byte unchanged: exact pin, frozen seed lockfile, `--ignore-scripts`.

## Verification

- `bunx tsc --noEmit` passes; `bun scripts/run-tests.ts` shows only the 5 `local-mode.test.ts` failures that also fail on clean main.
- `VELLUM_ENVIRONMENT=production bun run build` bakes no repo path.
- Full `pack:debug` succeeds with no npm resolution; the packaged `app.asar` contains the baked absolute CLI entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)