### PR TITLE
fix(ci): make upload-electron-updates actually run after successful Electron builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2901,14 +2901,8 @@ jobs:
           xcrun stapler validate "${{ steps.dmg.outputs.dmg_path }}"
           echo "Electron notarization ticket stapled and validated"
 
-      - name: Upload Electron DMG artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: ${{ matrix.artifact_name }}
-          path: apps/macos/dist/${{ matrix.dmg_name }}
-          if-no-files-found: error
-          retention-days: 7
-
+      # Update artifacts upload before the DMG so a DMG artifact never exists
+      # without its update feed (a DMG shipped without one strands auto-update).
       - name: Upload Electron update artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -2917,7 +2911,15 @@ jobs:
             apps/macos/dist/*-mac.yml
             apps/macos/dist/*.zip
             apps/macos/dist/*.zip.blockmap
-          if-no-files-found: warn
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload Electron DMG artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: apps/macos/dist/${{ matrix.dmg_name }}
+          if-no-files-found: error
           retention-days: 7
 
       - name: Cleanup keychain and keys
@@ -2944,23 +2946,35 @@ jobs:
       contents: read
       id-token: write
     steps:
+      # build-electron is continue-on-error, so a failed leg still reports
+      # result == 'success' to needs — its artifacts may simply not exist.
+      # Missing arches are skipped (Electron is non-blocking); an arch that is
+      # present but incomplete fails the job, which blocks the release gate.
       - name: Download arm64 update artifacts
+        continue-on-error: true
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: macos-electron-update-arm64
           path: electron-artifacts/arm64
 
       - name: Download x64 update artifacts
+        continue-on-error: true
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: macos-electron-update-x64
           path: electron-artifacts/x64
 
       - name: Validate update artifacts
+        id: validate
         run: |
-          MISSING=0
+          HAS_ARTIFACTS=false
           for ARCH in arm64 x64; do
             DIR="electron-artifacts/${ARCH}"
+            if [ ! -d "$DIR" ]; then
+              echo "::warning::No update artifacts for ${ARCH} (Electron build leg failed); skipping"
+              continue
+            fi
+            MISSING=0
             if [ ! -f "$(find "$DIR" -name '*-mac.yml' -type f 2>/dev/null | grep -m1 .)" ]; then
               echo "::error::Missing update manifest (*-mac.yml) for ${ARCH}"
               MISSING=1
@@ -2969,16 +2983,20 @@ jobs:
               echo "::error::Missing ZIP for ${ARCH}"
               MISSING=1
             fi
+            [ "$MISSING" -eq 0 ] || exit 1
+            HAS_ARTIFACTS=true
           done
-          [ "$MISSING" -eq 0 ] || exit 1
+          echo "has_artifacts=$HAS_ARTIFACTS" >> "$GITHUB_OUTPUT"
 
       - name: Authenticate to GCP
+        if: ${{ steps.validate.outputs.has_artifacts == 'true' }}
         uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
         with:
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
 
       - name: Upload Electron update artifacts to GCS
+        if: ${{ steps.validate.outputs.has_artifacts == 'true' }}
         run: |
           ENVIRONMENT=${{ needs.extract-version.outputs.is_staging == 'true' && 'staging' || 'production' }}
           BUCKET=${{ needs.extract-version.outputs.is_staging == 'true' && 'vellum-ai-staging-releases' || 'vellum-ai-prod-releases' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2934,7 +2934,9 @@ jobs:
 
   upload-electron-updates:
     needs: [extract-version, build-electron]
-    if: ${{ needs.build-electron.result == 'success' }}
+    # always() disables the implicit success(), which would always skip this
+    # job: one of build-electron's needs (publish-meta-prod/-staging) is skipped.
+    if: ${{ always() && !cancelled() && needs.build-electron.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: ${{ needs.extract-version.outputs.is_staging == 'true' && 'staging' || 'production' }}


### PR DESCRIPTION
## Summary

- `upload-electron-updates` has been skipped on **every** release run since it was added in #33993, so Electron auto-update artifacts (manifest + ZIP + blockmap) have never been published to GCS, and the Electron DMGs have never been attached to GitHub releases (those steps in the `release` job are gated on `upload-electron-updates.result == 'success'`).
- Root cause: the job's `if:` had no status-check function, so GitHub Actions applied the implicit `success()` — which evaluates false when **any transitive ancestor** in the `needs` chain was skipped, not just direct dependencies ([actions/runner#2205](https://github.com/actions/runner/issues/2205)). `build-electron` needs both `publish-meta-prod` and `publish-meta-staging`, and exactly one is always skipped (prod vs staging path), so the implicit `success()` was always false — the explicit `needs.build-electron.result == 'success'` check never mattered.
- Fix: add `always() && !cancelled()` to disable the implicit `success()`, matching the pattern `build-electron` and the other downstream jobs in this workflow already use. The explicit result check preserves the intended gating: skip when the Electron build fails (and the `release` gate from #34017 still accepts that skip).

## Original prompt

Investigated why the `upload-electron-updates` job was skipped in [release run 27444343507](https://github.com/vellum-ai/vellum-assistant/actions/runs/27444343507/job/81130728639) (v0.8.12 staging) even though both `build-electron` matrix legs succeeded. Found the job has never run in any release, silently masked by the skipped-allowance added in #34017. User asked for a PR fixing this for new releases going forward.