### PR TITLE
feat(web): render inline <thinking> tags in assistant text as thought-process blocks

### DIFF
--- a/apps/web/src/domains/chat/transcript/message-content.test.ts
+++ b/apps/web/src/domains/chat/transcript/message-content.test.ts
@@ -120,6 +120,53 @@ describe("groupContentBlocks", () => {
   test("empty blocks yield no groups", () => {
     expect(groupContentBlocks([])).toEqual([]);
   });
+
+  test("splitInlineThinking extracts <thinking> tags from text into activity groups", () => {
+    /**
+     * Models that emit reasoning as inline `<thinking>` text (rather than
+     * native thinking blocks) get the same thought-process rendering: the tag
+     * body becomes a thinking activity and the remaining text stays a text
+     * group, matching macOS's inline tag parsing.
+     */
+
+    // GIVEN a text block carrying an inline thinking tag plus a native run
+    const blocks: ConversationContentBlock[] = [
+      { type: "tool_use", toolCall: toolCall({ id: "call-a" }) },
+      { type: "text", text: "<thinking>weigh options</thinking>final answer" },
+    ];
+
+    // WHEN grouped with splitInlineThinking
+    // THEN the extracted thinking merges into the open activity run and the
+    // remaining text closes it
+    expect(groupContentBlocks(blocks, { splitInlineThinking: true })).toEqual([
+      {
+        type: "activity",
+        items: [
+          { type: "tool_use", toolCall: toolCall({ id: "call-a" }) },
+          {
+            type: "thinking",
+            thinking: "weigh options",
+            startedAt: undefined,
+            completedAt: undefined,
+          },
+        ],
+      },
+      { type: "text", text: "final answer" },
+    ]);
+  });
+
+  test("inline thinking tags pass through verbatim without splitInlineThinking", () => {
+    /**
+     * User messages must render typed tags verbatim, so the split is opt-in
+     * per message role at the call site.
+     */
+    const blocks: ConversationContentBlock[] = [
+      { type: "text", text: "<thinking>typed by a user</thinking>hi" },
+    ];
+    expect(groupContentBlocks(blocks)).toEqual([
+      { type: "text", text: "<thinking>typed by a user</thinking>hi" },
+    ]);
+  });
 });
 
 describe("isSubagentSpawnCall", () => {

--- a/apps/web/src/domains/chat/transcript/message-content.ts
+++ b/apps/web/src/domains/chat/transcript/message-content.ts
@@ -16,6 +16,10 @@ import type {
 
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { Surface } from "@/domains/chat/types/types";
+import {
+  containsInlineThinkingTag,
+  parseInlineThinkingTags,
+} from "@/domains/chat/utils/parse-inline-thinking";
 
 /**
  * One item inside a blocks-driven `activity` run, reusing the server block
@@ -57,6 +61,42 @@ function hasToolCallId(
   return typeof toolCall.id === "string" && toolCall.id.length > 0;
 }
 
+export interface GroupContentBlocksOptions {
+  /**
+   * Split inline `<thinking>`/`<think>` tags out of text blocks into
+   * synthesized thinking blocks before grouping, so tag-emitted reasoning
+   * renders through the same activity path as native thinking blocks
+   * (matching macOS). Pass for assistant messages only — user-typed tags must
+   * render verbatim.
+   */
+  splitInlineThinking?: boolean;
+}
+
+/**
+ * Expand text blocks containing inline `<thinking>`/`<think>` tags into
+ * interleaved thinking + text blocks. Returns the input array untouched when
+ * no text block carries a tag (the common case).
+ */
+function splitInlineThinkingBlocks(
+  blocks: ConversationContentBlock[],
+): ConversationContentBlock[] {
+  if (
+    !blocks.some((b) => b.type === "text" && containsInlineThinkingTag(b.text))
+  ) {
+    return blocks;
+  }
+  return blocks.flatMap((block): ConversationContentBlock[] => {
+    const segments =
+      block.type === "text" ? parseInlineThinkingTags(block.text) : null;
+    if (!segments) return [block];
+    return segments.map((seg) =>
+      seg.type === "thinking"
+        ? { type: "thinking", thinking: seg.thinking }
+        : { type: "text", text: seg.text },
+    );
+  });
+}
+
 /**
  * Group a message's unified `contentBlocks` into merged activity runs for the
  * render path. A contiguous run of `thinking` + `tool_use`
@@ -71,7 +111,12 @@ function hasToolCallId(
  */
 export function groupContentBlocks(
   blocks: ConversationContentBlock[],
+  options?: GroupContentBlocksOptions,
 ): ContentBlockGroup[] {
+  const walked = options?.splitInlineThinking
+    ? splitInlineThinkingBlocks(blocks)
+    : blocks;
+
   const groups: ContentBlockGroup[] = [];
   let current: { type: "activity"; items: ContentBlockActivityItem[] } | null =
     null;
@@ -84,7 +129,7 @@ export function groupContentBlocks(
     return current;
   };
 
-  for (const block of blocks) {
+  for (const block of walked) {
     if (block.type === "thinking") {
       const activity = openActivity();
       const lastItem = activity.items[activity.items.length - 1];

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -74,7 +74,10 @@ export function TranscriptMessageBody({
   const isUser = message.role === "user";
   const hasAttachments = Boolean(message.attachments?.length);
 
-  const groups = groupContentBlocks(message.contentBlocks ?? []);
+  // User-typed thinking tags must render verbatim; only assistant text splits.
+  const groups = groupContentBlocks(message.contentBlocks ?? [], {
+    splitInlineThinking: !isUser,
+  });
 
   const textBubbleClass = isSlackMessage
     ? "max-w-[80%] text-[var(--content-default)] sm:max-w-[640px]"

--- a/apps/web/src/domains/chat/utils/parse-inline-thinking.test.ts
+++ b/apps/web/src/domains/chat/utils/parse-inline-thinking.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  containsInlineThinkingTag,
+  parseInlineThinkingTags,
+} from "@/domains/chat/utils/parse-inline-thinking";
+
+describe("containsInlineThinkingTag", () => {
+  test("detects both tag formats and rejects plain text", () => {
+    expect(containsInlineThinkingTag("a <thinking>b</thinking>")).toBe(true);
+    expect(containsInlineThinkingTag("a <think>b</think>")).toBe(true);
+    expect(containsInlineThinkingTag("no tags here")).toBe(false);
+    // The `<think>` needle requires an immediate `>` so `<thinker>` is not a
+    // false positive.
+    expect(containsInlineThinkingTag("<thinker>nope</thinker>")).toBe(false);
+  });
+});
+
+describe("parseInlineThinkingTags", () => {
+  test("returns null when no tag is present", () => {
+    expect(parseInlineThinkingTags("just a normal reply")).toBeNull();
+  });
+
+  test("splits a closed tag into thinking and surrounding text", () => {
+    expect(
+      parseInlineThinkingTags("before <thinking> the plan </thinking> after"),
+    ).toEqual([
+      { type: "text", text: "before " },
+      { type: "thinking", thinking: "the plan" },
+      { type: "text", text: " after" },
+    ]);
+  });
+
+  test("treats an unclosed tag's remainder as still-streaming thinking", () => {
+    expect(parseInlineThinkingTags("<thinking>still figuring this out")).toEqual([
+      { type: "thinking", thinking: "still figuring this out" },
+    ]);
+  });
+
+  test("handles multiple blocks interleaved with text", () => {
+    expect(
+      parseInlineThinkingTags(
+        "<thinking>first</thinking>one<thinking>second</thinking>two",
+      ),
+    ).toEqual([
+      { type: "thinking", thinking: "first" },
+      { type: "text", text: "one" },
+      { type: "thinking", thinking: "second" },
+      { type: "text", text: "two" },
+    ]);
+  });
+
+  test("drops whitespace-only text between tags and empty thinking bodies", () => {
+    expect(
+      parseInlineThinkingTags("<thinking>a</thinking>\n\n<thinking>b</thinking>"),
+    ).toEqual([
+      { type: "thinking", thinking: "a" },
+      { type: "thinking", thinking: "b" },
+    ]);
+    expect(parseInlineThinkingTags("<thinking>  </thinking>ok")).toEqual([
+      { type: "text", text: "ok" },
+    ]);
+  });
+
+  test("supports the <think> variant alongside <thinking>", () => {
+    expect(
+      parseInlineThinkingTags("<think>short form</think>reply"),
+    ).toEqual([
+      { type: "thinking", thinking: "short form" },
+      { type: "text", text: "reply" },
+    ]);
+  });
+
+  test("a bare opening tag yields no segments", () => {
+    expect(parseInlineThinkingTags("<thinking>")).toEqual([]);
+  });
+});

--- a/apps/web/src/domains/chat/utils/parse-inline-thinking.ts
+++ b/apps/web/src/domains/chat/utils/parse-inline-thinking.ts
@@ -1,0 +1,69 @@
+export type InlineThinkingSegment =
+  | { type: "text"; text: string }
+  | { type: "thinking"; thinking: string };
+
+// <think>/</think> is MiniMax's format; <thinking>/</thinking> is the
+// standard format. `<thinking>` never matches the `<think>` needle because
+// the needle requires an immediate `>`.
+const TAG_PAIRS = [
+  { open: "<thinking>", close: "</thinking>" },
+  { open: "<think>", close: "</think>" },
+] as const;
+
+export function containsInlineThinkingTag(text: string): boolean {
+  return TAG_PAIRS.some((pair) => text.includes(pair.open));
+}
+
+/**
+ * Splits assistant text containing inline `<thinking>`/`<think>` reasoning
+ * tags (emitted by models that surface reasoning as plain text rather than
+ * native thinking blocks) into ordered text / thinking segments. Mirrors the
+ * macOS client's `InlineThinkingTagParser` so both clients chunk identically:
+ * thinking bodies are trimmed, whitespace-only text segments are dropped, and
+ * an unclosed tag treats the remainder as still-streaming thinking. Returns
+ * `null` when no tag is present so callers can skip the overhead.
+ */
+export function parseInlineThinkingTags(
+  text: string,
+): InlineThinkingSegment[] | null {
+  if (!containsInlineThinkingTag(text)) return null;
+
+  const segments: InlineThinkingSegment[] = [];
+  const pushText = (chunk: string) => {
+    if (chunk.trim()) segments.push({ type: "text", text: chunk });
+  };
+  const pushThinking = (chunk: string) => {
+    const trimmed = chunk.trim();
+    if (trimmed) segments.push({ type: "thinking", thinking: trimmed });
+  };
+
+  let cursor = 0;
+  for (;;) {
+    // Find the earliest opening tag of either type from the cursor.
+    let openIndex = -1;
+    let pair: (typeof TAG_PAIRS)[number] | undefined;
+    for (const candidate of TAG_PAIRS) {
+      const index = text.indexOf(candidate.open, cursor);
+      if (index !== -1 && (openIndex === -1 || index < openIndex)) {
+        openIndex = index;
+        pair = candidate;
+      }
+    }
+    if (!pair) break;
+
+    pushText(text.slice(cursor, openIndex));
+
+    const bodyStart = openIndex + pair.open.length;
+    const closeIndex = text.indexOf(pair.close, bodyStart);
+    if (closeIndex === -1) {
+      // Unclosed tag: the rest of the text is still-streaming thinking.
+      pushThinking(text.slice(bodyStart));
+      return segments;
+    }
+    pushThinking(text.slice(bodyStart, closeIndex));
+    cursor = closeIndex + pair.close.length;
+  }
+
+  pushText(text.slice(cursor));
+  return segments;
+}


### PR DESCRIPTION
## Summary
- Add `parseInlineThinkingTags()` mirroring the macOS client's `InlineThinkingTagParser`: splits assistant text on `<thinking>`/`</thinking>` (and MiniMax's `<think>`) into ordered text/thinking segments — thinking bodies trimmed, whitespace-only text dropped, and an unclosed tag's remainder treated as still-streaming thinking.
- `groupContentBlocks()` gains an opt-in `splitInlineThinking` option that expands tagged text blocks into synthesized thinking + text blocks, so tag-emitted reasoning flows through the existing activity grouping and renders as the standard Thought process link/drawer — including the streaming Thinking indicator while the tag is unclosed.
- The transcript render body enables the split for assistant messages only; user-typed tags still render verbatim. Covered by parser unit tests and grouping integration tests.

## Original prompt
The Electron desktop app (which wraps `apps/web`) should render text inside `<thinking></thinking>` blocks as a thinking block, matching the Swift macOS app's existing behavior. Models that emit reasoning as inline tagged text rather than native thinking blocks should get the same collapsed thought-process treatment in the web/Electron transcript instead of showing raw tags.