### PR TITLE
fix(auth): offline boot/resume no longer discards a valid session (LUM-2412)

### DIFF
--- a/apps/web/src/lib/auth/user-snapshot.ts
+++ b/apps/web/src/lib/auth/user-snapshot.ts
@@ -1,0 +1,53 @@
+/**
+ * Last-known authenticated platform user, persisted so an offline boot
+ * can restore the session optimistically instead of bouncing a
+ * still-logged-in user to the login screen (LUM-2412).
+ *
+ * The key uses the `vellum:` user-scoped prefix, so logout's
+ * `clearUserScopedStorage` sweep (and the cross-tab logout broadcast)
+ * removes it automatically; the auth store also clears it explicitly
+ * whenever a session check comes back with a settled "no session"
+ * answer, so a revoked session can't be resurrected by a later
+ * offline boot.
+ */
+import type { AuthUser } from "@/stores/auth-store";
+
+const SNAPSHOT_KEY = "vellum:auth:userSnapshot";
+
+export function persistUserSnapshot(user: AuthUser | null): void {
+  if (!user) return;
+  try {
+    localStorage.setItem(SNAPSHOT_KEY, JSON.stringify(user));
+  } catch {
+    // Storage unavailable — offline restore just won't have a snapshot.
+  }
+}
+
+export function readUserSnapshot(): AuthUser | null {
+  try {
+    const raw = localStorage.getItem(SNAPSHOT_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<AuthUser> | null;
+    if (!parsed || typeof parsed !== "object") return null;
+    // Field-by-field coercion so a malformed or stale-schema snapshot
+    // degrades to safe defaults instead of poisoning the auth state.
+    return {
+      id: typeof parsed.id === "string" ? parsed.id : null,
+      username: typeof parsed.username === "string" ? parsed.username : null,
+      email: typeof parsed.email === "string" ? parsed.email : null,
+      isStaff: parsed.isStaff === true,
+      firstName: typeof parsed.firstName === "string" ? parsed.firstName : "",
+      lastName: typeof parsed.lastName === "string" ? parsed.lastName : "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function clearUserSnapshot(): void {
+  try {
+    localStorage.removeItem(SNAPSHOT_KEY);
+  } catch {
+    // Storage unavailable.
+  }
+}

--- a/apps/web/src/stores/auth-store.test.ts
+++ b/apps/web/src/stores/auth-store.test.ts
@@ -11,7 +11,7 @@ let getSessionCallCount = 0;
 let getSessionFailFirstCall = false;
 // Transport-failure controls: `getSessionThrows` simulates a fetch
 // rejection; `getSessionFailStatus` sets the status of the !sessionUser
-// failure result (401 = settled "no session", 502 = proxy network 502).
+// failure result (401 = settled "no session"; 429/502 = non-authoritative).
 let getSessionThrows = false;
 let getSessionFailStatus: number | undefined = 401;
 // When set to an array, each `getSession` call blocks until its release fn
@@ -676,6 +676,31 @@ describe("offline session restore (LUM-2412)", () => {
 
     expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
     expect(useAuthStore.getState().user?.id).toBe("user-cached");
+  });
+
+  test("rate-limited boot (429) is non-authoritative — restores from cache instead of logging out", async () => {
+    getSessionFailStatus = 429;
+    mockElectronSessionToken = "tok-1";
+    seedSnapshot();
+
+    await useAuthStore.getState().initSession();
+
+    expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
+    expect(useAuthStore.getState().user?.id).toBe("user-cached");
+    expect(localStorage.getItem(SNAPSHOT_KEY)).not.toBeNull();
+  });
+
+  test("rate-limited refresh (429) keeps the authenticated session", async () => {
+    sessionUser = { id: "user-9", username: "nine", email: "nine@example.com" };
+    await useAuthStore.getState().initSession();
+    expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
+
+    sessionUser = null;
+    getSessionFailStatus = 429;
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
+
+    expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
+    expect(localStorage.getItem(SNAPSHOT_KEY)).not.toBeNull();
   });
 
   test("transport-failed boot without a local credential stays unauthenticated (web behavior)", async () => {

--- a/apps/web/src/stores/auth-store.test.ts
+++ b/apps/web/src/stores/auth-store.test.ts
@@ -9,6 +9,11 @@ type MockSessionUser = {
 let sessionUser: MockSessionUser | null = null;
 let getSessionCallCount = 0;
 let getSessionFailFirstCall = false;
+// Transport-failure controls: `getSessionThrows` simulates a fetch
+// rejection; `getSessionFailStatus` sets the status of the !sessionUser
+// failure result (401 = settled "no session", 502 = proxy network 502).
+let getSessionThrows = false;
+let getSessionFailStatus: number | undefined = 401;
 // When set to an array, each `getSession` call blocks until its release fn
 // (pushed here in call order) is invoked, so a test can hold one or more
 // probes in flight and settle them in a chosen order.
@@ -66,15 +71,25 @@ mock.module("@/lib/auth/allauth-client", () => ({
         getSessionGates!.push(resolve);
       });
     }
+    if (getSessionThrows) {
+      throw new TypeError("Failed to fetch");
+    }
     if (getSessionFailFirstCall && getSessionCallCount === 1) {
       return { ok: false, status: 401, error: { detail: "Unauthorized" } };
     }
     if (!sessionUser) {
-      return { ok: false, status: 401, error: { detail: "Unauthorized" } };
+      return { ok: false, status: getSessionFailStatus, error: { detail: "Unauthorized" } };
     }
     return { ok: true, data: { user: sessionUser } };
   },
   logout: logoutMock,
+}));
+
+let mockElectronSessionToken: string | null = null;
+mock.module("@/runtime/session-token", () => ({
+  getElectronSessionToken: () => mockElectronSessionToken,
+  primeElectronSessionToken: () => {},
+  __resetForTesting: () => {},
 }));
 
 mock.module("@/lib/auth/gateway-session", () => ({
@@ -205,7 +220,11 @@ beforeEach(() => {
   sessionUser = null;
   getSessionCallCount = 0;
   getSessionFailFirstCall = false;
+  getSessionThrows = false;
+  getSessionFailStatus = 401;
   getSessionGates = null;
+  mockElectronSessionToken = null;
+  localStorage.removeItem("vellum:auth:userSnapshot");
   mockIsGatewayAuth = false;
   mockIsLocalMode = false;
   mockPlatformAssistants = [];
@@ -602,5 +621,165 @@ describe("connectLocalAssistant", () => {
     // A failed connect leaves the previous selection in place.
     expect(setSelectedAssistantMock).not.toHaveBeenCalled();
     expect(useAuthStore.getState().sessionStatus).not.toBe("authenticated");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Offline session restore (LUM-2412)
+//
+// A transport-failed session probe (offline boot, tray reopen before
+// Wi-Fi reassociates, platform outage) says nothing about the session.
+// With a local credential (Electron session token) and a persisted user
+// snapshot, the store settles authenticated instead of bouncing a
+// logged-in user to the login screen. Only a settled "no session"
+// answer (401, or 2xx without user) ends the session — and it also
+// invalidates the snapshot so a revoked session can't be resurrected.
+// ---------------------------------------------------------------------------
+
+const SNAPSHOT_KEY = "vellum:auth:userSnapshot";
+
+function seedSnapshot(): void {
+  localStorage.setItem(
+    SNAPSHOT_KEY,
+    JSON.stringify({
+      id: "user-cached",
+      username: "cached",
+      email: "cached@example.com",
+      isStaff: false,
+      firstName: "Cached",
+      lastName: "User",
+    }),
+  );
+}
+
+describe("offline session restore (LUM-2412)", () => {
+  test("transport-failed boot (thrown fetch) with token + snapshot settles authenticated from cache", async () => {
+    getSessionThrows = true;
+    mockElectronSessionToken = "tok-1";
+    seedSnapshot();
+
+    await useAuthStore.getState().initSession();
+
+    expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
+    expect(useAuthStore.getState().user?.id).toBe("user-cached");
+    // Believed, not confirmed — platformSession stays unsettled until a
+    // real probe answers.
+    expect(useAuthStore.getState().platformSession).toBe("unknown");
+  });
+
+  test("transport-failed boot (proxy 502) with token + snapshot settles authenticated from cache", async () => {
+    getSessionFailStatus = 502;
+    mockElectronSessionToken = "tok-1";
+    seedSnapshot();
+
+    await useAuthStore.getState().initSession();
+
+    expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
+    expect(useAuthStore.getState().user?.id).toBe("user-cached");
+  });
+
+  test("transport-failed boot without a local credential stays unauthenticated (web behavior)", async () => {
+    getSessionThrows = true;
+    mockElectronSessionToken = null;
+    seedSnapshot();
+
+    await useAuthStore.getState().initSession();
+
+    expect(useAuthStore.getState().sessionStatus).toBe("unauthenticated");
+    // Transport failure must not invalidate the snapshot.
+    expect(localStorage.getItem(SNAPSHOT_KEY)).not.toBeNull();
+  });
+
+  test("transport-failed boot with token but no snapshot stays unauthenticated", async () => {
+    getSessionThrows = true;
+    mockElectronSessionToken = "tok-1";
+
+    await useAuthStore.getState().initSession();
+
+    expect(useAuthStore.getState().sessionStatus).toBe("unauthenticated");
+  });
+
+  test("settled 401 boot stays unauthenticated and invalidates the snapshot", async () => {
+    getSessionFailStatus = 401;
+    mockElectronSessionToken = "tok-1";
+    seedSnapshot();
+
+    await useAuthStore.getState().initSession();
+
+    expect(useAuthStore.getState().sessionStatus).toBe("unauthenticated");
+    expect(localStorage.getItem(SNAPSHOT_KEY)).toBeNull();
+  });
+
+  test("successful boot persists the snapshot for later offline restores", async () => {
+    sessionUser = { id: "user-9", username: "nine", email: "nine@example.com" };
+
+    await useAuthStore.getState().initSession();
+
+    const raw = localStorage.getItem(SNAPSHOT_KEY);
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw!)).toMatchObject({ id: "user-9", email: "nine@example.com" });
+  });
+
+  test("local-mode platform-assistants boot also restores from cache on transport failure", async () => {
+    mockIsLocalMode = true;
+    mockPlatformAssistants = [{ assistantId: "p1", cloud: "vellum" }];
+    getSessionThrows = true;
+    mockElectronSessionToken = "tok-1";
+    seedSnapshot();
+
+    await useAuthStore.getState().initSession();
+
+    expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
+    expect(useAuthStore.getState().user?.id).toBe("user-cached");
+  });
+
+  test("refreshSession transport failure keeps the authenticated session (offline resume)", async () => {
+    // Boot online…
+    sessionUser = { id: "user-9", username: "nine", email: "nine@example.com" };
+    await useAuthStore.getState().initSession();
+    expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
+
+    // …then the resume-driven refresh fires while offline.
+    getSessionThrows = true;
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
+
+    expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
+    expect(useAuthStore.getState().user?.id).toBe("user-9");
+  });
+
+  test("refreshSession transport failure while unauthenticated reports false without state churn", async () => {
+    getSessionThrows = true;
+    useAuthStore.setState({ sessionStatus: "unauthenticated", user: null });
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(false);
+
+    expect(useAuthStore.getState().sessionStatus).toBe("unauthenticated");
+  });
+
+  test("refreshSession settled 401 ends the session and invalidates the snapshot (reconnect revalidation)", async () => {
+    // Boot from cache while offline…
+    getSessionThrows = true;
+    mockElectronSessionToken = "tok-1";
+    seedSnapshot();
+    await useAuthStore.getState().initSession();
+    expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
+
+    // …network returns, the platform says the session was revoked.
+    getSessionThrows = false;
+    getSessionFailStatus = 401;
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(false);
+
+    expect(useAuthStore.getState().sessionStatus).toBe("unauthenticated");
+    expect(localStorage.getItem(SNAPSHOT_KEY)).toBeNull();
+  });
+
+  test("a corrupt snapshot is ignored — transport-failed boot stays unauthenticated", async () => {
+    getSessionThrows = true;
+    mockElectronSessionToken = "tok-1";
+    localStorage.setItem(SNAPSHOT_KEY, "{not json");
+
+    await useAuthStore.getState().initSession();
+
+    expect(useAuthStore.getState().sessionStatus).toBe("unauthenticated");
   });
 });

--- a/apps/web/src/stores/auth-store.test.ts
+++ b/apps/web/src/stores/auth-store.test.ts
@@ -662,9 +662,10 @@ describe("offline session restore (LUM-2412)", () => {
 
     expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
     expect(useAuthStore.getState().user?.id).toBe("user-cached");
-    // Believed, not confirmed — platformSession stays unsettled until a
-    // real probe answers.
-    expect(useAuthStore.getState().platformSession).toBe("unknown");
+    // The snapshot only exists for a confirmed platform session, and no
+    // probe runs offline to settle an "unknown" — so the restore settles
+    // "present" (believed state); reconnect revalidation corrects it.
+    expect(useAuthStore.getState().platformSession).toBe("present");
   });
 
   test("transport-failed boot (proxy 502) with token + snapshot settles authenticated from cache", async () => {

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -19,6 +19,7 @@ import { createSelectors } from "@/utils/create-selectors";
 import {
   isAuthenticated,
   isSessionSettled,
+  isTransportFailure,
   hasLivePlatformSession,
   type PlatformSessionStatus,
   type SessionStatus,
@@ -28,6 +29,12 @@ import {
   getSession,
   logout as allauthLogout,
 } from "@/lib/auth/allauth-client";
+import {
+  clearUserSnapshot,
+  persistUserSnapshot,
+  readUserSnapshot,
+} from "@/lib/auth/user-snapshot";
+import { getElectronSessionToken } from "@/runtime/session-token";
 import {
   isGatewayAuthEnabled,
   isGatewayAuthMode,
@@ -136,11 +143,18 @@ const GATEWAY_LOCAL_USER: AuthUser = {
  * `platformSession` is left untouched by transitions that don't know it yet
  * (a follow-up probe settles it); transitions that do know it set it inline.
  */
-const authenticatedPlatformUser = (user: AuthUser | null): Partial<AuthState> => ({
-  sessionStatus: "authenticated",
-  user,
-  platformSession: "present",
-});
+const authenticatedPlatformUser = (user: AuthUser | null): Partial<AuthState> => {
+  // Entering this state is the one place a platform session is freshly
+  // confirmed — persist the snapshot here so every confirmation path
+  // (boot, refresh, connect, biometric retry) feeds the offline restore
+  // (LUM-2412) without each call site remembering to.
+  persistUserSnapshot(user);
+  return {
+    sessionStatus: "authenticated",
+    user,
+    platformSession: "present",
+  };
+};
 
 const authenticatedLocalUser = (): Partial<AuthState> => ({
   sessionStatus: "authenticated",
@@ -152,6 +166,42 @@ const sessionEnded = (): Partial<AuthState> => ({
   user: null,
   platformSession: "absent",
 });
+
+/**
+ * A `getSession()` outcome that says nothing about the session itself —
+ * the request threw (fetch rejection) or failed at the transport layer
+ * (no response / 5xx, including the Electron proxy's offline 502).
+ * Distinct from a settled "no session" answer (2xx without user,
+ * 401/403), which is the only thing allowed to end the session.
+ */
+const isTransportFailedProbe = (
+  result: Awaited<ReturnType<typeof getSession>> | null,
+): boolean => result === null || isTransportFailure(result);
+
+/**
+ * Settle the session from the persisted user snapshot after a
+ * transport-failed boot probe (offline launch, tray reopen before Wi-Fi
+ * reassociates — LUM-2412). Requires a local credential: the Electron
+ * session token lives in the main process, so its presence means the
+ * user never signed out — the probe merely couldn't reach the platform.
+ * Web builds have no readable credential (cookie sessions), so they
+ * keep the conservative login-screen behavior.
+ *
+ * `platformSession` is deliberately left untouched: the session is
+ * believed, not confirmed. The app-resume/online refresh revalidates
+ * once the network returns; a settled "no session" answer there ends
+ * the session (and drops the snapshot) through the normal path.
+ */
+async function restoreOfflineSession(set: AuthSet): Promise<boolean> {
+  if (!getElectronSessionToken()) return false;
+  const cached = readUserSnapshot();
+  if (!cached) return false;
+  // Consent/org sync falls back to device-cached keys when the server
+  // fetch fails (it will, offline) — same continuity as an online boot.
+  await syncUserScopedState(cached.id);
+  set({ sessionStatus: "authenticated", user: cached });
+  return true;
+}
 
 function syncOrganizationState(nextUserId: string | null): void {
   if (!nextUserId || (previousUserId && previousUserId !== nextUserId)) {
@@ -257,9 +307,12 @@ function probePlatformSession(
     .then(async (result) => {
       if (isStale()) return;
       if (result.ok && result.data.user) {
-        const userUpdate = options.setUserOnSuccess
-          ? { user: toAuthUser(result.data.user) }
-          : {};
+        const probedUser = toAuthUser(result.data.user);
+        const userUpdate = options.setUserOnSuccess ? { user: probedUser } : {};
+        // Adopting the probed user confirms a platform session outside the
+        // `authenticatedPlatformUser` transition — persist here too so the
+        // local-mode path feeds the offline restore (LUM-2412).
+        if (options.setUserOnSuccess) persistUserSnapshot(probedUser);
         // Sync platform assistants to the lockfile BEFORE setting
         // platformSession to "present". The auth middleware unblocks on
         // `platformSession !== "unknown"`, and hasAssistants() must
@@ -366,7 +419,7 @@ function probePlatformSessionIfReachable(
   }
 }
 
-const useAuthStoreBase = create<AuthStore>()((set) => ({
+const useAuthStoreBase = create<AuthStore>()((set, get) => ({
   sessionStatus: "initializing",
   user: null,
   platformSession: "unknown",
@@ -390,8 +443,9 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
       if (hasPlatformAssistants) {
         // Platform assistants require a valid session — await the check
         // so the auth middleware can redirect to login if it fails.
+        let result: Awaited<ReturnType<typeof getSession>> | null = null;
         try {
-          const result = await getSession();
+          result = await getSession();
           if (result.ok && result.data.user) {
             const user = toAuthUser(result.data.user);
             await syncUserScopedState(user?.id ?? null);
@@ -412,7 +466,15 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
             return;
           }
         } catch {
-          // Session check failed — fall through to unauthenticated
+          // Thrown fetch — classified as a transport failure below.
+        }
+        // Offline boot with a still-valid local credential must not bounce
+        // to the login screen (LUM-2412); only a settled "no session"
+        // answer ends the session (and invalidates the snapshot).
+        if (isTransportFailedProbe(result)) {
+          if (await restoreOfflineSession(set)) return;
+        } else {
+          clearUserSnapshot();
         }
         set(sessionEnded());
         return;
@@ -427,8 +489,9 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
       return;
     }
 
+    let result: Awaited<ReturnType<typeof getSession>> | null = null;
     try {
-      const result = await getSession();
+      result = await getSession();
       if (result.ok && result.data.user) {
         const user = toAuthUser(result.data.user);
         await syncUserScopedState(user?.id ?? null);
@@ -444,6 +507,14 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
       }
     } catch (err) {
       console.error("auth.initSession failed", err);
+    }
+
+    // Offline boot (tray reopen recreating the window, app launch before
+    // Wi-Fi reassociates): a transport-failed probe says nothing about
+    // the session, so restore it from the snapshot instead of bouncing a
+    // logged-in user to the login screen (LUM-2412).
+    if (isTransportFailedProbe(result) && (await restoreOfflineSession(set))) {
+      return;
     }
 
     // Biometric recovery: on iOS, the session cookie may have been lost
@@ -475,6 +546,11 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
     }
 
     await syncUserScopedState(null);
+    // Only a settled "no session" answer invalidates the snapshot — a
+    // revoked session must not be resurrected by a later offline boot.
+    // Transport failures keep it (web builds land here too; without a
+    // readable credential they stay on the login-screen behavior).
+    if (!isTransportFailedProbe(result)) clearUserSnapshot();
     set(sessionEnded());
   },
 
@@ -543,8 +619,9 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
       return true;
     }
 
+    let result: Awaited<ReturnType<typeof getSession>> | null = null;
     try {
-      const result = await getSession();
+      result = await getSession();
       if (result.ok && result.data.user) {
         const user = toAuthUser(result.data.user);
         await syncUserScopedState(user?.id ?? null);
@@ -574,6 +651,15 @@ const useAuthStoreBase = create<AuthStore>()((set) => ({
     } catch (err) {
       console.warn("auth.refreshSession failed", err);
     }
+    // Offline resume (un-minimizing fires visibilitychange → app.resume →
+    // this refresh): a transport-failed probe must not tear a logged-in
+    // surface down to the login screen (LUM-2412). Keep the current state;
+    // the next resume/online refresh revalidates for real, and a settled
+    // "no session" answer below still ends the session normally.
+    if (isTransportFailedProbe(result)) {
+      return isAuthenticated(get().sessionStatus);
+    }
+    clearUserSnapshot();
     await syncUserScopedState(null);
     set(sessionEnded());
     return false;

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -191,10 +191,16 @@ const isInconclusiveProbe = (
  * Web builds have no readable credential (cookie sessions), so they
  * keep the conservative login-screen behavior.
  *
- * `platformSession` is deliberately left untouched: the session is
- * believed, not confirmed. The app-resume/online refresh revalidates
- * once the network returns; a settled "no session" answer there ends
- * the session (and drops the snapshot) through the normal path.
+ * Restores through the full `authenticatedPlatformUser` transition —
+ * including `platformSession: "present"` — rather than leaving the
+ * tri-state `"unknown"`: the snapshot is only ever written when a
+ * platform session was confirmed, and no probe runs offline to settle
+ * an `"unknown"`, so consumers gated on it (the auth middleware's
+ * no-assistant wait, the onboarding fork) would stall against their
+ * timeouts. "Present" is the believed state; the app-resume/online
+ * refresh revalidates once the network returns, and a settled "no
+ * session" answer there ends the session (and drops the snapshot)
+ * through the normal path.
  */
 async function restoreOfflineSession(set: AuthSet): Promise<boolean> {
   if (!getElectronSessionToken()) return false;
@@ -203,7 +209,7 @@ async function restoreOfflineSession(set: AuthSet): Promise<boolean> {
   // Consent/org sync falls back to device-cached keys when the server
   // fetch fails (it will, offline) — same continuity as an online boot.
   await syncUserScopedState(cached.id);
-  set({ sessionStatus: "authenticated", user: cached });
+  set(authenticatedPlatformUser(cached));
   return true;
 }
 

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -19,7 +19,7 @@ import { createSelectors } from "@/utils/create-selectors";
 import {
   isAuthenticated,
   isSessionSettled,
-  isTransportFailure,
+  isSettledSessionRejection,
   hasLivePlatformSession,
   type PlatformSessionStatus,
   type SessionStatus,
@@ -169,14 +169,18 @@ const sessionEnded = (): Partial<AuthState> => ({
 
 /**
  * A `getSession()` outcome that says nothing about the session itself —
- * the request threw (fetch rejection) or failed at the transport layer
- * (no response / 5xx, including the Electron proxy's offline 502).
- * Distinct from a settled "no session" answer (2xx without user,
- * 401/403), which is the only thing allowed to end the session.
+ * the request threw (fetch rejection), never completed, or failed for a
+ * non-auth reason (429 rate limiting, 5xx outages, the Electron proxy's
+ * offline 502). Distinct from a settled "no session" answer (2xx without
+ * user, or an explicit 401/403/410 rejection), which is the only thing
+ * allowed to end the session. Callers check the 2xx-without-user case
+ * themselves — by the time they consult this, `result.ok` means the user
+ * field was missing, a settled negative.
  */
-const isTransportFailedProbe = (
+const isInconclusiveProbe = (
   result: Awaited<ReturnType<typeof getSession>> | null,
-): boolean => result === null || isTransportFailure(result);
+): boolean =>
+  result === null || (!result.ok && !isSettledSessionRejection(result));
 
 /**
  * Settle the session from the persisted user snapshot after a
@@ -471,7 +475,7 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
         // Offline boot with a still-valid local credential must not bounce
         // to the login screen (LUM-2412); only a settled "no session"
         // answer ends the session (and invalidates the snapshot).
-        if (isTransportFailedProbe(result)) {
+        if (isInconclusiveProbe(result)) {
           if (await restoreOfflineSession(set)) return;
         } else {
           clearUserSnapshot();
@@ -513,7 +517,7 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
     // Wi-Fi reassociates): a transport-failed probe says nothing about
     // the session, so restore it from the snapshot instead of bouncing a
     // logged-in user to the login screen (LUM-2412).
-    if (isTransportFailedProbe(result) && (await restoreOfflineSession(set))) {
+    if (isInconclusiveProbe(result) && (await restoreOfflineSession(set))) {
       return;
     }
 
@@ -550,7 +554,7 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
     // revoked session must not be resurrected by a later offline boot.
     // Transport failures keep it (web builds land here too; without a
     // readable credential they stay on the login-screen behavior).
-    if (!isTransportFailedProbe(result)) clearUserSnapshot();
+    if (!isInconclusiveProbe(result)) clearUserSnapshot();
     set(sessionEnded());
   },
 
@@ -656,7 +660,7 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
     // surface down to the login screen (LUM-2412). Keep the current state;
     // the next resume/online refresh revalidates for real, and a settled
     // "no session" answer below still ends the session normally.
-    if (isTransportFailedProbe(result)) {
+    if (isInconclusiveProbe(result)) {
       return isAuthenticated(get().sessionStatus);
     }
     clearUserSnapshot();

--- a/apps/web/src/stores/session-status.ts
+++ b/apps/web/src/stores/session-status.ts
@@ -67,20 +67,29 @@ export const hasLivePlatformSession = (
 ): boolean => status === "present";
 
 /**
- * Transport-shaped failure of a session check: the request never produced
- * a settled server answer about the session. `status` undefined means the
- * request never completed; 5xx covers the Electron platform proxy's
- * synthesized 502 (`proxy_network_error` — see
- * `apps/macos/src/main/platform-forward.ts`) and genuine gateway/outage
- * errors. None of these say anything about the session itself, so callers
- * must not treat them as "signed out" (LUM-2412). A session check that
- * throws outright (fetch rejection) is classified the same way by callers.
+ * Statuses where the server itself said "no session": allauth's 401 for
+ * an unauthenticated probe, a 403, or 410 Gone (session invalidated).
+ */
+const SETTLED_SESSION_REJECTION_STATUSES = new Set([401, 403, 410]);
+
+/**
+ * A settled negative answer from a session check — the only failures
+ * allowed to end the session. Everything else that isn't ok says nothing
+ * about the session and must be treated as non-authoritative (LUM-2412):
+ * a request that never completed (`status` undefined), rate limiting
+ * (429), and gateway/outage 5xx including the Electron platform proxy's
+ * synthesized offline 502 (`proxy_network_error` — see
+ * `apps/macos/src/main/platform-forward.ts`). A session check that
+ * throws outright (fetch rejection) is classified the same way by
+ * callers.
  *
  * Structural parameter type (not `AllauthResult`) keeps this module
  * dependency-free per the header note.
  */
-export const isTransportFailure = (result: {
+export const isSettledSessionRejection = (result: {
   ok: boolean;
   status?: number;
 }): boolean =>
-  !result.ok && (result.status === undefined || result.status >= 500);
+  !result.ok &&
+  result.status !== undefined &&
+  SETTLED_SESSION_REJECTION_STATUSES.has(result.status);

--- a/apps/web/src/stores/session-status.ts
+++ b/apps/web/src/stores/session-status.ts
@@ -65,3 +65,22 @@ export const isSessionSettled = (status: SessionStatus): boolean =>
 export const hasLivePlatformSession = (
   status: PlatformSessionStatus,
 ): boolean => status === "present";
+
+/**
+ * Transport-shaped failure of a session check: the request never produced
+ * a settled server answer about the session. `status` undefined means the
+ * request never completed; 5xx covers the Electron platform proxy's
+ * synthesized 502 (`proxy_network_error` — see
+ * `apps/macos/src/main/platform-forward.ts`) and genuine gateway/outage
+ * errors. None of these say anything about the session itself, so callers
+ * must not treat them as "signed out" (LUM-2412). A session check that
+ * throws outright (fetch rejection) is classified the same way by callers.
+ *
+ * Structural parameter type (not `AllauthResult`) keeps this module
+ * dependency-free per the header note.
+ */
+export const isTransportFailure = (result: {
+  ok: boolean;
+  status?: number;
+}): boolean =>
+  !result.ok && (result.status === undefined || result.status >= 500);


### PR DESCRIPTION
## Summary
- **Failure classification**: `initSession` and `refreshSession` now distinguish a settled "no session" answer (2xx without user, 401/403) from a transport-shaped failure (thrown fetch, no response, 5xx including the Electron proxy's offline 502). Only the former ends the session; the new `isTransportFailure` predicate lives in the dependency-free `session-status.ts`. The resume-driven `refreshSession` (visibilitychange/online → `app.resume`) previously logged the user out on any offline blip — that was the literal repro: un-minimizing the window while offline showed the login screen.
- **Optimistic offline restore**: every confirmed platform session persists a minimal user snapshot (`vellum:auth:userSnapshot`, auto-swept by logout's `clearUserScopedStorage`). A transport-failed boot with the Electron session token still present restores from the snapshot and opens straight into the chat, where the LUM-2402 reconnecting UX takes over. `platformSession` stays "unknown" (believed, not confirmed) until a real probe settles it.
- **Reconnect revalidation**: the existing `app.resume`/online → `refreshSession` wiring revalidates once the network returns; a settled 401 then ends the session and invalidates the snapshot, so a revoked session can't be resurrected by later offline boots. Web builds (no readable credential) keep the conservative login-screen behavior.

Fixes [LUM-2412](https://linear.app/vellum/issue/LUM-2412/electron-shows-login-screen-when-window-is-reopened-while-offline). Sibling of LUM-2402 (#34742) — same transport-vs-settled classification bug, one layer up: the auth guard fired before the lifecycle's transient-error handling could run.

## Original prompt
While manually testing the LUM-2402 fix, reopening the Electron app from the tray while offline landed on the login screen despite a valid session — the session token was still in the main process, but the boot/resume session probes treated the offline transport failure as "signed out". The ask was to file LUM-2412 and implement the diagnosed fix: classify session-check failures (only settled server answers may end the session), optimistically restore from a persisted user snapshot when a local credential exists, and revalidate on reconnect so genuinely revoked sessions still log out.