### PR TITLE
fix(web): refresh only the first list page on conversation sync; raise daemon loopback rate limit

### DIFF
--- a/apps/web/src/hooks/use-conversation-sync.test.tsx
+++ b/apps/web/src/hooks/use-conversation-sync.test.tsx
@@ -6,6 +6,7 @@ import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { AssistantEventEnvelope } from "@vellumai/assistant-api";
 import type { Conversation } from "@/types/conversation-types";
 import {
+  archivedConversationsQueryKey,
   conversationGroupsQueryKey,
   conversationsQueryKey,
 } from "@/lib/sync/query-tags";
@@ -44,6 +45,39 @@ mock.module("@/utils/fetch-conversation-detail", () => ({
     fetchConversationDetailCalls.push({ assistantId, conversationId });
     return fetchConversationDetailImpl(queryClient, assistantId, conversationId);
   },
+}));
+
+// ---------------------------------------------------------------------------
+// Module mock — `@/utils/conversation-list-fetchers`.
+// ---------------------------------------------------------------------------
+const realListFetchersModule = await import(
+  "@/utils/conversation-list-fetchers"
+);
+type ListFirstPage = Awaited<
+  ReturnType<typeof realListFetchersModule.listConversationsFirstPage>
+>;
+
+let listFirstPageImpl: (
+  bucket: string,
+  assistantId: string,
+) => Promise<ListFirstPage> = async () => ({
+  conversations: [],
+  hasMore: false,
+});
+const listFirstPageCalls: Array<{ bucket: string; assistantId: string }> = [];
+
+function recordFirstPage(bucket: string) {
+  return (assistantId: string) => {
+    listFirstPageCalls.push({ bucket, assistantId });
+    return listFirstPageImpl(bucket, assistantId);
+  };
+}
+
+mock.module("@/utils/conversation-list-fetchers", () => ({
+  ...realListFetchersModule,
+  listConversationsFirstPage: recordFirstPage("foreground"),
+  listBackgroundConversationsFirstPage: recordFirstPage("background"),
+  listScheduledConversationsFirstPage: recordFirstPage("scheduled"),
 }));
 
 const { useConversationSync } = await import(
@@ -92,6 +126,8 @@ beforeEach(() => {
         "fetchConversationDetail mock not configured — set fetchConversationDetailImpl in the test",
       ),
     );
+  listFirstPageCalls.length = 0;
+  listFirstPageImpl = async () => ({ conversations: [], hasMore: false });
 });
 
 afterEach(() => {
@@ -122,8 +158,9 @@ describe("useConversationSync", () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
-  test("debounces conversations:list invalidation", async () => {
+  test("debounces conversations:list signals into one first-page window refresh", async () => {
     const queryClient = freshQueryClient();
+    queryClient.setQueryData(conversationsQueryKey("asst-1"), []);
     const spy = mock(() => Promise.resolve());
     queryClient.invalidateQueries = spy as never;
     renderHook(() => useConversationSync("asst-1", true), {
@@ -134,13 +171,54 @@ describe("useConversationSync", () => {
     emit(syncEvent([SYNC_TAGS.conversationsList]));
     // Debounced — wait past the 250ms window.
     await new Promise((resolve) => setTimeout(resolve, 350));
+    // One first-page fetch for the populated foreground bucket; the
+    // background/scheduled buckets were never fetched, so they're skipped.
+    expect(listFirstPageCalls).toEqual([
+      { bucket: "foreground", assistantId: "asst-1" },
+    ]);
+    // The full paginated list query is never invalidated.
     const listCalls = (spy.mock.calls as unknown as Array<[unknown]>).filter(
       (call) => {
         const arg = call[0] as { queryKey: readonly unknown[] } | undefined;
         return arg?.queryKey?.[0] === conversationsQueryKey("asst-1")[0];
       },
     );
-    expect(listCalls.length).toBe(1);
+    expect(listCalls.length).toBe(0);
+  });
+
+  test("merges the fetched first page into the cached foreground window", async () => {
+    const queryClient = freshQueryClient();
+    queryClient.setQueryData(conversationsQueryKey("asst-1"), [
+      { conversationId: "conv-new", title: "Recent", lastMessageAt: 5000 },
+      // Inside the fresh window (>= its oldest row) but missing from the
+      // page — deleted or archived by another client.
+      { conversationId: "conv-gone", title: "Removed elsewhere", lastMessageAt: 4950 },
+      // Below the fresh window — untouched deep history survives.
+      { conversationId: "conv-old", title: "Deep history", lastMessageAt: 1000 },
+    ]);
+    listFirstPageImpl = async () =>
+      ({
+        conversations: [
+          { conversationId: "conv-new", title: "Recent (renamed)", lastMessageAt: 5000 },
+          { conversationId: "conv-created", title: "Created elsewhere", lastMessageAt: 4900 },
+        ],
+        hasMore: true,
+      }) as ListFirstPage;
+    renderHook(() => useConversationSync("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+    emit(syncEvent([SYNC_TAGS.conversationsList]));
+    await waitFor(() => {
+      const list = queryClient.getQueryData(
+        conversationsQueryKey("asst-1"),
+      ) as Array<{ conversationId: string; title: string }>;
+      expect(list.map((c) => c.conversationId)).toEqual([
+        "conv-new",
+        "conv-created",
+        "conv-old",
+      ]);
+      expect(list[0].title).toBe("Recent (renamed)");
+    });
   });
 
   test("per-conversation metadata tags GET-and-patch the cached row (no list refetch)", async () => {
@@ -258,8 +336,9 @@ describe("useConversationSync", () => {
     expect(listCalls.length).toBe(0);
   });
 
-  test("invalidates conversation list queries on sse.opened reconnect (debounced)", async () => {
+  test("refreshes the list window on sse.opened reconnect (debounced)", async () => {
     const queryClient = freshQueryClient();
+    queryClient.setQueryData(conversationsQueryKey("asst-1"), []);
     const spy = mock(() => Promise.resolve());
     queryClient.invalidateQueries = spy as never;
     renderHook(() => useConversationSync("asst-1", true), {
@@ -268,12 +347,9 @@ describe("useConversationSync", () => {
     emitOpened("error");
     // Wait past the 250ms debounce window.
     await new Promise((resolve) => setTimeout(resolve, 350));
-    const chatCtxCalls = (spy.mock.calls as unknown as Array<[unknown]>).filter(
-      (call) => {
-        const arg = call[0] as { queryKey: readonly unknown[] } | undefined;
-        return arg?.queryKey?.[0] === conversationsQueryKey("asst-1")[0];
-      },
-    );
+    expect(listFirstPageCalls).toEqual([
+      { bucket: "foreground", assistantId: "asst-1" },
+    ]);
     const expectedGroupsKey = conversationGroupsQueryKey("asst-1")[0];
     const groupsCalls = (spy.mock.calls as unknown as Array<[unknown]>).filter(
       (call) => {
@@ -282,12 +358,21 @@ describe("useConversationSync", () => {
         return key?._id === (expectedGroupsKey as Record<string, unknown>)._id;
       },
     );
-    expect(chatCtxCalls.length).toBe(1);
+    const archivedCalls = (
+      spy.mock.calls as unknown as Array<[unknown]>
+    ).filter((call) => {
+      const arg = call[0] as { queryKey: readonly unknown[] } | undefined;
+      return (
+        arg?.queryKey?.[0] === archivedConversationsQueryKey("asst-1")[0]
+      );
+    });
     expect(groupsCalls.length).toBe(1);
+    expect(archivedCalls.length).toBe(1);
   });
 
-  test("does NOT invalidate on sse.opened (cause=fresh)", async () => {
+  test("does NOT refresh on sse.opened (cause=fresh)", async () => {
     const queryClient = freshQueryClient();
+    queryClient.setQueryData(conversationsQueryKey("asst-1"), []);
     const spy = mock(() => Promise.resolve());
     queryClient.invalidateQueries = spy as never;
     renderHook(() => useConversationSync("asst-1", true), {
@@ -296,6 +381,7 @@ describe("useConversationSync", () => {
     emitOpened("fresh");
     await Promise.resolve();
     expect(spy).not.toHaveBeenCalled();
+    expect(listFirstPageCalls.length).toBe(0);
   });
 
   test("patches conversation title in cache on conversation_title_updated", async () => {

--- a/apps/web/src/hooks/use-conversation-sync.ts
+++ b/apps/web/src/hooks/use-conversation-sync.ts
@@ -4,11 +4,14 @@
  * Routes `conversationsList` umbrella tags, per-conversation
  * `conversation:<id>:metadata` tags, and the `conversation_title_updated`
  * event into TanStack Query cache operations. Debounces list-level
- * invalidations so rapid-fire sync_changed bursts collapse into a
- * single refetch.
+ * signals so rapid-fire sync_changed bursts collapse into a single
+ * first-page window refresh (`refreshConversationListWindows`) rather
+ * than a full paginated re-drain — at thousands of conversations the
+ * drain is hundreds of sequential GETs, which exhausts the daemon's
+ * per-client rate-limit budget during active turns.
  *
- * Also handles SSE reconnect (`sse.opened`) by scheduling a debounced
- * conversation list refetch to catch events missed during the gap.
+ * Also handles SSE reconnect (`sse.opened`) by scheduling the same
+ * debounced window refresh to catch events missed during the gap.
  *
  * Per-conversation content events (text deltas, tool calls) are
  * ignored — those remain owned by the conversation-scoped
@@ -23,11 +26,17 @@ import { captureError } from "@/lib/sentry/capture-error";
 import { type MutableRefObject, useEffect, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
-import { refreshConversationRow } from "@/utils/conversation-cache-mutations";
-import { invalidateConversationQueries, patchConversation } from "@/utils/conversation-cache";
+import {
+  refreshConversationListWindows,
+  refreshConversationRow,
+} from "@/utils/conversation-cache-mutations";
+import { patchConversation } from "@/utils/conversation-cache";
 import { createConcurrencyLimiter } from "@/utils/concurrency-limiter";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
-import { conversationGroupsQueryKey } from "@/lib/sync/query-tags";
+import {
+  archivedConversationsQueryKey,
+  conversationGroupsQueryKey,
+} from "@/lib/sync/query-tags";
 import { getClientId } from "@/lib/telemetry/client-identity";
 import {
   parseConversationSyncTag,
@@ -44,11 +53,12 @@ const CONVERSATION_LIST_DEBOUNCE_MS = 250;
  * parallel, blowing the 300 req/min rate limit.
  *
  * Excess calls are dropped. For events that include `conversationsList`
- * (shape-changing: create, delete, reorder), the debounced list refetch
- * reconciles dropped rows. For metadata-only events (seen_changed),
- * dropped rows stay stale until the next reconnect/refetch — acceptable
- * as a rate-limit guard. The long-term fix is a typed event with inline
- * state so the client can patch the cache without a GET.
+ * (shape-changing: create, delete, reorder), the debounced first-page
+ * window refresh reconciles dropped rows. For metadata-only events
+ * (seen_changed), dropped rows stay stale until the next
+ * reconnect/refresh — acceptable as a rate-limit guard. The long-term
+ * fix is a typed event with inline state so the client can patch the
+ * cache without a GET.
  */
 const MAX_CONCURRENT_ROW_REFRESHES = 6;
 
@@ -58,8 +68,8 @@ const MAX_CONCURRENT_ROW_REFRESHES = 6;
  * Handles two bus channels:
  * - `sse.event` — routes `conversationsList` and `conversation:<id>:metadata`
  *   tags from `sync_changed` events
- * - `sse.opened` — schedules a debounced list refetch on reconnect to
- *   catch events missed during the transport gap
+ * - `sse.opened` — schedules a debounced first-page window refresh on
+ *   reconnect to catch events missed during the transport gap
  */
 export function useConversationSync(
   assistantId: string | null,
@@ -150,7 +160,23 @@ function scheduleConversationListRefetch(
   if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
   debounceTimerRef.current = setTimeout(() => {
     debounceTimerRef.current = null;
-    void invalidateConversationQueries(queryClient, assistantId);
+    // One first-page GET per populated list bucket — never a full
+    // paginated drain (see refreshConversationListWindows).
+    void refreshConversationListWindows(queryClient, assistantId).catch(
+      (err: unknown) => {
+        captureError(err, {
+          context: "useConversationSync.refreshListWindows",
+          bestEffort: true,
+          extra: { assistantId },
+        });
+      },
+    );
+    // The archive view renders rarely and sorts by archive time, so a
+    // plain invalidation (refetch only while its observer is mounted)
+    // stays cheap and correct. Groups are a single unpaginated GET.
+    void queryClient.invalidateQueries({
+      queryKey: archivedConversationsQueryKey(assistantId),
+    });
     void queryClient.invalidateQueries({
       queryKey: conversationGroupsQueryKey(assistantId),
     });

--- a/apps/web/src/utils/conversation-cache-mutations.test.ts
+++ b/apps/web/src/utils/conversation-cache-mutations.test.ts
@@ -13,6 +13,7 @@ import {
 
 import {
   markConversationSeenLocal,
+  mergeListFirstPage,
   prependConversation,
   removeConversation,
   shouldSurfaceConversationOnUserSend,
@@ -625,5 +626,92 @@ describe("deleteGroupAndResetConversations", () => {
     deleteGroupAndResetConversations(qc, ASSISTANT_ID, "g1");
 
     expect(getForeground(qc)).toBe(original);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeListFirstPage
+// ---------------------------------------------------------------------------
+
+describe("mergeListFirstPage", () => {
+  test("replaces the cache when the page is the complete list", () => {
+    const prev = [
+      makeConversation({ conversationId: "c1", lastMessageAt: 5000 }),
+      makeConversation({ conversationId: "c2", lastMessageAt: 1000 }),
+    ];
+    const page = {
+      conversations: [
+        makeConversation({ conversationId: "c1", lastMessageAt: 5000 }),
+      ],
+      hasMore: false,
+    };
+
+    expect(mergeListFirstPage(prev, page)).toBe(page.conversations);
+  });
+
+  test("drops cached rows inside the window that vanished from the page, keeps older rows", () => {
+    const prev = [
+      makeConversation({ conversationId: "c-new", lastMessageAt: 5000 }),
+      makeConversation({ conversationId: "c-gone", lastMessageAt: 4950 }),
+      makeConversation({ conversationId: "c-old", lastMessageAt: 1000 }),
+    ];
+    const fresh = [
+      makeConversation({ conversationId: "c-new", lastMessageAt: 5000, title: "Renamed" }),
+      makeConversation({ conversationId: "c-created", lastMessageAt: 4900 }),
+    ];
+
+    const merged = mergeListFirstPage(prev, { conversations: fresh, hasMore: true });
+
+    expect(merged.map((c) => c.conversationId)).toEqual([
+      "c-new",
+      "c-created",
+      "c-old",
+    ]);
+    expect(merged[0].title).toBe("Renamed");
+  });
+
+  test("excludes pinned rows from the window cutoff", () => {
+    // The daemon appends every pinned conversation to page 1 regardless of
+    // age. An ancient pinned row must not collapse the cutoff and drop
+    // live cached rows.
+    const prev = [
+      makeConversation({ conversationId: "c-live", lastMessageAt: 4000 }),
+    ];
+    const fresh = [
+      makeConversation({ conversationId: "c-top", lastMessageAt: 5000 }),
+      makeConversation({ conversationId: "c-pinned", lastMessageAt: 100, isPinned: true }),
+    ];
+
+    const merged = mergeListFirstPage(prev, { conversations: fresh, hasMore: true });
+
+    expect(merged.map((c) => c.conversationId)).toEqual([
+      "c-top",
+      "c-pinned",
+      "c-live",
+    ]);
+  });
+
+  test("always keeps client-local draft rows", () => {
+    const prev = [
+      makeConversation({ conversationId: "c-draft", lastMessageAt: 6000, draft: true }),
+    ];
+    const fresh = [
+      makeConversation({ conversationId: "c-top", lastMessageAt: 5000 }),
+    ];
+
+    const merged = mergeListFirstPage(prev, { conversations: fresh, hasMore: true });
+
+    expect(merged.map((c) => c.conversationId)).toEqual(["c-top", "c-draft"]);
+  });
+
+  test("returns the cache unchanged when every fresh row is pinned", () => {
+    const prev = [
+      makeConversation({ conversationId: "c1", lastMessageAt: 4000 }),
+    ];
+    const fresh = [
+      makeConversation({ conversationId: "c-pinned", lastMessageAt: 100, isPinned: true }),
+    ];
+
+    expect(mergeListFirstPage(prev, { conversations: fresh, hasMore: true })).toBe(prev);
   });
 });

--- a/apps/web/src/utils/conversation-cache-mutations.ts
+++ b/apps/web/src/utils/conversation-cache-mutations.ts
@@ -27,6 +27,17 @@ import {
   updateScheduledConversationsCache,
 } from "@/utils/conversation-cache";
 import {
+  backgroundConversationsQueryKey,
+  conversationsQueryKey,
+  scheduledConversationsQueryKey,
+} from "@/lib/sync/query-tags";
+import {
+  type ConversationListPage,
+  listBackgroundConversationsFirstPage,
+  listConversationsFirstPage,
+  listScheduledConversationsFirstPage,
+} from "@/utils/conversation-list-fetchers";
+import {
   ConversationNotFoundError,
   fetchConversationDetail,
 } from "@/utils/fetch-conversation-detail";
@@ -223,6 +234,91 @@ export async function refreshConversationRow(
     ...conversations,
     result,
   ]);
+}
+
+/**
+ * Reconcile one fetched first page into a cached newest-first list.
+ *
+ * - `hasMore === false`: the page is the complete list — replace the cache.
+ * - Otherwise the fresh rows win, and cached rows absent from the page
+ *   survive only when they sort strictly below the page's window (older
+ *   than the oldest non-pinned fresh row). A cached row whose timestamp
+ *   falls inside the window but is missing from the page no longer lives
+ *   there (deleted or archived), so it is dropped. Pinned rows are
+ *   excluded from the cutoff because the daemon appends every pinned
+ *   conversation to page 1 regardless of age — an ancient pinned row
+ *   would otherwise collapse the cutoff and drop live rows.
+ * - Client-local draft rows always survive; the server doesn't know them.
+ *
+ * The fresh window leads the result; surviving rows keep their existing
+ * relative order.
+ *
+ * @internal Exported for testing.
+ */
+export function mergeListFirstPage(
+  prev: Conversation[],
+  page: ConversationListPage,
+): Conversation[] {
+  if (!page.hasMore) return page.conversations;
+  const nonPinned = page.conversations.filter((c) => c.isPinned !== true);
+  if (nonPinned.length === 0) return prev;
+  const cutoff = Math.min(...nonPinned.map((c) => c.lastMessageAt ?? 0));
+  const freshIds = new Set(page.conversations.map((c) => c.conversationId));
+  const kept = prev.filter(
+    (c) =>
+      !freshIds.has(c.conversationId) &&
+      (c.draft === true || (c.lastMessageAt ?? 0) < cutoff),
+  );
+  return [...page.conversations, ...kept];
+}
+
+const LIST_WINDOW_BUCKETS = [
+  { queryKey: conversationsQueryKey, fetchFirstPage: listConversationsFirstPage },
+  {
+    queryKey: backgroundConversationsQueryKey,
+    fetchFirstPage: listBackgroundConversationsFirstPage,
+  },
+  {
+    queryKey: scheduledConversationsQueryKey,
+    fetchFirstPage: listScheduledConversationsFirstPage,
+  },
+] as const;
+
+/**
+ * Refresh the top window of every populated conversation-list cache with a
+ * single first-page GET per bucket, merging via {@link mergeListFirstPage}.
+ *
+ * Drives the `conversationsList` sync-tag and SSE-reconnect handlers in
+ * `use-conversation-sync.ts`. The full list query drains every page
+ * (hundreds of sequential GETs at thousands of conversations), so
+ * invalidating it on each sync signal exhausts the daemon's per-client
+ * rate-limit budget during active turns; refreshing just the visible
+ * window keeps the cost at one request per bucket per signal.
+ *
+ * Buckets that were never fetched (collapsed sidebar sections) are
+ * skipped — their queries fetch on first expand anyway. Fetch errors are
+ * rethrown so the caller can log/capture without silently dropping the
+ * signal.
+ */
+export async function refreshConversationListWindows(
+  queryClient: QueryClient,
+  assistantId: string | null,
+): Promise<void> {
+  if (!assistantId) return;
+  await Promise.all(
+    LIST_WINDOW_BUCKETS.map(async (bucket) => {
+      const queryKey = bucket.queryKey(assistantId);
+      if (queryClient.getQueryData<Conversation[]>(queryKey) === undefined) {
+        return;
+      }
+      const page = await bucket.fetchFirstPage(assistantId);
+      queryClient.setQueryData<Conversation[]>(
+        queryKey,
+        (prev: Conversation[] | undefined) =>
+          prev === undefined ? undefined : mergeListFirstPage(prev, page),
+      );
+    }),
+  );
 }
 
 export function resolveDraftKey(

--- a/apps/web/src/utils/conversation-list-fetchers.ts
+++ b/apps/web/src/utils/conversation-list-fetchers.ts
@@ -60,35 +60,55 @@ type FetchConversationListOptions = {
   archiveStatus?: "active" | "archived" | "all";
 };
 
+/** One page of a conversation list plus whether more pages exist. */
+export type ConversationListPage = {
+  conversations: Conversation[];
+  hasMore: boolean;
+};
+
+async function fetchConversationListPage(
+  assistantId: string,
+  offset: number,
+  options: FetchConversationListOptions = {},
+): Promise<ConversationListPage> {
+  const { conversationType, archiveStatus } = options;
+  const { data, error, response } = await conversationsGet({
+    path: { assistant_id: assistantId },
+    query: {
+      limit: CONVERSATION_LIST_PAGE_SIZE,
+      offset,
+      ...(conversationType ? { conversationType } : {}),
+      ...(archiveStatus ? { archiveStatus } : {}),
+    },
+    throwOnError: false,
+  });
+  assertHasResponse(response, error, "Failed to list conversations.");
+  if (!response.ok) {
+    const msg = extractErrorMessage(error, response, "Failed to list conversations.");
+    throw new ApiError(response.status, msg);
+  }
+
+  return {
+    conversations: (data?.conversations ?? []).map(toConversation),
+    hasMore: data?.hasMore ?? false,
+  };
+}
+
 async function fetchConversationList(
   assistantId: string,
   options: FetchConversationListOptions = {},
 ): Promise<Conversation[]> {
-  const { conversationType, archiveStatus } = options;
   const all: Conversation[] = [];
 
   for (let page = 0; page < CONVERSATION_LIST_MAX_PAGES; page++) {
     const offset = page * CONVERSATION_LIST_PAGE_SIZE;
-    const { data, error, response } = await conversationsGet({
-      path: { assistant_id: assistantId },
-      query: {
-        limit: CONVERSATION_LIST_PAGE_SIZE,
-        offset,
-        ...(conversationType ? { conversationType } : {}),
-        ...(archiveStatus ? { archiveStatus } : {}),
-      },
-      throwOnError: false,
-    });
-    assertHasResponse(response, error, "Failed to list conversations.");
-    if (!response.ok) {
-      const msg = extractErrorMessage(error, response, "Failed to list conversations.");
-      throw new ApiError(response.status, msg);
-    }
+    const { conversations, hasMore } = await fetchConversationListPage(
+      assistantId,
+      offset,
+      options,
+    );
+    all.push(...conversations);
 
-    const conversations = data?.conversations ?? [];
-    all.push(...conversations.map(toConversation));
-
-    const hasMore = data?.hasMore ?? false;
     if (!hasMore) break;
 
     if (conversations.length === 0) break;
@@ -227,6 +247,58 @@ export async function listArchivedConversations(
   assistantId: string,
 ): Promise<Conversation[]> {
   return fetchMergedConversationList(assistantId, "archived", "archivedAt");
+}
+
+// ---------------------------------------------------------------------------
+// First-page fetchers
+//
+// Single-request variants of the list fetchers above, used by the
+// sync_changed consumer to refresh the top of a cached list without
+// re-draining every page. At thousands of conversations the full drain is
+// hundreds of sequential GETs, which exhausts the daemon's per-client
+// rate-limit budget when sync events arrive continuously during an active
+// turn. Each returns the bucket's newest rows (one page, already filtered
+// and sorted with the same semantics as its full-list counterpart) plus
+// `hasMore` so callers can tell a complete list from a window.
+// ---------------------------------------------------------------------------
+
+/** First page of {@link listConversations} (foreground bucket). */
+export async function listConversationsFirstPage(
+  assistantId: string,
+): Promise<ConversationListPage> {
+  const page = await fetchConversationListPage(assistantId, 0);
+  return {
+    ...page,
+    conversations: [...page.conversations].sort(byTimestampDesc("lastMessageAt")),
+  };
+}
+
+/** First page of {@link listBackgroundConversations} (background bucket). */
+export async function listBackgroundConversationsFirstPage(
+  assistantId: string,
+): Promise<ConversationListPage> {
+  const page = await fetchConversationListPage(assistantId, 0, {
+    conversationType: "background",
+  });
+  return {
+    ...page,
+    conversations: page.conversations
+      .filter((c) => !isScheduledConversation(c))
+      .sort(byTimestampDesc("lastMessageAt")),
+  };
+}
+
+/** First page of {@link listScheduledConversations} (scheduled bucket). */
+export async function listScheduledConversationsFirstPage(
+  assistantId: string,
+): Promise<ConversationListPage> {
+  const page = await fetchConversationListPage(assistantId, 0, {
+    conversationType: "scheduled",
+  });
+  return {
+    ...page,
+    conversations: [...page.conversations].sort(byTimestampDesc("lastMessageAt")),
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -56,11 +56,11 @@ import {
 } from "./middleware/auth.js";
 import { withErrorHandling } from "./middleware/error-handler.js";
 import {
-  apiRateLimiter,
   extractClientIp,
   ipRateLimiter,
   rateLimitHeaders,
   rateLimitResponse,
+  selectAuthenticatedRateLimiter,
 } from "./middleware/rate-limiter.js";
 import { withRequestLogging } from "./middleware/request-logger.js";
 import {
@@ -690,7 +690,11 @@ export class RuntimeHttpServer {
     if (!isHttpAuthDisabled()) {
       const clientIp = extractClientIp(req, server);
       const token = extractBearerToken(req);
-      const limiter = token ? apiRateLimiter : ipRateLimiter;
+      // Authenticated loopback clients (desktop app, CLI — anything on the
+      // daemon's own host) get a higher budget than remote clients.
+      const limiter = token
+        ? selectAuthenticatedRateLimiter(clientIp)
+        : ipRateLimiter;
       const limiterKind = token ? "authenticated" : "unauthenticated";
       const result = limiter.check(clientIp, path);
       if (!result.allowed) {

--- a/assistant/src/runtime/middleware/__tests__/rate-limiter.test.ts
+++ b/assistant/src/runtime/middleware/__tests__/rate-limiter.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+
+import { isLoopbackAddress } from "../auth.js";
+import {
+  apiRateLimiter,
+  loopbackApiRateLimiter,
+  selectAuthenticatedRateLimiter,
+} from "../rate-limiter.js";
+
+describe("isLoopbackAddress", () => {
+  test("accepts loopback addresses", () => {
+    expect(isLoopbackAddress("127.0.0.1")).toBe(true);
+    expect(isLoopbackAddress("127.42.0.7")).toBe(true);
+    expect(isLoopbackAddress("::1")).toBe(true);
+    expect(isLoopbackAddress("::ffff:127.0.0.1")).toBe(true);
+  });
+
+  test("rejects private (non-loopback) and public addresses", () => {
+    expect(isLoopbackAddress("10.0.0.1")).toBe(false);
+    expect(isLoopbackAddress("192.168.1.20")).toBe(false);
+    expect(isLoopbackAddress("172.16.0.5")).toBe(false);
+    expect(isLoopbackAddress("169.254.0.1")).toBe(false);
+    expect(isLoopbackAddress("::ffff:10.0.0.1")).toBe(false);
+    expect(isLoopbackAddress("fe80::1")).toBe(false);
+    expect(isLoopbackAddress("fd00::1")).toBe(false);
+    expect(isLoopbackAddress("8.8.8.8")).toBe(false);
+  });
+
+  test("rejects malformed input", () => {
+    expect(isLoopbackAddress("")).toBe(false);
+    expect(isLoopbackAddress("localhost")).toBe(false);
+    expect(isLoopbackAddress("127.0.0")).toBe(false);
+    expect(isLoopbackAddress("127.0.0.999")).toBe(false);
+  });
+});
+
+describe("selectAuthenticatedRateLimiter", () => {
+  test("loopback clients get the higher-budget limiter", () => {
+    expect(selectAuthenticatedRateLimiter("127.0.0.1")).toBe(
+      loopbackApiRateLimiter,
+    );
+    expect(selectAuthenticatedRateLimiter("::1")).toBe(loopbackApiRateLimiter);
+    expect(selectAuthenticatedRateLimiter("::ffff:127.0.0.1")).toBe(
+      loopbackApiRateLimiter,
+    );
+  });
+
+  test("remote and LAN clients get the standard limiter", () => {
+    expect(selectAuthenticatedRateLimiter("192.168.1.20")).toBe(apiRateLimiter);
+    expect(selectAuthenticatedRateLimiter("203.0.113.9")).toBe(apiRateLimiter);
+  });
+
+  test("loopback budget exceeds the standard budget", () => {
+    const loopback = loopbackApiRateLimiter.check(
+      "test-loopback-budget",
+      "/v1/test",
+    );
+    const standard = apiRateLimiter.check("test-standard-budget", "/v1/test");
+    expect(loopback.limit).toBeGreaterThan(standard.limit);
+    expect(loopback.limit).toBe(1200);
+    expect(standard.limit).toBe(300);
+  });
+});

--- a/assistant/src/runtime/middleware/auth.ts
+++ b/assistant/src/runtime/middleware/auth.ts
@@ -12,6 +12,32 @@ export function isLoopbackHost(hostname: string): boolean {
   );
 }
 
+/** Unwrap IPv4-mapped IPv6 (e.g. ::ffff:10.0.0.1) to its IPv4 part. */
+function unwrapV4Mapped(addr: string): string {
+  const v4Mapped = addr.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
+  return v4Mapped ? v4Mapped[1] : addr;
+}
+
+/**
+ * Determine whether an IP address string is a loopback address —
+ * 127.0.0.0/8, ::1, or their IPv4-mapped IPv6 forms. Strictly narrower
+ * than {@link isPrivateAddress}: LAN peers (RFC 1918, link-local) are
+ * private but not loopback.
+ */
+export function isLoopbackAddress(addr: string): boolean {
+  const normalized = unwrapV4Mapped(addr);
+
+  if (normalized.includes(".")) {
+    const parts = normalized.split(".").map(Number);
+    if (parts.length !== 4 || parts.some((p) => isNaN(p) || p < 0 || p > 255))
+      return false;
+    // Loopback: 127.0.0.0/8
+    return parts[0] === 127;
+  }
+
+  return normalized.toLowerCase() === "::1";
+}
+
 /**
  * @internal Exported for testing.
  *
@@ -24,9 +50,7 @@ export function isLoopbackHost(hostname: string): boolean {
  *   - IPv4-mapped IPv6 variants of all of the above (::ffff:x.x.x.x)
  */
 export function isPrivateAddress(addr: string): boolean {
-  // Handle IPv4-mapped IPv6 (e.g. ::ffff:10.0.0.1) -- extract the IPv4 part
-  const v4Mapped = addr.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
-  const normalized = v4Mapped ? v4Mapped[1] : addr;
+  const normalized = unwrapV4Mapped(addr);
 
   // IPv4 checks
   if (normalized.includes(".")) {

--- a/assistant/src/runtime/middleware/rate-limiter.ts
+++ b/assistant/src/runtime/middleware/rate-limiter.ts
@@ -4,13 +4,21 @@
 
 import { getLogger } from "../../util/logger.js";
 import type { HttpErrorResponse } from "../http-errors.js";
-import { isPrivateAddress } from "./auth.js";
+import { isLoopbackAddress, isPrivateAddress } from "./auth.js";
 
 const log = getLogger("rate-limiter");
 
 const DEFAULT_MAX_REQUESTS = 300;
 const DEFAULT_WINDOW_MS = 60_000; // 60 seconds
 const MAX_TRACKED_TOKENS = 10_000;
+
+// Higher budget for authenticated loopback clients. Loopback means the
+// request originated on the daemon's own host (desktop app, CLI, local
+// scripts) — proxied remote traffic resolves to its forwarded client IP
+// instead (see extractClientIp). Local clients legitimately burst far
+// beyond the remote budget: a cold sidebar load at thousands of
+// conversations pages through hundreds of GETs in a few seconds.
+const LOOPBACK_MAX_REQUESTS = 1200;
 
 // Lower limit for unauthenticated (IP-based) requests to reduce abuse surface.
 const DEFAULT_IP_MAX_REQUESTS = 20;
@@ -186,12 +194,31 @@ export function rateLimitResponse(
 /** Singleton rate limiter for authenticated /v1/* requests (per-client-IP). */
 export const apiRateLimiter = new TokenRateLimiter();
 
+/**
+ * Singleton rate limiter for authenticated requests from loopback clients.
+ * Separate instance (not just a higher cap) so local and remote traffic
+ * never share or evict each other's buckets.
+ */
+export const loopbackApiRateLimiter = new TokenRateLimiter(
+  LOOPBACK_MAX_REQUESTS,
+);
+
 /** Singleton rate limiter for unauthenticated requests (per-IP, lower limits). */
 export const ipRateLimiter = new TokenRateLimiter(
   DEFAULT_IP_MAX_REQUESTS,
   DEFAULT_IP_WINDOW_MS,
   MAX_TRACKED_IPS,
 );
+
+/**
+ * Pick the rate limiter for an authenticated request: loopback client IPs
+ * get the higher local budget, everything else gets the standard one.
+ */
+export function selectAuthenticatedRateLimiter(
+  clientIp: string,
+): TokenRateLimiter {
+  return isLoopbackAddress(clientIp) ? loopbackApiRateLimiter : apiRateLimiter;
+}
 
 /**
  * Extract the client IP from a request. Only trusts proxy headers


### PR DESCRIPTION
## Summary
- `useConversationSync` no longer invalidates the full conversation-list queries on `conversationsList` sync tags / SSE reconnect. The list queryFn pages to exhaustion (~254 GETs at >10k conversations), and with sync signals arriving continuously during active turns the client saturated the daemon's 300 req/min per-client-IP budget (~68k denials/day observed), 429ing interactive requests (`POST /v1/messages`, SSE reconnects). The sync path now fetches just page 1 per populated bucket and merges it into the cache (`mergeListFirstPage`): fresh rows win, vanished in-window rows drop, older rows and client-local drafts survive, and pinned rows are excluded from the window cutoff since the daemon appends every pinned conversation to page 1 regardless of age.
- The daemon's authenticated rate limiter now routes loopback client IPs to a separate 1200 req/min limiter (`selectAuthenticatedRateLimiter`). Local clients (desktop app, CLI) legitimately burst far beyond the remote budget on cold sidebar loads; proxied remote traffic resolves to its forwarded IP via `extractClientIp` and keeps the standard 300 cap.
- Tests: unit tests for the merge semantics (replace/drop/keep/pinned-cutoff/draft cases), hook tests updated to the window-refresh contract, and new `isLoopbackAddress` / limiter-selection tests.

## Original prompt
Intermittent 429s while chatting were traced to the daemon's per-client-IP rate limiter being exhausted by the web client's conversation-list refetch, which re-drains the full paginated list on every `sync_changed` signal during active turns. The request was to (1) stop the sync-path full drain by refetching only the first page, and (2) raise the rate-limit threshold for loopback clients so local apps get a higher budget than remote ones.