### PR TITLE
feat(assistant): make heartbeats opt-in for new workspaces

### DIFF
--- a/assistant/src/__tests__/workspace-migration-102-preserve-heartbeat-enabled-for-existing-workspaces.test.ts
+++ b/assistant/src/__tests__/workspace-migration-102-preserve-heartbeat-enabled-for-existing-workspaces.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for workspace migration `102-preserve-heartbeat-enabled-for-existing-workspaces`.
+ *
+ * The schema default for `heartbeat.enabled` flipped from true to false so
+ * heartbeats are opt-in for new users. The migration persists an explicit
+ * `enabled: true` for upgrading workspaces that never wrote the key (they
+ * relied on the old default-on behavior), creating `config.json` when it
+ * does not exist. It must skip fresh workspaces, leave explicit user values
+ * untouched, and be idempotent.
+ */
+
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { HeartbeatConfigSchema } from "../config/schemas/heartbeat.js";
+import { preserveHeartbeatEnabledForExistingWorkspacesMigration } from "../workspace/migrations/102-preserve-heartbeat-enabled-for-existing-workspaces.js";
+import type { MigrationRunContext } from "../workspace/migrations/types.js";
+
+const NEW_WORKSPACE_CTX: MigrationRunContext = { isNewWorkspace: true };
+const UPGRADE_CTX: MigrationRunContext = { isNewWorkspace: false };
+
+let workspaceDir: string;
+let configPath: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-migration-102-test-"));
+  configPath = join(workspaceDir, "config.json");
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(configPath, "utf-8"));
+}
+
+describe("102-preserve-heartbeat-enabled-for-existing-workspaces migration", () => {
+  test("has correct id and description", () => {
+    expect(preserveHeartbeatEnabledForExistingWorkspacesMigration.id).toBe(
+      "102-preserve-heartbeat-enabled-for-existing-workspaces",
+    );
+    expect(
+      preserveHeartbeatEnabledForExistingWorkspacesMigration.description,
+    ).toContain("heartbeat.enabled");
+  });
+
+  test("schema default is disabled (the flip this migration compensates for)", () => {
+    expect(HeartbeatConfigSchema.parse({}).enabled).toBe(false);
+  });
+
+  test("skips fresh workspaces so new users get the opt-in default", () => {
+    preserveHeartbeatEnabledForExistingWorkspacesMigration.run(
+      workspaceDir,
+      NEW_WORKSPACE_CTX,
+    );
+
+    expect(existsSync(configPath)).toBe(false);
+  });
+
+  test("creates config.json with enabled=true when an existing workspace has none", () => {
+    preserveHeartbeatEnabledForExistingWorkspacesMigration.run(
+      workspaceDir,
+      UPGRADE_CTX,
+    );
+
+    expect(readConfig()).toEqual({ heartbeat: { enabled: true } });
+  });
+
+  test("adds heartbeat block to an existing config without one", () => {
+    writeFileSync(configPath, JSON.stringify({ name: "Assistant" }), "utf-8");
+
+    preserveHeartbeatEnabledForExistingWorkspacesMigration.run(
+      workspaceDir,
+      UPGRADE_CTX,
+    );
+
+    expect(readConfig()).toEqual({
+      name: "Assistant",
+      heartbeat: { enabled: true },
+    });
+  });
+
+  test("adds enabled=true to a heartbeat block without the key, preserving siblings", () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify({ heartbeat: { intervalMs: 1800000 } }),
+      "utf-8",
+    );
+
+    preserveHeartbeatEnabledForExistingWorkspacesMigration.run(
+      workspaceDir,
+      UPGRADE_CTX,
+    );
+
+    expect(readConfig()).toEqual({
+      heartbeat: { intervalMs: 1800000, enabled: true },
+    });
+  });
+
+  test.each([[true], [false]])(
+    "leaves an explicit enabled=%p untouched",
+    (enabled) => {
+      const original = JSON.stringify({ heartbeat: { enabled } });
+      writeFileSync(configPath, original, "utf-8");
+
+      preserveHeartbeatEnabledForExistingWorkspacesMigration.run(
+        workspaceDir,
+        UPGRADE_CTX,
+      );
+
+      expect(readFileSync(configPath, "utf-8")).toBe(original);
+    },
+  );
+
+  test("treats a missing context as an existing workspace", () => {
+    preserveHeartbeatEnabledForExistingWorkspacesMigration.run(workspaceDir);
+
+    expect(readConfig()).toEqual({ heartbeat: { enabled: true } });
+  });
+
+  test("leaves malformed config.json untouched", () => {
+    writeFileSync(configPath, "{ not json", "utf-8");
+
+    preserveHeartbeatEnabledForExistingWorkspacesMigration.run(
+      workspaceDir,
+      UPGRADE_CTX,
+    );
+
+    expect(readFileSync(configPath, "utf-8")).toBe("{ not json");
+  });
+
+  test("leaves a non-object heartbeat value untouched", () => {
+    const original = JSON.stringify({ heartbeat: "off" });
+    writeFileSync(configPath, original, "utf-8");
+
+    preserveHeartbeatEnabledForExistingWorkspacesMigration.run(
+      workspaceDir,
+      UPGRADE_CTX,
+    );
+
+    expect(readFileSync(configPath, "utf-8")).toBe(original);
+  });
+
+  test("is idempotent", () => {
+    preserveHeartbeatEnabledForExistingWorkspacesMigration.run(
+      workspaceDir,
+      UPGRADE_CTX,
+    );
+    const afterFirst = readFileSync(configPath, "utf-8");
+
+    preserveHeartbeatEnabledForExistingWorkspacesMigration.run(
+      workspaceDir,
+      UPGRADE_CTX,
+    );
+
+    expect(readFileSync(configPath, "utf-8")).toBe(afterFirst);
+  });
+
+  test("down is a no-op", () => {
+    preserveHeartbeatEnabledForExistingWorkspacesMigration.run(
+      workspaceDir,
+      UPGRADE_CTX,
+    );
+    const before = readFileSync(configPath, "utf-8");
+
+    preserveHeartbeatEnabledForExistingWorkspacesMigration.down(workspaceDir);
+
+    expect(readFileSync(configPath, "utf-8")).toBe(before);
+  });
+});

--- a/assistant/src/config/schemas/heartbeat.ts
+++ b/assistant/src/config/schemas/heartbeat.ts
@@ -5,7 +5,10 @@ export const HeartbeatConfigSchema = z
   .object({
     enabled: z
       .boolean({ error: "heartbeat.enabled must be a boolean" })
-      .default(true)
+      // Heartbeats are opt-in for new workspaces. Workspaces created while
+      // the default was true keep their behavior via workspace migration
+      // 102-preserve-heartbeat-enabled-for-existing-workspaces.
+      .default(false)
       .describe("Whether periodic heartbeat checks are enabled"),
     intervalMs: z
       .number({ error: "heartbeat.intervalMs must be a number" })

--- a/assistant/src/workspace/migrations/102-preserve-heartbeat-enabled-for-existing-workspaces.ts
+++ b/assistant/src/workspace/migrations/102-preserve-heartbeat-enabled-for-existing-workspaces.ts
@@ -1,0 +1,69 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { MigrationRunContext, WorkspaceMigration } from "./types.js";
+
+/**
+ * Preserve heartbeat behavior for existing workspaces after the schema
+ * default for `heartbeat.enabled` flipped from true to false (heartbeats are
+ * now opt-in for new users).
+ *
+ * Most configs never persist `heartbeat.enabled` — they relied on the old
+ * default-on schema behavior, so flipping the default would silently turn
+ * heartbeats off on upgrade. This migration writes an explicit
+ * `enabled: true` for upgrading workspaces that have no persisted value,
+ * keeping their effective behavior unchanged. Workspaces with an explicit
+ * `enabled` value (either way) are a user choice and are left untouched.
+ * Fresh workspaces are skipped so new users start with heartbeats off.
+ */
+export const preserveHeartbeatEnabledForExistingWorkspacesMigration: WorkspaceMigration =
+  {
+    id: "102-preserve-heartbeat-enabled-for-existing-workspaces",
+    description:
+      "Persist heartbeat.enabled=true for existing workspaces now that the default is off",
+    run(workspaceDir: string, ctx?: MigrationRunContext): void {
+      // Fresh workspaces get the new opt-in default. Without a context
+      // (older callers), treat the workspace as existing — writing
+      // enabled=true reproduces the legacy default and never disables
+      // heartbeats for anyone.
+      if (ctx?.isNewWorkspace) return;
+
+      const configPath = join(workspaceDir, "config.json");
+
+      // Existing workspaces may have no config.json at all (schema defaults
+      // are applied in memory at load time); create one so the legacy
+      // default-on behavior survives the flip.
+      let config: Record<string, unknown> = {};
+      if (existsSync(configPath)) {
+        try {
+          const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+          if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+          config = raw as Record<string, unknown>;
+        } catch {
+          return;
+        }
+      }
+
+      if (config.heartbeat === undefined) {
+        config.heartbeat = {};
+      }
+      const heartbeat = config.heartbeat;
+      if (
+        !heartbeat ||
+        typeof heartbeat !== "object" ||
+        Array.isArray(heartbeat)
+      ) {
+        return;
+      }
+
+      const heartbeatConfig = heartbeat as Record<string, unknown>;
+      if ("enabled" in heartbeatConfig) return;
+
+      heartbeatConfig.enabled = true;
+      writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+    },
+    down(_workspaceDir: string): void {
+      // Forward-only: cannot distinguish users who explicitly enabled
+      // heartbeats from those opted in by this migration.
+    },
+  };

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -99,6 +99,7 @@ import { removeStaleUpdatesBulletinFileMigration } from "./098-remove-stale-upda
 import { disableCacheOneShotCallsitesMigration } from "./099-disable-cache-one-shot-callsites.js";
 import { upgradeQualityProfileToFable5Migration } from "./100-upgrade-quality-profile-to-fable-5.js";
 import { upgradeBalancedEconomyToMinimaxM3Migration } from "./101-upgrade-balanced-economy-to-minimax-m3.js";
+import { preserveHeartbeatEnabledForExistingWorkspacesMigration } from "./102-preserve-heartbeat-enabled-for-existing-workspaces.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -209,4 +210,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   disableCacheOneShotCallsitesMigration,
   upgradeQualityProfileToFable5Migration,
   upgradeBalancedEconomyToMinimaxM3Migration,
+  preserveHeartbeatEnabledForExistingWorkspacesMigration,
 ];


### PR DESCRIPTION
## Summary
- Flip the `heartbeat.enabled` schema default from `true` to `false`, making heartbeats an opt-in feature for new workspaces.
- Add workspace migration `102-preserve-heartbeat-enabled-for-existing-workspaces`: for upgrading workspaces it persists an explicit `enabled: true` when the key was never written (creating `config.json` if absent, since schema defaults are applied in memory), leaves explicit user values untouched either way, and skips fresh workspaces via `ctx.isNewWorkspace` so new users get the new default.
- Add migration tests covering the fresh-workspace skip, config creation, sibling-key preservation, explicit user values, malformed config, missing migration context, and idempotency.

## Original prompt
Disable heartbeats by default for new users — heartbeats should be opt-in rather than opt-out. The open question was how to flip the default without impacting existing users who may want to keep heartbeats on; this PR resolves it with the workspace-migration `isNewWorkspace` mechanism, which freezes the legacy default-on behavior into existing workspaces' `config.json` before the schema default flips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)