### PR TITLE
fix(evals): make the compaction-thrash benchmark harness actually runnable

### DIFF
--- a/evals/benchmarks/compaction-thrash/scenarios/cron-noop/SPEC.md
+++ b/evals/benchmarks/compaction-thrash/scenarios/cron-noop/SPEC.md
@@ -5,15 +5,49 @@ status: experimental
 # cron-noop
 
 Simulates a long-running cron conversation where every tick is a no-op.
-Context grows unboundedly via repeated polling results and "remember"
-notes until compaction fires — and then re-fires every subsequent tick
-because the conservative `tail_start` barely shrinks the conversation.
+Context grows via repeated polling results and "remember" notes until
+compaction fires — and then re-fires on subsequent ticks because the
+conservative compaction barely shrinks the conversation, while each pass
+rewords the summary non-deterministically and invalidates the prompt-cache
+prefix.
+
+## How the threshold is reached
+
+The default 200k context window would never be crossed by a handful of
+ticks, so the `vellum-compaction-stress` profile shrinks it at setup:
+
+    assistant config set llm.default.contextWindow.maxInputTokens 40000
+
+This takes effect immediately — the daemon's `config_set` handler
+invalidates the in-memory config cache and per-call resolution re-reads it
+on the next turn, so no restart is needed.
+
+The daemon's proactive-compaction gate fires when its token estimate crosses
+`maxInputTokens × (1 − safetyMargin) × 0.85` (the `0.85` mid-loop yield ratio
+in `assistant/src/agent/loop.ts`). `safetyMargin` defaults to `0.05` and
+floors to `0.15` once history exceeds 50 messages. With `maxInputTokens =
+40000` the threshold is ~32.3k tokens early and ~28.9k once the history is
+long.
+
+Crucially, the daemon's estimate INCLUDES the system prompt and the full
+tool-definition catalog, not just message history — so the conversation
+starts a few thousand tokens above empty. Each tick message is padded to
+~2000 estimator-tokens of deterministic record-keeping filler, so a span of
+seed ticks adds a large, predictable amount that dominates the (large but
+not precisely known) base context and carries the conversation across the
+threshold within the seed phase, then keeps it there for every observation
+tick.
 
 ## Observables
 
-- Compaction fires on every post-threshold tick
-- Message count barely decreases after compaction
-- Cache-write tokens dominate (non-deterministic summary rewording)
+- Compaction fires on most/every post-threshold tick (counted from the
+  `assistant_activity_state` SSE event carrying `reason: "context_compacting"`)
+- Per-tick context-window size (`contextWindowTokens` from `usage_update`)
+  climbs toward, then hovers at, the threshold
+- Cache-write tokens dominate (non-deterministic summary rewording
+  invalidates the cached prefix). Cache-write/read counts come from the
+  egress jail's recorded usage (`readUsageRecords()`), the cost/usage
+  authority — the SSE wire carries no cache fields.
 - Cost grows superlinearly once compaction thrash begins
 
 ## Success criteria (scored by metrics)
@@ -21,3 +55,6 @@ because the conservative `tail_start` barely shrinks the conversation.
 - `compaction-efficiency` > 0.3 (compaction actually frees significant context)
 - `cache-write-ratio` < 0.5 (prompt cache stays warm)
 - `compaction-pass-count` < 5 for 10 post-threshold ticks
+
+A buggy/thrashing assistant fails these (low efficiency, high cache-write
+ratio, many passes); the criteria document the fixed-behavior target.

--- a/evals/benchmarks/compaction-thrash/src/__tests__/runner.test.ts
+++ b/evals/benchmarks/compaction-thrash/src/__tests__/runner.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Unit tests for the compaction-thrash per-tick observation logic.
+ *
+ * These cover the three measurement fixes the benchmark depends on:
+ *   1. Compaction passes are counted from the on-the-wire
+ *      `assistant_activity_state` event with `reason: "context_compacting"`,
+ *      not the phantom top-level `context_compacting` message type.
+ *   2. Per-tick cache/token usage prefers egress-jail records (snake_case,
+ *      with cache fields) over SSE `usage_update` (no cache fields).
+ *   3. `contextWindowTokens` is captured from `usage_update` as a diagnostic.
+ *
+ * Pure functions only — synthetic events in, observation out. No network,
+ * no agent, no daemon.
+ */
+import { describe, expect, test } from "bun:test";
+
+import type { AgentEvent } from "../../../../src/lib/adapter";
+import { countCompactionPasses, observeTick } from "../runner";
+
+/** An `assistant_activity_state` event with the given reason. */
+function activityState(reason: string): AgentEvent {
+  return {
+    message: {
+      type: "assistant_activity_state",
+      reason,
+    },
+  };
+}
+
+/** A daemon SSE `usage_update` event (camelCase, no cache fields). */
+function usageUpdate(fields: {
+  inputTokens?: number;
+  outputTokens?: number;
+  contextWindowTokens?: number;
+}): AgentEvent {
+  return {
+    message: {
+      type: "usage_update",
+      inputTokens: fields.inputTokens ?? 0,
+      outputTokens: fields.outputTokens ?? 0,
+      ...(fields.contextWindowTokens !== undefined
+        ? { contextWindowTokens: fields.contextWindowTokens }
+        : {}),
+    },
+  };
+}
+
+/** An egress-jail usage record (flat snake_case, with cache fields). */
+function jailRecord(fields: {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+}): Record<string, unknown> {
+  return {
+    input_tokens: fields.input_tokens ?? 0,
+    output_tokens: fields.output_tokens ?? 0,
+    cache_creation_input_tokens: fields.cache_creation_input_tokens ?? 0,
+    cache_read_input_tokens: fields.cache_read_input_tokens ?? 0,
+    model: "claude-opus-4-8",
+    recorded_at: "2026-06-12T00:00:00.000Z",
+    request_path: "/v1/messages",
+  };
+}
+
+describe("countCompactionPasses", () => {
+  test("counts the on-the-wire activity-state context_compacting marker", () => {
+    const events: AgentEvent[] = [
+      activityState("message_dequeued"),
+      activityState("context_compacting"),
+      activityState("message_complete"),
+    ];
+    expect(countCompactionPasses(events)).toBe(1);
+  });
+
+  test("does NOT count the phantom top-level context_compacting if used as a reason on a non-activity event", () => {
+    // A `usage_update` (or any non-activity-state event) that happens to
+    // carry `reason: "context_compacting"` must not be counted — only the
+    // `assistant_activity_state` marker (or the internal type) counts.
+    const events: AgentEvent[] = [
+      { message: { type: "usage_update", reason: "context_compacting" } },
+    ];
+    expect(countCompactionPasses(events)).toBe(0);
+  });
+
+  test("counts the internal context_compacting message type if it ever reaches the wire", () => {
+    const events: AgentEvent[] = [{ message: { type: "context_compacting" } }];
+    expect(countCompactionPasses(events)).toBe(1);
+  });
+
+  test("ignores compaction_completed (the paired end event)", () => {
+    const events: AgentEvent[] = [
+      { message: { type: "context_compacting" } },
+      { message: { type: "compaction_completed" } },
+    ];
+    expect(countCompactionPasses(events)).toBe(1);
+  });
+
+  test("collapses consecutive same-reason markers into one pass", () => {
+    // Defensive: if a future daemon emitted the marker twice back-to-back
+    // for the SAME pass, it must still count once.
+    const events: AgentEvent[] = [
+      activityState("context_compacting"),
+      activityState("context_compacting"),
+    ];
+    expect(countCompactionPasses(events)).toBe(1);
+  });
+
+  test("counts two distinct passes separated by other activity", () => {
+    const events: AgentEvent[] = [
+      activityState("context_compacting"),
+      activityState("message_complete"),
+      activityState("thinking"),
+      activityState("context_compacting"),
+      activityState("message_complete"),
+    ];
+    expect(countCompactionPasses(events)).toBe(2);
+  });
+
+  test("zero passes when no compaction occurs", () => {
+    const events: AgentEvent[] = [
+      activityState("message_dequeued"),
+      usageUpdate({ inputTokens: 100 }),
+      activityState("message_complete"),
+    ];
+    expect(countCompactionPasses(events)).toBe(0);
+  });
+});
+
+describe("observeTick", () => {
+  test("prefers egress-jail records for token + cache usage", () => {
+    const events: AgentEvent[] = [
+      activityState("context_compacting"),
+      // SSE usage_update is present but should be IGNORED when jail records
+      // exist — these numbers must not leak into the observation.
+      usageUpdate({ inputTokens: 999, outputTokens: 999 }),
+      activityState("message_complete"),
+    ];
+    const jailRecords = [
+      jailRecord({
+        input_tokens: 5000,
+        output_tokens: 80,
+        cache_creation_input_tokens: 4000,
+        cache_read_input_tokens: 1000,
+      }),
+      jailRecord({
+        input_tokens: 6000,
+        output_tokens: 40,
+        cache_creation_input_tokens: 5500,
+        cache_read_input_tokens: 500,
+      }),
+    ];
+
+    const obs = observeTick(7, "observe", events, jailRecords);
+
+    expect(obs.tick).toBe(7);
+    expect(obs.phase).toBe("observe");
+    expect(obs.compactionEvents).toBe(1);
+    expect(obs.inputTokens).toBe(11000);
+    expect(obs.outputTokens).toBe(120);
+    expect(obs.cacheCreationInputTokens).toBe(9500);
+    expect(obs.cacheReadInputTokens).toBe(1500);
+  });
+
+  test("falls back to SSE usage_update when no jail records exist", () => {
+    const events: AgentEvent[] = [
+      usageUpdate({ inputTokens: 1200, outputTokens: 60 }),
+      usageUpdate({ inputTokens: 300, outputTokens: 10 }),
+    ];
+
+    const obs = observeTick(3, "seed", events, []);
+
+    expect(obs.inputTokens).toBe(1500);
+    expect(obs.outputTokens).toBe(70);
+    // No cache fields on the SSE wire → zero.
+    expect(obs.cacheCreationInputTokens).toBe(0);
+    expect(obs.cacheReadInputTokens).toBe(0);
+  });
+
+  test("captures the max contextWindowTokens from usage_update", () => {
+    const events: AgentEvent[] = [
+      usageUpdate({ inputTokens: 100, contextWindowTokens: 25000 }),
+      usageUpdate({ inputTokens: 100, contextWindowTokens: 31000 }),
+      usageUpdate({ inputTokens: 100, contextWindowTokens: 28000 }),
+    ];
+
+    const obs = observeTick(9, "observe", events, []);
+
+    expect(obs.contextWindowTokens).toBe(31000);
+  });
+
+  test("omits contextWindowTokens when no usage_update carries it", () => {
+    const events: AgentEvent[] = [activityState("message_complete")];
+    const obs = observeTick(1, "seed", events, []);
+    expect(obs.contextWindowTokens).toBeUndefined();
+  });
+});

--- a/evals/benchmarks/compaction-thrash/src/runner.ts
+++ b/evals/benchmarks/compaction-thrash/src/runner.ts
@@ -59,18 +59,39 @@ const DEFAULT_SEED_TICKS = 20;
 const DEFAULT_OBSERVE_TICKS = 10;
 
 /**
+ * Approximate number of estimator-tokens each tick message should add to
+ * conversation history. Sized so a span of seed ticks reliably carries the
+ * conversation across the compaction threshold even though the base context
+ * (system prompt + tool catalog, which the daemon's overflow gate includes
+ * in its estimate) is large and not precisely known to the benchmark.
+ *
+ * The daemon estimates ~1 token per 4 characters (`CHARS_PER_TOKEN` in
+ * `assistant/src/context/token-estimator.ts`), so a ~2000-token message is
+ * ~8000 characters. See `vellum-compaction-stress` profile setup and the
+ * arithmetic in `scenarios/cron-noop/SPEC.md` for how this pairs with the
+ * shrunken `maxInputTokens` window to produce repeated compaction.
+ */
+const TICK_TARGET_TOKENS = 2000;
+const TICK_TARGET_CHARS = TICK_TARGET_TOKENS * 4;
+
+/**
  * Build a deterministic cron-tick message. Each tick simulates a
  * scheduled polling job checking a Slack channel that produces no
  * actionable results — mimicking the real-world pattern that caused
  * unbounded context growth.
  *
- * The message is deliberately verbose (~500 tokens) so context grows
- * meaningfully with each tick, reaching the compaction threshold in
- * a reasonable number of iterations.
+ * The message is padded with deterministic record-keeping filler to
+ * ~`TICK_TARGET_TOKENS` estimator-tokens so context grows by a large,
+ * predictable amount each tick. This dominates the unknown base-context
+ * size so the compaction threshold is reached within the seed phase
+ * regardless of how big the assistant's system prompt + tool catalog are.
+ * The content stays deterministic (no randomness) so the reproduction is
+ * reliable — the only varying tokens are the tick number and an ISO
+ * timestamp.
  */
 function buildTickMessage(tickNumber: number): string {
   const timestamp = new Date().toISOString();
-  return [
+  const header = [
     `Schedule fired: check-project-updates (tick #${tickNumber})`,
     `Timestamp: ${timestamp}`,
     "",
@@ -103,7 +124,23 @@ function buildTickMessage(tickNumber: number): string {
     "- Consecutive quiet polls: " + tickNumber,
     "- Monitoring category: low-priority",
     "- SLA status: within bounds",
+    "",
+    "Per-thread audit (all unchanged since last poll):",
   ].join("\n");
+
+  // Deterministic filler: one audit line per monitored thread, repeated
+  // until the message reaches the target size. Pure function of the tick
+  // number, so two runs produce byte-identical messages.
+  const lines: string[] = [];
+  let i = 0;
+  while (header.length + lines.join("\n").length < TICK_TARGET_CHARS) {
+    lines.push(
+      `- thread-${i}: status=quiet last_activity=none watchers=0 ` +
+        `escalation=none note="no change observed during poll ${tickNumber}"`,
+    );
+    i++;
+  }
+  return `${header}\n${lines.join("\n")}`;
 }
 
 /** Per-tick observation record written to the scenario artifacts. */
@@ -111,16 +148,39 @@ export interface TickObservation {
   tick: number;
   phase: "seed" | "observe";
   eventCount: number;
-  /** Number of usage events that mention compaction-related call sites. */
+  /**
+   * Number of compaction passes observed this tick. Counted from the
+   * `assistant_activity_state` SSE event with `reason: "context_compacting"`
+   * (the on-the-wire marker the daemon emits once per proactive compaction
+   * pass), collapsing any consecutive same-reason events so one pass counts
+   * once. Defensively also counts the internal `context_compacting`
+   * AgentEvent type, though that type does not cross the SSE wire today.
+   */
   compactionEvents: number;
-  /** Total input tokens across all usage events for this tick. */
+  /**
+   * Total input tokens for this tick. Sourced from the egress jail's
+   * recorded usage records when present (the cost/usage authority per
+   * `evals/AGENTS.md`); falls back to SSE `usage_update` events otherwise.
+   */
   inputTokens: number;
-  /** Total output tokens across all usage events for this tick. */
+  /** Total output tokens for this tick (same source preference as input). */
   outputTokens: number;
-  /** Cache-creation input tokens observed this tick. */
+  /**
+   * Cache-creation (cache-write) input tokens this tick, from jail
+   * records when present, else from the SSE `usage_update` event's
+   * optional cache fields (older daemons omit them, leaving this 0 on
+   * the SSE path). This is the headline signal for cache-write
+   * amplification.
+   */
   cacheCreationInputTokens: number;
-  /** Cache-read input tokens observed this tick. */
+  /** Cache-read input tokens this tick (same sources as cache-creation). */
   cacheReadInputTokens: number;
+  /**
+   * Max `contextWindowTokens` seen on `usage_update` SSE events this tick.
+   * Diagnostic only: shows the conversation's context growing toward the
+   * compaction threshold. `undefined` when no usage_update carried it.
+   */
+  contextWindowTokens?: number;
 }
 
 const num = (v: unknown): number =>
@@ -151,59 +211,133 @@ function extractUsageFields(record: Record<string, unknown>): {
 }
 
 /**
- * Observe per-tick metrics from agent events.
+ * Count proactive-compaction passes from a tick's SSE events.
  *
- * Usage data arrives in two shapes depending on the source:
- * 1. **Daemon SSE (`usage_update`):** fields live directly on
- *    `event.message` (camelCase: `inputTokens`, `outputTokens`, …).
- * 2. **Egress-proxy recorded usage (wrapped):** a nested
- *    `event.message.usage` object (snake_case or camelCase).
+ * On the wire (NDJSON from `vellum events --json`), a proactive compaction
+ * pass surfaces as an `assistant_activity_state` event with
+ * `reason: "context_compacting"` — NOT as a top-level `context_compacting`
+ * message type (that type only exists inside the daemon's agent loop and is
+ * translated to the activity-state event before it leaves the daemon; see
+ * `assistant/src/daemon/conversation-agent-loop-handlers.ts` case
+ * "context_compacting").
  *
- * Compaction is detected via `context_compacting` events emitted by
- * the agent loop when compaction starts — not inferred from usage
- * call sites (which aren't on the SSE wire).
+ * The auto-compaction path emits exactly one such activity-state event per
+ * pass, so a single pass counts once. We additionally collapse *consecutive*
+ * `context_compacting` activity-state events into one pass: if a future
+ * daemon change ever emitted the marker more than once back-to-back for the
+ * same pass, this still counts one. A new pass is recognized when a
+ * non-compacting activity-state (or any non-activity-state-compacting gap)
+ * separates two compacting markers — the daemon brackets each pass with
+ * other activity states (e.g. "thinking", "message_complete").
+ *
+ * The internal `context_compacting` / `compaction_completed` message types
+ * are also handled (the former counts, the latter is ignored) so the counter
+ * stays correct if the wire ever carries them directly.
  */
-function observeTick(
+export function countCompactionPasses(events: AgentEvent[]): number {
+  let passes = 0;
+  let inCompactingRun = false;
+  for (const event of events) {
+    const msg = event.message;
+    const isActivityCompacting =
+      msg.type === "assistant_activity_state" &&
+      msg.reason === "context_compacting";
+    const isInternalCompacting = msg.type === "context_compacting";
+
+    if (isActivityCompacting || isInternalCompacting) {
+      if (!inCompactingRun) {
+        passes++;
+        inCompactingRun = true;
+      }
+      continue;
+    }
+    // `compaction_completed` is the paired end of an internal pass; treat it
+    // (and any other event) as the boundary that closes the current run so a
+    // later compacting marker is counted as a fresh pass.
+    inCompactingRun = false;
+  }
+  return passes;
+}
+
+/**
+ * Observe per-tick metrics for a single tick.
+ *
+ * Compaction passes are counted from SSE events (see
+ * {@link countCompactionPasses}).
+ *
+ * Token usage is sourced with a strict preference order, per
+ * `evals/AGENTS.md` ("Assistant-side usage must come from
+ * `readUsageRecords()` — never from emitted events"):
+ *
+ * 1. **Egress jail records** (`jailRecords`) — the cost/usage authority.
+ *    Flat snake_case Anthropic-usage records (`input_tokens`,
+ *    `output_tokens`, `cache_creation_input_tokens`,
+ *    `cache_read_input_tokens`). These carry the cache fields that the
+ *    benchmark exists to measure; the SSE wire does not. When any jail
+ *    records exist for the tick, they are the sole source of token counts.
+ * 2. **SSE `usage_update` fallback** — used only when no jail records
+ *    exist (e.g. a non-vellum species whose adapter has no jail). Fields
+ *    live directly on `event.message` (camelCase); there are no cache
+ *    fields, so cache-write/read stay zero on this path.
+ *
+ * `contextWindowTokens` (a diagnostic showing context growth toward the
+ * threshold) is always read from `usage_update` SSE events — the jail does
+ * not carry it — and reports the max seen this tick.
+ */
+export function observeTick(
   tickNumber: number,
   phase: "seed" | "observe",
   events: AgentEvent[],
+  jailRecords: Array<Record<string, unknown>>,
 ): TickObservation {
-  let compactionEvents = 0;
+  const compactionEvents = countCompactionPasses(events);
+
+  // Diagnostic: max context-window size reported by usage_update this tick.
+  let contextWindowTokens: number | undefined;
+  for (const event of events) {
+    const msg = event.message;
+    if (msg.type !== "usage_update") continue;
+    const cw = msg["contextWindowTokens"];
+    if (typeof cw === "number" && Number.isFinite(cw)) {
+      contextWindowTokens = Math.max(contextWindowTokens ?? 0, cw);
+    }
+  }
+
   let inputTokens = 0;
   let outputTokens = 0;
   let cacheCreationInputTokens = 0;
   let cacheReadInputTokens = 0;
 
-  for (const event of events) {
-    const msg = event.message;
-
-    // Count each compaction pass once via the start event.
-    // `context_compacting` fires when the pipeline begins;
-    // `compaction_completed` is the paired end event.
-    if (msg.type === "context_compacting") {
-      compactionEvents++;
-      continue;
-    }
-    if (msg.type === "compaction_completed") continue;
-
-    // Path 1: daemon SSE `usage_update` — fields on msg directly
-    if (msg.type === "usage_update") {
-      const fields = extractUsageFields(msg as Record<string, unknown>);
+  if (jailRecords.length > 0) {
+    // Preferred path: jail-recorded usage is the authority and the only
+    // source of cache fields.
+    for (const record of jailRecords) {
+      const fields = extractUsageFields(record);
       inputTokens += fields.inputTokens;
       outputTokens += fields.outputTokens;
       cacheCreationInputTokens += fields.cacheCreationInputTokens;
       cacheReadInputTokens += fields.cacheReadInputTokens;
-      continue;
     }
-
-    // Path 2: wrapped usage (egress-proxy records or synthetic events)
-    const usage = msg.usage;
-    if (usage && typeof usage === "object" && !Array.isArray(usage)) {
-      const fields = extractUsageFields(usage as Record<string, unknown>);
-      inputTokens += fields.inputTokens;
-      outputTokens += fields.outputTokens;
-      cacheCreationInputTokens += fields.cacheCreationInputTokens;
-      cacheReadInputTokens += fields.cacheReadInputTokens;
+  } else {
+    // Fallback: SSE usage_update events (no cache fields on the wire).
+    for (const event of events) {
+      const msg = event.message;
+      if (msg.type === "usage_update") {
+        const fields = extractUsageFields(msg as Record<string, unknown>);
+        inputTokens += fields.inputTokens;
+        outputTokens += fields.outputTokens;
+        cacheCreationInputTokens += fields.cacheCreationInputTokens;
+        cacheReadInputTokens += fields.cacheReadInputTokens;
+        continue;
+      }
+      const usage = msg.usage;
+      if (usage && typeof usage === "object" && !Array.isArray(usage)) {
+        const fields = extractUsageFields(usage as Record<string, unknown>);
+        inputTokens += fields.inputTokens;
+        outputTokens += fields.outputTokens;
+        cacheCreationInputTokens += fields.cacheCreationInputTokens;
+        cacheReadInputTokens += fields.cacheReadInputTokens;
+      }
     }
   }
 
@@ -216,6 +350,7 @@ function observeTick(
     outputTokens,
     cacheCreationInputTokens,
     cacheReadInputTokens,
+    ...(contextWindowTokens !== undefined ? { contextWindowTokens } : {}),
   };
 }
 
@@ -232,14 +367,19 @@ export interface RunCompactionThrashInput {
 }
 
 /**
- * Compute metrics from observed tick data.
+ * Compute metrics from observed tick data. All token inputs come from the
+ * per-tick usage source `observeTick` chose (egress-jail records when
+ * present, else SSE `usage_update`); cache-derived metrics are only
+ * meaningful when jail records were available, since the SSE wire carries
+ * no cache fields.
  *
- * - `compaction-efficiency`: fraction of total input tokens that were
+ * - `compaction-efficiency`: fraction of total cache tokens that were
  *   cache-read (vs cache-write) during the observation phase. Higher
  *   is better — means the prompt cache stays warm.
  * - `cache-write-ratio`: fraction of observation-phase input tokens
  *   spent on cache creation. Lower is better.
- * - `compaction-pass-count`: total compaction-related usage events
+ * - `compaction-pass-count`: total proactive-compaction passes
+ *   (one per `assistant_activity_state` `context_compacting` marker)
  *   during the observation phase. Lower is better.
  * - `cost-per-tick`: average total input+output tokens per observation
  *   tick (raw count, not USD — pricing depends on model).
@@ -314,7 +454,7 @@ function computeMetrics(observations: TickObservation[]): MetricResult[] {
     {
       name: "compaction-pass-count",
       score: totalCompactionPasses,
-      reason: `${totalCompactionPasses} compaction events across ${observePhase.length} observation ticks`,
+      reason: `${totalCompactionPasses} compaction passes across ${observePhase.length} observation ticks`,
       unit: "raw",
       metadata: {
         totalCompactionPasses,
@@ -418,6 +558,15 @@ export async function runCompactionThrashScenario(
     const observations: TickObservation[] = [];
     const transcript: TranscriptTurn[] = [];
 
+    // The egress jail accumulates one cumulative NDJSON record per upstream
+    // LLM call. We snapshot the cumulative count after each tick and slice
+    // out the records that landed during the tick, so per-tick token/cache
+    // usage comes from the cost/usage authority (`evals/AGENTS.md`) rather
+    // than from SSE events (which carry no cache fields). When the adapter
+    // has no jail (`readUsageRecords` absent), the slice is always empty and
+    // `observeTick` falls back to SSE `usage_update`.
+    let prevRecordCount = 0;
+
     for (let tick = 1; tick <= totalTicks; tick++) {
       const phase: "seed" | "observe" = tick <= seedTicks ? "seed" : "observe";
       const message = buildTickMessage(tick);
@@ -481,13 +630,21 @@ export async function runCompactionThrashScenario(
         }
       }
 
-      const observation = observeTick(tick, phase, events);
+      // Slice the jail records that landed during this tick. Reading the
+      // full cumulative list and slicing (rather than diffing token sums)
+      // keeps the authority single-sourced and tolerant of records that
+      // arrive slightly out of order within a tick.
+      const cumulativeRecords = (await agent.readUsageRecords?.()) ?? [];
+      const tickRecords = cumulativeRecords.slice(prevRecordCount);
+      prevRecordCount = cumulativeRecords.length;
+
+      const observation = observeTick(tick, phase, events, tickRecords);
       observations.push(observation);
 
       progress({
         step: "events",
         status: "done",
-        message: `[${phase}] Tick ${tick}: ${events.length} events, ${observation.compactionEvents} compaction, cache_write=${observation.cacheCreationInputTokens} cache_read=${observation.cacheReadInputTokens}`,
+        message: `[${phase}] Tick ${tick}: ${events.length} events, ${observation.compactionEvents} compaction, cache_write=${observation.cacheCreationInputTokens} cache_read=${observation.cacheReadInputTokens}, ctx=${observation.contextWindowTokens ?? "?"}`,
         turn: tick,
       });
 
@@ -514,6 +671,24 @@ export async function runCompactionThrashScenario(
       `${artifactDir}/tick-observations.json`,
       JSON.stringify(observations, null, 2),
     );
+
+    // Dump the agent's own usage ledger (per-call-site attribution with
+    // cache splits) as a diagnostic artifact. This is the daemon-side
+    // ground truth for "how much of the spend was compaction" —
+    // independent of both the SSE event stream and the egress jail.
+    const usageLedger = (await agent.readUsageLedger?.()) ?? null;
+    if (usageLedger !== null) {
+      await writeFile(
+        `${artifactDir}/usage-ledger.json`,
+        JSON.stringify(usageLedger, null, 2),
+      );
+      progress({
+        step: "metrics",
+        status: "start",
+        message: "Usage ledger captured (per-call-site attribution)",
+        detail: `${artifactDir}/usage-ledger.json`,
+      });
+    }
 
     // Compute and persist metrics.
     const metrics = computeMetrics(observations);

--- a/evals/profiles/vellum-compaction-stress/manifest.json
+++ b/evals/profiles/vellum-compaction-stress/manifest.json
@@ -1,3 +1,8 @@
 {
-  "species": "vellum"
+  "species": "vellum",
+  "description": "Vellum Assistant with a deliberately shrunken context window so a modest number of fat cron-tick messages crosses the compaction threshold and keeps re-triggering it. Used by the compaction-thrash benchmark to reproduce cache-write amplification from repeated, non-deterministic summary rewording. The shrunken window takes effect immediately (config_set invalidates the in-memory config cache and per-call resolution re-reads it; no daemon restart needed). Setup pins the active inference profile to a small, cheap model: thrash dynamics are driven by the estimator and thresholds, not model quality, so benchmark runs should not burn frontier-model spend. The window and model are patched on the ACTIVE profile (not just llm.default) because the active profile floats above defaults in main-agent config resolution.",
+  "setup": [
+    "assistant config set llm.default.contextWindow.maxInputTokens 40000",
+    "p=$(assistant config get llm.activeProfile | tail -1); if [ -n \"$p\" ] && [ \"$p\" != \"null\" ]; then assistant config set \"llm.profiles.$p.contextWindow.maxInputTokens\" 40000 && assistant config set \"llm.profiles.$p.model\" claude-haiku-4-5-20251001 && assistant config set \"llm.profiles.$p.maxTokens\" 8192 && assistant config set \"llm.profiles.$p.thinking.enabled\" false; fi"
+  ]
 }

--- a/evals/src/lib/__tests__/vellum-adapter.test.ts
+++ b/evals/src/lib/__tests__/vellum-adapter.test.ts
@@ -117,8 +117,22 @@ describe("VellumAgent", () => {
 
     expect(agent.id).toBe("eval-run-1");
     expect(agent.conversationKey).toBe("evals:timeline-recall:eval-run-1");
-    // Recording sidecar adds docker build + run calls
+    // runs[0] is the bundled feature-flag registry sync — it runs
+    // BEFORE hatch so a fresh worktree (where the gitignored registry
+    // copies don't exist yet) produces a gateway that recognizes flag
+    // keys. `meta/feature-flags/sync-bundled-copies.ts` exists in this
+    // repo, so the existsSync guard fires here.
     expect(runner.runs[0]).toEqual({
+      command: "bun",
+      args: ["run", "meta/feature-flags/sync-bundled-copies.ts"],
+      opts: {
+        cwd: ADAPTER_REPO_ROOT,
+        logPath: expect.stringMatching(/\/subprocess-registry-sync\.log$/),
+        logStep: "registry-sync",
+      },
+    });
+    // Recording sidecar adds docker build + run calls
+    expect(runner.runs[1]).toEqual({
       command: "vellum",
       args: [
         "hatch",
@@ -142,18 +156,18 @@ describe("VellumAgent", () => {
         logStep: "hatch",
       },
     });
-    expect(runner.runs[1]).toEqual({
+    expect(runner.runs[2]).toEqual({
       command: "docker",
       args: ["rm", "-f", "eval-run-1-assistant-egress-jail"],
     });
     // Build command
-    expect(runner.runs[2].command).toBe("docker");
-    expect(runner.runs[2].args[0]).toBe("build");
-    expect(runner.runs[2].args[1]).toBe("-t");
-    expect(runner.runs[2].args[2]).toBe("vellum-evals-recording-jail:local");
-    // Run command (detached recording jail)
     expect(runner.runs[3].command).toBe("docker");
-    expect(runner.runs[3].args.slice(0, 6)).toEqual([
+    expect(runner.runs[3].args[0]).toBe("build");
+    expect(runner.runs[3].args[1]).toBe("-t");
+    expect(runner.runs[3].args[2]).toBe("vellum-evals-recording-jail:local");
+    // Run command (detached recording jail)
+    expect(runner.runs[4].command).toBe("docker");
+    expect(runner.runs[4].args.slice(0, 6)).toEqual([
       "run",
       "-d",
       "--name",
@@ -161,14 +175,14 @@ describe("VellumAgent", () => {
       "--network",
       "container:eval-run-1-assistant",
     ]);
-    expect(runner.runs[3].args).toContain("--cap-add");
-    expect(runner.runs[3].args).toContain("NET_ADMIN");
-    expect(runner.runs[3].args).toContain("evals.vellum.ai/egress-recording=1");
+    expect(runner.runs[4].args).toContain("--cap-add");
+    expect(runner.runs[4].args).toContain("NET_ADMIN");
+    expect(runner.runs[4].args).toContain("evals.vellum.ai/egress-recording=1");
     // Species default feature flag — runs between jail apply (which
-    // now includes the CA handoff at runs[4..5]) and the first setup
+    // now includes the CA handoff at runs[5..6]) and the first setup
     // command. See VELLUM_DEFAULT_FEATURE_FLAGS in the adapter for the
     // canonical list.
-    expect(runner.runs[6]).toEqual({
+    expect(runner.runs[7]).toEqual({
       command: "vellum",
       args: [
         "flags",
@@ -184,7 +198,7 @@ describe("VellumAgent", () => {
       },
     });
     // Setup command — gets a per-step subprocess-setup-N.log
-    expect(runner.runs[7]).toEqual({
+    expect(runner.runs[8]).toEqual({
       command: "vellum",
       args: [
         "exec",
@@ -249,17 +263,19 @@ describe("VellumAgent", () => {
     await preStageRecordingCa(agent.id);
     await agent.hatch();
 
-    // runs[0..3] are hatch + jail rm/build/run; runs[4..5] are the CA
-    // handoff (docker cp + docker exec update-ca-certificates) — same
-    // as the canonical happy-path test. Confirm the count to anchor
-    // the indices: 6 pre-flag steps + 1 species default flag
-    // (`external-plugins`) + 1 setup command = 8.
-    expect(runner.runs.length).toBe(8);
-    expect(runner.runs[0].args[0]).toBe("hatch");
+    // runs[0] is the registry sync; runs[1] is hatch; runs[2..4] are
+    // jail rm/build/run; runs[5..6] are the CA handoff (docker cp +
+    // docker exec update-ca-certificates) — same as the canonical
+    // happy-path test. Confirm the count to anchor the indices: 7
+    // pre-flag steps + 1 species default flag (`external-plugins`) + 1
+    // setup command = 9.
+    expect(runner.runs.length).toBe(9);
+    expect(runner.runs[0].command).toBe("bun");
+    expect(runner.runs[1].args[0]).toBe("hatch");
 
     // Species default: `external-plugins` is always flipped ON for
     // vellum hatches, regardless of manifest contents.
-    expect(runner.runs[6]).toEqual({
+    expect(runner.runs[7]).toEqual({
       command: "vellum",
       args: [
         "flags",
@@ -277,7 +293,7 @@ describe("VellumAgent", () => {
 
     // Setup command lands AFTER the species default flag — this is the
     // chicken-and-egg property the ordering protects.
-    expect(runner.runs[7]).toEqual({
+    expect(runner.runs[8]).toEqual({
       command: "vellum",
       args: [
         "exec",
@@ -317,10 +333,10 @@ describe("VellumAgent", () => {
     await preStageRecordingCa(agent.id);
     await agent.hatch();
 
-    // hatch + jail rm/build/run + CA install (cp + update-ca-certs) + 1
-    // species default flag = 7. No setup commands.
-    expect(runner.runs.length).toBe(7);
-    expect(runner.runs[6]).toEqual({
+    // registry sync + hatch + jail rm/build/run + CA install (cp +
+    // update-ca-certs) + 1 species default flag = 8. No setup commands.
+    expect(runner.runs.length).toBe(8);
+    expect(runner.runs[7]).toEqual({
       command: "vellum",
       args: [
         "flags",
@@ -464,7 +480,7 @@ describe("VellumAgent", () => {
         "hello",
       ],
       ["docker", "rm", "-f", "eval-run-2-assistant-egress-jail"],
-      ["vellum", "retire", "eval-run-2"],
+      ["vellum", "retire", "eval-run-2", "--yes"],
       ["docker", "rm", "-f", "eval-run-2-assistant"],
       ["docker", "rm", "-f", "eval-run-2-gateway"],
       ["docker", "rm", "-f", "eval-run-2-credential-executor"],

--- a/evals/src/lib/adapter.ts
+++ b/evals/src/lib/adapter.ts
@@ -76,6 +76,17 @@ export interface BaseAgent {
    */
   isTurnComplete(event: AgentEvent): boolean;
   readUsageRecords?(): Promise<Array<Record<string, unknown>>>;
+  /**
+   * Read the agent's own per-call-site usage accounting, when the
+   * species keeps one (e.g. the Vellum daemon's usage ledger).
+   * Complements `readUsageRecords()`: the egress jail observes wire
+   * traffic, while the ledger carries the agent's internal attribution
+   * (which call site — main agent vs compaction vs background — spent
+   * the tokens, including cache-creation/read splits). Returns `null`
+   * when the species has no ledger or the read fails; callers treat it
+   * as a best-effort diagnostic, never as the cost authority.
+   */
+  readUsageLedger?(): Promise<Record<string, unknown> | null>;
   shutdown(): Promise<void>;
   /**
    * Write a file into the agent's workspace. Optional capability:

--- a/evals/src/lib/adapters/vellum.ts
+++ b/evals/src/lib/adapters/vellum.ts
@@ -1,4 +1,5 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -296,6 +297,47 @@ export class VellumAgent implements BaseAgent {
     //   under our `instanceName` are ours.
     let hatchSucceeded = false;
     try {
+      // Generate the bundled feature-flag registry copies BEFORE hatch.
+      //
+      // The gateway/assistant Docker images need
+      // `gateway/src/feature-flag-registry.json` +
+      // `assistant/src/config/feature-flag-registry.json`. Those are
+      // generated (gitignored) from the canonical
+      // `meta/feature-flags/feature-flag-registry.json` by
+      // `sync-bundled-copies.ts` — normally run via postinstall or CI
+      // before image builds. But the Docker build context excludes
+      // `meta/`, so a fresh worktree that runs evals (which
+      // `vellum hatch --source <repoRoot>`) produces a gateway with NO
+      // registry: it then rejects every `vellum flags set` with
+      // "Unknown flag key" and hatch hard-fails. Running the sync here,
+      // against the repo root, makes a fresh checkout self-sufficient.
+      //
+      // Skipped silently when the script is absent (gateway-only
+      // layouts or a species whose source tree doesn't ship meta/).
+      const repoRoot = repoRootFromAdapter();
+      const registrySyncScript = join(
+        repoRoot,
+        "meta",
+        "feature-flags",
+        "sync-bundled-copies.ts",
+      );
+      if (existsSync(registrySyncScript)) {
+        const registrySync = await this.runner.run(
+          "bun",
+          ["run", "meta/feature-flags/sync-bundled-copies.ts"],
+          {
+            cwd: repoRoot,
+            logPath:
+              runArtifacts(this.id).runDir + "/subprocess-registry-sync.log",
+            logStep: "registry-sync",
+          },
+        );
+        assertSuccess(
+          registrySync,
+          `sync bundled feature-flag registry for profile ${this.profile.id}`,
+        );
+      }
+
       // Forward LLM provider API keys from the eval process env into the
       // hatch subprocess explicitly. The Vellum docker StatefulSet spec
       // conditionally re-forwards each of these from `vellum hatch`'s env
@@ -670,6 +712,44 @@ export class VellumAgent implements BaseAgent {
     return this.jail?.readUsageRecords() ?? [];
   }
 
+  /**
+   * Dump the daemon's persisted usage ledger, grouped by call site,
+   * plus all-time totals. The ledger records every LLM call with cache
+   * token splits and the call site that spent it (main agent vs
+   * compaction vs background work), so it directly answers "what
+   * fraction of spend was compaction" — the question the
+   * compaction-thrash benchmark exists to ask. Best-effort: returns
+   * `null` on any failure so a missing CLI surface never fails a run
+   * at collection time.
+   */
+  async readUsageLedger(): Promise<Record<string, unknown> | null> {
+    this.assertHatched();
+    try {
+      const read = async (subcommand: string): Promise<unknown> => {
+        const result = await this.runner.run(this.cliCommand, [
+          "exec",
+          this.id,
+          "--",
+          ...shellWords(`assistant usage ${subcommand} --range all --json`),
+        ]);
+        if (result.exitCode !== 0) return null;
+        try {
+          return JSON.parse(result.stdout);
+        } catch {
+          return null;
+        }
+      };
+      const [byCallSite, totals] = await Promise.all([
+        read("breakdown --group-by call_site"),
+        read("totals"),
+      ]);
+      if (byCallSite === null && totals === null) return null;
+      return { byCallSite, totals };
+    } catch {
+      return null;
+    }
+  }
+
   async shutdown(): Promise<void> {
     if (this.stopped) return;
     this.stopped = true;
@@ -722,9 +802,12 @@ export class VellumAgent implements BaseAgent {
     let retireResult: { exitCode: number; stderr: string } | undefined;
     let retireError: unknown;
     try {
+      // `--yes`: retire prompts for confirmation and refuses outright in a
+      // non-interactive terminal, which is where every eval run lives.
       retireResult = await this.runner.run(this.cliCommand, [
         "retire",
         this.id,
+        "--yes",
       ]);
     } catch (err) {
       retireError = err;

--- a/evals/src/lib/egress/recording/Dockerfile
+++ b/evals/src/lib/egress/recording/Dockerfile
@@ -18,12 +18,11 @@ FROM mitmproxy/mitmproxy:11.0.2
 
 USER root
 
-# `iptables` + `iproute2` for the netns policy. `conntrack` lets the
-# apply script flush pre-jail flows so connections the assistant opened
-# before the jail attached are re-evaluated against the NAT REDIRECT
-# rather than bypassing it. `getent` (for hostname resolution in the
-# apply script) is in `libc-bin` which is already in the base image.
-# `su` is from `util-linux` (also already in base).
+# `iptables` + `iproute2` for the netns policy; `conntrack` so the
+# apply script can evict pre-jail 443 flows (connections opened before
+# the sidecar started carry no REDIRECT verdict and would bypass
+# mitmproxy over HTTP keep-alive forever). `su` is from `util-linux`
+# (already in base).
 RUN apt-get update \
   && apt-get install -y --no-install-recommends iptables iproute2 conntrack \
   && rm -rf /var/lib/apt/lists/*

--- a/evals/src/lib/egress/recording/__tests__/apply-recording-jail.test.ts
+++ b/evals/src/lib/egress/recording/__tests__/apply-recording-jail.test.ts
@@ -102,9 +102,10 @@ describe("apply-recording-jail.sh", () => {
   });
 
   test("requires ALLOW_HOSTS so a misconfig fails loud, not silent", async () => {
-    // A missing ALLOW_HOSTS means no upstream the recording sidecar
-    // can reach — running mitmproxy in that state would record
-    // nothing and the jail would silently break every eval run. The
+    // ALLOW_HOSTS is consumed by the addon (proxy-layer allowlist)
+    // now, not by this script — but the script keeps the guard as a
+    // central fail-loud misconfig check. A sidecar booted without it
+    // would let the addon 403 every request once a mock misses. The
     // explicit guard at the top of the script makes that case
     // observable in `docker logs <jail-name>`.
     const lines = await readScript();
@@ -115,5 +116,47 @@ describe("apply-recording-jail.sh", () => {
     expect(guardCheck).toBeGreaterThanOrEqual(0);
     expect(guardExit).toBeGreaterThan(guardCheck);
     expect(guardExitCode).toBeGreaterThan(guardExit);
+  });
+
+  test("accepts mitmproxy's own upstream legs so DNS rotation can't strand a flow", async () => {
+    // The DNS-rotation fix: instead of resolving ALLOW_HOSTS to IPs
+    // once and pinning a per-IP ACCEPT (which goes stale when
+    // api.anthropic.com rotates IPs mid-run), the filter table lets
+    // mitmproxy ($MITM_UID) reach any IP. mitmproxy is free to dial
+    // whatever DNS returns; the hostname allowlist is enforced in the
+    // addon. This UID-scoped ACCEPT must land after the DROP policy is
+    // the active default so it's a genuine exception to block-by-default.
+    const lines = await readScript();
+    const policyDrop = findLine(lines, "iptables -P OUTPUT DROP");
+    const mitmAccept = findLine(
+      lines,
+      'iptables -A OUTPUT -m owner --uid-owner "$MITM_UID" -j ACCEPT',
+    );
+
+    expect(policyDrop).toBeGreaterThanOrEqual(0);
+    expect(mitmAccept).toBeGreaterThan(policyDrop);
+  });
+
+  test("does NOT resolve ALLOW_HOSTS to IPs (the stale-per-IP-ACCEPT design is gone)", async () => {
+    // Regression guard for the DNS-rotation bug. The old script ran
+    // `getent ahostsv4 $host` to resolve each allowlisted host to IPv4s
+    // at container start and installed a per-IP ACCEPT. That snapshot
+    // went stale when low-TTL hosts (api.anthropic.com) rotated IPs,
+    // stranding mitmproxy's upstream connect against the default DROP.
+    // Re-introducing any one-shot DNS resolution would bring the bug
+    // back, so we assert no EXECUTABLE line resolves hosts or pins a
+    // per-IP ACCEPT. Comment lines (which still document the old design
+    // for posterity) are stripped first so the doc reference doesn't
+    // trip the guard.
+    const codeLines = (await readScript()).filter(
+      (line) => !line.trimStart().startsWith("#"),
+    );
+    const code = codeLines.join("\n");
+    expect(code).not.toContain("getent");
+    expect(code).not.toContain("ahostsv4");
+    // No `-d <ip>` style ACCEPT for ALLOW_HOSTS members. The only
+    // destination-scoped ACCEPT that survives is the loopback one
+    // (127.0.0.0/8), which the test above already pins.
+    expect(code).not.toMatch(/--dport 443 -j ACCEPT/);
   });
 });

--- a/evals/src/lib/egress/recording/addon.py
+++ b/evals/src/lib/egress/recording/addon.py
@@ -1,5 +1,5 @@
 """
-mitmproxy addon. Two responsibilities:
+mitmproxy addon. Three responsibilities:
 
   1. **Recording.** Wires the `response` hook into the pure-function
      parser (`usage_parser.parse_anthropic_messages_response`) and
@@ -13,7 +13,19 @@ mitmproxy addon. Two responsibilities:
      `assistant plugins install` traffic at the egress jail and serve
      plugins from a fixtures directory bind-mounted into the sidecar,
      instead of allowing api.github.com / raw.githubusercontent.com
-     through the iptables allowlist.
+     out to the real GitHub.
+  3. **Allowlist enforcement.** Also in the `request` hook, after the
+     mock handler has had its chance: any request whose `pretty_host`
+     is not in `ALLOW_HOSTS` (and was not satisfied by a mock) is
+     short-circuited with a 403. This is the jail's primary egress
+     control now — it replaces the per-IP iptables ACCEPT rules that
+     `apply-recording-jail.sh` used to install from a one-shot DNS
+     resolution. Those broke under DNS rotation: api.anthropic.com
+     rotates IPs with low TTLs, so a fresh IP minutes into a run had
+     no matching ACCEPT and mitmproxy's upstream connect hit the
+     default DROP. Enforcing by hostname at the proxy is rotation-proof
+     — mitmproxy is free to dial whatever IP DNS returns, and the
+     allowlist decision is made on the stable Host header instead.
 
 Hosts intercepted for response parsing:
   - `api.anthropic.com` (the only provider parsed in v1)
@@ -23,8 +35,12 @@ set):
   - `api.github.com` — plugin Contents API listings
   - `raw.githubusercontent.com` — plugin file downloads
 
-Other allowlisted hosts (OpenAI, Gemini) flow through mitmproxy and out
-the egress jail just like before — the recording addon doesn't touch
+ALL TLS/443 flows are intercepted now (entrypoint.sh no longer passes
+`--allow-hosts` to mitmdump). That is safe because only the assistant
+container trusts the mitmproxy CA; the gateway / credential-executor
+containers don't share this netns, so their traffic never reaches us.
+Other allowlisted hosts (OpenAI, Gemini, the platform) flow through
+mitmproxy and out the egress jail — the recording addon doesn't touch
 their bodies. Follow-up tickets will add per-provider parsers as needed.
 
 Design notes:
@@ -79,8 +95,29 @@ MAX_PAYLOAD_CHARS = int(os.environ.get("RECORDING_MAX_PAYLOAD_CHARS", "32768"))
 
 # When set, the request hook serves plugin install traffic from this
 # directory instead of letting it egress. Unset = mocking disabled,
-# requests fall through to the iptables DROP-default policy.
+# requests fall through to the allowlist check (and out, if allowed).
 PLUGIN_FIXTURES_DIR: Optional[str] = os.environ.get("PLUGIN_FIXTURES_DIR")
+
+
+def _parse_allow_hosts(raw: Optional[str]) -> frozenset:
+    """Parse the comma-separated ALLOW_HOSTS env var into a lowercase set.
+
+    Hosts are compared case-insensitively (DNS is case-insensitive and
+    `pretty_host` can echo whatever case the client sent), so we
+    normalize both the allowlist and the request host to lowercase.
+    Blank entries and surrounding whitespace are stripped so a trailing
+    comma or a `"a, b"` style value parses cleanly.
+    """
+    if not raw:
+        return frozenset()
+    return frozenset(
+        host.strip().lower() for host in raw.split(",") if host.strip()
+    )
+
+
+# Hostname allowlist enforced in the `request` hook. Parsed once at
+# module load — ALLOW_HOSTS is fixed for the lifetime of the sidecar.
+ALLOW_HOSTS: frozenset = _parse_allow_hosts(os.environ.get("ALLOW_HOSTS"))
 
 # Lock guards the NDJSON file writer — mitmproxy can fire `response`
 # hooks concurrently for parallel requests.
@@ -116,49 +153,84 @@ def _append_ndjson(record: dict) -> None:
 def request(flow) -> None:  # type: ignore[no-untyped-def]
     """mitmproxy hook fired before mitmproxy makes the upstream request.
 
-    Dispatches to `mock_github_handler.handle`. On a match the handler
-    returns a `(status, content_type, body)` tuple; we set
-    `flow.response` inline so mitmproxy short-circuits and never makes
-    the upstream call. On a miss the handler returns `None` and the
-    request flows through to the response hook + addon's normal
-    upstream re-emission.
+    Two stages, in order:
 
-    Disabled when `PLUGIN_FIXTURES_DIR` is unset (no fixtures dir
-    bind-mounted) — every request falls through to the upstream path.
+      1. **Mock.** When `PLUGIN_FIXTURES_DIR` is set, dispatch to
+         `mock_github_handler.handle`. On a match the handler returns a
+         `(status, content_type, body)` tuple; we set `flow.response`
+         inline so mitmproxy short-circuits and never makes the upstream
+         call, and we return immediately (a mocked request is allowed by
+         construction — it never egresses).
+
+      2. **Allowlist.** If the request wasn't mocked, enforce the
+         hostname allowlist: when `request.pretty_host` is not in
+         `ALLOW_HOSTS` (case-insensitive exact match), short-circuit
+         with a 403 so mitmproxy never makes the upstream call. Allowed
+         hosts fall through to the response hook + normal upstream
+         re-emission.
+
+    This is the jail's egress control. Mock-then-allowlist ordering
+    matters: GitHub hosts are intentionally NOT in `ALLOW_HOSTS` (they're
+    served from disk), so the mock has to win before the allowlist would
+    403 them.
+
     Errors are swallowed via the same ctx.log pattern as the response
-    hook so a single bad request can never crash mitmproxy.
+    hook so a single bad request can never crash mitmproxy. On an
+    unexpected error we fail OPEN (let the request through) rather than
+    risk wedging a whole eval run — the iptables DROP-default + per-flow
+    REDIRECT still backstops any truly non-allowlisted path, and a
+    non-CA-trusting client's handshake fails regardless.
     """
-    if http is None or PLUGIN_FIXTURES_DIR is None:
+    if http is None:
         return
     try:
         request = flow.request
         method = request.method
+        host = (request.pretty_host or "").lower()
         # `--showhost` in entrypoint.sh makes `pretty_host` use the
         # original Host header from the client, so we reconstruct the
         # same URL the assistant CLI dialed before the iptables
         # REDIRECT bounced it into mitmproxy.
         url = f"https://{request.pretty_host}{request.path}"
-        result = mock_github_handler.handle(
-            method=method,
-            url=url,
-            fixtures_dir=PLUGIN_FIXTURES_DIR,
-        )
-        if result is None:
+
+        # Stage 1: mock (only when a fixtures dir is bind-mounted).
+        if PLUGIN_FIXTURES_DIR is not None:
+            result = mock_github_handler.handle(
+                method=method,
+                url=url,
+                fixtures_dir=PLUGIN_FIXTURES_DIR,
+            )
+            if result is not None:
+                status, content_type, body = result
+                flow.response = http.Response.make(
+                    status,
+                    body,
+                    {
+                        "content-type": content_type,
+                        "x-mocked-by": "vellum-evals-egress-mock",
+                    },
+                )
+                _log_info(
+                    f"mock_github: {method} {url} -> {status} "
+                    f"({len(body)} bytes)"
+                )
+                return
+
+        # Stage 2: hostname allowlist. A request that reaches here was
+        # not mocked; block it unless its host is explicitly allowed.
+        if host not in ALLOW_HOSTS:
+            flow.response = http.Response.make(
+                403,
+                b"blocked by vellum-evals egress jail: host not in allowlist\n",
+                {"content-type": "text/plain; charset=utf-8"},
+            )
+            _log_info(
+                f"egress-jail: blocked {method} {url} "
+                f"(host {host!r} not in allowlist)"
+            )
             return
-        status, content_type, body = result
-        flow.response = http.Response.make(
-            status,
-            body,
-            {
-                "content-type": content_type,
-                "x-mocked-by": "vellum-evals-egress-mock",
-            },
-        )
-        _log_info(
-            f"mock_github: {method} {url} -> {status} ({len(body)} bytes)"
-        )
     except Exception as err:  # noqa: BLE001 -- never crash mitmproxy
-        _log_warn(f"mock_github: hook raised {type(err).__name__}: {err}")
+        _log_warn(f"request: hook raised {type(err).__name__}: {err}")
 
 
 def _decoded_body(message) -> bytes:  # type: ignore[no-untyped-def]

--- a/evals/src/lib/egress/recording/apply-recording-jail.sh
+++ b/evals/src/lib/egress/recording/apply-recording-jail.sh
@@ -3,22 +3,46 @@
 #
 # Two layers:
 #
-#   1. DROP-by-default OUTPUT filter (same as the non-recording jail) —
-#      only the configured ALLOW_HOSTS keep outbound 443/80 access. The
-#      mitmproxy process inside this container is itself an outbound
-#      client to api.anthropic.com etc., so it needs the same allowlist.
+#   1. DROP-by-default OUTPUT filter. Loopback, conntrack-established,
+#      and DNS are allowed; everything else is dropped UNLESS it is
+#      mitmproxy's own outbound traffic (matched by UID). mitmproxy is
+#      the single egress point — every other outbound TCP/443 flow is
+#      bounced into it by the NAT REDIRECT (layer 2) and re-emitted by
+#      mitmproxy's own upstream legs, which the UID-owner ACCEPT below
+#      lets through to whatever IP the host resolved.
+#
+#      We deliberately do NOT install per-IP ACCEPT rules for the
+#      allowlisted hosts. The previous design resolved ALLOW_HOSTS to
+#      IPv4s ONCE at container start (`getent ahostsv4`) and pinned an
+#      ACCEPT per IP. api.anthropic.com rotates IPs with low TTLs, so
+#      minutes into a run the daemon dials a fresh IP: the NAT REDIRECT
+#      still bounces it into mitmproxy, but mitmproxy's upstream connect
+#      to the rotated IP hit the default DROP and every LLM call failed
+#      with "Connection error". Allowlist enforcement now lives at the
+#      proxy layer (addon.py matches `request.pretty_host` against
+#      ALLOW_HOSTS), so the filter table only needs to let mitmproxy
+#      reach any IP — DNS rotation can no longer strand a flow.
 #
 #   2. NAT OUTPUT REDIRECT — bounce outbound TCP/443 to mitmproxy's
 #      listening port (default 8443) so the mitmproxy proc terminates
-#      TLS, records usage, and re-emits the request upstream. The
-#      REDIRECT must NOT apply to mitmproxy's own outbound traffic; we
-#      exempt it by UID with `! -m owner --uid-owner <MITM_UID>`.
+#      TLS, records usage, enforces the hostname allowlist, and
+#      re-emits allowed requests upstream. The REDIRECT must NOT apply
+#      to mitmproxy's own outbound traffic; we exempt it by UID with
+#      `! -m owner --uid-owner <MITM_UID>` (a RETURN that precedes the
+#      REDIRECT).
 #
 # Run as the entrypoint of the recording sidecar; this script must
 # finish before `mitmdump` is exec'd so the rules are in place.
 
 set -eu
 
+# ALLOW_HOSTS is no longer consumed by this script — hostname allowlist
+# enforcement moved to the proxy layer (addon.py). We still require it
+# here as a fail-loud misconfig guard: it is the env contract the addon
+# depends on, and a sidecar booted without it would silently let the
+# addon block every request once mocking misses. Keeping the guard
+# central means the failure surfaces in `docker logs <jail-name>`
+# regardless of which layer ultimately reads the value.
 ALLOW_HOSTS="${ALLOW_HOSTS:-}"
 MITM_UID="${MITM_UID:-1000}"
 MITM_PORT="${MITM_PORT:-8443}"
@@ -28,15 +52,16 @@ if [ -z "$ALLOW_HOSTS" ]; then
   exit 64
 fi
 
-# ---- filter table: outbound allowlist (block-by-default; only the
-# resolved ALLOW_HOSTS IPs may egress)
+# ---- filter table: outbound DROP-by-default. Only loopback,
+# conntrack-established, DNS, and mitmproxy's own upstream legs egress;
+# everything else is bounced into mitmproxy by the NAT REDIRECT below.
 iptables -F OUTPUT
 iptables -P OUTPUT DROP
 # Accept by destination *before* the `-o lo` rule: on some kernels
 # (notably colima's macOS Virtualization.Framework VM), the filter
 # OUTPUT chain's `-o` interface match is evaluated against the
 # pre-routing interface, not the post-DNAT one. That means packets the
-# NAT OUTPUT REDIRECT below rewrites from `<allowed_ip>:443` to
+# NAT OUTPUT REDIRECT below rewrites from `<dest>:443` to
 # `127.0.0.1:<MITM_PORT>` still see `-o eth0` here and fall through to
 # the default DROP — silently breaking mitmproxy interception.
 # Matching by destination IP catches the DNAT'd loopback packets
@@ -45,25 +70,25 @@ iptables -P OUTPUT DROP
 # destined traffic mitmproxy emits over lo (none today, but cheap).
 iptables -A OUTPUT -d 127.0.0.0/8 -j ACCEPT
 iptables -A OUTPUT -o lo -j ACCEPT
+# REDIRECTed 443 packets re-enter this chain with their destination
+# rewritten to a local address and dport set to $MITM_PORT. Which local
+# address depends on the kernel: classic behavior is 127.0.0.1 (caught
+# by the 127.0.0.0/8 rule above), but some VM kernels (Docker Desktop /
+# colima) rewrite to the egress interface's primary address instead,
+# which matches neither rule above and would fall through to the DROP.
+# Accept by (local dst, mitm dport) to be robust across both.
+iptables -A OUTPUT -p tcp --dport "$MITM_PORT" -m addrtype --dst-type LOCAL -j ACCEPT
 iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
 iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT
-
-OLD_IFS="$IFS"
-IFS=','
-for host in $ALLOW_HOSTS; do
-  IFS="$OLD_IFS"
-  host=$(printf '%s' "$host" | tr -d '[:space:]')
-  [ -n "$host" ] || continue
-
-  getent ahostsv4 "$host" | awk '{print $1}' | sort -u | while read -r ip; do
-    [ -n "$ip" ] || continue
-    iptables -A OUTPUT -p tcp -d "$ip" --dport 443 -j ACCEPT
-    iptables -A OUTPUT -p tcp -d "$ip" --dport 80 -j ACCEPT
-  done
-  IFS=','
-done
-IFS="$OLD_IFS"
+# mitmproxy's upstream legs reach whatever IP the host resolved for an
+# allowlisted host. This replaces the old per-IP ALLOW_HOSTS ACCEPT
+# loop, which broke under DNS rotation (a fresh IP minutes into a run
+# had no matching ACCEPT and hit the default DROP). The hostname
+# allowlist is enforced at the proxy layer (addon.py), so this broad
+# UID-scoped ACCEPT is safe: only mitmproxy runs as $MITM_UID, and it
+# only forwards requests whose host is in ALLOW_HOSTS.
+iptables -A OUTPUT -m owner --uid-owner "$MITM_UID" -j ACCEPT
 
 # ---- nat table: REDIRECT 443 → mitmproxy, exempting mitmproxy itself.
 #
@@ -71,7 +96,19 @@ IFS="$OLD_IFS"
 # the REDIRECT so packets that are MITM-originated don't loop. The
 # exemption is matched by the mitmproxy process UID inside this
 # container's user namespace.
-iptables -t nat -F OUTPUT
+#
+# NEVER flush this chain (`-t nat -F OUTPUT`): Docker's embedded DNS
+# (the 127.0.0.11 resolver in /etc/resolv.conf) is implemented as
+# dockerd-installed DNAT rules in this same chain, mapping
+# 127.0.0.11:53 to the resolver's real per-container port. Flushing
+# the chain silently destroys DNS for the entire shared netns — every
+# warm connection keeps working until it dies, then every new
+# connection fails with a resolution timeout that surfaces as
+# "Connection error" minutes into a run. (Found live; this was the
+# root cause of all-provider-calls-failing mid-eval.) Instead, delete
+# exactly our own rules if present (idempotent re-apply), then append.
+iptables -t nat -D OUTPUT -p tcp --dport 443 -m owner --uid-owner "$MITM_UID" -j RETURN 2>/dev/null || true
+iptables -t nat -D OUTPUT -p tcp --dport 443 -j REDIRECT --to-port "$MITM_PORT" 2>/dev/null || true
 iptables -t nat -A OUTPUT -p tcp --dport 443 -m owner --uid-owner "$MITM_UID" -j RETURN
 iptables -t nat -A OUTPUT -p tcp --dport 443 -j REDIRECT --to-port "$MITM_PORT"
 
@@ -97,9 +134,12 @@ iptables -t nat -A OUTPUT -p tcp --dport 443 -j REDIRECT --to-port "$MITM_PORT"
 # REDIRECT, and the client transparently reconnects through mitmproxy.
 # conntrack is network-namespace scoped, so this only affects the
 # assistant's own flows, and it runs before `mitmdump` is exec'd so the
-# proxy has no upstream connections to disturb. Best-effort: a flush
-# failure must not take down the jail (recording degrades to the
-# pre-existing behaviour rather than breaking egress entirely).
+# proxy has no upstream connections to disturb. The flush must come
+# AFTER the NAT REDIRECT is installed — flushing before would just let
+# pre-jail flows re-establish on the still-unredirected path. Best-
+# effort: a flush failure must not take down the jail (recording
+# degrades to the pre-existing behaviour rather than breaking egress
+# entirely).
 conntrack -F >/dev/null 2>&1 \
   && echo "recording-jail: flushed pre-jail conntrack flows" >&2 \
   || echo "recording-jail: conntrack flush unavailable (pre-jail flows may bypass)" >&2

--- a/evals/src/lib/egress/recording/entrypoint.sh
+++ b/evals/src/lib/egress/recording/entrypoint.sh
@@ -21,10 +21,17 @@ MITM_UID="${MITM_UID:-1000}"
 MITM_PORT="${MITM_PORT:-8443}"
 RECORDING_OUTPUT_PATH="${RECORDING_OUTPUT_PATH:-/recording/egress-usage.ndjson}"
 
+# ALLOW_HOSTS is the comma-separated hostname allowlist. It is enforced
+# at the proxy layer now (addon.py rejects any request whose
+# `pretty_host` isn't in the set with a 403), so it must reach the
+# addon's process env. Fall back to api.anthropic.com so a sidecar
+# booted without it still permits the only host the recorder parses.
+ALLOW_HOSTS="${ALLOW_HOSTS:-api.anthropic.com}"
+
 # PLUGIN_FIXTURES_DIR is left empty when unset — the addon checks for
 # the env var directly and skips mocking when absent, so we don't need
 # a fallback path here.
-export MITM_UID MITM_PORT RECORDING_OUTPUT_PATH PLUGIN_FIXTURES_DIR
+export MITM_UID MITM_PORT RECORDING_OUTPUT_PATH PLUGIN_FIXTURES_DIR ALLOW_HOSTS
 
 # Phase 1: install iptables rules in this container's network namespace.
 /opt/recording/apply-recording-jail.sh
@@ -51,33 +58,30 @@ fi
 # `--listen-port $MITM_PORT` matches the REDIRECT target.
 # `--showhost` makes the request URL use the original Host header so
 #   the addon sees `api.anthropic.com` not the rewritten dest.
-# `--allow-hosts <regex>` restricts TLS interception. Anthropic for
-#   the usage parser; GitHub Contents + Raw when plugin fixtures are
-#   mounted (so the mock-github handler can synthesize plugin install
-#   responses). Other hosts get pure-TCP passthrough, which matters
-#   because:
-#   (a) the CA cert is only trusted by the assistant container
-#       (docker-jail.ts installs it post-hatch); gateway +
-#       credential-executor share the netns but don't trust the CA,
-#       so MITM'ing their outbound calls would break TLS for them.
-#   (b) the addon only synthesizes/parses these specific hosts;
-#       intercepting other providers is gross waste with no recording
-#       or mocking payoff.
-#   When ALLOW_HOSTS is empty, fall back to api.anthropic.com.
 # `--set block_global=false` allows transparent-mode traffic from
 #   localhost (the assistant container shares netns with us).
-ALLOW_HOSTS="${ALLOW_HOSTS:-api.anthropic.com}"
-if [ -n "${PLUGIN_FIXTURES_DIR:-}" ]; then
-  RECORDING_TLS_HOSTS_RE="${RECORDING_TLS_HOSTS_RE:-^(api\\.anthropic\\.com|api\\.github\\.com|raw\\.githubusercontent\\.com):443$}"
-else
-  RECORDING_TLS_HOSTS_RE="${RECORDING_TLS_HOSTS_RE:-^api\\.anthropic\\.com:443$}"
-fi
-
+#
+# We deliberately do NOT pass `--allow-hosts`: ALL TLS/443 flows the
+# REDIRECT bounces in are intercepted. The allowlist is now enforced in
+# the addon's `request` hook (it matches `pretty_host` against
+# ALLOW_HOSTS and 403s anything not allowed and not mocked), so the
+# proxy no longer needs a TLS-interception regex.
+#
+# Intercepting every host is safe here because only the ASSISTANT
+# container trusts the mitmproxy CA (docker-jail.ts installs it into
+# that container's trust store post-hatch). The gateway and
+# credential-executor containers do NOT share this netns, so their
+# outbound traffic never reaches this proxy and is unaffected by the
+# system-wide interception. The old `--allow-hosts` narrowing existed
+# to avoid MITM'ing those sibling containers, but they aren't reachable
+# here, so the narrowing only ever added a DNS-rotation failure mode
+# (a request to a host outside the regex got pure-TCP passthrough and
+# then hit the per-IP iptables ACCEPT that DNS rotation had
+# invalidated). Removing it lets the proxy own allowlisting end-to-end.
 exec su -s /bin/sh -c "exec mitmdump \
   --mode transparent \
   --listen-port \"$MITM_PORT\" \
   --showhost \
-  --allow-hosts \"$RECORDING_TLS_HOSTS_RE\" \
   --set block_global=false \
   --set confdir=/home/mitmproxy/.mitmproxy \
   --scripts /opt/recording/addon.py" mitmproxy

--- a/evals/src/lib/egress/recording/test_addon.py
+++ b/evals/src/lib/egress/recording/test_addon.py
@@ -1,25 +1,41 @@
 """
-Unit tests for addon.py's response hook body handling.
+Unit tests for addon.py's response- and request-hook behavior.
 
-Plain `unittest`, no third-party deps (mitmproxy is optional at import
-time — addon.py degrades to `ctx = http = None` when it's absent, which
-is exactly the case here). Runnable as:
+Plain `unittest`, no third-party deps. Runnable as:
 
     python3 -m unittest evals/src/lib/egress/recording/test_addon.py
 
-These tests pin the regression where the hook read `raw_content` (the
-compressed wire bytes) instead of the content-decoded body, which made
-the parser silently fail on every gzip'd Anthropic response and left
-`egress-usage.ndjson` empty.
+Two groups:
+
+  - `ResponseHookGzipTest` pins the regression where the response hook
+    read `raw_content` (the compressed wire bytes) instead of the
+    content-decoded body, which made the parser silently fail on every
+    gzip'd Anthropic response and left `egress-usage.ndjson` empty, plus
+    the payload-inlining behavior. These run against the addon imported
+    at module load — mitmproxy is optional there (addon.py degrades to
+    `ctx = http = None` when absent), which is fine for the response
+    hook.
+
+  - `AllowlistTests` drives the `request` hook's mock-then-allowlist
+    dispatch. The request hook needs `http.Response.make`, so these
+    install a minimal `mitmproxy` stub into `sys.modules` and reload the
+    addon with the env (ALLOW_HOSTS / PLUGIN_FIXTURES_DIR) under test —
+    both are read from os.environ at import time. The reload is in-place
+    (`importlib.reload`), so the module-level `addon` reference the
+    response-hook tests use stays valid.
 """
 
 from __future__ import annotations
 
 import gzip
+import importlib
 import json
 import os
+import sys
 import tempfile
+import types
 import unittest
+from typing import Optional
 
 import addon
 
@@ -205,6 +221,141 @@ class ResponseHookGzipTest(unittest.TestCase):
         records = self._records()
         self.assertEqual(len(records), 1)
         self.assertEqual(records[0]["input_tokens"], 16442)
+
+
+def _install_mitmproxy_stub() -> None:
+    """Install a minimal fake `mitmproxy` package into sys.modules.
+
+    Only the surface the addon touches is provided: `ctx.log.{info,warn}`
+    (no-ops) and `http.Response.make(status, body, headers)` returning a
+    simple namespace we can assert against.
+    """
+
+    class _FakeResponse:
+        def __init__(self, status_code: int, content: bytes, headers: dict):
+            self.status_code = status_code
+            self.content = content
+            self.headers = headers
+
+    class _FakeResponseFactory:
+        @staticmethod
+        def make(status: int, body: bytes, headers: dict) -> "_FakeResponse":
+            return _FakeResponse(status, body, headers)
+
+    mitmproxy = types.ModuleType("mitmproxy")
+
+    log = types.SimpleNamespace(info=lambda *_: None, warn=lambda *_: None)
+    ctx = types.SimpleNamespace(log=log)
+
+    http = types.SimpleNamespace(Response=_FakeResponseFactory)
+
+    mitmproxy.ctx = ctx  # type: ignore[attr-defined]
+    mitmproxy.http = http  # type: ignore[attr-defined]
+
+    sys.modules["mitmproxy"] = mitmproxy
+
+
+def _load_addon(*, allow_hosts: str, fixtures_dir: Optional[str] = None):
+    """Reload addon.py with the given env so module-level config refreshes."""
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    _install_mitmproxy_stub()
+    os.environ["ALLOW_HOSTS"] = allow_hosts
+    if fixtures_dir is None:
+        os.environ.pop("PLUGIN_FIXTURES_DIR", None)
+    else:
+        os.environ["PLUGIN_FIXTURES_DIR"] = fixtures_dir
+    if "addon" in sys.modules:
+        return importlib.reload(sys.modules["addon"])
+    return importlib.import_module("addon")
+
+
+class _AllowlistFakeRequest:
+    def __init__(self, host: str, path: str = "/v1/messages", method: str = "POST"):
+        self.pretty_host = host
+        self.path = path
+        self.method = method
+
+
+class _AllowlistFakeFlow:
+    def __init__(self, request: _AllowlistFakeRequest):
+        self.request = request
+        self.response = None
+
+
+class AllowlistTests(unittest.TestCase):
+    def test_blocks_a_host_not_in_the_allowlist_with_403(self) -> None:
+        addon = _load_addon(allow_hosts="api.anthropic.com")
+        flow = _AllowlistFakeFlow(_AllowlistFakeRequest("evil.example.com"))
+        addon.request(flow)
+        self.assertIsNotNone(flow.response)
+        self.assertEqual(flow.response.status_code, 403)
+        self.assertIn(b"blocked by vellum-evals egress jail", flow.response.content)
+
+    def test_allows_an_allowlisted_host_to_fall_through(self) -> None:
+        # An allowed host gets no short-circuit response — it flows to
+        # mitmproxy's normal upstream path. We assert `flow.response`
+        # stays None (the hook returned without setting it).
+        addon = _load_addon(allow_hosts="api.anthropic.com,api.openai.com")
+        flow = _AllowlistFakeFlow(_AllowlistFakeRequest("api.anthropic.com"))
+        addon.request(flow)
+        self.assertIsNone(flow.response)
+
+    def test_allowlist_match_is_case_insensitive(self) -> None:
+        addon = _load_addon(allow_hosts="API.Anthropic.com")
+        flow = _AllowlistFakeFlow(_AllowlistFakeRequest("api.anthropic.com"))
+        addon.request(flow)
+        self.assertIsNone(flow.response)
+
+    def test_blocks_when_allowlist_is_empty(self) -> None:
+        # A sidecar with no ALLOW_HOSTS blocks everything (fail closed).
+        addon = _load_addon(allow_hosts="")
+        flow = _AllowlistFakeFlow(_AllowlistFakeRequest("api.anthropic.com"))
+        addon.request(flow)
+        self.assertEqual(flow.response.status_code, 403)
+
+    def test_mocked_github_host_is_served_even_though_not_allowlisted(self) -> None:
+        # GitHub is intentionally NOT in ALLOW_HOSTS — it's served from
+        # the fixtures dir. The mock must win before the allowlist would
+        # 403 it. We point PLUGIN_FIXTURES_DIR at a temp dir with a
+        # `plugins/<name>/` layout so the contents-API mock returns 200.
+        with tempfile.TemporaryDirectory() as fixtures:
+            plugin_dir = os.path.join(fixtures, "demo-plugin")
+            os.makedirs(plugin_dir)
+            with open(os.path.join(plugin_dir, "SKILL.md"), "w") as fh:
+                fh.write("# demo\n")
+            addon = _load_addon(
+                allow_hosts="api.anthropic.com",
+                fixtures_dir=fixtures,
+            )
+            flow = _AllowlistFakeFlow(
+                _AllowlistFakeRequest(
+                    "api.github.com",
+                    path="/repos/vellum-ai/vellum-assistant/contents/plugins/demo-plugin",
+                    method="GET",
+                )
+            )
+            addon.request(flow)
+            self.assertIsNotNone(flow.response)
+            self.assertEqual(flow.response.status_code, 200)
+            self.assertEqual(
+                flow.response.headers.get("x-mocked-by"),
+                "vellum-evals-egress-mock",
+            )
+
+    def test_unmocked_github_path_falls_to_allowlist_and_is_blocked(self) -> None:
+        # With fixtures mounted but a path the mock doesn't recognize,
+        # the request falls through to the allowlist — github isn't
+        # allowlisted, so it 403s rather than egressing to real github.
+        with tempfile.TemporaryDirectory() as fixtures:
+            addon = _load_addon(
+                allow_hosts="api.anthropic.com",
+                fixtures_dir=fixtures,
+            )
+            flow = _AllowlistFakeFlow(
+                _AllowlistFakeRequest("api.github.com", path="/zen", method="GET")
+            )
+            addon.request(flow)
+            self.assertEqual(flow.response.status_code, 403)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Related to JARVIS-1159 · Companion to #34639 (the daemon compaction-thrash fix this harness verified)

## What

The `compaction-thrash` benchmark merged in #34570 had never successfully executed — every fresh-checkout run died at hatch, mid-run, or measured nothing. These are the harness repairs found by actually running it, minus the ones main shipped independently in the meantime (pre-jail conntrack flush #34731, beta-path usage parsing #34663 — both kept as-is here).

The two PRs are **not code-dependent** and can land in either order: the benchmark reads the daemon's new SSE cache fields opportunistically and falls back to egress-jail records.

## Fixes (each diagnosed live)

**Egress jail (`evals/src/lib/egress/recording/`):**
- **Never flush the nat OUTPUT chain.** `iptables -t nat -F OUTPUT` deletes the DNAT rules dockerd installs for the 127.0.0.11 embedded resolver, killing DNS for the entire shared netns — warm connections coast, then every new connection fails with "Connection error" minutes into a run. The script now deletes exactly its own rules and appends. This composes with (and is made *more* urgent by) main's `conntrack -F`, which drops live DNS NAT state.
- **Hostname allowlist instead of static IPs.** ALLOW_HOSTS was resolved to IPv4s once at container start (`getent ahostsv4`) and pinned as per-IP ACCEPTs; provider DNS rotation stranded mitmproxy's upstream connects mid-run. Enforcement moves to the addon (403 by `request.pretty_host`, mock-github stage first), mitmproxy's uid gets a filter-chain ACCEPT, and `--allow-hosts` interception-narrowing is removed.
- **Accept REDIRECTed packets by (local dst, mitm port)** — some VM kernels rewrite the REDIRECT destination to the egress interface's primary address, matching neither the `127.0.0.0/8` nor `-o lo` accepts.

**Vellum adapter:**
- Run `meta/feature-flags/sync-bundled-copies.ts` before hatch: the generated registry copies are gitignored and `meta/` is excluded from the Docker build context, so fresh checkouts hatched a gateway that rejected every `vellum flags set` with "Unknown flag key", aborting hatch.
- `vellum retire --yes`: retire refuses confirmation in non-interactive terminals, so eval teardown always fell through to the force-reaper.
- New optional `readUsageLedger()` — dumps the daemon's per-call-site usage breakdown (`assistant usage breakdown --group-by call_site --json`) as a run artifact: ground-truth attribution of compaction spend, independent of both the SSE stream and the jail.

**Benchmark measurement (`evals/benchmarks/compaction-thrash/`):**
- Compaction passes were counted via a `context_compacting` event type that never crosses the SSE wire; the wire marker is `assistant_activity_state` with `reason: "context_compacting"`. Counted there now, collapsing consecutive duplicates.
- Per-tick token/cache numbers now come from egress-jail `readUsageRecords()` diffs (the cost authority per evals/AGENTS.md) with SSE fallback, plus a per-tick `contextWindowTokens` diagnostic.
- The thresholds were unreachable: ~500-token ticks against a 200k window with a ~161k trigger. The stress profile now shrinks the window to 40k — on `llm.default` AND the active inference profile, which floats above defaults in main-agent resolution — pads ticks to ~2000 deterministic estimator-tokens, pins Haiku (a full 30-tick run costs ~$0.30 vs ~$4 on a frontier model; thrash dynamics are estimator/threshold-driven, not model-driven), and disables thinking (adaptive thinking 400s on small models).
- Formats `runner.test.ts` (the unformatted file that failed the original CI run).

## Verified

This harness produced the A/B/C verification for #34639: baseline reproduces the thrash (13 compaction passes in 10 observe ticks, every tick, actual context blowing past the window), fixed daemon passes all three criteria (2 passes, 20.5% cache-write ratio, −61% tokens/tick). Full metric tables in #34639.

Reconciliation against main's parallel evals work was reviewed topic-by-topic: main's `urlsplit` parsing, gzip decoding, cache-TTL usage forwarding, `conntrack -F`, and `isTurnComplete` collector contract are all preserved unchanged.

## Test plan

- `bunx tsc --noEmit`, `bun run lint`, `bun run format:check` clean in `evals/`
- bun tests: vellum-adapter, apply-recording-jail, compaction-thrash runner, run-once, run-ingest-ask, longmemeval-v2 runners — 86 pass / 0 fail
- python: test_usage_parser, test_addon, test_mock_github_handler — 39 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)