### PR TITLE
feat(web): close the right-hand side panel on Escape

### DIFF
--- a/apps/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
+++ b/apps/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
@@ -148,6 +148,9 @@ export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
       if (e.key === "Escape") {
+        // Mark the key as consumed so the window-level Escape listener
+        // (which closes the right-hand side panel) doesn't also fire.
+        e.preventDefault();
         onClose();
       }
     },

--- a/apps/web/src/domains/chat/components/chat-content-layout.tsx
+++ b/apps/web/src/domains/chat/components/chat-content-layout.tsx
@@ -10,7 +10,7 @@
  * from stores — no props required for layout decisions.
  */
 
-import { lazy, useCallback } from "react";
+import { lazy, useCallback, useEffect } from "react";
 import { useNavigate } from "react-router";
 import { Loader2 } from "lucide-react";
 import { ResizablePanel } from "@vellumai/design-library";
@@ -110,6 +110,47 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
     if (!aid) return;
     void useSubagentStore.getState().fetchDetailIfNeeded(aid, id);
   }, []);
+
+  // -------------------------------------------------------------------------
+  // Escape closes whichever right-hand side panel is open (tool detail /
+  // thought process, subagent detail, document viewer). Surfaces stacked
+  // above the panel that own Escape — Radix layers (dialogs, popovers,
+  // dropdowns), the command palette, voice recording, the attachment
+  // preview — all run before this bubble-phase window listener (document
+  // capture or React tree handlers) and call preventDefault when they
+  // consume the key, so `defaultPrevented` means the keypress was already
+  // claimed by something above the panel. The full-width app viewer and the
+  // app-editing split are deliberately excluded: the viewer owns Escape for
+  // fullscreen exit, and editing is an explicit session with its own close
+  // affordance. Closing restores `viewBefore*`, so repeated presses unwind
+  // stacked panels (tool detail → document → chat) one layer at a time.
+  // -------------------------------------------------------------------------
+
+  useEffect(() => {
+    if (isMobile) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape" || event.defaultPrevented) return;
+      // Don't intercept IME composition (CJK input confirmation).
+      if (event.isComposing || event.keyCode === 229) return;
+      const viewer = useViewerStore.getState();
+      switch (viewer.mainView) {
+        case "tool-detail":
+          viewer.closeToolDetail();
+          break;
+        case "subagent-detail":
+          viewer.closeSubagentDetail();
+          break;
+        case "document":
+          viewer.closeDocument();
+          break;
+        default:
+          return;
+      }
+      event.preventDefault();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [isMobile]);
 
   // -------------------------------------------------------------------------
   // Layout routing


### PR DESCRIPTION
## Summary
- Pressing Escape now closes the open right-hand side panel in the chat layout (thought process / tool detail, subagent detail, document viewer); repeated presses unwind stacked panels one layer at a time via the existing `viewBefore*` restoration.
- The window-level listener runs at bubble phase and skips `defaultPrevented` events, so surfaces stacked above the panel (Radix dialogs/popovers/menus, command palette, voice recording) keep owning Escape; the attachment preview modal now calls `preventDefault` when it consumes Escape so it participates in the same contract.
- The full-width app viewer and app-editing split are deliberately excluded — the app viewer owns Escape for fullscreen exit, and editing is an explicit session with its own close affordance.

## Original prompt
The user wanted the right-hand "Thought process" panel to close when hitting the Escape key in the Electron desktop app. That panel (and its sibling subagent-detail and document panels) is rendered by the shared web app in `apps/web/`, which the Electron shell wraps, so the fix lands there.