### PR TITLE
fix(web): use neutral ring color for low context-window fill

### DIFF
--- a/apps/web/src/domains/chat/components/context-window-indicator.tsx
+++ b/apps/web/src/domains/chat/components/context-window-indicator.tsx
@@ -32,7 +32,9 @@ function resolveRingColor(ratio: number): string {
   if (ratio >= 0.6) {
     return "var(--system-mid-strong)";
   }
-  return "var(--system-positive-strong)";
+  // Neutral below the warning thresholds, matching macOS VContextWindowIndicator.
+  // Not --system-positive-strong: velvet restyles that token to its pink accent.
+  return "var(--content-tertiary)";
 }
 
 function formatTokens(count: number): string {


### PR DESCRIPTION
## Summary
- The context-window indicator (ring + `% full` tooltip text) used `--system-positive-strong` below 60% fill; the velvet theme restyles that token to its pink accent (`#E83F5B`), so a 7%-full context rendered in alarm-red.
- Switch the low-fill color to `--content-tertiary`, matching the Swift macOS `VContextWindowIndicator` thresholds (neutral < 60%, `--system-mid-strong` ≥ 60%, `--system-negative-strong` ≥ 80%).

## Original prompt
A screenshot from the Electron macOS app showed the context-window tooltip reading "7% full" in red/pink despite the context being nearly empty. The user asked that the indicator color be based on how full the context is, as it is in the Swift macOS app. Root cause: the web component's low-fill color token is restyled to the pink accent under the velvet theme, while the Swift app uses a neutral gray for the low range.