### PR TITLE
feat(web): drag-to-reorder conversations in the sidebar (Pinned + custom groups)

### DIFF
--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -322,6 +322,7 @@ export function ChatLayout() {
     handleMarkConversationRead,
     handleTogglePinConversation,
     handleRenameConversation,
+    handleReorderConversations,
     handleMarkAllReadInGroup,
     handleArchiveAllInGroup,
   } = useConversationActions({
@@ -561,6 +562,7 @@ export function ChatLayout() {
       activeAppId={activeAppId ?? undefined}
       onOpenApp={handleOpenAppFromSidebar}
       onPinConversation={handleTogglePinConversation}
+      onReorderConversations={handleReorderConversations}
       onRenameConversation={handleRenameConversation}
       onArchiveConversation={handleArchiveConversation}
       onUnarchiveConversation={handleUnarchiveConversation}

--- a/apps/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/apps/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -22,7 +22,8 @@ import {
 } from "@/domains/chat/components/conversation-actions-menu";
 import { GroupActionsMenu, renderGroupMenuItems } from "@/domains/chat/components/group-actions-menu";
 import { ThreadPinToggle } from "@/domains/chat/components/thread-pin-toggle";
-import { SIDEBAR_CONVERSATION_LIMIT, useSidebarState, type UseSidebarStateParams } from "@/domains/chat/use-sidebar-state";
+import { useDragReorder } from "@/domains/chat/hooks/use-drag-reorder";
+import { SIDEBAR_CONVERSATION_LIMIT, useSidebarState, type PaginatedSection, type UseSidebarStateParams } from "@/domains/chat/use-sidebar-state";
 import { isChannelConversation } from "@/domains/chat/utils/conversation-channel";
 import { isConversationPinned } from "@/domains/chat/utils/group-conversations";
 import { usePinnedAppsStore } from "@/stores/pinned-apps-store";
@@ -34,6 +35,7 @@ import {
     PanelItem,
     SideMenu,
 } from "@vellumai/design-library";
+import { cn } from "@vellumai/design-library/utils/cn";
 
 /** @deprecated Use {@link SIDEBAR_CONVERSATION_LIMIT} from `use-sidebar-state.ts` */
 export const ASSISTANT_SIDE_MENU_CONVERSATION_LIMIT = SIDEBAR_CONVERSATION_LIMIT;
@@ -57,6 +59,13 @@ export interface AssistantSideMenuProps extends UseSidebarStateParams {
   onClose?: () => void;
 
   onPinConversation?: (conversation: Conversation) => void;
+  /**
+   * Persist a drag-reorder within a section. Receives the section's full
+   * conversation list in its new order. When omitted, rows aren't draggable.
+   * Only sections that honor `displayOrder` (Pinned, custom groups) offer
+   * drag-reordering — Recents and Slack stay recency-sorted.
+   */
+  onReorderConversations?: (conversations: Conversation[]) => void;
   onRenameConversation?: (conversation: Conversation) => void;
   onArchiveConversation?: (conversation: Conversation) => void;
   onUnarchiveConversation?: (conversation: Conversation) => void;
@@ -129,6 +138,7 @@ export function AssistantSideMenu({
   onStartNewConversation,
   footerAction,
   onPinConversation,
+  onReorderConversations,
   onRenameConversation,
   onArchiveConversation,
   onUnarchiveConversation,
@@ -156,6 +166,35 @@ export function AssistantSideMenu({
   });
 
   const pinnedApps = usePinnedAppsStore.use.pinnedApps();
+
+  // --- Drag-reorder (Pinned + custom groups; sections sorted by displayOrder) ---
+
+  const dragReorder = useDragReorder<Conversation>({
+    getId: (c) => c.conversationId,
+    onReorder: (_section, ordered) => onReorderConversations?.(ordered),
+  });
+
+  const buildDragProps = (
+    section: string | undefined,
+    items: Conversation[],
+    conversation: Conversation,
+  ) => {
+    if (!section || !onReorderConversations || items.length < 2) return {};
+    const { draggingId, dropIndicator } = dragReorder;
+    const edge =
+      dropIndicator?.section === section &&
+      dropIndicator.itemId === conversation.conversationId
+        ? dropIndicator.edge
+        : null;
+    return {
+      ...dragReorder.getItemProps(section, items, conversation),
+      className: cn(
+        draggingId === conversation.conversationId && "opacity-50",
+        edge === "before" && "shadow-[inset_0_2px_0_0_var(--primary-base)]",
+        edge === "after" && "shadow-[inset_0_-2px_0_0_var(--primary-base)]",
+      ),
+    };
+  };
 
   // --- Render helpers (action wiring, context menu, pin toggle) ---
 
@@ -296,10 +335,11 @@ export function AssistantSideMenu({
 
   const renderFlatList = (
     items: Conversation[],
-    showMore: boolean,
-    onShowMore?: () => void,
-    showLess = false,
-    onShowLess?: () => void,
+    pagination?: Pick<
+      PaginatedSection,
+      "showMore" | "onShowMore" | "showLess" | "onShowLess"
+    >,
+    reorderSection?: string,
   ): ReactNode => (
     <SideMenu.SubList>
       {items.map((c) =>
@@ -312,25 +352,26 @@ export function AssistantSideMenu({
             active={c.conversationId === activeConversationId}
             onSelect={() => selectAndClose(c.conversationId)}
             trailingAction={renderThreadActions(c)}
+            {...buildDragProps(reorderSection, items, c)}
           />,
         ),
       )}
-      {showMore && onShowMore ? (
+      {pagination?.showMore ? (
         <SideMenu.Item
           label="Show more"
           size="compact"
           indent
           emphasized
-          onSelect={onShowMore}
+          onSelect={pagination.onShowMore}
         />
       ) : null}
-      {showLess && onShowLess ? (
+      {pagination?.showLess ? (
         <SideMenu.Item
           label="Show less"
           size="compact"
           indent
           emphasized
-          onSelect={onShowLess}
+          onSelect={pagination.onShowLess}
         />
       ) : null}
     </SideMenu.SubList>
@@ -451,10 +492,7 @@ export function AssistantSideMenu({
           <>
             {sidebar.pinned.length > 0 ? (
               <SideMenu.Section title="Pinned">
-                {renderFlatList(
-                  sidebar.pinned,
-                  false,
-                )}
+                {renderFlatList(sidebar.pinned, undefined, "pinned")}
               </SideMenu.Section>
             ) : null}
 
@@ -463,13 +501,7 @@ export function AssistantSideMenu({
               className="gap-1"
               actions={variant === "overlay" ? undefined : headerActions}
             >
-              {renderFlatList(
-                sidebar.recents.items,
-                sidebar.recents.showMore,
-                sidebar.recents.onShowMore,
-                sidebar.recents.showLess,
-                sidebar.recents.onShowLess,
-              )}
+              {renderFlatList(sidebar.recents.items, sidebar.recents)}
 
               <CollapsibleNavSection.Root
                 type="multiple"
@@ -484,13 +516,7 @@ export function AssistantSideMenu({
                     label="Slack"
                     contextMenuContent={buildGroupContextMenu("Slack", sidebar.slack.all)}
                   >
-                    {renderFlatList(
-                      sidebar.slack.items,
-                      sidebar.slack.showMore,
-                      sidebar.slack.onShowMore,
-                      sidebar.slack.showLess,
-                      sidebar.slack.onShowLess,
-                    )}
+                    {renderFlatList(sidebar.slack.items, sidebar.slack)}
                   </CollapsibleNavSection.Section>
                 ) : null}
               </CollapsibleNavSection.Root>
@@ -543,6 +569,11 @@ export function AssistantSideMenu({
                                   active={c.conversationId === activeConversationId}
                                   onSelect={() => selectAndClose(c.conversationId)}
                                   trailingAction={renderThreadActions(c)}
+                                  {...buildDragProps(
+                                    `group:${group.id}`,
+                                    group.conversations,
+                                    c,
+                                  )}
                                 />,
                               ),
                             )}

--- a/apps/web/src/domains/chat/hooks/use-conversation-actions.ts
+++ b/apps/web/src/domains/chat/hooks/use-conversation-actions.ts
@@ -8,6 +8,7 @@ import {
   patchConversation,
   restoreConversationCaches,
   snapshotConversationCaches,
+  updateAllConversationCaches,
   type ConversationCacheSnapshot,
 } from "@/utils/conversation-cache";
 import { executeBulkWithFallback } from "@/utils/bulk-with-fallback";
@@ -46,6 +47,7 @@ type MoveToGroupVars = {
   previousIsPinned: boolean;
   previousGroupId: string | undefined;
 };
+type ReorderVars = { assistantId: string; orderedIds: string[] };
 
 type MutationContext = { snapshot: ConversationCacheSnapshot };
 
@@ -224,6 +226,42 @@ export function useConversationActions({
     },
   });
 
+  const reorderMutation = useMutation<void, Error, ReorderVars, MutationContext>({
+    mutationFn: async ({ assistantId: aid, orderedIds }) => {
+      await conversationsReorderPost({
+        path: { assistant_id: aid },
+        body: {
+          // displayOrder-only updates — the daemon preserves each
+          // conversation's pin state and group assignment.
+          updates: orderedIds.map((conversationId, index) => ({
+            conversationId,
+            displayOrder: index,
+          })),
+        },
+        throwOnError: true,
+      });
+    },
+    onMutate: async ({ assistantId: aid, orderedIds }) => {
+      await cancelConversationQueries(queryClient, aid);
+      const snapshot = snapshotConversationCaches(queryClient, aid);
+      const orderById = new Map(orderedIds.map((id, index) => [id, index]));
+      updateAllConversationCaches(queryClient, aid, (conversations) =>
+        conversations.map((c) => {
+          const displayOrder = orderById.get(c.conversationId);
+          return displayOrder === undefined ? c : { ...c, displayOrder };
+        }),
+      );
+      return { snapshot };
+    },
+    onError: (err, _vars, context) => {
+      if (context?.snapshot) restoreConversationCaches(queryClient, context.snapshot);
+      captureError(err, { context: "reorderConversations" });
+    },
+    onSettled: (_data, _err, { assistantId: aid }) => {
+      void invalidateConversationQueries(queryClient, aid);
+    },
+  });
+
   // -------------------------------------------------------------------------
   // Handlers — thin wrappers that compute UI side effects, then fire mutate
   // -------------------------------------------------------------------------
@@ -309,6 +347,23 @@ export function useConversationActions({
       handleMoveToGroup(conversation, targetGroupId);
     },
     [handleMoveToGroup, prePinGroupIdsRef],
+  );
+
+  /**
+   * Persist a user drag-reorder. `ordered` is a sidebar section's full
+   * conversation list (pinned or one custom group) in its new order;
+   * each row's `displayOrder` becomes its index.
+   */
+  const handleReorderConversations = useCallback(
+    (ordered: Conversation[]) => {
+      if (!assistantId || ordered.length < 2) return;
+      haptic.light();
+      reorderMutation.mutate({
+        assistantId,
+        orderedIds: ordered.map((c) => c.conversationId),
+      });
+    },
+    [assistantId, reorderMutation],
   );
 
   const handleRenameConversation = useCallback(
@@ -441,6 +496,7 @@ export function useConversationActions({
     handleMarkConversationRead,
     handleTogglePinConversation,
     handleRenameConversation,
+    handleReorderConversations,
     handleMarkAllReadInGroup,
     handleArchiveAllInGroup,
   };

--- a/apps/web/src/domains/chat/hooks/use-drag-reorder.test.ts
+++ b/apps/web/src/domains/chat/hooks/use-drag-reorder.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for the pure reorder computation behind sidebar drag-and-drop.
+ * The DOM event wiring in `useDragReorder` is exercised manually; the
+ * order math is what must stay correct.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { reorderByDrop } from "@/domains/chat/hooks/use-drag-reorder";
+
+type Item = { id: string };
+
+const items: Item[] = [{ id: "a" }, { id: "b" }, { id: "c" }, { id: "d" }];
+const getId = (item: Item) => item.id;
+const ids = (result: Item[] | null) => result?.map((i) => i.id) ?? null;
+
+describe("reorderByDrop", () => {
+  test("moves an item down, dropping after the target", () => {
+    expect(ids(reorderByDrop(items, getId, "a", "c", "after"))).toEqual([
+      "b",
+      "c",
+      "a",
+      "d",
+    ]);
+  });
+
+  test("moves an item up, dropping before the target", () => {
+    expect(ids(reorderByDrop(items, getId, "d", "b", "before"))).toEqual([
+      "a",
+      "d",
+      "b",
+      "c",
+    ]);
+  });
+
+  test("moves to the very top and very bottom", () => {
+    expect(ids(reorderByDrop(items, getId, "c", "a", "before"))).toEqual([
+      "c",
+      "a",
+      "b",
+      "d",
+    ]);
+    expect(ids(reorderByDrop(items, getId, "a", "d", "after"))).toEqual([
+      "b",
+      "c",
+      "d",
+      "a",
+    ]);
+  });
+
+  test("returns null when dropped on itself", () => {
+    expect(reorderByDrop(items, getId, "b", "b", "before")).toBeNull();
+  });
+
+  test("returns null when the resulting order is unchanged", () => {
+    expect(reorderByDrop(items, getId, "b", "a", "after")).toBeNull();
+    expect(reorderByDrop(items, getId, "b", "c", "before")).toBeNull();
+  });
+
+  test("returns null when source or target is not in the list", () => {
+    expect(reorderByDrop(items, getId, "missing", "a", "before")).toBeNull();
+    expect(reorderByDrop(items, getId, "a", "missing", "before")).toBeNull();
+  });
+
+  test("does not mutate the input list", () => {
+    const before = [...items];
+    reorderByDrop(items, getId, "a", "c", "after");
+    expect(items).toEqual(before);
+  });
+});

--- a/apps/web/src/domains/chat/hooks/use-drag-reorder.ts
+++ b/apps/web/src/domains/chat/hooks/use-drag-reorder.ts
@@ -1,0 +1,170 @@
+/**
+ * Native HTML5 drag-and-drop reordering for vertical lists.
+ *
+ * Generic over the item type so any sidebar section can opt in. Each
+ * reorderable list passes a stable `section` key; drags only land within
+ * the section they started in, so a pinned row can't be dropped into a
+ * custom group (cross-section moves stay an explicit menu action).
+ *
+ * Uses the platform drag events (no library) — `PanelItem` forwards
+ * unknown props to its row element, so callers spread
+ * `getItemProps(...)` straight onto it. Touch devices don't fire HTML5
+ * drag events, so this is a no-op there; pointer-based reordering on
+ * iOS would need a dedicated gesture layer.
+ *
+ * References:
+ * - https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API
+ */
+
+import { useRef, useState, type DragEvent } from "react";
+
+export type DropEdge = "before" | "after";
+
+export interface DropIndicator {
+  section: string;
+  itemId: string;
+  edge: DropEdge;
+}
+
+export interface DragReorderItemProps {
+  draggable: true;
+  onDragStart: (event: DragEvent<HTMLElement>) => void;
+  onDragOver: (event: DragEvent<HTMLElement>) => void;
+  onDragLeave: (event: DragEvent<HTMLElement>) => void;
+  onDrop: (event: DragEvent<HTMLElement>) => void;
+  onDragEnd: () => void;
+}
+
+/**
+ * Pure reorder computation: the list after dropping `sourceId` on the
+ * `edge` of `targetId`. Returns `null` when the drop is a no-op (source
+ * dropped on itself, ids missing from the list, or the resulting order
+ * is unchanged) so callers can skip the mutation entirely.
+ */
+export function reorderByDrop<T>(
+  items: readonly T[],
+  getId: (item: T) => string,
+  sourceId: string,
+  targetId: string,
+  edge: DropEdge,
+): T[] | null {
+  if (sourceId === targetId) return null;
+  const source = items.find((item) => getId(item) === sourceId);
+  if (!source) return null;
+  const without = items.filter((item) => getId(item) !== sourceId);
+  const targetIndex = without.findIndex((item) => getId(item) === targetId);
+  if (targetIndex === -1) return null;
+  const insertAt = edge === "before" ? targetIndex : targetIndex + 1;
+  const next = [
+    ...without.slice(0, insertAt),
+    source,
+    ...without.slice(insertAt),
+  ];
+  if (next.every((item, i) => item === items[i])) return null;
+  return next;
+}
+
+function edgeFromPointer(event: DragEvent<HTMLElement>): DropEdge {
+  const rect = event.currentTarget.getBoundingClientRect();
+  return event.clientY < rect.top + rect.height / 2 ? "before" : "after";
+}
+
+export interface UseDragReorderResult<T> {
+  /**
+   * Drag handlers for one row. `items` is the section's full ordered
+   * list (not a paginated slice) — the drop result is computed from it.
+   */
+  getItemProps: (section: string, items: T[], item: T) => DragReorderItemProps;
+  /** Id of the row currently being dragged, for dimming styles. */
+  draggingId: string | null;
+  /** Row + edge the pointer is hovering, for the insertion-line style. */
+  dropIndicator: DropIndicator | null;
+}
+
+export function useDragReorder<T>({
+  getId,
+  onReorder,
+}: {
+  getId: (item: T) => string;
+  onReorder: (section: string, ordered: T[]) => void;
+}): UseDragReorderResult<T> {
+  // The active drag lives in a ref (read synchronously by other rows'
+  // dragover handlers); `draggingId` mirrors it as state for styling.
+  const activeDragRef = useRef<{ section: string; itemId: string } | null>(
+    null,
+  );
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  const [dropIndicator, setDropIndicator] = useState<DropIndicator | null>(
+    null,
+  );
+
+  const clearDrag = () => {
+    activeDragRef.current = null;
+    setDraggingId(null);
+    setDropIndicator(null);
+  };
+
+  const getItemProps = (
+    section: string,
+    items: T[],
+    item: T,
+  ): DragReorderItemProps => {
+    const itemId = getId(item);
+    return {
+      draggable: true,
+      onDragStart: (event) => {
+        activeDragRef.current = { section, itemId };
+        event.dataTransfer.effectAllowed = "move";
+        // Firefox won't start a drag without payload data.
+        event.dataTransfer.setData("text/plain", itemId);
+        // Defer the style flip past dragstart — re-rendering the dragged
+        // node inside the dragstart dispatch cancels the drag in Chromium.
+        window.setTimeout(() => {
+          if (activeDragRef.current?.itemId === itemId) setDraggingId(itemId);
+        }, 0);
+      },
+      onDragOver: (event) => {
+        const drag = activeDragRef.current;
+        if (!drag || drag.section !== section) return;
+        // preventDefault marks this row as a valid drop target.
+        event.preventDefault();
+        event.dataTransfer.dropEffect = "move";
+        if (drag.itemId === itemId) {
+          setDropIndicator(null);
+          return;
+        }
+        const edge = edgeFromPointer(event);
+        setDropIndicator((prev) =>
+          prev?.section === section &&
+          prev.itemId === itemId &&
+          prev.edge === edge
+            ? prev
+            : { section, itemId, edge },
+        );
+      },
+      onDragLeave: (event) => {
+        // dragleave also fires when entering a child element of the row.
+        if (event.currentTarget.contains(event.relatedTarget as Node | null))
+          return;
+        setDropIndicator((prev) => (prev?.itemId === itemId ? null : prev));
+      },
+      onDrop: (event) => {
+        const drag = activeDragRef.current;
+        if (!drag || drag.section !== section) return;
+        event.preventDefault();
+        const next = reorderByDrop(
+          items,
+          getId,
+          drag.itemId,
+          itemId,
+          edgeFromPointer(event),
+        );
+        clearDrag();
+        if (next) onReorder(section, next);
+      },
+      onDragEnd: clearDrag,
+    };
+  };
+
+  return { getItemProps, draggingId, dropIndicator };
+}


### PR DESCRIPTION
## Summary
- Adds drag-and-drop reordering of conversations in the web sidebar — and therefore the Electron desktop app — matching the existing Swift macOS app capability. Works in the **Pinned** section and **custom groups** (the sections that honor `displayOrder`); Recents and Slack remain recency-sorted by design.
- New generic `useDragReorder` hook built on native HTML5 drag events (no new dependencies), with a pure, unit-tested `reorderByDrop` helper. Dragged rows dim, and an insertion line (design-token primary color) marks the drop position. Drags are scoped to the section they start in — cross-section moves remain an explicit menu action.
- Persists through the existing `POST conversations/reorder` endpoint with `displayOrder`-only updates (the daemon preserves pin state and group assignment for those), using the established TanStack Query optimistic-update lifecycle: single-pass cache patch, snapshot rollback on error, invalidate on settle.
- Drive-by: collapsed `renderFlatList`'s five positional pagination params into a `Pick<PaginatedSection, ...>` options arg.

## Original prompt
> I want to be able to reorder conversations in the sidebar of the electron app like I can in the swift app

(Screenshot of the Pinned sidebar section attached in the original request. The Electron app renders `apps/web/`, so the change lands in the web sidebar; the daemon API and Swift client already supported reordering.)