### PR TITLE
feat: show tool calls immediately while arguments stream, across providers

### DIFF
--- a/apps/web/src/domains/chat/api/event-types.ts
+++ b/apps/web/src/domains/chat/api/event-types.ts
@@ -36,6 +36,15 @@ export interface ChatMessageToolCall extends ConversationMessageToolCall {
    * Drop this narrowing once the wire `id` graduates to non-optional.
    */
   id: string;
+  /**
+   * Client-only marker for a tool call ingested from `tool_use_preview_start`
+   * — the model is still streaming the call's arguments, so `input` is empty
+   * and no execution has begun. Cleared (set `false`) when the matching
+   * `tool_use_start` upgrades the entry with real input. Previews are
+   * ephemeral: they are never force-completed by turn finalization and are
+   * removed on idle if no `tool_use_start` ever arrived (aborted mid-call).
+   */
+  isPreview?: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/domains/chat/hooks/use-message-reconciliation.ts
+++ b/apps/web/src/domains/chat/hooks/use-message-reconciliation.ts
@@ -12,8 +12,7 @@ import {
 import type { DisplayMessage } from "@/domains/chat/types/types";
 import { reconcileSnapshot } from "@/domains/chat/utils/reconcile-snapshot";
 import { getLocalSeq, recordLocalSeq } from "@/lib/streaming/local-seq";
-import { isToolCallRunning } from "@/domains/chat/utils/tool-call-status";
-import { mapMessageToolCalls } from "@/domains/chat/utils/map-message-tool-calls";
+import { finalizeOnIdle } from "@/domains/chat/utils/stream-updaters/message-updaters";
 import { messagePlainText } from "@/domains/chat/utils/message-plain-text";
 import { mapRuntimeToDisplayMessage } from "@/domains/chat/utils/map-runtime-message";
 import { liveAssistantRowId } from "@/domains/chat/utils/stream-updaters/shared";
@@ -310,22 +309,11 @@ export function useMessageReconciliation({
         });
       }
 
-      // Force-complete stale running tool calls. After onPollReconciled the
-      // turn is idle. With Zustand, getState() reflects the update
-      // immediately.
+      // Force-complete stale running tool calls (and drop orphaned preview
+      // blocks — see `finalizeOnIdle`). After onPollReconciled the turn is
+      // idle. With Zustand, getState() reflects the update immediately.
       if (wasStuck || !isSending(useTurnStore.getState().phase)) {
-        setMessages((prev) => {
-          const hasStaleToolCalls = prev.some((m) =>
-            m.toolCalls?.some((tc) => isToolCallRunning(tc)),
-          );
-          if (!hasStaleToolCalls) return prev;
-          const completedAt = Date.now();
-          return prev.map((m) =>
-            mapMessageToolCalls(m, (tc) =>
-              isToolCallRunning(tc) ? { ...tc, completedAt } : tc,
-            ),
-          );
-        });
+        setMessages(finalizeOnIdle);
       }
 
       return { changed, assistantProgress, messagesAdded };

--- a/apps/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/apps/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -47,6 +47,7 @@ import {
   handleUISurfaceComplete,
 } from "@/domains/chat/utils/stream-handlers/surface-handlers";
 import {
+  handleToolUsePreviewStart,
   handleToolUseStart,
   handleToolResult,
 } from "@/domains/chat/utils/stream-handlers/tool-call-handlers";
@@ -308,10 +309,11 @@ export function useStreamEventHandler(
         case "tool_result":
           handleToolResult(event, ctx);
           break;
-        // The web transcript renders tool activity from `tool_use_start`
-        // and `tool_result`. It does not surface the optimistic pre-input
-        // affordance or incremental output chunks, so these are ignored.
         case "tool_use_preview_start":
+          handleToolUsePreviewStart(event, ctx);
+          break;
+        // Incremental output chunks are not surfaced; the transcript shows
+        // the full result from `tool_result`.
         case "tool_output_chunk":
           break;
         case "usage_update":

--- a/apps/web/src/domains/chat/utils/stream-handlers/error-handlers.test.ts
+++ b/apps/web/src/domains/chat/utils/stream-handlers/error-handlers.test.ts
@@ -17,6 +17,32 @@ describe("handleStreamError", () => {
     expect(ctx.setError).toHaveBeenCalled();
     expect(ctx.cancelAndClearStream).toHaveBeenCalled();
   });
+
+  it("removes orphaned preview tool calls before tearing down the stream", () => {
+    // The teardown below kills the SSE connection before the daemon's idle
+    // activity event arrives, so the idle-time preview cleanup never runs.
+    const ctx = makeCtx();
+    handleStreamError({ type: "error", message: "boom" }, ctx);
+
+    const updater = (
+      ctx.setMessages as unknown as { mock: { calls: unknown[][] } }
+    ).mock.calls[0]![0] as (
+      prev: Array<{
+        role: string;
+        toolCalls?: Array<{ id: string; isPreview?: boolean }>;
+      }>,
+    ) => Array<{ toolCalls?: Array<{ id: string }> }>;
+    const next = updater([
+      {
+        role: "assistant",
+        toolCalls: [
+          { id: "tc-real" },
+          { id: "tc-preview", isPreview: true },
+        ],
+      },
+    ]);
+    expect(next[0]!.toolCalls!.map((tc) => tc.id)).toEqual(["tc-real"]);
+  });
 });
 
 describe("handleConversationErrorEvent", () => {

--- a/apps/web/src/domains/chat/utils/stream-handlers/error-handlers.test.ts
+++ b/apps/web/src/domains/chat/utils/stream-handlers/error-handlers.test.ts
@@ -29,18 +29,29 @@ describe("handleStreamError", () => {
     ).mock.calls[0]![0] as (
       prev: Array<{
         role: string;
-        toolCalls?: Array<{ id: string; isPreview?: boolean }>;
+        toolCalls?: Array<{ id: string; name?: string; isPreview?: boolean }>;
+        textSegments?: string[];
       }>,
-    ) => Array<{ toolCalls?: Array<{ id: string }> }>;
+    ) => Array<{ role: string; toolCalls?: Array<{ id: string }> }>;
     const next = updater([
       {
         role: "assistant",
+        textSegments: ["partial text"],
         toolCalls: [
-          { id: "tc-real" },
-          { id: "tc-preview", isPreview: true },
+          { id: "tc-real", name: "bash" },
+          { id: "tc-preview", name: "write_file", isPreview: true },
+        ],
+      },
+      {
+        // A bubble whose only content was the preview must vanish entirely,
+        // not linger as a blank assistant row.
+        role: "assistant",
+        toolCalls: [
+          { id: "tc-preview-2", name: "write_file", isPreview: true },
         ],
       },
     ]);
+    expect(next).toHaveLength(1);
     expect(next[0]!.toolCalls!.map((tc) => tc.id)).toEqual(["tc-real"]);
   });
 });

--- a/apps/web/src/domains/chat/utils/stream-handlers/error-handlers.ts
+++ b/apps/web/src/domains/chat/utils/stream-handlers/error-handlers.ts
@@ -1,5 +1,6 @@
 import { shouldSuppressGenericChatErrorNotice } from "@/domains/chat/utils/error-classification";
 import { handleConversationError } from "@/domains/chat/utils/stream-updaters/message-updaters";
+import { removePreviewToolCalls } from "@/domains/chat/utils/stream-updaters/shared";
 import { ERROR_MESSAGES } from "@/domains/chat/utils/chat";
 import type { StreamHandlerContext } from "@/domains/chat/utils/stream-handlers/types";
 import { patchConversation } from "@/utils/conversation-cache";
@@ -22,6 +23,16 @@ export function handleStreamError(
     });
   }
   ctx.endTurn({ conversationId: convId, reason: "error" });
+  // The stream is torn down below before the daemon's idle activity event
+  // can arrive, so `finalizeOnIdle` (the usual preview cleanup point) never
+  // runs — drop orphaned preview tool calls here or they spin forever.
+  ctx.setMessages((prev) =>
+    prev.map((m) => {
+      if (m.role !== "assistant") return m;
+      const removed = removePreviewToolCalls(m);
+      return removed ? { ...m, ...removed } : m;
+    }),
+  );
   const detail =
     (event.code && ERROR_MESSAGES[event.code]) ||
     event.message ||

--- a/apps/web/src/domains/chat/utils/stream-handlers/error-handlers.ts
+++ b/apps/web/src/domains/chat/utils/stream-handlers/error-handlers.ts
@@ -1,6 +1,8 @@
 import { shouldSuppressGenericChatErrorNotice } from "@/domains/chat/utils/error-classification";
-import { handleConversationError } from "@/domains/chat/utils/stream-updaters/message-updaters";
-import { removePreviewToolCalls } from "@/domains/chat/utils/stream-updaters/shared";
+import {
+  dropOrphanedPreviewToolCalls,
+  handleConversationError,
+} from "@/domains/chat/utils/stream-updaters/message-updaters";
 import { ERROR_MESSAGES } from "@/domains/chat/utils/chat";
 import type { StreamHandlerContext } from "@/domains/chat/utils/stream-handlers/types";
 import { patchConversation } from "@/utils/conversation-cache";
@@ -26,13 +28,7 @@ export function handleStreamError(
   // The stream is torn down below before the daemon's idle activity event
   // can arrive, so `finalizeOnIdle` (the usual preview cleanup point) never
   // runs — drop orphaned preview tool calls here or they spin forever.
-  ctx.setMessages((prev) =>
-    prev.map((m) => {
-      if (m.role !== "assistant") return m;
-      const removed = removePreviewToolCalls(m);
-      return removed ? { ...m, ...removed } : m;
-    }),
-  );
+  ctx.setMessages(dropOrphanedPreviewToolCalls);
   const detail =
     (event.code && ERROR_MESSAGES[event.code]) ||
     event.message ||

--- a/apps/web/src/domains/chat/utils/stream-handlers/tool-call-handlers.test.ts
+++ b/apps/web/src/domains/chat/utils/stream-handlers/tool-call-handlers.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "bun:test";
 import { makeCtx } from "@/domains/chat/utils/stream-handlers/test-helpers";
 import {
   handleToolResult,
+  handleToolUsePreviewStart,
   handleToolUseStart,
 } from "@/domains/chat/utils/stream-handlers/tool-call-handlers";
 
@@ -104,6 +105,85 @@ describe("handleToolUseStart", () => {
     expect(current[0]!.isOptimistic).toBeUndefined();
     expect(current[0]!.toolCalls).toHaveLength(3);
     expect(current[0]!.toolCalls!.map((tc) => tc.id)).toEqual(["tc-1", "tc-2", "tc-3"]);
+  });
+});
+
+describe("handleToolUsePreviewStart", () => {
+  it("renders a pending tool call block without touching the turn store", () => {
+    const ctx = makeCtx();
+    handleToolUsePreviewStart(
+      {
+        type: "tool_use_preview_start",
+        toolUseId: "tc-1",
+        toolName: "write_file",
+        messageId: "anchor-1",
+      },
+      ctx,
+    );
+    expect(ctx.cancelReconciliation).toHaveBeenCalled();
+    // Previews must not increment the onToolUseStart/onToolResult pair —
+    // the matching tool_use_start will, and a preview has no tool_result.
+    expect(ctx.turnActions.onToolUseStart).not.toHaveBeenCalled();
+
+    const updater = (ctx.setMessages as unknown as { mock: { calls: unknown[][] } })
+      .mock.calls[0]![0] as (
+      prev: never[],
+    ) => Array<{
+      role: string;
+      toolCalls: Array<{ id: string; name: string; input: unknown; isPreview?: boolean }>;
+    }>;
+    const next = updater([]);
+    expect(next).toHaveLength(1);
+    expect(next[0]?.role).toBe("assistant");
+    const tc = next[0]?.toolCalls[0];
+    expect(tc?.id).toBe("tc-1");
+    expect(tc?.name).toBe("write_file");
+    expect(tc?.input).toEqual({});
+    expect(tc?.isPreview).toBe(true);
+  });
+
+  it("is upgraded in place by a subsequent tool_use_start with the same id", () => {
+    const ctx = makeCtx();
+    type Row = {
+      role: string;
+      toolCalls?: Array<{
+        id: string;
+        input: Record<string, unknown>;
+        isPreview?: boolean;
+      }>;
+    };
+    let current: Row[] = [];
+    const setMessages = ctx.setMessages as unknown as {
+      mock: { calls: unknown[][] };
+    };
+
+    handleToolUsePreviewStart(
+      {
+        type: "tool_use_preview_start",
+        toolUseId: "tc-1",
+        toolName: "write_file",
+        messageId: "anchor-1",
+      },
+      ctx,
+    );
+    current = (setMessages.mock.calls[0]![0] as (p: Row[]) => Row[])(current);
+
+    handleToolUseStart(
+      {
+        type: "tool_use_start",
+        toolUseId: "tc-1",
+        toolName: "write_file",
+        input: { path: "a.txt" },
+        messageId: "anchor-1",
+      },
+      ctx,
+    );
+    current = (setMessages.mock.calls[1]![0] as (p: Row[]) => Row[])(current);
+
+    expect(current).toHaveLength(1);
+    expect(current[0]!.toolCalls).toHaveLength(1);
+    expect(current[0]!.toolCalls![0]!.isPreview).toBe(false);
+    expect(current[0]!.toolCalls![0]!.input).toEqual({ path: "a.txt" });
   });
 });
 

--- a/apps/web/src/domains/chat/utils/stream-handlers/tool-call-handlers.ts
+++ b/apps/web/src/domains/chat/utils/stream-handlers/tool-call-handlers.ts
@@ -6,8 +6,43 @@ import type { StreamHandlerContext } from "@/domains/chat/utils/stream-handlers/
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type {
   ToolResultEvent,
+  ToolUsePreviewStartEvent,
   ToolUseStartEvent,
 } from "@vellumai/assistant-api";
+
+/**
+ * Render a pending tool-call block the moment the model starts generating a
+ * tool call, before its arguments finish streaming. The block carries the
+ * tool name with empty input and reads as "running" (spinner) until the
+ * matching `tool_use_start` upgrades it in place with the real input —
+ * `upsertToolCall` merges by id, and the daemon emits both events with the
+ * same provider tool-use id.
+ *
+ * Deliberately does not touch the turn store: `onToolUseStart`/`onToolResult`
+ * are a balanced pair, and a preview followed by its `tool_use_start` would
+ * double-count the call.
+ */
+export function handleToolUsePreviewStart(
+  event: ToolUsePreviewStartEvent,
+  ctx: StreamHandlerContext,
+): void {
+  ctx.cancelReconciliation();
+  const newToolCall: ChatMessageToolCall = {
+    id: event.toolUseId,
+    name: event.toolName,
+    input: {},
+    isPreview: true,
+    startedAt: Date.now(),
+  };
+  ctx.setMessages((prev) => {
+    const next = upsertToolCall(prev, newToolCall, event.messageId);
+    const tail = next[next.length - 1];
+    if (tail?.role === "assistant") {
+      ctx.currentAssistantMessageIdRef.current = tail.id;
+    }
+    return next;
+  });
+}
 
 export function handleToolUseStart(
   event: ToolUseStartEvent,
@@ -21,6 +56,9 @@ export function handleToolUseStart(
     id: toolCallId,
     name: event.toolName,
     input: event.input,
+    // Explicit false (not omitted) so the by-id merge in `upsertToolCall`
+    // clears the flag when this event upgrades a preview block in place.
+    isPreview: false,
     startedAt:
       "startedAt" in event &&
       typeof event.startedAt === "number"

--- a/apps/web/src/domains/chat/utils/stream-updaters/message-updaters.ts
+++ b/apps/web/src/domains/chat/utils/stream-updaters/message-updaters.ts
@@ -21,6 +21,7 @@ import {
   findAssistantRowIndexByMessageId,
   withMergedAlias,
   finalizeRunningToolCalls,
+  removePreviewToolCalls,
 } from "@/domains/chat/utils/stream-updaters/shared";
 
 // ---------------------------------------------------------------------------
@@ -272,15 +273,24 @@ export function appendThinkingDelta(
  * any running tool calls as completed. Liveness is derived from the
  * conversation's processing state (see `liveAssistantRowId`), which the
  * idle event clears, so no per-row flag needs flipping here.
+ *
+ * Orphaned preview tool calls — `tool_use_preview_start` blocks whose
+ * `tool_use_start` never arrived (generation aborted or cancelled
+ * mid-arguments) — are removed rather than completed: previews are ephemeral
+ * and the durable transcript only contains real tool_use blocks. The daemon
+ * emits an idle activity state on every terminal path (complete, cancelled,
+ * error), so this is the single cleanup choke point.
  */
 export function finalizeOnIdle(prev: DisplayMessage[]): DisplayMessage[] {
   let changed = false;
   const updated = prev.map((m) => {
     if (m.role !== "assistant") return m;
-    const finalized = finalizeRunningToolCalls(m);
-    if (!finalized) return m;
+    const withoutPreviews = removePreviewToolCalls(m);
+    const row = withoutPreviews ? { ...m, ...withoutPreviews } : m;
+    const finalized = finalizeRunningToolCalls(row);
+    if (!withoutPreviews && !finalized) return m;
     changed = true;
-    return { ...m, ...finalized };
+    return finalized ? { ...row, ...finalized } : row;
   });
   return changed ? updated : prev;
 }

--- a/apps/web/src/domains/chat/utils/stream-updaters/message-updaters.ts
+++ b/apps/web/src/domains/chat/utils/stream-updaters/message-updaters.ts
@@ -475,8 +475,16 @@ export function handleConversationError(
   prev: DisplayMessage[],
 ): DisplayMessage[] {
   const lastIdx = prev.length - 1;
-  const last = prev[lastIdx];
-  if (!last || last.role !== "assistant") return prev;
+  const tail = prev[lastIdx];
+  if (!tail || tail.role !== "assistant") return prev;
+
+  // Drop preview tool calls first: a non-banner conversation_error tears the
+  // stream down before the idle activity event arrives, so `finalizeOnIdle`
+  // (the usual preview cleanup point) never runs and an orphaned preview
+  // would spin forever. Removing them here also lets a preview-only bubble
+  // correctly read as empty below.
+  const withoutPreviews = removePreviewToolCalls(tail);
+  const last = withoutPreviews ? { ...tail, ...withoutPreviews } : tail;
 
   const finalized = finalizeRunningToolCalls(last);
   const hasContent =

--- a/apps/web/src/domains/chat/utils/stream-updaters/message-updaters.ts
+++ b/apps/web/src/domains/chat/utils/stream-updaters/message-updaters.ts
@@ -470,6 +470,36 @@ export function applyUserMessageEcho(
 // conversation_error
 // ---------------------------------------------------------------------------
 
+/** Whether an assistant row carries any user-visible content. */
+function assistantRowHasContent(row: DisplayMessage): boolean {
+  return (
+    messagePlainText(row).trim().length > 0 ||
+    (row.thinkingSegments != null && row.thinkingSegments.length > 0) ||
+    (row.toolCalls != null && row.toolCalls.length > 0) ||
+    (row.surfaces != null && row.surfaces.length > 0)
+  );
+}
+
+/**
+ * Drop orphaned preview tool calls from every assistant row, removing rows
+ * left with no content at all (a bubble whose only content was the preview).
+ * Used by the terminal error handlers: they tear the stream down before the
+ * daemon's idle activity event arrives, so `finalizeOnIdle` (the usual
+ * preview cleanup point) never runs and an orphaned preview would spin
+ * forever.
+ */
+export function dropOrphanedPreviewToolCalls(
+  prev: DisplayMessage[],
+): DisplayMessage[] {
+  return prev.flatMap((m) => {
+    if (m.role !== "assistant") return [m];
+    const removed = removePreviewToolCalls(m);
+    if (!removed) return [m];
+    const row = { ...m, ...removed };
+    return assistantRowHasContent(row) ? [row] : [];
+  });
+}
+
 /** Handle conversation error: finalize tool calls, remove empty bubbles. */
 export function handleConversationError(
   prev: DisplayMessage[],
@@ -478,22 +508,14 @@ export function handleConversationError(
   const tail = prev[lastIdx];
   if (!tail || tail.role !== "assistant") return prev;
 
-  // Drop preview tool calls first: a non-banner conversation_error tears the
-  // stream down before the idle activity event arrives, so `finalizeOnIdle`
-  // (the usual preview cleanup point) never runs and an orphaned preview
-  // would spin forever. Removing them here also lets a preview-only bubble
-  // correctly read as empty below.
+  // Drop preview tool calls first — see `dropOrphanedPreviewToolCalls` for
+  // why error paths must clean previews themselves. Removing them here also
+  // lets a preview-only bubble correctly read as empty below.
   const withoutPreviews = removePreviewToolCalls(tail);
   const last = withoutPreviews ? { ...tail, ...withoutPreviews } : tail;
 
   const finalized = finalizeRunningToolCalls(last);
-  const hasContent =
-    messagePlainText(last).trim().length > 0 ||
-    (last.thinkingSegments != null && last.thinkingSegments.length > 0) ||
-    (last.toolCalls != null && last.toolCalls.length > 0) ||
-    (last.surfaces != null && last.surfaces.length > 0);
-
-  if (!hasContent) return prev.slice(0, -1);
+  if (!assistantRowHasContent(last)) return prev.slice(0, -1);
 
   const updated = [...prev];
   updated[lastIdx] = {

--- a/apps/web/src/domains/chat/utils/stream-updaters/shared.ts
+++ b/apps/web/src/domains/chat/utils/stream-updaters/shared.ts
@@ -104,25 +104,71 @@ export function withMergedAlias(
  * slice. With no `result`/`isError`, the timestamp alone reads as completed
  * (not running); reconcile later backfills the real result if it arrives.
  *
+ * Preview tool calls (`isPreview` — args still streaming) are skipped: the
+ * daemon emits `message_complete` *before* the `tool_use_start` events of the
+ * same LLM call, so stamping a preview here would freeze its eventual upgrade
+ * in a falsely-completed state. Orphaned previews are instead removed at turn
+ * idle via `removePreviewToolCalls`.
+ *
  * Returns the patched `toolCalls`/`contentBlocks` fields, or `null` when no
  * tool call was running, so callers can skip rewriting the row.
  */
 export function finalizeRunningToolCalls(
   row: Pick<DisplayMessage, "toolCalls" | "contentBlocks">,
 ): Pick<DisplayMessage, "toolCalls" | "contentBlocks"> | null {
-  if (!row.toolCalls?.some((tc) => isToolCallRunning(tc))) {
+  if (
+    !row.toolCalls?.some((tc) => !tc.isPreview && isToolCallRunning(tc))
+  ) {
     return null;
   }
+  const previewIds = new Set(
+    row.toolCalls.filter((tc) => tc.isPreview).map((tc) => tc.id),
+  );
   const completedAt = Date.now();
   const toolCalls = row.toolCalls.map((tc) =>
-    isToolCallRunning(tc) ? { ...tc, completedAt } : tc,
+    !tc.isPreview && isToolCallRunning(tc) ? { ...tc, completedAt } : tc,
   );
   const contentBlocks = row.contentBlocks?.map((block) =>
-    block.type === "tool_use" && isToolCallRunning(block.toolCall)
+    block.type === "tool_use" &&
+    isToolCallRunning(block.toolCall) &&
+    !previewIds.has(block.toolCall.id ?? "")
       ? { type: "tool_use" as const, toolCall: { ...block.toolCall, completedAt } }
       : block,
   );
   return { toolCalls, contentBlocks };
+}
+
+/**
+ * Drop preview tool calls (`isPreview` — see `ChatMessageToolCall`) from a
+ * row, across `toolCalls`, `contentOrder`, and `contentBlocks`. A preview
+ * still present at turn end never received its `tool_use_start` (the model
+ * aborted or was cancelled mid-arguments) and must not persist — the durable
+ * transcript only contains real tool_use blocks.
+ *
+ * Returns the patched fields, or `null` when the row has no previews.
+ */
+export function removePreviewToolCalls(
+  row: Pick<DisplayMessage, "toolCalls" | "contentOrder" | "contentBlocks">,
+): Pick<
+  DisplayMessage,
+  "toolCalls" | "contentOrder" | "contentBlocks"
+> | null {
+  const previewIds = new Set(
+    (row.toolCalls ?? []).filter((tc) => tc.isPreview).map((tc) => tc.id),
+  );
+  if (previewIds.size === 0) {
+    return null;
+  }
+  return {
+    toolCalls: row.toolCalls?.filter((tc) => !previewIds.has(tc.id)),
+    contentOrder: row.contentOrder?.filter(
+      (entry) => !(entry.type === "toolCall" && previewIds.has(entry.id)),
+    ),
+    contentBlocks: row.contentBlocks?.filter(
+      (block) =>
+        !(block.type === "tool_use" && previewIds.has(block.toolCall.id ?? "")),
+    ),
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/domains/chat/utils/stream-updaters/stream-updaters.test.ts
+++ b/apps/web/src/domains/chat/utils/stream-updaters/stream-updaters.test.ts
@@ -451,6 +451,41 @@ describe("handleConversationError", () => {
     const result = handleConversationError(prev);
     expect(result).toBe(prev);
   });
+
+  it("removes orphaned preview tool calls instead of leaving them spinning", () => {
+    // A non-banner conversation_error tears the stream down before the idle
+    // activity event arrives, so this handler is the preview's last chance
+    // at cleanup.
+    const msg = makeAssistantMsg({
+      ...seg("partial response"),
+      toolCalls: [
+        { id: "tc-real", name: "bash", input: {} },
+        { id: "tc-preview", name: "write_file", input: {}, isPreview: true },
+      ],
+      contentOrder: [
+        { type: "toolCall", id: "tc-real" },
+        { type: "toolCall", id: "tc-preview" },
+      ],
+    });
+    const result = handleConversationError([userMsg, msg]);
+
+    expect(result[1]!.toolCalls!.map((tc) => tc.id)).toEqual(["tc-real"]);
+    expect(isToolCallCompleted(result[1]!.toolCalls![0]!)).toBe(true);
+  });
+
+  it("removes a bubble whose only content was a preview tool call", () => {
+    const msg = makeAssistantMsg({
+      ...seg(""),
+      toolCalls: [
+        { id: "tc-preview", name: "write_file", input: {}, isPreview: true },
+      ],
+      contentOrder: [{ type: "toolCall", id: "tc-preview" }],
+    });
+    const result = handleConversationError([userMsg, msg]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(userMsg);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/domains/chat/utils/stream-updaters/stream-updaters.test.ts
+++ b/apps/web/src/domains/chat/utils/stream-updaters/stream-updaters.test.ts
@@ -895,6 +895,121 @@ describe("finalizeOnIdle", () => {
     expect(isToolCallCompleted(result[0]!.toolCalls![0]!)).toBe(true);
     expect(isToolCallCompleted(result[1]!.toolCalls![0]!)).toBe(true);
   });
+
+  it("removes orphaned preview tool calls instead of completing them", () => {
+    // A preview whose tool_use_start never arrived (model aborted or was
+    // cancelled mid-arguments) must vanish at idle, across all three slices.
+    const msg = makeAssistantMsg({
+      toolCalls: [
+        { id: "tc-real", name: "bash", input: {} },
+        { id: "tc-preview", name: "write_file", input: {}, isPreview: true },
+      ],
+      contentOrder: [
+        { type: "toolCall", id: "tc-real" },
+        { type: "toolCall", id: "tc-preview" },
+      ],
+      contentBlocks: [
+        {
+          type: "tool_use",
+          toolCall: { id: "tc-real", name: "bash", input: {} },
+        },
+        {
+          type: "tool_use",
+          toolCall: { id: "tc-preview", name: "write_file", input: {} },
+        },
+      ],
+    });
+    const result = finalizeOnIdle([msg]);
+
+    expect(result[0]!.toolCalls!.map((tc) => tc.id)).toEqual(["tc-real"]);
+    expect(isToolCallCompleted(result[0]!.toolCalls![0]!)).toBe(true);
+    expect(result[0]!.contentOrder).toEqual([
+      { type: "toolCall", id: "tc-real" },
+    ]);
+    expect(
+      result[0]!.contentBlocks!.filter((b) => b.type === "tool_use"),
+    ).toHaveLength(1);
+  });
+
+  it("removes previews even when no other tool call needs finalizing", () => {
+    const msg = makeAssistantMsg({
+      toolCalls: [
+        { id: "tc-preview", name: "write_file", input: {}, isPreview: true },
+      ],
+      contentOrder: [{ type: "toolCall", id: "tc-preview" }],
+    });
+    const result = finalizeOnIdle([msg]);
+
+    expect(result[0]!.toolCalls).toHaveLength(0);
+    expect(result[0]!.contentOrder).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// preview tool calls — message_complete must not freeze them
+// ---------------------------------------------------------------------------
+
+describe("finalizeMessageComplete with preview tool calls", () => {
+  it("leaves previews running: tool_use_start for them arrives after message_complete", () => {
+    // The daemon emits message_complete BEFORE the tool_use_start events of
+    // the same LLM call. Stamping completedAt on a preview here would make
+    // the eventual in-place upgrade read as already-completed while the tool
+    // is actually still executing.
+    const msg = makeAssistantMsg({
+      toolCalls: [
+        { id: "tc-preview", name: "write_file", input: {}, isPreview: true },
+      ],
+      contentOrder: [{ type: "toolCall", id: "tc-preview" }],
+    });
+    const result = finalizeMessageComplete([userMsg, msg], {
+      type: "message_complete",
+      messageId: "stable-1",
+    });
+
+    const tc = result[1]!.toolCalls![0]!;
+    expect(tc.completedAt).toBeUndefined();
+    expect(isToolCallRunning(tc)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// preview tool calls — in-place upgrade by tool_use_start
+// ---------------------------------------------------------------------------
+
+describe("upsertToolCall preview upgrade", () => {
+  it("upgrades a preview in place when tool_use_start arrives with the same id", () => {
+    const preview: ChatMessageToolCall = {
+      id: "tc-1",
+      name: "write_file",
+      input: {},
+      isPreview: true,
+      startedAt: 1000,
+    };
+    const withPreview = upsertToolCall([userMsg], preview, "anchor-1");
+    expect(withPreview[1]!.toolCalls![0]!.isPreview).toBe(true);
+
+    const real: ChatMessageToolCall = {
+      id: "tc-1",
+      name: "write_file",
+      input: { path: "a.txt", content: "hello" },
+      isPreview: false,
+      startedAt: 2000,
+    };
+    const upgraded = upsertToolCall(withPreview, real, "anchor-1");
+
+    // Same row, same single tool call — upgraded, not duplicated.
+    expect(upgraded).toHaveLength(2);
+    expect(upgraded[1]!.toolCalls).toHaveLength(1);
+    const tc = upgraded[1]!.toolCalls![0]!;
+    expect(tc.isPreview).toBe(false);
+    expect(tc.input).toEqual({ path: "a.txt", content: "hello" });
+    expect(tc.startedAt).toBe(2000);
+    expect(isToolCallRunning(tc)).toBe(true);
+    // contentOrder gains no duplicate entry.
+    expect(
+      upgraded[1]!.contentOrder!.filter((e) => e.id === "tc-1"),
+    ).toHaveLength(1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/providers/openai/__tests__/tool-use-preview.test.ts
+++ b/assistant/src/providers/openai/__tests__/tool-use-preview.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, test } from "bun:test";
+
+import { OpenAIChatCompletionsProvider } from "../chat-completions-provider.js";
+import { OpenAIResponsesProvider } from "../responses-provider.js";
+
+/**
+ * Both OpenAI-compatible providers must emit `tool_use_preview_start` as soon
+ * as a tool call's identity (id + name) is known in the stream — before its
+ * arguments finish — mirroring the Anthropic client's tool preview lifecycle
+ * (see `tool-preview-lifecycle.test.ts`). The preview's `toolUseId` must match
+ * the id of the final `tool_use` content block so clients can upgrade the
+ * preview block in place.
+ */
+
+type CapturedEvent = {
+  type: string;
+  toolUseId?: string;
+  toolName?: string;
+};
+
+function makeStream<T>(chunks: T[]): AsyncIterable<T> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const c of chunks) yield c;
+    },
+  };
+}
+
+async function collectEvents(
+  provider: OpenAIChatCompletionsProvider | OpenAIResponsesProvider,
+): Promise<{
+  events: CapturedEvent[];
+  content: Array<{ type: string; id?: string; name?: string; input?: unknown }>;
+}> {
+  const events: CapturedEvent[] = [];
+  const response = await provider.sendMessage(
+    [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+    { onEvent: (e) => events.push(e as CapturedEvent) },
+  );
+  return {
+    events,
+    content: response.content as Array<{
+      type: string;
+      id?: string;
+      name?: string;
+      input?: unknown;
+    }>,
+  };
+}
+
+describe("OpenAIChatCompletionsProvider tool_use_preview_start", () => {
+  function stubProvider(chunks: unknown[]): OpenAIChatCompletionsProvider {
+    const provider = new OpenAIChatCompletionsProvider(
+      "test-key",
+      "test-model",
+    );
+    (provider as unknown as { client: unknown }).client = {
+      chat: {
+        completions: {
+          create: async () => makeStream(chunks),
+        },
+      },
+    };
+    return provider;
+  }
+
+  test("emits preview once per tool call, before arguments finish, with the final tool_use id", async () => {
+    const provider = stubProvider([
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "call_abc",
+                  function: { name: "write_file", arguments: "" },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                { index: 0, function: { arguments: '{"path":"a.txt",' } },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                { index: 0, function: { arguments: '"content":"hello"}' } },
+              ],
+            },
+            finish_reason: "tool_calls",
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 2 },
+      },
+    ]);
+
+    const { events, content } = await collectEvents(provider);
+    const previews = events.filter((e) => e.type === "tool_use_preview_start");
+    expect(previews).toEqual([
+      {
+        type: "tool_use_preview_start",
+        toolUseId: "call_abc",
+        toolName: "write_file",
+      },
+    ]);
+
+    const toolUse = content.find((b) => b.type === "tool_use");
+    expect(toolUse?.id).toBe("call_abc");
+    expect(toolUse?.input).toEqual({ path: "a.txt", content: "hello" });
+  });
+
+  test("emits one preview per parallel tool call", async () => {
+    const provider = stubProvider([
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "call_1",
+                  function: { name: "tool_a", arguments: "{}" },
+                },
+                {
+                  index: 1,
+                  id: "call_2",
+                  function: { name: "tool_b", arguments: "{}" },
+                },
+              ],
+            },
+            finish_reason: "tool_calls",
+          },
+        ],
+        usage: { prompt_tokens: 1, completion_tokens: 2 },
+      },
+    ]);
+
+    const { events } = await collectEvents(provider);
+    const previews = events.filter((e) => e.type === "tool_use_preview_start");
+    expect(previews.map((p) => [p.toolUseId, p.toolName])).toEqual([
+      ["call_1", "tool_a"],
+      ["call_2", "tool_b"],
+    ]);
+  });
+
+  test("emits no preview when the stream has no tool calls", async () => {
+    const provider = stubProvider([
+      { choices: [{ delta: { content: "plain text" } }] },
+      {
+        choices: [{ delta: {}, finish_reason: "stop" }],
+        usage: { prompt_tokens: 1, completion_tokens: 2 },
+      },
+    ]);
+
+    const { events } = await collectEvents(provider);
+    expect(
+      events.filter((e) => e.type === "tool_use_preview_start"),
+    ).toHaveLength(0);
+  });
+});
+
+describe("OpenAIResponsesProvider tool_use_preview_start", () => {
+  function stubProvider(chunks: unknown[]): OpenAIResponsesProvider {
+    const provider = new OpenAIResponsesProvider("test-key", "test-model");
+    (provider as unknown as { client: unknown }).client = {
+      responses: {
+        create: async () => makeStream(chunks),
+      },
+    };
+    return provider;
+  }
+
+  test("emits preview at output_item.added, before arguments stream, with the final tool_use id", async () => {
+    const provider = stubProvider([
+      {
+        type: "response.output_item.added",
+        item: {
+          type: "function_call",
+          id: "item_1",
+          call_id: "call_xyz",
+          name: "write_file",
+        },
+      },
+      {
+        type: "response.function_call_arguments.delta",
+        item_id: "item_1",
+        delta: '{"path":"a.txt"}',
+      },
+      {
+        type: "response.function_call_arguments.done",
+        item_id: "item_1",
+        arguments: '{"path":"a.txt"}',
+      },
+      {
+        type: "response.completed",
+        response: {
+          status: "completed",
+          usage: { input_tokens: 1, output_tokens: 2 },
+        },
+      },
+    ]);
+
+    const { events, content } = await collectEvents(provider);
+    const previews = events.filter((e) => e.type === "tool_use_preview_start");
+    expect(previews).toEqual([
+      {
+        type: "tool_use_preview_start",
+        toolUseId: "call_xyz",
+        toolName: "write_file",
+      },
+    ]);
+
+    const toolUse = content.find((b) => b.type === "tool_use");
+    expect(toolUse?.id).toBe("call_xyz");
+    expect(toolUse?.input).toEqual({ path: "a.txt" });
+  });
+
+  test("emits no preview for non-function output items", async () => {
+    const provider = stubProvider([
+      {
+        type: "response.output_item.added",
+        item: { type: "web_search_call", id: "ws_1" },
+      },
+      { type: "response.output_text.delta", delta: "results" },
+      {
+        type: "response.completed",
+        response: {
+          status: "completed",
+          usage: { input_tokens: 1, output_tokens: 2 },
+        },
+      },
+    ]);
+
+    const { events } = await collectEvents(provider);
+    expect(
+      events.filter((e) => e.type === "tool_use_preview_start"),
+    ).toHaveLength(0);
+  });
+});

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -486,7 +486,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
 
       const toolCallMap = new Map<
         number,
-        { id: string; name: string; args: string }
+        { id: string; name: string; args: string; previewEmitted: boolean }
       >();
       let finishReason = "unknown";
       let responseModel = modelOverride ?? this.model;
@@ -572,12 +572,30 @@ export class OpenAIChatCompletionsProvider implements Provider {
             if (choice.delta.tool_calls) {
               for (const tc of choice.delta.tool_calls) {
                 if (!toolCallMap.has(tc.index)) {
-                  toolCallMap.set(tc.index, { id: "", name: "", args: "" });
+                  toolCallMap.set(tc.index, {
+                    id: "",
+                    name: "",
+                    args: "",
+                    previewEmitted: false,
+                  });
                 }
                 const entry = toolCallMap.get(tc.index)!;
                 if (tc.id) entry.id = tc.id;
                 if (tc.function?.name) entry.name += tc.function.name;
                 if (tc.function?.arguments) entry.args += tc.function.arguments;
+                // Surface the tool call as soon as its identity is known so
+                // clients can show activity while arguments stream. The id and
+                // full name arrive together in the call's first delta chunk;
+                // the toolUseId must match the final tool_use block (entry.id)
+                // so clients can upgrade the preview in place.
+                if (!entry.previewEmitted && entry.id && entry.name) {
+                  entry.previewEmitted = true;
+                  onEvent?.({
+                    type: "tool_use_preview_start",
+                    toolUseId: entry.id,
+                    toolName: entry.name,
+                  });
+                }
               }
             }
 

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -348,6 +348,17 @@ export class OpenAIResponsesProvider implements Provider {
                   args: "",
                 });
                 itemIdToCallId.set(itemId, callId);
+                // Surface the tool call as soon as the item is announced so
+                // clients can show activity while arguments stream. The
+                // toolUseId must match the final tool_use block (callId) so
+                // clients can upgrade the preview in place.
+                if (callId && name) {
+                  onEvent?.({
+                    type: "tool_use_preview_start",
+                    toolUseId: callId,
+                    toolName: name,
+                  });
+                }
               } else if (item?.type === "web_search_call") {
                 const toolUseId = item.id ?? "";
                 webSearchCallIds.push(toolUseId);


### PR DESCRIPTION
## Summary
- Emit `tool_use_preview_start` from the OpenAI Responses and chat-completions providers as soon as a tool call's id+name appear in the stream, mirroring the Anthropic client's tool preview lifecycle (#14887). One change covers OpenRouter/Fireworks/Minimax/Ollama/inference since they extend the chat-completions provider; Gemini is left alone because it never streams partial function-call args.
- Web now renders a pending tool-call block (name + spinner, empty input) on `tool_use_preview_start` and upgrades it in place when `tool_use_start` lands with the same tool-use id — previously the tool call only appeared after the full input JSON finished generating, so long-argument tools (file writes) made the UI look stalled.
- Preview blocks are ephemeral: `message_complete` finalization skips them (it fires *before* the same call's `tool_use_start`), and turn-idle finalization removes any orphaned preview whose `tool_use_start` never arrived (model aborted / user cancelled mid-arguments). The poll-rescue path in `use-message-reconciliation` now reuses `finalizeOnIdle` instead of its own inline stamping.

## Original prompt
While investigating whether the UI streams tool calls during generation, we found the daemon's tool-preview lifecycle was only wired into the Anthropic provider, the daemon-side `tool_input_delta` forwarding is filtered to app tools, and the web client explicitly ignored `tool_use_preview_start` — so for long-argument tools the UI showed nothing until the full tool call finished generating. The ask: show the tool call in the web UI as soon as the model starts generating it, and make it work across providers. Deliberate choices: render the actual pending tool block instead of 'Preparing X...' status copy, and leave the `APP_TOOL_NAMES` input-delta filter unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)