### PR TITLE
feat(web): open the LLM inspector to sessions with settings-developer-nav enabled

### DIFF
--- a/apps/web/src/domains/chat/active-chat-view.tsx
+++ b/apps/web/src/domains/chat/active-chat-view.tsx
@@ -17,8 +17,6 @@ import {
 } from "react";
 import { useParams, useSearchParams } from "react-router";
 
-import { useAuthStore } from "@/stores/auth-store";
-
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import { useAutoGreetGate } from "@/domains/chat/hooks/use-auto-greet-gate";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
@@ -50,7 +48,7 @@ import { useConversationLoader } from "@/domains/chat/hooks/use-conversation-loa
 import { useOnboardingOrchestrator } from "@/domains/chat/hooks/use-onboarding-orchestrator";
 
 import { useConversationSecondaryActions } from "@/domains/chat/hooks/use-conversation-secondary-actions";
-import { canUseLlmInspector } from "@/domains/chat/inspector/access";
+import { useCanUseLlmInspector } from "@/domains/chat/inspector/access";
 import { useSendMessage } from "@/domains/chat/hooks/use-send-message";
 import { useMessageLifecycle } from "@/domains/chat/hooks/use-message-lifecycle";
 import { useActiveAppPinSync } from "@/domains/chat/hooks/use-active-app-pin-sync";
@@ -87,8 +85,7 @@ import type { ChatMainPanelProps } from "@/domains/chat/components/chat-route-co
 // ---------------------------------------------------------------------------
 
 export function ActiveChatView() {
-  const authUser = useAuthStore.use.user();
-  const showLlmInspector = canUseLlmInspector(authUser);
+  const showLlmInspector = useCanUseLlmInspector();
   const [searchParams] = useSearchParams();
   const { conversationId: urlConversationId } = useParams<{ conversationId?: string }>();
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();

--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -30,7 +30,7 @@ import { useChatLayoutDrawer } from "@/domains/chat/hooks/use-chat-layout-drawer
 import { useChatLayoutShortcuts } from "@/domains/chat/hooks/use-chat-layout-shortcuts";
 import { useConversationActions } from "@/domains/chat/hooks/use-conversation-actions";
 import { useConversationGroupActions } from "@/domains/chat/hooks/use-conversation-group-actions";
-import { canUseLlmInspector } from "@/domains/chat/inspector/access";
+import { useCanUseLlmInspector } from "@/domains/chat/inspector/access";
 import {
     navigateToConversation,
     navigateToNewConversation,
@@ -47,7 +47,6 @@ import { useIsNativePlatform } from "@/runtime/native-auth";
 import { openPopoutWindow } from "@/runtime/popout-window";
 import { useVellumCommands } from "@/runtime/vellum-commands";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
-import { useAuthStore } from "@/stores/auth-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useViewerStore } from "@/stores/viewer-store";
 import type { Conversation } from "@/types/conversation-types";
@@ -192,8 +191,7 @@ export function ChatLayout() {
   const topBarCenterSlot = useChatLayoutSlotsStore.use.topBarCenter();
   const headerSupplements = useChatLayoutSlotsStore.use.headerSupplements();
   const topBarRightSlot = useChatLayoutSlotsStore.use.topBarRightSlot();
-  const authUser = useAuthStore.use.user();
-  const showLlmInspector = canUseLlmInspector(authUser);
+  const showLlmInspector = useCanUseLlmInspector();
   const isNative = useIsNativePlatform();
 
   // --- Assistant identity from store (written by ChatPage) ---

--- a/apps/web/src/domains/chat/inspector/access.test.ts
+++ b/apps/web/src/domains/chat/inspector/access.test.ts
@@ -17,14 +17,30 @@ function user(overrides: Partial<AuthUser>): AuthUser {
 
 describe("canUseLlmInspector", () => {
   test("allows staff users", () => {
-    expect(canUseLlmInspector(user({ isStaff: true }))).toBe(true);
+    expect(canUseLlmInspector(user({ isStaff: true }), false)).toBe(true);
   });
 
   test("allows Vellum email users case-insensitively", () => {
-    expect(canUseLlmInspector(user({ email: "alice@" + "VELLUM.AI" }))).toBe(true);
+    expect(
+      canUseLlmInspector(user({ email: "alice@" + "VELLUM.AI" }), false),
+    ).toBe(true);
   });
 
   test("rejects regular users", () => {
-    expect(canUseLlmInspector(user({ email: "user@example.com" }))).toBe(false);
+    expect(canUseLlmInspector(user({ email: "user@example.com" }), false)).toBe(
+      false,
+    );
+  });
+
+  test("allows any session when the developer-nav flag is enabled", () => {
+    // Local-gateway sessions carry no email or staff bit — the flag is
+    // their only path to the inspector.
+    expect(canUseLlmInspector(null, true)).toBe(true);
+    expect(canUseLlmInspector(user({ email: null }), true)).toBe(true);
+  });
+
+  test("rejects identity-less sessions when the flag is off", () => {
+    expect(canUseLlmInspector(null, false)).toBe(false);
+    expect(canUseLlmInspector(user({ email: null }), false)).toBe(false);
   });
 });

--- a/apps/web/src/domains/chat/inspector/access.ts
+++ b/apps/web/src/domains/chat/inspector/access.ts
@@ -1,8 +1,33 @@
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
+import { useAuthStore } from "@/stores/auth-store";
 import type { AuthUser } from "@/stores/auth-store";
 
-export function canUseLlmInspector(user: AuthUser | null): boolean {
+/**
+ * The LLM inspector is a developer tool. Vellum staff and @vellum.ai
+ * accounts always qualify; everyone else — including local-gateway
+ * sessions, which carry no email or staff bit — qualifies by enabling
+ * the `settings-developer-nav` assistant flag, the same flag the Swift
+ * macOS client gates its Message Inspector on.
+ */
+export function canUseLlmInspector(
+  user: AuthUser | null,
+  developerNavEnabled: boolean,
+): boolean {
   return (
+    developerNavEnabled ||
     user?.isStaff === true ||
     user?.email?.toLowerCase().endsWith("@vellum.ai") === true
   );
+}
+
+/**
+ * Store-connected variant for render bodies. Note the flag reads as
+ * `false` until `/feature-flags` hydrates — gate UI that must not
+ * flash a denial should also consult the store's `hasHydrated`.
+ */
+export function useCanUseLlmInspector(): boolean {
+  const user = useAuthStore.use.user();
+  const developerNavEnabled =
+    useAssistantFeatureFlagStore.use.settingsDeveloperNav();
+  return canUseLlmInspector(user, developerNavEnabled === true);
 }

--- a/apps/web/src/domains/chat/inspector/inspect-page.test.tsx
+++ b/apps/web/src/domains/chat/inspector/inspect-page.test.tsx
@@ -66,6 +66,8 @@ let authUserStub: AuthUserStub | null = {
   isStaff: false,
 };
 let sessionInitializingStub = false;
+let developerNavFlagStub = false;
+let flagsHydratedStub = true;
 
 let contextStub: ContextStub = {
   data: undefined,
@@ -137,6 +139,18 @@ mock.module("@/stores/auth-store", () => ({
   useIsSessionInitializing: () => sessionInitializingStub,
 }));
 
+// Mocked rather than driven via `setState`: zustand v5 serves
+// `getInitialState()` to server renders (`renderToStaticMarkup`), so
+// runtime state changes would never reach the component under test.
+mock.module("@/stores/assistant-feature-flag-store", () => ({
+  useAssistantFeatureFlagStore: {
+    use: {
+      settingsDeveloperNav: () => developerNavFlagStub,
+      hasHydrated: () => flagsHydratedStub,
+    },
+  },
+}));
+
 mock.module("@/domains/chat/inspector/inspector-api", () => ({
   useLlmContext: (
     _assistantId: string | undefined,
@@ -187,6 +201,10 @@ beforeEach(() => {
   assistantStub = { assistantId: "asst-1" };
   authUserStub = { email: "dev@vellum.ai", isStaff: false };
   sessionInitializingStub = false;
+  // Hydrated, flag-off baseline: gating tests exercise the denial branch
+  // by default; flag tests opt in explicitly.
+  developerNavFlagStub = false;
+  flagsHydratedStub = true;
   contextStub = {
     data: undefined,
     isLoading: true,
@@ -225,9 +243,49 @@ describe("InspectPage — gating", () => {
 
     const html = renderInspector();
 
-    expect(html).toContain("Inspector is available to Vellum developers only");
+    expect(html).toContain("Inspector is available to Vellum staff");
     // header chrome shouldn't render
     expect(html).not.toContain("LLM Context Inspector");
+  });
+
+  test("allows flag-gated sessions without a staff identity", () => {
+    // Local-gateway sessions have no email/staff bit; the
+    // settings-developer-nav assistant flag is their path in.
+    authUserStub = { email: null, isStaff: false };
+    developerNavFlagStub = true;
+    paramsStub = { conversationId: "conv-abc" };
+    contextStub = {
+      data: {
+        conversationId: "conv-int-1",
+        conversationKey: "conv-abc",
+        conversationKind: "user",
+        conversationTotalEstimatedCostUsd: null,
+        logs: [makeLog("log-1", 1)],
+        memoryRecall: null,
+        memoryV2Activation: null,
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: () => {},
+    };
+
+    const html = renderInspector();
+
+    expect(html).not.toContain("Inspector is available to Vellum staff");
+    expect(html).toContain("LLM Context Inspector");
+  });
+
+  test("treats the pre-hydration window as loading, not denial", () => {
+    // Until /feature-flags lands, the flag reads registry-default false —
+    // non-staff sessions must see the loading state, not a denial flash.
+    authUserStub = { email: "person@example.com", isStaff: false };
+    flagsHydratedStub = false;
+
+    const html = renderInspector();
+
+    expect(html).toContain("Loading…");
+    expect(html).not.toContain("Inspector is available to Vellum staff");
   });
 
   test("allows staff users even without a vellum.ai email", () => {
@@ -251,9 +309,7 @@ describe("InspectPage — gating", () => {
 
     const html = renderInspector();
 
-    expect(html).not.toContain(
-      "Inspector is available to Vellum developers only",
-    );
+    expect(html).not.toContain("Inspector is available to Vellum staff");
     // Real CallRail emits one row per log — assert the page reached the
     // loaded state, not the empty/loading/error branches.
     expect(html).toContain("LLM Context Inspector");

--- a/apps/web/src/domains/chat/inspector/inspect-page.tsx
+++ b/apps/web/src/domains/chat/inspector/inspect-page.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState, type ReactNode } from "react";
 import { Link, useNavigate, useParams, useSearchParams } from "react-router";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
-import { canUseLlmInspector } from "@/domains/chat/inspector/access";
+import { useCanUseLlmInspector } from "@/domains/chat/inspector/access";
 import {
     useConversationCallNumbering,
     useConversationMessageList,
@@ -27,7 +27,8 @@ import {
     supportsLlmContextSummaryView,
     useSupportsLlmContextSummaryView,
 } from "@/lib/backwards-compat/llm-context-summary-view";
-import { useAuthStore, useIsSessionInitializing } from "@/stores/auth-store";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
+import { useIsSessionInitializing } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
 import type {
   ConversationMessage,
@@ -68,7 +69,12 @@ import { SkillsTab } from "./components/tabs/skills-tab";
  * is absent or no longer points to a known log.
  */
 export function InspectPage(): ReactNode {
-  const user = useAuthStore.use.user();
+  const canInspect = useCanUseLlmInspector();
+  // The developer-nav flag reads as registry-default `false` until the
+  // `/feature-flags` response lands, so flag-gated sessions (e.g. local
+  // gateway) would flash the denial on deep links. Treat the pre-hydration
+  // window as loading instead.
+  const flagsHydrated = useAssistantFeatureFlagStore.use.hasHydrated();
   const authLoading = useIsSessionInitializing();
   // React Router's :conversationId segment is the source of truth; the
   // route definition guarantees it's present, but useParams still types
@@ -77,14 +83,15 @@ export function InspectPage(): ReactNode {
   const [searchParams] = useSearchParams();
   const messageId = searchParams.get("messageId");
 
-  if (authLoading) {
+  if (authLoading || (!canInspect && !flagsHydrated)) {
     return <CenteredMessage tone="muted">Loading…</CenteredMessage>;
   }
 
-  if (!canUseLlmInspector(user)) {
+  if (!canInspect) {
     return (
       <CenteredMessage tone="muted">
-        Inspector is available to Vellum developers only.
+        Inspector is available to Vellum staff, or when the
+        settings-developer-nav developer flag is enabled.
       </CenteredMessage>
     );
   }

--- a/apps/web/src/domains/chat/inspector/memory-router-playground-page.tsx
+++ b/apps/web/src/domains/chat/inspector/memory-router-playground-page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Card } from "@vellumai/design-library";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
-import { canUseLlmInspector } from "@/domains/chat/inspector/access";
+import { useCanUseLlmInspector } from "@/domains/chat/inspector/access";
 import type {
     MemoryRouterSimulateRequest,
     MemoryRouterSimulateResponse,
@@ -16,7 +16,7 @@ import {
     useLlmProfiles,
     useSimulateMemoryRouter,
 } from "@/domains/chat/inspector/memory-router-simulator-api";
-import { useAuthStore, useIsSessionInitializing } from "@/stores/auth-store";
+import { useIsSessionInitializing } from "@/stores/auth-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 
 /**
@@ -32,18 +32,18 @@ import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
  *
  * Gated by:
  *   1. The `memoryRouterPlayground` client feature flag (default off).
- *   2. The same staff gate that protects the LLM context inspector
- *      (/assistant/conversations/:conversationId/inspect).
+ *   2. The same staff/developer-flag gate that protects the LLM context
+ *      inspector (/assistant/conversations/:conversationId/inspect).
  */
 export function MemoryRouterPlaygroundPage(): ReactNode {
-  const user = useAuthStore.use.user();
+  const canInspect = useCanUseLlmInspector();
   const authLoading = useIsSessionInitializing();
   const flagEnabled = useClientFeatureFlagStore.use.memoryRouterPlayground();
 
   if (authLoading) {
     return <CenteredMessage>Loading…</CenteredMessage>;
   }
-  if (!canUseLlmInspector(user) || !flagEnabled) {
+  if (!canInspect || !flagEnabled) {
     return (
       <CenteredMessage>
         Memory router playground is not available.


### PR DESCRIPTION
## Why

The web LLM inspector (which is what the Electron desktop app ships) was gated solely on platform identity — `isStaff` or an `@vellum.ai` email. Local-gateway sessions authenticate as a synthetic user with neither, so self-hosted installs had **no path to the inspector at all**. Meanwhile the Swift macOS client exposes its equivalent Message Inspector behind the `settings-developer-nav` assistant flag (`PanelCoordinator.swift`), so the two clients disagreed about who can inspect.

## What

- `canUseLlmInspector()` now takes a `developerNavEnabled` argument; new `useCanUseLlmInspector()` hook reads the `settings-developer-nav` assistant flag from the feature-flag store and ORs it with the existing staff/vellum.ai check.
- All four gate consumers (inspect page, chat layout context menu, active-chat message action, memory-router playground) use the hook.
- The inspect page treats the pre-flag-hydration window as loading instead of flashing the denial at flag-gated sessions on deep links (registry default is `false` until `/feature-flags` lands).
- Denial copy updated to mention the flag.

## Why not `isStaff: true` for local sessions

Marking the local-gateway user staff would also surface the platform Admin menu item (dead without a platform session) and the internal debug controls. Honoring the existing developer flag is narrower and matches the Swift client's behavior.

Note the gate is UI visibility, not a security boundary — in local mode the daemon's `llm-context` routes are already reachable by any local session.

## Testing

- `bun test src/domains/chat/inspector/access.test.ts src/domains/chat/inspector/inspect-page.test.tsx` — 17 pass (new cases: flag grants access without identity; pre-hydration renders loading, not denial)
- `bunx tsc --noEmit` clean; lint clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)