### PR TITLE
feat(settings): memory retrospective runs in the Schedules System section

### DIFF
--- a/apps/web/src/domains/settings/api/schedules.test.ts
+++ b/apps/web/src/domains/settings/api/schedules.test.ts
@@ -5,6 +5,7 @@ import * as sdkGen from "@/generated/daemon/sdk.gen";
 import type {
   ConsolidationRunsGetResponse,
   HeartbeatRunsGetResponse,
+  RetrospectiveRunsGetResponse,
   SchedulesGetResponse,
   SchedulesUsagesummaryGetResponse,
 } from "@/generated/daemon/types.gen";
@@ -65,6 +66,26 @@ const consolidationRows: ConsolidationRunsGetResponse["runs"] = [
   },
 ];
 
+const retrospectiveRows: RetrospectiveRunsGetResponse["runs"] = [
+  {
+    id: "conv-retro-1",
+    scheduledFor: 1_761_792_000_000,
+    startedAt: 1_761_792_001_000,
+    finishedAt: 1_761_792_004_000,
+    durationMs: 3000,
+    status: "ok",
+    skipReason: null,
+    error: null,
+    conversationId: "conv-retro-1",
+    conversationExists: true,
+    conversationArchivedAt: null,
+    estimatedCostUsd: 0.0456,
+    createdAt: 1_761_792_000_000,
+    kind: "fork",
+    title: "Planning chat (Retrospective)",
+  },
+];
+
 const heartbeatRows: HeartbeatRunsGetResponse["runs"] = [
   {
     id: "heartbeat-run-1",
@@ -86,6 +107,7 @@ const heartbeatRows: HeartbeatRunsGetResponse["runs"] = [
 let usageSummaryCalls: UsageSummaryCall[] = [];
 let schedulesCalls: SchedulesCall[] = [];
 let consolidationRunsCalls: ConsolidationRunsCall[] = [];
+let retrospectiveRunsCalls: ConsolidationRunsCall[] = [];
 let heartbeatRunsCalls: HeartbeatRunsCall[] = [];
 let heartbeatConfigPutCalls: ConfigUpdateCall[] = [];
 let scheduleRows: SchedulesGetResponse["schedules"] = [];
@@ -106,6 +128,14 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
     consolidationRunsCalls.push(opts);
     return Promise.resolve({
       data: responseOk ? { runs: consolidationRows } : undefined,
+      error: undefined,
+      response: { ok: responseOk, status: responseStatus },
+    });
+  },
+  retrospectiveRunsGet: (opts: ConsolidationRunsCall) => {
+    retrospectiveRunsCalls.push(opts);
+    return Promise.resolve({
+      data: responseOk ? { runs: retrospectiveRows } : undefined,
       error: undefined,
       response: { ok: responseOk, status: responseStatus },
     });
@@ -152,6 +182,7 @@ const {
   fetchSchedules,
   fetchConsolidationRuns,
   fetchHeartbeatRuns,
+  fetchRetrospectiveRuns,
   fetchScheduleUsageSummary,
   updateHeartbeatConfig,
 } = await import("./schedules");
@@ -160,6 +191,7 @@ afterEach(() => {
   usageSummaryCalls = [];
   schedulesCalls = [];
   consolidationRunsCalls = [];
+  retrospectiveRunsCalls = [];
   heartbeatRunsCalls = [];
   heartbeatConfigPutCalls = [];
   scheduleRows = [];
@@ -270,6 +302,38 @@ describe("fetchConsolidationRuns", () => {
         conversationArchivedAt: null,
         estimatedCostUsd: 0.1234,
         createdAt: 1_761_792_000_000,
+      },
+    ]);
+  });
+});
+
+describe("fetchRetrospectiveRuns", () => {
+  test("maps daemon retrospective runs into shared schedule run rows with the title", async () => {
+    const result = await fetchRetrospectiveRuns("assistant-1");
+
+    expect(retrospectiveRunsCalls).toEqual([
+      {
+        path: { assistant_id: "assistant-1" },
+        query: { limit: 10 },
+        throwOnError: false,
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        id: "conv-retro-1",
+        jobId: "retrospective",
+        status: "ok",
+        startedAt: 1_761_792_001_000,
+        finishedAt: 1_761_792_004_000,
+        durationMs: 3000,
+        output: null,
+        error: null,
+        conversationId: "conv-retro-1",
+        conversationExists: true,
+        conversationArchivedAt: null,
+        estimatedCostUsd: 0.0456,
+        createdAt: 1_761_792_000_000,
+        title: "Planning chat (Retrospective)",
       },
     ]);
   });

--- a/apps/web/src/domains/settings/api/schedules.ts
+++ b/apps/web/src/domains/settings/api/schedules.ts
@@ -11,6 +11,8 @@ import {
   heartbeatConfigPut,
   heartbeatRunnowPost,
   heartbeatRunsGet,
+  retrospectiveConfigGet,
+  retrospectiveRunsGet,
   schedulesByIdDelete,
   schedulesByIdPatch,
   schedulesByIdRunPost,
@@ -25,6 +27,7 @@ import type {
   HeartbeatConfigGetResponse,
   HeartbeatConfigPutResponse,
   HeartbeatRunnowPostResponse,
+  RetrospectiveConfigGetResponse,
 } from "@/generated/daemon/types.gen";
 import {
   ApiError,
@@ -258,6 +261,40 @@ export async function fetchConsolidationRuns(
   }));
 }
 
+export async function fetchRetrospectiveRuns(
+  assistantId: string,
+  limit = 10,
+): Promise<ScheduleRun[]> {
+  const { data, error, response } = await retrospectiveRunsGet({
+    path: { assistant_id: assistantId },
+    query: { limit },
+    throwOnError: false,
+  });
+  assertHasResponse(response, error, "Failed to load retrospective runs.");
+  if (!response.ok) {
+    throw new ApiError(
+      response.status,
+      extractErrorMessage(error, response, "Failed to load retrospective runs."),
+    );
+  }
+  return (data?.runs ?? []).map((run) => ({
+    id: run.id,
+    jobId: "retrospective",
+    status: run.status,
+    startedAt: run.startedAt ?? run.scheduledFor,
+    finishedAt: run.finishedAt,
+    durationMs: run.durationMs,
+    output: null,
+    error: run.error,
+    conversationId: run.conversationId,
+    conversationExists: run.conversationExists,
+    conversationArchivedAt: run.conversationArchivedAt,
+    estimatedCostUsd: run.estimatedCostUsd,
+    createdAt: run.createdAt,
+    title: run.title,
+  }));
+}
+
 export async function fetchHeartbeatConfig(
   assistantId: string,
 ): Promise<HeartbeatConfigGetResponse> {
@@ -345,6 +382,27 @@ export async function fetchConsolidationConfig(
         error,
         response,
         "Failed to load consolidation config.",
+      ),
+    );
+  }
+  return data;
+}
+
+export async function fetchRetrospectiveConfig(
+  assistantId: string,
+): Promise<RetrospectiveConfigGetResponse> {
+  const { data, error, response } = await retrospectiveConfigGet({
+    path: { assistant_id: assistantId },
+    throwOnError: false,
+  });
+  assertHasResponse(response, error, "Failed to load retrospective config.");
+  if (!response.ok || !data) {
+    throw new ApiError(
+      response.status,
+      extractErrorMessage(
+        error,
+        response,
+        "Failed to load retrospective config.",
       ),
     );
   }

--- a/apps/web/src/domains/settings/components/recent-runs-card.tsx
+++ b/apps/web/src/domains/settings/components/recent-runs-card.tsx
@@ -56,10 +56,18 @@ export function RecentRunsCard({
                     <span className="flex min-w-0 flex-1 items-center gap-3">
                       <StatusDot status={run.status} />
                       <span className="min-w-0 flex-1">
-                        <span className="block text-body-medium-lighter text-[var(--content-default)]">
-                          {formatTimestamp(run.startedAt)}
+                        <span className="block truncate text-body-medium-lighter text-[var(--content-default)]">
+                          {/* Runs with a title (memory retrospectives) lead
+                              with it — it names the reviewed conversation —
+                              and keep the timestamp on the detail line. */}
+                          {hasRunText(run.title)
+                            ? run.title
+                            : formatTimestamp(run.startedAt)}
                         </span>
                         <span className="block text-body-small-default text-[var(--content-tertiary)]">
+                          {hasRunText(run.title)
+                            ? `${formatTimestamp(run.startedAt)} · `
+                            : ""}
                           {formatDuration(run.durationMs)} ·{" "}
                           {formatScheduleCost(run.estimatedCostUsd)}
                           {run.status === "error" && run.error && (

--- a/apps/web/src/domains/settings/components/system-task-detail-view.tsx
+++ b/apps/web/src/domains/settings/components/system-task-detail-view.tsx
@@ -5,6 +5,7 @@ import { DetailCard } from "@/components/detail-card";
 import {
   fetchConsolidationRuns,
   fetchHeartbeatRuns,
+  fetchRetrospectiveRuns,
 } from "@/domains/settings/api/schedules";
 import { RecentRunsCard } from "@/domains/settings/components/recent-runs-card";
 import { formatTimestamp } from "@/domains/settings/utils/schedule-formatters";
@@ -25,7 +26,12 @@ interface SystemTaskDetailViewProps {
   lastRunAt: number | null;
   isRunning: boolean;
   onBack: () => void;
-  onRunNow: () => void;
+  /**
+   * Triggers an immediate run. Omit for event-driven tasks (memory
+   * retrospective) that have nothing global to trigger — the Run now
+   * button is hidden when absent.
+   */
+  onRunNow?: () => void;
   /** Pauses/resumes automatic runs. Manual Run now stays available. */
   onToggleEnabled?: (enabled: boolean) => void;
   onOpenMemorySettings?: () => void;
@@ -45,23 +51,33 @@ export function SystemTaskDetailView({
   onToggleEnabled,
   onOpenMemorySettings,
 }: SystemTaskDetailViewProps) {
-  const isConsolidation = kind === "consolidation";
-  const isConsolidationPaused = isConsolidation && !enabled;
-  const runNowDisabled = isRunning || isConsolidationPaused;
-  const statusValue = isConsolidation
+  // Consolidation and retrospective are both owned by Memory: no toggle of
+  // their own, paused when Memory is off. Retrospective additionally has no
+  // global schedule (event-driven per conversation), so it hides Next run
+  // and is rendered without an onRunNow handler.
+  const isMemoryManaged = kind !== "heartbeat";
+  const isRetrospective = kind === "retrospective";
+  const isMemoryPaused = isMemoryManaged && !enabled;
+  const runNowDisabled = isRunning || isMemoryPaused;
+  const statusValue = isMemoryManaged
     ? enabled
       ? "On · Managed by Memory"
       : "Paused"
     : enabled
       ? "Enabled"
       : "Disabled";
+  const pausedNotice = isRetrospective
+    ? "Memory is off, so retrospectives are paused. Turn Memory back on to resume them."
+    : "Memory is off, so consolidation is paused. Turn Memory back on to resume consolidation.";
 
   const { data: runs, isLoading } = useQuery({
     queryKey: ["system-task-runs", assistantId, kind],
     queryFn: () =>
       kind === "heartbeat"
         ? fetchHeartbeatRuns(assistantId)
-        : fetchConsolidationRuns(assistantId),
+        : kind === "consolidation"
+          ? fetchConsolidationRuns(assistantId)
+          : fetchRetrospectiveRuns(assistantId),
     staleTime: 10_000,
   });
 
@@ -82,7 +98,7 @@ export function SystemTaskDetailView({
         accessory={
           <div className="flex items-center gap-2">
             <Tag tone="neutral">system</Tag>
-            {isConsolidation && enabled && onOpenMemorySettings ? (
+            {isMemoryManaged && enabled && onOpenMemorySettings ? (
               <Button
                 variant="outlined"
                 size="compact"
@@ -92,21 +108,23 @@ export function SystemTaskDetailView({
                 Memory settings
               </Button>
             ) : null}
-            <Button
-              variant="outlined"
-              size="compact"
-              leftIcon={
-                isRunning ? (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                ) : (
-                  <Play className="h-3.5 w-3.5" />
-                )
-              }
-              onClick={onRunNow}
-              disabled={runNowDisabled}
-            >
-              {isRunning ? "Running…" : "Run now"}
-            </Button>
+            {onRunNow ? (
+              <Button
+                variant="outlined"
+                size="compact"
+                leftIcon={
+                  isRunning ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <Play className="h-3.5 w-3.5" />
+                  )
+                }
+                onClick={onRunNow}
+                disabled={runNowDisabled}
+              >
+                {isRunning ? "Running…" : "Run now"}
+              </Button>
+            ) : null}
           </div>
         }
       >
@@ -115,7 +133,7 @@ export function SystemTaskDetailView({
             <span className="text-[var(--content-secondary)]">Status</span>
             <span className="flex items-center gap-2">
               <span>{statusValue}</span>
-              {!isConsolidation && onToggleEnabled ? (
+              {!isMemoryManaged && onToggleEnabled ? (
                 <Toggle
                   checked={enabled}
                   onChange={onToggleEnabled}
@@ -124,16 +142,18 @@ export function SystemTaskDetailView({
               ) : null}
             </span>
           </div>
-          <div className="flex items-center justify-between">
-            <span className="text-[var(--content-secondary)]">Next run</span>
-            <span>{formatTimestamp(nextRunAt)}</span>
-          </div>
+          {!isRetrospective ? (
+            <div className="flex items-center justify-between">
+              <span className="text-[var(--content-secondary)]">Next run</span>
+              <span>{formatTimestamp(nextRunAt)}</span>
+            </div>
+          ) : null}
           <div className="flex items-center justify-between">
             <span className="text-[var(--content-secondary)]">Last run</span>
             <span>{formatTimestamp(lastRunAt)}</span>
           </div>
         </div>
-        {isConsolidationPaused ? (
+        {isMemoryPaused ? (
           <Notice
             tone="warning"
             className="mt-4"
@@ -149,8 +169,7 @@ export function SystemTaskDetailView({
               ) : undefined
             }
           >
-            Memory is off, so consolidation is paused. Turn Memory back on to
-            resume consolidation.
+            {pausedNotice}
           </Notice>
         ) : null}
       </DetailCard>

--- a/apps/web/src/domains/settings/components/system-tasks-section.tsx
+++ b/apps/web/src/domains/settings/components/system-tasks-section.tsx
@@ -7,6 +7,7 @@ import {
   formatScheduleCost,
   formatTimestamp,
   heartbeatSubtitle,
+  RETROSPECTIVE_SUBTITLE,
   type ScheduleRowUsage,
 } from "@/domains/settings/utils/schedule-formatters";
 import { Collapsible } from "@vellumai/design-library/components/collapsible";
@@ -16,6 +17,7 @@ import { Tag, type TagTone } from "@vellumai/design-library/components/tag";
 import type {
   ConsolidationConfigGetResponse,
   HeartbeatConfigGetResponse,
+  RetrospectiveConfigGetResponse,
 } from "@/generated/daemon/types.gen";
 
 // ---------------------------------------------------------------------------
@@ -107,30 +109,38 @@ export function SystemTaskRow({
 interface SystemTasksSectionProps {
   heartbeatConfig: HeartbeatConfigGetResponse | undefined;
   consolidationConfig: ConsolidationConfigGetResponse | undefined;
+  retrospectiveConfig: RetrospectiveConfigGetResponse | undefined;
   heartbeatUsage: ScheduleRowUsage;
   consolidationUsage: ScheduleRowUsage;
+  retrospectiveUsage: ScheduleRowUsage;
   isLoading: boolean;
   hasError: boolean;
   onRetry: () => void;
   onSelectHeartbeat: () => void;
   onSelectConsolidation: () => void;
+  onSelectRetrospective: () => void;
 }
 
 export function SystemTasksSection({
   heartbeatConfig,
   consolidationConfig,
+  retrospectiveConfig,
   heartbeatUsage,
   consolidationUsage,
+  retrospectiveUsage,
   isLoading,
   hasError,
   onRetry,
   onSelectHeartbeat,
   onSelectConsolidation,
+  onSelectRetrospective,
 }: SystemTasksSectionProps) {
   const showHeartbeat = heartbeatConfig != null;
   const showConsolidation = consolidationConfig?.available === true;
+  const showRetrospective = retrospectiveConfig?.available === true;
+  const showAny = showHeartbeat || showConsolidation || showRetrospective;
 
-  if (!isLoading && !hasError && !showHeartbeat && !showConsolidation) {
+  if (!isLoading && !hasError && !showAny) {
     return null;
   }
 
@@ -139,6 +149,7 @@ export function SystemTasksSection({
   const readyUsages = [
     ...(showHeartbeat ? [heartbeatUsage] : []),
     ...(showConsolidation ? [consolidationUsage] : []),
+    ...(showRetrospective ? [retrospectiveUsage] : []),
   ].filter(
     (usage): usage is Extract<ScheduleRowUsage, { status: "ready" }> =>
       usage.status === "ready",
@@ -152,7 +163,7 @@ export function SystemTasksSection({
     <div className="flex items-center justify-center py-8">
       <Loader2 className="h-5 w-5 animate-spin text-stone-400" />
     </div>
-  ) : hasError && !showHeartbeat && !showConsolidation ? (
+  ) : hasError && !showAny ? (
     <Notice tone="error">
       Failed to load system jobs.{" "}
       <button
@@ -192,6 +203,26 @@ export function SystemTasksSection({
           statusLabel={consolidationConfig.enabled ? undefined : "Paused"}
           statusTone="warning"
           onClick={onSelectConsolidation}
+        />
+      ) : null}
+      {showRetrospective ? (
+        <SystemTaskRow
+          name="Memory retrospective"
+          subtitle={RETROSPECTIVE_SUBTITLE}
+          enabled={retrospectiveConfig.enabled}
+          helperText={
+            retrospectiveConfig.enabled
+              ? undefined
+              : "Memory is off, so retrospectives are paused."
+          }
+          // Always null — retrospectives are event-driven, not scheduled;
+          // the row simply omits the "Next:" timestamp.
+          nextRunAt={retrospectiveConfig.nextRunAt}
+          lastRunAt={retrospectiveConfig.lastRunAt}
+          usage={retrospectiveUsage}
+          statusLabel={retrospectiveConfig.enabled ? undefined : "Paused"}
+          statusTone="warning"
+          onClick={onSelectRetrospective}
         />
       ) : null}
       {hasError ? (

--- a/apps/web/src/domains/settings/hooks/use-system-tasks.ts
+++ b/apps/web/src/domains/settings/hooks/use-system-tasks.ts
@@ -6,6 +6,8 @@ import {
   fetchConsolidationRuns,
   fetchHeartbeatConfig,
   fetchHeartbeatRuns,
+  fetchRetrospectiveConfig,
+  fetchRetrospectiveRuns,
   runConsolidationNow,
   runHeartbeatNow,
   updateHeartbeatConfig,
@@ -30,9 +32,10 @@ import type { SystemTaskKind } from "@/domains/settings/types/schedules";
 
 /**
  * Encapsulates all TanStack Query composition + mutation logic for
- * system tasks (heartbeat, consolidation). Exposes a unified interface
- * that the page orchestrator consumes without managing 6 queries and
- * 5 callbacks itself.
+ * system tasks (heartbeat, consolidation, memory retrospective). Exposes
+ * a unified interface that the page orchestrator consumes without managing
+ * the queries and callbacks itself. Retrospectives are event-driven, so
+ * they have no run-now mutation or toggle.
  */
 export function useSystemTasks(assistantId: string | undefined, tz: string) {
   const queryClient = useQueryClient();
@@ -65,6 +68,18 @@ export function useSystemTasks(assistantId: string | undefined, tz: string) {
   } = useQuery({
     queryKey: ["consolidation-config", assistantId],
     queryFn: () => fetchConsolidationConfig(assistantId!),
+    enabled: !!assistantId,
+    staleTime: 10_000,
+  });
+
+  const {
+    data: retrospectiveConfig,
+    isLoading: isRetrospectiveLoading,
+    isError: isRetrospectiveError,
+    refetch: refetchRetrospective,
+  } = useQuery({
+    queryKey: ["retrospective-config", assistantId],
+    queryFn: () => fetchRetrospectiveConfig(assistantId!),
     enabled: !!assistantId,
     staleTime: 10_000,
   });
@@ -105,6 +120,24 @@ export function useSystemTasks(assistantId: string | undefined, tz: string) {
     queryFn: () =>
       fetchConsolidationRuns(assistantId!, SYSTEM_TASK_STATS_RUN_LIMIT),
     enabled: !!assistantId && consolidationConfig?.available === true,
+    staleTime: 10_000,
+  });
+
+  const {
+    data: retrospectiveRunsForStats,
+    isLoading: isRetrospectiveStatsLoading,
+    isError: isRetrospectiveStatsError,
+    refetch: refetchRetrospectiveStats,
+  } = useQuery({
+    queryKey: [
+      "system-task-runs-summary",
+      assistantId,
+      "retrospective",
+      SYSTEM_TASK_STATS_RUN_LIMIT,
+    ],
+    queryFn: () =>
+      fetchRetrospectiveRuns(assistantId!, SYSTEM_TASK_STATS_RUN_LIMIT),
+    enabled: !!assistantId && retrospectiveConfig?.available === true,
     staleTime: 10_000,
   });
 
@@ -153,6 +186,24 @@ export function useSystemTasks(assistantId: string | undefined, tz: string) {
     systemStatsRange,
   ]);
 
+  const retrospectiveUsage: ScheduleRowUsage = useMemo(() => {
+    if (isRetrospectiveStatsLoading) return { status: "loading" };
+    if (isRetrospectiveStatsError) return { status: "error" };
+    return {
+      status: "ready",
+      summary: summarizeRunsForUsage(
+        SYSTEM_TASK_URL_IDS.retrospective,
+        retrospectiveRunsForStats,
+        systemStatsRange,
+      ),
+    };
+  }, [
+    retrospectiveRunsForStats,
+    isRetrospectiveStatsError,
+    isRetrospectiveStatsLoading,
+    systemStatsRange,
+  ]);
+
   // -------------------------------------------------------------------------
   // Running state + timeout cleanup
   // -------------------------------------------------------------------------
@@ -184,6 +235,9 @@ export function useSystemTasks(assistantId: string | undefined, tz: string) {
   const handleRunNow = useCallback(
     async (kind: SystemTaskKind) => {
       if (!assistantId) return;
+      // Retrospectives are event-driven per conversation — there is nothing
+      // global to trigger, so no run-now exists for that kind.
+      if (kind === "retrospective") return;
       const setRunning =
         kind === "heartbeat" ? setIsHeartbeatRunning : setIsConsolidationRunning;
       const runFn = kind === "heartbeat" ? runHeartbeatNow : runConsolidationNow;
@@ -255,13 +309,17 @@ export function useSystemTasks(assistantId: string | undefined, tz: string) {
   const refetchAll = useCallback(() => {
     void refetchHeartbeat();
     void refetchConsolidation();
+    void refetchRetrospective();
     void refetchHeartbeatStats();
     void refetchConsolidationStats();
+    void refetchRetrospectiveStats();
   }, [
     refetchConsolidation,
     refetchConsolidationStats,
     refetchHeartbeat,
     refetchHeartbeatStats,
+    refetchRetrospective,
+    refetchRetrospectiveStats,
   ]);
 
   // -------------------------------------------------------------------------
@@ -279,18 +337,24 @@ export function useSystemTasks(assistantId: string | undefined, tz: string) {
   return {
     heartbeatConfig,
     consolidationConfig,
+    retrospectiveConfig,
     heartbeatUsage,
     consolidationUsage,
-    isLoading: isHeartbeatLoading || isConsolidationLoading,
-    hasError: isHeartbeatError || isConsolidationError,
+    retrospectiveUsage,
+    isLoading:
+      isHeartbeatLoading || isConsolidationLoading || isRetrospectiveLoading,
+    hasError: isHeartbeatError || isConsolidationError || isRetrospectiveError,
     isHeartbeatRunning,
     isConsolidationRunning,
     isHeartbeatLoading,
     isHeartbeatError,
     isConsolidationLoading,
     isConsolidationError,
+    isRetrospectiveLoading,
+    isRetrospectiveError,
     refetchHeartbeat,
     refetchConsolidation,
+    refetchRetrospective,
     handleRunNow,
     handleToggle,
     refetchAll,

--- a/apps/web/src/domains/settings/pages/schedules-page.test.ts
+++ b/apps/web/src/domains/settings/pages/schedules-page.test.ts
@@ -60,6 +60,26 @@ const fetchConsolidationRunsMock = mock(
 const fetchHeartbeatRunsMock = mock(
   async (_assistantId: string): Promise<ScheduleRun[]> => [],
 );
+const fetchRetrospectiveRunsMock = mock(
+  async (_assistantId: string): Promise<ScheduleRun[]> => [
+    {
+      id: "retro-run-1",
+      jobId: "retrospective",
+      status: "ok",
+      startedAt: 1_761_792_000_000,
+      finishedAt: 1_761_792_004_000,
+      durationMs: 4000,
+      output: null,
+      error: null,
+      conversationId: "conv-retro-1",
+      conversationExists: true,
+      conversationArchivedAt: null,
+      estimatedCostUsd: 0.0456,
+      createdAt: 1_761_792_000_000,
+      title: "Planning chat (Retrospective)",
+    },
+  ],
+);
 const fetchScheduleRunsMock = mock(
   async (_assistantId: string, _scheduleId: string): Promise<ScheduleRun[]> => [],
 );
@@ -76,6 +96,7 @@ mock.module("@/domains/settings/api/schedules", () => ({
   createSchedule: createScheduleMock,
   fetchConsolidationRuns: fetchConsolidationRunsMock,
   fetchHeartbeatRuns: fetchHeartbeatRunsMock,
+  fetchRetrospectiveRuns: fetchRetrospectiveRunsMock,
   fetchScheduleRuns: fetchScheduleRunsMock,
   fetchScheduleUsageSummary: fetchScheduleUsageSummaryMock,
 }));
@@ -88,6 +109,8 @@ const {
   formatTimestamp,
   groupSchedules,
   pastOneTimeStatus,
+  SYSTEM_TASK_URL_IDS,
+  systemTaskKindFromUrlId,
 } = await import("@/domains/settings/utils/schedule-formatters");
 const { RecentRunsCard } = await import(
   "@/domains/settings/components/recent-runs-card"
@@ -114,6 +137,7 @@ afterEach(() => {
   createScheduleMock.mockClear();
   fetchConsolidationRunsMock.mockClear();
   fetchHeartbeatRunsMock.mockClear();
+  fetchRetrospectiveRunsMock.mockClear();
   fetchScheduleRunsMock.mockClear();
   fetchScheduleUsageSummaryMock.mockClear();
   nowSpy?.mockRestore();
@@ -990,13 +1014,16 @@ describe("system task toggles", () => {
           success: true,
         },
         consolidationConfig: undefined,
+        retrospectiveConfig: undefined,
         heartbeatUsage: readySystemTaskUsage,
         consolidationUsage: readySystemTaskUsage,
+        retrospectiveUsage: readySystemTaskUsage,
         isLoading: false,
         hasError: false,
         onRetry: () => {},
         onSelectHeartbeat: () => {},
         onSelectConsolidation: () => {},
+        onSelectRetrospective: () => {},
       }),
     );
 
@@ -1056,13 +1083,16 @@ describe("system task toggles", () => {
           lastRunAt: null,
           success: true,
         },
+        retrospectiveConfig: undefined,
         heartbeatUsage: readySystemTaskUsage,
         consolidationUsage: readySystemTaskUsage,
+        retrospectiveUsage: readySystemTaskUsage,
         isLoading: false,
         hasError: false,
         onRetry: () => {},
         onSelectHeartbeat: () => {},
         onSelectConsolidation: () => {},
+        onSelectRetrospective: () => {},
       }),
     );
 
@@ -1081,6 +1111,108 @@ describe("system task toggles", () => {
     // Heartbeat is hidden here, so its cached usage must not inflate the
     // aggregate cost on the collapsed trigger ($0.42, not $0.84).
     expect(document.body.textContent).toContain("$0.42 (7d)");
+  });
+
+  test("maps system task url ids to kinds, including memory retrospective", () => {
+    expect(systemTaskKindFromUrlId(SYSTEM_TASK_URL_IDS.heartbeat)).toBe(
+      "heartbeat",
+    );
+    expect(systemTaskKindFromUrlId(SYSTEM_TASK_URL_IDS.consolidation)).toBe(
+      "consolidation",
+    );
+    expect(systemTaskKindFromUrlId(SYSTEM_TASK_URL_IDS.retrospective)).toBe(
+      "retrospective",
+    );
+    expect(SYSTEM_TASK_URL_IDS.retrospective).toBe(
+      "system-memory-retrospective",
+    );
+    expect(systemTaskKindFromUrlId("some-user-schedule")).toBeNull();
+    expect(systemTaskKindFromUrlId(undefined)).toBeNull();
+  });
+
+  test("memory retrospective renders as a third system row with event-driven cadence and no Next timestamp", () => {
+    let retrospectiveClicks = 0;
+
+    render(
+      createElement(SystemTasksSection, {
+        heartbeatConfig: undefined,
+        consolidationConfig: undefined,
+        retrospectiveConfig: {
+          available: true,
+          enabled: true,
+          intervalMs: 30 * 60_000,
+          nextRunAt: null,
+          lastRunAt: 1_761_792_000_000,
+          success: true,
+        },
+        heartbeatUsage: readySystemTaskUsage,
+        consolidationUsage: readySystemTaskUsage,
+        retrospectiveUsage: readySystemTaskUsage,
+        isLoading: false,
+        hasError: false,
+        onRetry: () => {},
+        onSelectHeartbeat: () => {},
+        onSelectConsolidation: () => {},
+        onSelectRetrospective: () => {
+          retrospectiveClicks += 1;
+        },
+      }),
+    );
+
+    // System jobs are collapsed by default — expand the disclosure first.
+    fireEvent.click(screen.getByRole("button", { name: /System/i }));
+
+    expect(screen.getByText("Memory retrospective")).toBeTruthy();
+    expect(screen.getByText("After conversation activity")).toBeTruthy();
+    // Event-driven: nextRunAt is always null and must render nothing —
+    // no "Next: —" placeholder.
+    expect(document.body.textContent).not.toContain("Next:");
+    expect(document.body.textContent).toContain(
+      `Last: ${formatTimestamp(1_761_792_000_000)}`,
+    );
+    expect(screen.queryByRole("button", { name: /run now/i })).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open Memory retrospective" }),
+    );
+
+    expect(retrospectiveClicks).toBe(1);
+  });
+
+  test("retrospective detail view titles runs by reviewed conversation and omits Run now and Next run", async () => {
+    renderWithQueryClient(
+      createElement(SystemTaskDetailView, {
+        kind: "retrospective",
+        assistantId: "assistant-1",
+        name: "Memory retrospective",
+        subtitle: "After conversation activity",
+        enabled: true,
+        nextRunAt: null,
+        lastRunAt: 1_761_792_000_000,
+        isRunning: false,
+        onBack: () => {},
+      }),
+    );
+
+    await waitFor(() =>
+      expect(fetchRetrospectiveRunsMock.mock.calls).toEqual([["assistant-1"]]),
+    );
+
+    // Event-driven task: nothing global to trigger, no scheduled next run.
+    expect(screen.queryByRole("button", { name: /Run now/i })).toBeNull();
+    expect(document.body.textContent).not.toContain("Next run");
+    expect(document.body.textContent).toContain("On · Managed by Memory");
+
+    // The run row leads with the reviewed conversation's title and opens
+    // the retrospective conversation like other system run rows.
+    await waitFor(() =>
+      expect(document.body.textContent).toContain(
+        "Planning chat (Retrospective)",
+      ),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Run at/i }));
+
+    expect(navigateCalls).toEqual([routes.conversation("conv-retro-1")]);
   });
 
   test("consolidation detail page never renders a toggle even if a handler is passed", async () => {

--- a/apps/web/src/domains/settings/pages/schedules-page.tsx
+++ b/apps/web/src/domains/settings/pages/schedules-page.tsx
@@ -20,6 +20,7 @@ import {
   groupSchedules,
   heartbeatSubtitle,
   pastOneTimeStatus,
+  RETROSPECTIVE_SUBTITLE,
   scheduleUsageSummaryQueryOptions,
   SYSTEM_TASK_URL_IDS,
   systemTaskKindFromUrlId,
@@ -133,7 +134,7 @@ export function SchedulesPage() {
   );
 
   // -------------------------------------------------------------------------
-  // System tasks (heartbeat + consolidation)
+  // System tasks (heartbeat + consolidation + memory retrospective)
   // -------------------------------------------------------------------------
 
   const systemTasks = useSystemTasks(assistantId, tz);
@@ -271,6 +272,31 @@ export function SchedulesPage() {
     );
   }
 
+  if (
+    selectedSystemTask === "retrospective" &&
+    systemTasks.retrospectiveConfig?.available === true
+  ) {
+    // Event-driven task: no onRunNow (nothing global to trigger) and
+    // nextRunAt is always null by design.
+    return (
+      <SystemTaskDetailView
+        key="retrospective"
+        kind="retrospective"
+        assistantId={assistantId}
+        name="Memory retrospective"
+        subtitle={RETROSPECTIVE_SUBTITLE}
+        enabled={systemTasks.retrospectiveConfig.enabled}
+        nextRunAt={systemTasks.retrospectiveConfig.nextRunAt}
+        lastRunAt={systemTasks.retrospectiveConfig.lastRunAt}
+        isRunning={false}
+        onBack={navigateToSchedules}
+        onOpenMemorySettings={
+          canOpenMemorySettings ? navigateToMemorySettings : undefined
+        }
+      />
+    );
+  }
+
   if (selectedSchedule) {
     return (
       <ScheduleDetailView
@@ -319,15 +345,21 @@ export function SchedulesPage() {
       <div className="mx-auto max-w-[940px] space-y-3">
         <Notice tone="error">
           Failed to load{" "}
-          {selectedSystemTask === "heartbeat" ? "heartbeat" : "consolidation"}{" "}
+          {selectedSystemTask === "heartbeat"
+            ? "heartbeat"
+            : selectedSystemTask === "consolidation"
+              ? "consolidation"
+              : "memory retrospective"}{" "}
           schedule.{" "}
           <button
             type="button"
             onClick={() => {
               if (selectedSystemTask === "heartbeat") {
                 void systemTasks.refetchHeartbeat();
-              } else {
+              } else if (selectedSystemTask === "consolidation") {
                 void systemTasks.refetchConsolidation();
+              } else {
+                void systemTasks.refetchRetrospective();
               }
             }}
             className="cursor-pointer underline hover:no-underline"
@@ -430,8 +462,10 @@ export function SchedulesPage() {
       <SystemTasksSection
         heartbeatConfig={systemTasks.heartbeatConfig}
         consolidationConfig={systemTasks.consolidationConfig}
+        retrospectiveConfig={systemTasks.retrospectiveConfig}
         heartbeatUsage={systemTasks.heartbeatUsage}
         consolidationUsage={systemTasks.consolidationUsage}
+        retrospectiveUsage={systemTasks.retrospectiveUsage}
         isLoading={systemTasks.isLoading}
         hasError={systemTasks.hasError}
         onRetry={systemTasks.refetchAll}
@@ -440,6 +474,9 @@ export function SchedulesPage() {
         }
         onSelectConsolidation={() =>
           navigateToSchedule(SYSTEM_TASK_URL_IDS.consolidation)
+        }
+        onSelectRetrospective={() =>
+          navigateToSchedule(SYSTEM_TASK_URL_IDS.retrospective)
         }
       />
 

--- a/apps/web/src/domains/settings/types/schedules.ts
+++ b/apps/web/src/domains/settings/types/schedules.ts
@@ -16,10 +16,16 @@ export type ScheduleRun = SchedulesByIdRunsGetResponse["runs"][number] & {
   conversationExists?: boolean;
   conversationArchivedAt?: number | null;
   estimatedCostUsd?: number;
+  /**
+   * Conversation title shown as the run's primary label when present.
+   * Set for memory retrospective runs, where the title ("<source title>
+   * (Retrospective)") identifies which conversation was reviewed.
+   */
+  title?: string | null;
 };
 
 export type ScheduleUsageSummaryResponse = SchedulesUsagesummaryGetResponse;
 export type ScheduleUsageSummary =
   ScheduleUsageSummaryResponse["summaries"][number];
 
-export type SystemTaskKind = "heartbeat" | "consolidation";
+export type SystemTaskKind = "heartbeat" | "consolidation" | "retrospective";

--- a/apps/web/src/domains/settings/utils/schedule-formatters.ts
+++ b/apps/web/src/domains/settings/utils/schedule-formatters.ts
@@ -107,6 +107,7 @@ export function hasRunText(value: string | null | undefined): value is string {
 export const SYSTEM_TASK_URL_IDS = {
   heartbeat: "system-heartbeat",
   consolidation: "system-consolidation",
+  retrospective: "system-memory-retrospective",
 } as const satisfies Record<SystemTaskKind, string>;
 
 export const SYSTEM_TASK_STATS_RUN_LIMIT = 100;
@@ -119,6 +120,8 @@ export function systemTaskKindFromUrlId(
       return "heartbeat";
     case SYSTEM_TASK_URL_IDS.consolidation:
       return "consolidation";
+    case SYSTEM_TASK_URL_IDS.retrospective:
+      return "retrospective";
     default:
       return null;
   }
@@ -142,6 +145,13 @@ export function consolidationSubtitle(
 ): string {
   return formatInterval(config.intervalMs);
 }
+
+/**
+ * Retrospectives are event-driven (per-conversation triggers after activity),
+ * not interval-scheduled — so the cadence line describes the trigger instead
+ * of formatting `intervalMs`.
+ */
+export const RETROSPECTIVE_SUBTITLE = "After conversation activity";
 
 // ---------------------------------------------------------------------------
 // Constants

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -22428,6 +22428,162 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/retrospective/config:
+    get:
+      operationId: retrospective_config_get
+      summary: Get memory retrospective config
+      description:
+        Return the memory retrospective configuration. Retrospectives are event-driven background passes triggered
+        per conversation after activity (time/message thresholds, pre-compaction) — there is no global schedule, so
+        `nextRunAt` is always null and no run-now endpoint exists. `intervalMs` is the per-conversation time threshold
+        (`memory.retrospective.timeThresholdMs`), `lastRunAt` is the `createdAt` of the most recent retrospective
+        conversation across both legacy and fork sources, and `available` gates on `memory.enabled` (not
+        `memory.v2.enabled`).
+      tags:
+        - retrospective
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  available:
+                    type: boolean
+                  enabled:
+                    type: boolean
+                  intervalMs:
+                    type: number
+                  nextRunAt:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  lastRunAt:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  success:
+                    type: boolean
+                required:
+                  - available
+                  - enabled
+                  - intervalMs
+                  - nextRunAt
+                  - lastRunAt
+                  - success
+                additionalProperties: false
+  /v1/retrospective/runs:
+    get:
+      operationId: retrospective_runs_get
+      summary: List memory retrospective runs
+      description:
+        "Return recent memory retrospective conversations as run records, merged across both sources
+        (`memory-retrospective` → kind `legacy`, `memory-retrospective-fork` → kind `fork`) and sorted newest first.
+        Each retrospective dispatch creates exactly one background conversation; that conversation IS the run. Shape
+        mirrors `consolidation/runs` (synthetic `id`/`scheduledFor`/`startedAt` from the conversation row,
+        `finishedAt`/`status` from assistant-message presence, `skipReason`/`error` always null) plus `kind` and `title`
+        (fork runs are titled '<source title> (Retrospective)', which identifies what was reviewed). For fork runs,
+        copied source messages keep their original timestamps, so only assistant messages at or after the fork's
+        creation count as agent output. NOTE: superseded runs are garbage-collected by default
+        (`memory.retrospective.keepSupersededRuns: false` deletes the prior run when a newer one succeeds), so this
+        lists what currently exists — typically the most recent run per source conversation unless the operator retains
+        history."
+      tags:
+        - retrospective
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  runs:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        scheduledFor:
+                          type: number
+                        startedAt:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                        finishedAt:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                        durationMs:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                        status:
+                          type: string
+                          enum:
+                            - ok
+                            - running
+                        skipReason:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        error:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        conversationId:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        conversationExists:
+                          type: boolean
+                        conversationArchivedAt:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                        estimatedCostUsd:
+                          type: number
+                        createdAt:
+                          type: number
+                        kind:
+                          type: string
+                          enum:
+                            - legacy
+                            - fork
+                        title:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                      required:
+                        - id
+                        - scheduledFor
+                        - startedAt
+                        - finishedAt
+                        - durationMs
+                        - status
+                        - skipReason
+                        - error
+                        - conversationId
+                        - conversationExists
+                        - conversationArchivedAt
+                        - estimatedCostUsd
+                        - createdAt
+                        - kind
+                        - title
+                      additionalProperties: false
+                    description: Retrospective run records
+                required:
+                  - runs
+                additionalProperties: false
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: Max runs to return (default 20, max 100)
   /v1/sanity/connect:
     post:
       operationId: sanity_connect_post

--- a/assistant/src/runtime/routes/__tests__/retrospective-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/retrospective-routes.test.ts
@@ -1,0 +1,436 @@
+/**
+ * Asserts `listRetrospectiveRuns` merges background-conversation rows from
+ * BOTH retrospective sources (`memory-retrospective` → kind `legacy`,
+ * `memory-retrospective-fork` → kind `fork`) into the heartbeat-runs
+ * response shape (plus `kind` and `title`), derives `status` / `finishedAt`
+ * from assistant-message presence **at or after the conversation's
+ * createdAt** (fork runs copy source messages with their original
+ * timestamps), and clamps the `limit` query param.
+ *
+ * Also asserts `getRetrospectiveConfig` gates `available` on
+ * `memory.enabled` alone (NOT `memory.v2.enabled`) and always reports
+ * `nextRunAt: null` — retrospectives are event-driven per conversation,
+ * never globally scheduled.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+import { invalidateConfigCache } from "../../../config/loader.js";
+import { createConversation } from "../../../memory/conversation-crud.js";
+import { getDb } from "../../../memory/db-connection.js";
+import { initializeDb } from "../../../memory/db-init.js";
+import { recordUsageEvent } from "../../../memory/llm-usage-store.js";
+import {
+  MEMORY_RETROSPECTIVE_FORK_SOURCE,
+  MEMORY_RETROSPECTIVE_SOURCE,
+} from "../../../memory/memory-retrospective-constants.js";
+import { rawRun } from "../../../memory/raw-query.js";
+import { ROUTES } from "../retrospective-routes.js";
+import type { RouteDefinition } from "../types.js";
+
+initializeDb();
+
+let workspaceDir: string;
+let origWorkspaceDir: string | undefined;
+let configPath: string;
+
+function resetTables(): void {
+  const db = getDb();
+  db.run(`DELETE FROM llm_usage_events`);
+  db.run(`DELETE FROM messages`);
+  db.run(`DELETE FROM conversations`);
+}
+
+function findHandler(operationId: string): RouteDefinition["handler"] {
+  const route = ROUTES.find((r) => r.operationId === operationId);
+  if (!route) throw new Error(`Route ${operationId} not found`);
+  return route.handler;
+}
+
+function insertMessage(
+  conversationId: string,
+  role: string,
+  createdAt: number,
+): void {
+  rawRun(
+    "INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES (?, ?, ?, ?, ?)",
+    `msg-${conversationId}-${role}-${createdAt}`,
+    conversationId,
+    role,
+    "x",
+    createdAt,
+  );
+}
+
+function setCreatedAt(conversationId: string, createdAt: number): void {
+  rawRun(
+    "UPDATE conversations SET created_at = ? WHERE id = ?",
+    createdAt,
+    conversationId,
+  );
+}
+
+function recordUsageCostAt(
+  conversationId: string,
+  requestId: string,
+  createdAt: number,
+  estimatedCostUsd: number,
+): void {
+  const event = recordUsageEvent(
+    {
+      conversationId,
+      runId: null,
+      requestId,
+      actor: "main_agent",
+      callSite: "mainAgent",
+      inferenceProfile: "balanced",
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 0,
+      rawUsage: null,
+    },
+    { estimatedCostUsd, pricingStatus: "priced" },
+  );
+  rawRun(
+    "UPDATE llm_usage_events SET created_at = ? WHERE id = ?",
+    createdAt,
+    event.id,
+  );
+}
+
+interface RunRecord {
+  id: string;
+  scheduledFor: number;
+  startedAt: number | null;
+  finishedAt: number | null;
+  durationMs: number | null;
+  status: "ok" | "running";
+  skipReason: string | null;
+  error: string | null;
+  conversationId: string | null;
+  estimatedCostUsd: number;
+  createdAt: number;
+  kind: "legacy" | "fork";
+  title: string | null;
+}
+
+interface ListRunsResponse {
+  runs: RunRecord[];
+}
+
+interface ConfigResponse {
+  available: boolean;
+  enabled: boolean;
+  intervalMs: number;
+  nextRunAt: number | null;
+  lastRunAt: number | null;
+  success: boolean;
+}
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-retrospective-routes-"));
+  origWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+  process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+  configPath = join(workspaceDir, "config.json");
+  invalidateConfigCache();
+  resetTables();
+});
+
+afterEach(() => {
+  if (origWorkspaceDir === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = origWorkspaceDir;
+  }
+  invalidateConfigCache();
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+describe("listRetrospectiveRuns handler", () => {
+  test("merges both retrospective sources with the kind field and excludes others", async () => {
+    const legacy = createConversation({
+      title: "legacy run",
+      source: MEMORY_RETROSPECTIVE_SOURCE,
+    });
+    const fork = createConversation({
+      title: "Planning chat (Retrospective)",
+      source: MEMORY_RETROSPECTIVE_FORK_SOURCE,
+    });
+    createConversation({ title: "h1", source: "heartbeat" });
+    createConversation({ title: "c1", source: "memory_v2_consolidation" });
+    createConversation({ title: "u1", source: "user" });
+    setCreatedAt(legacy.id, 1000);
+    setCreatedAt(fork.id, 2000);
+
+    const handler = findHandler("listRetrospectiveRuns");
+    const result = (await handler({})) as ListRunsResponse;
+
+    expect(result.runs).toHaveLength(2);
+    expect(result.runs.map((r) => [r.id, r.kind, r.title])).toEqual([
+      [fork.id, "fork", "Planning chat (Retrospective)"],
+      [legacy.id, "legacy", "legacy run"],
+    ]);
+  });
+
+  test("orders merged runs by createdAt descending across sources", async () => {
+    const a = createConversation({
+      title: "a",
+      source: MEMORY_RETROSPECTIVE_SOURCE,
+    });
+    const b = createConversation({
+      title: "b",
+      source: MEMORY_RETROSPECTIVE_FORK_SOURCE,
+    });
+    const c = createConversation({
+      title: "c",
+      source: MEMORY_RETROSPECTIVE_SOURCE,
+    });
+    setCreatedAt(a.id, 1000);
+    setCreatedAt(b.id, 3000);
+    setCreatedAt(c.id, 2000);
+
+    const handler = findHandler("listRetrospectiveRuns");
+    const result = (await handler({})) as ListRunsResponse;
+
+    expect(result.runs.map((r) => r.id)).toEqual([b.id, c.id, a.id]);
+  });
+
+  test("synthesizes status='ok' with finishedAt from latest assistant message", async () => {
+    const conv = createConversation({
+      title: "r1",
+      source: MEMORY_RETROSPECTIVE_SOURCE,
+    });
+    setCreatedAt(conv.id, 1000);
+    insertMessage(conv.id, "user", 1100);
+    insertMessage(conv.id, "assistant", 2000);
+    insertMessage(conv.id, "assistant", 2500);
+
+    const handler = findHandler("listRetrospectiveRuns");
+    const result = (await handler({})) as ListRunsResponse;
+
+    const run = result.runs[0]!;
+    expect(run.id).toBe(conv.id);
+    expect(run.conversationId).toBe(conv.id);
+    expect(run.status).toBe("ok");
+    expect(run.scheduledFor).toBe(1000);
+    expect(run.startedAt).toBe(1000);
+    expect(run.finishedAt).toBe(2500);
+    expect(run.durationMs).toBe(1500);
+    expect(run.skipReason).toBeNull();
+    expect(run.error).toBeNull();
+  });
+
+  test("fork run with only the copied source prefix stays 'running' (no negative duration)", async () => {
+    // forkConversation copies source messages with their ORIGINAL
+    // timestamps, so a fresh fork contains assistant messages that predate
+    // the fork conversation's createdAt. Those must not count as agent
+    // output — status stays 'running' until the retrospective agent itself
+    // replies (at-or-after the fork's creation).
+    const conv = createConversation({
+      title: "Planning chat (Retrospective)",
+      source: MEMORY_RETROSPECTIVE_FORK_SOURCE,
+    });
+    setCreatedAt(conv.id, 5000);
+    // Copied prefix from the source conversation (pre-fork timestamps).
+    insertMessage(conv.id, "user", 2000);
+    insertMessage(conv.id, "assistant", 3000);
+
+    const handler = findHandler("listRetrospectiveRuns");
+    const running = (await handler({})) as ListRunsResponse;
+    expect(running.runs[0]!.status).toBe("running");
+    expect(running.runs[0]!.finishedAt).toBeNull();
+    expect(running.runs[0]!.durationMs).toBeNull();
+
+    // Retrospective agent replies after the fork was created.
+    insertMessage(conv.id, "assistant", 6000);
+    const done = (await handler({})) as ListRunsResponse;
+    expect(done.runs[0]!.status).toBe("ok");
+    expect(done.runs[0]!.finishedAt).toBe(6000);
+    expect(done.runs[0]!.durationMs).toBe(1000);
+  });
+
+  test("exposes estimatedCostUsd from the conversation total, falling back to window usage", async () => {
+    const withTotal = createConversation({
+      title: "r1",
+      source: MEMORY_RETROSPECTIVE_SOURCE,
+    });
+    rawRun(
+      "UPDATE conversations SET created_at = ?, total_estimated_cost = ? WHERE id = ?",
+      1000,
+      0.42,
+      withTotal.id,
+    );
+    insertMessage(withTotal.id, "assistant", 2000);
+
+    const withWindow = createConversation({
+      title: "r2",
+      source: MEMORY_RETROSPECTIVE_FORK_SOURCE,
+    });
+    setCreatedAt(withWindow.id, 1000);
+    insertMessage(withWindow.id, "assistant", 2000);
+    recordUsageCostAt(withWindow.id, "retro-before", 999, 0.4);
+    recordUsageCostAt(withWindow.id, "retro-inside", 1500, 0.07);
+    recordUsageCostAt(withWindow.id, "retro-after", 2001, 0.5);
+
+    const handler = findHandler("listRetrospectiveRuns");
+    const result = (await handler({})) as ListRunsResponse;
+
+    const byId = new Map(result.runs.map((r) => [r.id, r]));
+    expect(byId.get(withTotal.id)!.estimatedCostUsd).toBeCloseTo(0.42);
+    expect(byId.get(withWindow.id)!.estimatedCostUsd).toBeCloseTo(0.07);
+  });
+
+  test("limit defaults to 20, clamps to [1, 100], and merges correctly under the cap", async () => {
+    // 3 legacy (newest) + 3 fork (older) — a merged limit of 4 must take
+    // all 3 legacy rows plus the newest fork row, which requires fetching
+    // the limit from EACH source before merging.
+    const ids: Array<{ id: string; createdAt: number }> = [];
+    for (let i = 0; i < 3; i++) {
+      const conv = createConversation({
+        title: `legacy-${i}`,
+        source: MEMORY_RETROSPECTIVE_SOURCE,
+      });
+      setCreatedAt(conv.id, 10_000 + i);
+      ids.push({ id: conv.id, createdAt: 10_000 + i });
+    }
+    for (let i = 0; i < 3; i++) {
+      const conv = createConversation({
+        title: `fork-${i}`,
+        source: MEMORY_RETROSPECTIVE_FORK_SOURCE,
+      });
+      setCreatedAt(conv.id, 5_000 + i);
+      ids.push({ id: conv.id, createdAt: 5_000 + i });
+    }
+    const expectedTop4 = ids
+      .sort((a, b) => b.createdAt - a.createdAt)
+      .slice(0, 4)
+      .map((entry) => entry.id);
+
+    const handler = findHandler("listRetrospectiveRuns");
+
+    const def = (await handler({})) as ListRunsResponse;
+    expect(def.runs).toHaveLength(6);
+
+    const lim4 = (await handler({
+      queryParams: { limit: "4" },
+    })) as ListRunsResponse;
+    expect(lim4.runs.map((r) => r.id)).toEqual(expectedTop4);
+
+    const neg = (await handler({
+      queryParams: { limit: "-5" },
+    })) as ListRunsResponse;
+    expect(neg.runs).toHaveLength(1);
+
+    const huge = (await handler({
+      queryParams: { limit: "5000" },
+    })) as ListRunsResponse;
+    expect(huge.runs).toHaveLength(6);
+
+    const bad = (await handler({
+      queryParams: { limit: "garbage" },
+    })) as ListRunsResponse;
+    expect(bad.runs).toHaveLength(6);
+  });
+});
+
+describe("getRetrospectiveConfig handler", () => {
+  test("reports availability and threshold interval with nextRunAt always null", async () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          memory: {
+            retrospective: { timeThresholdMs: 45 * 60 * 1000 },
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    const conv = createConversation({
+      title: "r1",
+      source: MEMORY_RETROSPECTIVE_FORK_SOURCE,
+    });
+    setCreatedAt(conv.id, 123_456);
+
+    const handler = findHandler("getRetrospectiveConfig");
+    const result = (await handler({})) as ConfigResponse;
+
+    expect(result).toEqual({
+      available: true,
+      enabled: true,
+      intervalMs: 45 * 60 * 1000,
+      nextRunAt: null,
+      lastRunAt: 123_456,
+      success: true,
+    });
+  });
+
+  test("lastRunAt is the newest run across both sources, null when none exist", async () => {
+    const handler = findHandler("getRetrospectiveConfig");
+    const empty = (await handler({})) as ConfigResponse;
+    expect(empty.lastRunAt).toBeNull();
+
+    const legacy = createConversation({
+      title: "legacy",
+      source: MEMORY_RETROSPECTIVE_SOURCE,
+    });
+    const fork = createConversation({
+      title: "fork",
+      source: MEMORY_RETROSPECTIVE_FORK_SOURCE,
+    });
+    setCreatedAt(legacy.id, 9000);
+    setCreatedAt(fork.id, 4000);
+
+    const result = (await handler({})) as ConfigResponse;
+    expect(result.lastRunAt).toBe(9000);
+  });
+
+  test("reports unavailable when global memory is disabled", async () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify({ memory: { enabled: false } }, null, 2) + "\n",
+    );
+
+    const handler = findHandler("getRetrospectiveConfig");
+    const result = (await handler({})) as ConfigResponse;
+
+    expect(result.available).toBe(false);
+    expect(result.enabled).toBe(false);
+    expect(result.nextRunAt).toBeNull();
+    expect(result.success).toBe(true);
+  });
+
+  test("stays available when memory v2 is disabled (retrospectives do not gate on v2)", async () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify({ memory: { v2: { enabled: false } } }, null, 2) + "\n",
+    );
+
+    const handler = findHandler("getRetrospectiveConfig");
+    const result = (await handler({})) as ConfigResponse;
+
+    expect(result.available).toBe(true);
+    expect(result.enabled).toBe(true);
+  });
+
+  test("no run-now route is exposed (retrospectives are event-driven)", () => {
+    expect(ROUTES.some((route) => route.method === "POST")).toBe(false);
+    expect(
+      ROUTES.find((route) => route.endpoint.includes("run-now")),
+    ).toBeUndefined();
+  });
+});

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -110,6 +110,7 @@ import { ROUTES as PUBLISH_ROUTES } from "./publish-routes.js";
 import { ROUTES as QUESTION_ROUTES } from "./question-routes.js";
 import { ROUTES as RECORDING_ROUTES } from "./recording-routes.js";
 import { ROUTES as RENAME_CONVERSATION_ROUTES } from "./rename-conversation-routes.js";
+import { ROUTES as RETROSPECTIVE_ROUTES } from "./retrospective-routes.js";
 import { ROUTES as SANITY_ROUTES } from "./sanity-routes.js";
 import { ROUTES as SCHEDULE_ROUTES } from "./schedule-routes.js";
 import { ROUTES as SECRET_ROUTES } from "./secret-routes.js";
@@ -239,6 +240,7 @@ export const ROUTES: RouteDefinition[] = [
   ...QUESTION_ROUTES,
   ...RECORDING_ROUTES,
   ...RENAME_CONVERSATION_ROUTES,
+  ...RETROSPECTIVE_ROUTES,
   ...SCHEDULE_ROUTES,
   ...SANITY_ROUTES,
   ...SECRET_ROUTES,

--- a/assistant/src/runtime/routes/retrospective-routes.ts
+++ b/assistant/src/runtime/routes/retrospective-routes.ts
@@ -1,0 +1,226 @@
+/**
+ * Route handlers for memory retrospective background runs.
+ *
+ * Retrospectives are per-conversation background passes that review recent
+ * activity in a source conversation and persist durable memories. They are
+ * event-driven — enqueued by per-conversation triggers (time/message-count
+ * thresholds after activity, pre-compaction) via
+ * `maybeEnqueueMemoryRetrospective` in `memory/memory-retrospective-enqueue.ts`
+ * — never globally scheduled, so there is no run-now endpoint and `nextRunAt`
+ * is always null. These routes only surface config and run history for the
+ * Settings UI.
+ *
+ * `available` gates on `memory.enabled` alone (matching `isMemoryEnabled` in
+ * the enqueue path). Retrospectives do NOT depend on `memory.v2.enabled`.
+ */
+
+import { z } from "zod";
+
+import { getConfig } from "../../config/loader.js";
+import type { ConversationRow } from "../../memory/conversation-crud.js";
+import {
+  getMessageRoleStatsByConversation,
+  listConversationsBySource,
+} from "../../memory/conversation-queries.js";
+import { isMemoryEnabled } from "../../memory/jobs-store.js";
+import { getUsageCostForConversationWindow } from "../../memory/llm-usage-store.js";
+import {
+  MEMORY_RETROSPECTIVE_FORK_SOURCE,
+  MEMORY_RETROSPECTIVE_SOURCE,
+} from "../../memory/memory-retrospective-constants.js";
+import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+type RetrospectiveKind = "legacy" | "fork";
+
+const SOURCE_KINDS: ReadonlyArray<{
+  source: string;
+  kind: RetrospectiveKind;
+}> = [
+  { source: MEMORY_RETROSPECTIVE_SOURCE, kind: "legacy" },
+  { source: MEMORY_RETROSPECTIVE_FORK_SOURCE, kind: "fork" },
+];
+
+/**
+ * Fetch the most recent retrospective conversations across BOTH source
+ * sentinels (legacy + fork), newest first. Fetches `limit` rows from each
+ * source before merging so the merged top-N is correct regardless of how
+ * runs are distributed across kinds.
+ */
+function listRetrospectiveConversations(
+  limit: number,
+): Array<{ row: ConversationRow; kind: RetrospectiveKind }> {
+  const merged = SOURCE_KINDS.flatMap(({ source, kind }) =>
+    listConversationsBySource(source, limit).map((row) => ({ row, kind })),
+  );
+  merged.sort((a, b) => b.row.createdAt - a.row.createdAt);
+  return merged.slice(0, limit);
+}
+
+function readRetrospectiveConfigResponse() {
+  const config = getConfig();
+  const available = isMemoryEnabled();
+  const enabled = available;
+  const intervalMs = config.memory.retrospective.timeThresholdMs;
+  // Retrospectives have no global schedule — runs are triggered per
+  // conversation after activity, so a future run time is never known.
+  const nextRunAt = null;
+  const lastRunAt = listRetrospectiveConversations(1)[0]?.row.createdAt ?? null;
+  return {
+    available,
+    enabled,
+    intervalMs,
+    nextRunAt,
+    lastRunAt,
+    success: true,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Shared ROUTES
+// ---------------------------------------------------------------------------
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "getRetrospectiveConfig",
+    endpoint: "retrospective/config",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Get memory retrospective config",
+    description:
+      "Return the memory retrospective configuration. Retrospectives are " +
+      "event-driven background passes triggered per conversation after " +
+      "activity (time/message thresholds, pre-compaction) — there is no " +
+      "global schedule, so `nextRunAt` is always null and no run-now " +
+      "endpoint exists. `intervalMs` is the per-conversation time threshold " +
+      "(`memory.retrospective.timeThresholdMs`), `lastRunAt` is the " +
+      "`createdAt` of the most recent retrospective conversation across " +
+      "both legacy and fork sources, and `available` gates on " +
+      "`memory.enabled` (not `memory.v2.enabled`).",
+    tags: ["retrospective"],
+    responseBody: z.object({
+      available: z.boolean(),
+      enabled: z.boolean(),
+      intervalMs: z.number(),
+      nextRunAt: z.number().nullable(),
+      lastRunAt: z.number().nullable(),
+      success: z.boolean(),
+    }),
+    handler: async (_args: RouteHandlerArgs) => {
+      return readRetrospectiveConfigResponse();
+    },
+  },
+  {
+    operationId: "listRetrospectiveRuns",
+    endpoint: "retrospective/runs",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "List memory retrospective runs",
+    description:
+      "Return recent memory retrospective conversations as run records, " +
+      "merged across both sources (`memory-retrospective` → kind `legacy`, " +
+      "`memory-retrospective-fork` → kind `fork`) and sorted newest first. " +
+      "Each retrospective dispatch creates exactly one background " +
+      "conversation; that conversation IS the run. Shape mirrors " +
+      "`consolidation/runs` (synthetic `id`/`scheduledFor`/`startedAt` from " +
+      "the conversation row, `finishedAt`/`status` from assistant-message " +
+      "presence, `skipReason`/`error` always null) plus `kind` and `title` " +
+      "(fork runs are titled '<source title> (Retrospective)', which " +
+      "identifies what was reviewed). For fork runs, copied source messages " +
+      "keep their original timestamps, so only assistant messages at or " +
+      "after the fork's creation count as agent output. NOTE: superseded " +
+      "runs are garbage-collected by default " +
+      "(`memory.retrospective.keepSupersededRuns: false` deletes the prior " +
+      "run when a newer one succeeds), so this lists what currently exists " +
+      "— typically the most recent run per source conversation unless the " +
+      "operator retains history.",
+    tags: ["retrospective"],
+    queryParams: [
+      {
+        name: "limit",
+        schema: { type: "integer" },
+        description: "Max runs to return (default 20, max 100)",
+      },
+    ],
+    responseBody: z.object({
+      runs: z
+        .array(
+          z.object({
+            id: z.string(),
+            scheduledFor: z.number(),
+            startedAt: z.number().nullable(),
+            finishedAt: z.number().nullable(),
+            durationMs: z.number().nullable(),
+            status: z.enum(["ok", "running"]),
+            skipReason: z.string().nullable(),
+            error: z.string().nullable(),
+            conversationId: z.string().nullable(),
+            conversationExists: z.boolean(),
+            conversationArchivedAt: z.number().nullable(),
+            estimatedCostUsd: z.number(),
+            createdAt: z.number(),
+            kind: z.enum(["legacy", "fork"]),
+            title: z.string().nullable(),
+          }),
+        )
+        .describe("Retrospective run records"),
+    }),
+    handler: async ({ queryParams }: RouteHandlerArgs) => {
+      const params = queryParams ?? {};
+      const rawLimit = Number(params.limit ?? 20);
+      const limit = Number.isFinite(rawLimit)
+        ? Math.min(Math.max(Math.floor(rawLimit), 1), 100)
+        : 20;
+      const rows = listRetrospectiveConversations(limit);
+      const assistantStats = getMessageRoleStatsByConversation(
+        rows.map((r) => r.row.id),
+        "assistant",
+      );
+      const now = Date.now();
+      return {
+        runs: rows.map(({ row: c, kind }) => {
+          const stat = assistantStats.get(c.id);
+          // Fork-based retrospectives copy the source conversation's
+          // messages with their ORIGINAL timestamps, so assistant messages
+          // can predate the fork row's createdAt. Only an assistant message
+          // at-or-after the conversation's creation is evidence the
+          // retrospective agent itself emitted output — without this guard
+          // an in-flight fork run would read "ok" with a negative duration.
+          const hasAssistantOutput = stat != null && stat.lastAt >= c.createdAt;
+          const finishedAt = hasAssistantOutput ? stat.lastAt : null;
+          const estimatedCostUsd =
+            c.totalEstimatedCost > 0
+              ? c.totalEstimatedCost
+              : getUsageCostForConversationWindow({
+                  conversationId: c.id,
+                  from: c.createdAt,
+                  to: finishedAt ?? now,
+                });
+          return {
+            id: c.id,
+            scheduledFor: c.createdAt,
+            startedAt: c.createdAt,
+            finishedAt,
+            durationMs: finishedAt != null ? finishedAt - c.createdAt : null,
+            status: (hasAssistantOutput ? "ok" : "running") as "ok" | "running",
+            skipReason: null,
+            error: null,
+            conversationId: c.id,
+            conversationExists: true,
+            conversationArchivedAt: c.archivedAt,
+            estimatedCostUsd,
+            createdAt: c.createdAt,
+            kind,
+            title: c.title ?? null,
+          };
+        }),
+      };
+    },
+  },
+];


### PR DESCRIPTION
## Summary
- New `retrospective/config` + `retrospective/runs` daemon routes mirroring consolidation: retrospective background conversations (legacy + fork sources, merged) are surfaced as run records with status/cost, plus `kind` and `title` fields
- Settings → Schedules → System gains a third task row (Memory retrospective) with an event-driven cadence label, 7d usage, and a drill-in runs list that opens the underlying conversations
- No run-now action: retrospectives are per-conversation, trigger-driven background passes; note that superseded runs are GC'd unless `memory.retrospective.keepSupersededRuns` is set

## Original prompt
The user wants to see memory-retrospective and memory-retrospective-fork conversations from the Electron app — surfaced under the System section of the Schedules tab in Settings (screenshot showed Heartbeat and Consolidation rows with cadence, cost, and run counts). This follows the memory-retrospective-fork hardening plan that landed earlier today; these background conversations were previously only reachable via the DB.