### PR TITLE
feat(schedules): cursor-paginate run history across all schedule pages

### DIFF
--- a/apps/web/src/domains/settings/api/schedules.test.ts
+++ b/apps/web/src/domains/settings/api/schedules.test.ts
@@ -256,23 +256,26 @@ describe("fetchHeartbeatRuns", () => {
         throwOnError: false,
       },
     ]);
-    expect(result).toEqual([
-      {
-        id: "heartbeat-run-1",
-        jobId: "heartbeat",
-        status: "ok",
-        startedAt: 1_761_792_001_000,
-        finishedAt: 1_761_792_004_000,
-        durationMs: 3000,
-        output: null,
-        error: null,
-        conversationId: "conv-heartbeat-1",
-        conversationExists: true,
-        conversationArchivedAt: null,
-        estimatedCostUsd: 0.0567,
-        createdAt: 1_761_792_000_000,
-      },
-    ]);
+    expect(result).toEqual({
+      runs: [
+        {
+          id: "heartbeat-run-1",
+          jobId: "heartbeat",
+          status: "ok",
+          startedAt: 1_761_792_001_000,
+          finishedAt: 1_761_792_004_000,
+          durationMs: 3000,
+          output: null,
+          error: null,
+          conversationId: "conv-heartbeat-1",
+          conversationExists: true,
+          conversationArchivedAt: null,
+          estimatedCostUsd: 0.0567,
+          createdAt: 1_761_792_000_000,
+        },
+      ],
+      nextCursor: null,
+    });
   });
 });
 
@@ -287,23 +290,26 @@ describe("fetchConsolidationRuns", () => {
         throwOnError: false,
       },
     ]);
-    expect(result).toEqual([
-      {
-        id: "conv-consolidation-1",
-        jobId: "consolidation",
-        status: "ok",
-        startedAt: 1_761_792_001_000,
-        finishedAt: 1_761_792_004_000,
-        durationMs: 3000,
-        output: null,
-        error: null,
-        conversationId: "conv-consolidation-1",
-        conversationExists: true,
-        conversationArchivedAt: null,
-        estimatedCostUsd: 0.1234,
-        createdAt: 1_761_792_000_000,
-      },
-    ]);
+    expect(result).toEqual({
+      runs: [
+        {
+          id: "conv-consolidation-1",
+          jobId: "consolidation",
+          status: "ok",
+          startedAt: 1_761_792_001_000,
+          finishedAt: 1_761_792_004_000,
+          durationMs: 3000,
+          output: null,
+          error: null,
+          conversationId: "conv-consolidation-1",
+          conversationExists: true,
+          conversationArchivedAt: null,
+          estimatedCostUsd: 0.1234,
+          createdAt: 1_761_792_000_000,
+        },
+      ],
+      nextCursor: null,
+    });
   });
 });
 
@@ -318,24 +324,27 @@ describe("fetchRetrospectiveRuns", () => {
         throwOnError: false,
       },
     ]);
-    expect(result).toEqual([
-      {
-        id: "conv-retro-1",
-        jobId: "retrospective",
-        status: "ok",
-        startedAt: 1_761_792_001_000,
-        finishedAt: 1_761_792_004_000,
-        durationMs: 3000,
-        output: null,
-        error: null,
-        conversationId: "conv-retro-1",
-        conversationExists: true,
-        conversationArchivedAt: null,
-        estimatedCostUsd: 0.0456,
-        createdAt: 1_761_792_000_000,
-        title: "Planning chat (Retrospective)",
-      },
-    ]);
+    expect(result).toEqual({
+      runs: [
+        {
+          id: "conv-retro-1",
+          jobId: "retrospective",
+          status: "ok",
+          startedAt: 1_761_792_001_000,
+          finishedAt: 1_761_792_004_000,
+          durationMs: 3000,
+          output: null,
+          error: null,
+          conversationId: "conv-retro-1",
+          conversationExists: true,
+          conversationArchivedAt: null,
+          estimatedCostUsd: 0.0456,
+          createdAt: 1_761_792_000_000,
+          title: "Planning chat (Retrospective)",
+        },
+      ],
+      nextCursor: null,
+    });
   });
 });
 

--- a/apps/web/src/domains/settings/api/schedules.ts
+++ b/apps/web/src/domains/settings/api/schedules.ts
@@ -44,6 +44,16 @@ import type {
 
 export { ApiError };
 
+/** One page of run history plus the cursor for fetching older runs. */
+export interface ScheduleRunsPage {
+  runs: ScheduleRun[];
+  /** Pass back as `before` to fetch older runs; null when history is exhausted. */
+  nextCursor: number | null;
+}
+
+/** Page size used by the run-history detail views. */
+export const SCHEDULE_RUNS_PAGE_SIZE = 25;
+
 export interface CreateSchedulePayload {
   name: string;
   description: string;
@@ -102,10 +112,11 @@ export async function fetchScheduleRuns(
   assistantId: string,
   scheduleId: string,
   limit = 10,
-): Promise<ScheduleRun[]> {
+  before?: number,
+): Promise<ScheduleRunsPage> {
   const { data, error, response } = await schedulesByIdRunsGet({
     path: { assistant_id: assistantId, id: scheduleId },
-    query: { limit },
+    query: { limit, before },
     throwOnError: false,
   });
   assertHasResponse(response, error, "Failed to load schedule runs.");
@@ -115,7 +126,7 @@ export async function fetchScheduleRuns(
       extractErrorMessage(error, response, "Failed to load schedule runs."),
     );
   }
-  return data?.runs ?? [];
+  return { runs: data?.runs ?? [], nextCursor: data?.nextCursor ?? null };
 }
 
 export interface ScheduleUsageSummaryRange {
@@ -198,10 +209,11 @@ export async function runScheduleNow(
 export async function fetchHeartbeatRuns(
   assistantId: string,
   limit = 10,
-): Promise<ScheduleRun[]> {
+  before?: number,
+): Promise<ScheduleRunsPage> {
   const { data, error, response } = await heartbeatRunsGet({
     path: { assistant_id: assistantId },
-    query: { limit },
+    query: { limit, before },
     throwOnError: false,
   });
   assertHasResponse(response, error, "Failed to load heartbeat runs.");
@@ -211,30 +223,34 @@ export async function fetchHeartbeatRuns(
       extractErrorMessage(error, response, "Failed to load heartbeat runs."),
     );
   }
-  return (data?.runs ?? []).map((run) => ({
-    id: run.id,
-    jobId: "heartbeat",
-    status: run.status,
-    startedAt: run.startedAt ?? run.scheduledFor,
-    finishedAt: run.finishedAt,
-    durationMs: run.durationMs,
-    output: run.skipReason ? `Skipped: ${run.skipReason}` : null,
-    error: run.error,
-    conversationId: run.conversationId,
-    conversationExists: run.conversationExists,
-    conversationArchivedAt: run.conversationArchivedAt,
-    estimatedCostUsd: run.estimatedCostUsd,
-    createdAt: run.createdAt,
-  }));
+  return {
+    nextCursor: data?.nextCursor ?? null,
+    runs: (data?.runs ?? []).map((run) => ({
+      id: run.id,
+      jobId: "heartbeat",
+      status: run.status,
+      startedAt: run.startedAt ?? run.scheduledFor,
+      finishedAt: run.finishedAt,
+      durationMs: run.durationMs,
+      output: run.skipReason ? `Skipped: ${run.skipReason}` : null,
+      error: run.error,
+      conversationId: run.conversationId,
+      conversationExists: run.conversationExists,
+      conversationArchivedAt: run.conversationArchivedAt,
+      estimatedCostUsd: run.estimatedCostUsd,
+      createdAt: run.createdAt,
+    })),
+  };
 }
 
 export async function fetchConsolidationRuns(
   assistantId: string,
   limit = 10,
-): Promise<ScheduleRun[]> {
+  before?: number,
+): Promise<ScheduleRunsPage> {
   const { data, error, response } = await consolidationRunsGet({
     path: { assistant_id: assistantId },
-    query: { limit },
+    query: { limit, before },
     throwOnError: false,
   });
   assertHasResponse(response, error, "Failed to load consolidation runs.");
@@ -244,30 +260,34 @@ export async function fetchConsolidationRuns(
       extractErrorMessage(error, response, "Failed to load consolidation runs."),
     );
   }
-  return (data?.runs ?? []).map((run) => ({
-    id: run.id,
-    jobId: "consolidation",
-    status: run.status,
-    startedAt: run.startedAt ?? run.scheduledFor,
-    finishedAt: run.finishedAt,
-    durationMs: run.durationMs,
-    output: null,
-    error: run.error,
-    conversationId: run.conversationId,
-    conversationExists: run.conversationExists,
-    conversationArchivedAt: run.conversationArchivedAt,
-    estimatedCostUsd: run.estimatedCostUsd,
-    createdAt: run.createdAt,
-  }));
+  return {
+    nextCursor: data?.nextCursor ?? null,
+    runs: (data?.runs ?? []).map((run) => ({
+      id: run.id,
+      jobId: "consolidation",
+      status: run.status,
+      startedAt: run.startedAt ?? run.scheduledFor,
+      finishedAt: run.finishedAt,
+      durationMs: run.durationMs,
+      output: null,
+      error: run.error,
+      conversationId: run.conversationId,
+      conversationExists: run.conversationExists,
+      conversationArchivedAt: run.conversationArchivedAt,
+      estimatedCostUsd: run.estimatedCostUsd,
+      createdAt: run.createdAt,
+    })),
+  };
 }
 
 export async function fetchRetrospectiveRuns(
   assistantId: string,
   limit = 10,
-): Promise<ScheduleRun[]> {
+  before?: number,
+): Promise<ScheduleRunsPage> {
   const { data, error, response } = await retrospectiveRunsGet({
     path: { assistant_id: assistantId },
-    query: { limit },
+    query: { limit, before },
     throwOnError: false,
   });
   assertHasResponse(response, error, "Failed to load retrospective runs.");
@@ -277,22 +297,25 @@ export async function fetchRetrospectiveRuns(
       extractErrorMessage(error, response, "Failed to load retrospective runs."),
     );
   }
-  return (data?.runs ?? []).map((run) => ({
-    id: run.id,
-    jobId: "retrospective",
-    status: run.status,
-    startedAt: run.startedAt ?? run.scheduledFor,
-    finishedAt: run.finishedAt,
-    durationMs: run.durationMs,
-    output: null,
-    error: run.error,
-    conversationId: run.conversationId,
-    conversationExists: run.conversationExists,
-    conversationArchivedAt: run.conversationArchivedAt,
-    estimatedCostUsd: run.estimatedCostUsd,
-    createdAt: run.createdAt,
-    title: run.title,
-  }));
+  return {
+    nextCursor: data?.nextCursor ?? null,
+    runs: (data?.runs ?? []).map((run) => ({
+      id: run.id,
+      jobId: "retrospective",
+      status: run.status,
+      startedAt: run.startedAt ?? run.scheduledFor,
+      finishedAt: run.finishedAt,
+      durationMs: run.durationMs,
+      output: null,
+      error: run.error,
+      conversationId: run.conversationId,
+      conversationExists: run.conversationExists,
+      conversationArchivedAt: run.conversationArchivedAt,
+      estimatedCostUsd: run.estimatedCostUsd,
+      createdAt: run.createdAt,
+      title: run.title,
+    })),
+  };
 }
 
 export async function fetchHeartbeatConfig(

--- a/apps/web/src/domains/settings/components/recent-runs-card.tsx
+++ b/apps/web/src/domains/settings/components/recent-runs-card.tsx
@@ -12,6 +12,7 @@ import {
   hasRunText,
 } from "@/domains/settings/utils/schedule-formatters";
 import { routes } from "@/utils/routes";
+import { Button } from "@vellumai/design-library/components/button";
 import { PanelItem } from "@vellumai/design-library/components/panel-item";
 
 import type { ScheduleRun } from "@/domains/settings/types/schedules";
@@ -20,12 +21,21 @@ interface RecentRunsCardProps {
   runs: ScheduleRun[] | undefined;
   isLoading: boolean;
   emptyMessage?: string;
+  /** Whether older runs exist beyond the loaded pages. */
+  hasMore?: boolean;
+  /** Whether an older page is currently being fetched. */
+  isLoadingMore?: boolean;
+  /** Fetch the next (older) page of runs. */
+  onLoadMore?: () => void;
 }
 
 export function RecentRunsCard({
   runs,
   isLoading,
   emptyMessage = "No runs yet.",
+  hasMore = false,
+  isLoadingMore = false,
+  onLoadMore,
 }: RecentRunsCardProps) {
   const navigate = useNavigate();
   const [expandedRunId, setExpandedRunId] = useState<string | null>(null);
@@ -129,6 +139,23 @@ export function RecentRunsCard({
               </div>
             );
           })}
+          {hasMore && onLoadMore ? (
+            <div className="flex justify-center pt-3">
+              <Button
+                variant="outlined"
+                size="compact"
+                onClick={onLoadMore}
+                disabled={isLoadingMore}
+                leftIcon={
+                  isLoadingMore ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : undefined
+                }
+              >
+                {isLoadingMore ? "Loading…" : "Load more"}
+              </Button>
+            </div>
+          ) : null}
         </div>
       )}
     </DetailCard>

--- a/apps/web/src/domains/settings/components/schedule-detail-view.tsx
+++ b/apps/web/src/domains/settings/components/schedule-detail-view.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import {
   ArrowLeft,
   BarChart3,
@@ -15,12 +15,14 @@ import {
   deleteSchedule,
   fetchScheduleRuns,
   runScheduleNow,
+  SCHEDULE_RUNS_PAGE_SIZE,
   updateSchedule,
 } from "@/domains/settings/api/schedules";
 import { RecentRunsCard } from "@/domains/settings/components/recent-runs-card";
 import { StatusDot } from "@/domains/settings/components/schedule-shared-ui";
 import {
   DEFAULT_SCRIPT_TIMEOUT_MS,
+  flattenRunPages,
   formatTimestamp,
   getOpenableScheduleSourceConversationId,
   MAX_SCRIPT_TIMEOUT_SECONDS,
@@ -163,14 +165,26 @@ export function ScheduleDetailView({
   const navigate = useNavigate();
 
   const {
-    data: runs,
+    data,
     isLoading,
     refetch,
-  } = useQuery({
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery({
     queryKey: assistantScheduleRunsQueryKey(assistantId, schedule.id),
-    queryFn: () => fetchScheduleRuns(assistantId, schedule.id),
+    queryFn: ({ pageParam }) =>
+      fetchScheduleRuns(
+        assistantId,
+        schedule.id,
+        SCHEDULE_RUNS_PAGE_SIZE,
+        pageParam,
+      ),
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
     staleTime: 10_000,
   });
+  const runs = flattenRunPages(data?.pages);
 
   const [isRunning, setIsRunning] = useState(false);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
@@ -312,7 +326,13 @@ export function ScheduleDetailView({
         </div>
       </DetailCard>
 
-      <RecentRunsCard runs={runs} isLoading={isLoading} />
+      <RecentRunsCard
+        runs={runs}
+        isLoading={isLoading}
+        hasMore={hasNextPage}
+        isLoadingMore={isFetchingNextPage}
+        onLoadMore={() => void fetchNextPage()}
+      />
 
       <DetailCard title="Danger zone">
         <div className="flex items-center justify-between gap-4">

--- a/apps/web/src/domains/settings/components/system-task-detail-view.tsx
+++ b/apps/web/src/domains/settings/components/system-task-detail-view.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import { ArrowLeft, Loader2, Play, Settings } from "lucide-react";
 
 import { DetailCard } from "@/components/detail-card";
@@ -6,9 +6,13 @@ import {
   fetchConsolidationRuns,
   fetchHeartbeatRuns,
   fetchRetrospectiveRuns,
+  SCHEDULE_RUNS_PAGE_SIZE,
 } from "@/domains/settings/api/schedules";
 import { RecentRunsCard } from "@/domains/settings/components/recent-runs-card";
-import { formatTimestamp } from "@/domains/settings/utils/schedule-formatters";
+import {
+  flattenRunPages,
+  formatTimestamp,
+} from "@/domains/settings/utils/schedule-formatters";
 import { Button } from "@vellumai/design-library/components/button";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { Tag } from "@vellumai/design-library/components/tag";
@@ -70,16 +74,28 @@ export function SystemTaskDetailView({
     ? "Memory is off, so retrospectives are paused. Turn Memory back on to resume them."
     : "Memory is off, so consolidation is paused. Turn Memory back on to resume consolidation.";
 
-  const { data: runs, isLoading } = useQuery({
-    queryKey: ["system-task-runs", assistantId, kind],
-    queryFn: () =>
-      kind === "heartbeat"
-        ? fetchHeartbeatRuns(assistantId)
-        : kind === "consolidation"
-          ? fetchConsolidationRuns(assistantId)
-          : fetchRetrospectiveRuns(assistantId),
-    staleTime: 10_000,
-  });
+  const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteQuery({
+      queryKey: ["system-task-runs", assistantId, kind],
+      queryFn: ({ pageParam }) =>
+        kind === "heartbeat"
+          ? fetchHeartbeatRuns(assistantId, SCHEDULE_RUNS_PAGE_SIZE, pageParam)
+          : kind === "consolidation"
+            ? fetchConsolidationRuns(
+                assistantId,
+                SCHEDULE_RUNS_PAGE_SIZE,
+                pageParam,
+              )
+            : fetchRetrospectiveRuns(
+                assistantId,
+                SCHEDULE_RUNS_PAGE_SIZE,
+                pageParam,
+              ),
+      initialPageParam: undefined as number | undefined,
+      getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+      staleTime: 10_000,
+    });
+  const runs = flattenRunPages(data?.pages);
 
   return (
     <div className="space-y-4">
@@ -174,7 +190,13 @@ export function SystemTaskDetailView({
         ) : null}
       </DetailCard>
 
-      <RecentRunsCard runs={runs} isLoading={isLoading} />
+      <RecentRunsCard
+        runs={runs}
+        isLoading={isLoading}
+        hasMore={hasNextPage}
+        isLoadingMore={isFetchingNextPage}
+        onLoadMore={() => void fetchNextPage()}
+      />
     </div>
   );
 }

--- a/apps/web/src/domains/settings/hooks/use-system-tasks.ts
+++ b/apps/web/src/domains/settings/hooks/use-system-tasks.ts
@@ -100,7 +100,10 @@ export function useSystemTasks(assistantId: string | undefined, tz: string) {
       "heartbeat",
       SYSTEM_TASK_STATS_RUN_LIMIT,
     ],
-    queryFn: () => fetchHeartbeatRuns(assistantId!, SYSTEM_TASK_STATS_RUN_LIMIT),
+    queryFn: () =>
+      fetchHeartbeatRuns(assistantId!, SYSTEM_TASK_STATS_RUN_LIMIT).then(
+        (page) => page.runs,
+      ),
     enabled: !!assistantId && heartbeatConfig != null,
     staleTime: 10_000,
   });
@@ -118,7 +121,9 @@ export function useSystemTasks(assistantId: string | undefined, tz: string) {
       SYSTEM_TASK_STATS_RUN_LIMIT,
     ],
     queryFn: () =>
-      fetchConsolidationRuns(assistantId!, SYSTEM_TASK_STATS_RUN_LIMIT),
+      fetchConsolidationRuns(assistantId!, SYSTEM_TASK_STATS_RUN_LIMIT).then(
+        (page) => page.runs,
+      ),
     enabled: !!assistantId && consolidationConfig?.available === true,
     staleTime: 10_000,
   });
@@ -136,7 +141,9 @@ export function useSystemTasks(assistantId: string | undefined, tz: string) {
       SYSTEM_TASK_STATS_RUN_LIMIT,
     ],
     queryFn: () =>
-      fetchRetrospectiveRuns(assistantId!, SYSTEM_TASK_STATS_RUN_LIMIT),
+      fetchRetrospectiveRuns(assistantId!, SYSTEM_TASK_STATS_RUN_LIMIT).then(
+        (page) => page.runs,
+      ),
     enabled: !!assistantId && retrospectiveConfig?.available === true,
     staleTime: 10_000,
   });

--- a/apps/web/src/domains/settings/pages/schedules-page.test.ts
+++ b/apps/web/src/domains/settings/pages/schedules-page.test.ts
@@ -18,7 +18,12 @@ import type {
   ScheduleRun,
   ScheduleUsageSummary,
 } from "@/domains/settings/types/schedules";
-import type { ScheduleUsageSummaryRange } from "@/domains/settings/api/schedules";
+import type {
+  ScheduleRunsPage,
+  ScheduleUsageSummaryRange,
+} from "@/domains/settings/api/schedules";
+
+const RUNS_PAGE_SIZE = schedulesApi.SCHEDULE_RUNS_PAGE_SIZE;
 
 const navigateCalls: string[] = [];
 const navigateMock = (to: string) => {
@@ -39,49 +44,72 @@ const fetchScheduleUsageSummaryMock = mock(
   ): Promise<ScheduleUsageSummary[]> => [],
 );
 const fetchConsolidationRunsMock = mock(
-  async (_assistantId: string): Promise<ScheduleRun[]> => [
-    {
-      id: "consolidation-run-1",
-      jobId: "consolidation",
-      status: "ok",
-      startedAt: 1_761_792_000_000,
-      finishedAt: 1_761_792_003_000,
-      durationMs: 3000,
-      output: null,
-      error: null,
-      conversationId: "conv-consolidation-1",
-      conversationExists: true,
-      conversationArchivedAt: null,
-      estimatedCostUsd: 0.1234,
-      createdAt: 1_761_792_000_000,
-    },
-  ],
+  async (
+    _assistantId: string,
+    _limit?: number,
+    _before?: number,
+  ): Promise<ScheduleRunsPage> => ({
+    runs: [
+      {
+        id: "consolidation-run-1",
+        jobId: "consolidation",
+        status: "ok",
+        startedAt: 1_761_792_000_000,
+        finishedAt: 1_761_792_003_000,
+        durationMs: 3000,
+        output: null,
+        error: null,
+        conversationId: "conv-consolidation-1",
+        conversationExists: true,
+        conversationArchivedAt: null,
+        estimatedCostUsd: 0.1234,
+        createdAt: 1_761_792_000_000,
+      },
+    ],
+    nextCursor: null,
+  }),
 );
 const fetchHeartbeatRunsMock = mock(
-  async (_assistantId: string): Promise<ScheduleRun[]> => [],
+  async (
+    _assistantId: string,
+    _limit?: number,
+    _before?: number,
+  ): Promise<ScheduleRunsPage> => ({ runs: [], nextCursor: null }),
 );
 const fetchRetrospectiveRunsMock = mock(
-  async (_assistantId: string): Promise<ScheduleRun[]> => [
-    {
-      id: "retro-run-1",
-      jobId: "retrospective",
-      status: "ok",
-      startedAt: 1_761_792_000_000,
-      finishedAt: 1_761_792_004_000,
-      durationMs: 4000,
-      output: null,
-      error: null,
-      conversationId: "conv-retro-1",
-      conversationExists: true,
-      conversationArchivedAt: null,
-      estimatedCostUsd: 0.0456,
-      createdAt: 1_761_792_000_000,
-      title: "Planning chat (Retrospective)",
-    },
-  ],
+  async (
+    _assistantId: string,
+    _limit?: number,
+    _before?: number,
+  ): Promise<ScheduleRunsPage> => ({
+    runs: [
+      {
+        id: "retro-run-1",
+        jobId: "retrospective",
+        status: "ok",
+        startedAt: 1_761_792_000_000,
+        finishedAt: 1_761_792_004_000,
+        durationMs: 4000,
+        output: null,
+        error: null,
+        conversationId: "conv-retro-1",
+        conversationExists: true,
+        conversationArchivedAt: null,
+        estimatedCostUsd: 0.0456,
+        createdAt: 1_761_792_000_000,
+        title: "Planning chat (Retrospective)",
+      },
+    ],
+    nextCursor: null,
+  }),
 );
 const fetchScheduleRunsMock = mock(
-  async (_assistantId: string, _scheduleId: string): Promise<ScheduleRun[]> => [],
+  async (
+    _assistantId: string,
+    _scheduleId: string,
+    _limit?: number,
+    _before?: number,
+  ): Promise<ScheduleRunsPage> => ({ runs: [], nextCursor: null }),
 );
 const createScheduleMock = mock(
   async (
@@ -441,7 +469,9 @@ describe("SystemTaskDetailView", () => {
     );
 
     await waitFor(() =>
-      expect(fetchConsolidationRunsMock.mock.calls).toEqual([["assistant-1"]]),
+      expect(fetchConsolidationRunsMock.mock.calls).toEqual([
+        ["assistant-1", RUNS_PAGE_SIZE, undefined],
+      ]),
     );
 
     await waitFor(() =>
@@ -485,7 +515,9 @@ describe("SystemTaskDetailView", () => {
     );
 
     await waitFor(() =>
-      expect(fetchConsolidationRunsMock.mock.calls).toEqual([["assistant-1"]]),
+      expect(fetchConsolidationRunsMock.mock.calls).toEqual([
+        ["assistant-1", RUNS_PAGE_SIZE, undefined],
+      ]),
     );
 
     expect(document.body.textContent).toContain(
@@ -944,7 +976,7 @@ describe("ScheduleDetailView", () => {
 
     await waitFor(() =>
       expect(fetchScheduleRunsMock.mock.calls).toEqual([
-        ["assistant-1", "schedule-123"],
+        ["assistant-1", "schedule-123", RUNS_PAGE_SIZE, undefined],
       ]),
     );
   });
@@ -1056,7 +1088,9 @@ describe("system task toggles", () => {
     );
 
     await waitFor(() =>
-      expect(fetchHeartbeatRunsMock.mock.calls).toEqual([["assistant-1"]]),
+      expect(fetchHeartbeatRunsMock.mock.calls).toEqual([
+        ["assistant-1", RUNS_PAGE_SIZE, undefined],
+      ]),
     );
 
     expect(document.body.textContent).toContain("Disabled");
@@ -1195,7 +1229,9 @@ describe("system task toggles", () => {
     );
 
     await waitFor(() =>
-      expect(fetchRetrospectiveRunsMock.mock.calls).toEqual([["assistant-1"]]),
+      expect(fetchRetrospectiveRunsMock.mock.calls).toEqual([
+        ["assistant-1", RUNS_PAGE_SIZE, undefined],
+      ]),
     );
 
     // Event-driven task: nothing global to trigger, no scheduled next run.
@@ -1233,7 +1269,9 @@ describe("system task toggles", () => {
     );
 
     await waitFor(() =>
-      expect(fetchConsolidationRunsMock.mock.calls).toEqual([["assistant-1"]]),
+      expect(fetchConsolidationRunsMock.mock.calls).toEqual([
+        ["assistant-1", RUNS_PAGE_SIZE, undefined],
+      ]),
     );
 
     expect(screen.queryByLabelText("Toggle Consolidation")).toBeNull();

--- a/apps/web/src/domains/settings/utils/schedule-formatters.ts
+++ b/apps/web/src/domains/settings/utils/schedule-formatters.ts
@@ -60,6 +60,27 @@ export function formatInterval(ms: number): string {
   return `Every ${minutes} min`;
 }
 
+/**
+ * Flatten infinite-query run pages into a single newest-first list,
+ * deduping by run id (a row can repeat across a page boundary when new
+ * runs land between page fetches).
+ */
+export function flattenRunPages(
+  pages: { runs: ScheduleRun[] }[] | undefined,
+): ScheduleRun[] | undefined {
+  if (!pages) return undefined;
+  const seen = new Set<string>();
+  const runs: ScheduleRun[] = [];
+  for (const page of pages) {
+    for (const run of page.runs) {
+      if (seen.has(run.id)) continue;
+      seen.add(run.id);
+      runs.push(run);
+    }
+  }
+  return runs;
+}
+
 // ---------------------------------------------------------------------------
 // Schedule / run predicates
 // ---------------------------------------------------------------------------

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6227,8 +6227,14 @@ paths:
                         - createdAt
                       additionalProperties: false
                     description: Consolidation run records
+                  nextCursor:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                    description: Cursor for fetching older runs (pass as `before`); null when no older runs exist
                 required:
                   - runs
+                  - nextCursor
                 additionalProperties: false
       parameters:
         - name: limit
@@ -6237,6 +6243,12 @@ paths:
           schema:
             type: integer
           description: Max runs to return (default 20, max 100)
+        - name: before
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: "Cursor for older runs: pass the previous page's `nextCursor` to return runs strictly older than it."
   /v1/contact-channels/{contactChannelId}:
     patch:
       operationId: contactchannels_by_contactChannelId_patch
@@ -13423,8 +13435,14 @@ paths:
                         - createdAt
                       additionalProperties: false
                     description: Heartbeat run records
+                  nextCursor:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                    description: Cursor for fetching older runs (pass as `before`); null when no older runs exist
                 required:
                   - runs
+                  - nextCursor
                 additionalProperties: false
       parameters:
         - name: limit
@@ -13433,6 +13451,12 @@ paths:
           schema:
             type: integer
           description: Max runs to return (default 20, max 100)
+        - name: before
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: "Cursor for older runs: pass the previous page's `nextCursor` to return runs strictly older than it."
   /v1/home/feed:
     get:
       operationId: home_feed_get
@@ -22574,8 +22598,14 @@ paths:
                         - title
                       additionalProperties: false
                     description: Retrospective run records
+                  nextCursor:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                    description: Cursor for fetching older runs (pass as `before`); null when no older runs exist
                 required:
                   - runs
+                  - nextCursor
                 additionalProperties: false
       parameters:
         - name: limit
@@ -22584,6 +22614,12 @@ paths:
           schema:
             type: integer
           description: Max runs to return (default 20, max 100)
+        - name: before
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: "Cursor for older runs: pass the previous page's `nextCursor` to return runs strictly older than it."
   /v1/sanity/connect:
     post:
       operationId: sanity_connect_post
@@ -23820,8 +23856,14 @@ paths:
                         - createdAt
                       additionalProperties: false
                     description: Schedule run objects
+                  nextCursor:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                    description: Cursor for fetching older runs (pass as `before`); null when no older runs exist
                 required:
                   - runs
+                  - nextCursor
                 additionalProperties: false
       parameters:
         - name: id
@@ -23835,6 +23877,12 @@ paths:
           schema:
             type: integer
           description: Max runs to return (default 10, max 100)
+        - name: before
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: "Cursor for older runs: pass the previous page's `nextCursor` to return runs strictly older than it."
   /v1/schedules/{id}/toggle:
     post:
       operationId: schedules_by_id_toggle_post

--- a/assistant/src/heartbeat/heartbeat-run-store.ts
+++ b/assistant/src/heartbeat/heartbeat-run-store.ts
@@ -1,4 +1,4 @@
-import { desc, eq, sql } from "drizzle-orm";
+import { desc, eq, lt, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb } from "../memory/db-connection.js";
@@ -272,12 +272,18 @@ export function countRecentConsecutiveRuns(maxToCheck: number): number {
 
 /**
  * List heartbeat runs ordered by `scheduledFor` descending.
+ * When `before` is set, only runs with `scheduledFor` strictly older than it
+ * are returned (cursor for paginating into history).
  */
-export function listHeartbeatRuns(limit = 20): HeartbeatRunRecord[] {
+export function listHeartbeatRuns(
+  limit = 20,
+  before?: number,
+): HeartbeatRunRecord[] {
   const db = getDb();
   const rows = db
     .select()
     .from(heartbeatRuns)
+    .where(before != null ? lt(heartbeatRuns.scheduledFor, before) : undefined)
     .orderBy(desc(heartbeatRuns.scheduledFor))
     .limit(limit)
     .all();

--- a/assistant/src/memory/conversation-queries.ts
+++ b/assistant/src/memory/conversation-queries.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq, inArray, isNull, sql } from "drizzle-orm";
+import { and, count, desc, eq, inArray, isNull, lt, sql } from "drizzle-orm";
 
 import {
   parseExternalContentEnvelope,
@@ -208,17 +208,24 @@ export function listConversations(
  *                              Defaults to `true` so callers that want a full
  *                              run history get one; pass `false` for views
  *                              that hide archived rows.
+ * @param opts.beforeCreatedAt  Only return rows with `createdAt` strictly
+ *                              older than this epoch-millis cursor (for
+ *                              paginating into history).
  */
 export function listConversationsBySource(
   source: string,
   limit = 20,
-  opts?: { includeArchived?: boolean },
+  opts?: { includeArchived?: boolean; beforeCreatedAt?: number },
 ): ConversationRow[] {
   const db = getDb();
   const includeArchived = opts?.includeArchived ?? true;
-  const where = includeArchived
-    ? eq(conversations.source, source)
-    : and(eq(conversations.source, source), isNull(conversations.archivedAt));
+  const where = and(
+    eq(conversations.source, source),
+    includeArchived ? undefined : isNull(conversations.archivedAt),
+    opts?.beforeCreatedAt != null
+      ? lt(conversations.createdAt, opts.beforeCreatedAt)
+      : undefined,
+  );
   const rows = db
     .select()
     .from(conversations)

--- a/assistant/src/runtime/routes/consolidation-routes.ts
+++ b/assistant/src/runtime/routes/consolidation-routes.ts
@@ -31,6 +31,13 @@ import { getUsageCostForConversationWindow } from "../../memory/llm-usage-store.
 import { MEMORY_V2_CONSOLIDATION_SOURCE } from "../../memory/v2/constants.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError } from "./errors.js";
+import {
+  paginateRuns,
+  parseRunsBeforeCursor,
+  parseRunsLimit,
+  RUNS_NEXT_CURSOR_SCHEMA,
+  RUNS_PAGINATION_QUERY_PARAMS,
+} from "./runs-pagination.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 function isConsolidationAvailable(): boolean {
@@ -162,13 +169,7 @@ export const ROUTES: RouteDefinition[] = [
       "on the conversation row. Shape mirrors `heartbeat/runs` so the " +
       "schedules settings UI can reuse its run-row component.",
     tags: ["consolidation"],
-    queryParams: [
-      {
-        name: "limit",
-        schema: { type: "integer" },
-        description: "Max runs to return (default 20, max 100)",
-      },
-    ],
+    queryParams: RUNS_PAGINATION_QUERY_PARAMS(20),
     responseBody: z.object({
       runs: z
         .array(
@@ -189,16 +190,18 @@ export const ROUTES: RouteDefinition[] = [
           }),
         )
         .describe("Consolidation run records"),
+      nextCursor: RUNS_NEXT_CURSOR_SCHEMA,
     }),
     handler: async ({ queryParams }: RouteHandlerArgs) => {
       const params = queryParams ?? {};
-      const rawLimit = Number(params.limit ?? 20);
-      const limit = Number.isFinite(rawLimit)
-        ? Math.min(Math.max(Math.floor(rawLimit), 1), 100)
-        : 20;
-      const rows = listConversationsBySource(
-        MEMORY_V2_CONSOLIDATION_SOURCE,
+      const limit = parseRunsLimit(params, 20);
+      const before = parseRunsBeforeCursor(params);
+      const { rows, nextCursor } = paginateRuns(
+        listConversationsBySource(MEMORY_V2_CONSOLIDATION_SOURCE, limit + 1, {
+          beforeCreatedAt: before,
+        }),
         limit,
+        (c) => c.createdAt,
       );
       // Aggregate assistant-message stats in one batched query: presence of
       // an assistant message is the strongest "agent emitted output" signal
@@ -212,6 +215,7 @@ export const ROUTES: RouteDefinition[] = [
       );
       const now = Date.now();
       return {
+        nextCursor,
         runs: rows.map((c) => {
           const stat = assistantStats.get(c.id);
           const hasAssistantOutput = (stat?.count ?? 0) > 0;

--- a/assistant/src/runtime/routes/heartbeat-routes.ts
+++ b/assistant/src/runtime/routes/heartbeat-routes.ts
@@ -25,6 +25,13 @@ import { getLogger } from "../../util/logger.js";
 import { getWorkspacePromptPath } from "../../util/platform.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError, InternalError } from "./errors.js";
+import {
+  paginateRuns,
+  parseRunsBeforeCursor,
+  parseRunsLimit,
+  RUNS_NEXT_CURSOR_SCHEMA,
+  RUNS_PAGINATION_QUERY_PARAMS,
+} from "./runs-pagination.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("heartbeat-routes");
@@ -34,15 +41,18 @@ const log = getLogger("heartbeat-routes");
 // ---------------------------------------------------------------------------
 
 function handleListRuns(queryParams: Record<string, string>) {
-  const rawLimit = Number(queryParams.limit ?? 20);
-  const limit = Number.isFinite(rawLimit)
-    ? Math.min(Math.max(Math.floor(rawLimit), 1), 100)
-    : 20;
+  const limit = parseRunsLimit(queryParams, 20);
+  const before = parseRunsBeforeCursor(queryParams);
 
-  const runs = listHeartbeatRuns(limit);
+  const { rows, nextCursor } = paginateRuns(
+    listHeartbeatRuns(limit + 1, before),
+    limit,
+    (r) => r.scheduledFor,
+  );
   const now = Date.now();
   return {
-    runs: runs.map((r) => {
+    nextCursor,
+    runs: rows.map((r) => {
       const conversation = r.conversationId
         ? getConversation(r.conversationId)
         : null;
@@ -113,13 +123,7 @@ export const ROUTES: RouteDefinition[] = [
     summary: "List heartbeat runs",
     description: "Return recent heartbeat conversation runs.",
     tags: ["heartbeat"],
-    queryParams: [
-      {
-        name: "limit",
-        schema: { type: "integer" },
-        description: "Max runs to return (default 20, max 100)",
-      },
-    ],
+    queryParams: RUNS_PAGINATION_QUERY_PARAMS(20),
     responseBody: z.object({
       runs: z
         .array(
@@ -140,6 +144,7 @@ export const ROUTES: RouteDefinition[] = [
           }),
         )
         .describe("Heartbeat run records"),
+      nextCursor: RUNS_NEXT_CURSOR_SCHEMA,
     }),
     handler: ({ queryParams }: RouteHandlerArgs) =>
       handleListRuns(queryParams ?? {}),

--- a/assistant/src/runtime/routes/retrospective-routes.ts
+++ b/assistant/src/runtime/routes/retrospective-routes.ts
@@ -29,6 +29,13 @@ import {
   MEMORY_RETROSPECTIVE_SOURCE,
 } from "../../memory/memory-retrospective-constants.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import {
+  paginateRuns,
+  parseRunsBeforeCursor,
+  parseRunsLimit,
+  RUNS_NEXT_CURSOR_SCHEMA,
+  RUNS_PAGINATION_QUERY_PARAMS,
+} from "./runs-pagination.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 type RetrospectiveKind = "legacy" | "fork";
@@ -45,13 +52,17 @@ const SOURCE_KINDS: ReadonlyArray<{
  * Fetch the most recent retrospective conversations across BOTH source
  * sentinels (legacy + fork), newest first. Fetches `limit` rows from each
  * source before merging so the merged top-N is correct regardless of how
- * runs are distributed across kinds.
+ * runs are distributed across kinds. The same `before` cursor applies to
+ * each source query, so paging never skips rows from either kind.
  */
 function listRetrospectiveConversations(
   limit: number,
+  before?: number,
 ): Array<{ row: ConversationRow; kind: RetrospectiveKind }> {
   const merged = SOURCE_KINDS.flatMap(({ source, kind }) =>
-    listConversationsBySource(source, limit).map((row) => ({ row, kind })),
+    listConversationsBySource(source, limit, {
+      beforeCreatedAt: before,
+    }).map((row) => ({ row, kind })),
   );
   merged.sort((a, b) => b.row.createdAt - a.row.createdAt);
   return merged.slice(0, limit);
@@ -141,13 +152,7 @@ export const ROUTES: RouteDefinition[] = [
       "— typically the most recent run per source conversation unless the " +
       "operator retains history.",
     tags: ["retrospective"],
-    queryParams: [
-      {
-        name: "limit",
-        schema: { type: "integer" },
-        description: "Max runs to return (default 20, max 100)",
-      },
-    ],
+    queryParams: RUNS_PAGINATION_QUERY_PARAMS(20),
     responseBody: z.object({
       runs: z
         .array(
@@ -170,20 +175,24 @@ export const ROUTES: RouteDefinition[] = [
           }),
         )
         .describe("Retrospective run records"),
+      nextCursor: RUNS_NEXT_CURSOR_SCHEMA,
     }),
     handler: async ({ queryParams }: RouteHandlerArgs) => {
       const params = queryParams ?? {};
-      const rawLimit = Number(params.limit ?? 20);
-      const limit = Number.isFinite(rawLimit)
-        ? Math.min(Math.max(Math.floor(rawLimit), 1), 100)
-        : 20;
-      const rows = listRetrospectiveConversations(limit);
+      const limit = parseRunsLimit(params, 20);
+      const before = parseRunsBeforeCursor(params);
+      const { rows, nextCursor } = paginateRuns(
+        listRetrospectiveConversations(limit + 1, before),
+        limit,
+        (r) => r.row.createdAt,
+      );
       const assistantStats = getMessageRoleStatsByConversation(
         rows.map((r) => r.row.id),
         "assistant",
       );
       const now = Date.now();
       return {
+        nextCursor,
         runs: rows.map(({ row: c, kind }) => {
           const stat = assistantStats.get(c.id);
           // Fork-based retrospectives copy the source conversation's

--- a/assistant/src/runtime/routes/runs-pagination.ts
+++ b/assistant/src/runtime/routes/runs-pagination.ts
@@ -1,0 +1,75 @@
+/**
+ * Shared cursor-pagination helpers for run-history routes
+ * (`heartbeat/runs`, `consolidation/runs`, `schedules/:id/runs`).
+ *
+ * Pages are keyed by each route's epoch-millis sort column. Clients pass the
+ * previous page's `nextCursor` back as `before` to fetch strictly older rows;
+ * a null `nextCursor` means the history is exhausted.
+ */
+
+import { z } from "zod";
+
+import type { RouteQueryParam } from "./types.js";
+
+/** Parse the optional `before` cursor query param (epoch millis). */
+export function parseRunsBeforeCursor(
+  queryParams: Record<string, string>,
+): number | undefined {
+  const raw = Number(queryParams.before);
+  return Number.isFinite(raw) ? raw : undefined;
+}
+
+/** Parse and clamp the `limit` query param to 1..100. */
+export function parseRunsLimit(
+  queryParams: Record<string, string>,
+  defaultLimit: number,
+): number {
+  const raw = Number(queryParams.limit ?? defaultLimit);
+  return Number.isFinite(raw)
+    ? Math.min(Math.max(Math.floor(raw), 1), 100)
+    : defaultLimit;
+}
+
+/**
+ * Slice a `limit + 1`-sized fetch down to the page and derive `nextCursor`
+ * from the last returned row's sort key (null when no older rows remain).
+ */
+export function paginateRuns<T>(
+  rows: T[],
+  limit: number,
+  cursorOf: (row: T) => number,
+): { rows: T[]; nextCursor: number | null } {
+  const hasMore = rows.length > limit;
+  const page = hasMore ? rows.slice(0, limit) : rows;
+  return {
+    rows: page,
+    nextCursor: hasMore ? cursorOf(page[page.length - 1]) : null,
+  };
+}
+
+/** Shared `nextCursor` response field for the paginated run-list routes. */
+export const RUNS_NEXT_CURSOR_SCHEMA = z
+  .number()
+  .nullable()
+  .describe(
+    "Cursor for fetching older runs (pass as `before`); null when no " +
+      "older runs exist",
+  );
+
+/** OpenAPI query-param entries shared by the paginated run-list routes. */
+export const RUNS_PAGINATION_QUERY_PARAMS = (
+  defaultLimit: number,
+): RouteQueryParam[] => [
+  {
+    name: "limit",
+    schema: { type: "integer" },
+    description: `Max runs to return (default ${defaultLimit}, max 100)`,
+  },
+  {
+    name: "before",
+    schema: { type: "integer" },
+    description:
+      "Cursor for older runs: pass the previous page's `nextCursor` to " +
+      "return runs strictly older than it.",
+  },
+];

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -41,6 +41,13 @@ import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { parseEpochMillisRange } from "./epoch-millis-range.js";
 import { BadRequestError, InternalError, NotFoundError } from "./errors.js";
+import {
+  paginateRuns,
+  parseRunsBeforeCursor,
+  parseRunsLimit,
+  RUNS_NEXT_CURSOR_SCHEMA,
+  RUNS_PAGINATION_QUERY_PARAMS,
+} from "./runs-pagination.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("schedule-routes");
@@ -419,14 +426,17 @@ function handleListScheduleRuns(
   if (!schedule) {
     throw new NotFoundError("Schedule not found");
   }
-  const rawLimit = Number(queryParams.limit ?? 10);
-  const limit = Number.isFinite(rawLimit)
-    ? Math.min(Math.max(Math.floor(rawLimit), 1), 100)
-    : 10;
-  const runs = getScheduleRuns(id, limit);
+  const limit = parseRunsLimit(queryParams, 10);
+  const before = parseRunsBeforeCursor(queryParams);
+  const { rows, nextCursor } = paginateRuns(
+    getScheduleRuns(id, limit + 1, before),
+    limit,
+    (r) => r.createdAt,
+  );
   const now = Date.now();
   return {
-    runs: runs.map((r) => {
+    nextCursor,
+    runs: rows.map((r) => {
       const conversation = r.conversationId
         ? getConversation(r.conversationId)
         : null;
@@ -592,15 +602,10 @@ export const ROUTES: RouteDefinition[] = [
     summary: "List schedule runs",
     description: "Return recent invocation history for a schedule.",
     tags: ["schedules"],
-    queryParams: [
-      {
-        name: "limit",
-        schema: { type: "integer" },
-        description: "Max runs to return (default 10, max 100)",
-      },
-    ],
+    queryParams: RUNS_PAGINATION_QUERY_PARAMS(10),
     responseBody: z.object({
       runs: z.array(scheduleRunSchema).describe("Schedule run objects"),
+      nextCursor: RUNS_NEXT_CURSOR_SCHEMA,
     }),
     handler: ({ pathParams, queryParams }: RouteHandlerArgs) =>
       handleListScheduleRuns(pathParams!.id, queryParams ?? {}),

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -1,5 +1,5 @@
 import { Cron } from "croner";
-import { and, asc, desc, eq, isNull, lte, sql } from "drizzle-orm";
+import { and, asc, desc, eq, isNull, lt, lte, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb } from "../memory/db-connection.js";
@@ -718,12 +718,26 @@ export function getLastScheduleConversationId(jobId: string): string | null {
   return row?.conversationId ?? null;
 }
 
-export function getScheduleRuns(jobId: string, limit?: number): ScheduleRun[] {
+/**
+ * List runs for a schedule, newest first. When `before` is set, only runs
+ * with `createdAt` strictly older than it are returned (cursor for
+ * paginating into history).
+ */
+export function getScheduleRuns(
+  jobId: string,
+  limit?: number,
+  before?: number,
+): ScheduleRun[] {
   const db = getDb();
   const rows = db
     .select()
     .from(scheduleRuns)
-    .where(eq(scheduleRuns.jobId, jobId))
+    .where(
+      and(
+        eq(scheduleRuns.jobId, jobId),
+        before != null ? lt(scheduleRuns.createdAt, before) : undefined,
+      ),
+    )
     .orderBy(desc(scheduleRuns.createdAt))
     .limit(limit ?? 10)
     .all();


### PR DESCRIPTION
## Summary
- Add cursor pagination to the three run-history endpoints — `heartbeat/runs`, `consolidation/runs`, `schedules/:id/runs` — via a shared `runs-pagination.ts` helper: `before` query param + `nextCursor` response field (additive, backward compatible; cursor is each route's epoch-millis sort key).
- The Heartbeat, Consolidation, and user-schedule detail pages now page through history with a **Load more** button: TanStack `useInfiniteQuery`, 25 runs per page, id-deduped across page boundaries so live inserts can't duplicate rows.
- Regenerated `assistant/openapi.yaml` from the route definitions and updated the affected web + assistant tests (all green; both packages typecheck clean).

## Original prompt
While investigating gray $0.00 heartbeat rows on the Electron app's Heartbeat schedule page, the user asked to be able to load more runs and paginate through historical runs on that page and all other schedule pages, instead of being limited to the fixed recent-runs list. Implemented as cursor-based pagination on all three run-list surfaces (system tasks + user schedules) with a shared daemon helper and a shared Load more UI.