### PR TITLE
fix(macos): recover the stuck "Trying to reach Vellum…" connectivity banner

### DIFF
--- a/apps/macos/src/main/connectivity-probe.ts
+++ b/apps/macos/src/main/connectivity-probe.ts
@@ -60,8 +60,12 @@ function stopProbing(): void {
   probeTimer = null;
 }
 
-export function installConnectivityProbe(lockfilePaths: string[]): () => void {
-  const runProbe = () => void runProbeOnce(lockfilePaths);
+export function installConnectivityProbe(
+  lockfilePaths: string[],
+): () => Promise<void> {
+  // Returns the probe's promise so the manual-retry IPC handler can await
+  // completion before reporting the post-probe state back to the renderer.
+  const runProbe = () => runProbeOnce(lockfilePaths);
 
   powerMonitor.on("suspend", stopProbing);
   powerMonitor.on("resume", () => startProbing(lockfilePaths));

--- a/apps/macos/src/main/status.test.ts
+++ b/apps/macos/src/main/status.test.ts
@@ -47,6 +47,10 @@ const handleMock = mock(
 );
 mock.module("./ipc", () => ({ on: onMock, handle: handleMock }));
 
+mock.module("./logger", () => ({
+  default: { info: () => {}, warn: () => {}, error: () => {} },
+}));
+
 const {
   ASSISTANT_STATUSES,
   CONNECTIVITY_STATES,
@@ -262,8 +266,9 @@ describe("installConnectivityIpc", () => {
     expect(
       channels.filter((c) => c === "vellum:connectivity:device"),
     ).toHaveLength(1);
+    const handled = handleRegistrations.map((r) => r.channel);
     expect(
-      channels.filter((c) => c === "vellum:connectivity:retry"),
+      handled.filter((c) => c === "vellum:connectivity:retry"),
     ).toHaveLength(1);
   });
 
@@ -278,14 +283,30 @@ describe("installConnectivityIpc", () => {
     expect(getConnectivity()).toBe("online");
   });
 
-  test("retry channel calls the onRetry callback", () => {
-    const onRetry = mock(() => {});
+  test("retry runs the probe and returns the post-probe state", async () => {
+    const onRetry = mock(() => Promise.resolve());
     installConnectivityIpc(onRetry);
-    const retryReg = registrations.find(
+    const retryReg = handleRegistrations.find(
       (r) => r.channel === "vellum:connectivity:retry",
     )!;
-    retryReg.fn([]);
+    setBackendReachable(false);
+    expect(await retryReg.fn([])).toBe("backend-unreachable");
     expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  test("retry rebroadcasts the current state even when unchanged", async () => {
+    installConnectivityIpc();
+    const retryReg = handleRegistrations.find(
+      (r) => r.channel === "vellum:connectivity:retry",
+    )!;
+    // State is "online" and never transitions, so the change-gated broadcast
+    // in setConnectivity stays silent — a desynced renderer depends on this
+    // unconditional resend to recover.
+    expect(await retryReg.fn([])).toBe("online");
+    const msgs = sentMessages.filter(
+      (m) => m.channel === "vellum:connectivity:state",
+    );
+    expect(msgs.map((m) => m.payload)).toEqual(["online"]);
   });
 
   test("registers the get channel for current state queries", () => {

--- a/apps/macos/src/main/status.ts
+++ b/apps/macos/src/main/status.ts
@@ -10,6 +10,7 @@ import {
 } from "@vellumai/ipc-contract";
 
 import { handle, on } from "./ipc";
+import log from "./logger";
 
 /**
  * Assistant connection status driving the menu-bar (Tray) indicator.
@@ -178,6 +179,7 @@ const broadcastConnectivity = (): void => {
 
 export const setConnectivity = (state: ConnectivityState): void => {
   if (state === currentConnectivity) return;
+  log.info(`[connectivity] ${currentConnectivity} → ${state}`);
   currentConnectivity = state;
   broadcastConnectivity();
   for (const listener of connectivityListeners) listener(state);
@@ -214,7 +216,7 @@ export const onConnectivityChange = (
 
 let connectivityInstalled = false;
 export const installConnectivityIpc = (
-  onRetry?: () => void,
+  onRetry?: () => void | Promise<void>,
 ): void => {
   if (connectivityInstalled) return;
   connectivityInstalled = true;
@@ -229,8 +231,16 @@ export const installConnectivityIpc = (
     },
   );
 
-  on("vellum:connectivity:retry", z.tuple([]), () => {
-    onRetry?.();
+  // A manual retry must be able to recover a renderer whose banner has
+  // desynced from main: a single missed `:state` broadcast leaves main
+  // "online" and the renderer degraded, and the change-gated broadcast in
+  // `setConnectivity` would then never resend. Run the probe to completion,
+  // rebroadcast unconditionally, and return the fresh state so the renderer
+  // can apply it without depending on broadcast delivery at all.
+  handle("vellum:connectivity:retry", z.tuple([]), async () => {
+    await onRetry?.();
+    broadcastConnectivity();
+    return currentConnectivity;
   });
 };
 

--- a/apps/macos/src/preload/index.ts
+++ b/apps/macos/src/preload/index.ts
@@ -398,12 +398,17 @@ const bridge: VellumBridge = {
         ipcRenderer.off("vellum:connectivity:state", handler);
       };
     },
+    get: () =>
+      ipcRenderer.invoke(
+        "vellum:connectivity:get",
+      ) as Promise<ConnectivityState>,
     setDevice: (online: boolean): void => {
       ipcRenderer.send("vellum:connectivity:device", online);
     },
-    retry: (): void => {
-      ipcRenderer.send("vellum:connectivity:retry");
-    },
+    retry: () =>
+      ipcRenderer.invoke(
+        "vellum:connectivity:retry",
+      ) as Promise<ConnectivityState>,
   },
   notifications: {
     show: (

--- a/apps/web/src/components/status-banner.test.tsx
+++ b/apps/web/src/components/status-banner.test.tsx
@@ -34,15 +34,14 @@ mock.module("@/hooks/use-network-status", () => ({
 }));
 
 mock.module("@/hooks/use-connectivity-state", () => ({
-  useConnectivityState: () => connectivityStateMock,
+  useConnectivityState: () => ({
+    connectivityState: connectivityStateMock,
+    retryConnectivity: () => {},
+  }),
 }));
 
 mock.module("@/runtime/is-electron", () => ({
   isElectron: () => isElectronMock,
-}));
-
-mock.module("@/runtime/connectivity", () => ({
-  retryConnectivity: () => {},
 }));
 
 mock.module("react-router", () => ({

--- a/apps/web/src/components/status-banner.tsx
+++ b/apps/web/src/components/status-banner.tsx
@@ -19,7 +19,6 @@ import { assistantsMaintenanceModeExitCreate } from "@/generated/api/sdk.gen";
 import { useConnectivityState } from "@/hooks/use-connectivity-state";
 import { useNetworkStatus } from "@/hooks/use-network-status";
 import { captureError } from "@/lib/sentry/capture-error";
-import { retryConnectivity } from "@/runtime/connectivity";
 import { isElectron } from "@/runtime/is-electron";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
@@ -126,7 +125,7 @@ function BannerNotice({
 function useAssistantBannerConfig(): BannerConfig | null {
   const electron = isElectron();
   const isNative = useIsNativePlatform();
-  const connectivityState = useConnectivityState();
+  const { connectivityState, retryConnectivity } = useConnectivityState();
   const nativeConnected = useNetworkStatus();
   const activeAssistantId = useResolvedAssistantsStore.use.activeAssistantId();
   const assistantState = useAssistantLifecycleStore.use.assistantState();

--- a/apps/web/src/hooks/use-connectivity-state.ts
+++ b/apps/web/src/hooks/use-connectivity-state.ts
@@ -1,6 +1,9 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
+import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import {
+  getConnectivityState,
+  retryConnectivity,
   subscribeToConnectivity,
   type ConnectivityState,
 } from "@/runtime/connectivity";
@@ -9,16 +12,56 @@ export type { ConnectivityState };
 
 const RECOVERY_DEBOUNCE_MS = 2_000;
 
+export interface ConnectivityStateHandle {
+  connectivityState: ConnectivityState;
+  /** Probe the host immediately and apply the post-probe state. */
+  retryConnectivity: () => void;
+}
+
 /**
  * React hook that tracks the Electron host's connectivity state.
  *
  * Returns `"online"` off Electron. Degraded states appear immediately;
- * recovery to `"online"` is debounced by 2 seconds so the banner
- * doesn't flicker on flaky networks.
+ * recovery to `"online"` via broadcast is debounced by 2 seconds so the
+ * banner doesn't flicker on flaky networks.
+ *
+ * Broadcasts alone can't be trusted to converge: main only broadcasts on
+ * state *change*, so a single missed message (window hidden, IPC race at
+ * startup) would otherwise leave the banner stuck with no path back. Two
+ * pull-based syncs recover from that, applying immediately (no debounce —
+ * a pulled snapshot is current truth, not a possibly-flapping transition):
+ *
+ *   1. Re-fetch on `app.resume` (visibility/online) and on window focus —
+ *      focus is not bus-owned and a desynced window can regain focus
+ *      without a visibility change.
+ *   2. `retryConnectivity` applies the state returned by the host's probe,
+ *      so the banner's "Retry now" works even if broadcasts never arrive.
  */
-export function useConnectivityState(): ConnectivityState {
+export function useConnectivityState(): ConnectivityStateHandle {
   const [state, setState] = useState<ConnectivityState>("online");
   const recoveryTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearRecoveryTimer = useCallback(() => {
+    if (recoveryTimer.current) {
+      clearTimeout(recoveryTimer.current);
+      recoveryTimer.current = null;
+    }
+  }, []);
+
+  const applySnapshot = useCallback(
+    (next: ConnectivityState | null) => {
+      if (!next) return;
+      clearRecoveryTimer();
+      setState(next);
+    },
+    [clearRecoveryTimer],
+  );
+
+  const resync = useCallback(() => {
+    void getConnectivityState().then(applySnapshot);
+  }, [applySnapshot]);
+
+  useBusSubscription("app.resume", resync);
 
   useEffect(() => {
     const unsub = subscribeToConnectivity((next) => {
@@ -29,22 +72,23 @@ export function useConnectivityState(): ConnectivityState {
           setState("online");
         }, RECOVERY_DEBOUNCE_MS);
       } else {
-        if (recoveryTimer.current) {
-          clearTimeout(recoveryTimer.current);
-          recoveryTimer.current = null;
-        }
+        clearRecoveryTimer();
         setState(next);
       }
     });
 
+    window.addEventListener("focus", resync);
+
     return () => {
       unsub();
-      if (recoveryTimer.current) {
-        clearTimeout(recoveryTimer.current);
-        recoveryTimer.current = null;
-      }
+      window.removeEventListener("focus", resync);
+      clearRecoveryTimer();
     };
-  }, []);
+  }, [resync, clearRecoveryTimer]);
 
-  return state;
+  const retry = useCallback(() => {
+    void retryConnectivity().then(applySnapshot);
+  }, [applySnapshot]);
+
+  return { connectivityState: state, retryConnectivity: retry };
 }

--- a/apps/web/src/runtime/connectivity.ts
+++ b/apps/web/src/runtime/connectivity.ts
@@ -22,11 +22,33 @@ export function reportDeviceOnline(online: boolean): void {
   window.vellum?.connectivity?.setDevice(online);
 }
 
+/** Resolves null off Electron, when the bridge is unavailable, or when the
+ * invocation fails — callers treat null as "no fresh state, change nothing". */
+async function pullConnectivityState(
+  invoke: () => Promise<ConnectivityState> | undefined,
+): Promise<ConnectivityState | null> {
+  if (!isElectron()) return null;
+  try {
+    return (await invoke()) ?? null;
+  } catch {
+    return null;
+  }
+}
+
 /**
- * Trigger an immediate connectivity retry from the Electron host.
- * No-op off Electron.
+ * Pull the Electron host's current connectivity state. Lets the renderer
+ * re-sync after a missed `onState` broadcast (e.g. when the window regains
+ * focus).
  */
-export function retryConnectivity(): void {
-  if (!isElectron()) return;
-  window.vellum?.connectivity?.retry();
+export function getConnectivityState(): Promise<ConnectivityState | null> {
+  return pullConnectivityState(() => window.vellum?.connectivity?.get());
+}
+
+/**
+ * Trigger an immediate connectivity probe on the Electron host and resolve
+ * with the post-probe state, so a manual retry can correct a renderer whose
+ * banner state desynced from main.
+ */
+export function retryConnectivity(): Promise<ConnectivityState | null> {
+  return pullConnectivityState(() => window.vellum?.connectivity?.retry());
 }

--- a/apps/web/src/runtime/is-electron.ts
+++ b/apps/web/src/runtime/is-electron.ts
@@ -232,8 +232,9 @@ declare global {
         onState(
           callback: (state: ConnectivityState) => void,
         ): () => void;
+        get(): Promise<ConnectivityState>;
         setDevice(online: boolean): void;
-        retry(): void;
+        retry(): Promise<ConnectivityState>;
       };
       quickInput?: {
         submit(message: string): Promise<void>;

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -193,8 +193,13 @@ export interface VellumBridge {
   };
   connectivity: {
     onState(callback: (state: ConnectivityState) => void): () => void;
+    /** Pull the current state — lets the renderer re-sync after a missed
+     * `onState` broadcast (e.g. on window focus). */
+    get(): Promise<ConnectivityState>;
     setDevice(online: boolean): void;
-    retry(): void;
+    /** Probe immediately and resolve with the post-probe state, so a manual
+     * retry recovers even when the broadcast channel failed. */
+    retry(): Promise<ConnectivityState>;
   };
   notifications: {
     show(


### PR DESCRIPTION
## Summary
- The Electron renderer's connectivity banner could desync permanently: main broadcasts state only on change over a lossy `webContents.send`, so one missed `online` broadcast left the banner stuck — and "Retry now" was a silent no-op (the probe succeeded, the state didn't change, nothing was resent).
- `vellum:connectivity:retry` is now an invoke that awaits the probe, rebroadcasts unconditionally, and returns the post-probe state; the renderer applies the returned state directly, so manual retry recovers even if broadcasts never arrive.
- The renderer also re-syncs through a new `connectivity.get()` bridge method on `app.resume` (canonical bus signal for visibility/online) and on window focus, and main now logs connectivity transitions for future diagnosis.

## Original prompt
After an incident where the desktop app showed "Trying to reach Vellum…" indefinitely while the daemon and gateway were healthy (the gateway restarted shortly after app launch; the renderer held a stale backend-unreachable state and the Retry button could not recover it), make the connectivity banner self-healing: deterministic retry that returns fresh state, unconditional rebroadcast after a manual retry, renderer re-sync on focus/visibility, and connectivity transition logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)