### PR TITLE
fix(design-library): render markdown paragraph breaks as a full blank line

### DIFF
--- a/packages/design-library/src/components/markdown-message.tsx
+++ b/packages/design-library/src/components/markdown-message.tsx
@@ -167,7 +167,10 @@ function buildMarkdownComponents(
   LinkComponent: MarkdownLinkComponent,
 ): Components {
   return {
-    p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
+    // mb-6 (24px) equals one --text-chat-line-height, so a `\n\n` paragraph
+    // break reads as a full blank line — distinct from the 24px hard break a
+    // single `\n` produces. Smaller margins make the two nearly identical.
+    p: ({ children }) => <p className="mb-6 last:mb-0">{children}</p>,
     // Markdown headings keep the canonical scale sizes but restore bold weight
     // via `!font-bold` (the scale variants bake font-weight:500 into the utility,
     // so a plain `font-bold` loses to the custom rule; `!important` wins).


### PR DESCRIPTION
## Summary
- Bump the markdown `<p>` bottom margin in `MarkdownMessage` from `mb-2` (8px) to `mb-6` (24px = one `--text-chat-line-height`), so a `\n\n` paragraph break renders as a full blank line (48px baseline-to-baseline) instead of 32px
- With `hardLineBreaks`, a single `\n` renders at 24px — the old 8px margin made paragraph breaks only 1.33× a plain line break, so double newlines read as squished; 2.0× matches the legacy macOS app, which preserves blank lines literally via `.inlineOnlyPreservingWhitespace`

## Original prompt
User noticed that double-newline paragraph breaks in the new web chat transcript looked squished compared to the legacy macOS app and asked for confirmation. Investigation traced it to the design-library `MarkdownMessage` paragraph margin (`mb-2`): a paragraph break was only 8px taller than a single-newline hard break. The user chose `mb-6` to exactly match the legacy app's full-blank-line spacing.