### PR TITLE
fix(cli): fix test-suite hang from self-recursive os.homedir mock

### DIFF
--- a/.github/workflows/ci-main-cli.yaml
+++ b/.github/workflows/ci-main-cli.yaml
@@ -16,6 +16,9 @@ jobs:
   checks:
     name: Lint, Type Check & Test
     runs-on: ubuntu-latest
+    # The suite normally finishes in ~1 minute; without a cap, a hung
+    # `bun test` occupies a runner for GitHub's 6-hour default.
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: cli

--- a/.github/workflows/pr-cli.yaml
+++ b/.github/workflows/pr-cli.yaml
@@ -19,6 +19,9 @@ jobs:
   checks:
     name: Lint, Type Check & Test
     runs-on: ubuntu-latest
+    # The suite normally finishes in ~1 minute; without a cap, a hung
+    # `bun test` occupies a runner for GitHub's 6-hour default.
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: cli

--- a/cli/src/__tests__/device-id.test.ts
+++ b/cli/src/__tests__/device-id.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   existsSync,
   mkdirSync,
@@ -11,22 +11,17 @@ import {
 import { tmpdir } from "os";
 import { join } from "path";
 
-// Bun's os.homedir() ignores runtime HOME changes, so mock it (same pattern
-// as multi-local.test.ts) to keep production-path tests off the real ~/.vellum.
+// Bun's os.homedir() ignores runtime HOME changes, so mock it (via the shared
+// helper) to keep production-path tests off the real ~/.vellum.
 let fakeHome: string | undefined;
-const realOs = await import("node:os");
-const osMock = () => ({
-  ...realOs,
-  homedir: () => fakeHome ?? realOs.homedir(),
-});
-mock.module("node:os", osMock);
-mock.module("os", osMock);
+await mockOsHomedir((realHomedir) => () => fakeHome ?? realHomedir());
 
 import {
   getOrCreateHostDeviceId,
   resetHostDeviceIdCache,
 } from "../lib/device-id.js";
 import { snapshotEnv } from "./helpers/env.js";
+import { mockOsHomedir } from "./helpers/os-mock.js";
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
@@ -154,10 +149,7 @@ describe("getOrCreateHostDeviceId (production)", () => {
 
   test("reuses an existing ~/.vellum/device.json", () => {
     mkdirSync(join(tempHome, ".vellum"), { recursive: true });
-    writeFileSync(
-      deviceFile,
-      JSON.stringify({ deviceId: "shared-prod-id" }),
-    );
+    writeFileSync(deviceFile, JSON.stringify({ deviceId: "shared-prod-id" }));
 
     expect(getOrCreateHostDeviceId()).toBe("shared-prod-id");
     expect(readFileSync(deviceFile, "utf-8")).toBe(

--- a/cli/src/__tests__/helpers/os-mock.ts
+++ b/cli/src/__tests__/helpers/os-mock.ts
@@ -1,0 +1,27 @@
+import { mock } from "bun:test";
+
+/**
+ * Mock `os.homedir()` (both the `"os"` and `"node:os"` specifiers) while
+ * keeping every other os export intact.
+ *
+ * The factory passed to `mock.module()` must only close over plain snapshots
+ * captured before the mock is installed. When another test file has already
+ * loaded "os", `mock.module()` patches the live namespace in place — a
+ * factory that spreads or calls back through that namespace resolves to the
+ * mock itself and recurses forever, a synchronous spin that froze the whole
+ * suite (and CI) at whichever file loaded next. This helper owns that
+ * invariant so test files don't have to.
+ *
+ * @param makeHomedir Receives the real (pre-mock) `homedir` and returns the
+ *   replacement implementation.
+ */
+export async function mockOsHomedir(
+  makeHomedir: (realHomedir: () => string) => () => string,
+): Promise<void> {
+  const realOs = await import("node:os");
+  const realOsSnapshot = { ...realOs };
+  const homedir = makeHomedir(realOs.homedir);
+  const factory = () => ({ ...realOsSnapshot, homedir });
+  mock.module("node:os", factory);
+  mock.module("os", factory);
+}

--- a/cli/src/__tests__/multi-local.test.ts
+++ b/cli/src/__tests__/multi-local.test.ts
@@ -10,16 +10,7 @@ process.env.VELLUM_LOCKFILE_DIR = testDir;
 
 // Mock homedir() to return testDir — this isolates allocateLocalResources()
 // which uses homedir() directly for instance directory creation.
-const realOs = await import("node:os");
-mock.module("node:os", () => ({
-  ...realOs,
-  homedir: () => testDir,
-}));
-// Also mock the bare "os" specifier since assistant-config.ts uses `from "os"`
-mock.module("os", () => ({
-  ...realOs,
-  homedir: () => testDir,
-}));
+await mockOsHomedir(() => () => testDir);
 
 // Mock probePort so we control which ports appear in-use without touching the network
 const probePortMock = mock<(port: number, host?: string) => Promise<boolean>>(
@@ -43,6 +34,7 @@ import {
   DEFAULT_GATEWAY_PORT,
   DEFAULT_QDRANT_PORT,
 } from "../lib/constants.js";
+import { mockOsHomedir } from "./helpers/os-mock.js";
 
 afterAll(() => {
   rmSync(testDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Fixes the CLI test suite hanging in CI since #34360 (every `CI Main CLI Checks` run sat at *Test with coverage* until GitHub's 6-hour kill). Root cause: `device-id.test.ts` mocked `os`/`node:os` with a factory whose `homedir` closure called back through the captured module namespace — bun's `mock.module()` patches that live namespace in place, so once another test file had already loaded `os`, the closure resolved to itself and recursed forever. The resulting synchronous spin blocked the event loop (per-test timeouts can't fire), freezing the suite at whichever file loaded next — which is why the hang point differed between runs.
- Adds a shared `mockOsHomedir()` test helper that owns the snapshot-before-mock invariant, and migrates both `device-id.test.ts` and `multi-local.test.ts` (the source of the copied pattern) onto it.
- Caps the `checks` job in `ci-main-cli.yaml` and `pr-cli.yaml` at `timeout-minutes: 15` so any future hang fails in minutes instead of occupying a runner for 6 hours.

## Verification
- Bisected the suite to a minimal 2-file repro (`device-id.test.ts` + `use.test.ts`) that hung 3/3 before the fix and passes 3/3 after.
- Full suite under CI-like conditions (fresh $HOME, gateway port free): hung 3/3 before; now **715 pass / 0 fail in ~10s**, 3/3 runs.
- The first hanging commit (ccc89d341e, #34360) reproduces locally; its parent runs clean — matching the CI history exactly.

## Original prompt
> Fix the issue with this test suite hanging: https://github.com/vellum-ai/vellum-assistant/actions/runs/27434092317/job/81091509293

The linked run is one of six `CI Main CLI Checks` runs on `main` stuck in progress at the *Test with coverage* step; the older ones were killed at GitHub's 6-hour limit. All trace back to the commit above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)