### PR TITLE
fix(web): exclude design library from Vite dep pre-bundling

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -112,6 +112,14 @@ export default defineConfig(({ mode }) => {
       dedupe: ["react", "react-dom"],
       preserveSymlinks: true,
     },
+    optimizeDeps: {
+      // The design library is a file: dependency, so the dep-optimizer cache
+      // (node_modules/.vite/deps) never invalidates on its source changes —
+      // the cache keys on lockfile/version only, and file: bumps neither.
+      // Excluding it serves the source directly, so pulled changes apply on
+      // reload and the watch-design-library plugin's HMR hits live modules.
+      exclude: ["@vellumai/design-library"],
+    },
     server: {
       port: parseInt(env.PORT || "3000"),
       strictPort: true,


### PR DESCRIPTION
## Summary
- Add `optimizeDeps.exclude: ["@vellumai/design-library"]` to `apps/web/vite.config.ts` so the dev server serves the design library's TypeScript source directly instead of a pre-bundled chunk
- Vite's dep-optimizer cache (`node_modules/.vite/deps`) keys on lockfile hash and package version — neither changes when a `file:` dependency's source changes, so pulled design-library changes were served stale until the cache was manually deleted
- Dev-server-only change: `optimizeDeps` has no effect on production builds

## Original prompt
A design-library styling fix (#34769) merged and the web app was rebuilt, but the running dev server kept showing the old styles: the stale pre-bundled design-library chunk from `node_modules/.vite/deps` was still being served because the cache never invalidates on `file:` dependency source changes. After confirming the root cause by clearing the cache by hand, the user asked to ship the durable fix: exclude `@vellumai/design-library` from dep pre-bundling so design-library changes (pulled or edited locally) are always served fresh.