### PR TITLE
revert(web): restore Vite dep pre-bundling for the design library

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -112,14 +112,6 @@ export default defineConfig(({ mode }) => {
       dedupe: ["react", "react-dom"],
       preserveSymlinks: true,
     },
-    optimizeDeps: {
-      // The design library is a file: dependency, so the dep-optimizer cache
-      // (node_modules/.vite/deps) never invalidates on its source changes —
-      // the cache keys on lockfile/version only, and file: bumps neither.
-      // Excluding it serves the source directly, so pulled changes apply on
-      // reload and the watch-design-library plugin's HMR hits live modules.
-      exclude: ["@vellumai/design-library"],
-    },
     server: {
       port: parseInt(env.PORT || "3000"),
       strictPort: true,


### PR DESCRIPTION
## Summary
- Revert #34771 (`optimizeDeps.exclude` for `@vellumai/design-library`): with pre-bundling off, the package's imports resolve into its nested `node_modules` (bun's `file:` install copies the package's full dev install) and are served raw — CJS files like `katex` then crash the renderer at boot (blank white window)
- The stale-prebundle problem #34771 tried to solve is real but needs a different fix (e.g. preventing the nested dev `node_modules` copy, or a workspace-link setup); until then the workaround after pulling design-library changes is `rm -rf apps/web/node_modules/.vite` or `vite --force`

## Original prompt
After shipping #34771, launching the dev stack produced a blank white Electron window. Tracing the served module graph showed design-library imports being rewritten to raw files under `node_modules/@vellumai/design-library/node_modules/` (rehype-katex, remark-math, unified, katex, …), including CJS that cannot run as browser ES modules. The user reported the breakage; this reverts to the known-good pre-bundling behavior.