### PR TITLE
feat(macos): open the main window in fullscreen by default

### DIFF
--- a/apps/macos/src/main/main-window.test.ts
+++ b/apps/macos/src/main/main-window.test.ts
@@ -26,6 +26,8 @@ type StubWindow = {
   setMinimumSize: ReturnType<typeof mock>;
   setBounds: ReturnType<typeof mock>;
   setPosition: ReturnType<typeof mock>;
+  setFullScreen: ReturnType<typeof mock>;
+  isFullScreen: () => boolean;
   center: ReturnType<typeof mock>;
   setWindowButtonPosition: ReturnType<typeof mock>;
   webContents: StubWebContents;
@@ -40,6 +42,7 @@ type WindowState = {
   visible: boolean;
   focused: boolean;
   resizable: boolean;
+  fullscreen: boolean;
 };
 
 let constructed: Array<{
@@ -66,6 +69,9 @@ const makeWindow = (opts: Record<string, unknown> = {}): StubWindow => {
     // Mirrors the BrowserWindow default (resizable) unless the
     // constructor opts opt out, as the onboarding branch does.
     resizable: opts.resizable !== false,
+    // Mirrors the BrowserWindow default (windowed) unless the constructor
+    // opts in, as the fresh-install fullscreen default does.
+    fullscreen: opts.fullscreen === true,
   };
   listeners = new Map();
   const stub: StubWindow = {
@@ -79,6 +85,10 @@ const makeWindow = (opts: Record<string, unknown> = {}): StubWindow => {
     setMinimumSize: mock(() => undefined),
     setBounds: mock(() => undefined),
     setPosition: mock(() => undefined),
+    setFullScreen: mock((value: boolean) => {
+      state.fullscreen = value;
+    }),
+    isFullScreen: () => state.fullscreen,
     center: mock(() => undefined),
     setWindowButtonPosition: mock(() => undefined),
     show: mock(() => {
@@ -156,8 +166,15 @@ mock.module("electron", () => ({
   shell: { openExternal: () => Promise.resolve() },
 }));
 
+// What the mocked `restoreBounds()` returns. Defaults to a saved windowed
+// state; tests exercising the fresh-install fullscreen default override it.
+let restoredBounds: { width: number; height: number; fullscreen?: boolean } = {
+  width: 1280,
+  height: 800,
+};
+
 mock.module("./window-state", () => ({
-  restoreBounds: () => ({ width: 1280, height: 800 }),
+  restoreBounds: () => restoredBounds,
   track: () => undefined,
   readOnboardingActive: () => onboardingActive,
   writeOnboardingActive: writeOnboardingActiveMock,
@@ -191,6 +208,7 @@ beforeEach(() => {
   ipcHandleMock.mockClear();
   onboardingActive = false;
   writeOnboardingActiveMock.mockClear();
+  restoredBounds = { width: 1280, height: 800 };
 });
 
 afterEach(() => {
@@ -479,6 +497,9 @@ describe("onboarding window sizing", () => {
     expect(win.opts.minHeight).toBe(600);
     expect(win.opts.resizable).toBeUndefined();
     expect(win.stub.isResizable()).toBe(true);
+    // A saved windowed state stays windowed — the fullscreen default only
+    // applies while nothing has been persisted.
+    expect(win.opts.fullscreen).toBeUndefined();
   });
 
   test("setOnboarding(true) shrinks an existing main window to the default", () => {
@@ -604,6 +625,86 @@ describe("onboarding window sizing", () => {
     setOnboarding(false);
 
     expect(win.stub.setWindowButtonPosition).not.toHaveBeenCalled();
+  });
+});
+
+describe("fullscreen default", () => {
+  test("constructs the main window fullscreen when the restored state says so (fresh-install default)", () => {
+    restoredBounds = { width: 1280, height: 800, fullscreen: true };
+    ensureVisible();
+    const win = constructed[0];
+    if (!win) throw new Error("expected a window");
+    expect(win.opts.fullscreen).toBe(true);
+  });
+
+  test("never constructs the compact onboarding window fullscreen", () => {
+    restoredBounds = { width: 1280, height: 800, fullscreen: true };
+    onboardingActive = true;
+    ensureVisible();
+    const win = constructed[0];
+    if (!win) throw new Error("expected a window");
+    expect(win.opts.fullscreen).toBeUndefined();
+  });
+
+  test("setOnboarding(true) on a fullscreen window leaves fullscreen and defers the shrink", () => {
+    restoredBounds = { width: 1280, height: 800, fullscreen: true };
+    ensureVisible();
+    const win = constructed[0];
+    if (!win) throw new Error("expected a window");
+    expect(win.stub.isFullScreen()).toBe(true);
+
+    setOnboarding(true);
+
+    expect(win.stub.setFullScreen).toHaveBeenCalledWith(false);
+    // Geometry changes are ignored mid-transition, so nothing is applied
+    // until `leave-full-screen` lands.
+    expect(win.stub.setContentSize).not.toHaveBeenCalled();
+    expect(win.stub.setMinimumSize).not.toHaveBeenCalled();
+
+    win.stub.emit("leave-full-screen");
+    expect(win.stub.setMinimumSize).toHaveBeenCalledWith(440, 660);
+    expect(win.stub.setContentSize).toHaveBeenCalledWith(440, 660);
+    expect(win.stub.center).toHaveBeenCalled();
+  });
+
+  test("drops the deferred shrink when the mode flips back to main before leave-full-screen lands", () => {
+    restoredBounds = { width: 1280, height: 800, fullscreen: true };
+    ensureVisible();
+    const win = constructed[0];
+    if (!win) throw new Error("expected a window");
+
+    setOnboarding(true);
+    setOnboarding(false);
+    win.stub.setContentSize.mockClear();
+
+    win.stub.emit("leave-full-screen");
+    expect(win.stub.setContentSize).not.toHaveBeenCalled();
+  });
+
+  test("setOnboarding(false) re-enters fullscreen when the restored state calls for it", () => {
+    onboardingActive = true;
+    ensureVisible();
+    const win = constructed[0];
+    if (!win) throw new Error("expected a window");
+    restoredBounds = { width: 1280, height: 800, fullscreen: true };
+
+    setOnboarding(false);
+
+    // Windowed geometry is applied first — it's the rectangle the user
+    // lands on when exiting fullscreen.
+    expect(win.stub.setBounds).toHaveBeenCalledWith({ width: 1280, height: 800 });
+    expect(win.stub.setFullScreen).toHaveBeenCalledWith(true);
+  });
+
+  test("setOnboarding(false) stays windowed when the restored state is windowed", () => {
+    onboardingActive = true;
+    ensureVisible();
+    const win = constructed[0];
+    if (!win) throw new Error("expected a window");
+
+    setOnboarding(false);
+
+    expect(win.stub.setFullScreen).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/macos/src/main/main-window.ts
+++ b/apps/macos/src/main/main-window.ts
@@ -25,8 +25,15 @@ import {
 // below its content.
 const ONBOARDING_CONTENT_SIZE = { width: 440, height: 660 } as const;
 
-// Default bounds for the main window once onboarding is done.
-const MAIN_DEFAULT_BOUNDS = { width: 1280, height: 800 } as const;
+// Default state for the main window once onboarding is done: native macOS
+// fullscreen. The 1280×800 rectangle is the windowed size the user lands on
+// when they exit fullscreen. Applies only until a real session is persisted —
+// after that, `window-state` restores whatever mode the user left.
+const MAIN_DEFAULT_BOUNDS = {
+  width: 1280,
+  height: 800,
+  fullscreen: true,
+} as const;
 
 // Minimum size for the main-app window, mirroring the macOS Swift client's
 // main window (`MainWindow.swift`: `contentMinSize` 800×600). The window can't
@@ -61,6 +68,22 @@ const applyTrafficLightPosition = (
   win.setWindowButtonPosition(
     compact ? null : { ...MAIN_TRAFFIC_LIGHT_POSITION },
   );
+};
+
+// Shrink the window to the compact onboarding layout. Lower the floor before
+// shrinking: `setContentSize` clamps to the current minimum, so the 800×600
+// main floor must drop to 440×660 first or the window wouldn't actually
+// shrink.
+const applyOnboardingContentSize = (win: BrowserWindow): void => {
+  win.setMinimumSize(
+    ONBOARDING_CONTENT_SIZE.width,
+    ONBOARDING_CONTENT_SIZE.height,
+  );
+  win.setContentSize(
+    ONBOARDING_CONTENT_SIZE.width,
+    ONBOARDING_CONTENT_SIZE.height,
+  );
+  win.center();
 };
 
 /**
@@ -177,10 +200,14 @@ const createMainWindow = (): BrowserWindow => {
   const loadTarget = getRendererRootUrl(app.isPackaged);
 
   // Onboarding opens at the 440×660 default; otherwise restore the user's
-  // saved main-app bounds. Both layouts are resizable larger, but each
-  // carries its own minimum (`minWidth`/`minHeight`): the compact onboarding
-  // flow can't be dragged below its 440×660 content, and the main app can't
-  // be dragged below 800×600 (mirroring the Swift client's `contentMinSize`).
+  // saved main-app state — which defaults to fullscreen when nothing has
+  // been persisted yet (`MAIN_DEFAULT_BOUNDS`). The `fullscreen` flag rides
+  // the spread into the `BrowserWindow` constructor, the same path a saved
+  // fullscreen session restores through. Both layouts are resizable larger,
+  // but each carries its own minimum (`minWidth`/`minHeight`): the compact
+  // onboarding flow can't be dragged below its 440×660 content, and the main
+  // app can't be dragged below 800×600 (mirroring the Swift client's
+  // `contentMinSize`).
   // The persisted flag lets a relaunch *during* onboarding rebuild the small
   // window directly (no flash); the absent-flag default is `false` (open large) so we
   // never cramp the `/account/*` screens that render outside RootLayout —
@@ -368,6 +395,12 @@ export const dispatchToMain = (command: VellumCommand): void => {
  * the entry shrink is skipped, the exit restore is captured under "main".
  * Re-asserting the current mode (the renderer fires this on every
  * navigation) is a cheap no-op past the early return.
+ *
+ * Native fullscreen is handled on both transitions: entering onboarding
+ * leaves fullscreen first (the fresh-install default opens fullscreen at the
+ * pre-onboarding `/account/*` screens), and leaving onboarding re-enters it
+ * when the restored state — including that same fresh-install default —
+ * calls for it.
  */
 export const setOnboarding = (active: boolean): void => {
   const wasActive = readOnboardingActive();
@@ -382,18 +415,19 @@ export const setOnboarding = (active: boolean): void => {
   applyTrafficLightPosition(win, active);
 
   if (active) {
-    // Lower the floor before shrinking: `setContentSize` clamps to the current
-    // minimum, so the 800×600 main floor must drop to 440×660 first or the
-    // window wouldn't actually shrink.
-    win.setMinimumSize(
-      ONBOARDING_CONTENT_SIZE.width,
-      ONBOARDING_CONTENT_SIZE.height,
-    );
-    win.setContentSize(
-      ONBOARDING_CONTENT_SIZE.width,
-      ONBOARDING_CONTENT_SIZE.height,
-    );
-    win.center();
+    if (win.isFullScreen()) {
+      // macOS ignores geometry changes while in (or animating out of)
+      // fullscreen, so leave fullscreen first and defer the shrink until
+      // the transition lands. The mode re-check guards the rare flip back
+      // to main before `leave-full-screen` fires.
+      win.once("leave-full-screen", () => {
+        if (win.isDestroyed() || !readOnboardingActive()) return;
+        applyOnboardingContentSize(win);
+      });
+      win.setFullScreen(false);
+    } else {
+      applyOnboardingContentSize(win);
+    }
   } else {
     // Swap the onboarding floor for the roomier 800×600 main-app floor.
     win.setMinimumSize(MAIN_MIN_SIZE.width, MAIN_MIN_SIZE.height);
@@ -403,6 +437,13 @@ export const setOnboarding = (active: boolean): void => {
       win.setPosition(bounds.x, bounds.y);
     } else {
       win.center();
+    }
+    if (bounds.fullscreen) {
+      // Enter fullscreen only after the windowed geometry above is applied —
+      // it becomes the rectangle the user lands on when exiting fullscreen.
+      // Entering (never forcing an exit) keeps a mid-onboarding green-button
+      // press intact when the saved state happens to be windowed.
+      win.setFullScreen(true);
     }
   }
 };

--- a/apps/macos/src/main/window-state.test.ts
+++ b/apps/macos/src/main/window-state.test.ts
@@ -163,6 +163,27 @@ describe("restoreBounds", () => {
     expect(restoreBounds("main", DEFAULTS).fullscreen).toBe(true);
   });
 
+  test("passes a fullscreen default through when nothing is persisted", () => {
+    expect(restoreBounds("main", { ...DEFAULTS, fullscreen: true })).toEqual({
+      width: 800,
+      height: 600,
+      fullscreen: true,
+    });
+  });
+
+  test("a saved windowed state overrides a fullscreen default", () => {
+    savedWindows.main = {
+      x: 0,
+      y: 0,
+      width: 800,
+      height: 600,
+      isFullScreen: false,
+    };
+    expect(
+      restoreBounds("main", { ...DEFAULTS, fullscreen: true }).fullscreen,
+    ).toBe(false);
+  });
+
   test("namespaces by key so windows don't clobber each other", () => {
     savedWindows.main = {
       x: 10,

--- a/apps/macos/src/main/window-state.ts
+++ b/apps/macos/src/main/window-state.ts
@@ -70,6 +70,11 @@ export const writeOnboardingActive = (active: boolean): void => {
 interface Defaults {
   width: number;
   height: number;
+  // Open in native fullscreen when no state has been persisted yet. The
+  // width/height still matter: they're the windowed rectangle the user
+  // lands on when they exit fullscreen. A saved state's own `isFullScreen`
+  // always wins once one exists.
+  fullscreen?: boolean;
 }
 
 export interface RestoredWindowState {


### PR DESCRIPTION
## Summary
- The Electron app's main window now opens in native macOS fullscreen by default — i.e. when no window state has been persisted yet. The `MAIN_DEFAULT_BOUNDS` rectangle (1280×800) remains the windowed size the user lands on when exiting fullscreen, and a saved session still restores exactly the mode the user left.
- Onboarding transitions handle fullscreen on both edges: entering onboarding exits fullscreen first and defers the 440×660 shrink until `leave-full-screen` lands (macOS ignores geometry changes mid-transition); leaving onboarding re-enters fullscreen when the restored state (including the fresh-install default) calls for it.
- Covered with unit tests: constructor receives the fullscreen flag, the compact onboarding window is never constructed fullscreen, deferred shrink fires (and is dropped on a mode flip-back), and `restoreBounds` passes a fullscreen default through while saved windowed state overrides it.

## Original prompt
The macOS Electron app should open full screen by default.