### PR TITLE
feat(web): add Send with Cmd+Enter composer setting

### DIFF
--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -61,6 +61,7 @@ import { useActiveProfileModel } from "@/domains/chat/hooks/use-active-profile-m
 import { useSubagentStore } from "@/domains/chat/subagent-store";
 import { isChannelConversation } from "@/domains/chat/utils/conversation-channel";
 import { useViewerStore } from "@/stores/viewer-store";
+import { cmdEnterToSend } from "@/utils/composer-settings";
 import { haptic } from "@/utils/haptics";
 import { routes } from "@/utils/routes";
 import { lifecycleService } from "@/assistant/lifecycle-service";
@@ -739,9 +740,12 @@ export function ChatMainPanel({
     onMaintenanceExited: handleMaintenanceExited,
   };
 
+  const cmdEnterMode = cmdEnterToSend.useValue();
+
   const chatBodyComposerProps = {
     input,
     setInput,
+    cmdEnterMode,
     placeholder: isEmptyConversation
       ? emptyStatePlaceholder
       : "What would you like to do?",

--- a/apps/web/src/domains/settings/components/composer-send-card.tsx
+++ b/apps/web/src/domains/settings/components/composer-send-card.tsx
@@ -1,0 +1,31 @@
+import { DetailCard } from "@/components/detail-card";
+import { isMacOSBrowser } from "@/runtime/platform-detection";
+import { cmdEnterToSend } from "@/utils/composer-settings";
+import { isPointerCoarse } from "@/utils/pointer";
+import { Toggle } from "@vellumai/design-library/components/toggle";
+
+/**
+ * General-settings card for the composer's Enter-key behavior, at parity
+ * with the macOS app's "Send with Cmd+Enter" toggle.
+ */
+export function ComposerSendCard() {
+  const enabled = cmdEnterToSend.useValue();
+
+  // On touch devices the composer never submits on Enter (it always inserts
+  // a newline; sending happens via the send button), so the toggle would be
+  // a no-op control.
+  if (isPointerCoarse()) return null;
+
+  const modifier = isMacOSBrowser() ? "Cmd" : "Ctrl";
+
+  return (
+    <DetailCard title="Composer">
+      <Toggle
+        checked={enabled}
+        onChange={cmdEnterToSend.save}
+        label={`Send with ${modifier}+Enter`}
+        helperText={`When enabled, Enter inserts a new line and ${modifier}+Enter sends.`}
+      />
+    </DetailCard>
+  );
+}

--- a/apps/web/src/domains/settings/pages/general-page.tsx
+++ b/apps/web/src/domains/settings/pages/general-page.tsx
@@ -13,6 +13,7 @@ import {
     useAssistantWithHealthz,
 } from "@/domains/settings/components/assistant-status-panel";
 import { AssistantUpgrades } from "@/domains/settings/components/assistant-upgrades";
+import { ComposerSendCard } from "@/domains/settings/components/composer-send-card";
 import { DeleteAccountSection } from "@/domains/settings/components/delete-account-section";
 import { IOSAppCard } from "@/domains/settings/components/ios-app-card";
 import { LaunchAtLoginCard } from "@/domains/settings/components/launch-at-login-card";
@@ -302,6 +303,8 @@ export function GeneralPage() {
       )}
 
       <ThemeCard />
+
+      <ComposerSendCard />
 
       {isElectron() && <LaunchAtLoginCard />}
 

--- a/apps/web/src/utils/composer-settings.ts
+++ b/apps/web/src/utils/composer-settings.ts
@@ -1,0 +1,25 @@
+/**
+ * Device-scoped chat composer preferences.
+ *
+ * `cmdEnterToSend` mirrors the macOS app's "Send with Cmd+Enter" setting
+ * (`SettingsStore.cmdEnterToSend`): when enabled, Enter inserts a newline
+ * in the composer and Cmd+Enter (Ctrl+Enter on Windows/Linux) sends the
+ * message. Device-scoped so it describes this machine's keyboard habits
+ * and survives logout, matching the native app's UserDefaults semantics.
+ */
+
+import { createStorageAccessor } from "@/utils/typed-storage";
+
+function parseBool(raw: string): boolean | null {
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  return null;
+}
+
+export const cmdEnterToSend = createStorageAccessor<boolean>({
+  key: "device:cmd_enter_to_send",
+  scope: "device",
+  parse: parseBool,
+  serialize: String,
+  fallback: false,
+});


### PR DESCRIPTION
## Summary
- Add a "Send with Cmd+Enter" toggle to Settings → General in the web app (and therefore the Electron desktop app), at parity with the Swift macOS app's setting: when enabled, Enter inserts a newline and Cmd+Enter (Ctrl+Enter on Windows/Linux) sends the message.
- Persist the preference as a device-scoped localStorage accessor (`device:cmd_enter_to_send` via `createStorageAccessor`, survives logout like the native app's UserDefaults) and wire the previously-unused `cmdEnterMode` prop of `ChatComposer` to it in `ChatMainPanel`.
- The card hides on coarse-pointer (touch) devices, where the composer never submits on Enter and the toggle would be a no-op.

## Original prompt
The user asked whether the Electron macOS app has the Swift app's setting that toggles Enter between sending and inserting a newline. Investigation showed the web composer already implements the behavior behind a `cmdEnterMode` prop (with policy logic and tests) but nothing wires it to a persisted setting or settings UI. The user then asked to ship exactly that wiring, matching the Swift app's "Send with Cmd+Enter" toggle.