### PR TITLE
fix(macos): default the main window to maximized bounds, not fullscreen

### DIFF
--- a/apps/macos/src/main/main-window.test.ts
+++ b/apps/macos/src/main/main-window.test.ts
@@ -167,8 +167,15 @@ mock.module("electron", () => ({
 }));
 
 // What the mocked `restoreBounds()` returns. Defaults to a saved windowed
-// state; tests exercising the fresh-install fullscreen default override it.
-let restoredBounds: { width: number; height: number; fullscreen?: boolean } = {
+// state; tests exercising the fresh-install maximized default or a saved
+// fullscreen session override it.
+let restoredBounds: {
+  x?: number;
+  y?: number;
+  width: number;
+  height: number;
+  fullscreen?: boolean;
+} = {
   width: 1280,
   height: 800,
 };
@@ -497,8 +504,7 @@ describe("onboarding window sizing", () => {
     expect(win.opts.minHeight).toBe(600);
     expect(win.opts.resizable).toBeUndefined();
     expect(win.stub.isResizable()).toBe(true);
-    // A saved windowed state stays windowed — the fullscreen default only
-    // applies while nothing has been persisted.
+    // A saved windowed state stays windowed — never upgraded to fullscreen.
     expect(win.opts.fullscreen).toBeUndefined();
   });
 
@@ -628,8 +634,38 @@ describe("onboarding window sizing", () => {
   });
 });
 
-describe("fullscreen default", () => {
-  test("constructs the main window fullscreen when the restored state says so (fresh-install default)", () => {
+describe("maximized default", () => {
+  test("constructs the main window at the restored work-area bounds (fresh-install default)", () => {
+    restoredBounds = { x: 0, y: 25, width: 1512, height: 944 };
+    ensureVisible();
+    const win = constructed[0];
+    if (!win) throw new Error("expected a window");
+    expect(win.opts.x).toBe(0);
+    expect(win.opts.y).toBe(25);
+    expect(win.opts.width).toBe(1512);
+    expect(win.opts.height).toBe(944);
+    // Maximized means work-area bounds — a normal window, never native
+    // fullscreen.
+    expect(win.opts.fullscreen).toBeUndefined();
+  });
+
+  test("setOnboarding(false) applies the work-area bounds without entering fullscreen", () => {
+    onboardingActive = true;
+    ensureVisible();
+    const win = constructed[0];
+    if (!win) throw new Error("expected a window");
+    restoredBounds = { x: 0, y: 25, width: 1512, height: 944 };
+
+    setOnboarding(false);
+
+    expect(win.stub.setBounds).toHaveBeenCalledWith({ width: 1512, height: 944 });
+    expect(win.stub.setPosition).toHaveBeenCalledWith(0, 25);
+    expect(win.stub.setFullScreen).not.toHaveBeenCalled();
+  });
+});
+
+describe("fullscreen session restore", () => {
+  test("constructs the main window fullscreen when the saved session was fullscreen", () => {
     restoredBounds = { width: 1280, height: 800, fullscreen: true };
     ensureVisible();
     const win = constructed[0];

--- a/apps/macos/src/main/main-window.ts
+++ b/apps/macos/src/main/main-window.ts
@@ -25,15 +25,11 @@ import {
 // below its content.
 const ONBOARDING_CONTENT_SIZE = { width: 440, height: 660 } as const;
 
-// Default state for the main window once onboarding is done: native macOS
-// fullscreen. The 1280×800 rectangle is the windowed size the user lands on
-// when they exit fullscreen. Applies only until a real session is persisted —
-// after that, `window-state` restores whatever mode the user left.
-const MAIN_DEFAULT_BOUNDS = {
-  width: 1280,
-  height: 800,
-  fullscreen: true,
-} as const;
+// Default state for the main window once onboarding is done: maximized — a
+// normal window filling the display's work area, deliberately NOT native
+// macOS fullscreen. Applies only until a real session is persisted; after
+// that, `window-state` restores whatever bounds/mode the user left.
+const MAIN_DEFAULT_STATE = "maximized";
 
 // Minimum size for the main-app window, mirroring the macOS Swift client's
 // main window (`MainWindow.swift`: `contentMinSize` 800×600). The window can't
@@ -200,14 +196,13 @@ const createMainWindow = (): BrowserWindow => {
   const loadTarget = getRendererRootUrl(app.isPackaged);
 
   // Onboarding opens at the 440×660 default; otherwise restore the user's
-  // saved main-app state — which defaults to fullscreen when nothing has
-  // been persisted yet (`MAIN_DEFAULT_BOUNDS`). The `fullscreen` flag rides
-  // the spread into the `BrowserWindow` constructor, the same path a saved
-  // fullscreen session restores through. Both layouts are resizable larger,
-  // but each carries its own minimum (`minWidth`/`minHeight`): the compact
-  // onboarding flow can't be dragged below its 440×660 content, and the main
-  // app can't be dragged below 800×600 (mirroring the Swift client's
-  // `contentMinSize`).
+  // saved main-app state — which defaults to maximized (work-area bounds)
+  // when nothing has been persisted yet. A saved fullscreen session's
+  // `fullscreen` flag rides the spread into the `BrowserWindow` constructor.
+  // Both layouts are resizable larger, but each carries its own minimum
+  // (`minWidth`/`minHeight`): the compact onboarding flow can't be dragged
+  // below its 440×660 content, and the main app can't be dragged below
+  // 800×600 (mirroring the Swift client's `contentMinSize`).
   // The persisted flag lets a relaunch *during* onboarding rebuild the small
   // window directly (no flash); the absent-flag default is `false` (open large) so we
   // never cramp the `/account/*` screens that render outside RootLayout —
@@ -222,7 +217,7 @@ const createMainWindow = (): BrowserWindow => {
         useContentSize: true,
       }
     : {
-        ...restoreBounds("main", MAIN_DEFAULT_BOUNDS),
+        ...restoreBounds("main", MAIN_DEFAULT_STATE),
         minWidth: MAIN_MIN_SIZE.width,
         minHeight: MAIN_MIN_SIZE.height,
       };
@@ -397,10 +392,9 @@ export const dispatchToMain = (command: VellumCommand): void => {
  * navigation) is a cheap no-op past the early return.
  *
  * Native fullscreen is handled on both transitions: entering onboarding
- * leaves fullscreen first (the fresh-install default opens fullscreen at the
- * pre-onboarding `/account/*` screens), and leaving onboarding re-enters it
- * when the restored state — including that same fresh-install default —
- * calls for it.
+ * leaves fullscreen first (a restored fullscreen session, or a green-button
+ * press at the pre-onboarding `/account/*` screens), and leaving onboarding
+ * re-enters it when the saved session being restored was fullscreen.
  */
 export const setOnboarding = (active: boolean): void => {
   const wasActive = readOnboardingActive();
@@ -431,7 +425,7 @@ export const setOnboarding = (active: boolean): void => {
   } else {
     // Swap the onboarding floor for the roomier 800×600 main-app floor.
     win.setMinimumSize(MAIN_MIN_SIZE.width, MAIN_MIN_SIZE.height);
-    const bounds = restoreBounds("main", MAIN_DEFAULT_BOUNDS);
+    const bounds = restoreBounds("main", MAIN_DEFAULT_STATE);
     win.setBounds({ width: bounds.width, height: bounds.height });
     if (bounds.x !== undefined && bounds.y !== undefined) {
       win.setPosition(bounds.x, bounds.y);

--- a/apps/macos/src/main/window-state.test.ts
+++ b/apps/macos/src/main/window-state.test.ts
@@ -38,6 +38,7 @@ mock.module("electron", () => ({
   BrowserWindow: class {},
   screen: {
     getDisplayMatching: () => ({ workArea }),
+    getPrimaryDisplay: () => ({ workArea }),
   },
 }));
 
@@ -163,25 +164,31 @@ describe("restoreBounds", () => {
     expect(restoreBounds("main", DEFAULTS).fullscreen).toBe(true);
   });
 
-  test("passes a fullscreen default through when nothing is persisted", () => {
-    expect(restoreBounds("main", { ...DEFAULTS, fullscreen: true })).toEqual({
-      width: 800,
-      height: 600,
-      fullscreen: true,
+  test("returns the primary display's work area for the maximized default", () => {
+    workArea = { x: 0, y: 25, width: 1512, height: 944 };
+    expect(restoreBounds("main", "maximized")).toEqual({
+      x: 0,
+      y: 25,
+      width: 1512,
+      height: 944,
     });
   });
 
-  test("a saved windowed state overrides a fullscreen default", () => {
+  test("a saved state overrides the maximized default", () => {
     savedWindows.main = {
-      x: 0,
-      y: 0,
-      width: 800,
-      height: 600,
+      x: 100,
+      y: 200,
+      width: 1000,
+      height: 700,
       isFullScreen: false,
     };
-    expect(
-      restoreBounds("main", { ...DEFAULTS, fullscreen: true }).fullscreen,
-    ).toBe(false);
+    expect(restoreBounds("main", "maximized")).toEqual({
+      x: 100,
+      y: 200,
+      width: 1000,
+      height: 700,
+      fullscreen: false,
+    });
   });
 
   test("namespaces by key so windows don't clobber each other", () => {

--- a/apps/macos/src/main/window-state.ts
+++ b/apps/macos/src/main/window-state.ts
@@ -67,15 +67,15 @@ export const writeOnboardingActive = (active: boolean): void => {
   store().set("onboardingActive", active);
 };
 
-interface Defaults {
-  width: number;
-  height: number;
-  // Open in native fullscreen when no state has been persisted yet. The
-  // width/height still matter: they're the windowed rectangle the user
-  // lands on when they exit fullscreen. A saved state's own `isFullScreen`
-  // always wins once one exists.
-  fullscreen?: boolean;
-}
+/**
+ * What to open with when no state has been persisted for the key yet:
+ * either a fixed windowed size (Electron centers it), or `"maximized"` —
+ * a normal window filling the primary display's work area. macOS has no
+ * sticky maximized window state, so work-area bounds are what "maximized"
+ * means there (the green button's zoom) — deliberately NOT native
+ * fullscreen. A saved state always wins once one exists.
+ */
+type Defaults = { width: number; height: number } | "maximized";
 
 export interface RestoredWindowState {
   x?: number;
@@ -98,15 +98,22 @@ export interface RestoredWindowState {
  *   - A monitor that shrunk (resolution change) doesn't leave the window
  *     extending past the new edge.
  *
- * Omitting `x` / `y` when no state exists is intentional — Electron
- * centers the window in that case, which is the right first-run UX.
+ * For fixed-size defaults, omitting `x` / `y` when no state exists is
+ * intentional — Electron centers the window in that case, which is the
+ * right first-run UX. The `"maximized"` default carries the work area's
+ * own origin instead.
  */
 export const restoreBounds = (
   key: string,
   defaults: Defaults,
 ): RestoredWindowState => {
   const saved = store().get("windows", {})[key];
-  if (!saved) return defaults;
+  if (!saved) {
+    if (defaults === "maximized") {
+      return { ...screen.getPrimaryDisplay().workArea };
+    }
+    return defaults;
+  }
 
   const display = screen.getDisplayMatching(saved);
   const wa = display.workArea;


### PR DESCRIPTION
## Summary
- Corrects #34774: the fresh-install default for the main window is now **maximized** — a normal window filling the primary display's work area — instead of native macOS fullscreen. `restoreBounds` gains a `"maximized"` defaults sentinel that resolves to the work area when nothing has been persisted; the work-area bounds then persist naturally, so launches stay maximized until the user resizes.
- A saved session still wins and restores exactly the mode the user left. The fullscreen handling from #34774 (constructor restore, onboarding enter/leave transitions) is kept, but now only applies to genuinely saved fullscreen sessions.
- Tests updated: work-area default pass-through, saved state overriding the maximized default, construction at work-area bounds, and onboarding exit applying work-area bounds without entering fullscreen.

## Original prompt
Follow-up correction to #34774 ("the macOS Electron app should open full screen by default"): the user clarified they meant the window should open at the maximum window size (maximized/work-area bounds), not in macOS full-screen mode.