### PR TITLE
feat(auth): app-held WorkOS PKCE login for native macOS

### DIFF
--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -145,81 +145,79 @@ public final class AuthManager {
         state = .validationFailed(lastError: lastError ?? AuthServiceError.networkError(URLError(.unknown)))
     }
 
+    /// Logs in via app-held WorkOS User Management PKCE.
+    ///
+    /// The client drives WorkOS directly (rather than letting Django run the
+    /// OAuth flow server-side) and exchanges the resulting WorkOS access
+    /// token for its own Django session token:
+    ///   1. Discover the WorkOS UM client id from the platform's headless
+    ///      config.
+    ///   2. Generate an S256 PKCE pair + CSRF `state`.
+    ///   3. Authorize at WorkOS via `ASWebAuthenticationSession`, receiving
+    ///      the one-time code on `{scheme}://auth/callback`.
+    ///   4. Exchange the code at WorkOS as a PUBLIC client → `access_token`.
+    ///   5. Exchange the access token for a Django session token via allauth's
+    ///      headless `auth/provider/token` endpoint, then store it.
     public func startWorkOSLogin() async {
         isSubmitting = true
         errorMessage = nil
         defer { isSubmitting = false }
 
         do {
-            guard let stateParam = generateRandomString(length: 32) else {
-                throw AuthServiceError.authCallbackFailed("Failed to generate secure random state.")
+            // 1. Discover the token-auth WorkOS UM client id. During the
+            // coexistence window two `workos-oidc` entries are listed; the
+            // OAuth2 one (provider_token flow, no OIDC discovery URL) is the
+            // usable one.
+            let config = try await authService.getConfig()
+            let providers = config.data?.socialaccount?.providers ?? []
+            guard let clientID = WorkOSPKCE.selectWorkosClientId(providers) else {
+                throw WorkOSPKCE.PkceError.noTokenAuthProvider
             }
 
-            // Build /accounts/native/start?state={state}. The server
-            // determines the callback scheme from settings.ENVIRONMENT
-            // — the client no longer sends it (ATL-454).
-            //
-            // ``client_version`` is forwarded so the server can attribute
-            // callback hits to a specific macOS build in
-            // ``native_login_callback`` (ATL-466). Absence of the param on
-            // the server-side fallback branch is the signal that a
-            // pre-ATL-454 (≤ v0.7.2) build initiated the flow — when that
-            // signal disappears from the logs, ``session_token`` can be
-            // dropped from the legacy redirect.
-            guard var startComponents = URLComponents(string: VellumEnvironment.resolvedWebURL) else {
-                throw AuthServiceError.invalidURL
-            }
-            startComponents.path = "/accounts/native/start"
-            var queryItems = [URLQueryItem(name: "state", value: stateParam)]
-            if let clientVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
-               !clientVersion.isEmpty {
-                queryItems.append(URLQueryItem(name: "client_version", value: clientVersion))
-            }
-            startComponents.queryItems = queryItems
-
-            guard let loginURL = startComponents.url else {
-                throw AuthServiceError.invalidURL
+            // 2. PKCE pair + CSRF state.
+            guard let pkce = WorkOSPKCE.generatePkcePair(),
+                  let stateParam = WorkOSPKCE.randomBase64URLString(byteCount: 32) else {
+                throw WorkOSPKCE.PkceError.randomGenerationFailed
             }
 
-            let callbackURL = try await performWebAuth(url: loginURL, callbackScheme: Self.callbackScheme)
+            // 3. Authorize at WorkOS. The redirect URI is the app's custom
+            // scheme from CFBundleURLSchemes (vellum-assistant in prod,
+            // vellum-assistant-{env} otherwise). performWebAuth keeps its
+            // non-ephemeral session so existing Safari IdP cookies are reused.
+            let redirectURI = WorkOSPKCE.redirectURI(scheme: Self.callbackScheme)
+            let authURL = try WorkOSPKCE.buildAuthorizeURL(
+                clientID: clientID,
+                redirectURI: redirectURI,
+                challenge: pkce.challenge,
+                state: stateParam
+            )
 
-            guard let components = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false),
-                  let queryItems = components.queryItems else {
-                throw AuthServiceError.authCallbackFailed("Missing callback URL components.")
-            }
+            let callbackURL = try await performWebAuth(url: authURL, callbackScheme: Self.callbackScheme)
+            let code = try WorkOSPKCE.extractCode(from: callbackURL, expectedState: stateParam)
 
-            let returnedState = queryItems.first(where: { $0.name == "state" })?.value
+            // 4. Exchange the code at WorkOS as a public client (no secret).
+            let accessToken = try await authService.exchangeWorkOSCode(
+                clientID: clientID,
+                code: code,
+                verifier: pkce.verifier
+            )
 
-            if let authError = queryItems.first(where: { $0.name == "error" })?.value, !authError.isEmpty {
-                throw AuthServiceError.authCallbackFailed("Auth error: \(authError)")
-            }
-
-            guard let returnedState else {
-                throw AuthServiceError.authCallbackFailed("Callback missing state.")
-            }
-
-            guard returnedState == stateParam else {
-                throw AuthServiceError.authCallbackFailed("State mismatch — possible CSRF.")
-            }
-
-            guard let code = queryItems.first(where: { $0.name == "code" })?.value, !code.isEmpty else {
-                throw AuthServiceError.authCallbackFailed("Callback missing authorization code.")
-            }
-
-            // Exchange the one-time code for a session token via POST.
-            // The code is short-lived (30 s) and single-use (ATL-454).
-            let sessionToken = try await exchangeCodeForSession(code: code)
+            // 5. Exchange the WorkOS access token for a Django session token.
+            let sessionToken = try await authService.exchangeWorkOSAccessTokenForSession(
+                clientID: clientID,
+                accessToken: accessToken
+            )
 
             await SessionTokenManager.setTokenAsync(sessionToken)
 
             let session = try await authService.getSession()
             if session.status == 200, session.meta?.is_authenticated != false, let user = session.data?.user {
                 state = .authenticated(user)
-                log.info("Login completed via native auth flow for user \(user.id ?? user.email ?? "unknown", privacy: .public)")
+                log.info("Login completed via WorkOS PKCE for user \(user.id ?? user.email ?? "unknown", privacy: .public)")
                 await resolveOrganizationIdAfterAuth()
                 await postAuthenticationHook?()
             } else {
-                log.error("Session validation after native auth flow did not return authenticated user. status=\(session.status, privacy: .public)")
+                log.error("Session validation after WorkOS PKCE did not return authenticated user. status=\(session.status, privacy: .public)")
                 errorMessage = "Authentication was not completed. Please try again."
             }
         } catch let error as ASWebAuthenticationSessionError where error.code == .canceledLogin {
@@ -228,38 +226,6 @@ public final class AuthManager {
             log.error("Login failed: baseURL=\(VellumEnvironment.resolvedPlatformURL, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
             errorMessage = "Unable to sign in. Please try again."
         }
-    }
-
-    /// Exchange a one-time authorization code for a session token.
-    private func exchangeCodeForSession(code: String) async throws -> String {
-        guard var exchangeComponents = URLComponents(string: VellumEnvironment.resolvedWebURL) else {
-            throw AuthServiceError.invalidURL
-        }
-        exchangeComponents.path = "/accounts/native/exchange"
-
-        guard let exchangeURL = exchangeComponents.url else {
-            throw AuthServiceError.invalidURL
-        }
-
-        var request = URLRequest(url: exchangeURL)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = try JSONSerialization.data(withJSONObject: ["code": code])
-
-        let (data, response) = try await URLSession.shared.data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
-            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
-            throw AuthServiceError.authCallbackFailed("Code exchange failed with status \(statusCode).")
-        }
-
-        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let sessionToken = json["session_token"] as? String,
-              !sessionToken.isEmpty else {
-            throw AuthServiceError.authCallbackFailed("Code exchange returned invalid response.")
-        }
-
-        return sessionToken
     }
 
     /// Logs out by deleting the server session, clearing local tokens and
@@ -297,17 +263,6 @@ public final class AuthManager {
         } catch {
             log.warning("Failed to resolve organization ID post-auth: \(error.localizedDescription, privacy: .public)")
         }
-    }
-
-    /// Generate a cryptographically random base64url string.
-    /// Returns `nil` if the system RNG is unavailable — callers must
-    /// treat this as a fatal condition since the state parameter is the
-    /// sole CSRF defense on the auth callback.
-    private func generateRandomString(length: Int) -> String? {
-        var bytes = [UInt8](repeating: 0, count: length)
-        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
-        guard status == errSecSuccess else { return nil }
-        return Data(bytes).base64URLEncodedString()
     }
 
     private func performWebAuth(url: URL, callbackScheme: String) async throws -> URL {

--- a/clients/shared/App/Auth/AuthService.swift
+++ b/clients/shared/App/Auth/AuthService.swift
@@ -52,6 +52,98 @@ public final class AuthService {
         try await request(AuthRequestConfig(path: "auth/session", method: "DELETE"))
     }
 
+    // MARK: - WorkOS app-held PKCE login
+
+    /// Fetch the headless auth config (`GET /_allauth/app/v1/config`) to
+    /// discover the WorkOS UM client id. Unauthenticated; the session-token
+    /// header (if any) is harmless here.
+    public func getConfig() async throws -> WorkOSPKCE.ConfigResponse {
+        guard let url = WorkOSPKCE.configURL(platformOrigin: VellumEnvironment.resolvedPlatformURL) else {
+            throw AuthServiceError.invalidURL
+        }
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "GET"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: urlRequest)
+        } catch {
+            throw AuthServiceError.networkError(error)
+        }
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+        log.debug("Auth request GET config -> \(statusCode, privacy: .public)")
+        guard statusCode == 200 else {
+            throw WorkOSPKCE.PkceError.configFetchFailed("HTTP \(statusCode)")
+        }
+        do {
+            return try JSONDecoder().decode(WorkOSPKCE.ConfigResponse.self, from: data)
+        } catch {
+            throw AuthServiceError.decodingError(error)
+        }
+    }
+
+    /// Exchange the PKCE authorization code at WorkOS as a PUBLIC client
+    /// (POST JSON: client_id, grant_type, code, code_verifier — no secret,
+    /// no API key) and return the WorkOS `access_token`.
+    public func exchangeWorkOSCode(clientID: String, code: String, verifier: String) async throws -> String {
+        guard let url = WorkOSPKCE.codeExchangeURL() else {
+            throw AuthServiceError.invalidURL
+        }
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.httpBody = try JSONSerialization.data(
+            withJSONObject: WorkOSPKCE.codeExchangeBody(clientID: clientID, code: code, verifier: verifier)
+        )
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: urlRequest)
+        } catch {
+            throw AuthServiceError.networkError(error)
+        }
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+        guard statusCode == 200 else {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            throw WorkOSPKCE.PkceError.codeExchangeFailed("HTTP \(statusCode): \(body)")
+        }
+        return try WorkOSPKCE.parseAccessToken(data)
+    }
+
+    /// Exchange the WorkOS access token for a Django session token via the
+    /// allauth headless `POST /_allauth/app/v1/auth/provider/token` endpoint.
+    /// This is a login, so no existing session token is sent.
+    public func exchangeWorkOSAccessTokenForSession(clientID: String, accessToken: String) async throws -> String {
+        guard let url = WorkOSPKCE.sessionExchangeURL(platformOrigin: VellumEnvironment.resolvedPlatformURL) else {
+            throw AuthServiceError.invalidURL
+        }
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
+        urlRequest.httpBody = try JSONSerialization.data(
+            withJSONObject: WorkOSPKCE.sessionExchangeBody(clientID: clientID, accessToken: accessToken)
+        )
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: urlRequest)
+        } catch {
+            throw AuthServiceError.networkError(error)
+        }
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+        log.debug("Auth request POST auth/provider/token -> \(statusCode, privacy: .public)")
+        guard statusCode == 200 else {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            throw WorkOSPKCE.PkceError.sessionExchangeFailed("HTTP \(statusCode): \(body)")
+        }
+        return try WorkOSPKCE.parseSessionToken(data)
+    }
+
     // MARK: - Platform Organizations API
 
     /// Fetch the current user's organizations. Does not require Vellum-Organization-Id header.

--- a/clients/shared/App/Auth/WorkOSPKCE.swift
+++ b/clients/shared/App/Auth/WorkOSPKCE.swift
@@ -1,0 +1,258 @@
+import CryptoKit
+import Foundation
+
+/// App-held PKCE login against WorkOS User Management. Pure helpers
+/// (Foundation + CryptoKit only, isolation-typecheckable + unit-testable);
+/// `AuthManager` drives the network/UI. Mirrors the Electron implementation.
+public enum WorkOSPKCE {
+    public static let apiBaseURL = "https://api.workos.com"
+    /// allauth provider `id` for the WorkOS OAuth2 provider — `workos`, even
+    /// though its `sub_id` (the config entry's id) is `workos-oidc`.
+    public static let providerID = "workos"
+    public static let scope = "openid profile email"
+    public static let callbackPath = "/auth/callback"
+
+    // MARK: - PKCE
+
+    public struct PkcePair: Sendable, Equatable {
+        public let verifier: String
+        public let challenge: String
+
+        public init(verifier: String, challenge: String) {
+            self.verifier = verifier
+            self.challenge = challenge
+        }
+    }
+
+    public enum PkceError: LocalizedError {
+        case randomGenerationFailed
+        case invalidURL
+        case configFetchFailed(String)
+        case noTokenAuthProvider
+        case callbackMissingComponents
+        case callbackError(String)
+        case callbackMissingState
+        case stateMismatch
+        case callbackMissingCode
+        case codeExchangeFailed(String)
+        case sessionExchangeFailed(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .randomGenerationFailed:
+                return "Failed to generate secure random bytes."
+            case .invalidURL:
+                return "Invalid URL."
+            case .configFetchFailed(let detail):
+                return "Failed to fetch auth config: \(detail)"
+            case .noTokenAuthProvider:
+                return "Platform does not advertise a token-auth WorkOS provider; cannot start PKCE login."
+            case .callbackMissingComponents:
+                return "Missing callback URL components."
+            case .callbackError(let detail):
+                return "Auth error: \(detail)"
+            case .callbackMissingState:
+                return "Callback missing state."
+            case .stateMismatch:
+                return "State mismatch — possible CSRF."
+            case .callbackMissingCode:
+                return "Callback missing authorization code."
+            case .codeExchangeFailed(let detail):
+                return "WorkOS code exchange failed: \(detail)"
+            case .sessionExchangeFailed(let detail):
+                return "Session exchange failed: \(detail)"
+            }
+        }
+    }
+
+    /// S256 PKCE pair: verifier = 32 random bytes, challenge =
+    /// base64url(SHA256(verifier)). Returns `nil` on RNG failure (fatal —
+    /// PKCE is the sole defense against an intercepted code).
+    public static func generatePkcePair() -> PkcePair? {
+        guard let verifier = randomBase64URLString(byteCount: 32) else { return nil }
+        let challengeData = Data(SHA256.hash(data: Data(verifier.utf8)))
+        return PkcePair(verifier: verifier, challenge: base64URLEncode(challengeData))
+    }
+
+    /// `byteCount` cryptographically-random bytes, base64url-encoded without
+    /// padding. Returns `nil` on RNG failure.
+    public static func randomBase64URLString(byteCount: Int) -> String? {
+        var bytes = [UInt8](repeating: 0, count: byteCount)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        guard status == errSecSuccess else { return nil }
+        return base64URLEncode(Data(bytes))
+    }
+
+    /// base64url without padding. Inlined to keep the module self-contained.
+    private static func base64URLEncode(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    // MARK: - Headless config provider selection
+
+    /// One entry of `data.socialaccount.providers` in the headless config.
+    public struct ProviderEntry: Codable, Sendable {
+        public let id: String
+        public let name: String?
+        public let client_id: String?
+        public let flows: [String]?
+        public let openid_configuration_url: String?
+    }
+
+    public struct SocialAccountConfig: Codable, Sendable {
+        public let providers: [ProviderEntry]?
+    }
+
+    public struct ConfigData: Codable, Sendable {
+        public let socialaccount: SocialAccountConfig?
+    }
+
+    /// Headless `GET /_allauth/app/v1/config` envelope.
+    public struct ConfigResponse: Codable, Sendable {
+        public let data: ConfigData?
+    }
+
+    /// Pick the OAuth2 WorkOS client id from the headless config. During the
+    /// coexistence window two entries share the `workos-oidc` id; the usable
+    /// one has token auth and no OIDC discovery URL. `nil` if none.
+    public static func selectWorkosClientId(_ providers: [ProviderEntry]) -> String? {
+        providers.first {
+            $0.openid_configuration_url == nil
+                && ($0.flows ?? []).contains("provider_token")
+                && $0.client_id != nil
+        }?.client_id
+    }
+
+    /// Build the `GET {platformOrigin}/_allauth/app/v1/config` URL.
+    public static func configURL(platformOrigin: String) -> URL? {
+        guard var components = URLComponents(string: platformOrigin) else { return nil }
+        components.path = "/_allauth/app/v1/config"
+        components.query = nil
+        components.fragment = nil
+        return components.url
+    }
+
+    // MARK: - Authorize URL
+
+    /// Build the WorkOS UM authorize URL.
+    public static func buildAuthorizeURL(
+        clientID: String,
+        redirectURI: String,
+        challenge: String,
+        state: String
+    ) throws -> URL {
+        guard var components = URLComponents(string: "\(apiBaseURL)/user_management/authorize") else {
+            throw PkceError.invalidURL
+        }
+        components.queryItems = [
+            URLQueryItem(name: "client_id", value: clientID),
+            URLQueryItem(name: "redirect_uri", value: redirectURI),
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "scope", value: scope),
+            URLQueryItem(name: "code_challenge", value: challenge),
+            URLQueryItem(name: "code_challenge_method", value: "S256"),
+            URLQueryItem(name: "state", value: state),
+            // No `prompt`: lets the browser's existing IdP session be reused.
+            URLQueryItem(name: "provider", value: "authkit"),
+        ]
+        guard let url = components.url else { throw PkceError.invalidURL }
+        return url
+    }
+
+    /// Custom-scheme redirect URI, e.g. `vellum-assistant://auth/callback`
+    /// (`scheme` comes from the caller's `CFBundleURLSchemes`, per build).
+    public static func redirectURI(scheme: String) -> String {
+        "\(scheme)://\(callbackPath.dropFirst())"
+    }
+
+    // MARK: - Callback parsing
+
+    /// Validate the callback URL and extract the one-time authorization code.
+    /// Verifies `state` against `expectedState` (CSRF defense) and surfaces a
+    /// returned `error` param ahead of a missing-state error.
+    public static func extractCode(from callbackURL: URL, expectedState: String) throws -> String {
+        guard let components = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false),
+              let queryItems = components.queryItems else {
+            throw PkceError.callbackMissingComponents
+        }
+
+        if let authError = queryItems.first(where: { $0.name == "error" })?.value, !authError.isEmpty {
+            throw PkceError.callbackError(authError)
+        }
+
+        guard let returnedState = queryItems.first(where: { $0.name == "state" })?.value else {
+            throw PkceError.callbackMissingState
+        }
+        guard returnedState == expectedState else {
+            throw PkceError.stateMismatch
+        }
+        guard let code = queryItems.first(where: { $0.name == "code" })?.value, !code.isEmpty else {
+            throw PkceError.callbackMissingCode
+        }
+        return code
+    }
+
+    // MARK: - Token-exchange request builders
+
+    /// POST body for the WorkOS public-client code exchange at
+    /// `/user_management/authenticate`. No secret, no API key.
+    public static func codeExchangeBody(clientID: String, code: String, verifier: String) -> [String: Any] {
+        [
+            "client_id": clientID,
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": verifier,
+        ]
+    }
+
+    public static func codeExchangeURL() -> URL? {
+        URL(string: "\(apiBaseURL)/user_management/authenticate")
+    }
+
+    /// POST body for the allauth headless provider-token exchange at
+    /// `/_allauth/app/v1/auth/provider/token`.
+    public static func sessionExchangeBody(clientID: String, accessToken: String) -> [String: Any] {
+        [
+            "provider": providerID,
+            "process": "login",
+            "token": [
+                "client_id": clientID,
+                "access_token": accessToken,
+            ],
+        ]
+    }
+
+    public static func sessionExchangeURL(platformOrigin: String) -> URL? {
+        guard var components = URLComponents(string: platformOrigin) else { return nil }
+        components.path = "/_allauth/app/v1/auth/provider/token"
+        components.query = nil
+        components.fragment = nil
+        return components.url
+    }
+
+    // MARK: - Response parsing
+
+    /// Extract `access_token` from the WorkOS authenticate response body.
+    public static func parseAccessToken(_ data: Data) throws -> String {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let token = json["access_token"] as? String,
+              !token.isEmpty else {
+            throw PkceError.codeExchangeFailed("response contained no access token")
+        }
+        return token
+    }
+
+    /// Extract `meta.session_token` from the allauth provider-token response.
+    public static func parseSessionToken(_ data: Data) throws -> String {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let meta = json["meta"] as? [String: Any],
+              let token = meta["session_token"] as? String,
+              !token.isEmpty else {
+            throw PkceError.sessionExchangeFailed("response contained no session token")
+        }
+        return token
+    }
+}

--- a/clients/shared/Tests/WorkOSPKCETests.swift
+++ b/clients/shared/Tests/WorkOSPKCETests.swift
@@ -1,0 +1,255 @@
+import CryptoKit
+import Foundation
+import XCTest
+
+@testable import VellumAssistantShared
+
+final class WorkOSPKCETests: XCTestCase {
+    // MARK: - PKCE pair
+
+    func test_generatePkcePair_isS256AndBase64URL() throws {
+        let pair = try XCTUnwrap(WorkOSPKCE.generatePkcePair())
+
+        // Verifier is base64url(32 bytes) → 43 chars, no padding/url-unsafe.
+        XCTAssertEqual(pair.verifier.count, 43)
+        XCTAssertFalse(pair.verifier.contains("="))
+        XCTAssertFalse(pair.verifier.contains("+"))
+        XCTAssertFalse(pair.verifier.contains("/"))
+
+        // Challenge must equal base64url(SHA256(verifier)).
+        let expected = Data(SHA256.hash(data: Data(pair.verifier.utf8)))
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        XCTAssertEqual(pair.challenge, expected)
+    }
+
+    func test_randomBase64URLString_lengthAndAlphabet() throws {
+        let value = try XCTUnwrap(WorkOSPKCE.randomBase64URLString(byteCount: 32))
+        XCTAssertEqual(value.count, 43)
+        let allowed = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_")
+        XCTAssertTrue(value.unicodeScalars.allSatisfy { allowed.contains($0) })
+    }
+
+    func test_pkcePairs_areUnique() throws {
+        let a = try XCTUnwrap(WorkOSPKCE.generatePkcePair())
+        let b = try XCTUnwrap(WorkOSPKCE.generatePkcePair())
+        XCTAssertNotEqual(a.verifier, b.verifier)
+        XCTAssertNotEqual(a.challenge, b.challenge)
+    }
+
+    // MARK: - Provider selection
+
+    private func entry(
+        id: String = "workos-oidc",
+        clientID: String?,
+        flows: [String]?,
+        oidcURL: String?
+    ) -> WorkOSPKCE.ProviderEntry {
+        WorkOSPKCE.ProviderEntry(
+            id: id,
+            name: nil,
+            client_id: clientID,
+            flows: flows,
+            openid_configuration_url: oidcURL
+        )
+    }
+
+    func test_selectWorkosClientId_picksOAuth2DuringCoexistence() {
+        // Two `workos-oidc` entries: the legacy OIDC one (has discovery URL)
+        // and the new OAuth2 one (provider_token flow, no discovery URL).
+        let providers = [
+            entry(clientID: "oidc_client", flows: ["provider_redirect"], oidcURL: "https://api.workos.com/sso/oidc/.well-known"),
+            entry(clientID: "oauth2_client", flows: ["provider_token", "provider_redirect"], oidcURL: nil),
+        ]
+        XCTAssertEqual(WorkOSPKCE.selectWorkosClientId(providers), "oauth2_client")
+    }
+
+    func test_selectWorkosClientId_nilWhenOnlyOIDC() {
+        let providers = [
+            entry(clientID: "oidc_client", flows: ["provider_token"], oidcURL: "https://discovery"),
+        ]
+        XCTAssertNil(WorkOSPKCE.selectWorkosClientId(providers))
+    }
+
+    func test_selectWorkosClientId_nilWhenNoProviderToken() {
+        let providers = [
+            entry(clientID: "oauth2_client", flows: ["provider_redirect"], oidcURL: nil),
+        ]
+        XCTAssertNil(WorkOSPKCE.selectWorkosClientId(providers))
+    }
+
+    func test_selectWorkosClientId_nilWhenNoClientId() {
+        let providers = [
+            entry(clientID: nil, flows: ["provider_token"], oidcURL: nil),
+        ]
+        XCTAssertNil(WorkOSPKCE.selectWorkosClientId(providers))
+    }
+
+    func test_selectWorkosClientId_emptyList() {
+        XCTAssertNil(WorkOSPKCE.selectWorkosClientId([]))
+    }
+
+    // MARK: - Config decoding
+
+    func test_configResponse_decodesAndSelects() throws {
+        let json = """
+        {
+          "status": 200,
+          "data": {
+            "socialaccount": {
+              "providers": [
+                {"id": "workos-oidc", "name": "WorkOS", "client_id": "oidc", "flows": ["provider_redirect"], "openid_configuration_url": "https://disc"},
+                {"id": "workos-oidc", "name": "WorkOS", "client_id": "client_abc", "flows": ["provider_token", "provider_redirect"]}
+              ]
+            }
+          }
+        }
+        """.data(using: .utf8)!
+        let response = try JSONDecoder().decode(WorkOSPKCE.ConfigResponse.self, from: json)
+        let providers = try XCTUnwrap(response.data?.socialaccount?.providers)
+        XCTAssertEqual(WorkOSPKCE.selectWorkosClientId(providers), "client_abc")
+    }
+
+    // MARK: - Authorize URL
+
+    func test_buildAuthorizeURL_hasExpectedParams() throws {
+        let url = try WorkOSPKCE.buildAuthorizeURL(
+            clientID: "client_abc",
+            redirectURI: "vellum-assistant://auth/callback",
+            challenge: "the-challenge",
+            state: "the-state"
+        )
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        XCTAssertEqual(components.scheme, "https")
+        XCTAssertEqual(components.host, "api.workos.com")
+        XCTAssertEqual(components.path, "/user_management/authorize")
+
+        let items = Dictionary(
+            uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value) }
+        )
+        XCTAssertEqual(items["client_id"], "client_abc")
+        XCTAssertEqual(items["redirect_uri"], "vellum-assistant://auth/callback")
+        XCTAssertEqual(items["response_type"], "code")
+        XCTAssertEqual(items["scope"], "openid profile email")
+        XCTAssertEqual(items["code_challenge"], "the-challenge")
+        XCTAssertEqual(items["code_challenge_method"], "S256")
+        XCTAssertEqual(items["state"], "the-state")
+        XCTAssertEqual(items["provider"], "authkit")
+        // No `prompt` param so the browser IdP session can be reused.
+        XCTAssertNil(items["prompt"])
+    }
+
+    // MARK: - Redirect URI
+
+    func test_redirectURI_prod() {
+        XCTAssertEqual(
+            WorkOSPKCE.redirectURI(scheme: "vellum-assistant"),
+            "vellum-assistant://auth/callback"
+        )
+    }
+
+    func test_redirectURI_dev() {
+        XCTAssertEqual(
+            WorkOSPKCE.redirectURI(scheme: "vellum-assistant-dev"),
+            "vellum-assistant-dev://auth/callback"
+        )
+    }
+
+    // MARK: - Callback parsing
+
+    func test_extractCode_success() throws {
+        let url = URL(string: "vellum-assistant://auth/callback?code=abc123&state=expected")!
+        XCTAssertEqual(try WorkOSPKCE.extractCode(from: url, expectedState: "expected"), "abc123")
+    }
+
+    func test_extractCode_stateMismatchThrows() {
+        let url = URL(string: "vellum-assistant://auth/callback?code=abc&state=wrong")!
+        XCTAssertThrowsError(try WorkOSPKCE.extractCode(from: url, expectedState: "expected")) {
+            guard case WorkOSPKCE.PkceError.stateMismatch = $0 else {
+                return XCTFail("expected stateMismatch, got \($0)")
+            }
+        }
+    }
+
+    func test_extractCode_errorParamThrowsBeforeMissingState() {
+        let url = URL(string: "vellum-assistant://auth/callback?error=access_denied")!
+        XCTAssertThrowsError(try WorkOSPKCE.extractCode(from: url, expectedState: "expected")) {
+            guard case WorkOSPKCE.PkceError.callbackError(let detail) = $0 else {
+                return XCTFail("expected callbackError, got \($0)")
+            }
+            XCTAssertEqual(detail, "access_denied")
+        }
+    }
+
+    func test_extractCode_missingCodeThrows() {
+        let url = URL(string: "vellum-assistant://auth/callback?state=expected")!
+        XCTAssertThrowsError(try WorkOSPKCE.extractCode(from: url, expectedState: "expected")) {
+            guard case WorkOSPKCE.PkceError.callbackMissingCode = $0 else {
+                return XCTFail("expected callbackMissingCode, got \($0)")
+            }
+        }
+    }
+
+    // MARK: - Request bodies & URLs
+
+    func test_codeExchangeBody_isPublicClient() {
+        let body = WorkOSPKCE.codeExchangeBody(clientID: "c", code: "code", verifier: "v")
+        XCTAssertEqual(body["client_id"] as? String, "c")
+        XCTAssertEqual(body["grant_type"] as? String, "authorization_code")
+        XCTAssertEqual(body["code"] as? String, "code")
+        XCTAssertEqual(body["code_verifier"] as? String, "v")
+        // No secret / API key.
+        XCTAssertNil(body["client_secret"])
+        XCTAssertNil(body["api_key"])
+    }
+
+    func test_sessionExchangeBody_shape() {
+        let body = WorkOSPKCE.sessionExchangeBody(clientID: "c", accessToken: "at")
+        XCTAssertEqual(body["provider"] as? String, "workos")
+        XCTAssertEqual(body["process"] as? String, "login")
+        let token = body["token"] as? [String: String]
+        XCTAssertEqual(token?["client_id"], "c")
+        XCTAssertEqual(token?["access_token"], "at")
+    }
+
+    func test_configURL_appendsPathAndStripsQuery() {
+        let url = WorkOSPKCE.configURL(platformOrigin: "https://platform.vellum.ai/some/path?x=1")
+        XCTAssertEqual(url?.absoluteString, "https://platform.vellum.ai/_allauth/app/v1/config")
+    }
+
+    func test_sessionExchangeURL_appendsPath() {
+        let url = WorkOSPKCE.sessionExchangeURL(platformOrigin: "http://localhost:8000")
+        XCTAssertEqual(url?.absoluteString, "http://localhost:8000/_allauth/app/v1/auth/provider/token")
+    }
+
+    func test_codeExchangeURL() {
+        XCTAssertEqual(
+            WorkOSPKCE.codeExchangeURL()?.absoluteString,
+            "https://api.workos.com/user_management/authenticate"
+        )
+    }
+
+    // MARK: - Response parsing
+
+    func test_parseAccessToken_success() throws {
+        let data = #"{"access_token": "tok_123", "user": {"id": "u"}}"#.data(using: .utf8)!
+        XCTAssertEqual(try WorkOSPKCE.parseAccessToken(data), "tok_123")
+    }
+
+    func test_parseAccessToken_missingThrows() {
+        let data = #"{"error": "invalid_grant"}"#.data(using: .utf8)!
+        XCTAssertThrowsError(try WorkOSPKCE.parseAccessToken(data))
+    }
+
+    func test_parseSessionToken_success() throws {
+        let data = #"{"status": 200, "meta": {"session_token": "sess_abc", "is_authenticated": true}}"#.data(using: .utf8)!
+        XCTAssertEqual(try WorkOSPKCE.parseSessionToken(data), "sess_abc")
+    }
+
+    func test_parseSessionToken_missingThrows() {
+        let data = #"{"status": 200, "meta": {"is_authenticated": false}}"#.data(using: .utf8)!
+        XCTAssertThrowsError(try WorkOSPKCE.parseSessionToken(data))
+    }
+}


### PR DESCRIPTION
ref ATL-842

Migrates the native Swift macOS client from the server-mediated native flow (`/accounts/native/*`) to app-held WorkOS PKCE — restoring the client-side PKCE removed in #26262, but against the new User Management contract (`provider=workos`, public-client `authenticate`, allauth `provider/token`) instead of the old Connect-OIDC one. Mirrors the Electron/CLI/extension clients.

- New `WorkOSPKCE.swift` (pure: PKCE via CryptoKit, authorize URL, config selection, callback parse with state/CSRF check, exchange request/response builders — isolation-typecheckable + unit-tested). `AuthService`/`AuthManager` drive the network + the **existing, unchanged** `performWebAuth` (non-ephemeral `ASWebAuthenticationSession`, so the user's Safari IdP session is reused — no Google re-login). Session token stored in Keychain as before.
- Custom-scheme redirect (`{scheme}://auth/callback`) — same scheme strings iOS uses; already registered on the UM apps (prod + dev/staging).

**Checks:** `WorkOSPKCE.swift` typechecks in isolation; `swift build --target VellumAssistantShared` succeeds; 25 PKCE unit tests pass. Full `.app` build / e2e needs Xcode — manual QA: sign in, confirm the AuthKit sheet reuses the Safari session and the session lands in Keychain. Server `/accounts/native/*` untouched for old builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)