### PR TITLE
fix(macos): reclaim stale Vite dev port before standalone dev start

### DIFF
--- a/apps/macos/package.json
+++ b/apps/macos/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "postinstall": "node node_modules/electron/install.js && bun run scripts/install-file-deps.ts && bash scripts/build-mac-helper.sh",
     "dev": "bun run install:all && bun scripts/dev.ts",
-    "dev:standalone": "bun run install:all && concurrently --kill-others --names web,electron --prefix-colors blue,green \"bun run dev:web\" \"bun run dev:electron\"",
+    "dev:standalone": "bun run install:all && bun run scripts/reclaim-dev-port.ts && concurrently --kill-others --names web,electron --prefix-colors blue,green \"bun run dev:web\" \"bun run dev:electron\"",
     "dev:electron-only": "bun install && bun run prepare:electron-dev && electron-vite dev",
     "install:all": "bun install && cd ../web && bun install",
     "dev:web": "cd ../web && bun run dev -- --port 5173 --strictPort",

--- a/apps/macos/scripts/reclaim-dev-port.ts
+++ b/apps/macos/scripts/reclaim-dev-port.ts
@@ -1,0 +1,103 @@
+#!/usr/bin/env bun
+/**
+ * Pre-flight reclaim for the standalone dev port (5173).
+ *
+ * Our standalone dev server binds Vite with `--strictPort`, because
+ * `dev:electron` waits on the fixed URL `http://localhost:5173`. The
+ * tradeoff is that a *stale* Vite — orphaned to PID 1 when a previous
+ * `bun run dev` was force-quit, crashed, or torn down without signals
+ * reaching the deeply-nested `bun → bun → vite` leaf — makes the next
+ * run fail with "Port 5173 is already in use" instead of recovering.
+ *
+ * Signal-handler hardening can't fully prevent that: SIGKILL and hard
+ * crashes leave orphans no matter what. So we reclaim the port here,
+ * right before `concurrently` starts Vite. We only kill a process that
+ * actually looks like our dev server (a `vite` listener) — an unrelated
+ * service squatting on 5173 is left alone so Vite's strictPort error
+ * still surfaces, just with a clearer log above it.
+ *
+ * Best-effort by design: every failure is caught and logged as a
+ * warning, then we return so dev startup is never blocked by this shim.
+ */
+import { execFileSync } from "node:child_process";
+
+const DEFAULT_PORT = 5173;
+const port = Number(process.argv[2] ?? process.env.VELLUM_DEV_PORT ?? DEFAULT_PORT);
+
+/** PIDs currently LISTENing on the port, or [] if none / lookup failed. */
+function listenersOn(p: number): number[] {
+  try {
+    const out = execFileSync("lsof", ["-ti", `tcp:${p}`, "-sTCP:LISTEN"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return out
+      .split("\n")
+      .map((line) => Number(line.trim()))
+      .filter((pid) => Number.isInteger(pid) && pid > 0);
+  } catch {
+    // lsof exits non-zero when nothing is listening — that's the happy path.
+    return [];
+  }
+}
+
+/** The full command line for a PID, or "" if it can't be read. */
+function commandFor(pid: number): string {
+  try {
+    return execFileSync("ps", ["-o", "command=", "-p", String(pid)], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+function reclaim(): void {
+  if (!Number.isInteger(port) || port <= 0) return;
+
+  for (const pid of listenersOn(port)) {
+    const command = commandFor(pid);
+
+    // Only reclaim our own dev server. Anything else gets a heads-up and is
+    // left running so Vite's own strictPort error still fires.
+    if (!/\bvite\b/.test(command)) {
+      console.warn(
+        `[dev] port ${port} held by PID ${pid} (${command || "unknown"}), ` +
+          `which is not a Vite dev server — leaving it. Vite will report the conflict.`,
+      );
+      continue;
+    }
+
+    console.log(
+      `[dev] reclaiming port ${port} from stale Vite (PID ${pid}) — ` +
+        `likely orphaned by a previous dev run.`,
+    );
+    try {
+      process.kill(pid, "SIGTERM");
+    } catch {
+      // Already gone between lookup and kill — nothing to do.
+      continue;
+    }
+
+    // Give it a moment to release the socket; escalate to SIGKILL if it clings.
+    const deadline = Date.now() + 2000;
+    while (Date.now() < deadline && listenersOn(port).includes(pid)) {
+      execFileSync("sleep", ["0.1"], { stdio: "ignore" });
+    }
+    if (listenersOn(port).includes(pid)) {
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {
+        /* raced to exit */
+      }
+    }
+  }
+}
+
+try {
+  reclaim();
+} catch (err) {
+  // Never let the reclaim shim block dev startup.
+  console.warn(`[dev] port reclaim skipped: ${(err as Error).message}`);
+}


### PR DESCRIPTION
## Summary
- Add `apps/macos/scripts/reclaim-dev-port.ts`, a best-effort pre-flight that frees port 5173 before `concurrently` starts Vite in the standalone dev path. It kills only a stale *Vite* listener (SIGTERM, then SIGKILL after a 2s grace) and leaves any unrelated process alone so Vite's own strictPort error still surfaces.
- Wire it into `dev:standalone` so both `bun run dev` (via `dev.ts`) and a direct `dev:standalone` self-heal from a Vite orphaned by a previous force-quit/crash. The `vel up` path (`dev:electron-only`) is unaffected since it never binds 5173.
- Fixes the recurring `Port 5173 is already in use` failure: Vite runs with `--strictPort` (required because `dev:electron` waits on the fixed `http://localhost:5173`), so a leftover orphan made every subsequent dev start fail hard.

## Original prompt
While starting the Electron app, `bun run dev` failed with `Port 5173 is already in use`. We traced it to a Vite dev server orphaned to PID 1 by a prior dev run that was torn down without signals reaching the deeply-nested `bun -> bun -> vite` leaf. The ask was how to prevent recurrence. Since SIGKILL/crash orphans can't be trapped by signal handlers, the robust fix is to reclaim the contended port at startup rather than try to harden teardown.