### PR TITLE
fix(web): render LLM Context Inspector prompt sections as raw text

### DIFF
--- a/apps/web/src/domains/chat/inspector/components/tabs/prompt-tab.test.tsx
+++ b/apps/web/src/domains/chat/inspector/components/tabs/prompt-tab.test.tsx
@@ -1,8 +1,8 @@
 /**
  * Tests for the PromptTab section rendering. Renders to static markup
- * (no DOM), mirroring `compaction-tab.test.tsx`, and asserts that text
- * sections render as Markdown while tool results render as code-style
- * `<pre>` text.
+ * (no DOM), mirroring `compaction-tab.test.tsx`, and asserts that every
+ * section renders as raw code-style `<pre>` text — Markdown syntax in a
+ * prompt is shown literally, never formatted.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -29,20 +29,25 @@ function render(sections: LLMContextSection[]): string {
 }
 
 describe("PromptTab", () => {
-  test("renders text sections as Markdown", () => {
+  test("renders text sections as raw text, not Markdown", () => {
     const html = render([
       {
         kind: "message",
         label: "User message 1",
         role: "user",
         toolName: null,
-        text: "# Heading\n\nplain prose",
+        text: "# Heading\n\n**bold** prose",
         data: null,
       },
     ]);
 
-    expect(html).toContain("<h1");
-    expect(html).toContain("Heading");
+    // No Markdown processing: the raw syntax is shown literally inside a
+    // <pre>, with no <h1>/<strong> elements emitted.
+    expect(html).not.toContain("<h1");
+    expect(html).not.toContain("<strong");
+    expect(html).toContain("<pre");
+    expect(html).toContain("# Heading");
+    expect(html).toContain("**bold** prose");
   });
 
   test("preserves XML-style prompt delimiters as literal text", () => {

--- a/apps/web/src/domains/chat/inspector/components/tabs/prompt-tab.tsx
+++ b/apps/web/src/domains/chat/inspector/components/tabs/prompt-tab.tsx
@@ -1,7 +1,6 @@
 import { Copy } from "lucide-react";
 import { type ReactNode } from "react";
 
-import { FileMarkdown } from "@/components/file-markdown";
 import { ToolDefinitionsCard } from "@/domains/chat/inspector/components/tool-definitions-card";
 import { parseToolDefinitions } from "@/domains/chat/inspector/tool-definitions";
 import type {
@@ -16,10 +15,12 @@ interface PromptTabProps {
 
 /**
  * Prompt tab rendering each normalized request section as a card.
- * Text sections render as Markdown; structured payloads and tool
- * results render as code-style `<pre>` text — tool output is program
- * output, not prose. Tool definitions render as an expandable per-tool
- * breakdown. The raw provider JSON lives on the Raw tab.
+ * Every section renders as raw `<pre>` text so the prompt is shown
+ * exactly as sent — no Markdown formatting applied. Structured payloads
+ * and tool output stay in a capped scroll box (they can be huge);
+ * prompt text renders uncapped so the full prompt is readable inline.
+ * Tool definitions render as an expandable per-tool breakdown. The raw
+ * provider JSON lives on the Raw tab.
  */
 export function PromptTab({ entry }: PromptTabProps): ReactNode {
   const sections = entry.requestSections ?? [];
@@ -93,7 +94,9 @@ function SectionCard({ section, index }: SectionCardProps): ReactNode {
   const kind = humanKindLabel(section.kind);
   const formatLabel = languageFormatLabel(section.language ?? null);
   const { text, isStructured } = renderContent(section);
-  const renderAsCode = isStructured || isToolResultKind(section.kind);
+  // Tool output and structured payloads can be huge, so cap their height
+  // into a scroll box; prompt text stays uncapped for inline reading.
+  const capHeight = isStructured || isToolResultKind(section.kind);
 
   return (
     <Card>
@@ -132,29 +135,16 @@ function SectionCard({ section, index }: SectionCardProps): ReactNode {
         />
       </div>
 
-      {renderAsCode ? (
-        <pre
-          className="mt-3 overflow-auto whitespace-pre-wrap break-words rounded-md p-3 text-body-small-default"
-          style={{
-            background: "var(--surface-base)",
-            color: "var(--content-default)",
-            maxHeight: "320px",
-          }}
-        >
-          {text}
-        </pre>
-      ) : (
-        <div
-          className="mt-3 min-w-0 break-words"
-          style={{ color: "var(--content-default)" }}
-        >
-          <FileMarkdown
-            content={text}
-            stripFrontmatter={false}
-            parseHtml={false}
-          />
-        </div>
-      )}
+      <pre
+        className="mt-3 overflow-auto whitespace-pre-wrap break-words rounded-md p-3 text-body-small-default"
+        style={{
+          background: "var(--surface-base)",
+          color: "var(--content-default)",
+          ...(capHeight ? { maxHeight: "320px" } : {}),
+        }}
+      >
+        {text}
+      </pre>
     </Card>
   );
 }


### PR DESCRIPTION
## Summary
- The LLM Context Inspector's Prompt tab rendered text sections (system prompt, messages) through `FileMarkdown`, so Markdown syntax in the prompt was formatted — bold `**CRITICAL:**`, inline-code styling on terms like `glob`/`grep`, headings — instead of shown verbatim.
- Render every prompt section as raw `<pre>` text so the prompt appears exactly as it was sent to the model. Tool output and structured payloads keep their capped scroll box (they can be huge); prompt text stays uncapped for inline reading.
- Removed the now-unused `FileMarkdown` import and updated the PromptTab test to assert raw-text rendering.

## Original prompt
In the macOS/Electron app's LLM Context Inspector, the prompt content on the Prompt tab was being rendered as formatted Markdown (bold "CRITICAL:", inline-code styling on backticked terms). The ask was to stop Markdown-formatting the prompt and show it as raw text, so the inspector reflects exactly what was sent to the model.