### PR TITLE
fix(web): make the LLM Context Inspector back button clickable on macOS

### DIFF
--- a/apps/web/src/domains/chat/inspector/inspect-page.tsx
+++ b/apps/web/src/domains/chat/inspector/inspect-page.tsx
@@ -27,6 +27,7 @@ import {
     supportsLlmContextSummaryView,
     useSupportsLlmContextSummaryView,
 } from "@/lib/backwards-compat/llm-context-summary-view";
+import { isElectron } from "@/runtime/is-electron";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useIsSessionInitializing } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
@@ -114,6 +115,7 @@ interface InspectorProps {
 
 function Inspector({ conversationId, messageId }: InspectorProps): ReactNode {
   const assistantId = useActiveAssistantId();
+  const electron = isElectron();
   const {
     data,
     isLoading: isLoadingContext,
@@ -168,8 +170,18 @@ function Inspector({ conversationId, messageId }: InspectorProps): ReactNode {
     [conversationId, messageId],
   );
 
+  // On the Electron macOS shell the window runs with a hidden title bar, so a
+  // global `WindowDragRegion` drag strip and the traffic lights occupy the top
+  // of the renderer. This standalone route has no inline title bar to claim that
+  // band (only chat does), so — like `SidebarShell` — reserve top space to clear
+  // the controls. Without it the header's back button sits under the drag strip
+  // and its clicks are swallowed by window dragging. Off Electron the layout is
+  // unchanged.
   return (
-    <div className="flex h-full min-h-0 flex-col">
+    <div
+      className="flex h-full min-h-0 flex-col"
+      style={electron ? { paddingTop: "2.75rem" } : undefined}
+    >
       <Header
         assistantId={assistantId}
         conversationId={conversationId}


### PR DESCRIPTION
## Summary

- On the Electron macOS shell, the LLM Context Inspector renders at the very top of the renderer, where the global `WindowDragRegion` strip (a 28px `-webkit-app-region: drag` band) and the macOS traffic lights sit. The route never claims an inline title bar — only chat routes do — so the back button sat *under* that drag band and its clicks (the left arrow worst of all, being top-left-most) were swallowed by window dragging.
- Mirror the established `SidebarShell` pattern for non-chat routes: reserve top space (Electron-only) so the inspector header clears the title-bar band. Window dragging via the global strip and text-selection of the message ID are both preserved, and the web / Capacitor iOS layouts are byte-for-byte unchanged.

## Original prompt

In the Electron macOS app, the small left-arrow next to "Back" in the LLM Context Inspector header was not acting as part of the back button — clicking the arrow did nothing while "Back" worked. The ask was to make that arrow function as part of the back button. The root cause is the macOS window's hidden title bar: a full-width drag region overlays the top of the renderer and eats pointer events on anything beneath it, so the fix reserves title-bar space (as other non-chat routes already do) to lift the back button out of that band.