### PR TITLE
fix(web): accept emoji autocomplete suggestion on Tab

### DIFF
--- a/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/apps/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -445,7 +445,7 @@ export function ChatComposer({
                       emoji.moveDown();
                       return;
                     }
-                    if (e.key === "Enter") {
+                    if (e.key === "Tab" || e.key === "Enter") {
                       e.preventDefault();
                       const selected = emoji.items[emoji.selectedIndex];
                       if (selected) insertEmoji(selected);


### PR DESCRIPTION
## Summary
- In the chat composer, pressing Tab while the emoji autocomplete dropdown is open now accepts the highlighted emoji (same as Enter) instead of moving focus to the next field.
- Mirrors the existing slash-command typeahead handler, which already accepts both Tab and Enter — the emoji handler was the only one still defaulting Tab to focus traversal.

## Original prompt
While the emoji autocomplete dropdown is showing in the desktop (Electron) app — e.g. typing `:smirk` surfaces `:smirk:` / `:smirk_cat:` — pressing Tab should accept the highlighted emoji like Enter does, rather than shifting focus out of the composer. This brings emoji selection in line with the slash-command typeahead.