### PR TITLE
fix(web): keep the thinking indicator up until visible content renders

### DIFF
--- a/apps/web/src/domains/chat/hooks/use-chat-debug-registration.ts
+++ b/apps/web/src/domains/chat/hooks/use-chat-debug-registration.ts
@@ -42,7 +42,7 @@ export interface UseChatDebugRegistrationOptions {
  */
 const EMPTY_UI_CONTEXT: UIContext = {
   hasStreamingAssistantMessage: false,
-  hasStreamingAssistantThinking: false,
+  hasVisibleResponseContent: false,
   hasPendingSecret: false,
   hasPendingConfirmation: false,
   hasPendingQuestion: false,

--- a/apps/web/src/domains/chat/hooks/use-chat-ui-state.ts
+++ b/apps/web/src/domains/chat/hooks/use-chat-ui-state.ts
@@ -100,17 +100,27 @@ export function useChatUIState(): ChatUIState {
   );
   const hasStreamingAssistantMessage = liveAssistantMessageId != null;
 
-  // True once the live assistant message has emitted reasoning content — at
-  // which point an inline `SingleActivity` is rendering it (and owning the
-  // streaming "Thinking" loading state). Used to hand off from the standalone
-  // thinking-dots row so the two indicators never compete.
-  const hasStreamingAssistantThinking = useMemo(() => {
+  // True once the live assistant row renders something visible — streamed
+  // text, reasoning (the inline `SingleActivity` owns the loading state
+  // then), a tool-call chip, or a surface. The standalone thinking-dots row
+  // yields to this, and ONLY this: a live bubble with no renderable content
+  // must keep the dots up, or the transcript reads as stalled (see
+  // `shouldShowThinkingIndicator`).
+  const hasVisibleResponseContent = useMemo(() => {
     if (liveAssistantMessageId == null) return false;
     const live = messages.find((m) => m.id === liveAssistantMessageId);
     if (!live) return false;
     return (
+      (live.textSegments?.some((s) => s.trim().length > 0) ?? false) ||
       (live.thinkingSegments?.length ?? 0) > 0 ||
-      !!live.contentBlocks?.some((b) => b.type === "thinking")
+      (live.toolCalls?.length ?? 0) > 0 ||
+      (live.surfaces?.length ?? 0) > 0 ||
+      !!live.contentBlocks?.some(
+        (b) =>
+          b.type === "thinking" ||
+          b.type === "tool_use" ||
+          (b.type === "text" && b.text.trim().length > 0),
+      )
     );
   }, [messages, liveAssistantMessageId]);
 
@@ -122,7 +132,7 @@ export function useChatUIState(): ChatUIState {
   const uiContext: UIContext = useMemo(
     () => ({
       hasStreamingAssistantMessage,
-      hasStreamingAssistantThinking,
+      hasVisibleResponseContent,
       hasPendingSecret: !!pendingSecret,
       hasPendingConfirmation: !!pendingConfirmation,
       hasPendingQuestion: !!pendingQuestion,
@@ -133,7 +143,7 @@ export function useChatUIState(): ChatUIState {
     }),
     [
       hasStreamingAssistantMessage,
-      hasStreamingAssistantThinking,
+      hasVisibleResponseContent,
       pendingSecret,
       pendingConfirmation,
       pendingQuestion,

--- a/apps/web/src/domains/chat/turn-selectors.ts
+++ b/apps/web/src/domains/chat/turn-selectors.ts
@@ -5,7 +5,7 @@
  * previously scattered across the component tree.
  */
 
-import { type TurnPhase, isSending, isThinking } from "@/domains/chat/turn-store";
+import { type TurnPhase, isSending } from "@/domains/chat/turn-store";
 
 // ---------------------------------------------------------------------------
 // UI context — values provided by the component that are NOT part of the
@@ -14,11 +14,17 @@ import { type TurnPhase, isSending, isThinking } from "@/domains/chat/turn-store
 
 export interface UIContext {
   hasStreamingAssistantMessage: boolean;
-  /** True when the live assistant message already carries reasoning/thinking
-   * content — i.e. an inline `SingleActivity` is showing it (and owning the
-   * streaming "Thinking" state). Gates off the standalone thinking-dots row so
-   * the two don't both render; the dots stay only for the pre-message window. */
-  hasStreamingAssistantThinking: boolean;
+  /** True when the live assistant row renders something the user can see —
+   * non-blank text, reasoning content (the inline `SingleActivity` owns the
+   * loading state then), a tool-call chip (including a streaming preview
+   * block), or a surface. This is the single handoff gate for the standalone
+   * thinking-dots row: the dots stay up for the entire window where the
+   * response area would otherwise be empty, and yield only once a visible
+   * element has actually replaced them. A live assistant bubble with no
+   * renderable content (e.g. created by an aux LLM call that produced no
+   * visible output) must NOT count — that was the "blank transcript while
+   * generating" bug. */
+  hasVisibleResponseContent: boolean;
   hasPendingSecret: boolean;
   hasPendingConfirmation: boolean;
   hasPendingQuestion: boolean;
@@ -40,22 +46,16 @@ export interface UIContext {
 /**
  * Whether the "Thinking..." indicator should be visible.
  *
- * Mirrors macOS TranscriptProjector.wouldShowThinking:
- *   isSending && (isThinking || !hasStreamingAssistantMessage) && !hasActiveToolCall
- *
- * Show the dots whenever the turn is actively processing, no assistant
- * text is streaming yet, and no tool call is in-flight. The fallback
- * `!hasStreamingAssistantMessage` keeps the dots visible even after the
- * phase moves past "thinking" (e.g. after a tool call completes before
- * any text arrives).
- *
- * Unlike macOS, this standalone row hands off to the inline
- * {@link SingleActivity} as soon as the live assistant message carries
- * reasoning content (`hasStreamingAssistantThinking`) — that link renders the
- * same three-dot "Thinking" loading state inline and is clickable to open the
- * streaming reasoning. So the dots row is scoped to the pre-reasoning window
- * (no assistant bubble yet, or a bubble that hasn't emitted reasoning) to avoid
- * two competing thinking indicators.
+ * Invariant: while a turn is in flight, the response area is never empty.
+ * The dots show for the entire window where nothing visible has rendered
+ * yet, and yield only to actual visible content
+ * (`hasVisibleResponseContent`) — streamed text, the inline reasoning
+ * `SingleActivity`, a tool-call chip (including a streaming preview block),
+ * or a surface. Gating on visible content rather than on bubble existence
+ * or phase choreography keeps the dots up across mid-turn hiccups — e.g.
+ * an aux LLM call's `message_complete` arriving while the real generation
+ * is still pending, which previously killed the dots and left the
+ * transcript blank for the rest of the model's time-to-first-token.
  *
  * Each potentially-competing UI surface has its own explicit gate:
  * pending secret/confirmation/question/contact prompts, and any
@@ -83,9 +83,7 @@ export function shouldShowThinkingIndicator(
     !ctx.hasPendingQuestion &&
     !ctx.hasPendingContactRequest &&
     !ctx.hasUncompletedVisibleSurface &&
-    (isThinking(phase) || restoredProcessing || !ctx.hasStreamingAssistantMessage) &&
-    // Inline SingleActivity owns the loading state once reasoning is present.
-    !ctx.hasStreamingAssistantThinking &&
+    !ctx.hasVisibleResponseContent &&
     activeToolCallCount === 0
   );
 }

--- a/apps/web/src/domains/chat/turn-store.test.ts
+++ b/apps/web/src/domains/chat/turn-store.test.ts
@@ -29,7 +29,7 @@ function applyEvents(
 
 const defaultCtx: UIContext = {
   hasStreamingAssistantMessage: false,
-  hasStreamingAssistantThinking: false,
+  hasVisibleResponseContent: false,
   hasPendingSecret: false,
   hasPendingConfirmation: false,
   hasPendingQuestion: false,
@@ -421,22 +421,25 @@ describe("ACTIVITY_STATE_THINKING", () => {
     expect(state.phase).toBe("thinking");
   });
 
-  test("is discarded when idle with null activeTurnId", () => {
+  test("revives a wrongly-idled turn", () => {
+    // A non-idle daemon activity state is authoritative liveness — it must
+    // restore the sending phase even from idle, because an aux LLM call's
+    // message_complete/idle can clobber the phase mid-turn while the real
+    // generation is still running. Out-of-order events are dropped upstream
+    // by the SSE handler's activityVersion gate.
     const state = turnReducer(INITIAL_TURN_STATE, {
       type: "ACTIVITY_STATE_THINKING",
     });
-    expect(state.phase).toBe("idle");
-    expect(state).toBe(INITIAL_TURN_STATE);
+    expect(state.phase).toBe("thinking");
   });
 
-  test("is discarded when errored with null activeTurnId", () => {
+  test("revives from errored: daemon activity outranks a local error verdict", () => {
     const errored: TurnState = {
       ...INITIAL_TURN_STATE,
       phase: "errored",
     };
     const state = turnReducer(errored, { type: "ACTIVITY_STATE_THINKING" });
-    expect(state.phase).toBe("errored");
-    expect(state).toBe(errored);
+    expect(state.phase).toBe("thinking");
   });
 
   test("does not affect activeToolCallCount", () => {
@@ -1244,7 +1247,7 @@ describe("shouldShowThinkingIndicator", () => {
     ).toBe(true);
   });
 
-  test("hidden when streaming and assistant text is present", () => {
+  test("hidden when streaming and visible assistant text is present", () => {
     const streaming = applyEvents(INITIAL_TURN_STATE, [
       { type: "USER_SEND_REQUESTED" },
       { type: "ASSISTANT_TEXT_DELTA" },
@@ -1253,6 +1256,7 @@ describe("shouldShowThinkingIndicator", () => {
       shouldShowThinkingIndicator(streaming.phase, streaming.activeToolCallCount, {
         ...defaultCtx,
         hasStreamingAssistantMessage: true,
+        hasVisibleResponseContent: true,
       }),
     ).toBe(false);
   });
@@ -1350,10 +1354,11 @@ describe("shouldShowThinkingIndicator", () => {
     ).toBe(true);
   });
 
-  test("hidden once the live message has reasoning content (inline link owns it)", () => {
-    // Same thinking phase as above, but the live assistant message has emitted
-    // reasoning — an inline SingleActivity is now showing the loading state,
-    // so the standalone dots row defers to avoid two competing indicators.
+  test("hidden once the live message renders visible content (inline UI owns it)", () => {
+    // Same thinking phase as above, but the live assistant message has
+    // visible content (e.g. streamed reasoning) — an inline SingleActivity
+    // is showing the loading state, so the standalone dots row defers to
+    // avoid two competing indicators.
     const afterTool = applyEvents(INITIAL_TURN_STATE, [
       { type: "USER_SEND_REQUESTED", turnId: "t-1" },
       { type: "ASSISTANT_TEXT_DELTA" },
@@ -1366,14 +1371,15 @@ describe("shouldShowThinkingIndicator", () => {
       shouldShowThinkingIndicator(afterTool.phase, afterTool.activeToolCallCount, {
         ...defaultCtx,
         hasStreamingAssistantMessage: true,
-        hasStreamingAssistantThinking: true,
+        hasVisibleResponseContent: true,
       }),
     ).toBe(false);
   });
 
-  test("still visible pre-reasoning: bubble exists but no thinking content yet", () => {
-    // A streaming assistant bubble with no reasoning content → the inline link
-    // isn't showing, so the standalone dots must remain to signal progress.
+  test("still visible when a live bubble exists but renders nothing yet", () => {
+    // A live assistant bubble with no visible content (e.g. created by an
+    // aux LLM call that produced no renderable output) → the dots must
+    // remain, or the transcript reads as stalled while the model works.
     const thinking = applyEvents(INITIAL_TURN_STATE, [
       { type: "USER_SEND_REQUESTED", turnId: "t-1" },
       { type: "ACTIVITY_STATE_THINKING" },
@@ -1382,7 +1388,20 @@ describe("shouldShowThinkingIndicator", () => {
       shouldShowThinkingIndicator(thinking.phase, thinking.activeToolCallCount, {
         ...defaultCtx,
         hasStreamingAssistantMessage: true,
-        hasStreamingAssistantThinking: false,
+        hasVisibleResponseContent: false,
+      }),
+    ).toBe(true);
+  });
+
+  test("visible during streaming phase while nothing has rendered yet", () => {
+    // Mid-turn false-idle recovery: the daemon's tool_running/streaming
+    // activity re-enters "streaming"; with no visible response content the
+    // dots must show — phase choreography alone must never blank the UI.
+    expect(
+      shouldShowThinkingIndicator("streaming", 0, {
+        ...defaultCtx,
+        hasStreamingAssistantMessage: true,
+        hasVisibleResponseContent: false,
       }),
     ).toBe(true);
   });

--- a/apps/web/src/domains/chat/turn-store.ts
+++ b/apps/web/src/domains/chat/turn-store.ts
@@ -49,7 +49,7 @@ export interface TurnState {
   lastTerminalReason: TerminalReason;
   /** Daemon-provided label describing current agent activity (e.g.
    *  "Processing bash results", "Compacting context"). Populated by
-   *  `onActivityThinking` and cleared on terminal transitions. */
+   *  `onDaemonActivity` and cleared on terminal transitions. */
   statusText: string | null;
   /**
    * Per-tool-call structured activity metadata (e.g. web_search,
@@ -262,7 +262,10 @@ export interface TurnActions {
     toolUseId: string,
     metadata: ToolActivityMetadata,
   ) => void;
-  onActivityThinking: (statusText?: string) => void;
+  onDaemonActivity: (
+    phase: "thinking" | "streaming" | "tool_running",
+    statusText?: string,
+  ) => void;
   showSurface: (interactive?: boolean) => void;
   updateSurface: () => void;
   dismissSurface: () => void;
@@ -383,15 +386,26 @@ const useTurnStoreBase = create<TurnStore>()((set, get) => ({
 
   // ----- Daemon activity state -----
 
-  onActivityThinking: (statusText) => {
+  onDaemonActivity: (phase, statusText) => {
     const s = get();
-    // Server-driven thinking signal — the daemon reports that the agent
-    // is processing (e.g. after a tool_result, during context compaction,
-    // or after confirmation resolution). Transition back to "thinking"
-    // so the thinking indicator re-appears in the post-tool-call gap.
-    if (isStale(s)) return;
+    // Server-driven liveness signal — the daemon reports the agent is
+    // processing (thinking after a tool_result, streaming text, running or
+    // preparing a tool). Re-enter the matching sending phase so the
+    // in-flight affordances stay accurate.
+    //
+    // Deliberately NO isStale() discard: a non-idle activity state is
+    // authoritative evidence that a generation is running, including after
+    // this client wrongly ended the turn — an aux LLM call's
+    // message_complete/idle can arrive mid-turn and clobber phase to
+    // "idle", which used to kill the thinking indicator for the rest of
+    // the real generation. Out-of-order events are already dropped by the
+    // SSE handler's per-conversation activityVersion gate, and a genuine
+    // terminal emits a later idle (higher version) that restores "idle".
     if (s.phase === "awaiting_user_input") return;
-    set({ phase: "thinking", statusText: statusText ?? null });
+    set({
+      phase: phase === "thinking" ? "thinking" : "streaming",
+      statusText: statusText ?? null,
+    });
   },
 
   // ----- UI surfaces -----
@@ -672,7 +686,9 @@ export function turnReducer(state: TurnState, event: DomainEvent): TurnState {
       };
 
     case "ACTIVITY_STATE_THINKING":
-      if (isStale(state)) return state;
+      // Parity with `onDaemonActivity`: no isStale() discard — a non-idle
+      // daemon activity state revives a wrongly-idled turn (see the action
+      // for the full rationale).
       if (state.phase === "awaiting_user_input") return state;
       return { ...state, phase: "thinking", statusText: event.statusText ?? null };
 

--- a/apps/web/src/domains/chat/utils/debug-api.test.ts
+++ b/apps/web/src/domains/chat/utils/debug-api.test.ts
@@ -57,7 +57,7 @@ function fakeRuntimeMessage(overrides: Partial<ConversationMessage> = {}): Conve
 
 const DEFAULT_UI_CONTEXT: UIContext = {
   hasStreamingAssistantMessage: false,
-  hasStreamingAssistantThinking: false,
+  hasVisibleResponseContent: false,
   hasPendingSecret: false,
   hasPendingConfirmation: false,
   hasPendingQuestion: false,
@@ -392,7 +392,32 @@ describe("createChatDebugApi.thinkingIndicator", () => {
     expect(snapshot.done.lastTerminalReason).toBe("complete");
   });
 
-  test("streaming with assistant message in flight → hidden with streamingAssistantMessageActive", () => {
+  test("streaming with visible response content → hidden with hasVisibleResponseContent", () => {
+    const refs = makeRefs({
+      turn: {
+        ...INITIAL_TURN_STATE,
+        phase: "streaming",
+        activeTurnId: "turn-1",
+      },
+      uiContext: {
+        hasStreamingAssistantMessage: true,
+        hasVisibleResponseContent: true,
+      },
+    });
+    const api = createChatDebugApi(refs);
+
+    const snapshot = api.thinkingIndicator();
+
+    expect(snapshot.visible).toBe(false);
+    expect(snapshot.failingConditions).toEqual([
+      "hasVisibleResponseContent",
+    ]);
+    expect(snapshot.done.terminal).toBe(false);
+  });
+
+  test("streaming with a live bubble but nothing visible → dots stay on", () => {
+    // The mid-turn blank-window regression: a live assistant bubble with no
+    // renderable content must not suppress the indicator.
     const refs = makeRefs({
       turn: {
         ...INITIAL_TURN_STATE,
@@ -405,11 +430,8 @@ describe("createChatDebugApi.thinkingIndicator", () => {
 
     const snapshot = api.thinkingIndicator();
 
-    expect(snapshot.visible).toBe(false);
-    expect(snapshot.failingConditions).toEqual([
-      "streamingAssistantMessageActive",
-    ]);
-    expect(snapshot.done.terminal).toBe(false);
+    expect(snapshot.visible).toBe(true);
+    expect(snapshot.failingConditions).toEqual([]);
   });
 
   test("active tool call suppresses indicator (activeToolCallCount>0)", () => {

--- a/apps/web/src/domains/chat/utils/debug-api.ts
+++ b/apps/web/src/domains/chat/utils/debug-api.ts
@@ -95,9 +95,9 @@ export interface ChatDebugThinkingConditions {
   hasPendingContactRequest: boolean;
   hasUncompletedVisibleSurface: boolean;
   hasStreamingAssistantMessage: boolean;
-  /** True when the live assistant message already has reasoning content, so the
-   * inline `SingleActivity` owns the loading state and the dots row defers. */
-  hasStreamingAssistantThinking: boolean;
+  /** True when the live assistant row renders visible content (text,
+   * reasoning, a tool chip, or a surface) — the dots row defers to it. */
+  hasVisibleResponseContent: boolean;
   activeConversationIsProcessing: boolean;
   hasPendingAssistantResponse: boolean;
 }
@@ -566,7 +566,7 @@ export function createChatDebugApi(refs: ChatDebugRefs): ChatDebugApi {
       hasPendingContactRequest: uiContext.hasPendingContactRequest,
       hasUncompletedVisibleSurface: uiContext.hasUncompletedVisibleSurface,
       hasStreamingAssistantMessage: uiContext.hasStreamingAssistantMessage,
-      hasStreamingAssistantThinking: uiContext.hasStreamingAssistantThinking,
+      hasVisibleResponseContent: uiContext.hasVisibleResponseContent,
       activeConversationIsProcessing:
         uiContext.activeConversationIsProcessing === true,
       hasPendingAssistantResponse:
@@ -595,17 +595,8 @@ export function createChatDebugApi(refs: ChatDebugRefs): ChatDebugApi {
     if (conditions.hasUncompletedVisibleSurface) {
       failingConditions.push("hasUncompletedVisibleSurface");
     }
-    if (
-      !(
-        conditions.isThinking ||
-        conditions.restoredProcessing ||
-        !conditions.hasStreamingAssistantMessage
-      )
-    ) {
-      failingConditions.push("streamingAssistantMessageActive");
-    }
-    if (conditions.hasStreamingAssistantThinking) {
-      failingConditions.push("hasStreamingAssistantThinking");
+    if (conditions.hasVisibleResponseContent) {
+      failingConditions.push("hasVisibleResponseContent");
     }
     if (conditions.activeToolCallCount > 0) {
       failingConditions.push("activeToolCallCount>0");

--- a/apps/web/src/domains/chat/utils/stream-handlers/message-handlers.test.ts
+++ b/apps/web/src/domains/chat/utils/stream-handlers/message-handlers.test.ts
@@ -144,7 +144,7 @@ describe("handleAssistantActivityState", () => {
       },
       ctx,
     );
-    expect(ctx.turnActions.onActivityThinking).not.toHaveBeenCalled();
+    expect(ctx.turnActions.onDaemonActivity).not.toHaveBeenCalled();
     expect(ctx.endTurn).not.toHaveBeenCalled();
   });
 
@@ -170,7 +170,7 @@ describe("handleAssistantActivityState", () => {
     expect(ctx.startReconciliationLoop).not.toHaveBeenCalled();
   });
 
-  it("calls onActivityThinking for thinking phase", () => {
+  it("calls onDaemonActivity for thinking phase", () => {
     const ctx = makeCtx();
     handleAssistantActivityState(
       {
@@ -184,12 +184,15 @@ describe("handleAssistantActivityState", () => {
       ctx,
     );
     expect(ctx.lastActivityVersionRef.current.get("conv-1")).toBe(2);
-    expect(ctx.turnActions.onActivityThinking).toHaveBeenCalledWith(undefined);
+    expect(ctx.turnActions.onDaemonActivity).toHaveBeenCalledWith(
+      "thinking",
+      undefined,
+    );
     expect(ctx.setMessages).not.toHaveBeenCalled();
     expect(ctx.startReconciliationLoop).not.toHaveBeenCalled();
   });
 
-  it("forwards statusText in onActivityThinking call", () => {
+  it("forwards statusText in onDaemonActivity call", () => {
     const ctx = makeCtx();
     handleAssistantActivityState(
       {
@@ -203,12 +206,38 @@ describe("handleAssistantActivityState", () => {
       },
       ctx,
     );
-    expect(ctx.turnActions.onActivityThinking).toHaveBeenCalledWith(
+    expect(ctx.turnActions.onDaemonActivity).toHaveBeenCalledWith(
+      "thinking",
       "Processing bash results",
     );
   });
 
-  it("returns early for non-idle, non-thinking phase", () => {
+  it("recovers liveness from tool_running phase (mid-turn false idle)", () => {
+    // An aux LLM call's message_complete/idle can wrongly end the local
+    // turn while the real generation is still running. The daemon's next
+    // tool_running activity (e.g. reason preview_start while tool args
+    // stream) must re-enter a sending phase so the UI isn't stuck blank.
+    const ctx = makeCtx();
+    handleAssistantActivityState(
+      {
+        type: "assistant_activity_state",
+        activityVersion: 8,
+        phase: "tool_running",
+        anchor: "assistant_turn",
+        reason: "preview_start",
+        statusText: "Preparing File Write...",
+        conversationId: "conv-1",
+      },
+      ctx,
+    );
+    expect(ctx.turnActions.onDaemonActivity).toHaveBeenCalledWith(
+      "tool_running",
+      "Preparing File Write...",
+    );
+    expect(ctx.endTurn).not.toHaveBeenCalled();
+  });
+
+  it("handles streaming phase as liveness", () => {
     const ctx = makeCtx();
     handleAssistantActivityState(
       {
@@ -226,7 +255,27 @@ describe("handleAssistantActivityState", () => {
         ctx.streamContext!.conversationId,
       ),
     ).toBe(1);
-    expect(ctx.turnActions.onActivityThinking).not.toHaveBeenCalled();
+    expect(ctx.turnActions.onDaemonActivity).toHaveBeenCalledWith(
+      "streaming",
+      undefined,
+    );
+    expect(ctx.endTurn).not.toHaveBeenCalled();
+  });
+
+  it("does not touch the turn phase for awaiting_confirmation", () => {
+    const ctx = makeCtx();
+    handleAssistantActivityState(
+      {
+        type: "assistant_activity_state",
+        activityVersion: 1,
+        phase: "awaiting_confirmation",
+        anchor: "assistant_turn",
+        reason: "confirmation_requested",
+        conversationId: "conv-1",
+      },
+      ctx,
+    );
+    expect(ctx.turnActions.onDaemonActivity).not.toHaveBeenCalled();
     expect(ctx.endTurn).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/domains/chat/utils/stream-handlers/message-handlers.ts
+++ b/apps/web/src/domains/chat/utils/stream-handlers/message-handlers.ts
@@ -181,18 +181,20 @@ export function handleAssistantActivityState(
     ctx.lastActivityVersionRef.current.set(convId, event.activityVersion);
   }
 
-  if (event.phase === "thinking") {
-    ctx.turnActions.onActivityThinking(event.statusText);
-    recordDiagnostic("sse_activity_state_thinking_handled", {
-      convId,
-      reason: event.reason,
-      activityVersion: event.activityVersion,
-    });
-    return;
-  }
-
   if (event.phase !== "idle") {
-    recordDiagnostic("sse_activity_state_non_idle", {
+    // Every running phase is a liveness signal: recover the local turn
+    // phase (it may have been wrongly idled by an aux LLM call's
+    // message_complete arriving mid-turn) and re-mark the conversation as
+    // processing so the indicator/stop affordances stay lit for the whole
+    // generation. `awaiting_confirmation` is excluded — the
+    // confirmation_request interaction flow owns the turn phase there.
+    if (event.phase !== "awaiting_confirmation") {
+      ctx.turnActions.onDaemonActivity(event.phase, event.statusText);
+      if (convId) {
+        markConversationProcessingFromStream(ctx, convId);
+      }
+    }
+    recordDiagnostic("sse_activity_state_non_idle_handled", {
       convId,
       phase: event.phase,
       reason: event.reason,

--- a/apps/web/src/domains/chat/utils/stream-handlers/test-helpers.ts
+++ b/apps/web/src/domains/chat/utils/stream-handlers/test-helpers.ts
@@ -48,7 +48,7 @@ export function makeCtx(
       onToolUseStart: mock(() => {}),
       onToolResult: mock(() => {}),
       onToolActivityMetadata: mock(() => {}),
-      onActivityThinking: mock(() => {}),
+      onDaemonActivity: mock(() => {}),
       showSurface: mock(() => {}),
       updateSurface: mock(() => {}),
       dismissSurface: mock(() => {}),


### PR DESCRIPTION
## Summary
- The standalone thinking-dots row was being torn down mid-turn, leaving the transcript **blank for seconds** while the model generated its first token / tool-call arguments (the "nothing happens until it says which tool" report).
- Root causes: (1) the dots deferred as soon as *any* assistant bubble existed (`!hasStreamingAssistantMessage`) or reasoning began (`hasStreamingAssistantThinking`) — so a live-but-**contentless** bubble suppressed them with nothing to replace them; (2) an intermediate `assistant_activity_state(idle)` (e.g. an aux turn's `message_complete`) clobbered the local phase to idle mid-turn, killing the dots until the next event.
- Fix: gate the dots on a single `hasVisibleResponseContent` signal (streamed text, reasoning, a tool chip incl. the streaming preview, or a surface) — **invariant: while a turn is in flight the response area is never empty, and the dots yield only to actual visible content**. Plus recover the turn phase from any non-idle daemon activity (`onDaemonActivity`) and re-mark the conversation processing, so a spurious mid-turn idle no longer strands the indicator.

## Verification
Verified live in-browser with a fine-grained indicator recorder + daemon trace:
- **Existing-conversation turns: zero blank frames** — timeline flows `thinking+dots → reasoning → tool preview chip`, continuously.
- Error path unaffected (dots show during thinking, clear on terminal).
- All touched chat-domain test files pass under the CI harness (`test:ci`, per-file isolation); `tsc` clean.

## Known residual (follow-up, not addressed here)
On a **new conversation's first message**, title-generation completes an *empty* assistant turn before real content, whose `message_complete` briefly ends the turn → a ~1s blank. Fully closing it means changing `message_complete`'s turn-termination semantics (rely solely on the idle activity state), which carries backwards-compat risk and is better scoped as its own change.

## Note
Independent of #34763 (tool-call preview streaming); different files. This is the UI-indicator companion to that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)