### PR TITLE
fix(memory): skip v2 graph retrieval under memory-v3-live

### DIFF
--- a/assistant/src/plugins/defaults/memory-retrieval/hooks/__tests__/user-prompt-submit.test.ts
+++ b/assistant/src/plugins/defaults/memory-retrieval/hooks/__tests__/user-prompt-submit.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+
+import { shouldRunV2Retrieval } from "../user-prompt-submit.js";
+
+/**
+ * v2 graph-memory retrieval is the deprecated path. It is gated off under
+ * `memory-v3-live` — v3 owns the injected-memory layer and runtime assembly
+ * strips any v2 `<memory>` block, so running v2's per-turn retrieval (embedding
+ * + hybrid search + the `memoryRetrieval` LLM router) would only have its
+ * result discarded. It is also skipped for untrusted actors. The
+ * conversation/abort-signal presence checks stay inline at the call site (for
+ * type narrowing) and are deliberately NOT part of this policy decision.
+ */
+describe("shouldRunV2Retrieval", () => {
+  test("runs for a trusted actor when memory-v3-live is off (v2/shadow path)", () => {
+    expect(
+      shouldRunV2Retrieval({ isTrustedActor: true, memoryV3Live: false }),
+    ).toBe(true);
+  });
+
+  test("is skipped under memory-v3-live even for a trusted actor", () => {
+    // The cutover: v3 owns memory, so v2 retrieval (and its LLM router) must
+    // not fire — this is the per-turn cost the gate removes.
+    expect(
+      shouldRunV2Retrieval({ isTrustedActor: true, memoryV3Live: true }),
+    ).toBe(false);
+  });
+
+  test("is skipped for an untrusted actor regardless of the flag", () => {
+    expect(
+      shouldRunV2Retrieval({ isTrustedActor: false, memoryV3Live: false }),
+    ).toBe(false);
+    expect(
+      shouldRunV2Retrieval({ isTrustedActor: false, memoryV3Live: true }),
+    ).toBe(false);
+  });
+});

--- a/assistant/src/plugins/defaults/memory-retrieval/hooks/user-prompt-submit.ts
+++ b/assistant/src/plugins/defaults/memory-retrieval/hooks/user-prompt-submit.ts
@@ -32,6 +32,7 @@ import type {
   UserPromptSubmitContext,
 } from "@vellumai/plugin-api";
 
+import { isAssistantFeatureFlagEnabled } from "../../../../config/assistant-feature-flags.js";
 import { getConfig } from "../../../../config/loader.js";
 import { findConversationOrSubagent } from "../../../../daemon/conversation-registry.js";
 import {
@@ -47,6 +48,22 @@ import { recordMemoryRecallLog } from "../../../../memory/memory-recall-log-stor
 import { broadcastMessage } from "../../../../runtime/assistant-event-hub.js";
 import type { GraphMemoryResult } from "../../../types.js";
 import { MEMORY_V3_INJECTED_BLOCK_METADATA_KEY } from "../../memory-v3-shadow/ever-injected-store.js";
+
+/**
+ * Whether to run v2 graph-memory retrieval this turn. v2 retrieval is the
+ * deprecated path: under `memory-v3-live`, v3 is the injected-memory source and
+ * runtime assembly strips any v2 `<memory>` block, so running v2's retrieval
+ * (embedding + hybrid search + the `memoryRetrieval` LLM router) only to
+ * discard the result is pure per-turn waste. Untrusted actors never run it
+ * either. The caller additionally requires the live conversation and its abort
+ * signal to be present (kept inline at the call site for type narrowing).
+ */
+export function shouldRunV2Retrieval(params: {
+  isTrustedActor: boolean;
+  memoryV3Live: boolean;
+}): boolean {
+  return params.isTrustedActor && !params.memoryV3Live;
+}
 
 /**
  * Persist and broadcast the retrieval's side effects: the injected block on
@@ -250,8 +267,19 @@ const userPromptSubmitMemoryRetrieval: PluginHookFn<
     conversation?.assistantId,
   );
 
+  // v2 graph retrieval is the deprecated path: `shouldRunV2Retrieval` skips it
+  // under memory-v3-live (v3 owns the `<memory>` layer and assembly strips any
+  // v2 block) and for untrusted actors. The `conversation && abortSignal`
+  // presence checks stay inline so the block below narrows. NOTE: this removes
+  // the v2 fallback — under v3-live, a v3 empty/failed selection yields no NEW
+  // injected memory that turn (prior turns' frozen v3 cards still ride history).
+  const memoryV3Live = isAssistantFeatureFlagEnabled("memory-v3-live", config);
   let v2BlockPersisted = false;
-  if (conversation && isTrustedActor && abortSignal) {
+  if (
+    shouldRunV2Retrieval({ isTrustedActor, memoryV3Live }) &&
+    conversation &&
+    abortSignal
+  ) {
     // Retrieval progress (`memory_status`) and the `memory_recalled` summary
     // publish to the shared `broadcastMessage` hub — the sink every turn
     // publisher converges to — rather than a threaded event callback. This

--- a/assistant/src/plugins/defaults/memory-v3-shadow/injector.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/injector.ts
@@ -24,8 +24,11 @@
  *    all-repeat turn returns an EMPTY-TEXT block: assembly attaches nothing,
  *    but the block's presence still keys v2 suppression (v3 ran and owns the
  *    `<memory>` layer this turn). A `null` return (failure / empty selection /
- *    every net-new card rendered empty) leaves v2's block intact — fallback to
- *    v2 rather than a memory-less turn.
+ *    every net-new card rendered empty) attaches no v3 block: in shadow mode
+ *    (`memory-v3-live` off) v2 still ran this turn, so its block stays as the
+ *    fallback; under `memory-v3-live` the user-prompt-submit hook skips v2
+ *    retrieval entirely, so a null return leaves the turn with no NEW injected
+ *    memory (prior turns' frozen cards still ride history).
  *
  *  - {@link memoryV3SpotlightInjector} (id `memory-v3-spotlight`,
  *    `append-user-tail`): the EPHEMERAL layer. Renders the top `spotlight.n`
@@ -239,9 +242,11 @@ export const memoryV3Injector: Injector = {
     if (!isPersonalMemoryAllowed(ctx.trust)) return null;
 
     const result = await observeTurnOnce(ctx.conversationId, ctx.turnIndex);
-    // Empty selection falls back to v2 (return null): v2 suppression keys off
-    // BOTH the flag AND a produced block, so a selector failure or a turn with
-    // nothing selected ships v2 memory rather than no memory.
+    // Empty selection → return null (attach nothing). Returning null (vs an
+    // empty block) preserves the shadow-mode v2 fallback: v2 suppression keys
+    // off BOTH the flag AND a produced block, so in shadow a selector failure
+    // or a turn with nothing selected ships v2's memory. Under `memory-v3-live`
+    // the hook skipped v2 retrieval, so the turn simply gets no injected memory.
     if (!result || result.selections.length === 0) return null;
 
     try {
@@ -258,11 +263,13 @@ export const memoryV3Injector: Injector = {
         const card = await renderV3CardContent(slug);
         if (card.trim().length > 0) cards.push({ slug, card });
       }
-      // Every net-new card rendered empty: return null (fall back to v2)
-      // rather than an empty-text block — suppressing v2 with nothing to show
-      // would ship a memory-less turn. Distinct from the all-repeat case
-      // (empty `netNew`), where the empty block correctly keeps v2 suppressed
-      // because the cards already ride history.
+      // Every net-new card rendered empty: return null rather than an
+      // empty-text block. Returning null preserves the shadow-mode v2 fallback
+      // (an empty block would key v2 suppression yet show nothing); under
+      // `memory-v3-live` there is no v2 block, so the turn simply gets no new
+      // memory. Distinct from the all-repeat case (empty `netNew`), where the
+      // empty block correctly keeps v2 suppressed because the cards already
+      // ride history.
       if (netNew.length > 0 && cards.length === 0) return null;
       const entries = cards.map(({ slug, card }) => ({
         slug,
@@ -332,7 +339,7 @@ export const memoryV3Injector: Injector = {
           err: err instanceof Error ? err.message : String(err),
           conversationId: ctx.conversationId,
         },
-        "memory-v3 live render failed (non-fatal) — falling back to v2",
+        "memory-v3 live render failed (non-fatal) — returning null (no v3 block this turn)",
       );
       return null;
     }


### PR DESCRIPTION
## Summary
- Under the `memory-v3-live` flag, the `user-prompt-submit` hook no longer runs v2 graph-memory retrieval (`prepareMemory`, including the `memoryRetrieval` LLM router). v3 owns the injected-memory layer and runtime assembly already strips any v2 `<memory>` block, so v2's per-turn retrieval was pure waste — its result was always discarded.
- Extracts the gating policy into a small, unit-tested `shouldRunV2Retrieval({ isTrustedActor, memoryV3Live })` helper; the `conversation && abortSignal` presence checks stay inline for type narrowing.
- Intentionally removes the v2 fallback: under `memory-v3-live`, a v3 empty/failed selection now yields no *new* injected memory for that turn (prior turns' frozen v3 cards still persist in history). v2 is being deprecated.
- Updates now-inaccurate "fallback to v2" comments in the v3 injector to note the fallback applies only in shadow mode (flag off); no logic change there.

## Original prompt
Memory-v3 is the live injected-memory source, but the v2 retrieval path (including its per-turn LLM router) was still firing every turn and having its result discarded — a redundant per-turn cost. The ask was to gate v2 retrieval off entirely under `memory-v3-live` (the "fully off" option, since v2 is being deprecated), accepting that a v3 miss now means no new memory that turn rather than falling back to v2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)