### PR TITLE
fix(memory): tolerate unknown frontmatter keys (.passthrough not .strict)

### DIFF
--- a/assistant/src/memory/v2/__tests__/concept-page-frontmatter-schema.test.ts
+++ b/assistant/src/memory/v2/__tests__/concept-page-frontmatter-schema.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+
+import { ConceptPageFrontmatterSchema } from "../types.js";
+
+/**
+ * Regression: the frontmatter schema is `.passthrough()`, not `.strict()`.
+ *
+ * Migrated/converted corpora carry leaked source-page fields the article model
+ * does not define (`date`, `sources`, `world`, `outcome`, `as_of`, …). Under
+ * `.strict()` every such page threw in `readPage()` and was silently dropped
+ * from BOTH the page index and the section dense lane (a bulk deploy of
+ * summary-less wiki pages lost ~45% of them this way). `.passthrough()` keeps
+ * them on disk and in the index; the frontmatter sweep still surfaces malformed
+ * pages.
+ */
+describe("ConceptPageFrontmatterSchema", () => {
+  test("tolerates unknown frontmatter keys instead of throwing (passthrough)", () => {
+    const raw = {
+      summary: "A page about something.",
+      date: "2026-06-13",
+      sources: ["source-a", "source-b"],
+      world: "example-world",
+      outcome: "resolved",
+      as_of: "2026-06-13",
+    };
+    expect(() => ConceptPageFrontmatterSchema.parse(raw)).not.toThrow();
+    const parsed = ConceptPageFrontmatterSchema.parse(raw) as Record<
+      string,
+      unknown
+    >;
+    // Declared field is typed/kept...
+    expect(parsed.summary).toBe("A page about something.");
+    // ...and unknown keys pass through rather than being stripped or rejected.
+    expect(parsed.date).toBe("2026-06-13");
+    expect(parsed.sources).toEqual(["source-a", "source-b"]);
+    expect(parsed.outcome).toBe("resolved");
+  });
+
+  test("still applies declared-field defaults", () => {
+    const parsed = ConceptPageFrontmatterSchema.parse({});
+    expect(parsed.edges).toEqual([]);
+    expect(parsed.ref_files).toEqual([]);
+    expect(parsed.ref_urls).toEqual([]);
+  });
+});

--- a/assistant/src/memory/v2/types.ts
+++ b/assistant/src/memory/v2/types.ts
@@ -42,17 +42,15 @@ export const ConceptPageFrontmatterSchema = z
     summary: z.string().optional(),
     leaves: z.array(z.string()).optional(),
     // Optional authored `"<target-slug> — <why>"` cross-links. Curated, first-class
-    // edges for the memory-v3 edge lane. Declared here so `.strict()` does not
-    // reject a page that uses `links:`, and so `renderPageContent` round-trips the
-    // field (the edge graph reads it back from the rendered frontmatter).
+    // edges for the memory-v3 edge lane. Declared (rather than left to the
+    // `.passthrough()` catchall below) so it carries a real type and so
+    // `renderPageContent` round-trips the field (the edge graph reads it back
+    // from the rendered frontmatter).
     links: z.array(z.string()).optional(),
     // The memory-v3 wiki-article fields — the shape CONSOLIDATION_PROMPT_V3
-    // teaches and migrated corpora arrive in. Declared for the same two
-    // reasons as `links:`: `.strict()` must not reject them (readPage()
-    // THROWS on schema failure, and a single invalid page in a turn's top-K
-    // no-ops the entire v2 injection block — see frontmatter-sweep.ts), and
-    // `renderPageContent` must round-trip them (a programmatic rewrite must
-    // not strip a page's `status:` draft marker or its display `title`).
+    // teaches and migrated corpora arrive in. Declared (not just tolerated by
+    // the catchall) so `renderPageContent` round-trips them — a programmatic
+    // rewrite must not strip a page's `status:` draft marker or `title`.
     // `kind` and `status` stay free-form strings: their known values today
     // ("index", "cc-draft") are conventions of the article model, not
     // invariants this storage layer should enforce.
@@ -68,7 +66,15 @@ export const ConceptPageFrontmatterSchema = z
     // from `status:` (the article-model draft marker, e.g. "cc-draft").
     current: z.string().optional(),
   })
-  .strict();
+  // `.passthrough()`, NOT `.strict()`: tolerate unknown frontmatter keys instead
+  // of throwing. Migrated/converted corpora carry leaked source-page fields the
+  // article model does not define (`date`, `sources`, `world`, `outcome`,
+  // `as_of`, …). Under `.strict()` every such page failed `readPage()` and was
+  // silently dropped from BOTH the page index and the section dense lane — a far
+  // worse failure than the schema drift strictness guarded against (a bulk
+  // wiki deploy lost ~45% of pages this way). Unknown keys pass through and stay
+  // on disk (loss-proof); the frontmatter sweep still surfaces malformed pages.
+  .passthrough();
 
 export type ConceptPageFrontmatter = z.infer<
   typeof ConceptPageFrontmatterSchema


### PR DESCRIPTION
## Summary
- `ConceptPageFrontmatterSchema` switches from `.strict()` to `.passthrough()`. Migrated/converted corpora carry leaked source-page fields the article model does not declare (`date`, `sources`, `world`, `outcome`, `as_of`, …). Under `.strict()`, `readPage()` threw on every such page and it was silently dropped from BOTH the page index and the section dense lane — a bulk deploy of summary-less pages lost ~45% of them this way.
- Unknown keys now pass through and stay on disk (loss-proof); the frontmatter sweep still surfaces malformed pages. Declared fields keep their real types.
- Adds a regression test asserting unknown keys parse instead of throwing, and that declared-field defaults still apply.

## Original prompt
A bulk deploy of summary-less wiki pages exposed that `.strict()` frontmatter validation was silently evicting any page carrying frontmatter keys the article model doesn't declare — dropping them from the page index and the dense retrieval lane. The fix is to make the schema `.passthrough()` so unknown keys are tolerated (kept on disk, surfaced by the sweep) rather than throwing in `readPage()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)