### PR TITLE
feat(web): stream the new-chat greeting with a configurable cache TTL

### DIFF
--- a/apps/web/src/domains/chat/api/stream-greeting.test.ts
+++ b/apps/web/src/domains/chat/api/stream-greeting.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+// Controllable stub for the daemon client's POST. Captures the args and
+// returns whatever the current test sets up.
+let postArgs: unknown = null;
+let postImpl: () => Promise<{ data: unknown; response: Response }> = async () => ({
+  data: null,
+  response: new Response(null, { status: 200 }),
+});
+
+mock.module("@/generated/daemon/client.gen", () => ({
+  client: {
+    post: (args: unknown) => {
+      postArgs = args;
+      return postImpl();
+    },
+  },
+}));
+
+import { streamEmptyStateGreeting } from "@/domains/chat/api/stream-greeting";
+
+function sseStream(frames: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const frame of frames) controller.enqueue(encoder.encode(frame));
+      controller.close();
+    },
+  });
+}
+
+function deltaFrame(text: string): string {
+  return `event: btw_text_delta\ndata: ${JSON.stringify({ text })}\n\n`;
+}
+const COMPLETE_FRAME = "event: btw_complete\ndata: {}\n\n";
+
+afterEach(() => {
+  postArgs = null;
+});
+
+describe("streamEmptyStateGreeting", () => {
+  test("accumulates deltas and resolves with the full greeting", async () => {
+    postImpl = async () => ({
+      data: sseStream([deltaFrame("hey "), deltaFrame("there"), COMPLETE_FRAME]),
+      response: new Response(null, { status: 200 }),
+    });
+
+    const deltas: string[] = [];
+    const result = await streamEmptyStateGreeting({
+      assistantId: "asst-1",
+      onDelta: (text) => deltas.push(text),
+    });
+
+    expect(result).toBe("hey there");
+    expect(deltas).toEqual(["hey ", "hey there"]);
+  });
+
+  test("posts to /btw with the greeting conversation key and a prompt", async () => {
+    postImpl = async () => ({
+      data: sseStream([deltaFrame("yo"), COMPLETE_FRAME]),
+      response: new Response(null, { status: 200 }),
+    });
+
+    await streamEmptyStateGreeting({ assistantId: "asst-1" });
+
+    const args = postArgs as {
+      url: string;
+      path: { assistant_id: string };
+      body: { conversationKey: string; content: string };
+      parseAs: string;
+    };
+    expect(args.url).toBe("/v1/assistants/{assistant_id}/btw");
+    expect(args.path.assistant_id).toBe("asst-1");
+    expect(args.body.conversationKey).toBe("greeting");
+    expect(args.body.content.length).toBeGreaterThan(0);
+    expect(args.parseAs).toBe("stream");
+  });
+
+  test("rejects on a btw_error event", async () => {
+    postImpl = async () => ({
+      data: sseStream(['event: btw_error\ndata: {"error":"boom"}\n\n']),
+      response: new Response(null, { status: 200 }),
+    });
+
+    await expect(
+      streamEmptyStateGreeting({ assistantId: "asst-1" }),
+    ).rejects.toThrow("boom");
+  });
+
+  test("rejects on a non-OK response", async () => {
+    postImpl = async () => ({
+      data: null,
+      response: new Response(null, { status: 503 }),
+    });
+
+    await expect(
+      streamEmptyStateGreeting({ assistantId: "asst-1" }),
+    ).rejects.toThrow();
+  });
+
+  test("parses an SSE frame split across stream chunks", async () => {
+    const full = deltaFrame("split works") + COMPLETE_FRAME;
+    const mid = Math.floor(full.length / 2);
+    postImpl = async () => ({
+      data: sseStream([full.slice(0, mid), full.slice(mid)]),
+      response: new Response(null, { status: 200 }),
+    });
+
+    const result = await streamEmptyStateGreeting({ assistantId: "asst-1" });
+    expect(result).toBe("split works");
+  });
+});

--- a/apps/web/src/domains/chat/api/stream-greeting.ts
+++ b/apps/web/src/domains/chat/api/stream-greeting.ts
@@ -1,0 +1,149 @@
+/**
+ * Streams an empty-state (new-chat) greeting from the daemon's
+ * `POST /v1/btw` side-chain.
+ *
+ * The daemon resolves an authored `## Greetings` line, a cached greeting, or a
+ * fresh generation server-side (gated by `ui.emptyStateGreetingCacheTtlMs`) and
+ * streams the result as Server-Sent Events: `btw_text_delta` carries each
+ * chunk, `btw_complete` ends the stream, and `btw_error` reports a failure.
+ *
+ * `/btw` is not part of the generated daemon SDK, so we issue the POST through
+ * the configured daemon `client` (which applies auth + local-mode forwarding
+ * interceptors) with `parseAs: "stream"` and parse the SSE frames here.
+ */
+
+import { client } from "@/generated/daemon/client.gen";
+
+/** Conversation key the daemon maps to the empty-state greeting call site. */
+const GREETING_CONVERSATION_KEY = "greeting";
+
+/**
+ * Prompt for the empty-state greeting, kept in parity with the macOS Swift
+ * client (`ChatGreetingState.generateGreeting()`) so both surfaces share one
+ * voice.
+ */
+const GREETING_PROMPT =
+  "Generate a short, casual greeting in your voice from you to your user. " +
+  "This will be displayed when the user opens a new conversation (under 8 words). " +
+  "Match your personality. Output ONLY the greeting text — no quotes, no formatting.";
+
+export interface StreamGreetingOptions {
+  assistantId: string;
+  /** Aborts the in-flight request (e.g. on conversation change / unmount). */
+  signal?: AbortSignal;
+  /** Invoked with the accumulated greeting text as each delta arrives. */
+  onDelta?: (text: string) => void;
+}
+
+/**
+ * Request a greeting and resolve with its full text. Rejects on a `btw_error`
+ * event, a non-OK response, or a transport/abort failure — callers should fall
+ * back to a default greeting.
+ */
+export async function streamEmptyStateGreeting({
+  assistantId,
+  signal,
+  onDelta,
+}: StreamGreetingOptions): Promise<string> {
+  const { data, response } = await client.post({
+    url: "/v1/assistants/{assistant_id}/btw",
+    path: { assistant_id: assistantId },
+    body: {
+      conversationKey: GREETING_CONVERSATION_KEY,
+      content: GREETING_PROMPT,
+    },
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "text/event-stream",
+    },
+    parseAs: "stream",
+    signal,
+  });
+
+  if (response && !response.ok) {
+    throw new Error(`Greeting request failed with status ${response.status}`);
+  }
+
+  const stream = (data ?? response?.body) as
+    | ReadableStream<Uint8Array>
+    | null
+    | undefined;
+  if (!stream) {
+    throw new Error("Greeting stream returned no body");
+  }
+
+  return readGreetingStream(stream, onDelta);
+}
+
+interface ParsedSseFrame {
+  event: string;
+  data: Record<string, unknown> | null;
+}
+
+/** Parse one `event: …\ndata: …` SSE frame. */
+function parseSseFrame(frame: string): ParsedSseFrame | null {
+  let event = "message";
+  const dataLines: string[] = [];
+  for (const line of frame.split("\n")) {
+    if (line.startsWith("event:")) {
+      event = line.slice("event:".length).trim();
+    } else if (line.startsWith("data:")) {
+      dataLines.push(line.slice("data:".length).trim());
+    }
+  }
+  if (dataLines.length === 0) return { event, data: null };
+  try {
+    return { event, data: JSON.parse(dataLines.join("\n")) };
+  } catch {
+    return { event, data: null };
+  }
+}
+
+async function readGreetingStream(
+  stream: ReadableStream<Uint8Array>,
+  onDelta?: (text: string) => void,
+): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let text = "";
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      // SSE frames are separated by a blank line.
+      let sep: number;
+      while ((sep = buffer.indexOf("\n\n")) !== -1) {
+        const frame = buffer.slice(0, sep);
+        buffer = buffer.slice(sep + 2);
+
+        const parsed = parseSseFrame(frame);
+        if (!parsed) continue;
+
+        if (parsed.event === "btw_text_delta") {
+          const delta =
+            typeof parsed.data?.text === "string" ? parsed.data.text : "";
+          if (delta) {
+            text += delta;
+            onDelta?.(text);
+          }
+        } else if (parsed.event === "btw_error") {
+          const message =
+            typeof parsed.data?.error === "string"
+              ? parsed.data.error
+              : "Greeting generation failed";
+          throw new Error(message);
+        } else if (parsed.event === "btw_complete") {
+          return text;
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return text;
+}

--- a/apps/web/src/domains/chat/components/chat-empty-state.tsx
+++ b/apps/web/src/domains/chat/components/chat-empty-state.tsx
@@ -1,6 +1,7 @@
 
 import { type ReactNode } from "react";
 
+import { BusyIndicator } from "@/domains/chat/components/busy-indicator";
 import { DEFAULT_EMPTY_STATE_GREETING } from "@/domains/chat/utils/empty-state-constants";
 import { Typography } from "@vellumai/design-library";
 
@@ -22,6 +23,12 @@ export interface ChatEmptyStateProps {
   /** Greeting headline. Defaults to {@link DEFAULT_EMPTY_STATE_GREETING}. */
   greeting?: string;
   /**
+   * True while the greeting is still generating and no text has streamed in
+   * yet. Renders a busy indicator in place of the headline so the default
+   * greeting doesn't flash before the personalized one arrives.
+   */
+  isGenerating?: boolean;
+  /**
    * Optional avatar rendered above the greeting on mobile, or to its left on
    * desktop. Caller passes a
    * `<ChatAvatar … size={40} interactive />` when avatar data is available;
@@ -32,6 +39,7 @@ export interface ChatEmptyStateProps {
 
 export function ChatEmptyState({
   greeting = DEFAULT_EMPTY_STATE_GREETING,
+  isGenerating = false,
   avatarSlot,
 }: ChatEmptyStateProps) {
   return (
@@ -39,12 +47,18 @@ export function ChatEmptyState({
       <div className="mx-auto w-full max-w-[var(--chat-max-width)] px-3 sm:px-6">
         <div className="flex flex-col items-center justify-center gap-3 md:flex-row">
           {avatarSlot}
-          <Typography variant="title-medium" className="text-[var(--content-emphasized)] md:hidden">
-            {greeting}
-          </Typography>
-          <Typography variant="title-large" className="hidden text-[var(--content-emphasized)] md:block">
-            {greeting}
-          </Typography>
+          {isGenerating ? (
+            <BusyIndicator size={10} />
+          ) : (
+            <>
+              <Typography variant="title-medium" className="text-[var(--content-emphasized)] md:hidden">
+                {greeting}
+              </Typography>
+              <Typography variant="title-large" className="hidden text-[var(--content-emphasized)] md:block">
+                {greeting}
+              </Typography>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/apps/web/src/domains/chat/components/chat-route-content.tsx
+++ b/apps/web/src/domains/chat/components/chat-route-content.tsx
@@ -619,6 +619,7 @@ export function ChatMainPanel({
     emptyStatePlaceholder,
   } = useChatEmptyState({
     assistantId,
+    conversationId: activeConversationId,
     isEmptyConversation,
     avatar,
     mainView,

--- a/apps/web/src/domains/chat/hooks/use-chat-empty-state.tsx
+++ b/apps/web/src/domains/chat/hooks/use-chat-empty-state.tsx
@@ -26,6 +26,8 @@ import type { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 
 export interface UseChatEmptyStateParams {
   assistantId: string | null;
+  /** Active empty conversation id — a change regenerates the greeting. */
+  conversationId: string | null | undefined;
   isEmptyConversation: boolean;
   avatar: ReturnType<typeof useAssistantAvatar>;
   /** Current main view from viewer-store. */
@@ -50,6 +52,7 @@ export interface ChatEmptyStateResult {
 
 export function useChatEmptyState({
   assistantId,
+  conversationId,
   isEmptyConversation,
   avatar,
   mainView,
@@ -61,7 +64,12 @@ export function useChatEmptyState({
   const { components: avatarComponents, traits: avatarTraits, customImageUrl: avatarImageUrl } = avatar;
 
   const emptyStatePlaceholder = useMemo(() => pickRandomPlaceholder(), []);
-  const emptyStateGreeting = useEmptyStateGreeting(assistantId);
+  const { greeting: emptyStateGreeting, isGenerating: greetingIsGenerating } =
+    useEmptyStateGreeting({
+      assistantId,
+      conversationId,
+      enabled: isEmptyConversation,
+    });
 
   // Gate the daemon fetch by `isEmptyConversation` so non-empty chats
   // stop polling for data that's never rendered.
@@ -87,6 +95,7 @@ export function useChatEmptyState({
         />
       ) : null,
     greeting: editingApp ? buildEditAppGreeting(editingApp) : emptyStateGreeting,
+    isGenerating: editingApp ? false : greetingIsGenerating,
   };
 
   const emptyStateStarters = editingApp

--- a/apps/web/src/domains/chat/hooks/use-empty-state-greeting.test.tsx
+++ b/apps/web/src/domains/chat/hooks/use-empty-state-greeting.test.tsx
@@ -1,197 +1,103 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import * as realRQ from "@tanstack/react-query";
-import { renderToStaticMarkup } from "react-dom/server";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
 
 import { DEFAULT_EMPTY_STATE_GREETING } from "@/domains/chat/utils/empty-state-constants";
-import { assistantIdentityIntroQueryKey } from "@/lib/sync/query-tags";
 
-interface CapturedQueryOptions {
-  queryKey: readonly unknown[];
-  queryFn: () => Promise<EmptyStateGreetingQueryResult | null>;
-  enabled: boolean;
-  staleTime: number;
-  refetchInterval?: (query: {
-    state: { data?: EmptyStateGreetingQueryResult | null };
-  }) => number | false;
+// Controllable stub for the streaming client.
+interface StreamCall {
+  assistantId: string;
+  signal?: AbortSignal;
+  onDelta?: (text: string) => void;
 }
 
-let lastCapturedOptions: CapturedQueryOptions | null = null;
+const streamCalls: StreamCall[] = [];
+let streamImpl: (opts: StreamCall) => Promise<string> = async () => "Hello there";
 
-interface EmptyStateGreetingQueryResult {
-  candidates: readonly string[];
-  refreshing: boolean;
-}
-
-interface UseQueryStub {
-  data: EmptyStateGreetingQueryResult | null | undefined;
-}
-
-let useQueryStub: UseQueryStub = { data: undefined };
-
-mock.module("@tanstack/react-query", () => ({
-  ...realRQ,
-  useQuery: (options: CapturedQueryOptions) => {
-    lastCapturedOptions = options;
-    return useQueryStub;
-  },
-}));
-
-interface ClientResponse {
-  data: unknown;
-  error: unknown;
-  response: { ok: boolean };
-}
-
-const identityIntroCalls: unknown[] = [];
-let clientResponse: ClientResponse = {
-  data: null,
-  error: null,
-  response: { ok: true },
-};
-
-mock.module("@/generated/daemon/sdk.gen", () => ({
-  identityIntroGet: (options: unknown) => {
-    identityIntroCalls.push(options);
-    return Promise.resolve(clientResponse);
+mock.module("@/domains/chat/api/stream-greeting", () => ({
+  streamEmptyStateGreeting: (opts: StreamCall) => {
+    streamCalls.push(opts);
+    return streamImpl(opts);
   },
 }));
 
 import { useEmptyStateGreeting } from "@/domains/chat/hooks/use-empty-state-greeting";
 
-function HookHarness({
-  assistantId,
-  collect,
-}: {
-  assistantId: string | null | undefined;
-  collect: (result: string) => void;
-}): null {
-  collect(useEmptyStateGreeting(assistantId));
-  return null;
-}
-
-function runHook(assistantId: string | null | undefined): string {
-  let captured: string | null = null;
-  renderToStaticMarkup(
-    <HookHarness
-      assistantId={assistantId}
-      collect={(result) => {
-        captured = result;
-      }}
-    />
-  );
-  if (captured === null) {
-    throw new Error("HookHarness did not invoke the hook");
-  }
-  return captured;
-}
-
-const originalRandom = Math.random;
-
 beforeEach(() => {
-  lastCapturedOptions = null;
-  identityIntroCalls.length = 0;
-  clientResponse = { data: null, error: null, response: { ok: true } };
-  useQueryStub = { data: undefined };
-  Math.random = originalRandom;
+  streamCalls.length = 0;
+  streamImpl = async () => "Hello there";
 });
 
 afterEach(() => {
-  Math.random = originalRandom;
+  cleanup();
 });
 
 describe("useEmptyStateGreeting", () => {
-  test("uses the identity intro query key for the active assistant", () => {
-    runHook("asst-1");
-
-    expect(lastCapturedOptions?.queryKey).toEqual(
-      assistantIdentityIntroQueryKey("asst-1")
+  test("returns the default and does not generate when disabled", () => {
+    const { result } = renderHook(() =>
+      useEmptyStateGreeting({
+        assistantId: "a1",
+        conversationId: "c1",
+        enabled: false,
+      }),
     );
-    expect(lastCapturedOptions?.enabled).toBe(true);
+
+    expect(result.current.greeting).toBe(DEFAULT_EMPTY_STATE_GREETING);
+    expect(result.current.isGenerating).toBe(false);
+    expect(streamCalls).toHaveLength(0);
   });
 
-  test("falls back when no greeting candidates are loaded", () => {
-    expect(runHook("asst-1")).toBe(DEFAULT_EMPTY_STATE_GREETING);
+  test("does not generate without an assistant or conversation id", () => {
+    renderHook(() =>
+      useEmptyStateGreeting({ assistantId: null, conversationId: "c1" }),
+    );
+    expect(streamCalls).toHaveLength(0);
   });
 
-  test("selects one greeting candidate from the daemon response", () => {
-    useQueryStub = {
-      data: {
-        candidates: ["First greeting", "Second greeting"],
-        refreshing: false,
-      },
-    };
-    Math.random = () => 0.99;
-
-    expect(runHook("asst-1")).toBe("Second greeting");
-  });
-
-  test("polls while fallback greetings are refreshing", () => {
-    runHook("asst-1");
-
-    expect(
-      lastCapturedOptions?.refetchInterval?.({
-        state: {
-          data: {
-            candidates: ["What are we working on?"],
-            refreshing: true,
-          },
-        },
-      })
-    ).toBe(1500);
-    expect(
-      lastCapturedOptions?.refetchInterval?.({
-        state: {
-          data: {
-            candidates: ["Generated greeting"],
-            refreshing: false,
-          },
-        },
-      })
-    ).toBe(false);
-  });
-
-  test("queryFn returns trimmed greetings from the daemon array", async () => {
-    clientResponse = {
-      data: {
-        greetings: ["  First greeting  ", "", "Second greeting"],
-        text: "Legacy text",
-      },
-      error: null,
-      response: { ok: true },
+  test("streams a greeting and renders it", async () => {
+    streamImpl = async (opts) => {
+      opts.onDelta?.("Hey");
+      opts.onDelta?.("Hey there");
+      return "Hey there";
     };
 
-    runHook("asst-1");
-    const result = await lastCapturedOptions!.queryFn();
+    const { result } = renderHook(() =>
+      useEmptyStateGreeting({ assistantId: "a1", conversationId: "c1" }),
+    );
 
-    expect(result).toEqual({
-      candidates: ["First greeting", "Second greeting"],
-      refreshing: false,
+    await waitFor(() => {
+      expect(result.current.greeting).toBe("Hey there");
     });
-    expect(identityIntroCalls).toHaveLength(1);
-    const call = identityIntroCalls[0] as {
-      path: { assistant_id: string };
-      query?: { localHour?: number; localMinute?: number };
-    };
-    expect(call.path).toEqual({ assistant_id: "asst-1" });
-    expect(call.query?.localHour).toBeGreaterThanOrEqual(0);
-    expect(call.query?.localHour).toBeLessThanOrEqual(23);
-    expect(call.query?.localMinute).toBeGreaterThanOrEqual(0);
-    expect(call.query?.localMinute).toBeLessThanOrEqual(59);
+    expect(result.current.isGenerating).toBe(false);
+    expect(streamCalls).toHaveLength(1);
+    expect(streamCalls[0]!.assistantId).toBe("a1");
   });
 
-  test("queryFn falls back to legacy text when greetings are absent", async () => {
-    clientResponse = {
-      data: { text: "  Legacy greeting  " },
-      error: null,
-      response: { ok: true },
+  test("falls back to the default greeting on error", async () => {
+    streamImpl = async () => {
+      throw new Error("network");
     };
 
-    runHook("asst-1");
-    const result = await lastCapturedOptions!.queryFn();
+    const { result } = renderHook(() =>
+      useEmptyStateGreeting({ assistantId: "a1", conversationId: "c1" }),
+    );
 
-    expect(result).toEqual({
-      candidates: ["Legacy greeting"],
-      refreshing: false,
+    await waitFor(() => {
+      expect(result.current.isGenerating).toBe(false);
     });
+    expect(result.current.greeting).toBe(DEFAULT_EMPTY_STATE_GREETING);
+  });
+
+  test("regenerates when the conversation id changes", async () => {
+    const { rerender } = renderHook(
+      ({ conversationId }: { conversationId: string }) =>
+        useEmptyStateGreeting({ assistantId: "a1", conversationId }),
+      { initialProps: { conversationId: "c1" } },
+    );
+
+    await waitFor(() => expect(streamCalls).toHaveLength(1));
+
+    rerender({ conversationId: "c2" });
+
+    await waitFor(() => expect(streamCalls).toHaveLength(2));
   });
 });

--- a/apps/web/src/domains/chat/hooks/use-empty-state-greeting.ts
+++ b/apps/web/src/domains/chat/hooks/use-empty-state-greeting.ts
@@ -1,125 +1,88 @@
 /**
- * React hook that fetches a personalized empty-state greeting from the daemon.
+ * React hook that streams a personalized empty-state greeting from the daemon.
  *
- * Calls `GET /v1/assistants/{assistant_id}/identity/intro` which returns a
- * list of greetings derived from SOUL.md, cached model output, fresh
- * generation, or generic fallback options. Falls back to
- * {@link DEFAULT_EMPTY_STATE_GREETING} when the assistant ID is missing, the
- * daemon is unreachable, or the response is empty.
- *
- * The query has a long `staleTime` (5 minutes) since the intro text is cached
- * server-side and refreshed in the background.
+ * Mirrors the macOS app: each new empty conversation triggers a single
+ * greeting generated via `POST /v1/btw` (`conversationKey: "greeting"`), which
+ * streams in token-by-token. The daemon owns the prompt, voice, authored
+ * `## Greetings` override, and a configurable cache TTL
+ * (`ui.emptyStateGreetingCacheTtlMs`) — so whether a request hits the LLM or
+ * replays a cached greeting is decided server-side. Falls back to
+ * {@link DEFAULT_EMPTY_STATE_GREETING} until text arrives and on any error.
  */
 
-import { useMemo } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
 
-import { identityIntroGet } from "@/generated/daemon/sdk.gen";
-import { assertHasResponse } from "@/utils/api-errors";
+import { streamEmptyStateGreeting } from "@/domains/chat/api/stream-greeting";
 import { DEFAULT_EMPTY_STATE_GREETING } from "@/domains/chat/utils/empty-state-constants";
-import type { IdentityIntroGetResponse } from "@/generated/daemon/types.gen";
-import { assistantIdentityIntroQueryKey } from "@/lib/sync/query-tags";
 
-const STALE_TIME_MS = 5 * 60 * 1000;
-const FALLBACK_REFRESH_INTERVAL_MS = 1500;
-
-type IdentityIntroResponse = Partial<IdentityIntroGetResponse> & {
-  greetings?: unknown;
-  text?: unknown;
-  source?: unknown;
-  refreshing?: unknown;
-};
-
-interface EmptyStateGreetingQueryResult {
-  candidates: readonly string[];
-  refreshing: boolean;
+export interface EmptyStateGreeting {
+  /** The greeting to render (defaults until the first token streams in). */
+  greeting: string;
+  /** True while generating and no text has arrived yet — render a spinner. */
+  isGenerating: boolean;
 }
 
-async function fetchIdentityIntro(
-  assistantId: string
-): Promise<EmptyStateGreetingQueryResult | null> {
-  try {
-    const { data, error, response } = await identityIntroGet({
-      path: { assistant_id: assistantId },
-      query: buildLocalTimeQuery(),
-      throwOnError: false,
-    });
-    assertHasResponse(response, error, "Failed to fetch identity intro");
+interface UseEmptyStateGreetingParams {
+  assistantId: string | null | undefined;
+  /** Identifies the current empty conversation; a change regenerates. */
+  conversationId: string | null | undefined;
+  /** Only generate while the empty state is actually shown. */
+  enabled?: boolean;
+}
 
-    if (!response.ok || !data || typeof data !== "object") {
-      return null;
+export function useEmptyStateGreeting({
+  assistantId,
+  conversationId,
+  enabled = true,
+}: UseEmptyStateGreetingParams): EmptyStateGreeting {
+  const [greeting, setGreeting] = useState("");
+  // Seed from the initial params so the very first paint shows the spinner
+  // rather than flashing the default greeting before the effect runs.
+  const [isGenerating, setIsGenerating] = useState(() =>
+    Boolean(enabled && assistantId && conversationId),
+  );
+
+  useEffect(() => {
+    if (!enabled || !assistantId || !conversationId) {
+      return;
     }
 
-    const candidates = normalizeIdentityIntroCandidates(data);
-    if (!candidates) {
-      return null;
-    }
+    const controller = new AbortController();
+    let active = true;
+    setGreeting("");
+    setIsGenerating(true);
 
-    return {
-      candidates,
-      refreshing: data.source === "fallback" && data.refreshing === true,
+    streamEmptyStateGreeting({
+      assistantId,
+      signal: controller.signal,
+      onDelta: (text) => {
+        if (active) setGreeting(text);
+      },
+    })
+      .then((text) => {
+        if (!active) return;
+        setGreeting(text.trim() || DEFAULT_EMPTY_STATE_GREETING);
+      })
+      .catch(() => {
+        // Transport error, abort, or generation failure — keep whatever
+        // streamed in, else fall back to a stable default.
+        if (!active) return;
+        setGreeting((current) => current || DEFAULT_EMPTY_STATE_GREETING);
+      })
+      .finally(() => {
+        if (active) setIsGenerating(false);
+      });
+
+    return () => {
+      active = false;
+      controller.abort();
     };
-  } catch {
-    return null;
-  }
-}
+  }, [assistantId, conversationId, enabled]);
 
-function buildLocalTimeQuery(date: Date = new Date()): {
-  localHour: number;
-  localMinute: number;
-} {
   return {
-    localHour: date.getHours(),
-    localMinute: date.getMinutes(),
+    greeting: greeting || DEFAULT_EMPTY_STATE_GREETING,
+    // Only signal "generating" before the first token; once text streams in we
+    // render it directly.
+    isGenerating: isGenerating && greeting.length === 0,
   };
-}
-
-function normalizeIdentityIntroCandidates(
-  data: IdentityIntroResponse
-): readonly string[] | null {
-  if (Array.isArray(data.greetings)) {
-    const greetings = data.greetings
-      .filter((candidate): candidate is string => typeof candidate === "string")
-      .map((candidate) => candidate.trim())
-      .filter(Boolean);
-    if (greetings.length > 0) {
-      return greetings;
-    }
-  }
-
-  const text = typeof data.text === "string" ? data.text.trim() : "";
-  return text ? [text] : null;
-}
-
-function pickGreetingCandidate(
-  candidates: readonly string[] | null | undefined
-): string | null {
-  if (!candidates || candidates.length === 0) return null;
-  const index = Math.min(
-    candidates.length - 1,
-    Math.floor(Math.random() * candidates.length)
-  );
-  return candidates[index] ?? null;
-}
-
-export function useEmptyStateGreeting(
-  assistantId: string | null | undefined
-): string {
-  const enabled = Boolean(assistantId);
-
-  const query = useQuery<EmptyStateGreetingQueryResult | null>({
-    queryKey: assistantIdentityIntroQueryKey(assistantId),
-    queryFn: () => fetchIdentityIntro(assistantId!),
-    enabled,
-    staleTime: STALE_TIME_MS,
-    refetchInterval: (query) =>
-      query.state.data?.refreshing ? FALLBACK_REFRESH_INTERVAL_MS : false,
-  });
-
-  const greeting = useMemo(
-    () => pickGreetingCandidate(query.data?.candidates),
-    [query.data]
-  );
-
-  return greeting ?? DEFAULT_EMPTY_STATE_GREETING;
 }

--- a/assistant/src/__tests__/empty-state-greeting-cache.test.ts
+++ b/assistant/src/__tests__/empty-state-greeting-cache.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Unit tests for the empty-state greeting cache
+ * (runtime/routes/empty-state-greeting-cache.ts).
+ *
+ * Validates TTL round-tripping, expiry, and the TTL=0 "always regenerate"
+ * behavior that disables caching entirely.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks — defined before importing the module under test
+// ---------------------------------------------------------------------------
+
+const checkpointStore = new Map<string, string>();
+
+mock.module("../memory/checkpoints.js", () => ({
+  getMemoryCheckpoint: (key: string) => checkpointStore.get(key) ?? null,
+  setMemoryCheckpoint: (key: string, value: string) => {
+    checkpointStore.set(key, value);
+  },
+}));
+
+let cacheTtlMs = 4 * 60 * 60 * 1000;
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({ ui: { emptyStateGreetingCacheTtlMs: cacheTtlMs } }),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import {
+  getCachedEmptyStateGreeting,
+  setCachedEmptyStateGreeting,
+} from "../runtime/routes/empty-state-greeting-cache.js";
+
+const TIMESTAMP_KEY = "empty_state:greeting:cached_at";
+
+beforeEach(() => {
+  cacheTtlMs = 4 * 60 * 60 * 1000;
+});
+
+afterEach(() => {
+  checkpointStore.clear();
+});
+
+describe("empty-state greeting cache", () => {
+  test("returns null when the cache is empty", () => {
+    expect(getCachedEmptyStateGreeting()).toBeNull();
+  });
+
+  test("round-trips set then get within the TTL", () => {
+    setCachedEmptyStateGreeting("hey there");
+    expect(getCachedEmptyStateGreeting()).toBe("hey there");
+  });
+
+  test("returns null once the TTL is exceeded", () => {
+    setCachedEmptyStateGreeting("stale");
+    checkpointStore.set(
+      TIMESTAMP_KEY,
+      String(Date.now() - (4 * 60 + 1) * 60 * 1000),
+    );
+    expect(getCachedEmptyStateGreeting()).toBeNull();
+  });
+
+  test("returns the cached value just within the TTL", () => {
+    setCachedEmptyStateGreeting("fresh enough");
+    checkpointStore.set(
+      TIMESTAMP_KEY,
+      String(Date.now() - (3 * 60 + 59) * 60 * 1000),
+    );
+    expect(getCachedEmptyStateGreeting()).toBe("fresh enough");
+  });
+
+  test("TTL of 0 disables caching: writes are skipped and reads miss", () => {
+    cacheTtlMs = 0;
+    setCachedEmptyStateGreeting("should not persist");
+    expect(checkpointStore.size).toBe(0);
+    expect(getCachedEmptyStateGreeting()).toBeNull();
+  });
+
+  test("TTL of 0 ignores a value cached while caching was enabled", () => {
+    setCachedEmptyStateGreeting("cached while on");
+    cacheTtlMs = 0;
+    expect(getCachedEmptyStateGreeting()).toBeNull();
+  });
+
+  test("returns null when the timestamp checkpoint is missing", () => {
+    checkpointStore.set("empty_state:greeting:text", "orphaned");
+    expect(getCachedEmptyStateGreeting()).toBeNull();
+  });
+});

--- a/assistant/src/config/schemas/platform.ts
+++ b/assistant/src/config/schemas/platform.ts
@@ -110,6 +110,14 @@ export const UiConfigSchema = z
       .describe(
         "IANA timezone identifier detected from the client environment for assistant temporal grounding when no manual override is configured (e.g. 'America/New_York'). Use an empty string to clear the setting.",
       ),
+    emptyStateGreetingCacheTtlMs: z
+      .number({ error: "ui.emptyStateGreetingCacheTtlMs must be a number" })
+      .int("ui.emptyStateGreetingCacheTtlMs must be an integer")
+      .min(0, "ui.emptyStateGreetingCacheTtlMs must be >= 0")
+      .default(4 * 60 * 60 * 1000)
+      .describe(
+        "Server-side cache TTL (ms) for the generated empty-state (new-chat) greeting. 0 disables caching, so a fresh greeting is generated on every request.",
+      ),
   })
   .describe(
     "User interface display settings. Empty-state greeting model selection lives under llm.callSites.emptyStateGreeting.",

--- a/assistant/src/runtime/routes/btw-routes.ts
+++ b/assistant/src/runtime/routes/btw-routes.ts
@@ -22,8 +22,16 @@ import { getAllToolDefinitions } from "../../tools/registry.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { runBtwSidechain } from "../btw-sidechain.js";
+import {
+  getCachedEmptyStateGreeting,
+  setCachedEmptyStateGreeting,
+} from "./empty-state-greeting-cache.js";
 import { BadRequestError, ServiceUnavailableError } from "./errors.js";
-import { getCachedIntro, setCachedIntro } from "./identity-intro-cache.js";
+import {
+  getCachedIntro,
+  readWorkspaceGreetings,
+  setCachedIntro,
+} from "./identity-intro-cache.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("btw-routes");
@@ -70,6 +78,24 @@ async function handleBtw({
     if (fastText) {
       log.debug("Returning identity intro fast-path");
       return streamText(fastText);
+    }
+  }
+
+  // ----- Empty-state greeting fast-path -----
+  // User-authored `## Greetings` win; otherwise replay a cached greeting when
+  // one is fresh within the configurable TTL (`ui.emptyStateGreetingCacheTtlMs`,
+  // 0 = always regenerate). Either path avoids an LLM call and streams the
+  // text straight back.
+  if (conversationKey === GREETING_KEY) {
+    const authored = readWorkspaceGreetings();
+    if (authored && authored.length > 0) {
+      log.debug("Returning authored empty-state greeting");
+      return streamText(pickRandom(authored));
+    }
+    const cached = getCachedEmptyStateGreeting();
+    if (cached) {
+      log.debug("Returning cached empty-state greeting");
+      return streamText(cached);
     }
   }
 
@@ -136,6 +162,12 @@ async function handleBtw({
             }
           }
 
+          if (isGreeting && result.text) {
+            // setCachedEmptyStateGreeting is a no-op when the TTL is 0.
+            setCachedEmptyStateGreeting(result.text);
+            log.debug("Cached empty-state greeting text");
+          }
+
           controller.enqueue(sseEvent("btw_complete", {}));
           controller.close();
         } catch (err: unknown) {
@@ -151,6 +183,10 @@ async function handleBtw({
       })();
     },
   });
+}
+
+function pickRandom<T>(items: readonly T[]): T {
+  return items[Math.floor(Math.random() * items.length)]!;
 }
 
 function streamText(text: string): ReadableStream<Uint8Array> {

--- a/assistant/src/runtime/routes/empty-state-greeting-cache.ts
+++ b/assistant/src/runtime/routes/empty-state-greeting-cache.ts
@@ -1,0 +1,65 @@
+/**
+ * Caching layer for the empty-state (new-chat) greeting generated via the
+ * `POST /v1/btw` side-chain with `conversationKey: "greeting"`.
+ *
+ * Stores a single greeting string with a configurable TTL
+ * (`ui.emptyStateGreetingCacheTtlMs`, default 4h). A TTL of `0` (or less)
+ * disables caching entirely — reads always miss and writes are skipped — so
+ * the greeting regenerates on every request. This is the knob a workspace
+ * sets to always receive a fresh greeting.
+ *
+ * Storage uses the existing `memory_checkpoints` table (simple key-value
+ * store), mirroring {@link ./identity-intro-cache.ts}.
+ */
+
+import { getConfig } from "../../config/loader.js";
+import {
+  getMemoryCheckpoint,
+  setMemoryCheckpoint,
+} from "../../memory/checkpoints.js";
+
+const CHECKPOINT_KEY_TEXT = "empty_state:greeting:text";
+const CHECKPOINT_KEY_TIMESTAMP = "empty_state:greeting:cached_at";
+
+function cacheTtlMs(): number {
+  return getConfig().ui.emptyStateGreetingCacheTtlMs;
+}
+
+/**
+ * Return the cached greeting if present and within the configured TTL.
+ * Returns `null` when caching is disabled (TTL <= 0), the cache is empty,
+ * or the entry has expired.
+ */
+export function getCachedEmptyStateGreeting(): string | null {
+  const ttl = cacheTtlMs();
+  if (ttl <= 0) return null; // caching disabled — always regenerate
+
+  try {
+    const text = getMemoryCheckpoint(CHECKPOINT_KEY_TEXT);
+    const timestampStr = getMemoryCheckpoint(CHECKPOINT_KEY_TIMESTAMP);
+    if (!text || !timestampStr) return null;
+
+    const cachedAt = Number(timestampStr);
+    if (Number.isNaN(cachedAt) || Date.now() - cachedAt > ttl) return null;
+
+    return text;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Store a freshly generated greeting along with the current timestamp.
+ * No-ops when caching is disabled (TTL <= 0) so a zero-TTL workspace never
+ * writes a stale entry.
+ */
+export function setCachedEmptyStateGreeting(text: string): void {
+  if (cacheTtlMs() <= 0) return; // caching disabled — skip write
+
+  try {
+    setMemoryCheckpoint(CHECKPOINT_KEY_TEXT, text);
+    setMemoryCheckpoint(CHECKPOINT_KEY_TIMESTAMP, String(Date.now()));
+  } catch {
+    // Cache write failure is non-fatal — next request will regenerate.
+  }
+}


### PR DESCRIPTION
## Summary
- Port the macOS app's warmer, in-voice new-chat greeting to the web/Electron (and iOS) client: the empty-chat greeting streams in token-by-token from `POST /v1/btw` (`conversationKey: "greeting"`) instead of random-picking one of five cached `/identity/intro` options rendered as static text.
- Add a server-side cache for the empty-state greeting with a configurable TTL — `ui.emptyStateGreetingCacheTtlMs` (default 4h). **`0` disables caching**, so a fresh greeting is generated on every new chat. User-authored `## Greetings` in SOUL.md still take priority over generation.
- New web SSE-POST reader (`stream-greeting.ts`) consumes the stream; a busy indicator shows until the first token arrives. Tests cover the cache (incl. TTL=0), the SSE reader (incl. chunk-split frames + error), and the hook.

## Original prompt
A user noticed the new-conversation greeting differed between the Electron and the legacy Swift desktop apps, and preferred the Swift version (warmer, fresher, in the assistant's voice). The Swift app generates one fresh greeting per new chat via `/btw` and streams it in; the web app random-picked from a 4h-cached five-option `/identity/intro` set and rendered it statically. The ask was to port the Swift greeting experience to Electron — streamed in — with a configurable cache TTL (default 4h) so generation frequency is tunable per instance.

## Notes for review
- The `/btw` `"greeting"` path is shared with the legacy Swift client, so it now also gets the cache + server-side authored-greeting handling (still backward-compatible — it returns a valid greeting either way).
- The web client no longer calls `GET /v1/identity/intro` for the empty chat; its sync-invalidation of that query key is now a harmless no-op (follow-up: prune it). `/identity/intro` itself is unchanged (still used by the native identity panel).
- No `btw-routes.test.ts` exists, so server coverage is the cache unit test; the `/btw` greeting wiring is exercised manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)