### PR TITLE
fix(memory): place v3 spotlight after the memory cards, not the user tail

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/carry-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/carry-integration.test.ts
@@ -631,7 +631,10 @@ async function runTurn(
   }
 
   // Spotlight: scoped strip of the stale block (real assembly helper), then
-  // append the fresh one at the current-message tail.
+  // re-attach the fresh one. Real assembly splices it after the memory cards
+  // (after-memory-prefix); this sim appends to the tail because only the
+  // block's presence, content, placement value, and strip-and-replace are
+  // asserted here — not its exact position within the message.
   const spotlight = await memoryV3SpotlightInjector.produce(ctx);
   const stripped = stripSpotlightInjections(history);
   history.splice(0, history.length, ...stripped);
@@ -976,13 +979,13 @@ describe("memory-v3 carry integration — cache contract", () => {
 });
 
 describe("memory-v3 carry integration — spotlight contract", () => {
-  test("spotlight is present every turn, at the user tail, bounded by n × (window + 1)", () => {
+  test("spotlight is present every turn, after the memory cards, bounded by n × (window + 1)", () => {
     for (const record of records) {
       expect(record.spotlightText.startsWith("<memory_spotlight>\n")).toBe(
         true,
       );
       expect(record.spotlightText.endsWith("\n</memory_spotlight>")).toBe(true);
-      expect(record.spotlightPlacement).toBe("append-user-tail");
+      expect(record.spotlightPlacement).toBe("after-memory-prefix");
       expect(record.spotlightEntries).toBeGreaterThanOrEqual(1);
       expect(record.spotlightEntries).toBeLessThanOrEqual(
         SPOTLIGHT_N * (SPOTLIGHT_WINDOW_TURNS + 1),

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/injection.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/injection.test.ts
@@ -573,13 +573,13 @@ describe("memoryV3SpotlightInjector — ephemeral section spotlight", () => {
   const sectionB = section("page-b", "Beta", "beta section text");
   const sectionC = section("page-c", "Gamma", "gamma section text");
 
-  test("renders selected finder hits' matched sections at the user tail", async () => {
+  test("renders selected finder hits' matched sections right after the memory cards", async () => {
     liveEnabled = true;
     turnResults.set(0, result(["page-a", "page-b"], [["page-a", sectionA]]));
 
     const block = await produceSpotlight("conv-1", 0);
     expect(block).not.toBeNull();
-    expect(block!.placement).toBe("append-user-tail");
+    expect(block!.placement).toBe("after-memory-prefix");
     expect(block!.text.startsWith("<memory_spotlight>\n")).toBe(true);
     expect(block!.text.endsWith("\n</memory_spotlight>")).toBe(true);
     expect(block!.text).toContain(

--- a/assistant/src/plugins/defaults/memory-v3-shadow/injector.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/injector.ts
@@ -31,13 +31,15 @@
  *    memory (prior turns' frozen cards still ride history).
  *
  *  - {@link memoryV3SpotlightInjector} (id `memory-v3-spotlight`,
- *    `append-user-tail`): the EPHEMERAL layer. Renders the top `spotlight.n`
+ *    `after-memory-prefix`): the EPHEMERAL layer. Renders the top `spotlight.n`
  *    selected finder hits' matched sections, plus the previous
  *    `spotlight.windowTurns` turns' entries from an in-memory per-conversation
  *    ring (a daemon restart simply re-warms it), as a `<memory_spotlight>`
- *    block at the current-message tail. Assembly strip-and-replaces this block
- *    every turn (scoped to this block id only); it is never persisted to
- *    metadata.
+ *    block spliced immediately after the `<memory>` cards block (so the two
+ *    memory layers sit adjacent in the prefix, ahead of the user's message
+ *    text). Assembly strip-and-replaces this block every turn (scoped to this
+ *    block id only); it is never persisted to metadata, so the frozen card
+ *    prefix it follows stays byte-stable and cached regardless.
  *
  * Flag gating is unchanged: `memory-v3-live` attaches blocks; `memory-v3-shadow`
  * (live off) logs what WOULD inject (net-new slugs + bytes + spotlight refs)
@@ -376,7 +378,14 @@ export const memoryV3SpotlightInjector: Injector = {
       return {
         id: MEMORY_V3_SPOTLIGHT_BLOCK_ID,
         text: wrapMemorySpotlightBlock(renderSpotlightInner(window)),
-        placement: "append-user-tail",
+        // Splices right after the `<memory>` cards block (this injector's
+        // order 1001 runs after the cards' 1000, and `countMemoryPrefixBlocks`
+        // counts the cards `<memory>` block but not `<memory_spotlight>`, so the
+        // spotlight lands immediately after the cards rather than at the user
+        // tail). Cache-neutral: the block is strip-and-replaced from prior
+        // messages by block id every turn regardless of placement, so the
+        // frozen card prefix stays byte-stable and cached.
+        placement: "after-memory-prefix",
       };
     } catch (err) {
       log.warn(


### PR DESCRIPTION
## Summary
- The ephemeral `<memory_spotlight>` block now uses `after-memory-prefix` placement (order 1001, after the cards' 1000) instead of `append-user-tail`, so it splices immediately after the frozen `<memory>` cards block — the two memory layers sit adjacent in the prefix, ahead of the user's message text.
- Cache-neutral: the spotlight is strip-and-replaced from prior messages by block id every turn regardless of placement, so the frozen card prefix stays byte-stable and cached. Under `memory-v3-live` the provider anchors its long-TTL cache breakpoint on the most recent *stable* user message (not the volatile latest one), so the spotlight's position within the latest message does not affect caching.
- Updates the existing spotlight placement test and the carry-integration spotlight contract to the new placement.

## Original prompt
The `<memory_spotlight>` block was rendering at the very end of the user's message; the request was to move it to sit right after the `<memory>` cards block so the two memory layers are grouped together (memory, then spotlight, then the user's text). The move was verified cache-neutral against the provider's cache-anchor logic before changing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)