### PR TITLE
fix(memory): align stale frontmatter tests with .passthrough() schema

### DIFF
--- a/assistant/src/memory/v2/__tests__/frontmatter-sweep.test.ts
+++ b/assistant/src/memory/v2/__tests__/frontmatter-sweep.test.ts
@@ -4,8 +4,8 @@
  * Coverage:
  *   - v2 disabled → returns early, no warns, no throw.
  *   - Empty workspace → no warns, no throw.
- *   - One bad page (unknown frontmatter key) → exactly one warn carrying
- *     `errCode: "unrecognized_keys"` and the offending slug.
+ *   - One bad page (malformed frontmatter — wrong type on a declared field) →
+ *     exactly one warn carrying `errCode: "invalid_type"` and the offending slug.
  *   - Two bad + one good page → two warns; good page produces nothing.
  *   - Malformed YAML → a warn surfaces; the sweep does not crash.
  */
@@ -59,7 +59,11 @@ function makeWorkspace(pages: Record<string, string>): string {
 }
 
 const goodPage = `---\nedges: []\nref_files: []\n---\nbody\n`;
-const badPage = `---\nedges: []\nref_files: []\nbogus_field: 1\n---\nbody\n`;
+// Malformed: `edges` is a declared `z.array(z.string())` field, so a scalar
+// value fails the schema with `invalid_type`. (An *unknown* key would NOT be
+// bad — the schema is `.passthrough()`, so unknown keys are tolerated; the
+// sweep only surfaces genuinely malformed pages that `readPage` would throw on.)
+const badPage = `---\nedges: not-a-list\nref_files: []\n---\nbody\n`;
 
 describe("sweepConceptPageFrontmatter", () => {
   beforeEach(() => {
@@ -86,14 +90,14 @@ describe("sweepConceptPageFrontmatter", () => {
     }
   });
 
-  test("one bad page emits exactly one unrecognized_keys warn", async () => {
+  test("one bad page emits exactly one invalid_type warn", async () => {
     const dir = makeWorkspace({ "bad-one": badPage });
     try {
       await sweepConceptPageFrontmatter(v2On, dir);
       expect(warnCalls).toHaveLength(1);
       expect(warnCalls[0].data.slug).toBe("bad-one");
-      expect(warnCalls[0].data.errCode).toBe("unrecognized_keys");
-      expect(warnCalls[0].data.errKeys).toEqual(["bogus_field"]);
+      expect(warnCalls[0].data.errCode).toBe("invalid_type");
+      expect(warnCalls[0].data.errPath).toEqual(["edges"]);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -110,7 +114,7 @@ describe("sweepConceptPageFrontmatter", () => {
       const slugs = warnCalls.map((c) => c.data.slug).sort();
       expect(slugs).toEqual(["bad-a", "bad-b"]);
       for (const call of warnCalls) {
-        expect(call.data.errCode).toBe("unrecognized_keys");
+        expect(call.data.errCode).toBe("invalid_type");
       }
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/assistant/src/memory/v2/__tests__/page-store.test.ts
+++ b/assistant/src/memory/v2/__tests__/page-store.test.ts
@@ -293,7 +293,11 @@ describe("writePage + readPage round-trip", () => {
     expect(read!.body).toBe(body);
   });
 
-  test("readPage throws on unknown frontmatter keys instead of silently dropping them", async () => {
+  test("readPage tolerates unknown frontmatter keys and passes them through", async () => {
+    // The schema is `.passthrough()`, not `.strict()`: migrated/converted
+    // corpora carry leaked source-page fields the article model doesn't define.
+    // Unknown keys must pass through and stay on disk (loss-proof) rather than
+    // throwing and silently dropping the page from the index.
     const slug = "extra-keys";
     const raw =
       "---\nedges: []\nref_files: []\nunknown_field: oops\n---\nbody\n";
@@ -303,7 +307,14 @@ describe("writePage + readPage round-trip", () => {
       "utf-8",
     );
 
-    await expect(readPage(workspaceDir, slug)).rejects.toThrow();
+    const read = await readPage(workspaceDir, slug);
+    expect(read).not.toBeNull();
+    expect(read!.frontmatter.edges).toEqual([]);
+    // Unknown key survives the round-trip instead of being rejected or stripped.
+    expect((read!.frontmatter as Record<string, unknown>).unknown_field).toBe(
+      "oops",
+    );
+    expect(read!.body).toBe("body\n");
   });
 
   test("writePage overwrites an existing page", async () => {

--- a/assistant/src/memory/v2/frontmatter-sweep.ts
+++ b/assistant/src/memory/v2/frontmatter-sweep.ts
@@ -3,12 +3,13 @@
 // ---------------------------------------------------------------------------
 //
 // At daemon startup, walk every concept page on disk and validate its
-// frontmatter against `ConceptPageFrontmatterSchema` (which is `.strict()`).
-// Schema-drifted pages — e.g. a user-authored file that adds a frontmatter
-// key the schema doesn't allow — would otherwise stay invisible until the
-// page lands in a conversation's top-K and `renderInjectionBlock`'s
-// `Promise.all` rejects, silently no-op'ing V2 dynamic injection for the
-// whole turn. Surfacing them as `warn` log lines at boot turns that into a
+// frontmatter against `ConceptPageFrontmatterSchema`. The schema is
+// `.passthrough()`, so unknown keys are tolerated; what this sweep catches is
+// genuinely malformed frontmatter — a wrong type on a declared field, or YAML
+// that doesn't parse. Such pages would otherwise stay invisible until one lands
+// in a conversation's top-K and `renderInjectionBlock`'s `Promise.all` rejects
+// (readPage throws), silently no-op'ing V2 dynamic injection for the whole
+// turn. Surfacing them as `warn` log lines at boot turns that into a
 // debuggable signal.
 //
 // This sweep is intentionally separate from `rebuildConceptPageCorpusStats`:

--- a/assistant/src/memory/v2/page-store.ts
+++ b/assistant/src/memory/v2/page-store.ts
@@ -192,9 +192,10 @@ export function slugFromConceptPath(
 /**
  * Split raw file contents into (frontmatter, body). If no frontmatter block
  * is present the entire input is treated as body and an empty frontmatter
- * block is returned (validated by `ConceptPageFrontmatterSchema` so any
- * unexpected shape — bad types, extra junk — surfaces as a parse error to
- * the caller, not silent dropped data).
+ * block is returned (validated by `ConceptPageFrontmatterSchema` so a bad
+ * type on a declared field surfaces as a parse error to the caller, not
+ * silently dropped data). The schema is `.passthrough()`, so unknown keys are
+ * kept rather than rejected — migrated corpora carry leaked source-page fields.
  *
  * The schema's defaults guarantee `edges` and `ref_files` are always arrays
  * even on freshly created pages with empty frontmatter.


### PR DESCRIPTION
## Summary
- Commit #34800 switched `ConceptPageFrontmatterSchema` from `.strict()` to `.passthrough()` but left two test files asserting the old reject-unknown-keys behavior, which turned `main` red.
- `frontmatter-sweep.test.ts`: the "bad page" fixture now uses a real type violation (`edges: not-a-list` → `invalid_type`) instead of an unknown key (now tolerated). The sweep still surfaces genuinely malformed pages that `readPage` would throw on.
- `page-store.test.ts`: the unknown-key test now asserts `readPage` tolerates the key and passes it through, instead of throwing.
- Refreshed two now-false doc comments in `frontmatter-sweep.ts` and `page-store.ts` that still described `.strict()`.

## Original prompt
Fix only the failing "Test" job in CI run 27488588625 on `main`. Three assertions across `frontmatter-sweep.test.ts` and `page-store.test.ts` broke after #34800 changed the concept-page frontmatter schema to `.passthrough()`; scope was limited to making that one job green by aligning the stale tests (and their stale doc comments) with the shipped passthrough contract.