### PR TITLE
feat(memory): show v3 selected sections in the LLM Context Inspector

### DIFF
--- a/apps/web/src/domains/chat/inspector/components/tabs/memory-tab.tsx
+++ b/apps/web/src/domains/chat/inspector/components/tabs/memory-tab.tsx
@@ -518,7 +518,7 @@ function MemoryV3Section({
 
       <SectionCard
         title={`Selected pages (${fmt(selection.selections.length)})`}
-        subtitle="Pages the v3 working set selected, tagged by the lane that surfaced them."
+        subtitle="Pages v3 selected, tagged by the lane that surfaced them and the matched section (when a finder lane surfaced one)."
       >
         {selection.selections.length > 0 ? (
           <div className="flex flex-col gap-1">
@@ -553,7 +553,19 @@ function MemoryV3Section({
   );
 }
 
-function V3SelectionRow({ row }: { row: MemoryV3SelectionRow }): ReactNode {
+/**
+ * The persisted v3 selection carries the matched section a finder lane
+ * surfaced. The generated `MemoryV3SelectionRow` type may not yet expose these
+ * fields (the wire schema is built out-of-band from the assistant); the daemon
+ * sends them at runtime, so they are read via this local augmentation until the
+ * generated type catches up.
+ */
+type V3SelectionRowData = MemoryV3SelectionRow & {
+  sectionOrdinal?: number | null;
+  sectionHeading?: string | null;
+};
+
+function V3SelectionRow({ row }: { row: V3SelectionRowData }): ReactNode {
   return (
     <div
       className="flex items-center justify-between gap-3 rounded-md px-3 py-2"
@@ -564,6 +576,11 @@ function V3SelectionRow({ row }: { row: MemoryV3SelectionRow }): ReactNode {
         style={{ color: "var(--content-default)" }}
       >
         {row.slug}
+        {row.sectionHeading ? (
+          <span style={{ color: "var(--content-secondary)" }}>
+            {` § ${row.sectionHeading}`}
+          </span>
+        ) : null}
       </code>
       <div className="flex shrink-0 items-center gap-1.5">
         {row.pinned && <TypeChip label="pinned" />}

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -9929,6 +9929,14 @@ paths:
                                   type: string
                                 pinned:
                                   type: boolean
+                                sectionOrdinal:
+                                  anyOf:
+                                    - type: number
+                                    - type: "null"
+                                sectionHeading:
+                                  anyOf:
+                                    - type: string
+                                    - type: "null"
                               required:
                                 - slug
                                 - source
@@ -19354,6 +19362,14 @@ paths:
                                   type: string
                                 pinned:
                                   type: boolean
+                                sectionOrdinal:
+                                  anyOf:
+                                    - type: number
+                                    - type: "null"
+                                sectionHeading:
+                                  anyOf:
+                                    - type: string
+                                    - type: "null"
                               required:
                                 - slug
                                 - source

--- a/assistant/src/api/responses/memory-v3-selection-log.ts
+++ b/assistant/src/api/responses/memory-v3-selection-log.ts
@@ -15,14 +15,13 @@
  * `injectedText` reflects the live selection; when only `shadow` is true it is
  * the block that WOULD have been injected.
  *
- * `injectedText` is APPROXIMATE, not a verbatim record. It is re-rendered from
- * the persisted selection rows, which store slug/source/pinned but NOT the
- * matched-section identity. A page that live injection sent as a single matched
- * section is re-rendered here as its FULL page (the section ordinal isn't
- * persisted), so the text can differ from what was actually sent to the model.
- * The selected slug set is exact — only the rendered text is full-page
- * approximate. Persisting the per-turn injected section is a documented
- * follow-up.
+ * `injectedText` is inspector-only, not a verbatim record of the live cards +
+ * spotlight. It re-renders each selection's matched section — resolved from the
+ * persisted `(slug, sectionOrdinal)` against the CURRENT page — falling back to
+ * the full page when no section was recorded. Because the section text is
+ * re-derived from the current page, it reflects bounded page-drift if the page
+ * changed since the turn (the same approximation the v2 inspector accepts). The
+ * selected slug set and each row's matched-section heading are exact as logged.
  */
 
 import { z } from "zod";
@@ -33,20 +32,28 @@ import { z } from "zod";
  * rows may carry retired labels) — but the schema stays a permissive string
  * so a new lane label (or a historical pre-lane row) doesn't break parsing on
  * the FE. `pinned` marks a page the turn was centrally about.
+ * `sectionOrdinal`/`sectionHeading` identify the matched section a finder lane
+ * surfaced (null for core/hot/fresh/edge selections and pre-migration rows).
  */
 export const MemoryV3SelectionRowSchema = z.object({
   slug: z.string(),
   source: z.string(),
   pinned: z.boolean(),
+  // The matched section a finder lane surfaced for this selection. Null for
+  // core/hot/fresh/edge selections with no matched section, and for rows
+  // written before the section columns existed. Optional + nullable so older
+  // clients and pre-migration rows round-trip.
+  sectionOrdinal: z.number().nullable().optional(),
+  sectionHeading: z.string().nullable().optional(),
 });
 
 export type MemoryV3SelectionRow = z.infer<typeof MemoryV3SelectionRowSchema>;
 
 /**
  * Memory v3 selection log shape. `injectedText` is the rendered
- * `<memory>…</memory>` block for the selection — APPROXIMATE: re-rendered from
- * the persisted rows, with full pages where live injection used a matched
- * section (the section identity isn't persisted). See the file header.
+ * `<memory>…</memory>` block for the selection — re-rendered from the persisted
+ * rows, with each selection's matched section resolved from its
+ * `(slug, sectionOrdinal)` (full-page fallback when none). See the file header.
  */
 export const MemoryV3SelectionLogSchema = z.object({
   turn: z.number(),

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -51,6 +51,7 @@ import {
   writeSlackMetadata,
 } from "../messaging/providers/slack/message-metadata.js";
 import type { ContextWindowResult } from "../plugins/defaults/compaction/window-manager.js";
+import { backfillMemoryV3SelectionMessageId } from "../plugins/defaults/memory-v3-shadow/shadow-plugin.js";
 import type {
   ContentBlock,
   ImageContent,
@@ -1943,6 +1944,18 @@ export async function handleMessageComplete(
     deps.rlog.warn(
       { err },
       "Failed to backfill memory v2 activation log messageId (non-fatal)",
+    );
+  }
+
+  try {
+    backfillMemoryV3SelectionMessageId(
+      deps.ctx.conversationId,
+      assistantMessageId,
+    );
+  } catch (err) {
+    deps.rlog.warn(
+      { err },
+      "Failed to backfill memory v3 selection messageId (non-fatal)",
     );
   }
 

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -142,6 +142,7 @@ import {
   migrateMemoryV2InjectionEvents,
   migrateMemoryV3AutoEdges,
   migrateMemoryV3Coactivation,
+  migrateMemoryV3SelectionsMessageIdAndSections,
   migrateMessageBookmarks,
   migrateMessagesClientMessageId,
   migrateMessagesConversationCreatedAtIndex,
@@ -502,6 +503,7 @@ export function initializeDb(): void {
     migrateConversationsSurfacedAt,
     migrateMemoryRetrospectiveRememberedLog,
     migrateScheduleInferenceProfile,
+    migrateMemoryV3SelectionsMessageIdAndSections,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/283-memory-v3-selections-message-id-and-sections.test.ts
+++ b/assistant/src/memory/migrations/283-memory-v3-selections-message-id-and-sections.test.ts
@@ -1,0 +1,102 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import * as schema from "../schema.js";
+import { migrateMemoryV3SelectionsMessageIdAndSections } from "./283-memory-v3-selections-message-id-and-sections.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  // Pre-283 shape: slug/source/pinned only, no message_id or section columns.
+  sqlite.exec(/*sql*/ `
+    CREATE TABLE memory_v3_selections (
+      conversation_id TEXT NOT NULL,
+      turn INTEGER NOT NULL,
+      slug TEXT NOT NULL,
+      source TEXT NOT NULL,
+      pinned INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      PRIMARY KEY (conversation_id, turn, slug)
+    )
+  `);
+  return { sqlite, db: drizzle(sqlite, { schema }) };
+}
+
+function columnNames(sqlite: Database): string[] {
+  return (
+    sqlite.query("PRAGMA table_info(memory_v3_selections)").all() as Array<{
+      name: string;
+    }>
+  ).map((c) => c.name);
+}
+
+function indexNames(sqlite: Database): string[] {
+  return (
+    sqlite.query("PRAGMA index_list(memory_v3_selections)").all() as Array<{
+      name: string;
+    }>
+  ).map((i) => i.name);
+}
+
+describe("migration 283: memory_v3_selections message_id + section columns", () => {
+  test("adds nullable message_id, section_ordinal, section_title + message_id index", () => {
+    const { sqlite, db } = createTestDb();
+    expect(columnNames(sqlite)).not.toContain("message_id");
+
+    migrateMemoryV3SelectionsMessageIdAndSections(db);
+
+    const cols = sqlite
+      .query("PRAGMA table_info(memory_v3_selections)")
+      .all() as Array<{ name: string; notnull: number }>;
+    for (const name of ["message_id", "section_ordinal", "section_title"]) {
+      const col = cols.find((c) => c.name === name);
+      expect(col).toBeDefined();
+      expect(col?.notnull).toBe(0); // nullable
+    }
+    expect(indexNames(sqlite)).toContain("idx_memory_v3_selections_message");
+  });
+
+  test("existing rows read back with the new columns null", () => {
+    const { sqlite, db } = createTestDb();
+    sqlite.exec(/*sql*/ `
+      INSERT INTO memory_v3_selections
+        (conversation_id, turn, slug, source, pinned, created_at)
+      VALUES ('conv-1', 0, 'a/page', 'needle', 0, 1000)
+    `);
+
+    migrateMemoryV3SelectionsMessageIdAndSections(db);
+
+    const row = sqlite
+      .query(
+        `SELECT message_id, section_ordinal, section_title
+           FROM memory_v3_selections WHERE conversation_id = 'conv-1'`,
+      )
+      .get() as {
+      message_id: string | null;
+      section_ordinal: number | null;
+      section_title: string | null;
+    };
+    expect(row.message_id).toBeNull();
+    expect(row.section_ordinal).toBeNull();
+    expect(row.section_title).toBeNull();
+  });
+
+  test("is idempotent — re-run is a no-op", () => {
+    const { sqlite, db } = createTestDb();
+
+    migrateMemoryV3SelectionsMessageIdAndSections(db);
+    expect(() =>
+      migrateMemoryV3SelectionsMessageIdAndSections(db),
+    ).not.toThrow();
+
+    expect(columnNames(sqlite).filter((n) => n === "message_id")).toHaveLength(
+      1,
+    );
+    expect(
+      indexNames(sqlite).filter(
+        (n) => n === "idx_memory_v3_selections_message",
+      ),
+    ).toHaveLength(1);
+  });
+});

--- a/assistant/src/memory/migrations/283-memory-v3-selections-message-id-and-sections.ts
+++ b/assistant/src/memory/migrations/283-memory-v3-selections-message-id-and-sections.ts
@@ -1,0 +1,53 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Add three nullable columns to `memory_v3_selections` for the inspector's
+ * Memory V3 panel:
+ *
+ *   - `message_id TEXT` — the turn's assistant message id, backfilled at turn
+ *     end (mirrors the v2 activation log). The inspector looks selections up by
+ *     the inspected message's turn message ids, which is robust against the
+ *     drift between v2's tracker turn and v3's orchestrator `turnCount` that
+ *     previously left the panel blank. NULL for pre-existing rows and until the
+ *     turn-end backfill stamps it.
+ *   - `section_ordinal INTEGER` / `section_title TEXT` — the matched section a
+ *     finder-lane selection surfaced (from `OrchestrateResult.matchedSections`).
+ *     NULL for pre-existing rows and for core/hot/fresh/edge selections that
+ *     carry no matched section (those render full-page, as before).
+ *
+ * All three are nullable and append-only — old rows degrade to the prior
+ * page-level / turn-keyed behavior. The PK (conversation_id, turn, slug) is
+ * unchanged; these are secondary attributes. The existing offline A/B readers
+ * (`summarizeSelections`, hot-set, learned-edges, prune) ignore them.
+ *
+ * Idempotent — the PRAGMA guards make re-running a no-op once the columns
+ * exist, and the index uses IF NOT EXISTS.
+ */
+export function migrateMemoryV3SelectionsMessageIdAndSections(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  const columns = raw
+    .query(`PRAGMA table_info(memory_v3_selections)`)
+    .all() as Array<{ name: string }>;
+  const columnNames = new Set(columns.map((c) => c.name));
+
+  if (!columnNames.has("message_id")) {
+    raw.exec(`ALTER TABLE memory_v3_selections ADD COLUMN message_id TEXT`);
+  }
+  if (!columnNames.has("section_ordinal")) {
+    raw.exec(
+      `ALTER TABLE memory_v3_selections ADD COLUMN section_ordinal INTEGER`,
+    );
+  }
+  if (!columnNames.has("section_title")) {
+    raw.exec(`ALTER TABLE memory_v3_selections ADD COLUMN section_title TEXT`);
+  }
+
+  raw.exec(
+    `CREATE INDEX IF NOT EXISTS idx_memory_v3_selections_message
+       ON memory_v3_selections (message_id)`,
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -274,6 +274,7 @@ export { createSkillLoadedEventsTable } from "./279-create-skill-loaded-events.j
 export { migrateConversationsSurfacedAt } from "./280-conversations-surfaced-at.js";
 export { migrateMemoryRetrospectiveRememberedLog } from "./281-memory-retrospective-remembered-log.js";
 export { migrateScheduleInferenceProfile } from "./282-schedule-inference-profile.js";
+export { migrateMemoryV3SelectionsMessageIdAndSections } from "./283-memory-v3-selections-message-id-and-sections.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/carry-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/carry-integration.test.ts
@@ -57,6 +57,7 @@ import {
 } from "../../../../memory/memory-marker.js";
 import { migrateAddMemoryV3Selections } from "../../../../memory/migrations/268-add-memory-v3-selections.js";
 import { migrateAddMemoryV3EverInjected } from "../../../../memory/migrations/277-add-memory-v3-ever-injected.js";
+import { migrateMemoryV3SelectionsMessageIdAndSections } from "../../../../memory/migrations/283-memory-v3-selections-message-id-and-sections.js";
 import * as schema from "../../../../memory/schema.js";
 import type { PageIndexEntry } from "../../../../memory/v2/page-index.js";
 import type {
@@ -131,6 +132,7 @@ function makeDb() {
   const db = drizzle(testSqlite, { schema });
   migrateAddMemoryV3EverInjected(db);
   migrateAddMemoryV3Selections(db);
+  migrateMemoryV3SelectionsMessageIdAndSections(db);
   // Minimal `messages` shape — metadata persistence, the prune valve's
   // v3-ownership scan, and the restart rehydration read only these columns.
   testSqlite.run(/*sql*/ `

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/injection.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/injection.test.ts
@@ -33,6 +33,7 @@ import { drizzle } from "drizzle-orm/bun-sqlite";
 import { unwrapMemoryBlock } from "../../../../memory/memory-marker.js";
 import { migrateAddMemoryV3Selections } from "../../../../memory/migrations/268-add-memory-v3-selections.js";
 import { migrateAddMemoryV3EverInjected } from "../../../../memory/migrations/277-add-memory-v3-ever-injected.js";
+import { migrateMemoryV3SelectionsMessageIdAndSections } from "../../../../memory/migrations/283-memory-v3-selections-message-id-and-sections.js";
 import * as schema from "../../../../memory/schema.js";
 import type { InjectionBlock } from "../../../types.js";
 import type { OrchestrateResult } from "../orchestrate.js";
@@ -93,6 +94,7 @@ function makeDb() {
   migrateAddMemoryV3EverInjected(db);
   // The prune valve's recency ranking reads `memory_v3_selections`.
   migrateAddMemoryV3Selections(db);
+  migrateMemoryV3SelectionsMessageIdAndSections(db);
   // The prune valve plans only against slugs whose card sections are
   // locatable in persisted `memoryV3InjectedBlock` rows
   // (`collectPersistedV3Cards`) — minimal `messages` shape it reads.

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/selection-log-store.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/selection-log-store.test.ts
@@ -1,18 +1,20 @@
 /**
- * Tests for `assistant/src/memory/v3/selection-log-store.ts`.
+ * Tests for `selection-log-store.ts`.
  *
  * Asserts the inspector read path over `memory_v3_selections`:
- *   - the selection for the exact turn;
- *   - null for a null turn, and null for a turn with no v3 rows;
- *   - NO fallback to another turn (would misattribute a future turn's
- *     selection to the inspected message);
- *   - source/pinned mapping and the rendered `<memory>` block;
+ *   - the selection for the exact turn (turn-keyed variant);
+ *   - the selection keyed by the turn's message ids (the route's path), which
+ *     is robust against v2/v3 turn-counter drift and does not match rows that
+ *     predate the message-id backfill;
+ *   - null for a null turn, empty message ids, or no matching rows;
+ *   - NO fallback to another turn/message;
+ *   - source/pinned/section mapping and the rendered `<memory>` block;
  *   - `live` / `shadow` reflect the flag resolver.
  *
  * `mock.module` is process-global and leaks into sibling files in a
- * `bun test src/memory/v3/` run, so every stub DELEGATES to the real
- * implementation unless this test is actively running (`storeMockActive`,
- * toggled in beforeEach/afterAll). Mirrors `shadow-plugin.test.ts`.
+ * `bun test <dir>` run, so every stub DELEGATES to the real implementation
+ * unless this test is actively running (`storeMockActive`, toggled in
+ * beforeEach/afterAll). Mirrors `shadow-plugin.test.ts`.
  */
 
 import { Database } from "bun:sqlite";
@@ -21,6 +23,7 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import { migrateAddMemoryV3Selections } from "../../../../memory/migrations/268-add-memory-v3-selections.js";
+import { migrateMemoryV3SelectionsMessageIdAndSections } from "../../../../memory/migrations/283-memory-v3-selections-message-id-and-sections.js";
 import * as schema from "../../../../memory/schema.js";
 
 const realFlags = {
@@ -41,16 +44,27 @@ function makeDb() {
   testSqlite.exec("PRAGMA journal_mode=WAL");
   const db = drizzle(testSqlite, { schema });
   migrateAddMemoryV3Selections(db);
+  migrateMemoryV3SelectionsMessageIdAndSections(db);
   return db;
 }
 
 function seed(
   conversationId: string,
   turn: number,
-  rows: Array<{ slug: string; source: string; pinned?: boolean }>,
+  rows: Array<{
+    slug: string;
+    source: string;
+    pinned?: boolean;
+    sectionOrdinal?: number;
+    sectionTitle?: string;
+  }>,
+  messageId: string | null = null,
 ): void {
   const stmt = testSqlite.query(
-    `INSERT INTO memory_v3_selections (conversation_id, turn, slug, source, pinned, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO memory_v3_selections
+       (conversation_id, turn, slug, source, pinned, created_at,
+        message_id, section_ordinal, section_title)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   );
   for (const r of rows) {
     stmt.run(
@@ -60,6 +74,9 @@ function seed(
       r.source,
       r.pinned ? 1 : 0,
       1000 + turn,
+      messageId,
+      r.sectionOrdinal ?? null,
+      r.sectionTitle ?? null,
     );
   }
 }
@@ -97,17 +114,23 @@ mock.module("../../../../memory/db-connection.js", () => ({
 
 mock.module("../page-content.js", () => ({
   ...realPageContent,
-  // The inspector store renders via `renderV3SectionContent` with an empty
-  // section map (sections are unavailable post-orchestration), so it falls back
-  // to the full page. The mock stands in for that full-page render.
-  renderV3SectionContent: async (slug: string) =>
+  // The inspector store reconstructs each selection's matched section from the
+  // current page; in this unit the test pages don't exist on disk, so the
+  // section map is empty and the renderer falls back to the full page. The mock
+  // stands in for that render and reflects whether a section was supplied.
+  renderV3SectionContent: async (slug: string, section?: { title: string }) =>
     storeMockActive
-      ? `body for ${slug}`
+      ? section
+        ? `section[${section.title}] for ${slug}`
+        : `body for ${slug}`
       : realPageContent.renderV3SectionContent(slug, undefined),
 }));
 
-const { getMemoryV3SelectionForInspector, summarizeSelections } =
-  await import("../selection-log-store.js");
+const {
+  getMemoryV3SelectionForInspector,
+  getMemoryV3SelectionForInspectorByMessageIds,
+  summarizeSelections,
+} = await import("../selection-log-store.js");
 
 beforeEach(() => {
   storeMockActive = true;
@@ -150,9 +173,11 @@ describe("getMemoryV3SelectionForInspector", () => {
     expect(await getMemoryV3SelectionForInspector("conv-3", 3)).toBeNull();
   });
 
-  test("maps source/pinned and renders the <memory> block", async () => {
+  test("maps source/pinned/section and renders the <memory> block", async () => {
     // The second row carries a retired free-text source label (the column is
-    // permissive); the inspector passes it through verbatim.
+    // permissive); the inspector passes it through verbatim. Neither row has a
+    // matched section, so section fields are null and the block falls back to
+    // full pages.
     seed("conv-4", 1, [
       { slug: "domain-a/page-1", source: "edge", pinned: true },
       { slug: "domain-b/page-2", source: "legacy-carry", pinned: false },
@@ -160,8 +185,20 @@ describe("getMemoryV3SelectionForInspector", () => {
 
     const log = await getMemoryV3SelectionForInspector("conv-4", 1);
     expect(log?.selections).toEqual([
-      { slug: "domain-a/page-1", source: "edge", pinned: true },
-      { slug: "domain-b/page-2", source: "legacy-carry", pinned: false },
+      {
+        slug: "domain-a/page-1",
+        source: "edge",
+        pinned: true,
+        sectionOrdinal: null,
+        sectionHeading: null,
+      },
+      {
+        slug: "domain-b/page-2",
+        source: "legacy-carry",
+        pinned: false,
+        sectionOrdinal: null,
+        sectionHeading: null,
+      },
     ]);
     expect(log?.injectedText).toContain("<memory>");
     expect(log?.injectedText).toContain("body for domain-a/page-1");
@@ -180,6 +217,69 @@ describe("getMemoryV3SelectionForInspector", () => {
     const on = await getMemoryV3SelectionForInspector("conv-5", 1);
     expect(on?.live).toBe(true);
     expect(on?.shadow).toBe(true);
+  });
+});
+
+describe("getMemoryV3SelectionForInspectorByMessageIds", () => {
+  test("returns the turn's selection (with section fields) keyed by message id", async () => {
+    seed(
+      "conv-m",
+      0,
+      [
+        {
+          slug: "domain-a/page-1",
+          source: "needle",
+          sectionOrdinal: 2,
+          sectionTitle: "Heading A",
+        },
+        { slug: "domain-b/page-2", source: "core" },
+      ],
+      "msg-assistant-1",
+    );
+    // A different turn under a different message must not bleed in.
+    seed(
+      "conv-m",
+      1,
+      [{ slug: "domain-c/page-9", source: "dense" }],
+      "msg-assistant-2",
+    );
+
+    const log = await getMemoryV3SelectionForInspectorByMessageIds([
+      "msg-assistant-1",
+    ]);
+    expect(log?.turn).toBe(0);
+    expect(log?.selections).toEqual([
+      {
+        slug: "domain-a/page-1",
+        source: "needle",
+        pinned: false,
+        sectionOrdinal: 2,
+        sectionHeading: "Heading A",
+      },
+      {
+        slug: "domain-b/page-2",
+        source: "core",
+        pinned: false,
+        sectionOrdinal: null,
+        sectionHeading: null,
+      },
+    ]);
+    expect(log?.injectedText).toContain("<memory>");
+  });
+
+  test("returns null for empty message ids and for an unmatched id", async () => {
+    seed("conv-m", 0, [{ slug: "domain-a/page-1", source: "needle" }], "msg-1");
+    expect(await getMemoryV3SelectionForInspectorByMessageIds([])).toBeNull();
+    expect(
+      await getMemoryV3SelectionForInspectorByMessageIds(["nope"]),
+    ).toBeNull();
+  });
+
+  test("does not match rows that predate the message-id backfill (null message_id)", async () => {
+    seed("conv-m", 0, [{ slug: "domain-a/page-1", source: "needle" }]); // message_id null
+    expect(
+      await getMemoryV3SelectionForInspectorByMessageIds(["any"]),
+    ).toBeNull();
   });
 });
 

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-integration.test.ts
@@ -34,6 +34,7 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import { migrateAddMemoryV3Selections } from "../../../../memory/migrations/268-add-memory-v3-selections.js";
+import { migrateMemoryV3SelectionsMessageIdAndSections } from "../../../../memory/migrations/283-memory-v3-selections-message-id-and-sections.js";
 import * as schema from "../../../../memory/schema.js";
 import type { PageIndexEntry } from "../../../../memory/v2/page-index.js";
 import type {
@@ -105,6 +106,7 @@ function makeDb() {
   testSqlite.exec("PRAGMA journal_mode=WAL");
   const db = drizzle(testSqlite, { schema });
   migrateAddMemoryV3Selections(db);
+  migrateMemoryV3SelectionsMessageIdAndSections(db);
   return db;
 }
 mock.module("../../../../memory/db-connection.js", () => ({

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
@@ -29,6 +29,7 @@ import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import { migrateAddMemoryV3Selections } from "../../../../memory/migrations/268-add-memory-v3-selections.js";
 import { migrateAddMemoryV3EverInjected } from "../../../../memory/migrations/277-add-memory-v3-ever-injected.js";
+import { migrateMemoryV3SelectionsMessageIdAndSections } from "../../../../memory/migrations/283-memory-v3-selections-message-id-and-sections.js";
 import * as schema from "../../../../memory/schema.js";
 import type { HotSetEntry, HotSetOptions } from "../hot-set.js";
 import type { OrchestrateResult } from "../orchestrate.js";
@@ -154,6 +155,7 @@ function makeDb() {
   testSqlite.exec("PRAGMA journal_mode=WAL");
   const db = drizzle(testSqlite, { schema });
   migrateAddMemoryV3Selections(db);
+  migrateMemoryV3SelectionsMessageIdAndSections(db);
   // The live injector's net-new dedup reads/writes the everInjected store.
   migrateAddMemoryV3EverInjected(db);
   return db;
@@ -545,7 +547,15 @@ describe("memory-v3 shadow plugin", () => {
         finder: [{ slug: "page-core", descriptor: "", lane: "needle" }],
       },
     });
-    expect(rows).toEqual([{ slug: "page-core", source: "core", pinned: 0 }]);
+    expect(rows).toEqual([
+      {
+        slug: "page-core",
+        source: "core",
+        pinned: 0,
+        sectionOrdinal: null,
+        sectionTitle: null,
+      },
+    ]);
   });
 
   test("the turn passed to orchestrate carries the latest user message", async () => {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
@@ -383,7 +383,7 @@ export async function orchestrate(
  * when the article or ordinal is not in the index (e.g. the dense store is
  * ahead of the in-memory rebuild).
  */
-function sectionByOrdinal(
+export function sectionByOrdinal(
   index: SectionIndex,
   article: Slug,
   ordinal: number,

--- a/assistant/src/plugins/defaults/memory-v3-shadow/selection-log-store.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/selection-log-store.ts
@@ -1,25 +1,32 @@
 /**
- * Read-side store for the inspector's Memory V3 section. Reads the persisted
- * `memory_v3_selections` rows for a turn and re-renders an APPROXIMATE
- * `<memory>` block for what v3 selected, so the inspector can show the turn's
- * selection without re-running orchestration — which would be wrong anyway,
- * since the hot lane is frecency-stateful and can't be reproduced after the
- * fact.
+ * Read-side store for the inspector's Memory V3 panel. Reads the persisted
+ * `memory_v3_selections` rows for a turn (by the turn's message ids) and
+ * re-renders the `<memory>` block for what v3 selected, so the inspector can
+ * show the turn's selection without re-running orchestration — which would be
+ * wrong anyway, since the hot lane is frecency-stateful and can't be reproduced
+ * after the fact.
  *
- * The rendered text is inspector-only and NOT byte-identical to live
- * injection: the live injector freezes net-new compact CARDS into history
- * (`renderV3CardContent`) plus an ephemeral spotlight, while this store
- * re-renders the whole selection set as full/lead pages
- * (`renderV3SectionContent` with no persisted section identity — see the
- * inline note at `injectedText`).
+ * The rendered text is inspector-only and NOT byte-identical to live injection:
+ * the live injector freezes net-new compact CARDS into history
+ * (`renderV3CardContent`) plus an ephemeral spotlight. Here we re-render each
+ * selection's MATCHED SECTION — resolved from the persisted `(slug, ordinal)`
+ * against the current page — when one was recorded, falling back to the
+ * full/lead page otherwise. Section text is re-derived from the current page,
+ * so it reflects bounded page-drift if the page changed since the turn (the
+ * same approximation the v2 inspector accepts).
  */
 
 import type { MemoryV3SelectionLog } from "../../../api/responses/memory-v3-selection-log.js";
 import { isAssistantFeatureFlagEnabled } from "../../../config/assistant-feature-flags.js";
 import { getConfig } from "../../../config/loader.js";
 import { getDb, getSqliteFrom } from "../../../memory/db-connection.js";
+import { readPage } from "../../../memory/v2/page-store.js";
+import { getWorkspaceDir } from "../../../util/platform.js";
+import { capabilityOrDiskBody } from "./capabilities.js";
+import { sectionByOrdinal } from "./orchestrate.js";
 import { renderV3SectionContent } from "./page-content.js";
 import { renderMemoryBlock } from "./render-injection.js";
+import { buildSectionIndex } from "./sections.js";
 import {
   type Section,
   SELECTION_SOURCES,
@@ -31,16 +38,21 @@ const MEMORY_V3_SHADOW = "memory-v3-shadow" as const;
 const MEMORY_V3_LIVE = "memory-v3-live" as const;
 
 interface SelectionRow {
+  turn: number;
   slug: string;
   source: string;
   pinned: number;
+  section_ordinal: number | null;
+  section_title: string | null;
 }
+
+const SELECTION_COLUMNS = `turn, slug, source, pinned, section_ordinal, section_title`;
 
 function rowsForTurn(conversationId: string, turn: number): SelectionRow[] {
   return getSqliteFrom(getDb())
     .query(
       /*sql*/ `
-      SELECT slug, source, pinned FROM memory_v3_selections
+      SELECT ${SELECTION_COLUMNS} FROM memory_v3_selections
       WHERE conversation_id = ? AND turn = ?
       ORDER BY rowid
     `,
@@ -48,32 +60,59 @@ function rowsForTurn(conversationId: string, turn: number): SelectionRow[] {
     .all(conversationId, turn) as SelectionRow[];
 }
 
-/**
- * Build the inspector's v3 selection log for one turn of a conversation.
- *
- * `turn` is the inspected message's turn (the v2-activation log's turn). The
- * selection is returned ONLY for that exact turn; when there are no v3 rows for
- * it — including when `turn` is null (the message has no v2-activation turn) —
- * this returns `null` rather than falling back to a different turn. A fallback
- * would attribute another turn's selection (e.g. a later turn's pages and
- * rendered block) to the inspected message, which corrupts shadow validation.
- *
- * Caveat: v3 rows are keyed by the orchestrator turn counter (`ctx.turnCount`)
- * while `turn` here is the v2 memory-tracker turn. They coincide for normal
- * turns, but if they diverge this simply yields `null` (no section) rather than
- * wrong data. Tying v3 rows to a message id for exact per-message attribution
- * regardless of counter drift is a documented follow-up.
- *
- * Selection rows are stored in selection order, so rendering them in row order
- * reproduces the block v3 would inject.
- */
-export async function getMemoryV3SelectionForInspector(
-  conversationId: string,
-  turn: number | null | undefined,
-): Promise<MemoryV3SelectionLog | null> {
-  if (turn == null) return null;
+function rowsForMessageIds(messageIds: string[]): SelectionRow[] {
+  if (messageIds.length === 0) return [];
+  const placeholders = messageIds.map(() => "?").join(", ");
+  return getSqliteFrom(getDb())
+    .query(
+      /*sql*/ `
+      SELECT ${SELECTION_COLUMNS} FROM memory_v3_selections
+      WHERE message_id IN (${placeholders})
+      ORDER BY rowid
+    `,
+    )
+    .all(...messageIds) as SelectionRow[];
+}
 
-  const rows = rowsForTurn(conversationId, turn);
+/**
+ * Resolve each selection's persisted matched section `(slug, ordinal)` to the
+ * concrete `Section` in the CURRENT page, so the injected block renders the
+ * matched section rather than the full page. Only slugs with a recorded ordinal
+ * are resolved (core/hot/fresh/edge selections have none and render full-page).
+ * A page edited since the turn re-derives the current section at that ordinal,
+ * or falls back to full-page when the ordinal no longer exists.
+ */
+async function reconstructMatchedSections(
+  rows: SelectionRow[],
+): Promise<Map<Slug, Section>> {
+  const sectionSlugs = rows
+    .filter((r) => r.section_ordinal != null)
+    .map((r) => r.slug);
+  if (sectionSlugs.length === 0) return new Map();
+
+  const workspaceDir = getWorkspaceDir();
+  const pageBody = (slug: Slug): Promise<string> =>
+    capabilityOrDiskBody(slug, async (s) => {
+      try {
+        return (await readPage(workspaceDir, s))?.body ?? "";
+      } catch {
+        return "";
+      }
+    });
+  const index = await buildSectionIndex(sectionSlugs, pageBody);
+
+  const sectionBySlug = new Map<Slug, Section>();
+  for (const row of rows) {
+    if (row.section_ordinal == null) continue;
+    const section = sectionByOrdinal(index, row.slug, row.section_ordinal);
+    if (section) sectionBySlug.set(row.slug, section);
+  }
+  return sectionBySlug;
+}
+
+async function buildSelectionLog(
+  rows: SelectionRow[],
+): Promise<MemoryV3SelectionLog | null> {
   if (rows.length === 0) return null;
 
   const config = getConfig();
@@ -81,30 +120,56 @@ export async function getMemoryV3SelectionForInspector(
     slug: r.slug,
     source: r.source,
     pinned: r.pinned === 1,
+    sectionOrdinal: r.section_ordinal,
+    sectionHeading: r.section_title,
   }));
   const slugs: Slug[] = selections.map((s) => s.slug);
-  // NOTE: `injectedText` is APPROXIMATE — it renders the full/lead page for
-  // every slug, not the exact matched section live injection used. The inspector
-  // re-renders from persisted rows without re-running orchestration, and the
-  // section identity is not persisted (`memory_v3_selections` stores
-  // slug/source/pinned, not the section ordinal), so the section map is empty
-  // and `renderV3SectionContent` falls back to the full page. Persisting the
-  // injected section (a schema migration) is deliberately deferred: the A/B's
-  // primary signal is slug-level recall via `summarizeSelections`, which is
-  // exact — only this debug-oriented injected text is an approximation.
+  const sectionBySlug = await reconstructMatchedSections(rows);
   const injectedText = await renderMemoryBlock(
     slugs,
-    new Map<Slug, Section>(),
+    sectionBySlug,
     renderV3SectionContent,
   );
 
   return {
-    turn,
+    turn: rows[0]!.turn,
     live: isAssistantFeatureFlagEnabled(MEMORY_V3_LIVE, config),
     shadow: isAssistantFeatureFlagEnabled(MEMORY_V3_SHADOW, config),
     selections,
     injectedText,
   };
+}
+
+/**
+ * Build the inspector's v3 selection log for the inspected message's turn,
+ * keyed by the turn's message ids. This is the durable join: `writeSelections`
+ * logs rows with `message_id = NULL` and the turn-end backfill stamps them with
+ * the assistant message id, so a per-message lookup is robust against the drift
+ * between v2's tracker turn and v3's orchestrator `turnCount`. Returns `null`
+ * when no v3 rows match (e.g. a turn predating the message-id backfill, or a
+ * conversation with no v3 data). Message ids are globally unique, so no
+ * conversation scope is needed.
+ *
+ * Selection rows are stored in selection order, so rendering them in row order
+ * reproduces the block v3 would inject.
+ */
+export async function getMemoryV3SelectionForInspectorByMessageIds(
+  messageIds: string[],
+): Promise<MemoryV3SelectionLog | null> {
+  return buildSelectionLog(rowsForMessageIds(messageIds));
+}
+
+/**
+ * Turn-keyed variant, retained for callers/tests that look up by an exact
+ * `(conversation, turn)`. Returns `null` when `turn` is null or there are no
+ * rows for it.
+ */
+export async function getMemoryV3SelectionForInspector(
+  conversationId: string,
+  turn: number | null | undefined,
+): Promise<MemoryV3SelectionLog | null> {
+  if (turn == null) return null;
+  return buildSelectionLog(rowsForTurn(conversationId, turn));
 }
 
 /**

--- a/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
@@ -418,6 +418,11 @@ interface SelectionRow {
   slug: Slug;
   source: SelectionSource;
   pinned: number;
+  /** Ordinal of the matched section a finder lane surfaced; null for
+   *  core/hot/fresh/edge selections with no matched section. */
+  sectionOrdinal: number | null;
+  /** Heading of the matched section; null when there is no matched section. */
+  sectionTitle: string | null;
 }
 
 /**
@@ -438,17 +443,24 @@ export function attributeSelections(result: OrchestrateResult): SelectionRow[] {
   const finderLane = new Map(
     result.lanes.finder.map((c) => [c.slug, c.lane] as const),
   );
-  return result.selections.map((sel) => ({
-    slug: sel.slug,
-    source: core.has(sel.slug)
-      ? ("core" as const)
-      : hot.has(sel.slug)
-        ? ("hot" as const)
-        : fresh.has(sel.slug)
-          ? ("fresh" as const)
-          : (finderLane.get(sel.slug) ?? "needle"),
-    pinned: sel.pinned ? 1 : 0,
-  }));
+  return result.selections.map((sel) => {
+    // The matched section is populated only for finder-lane hits (including
+    // hits on core/hot pages); core/hot/fresh/edge-only selections have none.
+    const section = result.matchedSections.get(sel.slug);
+    return {
+      slug: sel.slug,
+      source: core.has(sel.slug)
+        ? ("core" as const)
+        : hot.has(sel.slug)
+          ? ("hot" as const)
+          : fresh.has(sel.slug)
+            ? ("fresh" as const)
+            : (finderLane.get(sel.slug) ?? "needle"),
+      pinned: sel.pinned ? 1 : 0,
+      sectionOrdinal: section?.ordinal ?? null,
+      sectionTitle: section?.title ?? null,
+    };
+  });
 }
 
 /** Write the attributed selection rows to `memory_v3_selections`. */
@@ -461,15 +473,49 @@ export function writeSelections(
   const raw = getSqliteFrom(getDb());
   // PK is (conversation_id, turn, slug); OR REPLACE keeps the write
   // idempotent if the same turn is observed twice (e.g. a retried turn).
+  // `message_id` is written NULL here (the assistant message does not exist at
+  // injection time) and stamped at turn end by
+  // `backfillMemoryV3SelectionMessageId`.
   const stmt = raw.query(/*sql*/ `
     INSERT OR REPLACE INTO memory_v3_selections (
-      conversation_id, turn, slug, source, pinned, created_at
-    ) VALUES (?, ?, ?, ?, ?, ?)
+      conversation_id, turn, slug, source, pinned, created_at,
+      message_id, section_ordinal, section_title
+    ) VALUES (?, ?, ?, ?, ?, ?, NULL, ?, ?)
   `);
   const now = Date.now();
   for (const row of rows) {
-    stmt.run(conversationId, turn, row.slug, row.source, row.pinned, now);
+    stmt.run(
+      conversationId,
+      turn,
+      row.slug,
+      row.source,
+      row.pinned,
+      now,
+      row.sectionOrdinal,
+      row.sectionTitle,
+    );
   }
+}
+
+/**
+ * Stamp the turn's assistant message id onto the selection rows just written
+ * for it. Mirrors the v2 activation-log backfill: `writeSelections` writes
+ * `message_id = NULL` at injection time, and this runs at turn end once the
+ * assistant message exists. Relies on the single-threaded-per-conversation turn
+ * invariant — every NULL-`message_id` row for the conversation belongs to the
+ * turn that just finished. Lets the inspector look v3 selections up by the
+ * turn's message ids (robust against v2/v3 turn-counter drift).
+ */
+export function backfillMemoryV3SelectionMessageId(
+  conversationId: string,
+  assistantMessageId: string,
+): void {
+  getSqliteFrom(getDb())
+    .query(
+      /*sql*/ `UPDATE memory_v3_selections SET message_id = ?
+               WHERE conversation_id = ? AND message_id IS NULL`,
+    )
+    .run(assistantMessageId, conversationId);
 }
 
 /**

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -74,7 +74,7 @@ import { type LogRow } from "../../memory/llm-request-log-store.js";
 import { getMemoryRecallLogByMessageIds } from "../../memory/memory-recall-log-store.js";
 import { getMemoryV2ActivationLogByMessageIds } from "../../memory/memory-v2-activation-log-store.js";
 import { MEMORY_V2_CONSOLIDATION_SOURCE } from "../../memory/v2/constants.js";
-import { getMemoryV3SelectionForInspector } from "../../plugins/defaults/memory-v3-shadow/selection-log-store.js";
+import { getMemoryV3SelectionForInspectorByMessageIds } from "../../plugins/defaults/memory-v3-shadow/selection-log-store.js";
 import {
   createConnection,
   listConnections,
@@ -1127,12 +1127,11 @@ async function handleGetLlmContext({
   // turn finishes — see `assistant/src/memory/conversation-crud.ts`.
   const conversationTotalEstimatedCostUsd =
     conversation?.totalEstimatedCost ?? null;
-  const memoryV3Selection = message
-    ? await getMemoryV3SelectionForInspector(
-        message.conversationId,
-        memoryV2Activation?.turn ?? null,
-      )
-    : null;
+  // v3 selections are keyed to the turn's message ids (stamped by the turn-end
+  // backfill), independent of v2's tracker turn — so the panel shows whenever
+  // the turn has v3 data, regardless of v2/v3 turn-counter drift.
+  const memoryV3Selection =
+    await getMemoryV3SelectionForInspectorByMessageIds(turnMessageIds);
   return {
     messageId,
     conversationKind,


### PR DESCRIPTION
## Summary
- **Fixes the hidden V3 panel.** The inspector keyed v3 selections by v2's tracker turn, which diverges from v3's orchestrator `turnCount` — so the panel never appeared. v3 selection rows are now stamped with the turn's assistant message id (a turn-end backfill mirroring the v2 activation log) and the inspector looks them up by message id, decoupled from v2's turn entirely.
- **Adds the matched sections.** New nullable `message_id` / `section_ordinal` / `section_title` columns on `memory_v3_selections` (migration 283); the write path captures the matched section from `OrchestrateResult.matchedSections`; the read path re-renders each selection's section (resolved by ordinal against the current page, full-page fallback when none) for section-grain injected text. Inspector rows show `page § section` and the wire type carries `sectionOrdinal` / `sectionHeading`.
- Migration is nullable + append-only (historical rows degrade to page-level); the GET route stays read-only; the offline A/B (`summarizeSelections`) is untouched. The web row reads the new fields via a local type augmentation until the generated `@vellumai/assistant-api` picks them up.

## Original prompt
The LLM Context Inspector's Memory tab showed a rich Memory V2 panel but no Memory V3 panel, even though v3 is the live memory source. Investigation found a V3 panel already existed but was hidden by a v2/v3 turn-counter mismatch, and the matched sections weren't persisted. The ask was to make the V3 panel appear and show the selected sections (section-grain), like the V2 panel — chosen over a page-level-only fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)