### PR TITLE
feat(web): port message bookmarks from the macOS app

### DIFF
--- a/apps/web/src/domains/chat/active-chat-view.tsx
+++ b/apps/web/src/domains/chat/active-chat-view.tsx
@@ -56,6 +56,7 @@ import { useDeepLinkConsumer } from "@/domains/chat/hooks/use-deep-link-consumer
 
 import { useChatDebugRegistration } from "@/domains/chat/hooks/use-chat-debug-registration";
 import { useDeepLinkApp } from "@/domains/chat/hooks/use-deep-link-app";
+import { useScrollToMessageParam } from "@/domains/chat/hooks/use-scroll-to-message";
 import { lifecycleService } from "@/assistant/lifecycle-service";
 import { isSending, useTurnStore } from "@/domains/chat/turn-store";
 import { Button } from "@vellumai/design-library/components/button";
@@ -86,7 +87,7 @@ import type { ChatMainPanelProps } from "@/domains/chat/components/chat-route-co
 
 export function ActiveChatView() {
   const showLlmInspector = useCanUseLlmInspector();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { conversationId: urlConversationId } = useParams<{ conversationId?: string }>();
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
   const assistantState = useAssistantLifecycleStore.use.assistantState();
@@ -339,6 +340,15 @@ export function ActiveChatView() {
     transcriptRef,
     uiContextRef,
     reconcileActiveConversation,
+  });
+
+  // Deep-link: ?message=<id> scrolls to and highlights that message (e.g. the
+  // "Open" button on a saved bookmark).
+  useScrollToMessageParam({
+    transcriptRef,
+    searchParams,
+    setSearchParams,
+    conversationId: activeConversationId,
   });
 
   // -------------------------------------------------------------------------

--- a/apps/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
+++ b/apps/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
@@ -1,13 +1,21 @@
 
-import { Check, Copy, ExternalLink, FileCode, GitBranch } from "lucide-react";
+import { Bookmark, Check, Copy, ExternalLink, FileCode, GitBranch } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { DisplayMessage } from "@/domains/chat/types/types";
 import { messagePlainText } from "@/domains/chat/utils/message-plain-text";
+import {
+  useBookmarksEnabled,
+  useBookmarkToggle,
+  useIsBookmarked,
+} from "@/hooks/use-bookmarks";
 
 type MessageHoverActionsProps = {
   /** The message whose text is copied and whose role/timestamp drive the row. */
   message: DisplayMessage;
+  /** Conversation the message belongs to. Required for the bookmark toggle —
+   *  the bookmark API keys on (messageId, conversationId). */
+  conversationId?: string | null;
   /** Slack permalink for the message, shown as a hover action when present. */
   openInSlackUrl?: string;
   /** Callback when "Fork from here" is clicked. */
@@ -80,11 +88,25 @@ function latestMessageActivityTimestamp(
 
 export function MessageHoverActions({
   message,
+  conversationId,
   openInSlackUrl,
   onFork,
   onInspect,
 }: MessageHoverActionsProps) {
   const { role } = message;
+
+  // Bookmarks are feature-flag gated, and only persisted messages qualify —
+  // optimistic/streaming rows carry a client-generated id the daemon can't
+  // resolve. The toggle's data hooks live in `MessageBookmarkButton` so they
+  // only mount (and only touch TanStack Query) for bookmarkable rows; that
+  // keeps the flag-off and no-conversation paths free of any query client.
+  const bookmarksEnabled = useBookmarksEnabled();
+  const canBookmark =
+    bookmarksEnabled &&
+    Boolean(conversationId) &&
+    Boolean(message.id) &&
+    !message.isOptimistic;
+
   // Flat plain-text body derived from the message's text blocks; this is the
   // copy payload and mirrors the daemon's `joinWithSpacing`.
   const content = useMemo(
@@ -156,6 +178,13 @@ export function MessageHoverActions({
         </button>
       )}
 
+      {canBookmark && conversationId && message.id && (
+        <MessageBookmarkButton
+          messageId={message.id}
+          conversationId={conversationId}
+        />
+      )}
+
       {openInSlackUrl && (
         <a
           href={openInSlackUrl}
@@ -191,5 +220,41 @@ export function MessageHoverActions({
         </button>
       )}
     </div>
+  );
+}
+
+/**
+ * Bookmark toggle for a persisted message. Split out from the row so its
+ * TanStack Query hooks only mount for bookmarkable messages — rows without a
+ * conversation, optimistic rows, and flag-off installs never construct a query
+ * observer (and SSR render tests need no QueryClientProvider).
+ */
+function MessageBookmarkButton({
+  messageId,
+  conversationId,
+}: {
+  messageId: string;
+  conversationId: string;
+}) {
+  const isBookmarked = useIsBookmarked(messageId);
+  const toggleBookmark = useBookmarkToggle();
+  const handleToggle = useCallback(() => {
+    void toggleBookmark(messageId, conversationId, isBookmarked);
+  }, [messageId, conversationId, isBookmarked, toggleBookmark]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleToggle}
+      title={isBookmarked ? "Remove bookmark" : "Bookmark"}
+      aria-pressed={isBookmarked}
+      className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md text-[var(--content-tertiary)] transition-colors hover:bg-[var(--surface-active)] hover:text-[var(--content-default)]"
+    >
+      <Bookmark
+        className={`h-3.5 w-3.5 ${
+          isBookmarked ? "fill-current text-[var(--content-default)]" : ""
+        }`}
+      />
+    </button>
   );
 }

--- a/apps/web/src/domains/chat/hooks/use-scroll-to-message.ts
+++ b/apps/web/src/domains/chat/hooks/use-scroll-to-message.ts
@@ -1,0 +1,72 @@
+/**
+ * Deep-link: scroll to and highlight a specific message.
+ *
+ * When the chat route carries a `?message=<id>` search param (e.g. from the
+ * "Open" button on a saved bookmark), this hook drives the transcript to scroll
+ * that message into view and flash it. It polls for the message's DOM anchor
+ * for a bounded window because the conversation's history loads asynchronously
+ * after navigation; once found (or the window elapses) it clears the param so
+ * the jump fires exactly once.
+ *
+ * Limitation: if the target lives in an older history page that hasn't been
+ * loaded, its anchor never appears and the hook gives up silently. Forcing
+ * older pages to load until the message is present is a future enhancement.
+ */
+
+import { useEffect } from "react";
+import type { RefObject } from "react";
+import type { SetURLSearchParams } from "react-router";
+
+import type { TranscriptHandle } from "@/domains/chat/transcript/transcript";
+import { SCROLL_TO_MESSAGE_PARAM } from "@/utils/routes";
+
+/** Poll cadence and ceiling — ~3s total to cover async history settling. */
+const POLL_INTERVAL_MS = 150;
+const MAX_ATTEMPTS = 20;
+
+export function useScrollToMessageParam(args: {
+  transcriptRef: RefObject<TranscriptHandle | null>;
+  searchParams: URLSearchParams;
+  setSearchParams: SetURLSearchParams;
+  conversationId: string | null;
+}): void {
+  const { transcriptRef, searchParams, setSearchParams, conversationId } = args;
+  const targetMessageId = searchParams.get(SCROLL_TO_MESSAGE_PARAM);
+
+  useEffect(() => {
+    if (!targetMessageId) return;
+
+    let cancelled = false;
+    let attempts = 0;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const clearParam = () => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.delete(SCROLL_TO_MESSAGE_PARAM);
+          return next;
+        },
+        { replace: true },
+      );
+    };
+
+    const attempt = () => {
+      if (cancelled) return;
+      attempts += 1;
+      const found = transcriptRef.current?.scrollToMessage(targetMessageId) ?? false;
+      if (found || attempts >= MAX_ATTEMPTS) {
+        clearParam();
+        return;
+      }
+      timer = setTimeout(attempt, POLL_INTERVAL_MS);
+    };
+
+    timer = setTimeout(attempt, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+    // `conversationId` re-arms the jump when navigating between threads.
+  }, [targetMessageId, conversationId, transcriptRef, setSearchParams]);
+}

--- a/apps/web/src/domains/chat/transcript/latest-turn-row.tsx
+++ b/apps/web/src/domains/chat/transcript/latest-turn-row.tsx
@@ -21,6 +21,8 @@ import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 export interface LatestTurnRowProps {
   anchorMessage: MessageItem;
   responseItems: TranscriptItem[];
+  /** Conversation id, forwarded to message bodies for the bookmark toggle. */
+  conversationId?: string | null;
   assistantDisplayName?: string | null;
   onSurfaceAction: (
     surfaceId: string,
@@ -61,6 +63,7 @@ export interface LatestTurnRowProps {
 export const LatestTurnRow = memo(function LatestTurnRow({
   anchorMessage,
   responseItems,
+  conversationId,
   assistantDisplayName,
   onSurfaceAction,
   onForkConversation,
@@ -87,6 +90,7 @@ export const LatestTurnRow = memo(function LatestTurnRow({
     <div className="flex flex-col" data-latest-turn="true">
       <TranscriptRow
         item={anchorMessage}
+        conversationId={conversationId}
         assistantDisplayName={assistantDisplayName}
         onSurfaceAction={onSurfaceAction}
         onForkConversation={onForkConversation}
@@ -107,6 +111,7 @@ export const LatestTurnRow = memo(function LatestTurnRow({
         <Fragment key={response.key}>
           <TranscriptRow
             item={response}
+            conversationId={conversationId}
             assistantDisplayName={assistantDisplayName}
             onSurfaceAction={onSurfaceAction}
             onForkConversation={onForkConversation}

--- a/apps/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
@@ -29,6 +29,9 @@ export interface OpenRuleEditorContext {
  */
 export interface TranscriptMessageBodyProps {
   message: DisplayMessage;
+  /** Conversation the message belongs to. Forwarded to the hover actions so
+   *  the bookmark toggle can key on (messageId, conversationId). */
+  conversationId?: string | null;
   assistantDisplayName?: string | null;
 
   onSurfaceAction: (

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -54,6 +54,7 @@ import {
  */
 export function TranscriptMessageBody({
   message,
+  conversationId,
   assistantDisplayName,
   onSurfaceAction,
   onForkConversation,
@@ -379,6 +380,7 @@ export function TranscriptMessageBody({
       <div className="h-6 opacity-0 transition-opacity duration-150 group-hover/msg:opacity-100 has-[:focus-visible]:opacity-100 group-data-[revealed=true]/msg:opacity-100">
         <MessageHoverActions
           message={message}
+          conversationId={conversationId}
           openInSlackUrl={slackMessageUrl}
           onFork={forkHandler}
           onInspect={inspectHandler}
@@ -410,6 +412,7 @@ export function TranscriptMessageBody({
   return (
     <div
       ref={wrapperRef}
+      id={message.id ? `msg-${message.id}` : undefined}
       onClick={handleBubbleClick}
       data-revealed={revealed}
       className={wrapperClass}

--- a/apps/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-row.tsx
@@ -21,6 +21,8 @@ import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
  */
 export interface TranscriptRowProps {
   item: TranscriptItem;
+  /** Conversation id, forwarded to message bodies for the bookmark toggle. */
+  conversationId?: string | null;
   assistantDisplayName?: string | null;
   onSurfaceAction: (
     surfaceId: string,
@@ -69,6 +71,7 @@ export interface TranscriptRowProps {
 
 export const TranscriptRow = memo(function TranscriptRow({
   item,
+  conversationId,
   assistantDisplayName,
   onSurfaceAction,
   onForkConversation,
@@ -91,6 +94,7 @@ export const TranscriptRow = memo(function TranscriptRow({
       return (
         <TranscriptMessageBody
           message={item.message}
+          conversationId={conversationId}
           assistantDisplayName={assistantDisplayName}
           onSurfaceAction={onSurfaceAction}
           onForkConversation={onForkConversation}

--- a/apps/web/src/domains/chat/transcript/transcript.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript.tsx
@@ -3,6 +3,7 @@ import {
   Fragment,
   forwardRef,
   useCallback,
+  useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
@@ -119,6 +120,10 @@ export interface TranscriptProps {
 
 export interface TranscriptHandle {
   scrollToLatest(opts?: { behavior?: "auto" | "smooth" }): void;
+  /** Scroll a message into view by id and briefly highlight it. Returns
+   *  `false` when no element with that message id is currently rendered (e.g.
+   *  the message lives in an older history page not yet loaded). */
+  scrollToMessage(messageId: string): boolean;
   getScrollElement(): HTMLDivElement | null;
   /** Inner wrapper that surrounds all rendered children. Sized to the
    *  scroll content; observable via `ResizeObserver` to detect when
@@ -142,7 +147,15 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
       props;
     const scrollRef = useRef<HTMLDivElement | null>(null);
     const contentRef = useRef<HTMLDivElement | null>(null);
+    // Pending removal of the transient deep-link highlight class.
+    const highlightTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const viewportMinHeight = useViewportMinHeight(scrollRef);
+
+    useEffect(() => {
+      return () => {
+        if (highlightTimerRef.current) clearTimeout(highlightTimerRef.current);
+      };
+    }, []);
 
     const pullEnabled = !!pullRefreshEnabled && !!onPullRefresh;
     const handlePullRefresh = useCallback(async () => {
@@ -168,6 +181,20 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
             top: el.scrollHeight - el.clientHeight,
             behavior: opts?.behavior ?? "auto",
           });
+        },
+        scrollToMessage(messageId) {
+          const target = document.getElementById(`msg-${messageId}`);
+          if (!target) return false;
+          target.scrollIntoView({ block: "center", behavior: "smooth" });
+          target.classList.add("message-highlighted");
+          if (highlightTimerRef.current) {
+            clearTimeout(highlightTimerRef.current);
+          }
+          highlightTimerRef.current = setTimeout(() => {
+            target.classList.remove("message-highlighted");
+            highlightTimerRef.current = null;
+          }, 2000);
+          return true;
         },
         getScrollElement() {
           return scrollRef.current;
@@ -204,6 +231,7 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
     );
 
     const rowProps = {
+      conversationId,
       onSurfaceAction: rest.onSurfaceAction,
       onForkConversation: rest.onForkConversation,
       onInspectMessage: rest.onInspectMessage,

--- a/apps/web/src/domains/chat/transcript/use-transcript-scroll.test.ts
+++ b/apps/web/src/domains/chat/transcript/use-transcript-scroll.test.ts
@@ -110,6 +110,7 @@ function makeHandle(): TranscriptHandle & {
   }));
   return {
     scrollToLatest,
+    scrollToMessage: mock((): boolean => false),
     getScrollElement,
     getContentElement,
     getViewportHeight,

--- a/apps/web/src/domains/chat/utils/debug-api.test.ts
+++ b/apps/web/src/domains/chat/utils/debug-api.test.ts
@@ -889,6 +889,7 @@ function makeTranscriptHandle(
 ): TranscriptHandle {
   return {
     scrollToLatest: () => {},
+    scrollToMessage: () => false,
     getScrollElement: () => scrollEl,
     getContentElement: () => null,
     getViewportHeight: () => scrollEl?.clientHeight ?? 0,

--- a/apps/web/src/domains/settings/pages/bookmarks-page.tsx
+++ b/apps/web/src/domains/settings/pages/bookmarks-page.tsx
@@ -1,0 +1,190 @@
+import { AlertTriangle, Bookmark, Loader2, RotateCcw, X } from "lucide-react";
+import { useNavigate } from "react-router";
+
+import {
+  type Bookmark as BookmarkSummary,
+  useBookmarks,
+  useBookmarkToggle,
+} from "@/hooks/use-bookmarks";
+import { routes } from "@/utils/routes";
+import { Button } from "@vellumai/design-library/components/button";
+import { Card } from "@vellumai/design-library/components/card";
+
+function formatBookmarkDate(timestamp: number | undefined): string {
+  if (timestamp == null) return "";
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  });
+}
+
+function EmptyState() {
+  return (
+    <Card>
+      <div className="flex min-h-[400px] flex-col items-center justify-center px-6 py-16 text-center">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[var(--surface-base)]">
+          <Bookmark className="h-6 w-6 text-[var(--content-disabled)] dark:text-[var(--content-default)]" />
+        </div>
+        <h2 className="mt-4 text-title-small text-[var(--content-default)]">
+          No bookmarks
+        </h2>
+        <p className="mt-1 text-body-medium-lighter text-[var(--content-tertiary)]">
+          Hover any message and click the bookmark icon to save it here.
+        </p>
+      </div>
+    </Card>
+  );
+}
+
+function BookmarkRow({
+  bookmark,
+  isFirst,
+  onOpen,
+  onRemove,
+}: {
+  bookmark: BookmarkSummary;
+  isFirst: boolean;
+  onOpen: () => void;
+  onRemove: () => void;
+}) {
+  const title =
+    bookmark.conversationTitle && bookmark.conversationTitle.trim().length > 0
+      ? bookmark.conversationTitle
+      : "Untitled conversation";
+  // Accent the source: assistant replies read stronger than the user's own
+  // lines, matching the legacy macOS Bookmarks tab.
+  const isAssistant = bookmark.messageRole !== "user";
+  const savedAt = formatBookmarkDate(bookmark.createdAt);
+
+  return (
+    <div
+      className={`flex items-start gap-3 py-3 ${
+        isFirst ? "" : "border-t border-[var(--border-base)]"
+      }`}
+    >
+      <span
+        aria-hidden
+        className="mt-1 h-8 w-1 shrink-0 rounded-full"
+        style={{
+          backgroundColor: isAssistant
+            ? "var(--content-default)"
+            : "var(--content-tertiary)",
+        }}
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline justify-between gap-3">
+          <div className="truncate text-body-medium-default text-[var(--content-default)]">
+            {title}
+          </div>
+          {savedAt ? (
+            <span className="shrink-0 text-body-small-default text-[var(--content-tertiary)]">
+              {savedAt}
+            </span>
+          ) : null}
+        </div>
+        {bookmark.messagePreview ? (
+          <p className="mt-0.5 line-clamp-2 text-body-small-default text-[var(--content-tertiary)]">
+            {bookmark.messagePreview}
+          </p>
+        ) : null}
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        <Button variant="outlined" onClick={onOpen}>
+          Open
+        </Button>
+        <button
+          type="button"
+          onClick={onRemove}
+          title="Remove bookmark"
+          aria-label="Remove bookmark"
+          className="flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-[var(--content-tertiary)] transition-colors hover:bg-[var(--surface-active)] hover:text-[var(--content-default)]"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function BookmarksPage() {
+  const navigate = useNavigate();
+  const { bookmarks, isLoading, isError, refetch } = useBookmarks();
+  const toggleBookmark = useBookmarkToggle();
+
+  if (isLoading) {
+    return (
+      <div className="w-full">
+        <div className="flex min-h-[400px] items-center justify-center">
+          <Loader2 className="h-6 w-6 animate-spin text-[var(--content-disabled)]" />
+        </div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="w-full">
+        <Card>
+          <div className="flex min-h-[400px] flex-col items-center justify-center px-6 py-16 text-center">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[var(--system-error-lighter)]">
+              <AlertTriangle className="h-6 w-6 text-[var(--system-error-default)]" />
+            </div>
+            <h2 className="mt-4 text-title-small text-[var(--content-default)]">
+              Failed to load bookmarks
+            </h2>
+            <p className="mt-1 text-body-medium-lighter text-[var(--content-tertiary)]">
+              Something went wrong. Please try again.
+            </p>
+            <Button variant="outlined" onClick={refetch} className="mt-4">
+              <RotateCcw className="h-4 w-4" />
+              Retry
+            </Button>
+          </div>
+        </Card>
+      </div>
+    );
+  }
+
+  if (bookmarks.length === 0) {
+    return (
+      <div className="w-full">
+        <EmptyState />
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full">
+      <Card noPadding className="px-4">
+        {bookmarks.map((bookmark, index) => (
+          <BookmarkRow
+            key={bookmark.id}
+            bookmark={bookmark}
+            isFirst={index === 0}
+            onOpen={() => {
+              navigate(
+                routes.conversationAtMessage(
+                  bookmark.conversationId,
+                  bookmark.messageId,
+                ),
+              );
+            }}
+            onRemove={() => {
+              void toggleBookmark(
+                bookmark.messageId,
+                bookmark.conversationId,
+                true,
+              );
+            }}
+          />
+        ))}
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/domains/settings/settings-layout.tsx
+++ b/apps/web/src/domains/settings/settings-layout.tsx
@@ -23,6 +23,7 @@ import { SidebarTree, type SidebarItem } from "@/components/sidebar-tree";
 export function SettingsLayout() {
   const settingsDeveloperNav = useAssistantFeatureFlagStore.use.settingsDeveloperNav();
   const platformNotifications = useClientFeatureFlagStore.use.platformNotifications();
+  const bookmarksEnabled = useClientFeatureFlagStore.use.bookmarks();
   const platformGate = usePlatformGate({ platformHostedOnly: true });
   const billingGate = usePlatformGate();
   const { pathname } = useLocation();
@@ -43,6 +44,9 @@ export function SettingsLayout() {
         if (item.id === "billing" && billingGate !== "full") {
           return false;
         }
+        if (item.id === "bookmarks" && !bookmarksEnabled) {
+          return false;
+        }
         if (item.id === "devices" && platformGate === "gated") {
           return false;
         }
@@ -57,7 +61,7 @@ export function SettingsLayout() {
         }
         return true;
       }),
-    [platformNotifications, platformGate, billingGate],
+    [platformNotifications, platformGate, billingGate, bookmarksEnabled],
   );
 
   const bottomItems = useMemo<SidebarItem[]>(() => {

--- a/apps/web/src/hooks/use-bookmarks-sync.ts
+++ b/apps/web/src/hooks/use-bookmarks-sync.ts
@@ -1,0 +1,36 @@
+/**
+ * Bus consumer for cross-client bookmark invalidation.
+ *
+ * The daemon publishes `bookmark.created` / `bookmark.deleted` over SSE after
+ * every mutation so any other connected client refreshes its bookmark list in
+ * lock-step. This hook listens on the event bus and invalidates the shared
+ * bookmark query when one of those events lands.
+ *
+ * The discriminant is read as a plain string: the published
+ * `@vellumai/assistant-api` event union does not model bookmark events, so a
+ * typed `=== "bookmark.created"` comparison would not narrow.
+ *
+ * References:
+ * - EVENT_BUS.md — bus subscription contract
+ * - hooks/use-document-editor-sync.ts — sibling SSE bus consumer
+ */
+
+import { useQueryClient } from "@tanstack/react-query";
+
+import { bookmarksGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
+import { useBusSubscription } from "@/hooks/use-bus-subscription";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+
+export function useBookmarksSync(): void {
+  const queryClient = useQueryClient();
+  const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
+
+  useBusSubscription("sse.event", (envelope) => {
+    const type = (envelope.message as { type?: string }).type;
+    if (type !== "bookmark.created" && type !== "bookmark.deleted") return;
+    if (!assistantId) return;
+    void queryClient.invalidateQueries({
+      queryKey: bookmarksGetQueryKey({ path: { assistant_id: assistantId } }),
+    });
+  });
+}

--- a/apps/web/src/hooks/use-bookmarks.ts
+++ b/apps/web/src/hooks/use-bookmarks.ts
@@ -1,0 +1,162 @@
+/**
+ * Message bookmarks — client data layer.
+ *
+ * Wraps the generated bookmark API (`/v1/assistants/{id}/bookmarks`) in
+ * TanStack Query so the list is fetched once and shared across every caller
+ * (the per-message hover toggle and the Settings → Bookmarks tab). TanStack is
+ * the single source of truth — there is no separate store mirroring the list.
+ *
+ * The query only runs when the `bookmarks` client feature flag is on AND an
+ * assistant is resolved, so flag-off installs never hit the endpoint.
+ *
+ * Cross-client invalidation (a bookmark made in another tab/window) is handled
+ * by `use-bookmarks-sync.ts`, which listens for the daemon's
+ * `bookmark.created` / `bookmark.deleted` SSE events.
+ */
+
+import { useCallback } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  bookmarksGetOptions,
+  bookmarksGetQueryKey,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+import {
+  bookmarksBymessageByMessageIdDelete,
+  bookmarksPost,
+} from "@/generated/daemon/sdk.gen";
+import type { BookmarksGetResponse } from "@/generated/daemon/types.gen";
+import { captureError } from "@/lib/sentry/capture-error";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { toast } from "@vellumai/design-library";
+
+/** A single bookmark row as returned by `GET /v1/.../bookmarks`. */
+export type Bookmark = NonNullable<BookmarksGetResponse>["bookmarks"][number];
+
+const EMPTY_BOOKMARKS: Bookmark[] = [];
+
+/** Whether the `bookmarks` client feature flag is enabled. */
+export function useBookmarksEnabled(): boolean {
+  return useClientFeatureFlagStore.use.bookmarks();
+}
+
+/** Active assistant id + whether the shared bookmark query should run. */
+function useBookmarkQueryGate(): { assistantId: string | null; enabled: boolean } {
+  const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
+  const enabled = useBookmarksEnabled() && Boolean(assistantId);
+  return { assistantId, enabled };
+}
+
+/** Full bookmark list for the Settings tab, newest-first. */
+export function useBookmarks(): {
+  bookmarks: Bookmark[];
+  isLoading: boolean;
+  isError: boolean;
+  refetch: () => void;
+} {
+  const { assistantId, enabled } = useBookmarkQueryGate();
+  const query = useQuery({
+    ...bookmarksGetOptions({ path: { assistant_id: assistantId ?? "" } }),
+    enabled,
+  });
+  return {
+    bookmarks: query.data?.bookmarks ?? EMPTY_BOOKMARKS,
+    isLoading: query.isLoading,
+    isError: query.isError,
+    refetch: () => {
+      void query.refetch();
+    },
+  };
+}
+
+/**
+ * Whether `messageId` is currently bookmarked. Uses a `select` so a message
+ * row only re-renders when its own bookmarked state flips, not on every
+ * change to the list.
+ */
+export function useIsBookmarked(messageId: string | undefined): boolean {
+  const { assistantId, enabled } = useBookmarkQueryGate();
+  const query = useQuery({
+    ...bookmarksGetOptions({ path: { assistant_id: assistantId ?? "" } }),
+    enabled,
+    select: (res) =>
+      messageId ? res.bookmarks.some((b) => b.messageId === messageId) : false,
+  });
+  return query.data ?? false;
+}
+
+/**
+ * Returns a stable `toggle(messageId, conversationId, currentlyBookmarked)`
+ * that creates or deletes a bookmark with an optimistic cache update (rolled
+ * back on error), then invalidates to reconcile with the server. Mirrors the
+ * imperative SDK-call pattern used by the Archive settings page.
+ */
+export function useBookmarkToggle(): (
+  messageId: string,
+  conversationId: string,
+  currentlyBookmarked: boolean,
+) => Promise<void> {
+  const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
+  const queryClient = useQueryClient();
+
+  return useCallback(
+    async (messageId, conversationId, currentlyBookmarked) => {
+      if (!assistantId) return;
+      const queryKey = bookmarksGetQueryKey({
+        path: { assistant_id: assistantId },
+      });
+
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<BookmarksGetResponse>(queryKey);
+
+      queryClient.setQueryData<BookmarksGetResponse>(queryKey, (old) => {
+        const list = old?.bookmarks ?? [];
+        if (currentlyBookmarked) {
+          return { bookmarks: list.filter((b) => b.messageId !== messageId) };
+        }
+        if (list.some((b) => b.messageId === messageId)) return old;
+        const now = Date.now();
+        const optimistic: Bookmark = {
+          id: `optimistic-${messageId}`,
+          messageId,
+          conversationId,
+          conversationTitle: null,
+          messagePreview: "",
+          messageRole: "",
+          messageCreatedAt: now,
+          createdAt: now,
+        };
+        return { bookmarks: [optimistic, ...list] };
+      });
+
+      try {
+        if (currentlyBookmarked) {
+          await bookmarksBymessageByMessageIdDelete({
+            path: { assistant_id: assistantId, messageId },
+            throwOnError: true,
+          });
+        } else {
+          await bookmarksPost({
+            path: { assistant_id: assistantId },
+            body: { messageId, conversationId },
+            throwOnError: true,
+          });
+        }
+      } catch (error) {
+        if (previous !== undefined) {
+          queryClient.setQueryData(queryKey, previous);
+        }
+        captureError(error, { context: "bookmark_toggle" });
+        toast.error(
+          currentlyBookmarked
+            ? "Failed to remove bookmark."
+            : "Failed to bookmark message.",
+        );
+      } finally {
+        void queryClient.invalidateQueries({ queryKey });
+      }
+    },
+    [assistantId, queryClient],
+  );
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -85,6 +85,19 @@ body {
   animation: busy-pulse 1s ease-in-out infinite;
 }
 
+/* Deep-link message highlight — a one-shot background flash applied when the
+ * transcript scrolls to a message (e.g. opening a saved bookmark). Fades from
+ * the active-surface tint back to transparent over 2s. */
+@keyframes message-highlight-flash {
+  0% { background-color: var(--surface-active); }
+  100% { background-color: transparent; }
+}
+
+.message-highlighted {
+  animation: message-highlight-flash 2s ease-out;
+  border-radius: var(--radius-lg);
+}
+
 /* Avatar streaming ring — a semicircular arc that traces the circular avatar's
    edge and spins continuously while the assistant is streaming/loading. Used
    only for custom uploaded-image avatars; character avatars convey streaming

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -21,6 +21,7 @@ import { useVellumCommands } from "@/runtime/vellum-commands";
 import { routes } from "@/utils/routes";
 import { useAssistantResourceSync } from "@/hooks/use-assistant-resource-sync";
 import { useDocumentEditorSync } from "@/hooks/use-document-editor-sync";
+import { useBookmarksSync } from "@/hooks/use-bookmarks-sync";
 import { useNotificationIntentSync } from "@/hooks/use-notification-intent-sync";
 import { useOnboardingWindowSize } from "@/hooks/use-onboarding-window-size";
 import { useConversationSync } from "@/hooks/use-conversation-sync";
@@ -109,6 +110,7 @@ export function RootLayout() {
   useFeatureFlagBusSync(assistantId, isAssistantActive);
   useNotificationIntentSync(assistantId);
   useDocumentEditorSync();
+  useBookmarksSync();
 
   // Keep the browser favicon in sync with the assistant's avatar across
   // every authenticated route (chat, settings, logs, etc.). Mounted here

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -228,6 +228,7 @@ export const routeTree = [
                 { path: "devices", lazy: { Component: () => import("@/domains/settings/pages/devices-page").then((m) => m.DevicesPage) } },
                 { path: "privacy", lazy: { Component: () => import("@/domains/settings/pages/privacy-page").then((m) => m.PrivacyPage) } },
                 { path: "archive", lazy: { Component: () => import("@/domains/settings/pages/archive-page").then((m) => m.ArchivePage) } },
+                { path: "bookmarks", lazy: { Component: () => import("@/domains/settings/pages/bookmarks-page").then((m) => m.BookmarksPage) } },
                 { path: "billing", lazy: { Component: () => import("@/domains/settings/billing/billing-page").then((m) => m.BillingPage) } },
                 { path: "billing/upgrade/cancel", lazy: { Component: () => import("@/domains/settings/billing/upgrade-cancel-page").then((m) => m.UpgradeCancelPage) } },
                 { path: "billing/upgrade/success", lazy: { Component: () => import("@/domains/settings/billing/upgrade-success-page").then((m) => m.UpgradeSuccessPage) } },

--- a/apps/web/src/utils/routes.ts
+++ b/apps/web/src/utils/routes.ts
@@ -18,6 +18,13 @@ const dyn = (parent: string, id: string): string => `${parent}/${id}`;
 const LOCAL_ADMIN_ORIGIN = "http://localhost:3000";
 const LOGS_USAGE_PATH = r("/assistant/logs/usage");
 
+/**
+ * Search param the chat transcript reads on load to scroll to and highlight a
+ * specific message (e.g. the "Open" button on a saved bookmark). Shared by the
+ * link producer (settings) and the consumer (chat).
+ */
+export const SCROLL_TO_MESSAGE_PARAM = "message";
+
 export const routes = {
   assistant: r("/assistant"),
   /**
@@ -43,6 +50,10 @@ export const routes = {
   quickInput: r("/assistant/quick-input"),
   conversations: r("/assistant/conversations"),
   conversation: (key: string) => dyn(r("/assistant/conversations"), key),
+  /** Conversation URL that asks the transcript to scroll to + highlight a
+   *  specific message on load. */
+  conversationAtMessage: (conversationId: string, messageId: string) =>
+    `${dyn(r("/assistant/conversations"), conversationId)}?${SCROLL_TO_MESSAGE_PARAM}=${encodeURIComponent(messageId)}`,
   /**
    * LLM-context inspector for a single conversation. The conversation id
    * lives in the URL path so the link is sharable and the page can route
@@ -123,6 +134,7 @@ export const routes = {
     devices: r("/assistant/settings/devices"),
     privacy: r("/assistant/settings/privacy"),
     archive: r("/assistant/settings/archive"),
+    bookmarks: r("/assistant/settings/bookmarks"),
     billing: r("/assistant/settings/billing"),
     community: r("/assistant/settings/community"),
     debug: r("/assistant/settings/debug"),

--- a/apps/web/src/utils/settings-navigation.ts
+++ b/apps/web/src/utils/settings-navigation.ts
@@ -11,6 +11,7 @@ import type { LucideIcon } from "lucide-react";
 import {
   Archive,
   Bell,
+  Bookmark,
   Bug,
   CalendarClock,
   Code,
@@ -45,6 +46,7 @@ export const PANEL_IDS = [
   "privacy",
   "schedules",
   "archive",
+  "bookmarks",
   "billing",
   "community",
   "assistant-status",
@@ -87,6 +89,7 @@ export const SETTINGS_SIDEBAR: SidebarItem[] = [
   { id: "devices", label: "Self-Hosted Assistants", href: routes.settings.devices, icon: Laptop },
   { id: "privacy", label: "Permissions & Privacy", href: routes.settings.privacy, icon: ShieldCheck },
   { id: "archive", label: "Archive", href: routes.settings.archive, icon: Archive },
+  { id: "bookmarks", label: "Bookmarks", href: routes.settings.bookmarks, icon: Bookmark },
   { id: "billing", label: "Billing", href: routes.settings.billing, icon: CreditCard },
   { id: "community", label: "Community", href: routes.settings.community, icon: Users },
   { id: "assistant-debug", label: "Debug", href: routes.settings.debug, icon: Bug },


### PR DESCRIPTION
## Summary
- Port the message-bookmarks feature from the legacy Swift macOS app to `apps/web`, behind the existing `bookmarks` client flag (default off): a bookmark toggle in each message's hover actions, a Settings → Bookmarks tab listing saved messages with open/remove, and live cross-tab invalidation from the daemon's `bookmark.created` / `bookmark.deleted` SSE events.
- "Open" on a saved bookmark deep-links to the conversation and scrolls to + flashes the exact message via a new `?message=<id>` param (a `scrollToMessage` handle on the transcript + a one-shot highlight). The transcript is non-virtualized, so this is a DOM anchor (`id="msg-<id>"`) plus `scrollIntoView`; messages in an unloaded older page are a known no-op (follow-up).
- Backend API and the generated web SDK already existed, so this is UI + wiring only. TanStack Query is the single source of truth (no new store); the query hooks are isolated to a `MessageBookmarkButton` child so flag-off and SSR paths construct no query client.

## Original prompt
Port the message-bookmarks feature from the legacy Swift macOS app (`clients/macos/`) to the new Electron/web app (`apps/web/`), which only had a stub flag + icon. Per discussion: "Open" should scroll to and highlight the exact message (full parity with the Swift jump-to-message), and the feature ships behind the existing `bookmarks` client flag (default off), enabled per-instance via a client-flag override.

Verified locally: `bunx tsc --noEmit` clean; targeted tests pass (message-hover-actions, transcript, transcript-message-body, latest-turn-row, use-transcript-scroll, debug-api).

🤖 Generated with [Claude Code](https://claude.com/claude-code)