### PR TITLE
fix(memory): exempt host_file_read from result-time tool-result spooling

### DIFF
--- a/assistant/src/__tests__/post-turn-tool-result-truncation.test.ts
+++ b/assistant/src/__tests__/post-turn-tool-result-truncation.test.ts
@@ -49,8 +49,10 @@ describe("postTurnTruncateToolResults", () => {
     const shortContent = "a".repeat(THRESHOLD_CHARS);
     const messages = makeMessages([makeToolResult(shortContent)]);
 
-    const { messages: result, truncatedCount } =
-      postTurnTruncateToolResults(messages, { conversationDir: convDir });
+    const { messages: result, truncatedCount } = postTurnTruncateToolResults(
+      messages,
+      { conversationDir: convDir },
+    );
 
     expect(truncatedCount).toBe(0);
     expect(result).toBe(messages); // same reference — no copy
@@ -62,12 +64,17 @@ describe("postTurnTruncateToolResults", () => {
     const toolUseId = "tool_use_abc";
     const messages = makeMessages([makeToolResult(longContent, toolUseId)]);
 
-    const { messages: result, truncatedCount } =
-      postTurnTruncateToolResults(messages, { conversationDir: convDir });
+    const { messages: result, truncatedCount } = postTurnTruncateToolResults(
+      messages,
+      { conversationDir: convDir },
+    );
 
     expect(truncatedCount).toBe(1);
 
-    const block = result[0].content[0] as { type: "tool_result"; content: string };
+    const block = result[0].content[0] as {
+      type: "tool_result";
+      content: string;
+    };
     expect(block.content).toContain(TRUNCATION_MARKER);
     expect(block.content.length).toBeLessThan(longContent.length);
 
@@ -83,8 +90,10 @@ describe("postTurnTruncateToolResults", () => {
       makeToolResult(longContent, "tool_err", true),
     ]);
 
-    const { messages: result, truncatedCount } =
-      postTurnTruncateToolResults(messages, { conversationDir: convDir });
+    const { messages: result, truncatedCount } = postTurnTruncateToolResults(
+      messages,
+      { conversationDir: convDir },
+    );
 
     expect(truncatedCount).toBe(0);
     expect(result).toBe(messages);
@@ -100,8 +109,10 @@ describe("postTurnTruncateToolResults", () => {
       makeToolResult(alreadyTruncated, "tool_idempotent"),
     ]);
 
-    const { messages: result, truncatedCount } =
-      postTurnTruncateToolResults(messages, { conversationDir: convDir });
+    const { messages: result, truncatedCount } = postTurnTruncateToolResults(
+      messages,
+      { conversationDir: convDir },
+    );
 
     expect(truncatedCount).toBe(0);
     expect(result).toBe(messages);
@@ -117,8 +128,10 @@ describe("postTurnTruncateToolResults", () => {
       makeToolResult(long2, "tool_long2"),
     ]);
 
-    const { messages: result, truncatedCount } =
-      postTurnTruncateToolResults(messages, { conversationDir: convDir });
+    const { messages: result, truncatedCount } = postTurnTruncateToolResults(
+      messages,
+      { conversationDir: convDir },
+    );
 
     expect(truncatedCount).toBe(2);
 
@@ -174,8 +187,10 @@ describe("postTurnTruncateToolResults", () => {
       { role: "user", content: [makeToolResult(skillBody, toolUseId)] },
     ];
 
-    const { messages: result, truncatedCount } =
-      postTurnTruncateToolResults(messages, { conversationDir: convDir });
+    const { messages: result, truncatedCount } = postTurnTruncateToolResults(
+      messages,
+      { conversationDir: convDir },
+    );
 
     expect(truncatedCount).toBe(0);
     expect(result).toBe(messages); // same reference — no copy
@@ -209,8 +224,10 @@ describe("postTurnTruncateToolResults", () => {
       { role: "user", content: [makeToolResult(longContent, toolUseId)] },
     ];
 
-    const { messages: result, truncatedCount } =
-      postTurnTruncateToolResults(messages, { conversationDir: convDir });
+    const { messages: result, truncatedCount } = postTurnTruncateToolResults(
+      messages,
+      { conversationDir: convDir },
+    );
 
     expect(truncatedCount).toBe(1);
     const block = result[1].content[0] as {
@@ -262,7 +279,38 @@ describe("derefToolResultReReads", () => {
       derefToolResultReReads(messages);
 
     expect(dereferencedCount).toBe(1);
-    const block = result[1].content[0] as { type: "tool_result"; content: string };
+    const block = result[1].content[0] as {
+      type: "tool_result";
+      content: string;
+    };
+    expect(block.content).toBe(REREAD_STUB);
+  });
+
+  test("host_file_read of .tool-results/ path: tool_result content replaced with REREAD_STUB", () => {
+    const toolUseId = "tu_host_reread";
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: [
+          makeToolUse(toolUseId, "host_file_read", {
+            path: `/home/user/.local/share/vellum/conversations/abc/${TOOL_RESULT_DIR}/abc123.txt`,
+          }),
+        ],
+      },
+      {
+        role: "user",
+        content: [makeToolResult("full host file contents here", toolUseId)],
+      },
+    ];
+
+    const { messages: result, dereferencedCount } =
+      derefToolResultReReads(messages);
+
+    expect(dereferencedCount).toBe(1);
+    const block = result[1].content[0] as {
+      type: "tool_result";
+      content: string;
+    };
     expect(block.content).toBe(REREAD_STUB);
   });
 
@@ -289,7 +337,10 @@ describe("derefToolResultReReads", () => {
 
     expect(dereferencedCount).toBe(0);
     expect(result).toBe(messages); // same reference — no copy
-    const block = result[1].content[0] as { type: "tool_result"; content: string };
+    const block = result[1].content[0] as {
+      type: "tool_result";
+      content: string;
+    };
     expect(block.content).toBe(originalContent);
   });
 
@@ -316,7 +367,10 @@ describe("derefToolResultReReads", () => {
 
     expect(dereferencedCount).toBe(0);
     expect(result).toBe(messages);
-    const block = result[1].content[0] as { type: "tool_result"; content: string };
+    const block = result[1].content[0] as {
+      type: "tool_result";
+      content: string;
+    };
     expect(block.content).toBe(outputMentioningDir);
   });
 

--- a/assistant/src/__tests__/tool-result-spool.test.ts
+++ b/assistant/src/__tests__/tool-result-spool.test.ts
@@ -110,12 +110,13 @@ describe("spoolAndStubOversizedToolResults", () => {
     expect(messages).toBe(history);
   });
 
-  test("skips below-threshold, error, exempt, file_read, marked, and ax-tree results", () => {
+  test("skips below-threshold, error, exempt, file_read, host_file_read, marked, and ax-tree results", () => {
     const blocks = [
       makeToolResult(SHORT, "tu_short"),
       makeToolResult(LONG, "tu_err", true),
       makeToolResult(LONG, "tu_skill"),
       makeToolResult(LONG, "tu_read"),
+      makeToolResult(LONG, "tu_host_read"),
       makeToolResult(`${LONG}${TRUNCATION_MARKER}`, "tu_marked"),
       makeToolResult(`<ax-tree>${LONG}</ax-tree>`, "tu_ax"),
       { type: "text" as const, text: LONG },
@@ -127,6 +128,7 @@ describe("spoolAndStubOversizedToolResults", () => {
       toolNameById: (id) => {
         if (id === "tu_skill") return "skill_load";
         if (id === "tu_read") return "file_read";
+        if (id === "tu_host_read") return "host_file_read";
         return undefined;
       },
     });

--- a/assistant/src/context/post-turn-tool-result-truncation.ts
+++ b/assistant/src/context/post-turn-tool-result-truncation.ts
@@ -33,6 +33,21 @@ export const TRUNCATION_MARKER = "\u2014 full result:";
 export const TRUNCATION_EXEMPT_TOOLS = new Set<string>(["skill_load"]);
 
 /**
+ * File-read tools that page spooled `.tool-results/` content back into context.
+ * `file_read` reads inside the workspace; `host_file_read` reads anywhere on the
+ * host. Both are (a) exempt from the result-time spool pass — re-stubbing a read
+ * of a spooled file would hand back another stub, so the content could never be
+ * paged back at all — and (b) recognized by {@link derefToolResultReReads}, so a
+ * re-read of a spooled file collapses to a stub instead of duplicating content
+ * already in context. Sharing one set keeps the two passes from drifting if a
+ * new file-read tool is added.
+ */
+export const FILE_READ_TOOL_NAMES = new Set<string>([
+  "file_read",
+  "host_file_read",
+]);
+
+/**
  * Build a map of tool_use_id -> originating tool name by walking the tool_use
  * blocks in assistant messages. A tool_result only carries `tool_use_id`, so
  * this is the only way to recover which tool produced a given result.
@@ -170,16 +185,18 @@ export const REREAD_STUB =
  * Deduplicate re-reads of saved tool results.
  *
  * When `postTurnTruncateToolResults` truncates a large result, it saves the full
- * content to a `.tool-results/` file. If the model later calls `file_read` on that
- * saved file, the result is a second copy of content whose truncated prefix/suffix
- * is already in context. This function detects those re-reads and replaces their
- * tool_result content with a short stub to avoid duplication.
+ * content to a `.tool-results/` file. If the model later calls `file_read` or
+ * `host_file_read` on that saved file, the result is a second copy of content
+ * whose truncated prefix/suffix is already in context. This function detects
+ * those re-reads and replaces their tool_result content with a short stub to
+ * avoid duplication.
  */
 export function derefToolResultReReads(messages: Message[]): {
   messages: Message[];
   dereferencedCount: number;
 } {
-  // Build a set of tool_use_ids that are file_read calls targeting .tool-results/ paths.
+  // Build a set of tool_use_ids that are file-read calls (file_read or
+  // host_file_read) targeting .tool-results/ paths.
   const reReadToolUseIds = new Set<string>();
 
   for (const msg of messages) {
@@ -187,7 +204,7 @@ export function derefToolResultReReads(messages: Message[]): {
     for (const block of msg.content) {
       if (block.type !== "tool_use") continue;
       const tu = block as ToolUseContent;
-      if (tu.name !== "file_read") continue;
+      if (!FILE_READ_TOOL_NAMES.has(tu.name)) continue;
       const filePath = tu.input.path ?? tu.input.file_path;
       if (typeof filePath !== "string") continue;
       if (filePath.includes(`/${TOOL_RESULT_DIR}/`)) {

--- a/assistant/src/context/tool-result-spool.ts
+++ b/assistant/src/context/tool-result-spool.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import type { ContentBlock, ToolResultContent } from "../providers/types.js";
 import {
   buildTruncatedContent,
+  FILE_READ_TOOL_NAMES,
   getToolResultFilePath,
   isTruncationEligible,
   TOOL_RESULT_DIR,
@@ -18,27 +19,21 @@ import {
 const AX_TREE_TAG = "<ax-tree>";
 
 /**
- * Tools whose results keep their full content at result time even when
- * oversized. `file_read` is the model's only way to page spooled content back
- * into context: stubbing a read of a `.tool-results/` file would spool a
- * fresh copy and hand back another stub, so oversized content could never be
- * read at all. Explicit reads are therefore honored in full; the post-turn
- * pass still truncates them at turn end, after the model has consumed the
- * content.
- */
-const RESULT_TIME_STUB_EXEMPT_TOOLS = new Set<string>(["file_read"]);
-
-/**
- * Whether a tool result is eligible for the result-time spool/stub pass:
- * the post-turn pass's shared rules plus the AX-tree and `file_read`
- * exemptions above.
+ * Whether a tool result is eligible for the result-time spool/stub pass: the
+ * post-turn pass's shared rules plus the AX-tree exemption, minus the file-read
+ * tools ({@link FILE_READ_TOOL_NAMES}). The file-read tools are the model's only
+ * way to page spooled content back into context: stubbing a read of a
+ * `.tool-results/` file would spool a fresh copy and hand back another stub, so
+ * oversized content could never be read at all. Explicit reads are therefore
+ * honored in full; the post-turn pass still truncates them at turn end, after
+ * the model has consumed the content.
  */
 function isSpoolEligible(
   tr: ToolResultContent,
   toolName: string | undefined,
 ): boolean {
   if (!isTruncationEligible(tr, toolName)) return false;
-  if (toolName !== undefined && RESULT_TIME_STUB_EXEMPT_TOOLS.has(toolName)) {
+  if (toolName !== undefined && FILE_READ_TOOL_NAMES.has(toolName)) {
     return false;
   }
   if (tr.content.includes(AX_TREE_TAG)) return false;
@@ -56,8 +51,8 @@ function isSpoolEligible(
  * rewriting an earlier message between calls would invalidate the cache from
  * that point on every iteration. The model still gets the head/tail preview
  * plus the on-disk path, so it can page the full content back in with
- * `file_read` (whose results are exempt from this pass) when it actually
- * needs it.
+ * `file_read` or `host_file_read` (whose results are exempt from this pass)
+ * when it actually needs it.
  *
  * Uses the same file paths, stub bytes, and eligibility rules as
  * `postTurnTruncateToolResults`, whose `TRUNCATION_MARKER` guard then skips


### PR DESCRIPTION
## Summary

- `host_file_read` results over the 8K-char threshold were being middle-truncated by the **result-time** spool pass (`spoolAndStubOversizedToolResults`) mid-turn, because only `file_read` was on `RESULT_TIME_STUB_EXEMPT_TOOLS`. The equivalent in-workspace `file_read` was exempt, so the two behaved asymmetrically. The model could end up acting on just the head/tail preview of a host file within the same turn.
- Introduce a shared `FILE_READ_TOOL_NAMES` set (`file_read`, `host_file_read`) in `post-turn-tool-result-truncation.ts` and use it in both places: the result-time spool pass now keeps host-read content in full mid-turn (the post-turn pass still truncates it at turn end, after the model has consumed it), and `derefToolResultReReads` now recognizes `host_file_read` re-reads of `.tool-results/` files so they collapse to a stub instead of duplicating context — keeping the page-back-loop protection and the dedup path consistent.
- Extend the spool exemption test and add a `host_file_read` deref test.

## Original prompt

In the desktop app, a large `host_file_read` (the pilgrimage spec) showed up truncated with a `...(N tokens omitted — full result: …)` marker mid-turn. Diagnosed it to the result-time spool pass, which exempts `file_read` but not `host_file_read`, so host reads (unlike workspace reads) get stubbed before turn end. Fix: add `host_file_read` to the result-time exemption so it's kept in full mid-turn and only stubbed at turn end, and update the re-read dedup path to match.