### PR TITLE
feat(onboarding): thread occupation/role through PreChatOnboardingContext

### DIFF
--- a/apps/web/src/domains/chat/api/messages.ts
+++ b/apps/web/src/domains/chat/api/messages.ts
@@ -485,6 +485,8 @@ export async function postChatMessage(
       };
     if (normalizedOnboarding.userName !== undefined)
       onboardingDict.userName = normalizedOnboarding.userName;
+    if (normalizedOnboarding.occupation !== undefined)
+      onboardingDict.occupation = normalizedOnboarding.occupation;
     if (normalizedOnboarding.assistantName !== undefined)
       onboardingDict.assistantName = normalizedOnboarding.assistantName;
     if (normalizedOnboarding.googleConnected !== undefined)

--- a/apps/web/src/domains/chat/api/post-chat-message.test.ts
+++ b/apps/web/src/domains/chat/api/post-chat-message.test.ts
@@ -104,6 +104,7 @@ describe("postChatMessage onboarding payload", () => {
       tasks: ["code-building", "writing"],
       tone: "friendly",
       userName: "Ada",
+      occupation: "Software Engineer",
       assistantName: "Vel",
     });
     // Profile seeding is fire-and-forget — flush the microtask queue so
@@ -116,6 +117,7 @@ describe("postChatMessage onboarding payload", () => {
       tasks: ["builds code, apps, or tools", "writes docs, emails, or content"],
       tone: "friendly",
       userName: "Ada",
+      occupation: "Software Engineer",
       assistantName: "Vel",
     });
 
@@ -127,6 +129,7 @@ describe("postChatMessage onboarding payload", () => {
     for (const write of writes) {
       expect(write.content).toContain("## Onboarding Context");
       expect(write.content).toContain("- **Preferred name:** Ada");
+      expect(write.content).toContain("- **Role:** Software Engineer");
       expect(write.content).toContain(
         "- **Common work:** builds code, apps, or tools; writes docs, emails, or content",
       );

--- a/apps/web/src/domains/onboarding/prechat-context.test.ts
+++ b/apps/web/src/domains/onboarding/prechat-context.test.ts
@@ -80,6 +80,20 @@ describe("buildPreChatContext — control", () => {
     expect(context.priorAssistants).toEqual(["asst-1"]);
   });
 
+  test("carries a trimmed occupation when provided", () => {
+    const context = buildPreChatContext(
+      baseInput({ occupation: "  Software Engineer  " }),
+    );
+    expect(context.occupation).toBe("Software Engineer");
+  });
+
+  test("omits occupation when absent or blank", () => {
+    expect(buildPreChatContext(baseInput()).occupation).toBeUndefined();
+    expect(
+      buildPreChatContext(baseInput({ occupation: "   " })).occupation,
+    ).toBeUndefined();
+  });
+
   test("uses scopes from the connecting action over stored state", () => {
     const context = buildPreChatContext(
       baseInput({

--- a/apps/web/src/domains/onboarding/prechat-context.ts
+++ b/apps/web/src/domains/onboarding/prechat-context.ts
@@ -39,6 +39,8 @@ export interface BuildPreChatContextInput {
   /** Already resolved: `selectedGroupId ?? recipe?.tone ?? DEFAULT_GROUP_ID`. */
   tone: string;
   userName: string;
+  /** The user's role / occupation. Empty string when not collected. */
+  occupation?: string;
   assistantName: string;
   selfIntroGreetingEnabled: boolean;
   /** Selects the activation rail bootstrap template for experiment users. */
@@ -107,6 +109,8 @@ export function buildPreChatContext(
 
   const trimmedUser = input.userName.trim();
   if (trimmedUser) context.userName = trimmedUser;
+  const trimmedOccupation = input.occupation?.trim();
+  if (trimmedOccupation) context.occupation = trimmedOccupation;
   const trimmedAssistant = input.assistantName.trim();
   if (trimmedAssistant) context.assistantName = trimmedAssistant;
 

--- a/apps/web/src/domains/onboarding/prechat-profile.ts
+++ b/apps/web/src/domains/onboarding/prechat-profile.ts
@@ -24,6 +24,9 @@ export function buildOnboardingSection(
   if (fields.preferredName) {
     lines.push(`- **Preferred name:** ${fields.preferredName}`);
   }
+  if (fields.occupation) {
+    lines.push(`- **Role:** ${fields.occupation}`);
+  }
   if (fields.commonWork.length > 0) {
     lines.push(`- **Common work:** ${fields.commonWork.join("; ")}`);
   }

--- a/apps/web/src/domains/onboarding/prechat.test.ts
+++ b/apps/web/src/domains/onboarding/prechat.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import {
   buildPreChatInitialMessage,
+  consumePendingPreChatContext,
   DEFAULT_PRECHAT_INITIAL_MESSAGE,
+  preChatOnboardingProfileFields,
+  type PreChatOnboardingContext,
+  setPendingPreChatContext,
 } from "@/domains/onboarding/prechat";
 
 describe("buildPreChatInitialMessage", () => {
@@ -34,5 +38,71 @@ describe("buildPreChatInitialMessage", () => {
     expect(
       buildPreChatInitialMessage({ assistantName: "  ", userName: "  " }),
     ).toBe(DEFAULT_PRECHAT_INITIAL_MESSAGE);
+  });
+});
+
+describe("preChatOnboardingProfileFields", () => {
+  const base: PreChatOnboardingContext = { tools: [], tasks: [], tone: "warm" };
+
+  test("maps occupation through, trimmed", () => {
+    expect(
+      preChatOnboardingProfileFields({ ...base, occupation: "  Designer  " })
+        .occupation,
+    ).toBe("Designer");
+  });
+
+  test("omits occupation when absent or blank", () => {
+    expect(preChatOnboardingProfileFields(base).occupation).toBeUndefined();
+    expect(
+      preChatOnboardingProfileFields({ ...base, occupation: "   " }).occupation,
+    ).toBeUndefined();
+  });
+});
+
+describe("pending pre-chat context round-trip — occupation", () => {
+  // Minimal Map-backed sessionStorage shim, installed/removed per-test so it
+  // can't leak into other test files sharing the bun process.
+  let store: Map<string, string>;
+  let prior: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    store = new Map();
+    prior = Object.getOwnPropertyDescriptor(globalThis, "sessionStorage");
+    Object.defineProperty(globalThis, "sessionStorage", {
+      configurable: true,
+      value: {
+        getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+        setItem: (k: string, v: string) => void store.set(k, v),
+        removeItem: (k: string) => void store.delete(k),
+      },
+    });
+  });
+
+  afterEach(() => {
+    if (prior) {
+      Object.defineProperty(globalThis, "sessionStorage", prior);
+    } else {
+      delete (globalThis as { sessionStorage?: unknown }).sessionStorage;
+    }
+  });
+
+  test("occupation survives set → consume", () => {
+    setPendingPreChatContext({
+      tools: [],
+      tasks: [],
+      tone: "warm",
+      occupation: "Software Engineer",
+    });
+    expect(consumePendingPreChatContext()?.occupation).toBe(
+      "Software Engineer",
+    );
+  });
+
+  test("a non-string occupation is rejected by validation", () => {
+    store.set(
+      "onboarding.prechat.pendingContext",
+      JSON.stringify({ tools: [], tasks: [], tone: "warm", occupation: 42 }),
+    );
+    expect(consumePendingPreChatContext()).toBeNull();
   });
 });

--- a/apps/web/src/domains/onboarding/prechat.ts
+++ b/apps/web/src/domains/onboarding/prechat.ts
@@ -31,6 +31,8 @@ export interface PreChatOnboardingContext {
   tone: string;
   /** Undefined if the user skipped the name step. */
   userName?: string;
+  /** The user's role / occupation, e.g. "Software Engineer". Undefined if not collected. */
+  occupation?: string;
   /** Undefined if the user kept the default assistant name. */
   assistantName?: string;
   /** e.g. ["chatgpt", "openclaw", "hermes"] */
@@ -156,6 +158,7 @@ export function normalizePreChatOnboardingContext(
 
 export interface PreChatOnboardingProfileFields {
   preferredName?: string;
+  occupation?: string;
   commonWork: string[];
   dailyTools: string[];
 }
@@ -166,6 +169,7 @@ export function preChatOnboardingProfileFields(
   const normalized = normalizePreChatOnboardingContext(ctx);
   return {
     preferredName: normalized.userName?.trim() || undefined,
+    occupation: normalized.occupation?.trim() || undefined,
     commonWork: normalized.tasks,
     dailyTools: normalized.tools,
   };
@@ -225,6 +229,12 @@ function isPreChatOnboardingContext(
   if (
     candidate.userName !== undefined &&
     typeof candidate.userName !== "string"
+  ) {
+    return false;
+  }
+  if (
+    candidate.occupation !== undefined &&
+    typeof candidate.occupation !== "string"
   ) {
     return false;
   }

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -18878,6 +18878,8 @@ paths:
                       type: string
                     userName:
                       type: string
+                    occupation:
+                      type: string
                     assistantName:
                       type: string
                     googleConnected:

--- a/assistant/src/__tests__/normalize-onboarding.test.ts
+++ b/assistant/src/__tests__/normalize-onboarding.test.ts
@@ -139,6 +139,32 @@ describe("normalizeOnboardingContext", () => {
     expect(result.preferredName).toBeUndefined();
   });
 
+  test("maps occupation through, trimmed", () => {
+    const ctx: OnboardingContext = {
+      tools: [],
+      tasks: [],
+      tone: "friendly",
+      occupation: "  Software Engineer  ",
+    };
+    const result = normalizeOnboardingContext(ctx);
+    expect(result.occupation).toBe("Software Engineer");
+  });
+
+  test("absent or blank occupation yields undefined", () => {
+    expect(
+      normalizeOnboardingContext({ tools: [], tasks: [], tone: "friendly" })
+        .occupation,
+    ).toBeUndefined();
+    expect(
+      normalizeOnboardingContext({
+        tools: [],
+        tasks: [],
+        tone: "friendly",
+        occupation: "   ",
+      }).occupation,
+    ).toBeUndefined();
+  });
+
   test("tone passes through", () => {
     const ctx: OnboardingContext = {
       tools: [],

--- a/assistant/src/prompts/normalize-onboarding.ts
+++ b/assistant/src/prompts/normalize-onboarding.ts
@@ -82,6 +82,7 @@ export function normalizePriorAssistants(assistants: string[]): string[] {
 
 export interface NormalizedOnboarding {
   preferredName?: string;
+  occupation?: string;
   commonWork: string[];
   dailyTools: string[];
   tone?: string;
@@ -123,6 +124,7 @@ export function normalizeOnboardingContext(
 ): NormalizedOnboarding {
   return {
     preferredName: ctx.userName?.trim() || undefined,
+    occupation: ctx.occupation?.trim() || undefined,
     commonWork: normalizeTasks(ctx.tasks),
     dailyTools: normalizeTools(ctx.tools),
     tone: ctx.tone,

--- a/assistant/src/prompts/persona-resolver.ts
+++ b/assistant/src/prompts/persona-resolver.ts
@@ -348,6 +348,9 @@ function buildOnboardingSection(normalized: NormalizedOnboarding): string {
   if (normalized.preferredName) {
     lines.push(`- **Preferred name:** ${normalized.preferredName}`);
   }
+  if (normalized.occupation) {
+    lines.push(`- **Role:** ${normalized.occupation}`);
+  }
   if (normalized.commonWork.length > 0) {
     lines.push(`- **Common work:** ${normalized.commonWork.join("; ")}`);
   }

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1030,6 +1030,7 @@ export function persistOnboardingArtifacts(onboarding: {
   tasks: string[];
   tone: string;
   userName?: string;
+  occupation?: string;
   assistantName?: string;
   priorAssistants?: string[];
   cohort?: string;
@@ -2693,6 +2694,7 @@ export const ROUTES: RouteDefinition[] = [
           tasks: z.array(z.string()),
           tone: z.string(),
           userName: z.string().optional(),
+          occupation: z.string().optional(),
           assistantName: z.string().optional(),
           googleConnected: z.boolean().optional(),
           googleScopes: z.array(z.string()).optional(),

--- a/assistant/src/types/onboarding-context.ts
+++ b/assistant/src/types/onboarding-context.ts
@@ -3,6 +3,8 @@ export interface OnboardingContext {
   tasks: string[];
   tone: string;
   userName?: string;
+  /** The user's role / occupation, e.g. "Software Engineer". */
+  occupation?: string;
   assistantName?: string;
   priorAssistants?: string[];
   googleConnected?: boolean;


### PR DESCRIPTION
## What

Adds a durable, flow-agnostic `occupation` field to the pre-chat onboarding handoff (`PreChatOnboardingContext`) so a user's role (e.g. "Software Engineer") flows end-to-end into the assistant's profile + persona.

**No collection UI** is added — this is the persistence contract only. Collection is deferred to the cast activation flow, which already has a "Your role" field but no persistence wiring (`kickoffJobContext` is a stub; it doesn't touch `PreChatOnboardingContext`). When cast's handoff is implemented, its existing field plugs into this contract.

## Why

The personal-page sign-up flow (#34807) added a post-OAuth "Your role" field in the SPA account domain, but:
1. That page (`provider-signup-page.tsx`) is **unreachable** — the backend auto-provisions WorkOS social signups (`SOCIALACCOUNT_AUTO_SIGNUP` default + `EMAIL_VERIFICATION="none"`), so the OAuth callback always returns `authenticated`, never the pending `provider_signup` flow the page depends on.
2. Even when collected, occupation was **dropped** (persisting it needs a cross-domain handoff the `account` domain can't make).

Threading it through `PreChatOnboardingContext` solves the persistence cleanly within the onboarding/chat domains, independent of which flow ends up collecting it.

## Changes

**Web (`apps/web`)**
- `prechat.ts` — `occupation` on `PreChatOnboardingContext`, the sessionStorage validator, and `PreChatOnboardingProfileFields`.
- `prechat-context.ts` — accept + set `occupation` in `buildPreChatContext` (trimmed, mode-agnostic, mirroring `userName`).
- `prechat-profile.ts` — render `- **Role:**` in the workspace profile section.
- `chat/api/messages.ts` — wire passthrough into the `onboarding` payload.

**Daemon (`assistant/`)**
- `types/onboarding-context.ts` + `prompts/normalize-onboarding.ts` — carry + normalize `occupation`.
- `prompts/persona-resolver.ts` — emit `- **Role:**` in the persona section.
- `runtime/routes/conversation-routes.ts` — accept `occupation` in the `/v1/messages` onboarding zod schema; regenerated `openapi.yaml`.

## Out of scope
- Collection UI (deferred to cast).
- `pre-chat-flow.tsx` / `name-step-screen.tsx` (the flow being replaced by cast).
- `provider-signup-page.tsx` cleanup (left as-is).
- Swift `PreChatOnboardingContext.swift` parity (optional follow-up).

## Tests
- `prechat.test.ts` — profile-field mapping + sessionStorage round-trip (validator accepts `occupation`, rejects non-string).
- `prechat-context.test.ts` — `buildPreChatContext` trims/omits occupation.
- `post-chat-message.test.ts` — occupation on the wire payload + `- **Role:**` in seeded profile files.
- `normalize-onboarding.test.ts` (daemon) — normalize maps/trims/omits occupation.

Web + daemon `tsc` clean; lint clean; affected tests pass (run single-file per the known bun multi-file mock-leak isolation issue).

Closes JARVIS-1177

🤖 Generated with [Claude Code](https://claude.com/claude-code)