### PR TITLE
feat(onboarding): gate onboarding/prechat by activation arm (cast vs control)

### DIFF
--- a/apps/web/src/domains/onboarding/cast/cast-onboarding-flow.tsx
+++ b/apps/web/src/domains/onboarding/cast/cast-onboarding-flow.tsx
@@ -1,0 +1,13 @@
+/**
+ * Cast onboarding flow — the replacement for the legacy `PreChatFlow` step
+ * pages, served only to the `experiment-activation-flow-2026-06-03 =
+ * personal-page` arm. Control / variant-a users continue to see `PreChatFlow`.
+ *
+ * Placeholder for now: routing is gated through `PreChatRoute`, and the real
+ * screens (and the handoff into hatching) land in later PRs of the cast
+ * onboarding plan. Keeping this in its own file means those PRs replace only
+ * this component body without touching the routing seam.
+ */
+export function CastOnboardingFlow() {
+  return null;
+}

--- a/apps/web/src/domains/onboarding/pages/prechat-route.tsx
+++ b/apps/web/src/domains/onboarding/pages/prechat-route.tsx
@@ -1,0 +1,38 @@
+import { Suspense, lazy } from "react";
+
+import { PreChatFlow } from "@/domains/onboarding/pages/pre-chat-flow";
+import { useActivationFlowArm } from "@/hooks/use-client-feature-flag-sync";
+
+const CastOnboardingFlow = lazy(() =>
+  import("@/domains/onboarding/cast/cast-onboarding-flow").then((m) => ({
+    default: m.CastOnboardingFlow,
+  })),
+);
+
+/**
+ * Routing seam for `onboarding/prechat`. Picks the onboarding flow by
+ * activation arm: the `experiment-activation-flow-2026-06-03 = personal-page`
+ * arm gets the new `CastOnboardingFlow`, everyone else (control / variant-a)
+ * keeps the legacy `PreChatFlow`.
+ *
+ * Nothing renders until the flag has `settled` (server fetch resolved/errored)
+ * — otherwise a targeted anonymous visitor would briefly see the control
+ * `PreChatFlow` on the registry default before their `personal-page` value
+ * arrives. Mirrors the settle-guard in `account/pages/signup-page.tsx`.
+ */
+export function PreChatRoute() {
+  const { arm, settled } = useActivationFlowArm();
+
+  // Hold rendering until the flag resolves to avoid flashing the wrong flow.
+  if (!settled) return null;
+
+  if (arm === "personal-page") {
+    return (
+      <Suspense fallback={null}>
+        <CastOnboardingFlow />
+      </Suspense>
+    );
+  }
+
+  return <PreChatFlow />;
+}

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -192,7 +192,7 @@ export const routeTree = [
             },
             {
               path: "onboarding/prechat",
-              lazy: { Component: () => import("@/domains/onboarding/pages/pre-chat-flow").then((m) => m.PreChatFlow) },
+              lazy: { Component: () => import("@/domains/onboarding/pages/prechat-route").then((m) => m.PreChatRoute) },
             },
             {
               path: "onboarding/hatching",


### PR DESCRIPTION
## Summary
- Add PreChatRoute that renders CastOnboardingFlow for the personal-page arm, else PreChatFlow
- Add CastOnboardingFlow placeholder (null) for later screen ports
- Point onboarding/prechat route at PreChatRoute; privacy/consent left in place

Part of plan: cast-prechat-flow.md (PR 1 of 13)