### PR TITLE
feat(onboarding): map cast selections to PreChatOnboardingContext + research directive

### DIFF
--- a/apps/web/src/domains/onboarding/cast/cast-prechat-mapping.test.ts
+++ b/apps/web/src/domains/onboarding/cast/cast-prechat-mapping.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+
+import { DEFAULT_GROUP_ID } from "@/domains/onboarding/prechat-names";
+import {
+  ACTIVATION_FLOW_COHORT,
+  ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE,
+} from "@/domains/onboarding/prechat-context";
+import {
+  buildCastPreChatContext,
+  CAST_RESEARCH_DIRECTIVE,
+  type CastSelections,
+} from "@/domains/onboarding/cast/cast-prechat-mapping";
+
+function baseSelections(
+  overrides: Partial<CastSelections> = {},
+): CastSelections {
+  return {
+    firstName: "Alex",
+    lastName: "Nork",
+    role: "Founder",
+    jobs: [],
+    reachTools: [],
+    ...overrides,
+  };
+}
+
+describe("buildCastPreChatContext", () => {
+  test("maps first + last name into userName", () => {
+    const context = buildCastPreChatContext(baseSelections());
+    expect(context.userName).toBe("Alex Nork");
+  });
+
+  test("joins only the present name parts", () => {
+    expect(
+      buildCastPreChatContext(
+        baseSelections({ firstName: "Alex", lastName: undefined }),
+      ).userName,
+    ).toBe("Alex");
+    expect(
+      buildCastPreChatContext(
+        baseSelections({ firstName: undefined, lastName: "Nork" }),
+      ).userName,
+    ).toBe("Nork");
+  });
+
+  test("maps role into occupation", () => {
+    const context = buildCastPreChatContext(
+      baseSelections({ role: "Software Engineer" }),
+    );
+    expect(context.occupation).toBe("Software Engineer");
+  });
+
+  test("trims occupation", () => {
+    const context = buildCastPreChatContext(
+      baseSelections({ role: "  Designer  " }),
+    );
+    expect(context.occupation).toBe("Designer");
+  });
+
+  test("omits occupation when role is blank", () => {
+    const context = buildCastPreChatContext(baseSelections({ role: "   " }));
+    expect(context.occupation).toBeUndefined();
+  });
+
+  test("omits occupation when role is absent", () => {
+    const context = buildCastPreChatContext(
+      baseSelections({ role: undefined }),
+    );
+    expect(context.occupation).toBeUndefined();
+  });
+
+  test("maps jobs into tasks", () => {
+    const context = buildCastPreChatContext(
+      baseSelections({ jobs: ["writing", "research"] }),
+    );
+    expect(context.tasks).toEqual(["research", "writing"]);
+  });
+
+  test("maps reachTools into tools", () => {
+    const context = buildCastPreChatContext(
+      baseSelections({ reachTools: ["slack", "linear"] }),
+    );
+    expect(context.tools).toEqual(expect.arrayContaining(["slack", "linear"]));
+    expect(context.tools).toHaveLength(2);
+  });
+
+  test("maps prior assistant into priorAssistants", () => {
+    const context = buildCastPreChatContext(
+      baseSelections({ priorAssistant: "chatgpt" }),
+    );
+    expect(context.priorAssistants).toEqual(["chatgpt"]);
+  });
+
+  test("omits priorAssistants when no prior assistant", () => {
+    const context = buildCastPreChatContext(
+      baseSelections({ priorAssistant: undefined }),
+    );
+    expect(context.priorAssistants).toBeUndefined();
+  });
+
+  test("uses provided tone", () => {
+    const context = buildCastPreChatContext(
+      baseSelections({ tone: "warm" }),
+    );
+    expect(context.tone).toBe("warm");
+  });
+
+  test("falls back to the default group id when tone is absent", () => {
+    const context = buildCastPreChatContext(
+      baseSelections({ tone: undefined }),
+    );
+    expect(context.tone).toBe(DEFAULT_GROUP_ID);
+  });
+
+  test("overrides initialMessage with the research directive", () => {
+    const context = buildCastPreChatContext(baseSelections());
+    expect(context.initialMessage).toBe(CAST_RESEARCH_DIRECTIVE);
+  });
+
+  test("carries the activation cohort and bootstrap template", () => {
+    const context = buildCastPreChatContext(baseSelections());
+    expect(context.cohort).toBe(ACTIVATION_FLOW_COHORT);
+    expect(context.bootstrapTemplate).toBe(ACTIVATION_RAIL_BOOTSTRAP_TEMPLATE);
+  });
+});

--- a/apps/web/src/domains/onboarding/cast/cast-prechat-mapping.ts
+++ b/apps/web/src/domains/onboarding/cast/cast-prechat-mapping.ts
@@ -1,0 +1,70 @@
+/**
+ * Field-mapping from the cast onboarding flow's collected selections into the
+ * existing {@link PreChatOnboardingContext} handoff.
+ *
+ * This is the load-bearing translation that lets the cast (personal-page arm)
+ * flow reuse the same pre-chat plumbing as the control funnel: the user's
+ * role becomes their occupation, the jobs/tools they picked become the
+ * selected tasks/tools, and the first chat message is overridden with the
+ * research directive that kicks off the personal-page build.
+ *
+ * `CastSelections` is declared locally (rather than imported from the cast
+ * roster types) so this mapping stays independent of the rest of the cast
+ * flow and can be unit-tested in isolation. The defaults here may be
+ * revisited once the real cast steps are wired up.
+ */
+import { DEFAULT_GROUP_ID } from "@/domains/onboarding/prechat-names";
+import { buildPreChatContext } from "@/domains/onboarding/prechat-context";
+import type { PreChatOnboardingContext } from "@/domains/onboarding/prechat";
+
+/** Selections collected during the cast onboarding flow. */
+export interface CastSelections {
+  firstName?: string;
+  lastName?: string;
+  role?: string;
+  tone?: string;
+  jobs: string[];
+  reachTools: string[];
+  priorAssistant?: string;
+}
+
+/**
+ * The auto-sent first message for the cast/personal-page arm. Instead of a
+ * canned greeting, it directs the assistant to research the user and build out
+ * their personal-page app.
+ */
+export const CAST_RESEARCH_DIRECTIVE =
+  "Research me based on my name and role, then build out my personal-page app with what you find.";
+
+/**
+ * Map cast selections into a {@link PreChatOnboardingContext} by delegating to
+ * the shared {@link buildPreChatContext} builder, then overriding the initial
+ * message with the research directive so the activation arm kicks off the
+ * personal-page build rather than sending the default greeting.
+ */
+export function buildCastPreChatContext(
+  sel: CastSelections,
+): PreChatOnboardingContext {
+  const context = buildPreChatContext({
+    mode: "control",
+    activationFlowEnabled: true,
+    recipe: null,
+    userName: [sel.firstName, sel.lastName].filter(Boolean).join(" "),
+    occupation: sel.role,
+    tone: sel.tone ?? DEFAULT_GROUP_ID,
+    selectedTasks: new Set(sel.jobs),
+    selectedTools: new Set(sel.reachTools),
+    selectedPriorAssistants: sel.priorAssistant
+      ? new Set([sel.priorAssistant])
+      : new Set(),
+    assistantName: "",
+    selfIntroGreetingEnabled: false,
+    googleConnected: false,
+    googleScopes: [],
+  });
+
+  // buildPreChatContext sets initialMessage itself; the cast arm always sends
+  // the research directive instead.
+  context.initialMessage = CAST_RESEARCH_DIRECTIVE;
+  return context;
+}


### PR DESCRIPTION
## Summary
- Add buildCastPreChatContext mapping CastSelections -> PreChatOnboardingContext (role->occupation, jobs->tasks, reach->tools, prior->priorAssistants)
- Override initialMessage with CAST_RESEARCH_DIRECTIVE; carry activation cohort/template
- Unit tests for the mapping

Part of plan: cast-prechat-flow.md (PR 3 of 13)