### PR TITLE
fix(cli): give the assistant daemon a generous shutdown grace in vellum sleep

### DIFF
--- a/cli/src/__tests__/sleep.test.ts
+++ b/cli/src/__tests__/sleep.test.ts
@@ -155,10 +155,14 @@ describe("sleep command", () => {
     }
 
     expect(stopProcessByPidFileMock).toHaveBeenCalledTimes(2);
+    // The assistant stop passes a generous 120s grace so the daemon's WAL
+    // checkpoint completes before any SIGKILL (default 2s would truncate it).
     expect(stopProcessByPidFileMock).toHaveBeenNthCalledWith(
       1,
       join(assistantRootDir, "workspace", "vellum.pid"),
       "assistant",
+      undefined,
+      120_000,
     );
     expect(stopProcessByPidFileMock).toHaveBeenNthCalledWith(
       2,

--- a/cli/src/commands/sleep.ts
+++ b/cli/src/commands/sleep.ts
@@ -134,9 +134,18 @@ export async function sleep(): Promise<void> {
     }
   }
 
+  // Stop assistant — use a generous timeout. On SIGTERM the daemon runs a
+  // WAL checkpoint before exiting, which can take several seconds on a
+  // multi-GB database. The default 2s grace in stopProcess() would SIGKILL a
+  // healthy daemon mid-checkpoint, forcing a costly multi-minute WAL recovery
+  // on the next start. The timeout is only a SIGKILL ceiling — stopProcess
+  // returns as soon as the process exits, so this adds no delay in the common
+  // case and only applies when the daemon is genuinely wedged.
   const assistantStopped = await stopProcessByPidFile(
     assistantPidFile,
     "assistant",
+    undefined,
+    120_000,
   );
   if (!assistantStopped) {
     console.log("Assistant is not running.");


### PR DESCRIPTION
## Summary
- `vellum sleep` stopped the assistant daemon with `stopProcess`'s default **2s** SIGTERM grace before SIGKILL. On a multi-GB database the daemon's shutdown WAL checkpoint can exceed that (observed ~4s), so `vellum sleep` would SIGKILL a healthy daemon mid-checkpoint — forcing a costly multi-minute WAL recovery on the next start.
- Pass an explicit **120s** grace for the assistant stop in `sleep.ts`, mirroring the gateway's existing explicit 7s timeout. The timeout is only a SIGKILL ceiling — `stopProcess` returns as soon as the process exits, so this adds no delay in the common case and only applies when the daemon is genuinely wedged.
- Updated `sleep.test.ts` to assert the assistant stop is invoked with the 120s grace.

## Original prompt
While moving an assistant back onto the default `~/.vellum/workspace` path, we observed the daemon take ~4s to shut down cleanly (its WAL checkpoint) — longer than the 2s grace `vellum sleep` gives the daemon before SIGKILL, which on a large DB triggers a multi-minute WAL recovery on the next wake. This is the first of three proposed fixes: bump the daemon's shutdown grace in `vellum sleep` to a generous ceiling so healthy shutdowns are never truncated (progress-aware shutdown and WAL-size bounding were deferred as separate follow-ups).