### PR TITLE
feat(onboarding): cast done/handoff screen + task derivation

### DIFF
--- a/apps/web/src/domains/onboarding/cast/cast-avatar.tsx
+++ b/apps/web/src/domains/onboarding/cast/cast-avatar.tsx
@@ -1,0 +1,46 @@
+/**
+ * Roster-character avatar renderer.
+ *
+ * Ported from the prototype's `@/cast/cast-avatar`. Only `CastAvatar` is lifted
+ * here — the prototype also exported a `BlinkingAvatar`, but base `cast-shell`
+ * already ships an equivalent (keyed by `CastCharacter`), so the done screen
+ * reuses that one and we avoid duplicating the blink closure. `CastAvatar` is
+ * the static, container-filling variant the proof view renders (held dude +
+ * artifact-overlay corner dude).
+ *
+ * Depends only on `cast-roster` (COMPONENTS) and the shared
+ * `avatar-svg-compositor` util — both already on base — so no marketing/demo
+ * closure is pulled in.
+ */
+
+import { useMemo } from "react";
+
+import type { CastCharacter } from "@/domains/onboarding/cast/cast-roster";
+import { COMPONENTS } from "@/domains/onboarding/cast/cast-roster";
+import { composeSvg } from "@/utils/avatar-svg-compositor";
+
+/**
+ * Renders a roster character as a container-filling SVG. We compose at a fixed
+ * internal size and let CSS scale the `<svg>` to 100% of its box.
+ */
+export function CastAvatar({ character }: { character: CastCharacter }) {
+  const svg = useMemo(
+    () =>
+      composeSvg(
+        COMPONENTS,
+        character.bodyShape,
+        character.eyeStyle,
+        character.color,
+        240,
+      ),
+    [character.bodyShape, character.eyeStyle, character.color],
+  );
+
+  return (
+    <div
+      className="cast-avatar"
+      aria-hidden
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
+  );
+}

--- a/apps/web/src/domains/onboarding/cast/cast-proof-view.tsx
+++ b/apps/web/src/domains/onboarding/cast/cast-proof-view.tsx
@@ -1,0 +1,400 @@
+import { useEffect, useRef, useState } from "react";
+import { AnimatePresence, motion } from "motion/react";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+import { CastAvatar } from "@/domains/onboarding/cast/cast-avatar";
+import { JOBS, type JobKey, type RatherKey } from "@/domains/onboarding/cast/cast-content";
+import type { Rect } from "@/domains/onboarding/cast/cast-hero-types";
+import { CastProp, type PropKey } from "@/domains/onboarding/cast/cast-prop-art";
+import {
+  generateArtifacts,
+  generateFullArtifact,
+  resolveAssistantId,
+  type Artifact,
+  type Picks,
+} from "@/domains/onboarding/cast/cast-proof";
+import type { StyleProfile } from "@/domains/onboarding/cast/cast-templates";
+import type { CastCharacter } from "@/domains/onboarding/cast/cast-roster";
+
+/**
+ * Beat 6 — Proof. The character settles, then presents what it made. Round 3 of
+ * This/That shapes this beat:
+ *  - shape "one" → a focused dude holding a single item + ONE artifact card.
+ *  - shape "few" → a juggling dude (props arcing overhead) + a STACK of 2-3
+ *    artifact cards.
+ * The receipt (observation → inference → one-tap offer) sits above either way.
+ *
+ * Ported from the prototype's `@/cast/cast-proof-view`. Imports rewritten to
+ * base. The prototype rendered the persistent character via the `cast-hero`
+ * `HeroCharacter` — a 400-line marketing/demo surface (Super-Saiyan aura,
+ * autonomous reaction loop, mime beats, buddies) that base deliberately did NOT
+ * lift. Proof only ever used the static avatar + held props, so we render those
+ * via the lightweight `ProofHero` below (`CastAvatar` + `CastProp`), keeping the
+ * excluded hero closure out of the onboarding flow.
+ */
+export function CastProof({
+  character,
+  box,
+  jobs,
+  rathers,
+  style,
+  ascended,
+  assistantId,
+  onAction,
+  onEndpoint,
+  onBack,
+}: {
+  character: CastCharacter;
+  box: Rect;
+  jobs: JobKey[];
+  rathers: RatherKey[];
+  style: StyleProfile;
+  ascended: boolean;
+  assistantId: string | null;
+  onAction: (which: "artifact" | "save") => void;
+  onEndpoint: (which: "chat" | "boost") => void;
+  onBack: () => void;
+}) {
+  const few = style.shape === "few";
+  const count = few ? 3 : 1;
+
+  const [showProps, setShowProps] = useState(false);
+  const [artifacts, setArtifacts] = useState<Artifact[] | null>(null);
+  const [openIdx, setOpenIdx] = useState<number | null>(null);
+  const [fullByIdx, setFullByIdx] = useState<Record<number, string | null>>({});
+  const resolvedIdRef = useRef<string | null>(null);
+
+  // Props the dude works with: its chosen job props (padded with defaults).
+  const DEFAULT_PROPS: PropKey[] = ["book", "laptop", "pen"];
+  const jobProps: PropKey[] = jobs.map((k) => JOBS.find((j) => j.key === k)?.prop ?? "book");
+  const propKeys: PropKey[] = [...jobProps, ...DEFAULT_PROPS].slice(0, few ? 3 : 1);
+
+  // Ascended easter-egg keeps the whole prop pile clustered.
+  const heldProps: HeldProp[] = ascended
+    ? jobs.map((k) => {
+        const idx = JOBS.findIndex((j) => j.key === k);
+        return { key: JOBS[idx].prop, slot: idx };
+      })
+    : [];
+
+  useEffect(() => {
+    const t = setTimeout(() => setShowProps(true), 600);
+    return () => clearTimeout(t);
+  }, []);
+
+  // Generate receipt + artifacts on entering Proof (picks fixed for this beat).
+  const picksRef = useRef<Picks>({ jobs, rathers, style });
+  useEffect(() => {
+    const picks = picksRef.current;
+    let alive = true;
+    void resolveAssistantId(assistantId).then((id) => {
+      if (!alive) return;
+      resolvedIdRef.current = id;
+      void generateArtifacts(picks, count, id).then((a) => alive && setArtifacts(a));
+    });
+    return () => {
+      alive = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function openArtifact(i: number) {
+    setOpenIdx(i);
+    onAction("artifact");
+    // Lazily generate the full body for this card the first time it's opened.
+    if (fullByIdx[i] === undefined && artifacts) {
+      setFullByIdx((m) => ({ ...m, [i]: null }));
+      void generateFullArtifact(picksRef.current, artifacts[i], resolvedIdRef.current).then(
+        (full) => setFullByIdx((m) => ({ ...m, [i]: full })),
+      );
+    }
+  }
+
+  return (
+    <motion.div className="cast-focus" initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
+      <button className="cast-back" onClick={onBack} aria-label="Back">
+        ‹
+      </button>
+
+      <ProofHero character={character} box={box} heldProps={heldProps} ascended={ascended} />
+
+      {/* the dude presents what it made: juggling (few) or holding one (one) */}
+      {showProps && !ascended && (
+        few ? (
+          <JuggleProps box={box} props={propKeys} />
+        ) : (
+          <motion.div
+            className="cast-proof-prop"
+            style={{ left: box.left + box.size * 0.6, top: box.top + box.size * 0.56, width: box.size * 0.5 }}
+            initial={{ scale: 0, y: -10, rotate: -20, opacity: 0 }}
+            animate={{ scale: [0, 1.15, 0.95, 1], y: [-10, 0, 0, 0], rotate: 0, opacity: 1 }}
+            transition={{ duration: 0.6, ease: "easeOut", times: [0, 0.5, 0.78, 1] }}
+          >
+            <CastProp name={propKeys[0]} className="cast-prop__art" />
+          </motion.div>
+        )
+      )}
+
+      <div className="cast-proof" style={{ top: box.top + box.size + 28 }}>
+        {/* artifact card(s): one focused card, or a stack of a few quick wins.
+            No receipt — the inference moment lives in the endpoint chat now. */}
+        <div className="cast-artifacts">
+          {artifacts
+            ? artifacts.map((a, i) => (
+                <motion.div
+                  key={i}
+                  className="cast-artifact"
+                  initial={{ opacity: 0, y: 18 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.7 + i * 0.12, duration: 0.45, ease: "easeOut" }}
+                >
+                  <span className="cast-artifact__icon">
+                    <CastProp name={propKeys[i % propKeys.length]} className="cast-prop__art" />
+                  </span>
+                  <div className="cast-artifact__body">
+                    <p className="cast-artifact__title">{a.title}</p>
+                    <p className="cast-artifact__desc">{a.description}</p>
+                  </div>
+                  <button className="cast-artifact__open" onClick={() => openArtifact(i)}>
+                    Open
+                  </button>
+                </motion.div>
+              ))
+            : Array.from({ length: count }).map((_, i) => <ArtifactSkeleton key={i} />)}
+        </div>
+
+        {/* Endpoint: drop into real chat, or boost with a prior assistant. */}
+        {artifacts && (
+          <motion.div
+            className="cast-endpoints"
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.7 + count * 0.12 + 0.15, duration: 0.4, ease: "easeOut" }}
+          >
+            <button className="cast-endpoints__primary" onClick={() => onEndpoint("chat")}>
+              Start chatting
+            </button>
+            <button className="cast-endpoints__secondary" onClick={() => onEndpoint("boost")}>
+              Give me a boost
+            </button>
+          </motion.div>
+        )}
+      </div>
+
+      <AnimatePresence>
+        {openIdx !== null && artifacts && (
+          <ArtifactOverlay
+            character={character}
+            title={artifacts[openIdx].title}
+            content={fullByIdx[openIdx] ?? null}
+            onClose={() => setOpenIdx(null)}
+            onSave={() => onAction("save")}
+          />
+        )}
+      </AnimatePresence>
+    </motion.div>
+  );
+}
+
+/* ---------------- ProofHero (static hero substitute) ----------------
+ * Lifts only what Proof used from the excluded `cast-hero` `HeroCharacter`:
+ * the positioned character box + its held props. None of the marketing-only
+ * behaviors (aura, reaction loop, mime, buddies, cue) are reachable from this
+ * beat, so they are intentionally dropped. */
+
+/** A held job prop and the fixed slot it occupies around the character. */
+interface HeldProp {
+  key: PropKey;
+  slot: number; // stable index (JOBS order) so props don't reshuffle on removal
+}
+
+/** Stable slots ringing the character — one per job, so multiple props cluster
+ * around the dude without overlapping. Lifted verbatim from `cast-hero`. */
+const HELD_SLOTS: React.CSSProperties[] = [
+  { left: "48%", top: "54%", width: "46%" }, // lower-right
+  { left: "6%", top: "54%", width: "46%" }, // lower-left
+  { left: "64%", top: "26%", width: "42%" }, // right
+  { left: "-6%", top: "26%", width: "42%" }, // left
+  { left: "27%", top: "68%", width: "46%" }, // bottom
+  { left: "60%", top: "-8%", width: "40%" }, // upper-right
+  { left: "0%", top: "-8%", width: "40%" }, // upper-left
+  { left: "30%", top: "-24%", width: "40%" }, // top
+];
+
+function ProofHero({
+  character,
+  box,
+  heldProps,
+  ascended,
+}: {
+  character: CastCharacter;
+  box: Rect;
+  heldProps: HeldProp[];
+  ascended: boolean;
+}) {
+  // On ascension the dude turns gold — same recolor the prototype hero applied.
+  const shown = ascended ? { ...character, color: "yellow" } : character;
+  return (
+    <motion.div
+      className={`cast-hero${ascended ? " is-ascended" : ""}`}
+      layoutId="cast-hero"
+      style={{ left: box.left, top: box.top, width: box.size, height: box.size }}
+    >
+      <div className="cast-hero__body">
+        <div className="cast-focus-alive">
+          <div className="cast-hover" data-anim={character.hover}>
+            <CastAvatar character={shown} />
+          </div>
+        </div>
+      </div>
+
+      <AnimatePresence>
+        {heldProps.map((hp) => (
+          <motion.div
+            key={`held-${hp.key}`}
+            className="cast-prop"
+            style={{ ...HELD_SLOTS[hp.slot % HELD_SLOTS.length], zIndex: 3 }}
+            initial={{ scaleX: 0.7, scaleY: 0.7, opacity: 0 }}
+            animate={{ scaleX: 1, scaleY: 1, opacity: 1 }}
+            exit={{ opacity: 0, scale: 0.8, transition: { duration: 0.2 } }}
+            transition={{ duration: 0.4, ease: "easeOut" }}
+          >
+            <CastProp name={hp.key} className="cast-prop__art" />
+          </motion.div>
+        ))}
+      </AnimatePresence>
+    </motion.div>
+  );
+}
+
+/* ---------------- juggling props (shape "few") ---------------- */
+
+function JuggleProps({ box, props }: { box: Rect; props: PropKey[] }) {
+  const size = box.size * 0.36;
+  const A = box.size * 0.5; // throw width
+  const H = box.size * 0.5; // throw height (kept modest so it stays in frame)
+  const dur = 1.25;
+  return (
+    <div
+      className="cast-juggle"
+      style={{ left: box.left, top: box.top - box.size * 0.18, width: box.size, height: box.size }}
+      aria-hidden
+    >
+      {props.map((p, i) => {
+        const dir = i % 2 === 0 ? 1 : -1;
+        return (
+          <motion.div
+            key={i}
+            className="cast-juggle__item"
+            style={{ width: size, height: size, marginLeft: -size / 2, marginTop: -size / 2 }}
+            initial={{ x: -dir * A, y: 0, rotate: 0 }}
+            animate={{ x: [-dir * A, dir * A, -dir * A], y: [0, -H, 0], rotate: [0, dir * 200, dir * 360] }}
+            transition={{
+              duration: dur,
+              repeat: Infinity,
+              ease: "easeInOut",
+              times: [0, 0.5, 1],
+              delay: (i * dur) / props.length,
+            }}
+          >
+            <CastProp name={p} className="cast-prop__art" />
+          </motion.div>
+        );
+      })}
+    </div>
+  );
+}
+
+/* ---------------- Open overlay: full artifact ---------------- */
+
+function ArtifactOverlay({
+  character,
+  title,
+  content,
+  onClose,
+  onSave,
+}: {
+  character: CastCharacter;
+  title: string;
+  content: string | null;
+  onClose: () => void;
+  onSave: () => void;
+}) {
+  // Reveal the body line by line once it's available. While `content` is still
+  // null the dude scribbles and only the title shows.
+  const [revealed, setRevealed] = useState("");
+  const streaming = content !== null && revealed.length < content.length;
+
+  useEffect(() => {
+    if (content === null) return;
+    const lines = content.split("\n");
+    let i = 0;
+    setRevealed("");
+    const id = setInterval(() => {
+      i += 1;
+      setRevealed(lines.slice(0, i).join("\n"));
+      if (i >= lines.length) clearInterval(id);
+    }, 90);
+    return () => clearInterval(id);
+  }, [content]);
+
+  const writing = content === null || streaming;
+
+  return (
+    <motion.div
+      className="cast-overlay"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+    >
+      <button className="cast-overlay__close" onClick={onClose} aria-label="Close">
+        ✕
+      </button>
+
+      {/* the dude, small and persistent in the corner; scribbles while writing */}
+      <div className="cast-overlay__dude">
+        <div className={writing ? "cast-scribble" : undefined}>
+          <CastAvatar character={character} />
+        </div>
+        {writing && (
+          <span className="cast-overlay__pencil">
+            <CastProp name="pen" className="cast-prop__art" />
+          </span>
+        )}
+      </div>
+
+      <motion.div
+        className="cast-overlay__sheet"
+        initial={{ y: 24, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        exit={{ y: 24, opacity: 0 }}
+        transition={{ duration: 0.3, ease: "easeOut" }}
+      >
+        <h1 className="cast-overlay__title">{title}</h1>
+        <div className="cast-overlay__body">
+          {content === null ? (
+            <p className="cast-overlay__writing">Writing it out…</p>
+          ) : (
+            <Markdown remarkPlugins={[remarkGfm]}>{revealed}</Markdown>
+          )}
+        </div>
+        <button className="cast-overlay__save" onClick={onSave}>
+          Save
+        </button>
+      </motion.div>
+    </motion.div>
+  );
+}
+
+function ArtifactSkeleton() {
+  return (
+    <div className="cast-skeleton cast-skeleton--row" aria-hidden>
+      <span className="cast-skel-icon" />
+      <div style={{ flex: 1 }}>
+        <span className="cast-skel-line" style={{ width: "60%" }} />
+        <span className="cast-skel-line" style={{ width: "90%" }} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/domains/onboarding/cast/cast-proof.ts
+++ b/apps/web/src/domains/onboarding/cast/cast-proof.ts
@@ -1,0 +1,323 @@
+/**
+ * Beat 6 (Proof) data layer.
+ *
+ * Generates two artifacts from the user's picks:
+ *  - RECEIPT  — observation → inference → one-tap offer (the piece the user
+ *    reads carefully) — Sonnet 4.6.
+ *  - ARTIFACT — a small proactive thing the dude "made" (title + description) —
+ *    Haiku 4.5 (fast).
+ *
+ * Both go through the daemon's `POST /v1/assistants/{id}/inference/send`
+ * endpoint, which runs server-side with the Anthropic key held in the daemon's
+ * credential vault — no key is ever exposed to the browser. Since `/assistant/
+ * cast` is a public, unauthenticated prototype route there may be no active
+ * assistant / session, so every call falls back to local templated generation
+ * if the live call is unavailable or fails. The prototype always renders.
+ *
+ * Ported from the prototype's `@/cast/cast-proof`. Imports rewritten to base:
+ * `JOBS`/`RATHERS`/`JobKey`/`RatherKey` come from `cast-content`, and
+ * `StyleProfile` from `cast-templates` (the prototype's `cast-hooks` module was
+ * not lifted — `cast-templates` is base's home for that type). The daemon SDK
+ * and `listAssistants` are shared infra, unchanged.
+ */
+
+import { listAssistants } from "@/assistant/api";
+import { JOBS, RATHERS, type JobKey, type RatherKey } from "@/domains/onboarding/cast/cast-content";
+import type { StyleProfile } from "@/domains/onboarding/cast/cast-templates";
+import { inferenceSendPost } from "@/generated/daemon/sdk.gen";
+
+// Current model IDs (see the Claude model catalog). The receipt is the one
+// piece the user reads, so it gets Sonnet; the artifact title is latency-
+// sensitive, so it gets Haiku.
+const RECEIPT_MODEL = "claude-sonnet-4-6";
+const ARTIFACT_MODEL = "claude-haiku-4-5";
+
+export interface Picks {
+  jobs: JobKey[];
+  rathers: RatherKey[];
+  style: StyleProfile;
+}
+
+/**
+ * Resolve an assistant id for the live model calls. `/assistant/cast` is a
+ * public route with no ActiveAssistantGate, so the selection store is usually
+ * empty here — fall back to listing assistants (works when the browser has a
+ * session). Returns null when unauthenticated, which routes every generation
+ * to its local fallback. Resolved once and memoized.
+ */
+let resolvedAssistantId: string | null | undefined;
+export async function resolveAssistantId(fromStore: string | null): Promise<string | null> {
+  if (fromStore) return fromStore;
+  if (resolvedAssistantId !== undefined) return resolvedAssistantId;
+  try {
+    const result = await listAssistants();
+    resolvedAssistantId = result.ok && result.data.length ? result.data[0].id : null;
+  } catch {
+    resolvedAssistantId = null;
+  }
+  return resolvedAssistantId;
+}
+
+export interface Receipt {
+  observation: string;
+  inference: string;
+  offer: string;
+  verb: string; // primary-button label, e.g. "Set it up"
+}
+
+export interface Artifact {
+  title: string;
+  description: string;
+}
+
+function labelsFor<T extends string>(
+  keys: T[],
+  table: { key: T; label: string }[],
+): string {
+  const labels = keys.map((k) => table.find((t) => t.key === k)?.label ?? k);
+  if (labels.length === 0) return "exploring";
+  if (labels.length === 1) return labels[0].toLowerCase();
+  return (
+    labels.slice(0, -1).map((l) => l.toLowerCase()).join(", ") +
+    " and " +
+    labels[labels.length - 1].toLowerCase()
+  );
+}
+
+function styleWords(style: StyleProfile): string {
+  const map: Record<string, string> = {
+    send_it: "act without waiting for approval",
+    show_me: "check with them before acting",
+    point: "keep it short and to the point",
+    walk: "walk them through it",
+    one: "do one thing really well",
+    few: "knock out a few quick wins",
+  };
+  return [style.autonomy, style.tone, style.shape]
+    .filter(Boolean)
+    .map((v) => map[v as string] ?? v)
+    .join("; ");
+}
+
+/** Pull the first JSON object out of a model response, tolerating prose/fences. */
+function extractJson(text: string): Record<string, unknown> | null {
+  const start = text.indexOf("{");
+  const end = text.lastIndexOf("}");
+  if (start === -1 || end === -1 || end < start) return null;
+  try {
+    return JSON.parse(text.slice(start, end + 1)) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+/** Live model call with a hard timeout — the prototype's public route may have
+ * a stale/unreachable daemon, so we never let a hung request block the UI. On
+ * timeout or any error we return null and the caller uses its local fallback. */
+async function callModel(
+  assistantId: string,
+  model: string,
+  systemPrompt: string,
+  message: string,
+  { maxTokens = 400, timeoutMs = 6000 }: { maxTokens?: number; timeoutMs?: number } = {},
+): Promise<string | null> {
+  const live = (async () => {
+    try {
+      const { data } = await inferenceSendPost({
+        path: { assistant_id: assistantId },
+        body: { message, systemPrompt, model, maxTokens },
+        throwOnError: false,
+      });
+      return data?.response ?? null;
+    } catch {
+      return null;
+    }
+  })();
+  const timeout = new Promise<null>((resolve) => setTimeout(() => resolve(null), timeoutMs));
+  return Promise.race([live, timeout]);
+}
+
+/* ---------------- Receipt ---------------- */
+
+export async function generateReceipt(
+  picks: Picks,
+  assistantId: string | null,
+): Promise<Receipt> {
+  const job = labelsFor(picks.jobs, JOBS);
+  const rather = labelsFor(picks.rathers, RATHERS);
+  const style = styleWords(picks.style);
+
+  if (assistantId) {
+    const raw = await callModel(
+      assistantId,
+      RECEIPT_MODEL,
+      "You write tight, perceptive onboarding copy. No greeting, no fluff, no emoji. " +
+        'Return ONLY a JSON object: {"observation": string, "inference": string, "offer": string, "verb": string}. ' +
+        "observation = one specific thing about them; inference = one non-obvious thing you infer; " +
+        "offer = one concrete one-tap thing you can do for them; verb = a 1-2 word button label for the offer.",
+      `The user's job is ${job}. They would rather be ${rather}. They prefer ${style}. ` +
+        "Write the observation, inference, offer, and verb.",
+    );
+    const j = raw ? extractJson(raw) : null;
+    if (
+      j &&
+      typeof j.observation === "string" &&
+      typeof j.inference === "string" &&
+      typeof j.offer === "string"
+    ) {
+      return {
+        observation: j.observation,
+        inference: j.inference,
+        offer: j.offer,
+        verb: typeof j.verb === "string" && j.verb.trim() ? j.verb.trim() : "Set it up",
+      };
+    }
+  }
+
+  return localReceipt(picks);
+}
+
+function localReceipt(picks: Picks): Receipt {
+  const job = labelsFor(picks.jobs, JOBS);
+  const rather = labelsFor(picks.rathers, RATHERS);
+  const sendIt = picks.style.autonomy === "send_it";
+  const walk = picks.style.tone === "walk";
+  return {
+    observation: `You're spending your days ${job}.`,
+    inference: `But you'd rather be ${rather} — which usually means the busywork is eating the part you actually like.`,
+    offer: `I can take the ${job} grind off your plate${sendIt ? " and just handle it" : walk ? " and keep you in the loop" : ""}, starting with the most repetitive piece.`,
+    verb: sendIt ? "Set it up" : "Show me",
+  };
+}
+
+/* ---------------- Artifact ---------------- */
+
+export async function generateArtifact(
+  picks: Picks,
+  assistantId: string | null,
+): Promise<Artifact> {
+  const job = labelsFor(picks.jobs, JOBS);
+  const rather = labelsFor(picks.rathers, RATHERS);
+
+  if (assistantId) {
+    const raw = await callModel(
+      assistantId,
+      ARTIFACT_MODEL,
+      "You are an assistant who quietly made the user a small useful or delightful artifact while they were " +
+        "being onboarded. No greeting, no fluff. " +
+        'Return ONLY a JSON object: {"title": string, "description": string}. ' +
+        "title = max 6 words; description = one sentence. " +
+        'Examples: {"title":"Three weekend trails near you","description":"..."}, ' +
+        '{"title":"Five investor letters worth stealing from","description":"..."}.',
+      `Tie it to their job (${job}) and what they'd rather be doing (${rather}).`,
+    );
+    const j = raw ? extractJson(raw) : null;
+    if (j && typeof j.title === "string" && typeof j.description === "string") {
+      return { title: j.title, description: j.description };
+    }
+  }
+
+  return localArtifact(picks);
+}
+
+/**
+ * Generate N artifacts. The "few quick wins" Proof shape asks for 2-3 small
+ * cards; "one thing, well" asks for a single focused one. Each is generated
+ * independently (varied by index) so the stack reads as distinct wins.
+ */
+export async function generateArtifacts(
+  picks: Picks,
+  count: number,
+  assistantId: string | null,
+): Promise<Artifact[]> {
+  if (count <= 1) return [await generateArtifact(picks, assistantId)];
+  const job = labelsFor(picks.jobs, JOBS);
+  const rather = labelsFor(picks.rathers, RATHERS);
+  const tasks = Array.from({ length: count }, async (_, i) => {
+    if (assistantId) {
+      const raw = await callModel(
+        assistantId,
+        ARTIFACT_MODEL,
+        "You are an assistant who quietly made the user a few small useful or delightful artifacts " +
+          "while they were being onboarded. No greeting, no fluff. " +
+          'Return ONLY a JSON object: {"title": string, "description": string}. ' +
+          "title = max 6 words; description = one sentence.",
+        `This is quick win #${i + 1} of ${count}, distinct from the others. ` +
+          `Tie it to their job (${job}) and what they'd rather be doing (${rather}).`,
+      );
+      const j = raw ? extractJson(raw) : null;
+      if (j && typeof j.title === "string" && typeof j.description === "string") {
+        return { title: j.title, description: j.description };
+      }
+    }
+    return localArtifact(picks, i);
+  });
+  return Promise.all(tasks);
+}
+
+function localArtifact(picks: Picks, variant = 0): Artifact {
+  const rather = labelsFor(picks.rathers, RATHERS);
+  const job = labelsFor(picks.jobs, JOBS);
+  const variants: Artifact[] = [
+    {
+      title: `A head start on ${rather}`,
+      description: `A few things I lined up to make ${rather} easier to get to — between the ${job}.`,
+    },
+    {
+      title: `${job} on autopilot`,
+      description: `The most repetitive part of ${job}, drafted and ready for a glance.`,
+    },
+    {
+      title: `15 minutes back`,
+      description: `One recurring chore I can take off your plate this week.`,
+    },
+  ];
+  return variants[variant % variants.length];
+}
+
+/* ---------------- Full artifact body (Open overlay) ---------------- */
+
+export async function generateFullArtifact(
+  picks: Picks,
+  artifact: Artifact,
+  assistantId: string | null,
+): Promise<string> {
+  const job = labelsFor(picks.jobs, JOBS);
+  const rather = labelsFor(picks.rathers, RATHERS);
+  const style = styleWords(picks.style);
+
+  if (assistantId) {
+    const raw = await callModel(
+      assistantId,
+      RECEIPT_MODEL, // Sonnet — the body is read carefully
+      "You write short, genuinely useful or delightful pieces. No preamble, no " +
+        '"here is your...". Start directly with the content. Use light markdown ' +
+        "(a heading, a short list, a line or two of prose). 200-400 words.",
+      `You quietly made this for a user during onboarding. Their job is ${job}, ` +
+        `they would rather be ${rather}, and they prefer ${style}. ` +
+        `The artifact is titled "${artifact.title}" — "${artifact.description}". ` +
+        "Write the full artifact.",
+      { maxTokens: 900, timeoutMs: 20000 },
+    );
+    if (raw && raw.trim()) return raw.trim();
+  }
+
+  return localFullArtifact(picks, artifact);
+}
+
+function localFullArtifact(picks: Picks, artifact: Artifact): string {
+  const rather = labelsFor(picks.rathers, RATHERS);
+  const job = labelsFor(picks.jobs, JOBS);
+  return [
+    `## ${artifact.title}`,
+    "",
+    `You're deep in ${job} — so here's a small running start on **${rather}**, ready whenever you are.`,
+    "",
+    "- **Pick a window.** Block 90 minutes this week and treat it like a meeting that can't move.",
+    "- **Lower the bar to start.** One small step counts; momentum does the rest.",
+    "- **Make it visible.** Put it on the calendar where the busywork can't quietly crowd it out.",
+    "",
+    `I'll keep an eye on the ${job} side so this stays the part you look forward to. ` +
+      "Tap Save and I'll keep it handy.",
+  ].join("\n");
+}

--- a/apps/web/src/domains/onboarding/cast/cast-prop-art.tsx
+++ b/apps/web/src/domains/onboarding/cast/cast-prop-art.tsx
@@ -1,0 +1,203 @@
+/**
+ * Chunky flat-fill prop art — drawn in the dudes' visual language: bold solid
+ * fills, rounded forms, white/black accents, no outline strokes or gradients
+ * (a couple of inherently-tubular props use a round-capped stroke as the shape
+ * itself, e.g. the headset band and stethoscope tubing). One drawing per prop,
+ * reused at tile size and as the larger flying/held prop.
+ *
+ * Ported from the prototype's `@/cast/cast-prop-art`. The `PropKey` union was
+ * already inlined into `cast-content` on base (it keys job/rather icons there),
+ * so this module imports + re-exports it from `cast-content` rather than
+ * redeclaring it — the art table is the only new surface. Needed by the done
+ * screen's proof view (`cast-proof-view`) for held/juggled/artifact prop icons.
+ */
+
+import type { ReactNode } from "react";
+
+import type { PropKey } from "@/domains/onboarding/cast/cast-content";
+
+export type { PropKey };
+
+// Shared palette — the dude colors plus a few prop neutrals.
+const INK = "#1A1A1A";
+const PAPER = "#F2F2F2";
+const GREEN = "#4C9B50";
+const ORANGE = "#E9642F";
+const PINK = "#DB4B77";
+const PURPLE = "#A665C9";
+const TEAL = "#0E9B8B";
+const YELLOW = "#E9C91A";
+const METAL = "#C7CDD6";
+const DARK_METAL = "#5B6270";
+const SLATE = "#3A3F4D";
+const WOOD = "#C8863E";
+const WOOD_DARK = "#9C6526";
+
+const ART: Record<PropKey, ReactNode> = {
+  laptop: (
+    <>
+      <rect x="20" y="26" width="80" height="54" rx="10" fill={INK} />
+      <rect x="28" y="33" width="64" height="40" rx="6" fill={TEAL} />
+      <rect x="34" y="39" width="20" height="6" rx="3" fill="#3fcbb8" />
+      <rect x="8" y="80" width="104" height="16" rx="8" fill={SLATE} />
+      <rect x="48" y="84" width="24" height="5" rx="2.5" fill={DARK_METAL} />
+    </>
+  ),
+  pen: (
+    <g transform="rotate(-38 60 60)">
+      <rect x="50" y="14" width="20" height="66" rx="10" fill={ORANGE} />
+      <rect x="50" y="14" width="20" height="12" rx="6" fill="#b94413" />
+      <rect x="72" y="22" width="6" height="26" rx="3" fill="#b94413" />
+      <polygon points="50,80 70,80 60,104" fill={INK} />
+      <polygon points="57,97 63,97 60,104" fill={PAPER} />
+    </g>
+  ),
+  brush: (
+    <g transform="rotate(-38 60 60)">
+      <rect x="52" y="10" width="16" height="56" rx="8" fill={WOOD} />
+      <rect x="50" y="62" width="20" height="14" rx="4" fill={METAL} />
+      <path d="M50 76 H70 L66 104 Q60 112 54 104 Z" fill={PINK} />
+    </g>
+  ),
+  headset: (
+    <>
+      <path
+        d="M26 70 V58 A34 34 0 0 1 94 58 V70"
+        fill="none"
+        stroke={PURPLE}
+        strokeWidth="12"
+        strokeLinecap="round"
+      />
+      <rect x="16" y="62" width="22" height="34" rx="11" fill={INK} />
+      <rect x="22" y="69" width="10" height="20" rx="5" fill={PURPLE} />
+      <rect x="82" y="62" width="22" height="34" rx="11" fill={INK} />
+      <rect x="88" y="69" width="10" height="20" rx="5" fill={PURPLE} />
+      <path d="M27 92 Q27 104 46 104" fill="none" stroke={INK} strokeWidth="7" strokeLinecap="round" />
+      <circle cx="48" cy="104" r="6" fill={INK} />
+    </>
+  ),
+  clipboard: (
+    <>
+      <rect x="22" y="16" width="76" height="94" rx="11" fill={WOOD} />
+      <rect x="32" y="28" width="56" height="74" rx="5" fill={PAPER} />
+      <rect x="40" y="40" width="40" height="6" rx="3" fill="#D2D6DE" />
+      <rect x="40" y="54" width="40" height="6" rx="3" fill="#D2D6DE" />
+      <rect x="40" y="68" width="28" height="6" rx="3" fill="#D2D6DE" />
+      <rect x="46" y="8" width="28" height="18" rx="6" fill={DARK_METAL} />
+    </>
+  ),
+  book: (
+    <>
+      <rect x="26" y="24" width="70" height="74" rx="9" fill={PINK} />
+      <rect x="26" y="24" width="13" height="74" rx="6" fill="#b23a62" />
+      <rect x="84" y="30" width="10" height="62" rx="3" fill={PAPER} />
+      <rect x="62" y="20" width="11" height="34" rx="2" fill={YELLOW} />
+    </>
+  ),
+  stethoscope: (
+    <>
+      <path
+        d="M40 22 V44 Q40 74 60 74 Q80 74 80 44 V22"
+        fill="none"
+        stroke={TEAL}
+        strokeWidth="9"
+        strokeLinecap="round"
+      />
+      <circle cx="40" cy="20" r="7" fill={INK} />
+      <circle cx="80" cy="20" r="7" fill={INK} />
+      <path d="M60 74 V90" fill="none" stroke={TEAL} strokeWidth="9" strokeLinecap="round" />
+      <circle cx="60" cy="98" r="15" fill={METAL} />
+      <circle cx="60" cy="98" r="7" fill={DARK_METAL} />
+    </>
+  ),
+  hammer: (
+    <>
+      <path d="M24 24 H84 V44 H58 L50 36 H24 Z" fill={DARK_METAL} />
+      <rect x="24" y="24" width="14" height="20" rx="3" fill={METAL} />
+      <rect x="52" y="40" width="16" height="64" rx="8" fill={WOOD} />
+      <rect x="52" y="40" width="16" height="64" rx="8" fill={WOOD} />
+      <rect x="54" y="86" width="12" height="18" rx="5" fill={WOOD_DARK} />
+    </>
+  ),
+  sunglasses: (
+    <>
+      <rect x="16" y="46" width="38" height="30" rx="13" fill={INK} />
+      <rect x="66" y="46" width="38" height="30" rx="13" fill={INK} />
+      <rect x="50" y="52" width="20" height="9" rx="4" fill={INK} />
+      <rect x="6" y="50" width="14" height="8" rx="4" fill={INK} transform="rotate(18 13 54)" />
+      <rect x="100" y="50" width="14" height="8" rx="4" fill={INK} transform="rotate(-18 107 54)" />
+      <rect x="22" y="51" width="11" height="7" rx="3.5" fill="#5b6270" />
+      <rect x="72" y="51" width="11" height="7" rx="3.5" fill="#5b6270" />
+    </>
+  ),
+  backpack: (
+    <>
+      <rect x="34" y="20" width="14" height="26" rx="7" fill="#3c7d40" />
+      <rect x="72" y="20" width="14" height="26" rx="7" fill="#3c7d40" />
+      <rect x="24" y="30" width="72" height="78" rx="22" fill={GREEN} />
+      <rect x="40" y="40" width="40" height="18" rx="9" fill="#3c7d40" />
+      <rect x="38" y="64" width="44" height="38" rx="13" fill="#3c7d40" />
+      <rect x="56" y="70" width="8" height="22" rx="4" fill={YELLOW} />
+    </>
+  ),
+  chefhat: (
+    <>
+      <rect x="38" y="74" width="44" height="30" rx="7" fill="#E2E2E2" />
+      <circle cx="42" cy="52" r="20" fill={PAPER} />
+      <circle cx="78" cy="52" r="20" fill={PAPER} />
+      <circle cx="60" cy="42" r="25" fill={PAPER} />
+      <rect x="36" y="56" width="48" height="26" fill={PAPER} />
+    </>
+  ),
+  gamepad: (
+    <>
+      <circle cx="34" cy="78" r="20" fill={SLATE} />
+      <circle cx="86" cy="78" r="20" fill={SLATE} />
+      <rect x="22" y="46" width="76" height="36" rx="18" fill={SLATE} />
+      <rect x="33" y="60" width="18" height="6" rx="3" fill={PAPER} />
+      <rect x="39" y="54" width="6" height="18" rx="3" fill={PAPER} />
+      <circle cx="76" cy="60" r="5" fill={PINK} />
+      <circle cx="88" cy="64" r="5" fill={YELLOW} />
+      <circle cx="76" cy="72" r="5" fill={TEAL} />
+    </>
+  ),
+  plane: (
+    <g transform="rotate(38 60 60)">
+      <rect x="53" y="20" width="14" height="80" rx="7" fill={PAPER} />
+      <polygon points="60,44 102,70 60,60 18,70" fill={PAPER} />
+      <polygon points="60,92 76,104 60,100 44,104" fill={PAPER} />
+      <circle cx="60" cy="30" r="6" fill={TEAL} />
+      <rect x="55" y="62" width="10" height="6" rx="3" fill={TEAL} />
+    </g>
+  ),
+  moon: (
+    <>
+      <path d="M78 30 A34 34 0 1 0 78 90 A26 26 0 1 1 78 30 Z" fill={YELLOW} />
+      <circle cx="86" cy="34" r="4" fill={PAPER} />
+      <circle cx="96" cy="52" r="3" fill={PAPER} />
+      <circle cx="84" cy="64" r="2.5" fill={PAPER} />
+    </>
+  ),
+  buddies: (
+    <>
+      <path d="M22 96 Q22 56 46 56 Q70 56 70 96 Z" fill={TEAL} />
+      <circle cx="38" cy="74" r="5" fill={PAPER} />
+      <circle cx="54" cy="74" r="5" fill={PAPER} />
+      <circle cx="38" cy="74" r="2.4" fill={INK} />
+      <circle cx="54" cy="74" r="2.4" fill={INK} />
+      <path d="M62 98 Q62 62 84 62 Q106 62 106 98 Z" fill={PINK} />
+      <circle cx="78" cy="80" r="4.5" fill={PAPER} />
+      <circle cx="92" cy="80" r="4.5" fill={PAPER} />
+      <circle cx="78" cy="80" r="2.2" fill={INK} />
+      <circle cx="92" cy="80" r="2.2" fill={INK} />
+    </>
+  ),
+};
+
+export function CastProp({ name, className }: { name: PropKey; className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 120 120" aria-hidden="true">
+      {ART[name]}
+    </svg>
+  );
+}

--- a/apps/web/src/domains/onboarding/cast/cast-task-derivation.test.ts
+++ b/apps/web/src/domains/onboarding/cast/cast-task-derivation.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  ALL_STEPS,
+  FALLBACK_TASKS,
+  TOOL_TASKS,
+  deriveTaskSuggestions,
+} from "@/domains/onboarding/cast/cast-task-derivation";
+
+describe("deriveTaskSuggestions", () => {
+  it("falls back to generic tasks when there are no memories", () => {
+    const tasks = deriveTaskSuggestions([]);
+    expect(tasks).toEqual(FALLBACK_TASKS.slice(0, 3));
+  });
+
+  it("always returns at most three tasks", () => {
+    const tasks = deriveTaskSuggestions([
+      ["reach", "Connected: Slack, Gmail, Notion, Linear"],
+    ]);
+    expect(tasks.length).toBeLessThanOrEqual(3);
+  });
+
+  it("derives a task from each connected tool, drawn from that tool's pool", () => {
+    const tasks = deriveTaskSuggestions([["reach", "Connected: Slack, Gmail"]]);
+    expect(tasks.length).toBe(3); // 2 tool tasks + 1 fallback
+    expect(TOOL_TASKS["slack"]).toContain(tasks[0]);
+    expect(TOOL_TASKS["gmail"]).toContain(tasks[1]);
+  });
+
+  it("maps the 'Google Calendar' label to the google-calendar slug", () => {
+    const tasks = deriveTaskSuggestions([["reach", "Connected: Google Calendar"]]);
+    expect(TOOL_TASKS["google-calendar"]).toContain(tasks[0]);
+  });
+
+  it("slugifies multi-word tool labels (Google Drive -> google-drive)", () => {
+    const tasks = deriveTaskSuggestions([["reach", "Connected: Google Drive"]]);
+    expect(TOOL_TASKS["google-drive"]).toContain(tasks[0]);
+  });
+
+  it("ignores unknown tool labels and falls back", () => {
+    const tasks = deriveTaskSuggestions([["reach", "Connected: Telepathy"]]);
+    expect(tasks).toEqual(FALLBACK_TASKS.slice(0, 3));
+  });
+
+  it("ignores a reach entry that is not a 'Connected:' list", () => {
+    const tasks = deriveTaskSuggestions([["reach", "SMS"]]);
+    expect(tasks).toEqual(FALLBACK_TASKS.slice(0, 3));
+  });
+
+  it("adds a continuation task when a brain was imported", () => {
+    const tasks = deriveTaskSuggestions([["brain", "Import from: ChatGPT"]]);
+    expect(tasks[0]).toBe("Pick up where I left off with my previous conversations");
+    expect(tasks.length).toBe(3);
+  });
+
+  it("does not add a continuation task for a non-import brain entry", () => {
+    const tasks = deriveTaskSuggestions([["brain", "Skipped"]]);
+    expect(tasks).not.toContain(
+      "Pick up where I left off with my previous conversations",
+    );
+  });
+
+  it("fills tool + brain tasks before fallbacks, capped at three", () => {
+    const tasks = deriveTaskSuggestions([
+      ["reach", "Connected: Slack, Gmail"],
+      ["brain", "Import from: Claude"],
+    ]);
+    expect(tasks.length).toBe(3);
+    expect(TOOL_TASKS["slack"]).toContain(tasks[0]);
+    expect(TOOL_TASKS["gmail"]).toContain(tasks[1]);
+    expect(tasks[2]).toBe("Pick up where I left off with my previous conversations");
+  });
+
+  it("does not duplicate fallback tasks", () => {
+    const tasks = deriveTaskSuggestions([]);
+    expect(new Set(tasks).size).toBe(tasks.length);
+  });
+});
+
+describe("ALL_STEPS", () => {
+  it("exposes the active onboarding steps that feed task derivation", () => {
+    expect(ALL_STEPS.map((s) => s.step)).toEqual(["face", "tone", "reach"]);
+  });
+});

--- a/apps/web/src/domains/onboarding/cast/cast-task-derivation.ts
+++ b/apps/web/src/domains/onboarding/cast/cast-task-derivation.ts
@@ -1,0 +1,96 @@
+/**
+ * Cast task derivation — the SOURCE OF TRUTH for the user's suggested tasks.
+ *
+ * Ported verbatim from the prototype's `interactive-setup.tsx` (the
+ * `HandoffScreen` closure). The prototype's separate `job` phase is gone, so
+ * `deriveTaskSuggestions` is now the single place tasks are computed: the
+ * done/handoff screen renders them, and the downstream PreChatOnboardingContext
+ * handoff maps its `tasks` from this output. Kept as a pure, dependency-free
+ * module so it can be unit-tested and consumed by the orchestrator without
+ * pulling in any React/screen closure.
+ *
+ * `deriveTaskSuggestions` reads the persistent "making of" memory list (the
+ * `[step, text]` tuples recorded during onboarding): connected tools (the
+ * `reach` entry) drive tool-specific tasks, an imported brain adds a
+ * continuation task, and the rest are filled from generic fallbacks. The result
+ * is always capped at three.
+ */
+
+/** Tool-specific task suggestions, keyed by the connected tool's slug. */
+export const TOOL_TASKS: Record<string, string[]> = {
+  "google-calendar": ["Check my schedule for today", "Block focus time this week"],
+  "notion": ["Summarize my recent Notion updates", "Create a weekly planner page"],
+  "linear": ["Show my open Linear issues", "Draft a sprint summary"],
+  "github": ["Review my open pull requests", "Summarize recent commits"],
+  "slack": ["Catch me up on unread Slack messages", "Draft a standup update"],
+  "gmail": ["Summarize my unread emails", "Draft a follow-up email"],
+  "figma": ["List recent Figma file changes", "Prepare design review notes"],
+  "outlook": ["Check my Outlook calendar for today", "Summarize flagged emails"],
+  "google-drive": ["Find my most recent shared docs", "Organize my Drive files"],
+};
+
+/** Generic tasks used to fill any remaining slots. */
+export const FALLBACK_TASKS = [
+  "Draft a daily plan for me",
+  "Help me write a professional email",
+  "Summarize a document for me",
+  "Create a to-do list for this week",
+  "Research a topic and brief me",
+];
+
+/**
+ * Derive up to three suggested tasks from the onboarding memory list. Pulls one
+ * task per connected tool, adds a continuation task when a brain was imported,
+ * then tops up from `FALLBACK_TASKS`.
+ */
+export function deriveTaskSuggestions(memories: [string, string][]): string[] {
+  const tasks: string[] = [];
+  const memMap = new Map(memories);
+
+  // Pull tasks from connected tools
+  const reachText = memMap.get("reach") ?? "";
+  if (reachText.startsWith("Connected:")) {
+    const toolNames = reachText.replace("Connected: ", "").split(", ");
+    for (const toolName of toolNames) {
+      // Find key by label
+      const key =
+        toolName === "Google Calendar"
+          ? "google-calendar"
+          : toolName.toLowerCase().replace(/\s+/g, "-");
+      const pool = TOOL_TASKS[key];
+      if (pool) tasks.push(pool[Math.floor(Math.random() * pool.length)]);
+    }
+  }
+
+  // If brain was imported, add a related task
+  const brainText = memMap.get("brain") ?? "";
+  if (brainText.includes("Import from:")) {
+    tasks.push("Pick up where I left off with my previous conversations");
+  }
+
+  // Fill remaining slots from fallbacks
+  const seen = new Set(tasks);
+  for (const t of FALLBACK_TASKS) {
+    if (tasks.length >= 3) break;
+    if (!seen.has(t)) {
+      tasks.push(t);
+      seen.add(t);
+    }
+  }
+
+  return tasks.slice(0, 3);
+}
+
+/**
+ * The persistent "making of" step list. Ported from the prototype's
+ * `interactive-setup.tsx`; the commented-out `brain`/`email` steps are kept as
+ * the prototype left them. Used by the memory-list UI and as documentation of
+ * which steps feed `deriveTaskSuggestions`.
+ */
+export const ALL_STEPS: { step: string; pending: string; credits?: number }[] = [
+  { step: "face", pending: "Look & feel" },
+  { step: "tone", pending: "Communication style" },
+  // { step: "brain", pending: "Context import", credits: 50 },
+  { step: "reach", pending: "Primary channel", credits: 25 },
+  // { step: "email", pending: "Email address" },
+];

--- a/apps/web/src/domains/onboarding/cast/screens/done-screen.tsx
+++ b/apps/web/src/domains/onboarding/cast/screens/done-screen.tsx
@@ -1,0 +1,132 @@
+/**
+ * `done` screen — proof / endpoint that finishes the cast onboarding flow.
+ *
+ * Conforms to `DoneScreenProps` (see `screen-slot.ts`). The character settles
+ * and presents the small artifacts it "made", then offers the two endpoints
+ * (drop into chat / boost). The proof/endpoint surface itself is the ported
+ * sibling `CastProof` (`@/domains/onboarding/cast/cast-proof-view`).
+ *
+ * The slot contract narrows the proof view's callbacks: `onAction(which)` is
+ * widened to a plain string, and `onEndpoint()` takes no argument (the
+ * orchestrator decides what "finish" means), so the chat/boost distinction is
+ * collapsed here — both route through the single `onEndpoint`.
+ *
+ * This module also re-exports `HandoffScreen` (ported verbatim from the
+ * prototype's `interactive-setup.tsx`). With the prototype's `job` phase gone,
+ * `deriveTaskSuggestions` (in `cast-task-derivation`) is the source of truth for
+ * the user's tasks; `HandoffScreen` renders those derived tasks and doubles as
+ * the loading/handoff visual a later PR shows while awaiting hatch readiness.
+ * It keeps its own prop shape (it needs the raw memory list, which is not part
+ * of `DoneScreenProps`) so the integration PR can wire it independently.
+ */
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { AnimatePresence, motion } from "motion/react";
+
+import { BlinkingAvatar } from "@/domains/onboarding/cast/cast-shell";
+import { CastProof } from "@/domains/onboarding/cast/cast-proof-view";
+import { deriveTaskSuggestions } from "@/domains/onboarding/cast/cast-task-derivation";
+import type { CastCharacter } from "@/domains/onboarding/cast/cast-roster";
+import type { MemoryEntry, DoneScreenProps } from "@/domains/onboarding/cast/screens/screen-slot";
+
+export function DoneScreen({
+  character,
+  box,
+  jobs,
+  rathers,
+  style,
+  ascended,
+  assistantId,
+  onAction,
+  onEndpoint,
+  onBack,
+}: DoneScreenProps) {
+  return (
+    <CastProof
+      character={character}
+      box={box}
+      jobs={jobs}
+      rathers={rathers}
+      style={style}
+      ascended={ascended}
+      assistantId={assistantId}
+      onAction={onAction}
+      onEndpoint={() => onEndpoint()}
+      onBack={() => onBack?.()}
+    />
+  );
+}
+
+/**
+ * HandoffScreen — transition screen before dropping into the chat sandbox.
+ * Ported verbatim from the prototype's `interactive-setup.tsx`; renders the
+ * tasks derived from the onboarding memory list and reveals a "Let's go" CTA
+ * after a short beat. Kept as a named export for the later integration PR.
+ */
+export function HandoffScreen({
+  character,
+  memories,
+  onComplete,
+}: {
+  character: CastCharacter;
+  memories: MemoryEntry[];
+  onComplete: () => void;
+}) {
+  const [showCta, setShowCta] = useState(false);
+  const onCompleteRef = useRef(onComplete);
+  useEffect(() => {
+    onCompleteRef.current = onComplete;
+  });
+
+  const tasks = useMemo(() => deriveTaskSuggestions(memories), [memories]);
+
+  useEffect(() => {
+    const ctaTimer = window.setTimeout(() => setShowCta(true), 1800);
+    return () => clearTimeout(ctaTimer);
+  }, []);
+
+  return (
+    <motion.div
+      className="cast-handoff"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.4 }}
+    >
+      <div style={{ width: 200, height: 200, marginBottom: 32 }}>
+        <BlinkingAvatar character={character} />
+      </div>
+      <h2 className="cast-handoff__heading">
+        Here's what I found I can take care of for you today
+      </h2>
+      <ul className="cast-handoff__tasks">
+        {tasks.map((task, i) => (
+          <motion.li
+            key={task}
+            className="cast-handoff__task"
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.3, delay: 0.4 + i * 0.2 }}
+          >
+            {task}
+          </motion.li>
+        ))}
+      </ul>
+      <AnimatePresence>
+        {showCta && (
+          <motion.button
+            className="cast-handoff__cta"
+            onClick={() => onCompleteRef.current()}
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.3 }}
+          >
+            Let's go &rarr;
+          </motion.button>
+        )}
+      </AnimatePresence>
+    </motion.div>
+  );
+}
+
+export default DoneScreen;


### PR DESCRIPTION
## Summary
- Port cast done/handoff screen (HandoffScreen + cast-proof-view) conforming to DoneScreenProps
- Extract deriveTaskSuggestions into cast-task-derivation.ts (now the tasks source) + unit test

Part of plan: cast-prechat-flow.md (PR 5g)