### PR TITLE
feat(onboarding): cast flow hatches during occupation, fires research directive

### DIFF
--- a/apps/web/src/assistant/lifecycle-service.ts
+++ b/apps/web/src/assistant/lifecycle-service.ts
@@ -217,7 +217,19 @@ class AssistantLifecycleService {
   // Imperative actions — called from event handlers / consumers
   // ---------------------------------------------------------------------------
 
-  async checkAssistant(): Promise<void> {
+  /**
+   * Force a fresh assistant-status fetch and project it.
+   *
+   * `assistantIdOverride` pins this one refresh to a specific assistant
+   * instead of the multi-assistant selection carried in
+   * `inputs.selectedPlatformAssistantId`. The onboarding handoff uses it so a
+   * just-hatched assistant is the one fetched and projected — otherwise, in a
+   * multi-assistant session where a *different* assistant is already selected,
+   * the refresh would re-fetch that selection and `projectActive` would
+   * overwrite the active id back to it, sending the onboarding payload to the
+   * wrong assistant.
+   */
+  async checkAssistant(assistantIdOverride?: string): Promise<void> {
     if (!this.ready) return;
     if (isGatewayAuthMode()) {
       this.applyGatewayAuthShortCircuit();
@@ -235,7 +247,8 @@ class AssistantLifecycleService {
       // network so a 10s-old cached 404 or initializing result
       // doesn't silently replay. Poll-driven projections go through
       // `applyServerResult` to avoid the read-back loop.
-      const selectedId = this.inputs.selectedPlatformAssistantId ?? null;
+      const selectedId =
+        assistantIdOverride ?? this.inputs.selectedPlatformAssistantId ?? null;
       let result = await this.inputs.queryClient.fetchQuery({
         queryKey: assistantQueryKey(selectedId),
         queryFn: () => getAssistant(selectedId ?? undefined),

--- a/apps/web/src/domains/onboarding/cast/cast-onboarding-flow.test.tsx
+++ b/apps/web/src/domains/onboarding/cast/cast-onboarding-flow.test.tsx
@@ -34,8 +34,16 @@ mock.module("@/domains/onboarding/cast/use-background-hatch", () => ({
 }));
 
 // --- prechat handoff ---------------------------------------------------------
-const setPendingPreChatContextMock = mock(() => {});
-const setPendingAssistantNameMock = mock(() => {});
+interface CapturedPreChatContext {
+  occupation?: string;
+  initialMessage?: string;
+  assistantName?: string;
+  tasks: string[];
+}
+const setPendingPreChatContextMock = mock(
+  (_ctx: CapturedPreChatContext) => {},
+);
+const setPendingAssistantNameMock = mock((_name: string) => {});
 
 mock.module("@/domains/onboarding/prechat", () => ({
   setPendingPreChatContext: setPendingPreChatContextMock,
@@ -44,8 +52,9 @@ mock.module("@/domains/onboarding/prechat", () => ({
 
 // --- lifecycle / navigation --------------------------------------------------
 const markExpectingFirstMessageMock = mock(() => {});
-const checkAssistantMock = mock(async () => {});
-const setActiveAssistantIdMock = mock(() => {});
+const checkAssistantMock = mock(async (_assistantId?: string) => {});
+const setActiveAssistantIdMock = mock((_id: string) => {});
+const setSelectedAssistantMock = mock(async (_id: string) => {});
 const navigateMock = mock(() => {});
 
 mock.module("@/assistant/lifecycle-service", () => ({
@@ -53,6 +62,10 @@ mock.module("@/assistant/lifecycle-service", () => ({
     markExpectingFirstMessage: markExpectingFirstMessageMock,
     checkAssistant: checkAssistantMock,
   },
+}));
+
+mock.module("@/assistant/selection", () => ({
+  setSelectedAssistant: setSelectedAssistantMock,
 }));
 
 mock.module("@/stores/resolved-assistants-store", () => ({
@@ -87,8 +100,8 @@ mock.module("@/domains/onboarding/cast/screens/login-screen", () => ({
       type="button"
       data-testid="login-continue"
       onClick={() => {
-        onContinue("Ada");
-        onIdentity?.({ lastName: "Lovelace", role: "Software Engineer" });
+        onContinue("Alice");
+        onIdentity?.({ lastName: "Example", role: "Software Engineer" });
         onAdvance();
       }}
     >
@@ -170,6 +183,7 @@ beforeEach(() => {
   markExpectingFirstMessageMock.mockClear();
   checkAssistantMock.mockClear();
   setActiveAssistantIdMock.mockClear();
+  setSelectedAssistantMock.mockClear();
   navigateMock.mockClear();
 });
 
@@ -195,14 +209,12 @@ describe("CastOnboardingFlow handoff", () => {
 
     await waitFor(() => expect(setPendingPreChatContextMock).toHaveBeenCalledTimes(1));
 
-    const ctx = setPendingPreChatContextMock.mock.calls[0]![0] as {
-      occupation?: string;
-      initialMessage?: string;
-      tasks: string[];
-    };
+    const ctx = setPendingPreChatContextMock.mock.calls[0]![0];
     expect(ctx.occupation).toBe("Software Engineer");
     expect(ctx.initialMessage).toBe(CAST_RESEARCH_DIRECTIVE);
     expect(ctx.tasks.length).toBeGreaterThan(0);
+    // The chosen cast name rides the context, not just the optimistic key.
+    expect(ctx.assistantName).toBe("Pixel");
 
     expect(setPendingAssistantNameMock).toHaveBeenCalledWith("Pixel");
     await waitFor(() =>

--- a/apps/web/src/domains/onboarding/cast/cast-onboarding-flow.test.tsx
+++ b/apps/web/src/domains/onboarding/cast/cast-onboarding-flow.test.tsx
@@ -1,0 +1,258 @@
+/**
+ * Tests for the cast onboarding flow's PR-6 handoff:
+ *   - login-phase entry starts the background hatch exactly once
+ *   - completion builds a PreChatOnboardingContext (occupation + research
+ *     directive as initialMessage) and stashes it via setPendingPreChatContext
+ *   - completion awaits hatch readiness before navigating
+ *   - a terminal hatch failure surfaces a retry affordance instead of navigating
+ *
+ * Heavy cast screens are mocked down to single buttons so the test can drive
+ * the phase machine (login -> starter -> dialogue completion) deterministically.
+ * The background hatch, prechat handoff, lifecycle service, and navigation are
+ * all mocked so we can assert the orchestration without real I/O.
+ *
+ * Single-file `bun test` — multi-file runs leak `mock.module` across files.
+ */
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { CAST_RESEARCH_DIRECTIVE } from "@/domains/onboarding/cast/cast-prechat-mapping";
+
+// --- background hatch --------------------------------------------------------
+const startMock = mock(() => {});
+let awaitReadyImpl: () => Promise<string> = async () => "asst-ready";
+const awaitReadyMock = mock(() => awaitReadyImpl());
+
+mock.module("@/domains/onboarding/cast/use-background-hatch", () => ({
+  useBackgroundHatch: () => ({
+    start: startMock,
+    ready: false,
+    assistantId: null,
+    error: null,
+    awaitReady: awaitReadyMock,
+  }),
+}));
+
+// --- prechat handoff ---------------------------------------------------------
+const setPendingPreChatContextMock = mock(() => {});
+const setPendingAssistantNameMock = mock(() => {});
+
+mock.module("@/domains/onboarding/prechat", () => ({
+  setPendingPreChatContext: setPendingPreChatContextMock,
+  setPendingAssistantName: setPendingAssistantNameMock,
+}));
+
+// --- lifecycle / navigation --------------------------------------------------
+const markExpectingFirstMessageMock = mock(() => {});
+const checkAssistantMock = mock(async () => {});
+const setActiveAssistantIdMock = mock(() => {});
+const navigateMock = mock(() => {});
+
+mock.module("@/assistant/lifecycle-service", () => ({
+  lifecycleService: {
+    markExpectingFirstMessage: markExpectingFirstMessageMock,
+    checkAssistant: checkAssistantMock,
+  },
+}));
+
+mock.module("@/stores/resolved-assistants-store", () => ({
+  useResolvedAssistantsStore: {
+    getState: () => ({ setActiveAssistantId: setActiveAssistantIdMock }),
+  },
+}));
+
+mock.module("react-router", () => ({
+  useNavigate: () => navigateMock,
+}));
+
+// --- cast screens (driven via testid buttons) --------------------------------
+mock.module("@/domains/onboarding/cast/cast.css", () => ({}));
+
+mock.module("@/domains/onboarding/cast/cast-shell", () => ({
+  SetupShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  MemoryList: () => null,
+}));
+
+mock.module("@/domains/onboarding/cast/screens/login-screen", () => ({
+  LoginScreen: ({
+    onAdvance,
+    onContinue,
+    onIdentity,
+  }: {
+    onAdvance: () => void;
+    onContinue: (fn: string) => void;
+    onIdentity?: (id: { lastName: string; role: string }) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="login-continue"
+      onClick={() => {
+        onContinue("Ada");
+        onIdentity?.({ lastName: "Lovelace", role: "Software Engineer" });
+        onAdvance();
+      }}
+    >
+      login
+    </button>
+  ),
+}));
+
+mock.module("@/domains/onboarding/cast/screens/preamble-screen", () => ({
+  PreambleScreen: ({ onAdvance }: { onAdvance: () => void }) => (
+    <button type="button" data-testid="preamble-continue" onClick={onAdvance}>
+      preamble
+    </button>
+  ),
+}));
+
+const FAKE_CHARACTER = {
+  id: "cast-1",
+  name: "Pixel",
+  bodyShape: "round",
+  eyeStyle: "dot",
+  color: "blue",
+};
+
+mock.module("@/domains/onboarding/cast/screens/starter-screen", () => ({
+  StarterScreen: ({
+    onChoose,
+  }: {
+    onChoose: (c: typeof FAKE_CHARACTER, name: string) => void;
+  }) => (
+    <button
+      type="button"
+      data-testid="starter-choose"
+      onClick={() => onChoose(FAKE_CHARACTER, "Pixel")}
+    >
+      starter
+    </button>
+  ),
+}));
+
+mock.module("@/domains/onboarding/cast/screens/dialogue-screen", () => ({
+  DialogueScreen: ({ onAdvance }: { onAdvance: () => void }) => (
+    <button type="button" data-testid="dialogue-complete" onClick={onAdvance}>
+      dialogue
+    </button>
+  ),
+}));
+
+mock.module("@/domains/onboarding/cast/screens/style-screen", () => ({
+  StyleScreen: () => null,
+}));
+
+mock.module("@/domains/onboarding/cast/screens/done-screen", () => ({
+  DoneScreen: () => null,
+}));
+
+const { CastOnboardingFlow } = await import(
+  "@/domains/onboarding/cast/cast-onboarding-flow"
+);
+
+function drainMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/** Walk login -> preamble -> starter -> dialogue completion. */
+async function completeFlow(): Promise<void> {
+  fireEvent.click(await screen.findByTestId("login-continue"));
+  fireEvent.click(await screen.findByTestId("preamble-continue"));
+  fireEvent.click(await screen.findByTestId("starter-choose"));
+  fireEvent.click(await screen.findByTestId("dialogue-complete"));
+}
+
+beforeEach(() => {
+  awaitReadyImpl = async () => "asst-ready";
+  startMock.mockClear();
+  awaitReadyMock.mockClear();
+  setPendingPreChatContextMock.mockClear();
+  setPendingAssistantNameMock.mockClear();
+  markExpectingFirstMessageMock.mockClear();
+  checkAssistantMock.mockClear();
+  setActiveAssistantIdMock.mockClear();
+  navigateMock.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CastOnboardingFlow handoff", () => {
+  test("entering the login phase starts the hatch exactly once", async () => {
+    render(<CastOnboardingFlow />);
+    await screen.findByTestId("login-continue");
+    expect(startMock).toHaveBeenCalledTimes(1);
+
+    // Re-rendering / advancing past login must not re-fire the hatch.
+    fireEvent.click(screen.getByTestId("login-continue"));
+    await screen.findByTestId("preamble-continue");
+    expect(startMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("completion builds a context with occupation + research directive and stashes it", async () => {
+    render(<CastOnboardingFlow />);
+    await completeFlow();
+
+    await waitFor(() => expect(setPendingPreChatContextMock).toHaveBeenCalledTimes(1));
+
+    const ctx = setPendingPreChatContextMock.mock.calls[0]![0] as {
+      occupation?: string;
+      initialMessage?: string;
+      tasks: string[];
+    };
+    expect(ctx.occupation).toBe("Software Engineer");
+    expect(ctx.initialMessage).toBe(CAST_RESEARCH_DIRECTIVE);
+    expect(ctx.tasks.length).toBeGreaterThan(0);
+
+    expect(setPendingAssistantNameMock).toHaveBeenCalledWith("Pixel");
+    await waitFor(() =>
+      expect(navigateMock).toHaveBeenCalledWith(
+        expect.stringContaining("onboarding=1"),
+        { replace: true },
+      ),
+    );
+  });
+
+  test("completion awaits hatch readiness before navigating", async () => {
+    let resolveReady!: (id: string) => void;
+    awaitReadyImpl = () =>
+      new Promise<string>((resolve) => {
+        resolveReady = resolve;
+      });
+
+    render(<CastOnboardingFlow />);
+    await completeFlow();
+
+    // Readiness still pending: nothing handed off / navigated yet.
+    await drainMicrotasks();
+    expect(setPendingPreChatContextMock).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalled();
+
+    resolveReady("asst-ready");
+
+    await waitFor(() => expect(setPendingPreChatContextMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledTimes(1));
+    expect(setActiveAssistantIdMock).toHaveBeenCalledWith("asst-ready");
+  });
+
+  test("terminal hatch failure surfaces retry rather than navigating", async () => {
+    awaitReadyImpl = async () => {
+      throw new Error("Failed to start your assistant. Please try again.");
+    };
+
+    render(<CastOnboardingFlow />);
+    await completeFlow();
+
+    await screen.findByRole("alert");
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(setPendingPreChatContextMock).not.toHaveBeenCalled();
+
+    // Retrying re-arms the hatch and, once it succeeds, completes the handoff.
+    awaitReadyImpl = async () => "asst-retry";
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    await waitFor(() => expect(setPendingPreChatContextMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledTimes(1));
+    expect(setActiveAssistantIdMock).toHaveBeenCalledWith("asst-retry");
+  });
+});

--- a/apps/web/src/domains/onboarding/cast/cast-onboarding-flow.tsx
+++ b/apps/web/src/domains/onboarding/cast/cast-onboarding-flow.tsx
@@ -51,6 +51,7 @@ import {
 } from "@/domains/onboarding/prechat";
 import { DEFAULT_GROUP_ID } from "@/domains/onboarding/prechat-names";
 import { lifecycleService } from "@/assistant/lifecycle-service";
+import { setSelectedAssistant } from "@/assistant/selection";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { useNavigate } from "react-router";
 import { routes } from "@/utils/routes";
@@ -425,6 +426,10 @@ function buildHandoffFromCompletion(
     ),
     // `priorAssistant` is not collected by the cast flow yet.
     priorAssistant: undefined,
+    // The chosen cast name rides the context (not just the optimistic
+    // pending-name key) so the onboarding payload carries `assistantName` and
+    // the daemon persists it to IDENTITY.md after the first message.
+    assistantName: data.name || undefined,
   };
   return {
     context: buildCastPreChatContext(selections),
@@ -474,9 +479,18 @@ function CastFlowBody({
     // mark the chat surface as expecting the first message, refresh lifecycle,
     // then navigate to chat. The chat surface auto-sends `initialMessage`
     // (the research directive) with the context attached.
+    //
+    // In a multi-assistant session a *different* assistant may already be the
+    // platform selection. Make the hatched assistant the selection (so the
+    // persisted selection + lockfile converge on it) AND pin the lifecycle
+    // refresh to the hatched id, so `checkAssistant` fetches/projects the
+    // hatched assistant rather than re-fetching the prior selection and
+    // overwriting `activeAssistantId` back to it — otherwise the onboarding
+    // payload would be sent to the wrong assistant.
     useResolvedAssistantsStore.getState().setActiveAssistantId(assistantId);
+    await setSelectedAssistant(assistantId);
     lifecycleService.markExpectingFirstMessage();
-    await lifecycleService.checkAssistant();
+    await lifecycleService.checkAssistant(assistantId);
     void navigate(`${routes.assistant}?onboarding=1`, { replace: true });
   }
 

--- a/apps/web/src/domains/onboarding/cast/cast-onboarding-flow.tsx
+++ b/apps/web/src/domains/onboarding/cast/cast-onboarding-flow.tsx
@@ -9,16 +9,21 @@
  * screen per phase through the screen-slot contract in `screens/screen-slot.ts`.
  *
  * PR 5h wires the six real screens (login / preamble / starter / dialogue /
- * style / done) in against the contract, replacing the PR 5a stubs. The
- * completion path stays the prototype's existing `navigate` stub — the
- * `PreChatOnboardingContext` handoff + background hatch land in a later PR.
+ * style / done) in against the contract, replacing the PR 5a stubs.
+ *
+ * PR 6 replaces the prototype's `navigate` stub with the real handoff: the
+ * assistant is background-hatched on entry to the login/role step (maximizing
+ * overlap with the time the user spends in the flow), and on completion the
+ * flow awaits hatch readiness, builds a `PreChatOnboardingContext` from the
+ * collected selections, stashes it for the chat surface, and navigates — the
+ * same finish sequence as `pages/pre-chat-flow.tsx`. The chat surface
+ * auto-sends the research directive (the context's `initialMessage`) and
+ * attaches the context as the `onboarding` payload on that same first send.
  */
 
 import { useEffect, useRef, useState } from "react";
-import { useNavigate } from "react-router";
 import { AnimatePresence } from "motion/react";
 
-import { routes } from "@/utils/routes";
 import type { JobKey, RatherKey } from "@/domains/onboarding/cast/cast-content";
 import type { StyleProfile } from "@/domains/onboarding/cast/cast-templates";
 import type { CastCharacter } from "@/domains/onboarding/cast/cast-roster";
@@ -34,7 +39,40 @@ import type {
   MemoryEntry,
   StarterResume,
 } from "@/domains/onboarding/cast/screens/screen-slot";
+import {
+  buildCastPreChatContext,
+  type CastSelections,
+} from "@/domains/onboarding/cast/cast-prechat-mapping";
+import { deriveTaskSuggestions } from "@/domains/onboarding/cast/cast-task-derivation";
+import { useBackgroundHatch } from "@/domains/onboarding/cast/use-background-hatch";
+import {
+  setPendingAssistantName,
+  setPendingPreChatContext,
+} from "@/domains/onboarding/prechat";
+import { DEFAULT_GROUP_ID } from "@/domains/onboarding/prechat-names";
+import { lifecycleService } from "@/assistant/lifecycle-service";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { useNavigate } from "react-router";
+import { routes } from "@/utils/routes";
 import "@/domains/onboarding/cast/cast.css";
+
+/**
+ * Map the cast dialogue "tone" choice onto a personality tone group id
+ * understood by {@link PreChatOnboardingContext} ("grounded" | "warm" |
+ * "energetic" | "poetic"). The cast flow only collects a binary
+ * fast/deep axis, so this is a deliberate, lossy projection:
+ *   - `"fast"` (concise, direct) → `"energetic"`
+ *   - `"deep"` (thorough, detailed) → `"grounded"`
+ *   - `null` (skipped) → `DEFAULT_GROUP_ID` ("grounded")
+ *
+ * TODO(PR 7): confirm this mapping with design — it's a placeholder pick
+ * pending the tone/tasks reconciliation pass.
+ */
+function castToneToGroupId(tone: "fast" | "deep" | null): string {
+  if (tone === "fast") return "energetic";
+  if (tone === "deep") return "grounded";
+  return DEFAULT_GROUP_ID;
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -97,10 +135,29 @@ const win = () => ({
 // renders one screen per phase through the screen-slot contract.
 // ---------------------------------------------------------------------------
 
-function InteractiveCastFlow({ onComplete }: { onComplete: (data: CastCompletionData) => void }) {
+function InteractiveCastFlow({
+  onComplete,
+  onLoginPhase,
+}: {
+  onComplete: (data: CastCompletionData) => void;
+  /** Fired once when the flow first enters the login/role phase. */
+  onLoginPhase: () => void;
+}) {
   const panelRef = useRef<HTMLDivElement>(null);
 
   const [phase, setPhase] = useState<CastPhase>("login");
+
+  // Kick off the background hatch on entry to the login/role step — the first
+  // phase where the user supplies their occupation, so the hatch overlaps the
+  // rest of the flow. Ref-guarded so it fires at most once regardless of
+  // re-renders/keystrokes while the login screen is mounted.
+  const loginHatchFiredRef = useRef(false);
+  useEffect(() => {
+    if (phase !== "login" || loginHatchFiredRef.current) return;
+    loginHatchFiredRef.current = true;
+    onLoginPhase();
+  }, [phase, onLoginPhase]);
+
   const [userFirstName, setUserFirstName] = useState("");
   const [userLastName, setUserLastName] = useState("");
   // `userRole` is the field the later handoff maps to `occupation`.
@@ -341,21 +398,142 @@ function InteractiveCastFlow({ onComplete }: { onComplete: (data: CastCompletion
 
 // ---------------------------------------------------------------------------
 // CastOnboardingFlow — top-level orchestrator entry (was `InteractiveSetup`).
-// Wraps the flow in the themed cast stage and routes completion. The completion
-// handler stays a navigate-to-home stub until PR 6 swaps in the
-// PreChatOnboardingContext handoff + background hatch.
+// Wraps the flow in the themed cast stage and owns the completion handoff:
+// background-hatch on login-step entry, then on completion await readiness,
+// build the PreChatOnboardingContext, stash it, and finish like
+// `pages/pre-chat-flow.tsx`. The chat surface auto-sends the research directive
+// (the context's `initialMessage`) with the context attached as the
+// `onboarding` payload — no extra send wiring here.
 // ---------------------------------------------------------------------------
 
-export function CastOnboardingFlow() {
-  const navigate = useNavigate();
+/** Build the handoff context from the flow's collected completion data. */
+function buildHandoffFromCompletion(
+  data: CastCompletionData,
+): { context: ReturnType<typeof buildCastPreChatContext>; assistantName: string } {
+  const selections: CastSelections = {
+    firstName: data.firstName || undefined,
+    lastName: data.lastName || undefined,
+    role: data.role || undefined,
+    tone: castToneToGroupId(data.tone),
+    reachTools: data.connectedTools,
+    // The dedicated `job` phase is gone, so tasks come from the designated
+    // source — `deriveTaskSuggestions`, fed by the connected-tools memory.
+    jobs: deriveTaskSuggestions(
+      data.connectedTools.length > 0
+        ? [["reach", `Connected: ${data.connectedTools.join(", ")}`]]
+        : [],
+    ),
+    // `priorAssistant` is not collected by the cast flow yet.
+    priorAssistant: undefined,
+  };
+  return {
+    context: buildCastPreChatContext(selections),
+    assistantName: data.name,
+  };
+}
 
-  function handleComplete(_data: CastCompletionData) {
-    navigate(routes.home);
+/**
+ * Inner flow body that owns one background-hatch instance. `useBackgroundHatch`
+ * is ref-guarded with no reset, so a terminal failure is recovered by
+ * remounting this component (the parent bumps `attempt`), which provisions a
+ * fresh hatch. The completion data is lifted to the parent so it survives the
+ * remount and the retry can replay the handoff without re-walking the flow.
+ */
+function CastFlowBody({
+  completedData,
+  onCompleted,
+  onHandoffError,
+}: {
+  completedData: CastCompletionData | null;
+  onCompleted: (data: CastCompletionData) => void;
+  onHandoffError: (message: string) => void;
+}) {
+  const navigate = useNavigate();
+  const { start, awaitReady } = useBackgroundHatch();
+  const handoffStartedRef = useRef(false);
+
+  async function runHandoff(data: CastCompletionData): Promise<void> {
+    let assistantId: string;
+    try {
+      // Wait for the background hatch to report healthy before handing off.
+      assistantId = await awaitReady();
+    } catch (err) {
+      onHandoffError(
+        err instanceof Error
+          ? err.message
+          : "Failed to start your assistant. Please try again.",
+      );
+      return;
+    }
+
+    const { context, assistantName } = buildHandoffFromCompletion(data);
+    setPendingPreChatContext(context);
+    setPendingAssistantName(assistantName);
+
+    // Mirror `pages/pre-chat-flow.tsx`'s finish: select the hatched assistant,
+    // mark the chat surface as expecting the first message, refresh lifecycle,
+    // then navigate to chat. The chat surface auto-sends `initialMessage`
+    // (the research directive) with the context attached.
+    useResolvedAssistantsStore.getState().setActiveAssistantId(assistantId);
+    lifecycleService.markExpectingFirstMessage();
+    await lifecycleService.checkAssistant();
+    void navigate(`${routes.assistant}?onboarding=1`, { replace: true });
+  }
+
+  // On a (re)mount that already has completion data — i.e. a retry — provision a
+  // fresh hatch (the user is past the login step, so nothing else triggers it)
+  // and replay the handoff. Ref-guarded so it fires once per mount.
+  useEffect(() => {
+    if (!completedData || handoffStartedRef.current) return;
+    handoffStartedRef.current = true;
+    start();
+    void runHandoff(completedData);
+    // runHandoff/start are stable for the lifetime of this mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [completedData]);
+
+  function handleComplete(data: CastCompletionData) {
+    if (handoffStartedRef.current) return;
+    handoffStartedRef.current = true;
+    onCompleted(data);
+    void runHandoff(data);
+  }
+
+  return (
+    <InteractiveCastFlow onComplete={handleComplete} onLoginPhase={start} />
+  );
+}
+
+export function CastOnboardingFlow() {
+  // Captured completion data survives a retry remount; bumping `attempt`
+  // remounts `CastFlowBody` to provision a fresh hatch after a terminal failure.
+  const [completedData, setCompletedData] = useState<CastCompletionData | null>(
+    null,
+  );
+  const [handoffError, setHandoffError] = useState<string | null>(null);
+  const [attempt, setAttempt] = useState(0);
+
+  function retryHandoff() {
+    setHandoffError(null);
+    setAttempt((n) => n + 1);
   }
 
   return (
     <div className="cast-stage" data-theme="dark">
-      <InteractiveCastFlow onComplete={handleComplete} />
+      <CastFlowBody
+        key={attempt}
+        completedData={completedData}
+        onCompleted={setCompletedData}
+        onHandoffError={setHandoffError}
+      />
+      {handoffError !== null && (
+        <div className="cast-handoff-error" role="alert">
+          <p>{handoffError}</p>
+          <button type="button" onClick={retryHandoff}>
+            Try again
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/domains/onboarding/cast/cast-prechat-mapping.ts
+++ b/apps/web/src/domains/onboarding/cast/cast-prechat-mapping.ts
@@ -26,6 +26,13 @@ export interface CastSelections {
   jobs: string[];
   reachTools: string[];
   priorAssistant?: string;
+  /**
+   * The name the user gave their chosen cast assistant. Threaded into the
+   * context's `assistantName` so the auto-sent onboarding payload carries it —
+   * the daemon persists `IDENTITY.md` only when `onboarding.assistantName` is
+   * present, so without this the chosen cast name would never be written.
+   */
+  assistantName?: string;
 }
 
 /**
@@ -57,7 +64,7 @@ export function buildCastPreChatContext(
     selectedPriorAssistants: sel.priorAssistant
       ? new Set([sel.priorAssistant])
       : new Set(),
-    assistantName: "",
+    assistantName: sel.assistantName ?? "",
     selfIntroGreetingEnabled: false,
     googleConnected: false,
     googleScopes: [],


### PR DESCRIPTION
## Summary
- Background-hatch on login/role step entry (ref-guarded); await readiness on completion
- Replace navigate stub with PreChatOnboardingContext handoff: build context from CastCompletionData (role->occupation, tone, reach->tools, derived tasks), research directive as initialMessage
- Tests for once-only hatch, handoff context, readiness gating, terminal-failure retry

Part of plan: cast-prechat-flow.md (PR 6)