### PR TITLE
feat(onboarding): cast flow funnel instrumentation + integration tests

### DIFF
--- a/apps/web/src/domains/onboarding/cast/cast-handoff-integration.test.ts
+++ b/apps/web/src/domains/onboarding/cast/cast-handoff-integration.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Cast onboarding → chat handoff integration coverage.
+ *
+ * Proves the load-bearing contract for the personal-page activation arm
+ * end-to-end: the user's collected `role` reaches both the chat wire (as the
+ * `onboarding.occupation` field) and the seeded profile file (as `- **Role:**`),
+ * and the cast research directive is the auto-sent first message.
+ *
+ * The handoff is exercised through the *real* flow + onboarding plumbing, but
+ * deliberately stops at the onboarding-owned boundary so the test stays within
+ * the `onboarding` domain (no cross-domain `chat` import — see
+ * `local/no-cross-domain-imports`):
+ *
+ *   1. The flow's completion logic (`buildHandoffFromCompletion`) builds a
+ *      context, `setPendingPreChatContext` stashes it, and
+ *      `consumePendingPreChatContext` returns it with `occupation` set and
+ *      `initialMessage === CAST_RESEARCH_DIRECTIVE`.
+ *   2. The exact transforms the chat send applies to that context — wire
+ *      normalization (`normalizePreChatOnboardingContext`, which
+ *      `chat/api/messages.ts` copies field-for-field onto the wire
+ *      `onboarding` dict) and the seeded-profile section
+ *      (`buildOnboardingSection(preChatOnboardingProfileFields(...))`, which
+ *      `chat/api/messages.ts` writes to the profile files) — both carry
+ *      `occupation` through as `occupation` / `- **Role:**`.
+ *
+ * The wire-and-profile *transport* (the `postChatMessage` fetch + workspace
+ * writes) is covered directly in `chat/api/post-chat-message.test.ts`; this
+ * test proves the cast context feeds those transforms the right inputs.
+ */
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+
+import {
+  buildHandoffFromCompletion,
+  castToneToGroupId,
+  type CastCompletionData,
+} from "@/domains/onboarding/cast/cast-onboarding-flow";
+import { CAST_RESEARCH_DIRECTIVE } from "@/domains/onboarding/cast/cast-prechat-mapping";
+import {
+  consumePendingPreChatContext,
+  normalizePreChatOnboardingContext,
+  preChatOnboardingProfileFields,
+  setPendingPreChatContext,
+} from "@/domains/onboarding/prechat";
+import { buildOnboardingSection } from "@/domains/onboarding/prechat-profile";
+import {
+  DEFAULT_GROUP_ID,
+  PERSONALITY_GROUPS,
+} from "@/domains/onboarding/prechat-names";
+
+/** A representative completed cast walk. Placeholder identity, no real person. */
+function castCompletion(
+  overrides: Partial<CastCompletionData> = {},
+): CastCompletionData {
+  return {
+    firstName: "Riverdance",
+    lastName: "Placeholder",
+    role: "Product Manager",
+    // `character` is not read by the handoff; a minimal stand-in satisfies the
+    // type without pulling in the roster.
+    character: {} as CastCompletionData["character"],
+    name: "Vel",
+    tone: "deep",
+    connectedTools: ["linear", "slack"],
+    jobs: [],
+    rathers: [],
+    style: {},
+    credits: 0,
+    ...overrides,
+  };
+}
+
+describe("cast onboarding → chat handoff", () => {
+  // `globalThis.sessionStorage` is a readonly getter under bun, so install the
+  // shim via `defineProperty` and restore the prior descriptor — matches
+  // `onboarding/prechat.test.ts` and avoids leaking across the bun process.
+  let priorSessionStorage: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    const store = new Map<string, string>();
+    priorSessionStorage = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "sessionStorage",
+    );
+    Object.defineProperty(globalThis, "sessionStorage", {
+      configurable: true,
+      value: {
+        getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+        setItem: (k: string, v: string) => void store.set(k, v),
+        removeItem: (k: string) => void store.delete(k),
+      },
+    });
+  });
+
+  afterEach(() => {
+    if (priorSessionStorage) {
+      Object.defineProperty(globalThis, "sessionStorage", priorSessionStorage);
+    } else {
+      delete (globalThis as { sessionStorage?: unknown }).sessionStorage;
+    }
+  });
+
+  test("build → stash → consume round-trips occupation and the research directive", () => {
+    const { context } = buildHandoffFromCompletion(castCompletion());
+    setPendingPreChatContext(context);
+
+    const consumed = consumePendingPreChatContext();
+    expect(consumed).not.toBeNull();
+    expect(consumed!.occupation).toBe("Product Manager");
+    expect(consumed!.initialMessage).toBe(CAST_RESEARCH_DIRECTIVE);
+    // `deep` tone → grounded group id (see `castToneToGroupId`).
+    expect(consumed!.tone).toBe("grounded");
+
+    // Consume-once: a second read returns null.
+    expect(consumePendingPreChatContext()).toBeNull();
+  });
+
+  test("the consumed context carries occupation onto the wire payload shape", () => {
+    const { context } = buildHandoffFromCompletion(castCompletion());
+    setPendingPreChatContext(context);
+    const consumed = consumePendingPreChatContext();
+    expect(consumed).not.toBeNull();
+
+    // `chat/api/messages.ts` copies `normalizePreChatOnboardingContext(ctx)`
+    // field-for-field onto the wire `onboarding` dict, including `occupation`.
+    const wireShape = normalizePreChatOnboardingContext(consumed!);
+    expect(wireShape.occupation).toBe("Product Manager");
+  });
+
+  test("the consumed context seeds a profile section with the Role line", () => {
+    const { context } = buildHandoffFromCompletion(castCompletion());
+    setPendingPreChatContext(context);
+    const consumed = consumePendingPreChatContext();
+    expect(consumed).not.toBeNull();
+
+    // `chat/api/messages.ts` writes
+    // `buildOnboardingSection(preChatOnboardingProfileFields(ctx))` to the
+    // seeded profile files (`users/default.md`, `users/guardian.md`).
+    const section = buildOnboardingSection(
+      preChatOnboardingProfileFields(consumed!),
+    );
+    expect(section).toContain("- **Role:** Product Manager");
+  });
+
+  test("the auto-sent first message is the research directive", () => {
+    const { context } = buildHandoffFromCompletion(castCompletion());
+    setPendingPreChatContext(context);
+    const consumed = consumePendingPreChatContext();
+    // ChatPage auto-sends `consumed.initialMessage` as the first message.
+    expect(consumed!.initialMessage).toBe(CAST_RESEARCH_DIRECTIVE);
+  });
+});
+
+describe("castToneToGroupId (finalized fast/deep → group mapping)", () => {
+  const validGroupIds = new Set(PERSONALITY_GROUPS.map((g) => g.id));
+
+  test("maps fast → energetic", () => {
+    expect(castToneToGroupId("fast")).toBe("energetic");
+  });
+
+  test("maps deep → grounded", () => {
+    expect(castToneToGroupId("deep")).toBe("grounded");
+  });
+
+  test("maps a skipped tone to the default group id", () => {
+    expect(castToneToGroupId(null)).toBe(DEFAULT_GROUP_ID);
+  });
+
+  test("only ever yields a valid personality group id", () => {
+    for (const tone of ["fast", "deep", null] as const) {
+      expect(validGroupIds.has(castToneToGroupId(tone))).toBe(true);
+    }
+  });
+});

--- a/apps/web/src/domains/onboarding/cast/cast-onboarding-flow.test.tsx
+++ b/apps/web/src/domains/onboarding/cast/cast-onboarding-flow.test.tsx
@@ -74,8 +74,11 @@ mock.module("@/stores/resolved-assistants-store", () => ({
   },
 }));
 
+const setSearchParamsMock = mock(() => {});
 mock.module("react-router", () => ({
   useNavigate: () => navigateMock,
+  useSearchParams: () =>
+    [new URLSearchParams(), setSearchParamsMock] as const,
 }));
 
 // --- cast screens (driven via testid buttons) --------------------------------

--- a/apps/web/src/domains/onboarding/cast/cast-onboarding-flow.tsx
+++ b/apps/web/src/domains/onboarding/cast/cast-onboarding-flow.tsx
@@ -53,7 +53,6 @@ import { DEFAULT_GROUP_ID } from "@/domains/onboarding/prechat-names";
 import {
   emitOnboardingFunnelStepCompleted,
   ONBOARDING_FUNNEL_STEPS,
-  resolveOnboardingFunnelVariant,
   ONBOARDING_FUNNEL_VARIANTS,
 } from "@/domains/onboarding/funnel-events";
 import { lifecycleService } from "@/assistant/lifecycle-service";
@@ -613,15 +612,16 @@ export function CastOnboardingFlow() {
   // Emit one cast funnel step per surviving phase. Gated exactly like
   // `pre-chat-flow.tsx`'s `emitWebFunnelStep`: skipped entirely in preview, and
   // (inside `emitOnboardingFunnelStepCompleted`) only sent when share-analytics
-  // is enabled. The cast arm always reports the `control` variant — it is a
-  // distinct activation arm, not part of the pared-down/control A/B split.
+  // is enabled. The cast arm always reports the deterministic `cast` variant —
+  // it is a distinct activation arm, not part of the pared-down/control A/B
+  // split. We pass the variant explicitly rather than resolving from stored
+  // state so a value cached under another experiment (e.g. `pared_down` from the
+  // privacy screen) can never leak into cast funnel events.
   function emitFunnelStep(phase: CastFunnelPhase): void {
     if (isPreview) return;
     emitOnboardingFunnelStepCompleted(CAST_FUNNEL_STEP_BY_PHASE[phase], {
       userId,
-      variant: resolveOnboardingFunnelVariant(
-        ONBOARDING_FUNNEL_VARIANTS.control,
-      ),
+      variant: ONBOARDING_FUNNEL_VARIANTS.cast,
     });
   }
 

--- a/apps/web/src/domains/onboarding/cast/cast-onboarding-flow.tsx
+++ b/apps/web/src/domains/onboarding/cast/cast-onboarding-flow.tsx
@@ -50,26 +50,59 @@ import {
   setPendingPreChatContext,
 } from "@/domains/onboarding/prechat";
 import { DEFAULT_GROUP_ID } from "@/domains/onboarding/prechat-names";
+import {
+  emitOnboardingFunnelStepCompleted,
+  ONBOARDING_FUNNEL_STEPS,
+  resolveOnboardingFunnelVariant,
+  ONBOARDING_FUNNEL_VARIANTS,
+} from "@/domains/onboarding/funnel-events";
 import { lifecycleService } from "@/assistant/lifecycle-service";
 import { setSelectedAssistant } from "@/assistant/selection";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
-import { useNavigate } from "react-router";
+import { useAuthStore } from "@/stores/auth-store";
+import { useNavigate, useSearchParams } from "react-router";
 import { routes } from "@/utils/routes";
 import "@/domains/onboarding/cast/cast.css";
 
 /**
+ * The surviving cast phases that emit a funnel step on advance. Each maps to a
+ * `cast_*` entry in `ONBOARDING_FUNNEL_STEPS`. The funnel is emitted on the
+ * *advance out of* each phase, mirroring `pre-chat-flow.tsx`'s
+ * `advance(from)` → `emitWebFunnelStep(from.funnelStep)`.
+ */
+const CAST_FUNNEL_STEP_BY_PHASE = {
+  login: ONBOARDING_FUNNEL_STEPS.castLogin,
+  preamble: ONBOARDING_FUNNEL_STEPS.castPreamble,
+  starter: ONBOARDING_FUNNEL_STEPS.castStarter,
+  dialogue: ONBOARDING_FUNNEL_STEPS.castDialogue,
+  style: ONBOARDING_FUNNEL_STEPS.castStyle,
+  done: ONBOARDING_FUNNEL_STEPS.castDone,
+} as const;
+
+/** Phase keys that emit a funnel step (the surviving cast walk). */
+type CastFunnelPhase = keyof typeof CAST_FUNNEL_STEP_BY_PHASE;
+
+/** Callback that emits one cast funnel step for the given phase. */
+type EmitCastFunnelStep = (phase: CastFunnelPhase) => void;
+
+/**
  * Map the cast dialogue "tone" choice onto a personality tone group id
  * understood by {@link PreChatOnboardingContext} ("grounded" | "warm" |
- * "energetic" | "poetic"). The cast flow only collects a binary
- * fast/deep axis, so this is a deliberate, lossy projection:
- *   - `"fast"` (concise, direct) → `"energetic"`
- *   - `"deep"` (thorough, detailed) → `"grounded"`
+ * "energetic" | "poetic", per `PERSONALITY_GROUPS` in
+ * `onboarding/prechat-names.ts`). The cast flow only collects a binary
+ * fast/deep axis, so this is a deliberate, lossy projection onto the two
+ * groups whose descriptors line up with that axis:
+ *   - `"fast"` (concise, direct) → `"energetic"` (descriptor "Fast and direct")
+ *   - `"deep"` (thorough, detailed) → `"grounded"` (descriptor "Calm and precise")
  *   - `null` (skipped) → `DEFAULT_GROUP_ID` ("grounded")
  *
- * TODO(PR 7): confirm this mapping with design — it's a placeholder pick
- * pending the tone/tasks reconciliation pass.
+ * Finalized in PR 7: the fast→energetic / deep→grounded pairing matches the
+ * group descriptors directly, and a skipped tone defaulting to "grounded"
+ * (the same `DEFAULT_GROUP_ID` the control funnel falls back to) keeps the
+ * cast arm consistent with the rest of onboarding. The remaining two groups
+ * ("warm", "poetic") have no corresponding cast axis to project from.
  */
-function castToneToGroupId(tone: "fast" | "deep" | null): string {
+export function castToneToGroupId(tone: "fast" | "deep" | null): string {
   if (tone === "fast") return "energetic";
   if (tone === "deep") return "grounded";
   return DEFAULT_GROUP_ID;
@@ -79,7 +112,7 @@ function castToneToGroupId(tone: "fast" | "deep" | null): string {
 // Types
 // ---------------------------------------------------------------------------
 
-interface CastCompletionData {
+export interface CastCompletionData {
   /** The user identity collected on the login screen. `role` → occupation. */
   firstName: string;
   lastName: string;
@@ -139,10 +172,13 @@ const win = () => ({
 function InteractiveCastFlow({
   onComplete,
   onLoginPhase,
+  emitFunnelStep,
 }: {
   onComplete: (data: CastCompletionData) => void;
   /** Fired once when the flow first enters the login/role phase. */
   onLoginPhase: () => void;
+  /** Emit a cast funnel step on advance out of the given phase. */
+  emitFunnelStep: EmitCastFunnelStep;
 }) {
   const panelRef = useRef<HTMLDivElement>(null);
 
@@ -158,6 +194,16 @@ function InteractiveCastFlow({
     loginHatchFiredRef.current = true;
     onLoginPhase();
   }, [phase, onLoginPhase]);
+
+  // De-dupe funnel emissions: a phase can advance from multiple call sites
+  // (e.g. style → done via both `onAdvance` and `onDone`), so guard each phase
+  // to fire its step at most once per flow walk.
+  const emittedPhasesRef = useRef<Set<CastFunnelPhase>>(new Set());
+  function emitPhaseOnce(phase: CastFunnelPhase): void {
+    if (emittedPhasesRef.current.has(phase)) return;
+    emittedPhasesRef.current.add(phase);
+    emitFunnelStep(phase);
+  }
 
   const [userFirstName, setUserFirstName] = useState("");
   const [userLastName, setUserLastName] = useState("");
@@ -248,10 +294,21 @@ function InteractiveCastFlow({
     };
   }
 
+  /**
+   * Finish the flow: emit the terminal `done` funnel step, then hand the
+   * collected selections off to the parent. Wraps every handoff call site so
+   * the `done` step fires exactly once regardless of which screen completes.
+   */
+  function completeHandoff(data: CastCompletionData) {
+    emitPhaseOnce("done");
+    onComplete(data);
+  }
+
   function chooseStarter(char: CastCharacter, chosenName: string) {
     setSelected(char);
     setNames((prev) => ({ ...prev, [char.id]: chosenName }));
     addMemory("face", `Look & feel: ${chosenName}`, "dialogue");
+    emitPhaseOnce("starter");
     setPhase("dialogue");
   }
 
@@ -274,6 +331,7 @@ function InteractiveCastFlow({
   }
   function onStyleDone(next: StyleProfile) {
     setStyle(next);
+    emitPhaseOnce("style");
     setPhase("done");
   }
 
@@ -283,7 +341,10 @@ function InteractiveCastFlow({
     <div className="cast-panel" ref={panelRef}>
       {phase === "login" && (
         <LoginScreen
-          onAdvance={() => setPhase("preamble")}
+          onAdvance={() => {
+            emitPhaseOnce("login");
+            setPhase("preamble");
+          }}
           onContinue={(fn) => setUserFirstName(fn)}
           onIdentity={({ lastName, role }) => {
             setUserLastName(lastName);
@@ -295,7 +356,13 @@ function InteractiveCastFlow({
       {isShellPhase && (
         <SetupShell>
           {phase === "preamble" && (
-            <PreambleScreen firstName={userFirstName} onAdvance={() => setPhase("starter")} />
+            <PreambleScreen
+              firstName={userFirstName}
+              onAdvance={() => {
+                emitPhaseOnce("preamble");
+                setPhase("starter");
+              }}
+            />
           )}
 
           {phase === "starter" && (
@@ -317,7 +384,7 @@ function InteractiveCastFlow({
               brainFileContent={brainFileContent}
               memories={memories}
               onAdvance={() =>
-                onComplete(completionData(selected))
+                completeHandoff(completionData(selected))
               }
               onTonePicked={(value) => {
                 setTone(value);
@@ -336,7 +403,10 @@ function InteractiveCastFlow({
                   connected.length > 0 ? `Connected: ${connected.join(", ")}` : "Tools: skipped",
                 );
               }}
-              onComplete={() => setPhase("style")}
+              onComplete={() => {
+                emitPhaseOnce("dialogue");
+                setPhase("style");
+              }}
               onBack={reopenCustomize}
             />
           )}
@@ -362,7 +432,10 @@ function InteractiveCastFlow({
           heroBox={leftPanelBox}
           jobs={jobs}
           ascended={false}
-          onAdvance={() => setPhase("done")}
+          onAdvance={() => {
+            emitPhaseOnce("style");
+            setPhase("done");
+          }}
           onChoose={() => {
             /* style demo turn — no orchestrator state to capture here */
           }}
@@ -382,13 +455,13 @@ function InteractiveCastFlow({
           ascended={false}
           assistantId={null}
           onAdvance={() =>
-            onComplete(completionData(selected))
+            completeHandoff(completionData(selected))
           }
           onAction={() => {
             /* proof action — no orchestrator state to capture here */
           }}
           onEndpoint={() =>
-            onComplete(completionData(selected))
+            completeHandoff(completionData(selected))
           }
           onBack={() => setPhase("style")}
         />
@@ -408,7 +481,7 @@ function InteractiveCastFlow({
 // ---------------------------------------------------------------------------
 
 /** Build the handoff context from the flow's collected completion data. */
-function buildHandoffFromCompletion(
+export function buildHandoffFromCompletion(
   data: CastCompletionData,
 ): { context: ReturnType<typeof buildCastPreChatContext>; assistantName: string } {
   const selections: CastSelections = {
@@ -448,10 +521,12 @@ function CastFlowBody({
   completedData,
   onCompleted,
   onHandoffError,
+  emitFunnelStep,
 }: {
   completedData: CastCompletionData | null;
   onCompleted: (data: CastCompletionData) => void;
   onHandoffError: (message: string) => void;
+  emitFunnelStep: EmitCastFunnelStep;
 }) {
   const navigate = useNavigate();
   const { start, awaitReady } = useBackgroundHatch();
@@ -514,7 +589,11 @@ function CastFlowBody({
   }
 
   return (
-    <InteractiveCastFlow onComplete={handleComplete} onLoginPhase={start} />
+    <InteractiveCastFlow
+      onComplete={handleComplete}
+      onLoginPhase={start}
+      emitFunnelStep={emitFunnelStep}
+    />
   );
 }
 
@@ -526,6 +605,25 @@ export function CastOnboardingFlow() {
   );
   const [handoffError, setHandoffError] = useState<string | null>(null);
   const [attempt, setAttempt] = useState(0);
+
+  const [searchParams] = useSearchParams();
+  const isPreview = searchParams.get("preview") === "true";
+  const userId = useAuthStore.use.user()?.id ?? null;
+
+  // Emit one cast funnel step per surviving phase. Gated exactly like
+  // `pre-chat-flow.tsx`'s `emitWebFunnelStep`: skipped entirely in preview, and
+  // (inside `emitOnboardingFunnelStepCompleted`) only sent when share-analytics
+  // is enabled. The cast arm always reports the `control` variant — it is a
+  // distinct activation arm, not part of the pared-down/control A/B split.
+  function emitFunnelStep(phase: CastFunnelPhase): void {
+    if (isPreview) return;
+    emitOnboardingFunnelStepCompleted(CAST_FUNNEL_STEP_BY_PHASE[phase], {
+      userId,
+      variant: resolveOnboardingFunnelVariant(
+        ONBOARDING_FUNNEL_VARIANTS.control,
+      ),
+    });
+  }
 
   function retryHandoff() {
     setHandoffError(null);
@@ -539,6 +637,7 @@ export function CastOnboardingFlow() {
         completedData={completedData}
         onCompleted={setCompletedData}
         onHandoffError={setHandoffError}
+        emitFunnelStep={emitFunnelStep}
       />
       {handoffError !== null && (
         <div className="cast-handoff-error" role="alert">

--- a/apps/web/src/domains/onboarding/funnel-events.test.ts
+++ b/apps/web/src/domains/onboarding/funnel-events.test.ts
@@ -83,6 +83,32 @@ describe("onboarding funnel events", () => {
     expect(readOnboardingFunnelVariant()).toBe("pared_down");
   });
 
+  test("an explicit cast variant overrides a stale stored variant", () => {
+    // Simulate a user who saw the privacy screen under the legacy A/B split and
+    // had `pared_down` cached for the session.
+    resolveOnboardingFunnelVariant(ONBOARDING_FUNNEL_VARIANTS.paredDown);
+    expect(readOnboardingFunnelVariant()).toBe("pared_down");
+
+    // The cast arm passes its deterministic variant explicitly; the built event
+    // must report `cast`, never the stale stored `pared_down`.
+    const castDone = buildOnboardingFunnelEvent(
+      ONBOARDING_FUNNEL_STEPS.castDone,
+      {
+        userId: "user-123",
+        variant: ONBOARDING_FUNNEL_VARIANTS.cast,
+      },
+    );
+
+    expect(castDone).toMatchObject({
+      screen: "cast_done",
+      step_name: "cast_done",
+      step_index: 5,
+      ab_variant: "cast",
+    });
+    // The cast emit must not mutate the stored A/B variant either.
+    expect(readOnboardingFunnelVariant()).toBe("pared_down");
+  });
+
   test("uses control step indices for the existing funnel", () => {
     const tools = buildOnboardingFunnelEvent(
       ONBOARDING_FUNNEL_STEPS.controlTools,

--- a/apps/web/src/domains/onboarding/funnel-events.ts
+++ b/apps/web/src/domains/onboarding/funnel-events.ts
@@ -8,6 +8,10 @@ const VARIANT_STORAGE_KEY = "onboarding.funnelVariant";
 export const ONBOARDING_FUNNEL_VARIANTS = {
   control: "control",
   paredDown: "pared_down",
+  // The cast / personal-page activation arm is a distinct arm, not part of the
+  // control/pared-down A/B split. Cast funnel steps report this deterministic
+  // label so they are never conflated with a stale stored control/variant value.
+  cast: "cast",
 } as const;
 
 export type OnboardingFunnelVariant =
@@ -96,7 +100,8 @@ function isOnboardingFunnelVariant(
 ): value is OnboardingFunnelVariant {
   return (
     value === ONBOARDING_FUNNEL_VARIANTS.control ||
-    value === ONBOARDING_FUNNEL_VARIANTS.paredDown
+    value === ONBOARDING_FUNNEL_VARIANTS.paredDown ||
+    value === ONBOARDING_FUNNEL_VARIANTS.cast
   );
 }
 

--- a/apps/web/src/domains/onboarding/funnel-events.ts
+++ b/apps/web/src/domains/onboarding/funnel-events.ts
@@ -30,6 +30,17 @@ export const ONBOARDING_FUNNEL_STEPS = {
   controlGmailConnect: { stepName: "gmail_connect", stepIndex: 5 },
   controlGetApp: { stepName: "get_app", stepIndex: 6 },
   gmailConnect: { stepName: "gmail_connect", stepIndex: 2 },
+  // Cast (personal-page arm) flow. The cast orchestrator
+  // (`cast/cast-onboarding-flow.tsx`) walks `login → preamble → starter →
+  // dialogue → style → done`; each surviving phase emits its step on advance,
+  // gated exactly like the control funnel (skipped in preview, share-analytics
+  // respected). Indices are flow-local to the cast walk.
+  castLogin: { stepName: "cast_login", stepIndex: 0 },
+  castPreamble: { stepName: "cast_preamble", stepIndex: 1 },
+  castStarter: { stepName: "cast_starter", stepIndex: 2 },
+  castDialogue: { stepName: "cast_dialogue", stepIndex: 3 },
+  castStyle: { stepName: "cast_style", stepIndex: 4 },
+  castDone: { stepName: "cast_done", stepIndex: 5 },
 } as const;
 
 export type OnboardingFunnelStep =


### PR DESCRIPTION
## Summary
- Add cast-flow funnel events emitted per surviving phase (skipped in preview)
- Integration test: occupation + research directive reach the wire/profile
- Finalize tone (fast/deep->group) mapping + deterministic task-derivation test assertions

Part of plan: cast-prechat-flow.md (PR 7)