### PR TITLE
refactor(onboarding): dedup cast shared modules

### DIFF
--- a/apps/web/src/domains/onboarding/cast/cast-roster.ts
+++ b/apps/web/src/domains/onboarding/cast/cast-roster.ts
@@ -82,7 +82,7 @@ const NAMES = [
  * once it aligned with the 6-wide grid, so we hash instead. Not random (no
  * Date/Math.random), just well-mixed and stable across reloads.
  */
-function hash(n: number, salt: number): number {
+export function hash(n: number, salt: number): number {
   let v = Math.imul(n ^ (salt * 0x9e3779b1), 2654435761);
   v ^= v >>> 15;
   v = Math.imul(v, 0x85ebca6b);

--- a/apps/web/src/domains/onboarding/cast/cast-shell.tsx
+++ b/apps/web/src/domains/onboarding/cast/cast-shell.tsx
@@ -13,6 +13,7 @@ import { AnimatePresence, motion } from "motion/react";
 
 import { COMPONENTS } from "@/domains/onboarding/cast/cast-roster";
 import type { CastCharacter } from "@/domains/onboarding/cast/cast-roster";
+import { ALL_STEPS } from "@/domains/onboarding/cast/cast-task-derivation";
 import { computeTransforms, resolveDefinitions } from "@/utils/avatar-svg-compositor";
 import { publicAsset } from "@/utils/public-asset";
 
@@ -108,14 +109,9 @@ export function TypewriterLine({ text, onDone }: { text: string; onDone: () => v
 }
 
 // ---------------------------------------------------------------------------
-// MemoryList — persistent "grocery list" of remembered preferences
+// MemoryList — persistent "grocery list" of remembered preferences.
+// Renders the shared `ALL_STEPS` (single source of truth in cast-task-derivation).
 // ---------------------------------------------------------------------------
-
-const ALL_STEPS: { step: string; pending: string; credits?: number }[] = [
-  { step: "face", pending: "Look & feel" },
-  { step: "tone", pending: "Communication style" },
-  { step: "reach", pending: "Primary channel", credits: 25 },
-];
 
 export function MemoryList({
   entries,

--- a/apps/web/src/domains/onboarding/cast/cast-starter.tsx
+++ b/apps/web/src/domains/onboarding/cast/cast-starter.tsx
@@ -24,20 +24,13 @@ import { LayoutGroup, motion } from "motion/react";
 import {
   COMPONENTS,
   buildCharacter,
+  hash,
   type CastCharacter,
   type HoverAnim,
 } from "@/domains/onboarding/cast/cast-roster";
 import { BlinkingAvatar } from "@/domains/onboarding/cast/cast-shell";
+import type { StarterResume } from "@/domains/onboarding/cast/screens/screen-slot";
 import { composeSvg } from "@/utils/avatar-svg-compositor";
-
-/** A character already chosen, used to reopen the modal mid-flow (e.g. Back
- * from a later beat) instead of dropping the user back at the bare line-up. */
-export interface StarterResume {
-  bodyShape: string;
-  eyeStyle: string;
-  color: string;
-  name: string;
-}
 
 const indexOfBody = (id: string) => Math.max(0, BODIES.findIndex((b) => b.id === id));
 const indexOfEye = (id: string) => Math.max(0, EYES.findIndex((e) => e.id === id));
@@ -59,15 +52,6 @@ const STARTER_HOVERS: HoverAnim[] = ["jump", "wiggle", "flip", "spin"];
 /** Grid width — must match the CSS `repeat(5, …)` so the neighbour-aware color
  * assignment below knows which cards are adjacent (incl. diagonals). */
 const ROSTER_COLS = 5;
-
-/** Deterministic, well-mixed hash (no Math.random in Cast). */
-function hash(n: number): number {
-  let v = Math.imul(n ^ 0x9e3779b1, 2654435761);
-  v ^= v >>> 15;
-  v = Math.imul(v, 0x85ebca6b);
-  v ^= v >>> 13;
-  return v >>> 0;
-}
 
 /**
  * A scattered color per starter. A color linear in the index repeats on the
@@ -93,7 +77,7 @@ const STARTER_COLOR_INDEX: number[] = (() => {
     const soft = new Set(hard);
     for (let j = i - col; j < i; j++) soft.add(out[j]); // colors already in this row
 
-    const start = hash(i) % COLORS.length;
+    const start = hash(i, 1) % COLORS.length;
     const pick = (avoid: Set<number>): number | null => {
       for (let k = 0; k < COLORS.length; k++) {
         const c = (start + k) % COLORS.length;

--- a/apps/web/src/domains/onboarding/cast/cast-task-derivation.test.ts
+++ b/apps/web/src/domains/onboarding/cast/cast-task-derivation.test.ts
@@ -3,9 +3,12 @@ import { describe, expect, it } from "bun:test";
 import {
   ALL_STEPS,
   FALLBACK_TASKS,
-  TOOL_TASKS,
   deriveTaskSuggestions,
 } from "@/domains/onboarding/cast/cast-task-derivation";
+import { CAST_TOOL_BY_SLUG } from "@/domains/onboarding/cast/cast-tools";
+
+/** Task pool for a tool, looked up by its slug (shared registry). */
+const tasksFor = (slug: string): string[] => CAST_TOOL_BY_SLUG.get(slug)!.tasks;
 
 describe("deriveTaskSuggestions", () => {
   it("falls back to generic tasks when there are no memories", () => {
@@ -15,30 +18,30 @@ describe("deriveTaskSuggestions", () => {
 
   it("always returns at most three tasks", () => {
     const tasks = deriveTaskSuggestions([
-      ["reach", "Connected: Slack, Gmail, Notion, Linear"],
+      ["reach", "Connected: slack, gmail, notion, linear"],
     ]);
     expect(tasks.length).toBeLessThanOrEqual(3);
   });
 
   it("derives a task from each connected tool, drawn from that tool's pool", () => {
-    const tasks = deriveTaskSuggestions([["reach", "Connected: Slack, Gmail"]]);
+    const tasks = deriveTaskSuggestions([["reach", "Connected: slack, gmail"]]);
     expect(tasks.length).toBe(3); // 2 tool tasks + 1 fallback
-    expect(TOOL_TASKS["slack"]).toContain(tasks[0]);
-    expect(TOOL_TASKS["gmail"]).toContain(tasks[1]);
+    expect(tasksFor("slack")).toContain(tasks[0]);
+    expect(tasksFor("gmail")).toContain(tasks[1]);
   });
 
-  it("maps the 'Google Calendar' label to the google-calendar slug", () => {
-    const tasks = deriveTaskSuggestions([["reach", "Connected: Google Calendar"]]);
-    expect(TOOL_TASKS["google-calendar"]).toContain(tasks[0]);
+  it("resolves the google-calendar slug to its task pool", () => {
+    const tasks = deriveTaskSuggestions([["reach", "Connected: google-calendar"]]);
+    expect(tasksFor("google-calendar")).toContain(tasks[0]);
   });
 
-  it("slugifies multi-word tool labels (Google Drive -> google-drive)", () => {
-    const tasks = deriveTaskSuggestions([["reach", "Connected: Google Drive"]]);
-    expect(TOOL_TASKS["google-drive"]).toContain(tasks[0]);
+  it("resolves multi-word tool slugs (google-drive)", () => {
+    const tasks = deriveTaskSuggestions([["reach", "Connected: google-drive"]]);
+    expect(tasksFor("google-drive")).toContain(tasks[0]);
   });
 
-  it("ignores unknown tool labels and falls back", () => {
-    const tasks = deriveTaskSuggestions([["reach", "Connected: Telepathy"]]);
+  it("ignores unknown tool slugs and falls back", () => {
+    const tasks = deriveTaskSuggestions([["reach", "Connected: telepathy"]]);
     expect(tasks).toEqual(FALLBACK_TASKS.slice(0, 3));
   });
 
@@ -62,12 +65,12 @@ describe("deriveTaskSuggestions", () => {
 
   it("fills tool + brain tasks before fallbacks, capped at three", () => {
     const tasks = deriveTaskSuggestions([
-      ["reach", "Connected: Slack, Gmail"],
+      ["reach", "Connected: slack, gmail"],
       ["brain", "Import from: Claude"],
     ]);
     expect(tasks.length).toBe(3);
-    expect(TOOL_TASKS["slack"]).toContain(tasks[0]);
-    expect(TOOL_TASKS["gmail"]).toContain(tasks[1]);
+    expect(tasksFor("slack")).toContain(tasks[0]);
+    expect(tasksFor("gmail")).toContain(tasks[1]);
     expect(tasks[2]).toBe("Pick up where I left off with my previous conversations");
   });
 

--- a/apps/web/src/domains/onboarding/cast/cast-task-derivation.ts
+++ b/apps/web/src/domains/onboarding/cast/cast-task-derivation.ts
@@ -14,20 +14,13 @@
  * `reach` entry) drive tool-specific tasks, an imported brain adds a
  * continuation task, and the rest are filled from generic fallbacks. The result
  * is always capped at three.
+ *
+ * Tool slugs and task pools come from the shared `cast-tools` registry
+ * (`CAST_TOOL_BY_SLUG`), so the connected-tool slugs recorded in the memory
+ * list resolve to tasks by direct lookup — no label→slug string transform.
  */
 
-/** Tool-specific task suggestions, keyed by the connected tool's slug. */
-export const TOOL_TASKS: Record<string, string[]> = {
-  "google-calendar": ["Check my schedule for today", "Block focus time this week"],
-  "notion": ["Summarize my recent Notion updates", "Create a weekly planner page"],
-  "linear": ["Show my open Linear issues", "Draft a sprint summary"],
-  "github": ["Review my open pull requests", "Summarize recent commits"],
-  "slack": ["Catch me up on unread Slack messages", "Draft a standup update"],
-  "gmail": ["Summarize my unread emails", "Draft a follow-up email"],
-  "figma": ["List recent Figma file changes", "Prepare design review notes"],
-  "outlook": ["Check my Outlook calendar for today", "Summarize flagged emails"],
-  "google-drive": ["Find my most recent shared docs", "Organize my Drive files"],
-};
+import { CAST_TOOL_BY_SLUG } from "@/domains/onboarding/cast/cast-tools";
 
 /** Generic tasks used to fill any remaining slots. */
 export const FALLBACK_TASKS = [
@@ -50,14 +43,9 @@ export function deriveTaskSuggestions(memories: [string, string][]): string[] {
   // Pull tasks from connected tools
   const reachText = memMap.get("reach") ?? "";
   if (reachText.startsWith("Connected:")) {
-    const toolNames = reachText.replace("Connected: ", "").split(", ");
-    for (const toolName of toolNames) {
-      // Find key by label
-      const key =
-        toolName === "Google Calendar"
-          ? "google-calendar"
-          : toolName.toLowerCase().replace(/\s+/g, "-");
-      const pool = TOOL_TASKS[key];
+    const toolSlugs = reachText.replace("Connected: ", "").split(", ");
+    for (const slug of toolSlugs) {
+      const pool = CAST_TOOL_BY_SLUG.get(slug)?.tasks;
       if (pool) tasks.push(pool[Math.floor(Math.random() * pool.length)]);
     }
   }

--- a/apps/web/src/domains/onboarding/cast/cast-tools.ts
+++ b/apps/web/src/domains/onboarding/cast/cast-tools.ts
@@ -1,0 +1,117 @@
+/**
+ * Cast tool registry — the single source of truth for the OAuth tools the
+ * dialogue "reach" phase offers and the per-tool task pools the done/handoff
+ * screen suggests.
+ *
+ * Previously these lived in two places that had to agree by convention:
+ * `screens/dialogue-screen.tsx` declared `REACH_TOOLS` (slug + label + icon +
+ * keywords) and `cast-task-derivation.ts` declared `TOOL_TASKS` keyed by the
+ * same slugs, with `deriveTaskSuggestions` reconstructing slugs from display
+ * labels via a brittle string transform. Both now consume this registry:
+ * `dialogue-screen.tsx` connects tools by `slug` (recorded in the memory list)
+ * and `cast-task-derivation.ts` looks tasks up by that same slug, so there is no
+ * label→slug round-trip.
+ *
+ * Kept pure and React-free (icons are described by asset path + alt, not a
+ * rendered node) so the task-derivation module stays dependency-free and
+ * unit-testable.
+ */
+
+/** A connectable tool: stable slug, display label, suggested tasks, and the
+ * reach-phase picker presentation (keywords for context matching + icon). */
+export interface CastTool {
+  /** Stable identifier; never derived from the label. */
+  slug: string;
+  /** Display label shown in the reach picker and recorded in the memory list. */
+  label: string;
+  /** Suggested tasks for the done/handoff screen when this tool is connected. */
+  tasks: string[];
+  /** Keywords used to score this tool against the brain-import context. */
+  keywords: string[];
+  /** Reach-picker icon asset (relative to `publicAsset`). */
+  icon: string;
+}
+
+/**
+ * The tool catalog. `google-calendar` is the always-offered first reach tool;
+ * the rest are candidates for the analysed second slot (see
+ * `pickSecondReachTool` in `dialogue-screen.tsx`).
+ */
+export const CAST_TOOLS: CastTool[] = [
+  {
+    slug: "google-calendar",
+    label: "Google Calendar",
+    tasks: ["Check my schedule for today", "Block focus time this week"],
+    keywords: ["calendar", "schedule", "meeting", "event", "appointment", "availability"],
+    icon: "/images/integrations/google-calendar.svg",
+  },
+  {
+    slug: "notion",
+    label: "Notion",
+    tasks: ["Summarize my recent Notion updates", "Create a weekly planner page"],
+    keywords: ["notion", "notes", "wiki", "documentation", "docs", "database", "knowledge base", "writing"],
+    icon: "/images/integrations/notion.svg",
+  },
+  {
+    slug: "linear",
+    label: "Linear",
+    tasks: ["Show my open Linear issues", "Draft a sprint summary"],
+    keywords: ["linear", "sprint", "issue", "ticket", "project management", "backlog", "roadmap", "kanban"],
+    icon: "/images/integrations/linear-light-logo.svg",
+  },
+  {
+    slug: "github",
+    label: "GitHub",
+    tasks: ["Review my open pull requests", "Summarize recent commits"],
+    keywords: ["github", "code", "programming", "repo", "pull request", "commit", "developer", "engineering", "software"],
+    icon: "/images/integrations/github.svg",
+  },
+  {
+    slug: "slack",
+    label: "Slack",
+    tasks: ["Catch me up on unread Slack messages", "Draft a standup update"],
+    keywords: ["slack", "team", "channel", "messaging", "chat", "standup", "communication"],
+    icon: "/images/integrations/slack.svg",
+  },
+  {
+    slug: "gmail",
+    label: "Gmail",
+    tasks: ["Summarize my unread emails", "Draft a follow-up email"],
+    keywords: ["gmail", "email", "inbox", "newsletter", "outreach", "correspondence"],
+    icon: "/images/integrations/gmail.svg",
+  },
+  {
+    slug: "figma",
+    label: "Figma",
+    tasks: ["List recent Figma file changes", "Prepare design review notes"],
+    keywords: ["figma", "design", "ui", "ux", "wireframe", "prototype", "mockup", "visual"],
+    icon: "/images/integrations/figma.svg",
+  },
+  {
+    slug: "outlook",
+    label: "Outlook",
+    tasks: ["Check my Outlook calendar for today", "Summarize flagged emails"],
+    keywords: ["outlook", "microsoft", "office", "teams", "enterprise"],
+    icon: "/images/integrations/outlook.png",
+  },
+  {
+    slug: "google-drive",
+    label: "Google Drive",
+    tasks: ["Find my most recent shared docs", "Organize my Drive files"],
+    keywords: ["drive", "files", "storage", "documents", "spreadsheet", "folder", "share", "upload"],
+    icon: "/images/integrations/google-drive.svg",
+  },
+];
+
+/** Tools eligible for the analysed second reach slot (everything but the
+ * always-first Google Calendar). */
+export const SECOND_REACH_TOOLS: CastTool[] = CAST_TOOLS.filter(
+  (t) => t.slug !== "google-calendar",
+);
+
+/** Lookup by slug — the form recorded in the "Connected: …" memory list (the
+ * reach picker connects tools by `slug`, and the orchestrator joins those slugs
+ * into the memory text consumed by `deriveTaskSuggestions`). */
+export const CAST_TOOL_BY_SLUG: ReadonlyMap<string, CastTool> = new Map(
+  CAST_TOOLS.map((t) => [t.slug, t]),
+);

--- a/apps/web/src/domains/onboarding/cast/screens/dialogue-screen.tsx
+++ b/apps/web/src/domains/onboarding/cast/screens/dialogue-screen.tsx
@@ -16,80 +16,38 @@ import { AnimatePresence, motion } from "motion/react";
 
 import { BlinkingAvatar } from "@/domains/onboarding/cast/cast-shell";
 import type { CastCharacter } from "@/domains/onboarding/cast/cast-roster";
+import type { CastTool } from "@/domains/onboarding/cast/cast-tools";
+import { CAST_TOOLS, SECOND_REACH_TOOLS } from "@/domains/onboarding/cast/cast-tools";
 import type { DialogueScreenProps } from "@/domains/onboarding/cast/screens/screen-slot";
 import { publicAsset } from "@/utils/public-asset";
 import "@/domains/onboarding/cast/cast.css";
 
 // ---------------------------------------------------------------------------
-// Reach tools — minimal closure for the reach phase. The second tool offered is
-// chosen by analysing the brain-import context (or a deterministic per-character
-// fallback); Google Calendar is always the first.
+// Reach tools — driven by the shared `cast-tools` registry. The second tool
+// offered is chosen by analysing the brain-import context (or a deterministic
+// per-character fallback); Google Calendar (the registry's first entry) is
+// always offered first and is excluded from the second-slot candidates.
 // ---------------------------------------------------------------------------
 
-type ReachTool = { key: string; label: string; icon: React.ReactNode; keywords: string[] };
+const GOOGLE_CALENDAR = CAST_TOOLS[0];
 
-const REACH_TOOLS: ReachTool[] = [
-  {
-    key: "notion",
-    label: "Notion",
-    icon: <img src={publicAsset("/images/integrations/notion.svg")} alt="Notion" width={32} height={32} />,
-    keywords: ["notion", "notes", "wiki", "documentation", "docs", "database", "knowledge base", "writing"],
-  },
-  {
-    key: "linear",
-    label: "Linear",
-    icon: <img src={publicAsset("/images/integrations/linear-light-logo.svg")} alt="Linear" width={32} height={32} />,
-    keywords: ["linear", "sprint", "issue", "ticket", "project management", "backlog", "roadmap", "kanban"],
-  },
-  {
-    key: "github",
-    label: "GitHub",
-    icon: <img src={publicAsset("/images/integrations/github.svg")} alt="GitHub" width={32} height={32} />,
-    keywords: ["github", "code", "programming", "repo", "pull request", "commit", "developer", "engineering", "software"],
-  },
-  {
-    key: "slack",
-    label: "Slack",
-    icon: <img src={publicAsset("/images/integrations/slack.svg")} alt="Slack" width={32} height={32} />,
-    keywords: ["slack", "team", "channel", "messaging", "chat", "standup", "communication"],
-  },
-  {
-    key: "gmail",
-    label: "Gmail",
-    icon: <img src={publicAsset("/images/integrations/gmail.svg")} alt="Gmail" width={32} height={32} />,
-    keywords: ["gmail", "email", "inbox", "newsletter", "outreach", "correspondence"],
-  },
-  {
-    key: "figma",
-    label: "Figma",
-    icon: <img src={publicAsset("/images/integrations/figma.svg")} alt="Figma" width={32} height={32} />,
-    keywords: ["figma", "design", "ui", "ux", "wireframe", "prototype", "mockup", "visual"],
-  },
-  {
-    key: "outlook",
-    label: "Outlook",
-    icon: <img src={publicAsset("/images/integrations/outlook.png")} alt="Outlook" width={32} height={32} />,
-    keywords: ["outlook", "microsoft", "office", "teams", "enterprise"],
-  },
-  {
-    key: "google-drive",
-    label: "Google Drive",
-    icon: <img src={publicAsset("/images/integrations/google-drive.svg")} alt="Google Drive" width={32} height={32} />,
-    keywords: ["drive", "files", "storage", "documents", "spreadsheet", "folder", "share", "upload"],
-  },
-];
+/** Render a tool's registry icon as the 32px reach-card image. */
+function toolIcon(tool: CastTool): React.ReactNode {
+  return <img src={publicAsset(tool.icon)} alt={tool.label} width={32} height={32} />;
+}
 
 /**
  * Analyse uploaded brain-import context to pick the best second OAuth tool.
- * Returns a tool from REACH_TOOLS. Falls back to a deterministic random pick
- * seeded from `characterId` when no context was uploaded or no keywords match.
+ * Returns a tool from `SECOND_REACH_TOOLS`. Falls back to a deterministic
+ * pick seeded from `characterId` when no context was uploaded or no keywords
+ * match.
  */
-function pickSecondReachTool(fileContent: string | null, characterId: string): ReachTool {
+function pickSecondReachTool(fileContent: string | null, characterId: string): CastTool {
   if (fileContent) {
     const lower = fileContent.toLowerCase();
-    let best: ReachTool | null = null;
+    let best: CastTool | null = null;
     let bestScore = 0;
-    for (const tool of REACH_TOOLS) {
+    for (const tool of SECOND_REACH_TOOLS) {
       const score = tool.keywords.reduce((n, kw) => {
         // Count occurrences of each keyword (case-insensitive, whole-word-ish)
         const re = new RegExp(`\\b${kw.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`, "gi");
@@ -108,7 +66,7 @@ function pickSecondReachTool(fileContent: string | null, characterId: string): R
   for (let i = 0; i < characterId.length; i++) {
     hash = (hash * 31 + characterId.charCodeAt(i)) | 0;
   }
-  return REACH_TOOLS[Math.abs(hash) % REACH_TOOLS.length];
+  return SECOND_REACH_TOOLS[Math.abs(hash) % SECOND_REACH_TOOLS.length];
 }
 
 // ---------------------------------------------------------------------------
@@ -197,15 +155,8 @@ function VNDialogueFlow({
     () => pickSecondReachTool(brainFileContent, character.id),
     [brainFileContent, character.id],
   );
-  const reachTools = useMemo(
-    () => [
-      {
-        key: "google-calendar",
-        label: "Google Calendar",
-        icon: <img src={publicAsset("/images/integrations/google-calendar.svg")} alt="Google Calendar" width={32} height={32} />,
-      },
-      { key: secondTool.key, label: secondTool.label, icon: secondTool.icon },
-    ],
+  const reachTools = useMemo<CastTool[]>(
+    () => [GOOGLE_CALENDAR, secondTool],
     [secondTool],
   );
 
@@ -339,12 +290,12 @@ function VNDialogueFlow({
           <>
             <div className="cast-vn__choices">
               {reachTools.map((tool) => {
-                const isConnected = reachConnected.has(tool.key);
+                const isConnected = reachConnected.has(tool.slug);
                 return (
                   <motion.button
-                    key={tool.key}
+                    key={tool.slug}
                     className="cast-vs"
-                    onClick={(e) => !isConnected && handleReachConnect(tool.key, e)}
+                    onClick={(e) => !isConnected && handleReachConnect(tool.slug, e)}
                     whileHover={isConnected ? undefined : { y: -6 }}
                     whileTap={isConnected ? undefined : { scale: 0.97 }}
                     style={{
@@ -355,7 +306,7 @@ function VNDialogueFlow({
                       cursor: isConnected ? "default" : "pointer",
                     }}
                   >
-                    {tool.icon}
+                    {toolIcon(tool)}
                     {tool.label}
                     {isConnected && (
                       <span


### PR DESCRIPTION
## Summary
- Single shared cast tool registry consumed by dialogue + task-derivation (removes label->slug round-trip)
- Single ALL_STEPS source; cast-shell imports from cast-task-derivation
- Dedup StarterResume (import from screen-slot) and hash() (import salted from cast-roster)

Part of plan: cast-prechat-flow.md (self-review remediation)