### PR TITLE
fix(onboarding): cast arm owns provisioning (nav + auth surface + avatar seed)

### DIFF
--- a/apps/web/src/assistant/seed-hatch-avatar.test.ts
+++ b/apps/web/src/assistant/seed-hatch-avatar.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for `seedHatchAvatar` — the shared hatch-avatar seed used by both the
+ * standalone hatching screen and the cast flow's background hatch.
+ *
+ * Pins:
+ *   - Saves traits + invalidates the avatar query when no avatar exists yet.
+ *   - Skips the save (but still invalidates) when an avatar already exists, so
+ *     a returning user's uploaded/AI image is never clobbered.
+ *   - Swallows transport failures (fire-and-forget).
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { CharacterTraits } from "@/types/avatar";
+
+const fetchCharacterTraitsMock = mock(
+  async (_id: string): Promise<CharacterTraits | null> => null,
+);
+const saveCharacterTraitsMock = mock(
+  async (_id: string, _t: CharacterTraits): Promise<boolean> => true,
+);
+mock.module("@/assistant/avatar-api", () => ({
+  fetchCharacterTraits: fetchCharacterTraitsMock,
+  saveCharacterTraits: saveCharacterTraitsMock,
+}));
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: () => {},
+}));
+mock.module("@/lib/sync/query-tags", () => ({
+  avatarQueryKey: (id: string) => ["avatar", id],
+}));
+
+const { seedHatchAvatar } = await import("./seed-hatch-avatar");
+
+const TRAITS: CharacterTraits = {
+  bodyShape: "round",
+  eyeStyle: "happy",
+  color: "#123456",
+};
+
+function makeQueryClient(): {
+  invalidateQueries: ReturnType<typeof mock>;
+} {
+  return { invalidateQueries: mock(() => {}) };
+}
+
+beforeEach(() => {
+  fetchCharacterTraitsMock.mockClear();
+  saveCharacterTraitsMock.mockClear();
+});
+
+describe("seedHatchAvatar", () => {
+  test("saves traits and invalidates when no avatar exists", async () => {
+    fetchCharacterTraitsMock.mockResolvedValueOnce(null);
+    const qc = makeQueryClient();
+
+    await seedHatchAvatar("ast-1", TRAITS, qc as never);
+
+    expect(saveCharacterTraitsMock).toHaveBeenCalledTimes(1);
+    expect(saveCharacterTraitsMock.mock.calls[0]?.[0]).toBe("ast-1");
+    expect(qc.invalidateQueries).toHaveBeenCalledTimes(1);
+  });
+
+  test("skips the save but still invalidates when an avatar already exists", async () => {
+    fetchCharacterTraitsMock.mockResolvedValueOnce(TRAITS);
+    const qc = makeQueryClient();
+
+    await seedHatchAvatar("ast-1", TRAITS, qc as never);
+
+    expect(saveCharacterTraitsMock).not.toHaveBeenCalled();
+    expect(qc.invalidateQueries).toHaveBeenCalledTimes(1);
+  });
+
+  test("swallows transport failures", async () => {
+    fetchCharacterTraitsMock.mockRejectedValueOnce(new Error("boom"));
+    const qc = makeQueryClient();
+
+    await seedHatchAvatar("ast-1", TRAITS, qc as never);
+
+    expect(saveCharacterTraitsMock).not.toHaveBeenCalled();
+    expect(qc.invalidateQueries).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/assistant/seed-hatch-avatar.ts
+++ b/apps/web/src/assistant/seed-hatch-avatar.ts
@@ -1,0 +1,43 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+import { fetchCharacterTraits, saveCharacterTraits } from "@/assistant/avatar-api";
+import { captureError } from "@/lib/sentry/capture-error";
+import { avatarQueryKey } from "@/lib/sync/query-tags";
+import type { CharacterTraits } from "@/types/avatar";
+
+/**
+ * Persist the random hatch avatar (skipping the save when one already exists)
+ * and invalidate the avatar query that feeds the Dock + menu-bar icons, the
+ * favicon, and the in-app avatar. Fire-and-forget: callers do NOT await it, so
+ * onboarding never blocks on the server-side render — it runs in the background
+ * as the user lands in the app. The avatar query holds results with
+ * `staleTime: Infinity` and is disabled until the assistant activates, so its
+ * first fetch can beat the save and cache an avatar-less result; the post-save
+ * invalidate forces a refetch that picks up the persisted traits, so the icons
+ * self-correct within a beat rather than sticking on the bundled mark.
+ *
+ * Only call this for a freshly hatched assistant, never for an already-active
+ * one: a returning user may have an uploaded/AI image avatar, which deletes the
+ * character-traits sidecar, so a "no traits" read would wrongly seed random
+ * traits over their image.
+ *
+ * Shared by the standalone hatching screen and the cast flow's background
+ * hatch so a cast-hatched assistant lands with a seeded avatar too.
+ */
+export async function seedHatchAvatar(
+  assistantId: string,
+  traits: CharacterTraits,
+  queryClient: QueryClient,
+): Promise<void> {
+  try {
+    const existing = await fetchCharacterTraits(assistantId);
+    if (!existing) {
+      await saveCharacterTraits(assistantId, traits);
+    }
+    void queryClient.invalidateQueries({
+      queryKey: avatarQueryKey(assistantId),
+    });
+  } catch (err) {
+    captureError(err, { context: "onboarding_avatar_sync" });
+  }
+}

--- a/apps/web/src/domains/onboarding/cast/screens/login-screen.tsx
+++ b/apps/web/src/domains/onboarding/cast/screens/login-screen.tsx
@@ -22,18 +22,25 @@ import type {
   LoginIdentity,
   LoginScreenProps,
 } from "@/domains/onboarding/cast/screens/screen-slot";
+import { useIsAuthenticated } from "@/stores/auth-store";
 import "@/domains/onboarding/cast/cast.css";
 
 export type { LoginIdentity };
 
 export function LoginScreen({ onAdvance, onContinue, onIdentity }: LoginScreenProps) {
-  const [loggedIn, setLoggedIn] = useState(false);
+  // The cast arm only runs post-auth/post-consent, so the sign-in buttons are
+  // mock theatre. When already authenticated, skip the fake sign-in stage and
+  // render the about-you form directly; the provider-button path survives only
+  // for the (unexpected) unauthenticated case.
+  const isAuthenticated = useIsAuthenticated();
+  const [loggedIn, setLoggedIn] = useState(isAuthenticated);
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
   const [role, setRole] = useState("");
   const [exiting, setExiting] = useState(false);
 
-  // Reveal the about-you form once a provider is chosen (mock sign-in).
+  // Reveal the about-you form once a provider is chosen (mock sign-in). Only
+  // reachable on the unauthenticated fallback path.
   function handleLogin() {
     if (loggedIn) return;
     setLoggedIn(true);
@@ -176,16 +183,16 @@ export function LoginScreen({ onAdvance, onContinue, onIdentity }: LoginScreenPr
                   </button>
                 </motion.p>
 
-                <motion.button
+                <motion.a
                   className="cast-login__download"
-                  onClick={handleLogin}
+                  href="/downloads"
                   initial={{ opacity: 0 }}
                   animate={{ opacity: 1 }}
                   transition={{ duration: 0.3, delay: 0.75 }}
                 >
                   <AppleLogo size={16} />
                   Download for macOS
-                </motion.button>
+                </motion.a>
               </motion.div>
             ) : (
               <motion.div

--- a/apps/web/src/domains/onboarding/cast/use-background-hatch.test.ts
+++ b/apps/web/src/domains/onboarding/cast/use-background-hatch.test.ts
@@ -46,6 +46,16 @@ mock.module("@/assistant/api", () => ({
 mock.module("@/lib/sentry/capture-error", () => ({
   captureError: () => {},
 }));
+
+// Avatar seeding is fire-and-forget and tested separately; stub it and the
+// QueryClient the hook reads so the hook renders without a provider.
+const seedHatchAvatarMock = mock(async (..._args: unknown[]) => {});
+mock.module("@/assistant/seed-hatch-avatar", () => ({
+  seedHatchAvatar: seedHatchAvatarMock,
+}));
+mock.module("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries: () => {} }),
+}));
 mock.module("@/utils/api-errors", () => ({
   extractErrorMessage: (
     e: unknown,
@@ -70,6 +80,7 @@ beforeEach(() => {
   hatchAssistantMock.mockClear();
   getAssistantMock.mockClear();
   getAssistantHealthzMock.mockClear();
+  seedHatchAvatarMock.mockClear();
 });
 
 describe("useBackgroundHatch", () => {
@@ -126,5 +137,35 @@ describe("useBackgroundHatch", () => {
     await waitFor(() => expect(rejection?.message).toBe("Bad hatch request"));
     // A terminal (non-5xx) hatch failure must not fall through to polling.
     expect(getAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("seeds the avatar for a freshly created (201) assistant", async () => {
+    const { result } = renderHook(() => useBackgroundHatch());
+
+    act(() => {
+      result.current.start();
+    });
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(seedHatchAvatarMock).toHaveBeenCalledTimes(1);
+    expect(seedHatchAvatarMock.mock.calls[0]?.[0]).toBe("ast-cast");
+  });
+
+  test("does not seed the avatar for an existing (200) assistant", async () => {
+    hatchResult = {
+      ok: true,
+      status: 200,
+      data: { id: "ast-cast" } as never,
+    };
+
+    const { result } = renderHook(() => useBackgroundHatch());
+
+    act(() => {
+      result.current.start();
+    });
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    // A 200 returned an existing assistant — its avatar must not be clobbered.
+    expect(seedHatchAvatarMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/domains/onboarding/cast/use-background-hatch.ts
+++ b/apps/web/src/domains/onboarding/cast/use-background-hatch.ts
@@ -1,4 +1,5 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 
 import {
   getAssistant,
@@ -11,8 +12,12 @@ import {
   resolveAssistantLifecycleState,
   shouldRecoverFromHatchFailure,
 } from "@/assistant/lifecycle";
+import { seedHatchAvatar } from "@/assistant/seed-hatch-avatar";
 import { captureError } from "@/lib/sentry/capture-error";
 import { extractErrorMessage } from "@/utils/api-errors";
+import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
+import { randomCharacterTraits } from "@/utils/avatar-random";
+import type { CharacterTraits } from "@/types/avatar";
 
 // Mirrors the poll/backoff constants in
 // `@/domains/onboarding/pages/hatching-screen.tsx`. The cast onboarding flow
@@ -59,11 +64,22 @@ export interface UseBackgroundHatch {
  * Recoverable failures (5xx / network) keep polling.
  */
 export function useBackgroundHatch(): UseBackgroundHatch {
+  const queryClient = useQueryClient();
   const [ready, setReady] = useState(false);
   const [assistantId, setAssistantId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const startedRef = useRef(false);
+  // Set on unmount so the poll loop bails instead of running to the 5-min
+  // timeout — mirrors the `cancelled` flag in `hatching-screen.tsx`. A
+  // retry-remount would otherwise leave a stale loop polling in the background.
+  const cancelledRef = useRef(false);
+  // Random hatch traits, generated once per instance via a lazy state
+  // initializer (matching the standalone hatching screen) so a cast-hatched
+  // assistant lands with a seeded avatar.
+  const [hatchTraits] = useState<CharacterTraits>(() =>
+    randomCharacterTraits(BUNDLED_COMPONENTS),
+  );
   // Resolvers for any `awaitReady()` callers waiting on the in-flight hatch.
   const waitersRef = useRef<{
     resolve: (id: string) => void;
@@ -100,11 +116,17 @@ export function useBackgroundHatch(): UseBackgroundHatch {
     void (async () => {
       // 1. Hatch (managed/platform). 201 = newly created, 200 = existing.
       let hatchedAssistantId: string | undefined;
+      // A 201 means a brand-new assistant — seedable with a random avatar (the
+      // same signal `hatching-screen.tsx` uses). A 200 returned an existing
+      // assistant, whose avatar must not be clobbered.
+      let createdFreshAssistant = false;
       try {
         const result = await hatchAssistant();
+        if (cancelledRef.current) return;
         if (result.ok) {
           hatchedAssistantId = result.data.id;
           setAssistantId(result.data.id);
+          createdFreshAssistant = result.status === 201;
         } else {
           if (isPlatformHostedDisabled(result.status, result.error)) {
             settleError(PLATFORM_HOSTED_DISABLED_MESSAGE);
@@ -130,6 +152,7 @@ export function useBackgroundHatch(): UseBackgroundHatch {
       // 2. Poll until the assistant reports `active`.
       let activeAssistantId: string | undefined;
       while (!activeAssistantId) {
+        if (cancelledRef.current) return;
         if (timedOut()) {
           settleError(TIMEOUT_ERROR);
           return;
@@ -157,8 +180,14 @@ export function useBackgroundHatch(): UseBackgroundHatch {
         await sleep(POLL_INTERVAL_MS);
       }
 
+      // Fire-and-forget — readiness never blocks on the avatar render.
+      if (createdFreshAssistant) {
+        void seedHatchAvatar(activeAssistantId, hatchTraits, queryClient);
+      }
+
       // 3. Poll healthz until the daemon is reachable, then mark ready.
       while (true) {
+        if (cancelledRef.current) return;
         try {
           const health = await getAssistantHealthz(activeAssistantId);
           if (health.ok) break;
@@ -174,7 +203,16 @@ export function useBackgroundHatch(): UseBackgroundHatch {
 
       settleReady(activeAssistantId);
     })();
-  }, [settleError, settleReady]);
+  }, [hatchTraits, queryClient, settleError, settleReady]);
+
+  // Cancel the poll loop on unmount so a retry-remount doesn't leave a stale
+  // loop running to the 5-min timeout. Effect cleanup runs on unmount only
+  // (empty deps), mirroring the hatching-screen's `cancelled` teardown.
+  useEffect(() => {
+    return () => {
+      cancelledRef.current = true;
+    };
+  }, []);
 
   const awaitReady = useCallback((): Promise<string> => {
     const settled = settledRef.current;

--- a/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
 import { getAssistant, getAssistantHealthz, hatchAssistant, type Assistant } from "@/assistant/api";
-import { fetchCharacterTraits, saveCharacterTraits } from "@/assistant/avatar-api";
+import { seedHatchAvatar } from "@/assistant/seed-hatch-avatar";
 import {
     isPlatformHostedDisabled,
     PLATFORM_HOSTED_DISABLED_MESSAGE,
@@ -21,7 +21,6 @@ import {
 import { applyPendingProviderKey } from "@/domains/onboarding/provider-key";
 import { getLocalGatewayUrl, getPlatformRuntimeUrl, isLocalMode, loadLockfile, primeLocalGatewayConnection, saveLockfileAssistant } from "@/lib/local-mode";
 import { clearGatewayToken } from "@/lib/auth/gateway-session";
-import { avatarQueryKey } from "@/lib/sync/query-tags";
 import { resolveNavigation } from "@/lib/navigation/navigation-resolver";
 import { buildNavigationState } from "@/lib/navigation/build-state";
 import { hatchLocalAssistant } from "@/runtime/local-mode-host";
@@ -212,34 +211,10 @@ export function HatchingScreen() {
       }, COMPLETION_NAVIGATE_DELAY_MS);
     };
 
-    // Persist the random hatch avatar (skipping the save when one already
-    // exists) and invalidate the avatar query that feeds the Dock + menu-bar
-    // icons, the favicon, and the in-app avatar. Fire-and-forget: callers do
-    // NOT await it, so onboarding never blocks on the server-side render — it
-    // runs in the background as the user lands in the app. The avatar query
-    // holds results with `staleTime: Infinity` and is disabled until the
-    // assistant activates, so its first fetch can beat the save and cache an
-    // avatar-less result; the post-save invalidate forces a refetch that picks
-    // up the persisted traits, so the icons self-correct within a beat rather
-    // than sticking on the bundled mark.
-    //
-    // Only call this for a freshly hatched assistant, never for an
-    // already-active one: a returning user may have an uploaded/AI image
-    // avatar, which deletes the character-traits sidecar, so a "no traits"
-    // read would wrongly seed random traits over their image.
-    const persistHatchAvatar = async (assistantId: string): Promise<void> => {
-      try {
-        const existing = await fetchCharacterTraits(assistantId);
-        if (!existing) {
-          await saveCharacterTraits(assistantId, hatchTraits);
-        }
-        void queryClient.invalidateQueries({
-          queryKey: avatarQueryKey(assistantId),
-        });
-      } catch (err) {
-        captureError(err, { context: "onboarding_avatar_sync" });
-      }
-    };
+    // Seed the random hatch avatar for a freshly hatched assistant (never an
+    // already-active one — see `seedHatchAvatar` for the why). Fire-and-forget.
+    const persistHatchAvatar = (assistantId: string): Promise<void> =>
+      seedHatchAvatar(assistantId, hatchTraits, queryClient);
 
     const startHatch = async () => {
       transitionPhase("provisioning");

--- a/apps/web/src/domains/onboarding/pages/privacy-screen.test.tsx
+++ b/apps/web/src/domains/onboarding/pages/privacy-screen.test.tsx
@@ -49,6 +49,12 @@ mock.module("@/stores/client-feature-flag-store", () => ({
   useClientFeatureFlagStore: { use: { stringFlags: () => ({}) } },
 }));
 
+// Activation-flow arm — drives the post-consent destination (cast → prechat).
+let activationArm = "control";
+mock.module("@/hooks/use-client-feature-flag-sync", () => ({
+  useActivationFlowArm: () => ({ arm: activationArm, settled: true }),
+}));
+
 // Light passthroughs for layout/design-library so the screen renders in happy-dom.
 mock.module("@/domains/onboarding/components/onboarding-layout", () => ({
   OnboardingLayout: ({ children }: { children: React.ReactNode }) => children,
@@ -85,6 +91,7 @@ describe("PrivacyScreen — Start navigation", () => {
     navigateMock.mockClear();
     saveConsentMock.mockClear();
     emitFunnelStepCompletedMock.mockClear();
+    activationArm = "control";
   });
   afterEach(cleanup);
 
@@ -111,5 +118,19 @@ describe("PrivacyScreen — Start navigation", () => {
 
     expect(saveConsentMock).toHaveBeenCalledTimes(1);
     expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.hatching);
+  });
+
+  test("cast arm persists consent and skips hatching for prechat", () => {
+    searchParamsValue = new URLSearchParams();
+    activationArm = "personal-page";
+    render(<PrivacyScreen />);
+
+    clickStart();
+
+    // The cast flow owns its own provisioning, so post-consent goes straight to
+    // prechat (no standalone hatching step).
+    expect(saveConsentMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.prechat);
+    expect(navigateMock).not.toHaveBeenCalledWith(routes.onboarding.hatching);
   });
 });

--- a/apps/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/apps/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -17,6 +17,7 @@ import {
     useShareDiagnostics,
     useTosAccepted,
 } from "@/domains/onboarding/prefs";
+import { useActivationFlowArm } from "@/hooks/use-client-feature-flag-sync";
 import { isElectron } from "@/runtime/is-electron";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
@@ -75,6 +76,12 @@ export function PrivacyScreen() {
   const isNative = useIsNativePlatform();
   const preChatExperimentArm =
     useClientFeatureFlagStore.use.stringFlags().preChatOnboardingExperiment20260606 ?? "control";
+  // The cast / personal-page activation arm owns its own provisioning: its
+  // pre-chat flow background-hatches the assistant, so post-consent it skips
+  // the standalone hatching screen and goes straight to prechat. Every other
+  // arm (control / variant-a) keeps the hatching step.
+  const { arm: activationArm } = useActivationFlowArm();
+  const isCastArm = activationArm === "personal-page";
   const preferredFunnelVariant =
     onboardingFunnelVariantFromExperiment(preChatExperimentArm);
   const [shareAnalytics, setShareAnalyticsReal] = useShareAnalytics();
@@ -115,6 +122,13 @@ export function PrivacyScreen() {
       });
     }
 
+    // Cast arm: skip the standalone hatching screen — the prechat flow
+    // background-hatches its own assistant.
+    if (isCastArm) {
+      void navigate(routes.onboarding.prechat);
+      return;
+    }
+
     const hostingParam = searchParams.get("hosting");
     const params = new URLSearchParams();
     if (hostingParam) params.set("hosting", hostingParam);
@@ -123,6 +137,7 @@ export function PrivacyScreen() {
   }, [
     aiDataConsent,
     hasPlatformSession,
+    isCastArm,
     isNative,
     isPreview,
     navigate,

--- a/apps/web/src/lib/navigation/build-state.ts
+++ b/apps/web/src/lib/navigation/build-state.ts
@@ -6,8 +6,25 @@ import {
   readTosAccepted,
   readAiDataConsent,
 } from "@/domains/onboarding/prefs";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import type { NavigationState } from "./navigation-resolver";
+
+// Store key for `experiment-activation-flow-2026-06-03` (camelCase), matching
+// `ACTIVATION_FLOW_STORE_KEY` in `hooks/use-client-feature-flag-sync.ts`. The
+// store's `stringFlags` already folds in any localStorage override.
+const ACTIVATION_FLOW_STORE_KEY = "experimentActivationFlow20260603";
+const CAST_ARM = "personal-page";
+
+function isCastArm(): boolean {
+  // Local mode never runs the platform activation experiment.
+  if (isLocalMode()) return false;
+  return (
+    useClientFeatureFlagStore.getState().stringFlags[
+      ACTIVATION_FLOW_STORE_KEY
+    ] === CAST_ARM
+  );
+}
 
 export function buildNavigationState(
   overrides?: Partial<NavigationState>,
@@ -22,6 +39,7 @@ export function buildNavigationState(
     platformSession,
     tosAccepted: readTosAccepted(),
     aiDataConsent: readAiDataConsent(),
+    isCastArm: isCastArm(),
     ...overrides,
   };
 }

--- a/apps/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/apps/web/src/lib/navigation/navigation-resolver.test.ts
@@ -16,6 +16,7 @@ const base: NavigationState = {
   platformSession: "present",
   tosAccepted: true,
   aiDataConsent: true,
+  isCastArm: false,
 };
 
 function s(overrides: Partial<NavigationState>): NavigationState {
@@ -292,6 +293,43 @@ describe("resolveNavigation", () => {
         action: "redirect",
         to: "/assistant/onboarding/hatching",
       });
+    });
+
+    // -- cast arm (personal-page): owns its own provisioning -----------------
+
+    test("redirects consented cast-arm user without assistants to prechat, not hatching", () => {
+      expect(
+        guard(s({ hasAssistants: false, isCastArm: true })),
+      ).toEqual({
+        action: "redirect",
+        to: "/assistant/onboarding/prechat",
+      });
+    });
+
+    test("redirects cast-arm user without assistants to prechat from a deep path", () => {
+      expect(
+        guard(s({ hasAssistants: false, isCastArm: true }), "/assistant/home"),
+      ).toEqual({
+        action: "redirect",
+        to: "/assistant/onboarding/prechat",
+      });
+    });
+
+    test("cast-arm user without consent still goes to privacy first", () => {
+      expect(
+        guard(
+          s({
+            hasAssistants: false,
+            isCastArm: true,
+            tosAccepted: false,
+            aiDataConsent: false,
+          }),
+        ),
+      ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
+    });
+
+    test("cast-arm flag does not change routing for a user who has an assistant", () => {
+      expect(guard(s({ isCastArm: true }))).toEqual(ALLOW);
     });
   });
 

--- a/apps/web/src/lib/navigation/navigation-resolver.ts
+++ b/apps/web/src/lib/navigation/navigation-resolver.ts
@@ -15,6 +15,14 @@ export interface NavigationState {
   platformSession: PlatformSessionStatus;
   tosAccepted: boolean;
   aiDataConsent: boolean;
+  /**
+   * The `experiment-activation-flow-2026-06-03 = personal-page` ("cast") arm.
+   * The cast flow owns its own provisioning (it background-hatches itself from
+   * the pre-chat step), so a no-assistant cast user is routed to prechat rather
+   * than the standalone hatching screen. Defaults to `false` for every other
+   * arm (control / variant-a) and for local mode, leaving their routing intact.
+   */
+  isCastArm: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -255,6 +263,12 @@ function requireAssistant(state: NavigationState): NavigationDecision | null {
 
   if (!hasCompletedOnboarding(state)) {
     return { action: "redirect", to: routes.onboarding.privacy };
+  }
+  // The cast arm's pre-chat flow hatches its own assistant, so a consented
+  // cast user with no assistant belongs in prechat, not the standalone
+  // hatching screen. Every other arm keeps the hatching redirect.
+  if (state.isCastArm) {
+    return { action: "redirect", to: routes.onboarding.prechat };
   }
   return { action: "redirect", to: routes.onboarding.hatching };
 }


### PR DESCRIPTION
## Summary
Fixes review gaps for the cast/personal-page arm:
- Arm-aware nav: cast arm skips the standalone hatching screen (post-consent → prechat); control/variant-a/local-mode unchanged
- Cast LoginScreen drops mock-auth buttons for authenticated users (about-you form directly); macOS Download CTA → /downloads
- useBackgroundHatch seeds the avatar on 201 (shared helper with hatching-screen) + cancels its poll loop on unmount

Part of plan: cast-prechat-flow.md (self-review remediation)