### PR TITLE
prompt(activation-rail): require a proposal on thin signal, keep tool mechanics out of prose

### DIFF
--- a/assistant/src/prompts/templates/BOOTSTRAP-ACTIVATION-RAIL.md
+++ b/assistant/src/prompts/templates/BOOTSTRAP-ACTIVATION-RAIL.md
@@ -35,6 +35,8 @@ Surface the outcome as a clickable component, strongest first. The component is 
 
 DONE: you cannot exit Propose without emitting at least one `ui_show` offer surface (card / choice). A proposal in prose is not a proposal.
 
+Thin signal still ships a proposal. Weak findings mean you make the smallest defensible offer and name the confidence in a clause ("low confidence, but —") — they do not mean you skip the move. Never resolve Propose into a critique of why the signal's too thin: "not enough here to suggest anything" is a stall, not a move. The least-wrong job for someone who looks like them beats an honest shrug, every time.
+
 **Run.** Do it. Real tools, real data. The user watches something happen.
 
 DONE: a real tool ran against real data and the user can see the result.
@@ -69,7 +71,7 @@ These are enforcement rules, not advice.
 
 **Self-check before final emit.** If this turn contains an offer or a follow-up, render it via `ui_show`, not prose.
 
-**Long turns show progress.** Any post-submit / post-skill-load turn must render a `task_progress` card within ~5s, or fall back to streaming text. Bind "long turn" → "task_progress emitted": a long-running turn that produces neither a progress card nor streaming text didn't satisfy this move.
+**Long turns show progress.** Any post-submit / post-skill-load turn must render a `task_progress` card within ~5s, or fall back to streaming text. Bind "long turn" → "task_progress emitted": a long-running turn that produces neither a progress card nor streaming text didn't satisfy this move. Progress is the card, not a play-by-play. Tool selection, routing, retries, and failures ("search blocked, trying the browser…", "that captcha'd, falling back to —") belong in thinking, never in visible prose: the card shows progress, the result surface shows outcome, and the mechanics in between stay out of the user's view.
 
 **Action Trust-Guarantee.** Sibling to the OAuth Trust-Guarantee. Before a bulk write / delete / destructive op, render a `ui_show` preview — a table surface showing total count, breakdown, sample rows, and the categories to confirm. The user commits or refines on that surface; only then do you execute. Single-item actions use the natural draft instead. Threshold for the preview gate: bulk _and_ low recoverability. One of the two alone doesn't trip it.
 


### PR DESCRIPTION
## Why

Triaging a feedback item where the assistant "did a better job researching me and suggesting scheduled jobs" under the **Balanced** profile (Claude Sonnet 4.6) than under **Balanced Economy** (an open-weight model). I pulled the diagnostics: it was the *same* onboarding task — research the user, suggest a scheduled job — run back-to-back with only the model swapped (the two profiles are identical except for the model).

The weaker model didn't lose on retrieval — it actually researched *more*. It lost **after** retrieval, in two ways that map cleanly to gaps in the activation-rail template:

1. **Thin-signal refusal.** It talked itself out of proposing because signal was thin ("none of these are worth running") instead of committing to an offer. The rail only said "a thin proposal beats stalling" inside the `port_declined` branch — there was no general rule, so the model generalized the opposite.
2. **Tool-routing narration.** It emitted a visible prose play-by-play ("search blocked, trying the browser, that captcha'd, falling back to…"). The rail said "long turns show progress" via a `task_progress` card but never said *don't narrate routing in prose*.

## What

Two enforcement-rule additions to `BOOTSTRAP-ACTIVATION-RAIL.md`, in the template's existing terse voice:

- **Propose move:** thin signal still ships the smallest defensible proposal + a confidence clause; never resolve Propose into a critique of why the signal's too thin.
- **"Long turns show progress" principle:** mechanics (tool selection, routing, retries, failures) stay in thinking; the card shows progress, the result shows outcome.

Both help every model and disproportionately help weaker ones — the frontier model already did both unprompted.

## Scope / safety

- Scoped to the **live activation-rail experiment template only** (cohort `experiment-activation-flow-2026-06-03`). Base `BOOTSTRAP.md` untouched.
- Per-conversation onboarding template, **not** the global system prompt — no cross-request token cost.
- `+3 / -1` lines. Contract test `onboarding-template-contract.test.ts` still green (18 pass).

## Not in this PR (deliberately)

The same triage looked at whether the shipped **Balanced Economy** config needed changes. It does **not** — that profile resolves to Kimi K2.6 (description accurate, logit-bias and effort correctly wired); the feedback was against an ad-hoc MiniMax M3 override that isn't the shipped config. No config change is warranted from this feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)