### PR TITLE
ci(release): attach Electron auto-update feed to GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2705,16 +2705,16 @@ jobs:
 
   # ── Electron macOS build (arm64 + x64) ────────────────────────────────
   # Builds the Electron-wrapped macOS app for each architecture, code-signs,
-  # notarizes, and uploads as release assets. Now GA: a failure on either arch
-  # fails this job and blocks the release (no longer continue-on-error).
+  # notarizes, and uploads as release assets. A failure on either arch fails
+  # this job and blocks the release.
   build-electron:
     needs: [extract-version, publish-meta-prod, publish-meta-staging]
     if: ${{ always() && !cancelled() && (needs.publish-meta-prod.result == 'success' || needs.publish-meta-staging.result == 'success') }}
     runs-on: macos-26
     timeout-minutes: 30
     strategy:
-      # Let both arches finish so a failure reports which arch(es) broke, but
-      # any failed leg still fails the job (and therefore the release).
+      # Let both arches finish so a failure reports which arch(es) broke; any
+      # failed leg fails the job (and therefore the release).
       fail-fast: false
       matrix:
         include:
@@ -2947,9 +2947,9 @@ jobs:
       contents: read
       id-token: write
     steps:
-      # build-electron is a hard dependency (no longer continue-on-error), so
-      # both arches' update artifacts must be present and complete. A missing
-      # download or artifact fails the job, which blocks the release gate.
+      # build-electron is a hard dependency, so both arches' update artifacts
+      # must be present and complete. A missing download or artifact fails the
+      # job, which blocks the release gate.
       - name: Download arm64 update artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
@@ -3076,10 +3076,10 @@ jobs:
           name: chrome-extension-crx-zip
           path: chrome-extension-artifacts
 
-      # Electron is GA and a hard release dependency: the `release` job only
-      # runs when both build-electron and upload-electron-updates succeeded, so
-      # these artifacts are guaranteed present. A download failure here fails
-      # the release rather than silently shipping without Electron assets.
+      # Electron is a hard release dependency: the `release` job only runs when
+      # both build-electron and upload-electron-updates succeeded, so these
+      # artifacts are guaranteed present. A download failure here fails the
+      # release rather than silently shipping without Electron assets.
       - name: Download Electron DMG artifact (arm64)
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
@@ -3131,7 +3131,7 @@ jobs:
             [ -n "$X64_DMG" ] && ASSETS+=("$X64_DMG#vellum-assistant-x64.dmg")
           fi
 
-          # Electron is GA: its DMGs are required. A missing DMG here fails the
+          # The Electron DMGs are required. A missing DMG here fails the
           # release rather than publishing without it.
           ELECTRON_DMG=$(find electron-artifacts -name "vellum-assistant-electron.dmg" -type f | grep -m1 .)
           if [ -z "$ELECTRON_DMG" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3107,6 +3107,25 @@ jobs:
           name: macos-build-electron-x64
           path: electron-artifacts-x64
 
+      # Also attach the Electron auto-update feed (zip + blockmap + manifest)
+      # to the Release for parity with Sparkle. electron-updater still pulls
+      # the feed from GCS; these copies are for visibility / manual installs.
+      - name: Download Electron update artifacts (arm64)
+        if: ${{ needs.upload-electron-updates.result == 'success' }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        continue-on-error: true
+        with:
+          name: macos-electron-update-arm64
+          path: electron-update-artifacts/arm64
+
+      - name: Download Electron update artifacts (x64)
+        if: ${{ needs.upload-electron-updates.result == 'success' }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        continue-on-error: true
+        with:
+          name: macos-electron-update-x64
+          path: electron-update-artifacts/x64
+
       - name: Create GitHub Releases
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -3140,6 +3159,21 @@ jobs:
             ELECTRON_X64_DMG=$(find electron-artifacts-x64 -name "vellum-assistant-electron-x64.dmg" -type f | grep -m1 .)
             [ -n "$ELECTRON_X64_DMG" ] && ASSETS+=("$ELECTRON_X64_DMG#vellum-assistant-electron-x64.dmg")
           fi
+
+          # Add the Electron auto-update feed (zip + blockmap + per-arch manifest).
+          # electron-builder names the manifest latest-mac.yml for BOTH arches, so
+          # rename per arch to avoid a collision in the Release's flat namespace.
+          # The zips/blockmaps already embed the arch in their names.
+          for ARCH in arm64 x64; do
+            UPDATE_DIR="electron-update-artifacts/${ARCH}"
+            [ -d "$UPDATE_DIR" ] || continue
+            UPDATE_ZIP=$(find "$UPDATE_DIR" -name "*-mac.zip" -type f | grep -m1 .)
+            [ -n "$UPDATE_ZIP" ] && ASSETS+=("$UPDATE_ZIP#$(basename "$UPDATE_ZIP")")
+            UPDATE_BLOCKMAP=$(find "$UPDATE_DIR" -name "*-mac.zip.blockmap" -type f | grep -m1 .)
+            [ -n "$UPDATE_BLOCKMAP" ] && ASSETS+=("$UPDATE_BLOCKMAP#$(basename "$UPDATE_BLOCKMAP")")
+            UPDATE_YML=$(find "$UPDATE_DIR" -name "*-mac.yml" -type f | grep -m1 .)
+            [ -n "$UPDATE_YML" ] && ASSETS+=("$UPDATE_YML#latest-mac-${ARCH}.yml")
+          done
 
           INSTALL_SH="cli/src/adapters/install.sh"
           [ -f "$INSTALL_SH" ] && ASSETS+=("$INSTALL_SH#install.sh")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3162,17 +3162,23 @@ jobs:
 
           # Add the Electron auto-update feed (zip + blockmap + per-arch manifest).
           # electron-builder names the manifest latest-mac.yml for BOTH arches, so
-          # rename per arch to avoid a collision in the Release's flat namespace.
-          # The zips/blockmaps already embed the arch in their names.
+          # copy it to a per-arch filename before upload to avoid an asset-name
+          # collision in the Release's flat namespace. The "#" suffix on a gh asset
+          # sets only a display label, not the uploaded filename, so the rename has
+          # to happen on disk. The zips/blockmaps already embed the arch.
           for ARCH in arm64 x64; do
             UPDATE_DIR="electron-update-artifacts/${ARCH}"
             [ -d "$UPDATE_DIR" ] || continue
             UPDATE_ZIP=$(find "$UPDATE_DIR" -name "*-mac.zip" -type f | grep -m1 .)
-            [ -n "$UPDATE_ZIP" ] && ASSETS+=("$UPDATE_ZIP#$(basename "$UPDATE_ZIP")")
+            [ -n "$UPDATE_ZIP" ] && ASSETS+=("$UPDATE_ZIP")
             UPDATE_BLOCKMAP=$(find "$UPDATE_DIR" -name "*-mac.zip.blockmap" -type f | grep -m1 .)
-            [ -n "$UPDATE_BLOCKMAP" ] && ASSETS+=("$UPDATE_BLOCKMAP#$(basename "$UPDATE_BLOCKMAP")")
+            [ -n "$UPDATE_BLOCKMAP" ] && ASSETS+=("$UPDATE_BLOCKMAP")
             UPDATE_YML=$(find "$UPDATE_DIR" -name "*-mac.yml" -type f | grep -m1 .)
-            [ -n "$UPDATE_YML" ] && ASSETS+=("$UPDATE_YML#latest-mac-${ARCH}.yml")
+            if [ -n "$UPDATE_YML" ]; then
+              RENAMED_YML="${UPDATE_DIR}/latest-mac-${ARCH}.yml"
+              cp "$UPDATE_YML" "$RENAMED_YML"
+              ASSETS+=("$RENAMED_YML")
+            fi
           done
 
           INSTALL_SH="cli/src/adapters/install.sh"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2705,15 +2705,16 @@ jobs:
 
   # ── Electron macOS build (arm64 + x64) ────────────────────────────────
   # Builds the Electron-wrapped macOS app for each architecture, code-signs,
-  # notarizes, and uploads as release assets. Non-blocking (continue-on-error)
-  # while the Electron client is WIP.
+  # notarizes, and uploads as release assets. Now GA: a failure on either arch
+  # fails this job and blocks the release (no longer continue-on-error).
   build-electron:
     needs: [extract-version, publish-meta-prod, publish-meta-staging]
     if: ${{ always() && !cancelled() && (needs.publish-meta-prod.result == 'success' || needs.publish-meta-staging.result == 'success') }}
     runs-on: macos-26
     timeout-minutes: 30
-    continue-on-error: true
     strategy:
+      # Let both arches finish so a failure reports which arch(es) broke, but
+      # any failed leg still fails the job (and therefore the release).
       fail-fast: false
       matrix:
         include:
@@ -2946,57 +2947,46 @@ jobs:
       contents: read
       id-token: write
     steps:
-      # build-electron is continue-on-error, so a failed leg still reports
-      # result == 'success' to needs — its artifacts may simply not exist.
-      # Missing arches are skipped (Electron is non-blocking); an arch that is
-      # present but incomplete fails the job, which blocks the release gate.
+      # build-electron is a hard dependency (no longer continue-on-error), so
+      # both arches' update artifacts must be present and complete. A missing
+      # download or artifact fails the job, which blocks the release gate.
       - name: Download arm64 update artifacts
-        continue-on-error: true
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: macos-electron-update-arm64
           path: electron-artifacts/arm64
 
       - name: Download x64 update artifacts
-        continue-on-error: true
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: macos-electron-update-x64
           path: electron-artifacts/x64
 
       - name: Validate update artifacts
-        id: validate
         run: |
-          HAS_ARTIFACTS=false
           for ARCH in arm64 x64; do
             DIR="electron-artifacts/${ARCH}"
             if [ ! -d "$DIR" ]; then
-              echo "::warning::No update artifacts for ${ARCH} (Electron build leg failed); skipping"
-              continue
+              echo "::error::No update artifacts for ${ARCH}"
+              exit 1
             fi
-            MISSING=0
-            if [ ! -f "$(find "$DIR" -name '*-mac.yml' -type f 2>/dev/null | grep -m1 .)" ]; then
+            if [ -z "$(find "$DIR" -name '*-mac.yml' -type f 2>/dev/null | grep -m1 .)" ]; then
               echo "::error::Missing update manifest (*-mac.yml) for ${ARCH}"
-              MISSING=1
+              exit 1
             fi
             if [ -z "$(find "$DIR" -name '*.zip' -type f ! -name '*.blockmap' 2>/dev/null | grep -m1 .)" ]; then
               echo "::error::Missing ZIP for ${ARCH}"
-              MISSING=1
+              exit 1
             fi
-            [ "$MISSING" -eq 0 ] || exit 1
-            HAS_ARTIFACTS=true
           done
-          echo "has_artifacts=$HAS_ARTIFACTS" >> "$GITHUB_OUTPUT"
 
       - name: Authenticate to GCP
-        if: ${{ steps.validate.outputs.has_artifacts == 'true' }}
         uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
         with:
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
 
       - name: Upload Electron update artifacts to GCS
-        if: ${{ steps.validate.outputs.has_artifacts == 'true' }}
         run: |
           ENVIRONMENT=${{ needs.extract-version.outputs.is_staging == 'true' && 'staging' || 'production' }}
           BUCKET=${{ needs.extract-version.outputs.is_staging == 'true' && 'vellum-ai-staging-releases' || 'vellum-ai-prod-releases' }}
@@ -3021,7 +3011,7 @@ jobs:
 
   release:
     needs: [extract-version, publish-npm-prod, publish-web-prod, publish-meta-prod, publish-plugin-api-prod, build-macos-arm64, build-macos-x64, build-electron, upload-electron-updates, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image, ci-playwright, build-chrome-extension]
-    if: ${{ always() && !cancelled() && needs.extract-version.outputs.is_staging != 'true' && needs.extract-version.result == 'success' && needs.publish-npm-prod.result == 'success' && needs.publish-web-prod.result == 'success' && needs.publish-meta-prod.result == 'success' && needs.publish-plugin-api-prod.result == 'success' && needs.build-macos-arm64.result == 'success' && (needs.ci-playwright.result == 'success' || inputs.playwright_blocks_release != true) && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' && (needs.upload-electron-updates.result == 'success' || needs.upload-electron-updates.result == 'skipped') }}
+    if: ${{ always() && !cancelled() && needs.extract-version.outputs.is_staging != 'true' && needs.extract-version.result == 'success' && needs.publish-npm-prod.result == 'success' && needs.publish-web-prod.result == 'success' && needs.publish-meta-prod.result == 'success' && needs.publish-plugin-api-prod.result == 'success' && needs.build-macos-arm64.result == 'success' && (needs.ci-playwright.result == 'success' || inputs.playwright_blocks_release != true) && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' && needs.build-electron.result == 'success' && needs.upload-electron-updates.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -3086,23 +3076,18 @@ jobs:
           name: chrome-extension-crx-zip
           path: chrome-extension-artifacts
 
-      # Only attach Electron DMGs when their update feed was successfully
-      # published to GCS. If `upload-electron-updates` was skipped (Electron
-      # build failed, or its DMG step succeeded while the update-artifact
-      # step did not), shipping the DMG without a matching update manifest
-      # would strand installed clients with no path back to auto-update.
+      # Electron is GA and a hard release dependency: the `release` job only
+      # runs when both build-electron and upload-electron-updates succeeded, so
+      # these artifacts are guaranteed present. A download failure here fails
+      # the release rather than silently shipping without Electron assets.
       - name: Download Electron DMG artifact (arm64)
-        if: ${{ needs.upload-electron-updates.result == 'success' }}
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        continue-on-error: true
         with:
           name: macos-build-electron
           path: electron-artifacts
 
       - name: Download Electron DMG artifact (x64)
-        if: ${{ needs.upload-electron-updates.result == 'success' }}
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        continue-on-error: true
         with:
           name: macos-build-electron-x64
           path: electron-artifacts-x64
@@ -3111,17 +3096,13 @@ jobs:
       # to the Release for parity with Sparkle. electron-updater still pulls
       # the feed from GCS; these copies are for visibility / manual installs.
       - name: Download Electron update artifacts (arm64)
-        if: ${{ needs.upload-electron-updates.result == 'success' }}
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        continue-on-error: true
         with:
           name: macos-electron-update-arm64
           path: electron-update-artifacts/arm64
 
       - name: Download Electron update artifacts (x64)
-        if: ${{ needs.upload-electron-updates.result == 'success' }}
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        continue-on-error: true
         with:
           name: macos-electron-update-x64
           path: electron-update-artifacts/x64
@@ -3150,35 +3131,40 @@ jobs:
             [ -n "$X64_DMG" ] && ASSETS+=("$X64_DMG#vellum-assistant-x64.dmg")
           fi
 
-          # Add Electron DMGs if available (non-blocking — may not exist if Electron build failed)
-          if [ -d "electron-artifacts" ]; then
-            ELECTRON_DMG=$(find electron-artifacts -name "vellum-assistant-electron.dmg" -type f | grep -m1 .)
-            [ -n "$ELECTRON_DMG" ] && ASSETS+=("$ELECTRON_DMG#vellum-assistant-electron.dmg")
+          # Electron is GA: its DMGs are required. A missing DMG here fails the
+          # release rather than publishing without it.
+          ELECTRON_DMG=$(find electron-artifacts -name "vellum-assistant-electron.dmg" -type f | grep -m1 .)
+          if [ -z "$ELECTRON_DMG" ]; then
+            echo "::error::Electron arm64 DMG missing"
+            exit 1
           fi
-          if [ -d "electron-artifacts-x64" ]; then
-            ELECTRON_X64_DMG=$(find electron-artifacts-x64 -name "vellum-assistant-electron-x64.dmg" -type f | grep -m1 .)
-            [ -n "$ELECTRON_X64_DMG" ] && ASSETS+=("$ELECTRON_X64_DMG#vellum-assistant-electron-x64.dmg")
+          ASSETS+=("$ELECTRON_DMG#vellum-assistant-electron.dmg")
+          ELECTRON_X64_DMG=$(find electron-artifacts-x64 -name "vellum-assistant-electron-x64.dmg" -type f | grep -m1 .)
+          if [ -z "$ELECTRON_X64_DMG" ]; then
+            echo "::error::Electron x64 DMG missing"
+            exit 1
           fi
+          ASSETS+=("$ELECTRON_X64_DMG#vellum-assistant-electron-x64.dmg")
 
-          # Add the Electron auto-update feed (zip + blockmap + per-arch manifest).
-          # electron-builder names the manifest latest-mac.yml for BOTH arches, so
-          # copy it to a per-arch filename before upload to avoid an asset-name
-          # collision in the Release's flat namespace. The "#" suffix on a gh asset
-          # sets only a display label, not the uploaded filename, so the rename has
-          # to happen on disk. The zips/blockmaps already embed the arch.
+          # Add the Electron auto-update feed (zip + blockmap + per-arch manifest),
+          # required for both arches. electron-builder names the manifest
+          # latest-mac.yml for BOTH arches, so copy it to a per-arch filename before
+          # upload to avoid an asset-name collision in the Release's flat namespace.
+          # The "#" suffix on a gh asset sets only a display label, not the uploaded
+          # filename, so the rename has to happen on disk. The zips/blockmaps
+          # already embed the arch.
           for ARCH in arm64 x64; do
             UPDATE_DIR="electron-update-artifacts/${ARCH}"
-            [ -d "$UPDATE_DIR" ] || continue
             UPDATE_ZIP=$(find "$UPDATE_DIR" -name "*-mac.zip" -type f | grep -m1 .)
-            [ -n "$UPDATE_ZIP" ] && ASSETS+=("$UPDATE_ZIP")
             UPDATE_BLOCKMAP=$(find "$UPDATE_DIR" -name "*-mac.zip.blockmap" -type f | grep -m1 .)
-            [ -n "$UPDATE_BLOCKMAP" ] && ASSETS+=("$UPDATE_BLOCKMAP")
             UPDATE_YML=$(find "$UPDATE_DIR" -name "*-mac.yml" -type f | grep -m1 .)
-            if [ -n "$UPDATE_YML" ]; then
-              RENAMED_YML="${UPDATE_DIR}/latest-mac-${ARCH}.yml"
-              cp "$UPDATE_YML" "$RENAMED_YML"
-              ASSETS+=("$RENAMED_YML")
+            if [ -z "$UPDATE_ZIP" ] || [ -z "$UPDATE_BLOCKMAP" ] || [ -z "$UPDATE_YML" ]; then
+              echo "::error::Electron ${ARCH} update feed incomplete (zip/blockmap/manifest)"
+              exit 1
             fi
+            RENAMED_YML="${UPDATE_DIR}/latest-mac-${ARCH}.yml"
+            cp "$UPDATE_YML" "$RENAMED_YML"
+            ASSETS+=("$UPDATE_ZIP" "$UPDATE_BLOCKMAP" "$RENAMED_YML")
           done
 
           INSTALL_SH="cli/src/adapters/install.sh"


### PR DESCRIPTION
## Summary
- The `release` job now also downloads the Electron update artifacts (`macos-electron-update-arm64` / `-x64`) and attaches the auto-update feed — `*-mac.zip`, `*.zip.blockmap`, and the per-arch manifest — to the GitHub Release, alongside the existing Electron `.dmg` installers.
- This is **additive / for parity** with Sparkle, whose `appcast.xml` + `vellum-assistant.zip` are already attached. `electron-updater` still pulls the feed from GCS (`apps/macos/electron-builder.config.cjs` is unchanged); these Release copies are for visibility and manual installs.
- The manifest is renamed per arch to `latest-mac-arm64.yml` / `latest-mac-x64.yml` because electron-builder names it `latest-mac.yml` for **both** arches and a GitHub Release is a flat asset namespace, so the two would otherwise collide. The zips/blockmaps already embed the arch in their names. Both new downloads reuse the same `needs.upload-electron-updates.result == 'success'` guard and `continue-on-error` as the DMG steps.

## Original prompt
Investigating why the Electron artifacts were missing from the v0.8.12 GitHub Release led to PR #34749 (which fixed `upload-electron-updates` being skipped, so the DMGs now attach). The follow-up ask: make future releases also include the Electron **auto-update** artifacts on the GitHub Release, the same way the native Sparkle feed is published — explicitly additive, without touching the electron-builder config or the GCS upload job.