### PR TITLE
fix(web): preserve ordered-list start in MarkdownMessage

### DIFF
--- a/packages/design-library/src/components/markdown-message.test.tsx
+++ b/packages/design-library/src/components/markdown-message.test.tsx
@@ -35,6 +35,25 @@ describe("MarkdownMessage", () => {
     expect(html).toContain("text-body-medium-default");
   });
 
+  test("ordered list beginning at a non-1 number preserves its start", () => {
+    // A terse "3." answer is parsed as a one-item ordered list starting at 3.
+    // Without forwarding `start`, the <ol> defaults to 1 and renders "1.".
+    const html = renderToStaticMarkup(
+      createElement(MarkdownMessage, { content: "3." }),
+    );
+
+    expect(html).toContain('<ol start="3"');
+  });
+
+  test("ordered list starting at 1 omits a redundant start attribute", () => {
+    const html = renderToStaticMarkup(
+      createElement(MarkdownMessage, { content: "1. first\n2. second" }),
+    );
+
+    expect(html).toContain("<ol");
+    expect(html).not.toContain("start=");
+  });
+
   test("tables render with the body-small typography token", () => {
     const html = renderToStaticMarkup(
       createElement(MarkdownMessage, {

--- a/packages/design-library/src/components/markdown-message.tsx
+++ b/packages/design-library/src/components/markdown-message.tsx
@@ -272,8 +272,12 @@ function buildMarkdownComponents(
     ul: ({ children }) => (
       <ul className="mb-2 list-disc pl-5 last:mb-0">{children}</ul>
     ),
-    ol: ({ children }) => (
-      <ol className="mb-2 list-decimal pl-5 last:mb-0">{children}</ol>
+    // `start` must be forwarded: react-markdown emits `<ol start="N">` for a
+    // list that begins at a non-1 number (a bare "3." answer, or a list the
+    // model continues from a prior number). Dropping it silently renumbers
+    // every such list to 1 — e.g. "3." would render as "1.".
+    ol: ({ children, start }) => (
+      <ol start={start} className="mb-2 list-decimal pl-5 last:mb-0">{children}</ol>
     ),
     // h4-h6 are rare in assistant output but must not fall through to
     // unstyled browser defaults (a Tailwind reset strips their size/weight,


### PR DESCRIPTION
## Problem

A feedback report showed the answer to *"how many r's in strawberry?"* rendering as a lone **"1."** that looked like a broken/truncated response.

Root cause: the model's answer was the literal text `"3."`. Markdown parses a line starting with `<number>.` as an ordered list, and `react-markdown` correctly emits `<ol start="3">`. But the `ol` override in `markdown-message.tsx` discarded every prop except `children`:

```tsx
ol: ({ children }) => (
  <ol className="...">{children}</ol>
),
```

With no `start`, the `<ol>` defaults to 1, so `"3."` rendered as an empty **"1."** list item. This affects **any** ordered list beginning at a non-1 number (e.g. a list the model continues from a prior number renders as "1. 2." instead of "3. 4.").

## Fix

Forward the `start` prop. Lists starting at 1 are unaffected (react-markdown emits no `start` attribute, verified by test).

## Test

Reproduced via `renderToStaticMarkup`:
- `"3."` → asserts `<ol start="3"`
- `"1. first\n2. second"` → asserts no `start=` attribute

All 27 `markdown-message.test.tsx` tests pass; `apps/web` typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)