### PR TITLE
fix(web): keep profile pickers from blanking on a transient empty config

### DIFF
--- a/apps/web/src/assistant/use-sticky-profiles.test.tsx
+++ b/apps/web/src/assistant/use-sticky-profiles.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { renderHook } from "@testing-library/react";
+
+import type { ConfigGetResponse } from "@/generated/daemon/types.gen";
+import { useStickyProfiles } from "./use-sticky-profiles";
+
+type Llm = NonNullable<ConfigGetResponse["llm"]>;
+
+/** Build a minimal `llm` config slice for the hook under test. */
+function llm(
+  profiles: Record<string, { label?: string }>,
+  profileOrder: string[],
+): Llm {
+  return { profiles, profileOrder } as Llm;
+}
+
+const FULL = llm({ smart: { label: "Smart" } }, ["smart"]);
+const EMPTY = llm({}, []);
+
+describe("useStickyProfiles", () => {
+  test("returns empty before any non-empty config has loaded", () => {
+    const { result } = renderHook(() => useStickyProfiles(undefined, "asst-1"));
+    expect(result.current.profiles).toEqual({});
+    expect(result.current.profileOrder).toEqual([]);
+  });
+
+  test("passes through live profiles", () => {
+    const { result } = renderHook(() => useStickyProfiles(FULL, "asst-1"));
+    expect(Object.keys(result.current.profiles)).toEqual(["smart"]);
+    expect(result.current.profileOrder).toEqual(["smart"]);
+  });
+
+  test("retains the last non-empty list when config transiently empties", () => {
+    const { result, rerender } = renderHook(
+      ({ value }: { value: Llm }) => useStickyProfiles(value, "asst-1"),
+      { initialProps: { value: FULL } },
+    );
+    expect(Object.keys(result.current.profiles)).toEqual(["smart"]);
+
+    // A transient empty config payload must NOT blank the picker.
+    rerender({ value: EMPTY });
+    expect(Object.keys(result.current.profiles)).toEqual(["smart"]);
+    expect(result.current.profileOrder).toEqual(["smart"]);
+  });
+
+  test("adopts a newer non-empty list when it arrives", () => {
+    const { result, rerender } = renderHook(
+      ({ value }: { value: Llm }) => useStickyProfiles(value, "asst-1"),
+      { initialProps: { value: FULL } },
+    );
+    const next = llm(
+      { smart: { label: "Smart" }, fast: { label: "Fast" } },
+      ["smart", "fast"],
+    );
+    rerender({ value: next });
+    expect(Object.keys(result.current.profiles)).toEqual(["smart", "fast"]);
+    expect(result.current.profileOrder).toEqual(["smart", "fast"]);
+  });
+
+  test("drops the retained snapshot when the assistant (resetKey) changes", () => {
+    const { result, rerender } = renderHook(
+      ({ value, key }: { value: Llm; key: string }) =>
+        useStickyProfiles(value, key),
+      { initialProps: { value: FULL, key: "asst-1" } },
+    );
+    expect(Object.keys(result.current.profiles)).toEqual(["smart"]);
+
+    // Switch assistants while the new assistant's config is still loading
+    // (empty). The previous assistant's profiles must not leak through.
+    rerender({ value: EMPTY, key: "asst-2" });
+    expect(result.current.profiles).toEqual({});
+    expect(result.current.profileOrder).toEqual([]);
+  });
+});

--- a/apps/web/src/assistant/use-sticky-profiles.ts
+++ b/apps/web/src/assistant/use-sticky-profiles.ts
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react";
+
+import type { ConfigGetResponse } from "@/generated/daemon/types.gen";
+
+type Llm = ConfigGetResponse["llm"];
+
+/** The `llm.profiles` map as served by `GET /v1/config`. */
+export type ProfileMap = NonNullable<NonNullable<Llm>["profiles"]>;
+
+export interface StickyProfiles {
+  profiles: ProfileMap;
+  profileOrder: string[];
+}
+
+const EMPTY: StickyProfiles = { profiles: {}, profileOrder: [] };
+
+/**
+ * Read `llm.profiles` / `llm.profileOrder` from the shared daemon-config query,
+ * retaining the last non-empty snapshot.
+ *
+ * Managed profiles are always daemon-seeded, so an empty profile map is never a
+ * legitimate steady state — it only appears transiently (e.g. a partial config
+ * payload written into the shared query cache while the daemon rewrites
+ * settings.json). Falling back to the last non-empty list during that window
+ * stops the profile pickers (composer Model Profile menu, settings Default
+ * Profile dropdown) from blanking until the next good fetch. Before this guard,
+ * a momentary empty config latched the picker empty until a full page reload.
+ *
+ * Pass `resetKey` (the assistant id) so the retained snapshot is dropped when
+ * the context it belongs to changes — otherwise switching assistants could
+ * briefly show the previous assistant's profiles before the new config loads.
+ */
+export function useStickyProfiles(
+  llm: Llm | undefined,
+  resetKey?: string,
+): StickyProfiles {
+  const liveProfiles = llm?.profiles;
+  const liveOrder = llm?.profileOrder;
+  const hasLive = !!liveProfiles && Object.keys(liveProfiles).length > 0;
+
+  const [sticky, setSticky] = useState<StickyProfiles>(EMPTY);
+
+  // Reset the retained snapshot when the context changes (React's "adjust state
+  // during render" pattern). Runs before the effect below so a context switch
+  // never serves the previous context's stale profiles.
+  const [prevResetKey, setPrevResetKey] = useState(resetKey);
+  if (resetKey !== prevResetKey) {
+    setPrevResetKey(resetKey);
+    setSticky(EMPTY);
+  }
+
+  useEffect(() => {
+    if (hasLive) {
+      setSticky({ profiles: liveProfiles, profileOrder: liveOrder ?? [] });
+    }
+  }, [hasLive, liveProfiles, liveOrder]);
+
+  if (hasLive) {
+    return { profiles: liveProfiles, profileOrder: liveOrder ?? [] };
+  }
+  return resetKey !== prevResetKey ? EMPTY : sticky;
+}

--- a/apps/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/apps/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -8,6 +8,7 @@ import {
     visibleProfilesForPicker,
     type ProfilePickerEntry,
 } from "@/assistant/profile-pickers";
+import { useStickyProfiles } from "@/assistant/use-sticky-profiles";
 import { useProfileQuickAdd } from "@/components/profile-quick-add-provider";
 import {
     configGetOptions,
@@ -19,7 +20,6 @@ import {
     configPatch,
     conversationsByIdInferenceprofilePut,
 } from "@/generated/daemon/sdk.gen";
-import type { ConfigGetResponse } from "@/generated/daemon/types.gen";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import {
     deleteConversationOverride,
@@ -83,14 +83,13 @@ export function ComposerSettingsMenu({ assistantId, conversationId }: Props) {
   // Derived server data — read from query cache, no useState copies.
   // ---------------------------------------------------------------------------
 
-  type Profiles = NonNullable<NonNullable<ConfigGetResponse["llm"]>["profiles"]>;
-  const profiles = useMemo<Profiles>(
-    () => configQuery.data?.llm?.profiles ?? {},
-    [configQuery.data],
-  );
-  const profileOrder = useMemo<string[]>(
-    () => configQuery.data?.llm?.profileOrder ?? [],
-    [configQuery.data],
+  // Retain the last non-empty profile list so a transient empty config payload
+  // (e.g. a partial read while the daemon rewrites settings.json) can't blank
+  // the picker until the next good fetch — managed profiles are always seeded,
+  // so an empty profile map is never a legitimate steady state.
+  const { profiles, profileOrder } = useStickyProfiles(
+    configQuery.data?.llm,
+    assistantId,
   );
   const globalActiveProfile = configQuery.data?.llm?.activeProfile ?? null;
   const conversationProfileOverride =

--- a/apps/web/src/domains/settings/ai/language-model-card.tsx
+++ b/apps/web/src/domains/settings/ai/language-model-card.tsx
@@ -22,6 +22,7 @@ import {
     profilePickerLabel,
     visibleProfilesForPicker,
 } from "@/assistant/profile-pickers";
+import { useStickyProfiles } from "@/assistant/use-sticky-profiles";
 import { configGetOptions, configGetSetQueryData, useConfigPatchMutation } from "@/generated/daemon/@tanstack/react-query.gen";
 import { useDraftOverride } from "@/domains/settings/ai/use-draft-override";
 import { useQuery } from "@tanstack/react-query";
@@ -37,12 +38,13 @@ export function LanguageModelCard() {
 
   const activeProfile = config?.llm?.activeProfile ?? null;
   const callSites = config?.llm?.callSites ?? {};
+  // Retain the last non-empty profile list so a transient empty config payload
+  // can't blank the Default Profile dropdown until the next good fetch — managed
+  // profiles are always seeded, so an empty map is never a steady state.
+  const { profiles, profileOrder } = useStickyProfiles(config?.llm, assistantId);
   const orderedProfiles = useMemo(
-    () => buildOrderedProfiles(
-      config?.llm?.profiles ?? {},
-      config?.llm?.profileOrder ?? [],
-    ),
-    [config?.llm?.profiles, config?.llm?.profileOrder],
+    () => buildOrderedProfiles(profiles, profileOrder),
+    [profiles, profileOrder],
   );
 
   const configMutation = useConfigPatchMutation({


### PR DESCRIPTION
## Summary
- The composer **Model Profile** menu and the settings **Default Profile** dropdown read `llm.profiles` from the shared daemon-config query cache. When that cache momentarily holds an empty `llm.profiles` (e.g. a partial config payload while the daemon rewrites `settings.json`), the picker blanked and stayed blank until a full page reload.
- Added `useStickyProfiles` in shared `@/assistant/` (so both the chat and settings domains can use it without a cross-domain import). It returns live profiles when present and otherwise falls back to the **last non-empty** snapshot — managed profiles are always daemon-seeded, so an empty profile map is never a legitimate steady state.
- The hook takes a `resetKey` (the assistant id) and drops the retained snapshot on change, so switching assistants never briefly shows the previous assistant's profiles.
- Wired into `composer-settings-menu.tsx` and `language-model-card.tsx`; added unit tests for the hook (pass-through, retain-on-empty, adopt-newer, reset-on-assistant-change).

## Original prompt
A user reported that after updating their model profile to "Balanced Economy" the profiles dropdown went blank, and only a page refresh restored it; a colleague hit the same on the latest web build. The earlier one-shot-fetch bug was already fixed by #34583 (the composer now reads the shared TanStack cache), so the remaining failure mode is the shared config cache transiently reporting zero profiles. Rather than chase the exact transient, this adds a defensive guard so the pickers retain their last non-empty list and can never blank from a momentary empty config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)