### PR TITLE
refactor(onboarding): cast done/handoff screen -> tokens + Tailwind

### DIFF
--- a/apps/web/src/domains/onboarding/cast/screens/done-screen.tsx
+++ b/apps/web/src/domains/onboarding/cast/screens/done-screen.tsx
@@ -22,6 +22,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { AnimatePresence, motion } from "motion/react";
+import { Button, Typography } from "@vellumai/design-library";
 
 import { BlinkingAvatar } from "@/domains/onboarding/cast/cast-shell";
 import { CastProof } from "@/domains/onboarding/cast/cast-proof-view";
@@ -87,42 +88,48 @@ export function HandoffScreen({
 
   return (
     <motion.div
-      className="cast-handoff"
+      className="absolute inset-0 z-[4] flex flex-col items-center justify-center p-6"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.4 }}
     >
-      <div style={{ width: 200, height: 200, marginBottom: 32 }}>
+      <div className="mb-8 h-[200px] w-[200px]">
         <BlinkingAvatar character={character} />
       </div>
       <h2 className="cast-handoff__heading">
         Here's what I found I can take care of for you today
       </h2>
-      <ul className="cast-handoff__tasks">
+      <ul className="m-0 mt-7 flex w-full max-w-[340px] list-none flex-col gap-2.5 p-0">
         {tasks.map((task, i) => (
           <motion.li
             key={task}
-            className="cast-handoff__task"
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.3, delay: 0.4 + i * 0.2 }}
           >
-            {task}
+            <Typography
+              variant="body-medium-default"
+              as="div"
+              className="rounded-[var(--radius-xl)] border border-[var(--border-subtle)] bg-[var(--surface-hover)] px-[18px] py-3.5 text-center font-semibold text-[var(--content-default)]"
+            >
+              {task}
+            </Typography>
           </motion.li>
         ))}
       </ul>
       <AnimatePresence>
         {showCta && (
-          <motion.button
-            className="cast-handoff__cta"
-            onClick={() => onCompleteRef.current()}
+          <motion.div
+            className="mt-[18px]"
             initial={{ opacity: 0, y: 8 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.3 }}
           >
-            Let's go &rarr;
-          </motion.button>
+            <Button variant="ghost" onClick={() => onCompleteRef.current()}>
+              Let's go &rarr;
+            </Button>
+          </motion.div>
         )}
       </AnimatePresence>
     </motion.div>

--- a/apps/web/src/domains/onboarding/cast/styles/done.css
+++ b/apps/web/src/domains/onboarding/cast/styles/done.css
@@ -1,23 +1,6 @@
-/* Cast — handoff / done / style-done completion screens. Split from cast.css (PR 1, verbatim move). */
+/* Cast — handoff screen. Layout/chrome moved to Tailwind + design tokens in
+ * done-screen.tsx; only the bespoke editorial serif heading remains here. */
 
-.cast-done__sub {
-  margin: var(--app-spacing-sm) 0 0;
-  font-size: 13px;
-  color: var(--content-tertiary);
-}
-
-/* Handoff screen — transition to chat sandbox */
-.cast-handoff {
-  position: absolute;
-  inset: 0;
-  z-index: 4;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 0;
-  padding: 24px;
-}
 .cast-handoff__heading {
   margin: 0;
   font-family: "Instrument Serif", var(--font-serif), serif;
@@ -29,80 +12,3 @@
   max-width: 380px;
   line-height: 1.3;
 }
-.cast-handoff__tasks {
-  list-style: none;
-  margin: 28px 0 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  width: 100%;
-  max-width: 340px;
-}
-.cast-handoff__task {
-  padding: 14px 18px;
-  border-radius: var(--radius-xl);
-  background: var(--surface-hover);
-  border: 1px solid var(--border-subtle);
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--content-default);
-  text-align: center;
-}
-.cast-handoff__cta {
-  appearance: none;
-  border: none;
-  background: none;
-  color: var(--content-secondary);
-  font-size: 15px;
-  font-weight: 600;
-  padding: 12px 0;
-  margin-top: 18px;
-  cursor: pointer;
-  transition: color 140ms ease;
-}
-.cast-handoff__cta:hover {
-  color: var(--content-default);
-}
-
-/* Standalone This/That page — completion panel. */
-.cast-style-done {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 12px;
-  text-align: center;
-  padding: 24px;
-}
-.cast-style-done__title {
-  margin: 0;
-  font-size: 26px;
-  font-weight: 700;
-  letter-spacing: -0.01em;
-  color: var(--content-default);
-}
-.cast-style-done__sub {
-  margin: 0;
-  font-size: 14px;
-  color: var(--content-secondary);
-  text-transform: capitalize;
-}
-.cast-style-done__btn {
-  margin-top: 8px;
-  appearance: none;
-  border: none;
-  background: var(--primary-base);
-  color: var(--content-inset);
-  font-size: 14px;
-  font-weight: 650;
-  padding: 10px 22px;
-  border-radius: var(--radius-xl);
-  cursor: pointer;
-}
-.cast-style-done__btn:hover {
-  background: var(--primary-hover);
-}
-


### PR DESCRIPTION
## Summary
- Convert cast done/handoff chrome to components/tokens/Tailwind; reduce done.css to bespoke loading animation

Part of plan: cast-styling-design-system.md (PR 8 of 10)