### PR TITLE
refactor(onboarding): cast preamble screen -> tokens + Tailwind

### DIFF
--- a/apps/web/src/domains/onboarding/cast/screens/preamble-screen.tsx
+++ b/apps/web/src/domains/onboarding/cast/screens/preamble-screen.tsx
@@ -5,6 +5,10 @@
  * then advances on click. The dark-green grid backdrop, topbar, and gradient
  * are supplied by `SetupShell` (from `cast-shell`), which the orchestrator wraps
  * around this phase — so this screen renders only the centered dialogue content.
+ *
+ * Styling: layout/typography use Tailwind + design tokens (`--content-*`,
+ * `--app-spacing-*`, `--font-serif`). The blink choreography reuses the shared
+ * `cast-blink` keyframe from `cast-animations.css`.
  */
 
 import { useEffect, useMemo, useState } from "react";
@@ -23,6 +27,19 @@ function preambleLines() {
     "First, let’s figure out who I am.",
   ];
 }
+
+// Serif title matching the cast about/heading treatment (Instrument Serif via
+// the `--font-serif` token, fluid clamp size). Left-aligned in the preamble.
+const HEADING_CLASS =
+  "m-0 mb-[var(--app-spacing-xl)] text-left font-serif text-[clamp(2.1rem,1rem+2.8vw,3.75rem)] font-normal leading-[1.15] tracking-[-0.01em] text-[var(--content-default)]";
+const BODY_CLASS =
+  "m-0 text-[20px] font-light leading-[1.6] text-[var(--content-default)]";
+const CURSOR_CLASS =
+  "inline animate-[cast-blink_0.6s_steps(2)_infinite] font-light text-[var(--content-tertiary)]";
+const ADVANCE_CLASS =
+  "mt-[var(--app-spacing-lg)] inline-block animate-[cast-blink_1.2s_ease-in-out_infinite] text-[14px] font-[620] text-[var(--content-secondary)]";
+// Reserve the final dimensions so the typewriter never reflows the layout.
+const STACK_CLASS = "flex max-w-[500px] flex-col gap-[var(--app-spacing-xl)] text-left";
 
 export function PreambleScreen({ firstName, onAdvance }: PreambleScreenProps) {
   const greeting = useMemo(() => preambleGreeting(firstName), [firstName]);
@@ -77,43 +94,41 @@ export function PreambleScreen({ firstName, onAdvance }: PreambleScreenProps) {
   return (
     <motion.div
       key="preamble"
-      className="cast-vn cast-vn--centered cast-vn--clickable cast-vn--embedded"
+      className="relative flex h-full w-full cursor-pointer flex-col items-center justify-center p-[var(--app-spacing-xxl)]"
       onClick={handleClick}
       initial={{ opacity: 0, y: 40 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: -40 }}
       transition={{ duration: 0.5, ease: "easeOut" }}
     >
-      <div className="cast-vn__bottom" style={{ position: "relative" }}>
+      <div className="relative">
         {/* Invisible full content to reserve the final dimensions. */}
-        <div aria-hidden className="cast-vn__bottom" style={{ visibility: "hidden" }}>
-          <h2 className="cast-about__heading" style={{ textAlign: "left" }}>
-            {greeting}
-          </h2>
+        <div aria-hidden className={`${STACK_CLASS} invisible`}>
+          <h2 className={HEADING_CLASS}>{greeting}</h2>
           {lines.map((line, i) => (
-            <p key={i} className="cast-vn__text">
+            <p key={i} className={BODY_CLASS}>
               {line}
             </p>
           ))}
-          <span className="cast-vn__advance">Next &#9660;</span>
+          <span className={ADVANCE_CLASS}>Next &#9660;</span>
         </div>
         {/* Visible typed overlay. */}
-        <div className="cast-vn__bottom" style={{ position: "absolute", inset: 0 }}>
-          <h2 className="cast-about__heading" style={{ textAlign: "left" }}>
+        <div className={`${STACK_CLASS} absolute inset-0`}>
+          <h2 className={HEADING_CLASS}>
             {greeting.slice(0, greetCharCount)}
-            {!greetTyped && <span className="cast-vn__cursor">|</span>}
+            {!greetTyped && <span className={CURSOR_CLASS}>|</span>}
           </h2>
           {bodyStarted &&
             lines.map((line, i) => {
               if (!reached[i]) return null;
               return (
-                <p key={i} className="cast-vn__text">
+                <p key={i} className={BODY_CLASS}>
                   {revealed[i]}
-                  {i === typingLineIdx && <span className="cast-vn__cursor">|</span>}
+                  {i === typingLineIdx && <span className={CURSOR_CLASS}>|</span>}
                 </p>
               );
             })}
-          {typed && <span className="cast-vn__advance">Next &#9660;</span>}
+          {typed && <span className={ADVANCE_CLASS}>Next &#9660;</span>}
         </div>
       </div>
     </motion.div>

--- a/apps/web/src/domains/onboarding/cast/styles/preamble.css
+++ b/apps/web/src/domains/onboarding/cast/styles/preamble.css
@@ -1,26 +1,29 @@
-/* Cast — preamble screen (grid backdrop + preamble VN bg). Split from cast.css (PR 1, verbatim move). */
+/* Cast — preamble screen: bespoke grid-art backdrop only.
+ *
+ * The preamble layout/typography now lives in `preamble-screen.tsx` as Tailwind
+ * + design tokens. What remains here is the irreducibly-bespoke setup-shell
+ * furniture rendered by `cast-shell.tsx` (SetupShell): the green character-grid
+ * art anchored to the bottom corners, its masked grid-lines, and the topbar.
+ * Grid stroke/outline colors are bespoke rgba literals set inline on the SVGs
+ * in `cast-shell.tsx` (no token equivalent for the faint ground-plane wash). */
 
-.cast-vn--preamble {
-  background: radial-gradient(ellipse at 50% 30%, #162b16 0%, #0f1f0f 40%, #091509 100%);
-}
 .cast-preamble__topbar {
   position: absolute;
-  top: 32px;
-  left: 80px;
-  transform: none;
+  top: var(--app-spacing-xxl);
+  left: 80px; /* bespoke: aligns the topbar with the grid gutter */
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--app-spacing-md);
   z-index: 5;
 }
 .cast-preamble__setup-label {
   font-size: 13px;
   font-weight: 500;
-  color: rgba(255, 255, 255, 0.45);
+  color: var(--content-tertiary);
   white-space: nowrap;
 }
 
-/* Preamble grid — cohesive grid anchored to bottom corners */
+/* Preamble grid — cohesive character-outline grid anchored to bottom corners. */
 .cast-preamble__boxes {
   position: absolute;
   inset: 0;
@@ -41,6 +44,7 @@
   position: absolute;
   inset: 0;
 }
+/* bespoke: dual-gradient mask fades the grid-lines toward the top + outer edge */
 .cast-preamble__lines--left {
   mask-image: linear-gradient(to bottom, transparent 0%, black 25%),
               linear-gradient(to left, transparent 0%, black 20%);
@@ -64,7 +68,7 @@
 }
 .cast-preamble__cell {
   position: absolute;
-  padding: 16px;
+  padding: var(--app-spacing-lg);
 }
 .cast-preamble__cell svg {
   display: block;


### PR DESCRIPTION
## Summary
- Convert cast preamble to tokens/Tailwind; reduce preamble.css to bespoke grid-art only

Part of plan: cast-styling-design-system.md (PR 4 of 10)