### PR TITLE
refactor(onboarding): cast style screen -> tokens + Tailwind

### DIFF
--- a/apps/web/src/domains/onboarding/cast/cast-style.tsx
+++ b/apps/web/src/domains/onboarding/cast/cast-style.tsx
@@ -14,6 +14,7 @@
  */
 import { useEffect, useRef, useState } from "react";
 import { AnimatePresence, motion } from "motion/react";
+import { cn } from "@vellumai/design-library";
 
 import { BlinkingAvatar } from "@/domains/onboarding/cast/cast-shell";
 import type { StyleProfile } from "@/domains/onboarding/cast/cast-templates";
@@ -124,9 +125,8 @@ export function CastStyle({
       {/* `.cast-avatar` is width/height:100%, so it must live in a hero-box-sized
           wrapper or it fills the whole stage. Size it from `heroBox`. */}
       <div
-        className="cast-style__hero"
+        className="absolute"
         style={{
-          position: "absolute",
           left: heroBox.left,
           top: heroBox.top,
           width: heroBox.size,
@@ -140,7 +140,7 @@ export function CastStyle({
         <AnimatePresence mode="wait">
           <motion.div
             key={roundIdx}
-            className="cast-thisthat__group"
+            className="flex w-full flex-col items-center gap-[var(--app-spacing-lg)]"
             initial={{ opacity: 0, y: 14 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0 }}
@@ -148,7 +148,9 @@ export function CastStyle({
           >
             {/* the character asks — the cards are the user's reply */}
             <p className="cast-thisthat__title">
-              <span className="cast-thisthat__asker">{name} asks</span>
+              <span className="mb-[6px] block text-[11px] uppercase tracking-[0.06em] text-[var(--content-tertiary)] [font-family:var(--font-sans),system-ui,sans-serif] [font-weight:560]">
+                {name} asks
+              </span>
               {round.title}
             </p>
             <div className="cast-thisthat__row">
@@ -179,9 +181,15 @@ export function CastStyle({
           </motion.div>
         </AnimatePresence>
 
-        <div className="cast-thisthat__dots">
+        <div className="flex gap-[var(--app-spacing-sm)]">
           {ROUNDS.map((_, i) => (
-            <span key={i} className={`cast-dot${i === roundIdx ? " is-on" : ""}`} />
+            <span
+              key={i}
+              className={cn(
+                "h-[7px] w-[7px] rounded-[var(--radius-pill)] bg-[var(--border-element)] transition-[background,transform] duration-200",
+                i === roundIdx && "scale-125 bg-[var(--content-default)]",
+              )}
+            />
           ))}
         </div>
       </div>

--- a/apps/web/src/domains/onboarding/cast/styles/style.css
+++ b/apps/web/src/domains/onboarding/cast/styles/style.css
@@ -1,4 +1,12 @@
-/* Cast — style (this/that), two-panel beats, tiles/cards, memory list. Split from cast.css (PR 1, verbatim move). */
+/* Cast — style (this/that), two-panel beats, tiles/cards, memory list. Split from cast.css (PR 1, verbatim move).
+ *
+ * The this/that style screen (cast-style.tsx) was converted to tokens + Tailwind;
+ * its layout/indicator/asker rules now live inline on the components. What remains
+ * for that screen is the bespoke serif round-title (.cast-thisthat__title) plus the
+ * shared .cast-thisthat / .cast-thisthat__row / .cast-vs primitives (also consumed
+ * by cast-starter + dialogue-screen, so left in place). Unrelated orphans
+ * (brain/celebration/memory-list/two-panel/tiles/card) are handled by a later
+ * cleanup PR. */
 
 /* ---- Beats 3 & 4: prompt + choice tiles + card ---- */
 
@@ -148,13 +156,6 @@
   gap: 22px;
 }
 
-.cast-thisthat__group {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--app-spacing-lg);
-}
 /* the dude's question, in its voice — the cards are the user's reply */
 .cast-thisthat__title {
   margin: 0;
@@ -165,16 +166,6 @@
   letter-spacing: -0.01em;
   color: var(--content-default);
   text-shadow: 0 2px 12px color-mix(in srgb, var(--cast-shroud) 70%, transparent);
-}
-.cast-thisthat__asker {
-  display: block;
-  margin-bottom: 6px;
-  font-family: var(--font-sans), system-ui, sans-serif;
-  font-size: 11px;
-  font-weight: 560;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--content-tertiary);
 }
 .cast-thisthat__sub {
   display: block;
@@ -481,22 +472,6 @@
   animation: cast-cursor-blink 0.6s steps(1) infinite;
   color: var(--content-tertiary);
 }
-.cast-thisthat__dots {
-  display: flex;
-  gap: var(--app-spacing-sm);
-}
-.cast-dot {
-  width: 7px;
-  height: 7px;
-  border-radius: var(--radius-pill);
-  background: var(--border-element);
-  transition: background 200ms ease, transform 200ms ease;
-}
-.cast-dot.is-on {
-  background: var(--content-default);
-  transform: scale(1.25);
-}
-
 /* ---- Beats 3–6: two-panel (options | live conversation) ---- */
 
 .cast-twopanel {


### PR DESCRIPTION
## Summary
- Convert cast style this/that screen to components/tokens/Tailwind; reduce its style.css rules to bespoke-only

Part of plan: cast-styling-design-system.md (PR 7 of 10)