### PR TITLE
[codex] Serve web SPA from nginx ingress

### DIFF
--- a/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/apps/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -98,7 +98,11 @@ mock.module("@/assistant/lifecycle-service", () => ({
 mock.module("@/assistant/api", () => ({
   hatchAssistant: hatchAssistantMock,
   getAssistant: getAssistantMock,
-  getAssistantHealthz: async () => ({ ok: true, status: 200, data: { status: "ok" } }),
+  getAssistantHealthz: async () => ({
+    ok: true,
+    status: 200,
+    data: { status: "ok" },
+  }),
 }));
 
 mock.module("@/assistant/avatar-api", () => ({
@@ -200,6 +204,7 @@ mock.module("@/runtime/native-auth", () => ({
 
 mock.module("@/lib/local-mode", () => ({
   isLocalMode: () => isLocalModeValue,
+  isRemoteGatewayMode: () => false,
   isLocalAssistant: () => false,
   isPlatformAssistant: () => false,
   hasAssistants: () => false,

--- a/apps/web/src/env.d.ts
+++ b/apps/web/src/env.d.ts
@@ -40,5 +40,5 @@ interface Window {
   /** Feature flag overrides injected by Electron preload or CLI script. */
   __VELLUM_FLAG_OVERRIDES__?: Record<string, boolean | string>;
   /** Runtime config injected by the shell (Electron preload, CLI, etc.). */
-  __VELLUM_CONFIG__?: { disablePlatform?: boolean };
+  __VELLUM_CONFIG__?: { disablePlatform?: boolean; mode?: string };
 }

--- a/apps/web/src/lib/auth/gateway-session.test.ts
+++ b/apps/web/src/lib/auth/gateway-session.test.ts
@@ -4,6 +4,8 @@ import {
   GatewayTokenError,
   clearGatewayToken,
   ensureGatewayToken,
+  isGatewayAuthEnabled,
+  isGatewayAuthMode,
   isRepairableGatewayTokenError,
 } from "@/lib/auth/gateway-session";
 
@@ -16,8 +18,18 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  window.__VELLUM_CONFIG__ = undefined;
   globalThis.fetch = realFetch;
   clearGatewayToken();
+});
+
+describe("remote gateway mode", () => {
+  test("does not require a stored gateway token", () => {
+    window.__VELLUM_CONFIG__ = { mode: "remote-gateway" };
+
+    expect(isGatewayAuthEnabled()).toBe(true);
+    expect(isGatewayAuthMode()).toBe(true);
+  });
 });
 
 describe("ensureGatewayToken mint failure", () => {

--- a/apps/web/src/lib/auth/gateway-session.ts
+++ b/apps/web/src/lib/auth/gateway-session.ts
@@ -1,6 +1,7 @@
 import {
   isLocalMode,
   getLocalGatewayUrl,
+  isRemoteGatewayMode,
 } from "@/lib/local-mode";
 import type { LockfileAssistant } from "@/runtime/local-mode-host";
 
@@ -52,10 +53,12 @@ let cachedExpiresAt: number = 0;
 let cachedTokenSource: string | null = null;
 
 export function isGatewayAuthEnabled(): boolean {
+  if (isRemoteGatewayMode()) return true;
   return isLocalMode() && getLocalGatewayUrl() != null;
 }
 
 export function isGatewayAuthMode(): boolean {
+  if (isRemoteGatewayMode()) return true;
   return isGatewayAuthEnabled() && getGatewayToken() !== null;
 }
 
@@ -89,7 +92,10 @@ export function getGatewayToken(): string | null {
   return null;
 }
 
-async function acquireGatewayToken(tokenUrl?: string, guardianToken?: string): Promise<string> {
+async function acquireGatewayToken(
+  tokenUrl?: string,
+  guardianToken?: string,
+): Promise<string> {
   const url = tokenUrl ?? "/auth/token";
   const headers: Record<string, string> = {};
   if (guardianToken) {
@@ -119,7 +125,10 @@ async function acquireGatewayToken(tokenUrl?: string, guardianToken?: string): P
   return token;
 }
 
-export async function ensureGatewayToken(tokenUrl?: string, guardianToken?: string): Promise<string> {
+export async function ensureGatewayToken(
+  tokenUrl?: string,
+  guardianToken?: string,
+): Promise<string> {
   const source = tokenUrl ?? "/auth/token";
   const storedSource =
     cachedTokenSource ??

--- a/apps/web/src/lib/local-mode.test.ts
+++ b/apps/web/src/lib/local-mode.test.ts
@@ -24,12 +24,14 @@ mock.module("@/runtime/local-mode-host", () => ({
 
 import {
   getActiveAssistant,
+  getLocalGatewayUrl,
   getLocalAssistants,
   getLockfile,
   getPlatformAssistants,
   getSelectedAssistant,
   isLocalAssistant,
   isPlatformAssistant,
+  isRemoteGatewayMode,
   loadLockfile,
   reconcileSelectedAssistant,
   syncPlatformAssistantsToLockfile,
@@ -66,10 +68,34 @@ function setLockfile(lockfile: Lockfile): void {
 }
 
 afterEach(() => {
+  window.__VELLUM_CONFIG__ = undefined;
   useLockfileStore.setState({ lockfile: null, committed: false });
   localStorage.removeItem(LOCKFILE_STORAGE_KEY);
   localStorage.removeItem(SELECTED_ASSISTANT_STORAGE_KEY);
   replacePlatformAssistantsHost.mockClear();
+});
+
+describe("remote gateway mode", () => {
+  test("loads a synthetic active assistant without calling the local host", async () => {
+    window.__VELLUM_CONFIG__ = { mode: "remote-gateway" };
+
+    const lockfile = await loadLockfile();
+
+    expect(isRemoteGatewayMode()).toBe(true);
+    expect(loadLockfileHost).not.toHaveBeenCalled();
+    expect(lockfile.activeAssistant).toBe("self");
+    expect(lockfile.assistants).toEqual([
+      expect.objectContaining({
+        assistantId: "self",
+        cloud: "local",
+        name: "Local Assistant",
+        runtimeUrl: window.location.origin,
+      }),
+    ]);
+    expect(getLocalAssistants().map((a) => a.assistantId)).toEqual(["self"]);
+    expect(getLocalGatewayUrl()).toBeUndefined();
+    expect(useLockfileStore.getState().committed).toBe(true);
+  });
 });
 
 describe("syncPlatformAssistantsToLockfile", () => {
@@ -94,7 +120,10 @@ describe("syncPlatformAssistantsToLockfile", () => {
     const [entries, org] = replacePlatformAssistantsHost.mock.calls[0]!;
     expect(org).toBe("org-1");
     expect(entries).toEqual([
-      expect.objectContaining({ assistantId: "platform-a", organizationId: "org-1" }),
+      expect.objectContaining({
+        assistantId: "platform-a",
+        organizationId: "org-1",
+      }),
     ]);
   });
 
@@ -207,9 +236,7 @@ describe("reconcileSelectedAssistant", () => {
 
     reconcileSelectedAssistant();
 
-    expect(
-      localStorage.getItem(SELECTED_ASSISTANT_STORAGE_KEY),
-    ).toBeNull();
+    expect(localStorage.getItem(SELECTED_ASSISTANT_STORAGE_KEY)).toBeNull();
     expect(getSelectedAssistant()).toBe(localA);
   });
 
@@ -219,7 +246,9 @@ describe("reconcileSelectedAssistant", () => {
 
     reconcileSelectedAssistant();
 
-    expect(localStorage.getItem(SELECTED_ASSISTANT_STORAGE_KEY)).toBe("local-b");
+    expect(localStorage.getItem(SELECTED_ASSISTANT_STORAGE_KEY)).toBe(
+      "local-b",
+    );
     expect(getSelectedAssistant()).toBe(localB);
   });
 
@@ -228,9 +257,7 @@ describe("reconcileSelectedAssistant", () => {
 
     reconcileSelectedAssistant();
 
-    expect(
-      localStorage.getItem(SELECTED_ASSISTANT_STORAGE_KEY),
-    ).toBeNull();
+    expect(localStorage.getItem(SELECTED_ASSISTANT_STORAGE_KEY)).toBeNull();
   });
 
   test("a transient empty-lockfile read does not clear the selection", () => {
@@ -241,7 +268,9 @@ describe("reconcileSelectedAssistant", () => {
 
     getLockfile();
 
-    expect(localStorage.getItem(SELECTED_ASSISTANT_STORAGE_KEY)).toBe("local-a");
+    expect(localStorage.getItem(SELECTED_ASSISTANT_STORAGE_KEY)).toBe(
+      "local-a",
+    );
   });
 });
 

--- a/apps/web/src/lib/local-mode.ts
+++ b/apps/web/src/lib/local-mode.ts
@@ -66,6 +66,44 @@ export function getPlatformRuntimeUrl(): string {
   return injected?.platformUrl || window.location.origin;
 }
 
+function getInjectedConfig(): {
+  disablePlatform?: boolean;
+  mode?: string;
+  platformUrl?: string;
+} {
+  return (
+    (
+      window as unknown as {
+        __VELLUM_CONFIG__?: {
+          disablePlatform?: boolean;
+          mode?: string;
+          platformUrl?: string;
+        };
+      }
+    ).__VELLUM_CONFIG__ ?? {}
+  );
+}
+
+export function isRemoteGatewayMode(): boolean {
+  return getInjectedConfig().mode === "remote-gateway";
+}
+
+function getRemoteGatewayLockfile(): Lockfile {
+  return {
+    assistants: [
+      {
+        assistantId: "self",
+        name: "Local Assistant",
+        cloud: "local",
+        runtimeUrl: window.location.origin,
+        hatchedAt: "1970-01-01T00:00:00.000Z",
+        resources: { gatewayPort: 0, daemonPort: 0 },
+      },
+    ],
+    activeAssistant: "self",
+  };
+}
+
 // Advance the in-memory cache and mirror the lockfile to persisted storage in
 // one step. The mirror lets the synchronous `getLockfile()` hydrate from
 // storage on a cold read before the host transport has responded.
@@ -91,11 +129,7 @@ export function isLocalMode(): boolean {
 }
 
 export function isPlatformDisabled(): boolean {
-  const config = (
-    window as unknown as {
-      __VELLUM_CONFIG__?: { disablePlatform?: boolean };
-    }
-  ).__VELLUM_CONFIG__;
+  const config = getInjectedConfig();
   if (config?.disablePlatform != null) return !!config.disablePlatform;
 
   const raw = import.meta.env.VITE_VELLUM_DISABLE_PLATFORM;
@@ -108,6 +142,12 @@ export function isPlatformDisabled(): boolean {
 }
 
 export async function loadLockfile(): Promise<Lockfile> {
+  if (isRemoteGatewayMode()) {
+    const lockfile = getRemoteGatewayLockfile();
+    commitLockfile(lockfile);
+    return lockfile;
+  }
+
   try {
     const data = await loadLockfileHost();
     commitLockfile(data);
@@ -121,6 +161,12 @@ export async function loadLockfile(): Promise<Lockfile> {
 }
 
 export function getLockfile(): Lockfile {
+  if (isRemoteGatewayMode()) {
+    const lockfile = getRemoteGatewayLockfile();
+    setCachedLockfile(lockfile);
+    return lockfile;
+  }
+
   const cached = getCachedLockfile();
   if (cached) return cached;
 
@@ -152,9 +198,14 @@ export function getLockfile(): Lockfile {
  * making it the active assistant. Silently no-ops on a write failure: the
  * cache only advances once the on-disk write succeeds.
  */
-export async function saveLockfileAssistant(
-  assistant: { assistantId: string; name?: string; cloud: string; runtimeUrl: string; hatchedAt: string; organizationId?: string },
-): Promise<void> {
+export async function saveLockfileAssistant(assistant: {
+  assistantId: string;
+  name?: string;
+  cloud: string;
+  runtimeUrl: string;
+  hatchedAt: string;
+  organizationId?: string;
+}): Promise<void> {
   const result = await saveLockfileAssistantHost(
     assistant,
     assistant.assistantId,
@@ -174,6 +225,8 @@ export async function saveLockfileAssistant(
 export async function setActiveLockfileAssistant(
   assistantId: string,
 ): Promise<void> {
+  if (isRemoteGatewayMode()) return;
+
   const entry = getLockfile().assistants.find(
     (a) => a.assistantId === assistantId,
   );
@@ -194,7 +247,12 @@ export async function setActiveLockfileAssistant(
  * in `assistants` belongs to that org.
  */
 export async function syncPlatformAssistantsToLockfile(
-  assistants: Array<{ id: string; name?: string; is_local: boolean; created: string }>,
+  assistants: Array<{
+    id: string;
+    name?: string;
+    is_local: boolean;
+    created: string;
+  }>,
   organizationId?: string,
   shouldApply: () => boolean = () => true,
 ): Promise<void> {
@@ -354,6 +412,7 @@ export function getLocalGatewayUrl(
   assistant: LockfileAssistant | undefined = getSelectedAssistant(),
 ): string | undefined {
   if (!isLocalMode()) return undefined;
+  if (isRemoteGatewayMode()) return undefined;
   if (!assistant || !isLocalAssistant(assistant)) return undefined;
   return gatewayProxyUrl(assistant.resources!.gatewayPort);
 }

--- a/apps/web/src/stores/auth-store.test.ts
+++ b/apps/web/src/stores/auth-store.test.ts
@@ -21,6 +21,7 @@ let getSessionGates: Array<() => void> | null = null;
 
 let mockIsGatewayAuth = false;
 let mockIsLocalMode = false;
+let mockIsRemoteGatewayMode = false;
 let mockPlatformAssistants: unknown[] = [];
 let mockPrimeError: Error | null = null;
 const setSelectedAssistantMock = mock(async (_id: string | null) => {});
@@ -31,13 +32,29 @@ const primeLocalGatewayConnectionMock = mock(async () => {
 const primeLocalGatewayConnectionWithRepairMock = mock(async () => {
   if (mockPrimeError) throw mockPrimeError;
 });
-const restoreConsentForUserMock = mock((_userId: string | null) => ({ tos: false, ai: false }));
-const persistConsentForUserMock = mock((_userId: string | null, _tos: boolean, _ai: boolean) => {});
+const ensureGatewayTokenMock = mock(async () => {});
+const restoreConsentForUserMock = mock((_userId: string | null) => ({
+  tos: false,
+  ai: false,
+}));
+const persistConsentForUserMock = mock(
+  (_userId: string | null, _tos: boolean, _ai: boolean) => {},
+);
 const resolveServerConsentMock = mock((_consent: unknown) => ({
-  tos: false, ai: false, shareAnalytics: null, shareDiagnostics: null,
+  tos: false,
+  ai: false,
+  shareAnalytics: null,
+  shareDiagnostics: null,
 }));
 
-let mockFetchMeResult: unknown = { id: "user-1", username: "test", email: "test@example.com", first_name: "", last_name: "", consent: null };
+let mockFetchMeResult: unknown = {
+  id: "user-1",
+  username: "test",
+  email: "test@example.com",
+  first_name: "",
+  last_name: "",
+  consent: null,
+};
 let mockFetchMeError: Error | null = null;
 const fetchMeMock = mock(async () => {
   if (mockFetchMeError) throw mockFetchMeError;
@@ -78,7 +95,11 @@ mock.module("@/lib/auth/allauth-client", () => ({
       return { ok: false, status: 401, error: { detail: "Unauthorized" } };
     }
     if (!sessionUser) {
-      return { ok: false, status: getSessionFailStatus, error: { detail: "Unauthorized" } };
+      return {
+        ok: false,
+        status: getSessionFailStatus,
+        error: { detail: "Unauthorized" },
+      };
     }
     return { ok: true, data: { user: sessionUser } };
   },
@@ -95,15 +116,18 @@ mock.module("@/runtime/session-token", () => ({
 mock.module("@/lib/auth/gateway-session", () => ({
   isGatewayAuthEnabled: () => mockIsGatewayAuth,
   isGatewayAuthMode: () => mockIsGatewayAuth,
-  ensureGatewayToken: async () => {},
+  ensureGatewayToken: ensureGatewayTokenMock,
   clearGatewayToken: () => {},
   getLocalTokenUrl: () => "http://localhost/token",
 }));
 
 mock.module("@/lib/local-mode", () => ({
   isLocalMode: () => mockIsLocalMode,
-  isLocalAssistant: (a: { cloud?: string; resources?: { gatewayPort?: number } }) =>
-    a.cloud !== "vellum" && a.resources?.gatewayPort != null,
+  isRemoteGatewayMode: () => mockIsRemoteGatewayMode,
+  isLocalAssistant: (a: {
+    cloud?: string;
+    resources?: { gatewayPort?: number };
+  }) => a.cloud !== "vellum" && a.resources?.gatewayPort != null,
   isPlatformAssistant: (a: { cloud?: string }) => a.cloud === "vellum",
   getPlatformAssistants: () => mockPlatformAssistants,
   getLocalAssistants: () => [],
@@ -227,6 +251,7 @@ beforeEach(() => {
   localStorage.removeItem("vellum:auth:userSnapshot");
   mockIsGatewayAuth = false;
   mockIsLocalMode = false;
+  mockIsRemoteGatewayMode = false;
   mockPlatformAssistants = [];
   mockIsNativePlatform = false;
   mockIsBiometricEnabled = false;
@@ -236,12 +261,20 @@ beforeEach(() => {
   setFromApiMock.mockClear();
   primeLocalGatewayConnectionMock.mockClear();
   primeLocalGatewayConnectionWithRepairMock.mockClear();
+  ensureGatewayTokenMock.mockClear();
   restoreConsentForUserMock.mockClear();
   persistConsentForUserMock.mockClear();
   resolveServerConsentMock.mockClear();
   fetchMeMock.mockClear();
   patchConsentMock.mockClear();
-  mockFetchMeResult = { id: "user-1", username: "test", email: "test@example.com", first_name: "", last_name: "", consent: null };
+  mockFetchMeResult = {
+    id: "user-1",
+    username: "test",
+    email: "test@example.com",
+    first_name: "",
+    last_name: "",
+    consent: null,
+  };
   mockFetchMeError = null;
   clearOrganizationMock.mockClear();
   clearUserScopedStorageMock.mockClear();
@@ -258,12 +291,47 @@ beforeEach(() => {
 });
 
 describe("auth store onboarding flag reconciliation", () => {
+  test("initSession treats remote-gateway mode as an authenticated local session", async () => {
+    mockIsRemoteGatewayMode = true;
+
+    await useAuthStore.getState().initSession();
+
+    expect(primeLocalGatewayConnectionMock).not.toHaveBeenCalled();
+    expect(getSessionCallCount).toBe(0);
+    expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
+    expect(useAuthStore.getState().user?.id).toBe("gateway-local");
+    expect(useAuthStore.getState().platformSession).toBe("absent");
+  });
+
+  test("refreshSession keeps remote-gateway mode authenticated without minting a local token", async () => {
+    mockIsRemoteGatewayMode = true;
+    mockIsGatewayAuth = true;
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
+
+    expect(ensureGatewayTokenMock).not.toHaveBeenCalled();
+    expect(primeLocalGatewayConnectionMock).not.toHaveBeenCalled();
+    expect(getSessionCallCount).toBe(0);
+    expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
+    expect(useAuthStore.getState().user?.id).toBe("gateway-local");
+    expect(useAuthStore.getState().platformSession).toBe("absent");
+  });
+
   test("initSession uses server consent when server has a consent record", async () => {
     sessionUser = { id: "user-1", email: "user@example.com" };
     mockFetchMeResult = {
-      id: "user-1", username: "test", email: "test@example.com",
-      first_name: "", last_name: "",
-      consent: { tos_accepted_version: "2026-06-08", privacy_policy_accepted_version: "2026-06-08", ai_data_sharing_accepted_version: "2026-06-08", share_analytics: true, share_diagnostics: true },
+      id: "user-1",
+      username: "test",
+      email: "test@example.com",
+      first_name: "",
+      last_name: "",
+      consent: {
+        tos_accepted_version: "2026-06-08",
+        privacy_policy_accepted_version: "2026-06-08",
+        ai_data_sharing_accepted_version: "2026-06-08",
+        share_analytics: true,
+        share_diagnostics: true,
+      },
     };
 
     await useAuthStore.getState().initSession();
@@ -310,9 +378,18 @@ describe("auth store onboarding flag reconciliation", () => {
     sessionUser = { id: "user-1", email: "user@example.com" };
     mockPlatformAssistants = [{ assistantId: "p1", cloud: "vellum" }];
     mockFetchMeResult = {
-      id: "user-1", username: "test", email: "test@example.com",
-      first_name: "", last_name: "",
-      consent: { tos_accepted_version: "2026-06-08", privacy_policy_accepted_version: "2026-06-08", ai_data_sharing_accepted_version: "2026-06-08", share_analytics: true, share_diagnostics: true },
+      id: "user-1",
+      username: "test",
+      email: "test@example.com",
+      first_name: "",
+      last_name: "",
+      consent: {
+        tos_accepted_version: "2026-06-08",
+        privacy_policy_accepted_version: "2026-06-08",
+        ai_data_sharing_accepted_version: "2026-06-08",
+        share_analytics: true,
+        share_diagnostics: true,
+      },
     };
 
     await useAuthStore.getState().initSession();
@@ -325,9 +402,18 @@ describe("auth store onboarding flag reconciliation", () => {
   test("refreshSession fetches consent from server for platform users", async () => {
     sessionUser = { id: "user-2", email: "user@example.com" };
     mockFetchMeResult = {
-      id: "user-2", username: "test", email: "user@example.com",
-      first_name: "", last_name: "",
-      consent: { tos_accepted_version: "2026-06-08", privacy_policy_accepted_version: "2026-06-08", ai_data_sharing_accepted_version: "2026-06-08", share_analytics: true, share_diagnostics: true },
+      id: "user-2",
+      username: "test",
+      email: "user@example.com",
+      first_name: "",
+      last_name: "",
+      consent: {
+        tos_accepted_version: "2026-06-08",
+        privacy_policy_accepted_version: "2026-06-08",
+        ai_data_sharing_accepted_version: "2026-06-08",
+        share_analytics: true,
+        share_diagnostics: true,
+      },
     };
 
     await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
@@ -347,14 +433,28 @@ describe("auth store onboarding flag reconciliation", () => {
     mockListAssistantsResult = {
       ok: true,
       status: 200,
-      data: [{ id: "assistant-3", name: "My Assistant", is_local: false, created: "2026-06-05T00:00:00Z" }],
+      data: [
+        {
+          id: "assistant-3",
+          name: "My Assistant",
+          is_local: false,
+          created: "2026-06-05T00:00:00Z",
+        },
+      ],
     };
 
     await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
 
     expect(listAssistantsMock).toHaveBeenCalled();
     expect(syncPlatformAssistantsToLockfileMock).toHaveBeenCalledWith(
-      [{ id: "assistant-3", name: "My Assistant", is_local: false, created: "2026-06-05T00:00:00Z" }],
+      [
+        {
+          id: "assistant-3",
+          name: "My Assistant",
+          is_local: false,
+          created: "2026-06-05T00:00:00Z",
+        },
+      ],
       "org-test",
     );
   });
@@ -366,7 +466,9 @@ describe("auth store onboarding flag reconciliation", () => {
     mockListAssistantsResult = {
       ok: true,
       status: 200,
-      data: [{ id: "assistant-4", is_local: false, created: "2026-06-05T00:00:00Z" }],
+      data: [
+        { id: "assistant-4", is_local: false, created: "2026-06-05T00:00:00Z" },
+      ],
     };
 
     await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
@@ -511,7 +613,6 @@ describe("platform session probe resolution", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(useAuthStore.getState().platformSession).toBe("present");
   });
-
 });
 
 describe("biometric session recovery", () => {
@@ -743,7 +844,10 @@ describe("offline session restore (LUM-2412)", () => {
 
     const raw = localStorage.getItem(SNAPSHOT_KEY);
     expect(raw).not.toBeNull();
-    expect(JSON.parse(raw!)).toMatchObject({ id: "user-9", email: "nine@example.com" });
+    expect(JSON.parse(raw!)).toMatchObject({
+      id: "user-9",
+      email: "nine@example.com",
+    });
   });
 
   test("local-mode platform-assistants boot also restores from cache on transport failure", async () => {

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -25,10 +25,7 @@ import {
   type SessionStatus,
 } from "@/stores/session-status";
 
-import {
-  getSession,
-  logout as allauthLogout,
-} from "@/lib/auth/allauth-client";
+import { getSession, logout as allauthLogout } from "@/lib/auth/allauth-client";
 import {
   clearUserSnapshot,
   persistUserSnapshot,
@@ -44,6 +41,7 @@ import {
 } from "@/lib/auth/gateway-session";
 import {
   isLocalMode,
+  isRemoteGatewayMode,
   getPlatformAssistants,
   getLocalAssistants,
   primeLocalGatewayConnection,
@@ -54,14 +52,30 @@ import { listAssistants } from "@/assistant/api";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { deleteBiometricToken } from "@/runtime/native-biometric";
 import { fetchMe, patchConsent } from "@/domains/account/profile";
-import { restoreConsentForUser, persistConsentForUser, resolveServerConsent, CONSENT_VERSION } from "@/utils/onboarding-cleanup";
+import {
+  restoreConsentForUser,
+  persistConsentForUser,
+  resolveServerConsent,
+  CONSENT_VERSION,
+} from "@/utils/onboarding-cleanup";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
-import { clearOrganization, useOrganizationStore } from "@/stores/organization-store";
+import {
+  clearOrganization,
+  useOrganizationStore,
+} from "@/stores/organization-store";
 import { clearUserScopedStorage } from "@/lib/auth/session-cleanup";
 import { subscribe } from "@/lib/event-bus";
 import { isElectron } from "@/runtime/is-electron";
-import { isNativePlatform, isOAuthFlowInFlight, installSessionCookies, waitForNativeSessionCookie } from "@/runtime/native-auth";
-import { isBiometricEnabled, retrieveBiometricToken } from "@/runtime/native-biometric";
+import {
+  isNativePlatform,
+  isOAuthFlowInFlight,
+  installSessionCookies,
+  waitForNativeSessionCookie,
+} from "@/runtime/native-auth";
+import {
+  isBiometricEnabled,
+  retrieveBiometricToken,
+} from "@/runtime/native-biometric";
 
 export interface AuthUser {
   id: string | null;
@@ -143,7 +157,9 @@ const GATEWAY_LOCAL_USER: AuthUser = {
  * `platformSession` is left untouched by transitions that don't know it yet
  * (a follow-up probe settles it); transitions that do know it set it inline.
  */
-const authenticatedPlatformUser = (user: AuthUser | null): Partial<AuthState> => {
+const authenticatedPlatformUser = (
+  user: AuthUser | null,
+): Partial<AuthState> => {
   // Entering this state is the one place a platform session is freshly
   // confirmed — persist the snapshot here so every confirmation path
   // (boot, refresh, connect, biometric retry) feeds the offline restore
@@ -233,8 +249,10 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
         const store = useOnboardingStore.getState();
         store.setTosAccepted(resolved.tos);
         store.setAiDataConsent(resolved.ai);
-        if (resolved.shareAnalytics !== null) store.setShareAnalytics(resolved.shareAnalytics);
-        if (resolved.shareDiagnostics !== null) store.setShareDiagnostics(resolved.shareDiagnostics);
+        if (resolved.shareAnalytics !== null)
+          store.setShareAnalytics(resolved.shareAnalytics);
+        if (resolved.shareDiagnostics !== null)
+          store.setShareDiagnostics(resolved.shareDiagnostics);
         persistConsentForUser(nextUserId, resolved.tos, resolved.ai);
         syncOrganizationState(nextUserId);
         return;
@@ -346,7 +364,8 @@ function probePlatformSession(
                 if (syncIsCurrent() && apiAssistants.ok) {
                   await syncPlatformAssistantsToLockfile(
                     apiAssistants.data,
-                    useOrganizationStore.getState().currentOrganizationId ?? undefined,
+                    useOrganizationStore.getState().currentOrganizationId ??
+                      undefined,
                     syncIsCurrent,
                   );
                 }
@@ -422,7 +441,11 @@ function probePlatformSessionIfReachable(
   set: AuthSet,
   options?: { setUserOnSuccess?: boolean; clearOnFailure?: boolean },
 ): void {
-  if (!isLocalMode() || isGatewayAuthEnabled() || getPlatformAssistants().length > 0) {
+  if (
+    !isLocalMode() ||
+    isGatewayAuthEnabled() ||
+    getPlatformAssistants().length > 0
+  ) {
     probePlatformSession(set, options);
   } else {
     set({ platformSession: "absent" });
@@ -435,6 +458,11 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
   platformSession: "unknown",
 
   initSession: async () => {
+    if (isRemoteGatewayMode()) {
+      set({ ...authenticatedLocalUser(), platformSession: "absent" });
+      return;
+    }
+
     if (isGatewayAuthEnabled()) {
       try {
         await primeLocalGatewayConnection();
@@ -466,7 +494,8 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
               if (apiAssistants.ok) {
                 await syncPlatformAssistantsToLockfile(
                   apiAssistants.data,
-                  useOrganizationStore.getState().currentOrganizationId ?? undefined,
+                  useOrganizationStore.getState().currentOrganizationId ??
+                    undefined,
                 );
               }
             } catch {
@@ -509,9 +538,13 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
           await useOrganizationStore.getState().fetchOrganizations();
           const apiAssistants = await listAssistants();
           if (apiAssistants.ok) {
-            useResolvedAssistantsStore.getState().setFromApi(apiAssistants.data);
+            useResolvedAssistantsStore
+              .getState()
+              .setFromApi(apiAssistants.data);
           }
-        } catch { /* best effort */ }
+        } catch {
+          /* best effort */
+        }
         set(authenticatedPlatformUser(user));
         return;
       }
@@ -543,9 +576,13 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
               await useOrganizationStore.getState().fetchOrganizations();
               const apiAssistants = await listAssistants();
               if (apiAssistants.ok) {
-                useResolvedAssistantsStore.getState().setFromApi(apiAssistants.data);
+                useResolvedAssistantsStore
+                  .getState()
+                  .setFromApi(apiAssistants.data);
               }
-            } catch { /* best effort */ }
+            } catch {
+              /* best effort */
+            }
             set(authenticatedPlatformUser(user));
             return;
           }
@@ -617,6 +654,11 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
   },
 
   refreshSession: async () => {
+    if (isRemoteGatewayMode()) {
+      set({ ...authenticatedLocalUser(), platformSession: "absent" });
+      return true;
+    }
+
     if (isGatewayAuthMode()) {
       try {
         await ensureGatewayToken(getLocalTokenUrl());
@@ -648,7 +690,8 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
             if (apiAssistants.ok) {
               await syncPlatformAssistantsToLockfile(
                 apiAssistants.data,
-                useOrganizationStore.getState().currentOrganizationId ?? undefined,
+                useOrganizationStore.getState().currentOrganizationId ??
+                  undefined,
               );
             }
           } catch {
@@ -701,7 +744,8 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
       // Clean up session token in the main process.
       if (isElectron()) await window.vellum?.auth?.signOut?.();
       if (isLocalMode()) {
-        document.cookie = "sessionid=; path=/; samesite=lax; expires=Thu, 01 Jan 1970 00:00:00 UTC";
+        document.cookie =
+          "sessionid=; path=/; samesite=lax; expires=Thu, 01 Jan 1970 00:00:00 UTC";
       }
       void deleteBiometricToken();
       clearOrganization();

--- a/cli/src/__tests__/nginx-ingress.test.ts
+++ b/cli/src/__tests__/nginx-ingress.test.ts
@@ -21,6 +21,7 @@ mock.module("node:child_process", () => ({
 
 import {
   buildIngressNginxConfig,
+  buildRemoteWebIndexHtml,
   resolveTunnelTargetPort,
   stopIngressNginx,
 } from "../lib/nginx-ingress.js";
@@ -29,6 +30,18 @@ const originalKill = process.kill;
 
 describe("buildIngressNginxConfig", () => {
   const conf = buildIngressNginxConfig({ gatewayPort: 7830, listenPort: 7840 });
+  const remoteConf = buildIngressNginxConfig({
+    gatewayPort: 7830,
+    listenPort: 7840,
+    remoteWebIngress: {
+      webDistDir: "/tmp/vellum web/dist",
+      config: {
+        mode: "remote-gateway",
+        apiBaseUrl: "/v1",
+        platformDisabled: true,
+      },
+    },
+  });
 
   test("listens on loopback only", () => {
     expect(conf).toContain("listen 127.0.0.1:7840;");
@@ -42,10 +55,95 @@ describe("buildIngressNginxConfig", () => {
   test("proxies requests to the gateway", () => {
     expect(conf).toContain("location / {");
     expect(conf).toContain("proxy_pass http://127.0.0.1:7830;");
+    expect(conf).toContain('proxy_set_header X-Vellum-Edge-Forwarded "1";');
     expect(conf).not.toContain("return 404;");
     expect(conf).not.toContain("return 403;");
     expect(conf).not.toContain("location =");
     expect(conf).not.toContain("location ~");
+  });
+
+  test("declares static MIME types needed by the SPA", () => {
+    expect(remoteConf).toContain("default_type application/octet-stream;");
+    expect(remoteConf).toContain("types {");
+    expect(remoteConf).toContain("application/javascript js mjs;");
+    expect(remoteConf).toContain("text/css css;");
+    expect(remoteConf).toContain("text/html html htm;");
+    expect(remoteConf).toContain("font/woff2 woff2;");
+    expect(remoteConf).toContain("image/svg+xml svg svgz;");
+  });
+
+  test("serves the remote web SPA from /assistant when configured", () => {
+    expect(remoteConf).toContain("location = / {");
+    expect(remoteConf).toContain("return 302 /assistant/;");
+    expect(remoteConf.indexOf("location = / {")).toBeLessThan(
+      remoteConf.indexOf("location / {"),
+    );
+    expect(remoteConf).toContain("location = /assistant {");
+    expect(remoteConf).toContain("return 302 /assistant/;");
+    expect(remoteConf).toContain("location ^~ /assistant/assets/ {");
+    expect(remoteConf).toContain('alias "/tmp/vellum web/dist/assets/";');
+    expect(remoteConf).toContain("try_files $uri =404;");
+    expect(remoteConf).toContain("location = /assistant/ {");
+    expect(remoteConf).toContain(
+      "rewrite ^ /assistant/__remote-index.html last;",
+    );
+    expect(remoteConf).toContain("location = /assistant/index.html {");
+    expect(remoteConf).toContain("location = /assistant/__remote-index.html {");
+    expect(remoteConf).toContain("internal;");
+    expect(remoteConf).toContain('alias "/tmp/vellum web/dist/index.html";');
+    expect(remoteConf).toContain("location ^~ /assistant/ {");
+    expect(remoteConf).toContain('alias "/tmp/vellum web/dist/";');
+    expect(remoteConf).toContain(
+      "try_files $uri $uri/ /assistant/__remote-index.html;",
+    );
+    expect(remoteConf).toContain("location / {\n      return 404;\n    }");
+  });
+
+  test("serves remote web config for the SPA", () => {
+    expect(remoteConf).toContain("location = /assistant/__config {");
+    expect(remoteConf).toContain("default_type application/json;");
+    expect(remoteConf).toContain('add_header Cache-Control "no-store";');
+    expect(remoteConf).toContain(
+      'return 200 "{\\"mode\\":\\"remote-gateway\\",\\"apiBaseUrl\\":\\"/v1\\",\\"platformDisabled\\":true,\\"disablePlatform\\":true}";',
+    );
+  });
+
+  test("proxies health and public API traffic to the gateway in remote web mode", () => {
+    expect(remoteConf).toContain("location = /healthz {");
+    expect(remoteConf).toContain("location ^~ /v1/ {");
+    expect(remoteConf).toContain("proxy_pass http://127.0.0.1:7830;");
+    expect(remoteConf).toContain("proxy_request_buffering off;");
+    expect(remoteConf).toContain("proxy_buffering off;");
+    expect(remoteConf).toContain(
+      'proxy_set_header X-Vellum-Edge-Forwarded "1";',
+    );
+  });
+
+  test("blocks local-only bootstrap helpers before generic API proxying", () => {
+    const deniedLocations = [
+      "location = /auth/token { return 404; }",
+      "location = /auth/token/ { return 404; }",
+      "location = /v1/pair { return 404; }",
+      "location = /v1/pair/ { return 404; }",
+      "location = /v1/pair/web-init { return 404; }",
+      "location = /v1/pair/web-init/ { return 404; }",
+      "location = /v1/devices { return 404; }",
+      "location = /v1/devices/ { return 404; }",
+      "location = /v1/devices/revoke { return 404; }",
+      "location = /v1/devices/revoke/ { return 404; }",
+      "location = /v1/guardian/init { return 404; }",
+      "location = /v1/guardian/init/ { return 404; }",
+      "location = /v1/guardian/reset-bootstrap { return 404; }",
+      "location = /v1/guardian/reset-bootstrap/ { return 404; }",
+      "location ^~ /assistant/__local/ { return 404; }",
+      "location ^~ /assistant/__gateway/ { return 404; }",
+    ];
+    for (const location of deniedLocations) {
+      expect(remoteConf).toContain(location);
+      expect(remoteConf.indexOf(location)).toBeLessThan(
+        remoteConf.indexOf("location ^~ /v1/ {"),
+      );
+    }
   });
 
   test("supports websockets and SSE streaming", () => {
@@ -56,6 +154,37 @@ describe("buildIngressNginxConfig", () => {
     expect(conf).toContain("proxy_request_buffering off;");
     expect(conf).toContain("proxy_buffering off;");
     expect(conf).toContain("proxy_read_timeout 1h;");
+  });
+});
+
+describe("buildRemoteWebIndexHtml", () => {
+  test("injects the remote gateway config after any bundled local config", () => {
+    const html =
+      '<html><head><script>window.__VELLUM_CONFIG__={"webUrl":"https://www.vellum.ai"}</script></head><body></body></html>';
+    const result = buildRemoteWebIndexHtml(html, {
+      mode: "remote-gateway",
+      apiBaseUrl: "/v1",
+      disablePlatform: true,
+    });
+
+    expect(result).toContain(
+      'window.__VELLUM_CONFIG__={"webUrl":"https://www.vellum.ai"}',
+    );
+    expect(result).toContain(
+      'window.__VELLUM_CONFIG__={"mode":"remote-gateway","apiBaseUrl":"/v1","disablePlatform":true}',
+    );
+    expect(result.indexOf('"webUrl"')).toBeLessThan(
+      result.indexOf('"remote-gateway"'),
+    );
+  });
+
+  test("escapes config JSON before embedding it in a script tag", () => {
+    const result = buildRemoteWebIndexHtml("</head>", {
+      value: "</script><script>alert(1)</script>",
+    });
+
+    expect(result).not.toContain("</script><script>alert(1)</script>");
+    expect(result).toContain("\\u003c/script\\u003e");
   });
 });
 

--- a/cli/src/__tests__/tunnel.test.ts
+++ b/cli/src/__tests__/tunnel.test.ts
@@ -74,6 +74,19 @@ function writeLockfile(entry: AssistantEntry): void {
   );
 }
 
+function mockEnabledFlagFetch() {
+  const fetchMock = mock(async (_input: string, _init?: RequestInit) => {
+    return new Response(
+      JSON.stringify({
+        flags: [{ key: "web-remote-ingress", enabled: true }],
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  });
+  globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+  return fetchMock;
+}
+
 describe("tunnel nginx ingress feature flag", () => {
   beforeEach(() => {
     process.argv = ["bun", "vellum", "tunnel"];
@@ -113,6 +126,28 @@ describe("tunnel nginx ingress feature flag", () => {
     );
 
     expect(runNgrokTunnelMock).not.toHaveBeenCalled();
+    expect(runCloudflareTunnelMock).not.toHaveBeenCalled();
+  });
+
+  test("checks the nginx flag through the local gateway for ngrok", async () => {
+    const entry = makeLocalEntry();
+    entry.runtimeUrl = "https://stale-tunnel.ngrok-free.dev";
+    writeLockfile(entry);
+    process.argv = ["bun", "vellum", "tunnel", "--provider", "ngrok"];
+    const fetchMock = mockEnabledFlagFetch();
+
+    await tunnel();
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(
+      "http://127.0.0.1:7830/v1/assistants/assistant-1/feature-flags",
+    );
+    expect(init?.method).toBe("GET");
+    expect(runNgrokTunnelMock).toHaveBeenCalledWith({
+      port: 7830,
+      workspaceDir: join(entry.resources!.instanceDir, ".vellum", "workspace"),
+      preferNginxIngress: true,
+    });
     expect(runCloudflareTunnelMock).not.toHaveBeenCalled();
   });
 

--- a/cli/src/commands/nginx-ingress.ts
+++ b/cli/src/commands/nginx-ingress.ts
@@ -17,6 +17,7 @@ import {
 import { waitForDaemonReady } from "../lib/http-client.js";
 import {
   DEFAULT_NGINX_INGRESS_PORT,
+  findWebDistDir,
   getIngressPaths,
   getIngressPid,
   getNginxIngressPort,
@@ -33,14 +34,12 @@ function printHelp(): void {
   console.log("Usage: vellum nginx-ingress <subcommand> [<name>] [options]");
   console.log("");
   console.log(
-    "Manage the nginx reverse proxy that fronts the gateway for remote web",
+    "Manage the nginx web edge that serves the SPA and fronts the gateway",
   );
   console.log(
-    "access: browser → tunnel (TLS) → nginx@127.0.0.1 → gateway. While the",
+    "for remote web access: browser → tunnel (TLS) → nginx@127.0.0.1.",
   );
-  console.log(
-    "nginx ingress is running, `vellum tunnel` targets it instead of the gateway.",
-  );
+  console.log("While nginx ingress is running, `vellum tunnel` targets it.");
   console.log("");
   console.log("Subcommands:");
   console.log("  up       Generate the nginx config and start the proxy");
@@ -148,6 +147,7 @@ async function assertWebRemoteIngressEnabled(
     enabled = await isAssistantFeatureFlagEnabled(
       target.assistantId,
       WEB_REMOTE_INGRESS_FLAG,
+      { runtimeUrl: `http://127.0.0.1:${target.gatewayPort}` },
     );
   } catch (err) {
     throw new Error(
@@ -188,15 +188,31 @@ async function up(target: NginxIngressTarget): Promise<void> {
     return;
   }
 
+  const webDistDir = findWebDistDir();
+  if (!webDistDir) {
+    console.error(
+      "Error: unable to locate built web assets for remote web ingress.",
+    );
+    console.error("");
+    console.error("Build the SPA first:");
+    console.error("  cd apps/web && VITE_PLATFORM_MODE=false bun run build");
+    console.error("");
+    console.error(
+      "Or install @vellumai/web so its packaged dist directory is available.",
+    );
+    process.exit(1);
+  }
+
   console.log(`Using ${version}`);
   console.log(
-    `Starting nginx ingress on 127.0.0.1:${listenPort} → gateway 127.0.0.1:${gatewayPort}...`,
+    `Starting nginx ingress on 127.0.0.1:${listenPort} → web ${webDistDir} + gateway 127.0.0.1:${gatewayPort}...`,
   );
 
   const child = startIngressNginx({
     workspaceDir,
     gatewayPort,
     listenPort,
+    remoteWebIngress: { webDistDir },
   });
   child.unref();
 

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -1,7 +1,8 @@
 import { join } from "path";
 
-import { resolveAssistant } from "../lib/assistant-config";
+import { resolveAssistant, type AssistantEntry } from "../lib/assistant-config";
 import { runCloudflareTunnel } from "../lib/cloudflare-tunnel.js";
+import { GATEWAY_PORT } from "../lib/constants.js";
 import {
   isAssistantFeatureFlagEnabled,
   WEB_REMOTE_INGRESS_FLAG,
@@ -92,11 +93,36 @@ function parseArgs(): TunnelArgs {
   return { assistantName, provider };
 }
 
-async function shouldPreferNginxIngress(assistantId: string): Promise<boolean> {
+function parsePortFromUrl(url: unknown): number | undefined {
+  if (typeof url !== "string" || !url.trim()) return undefined;
+  try {
+    const port = Number(new URL(url).port);
+    return Number.isInteger(port) && port > 0 && port <= 65535
+      ? port
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveEntryGatewayPort(entry: AssistantEntry): number {
+  return (
+    entry.resources?.gatewayPort ??
+    parsePortFromUrl(entry.localUrl) ??
+    parsePortFromUrl(entry.runtimeUrl) ??
+    GATEWAY_PORT
+  );
+}
+
+async function shouldPreferNginxIngress(
+  assistantId: string,
+  gatewayPort: number,
+): Promise<boolean> {
   try {
     return await isAssistantFeatureFlagEnabled(
       assistantId,
       WEB_REMOTE_INGRESS_FLAG,
+      { runtimeUrl: `http://127.0.0.1:${gatewayPort}` },
     );
   } catch (err) {
     throw new Error(
@@ -124,17 +150,21 @@ export async function tunnel(): Promise<void> {
   }
 
   const resources = entry.resources;
-  const baseTunnelOpts = resources
-    ? {
-        port: resources.gatewayPort,
-        workspaceDir: join(resources.instanceDir, ".vellum", "workspace"),
-      }
-    : {};
+  const gatewayPort = resolveEntryGatewayPort(entry);
+  const baseTunnelOpts = {
+    port: gatewayPort,
+    ...(resources
+      ? { workspaceDir: join(resources.instanceDir, ".vellum", "workspace") }
+      : {}),
+  };
 
   if (provider === "ngrok") {
     await runNgrokTunnel({
       ...baseTunnelOpts,
-      preferNginxIngress: await shouldPreferNginxIngress(entry.assistantId),
+      preferNginxIngress: await shouldPreferNginxIngress(
+        entry.assistantId,
+        gatewayPort,
+      ),
     });
     return;
   }
@@ -142,7 +172,10 @@ export async function tunnel(): Promise<void> {
   if (provider === "cloudflare") {
     await runCloudflareTunnel({
       ...baseTunnelOpts,
-      preferNginxIngress: await shouldPreferNginxIngress(entry.assistantId),
+      preferNginxIngress: await shouldPreferNginxIngress(
+        entry.assistantId,
+        gatewayPort,
+      ),
     });
     return;
   }

--- a/cli/src/lib/assistant-client.ts
+++ b/cli/src/lib/assistant-client.ts
@@ -26,6 +26,7 @@ const FALLBACK_RUNTIME_URL = `http://127.0.0.1:${GATEWAY_PORT}`;
 
 export interface AssistantClientOpts {
   assistantId?: string;
+  runtimeUrl?: string;
   /**
    * When provided alongside `orgId`, the client authenticates with a
    * session token instead of a guardian token.  The session token is
@@ -73,6 +74,7 @@ export class AssistantClient {
     }
 
     this.runtimeUrl = (
+      opts?.runtimeUrl ||
       entry.localUrl ||
       entry.runtimeUrl ||
       FALLBACK_RUNTIME_URL

--- a/cli/src/lib/feature-flags.test.ts
+++ b/cli/src/lib/feature-flags.test.ts
@@ -52,6 +52,16 @@ function mockFetch(response: Response): void {
   globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
 }
 
+function mockFetchWithUrls(response: Response): string[] {
+  const urls: string[] = [];
+  const fetchMock = async (input: RequestInfo | URL) => {
+    urls.push(String(input));
+    return response;
+  };
+  globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+  return urls;
+}
+
 describe("isAssistantFeatureFlagEnabled", () => {
   beforeEach(() => {
     process.env.VELLUM_LOCKFILE_DIR = testDir;
@@ -82,6 +92,41 @@ describe("isAssistantFeatureFlagEnabled", () => {
     await expect(
       isAssistantFeatureFlagEnabled("assistant-1", WEB_REMOTE_INGRESS_FLAG),
     ).resolves.toBe(true);
+  });
+
+  test("uses the supplied runtime URL instead of a stale lockfile runtimeUrl", async () => {
+    writeFileSync(
+      join(testDir, ".vellum.lock.json"),
+      JSON.stringify(
+        {
+          activeAssistant: "assistant-1",
+          assistants: [
+            {
+              assistantId: "assistant-1",
+              runtimeUrl: "https://stale-tunnel.ngrok-free.dev",
+              cloud: "local",
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+    );
+    const urls = mockFetchWithUrls(
+      jsonResponse({
+        flags: [{ key: WEB_REMOTE_INGRESS_FLAG, enabled: true }],
+      }),
+    );
+
+    await expect(
+      isAssistantFeatureFlagEnabled("assistant-1", WEB_REMOTE_INGRESS_FLAG, {
+        runtimeUrl: "http://127.0.0.1:9123",
+      }),
+    ).resolves.toBe(true);
+
+    expect(urls).toEqual([
+      "http://127.0.0.1:9123/v1/assistants/assistant-1/feature-flags",
+    ]);
   });
 
   test("returns false when the assistant flag is disabled or missing", async () => {

--- a/cli/src/lib/feature-flags.ts
+++ b/cli/src/lib/feature-flags.ts
@@ -14,8 +14,12 @@ type FeatureFlagsResponse = {
 export async function isAssistantFeatureFlagEnabled(
   assistantId: string,
   key: string,
+  opts: { runtimeUrl?: string } = {},
 ): Promise<boolean> {
-  const client = new AssistantClient({ assistantId });
+  const client = new AssistantClient({
+    assistantId,
+    runtimeUrl: opts.runtimeUrl,
+  });
   const res = await client.get("/feature-flags");
   if (!res.ok) {
     const body = await res.text().catch(() => "");

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -13,6 +13,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 
 import { GATEWAY_PORT } from "./constants.js";
@@ -26,6 +27,7 @@ import { GATEWAY_PORT } from "./constants.js";
  */
 
 export const DEFAULT_NGINX_INGRESS_PORT = 7840;
+const _require = createRequire(import.meta.url);
 
 /** Listen port for nginx ingress, from VELLUM_NGINX_INGRESS_PORT. */
 export function getNginxIngressPort(): number {
@@ -79,12 +81,118 @@ function saveRawConfig(
 }
 
 /**
+ * Locate the pre-built @vellumai/web dist directory.
+ *
+ * Resolution order:
+ *   1. npm-installed package — require.resolve('@vellumai/web/package.json')
+ *   2. Source checkout — walk up from cli/ to find apps/web/dist/
+ */
+export function findWebDistDir(): string | null {
+  try {
+    const pkgPath = _require.resolve("@vellumai/web/package.json");
+    const distDir = join(dirname(pkgPath), "dist");
+    if (existsSync(join(distDir, "index.html"))) {
+      return distDir;
+    }
+  } catch {
+    // Package not installed; try source checkout.
+  }
+
+  let dir = import.meta.dir;
+  for (let depth = 0; depth < 8; depth++) {
+    const candidate = join(dir, "apps", "web", "dist", "index.html");
+    if (existsSync(candidate)) {
+      return dirname(candidate);
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+function nginxQuoted(value: string, label: string): string {
+  if (/[\u0000-\u001f\u007f]/.test(value)) {
+    throw new Error(`${label} contains a control character`);
+  }
+  return `"${value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\$/g, "\\$")}"`;
+}
+
+function nginxDirPath(dir: string): string {
+  return dir.endsWith("/") ? dir : `${dir}/`;
+}
+
+function gatewayProxyBlock(gatewayPort: number): string {
+  return `      proxy_pass http://127.0.0.1:${gatewayPort};
+      proxy_http_version 1.1;
+      proxy_request_buffering off;
+      proxy_buffering off;
+      proxy_read_timeout 1h;
+      proxy_set_header Host $host;
+      proxy_set_header X-Vellum-Edge-Forwarded "1";
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;`;
+}
+
+export interface RemoteWebIngressOptions {
+  webDistDir: string;
+  indexHtmlPath?: string;
+  config?: Record<string, unknown>;
+}
+
+function remoteWebIngressConfig(
+  config: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  return {
+    mode: "remote-gateway",
+    apiBaseUrl: "/v1",
+    platformDisabled: true,
+    disablePlatform: true,
+    ...config,
+  };
+}
+
+function safeScriptJson(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e");
+}
+
+export function buildRemoteWebIndexHtml(
+  rawHtml: string,
+  config: Record<string, unknown>,
+): string {
+  const script = `<script>window.__VELLUM_CONFIG__=${safeScriptJson(config)}</script>`;
+  if (rawHtml.includes("</head>")) {
+    return rawHtml.replace("</head>", `${script}</head>`);
+  }
+  return `${script}${rawHtml}`;
+}
+
+/**
  * Build the nginx config that forwards tunnel web traffic to the gateway.
  */
 export function buildIngressNginxConfig(opts: {
   gatewayPort: number;
   listenPort: number;
+  remoteWebIngress?: RemoteWebIngressOptions;
 }): string {
+  const proxyBlock = gatewayProxyBlock(opts.gatewayPort);
+  const remoteWebIngress = opts.remoteWebIngress;
+  const serverLocations = remoteWebIngress
+    ? buildRemoteWebIngressLocations({
+        gatewayPort: opts.gatewayPort,
+        webDistDir: remoteWebIngress.webDistDir,
+        indexHtmlPath: remoteWebIngress.indexHtmlPath,
+        config: remoteWebIngressConfig(remoteWebIngress.config),
+      })
+    : `    location / {
+${proxyBlock}
+    }`;
+
   return `
 worker_processes 1;
 error_log stderr;
@@ -94,6 +202,24 @@ events {}
 
 http {
   access_log off;
+  default_type application/octet-stream;
+
+  types {
+    application/javascript js mjs;
+    application/json json map;
+    application/wasm wasm;
+    font/woff woff;
+    font/woff2 woff2;
+    image/gif gif;
+    image/jpeg jpeg jpg;
+    image/png png;
+    image/svg+xml svg svgz;
+    image/webp webp;
+    image/x-icon ico;
+    text/css css;
+    text/html html htm;
+    text/plain txt;
+  }
 
   map $http_upgrade $connection_upgrade {
     default upgrade;
@@ -104,19 +230,93 @@ http {
     listen 127.0.0.1:${opts.listenPort};
     client_max_body_size 512m;
 
-    location / {
-      proxy_pass http://127.0.0.1:${opts.gatewayPort};
-      proxy_http_version 1.1;
-      proxy_request_buffering off;
-      proxy_buffering off;
-      proxy_read_timeout 1h;
-      proxy_set_header Host $host;
-      proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection $connection_upgrade;
-    }
+${serverLocations}
   }
 }
 `;
+}
+
+function buildRemoteWebIngressLocations(opts: {
+  gatewayPort: number;
+  webDistDir: string;
+  indexHtmlPath?: string;
+  config: Record<string, unknown>;
+}): string {
+  const proxyBlock = gatewayProxyBlock(opts.gatewayPort);
+  const webDistDir = nginxDirPath(opts.webDistDir);
+  const webAssetsDir = join(opts.webDistDir, "assets");
+  const indexHtmlPath =
+    opts.indexHtmlPath ?? join(opts.webDistDir, "index.html");
+  const configJson = JSON.stringify(opts.config);
+
+  return `    location = /auth/token { return 404; }
+    location = /auth/token/ { return 404; }
+    location = /v1/pair { return 404; }
+    location = /v1/pair/ { return 404; }
+    location = /v1/pair/web-init { return 404; }
+    location = /v1/pair/web-init/ { return 404; }
+    location = /v1/devices { return 404; }
+    location = /v1/devices/ { return 404; }
+    location = /v1/devices/revoke { return 404; }
+    location = /v1/devices/revoke/ { return 404; }
+    location = /v1/guardian/init { return 404; }
+    location = /v1/guardian/init/ { return 404; }
+    location = /v1/guardian/reset-bootstrap { return 404; }
+    location = /v1/guardian/reset-bootstrap/ { return 404; }
+    location ^~ /assistant/__local/ { return 404; }
+    location ^~ /assistant/__gateway/ { return 404; }
+
+    location = /healthz {
+${proxyBlock}
+    }
+
+    location ^~ /v1/ {
+${proxyBlock}
+    }
+
+    location = /assistant {
+      return 302 /assistant/;
+    }
+
+    location = /assistant/ {
+      rewrite ^ /assistant/__remote-index.html last;
+    }
+
+    location = /assistant/index.html {
+      rewrite ^ /assistant/__remote-index.html last;
+    }
+
+    location = /assistant/__remote-index.html {
+      internal;
+      alias ${nginxQuoted(indexHtmlPath, "remote web ingress index path")};
+      add_header Cache-Control "no-store";
+    }
+
+    location = /assistant/__config {
+      default_type application/json;
+      add_header Cache-Control "no-store";
+      return 200 ${nginxQuoted(configJson, "remote web ingress config")};
+    }
+
+    location ^~ /assistant/assets/ {
+      alias ${nginxQuoted(nginxDirPath(webAssetsDir), "web assets path")};
+      try_files $uri =404;
+      add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
+    location ^~ /assistant/ {
+      alias ${nginxQuoted(webDistDir, "web dist path")};
+      try_files $uri $uri/ /assistant/__remote-index.html;
+      add_header Cache-Control "no-store";
+    }
+
+    location = / {
+      return 302 /assistant/;
+    }
+
+    location / {
+      return 404;
+    }`;
 }
 
 function nginxBin(): string {
@@ -250,15 +450,34 @@ export function startIngressNginx(opts: {
   workspaceDir: string;
   gatewayPort: number;
   listenPort: number;
+  remoteWebIngress?: RemoteWebIngressOptions;
 }): ChildProcess {
   const paths = getIngressPaths(opts.workspaceDir);
   mkdirSync(paths.dir, { recursive: true });
   mkdirSync(join(opts.workspaceDir, "data", "logs"), { recursive: true });
+  const remoteWebIngress = opts.remoteWebIngress
+    ? {
+        ...opts.remoteWebIngress,
+        config: remoteWebIngressConfig(opts.remoteWebIngress.config),
+        indexHtmlPath: join(paths.dir, "assistant-index.html"),
+      }
+    : undefined;
+  if (remoteWebIngress) {
+    const rawIndexHtml = readFileSync(
+      join(remoteWebIngress.webDistDir, "index.html"),
+      "utf-8",
+    );
+    writeFileSync(
+      remoteWebIngress.indexHtmlPath,
+      buildRemoteWebIndexHtml(rawIndexHtml, remoteWebIngress.config),
+    );
+  }
   writeFileSync(
     paths.confPath,
     buildIngressNginxConfig({
       gatewayPort: opts.gatewayPort,
       listenPort: opts.listenPort,
+      remoteWebIngress,
     }),
   );
 

--- a/gateway/src/__tests__/remote-web-ingress-denylist.test.ts
+++ b/gateway/src/__tests__/remote-web-ingress-denylist.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const gatewayIndexSource = readFileSync(
+  join(import.meta.dir, "..", "index.ts"),
+  "utf8",
+);
+
+const nginxIngressSource = readFileSync(
+  join(
+    import.meta.dir,
+    "..",
+    "..",
+    "..",
+    "cli",
+    "src",
+    "lib",
+    "nginx-ingress.ts",
+  ),
+  "utf8",
+);
+
+function extractGatewayRouteObjects(): string[] {
+  const routesStart = gatewayIndexSource.indexOf(
+    "const routes: RouteDefinition[] = [",
+  );
+  const routesEnd = gatewayIndexSource.indexOf(
+    "// Runtime proxy catch-all",
+    routesStart,
+  );
+  expect(routesStart).toBeGreaterThanOrEqual(0);
+  expect(routesEnd).toBeGreaterThan(routesStart);
+
+  const routesSource = gatewayIndexSource.slice(routesStart, routesEnd);
+  return routesSource.split(/\n    \},\n/);
+}
+
+function extractUnprotectedStaticV1Routes(): string[] {
+  return extractGatewayRouteObjects()
+    .flatMap((routeObject) => {
+      const path = routeObject.match(/path:\s*"([^"]+)"/)?.[1];
+      if (!path?.startsWith("/v1/")) return [];
+
+      const auth = routeObject.match(/auth:\s*"([^"]+)"/)?.[1];
+      return auth === undefined || auth === "none" ? [path] : [];
+    })
+    .sort();
+}
+
+function assertDeniedBeforeV1Proxy(path: string): void {
+  const proxyIndex = nginxIngressSource.indexOf("location ^~ /v1/ {");
+  expect(proxyIndex).toBeGreaterThanOrEqual(0);
+
+  for (const deniedPath of [path, `${path}/`]) {
+    const location = `location = ${deniedPath} { return 404; }`;
+    const locationIndex = nginxIngressSource.indexOf(location);
+    expect(locationIndex).toBeGreaterThanOrEqual(0);
+    expect(locationIndex).toBeLessThan(proxyIndex);
+  }
+}
+
+describe("remote web ingress denylist", () => {
+  test("blocks every unprotected static gateway /v1 route before proxying /v1", () => {
+    const unprotectedV1Routes = extractUnprotectedStaticV1Routes();
+    expect(unprotectedV1Routes).toEqual([
+      "/v1/devices",
+      "/v1/devices/revoke",
+      "/v1/guardian/init",
+      "/v1/guardian/reset-bootstrap",
+      "/v1/pair",
+    ]);
+
+    for (const path of unprotectedV1Routes) {
+      assertDeniedBeforeV1Proxy(path);
+    }
+  });
+
+  test("blocks local web token minting before proxying remote requests", () => {
+    const tokenRoute = gatewayIndexSource.slice(
+      gatewayIndexSource.indexOf("// ── Web token auth ──"),
+      gatewayIndexSource.indexOf("// Runtime proxy catch-all"),
+    );
+
+    expect(tokenRoute).toContain('path: "/auth/token"');
+    expect(tokenRoute).toContain('auth: "custom"');
+    assertDeniedBeforeV1Proxy("/auth/token");
+  });
+});

--- a/gateway/src/http/edge-forwarded-header.ts
+++ b/gateway/src/http/edge-forwarded-header.ts
@@ -24,8 +24,7 @@
  * ingress does not, so guards may check it unconditionally across deploy modes.
  *
  * NOTE: The literal value is mirrored as a hardcoded string in the nginx
- * config in cli/src/commands/client.ts (`proxy_set_header X-Vellum-Edge-Forwarded`).
- * Keep the two in sync.
+ * configs (`proxy_set_header X-Vellum-Edge-Forwarded`). Keep them in sync.
  */
 export const EDGE_FORWARDED_HEADER = "x-vellum-edge-forwarded" as const;
 


### PR DESCRIPTION
## Summary
- add remote-web nginx ingress config that serves `apps/web/dist` under `/assistant/`
- keep `/v1/*` and `/healthz` proxied to the gateway for API and readiness traffic
- deny local-only bootstrap/helper endpoints before the generic gateway proxy
- require built web assets before starting `vellum nginx-ingress up`

## Validation
- `bun test src/__tests__/nginx-ingress.test.ts`
- `bunx prettier --check src/lib/nginx-ingress.ts src/commands/nginx-ingress.ts src/__tests__/nginx-ingress.test.ts`
- generated remote-web nginx config validated with `nginx -t`
- live nginx smoke test for `/assistant/`, `/assistant/assets/app.js`, and SPA deep-link fallback
- pre-push hook passed: Swift build, assistant typecheck, chrome-extension typecheck, and changed-file lint checks