### PR TITLE
fix(providers): preserve object-typed tool args for minimax on Fireworks

### DIFF
--- a/assistant/src/providers/fireworks/client.ts
+++ b/assistant/src/providers/fireworks/client.ts
@@ -35,6 +35,9 @@ export class FireworksProvider extends OpenAIChatCompletionsProvider {
       // {@link resolveMaxReasoningEffort}.
       maxReasoningEffort: "high",
       assistantReasoningField: "reasoning_content",
+      // minimax-m3's function-call serialization collapses object-typed tool
+      // args to `{}` on the wire; present them as JSON strings and decode back.
+      coerceObjectArgsToJsonString: /minimax/i.test(model),
     });
   }
 

--- a/assistant/src/providers/openai/__tests__/coerce-object-args.test.ts
+++ b/assistant/src/providers/openai/__tests__/coerce-object-args.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  coerceObjectParamsToJsonString,
+  decodeCoercedObjectArgs,
+} from "../coerce-object-args.js";
+
+const SKILL_EXECUTE_SCHEMA = {
+  type: "object",
+  properties: {
+    tool: { type: "string", description: "The skill tool name" },
+    input: { type: "object", description: "Tool-specific parameters" },
+    activity: { type: "string", description: "Progress update" },
+  },
+  required: ["tool", "input", "activity"],
+};
+
+describe("coerceObjectParamsToJsonString", () => {
+  test("rewrites object params to strings and reports the keys", () => {
+    const { parameters, objectKeys } =
+      coerceObjectParamsToJsonString(SKILL_EXECUTE_SCHEMA);
+
+    expect(objectKeys).toEqual(["input"]);
+    const props = (
+      parameters as { properties: Record<string, { type: string }> }
+    ).properties;
+    expect(props.input.type).toBe("string");
+    // Scalars are left untouched.
+    expect(props.tool.type).toBe("string");
+    expect(props.activity.type).toBe("string");
+    // The required list is preserved.
+    expect((parameters as { required: string[] }).required).toEqual([
+      "tool",
+      "input",
+      "activity",
+    ]);
+  });
+
+  test("leaves array and scalar params alone (no coercion)", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+        sources: { type: "array", items: { type: "string" } },
+      },
+    };
+    const { parameters, objectKeys } = coerceObjectParamsToJsonString(schema);
+    expect(objectKeys).toEqual([]);
+    expect(parameters).toEqual(schema);
+  });
+
+  test("handles type unions that include object", () => {
+    const schema = {
+      type: "object",
+      properties: { data: { type: ["object", "null"] } },
+    };
+    const { objectKeys } = coerceObjectParamsToJsonString(schema);
+    expect(objectKeys).toEqual(["data"]);
+  });
+});
+
+describe("decodeCoercedObjectArgs", () => {
+  test("round-trips a JSON-string object back into an object", () => {
+    const { objectKeys } = coerceObjectParamsToJsonString(SKILL_EXECUTE_SCHEMA);
+    // What minimax would send once `input` is a string param.
+    const onWire = {
+      tool: "app_delete",
+      input: '{"app_id": "5ee3d2d5-46e8-4a79-928f-00a7471d340b"}',
+      activity: "Delete placeholder",
+    };
+    const { input, failedKey } = decodeCoercedObjectArgs(onWire, objectKeys);
+    expect(failedKey).toBeUndefined();
+    expect(input.input).toEqual({
+      app_id: "5ee3d2d5-46e8-4a79-928f-00a7471d340b",
+    });
+    // Scalars pass through unchanged.
+    expect(input.tool).toBe("app_delete");
+  });
+
+  test("empty string decodes to an empty object", () => {
+    const { input } = decodeCoercedObjectArgs({ input: "" }, ["input"]);
+    expect(input.input).toEqual({});
+  });
+
+  test("is idempotent when the value is already an object", () => {
+    const args = { input: { app_id: "x" } };
+    const { input, failedKey } = decodeCoercedObjectArgs(args, ["input"]);
+    expect(failedKey).toBeUndefined();
+    expect(input.input).toEqual({ app_id: "x" });
+  });
+
+  test("reports failedKey on invalid JSON instead of throwing", () => {
+    const { failedKey } = decodeCoercedObjectArgs(
+      { input: "{not valid json" },
+      ["input"],
+    );
+    expect(failedKey).toBe("input");
+  });
+
+  test("no-op when there are no coerced keys", () => {
+    const args = { tool: "x", input: "{}" };
+    const { input } = decodeCoercedObjectArgs(args, []);
+    expect(input).toEqual(args);
+  });
+});

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -18,7 +18,14 @@ import {
   ContextOverflowError,
   extractOverflowTokensFromMessage,
 } from "../types.js";
-import { wrapUnparseableToolArgs } from "../unparseable-tool-args.js";
+import {
+  isUnparseableToolArgs,
+  wrapUnparseableToolArgs,
+} from "../unparseable-tool-args.js";
+import {
+  coerceObjectParamsToJsonString,
+  decodeCoercedObjectArgs,
+} from "./coerce-object-args.js";
 
 /**
  * Detect OpenAI-compatible context-overflow signals on an `OpenAI.APIError`.
@@ -199,6 +206,12 @@ export interface OpenAIChatCompletionsProviderOptions {
    *  content or tool_calls must be set`. See {@link
    *  EMPTY_ASSISTANT_TURN_PLACEHOLDER}. */
   backfillEmptyAssistantContent?: boolean;
+  /** Present object-typed tool params to the model as JSON-string params and
+   *  decode them back to objects on the response. Works around models whose
+   *  function-call serialization collapses nested objects to `{}` (observed
+   *  with minimax-m3 on Fireworks). Off by default; scalars/arrays unaffected.
+   *  See {@link coerceObjectParamsToJsonString}. */
+  coerceObjectArgsToJsonString?: boolean;
 }
 
 /** Wire-level reasoning_effort values. The OpenAI SDK type doesn't include
@@ -312,6 +325,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
     | "reasoning_content"
     | undefined;
   private backfillEmptyAssistantContent: boolean;
+  private coerceObjectArgsToJsonString: boolean;
 
   constructor(
     apiKey: string,
@@ -337,6 +351,8 @@ export class OpenAIChatCompletionsProvider implements Provider {
     this.assistantReasoningField = options.assistantReasoningField;
     this.backfillEmptyAssistantContent =
       options.backfillEmptyAssistantContent ?? false;
+    this.coerceObjectArgsToJsonString =
+      options.coerceObjectArgsToJsonString ?? false;
   }
 
   async sendMessage(
@@ -354,6 +370,11 @@ export class OpenAIChatCompletionsProvider implements Provider {
     const usageAttributionHeaders = configObj?.usageAttributionHeaders as
       | Record<string, string>
       | undefined;
+
+    // Per-tool keys whose object schemas were rewritten to JSON strings for the
+    // wire, to be decoded back on the response. Empty unless
+    // `coerceObjectArgsToJsonString` is enabled.
+    const coercedObjectKeys = new Map<string, string[]>();
 
     try {
       const openaiMessages = this.toOpenAIMessages(messages, systemPrompt);
@@ -398,14 +419,24 @@ export class OpenAIChatCompletionsProvider implements Provider {
       }
 
       if (tools && tools.length > 0) {
-        params.tools = tools.map((t) => ({
-          type: "function" as const,
-          function: {
-            name: t.name,
-            description: t.description,
-            parameters: t.input_schema as OpenAI.FunctionParameters,
-          },
-        }));
+        params.tools = tools.map((t) => {
+          let parameters = t.input_schema as OpenAI.FunctionParameters;
+          if (this.coerceObjectArgsToJsonString) {
+            const coerced = coerceObjectParamsToJsonString(t.input_schema);
+            parameters = coerced.parameters as OpenAI.FunctionParameters;
+            if (coerced.objectKeys.length > 0) {
+              coercedObjectKeys.set(t.name, coerced.objectKeys);
+            }
+          }
+          return {
+            type: "function" as const,
+            function: {
+              name: t.name,
+              description: t.description,
+              parameters,
+            },
+          };
+        });
 
         // Honor a caller-supplied tool_choice (e.g. `{ type: "none" }` to force
         // a text-only answer, or `{ type: "tool", name }` for a forced call).
@@ -637,6 +668,13 @@ export class OpenAIChatCompletionsProvider implements Provider {
           input = JSON.parse(tc.args);
         } catch {
           input = wrapUnparseableToolArgs(tc.args);
+        }
+        const objectKeys = coercedObjectKeys.get(tc.name);
+        if (objectKeys && !isUnparseableToolArgs(input)) {
+          const decoded = decodeCoercedObjectArgs(input, objectKeys);
+          input = decoded.failedKey
+            ? wrapUnparseableToolArgs(tc.args)
+            : decoded.input;
         }
         content.push({
           type: "tool_use",

--- a/assistant/src/providers/openai/coerce-object-args.ts
+++ b/assistant/src/providers/openai/coerce-object-args.ts
@@ -1,0 +1,104 @@
+/**
+ * Some OpenAI-compatible models (notably minimax-m3 served via Fireworks)
+ * collapse nested *object*-typed tool arguments to `{}` during their
+ * function-call serialization, while scalars and arrays survive intact. The
+ * model reasons correctly about the intended fields, but the object value is
+ * lost on the wire before it reaches us as valid-but-empty JSON, so there is
+ * nothing to recover at parse time.
+ *
+ * The workaround presents every top-level object-typed parameter to the model
+ * as a `string` it fills with JSON (strings survive the serializer), then
+ * decodes that string back into an object before dispatch. The transform is a
+ * matched pair — {@link coerceObjectParamsToJsonString} on the outbound schema
+ * and {@link decodeCoercedObjectArgs} on the inbound tool-call arguments — and
+ * is gated to the affected providers so other models keep native object
+ * passthrough.
+ */
+
+interface ObjectSchemaLike {
+  type?: unknown;
+  properties?: Record<string, { type?: unknown; description?: string }>;
+}
+
+function isObjectTyped(prop: { type?: unknown }): boolean {
+  if (prop?.type === "object") return true;
+  if (Array.isArray(prop?.type) && prop.type.includes("object")) return true;
+  return false;
+}
+
+export interface CoercedToolSchema {
+  /** The tool's JSON schema with object params rewritten to JSON-string params. */
+  parameters: Record<string, unknown>;
+  /** Top-level param keys that were object-typed and are now JSON strings. */
+  objectKeys: string[];
+}
+
+/**
+ * Rewrite top-level `type: "object"` properties of a tool's input schema into
+ * `type: "string"` params the model fills with JSON. Returns the rewritten
+ * schema plus the list of converted keys so the inbound side can reverse it.
+ * Non-object params (scalars, arrays) are passed through unchanged. Arrays and
+ * deeper-nested objects are intentionally left alone — only top-level object
+ * params are observed to collapse.
+ */
+export function coerceObjectParamsToJsonString(
+  inputSchema: unknown,
+): CoercedToolSchema {
+  const schema = inputSchema as ObjectSchemaLike | undefined;
+  if (!schema || schema.type !== "object" || !schema.properties) {
+    return {
+      parameters: (inputSchema as Record<string, unknown>) ?? {},
+      objectKeys: [],
+    };
+  }
+
+  const objectKeys: string[] = [];
+  const properties: Record<string, unknown> = {};
+  for (const [key, prop] of Object.entries(schema.properties)) {
+    if (isObjectTyped(prop)) {
+      objectKeys.push(key);
+      properties[key] = {
+        type: "string",
+        description:
+          `${prop.description ?? ""}\n\nPass this argument as a JSON object encoded as a string, e.g. "{\\"key\\": \\"value\\"}".`.trim(),
+      };
+    } else {
+      properties[key] = prop;
+    }
+  }
+
+  return { parameters: { ...schema, properties }, objectKeys };
+}
+
+/**
+ * Reverse {@link coerceObjectParamsToJsonString}: for each coerced key whose
+ * value arrived as a string, JSON-parse it back into an object. Values that are
+ * already objects (e.g. replayed conversation history, or a model that sent the
+ * object natively) are left untouched, so the decode is idempotent. An empty
+ * string decodes to `{}`. If a non-empty string fails to parse, the key name is
+ * returned in `failedKey` so the caller can surface a retryable error instead of
+ * silently dispatching garbage.
+ */
+export function decodeCoercedObjectArgs(
+  input: Record<string, unknown>,
+  objectKeys: string[],
+): { input: Record<string, unknown>; failedKey?: string } {
+  if (objectKeys.length === 0) return { input };
+
+  const result: Record<string, unknown> = { ...input };
+  for (const key of objectKeys) {
+    const value = result[key];
+    if (typeof value !== "string") continue;
+    const trimmed = value.trim();
+    if (trimmed === "") {
+      result[key] = {};
+      continue;
+    }
+    try {
+      result[key] = JSON.parse(trimmed);
+    } catch {
+      return { input: result, failedKey: key };
+    }
+  }
+  return { input: result };
+}


### PR DESCRIPTION
## Problem

minimax-m3 served via Fireworks **collapses every nested object-typed tool argument to `{}`** during its function-call serialization, while scalars and arrays survive intact. Diagnosed from an inspector export where the agent looped 8 times trying to call `app_delete` (via `skill_execute`) — its retained reasoning showed it knew the exact key (`app_id`) and value (`5ee3d2d5…`) and even constructed the correct `<input><app_id>…</app_id></input>`, but every emitted call arrived as `input: {}`.

The signature across the whole conversation was unambiguous:
- Every `object`-typed arg (`skill_execute.input`, `ui_show.data`, `ui_update.data`) → `{}`
- The one `array`-typed arg (`recall.sources`) → populated
- All scalars (`tool`, `activity`, `query`) → intact

By the time the args reach us they're *valid* JSON (`{"input":{}}`), so the malformed-args guard from #34574 (`_raw` wrapper) never fires — the empty object dispatches silently and the tool rejects it with "app_id is required," producing an unrecoverable retry loop. The data is lost upstream in the model's serialization, so there's nothing to recover at parse time.

## Fix

Strings survive the serializer, so we present every top-level object-typed param to the model as a **JSON string** it fills, then decode it back into an object before dispatch. A matched transform pair in the OpenAI-compatible provider:

- **Outbound** (`chat-completions-provider.ts`): rewrite each tool's `type: "object"` params to `type: "string"` (with a "pass JSON encoded as a string" hint) and record the converted keys.
- **Inbound**: after the existing `JSON.parse`, decode those keys back to objects. A decode failure routes through the existing `wrapUnparseableToolArgs` path, so the model gets a real retry signal instead of a silent `{}`.

The new logic lives in `providers/openai/coerce-object-args.ts` (pure, unit-tested round-trip).

## Scope / blast radius

- Gated behind a new `coerceObjectArgsToJsonString` option, **off by default**.
- The **only** caller that enables it is the Fireworks client, and **only for minimax models** (`/minimax/i.test(model)`).
- Every other provider/model — Anthropic, OpenAI, OpenRouter, non-minimax Fireworks — flows through the unchanged native object passthrough.
- **Tool definitions and handlers are untouched.** No shared default changed.

## Testing

- New `coerce-object-args.test.ts`: schema rewrite, array/scalar passthrough, type-union handling, and the full round-trip (incl. the exact `app_delete` case decoding back to `{app_id: "5ee3d2d5…"}`), idempotency, empty-string, and invalid-JSON handling. 8/8 pass.
- All 41 existing OpenAI provider tests pass; `tsc` and lint clean.

## Review focus

⚠️ **Behavioral change to watch:** minimax now sees `input` / `ui_show.data` typed as `string` rather than `object`. The reasoning trace showed the model already constructs correct JSON, so this should land cleanly — but it's worth a dogfood run against minimax-m3 to confirm a real `skill_execute` call survives the round-trip. Risk: **low-medium**, fully isolated to the minimax-on-Fireworks path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)