### PR TITLE
ci(release): stop attaching Electron auto-update feed to GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2978,6 +2978,10 @@ jobs:
               echo "::error::Missing ZIP for ${ARCH}"
               exit 1
             fi
+            if [ -z "$(find "$DIR" -name '*.zip.blockmap' -type f 2>/dev/null | grep -m1 .)" ]; then
+              echo "::error::Missing blockmap (*.zip.blockmap) for ${ARCH}"
+              exit 1
+            fi
           done
 
       - name: Authenticate to GCP

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3092,21 +3092,6 @@ jobs:
           name: macos-build-electron-x64
           path: electron-artifacts-x64
 
-      # Also attach the Electron auto-update feed (zip + blockmap + manifest)
-      # to the Release for parity with Sparkle. electron-updater still pulls
-      # the feed from GCS; these copies are for visibility / manual installs.
-      - name: Download Electron update artifacts (arm64)
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: macos-electron-update-arm64
-          path: electron-update-artifacts/arm64
-
-      - name: Download Electron update artifacts (x64)
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: macos-electron-update-x64
-          path: electron-update-artifacts/x64
-
       - name: Create GitHub Releases
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -3145,27 +3130,6 @@ jobs:
             exit 1
           fi
           ASSETS+=("$ELECTRON_X64_DMG#vellum-assistant-electron-x64.dmg")
-
-          # Add the Electron auto-update feed (zip + blockmap + per-arch manifest),
-          # required for both arches. electron-builder names the manifest
-          # latest-mac.yml for BOTH arches, so copy it to a per-arch filename before
-          # upload to avoid an asset-name collision in the Release's flat namespace.
-          # The "#" suffix on a gh asset sets only a display label, not the uploaded
-          # filename, so the rename has to happen on disk. The zips/blockmaps
-          # already embed the arch.
-          for ARCH in arm64 x64; do
-            UPDATE_DIR="electron-update-artifacts/${ARCH}"
-            UPDATE_ZIP=$(find "$UPDATE_DIR" -name "*-mac.zip" -type f | grep -m1 .)
-            UPDATE_BLOCKMAP=$(find "$UPDATE_DIR" -name "*-mac.zip.blockmap" -type f | grep -m1 .)
-            UPDATE_YML=$(find "$UPDATE_DIR" -name "*-mac.yml" -type f | grep -m1 .)
-            if [ -z "$UPDATE_ZIP" ] || [ -z "$UPDATE_BLOCKMAP" ] || [ -z "$UPDATE_YML" ]; then
-              echo "::error::Electron ${ARCH} update feed incomplete (zip/blockmap/manifest)"
-              exit 1
-            fi
-            RENAMED_YML="${UPDATE_DIR}/latest-mac-${ARCH}.yml"
-            cp "$UPDATE_YML" "$RENAMED_YML"
-            ASSETS+=("$UPDATE_ZIP" "$UPDATE_BLOCKMAP" "$RENAMED_YML")
-          done
 
           INSTALL_SH="cli/src/adapters/install.sh"
           [ -f "$INSTALL_SH" ] && ASSETS+=("$INSTALL_SH#install.sh")


### PR DESCRIPTION
## Summary
- Removes the auto-update feed (zip + blockmap + per-arch manifest) from the GitHub Release assets — attaching all 6 files was overkill. The Release keeps the Electron `.dmg` installers for first-time/manual installs.
- The real auto-update channel is unchanged: `upload-electron-updates` still publishes the feed to GCS (`gs://vellum-ai-*-releases/mac-electron/{arch}/`), and the `release` job still gates on that job succeeding. Electron GA-blocking is untouched.
- Also drops the inaccurate comment claiming "zips/blockmaps already embed the arch" — the x64 zip is `Vellum-<ver>-mac.zip` with no arch suffix (only arm64 carries `-arm64-`); removing the block removes the comment with it.

## Original prompt
Follow-up to #34873, which attached the Electron auto-update feed to the GitHub Release for Sparkle-style parity and made Electron a GA-blocking release dependency. On reflection the feed-on-Release was redundant with the GCS feed electron-updater actually uses, so this reverts just that part (keeping the DMG attach and GA-blocking). The 6 feed assets manually backfilled onto v0.8.12 were also removed by hand.