### PR TITLE
fix(web): parse invoice zip download as blob, not JSON

### DIFF
--- a/apps/web/src/domains/settings/components/invoices-modal.tsx
+++ b/apps/web/src/domains/settings/components/invoices-modal.tsx
@@ -115,9 +115,13 @@ export function InvoicesModal({ open, onOpenChange }: InvoicesModalProps) {
   async function downloadAllInvoices(): Promise<void> {
     setIsDownloadingAll(true);
     try {
+      // The generated clients are pinned to `parseAs: "json"` (see
+      // api-interceptors.ts), so blob downloads must opt back into binary
+      // parsing or the zip body is run through JSON.parse and fails.
       const { data, response } =
         await organizationsBillingInvoicesDownloadRetrieve({
           throwOnError: false,
+          parseAs: "blob",
         });
       if (!response?.ok || !(data instanceof Blob)) {
         throw new Error(


### PR DESCRIPTION
## Summary

- `Download all` on the invoices modal failed every time despite the API returning a valid `200 application/zip`. The three generated API clients are pinned to `parseAs: "json"` in `api-interceptors.ts` (LUM-2371 fix), so the zip body was being run through `JSON.parse` and threw before `saveFile` was ever reached.
- Pass `parseAs: "blob"` at the `organizationsBillingInvoicesDownloadRetrieve` call site so the body is parsed as binary, matching every other blob-download call site in the app (surfaces.ts, sounds.ts, share-app.ts, etc.).

## Original prompt

Investigate why clicking `Download all` on invoices fails every time even though the network tab shows the API call succeeding. The backend (`platform`) correctly returns `application/zip`; the failure is client-side response parsing. Fix it.