### PR TITLE
fix(macos): give dev Electron app an owned bundle id for notifications

### DIFF
--- a/apps/macos/scripts/prepare-electron-dev-app.ts
+++ b/apps/macos/scripts/prepare-electron-dev-app.ts
@@ -17,9 +17,20 @@ const ELECTRON_INFO_PLIST = path.join(
   "Info.plist",
 );
 
+// macOS keys notification authorization to the bundle identifier. The stock
+// Electron.app ships as `com.github.Electron` — an identifier shared by every
+// Electron app on the machine, which routinely lands in a denied state and
+// makes `new Notification().show()` fail with `UNErrorDomain error 1`
+// (notificationsNotAllowed). Stamp our own owned identifier so the dev app
+// gets a clean authorization prompt, mirroring electron-builder's dev scheme
+// (`com.vellum.vellum-assistant-electron-${env}`) in electron-builder.config.cjs.
+const VELLUM_ENVIRONMENT = process.env.VELLUM_ENVIRONMENT || "local";
+const DEV_BUNDLE_ID = `com.vellum.vellum-assistant-electron-${VELLUM_ENVIRONMENT}`;
+
 const REQUIRED_PLIST_STRINGS: Record<string, string> = {
   CFBundleDisplayName: "Vellum Electron",
   CFBundleName: "Vellum Electron",
+  CFBundleIdentifier: DEV_BUNDLE_ID,
   NSUserNotificationAlertStyle: "alert",
 };
 
@@ -80,6 +91,21 @@ if (changed || !isValidSignature()) {
   execFileSync("codesign", ["--force", "--deep", "--sign", "-", ELECTRON_APP], {
     stdio: "inherit",
   });
+
+  // Re-register the (re-signed) bundle with Launch Services so macOS picks up
+  // the new identifier — without this the first `.show()` may not surface an
+  // authorization prompt and the app won't appear under
+  // System Settings → Notifications. Best-effort: never block the dev flow.
+  const lsregister =
+    "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister";
+  try {
+    execFileSync(lsregister, ["-f", ELECTRON_APP], { stdio: "inherit" });
+  } catch (error) {
+    console.warn(
+      "[prepare-electron-dev-app] lsregister failed (continuing):",
+      error instanceof Error ? error.message : error,
+    );
+  }
 }
 
 console.log("[prepare-electron-dev-app] Electron.app is ready");


### PR DESCRIPTION
## Problem

Native macOS notifications never appeared in the **Electron** dev build, even though they work in the Swift client. Logs showed every attempt failing at the OS authorization gate:

```
[main] [notifications] Notification failed: The operation couldn't be completed. (UNErrorDomain error 1.)
```

`UNErrorDomain error 1` = `UNErrorCodeNotificationsNotAllowed`. The full pipeline (daemon `notification_intent` SSE → web renderer hook → `window.vellum.notifications.show()` → IPC → main-process `new Notification().show()`) was already wired correctly — the only failure was authorization.

## Root cause

The dev `Electron.app` runs under the stock `CFBundleIdentifier = com.github.Electron`, the generic identifier shared by every Electron app on the machine. macOS keys notification authorization to the bundle id, and that shared id routinely lands in a denied state, so the dev app could never get its own grant. The Swift client works because it ships with its own owned bundle id (`com.vellum.vellum-assistant-*`).

`prepare-electron-dev-app.ts` already set the display name + alert style and ad-hoc-signed the bundle, but never set the bundle identifier.

## Fix

`apps/macos/scripts/prepare-electron-dev-app.ts` now:
1. Stamps an owned, environment-aware `CFBundleIdentifier` (`com.vellum.vellum-assistant-electron-${VELLUM_ENVIRONMENT}`, defaulting to `…-local`), matching electron-builder's dev scheme. A brand-new identity gets a clean authorization prompt instead of inheriting `com.github.Electron`'s denial. Setting a new key flips `changed = true`, so the existing block re-ad-hoc-signs automatically.
2. Re-registers the re-signed bundle with Launch Services (`lsregister -f`) so macOS surfaces the prompt and lists the app under System Settings → Notifications. Best-effort: failures only warn, never block dev.

## Verification

Ran the edited script against the real dev bundle:
- `CFBundleIdentifier`: `com.github.Electron` → `com.vellum.vellum-assistant-electron-local`
- Re-signed ad-hoc; `codesign --verify --deep --strict` → **VALID**
- `lsregister` ran cleanly

After this change, the user approves the one-time macOS notification prompt and `UNErrorDomain error 1` no longer appears in `~/Library/Logs/Vellum Electron/vellum.log`.

## Scope / risk

🟢 Low. Confined to a dev-only prep script that patches the throwaway `node_modules/electron/dist/Electron.app`. Production builds are unaffected — they already receive the correct `appId` via `electron-builder.config.cjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)