### PR TITLE
fix(risk): escalate workspace tools-dir writes to high-risk approval (ATL-830)

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -280,7 +280,6 @@ function buildFileContext(): FileContext {
     hooksDir: getWorkspaceHooksDir(),
     pluginsDir: getWorkspacePluginsDir(),
     toolsDir: getWorkspaceToolsDir(),
-    workspaceDir: getWorkspaceDir(),
     actorTokenSigningKeyPath: join(
       getProtectedDir(),
       "actor-token-signing-key",

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -23,6 +23,7 @@ import {
   getWorkspaceDir,
   getWorkspaceHooksDir,
   getWorkspacePluginsDir,
+  getWorkspaceToolsDir,
 } from "../util/platform.js";
 import {
   type ApprovalContext,
@@ -278,6 +279,7 @@ function buildFileContext(): FileContext {
     deprecatedDir: getDeprecatedDir(),
     hooksDir: getWorkspaceHooksDir(),
     pluginsDir: getWorkspacePluginsDir(),
+    toolsDir: getWorkspaceToolsDir(),
     actorTokenSigningKeyPath: join(
       getProtectedDir(),
       "actor-token-signing-key",

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -280,6 +280,7 @@ function buildFileContext(): FileContext {
     hooksDir: getWorkspaceHooksDir(),
     pluginsDir: getWorkspacePluginsDir(),
     toolsDir: getWorkspaceToolsDir(),
+    workspaceDir: getWorkspaceDir(),
     actorTokenSigningKeyPath: join(
       getProtectedDir(),
       "actor-token-signing-key",

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -352,6 +352,8 @@ function buildClassifyRiskParams(
   ) {
     const isHostTool = toolName.startsWith("host_");
     let filePath: string;
+    let sandboxPath: string | undefined;
+    let sandboxWorkingDir: string | undefined;
     if (toolName === "host_file_transfer") {
       // For host_file_transfer the security-sensitive path is the host-side
       // path: source_path when reading from the host (to_sandbox), dest_path
@@ -361,12 +363,22 @@ function buildClassifyRiskParams(
         direction === "to_sandbox"
           ? getStringField(input, "source_path")
           : getStringField(input, "dest_path");
+      // For to_sandbox the transfer *writes* into the workspace at dest_path,
+      // which can plant daemon-loaded code (workspace tool / plugin / hook /
+      // skill). Forward it so the gateway runs the workspace escalations on
+      // the destination, not just the benign host source.
+      if (direction === "to_sandbox") {
+        sandboxPath = getStringField(input, "dest_path");
+        sandboxWorkingDir = workingDir ?? process.cwd();
+      }
     } else {
       filePath = getStringField(input, "path", "file_path");
     }
     return {
       tool: toolName,
       path: filePath,
+      sandboxPath,
+      sandboxWorkingDir,
       workingDir: isHostTool ? "/" : (workingDir ?? process.cwd()),
       fileContext: buildFileContext(),
     };

--- a/assistant/src/permissions/ipc-risk-types.ts
+++ b/assistant/src/permissions/ipc-risk-types.ts
@@ -54,7 +54,6 @@ export interface FileContext {
   hooksDir: string;
   pluginsDir: string;
   toolsDir: string;
-  workspaceDir: string;
   actorTokenSigningKeyPath: string;
   skillSourceDirs: string[];
 }

--- a/assistant/src/permissions/ipc-risk-types.ts
+++ b/assistant/src/permissions/ipc-risk-types.ts
@@ -83,6 +83,10 @@ export interface ClassifyRiskParams {
   command?: string;
   url?: string;
   path?: string;
+  /** host_file_transfer to_sandbox destination — see FileClassifierInput.sandboxPath. */
+  sandboxPath?: string;
+  /** Sandbox working dir for resolving a relative sandboxPath. */
+  sandboxWorkingDir?: string;
   skill?: string;
   mode?: string;
   script?: string;

--- a/assistant/src/permissions/ipc-risk-types.ts
+++ b/assistant/src/permissions/ipc-risk-types.ts
@@ -53,6 +53,7 @@ export interface FileContext {
   deprecatedDir: string;
   hooksDir: string;
   pluginsDir: string;
+  toolsDir: string;
   actorTokenSigningKeyPath: string;
   skillSourceDirs: string[];
 }

--- a/assistant/src/permissions/ipc-risk-types.ts
+++ b/assistant/src/permissions/ipc-risk-types.ts
@@ -54,6 +54,7 @@ export interface FileContext {
   hooksDir: string;
   pluginsDir: string;
   toolsDir: string;
+  workspaceDir: string;
   actorTokenSigningKeyPath: string;
   skillSourceDirs: string[];
 }

--- a/gateway/src/__tests__/nonbash-trust-rule-overrides.test.ts
+++ b/gateway/src/__tests__/nonbash-trust-rule-overrides.test.ts
@@ -25,6 +25,7 @@ const dummyFileContext: FileClassificationContext = {
   deprecatedDir: "/tmp/test-deprecated",
   hooksDir: "/tmp/test-hooks",
   pluginsDir: "/tmp/test-plugins",
+  toolsDir: "/tmp/test-tools",
   skillSourceDirs: [],
 };
 

--- a/gateway/src/__tests__/nonbash-trust-rule-overrides.test.ts
+++ b/gateway/src/__tests__/nonbash-trust-rule-overrides.test.ts
@@ -26,6 +26,7 @@ const dummyFileContext: FileClassificationContext = {
   hooksDir: "/tmp/test-hooks",
   pluginsDir: "/tmp/test-plugins",
   toolsDir: "/tmp/test-tools",
+  workspaceDir: "/tmp/test-workspace",
   skillSourceDirs: [],
 };
 

--- a/gateway/src/__tests__/nonbash-trust-rule-overrides.test.ts
+++ b/gateway/src/__tests__/nonbash-trust-rule-overrides.test.ts
@@ -26,7 +26,6 @@ const dummyFileContext: FileClassificationContext = {
   hooksDir: "/tmp/test-hooks",
   pluginsDir: "/tmp/test-plugins",
   toolsDir: "/tmp/test-tools",
-  workspaceDir: "/tmp/test-workspace",
   skillSourceDirs: [],
 };
 

--- a/gateway/src/__tests__/nonbash-trust-rule-overrides.test.ts
+++ b/gateway/src/__tests__/nonbash-trust-rule-overrides.test.ts
@@ -97,6 +97,33 @@ describe("FileRiskClassifier user overrides", () => {
     expect(result.matchType).toBe("user_rule");
   });
 
+  test("a legacy high-risk rule saved on a raw relative path still applies", async () => {
+    // Rules created before subject-path canonicalization are keyed on the raw
+    // (relative/alias) path. A high-risk one must still escalate via the
+    // raise-only raw fallback rather than silently falling back to low.
+    store.create({
+      tool: "file_write",
+      pattern: "src/secret.txt",
+      risk: "high",
+      description: "Legacy raw-path rule",
+    });
+
+    initTrustRuleCache(store);
+
+    const classifier = new FileRiskClassifier();
+    const result = await classifier.classify(
+      {
+        toolName: "file_write",
+        filePath: "src/secret.txt",
+        workingDir: "/repo",
+      },
+      dummyFileContext,
+    );
+
+    expect(result.riskLevel).toBe("high");
+    expect(result.matchType).toBe("user_rule");
+  });
+
   test("a low rule on a /workspace alias from a benign dir does not downgrade a tools-dir write", async () => {
     // "/workspace/skill_load.ts" resolves differently per working dir. A low
     // rule whose resolved key is a benign path must NOT match a write that

--- a/gateway/src/__tests__/nonbash-trust-rule-overrides.test.ts
+++ b/gateway/src/__tests__/nonbash-trust-rule-overrides.test.ts
@@ -96,6 +96,64 @@ describe("FileRiskClassifier user overrides", () => {
     expect(result.reason).toBe("User modified this default rule");
     expect(result.matchType).toBe("user_rule");
   });
+
+  test("to_sandbox transfer honors a high-risk rule on the host source", async () => {
+    // The host source carries a sensitive-source rule; the sandbox destination
+    // is benign. The transfer must take the higher (source) risk rather than
+    // ignoring the source rule and falling back to the benign-destination default.
+    store.create({
+      tool: "host_file_transfer",
+      pattern: "/etc/secret",
+      risk: "high",
+      description: "Sensitive host source",
+    });
+
+    initTrustRuleCache(store);
+
+    const classifier = new FileRiskClassifier();
+    const result = await classifier.classify(
+      {
+        toolName: "host_file_transfer",
+        filePath: "/etc/secret",
+        workingDir: "/",
+        sandboxPath: "/tmp/test-workspace/scratch/note.txt",
+        sandboxWorkingDir: "/tmp/test-workspace",
+      },
+      dummyFileContext,
+    );
+
+    expect(result.riskLevel).toBe("high");
+    expect(result.matchType).toBe("user_rule");
+  });
+
+  test("to_sandbox destination escalation is not downgraded by a benign source rule", async () => {
+    // The host source has a low-risk rule, but the destination lands in the
+    // tools dir (toolsDir = /tmp/test-tools). The destination escalation must
+    // win — the benign-source rule cannot downgrade it.
+    store.create({
+      tool: "host_file_transfer",
+      pattern: "/tmp/evil.ts",
+      risk: "low",
+      description: "Trusted host source",
+    });
+
+    initTrustRuleCache(store);
+
+    const classifier = new FileRiskClassifier();
+    const result = await classifier.classify(
+      {
+        toolName: "host_file_transfer",
+        filePath: "/tmp/evil.ts",
+        workingDir: "/",
+        sandboxPath: "/tmp/test-tools/skill_load.ts",
+        sandboxWorkingDir: "/tmp/test-workspace",
+      },
+      dummyFileContext,
+    );
+
+    expect(result.riskLevel).toBe("high");
+    expect(result.reason).toBe("Transfers to workspace tools directory");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/gateway/src/__tests__/nonbash-trust-rule-overrides.test.ts
+++ b/gateway/src/__tests__/nonbash-trust-rule-overrides.test.ts
@@ -97,6 +97,59 @@ describe("FileRiskClassifier user overrides", () => {
     expect(result.matchType).toBe("user_rule");
   });
 
+  test("a low rule on a /workspace alias from a benign dir does not downgrade a tools-dir write", async () => {
+    // "/workspace/skill_load.ts" resolves differently per working dir. A low
+    // rule whose resolved key is a benign path must NOT match a write that
+    // resolves into the tools dir (toolsDir = /tmp/test-tools).
+    store.create({
+      tool: "file_write",
+      pattern: "/home/user/project/skill_load.ts",
+      risk: "low",
+      description: "Trusted benign path",
+    });
+
+    initTrustRuleCache(store);
+
+    const classifier = new FileRiskClassifier();
+    const result = await classifier.classify(
+      {
+        toolName: "file_write",
+        filePath: "/workspace/skill_load.ts",
+        workingDir: "/tmp/test-tools",
+      },
+      dummyFileContext,
+    );
+
+    expect(result.riskLevel).toBe("high");
+    expect(result.reason).toBe("Writes to workspace tools directory");
+  });
+
+  test("a rule keyed on the resolved path applies even when the call uses a /workspace alias", async () => {
+    // The user explicitly trusted the actual file; canonicalization lets the
+    // alias-addressed write find that rule and lower the risk.
+    store.create({
+      tool: "file_write",
+      pattern: "/tmp/test-tools/skill_load.ts",
+      risk: "low",
+      description: "Explicitly trusted tools file",
+    });
+
+    initTrustRuleCache(store);
+
+    const classifier = new FileRiskClassifier();
+    const result = await classifier.classify(
+      {
+        toolName: "file_write",
+        filePath: "/workspace/skill_load.ts",
+        workingDir: "/tmp/test-tools",
+      },
+      dummyFileContext,
+    );
+
+    expect(result.riskLevel).toBe("low");
+    expect(result.matchType).toBe("user_rule");
+  });
+
   test("to_sandbox transfer honors a high-risk rule on the host source", async () => {
     // The host source carries a sensitive-source rule; the sandbox destination
     // is benign. The transfer must take the higher (source) risk rather than

--- a/gateway/src/__tests__/nonbash-trust-rule-overrides.test.ts
+++ b/gateway/src/__tests__/nonbash-trust-rule-overrides.test.ts
@@ -126,6 +126,35 @@ describe("FileRiskClassifier user overrides", () => {
     expect(result.matchType).toBe("user_rule");
   });
 
+  test("to_sandbox transfer honors a user low-risk rule on the destination", async () => {
+    // Approving a benign transfer saves a low rule keyed to the destination.
+    // The destination is the primary subject, so its override replaces the
+    // classification and lowers it — the transfer must stop prompting.
+    store.create({
+      tool: "host_file_transfer",
+      pattern: "/tmp/test-workspace/scratch/note.txt",
+      risk: "low",
+      description: "Trusted destination",
+    });
+
+    initTrustRuleCache(store);
+
+    const classifier = new FileRiskClassifier();
+    const result = await classifier.classify(
+      {
+        toolName: "host_file_transfer",
+        filePath: "/tmp/source.txt",
+        workingDir: "/",
+        sandboxPath: "/tmp/test-workspace/scratch/note.txt",
+        sandboxWorkingDir: "/tmp/test-workspace",
+      },
+      dummyFileContext,
+    );
+
+    expect(result.riskLevel).toBe("low");
+    expect(result.matchType).toBe("user_rule");
+  });
+
   test("to_sandbox destination escalation is not downgraded by a benign source rule", async () => {
     // The host source has a low-risk rule, but the destination lands in the
     // tools dir (toolsDir = /tmp/test-tools). The destination escalation must

--- a/gateway/src/ipc/risk-classification-handlers.test.ts
+++ b/gateway/src/ipc/risk-classification-handlers.test.ts
@@ -223,6 +223,24 @@ describe("file classification", () => {
     expect(result.risk).toBe("high");
     expect(result.reason).toContain("skill source");
   });
+
+  test("file context with tools dir escalates workspace tool writes", async () => {
+    const result = await classify({
+      tool: "file_write",
+      path: "/workspace/.vellum/tools/skill_load.ts",
+      workingDir: "/workspace",
+      fileContext: {
+        protectedDir: "/workspace/.vellum/protected",
+        hooksDir: "/workspace/.hooks",
+        toolsDir: "/workspace/.vellum/tools",
+        actorTokenSigningKeyPath:
+          "/workspace/.vellum/protected/actor-token-signing-key",
+        skillSourceDirs: ["/workspace/.vellum/skills"],
+      },
+    });
+    expect(result.risk).toBe("high");
+    expect(result.reason).toContain("workspace tools");
+  });
 });
 
 // ── Web classification ──────────────────────────────────────────────────────

--- a/gateway/src/ipc/risk-classification-handlers.test.ts
+++ b/gateway/src/ipc/risk-classification-handlers.test.ts
@@ -198,7 +198,6 @@ describe("file classification", () => {
       fileContext: {
         protectedDir: "/workspace/.vellum/protected",
         hooksDir: "/workspace/.hooks",
-        workspaceDir: "/workspace",
         actorTokenSigningKeyPath:
           "/workspace/.vellum/protected/actor-token-signing-key",
         skillSourceDirs: ["/workspace/.vellum/skills"],
@@ -216,7 +215,6 @@ describe("file classification", () => {
       fileContext: {
         protectedDir: "/workspace/.vellum/protected",
         hooksDir: "/workspace/.hooks",
-        workspaceDir: "/workspace",
         actorTokenSigningKeyPath:
           "/workspace/.vellum/protected/actor-token-signing-key",
         skillSourceDirs: ["/workspace/.vellum/skills"],
@@ -235,7 +233,6 @@ describe("file classification", () => {
         protectedDir: "/workspace/.vellum/protected",
         hooksDir: "/workspace/.hooks",
         toolsDir: "/workspace/.vellum/tools",
-        workspaceDir: "/workspace",
         actorTokenSigningKeyPath:
           "/workspace/.vellum/protected/actor-token-signing-key",
         skillSourceDirs: ["/workspace/.vellum/skills"],
@@ -256,7 +253,6 @@ describe("file classification", () => {
         protectedDir: "/workspace/.vellum/protected",
         hooksDir: "/workspace/.hooks",
         toolsDir: "/workspace/.vellum/tools",
-        workspaceDir: "/workspace",
         actorTokenSigningKeyPath:
           "/workspace/.vellum/protected/actor-token-signing-key",
         skillSourceDirs: ["/workspace/.vellum/skills"],

--- a/gateway/src/ipc/risk-classification-handlers.test.ts
+++ b/gateway/src/ipc/risk-classification-handlers.test.ts
@@ -198,6 +198,7 @@ describe("file classification", () => {
       fileContext: {
         protectedDir: "/workspace/.vellum/protected",
         hooksDir: "/workspace/.hooks",
+        workspaceDir: "/workspace",
         actorTokenSigningKeyPath:
           "/workspace/.vellum/protected/actor-token-signing-key",
         skillSourceDirs: ["/workspace/.vellum/skills"],
@@ -215,6 +216,7 @@ describe("file classification", () => {
       fileContext: {
         protectedDir: "/workspace/.vellum/protected",
         hooksDir: "/workspace/.hooks",
+        workspaceDir: "/workspace",
         actorTokenSigningKeyPath:
           "/workspace/.vellum/protected/actor-token-signing-key",
         skillSourceDirs: ["/workspace/.vellum/skills"],
@@ -233,6 +235,7 @@ describe("file classification", () => {
         protectedDir: "/workspace/.vellum/protected",
         hooksDir: "/workspace/.hooks",
         toolsDir: "/workspace/.vellum/tools",
+        workspaceDir: "/workspace",
         actorTokenSigningKeyPath:
           "/workspace/.vellum/protected/actor-token-signing-key",
         skillSourceDirs: ["/workspace/.vellum/skills"],
@@ -240,6 +243,18 @@ describe("file classification", () => {
     });
     expect(result.risk).toBe("high");
     expect(result.reason).toContain("workspace tools");
+  });
+
+  test("workspace alias write without file context is not falsely escalated", async () => {
+    // No fileContext: the /workspace remapping must stay inert (distinct
+    // workspace sentinel) so an aliased path can't collide with the escalation
+    // dirs' sentinel and produce a false-positive high.
+    const result = await classify({
+      tool: "file_write",
+      path: "/workspace/tools/skill_load.ts",
+      workingDir: "/workspace",
+    });
+    expect(result.risk).toBe("low");
   });
 });
 

--- a/gateway/src/ipc/risk-classification-handlers.test.ts
+++ b/gateway/src/ipc/risk-classification-handlers.test.ts
@@ -245,6 +245,27 @@ describe("file classification", () => {
     expect(result.reason).toContain("workspace tools");
   });
 
+  test("to_sandbox transfer destination into tools dir escalates to high", async () => {
+    const result = await classify({
+      tool: "host_file_transfer",
+      // Host source is benign; the sandbox destination plants the tool override.
+      path: "/tmp/evil.ts",
+      sandboxPath: "/workspace/.vellum/tools/skill_load.ts",
+      sandboxWorkingDir: "/workspace",
+      fileContext: {
+        protectedDir: "/workspace/.vellum/protected",
+        hooksDir: "/workspace/.hooks",
+        toolsDir: "/workspace/.vellum/tools",
+        workspaceDir: "/workspace",
+        actorTokenSigningKeyPath:
+          "/workspace/.vellum/protected/actor-token-signing-key",
+        skillSourceDirs: ["/workspace/.vellum/skills"],
+      },
+    });
+    expect(result.risk).toBe("high");
+    expect(result.reason).toContain("workspace tools");
+  });
+
   test("workspace alias write without file context is not falsely escalated", async () => {
     // No fileContext: the /workspace remapping must stay inert (distinct
     // workspace sentinel) so an aliased path can't collide with the escalation

--- a/gateway/src/ipc/risk-classification-handlers.test.ts
+++ b/gateway/src/ipc/risk-classification-handlers.test.ts
@@ -260,6 +260,16 @@ describe("file classification", () => {
     });
     expect(result.risk).toBe("high");
     expect(result.reason).toContain("workspace tools");
+    // Scope grants + resolved paths must reflect the sandbox destination, not
+    // the benign host source, so a source-scoped grant can't downgrade it.
+    const resolvedPaths = result.resolvedPaths as string[] | undefined;
+    expect(resolvedPaths).toEqual(["/workspace/.vellum/tools/skill_load.ts"]);
+    const allowlistPatterns = (
+      (result.allowlistOptions as Array<{ pattern: string }>) ?? []
+    ).map((o) => o.pattern);
+    expect(allowlistPatterns.some((p) => p.includes("/tmp/evil.ts"))).toBe(
+      false,
+    );
   });
 
   test("workspace alias write without file context is not falsely escalated", async () => {

--- a/gateway/src/ipc/risk-classification-handlers.ts
+++ b/gateway/src/ipc/risk-classification-handlers.ts
@@ -58,6 +58,7 @@ const ClassifyRiskSchema = z.object({
       hooksDir: z.string(),
       pluginsDir: z.string().optional(),
       toolsDir: z.string().optional(),
+      workspaceDir: z.string().optional(),
       actorTokenSigningKeyPath: z.string(),
       skillSourceDirs: z.array(z.string()),
     })
@@ -424,6 +425,12 @@ export async function handleClassifyRisk(
       // classifier never produces false-positive escalations (an empty string
       // for hooksDir would normalize to "/" and match every path).
       const SENTINEL = "/__vellum_no_context__";
+      // workspaceDir gets a *distinct* sentinel: the classifier remaps
+      // container-scoped `/workspace/...` paths onto workspaceDir, so sharing
+      // SENTINEL with the escalation dirs would nest aliased paths under those
+      // sentinels and falsely escalate. A separate value keeps the remap inert
+      // when no real context was supplied.
+      const WORKSPACE_SENTINEL = "/__vellum_no_workspace__";
       const fileCtx = params.fileContext;
       const context: FileClassificationContext = {
         protectedDir: fileCtx?.protectedDir ?? SENTINEL,
@@ -431,6 +438,7 @@ export async function handleClassifyRisk(
         hooksDir: fileCtx?.hooksDir ?? SENTINEL,
         pluginsDir: fileCtx?.pluginsDir ?? SENTINEL,
         toolsDir: fileCtx?.toolsDir ?? SENTINEL,
+        workspaceDir: fileCtx?.workspaceDir ?? WORKSPACE_SENTINEL,
         skillSourceDirs: fileCtx?.skillSourceDirs ?? [],
       };
 

--- a/gateway/src/ipc/risk-classification-handlers.ts
+++ b/gateway/src/ipc/risk-classification-handlers.ts
@@ -57,6 +57,7 @@ const ClassifyRiskSchema = z.object({
       deprecatedDir: z.string(),
       hooksDir: z.string(),
       pluginsDir: z.string().optional(),
+      toolsDir: z.string().optional(),
       actorTokenSigningKeyPath: z.string(),
       skillSourceDirs: z.array(z.string()),
     })
@@ -429,6 +430,7 @@ export async function handleClassifyRisk(
         deprecatedDir: fileCtx?.deprecatedDir ?? SENTINEL,
         hooksDir: fileCtx?.hooksDir ?? SENTINEL,
         pluginsDir: fileCtx?.pluginsDir ?? SENTINEL,
+        toolsDir: fileCtx?.toolsDir ?? SENTINEL,
         skillSourceDirs: fileCtx?.skillSourceDirs ?? [],
       };
 

--- a/gateway/src/ipc/risk-classification-handlers.ts
+++ b/gateway/src/ipc/risk-classification-handlers.ts
@@ -42,6 +42,8 @@ const ClassifyRiskSchema = z.object({
   command: z.string().optional(),
   url: z.string().optional(),
   path: z.string().optional(),
+  sandboxPath: z.string().optional(),
+  sandboxWorkingDir: z.string().optional(),
   skill: z.string().optional(),
   mode: z.string().optional(),
   script: z.string().optional(),
@@ -443,7 +445,13 @@ export async function handleClassifyRisk(
       };
 
       const assessment = await fileRiskClassifier.classify(
-        { toolName: tool, filePath, workingDir },
+        {
+          toolName: tool,
+          filePath,
+          workingDir,
+          sandboxPath: params.sandboxPath,
+          sandboxWorkingDir: params.sandboxWorkingDir,
+        },
         context,
       );
 

--- a/gateway/src/ipc/risk-classification-handlers.ts
+++ b/gateway/src/ipc/risk-classification-handlers.ts
@@ -60,7 +60,6 @@ const ClassifyRiskSchema = z.object({
       hooksDir: z.string(),
       pluginsDir: z.string().optional(),
       toolsDir: z.string().optional(),
-      workspaceDir: z.string().optional(),
       actorTokenSigningKeyPath: z.string(),
       skillSourceDirs: z.array(z.string()),
     })
@@ -427,12 +426,6 @@ export async function handleClassifyRisk(
       // classifier never produces false-positive escalations (an empty string
       // for hooksDir would normalize to "/" and match every path).
       const SENTINEL = "/__vellum_no_context__";
-      // workspaceDir gets a *distinct* sentinel: the classifier remaps
-      // container-scoped `/workspace/...` paths onto workspaceDir, so sharing
-      // SENTINEL with the escalation dirs would nest aliased paths under those
-      // sentinels and falsely escalate. A separate value keeps the remap inert
-      // when no real context was supplied.
-      const WORKSPACE_SENTINEL = "/__vellum_no_workspace__";
       const fileCtx = params.fileContext;
       const context: FileClassificationContext = {
         protectedDir: fileCtx?.protectedDir ?? SENTINEL,
@@ -440,7 +433,6 @@ export async function handleClassifyRisk(
         hooksDir: fileCtx?.hooksDir ?? SENTINEL,
         pluginsDir: fileCtx?.pluginsDir ?? SENTINEL,
         toolsDir: fileCtx?.toolsDir ?? SENTINEL,
-        workspaceDir: fileCtx?.workspaceDir ?? WORKSPACE_SENTINEL,
         skillSourceDirs: fileCtx?.skillSourceDirs ?? [],
       };
 

--- a/gateway/src/ipc/risk-classification-handlers.ts
+++ b/gateway/src/ipc/risk-classification-handlers.ts
@@ -447,11 +447,21 @@ export async function handleClassifyRisk(
         context,
       );
 
-      // File tools always emit a directory scope ladder: either the filePath's
-      // parent (when provided) or the working directory as the ancestor.
+      // For a to_sandbox transfer the operation's subject is the sandbox
+      // destination (resolved against the sandbox working dir), not the host
+      // source — scope grants and resolved paths must reflect that target so a
+      // source-scoped directory grant can't auto-approve a destination
+      // escalation. sandboxPath is only set for to_sandbox transfers.
+      const subjectPath = params.sandboxPath ?? filePath;
+      const subjectWorkingDir = params.sandboxPath
+        ? (params.sandboxWorkingDir ?? workingDir)
+        : workingDir;
+
+      // File tools always emit a directory scope ladder: either the subject
+      // path's parent (when provided) or the working directory as the ancestor.
       const directoryScopeOptions = generateDirectoryScopeOptions({
-        pathArgs: filePath ? [filePath] : [],
-        workingDir,
+        pathArgs: subjectPath ? [subjectPath] : [],
+        workingDir: subjectWorkingDir,
         workspaceRoot: params.workspaceRoot,
       });
 
@@ -461,15 +471,15 @@ export async function handleClassifyRisk(
         scopeOptions: assessment.scopeOptions,
         allowlistOptions: assessment.allowlistOptions,
         directoryScopeOptions,
-        resolvedPaths: filePath
+        resolvedPaths: subjectPath
           ? [
-              filePath === "~"
+              subjectPath === "~"
                 ? homedir()
-                : filePath.startsWith("~/")
-                  ? join(homedir(), filePath.slice(2))
-                  : isAbsolute(filePath)
-                    ? resolve(filePath)
-                    : resolve(workingDir, filePath),
+                : subjectPath.startsWith("~/")
+                  ? join(homedir(), subjectPath.slice(2))
+                  : isAbsolute(subjectPath)
+                    ? resolve(subjectPath)
+                    : resolve(subjectWorkingDir, subjectPath),
             ]
           : undefined,
         matchType: assessment.matchType,

--- a/gateway/src/risk/file-risk-classifier.test.ts
+++ b/gateway/src/risk/file-risk-classifier.test.ts
@@ -18,9 +18,10 @@ const MOCK_DEPRECATED_DIR = join(
   "workspace",
   "deprecated",
 );
-const MOCK_HOOKS_DIR = join(homedir(), ".vellum", "workspace", "hooks");
-const MOCK_PLUGINS_DIR = join(homedir(), ".vellum", "workspace", "plugins");
-const MOCK_TOOLS_DIR = join(homedir(), ".vellum", "workspace", "tools");
+const MOCK_WORKSPACE_DIR = join(homedir(), ".vellum", "workspace");
+const MOCK_HOOKS_DIR = join(MOCK_WORKSPACE_DIR, "hooks");
+const MOCK_PLUGINS_DIR = join(MOCK_WORKSPACE_DIR, "plugins");
+const MOCK_TOOLS_DIR = join(MOCK_WORKSPACE_DIR, "tools");
 
 /** Skill source paths managed per-test via the context's skillSourceDirs. */
 let testSkillSourceDirs: string[] = [];
@@ -32,6 +33,7 @@ function makeContext(): FileClassificationContext {
     hooksDir: MOCK_HOOKS_DIR,
     pluginsDir: MOCK_PLUGINS_DIR,
     toolsDir: MOCK_TOOLS_DIR,
+    workspaceDir: MOCK_WORKSPACE_DIR,
     skillSourceDirs: testSkillSourceDirs,
   };
 }
@@ -311,6 +313,33 @@ describe("FileRiskClassifier", () => {
         workingDir: "/",
       });
       expect(result.riskLevel).toBe("low");
+    });
+
+    // The sandbox executor remaps container-scoped /workspace/... paths onto
+    // the real workspace dir even in local mode, so the classifier must too —
+    // otherwise the alias dodges the tools-dir escalation.
+    test("/workspace/ alias into tools directory is high", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: "/workspace/tools/skill_load.ts",
+        // workingDir intentionally unrelated to the workspace dir: only the
+        // /workspace alias remapping should make this resolve into toolsDir.
+        workingDir: "/some/other/cwd",
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to workspace tools directory");
+    });
+
+    test("/workspace/ alias into plugins directory is high", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: "/workspace/plugins/evil/register.ts",
+        workingDir: "/some/other/cwd",
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to plugins directory");
     });
 
     test("non-skill, non-hooks path is low", async () => {

--- a/gateway/src/risk/file-risk-classifier.test.ts
+++ b/gateway/src/risk/file-risk-classifier.test.ts
@@ -777,6 +777,23 @@ describe("FileRiskClassifier", () => {
       });
       expect(result.riskLevel).toBe("medium");
     });
+
+    test("to_sandbox allowlist grants are scoped to the destination, not the source", async () => {
+      testSkillSourceDirs = [];
+      const destFile = join(MOCK_TOOLS_DIR, "skill_load.ts");
+      const result = await classifyInput({
+        toolName: "host_file_transfer",
+        filePath: "/tmp/evil.ts",
+        sandboxPath: destFile,
+        sandboxWorkingDir: MOCK_WORKSPACE_DIR,
+      });
+      const patterns = (result.allowlistOptions ?? []).map((o) => o.pattern);
+      // The exact-file grant targets the dangerous destination...
+      expect(patterns).toContain(`host_file_transfer:${destFile}`);
+      // ...and never the benign host source, which would auto-approve future
+      // transfers into the tools dir.
+      expect(patterns.some((p) => p.includes("/tmp/evil.ts"))).toBe(false);
+    });
   });
 
   // -- Singleton export -------------------------------------------------------

--- a/gateway/src/risk/file-risk-classifier.test.ts
+++ b/gateway/src/risk/file-risk-classifier.test.ts
@@ -33,7 +33,6 @@ function makeContext(): FileClassificationContext {
     hooksDir: MOCK_HOOKS_DIR,
     pluginsDir: MOCK_PLUGINS_DIR,
     toolsDir: MOCK_TOOLS_DIR,
-    workspaceDir: MOCK_WORKSPACE_DIR,
     skillSourceDirs: testSkillSourceDirs,
   };
 }
@@ -317,17 +316,17 @@ describe("FileRiskClassifier", () => {
       expect(result.riskLevel).toBe("low");
     });
 
-    // The sandbox executor remaps container-scoped /workspace/... paths onto
-    // the real workspace dir even in local mode, so the classifier must too —
-    // otherwise the alias dodges the tools-dir escalation.
+    // The sandbox executor strips a container-scoped /workspace/ alias and
+    // resolves the remainder against the tool's workingDir, so the classifier
+    // must too — otherwise the alias dodges the tools-dir escalation.
     test("/workspace/ alias into tools directory is high", async () => {
       testSkillSourceDirs = [];
       const result = await classifyInput({
         toolName: "file_write",
         filePath: "/workspace/tools/skill_load.ts",
-        // workingDir intentionally unrelated to the workspace dir: only the
-        // /workspace alias remapping should make this resolve into toolsDir.
-        workingDir: "/some/other/cwd",
+        // workingDir is the workspace root (the sandbox boundary); the alias
+        // strips to "tools/skill_load.ts" and resolves into toolsDir.
+        workingDir: MOCK_WORKSPACE_DIR,
       });
       expect(result.riskLevel).toBe("high");
       expect(result.reason).toBe("Writes to workspace tools directory");
@@ -338,10 +337,24 @@ describe("FileRiskClassifier", () => {
       const result = await classifyInput({
         toolName: "file_write",
         filePath: "/workspace/plugins/evil/register.ts",
-        workingDir: "/some/other/cwd",
+        workingDir: MOCK_WORKSPACE_DIR,
       });
       expect(result.riskLevel).toBe("high");
       expect(result.reason).toBe("Writes to plugins directory");
+    });
+
+    // workingDir is a sub-directory of the workspace (e.g. the tools dir
+    // itself): the executor resolves /workspace/<name> against it, so a bare
+    // /workspace/skill_load.ts lands in the tools dir and must escalate.
+    test("/workspace alias resolves against a sub-directory workingDir", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: "/workspace/skill_load.ts",
+        workingDir: MOCK_TOOLS_DIR,
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to workspace tools directory");
     });
 
     test("non-skill, non-hooks path is low", async () => {
@@ -736,7 +749,7 @@ describe("FileRiskClassifier", () => {
         toolName: "host_file_transfer",
         filePath: "/tmp/evil.ts",
         sandboxPath: "/workspace/tools/skill_load.ts",
-        sandboxWorkingDir: "/some/other/cwd",
+        sandboxWorkingDir: MOCK_WORKSPACE_DIR,
       });
       expect(result.riskLevel).toBe("high");
       expect(result.reason).toBe("Transfers to workspace tools directory");

--- a/gateway/src/risk/file-risk-classifier.test.ts
+++ b/gateway/src/risk/file-risk-classifier.test.ts
@@ -20,6 +20,7 @@ const MOCK_DEPRECATED_DIR = join(
 );
 const MOCK_HOOKS_DIR = join(homedir(), ".vellum", "workspace", "hooks");
 const MOCK_PLUGINS_DIR = join(homedir(), ".vellum", "workspace", "plugins");
+const MOCK_TOOLS_DIR = join(homedir(), ".vellum", "workspace", "tools");
 
 /** Skill source paths managed per-test via the context's skillSourceDirs. */
 let testSkillSourceDirs: string[] = [];
@@ -30,6 +31,7 @@ function makeContext(): FileClassificationContext {
     deprecatedDir: MOCK_DEPRECATED_DIR,
     hooksDir: MOCK_HOOKS_DIR,
     pluginsDir: MOCK_PLUGINS_DIR,
+    toolsDir: MOCK_TOOLS_DIR,
     skillSourceDirs: testSkillSourceDirs,
   };
 }
@@ -259,6 +261,58 @@ describe("FileRiskClassifier", () => {
       expect(result.riskLevel).toBe("low");
     });
 
+    // Workspace tools dir: <name>.{ts,js} files are dynamic-imported with
+    // daemon privileges on next startup (or hot-loaded by the watcher) and may
+    // override a same-named core tool, so writes here are code-injection risk.
+    test("workspace tools directory itself is high", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: MOCK_TOOLS_DIR,
+        workingDir: "/",
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to workspace tools directory");
+    });
+
+    test("tool file inside workspace tools directory is high", async () => {
+      testSkillSourceDirs = [];
+      const toolFile = join(MOCK_TOOLS_DIR, "my_tool.ts");
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: toolFile,
+        workingDir: "/",
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to workspace tools directory");
+    });
+
+    test("core-tool override inside workspace tools directory is high", async () => {
+      // A workspace tool named after a core tool (e.g. skill_load) overrides it,
+      // so a write here must not be auto-approved as a low-risk workspace write.
+      testSkillSourceDirs = [];
+      const overrideFile = join(MOCK_TOOLS_DIR, "skill_load.ts");
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: overrideFile,
+        workingDir: "/",
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to workspace tools directory");
+    });
+
+    test("path containing 'tools' substring outside tools dir is low", async () => {
+      // Guard against substring matching: only paths under the exact tools dir
+      // escalate, not siblings like /workspace/tools-data/.
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: join(homedir(), ".vellum", "workspace", "tools-data", "x"),
+        workingDir: "/",
+      });
+      expect(result.riskLevel).toBe("low");
+    });
+
     test("non-skill, non-hooks path is low", async () => {
       testSkillSourceDirs = [];
       const result = await classifyInput({
@@ -317,6 +371,18 @@ describe("FileRiskClassifier", () => {
       });
       expect(result.riskLevel).toBe("high");
       expect(result.reason).toBe("Writes to plugins directory");
+    });
+
+    test("workspace tools directory path is high", async () => {
+      testSkillSourceDirs = [];
+      const toolFile = join(MOCK_TOOLS_DIR, "skill_load.ts");
+      const result = await classifyInput({
+        toolName: "file_edit",
+        filePath: toolFile,
+        workingDir: "/",
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to workspace tools directory");
     });
   });
 
@@ -436,6 +502,27 @@ describe("FileRiskClassifier", () => {
       expect(result.riskLevel).toBe("high");
       expect(result.reason).toBe("Writes to plugins directory");
     });
+
+    test("workspace tools directory is high", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "host_file_write",
+        filePath: MOCK_TOOLS_DIR,
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to workspace tools directory");
+    });
+
+    test("tool file inside workspace tools directory is high", async () => {
+      testSkillSourceDirs = [];
+      const toolFile = join(MOCK_TOOLS_DIR, "skill_load.ts");
+      const result = await classifyInput({
+        toolName: "host_file_write",
+        filePath: toolFile,
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to workspace tools directory");
+    });
   });
 
   // -- host_file_edit ---------------------------------------------------------
@@ -484,6 +571,17 @@ describe("FileRiskClassifier", () => {
       });
       expect(result.riskLevel).toBe("high");
       expect(result.reason).toBe("Writes to plugins directory");
+    });
+
+    test("workspace tools directory path is high", async () => {
+      testSkillSourceDirs = [];
+      const toolFile = join(MOCK_TOOLS_DIR, "skill_load.ts");
+      const result = await classifyInput({
+        toolName: "host_file_edit",
+        filePath: toolFile,
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to workspace tools directory");
     });
   });
 
@@ -563,6 +661,27 @@ describe("FileRiskClassifier", () => {
       });
       expect(result.riskLevel).toBe("high");
       expect(result.reason).toBe("Transfers to plugins directory");
+    });
+
+    test("workspace tools directory is high", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "host_file_transfer",
+        filePath: MOCK_TOOLS_DIR,
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Transfers to workspace tools directory");
+    });
+
+    test("tool file inside workspace tools directory is high", async () => {
+      testSkillSourceDirs = [];
+      const toolFile = join(MOCK_TOOLS_DIR, "skill_load.ts");
+      const result = await classifyInput({
+        toolName: "host_file_transfer",
+        filePath: toolFile,
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Transfers to workspace tools directory");
     });
   });
 

--- a/gateway/src/risk/file-risk-classifier.test.ts
+++ b/gateway/src/risk/file-risk-classifier.test.ts
@@ -54,6 +54,8 @@ function classifyInput(
       filePath: input.filePath ?? "",
       workingDir: input.workingDir ?? WORKING_DIR,
       toolName: input.toolName,
+      sandboxPath: input.sandboxPath,
+      sandboxWorkingDir: input.sandboxWorkingDir,
     },
     makeContext(),
   );
@@ -711,6 +713,56 @@ describe("FileRiskClassifier", () => {
       });
       expect(result.riskLevel).toBe("high");
       expect(result.reason).toBe("Transfers to workspace tools directory");
+    });
+
+    // to_sandbox transfers: the host source (filePath) is benign, but the
+    // sandbox destination (sandboxPath) plants daemon-loaded code. The
+    // destination must be classified for the workspace escalations.
+    test("to_sandbox destination inside tools dir is high (benign host source)", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "host_file_transfer",
+        filePath: "/tmp/evil.ts",
+        sandboxPath: join(MOCK_TOOLS_DIR, "skill_load.ts"),
+        sandboxWorkingDir: MOCK_WORKSPACE_DIR,
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Transfers to workspace tools directory");
+    });
+
+    test("to_sandbox destination via /workspace alias into tools dir is high", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "host_file_transfer",
+        filePath: "/tmp/evil.ts",
+        sandboxPath: "/workspace/tools/skill_load.ts",
+        sandboxWorkingDir: "/some/other/cwd",
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Transfers to workspace tools directory");
+    });
+
+    test("to_sandbox destination into plugins dir is high", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "host_file_transfer",
+        filePath: "/tmp/evil.ts",
+        sandboxPath: join(MOCK_PLUGINS_DIR, "evil", "register.ts"),
+        sandboxWorkingDir: MOCK_WORKSPACE_DIR,
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Transfers to plugins directory");
+    });
+
+    test("to_sandbox destination outside escalation dirs is medium", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "host_file_transfer",
+        filePath: "/tmp/evil.ts",
+        sandboxPath: join(MOCK_WORKSPACE_DIR, "scratch", "note.txt"),
+        sandboxWorkingDir: MOCK_WORKSPACE_DIR,
+      });
+      expect(result.riskLevel).toBe("medium");
     });
   });
 

--- a/gateway/src/risk/file-risk-classifier.ts
+++ b/gateway/src/risk/file-risk-classifier.ts
@@ -66,16 +66,6 @@ export interface FileClassificationContext {
    */
   toolsDir: string;
   /**
-   * Absolute path to the sandbox workspace boundary directory
-   * (`VELLUM_WORKSPACE_DIR`). Sandbox file tools accept container-scoped
-   * `/workspace/...` paths and the executor remaps them onto this boundary
-   * (see {@link ../tools/shared/filesystem/path-policy.ts sandboxPolicy}).
-   * The classifier applies the same remapping before its escalation checks
-   * so a `/workspace/tools/<name>.ts` alias can't slip a write past the
-   * tools/hooks/plugins/skill escalations in local (non-`/workspace`) mode.
-   */
-  workspaceDir: string;
-  /**
    * Absolute paths of all skill source root directories (managed, bundled,
    * and any extra dirs from config). The classifier checks whether a file
    * path falls under any of these roots.
@@ -127,30 +117,23 @@ const CONTAINER_WORKSPACE_PREFIX = "/workspace/";
 const CONTAINER_WORKSPACE_EXACT = "/workspace";
 
 /**
- * Remap a container-scoped `/workspace/...` path onto the real workspace
- * boundary before resolution, mirroring `sandboxPolicy` in path-policy.ts.
- * Only sandbox file tools (file_read/file_write/file_edit) accept the alias;
- * host file tools operate on real host paths and must not be remapped.
+ * Resolve a sandbox file path the same way the executor's `sandboxPolicy`
+ * (path-policy.ts) does: a container-scoped `/workspace/...` alias is stripped
+ * to its remainder and resolved against `workingDir` (the sandbox boundary),
+ * so classification and execution land on the same target — including when
+ * `workingDir` is a sub-directory of the workspace. Only sandbox file tools
+ * (file_read/file_write/file_edit, and the sandbox side of host_file_transfer)
+ * accept the alias; host paths must not be remapped.
  */
-function resolveSandboxPath(
-  filePath: string,
-  workingDir: string,
-  context: FileClassificationContext,
-): string {
+function resolveSandboxPath(filePath: string, workingDir: string): string {
   let effectivePath = filePath;
-  // Skip remapping if the path already starts with the real workspace dir, to
-  // avoid double-nesting (matches sandboxPolicy's guard).
-  if (
-    !filePath.startsWith(context.workspaceDir + "/") &&
-    filePath !== context.workspaceDir
-  ) {
+  // Skip remapping if the path already sits under workingDir, to avoid
+  // double-nesting (matches sandboxPolicy's guard).
+  if (!filePath.startsWith(workingDir + "/") && filePath !== workingDir) {
     if (filePath.startsWith(CONTAINER_WORKSPACE_PREFIX)) {
-      effectivePath = join(
-        context.workspaceDir,
-        filePath.slice(CONTAINER_WORKSPACE_PREFIX.length),
-      );
+      effectivePath = filePath.slice(CONTAINER_WORKSPACE_PREFIX.length);
     } else if (filePath === CONTAINER_WORKSPACE_EXACT) {
-      effectivePath = context.workspaceDir;
+      effectivePath = ".";
     }
   }
   return resolve(workingDir, effectivePath);
@@ -374,11 +357,7 @@ export class FileRiskClassifier implements RiskClassifier<
     switch (toolName) {
       case "file_read": {
         if (filePath) {
-          const resolvedPath = resolveSandboxPath(
-            filePath,
-            workingDir,
-            context,
-          );
+          const resolvedPath = resolveSandboxPath(filePath, workingDir);
           if (isActorTokenSigningKeyPath(resolvedPath, workingDir, context)) {
             assessment = {
               riskLevel: "high",
@@ -403,11 +382,7 @@ export class FileRiskClassifier implements RiskClassifier<
       case "file_write":
       case "file_edit": {
         if (filePath) {
-          const resolvedPath = resolveSandboxPath(
-            filePath,
-            workingDir,
-            context,
-          );
+          const resolvedPath = resolveSandboxPath(filePath, workingDir);
           const reason = workspaceCodeWriteReason(
             resolvedPath,
             context,
@@ -464,7 +439,6 @@ export class FileRiskClassifier implements RiskClassifier<
           const sandboxResolved = resolveSandboxPath(
             input.sandboxPath,
             input.sandboxWorkingDir ?? workingDir,
-            context,
           );
           const reason = workspaceCodeWriteReason(
             sandboxResolved,

--- a/gateway/src/risk/file-risk-classifier.ts
+++ b/gateway/src/risk/file-risk-classifier.ts
@@ -66,6 +66,16 @@ export interface FileClassificationContext {
    */
   toolsDir: string;
   /**
+   * Absolute path to the sandbox workspace boundary directory
+   * (`VELLUM_WORKSPACE_DIR`). Sandbox file tools accept container-scoped
+   * `/workspace/...` paths and the executor remaps them onto this boundary
+   * (see {@link ../tools/shared/filesystem/path-policy.ts sandboxPolicy}).
+   * The classifier applies the same remapping before its escalation checks
+   * so a `/workspace/tools/<name>.ts` alias can't slip a write past the
+   * tools/hooks/plugins/skill escalations in local (non-`/workspace`) mode.
+   */
+  workspaceDir: string;
+  /**
    * Absolute paths of all skill source root directories (managed, bundled,
    * and any extra dirs from config). The classifier checks whether a file
    * path falls under any of these roots.
@@ -96,6 +106,44 @@ export interface FileClassifierInput {
  */
 function normalizeDirPath(dirPath: string): string {
   return dirPath.endsWith("/") ? dirPath : dirPath + "/";
+}
+
+// The Docker sandbox mounts the host workspace at /workspace inside the
+// container, and the sandbox file executor accepts these container-scoped
+// paths even in local mode (see path-policy.ts sandboxPolicy). Mirror its
+// remapping so an attacker can't dodge an escalation by addressing a
+// protected directory through the alias instead of the real path.
+const CONTAINER_WORKSPACE_PREFIX = "/workspace/";
+const CONTAINER_WORKSPACE_EXACT = "/workspace";
+
+/**
+ * Remap a container-scoped `/workspace/...` path onto the real workspace
+ * boundary before resolution, mirroring `sandboxPolicy` in path-policy.ts.
+ * Only sandbox file tools (file_read/file_write/file_edit) accept the alias;
+ * host file tools operate on real host paths and must not be remapped.
+ */
+function resolveSandboxPath(
+  filePath: string,
+  workingDir: string,
+  context: FileClassificationContext,
+): string {
+  let effectivePath = filePath;
+  // Skip remapping if the path already starts with the real workspace dir, to
+  // avoid double-nesting (matches sandboxPolicy's guard).
+  if (
+    !filePath.startsWith(context.workspaceDir + "/") &&
+    filePath !== context.workspaceDir
+  ) {
+    if (filePath.startsWith(CONTAINER_WORKSPACE_PREFIX)) {
+      effectivePath = join(
+        context.workspaceDir,
+        filePath.slice(CONTAINER_WORKSPACE_PREFIX.length),
+      );
+    } else if (filePath === CONTAINER_WORKSPACE_EXACT) {
+      effectivePath = context.workspaceDir;
+    }
+  }
+  return resolve(workingDir, effectivePath);
 }
 
 /**
@@ -289,7 +337,11 @@ export class FileRiskClassifier implements RiskClassifier<
     switch (toolName) {
       case "file_read": {
         if (filePath) {
-          const resolvedPath = resolve(workingDir, filePath);
+          const resolvedPath = resolveSandboxPath(
+            filePath,
+            workingDir,
+            context,
+          );
           if (isActorTokenSigningKeyPath(resolvedPath, workingDir, context)) {
             assessment = {
               riskLevel: "high",
@@ -314,7 +366,11 @@ export class FileRiskClassifier implements RiskClassifier<
       case "file_write":
       case "file_edit": {
         if (filePath) {
-          const resolvedPath = resolve(workingDir, filePath);
+          const resolvedPath = resolveSandboxPath(
+            filePath,
+            workingDir,
+            context,
+          );
           if (isSkillSourcePath(resolvedPath, context)) {
             assessment = {
               riskLevel: "high",

--- a/gateway/src/risk/file-risk-classifier.ts
+++ b/gateway/src/risk/file-risk-classifier.ts
@@ -346,8 +346,15 @@ export class FileRiskClassifier implements RiskClassifier<
     context: FileClassificationContext,
   ): Promise<RiskAssessment> {
     const { toolName, filePath, workingDir } = input;
-    const allowlistOptions = filePath
-      ? buildFileAllowlistOptions(toolName, filePath)
+    // The security-relevant subject of the operation. For a to_sandbox
+    // transfer that's the sandbox destination (where code is planted), not the
+    // benign host source in `filePath`. Allowlist grants and user-override
+    // lookups key on this so a source-scoped rule can't downgrade a
+    // destination escalation, and an approval grants the destination. Only
+    // to_sandbox transfers set `sandboxPath`, so every other case is unchanged.
+    const subjectPath = input.sandboxPath ?? filePath;
+    const allowlistOptions = subjectPath
+      ? buildFileAllowlistOptions(toolName, subjectPath)
       : [];
 
     // Run normal classification first (including all security escalations),
@@ -501,7 +508,7 @@ export class FileRiskClassifier implements RiskClassifier<
     // created them.
     try {
       const ruleCache = getTrustRuleCache();
-      const override = ruleCache.findToolOverride(toolName, filePath);
+      const override = ruleCache.findToolOverride(toolName, subjectPath);
       if (
         override &&
         (override.userModified || override.origin === "user_defined")

--- a/gateway/src/risk/file-risk-classifier.ts
+++ b/gateway/src/risk/file-risk-classifier.ts
@@ -8,14 +8,15 @@
  * Risk escalation paths:
  * - file_read: Low by default, High if targeting the actor token signing key.
  * - file_write / file_edit: Low by default, High if targeting skill source
- *   code, the workspace hooks directory, or the user plugins directory.
+ *   code, the workspace hooks directory, the user plugins directory, or the
+ *   workspace tools directory.
  * - host_file_read: Medium (tool registry default; no special escalation).
  * - host_file_write / host_file_edit: Medium by default, High if targeting
- *   skill source code, the workspace hooks directory, or the user plugins
- *   directory.
+ *   skill source code, the workspace hooks directory, the user plugins
+ *   directory, or the workspace tools directory.
  * - host_file_transfer: Medium by default, High if the host-side path
- *   targets skill source code, the workspace hooks directory, or the user
- *   plugins directory.
+ *   targets skill source code, the workspace hooks directory, the user
+ *   plugins directory, or the workspace tools directory.
  *
  * Gateway adaptation: accepts a FileClassificationContext parameter instead
  * of importing assistant platform utilities directly. The assistant is
@@ -55,6 +56,15 @@ export interface FileClassificationContext {
   hooksDir: string;
   /** Absolute path to the user plugins directory. */
   pluginsDir: string;
+  /**
+   * Absolute path to the workspace tools directory
+   * (`<workspaceDir>/tools`). Workspace tool files (`<name>.{ts,js}`) are
+   * dynamic-imported with daemon privileges at next startup (and hot-loaded
+   * by the workspace-tools watcher), and a workspace tool may override a
+   * same-named core tool — so a write here must be treated as code-injection
+   * risk, exactly like {@link pluginsDir}.
+   */
+  toolsDir: string;
   /**
    * Absolute paths of all skill source root directories (managed, bundled,
    * and any extra dirs from config). The classifier checks whether a file
@@ -146,6 +156,26 @@ function isPluginsPath(
 }
 
 /**
+ * Check whether a resolved absolute path falls inside the workspace tools
+ * directory (or IS the tools directory itself). Mirrors {@link isPluginsPath}
+ * because the workspace tool loader has the same threat model: any file under
+ * `<toolsDir>/<name>.{ts,js}` may be dynamic-imported at next daemon startup
+ * (or hot-loaded by the watcher) and may override a same-named core tool, so a
+ * write here must be treated as code-injection risk.
+ */
+function isToolsPath(
+  resolvedPath: string,
+  context: FileClassificationContext,
+): boolean {
+  const normalizedToolsDir = normalizeDirPath(context.toolsDir);
+  const toolsDirNoTrailingSlash = normalizedToolsDir.slice(0, -1);
+  return (
+    resolvedPath === toolsDirNoTrailingSlash ||
+    resolvedPath.startsWith(normalizedToolsDir)
+  );
+}
+
+/**
  * Check whether a resolved absolute path falls under any skill source
  * directory.
  */
@@ -232,7 +262,8 @@ function buildFileAllowlistOptions(
  * File risk classifier implementation.
  *
  * Classifies all six file tool types by risk level, with escalation paths
- * for skill source code, workspace hooks, and the actor token signing key.
+ * for skill source code, workspace hooks, the user plugins directory, the
+ * workspace tools directory, and the actor token signing key.
  *
  * Unlike the assistant version, this classifier accepts a
  * FileClassificationContext parameter on classify() instead of importing
@@ -314,6 +345,16 @@ export class FileRiskClassifier implements RiskClassifier<
             };
             break;
           }
+          if (isToolsPath(resolvedPath, context)) {
+            assessment = {
+              riskLevel: "high",
+              reason: "Writes to workspace tools directory",
+              scopeOptions: [],
+              matchType: "registry",
+              allowlistOptions,
+            };
+            break;
+          }
         }
         assessment = {
           riskLevel: "low",
@@ -373,6 +414,16 @@ export class FileRiskClassifier implements RiskClassifier<
             assessment = {
               riskLevel: "high",
               reason: `${actionVerb} to plugins directory`,
+              scopeOptions: [],
+              matchType: "registry",
+              allowlistOptions,
+            };
+            break;
+          }
+          if (isToolsPath(resolvedPath, context)) {
+            assessment = {
+              riskLevel: "high",
+              reason: `${actionVerb} to workspace tools directory`,
               scopeOptions: [],
               matchType: "registry",
               allowlistOptions,

--- a/gateway/src/risk/file-risk-classifier.ts
+++ b/gateway/src/risk/file-risk-classifier.ts
@@ -97,6 +97,16 @@ export interface FileClassifierInput {
     | "host_file_transfer";
   filePath: string;
   workingDir: string;
+  /**
+   * For `host_file_transfer` with `direction: "to_sandbox"`, the sandbox-side
+   * destination path — the workspace location the transfer writes to. The
+   * host-side `filePath` is the (benign) read source, so the workspace
+   * code-injection escalations must run against this path instead. Unset for
+   * every other tool / direction.
+   */
+  sandboxPath?: string;
+  /** Sandbox working directory used to resolve a relative {@link sandboxPath}. */
+  sandboxWorkingDir?: string;
 }
 
 // -- Helpers ------------------------------------------------------------------
@@ -240,6 +250,33 @@ function isSkillSourcePath(
   return false;
 }
 
+/**
+ * If a resolved path targets a workspace directory whose contents become
+ * daemon-executed / hot-loaded code (skill source, hooks, user plugins, or
+ * workspace tools), return the high-risk escalation reason; otherwise null.
+ * `verb` is "Writes" for direct writes/edits and "Transfers" for host
+ * transfers, matching the existing reason strings.
+ */
+function workspaceCodeWriteReason(
+  resolvedPath: string,
+  context: FileClassificationContext,
+  verb: "Writes" | "Transfers",
+): string | null {
+  if (isSkillSourcePath(resolvedPath, context)) {
+    return `${verb} to skill source code`;
+  }
+  if (isHooksPath(resolvedPath, context)) {
+    return `${verb} to hooks directory`;
+  }
+  if (isPluginsPath(resolvedPath, context)) {
+    return `${verb} to plugins directory`;
+  }
+  if (isToolsPath(resolvedPath, context)) {
+    return `${verb} to workspace tools directory`;
+  }
+  return null;
+}
+
 // -- Allowlist option helpers -------------------------------------------------
 
 const FILE_TOOL_DISPLAY_NAMES: Record<string, string> = {
@@ -371,40 +408,15 @@ export class FileRiskClassifier implements RiskClassifier<
             workingDir,
             context,
           );
-          if (isSkillSourcePath(resolvedPath, context)) {
+          const reason = workspaceCodeWriteReason(
+            resolvedPath,
+            context,
+            "Writes",
+          );
+          if (reason) {
             assessment = {
               riskLevel: "high",
-              reason: "Writes to skill source code",
-              scopeOptions: [],
-              matchType: "registry",
-              allowlistOptions,
-            };
-            break;
-          }
-          if (isHooksPath(resolvedPath, context)) {
-            assessment = {
-              riskLevel: "high",
-              reason: "Writes to hooks directory",
-              scopeOptions: [],
-              matchType: "registry",
-              allowlistOptions,
-            };
-            break;
-          }
-          if (isPluginsPath(resolvedPath, context)) {
-            assessment = {
-              riskLevel: "high",
-              reason: "Writes to plugins directory",
-              scopeOptions: [],
-              matchType: "registry",
-              allowlistOptions,
-            };
-            break;
-          }
-          if (isToolsPath(resolvedPath, context)) {
-            assessment = {
-              riskLevel: "high",
-              reason: "Writes to workspace tools directory",
+              reason,
               scopeOptions: [],
               matchType: "registry",
               allowlistOptions,
@@ -442,44 +454,48 @@ export class FileRiskClassifier implements RiskClassifier<
         // "Writes" for write/edit (both mutate files), "Transfers" for transfer.
         const actionVerb =
           toolName === "host_file_transfer" ? "Transfers" : "Writes";
+
+        // For a `to_sandbox` transfer the file the model can weaponize is the
+        // sandbox *destination* (where daemon-loaded code is planted), not the
+        // host source carried by `filePath`. Classify that destination against
+        // the workspace code-injection escalations — with the same /workspace
+        // remapping — and take the higher risk.
+        if (toolName === "host_file_transfer" && input.sandboxPath) {
+          const sandboxResolved = resolveSandboxPath(
+            input.sandboxPath,
+            input.sandboxWorkingDir ?? workingDir,
+            context,
+          );
+          const reason = workspaceCodeWriteReason(
+            sandboxResolved,
+            context,
+            "Transfers",
+          );
+          if (reason) {
+            assessment = {
+              riskLevel: "high",
+              reason,
+              scopeOptions: [],
+              matchType: "registry",
+              allowlistOptions,
+            };
+            break;
+          }
+        }
+
         if (filePath) {
           // Host file tools resolve paths without workingDir — resolve(filePath)
           // treats the path as absolute or relative to cwd.
           const resolvedPath = resolve(filePath);
-          if (isSkillSourcePath(resolvedPath, context)) {
+          const reason = workspaceCodeWriteReason(
+            resolvedPath,
+            context,
+            actionVerb,
+          );
+          if (reason) {
             assessment = {
               riskLevel: "high",
-              reason: `${actionVerb} to skill source code`,
-              scopeOptions: [],
-              matchType: "registry",
-              allowlistOptions,
-            };
-            break;
-          }
-          if (isHooksPath(resolvedPath, context)) {
-            assessment = {
-              riskLevel: "high",
-              reason: `${actionVerb} to hooks directory`,
-              scopeOptions: [],
-              matchType: "registry",
-              allowlistOptions,
-            };
-            break;
-          }
-          if (isPluginsPath(resolvedPath, context)) {
-            assessment = {
-              riskLevel: "high",
-              reason: `${actionVerb} to plugins directory`,
-              scopeOptions: [],
-              matchType: "registry",
-              allowlistOptions,
-            };
-            break;
-          }
-          if (isToolsPath(resolvedPath, context)) {
-            assessment = {
-              riskLevel: "high",
-              reason: `${actionVerb} to workspace tools directory`,
+              reason,
               scopeOptions: [],
               matchType: "registry",
               allowlistOptions,

--- a/gateway/src/risk/file-risk-classifier.ts
+++ b/gateway/src/risk/file-risk-classifier.ts
@@ -354,8 +354,32 @@ export class FileRiskClassifier implements RiskClassifier<
     // destination escalation, and an approval grants the destination. Only
     // to_sandbox transfers set `sandboxPath`, so every other case is unchanged.
     const subjectPath = input.sandboxPath ?? filePath;
-    const allowlistOptions = subjectPath
-      ? buildFileAllowlistOptions(toolName, subjectPath)
+    // Canonicalize the subject the same way the executor resolves it, so
+    // allowlist grants and user-override lookups key on the actual target file
+    // rather than a `/workspace` alias or relative string. The same literal
+    // path resolves to different files under different working dirs, so keying
+    // on the raw string would let a rule saved from a benign directory match —
+    // and downgrade — a later write that resolves into an escalated dir.
+    const isSandboxFileTool =
+      toolName === "file_read" ||
+      toolName === "file_write" ||
+      toolName === "file_edit";
+    let resolvedSubjectPath = subjectPath;
+    if (subjectPath) {
+      if (input.sandboxPath) {
+        resolvedSubjectPath = resolveSandboxPath(
+          input.sandboxPath,
+          input.sandboxWorkingDir ?? workingDir,
+        );
+      } else if (isSandboxFileTool) {
+        resolvedSubjectPath = resolveSandboxPath(filePath, workingDir);
+      } else {
+        // Host tools operate on real host paths (no /workspace remapping).
+        resolvedSubjectPath = resolve(filePath);
+      }
+    }
+    const allowlistOptions = resolvedSubjectPath
+      ? buildFileAllowlistOptions(toolName, resolvedSubjectPath)
       : [];
 
     // Run normal classification first (including all security escalations),
@@ -520,7 +544,10 @@ export class FileRiskClassifier implements RiskClassifier<
       const ruleCache = getTrustRuleCache();
       let result = assessment!;
 
-      const primaryOverride = ruleCache.findToolOverride(toolName, subjectPath);
+      const primaryOverride = ruleCache.findToolOverride(
+        toolName,
+        resolvedSubjectPath,
+      );
       if (
         primaryOverride &&
         (primaryOverride.userModified ||
@@ -536,7 +563,10 @@ export class FileRiskClassifier implements RiskClassifier<
       }
 
       if (input.sandboxPath) {
-        const sourceOverride = ruleCache.findToolOverride(toolName, filePath);
+        const sourceOverride = ruleCache.findToolOverride(
+          toolName,
+          resolve(filePath),
+        );
         if (
           sourceOverride &&
           (sourceOverride.userModified ||

--- a/gateway/src/risk/file-risk-classifier.ts
+++ b/gateway/src/risk/file-risk-classifier.ts
@@ -38,6 +38,7 @@ import type {
   RiskAssessment,
   RiskClassifier,
 } from "./risk-types.js";
+import { riskOrd } from "./risk-types.js";
 import { getTrustRuleCache } from "./trust-rule-cache.js";
 
 // -- Context interface --------------------------------------------------------
@@ -502,12 +503,38 @@ export class FileRiskClassifier implements RiskClassifier<
       }
     }
 
-    // User override is applied after normal classification. This means a user-defined
-    // rule CAN lower a security-escalated risk (e.g., actor-token-signing-key read).
-    // This is intentional — user overrides are authoritative for users who explicitly
-    // created them.
+    // User override is applied after normal classification. For a single-
+    // subject tool this means a user-defined rule CAN lower a security-
+    // escalated risk (e.g., actor-token-signing-key read) — intentional, since
+    // user overrides are authoritative for rules they explicitly created.
     try {
       const ruleCache = getTrustRuleCache();
+      if (input.sandboxPath) {
+        // A to_sandbox transfer has two subjects: the host source (filePath)
+        // and the sandbox destination (sandboxPath). A user rule on either
+        // applies; take the highest risk among the joint classification and
+        // both overrides so neither a benign-source rule downgrades a
+        // dangerous destination, nor a sensitive-source rule (e.g.
+        // `host_file_transfer:/etc/secret`) is ignored for a benign one.
+        let best = assessment!;
+        for (const p of [filePath, input.sandboxPath]) {
+          const override = ruleCache.findToolOverride(toolName, p);
+          if (
+            override &&
+            (override.userModified || override.origin === "user_defined") &&
+            riskOrd(override.risk) > riskOrd(best.riskLevel)
+          ) {
+            best = {
+              riskLevel: override.risk,
+              reason: override.description,
+              scopeOptions: [],
+              matchType: "user_rule",
+              allowlistOptions,
+            };
+          }
+        }
+        return best;
+      }
       const override = ruleCache.findToolOverride(toolName, subjectPath);
       if (
         override &&

--- a/gateway/src/risk/file-risk-classifier.ts
+++ b/gateway/src/risk/file-risk-classifier.ts
@@ -503,51 +503,57 @@ export class FileRiskClassifier implements RiskClassifier<
       }
     }
 
-    // User override is applied after normal classification. For a single-
-    // subject tool this means a user-defined rule CAN lower a security-
-    // escalated risk (e.g., actor-token-signing-key read) — intentional, since
-    // user overrides are authoritative for rules they explicitly created.
+    // User overrides are applied after normal classification.
+    //
+    // The primary subject (`subjectPath` — filePath for most tools, the
+    // sandbox destination for a to_sandbox transfer) is authoritative: a rule
+    // the user explicitly created for it REPLACES the classification and may
+    // intentionally lower it (e.g. honoring an approval of a benign transfer's
+    // destination, or lowering an actor-token-signing-key read).
+    //
+    // A to_sandbox transfer also has a secondary subject — the host source
+    // (`filePath`). A rule there may only RAISE risk (e.g. a sensitive source
+    // such as `host_file_transfer:/etc/secret`); it must not downgrade a
+    // dangerous destination, so it applies only when it escalates above the
+    // already-resolved result.
     try {
       const ruleCache = getTrustRuleCache();
-      if (input.sandboxPath) {
-        // A to_sandbox transfer has two subjects: the host source (filePath)
-        // and the sandbox destination (sandboxPath). A user rule on either
-        // applies; take the highest risk among the joint classification and
-        // both overrides so neither a benign-source rule downgrades a
-        // dangerous destination, nor a sensitive-source rule (e.g.
-        // `host_file_transfer:/etc/secret`) is ignored for a benign one.
-        let best = assessment!;
-        for (const p of [filePath, input.sandboxPath]) {
-          const override = ruleCache.findToolOverride(toolName, p);
-          if (
-            override &&
-            (override.userModified || override.origin === "user_defined") &&
-            riskOrd(override.risk) > riskOrd(best.riskLevel)
-          ) {
-            best = {
-              riskLevel: override.risk,
-              reason: override.description,
-              scopeOptions: [],
-              matchType: "user_rule",
-              allowlistOptions,
-            };
-          }
-        }
-        return best;
-      }
-      const override = ruleCache.findToolOverride(toolName, subjectPath);
+      let result = assessment!;
+
+      const primaryOverride = ruleCache.findToolOverride(toolName, subjectPath);
       if (
-        override &&
-        (override.userModified || override.origin === "user_defined")
+        primaryOverride &&
+        (primaryOverride.userModified ||
+          primaryOverride.origin === "user_defined")
       ) {
-        return {
-          riskLevel: override.risk,
-          reason: override.description,
+        result = {
+          riskLevel: primaryOverride.risk,
+          reason: primaryOverride.description,
           scopeOptions: [],
           matchType: "user_rule",
           allowlistOptions,
         };
       }
+
+      if (input.sandboxPath) {
+        const sourceOverride = ruleCache.findToolOverride(toolName, filePath);
+        if (
+          sourceOverride &&
+          (sourceOverride.userModified ||
+            sourceOverride.origin === "user_defined") &&
+          riskOrd(sourceOverride.risk) > riskOrd(result.riskLevel)
+        ) {
+          result = {
+            riskLevel: sourceOverride.risk,
+            reason: sourceOverride.description,
+            scopeOptions: [],
+            matchType: "user_rule",
+            allowlistOptions,
+          };
+        }
+      }
+
+      return result;
     } catch {
       // Cache not initialized — no override
     }

--- a/gateway/src/risk/file-risk-classifier.ts
+++ b/gateway/src/risk/file-risk-classifier.ts
@@ -529,57 +529,61 @@ export class FileRiskClassifier implements RiskClassifier<
 
     // User overrides are applied after normal classification.
     //
-    // The primary subject (`subjectPath` — filePath for most tools, the
-    // sandbox destination for a to_sandbox transfer) is authoritative: a rule
-    // the user explicitly created for it REPLACES the classification and may
-    // intentionally lower it (e.g. honoring an approval of a benign transfer's
-    // destination, or lowering an actor-token-signing-key read).
+    // The primary subject (the resolved `subjectPath` — filePath for most
+    // tools, the sandbox destination for a to_sandbox transfer) is
+    // authoritative: a rule the user explicitly created for the actual target
+    // file REPLACES the classification and may intentionally lower it (e.g.
+    // honoring an approval of a benign transfer's destination, or lowering an
+    // actor-token-signing-key read).
     //
-    // A to_sandbox transfer also has a secondary subject — the host source
-    // (`filePath`). A rule there may only RAISE risk (e.g. a sensitive source
-    // such as `host_file_transfer:/etc/secret`); it must not downgrade a
-    // dangerous destination, so it applies only when it escalates above the
-    // already-resolved result.
+    // Two secondary lookups may only RAISE risk (never downgrade the resolved
+    // result): (1) the host source of a to_sandbox transfer — a sensitive
+    // source such as `host_file_transfer:/etc/secret` must still escalate; and
+    // (2) the pre-canonicalization RAW path — a legacy rule saved against a
+    // relative/alias path is kept working, but only to escalate, since a raw
+    // path resolves ambiguously across working dirs and must not be trusted to
+    // lower a now-escalated write.
     try {
       const ruleCache = getTrustRuleCache();
-      let result = assessment!;
-
-      const primaryOverride = ruleCache.findToolOverride(
-        toolName,
-        resolvedSubjectPath,
-      );
-      if (
-        primaryOverride &&
-        (primaryOverride.userModified ||
-          primaryOverride.origin === "user_defined")
-      ) {
-        result = {
-          riskLevel: primaryOverride.risk,
-          reason: primaryOverride.description,
-          scopeOptions: [],
-          matchType: "user_rule",
-          allowlistOptions,
-        };
-      }
-
-      if (input.sandboxPath) {
-        const sourceOverride = ruleCache.findToolOverride(
-          toolName,
-          resolve(filePath),
-        );
-        if (
-          sourceOverride &&
-          (sourceOverride.userModified ||
-            sourceOverride.origin === "user_defined") &&
-          riskOrd(sourceOverride.risk) > riskOrd(result.riskLevel)
-        ) {
-          result = {
-            riskLevel: sourceOverride.risk,
-            reason: sourceOverride.description,
+      const asUserRule = (path: string): RiskAssessment | null => {
+        const ov = ruleCache.findToolOverride(toolName, path);
+        if (ov && (ov.userModified || ov.origin === "user_defined")) {
+          return {
+            riskLevel: ov.risk,
+            reason: ov.description,
             scopeOptions: [],
             matchType: "user_rule",
             allowlistOptions,
           };
+        }
+        return null;
+      };
+
+      let result = assessment!;
+
+      // Primary (canonical) subject rule replaces — may lower or raise.
+      const primary = asUserRule(resolvedSubjectPath);
+      if (primary) {
+        result = primary;
+      }
+
+      // Raise-only lookups: the legacy raw subject path, and (for a to_sandbox
+      // transfer) the host source in both resolved and raw form.
+      const raiseOnlyPaths = new Set<string>();
+      if (subjectPath && subjectPath !== resolvedSubjectPath) {
+        raiseOnlyPaths.add(subjectPath);
+      }
+      if (input.sandboxPath && filePath) {
+        raiseOnlyPaths.add(resolve(filePath));
+        raiseOnlyPaths.add(filePath);
+      }
+      for (const path of raiseOnlyPaths) {
+        const candidate = asUserRule(path);
+        if (
+          candidate &&
+          riskOrd(candidate.riskLevel) > riskOrd(result.riskLevel)
+        ) {
+          result = candidate;
         }
       }
 


### PR DESCRIPTION
## Summary
- Workspace tool files at `<workspaceDir>/tools/<name>.{ts,js}` are dynamic-`import()`-ed with daemon privileges at startup (and hot-loaded by the workspace-tools watcher), and a workspace tool may **override a same-named core tool** (e.g. `skill_load`). Writes to that directory were classified as default **low/medium** risk and could be auto-approved — so a prompt-injected assistant could plant daemon-privileged code that runs on next restart.
- Adds `<workspaceDir>/tools` as a **high-risk** write target in the gateway file-risk classifier for `file_write`/`file_edit` and `host_file_write`/`host_file_edit`/`host_file_transfer`, exactly mirroring the existing plugins-directory escalation (ATL-534 / #30399). The platform helper `getWorkspaceToolsDir` already documented that this path *should* be escalated 'for the same reason `plugins/` is escalated' — this wires it up.
- Threads a new `toolsDir` through `FileClassificationContext`, the IPC `FileContext` type + zod schema (optional, SENTINEL fallback), and `buildFileContext()`. Adds classifier + IPC-handler tests covering the tools dir itself, files inside it, the core-tool-override case, and a substring guard.

Codex finding: https://chatgpt.com/codex/security/findings/62742d645d808191b5c8e92b3b28aa1f

## Original prompt
Triage of Codex security finding ATL-830: workspace tool writes bypass high-risk approval because `<workspaceDir>/tools` was missing from the gateway file-risk classifier. Verified the vulnerability is real and current (the classifier escalated skills/hooks/plugins dirs but not the tools dir, despite the registry allowing workspace tools to override core tools and the loader importing them with daemon privileges). The fix is purely additive — a new escalation branch mirroring the established plugins-dir precedent — and regresses no functionality.