### PR TITLE
fix(web): persist assistant-scope feature-flag toggles to the gateway

### DIFF
--- a/apps/web/src/domains/settings/components/panels/feature-flags-panel.test.tsx
+++ b/apps/web/src/domains/settings/components/panels/feature-flags-panel.test.tsx
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+// Regression test for the bug where assistant-scoped flag toggles never
+// persisted: the panel read the active assistant id from the platform
+// `assistants/active` query (null in local mode), so the store silently
+// skipped the gateway PATCH. The fix sources the id from the gate-backed
+// resolved-assistants store via `useActiveAssistantId`. This test locks in
+// that a toggle issues the PATCH against that id.
+
+const patchMock = mock((_request: unknown) =>
+  Promise.resolve({ response: new Response(null, { status: 204 }) }),
+);
+const getMock = mock((_request: unknown) =>
+  Promise.resolve({
+    data: { flags: [] },
+    response: new Response(null, { status: 200 }),
+  }),
+);
+
+mock.module("@/generated/api/client.gen", () => ({
+  client: { patch: patchMock, get: getMock },
+}));
+
+mock.module("@/assistant/use-active-assistant-id", () => ({
+  useActiveAssistantId: () => "assistant-1",
+}));
+
+mock.module("@/hooks/use-is-org-ready", () => ({
+  useIsOrgReady: () => true,
+}));
+
+mock.module("@vellumai/design-library/components/toast", () => ({
+  toast: { error: () => {}, success: () => {} },
+}));
+
+const { FeatureFlagsPanel } = await import("./feature-flags-panel");
+
+function renderPanel() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 0 } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <FeatureFlagsPanel />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  patchMock.mockReset();
+  patchMock.mockImplementation((_request: unknown) =>
+    Promise.resolve({ response: new Response(null, { status: 204 }) }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("FeatureFlagsPanel", () => {
+  test("PATCHes an assistant-scoped flag to the active assistant when toggled", () => {
+    renderPanel();
+
+    // `memory-retrospective-fork` is an assistant-scoped boolean flag that
+    // defaults off — its row renders with the "... is off" label.
+    const toggle = screen.getByRole("switch", {
+      name: "Fork-based memory retrospective is off",
+    });
+    fireEvent.click(toggle);
+
+    const request = patchMock.mock.calls[0]?.[0];
+    expect(request).toMatchObject({
+      url: "/v1/assistants/assistant-1/feature-flags/memory-retrospective-fork",
+      body: { enabled: true },
+      throwOnError: false,
+    });
+  });
+});

--- a/apps/web/src/domains/settings/components/panels/feature-flags-panel.tsx
+++ b/apps/web/src/domains/settings/components/panels/feature-flags-panel.tsx
@@ -2,12 +2,10 @@ import { useQuery } from "@tanstack/react-query";
 import { Search } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
+import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { DetailCard } from "@/components/detail-card";
-import { assistantsActiveRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
 import { client } from "@/generated/api/client.gen";
-import { fetchAssistantFlagValues } from "@/hooks/use-assistant-feature-flag-sync";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
-import { useFlagQueryFreshness } from "@/lib/backwards-compat/flag-query-freshness";
 import {
     ALL_FLAGS,
     flagKeyToStoreKey,
@@ -15,7 +13,6 @@ import {
     type FlagScope,
     type SingleScope,
 } from "@/lib/feature-flags/feature-flag-catalog";
-import { assistantFlagValuesQueryKey } from "@/lib/sync/query-tags";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { cn } from "@vellumai/design-library";
@@ -67,21 +64,14 @@ type FlagDisplayEntry =
     };
 
 export function FeatureFlagsPanel() {
-  const { data: activeAssistant } = useQuery(assistantsActiveRetrieveOptions());
-  const assistantId = activeAssistant?.id ?? null;
-
-  // Same-key observer: TanStack dedups with `useAssistantFeatureFlagSync`'s
-  // root-level query. Kept so the panel stays live while toggling on
-  // older daemons; on push-capable daemons this resolves to a no-op
-  // (`refetchInterval: false`).
-  const freshness = useFlagQueryFreshness();
-  useQuery({
-    queryKey: assistantFlagValuesQueryKey(assistantId),
-    queryFn: () => fetchAssistantFlagValues(assistantId!),
-    enabled: assistantId !== null,
-    ...freshness,
-    retry: 1,
-  });
+  // The panel renders under `ActiveAssistantGate` (routes.tsx), which defers
+  // child rendering until an assistant is resolved — so the id is always
+  // available here. Reading it from the resolved-assistants store (via
+  // `useActiveAssistantId`) rather than the platform `assistants/active` query
+  // is what makes assistant-scoped flag PATCHes work in local mode, where the
+  // platform query has no id and the write was silently dropped. Live flag
+  // updates are owned by the root-level `useAssistantFeatureFlagSync`.
+  const assistantId = useActiveAssistantId();
 
   const isOrgReady = useIsOrgReady();
   const { data: definitions } = useQuery({
@@ -211,12 +201,8 @@ export function FeatureFlagsPanel() {
 
 interface FeatureFlagRowProps {
   flag: FlagDisplayEntry;
-  /**
-   * Active assistant id for PATCH'ing assistant-scoped overrides.
-   * `null` while the active-assistant query is still in-flight; toggle
-   * is still functional client-side, the server PATCH is just skipped.
-   */
-  assistantId: string | null;
+  /** Active assistant id for PATCH'ing assistant-scoped overrides. */
+  assistantId: string;
 }
 
 function ScopeChips({ scope }: { scope: FlagScope }) {
@@ -236,7 +222,7 @@ function BooleanFlagRow({
   assistantId,
 }: {
   flag: Extract<FlagDisplayEntry, { kind: "boolean" }>;
-  assistantId: string | null;
+  assistantId: string;
 }) {
   const clientSetFlag = useClientFeatureFlagStore.use.setFlag();
   const assistantSetFlag = useAssistantFeatureFlagStore.use.setFlag();
@@ -285,7 +271,7 @@ function StringFlagRow({
   assistantId,
 }: {
   flag: Extract<FlagDisplayEntry, { kind: "string" }>;
-  assistantId: string | null;
+  assistantId: string;
 }) {
   const clientSetStringFlag = useClientFeatureFlagStore.use.setStringFlag();
   const assistantSetStringFlag = useAssistantFeatureFlagStore.use.setStringFlag();

--- a/apps/web/src/stores/assistant-feature-flag-store.test.ts
+++ b/apps/web/src/stores/assistant-feature-flag-store.test.ts
@@ -8,6 +8,12 @@ mock.module("@/generated/api/client.gen", () => ({
   client: { patch: patchMock },
 }));
 
+const toastErrorMock = mock((_message: string) => {});
+
+mock.module("@vellumai/design-library/components/toast", () => ({
+  toast: { error: toastErrorMock, success: () => {} },
+}));
+
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
 function store() {
@@ -20,6 +26,7 @@ beforeEach(() => {
   patchMock.mockImplementation((_request: unknown) =>
     Promise.resolve({ response: new Response(null, { status: 204 }) }),
   );
+  toastErrorMock.mockReset();
 });
 
 describe("useAssistantFeatureFlagStore", () => {
@@ -56,6 +63,7 @@ describe("useAssistantFeatureFlagStore", () => {
     await Promise.resolve();
 
     expect(store().selfIntroGreeting).toBe(false);
+    expect(toastErrorMock).toHaveBeenCalledTimes(1);
   });
 
   test("reverts to the last confirmed value when repeated optimistic updates are rejected", async () => {
@@ -82,11 +90,16 @@ describe("useAssistantFeatureFlagStore", () => {
     expect(store().selfIntroGreeting).toBe(false);
   });
 
-  test("keeps local-only assistant flag updates when there is no assistant id", async () => {
-    store().setFlag("selfIntroGreeting", true, null);
+  test("is a no-op for an assistant flag when there is no assistant id", async () => {
+    store().setFlag("memoryRetrospectiveFork", true, null);
     await Promise.resolve();
 
-    expect(store().selfIntroGreeting).toBe(true);
+    // No assistant id => nowhere to persist => true no-op. It must not apply an
+    // optimistic value or fake a "confirmed" one: a local-only write is exactly
+    // what masked the silent persistence failure (the toggle looked saved while
+    // the gateway, and therefore the daemon, never received it).
+    expect(store().memoryRetrospectiveFork).toBe(false);
     expect(patchMock).not.toHaveBeenCalled();
+    expect(toastErrorMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/stores/assistant-feature-flag-store.ts
+++ b/apps/web/src/stores/assistant-feature-flag-store.ts
@@ -6,8 +6,10 @@ import {
   ASSISTANT_FLAG_DEFAULTS,
   ASSISTANT_STRING_FLAG_DEFAULTS,
   getEnvFlagOverridesForScope,
+  getFlagDefinition,
   storeKeyToFlagKey,
 } from "@/lib/feature-flags/feature-flag-catalog";
+import { toast } from "@vellumai/design-library/components/toast";
 
 /**
  * Internal store fields that are NOT feature flag values. Surfaces that
@@ -126,31 +128,37 @@ const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()(
             }
             return { [key]: confirmedValue };
           });
+          toast.error(
+            `Couldn't update "${getFlagDefinition(key)?.label ?? key}" — change reverted.`,
+          );
         };
         const flagKey = storeKeyToFlagKey(key);
-        if (assistantId && flagKey) {
-          pendingFlagRequestIds[key] = requestId;
-          void client
-            .patch({
-              url: `/v1/assistants/${assistantId}/feature-flags/${flagKey}`,
-              body: { enabled: value },
-              throwOnError: false,
-            } as Parameters<typeof client.patch>[0])
-            .then((result) => {
-              const response = (result as { response?: Response }).response;
-              if (response?.ok) {
-                confirmedAssistantFlagValues[key] = value;
-                if (pendingFlagRequestIds[key] === requestId) {
-                  delete pendingFlagRequestIds[key];
-                }
-              } else {
-                revertIfLatestRejectedRequest();
-              }
-            })
-            .catch(revertIfLatestRejectedRequest);
-        } else {
-          confirmedAssistantFlagValues[key] = value;
+        // Assistant-scoped flags persist via the gateway. Without an assistant
+        // id there is nowhere to write, so this is a true no-op: never apply an
+        // optimistic value or fake a "confirmed" one the daemon will never
+        // receive — that local-only write is what masked the silent failure.
+        if (!assistantId || !flagKey) {
+          return;
         }
+        pendingFlagRequestIds[key] = requestId;
+        void client
+          .patch({
+            url: `/v1/assistants/${assistantId}/feature-flags/${flagKey}`,
+            body: { enabled: value },
+            throwOnError: false,
+          } as Parameters<typeof client.patch>[0])
+          .then((result) => {
+            const response = (result as { response?: Response }).response;
+            if (response?.ok) {
+              confirmedAssistantFlagValues[key] = value;
+              if (pendingFlagRequestIds[key] === requestId) {
+                delete pendingFlagRequestIds[key];
+              }
+            } else {
+              revertIfLatestRejectedRequest();
+            }
+          })
+          .catch(revertIfLatestRejectedRequest);
 
         set({ [key]: envOverrides.bool[key] ?? value });
       },
@@ -188,31 +196,35 @@ const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()(
             }
             return { stringFlags: { ...prev.stringFlags, [key]: confirmedValue } };
           });
+          toast.error(
+            `Couldn't update "${getFlagDefinition(key)?.label ?? key}" — change reverted.`,
+          );
         };
         const flagKey = storeKeyToFlagKey(key);
-        if (assistantId && flagKey) {
-          pendingFlagRequestIds[key] = requestId;
-          void client
-            .patch({
-              url: `/v1/assistants/${assistantId}/feature-flags/${flagKey}`,
-              body: { enabled: value },
-              throwOnError: false,
-            } as Parameters<typeof client.patch>[0])
-            .then((result) => {
-              const response = (result as { response?: Response }).response;
-              if (response?.ok) {
-                confirmedAssistantStringFlagValues[key] = value;
-                if (pendingFlagRequestIds[key] === requestId) {
-                  delete pendingFlagRequestIds[key];
-                }
-              } else {
-                revertIfLatestRejectedRequest();
-              }
-            })
-            .catch(revertIfLatestRejectedRequest);
-        } else {
-          confirmedAssistantStringFlagValues[key] = value;
+        // See `setFlag`: a missing assistant id is a true no-op for
+        // assistant-scoped flags rather than a local-only write.
+        if (!assistantId || !flagKey) {
+          return;
         }
+        pendingFlagRequestIds[key] = requestId;
+        void client
+          .patch({
+            url: `/v1/assistants/${assistantId}/feature-flags/${flagKey}`,
+            body: { enabled: value },
+            throwOnError: false,
+          } as Parameters<typeof client.patch>[0])
+          .then((result) => {
+            const response = (result as { response?: Response }).response;
+            if (response?.ok) {
+              confirmedAssistantStringFlagValues[key] = value;
+              if (pendingFlagRequestIds[key] === requestId) {
+                delete pendingFlagRequestIds[key];
+              }
+            } else {
+              revertIfLatestRejectedRequest();
+            }
+          })
+          .catch(revertIfLatestRejectedRequest);
 
         setStr((prev) => ({
           stringFlags: { ...prev.stringFlags, [key]: envOverrides.str[key] ?? value },


### PR DESCRIPTION
## Summary
- The Feature Flags panel (Settings -> Developer) read the active assistant id from the platform `assistants/active` query, which has no id in local mode — so assistant-scoped toggles (e.g. `memory-retrospective-fork`) silently skipped the gateway PATCH and only updated client-local state while the daemon never saw the change. It now sources the id from the gate-backed resolved-assistants store via `useActiveAssistantId` (the panel renders under `ActiveAssistantGate`, so the id is always available), and drops the redundant duplicate flag-values observer query.
- Hardened the assistant feature-flag store: a missing assistant id is now a true no-op instead of faking a local "confirmed" write (that local-only write is what masked the silent failure), and a rejected PATCH now surfaces a toast error instead of reverting silently.
- Added a panel regression test (toggling an assistant flag issues the PATCH against the active id) and updated the store tests for the new no-op + toast contract.

## Original prompt
While testing the memory-retrospective-fork rollout, toggling the flag in the desktop Settings -> Developer -> Feature Flags panel did not persist: the gateway flag store the daemon reads was never written, so the flag had to be edited on disk by hand. The task was to find and fix the root cause of assistant-scope feature-flag toggles silently failing to persist.