### PR TITLE
fix(memory-v3): hard-fail the turn on a retrieval infra failure instead of silently dropping memory

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/pool-select.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/pool-select.test.ts
@@ -13,10 +13,12 @@
  *     by `pinned_ids`; out-of-range IDs dropped; selections deduped by slug
  *     (a page can appear as both a card and a finder line; pinned flags OR).
  *   - Omitted `ids` → keep ALL candidates (recall-safe, slug-deduped).
- *   - Explicit `ids: []` → keep none (deliberate abstention).
+ *   - Explicit `ids: []` → keep none (deliberate abstention) — a normal result.
+ *   - Empty candidate pool → keep none (nothing to select).
  *   - Finder snippets are whitespace-collapsed and truncated (~300 chars).
- *   - No provider / missing tool_use / schema mismatch / throw → keep none
- *     (degrade to deterministic lanes), the last three after a re-prompt retry.
+ *   - No provider / missing tool_use / schema mismatch / provider throw → throw
+ *     MemoryV3RetrievalUnavailableError (an INFRA failure, deliberately DISTINCT
+ *     from a deliberate empty selection), the last three after a re-prompt retry.
  *   - One forced-tool `select_pages` call on the v3 L2 call site with
  *     `disableTurnStartCache` (the tail varies per turn — the provider's
  *     auto-anchor would never hit).
@@ -61,7 +63,8 @@ mock.module("../../../../util/logger.js", () => ({
     }),
 }));
 
-const { selectPool } = await import("../pool-select.js");
+const { selectPool, MemoryV3RetrievalUnavailableError } =
+  await import("../pool-select.js");
 type SelectorPool = Parameters<typeof selectPool>[0];
 
 // ---------------------------------------------------------------------------
@@ -226,35 +229,42 @@ describe("selectPool — id mapping", () => {
 });
 
 // ---------------------------------------------------------------------------
-// selectPool — recall-safe fallbacks.
+// selectPool — infrastructure failures THROW (no silent degradation). A
+// deliberate empty selection and an empty pool (covered above) still return
+// normally; only a genuine infra failure throws so the LIVE injector can
+// hard-fail the turn instead of shipping it with no memory.
 // ---------------------------------------------------------------------------
 
-describe("selectPool — degradation on failure", () => {
-  test("no provider → no pages, without calling the provider", async () => {
+describe("selectPool — infrastructure failures throw", () => {
+  test("no provider → throws without calling the provider", async () => {
     providerStub = null;
-    const result = await selectPool(makePool(), makeTurn("x"));
-    expect(result).toEqual([]);
+    await expect(selectPool(makePool(), makeTurn("x"))).rejects.toThrow(
+      MemoryV3RetrievalUnavailableError,
+    );
     expect(providerCalls).toHaveLength(0);
   });
 
-  test("missing tool_use → no pages after retrying", async () => {
+  test("missing tool_use → throws after retrying", async () => {
     providerStub = makeProvider(noToolResponse());
-    const result = await selectPool(makePool(), makeTurn("x"));
-    expect(result).toEqual([]);
+    await expect(selectPool(makePool(), makeTurn("x"))).rejects.toThrow(
+      MemoryV3RetrievalUnavailableError,
+    );
     expect(providerCalls).toHaveLength(3);
   });
 
-  test("schema mismatch → no pages after retrying", async () => {
+  test("schema mismatch → throws after retrying", async () => {
     providerStub = makeProvider(toolUseResponse({ ids: "not-an-array" }));
-    const result = await selectPool(makePool(), makeTurn("x"));
-    expect(result).toEqual([]);
+    await expect(selectPool(makePool(), makeTurn("x"))).rejects.toThrow(
+      MemoryV3RetrievalUnavailableError,
+    );
     expect(providerCalls).toHaveLength(3);
   });
 
-  test("provider throw → no pages after retrying", async () => {
+  test("provider throw → throws after retrying", async () => {
     providerStub = makeThrowingProvider();
-    const result = await selectPool(makePool(), makeTurn("x"));
-    expect(result).toEqual([]);
+    await expect(selectPool(makePool(), makeTurn("x"))).rejects.toThrow(
+      MemoryV3RetrievalUnavailableError,
+    );
     expect(providerCalls).toHaveLength(3);
   });
 

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
@@ -388,6 +388,7 @@ const {
 } = await import("../shadow-plugin.js");
 const { memoryV3Injector, resetMemoryV3InjectorStateForTests } =
   await import("../injector.js");
+const { MemoryV3RetrievalUnavailableError } = await import("../pool-select.js");
 
 afterAll(() => {
   shadowMockActive = false;
@@ -803,5 +804,56 @@ describe("memory-v3 shadow plugin", () => {
       const hits = needle.query("kumquat", 5);
       expect(hits.map((h) => h.article)).toContain(CAPABILITY_SLUG);
     });
+  });
+});
+
+describe("memory-v3 infrastructure-failure handling (hard-fail vs swallow)", () => {
+  const throwInfra = () =>
+    orchestrateSpy.mockImplementationOnce(async () => {
+      throw new MemoryV3RetrievalUnavailableError(
+        "selector provider unavailable",
+      );
+    });
+
+  test("LIVE injector HARD-FAILS the turn on an infra failure (no silent memory loss)", async () => {
+    liveEnabled = true;
+    shadowEnabled = false;
+    throwInfra();
+
+    await expect(produce("conv-infra-live", 0)).rejects.toThrow(
+      MemoryV3RetrievalUnavailableError,
+    );
+  });
+
+  test("SHADOW injector swallows an infra failure (v2 fallback) — no throw, no block", async () => {
+    liveEnabled = false;
+    shadowEnabled = true;
+    throwInfra();
+
+    // Shadow mode: v2 retrieval still ran this turn, so the v3 injector returns
+    // null rather than failing the turn.
+    expect(await produce("conv-infra-shadow", 0)).toBeNull();
+  });
+
+  test("runShadowObservation never throws on an infra failure (fire-and-forget)", async () => {
+    liveEnabled = false;
+    shadowEnabled = true;
+    throwInfra();
+
+    await expect(
+      runShadowObservation("conv-infra-obs", 0),
+    ).resolves.toBeUndefined();
+  });
+
+  test("LIVE injector stays NON-fatal on a non-infra error (degrades to no v3 block)", async () => {
+    liveEnabled = true;
+    shadowEnabled = false;
+    orchestrateSpy.mockImplementationOnce(async () => {
+      throw new Error("some unexpected non-infra bug");
+    });
+
+    // Only INFRA failures hard-fail; any other error stays non-fatal so a bug
+    // in one lane can't take every turn down.
+    expect(await produce("conv-nonfatal-live", 0)).toBeNull();
   });
 });

--- a/assistant/src/plugins/defaults/memory-v3-shadow/injector.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/injector.ts
@@ -78,6 +78,7 @@ import { cardBytes } from "./card.js";
 import { getActiveSlugs, recordInjected } from "./ever-injected-store.js";
 import type { OrchestrateResult } from "./orchestrate.js";
 import { renderV3CardContent } from "./page-content.js";
+import { MemoryV3RetrievalUnavailableError } from "./pool-select.js";
 import { schedulePruneValve } from "./prune.js";
 import {
   renderCardsBlockInner,
@@ -243,13 +244,32 @@ export const memoryV3Injector: Injector = {
     if (!live && !shadow) return null;
     if (!isPersonalMemoryAllowed(ctx.trust)) return null;
 
-    const result = await observeTurnOnce(ctx.conversationId, ctx.turnIndex);
+    let observed: OrchestrateResult | null;
+    try {
+      observed = await observeTurnOnce(ctx.conversationId, ctx.turnIndex);
+    } catch (err) {
+      // A memory-v3 INFRASTRUCTURE failure (the selector lost its provider —
+      // e.g. a transient CES credential blip). Under `memory-v3-live` the
+      // user-prompt-submit hook already skipped v2 retrieval, so swallowing
+      // here would ship the turn with NO memory at all — exactly the silent
+      // degradation we want to eliminate. Hard-fail the turn instead (a clean,
+      // retryable error). In shadow mode v2 still ran this turn, so fall back
+      // to it (return null). Non-infra errors are already swallowed inside
+      // observeTurn; anything else reaching here stays non-fatal.
+      if (live && err instanceof MemoryV3RetrievalUnavailableError) {
+        throw err;
+      }
+      return null;
+    }
     // Empty selection → return null (attach nothing). Returning null (vs an
     // empty block) preserves the shadow-mode v2 fallback: v2 suppression keys
-    // off BOTH the flag AND a produced block, so in shadow a selector failure
-    // or a turn with nothing selected ships v2's memory. Under `memory-v3-live`
-    // the hook skipped v2 retrieval, so the turn simply gets no injected memory.
-    if (!result || result.selections.length === 0) return null;
+    // off BOTH the flag AND a produced block, so in shadow a turn with nothing
+    // selected ships v2's memory. Under `memory-v3-live` the hook skipped v2
+    // retrieval, so the turn simply gets no injected memory.
+    if (!observed || observed.selections.length === 0) return null;
+    // `const` so the non-null narrowing survives capture in the `commit`
+    // closure below (a `let` would re-widen to `OrchestrateResult | null`).
+    const result = observed;
 
     try {
       const active = getActiveSlugs(ctx.conversationId);
@@ -388,6 +408,13 @@ export const memoryV3SpotlightInjector: Injector = {
         placement: "after-memory-prefix",
       };
     } catch (err) {
+      // Live-only injector: an infra failure must hard-fail the turn. The cards
+      // injector (ordered ahead of this one) normally throws first, so this
+      // path is defensive — it keeps the behavior correct if the cards injector
+      // is ever disabled or reordered.
+      if (err instanceof MemoryV3RetrievalUnavailableError) {
+        throw err;
+      }
       log.warn(
         {
           err: err instanceof Error ? err.message : String(err),

--- a/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/pool-select.ts
@@ -30,15 +30,22 @@
  * stable-prefix card and as a finder line (its current matched section);
  * selections are deduped by slug.
  *
- * Failure handling is recall-safe by construction:
+ * Failure handling distinguishes a DELIBERATE empty selection from an
+ * INFRASTRUCTURE failure — the two are different outcomes, not the same one:
  *   - explicit `ids` → select exactly those candidates,
- *   - explicit empty `ids: []` → select none (deliberate abstention),
+ *   - explicit empty `ids: []` → select none (deliberate abstention) — a
+ *     normal, non-error result; the turn proceeds,
  *   - omitted `ids` → keep ALL candidates (the recall-safe "all of these are
  *     relevant" signal),
- *   - infrastructure failure (provider unavailable, a throw that survived the
- *     provider's own retries, no usable `tool_use`, or a schema mismatch) →
- *     select nothing after a short re-prompt retry, degrading to the
- *     deterministic recall lanes the orchestrator unions in regardless.
+ *   - empty candidate pool → return none (nothing to select),
+ *   - infrastructure failure (selector provider unavailable — e.g. a transient
+ *     CES credential blip drops the API key — or no usable `tool_use` / schema
+ *     mismatch surviving the short re-prompt retry) → throw
+ *     {@link MemoryV3RetrievalUnavailableError}. There is NO deterministic-lane
+ *     fallback: the LIVE injector propagates this to hard-fail the turn
+ *     (retryable) rather than silently shipping it with no `<memory>` block,
+ *     while the shadow/observation path swallows it and lets v2 retrieval serve
+ *     the turn.
  */
 
 import { z } from "zod";
@@ -59,6 +66,24 @@ import { retryForResult } from "./llm-retry.js";
 import type { MemoryRoutingTurn, SelectedPage, Slug } from "./types.js";
 
 const log = getLogger("memory-v3-pool-select");
+
+/**
+ * Thrown when the pool selector cannot produce a selection because of an
+ * INFRASTRUCTURE failure — its LLM provider is unavailable (e.g. a transient
+ * CES credential blip drops the API key), or no usable `tool_use` survives the
+ * re-prompt retry. Deliberately DISTINCT from a deliberate empty selection
+ * (`ids: []`) and an empty candidate pool, both of which return normally.
+ *
+ * The LIVE memory-v3 injector propagates this to hard-fail the turn (a clean,
+ * retryable failure) rather than silently shipping with no memory; the
+ * shadow/observation path catches and swallows it.
+ */
+export class MemoryV3RetrievalUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MemoryV3RetrievalUnavailableError";
+  }
+}
 
 /** A dynamic-tail (finder) candidate: the slug plus the descriptor that
  *  justifies it — a matched section for a needle/dense hit, or a curated link
@@ -213,9 +238,11 @@ export async function selectPool(
   if (!provider) {
     log.warn(
       { candidateCount: ordered.length },
-      "pool selector provider unavailable; degrading to deterministic lanes",
+      "pool selector provider unavailable — failing the turn rather than dropping memory",
     );
-    return [];
+    throw new MemoryV3RetrievalUnavailableError(
+      "memory-v3 pool selector provider unavailable",
+    );
   }
 
   // Two content blocks: the stable prefix (cards) carries the cache
@@ -265,9 +292,11 @@ export async function selectPool(
   if (parsed === null) {
     log.warn(
       { candidateCount: ordered.length },
-      "pool selector could not obtain a selection after retries; degrading to deterministic lanes",
+      "pool selector could not obtain a selection after retries — failing the turn rather than dropping memory",
     );
-    return [];
+    throw new MemoryV3RetrievalUnavailableError(
+      "memory-v3 pool selector returned no usable selection after retries",
+    );
   }
 
   // Omitted `ids` is the recall-safe "keep all candidates" signal.

--- a/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
@@ -55,6 +55,7 @@ import { computeHotSet } from "./hot-set.js";
 import { computeLearnedEdgeGraph } from "./learned-edges.js";
 import type { OrchestrateResult } from "./orchestrate.js";
 import { orchestrate } from "./orchestrate.js";
+import { MemoryV3RetrievalUnavailableError } from "./pool-select.js";
 import { ensureSectionCollection } from "./section-dense-store.js";
 import type { SectionNeedle } from "./section-needle.js";
 import { buildSectionNeedle } from "./section-needle.js";
@@ -576,6 +577,16 @@ export async function observeTurn(
     writeSelections(conversationId, turnIndex, rows);
     return result;
   } catch (err) {
+    // An INFRASTRUCTURE failure (the selector lost its provider — e.g. a
+    // transient CES credential blip) must NOT be silently swallowed: re-throw
+    // so the LIVE injector hard-fails the turn (a clean, retryable failure)
+    // rather than shipping it with no `<memory>` block. The shadow/observation
+    // callers (the injector in shadow mode, runShadowObservation) catch this
+    // and swallow it, so observation never fails a turn. Other (non-infra)
+    // errors stay non-fatal and degrade to no v3 block, as before.
+    if (err instanceof MemoryV3RetrievalUnavailableError) {
+      throw err;
+    }
     log.warn(
       { err: err instanceof Error ? err.message : String(err), conversationId },
       "memory-v3 orchestration failed (non-fatal)",
@@ -599,5 +610,11 @@ export async function runShadowObservation(
   const config = getConfig();
   if (config.memory.enabled === false) return;
   if (!isAssistantFeatureFlagEnabled(MEMORY_V3_SHADOW, config)) return;
-  await observeTurn(conversationId, turnIndex);
+  try {
+    await observeTurn(conversationId, turnIndex);
+  } catch {
+    // Shadow observation is fire-and-forget and must NEVER fail a turn.
+    // `observeTurn` now re-throws infra failures so the LIVE injector can
+    // hard-fail on them; here (observation only) we swallow them.
+  }
 }


### PR DESCRIPTION
## Summary

- The memory-v3 pool selector is an LLM pass. When its provider is momentarily unavailable (e.g. a transient CES credential blip drops the OpenRouter key), it previously returned `[]` and the turn shipped with **no `<memory>` block at all** — silent degradation that's only caught by luck. It now throws a typed `MemoryV3RetrievalUnavailableError`.
- On the **live** injection path that error propagates (through the existing memory-retrieval-blocks-the-turn path) to hard-fail the turn as a clean, **retryable** failure — a retry hits a warm vault. The **shadow/observation** path (and `runShadowObservation`) swallows it so observation never fails a turn, and v2 retrieval still serves shadow turns.
- A **deliberate** empty selection (`ids: []`) and an empty candidate pool still return normally — only genuine infra failures throw. Non-infra errors stay non-fatal so a bug in one lane can't take every turn down. Also corrects the `pool-select.ts` docstring, which claimed a deterministic-lane fallback that `orchestrate()` never actually performed.

## Original prompt

While diagnosing why a fresh conversation's first turn shipped with no v3 memory, we traced it to a transient CES credential outage that starved the v3 pool selector of its provider — and the selector silently degraded to zero injection. Sidd asked for a hard, retryable failure instead of silently degraded memory ("I'd rather have a hard fail I can retry than silently degraded memory that I only notice if I'm lucky"). This PR makes a v3 retrieval *infrastructure* failure fail the turn on the live path, while keeping deliberate empty selections and the shadow/observation path unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)