### PR TITLE
chore(ces): log whether a stdio transport death is spurious (process still alive)

### DIFF
--- a/assistant/src/credential-execution/process-manager.ts
+++ b/assistant/src/credential-execution/process-manager.ts
@@ -327,6 +327,8 @@ function createStdioTransport(proc: Subprocess): CesTransport {
     const decoder = new TextDecoder();
 
     void (async () => {
+      let endReason: "eof" | "error" = "eof";
+      let readError: unknown;
       try {
         while (true) {
           const { value, done } = await reader.read();
@@ -344,17 +346,49 @@ function createStdioTransport(proc: Subprocess): CesTransport {
             }
           }
         }
-      } catch {
-        // Process ended
+      } catch (err) {
+        endReason = "error";
+        readError = err;
       } finally {
+        // Preserve existing semantics: the transport reports dead the moment
+        // the stdout stream ends, regardless of why.
         alive = false;
+
+        // DIAGNOSTIC (observation only). The reconnection path (secure-keys.ts)
+        // bounces CES whenever isAlive() goes false. This classifies WHY the
+        // transport died: a real process exit, or a stdout stream that
+        // ended/errored while the process is STILL RUNNING — the spurious case
+        // that needlessly restarts a healthy CES. Let `proc.exited` settle one
+        // tick so a near-simultaneous real exit isn't misread as spurious, then
+        // snapshot the exit code (`null` = still running).
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        const exitCode = proc.exitCode;
+        if (exitCode === null) {
+          log.warn(
+            {
+              pid: proc.pid,
+              endReason,
+              err: readError instanceof Error ? readError.message : readError,
+            },
+            "CES stdio transport: stdout stream ended while the process is still alive (spurious transport death)",
+          );
+        } else {
+          log.debug(
+            { pid: proc.pid, endReason, exitCode },
+            "CES stdio transport: stdout stream ended after process exit",
+          );
+        }
       }
     })();
   }
 
   // Track process exit
-  proc.exited.then(() => {
+  void proc.exited.then((exitCode) => {
     alive = false;
+    log.info(
+      { pid: proc.pid, exitCode },
+      "CES stdio transport: process exited",
+    );
   });
 
   return {


### PR DESCRIPTION
## Summary

- The daemon's secure-keys reconnection path tears down and respawns the CES credential-executor whenever the stdio transport's `isAlive()` goes false — historically ~100–240×/day — yet CES is healthy (it shuts down gracefully on the SIGTERM that follows, proving it was alive). The transport is being marked dead while the process still runs.
- This adds **observation-only** logging in `createStdioTransport` that classifies every transport death: a **WARN** ("stdout stream ended while the process is still alive (spurious transport death)") when the stdout reader ends/errors while `proc.exitCode` is still `null`, vs a quiet debug when the process actually exited. The `proc.exited` handler now logs the exit code. A one-tick settle before the exitCode snapshot avoids misclassifying a near-simultaneous real exit.
- **No behavior change**: `alive = false` semantics, teardown order, and the reconnection logic are untouched. This is the diagnostic that will pin which of {stdout EOF, reader throw, process exit} fires for the spurious deaths, before a follow-up PR changes the reconnection heuristic.

## Original prompt

While diagnosing a memory-injection miss, we traced the root cause to the CES credential service flapping (~150 restarts/day) because the daemon spuriously marks its stdio transport dead and bounces a perfectly healthy CES. The exact mechanism (which of the three `alive = false` paths fires) couldn't be determined from existing logs. Sidd asked to land the diagnostic first and hold the behavioral fix until the data is in — this PR is that instrumentation, observation-only.

## Note

No unit test: `createStdioTransport` is private and runs its stdout reader as a fire-and-forget async IIFE whose teardown logging is gated on a stream-end plus a `setTimeout(0)` settle — a test would be timing-dependent and more fragile than the observation-only logging it covers. The classification (`exitCode === null` → spurious) is validated live by grepping the daemon log after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)