### PR TITLE
fix(web): stub Toaster/ToastContent in feature-flags-panel test toast mock

### DIFF
--- a/apps/web/src/domains/settings/components/panels/feature-flags-panel.test.tsx
+++ b/apps/web/src/domains/settings/components/panels/feature-flags-panel.test.tsx
@@ -31,8 +31,14 @@ mock.module("@/hooks/use-is-org-ready", () => ({
   useIsOrgReady: () => true,
 }));
 
+// The toast mock must also satisfy the design-library barrel's re-exports:
+// the panel pulls `cn` from the barrel index, which re-exports
+// `Toaster`/`ToastContent` from this module. Missing exports here surface as
+// parse-time "export not found" errors during barrel resolution, so stub them.
 mock.module("@vellumai/design-library/components/toast", () => ({
   toast: { error: () => {}, success: () => {} },
+  Toaster: () => null,
+  ToastContent: () => null,
 }));
 
 const { FeatureFlagsPanel } = await import("./feature-flags-panel");


### PR DESCRIPTION
## Summary
- The Web `Test` CI job failed with `SyntaxError: export 'ToastContent' not found in './components/toast'` in `feature-flags-panel.test.tsx`.
- Root cause: the test mocks `@vellumai/design-library/components/toast` with only `{ toast }`, but the panel pulls `cn` from the design-library barrel, whose `index.ts` re-exports `Toaster`/`ToastContent` from that module. The incomplete mock breaks barrel re-export resolution at parse time.
- Fix: add `Toaster`/`ToastContent` no-op stubs to the mock, mirroring the already-documented pattern in `profile-card.test.tsx`. Verified the file passes in isolation.

## Original prompt
Fix the specific CI issue in the failing Web `Test` job of run 27574335570 (commit c986b7a7f6, PR #34902) — and only that job. The job failed because the newly-added `feature-flags-panel.test.tsx` regression test stubbed the toast module without the `Toaster`/`ToastContent` exports the design-library barrel re-exports, producing a parse-time "export not found" error during barrel resolution.