### PR TITLE
test(background-wake): deflake the drain-due slow-work-settles deadline assertion

### DIFF
--- a/assistant/src/background-wake/background-wake-routes.test.ts
+++ b/assistant/src/background-wake/background-wake-routes.test.ts
@@ -648,7 +648,10 @@ describe("background wake runtime routes", () => {
       },
     });
     const handler = findHandler("drainDueBackgroundWake");
-    const deadlineAt = Date.now() + 10;
+    // Keep the deadline far enough ahead that the synchronous start-check always
+    // sees it as live; the wait below outlasts it, so completion is verified to
+    // hold until the work settles rather than fire when the deadline elapses.
+    const deadlineAt = Date.now() + 200;
 
     const firstResponse = await handler({
       body: drainBodyFixture({
@@ -658,7 +661,7 @@ describe("background wake runtime routes", () => {
     });
 
     try {
-      await new Promise((resolve) => setTimeout(resolve, 25));
+      await new Promise((resolve) => setTimeout(resolve, 280));
       expect(mockCompleteBackgroundWakeLease).not.toHaveBeenCalled();
 
       const duplicateResponse = await handler({


### PR DESCRIPTION
## Summary
- `background-wake-routes.test.ts`'s "drain-due keeps a lease active until slow work settles" test set a 10ms drain deadline (`Date.now() + 10`) and relied on the handler's synchronous `assertDrainCanStart` start-check still observing it as live. Under CI contention the synchronous prelude (zod parse + fixture build) can stall past 10ms, so the start-check sees the deadline already elapsed, reports the lease `expired`, and trips `expect(mockCompleteBackgroundWakeLease).not.toHaveBeenCalled()` — the exact "Received number of calls: 1" failure in the Test job.
- Widen the deadline to 200ms and the in-flight wait to 280ms: the deadline now sits far ahead of the synchronous start-check (deterministically live at start) while the wait still outlasts it, preserving the test's intent that completion holds until the work *settles*, not when the deadline elapses.
- Test-only change; no production behavior touched. Verified with 6 consecutive local runs.

## Original prompt
Fix the specific CI failure in the `Test` job of run 27574806545 on `main`, where `background-wake-routes.test.ts:662` failed with "Expected number of calls: 0, Received number of calls: 1". The ask was to scope the fix to that one failing job only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)