### PR TITLE
fix(providers): split MiniMax reasoning into reasoning_content on Fireworks

### DIFF
--- a/assistant/src/providers/fireworks/__tests__/reasoning-split.test.ts
+++ b/assistant/src/providers/fireworks/__tests__/reasoning-split.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+
+import { FireworksProvider } from "../client.js";
+
+type MockChunk = {
+  choices: Array<{
+    delta: { content?: string };
+    finish_reason?: string | null;
+  }>;
+  usage?: { prompt_tokens: number; completion_tokens: number };
+};
+
+function stubFireworks(model: string): {
+  provider: FireworksProvider;
+  requests: Array<Record<string, unknown>>;
+} {
+  const provider = new FireworksProvider("test-key", model);
+  const requests: Array<Record<string, unknown>> = [];
+  (provider as unknown as { client: unknown }).client = {
+    chat: {
+      completions: {
+        create: async (params: Record<string, unknown>) => {
+          requests.push(params);
+          const chunks: MockChunk[] = [
+            {
+              choices: [{ delta: {}, finish_reason: "stop" }],
+              usage: { prompt_tokens: 1, completion_tokens: 1 },
+            },
+          ];
+          return {
+            async *[Symbol.asyncIterator]() {
+              for (const c of chunks) yield c;
+            },
+          };
+        },
+      },
+    },
+  };
+  return { provider, requests };
+}
+
+async function send(provider: FireworksProvider): Promise<void> {
+  await provider.sendMessage([
+    { role: "user", content: [{ type: "text", text: "hi" }] },
+  ]);
+}
+
+describe("FireworksProvider reasoning_split", () => {
+  test("sends reasoning_split for MiniMax models so thinking lands in reasoning_content", async () => {
+    const { provider, requests } = stubFireworks(
+      "accounts/fireworks/models/minimax-m3",
+    );
+    await send(provider);
+    expect(requests[0].reasoning_split).toBe(true);
+  });
+
+  test("omits reasoning_split for non-MiniMax models", async () => {
+    const { provider, requests } = stubFireworks(
+      "accounts/fireworks/models/deepseek-v4",
+    );
+    await send(provider);
+    expect(requests[0].reasoning_split).toBeUndefined();
+  });
+});

--- a/assistant/src/providers/fireworks/client.ts
+++ b/assistant/src/providers/fireworks/client.ts
@@ -24,6 +24,7 @@ export class FireworksProvider extends OpenAIChatCompletionsProvider {
     model: string,
     options: FireworksProviderOptions = {},
   ) {
+    const isMinimax = /minimax/i.test(model);
     super(apiKey, model, {
       baseURL: options.baseURL?.trim() || DEFAULT_FIREWORKS_BASE_URL,
       providerName: "fireworks",
@@ -35,9 +36,14 @@ export class FireworksProvider extends OpenAIChatCompletionsProvider {
       // {@link resolveMaxReasoningEffort}.
       maxReasoningEffort: "high",
       assistantReasoningField: "reasoning_content",
+      // MiniMax M3 reasons by default, but without reasoning_split it embeds the
+      // thinking in `content` (no <think> tags, no separate stream), so planning
+      // prose leaks into user-visible text. reasoning_split routes it to
+      // `reasoning_content`, which the base provider parses into thinking blocks.
+      ...(isMinimax ? { extraCreateParams: { reasoning_split: true } } : {}),
       // minimax-m3's function-call serialization collapses object-typed tool
       // args to `{}` on the wire; present them as JSON strings and decode back.
-      coerceObjectArgsToJsonString: /minimax/i.test(model),
+      coerceObjectArgsToJsonString: isMinimax,
     });
   }
 


### PR DESCRIPTION
## Problem

A user on the `balanced-economy` profile (Fireworks MiniMax M3) reported it felt "less actionable than Claude" — "had to plead my case before it would do what I asked." The logs ([feedback conversation](#)) bear this out: given a clear directive ("we shouldn't use tavily… push to agentcup and github"), M3 produced paragraphs of deliberative prose ending in "Want me to refactor… or hold?" and exited with **zero tool calls**. The user had to repeat "i just told you to change it" before it acted.

## Root cause

MiniMax M3 reasons by default, but **Fireworks only routes that thinking into the `reasoning_content` field when `reasoning_split: true` is sent.** We weren't sending it. Every turn in the logs came back with `reasoning_content` empty and **no `<think>` tags** — the planning prose was embedded directly in the visible `content` block. This is MiniMax's documented [issue #10](https://github.com/MiniMax-AI/MiniMax-M3/issues/10): without separation, M3 emits chain-of-thought into the visible text with no separate reasoning stream.

Our `reasoning_effort: high` was real but cosmetic — the model thought, the thinking just leaked into chat. With no effective private channel, the "keep reasoning private" system-prompt rule is unsatisfiable, and deliberation ("should I do this or confirm?") surfaces as hedging.

The fix is already proven in-repo: the **direct** MiniMax client (`minimax/client.ts`) sets `reasoning_split: true` with a comment describing this exact failure. The Fireworks client just never got it.

## Change

Send `reasoning_split: true` for MiniMax models on Fireworks (`fireworks/client.ts`):
- Gated to `/minimax/i` since the Fireworks client also serves DeepSeek/Qwen, which don't accept the param.
- Rides the existing `extraCreateParams` path; orthogonal to `reasoning_effort` (no conflict).
- The base provider already parses `reasoning_content` → thinking blocks and replays them on multi-turn (`assistantReasoningField` was already set), so this one line completes the pipeline.

Adds `fireworks/__tests__/reasoning-split.test.ts` (sends it for `minimax-m3`, omits it for `deepseek-v4`).

## ⚠️ Needs runtime validation

This is a behavioral change on a **managed** Fireworks connection — I couldn't probe it live. The unit test proves we *send* the param; it does **not** prove Fireworks' M3 deployment behaves as documented. Before relying on this (e.g. promoting MiniMax to the `mainAgent` default), validate on a real conversation that (a) `reasoning_content` is now populated and (b) M3 acts on directives without re-asking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)