### PR TITLE
fix(assistant): show full transcript for memory-retrospective fork conversations

### DIFF
--- a/assistant/src/__tests__/list-messages-hidden-metadata.test.ts
+++ b/assistant/src/__tests__/list-messages-hidden-metadata.test.ts
@@ -33,6 +33,10 @@ import {
 } from "../memory/conversation-crud.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
+import {
+  MEMORY_RETROSPECTIVE_FORK_SOURCE,
+  MEMORY_RETROSPECTIVE_INSTRUCTION_KIND,
+} from "../memory/memory-retrospective-constants.js";
 import { messages } from "../memory/schema.js";
 import { handleListMessages } from "../runtime/routes/conversation-routes.js";
 
@@ -333,5 +337,100 @@ describe("handleListMessages metadata.hidden filtering", () => {
     ]);
     expect(latest.hasMore).toBe(false);
     expect(latest.oldestTimestamp).not.toBeNull();
+  });
+
+  test("fork retrospective conversations expose the hidden instruction and keep the review as its own turn", async () => {
+    const conv = createConversation({
+      source: MEMORY_RETROSPECTIVE_FORK_SOURCE,
+    });
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "source question" }]),
+    );
+    await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([{ type: "text", text: "source answer" }]),
+    );
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([
+        { type: "text", text: "background memory pass instruction" },
+      ]),
+      {
+        metadata: { kind: MEMORY_RETROSPECTIVE_INSTRUCTION_KIND, hidden: true },
+      },
+    );
+    await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([{ type: "text", text: "retrospective review" }]),
+    );
+
+    const response = handleListMessages({
+      queryParams: { conversationId: conv.id },
+    });
+    const body = response as { messages: MessagePayload[] };
+
+    // The hidden instruction is shown, and because it sits between the two
+    // assistant rows they do NOT merge — the review stands as its own turn.
+    expect(body.messages.map((m) => m.role)).toEqual([
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+    ]);
+    expect(plainText(body.messages[1])).toBe("source answer");
+    expect(plainText(body.messages[2])).toContain(
+      "background memory pass instruction",
+    );
+    expect(plainText(body.messages[3])).toBe("retrospective review");
+  });
+
+  test("non-fork conversations still hide the retrospective instruction (relaxation is fork-scoped)", async () => {
+    const conv = createConversation();
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "source question" }]),
+    );
+    await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([{ type: "text", text: "source answer" }]),
+    );
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([
+        { type: "text", text: "background memory pass instruction" },
+      ]),
+      {
+        metadata: { kind: MEMORY_RETROSPECTIVE_INSTRUCTION_KIND, hidden: true },
+      },
+    );
+    await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([{ type: "text", text: "retrospective review" }]),
+    );
+
+    const response = handleListMessages({
+      queryParams: { conversationId: conv.id },
+    });
+    const body = response as { messages: MessagePayload[] };
+
+    // Instruction stays hidden for non-retrospective conversations; the review
+    // (a normal assistant message) is still returned.
+    expect(
+      body.messages.some((m) =>
+        plainText(m).includes("background memory pass instruction"),
+      ),
+    ).toBe(false);
+    expect(
+      body.messages.some((m) => plainText(m).includes("retrospective review")),
+    ).toBe(true);
   });
 });

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -97,6 +97,7 @@ import {
   getOrCreateConversation,
 } from "../../memory/conversation-key-store.js";
 import { searchConversations } from "../../memory/conversation-queries.js";
+import { MEMORY_RETROSPECTIVE_FORK_SOURCE } from "../../memory/memory-retrospective-constants.js";
 import { recordOnboardingEvent } from "../../memory/onboarding-events-store.js";
 import { buildSlackMessageDeepLinks } from "../../messaging/providers/slack/deep-link.js";
 import {
@@ -681,12 +682,23 @@ export function handleListMessages({
   // is left visible, the result will render as a standalone orphan because
   // `mergeToolResultsIntoAssistantMessages` has nothing to merge it into.
   //
+  // Exception: memory-retrospective fork conversations show their hidden rows
+  // (the retrospective instruction) so the run is readable as a distinct turn
+  // and its LLM call is inspectable. The instruction row also separates the
+  // copied source tail from the review turn, so `mergeConsecutiveAssistantMessages`
+  // no longer folds the review into the source's last assistant message. This
+  // is display-only and scoped to the fork source; the LLM-side `getMessages`
+  // loader is unfiltered regardless.
+  //
   // Only renderable roles reach this UI-facing transcript. `system` rows (a
   // permitted `MessageRole`, e.g. skill-authored context) are agent-context
   // scaffolding, never a displayed turn, so they are dropped here at the
   // source rather than narrowed away per-client.
+  const isRetrospectiveFork =
+    getConversation(resolvedConversationId)?.source ===
+    MEMORY_RETROSPECTIVE_FORK_SOURCE;
   const visibleFilter = (m: MessageRow) =>
-    !isHiddenMessage(m.metadata) &&
+    (isRetrospectiveFork || !isHiddenMessage(m.metadata)) &&
     (m.role === "user" || m.role === "assistant");
 
   if (isPaginated) {


### PR DESCRIPTION
## Summary
- The chat message-list endpoint (`handleListMessages`) filters out `hidden` messages. For a `memory-retrospective-fork` conversation this hid the retrospective instruction and caused `mergeConsecutiveAssistantMessages` to fold the assistant's review into the copied source's last turn — so opening a fork retrospective rendered identically to the source it reviewed, and there was no distinct turn to open in the LLM call inspector.
- Relax the display filter for `memory-retrospective-fork` conversations only so hidden rows are included: the instruction and review now render as separate turns (the instruction row also separates the copied source tail from the review, preventing the merge).
- Display-only and fork-scoped: the LLM-side `getMessages` loader is unfiltered regardless, so what the agent/model sees is unchanged. No web or inspector changes were needed — the client renders whatever the daemon returns, and the inspector works on the now-visible review turn (logs are already captured for fork turns, keyed by conversation/message id).

## Original prompt
With the fork-based memory retrospective path now enabled, clicking a retrospective run in Settings → Schedules opened a conversation that looked identical to the source it reviewed (the instruction is hidden and the review merged into the copied turn), with no separate turn to inspect the retrospective's LLM call. The ask was to see the whole retrospective conversation and be able to open the LLM call inspector on its turn. The fix is scoped to fork conversations and is display-only, leaving the agent/LLM-context path untouched.

## Test plan
- `bunx tsc --noEmit` (assistant): clean
- `bun test src/__tests__/list-messages-hidden-metadata.test.ts`: 8 pass (added a fork-shows-instruction+separate-review case and a non-fork-still-hides regression case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)