### PR TITLE
Add telegram-voice-transcribe plugin to marketplace catalog

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -52,6 +52,18 @@
       "category": "developer",
       "homepage": "https://github.com/vellum-ai/level-up",
       "license": "MIT"
+    },
+    {
+      "name": "telegram-voice-transcribe",
+      "source": {
+        "source": "github",
+        "repo": "marinatrajk/telegram-voice-transcribe",
+        "ref": "5c0fcaf68f48e647fd4a0f73bfa9ace84d55dc8e"
+      },
+      "description": "Transcribes Telegram voice notes to text via a user-prompt-submit hook, rewriting the message before the agent loop sees it.",
+      "category": "channels",
+      "homepage": "https://github.com/marinatrajk/telegram-voice-transcribe",
+      "license": "MIT"
     }
   ]
 }


### PR DESCRIPTION
## What

Adds `telegram-voice-transcribe` to the curated plugins catalog.

## Why

Marina wants Telegram voice notes to flow as searchable text into the agent loop instead of opaque audio blobs. The plugin reads inbound messages at the `user-prompt-submit` seam, downloads voice attachments via the Telegram Bot API, transcribes via the host `/v1/stt/transcribe` endpoint (with ElevenLabs Scribe and OpenAI Whisper as fallbacks), and rewrites `ContentBlock` audio parts as `[voice transcript, M:SS]` text so the model sees the words by default.

## Pin

Plugin repo `marinatrajk/telegram-voice-transcribe` at `5c0fcaf68f48e647fd4a0f73bfa9ace84d55dc8e` (the commit that bumps the marketplace-pr SHA in the plugin docs).

## Source

Plugin: https://github.com/marinatrajk/telegram-voice-transcribe
SKILL.md activation hints live in `skills/telegram-voice-transcribe/SKILL.md` (companion fallback). Real work happens at `hooks/user-prompt-submit.ts`.

## Risk

Plugin API is in beta (`@vellumai/plugin-api` peerDeps at `^0.8.0`); expect migration churn until 1.0. Hook is observation-over-transformation in spirit, but in this case we mutate `latestMessages: Message[]` in place before the agent loop reads them.

## Caveat for Vellum team

Approving this means anyone with `assistant plugins install telegram-voice-transcribe` can pull from the pinned repo. The plugin also installs a companion skill under `skills/telegram-voice-transcribe/` that activates on hint match. Both originate from a non-`vellum-ai` GitHub account (marinatrajk). If the team prefers a `vellum-ai/` org fork, Marina will move.