### PR TITLE
fix(ces): distinguish an unreadable credential store from a missing key (cold-start false 'not found')

### DIFF
--- a/credential-executor/src/__tests__/local-secure-key-backend.test.ts
+++ b/credential-executor/src/__tests__/local-secure-key-backend.test.ts
@@ -12,7 +12,10 @@ import { randomBytes } from "node:crypto";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-import { createLocalSecureKeyBackend } from "../materializers/local-secure-key-backend.js";
+import {
+  createLocalSecureKeyBackend,
+  StoreUnavailableError,
+} from "../materializers/local-secure-key-backend.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -152,5 +155,50 @@ describe("createLocalSecureKeyBackend — filesystem", () => {
     const backend = createLocalSecureKeyBackend(vellumRoot);
     const result = await backend.delete("anything");
     expect(result).toBe("error");
+  });
+
+  // -------------------------------------------------------------------------
+  // UNAVAILABLE (store exists but cannot be read / decrypted) must be distinct
+  // from ABSENT (no store, or the store reads cleanly but lacks the key). The
+  // former throws so the RPC layer reports `unreachable`; the latter returns
+  // undefined/[]. This is the cold-start fix: a transiently-unreadable store or
+  // missing key material must never masquerade as "credential not found".
+  // -------------------------------------------------------------------------
+
+  test("get() THROWS (not undefined) when the store file exists but is unreadable", async () => {
+    const { securityDir, vellumRoot } = setup();
+    // A store file that exists but cannot be parsed (e.g. a partial/corrupt
+    // read) — distinct from no store at all.
+    writeFileSync(join(securityDir, "keys.enc"), "{ not valid json", {
+      mode: 0o600,
+    });
+    const backend = createLocalSecureKeyBackend(vellumRoot);
+    await expect(backend.get("anything")).rejects.toThrow(StoreUnavailableError);
+  });
+
+  test("get() returns undefined when the store reads cleanly but the key is absent", async () => {
+    const { vellumRoot } = setup();
+    const backend = createLocalSecureKeyBackend(vellumRoot);
+    await backend.set("present/key", "v"); // valid store with one entry
+    // A genuinely missing key in a readable store is ABSENT, not unavailable.
+    expect(await backend.get("absent/key")).toBeUndefined();
+  });
+
+  test("get() THROWS when a v2 entry exists but store.key is missing (cold-start key-material race)", async () => {
+    const { securityDir, vellumRoot } = setup();
+    const backend = createLocalSecureKeyBackend(vellumRoot);
+    await backend.set("k", "v"); // creates the v2 store + store.key
+    expect(await backend.get("k")).toBe("v"); // sanity: warm read works
+    // Simulate the cold-start window where the key material is transiently
+    // unavailable: the entry still exists, but it cannot be decrypted yet.
+    rmSync(join(securityDir, "store.key"));
+    await expect(backend.get("k")).rejects.toThrow(StoreUnavailableError);
+  });
+
+  test("list() THROWS (not []) when the store file exists but is unreadable", async () => {
+    const { securityDir, vellumRoot } = setup();
+    writeFileSync(join(securityDir, "keys.enc"), "{ corrupt", { mode: 0o600 });
+    const backend = createLocalSecureKeyBackend(vellumRoot);
+    await expect(backend.list()).rejects.toThrow(StoreUnavailableError);
   });
 });

--- a/credential-executor/src/materializers/local-secure-key-backend.ts
+++ b/credential-executor/src/materializers/local-secure-key-backend.ts
@@ -279,6 +279,34 @@ function readStore(storePath: string): StoreFile | null {
 }
 
 // ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown by `get()` / `list()` when the credential store is UNAVAILABLE — the
+ * store file exists but cannot be read, the v2 `store.key` (or v1 machine
+ * entropy) key material is missing, or an entry fails to decrypt. This is
+ * deliberately DISTINCT from a credential being ABSENT (no store file yet, or
+ * the store reads cleanly but lacks the requested key), which returns
+ * `undefined` / `[]`.
+ *
+ * The distinction matters on CES cold start: for a brief window after a
+ * (re)start the key material can be transiently unreadable (see the
+ * `entropyGetter` note on {@link createLocalSecureKeyBackend} — "the file may
+ * not exist at construction time but appears later"). Returning `undefined`
+ * there reports a credential that EXISTS as "not found"; throwing instead
+ * surfaces the true state to the RPC layer (a `HANDLER_ERROR` the daemon maps
+ * to `unreachable`), so a transient read failure is never mistaken for a
+ * missing credential.
+ */
+export class StoreUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "StoreUnavailableError";
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Backend implementation
 // ---------------------------------------------------------------------------
 
@@ -310,29 +338,50 @@ export function createLocalSecureKeyBackend(
 
   return {
     async get(key: string): Promise<string | undefined> {
-      try {
-        const store = readStore(storePath);
-        if (!store) return undefined;
-
-        const entry = store.entries[key];
-        if (!entry) return undefined;
-
-        let aesKey: Buffer;
-        if (store.version === 2) {
-          const storeKey = readStoreKey(vellumRoot);
-          if (!storeKey) return undefined;
-          aesKey = storeKey;
-        } else {
-          // v1: derive key from machine entropy via PBKDF2
-          const entropy = entropyGetter?.() ?? staticEntropy;
-          const salt = Buffer.from(store.salt, "hex");
-          aesKey = deriveKey(salt, entropy);
+      const store = readStore(storePath);
+      if (!store) {
+        // No store file at all → the credential is genuinely ABSENT. A store
+        // file that EXISTS but could not be read is UNAVAILABLE, not absent —
+        // surface it rather than reporting a false "not found".
+        if (existsSync(storePath)) {
+          throw new StoreUnavailableError(
+            "credential store exists but could not be read",
+          );
         }
-
-        return decrypt(entry, aesKey);
-      } catch {
         return undefined;
       }
+
+      const entry = store.entries[key];
+      // The store read cleanly and has no such entry → genuinely not found.
+      if (!entry) return undefined;
+
+      let aesKey: Buffer;
+      if (store.version === 2) {
+        const storeKey = readStoreKey(vellumRoot);
+        if (!storeKey) {
+          // The entry exists but the key material to decrypt it is unavailable
+          // (the cold-start race). Unavailable, NOT not-found.
+          throw new StoreUnavailableError(
+            "v2 store entry present but store.key is unavailable",
+          );
+        }
+        aesKey = storeKey;
+      } else {
+        // v1: derive key from machine entropy via PBKDF2. `entropy` is an
+        // OPTIONAL override (managed mode); when undefined, deriveKey falls
+        // back to local machine entropy — the normal local-mode path, so an
+        // undefined value here is NOT "unavailable". A v1 cold-start race (the
+        // override entropy file not yet present) yields the wrong key and
+        // surfaces below as a decrypt failure → unavailable.
+        const entropy = entropyGetter?.() ?? staticEntropy;
+        const salt = Buffer.from(store.salt, "hex");
+        aesKey = deriveKey(salt, entropy);
+      }
+
+      // A decrypt failure means corrupt data or wrong key material — the
+      // credential exists but we cannot produce its value. Let it propagate as
+      // unavailable rather than swallowing it into a false "not found".
+      return decrypt(entry, aesKey);
     },
 
     // NOTE: read-modify-write without file locking. The atomic rename
@@ -387,13 +436,18 @@ export function createLocalSecureKeyBackend(
     },
 
     async list(): Promise<string[]> {
-      try {
-        const store = readStore(storePath);
-        if (!store) return [];
-        return Object.keys(store.entries);
-      } catch {
+      const store = readStore(storePath);
+      if (!store) {
+        // Mirror get(): a store file that exists but is unreadable is
+        // UNAVAILABLE (surface it), not an empty credential set.
+        if (existsSync(storePath)) {
+          throw new StoreUnavailableError(
+            "credential store exists but could not be read",
+          );
+        }
         return [];
       }
+      return Object.keys(store.entries);
     },
   };
 }


### PR DESCRIPTION
## Summary

- CES's local key-store `get()` returned `undefined` — i.e. "not found" — whenever it *could not read* the store (store file present but unparseable, v2 `store.key` missing, or a decrypt failure), conflating "I couldn't check the vault" with "the credential isn't there." On CES cold start the key material is transiently unreadable for a brief window (the `entropyGetter` docstring already notes "the file may not exist at construction time but appears later"), so a freshly-(re)started CES reported existing keys as missing — the root of the ~2s post-restart false "not found" that (pre-hard-fail) silently starved memory-v3.
- `get()`/`list()` now **throw** a typed `StoreUnavailableError` for the unavailable cases (store-exists-but-unreadable / missing `store.key` / decrypt failure), distinct from genuine absence (no store file, or a clean store that lacks the key → still `undefined`/`[]`). The throw is caught at the RPC boundary (`HANDLER_ERROR`) and the daemon maps it to `unreachable` rather than not-found.
- **No behavior regression**: in local (ces-rpc) mode the daemon currently collapses `unreachable` to the same `undefined` for provider keys, so downstream resolution is unchanged — but the cold-start cause now **surfaces** in the daemon log (the existing `"CES RPC credential get failed"` warn carries the specific reason), where today it is an invisible silent miss.

## Original prompt

Diagnosing why memory-v3 lost its memory traced to CES flapping → a ~2s cold-vault window where a freshly-restarted CES returns "not found" for keys that exist. Sidd chose to root-fix the CES cold start. This makes CES honest — an unreadable store is "unavailable", not "absent" — fixing the latent correctness bug and making the exact cold-start failure mode visible in the logs.

## Follow-up (gated on this PR's data)

This is the CES-side half. The daemon still collapses `unreachable` → `undefined` for provider keys (`getSecureKeyAsync` drops the flag), so the user-visible cold window isn't fully closed until the daemon **retries** on `unreachable` across the warm-up. Sizing that retry needs the cold-window duration — which this PR's logs will reveal after deploy. (The worst symptom, silent v3 memory loss, is already hard-failed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)