### PR TITLE
feat(web): deep-link workspace browser to a file via ?path=

### DIFF
--- a/apps/web/src/domains/workspace/components/workspace-browser.tsx
+++ b/apps/web/src/domains/workspace/components/workspace-browser.tsx
@@ -16,14 +16,27 @@ import {
   WorkspaceTree,
   type WorkspaceSortMode,
 } from "@/domains/workspace/components/workspace-tree";
+import {
+  ancestorPaths,
+  normalizeDeepLinkPath,
+} from "@/domains/workspace/utils/deep-link";
 
 export type WorkspaceViewMode = "preview" | "source";
 
 export function WorkspaceBrowser({ assistantId }: { assistantId: string }) {
-  const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set());
-  const [selectedPath, setSelectedPath] = useState<string | null>(null);
-  const [showHidden, setShowHidden] = useState(false);
   const [searchParams] = useSearchParams();
+  // Seed selection/expansion from `?path=` on mount so links into the workspace
+  // (e.g. file paths in chat) open the targeted entry with its ancestors
+  // revealed. Subsequent param changes are ignored — selection is then
+  // user-driven via the tree.
+  const [initialPath] = useState(() =>
+    normalizeDeepLinkPath(searchParams.get("path")),
+  );
+  const [expandedPaths, setExpandedPaths] = useState<Set<string>>(
+    () => new Set(initialPath ? ancestorPaths(initialPath) : []),
+  );
+  const [selectedPath, setSelectedPath] = useState<string | null>(initialPath);
+  const [showHidden, setShowHidden] = useState(false);
   const [sortMode, setSortMode] = useState<WorkspaceSortMode>(() =>
     searchParams.get("sort") === "size" ? "size" : "name",
   );

--- a/apps/web/src/domains/workspace/utils/deep-link.test.ts
+++ b/apps/web/src/domains/workspace/utils/deep-link.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+
+import { ancestorPaths, normalizeDeepLinkPath } from "./deep-link";
+
+describe("normalizeDeepLinkPath", () => {
+  test("returns null for absent or empty values", () => {
+    expect(normalizeDeepLinkPath(null)).toBeNull();
+    expect(normalizeDeepLinkPath("")).toBeNull();
+    expect(normalizeDeepLinkPath("   ")).toBeNull();
+    expect(normalizeDeepLinkPath("/")).toBeNull();
+    expect(normalizeDeepLinkPath("///")).toBeNull();
+  });
+
+  test("strips surrounding whitespace and leading/trailing slashes", () => {
+    expect(normalizeDeepLinkPath("scratch/foo")).toBe("scratch/foo");
+    expect(normalizeDeepLinkPath("/scratch/foo/")).toBe("scratch/foo");
+    expect(normalizeDeepLinkPath("  scratch/foo  ")).toBe("scratch/foo");
+    expect(normalizeDeepLinkPath("scratch/foo.md")).toBe("scratch/foo.md");
+  });
+});
+
+describe("ancestorPaths", () => {
+  test("returns every ancestor prefix plus the path itself, shallowest-first", () => {
+    expect(ancestorPaths("a/b/c")).toEqual(["a", "a/b", "a/b/c"]);
+  });
+
+  test("single segment yields just that segment", () => {
+    expect(ancestorPaths("scratch")).toEqual(["scratch"]);
+  });
+
+  test("empty path yields no prefixes", () => {
+    expect(ancestorPaths("")).toEqual([]);
+  });
+
+  test("ignores empty interior segments from stray slashes", () => {
+    expect(ancestorPaths("a//b")).toEqual(["a", "a/b"]);
+  });
+});

--- a/apps/web/src/domains/workspace/utils/deep-link.ts
+++ b/apps/web/src/domains/workspace/utils/deep-link.ts
@@ -1,0 +1,33 @@
+/**
+ * Helpers for deep-linking the workspace browser to a specific entry via the
+ * `?path=` search param. Paths are workspace-relative (matching the keys the
+ * workspace tree/file APIs use), e.g. `scratch/figma-cli/README.md`.
+ */
+
+/**
+ * Normalize a raw `?path=` value into a workspace-relative path, or `null` when
+ * it is absent or empty. Strips surrounding whitespace and leading/trailing
+ * slashes so `/scratch/foo/` and `scratch/foo` resolve identically.
+ */
+export function normalizeDeepLinkPath(raw: string | null): string | null {
+  if (raw === null) return null;
+  const trimmed = raw.trim().replace(/^\/+/, "").replace(/\/+$/, "");
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Every ancestor directory prefix of `path`, plus `path` itself, ordered
+ * shallowest-first. Seeding these into the tree's expanded set reveals a nested
+ * target. Expanding the target itself is harmless when it turns out to be a
+ * file — the tree simply renders no children.
+ *
+ * `ancestorPaths("a/b/c")` → `["a", "a/b", "a/b/c"]`.
+ */
+export function ancestorPaths(path: string): string[] {
+  const segments = path.split("/").filter((s) => s.length > 0);
+  const prefixes: string[] = [];
+  for (let i = 0; i < segments.length; i++) {
+    prefixes.push(segments.slice(0, i + 1).join("/"));
+  }
+  return prefixes;
+}


### PR DESCRIPTION
## What

Adds `?path=` deep-linking to the workspace browser. On mount, `WorkspaceBrowser` seeds its selected entry and expanded directories from the param, so a link can open a targeted (possibly nested) file with its ancestor folders revealed.

- The param is **workspace-relative** (e.g. `scratch/figma-cli/README.md`), matching the keys the workspace tree/file APIs use (`workspace-routes.ts` returns `fullPath.slice(workspaceDir.length + 1)`).
- Absent/empty/`/`-only params leave the browser in its default state.
- Selection is user-driven after mount; later param changes are intentionally ignored.
- Path normalization + ancestor-prefix computation live in a pure `deep-link` util (`normalizeDeepLinkPath`, `ancestorPaths`) with unit tests.

## Why

First half of making file paths in chat clickable. This PR provides the navigation target; a follow-up PR linkifies workspace paths in chat messages to point here. Independently useful — any in-app surface can now link into the workspace.

## Notes for review

- A `?path=` that no longer exists degrades gracefully: the file viewer already renders its not-found state, and pre-expanding a path that turns out to be a file is a no-op (the tree renders no children).
- Reuses the existing lazy per-directory fetch — pre-seeded `expandedPaths` trigger the same child fetches as a manual expand.

## Test plan

- `bun test src/domains/workspace/utils/deep-link.test.ts` — 6 pass
- `bunx tsc --noEmit` — clean
- `bun run lint` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)