### PR TITLE
fix(web): show "Thinking…" label on the pre-thinking indicator

### DIFF
--- a/apps/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-row.tsx
@@ -144,13 +144,9 @@ export const TranscriptRow = memo(function TranscriptRow({
                 }}
               />
             ))}
-            {item.label ? (
-              <span className="ml-1 text-body-small-default text-[var(--content-secondary)]">
-                {item.label}
-              </span>
-            ) : (
-              <span className="sr-only">Thinking…</span>
-            )}
+            <span className="ml-1 text-body-small-default text-[var(--content-secondary)]">
+              {item.label ?? "Thinking…"}
+            </span>
           </div>
         </div>
       );


### PR DESCRIPTION
## What

The standalone pre-thinking indicator (the `"thinking"` transcript row gated by `shouldShowThinkingIndicator()`) rendered a daemon-supplied status label when one was present, but otherwise fell back to a **visually-hidden `sr-only` "Thinking…"** — leaving only the bare animated dots on screen.

That fallback is hit during the window after a turn starts but before any reasoning content hydrates the live message. On slow open-weight reasoning models (e.g. **MiniMax M3 on Fireworks**, the `balanced-economy` profile) that window is ~2s at the start of *every* agent-loop iteration, so in a tool-heavy turn the bare dots flash repeatedly and read as a stall.

## Change

Always render a visible label, defaulting to `"Thinking…"` when the daemon supplies no status text. Richer daemon-supplied status text (e.g. "Reading files") still wins when present.

## Why

Came out of triaging user feedback: *"There is a pre-thinking state showing only 3 dots in the chat… noticing it more on OS models."* Root cause is the long per-iteration time-to-first-reasoning-token on OS models combined with the bare-dots fallback. This is the low-risk UX half of the fix — it makes the latency window read as deliberate ("Thinking…") rather than a hang. Model-agnostic: frontier models hit the same row briefly; OS models linger in it.

## Test

- `build-items` + `transcript-message-body` tests pass (53/53).
- `transcript-row.tsx` typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)