### PR TITLE
fix(assistant): keep full tool surface on the wire for fork retrospectives (prompt-cache parity)

### DIFF
--- a/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
@@ -764,12 +764,14 @@ describe("memoryRetrospectiveJob", () => {
 
     expect(wakeCalls).toHaveLength(1);
     expect("forceOverrideProfile" in wakeCalls[0]!.opts).toBe(false);
-    // Wire mode (default) when not matching the profile — there is no cache
-    // to preserve, so the smaller filtered request wins.
-    expect("toolGateMode" in wakeCalls[0]!.opts).toBe(false);
+    // Tool-surface parity is unconditional: execution gate mode + the
+    // source-derived tool-context pin ride every fork wake, independently of
+    // profile matching. Only `forceOverrideProfile` is gated on the flag.
+    expect(wakeCalls[0]!.opts.toolGateMode).toBe("execution");
+    expect(wakeCalls[0]!.opts.toolContextPin).toBeDefined();
   });
 
-  test("fork path: matchConversationProfile on but source has no inferenceProfile → wire mode, no forceOverrideProfile", async () => {
+  test("fork path: matchConversationProfile on but source has no inferenceProfile → execution mode (tool parity unconditional), no forceOverrideProfile", async () => {
     forkFlagEnabled = true;
 
     await memoryRetrospectiveJob(
@@ -778,16 +780,15 @@ describe("memoryRetrospectiveJob", () => {
     );
 
     expect(wakeCalls).toHaveLength(1);
+    // No resolved profile ⇒ no forceOverrideProfile, but tool-surface parity
+    // (execution mode + tool-context pin) still rides — it's decoupled from
+    // profile matching.
     expect("forceOverrideProfile" in wakeCalls[0]!.opts).toBe(false);
-    // toolGateMode keys on the RESOLVED profile match, not the bare config
-    // flag: with no pinned profile the wake runs the call-site default
-    // model, so there is no source cache to preserve — shipping the full
-    // tool surface would pay wire cost for nothing. Wire mode (absent
-    // toolGateMode) keeps the smaller filtered request.
-    expect("toolGateMode" in wakeCalls[0]!.opts).toBe(false);
+    expect(wakeCalls[0]!.opts.toolGateMode).toBe("execution");
+    expect(wakeCalls[0]!.opts.toolContextPin).toBeDefined();
   });
 
-  test("fork path: matchConversationProfile on but the profile session expired → wire mode, no forceOverrideProfile", async () => {
+  test("fork path: matchConversationProfile on but the profile session expired → execution mode, no forceOverrideProfile", async () => {
     forkFlagEnabled = true;
     conversationOverrides["src-conv-1"] = {
       source: "user",
@@ -805,7 +806,7 @@ describe("memoryRetrospectiveJob", () => {
 
     expect(wakeCalls).toHaveLength(1);
     expect("forceOverrideProfile" in wakeCalls[0]!.opts).toBe(false);
-    expect("toolGateMode" in wakeCalls[0]!.opts).toBe(false);
+    expect(wakeCalls[0]!.opts.toolGateMode).toBe("execution");
   });
 
   test("fork path: local/vellum source → wake carries the guardian persona + vellum channel override", async () => {
@@ -918,7 +919,7 @@ describe("memoryRetrospectiveJob", () => {
     });
   });
 
-  test("fork path: wire mode (no resolved profile) → no toolContextPin on the wake", async () => {
+  test("fork path: execution mode is unconditional → toolContextPin rides even without a resolved profile", async () => {
     forkFlagEnabled = true;
 
     await memoryRetrospectiveJob(
@@ -927,9 +928,10 @@ describe("memoryRetrospectiveJob", () => {
     );
 
     expect(wakeCalls).toHaveLength(1);
-    // The pin exists purely for wire tool-surface cache parity, which is
-    // only in play in execution gate mode.
-    expect("toolContextPin" in wakeCalls[0]!.opts).toBe(false);
+    // Tool-surface parity is unconditional: the pin + execution gate mode ride
+    // every fork wake, even when no profile resolved.
+    expect(wakeCalls[0]!.opts.toolGateMode).toBe("execution");
+    expect(wakeCalls[0]!.opts.toolContextPin).toBeDefined();
   });
 
   test("fork path: toolContextPin recovers the interface from the NEWEST stamped user message in the slice", async () => {

--- a/assistant/src/memory/memory-retrospective-job.ts
+++ b/assistant/src/memory/memory-retrospective-job.ts
@@ -445,12 +445,12 @@ async function runForkBasedRetrospective(
     : undefined;
 
   // Persona + tool-context parity pins derived from the source conversation
-  // (see `resolveSourceParityPins`). The persona override is passed
-  // unconditionally — the correct persona is a review-quality fix on its
-  // own; with profile matching it additionally preserves the source's
-  // cached system-prompt prefix. The tool-context pin rides only with
-  // execution gate mode below: it exists purely for wire tool-surface
-  // cache parity.
+  // (see `resolveSourceParityPins`), both passed unconditionally. The persona
+  // override keeps the system-prompt prefix in parity (and is a review-quality
+  // fix on its own); the tool-context pin keeps the wire tool surface in
+  // parity — the fork always runs execution gate mode below, so the source's
+  // full tool surface stays on the wire while the allowlist holds at
+  // execution time.
   const { personaOverride, toolContextPin } = resolveSourceParityPins(
     sourceConversation,
     newMessages,
@@ -469,19 +469,21 @@ async function runForkBasedRetrospective(
       trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT,
       callSite: "memoryRetrospective",
       allowedTools: ["remember"],
-      // When the profile match resolved (cache parity is in play), keep the
-      // source's full tool surface on the wire AND resolve it under the
-      // source's client context — see {@link SubagentToolGateMode} and
-      // {@link WakeToolContextPin} for the rationale; the allowlist still
-      // holds at execution time. No match ⇒ no source cache to preserve, so
-      // the smaller wire-filtered request wins (keyed on `matchedProfile`,
-      // not the bare config flag).
+      // Always keep the source's full tool surface on the wire and resolve it
+      // under the source's client context (`toolContextPin`). The wire tool
+      // block is the first tier of the provider cache prefix
+      // (tools → system → messages), so a `remember`-only wire filter busts
+      // cache parity with the source's live turns — re-creating the cached
+      // prefix instead of reading it. The allowlist still holds at execution
+      // time: non-`remember` calls are rejected before any executor or side
+      // effect runs. See {@link SubagentToolGateMode} and
+      // {@link WakeToolContextPin}.
+      toolGateMode: "execution" as const,
+      toolContextPin,
+      // Profile forcing (model/thinking/effort parity) is a separate concern
+      // and stays keyed on `matchConversationProfile` via `matchedProfile`.
       ...(matchedProfile !== undefined
-        ? {
-            toolGateMode: "execution" as const,
-            forceOverrideProfile: matchedProfile,
-            toolContextPin,
-          }
+        ? { forceOverrideProfile: matchedProfile }
         : {}),
       personaOverride,
       hintRole: "user",
@@ -595,12 +597,27 @@ interface SourceParityPins {
  * for the former and outcome-equal for the latter.
  */
 function resolveSourceParityPins(
-  source: Pick<ConversationRow, "originChannel" | "originInterface">,
+  source: Pick<ConversationRow, "id" | "originChannel" | "originInterface">,
   sliceMessages: Array<{ role: string; metadata: string | null }>,
 ): SourceParityPins {
   const channel = source.originChannel;
   const channelRouted = channel != null && channel !== "vellum";
   const recovered = resolveSourceLiveInterface(source, sliceMessages);
+  if (recovered === undefined && !channelRouted) {
+    // No per-turn interface stamp and no originInterface, so the pin falls
+    // back to "web" below. If the source actually ran on a desktop interface
+    // (e.g. macos with host_* tools), those tools won't be reproduced on the
+    // fork's wire and tool-surface cache parity will partially miss. Surface
+    // it rather than silently miss.
+    log.warn(
+      {
+        conversationId: source.id,
+        originInterface: source.originInterface,
+        originChannel: source.originChannel,
+      },
+      "memory-retrospective (fork): source live interface unrecoverable; tool-surface cache parity may miss (defaulting to web)",
+    );
+  }
   // Non-channel-routed sources always have a client-connected interface;
   // when none is recoverable, default to "web" — the same terminal fallback
   // `resolveTurnInterface` applies to live turns. Channel-routed sources
@@ -1031,7 +1048,7 @@ function buildForkInstruction({
     ? "Your review window is the full conversation above, ending just before this instruction message."
     : `Your review window starts at ${anchorDescription} and ends just before this instruction message. If you cannot locate that anchoring turn in your visible history (for example, it is behind the compaction summary), fail closed: review only the most recent visible messages after the summary, not the whole conversation.`;
 
-  return `This is an automated background memory pass over the conversation above — not a message from the user. Do not reply conversationally or in persona; just perform the review described here.
+  return `This is an automated background memory pass over the conversation above — not a message from the user. Do not reply conversationally or in persona; just perform the review described here. Only the \`remember\` tool is available for this pass — any other tool call will be rejected, so don't attempt one.
 
 ${windowAnchor}
 


### PR DESCRIPTION
## Summary
- Fork memory retrospectives ran the review wake in the default `wire` tool-gate mode, filtering the wire tools down to `["remember"]`. Since the tool block is the first tier of the provider cache prefix (`tools → system → messages`), the 1-vs-N tool mismatch invalidated the whole cached prefix — the fork re-created ~63k tokens instead of reading them from the source's warm cache (confirmed in `llm_request_logs`: fork `cache_creation 62874 / cache_read 9120` vs source turn `9914 / 61893`; model/thinking/system/persona already matched).
- Make `toolGateMode: "execution"` + the source-derived `toolContextPin` **unconditional** for the fork path: the full tool surface always rides the wire (cache-stable), while the allowlist is still enforced at execution time — non-`remember` calls are rejected before any executor or side effect runs. Profile forcing (model/thinking/effort parity) stays separately gated on `memory.retrospective.matchConversationProfile`.
- Warn when the source's live interface can't be recovered (the pin falls back to `web`, so host/ui tools may not reproduce and parity can still partially miss — now observable instead of silent), and note in the review instruction that only `remember` is available (the agent now sees the full tool list).

## Original prompt
Inspecting a fork retrospective's first LLM call showed a large prompt-cache miss. The cause was that the retrospective wake only puts the `remember` tool on the wire, so the tool block — the first part of the cache prefix — diverges from the source conversation's live turns and busts the cache. The fix is to send the source's full tool surface for cache stability while blocking execution of everything except `remember`, which is exactly what the existing `execution` gate mode + tool-context pin do; this decouples that tool-surface parity from the `matchConversationProfile` flag so it's on by default.

## Test plan
- `bunx tsc --noEmit` (assistant): clean
- `bun test src/memory/__tests__/memory-retrospective-job.test.ts`: 62 pass (updated the no-resolved-profile cases to expect execution mode + tool-context pin unconditionally)
- `bun test src/__tests__/subagent-tool-gate-mode.test.ts`: 16 pass (safety gate unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)