### PR TITLE
fix(web): guard the seq-aware merge against truncating a streamed answer when seq is absent

### DIFF
--- a/apps/web/src/domains/chat/utils/reconcile-with-seq.test.ts
+++ b/apps/web/src/domains/chat/utils/reconcile-with-seq.test.ts
@@ -126,6 +126,85 @@ describe("reconcileMessagesWithSeq", () => {
     expect(messageText(result[0])).toBe("server");
   });
 
+  test("keeps the streamed assistant row when a seq-unknown snapshot would truncate it", () => {
+    /**
+     * The seq-unknown safety net. On paths with no honest seq (a pre-seq
+     * daemon image, an older client), a debounced `/messages` snapshot that
+     * still lags the just-streamed answer must not blow it away. This is the
+     * 2026-06-15 "how many r's in strawberry" report: the stream rendered the
+     * answer, then a post-completion reconcile carrying an empty snapshot row
+     * clobbered it to nothing while the turn already showed as done.
+     */
+    // GIVEN a fully-streamed assistant answer
+    const local = [
+      makeRow({
+        id: "a1",
+        role: "assistant",
+        ...textBody("3."),
+        timestamp: 1000,
+      }),
+    ];
+
+    // AND a debounced snapshot of the same row that still carries no text
+    const server = [
+      makeRow({
+        id: "a1",
+        role: "assistant",
+        ...textBody(""),
+        timestamp: 1000,
+      }),
+    ];
+
+    // WHEN neither side carries an honest seq
+    const result = reconcileMessagesWithSeq(local, server, {
+      serverSeq: null,
+      localSeq: null,
+    });
+
+    // THEN the rendered answer is preserved, not truncated away
+    expect(result).toHaveLength(1);
+    expect(messageText(result[0])).toBe("3.");
+    // AND the server-assigned identity is still adopted
+    expect(result[0]!.id).toBe("a1");
+  });
+
+  test("still takes a seq-unknown snapshot that extends the row rather than truncating it", () => {
+    /**
+     * The guard fires only on strict truncation. A snapshot that grows the row
+     * (an authoritative correction or a later, fuller persist) is not a
+     * regression, so it still wins even with no seq — keeping the safety net
+     * from pinning the client to stale local content.
+     */
+    // GIVEN a partially-rendered local row
+    const local = [
+      makeRow({
+        id: "a1",
+        role: "assistant",
+        ...textBody("3"),
+        timestamp: 1000,
+      }),
+    ];
+
+    // AND a fuller server row that extends it
+    const server = [
+      makeRow({
+        id: "a1",
+        role: "assistant",
+        ...textBody("3 r's, to be precise."),
+        timestamp: 1000,
+      }),
+    ];
+
+    // WHEN seq is unknown
+    const result = reconcileMessagesWithSeq(local, server, {
+      serverSeq: null,
+      localSeq: null,
+    });
+
+    // THEN the fuller server content is applied
+    expect(messageText(result[0])).toBe("3 r's, to be precise.");
+  });
+
   test("admits brand-new server rows even while the snapshot is stale", () => {
     /**
      * The stale-snapshot gate only protects rows the stream already advanced;

--- a/apps/web/src/domains/chat/utils/reconcile-with-seq.ts
+++ b/apps/web/src/domains/chat/utils/reconcile-with-seq.ts
@@ -31,9 +31,20 @@ import type { DisplayMessage } from "@/domains/chat/types/types";
  *
  * When `L > S` the snapshot is stale: every row it carries reflects state at
  * or below `S`, so applying it would regress rows the stream advanced past
- * `S`. We keep the live local rows. When `S >= L` (or either is unknown) the
- * snapshot has seen everything the stream applied, so it is authoritative and
- * we take the server rows wholesale.
+ * `S`. We keep the live local rows. When `S >= L` the snapshot has seen
+ * everything the stream applied, so it is authoritative and we take the
+ * server rows wholesale.
+ *
+ * Seq-unknown safety net: `seq` only steers the merge when it is present on
+ * BOTH sides — stamped by the daemon AND surviving to the client. On paths
+ * where it is absent (a pre-seq daemon image, an older client, a replay edge)
+ * the CDC invariant cannot fire, and an authoritative-by-default snapshot
+ * would take server rows wholesale — including a debounced snapshot still
+ * lagging the stream, which truncates the rendered answer (the exact
+ * regression this reconciler exists to prevent). So when seq is unavailable
+ * we apply one narrow guard: never replace a local assistant row with a
+ * snapshot row whose text strictly truncates it (see
+ * {@link snapshotTruncatesRow}). The seq-present path is untouched.
  *
  * Idempotent stream apply (events with `seq <= L` are no-ops) is enforced
  * upstream in the SSE consumer, so this merge never has to dedupe replays.
@@ -76,6 +87,12 @@ export function reconcileMessagesWithSeq(
     options.localSeq != null &&
     options.serverSeq < options.localSeq;
 
+  // Seq absent on either side disables the CDC invariant above. We can no
+  // longer prove staleness, so a debounced snapshot would otherwise truncate
+  // a live answer; the per-row guard below restores a narrow protection only
+  // on this path. No-op whenever seq is present (both non-null).
+  const seqUnknown = options.serverSeq == null || options.localSeq == null;
+
   const serverIds = new Set(server.flatMap((m) => messageIdentityKeys(m)));
 
   const oldestLocalTs =
@@ -111,10 +128,15 @@ export function reconcileMessagesWithSeq(
       return [];
     }
 
-    if (streamAhead && localMsg) {
+    if (
+      localMsg &&
+      (streamAhead || (seqUnknown && snapshotTruncatesRow(localMsg, m)))
+    ) {
       // Stale snapshot, live local row: keep the streamed row and adopt
       // only the server-assigned identity so dedupe and the optimistic
-      // echo-swap still resolve the row to its canonical id.
+      // echo-swap still resolve the row to its canonical id. The
+      // seq-unknown arm is the safety net for paths with no honest seq —
+      // it fires only when the snapshot would strictly truncate the row.
       return [adoptServerIdentity(localMsg, m)];
     }
 
@@ -163,6 +185,31 @@ function sameIdentitySequence(
     return false;
   }
   return a.every((row, i) => row.id === b[i]?.id);
+}
+
+/**
+ * Whether `server` would regress `local` by dropping rendered text — the
+ * seq-unknown safety net's sole trigger. True only for an assistant row whose
+ * server text is a strictly shorter prefix of the local text: the signature of
+ * a debounced snapshot that still lags the stream. A genuine server correction
+ * is rarely a pure prefix, so the guard stays tight — it shields a live or
+ * just-streamed answer from truncation without pinning the client to stale
+ * local content on a real edit (those fall through to the wholesale take).
+ * Restricted to assistant rows because only assistant turns stream deltas;
+ * user rows are written whole and never arrive truncated.
+ */
+function snapshotTruncatesRow(
+  local: DisplayMessage,
+  server: DisplayMessage,
+): boolean {
+  if (local.role !== "assistant") {
+    return false;
+  }
+  const localText = messagePlainText(local);
+  const serverText = messagePlainText(server);
+  return (
+    serverText.length < localText.length && localText.startsWith(serverText)
+  );
 }
 
 /**


### PR DESCRIPTION
## What & why

A user reported (2026-06-15, "how many r's in strawberry" / "Counting Letters") that a reply took ~30s to start, then **showed as done with no answer** — only a truncated thought process.

Investigation (full trace below) found the model answered correctly (`"3."`) and **persisted fine** — this is a purely client-side live-render clobber. Root cause: the managed/cloud daemon serving that assistant emitted streaming deltas with **no `seq`**, which silently disables the ATL-781 monotonic merge and lets a debounced `/messages` snapshot overwrite the just-streamed answer.

### The hole

`reconcileMessagesWithSeq` keeps local rows only when it can prove the stream is ahead (`serverSeq < localSeq`). The `else` branch — *take server wholesale* — also swallowed the **seq-unknown** case. Its own docstring said "When `S >= L` (or either is unknown) … take the server rows wholesale." When `seq` is absent on either side, a post-completion reconcile carrying a debounced (lagging) snapshot truncates the rendered answer. That's the exact regression this reconciler exists to prevent, reintroduced on any path where `seq` doesn't survive end-to-end (a pre-seq managed daemon image, an older client, a replay edge).

Evidence from the feedback bundle:
- Deltas (`assistant_thinking_delta` / `assistant_text_delta` / `message_complete`) carried `messageId`, `conversationId`, `timestampMs` — **no `seq`** on any event.
- Platform proxy is transparent passthrough (raw SSE bytes + raw `/messages` JSON) — it does **not** strip `seq`.
- Daemon `broadcastMessage → stampAndBuffer` stamps `seq` on any conversation-scoped event (in mainline since #32676, 2026-05-30) → the reporting assistant ran a **pre-seq daemon image**.
- Timeline: `message_complete` at 16:59:16.476, then a `reconciliation_active_fetch` at 16:59:16.717 took the lagging snapshot wholesale → clobber.

## The fix

A narrow **seq-unknown safety net** that engages **only** when `seq` is unavailable: never replace a local **assistant** row with a snapshot row whose text is a **strictly shorter prefix** of it (the truncation signature). It reuses the existing `adoptServerIdentity` path — keep local content, adopt the server id.

## Additive to the existing seq stack (@dvargasfuertes)

I mapped the full SSE/seq lineage before touching anything (B7.1 #32676 → seq cursor #32736 → gap detection #32948 → per-assistant seq #33225 → **monotonic merge ATL-781 #33574** → stability-from-seq #33802 → GA #33985 → generation-reset). This change is designed to not disturb any of it:

- **Seq-present path is byte-identical.** `seqUnknown = serverSeq == null || localSeq == null` — when both seqs exist the new branch can't fire. Monotonic core, idempotent apply, id-walk/deep-compare stability, cross-conversation filter, client-owned `isStreaming` all untouched.
- **Not a revival of the removed content heuristic.** Far tighter: strict prefix truncation of an *assistant* row only, so a genuine server correction (rarely a pure prefix) still wins. Included a test proving it doesn't over-fire on a snapshot that *extends* a row.

## Tests

- `reconcile-with-seq.test.ts`: **19 pass / 0 fail** (17 existing + 2 new: the strawberry repro, and extend-not-truncate).
- Typecheck clean; no new lint warnings (pure util).

## Follow-ups (not in this PR)

1. **Managed fleet** should ship a daemon ≥ #32676 so `seq` is present and the *primary* protection engages — this web change is the safety net, not a substitute.
2. **Pre-existing test-isolation bug**: `use-event-stream-resume-reconcile.test.tsx` fails when run alongside sibling streaming tests on `main` (reproduced with this PR's changes stashed). Worth a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)