### PR TITLE
[codex] Fix skipped heartbeat usage display

### DIFF
--- a/clients/web/src/domains/settings/components/recent-runs-card.tsx
+++ b/clients/web/src/domains/settings/components/recent-runs-card.tsx
@@ -57,6 +57,8 @@ export function RecentRunsCard({
             const hasOutput = hasRunText(run.output);
             const hasError = hasRunText(run.error);
             const hasLocalDetails = !conversationId && (hasOutput || hasError);
+            const collapsedOutput =
+              run.status === "skipped" && hasOutput ? run.output : null;
             const isExpanded = expandedRunId === run.id;
             const detailsId = `schedule-run-details-${index}`;
             return (
@@ -78,6 +80,7 @@ export function RecentRunsCard({
                           {hasRunText(run.title)
                             ? `${formatTimestamp(run.startedAt)} · `
                             : ""}
+                          {collapsedOutput ? `${collapsedOutput} · ` : ""}
                           {formatDuration(run.durationMs)} ·{" "}
                           {formatScheduleCost(run.estimatedCostUsd)}
                           {run.status === "error" && run.error && (

--- a/clients/web/src/domains/settings/components/schedule-components.test.ts
+++ b/clients/web/src/domains/settings/components/schedule-components.test.ts
@@ -429,6 +429,28 @@ describe("RecentRunsCard", () => {
     expect(document.body.textContent).not.toContain("Run details");
     expect(document.body.textContent).not.toContain("Back to runs");
   });
+
+  test("skipped no-op runs show their reason while collapsed", () => {
+    render(
+      createElement(RecentRunsCard, {
+        runs: [
+          run({
+            id: "heartbeat-skip-1",
+            status: "skipped",
+            conversationId: null,
+            startedAt: 1_761_792_000_000,
+            durationMs: null,
+            estimatedCostUsd: 0,
+            output: "Skipped: max_daily_runs",
+            error: null,
+          }),
+        ],
+        isLoading: false,
+      }),
+    );
+
+    expect(document.body.textContent).toContain("Skipped: max_daily_runs");
+  });
 });
 
 describe("CreateScheduleModal", () => {

--- a/clients/web/src/domains/settings/hooks/use-system-tasks.ts
+++ b/clients/web/src/domains/settings/hooks/use-system-tasks.ts
@@ -17,10 +17,11 @@ import {
   useHeartbeatRunnowPostMutation,
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import {
-  selectConsolidationRuns,
-  selectHeartbeatRuns,
-  selectRetrospectiveRuns,
-} from "@/domains/settings/utils/system-task-run-transforms";
+  consolidationRunsGet,
+  heartbeatRunsGet,
+  retrospectiveRunsGet,
+} from "@/generated/daemon/sdk.gen";
+import { fetchSystemTaskRunsForUsage } from "@/domains/settings/utils/system-task-run-transforms";
 import {
   type ScheduleRowUsage,
   SYSTEM_TASK_STATS_RUN_LIMIT,
@@ -52,8 +53,9 @@ function deriveUsage(
 
 /**
  * Composes all TanStack Query state + mutations for system tasks (heartbeat,
- * consolidation, memory retrospective). Uses generated SDK options for both
- * query keys and query functions — no custom fetch wrappers or hand-rolled keys.
+ * consolidation, memory retrospective). Generated SDK options provide cache
+ * keys; stats queries page through generated SDK calls so usage summaries cover
+ * the full window.
  */
 export function useSystemTasks(assistantId: string | undefined, tz: string) {
   const queryClient = useQueryClient();
@@ -96,6 +98,11 @@ export function useSystemTasks(assistantId: string | undefined, tz: string) {
     staleTime: STALE_TIME,
   });
 
+  const systemStatsRange = useMemo(
+    () => resolveScheduleUsageWindow(tz),
+    [tz],
+  );
+
   // ---------------------------------------------------------------------------
   // Stats queries (recent runs for usage summary in the list view)
   // ---------------------------------------------------------------------------
@@ -110,9 +117,26 @@ export function useSystemTasks(assistantId: string | undefined, tz: string) {
     isLoading: isHeartbeatStatsLoading,
     isError: isHeartbeatStatsError,
     refetch: refetchHeartbeatStats,
-  } = useQuery({
-    ...heartbeatRunsGetOptions(statsOpts),
-    select: selectHeartbeatRuns,
+  } = useQuery<ScheduleRun[]>({
+    queryKey: heartbeatRunsGetOptions(statsOpts).queryKey,
+    queryFn: ({ signal }) =>
+      fetchSystemTaskRunsForUsage({
+        kind: "heartbeat",
+        range: systemStatsRange,
+        signal,
+        fetchPage: async (before, signal) => {
+          const { data } = await heartbeatRunsGet({
+            ...statsOpts,
+            query:
+              before == null
+                ? statsOpts.query
+                : { ...statsOpts.query, before },
+            signal,
+            throwOnError: true,
+          });
+          return data;
+        },
+      }),
     enabled: Boolean(assistantId) && heartbeatConfig != null,
     staleTime: STALE_TIME,
   });
@@ -122,9 +146,26 @@ export function useSystemTasks(assistantId: string | undefined, tz: string) {
     isLoading: isConsolidationStatsLoading,
     isError: isConsolidationStatsError,
     refetch: refetchConsolidationStats,
-  } = useQuery({
-    ...consolidationRunsGetOptions(statsOpts),
-    select: selectConsolidationRuns,
+  } = useQuery<ScheduleRun[]>({
+    queryKey: consolidationRunsGetOptions(statsOpts).queryKey,
+    queryFn: ({ signal }) =>
+      fetchSystemTaskRunsForUsage({
+        kind: "consolidation",
+        range: systemStatsRange,
+        signal,
+        fetchPage: async (before, signal) => {
+          const { data } = await consolidationRunsGet({
+            ...statsOpts,
+            query:
+              before == null
+                ? statsOpts.query
+                : { ...statsOpts.query, before },
+            signal,
+            throwOnError: true,
+          });
+          return data;
+        },
+      }),
     enabled: Boolean(assistantId) && consolidationConfig?.available === true,
     staleTime: STALE_TIME,
   });
@@ -134,9 +175,26 @@ export function useSystemTasks(assistantId: string | undefined, tz: string) {
     isLoading: isRetrospectiveStatsLoading,
     isError: isRetrospectiveStatsError,
     refetch: refetchRetrospectiveStats,
-  } = useQuery({
-    ...retrospectiveRunsGetOptions(statsOpts),
-    select: selectRetrospectiveRuns,
+  } = useQuery<ScheduleRun[]>({
+    queryKey: retrospectiveRunsGetOptions(statsOpts).queryKey,
+    queryFn: ({ signal }) =>
+      fetchSystemTaskRunsForUsage({
+        kind: "retrospective",
+        range: systemStatsRange,
+        signal,
+        fetchPage: async (before, signal) => {
+          const { data } = await retrospectiveRunsGet({
+            ...statsOpts,
+            query:
+              before == null
+                ? statsOpts.query
+                : { ...statsOpts.query, before },
+            signal,
+            throwOnError: true,
+          });
+          return data;
+        },
+      }),
     enabled: Boolean(assistantId) && retrospectiveConfig?.available === true,
     staleTime: STALE_TIME,
   });
@@ -144,11 +202,6 @@ export function useSystemTasks(assistantId: string | undefined, tz: string) {
   // ---------------------------------------------------------------------------
   // Derived usage stats
   // ---------------------------------------------------------------------------
-
-  const systemStatsRange = useMemo(
-    () => resolveScheduleUsageWindow(tz),
-    [tz],
-  );
 
   const heartbeatUsage: ScheduleRowUsage = useMemo(
     () => deriveUsage(isHeartbeatStatsLoading, isHeartbeatStatsError, SYSTEM_TASK_URL_IDS.heartbeat, heartbeatRunsForStats, systemStatsRange),

--- a/clients/web/src/domains/settings/utils/schedule-formatters.test.ts
+++ b/clients/web/src/domains/settings/utils/schedule-formatters.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, test } from "bun:test";
 
-import type { ScheduleUsageSummary } from "@/domains/settings/types/schedules";
+import type {
+  ScheduleRun,
+  ScheduleUsageSummary,
+} from "@/domains/settings/types/schedules";
 
-import { systemTaskUsageCost, totalUsageCost } from "./schedule-formatters";
+import {
+  summarizeRunsForUsage,
+  systemTaskUsageCost,
+  SYSTEM_TASK_URL_IDS,
+  totalUsageCost,
+} from "./schedule-formatters";
 
 function summary(
   scheduleId: string,
@@ -14,6 +22,17 @@ function summary(
     totalEstimatedCostUsd,
     eventCount: 0,
   };
+}
+
+function run(overrides: Partial<ScheduleRun> = {}): ScheduleRun {
+  return {
+    id: "run-1",
+    status: "ok",
+    startedAt: 1_761_792_000_000,
+    createdAt: 1_761_792_000_000,
+    estimatedCostUsd: 0,
+    ...overrides,
+  } as ScheduleRun;
 }
 
 describe("totalUsageCost", () => {
@@ -63,5 +82,35 @@ describe("systemTaskUsageCost", () => {
     expect(
       systemTaskUsageCost({ status: "ready", summary: summary("a", 0) }),
     ).toBe(0);
+  });
+});
+
+describe("summarizeRunsForUsage", () => {
+  test("ignores skipped no-op attempts in run counts", () => {
+    const summary = summarizeRunsForUsage(
+      SYSTEM_TASK_URL_IDS.heartbeat,
+      [
+        run({
+          id: "heartbeat-ok",
+          status: "ok",
+          estimatedCostUsd: 0.02,
+        }),
+        run({
+          id: "heartbeat-skipped",
+          status: "skipped",
+          startedAt: 1_761_792_010_000,
+          createdAt: 1_761_792_010_000,
+          estimatedCostUsd: 0,
+        }),
+      ],
+      { from: 1_761_791_000_000, to: 1_761_793_000_000 },
+    );
+
+    expect(summary).toEqual({
+      scheduleId: SYSTEM_TASK_URL_IDS.heartbeat,
+      runCount: 1,
+      totalEstimatedCostUsd: 0.02,
+      eventCount: 0,
+    });
   });
 });

--- a/clients/web/src/domains/settings/utils/schedule-formatters.ts
+++ b/clients/web/src/domains/settings/utils/schedule-formatters.ts
@@ -325,7 +325,11 @@ export function summarizeRunsForUsage(
 ): ScheduleUsageSummary {
   const runsInRange = (runs ?? []).filter((run) => {
     const startedAt = run.startedAt ?? run.createdAt;
-    return startedAt >= range.from && startedAt <= range.to;
+    return (
+      startedAt >= range.from &&
+      startedAt <= range.to &&
+      isUsageCountingRun(run)
+    );
   });
 
   return {
@@ -339,6 +343,12 @@ export function summarizeRunsForUsage(
     }, 0),
     eventCount: 0,
   };
+}
+
+function isUsageCountingRun(run: ScheduleRun): boolean {
+  return !["pending", "skipped", "missed", "superseded"].includes(
+    run.status ?? "",
+  );
 }
 
 export function totalUsageCost(

--- a/clients/web/src/domains/settings/utils/system-task-run-transforms.test.ts
+++ b/clients/web/src/domains/settings/utils/system-task-run-transforms.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import {
+  summarizeRunsForUsage,
+  SYSTEM_TASK_URL_IDS,
+} from "./schedule-formatters";
+import { fetchSystemTaskRunsForUsage } from "./system-task-run-transforms";
+
+import type { HeartbeatRunsGetResponse } from "@/generated/daemon/types.gen";
+
+type HeartbeatRun = HeartbeatRunsGetResponse["runs"][number];
+
+function heartbeatRun(overrides: Partial<HeartbeatRun> = {}): HeartbeatRun {
+  return {
+    id: "heartbeat-run",
+    scheduledFor: 1_761_792_000_000,
+    startedAt: 1_761_792_000_000,
+    finishedAt: 1_761_792_010_000,
+    durationMs: 10_000,
+    status: "ok",
+    skipReason: null,
+    error: null,
+    conversationId: "conv-run",
+    conversationExists: true,
+    conversationArchivedAt: null,
+    estimatedCostUsd: 0.02,
+    createdAt: 1_761_792_000_000,
+    ...overrides,
+  };
+}
+
+describe("fetchSystemTaskRunsForUsage", () => {
+  test("continues past a skipped-only capped page until the usage window is covered", async () => {
+    const fetchPage = mock(async (before: number | undefined) => {
+      if (before == null) {
+        return {
+          runs: [
+            heartbeatRun({
+              id: "heartbeat-skipped",
+              status: "skipped",
+              skipReason: "max_daily_runs",
+              conversationId: null,
+              estimatedCostUsd: 0,
+            }),
+          ],
+          nextCursor: 1_761_791_990_000,
+        };
+      }
+
+      return {
+        runs: [
+          heartbeatRun({
+            id: "heartbeat-ok",
+            scheduledFor: 1_761_791_990_000,
+            startedAt: 1_761_791_990_000,
+            createdAt: 1_761_791_990_000,
+            estimatedCostUsd: 0.02,
+          }),
+        ],
+        nextCursor: null,
+      };
+    });
+
+    const runs = await fetchSystemTaskRunsForUsage({
+      kind: "heartbeat",
+      range: { from: 1_761_791_000_000, to: 1_761_793_000_000 },
+      fetchPage,
+    });
+    const summary = summarizeRunsForUsage(
+      SYSTEM_TASK_URL_IDS.heartbeat,
+      runs,
+      { from: 1_761_791_000_000, to: 1_761_793_000_000 },
+    );
+
+    expect(fetchPage.mock.calls.map(([before]) => before)).toEqual([
+      undefined,
+      1_761_791_990_000,
+    ]);
+    expect(summary.runCount).toBe(1);
+    expect(summary.totalEstimatedCostUsd).toBe(0.02);
+  });
+
+  test("stops after the page that reaches older runs", async () => {
+    const fetchPage = mock(async (before: number | undefined) => ({
+      runs: [
+        heartbeatRun({
+          id: before == null ? "heartbeat-new" : "heartbeat-old",
+          scheduledFor:
+            before == null ? 1_761_792_000_000 : 1_761_790_999_999,
+          startedAt:
+            before == null ? 1_761_792_000_000 : 1_761_790_999_999,
+          createdAt:
+            before == null ? 1_761_792_000_000 : 1_761_790_999_999,
+        }),
+      ],
+      nextCursor: before == null ? 1_761_791_990_000 : 1_761_790_000_000,
+    }));
+
+    await fetchSystemTaskRunsForUsage({
+      kind: "heartbeat",
+      range: { from: 1_761_791_000_000, to: 1_761_793_000_000 },
+      fetchPage,
+    });
+
+    expect(fetchPage.mock.calls.map(([before]) => before)).toEqual([
+      undefined,
+      1_761_791_990_000,
+    ]);
+  });
+});

--- a/clients/web/src/domains/settings/utils/system-task-run-transforms.ts
+++ b/clients/web/src/domains/settings/utils/system-task-run-transforms.ts
@@ -16,6 +16,21 @@ type RetrospectiveRun = RetrospectiveRunsGetResponse["runs"][number];
 /** Union of all raw system-task run types from the daemon SDK. */
 export type AnySystemTaskRun = HeartbeatRun | ConsolidationRun | RetrospectiveRun;
 
+interface SystemTaskRunPage<T extends AnySystemTaskRun> {
+  runs: T[];
+  nextCursor: number | null;
+}
+
+interface FetchSystemTaskRunsForUsageArgs<T extends AnySystemTaskRun> {
+  kind: SystemTaskKind;
+  range: { from: number; to: number };
+  signal?: AbortSignal;
+  fetchPage: (
+    before: number | undefined,
+    signal: AbortSignal | undefined,
+  ) => Promise<SystemTaskRunPage<T>>;
+}
+
 /**
  * Maps a raw system-task run from the daemon SDK into the shared
  * {@link ScheduleRun} shape consumed by the schedule UI.
@@ -84,4 +99,36 @@ export function selectRetrospectiveRuns(
   data: RetrospectiveRunsGetResponse,
 ): ScheduleRun[] {
   return data.runs.map((r) => toScheduleRun(r, "retrospective"));
+}
+
+export async function fetchSystemTaskRunsForUsage<T extends AnySystemTaskRun>({
+  kind,
+  range,
+  signal,
+  fetchPage,
+}: FetchSystemTaskRunsForUsageArgs<T>): Promise<ScheduleRun[]> {
+  const runs: ScheduleRun[] = [];
+  const seenCursors = new Set<number>();
+  let before: number | undefined;
+
+  while (true) {
+    const page = await fetchPage(before, signal);
+    const pageRuns = page.runs.map((run) => toScheduleRun(run, kind));
+    runs.push(...pageRuns);
+
+    const reachedOlderRuns = pageRuns.some(
+      (run) => (run.startedAt ?? run.createdAt) < range.from,
+    );
+    if (reachedOlderRuns || page.nextCursor == null || pageRuns.length === 0) {
+      break;
+    }
+
+    if (seenCursors.has(page.nextCursor)) {
+      break;
+    }
+    seenCursors.add(page.nextCursor);
+    before = page.nextCursor;
+  }
+
+  return runs;
 }


### PR DESCRIPTION
## Summary

- Exclude skipped/no-op heartbeat attempts from system task usage run counts.
- Show skipped heartbeat reasons inline in recent run rows so no-op attempts do not look like normal runs.
- Add regressions for both the usage count and collapsed row display.

## Root Cause

Heartbeat no-op attempts are persisted as `status: "skipped"` rows with a `skipReason`. The schedules UI reused those rows for both the recent-runs list and the system task usage summary, so skipped hourly attempts appeared like ordinary `$0.00` runs and inflated the 7-day run count.

## Validation

- `cd apps/web && bun test src/domains/settings/pages/schedules-page.test.ts`
- `cd apps/web && bunx tsc --noEmit`
