### PR TITLE
fix(workspace): preserve model-implied Anthropic profiles in adaptive-thinking repair

### DIFF
--- a/assistant/src/__tests__/adaptive-thinking-repair.test.ts
+++ b/assistant/src/__tests__/adaptive-thinking-repair.test.ts
@@ -131,6 +131,30 @@ describe.each(implementations)("%s", (_label, run) => {
     expect(profile("balanced").thinking).toEqual(ADAPTIVE);
   });
 
+  test("patches source-less profiles pinning a known Claude model under a non-Anthropic default", () => {
+    // A managed/source-less profile that omits `provider` but pins a known
+    // Claude model is Anthropic via the resolver's model-implied provider, even
+    // when llm.default.provider is non-Anthropic. It must still get adaptive
+    // thinking rather than being skipped.
+    writeConfig({
+      llm: {
+        default: { provider: "gemini", model: "gemini-2.5-pro" },
+        profiles: {
+          balanced: { model: "claude-sonnet-4-6" },
+          "quality-optimized": {
+            source: "managed",
+            model: "claude-opus-4-8",
+          },
+        },
+      },
+    });
+
+    run(workspaceDir);
+
+    expect(profile("balanced").thinking).toEqual(ADAPTIVE);
+    expect(profile("quality-optimized").thinking).toEqual(ADAPTIVE);
+  });
+
   test("skips profiles with an explicit non-Anthropic provider", () => {
     writeConfig({
       llm: {

--- a/assistant/src/workspace/adaptive-thinking-repair.ts
+++ b/assistant/src/workspace/adaptive-thinking-repair.ts
@@ -1,6 +1,8 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { getCatalogProviderForModel } from "../providers/model-catalog.js";
+
 // Enable adaptive thinking on the managed "balanced" and "quality-optimized"
 // profiles.
 //
@@ -28,11 +30,14 @@ import { join } from "node:path";
 //   - Are source: "user" (user-created profiles are untouched)
 //   - Have a non-managed, non-absent source (unknown origin)
 //   - Resolve to a non-Anthropic provider (adaptive thinking is
-//     Anthropic-specific). A profile with no explicit provider inherits
-//     llm.default.provider, so the check falls back to that — with a
-//     completely absent llm.default.provider treated as Anthropic, matching
-//     migration 052's own `?? "anthropic"` default. This keeps the legacy
-//     non-Anthropic empty `{}` shells seeded by migration 052 off the repair.
+//     Anthropic-specific). Effective provider is the profile's explicit
+//     `provider`; otherwise the provider implied by a known catalog `model`
+//     (mirroring the resolver's withImpliedProviderForKnownModel); otherwise
+//     llm.default.provider — with a completely absent llm.default.provider
+//     treated as Anthropic, matching migration 052's own `?? "anthropic"`
+//     default. This keeps the legacy non-Anthropic empty `{}` shells seeded by
+//     migration 052 off the repair while still patching profiles that pin a
+//     known Claude model under a non-Anthropic default.
 
 const ADAPTIVE_THINKING = { enabled: true, streamThinking: true } as const;
 const TARGET_PROFILES = ["balanced", "quality-optimized"] as const;
@@ -63,8 +68,9 @@ export function repairAdaptiveThinkingOnManagedProfiles(
   const profiles = readObject(llm.profiles);
   if (profiles === null) return;
 
-  // Profiles without an explicit provider inherit llm.default.provider at
-  // resolution time; an absent llm.default.provider resolves to Anthropic.
+  // Profiles without an explicit provider and without a model-implied provider
+  // inherit llm.default.provider at resolution time; an absent
+  // llm.default.provider resolves to Anthropic.
   const defaultBlock = readObject(llm.default);
   const defaultProvider =
     typeof defaultBlock?.provider === "string"
@@ -81,12 +87,16 @@ export function repairAdaptiveThinkingOnManagedProfiles(
     // Legacy profiles created before the `source` metadata field was introduced
     // have source=undefined. Treat these as managed when the profile name is one
     // of the canonical managed names (which TARGET_PROFILES already guarantees)
-    // and the effective provider — explicit, or inherited from llm.default — is
-    // Anthropic. Explicit `source: "user"` profiles are always skipped.
+    // and the effective provider is Anthropic. Effective provider is the
+    // explicit `provider`, else the provider implied by a known catalog
+    // `model`, else the inherited llm.default.provider. Explicit
+    // `source: "user"` profiles are always skipped.
     if (profile.source === "user") continue;
     if (profile.source !== undefined && profile.source !== "managed") continue;
-    const effectiveProvider =
-      typeof profile.provider === "string" ? profile.provider : defaultProvider;
+    const effectiveProvider = resolveEffectiveProvider(
+      profile,
+      defaultProvider,
+    );
     if (effectiveProvider !== "anthropic") continue;
 
     // Skip if thinking is already enabled.
@@ -103,6 +113,18 @@ export function repairAdaptiveThinkingOnManagedProfiles(
     config.llm = llm;
     writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
   }
+}
+
+function resolveEffectiveProvider(
+  profile: Record<string, unknown>,
+  defaultProvider: string,
+): string {
+  if (typeof profile.provider === "string") return profile.provider;
+  if (typeof profile.model === "string") {
+    const implied = getCatalogProviderForModel(profile.model);
+    if (implied !== undefined) return implied;
+  }
+  return defaultProvider;
 }
 
 function readObject(value: unknown): Record<string, unknown> | null {

--- a/assistant/src/workspace/migrations/097-enable-adaptive-thinking-managed-profiles.ts
+++ b/assistant/src/workspace/migrations/097-enable-adaptive-thinking-managed-profiles.ts
@@ -23,11 +23,14 @@ import type { WorkspaceMigration } from "./types.js";
 //   - Are source: "user" (user-created profiles are untouched)
 //   - Have a non-managed, non-absent source (unknown origin)
 //   - Resolve to a non-Anthropic provider (adaptive thinking is
-//     Anthropic-specific). A profile with no explicit provider inherits
-//     llm.default.provider, so the check falls back to that — with a
-//     completely absent llm.default.provider treated as Anthropic, matching
-//     migration 052's own `?? "anthropic"` default. This keeps the legacy
-//     non-Anthropic empty `{}` shells seeded by migration 052 off the repair.
+//     Anthropic-specific). Effective provider is the profile's explicit
+//     `provider`; otherwise the provider implied by a known Claude `model`
+//     (mirroring the resolver's withImpliedProviderForKnownModel); otherwise
+//     llm.default.provider — with a completely absent llm.default.provider
+//     treated as Anthropic, matching migration 052's own `?? "anthropic"`
+//     default. This keeps the legacy non-Anthropic empty `{}` shells seeded by
+//     migration 052 off the repair while still patching profiles that pin a
+//     known Claude model under a non-Anthropic default.
 //
 // Note: the live startup path re-runs the same repair after the platform
 // overlay merge — see assistant/src/workspace/adaptive-thinking-repair.ts.
@@ -61,8 +64,9 @@ export const enableAdaptiveThinkingManagedProfilesMigration: WorkspaceMigration 
       const profiles = readObject(llm.profiles);
       if (profiles === null) return;
 
-      // Profiles without an explicit provider inherit llm.default.provider at
-      // resolution time; an absent llm.default.provider resolves to Anthropic.
+      // Profiles without an explicit provider and without a model-implied
+      // provider inherit llm.default.provider at resolution time; an absent
+      // llm.default.provider resolves to Anthropic.
       const defaultBlock = readObject(llm.default);
       const defaultProvider =
         typeof defaultBlock?.provider === "string"
@@ -79,17 +83,19 @@ export const enableAdaptiveThinkingManagedProfilesMigration: WorkspaceMigration 
         // Legacy profiles created before the `source` metadata field was
         // introduced have source=undefined. Treat these as managed when the
         // profile name is one of the canonical managed names (which
-        // TARGET_PROFILES already guarantees) and the effective provider —
-        // explicit, or inherited from llm.default — is Anthropic. Explicit
-        // `source: "user"` profiles are always skipped.
+        // TARGET_PROFILES already guarantees) and the effective provider is
+        // Anthropic. Effective provider is the explicit `provider`, else the
+        // provider implied by a known Claude `model`, else the inherited
+        // llm.default.provider. Explicit `source: "user"` profiles are always
+        // skipped.
         if (profile.source === "user") continue;
         if (profile.source !== undefined && profile.source !== "managed") {
           continue;
         }
-        const effectiveProvider =
-          typeof profile.provider === "string"
-            ? profile.provider
-            : defaultProvider;
+        const effectiveProvider = resolveEffectiveProvider(
+          profile,
+          defaultProvider,
+        );
         if (effectiveProvider !== "anthropic") continue;
 
         // Skip if thinking is already enabled.
@@ -111,6 +117,27 @@ export const enableAdaptiveThinkingManagedProfilesMigration: WorkspaceMigration 
       // Forward-only.
     },
   };
+
+// Inline, conservative mirror of the resolver's catalog-based provider
+// implication. Migration modules are frozen, self-contained snapshots and must
+// not import the live model catalog. Anthropic's catalog model ids are bare
+// `claude-*` ids (the slash-prefixed `anthropic/claude-*` ids belong to
+// OpenRouter), so a profile pinning a `claude-*` model with no slash counts as
+// Anthropic.
+function resolveEffectiveProvider(
+  profile: Record<string, unknown>,
+  defaultProvider: string,
+): string {
+  if (typeof profile.provider === "string") return profile.provider;
+  if (
+    typeof profile.model === "string" &&
+    profile.model.startsWith("claude-") &&
+    !profile.model.includes("/")
+  ) {
+    return "anthropic";
+  }
+  return defaultProvider;
+}
 
 function readObject(value: unknown): Record<string, unknown> | null {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {


### PR DESCRIPTION
Addresses Codex P2 review feedback on the merged #34578 ('Preserve model-implied Anthropic profiles').

## Problem
The effective-provider check added in #34578 computed `effectiveProvider = profile.provider ?? llm.default.provider`. A managed/source-less profile that omits `provider` but pins a known Claude `model` is treated as Anthropic by the resolver's `withImpliedProviderForKnownModel()`, yet the repair classified it by the non-Anthropic default and skipped it — leaving valid Anthropic `balanced`/`quality-optimized` profiles without adaptive thinking.

## Fix
Effective-provider resolution follows: explicit `profile.provider` → provider implied by a known catalog `model` → `llm.default.provider` (absent → anthropic), in both the live repair and the frozen migration 097 copy.

- `adaptive-thinking-repair.ts` (live path) imports `getCatalogProviderForModel` from the model catalog (import-safe pure data module).
- Migration 097 stays self-contained per `migrations/AGENTS.md` — it inlines a conservative implication: a `claude-*` model id without a slash counts as Anthropic (bare `claude-*` ids are owned only by the Anthropic catalog entry; `anthropic/claude-*` slash ids belong to OpenRouter).

## Tests
Extended `adaptive-thinking-repair.test.ts` (runs every scenario against both the startup repair and migration 097): a source-less profile pinning a known Claude model under a non-Anthropic default now gets adaptive thinking. All 16 tests pass.

Part of #34578

🤖 Generated with [Claude Code](https://claude.com/claude-code)