### PR TITLE
fix(skills): add activation-hints to Notion skill so the model loads it

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -60,7 +60,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T20:42:53.000Z"
+      "updatedAt": "2026-06-15T21:08:24.000Z"
     },
     {
       "id": "chatgpt-import",
@@ -161,7 +161,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T19:02:12.000Z"
+      "updatedAt": "2026-06-15T21:08:24.000Z"
     },
     {
       "id": "email-setup",
@@ -189,7 +189,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T19:02:12.000Z"
+      "updatedAt": "2026-06-15T21:08:24.000Z"
     },
     {
       "id": "frontend-design",
@@ -411,7 +411,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T19:02:12.000Z"
+      "updatedAt": "2026-06-15T21:08:24.000Z"
     },
     {
       "id": "llm-cost-optimizer",
@@ -424,7 +424,7 @@
           "display-name": "LLM Cost Optimizer"
         }
       },
-      "updatedAt": "2026-06-15T19:02:12.000Z"
+      "updatedAt": "2026-06-15T21:08:24.000Z"
     },
     {
       "id": "macos-automation",
@@ -541,11 +541,20 @@
         "emoji": "📝",
         "vellum": {
           "category": "productivity",
-          "display-name": "Notion"
+          "display-name": "Notion",
+          "activation-hints": [
+            "User asks to read, find, search, or open a page, doc, database, or directory in their Notion (e.g. 'find it in notion', 'look in my Notion', 'this is a notion directory')",
+            "User references Notion content by name or path and wants its contents pulled",
+            "User wants to create, update, append to, or query Notion pages or databases",
+            "User asks anything that requires reading or writing Notion data, including checking a task list or workspace held in Notion"
+          ],
+          "avoid-when": [
+            "User wants to set up, connect, or reconnect the Notion OAuth integration for the first time; load vellum-oauth-integrations instead"
+          ]
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T19:02:12.000Z"
+      "updatedAt": "2026-06-15T22:24:10.000Z"
     },
     {
       "id": "oura",
@@ -562,7 +571,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T19:02:12.000Z"
+      "updatedAt": "2026-06-15T21:08:24.000Z"
     },
     {
       "id": "oura-setup",
@@ -576,7 +585,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T19:02:12.000Z"
+      "updatedAt": "2026-06-15T21:08:24.000Z"
     },
     {
       "id": "outlook",
@@ -629,7 +638,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T19:02:12.000Z"
+      "updatedAt": "2026-06-15T21:08:24.000Z"
     },
     {
       "id": "resend-setup",
@@ -746,7 +755,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T20:42:53.000Z"
+      "updatedAt": "2026-06-15T21:08:24.000Z"
     },
     {
       "id": "start-the-day",
@@ -836,7 +845,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T19:02:12.000Z"
+      "updatedAt": "2026-06-15T21:08:24.000Z"
     },
     {
       "id": "time-based-actions",
@@ -868,7 +877,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T19:02:12.000Z"
+      "updatedAt": "2026-06-15T21:08:24.000Z"
     },
     {
       "id": "typescript-eval",
@@ -1001,7 +1010,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T19:02:12.000Z"
+      "updatedAt": "2026-06-15T21:08:24.000Z"
     },
     {
       "id": "vellum-self-knowledge",
@@ -1108,7 +1117,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T19:02:12.000Z"
+      "updatedAt": "2026-06-15T21:08:24.000Z"
     },
     {
       "id": "voice-setup",
@@ -1133,7 +1142,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T19:02:12.000Z"
+      "updatedAt": "2026-06-15T21:08:24.000Z"
     },
     {
       "id": "watch-together",

--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -8,6 +8,13 @@ metadata:
   vellum:
     category: "productivity"
     display-name: "Notion"
+    activation-hints:
+      - "User asks to read, find, search, or open a page, doc, database, or directory in their Notion (e.g. 'find it in notion', 'look in my Notion', 'this is a notion directory')"
+      - "User references Notion content by name or path and wants its contents pulled"
+      - "User wants to create, update, append to, or query Notion pages or databases"
+      - "User asks anything that requires reading or writing Notion data, including checking a task list or workspace held in Notion"
+    avoid-when:
+      - "User wants to set up, connect, or reconnect the Notion OAuth integration for the first time; load vellum-oauth-integrations instead"
 ---
 
 You have access to the Notion API via the managed OAuth connection or an internal integration secret stored in the credential vault. Both paths inject the Authorization header automatically. Never reveal credential values or echo token values into the shell.


### PR DESCRIPTION
## What

Adds `activation-hints` and an `avoid-when` to the Notion skill's frontmatter (and regenerates its `catalog.json` entry).

## Why

A dogfood session surfaced this: on a managed assistant, a user asked the assistant to read a page in their Notion, and instead of loading the `notion` skill it reverse-engineered raw `assistant oauth request --provider notion` REST calls over ~10 fumbling bash steps (wrong CLI syntax, missing flags, manual pagination) — eventually landing on exactly the `oauth request` recipe the skill already documents.

Root cause: the Notion skill had **no `activation-hints`**, so it surfaced to the model only as a bare one-line description and never won a capability-injection slot when the user referenced Notion. Most comparable skills (inbox-management, geo-audit, assistant-migration, …) carry rich activation hints; Notion was an outlier.

## How

`activation-hints` / `avoid-when` feed `buildSkillContent()` in the memory-graph capability seeder (`assistant/src/memory/graph/capability-seed.ts`), which emits a `Use when: …` nudge and strengthens semantic retrieval of the capability node. The hints cover the actual phrasings from the failed session (read / find / search / open a Notion page or directory) plus create/update/query; `avoid-when` routes first-time setup to `vellum-oauth-integrations`.

This uses the existing skill-discovery mechanism rather than a hardcoded "if notion, load skill" heuristic (which would violate *Assistant-Driven Judgement*) or a system-prompt addition (*System Prompt Minimalism*).

## Notes for review

- The inline examples use **single quotes** intentionally: the custom frontmatter parser (`scripts/skills/parse-skill-yaml.mjs`) only unescapes `\uXXXX`, not `\"`, so double-quoted inner quotes would leak literal backslashes into the model-facing text. Verified the parsed output is clean.
- `catalog.json` is a full `generate-catalog.mjs` regeneration (required by the `Check catalog.json is up to date` CI gate). Besides the Notion entry, it also refreshes ~20 unrelated `updatedAt` timestamps that were already stale on `main` (left behind by #34901, which touched many skill dirs without regenerating) — the generator stamps them from each skill's last commit date. No content changes other than Notion.

## Validation

- `node scripts/skills/lint-skill-spec.mjs` → all 67 skills conform
- `catalog.json` re-validated as valid JSON; parsed hints confirmed backslash-free

🤖 Generated with [Claude Code](https://claude.com/claude-code)
