### PR TITLE
fix(ui-surface): reject empty dynamic_page ui_show instead of rendering a blank box

### DIFF
--- a/assistant/src/__tests__/dynamic-page-surface.test.ts
+++ b/assistant/src/__tests__/dynamic-page-surface.test.ts
@@ -125,6 +125,56 @@ describe("ui_show dynamic_page app substitute guard", () => {
     expect(proxied).toBe(false);
   });
 
+  test("rejects dynamic_page with empty data and does not proxy", async () => {
+    let proxied = false;
+
+    const result = await uiShowTool.execute(
+      {
+        surface_type: "dynamic_page",
+        title: "SKILL.md — elevenlabs-tts",
+        activity: "Reopening SKILL.md with rendered content",
+        data: {},
+      },
+      {
+        conversationId: "conversation-123",
+        workingDir: "/tmp",
+        trustClass: "guardian",
+        proxyToolResolver: async () => {
+          proxied = true;
+          return { content: "proxied", isError: false };
+        },
+      },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("data.html");
+    expect(proxied).toBe(false);
+  });
+
+  test("rejects dynamic_page with whitespace-only html and does not proxy", async () => {
+    let proxied = false;
+
+    const result = await uiShowTool.execute(
+      {
+        surface_type: "dynamic_page",
+        title: "Blank",
+        data: { html: "   \n  " },
+      },
+      {
+        conversationId: "conversation-123",
+        workingDir: "/tmp",
+        trustClass: "guardian",
+        proxyToolResolver: async () => {
+          proxied = true;
+          return { content: "proxied", isError: false };
+        },
+      },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(proxied).toBe(false);
+  });
+
   test("allows transient non-app dynamic_page surfaces", async () => {
     let proxied = false;
 

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -35,6 +35,14 @@ function proxyExecute(toolName: string) {
     input: Record<string, unknown>,
     context: ToolContext,
   ): Promise<ToolExecutionResult> => {
+    if (toolName === "ui_show" && isEmptyDynamicPage(input)) {
+      return {
+        content:
+          "Error: ui_show dynamic_page requires non-empty HTML in `data.html`. The surface was not displayed because no content was provided — the user would see a blank box. Resend ui_show with the full HTML markup in `data.html`.",
+        isError: true,
+      };
+    }
+
     if (toolName === "ui_show" && isDynamicPageAppSubstitute(input)) {
       return {
         content:
@@ -51,6 +59,15 @@ function proxyExecute(toolName: string) {
     }
     return context.proxyToolResolver(toolName, input);
   };
+}
+
+function isEmptyDynamicPage(input: Record<string, unknown>): boolean {
+  if (input.surface_type !== "dynamic_page") {
+    return false;
+  }
+  const data = asRecord(input.data);
+  const html = data?.html;
+  return typeof html !== "string" || html.trim().length === 0;
 }
 
 function isDynamicPageAppSubstitute(input: Record<string, unknown>): boolean {


### PR DESCRIPTION
## Problem

The preview box in chat renders blank when the assistant tries to open/show a file (reported across MiniMax *and* Claude-quality models).

From a user's feedback diagnostics, the model called:

```json
ui_show { "surface_type": "dynamic_page", "title": "SKILL.md — elevenlabs-tts", "data": {} }
```

with **empty `data`** (no `html`). The tool proxied it straight to the client, which rendered an empty `<iframe srcDoc="">` — the blank box. The tool then returned success:

> `"status":"awaiting_user_action","message":"Surface displayed and the user can see it."`

That false-success is the root cause: the model is told it succeeded, never learns it rendered nothing, and loops (logs show "attempt 3" with `data: {}` again, alongside its own reasoning *"yeah i sent an empty payload"*). Because the `dynamic_page` contract never validated renderable content, the failure is model-agnostic.

## Fix

Add an `isEmptyDynamicPage` guard in `proxyExecute`, mirroring the existing app-substitute guard. A `dynamic_page` `ui_show` with missing, empty, or whitespace-only `data.html` is rejected **before** proxying, with an actionable error so the model resends the full HTML instead of spamming blank surfaces. The empty surface never reaches the client.

Scoped strictly to `dynamic_page` so `task_preferences: {}` and other legitimately-empty surfaces are unaffected.

## Tests

Added two regression tests (empty `data: {}`; whitespace-only `html`) asserting `isError` and that proxying is skipped. Full file: `bun test src/__tests__/dynamic-page-surface.test.ts` → 11 pass.

## Review focus

Risk: **low**. Behavior change is a new pre-proxy rejection; verify the empty-HTML check doesn't catch any valid `dynamic_page` flow that legitimately populates HTML through a path other than `data.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)