### PR TITLE
fix(workspace): re-run adaptive-thinking repair for checkpointed workspaces

### DIFF
--- a/assistant/src/__tests__/adaptive-thinking-repair.test.ts
+++ b/assistant/src/__tests__/adaptive-thinking-repair.test.ts
@@ -11,6 +11,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { repairAdaptiveThinkingOnManagedProfiles } from "../workspace/adaptive-thinking-repair.js";
 import { enableAdaptiveThinkingManagedProfilesMigration } from "../workspace/migrations/097-enable-adaptive-thinking-managed-profiles.js";
+import { recheckAdaptiveThinkingModelImpliedAnthropicMigration } from "../workspace/migrations/104-recheck-adaptive-thinking-model-implied-anthropic.js";
 
 const ADAPTIVE = { enabled: true, streamThinking: true };
 
@@ -48,14 +49,18 @@ function profile(name: string): Record<string, unknown> {
   return profiles[name] as Record<string, unknown>;
 }
 
-// The startup repair and migration 097 keep frozen copies of the same logic
-// (migration modules must stay self-contained). Run every scenario against
-// both so the copies can't drift.
+// The startup repair, migration 097, and migration 104 keep frozen copies of
+// the same logic (migration modules must stay self-contained). Run every
+// scenario against all of them so the copies can't drift.
 const implementations: Array<[string, (dir: string) => void]> = [
   ["startup repair", repairAdaptiveThinkingOnManagedProfiles],
   [
     "migration 097",
     (dir) => enableAdaptiveThinkingManagedProfilesMigration.run(dir),
+  ],
+  [
+    "migration 104",
+    (dir) => recheckAdaptiveThinkingModelImpliedAnthropicMigration.run(dir),
   ],
 ];
 

--- a/assistant/src/workspace/migrations/104-recheck-adaptive-thinking-model-implied-anthropic.ts
+++ b/assistant/src/workspace/migrations/104-recheck-adaptive-thinking-model-implied-anthropic.ts
@@ -1,0 +1,133 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+// Re-run the adaptive-thinking repair on managed "balanced" and
+// "quality-optimized" profiles, this time honoring the provider implied by a
+// known Claude `model`.
+//
+// Migration 097 patches managed Anthropic profiles to enable adaptive thinking.
+// Its original release classified a source-less profile by
+// `profile.provider ?? llm.default.provider`, so a profile that omits
+// `provider` but pins a known Claude `model` under a non-Anthropic default was
+// treated as non-Anthropic and skipped — even though the resolver implies
+// Anthropic from the model id. 097's frozen copy was later corrected to imply
+// the provider from the model, but workspaces that already ran 097 have it
+// checkpointed as completed, so the corrected logic never re-runs for them.
+// The live startup repair (adaptive-thinking-repair.ts) only runs behind the
+// hatch overlay, which is archived after hatch, so already-hatched platform
+// instances are not covered either.
+//
+// This migration re-applies the corrected repair once for those checkpointed
+// workspaces. It is idempotent: profiles that already have thinking enabled are
+// left untouched, so workspaces that were already patched (or that never had
+// the gap) are no-ops.
+//
+// The migration keeps its own frozen copy of the logic because migration
+// modules are self-contained snapshots and must never be imported by other
+// code.
+
+const ADAPTIVE_THINKING = { enabled: true, streamThinking: true } as const;
+const TARGET_PROFILES = ["balanced", "quality-optimized"] as const;
+
+export const recheckAdaptiveThinkingModelImpliedAnthropicMigration: WorkspaceMigration =
+  {
+    id: "104-recheck-adaptive-thinking-model-implied-anthropic",
+    description:
+      "Re-enable adaptive thinking on managed profiles that imply Anthropic via a known Claude model",
+    run(workspaceDir: string): void {
+      const configPath = join(workspaceDir, "config.json");
+      if (!existsSync(configPath)) return;
+
+      let config: Record<string, unknown>;
+      try {
+        const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+        if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+        config = raw as Record<string, unknown>;
+      } catch {
+        return;
+      }
+
+      const llm = readObject(config.llm);
+      if (llm === null) return;
+
+      const profiles = readObject(llm.profiles);
+      if (profiles === null) return;
+
+      // Profiles without an explicit provider and without a model-implied
+      // provider inherit llm.default.provider at resolution time; an absent
+      // llm.default.provider resolves to Anthropic.
+      const defaultBlock = readObject(llm.default);
+      const defaultProvider =
+        typeof defaultBlock?.provider === "string"
+          ? defaultBlock.provider
+          : "anthropic";
+
+      let changed = false;
+
+      for (const name of TARGET_PROFILES) {
+        const profile = readObject(profiles[name]);
+        if (profile === null) continue;
+
+        // Only patch managed Anthropic profiles. Explicit `source: "user"`
+        // profiles and non-managed, non-absent sources are skipped. Effective
+        // provider is the explicit `provider`, else the provider implied by a
+        // known Claude `model`, else the inherited llm.default.provider.
+        if (profile.source === "user") continue;
+        if (profile.source !== undefined && profile.source !== "managed") {
+          continue;
+        }
+        const effectiveProvider = resolveEffectiveProvider(
+          profile,
+          defaultProvider,
+        );
+        if (effectiveProvider !== "anthropic") continue;
+
+        // Skip if thinking is already enabled.
+        const thinking = readObject(profile.thinking);
+        if (thinking !== null && thinking.enabled === true) continue;
+
+        profile.thinking = { ...ADAPTIVE_THINKING };
+        profiles[name] = profile;
+        changed = true;
+      }
+
+      if (changed) {
+        llm.profiles = profiles;
+        config.llm = llm;
+        writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+      }
+    },
+    down(_workspaceDir: string): void {
+      // Forward-only.
+    },
+  };
+
+// Inline, conservative mirror of the resolver's catalog-based provider
+// implication. Migration modules are frozen, self-contained snapshots and must
+// not import the live model catalog. Anthropic's catalog model ids are bare
+// `claude-*` ids (the slash-prefixed `anthropic/claude-*` ids belong to
+// OpenRouter), so a profile pinning a `claude-*` model with no slash counts as
+// Anthropic.
+function resolveEffectiveProvider(
+  profile: Record<string, unknown>,
+  defaultProvider: string,
+): string {
+  if (typeof profile.provider === "string") return profile.provider;
+  if (
+    typeof profile.model === "string" &&
+    profile.model.startsWith("claude-") &&
+    !profile.model.includes("/")
+  ) {
+    return "anthropic";
+  }
+  return defaultProvider;
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -101,6 +101,7 @@ import { upgradeQualityProfileToFable5Migration } from "./100-upgrade-quality-pr
 import { upgradeBalancedEconomyToMinimaxM3Migration } from "./101-upgrade-balanced-economy-to-minimax-m3.js";
 import { preserveHeartbeatEnabledForExistingWorkspacesMigration } from "./102-preserve-heartbeat-enabled-for-existing-workspaces.js";
 import { upgradeQualityProfileToOpus48Migration } from "./103-upgrade-quality-profile-to-opus-4-8.js";
+import { recheckAdaptiveThinkingModelImpliedAnthropicMigration } from "./104-recheck-adaptive-thinking-model-implied-anthropic.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -213,4 +214,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   upgradeBalancedEconomyToMinimaxM3Migration,
   preserveHeartbeatEnabledForExistingWorkspacesMigration,
   upgradeQualityProfileToOpus48Migration,
+  recheckAdaptiveThinkingModelImpliedAnthropicMigration,
 ];


### PR DESCRIPTION
Addresses the Codex P2 review feedback on the merged #34933 ("Preserve model-implied Anthropic profiles in adaptive-thinking repair").

## Problem
Migration 097 enables adaptive thinking on the managed `balanced` / `quality-optimized` profiles. Its **original** release classified a source-less profile by `profile.provider ?? llm.default.provider`, so a profile that omits `provider` but pins a known Claude `model` under a non-Anthropic default was treated as non-Anthropic and skipped.

#34578 corrected 097's frozen copy (and the live repair) to imply the provider from the model id. But:

- Workspaces that **already ran** 097 have it checkpointed as `completed`, so the corrected frozen logic never re-runs for them — migrations are append-only and never re-execute.
- The live repair (`adaptive-thinking-repair.ts`) only runs behind the hatch overlay (`defaultConfigMerge.hadOverlay`), which is archived after hatch — so already-hatched platform instances aren't covered either.

Net: a workspace hatched before #34578 with a source-less `balanced`/`quality-optimized` profile pinning a Claude model under a non-Anthropic default stays permanently without adaptive thinking.

## Fix
Add **migration 104** carrying the corrected effective-provider logic under a new id, so it runs once on already-checkpointed workspaces. It is idempotent — profiles that already have thinking enabled are no-ops, so workspaces that never had the gap (or were already patched) are unaffected. Per `migrations/AGENTS.md` the migration is fully self-contained and inlines the same conservative model→Anthropic implication 097 uses.

## Tests
The shared `adaptive-thinking-repair.test.ts` runs every scenario against all frozen copies of the logic; migration 104 is added to that matrix alongside the startup repair and migration 097. All 24 cases pass; `tsc --noEmit` and the migrations-runner suite are green.

Part of #34578

🤖 Generated with [Claude Code](https://claude.com/claude-code)