### PR TITLE
fix(prompts): give the task_progress directive its own best-effort section

### DIFF
--- a/assistant/src/prompts/__tests__/task-progress-hint-section.test.ts
+++ b/assistant/src/prompts/__tests__/task-progress-hint-section.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for the task_progress hint in the 01-parallel-tool-calls workspace
+ * Tests for the task_progress hint in the 01-progress-surface workspace
  * system prompt section.
  *
  * Verifies that the task_progress guidance renders unconditionally in the
@@ -54,11 +54,10 @@ mock.module("../../config/loader.js", () => ({
   setNestedValue: () => {},
 }));
 
-const { buildSystemPrompt, ensurePromptFiles } = await import(
-  "../system-prompt.js"
-);
+const { buildSystemPrompt, ensurePromptFiles } =
+  await import("../system-prompt.js");
 
-describe("task_progress hint in parallel-tool-calls section", () => {
+describe("task_progress hint in progress-surface section", () => {
   beforeEach(() => {
     ensurePromptFiles();
   });
@@ -66,7 +65,7 @@ describe("task_progress hint in parallel-tool-calls section", () => {
   test("buildSystemPrompt() includes task_progress guidance", () => {
     const result = buildSystemPrompt();
     expect(result).toContain("task_progress");
-    expect(result).toContain("No exceptions");
+    expect(result).toContain("Show Progress on Long Turns");
   });
 
   test("renders unconditionally — no options required", () => {
@@ -85,5 +84,4 @@ describe("task_progress hint in parallel-tool-calls section", () => {
     expect(withoutClientFlag).toContain("task_progress");
     expect(withExcludePrefix).toContain("task_progress");
   });
-
 });

--- a/assistant/src/prompts/templates/system-sections.ts
+++ b/assistant/src/prompts/templates/system-sections.ts
@@ -269,9 +269,14 @@ Batch independent tool calls into the same response. An extra LLM round trip cos
 Before emitting a single tool call, ask whether your next turn would be another tool call that doesn't consume this one's output — if so, they belong together. Serialized tool calls without a real data dependency are a bug.
 
 For non-trivial independent workstreams — research, coding, multi-step investigations — delegate to subagents (load the \`subagent\` skill) and spawn them early and in parallel; an unnecessary subagent is cheaper than serialized work.
-
-**Before your first tool call**, check: does this turn involve a web search, file operations, multi-step work, or anything that will take more than a few seconds? If yes, call ui_show with surface_type "card" and template "task_progress" first, then update steps via ui_update as work progresses. No exceptions.
 </use_parallel_tool_calls>
+`,
+  },
+  {
+    id: "01-progress-surface",
+    body: `## Show Progress on Long Turns
+
+When a turn will take more than a few seconds — web searches, multi-step file work, research — show the user a progress card early: call ui_show with surface_type "card" and template "task_progress", then flip each step pending → in_progress → completed via ui_update as you go. Coarse steps are fine; a rough "Working on X" beats no signal at all. You can add or revise steps as the work takes shape — you are not committed to your first list. Skip the card when the turn is quick or you are already wrapping up; never let it get in the way of doing the actual work.
 `,
   },
   {


### PR DESCRIPTION
## What

Moves the `task_progress` progress-card directive out of the `<use_parallel_tool_calls>` section into its own dedicated `01-progress-surface` section ("Show Progress on Long Turns"), and **reframes it from mandatory to best-effort**.

## Why

While triaging a feedback report where MiniMax M3 (the `balanced-economy` profile) built an ElevenLabs CLI + skill across 30+ tool calls without ever showing a progress card, I traced the behavior to the prompt:

1. **Placement.** The directive was the 4th paragraph inside a block whose XML tag is `<use_parallel_tool_calls>` — the tag frames the whole block as guidance about *batching parallel calls*, so the progress rule read as a sub-point of parallelization rather than a standalone behavior.
2. **Rigidity.** The old wording ("list the concrete steps … a multi-step turn that produces no progress card is a defect … No exceptions") pressures weaker models into enumerating a full plan upfront. For exploratory work that plan is fiction, and a weak model may then follow its stated plan rigidly. The same session showed MiniMax can't reliably fill even one `ui_show` field (it produced blank `dynamic_page` boxes), so piling on a rigid, mandatory card requirement risks degrading the actual task.

## What changed

- New `##`-titled `01-progress-surface` section at the same altitude as Communication and Container rules.
- Best-effort framing: **coarse or indeterminate steps are fine**, steps **may be revised** as the work takes shape, and the card is **skippable** when the turn is quick or wrapping up — "never let it get in the way of doing the actual work."

## Scope / confidence

This is correct prompt hygiene and helps the capable models stay consistent by fixing the placement and removing the rigid framing. It is **not expected to be the full fix for MiniMax** — a model that ignored an emphatic static directive ~30× needs a stronger, action-adjacent signal. Follow-up PRs add (B) a worked example in the `ui_show` tool description + wider normalization tolerance, and (A) a soft mid-turn nudge backstop gated on task quality. This PR is the first of that series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)