### PR TITLE
Support spawn-time inference profiles for subagents

### DIFF
--- a/assistant/src/__tests__/agent-loop-override-profile.test.ts
+++ b/assistant/src/__tests__/agent-loop-override-profile.test.ts
@@ -195,6 +195,7 @@ interface CapturedRunAgentLoopOptions {
   titleText?: string;
   callSite?: string;
   overrideProfile?: string;
+  forceOverrideProfile?: boolean;
 }
 
 const capturedRunAgentLoopOptions: CapturedRunAgentLoopOptions[] = [];
@@ -323,6 +324,29 @@ describe("SubagentManager.spawn — overrideProfile inheritance", () => {
     const captured = capturedRunAgentLoopOptions[0];
     expect(captured.callSite).toBe("subagentSpawn");
     expect(captured.overrideProfile).toBe("fast");
+    expect("forceOverrideProfile" in captured).toBe(false);
+  });
+
+  test("forwards forced overrideProfile from SubagentConfig into runAgentLoop", async () => {
+    capturedRunAgentLoopOptions.length = 0;
+
+    const manager = new SubagentManager();
+    await manager.spawn(
+      {
+        parentConversationId: "parent-forced",
+        label: "child",
+        objective: "do the thing",
+        overrideProfile: "fast",
+        forceOverrideProfile: true,
+      },
+      () => {},
+    );
+
+    expect(capturedRunAgentLoopOptions).toHaveLength(1);
+    const captured = capturedRunAgentLoopOptions[0];
+    expect(captured.callSite).toBe("subagentSpawn");
+    expect(captured.overrideProfile).toBe("fast");
+    expect(captured.forceOverrideProfile).toBe(true);
   });
 
   test("omits overrideProfile when SubagentConfig does not set it", async () => {
@@ -344,6 +368,7 @@ describe("SubagentManager.spawn — overrideProfile inheritance", () => {
     // Field must be absent rather than carrying `undefined`, mirroring the
     // agent loop's "field omitted when unset" contract.
     expect("overrideProfile" in captured).toBe(false);
+    expect("forceOverrideProfile" in captured).toBe(false);
   });
 });
 

--- a/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
@@ -366,6 +366,7 @@ import { runAgentLoopImpl } from "../daemon/conversation-agent-loop.js";
 interface CapturedAgentLoopRun {
   callSite: LLMCallSite | undefined;
   overrideProfile: string | undefined;
+  forceOverrideProfile: boolean | undefined;
   resolvedOverrideProfile: string | undefined;
   resolvedMaxInputTokens: number | undefined;
 }
@@ -383,6 +384,7 @@ function makeCtx(
     captured.push({
       callSite: options.callSite,
       overrideProfile: options.overrideProfile,
+      forceOverrideProfile: options.forceOverrideProfile,
       resolvedOverrideProfile: options.resolveOverrideProfile?.(),
       resolvedMaxInputTokens: options.resolveContextWindow?.().maxInputTokens,
     });
@@ -620,6 +622,26 @@ describe("runAgentLoopImpl — per-conversation inferenceProfile", () => {
     expect(captured.length).toBeGreaterThan(0);
     for (const call of captured) {
       expect(call.overrideProfile).toBe("fast");
+      expect(call.forceOverrideProfile).toBeUndefined();
+    }
+  });
+
+  test("explicit options.forceOverrideProfile is passed to AgentLoop.run", async () => {
+    const captured: CapturedAgentLoopRun[] = [];
+    const ctx = makeCtx(captured, {
+      conversationType: "background",
+      inferenceProfile: null,
+    });
+
+    await runAgentLoopImpl(ctx, "hello", "msg-1", () => {}, {
+      overrideProfile: "fast",
+      forceOverrideProfile: true,
+    });
+
+    expect(captured.length).toBeGreaterThan(0);
+    for (const call of captured) {
+      expect(call.overrideProfile).toBe("fast");
+      expect(call.forceOverrideProfile).toBe(true);
     }
   });
 

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -506,36 +506,6 @@ describe("Subagent spawn success and failure", () => {
     }
   });
 
-  test("spawn returns error for inherited-property inference_profile", async () => {
-    const manager = getSubagentManager();
-    const originalSpawn = manager.spawn.bind(manager);
-    let spawnCalled = false;
-
-    manager.spawn = async () => {
-      spawnCalled = true;
-      return "profile-subagent-id";
-    };
-
-    try {
-      const result = await executeSubagentSpawn(
-        {
-          label: "Inherited profile",
-          objective: "Do it",
-          inference_profile: "toString",
-        },
-        makeContext("sess-spawn-inherited-profile", { sendToClient: () => {} }),
-      );
-
-      expect(result.isError).toBe(true);
-      expect(result.content).toContain(
-        'Inference profile "toString" is not defined',
-      );
-      expect(spawnCalled).toBe(false);
-    } finally {
-      manager.spawn = originalSpawn;
-    }
-  });
-
   test("spawn returns error for disabled inference_profile", async () => {
     const manager = getSubagentManager();
     const originalSpawn = manager.spawn.bind(manager);

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -8,6 +8,7 @@ let mockGetMessages: (
 ) => Array<{ role: string; content: string }> | null = () => null;
 const mockProfiles = {
   balanced: {},
+  disabled: { status: "disabled" },
   "quality-optimized": {},
 };
 mock.module("../config/loader.js", () => ({
@@ -469,6 +470,7 @@ describe("Subagent spawn success and failure", () => {
       expect(result.isError).toBe(false);
       expect(capturedConfig).toBeDefined();
       expect(capturedConfig!.overrideProfile).toBe("quality-optimized");
+      expect(capturedConfig!.forceOverrideProfile).toBe(true);
     } finally {
       manager.spawn = originalSpawn;
     }
@@ -497,6 +499,38 @@ describe("Subagent spawn success and failure", () => {
       expect(result.isError).toBe(true);
       expect(result.content).toContain(
         'Inference profile "does-not-exist" is not defined',
+      );
+      expect(spawnCalled).toBe(false);
+    } finally {
+      manager.spawn = originalSpawn;
+    }
+  });
+
+  test("spawn returns error for disabled inference_profile", async () => {
+    const manager = getSubagentManager();
+    const originalSpawn = manager.spawn.bind(manager);
+    let spawnCalled = false;
+
+    manager.spawn = async () => {
+      spawnCalled = true;
+      return "profile-subagent-id";
+    };
+
+    try {
+      const result = await executeSubagentSpawn(
+        {
+          label: "Disabled profile",
+          objective: "Do it",
+          inference_profile: "disabled",
+        },
+        makeContext("sess-spawn-disabled-profile", {
+          sendToClient: () => {},
+        }),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain(
+        'Inference profile "disabled" is disabled',
       );
       expect(spawnCalled).toBe(false);
     } finally {

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -506,6 +506,36 @@ describe("Subagent spawn success and failure", () => {
     }
   });
 
+  test("spawn returns error for inherited-property inference_profile", async () => {
+    const manager = getSubagentManager();
+    const originalSpawn = manager.spawn.bind(manager);
+    let spawnCalled = false;
+
+    manager.spawn = async () => {
+      spawnCalled = true;
+      return "profile-subagent-id";
+    };
+
+    try {
+      const result = await executeSubagentSpawn(
+        {
+          label: "Inherited profile",
+          objective: "Do it",
+          inference_profile: "toString",
+        },
+        makeContext("sess-spawn-inherited-profile", { sendToClient: () => {} }),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain(
+        'Inference profile "toString" is not defined',
+      );
+      expect(spawnCalled).toBe(false);
+    } finally {
+      manager.spawn = originalSpawn;
+    }
+  });
+
   test("spawn returns error for disabled inference_profile", async () => {
     const manager = getSubagentManager();
     const originalSpawn = manager.spawn.bind(manager);

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -6,6 +6,26 @@ import { describe, expect, mock, test } from "bun:test";
 let mockGetMessages: (
   conversationId: string,
 ) => Array<{ role: string; content: string }> | null = () => null;
+const mockProfiles = {
+  balanced: {},
+  "quality-optimized": {},
+};
+mock.module("../config/loader.js", () => ({
+  getConfigReadOnly: () => ({
+    llm: { profiles: mockProfiles },
+  }),
+  getConfig: () => ({
+    llm: {
+      default: {
+        provider: "anthropic",
+        provider_connection: "anthropic-managed",
+        model: "claude-opus-4-7",
+      },
+      profiles: mockProfiles,
+    },
+    rateLimit: { maxRequestsPerMinute: 0 },
+  }),
+}));
 mock.module("../memory/conversation-crud.js", () => ({
   setConversationOriginChannelIfUnset: () => {},
   updateConversationContextWindow: () => {},
@@ -140,6 +160,7 @@ describe("Subagent tool definitions", () => {
     const def = findTool("subagent_spawn");
     expect(def).toBeDefined();
     expect(def.input_schema.required).toEqual(["label", "objective"]);
+    expect(def.input_schema.properties.inference_profile).toBeDefined();
   });
 
   test("abort tool has correct definition", () => {
@@ -417,6 +438,67 @@ describe("Subagent spawn success and failure", () => {
       expect(capturedConfig!.objective).toBe("Do it");
       expect(capturedConfig!.context).toBe("Extra info here");
       expect(capturedConfig!.parentConversationId).toBe("sess-spawn-3");
+    } finally {
+      manager.spawn = originalSpawn;
+    }
+  });
+
+  test("spawn passes explicit inference_profile to manager over inherited override", async () => {
+    const manager = getSubagentManager();
+    const originalSpawn = manager.spawn.bind(manager);
+    let capturedConfig: Record<string, unknown> | undefined;
+
+    manager.spawn = async (config: Record<string, unknown>) => {
+      capturedConfig = config;
+      return "profile-subagent-id";
+    };
+
+    try {
+      const result = await executeSubagentSpawn(
+        {
+          label: "Profile test",
+          objective: "Do it with a chosen model profile",
+          inference_profile: "quality-optimized",
+        },
+        makeContext("sess-spawn-profile", {
+          sendToClient: () => {},
+          overrideProfile: "balanced",
+        }),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(capturedConfig).toBeDefined();
+      expect(capturedConfig!.overrideProfile).toBe("quality-optimized");
+    } finally {
+      manager.spawn = originalSpawn;
+    }
+  });
+
+  test("spawn returns error for unknown inference_profile", async () => {
+    const manager = getSubagentManager();
+    const originalSpawn = manager.spawn.bind(manager);
+    let spawnCalled = false;
+
+    manager.spawn = async () => {
+      spawnCalled = true;
+      return "profile-subagent-id";
+    };
+
+    try {
+      const result = await executeSubagentSpawn(
+        {
+          label: "Bad profile",
+          objective: "Do it",
+          inference_profile: "does-not-exist",
+        },
+        makeContext("sess-spawn-bad-profile", { sendToClient: () => {} }),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain(
+        'Inference profile "does-not-exist" is not defined',
+      );
+      expect(spawnCalled).toBe(false);
     } finally {
       manager.spawn = originalSpawn;
     }

--- a/assistant/src/config/bundled-skills/subagent/SKILL.md
+++ b/assistant/src/config/bundled-skills/subagent/SKILL.md
@@ -71,6 +71,10 @@ Only the parent conversation that spawned a subagent can interact with it (check
 
 Set `send_result_to_user: false` when spawning a subagent whose result is for internal processing only. The parent will still be notified on completion, but the notification will instruct it to read the result without presenting it to the user.
 
+## Inference Profile
+
+Set `inference_profile` to an `llm.profiles` key when a subagent should run under a specific model profile. When omitted, the subagent inherits the parent turn's active profile if one exists; otherwise it uses the `subagentSpawn` call site's default model selection.
+
 ## Fork Mode
 
 Forks are sub-agents that inherit the parent's full context -- messages, system prompt, and memory -- sharing the KV cache for near-free context inheritance. Use forks when the task benefits from knowing what you've been discussing; use a regular sub-agent when the task is self-contained.

--- a/assistant/src/config/bundled-skills/subagent/TOOLS.json
+++ b/assistant/src/config/bundled-skills/subagent/TOOLS.json
@@ -39,6 +39,10 @@
               "investigator"
             ],
             "description": "Agent specialization that controls tool access. 'researcher': read-only (web, files, memory). 'coder': file and bash access. 'planner': read-only analysis. 'investigator': root-cause analysis — debugging, log forensics, tracing behavior across many files; has bash for read-only investigation (grep/find/log inspection) and returns a compact root-cause report. 'general': full access (default). Ignored when fork: true (forks always use general)."
+          },
+          "inference_profile": {
+            "type": "string",
+            "description": "Optional llm.profiles key this subagent should run under. When omitted, the subagent inherits the parent turn's profile when one is active; otherwise it uses the subagentSpawn call site's default model selection."
           }
         },
         "required": ["label", "objective"]

--- a/assistant/src/config/inference-profile-validation.ts
+++ b/assistant/src/config/inference-profile-validation.ts
@@ -10,8 +10,7 @@ export function validateInferenceProfileKey(profile: string): string | null {
     return "inferenceProfile must be a non-empty string";
   }
   const profiles = getConfigReadOnly().llm?.profiles ?? {};
-  const entry = profiles[profile];
-  if (entry === undefined) {
+  if (!Object.prototype.hasOwnProperty.call(profiles, profile)) {
     const available = Object.keys(profiles).sort();
     const hint =
       available.length > 0
@@ -19,6 +18,7 @@ export function validateInferenceProfileKey(profile: string): string | null {
         : " No profiles defined in llm.profiles.";
     return `Inference profile "${profile}" is not defined in llm.profiles.${hint}`;
   }
+  const entry = profiles[profile]!;
   if (entry.status === "disabled") {
     return `Inference profile "${profile}" is disabled.`;
   }

--- a/assistant/src/config/inference-profile-validation.ts
+++ b/assistant/src/config/inference-profile-validation.ts
@@ -10,7 +10,8 @@ export function validateInferenceProfileKey(profile: string): string | null {
     return "inferenceProfile must be a non-empty string";
   }
   const profiles = getConfigReadOnly().llm?.profiles ?? {};
-  if (!Object.prototype.hasOwnProperty.call(profiles, profile)) {
+  const entry = profiles[profile];
+  if (entry === undefined) {
     const available = Object.keys(profiles).sort();
     const hint =
       available.length > 0
@@ -18,7 +19,6 @@ export function validateInferenceProfileKey(profile: string): string | null {
         : " No profiles defined in llm.profiles.";
     return `Inference profile "${profile}" is not defined in llm.profiles.${hint}`;
   }
-  const entry = profiles[profile]!;
   if (entry.status === "disabled") {
     return `Inference profile "${profile}" is disabled.`;
   }

--- a/assistant/src/config/inference-profile-validation.ts
+++ b/assistant/src/config/inference-profile-validation.ts
@@ -10,13 +10,17 @@ export function validateInferenceProfileKey(profile: string): string | null {
     return "inferenceProfile must be a non-empty string";
   }
   const profiles = getConfigReadOnly().llm?.profiles ?? {};
-  if (!Object.prototype.hasOwnProperty.call(profiles, profile)) {
+  const entry = profiles[profile];
+  if (entry === undefined) {
     const available = Object.keys(profiles).sort();
     const hint =
       available.length > 0
         ? ` Available profiles: ${available.join(", ")}.`
         : " No profiles defined in llm.profiles.";
     return `Inference profile "${profile}" is not defined in llm.profiles.${hint}`;
+  }
+  if (entry.status === "disabled") {
+    return `Inference profile "${profile}" is disabled.`;
   }
   return null;
 }

--- a/assistant/src/config/inference-profile-validation.ts
+++ b/assistant/src/config/inference-profile-validation.ts
@@ -1,0 +1,22 @@
+import { getConfigReadOnly } from "./loader.js";
+
+/**
+ * Validate an inference-profile key against the configured `llm.profiles`
+ * catalog. Returns a user-facing error message when the key is empty or
+ * unknown, or `null` when valid.
+ */
+export function validateInferenceProfileKey(profile: string): string | null {
+  if (!profile.trim()) {
+    return "inferenceProfile must be a non-empty string";
+  }
+  const profiles = getConfigReadOnly().llm?.profiles ?? {};
+  if (!Object.prototype.hasOwnProperty.call(profiles, profile)) {
+    const available = Object.keys(profiles).sort();
+    const hint =
+      available.length > 0
+        ? ` Available profiles: ${available.join(", ")}.`
+        : " No profiles defined in llm.profiles.";
+    return `Inference profile "${profile}" is not defined in llm.profiles.${hint}`;
+  }
+  return null;
+}

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -215,6 +215,11 @@ export async function runAgentLoopImpl(
      * spawns).
      */
     overrideProfile?: string;
+    /**
+     * Float `overrideProfile` above call-site layers for non-main-agent call
+     * sites. Used when a caller explicitly pins a background run to a profile.
+     */
+    forceOverrideProfile?: boolean;
   },
 ): Promise<void> {
   if (!ctx.abortController) {
@@ -290,6 +295,7 @@ export async function runAgentLoopImpl(
   ctx.toolRoutedProfile = undefined;
 
   const turnOverrideProfile = userExplicitOverride;
+  const forceOverrideProfile = options?.forceOverrideProfile === true;
 
   const readCurrentOverrideProfile = (): string | undefined =>
     options?.overrideProfile ??
@@ -300,6 +306,7 @@ export async function runAgentLoopImpl(
     llm: config.llm,
     callSite: turnCallSite,
     overrideProfile: turnOverrideProfile ?? undefined,
+    forceOverrideProfile,
     selectionSeed: ctx.conversationId,
   });
   let currentEffectiveContextWindow: EffectiveContextWindow =
@@ -307,6 +314,7 @@ export async function runAgentLoopImpl(
   let currentContextWindowConfig = contextWindowConfigFromEffective(
     resolveCallSiteConfig(turnCallSite, config.llm, {
       overrideProfile: turnOverrideProfile ?? undefined,
+      forceOverrideProfile,
       selectionSeed: ctx.conversationId,
     }).contextWindow,
     currentEffectiveContextWindow,
@@ -322,11 +330,13 @@ export async function runAgentLoopImpl(
         llm: config.llm,
         callSite: turnCallSite,
         overrideProfile: currentOverrideProfile,
+        forceOverrideProfile,
         selectionSeed: ctx.conversationId,
       });
       currentContextWindowConfig = contextWindowConfigFromEffective(
         resolveCallSiteConfig(turnCallSite, config.llm, {
           overrideProfile: currentOverrideProfile,
+          forceOverrideProfile,
           selectionSeed: ctx.conversationId,
         }).contextWindow,
         currentEffectiveContextWindow,
@@ -901,6 +911,7 @@ export async function runAgentLoopImpl(
         callSite: turnCallSite,
         trust: loopTrust,
         overrideProfile: turnOverrideProfile,
+        ...(forceOverrideProfile ? { forceOverrideProfile: true } : {}),
         resolveOverrideProfile: resolveCurrentOverrideProfile,
         resolveContextWindow,
         compactInPlace,

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -1847,6 +1847,8 @@ export class Conversation {
        * this value via {@link SubagentManager.spawn}.
        */
       overrideProfile?: string;
+      /** Float `overrideProfile` above call-site layers for this run. */
+      forceOverrideProfile?: boolean;
     },
   ): Promise<void> {
     const { onEvent, ...rest } = options ?? {};

--- a/assistant/src/schedule/inference-profile.ts
+++ b/assistant/src/schedule/inference-profile.ts
@@ -1,4 +1,4 @@
-import { getConfigReadOnly } from "../config/loader.js";
+import { validateInferenceProfileKey } from "../config/inference-profile-validation.js";
 
 /**
  * Validate a schedule's inference-profile key against the configured
@@ -12,17 +12,5 @@ import { getConfigReadOnly } from "../config/loader.js";
 export function validateScheduleInferenceProfile(
   profile: string,
 ): string | null {
-  if (!profile.trim()) {
-    return "inferenceProfile must be a non-empty string";
-  }
-  const profiles = getConfigReadOnly().llm?.profiles ?? {};
-  if (!Object.prototype.hasOwnProperty.call(profiles, profile)) {
-    const available = Object.keys(profiles).sort();
-    const hint =
-      available.length > 0
-        ? ` Available profiles: ${available.join(", ")}.`
-        : " No profiles defined in llm.profiles.";
-    return `Inference profile "${profile}" is not defined in llm.profiles.${hint}`;
-  }
-  return null;
+  return validateInferenceProfileKey(profile);
 }

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -453,6 +453,9 @@ export class SubagentManager {
         ...(managed.state.config.overrideProfile
           ? { overrideProfile: managed.state.config.overrideProfile }
           : {}),
+        ...(managed.state.config.forceOverrideProfile
+          ? { forceOverrideProfile: true }
+          : {}),
       });
 
       // Agent loop completed successfully.
@@ -640,6 +643,9 @@ export class SubagentManager {
           callSite: "subagentSpawn",
           ...(managed.state.config.overrideProfile
             ? { overrideProfile: managed.state.config.overrideProfile }
+            : {}),
+          ...(managed.state.config.forceOverrideProfile
+            ? { forceOverrideProfile: true }
             : {}),
         })
         .catch((err) => {

--- a/assistant/src/subagent/types.ts
+++ b/assistant/src/subagent/types.ts
@@ -70,6 +70,12 @@ export interface SubagentConfig {
    */
   overrideProfile?: string;
   /**
+   * When true, the subagent's `overrideProfile` is an explicit spawn-time
+   * request and must float above call-site layers. Inherited parent profiles
+   * leave this unset so existing call-site precedence stays intact.
+   */
+  forceOverrideProfile?: boolean;
+  /**
    * Tool-use id of the `skill_execute` call that spawned this subagent.
    * Forwarded into the `subagent_spawned` event so the client can anchor the
    * inline subagent card to the exact spawn tool call.

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -1,3 +1,4 @@
+import { validateInferenceProfileKey } from "../../config/inference-profile-validation.js";
 import { findConversation } from "../../daemon/conversation-registry.js";
 import { getConversationOverrideProfile } from "../../memory/conversation-crud.js";
 import type { Message } from "../../providers/types.js";
@@ -14,6 +15,7 @@ export async function executeSubagentSpawn(
   const extraContext = input.context as string | undefined;
   const fork = input.fork === true;
   const role = (input.role as string | undefined) ?? undefined;
+  const inferenceProfile = input.inference_profile;
 
   // For fork mode, sendResultToUser defaults to false unless explicitly set to true.
   // For regular mode, sendResultToUser defaults to true (existing behavior).
@@ -26,6 +28,24 @@ export async function executeSubagentSpawn(
       content: 'Both "label" and "objective" are required.',
       isError: true,
     };
+  }
+
+  let requestedOverrideProfile: string | undefined;
+  if (inferenceProfile !== undefined) {
+    if (typeof inferenceProfile !== "string") {
+      return {
+        content: "Error: inference_profile must be a string",
+        isError: true,
+      };
+    }
+    const profileError = validateInferenceProfileKey(inferenceProfile);
+    if (profileError) {
+      return {
+        content: `Error: ${profileError}`,
+        isError: true,
+      };
+    }
+    requestedOverrideProfile = inferenceProfile;
   }
 
   const manager = getSubagentManager();
@@ -75,16 +95,18 @@ export async function executeSubagentSpawn(
   // `SubagentManager.spawn` forwards it back into the subagent's
   // `runAgentLoop` call as `options.overrideProfile`.
   //
-  // Prefer the per-turn `context.overrideProfile` (populated by
-  // `runAgentLoopImpl` from its resolved `turnOverrideProfile`) over a
-  // row read so nested spawns inherit correctly. The current subagent's
-  // own conversation row never has `inferenceProfile` set — its override
-  // arrived via in-memory `SubagentConfig.overrideProfile` — and even if it
-  // were set, `getConversationOverrideProfile` short-circuits for
-  // background conversations and returns `undefined`. Falling back to the
-  // row read preserves behavior for tool calls that originate outside an
-  // agent-loop turn.
+  // Prefer an explicit spawn-time profile, then the per-turn
+  // `context.overrideProfile` (populated by `runAgentLoopImpl` from its
+  // resolved `turnOverrideProfile`) over a row read so nested spawns inherit
+  // correctly. The current subagent's own conversation row never has
+  // `inferenceProfile` set — its override arrived via in-memory
+  // `SubagentConfig.overrideProfile` — and even if it were set,
+  // `getConversationOverrideProfile` short-circuits for background
+  // conversations and returns `undefined`. Falling back to the row read
+  // preserves behavior for tool calls that originate outside an agent-loop
+  // turn.
   const inheritedOverrideProfile =
+    requestedOverrideProfile ??
     context.overrideProfile ??
     getConversationOverrideProfile(context.conversationId);
 

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -31,6 +31,7 @@ export async function executeSubagentSpawn(
   }
 
   let requestedOverrideProfile: string | undefined;
+  let forceOverrideProfile = false;
   if (inferenceProfile !== undefined) {
     if (typeof inferenceProfile !== "string") {
       return {
@@ -46,6 +47,7 @@ export async function executeSubagentSpawn(
       };
     }
     requestedOverrideProfile = inferenceProfile;
+    forceOverrideProfile = true;
   }
 
   const manager = getSubagentManager();
@@ -124,6 +126,7 @@ export async function executeSubagentSpawn(
         ...(inheritedOverrideProfile
           ? { overrideProfile: inheritedOverrideProfile }
           : {}),
+        ...(forceOverrideProfile ? { forceOverrideProfile: true } : {}),
         ...(context.toolUseId ? { parentToolUseId: context.toolUseId } : {}),
         ...forkFields,
       },


### PR DESCRIPTION
## Summary
- Add an optional `inference_profile` field to `subagent_spawn` so parent agents can pin spawned subagents to a configured profile.
- Validate requested profile keys against `llm.profiles` and pass the selected profile into `SubagentConfig.overrideProfile`, taking precedence over inherited turn profiles.
- Share inference-profile validation with the schedule path and cover schema, success, and invalid-profile cases in subagent tests.

## Testing
- `cd assistant && bun test src/__tests__/subagent-tools.test.ts`
- `cd assistant && bun test src/__tests__/schedule-routes.test.ts --grep inference`
- `cd assistant && bun test src/__tests__/conversation-agent-loop-inference-profile.test.ts`
- `cd assistant && bunx prettier --check src/tools/subagent/spawn.ts src/config/inference-profile-validation.ts src/schedule/inference-profile.ts src/__tests__/subagent-tools.test.ts src/config/bundled-skills/subagent/SKILL.md src/config/bundled-skills/subagent/TOOLS.json`
- `cd assistant && bunx eslint src/tools/subagent/spawn.ts src/config/inference-profile-validation.ts src/schedule/inference-profile.ts src/__tests__/subagent-tools.test.ts`
- `cd assistant && bunx tsc --noEmit`

## Original prompt
Take the main idea from PR #34772 and let the main agent specify which model or inference profile to use when spawning subagents.