### PR TITLE
fix(ui-surface): teach + tolerate coarse task_progress cards

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-task-progress.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-task-progress.test.ts
@@ -208,6 +208,73 @@ describe("task_progress surface compatibility", () => {
     );
   });
 
+  test("ui_show fills well-formed templateData for a stepless task_progress card", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    const result = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "card",
+      title: "Researching",
+      template: "task_progress",
+      data: {},
+    });
+
+    expect(result.isError).toBe(false);
+
+    const showMessage = sent.find(
+      (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+    );
+    expect(showMessage).toBeDefined();
+    if (!showMessage || showMessage.surfaceType !== "card") return;
+
+    const card = showMessage.data as CardSurfaceData;
+    expect(card.template).toBe("task_progress");
+    const templateData = card.templateData as Record<string, unknown>;
+    expect(templateData.status).toBe("in_progress");
+    expect(templateData.title).toBe("Researching");
+    expect(templateData.steps).toEqual([]);
+  });
+
+  test("ui_show coerces invalid status and malformed steps on a task_progress card", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+
+    const result = await surfaceProxyResolver(ctx, "ui_show", {
+      surface_type: "card",
+      title: "Building",
+      template: "task_progress",
+      templateData: {
+        status: "working",
+        steps: [
+          { label: "Valid step" },
+          { title: "Aliased label", status: "completed" },
+          { status: "in_progress" },
+          "not an object",
+        ],
+      },
+    });
+
+    expect(result.isError).toBe(false);
+
+    const showMessage = sent.find(
+      (msg): msg is UiSurfaceShow => msg.type === "ui_surface_show",
+    );
+    expect(showMessage).toBeDefined();
+    if (!showMessage || showMessage.surfaceType !== "card") return;
+
+    const templateData = (showMessage.data as CardSurfaceData)
+      .templateData as Record<string, unknown>;
+    expect(templateData.status).toBe("in_progress");
+    const steps = templateData.steps as Array<Record<string, unknown>>;
+    expect(steps).toHaveLength(2);
+    expect(steps[0]).toEqual({ label: "Valid step", status: "pending" });
+    expect(steps[1]).toEqual({
+      title: "Aliased label",
+      label: "Aliased label",
+      status: "completed",
+    });
+  });
+
   test("ui_show normalizes top-level dynamic_page fields into data", async () => {
     const sent: ServerMessage[] = [];
     const ctx = makeContext(sent);

--- a/assistant/src/__tests__/dynamic-page-surface.test.ts
+++ b/assistant/src/__tests__/dynamic-page-surface.test.ts
@@ -207,6 +207,81 @@ describe("ui_show dynamic_page app substitute guard", () => {
 });
 
 // ---------------------------------------------------------------------------
+// task_progress ui_show appends the update hint to its return value
+// ---------------------------------------------------------------------------
+
+describe("ui_show task_progress update hint", () => {
+  const ctx = {
+    conversationId: "conversation-123",
+    workingDir: "/tmp",
+    trustClass: "guardian" as const,
+    proxyToolResolver: async () => ({
+      content: "Surface displayed (surface_id: surf-1).",
+      isError: false,
+    }),
+  };
+
+  test("appends the ui_update hint after a task_progress card is shown", async () => {
+    const result = await uiShowTool.execute(
+      {
+        surface_type: "card",
+        template: "task_progress",
+        templateData: { status: "in_progress", steps: [] },
+      },
+      ctx,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Surface displayed (surface_id: surf-1).");
+    expect(result.content).toContain("call ui_update with this surface_id");
+  });
+
+  test("recognizes task_progress nested under data", async () => {
+    const result = await uiShowTool.execute(
+      {
+        surface_type: "card",
+        data: {
+          template: "task_progress",
+          templateData: { status: "in_progress" },
+        },
+      },
+      ctx,
+    );
+
+    expect(result.content).toContain("call ui_update with this surface_id");
+  });
+
+  test("does not append the hint for a non-task_progress card", async () => {
+    const result = await uiShowTool.execute(
+      { surface_type: "card", data: { title: "Plain", body: "hi" } },
+      ctx,
+    );
+
+    expect(result.content).toBe("Surface displayed (surface_id: surf-1).");
+  });
+
+  test("does not append the hint when the surface call errors", async () => {
+    const result = await uiShowTool.execute(
+      {
+        surface_type: "card",
+        template: "task_progress",
+        templateData: { status: "in_progress" },
+      },
+      {
+        ...ctx,
+        proxyToolResolver: async () => ({
+          content: "blocked on this channel",
+          isError: true,
+        }),
+      },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toBe("blocked on this channel");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // UiSurfaceShowDynamicPage structure
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -279,6 +279,77 @@ export function markSurfaceCompleted(
 }
 const TASK_PROGRESS_TEMPLATE_FIELDS = ["title", "status", "steps"] as const;
 
+const TASK_PROGRESS_CARD_STATUSES = new Set([
+  "in_progress",
+  "completed",
+  "failed",
+]);
+const TASK_PROGRESS_STEP_STATUSES = new Set([
+  "pending",
+  "in_progress",
+  "completed",
+  "failed",
+]);
+
+/**
+ * Coerce a model-supplied `steps` value into a renderable array. Drops
+ * non-object and label-less entries, accepts `title` as a `label` alias, and
+ * defaults a missing/invalid per-step status to "pending". Returns `[]` for a
+ * missing or non-array input so an indeterminate card still renders.
+ */
+function normalizeTaskProgressSteps(
+  value: unknown,
+): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((step): step is Record<string, unknown> => isPlainObject(step))
+    .map((step) => {
+      const label =
+        typeof step.label === "string"
+          ? step.label
+          : typeof step.title === "string"
+            ? step.title
+            : "";
+      const status =
+        typeof step.status === "string" &&
+        TASK_PROGRESS_STEP_STATUSES.has(step.status)
+          ? step.status
+          : "pending";
+      return { ...step, label, status };
+    })
+    .filter((step) => (step.label as string).trim().length > 0);
+}
+
+/**
+ * Guarantee a task_progress card reaches the client with a well-formed
+ * `templateData` object so a coarse or indeterminate attempt (missing steps,
+ * missing status) renders instead of being silently dropped. Fills only
+ * missing fields — a fully-specified card is left intact.
+ */
+function ensureTaskProgressTemplateData(
+  normalized: Record<string, unknown>,
+): void {
+  const templateData: Record<string, unknown> = isPlainObject(
+    normalized.templateData,
+  )
+    ? { ...normalized.templateData }
+    : {};
+  if (
+    typeof templateData.title !== "string" &&
+    typeof normalized.title === "string"
+  ) {
+    templateData.title = normalized.title;
+  }
+  if (
+    typeof templateData.status !== "string" ||
+    !TASK_PROGRESS_CARD_STATUSES.has(templateData.status)
+  ) {
+    templateData.status = "in_progress";
+  }
+  templateData.steps = normalizeTaskProgressSteps(templateData.steps);
+  normalized.templateData = templateData;
+}
+
 /**
  * Migrate dynamic_page fields from the top-level tool input into `data`.
  *
@@ -363,6 +434,10 @@ function normalizeCardShowData(
     typeof normalized.body !== "string"
   ) {
     normalized.body = "";
+  }
+
+  if (normalized.template === "task_progress") {
+    ensureTaskProgressTemplateData(normalized);
   }
 
   return normalized as unknown as CardSurfaceData;

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -57,8 +57,37 @@ function proxyExecute(toolName: string) {
         isError: true,
       };
     }
-    return context.proxyToolResolver(toolName, input);
+    const result = await context.proxyToolResolver(toolName, input);
+    if (
+      toolName === "ui_show" &&
+      !result.isError &&
+      typeof result.content === "string" &&
+      isTaskProgressCardShow(input)
+    ) {
+      return {
+        ...result,
+        content: `${result.content}\n\n${TASK_PROGRESS_UPDATE_HINT}`,
+      };
+    }
+    return result;
   };
+}
+
+/**
+ * Worked ui_update example, appended to a successful task_progress `ui_show`
+ * result so the model learns the update pattern at the point of use (with the
+ * real surface_id in hand) rather than carrying it in the always-present tool
+ * description.
+ */
+const TASK_PROGRESS_UPDATE_HINT =
+  'As each step finishes, call ui_update with this surface_id to advance it — e.g. ui_update { surface_id: "<the surface_id above>", data: { templateData: { steps: [{ label: "Scaffold project", status: "completed" }, { label: "Wire up commands", status: "in_progress" }] } } }';
+
+function isTaskProgressCardShow(input: Record<string, unknown>): boolean {
+  if (input.template === "task_progress") {
+    return true;
+  }
+  const data = asRecord(input.data);
+  return data?.template === "task_progress";
 }
 
 function isEmptyDynamicPage(input: Record<string, unknown>): boolean {
@@ -154,9 +183,7 @@ export const uiShowTool = {
     "- file_upload: { prompt, acceptedTypes?, maxFiles? }\n" +
     "- task_preferences: {} (no data needed — categories are rendered client-side)\n" +
     '- work_result: { eyebrow?, status?: "completed"|"partial"|"failed"|"in_progress", summary?, metrics?: [{ label, value, detail?, tone?: "neutral"|"positive"|"warning"|"negative" }], sections?: [{ id?, title, description?, type?: "items"|"timeline"|"diff"|"artifacts"|"warnings", items?: [{ id?, title, description?, status?, tone?, metadata?: [{ label, value }], href? }], diffs?: [{ label?, before?, after? }] }] }. Shows a structured receipt after real work: what changed, what was skipped, proof points, and next actions. Keep display-only unless explicit follow-up buttons are needed.\n\n' +
-    "For multi-step or long-running turns (web searches, file operations, research), show a task_progress card early and keep its steps updated as work progresses. Coarse steps are fine, and you can add or revise them as the work takes shape — a rough card beats no signal. Example:\n" +
-    '  ui_show { surface_type: "card", template: "task_progress", templateData: { title: "Building CLI", status: "in_progress", steps: [{ label: "Scaffold project", status: "in_progress" }, { label: "Wire up commands", status: "pending" }] } }\n' +
-    '  then as a step finishes, reuse the returned surface_id: ui_update { surface_id: "<id from ui_show>", data: { templateData: { steps: [{ label: "Scaffold project", status: "completed" }, { label: "Wire up commands", status: "in_progress" }] } } }',
+    "For multi-step or long-running turns (web searches, file operations, research), show a task_progress card early and keep its steps updated as work progresses. Coarse steps are fine, and you can add or revise them as the work takes shape — a rough card beats no signal.",
   category: "ui-surface",
   defaultRiskLevel: RiskLevel.Low,
   executionTarget: "host",

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -154,7 +154,9 @@ export const uiShowTool = {
     "- file_upload: { prompt, acceptedTypes?, maxFiles? }\n" +
     "- task_preferences: {} (no data needed — categories are rendered client-side)\n" +
     '- work_result: { eyebrow?, status?: "completed"|"partial"|"failed"|"in_progress", summary?, metrics?: [{ label, value, detail?, tone?: "neutral"|"positive"|"warning"|"negative" }], sections?: [{ id?, title, description?, type?: "items"|"timeline"|"diff"|"artifacts"|"warnings", items?: [{ id?, title, description?, status?, tone?, metadata?: [{ label, value }], href? }], diffs?: [{ label?, before?, after? }] }] }. Shows a structured receipt after real work: what changed, what was skipped, proof points, and next actions. Keep display-only unless explicit follow-up buttons are needed.\n\n' +
-    "Emit a task_progress card BEFORE your first tool call on any multi-step, long-running, or post-form turn (web searches, file operations, research), and keep its steps updated as work progresses. Skills that estimate >30s of work should declare progress upfront with concrete step labels (and counts when known).",
+    "For multi-step or long-running turns (web searches, file operations, research), show a task_progress card early and keep its steps updated as work progresses. Coarse steps are fine, and you can add or revise them as the work takes shape — a rough card beats no signal. Example:\n" +
+    '  ui_show { surface_type: "card", template: "task_progress", templateData: { title: "Building CLI", status: "in_progress", steps: [{ label: "Scaffold project", status: "in_progress" }, { label: "Wire up commands", status: "pending" }] } }\n' +
+    '  then as a step finishes, reuse the returned surface_id: ui_update { surface_id: "<id from ui_show>", data: { templateData: { steps: [{ label: "Scaffold project", status: "completed" }, { label: "Wire up commands", status: "in_progress" }] } } }',
   category: "ui-surface",
   defaultRiskLevel: RiskLevel.Low,
   executionTarget: "host",


### PR DESCRIPTION
## What

Two changes that make the `task_progress` progress card easier for weaker models to emit correctly, so a rough attempt renders instead of failing. Part of the series investigating why MiniMax M3 never shows progress cards (#34947 is the prompt-placement fix, #34955 is the mid-turn nudge).

**B2 — `ui_show` tool description:**
- Replaces the rigid "emit a task_progress card BEFORE your first tool call … with concrete step labels" instruction with best-effort guidance (coarse steps are fine; revise as the work takes shape).
- The worked `ui_show` + `ui_update` example is **not** baked into the always-present description (the most expensive prompt real estate). Instead, the `ui_update` example is delivered via the **`ui_show` return value**, appended only after a task_progress card is actually shown — the model learns the update pattern at the point of use, with the real `surface_id` in hand, and capable models that never show a card never carry it.

**B3 — `conversation-surfaces` normalization:**
- Guarantees a task_progress card reaches the client with a well-formed `templateData` object. A **stepless / indeterminate** attempt now renders as an in-progress card (`steps: []`) with a title instead of being dropped.
- Invalid card `status` defaults to `in_progress`; malformed steps are coerced (`title`→`label` alias, default per-step status `pending`, non-object and label-less entries dropped).
- Fully-specified cards (the Claude path) are left intact — only missing/invalid fields are filled.

## Why

This is the direct follow-on to the blank-box `dynamic_page` fix (#34940): be liberal in what we accept from the model so an imperfect surface attempt still shows progress, rather than erroring into a retry loop. It pairs with the best-effort prompt reframe in #34947 — lower the bar to emit a card rather than demand a perfect one — while keeping the static tool description lean.

## Tests

- `conversation-surfaces-task-progress.test.ts`: +2 cases (stepless card gets well-formed templateData; invalid status + malformed steps are coerced).
- `dynamic-page-surface.test.ts`: +4 cases (update hint appended after a task_progress show; recognized when nested under `data`; not appended for plain cards; not appended on error).
- All 35 pass. Type-check + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)