### PR TITLE
fix(prompt): stop the connected-services list reading as infrastructure

### DIFF
--- a/assistant/src/__tests__/system-prompt.test.ts
+++ b/assistant/src/__tests__/system-prompt.test.ts
@@ -194,6 +194,23 @@ describe("buildSystemPrompt", () => {
     expect(dynamicIdx).toBeGreaterThan(staticIdx);
   });
 
+  test("connected-services block warns against inferring hosting from a connection", () => {
+    mockManagedConnections.push({ provider: "vercel", accountInfo: null });
+
+    const result = buildSystemPrompt();
+
+    const headerIdx = result.indexOf("# Connected Services");
+    const caveatIdx = result.indexOf(
+      "Don't infer where something is hosted, deployed, or stored from this list",
+    );
+    const entryIdx = result.indexOf("- **vercel**: Connected");
+    expect(headerIdx).toBeGreaterThan(-1);
+    // The caveat sits between the header and the connection entries so the
+    // model reads "available tools, not infrastructure" before the list.
+    expect(caveatIdx).toBeGreaterThan(headerIdx);
+    expect(entryIdx).toBeGreaterThan(caveatIdx);
+  });
+
   test("side-chain prompt options still include IDENTITY.md and SOUL.md", () => {
     writeFileSync(join(TEST_DIR, "IDENTITY.md"), "# Identity\n\nI am Vellum.");
     writeFileSync(join(TEST_DIR, "SOUL.md"), "# Soul\n\nBe thoughtful.");

--- a/assistant/src/prompts/templates/system-sections.ts
+++ b/assistant/src/prompts/templates/system-sections.ts
@@ -143,7 +143,12 @@ function renderConnectedServices(): string | null {
 
   if (entries.length === 0) return null;
 
-  const lines = ["# Connected Services", ""];
+  const lines = [
+    "# Connected Services",
+    "",
+    "Each entry means the integration is authorized and its tools are available to you — not that the user's projects, sites, or data live on that service. Don't infer where something is hosted, deployed, or stored from this list; verify with a tool before stating it.",
+    "",
+  ];
   for (const conn of entries) {
     const state = conn.accountInfo
       ? `Connected (${conn.accountInfo})`


### PR DESCRIPTION
## What

Adds a one-line caveat to the top of the dynamic `# Connected Services` system-prompt block clarifying that a listed connection means the integration's **tools are available** — not that the user's projects, sites, or data live on that service — and that hosting/deployment/storage must be verified with a tool before being stated.

## Why

Dogfood feedback: on the **balanced-economy** profile (MiniMax M3), the assistant claimed the user's marketing site was hosted on **Vercel**, built a measurement plan around Vercel logs, and only after correction discovered the site runs on GCP/Kubernetes. The hallucination wasn't random — the user has the **Vercel** MCP connection, so the prompt's `Connected Services` block listed `- **Vercel**: Connected`, and the weaker model read that bare fact as an infrastructure claim. A stronger model (Sonnet/Opus) reads it correctly as "I have Vercel tools available."

This is the demonstrable anchor for that failure. `Connected ≠ hosts your project` — the user almost certainly has Vercel connected for something else entirely.

## Scope / cost

- The caveat renders **only when the section does** (the user has ≥1 active connection), so installs with no connections pay nothing.
- It's one line; strong models never made this error, but the section text genuinely *was* ambiguous, so this is a prompt-clarity fix, not just weak-model coddling.

## Test

`assistant/src/__tests__/system-prompt.test.ts` — new case asserts the caveat renders between the header and the connection entries. Full file green (115 pass), typecheck clean.

## Reviewer focus

Wording of the caveat (altitude/tone vs. the rest of the prompt) and whether one line is the right amount — risk is low. This is **B1** of a two-PR response to the feedback; **C1** (a weak-model "verify-before-asserting / act-don't-ask" nudge) follows as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)