### PR TITLE
fix(web): stream model reasoning live in the Thought process drawer

### DIFF
--- a/apps/web/src/domains/chat/components/multi-activity-group/multi-activity-group.tsx
+++ b/apps/web/src/domains/chat/components/multi-activity-group/multi-activity-group.tsx
@@ -93,6 +93,13 @@ export interface MultiActivityGroupProps {
    * ordered list here.
    */
   items?: ToolCallCardItem[];
+  /**
+   * Source address of the group so a thinking pill can re-derive its live
+   * reasoning from the message for the streaming drawer instead of freezing a
+   * snapshot. `groupIndex` is the index into `groupContentBlocks(message)`.
+   */
+  messageId?: string;
+  groupIndex?: number;
 }
 
 /**
@@ -345,6 +352,8 @@ function UnifiedMultiActivityGroup({
   onOpenRuleEditor,
   unknownNudgeToolCallIds,
   onDismissUnknownNudge,
+  messageId,
+  groupIndex,
 }: MultiActivityGroupProps & {
   cardData: ToolCallCardData;
   expanded: boolean;
@@ -467,9 +476,19 @@ function UnifiedMultiActivityGroup({
             // Thinking steps render as a clickable, brain-branded pill that
             // opens the full reasoning in the shared tool-detail drawer.
             if (step.kind === "thinking") {
-              const active =
-                activeDetail?.kind === "thinking" &&
-                activeDetail.thinkingText === step.text;
+              // Genuine reasoning steps carry a `thinkingItemIndex` so the
+              // drawer can stream their live source; web-synthesized "Reading …"
+              // thinking steps omit it and fall back to the static snapshot.
+              const liveAddressed =
+                messageId != null && step.thinkingItemIndex != null;
+              const active = liveAddressed
+                ? activeDetail?.kind === "thinking" &&
+                  activeDetail.thinkingMessageId === messageId &&
+                  activeDetail.thinkingGroupIndex === groupIndex &&
+                  activeDetail.thinkingItemIndex === step.thinkingItemIndex
+                : activeDetail?.kind === "thinking" &&
+                  activeDetail.thinkingMessageId === undefined &&
+                  activeDetail.thinkingText === step.text;
               return (
                 <ToolStepPill
                   iconName="brain"
@@ -491,6 +510,13 @@ function UnifiedMultiActivityGroup({
                       activity: "",
                       input: {},
                       status: "completed",
+                      ...(liveAddressed
+                        ? {
+                            thinkingMessageId: messageId,
+                            thinkingGroupIndex: groupIndex,
+                            thinkingItemIndex: step.thinkingItemIndex,
+                          }
+                        : {}),
                       thinkingText: step.text,
                     });
                   }}

--- a/apps/web/src/domains/chat/components/single-activity/single-activity.tsx
+++ b/apps/web/src/domains/chat/components/single-activity/single-activity.tsx
@@ -67,6 +67,13 @@ export type SingleActivityProps =
       content: string;
       /** Whether the reasoning is still streaming in (drives the glyph + label). */
       isStreaming?: boolean;
+      /**
+       * Source address of the reasoning so the drawer can re-derive it live from
+       * the message instead of freezing `content` at open time. The whole
+       * group's combined reasoning (no item index).
+       */
+      messageId?: string;
+      groupIndex?: number;
     }
   | {
       variant: "tool";
@@ -211,7 +218,7 @@ export function SingleActivity(props: SingleActivityProps) {
   let view: ResolvedView;
 
   if (props.variant === "thinking") {
-    const { content, isStreaming = false } = props;
+    const { content, isStreaming = false, messageId, groupIndex } = props;
     // While streaming, render even before any reasoning text has landed so this
     // link can be the single thinking affordance from the start of the turn.
     // Once settled, an empty thought process has nothing to show, so collapse it.
@@ -229,11 +236,14 @@ export function SingleActivity(props: SingleActivityProps) {
       ),
       label: isStreaming ? "Thinking" : "Thought process",
       tone: "default",
-      // Thinking payloads carry an empty `toolCallId`, so we match on the
-      // thinking text instead (mirrors the in-card thinking pill).
+      // Thinking payloads carry an empty `toolCallId`, so we match on the source
+      // address (message + group) instead — text identity breaks mid-stream as
+      // `content` grows past the opened snapshot.
       active:
         activeDetail?.kind === "thinking" &&
-        activeDetail.thinkingText === content,
+        activeDetail.thinkingMessageId === messageId &&
+        activeDetail.thinkingGroupIndex === groupIndex &&
+        activeDetail.thinkingItemIndex === undefined,
       onClick: () =>
         toggleToolDetail({
           kind: "thinking",
@@ -243,6 +253,8 @@ export function SingleActivity(props: SingleActivityProps) {
           activity: "",
           input: {},
           status: "completed",
+          thinkingMessageId: messageId,
+          thinkingGroupIndex: groupIndex,
           thinkingText: content,
         }),
     };

--- a/apps/web/src/domains/chat/components/tool-detail-panel.test.tsx
+++ b/apps/web/src/domains/chat/components/tool-detail-panel.test.tsx
@@ -6,9 +6,11 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
 
 import { ToolDetailPanel } from "@/domains/chat/components/tool-detail-panel";
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import type { DisplayMessage } from "@/domains/chat/types/types";
 import type { ToolDetailPayload } from "@/stores/viewer-store";
 
 const noop = () => {};
@@ -39,7 +41,18 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  act(() => {
+    useChatSessionStore.getState().setMessages([]);
+  });
 });
+
+function assistantThinkingMessage(thinking: string): DisplayMessage {
+  return {
+    id: "msg-1",
+    role: "assistant",
+    contentBlocks: [{ type: "thinking", thinking }],
+  };
+}
 
 describe("ToolDetailPanel", () => {
   test("renders the activity title, friendly tool name, input JSON and output", () => {
@@ -133,6 +146,86 @@ describe("ToolDetailPanel", () => {
     expect(queryByText("Output")).toBeNull();
     // No risk badge.
     expect(queryByText("Subagent Spawn")).toBeNull();
+  });
+
+  test("thinking variant streams live as the source message's reasoning grows", () => {
+    act(() => {
+      useChatSessionStore
+        .getState()
+        .setMessages([assistantThinkingMessage("First thought.")]);
+    });
+    const detail = makeDetail({
+      kind: "thinking",
+      title: "Thought process",
+      thinkingMessageId: "msg-1",
+      thinkingGroupIndex: 0,
+      // The snapshot is stale on purpose — the live message is the source.
+      thinkingText: "First thought.",
+    });
+    const { container } = render(
+      <ToolDetailPanel detail={detail} onClose={noop} />,
+    );
+    expect(container.textContent ?? "").toContain("First thought.");
+
+    // A new `assistant_thinking_delta` lands: the drawer reflects it without a
+    // re-open.
+    act(() => {
+      useChatSessionStore
+        .getState()
+        .setMessages([
+          assistantThinkingMessage("First thought.\nSecond thought."),
+        ]);
+    });
+    expect(container.textContent ?? "").toContain("Second thought.");
+  });
+
+  test("thinking variant indexes a single run for a MultiActivityGroup pill", () => {
+    act(() => {
+      useChatSessionStore.getState().setMessages([
+        {
+          id: "msg-1",
+          role: "assistant",
+          // Two reasoning runs split by a tool call — the panel must show only
+          // the addressed run, not the joined group.
+          contentBlocks: [
+            { type: "thinking", thinking: "Run one." },
+            {
+              type: "tool_use",
+              toolCall: { id: "tc-1", name: "bash", input: {} },
+            },
+            { type: "thinking", thinking: "Run two." },
+          ],
+        },
+      ]);
+    });
+    const detail = makeDetail({
+      kind: "thinking",
+      title: "Thinking",
+      thinkingMessageId: "msg-1",
+      thinkingGroupIndex: 0,
+      thinkingItemIndex: 1,
+      thinkingText: "Run two.",
+    });
+    const { container } = render(
+      <ToolDetailPanel detail={detail} onClose={noop} />,
+    );
+    const text = container.textContent ?? "";
+    expect(text).toContain("Run two.");
+    expect(text).not.toContain("Run one.");
+  });
+
+  test("thinking variant falls back to the snapshot when the message is gone", () => {
+    const detail = makeDetail({
+      kind: "thinking",
+      title: "Thought process",
+      thinkingMessageId: "missing",
+      thinkingGroupIndex: 0,
+      thinkingText: "Snapshot reasoning.",
+    });
+    const { container } = render(
+      <ToolDetailPanel detail={detail} onClose={noop} />,
+    );
+    expect(container.textContent ?? "").toContain("Snapshot reasoning.");
   });
 
   test("thinking variant close button fires onClose", () => {

--- a/apps/web/src/domains/chat/components/tool-detail-panel.tsx
+++ b/apps/web/src/domains/chat/components/tool-detail-panel.tsx
@@ -23,7 +23,7 @@ import {
   X,
   type LucideIcon,
 } from "lucide-react";
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type Ref, type ReactNode } from "react";
 
 import { Button, Typography } from "@vellumai/design-library";
 
@@ -34,6 +34,11 @@ import {
     deriveStepLabelFromName,
     type IconName,
 } from "@/domains/chat/components/tool-progress-card/derive-step-label";
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import {
+  activityThinkingTexts,
+  groupContentBlocks,
+} from "@/domains/chat/transcript/message-content";
 import type { ToolDetailPayload } from "@/stores/viewer-store";
 
 /**
@@ -126,12 +131,15 @@ function DetailShell({
   headerTrailing,
   onClose,
   children,
+  bodyRef,
 }: {
   Glyph: LucideIcon;
   title: string;
   headerTrailing?: ReactNode;
   onClose: () => void;
   children: ReactNode;
+  /** Ref to the scrollable body, so callers can drive auto-scroll. */
+  bodyRef?: Ref<HTMLDivElement>;
 }) {
   return (
     <div className="flex h-full flex-col overflow-hidden rounded-xl bg-[var(--surface-lift)]">
@@ -163,8 +171,93 @@ function DetailShell({
       </div>
 
       {/* Scrollable body */}
-      <div className="flex-1 overflow-y-auto px-5 py-5">{children}</div>
+      <div ref={bodyRef} className="flex-1 overflow-y-auto px-5 py-5">
+        {children}
+      </div>
     </div>
+  );
+}
+
+/**
+ * Live reasoning text for a thinking payload. Re-derives the text from the
+ * source message's `contentBlocks` on every store change so the drawer streams
+ * in place as `assistant_thinking_delta` events land — keyed by the message +
+ * group (+ item) address the pill captured, never a frozen string. Falls back
+ * to the `thinkingText` snapshot when the source message is no longer in the
+ * store (e.g. after a conversation switch).
+ */
+function useLiveThinkingText(detail: ToolDetailPayload): string {
+  return useChatSessionStore((s) => {
+    const fallback = detail.thinkingText ?? "";
+    const id = detail.thinkingMessageId;
+    if (id == null) return fallback;
+    const message = s.messages.find((m) => m.id === id);
+    if (!message) return fallback;
+    const groups = groupContentBlocks(message.contentBlocks ?? [], {
+      splitInlineThinking: message.role !== "user",
+    });
+    const group = groups[detail.thinkingGroupIndex ?? -1];
+    if (!group || group.type !== "activity") return fallback;
+    const texts = activityThinkingTexts(group.items);
+    if (detail.thinkingItemIndex != null) {
+      return texts[detail.thinkingItemIndex] ?? fallback;
+    }
+    return texts.length > 0 ? texts.join("\n") : fallback;
+  });
+}
+
+/**
+ * Reasoning view of the detail drawer. Streams live thinking
+ * ({@link useLiveThinkingText}) and keeps the latest text in view while it
+ * grows, unless the user has scrolled up to read earlier reasoning.
+ */
+function ThinkingDetail({
+  detail,
+  onClose,
+}: {
+  detail: ToolDetailPayload;
+  onClose: () => void;
+}) {
+  const text = useLiveThinkingText(detail);
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+  // Whether to pin to the bottom as new reasoning streams in. Starts pinned;
+  // toggled by the user's own scrolling.
+  const stickToBottom = useRef(true);
+  // Previous text, to scroll only when reasoning GROWS. `null` until the first
+  // effect run so opening a completed thought starts at the top, not pinned to
+  // the bottom.
+  const prevText = useRef<string | null>(null);
+
+  useEffect(() => {
+    const el = bodyRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      stickToBottom.current =
+        el.scrollHeight - el.scrollTop - el.clientHeight < 32;
+    };
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, []);
+
+  useEffect(() => {
+    const el = bodyRef.current;
+    const prev = prevText.current;
+    prevText.current = text;
+    if (prev === null) return;
+    if (el && stickToBottom.current && text.length > prev.length) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [text]);
+
+  return (
+    <DetailShell
+      Glyph={Brain}
+      title={detail.title}
+      onClose={onClose}
+      bodyRef={bodyRef}
+    >
+      <ChatMarkdownMessage content={text} hardLineBreaks />
+    </DetailShell>
   );
 }
 
@@ -180,11 +273,7 @@ export function ToolDetailPanel({
   // Thinking variant — reuse the same shell/header but render the full
   // reasoning markdown with no input/output sections and no risk badge.
   if (detail.kind === "thinking") {
-    return (
-      <DetailShell Glyph={Brain} title={detail.title} onClose={onClose}>
-        <ChatMarkdownMessage content={detail.thinkingText ?? ""} hardLineBreaks />
-      </DetailShell>
-    );
+    return <ThinkingDetail detail={detail} onClose={onClose} />;
   }
 
   const { iconName } = deriveStepLabelFromName(detail.toolName, detail.input);

--- a/apps/web/src/domains/chat/transcript/message-content.ts
+++ b/apps/web/src/domains/chat/transcript/message-content.ts
@@ -180,6 +180,25 @@ export function groupContentBlocks(
 }
 
 /**
+ * Non-empty reasoning strings for an activity group's items, in order. The
+ * single source of truth for how a group's thinking is projected to text:
+ * `SingleActivity` joins the whole array (one combined "Thought process"), and
+ * the live thinking drawer indexes into it (the Nth `MultiActivityGroup`
+ * thinking pill). Keeping both on this helper means the inline affordance and
+ * the drawer can never show different reasoning for the same group.
+ */
+export function activityThinkingTexts(
+  items: ContentBlockActivityItem[],
+): string[] {
+  return items
+    .filter(
+      (i): i is ConversationThinkingBlock =>
+        i.type === "thinking" && Boolean(i.thinking),
+    )
+    .map((i) => i.thinking);
+}
+
+/**
  * UI surface tools are rendered by the inline surface widget, not as tool-call
  * chips — unless they carry a pending confirmation, in which case the chip must
  * render so the inline confirmation card is visible.

--- a/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/apps/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -21,6 +21,7 @@ import {
   type ToolCallCardItem,
 } from "@/domains/chat/utils/tool-call-card-utils";
 import {
+  activityThinkingTexts,
   type ContentBlockActivityItem,
   groupContentBlocks,
   isSubagentSpawnCall,
@@ -219,15 +220,14 @@ export function TranscriptMessageBody({
   const renderActivityGroup = (
     items: ContentBlockActivityItem[],
     key: string,
+    groupIndex: number,
     isLastGroup: boolean,
   ): ReactNode => {
     const cardItems: ToolCallCardItem[] = [];
     const groupToolCalls: ChatMessageToolCall[] = [];
-    const thinkingContents: string[] = [];
     for (const item of items) {
       if (item.type === "thinking") {
         if (item.thinking) {
-          thinkingContents.push(item.thinking);
           cardItems.push({
             kind: "thinking",
             text: item.thinking,
@@ -270,6 +270,8 @@ export function TranscriptMessageBody({
             <MultiActivityGroup
               toolCalls={groupToolCalls}
               items={cardItems}
+              messageId={message.id}
+              groupIndex={groupIndex}
               onOpenRuleEditor={onOpenRuleEditor}
               onConfirmationSubmit={onConfirmationSubmit}
               onAllowAndCreateRule={onAllowAndCreateRule}
@@ -284,7 +286,7 @@ export function TranscriptMessageBody({
     // No renderable tool call — render the combined thinking as a minimal
     // inline thinking `SingleActivity`, plus any spawn cards. A trailing run
     // reads as still-streaming only while the row is live.
-    const combinedThinking = thinkingContents.join("\n");
+    const combinedThinking = activityThinkingTexts(items).join("\n");
     const showThinking = combinedThinking || (isStreaming && isLastGroup);
     return (
       <Fragment key={key}>
@@ -293,6 +295,8 @@ export function TranscriptMessageBody({
             variant="thinking"
             content={combinedThinking}
             isStreaming={isStreaming && isLastGroup}
+            messageId={message.id}
+            groupIndex={groupIndex}
           />
         )}
         {renderInlineSubagentCards(groupToolCalls)}
@@ -365,7 +369,12 @@ export function TranscriptMessageBody({
     if (group.type === "surface") {
       return renderSurfaceNode(group.surface, `b-surface-${gi}`);
     }
-    return renderActivityGroup(group.items, `b-activity-${gi}`, gi === lastGroupIndex);
+    return renderActivityGroup(
+      group.items,
+      `b-activity-${gi}`,
+      gi,
+      gi === lastGroupIndex,
+    );
   };
 
   const wrapperClass = `group/msg flex ${isUser ? "justify-end" : "justify-start"}`;

--- a/apps/web/src/domains/chat/utils/tool-call-card-utils.ts
+++ b/apps/web/src/domains/chat/utils/tool-call-card-utils.ts
@@ -62,6 +62,13 @@ export type ToolCallCardStep =
       startedAt?: number;
       /** Epoch-ms end of the reasoning run, when known. */
       completedAt?: number;
+      /**
+       * Index of this run among the group's genuine thinking items, so a pill
+       * can address its live source for the streaming drawer. Present only for
+       * steps built from real reasoning items — web-tool-synthesized "Reading …"
+       * thinking steps have no reasoning source and omit it.
+       */
+      thinkingItemIndex?: number;
     }
   | {
       kind: "web_search";
@@ -764,6 +771,10 @@ export function computeToolCallCardDataFromItems(
   // flowing through the tool/web header derivation, so we don't promote them
   // to a "Thinking" header.
   let trailingThinkingText: string | null = null;
+  // Ordinal of the current genuine thinking item, matching the panel's
+  // `activityThinkingTexts(group.items)` indexing so a pill addresses the right
+  // live reasoning run.
+  let thinkingItemIndex = 0;
   for (const item of items) {
     if (item.kind === "thinking") {
       if (item.text) {
@@ -773,6 +784,7 @@ export function computeToolCallCardDataFromItems(
           text: item.text,
           startedAt: item.startedAt,
           completedAt: item.completedAt,
+          thinkingItemIndex: thinkingItemIndex++,
         });
         trailingThinkingText = item.text;
       }

--- a/apps/web/src/stores/viewer-store.test.ts
+++ b/apps/web/src/stores/viewer-store.test.ts
@@ -305,10 +305,14 @@ describe("toggleToolDetail", () => {
       activity: "",
       input: {},
       status: "completed",
-      thinkingText: "reasoning",
+      thinkingMessageId: "msg-1",
+      thinkingGroupIndex: 0,
+      // Text grows as reasoning streams, but the source address is unchanged —
+      // toggling the same target still closes the drawer.
+      thinkingText: "reasoning so far",
     };
     getState().openToolDetail(thinking);
-    getState().toggleToolDetail(thinking);
+    getState().toggleToolDetail({ ...thinking, thinkingText: "reasoning so far + more" });
     const state = getState();
     expect(state.mainView).toBe("chat");
     expect(state.activeToolDetail).toBeNull();
@@ -323,10 +327,16 @@ describe("toggleToolDetail", () => {
       activity: "",
       input: {},
       status: "completed",
+      thinkingMessageId: "msg-1",
+      thinkingGroupIndex: 0,
       thinkingText: "reasoning A",
     };
     getState().openToolDetail(thinking);
-    getState().toggleToolDetail({ ...thinking, thinkingText: "reasoning B" });
+    getState().toggleToolDetail({
+      ...thinking,
+      thinkingGroupIndex: 2,
+      thinkingText: "reasoning B",
+    });
     const state = getState();
     expect(state.mainView).toBe("tool-detail");
     expect(state.activeToolDetail?.thinkingText).toBe("reasoning B");

--- a/apps/web/src/stores/viewer-store.ts
+++ b/apps/web/src/stores/viewer-store.ts
@@ -135,10 +135,27 @@ export interface ToolDetailPayload {
   /**
    * Variant discriminator. Absent or `"tool"` → the standard tool-call detail
    * view (technical details + output). `"thinking"` → the reasoning view that
-   * renders `thinkingText` as markdown with no input/output sections.
+   * renders live reasoning markdown with no input/output sections.
    */
   kind?: "tool" | "thinking";
-  /** Full reasoning markdown rendered when `kind === "thinking"`. */
+  /**
+   * Source address of the reasoning shown in the `kind === "thinking"` view.
+   * The panel re-derives the live text from this message's `contentBlocks` so
+   * the drawer streams in place instead of freezing a snapshot. `thinkingText`
+   * is the snapshot captured at open time, kept only as a fallback for when the
+   * source message is no longer in the store (e.g. after a conversation switch).
+   */
+  thinkingMessageId?: string;
+  /** Index into `groupContentBlocks(message)` of the reasoning's activity group. */
+  thinkingGroupIndex?: number;
+  /**
+   * Index into the group's non-empty thinking items
+   * ({@link activityThinkingTexts}) for a single reasoning run (a
+   * `MultiActivityGroup` pill). Absent → the whole group's combined reasoning
+   * (the `SingleActivity` "Thought process" link).
+   */
+  thinkingItemIndex?: number;
+  /** Snapshot fallback rendered when the source message can't be resolved. */
   thinkingText?: string;
 }
 
@@ -379,7 +396,9 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
       active != null &&
       (payload.kind === "thinking"
         ? active.kind === "thinking" &&
-          active.thinkingText === payload.thinkingText
+          active.thinkingMessageId === payload.thinkingMessageId &&
+          active.thinkingGroupIndex === payload.thinkingGroupIndex &&
+          active.thinkingItemIndex === payload.thinkingItemIndex
         : active.kind !== "thinking" &&
           active.toolCallId === payload.toolCallId);
     if (isSameTarget) {


### PR DESCRIPTION
## Problem

The model's **Thought process** reasoning doesn't stream — opening the drawer freezes a snapshot of the reasoning text, so live updates only appear if you click out and back in. Reported from the chat greeting where the thinking panel sat stale while reasoning kept arriving.

Two coupled root causes, both from keying the thinking detail on the **text** rather than its **source**:
1. `ToolDetailPanel` rendered `detail.thinkingText` — a frozen string captured at open time, with no subscription to the live message.
2. The link's "active" highlight matched on `thinkingText === content`, so it dropped mid-stream once the live text grew past the snapshot.

## Fix

Key the thinking detail on its **source address** (`thinkingMessageId` + `thinkingGroupIndex` + optional `thinkingItemIndex`) instead of the text. The drawer re-derives the reasoning from the live message's `contentBlocks` via the shared `groupContentBlocks` / new `activityThinkingTexts` projection on every `assistant_thinking_delta`, so it streams in place — opened mid-turn or after. A stick-to-bottom auto-scroll follows new reasoning while it grows and releases when the user scrolls up; a completed thought still opens at the top. `thinkingText` is retained only as a fallback when the source message is no longer in the store. The mobile overlay reuses `ToolDetailPanel` and inherits the fix.

### Multi-group handling
A message can produce several thinking groups (a `text`/`surface` block closes one), and a single group can hold multiple reasoning runs interleaved with tools. The card walker (`computeToolCallCardDataFromItems`) stamps a genuine-thinking ordinal (`thinkingItemIndex`) on each real reasoning step so each in-card thinking pill addresses its own run; web-synthesized "Reading…" thinking steps carry no source and fall back to the snapshot.

## Files
- `viewer-store.ts` — payload carries the source address; `toggleToolDetail` identity matches on it.
- `tool-detail-panel.tsx` — new `ThinkingDetail` subscribes to the live message + stick-to-bottom scroll.
- `message-content.ts` — `activityThinkingTexts()` as the single source of truth for group→text projection.
- `single-activity.tsx` / `transcript-message-body.tsx` — thread `messageId`/`groupIndex` into the link.
- `multi-activity-group.tsx` / `tool-call-card-utils.ts` — per-run live addressing for in-card thinking pills.

## Testing
- `bunx tsc --noEmit` clean on all touched files; lint clean (0 errors).
- New tests: live growth without re-open, single-run indexing within a mixed group, and snapshot fallback when the source message is gone. Updated `viewer-store` toggle tests to reflect address-based identity.

## Review focus
- `useLiveThinkingText` index alignment between the transcript's grouping and the panel's re-derivation (medium risk — relies on both using the same `splitInlineThinking` option and `activityThinkingTexts` ordering).
- The genuine-thinking ordinal stamping in `computeToolCallCardDataFromItems` vs. web-synthesized thinking steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)