### PR TITLE
feat(plugins): nudge the model to show a task_progress card on long turns

### DIFF
--- a/assistant/src/__tests__/task-progress-nudge-hook.test.ts
+++ b/assistant/src/__tests__/task-progress-nudge-hook.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Tests for the default `task-progress-nudge` plugin's `post-tool-use` hook.
+ *
+ * Covers:
+ * - Stays silent below the round threshold; nudges once a multi-step turn
+ *   reaches it with no task_progress card shown.
+ * - Never nudges when a task_progress card was already shown this turn.
+ * - Fires at most once per turn (dedupes parallel results / further rounds).
+ * - Resets across turns so a later multi-step turn can nudge again.
+ * - Gating: skips non-mainAgent call sites, surface-incapable clients, and
+ *   subagent conversations.
+ * - Appends to (not overwrites) `additionalContext` set by an earlier hook.
+ * - The nudge leaves the tool result's `content` untouched.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import * as realConversationRegistry from "../daemon/conversation-registry.js";
+
+// The hook lazily imports the conversation registry and subagent manager on
+// the would-nudge path; mock both before importing the hook. The registry mock
+// spreads the real module so other consumers in the shared test process keep
+// their exports — only `findConversation` is overridden.
+interface MockConversation {
+  currentCallSite?: string;
+  currentTurnChannelCapabilities?: {
+    channel: string;
+    supportsDynamicUi: boolean;
+  };
+  channelCapabilities?: { channel: string; supportsDynamicUi: boolean };
+}
+let mockConversation: (
+  conversationId: string,
+) => MockConversation | undefined = () => ({
+  currentCallSite: "mainAgent",
+  currentTurnChannelCapabilities: { channel: "web", supportsDynamicUi: true },
+});
+mock.module("../daemon/conversation-registry.js", () => ({
+  ...realConversationRegistry,
+  findConversation: (conversationId: string) =>
+    mockConversation(conversationId),
+}));
+
+let mockParentInfo: (conversationId: string) => unknown = () => undefined;
+mock.module("../subagent/index.js", () => ({
+  getSubagentManager: () => ({
+    getParentInfo: (conversationId: string) => mockParentInfo(conversationId),
+  }),
+}));
+
+import type { PluginLogger, PostToolUseContext } from "../plugin-api/types.js";
+import postToolUse, {
+  resetTaskProgressNudgeStateForTests,
+  TASK_PROGRESS_NUDGE_ROUND_THRESHOLD,
+  TASK_PROGRESS_NUDGE_TEXT,
+} from "../plugins/defaults/task-progress-nudge/hooks/post-tool-use.js";
+import type { Message, ToolResultContent } from "../providers/types.js";
+
+const noopLogger: PluginLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+let conversationCounter = 0;
+function freshConversationId(): string {
+  conversationCounter++;
+  return `conv-nudge-test-${conversationCounter}`;
+}
+
+function toolUseTurn(
+  id: string,
+  name: string,
+  input: Record<string, unknown> = {},
+): Message {
+  return {
+    role: "assistant",
+    content: [{ type: "tool_use", id, name, input }],
+  };
+}
+
+function toolResultTurn(toolUseId: string): Message {
+  return {
+    role: "user",
+    content: [
+      {
+        type: "tool_result",
+        tool_use_id: toolUseId,
+        content: "ok",
+        is_error: false,
+      },
+    ],
+  };
+}
+
+function currentResponse(toolUseId: string): ToolResultContent {
+  return {
+    type: "tool_result",
+    tool_use_id: toolUseId,
+    content: "result body",
+    is_error: false,
+  };
+}
+
+function makeCtx(
+  conversationId: string,
+  toolResponse: ToolResultContent,
+  messages: Message[],
+): PostToolUseContext {
+  return {
+    conversationId,
+    toolResponse,
+    messages,
+    additionalContext: null,
+    model: "any-model",
+    maxInputTokens: 10_000,
+    logger: noopLogger,
+  };
+}
+
+/**
+ * Build a turn of `rounds` tool-use rounds. The last round's tool_use has no
+ * result in history (it arrives via `ctx.toolResponse`). When `showCardAtRound`
+ * is set, that round issues a `ui_show` task_progress card instead of a plain
+ * tool.
+ */
+function turnWithRounds(
+  rounds: number,
+  opts: { showCardAtRound?: number } = {},
+): { messages: Message[]; currentToolUseId: string } {
+  const messages: Message[] = [
+    { role: "user", content: [{ type: "text", text: "build the thing" }] },
+  ];
+  for (let r = 1; r <= rounds; r++) {
+    const id = `tool-${r}`;
+    if (opts.showCardAtRound === r) {
+      messages.push(
+        toolUseTurn(id, "ui_show", {
+          surface_type: "card",
+          template: "task_progress",
+          templateData: { status: "in_progress", steps: [] },
+        }),
+      );
+    } else {
+      messages.push(toolUseTurn(id, "bash", { command: `cmd-${r}` }));
+    }
+    if (r < rounds) messages.push(toolResultTurn(id));
+  }
+  return { messages, currentToolUseId: `tool-${rounds}` };
+}
+
+describe("task-progress-nudge post-tool-use hook", () => {
+  beforeEach(() => {
+    resetTaskProgressNudgeStateForTests();
+    mockConversation = () => ({
+      currentCallSite: "mainAgent",
+      currentTurnChannelCapabilities: {
+        channel: "web",
+        supportsDynamicUi: true,
+      },
+    });
+    mockParentInfo = () => undefined;
+  });
+
+  test("stays silent below the round threshold", async () => {
+    const { messages, currentToolUseId } = turnWithRounds(
+      TASK_PROGRESS_NUDGE_ROUND_THRESHOLD - 1,
+    );
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse(currentToolUseId),
+      messages,
+    );
+    await postToolUse(ctx);
+    expect(ctx.additionalContext).toBeNull();
+  });
+
+  test("nudges once the turn reaches the threshold with no card shown", async () => {
+    const { messages, currentToolUseId } = turnWithRounds(
+      TASK_PROGRESS_NUDGE_ROUND_THRESHOLD,
+    );
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse(currentToolUseId),
+      messages,
+    );
+    await postToolUse(ctx);
+    expect(ctx.additionalContext).toBe(TASK_PROGRESS_NUDGE_TEXT);
+    // tool result content is untouched
+    expect(ctx.toolResponse.content).toBe("result body");
+  });
+
+  test("never nudges when a task_progress card was already shown this turn", async () => {
+    const { messages, currentToolUseId } = turnWithRounds(
+      TASK_PROGRESS_NUDGE_ROUND_THRESHOLD + 2,
+      { showCardAtRound: 1 },
+    );
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse(currentToolUseId),
+      messages,
+    );
+    await postToolUse(ctx);
+    expect(ctx.additionalContext).toBeNull();
+  });
+
+  test("fires at most once per turn", async () => {
+    const conversationId = freshConversationId();
+    const first = turnWithRounds(TASK_PROGRESS_NUDGE_ROUND_THRESHOLD);
+    const ctx1 = makeCtx(
+      conversationId,
+      currentResponse(first.currentToolUseId),
+      first.messages,
+    );
+    await postToolUse(ctx1);
+    expect(ctx1.additionalContext).toBe(TASK_PROGRESS_NUDGE_TEXT);
+
+    // One more round, still no card — must not nudge again this turn.
+    const second = turnWithRounds(TASK_PROGRESS_NUDGE_ROUND_THRESHOLD + 1);
+    const ctx2 = makeCtx(
+      conversationId,
+      currentResponse(second.currentToolUseId),
+      second.messages,
+    );
+    await postToolUse(ctx2);
+    expect(ctx2.additionalContext).toBeNull();
+  });
+
+  test("resets across turns so a later multi-step turn nudges again", async () => {
+    const conversationId = freshConversationId();
+    const first = turnWithRounds(TASK_PROGRESS_NUDGE_ROUND_THRESHOLD);
+    const ctx1 = makeCtx(
+      conversationId,
+      currentResponse(first.currentToolUseId),
+      first.messages,
+    );
+    await postToolUse(ctx1);
+    expect(ctx1.additionalContext).toBe(TASK_PROGRESS_NUDGE_TEXT);
+
+    // A brand-new turn (counting restarts low) below threshold — resets state.
+    const lull = turnWithRounds(1);
+    const ctxLull = makeCtx(
+      conversationId,
+      currentResponse(lull.currentToolUseId),
+      lull.messages,
+    );
+    await postToolUse(ctxLull);
+    expect(ctxLull.additionalContext).toBeNull();
+
+    // Another multi-step turn — should nudge again.
+    const third = turnWithRounds(TASK_PROGRESS_NUDGE_ROUND_THRESHOLD);
+    const ctx3 = makeCtx(
+      conversationId,
+      currentResponse(third.currentToolUseId),
+      third.messages,
+    );
+    await postToolUse(ctx3);
+    expect(ctx3.additionalContext).toBe(TASK_PROGRESS_NUDGE_TEXT);
+  });
+
+  test("skips non-mainAgent call sites", async () => {
+    mockConversation = () => ({
+      currentCallSite: "wake",
+      currentTurnChannelCapabilities: {
+        channel: "web",
+        supportsDynamicUi: true,
+      },
+    });
+    const { messages, currentToolUseId } = turnWithRounds(
+      TASK_PROGRESS_NUDGE_ROUND_THRESHOLD,
+    );
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse(currentToolUseId),
+      messages,
+    );
+    await postToolUse(ctx);
+    expect(ctx.additionalContext).toBeNull();
+  });
+
+  test("skips clients without dynamic UI support", async () => {
+    mockConversation = () => ({
+      currentCallSite: "mainAgent",
+      currentTurnChannelCapabilities: {
+        channel: "telegram",
+        supportsDynamicUi: false,
+      },
+    });
+    const { messages, currentToolUseId } = turnWithRounds(
+      TASK_PROGRESS_NUDGE_ROUND_THRESHOLD,
+    );
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse(currentToolUseId),
+      messages,
+    );
+    await postToolUse(ctx);
+    expect(ctx.additionalContext).toBeNull();
+  });
+
+  test("skips subagent conversations", async () => {
+    mockParentInfo = () => ({ parentConversationId: "parent-1" });
+    const { messages, currentToolUseId } = turnWithRounds(
+      TASK_PROGRESS_NUDGE_ROUND_THRESHOLD,
+    );
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse(currentToolUseId),
+      messages,
+    );
+    await postToolUse(ctx);
+    expect(ctx.additionalContext).toBeNull();
+  });
+
+  test("appends to existing additionalContext rather than overwriting", async () => {
+    const { messages, currentToolUseId } = turnWithRounds(
+      TASK_PROGRESS_NUDGE_ROUND_THRESHOLD,
+    );
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResponse(currentToolUseId),
+      messages,
+    );
+    ctx.additionalContext = "<system_notice>prior coaching</system_notice>";
+    await postToolUse(ctx);
+    expect(ctx.additionalContext).toBe(
+      `<system_notice>prior coaching</system_notice>\n${TASK_PROGRESS_NUDGE_TEXT}`,
+    );
+  });
+});

--- a/assistant/src/__tests__/task-progress-nudge-hook.test.ts
+++ b/assistant/src/__tests__/task-progress-nudge-hook.test.ts
@@ -7,7 +7,8 @@
  * - Never nudges when a task_progress card was already shown this turn.
  * - Fires at most once per turn (dedupes parallel results / further rounds).
  * - Resets across turns so a later multi-step turn can nudge again.
- * - Gating: skips non-mainAgent call sites, surface-incapable clients, and
+ * - Gating: fires only for weak models (Kimi/DeepSeek/MiniMax) and skips
+ *   capable models, non-mainAgent call sites, surface-incapable clients, and
  *   subagent conversations.
  * - Appends to (not overwrites) `additionalContext` set by an earlier hook.
  * - The nudge leaves the tool result's `content` untouched.
@@ -103,17 +104,21 @@ function currentResponse(toolUseId: string): ToolResultContent {
   };
 }
 
+/** A weak-model id that matches WEAK_MODEL_PATTERN (the gated population). */
+const WEAK_MODEL = "minimax/minimax-m3";
+
 function makeCtx(
   conversationId: string,
   toolResponse: ToolResultContent,
   messages: Message[],
+  model: string = WEAK_MODEL,
 ): PostToolUseContext {
   return {
     conversationId,
     toolResponse,
     messages,
     additionalContext: null,
-    model: "any-model",
+    model,
     maxInputTokens: 10_000,
     logger: noopLogger,
   };
@@ -257,6 +262,42 @@ describe("task-progress-nudge post-tool-use hook", () => {
     );
     await postToolUse(ctx3);
     expect(ctx3.additionalContext).toBe(TASK_PROGRESS_NUDGE_TEXT);
+  });
+
+  test("fires for weak models (Kimi, DeepSeek, MiniMax)", async () => {
+    for (const model of [
+      "moonshotai/kimi-k2.6",
+      "deepseek/deepseek-chat",
+      "accounts/fireworks/models/minimax-m3",
+    ]) {
+      const { messages, currentToolUseId } = turnWithRounds(
+        TASK_PROGRESS_NUDGE_ROUND_THRESHOLD,
+      );
+      const ctx = makeCtx(
+        freshConversationId(),
+        currentResponse(currentToolUseId),
+        messages,
+        model,
+      );
+      await postToolUse(ctx);
+      expect(ctx.additionalContext).toBe(TASK_PROGRESS_NUDGE_TEXT);
+    }
+  });
+
+  test("skips capable models (not in the weak-model set)", async () => {
+    for (const model of ["claude-opus-4-8", "gpt-5.5"]) {
+      const { messages, currentToolUseId } = turnWithRounds(
+        TASK_PROGRESS_NUDGE_ROUND_THRESHOLD + 2,
+      );
+      const ctx = makeCtx(
+        freshConversationId(),
+        currentResponse(currentToolUseId),
+        messages,
+        model,
+      );
+      await postToolUse(ctx);
+      expect(ctx.additionalContext).toBeNull();
+    }
   });
 
   test("skips non-mainAgent call sites", async () => {

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -54,6 +54,10 @@ import memoryRetrievalPkg from "./memory-retrieval/package.json" with { type: "j
 import memoryV3PostCompact from "./memory-v3-shadow/hooks/post-compact.js";
 import memoryV3UserPromptSubmit from "./memory-v3-shadow/hooks/user-prompt-submit.js";
 import memoryV3Pkg from "./memory-v3-shadow/package.json" with { type: "json" };
+import taskProgressNudgePostToolUse, {
+  resetTaskProgressNudgeStateForTests,
+} from "./task-progress-nudge/hooks/post-tool-use.js";
+import taskProgressNudgePkg from "./task-progress-nudge/package.json" with { type: "json" };
 import titleGenerateStop from "./title-generate/hooks/stop.js";
 import titleGenerateUserPromptSubmit from "./title-generate/hooks/user-prompt-submit.js";
 import titleGeneratePkg from "./title-generate/package.json" with { type: "json" };
@@ -240,6 +244,22 @@ export const defaultExplorationDriftPlugin: Plugin = {
 };
 
 /**
+ * `task-progress-nudge` — a `post-tool-use` hook that nudges the model to show
+ * a `task_progress` card once an interactive turn has accumulated several
+ * tool-call rounds without one. Best-effort and once-per-turn; capable models
+ * that already show a card are never nudged.
+ */
+export const defaultTaskProgressNudgePlugin: Plugin = {
+  manifest: {
+    name: taskProgressNudgePkg.name,
+    version: taskProgressNudgePkg.version,
+  },
+  hooks: {
+    "post-tool-use": taskProgressNudgePostToolUse,
+  },
+};
+
+/**
  * `tool-result-truncate` — a `post-tool-use` hook that tail-drops an oversized
  * tool result down to a character budget derived from the model's context
  * window before the result is sent to the provider.
@@ -268,6 +288,7 @@ function getAllDefaultPlugins(): readonly Plugin[] {
     defaultMaxTokensContinuePlugin,
     defaultToolErrorPlugin,
     defaultExplorationDriftPlugin,
+    defaultTaskProgressNudgePlugin,
     defaultHistoryRepairPlugin,
     defaultImageRecoveryPlugin,
     defaultCompactionPlugin,
@@ -317,5 +338,6 @@ export function resetPluginRegistryAndRegisterDefaults(): void {
   resetRepairStateStoreForTests();
   resetImageRecoveryStoreForTests();
   resetExplorationDriftStateForTests();
+  resetTaskProgressNudgeStateForTests();
   registerDefaultPlugins();
 }

--- a/assistant/src/plugins/defaults/task-progress-nudge/hooks/post-tool-use.ts
+++ b/assistant/src/plugins/defaults/task-progress-nudge/hooks/post-tool-use.ts
@@ -1,0 +1,184 @@
+/**
+ * Default `post-tool-use` hook: when an interactive turn accumulates several
+ * tool-call rounds without the model having shown a `task_progress` card,
+ * surface a soft notice via `additionalContext` reminding it to show progress.
+ *
+ * Motivation: the system prompt and the `ui_show` tool description both ask
+ * the model to show a `task_progress` card on long multi-step turns, but
+ * weaker models (e.g. MiniMax M3) disregard the static instruction and run
+ * 30+ tool calls with no user-visible progress. A reminder injected mid-turn,
+ * right after a tool result, is far more salient than static prompt text.
+ *
+ * The nudge is strictly best-effort:
+ * - It fires at most once per turn (no nagging).
+ * - It is advisory — the model may decline if it is about to finish or judges
+ *   a card unnecessary.
+ * - A failed or ignored card never blocks the turn.
+ *
+ * It self-targets: a model that already showed a card (`shown`) is never
+ * nudged, so capable models that follow the prompt pay nothing.
+ *
+ * The turn state is derived from conversation history on every call (mirroring
+ * the tool-error and exploration-drift plugins) so the signal survives
+ * mid-turn compaction rewriting the array. The current turn is the trailing
+ * window bounded by the last genuine user message (a user row with no
+ * tool_result blocks). Within it we count tool-use rounds and detect whether a
+ * `ui_show` task_progress card was issued.
+ *
+ * Gating (resolved lazily on the would-nudge path, off the hot path):
+ * - mainAgent call site only — background turns (wake, title-gen, memory) and
+ *   subagents have no live user watching, so a progress card is pointless.
+ * - the client must support dynamic UI — otherwise `ui_show` is blocked
+ *   client-side and the nudge would only provoke a wasted, erroring call.
+ *
+ * Dedup uses a per-conversation high-water mark of the round count at the last
+ * nudge: a non-zero mark means "already nudged this turn", which also dedupes
+ * the parallel tool results of one batch (they observe identical history and
+ * compute the same round count). The mark resets when the round count drops
+ * below it (a new turn restarts counting low).
+ */
+
+import type { PluginHookFn, PostToolUseContext } from "@vellumai/plugin-api";
+
+import type { ContentBlock, Message } from "../../../../providers/types.js";
+
+/**
+ * Canonical nudge notice. Module-level constant so tests and wrapping plugins
+ * can match it without duplicating the string. Shown to the model as
+ * provider-only context, never to the user. Deliberately soft: coarse steps
+ * are fine and the model may skip it when wrapping up.
+ */
+export const TASK_PROGRESS_NUDGE_TEXT =
+  '<system_notice>You are several tool calls into this turn and have not shown the user a progress card. If you are doing multi-step work, call ui_show now with surface_type "card" and template "task_progress" (coarse steps are fine — a rough "Working on X" beats no signal) so the user can see what is happening, and keep it updated with ui_update as you go. Skip this if you are about to finish; never let it interrupt the actual work.</system_notice>';
+
+/**
+ * Number of tool-use rounds in a turn, with no task_progress card shown, that
+ * triggers the nudge. Tuned conservatively: a turn of one or two rounds (the
+ * common simple case) is never touched; only a clearly multi-step turn is
+ * nudged, and only once. Lower from telemetry if cards still arrive too late.
+ */
+export const TASK_PROGRESS_NUDGE_ROUND_THRESHOLD = 3;
+
+/**
+ * Round count at the last nudge, per conversation. A non-zero entry means the
+ * turn has already been nudged; it resets when the round count drops below the
+ * mark (a new turn). Mirrors the exploration-drift high-water mark so parallel
+ * results of one batch dedupe to a single notice.
+ */
+const lastNudgedRoundsByConversation = new Map<string, number>();
+
+/** Test-only: clear the per-conversation nudge high-water marks. */
+export function resetTaskProgressNudgeStateForTests(): void {
+  lastNudgedRoundsByConversation.clear();
+}
+
+/**
+ * True when a `ui_show` tool input shows a `task_progress` card — accepting the
+ * template either at the top level or nested under `data`, mirroring the
+ * server-side normalization tolerance.
+ */
+function isTaskProgressShowInput(input: unknown): boolean {
+  if (input === null || typeof input !== "object") return false;
+  const record = input as Record<string, unknown>;
+  if (record.template === "task_progress") return true;
+  const data = record.data;
+  return (
+    data !== null &&
+    typeof data === "object" &&
+    (data as Record<string, unknown>).template === "task_progress"
+  );
+}
+
+/**
+ * Scan the trailing turn (walking back to the last genuine user message) for
+ * the number of tool-use rounds and whether a task_progress card was shown.
+ * The current round's assistant tool_use is already in history; its result is
+ * not, so the count includes the current round.
+ */
+function scanTurn(messages: ReadonlyArray<Message>): {
+  rounds: number;
+  taskProgressShown: boolean;
+} {
+  let rounds = 0;
+  let taskProgressShown = false;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message.role === "user") {
+      const carriesToolResult = message.content.some(
+        (block: ContentBlock) => block.type === "tool_result",
+      );
+      if (!carriesToolResult) break; // genuine user prompt — turn boundary
+      continue;
+    }
+    if (message.role !== "assistant") continue;
+    let hasToolUse = false;
+    for (const block of message.content) {
+      if (block.type !== "tool_use") continue;
+      hasToolUse = true;
+      if (block.name === "ui_show" && isTaskProgressShowInput(block.input)) {
+        taskProgressShown = true;
+      }
+    }
+    if (hasToolUse) rounds++;
+  }
+  return { rounds, taskProgressShown };
+}
+
+const postToolUse: PluginHookFn<PostToolUseContext> = async (ctx) => {
+  const { rounds, taskProgressShown } = scanTurn(ctx.messages);
+
+  let lastNudged = lastNudgedRoundsByConversation.get(ctx.conversationId) ?? 0;
+  if (rounds < lastNudged) {
+    // New turn (round count restarted low) — drop the stale mark.
+    lastNudgedRoundsByConversation.delete(ctx.conversationId);
+    lastNudged = 0;
+  }
+
+  // A card now exists this turn: clear any stale mark and never nudge.
+  if (taskProgressShown) {
+    if (lastNudged !== 0) {
+      lastNudgedRoundsByConversation.delete(ctx.conversationId);
+    }
+    return;
+  }
+
+  if (rounds < TASK_PROGRESS_NUDGE_ROUND_THRESHOLD) return;
+  if (lastNudged !== 0) return; // already nudged this turn
+
+  // Resolve gating lazily on the rare would-nudge path to keep the hot path
+  // free of the conversation-registry and subagent module graphs.
+  const { findConversation } =
+    await import("../../../../daemon/conversation-registry.js");
+  const conversation = findConversation(ctx.conversationId);
+  if (!conversation) return;
+
+  if (
+    conversation.currentCallSite &&
+    conversation.currentCallSite !== "mainAgent"
+  ) {
+    return; // background call site — no live user watching
+  }
+
+  const capabilities =
+    conversation.currentTurnChannelCapabilities ??
+    conversation.channelCapabilities;
+  if (capabilities && capabilities.supportsDynamicUi === false) {
+    return; // client cannot render surfaces — a nudge would only error
+  }
+
+  const { getSubagentManager } = await import("../../../../subagent/index.js");
+  if (getSubagentManager().getParentInfo(ctx.conversationId) !== undefined) {
+    return; // subagents have no live user
+  }
+
+  lastNudgedRoundsByConversation.set(ctx.conversationId, rounds);
+  ctx.logger.info(
+    { plugin: "task-progress-nudge", rounds },
+    "Multi-step turn with no task_progress card — nudging the model to show progress",
+  );
+  ctx.additionalContext = ctx.additionalContext
+    ? `${ctx.additionalContext}\n${TASK_PROGRESS_NUDGE_TEXT}`
+    : TASK_PROGRESS_NUDGE_TEXT;
+};
+
+export default postToolUse;

--- a/assistant/src/plugins/defaults/task-progress-nudge/hooks/post-tool-use.ts
+++ b/assistant/src/plugins/defaults/task-progress-nudge/hooks/post-tool-use.ts
@@ -15,8 +15,10 @@
  *   a card unnecessary.
  * - A failed or ignored card never blocks the turn.
  *
- * It self-targets: a model that already showed a card (`shown`) is never
- * nudged, so capable models that follow the prompt pay nothing.
+ * It is scoped to weaker open models (Kimi, DeepSeek, MiniMax) that disregard
+ * the static progress-card instruction; capable models follow the prompt and
+ * never need the reminder. It also self-targets: a model that already showed a
+ * card this turn is never nudged.
  *
  * The turn state is derived from conversation history on every call (mirroring
  * the tool-error and exploration-drift plugins) so the signal survives
@@ -25,11 +27,16 @@
  * tool_result blocks). Within it we count tool-use rounds and detect whether a
  * `ui_show` task_progress card was issued.
  *
- * Gating (resolved lazily on the would-nudge path, off the hot path):
+ * Gating:
+ * - weaker open models only (Kimi, DeepSeek, MiniMax) — checked first on the
+ *   hot path so capable-model turns short-circuit immediately.
  * - mainAgent call site only — background turns (wake, title-gen, memory) and
  *   subagents have no live user watching, so a progress card is pointless.
  * - the client must support dynamic UI — otherwise `ui_show` is blocked
  *   client-side and the nudge would only provoke a wasted, erroring call.
+ *
+ * The call-site, capability, and subagent gates are resolved lazily on the
+ * would-nudge path; the model gate is a cheap regex test run up front.
  *
  * Dedup uses a per-conversation high-water mark of the round count at the last
  * nudge: a non-zero mark means "already nudged this turn", which also dedupes
@@ -58,6 +65,17 @@ export const TASK_PROGRESS_NUDGE_TEXT =
  * nudged, and only once. Lower from telemetry if cards still arrive too late.
  */
 export const TASK_PROGRESS_NUDGE_ROUND_THRESHOLD = 3;
+
+/**
+ * Weaker open models that disregard the static progress-card instruction and
+ * so get the mid-turn nudge: Kimi, DeepSeek, and MiniMax. Family-level matching
+ * spans provider naming conventions (OpenRouter `moonshotai/kimi-k2.6`,
+ * `deepseek/deepseek-chat`, `minimax/minimax-m3`; Fireworks
+ * `accounts/fireworks/models/minimax-m3`, `kimi-k2p6`). Extend as other models
+ * show the same gap. Capable models (Claude, GPT) follow the prompt and are
+ * intentionally excluded.
+ */
+const WEAK_MODEL_PATTERN = /kimi|deepseek|minimax/i;
 
 /**
  * Round count at the last nudge, per conversation. A non-zero entry means the
@@ -125,6 +143,8 @@ function scanTurn(messages: ReadonlyArray<Message>): {
 }
 
 const postToolUse: PluginHookFn<PostToolUseContext> = async (ctx) => {
+  if (!WEAK_MODEL_PATTERN.test(ctx.model)) return;
+
   const { rounds, taskProgressShown } = scanTurn(ctx.messages);
 
   let lastNudged = lastNudgedRoundsByConversation.get(ctx.conversationId) ?? 0;

--- a/assistant/src/plugins/defaults/task-progress-nudge/package.json
+++ b/assistant/src/plugins/defaults/task-progress-nudge/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "default-task-progress-nudge",
+  "version": "1.0.0",
+  "description": "First-party default plugin contributing a post-tool-use hook that nudges the model to show a task_progress card when an interactive turn accumulates several tool-call rounds without one.",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "main": "./register.ts",
+  "engines": {
+    "node": ">=20.12.0"
+  },
+  "peerDependencies": {
+    "@vellumai/plugin-api": "^0.8.0"
+  }
+}


### PR DESCRIPTION
## What

Adds a `task-progress-nudge` default plugin — a `post-tool-use` hook that injects a soft, one-time `<system_notice>` reminding the model to show a `task_progress` card once an interactive turn has run several tool-call rounds without one. **Scoped to weaker open models (Kimi, DeepSeek, MiniMax).** This is **Step A** of the series (see #34947 for the prompt reframe and #34951 for the tool-description example + normalization tolerance).

## Why

The prompt and tool description already ask for a progress card on long turns, but weaker models (MiniMax M3) disregard the static instruction — the motivating session ran 30+ tool calls with no card. A reminder injected mid-turn, right after a tool result, is far more salient than static system-prompt text. This is the reliability lever the prompt change alone can't provide.

## Design — best-effort, never in the way

Mirrors the existing `exploration-drift` plugin (also a behavioral nudge scoped to these models):

- **Model-scoped.** Gated to Kimi / DeepSeek / MiniMax via `WEAK_MODEL_PATTERN` (family-level, spans provider naming conventions), checked first so capable-model turns short-circuit before any history scan. Capable models (Claude, GPT) follow the prompt and are intentionally excluded.
- **Stateless turn detection.** Round count and "card already shown" are derived from `ctx.messages` on every call, so the signal survives mid-turn compaction. The trailing turn is bounded by the last genuine user message.
- **Self-targeting too.** A model that already showed a card this turn is never nudged.
- **Soft + once-per-turn.** The notice is advisory and skippable ("coarse steps are fine… skip if you're about to finish; never let it interrupt the actual work"); a per-conversation high-water mark fires it at most once per turn and dedupes parallel tool-result batches. A failed or ignored card never blocks the turn.
- **Further gates** (lazy, on the would-nudge path): `mainAgent` call site only (background wake/title/memory excluded), dynamic-UI-capable client only, subagents exempt.
- **Threshold** is a single named constant `TASK_PROGRESS_NUDGE_ROUND_THRESHOLD = 3`, tuned conservatively so the common one/two-round turn is never touched. Lower from telemetry if cards still arrive too late.

This directly addresses the concern that forcing a card could confuse a weak model: nothing is forced, the card may be coarse, and the actual task is never blocked.

## Tests

`task-progress-nudge-hook.test.ts` (11 cases): below/at threshold, card-already-shown, once-per-turn dedup, cross-turn reset, the model gate (fires for Kimi/DeepSeek/MiniMax, skips Claude/GPT), the call-site/capability/subagent gates, and append-not-overwrite. All pass; type-check + lint clean.

## Follow-up (not in this PR)

G1 telemetry — emission rate **and** task-quality signals (tool-error rate, turn duration, exitReason) for nudged vs non-nudged turns, so we can confirm the nudge helps without a quality regression and tune the threshold/model set. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)