### PR TITLE
feat(prompt): coach verify-before-asserting on weak open models

### DIFF
--- a/assistant/src/__tests__/agentic-initiative-hook.test.ts
+++ b/assistant/src/__tests__/agentic-initiative-hook.test.ts
@@ -1,0 +1,125 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { PluginHookFn, PreModelCallContext } from "@vellumai/plugin-api";
+
+import {
+  isWeakOpenModel,
+  WEAK_OPEN_MODEL_PATTERN,
+} from "../providers/weak-open-model.js";
+
+// Drive the gate by varying the model the resolver returns. mock.module is not
+// hoisted above the static import graph, so the hook is pulled in dynamically
+// (in beforeAll) after these mocks register.
+let resolvedModel = "claude-sonnet-4-6";
+
+mock.module("../config/loader.js", () => ({
+  getConfigReadOnly: () => ({ llm: {} }),
+}));
+mock.module("../config/llm-resolver.js", () => ({
+  resolveCallSiteConfig: () => ({ model: resolvedModel }),
+}));
+
+let preModelCall: PluginHookFn<PreModelCallContext>;
+let INITIATIVE_COACHING_TEXT: string;
+
+beforeAll(async () => {
+  const mod =
+    await import("../plugins/defaults/agentic-initiative/hooks/pre-model-call.js");
+  preModelCall = mod.default;
+  INITIATIVE_COACHING_TEXT = mod.INITIATIVE_COACHING_TEXT;
+});
+
+const BASE_PROMPT = "# System\n\nYou are a helpful assistant.";
+
+function makeCtx(
+  overrides: Partial<PreModelCallContext> = {},
+): PreModelCallContext {
+  return {
+    conversationId: "conv-1",
+    callSite: "mainAgent",
+    systemPrompt: BASE_PROMPT,
+    deferAssistantOutput: false,
+    logger: {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    },
+    ...overrides,
+  } as PreModelCallContext;
+}
+
+describe("isWeakOpenModel", () => {
+  test("matches the shipped weak open models across provider spellings", () => {
+    for (const model of [
+      "accounts/fireworks/models/minimax-m3",
+      "minimax/minimax-m3",
+      "accounts/fireworks/models/kimi-k2p6",
+      "moonshotai/kimi-k2.6",
+    ]) {
+      expect(isWeakOpenModel(model)).toBe(true);
+    }
+  });
+
+  test("does not match managed Claude models or adjacent open models", () => {
+    for (const model of [
+      "claude-sonnet-4-6",
+      "claude-opus-4-8",
+      "claude-fable-5",
+      "accounts/fireworks/models/kimi-k2p5",
+      "accounts/fireworks/models/minimax-m2p7",
+    ]) {
+      expect(isWeakOpenModel(model)).toBe(false);
+    }
+    // The exported pattern is the single source the exploration-drift loop
+    // trigger also gates on.
+    expect(WEAK_OPEN_MODEL_PATTERN.test("claude-sonnet-4-6")).toBe(false);
+  });
+});
+
+describe("agentic-initiative pre-model-call hook", () => {
+  beforeEach(() => {
+    resolvedModel = "claude-sonnet-4-6";
+  });
+
+  test("appends coaching for the user-facing reply on a weak open model", async () => {
+    resolvedModel = "accounts/fireworks/models/minimax-m3";
+    const ctx = makeCtx();
+    await preModelCall(ctx);
+    expect(ctx.systemPrompt).toContain(BASE_PROMPT);
+    expect(ctx.systemPrompt).toContain(INITIATIVE_COACHING_TEXT);
+  });
+
+  test("leaves the prompt untouched on managed Claude models", async () => {
+    resolvedModel = "claude-sonnet-4-6";
+    const ctx = makeCtx();
+    await preModelCall(ctx);
+    expect(ctx.systemPrompt).toBe(BASE_PROMPT);
+  });
+
+  test("does not coach non-mainAgent call sites even on a weak model", async () => {
+    resolvedModel = "accounts/fireworks/models/minimax-m3";
+    const ctx = makeCtx({ callSite: "subagentSpawn" });
+    await preModelCall(ctx);
+    expect(ctx.systemPrompt).toBe(BASE_PROMPT);
+  });
+
+  test("no-ops when there is no system prompt to append to", async () => {
+    resolvedModel = "accounts/fireworks/models/minimax-m3";
+    const ctx = makeCtx({ systemPrompt: null });
+    await preModelCall(ctx);
+    expect(ctx.systemPrompt).toBeNull();
+  });
+
+  test("is idempotent — a re-entrant call does not stack the block", async () => {
+    resolvedModel = "accounts/fireworks/models/minimax-m3";
+    const ctx = makeCtx();
+    await preModelCall(ctx);
+    const afterFirst = ctx.systemPrompt;
+    await preModelCall(ctx);
+    expect(ctx.systemPrompt).toBe(afterFirst);
+    const occurrences =
+      ctx.systemPrompt!.split(INITIATIVE_COACHING_TEXT).length - 1;
+    expect(occurrences).toBe(1);
+  });
+});

--- a/assistant/src/plugins/defaults/agentic-initiative/hooks/pre-model-call.ts
+++ b/assistant/src/plugins/defaults/agentic-initiative/hooks/pre-model-call.ts
@@ -1,0 +1,74 @@
+/**
+ * Default `pre-model-call` hook: for the user-facing reply on a weak open
+ * model (see {@link isWeakOpenModel}), append two short behavioral directives
+ * to the system prompt — verify-before-asserting and attempt-don't-ask.
+ *
+ * Motivation: on the `balanced-economy` profile (MiniMax M3) the assistant
+ * asserted the user's site was hosted on Vercel (it runs on GCP) and, once
+ * corrected, asked "do you have gcloud set up?" instead of just running it —
+ * both behaviors the managed Claude profiles don't exhibit. The soul/bootstrap
+ * prompt already carries "be resourceful before asking," but the weaker models
+ * don't reliably follow prose that's shared with every model; this gives them a
+ * firmer, model-gated restatement at the seam right before the provider call.
+ *
+ * Gated three ways so the cost lands only where it helps:
+ * - `callSite === "mainAgent"` — only the user-facing reply. Background,
+ *   subagent, compaction, and utility call sites run their own resolved models
+ *   and don't need this coaching.
+ * - the resolved main-agent model is a weak open model — managed Claude
+ *   profiles pay nothing (the section is never appended for them).
+ * - idempotent append — re-entrant provider calls within a turn never stack
+ *   the block twice.
+ *
+ * The model is resolved from the workspace's active profile via
+ * `resolveCallSiteConfig`, matching how the user selects a chat model
+ * (`llm.activeProfile`). A per-conversation inference-profile override is not
+ * visible at this seam, so a conversation that overrides onto a weak model
+ * while the workspace active profile is a managed one is not coached; that is
+ * the rare path and the failure mode is only a missing nudge, never a wrong
+ * one.
+ */
+
+import type { PluginHookFn, PreModelCallContext } from "@vellumai/plugin-api";
+
+import { resolveCallSiteConfig } from "../../../../config/llm-resolver.js";
+import { getConfigReadOnly } from "../../../../config/loader.js";
+import { isWeakOpenModel } from "../../../../providers/weak-open-model.js";
+
+/**
+ * The appended directives. Module-level constant so tests and any wrapping
+ * plugin can match it without duplicating the string, and so the idempotency
+ * guard can detect an already-appended block.
+ */
+export const INITIATIVE_COACHING_TEXT = `<initiative_and_grounding>
+Two habits for this turn:
+
+1. Verify before asserting. Before stating where something is hosted, deployed, stored, or configured — or any other fact about the user's systems you have not confirmed this session — check it with a read-only tool call. Do not infer it from which integrations are connected, and do not state it from memory. If you cannot verify it, say so instead of guessing.
+
+2. Attempt, don't ask. When you need a tool, connection, or credential to make progress, try it and handle any failure — do not ask the user whether it is set up or available. Ask only after an attempt actually fails, or when the action is destructive or genuinely ambiguous.
+</initiative_and_grounding>`;
+
+const preModelCall: PluginHookFn<PreModelCallContext> = async (ctx) => {
+  if (ctx.callSite !== "mainAgent") return;
+  if (ctx.systemPrompt == null) return;
+  // Re-entrant calls within a turn rebuild from the base prompt, but guard
+  // anyway so the block is never stacked.
+  if (ctx.systemPrompt.includes(INITIATIVE_COACHING_TEXT)) return;
+
+  let model: string;
+  try {
+    model = resolveCallSiteConfig("mainAgent", getConfigReadOnly().llm).model;
+  } catch {
+    // Config unavailable — leave the prompt untouched.
+    return;
+  }
+  if (!isWeakOpenModel(model)) return;
+
+  ctx.systemPrompt = `${ctx.systemPrompt}\n\n${INITIATIVE_COACHING_TEXT}`;
+  ctx.logger.info(
+    { plugin: "agentic-initiative", model },
+    "Appended initiative + grounding coaching for weak open model",
+  );
+};
+
+export default preModelCall;

--- a/assistant/src/plugins/defaults/agentic-initiative/package.json
+++ b/assistant/src/plugins/defaults/agentic-initiative/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "default-agentic-initiative",
+  "version": "1.0.0",
+  "description": "First-party default plugin contributing a pre-model-call hook that appends verify-before-asserting and attempt-don't-ask coaching to the user-facing system prompt on weak open models.",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "main": "./register.ts",
+  "engines": {
+    "node": ">=20.12.0"
+  },
+  "peerDependencies": {
+    "@vellumai/plugin-api": "^0.8.0"
+  }
+}

--- a/assistant/src/plugins/defaults/exploration-drift/hooks/post-tool-use.ts
+++ b/assistant/src/plugins/defaults/exploration-drift/hooks/post-tool-use.ts
@@ -58,6 +58,7 @@
 import type { PluginHookFn, PostToolUseContext } from "@vellumai/plugin-api";
 
 import type { Message } from "../../../../providers/types.js";
+import { WEAK_OPEN_MODEL_PATTERN } from "../../../../providers/weak-open-model.js";
 
 /**
  * Canonical long-dig notice. Module-level constant so tests and wrapping
@@ -94,13 +95,11 @@ export const EXPLORATION_NUDGE_THRESHOLD = 25;
 export const EXPLORATION_LOOP_REPEAT_THRESHOLD = 3;
 
 /**
- * Models that get the early loop trigger: Kimi K2.6 and MiniMax M3, matched
- * across provider naming conventions (Fireworks spells the dot as `p`, e.g.
- * `accounts/fireworks/models/kimi-k2p6`; OpenRouter reports
- * `moonshotai/kimi-k2.6` and `minimax/minimax-m3`). Extend the pattern as
- * other models exhibit the same re-exploration looping.
+ * Models that get the early loop trigger — the shared weak-open-model set
+ * (Kimi K2.6, MiniMax M3), which exhibits the re-exploration looping this
+ * trigger catches.
  */
-const LOOP_PRONE_MODEL_PATTERN = /kimi-k2[p.]6|minimax-m3/i;
+const LOOP_PRONE_MODEL_PATTERN = WEAK_OPEN_MODEL_PATTERN;
 
 /** Read-only exploration tools whose unbroken runs indicate inline drift. */
 const EXPLORATION_TOOL_NAMES: ReadonlySet<string> = new Set([

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -26,6 +26,8 @@
 
 import { registerPlugin, resetPluginRegistryForTests } from "../registry.js";
 import { type Plugin, PluginExecutionError } from "../types.js";
+import agenticInitiativePreModelCall from "./agentic-initiative/hooks/pre-model-call.js";
+import agenticInitiativePkg from "./agentic-initiative/package.json" with { type: "json" };
 import compactionPkg from "./compaction/package.json" with { type: "json" };
 import emptyResponsePostModelCall from "./empty-response/hooks/post-model-call.js";
 import emptyResponseStop from "./empty-response/hooks/stop.js";
@@ -240,6 +242,21 @@ export const defaultExplorationDriftPlugin: Plugin = {
 };
 
 /**
+ * `agentic-initiative` — a `pre-model-call` hook that appends
+ * verify-before-asserting and attempt-don't-ask coaching to the user-facing
+ * system prompt when the resolved main-agent model is a weak open model.
+ */
+export const defaultAgenticInitiativePlugin: Plugin = {
+  manifest: {
+    name: agenticInitiativePkg.name,
+    version: agenticInitiativePkg.version,
+  },
+  hooks: {
+    "pre-model-call": agenticInitiativePreModelCall,
+  },
+};
+
+/**
  * `tool-result-truncate` — a `post-tool-use` hook that tail-drops an oversized
  * tool result down to a character budget derived from the model's context
  * window before the result is sent to the provider.
@@ -268,6 +285,7 @@ function getAllDefaultPlugins(): readonly Plugin[] {
     defaultMaxTokensContinuePlugin,
     defaultToolErrorPlugin,
     defaultExplorationDriftPlugin,
+    defaultAgenticInitiativePlugin,
     defaultHistoryRepairPlugin,
     defaultImageRecoveryPlugin,
     defaultCompactionPlugin,

--- a/assistant/src/providers/weak-open-model.ts
+++ b/assistant/src/providers/weak-open-model.ts
@@ -1,0 +1,21 @@
+/**
+ * Classifier for the open models the assistant ships as lower-cost profiles
+ * (currently Kimi K2.6 and MiniMax M3, the `balanced-economy` / `open-router`
+ * profile models). These need explicit behavioral scaffolding that the managed
+ * Claude profiles do not: they re-issue identical exploration calls in a loop,
+ * confidently assert unverified facts, and defer to the user ("do you have X
+ * set up?") instead of just attempting an available tool. Default plugins gate
+ * model-specific nudges on this set.
+ *
+ * Matched across provider naming conventions: Fireworks spells the version dot
+ * as `p` (`accounts/fireworks/models/kimi-k2p6`,
+ * `accounts/fireworks/models/minimax-m3`); OpenRouter reports
+ * `moonshotai/kimi-k2.6` and `minimax/minimax-m3`. Extend the pattern as other
+ * models exhibit the same need.
+ */
+export const WEAK_OPEN_MODEL_PATTERN = /kimi-k2[p.]6|minimax-m3/i;
+
+/** True when `model` is an open model that needs extra behavioral scaffolding. */
+export function isWeakOpenModel(model: string): boolean {
+  return WEAK_OPEN_MODEL_PATTERN.test(model);
+}


### PR DESCRIPTION
## What

Adds a `pre-model-call` default plugin (`agentic-initiative`) that, **only for the user-facing reply (`mainAgent`) on a weak open model**, appends two short directives to the system prompt:

1. **Verify before asserting** — check infra facts (where something is hosted/deployed/stored/configured) with a read-only tool before stating them; don't infer from which integrations are connected, and don't state from memory.
2. **Attempt, don't ask** — try an available tool/connection and handle failure, rather than asking the user whether a capability is set up.

Also extracts the weak-open-model set (Kimi K2.6, MiniMax M3) into `providers/weak-open-model.ts` as a single source of truth, and points the existing `exploration-drift` loop trigger at it so the two model-gated behaviors can't drift apart.

## Why

Dogfood feedback on the **balanced-economy** profile (MiniMax M3): the assistant asserted the user's marketing site was hosted on **Vercel** (it runs on **GCP/Kubernetes**), built a measurement plan on the wrong host, and — once corrected — asked *"do you have gcloud set up?"* instead of just running it. Both are behaviors the managed Claude profiles don't exhibit. `SOUL.md` already says "be resourceful before asking," but the weaker open models don't reliably follow prose shared with every model — so this gives them a firmer, model-gated restatement at the seam right before the provider call.

This is **C1** of a two-PR response; **B1** (#34952) fixes the connected-services prompt block that anchored the Vercel hallucination.

## Scope / cost

- Gated three ways: `callSite === "mainAgent"`, resolved model is a weak open model, and idempotent append. **Managed Claude profiles pay nothing** — the block is never appended for them, so the always-on prompt is untouched for the common path.
- Delivered via `pre-model-call` (mutates the per-call `systemPrompt`) rather than the always-on system-prompt sections, keeping it out of the cached prefix for strong models.

## Known limitation (reviewer focus)

The model is resolved from the **workspace active profile** (`resolveCallSiteConfig`), matching how the chat-model selector works. A **per-conversation inference-profile override** isn't visible at the `pre-model-call` seam, so a conversation that overrides onto a weak model while the workspace active profile is a managed one is **not** coached. The failure mode is only a *missing* nudge, never a wrong one. If we want per-conversation fidelity, the follow-up is to thread the resolved model onto `PreModelCallContext` from the agent loop (where it's ground-truth) — I kept this PR off the hot loop deliberately.

Also worth a look: the coaching wording/altitude, and whether "attempt don't ask" needs a sharper carve-out for destructive actions (current text exempts "destructive or genuinely ambiguous").

## Test

`assistant/src/__tests__/agentic-initiative-hook.test.ts` — model-spelling coverage for the classifier, plus the hook's gates (weak vs managed model, non-mainAgent skip, null prompt, idempotency). Exploration-drift suite still green (23 pass) after the shared-classifier refactor; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)