### PR TITLE
feat(schedule): persist a capability manifest column on cron_jobs

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -194,6 +194,7 @@ import {
   migrateRenameVerificationSessionIdColumn,
   migrateRenameVerificationTable,
   migrateRenameVoiceToPhone,
+  migrateScheduleCapabilities,
   migrateScheduleDescription,
   migrateScheduleInferenceProfile,
   migrateScheduleOneShotRouting,
@@ -516,6 +517,7 @@ export function initializeDb(): void {
     migrateConversationOriginChannelIndex,
     migrateBackfillOriginChannelFromBindings,
     migrateContactChannelsUniqueExtUser,
+    migrateScheduleCapabilities,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/290-schedule-capabilities.test.ts
+++ b/assistant/src/memory/migrations/290-schedule-capabilities.test.ts
@@ -1,0 +1,77 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import * as schema from "../schema.js";
+import { migrateScheduleCapabilities } from "./290-schedule-capabilities.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  // Pre-290 shape: no capabilities_json column (trimmed to the columns the
+  // migration and assertions touch).
+  sqlite.exec(/*sql*/ `
+    CREATE TABLE cron_jobs (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      message TEXT NOT NULL,
+      next_run_at INTEGER NOT NULL,
+      created_by TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+  return { sqlite, db: drizzle(sqlite, { schema }) };
+}
+
+function columnNames(sqlite: Database): string[] {
+  return (
+    sqlite.query("PRAGMA table_info(cron_jobs)").all() as Array<{
+      name: string;
+    }>
+  ).map((c) => c.name);
+}
+
+describe("migration 290: cron_jobs capabilities_json", () => {
+  test("adds a nullable capabilities_json column", () => {
+    const { sqlite, db } = createTestDb();
+    expect(columnNames(sqlite)).not.toContain("capabilities_json");
+
+    migrateScheduleCapabilities(db);
+
+    const column = (
+      sqlite.query("PRAGMA table_info(cron_jobs)").all() as Array<{
+        name: string;
+        notnull: number;
+      }>
+    ).find((c) => c.name === "capabilities_json");
+    expect(column).toBeDefined();
+    expect(column?.notnull).toBe(0);
+  });
+
+  test("existing rows read back with capabilities_json null", () => {
+    const { sqlite, db } = createTestDb();
+    sqlite.exec(/*sql*/ `
+      INSERT INTO cron_jobs (id, name, message, next_run_at, created_by, created_at, updated_at)
+      VALUES ('job-1', 'Daily digest', 'write the digest', 1000, 'agent', 1000, 1000)
+    `);
+
+    migrateScheduleCapabilities(db);
+
+    const row = sqlite
+      .query("SELECT capabilities_json FROM cron_jobs WHERE id = 'job-1'")
+      .get() as { capabilities_json: string | null };
+    expect(row.capabilities_json).toBeNull();
+  });
+
+  test("is idempotent — re-run is a no-op", () => {
+    const { sqlite, db } = createTestDb();
+
+    migrateScheduleCapabilities(db);
+    expect(() => migrateScheduleCapabilities(db)).not.toThrow();
+
+    expect(
+      columnNames(sqlite).filter((name) => name === "capabilities_json"),
+    ).toHaveLength(1);
+  });
+});

--- a/assistant/src/memory/migrations/290-schedule-capabilities.ts
+++ b/assistant/src/memory/migrations/290-schedule-capabilities.ts
@@ -1,0 +1,25 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Add a nullable `capabilities_json TEXT` column to `cron_jobs`.
+ *
+ * Persists the capability manifest a scheduled workflow run should execute
+ * under. `NULL` (all pre-existing rows) means no persisted manifest — runs
+ * fall back to the hardcoded read-only manifest.
+ *
+ * Idempotent — the PRAGMA guard makes re-running a no-op once the column
+ * exists.
+ */
+export function migrateScheduleCapabilities(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  const columns = raw.query(`PRAGMA table_info(cron_jobs)`).all() as Array<{
+    name: string;
+  }>;
+  const columnNames = new Set(columns.map((c) => c.name));
+
+  if (!columnNames.has("capabilities_json")) {
+    raw.exec(`ALTER TABLE cron_jobs ADD COLUMN capabilities_json TEXT`);
+  }
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -281,6 +281,7 @@ export { migrateWorkflowRunTrust } from "./286-workflow-run-trust.js";
 export { migrateConversationOriginChannelIndex } from "./287-conversation-origin-channel-index.js";
 export { migrateBackfillOriginChannelFromBindings } from "./288-backfill-origin-channel-from-bindings.js";
 export { migrateContactChannelsUniqueExtUser } from "./289-contact-channels-unique-ext-user.js";
+export { migrateScheduleCapabilities } from "./290-schedule-capabilities.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/infrastructure.ts
+++ b/assistant/src/memory/schema/infrastructure.ts
@@ -38,6 +38,7 @@ export const cronJobs = sqliteTable("cron_jobs", {
   wakeConversationId: text("wake_conversation_id"), // target conversation for wake mode (nullable)
   workflowName: text("workflow_name"), // saved workflow to trigger (nullable, only used when mode = 'workflow')
   workflowArgsJson: text("workflow_args_json"), // JSON-encoded args passed to the workflow run (nullable)
+  capabilitiesJson: text("capabilities_json"), // JSON-encoded capability manifest for the run (nullable; null = hardcoded read-only manifest)
   createdAt: integer("created_at").notNull(),
   updatedAt: integer("updated_at").notNull(),
 });

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -191,6 +191,7 @@ export function createSchedule(params: {
       params.workflowArgs === undefined
         ? null
         : JSON.stringify(params.workflowArgs),
+    capabilitiesJson: null as string | null,
     nextRunAt,
     lastRunAt: null as number | null,
     lastStatus: null as string | null,


### PR DESCRIPTION
## Summary
- Add nullable capabilities_json column to cron_jobs (migration + Drizzle schema + registration).
- Additive; later PRs plumb and use it. Existing rows read back null.

Part of plan: workflow-engine-followups.md (PR 7 of 11)