### PR TITLE
fix(skills): rescue misplaced skill_execute params instead of dropping them

### DIFF
--- a/assistant/src/__tests__/skill-execute-input.test.ts
+++ b/assistant/src/__tests__/skill-execute-input.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveSkillExecuteInput } from "../tools/skills/execute.js";
+
+describe("resolveSkillExecuteInput", () => {
+  test("returns a correctly nested object unchanged", () => {
+    const input = { prompt: "a sunset", variants: 2 };
+    const result = resolveSkillExecuteInput({
+      tool: "media_generate_image",
+      input,
+      activity: "Generating image",
+    });
+    expect(result).toEqual(input);
+  });
+
+  test("rescues parameters spread as top-level siblings", () => {
+    // Weak model put `prompt` next to `tool`/`activity` instead of under `input`.
+    const result = resolveSkillExecuteInput({
+      tool: "media_generate_image",
+      activity: "Generating image",
+      prompt: "a sunset over the ocean",
+      variants: 2,
+    });
+    expect(result).toEqual({ prompt: "a sunset over the ocean", variants: 2 });
+  });
+
+  test("rescues siblings when input is an empty object", () => {
+    // The exact shape from the room-redesign failure: `input: {}` plus the
+    // real parameter placed at the top level.
+    const result = resolveSkillExecuteInput({
+      tool: "media_generate_image",
+      input: {},
+      activity: "Generating room concept image",
+      prompt: "a cozy living room",
+    });
+    expect(result).toEqual({ prompt: "a cozy living room" });
+  });
+
+  test("parses input passed as a JSON string", () => {
+    const result = resolveSkillExecuteInput({
+      tool: "media_generate_image",
+      input: '{"prompt":"a sunset","variants":3}',
+      activity: "Generating image",
+    });
+    expect(result).toEqual({ prompt: "a sunset", variants: 3 });
+  });
+
+  test("non-empty nested object wins over stray siblings", () => {
+    const result = resolveSkillExecuteInput({
+      tool: "media_generate_image",
+      input: { prompt: "the real prompt" },
+      activity: "Generating image",
+      prompt: "a stray sibling",
+    });
+    expect(result).toEqual({ prompt: "the real prompt" });
+  });
+
+  test("returns empty object when no parameters are present anywhere", () => {
+    const result = resolveSkillExecuteInput({
+      tool: "media_generate_image",
+      input: {},
+      activity: "Generating image",
+    });
+    expect(result).toEqual({});
+  });
+
+  test("does not treat a JSON array string as input", () => {
+    // An array isn't a valid parameter map; fall through to (absent) siblings.
+    const result = resolveSkillExecuteInput({
+      tool: "some_tool",
+      input: "[1,2,3]",
+      activity: "Doing work",
+    });
+    expect(result).toEqual({});
+  });
+
+  test("ignores envelope keys when rescuing siblings", () => {
+    const result = resolveSkillExecuteInput({
+      tool: "some_tool",
+      activity: "Doing work",
+      foo: "bar",
+    });
+    expect(result).toEqual({ foo: "bar" });
+  });
+});

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -26,6 +26,7 @@ import {
   ACTIVITY_SKIP_SET,
   injectActivityField,
 } from "../tools/schema-transforms.js";
+import { resolveSkillExecuteInput } from "../tools/skills/execute.js";
 import { resolveToolInvocationAlias } from "../tools/tool-name-aliases.js";
 import {
   isDiskPressureCleanupToolName,
@@ -296,10 +297,7 @@ export function createToolExecutor(
     if (executionName === "skill_execute") {
       const rawToolName =
         typeof executionInput.tool === "string" ? executionInput.tool : "";
-      const rawToolInput =
-        executionInput.input != null && typeof executionInput.input === "object"
-          ? (executionInput.input as Record<string, unknown>)
-          : {};
+      const rawToolInput = resolveSkillExecuteInput(executionInput);
 
       // Clone to avoid mutating shared input objects
       const { name: toolName, input: toolInput } = resolveToolInvocationAlias(

--- a/assistant/src/tools/skills/execute.ts
+++ b/assistant/src/tools/skills/execute.ts
@@ -6,6 +6,62 @@ import type {
   ToolExecutionResult,
 } from "../types.js";
 
+/** Envelope keys consumed by `skill_execute` itself, never inner-tool params. */
+const SKILL_EXECUTE_ENVELOPE_KEYS = new Set(["tool", "input", "activity"]);
+
+/**
+ * Resolve the inner tool's parameters from a `skill_execute` envelope.
+ *
+ * The documented contract is `{ tool, input: {...}, activity }` — the inner
+ * tool's parameters nested under `input`. A correctly nested, non-empty object
+ * is returned unchanged, so well-formed callers are unaffected.
+ *
+ * Weaker models routinely misplace the parameters. Left unhandled, the inner
+ * tool receives `{}`, fails schema validation ("<field> is required"), and the
+ * model retries the identical malformed call until it gives up — the empty-
+ * input retry loop. Two common misplacements are rescued so the call can
+ * succeed instead:
+ *
+ * 1. `input` passed as a JSON-encoded string instead of an object.
+ * 2. Parameters spread as top-level siblings of `tool`/`activity`, with `input`
+ *    absent or an empty object.
+ */
+export function resolveSkillExecuteInput(
+  envelope: Record<string, unknown>,
+): Record<string, unknown> {
+  const raw = envelope.input;
+
+  if (raw != null && typeof raw === "object" && !Array.isArray(raw)) {
+    const obj = raw as Record<string, unknown>;
+    // A populated object is the well-formed case. An empty object falls
+    // through to sibling rescue: the model may have nested nothing yet placed
+    // the real parameters at the top level.
+    if (Object.keys(obj).length > 0) return obj;
+  } else if (typeof raw === "string" && raw.trim()) {
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      if (
+        parsed != null &&
+        typeof parsed === "object" &&
+        !Array.isArray(parsed)
+      ) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Not JSON — fall through to sibling rescue.
+    }
+  }
+
+  const siblings = Object.fromEntries(
+    Object.entries(envelope).filter(
+      ([key]) => !SKILL_EXECUTE_ENVELOPE_KEYS.has(key),
+    ),
+  );
+  if (Object.keys(siblings).length > 0) return siblings;
+
+  return {};
+}
+
 export const skillExecuteTool = {
   name: "skill_execute",
   description:


### PR DESCRIPTION
## Problem

On the **economy** profile (a weak open model), asking the assistant to generate images error-looped for ~5 minutes. Every `media_generate_image` call showed `input: {}` and failed with `Invalid input for tool "media_generate_image": prompt is required. Fix the arguments and retry.` — the model retried the identical malformed call ~24 times without recovering.

Root cause: skill-tool schemas are **not** sent to the LLM (`conversation-skill-tools.ts` returns no tool definitions); tools are driven through the generic `skill_execute` envelope `{ tool, input, activity }` using SKILL.md prose. The dispatch interceptor coerced any non-object `input` to `{}`:

```ts
const rawToolInput =
  executionInput.input != null && typeof executionInput.input === "object"
    ? executionInput.input : {};
```

So when a weak model misplaced the inner tool's parameters, they were **silently dropped** and the inner tool received `{}`. The resulting `"<field> is required"` error never hints that the params went to the wrong nesting level, so the model can't self-correct.

## Fix

Add `resolveSkillExecuteInput()` (in `tools/skills/execute.ts`) and use it in the dispatch interceptor. It recovers the three real-world misplacements:

1. `input` passed as a **JSON-encoded string** instead of an object.
2. Parameters spread as **top-level siblings** of `tool`/`activity`.
3. `input: {}` (empty) **plus** the real params placed at the top level.

A correctly nested, **non-empty** `input` object is returned unchanged, so well-formed callers are unaffected — the rescue only runs on the failure path. **No behavior change for capable models.**

## Scope / non-goals

This fixes the dominant failure (the loop). A related, separate issue is **deferred**: when history compaction drops a skill's `<loaded_skill>` activation marker, the skill deactivates mid-conversation and its tool flips to an "unknown tool" confirmation prompt that errors on Allow. That needs a compaction-pipeline change and is tracked separately. Fixing the loop here makes that path far less likely to trigger (no 5-minute loop → no compaction).

## Testing

- New unit tests: `assistant/src/__tests__/skill-execute-input.test.ts` (8 cases — correct nesting, sibling rescue, empty-`input` + siblings, JSON-string `input`, non-empty object wins over strays, no-params, array-string guard, envelope-key exclusion).
- Existing `skill_execute` dispatch tests still green; `tsc` and lint clean.
