### PR TITLE
feat(schedule): read/write capability manifest in the schedule store

### DIFF
--- a/assistant/src/__tests__/schedule-store.test.ts
+++ b/assistant/src/__tests__/schedule-store.test.ts
@@ -1170,6 +1170,66 @@ describe("script timeout override", () => {
   });
 });
 
+// ── Capability manifest ─────────────────────────────────────────────
+
+describe("capability manifest", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run("DELETE FROM cron_runs");
+    db.run("DELETE FROM cron_jobs");
+  });
+
+  const manifest = {
+    tools: ["file_write"],
+    hostFunctions: [],
+    persona: false,
+  };
+
+  test("persists a capability manifest through create/read", () => {
+    const job = createSchedule({
+      name: "Capable schedule",
+      cronExpression: "0 9 * * *",
+      message: "do scoped work",
+      syntax: "cron",
+      capabilities: manifest,
+    });
+
+    expect(job.capabilities).toEqual(manifest);
+    expect(getSchedule(job.id)!.capabilities).toEqual(manifest);
+  });
+
+  test("defaults capabilities to null when not provided", () => {
+    const job = createSchedule({
+      name: "No manifest",
+      cronExpression: "0 9 * * *",
+      message: "unconstrained",
+      syntax: "cron",
+    });
+
+    expect(job.capabilities).toBeNull();
+    expect(getSchedule(job.id)!.capabilities).toBeNull();
+  });
+
+  test("updateSchedule sets and clears the capability manifest", () => {
+    const job = createSchedule({
+      name: "Update manifest",
+      cronExpression: "0 9 * * *",
+      message: "update manifest",
+      syntax: "cron",
+    });
+
+    expect(job.capabilities).toBeNull();
+
+    const updated = updateSchedule(job.id, { capabilities: manifest });
+    expect(updated!.capabilities).toEqual(manifest);
+    expect(getSchedule(job.id)!.capabilities).toEqual(manifest);
+
+    const cleared = updateSchedule(job.id, { capabilities: null });
+    expect(cleared!.capabilities).toBeNull();
+    expect(getSchedule(job.id)!.capabilities).toBeNull();
+  });
+});
+
 // ── listSchedules filters ───────────────────────────────────────────
 
 describe("listSchedules filters", () => {

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -51,6 +51,8 @@ export interface ScheduleJob {
   workflowName: string | null;
   /** Args passed verbatim to the workflow run; only used when mode = 'workflow'. */
   workflowArgs: unknown;
+  /** Capability manifest scoping the schedule's run; null = unconstrained. */
+  capabilities: unknown | null;
   nextRunAt: number;
   lastRunAt: number | null;
   lastStatus: string | null;
@@ -108,6 +110,7 @@ export function createSchedule(params: {
   wakeConversationId?: string | null;
   workflowName?: string | null;
   workflowArgs?: unknown;
+  capabilities?: unknown;
   enabled?: boolean;
   createdBy?: string;
   syntax?: ScheduleSyntax;
@@ -191,7 +194,8 @@ export function createSchedule(params: {
       params.workflowArgs === undefined
         ? null
         : JSON.stringify(params.workflowArgs),
-    capabilitiesJson: null as string | null,
+    capabilitiesJson:
+      params.capabilities != null ? JSON.stringify(params.capabilities) : null,
     nextRunAt,
     lastRunAt: null as number | null,
     lastStatus: null as string | null,
@@ -300,6 +304,7 @@ export function updateSchedule(
     wakeConversationId?: string | null;
     workflowName?: string | null;
     workflowArgs?: unknown;
+    capabilities?: unknown;
     maxRetries?: number;
     retryBackoffMs?: number;
     timeoutMs?: number | null;
@@ -377,6 +382,13 @@ export function updateSchedule(
       updates.workflowArgs === undefined
         ? null
         : JSON.stringify(updates.workflowArgs);
+  // `capabilities` may legitimately be any JSON value (including null), so
+  // detect presence by key rather than `!== undefined`.
+  if ("capabilities" in updates)
+    set.capabilitiesJson =
+      updates.capabilities == null
+        ? null
+        : JSON.stringify(updates.capabilities);
   if (updates.maxRetries !== undefined) set.maxRetries = updates.maxRetries;
   if (updates.retryBackoffMs !== undefined)
     set.retryBackoffMs = updates.retryBackoffMs;
@@ -1089,6 +1101,7 @@ function parseJobRow(row: typeof scheduleJobs.$inferSelect): ScheduleJob {
     wakeConversationId: row.wakeConversationId ?? null,
     workflowName: row.workflowName ?? null,
     workflowArgs: parseOptionalJson(row.workflowArgsJson),
+    capabilities: parseOptionalJson(row.capabilitiesJson),
     nextRunAt: row.nextRunAt,
     lastRunAt: row.lastRunAt,
     lastStatus: row.lastStatus,


### PR DESCRIPTION
## Summary
- Thread capabilities through createSchedule/updateSchedule (serialize to capabilities_json) and parseJobRow (parse back). Absent manifest reads back null.

Part of plan: workflow-engine-followups.md (PR 8 of 11)