### PR TITLE
feat(workflows): serve run_workflow / manage_workflows via the workflows skill

### DIFF
--- a/assistant/src/config/bundled-skills/workflows/TOOLS.json
+++ b/assistant/src/config/bundled-skills/workflows/TOOLS.json
@@ -1,0 +1,77 @@
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "run_workflow",
+      "description": "Launch an autonomous, multi-agent workflow from a script you author (or by saved name); returns a runId immediately and notifies this conversation on completion. See SKILL.md for the full script-authoring contract.",
+      "category": "workflow",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "script": {
+            "type": "string",
+            "description": "Inline workflow source (JavaScript/TypeScript) following the authoring contract. Provide this OR name, not both."
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of a previously saved workflow to run. Provide this OR script, not both."
+          },
+          "args": {
+            "type": "object",
+            "description": "Verbatim input object exposed to the script as `args`. Pass timestamps/seeds here (the script may not generate them)."
+          },
+          "capabilities": {
+            "type": "object",
+            "description": "Per-run capability grant (the single consent point). Leaves get a read-only baseline by default.",
+            "properties": {
+              "tools": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Side-effecting tool names granted to leaves on top of the read-only baseline."
+              },
+              "hostFunctions": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Host-function names the run may invoke."
+              },
+              "persona": {
+                "type": "boolean",
+                "description": "Grant leaves access to persona (identity + memory) context."
+              }
+            }
+          },
+          "label": {
+            "type": "string",
+            "description": "Human-readable label for display; defaults to the script's meta.name."
+          }
+        }
+      },
+      "executor": "tools/run-workflow.ts",
+      "execution_target": "host"
+    },
+    {
+      "name": "manage_workflows",
+      "description": "Inspect or control workflow runs started by run_workflow: status, abort, resume, list_runs, and list_profiles. See SKILL.md for details.",
+      "category": "workflow",
+      "risk": "low",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": ["status", "abort", "resume", "list_runs", "list_profiles"],
+            "description": "What to do."
+          },
+          "run_id": {
+            "type": "string",
+            "description": "Target run id (required for \"status\", \"abort\", and \"resume\")."
+          }
+        },
+        "required": ["action"]
+      },
+      "executor": "tools/manage-workflows.ts",
+      "execution_target": "host"
+    }
+  ]
+}

--- a/assistant/src/config/bundled-skills/workflows/tools/manage-workflows.ts
+++ b/assistant/src/config/bundled-skills/workflows/tools/manage-workflows.ts
@@ -1,0 +1,12 @@
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { executeManageWorkflows } from "../../../../tools/workflows/manage-workflows.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeManageWorkflows(input, context);
+}

--- a/assistant/src/config/bundled-skills/workflows/tools/run-workflow.ts
+++ b/assistant/src/config/bundled-skills/workflows/tools/run-workflow.ts
@@ -1,0 +1,12 @@
+import type {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../tools/types.js";
+import { executeRunWorkflow } from "../../../../tools/workflows/run-workflow.js";
+
+export async function run(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  return executeRunWorkflow(input, context);
+}

--- a/assistant/src/config/bundled-tool-registry.ts
+++ b/assistant/src/config/bundled-tool-registry.ts
@@ -129,6 +129,9 @@ import * as subagentSpawn from "./bundled-skills/subagent/tools/subagent-spawn.j
 import * as subagentStatus from "./bundled-skills/subagent/tools/subagent-status.js";
 // ── transcribe ─────────────────────────────────────────────────────────────────
 import * as transcribeMedia from "./bundled-skills/transcribe/tools/transcribe-media.js";
+// ── workflows ──────────────────────────────────────────────────────────────────
+import * as manageWorkflows from "./bundled-skills/workflows/tools/manage-workflows.js";
+import * as runWorkflow from "./bundled-skills/workflows/tools/run-workflow.js";
 
 // ─── Registry ────────────────────────────────────────────────────────────────
 
@@ -274,4 +277,8 @@ export const bundledToolRegistry = new Map<string, SkillToolScript>([
 
   // transcribe
   ["transcribe:tools/transcribe-media.ts", transcribeMedia],
+
+  // workflows
+  ["workflows:tools/run-workflow.ts", runWorkflow],
+  ["workflows:tools/manage-workflows.ts", manageWorkflows],
 ]);

--- a/assistant/src/tools/flag-gated-tools.test.ts
+++ b/assistant/src/tools/flag-gated-tools.test.ts
@@ -17,14 +17,12 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-// Controllable gated-tool sets. `syncFlagGatedTools()` dynamically imports
-// `./tool-manifest.js` and reads only these two helpers, so mocking them lets a
-// test simulate "flag enabled" (non-empty) vs "flag off / not yet loaded" ([]).
+// Controllable gated-tool set. `syncFlagGatedTools()` dynamically imports
+// `./tool-manifest.js` and reads only this helper, so mocking it lets a test
+// simulate "flag enabled" (non-empty) vs "flag off / not yet loaded" ([]).
 let cesEnabled: Array<{ name: string }> = [];
-let workflowEnabled: Array<{ name: string }> = [];
 mock.module("./tool-manifest.js", () => ({
   getCesToolsIfEnabled: () => cesEnabled,
-  getWorkflowToolsIfEnabled: () => workflowEnabled,
 }));
 
 import {
@@ -49,22 +47,12 @@ describe("syncFlagGatedTools", () => {
   beforeEach(() => {
     __clearRegistryForTesting();
     cesEnabled = [];
-    workflowEnabled = [];
   });
 
-  test("registers a workflow tool that startup registration missed (the race)", async () => {
-    workflowEnabled = [fakeTool("run_workflow"), fakeTool("manage_workflows")];
-    // Simulates initializeTools() having run before the flag was known.
-    expect(getTool("run_workflow")).toBeUndefined();
-
-    await syncFlagGatedTools();
-
-    expect(getTool("run_workflow")).toBeDefined();
-    expect(getTool("manage_workflows")).toBeDefined();
-  });
-
-  test("registers enabled CES tools by the same path", async () => {
+  test("registers a CES tool that startup registration missed (the race)", async () => {
     cesEnabled = [fakeTool("make_authenticated_request")];
+    // Simulates initializeTools() having run before the flag was known.
+    expect(getTool("make_authenticated_request")).toBeUndefined();
 
     await syncFlagGatedTools();
 
@@ -72,18 +60,17 @@ describe("syncFlagGatedTools", () => {
   });
 
   test("is idempotent — re-running does not throw or duplicate", async () => {
-    workflowEnabled = [fakeTool("run_workflow")];
+    cesEnabled = [fakeTool("make_authenticated_request")];
 
     await syncFlagGatedTools();
     await syncFlagGatedTools();
 
-    expect(getTool("run_workflow")).toBeDefined();
+    expect(getTool("make_authenticated_request")).toBeDefined();
   });
 
   test("registers nothing when no gated flag is enabled", async () => {
     await syncFlagGatedTools();
 
-    expect(getTool("run_workflow")).toBeUndefined();
     expect(getTool("make_authenticated_request")).toBeUndefined();
   });
 });

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -856,8 +856,6 @@ export async function initializeTools(): Promise<void> {
     explicitTools,
     getCesToolsIfEnabled,
     cesTools,
-    getWorkflowToolsIfEnabled,
-    workflowTools,
   } = await import("./tool-manifest.js");
 
   // Capture tool names already in the registry before any manifest
@@ -904,12 +902,6 @@ export async function initializeTools(): Promise<void> {
     registerTool(tool);
   }
 
-  // Workflow tools - registered only when the `workflows` feature flag is on.
-  const activeWorkflowTools = getWorkflowToolsIfEnabled();
-  for (const tool of activeWorkflowTools) {
-    registerTool(tool);
-  }
-
   registerUiSurfaceTools();
   registerAppTools();
   registerSystemTools();
@@ -932,7 +924,6 @@ export async function initializeTools(): Promise<void> {
       ...extEntries.map(({ tool }) => tool.name),
       ...hostTools.map((t) => t.name!),
       ...cesTools.map((t) => t.name!),
-      ...workflowTools.map((t) => t.name!),
       ...allUiSurfaceTools.map((t) => t.name!),
       ...coreAppProxyTools.map((t) => t.name!),
     ]);
@@ -965,8 +956,8 @@ export async function initializeTools(): Promise<void> {
 }
 
 /**
- * Register any feature-flag-gated tools (CES `ces-tools`, `workflows`) that are
- * enabled but not yet in the registry. Idempotent and safe to call repeatedly.
+ * Register any feature-flag-gated tools (CES `ces-tools`) that are enabled but
+ * not yet in the registry. Idempotent and safe to call repeatedly.
  *
  * `initializeTools()` registers the gated tools once at startup, but feature-flag
  * overrides are fetched from the gateway ASYNCHRONOUSLY and non-blocking (see
@@ -984,9 +975,8 @@ export async function initializeTools(): Promise<void> {
  */
 export async function syncFlagGatedTools(): Promise<void> {
   try {
-    const { getCesToolsIfEnabled, getWorkflowToolsIfEnabled } =
-      await import("./tool-manifest.js");
-    const enabled = [...getCesToolsIfEnabled(), ...getWorkflowToolsIfEnabled()];
+    const { getCesToolsIfEnabled } = await import("./tool-manifest.js");
+    const enabled = [...getCesToolsIfEnabled()];
     const added: string[] = [];
     for (const tool of enabled) {
       if (tool.name && !tools.has(tool.name)) {

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -6,7 +6,6 @@
  * so adding/removing tools only requires editing this manifest.
  */
 
-import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
 import {
   isCesSecureInstallEnabled,
@@ -30,8 +29,6 @@ import { notifyParentTool } from "./subagent/notify-parent.js";
 import { requestSystemPermissionTool } from "./system/request-permission.js";
 import { shellTool } from "./terminal/shell.js";
 import type { ToolDefinition } from "./types.js";
-import { manageWorkflowsTool } from "./workflows/manage-workflows.js";
-import { runWorkflowTool } from "./workflows/run-workflow.js";
 
 // ── Eager side-effect modules ───────────────────────────────────────
 // These static imports trigger top-level `registerTool()` side effects on
@@ -135,34 +132,6 @@ export function getCesToolsIfEnabled(): ToolDefinition[] {
     }
   } catch {
     // Config not yet loaded (e.g. during test setup) - CES tools stay off.
-  }
-  return [];
-}
-
-// ── Workflow tools (feature-flag gated) ─────────────────────────────
-// The workflow orchestration tools (`run_workflow`, `manage_workflows`) are
-// only registered when the `workflows` feature flag is enabled. Kept separate
-// from `explicitTools` so initializeTools() can include them conditionally.
-
-/** All workflow tools - stable references for the manifest snapshot. */
-export const workflowTools: ToolDefinition[] = [
-  runWorkflowTool,
-  manageWorkflowsTool,
-];
-
-/**
- * Return the workflow tools only if the `workflows` feature flag is enabled.
- * Returns an empty array when the flag is off so callers can unconditionally
- * iterate the result.
- */
-export function getWorkflowToolsIfEnabled(): ToolDefinition[] {
-  try {
-    const config = getConfig();
-    if (isAssistantFeatureFlagEnabled("workflows", config)) {
-      return workflowTools;
-    }
-  } catch {
-    // Config not yet loaded (e.g. during test setup) - workflow tools stay off.
   }
   return [];
 }

--- a/assistant/src/tools/workflows/manage-workflows.ts
+++ b/assistant/src/tools/workflows/manage-workflows.ts
@@ -13,6 +13,7 @@
  * by the type checker.
  */
 
+import { loadConfig } from "../../config/loader.js";
 import { callerOwnsWorkflowRun } from "../../workflows/capabilities.js";
 import type { WorkflowRun } from "../../workflows/journal-store.js";
 import { getWorkflowRunManager } from "../../workflows/run-manager.js";
@@ -134,10 +135,25 @@ export async function executeManageWorkflows(
         isError: false,
       };
     }
+    case "list_profiles": {
+      // Mirror the `config/llm/profiles` route: sorted profile names plus the
+      // workspace-wide active profile. Read-only — leaves use this to pick a
+      // valid `profile` for `run_workflow` (an unknown profile throws).
+      const { llm } = loadConfig();
+      const profiles = llm?.profiles ?? {};
+      return {
+        content: JSON.stringify({
+          profiles: Object.keys(profiles).sort(),
+          activeProfile:
+            typeof llm?.activeProfile === "string" ? llm.activeProfile : null,
+        }),
+        isError: false,
+      };
+    }
     default:
       return {
         content:
-          'Unknown action. Use one of: "status", "abort", "resume", "list_runs".',
+          'Unknown action. Use one of: "status", "abort", "resume", "list_runs", "list_profiles".',
         isError: true,
       };
   }
@@ -146,7 +162,7 @@ export async function executeManageWorkflows(
 export const manageWorkflowsTool = {
   name: "manage_workflows",
   description:
-    'Inspect or control workflow runs started by run_workflow. action="status" (requires run_id) returns a run\'s status and counts; action="abort" (requires run_id) signals an in-flight run to stop; action="resume" (requires run_id) restarts an interrupted run (one orphaned by an assistant restart), replaying its journaled prefix and continuing from the first unfinished step; action="list_runs" returns recent runs newest-first.',
+    'Inspect or control workflow runs started by run_workflow. action="status" (requires run_id) returns a run\'s status and counts; action="abort" (requires run_id) signals an in-flight run to stop; action="resume" (requires run_id) restarts an interrupted run (one orphaned by an assistant restart), replaying its journaled prefix and continuing from the first unfinished step; action="list_runs" returns recent runs newest-first; action="list_profiles" returns the defined LLM profile names plus the active profile (use to pick a valid leaf `profile`).',
   // Low risk by default: status/list are pure reads; abort only signals an
   // existing run to stop; resuming a READ-ONLY run replays a journaled prefix
   // and continues under the same structural agent cap. Resuming a run whose
@@ -161,7 +177,7 @@ export const manageWorkflowsTool = {
     properties: {
       action: {
         type: "string",
-        enum: ["status", "abort", "resume", "list_runs"],
+        enum: ["status", "abort", "resume", "list_runs", "list_profiles"],
         description: "What to do.",
       },
       run_id: {

--- a/assistant/src/tools/workflows/run-workflow.test.ts
+++ b/assistant/src/tools/workflows/run-workflow.test.ts
@@ -25,6 +25,14 @@ mock.module("../../config/loader.js", () => ({
     if (configThrows) throw new Error("config not loaded");
     return {} as ReturnType<typeof realLoader.getConfig>;
   },
+  // manage_workflows `list_profiles` reads profiles via loadConfig().
+  loadConfig: () =>
+    ({
+      llm: {
+        profiles: { "cost-optimized": {}, balanced: {} },
+        activeProfile: "balanced",
+      },
+    }) as unknown as ReturnType<typeof realLoader.loadConfig>,
 }));
 
 const realFlags = await import("../../config/assistant-feature-flags.js");
@@ -69,7 +77,6 @@ mock.module("../../workflows/run-manager.js", () => ({
 }));
 
 // Imports AFTER mocks so the mocked modules are picked up.
-const { getWorkflowToolsIfEnabled } = await import("../tool-manifest.js");
 const { runWorkflowTool } = await import("./run-workflow.js");
 const { manageWorkflowsTool } = await import("./manage-workflows.js");
 const { WORKFLOW_READONLY_BASELINE } =
@@ -97,22 +104,28 @@ beforeEach(() => {
   resumeMock.mockClear();
 });
 
-describe("workflow tool registration gating", () => {
-  test("registers both tools when the workflows flag is enabled", () => {
-    flagEnabled = true;
-    const names = getWorkflowToolsIfEnabled().map((t) => t.name);
-    expect(names).toContain("run_workflow");
-    expect(names).toContain("manage_workflows");
-  });
-
-  test("registers nothing when the workflows flag is disabled", () => {
-    flagEnabled = false;
-    expect(getWorkflowToolsIfEnabled()).toEqual([]);
-  });
-
-  test("registers nothing when config is not yet loaded", () => {
-    configThrows = true;
-    expect(getWorkflowToolsIfEnabled()).toEqual([]);
+describe("workflow tools are served by the workflows skill", () => {
+  // The cutover moved run_workflow / manage_workflows out of the always-on tool
+  // manifest into the flag-gated `workflows` bundled skill (loaded via
+  // skill_load, invoked via skill_execute). The skill manifest is the
+  // source of truth; assert it declares both as in-process host tools.
+  test("the workflows skill TOOLS.json declares both host-executed tools", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    const manifest = JSON.parse(
+      readFileSync(
+        join(
+          import.meta.dir,
+          "../../config/bundled-skills/workflows/TOOLS.json",
+        ),
+        "utf-8",
+      ),
+    ) as {
+      tools: Array<{ name: string; execution_target: string }>;
+    };
+    const byName = new Map(manifest.tools.map((t) => [t.name, t]));
+    expect(byName.get("run_workflow")?.execution_target).toBe("host");
+    expect(byName.get("manage_workflows")?.execution_target).toBe("host");
   });
 });
 
@@ -291,6 +304,17 @@ describe("manage_workflows", () => {
     );
     expect(res.isError).toBe(true);
     expect(res.content).toContain("not resumable");
+  });
+
+  test("list_profiles returns sorted profile names and the active profile", async () => {
+    const res = await manageWorkflowsTool.execute(
+      { action: "list_profiles" },
+      makeContext(),
+    );
+    expect(res.isError).toBe(false);
+    const parsed = JSON.parse(res.content);
+    expect(parsed.profiles).toEqual(["balanced", "cost-optimized"]);
+    expect(parsed.activeProfile).toBe("balanced");
   });
 
   test("rejects an unknown action", async () => {


### PR DESCRIPTION
## Summary
- Move run_workflow + manage_workflows out of the always-on tool manifest into the flag-gated workflows bundled skill (skill_load + skill_execute, in-process host executors).
- Add manage_workflows list_profiles action ({ profiles, activeProfile }).
- requireFreshApproval consent gate preserved (executor keys on inner tool name).

Part of plan: workflow-engine-followups.md (PR 3 of 11)