### PR TITLE
feat(schedule): scheduled + run-now workflows use the persisted manifest

### DIFF
--- a/assistant/src/__tests__/schedule-routes-workflow-validation.test.ts
+++ b/assistant/src/__tests__/schedule-routes-workflow-validation.test.ts
@@ -319,6 +319,52 @@ describe("POST /schedules/:id/run — workflow mode triggers the workflow", () =
     expect(Array.isArray(result.schedules)).toBe(true);
   });
 
+  test("fires with the schedule's stored side-effecting manifest", async () => {
+    const schedule = createSchedule({
+      name: "Side-effecting workflow",
+      cronExpression: "0 9 * * *",
+      message: "",
+      syntax: "cron",
+      mode: "workflow",
+      workflowName: "send-report",
+      capabilities: {
+        tools: ["file_write"],
+        hostFunctions: ["notify"],
+        persona: true,
+      },
+    });
+
+    await runNowRoute().handler({ pathParams: { id: schedule.id } });
+
+    expect(workflowStartCalls).toHaveLength(1);
+    expect(workflowStartCalls[0]!.manifest).toEqual({
+      tools: ["file_write"],
+      hostFunctions: ["notify"],
+      persona: true,
+    });
+  });
+
+  test("a legacy schedule (null capabilities) fires with the read-only baseline", async () => {
+    const schedule = createSchedule({
+      name: "Legacy workflow",
+      cronExpression: "0 9 * * *",
+      message: "",
+      syntax: "cron",
+      mode: "workflow",
+      workflowName: "triage-inbox",
+      capabilities: null,
+    });
+
+    await runNowRoute().handler({ pathParams: { id: schedule.id } });
+
+    expect(workflowStartCalls).toHaveLength(1);
+    expect(workflowStartCalls[0]!.manifest).toEqual({
+      tools: [],
+      hostFunctions: [],
+      persona: false,
+    });
+  });
+
   test("rejects a workflow schedule with no workflowName", async () => {
     // Defensive guard mirroring the scheduler's automatic firing path; a
     // nameless workflow schedule cannot be created via the routes, but the store

--- a/assistant/src/__tests__/task-scheduler.test.ts
+++ b/assistant/src/__tests__/task-scheduler.test.ts
@@ -535,6 +535,60 @@ describe("scheduler workflow mode", () => {
     expect(runs[0].status).toBe("ok");
   });
 
+  test("fires with the schedule's stored side-effecting manifest", async () => {
+    const schedule = createSchedule({
+      name: "Side-effecting workflow",
+      cronExpression: "0 9 * * *",
+      message: "go",
+      syntax: "cron",
+      mode: "workflow",
+      workflowName: "send-report",
+      capabilities: {
+        tools: ["file_write"],
+        hostFunctions: ["notify"],
+        persona: true,
+      },
+    });
+    forceScheduleDue(schedule.id);
+
+    await runScheduleDueWorkOnce(
+      async () => {},
+      () => {},
+    );
+
+    expect(workflowStartCalls).toHaveLength(1);
+    expect(workflowStartCalls[0]).toMatchObject({
+      manifest: {
+        tools: ["file_write"],
+        hostFunctions: ["notify"],
+        persona: true,
+      },
+    });
+  });
+
+  test("a legacy schedule (null capabilities) fires with the read-only baseline", async () => {
+    const schedule = createSchedule({
+      name: "Legacy workflow",
+      cronExpression: "0 9 * * *",
+      message: "go",
+      syntax: "cron",
+      mode: "workflow",
+      workflowName: "digest",
+      capabilities: null,
+    });
+    forceScheduleDue(schedule.id);
+
+    await runScheduleDueWorkOnce(
+      async () => {},
+      () => {},
+    );
+
+    expect(workflowStartCalls).toHaveLength(1);
+    expect(workflowStartCalls[0]).toMatchObject({
+      manifest: { tools: [], hostFunctions: [], persona: false },
+    });
+  });
+
   test("falls back to createdFromConversationId for the completion wake", async () => {
     // Workflow schedules created via schedule_create store the originating
     // conversation as createdFromConversationId and leave wakeConversationId

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -42,6 +42,7 @@ import {
 import { getScheduleUsageSummaries } from "../../schedule/schedule-usage-store.js";
 import { areCoreToolsInitialized } from "../../tools/registry.js";
 import { getLogger } from "../../util/logger.js";
+import { normalizeCapabilityManifest } from "../../workflows/capabilities.js";
 import { getWorkflowRunManager } from "../../workflows/run-manager.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { parseEpochMillisRange } from "./epoch-millis-range.js";
@@ -974,10 +975,6 @@ async function handleRunScheduleNow(id: string) {
         },
         "Triggering workflow schedule manually (run now)",
       );
-      // V1 LIMITATION: scheduled workflows run with the read-only baseline
-      // manifest only (no tools / host functions / persona), exactly as the
-      // scheduler's automatic firing path does — the schedule record carries no
-      // capability manifest.
       const { runId: workflowRunId } = getWorkflowRunManager().start({
         name: schedule.workflowName,
         args: schedule.workflowArgs ?? {},
@@ -989,7 +986,10 @@ async function handleRunScheduleNow(id: string) {
           schedule.wakeConversationId ??
           schedule.createdFromConversationId ??
           undefined,
-        manifest: { tools: [], hostFunctions: [], persona: false },
+        // The schedule's persisted capability manifest scopes the run, mirroring
+        // the scheduler's firing path; a legacy schedule with null
+        // `capabilities` normalizes to the read-only baseline.
+        manifest: normalizeCapabilityManifest(schedule.capabilities),
         trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT,
       });
       // `start` launches the run fire-and-forget and returns synchronously;

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -14,6 +14,7 @@ import { runSequencesOnce } from "../sequence/engine.js";
 import { areCoreToolsInitialized } from "../tools/registry.js";
 import { getLogger } from "../util/logger.js";
 import { runWatchersOnce, type WatcherNotifier } from "../watcher/engine.js";
+import { normalizeCapabilityManifest } from "../workflows/capabilities.js";
 import { getWorkflowRunManager } from "../workflows/run-manager.js";
 import { hasSetConstructs } from "./recurrence-engine.js";
 import { applyRetryDecision, decideRetry } from "./retry-policy.js";
@@ -478,10 +479,6 @@ export async function runScheduleDueWorkOnce(
           },
           "Triggering workflow schedule",
         );
-        // V1 LIMITATION: scheduled workflows run with the read-only baseline
-        // manifest only (no tools / host functions / persona). The schedule
-        // record carries no capability manifest, so declaring side-effecting
-        // tools for scheduled runs is a future enhancement.
         const { runId: workflowRunId } = getWorkflowRunManager().start({
           name: job.workflowName,
           args: job.workflowArgs ?? {},
@@ -495,7 +492,10 @@ export async function runScheduleDueWorkOnce(
             job.wakeConversationId ??
             job.createdFromConversationId ??
             undefined,
-          manifest: { tools: [], hostFunctions: [], persona: false },
+          // The schedule's persisted capability manifest scopes the run; a
+          // legacy schedule with null `capabilities` normalizes to the read-only
+          // baseline.
+          manifest: normalizeCapabilityManifest(job.capabilities),
           trustContext: INTERNAL_GUARDIAN_TRUST_CONTEXT,
         });
         // `start` launches the run fire-and-forget and returns synchronously;


### PR DESCRIPTION
## Summary
- Scheduler auto-fire and run-now both pass the schedule's stored capability manifest to the workflow run (legacy/null → read-only baseline). Removes the V1 read-only-only limitation.

Part of plan: workflow-engine-followups.md (PR 10 of 11)