### PR TITLE
docs(workflows): skill invocation, threshold-aware approval, scheduled capabilities

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -655,24 +655,27 @@ End-to-end coverage lives in `assistant/src/__tests__/web-search-backend-failure
 
 ## Workflow Orchestration Engine
 
-The workflow engine lets the assistant author a short JS/TS script that runs in a sandbox and fans work out across many parallel, ephemeral **leaf agents** — for example: score every option in a list in parallel, then synthesize the winner. It is gated by the `workflows` feature flag (default off) and lives under `assistant/src/workflows/` with the launching tools at `assistant/src/tools/workflows/`. The authoring guide and a manual e2e runbook are at [`assistant/docs/workflows.md`](assistant/docs/workflows.md) and [`assistant/docs/workflows-testing.md`](assistant/docs/workflows-testing.md).
+The workflow engine lets the assistant author a short JS/TS script that runs in a sandbox and fans work out across many parallel, ephemeral **leaf agents** — for example: score every option in a list in parallel, then synthesize the winner. It is gated by the `workflows` feature flag (default off) and lives under `assistant/src/workflows/`. The launching tools (`run_workflow`, `manage_workflows`) are not always-on: they are served by the flag-gated `workflows` bundled skill at `assistant/src/config/bundled-skills/workflows/`, loaded with `skill_load` and invoked via `skill_execute`. The authoring guide and a manual e2e runbook are at [`assistant/docs/workflows.md`](assistant/docs/workflows.md) and [`assistant/docs/workflows-testing.md`](assistant/docs/workflows-testing.md).
 
 ### Modules
 
 - **`run-manager.ts`** (`WorkflowRunManager`) — the lifecycle surface the tool, scheduler, and routes drive. Gates on the feature flag and the concurrent-run cap, resolves the capability manifest, creates the journal run row, launches `executeWorkflow` **without awaiting it** (returns the `runId` immediately), and republishes engine progress/completion as `workflow_progress` / `workflow_completed` events. On completion it wakes the originating conversation with a human-readable summary via the same `wakeAgentForOpportunity` path scheduled tasks and background shell jobs use.
 - **`engine.ts`** (`executeWorkflow`) — runs the script in the sandbox and owns the host API (`agent`, `leaf`, `parallel`, `map`, `pipeline`, `phase`, `log`, `usage`, `workflow`, `args`), the deterministic `seq` assignment, the agent cap, and journaled resume. `map`/`pipeline` are JS-prelude helpers over the `parallel` host function (the single-threaded VM cannot re-enter itself mid-call); `pipeline` has a per-stage barrier.
 - **`sandbox.ts`** (`createWorkflowSandbox`) — a fresh QuickJS-WASM VM per run with **no** `fetch`/`process`/`Bun`/`require`/network/filesystem and a banned `Date.now`/`Math.random`/argless `new Date()`. Host functions are *asyncified*: a host call suspends the whole VM until its promise settles, so from the script's view host calls are **synchronous** (authors write `const r = agent(...)`, never `await`). An interrupt handler enforces a CPU deadline and cooperative abort.
-- **`capabilities.ts`** (`resolveCapabilities`) — resolves the per-run manifest into the concrete allow-set: a read-only baseline (`file_read`, `file_list`, `recall`, `web_search`, `web_fetch`) unioned with declared `tools`, with a forbidden set always denied. This is the single consent point; the leaf runner hard-denies anything outside it.
+- **`capabilities.ts`** (`resolveCapabilities`) — resolves the per-run manifest into the concrete allow-set: a read-only baseline (`file_read`, `file_list`, `recall`, `web_search`) unioned with declared `tools`, with a forbidden set always denied. `web_fetch` is **not** in the baseline (its URL can exfiltrate read data), so a run that fetches must declare it. This is the single consent point; the leaf runner hard-denies anything outside it. Declaring any side-effecting tool/host function arms the **threshold-aware launch approval** (`isFullAccessThreshold` in `permissions/threshold.ts`): full-access posture bypasses the prompt, normal posture prompts once. The same gate guards resume of a side-effecting run (re-prompt conversationally, 403 over the HTTP route in normal posture).
 - **`leaf-runner.ts`** (`runLeaf`) — the single-leaf primitive. A *schema* leaf makes one forced-`tool_choice` provider call returning structured output (no tools); a *tool* leaf runs a restricted agent loop. Leaves are anonymous by default (minimal task prompt, no identity, no memory); `persona: true` injects the assistant identity + memory pipeline. No leaf ever creates a conversation row, jsonl mirror, title job, or turn broadcast. Every leaf call resolves through the `workflowLeaf` call site (cost-optimized profile by default).
-- **`journal-store.ts`** — typed persistence over the `workflow_runs` and `workflow_journal` tables (migration 282). The journal is an append-only `(run_id, seq)` log; on resume the engine replays cached results for the unchanged call prefix instead of re-spawning agents.
+- **`journal-store.ts`** — typed persistence over the `workflow_runs` and `workflow_journal` tables (migration 284). The journal is an append-only `(run_id, seq)` log; on resume the engine replays cached results for the unchanged call prefix instead of re-spawning agents.
 - **`library.ts`** — saved workflows at `<workspace>/workflows/*.workflow.ts`, resolvable by name (by `meta.name`, then filename base) for `run_workflow({ name })`, `workflow(name)`, and the scheduler's `workflow` mode.
+
+A `workflow`-mode schedule carries a **persisted capability manifest** (`capabilities_json` on `cron_jobs`, migration 290), consented to once at `schedule_create` (which validates it and arms the threshold-aware approval at creation if it grants side effects). Both firing paths — the scheduler's auto-fire and the run-now `POST /v1/schedules/:id/run` route — execute under the stored manifest; a legacy/null manifest falls back to the read-only baseline.
 
 ### Data flow
 
 ```mermaid
 graph TB
-    TOOL["run_workflow tool<br/>(flag-gated)"]
-    SCHED["Scheduler<br/>(workflow mode)"]
+    TOOL["run_workflow / manage_workflows<br/>(workflows skill · skill_execute)"]
+    SCHED["Scheduler<br/>(workflow mode · stored manifest)"]
+    GATE["Threshold-aware consent<br/>side-effecting manifest:<br/>full-access bypass / else prompt"]
     RM["WorkflowRunManager<br/>flag + run-cap gate<br/>async launch"]
     CAPS["resolveCapabilities<br/>baseline ∪ declared − forbidden"]
     ENGINE["executeWorkflow<br/>host API + seq + agent cap"]
@@ -684,8 +687,9 @@ graph TB
     WAKE["Conversation wake<br/>completion summary"]
     ROUTES["GET /v1/workflows*<br/>+ vellum workflows CLI"]
 
-    TOOL --> RM
+    TOOL --> GATE
     SCHED --> RM
+    GATE --> RM
     RM --> CAPS
     CAPS --> ENGINE
     RM --> ENGINE
@@ -702,9 +706,9 @@ graph TB
 
 ### Tables, routes, and CLI
 
-- **Tables** (migration 282): `workflow_runs` (one row per run — status, agent/token counts, script source/hash, capabilities, originating conversation) and `workflow_journal` (append-only `(run_id, seq)` leaf-call log). Leaf cost is attributed in `llm_usage_events` under `call_site = 'workflowLeaf'`.
-- **Routes** (read/abort surfaces, all 404 when the flag is off): `GET /v1/workflows`, `GET /v1/workflows/runs`, `GET /v1/workflows/runs/:id`, `POST /v1/workflows/runs/:id/abort`.
-- **CLI**: `vellum workflows list | runs | show <id> | abort <id>`.
+- **Tables** (migration 284): `workflow_runs` (one row per run — status, agent/token counts, script source/hash, capabilities, originating conversation) and `workflow_journal` (append-only `(run_id, seq)` leaf-call log). Scheduled workflows persist their manifest in `cron_jobs.capabilities_json` (migration 290). Leaf cost is attributed in `llm_usage_events` under `call_site = 'workflowLeaf'`.
+- **Routes** (read/abort/resume surfaces, all 404 when the flag is off): `GET /v1/workflows`, `GET /v1/workflows/runs`, `GET /v1/workflows/runs/:id`, `POST /v1/workflows/runs/:id/abort`, `POST /v1/workflows/runs/:id/resume` (the resume route refuses a side-effecting run in normal posture and proceeds at full access).
+- **CLI**: `vellum workflows list | runs | show <id> | abort <id> | resume <id>`.
 - **Config** (`workflows.*`): `maxAgentsPerRun` (500), `maxConcurrentLeaves` (6), `maxConcurrentRuns` (3), `journalRetentionDays` (30).
 
 ## Maintenance Rule

--- a/assistant/docs/workflows.md
+++ b/assistant/docs/workflows.md
@@ -8,12 +8,14 @@ from each of a hundred documents, draft-then-verify a batch — and you want the
 results orchestrated deterministically and reported back when the whole run
 finishes.
 
-Workflows are gated behind the `workflows` feature flag (default **off**). When it
-is off, the `run_workflow` / `manage_workflows` tools are absent, the management
-routes 404, and the scheduler rejects `workflow`-mode jobs.
+Workflows are gated behind the `workflows` feature flag (default **off**). The
+`run_workflow` / `manage_workflows` tools are served by the flag-gated `workflows`
+bundled skill rather than as always-on tools — load it with `skill_load` and invoke
+its tools via `skill_execute`. When the flag is off, the skill is absent, the
+management routes 404, and the scheduler rejects `workflow`-mode jobs.
 
 - Engine code: `assistant/src/workflows/`
-- Launching tools: `assistant/src/tools/workflows/`
+- Skill (tool surface): `assistant/src/config/bundled-skills/workflows/`
 - Architecture overview: [`ARCHITECTURE.md` § Workflow Orchestration Engine](../../ARCHITECTURE.md#workflow-orchestration-engine)
 - Manual e2e runbook: [`workflows-testing.md`](./workflows-testing.md)
 
@@ -222,7 +224,7 @@ minus a forbidden set.
   launch approval, so it carries only read-only tools. `web_fetch` is **not**
   here — it is classified as a side-effect tool (its URL can exfiltrate read data
   or trigger external actions), so a run that needs it must declare it (which
-  forces the launch approval gate).
+  arms the threshold-aware launch approval gate).
 - **Declared tools** must exist in the tool registry — an unknown name is a hard
   authoring error, not a silent drop.
 - **Forbidden tools** can never be granted, even if declared (declaring one is a
@@ -239,6 +241,28 @@ minus a forbidden set.
 Side-effecting tools (`file_write`, sends, shell, …) and `persona` are **not** in
 the baseline; a run must declare them. Once declared, every leaf may use them with
 no further prompting.
+
+### Launch and resume approval are threshold-aware
+
+Declaring any side-effecting tool or host function arms a **launch approval**: the
+single point at which the user consents to the whole run. It is threshold-aware —
+at the full-access posture (auto-approve threshold `high`) it does **not** prompt;
+in normal posture it prompts once. A read-only run (no declared side effects)
+never prompts.
+
+The same posture gates **resume** of a run whose stored manifest granted side
+effects, since resuming restarts the unfinished side-effecting leaves:
+
+- **Conversationally** (`manage_workflows` action `resume`): full access bypasses;
+  normal posture re-prompts for fresh approval.
+- **Over HTTP** (`POST /v1/workflows/runs/:id/resume`, and the
+  `vellum workflows resume` CLI on top of it): full access proceeds; normal
+  posture is **refused** (403) and the caller is directed to resume through the
+  assistant, since the route has no prompt channel.
+
+A read-only run resumes freely regardless of posture. The check is
+`isFullAccessThreshold` in `assistant/src/permissions/threshold.ts`, applied in
+`permission-checker.ts` and `workflow-routes.ts`.
 
 ---
 
@@ -385,32 +409,43 @@ call `workflow()` — nesting deeper than one level throws.
 ### Scheduler `workflow` mode
 
 A scheduled job can trigger a saved workflow by name (e.g. "triage the inbox every
-morning"). In v1 the scheduler runs the workflow with **only the read-only
-baseline** — a scheduled run cannot be granted side-effecting tools. The trigger
-records success once the run starts; completion/failure is surfaced out-of-band
-via workflow events and the completion wake.
+morning"). Each `workflow`-mode schedule carries a **persisted capability manifest**
+(`capabilities_json` on `cron_jobs`), consented to **once at schedule creation**:
+`schedule_create` accepts a `capabilities` manifest, validates it against the same
+forbidden/unknown checks `run_workflow` applies, and — if it grants side effects —
+arms the threshold-aware approval at creation time. Both firing paths (the
+scheduler's auto-fire and the run-now `POST /v1/schedules/:id/run` route) execute
+the run under that stored manifest. Legacy or null-manifest schedules fall back to
+the read-only baseline. The trigger records success once the run starts;
+completion/failure is surfaced out-of-band via workflow events and the completion
+wake.
 
 ---
 
 ## Tools, routes, and CLI
 
-### Tools (flag-gated)
+### Tools (served by the `workflows` skill)
+
+Reached via the skill (`skill_load` then `skill_execute`), not as always-on tools.
 
 - **`run_workflow`** — `{ script?, name?, args?, capabilities?, label? }` (exactly
   one of `script`/`name`). Returns `{ runId }` immediately; the run is
   asynchronous and you are notified in the conversation when it completes. **Do
   not poll.**
-- **`manage_workflows`** — `{ action: "status" | "abort" | "list_runs", run_id? }`.
-  `status`/`abort` require `run_id`.
+- **`manage_workflows`** — `{ action: "status" | "abort" | "resume" | "list_runs"
+| "list_profiles", run_id? }`. `status`/`abort`/`resume` require `run_id`.
+  `list_profiles` returns `{ profiles, activeProfile }` — the defined LLM profile
+  names plus the workspace active profile, used to pick a valid leaf `profile`.
 
-### Routes (read/abort, all 404 when the flag is off)
+### Routes (read/abort/resume, all 404 when the flag is off)
 
-| Method | Path                           | Purpose                                               |
-| ------ | ------------------------------ | ----------------------------------------------------- |
-| `GET`  | `/v1/workflows`                | List saved (named) workflows.                         |
-| `GET`  | `/v1/workflows/runs`           | List recent runs (newest first); `?limit`, `?status`. |
-| `GET`  | `/v1/workflows/runs/:id`       | Get one run.                                          |
-| `POST` | `/v1/workflows/runs/:id/abort` | Signal an in-flight run to abort.                     |
+| Method | Path                            | Purpose                                                                                              |
+| ------ | ------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `GET`  | `/v1/workflows`                 | List saved (named) workflows.                                                                        |
+| `GET`  | `/v1/workflows/runs`            | List recent runs (newest first); `?limit`, `?status`.                                                |
+| `GET`  | `/v1/workflows/runs/:id`        | Get one run.                                                                                         |
+| `POST` | `/v1/workflows/runs/:id/abort`  | Signal an in-flight run to abort.                                                                    |
+| `POST` | `/v1/workflows/runs/:id/resume` | Resume an interrupted run (refuses a side-effecting run in normal posture; proceeds at full access). |
 
 ### CLI
 
@@ -419,6 +454,7 @@ vellum workflows list              # saved (named) workflows
 vellum workflows runs              # recent runs  (--limit, --status)
 vellum workflows show <run-id>     # one run's status + counts
 vellum workflows abort <run-id>    # abort an in-flight run
+vellum workflows resume <run-id>   # resume an interrupted run
 ```
 
 All subcommands accept `--assistant <name>` to target a specific instance.
@@ -440,7 +476,7 @@ Engine caps live under `workflows.*` in assistant config:
 
 ## Persistence and resume
 
-Run state lives in two tables (migration 282):
+Run state lives in two tables (migration 284):
 
 - **`workflow_runs`** — one row per run: status (`running` / `completed` /
   `failed` / `aborted` / `cap_exceeded` / `interrupted`), agent/token counts,


### PR DESCRIPTION
## Summary
- Update workflows.md + ARCHITECTURE.md to match shipped behavior: skill-served tools (skill_load/skill_execute) + list_profiles, threshold-aware launch+resume approval, and scheduled capability manifests with creation-time consent. Removes stale V1/read-only-only language.

Part of plan: workflow-engine-followups.md (PR 11 of 11)