### PR TITLE
docs: correct stale comments about workflow tool gating

### DIFF
--- a/assistant/src/ipc/gateway-flag-listener.ts
+++ b/assistant/src/ipc/gateway-flag-listener.ts
@@ -10,14 +10,16 @@ import { resolveIpcSocketPath } from "./socket-path.js";
 const log = getLogger("gateway-flag-listener");
 
 /**
- * Refresh the flag-overrides cache from the gateway, then register any tools
- * whose flag gate has since opened. Both the `feature_flags_changed` event and a
- * reconnect only refresh the cache; without this follow-up, enabling a
- * tool-gating flag (e.g. `workflows`) at runtime would open the corresponding
- * routes' flag gate while the flag-gated tools (`run_workflow` /
- * `manage_workflows`, CES tools) stay absent from the registry until a daemon
- * restart. `syncFlagGatedTools` is idempotent and enable-only, so re-running it
- * on every refresh is safe; it also never throws (it logs internally).
+ * Refresh the flag-overrides cache from the gateway, then register any
+ * registry-gated tools whose flag gate has since opened. Both the
+ * `feature_flags_changed` event and a reconnect only refresh the cache;
+ * `syncFlagGatedTools` registers the CES tools whose flag is enabled so that
+ * enabling a CES-gating flag at runtime surfaces them without a daemon restart.
+ * Workflow tools (`run_workflow` / `manage_workflows`) are not registry-gated:
+ * they live in a flag-gated bundled skill surfaced via `skill_load` against the
+ * live flag cache, so they need no registry sync here. `syncFlagGatedTools` is
+ * idempotent and enable-only, so re-running it on every refresh is safe; it also
+ * never throws (it logs internally).
  */
 function refreshFlagsAndSyncTools(context: string): void {
   refreshOverridesFromGateway()

--- a/assistant/src/workflows/capabilities.ts
+++ b/assistant/src/workflows/capabilities.ts
@@ -6,7 +6,7 @@
  * functions, and persona access its leaf agents may use. That declaration is
  * the **single consent point** for the entire run: there are no per-leaf or
  * per-call permission prompts inside a workflow run. The engine/leaf runner
- * (a later PR) calls {@link resolveCapabilities} once and then **hard-denies**
+ * calls {@link resolveCapabilities} once and then **hard-denies**
  * any tool invocation that falls outside the resolved set.
  *
  * Resolution policy:
@@ -77,9 +77,9 @@ export const WORKFLOW_READONLY_BASELINE: readonly string[] = [
  *
  * - `subagent_spawn` — leaves must not spawn nested agents; the workflow
  *   engine owns fan-out.
- * - `run_workflow` / `manage_workflows` — the workflow tools themselves
- *   (registered by a later PR; referenced here by name) would let a leaf
- *   recurse into or reconfigure the engine.
+ * - `run_workflow` / `manage_workflows` — the workflow tools themselves;
+ *   granting either to a leaf would let it recurse into or reconfigure the
+ *   engine.
  * - `manage_secure_command_tool` — CES secure-bundle management is a
  *   human-in-the-loop install path and is never delegated to an unattended
  *   leaf.


### PR DESCRIPTION
## Summary
- gateway-flag-listener.ts: syncFlagGatedTools governs CES tools; workflow tools are skill-gated via skill_load (not registry sync).
- capabilities.ts: drop temporal 'registered by a later PR' clause from WORKFLOW_FORBIDDEN_TOOLS; state present fact.

Addresses self-review gaps for plan workflow-engine-followups.md