### PR TITLE
refactor(workflows): remove dead Tool objects after skill cutover

### DIFF
--- a/assistant/src/tools/workflows/manage-workflows.ts
+++ b/assistant/src/tools/workflows/manage-workflows.ts
@@ -1,12 +1,12 @@
 /**
- * `manage_workflows` core tool — thin reads/controls over
+ * `manage_workflows` core implementation — thin reads/controls over
  * {@link WorkflowRunManager}: check a run's status, abort a run, or list recent
- * runs. All state lives in the run manager / journal; this tool only delegates
- * and compacts the result to JSON.
+ * runs. All state lives in the run manager / journal; this delegates and
+ * compacts the result to JSON.
  *
- * NOTE: this tool runs in-process and returns a `runId`-keyed, deliberately
- * trimmed projection for the model — a DIFFERENT contract from the HTTP wire
- * shape (`id`-keyed `toWireRun`/`workflowRunSchema` in
+ * NOTE: this runs in-process and returns a `runId`-keyed, deliberately trimmed
+ * projection for the model — a DIFFERENT contract from the HTTP wire shape
+ * (`id`-keyed `toWireRun`/`workflowRunSchema` in
  * `runtime/routes/workflow-routes.ts`). The two are intentionally not unified:
  * converging on `toWireRun` here would change this tool's emitted JSON. Both
  * project from the same `WorkflowRun` source type, so field renames are caught
@@ -17,12 +17,7 @@ import { loadConfig } from "../../config/loader.js";
 import { callerOwnsWorkflowRun } from "../../workflows/capabilities.js";
 import type { WorkflowRun } from "../../workflows/journal-store.js";
 import { getWorkflowRunManager } from "../../workflows/run-manager.js";
-import {
-  RiskLevel,
-  type ToolContext,
-  type ToolDefinition,
-  type ToolExecutionResult,
-} from "../types.js";
+import type { ToolContext, ToolExecutionResult } from "../types.js";
 
 export async function executeManageWorkflows(
   input: Record<string, unknown>,
@@ -158,35 +153,3 @@ export async function executeManageWorkflows(
       };
   }
 }
-
-export const manageWorkflowsTool = {
-  name: "manage_workflows",
-  description:
-    'Inspect or control workflow runs started by run_workflow. action="status" (requires run_id) returns a run\'s status and counts; action="abort" (requires run_id) signals an in-flight run to stop; action="resume" (requires run_id) restarts an interrupted run (one orphaned by an assistant restart), replaying its journaled prefix and continuing from the first unfinished step; action="list_runs" returns recent runs newest-first; action="list_profiles" returns the defined LLM profile names plus the active profile (use to pick a valid leaf `profile`).',
-  // Low risk by default: status/list are pure reads; abort only signals an
-  // existing run to stop; resuming a READ-ONLY run replays a journaled prefix
-  // and continues under the same structural agent cap. Resuming a run whose
-  // STORED manifest granted side-effecting tools/host functions is promoted to
-  // require fresh interactive approval in the executor (see executor.ts) —
-  // resume restarts unfinished side-effecting leaves and is reachable by any
-  // actor who can list/guess the run id, so it must not silently reuse the
-  // launch-time consent.
-  defaultRiskLevel: RiskLevel.Low,
-  input_schema: {
-    type: "object",
-    properties: {
-      action: {
-        type: "string",
-        enum: ["status", "abort", "resume", "list_runs", "list_profiles"],
-        description: "What to do.",
-      },
-      run_id: {
-        type: "string",
-        description:
-          'Target run id (required for "status", "abort", and "resume").',
-      },
-    },
-    required: ["action"],
-  },
-  execute: executeManageWorkflows,
-} satisfies ToolDefinition;

--- a/assistant/src/tools/workflows/run-workflow.test.ts
+++ b/assistant/src/tools/workflows/run-workflow.test.ts
@@ -77,18 +77,18 @@ mock.module("../../workflows/run-manager.js", () => ({
 }));
 
 // Imports AFTER mocks so the mocked modules are picked up.
-const { runWorkflowTool } = await import("./run-workflow.js");
-const { manageWorkflowsTool } = await import("./manage-workflows.js");
+const { executeRunWorkflow } = await import("./run-workflow.js");
+const { executeManageWorkflows } = await import("./manage-workflows.js");
 const { WORKFLOW_READONLY_BASELINE } =
   await import("../../workflows/capabilities.js");
 
 // Minimal tool context — only the fields the workflow tools read.
-function makeContext(): Parameters<typeof runWorkflowTool.execute>[1] {
+function makeContext(): Parameters<typeof executeRunWorkflow>[1] {
   return {
     conversationId: "conv-1",
     workingDir: "/tmp",
     trustClass: "guardian",
-  } as Parameters<typeof runWorkflowTool.execute>[1];
+  } as Parameters<typeof executeRunWorkflow>[1];
 }
 
 beforeEach(() => {
@@ -130,12 +130,20 @@ describe("workflow tools are served by the workflows skill", () => {
 });
 
 describe("run_workflow capability contract", () => {
-  test("advertises the actual read-only baseline (no drift from the code)", () => {
-    // The description interpolates WORKFLOW_READONLY_BASELINE, so the contract
-    // the model reads always matches what resolveCapabilities actually grants.
-    // Guards against re-hardcoding a stale list (e.g. re-advertising web_fetch).
+  test("SKILL.md advertises the actual read-only baseline (no drift from the code)", async () => {
+    // The workflows skill's SKILL.md is the authoring contract the model reads
+    // when generating scripts. Guard it against the code: every
+    // WORKFLOW_READONLY_BASELINE entry must appear, so the documented baseline
+    // never drifts from what resolveCapabilities actually grants (e.g.
+    // re-advertising web_fetch as a default).
+    const { readFileSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    const skillMd = readFileSync(
+      join(import.meta.dir, "../../config/bundled-skills/workflows/SKILL.md"),
+      "utf-8",
+    );
     for (const name of WORKFLOW_READONLY_BASELINE) {
-      expect(runWorkflowTool.description).toContain(name);
+      expect(skillMd).toContain(name);
     }
     // web_fetch is side-effecting, so it is NOT a default — the contract must
     // present it as a tool to DECLARE, never as part of the baseline.
@@ -145,13 +153,13 @@ describe("run_workflow capability contract", () => {
 
 describe("run_workflow input validation", () => {
   test("rejects when neither script nor name is provided", async () => {
-    const res = await runWorkflowTool.execute({}, makeContext());
+    const res = await executeRunWorkflow({}, makeContext());
     expect(res.isError).toBe(true);
     expect(startMock).not.toHaveBeenCalled();
   });
 
   test("rejects when BOTH script and name are provided", async () => {
-    const res = await runWorkflowTool.execute(
+    const res = await executeRunWorkflow(
       { script: "export const meta = {};", name: "saved" },
       makeContext(),
     );
@@ -162,7 +170,7 @@ describe("run_workflow input validation", () => {
 
 describe("run_workflow launch", () => {
   test("starts an inline-script run with the built manifest and returns runId", async () => {
-    const res = await runWorkflowTool.execute(
+    const res = await executeRunWorkflow(
       {
         script: "export const meta = { name: 'x', description: 'y' };",
         args: { foo: 1 },
@@ -192,7 +200,7 @@ describe("run_workflow launch", () => {
   });
 
   test("starts a saved-name run and defaults the manifest to empties", async () => {
-    await runWorkflowTool.execute({ name: "saved-flow" }, makeContext());
+    await executeRunWorkflow({ name: "saved-flow" }, makeContext());
     expect(lastStartArgs).toMatchObject({
       name: "saved-flow",
       manifest: { tools: [], hostFunctions: [], persona: false },
@@ -204,7 +212,7 @@ describe("run_workflow launch", () => {
 
   test("surfaces a run-manager start error as a tool error", async () => {
     startThrows = new Error("Workflows are not enabled.");
-    const res = await runWorkflowTool.execute(
+    const res = await executeRunWorkflow(
       { script: "export const meta = {};" },
       makeContext(),
     );
@@ -223,7 +231,7 @@ describe("manage_workflows", () => {
         agentsSpawned: 3,
       },
     ] as unknown[]);
-    const res = await manageWorkflowsTool.execute(
+    const res = await executeManageWorkflows(
       { action: "list_runs" },
       makeContext(),
     );
@@ -233,7 +241,7 @@ describe("manage_workflows", () => {
   });
 
   test("abort requires run_id and delegates to abort()", async () => {
-    const missing = await manageWorkflowsTool.execute(
+    const missing = await executeManageWorkflows(
       { action: "abort" },
       makeContext(),
     );
@@ -245,7 +253,7 @@ describe("manage_workflows", () => {
       id: "r9",
       conversationId: "conv-1",
     } as unknown);
-    const ok = await manageWorkflowsTool.execute(
+    const ok = await executeManageWorkflows(
       { action: "abort", run_id: "r9" },
       makeContext(),
     );
@@ -254,13 +262,13 @@ describe("manage_workflows", () => {
   });
 
   test("status requires run_id and reports not-found cleanly", async () => {
-    const missing = await manageWorkflowsTool.execute(
+    const missing = await executeManageWorkflows(
       { action: "status" },
       makeContext(),
     );
     expect(missing.isError).toBe(true);
 
-    const res = await manageWorkflowsTool.execute(
+    const res = await executeManageWorkflows(
       { action: "status", run_id: "nope" },
       makeContext(),
     );
@@ -269,7 +277,7 @@ describe("manage_workflows", () => {
   });
 
   test("resume requires run_id and delegates to resume()", async () => {
-    const missing = await manageWorkflowsTool.execute(
+    const missing = await executeManageWorkflows(
       { action: "resume" },
       makeContext(),
     );
@@ -281,7 +289,7 @@ describe("manage_workflows", () => {
       id: "r9",
       conversationId: "conv-1",
     } as unknown);
-    const ok = await manageWorkflowsTool.execute(
+    const ok = await executeManageWorkflows(
       { action: "resume", run_id: "r9" },
       makeContext(),
     );
@@ -298,7 +306,7 @@ describe("manage_workflows", () => {
     resumeThrows = new Error(
       "Workflow run r9 is not resumable (status: completed).",
     );
-    const res = await manageWorkflowsTool.execute(
+    const res = await executeManageWorkflows(
       { action: "resume", run_id: "r9" },
       makeContext(),
     );
@@ -307,7 +315,7 @@ describe("manage_workflows", () => {
   });
 
   test("list_profiles returns sorted profile names and the active profile", async () => {
-    const res = await manageWorkflowsTool.execute(
+    const res = await executeManageWorkflows(
       { action: "list_profiles" },
       makeContext(),
     );
@@ -318,7 +326,7 @@ describe("manage_workflows", () => {
   });
 
   test("rejects an unknown action", async () => {
-    const res = await manageWorkflowsTool.execute(
+    const res = await executeManageWorkflows(
       { action: "bogus" },
       makeContext(),
     );
@@ -332,7 +340,7 @@ describe("manage_workflows", () => {
       conversationId: "conv-1",
       workingDir: "/tmp",
       trustClass: "trusted_contact",
-    }) as Parameters<typeof manageWorkflowsTool.execute>[1];
+    }) as Parameters<typeof executeManageWorkflows>[1];
 
   test("list_runs is scoped to the caller's conversation for a non-guardian", async () => {
     listMock.mockReturnValueOnce([
@@ -340,7 +348,7 @@ describe("manage_workflows", () => {
       { id: "theirs", name: "b", status: "running", conversationId: "conv-2" },
       { id: "nullconv", name: "c", status: "running", conversationId: null },
     ] as unknown[]);
-    const res = await manageWorkflowsTool.execute(
+    const res = await executeManageWorkflows(
       { action: "list_runs" },
       contactContext(),
     );
@@ -359,7 +367,7 @@ describe("manage_workflows", () => {
     } as unknown;
 
     statusMock.mockReturnValueOnce(foreign);
-    const status = await manageWorkflowsTool.execute(
+    const status = await executeManageWorkflows(
       { action: "status", run_id: "theirs" },
       contactContext(),
     );
@@ -367,14 +375,14 @@ describe("manage_workflows", () => {
     expect(JSON.parse(status.content).found).toBe(false);
 
     statusMock.mockReturnValueOnce(foreign);
-    await manageWorkflowsTool.execute(
+    await executeManageWorkflows(
       { action: "abort", run_id: "theirs" },
       contactContext(),
     );
     expect(abortMock).not.toHaveBeenCalled();
 
     statusMock.mockReturnValueOnce(foreign);
-    const resume = await manageWorkflowsTool.execute(
+    const resume = await executeManageWorkflows(
       { action: "resume", run_id: "theirs" },
       contactContext(),
     );
@@ -388,7 +396,7 @@ describe("manage_workflows", () => {
       id: "mine",
       conversationId: "conv-1",
     } as unknown);
-    await manageWorkflowsTool.execute(
+    await executeManageWorkflows(
       { action: "abort", run_id: "mine" },
       contactContext(),
     );

--- a/assistant/src/tools/workflows/run-workflow.ts
+++ b/assistant/src/tools/workflows/run-workflow.ts
@@ -1,16 +1,18 @@
 /**
- * `run_workflow` core tool — a thin launcher over {@link WorkflowRunManager}.
+ * `run_workflow` core implementation — a thin launcher over
+ * {@link WorkflowRunManager}.
  *
  * The assistant calls this to kick off an autonomous, multi-agent workflow from
  * either an inline script or a saved workflow name. All orchestration logic
- * lives in the run manager and engine; this tool only validates input, builds
- * the per-run capability manifest, resolves the originating conversation's
- * trust context, and fires `start()` (which returns immediately — the run is
- * asynchronous; its completion is surfaced later as a conversation injection).
+ * lives in the run manager and engine; this implementation only validates
+ * input, builds the per-run capability manifest, resolves the originating
+ * conversation's trust context, and fires `start()` (which returns immediately —
+ * the run is asynchronous; its completion is surfaced later as a conversation
+ * injection).
  *
- * The tool DESCRIPTION below is the authoring contract the assistant follows
- * when writing workflow scripts. Keep it precise — it is the single source of
- * truth the model reads when generating the `script`.
+ * The script-authoring contract the assistant follows when writing workflow
+ * scripts lives in the `workflows` bundled skill's SKILL.md, the single source
+ * of truth the model reads when generating the `script`.
  */
 
 import { findConversation } from "../../daemon/conversation-registry.js";
@@ -18,68 +20,9 @@ import {
   FALLBACK_TURN_TRUST,
   type TrustContext,
 } from "../../daemon/trust-context.js";
-import {
-  CapabilityManifestSchema,
-  WORKFLOW_READONLY_BASELINE,
-} from "../../workflows/capabilities.js";
+import { CapabilityManifestSchema } from "../../workflows/capabilities.js";
 import { getWorkflowRunManager } from "../../workflows/run-manager.js";
-import {
-  RiskLevel,
-  type ToolContext,
-  type ToolDefinition,
-  type ToolExecutionResult,
-} from "../types.js";
-
-export const RUN_WORKFLOW_DESCRIPTION = `Launch an autonomous, multi-agent WORKFLOW from a script you author (or by saved name). A workflow fans work out across many short-lived leaf agents and orchestrates them deterministically. Returns a runId immediately; the run is asynchronous and you are notified in this conversation when it completes — do NOT poll.
-
-Provide EXACTLY ONE of:
-- "script": the workflow source (JavaScript/TypeScript), or
-- "name": the name of a previously saved workflow.
-
-=== SCRIPT AUTHORING CONTRACT ===
-Scripts run in a SANDBOX with a SYNCHRONOUS host API. You write straight-line code — NEVER use \`await\`. The host functions block and return their results directly. An \`async\` script will NOT work.
-
-The script MUST begin with a pure-literal export (no computed values, no template strings, no concatenation):
-  export const meta = { name: "summarize-inbox", description: "Summarize and triage the inbox" };
-
-The script's RESULT is whatever it \`return\`s at the top level: end with \`return <result>;\`. A bare trailing expression (e.g. \`result;\`) is NOT captured — the run would complete with no result. Always \`return\` the value you want surfaced.
-
-DETERMINISM (this is what makes runs resumable): do NOT call \`Date.now()\`, \`Math.random()\`, or \`new Date()\` — they THROW. Pass any timestamps or random seeds in via \`args\`.
-
-HOST API (all synchronous):
-- \`agent(prompt, opts?)\` — run ONE leaf agent; returns its result, throws on failure.
-- \`leaf(prompt, opts?)\` — return a leaf DESCRIPTOR (does not run yet) for use inside \`parallel\`/\`map\`/\`pipeline\`.
-- \`parallel(specs)\` — run an array of \`leaf(...)\` descriptors CONCURRENTLY; returns results in order; a failed leaf becomes \`null\` (does not throw).
-- \`map(items, build)\` — \`build(item, i)\` returns a \`leaf(...)\` descriptor per item; runs them like \`parallel\`.
-- \`pipeline(items, ...stages)\` — each stage maps over the prior stage's results: return a \`leaf(...)\` descriptor to run an agent on that item, OR any plain value (string/number/object/null) to pass it through UNCHANGED (filter/transform/skip locally — no agent spent). Per-stage barrier (each stage sees the prior stage's results).
-- \`phase(title)\` — mark a named phase for progress reporting.
-- \`log(msg)\` — emit a progress log line.
-- \`usage()\` — returns \`{ agentsSpawned, inputTokens, outputTokens }\` so far.
-- \`workflow(name, args)\` — run a SAVED workflow inline (one level deep only).
-- \`args\` — the \`args\` object you passed to this tool.
-
-LEAF OPTIONS (\`opts\` for \`agent\`/\`leaf\`):
-- \`schema\` — a JSON Schema object LITERAL. Forces structured output via a tool; a leaf WITH a schema runs with NO tools (pure judging/extraction).
-- \`label\` — short display label for the leaf.
-- \`profile\` — override the model profile (must exist in config).
-- \`persona\` — \`true\` makes the leaf speak AS the assistant (identity + memory) — use for output meant to be in her voice; DEFAULT is anonymous (use for impartial judging/extraction of input).
-
-CAPABILITIES (the \`capabilities\` argument — the SINGLE consent point for the whole run):
-- Leaves get a curated read-only baseline by default: ${WORKFLOW_READONLY_BASELINE.join(", ")}. NOTE: \`web_fetch\` is NOT in the baseline (an outbound fetch is side-effecting — its URL can exfiltrate data), so if a leaf must fetch a URL, declare \`"web_fetch"\` in \`capabilities.tools\` (which makes the launch prompt for approval once, like any side-effecting tool).
-- To let leaves use SIDE-EFFECTING tools (writes, sends, shell, \`web_fetch\`, etc.), list them in \`capabilities.tools\`. Declaring ANY side-effecting tool (or host function) makes the LAUNCH prompt the user for approval ONCE — that single approval covers the whole run; there are no per-call prompts inside it. A read-only run (no declared tools) launches with no prompt. So declare the minimum you need.
-- \`capabilities.hostFunctions\` and \`capabilities.persona\` similarly grant host-function and persona access.
-
-Runs are autonomous but BOUNDED by an agent cap; you cannot exceed it. Spend is structurally capped. Side effects are consented to ONCE at launch (via the capability declaration above), not by per-call approval inside the run.
-
-EXAMPLE script:
-  export const meta = { name: "rank-options", description: "Rank options and pick the best" };
-  phase("score");
-  const scores = map(args.options, (opt) => leaf(
-    \`Score this option 0-10 for fit: \${opt}\`,
-    { schema: { type: "object", properties: { score: { type: "number" } }, required: ["score"] } }
-  ));
-  const best = agent(\`Given these scored options, write the final recommendation in your own voice: \${JSON.stringify(scores)}\`, { persona: true });
-  return best;`;
+import type { ToolContext, ToolExecutionResult } from "../types.js";
 
 /**
  * Resolve the {@link TrustContext} to forward to the run's leaves. Prefer the
@@ -143,67 +86,3 @@ export async function executeRunWorkflow(
     return { content: `Failed to start workflow: ${msg}`, isError: true };
   }
 }
-
-export const runWorkflowTool = {
-  name: "run_workflow",
-  description: RUN_WORKFLOW_DESCRIPTION,
-  // Default risk is "low": a READ-ONLY run (no side-effecting capabilities)
-  // launches silently — spend is structurally capped by the per-run agent cap,
-  // and leaves can only read. But when the manifest grants side-effecting tools
-  // or host functions, the executor promotes the launch to a fresh interactive
-  // approval (`requireFreshApproval`, see executor.ts): the manifest is the
-  // single consent point, but it is declared by the model and leaves execute
-  // granted tools directly (no per-call prompt), so the launch is where the
-  // user consents to the grant. Per-call prompts inside a run are still never
-  // used — consent is once, at launch.
-  defaultRiskLevel: RiskLevel.Low,
-  input_schema: {
-    type: "object",
-    properties: {
-      script: {
-        type: "string",
-        description:
-          "Inline workflow source (JavaScript/TypeScript) following the authoring contract. Provide this OR name, not both.",
-      },
-      name: {
-        type: "string",
-        description:
-          "Name of a previously saved workflow to run. Provide this OR script, not both.",
-      },
-      args: {
-        type: "object",
-        description:
-          "Verbatim input object exposed to the script as `args`. Pass timestamps/seeds here (the script may not generate them).",
-      },
-      capabilities: {
-        type: "object",
-        description:
-          "Per-run capability grant (the single consent point). Leaves get a read-only baseline by default.",
-        properties: {
-          tools: {
-            type: "array",
-            items: { type: "string" },
-            description:
-              "Side-effecting tool names granted to leaves on top of the read-only baseline.",
-          },
-          hostFunctions: {
-            type: "array",
-            items: { type: "string" },
-            description: "Host-function names the run may invoke.",
-          },
-          persona: {
-            type: "boolean",
-            description:
-              "Grant leaves access to persona (identity + memory) context.",
-          },
-        },
-      },
-      label: {
-        type: "string",
-        description:
-          "Human-readable label for display; defaults to the script's meta.name.",
-      },
-    },
-  },
-  execute: executeRunWorkflow,
-} satisfies ToolDefinition;


### PR DESCRIPTION
## Summary
- Delete orphaned runWorkflowTool/manageWorkflowsTool + RUN_WORKFLOW_DESCRIPTION (dead after the skill cutover; only the test referenced them).
- Retarget the baseline drift-guard at the live SKILL.md (the production authoring contract).

Addresses self-review gaps for plan workflow-engine-followups.md