### PR TITLE
feat(workflows): add manage_workflows get_result to fetch full run results

### DIFF
--- a/assistant/src/config/bundled-skills/workflows/SKILL.md
+++ b/assistant/src/config/bundled-skills/workflows/SKILL.md
@@ -156,11 +156,17 @@ Use `manage_workflows` to inspect and control runs:
 
 | Action          | Requires   | Purpose                                                          |
 | --------------- | ---------- | ---------------------------------------------------------------- |
-| `status`        | `run_id`   | Status + agent/token counts for one run.                        |
+| `status`        | `run_id`   | Status + agent/token counts for one run (NOT the result).       |
+| `get_result`    | `run_id`   | The full result of a finished run.                              |
 | `list_runs`     | —          | Recent runs, newest first.                                      |
 | `abort`         | `run_id`   | Signal an in-flight run to abort.                               |
 | `resume`        | `run_id`   | Resume an `interrupted` run (see below).                        |
 | `list_profiles` | —          | List defined profiles + the active profile (for leaf `profile`).|
+
+The completion notification injected when a run finishes carries a **truncated**
+preview of the result (large results are cut off). To read the complete result,
+call `manage_workflows` with action `get_result` and the `run_id` — `status`
+deliberately omits the result to stay lightweight.
 
 ### Crash recovery / resume
 

--- a/assistant/src/config/bundled-skills/workflows/TOOLS.json
+++ b/assistant/src/config/bundled-skills/workflows/TOOLS.json
@@ -52,7 +52,7 @@
     },
     {
       "name": "manage_workflows",
-      "description": "Inspect or control workflow runs started by run_workflow: status, abort, resume, list_runs, and list_profiles. See SKILL.md for details.",
+      "description": "Inspect or control workflow runs started by run_workflow: status, get_result (the full result of a finished run — the completion notification truncates large results), abort, resume, list_runs, and list_profiles. See SKILL.md for details.",
       "category": "workflow",
       "risk": "low",
       "input_schema": {
@@ -60,12 +60,19 @@
         "properties": {
           "action": {
             "type": "string",
-            "enum": ["status", "abort", "resume", "list_runs", "list_profiles"],
+            "enum": [
+              "status",
+              "get_result",
+              "abort",
+              "resume",
+              "list_runs",
+              "list_profiles"
+            ],
             "description": "What to do."
           },
           "run_id": {
             "type": "string",
-            "description": "Target run id (required for \"status\", \"abort\", and \"resume\")."
+            "description": "Target run id (required for \"status\", \"get_result\", \"abort\", and \"resume\")."
           }
         },
         "required": ["action"]

--- a/assistant/src/tools/workflows/manage-workflows.ts
+++ b/assistant/src/tools/workflows/manage-workflows.ts
@@ -65,6 +65,34 @@ export async function executeManageWorkflows(
         isError: false,
       };
     }
+    case "get_result": {
+      if (!runId) {
+        return {
+          content: '"run_id" is required for action "get_result".',
+          isError: true,
+        };
+      }
+      // The full result payload rides on the run record (journal getRun);
+      // `status` omits it to stay lightweight, so this action returns it in
+      // full. The completion-summary wake truncates large results and points
+      // the assistant here for the complete value.
+      const run = manager.status(runId);
+      if (!run || !ownsRun(run)) {
+        return {
+          content: JSON.stringify({ runId, found: false }),
+          isError: false,
+        };
+      }
+      return {
+        content: JSON.stringify({
+          runId: run.id,
+          status: run.status,
+          result: run.result ?? null,
+          error: run.error ?? null,
+        }),
+        isError: false,
+      };
+    }
     case "abort": {
       if (!runId) {
         return {
@@ -148,7 +176,7 @@ export async function executeManageWorkflows(
     default:
       return {
         content:
-          'Unknown action. Use one of: "status", "abort", "resume", "list_runs", "list_profiles".',
+          'Unknown action. Use one of: "status", "get_result", "abort", "resume", "list_runs", "list_profiles".',
         isError: true,
       };
   }

--- a/assistant/src/tools/workflows/run-workflow.test.ts
+++ b/assistant/src/tools/workflows/run-workflow.test.ts
@@ -276,6 +276,43 @@ describe("manage_workflows", () => {
     expect(JSON.parse(res.content).found).toBe(false);
   });
 
+  test("get_result requires run_id and returns the full result", async () => {
+    const missing = await executeManageWorkflows(
+      { action: "get_result" },
+      makeContext(),
+    );
+    expect(missing.isError).toBe(true);
+
+    // not-found / not-owned reports cleanly, without leaking a result
+    const notFound = await executeManageWorkflows(
+      { action: "get_result", run_id: "nope" },
+      makeContext(),
+    );
+    expect(notFound.isError).toBe(false);
+    expect(JSON.parse(notFound.content).found).toBe(false);
+
+    // an owned, finished run returns the full (untruncated) result payload
+    statusMock.mockReturnValueOnce({
+      id: "r5",
+      conversationId: "conv-1",
+      status: "completed",
+      result: { scores: [1, 2, 3], note: "the full result lives here" },
+      error: null,
+    } as unknown);
+    const ok = await executeManageWorkflows(
+      { action: "get_result", run_id: "r5" },
+      makeContext(),
+    );
+    expect(ok.isError).toBe(false);
+    const parsed = JSON.parse(ok.content);
+    expect(parsed.runId).toBe("r5");
+    expect(parsed.status).toBe("completed");
+    expect(parsed.result).toEqual({
+      scores: [1, 2, 3],
+      note: "the full result lives here",
+    });
+  });
+
   test("resume requires run_id and delegates to resume()", async () => {
     const missing = await executeManageWorkflows(
       { action: "resume" },

--- a/assistant/src/workflows/run-manager.ts
+++ b/assistant/src/workflows/run-manager.ts
@@ -540,7 +540,9 @@ function buildCompletionSummary(
       `Tokens: ${result.inputTokens} in / ${result.outputTokens} out.`,
   ];
   if (result.status === "completed") {
-    lines.push(`Result: ${truncateForSummary(stringifyResult(result.result))}`);
+    lines.push(
+      `Result: ${truncateForSummary(stringifyResult(result.result), runId)}`,
+    );
   } else {
     lines.push(`Outcome: ${run?.error ?? result.status}`);
   }
@@ -557,12 +559,13 @@ function buildCompletionSummary(
 const MAX_SUMMARY_RESULT_CHARS = 2000;
 
 /** Bound a result tail for the summary; the full value stays on the run row. */
-function truncateForSummary(s: string): string {
+function truncateForSummary(s: string, runId: string): string {
   if (s.length <= MAX_SUMMARY_RESULT_CHARS) return s;
   const omitted = s.length - MAX_SUMMARY_RESULT_CHARS;
   return (
     `${s.slice(0, MAX_SUMMARY_RESULT_CHARS)}… ` +
-    `[truncated ${omitted} chars; full result on the workflow run record]`
+    `[truncated ${omitted} chars — fetch the full result with manage_workflows ` +
+    `{ action: "get_result", run_id: "${runId}" }]`
   );
 }
 


### PR DESCRIPTION
## Summary
The completion notification truncates large workflow results (2000 chars) and pointed the assistant at "the workflow run record" — but there was **no in-conversation way to fetch the full result**. `manage_workflows status` returns only metadata, so a finished run's full output was unreachable from a conversation.

- Add `manage_workflows` action **`get_result`** → returns the full `result_json` (+ status/error) from the run record (owner-scoped, like the other actions). The data already rides on `WorkflowRun.result`; `status` deliberately omits it to stay lightweight.
- Completion summary now points at `get_result` with the concrete `run_id` instead of the vague "on the workflow run record".
- TOOLS.json action enum + SKILL.md updated; test added.

Works retroactively — `get_result` reads the persisted result, so it fetches the full output of any already-completed run.