### PR TITLE
feat(providers): add model capability ranking + isStrictlyMoreCapable

### DIFF
--- a/assistant/src/providers/__tests__/model-tier.test.ts
+++ b/assistant/src/providers/__tests__/model-tier.test.ts
@@ -192,4 +192,22 @@ describe("isStrictlyMoreCapable", () => {
     );
     expect(isStrictlyMoreCapable("gpt-4o", "minimax-m3")).toBe(false);
   });
+
+  test("date-only Claude slugs do not outrank a real major.minor release", () => {
+    // The release date sits where the minor would be; it must parse as
+    // major-only (4.0), not minor 20250514.
+    expect(parseModelCapability("claude-sonnet-4-20250514")).toEqual({
+      lineage: "claude",
+      familyRank: CLAUDE_FAMILY_RANK.sonnet!,
+      version: 4,
+    });
+    // The dated 4.x build must NOT be surfaced as an upgrade over 4.6.
+    expect(
+      isStrictlyMoreCapable("claude-sonnet-4-20250514", "claude-sonnet-4-6"),
+    ).toBe(false);
+    // A higher family still upgrades over a dated lower-family build.
+    expect(
+      isStrictlyMoreCapable("claude-opus-4-8", "claude-sonnet-4-20250514"),
+    ).toBe(true);
+  });
 });

--- a/assistant/src/providers/__tests__/model-tier.test.ts
+++ b/assistant/src/providers/__tests__/model-tier.test.ts
@@ -11,12 +11,12 @@ describe("parseModelCapability", () => {
     expect(parseModelCapability("claude-opus-4-8")).toEqual({
       lineage: "claude",
       familyRank: CLAUDE_FAMILY_RANK.opus!,
-      version: 4.8,
+      version: 4.08,
     });
     expect(parseModelCapability("claude-sonnet-4-6")).toEqual({
       lineage: "claude",
       familyRank: CLAUDE_FAMILY_RANK.sonnet!,
-      version: 4.6,
+      version: 4.06,
     });
   });
 
@@ -24,7 +24,7 @@ describe("parseModelCapability", () => {
     expect(parseModelCapability("claude-haiku-4-5-20251001")).toEqual({
       lineage: "claude",
       familyRank: CLAUDE_FAMILY_RANK.haiku!,
-      version: 4.5,
+      version: 4.05,
     });
   });
 
@@ -32,7 +32,7 @@ describe("parseModelCapability", () => {
     expect(parseModelCapability("Claude-Opus-4-8")).toEqual({
       lineage: "claude",
       familyRank: CLAUDE_FAMILY_RANK.opus!,
-      version: 4.8,
+      version: 4.08,
     });
   });
 
@@ -40,17 +40,17 @@ describe("parseModelCapability", () => {
     expect(parseModelCapability("anthropic/claude-opus-4.8")).toEqual({
       lineage: "claude",
       familyRank: CLAUDE_FAMILY_RANK.opus!,
-      version: 4.8,
+      version: 4.08,
     });
     expect(parseModelCapability("anthropic/claude-sonnet-4.6")).toEqual({
       lineage: "claude",
       familyRank: CLAUDE_FAMILY_RANK.sonnet!,
-      version: 4.6,
+      version: 4.06,
     });
     expect(parseModelCapability("anthropic/claude-haiku-4.5")).toEqual({
       lineage: "claude",
       familyRank: CLAUDE_FAMILY_RANK.haiku!,
-      version: 4.5,
+      version: 4.05,
     });
   });
 

--- a/assistant/src/providers/__tests__/model-tier.test.ts
+++ b/assistant/src/providers/__tests__/model-tier.test.ts
@@ -36,6 +36,38 @@ describe("parseModelCapability", () => {
     });
   });
 
+  test("parses dotted, provider-prefixed OpenRouter ids", () => {
+    expect(parseModelCapability("anthropic/claude-opus-4.8")).toEqual({
+      lineage: "claude",
+      familyRank: CLAUDE_FAMILY_RANK.opus!,
+      version: 4.8,
+    });
+    expect(parseModelCapability("anthropic/claude-sonnet-4.6")).toEqual({
+      lineage: "claude",
+      familyRank: CLAUDE_FAMILY_RANK.sonnet!,
+      version: 4.6,
+    });
+    expect(parseModelCapability("anthropic/claude-haiku-4.5")).toEqual({
+      lineage: "claude",
+      familyRank: CLAUDE_FAMILY_RANK.haiku!,
+      version: 4.5,
+    });
+  });
+
+  test("dashed and dotted forms of the same model encode equal capability", () => {
+    expect(parseModelCapability("anthropic/claude-opus-4.8")).toEqual(
+      parseModelCapability("claude-opus-4-8")!,
+    );
+  });
+
+  test("parses a dotted, provider-prefixed single-tier id", () => {
+    expect(parseModelCapability("anthropic/claude-fable-5")).toEqual({
+      lineage: "fable",
+      familyRank: 0,
+      version: 5,
+    });
+  });
+
   test("parses single-tier lineages with familyRank 0", () => {
     expect(parseModelCapability("claude-fable-5")).toEqual({
       lineage: "fable",
@@ -107,6 +139,46 @@ describe("isStrictlyMoreCapable", () => {
     expect(isStrictlyMoreCapable("claude-mythos-5", "claude-opus-4-8")).toBe(
       false,
     );
+  });
+
+  test("ranks dotted, provider-prefixed OpenRouter ids", () => {
+    expect(
+      isStrictlyMoreCapable(
+        "anthropic/claude-opus-4.8",
+        "anthropic/claude-sonnet-4.6",
+      ),
+    ).toBe(true);
+    expect(
+      isStrictlyMoreCapable(
+        "anthropic/claude-sonnet-4.6",
+        "anthropic/claude-opus-4.8",
+      ),
+    ).toBe(false);
+  });
+
+  test("dashed and dotted forms of the same model are equal (neither more capable)", () => {
+    expect(
+      isStrictlyMoreCapable("claude-opus-4-8", "anthropic/claude-opus-4.8"),
+    ).toBe(false);
+    expect(
+      isStrictlyMoreCapable("anthropic/claude-opus-4.8", "claude-opus-4-8"),
+    ).toBe(false);
+  });
+
+  test("a dotted single-tier id is cross-lineage-false vs opus", () => {
+    expect(parseModelCapability("anthropic/claude-fable-5")).not.toBeNull();
+    expect(
+      isStrictlyMoreCapable(
+        "anthropic/claude-fable-5",
+        "anthropic/claude-opus-4.8",
+      ),
+    ).toBe(false);
+    expect(
+      isStrictlyMoreCapable(
+        "anthropic/claude-opus-4.8",
+        "anthropic/claude-fable-5",
+      ),
+    ).toBe(false);
   });
 
   test("unknown or non-Claude model on either side is false", () => {

--- a/assistant/src/providers/__tests__/model-tier.test.ts
+++ b/assistant/src/providers/__tests__/model-tier.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  CLAUDE_FAMILY_RANK,
+  isStrictlyMoreCapable,
+  parseModelCapability,
+} from "../model-tier.js";
+
+describe("parseModelCapability", () => {
+  test("parses tiered Claude families with version", () => {
+    expect(parseModelCapability("claude-opus-4-8")).toEqual({
+      lineage: "claude",
+      familyRank: CLAUDE_FAMILY_RANK.opus!,
+      version: 4.8,
+    });
+    expect(parseModelCapability("claude-sonnet-4-6")).toEqual({
+      lineage: "claude",
+      familyRank: CLAUDE_FAMILY_RANK.sonnet!,
+      version: 4.6,
+    });
+  });
+
+  test("ignores a trailing date suffix", () => {
+    expect(parseModelCapability("claude-haiku-4-5-20251001")).toEqual({
+      lineage: "claude",
+      familyRank: CLAUDE_FAMILY_RANK.haiku!,
+      version: 4.5,
+    });
+  });
+
+  test("is case-insensitive", () => {
+    expect(parseModelCapability("Claude-Opus-4-8")).toEqual({
+      lineage: "claude",
+      familyRank: CLAUDE_FAMILY_RANK.opus!,
+      version: 4.8,
+    });
+  });
+
+  test("parses single-tier lineages with familyRank 0", () => {
+    expect(parseModelCapability("claude-fable-5")).toEqual({
+      lineage: "fable",
+      familyRank: 0,
+      version: 5,
+    });
+    expect(parseModelCapability("claude-mythos-5")).toEqual({
+      lineage: "mythos",
+      familyRank: 0,
+      version: 5,
+    });
+  });
+
+  test("returns null for non-Claude and unknown ids", () => {
+    expect(parseModelCapability("gpt-4o")).toBeNull();
+    expect(parseModelCapability("minimax-m3")).toBeNull();
+    expect(parseModelCapability("gemini-2.5-pro")).toBeNull();
+    expect(parseModelCapability("")).toBeNull();
+  });
+});
+
+describe("isStrictlyMoreCapable", () => {
+  test("cross-family within the claude lineage: opus > sonnet > haiku", () => {
+    expect(
+      isStrictlyMoreCapable("claude-opus-4-8", "claude-sonnet-4-6"),
+    ).toBe(true);
+    expect(
+      isStrictlyMoreCapable("claude-sonnet-4-6", "claude-haiku-4-5-20251001"),
+    ).toBe(true);
+    expect(
+      isStrictlyMoreCapable("claude-opus-4-8", "claude-haiku-4-5-20251001"),
+    ).toBe(true);
+  });
+
+  test("lower family is not more capable than higher family", () => {
+    expect(
+      isStrictlyMoreCapable("claude-sonnet-4-6", "claude-opus-4-8"),
+    ).toBe(false);
+    expect(
+      isStrictlyMoreCapable("claude-haiku-4-5-20251001", "claude-sonnet-4-6"),
+    ).toBe(false);
+  });
+
+  test("version tiebreak within the same family", () => {
+    expect(
+      isStrictlyMoreCapable("claude-opus-4-8", "claude-opus-4-6"),
+    ).toBe(true);
+    expect(
+      isStrictlyMoreCapable("claude-opus-4-6", "claude-opus-4-8"),
+    ).toBe(false);
+  });
+
+  test("equal models are not strictly more capable", () => {
+    expect(
+      isStrictlyMoreCapable("claude-opus-4-8", "claude-opus-4-8"),
+    ).toBe(false);
+  });
+
+  test("cross-lineage comparisons are always false", () => {
+    expect(isStrictlyMoreCapable("claude-opus-4-8", "claude-fable-5")).toBe(
+      false,
+    );
+    expect(isStrictlyMoreCapable("claude-fable-5", "claude-opus-4-8")).toBe(
+      false,
+    );
+    expect(isStrictlyMoreCapable("claude-opus-4-8", "claude-mythos-5")).toBe(
+      false,
+    );
+    expect(isStrictlyMoreCapable("claude-mythos-5", "claude-opus-4-8")).toBe(
+      false,
+    );
+  });
+
+  test("unknown or non-Claude model on either side is false", () => {
+    expect(isStrictlyMoreCapable("gpt-4o", "claude-opus-4-8")).toBe(false);
+    expect(isStrictlyMoreCapable("claude-opus-4-8", "gpt-4o")).toBe(false);
+    expect(isStrictlyMoreCapable("minimax-m3", "claude-sonnet-4-6")).toBe(
+      false,
+    );
+    expect(isStrictlyMoreCapable("claude-sonnet-4-6", "minimax-m3")).toBe(
+      false,
+    );
+    expect(isStrictlyMoreCapable("gpt-4o", "minimax-m3")).toBe(false);
+  });
+});

--- a/assistant/src/providers/model-tier.ts
+++ b/assistant/src/providers/model-tier.ts
@@ -38,14 +38,54 @@ export const CLAUDE_FAMILY_RANK: Record<string, number> = {
 /** Single-tier Claude lineages, each its own non-comparable namespace. */
 const CLAUDE_SINGLE_TIER_LINEAGES = ["fable", "mythos"] as const;
 
-/** First `-<major>-<minor>` pair, e.g. `claude-opus-4-8` → major 4, minor 8. */
-const VERSION_PATTERN = /-(\d+)-(\d+)/;
+/**
+ * First `-<major>-<minor>` pair, e.g. `claude-opus-4-8` → major 4, minor 8.
+ * Matches the dashed ids used by first-party Anthropic configs.
+ */
+const VERSION_PATTERN_DASHED = /-(\d+)-(\d+)/;
 
-/** Single-tier lineages encode version as a bare trailing integer, e.g. `-5`. */
-const SINGLE_TIER_VERSION_PATTERN = /-(\d+)/;
+/**
+ * First `<major>.<minor>` pair, e.g. `anthropic/claude-opus-4.8` → major 4,
+ * minor 8. Matches the dotted, provider-prefixed ids OpenRouter exposes.
+ */
+const VERSION_PATTERN_DOTTED = /(\d+)\.(\d+)/;
+
+/**
+ * Single-tier lineages encode version as a trailing integer. Accepts both the
+ * dashed (`claude-fable-5`, also matches `anthropic/claude-fable-5`) and dotted
+ * (`claude-fable-5.2`) forms.
+ */
+const SINGLE_TIER_VERSION_PATTERN_DASHED = /-(\d+)/;
+const SINGLE_TIER_VERSION_PATTERN_DOTTED = /(\d+)\.(\d+)/;
 
 function encodeVersion(major: number, minor: number): number {
   return major + minor / 10;
+}
+
+/**
+ * Parse a tiered family's version from either the dashed (`-4-8`) or dotted
+ * (`4.8`) form, returning the same monotonic encoding for both so that the two
+ * spellings of one model compare equal. `null` when neither form is present.
+ */
+function parseTieredVersion(id: string): number | null {
+  const dashed = id.match(VERSION_PATTERN_DASHED);
+  if (dashed) return encodeVersion(Number(dashed[1]), Number(dashed[2]));
+  const dotted = id.match(VERSION_PATTERN_DOTTED);
+  if (dotted) return encodeVersion(Number(dotted[1]), Number(dotted[2]));
+  return null;
+}
+
+/**
+ * Parse a single-tier lineage's version from the bare trailing integer
+ * (`-5`, also matches a `provider/` prefix) or the dotted form (`5.2`).
+ * `null` when neither form is present.
+ */
+function parseSingleTierVersion(id: string): number | null {
+  const dotted = id.match(SINGLE_TIER_VERSION_PATTERN_DOTTED);
+  if (dotted) return encodeVersion(Number(dotted[1]), Number(dotted[2]));
+  const dashed = id.match(SINGLE_TIER_VERSION_PATTERN_DASHED);
+  if (dashed) return Number(dashed[1]);
+  return null;
 }
 
 /**
@@ -57,9 +97,8 @@ export function parseModelCapability(modelId: string): ModelCapability | null {
 
   for (const family of Object.keys(CLAUDE_FAMILY_RANK)) {
     if (id.includes(family)) {
-      const match = id.match(VERSION_PATTERN);
-      if (!match) return null;
-      const version = encodeVersion(Number(match[1]), Number(match[2]));
+      const version = parseTieredVersion(id);
+      if (version === null) return null;
       return {
         lineage: "claude",
         familyRank: CLAUDE_FAMILY_RANK[family]!,
@@ -70,9 +109,9 @@ export function parseModelCapability(modelId: string): ModelCapability | null {
 
   for (const lineage of CLAUDE_SINGLE_TIER_LINEAGES) {
     if (id.includes(lineage)) {
-      const match = id.match(SINGLE_TIER_VERSION_PATTERN);
-      if (!match) return null;
-      return { lineage, familyRank: 0, version: Number(match[1]) };
+      const version = parseSingleTierVersion(id);
+      if (version === null) return null;
+      return { lineage, familyRank: 0, version };
     }
   }
 

--- a/assistant/src/providers/model-tier.ts
+++ b/assistant/src/providers/model-tier.ts
@@ -22,8 +22,9 @@ export interface ModelCapability {
    */
   familyRank: number;
   /**
-   * Monotonic version. Tiered families encode `major + minor / 10` so that
-   * 4.8 > 4.6 > 4.5; single-tier lineages use the bare release integer.
+   * Monotonic version. Tiered families encode `major + minor / 100` so that
+   * 4.8 > 4.6 > 4.5 and a two-digit minor (4.10) stays within its major;
+   * single-tier lineages use the bare release integer.
    */
   version: number;
 }
@@ -59,7 +60,9 @@ const SINGLE_TIER_VERSION_PATTERN_DASHED = /-(\d+)/;
 const SINGLE_TIER_VERSION_PATTERN_DOTTED = /(\d+)\.(\d+)/;
 
 function encodeVersion(major: number, minor: number): number {
-  return major + minor / 10;
+  // Divide by 100 (not 10) so a two-digit minor (e.g. `4.10`) stays within its
+  // major (4.10, not 5.0) and never collides with the next major release.
+  return major + minor / 100;
 }
 
 /**
@@ -105,6 +108,10 @@ function parseSingleTierVersion(id: string): number | null {
  */
 export function parseModelCapability(modelId: string): ModelCapability | null {
   const id = modelId.toLowerCase();
+
+  // Require an explicit Claude marker so custom/BYOK ids that merely contain a
+  // family word (e.g. "my-sonnet-finetune") aren't mistaken for Claude models.
+  if (!id.includes("claude")) return null;
 
   for (const family of Object.keys(CLAUDE_FAMILY_RANK)) {
     if (id.includes(family)) {

--- a/assistant/src/providers/model-tier.ts
+++ b/assistant/src/providers/model-tier.ts
@@ -63,15 +63,26 @@ function encodeVersion(major: number, minor: number): number {
 }
 
 /**
+ * A version minor is a small integer. A large trailing segment is a release
+ * date (e.g. `claude-sonnet-4-20250514` → `20250514`), not a minor — treat
+ * such date-only slugs as major-only (minor 0) so an old dated build never
+ * outranks a real `major.minor` release like `claude-sonnet-4-6`.
+ */
+function normalizeMinor(raw: string): number {
+  const n = Number(raw);
+  return n >= 100 ? 0 : n;
+}
+
+/**
  * Parse a tiered family's version from either the dashed (`-4-8`) or dotted
  * (`4.8`) form, returning the same monotonic encoding for both so that the two
  * spellings of one model compare equal. `null` when neither form is present.
  */
 function parseTieredVersion(id: string): number | null {
   const dashed = id.match(VERSION_PATTERN_DASHED);
-  if (dashed) return encodeVersion(Number(dashed[1]), Number(dashed[2]));
+  if (dashed) return encodeVersion(Number(dashed[1]), normalizeMinor(dashed[2]));
   const dotted = id.match(VERSION_PATTERN_DOTTED);
-  if (dotted) return encodeVersion(Number(dotted[1]), Number(dotted[2]));
+  if (dotted) return encodeVersion(Number(dotted[1]), normalizeMinor(dotted[2]));
   return null;
 }
 

--- a/assistant/src/providers/model-tier.ts
+++ b/assistant/src/providers/model-tier.ts
@@ -1,0 +1,104 @@
+/**
+ * Explicit, ordinal capability ranking for Claude models.
+ *
+ * The model catalog carries pricing, context windows, and feature flags, but no
+ * ordinal "tier" field — there is no machine-readable way to say opus outranks
+ * sonnet outranks haiku, or that 4.8 outranks 4.6. This module defines that
+ * ordering so callers can decide whether one model is a genuine step up from
+ * another (e.g. surfacing a more capable advisor than the current executor).
+ *
+ * Pure module: no I/O, no daemon/config imports. Cheap to test and reuse.
+ */
+
+export interface ModelCapability {
+  /**
+   * Capability namespace. Models only compare against others sharing a lineage
+   * (e.g. the tiered "claude" family, or single-tier lineages like "fable").
+   */
+  lineage: string;
+  /**
+   * Ordinal rank within a tiered lineage (haiku < sonnet < opus). Single-tier
+   * lineages use 0 since there is no intra-lineage family ordering.
+   */
+  familyRank: number;
+  /**
+   * Monotonic version. Tiered families encode `major + minor / 10` so that
+   * 4.8 > 4.6 > 4.5; single-tier lineages use the bare release integer.
+   */
+  version: number;
+}
+
+/** Ordinal rank of each tiered Claude family. Higher is more capable. */
+export const CLAUDE_FAMILY_RANK: Record<string, number> = {
+  haiku: 1,
+  sonnet: 2,
+  opus: 3,
+};
+
+/** Single-tier Claude lineages, each its own non-comparable namespace. */
+const CLAUDE_SINGLE_TIER_LINEAGES = ["fable", "mythos"] as const;
+
+/** First `-<major>-<minor>` pair, e.g. `claude-opus-4-8` → major 4, minor 8. */
+const VERSION_PATTERN = /-(\d+)-(\d+)/;
+
+/** Single-tier lineages encode version as a bare trailing integer, e.g. `-5`. */
+const SINGLE_TIER_VERSION_PATTERN = /-(\d+)/;
+
+function encodeVersion(major: number, minor: number): number {
+  return major + minor / 10;
+}
+
+/**
+ * Parse a model id into its capability coordinates, or `null` when the id is
+ * not a recognized Claude model (other providers, unknown ids).
+ */
+export function parseModelCapability(modelId: string): ModelCapability | null {
+  const id = modelId.toLowerCase();
+
+  for (const family of Object.keys(CLAUDE_FAMILY_RANK)) {
+    if (id.includes(family)) {
+      const match = id.match(VERSION_PATTERN);
+      if (!match) return null;
+      const version = encodeVersion(Number(match[1]), Number(match[2]));
+      return {
+        lineage: "claude",
+        familyRank: CLAUDE_FAMILY_RANK[family]!,
+        version,
+      };
+    }
+  }
+
+  for (const lineage of CLAUDE_SINGLE_TIER_LINEAGES) {
+    if (id.includes(lineage)) {
+      const match = id.match(SINGLE_TIER_VERSION_PATTERN);
+      if (!match) return null;
+      return { lineage, familyRank: 0, version: Number(match[1]) };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Whether `advisorModel` is a strictly more capable model than `executorModel`.
+ *
+ * Conservative by design: returns `false` for any unrecognized model or any
+ * cross-lineage comparison, so callers never surface an "upgrade" they cannot
+ * confidently rank. Within a lineage, capability is ordered lexicographically
+ * by `(familyRank, version)`.
+ */
+export function isStrictlyMoreCapable(
+  advisorModel: string,
+  executorModel: string,
+): boolean {
+  const advisor = parseModelCapability(advisorModel);
+  const executor = parseModelCapability(executorModel);
+
+  if (!advisor || !executor) return false;
+  if (advisor.lineage !== executor.lineage) return false;
+
+  if (advisor.familyRank !== executor.familyRank) {
+    return advisor.familyRank > executor.familyRank;
+  }
+  return advisor.version > executor.version;
+}


### PR DESCRIPTION
## Summary
- Add `model-tier.ts`: explicit Claude family ranking (haiku<sonnet<opus, version tiebreak) since the catalog has no ordinal tier
- `isStrictlyMoreCapable(advisor, executor)` — conservative false on unknown/cross-lineage
- Unit tests across families, versions, lineages, unknown ids

Part of plan: advisor-tool.md (PR 2 of 6)