### PR TITLE
feat(providers): sanitize trailing dangling tool_use for nested inference

### DIFF
--- a/assistant/src/__tests__/conversation-history-web-search.test.ts
+++ b/assistant/src/__tests__/conversation-history-web-search.test.ts
@@ -834,6 +834,13 @@ describe("web_search_tool_result structural guard", () => {
     // are stripped earlier by `buildMessageContentBlocks` and cannot reach
     // this filter, so only `tool_use` ↔ `tool_result` pairing is relevant.
     "messaging/providers/slack/render-transcript.ts",
+
+    // Removes orphaned `tool_use` blocks (e.g. the advisor tool's own in-flight
+    // `tool_use`) before a mid-turn nested inference. Only `tool_use` ↔
+    // `tool_result` pairing is relevant; server-side blocks (`server_tool_use` /
+    // `web_search_tool_result`) are left intact and repaired by the Anthropic
+    // client's orphan pass downstream. Same reasoning as the Slack renderer above.
+    "providers/sanitize-transcript.ts",
   ]);
 
   /**

--- a/assistant/src/providers/__tests__/sanitize-transcript.test.ts
+++ b/assistant/src/providers/__tests__/sanitize-transcript.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+
+import { sanitizeTranscriptForNestedInference } from "../sanitize-transcript.js";
+import type { Message } from "../types.js";
+
+describe("sanitizeTranscriptForNestedInference", () => {
+  test("drops a trailing dangling tool_use and the now-empty message", () => {
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "do the thing" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "working on it" },
+          { type: "tool_use", id: "tu_done", name: "search", input: {} },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "tu_done",
+            content: "found it",
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "tu_inflight", name: "advisor", input: {} },
+        ],
+      },
+    ];
+
+    const result = sanitizeTranscriptForNestedInference(messages);
+
+    expect(result).toHaveLength(3);
+    expect(result[1].content).toEqual([
+      { type: "text", text: "working on it" },
+      { type: "tool_use", id: "tu_done", name: "search", input: {} },
+    ]);
+    expect(result[2].role).toBe("user");
+    const allToolUseIds = result.flatMap((m) =>
+      m.content
+        .filter((b) => b.type === "tool_use")
+        .map((b) => (b as { id: string }).id),
+    );
+    expect(allToolUseIds).toEqual(["tu_done"]);
+  });
+
+  test("dropToolUseId removes a matched tool_use too", () => {
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "calling advisor" },
+          { type: "tool_use", id: "tu_advisor", name: "advisor", input: {} },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "tu_advisor",
+            content: "advice",
+          },
+        ],
+      },
+    ];
+
+    const result = sanitizeTranscriptForNestedInference(messages, {
+      dropToolUseId: "tu_advisor",
+    });
+
+    expect(result[0].content).toEqual([
+      { type: "text", text: "calling advisor" },
+    ]);
+  });
+
+  test("preserves a tool_use with a matching tool_result in a later message", () => {
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "tu_ok", name: "search", input: { q: "x" } },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "tu_ok", content: "result" },
+        ],
+      },
+    ];
+
+    const result = sanitizeTranscriptForNestedInference(messages);
+
+    expect(result).toEqual(messages);
+  });
+
+  test("does not mutate the input", () => {
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "thinking" },
+          { type: "tool_use", id: "tu_inflight", name: "advisor", input: {} },
+        ],
+      },
+    ];
+    const snapshot = structuredClone(messages);
+
+    sanitizeTranscriptForNestedInference(messages, {
+      dropToolUseId: "tu_inflight",
+    });
+
+    expect(messages).toEqual(snapshot);
+  });
+});

--- a/assistant/src/providers/sanitize-transcript.test.ts
+++ b/assistant/src/providers/sanitize-transcript.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from "bun:test";
+
+import { sanitizeTranscriptForNestedInference } from "./sanitize-transcript.js";
+import type { Message } from "./types.js";
+
+describe("sanitizeTranscriptForNestedInference", () => {
+  test("drops a trailing dangling tool_use with no matching tool_result", () => {
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "calling a tool" },
+          { type: "tool_use", id: "call_1", name: "search", input: {} },
+        ],
+      },
+    ];
+
+    const result = sanitizeTranscriptForNestedInference(messages);
+
+    expect(result).toEqual([
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+      { role: "assistant", content: [{ type: "text", text: "calling a tool" }] },
+    ]);
+  });
+
+  test("drops a message left empty after removing its only tool_use", () => {
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "call_1", name: "search", input: {} }],
+      },
+    ];
+
+    const result = sanitizeTranscriptForNestedInference(messages);
+
+    expect(result).toEqual([
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+    ]);
+  });
+
+  test("keeps a completed tool_use/tool_result pair untouched", () => {
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "call_1", name: "search", input: {} }],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "call_1", content: "result" },
+        ],
+      },
+    ];
+
+    const result = sanitizeTranscriptForNestedInference(messages);
+
+    expect(result).toEqual(messages);
+  });
+
+  test("removes paired tool_result when dropToolUseId targets a completed call", () => {
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "thinking" },
+          { type: "tool_use", id: "advisor_call", name: "advisor", input: {} },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "advisor_call",
+            content: "advice",
+          },
+        ],
+      },
+    ];
+
+    const result = sanitizeTranscriptForNestedInference(messages, {
+      dropToolUseId: "advisor_call",
+    });
+
+    // The assistant tool_use is gone, its text survives, and the user message
+    // that held only the paired tool_result is dropped entirely — no orphan.
+    expect(result).toEqual([
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+      { role: "assistant", content: [{ type: "text", text: "thinking" }] },
+    ]);
+
+    const orphanResults = result.flatMap((m) =>
+      m.content.filter((b) => b.type === "tool_result"),
+    );
+    expect(orphanResults).toEqual([]);
+  });
+
+  test("removes only the targeted pair, leaving sibling pairs intact", () => {
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "call_keep", name: "search", input: {} },
+          { type: "tool_use", id: "call_drop", name: "advisor", input: {} },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "call_keep", content: "kept" },
+          { type: "tool_result", tool_use_id: "call_drop", content: "dropped" },
+        ],
+      },
+    ];
+
+    const result = sanitizeTranscriptForNestedInference(messages, {
+      dropToolUseId: "call_drop",
+    });
+
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "call_keep", name: "search", input: {} },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "call_keep", content: "kept" },
+        ],
+      },
+    ]);
+  });
+
+  test("does not mutate the input messages or their content arrays", () => {
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "thinking" },
+          { type: "tool_use", id: "call_1", name: "search", input: {} },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "call_1", content: "result" },
+        ],
+      },
+    ];
+    const snapshot = JSON.parse(JSON.stringify(messages));
+
+    sanitizeTranscriptForNestedInference(messages, { dropToolUseId: "call_1" });
+
+    expect(messages).toEqual(snapshot);
+  });
+
+  test("leaves other block types untouched", () => {
+    const messages: Message[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "hmm", signature: "sig" },
+          { type: "server_tool_use", id: "srv_1", name: "web_search", input: {} },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "web_search_tool_result",
+            tool_use_id: "srv_1",
+            content: "opaque",
+          },
+        ],
+      },
+    ];
+
+    const result = sanitizeTranscriptForNestedInference(messages, {
+      dropToolUseId: "nonexistent",
+    });
+
+    expect(result).toEqual(messages);
+  });
+});

--- a/assistant/src/providers/sanitize-transcript.ts
+++ b/assistant/src/providers/sanitize-transcript.ts
@@ -12,6 +12,12 @@ import type { ContentBlock, Message } from "./types.js";
  * caller additionally drop a specific `tool_use` (e.g. the advisor tool's own
  * call) even when it does have a matching result.
  *
+ * Pairing is bidirectional: whenever a `tool_use` block is removed, its paired
+ * `tool_result` (if the call had completed) is removed too. Leaving the
+ * `tool_result` behind would orphan it — a `tool_result` whose `tool_use_id`
+ * references nothing — which is the same invalid shape this sanitizer exists to
+ * prevent and would still cause a provider 400.
+ *
  * Pure: the input and its blocks are never mutated; modified messages are
  * cloned and a new array is returned.
  */
@@ -31,23 +37,38 @@ export function sanitizeTranscriptForNestedInference(
     }
   }
 
+  // Every `tool_use` id we will remove: the explicitly dropped one (if any)
+  // plus every assistant `tool_use` with no matching `tool_result` (the
+  // trailing-dangling case). Both their `tool_use` blocks AND any paired
+  // `tool_result` blocks are stripped below so neither side is left orphaned.
+  const removedToolUseIds = new Set<string>();
+  if (dropToolUseId !== undefined) {
+    removedToolUseIds.add(dropToolUseId);
+  }
+  for (const message of messages) {
+    if (message.role !== "assistant") continue;
+    for (const block of message.content) {
+      if (block.type === "tool_use" && !matchedResultIds.has(block.id)) {
+        removedToolUseIds.add(block.id);
+      }
+    }
+  }
+
   const sanitized: Message[] = [];
   for (const message of messages) {
-    if (message.role !== "assistant") {
-      sanitized.push(message);
-      continue;
-    }
-
     const keptContent: ContentBlock[] = [];
     let droppedAny = false;
     for (const block of message.content) {
-      if (block.type === "tool_use") {
-        const isUnmatched = !matchedResultIds.has(block.id);
-        const isExplicitlyDropped = block.id === dropToolUseId;
-        if (isUnmatched || isExplicitlyDropped) {
-          droppedAny = true;
-          continue;
-        }
+      if (block.type === "tool_use" && removedToolUseIds.has(block.id)) {
+        droppedAny = true;
+        continue;
+      }
+      if (
+        block.type === "tool_result" &&
+        removedToolUseIds.has(block.tool_use_id)
+      ) {
+        droppedAny = true;
+        continue;
       }
       keptContent.push(block);
     }

--- a/assistant/src/providers/sanitize-transcript.ts
+++ b/assistant/src/providers/sanitize-transcript.ts
@@ -1,0 +1,64 @@
+import type { ContentBlock, Message } from "./types.js";
+
+/**
+ * Strip trailing dangling `tool_use` blocks from a transcript before running a
+ * nested inference call mid-turn.
+ *
+ * When a tool executor makes its own inference partway through a turn, the
+ * transcript it inherits ends with the assistant message holding the in-flight
+ * `tool_use` block(s) — the tool hasn't returned yet, so there is no matching
+ * `tool_result`. Anthropic 400s on any `tool_use` without a paired result, so
+ * those blocks must be removed before the nested call. `dropToolUseId` lets a
+ * caller additionally drop a specific `tool_use` (e.g. the advisor tool's own
+ * call) even when it does have a matching result.
+ *
+ * Pure: the input and its blocks are never mutated; modified messages are
+ * cloned and a new array is returned.
+ */
+export function sanitizeTranscriptForNestedInference(
+  messages: Message[],
+  opts?: { dropToolUseId?: string },
+): Message[] {
+  const dropToolUseId = opts?.dropToolUseId;
+
+  const matchedResultIds = new Set<string>();
+  for (const message of messages) {
+    if (message.role !== "user") continue;
+    for (const block of message.content) {
+      if (block.type === "tool_result") {
+        matchedResultIds.add(block.tool_use_id);
+      }
+    }
+  }
+
+  const sanitized: Message[] = [];
+  for (const message of messages) {
+    if (message.role !== "assistant") {
+      sanitized.push(message);
+      continue;
+    }
+
+    const keptContent: ContentBlock[] = [];
+    let droppedAny = false;
+    for (const block of message.content) {
+      if (block.type === "tool_use") {
+        const isUnmatched = !matchedResultIds.has(block.id);
+        const isExplicitlyDropped = block.id === dropToolUseId;
+        if (isUnmatched || isExplicitlyDropped) {
+          droppedAny = true;
+          continue;
+        }
+      }
+      keptContent.push(block);
+    }
+
+    if (!droppedAny) {
+      sanitized.push(message);
+      continue;
+    }
+    if (keptContent.length === 0) continue;
+    sanitized.push({ role: message.role, content: keptContent });
+  }
+
+  return sanitized;
+}


### PR DESCRIPTION
## Summary
- Add `sanitizeTranscriptForNestedInference`: drops trailing unmatched `tool_use` blocks (and an explicit `dropToolUseId`) so a mid-turn nested inference doesn't 400
- Pure, non-mutating; modeled on the existing anthropic orphan-repair
- Unit tests for dangling/ matched / dropToolUseId / no-mutation

Part of plan: advisor-tool.md (PR 3 of 6)