### PR TITLE
feat(tools): add synchronous advisor consult executor

### DIFF
--- a/assistant/src/tools/advisor/__tests__/consult.test.ts
+++ b/assistant/src/tools/advisor/__tests__/consult.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  Message,
+  ProviderResponse,
+  SendMessageOptions,
+} from "../../../providers/types.js";
+import type { ToolContext } from "../../types.js";
+
+// ── Silence the logger ─────────────────────────────────────────────────
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// ── Mutable mock state ─────────────────────────────────────────────────
+// `mockMessages` stands in for the live conversation's transcript;
+// `conversationExists` toggles the registry lookup. `providerResult`
+// controls what `getConfiguredProvider` returns; `sendMessageImpl` lets a
+// test stub the provider response or throw.
+
+let mockMessages: Message[] = [];
+let conversationExists = true;
+
+let providerResult: { sendMessage: typeof sendMessageMock } | null = null;
+let lastSendMessages: Message[] | null = null;
+let lastSendOptions: SendMessageOptions | undefined;
+
+let sendMessageImpl: (
+  messages: Message[],
+  options?: SendMessageOptions,
+) => Promise<ProviderResponse> = async () => textResponse("default advice");
+
+const sendMessageMock = mock(
+  (messages: Message[], options?: SendMessageOptions) => {
+    lastSendMessages = messages;
+    lastSendOptions = options;
+    return sendMessageImpl(messages, options);
+  },
+);
+
+mock.module("../../../daemon/conversation-registry.js", () => ({
+  findConversation: () =>
+    conversationExists ? { messages: mockMessages } : undefined,
+}));
+
+// Spread the real module so `extractAllText` (also imported by consult.ts)
+// keeps its production implementation; only `getConfiguredProvider` is stubbed.
+const realProviderSend = await import(
+  "../../../providers/provider-send-message.js"
+);
+mock.module("../../../providers/provider-send-message.js", () => ({
+  ...realProviderSend,
+  getConfiguredProvider: async () => providerResult,
+}));
+
+// Imports AFTER mocks so the mocked modules are picked up.
+const { executeAdvisorConsult } = await import("../consult.js");
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function textResponse(text: string): ProviderResponse {
+  return {
+    content: [{ type: "text", text }],
+    model: "mock-model",
+    usage: { inputTokens: 0, outputTokens: 0 },
+    stopReason: "end_turn",
+  };
+}
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    conversationId: "conv-1",
+    workingDir: "/tmp",
+    trustClass: "guardian",
+    ...overrides,
+  };
+}
+
+function userText(text: string): Message {
+  return { role: "user", content: [{ type: "text", text }] };
+}
+
+beforeEach(() => {
+  mockMessages = [];
+  conversationExists = true;
+  providerResult = { sendMessage: sendMessageMock };
+  lastSendMessages = null;
+  lastSendOptions = undefined;
+  sendMessageImpl = async () => textResponse("default advice");
+  sendMessageMock.mockClear();
+});
+
+describe("executeAdvisorConsult", () => {
+  test("happy path: sanitizes transcript, appends focus nudge, sends one tool-less advisor call", async () => {
+    // A completed turn plus a DANGLING tool_use the sanitizer must drop.
+    mockMessages = [
+      userText("Build the feature"),
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "On it." }],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "dangling-1", name: "bash", input: {} },
+        ],
+      },
+    ];
+    sendMessageImpl = async () => textResponse("Do X before Y.");
+
+    const result = await executeAdvisorConsult({}, makeContext());
+
+    expect(result).toEqual({ content: "Do X before Y.", isError: false });
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+
+    const sent = lastSendMessages ?? [];
+    // (a) sanitizer ran — the dangling tool_use is gone.
+    const hasDangling = sent.some((m) =>
+      m.content.some(
+        (b) => b.type === "tool_use" && b.id === "dangling-1",
+      ),
+    );
+    expect(hasDangling).toBe(false);
+
+    // (b) ends with the advisor's trailing user turn carrying the nudge.
+    const last = sent[sent.length - 1];
+    expect(last.role).toBe("user");
+    const lastText =
+      last.content[0]?.type === "text" ? last.content[0].text : "";
+    expect(lastText).toContain("Review the work so far");
+    expect(lastText).toContain("under ~120 words");
+
+    // (c) no tools, correct call site.
+    expect(lastSendOptions?.tools).toBeUndefined();
+    expect(lastSendOptions?.config?.callSite).toBe("advisor");
+    expect(lastSendOptions?.systemPrompt).toBeTruthy();
+  });
+
+  test("focus provided: it appears in the trailing user message", async () => {
+    mockMessages = [userText("Working on auth")];
+
+    await executeAdvisorConsult(
+      { focus: "Is the token refresh logic safe?" },
+      makeContext(),
+    );
+
+    const sent = lastSendMessages ?? [];
+    const last = sent[sent.length - 1];
+    const lastText =
+      last.content[0]?.type === "text" ? last.content[0].text : "";
+    expect(lastText).toContain("Is the token refresh logic safe?");
+    expect(lastText).toContain("under ~120 words");
+  });
+
+  test("no provider configured: returns higher-tier message, never calls sendMessage", async () => {
+    mockMessages = [userText("hi")];
+    providerResult = null;
+
+    const result = await executeAdvisorConsult({}, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("no higher-tier model");
+    expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  test("no conversation: degrades without throwing or calling sendMessage", async () => {
+    conversationExists = false;
+
+    const result = await executeAdvisorConsult({}, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("conversation could not be resolved");
+    expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  test("empty transcript: nothing to advise on", async () => {
+    mockMessages = [];
+
+    const result = await executeAdvisorConsult({}, makeContext());
+
+    expect(result).toEqual({
+      content: "Nothing to advise on yet.",
+      isError: false,
+    });
+    expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  test("sendMessage throws: degrades as isError:false and does not throw", async () => {
+    mockMessages = [userText("hi")];
+    sendMessageImpl = async () => {
+      throw new Error("provider exploded");
+    };
+
+    const result = await executeAdvisorConsult({}, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Advisor consult failed");
+    expect(result.content).toContain("provider exploded");
+  });
+
+  test("empty advice: returns the no-guidance message", async () => {
+    mockMessages = [userText("hi")];
+    sendMessageImpl = async () => textResponse("   ");
+
+    const result = await executeAdvisorConsult({}, makeContext());
+
+    expect(result).toEqual({
+      content: "Advisor returned no guidance.",
+      isError: false,
+    });
+  });
+});

--- a/assistant/src/tools/advisor/__tests__/consult.test.ts
+++ b/assistant/src/tools/advisor/__tests__/consult.test.ts
@@ -25,6 +25,7 @@ let mockMessages: Message[] = [];
 let conversationExists = true;
 
 let providerResult: { sendMessage: typeof sendMessageMock } | null = null;
+let providerResolveThrows = false;
 let lastSendMessages: Message[] | null = null;
 let lastSendOptions: SendMessageOptions | undefined;
 
@@ -53,7 +54,10 @@ const realProviderSend = await import(
 );
 mock.module("../../../providers/provider-send-message.js", () => ({
   ...realProviderSend,
-  getConfiguredProvider: async () => providerResult,
+  getConfiguredProvider: async () => {
+    if (providerResolveThrows) throw new Error("stale provider_connection");
+    return providerResult;
+  },
 }));
 
 // Imports AFTER mocks so the mocked modules are picked up.
@@ -87,6 +91,7 @@ beforeEach(() => {
   mockMessages = [];
   conversationExists = true;
   providerResult = { sendMessage: sendMessageMock };
+  providerResolveThrows = false;
   lastSendMessages = null;
   lastSendOptions = undefined;
   sendMessageImpl = async () => textResponse("default advice");
@@ -163,6 +168,17 @@ describe("executeAdvisorConsult", () => {
 
     expect(result.isError).toBe(false);
     expect(result.content).toContain("no higher-tier model");
+    expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  test("provider resolution throws: degrades as isError:false and does not throw", async () => {
+    mockMessages = [userText("hi")];
+    providerResolveThrows = true;
+
+    const result = await executeAdvisorConsult({}, makeContext());
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Advisor consult failed");
     expect(sendMessageMock).not.toHaveBeenCalled();
   });
 

--- a/assistant/src/tools/advisor/consult.ts
+++ b/assistant/src/tools/advisor/consult.ts
@@ -59,16 +59,21 @@ export async function executeAdvisorConsult(
     : `Review the work so far and advise on the best next step or any course-correction.\n\n${nudge}`;
   const messages: Message[] = [...base, userMessage(ask)];
 
-  const provider = await getConfiguredProvider("advisor");
-  if (!provider) {
-    return {
-      content:
-        "Advisor unavailable: no higher-tier model is configured or reachable.",
-      isError: false,
-    };
-  }
-
   try {
+    // Provider resolution stays inside the soft-fail path: a misconfigured
+    // advisor call site (stale provider_connection, DB lookup failure, invalid
+    // profile) can make getConfiguredProvider throw, and the advisor must never
+    // abort the executor's turn — degrade to isError:false like every other
+    // failure mode here.
+    const provider = await getConfiguredProvider("advisor");
+    if (!provider) {
+      return {
+        content:
+          "Advisor unavailable: no higher-tier model is configured or reachable.",
+        isError: false,
+      };
+    }
+
     const response = await provider.sendMessage(messages, {
       systemPrompt: ADVISOR_SYSTEM_PROMPT,
       config: { callSite: "advisor" },

--- a/assistant/src/tools/advisor/consult.ts
+++ b/assistant/src/tools/advisor/consult.ts
@@ -1,0 +1,87 @@
+import { findConversation } from "../../daemon/conversation-registry.js";
+import {
+  extractAllText,
+  getConfiguredProvider,
+  userMessage,
+} from "../../providers/provider-send-message.js";
+import { sanitizeTranscriptForNestedInference } from "../../providers/sanitize-transcript.js";
+import type { Message } from "../../providers/types.js";
+import { getLogger } from "../../util/logger.js";
+import type { ToolContext, ToolExecutionResult } from "../types.js";
+
+const log = getLogger("advisor-consult");
+
+/**
+ * Advisor's own system prompt. The native advisor tool supplies this
+ * server-side; for the local executor we author it here.
+ */
+const ADVISOR_SYSTEM_PROMPT =
+  "You are a senior technical advisor reviewing another AI agent's work. You see its full conversation transcript — the task, every tool call, and every result. You have no tools and cannot ask questions: give your single best judgment. Produce a focused plan or course-correction, not a comprehensive write-up. Lead with the most important decision or risk. If the agent is about to commit to a flawed approach, say so plainly and give the better one. Keep it tight (aim for under ~120 words).";
+
+/**
+ * Run a single synchronous "consult the advisor" inference: a higher-tier model
+ * reviews the executor's transcript so far and returns focused guidance, which
+ * becomes the tool result.
+ *
+ * Error-handling decision (see `assistant/docs/error-handling.md`, pattern 2 —
+ * `ToolExecutionResult` content + error flag): EVERY failure mode here degrades
+ * as `isError: false`. A flaky or unavailable advisor must never abort the
+ * executor's turn — it is an optional second opinion, not a load-bearing step.
+ * This mirrors the native advisor tool's "the request itself does not fail"
+ * behavior. Do NOT switch these to `isError: true`.
+ */
+export async function executeAdvisorConsult(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): Promise<ToolExecutionResult> {
+  const focus = input.focus as string | undefined;
+
+  const conversation = findConversation(context.conversationId);
+  if (!conversation) {
+    return {
+      content: "Advisor unavailable: conversation could not be resolved.",
+      isError: false,
+    };
+  }
+
+  const base = sanitizeTranscriptForNestedInference(
+    [...conversation.messages],
+    context.toolUseId ? { dropToolUseId: context.toolUseId } : undefined,
+  );
+  if (base.length === 0) {
+    return { content: "Nothing to advise on yet.", isError: false };
+  }
+
+  const nudge =
+    "(Advisor: keep your guidance under ~120 words — a focused plan or course-correction, not a comprehensive write-up.)";
+  const ask = focus
+    ? `${focus}\n\n${nudge}`
+    : `Review the work so far and advise on the best next step or any course-correction.\n\n${nudge}`;
+  const messages: Message[] = [...base, userMessage(ask)];
+
+  const provider = await getConfiguredProvider("advisor");
+  if (!provider) {
+    return {
+      content:
+        "Advisor unavailable: no higher-tier model is configured or reachable.",
+      isError: false,
+    };
+  }
+
+  try {
+    const response = await provider.sendMessage(messages, {
+      systemPrompt: ADVISOR_SYSTEM_PROMPT,
+      config: { callSite: "advisor" },
+      signal: context.signal,
+    });
+    const advice = extractAllText(response).trim();
+    if (!advice) {
+      return { content: "Advisor returned no guidance.", isError: false };
+    }
+    return { content: advice, isError: false };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.warn({ err }, "advisor consult failed");
+    return { content: `Advisor consult failed: ${msg}`, isError: false };
+  }
+}


### PR DESCRIPTION
## Summary
- Add executeAdvisorConsult: one nested LLM call to the advisor call-site over the sanitized transcript, no tools, returns advice as the tool result
- All failure modes degrade as isError:false so a flaky/unavailable advisor never aborts the turn
- Tests for happy path, no-provider, throw, and focus threading

Part of plan: advisor-tool.md (PR 4 of 6)