### PR TITLE
feat(tools): register advisor tool gated by higher-tier availability

### DIFF
--- a/assistant/src/daemon/__tests__/conversation-tool-setup-advisor.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-tool-setup-advisor.test.ts
@@ -47,6 +47,7 @@ function makeLlmConfig(
   executorModel: string,
   advisorModel: string,
   overrideProfiles: Record<string, string> = {},
+  extraCallSites: Record<string, unknown> = {},
 ): LLMConfig {
   return {
     default: { model: executorModel },
@@ -63,6 +64,7 @@ function makeLlmConfig(
     callSites: {
       mainAgent: { model: executorModel },
       advisor: { profile: "advisor" },
+      ...extraCallSites,
     },
   } as unknown as LLMConfig;
 }
@@ -156,6 +158,24 @@ describe("advisor gate — per-turn override re-evaluation", () => {
       isToolActiveForContext(
         "advisor",
         makeCtx({ currentTurnOverrideProfile: "lowTier" }),
+      ),
+    ).toBe(true);
+  });
+
+  test("gates against the actual turn call site, not always mainAgent", () => {
+    // mainAgent is top-tier (== advisor), but this turn runs under
+    // heartbeatAgent, which uses a lower-tier model — so the advisor IS a
+    // genuine upgrade for the turn and must be exposed.
+    getConfigSpy = stubConfig(
+      makeLlmConfig(OPUS, OPUS, {}, { heartbeatAgent: { model: HAIKU } }),
+    );
+    // Default call site is mainAgent (== advisor) → hidden.
+    expect(isToolActiveForContext("advisor", makeCtx())).toBe(false);
+    // The actual turn call site (heartbeatAgent, HAIKU) → exposed.
+    expect(
+      isToolActiveForContext(
+        "advisor",
+        makeCtx({ currentCallSite: "heartbeatAgent" }),
       ),
     ).toBe(true);
   });

--- a/assistant/src/daemon/__tests__/conversation-tool-setup-advisor.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-tool-setup-advisor.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for the per-turn advisor-tool gate in `conversation-tool-setup.ts`.
+ *
+ * The advisor tool is registered as an always-on core tool, but it is only
+ * exposed to the model when a strictly-more-capable model is configured for
+ * the conversation's current executor. The gate is re-evaluated each turn and
+ * respects per-conversation profile overrides, so:
+ *
+ * - executor on a lower tier than the advisor → advisor present / active.
+ * - executor == advisor (top tier) → advisor absent / inactive.
+ * - a per-turn override that pins a top-tier executor → advisor absent.
+ * - a per-turn override that pins a low-tier executor → advisor present.
+ *
+ * `createResolveToolsCallback` and `isToolActiveForContext` must agree on
+ * advisor visibility — the callback filters core tools through the same gate.
+ */
+
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+
+import * as configLoader from "../../config/loader.js";
+import type { AssistantConfig } from "../../config/schema.js";
+import type { LLMSchema } from "../../config/schemas/llm.js";
+import type { ToolDefinition } from "../../providers/types.js";
+import { __clearRegistryForTesting } from "../../tools/registry.js";
+import {
+  createResolveToolsCallback,
+  isToolActiveForContext,
+} from "../conversation-tool-setup.js";
+
+type SkillProjectionContext =
+  import("../conversation-tool-setup.js").SkillProjectionContext;
+type SkillProjectionCache =
+  import("../conversation-skill-tools.js").SkillProjectionCache;
+type LLMConfig = import("zod").z.infer<typeof LLMSchema>;
+
+const OPUS = "claude-opus-4-8";
+const SONNET = "claude-sonnet-4-6";
+const HAIKU = "claude-haiku-4-5";
+
+/**
+ * Build an `llm` config whose `mainAgent` resolves to `executorModel` and
+ * whose `advisor` call-site resolves to `advisorModel`. The advisor call-site
+ * points at the `advisor` profile (mirroring the seeded default); the
+ * executor model comes from the `mainAgent` call-site override.
+ */
+function makeLlmConfig(
+  executorModel: string,
+  advisorModel: string,
+  overrideProfiles: Record<string, string> = {},
+): LLMConfig {
+  return {
+    default: { model: executorModel },
+    activeProfile: undefined,
+    profiles: {
+      advisor: { model: advisorModel },
+      ...Object.fromEntries(
+        Object.entries(overrideProfiles).map(([name, model]) => [
+          name,
+          { model },
+        ]),
+      ),
+    },
+    callSites: {
+      mainAgent: { model: executorModel },
+      advisor: { profile: "advisor" },
+    },
+  } as unknown as LLMConfig;
+}
+
+function stubConfig(llm: LLMConfig): ReturnType<typeof spyOn> {
+  const stub: Partial<AssistantConfig> = {
+    llm: llm as AssistantConfig["llm"],
+    tools: { exclude: [] },
+  };
+  return spyOn(configLoader, "getConfig").mockReturnValue(
+    stub as AssistantConfig,
+  );
+}
+
+function makeCtx(
+  overrides: Partial<SkillProjectionContext> = {},
+): SkillProjectionContext {
+  return {
+    skillProjectionState: new Map(),
+    skillProjectionCache: { fingerprints: new Map() } as SkillProjectionCache,
+    coreToolNames: new Set<string>(),
+    toolsDisabledDepth: 0,
+    conversationId: "conv-advisor",
+    ...overrides,
+  };
+}
+
+function def(name: string): ToolDefinition {
+  return { name, description: name, input_schema: { type: "object" } };
+}
+
+let getConfigSpy: ReturnType<typeof spyOn> | undefined;
+
+beforeEach(() => {
+  __clearRegistryForTesting();
+});
+
+afterEach(() => {
+  getConfigSpy?.mockRestore();
+  getConfigSpy = undefined;
+  __clearRegistryForTesting();
+});
+
+describe("advisor gate — isToolActiveForContext", () => {
+  test("advisor IS active when executor is below the advisor tier (sonnet < opus)", () => {
+    getConfigSpy = stubConfig(makeLlmConfig(SONNET, OPUS));
+    expect(isToolActiveForContext("advisor", makeCtx())).toBe(true);
+  });
+
+  test("advisor IS active when executor is haiku and advisor is opus", () => {
+    getConfigSpy = stubConfig(makeLlmConfig(HAIKU, OPUS));
+    expect(isToolActiveForContext("advisor", makeCtx())).toBe(true);
+  });
+
+  test("advisor is INACTIVE when executor == advisor (opus 4.8)", () => {
+    getConfigSpy = stubConfig(makeLlmConfig(OPUS, OPUS));
+    expect(isToolActiveForContext("advisor", makeCtx())).toBe(false);
+  });
+
+  test("advisor is INACTIVE when config is unavailable (conservative default)", () => {
+    getConfigSpy = spyOn(configLoader, "getConfig").mockImplementation(() => {
+      throw new Error("config not loaded");
+    });
+    expect(isToolActiveForContext("advisor", makeCtx())).toBe(false);
+  });
+
+  test("non-advisor core tools are unaffected by the gate", () => {
+    getConfigSpy = stubConfig(makeLlmConfig(OPUS, OPUS));
+    expect(isToolActiveForContext("file_read", makeCtx())).toBe(true);
+  });
+});
+
+describe("advisor gate — per-turn override re-evaluation", () => {
+  test("a top-tier override hides the advisor even when the default executor is lower", () => {
+    // Default executor is sonnet (below advisor), but this turn pins a
+    // top-tier override profile, so the advisor must be hidden.
+    getConfigSpy = stubConfig(makeLlmConfig(SONNET, OPUS, { topTier: OPUS }));
+    expect(
+      isToolActiveForContext(
+        "advisor",
+        makeCtx({ currentTurnOverrideProfile: "topTier" }),
+      ),
+    ).toBe(false);
+  });
+
+  test("a low-tier override shows the advisor even when the default executor is top tier", () => {
+    // Default executor is opus (== advisor), but this turn pins a low-tier
+    // override profile, so the advisor must be exposed.
+    getConfigSpy = stubConfig(makeLlmConfig(OPUS, OPUS, { lowTier: HAIKU }));
+    expect(
+      isToolActiveForContext(
+        "advisor",
+        makeCtx({ currentTurnOverrideProfile: "lowTier" }),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("advisor gate — createResolveToolsCallback agreement", () => {
+  test("advisor is present in the resolved tool list when below tier", () => {
+    getConfigSpy = stubConfig(makeLlmConfig(SONNET, OPUS));
+    const resolver = createResolveToolsCallback(
+      [def("advisor"), def("file_read")],
+      makeCtx(),
+    );
+    const names = resolver!([]).map((d) => d.name);
+    expect(names).toContain("advisor");
+    expect(names).toContain("file_read");
+  });
+
+  test("advisor is absent from the resolved tool list when at tier", () => {
+    getConfigSpy = stubConfig(makeLlmConfig(OPUS, OPUS));
+    const ctx = makeCtx();
+    const resolver = createResolveToolsCallback(
+      [def("advisor"), def("file_read")],
+      ctx,
+    );
+    const names = resolver!([]).map((d) => d.name);
+    expect(names).not.toContain("advisor");
+    expect(names).toContain("file_read");
+    // The per-turn execution allowlist must agree with the wire list.
+    expect(ctx.allowedToolNames?.has("advisor")).toBe(false);
+  });
+
+  test("callback and isToolActiveForContext agree on advisor visibility", () => {
+    getConfigSpy = stubConfig(makeLlmConfig(OPUS, OPUS));
+    const ctx = makeCtx();
+    const resolver = createResolveToolsCallback([def("advisor")], ctx);
+    const inList = resolver!([]).some((d) => d.name === "advisor");
+    expect(inList).toBe(isToolActiveForContext("advisor", ctx));
+  });
+});

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -12,11 +12,13 @@ import {
   supportsHostProxy,
 } from "../channels/types.js";
 import { getIsPlatform } from "../config/env-registry.js";
+import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import { getBindingByConversation } from "../memory/external-conversation-store.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
+import { isStrictlyMoreCapable } from "../providers/model-tier.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { registerConversationSender } from "../tools/browser/browser-screencast.js";
@@ -521,6 +523,44 @@ export const SUBAGENT_ONLY_TOOL_NAMES = new Set<string>([
   "notify_parent",
 ]);
 
+/** Name of the always-on advisor tool, gated per turn by executor tier. */
+const ADVISOR_TOOL_NAME = "advisor";
+
+/**
+ * Whether the advisor tool should be exposed for the conversation's current
+ * turn: true only when the advisor's configured model is strictly more
+ * capable than the conversation's current executor model.
+ *
+ * Re-evaluated per turn because the executor profile can change per
+ * conversation (per-turn override profile or a workspace active-profile edit).
+ * The executor is resolved WITH the conversation's `overrideProfile` so a
+ * per-conversation pinned profile is reflected; the advisor is resolved
+ * WITHOUT an override because it is pinned by its own seeded call-site.
+ *
+ * Conservative on failure: returns `false` if config or resolution is
+ * unavailable, so a misconfigured install never surfaces an advisor tool it
+ * cannot rank.
+ */
+export function advisorActiveForConversation(
+  overrideProfile: string | undefined,
+  conversationId: string | undefined,
+): boolean {
+  try {
+    const llm = getConfig().llm;
+    if (!llm) return false;
+    const executor = resolveCallSiteConfig("mainAgent", llm, {
+      overrideProfile,
+      selectionSeed: conversationId,
+    });
+    const advisor = resolveCallSiteConfig("advisor", llm, {
+      selectionSeed: conversationId,
+    });
+    return isStrictlyMoreCapable(advisor.model, executor.model);
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Determine whether a tool is part of the final exposed tool set for the
  * current turn. This helper mirrors the filtering applied by
@@ -643,6 +683,12 @@ export function isToolActiveForContext(
   }
   if (SUBAGENT_ONLY_TOOL_NAMES.has(name)) {
     return ctx.isSubagent === true;
+  }
+  if (name === ADVISOR_TOOL_NAME) {
+    return advisorActiveForConversation(
+      ctx.currentTurnOverrideProfile,
+      ctx.conversationId,
+    );
   }
   return true;
 }

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -542,13 +542,18 @@ const ADVISOR_TOOL_NAME = "advisor";
  * cannot rank.
  */
 export function advisorActiveForConversation(
+  executorCallSite: LLMCallSite,
   overrideProfile: string | undefined,
   conversationId: string | undefined,
 ): boolean {
   try {
     const llm = getConfig().llm;
     if (!llm) return false;
-    const executor = resolveCallSiteConfig("mainAgent", llm, {
+    // Resolve the executor against the call site actually serving this turn
+    // (e.g. heartbeatAgent/filingAgent can use a different profile than the
+    // chat model), not always mainAgent, so the tier comparison matches the
+    // model the executor is really running.
+    const executor = resolveCallSiteConfig(executorCallSite, llm, {
       overrideProfile,
       selectionSeed: conversationId,
     });
@@ -686,6 +691,7 @@ export function isToolActiveForContext(
   }
   if (name === ADVISOR_TOOL_NAME) {
     return advisorActiveForConversation(
+      ctx.currentCallSite ?? "mainAgent",
       ctx.currentTurnOverrideProfile,
       ctx.conversationId,
     );

--- a/assistant/src/tools/registry.ts
+++ b/assistant/src/tools/registry.ts
@@ -854,6 +854,7 @@ export async function initializeTools(): Promise<void> {
     loadEagerModules,
     eagerModuleToolNames,
     explicitTools,
+    getAdvisorTool,
     getCesToolsIfEnabled,
     cesTools,
   } = await import("./tool-manifest.js");
@@ -896,6 +897,14 @@ export async function initializeTools(): Promise<void> {
     registerTool(tool);
   }
 
+  // Always-on advisor tool. It is registered unconditionally as a core tool;
+  // its per-turn visibility is gated in the conversation tool-projection layer
+  // (createResolveToolsCallback / isToolActiveForContext), which exposes it to
+  // the model only when a strictly-more-capable model is configured for the
+  // conversation's current executor.
+  const advisorTool = getAdvisorTool();
+  registerTool(advisorTool);
+
   // CES tools - registered only when the CES feature flag is enabled.
   const activeCesTools = getCesToolsIfEnabled();
   for (const tool of activeCesTools) {
@@ -923,6 +932,7 @@ export async function initializeTools(): Promise<void> {
       ...explicitTools.map((t) => t.name!),
       ...extEntries.map(({ tool }) => tool.name),
       ...hostTools.map((t) => t.name!),
+      advisorTool.name,
       ...cesTools.map((t) => t.name!),
       ...allUiSurfaceTools.map((t) => t.name!),
       ...coreAppProxyTools.map((t) => t.name!),

--- a/assistant/src/tools/tool-manifest.ts
+++ b/assistant/src/tools/tool-manifest.ts
@@ -11,6 +11,8 @@ import {
   isCesSecureInstallEnabled,
   isCesToolsEnabled,
 } from "../credential-execution/feature-gates.js";
+import { RiskLevel } from "../permissions/types.js";
+import { executeAdvisorConsult } from "./advisor/consult.js";
 import { askQuestionTool } from "./ask-question/ask-question-tool.js";
 import { makeAuthenticatedRequestTool } from "./credential-execution/make-authenticated-request.js";
 import { manageSecureCommandTool } from "./credential-execution/manage-secure-command-tool.js";
@@ -28,7 +30,8 @@ import { skillLoadTool } from "./skills/load.js";
 import { notifyParentTool } from "./subagent/notify-parent.js";
 import { requestSystemPermissionTool } from "./system/request-permission.js";
 import { shellTool } from "./terminal/shell.js";
-import type { ToolDefinition } from "./types.js";
+import { finalizeTool } from "./tool-defaults.js";
+import type { Tool, ToolDefinition } from "./types.js";
 
 // ── Eager side-effect modules ───────────────────────────────────────
 // These static imports trigger top-level `registerTool()` side effects on
@@ -113,6 +116,38 @@ export const cesTools: ToolDefinition[] = [
   runAuthenticatedCommandTool,
   manageSecureCommandTool,
 ];
+
+// ── Advisor tool ────────────────────────────────────────────────────
+// Always-on core tool whose per-turn visibility is gated by
+// `conversation-tool-setup.ts`: it is exposed to the model only when a
+// strictly-more-capable model is configured for the conversation's current
+// executor. The gate lives in the tool-projection layer, not here, because
+// it depends on per-conversation executor state.
+
+const advisorTool: ToolDefinition = {
+  name: "advisor",
+  description:
+    "Consult a higher-tier model that sees your full conversation. Call it BEFORE substantive work (before writing or committing to an approach), when stuck (errors recurring, approach not converging), and before declaring a task done. Read-only orientation (ls/grep/cat) is not substantive work and does not need a call. Takes no required arguments; pass an optional `focus` to ask about a specific decision.",
+  defaultRiskLevel: RiskLevel.Low,
+  category: "orchestration",
+  input_schema: {
+    type: "object",
+    properties: {
+      focus: {
+        type: "string",
+        description:
+          "Optional specific question or decision to focus the advisor on. Omit for a general review of the work so far.",
+      },
+    },
+    additionalProperties: false,
+  },
+  execute: (input, context) => executeAdvisorConsult(input, context),
+};
+
+/** Finalized advisor tool, registered by `initializeTools()` in registry.ts. */
+export function getAdvisorTool(): Tool {
+  return finalizeTool(advisorTool, "advisor");
+}
 
 /**
  * Return CES tools only if the CES feature flag is enabled.


### PR DESCRIPTION
## Summary
- Register an always-on `advisor` core tool (executes executeAdvisorConsult)
- Per-turn toggle-off gate: advisor is exposed only when a strictly-more-capable model is configured for the conversation's current executor
- Mirrored in createResolveToolsCallback and isToolActiveForContext

Part of plan: advisor-tool.md (PR 5 of 6)