### PR TITLE
fix(plugins): handle web_search_tool_result in task-progress-nudge turn scan

### DIFF
--- a/assistant/src/plugins/defaults/task-progress-nudge/hooks/post-tool-use.ts
+++ b/assistant/src/plugins/defaults/task-progress-nudge/hooks/post-tool-use.ts
@@ -123,7 +123,9 @@ function scanTurn(messages: ReadonlyArray<Message>): {
     const message = messages[i];
     if (message.role === "user") {
       const carriesToolResult = message.content.some(
-        (block: ContentBlock) => block.type === "tool_result",
+        (block: ContentBlock) =>
+          block.type === "tool_result" ||
+          block.type === "web_search_tool_result",
       );
       if (!carriesToolResult) break; // genuine user prompt — turn boundary
       continue;


### PR DESCRIPTION
## Summary
- The task-progress-nudge `scanTurn` only checked for `tool_result` blocks when detecting turn boundaries, which tripped the `conversation-history-web-search` guard test on main (broke CI).
- Treat `web_search_tool_result` the same as `tool_result` so web search results aren't silently dropped at the turn boundary.

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/27586635161

🤖 Generated with [Claude Code](https://claude.com/claude-code)