### PR TITLE
fix(auth): migrate ASWebAuthenticationSession to non-deprecated init (ATL-812)

### DIFF
--- a/apps/ios/App/App/NativeAuthPlugin.swift
+++ b/apps/ios/App/App/NativeAuthPlugin.swift
@@ -180,10 +180,7 @@ public class NativeAuthPlugin: CAPPlugin, CAPBridgedPlugin {
         self.authSession?.cancel()
         self.authSession = nil
 
-        let session = ASWebAuthenticationSession(
-            url: authorizeURL,
-            callbackURLScheme: NativeAuthPlugin.callbackScheme
-        ) { [weak self] callbackURL, error in
+        let completionHandler: ASWebAuthenticationSession.CompletionHandler = { [weak self] callbackURL, error in
             // Deliberately NOT clearing `self.authSession` here: a late-firing
             // completion from a cancelled prior session would otherwise wipe
             // the replacement the outer call has since installed. Cleared only
@@ -252,6 +249,22 @@ public class NativeAuthPlugin: CAPPlugin, CAPBridgedPlugin {
                     }
                 }
             }
+        }
+
+        // Use the non-deprecated `callback:` initializer on iOS 17.4+
+        let session: ASWebAuthenticationSession
+        if #available(iOS 17.4, *) {
+            session = ASWebAuthenticationSession(
+                url: authorizeURL,
+                callback: .customScheme(NativeAuthPlugin.callbackScheme),
+                completionHandler: completionHandler
+            )
+        } else {
+            session = ASWebAuthenticationSession(
+                url: authorizeURL,
+                callbackURLScheme: NativeAuthPlugin.callbackScheme,
+                completionHandler: completionHandler
+            )
         }
 
         // Ephemeral (private) session: a clean cookie jar per attempt. Without

--- a/clients/shared/App/Auth/AuthManager.swift
+++ b/clients/shared/App/Auth/AuthManager.swift
@@ -267,7 +267,7 @@ public final class AuthManager {
 
     private func performWebAuth(url: URL, callbackScheme: String) async throws -> URL {
         try await withCheckedThrowingContinuation { continuation in
-            let session = ASWebAuthenticationSession(url: url, callbackURLScheme: callbackScheme) { [weak self] callbackURL, error in
+            let session = ASWebAuthenticationSession(url: url, callback: .customScheme(callbackScheme)) { [weak self] callbackURL, error in
                 self?.webAuthSession = nil
                 if let error {
                     continuation.resume(throwing: error)

--- a/clients/shared/App/Auth/OAuthConnectSurfaceCoordinator.swift
+++ b/clients/shared/App/Auth/OAuthConnectSurfaceCoordinator.swift
@@ -77,7 +77,7 @@ public final class OAuthConnectSurfaceCoordinator {
 
     private func performWebAuth(url: URL) async throws -> URL {
         try await withCheckedThrowingContinuation { continuation in
-            let session = ASWebAuthenticationSession(url: url, callbackURLScheme: "vellum-assistant") { [weak self] callbackURL, error in
+            let session = ASWebAuthenticationSession(url: url, callback: .customScheme("vellum-assistant")) { [weak self] callbackURL, error in
                 self?.activeSession = nil
                 if let error {
                     continuation.resume(throwing: error)


### PR DESCRIPTION
Migrates all three `ASWebAuthenticationSession` call sites off the initializer deprecated in iOS 17.4 / macOS 14.4 to `init(url:callback:completionHandler:)` with `.customScheme`. Behavior unchanged.

- `NativeAuthPlugin.swift` — `#available(iOS 17.4, *)` branch; deprecated init kept as iOS 15.0–17.3 fallback.
- `AuthManager.swift` / `OAuthConnectSurfaceCoordinator.swift` — new init unconditionally (macOS target 15.0).

Stays on `.customScheme` since PKCE + in-session callback delivery already close scheme-interception.