### PR TITLE
fix(surfaces): converge persisted state on passive ui_dismiss so progress cards don't render stuck

### DIFF
--- a/apps/web/src/domains/chat/components/surfaces/card-surface.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/card-surface.tsx
@@ -80,15 +80,17 @@ function getStatusConfig(status: string | undefined) {
   return STATUS_CONFIG[status ?? ""] ?? DEFAULT_STATUS;
 }
 
-// Once the overall task is `completed`, treat any lingering `failed` step as
-// recovered: a recoverable step (e.g. a Gmail reconnect) can be left `failed`
-// with no corrective per-step update, which would otherwise show a permanent red
-// glyph on a successful flow.
+// Once the overall task is `completed`, no step should still read as unfinished:
+// a model can mark the card done while leaving a step `in_progress` (a spinner),
+// `waiting`, `pending`, or `failed` with no corrective per-step update, which
+// would otherwise show a perpetual spinner or red glyph under a "Completed"
+// header. The card's own `completed` status is the model's terminal assertion,
+// so any lingering step resolves to `completed`.
 function effectiveStepStatus(
   stepStatus: string | undefined,
   taskCompleted: boolean,
 ): string | undefined {
-  if (taskCompleted && stepStatus === "failed") {
+  if (taskCompleted && stepStatus !== "completed") {
     return "completed";
   }
   return stepStatus;

--- a/assistant/src/__tests__/conversation-surfaces-data-persist.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-data-persist.test.ts
@@ -416,6 +416,103 @@ describe("ui_surface_update persistence", () => {
   });
 });
 
+describe("ui_dismiss persisted-state convergence", () => {
+  let writes: Array<{ id: string; content: unknown }> = [];
+
+  beforeEach(() => {
+    writes = [];
+    updateMessageContentSpy = (id: string, content: string) => {
+      writes.push({ id, content: JSON.parse(content) });
+    };
+    getMessagesImpl = () => [];
+    cancelPendingSurfaceDataPersists();
+  });
+
+  afterEach(() => {
+    cancelPendingSurfaceDataPersists();
+  });
+
+  test("passive dismiss drops the surface from the turn snapshot and strips the persisted block", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+    const surfaceId = "surface-dismiss-1";
+    // A progress card the model marked `completed` while leaving step 4 spinning.
+    const data: CardSurfaceData = {
+      title: "Refreshing dashboard",
+      body: "",
+      template: "task_progress",
+      templateData: {
+        status: "completed",
+        steps: [{ label: "Surface today's numbers", status: "in_progress" }],
+      },
+    };
+    ctx.surfaceState.set(surfaceId, { surfaceType: "card", data });
+    ctx.currentTurnSurfaces.push({ surfaceId, surfaceType: "card", data });
+    seedRows([
+      {
+        id: "msg-dismiss",
+        content: [
+          { type: "text", text: "done" },
+          { type: "ui_surface", surfaceId, surfaceType: "card", data },
+        ],
+      },
+    ]);
+
+    const result = await surfaceProxyResolver(ctx, "ui_dismiss", {
+      surface_id: surfaceId,
+    });
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe("Surface dismissed");
+
+    // Removed from the pending turn snapshot so turn completion never re-appends it.
+    expect(
+      ctx.currentTurnSurfaces.find((s) => s.surfaceId === surfaceId),
+    ).toBeUndefined();
+
+    // The already-persisted block is stripped; the sibling text block survives.
+    expect(writes).toHaveLength(1);
+    const blocks = writes[0].content as Array<Record<string, unknown>>;
+    expect(blocks.find((b) => b.type === "ui_surface")).toBeUndefined();
+    expect(blocks.find((b) => b.type === "text")).toBeDefined();
+
+    // A passive dismiss event (not a completion) was emitted to the client.
+    expect(sent.some((m) => m.type === "ui_surface_dismiss")).toBe(true);
+    expect(sent.some((m) => m.type === "ui_surface_complete")).toBe(false);
+  });
+
+  test("dismiss cancels a pending debounced persist so a stale update cannot re-add the block", async () => {
+    const sent: ServerMessage[] = [];
+    const ctx = makeContext(sent);
+    const surfaceId = "surface-dismiss-2";
+    const data: CardSurfaceData = {
+      title: "x",
+      body: "",
+      template: "task_progress",
+      templateData: { status: "in_progress" },
+    };
+    ctx.surfaceState.set(surfaceId, { surfaceType: "card", data });
+    seedRows([
+      {
+        id: "msg-dismiss-2",
+        content: [{ type: "ui_surface", surfaceId, surfaceType: "card", data }],
+      },
+    ]);
+
+    // A final ui_update is still inside the debounce window when dismiss fires.
+    scheduleSurfaceDataPersist("conv-persist-1", surfaceId, {
+      ...data,
+      templateData: { status: "completed" },
+    } as SurfaceData);
+
+    await surfaceProxyResolver(ctx, "ui_dismiss", { surface_id: surfaceId });
+    const writeCountAfterDismiss = writes.length;
+
+    // The cancelled debounce must not fire a write that resurrects the block.
+    await new Promise((r) => setTimeout(r, 600));
+    expect(writes).toHaveLength(writeCountAfterDismiss);
+  });
+});
+
 describe("standalone surface DB persistence", () => {
   let writes: Array<{ id: string; content: unknown }> = [];
 

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -180,6 +180,18 @@ export function flushSurfaceDataPersist(surfaceId: string): void {
 }
 
 /**
+ * Discard (without writing) any pending debounced persist for `surfaceId`.
+ * Called on dismissal so an in-flight `ui_update` snapshot cannot land after
+ * the surface block has been removed.
+ */
+export function cancelSurfaceDataPersist(surfaceId: string): void {
+  const pending = pendingSurfacePersists.get(surfaceId);
+  if (!pending) return;
+  clearTimeout(pending.timer);
+  pendingSurfacePersists.delete(surfaceId);
+}
+
+/**
  * Cancel all pending debounced persists. Called on conversation
  * teardown to avoid timers firing against torn-down state.
  *
@@ -275,6 +287,60 @@ export function markSurfaceCompleted(
     }
   } catch (err) {
     log.warn({ err, surfaceId }, "Failed to persist surface completion to DB");
+  }
+}
+
+/**
+ * Remove a `ui_surface` content block from history so a passively dismissed
+ * surface does not survive a reload. The live client drops a dismissed surface
+ * entirely; this converges persisted state with that behaviour. Cancels any
+ * pending debounced data persist first so a late `ui_update` snapshot cannot
+ * re-add the block, then strips the block from in-memory messages and the DB.
+ */
+export function removeSurfaceBlock(
+  ctx: { conversationId: string; messages?: Array<{ content: unknown }> },
+  surfaceId: string,
+): void {
+  cancelSurfaceDataPersist(surfaceId);
+
+  if (ctx.messages) {
+    for (let i = ctx.messages.length - 1; i >= 0; i--) {
+      const msg = ctx.messages[i];
+      if (!Array.isArray(msg.content)) continue;
+      const idx = msg.content.findIndex((block) => {
+        const b = block as Record<string, unknown>;
+        return b.type === "ui_surface" && b.surfaceId === surfaceId;
+      });
+      if (idx !== -1) {
+        msg.content.splice(idx, 1);
+        break;
+      }
+    }
+  }
+
+  try {
+    const rows = getMessages(ctx.conversationId);
+    for (let r = rows.length - 1; r >= 0; r--) {
+      let parsed: unknown[];
+      try {
+        const result = JSON.parse(rows[r].content);
+        if (!Array.isArray(result)) continue;
+        parsed = result;
+      } catch {
+        continue;
+      }
+      const idx = parsed.findIndex((pb) => {
+        const rb = pb as Record<string, unknown>;
+        return rb.type === "ui_surface" && rb.surfaceId === surfaceId;
+      });
+      if (idx !== -1) {
+        parsed.splice(idx, 1);
+        updateMessageContent(rows[r].id, JSON.stringify(parsed));
+        return;
+      }
+    }
+  } catch (err) {
+    log.warn({ err, surfaceId }, "Failed to remove dismissed surface from DB");
   }
 }
 const TASK_PROGRESS_TEMPLATE_FIELDS = ["title", "status", "steps"] as const;
@@ -2858,6 +2924,15 @@ export async function surfaceProxyResolver(
         conversationId: ctx.conversationId,
         surfaceId,
       });
+      // The live client drops a dismissed surface entirely. Mirror that in
+      // persisted state: pull it from the pending turn snapshot (appended to
+      // the message at turn completion) and strip any already-persisted block,
+      // so a reload does not resurrect a half-finished progress card.
+      const turnIdx = ctx.currentTurnSurfaces.findIndex(
+        (s) => s.surfaceId === surfaceId,
+      );
+      if (turnIdx !== -1) ctx.currentTurnSurfaces.splice(turnIdx, 1);
+      removeSurfaceBlock(ctx, surfaceId);
     }
     ctx.pendingSurfaceActions.delete(surfaceId);
     ctx.surfaceState.delete(surfaceId);


### PR DESCRIPTION
## Problem

From a dogfood feedback bundle: a task-progress card titled "Refreshing internal usage dashboard" rendered with a green **Completed** header, but its 4th step ("Surface today's numbers") kept showing a spinning loader. The turn was actually finished (`phase: idle`, `lastTerminalReason: complete`).

## Root cause

The persisted `ui_surface` blocks are appended to the assistant message at turn completion from `ctx.currentTurnSurfaces`. In the captured turn the model:
1. `ui_show`'d the card,
2. `ui_update`'d it to `status: completed` while leaving step 4 `in_progress`,
3. `ui_dismiss`'d it.

The live client drops a dismissed surface entirely, but the daemon's passive-dismiss branch (`conversation-surfaces.ts`) only sent a live `ui_surface_dismiss` event — it left the surface in `currentTurnSurfaces` (so it got persisted at turn completion) and never stripped any already-persisted block. On reload, reconciliation re-rendered the half-finished card. A debounced `ui_update` persist firing ~166 ms after the dismiss (inside the 500 ms window) could also re-stamp the broken snapshot.

The client render compounded it: `effectiveStepStatus` only normalized `failed → completed` on a finished task, so a lingering `in_progress` step kept its spinner under a "Completed" header.

## Fix

**Server** (`conversation-surfaces.ts`): on a passive (no-action) `ui_dismiss`, drop the surface from the pending turn snapshot, cancel any pending debounced persist (`cancelSurfaceDataPersist`), and strip the persisted `ui_surface` block (`removeSurfaceBlock`). Converges persisted state with the live client.

**Client** (`card-surface.tsx`): once a card is `completed`, any lingering step status resolves to `completed` — defense-in-depth for the "turn went terminal with a dangling in-progress child" case, independent of model sloppiness or server races.

## Tests

Added two cases to `conversation-surfaces-data-persist.test.ts`:
- passive dismiss drops the surface from the turn snapshot and strips the persisted block (sibling blocks survive; emits `ui_surface_dismiss`, not `ui_surface_complete`).
- dismiss cancels a pending debounced persist so a stale update can't re-add the block.

`bun test` green; `tsc --noEmit` clean for both packages on the touched files.

## Review focus — **medium risk**

`removeSurfaceBlock` mutates persisted conversation history (removes a content block). It mirrors the existing live-client dismiss semantics and only fires on a passive dismiss, but reviewers should confirm removing the block (vs. marking it completed) is the desired convergence — the live client removes, so this matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)