### PR TITLE
fix(ui-surface): loading affordance for content-free cards + reject empty card ui_show

### DIFF
--- a/apps/web/src/domains/chat/components/surfaces/card-surface.tsx
+++ b/apps/web/src/domains/chat/components/surfaces/card-surface.tsx
@@ -267,6 +267,32 @@ export function CardSurface({ surface, onAction }: CardSurfaceProps) {
     );
   }
 
+  // A card the model has shown but not yet populated (e.g. an interim
+  // "building the app" placeholder emitted as `data: {}`) carries nothing
+  // renderable. Rather than a bare bordered box with only a title, show a
+  // loading affordance until real content arrives. A `completed` card is
+  // terminal, so it falls through to the normal render even when empty.
+  const hasRenderableContent =
+    normalizedTitle(data.body).length > 0 ||
+    !!data.subtitle ||
+    (data.metadata?.length ?? 0) > 0 ||
+    (surface.actions?.length ?? 0) > 0 ||
+    !!isWeather ||
+    isTaskProgress;
+
+  if (!hasRenderableContent && !surface.completed) {
+    return (
+      <SurfaceContainer surface={surface} onAction={onAction} hideTitle>
+        <div className="flex items-center gap-2.5">
+          <Loader2 className="h-4 w-4 shrink-0 animate-spin text-[var(--content-tertiary)]" />
+          <span className="text-body-medium-default text-[var(--content-tertiary)]">
+            {cardTitle || "Working…"}
+          </span>
+        </div>
+      </SurfaceContainer>
+    );
+  }
+
   const bodyMarkdown = (
     <ChatMarkdownMessage
       content={data.body}

--- a/assistant/src/__tests__/dynamic-page-surface.test.ts
+++ b/assistant/src/__tests__/dynamic-page-surface.test.ts
@@ -206,6 +206,100 @@ describe("ui_show dynamic_page app substitute guard", () => {
   });
 });
 
+describe("ui_show empty card guard", () => {
+  function makeCtx(onProxy: () => void) {
+    return {
+      conversationId: "conversation-123",
+      workingDir: "/tmp",
+      trustClass: "guardian" as const,
+      proxyToolResolver: async () => {
+        onProxy();
+        return { content: "proxied", isError: false };
+      },
+    };
+  }
+
+  test("rejects a card carrying only a title and does not proxy", async () => {
+    let proxied = false;
+    const result = await uiShowTool.execute(
+      {
+        surface_type: "card",
+        title: "Vellum Internal Usage app",
+        activity: "Showing progress",
+        data: {},
+      },
+      makeCtx(() => {
+        proxied = true;
+      }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("card requires content");
+    expect(proxied).toBe(false);
+  });
+
+  test("rejects a card with no content at all", async () => {
+    let proxied = false;
+    const result = await uiShowTool.execute(
+      { surface_type: "card", data: {} },
+      makeCtx(() => {
+        proxied = true;
+      }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(proxied).toBe(false);
+  });
+
+  test("allows a card with a body", async () => {
+    let proxied = false;
+    const result = await uiShowTool.execute(
+      { surface_type: "card", data: { title: "Plain", body: "hi" } },
+      makeCtx(() => {
+        proxied = true;
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(proxied).toBe(true);
+  });
+
+  test("allows a task_progress card with empty data (template renders a shell)", async () => {
+    let proxied = false;
+    const result = await uiShowTool.execute(
+      {
+        surface_type: "card",
+        template: "task_progress",
+        templateData: { status: "in_progress", steps: [] },
+      },
+      makeCtx(() => {
+        proxied = true;
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(proxied).toBe(true);
+  });
+
+  test("allows an action-only card", async () => {
+    let proxied = false;
+    const result = await uiShowTool.execute(
+      {
+        surface_type: "card",
+        title: "Confirm",
+        actions: [{ id: "ok", label: "OK" }],
+        data: {},
+      },
+      makeCtx(() => {
+        proxied = true;
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(proxied).toBe(true);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // task_progress ui_show appends the update hint to its return value
 // ---------------------------------------------------------------------------

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -43,6 +43,14 @@ function proxyExecute(toolName: string) {
       };
     }
 
+    if (toolName === "ui_show" && isEmptyCard(input)) {
+      return {
+        content:
+          "Error: ui_show card requires content — provide `data.body`, a `template` (e.g. task_progress with steps), `data.metadata`, or `actions`. The surface was not displayed because it carried only a title, which renders as a blank box. Resend ui_show with populated card content.",
+        isError: true,
+      };
+    }
+
     if (toolName === "ui_show" && isDynamicPageAppSubstitute(input)) {
       return {
         content:
@@ -97,6 +105,41 @@ function isEmptyDynamicPage(input: Record<string, unknown>): boolean {
   const data = asRecord(input.data);
   const html = data?.html;
   return typeof html !== "string" || html.trim().length === 0;
+}
+
+/**
+ * A `card` ui_show carrying no renderable content — only a title (or nothing)
+ * — renders as a blank bordered box. A declared `template` (task_progress,
+ * weather_forecast, …) renders its own shell, and `body`/`subtitle`/`metadata`/
+ * `actions` are real content; any of those passes. The model places these
+ * either nested in `data` or at the top level, so both are checked. Title is
+ * intentionally not content: a title-only card is the blank box.
+ */
+function isEmptyCard(input: Record<string, unknown>): boolean {
+  if (input.surface_type !== "card") {
+    return false;
+  }
+  const data = asRecord(input.data) ?? {};
+
+  const template =
+    nonEmptyString(input.template) ?? nonEmptyString(data.template);
+  if (template) {
+    return false;
+  }
+
+  const hasBody = !!(nonEmptyString(input.body) ?? nonEmptyString(data.body));
+  const hasSubtitle = !!nonEmptyString(data.subtitle);
+  const hasMetadata = Array.isArray(data.metadata) && data.metadata.length > 0;
+  const actions = input.actions ?? data.actions;
+  const hasActions = Array.isArray(actions) && actions.length > 0;
+
+  return !(hasBody || hasSubtitle || hasMetadata || hasActions);
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : undefined;
 }
 
 function isDynamicPageAppSubstitute(input: Record<string, unknown>): boolean {


### PR DESCRIPTION
## Problem

From the same dogfood bundle: while the app-builder skill built a dashboard, the model emitted a `card` surface with `data: {}` and only a title ("Vellum Internal Usage app"). It rendered as a bare bordered box with a single line of title text and stayed that way for **~4.6 minutes**. The user: *"there was a UI which showed it's building the app but the UI was kinda blank, ideally we don't show it."*

The #34940 guard rejects empty **`dynamic_page`** surfaces, but its check early-returns for any other surface type, so this empty **`card`** slipped through.

## Fix

**Client** (`card-surface.tsx`) — primary, addresses the exact ask: when a card has no renderable content (no body, subtitle, metadata, actions, or recognized template) and isn't `completed`, render a loading affordance — a spinner + the title — instead of an empty bordered box. This honors a progressive placeholder filled later via `ui_update`, and covers any empty/mid-update card at render time. Shared across web, Electron macOS, and Capacitor iOS.

**Daemon** (`ui-surface/definitions.ts`) — corrective signal mirroring #34940: reject a `card` ui_show that carries only a title. The error steers the model to send real content or a `task_progress` template up front instead of an empty placeholder. A declared template, body, subtitle, metadata, or actions (top-level or nested in `data`) all pass — so existing task_progress / weather / content / action cards are unaffected. Title alone is intentionally not "content" (a title-only card is the blank box).

## Tests

`dynamic-page-surface.test.ts` — 5 new cases: rejects title-only card, rejects fully-empty card, and allows body / task_progress-empty-data / action-only cards. Regression suites (`conversation-surfaces-task-progress`, `ui-work-result-surface`) still green. `tsc --noEmit` clean for the touched files.

## Relationship to #34993

Companion to #34993 (stuck progress card). Both are empty/degenerate-surface hardening surfaced by the same weak-model app-builder run; they touch `card-surface.tsx` in disjoint spots and can merge in either order (trivial rebase if needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)