### PR TITLE
fix(apps): rescue omitted app_id for app-builder tools instead of looping on "Invalid ID"

### DIFF
--- a/assistant/src/__tests__/app-executors.test.ts
+++ b/assistant/src/__tests__/app-executors.test.ts
@@ -168,6 +168,49 @@ describe("executeAppCreate", () => {
     expect(parsed.next_steps).toContain("app_refresh");
   });
 
+  test("associates the new app with its conversation when a conversationId is given", async () => {
+    const app = makeMultifileApp({ id: "app-xyz", name: "Assoc App" });
+    const associated: Array<{ appId: string; conversationId: string }> = [];
+    const store: AppStore = {
+      ...mockStore(app, {}),
+      addAppConversationId: (appId, conversationId) => {
+        associated.push({ appId, conversationId });
+        return true;
+      },
+    };
+
+    const result = await executeAppCreate(
+      { name: "Assoc App" },
+      store,
+      undefined,
+      "conv-assoc-1",
+    );
+
+    expect(result.isError).toBe(false);
+    expect(associated).toEqual([
+      { appId: "app-xyz", conversationId: "conv-assoc-1" },
+    ]);
+  });
+
+  test("a failed conversation association does not fail the create", async () => {
+    const app = makeMultifileApp({ id: "app-throw", name: "Throw App" });
+    const store: AppStore = {
+      ...mockStore(app, {}),
+      addAppConversationId: () => {
+        throw new Error("disk gone");
+      },
+    };
+
+    const result = await executeAppCreate(
+      { name: "Throw App" },
+      store,
+      undefined,
+      "conv-assoc-2",
+    );
+
+    expect(result.isError).toBe(false);
+  });
+
   test("skips auto_open on scaffold even when proxy resolver is available", async () => {
     const files: Record<string, string> = {};
     const app = makeMultifileApp({ name: "New App" });

--- a/assistant/src/__tests__/resolve-app-id.test.ts
+++ b/assistant/src/__tests__/resolve-app-id.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type { AppDefinition } from "../memory/app-store.js";
+
+let appsByConversation: AppDefinition[] = [];
+
+const realStore = await import("../memory/app-store.js");
+mock.module("../memory/app-store.js", () => ({
+  ...realStore,
+  listAppsByConversation: (_conversationId: string) => appsByConversation,
+}));
+
+const { resolveAppId, missingAppIdError } =
+  await import("../tools/apps/resolve-app-id.js");
+
+function makeApp(id: string, updatedAt: number): AppDefinition {
+  return {
+    id,
+    name: id,
+    schemaJson: "{}",
+    htmlDefinition: "",
+    createdAt: updatedAt,
+    updatedAt,
+  };
+}
+
+describe("resolveAppId", () => {
+  test("returns an explicit non-empty app_id unchanged", () => {
+    appsByConversation = [makeApp("other", 1)];
+    expect(resolveAppId({ app_id: "explicit" }, "conv-1")).toBe("explicit");
+  });
+
+  test("falls back to the most-recently-updated conversation app when missing", () => {
+    // listAppsByConversation inherits listApps' updatedAt-descending order.
+    appsByConversation = [makeApp("newest", 30), makeApp("older", 10)];
+    expect(resolveAppId({}, "conv-1")).toBe("newest");
+  });
+
+  test("treats a blank app_id as missing", () => {
+    appsByConversation = [makeApp("active", 5)];
+    expect(resolveAppId({ app_id: "   " }, "conv-1")).toBe("active");
+  });
+
+  test("returns null when no app_id is given and the conversation has no app", () => {
+    appsByConversation = [];
+    expect(resolveAppId({}, "conv-1")).toBeNull();
+  });
+});
+
+describe("missingAppIdError", () => {
+  test("is an actionable error result", () => {
+    const result = missingAppIdError();
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content).error).toContain("app_create");
+  });
+});

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-create.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-create.ts
@@ -15,5 +15,10 @@ export async function run(
     setAppCommitMessage(context.conversationId, input.change_summary.trim());
   }
   const createInput: AppCreateInput = input as unknown as AppCreateInput;
-  return executeAppCreate(createInput, appStore, context.proxyToolResolver);
+  return executeAppCreate(
+    createInput,
+    appStore,
+    context.proxyToolResolver,
+    context.conversationId,
+  );
 }

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-generate-icon.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-generate-icon.ts
@@ -2,6 +2,10 @@ import { setAppCommitMessage } from "../../../../memory/app-git-service.js";
 import * as appStore from "../../../../memory/app-store.js";
 import type { AppGenerateIconInput } from "../../../../tools/apps/executors.js";
 import { executeAppGenerateIcon } from "../../../../tools/apps/executors.js";
+import {
+  missingAppIdError,
+  resolveAppId,
+} from "../../../../tools/apps/resolve-app-id.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -14,8 +18,10 @@ export async function run(
   if (typeof input.change_summary === "string" && input.change_summary.trim()) {
     setAppCommitMessage(context.conversationId, input.change_summary.trim());
   }
+  const appId = resolveAppId(input, context.conversationId);
+  if (!appId) return missingAppIdError();
   return executeAppGenerateIcon(
-    input as unknown as AppGenerateIconInput,
+    { ...input, app_id: appId } as unknown as AppGenerateIconInput,
     appStore,
   );
 }

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-refresh.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-refresh.ts
@@ -1,6 +1,10 @@
 import { setAppCommitMessage } from "../../../../memory/app-git-service.js";
 import * as appStore from "../../../../memory/app-store.js";
 import { executeAppRefresh } from "../../../../tools/apps/executors.js";
+import {
+  missingAppIdError,
+  resolveAppId,
+} from "../../../../tools/apps/resolve-app-id.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -13,5 +17,7 @@ export async function run(
   if (typeof input.change_summary === "string" && input.change_summary.trim()) {
     setAppCommitMessage(context.conversationId, input.change_summary.trim());
   }
-  return executeAppRefresh({ app_id: input.app_id as string }, appStore);
+  const appId = resolveAppId(input, context.conversationId);
+  if (!appId) return missingAppIdError();
+  return executeAppRefresh({ app_id: appId }, appStore);
 }

--- a/assistant/src/config/bundled-skills/app-builder/tools/app-update.ts
+++ b/assistant/src/config/bundled-skills/app-builder/tools/app-update.ts
@@ -2,6 +2,10 @@ import { setAppCommitMessage } from "../../../../memory/app-git-service.js";
 import * as appStore from "../../../../memory/app-store.js";
 import type { AppUpdateInput } from "../../../../tools/apps/executors.js";
 import { executeAppUpdate } from "../../../../tools/apps/executors.js";
+import {
+  missingAppIdError,
+  resolveAppId,
+} from "../../../../tools/apps/resolve-app-id.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -14,5 +18,10 @@ export async function run(
   if (typeof input.change_summary === "string" && input.change_summary.trim()) {
     setAppCommitMessage(context.conversationId, input.change_summary.trim());
   }
-  return executeAppUpdate(input as unknown as AppUpdateInput, appStore);
+  const appId = resolveAppId(input, context.conversationId);
+  if (!appId) return missingAppIdError();
+  return executeAppUpdate(
+    { ...input, app_id: appId } as unknown as AppUpdateInput,
+    appStore,
+  );
 }

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -7,6 +7,7 @@ import {
   getAppDirPath,
   getAppPreview,
   isMultifileApp,
+  listAppsByConversation,
   resolveAppDir,
   resolveEffectiveAppHtml,
   updateApp,
@@ -2871,11 +2872,24 @@ export async function surfaceProxyResolver(
   }
 
   if (toolName === "app_open") {
-    const appId = input.app_id as string;
+    // Weaker models routinely omit app_id even though the active app is in
+    // context. Fall back to the conversation's most-recently-updated app
+    // rather than failing with "Invalid ID: undefined".
+    let appId = input.app_id as string;
+    if (typeof appId !== "string" || appId.trim().length === 0) {
+      appId = listAppsByConversation(ctx.conversationId)[0]?.id ?? "";
+    }
     const preview = input.preview as DynamicPageSurfaceData["preview"];
     const openMode = input.open_mode as string | undefined;
-    const app = getApp(appId);
-    if (!app) return { content: `App not found: ${appId}`, isError: true };
+    const app = appId ? getApp(appId) : null;
+    if (!app) {
+      return {
+        content: appId
+          ? `App not found: ${appId}`
+          : "app_id is required and no active app exists in this conversation. Call app_create first, or pass app_id explicitly.",
+        isError: true,
+      };
+    }
 
     // Track conversation association (best-effort — failures must not break open flow).
     try {

--- a/assistant/src/tools/apps/executors.ts
+++ b/assistant/src/tools/apps/executors.ts
@@ -12,6 +12,7 @@ import { compileApp } from "../../bundler/app-compiler.js";
 import { generateAppIcon } from "../../media/app-icon-generator.js";
 import type { AppDefinition } from "../../memory/app-store.js";
 import { getAppDirPath } from "../../memory/app-store.js";
+import { getLogger } from "../../util/logger.js";
 
 // ---------------------------------------------------------------------------
 // Shared result type
@@ -55,6 +56,11 @@ export interface AppStoreWriter {
   ): AppDefinition;
   deleteApp(id: string): void;
   writeAppFile(appId: string, path: string, content: string): void;
+  /**
+   * Associate a freshly created app with the conversation that created it.
+   * Optional so test doubles need not implement it; the real store does.
+   */
+  addAppConversationId?(appId: string, conversationId: string): boolean;
 }
 
 export type AppStore = AppStoreReader & AppStoreWriter;
@@ -158,6 +164,7 @@ export async function executeAppCreate(
   input: AppCreateInput,
   store: AppStore,
   proxyToolResolver?: ProxyResolver,
+  conversationId?: string,
 ): Promise<ExecutorResult> {
   // The model sometimes omits a name; resolve a sensible one rather than
   // erroring out so the build still succeeds. Users can rename via app_update.
@@ -212,6 +219,22 @@ export async function executeAppCreate(
     htmlDefinition: "",
     formatVersion: 2,
   });
+
+  // Associate the app with its conversation at creation so subsequent
+  // `app_*` calls in the same turn can resolve it even when the model omits
+  // `app_id` (see resolveAppId). Without this the link is only formed at
+  // `app_open`, leaving the create→update→refresh gap unresolvable.
+  // Best-effort: a failed association must never fail the create.
+  if (conversationId && store.addAppConversationId) {
+    try {
+      store.addAppConversationId(app.id, conversationId);
+    } catch (err) {
+      getLogger("app-executors").debug(
+        { err, appId: app.id, conversationId },
+        "Failed to associate app with conversation at create",
+      );
+    }
+  }
 
   // Scaffold multifile app with src/ files and compile to dist/
   const htmlSafeName = name

--- a/assistant/src/tools/apps/resolve-app-id.ts
+++ b/assistant/src/tools/apps/resolve-app-id.ts
@@ -1,0 +1,42 @@
+import { listAppsByConversation } from "../../memory/app-store.js";
+
+/**
+ * Resolve the `app_id` an app-builder tool should operate on.
+ *
+ * Weaker models routinely omit `app_id` when calling `app_*` tools through
+ * `skill_execute`, even though the active app's id is in their context from the
+ * preceding `app_create`/`app_update` result. Left unhandled, the executor
+ * fails with a cryptic "Invalid ID: undefined", the model retries the same
+ * empty call, and the turn burns many steps before recovering.
+ *
+ * An explicit, non-empty `app_id` always wins. When it is missing, fall back to
+ * the conversation's most-recently-updated app — the one being actively built.
+ * Returns `null` when no app_id is supplied and the conversation has no app, so
+ * callers can surface an actionable error instead of a raw store throw.
+ *
+ * Not used for destructive operations (`app_delete`): deleting an inferred app
+ * is unsafe, so deletion requires an explicit id.
+ */
+export function resolveAppId(
+  input: Record<string, unknown>,
+  conversationId: string,
+): string | null {
+  if (typeof input.app_id === "string" && input.app_id.trim().length > 0) {
+    return input.app_id;
+  }
+  // `listAppsByConversation` preserves `listApps`' updatedAt-descending order,
+  // so the first entry is the app the model is actively working on.
+  const apps = listAppsByConversation(conversationId);
+  return apps.length > 0 ? apps[0].id : null;
+}
+
+/** Error payload returned when no app_id is supplied and none can be inferred. */
+export function missingAppIdError(): { content: string; isError: boolean } {
+  return {
+    content: JSON.stringify({
+      error:
+        "app_id is required and no active app exists in this conversation. Call app_create first, or pass app_id explicitly.",
+    }),
+    isError: true,
+  };
+}


### PR DESCRIPTION
## Problem

From the dogfood bundle, the longest assistant turn building a dashboard had a **35% tool-failure rate**, and ~16 of ~49 calls were a single avoidable loop: the model called `app_*` tools through `skill_execute` with the required `app_id` omitted (literally `input: {}`), even though the active app's id was in its context from the preceding `app_create`/`app_update` result. The executor failed with a cryptic `Invalid ID: undefined`, the model retried the identical empty call, and burned steps before recovering (`app_refresh` failed 5×, `app_open` 4×). This is the biggest single driver of the "48/73 steps" complaint.

The daemon already tracks which conversation an app belongs to — but only forms that link at `app_open`, so during the create→update→refresh sequence the active app couldn't be resolved.

## Fix

1. **Associate at create** — `executeAppCreate` now links the new app to its conversation (best-effort; a failed association never fails the create). This closes the create→update→refresh gap.

2. **`resolveAppId`** (new helper) fills a missing `app_id` from the conversation's most-recently-updated app — the one being actively built. Applied to the **non-destructive** app tools: `app_refresh`, `app_update`, `app_generate_icon`, and the `app_open` proxy. An explicit `app_id` always wins; when none is supplied and none can be inferred, callers return an actionable error (`"app_id is required and no active app exists… Call app_create first…"`) instead of a raw store throw.

`app_delete` is **intentionally excluded** — deleting an inferred app is unsafe, so deletion still requires an explicit id.

## Tests

- `resolve-app-id.test.ts` — explicit wins, blank treated as missing, falls back to most-recent, null when none.
- `app-executors.test.ts` — create associates the conversation; a throwing association still succeeds.
- Regression: `app-builder-tool-scripts`, `app-control-flow` green. `tsc --noEmit` clean.

## Review focus — **medium risk**

The most-recent-app fallback is a heuristic. It only fires when `app_id` is **absent** (never overrides an explicit id), is scoped to app-builder tools, and excludes destructive deletes — so the blast radius is small. Please sanity-check the "most-recently-updated app is the active one" assumption for multi-app conversations.

Part of the app-builder weak-model efficiency work (companion to the skill-tuning PR for `lucide`/profile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)