### PR TITLE
fix(app-builder): stop recommending lucide — it can never resolve in the sandbox

### DIFF
--- a/assistant/src/__tests__/app-compiler.test.ts
+++ b/assistant/src/__tests__/app-compiler.test.ts
@@ -450,6 +450,12 @@ describe("package-resolver", () => {
     expect(ALLOWED_PACKAGES).toContain("lodash-es");
     expect(ALLOWED_PACKAGES).toContain("zod");
     expect(ALLOWED_PACKAGES).toContain("clsx");
-    expect(ALLOWED_PACKAGES).toContain("lucide");
+  });
+
+  // `lucide` (the vanilla package) unpacks to ~29 MB, far above the resolver's
+  // size cap, so it is installed then deleted and never resolves. It also
+  // exports icon data arrays, not Preact components. Apps use inline SVG.
+  test("ALLOWED_PACKAGES excludes lucide", () => {
+    expect(ALLOWED_PACKAGES).not.toContain("lucide");
   });
 });

--- a/assistant/src/bundler/package-resolver.ts
+++ b/assistant/src/bundler/package-resolver.ts
@@ -22,7 +22,6 @@ export const ALLOWED_PACKAGES: readonly string[] = [
   "lodash-es",
   "zod",
   "clsx",
-  "lucide",
 ] as const;
 
 const INSTALL_TIMEOUT_MS = 10_000;

--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -196,7 +196,7 @@ render(<App />, document.getElementById("app")!);
 2. **`file_write`** each real file, one per tool call, overwriting the placeholders and adding components.
 3. **`app_refresh`** ONCE at the end to compile.
 
-**Allowed packages** (esbuild-resolved, no CDN): `date-fns`, `chart.js`, `lodash-es`, `zod`, `clsx`, `lucide` (use `lucide`, NOT `lucide-react`).
+**Allowed packages** (esbuild-resolved, no CDN): `date-fns`, `chart.js`, `lodash-es`, `zod`, `clsx`. For icons, write inline `<svg>` markup directly — no icon package is bundled.
 
 **Constraints:** Preact not React. No CDN imports. No external fonts/images (system fonts, inline CSS/SVG). Responsive only, no fixed-pixel widths. The WebView blocks navigation — `href` and form `action` don't work.
 


### PR DESCRIPTION
## Problem

From the dogfood bundle, the app-builder run spent ~8 calls fighting a `lucide` import: write components importing `lucide` → compile fails `Could not resolve "lucide"` → grep node_modules → strip the imports → re-edit. SKILL.md explicitly told the model to use `lucide` ("use `lucide`, NOT `lucide-react`"), and it was on the compiler's package allowlist — so this looked like it should work.

## Root cause (verified empirically)

The vanilla `lucide` package unpacks to **~29 MB**, far above the resolver's **5 MB** `MAX_PACKAGE_SIZE_BYTES` cap (`package-resolver.ts`). So the resolver installs it, measures it, **deletes it for exceeding the limit**, and returns null → esbuild reports `Could not resolve "lucide"`. The guidance steered every app into a guaranteed compile failure.

```
$ bun install --no-save lucide && du -sh node_modules/lucide
29M  node_modules/lucide          # cap is 5 MB
```

Compounding it, vanilla `lucide` exports icon **data arrays** (`Home === [["path",{…}], …]`), not Preact components — so `<Home/>` JSX would never work even if it resolved. (`lucide-react` would, but SKILL.md says not to use it.)

## Fix

Remove `lucide` from `ALLOWED_PACKAGES` and from the SKILL.md allowed-packages line, and steer the model to inline `<svg>` markup for icons — zero deps, always compiles, and consistent with the skill's existing "inline CSS/SVG" constraint.

## Tests

`app-compiler.test.ts`: replaced the `toContain("lucide")` assertion with `not.toContain("lucide")` plus a comment documenting why. Suite green; `tsc`/lint clean.

## Note

This is the contained, verified half of the app-builder efficiency findings. The *other* lever — floating app-builder to a stronger inference profile (the 35% tool-failure rate on the economy model is the bigger driver) — is a cost/product decision I've left out deliberately; flagging separately for an owner call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)