### PR TITLE
Add remote web pairing verification

### DIFF
--- a/gateway/src/__tests__/remote-web-ingress-denylist.test.ts
+++ b/gateway/src/__tests__/remote-web-ingress-denylist.test.ts
@@ -60,8 +60,15 @@ function assertDeniedBeforeV1Proxy(path: string): void {
   }
 }
 
+function assertNotExplicitlyDenied(path: string): void {
+  for (const deniedPath of [path, `${path}/`]) {
+    const location = `location = ${deniedPath} { return 404; }`;
+    expect(nginxIngressSource).not.toContain(location);
+  }
+}
+
 describe("remote web ingress denylist", () => {
-  test("blocks every unprotected static gateway /v1 route before proxying /v1", () => {
+  test("blocks local-only unprotected static gateway /v1 routes before proxying /v1", () => {
     const unprotectedV1Routes = extractUnprotectedStaticV1Routes();
     expect(unprotectedV1Routes).toEqual([
       "/v1/devices",
@@ -70,10 +77,20 @@ describe("remote web ingress denylist", () => {
       "/v1/guardian/reset-bootstrap",
       "/v1/pair",
       "/v1/remote-web/pairing-challenge",
+      "/v1/remote-web/pairing-verification",
+    ]);
+
+    const publicRemoteWebRoutes = new Set([
+      "/v1/remote-web/pairing-verification",
     ]);
 
     for (const path of unprotectedV1Routes) {
+      if (publicRemoteWebRoutes.has(path)) continue;
       assertDeniedBeforeV1Proxy(path);
+    }
+
+    for (const path of publicRemoteWebRoutes) {
+      assertNotExplicitlyDenied(path);
     }
   });
 

--- a/gateway/src/__tests__/remote-web-pairing-challenge.test.ts
+++ b/gateway/src/__tests__/remote-web-pairing-challenge.test.ts
@@ -102,6 +102,7 @@ describe("remote web pairing challenge", () => {
     expect(record?.deviceCodeHash).not.toBe(body.deviceCode);
     expect(record?.userCodeHash).not.toBe(body.userCode);
     expect(record?.publicBaseUrl).toBe(PUBLIC_BASE_URL);
+    expect(record?.status).toBe("pending");
   });
 
   test("rejects challenge creation through the nginx edge", async () => {

--- a/gateway/src/__tests__/remote-web-pairing-verification.test.ts
+++ b/gateway/src/__tests__/remote-web-pairing-verification.test.ts
@@ -125,11 +125,14 @@ describe("remote web pairing verification", () => {
     expect(limited.headers.get("Retry-After")).toBeTruthy();
 
     const challenge = await createChallenge();
-    const approved = await handleVerifyRemoteWebPairingChallenge(
+    const blockedValidCode = await handleVerifyRemoteWebPairingChallenge(
       makeVerificationRequest({ userCode: challenge.userCode }),
       CLIENT_IP,
     );
 
-    expect(approved.status).toBe(200);
+    expect(blockedValidCode.status).toBe(429);
+    expect(
+      getRemoteWebPairingChallengeForTests(challenge.userCode)?.status,
+    ).toBe("pending");
   });
 });

--- a/gateway/src/__tests__/remote-web-pairing-verification.test.ts
+++ b/gateway/src/__tests__/remote-web-pairing-verification.test.ts
@@ -123,5 +123,13 @@ describe("remote web pairing verification", () => {
 
     expect(limited.status).toBe(429);
     expect(limited.headers.get("Retry-After")).toBeTruthy();
+
+    const challenge = await createChallenge();
+    const approved = await handleVerifyRemoteWebPairingChallenge(
+      makeVerificationRequest({ userCode: challenge.userCode }),
+      CLIENT_IP,
+    );
+
+    expect(approved.status).toBe(200);
   });
 });

--- a/gateway/src/__tests__/remote-web-pairing-verification.test.ts
+++ b/gateway/src/__tests__/remote-web-pairing-verification.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+const { handleCreateRemoteWebPairingChallenge } =
+  await import("../http/routes/remote-web-pairing-challenge.js");
+const {
+  handleVerifyRemoteWebPairingChallenge,
+  resetRemoteWebPairingVerificationRateLimiterForTests,
+} = await import("../http/routes/remote-web-pairing-verification.js");
+const {
+  getRemoteWebPairingChallengeForTests,
+  resetRemoteWebPairingChallengesForTests,
+  setRemoteWebPairingChallengeNowForTests,
+} = await import("../remote-web/pairing-challenge-store.js");
+
+const CLIENT_IP = "203.0.113.10";
+const LOOPBACK_IP = "127.0.0.1";
+const PUBLIC_BASE_URL = "https://paired.example.com";
+
+function makeChallengeRequest(): Request {
+  return new Request("http://localhost:7830/v1/remote-web/pairing-challenge", {
+    method: "POST",
+    headers: {
+      host: "localhost:7830",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ publicBaseUrl: PUBLIC_BASE_URL }),
+  });
+}
+
+function makeVerificationRequest(body: unknown): Request {
+  return new Request(
+    "https://paired.example.com/v1/remote-web/pairing-verification",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+async function createChallenge(): Promise<{
+  userCode: string;
+  verificationUri: string;
+  expiresAt: string;
+}> {
+  const res = await handleCreateRemoteWebPairingChallenge(
+    makeChallengeRequest(),
+    LOOPBACK_IP,
+  );
+  expect(res.status).toBe(200);
+  return (await res.json()) as {
+    userCode: string;
+    verificationUri: string;
+    expiresAt: string;
+  };
+}
+
+beforeEach(() => {
+  resetRemoteWebPairingChallengesForTests();
+  resetRemoteWebPairingVerificationRateLimiterForTests();
+});
+
+describe("remote web pairing verification", () => {
+  test("approves a pending challenge by user code", async () => {
+    setRemoteWebPairingChallengeNowForTests(() => 1_000);
+    const challenge = await createChallenge();
+
+    const res = await handleVerifyRemoteWebPairingChallenge(
+      makeVerificationRequest({
+        userCode: challenge.userCode.replace("-", "").toLowerCase(),
+      }),
+      CLIENT_IP,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(await res.json()).toEqual({
+      status: "approved",
+      verificationUri: challenge.verificationUri,
+      expiresAt: challenge.expiresAt,
+    });
+
+    const record = getRemoteWebPairingChallengeForTests(challenge.userCode);
+    expect(record?.status).toBe("approved");
+    expect(record?.approvedAtMs).toBe(1_000);
+  });
+
+  test("expires stale challenges instead of approving them", async () => {
+    setRemoteWebPairingChallengeNowForTests(() => 1_000);
+    const challenge = await createChallenge();
+    setRemoteWebPairingChallengeNowForTests(() => 601_000);
+
+    const res = await handleVerifyRemoteWebPairingChallenge(
+      makeVerificationRequest({ userCode: challenge.userCode }),
+      CLIENT_IP,
+    );
+
+    expect(res.status).toBe(410);
+    expect(await res.json()).toEqual({
+      error: {
+        code: "EXPIRED_USER_CODE",
+        message: "pairing code expired",
+      },
+    });
+    expect(getRemoteWebPairingChallengeForTests(challenge.userCode)).toBe(
+      undefined,
+    );
+  });
+
+  test("rate limits repeated failed verification attempts", async () => {
+    for (let i = 0; i < 10; i++) {
+      const res = await handleVerifyRemoteWebPairingChallenge(
+        makeVerificationRequest({ userCode: `BAD-${i}` }),
+        CLIENT_IP,
+      );
+      expect(res.status).toBe(404);
+    }
+
+    const limited = await handleVerifyRemoteWebPairingChallenge(
+      makeVerificationRequest({ userCode: "BAD-10" }),
+      CLIENT_IP,
+    );
+
+    expect(limited.status).toBe(429);
+    expect(limited.headers.get("Retry-After")).toBeTruthy();
+  });
+});

--- a/gateway/src/__tests__/remote-web-pairing-verification.test.ts
+++ b/gateway/src/__tests__/remote-web-pairing-verification.test.ts
@@ -2,15 +2,15 @@ import { beforeEach, describe, expect, test } from "bun:test";
 
 const { handleCreateRemoteWebPairingChallenge } =
   await import("../http/routes/remote-web-pairing-challenge.js");
-const {
-  handleVerifyRemoteWebPairingChallenge,
-  resetRemoteWebPairingVerificationRateLimiterForTests,
-} = await import("../http/routes/remote-web-pairing-verification.js");
+const { handleVerifyRemoteWebPairingChallenge } =
+  await import("../http/routes/remote-web-pairing-verification.js");
 const {
   getRemoteWebPairingChallengeForTests,
   resetRemoteWebPairingChallengesForTests,
   setRemoteWebPairingChallengeNowForTests,
 } = await import("../remote-web/pairing-challenge-store.js");
+const { resetRemoteWebPairingVerificationRateLimiterForTests } =
+  await import("../remote-web/pairing-verification-rate-limit-store.js");
 
 const CLIENT_IP = "203.0.113.10";
 const LOOPBACK_IP = "127.0.0.1";

--- a/gateway/src/__tests__/remote-web-pairing-verification.test.ts
+++ b/gateway/src/__tests__/remote-web-pairing-verification.test.ts
@@ -28,14 +28,41 @@ function makeChallengeRequest(): Request {
 }
 
 function makeVerificationRequest(body: unknown): Request {
+  return makeRawVerificationRequest(JSON.stringify(body));
+}
+
+function makeRawVerificationRequest(
+  body: BodyInit,
+  headers: Record<string, string> = {},
+): Request {
   return new Request(
     "https://paired.example.com/v1/remote-web/pairing-verification",
     {
       method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(body),
+      headers: { "content-type": "application/json", ...headers },
+      body,
     },
   );
+}
+
+function makeTrackedBodyAccessVerificationRequest(): {
+  req: Request;
+  getBodyAccessCount: () => number;
+} {
+  let bodyAccessCount = 0;
+  const req = {
+    method: "POST",
+    headers: new Headers({ "content-type": "application/json" }),
+    get body() {
+      bodyAccessCount += 1;
+      return new ReadableStream<Uint8Array>();
+    },
+  } as unknown as Request;
+
+  return {
+    req,
+    getBodyAccessCount: () => bodyAccessCount,
+  };
 }
 
 async function createChallenge(): Promise<{
@@ -134,5 +161,32 @@ describe("remote web pairing verification", () => {
     expect(
       getRemoteWebPairingChallengeForTests(challenge.userCode)?.status,
     ).toBe("pending");
+
+    const tracked = makeTrackedBodyAccessVerificationRequest();
+    const blockedUnreadBody = await handleVerifyRemoteWebPairingChallenge(
+      tracked.req,
+      CLIENT_IP,
+    );
+
+    expect(blockedUnreadBody.status).toBe(429);
+    expect(tracked.getBodyAccessCount()).toBe(0);
+  });
+
+  test("rejects oversized verification bodies", async () => {
+    const body = JSON.stringify({ userCode: "A".repeat(512) });
+    const res = await handleVerifyRemoteWebPairingChallenge(
+      makeRawVerificationRequest(body, {
+        "content-length": String(body.length),
+      }),
+      CLIENT_IP,
+    );
+
+    expect(res.status).toBe(413);
+    expect(await res.json()).toEqual({
+      error: {
+        code: "PAYLOAD_TOO_LARGE",
+        message: "request body too large",
+      },
+    });
   });
 });

--- a/gateway/src/__tests__/route-schema-guard.test.ts
+++ b/gateway/src/__tests__/route-schema-guard.test.ts
@@ -173,6 +173,8 @@ const EXCLUDED_FROM_SCHEMA = new Set([
   "/v1/pair",
   // Loopback-only remote web pairing challenge — not part of the public gateway API
   "/v1/remote-web/pairing-challenge",
+  // Remote web pairing verification bootstrap — not part of the public gateway API
+  "/v1/remote-web/pairing-verification",
   // Loopback-only device management — not part of the public gateway API
   "/v1/devices",
   "/v1/devices/revoke",

--- a/gateway/src/http/routes/remote-web-pairing-verification.ts
+++ b/gateway/src/http/routes/remote-web-pairing-verification.ts
@@ -1,0 +1,105 @@
+import { approveRemoteWebPairingChallenge } from "../../remote-web/pairing-challenge-store.js";
+
+const RATE_LIMIT_MAX_FAILURES = 10;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+
+interface RateLimitEntry {
+  timestamps: number[];
+}
+
+const failureRateLimitByIp = new Map<string, RateLimitEntry>();
+
+function jsonError(code: string, message: string, status: number): Response {
+  return Response.json({ error: { code, message } }, { status });
+}
+
+function checkFailureRateLimit(clientIp: string): Response | null {
+  const now = Date.now();
+  const windowStart = now - RATE_LIMIT_WINDOW_MS;
+  const entry = failureRateLimitByIp.get(clientIp);
+  if (!entry) return null;
+
+  entry.timestamps = entry.timestamps.filter((t) => t > windowStart);
+  if (entry.timestamps.length === 0) {
+    failureRateLimitByIp.delete(clientIp);
+    return null;
+  }
+  if (entry.timestamps.length < RATE_LIMIT_MAX_FAILURES) return null;
+
+  const resetAtMs = entry.timestamps[0] + RATE_LIMIT_WINDOW_MS;
+  const retryAfter = Math.max(1, Math.ceil((resetAtMs - now) / 1000));
+  return Response.json(
+    {
+      error: {
+        code: "RATE_LIMITED",
+        message: "too many invalid pairing verification attempts",
+      },
+    },
+    { status: 429, headers: { "Retry-After": String(retryAfter) } },
+  );
+}
+
+function recordFailure(clientIp: string): void {
+  const now = Date.now();
+  const windowStart = now - RATE_LIMIT_WINDOW_MS;
+  let entry = failureRateLimitByIp.get(clientIp);
+  if (!entry) {
+    entry = { timestamps: [] };
+    failureRateLimitByIp.set(clientIp, entry);
+  }
+  entry.timestamps = entry.timestamps.filter((t) => t > windowStart);
+  entry.timestamps.push(now);
+}
+
+function clearFailures(clientIp: string): void {
+  failureRateLimitByIp.delete(clientIp);
+}
+
+export function resetRemoteWebPairingVerificationRateLimiterForTests(): void {
+  failureRateLimitByIp.clear();
+}
+
+export async function handleVerifyRemoteWebPairingChallenge(
+  req: Request,
+  clientIp: string,
+): Promise<Response> {
+  if (req.method !== "POST") {
+    return new Response("method not allowed", {
+      status: 405,
+      headers: { Allow: "POST" },
+    });
+  }
+
+  const rateLimited = checkFailureRateLimit(clientIp);
+  if (rateLimited) return rateLimited;
+
+  let userCode: string | null = null;
+  try {
+    const body = (await req.json()) as { userCode?: unknown };
+    userCode =
+      typeof body.userCode === "string" && body.userCode.trim()
+        ? body.userCode
+        : null;
+  } catch {
+    recordFailure(clientIp);
+    return jsonError("BAD_REQUEST", "invalid JSON body", 400);
+  }
+
+  if (!userCode) {
+    recordFailure(clientIp);
+    return jsonError("BAD_REQUEST", "userCode is required", 400);
+  }
+
+  const result = approveRemoteWebPairingChallenge(userCode);
+  if (result.status === "invalid") {
+    recordFailure(clientIp);
+    return jsonError("INVALID_USER_CODE", "invalid pairing code", 404);
+  }
+  if (result.status === "expired") {
+    recordFailure(clientIp);
+    return jsonError("EXPIRED_USER_CODE", "pairing code expired", 410);
+  }
+
+  clearFailures(clientIp);
+  return Response.json(result, { headers: { "Cache-Control": "no-store" } });
+}

--- a/gateway/src/http/routes/remote-web-pairing-verification.ts
+++ b/gateway/src/http/routes/remote-web-pairing-verification.ts
@@ -98,6 +98,9 @@ export async function handleVerifyRemoteWebPairingChallenge(
     );
   }
 
+  const rateLimited = checkFailureRateLimit(clientIp);
+  if (rateLimited) return rateLimited;
+
   const result = approveRemoteWebPairingChallenge(userCode);
   if (result.status === "invalid") {
     return failedAttemptResponse(

--- a/gateway/src/http/routes/remote-web-pairing-verification.ts
+++ b/gateway/src/http/routes/remote-web-pairing-verification.ts
@@ -55,6 +55,13 @@ function clearFailures(clientIp: string): void {
   failureRateLimitByIp.delete(clientIp);
 }
 
+function failedAttemptResponse(clientIp: string, response: Response): Response {
+  const rateLimited = checkFailureRateLimit(clientIp);
+  if (rateLimited) return rateLimited;
+  recordFailure(clientIp);
+  return response;
+}
+
 export function resetRemoteWebPairingVerificationRateLimiterForTests(): void {
   failureRateLimitByIp.clear();
 }
@@ -70,9 +77,6 @@ export async function handleVerifyRemoteWebPairingChallenge(
     });
   }
 
-  const rateLimited = checkFailureRateLimit(clientIp);
-  if (rateLimited) return rateLimited;
-
   let userCode: string | null = null;
   try {
     const body = (await req.json()) as { userCode?: unknown };
@@ -81,23 +85,31 @@ export async function handleVerifyRemoteWebPairingChallenge(
         ? body.userCode
         : null;
   } catch {
-    recordFailure(clientIp);
-    return jsonError("BAD_REQUEST", "invalid JSON body", 400);
+    return failedAttemptResponse(
+      clientIp,
+      jsonError("BAD_REQUEST", "invalid JSON body", 400),
+    );
   }
 
   if (!userCode) {
-    recordFailure(clientIp);
-    return jsonError("BAD_REQUEST", "userCode is required", 400);
+    return failedAttemptResponse(
+      clientIp,
+      jsonError("BAD_REQUEST", "userCode is required", 400),
+    );
   }
 
   const result = approveRemoteWebPairingChallenge(userCode);
   if (result.status === "invalid") {
-    recordFailure(clientIp);
-    return jsonError("INVALID_USER_CODE", "invalid pairing code", 404);
+    return failedAttemptResponse(
+      clientIp,
+      jsonError("INVALID_USER_CODE", "invalid pairing code", 404),
+    );
   }
   if (result.status === "expired") {
-    recordFailure(clientIp);
-    return jsonError("EXPIRED_USER_CODE", "pairing code expired", 410);
+    return failedAttemptResponse(
+      clientIp,
+      jsonError("EXPIRED_USER_CODE", "pairing code expired", 410),
+    );
   }
 
   clearFailures(clientIp);

--- a/gateway/src/http/routes/remote-web-pairing-verification.ts
+++ b/gateway/src/http/routes/remote-web-pairing-verification.ts
@@ -1,33 +1,18 @@
 import { approveRemoteWebPairingChallenge } from "../../remote-web/pairing-challenge-store.js";
-
-const RATE_LIMIT_MAX_FAILURES = 10;
-const RATE_LIMIT_WINDOW_MS = 60_000;
-
-interface RateLimitEntry {
-  timestamps: number[];
-}
-
-const failureRateLimitByIp = new Map<string, RateLimitEntry>();
+import {
+  checkRemoteWebPairingVerificationRateLimit,
+  clearRemoteWebPairingVerificationFailures,
+  recordRemoteWebPairingVerificationFailure,
+  type RemoteWebPairingVerificationRateLimit,
+} from "../../remote-web/pairing-verification-rate-limit-store.js";
 
 function jsonError(code: string, message: string, status: number): Response {
   return Response.json({ error: { code, message } }, { status });
 }
 
-function checkFailureRateLimit(clientIp: string): Response | null {
-  const now = Date.now();
-  const windowStart = now - RATE_LIMIT_WINDOW_MS;
-  const entry = failureRateLimitByIp.get(clientIp);
-  if (!entry) return null;
-
-  entry.timestamps = entry.timestamps.filter((t) => t > windowStart);
-  if (entry.timestamps.length === 0) {
-    failureRateLimitByIp.delete(clientIp);
-    return null;
-  }
-  if (entry.timestamps.length < RATE_LIMIT_MAX_FAILURES) return null;
-
-  const resetAtMs = entry.timestamps[0] + RATE_LIMIT_WINDOW_MS;
-  const retryAfter = Math.max(1, Math.ceil((resetAtMs - now) / 1000));
+function rateLimitedResponse(
+  rateLimit: RemoteWebPairingVerificationRateLimit,
+): Response {
   return Response.json(
     {
       error: {
@@ -35,35 +20,18 @@ function checkFailureRateLimit(clientIp: string): Response | null {
         message: "too many invalid pairing verification attempts",
       },
     },
-    { status: 429, headers: { "Retry-After": String(retryAfter) } },
+    {
+      status: 429,
+      headers: { "Retry-After": String(rateLimit.retryAfterSeconds) },
+    },
   );
 }
 
-function recordFailure(clientIp: string): void {
-  const now = Date.now();
-  const windowStart = now - RATE_LIMIT_WINDOW_MS;
-  let entry = failureRateLimitByIp.get(clientIp);
-  if (!entry) {
-    entry = { timestamps: [] };
-    failureRateLimitByIp.set(clientIp, entry);
-  }
-  entry.timestamps = entry.timestamps.filter((t) => t > windowStart);
-  entry.timestamps.push(now);
-}
-
-function clearFailures(clientIp: string): void {
-  failureRateLimitByIp.delete(clientIp);
-}
-
 function failedAttemptResponse(clientIp: string, response: Response): Response {
-  const rateLimited = checkFailureRateLimit(clientIp);
-  if (rateLimited) return rateLimited;
-  recordFailure(clientIp);
+  const rateLimited = checkRemoteWebPairingVerificationRateLimit(clientIp);
+  if (rateLimited) return rateLimitedResponse(rateLimited);
+  recordRemoteWebPairingVerificationFailure(clientIp);
   return response;
-}
-
-export function resetRemoteWebPairingVerificationRateLimiterForTests(): void {
-  failureRateLimitByIp.clear();
 }
 
 export async function handleVerifyRemoteWebPairingChallenge(
@@ -98,8 +66,8 @@ export async function handleVerifyRemoteWebPairingChallenge(
     );
   }
 
-  const rateLimited = checkFailureRateLimit(clientIp);
-  if (rateLimited) return rateLimited;
+  const rateLimited = checkRemoteWebPairingVerificationRateLimit(clientIp);
+  if (rateLimited) return rateLimitedResponse(rateLimited);
 
   const result = approveRemoteWebPairingChallenge(userCode);
   if (result.status === "invalid") {
@@ -115,6 +83,6 @@ export async function handleVerifyRemoteWebPairingChallenge(
     );
   }
 
-  clearFailures(clientIp);
+  clearRemoteWebPairingVerificationFailures(clientIp);
   return Response.json(result, { headers: { "Cache-Control": "no-store" } });
 }

--- a/gateway/src/http/routes/remote-web-pairing-verification.ts
+++ b/gateway/src/http/routes/remote-web-pairing-verification.ts
@@ -6,6 +6,13 @@ import {
   type RemoteWebPairingVerificationRateLimit,
 } from "../../remote-web/pairing-verification-rate-limit-store.js";
 
+const MAX_VERIFICATION_BODY_BYTES = 256;
+
+type ReadVerificationBodyResult =
+  | { status: "ok"; text: string }
+  | { status: "too_large" }
+  | { status: "unreadable" };
+
 function jsonError(code: string, message: string, status: number): Response {
   return Response.json({ error: { code, message } }, { status });
 }
@@ -34,6 +41,57 @@ function failedAttemptResponse(clientIp: string, response: Response): Response {
   return response;
 }
 
+function concatChunks(chunks: Uint8Array[], totalBytes: number): Uint8Array {
+  const bytes = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+async function readVerificationBody(
+  req: Request,
+): Promise<ReadVerificationBodyResult> {
+  const contentLength = req.headers.get("content-length");
+  if (
+    contentLength &&
+    Number.isFinite(Number(contentLength)) &&
+    Number(contentLength) > MAX_VERIFICATION_BODY_BYTES
+  ) {
+    return { status: "too_large" };
+  }
+
+  if (!req.body) return { status: "ok", text: "" };
+
+  const reader = req.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+
+      totalBytes += value.byteLength;
+      if (totalBytes > MAX_VERIFICATION_BODY_BYTES) {
+        await reader.cancel().catch(() => {});
+        return { status: "too_large" };
+      }
+      chunks.push(value);
+    }
+  } catch {
+    return { status: "unreadable" };
+  }
+
+  return {
+    status: "ok",
+    text: new TextDecoder().decode(concatChunks(chunks, totalBytes)),
+  };
+}
+
 export async function handleVerifyRemoteWebPairingChallenge(
   req: Request,
   clientIp: string,
@@ -45,9 +103,29 @@ export async function handleVerifyRemoteWebPairingChallenge(
     });
   }
 
+  const rateLimitedBeforeBodyRead =
+    checkRemoteWebPairingVerificationRateLimit(clientIp);
+  if (rateLimitedBeforeBodyRead) {
+    return rateLimitedResponse(rateLimitedBeforeBodyRead);
+  }
+
+  const rawBody = await readVerificationBody(req);
+  if (rawBody.status === "too_large") {
+    return failedAttemptResponse(
+      clientIp,
+      jsonError("PAYLOAD_TOO_LARGE", "request body too large", 413),
+    );
+  }
+  if (rawBody.status === "unreadable") {
+    return failedAttemptResponse(
+      clientIp,
+      jsonError("BAD_REQUEST", "failed to read request body", 400),
+    );
+  }
+
   let userCode: string | null = null;
   try {
-    const body = (await req.json()) as { userCode?: unknown };
+    const body = JSON.parse(rawBody.text) as { userCode?: unknown };
     userCode =
       typeof body.userCode === "string" && body.userCode.trim()
         ? body.userCode
@@ -66,8 +144,11 @@ export async function handleVerifyRemoteWebPairingChallenge(
     );
   }
 
-  const rateLimited = checkRemoteWebPairingVerificationRateLimit(clientIp);
-  if (rateLimited) return rateLimitedResponse(rateLimited);
+  const rateLimitedBeforeCodeCheck =
+    checkRemoteWebPairingVerificationRateLimit(clientIp);
+  if (rateLimitedBeforeCodeCheck) {
+    return rateLimitedResponse(rateLimitedBeforeCodeCheck);
+  }
 
   const result = approveRemoteWebPairingChallenge(userCode);
   if (result.status === "invalid") {

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -95,6 +95,7 @@ import {
 } from "./http/routes/devices.js";
 import { handlePair } from "./http/routes/pair.js";
 import { handleCreateRemoteWebPairingChallenge } from "./http/routes/remote-web-pairing-challenge.js";
+import { handleVerifyRemoteWebPairingChallenge } from "./http/routes/remote-web-pairing-verification.js";
 import { createSlackControlPlaneProxyHandler } from "./http/routes/slack-control-plane-proxy.js";
 import { createOAuthAppsProxyHandler } from "./http/routes/oauth-apps-proxy.js";
 import { createOAuthProvidersProxyHandler } from "./http/routes/oauth-providers-proxy.js";
@@ -837,6 +838,13 @@ async function main() {
       auth: "none",
       handler: (req, _params, getClientIp) =>
         handleCreateRemoteWebPairingChallenge(req, getClientIp()),
+    },
+    {
+      path: "/v1/remote-web/pairing-verification",
+      method: "POST",
+      auth: "none",
+      handler: (req, _params, getClientIp) =>
+        handleVerifyRemoteWebPairingChallenge(req, getClientIp()),
     },
     // ── Device management (localhost-only, auth: none; self-guards loopback) ──
     {

--- a/gateway/src/remote-web/pairing-challenge-store.ts
+++ b/gateway/src/remote-web/pairing-challenge-store.ts
@@ -11,7 +11,9 @@ export interface PendingRemoteWebPairingChallenge {
   userCodeHash: string;
   publicBaseUrl: string;
   verificationUri: string;
+  status: "pending" | "approved";
   expiresAtMs: number;
+  approvedAtMs?: number;
 }
 
 export interface CreatedRemoteWebPairingChallenge {
@@ -22,6 +24,15 @@ export interface CreatedRemoteWebPairingChallenge {
   expiresInSeconds: number;
   intervalSeconds: number;
 }
+
+export type ApproveRemoteWebPairingChallengeResult =
+  | {
+      status: "approved";
+      verificationUri: string;
+      expiresAt: string;
+    }
+  | { status: "expired" }
+  | { status: "invalid" };
 
 const challengesByUserCodeHash = new Map<
   string,
@@ -76,6 +87,7 @@ export function createRemoteWebPairingChallenge(
     userCodeHash,
     publicBaseUrl,
     verificationUri,
+    status: "pending",
     expiresAtMs,
   });
 
@@ -86,6 +98,28 @@ export function createRemoteWebPairingChallenge(
     expiresAt: new Date(expiresAtMs).toISOString(),
     expiresInSeconds: Math.ceil(CODE_TTL_MS / 1000),
     intervalSeconds: POLL_INTERVAL_SECONDS,
+  };
+}
+
+export function approveRemoteWebPairingChallenge(
+  userCode: string,
+): ApproveRemoteWebPairingChallengeResult {
+  const userCodeHash = hashSecret(normalizeUserCode(userCode));
+  const challenge = challengesByUserCodeHash.get(userCodeHash);
+  if (!challenge) return { status: "invalid" };
+
+  const now = nowMs();
+  if (challenge.expiresAtMs <= now) {
+    challengesByUserCodeHash.delete(userCodeHash);
+    return { status: "expired" };
+  }
+
+  challenge.status = "approved";
+  challenge.approvedAtMs = now;
+  return {
+    status: "approved",
+    verificationUri: challenge.verificationUri,
+    expiresAt: new Date(challenge.expiresAtMs).toISOString(),
   };
 }
 

--- a/gateway/src/remote-web/pairing-verification-rate-limit-store.ts
+++ b/gateway/src/remote-web/pairing-verification-rate-limit-store.ts
@@ -1,0 +1,57 @@
+const RATE_LIMIT_MAX_FAILURES = 10;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+
+interface RateLimitEntry {
+  timestamps: number[];
+}
+
+export interface RemoteWebPairingVerificationRateLimit {
+  retryAfterSeconds: number;
+}
+
+const failureRateLimitByIp = new Map<string, RateLimitEntry>();
+
+export function checkRemoteWebPairingVerificationRateLimit(
+  clientIp: string,
+): RemoteWebPairingVerificationRateLimit | null {
+  const now = Date.now();
+  const windowStart = now - RATE_LIMIT_WINDOW_MS;
+  const entry = failureRateLimitByIp.get(clientIp);
+  if (!entry) return null;
+
+  entry.timestamps = entry.timestamps.filter((t) => t > windowStart);
+  if (entry.timestamps.length === 0) {
+    failureRateLimitByIp.delete(clientIp);
+    return null;
+  }
+  if (entry.timestamps.length < RATE_LIMIT_MAX_FAILURES) return null;
+
+  const resetAtMs = entry.timestamps[0] + RATE_LIMIT_WINDOW_MS;
+  return {
+    retryAfterSeconds: Math.max(1, Math.ceil((resetAtMs - now) / 1000)),
+  };
+}
+
+export function recordRemoteWebPairingVerificationFailure(
+  clientIp: string,
+): void {
+  const now = Date.now();
+  const windowStart = now - RATE_LIMIT_WINDOW_MS;
+  let entry = failureRateLimitByIp.get(clientIp);
+  if (!entry) {
+    entry = { timestamps: [] };
+    failureRateLimitByIp.set(clientIp, entry);
+  }
+  entry.timestamps = entry.timestamps.filter((t) => t > windowStart);
+  entry.timestamps.push(now);
+}
+
+export function clearRemoteWebPairingVerificationFailures(
+  clientIp: string,
+): void {
+  failureRateLimitByIp.delete(clientIp);
+}
+
+export function resetRemoteWebPairingVerificationRateLimiterForTests(): void {
+  failureRateLimitByIp.clear();
+}


### PR DESCRIPTION
## Summary
- Add a browser-facing remote web pairing verification endpoint that approves a pending user-code challenge.
- Track pairing challenge state as pending or approved and expire stale codes before approval.
- Add a small per-client failure limiter for invalid verification attempts.
- Keep local-only bootstrap routes denied by nginx while explicitly allowing the browser verification route through remote web ingress.

## Scope
This does not mint a remote web auth session, set cookies, or add SPA UI. It only transitions an existing pairing challenge to approved so the next PR can exchange the device code for a session.

## Tests
- Focused gateway pairing, ingress denylist, and schema guard tests passed.
- Gateway lint passed for touched files.
- Gateway typecheck passed.
- CLI nginx ingress test passed.

## Review focus
This intentionally adds one unauthenticated /v1 route for remote web pairing verification. It is allowed through nginx, but it only approves an existing short-lived challenge and does not mint a token.