### PR TITLE
fix(ces): fail-fast in-flight RPC calls when the transport dies (no more 30s credential stalls)

### DIFF
--- a/assistant/src/credential-execution/process-manager.ts
+++ b/assistant/src/credential-execution/process-manager.ts
@@ -313,13 +313,50 @@ function buildLocalCesEnv(): Record<string, string | undefined> {
 }
 
 // ---------------------------------------------------------------------------
+// Close notification (shared by both transports)
+// ---------------------------------------------------------------------------
+
+/**
+ * Tracks the transport `alive` state and notifies registered handlers exactly
+ * once when the transport dies, so the RPC client can fail-fast any in-flight
+ * calls instead of waiting out their timeouts.
+ */
+function createCloseNotifier(): {
+  isAlive: () => boolean;
+  markDead: () => void;
+  onClose: (handler: () => void) => void;
+} {
+  let alive = true;
+  let notified = false;
+  const handlers: Array<() => void> = [];
+  return {
+    isAlive: () => alive,
+    markDead() {
+      alive = false;
+      if (notified) return;
+      notified = true;
+      for (const handler of handlers) {
+        try {
+          handler();
+        } catch {
+          // a close handler must never throw back into the transport
+        }
+      }
+    },
+    onClose(handler) {
+      handlers.push(handler);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Stdio transport (local mode)
 // ---------------------------------------------------------------------------
 
 function createStdioTransport(proc: Subprocess): CesTransport {
   const messageHandlers: Array<(message: string) => void> = [];
   let buffer = "";
-  let alive = true;
+  const death = createCloseNotifier();
 
   // Read stdout line by line — narrow past `number` union arm from Subprocess type
   if (proc.stdout && typeof proc.stdout !== "number") {
@@ -350,9 +387,9 @@ function createStdioTransport(proc: Subprocess): CesTransport {
         endReason = "error";
         readError = err;
       } finally {
-        // Preserve existing semantics: the transport reports dead the moment
-        // the stdout stream ends, regardless of why.
-        alive = false;
+        // Report dead the moment the stdout stream ends (regardless of why),
+        // and notify the client so it can fail-fast any in-flight calls.
+        death.markDead();
 
         // DIAGNOSTIC (observation only). The reconnection path (secure-keys.ts)
         // bounces CES whenever isAlive() goes false. This classifies WHY the
@@ -384,7 +421,7 @@ function createStdioTransport(proc: Subprocess): CesTransport {
 
   // Track process exit
   void proc.exited.then((exitCode) => {
-    alive = false;
+    death.markDead();
     log.info(
       { pid: proc.pid, exitCode },
       "CES stdio transport: process exited",
@@ -393,7 +430,7 @@ function createStdioTransport(proc: Subprocess): CesTransport {
 
   return {
     write(line: string): void {
-      if (!alive || !proc.stdin || typeof proc.stdin === "number") {
+      if (!death.isAlive() || !proc.stdin || typeof proc.stdin === "number") {
         throw new Error("CES stdio transport is not alive");
       }
       proc.stdin.write(line + "\n");
@@ -404,11 +441,13 @@ function createStdioTransport(proc: Subprocess): CesTransport {
     },
 
     isAlive(): boolean {
-      return alive;
+      return death.isAlive();
     },
 
+    onClose: death.onClose,
+
     close(): void {
-      alive = false;
+      death.markDead();
       if (proc.stdin && typeof proc.stdin !== "number") {
         proc.stdin.end();
       }
@@ -423,7 +462,7 @@ function createStdioTransport(proc: Subprocess): CesTransport {
 function createSocketTransport(socket: Socket): CesTransport {
   const messageHandlers: Array<(message: string) => void> = [];
   let buffer = "";
-  let alive = true;
+  const death = createCloseNotifier();
 
   const decoder = new StringDecoder("utf8");
 
@@ -442,17 +481,17 @@ function createSocketTransport(socket: Socket): CesTransport {
   });
 
   socket.on("close", () => {
-    alive = false;
+    death.markDead();
   });
 
   socket.on("error", (err) => {
     log.warn({ err }, "CES socket transport error");
-    alive = false;
+    death.markDead();
   });
 
   return {
     write(line: string): void {
-      if (!alive || socket.destroyed) {
+      if (!death.isAlive() || socket.destroyed) {
         throw new Error("CES socket transport is not alive");
       }
       socket.write(line + "\n");
@@ -463,11 +502,13 @@ function createSocketTransport(socket: Socket): CesTransport {
     },
 
     isAlive(): boolean {
-      return alive && !socket.destroyed;
+      return death.isAlive() && !socket.destroyed;
     },
 
+    onClose: death.onClose,
+
     close(): void {
-      alive = false;
+      death.markDead();
       socket.destroy();
     },
   };

--- a/packages/ces-client/src/__tests__/ces-client.test.ts
+++ b/packages/ces-client/src/__tests__/ces-client.test.ts
@@ -74,7 +74,11 @@ function createMockTransport(): CesTransport & {
   messages: string[];
   messageHandler: ((msg: string) => void) | null;
   alive: boolean;
+  /** Simulate the transport dying (e.g. a spurious stdout EOF): mark it dead
+   *  and fire the registered close handlers, as the real transports do. */
+  die: () => void;
 } {
+  const closeHandlers: Array<() => void> = [];
   const transport = {
     messages: [] as string[],
     messageHandler: null as ((msg: string) => void) | null,
@@ -88,8 +92,15 @@ function createMockTransport(): CesTransport & {
     isAlive() {
       return transport.alive;
     },
+    onClose(handler: () => void) {
+      closeHandlers.push(handler);
+    },
     close() {
       transport.alive = false;
+    },
+    die() {
+      transport.alive = false;
+      for (const handler of closeHandlers) handler();
     },
   };
   return transport;
@@ -603,6 +614,42 @@ describe("CesRpcClient", () => {
     }
 
     expect(client.isReady()).toBe(false);
+  });
+
+  test("a pending request fails fast when the transport dies (no timeout wait)", async () => {
+    const transport = createMockTransport();
+    const client = createCesRpcClient(transport, {
+      handshakeTimeoutMs: 5000,
+      // Long timeout on purpose: the call must reject from the transport
+      // DEATH, not this timer. Without the fail-fast it would hang 60s.
+      requestTimeoutMs: 60_000,
+    });
+
+    // Handshake
+    const hPromise = client.handshake();
+    const hSent = JSON.parse(transport.messages[0]!);
+    transport.messageHandler!(
+      JSON.stringify({
+        type: "handshake_ack",
+        protocolVersion: CES_PROTOCOL_VERSION,
+        sessionId: hSent.sessionId,
+        accepted: true,
+      }),
+    );
+    await hPromise;
+
+    const callPromise = client.call("list_credentials", {});
+
+    // The transport's read side dies (e.g. a spurious stdout EOF on a CES
+    // bounce) while the request is in flight — the response can never arrive.
+    transport.die();
+
+    try {
+      await callPromise;
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(CesTransportError);
+    }
   });
 
   test("subsequent handshake call returns immediately if already ready", async () => {

--- a/packages/ces-client/src/rpc-client.ts
+++ b/packages/ces-client/src/rpc-client.ts
@@ -45,6 +45,14 @@ export interface CesTransport {
   isAlive(): boolean;
   /** Tear down the transport connection. */
   close(): void;
+  /**
+   * Register a callback that fires once when the transport dies (its read side
+   * ends, the process exits, or the socket closes). Lets the client fail-fast
+   * any in-flight requests instead of letting each wait out its timeout.
+   * Optional: a transport that doesn't implement it falls back to
+   * timeout-based failure.
+   */
+  onClose?(handler: () => void): void;
 }
 
 // ---------------------------------------------------------------------------
@@ -155,6 +163,16 @@ export function createCesRpcClient(
 
   const pending = new Map<string, PendingRequest>();
 
+  /** Reject and clear every in-flight request. Shared by `close()` and the
+   *  transport-death handler. */
+  function rejectAllPending(error: Error): void {
+    for (const [id, entry] of pending) {
+      clearTimeout(entry.timer);
+      pending.delete(id);
+      entry.reject(error);
+    }
+  }
+
   // -------------------------------------------------------------------------
   // Incoming message dispatch
   // -------------------------------------------------------------------------
@@ -207,6 +225,15 @@ export function createCesRpcClient(
       }
       return;
     }
+  });
+
+  // Fail-fast on transport death: when the transport's read side ends (e.g. a
+  // spurious stdout EOF on a CES bounce) or the connection closes, reject every
+  // in-flight request immediately. The response can never arrive on a dead
+  // transport, so without this a pending call hangs until `requestTimeoutMs`
+  // (observed: 30s stalls on credential reads that raced a CES restart).
+  transport.onClose?.(() => {
+    rejectAllPending(new CesTransportError("CES transport closed"));
   });
 
   // -------------------------------------------------------------------------
@@ -384,11 +411,7 @@ export function createCesRpcClient(
     },
 
     close(): void {
-      for (const [id, entry] of pending) {
-        clearTimeout(entry.timer);
-        entry.reject(new CesTransportError("CES client closed"));
-        pending.delete(id);
-      }
+      rejectAllPending(new CesTransportError("CES client closed"));
       ready = false;
       transport.close();
     },


### PR DESCRIPTION
## Summary

- A credential `get` that's *in-flight* when CES spuriously bounces (the stdout read-side dies mid-call) never receives its response, and nothing rejected it — so it hung the full `requestTimeoutMs` (30s). Observed ~2×/day on the local instance: `vellum/assistant_api_key` and `oura/access_token` each stalled 30s after a get raced a CES restart.
- The CES transport now **notifies the client when it dies** — a new optional `onClose` hook on `CesTransport`, fired exactly once via a shared `createCloseNotifier` in both the stdio and socket transports — and the client **rejects every pending request immediately** with `CesTransportError`, so the daemon sees `unreachable` and falls back instantly instead of waiting 30s. Mirrors the existing `embedding-local` worker pattern.
- **Strictly correct + mechanism-agnostic**: a dead transport's pending call can never succeed (the response physically can't arrive), so rejecting early only removes dead waiting — and it fixes the hang regardless of *why* the stdout died.

## Original prompt

The CES cold-vault tripwire (set up after the memory-v3 diagnosis) caught the actual recurring harm — not the rare cold-vault "not found", but 30-second `get_credential` timeouts from credential reads racing a CES bounce. Root cause: the rpc-client checks `isAlive()` before sending but had no way to reject calls already in-flight when the transport's read side dies. This wires transport-death → reject-pending.

## Note

No transport-level unit test for the stdio `onClose` wiring — `createStdioTransport`'s reader is a fire-and-forget async IIFE that can't be awaited deterministically (same reason the #34906 diagnostic skipped one). The fail-fast *contract* is tested at the client layer (60s request timeout, so the rejection provably comes from the death, not the timer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)