### PR TITLE
feat(plugins): nudge the model to close a progress surface it left open

### DIFF
--- a/assistant/bun.lock
+++ b/assistant/bun.lock
@@ -25,6 +25,7 @@
         "@vellumai/twilio-client": "file:../packages/twilio-client",
         "commander": "13.1.0",
         "croner": "10.0.1",
+        "diff": "8.0.4",
         "dotenv": "17.3.1",
         "drizzle-orm": "0.45.2",
         "jszip": "3.10.1",
@@ -1244,17 +1245,13 @@
 
     "@vellumai/ces-client/@types/bun": ["@types/bun@1.2.4", "", { "dependencies": { "bun-types": "1.2.4" } }, "sha512-QtuV5OMR8/rdKJs213iwXDpfVvnskPXY/S0ZiFbsTjQZycuqPbMW8Gf/XhLfwE5njW8sxI2WjISURXPlHypMFA=="],
 
-    "@vellumai/ces-client/@vellumai/service-contracts": ["@vellumai/service-contracts@file:../packages/service-contracts", {}],
+    "@vellumai/ces-client/@vellumai/service-contracts": ["@vellumai/service-contracts@file:../packages/service-contracts", { "dependencies": { "zod": "4.3.6" }, "devDependencies": { "@types/bun": "1.2.4", "typescript": "5.7.3" } }],
 
     "@vellumai/ces-client/typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
 
     "@vellumai/environments/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
-    "@vellumai/gateway-client/@vellumai/service-contracts": ["@vellumai/service-contracts@file:../packages/service-contracts", {}],
-
-    "@vellumai/service-contracts/@types/bun": ["@types/bun@1.2.4", "", { "dependencies": { "bun-types": "1.2.4" } }, "sha512-QtuV5OMR8/rdKJs213iwXDpfVvnskPXY/S0ZiFbsTjQZycuqPbMW8Gf/XhLfwE5njW8sxI2WjISURXPlHypMFA=="],
-
-    "@vellumai/service-contracts/typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
+    "@vellumai/gateway-client/@vellumai/service-contracts": ["@vellumai/service-contracts@file:../packages/service-contracts", { "dependencies": { "zod": "4.3.6" }, "devDependencies": { "@types/bun": "1.2.4", "typescript": "5.7.3" } }],
 
     "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
@@ -1342,9 +1339,11 @@
 
     "@vellumai/ces-client/@types/bun/bun-types": ["bun-types@1.2.4", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-nDPymR207ZZEoWD4AavvEaa/KZe/qlrbMSchqpQwovPZCKc7pwMoENjEtHgMKaAjJhy+x6vfqSBA1QU3bJgs0Q=="],
 
-    "@vellumai/environments/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+    "@vellumai/ces-client/@vellumai/service-contracts/@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
 
-    "@vellumai/service-contracts/@types/bun/bun-types": ["bun-types@1.2.4", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-nDPymR207ZZEoWD4AavvEaa/KZe/qlrbMSchqpQwovPZCKc7pwMoENjEtHgMKaAjJhy+x6vfqSBA1QU3bJgs0Q=="],
+    "@vellumai/ces-client/@vellumai/service-contracts/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "@vellumai/environments/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "detective-typescript/@typescript-eslint/typescript-estree/@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.61.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.61.0", "@typescript-eslint/types": "^8.61.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA=="],
 

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -19245,6 +19245,109 @@ paths:
           description: The plugin name failed sanitization (e.g. contained slashes, dots, or uppercase letters).
         "404":
           description: No installed copy and no catalog entry claims the given name.
+  /v1/plugins/{name}/diff:
+    post:
+      operationId: plugins_by_name_diff_post
+      summary: Diff a plugin against its install commit
+      description:
+        "Show a unified diff of local edits to an installed plugin against the exact commit it was installed at
+        (recorded in its `install-meta.json`). Computing the diff re-materializes the baseline through the install
+        pipeline — a network clone plus a temp-dir write — so this is a POST: it is not a safe, cacheable GET even
+        though it leaves persistent state untouched (requires only `settings.read`). Drift is classified against the
+        install-time fingerprint so an adapter overlay that moved since install never reads as a local change. Returns
+        the baseline `commit`, a `clean` flag, and a `files` array of `{ path, status, diff, binary, reconstructed }`
+        for each modified/added/removed file. The baseline is the install commit, not the marketplace pin — comparing
+        against the current pin is `POST /v1/plugins/:name/upgrade` with `dryRun`. A name with no installed copy returns
+        404; an install that recorded no commit or fingerprint returns 409; an unreachable source returns 503. Mirrors
+        the CLI's `assistant plugins diff <name>`."
+      tags:
+        - plugins
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    description: Install name. Matches `assistant plugins install <name>`.
+                  target:
+                    type: string
+                    description: Absolute path to the installed plugin directory on the host.
+                  commit:
+                    type: string
+                    description: Commit the baseline was re-materialized from (the recorded install SHA).
+                  committedAt:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                    description: ISO-8601 committer timestamp (UTC) of `commit`; null when not recorded.
+                  clean:
+                    type: boolean
+                    description: True when the on-disk tree exactly matches the re-materialized baseline.
+                  files:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        path:
+                          type: string
+                          description: POSIX-relative path within the plugin root.
+                        status:
+                          type: string
+                          enum:
+                            - modified
+                            - added
+                            - removed
+                          description: Whether the file was edited, newly added, or deleted since install.
+                        diff:
+                          type: string
+                          description:
+                            Unified diff (`--- a/… / +++ b/…`) of the file. A short `Binary files differ` marker for binary files, or a
+                            `Baseline unavailable` marker when `reconstructed` is false.
+                        binary:
+                          type: boolean
+                          description: True when either side was detected as binary (NUL byte present).
+                        reconstructed:
+                          type: boolean
+                          description:
+                            True when the install-time baseline for this file was faithfully recovered (re-materialized bytes
+                            hash-match the install fingerprint). False when it could not be reconstructed (e.g. the
+                            curated adapter overlay changed since install), in which case `diff` is a marker, not a
+                            patch. Always true for added files.
+                      required:
+                        - path
+                        - status
+                        - diff
+                        - binary
+                        - reconstructed
+                      additionalProperties: false
+                      description: Unified diff of a single drifted file.
+                    description: One entry per drifted file, sorted by path. Empty when `clean`.
+                required:
+                  - name
+                  - target
+                  - commit
+                  - committedAt
+                  - clean
+                  - files
+                additionalProperties: false
+        "400":
+          description: The plugin name failed sanitization (e.g. contained slashes, dots, or uppercase letters).
+        "404":
+          description: No copy of the plugin is installed, or its recorded commit resolves to nothing.
+        "409":
+          description: The install recorded no commit or no fingerprint to re-materialize and verify a baseline from.
+        "503":
+          description: The plugin source (GitHub) was temporarily unavailable; the diff is retryable.
   /v1/plugins/{name}/inspect:
     get:
       operationId: plugins_by_name_inspect_get

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -53,6 +53,7 @@
     "@vellumai/twilio-client": "file:../packages/twilio-client",
     "commander": "13.1.0",
     "croner": "10.0.1",
+    "diff": "8.0.4",
     "dotenv": "17.3.1",
     "drizzle-orm": "0.45.2",
     "jszip": "3.10.1",

--- a/assistant/src/__tests__/surface-completion-nudge-hook.test.ts
+++ b/assistant/src/__tests__/surface-completion-nudge-hook.test.ts
@@ -1,0 +1,367 @@
+/**
+ * Tests for the default `surface-completion-nudge` plugin's hooks.
+ *
+ * Covers:
+ * - The `post-model-call` hook nudges (continue + canonical text appended as a
+ *   `user` message) when a turn ends with a progress surface left open: a
+ *   `task_progress` card shown and never advanced to a terminal status, and a
+ *   `work_result` shown `in_progress`.
+ * - It does NOT nudge when the surface was completed via `ui_update`, dismissed
+ *   via `ui_dismiss`, or was never a progress surface (a plain card / a form).
+ * - Outcomes it does not own are ignored: a provider rejection, a tool-bearing
+ *   turn, and a non-main-agent call site.
+ * - The signal is scoped to the current response cycle — a surface left open in
+ *   a prior cycle (before the last genuine user prompt) does not trigger it.
+ * - The one-shot bound is split across the two hooks: `post-model-call` marks it
+ *   (nudging at most once per run) and `stop` clears it so the next run nudges
+ *   afresh.
+ *
+ * The loop's actual continuation side-effects live in `agent/loop.ts` and are
+ * covered by integration tests. This file isolates the hook.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type {
+  PluginLogger,
+  PostModelCallContext,
+} from "../plugin-api/types.js";
+import postModelCall, {
+  SURFACE_COMPLETION_NUDGE_TEXT,
+} from "../plugins/defaults/surface-completion-nudge/hooks/post-model-call.js";
+import stop from "../plugins/defaults/surface-completion-nudge/hooks/stop.js";
+import {
+  isSurfaceCompletionNudged,
+  resetSurfaceCompletionNudgeStoreForTests,
+} from "../plugins/defaults/surface-completion-nudge/nudge-state-store.js";
+import type { ContentBlock, Message } from "../providers/types.js";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const noopLogger: PluginLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+const finalText: ContentBlock = { type: "text", text: "All set." };
+
+let surfaceCounter = 0;
+
+/**
+ * An assistant `ui_show` turn paired with its `{ surfaceId }` tool result.
+ * Returns both messages plus the assigned surface id.
+ */
+function showSurface(input: Record<string, unknown>): {
+  messages: Message[];
+  surfaceId: string;
+} {
+  surfaceCounter += 1;
+  const toolUseId = `tu_show_${surfaceCounter}`;
+  const surfaceId = `surface-${surfaceCounter}`;
+  return {
+    surfaceId,
+    messages: [
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: toolUseId, name: "ui_show", input }],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: toolUseId,
+            content: JSON.stringify({ surfaceId }),
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function updateSurface(
+  surfaceId: string,
+  data: Record<string, unknown>,
+): Message {
+  return {
+    role: "assistant",
+    content: [
+      {
+        type: "tool_use",
+        id: `tu_update_${surfaceId}`,
+        name: "ui_update",
+        input: { surface_id: surfaceId, data },
+      },
+    ],
+  };
+}
+
+function dismissSurface(surfaceId: string): Message {
+  return {
+    role: "assistant",
+    content: [
+      {
+        type: "tool_use",
+        id: `tu_dismiss_${surfaceId}`,
+        name: "ui_dismiss",
+        input: { surface_id: surfaceId },
+      },
+    ],
+  };
+}
+
+function userPrompt(text: string): Message {
+  return { role: "user", content: [{ type: "text", text }] };
+}
+
+const taskProgressShow = (status?: string): Record<string, unknown> => ({
+  surface_type: "card",
+  title: "Working on X",
+  data: {
+    template: "task_progress",
+    templateData: {
+      title: "Working on X",
+      ...(status ? { status } : {}),
+      steps: [{ label: "Step 1", status: status ?? "in_progress" }],
+    },
+  },
+});
+
+function makeCtx(
+  overrides: Partial<PostModelCallContext> = {},
+): PostModelCallContext {
+  return {
+    conversationId: "conv-scn",
+    callSite: "mainAgent",
+    content: [finalText],
+    messages: [],
+    stopReason: null,
+    decision: "stop",
+    logger: noopLogger,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  resetSurfaceCompletionNudgeStoreForTests();
+  surfaceCounter = 0;
+});
+
+// ─── Nudges when a progress surface is left open ──────────────────────────────
+
+describe("surface-completion-nudge — nudges on a dangling progress surface", () => {
+  test("task_progress card shown and never completed → continue with nudge", async () => {
+    const shown = showSurface(taskProgressShow("in_progress"));
+    const ctx = makeCtx({
+      messages: [userPrompt("do the thing"), ...shown.messages],
+    });
+
+    await postModelCall(ctx);
+
+    expect(ctx.decision).toBe("continue");
+    const last = ctx.messages[ctx.messages.length - 1];
+    expect(last.role).toBe("user");
+    expect(last.content[0]).toEqual({
+      type: "text",
+      text: SURFACE_COMPLETION_NUDGE_TEXT,
+    });
+    expect(isSurfaceCompletionNudged("conv-scn")).toBe(true);
+  });
+
+  test("task_progress card shown with no explicit status → continue with nudge", async () => {
+    const shown = showSurface(taskProgressShow());
+    const ctx = makeCtx({
+      messages: [userPrompt("go"), ...shown.messages],
+    });
+
+    await postModelCall(ctx);
+
+    expect(ctx.decision).toBe("continue");
+  });
+
+  test("work_result shown in_progress → continue with nudge", async () => {
+    const shown = showSurface({
+      surface_type: "work_result",
+      data: { status: "in_progress", summary: "Crunching" },
+    });
+    const ctx = makeCtx({
+      messages: [userPrompt("go"), ...shown.messages],
+    });
+
+    await postModelCall(ctx);
+
+    expect(ctx.decision).toBe("continue");
+  });
+});
+
+// ─── Stays quiet when there is nothing to close ───────────────────────────────
+
+describe("surface-completion-nudge — no nudge when surface is closed or absent", () => {
+  test("task_progress completed via ui_update → stop", async () => {
+    const shown = showSurface(taskProgressShow("in_progress"));
+    const ctx = makeCtx({
+      messages: [
+        userPrompt("go"),
+        ...shown.messages,
+        updateSurface(shown.surfaceId, {
+          templateData: { status: "completed" },
+        }),
+      ],
+    });
+
+    await postModelCall(ctx);
+
+    expect(ctx.decision).toBe("stop");
+    expect(isSurfaceCompletionNudged("conv-scn")).toBe(false);
+  });
+
+  test("progress surface dismissed via ui_dismiss → stop", async () => {
+    const shown = showSurface(taskProgressShow("in_progress"));
+    const ctx = makeCtx({
+      messages: [
+        userPrompt("go"),
+        ...shown.messages,
+        dismissSurface(shown.surfaceId),
+      ],
+    });
+
+    await postModelCall(ctx);
+
+    expect(ctx.decision).toBe("stop");
+  });
+
+  test("work_result shown completed → stop", async () => {
+    const shown = showSurface({
+      surface_type: "work_result",
+      data: { status: "completed", summary: "Done" },
+    });
+    const ctx = makeCtx({
+      messages: [userPrompt("go"), ...shown.messages],
+    });
+
+    await postModelCall(ctx);
+
+    expect(ctx.decision).toBe("stop");
+  });
+
+  test("plain card (not a progress surface) → stop", async () => {
+    const shown = showSurface({
+      surface_type: "card",
+      title: "Weather",
+      data: { template: "weather_forecast", body: "Sunny" },
+    });
+    const ctx = makeCtx({
+      messages: [userPrompt("go"), ...shown.messages],
+    });
+
+    await postModelCall(ctx);
+
+    expect(ctx.decision).toBe("stop");
+  });
+
+  test("no surfaces shown at all → stop", async () => {
+    const ctx = makeCtx({
+      messages: [userPrompt("go")],
+    });
+
+    await postModelCall(ctx);
+
+    expect(ctx.decision).toBe("stop");
+  });
+});
+
+// ─── Outcomes the hook does not own ───────────────────────────────────────────
+
+describe("surface-completion-nudge — ignores outcomes it does not own", () => {
+  test("provider rejection (error present) → stop", async () => {
+    const shown = showSurface(taskProgressShow("in_progress"));
+    const ctx = makeCtx({
+      messages: [userPrompt("go"), ...shown.messages],
+      error: new Error("provider exploded"),
+    });
+
+    await postModelCall(ctx);
+
+    expect(ctx.decision).toBe("stop");
+  });
+
+  test("tool-bearing turn (model still working) → stop", async () => {
+    const shown = showSurface(taskProgressShow("in_progress"));
+    const ctx = makeCtx({
+      messages: [userPrompt("go"), ...shown.messages],
+      content: [
+        { type: "tool_use", id: "tu_next", name: "read_file", input: {} },
+      ],
+    });
+
+    await postModelCall(ctx);
+
+    expect(ctx.decision).toBe("stop");
+  });
+
+  test("non-main-agent call site → stop", async () => {
+    const shown = showSurface(taskProgressShow("in_progress"));
+    const ctx = makeCtx({
+      messages: [userPrompt("go"), ...shown.messages],
+      callSite: "heartbeatAgent",
+    });
+
+    await postModelCall(ctx);
+
+    expect(ctx.decision).toBe("stop");
+  });
+});
+
+// ─── Cycle scoping and the one-shot bound ─────────────────────────────────────
+
+describe("surface-completion-nudge — cycle scoping and one-shot bound", () => {
+  test("a surface left open in a prior cycle does not trigger this cycle", async () => {
+    const priorOpen = showSurface(taskProgressShow("in_progress"));
+    const ctx = makeCtx({
+      messages: [
+        userPrompt("first task"),
+        ...priorOpen.messages,
+        // New genuine user prompt opens a fresh cycle with no open surface.
+        userPrompt("second task"),
+      ],
+    });
+
+    await postModelCall(ctx);
+
+    expect(ctx.decision).toBe("stop");
+  });
+
+  test("nudges at most once per run; stop clears the bound", async () => {
+    const shown = showSurface(taskProgressShow("in_progress"));
+    const firstCtx = makeCtx({
+      messages: [userPrompt("go"), ...shown.messages],
+    });
+
+    await postModelCall(firstCtx);
+    expect(firstCtx.decision).toBe("continue");
+
+    // Same run, surface still open: the one-shot bound suppresses a second nudge.
+    const secondCtx = makeCtx({
+      messages: [userPrompt("go"), ...shown.messages],
+    });
+    await postModelCall(secondCtx);
+    expect(secondCtx.decision).toBe("stop");
+
+    // Terminal stop clears the bound so the next run nudges afresh.
+    await stop({
+      conversationId: "conv-scn",
+      messages: [],
+      exitReason: "no_tool_calls",
+      logger: noopLogger,
+    });
+    expect(isSurfaceCompletionNudged("conv-scn")).toBe(false);
+
+    const thirdCtx = makeCtx({
+      messages: [userPrompt("go"), ...shown.messages],
+    });
+    await postModelCall(thirdCtx);
+    expect(thirdCtx.decision).toBe("continue");
+  });
+});

--- a/assistant/src/cli/commands/plugins.ts
+++ b/assistant/src/cli/commands/plugins.ts
@@ -11,6 +11,11 @@ import type { Command } from "commander";
 
 import { confirmPrompt } from "../lib/confirm-prompt.js";
 import {
+  diffPlugin,
+  type PluginDiffResult,
+  PluginDiffUnavailableError,
+} from "../lib/diff-plugin.js";
+import {
   inspectPlugin,
   type PluginInspection,
   PluginInspectNotFoundError,
@@ -60,6 +65,8 @@ Examples:
   $ assistant plugins list --json
   $ assistant plugins inspect example
   $ assistant plugins inspect example --json
+  $ assistant plugins diff example
+  $ assistant plugins diff example --json
   $ assistant plugins upgrade example
   $ assistant plugins upgrade example --dry-run
   $ assistant plugins search example
@@ -208,6 +215,73 @@ Examples:
             }
             const message = err instanceof Error ? err.message : String(err);
             console.error(`Plugin inspect failed: ${message}`);
+            process.exitCode = 1;
+          }
+        });
+
+      plugins
+        .command("diff <name>")
+        .description(
+          "Show a unified diff of local edits to an installed plugin against the commit it was installed at",
+        )
+        .option(
+          "--json",
+          "Emit the machine-readable diff result as JSON (files: { path, status, diff, binary, reconstructed }[]) instead of a unified diff",
+        )
+        .addHelpText(
+          "after",
+          `
+Arguments:
+  name   Install name (kebab-case directory under the workspace plugins dir);
+         run 'assistant plugins list' to see installed names.
+
+The baseline is the exact commit the plugin was installed at (recorded in its
+install-meta.json), re-materialized through the install pipeline — so an
+install-time adapter transform never reads as a local change. To compare
+against the marketplace's current pin instead, use 'plugins upgrade --dry-run'.
+
+Examples:
+  $ assistant plugins diff example
+  $ assistant plugins diff example --json`,
+        )
+        .action(async (name: string, opts: { json?: boolean }) => {
+          try {
+            const result = await diffPlugin(
+              { name },
+              { fetch: globalThis.fetch.bind(globalThis) },
+            );
+
+            if (opts.json) {
+              process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+              return;
+            }
+
+            // Logged after the JSON early-return: the CLI logger writes
+            // info to stdout, which would otherwise corrupt --json output.
+            log.info(
+              {
+                name: result.name,
+                clean: result.clean,
+                files: result.files.length,
+              },
+              "plugin diff",
+            );
+
+            for (const line of formatDiff(result)) {
+              console.log(line);
+            }
+          } catch (err) {
+            if (
+              err instanceof PluginNotInstalledError ||
+              err instanceof PluginDiffUnavailableError ||
+              err instanceof InvalidPluginNameError
+            ) {
+              console.error(err.message);
+              process.exitCode = 1;
+              return;
+            }
+            const message = err instanceof Error ? err.message : String(err);
+            console.error(`Plugin diff failed: ${message}`);
             process.exitCode = 1;
           }
         });
@@ -531,4 +605,33 @@ function formatUpgrade(result: PluginUpgradeResult): string[] {
       return lines;
     }
   }
+}
+
+/**
+ * Render a diff result: a one-line "no local changes" when clean, otherwise a
+ * header naming the install-commit baseline followed by each file's unified
+ * diff (blank-line separated, mirroring how `git diff` stacks file patches).
+ */
+function formatDiff(result: PluginDiffResult): string[] {
+  const baseline = `${formatTimestamp(result.committedAt)} (${shortSha(result.commit)})`;
+  if (result.clean) {
+    return [
+      `"${result.name}" has no local changes (matches install commit ${baseline}).`,
+    ];
+  }
+  const count = result.files.length;
+  const lines = [
+    `"${result.name}" — ${count} file${count === 1 ? "" : "s"} changed vs install commit ${baseline}`,
+    "",
+  ];
+  for (const file of result.files) {
+    // A non-reconstructed baseline carries an explanatory marker, not a patch
+    // with `a/`–`b/` headers, so name the file it refers to.
+    if (!file.reconstructed) {
+      lines.push(`${file.path}: ${file.diff.trimEnd()}`, "");
+      continue;
+    }
+    lines.push(file.diff.trimEnd(), "");
+  }
+  return lines;
 }

--- a/assistant/src/cli/lib/__tests__/diff-plugin.test.ts
+++ b/assistant/src/cli/lib/__tests__/diff-plugin.test.ts
@@ -1,0 +1,443 @@
+/**
+ * Tests for {@link diffPlugin}.
+ *
+ * A diff re-materializes the recorded install commit through the same pipeline
+ * install uses, then compares that baseline tree against the on-disk install.
+ * The clone is replaced with a fake {@link GitRunner} that writes a known
+ * baseline tree, the adapter-stub lookup is answered 404 by an in-memory
+ * `fetch` (so the clone is treated as a raw external tree), and the install
+ * target is a real temp directory passed via `workspacePluginsDir` — no globals
+ * are patched. Fixtures vary the on-disk tree to exercise modified/added/
+ * removed drift, binary content, and the clean case.
+ */
+
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { diffPlugin, PluginDiffUnavailableError } from "../diff-plugin.js";
+import {
+  type FetchLike,
+  type GitRunner,
+  PluginNotFoundError,
+} from "../install-from-github.js";
+import { PluginNotInstalledError } from "../uninstall-plugin.js";
+
+const SHA_A = "a".repeat(40);
+
+/** Bytes for each baseline / on-disk file, keyed by repo-relative POSIX path. */
+type Tree = Record<string, string | Buffer>;
+
+/**
+ * Build a `fetch` that answers the GitHub Contents API listing (the adapter
+ * stub lookup) with a 404, so the clone is materialized as a raw external tree
+ * with no overlay. Anything else surfaces a 500 so test bugs are loud.
+ */
+function makeFetch(): FetchLike {
+  return (async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.includes("api.github.com")) {
+      return new Response("not found", { status: 404 });
+    }
+    return new Response(`unexpected url: ${url}`, { status: 500 });
+  }) as FetchLike;
+}
+
+/**
+ * A fake clone that materializes `files` into the scratch clone dir at `fetch`
+ * and reports `commit` at HEAD, mirroring how the real git pipeline stages a
+ * tree before it is copied into the destination.
+ */
+function fakeGitRunner(commit: string, files: Tree): GitRunner {
+  return async (args, { cwd }) => {
+    switch (args[0]) {
+      case "fetch": {
+        mkdirSync(join(cwd, ".git"), { recursive: true });
+        writeFileSync(join(cwd, ".git", "config"), "[core]\n");
+        for (const [rel, content] of Object.entries(files)) {
+          const abs = join(cwd, rel);
+          mkdirSync(dirname(abs), { recursive: true });
+          writeFileSync(abs, content);
+        }
+        return { stdout: "" };
+      }
+      case "rev-parse":
+        return { stdout: `${commit}\n` };
+      default:
+        return { stdout: "" };
+    }
+  };
+}
+
+/** A git runner that fails the test if any git command runs. */
+const unusedGitRunner: GitRunner = async (args) => {
+  throw new Error(`git should not run for this diff: ${args.join(" ")}`);
+};
+
+/**
+ * Per-file SHA-256 digest of a tree, in the {@link Fingerprint} shape install
+ * records in `install-meta.json`. Drift is classified against this recorded
+ * baseline (as `inspect` does), so each fixture records the digest of its
+ * install-time tree.
+ */
+function fingerprintOf(tree: Tree): {
+  algorithm: "sha256";
+  files: Record<string, string>;
+} {
+  const files: Record<string, string> = {};
+  for (const [rel, content] of Object.entries(tree)) {
+    const buf = typeof content === "string" ? Buffer.from(content) : content;
+    files[rel] = createHash("sha256").update(buf).digest("hex");
+  }
+  return { algorithm: "sha256", files };
+}
+
+/**
+ * Materialize an installed plugin copy with `files` on disk and an optional
+ * provenance sidecar. `sidecar: null` writes no `install-meta.json`; a sidecar
+ * with `commit: null` records an install that captured no commit. `baseline`
+ * is the install-time tree whose fingerprint is recorded — drift is classified
+ * against it (as `inspect` does); omit it to record an install with no
+ * fingerprint (an older or manually-copied install).
+ */
+function installCopy(
+  pluginsDir: string,
+  name: string,
+  files: Tree,
+  sidecar: {
+    commit: string | null;
+    committedAt?: string;
+    baseline?: Tree;
+  } | null,
+): void {
+  const dir = join(pluginsDir, name);
+  mkdirSync(dir, { recursive: true });
+  for (const [rel, content] of Object.entries(files)) {
+    const abs = join(dir, rel);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, content);
+  }
+  if (sidecar !== null) {
+    writeFileSync(
+      join(dir, "install-meta.json"),
+      JSON.stringify({
+        origin: "vellum",
+        name,
+        source: {
+          kind: "github",
+          owner: "example-org",
+          repo: name,
+          ref: SHA_A,
+        },
+        commit: sidecar.commit,
+        committedAt: sidecar.committedAt,
+        installedAt: "2026-06-10T12:00:00.000Z",
+        fingerprint:
+          sidecar.baseline !== undefined
+            ? fingerprintOf(sidecar.baseline)
+            : null,
+      }),
+    );
+  }
+}
+
+let ws: string;
+let pluginsDir: string;
+
+beforeEach(() => {
+  ws = mkdtempSync(join(tmpdir(), "diff-plugin-"));
+  pluginsDir = join(ws, "plugins");
+  mkdirSync(pluginsDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(ws, { recursive: true, force: true });
+});
+
+describe("diffPlugin", () => {
+  test("reports a unified diff for a file edited since install", async () => {
+    // GIVEN a plugin whose install baseline declares a two-line file
+    const baseline: Tree = {
+      "package.json": '{"name":"level-up"}',
+      "src/skill.ts": "export const a = 1;\nexport const b = 2;\n",
+    };
+    // AND the on-disk copy edited the second line of that file
+    installCopy(
+      pluginsDir,
+      "level-up",
+      {
+        "package.json": '{"name":"level-up"}',
+        "src/skill.ts": "export const a = 1;\nexport const b = 99;\n",
+      },
+      { commit: SHA_A, baseline },
+    );
+
+    // WHEN the plugin is diffed against its install commit
+    const result = await diffPlugin(
+      { name: "level-up" },
+      {
+        fetch: makeFetch(),
+        runGit: fakeGitRunner(SHA_A, baseline),
+        workspacePluginsDir: pluginsDir,
+      },
+    );
+
+    // THEN the recorded baseline commit is reported as drifted
+    expect(result.commit).toBe(SHA_A);
+    expect(result.clean).toBe(false);
+    // AND exactly the edited file is surfaced as modified
+    expect(result.files).toHaveLength(1);
+    const [file] = result.files;
+    expect(file.path).toBe("src/skill.ts");
+    expect(file.status).toBe("modified");
+    expect(file.binary).toBe(false);
+    expect(file.reconstructed).toBe(true);
+    // AND the unified diff shows the old and new line
+    expect(file.diff).toContain("-export const b = 2;");
+    expect(file.diff).toContain("+export const b = 99;");
+    expect(file.diff).toContain("a/src/skill.ts");
+    expect(file.diff).toContain("b/src/skill.ts");
+  });
+
+  test("classifies added and removed files against the baseline", async () => {
+    // GIVEN a baseline with a single source file besides the manifest
+    const baseline: Tree = {
+      "package.json": '{"name":"level-up"}',
+      "src/old.ts": "export const gone = true;\n",
+    };
+    // AND an on-disk copy that dropped that file and added a new one
+    installCopy(
+      pluginsDir,
+      "level-up",
+      {
+        "package.json": '{"name":"level-up"}',
+        "src/new.ts": "export const added = true;\n",
+      },
+      { commit: SHA_A, baseline },
+    );
+
+    // WHEN the plugin is diffed
+    const result = await diffPlugin(
+      { name: "level-up" },
+      {
+        fetch: makeFetch(),
+        runGit: fakeGitRunner(SHA_A, baseline),
+        workspacePluginsDir: pluginsDir,
+      },
+    );
+
+    // THEN both the addition and the removal are reported, sorted by path
+    expect(result.clean).toBe(false);
+    expect(result.files.map((f) => [f.path, f.status])).toEqual([
+      ["src/new.ts", "added"],
+      ["src/old.ts", "removed"],
+    ]);
+    // AND each side diffs against /dev/null like git
+    const added = result.files[0];
+    const removed = result.files[1];
+    expect(added.diff).toContain("+export const added = true;");
+    expect(added.diff).toContain("/dev/null");
+    expect(removed.diff).toContain("-export const gone = true;");
+    expect(removed.diff).toContain("/dev/null");
+  });
+
+  test("reports clean when the on-disk tree matches the baseline", async () => {
+    // GIVEN a baseline and an identical on-disk copy
+    const tree: Tree = {
+      "package.json": '{"name":"level-up"}',
+      "src/skill.ts": "export const a = 1;\n",
+    };
+    installCopy(pluginsDir, "level-up", tree, {
+      commit: SHA_A,
+      baseline: tree,
+    });
+
+    // WHEN the plugin is diffed
+    const result = await diffPlugin(
+      { name: "level-up" },
+      {
+        fetch: makeFetch(),
+        runGit: fakeGitRunner(SHA_A, tree),
+        workspacePluginsDir: pluginsDir,
+      },
+    );
+
+    // THEN no drift is reported and the file list is empty
+    expect(result.clean).toBe(true);
+    expect(result.files).toHaveLength(0);
+  });
+
+  test("excludes the provenance sidecar from the diff", async () => {
+    // GIVEN a baseline (which never contains install-meta.json) and an on-disk
+    // copy identical to it apart from the sidecar install always writes
+    const tree: Tree = { "package.json": '{"name":"level-up"}' };
+    installCopy(pluginsDir, "level-up", tree, {
+      commit: SHA_A,
+      baseline: tree,
+    });
+
+    // WHEN the plugin is diffed
+    const result = await diffPlugin(
+      { name: "level-up" },
+      {
+        fetch: makeFetch(),
+        runGit: fakeGitRunner(SHA_A, tree),
+        workspacePluginsDir: pluginsDir,
+      },
+    );
+
+    // THEN the sidecar is not surfaced as a local addition
+    expect(result.clean).toBe(true);
+    expect(result.files.map((f) => f.path)).not.toContain("install-meta.json");
+  });
+
+  test("marks a drifted binary file instead of emitting a line diff", async () => {
+    // GIVEN a baseline binary blob and an on-disk copy with different bytes
+    const baseline: Tree = {
+      "package.json": '{"name":"level-up"}',
+      "assets/icon.bin": Buffer.from([0x00, 0x01, 0x02, 0x03]),
+    };
+    installCopy(
+      pluginsDir,
+      "level-up",
+      {
+        "package.json": '{"name":"level-up"}',
+        "assets/icon.bin": Buffer.from([0x00, 0xff, 0xfe, 0xfd]),
+      },
+      { commit: SHA_A, baseline },
+    );
+
+    // WHEN the plugin is diffed
+    const result = await diffPlugin(
+      { name: "level-up" },
+      {
+        fetch: makeFetch(),
+        runGit: fakeGitRunner(SHA_A, baseline),
+        workspacePluginsDir: pluginsDir,
+      },
+    );
+
+    // THEN the binary file is flagged rather than line-diffed
+    expect(result.files).toHaveLength(1);
+    const [file] = result.files;
+    expect(file.path).toBe("assets/icon.bin");
+    expect(file.binary).toBe(true);
+    expect(file.reconstructed).toBe(true);
+    expect(file.diff).toContain("Binary files differ");
+  });
+
+  test("flags a file whose install-time baseline cannot be reconstructed", async () => {
+    // GIVEN an install whose recorded fingerprint captured one version of a file
+    const recorded: Tree = {
+      "package.json": '{"name":"level-up"}',
+      "src/skill.ts": "export const v = 1;\n",
+    };
+    // AND an on-disk copy the user edited (drift vs the recorded baseline)
+    installCopy(
+      pluginsDir,
+      "level-up",
+      {
+        "package.json": '{"name":"level-up"}',
+        "src/skill.ts": "export const v = 2;\n",
+      },
+      { commit: SHA_A, baseline: recorded },
+    );
+    // AND a re-materialization that yields DIFFERENT bytes than were recorded
+    // (e.g. the curated adapter overlay moved since install), so the baseline
+    // bytes cannot be faithfully reconstructed for this file
+    const driftedClone: Tree = {
+      "package.json": '{"name":"level-up"}',
+      "src/skill.ts": "export const v = 3;\n",
+    };
+
+    // WHEN the plugin is diffed
+    const result = await diffPlugin(
+      { name: "level-up" },
+      {
+        fetch: makeFetch(),
+        runGit: fakeGitRunner(SHA_A, driftedClone),
+        workspacePluginsDir: pluginsDir,
+      },
+    );
+
+    // THEN the file is still reported as drifted (classified vs the recorded
+    // fingerprint, like inspect), but flagged rather than diffed against the
+    // fabricated baseline bytes
+    expect(result.clean).toBe(false);
+    expect(result.files).toHaveLength(1);
+    const [file] = result.files;
+    expect(file.path).toBe("src/skill.ts");
+    expect(file.status).toBe("modified");
+    expect(file.reconstructed).toBe(false);
+    expect(file.diff).toContain("Baseline unavailable");
+    // AND the re-materialized (wrong) bytes are never presented as the baseline
+    expect(file.diff).not.toContain("export const v = 3;");
+  });
+
+  test("throws PluginNotInstalledError when no copy is installed", async () => {
+    // GIVEN an empty plugins directory
+    // WHEN a plugin that was never installed is diffed
+    // THEN it reports the install is missing (git is never reached)
+    await expect(
+      diffPlugin(
+        { name: "level-up" },
+        {
+          fetch: makeFetch(),
+          runGit: unusedGitRunner,
+          workspacePluginsDir: pluginsDir,
+        },
+      ),
+    ).rejects.toBeInstanceOf(PluginNotInstalledError);
+  });
+
+  test("throws PluginDiffUnavailableError when the install recorded no commit", async () => {
+    // GIVEN an installed copy whose sidecar captured no commit
+    installCopy(
+      pluginsDir,
+      "level-up",
+      { "package.json": '{"name":"level-up"}' },
+      { commit: null },
+    );
+
+    // WHEN the plugin is diffed
+    // THEN there is no immutable baseline to re-materialize (git is never run)
+    await expect(
+      diffPlugin(
+        { name: "level-up" },
+        {
+          fetch: makeFetch(),
+          runGit: unusedGitRunner,
+          workspacePluginsDir: pluginsDir,
+        },
+      ),
+    ).rejects.toBeInstanceOf(PluginDiffUnavailableError);
+  });
+
+  test("throws PluginNotFoundError when the recorded commit yields no tree", async () => {
+    // GIVEN an installed copy with a recorded commit and fingerprint (so the
+    // baseline-classification guard passes and execution reaches the clone)
+    installCopy(
+      pluginsDir,
+      "level-up",
+      { "package.json": '{"name":"level-up"}' },
+      { commit: SHA_A, baseline: { "package.json": '{"name":"level-up"}' } },
+    );
+    // AND a clone that materializes no files (the commit/sub-path is gone)
+    const emptyClone = fakeGitRunner(SHA_A, {});
+
+    // WHEN the plugin is diffed
+    // THEN the missing baseline is surfaced as not-found
+    await expect(
+      diffPlugin(
+        { name: "level-up" },
+        {
+          fetch: makeFetch(),
+          runGit: emptyClone,
+          workspacePluginsDir: pluginsDir,
+        },
+      ),
+    ).rejects.toBeInstanceOf(PluginNotFoundError);
+  });
+});

--- a/assistant/src/cli/lib/diff-plugin.ts
+++ b/assistant/src/cli/lib/diff-plugin.ts
@@ -1,0 +1,346 @@
+/**
+ * Show the unified diff of local edits to an installed plugin, against the
+ * exact commit it was installed at.
+ *
+ * `plugins inspect` already reports *which* files drifted via the install-time
+ * per-file fingerprint (see {@link ./plugin-fingerprint}), but that digest is
+ * one-way — it cannot reconstruct the original bytes, so it can't show *what*
+ * changed. Drift here is classified the same way `inspect` does — against the
+ * fingerprint recorded at install — so the two surfaces always agree and a
+ * curated adapter overlay that changed since install never misreads as local
+ * drift.
+ *
+ * Showing *what* changed still needs the baseline *bytes*, which the fingerprint
+ * cannot reconstruct. Those are re-derived by re-materializing the recorded
+ * commit (from `install-meta.json`) through the *same* pipeline install used
+ * (see {@link ./install-from-github.materializePluginTree}): a shallow clone at
+ * the immutable SHA plus the curated adapter overlay. The adapter overlay is
+ * fetched from the canonical repo's current ref, not the install-time ref (which
+ * is not recorded), so a re-materialized file can diverge from what install
+ * produced. Each baseline file is therefore verified against the recorded
+ * fingerprint digest before it is diffed: on a mismatch the install-time bytes
+ * cannot be faithfully reconstructed, so the file is flagged rather than diffed
+ * against a fabricated baseline.
+ *
+ * The baseline is always the recorded install commit, not the marketplace's
+ * current pin: this answers "what local changes have been made since install",
+ * independent of marketplace movement. Comparing against the latest pin is the
+ * separate concern `plugins upgrade --dry-run` already covers.
+ *
+ * Designed for direct programmatic use with injected dependencies, mirroring
+ * the sibling plugin libraries. The CLI command `assistant plugins diff <name>`
+ * is a thin wrapper that supplies production deps and formats the result.
+ */
+
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createTwoFilesPatch } from "diff";
+
+import { getWorkspacePluginsDir } from "../../util/platform.js";
+import {
+  DEFAULT_PLUGIN_REF,
+  type FetchLike,
+  type GitRunner,
+  INSTALL_META_FILENAME,
+  materializePluginTree,
+  type PluginFetchSource,
+  PluginNotFoundError,
+  type PostinstallRunner,
+  readInstallMeta,
+  sanitizePluginName,
+} from "./install-from-github.js";
+import { readInstalledPlugin } from "./list-installed-plugins.js";
+import {
+  compareFingerprint,
+  computeFingerprint,
+  type Fingerprint,
+} from "./plugin-fingerprint.js";
+import { PluginNotInstalledError } from "./uninstall-plugin.js";
+
+/** How a file drifted from the install-time baseline. */
+export type PluginFileDiffStatus = "modified" | "added" | "removed";
+
+/** Unified diff of a single drifted file. */
+export interface PluginFileDiff {
+  /** POSIX-relative path within the plugin root. */
+  readonly path: string;
+  /** Whether the file was edited, newly added, or deleted since install. */
+  readonly status: PluginFileDiffStatus;
+  /**
+   * Unified diff (`--- a/… / +++ b/…`) of the file's bytes. For a binary file
+   * this is a short `Binary files differ` marker instead of a line diff, since
+   * a line-based patch of non-text content is noise. When {@link
+   * PluginFileDiff.reconstructed} is false this is a short explanatory marker
+   * rather than a patch, since the install-time bytes are unavailable.
+   */
+  readonly diff: string;
+  /** True when either side was detected as binary (NUL byte present). */
+  readonly binary: boolean;
+  /**
+   * True when the install-time baseline for this file was faithfully recovered
+   * (its re-materialized bytes hash-match the digest recorded at install).
+   * False when the baseline could not be reconstructed — e.g. the curated
+   * adapter overlay the file was built from has changed since install — in
+   * which case {@link PluginFileDiff.diff} is a marker, not a real patch.
+   * Always true for `added` files, whose baseline is the empty side.
+   */
+  readonly reconstructed: boolean;
+}
+
+/** Resolved diff of an installed plugin against its install-time baseline. */
+export interface PluginDiffResult {
+  /** Install name. Matches `assistant plugins install <name>`. */
+  readonly name: string;
+  /** Absolute path to the installed plugin directory. */
+  readonly target: string;
+  /** Commit the baseline was re-materialized from (the recorded install SHA). */
+  readonly commit: string;
+  /** ISO-8601 committer timestamp (UTC) of {@link PluginDiffResult.commit}; `null` when unrecorded. */
+  readonly committedAt: string | null;
+  /** True when the on-disk tree exactly matches the re-materialized baseline. */
+  readonly clean: boolean;
+  /** One entry per drifted file, sorted by path. Empty when `clean`. */
+  readonly files: readonly PluginFileDiff[];
+}
+
+/**
+ * The installed copy carries no resolvable commit, so there is no immutable
+ * baseline to re-materialize and diff against.
+ */
+export class PluginDiffUnavailableError extends Error {
+  constructor(
+    readonly pluginName: string,
+    reason: string,
+  ) {
+    super(`Plugin "${pluginName}" cannot be diffed: ${reason}.`);
+    this.name = "PluginDiffUnavailableError";
+  }
+}
+
+/** Options that control which plugin to diff. */
+export interface DiffPluginOptions {
+  /** Install name (kebab-case directory name). */
+  readonly name: string;
+}
+
+/** Dependencies injected by the caller. */
+export interface DiffPluginDeps {
+  /** HTTP client used to fetch any curated adapter stub. Production callers pass `globalThis.fetch.bind(globalThis)`. */
+  readonly fetch: FetchLike;
+  /** Override the workspace plugins directory. Falls back to the live workspace. */
+  readonly workspacePluginsDir?: string;
+  /** Override the git runner used to clone the baseline. Forwarded to {@link materializePluginTree}. */
+  readonly runGit?: GitRunner;
+  /** Override the postinstall adapter runner. Forwarded to {@link materializePluginTree}. */
+  readonly runPostinstall?: PostinstallRunner;
+}
+
+/** A NUL byte in the leading bytes is the heuristic git uses to flag a blob as binary. */
+function isBinary(buf: Buffer): boolean {
+  const len = Math.min(buf.length, 8000);
+  for (let i = 0; i < len; i++) {
+    if (buf[i] === 0) return true;
+  }
+  return false;
+}
+
+interface FileContent {
+  readonly text: string;
+  readonly binary: boolean;
+}
+
+function readContent(absPath: string): FileContent {
+  const buf = readFileSync(absPath);
+  const binary = isBinary(buf);
+  return { text: binary ? "" : buf.toString("utf8"), binary };
+}
+
+function makeDiff(
+  path: string,
+  status: PluginFileDiffStatus,
+  before: FileContent | null,
+  after: FileContent | null,
+  reconstructed: boolean,
+): PluginFileDiff {
+  if (!reconstructed) {
+    return {
+      path,
+      status,
+      diff: `Baseline unavailable (${status}): the install-time content of this file could not be reconstructed — the curated adapter overlay it was built from has changed since install. Reinstall with 'plugins install <name> --force' to refresh the baseline.`,
+      binary: false,
+      reconstructed: false,
+    };
+  }
+  const binary = (before?.binary ?? false) || (after?.binary ?? false);
+  if (binary) {
+    return {
+      path,
+      status,
+      diff: `Binary files differ (${status})`,
+      binary: true,
+      reconstructed: true,
+    };
+  }
+  // `/dev/null` on the absent side and `a/`–`b/` prefixes mirror `git diff`, so
+  // the output is familiar and consumable by tools that parse unified diffs.
+  const oldName = status === "added" ? "/dev/null" : `a/${path}`;
+  const newName = status === "removed" ? "/dev/null" : `b/${path}`;
+  const diff = createTwoFilesPatch(
+    oldName,
+    newName,
+    before?.text ?? "",
+    after?.text ?? "",
+    undefined,
+    undefined,
+    { context: 3 },
+  );
+  return { path, status, diff, binary: false, reconstructed: true };
+}
+
+/**
+ * Recover the install-time bytes of `path` from the re-materialized baseline
+ * tree, but only when they faithfully match what install produced: the
+ * re-materialized digest must equal the digest `recorded` at install. A
+ * mismatch (or a file the re-materialization did not produce) means the
+ * install-time content cannot be reconstructed — typically because the curated
+ * adapter overlay the file was built from changed since install — so `null` is
+ * returned and the caller flags the file instead of diffing fabricated bytes.
+ */
+function baselineContent(
+  path: string,
+  baselineRoot: string,
+  recorded: Fingerprint,
+  materialized: Fingerprint,
+): FileContent | null {
+  if (materialized.files[path] !== recorded.files[path]) return null;
+  return readContent(join(baselineRoot, path));
+}
+
+/**
+ * Build a per-file unified diff for the on-disk install, classifying drift
+ * against the fingerprint `recorded` at install — the same baseline `inspect`
+ * uses, so the two surfaces always agree on which files changed and an adapter
+ * overlay that moved since install never reads as drift. The re-materialized
+ * tree supplies the baseline *bytes* for the diff, verified per file against
+ * `recorded`. The provenance sidecar is excluded on both sides — it never
+ * exists in the baseline and must not read as a local addition.
+ */
+function buildFileDiffs(
+  baselineRoot: string,
+  target: string,
+  recorded: Fingerprint,
+): PluginFileDiff[] {
+  const comparison = compareFingerprint(target, recorded, [
+    INSTALL_META_FILENAME,
+  ]);
+  const materialized = computeFingerprint(baselineRoot, [
+    INSTALL_META_FILENAME,
+  ]);
+
+  const files: PluginFileDiff[] = [];
+  for (const path of comparison.modified) {
+    const before = baselineContent(path, baselineRoot, recorded, materialized);
+    files.push(
+      makeDiff(
+        path,
+        "modified",
+        before,
+        readContent(join(target, path)),
+        before !== null,
+      ),
+    );
+  }
+  for (const path of comparison.added) {
+    files.push(
+      makeDiff(path, "added", null, readContent(join(target, path)), true),
+    );
+  }
+  for (const path of comparison.removed) {
+    const before = baselineContent(path, baselineRoot, recorded, materialized);
+    files.push(makeDiff(path, "removed", before, null, before !== null));
+  }
+  files.sort((a, b) => a.path.localeCompare(b.path));
+  return files;
+}
+
+/**
+ * Resolve the unified diff of an installed plugin against its install-time
+ * baseline.
+ *
+ * Throws {@link PluginNotInstalledError} when no copy is installed,
+ * {@link PluginDiffUnavailableError} when the install recorded no commit to
+ * re-materialize, {@link PluginNotFoundError} when the recorded commit can no
+ * longer be fetched (e.g. the source repo or commit was removed), and
+ * propagates {@link materializePluginTree}'s errors (e.g. source unavailable)
+ * when the baseline clone itself fails.
+ */
+export async function diffPlugin(
+  opts: DiffPluginOptions,
+  deps: DiffPluginDeps,
+): Promise<PluginDiffResult> {
+  const name = sanitizePluginName(opts.name);
+  const dir = deps.workspacePluginsDir ?? getWorkspacePluginsDir();
+  const target = join(dir, name);
+
+  if (!readInstalledPlugin(name, { workspacePluginsDir: dir })) {
+    throw new PluginNotInstalledError(name, target);
+  }
+
+  const meta = readInstallMeta(target);
+  const commit = meta?.commit ?? null;
+  if (!meta || !commit) {
+    throw new PluginDiffUnavailableError(
+      name,
+      `no install commit was recorded (an older or manually-copied install); reinstall with 'assistant plugins install ${name} --force' to record provenance`,
+    );
+  }
+  // Drift is classified against the install-time fingerprint (as `inspect`
+  // does), so without it there is no trustworthy baseline to diff against.
+  const recorded = meta.fingerprint;
+  if (!recorded) {
+    throw new PluginDiffUnavailableError(
+      name,
+      `no install-time fingerprint was recorded (an older or manually-copied install); reinstall with 'assistant plugins install ${name} --force' to record provenance`,
+    );
+  }
+
+  const source: PluginFetchSource = {
+    owner: meta.source.owner,
+    repo: meta.source.repo,
+    rootPath: meta.source.path ?? "",
+    ref: commit,
+  };
+
+  const baselineRoot = mkdtempSync(join(tmpdir(), `plugin-diff-${name}-`));
+  try {
+    const materialized = await materializePluginTree(
+      { source, name, stubRef: DEFAULT_PLUGIN_REF, destDir: baselineRoot },
+      {
+        fetch: deps.fetch,
+        runGit: deps.runGit,
+        runPostinstall: deps.runPostinstall,
+      },
+    );
+    if (materialized.fileCount === 0) {
+      throw new PluginNotFoundError(
+        name,
+        commit,
+        `${source.owner}/${source.repo}`,
+      );
+    }
+
+    const files = buildFileDiffs(baselineRoot, target, recorded);
+    return {
+      name,
+      target,
+      commit,
+      committedAt: meta.committedAt ?? materialized.committedAt ?? null,
+      clean: files.length === 0,
+      files,
+    };
+  } finally {
+    rmSync(baselineRoot, { recursive: true, force: true });
+  }
+}

--- a/assistant/src/cli/lib/install-from-github.ts
+++ b/assistant/src/cli/lib/install-from-github.ts
@@ -221,7 +221,7 @@ function isTransientUpstreamStatus(res: Response): boolean {
 }
 
 /** Resolved GitHub coordinates a plugin name is fetched from. */
-interface PluginFetchSource {
+export interface PluginFetchSource {
   readonly owner: string;
   readonly repo: string;
   /** Repo-relative directory holding the plugin root; `""` = repo root. */
@@ -376,22 +376,13 @@ export async function installPlugin(
   let commit: string | null = null;
   let committedAt: string | null = null;
   try {
-    const cloned = await copyExternalViaGit(
-      source,
-      stagingDir,
-      deps.runGit ?? defaultGitRunner,
+    const materialized = await materializePluginTree(
+      { source, name, stubRef: marketplaceRef, destDir: stagingDir },
+      deps,
     );
-    fileCount = cloned.fileCount;
-    commit = cloned.commit;
-    committedAt = cloned.committedAt;
-    // An external clone is often a foreign-ecosystem plugin (e.g. a Claude
-    // Code plugin) that the Vellum loader can't run as-is. When we curate an
-    // adapter stub for it, overlay the stub and run its transform so the
-    // materialized tree is a valid Vellum plugin. Raw clones (no stub) are
-    // left untouched.
-    if (fileCount > 0) {
-      await applyAdapterStub(name, marketplaceRef, stagingDir, deps);
-    }
+    fileCount = materialized.fileCount;
+    commit = materialized.commit;
+    committedAt = materialized.committedAt;
   } catch (err) {
     rmSync(stagingDir, { recursive: true, force: true });
     throw err;
@@ -521,6 +512,56 @@ export interface InstallMeta {
    * then report local-modification state as unknown rather than clean.
    */
   readonly fingerprint: Fingerprint | null;
+}
+
+/** Outcome of materializing an external plugin tree into a directory. */
+export interface MaterializedTree {
+  /** Number of regular files written into the destination. */
+  readonly fileCount: number;
+  /** Commit SHA the source was cloned at; `null` when it could not be read. */
+  readonly commit: string | null;
+  /** ISO-8601 committer timestamp of {@link MaterializedTree.commit}; `null` when unread. */
+  readonly committedAt: string | null;
+}
+
+/**
+ * Produce the exact plugin tree an install stages, into `destDir`: clone the
+ * source at `source.ref`, then overlay the curated adapter stub (when one
+ * exists) so a foreign-ecosystem clone is translated into Vellum shape.
+ *
+ * `installPlugin` calls this and then fingerprints, records provenance, and
+ * swaps the result into the workspace. `diffPlugin` (see {@link ./diff-plugin})
+ * calls it with the *recorded install commit* to reconstruct the install-time
+ * baseline. Routing both through one path guarantees a re-materialized commit
+ * is byte-identical to what the original install produced, so an install-time
+ * adapter transform never reads as local drift when diffing.
+ */
+export async function materializePluginTree(
+  opts: {
+    /** Source coordinates; `source.ref` selects the commit to clone. */
+    readonly source: PluginFetchSource;
+    /** Install name, used to locate the curated adapter stub. */
+    readonly name: string;
+    /** Ref the curated adapter stub is fetched at (the canonical repo ref). */
+    readonly stubRef: string;
+    /** Directory the tree is written into. */
+    readonly destDir: string;
+  },
+  deps: InstallPluginDeps,
+): Promise<MaterializedTree> {
+  const cloned = await copyExternalViaGit(
+    opts.source,
+    opts.destDir,
+    deps.runGit ?? defaultGitRunner,
+  );
+  // An external clone is often a foreign-ecosystem plugin (e.g. a Claude Code
+  // plugin) that the Vellum loader can't run as-is. When we curate an adapter
+  // stub for it, overlay the stub and run its transform so the materialized
+  // tree is a valid Vellum plugin. Raw clones (no stub) are left untouched.
+  if (cloned.fileCount > 0) {
+    await applyAdapterStub(opts.name, opts.stubRef, opts.destDir, deps);
+  }
+  return cloned;
 }
 
 /**

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -54,6 +54,10 @@ import memoryRetrievalPkg from "./memory-retrieval/package.json" with { type: "j
 import memoryV3PostCompact from "./memory-v3-shadow/hooks/post-compact.js";
 import memoryV3UserPromptSubmit from "./memory-v3-shadow/hooks/user-prompt-submit.js";
 import memoryV3Pkg from "./memory-v3-shadow/package.json" with { type: "json" };
+import surfaceCompletionNudgePostModelCall from "./surface-completion-nudge/hooks/post-model-call.js";
+import surfaceCompletionNudgeStop from "./surface-completion-nudge/hooks/stop.js";
+import { resetSurfaceCompletionNudgeStoreForTests } from "./surface-completion-nudge/nudge-state-store.js";
+import surfaceCompletionNudgePkg from "./surface-completion-nudge/package.json" with { type: "json" };
 import taskProgressNudgePostToolUse, {
   resetTaskProgressNudgeStateForTests,
 } from "./task-progress-nudge/hooks/post-tool-use.js";
@@ -260,6 +264,25 @@ export const defaultTaskProgressNudgePlugin: Plugin = {
 };
 
 /**
+ * `surface-completion-nudge` — a `post-model-call` hook that, when a user-facing
+ * turn is about to end with a progress surface (a `task_progress` card or
+ * `work_result`) the model showed but never advanced to a terminal status or
+ * dismissed, nudges the model once to close it and re-queries so it can act; the
+ * `stop` hook clears the one-shot bound on a terminal stop so the next run
+ * nudges afresh.
+ */
+export const defaultSurfaceCompletionNudgePlugin: Plugin = {
+  manifest: {
+    name: surfaceCompletionNudgePkg.name,
+    version: surfaceCompletionNudgePkg.version,
+  },
+  hooks: {
+    "post-model-call": surfaceCompletionNudgePostModelCall,
+    stop: surfaceCompletionNudgeStop,
+  },
+};
+
+/**
  * `tool-result-truncate` — a `post-tool-use` hook that tail-drops an oversized
  * tool result down to a character budget derived from the model's context
  * window before the result is sent to the provider.
@@ -289,6 +312,7 @@ function getAllDefaultPlugins(): readonly Plugin[] {
     defaultToolErrorPlugin,
     defaultExplorationDriftPlugin,
     defaultTaskProgressNudgePlugin,
+    defaultSurfaceCompletionNudgePlugin,
     defaultHistoryRepairPlugin,
     defaultImageRecoveryPlugin,
     defaultCompactionPlugin,
@@ -339,5 +363,6 @@ export function resetPluginRegistryAndRegisterDefaults(): void {
   resetImageRecoveryStoreForTests();
   resetExplorationDriftStateForTests();
   resetTaskProgressNudgeStateForTests();
+  resetSurfaceCompletionNudgeStoreForTests();
   registerDefaultPlugins();
 }

--- a/assistant/src/plugins/defaults/surface-completion-nudge/hooks/post-model-call.ts
+++ b/assistant/src/plugins/defaults/surface-completion-nudge/hooks/post-model-call.ts
@@ -1,0 +1,272 @@
+/**
+ * Default `post-model-call` hook: when a user-facing turn is about to end with a
+ * progress surface the model showed but never closed, nudge the model — once
+ * per run — to complete or dismiss it, then re-query so it can act.
+ *
+ * Motivation: the model can call `ui_show` with a `task_progress` card (or a
+ * `work_result` in an `in_progress` state) to show live progress, but weaker
+ * models often never advance it to a terminal status or `ui_dismiss` it. The
+ * surface then renders a spinner forever, long after the work finished. Static
+ * prompt guidance is easy to ignore; a reminder injected at the moment the turn
+ * would otherwise end — with a concrete "you left this open" signal — is far
+ * more salient.
+ *
+ * The nudge is strictly best-effort and self-targeting:
+ * - It fires at most once per run (no looping if the model declines).
+ * - It is advisory — the model may leave the surface open if the work it
+ *   represents is genuinely still running.
+ * - A model that already completed or dismissed its surfaces is never nudged,
+ *   so capable models that close their surfaces pay nothing.
+ *
+ * Only a finalized, no-tool, main-agent reply is actionable:
+ * - A provider rejection carries no turn content to assess (a recovery hook
+ *   like history-repair owns that).
+ * - A tool-bearing turn continues naturally — the loop runs the tools and the
+ *   model gets another chance to close the surface — so we leave it alone.
+ * - Background call sites (wake, title-gen, memory) have no live user watching
+ *   a spinner, so the nudge would only burn a model round.
+ *
+ * No subagent guard is needed: the `ui-surface` tools are gated on a connected
+ * client (see `conversation-tool-setup.ts`), and subagents have none — so a
+ * subagent can never create a surface and so can never trigger this hook.
+ *
+ * The dangling-surface signal is derived from the current response cycle (the
+ * messages after the last genuine user prompt) by correlating each progress
+ * `ui_show` with its `surface_id` result and folding in later `ui_update` /
+ * `ui_dismiss` calls. Deriving the cycle boundary from history content rather
+ * than an index means mid-run compaction (which rewrites the array in place)
+ * can't invalidate it.
+ *
+ * The one-shot bound is split across two hooks: this hook marks the
+ * conversation when it nudges, and the sibling `stop` hook clears the mark when
+ * the turn terminates, so the next run nudges afresh.
+ *
+ * Defaults register before any user plugin, so this hook runs at the front of
+ * the `post-model-call` chain — later hooks see (and may override) its decision.
+ */
+
+import type { PluginHookFn, PostModelCallContext } from "@vellumai/plugin-api";
+
+import type { ContentBlock, Message } from "../../../../providers/types.js";
+import {
+  isSurfaceCompletionNudged,
+  markSurfaceCompletionNudged,
+} from "../nudge-state-store.js";
+
+/**
+ * Canonical nudge text. Shown to the model as provider-only context, never to
+ * the user. Kept verbatim so a plugin that wraps the default sees a stable
+ * string. Deliberately soft: the model may leave the surface open if the work
+ * is genuinely still running.
+ */
+export const SURFACE_COMPLETION_NUDGE_TEXT =
+  '<system_notice>You showed the user a progress surface this turn (a task_progress card or a work_result) and are about to end the turn with it still marked in_progress. If that work is finished, advance it to a terminal state now — call ui_update to set its status to "completed" (or "failed"), or ui_dismiss it — so the user is not left watching a card spin forever. Do this only if the work it represents is actually done; if it is genuinely still running, leave it. Then give your final reply.</system_notice>';
+
+/**
+ * Surface statuses that mean the progress surface has reached a terminal state
+ * and needs no completion nudge. Covers both `task_progress`
+ * (`completed`/`failed`) and `work_result` (`completed`/`partial`/`failed`),
+ * plus `cancelled` for tolerance.
+ */
+const TERMINAL_STATUSES = new Set([
+  "completed",
+  "failed",
+  "partial",
+  "cancelled",
+]);
+
+function hasToolUse(content: ReadonlyArray<ContentBlock>): boolean {
+  return content.some((block) => block.type === "tool_use");
+}
+
+/** A user-role message carrying only tool results, not a fresh prompt. */
+function isToolResultMessage(message: Message): boolean {
+  return (
+    message.role === "user" &&
+    message.content.length > 0 &&
+    message.content.every((block) => block.type === "tool_result")
+  );
+}
+
+/**
+ * Messages belonging to the current response cycle: everything after the last
+ * genuine user prompt. Falls back to the whole history when none is found.
+ */
+function currentCycleMessages(
+  messages: ReadonlyArray<Message>,
+): ReadonlyArray<Message> {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message.role === "user" && !isToolResultMessage(message)) {
+      return messages.slice(i + 1);
+    }
+  }
+  return messages;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+/**
+ * Pull a surface status out of a `ui_show` / `ui_update` input, tolerating the
+ * shapes the server-side normalization accepts: nested under
+ * `data.templateData` (task_progress), under `data` (work_result), or at the
+ * top level. Returns a lowercased status, or `undefined` when none is present.
+ */
+function extractStatus(input: Record<string, unknown>): string | undefined {
+  const data = asRecord(input.data);
+  const templateData =
+    asRecord(data?.templateData) ?? asRecord(input.templateData);
+  const raw = templateData?.status ?? data?.status ?? input.status;
+  return typeof raw === "string" ? raw.trim().toLowerCase() : undefined;
+}
+
+/**
+ * Whether a `ui_show` input describes a surface with a progress lifecycle: a
+ * `task_progress` card or a `work_result`. Returns the initial status when so.
+ */
+function progressShowInfo(input: Record<string, unknown>): {
+  isProgress: boolean;
+  status: string | undefined;
+} {
+  const surfaceType = input.surface_type;
+  if (surfaceType === "work_result") {
+    return { isProgress: true, status: extractStatus(input) };
+  }
+  if (surfaceType === "card") {
+    const data = asRecord(input.data);
+    const template = data?.template ?? input.template;
+    if (template === "task_progress") {
+      return { isProgress: true, status: extractStatus(input) };
+    }
+  }
+  return { isProgress: false, status: undefined };
+}
+
+function surfaceIdOf(input: Record<string, unknown>): string | undefined {
+  return typeof input.surface_id === "string" ? input.surface_id : undefined;
+}
+
+/** Parse the `{ surfaceId }` JSON a successful `ui_show` returns. */
+function parseSurfaceId(content: string): string | undefined {
+  try {
+    const parsed = JSON.parse(content) as unknown;
+    const record = asRecord(parsed);
+    return typeof record?.surfaceId === "string" ? record.surfaceId : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+interface SurfaceState {
+  /** Latest known status, lowercased; `undefined` when never set explicitly. */
+  status: string | undefined;
+  dismissed: boolean;
+}
+
+function isNonTerminal(state: SurfaceState): boolean {
+  if (state.dismissed) return false;
+  return state.status === undefined || !TERMINAL_STATUSES.has(state.status);
+}
+
+/**
+ * True when the current response cycle left at least one progress surface
+ * (a `task_progress` card or `work_result`) open: shown but neither advanced to
+ * a terminal status nor dismissed.
+ *
+ * Each progress `ui_show` is correlated to its `surface_id` via the matching
+ * tool result (the result lands in the next message; updates and dismisses
+ * arrive in later messages, after the model has the id in hand). Later
+ * `ui_update` / `ui_dismiss` calls fold their status / dismissal onto the
+ * tracked surface.
+ */
+function hasDanglingProgressSurface(messages: ReadonlyArray<Message>): boolean {
+  const surfaces = new Map<string, SurfaceState>();
+  // tool_use_id -> initial status of a progress ui_show awaiting its result id.
+  const pendingShows = new Map<string, string | undefined>();
+
+  for (const message of currentCycleMessages(messages)) {
+    if (message.role === "assistant") {
+      for (const block of message.content) {
+        if (block.type !== "tool_use") continue;
+        if (block.name === "ui_show") {
+          const info = progressShowInfo(block.input);
+          if (info.isProgress) pendingShows.set(block.id, info.status);
+        } else if (block.name === "ui_update") {
+          const id = surfaceIdOf(block.input);
+          const status = extractStatus(block.input);
+          if (id && status !== undefined) {
+            const existing = surfaces.get(id);
+            if (existing) existing.status = status;
+            else surfaces.set(id, { status, dismissed: false });
+          }
+        } else if (block.name === "ui_dismiss") {
+          const id = surfaceIdOf(block.input);
+          if (id) {
+            const existing = surfaces.get(id);
+            if (existing) existing.dismissed = true;
+            else surfaces.set(id, { status: undefined, dismissed: true });
+          }
+        }
+      }
+      continue;
+    }
+    if (message.role !== "user") continue;
+    for (const block of message.content) {
+      if (block.type !== "tool_result") continue;
+      if (!pendingShows.has(block.tool_use_id)) continue;
+      const initialStatus = pendingShows.get(block.tool_use_id);
+      pendingShows.delete(block.tool_use_id);
+      const id = parseSurfaceId(block.content);
+      if (!id) continue;
+      const existing = surfaces.get(id);
+      // A later update/dismiss can register the id before its show result is
+      // scanned only if history was reordered; guard so we never clobber a
+      // known terminal/dismissed state with the initial status.
+      if (existing) {
+        if (existing.status === undefined && !existing.dismissed) {
+          existing.status = initialStatus;
+        }
+      } else {
+        surfaces.set(id, { status: initialStatus, dismissed: false });
+      }
+    }
+  }
+
+  for (const state of surfaces.values()) {
+    if (isNonTerminal(state)) return true;
+  }
+  return false;
+}
+
+const postModelCall: PluginHookFn<PostModelCallContext> = async (ctx) => {
+  // A provider rejection carries no turn content to assess (a recovery hook
+  // owns the rejection).
+  if (ctx.error) return;
+  // A tool-bearing turn continues mid-run — the loop runs the tools and the
+  // model gets another chance to close the surface — so leave it alone.
+  if (hasToolUse(ctx.content)) return;
+  // Only nudge the user-facing reply: background call sites have no live user
+  // watching a spinner.
+  if (ctx.callSite !== "mainAgent") return;
+  // One nudge per run; the sibling `stop` hook clears the mark on terminal stop.
+  if (isSurfaceCompletionNudged(ctx.conversationId)) return;
+
+  if (!hasDanglingProgressSurface(ctx.messages)) return;
+
+  markSurfaceCompletionNudged(ctx.conversationId);
+  ctx.messages.push({
+    role: "user",
+    content: [{ type: "text", text: SURFACE_COMPLETION_NUDGE_TEXT }],
+  });
+  ctx.decision = "continue";
+  ctx.logger.info(
+    { plugin: "surface-completion-nudge", conversationId: ctx.conversationId },
+    "Turn ending with an open progress surface — nudging the model to complete or dismiss it",
+  );
+};
+
+export default postModelCall;

--- a/assistant/src/plugins/defaults/surface-completion-nudge/hooks/post-model-call.ts
+++ b/assistant/src/plugins/defaults/surface-completion-nudge/hooks/post-model-call.ts
@@ -216,6 +216,10 @@ function hasDanglingProgressSurface(messages: ReadonlyArray<Message>): boolean {
     }
     if (message.role !== "user") continue;
     for (const block of message.content) {
+      // guard:allow-tool-result-only — only the local tool executor's
+      // `tool_result` carries a `ui_show` `surfaceId` to correlate. A
+      // `web_search_tool_result` comes from a `server_tool_use`, never a
+      // `ui_show`, so it can never match a pending show and is correctly skipped.
       if (block.type !== "tool_result") continue;
       if (!pendingShows.has(block.tool_use_id)) continue;
       const initialStatus = pendingShows.get(block.tool_use_id);

--- a/assistant/src/plugins/defaults/surface-completion-nudge/hooks/stop.ts
+++ b/assistant/src/plugins/defaults/surface-completion-nudge/hooks/stop.ts
@@ -1,0 +1,22 @@
+/**
+ * Default `stop` hook: clears the per-conversation surface-completion nudge
+ * bound when a turn terminates.
+ *
+ * The `post-model-call` hook (see `./post-model-call.ts`) marks the bound when
+ * it nudges the model to close a dangling progress surface. `stop` is the
+ * definitive terminal hook — it fires exactly once when the turn is truly
+ * ending, after every retry decision has been made — so clearing the bound here
+ * unconditionally guarantees the next run nudges afresh, no matter how the turn
+ * ended (a finalized reply, an abort, or a retry the loop's per-run backstop
+ * refused).
+ */
+
+import type { PluginHookFn, StopContext } from "@vellumai/plugin-api";
+
+import { clearSurfaceCompletionNudged } from "../nudge-state-store.js";
+
+const stop: PluginHookFn<StopContext> = async (ctx) => {
+  clearSurfaceCompletionNudged(ctx.conversationId);
+};
+
+export default stop;

--- a/assistant/src/plugins/defaults/surface-completion-nudge/nudge-state-store.ts
+++ b/assistant/src/plugins/defaults/surface-completion-nudge/nudge-state-store.ts
@@ -1,0 +1,46 @@
+/**
+ * Per-conversation surface-completion nudge state.
+ *
+ * The `post-model-call` hook nudges the model — once per run — to complete or
+ * dismiss a progress surface it left `in_progress` when the turn was about to
+ * end, asking the loop to re-query so the model can act on it. That nudge is
+ * bounded to one pass per run: if the model declines or fails to close the
+ * surface, the hook lets the turn end rather than looping on it.
+ *
+ * The two hooks split this state's lifecycle: `post-model-call` marks a
+ * conversation when it issues the nudge, and the sibling `stop` hook clears the
+ * mark when the turn terminates. A conversation therefore only holds an entry
+ * while a nudge is in flight, and the next run nudges afresh.
+ *
+ * This module is side-effect free: importing it only initializes an empty store
+ * and registers no plugin.
+ */
+
+/** Conversations with a surface-completion nudge in flight for the current run. */
+const nudgeInFlight = new Set<string>();
+
+/** Whether the conversation already issued its one nudge this run. */
+export function isSurfaceCompletionNudged(conversationId: string): boolean {
+  return nudgeInFlight.has(conversationId);
+}
+
+/** Record that the conversation issued its one nudge this run. */
+export function markSurfaceCompletionNudged(conversationId: string): void {
+  nudgeInFlight.add(conversationId);
+}
+
+/**
+ * Clear the conversation's nudge mark so the next run nudges afresh. The
+ * sibling `stop` hook calls this when the turn terminates.
+ */
+export function clearSurfaceCompletionNudged(conversationId: string): void {
+  nudgeInFlight.delete(conversationId);
+}
+
+/**
+ * Test-only: drop every conversation's nudge state so a suite that drives the
+ * hook directly starts each case from an empty store.
+ */
+export function resetSurfaceCompletionNudgeStoreForTests(): void {
+  nudgeInFlight.clear();
+}

--- a/assistant/src/plugins/defaults/surface-completion-nudge/package.json
+++ b/assistant/src/plugins/defaults/surface-completion-nudge/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "default-surface-completion-nudge",
+  "version": "1.0.0",
+  "description": "First-party default plugin that nudges the model to complete or dismiss a progress surface it left in_progress when the turn ends.",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "engines": {
+    "node": ">=20.12.0"
+  },
+  "peerDependencies": {
+    "@vellumai/plugin-api": "^0.8.0"
+  }
+}

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -35,6 +35,12 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import {
+  type DiffPluginDeps,
+  type DiffPluginOptions,
+  type PluginDiffResult,
+  PluginDiffUnavailableError,
+} from "../../../cli/lib/diff-plugin.js";
+import {
   type InspectPluginDeps,
   type InspectPluginOptions,
   type PluginInspection,
@@ -177,6 +183,23 @@ mock.module("../../../cli/lib/upgrade-plugin.js", () => ({
   upgradePlugin: upgradeSpy,
 }));
 
+// Mock diffPlugin: the lib re-materializes the install commit and computes the
+// per-file unified diff (covered by diff-plugin.test.ts); the route forwards
+// the name and maps the lib's error taxonomy to HTTP status codes.
+const diffSpy = mock(
+  async (
+    _opts: DiffPluginOptions,
+    _deps: DiffPluginDeps,
+  ): Promise<PluginDiffResult> => {
+    throw new Error("diffSpy default impl not configured");
+  },
+);
+
+mock.module("../../../cli/lib/diff-plugin.js", () => ({
+  PluginDiffUnavailableError,
+  diffPlugin: diffSpy,
+}));
+
 import {
   BadRequestError,
   ConflictError,
@@ -200,6 +223,7 @@ const getHandler = findHandler("plugins_get");
 const installHandler = findHandler("plugins_install");
 const inspectHandler = findHandler("plugins_inspect");
 const upgradeHandler = findHandler("plugins_upgrade");
+const diffHandler = findHandler("plugins_diff");
 
 function invoke(args: RouteHandlerArgs = {}): {
   plugins: Array<Record<string, unknown>>;
@@ -1239,6 +1263,136 @@ describe("POST /v1/plugins/:name/upgrade", () => {
     let caught: unknown;
     try {
       await invokeUpgrade({ pathParams: { name: "level-up" } });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(InternalError);
+    expect((caught as Error).message).toContain("ECONNRESET");
+  });
+});
+
+function diffResult(
+  overrides: Partial<PluginDiffResult> = {},
+): PluginDiffResult {
+  return {
+    name: overrides.name ?? "level-up",
+    target: overrides.target ?? "/workspace/.vellum/plugins/level-up",
+    commit: overrides.commit ?? "60a392b0000000000000000000000000000000aa",
+    committedAt: overrides.committedAt ?? "2026-06-01T12:34:56.000Z",
+    clean: overrides.clean ?? false,
+    files: overrides.files ?? [
+      {
+        path: "src/skill.ts",
+        status: "modified",
+        diff: "--- a/src/skill.ts\n+++ b/src/skill.ts\n@@ -1 +1 @@\n-old\n+new\n",
+        binary: false,
+        reconstructed: true,
+      },
+    ],
+  };
+}
+
+async function invokeDiff(
+  args: RouteHandlerArgs = {},
+): Promise<PluginDiffResult> {
+  return (await diffHandler(args)) as PluginDiffResult;
+}
+
+describe("POST /v1/plugins/:name/diff", () => {
+  beforeEach(() => {
+    diffSpy.mockReset();
+  });
+
+  test("forwards the name to diffPlugin and returns the diff verbatim", async () => {
+    // GIVEN diffPlugin reports a single modified file against the install commit
+    const view = diffResult();
+    diffSpy.mockImplementation(async () => view);
+
+    // WHEN the route handler is invoked with the path name
+    const result = await invokeDiff({ pathParams: { name: "level-up" } });
+
+    // THEN the diff is returned unchanged
+    expect(result).toEqual(view);
+    // AND only the name is forwarded to the lib (ref is never caller-supplied)
+    expect(diffSpy.mock.calls[0]?.[0]).toEqual({ name: "level-up" });
+  });
+
+  test("InvalidPluginNameError → BadRequestError (400)", async () => {
+    diffSpy.mockImplementation(async () => {
+      throw new InvalidPluginNameError("../escape");
+    });
+
+    await expect(
+      invokeDiff({ pathParams: { name: "../escape" } }),
+    ).rejects.toBeInstanceOf(BadRequestError);
+  });
+
+  test("PluginNotInstalledError → NotFoundError (404)", async () => {
+    diffSpy.mockImplementation(async () => {
+      throw new PluginNotInstalledError(
+        "ghost",
+        "/workspace/.vellum/plugins/ghost",
+      );
+    });
+
+    await expect(
+      invokeDiff({ pathParams: { name: "ghost" } }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  test("PluginNotFoundError → NotFoundError (404)", async () => {
+    // The recorded commit no longer resolves to a tree (source/commit gone).
+    diffSpy.mockImplementation(async () => {
+      throw new PluginNotFoundError(
+        "level-up",
+        "deadbeef",
+        "vellum-ai/level-up",
+      );
+    });
+
+    await expect(
+      invokeDiff({ pathParams: { name: "level-up" } }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  test("PluginDiffUnavailableError → ConflictError (409)", async () => {
+    // The install recorded no commit, so there is no baseline to diff against:
+    // a well-formed request that is not actionable in the current state.
+    diffSpy.mockImplementation(async () => {
+      throw new PluginDiffUnavailableError(
+        "level-up",
+        "no install commit was recorded",
+      );
+    });
+
+    await expect(
+      invokeDiff({ pathParams: { name: "level-up" } }),
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+
+  test("PluginSourceUnavailableError → ServiceUnavailableError (503)", async () => {
+    // Re-materializing the baseline can hit a rate-limited/down GitHub; that is
+    // retryable, so surface 503 rather than a misleading 500.
+    diffSpy.mockImplementation(async () => {
+      throw new PluginSourceUnavailableError(
+        "git clone failed for vellum-ai/level-up: HTTP 403",
+        503,
+      );
+    });
+
+    await expect(
+      invokeDiff({ pathParams: { name: "level-up" } }),
+    ).rejects.toBeInstanceOf(ServiceUnavailableError);
+  });
+
+  test("unknown errors → InternalError with original message preserved", async () => {
+    diffSpy.mockImplementation(async () => {
+      throw new Error("ECONNRESET");
+    });
+
+    let caught: unknown;
+    try {
+      await invokeDiff({ pathParams: { name: "level-up" } });
     } catch (err) {
       caught = err;
     }

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -26,6 +26,10 @@
 import { z } from "zod";
 
 import {
+  diffPlugin,
+  PluginDiffUnavailableError,
+} from "../../cli/lib/diff-plugin.js";
+import {
   inspectPlugin,
   PluginInspectNotFoundError,
 } from "../../cli/lib/inspect-plugin.js";
@@ -459,6 +463,62 @@ const pluginUpgradeResponseSchema = z.object({
     ),
 });
 
+const pluginFileDiffSchema = z
+  .object({
+    path: z.string().describe("POSIX-relative path within the plugin root."),
+    status: z
+      .enum(["modified", "added", "removed"])
+      .describe(
+        "Whether the file was edited, newly added, or deleted since install.",
+      ),
+    diff: z
+      .string()
+      .describe(
+        "Unified diff (`--- a/… / +++ b/…`) of the file. A short `Binary files differ` marker for binary files, or a `Baseline unavailable` marker when `reconstructed` is false.",
+      ),
+    binary: z
+      .boolean()
+      .describe(
+        "True when either side was detected as binary (NUL byte present).",
+      ),
+    reconstructed: z
+      .boolean()
+      .describe(
+        "True when the install-time baseline for this file was faithfully recovered (re-materialized bytes hash-match the install fingerprint). False when it could not be reconstructed (e.g. the curated adapter overlay changed since install), in which case `diff` is a marker, not a patch. Always true for added files.",
+      ),
+  })
+  .describe("Unified diff of a single drifted file.");
+
+const pluginDiffResponseSchema = z.object({
+  name: z
+    .string()
+    .describe("Install name. Matches `assistant plugins install <name>`."),
+  target: z
+    .string()
+    .describe("Absolute path to the installed plugin directory on the host."),
+  commit: z
+    .string()
+    .describe(
+      "Commit the baseline was re-materialized from (the recorded install SHA).",
+    ),
+  committedAt: z
+    .string()
+    .nullable()
+    .describe(
+      "ISO-8601 committer timestamp (UTC) of `commit`; null when not recorded.",
+    ),
+  clean: z
+    .boolean()
+    .describe(
+      "True when the on-disk tree exactly matches the re-materialized baseline.",
+    ),
+  files: z
+    .array(pluginFileDiffSchema)
+    .describe(
+      "One entry per drifted file, sorted by path. Empty when `clean`.",
+    ),
+});
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -741,6 +801,45 @@ async function handleInspectPlugin({ pathParams = {} }: RouteHandlerArgs) {
 }
 
 // ---------------------------------------------------------------------------
+// Handler — diff
+// ---------------------------------------------------------------------------
+
+async function handleDiffPlugin({ pathParams = {} }: RouteHandlerArgs) {
+  const rawName = pathParams.name ?? "";
+
+  try {
+    return await diffPlugin(
+      { name: rawName },
+      { fetch: globalThis.fetch.bind(globalThis) },
+    );
+  } catch (err) {
+    if (err instanceof InvalidPluginNameError) {
+      throw new BadRequestError(err.message);
+    }
+    if (
+      err instanceof PluginNotInstalledError ||
+      err instanceof PluginNotFoundError
+    ) {
+      throw new NotFoundError(err.message);
+    }
+    // The install exists but recorded no commit to re-materialize a baseline
+    // from — a permanent state the caller cannot resolve by retrying. 409
+    // marks the request as well-formed but not actionable in the current state.
+    if (err instanceof PluginDiffUnavailableError) {
+      throw new ConflictError(err.message);
+    }
+    // A rate-limited or temporarily-down source (the plugin repo) is a
+    // retryable outage, not a conflict — 503.
+    if (err instanceof PluginSourceUnavailableError) {
+      throw new ServiceUnavailableError(err.message);
+    }
+    throw new InternalError(
+      err instanceof Error ? err.message : "plugin diff failed",
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Handler — upgrade
 // ---------------------------------------------------------------------------
 
@@ -991,6 +1090,47 @@ export const ROUTES: RouteDefinition[] = [
       },
     },
     handler: handleInspectPlugin,
+  },
+  {
+    operationId: "plugins_diff",
+    endpoint: "plugins/:name/diff",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Diff a plugin against its install commit",
+    description:
+      "Show a unified diff of local edits to an installed plugin against the exact commit it was installed at (recorded in its `install-meta.json`). Computing the diff re-materializes the baseline through the install pipeline — a network clone plus a temp-dir write — so this is a POST: it is not a safe, cacheable GET even though it leaves persistent state untouched (requires only `settings.read`). Drift is classified against the install-time fingerprint so an adapter overlay that moved since install never reads as a local change. Returns the baseline `commit`, a `clean` flag, and a `files` array of `{ path, status, diff, binary, reconstructed }` for each modified/added/removed file. The baseline is the install commit, not the marketplace pin — comparing against the current pin is `POST /v1/plugins/:name/upgrade` with `dryRun`. A name with no installed copy returns 404; an install that recorded no commit or fingerprint returns 409; an unreachable source returns 503. Mirrors the CLI's `assistant plugins diff <name>`.",
+    tags: ["plugins"],
+    pathParams: [
+      {
+        name: "name",
+        type: "string",
+        description:
+          "Install name. Must match the kebab-case name accepted by `assistant plugins install`.",
+      },
+    ],
+    responseBody: pluginDiffResponseSchema,
+    additionalResponses: {
+      "400": {
+        description:
+          "The plugin name failed sanitization (e.g. contained slashes, dots, or uppercase letters).",
+      },
+      "404": {
+        description:
+          "No copy of the plugin is installed, or its recorded commit resolves to nothing.",
+      },
+      "409": {
+        description:
+          "The install recorded no commit or no fingerprint to re-materialize and verify a baseline from.",
+      },
+      "503": {
+        description:
+          "The plugin source (GitHub) was temporarily unavailable; the diff is retryable.",
+      },
+    },
+    handler: handleDiffPlugin,
   },
   {
     operationId: "plugins_upgrade",

--- a/gateway/src/risk/command-registry.test.ts
+++ b/gateway/src/risk/command-registry.test.ts
@@ -610,6 +610,7 @@ describe("command-registry", () => {
       expect(getAssistantPath("schedules execute").baseRisk).toBe("high");
       expect(getAssistantPath("plugins list").baseRisk).toBe("low");
       expect(getAssistantPath("plugins inspect").baseRisk).toBe("low");
+      expect(getAssistantPath("plugins diff").baseRisk).toBe("low");
       expect(getAssistantPath("plugins install").baseRisk).toBe("high");
       expect(getAssistantPath("plugins upgrade").baseRisk).toBe("high");
       expect(getAssistantPath("plugins uninstall").baseRisk).toBe("medium");

--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -278,6 +278,7 @@ const ASSISTANT_SUPPORTED_COMMAND_PATHS = [
   "email send",
   "email attachment",
   "plugins",
+  "plugins diff",
   "plugins install",
   "plugins inspect",
   "plugins list",


### PR DESCRIPTION
## Why

From a dogfood session: the model showed an inline progress surface (a `task_progress`-style card) and the turn moved on, leaving the card spinning forever. Investigating the feedback logs confirmed the model called `ui_show` to create a progress surface and then never advanced it to a terminal status or `ui_dismiss`-ed it. Weaker models do this routinely; the user asked for a **model-behavior** fix rather than another deterministic, hardcoded coercion.

## What

Adds a `surface-completion-nudge` default plugin (`post-model-call` + `stop`), mirroring the `empty-response` / `task-progress-nudge` pattern:

- When a user-facing turn is about to end — a finalized, no-tool `mainAgent` reply — and the current response cycle left a **progress surface** open (a `task_progress` card or a `work_result` whose latest status is non-terminal and that was not dismissed), the hook appends a soft, provider-only `<system_notice>` and sets `decision = "continue"` so the model gets one round to `ui_update` it to `completed`/`failed` or `ui_dismiss` it.
- The `stop` hook clears the one-shot bound on a terminal stop so the next run nudges afresh.

### Design notes

- **Model-mediated, not deterministic.** The hook only *detects* the open surface and *asks*; the model decides whether the work is actually done (the notice says to leave it if genuinely still running). This is the `#2` approach — no hardcoded turn-end coercion of surface state.
- **Behavior-gated, so capable models pay nothing.** It fires only when a surface is *actually* left open; a model that already closes its surfaces never triggers it.
- **Self-limiting.** At most one nudge per run; a model that declines doesn't get re-nudged.
- **No subagent guard needed.** `ui-surface` tools are gated on a connected client (`conversation-tool-setup.ts`); subagents have none, so they can never create a surface to leave dangling.
- The dangling-surface signal is derived from the current response cycle by correlating each progress `ui_show` to its `surface_id` result and folding in later `ui_update` / `ui_dismiss` calls, so mid-run compaction can't invalidate it.

## Relation to prior fixes

Complements the two surface fixes already on `main`: #34993 (converge `task_progress` persisted state on passive dismiss) and #34994 (reject empty cards). Those address the *empty card* and *header/step mismatch* cases; this addresses the broader complaint — a populated progress surface left `in_progress` when the turn ends.

## Testing

`assistant/src/__tests__/surface-completion-nudge-hook.test.ts` — 13 tests: nudges on a dangling `task_progress`/`work_result`; stays quiet when completed/dismissed/not-a-progress-surface; ignores rejections, tool-bearing turns, and background call sites; cycle scoping; one-shot bound + `stop` clears it. Typecheck and lint clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)