### PR TITLE
feat(web): ship personal-page sign-up screen to all users

### DIFF
--- a/apps/web/src/domains/account/account-layout.tsx
+++ b/apps/web/src/domains/account/account-layout.tsx
@@ -19,9 +19,9 @@ import { useOnboardingWindowSize } from "@/hooks/use-onboarding-window-size";
 export function AccountLayout() {
   useOnboardingWindowSize();
   // The account screens render before authentication, outside RootLayout (which
-  // owns the post-auth flag sync). Sync client flags here too so flag-gated
-  // sign-up (experiment-activation-flow-2026-06-03 → personal-page) can be
-  // served to anonymous visitors. Failures degrade to registry defaults.
+  // owns the post-auth flag sync). Sync client flags here too so any flag-gated
+  // pre-auth UI is served to anonymous visitors. Failures degrade to registry
+  // defaults.
   useClientFeatureFlagSync(true);
   return <Outlet />;
 }

--- a/apps/web/src/domains/account/components/personal-page-shell.tsx
+++ b/apps/web/src/domains/account/components/personal-page-shell.tsx
@@ -6,10 +6,10 @@ import { publicAsset } from "@/utils/public-asset";
 import "@/domains/account/components/personal-page-signup.css";
 
 /**
- * Two-column activation-flow shell ported from the cast prototype: brand + form
- * on the left, a full-bleed looping product video on the right (hidden under
- * 768px). Used by both the sign-up screen and the post-OAuth name/occupation
- * step so the experience stays visually consistent across the flow.
+ * Two-column sign-up shell: brand + form on the left, a full-bleed looping
+ * product video on the right (hidden under 768px). Used by both the sign-up
+ * screen and the post-OAuth name/occupation step so the experience stays
+ * visually consistent across the flow.
  */
 export function PersonalPageShell({ children }: { children: ReactNode }) {
   return (
@@ -19,13 +19,13 @@ export function PersonalPageShell({ children }: { children: ReactNode }) {
     // read correctly even when the app is in light mode.
     <motion.div
       data-theme="dark"
-      className="cast-login"
+      className="signup"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.5 }}
     >
-      <div className="cast-login__left">
-        <div className="cast-login__logo">
+      <div className="signup__left">
+        <div className="signup__logo">
           <img
             src={publicAsset("/vellum-logo-white.svg")}
             alt="Vellum"
@@ -33,18 +33,18 @@ export function PersonalPageShell({ children }: { children: ReactNode }) {
             height={25}
           />
         </div>
-        <div className="cast-login__form">{children}</div>
+        <div className="signup__form">{children}</div>
       </div>
 
       <motion.div
-        className="cast-login__right"
+        className="signup__right"
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ duration: 0.6, delay: 0.15 }}
         aria-hidden
       >
         <video
-          className="cast-login__video"
+          className="signup__video"
           src={publicAsset("/vellum-scene-cut.mp4")}
           autoPlay
           loop

--- a/apps/web/src/domains/account/components/personal-page-signup-screen.tsx
+++ b/apps/web/src/domains/account/components/personal-page-signup-screen.tsx
@@ -56,11 +56,10 @@ interface PersonalPageSignupScreenProps {
 }
 
 /**
- * Personal-page activation sign-up screen, matching the cast prototype demo: a
- * brand-left / full-bleed-video-right layout with a rotating headline and
- * Google / Apple / Email buttons. Unlike the prototype's mock buttons, each
- * hands off to the real WorkOS `startAuthFlow` (`intent: "signup"`); the
- * post-OAuth name/occupation step lives in `ProviderSignupPage`.
+ * Branded sign-up screen: a brand-left / full-bleed-video-right layout with a
+ * rotating headline and Google / Apple / Email buttons. Each button hands off
+ * to the real WorkOS `startAuthFlow` (`intent: "signup"`); the post-OAuth
+ * name/occupation step lives in `ProviderSignupPage`.
  */
 export function PersonalPageSignupScreen({
   returnTo,
@@ -94,41 +93,41 @@ export function PersonalPageSignupScreen({
 
   return (
     <PersonalPageShell>
-      <h1 className="cast-login__title">
+      <h1 className="signup__title">
         Meet your own
         <br />
         <RotatingWord words={HEADLINE_WORDS} />
       </h1>
-      <p className="cast-login__subtitle">
+      <p className="signup__subtitle">
         The most powerful assistant that can handle your work and life admin
         tasks.
       </p>
 
-      <div className="cast-login__buttons">
+      <div className="signup__buttons">
         {BUTTONS.map((btn, i) => (
           <button
             key={btn.label}
             type="button"
-            className="cast-login__btn"
+            className="signup__btn"
             onClick={() => start(btn.providerHint)}
           >
-            {i === 0 && <span className="cast-login__tag">Most used</span>}
+            {i === 0 && <span className="signup__tag">Most used</span>}
             {btn.icon}
             {btn.label}
           </button>
         ))}
       </div>
 
-      {error && <p className="cast-login__error">{error}</p>}
+      {error && <p className="signup__error">{error}</p>}
 
-      <p className="cast-login__footer">
+      <p className="signup__footer">
         Already have an account?{" "}
-        <Link to={routes.account.login} className="cast-login__link">
+        <Link to={routes.account.login} className="signup__link">
           Sign in
         </Link>
       </p>
 
-      <a className="cast-login__download" href="/downloads">
+      <a className="signup__download" href="/downloads">
         <AppleLogo size={16} />
         Download for macOS
       </a>

--- a/apps/web/src/domains/account/components/personal-page-signup-screen.tsx
+++ b/apps/web/src/domains/account/components/personal-page-signup-screen.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from "react";
+import { type ReactNode, useState } from "react";
 import { Link } from "react-router";
 
 import { AppleLogo } from "@/components/icons/apple-logo";
@@ -9,7 +9,8 @@ import {
   PROVIDER_ID,
   buildProviderCallbackUrl,
 } from "@/domains/account/login-flow";
-import { startAuthFlow } from "@/runtime/native-auth";
+import { isElectron } from "@/runtime/is-electron";
+import { isNativePlatform, startAuthFlow } from "@/runtime/native-auth";
 import { routes } from "@/utils/routes";
 
 const HEADLINE_WORDS = [
@@ -52,8 +53,6 @@ const BUTTONS: ProviderButton[] = [
 
 interface PersonalPageSignupScreenProps {
   returnTo: string | null;
-  /** Surfaces an auth-flow failure to the host page. */
-  onError?: (message: string) => void;
 }
 
 /**
@@ -61,31 +60,35 @@ interface PersonalPageSignupScreenProps {
  * brand-left / full-bleed-video-right layout with a rotating headline and
  * Google / Apple / Email buttons. Unlike the prototype's mock buttons, each
  * hands off to the real WorkOS `startAuthFlow` (`intent: "signup"`); the
- * post-OAuth name/occupation step lives in `ProviderSignupPage` (same flag).
+ * post-OAuth name/occupation step lives in `ProviderSignupPage`.
  */
 export function PersonalPageSignupScreen({
   returnTo,
-  onError,
 }: PersonalPageSignupScreenProps) {
+  const [error, setError] = useState<string | null>(null);
   const callbackUrl = buildProviderCallbackUrl(returnTo, {
     authIntent: "signup",
   });
 
   const start = (providerHint?: string) => {
-    // A direct provider hint (Apple/Google) goes straight to the social
-    // connection — match the proven /account/login wiring and do NOT also send
-    // the signup `intent` (WorkOS rejects a sign-up screen_hint combined with a
-    // direct provider redirect → error.workos.com/sso). Email (no hint) keeps
-    // `intent: "signup"` so AuthKit shows its hosted sign-up screen. Either way
-    // the post-OAuth routing to the name/occupation step is driven by
-    // `authIntent=signup` in `callbackUrl`, and a first-time social login still
-    // triggers the provider-signup flow.
+    setError(null);
+    // On WEB, a direct provider hint (Apple/Google) goes straight to the social
+    // connection and must NOT also send the signup `intent` — WorkOS hosted
+    // AuthKit rejects a sign-up screen_hint combined with a direct provider
+    // redirect (error.workos.com/sso); post-OAuth signup routing is driven by
+    // `authIntent=signup` in `callbackUrl` instead. Native (Capacitor) and
+    // Electron, however, pick the signup destination from `options.intent`, not
+    // the callback URL, so they must send `intent` even alongside a provider
+    // hint or the user lands in the login destination. Email (no hint) always
+    // sends `intent` so AuthKit shows its hosted sign-up screen.
+    const omitIntent = !!providerHint && !isNativePlatform() && !isElectron();
     startAuthFlow(PROVIDER_ID, callbackUrl, {
       returnTo,
-      ...(providerHint ? { providerHint } : { intent: "signup" }),
+      ...(providerHint ? { providerHint } : {}),
+      ...(omitIntent ? {} : { intent: "signup" }),
     }).catch((err) => {
       console.error("[signup] auth flow failed:", err);
-      onError?.("Something went wrong. Please try again.");
+      setError("Something went wrong. Please try again.");
     });
   };
 
@@ -115,6 +118,8 @@ export function PersonalPageSignupScreen({
           </button>
         ))}
       </div>
+
+      {error && <p className="cast-login__error">{error}</p>}
 
       <p className="cast-login__footer">
         Already have an account?{" "}

--- a/apps/web/src/domains/account/components/personal-page-signup.css
+++ b/apps/web/src/domains/account/components/personal-page-signup.css
@@ -135,6 +135,11 @@
   line-height: 1.4;
   pointer-events: none;
 }
+.cast-login__error {
+  margin: 0;
+  font-size: 13px;
+  color: var(--system-negative-strong);
+}
 .cast-login__footer {
   margin: 0;
   font-size: 13px;

--- a/apps/web/src/domains/account/components/personal-page-signup.css
+++ b/apps/web/src/domains/account/components/personal-page-signup.css
@@ -1,16 +1,14 @@
 /**
- * Styling for the personal-page activation sign-up flow, ported from the cast
- * activation prototype (apps/web/src/cast/cast.css @ 18c44510d4) so the screen
- * matches the demo. Scoped to the account domain; class names are unique
- * (no collision with anything on main). All colors come from design tokens
- * except the prototype's brand green (#46c178), kept for fidelity.
+ * Styling for the branded sign-up flow (the sign-up screen + the post-OAuth
+ * name/occupation step). Scoped to the account domain. All colors come from
+ * design tokens except the brand green (#46c178).
  *
- * The root is `position: fixed; inset: 0` (vs the prototype's `absolute`) so it
- * fills the viewport on its own — the account routes have no full-screen
- * positioned ancestor. Collapses to a single column (video hidden) under 768px.
+ * The root is `position: fixed; inset: 0` so it fills the viewport on its own —
+ * the account routes have no full-screen positioned ancestor. Collapses to a
+ * single column (video hidden) under 768px.
  */
 
-.cast-login {
+.signup {
   position: fixed;
   inset: 0;
   z-index: 4;
@@ -20,7 +18,7 @@
 }
 
 /* Left column — logo at top, form centered */
-.cast-login__left {
+.signup__left {
   flex: 0 0 42%;
   min-width: 0;
   display: flex;
@@ -29,13 +27,13 @@
   justify-content: center;
   padding: 40px 48px;
 }
-.cast-login__logo {
+.signup__logo {
   position: absolute;
   top: 40px;
   left: 50%;
   transform: translateX(-50%);
 }
-.cast-login__form {
+.signup__form {
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -46,7 +44,7 @@
   width: 100%;
   gap: 0;
 }
-.cast-login__title {
+.signup__title {
   margin: 0 0 12px;
   font-family: "Instrument Serif", var(--font-serif), serif;
   font-size: clamp(2.1rem, 1rem + 2.8vw, 3.75rem);
@@ -56,39 +54,39 @@
   line-height: 1.15;
   color: var(--content-default);
 }
-.cast-login__rotating {
+.signup__rotating {
   display: inline-block;
   position: relative;
   text-align: center;
   vertical-align: baseline;
   overflow: hidden;
 }
-.cast-login__rotating-sizer {
+.signup__rotating-sizer {
   display: block;
   height: 0;
   visibility: hidden;
   white-space: nowrap;
 }
-.cast-login__title em {
+.signup__title em {
   display: block;
   font-style: normal;
   color: #46c178;
   white-space: nowrap;
 }
-.cast-login__subtitle {
+.signup__subtitle {
   margin: 0 0 32px;
   font-size: 15px;
   line-height: 1.5;
   color: var(--content-secondary);
 }
-.cast-login__buttons {
+.signup__buttons {
   width: 100%;
   display: flex;
   flex-direction: column;
   gap: 10px;
   margin-bottom: 24px;
 }
-.cast-login__btn {
+.signup__btn {
   position: relative;
   width: 100%;
   appearance: none;
@@ -106,21 +104,21 @@
   cursor: pointer;
   transition: background 160ms ease, border-color 160ms ease, transform 160ms ease;
 }
-.cast-login__btn:hover {
+.signup__btn:hover {
   background: var(--surface-active);
   border-color: var(--border-element);
   transform: translateY(-1px);
 }
-.cast-login__btn:active {
+.signup__btn:active {
   transform: translateY(0) scale(0.985);
 }
-.cast-login__btn:disabled {
+.signup__btn:disabled {
   opacity: 0.6;
   cursor: default;
   transform: none;
 }
 /* "Most used" corner badge on the Google button */
-.cast-login__tag {
+.signup__tag {
   position: absolute;
   top: -8px;
   right: -6px;
@@ -135,17 +133,17 @@
   line-height: 1.4;
   pointer-events: none;
 }
-.cast-login__error {
+.signup__error {
   margin: 0;
   font-size: 13px;
   color: var(--system-negative-strong);
 }
-.cast-login__footer {
+.signup__footer {
   margin: 0;
   font-size: 13px;
   color: var(--content-secondary);
 }
-.cast-login__link {
+.signup__link {
   appearance: none;
   border: none;
   background: none;
@@ -158,10 +156,10 @@
   text-underline-offset: 3px;
   transition: color 140ms ease;
 }
-.cast-login__link:hover {
+.signup__link:hover {
   color: var(--primary-base);
 }
-.cast-login__download {
+.signup__download {
   appearance: none;
   background: none;
   display: inline-flex;
@@ -179,13 +177,13 @@
   text-decoration: none;
   transition: background 140ms ease, color 140ms ease;
 }
-.cast-login__download:hover {
+.signup__download:hover {
   background: color-mix(in srgb, var(--content-default) 10%, transparent);
 }
 
 /* ---- About step (post-OAuth name/occupation) ---- */
 
-.cast-about__heading {
+.signup-details__heading {
   margin: 0 0 24px;
   font-family: "Instrument Serif", var(--font-serif), serif;
   font-size: clamp(2.1rem, 1rem + 2.8vw, 3.75rem);
@@ -195,7 +193,7 @@
   color: var(--content-default);
   text-align: center;
 }
-.cast-about__thread {
+.signup-details__thread {
   width: 100%;
   max-width: 480px;
   display: flex;
@@ -206,23 +204,23 @@
   text-align: left;
 }
 /* Keep the heading pinned — don't let growing steps re-center the form */
-.cast-login__form:has(.cast-about__thread) {
+.signup__form:has(.signup-details__thread) {
   justify-content: center;
 }
-.cast-about__step {
+.signup-details__step {
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
-.cast-about__label {
+.signup-details__label {
   font-size: 18px;
   font-weight: 400;
   color: var(--content-secondary);
 }
-.cast-about__req {
+.signup-details__req {
   color: var(--content-tertiary);
 }
-.cast-about__input {
+.signup-details__input {
   width: 100%;
   appearance: none;
   padding: 11px 14px;
@@ -236,23 +234,23 @@
   outline: none;
   transition: border-color 160ms ease, box-shadow 160ms ease, opacity 160ms ease;
 }
-.cast-about__input:focus {
+.signup-details__input:focus {
   border-color: var(--primary-base);
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary-base) 18%, transparent);
 }
-.cast-about__input:disabled {
+.signup-details__input:disabled {
   opacity: 0.6;
 }
-.cast-about__input::placeholder {
+.signup-details__input::placeholder {
   color: var(--content-tertiary);
 }
-.cast-about__error {
+.signup-details__error {
   margin: 0;
   font-size: 13px;
   color: var(--system-negative-strong);
   text-align: left;
 }
-.cast-about__continue {
+.signup-details__continue {
   width: 100%;
   appearance: none;
   border: none;
@@ -266,24 +264,24 @@
   cursor: pointer;
   transition: background 160ms ease, transform 160ms ease;
 }
-.cast-about__continue:hover:not(:disabled) {
+.signup-details__continue:hover:not(:disabled) {
   background: #3ad17a;
   transform: translateY(-1px);
 }
-.cast-about__continue:disabled {
+.signup-details__continue:disabled {
   opacity: 0.4;
   cursor: default;
 }
 
 /* Right column — video */
-.cast-login__right {
+.signup__right {
   flex: 1 1 0;
   min-width: 0;
   position: relative;
   overflow: hidden;
   padding: 40px 40px 40px 0;
 }
-.cast-login__video {
+.signup__video {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -292,17 +290,17 @@
 
 /* Collapse to single-column on narrow viewports */
 @media (max-width: 768px) {
-  .cast-login {
+  .signup {
     flex-direction: column;
   }
-  .cast-login__left {
+  .signup__left {
     flex: 1;
     padding: 32px 28px;
   }
-  .cast-login__logo {
+  .signup__logo {
     align-self: flex-start;
   }
-  .cast-login__right {
+  .signup__right {
     display: none;
   }
 }

--- a/apps/web/src/domains/account/components/rotating-word.tsx
+++ b/apps/web/src/domains/account/components/rotating-word.tsx
@@ -3,9 +3,8 @@ import { useEffect, useMemo, useState } from "react";
 
 /**
  * Cycles `words` in place inside the headline with a vertical cross-fade,
- * rendered as a styled `<em>` (see `.cast-login__title em`). A hidden sizer
- * (longest word) reserves width so the headline doesn't reflow. Ported from
- * the cast prototype's RotatingWord.
+ * rendered as a styled `<em>` (see `.signup__title em`). A hidden sizer
+ * (longest word) reserves width so the headline doesn't reflow.
  */
 export function RotatingWord({ words }: { words: string[] }) {
   const [index, setIndex] = useState(0);
@@ -22,8 +21,8 @@ export function RotatingWord({ words }: { words: string[] }) {
   }, [words.length]);
 
   return (
-    <span className="cast-login__rotating">
-      <span className="cast-login__rotating-sizer" aria-hidden>
+    <span className="signup__rotating">
+      <span className="signup__rotating-sizer" aria-hidden>
         {longest}.
       </span>
       <AnimatePresence mode="wait">

--- a/apps/web/src/domains/account/pages/provider-signup-page.tsx
+++ b/apps/web/src/domains/account/pages/provider-signup-page.tsx
@@ -155,21 +155,21 @@ export function ProviderSignupPage() {
     const canSubmit = occupation.trim().length > 0 && !isSubmitting;
     return (
       <PersonalPageShell>
-        <form onSubmit={onPersonalPageSubmit} className="cast-about__thread">
-          <h2 className="cast-about__heading">
+        <form onSubmit={onPersonalPageSubmit} className="signup-details__thread">
+          <h2 className="signup-details__heading">
             Almost there,
             <br />
             one more detail
           </h2>
 
-          {error && <p className="cast-about__error">{error}</p>}
+          {error && <p className="signup-details__error">{error}</p>}
 
-          <div className="cast-about__step">
-            <span className="cast-about__label">
-              What should I call you? <span className="cast-about__req">*</span>
+          <div className="signup-details__step">
+            <span className="signup-details__label">
+              What should I call you? <span className="signup-details__req">*</span>
             </span>
             <input
-              className="cast-about__input"
+              className="signup-details__input"
               type="text"
               placeholder="First name"
               value={firstName}
@@ -178,12 +178,12 @@ export function ProviderSignupPage() {
             />
           </div>
 
-          <div className="cast-about__step">
-            <span className="cast-about__label">
-              And your last name? <span className="cast-about__req">*</span>
+          <div className="signup-details__step">
+            <span className="signup-details__label">
+              And your last name? <span className="signup-details__req">*</span>
             </span>
             <input
-              className="cast-about__input"
+              className="signup-details__input"
               type="text"
               placeholder="Last name"
               value={lastName}
@@ -192,12 +192,12 @@ export function ProviderSignupPage() {
             />
           </div>
 
-          <div className="cast-about__step">
-            <span className="cast-about__label">
-              Your role <span className="cast-about__req">*</span>
+          <div className="signup-details__step">
+            <span className="signup-details__label">
+              Your role <span className="signup-details__req">*</span>
             </span>
             <input
-              className="cast-about__input"
+              className="signup-details__input"
               type="text"
               autoComplete="organization-title"
               placeholder="e.g. Software Engineer"
@@ -207,10 +207,10 @@ export function ProviderSignupPage() {
             />
           </div>
 
-          <div className="cast-about__step">
+          <div className="signup-details__step">
             <button
               type="submit"
-              className="cast-about__continue"
+              className="signup-details__continue"
               disabled={!canSubmit}
             >
               {isSubmitting ? "Setting up…" : "Continue →"}

--- a/apps/web/src/domains/account/pages/provider-signup-page.tsx
+++ b/apps/web/src/domains/account/pages/provider-signup-page.tsx
@@ -18,21 +18,18 @@ import {
   resolvePostLoginDestination,
 } from "@/domains/account/login-flow";
 import { useAuthStore } from "@/stores/auth-store";
-import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { routes } from "@/utils/routes";
 
 /**
  * Provider signup completion page. Shown when allauth's provider flow needs
  * additional information before creating the account.
  *
- * Default (control / variant-a): collect email + username.
- *
- * When `experiment-activation-flow-2026-06-03` serves `personal-page`: show the
- * OAuth-claim first/last name as read-only and collect an occupation, which is
- * forwarded into the pre-chat onboarding context. The account is still
- * completed via the same `submitProviderSignup` call using the provider-supplied
- * email + username (no username field — matching the standard sign-up, which
- * does not surface one to the user).
+ * Shows the OAuth-claim first/last name as read-only and collects an
+ * occupation. The account is completed via `submitProviderSignup` using the
+ * provider-supplied email + username (no username field — matching the standard
+ * sign-up, which does not surface one to the user). If the provider didn't
+ * supply email + username, it falls back to the editable form so the user can
+ * still complete signup.
  */
 export function ProviderSignupPage() {
   const navigate = useNavigate();
@@ -40,14 +37,9 @@ export function ProviderSignupPage() {
   const refreshSession = useAuthStore.use.refreshSession();
   const returnTo = searchParams.get("returnTo");
 
-  const activationArm =
-    useClientFeatureFlagStore.use.stringFlags().experimentActivationFlow20260603 ??
-    "control";
-  const personalPage = activationArm === "personal-page";
-
   // Provider-supplied identity. email + username are submitted to complete the
-  // account; firstName/lastName are display-only (read-only) in the
-  // personal-page variant. All come from the pending provider-signup context.
+  // account; firstName/lastName are display-only (read-only). All come from the
+  // pending provider-signup context.
   const [email, setEmail] = useState("");
   const [username, setUsername] = useState("");
   const [firstName, setFirstName] = useState("");
@@ -154,12 +146,12 @@ export function ProviderSignupPage() {
     );
   }
 
-  // The personal-page step hides email/username and submits the provider-
-  // supplied values. If the provider didn't supply them (rare — WorkOS social
-  // always returns an email, and allauth suggests a username), fall through to
-  // the editable control form so the user can complete signup rather than hit
-  // an uncorrectable validation error.
-  if (personalPage && email && username) {
+  // The branded step hides email/username and submits the provider-supplied
+  // values. If the provider didn't supply them (rare — WorkOS social always
+  // returns an email, and allauth suggests a username), fall through to the
+  // editable form so the user can complete signup rather than hit an
+  // uncorrectable validation error.
+  if (email && username) {
     const canSubmit = occupation.trim().length > 0 && !isSubmitting;
     return (
       <PersonalPageShell>

--- a/apps/web/src/domains/account/pages/signup-page.tsx
+++ b/apps/web/src/domains/account/pages/signup-page.tsx
@@ -1,76 +1,16 @@
-import { useEffect, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
 
 import { PersonalPageSignupScreen } from "@/domains/account/components/personal-page-signup-screen";
-import {
-  PROVIDER_ID,
-  buildProviderCallbackUrl,
-} from "@/domains/account/login-flow";
-import { useActivationFlowArm } from "@/hooks/use-client-feature-flag-sync";
-import { startAuthFlow } from "@/runtime/native-auth";
 
 /**
- * Signup entry. By default (control / variant-a) it triggers the auth flow with
- * `intent: "signup"` so WorkOS opens the sign-up screen. When the
- * `experiment-activation-flow-2026-06-03` flag serves `personal-page`, it
- * renders the branded video sign-up screen instead (its buttons hand off to the
- * same WorkOS flow on click; the post-OAuth name/occupation step lives in
- * `ProviderSignupPage`, gated by the same flag).
- *
- * The redirect is held until the flag value has `settled` (server fetch
- * resolved/errored) — otherwise a first-time anonymous visitor would be
- * redirected on the registry default (`control`) before their targeted
- * `personal-page` value arrives, and never see the new screen.
- *
- * `startAuthFlow` routes through the native `ASWebAuthenticationSession` path on
- * Capacitor iOS (the signup link on `/account/login` is reachable inside the
- * shell, so this page must not hit the embedded WKWebView OAuth flow that
- * Google blocks).
+ * Signup entry. Renders the branded sign-up screen for everyone: a rotating
+ * headline with Google / Apple / Email buttons. Each button hands off to the
+ * WorkOS auth flow (`intent: "signup"`); the post-OAuth name/occupation step
+ * lives in `ProviderSignupPage`.
  */
 export function SignupPage() {
   const [searchParams] = useSearchParams();
-  const { arm, settled } = useActivationFlowArm();
-  const personalPage = arm === "personal-page";
-
-  const didRedirect = useRef(false);
-  const [error, setError] = useState<string | null>(null);
   const returnTo = searchParams.get("returnTo");
 
-  useEffect(() => {
-    // The personal-page variant renders an interactive screen; it must NOT
-    // auto-redirect — the user picks a provider there.
-    if (personalPage) return;
-    // Wait for the flag to resolve before redirecting, so a targeted anonymous
-    // visitor isn't bounced to WorkOS on the default arm before their value loads.
-    if (!settled) return;
-    if (didRedirect.current) return;
-    didRedirect.current = true;
-
-    const callbackUrl = buildProviderCallbackUrl(returnTo, {
-      authIntent: "signup",
-    });
-
-    startAuthFlow(PROVIDER_ID, callbackUrl, {
-      intent: "signup",
-      returnTo,
-    }).catch((err) => {
-      console.error("[signup] auth flow failed:", err);
-      setError("Something went wrong. Please try again.");
-    });
-  }, [personalPage, settled, returnTo]);
-
-  if (personalPage) {
-    return <PersonalPageSignupScreen returnTo={returnTo} onError={setError} />;
-  }
-
-  if (error) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <p className="text-[var(--system-negative-strong)]">{error}</p>
-      </div>
-    );
-  }
-
-  // Blank while the flag resolves / the control redirect kicks off.
-  return null;
+  return <PersonalPageSignupScreen returnTo={returnTo} />;
 }

--- a/apps/web/src/hooks/use-client-feature-flag-sync.ts
+++ b/apps/web/src/hooks/use-client-feature-flag-sync.ts
@@ -45,7 +45,7 @@ function mapFlags(
 
 export function useClientFeatureFlagSync(enabled: boolean) {
   const freshness = useFlagQueryFreshness();
-  const { data, isFetched } = useQuery({
+  const { data } = useQuery({
     queryKey: CLIENT_FLAG_QUERY_KEY,
     queryFn: fetchClientFlagValues,
     enabled,
@@ -63,53 +63,4 @@ export function useClientFeatureFlagSync(enabled: boolean) {
       }
     }
   }, [data]);
-
-  // Mark the store `loaded` once the query SETTLES — `isFetched` is true on
-  // success AND on terminal error (react-query's `isFetched`, same signal
-  // `useActivationFlowArm` exposes as `settled`). Persisting it into the store
-  // lets the synchronous `buildNavigationState()` know the arm is no longer
-  // unknown, so a failed fetch doesn't hang the route guard forever.
-  useEffect(() => {
-    if (isFetched) {
-      useClientFeatureFlagStore.getState().setLoaded();
-    }
-  }, [isFetched]);
-}
-
-const ACTIVATION_FLOW_STORE_KEY = "experimentActivationFlow20260603";
-const ACTIVATION_FLOW_LS_KEY = `vellum:ff-str:${ACTIVATION_FLOW_STORE_KEY}`;
-
-function readActivationFlowOverride(): string | null {
-  if (typeof window === "undefined") return null;
-  try {
-    return localStorage.getItem(ACTIVATION_FLOW_LS_KEY);
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Resolves the `experiment-activation-flow-2026-06-03` arm for the pre-auth
- * sign-up pages, with `settled` indicating the server fetch has completed.
- *
- * Reads the value DIRECTLY from the flag query data (not the store) so the
- * decision never races the store write: React runs child effects before parent
- * effects, so a consumer's redirect effect would otherwise fire before
- * `AccountLayout`'s sync writes the store, reading a stale default. Precedence:
- * a local `localStorage` override wins (for testing), then the server-synced
- * value, then `control`. Callers should hold off acting until `settled`.
- */
-export function useActivationFlowArm(): { arm: string; settled: boolean } {
-  const freshness = useFlagQueryFreshness();
-  const { data, isFetched } = useQuery({
-    queryKey: CLIENT_FLAG_QUERY_KEY,
-    queryFn: fetchClientFlagValues,
-    ...freshness,
-    retry: 1,
-  });
-  const override = readActivationFlowOverride();
-  const synced = data?.flags
-    ? mapFlags(data.flags).stringFlags[ACTIVATION_FLOW_STORE_KEY]
-    : undefined;
-  return { arm: override ?? synced ?? "control", settled: isFetched };
 }

--- a/apps/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/apps/web/src/lib/feature-flags/feature-flag-registry.json
@@ -39,7 +39,7 @@
       "scope": "both",
       "key": "experiment-activation-flow-2026-06-03",
       "label": "Activation Flow Experiment 2026-06-03",
-      "description": "Multivariate activation-flow experiment. control = standard flow; variant-a = activation rail; personal-page = preseeded personal-page app (read by the daemon, hence scope \"both\"). Targeted via LaunchDarkly.",
+      "description": "Multivariate activation-flow experiment. control = standard flow; variant-a = activation rail; personal-page = new sign-up-page variant (front-end only). Targeted via LaunchDarkly.",
       "defaultEnabled": "control",
       "values": ["control", "variant-a", "personal-page"]
     },

--- a/apps/web/src/stores/client-feature-flag-store.ts
+++ b/apps/web/src/stores/client-feature-flag-store.ts
@@ -48,13 +48,6 @@ const envOverrides = getEnvFlagOverridesForScope("client");
 
 interface ClientFeatureFlagMeta {
   stringFlags: Record<string, string>;
-  /**
-   * Flips `true` the first time the client flag query settles (success OR
-   * terminal error), so the synchronous `buildNavigationState()` can tell
-   * whether a server-synced arm has had a chance to land. Stays `false` until
-   * then. See `use-client-feature-flag-sync.ts` for where it is set.
-   */
-  loaded: boolean;
 }
 
 interface ClientFeatureFlagActions {
@@ -64,7 +57,6 @@ interface ClientFeatureFlagActions {
   setStringFlags: (flags: Record<string, string>) => void;
   setStringFlag: (key: string, value: string) => void;
   clearStringOverride: (key: string) => void;
-  setLoaded: () => void;
 }
 
 type ClientFeatureFlagStore = Record<string, boolean> &
@@ -85,7 +77,6 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
       ...localOverrides,
       ...envOverrides.bool,
       stringFlags: { ...CLIENT_STRING_FLAG_DEFAULTS, ...localStringOverrides, ...envOverrides.str },
-      loaded: false,
 
       setFlags: (flags: Record<string, boolean>) =>
         set((prev) => {
@@ -94,16 +85,8 @@ const useClientFeatureFlagStoreBase = create<ClientFeatureFlagStore>()(
           const changed = Object.keys(merged).some(
             (k) => merged[k] !== prev[k],
           );
-          // Receiving server flags means the query has settled; mark loaded so
-          // the synchronous nav-state read no longer treats the arm as unknown.
-          if (!prev.loaded) {
-            return { ...(changed ? merged : {}), loaded: true };
-          }
           return changed ? merged : prev;
         }),
-
-      setLoaded: () =>
-        set((prev) => (prev.loaded ? prev : { loaded: true })),
 
       setFlag: (key: string, value: boolean) => {
         try {


### PR DESCRIPTION
## Summary

Brings the branded **personal-page sign-up screen out from behind the `experiment-activation-flow-2026-06-03 = personal-page` arm** — it's now the **default sign-up experience for everyone**.

## Changes
- **`signup-page.tsx`** — renders `PersonalPageSignupScreen` unconditionally; drops the control auto-redirect to WorkOS (the screen's Google/Apple/Email buttons already hand off to the same WorkOS flow on click).
- **`provider-signup-page.tsx`** — always shows the branded post-OAuth name/occupation step, keeping the **editable email/username form as a fallback** when the provider doesn't supply them.
- **`use-client-feature-flag-sync.ts`** — removes the now-orphaned `useActivationFlowArm` hook (its only consumers were the two signup pages).
- **`client-feature-flag-store.ts`** — removes the write-only `loaded` / `setLoaded` state (its only reader, `activationArmSettled` in the navigation resolver, was removed with the cast onboarding flow).
- **`account-layout.tsx`** — de-stale a comment.

## Flag stays
The `experiment-activation-flow-2026-06-03` flag is **not removed** — `variant-a` still reads it in `pre-chat-flow.tsx`. The `personal-page` value is now a code no-op; LaunchDarkly targeting is unchanged (owned separately, per the call on this change).

## Verification
- Frontend: filtered typecheck (0 non-lucide errors), lint clean on changed files, production build ✓.
- Tests: `feature-flag-catalog` + `onboarding-lifecycle-sync` pass; no signup/provider-signup test suites exist.

## Notes
- No Linear ticket (intentional).
- The `apps/web/.../feature-flag-registry.json` description tweak is codegen syncing the generated copy to the `meta/` change already merged in the rip-out PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)