### PR TITLE
Update status banner sizing and placement

### DIFF
--- a/apps/web/src/components/sidebar-shell.tsx
+++ b/apps/web/src/components/sidebar-shell.tsx
@@ -116,7 +116,7 @@ export function SidebarShell({
       </div>
 
       {electron ? (
-        <StatusBanner placement="electron" className="px-0 pt-0" />
+        <StatusBanner placement="electron" className="mb-4 px-0 pt-0" />
       ) : null}
 
       {/* Card chrome — desktop only */}

--- a/apps/web/src/components/sidebar-shell.tsx
+++ b/apps/web/src/components/sidebar-shell.tsx
@@ -116,7 +116,9 @@ export function SidebarShell({
       </div>
 
       {electron ? (
-        <StatusBanner placement="electron" className="mb-4 px-0 pt-0" />
+        <div className="shrink-0 pb-4 empty:hidden">
+          <StatusBanner placement="electron" className="px-0 pt-0" />
+        </div>
       ) : null}
 
       {/* Card chrome — desktop only */}

--- a/apps/web/src/components/sidebar-shell.tsx
+++ b/apps/web/src/components/sidebar-shell.tsx
@@ -115,7 +115,9 @@ export function SidebarShell({
         <div className="h-10 w-10 shrink-0" aria-hidden="true" />
       </div>
 
-      <StatusBanner className="px-0 pt-0" />
+      {electron ? (
+        <StatusBanner placement="electron" className="px-0 pt-0" />
+      ) : null}
 
       {/* Card chrome — desktop only */}
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden md:rounded-[12px] md:border md:border-[var(--border-base)] md:bg-[var(--surface-overlay)]">

--- a/apps/web/src/components/status-banner.stories.tsx
+++ b/apps/web/src/components/status-banner.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Button } from "@vellumai/design-library";
+import { Info, LoaderCircle } from "lucide-react";
+
+import { StatusBannerNotice } from "@/components/status-banner";
+
+const meta: Meta<typeof StatusBannerNotice> = {
+  title: "Components/StatusBanner",
+  component: StatusBannerNotice,
+  parameters: {
+    layout: "fullscreen",
+  },
+  argTypes: {
+    tone: {
+      control: "select",
+      options: ["info", "success", "warning", "error", "neutral"],
+    },
+    placement: {
+      control: "select",
+      options: ["web", "electron"],
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof StatusBannerNotice>;
+
+const action = (
+  <Button variant="ghost" size="compact">
+    Action
+  </Button>
+);
+
+export const Web: Story = {
+  args: {
+    tone: "warning",
+    placement: "web",
+    title: "Assistant is upgrading.",
+    icon: <Info aria-hidden="true" />,
+    actions: action,
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-full">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const Electron: Story = {
+  args: {
+    tone: "warning",
+    placement: "electron",
+    title: "Assistant is upgrading.",
+    icon: <Info aria-hidden="true" />,
+    actions: action,
+  },
+  decorators: [
+    (Story) => (
+      <div className="bg-[var(--surface-base)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const ElectronWorking: Story = {
+  args: {
+    tone: "warning",
+    placement: "electron",
+    title: "Assistant is upgrading.",
+    icon: <LoaderCircle className="animate-spin" aria-hidden="true" />,
+  },
+  decorators: [
+    (Story) => (
+      <div className="bg-[var(--surface-base)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/apps/web/src/components/status-banner.test.tsx
+++ b/apps/web/src/components/status-banner.test.tsx
@@ -52,7 +52,10 @@ let refetchOperationalStatusMock = mock(async () => {});
 let wakeLocalAssistantHostMock = mock(async (_assistantId: string) => ({
   ok: true,
 }));
-let StatusBanner: ComponentType<{ className?: string }>;
+let StatusBanner: ComponentType<{
+  className?: string;
+  placement?: "web" | "electron";
+}>;
 
 mock.module("@/runtime/native-auth", () => ({
   isNativePlatform: () => isNativePlatformMock,
@@ -134,28 +137,6 @@ mock.module("@/stores/resolved-assistants-store", () => ({
   },
 }));
 
-mock.module("@vellumai/design-library/components/notice", () => ({
-  Notice: (props: {
-    title: ReactNode;
-    tone?: string;
-    icon?: ReactNode;
-    children?: ReactNode;
-    actions?: ReactNode;
-    className?: string;
-  }) => (
-    <div
-      data-testid="notice"
-      data-tone={props.tone}
-      data-class-name={props.className}
-    >
-      {props.icon}
-      {props.title}
-      {props.children}
-      {props.actions}
-    </div>
-  ),
-}));
-
 mock.module("@vellumai/design-library/components/button", () => ({
   Button: (props: {
     children: ReactNode;
@@ -232,6 +213,34 @@ describe("StatusBanner", () => {
 
     expect(html).toContain("Assistant is restarting");
     expect(html).toContain('data-tone="warning"');
+  });
+
+  test("uses the full-width web banner sizing by default", () => {
+    operationalStatusQueryMock = {
+      data: { state: "restarting" },
+      isError: false,
+    };
+
+    const html = renderToStaticMarkup(<StatusBanner />);
+
+    expect(html).toContain('data-placement="web"');
+    expect(html).toContain("min-h-10");
+    expect(html).toContain("py-[10px]");
+    expect(html).toContain("rounded-none");
+  });
+
+  test("uses compact rounded sizing for Electron placement", () => {
+    operationalStatusQueryMock = {
+      data: { state: "restarting" },
+      isError: false,
+    };
+
+    const html = renderToStaticMarkup(<StatusBanner placement="electron" />);
+
+    expect(html).toContain('data-placement="electron"');
+    expect(html).toContain("min-h-8");
+    expect(html).toContain("py-[7px]");
+    expect(html).toContain("rounded-lg");
   });
 
   test("uses lifecycle operation assistant id when present", () => {

--- a/apps/web/src/components/status-banner.test.tsx
+++ b/apps/web/src/components/status-banner.test.tsx
@@ -381,6 +381,10 @@ describe("StatusBanner", () => {
       expect(html).toContain("Wake up");
       expect(html).toContain('data-tone="neutral"');
       expect(html).toContain("items-center");
+      expect(html).toContain(
+        "[&amp;_[data-slot=button]]:hover:bg-[color-mix(in_srgb,var(--status-banner-action-color)_12%,transparent)]",
+      );
+      expect(html).toContain("[&amp;_[data-slot=button]]:hover:opacity-90");
     });
 
     test("renders unreachable local health as an asleep fallback", () => {

--- a/apps/web/src/components/status-banner.test.tsx
+++ b/apps/web/src/components/status-banner.test.tsx
@@ -381,10 +381,11 @@ describe("StatusBanner", () => {
       expect(html).toContain("Wake up");
       expect(html).toContain('data-tone="neutral"');
       expect(html).toContain("items-center");
-      expect(html).toContain(
+      expect(html).toContain("[&amp;_[data-slot=button]]:uppercase");
+      expect(html).not.toContain(
         "[&amp;_[data-slot=button]]:hover:bg-[color-mix(in_srgb,var(--status-banner-action-color)_12%,transparent)]",
       );
-      expect(html).toContain("[&amp;_[data-slot=button]]:hover:opacity-90");
+      expect(html).not.toContain("[&amp;_[data-slot=button]]:hover:opacity-90");
     });
 
     test("renders unreachable local health as an asleep fallback", () => {

--- a/apps/web/src/components/status-banner.test.tsx
+++ b/apps/web/src/components/status-banner.test.tsx
@@ -240,7 +240,7 @@ describe("StatusBanner", () => {
     expect(html).toContain('data-placement="electron"');
     expect(html).toContain("min-h-8");
     expect(html).toContain("py-[7px]");
-    expect(html).toContain("rounded-lg");
+    expect(html).toContain("rounded-[6px]");
   });
 
   test("uses lifecycle operation assistant id when present", () => {

--- a/apps/web/src/components/status-banner.tsx
+++ b/apps/web/src/components/status-banner.tsx
@@ -98,7 +98,7 @@ const STATUS_TONE_CLASSES: Record<NoticeTone, StatusToneClasses> = {
 
 const STATUS_BANNER_PLACEMENT_CLASSES: Record<StatusBannerPlacement, string> = {
   web: "min-h-10 rounded-none px-4 py-[10px]",
-  electron: "min-h-8 rounded-lg px-2 py-[7px]",
+  electron: "min-h-8 rounded-[6px] px-2 py-[7px]",
 };
 
 export interface StatusBannerNoticeProps

--- a/apps/web/src/components/status-banner.tsx
+++ b/apps/web/src/components/status-banner.tsx
@@ -190,11 +190,11 @@ export function StatusBannerNotice({
               : "gap-1.5 pl-2 leading-[18px]",
             "[&_[data-slot=button]]:h-auto [&_[data-slot=button]]:border-0 [&_[data-slot=button]]:bg-transparent",
             "[&_[data-slot=button]]:-mx-1 [&_[data-slot=button]]:rounded-sm [&_[data-slot=button]]:px-1 [&_[data-slot=button]]:py-0",
-            "[&_[data-slot=button]]:text-label-medium-default [&_[data-slot=button]]:transition-[background-color,color,opacity]",
+            "[&_[data-slot=button]]:text-label-medium-default [&_[data-slot=button]]:uppercase",
             "[&_[data-slot=button]]:leading-[inherit] [&_[data-slot=button]]:shadow-none",
             "[&_[data-slot=button]]:[--vbtn-fg:var(--status-banner-action-color)]",
+            "[&_[data-slot=button]]:hover:!bg-transparent [&_[data-slot=button]]:hover:!opacity-100",
             "[&_[data-slot=button]]:hover:[--vbtn-fg:var(--status-banner-action-color)]",
-            "[&_[data-slot=button]]:hover:bg-[color-mix(in_srgb,var(--status-banner-action-color)_12%,transparent)] [&_[data-slot=button]]:hover:opacity-90",
             "[&_[data-slot=button]]:focus-visible:ring-2 [&_[data-slot=button]]:focus-visible:ring-[var(--ring)] [&_[data-slot=button]]:focus-visible:ring-offset-0",
           )}
         >

--- a/apps/web/src/components/status-banner.tsx
+++ b/apps/web/src/components/status-banner.tsx
@@ -1,11 +1,25 @@
-import { CloudOff, LoaderCircle, Moon, WifiOff, Wrench } from "lucide-react";
-import { type ReactNode, useCallback, useEffect, useState } from "react";
+import {
+  CircleAlert,
+  CircleCheck,
+  CloudOff,
+  Info,
+  LoaderCircle,
+  Moon,
+  OctagonX,
+  WifiOff,
+  Wrench,
+  type LucideIcon,
+} from "lucide-react";
+import {
+  type ComponentProps,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useState,
+} from "react";
 import { Link } from "react-router";
 import { Button } from "@vellumai/design-library/components/button";
-import {
-  Notice,
-  type NoticeTone,
-} from "@vellumai/design-library/components/notice";
+import { type NoticeTone } from "@vellumai/design-library/components/notice";
 
 import {
   type LocalAssistantHealth,
@@ -39,6 +53,153 @@ interface BannerConfig {
 }
 
 const LOCAL_WAKE_SETTLING_MS = 60_000;
+
+export type StatusBannerPlacement = "web" | "electron";
+
+interface StatusToneClasses {
+  container: string;
+  icon: string;
+  action: string;
+  DefaultIcon: LucideIcon | null;
+}
+
+const STATUS_TONE_CLASSES: Record<NoticeTone, StatusToneClasses> = {
+  info: {
+    container: "bg-[var(--surface-overlay)]",
+    icon: "text-[color:var(--content-secondary)]",
+    action: "[--status-banner-action-color:var(--primary-base)]",
+    DefaultIcon: Info,
+  },
+  success: {
+    container: "bg-[var(--system-positive-weak)]",
+    icon: "text-[color:var(--system-positive-strong)]",
+    action: "[--status-banner-action-color:var(--system-positive-strong)]",
+    DefaultIcon: CircleCheck,
+  },
+  warning: {
+    container: "bg-[var(--system-mid-weak)]",
+    icon: "text-[color:var(--system-mid-strong)]",
+    action: "[--status-banner-action-color:var(--system-mid-strong)]",
+    DefaultIcon: CircleAlert,
+  },
+  error: {
+    container: "bg-[var(--system-negative-weak)]",
+    icon: "text-[color:var(--system-negative-strong)]",
+    action: "[--status-banner-action-color:var(--system-negative-strong)]",
+    DefaultIcon: OctagonX,
+  },
+  neutral: {
+    container: "bg-[var(--surface-overlay)]",
+    icon: "text-[color:var(--content-secondary)]",
+    action: "[--status-banner-action-color:var(--primary-base)]",
+    DefaultIcon: null,
+  },
+};
+
+const STATUS_BANNER_PLACEMENT_CLASSES: Record<StatusBannerPlacement, string> = {
+  web: "min-h-10 rounded-none px-4 py-[10px]",
+  electron: "min-h-8 rounded-lg px-2 py-[7px]",
+};
+
+export interface StatusBannerNoticeProps
+  extends Omit<ComponentProps<"div">, "title" | "children"> {
+  tone: NoticeTone;
+  title: ReactNode;
+  children?: ReactNode;
+  icon?: ReactNode;
+  actions?: ReactNode;
+  placement?: StatusBannerPlacement;
+}
+
+export function StatusBannerNotice({
+  tone,
+  title,
+  children,
+  icon,
+  actions,
+  placement = "web",
+  className,
+  ref,
+  ...rest
+}: StatusBannerNoticeProps) {
+  const toneClasses = STATUS_TONE_CLASSES[tone];
+  const role = tone === "error" ? "alert" : "status";
+  const titleClassName =
+    placement === "web"
+      ? "text-body-medium-default leading-5"
+      : "text-body-small-default leading-[18px]";
+  const resolvedIcon =
+    icon === undefined
+      ? toneClasses.DefaultIcon
+        ? <toneClasses.DefaultIcon aria-hidden="true" />
+        : null
+      : icon;
+
+  return (
+    <div
+      {...rest}
+      ref={ref}
+      role={role}
+      data-slot="status-banner-notice"
+      data-placement={placement}
+      data-tone={tone}
+      className={cn(
+        "flex w-full shrink-0 items-center justify-between gap-3 overflow-hidden",
+        "text-[color:var(--content-default)]",
+        STATUS_BANNER_PLACEMENT_CLASSES[placement],
+        toneClasses.container,
+        className,
+      )}
+    >
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        {resolvedIcon ? (
+          <span
+            className={cn(
+              "flex size-3.5 shrink-0 items-center justify-center [&_svg]:size-3.5",
+              toneClasses.icon,
+            )}
+          >
+            {resolvedIcon}
+          </span>
+        ) : null}
+        <div className="min-w-0">
+          <div
+            className={cn(
+              "truncate text-[color:var(--content-emphasised)]",
+              titleClassName,
+            )}
+          >
+            {title}
+          </div>
+          {children ? (
+            <div className="text-body-small-default leading-4 text-[color:var(--content-secondary)]">
+              {children}
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      {actions ? (
+        <div
+          className={cn(
+            "flex shrink-0 items-center border-l border-[color-mix(in_srgb,var(--content-default)_14%,transparent)] text-label-medium-default",
+            "text-[color:var(--status-banner-action-color)]",
+            toneClasses.action,
+            placement === "web"
+              ? "gap-2 pl-4 leading-5"
+              : "gap-1.5 pl-2 leading-[18px]",
+            "[&_[data-slot=button]]:h-auto [&_[data-slot=button]]:border-0 [&_[data-slot=button]]:bg-transparent",
+            "[&_[data-slot=button]]:p-0 [&_[data-slot=button]]:text-label-medium-default",
+            "[&_[data-slot=button]]:leading-[inherit] [&_[data-slot=button]]:shadow-none",
+            "[&_[data-slot=button]]:[--vbtn-fg:var(--status-banner-action-color)]",
+          )}
+        >
+          {actions}
+        </div>
+      ) : null}
+    </div>
+  );
+}
 
 const OPERATIONAL_STATUS_TITLES: Record<AssistantOperationalState, string> = {
   initializing: "Assistant is initializing",
@@ -164,24 +325,28 @@ function canWakeLocalHealth(health: LocalAssistantHealth | null): boolean {
 function BannerNotice({
   banner,
   className,
+  placement,
 }: {
   banner: BannerConfig;
   className?: string;
+  placement: StatusBannerPlacement;
 }) {
   return (
-    <div className={cn("px-4 pt-2", className)}>
-      <Notice
+    <div
+      className={cn(
+        placement === "electron" ? "px-4 pt-2" : "px-0 pt-0",
+        className,
+      )}
+    >
+      <StatusBannerNotice
         tone={banner.tone}
         title={banner.title}
         icon={banner.icon}
         actions={banner.actions}
-        className={cn(
-          !banner.children &&
-            "items-center [&>span:first-child]:mt-0",
-        )}
+        placement={placement}
       >
         {banner.children}
-      </Notice>
+      </StatusBannerNotice>
     </div>
   );
 }
@@ -466,8 +631,16 @@ function useAssistantBannerConfig(): BannerConfig | null {
   };
 }
 
-export function StatusBanner({ className }: { className?: string }) {
+export function StatusBanner({
+  className,
+  placement = isElectron() ? "electron" : "web",
+}: {
+  className?: string;
+  placement?: StatusBannerPlacement;
+}) {
   const banner = useAssistantBannerConfig();
 
-  return banner ? <BannerNotice banner={banner} className={className} /> : null;
+  return banner ? (
+    <BannerNotice banner={banner} className={className} placement={placement} />
+  ) : null;
 }

--- a/apps/web/src/components/status-banner.tsx
+++ b/apps/web/src/components/status-banner.tsx
@@ -189,9 +189,13 @@ export function StatusBannerNotice({
               ? "gap-2 pl-4 leading-5"
               : "gap-1.5 pl-2 leading-[18px]",
             "[&_[data-slot=button]]:h-auto [&_[data-slot=button]]:border-0 [&_[data-slot=button]]:bg-transparent",
-            "[&_[data-slot=button]]:p-0 [&_[data-slot=button]]:text-label-medium-default",
+            "[&_[data-slot=button]]:-mx-1 [&_[data-slot=button]]:rounded-sm [&_[data-slot=button]]:px-1 [&_[data-slot=button]]:py-0",
+            "[&_[data-slot=button]]:text-label-medium-default [&_[data-slot=button]]:transition-[background-color,color,opacity]",
             "[&_[data-slot=button]]:leading-[inherit] [&_[data-slot=button]]:shadow-none",
             "[&_[data-slot=button]]:[--vbtn-fg:var(--status-banner-action-color)]",
+            "[&_[data-slot=button]]:hover:[--vbtn-fg:var(--status-banner-action-color)]",
+            "[&_[data-slot=button]]:hover:bg-[color-mix(in_srgb,var(--status-banner-action-color)_12%,transparent)] [&_[data-slot=button]]:hover:opacity-90",
+            "[&_[data-slot=button]]:focus-visible:ring-2 [&_[data-slot=button]]:focus-visible:ring-[var(--ring)] [&_[data-slot=button]]:focus-visible:ring-offset-0",
           )}
         >
           {actions}

--- a/apps/web/src/domains/chat/chat-layout.tsx
+++ b/apps/web/src/domains/chat/chat-layout.tsx
@@ -193,6 +193,7 @@ export function ChatLayout() {
   const topBarRightSlot = useChatLayoutSlotsStore.use.topBarRightSlot();
   const showLlmInspector = useCanUseLlmInspector();
   const isNative = useIsNativePlatform();
+  const electron = isElectron();
 
   // --- Assistant identity from store (written by ChatPage) ---
   const assistantName = useAssistantIdentityStore.use.name();
@@ -529,13 +530,13 @@ export function ChatLayout() {
 
   const handleOpenInNewWindow = useCallback(
     (conversation: Conversation) => {
-      if (isElectron()) {
+      if (electron) {
         void openPopoutWindow(conversation.conversationId);
       } else {
         window.open(routes.conversation(conversation.conversationId), "_blank");
       }
     },
-    [],
+    [electron],
   );
 
   const renderSideMenu = (args: SideMenuRenderArgs): ReactNode => (
@@ -604,7 +605,7 @@ export function ChatLayout() {
         />
       )}
 
-      {!isPopout && <StatusBanner />}
+      {!isPopout && electron ? <StatusBanner placement="electron" /> : null}
 
       {isMobile ? (
         <main className="relative flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden">

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -1,5 +1,5 @@
 import { lazy, useState } from "react";
-import { Outlet, useNavigate } from "react-router";
+import { Outlet, useLocation, useNavigate } from "react-router";
 
 import { LazyBoundary } from "@/components/lazy-boundary";
 import { useAppTheme } from "@/hooks/use-app-theme";
@@ -38,8 +38,10 @@ import { useDynamicFavicon } from "@/hooks/use-dynamic-favicon";
 import { useElectronIconSync } from "@/hooks/use-electron-icon-sync";
 import { useElectronStatusSync } from "@/hooks/use-electron-status-sync";
 import { useElectronFeatureFlagBridge } from "@/runtime/electron-feature-flags";
+import { isElectron } from "@/runtime/is-electron";
 import { GlobalPushToTalkBridge } from "@/domains/chat/voice/global-push-to-talk-bridge";
 import { TimezoneSync } from "@/components/timezone-sync";
+import { StatusBanner } from "@/components/status-banner";
 import { UpdateToast } from "@/components/update-toast";
 import { retireAssistant } from "@/assistant/retire-service";
 import { setSelectedAssistant } from "@/assistant/selection";
@@ -87,6 +89,7 @@ export function RootLayout() {
   const isMobile = useIsMobile();
   const visibleViewport = useVisibleViewport();
 
+  const location = useLocation();
   const navigate = useNavigate();
   const sessionStatus = useAuthStore.use.sessionStatus();
   const isSessionInitializing = useIsSessionInitializing();
@@ -241,6 +244,8 @@ export function RootLayout() {
   // background as a visible gap above the keyboard.
   const keyboardOffsetTop =
     keyboardOpen && visibleViewport ? visibleViewport.offsetTop : 0;
+  const electron = isElectron();
+  const isPopout = location.search.includes("popout=1");
 
   return (
     <div
@@ -266,6 +271,7 @@ export function RootLayout() {
       }}
     >
       <UpdateToast />
+      {!electron && !isPopout ? <StatusBanner placement="web" /> : null}
       <div className="flex min-w-0 flex-col overflow-hidden w-full" style={{ flex: "1 1 0%", minHeight: 0 }}>
         <Outlet />
       </div>

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -19,6 +19,7 @@ import { getSelectedAssistant } from "@/lib/local-mode";
 import { useVellumCommands } from "@/runtime/vellum-commands";
 
 import { routes } from "@/utils/routes";
+import { shouldSuppressRootStatusBanner } from "@/utils/status-banner-visibility";
 import { useAssistantResourceSync } from "@/hooks/use-assistant-resource-sync";
 import { useDocumentEditorSync } from "@/hooks/use-document-editor-sync";
 import { useBookmarksSync } from "@/hooks/use-bookmarks-sync";
@@ -246,6 +247,10 @@ export function RootLayout() {
     keyboardOpen && visibleViewport ? visibleViewport.offsetTop : 0;
   const electron = isElectron();
   const isPopout = location.search.includes("popout=1");
+  const suppressStatusBanner = shouldSuppressRootStatusBanner(
+    location.pathname,
+    location.search,
+  );
 
   return (
     <div
@@ -271,7 +276,9 @@ export function RootLayout() {
       }}
     >
       <UpdateToast />
-      {!electron && !isPopout ? <StatusBanner placement="web" /> : null}
+      {!electron && !isPopout && !suppressStatusBanner ? (
+        <StatusBanner placement="web" />
+      ) : null}
       <div className="flex min-w-0 flex-col overflow-hidden w-full" style={{ flex: "1 1 0%", minHeight: 0 }}>
         <Outlet />
       </div>

--- a/apps/web/src/utils/status-banner-visibility.test.ts
+++ b/apps/web/src/utils/status-banner-visibility.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+
+import { shouldSuppressRootStatusBanner } from "@/utils/status-banner-visibility";
+import { routes } from "@/utils/routes";
+
+describe("shouldSuppressRootStatusBanner", () => {
+  test("suppresses onboarding funnel routes", () => {
+    for (const pathname of [
+      routes.onboarding.hosting,
+      routes.onboarding.apiKey,
+      routes.onboarding.privacy,
+      routes.onboarding.prechat,
+      routes.onboarding.hatching,
+      `${routes.assistant}/onboarding`,
+    ]) {
+      expect(shouldSuppressRootStatusBanner(pathname, "")).toBe(true);
+    }
+  });
+
+  test("suppresses setup routes around onboarding", () => {
+    for (const pathname of [
+      routes.welcome,
+      routes.selectAssistant,
+      routes.reviewTerms,
+    ]) {
+      expect(shouldSuppressRootStatusBanner(pathname, "")).toBe(true);
+    }
+  });
+
+  test("suppresses the onboarding handoff query on the assistant route", () => {
+    expect(shouldSuppressRootStatusBanner(routes.assistant, "?onboarding=1")).toBe(
+      true,
+    );
+  });
+
+  test("allows normal app routes", () => {
+    expect(shouldSuppressRootStatusBanner(routes.settings.root, "")).toBe(false);
+    expect(shouldSuppressRootStatusBanner(routes.assistant, "")).toBe(false);
+  });
+});

--- a/apps/web/src/utils/status-banner-visibility.ts
+++ b/apps/web/src/utils/status-banner-visibility.ts
@@ -1,0 +1,24 @@
+import { routes } from "@/utils/routes";
+
+const ONBOARDING_PREFIX = `${routes.assistant}/onboarding`;
+
+const STATUS_BANNER_SETUP_PATHS: ReadonlySet<string> = new Set([
+  routes.welcome,
+  routes.selectAssistant,
+  routes.reviewTerms,
+]);
+
+export function shouldSuppressRootStatusBanner(
+  pathname: string,
+  search: string,
+): boolean {
+  if (
+    pathname === ONBOARDING_PREFIX ||
+    pathname.startsWith(`${ONBOARDING_PREFIX}/`) ||
+    STATUS_BANNER_SETUP_PATHS.has(pathname)
+  ) {
+    return true;
+  }
+
+  return new URLSearchParams(search).get("onboarding") === "1";
+}


### PR DESCRIPTION
## Summary
- Adds a reusable app-level StatusBannerNotice presenter with web/electron sizing variants and Storybook coverage.
- Moves the web status banner to RootLayout so it renders above route navigation, while Electron keeps compact rounded placement under its toolbar/title strip.
- Preserves the existing status decision logic and banner actions while tightening action sizing for the compact bar.

## Original prompt
The user asked to update the centralized web/Electron app banner styling to match provided Figma screenshots, ignoring color and focusing on sizing. The web app banner should appear above navigation, while the Electron app should keep it below the toolbar because navigation lives in the toolbar header. They also asked to make the banner a standard component if it was not already and add Storybook coverage after checking the local guidelines.