### PR TITLE
Add remote web pairing token exchange

### DIFF
--- a/gateway/src/__tests__/remote-web-ingress-denylist.test.ts
+++ b/gateway/src/__tests__/remote-web-ingress-denylist.test.ts
@@ -77,10 +77,12 @@ describe("remote web ingress denylist", () => {
       "/v1/guardian/reset-bootstrap",
       "/v1/pair",
       "/v1/remote-web/pairing-challenge",
+      "/v1/remote-web/pairing-token",
       "/v1/remote-web/pairing-verification",
     ]);
 
     const publicRemoteWebRoutes = new Set([
+      "/v1/remote-web/pairing-token",
       "/v1/remote-web/pairing-verification",
     ]);
 

--- a/gateway/src/__tests__/remote-web-pairing-token.test.ts
+++ b/gateway/src/__tests__/remote-web-pairing-token.test.ts
@@ -1,0 +1,334 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { eq } from "drizzle-orm";
+
+import { initSigningKey } from "../auth/token-service.js";
+
+initSigningKey(Buffer.from("test-signing-key-at-least-32-bytes-long-xx"));
+
+const mockQuery = mock();
+mock.module("../db/assistant-db-proxy.js", () => ({
+  assistantDbQuery: mockQuery,
+  assistantDbRun: mock(),
+  assistantDbExec: mock(),
+}));
+
+const { hashToken, mintAndRecordDeviceBoundTokenPair } =
+  await import("../auth/guardian-bootstrap.js");
+const { initGatewayDb, resetGatewayDb, getGatewayDb } =
+  await import("../db/connection.js");
+const { actorRefreshTokenRecords, actorTokenRecords } =
+  await import("../db/schema.js");
+const { handleGuardianRefresh } =
+  await import("../http/routes/guardian-refresh.js");
+const { handleRemoteWebPairingToken } =
+  await import("../http/routes/remote-web-pairing-token.js");
+const {
+  approveRemoteWebPairingChallenge,
+  createRemoteWebPairingChallenge,
+  getRemoteWebPairingChallengeForTests,
+  resetRemoteWebPairingChallengesForTests,
+  setRemoteWebPairingChallengeNowForTests,
+} = await import("../remote-web/pairing-challenge-store.js");
+
+const GUARDIAN_ID = "guardian-001";
+const PUBLIC_BASE_URL = "https://paired.example.com";
+
+let testRoot: string;
+
+function makeTokenRequest(body: unknown): Request {
+  return new Request("https://paired.example.com/v1/remote-web/pairing-token", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeRefreshRequest(refreshToken: string): Request {
+  return new Request("https://paired.example.com/v1/guardian/refresh", {
+    method: "POST",
+    headers: {
+      cookie: `vellum_web_refresh=${encodeURIComponent(refreshToken)}`,
+    },
+  });
+}
+
+function setCookies(res: Response): string[] {
+  const headers = res.headers as Headers & {
+    getSetCookie?: () => string[];
+  };
+  const cookies = headers.getSetCookie?.();
+  if (cookies) return cookies;
+  const cookie = headers.get("set-cookie");
+  return cookie ? [cookie] : [];
+}
+
+function cookieValue(cookies: string[], name: string): string {
+  const cookie = cookies.find((candidate) => candidate.startsWith(`${name}=`));
+  expect(cookie).toBeTruthy();
+  return decodeURIComponent(cookie!.split(";")[0].slice(name.length + 1));
+}
+
+function activeTokens() {
+  return getGatewayDb()
+    .select()
+    .from(actorTokenRecords)
+    .where(eq(actorTokenRecords.status, "active"))
+    .all();
+}
+
+function activeRefreshTokens() {
+  return getGatewayDb()
+    .select()
+    .from(actorRefreshTokenRecords)
+    .where(eq(actorRefreshTokenRecords.status, "active"))
+    .all();
+}
+
+beforeEach(async () => {
+  resetRemoteWebPairingChallengesForTests();
+  mockQuery.mockResolvedValue([{ principal_id: GUARDIAN_ID }]);
+  testRoot = mkdtempSync(join(tmpdir(), "remote-web-pairing-token-test-"));
+  const securityDir = join(testRoot, "protected");
+  mkdirSync(securityDir, { recursive: true });
+  process.env.GATEWAY_SECURITY_DIR = securityDir;
+  await initGatewayDb();
+});
+
+afterEach(() => {
+  resetRemoteWebPairingChallengesForTests();
+  resetGatewayDb();
+  delete process.env.GATEWAY_SECURITY_DIR;
+  try {
+    rmSync(testRoot, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+describe("remote web pairing token exchange", () => {
+  test("returns pending before the user approves the code", async () => {
+    setRemoteWebPairingChallengeNowForTests(() => 1_000);
+    const challenge = createRemoteWebPairingChallenge(PUBLIC_BASE_URL);
+
+    const res = await handleRemoteWebPairingToken(
+      makeTokenRequest({ deviceCode: challenge.deviceCode }),
+    );
+
+    expect(res.status).toBe(202);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(await res.json()).toEqual({
+      status: "pending",
+      expiresAt: challenge.expiresAt,
+      intervalSeconds: challenge.intervalSeconds,
+    });
+    expect(activeTokens()).toHaveLength(0);
+  });
+
+  test("approved device code mints access token and HttpOnly refresh cookies once", async () => {
+    const challenge = createRemoteWebPairingChallenge(PUBLIC_BASE_URL);
+    expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
+      "approved",
+    );
+
+    const res = await handleRemoteWebPairingToken(
+      makeTokenRequest({ deviceCode: challenge.deviceCode }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.status).toBe("approved");
+    expect(typeof body.accessToken).toBe("string");
+    expect(typeof body.accessTokenExpiresAt).toBe("string");
+    expect(typeof body.refreshAfter).toBe("string");
+    expect(body.guardianId).toBe(GUARDIAN_ID);
+    expect(body.refreshToken).toBeUndefined();
+    expect(body.deviceId).toBeUndefined();
+
+    const cookies = setCookies(res);
+    expect(cookies).toHaveLength(1);
+    for (const cookie of cookies) {
+      expect(cookie).toContain("HttpOnly");
+      expect(cookie).toContain("Secure");
+      expect(cookie).toContain("SameSite=Strict");
+      expect(cookie).toContain("Path=/v1/guardian/refresh");
+    }
+
+    const refreshToken = cookieValue(cookies, "vellum_web_refresh");
+    const tokens = activeTokens();
+    const refreshTokens = activeRefreshTokens();
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0].guardianPrincipalId).toBe(GUARDIAN_ID);
+    expect(tokens[0].platform).toBe("web");
+    expect(refreshTokens).toHaveLength(1);
+    expect(refreshTokens[0].tokenHash).toBe(hashToken(refreshToken));
+    expect(refreshTokens[0].hashedDeviceId).toBe(tokens[0].hashedDeviceId);
+
+    const replay = await handleRemoteWebPairingToken(
+      makeTokenRequest({ deviceCode: challenge.deviceCode }),
+    );
+    expect(replay.status).toBe(401);
+    expect(setCookies(replay)).toHaveLength(0);
+    expect(activeTokens()).toHaveLength(1);
+  });
+
+  test("browser refresh rotates using only the HttpOnly refresh cookie", async () => {
+    const challenge = createRemoteWebPairingChallenge(PUBLIC_BASE_URL);
+    expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
+      "approved",
+    );
+
+    const exchange = await handleRemoteWebPairingToken(
+      makeTokenRequest({ deviceCode: challenge.deviceCode }),
+    );
+    const originalRefreshToken = cookieValue(
+      setCookies(exchange),
+      "vellum_web_refresh",
+    );
+    const originalRefreshRecord = activeRefreshTokens()[0];
+
+    const refresh = await handleGuardianRefresh(
+      makeRefreshRequest(originalRefreshToken),
+    );
+
+    expect(refresh.status).toBe(200);
+    expect(refresh.headers.get("Cache-Control")).toBe("no-store");
+    const body = (await refresh.json()) as Record<string, unknown>;
+    expect(typeof body.accessToken).toBe("string");
+    expect(typeof body.accessTokenExpiresAt).toBe("number");
+    expect(typeof body.refreshAfter).toBe("number");
+    expect(body.refreshToken).toBeUndefined();
+    expect(body.deviceId).toBeUndefined();
+
+    const rotatedRefreshToken = cookieValue(
+      setCookies(refresh),
+      "vellum_web_refresh",
+    );
+    expect(rotatedRefreshToken).not.toBe(originalRefreshToken);
+
+    const refreshTokens = getGatewayDb()
+      .select()
+      .from(actorRefreshTokenRecords)
+      .all();
+    expect(
+      refreshTokens.find((token) => token.id === originalRefreshRecord.id)
+        ?.status,
+    ).toBe("rotated");
+    expect(activeRefreshTokens()).toHaveLength(1);
+    expect(activeRefreshTokens()[0].tokenHash).toBe(
+      hashToken(rotatedRefreshToken),
+    );
+    expect(activeTokens()).toHaveLength(1);
+  });
+
+  test("path-prefixed public base URLs keep refresh cookies on the public refresh path", async () => {
+    const publicBaseUrl = `${PUBLIC_BASE_URL}/assistant-123`;
+    const expectedCookiePath = "/assistant-123/v1/guardian/refresh";
+    const challenge = createRemoteWebPairingChallenge(publicBaseUrl);
+    expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
+      "approved",
+    );
+
+    const exchange = await handleRemoteWebPairingToken(
+      makeTokenRequest({ deviceCode: challenge.deviceCode }),
+    );
+
+    const exchangeCookies = setCookies(exchange);
+    expect(exchangeCookies).toHaveLength(1);
+    expect(exchangeCookies[0]).toContain(`Path=${expectedCookiePath}`);
+    const originalRefreshToken = cookieValue(
+      exchangeCookies,
+      "vellum_web_refresh",
+    );
+    expect(activeRefreshTokens()[0].browserRefreshCookiePath).toBe(
+      expectedCookiePath,
+    );
+
+    const refresh = await handleGuardianRefresh(
+      makeRefreshRequest(originalRefreshToken),
+    );
+
+    expect(refresh.status).toBe(200);
+    const refreshCookies = setCookies(refresh);
+    expect(refreshCookies).toHaveLength(1);
+    expect(refreshCookies[0]).toContain(`Path=${expectedCookiePath}`);
+    expect(activeRefreshTokens()[0].browserRefreshCookiePath).toBe(
+      expectedCookiePath,
+    );
+  });
+
+  test("cookie refresh rejects legacy device-bound refresh tokens", async () => {
+    const legacyPair = mintAndRecordDeviceBoundTokenPair({
+      guardianPrincipalId: GUARDIAN_ID,
+      deviceId: "legacy-device",
+      platform: "cli",
+    });
+
+    const refresh = await handleGuardianRefresh(
+      makeRefreshRequest(legacyPair.refreshToken),
+    );
+
+    expect(refresh.status).toBe(401);
+    expect(await refresh.json()).toEqual({ error: "refresh_invalid" });
+    const refreshTokens = activeRefreshTokens();
+    expect(refreshTokens).toHaveLength(1);
+    expect(refreshTokens[0].tokenHash).toBe(hashToken(legacyPair.refreshToken));
+    expect(refreshTokens[0].browserRefreshCookiePath).toBeNull();
+  });
+
+  test("failed credential mint leaves the approved device code retryable", async () => {
+    const challenge = createRemoteWebPairingChallenge(PUBLIC_BASE_URL);
+    expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
+      "approved",
+    );
+
+    mockQuery.mockRejectedValueOnce(new Error("temporary guardian lookup"));
+    await expect(
+      handleRemoteWebPairingToken(
+        makeTokenRequest({ deviceCode: challenge.deviceCode }),
+      ),
+    ).rejects.toThrow("temporary guardian lookup");
+
+    expect(
+      getRemoteWebPairingChallengeForTests(challenge.userCode)?.status,
+    ).toBe("approved");
+    expect(activeTokens()).toHaveLength(0);
+    expect(activeRefreshTokens()).toHaveLength(0);
+
+    const retry = await handleRemoteWebPairingToken(
+      makeTokenRequest({ deviceCode: challenge.deviceCode }),
+    );
+
+    expect(retry.status).toBe(200);
+    expect(setCookies(retry)).toHaveLength(1);
+    expect(activeTokens()).toHaveLength(1);
+    expect(activeRefreshTokens()).toHaveLength(1);
+  });
+
+  test("expired device code does not mint credentials", async () => {
+    setRemoteWebPairingChallengeNowForTests(() => 1_000);
+    const challenge = createRemoteWebPairingChallenge(PUBLIC_BASE_URL);
+    expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
+      "approved",
+    );
+    setRemoteWebPairingChallengeNowForTests(() => 601_000);
+
+    const res = await handleRemoteWebPairingToken(
+      makeTokenRequest({ deviceCode: challenge.deviceCode }),
+    );
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({
+      error: {
+        code: "INVALID_OR_EXPIRED_DEVICE_CODE",
+        message: "invalid or expired pairing device code",
+      },
+    });
+    expect(activeTokens()).toHaveLength(0);
+    expect(activeRefreshTokens()).toHaveLength(0);
+  });
+});

--- a/gateway/src/__tests__/route-schema-guard.test.ts
+++ b/gateway/src/__tests__/route-schema-guard.test.ts
@@ -175,6 +175,8 @@ const EXCLUDED_FROM_SCHEMA = new Set([
   "/v1/remote-web/pairing-challenge",
   // Remote web pairing verification bootstrap — not part of the public gateway API
   "/v1/remote-web/pairing-verification",
+  // Remote web pairing token bootstrap — not part of the public gateway API
+  "/v1/remote-web/pairing-token",
   // Loopback-only device management — not part of the public gateway API
   "/v1/devices",
   "/v1/devices/revoke",

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -399,16 +399,18 @@ export async function createGuardianBinding(
 // Token operations (against the gateway's own DB — no cross-container issue)
 // ---------------------------------------------------------------------------
 
-/**
- * A freshly minted, DB-recorded access + refresh token pair bound to a device.
- */
-export interface DeviceBoundTokenPair {
+export interface RefreshableTokenPair {
   accessToken: string;
   accessTokenExpiresAt: number;
   refreshToken: string;
   refreshTokenExpiresAt: number;
   refreshAfter: number;
 }
+
+/**
+ * A freshly minted, DB-recorded access + refresh token pair bound to a device.
+ */
+export type DeviceBoundTokenPair = RefreshableTokenPair;
 
 /**
  * Revoke active actor tokens for a device binding.
@@ -502,6 +504,7 @@ function mintRefreshToken(
   guardianPrincipalId: string,
   hashedDeviceId: string,
   platform: string,
+  options: { browserRefreshCookiePath?: string } = {},
 ): {
   refreshToken: string;
   refreshTokenExpiresAt: number;
@@ -528,6 +531,7 @@ function mintRefreshToken(
       absoluteExpiresAt,
       inactivityExpiresAt,
       lastUsedAt: null,
+      browserRefreshCookiePath: options.browserRefreshCookiePath,
       createdAt: now,
       updatedAt: now,
     })
@@ -569,6 +573,40 @@ export function mintAndRecordDeviceBoundTokenPair(params: {
     params.guardianPrincipalId,
     hashedDeviceId,
     params.platform,
+  );
+
+  return {
+    accessToken: access.token,
+    accessTokenExpiresAt: access.expiresAt,
+    refreshToken: refresh.refreshToken,
+    refreshTokenExpiresAt: refresh.refreshTokenExpiresAt,
+    refreshAfter: refresh.refreshAfter,
+  };
+}
+
+/**
+ * Mint a refreshable browser credential without requiring the browser to track a
+ * separate device id. The current token tables still require a binding column,
+ * so remote web uses an internal random binding that never leaves the gateway.
+ */
+export function mintAndRecordBrowserTokenPair(params: {
+  guardianPrincipalId: string;
+  platform: string;
+  browserRefreshCookiePath: string;
+}): RefreshableTokenPair {
+  const internalBinding = randomBytes(32).toString("base64url");
+  const hashedDeviceId = hashToken(internalBinding);
+
+  const access = mintAccessToken(
+    params.guardianPrincipalId,
+    hashedDeviceId,
+    params.platform,
+  );
+  const refresh = mintRefreshToken(
+    params.guardianPrincipalId,
+    hashedDeviceId,
+    params.platform,
+    { browserRefreshCookiePath: params.browserRefreshCookiePath },
   );
 
   return {

--- a/gateway/src/auth/guardian-refresh.ts
+++ b/gateway/src/auth/guardian-refresh.ts
@@ -42,6 +42,7 @@ export interface RotateResult {
   refreshToken: string;
   refreshTokenExpiresAt: number;
   refreshAfter: number;
+  browserRefreshCookiePath?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -55,6 +56,8 @@ function findRefreshByHash(tokenHash: string) {
     .where(eq(actorRefreshTokenRecords.tokenHash, tokenHash))
     .get();
 }
+
+type RefreshTokenRecord = NonNullable<ReturnType<typeof findRefreshByHash>>;
 
 function markRotated(tokenHash: string): boolean {
   const now = Date.now();
@@ -166,6 +169,7 @@ function mintRefreshTokenInFamily(params: {
   platform: string;
   familyId: string;
   absoluteExpiresAt: number;
+  browserRefreshCookiePath?: string;
 }): {
   refreshToken: string;
   refreshTokenExpiresAt: number;
@@ -190,6 +194,7 @@ function mintRefreshTokenInFamily(params: {
       absoluteExpiresAt: params.absoluteExpiresAt,
       inactivityExpiresAt,
       lastUsedAt: null,
+      browserRefreshCookiePath: params.browserRefreshCookiePath,
       createdAt: now,
       updatedAt: now,
     })
@@ -206,44 +211,10 @@ function mintRefreshTokenInFamily(params: {
   };
 }
 
-// ---------------------------------------------------------------------------
-// Public: rotate credentials
-// ---------------------------------------------------------------------------
-
-/**
- * Rotate credentials: validate refresh token, revoke old, mint new pair.
- *
- * All token operations run against the gateway's SQLite database.
- *
- * The refresh token is bound to the device it was issued to: the caller must
- * supply the hashed device id, and it must match the record's stored binding.
- * This ensures a leaked refresh token cannot be redeemed from a different
- * device. The binding is checked before any side effects (rotation, family
- * revocation) so a request from a non-matching device cannot disturb the
- * legitimate token family.
- */
-export function rotateCredentials(params: {
-  refreshToken: string;
-  hashedDeviceId: string;
-}):
-  | { ok: true; result: RotateResult }
-  | { ok: false; error: RefreshErrorCode } {
-  const refreshTokenHash = hashToken(params.refreshToken);
-
-  const record = findRefreshByHash(refreshTokenHash);
-
-  if (!record) {
-    return { ok: false, error: "refresh_invalid" };
-  }
-
-  if (record.hashedDeviceId !== params.hashedDeviceId) {
-    log.warn(
-      { familyId: record.familyId },
-      "Refresh rejected — device binding mismatch",
-    );
-    return { ok: false, error: "device_binding_mismatch" };
-  }
-
+function rotateRefreshTokenRecord(
+  refreshTokenHash: string,
+  record: RefreshTokenRecord,
+): { ok: true; result: RotateResult } | { ok: false; error: RefreshErrorCode } {
   if (record.status === "rotated") {
     log.warn(
       { familyId: record.familyId, hashedDeviceId: record.hashedDeviceId },
@@ -296,6 +267,7 @@ export function rotateCredentials(params: {
       platform: record.platform,
       familyId: record.familyId,
       absoluteExpiresAt: record.absoluteExpiresAt,
+      browserRefreshCookiePath: record.browserRefreshCookiePath ?? undefined,
     });
 
     log.info(
@@ -312,7 +284,75 @@ export function rotateCredentials(params: {
         refreshToken: refresh.refreshToken,
         refreshTokenExpiresAt: refresh.refreshTokenExpiresAt,
         refreshAfter: refresh.refreshAfter,
+        browserRefreshCookiePath: record.browserRefreshCookiePath ?? undefined,
       },
     };
   });
+}
+
+// ---------------------------------------------------------------------------
+// Public: rotate credentials
+// ---------------------------------------------------------------------------
+
+/**
+ * Rotate credentials: validate refresh token, revoke old, mint new pair.
+ *
+ * All token operations run against the gateway's SQLite database.
+ *
+ * The refresh token is bound to the device it was issued to: the caller must
+ * supply the hashed device id, and it must match the record's stored binding.
+ * This ensures a leaked refresh token cannot be redeemed from a different
+ * device. The binding is checked before any side effects (rotation, family
+ * revocation) so a request from a non-matching device cannot disturb the
+ * legitimate token family.
+ */
+export function rotateCredentials(params: {
+  refreshToken: string;
+  hashedDeviceId: string;
+}):
+  | { ok: true; result: RotateResult }
+  | { ok: false; error: RefreshErrorCode } {
+  const refreshTokenHash = hashToken(params.refreshToken);
+  const record = findRefreshByHash(refreshTokenHash);
+
+  if (!record) {
+    return { ok: false, error: "refresh_invalid" };
+  }
+
+  if (record.hashedDeviceId !== params.hashedDeviceId) {
+    log.warn(
+      { familyId: record.familyId },
+      "Refresh rejected — device binding mismatch",
+    );
+    return { ok: false, error: "device_binding_mismatch" };
+  }
+
+  return rotateRefreshTokenRecord(refreshTokenHash, record);
+}
+
+/**
+ * Browser refresh rotates using only the refresh token. The refresh token is the
+ * bearer credential and the stored binding is recovered from its DB record.
+ *
+ * Only refresh-token records minted for the browser flow carry a browser cookie
+ * path. Legacy CLI/macOS records still require the explicit device-bound
+ * `rotateCredentials` path until that contract is migrated intentionally.
+ */
+export function rotateBrowserCredentialsByRefreshToken(params: {
+  refreshToken: string;
+}):
+  | { ok: true; result: RotateResult }
+  | { ok: false; error: RefreshErrorCode } {
+  const refreshTokenHash = hashToken(params.refreshToken);
+  const record = findRefreshByHash(refreshTokenHash);
+
+  if (!record) {
+    return { ok: false, error: "refresh_invalid" };
+  }
+
+  if (!record.browserRefreshCookiePath) {
+    return { ok: false, error: "refresh_invalid" };
+  }
+
+  return rotateRefreshTokenRecord(refreshTokenHash, record);
 }

--- a/gateway/src/db/schema.ts
+++ b/gateway/src/db/schema.ts
@@ -250,6 +250,7 @@ export const actorRefreshTokenRecords = sqliteTable(
     absoluteExpiresAt: integer("absolute_expires_at").notNull(),
     inactivityExpiresAt: integer("inactivity_expires_at").notNull(),
     lastUsedAt: integer("last_used_at"),
+    browserRefreshCookiePath: text("browser_refresh_cookie_path"),
     createdAt: integer("created_at").notNull(),
     updatedAt: integer("updated_at").notNull(),
   },

--- a/gateway/src/http/browser-auth-cookies.ts
+++ b/gateway/src/http/browser-auth-cookies.ts
@@ -1,0 +1,77 @@
+export const BROWSER_REFRESH_COOKIE = "vellum_web_refresh";
+const BROWSER_REFRESH_PATH = "/v1/guardian/refresh";
+
+function normalizeCookiePath(value: string | undefined): string {
+  if (!value || !value.startsWith("/") || /[;\r\n]/.test(value)) {
+    return BROWSER_REFRESH_PATH;
+  }
+  return value;
+}
+
+export function remoteWebRefreshCookiePathForPublicBaseUrl(
+  publicBaseUrl: string,
+): string {
+  const url = new URL(publicBaseUrl);
+  const pathPrefix = url.pathname.replace(/\/+$/, "");
+  return normalizeCookiePath(`${pathPrefix}${BROWSER_REFRESH_PATH}`);
+}
+
+function encodeCookieValue(value: string): string {
+  return encodeURIComponent(value);
+}
+
+function browserAuthCookie(
+  name: string,
+  value: string,
+  maxAgeSeconds: number,
+  path: string | undefined,
+): string {
+  return [
+    `${name}=${encodeCookieValue(value)}`,
+    "HttpOnly",
+    "Secure",
+    "SameSite=Strict",
+    `Path=${normalizeCookiePath(path)}`,
+    `Max-Age=${Math.max(0, Math.floor(maxAgeSeconds))}`,
+  ].join("; ");
+}
+
+export function buildRemoteWebBrowserAuthCookies(params: {
+  refreshToken: string;
+  refreshTokenExpiresAtMs: number;
+  refreshCookiePath?: string;
+}): string[] {
+  const maxAgeSeconds = Math.ceil(
+    (params.refreshTokenExpiresAtMs - Date.now()) / 1000,
+  );
+  return [
+    browserAuthCookie(
+      BROWSER_REFRESH_COOKIE,
+      params.refreshToken,
+      maxAgeSeconds,
+      params.refreshCookiePath,
+    ),
+  ];
+}
+
+export function getRemoteWebRefreshCookie(req: Request): string {
+  const header = req.headers.get("cookie");
+  if (!header) return "";
+
+  for (const part of header.split(";")) {
+    const [rawName, ...rawValue] = part.trim().split("=");
+    if (rawName !== BROWSER_REFRESH_COOKIE) continue;
+    const value = rawValue.join("=");
+    try {
+      return decodeURIComponent(value);
+    } catch {
+      return value;
+    }
+  }
+
+  return "";
+}
+
+export function hasRemoteWebRefreshCookie(req: Request): boolean {
+  return Boolean(getRemoteWebRefreshCookie(req));
+}

--- a/gateway/src/http/read-limited-body.ts
+++ b/gateway/src/http/read-limited-body.ts
@@ -1,0 +1,50 @@
+export type ReadLimitedBodyResult =
+  | { status: "ok"; text: string }
+  | { status: "too_large" }
+  | { status: "unreadable" };
+
+export async function readLimitedBody(
+  req: Request,
+  maxBytes: number,
+): Promise<ReadLimitedBodyResult> {
+  const contentLength = req.headers.get("content-length");
+  if (
+    contentLength &&
+    Number.isFinite(Number(contentLength)) &&
+    Number(contentLength) > maxBytes
+  ) {
+    return { status: "too_large" };
+  }
+
+  if (!req.body) return { status: "ok", text: "" };
+
+  const reader = req.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBytes) {
+        await reader.cancel().catch(() => {});
+        return { status: "too_large" };
+      }
+      chunks.push(value);
+    }
+  } catch {
+    return { status: "unreadable" };
+  }
+
+  const bytes = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return { status: "ok", text: new TextDecoder().decode(bytes) };
+}

--- a/gateway/src/http/routes/channel-verification-session-proxy.test.ts
+++ b/gateway/src/http/routes/channel-verification-session-proxy.test.ts
@@ -46,21 +46,6 @@ mock.module("../../auth/guardian-bootstrap.js", () => ({
   REFRESH_AFTER_FRACTION: 0.8,
 }));
 
-mock.module("../../auth/guardian-refresh.js", () => ({
-  rotateCredentials: () => ({
-    ok: true,
-    result: {
-      guardianPrincipalId: "vellum-principal-test",
-      accessToken: "test-new-at",
-      accessTokenExpiresAt: Date.now() + 86400_000,
-      refreshToken: "test-new-rt",
-      refreshTokenExpiresAt: Date.now() + 86400_000 * 30,
-      refreshAfter: Date.now() + 86400_000 * 15,
-    },
-  }),
-  closeAssistantDb: () => {},
-}));
-
 // Import after mocks are registered
 const { createChannelVerificationSessionProxyHandler } =
   await import("./channel-verification-session-proxy.js");

--- a/gateway/src/http/routes/channel-verification-session-proxy.ts
+++ b/gateway/src/http/routes/channel-verification-session-proxy.ts
@@ -10,8 +10,7 @@ import { join } from "node:path";
 
 import { proxyForwardToResponse } from "@vellumai/assistant-client";
 
-import { bootstrapGuardian, hashToken } from "../../auth/guardian-bootstrap.js";
-import { rotateCredentials } from "../../auth/guardian-refresh.js";
+import { bootstrapGuardian } from "../../auth/guardian-bootstrap.js";
 import { mintServiceToken } from "../../auth/token-exchange.js";
 import type { GatewayConfig } from "../../config.js";
 import { getGatewaySecurityDir } from "../../paths.js";
@@ -417,75 +416,6 @@ export function createChannelVerificationSessionProxyHandler(
         if (providedIndex >= 0) {
           secretsInFlight.delete(providedIndex);
         }
-      }
-    },
-
-    async handleGuardianRefresh(req: Request): Promise<Response> {
-      try {
-        const body = (await req.json()) as Record<string, unknown>;
-        const refreshToken =
-          typeof body.refreshToken === "string" ? body.refreshToken : "";
-        const deviceId = typeof body.deviceId === "string" ? body.deviceId : "";
-
-        if (!refreshToken) {
-          return Response.json(
-            {
-              error: {
-                code: "BAD_REQUEST",
-                message: "Missing required field: refreshToken",
-              },
-            },
-            { status: 400 },
-          );
-        }
-
-        // The refresh token is bound to the device it was issued to. Require
-        // the caller to prove the device so a leaked refresh token cannot be
-        // redeemed from a different device.
-        if (!deviceId) {
-          return Response.json(
-            {
-              error: {
-                code: "BAD_REQUEST",
-                message: "Missing required field: deviceId",
-              },
-            },
-            { status: 400 },
-          );
-        }
-
-        const result = rotateCredentials({
-          refreshToken,
-          hashedDeviceId: hashToken(deviceId),
-        });
-
-        if (!result.ok) {
-          // 403 for tokens that are valid-but-forbidden (revoked, reused, or
-          // presented from the wrong device); 401 for invalid/expired tokens.
-          const forbidden: Array<typeof result.error> = [
-            "refresh_reuse_detected",
-            "device_binding_mismatch",
-            "revoked",
-          ];
-          const statusCode = forbidden.includes(result.error) ? 403 : 401;
-
-          log.warn({ error: result.error }, "Refresh token rotation failed");
-          return Response.json({ error: result.error }, { status: statusCode });
-        }
-
-        log.info(
-          {
-            guardianPrincipalId: result.result.guardianPrincipalId,
-          },
-          "Refresh token rotation succeeded",
-        );
-        return Response.json(result.result);
-      } catch (err) {
-        log.error({ err }, "Guardian refresh failed");
-        return Response.json(
-          { error: "Internal server error" },
-          { status: 500 },
-        );
       }
     },
 

--- a/gateway/src/http/routes/guardian-refresh.ts
+++ b/gateway/src/http/routes/guardian-refresh.ts
@@ -1,0 +1,125 @@
+import { hashToken } from "../../auth/guardian-bootstrap.js";
+import {
+  rotateCredentials,
+  rotateBrowserCredentialsByRefreshToken,
+  type RefreshErrorCode,
+} from "../../auth/guardian-refresh.js";
+import { getLogger } from "../../logger.js";
+import {
+  buildRemoteWebBrowserAuthCookies,
+  getRemoteWebRefreshCookie,
+} from "../browser-auth-cookies.js";
+
+const log = getLogger("guardian-refresh-route");
+
+function refreshFailureResponse(error: RefreshErrorCode): Response {
+  // 403 for tokens that are valid-but-forbidden (revoked, reused, or presented
+  // from the wrong device); 401 for invalid/expired tokens.
+  const forbidden: RefreshErrorCode[] = [
+    "refresh_reuse_detected",
+    "device_binding_mismatch",
+    "revoked",
+  ];
+  const statusCode = forbidden.includes(error) ? 403 : 401;
+
+  log.warn({ error }, "Refresh token rotation failed");
+  return Response.json({ error }, { status: statusCode });
+}
+
+function browserRefreshResponse(
+  result: Extract<
+    ReturnType<typeof rotateBrowserCredentialsByRefreshToken>,
+    { ok: true }
+  >["result"],
+): Response {
+  const headers = new Headers({ "Cache-Control": "no-store" });
+  for (const cookie of buildRemoteWebBrowserAuthCookies({
+    refreshToken: result.refreshToken,
+    refreshTokenExpiresAtMs: result.refreshTokenExpiresAt,
+    refreshCookiePath: result.browserRefreshCookiePath,
+  })) {
+    headers.append("Set-Cookie", cookie);
+  }
+
+  return Response.json(
+    {
+      guardianPrincipalId: result.guardianPrincipalId,
+      accessToken: result.accessToken,
+      accessTokenExpiresAt: result.accessTokenExpiresAt,
+      refreshAfter: result.refreshAfter,
+    },
+    { headers },
+  );
+}
+
+export async function handleGuardianRefresh(req: Request): Promise<Response> {
+  try {
+    const browserRefreshToken = getRemoteWebRefreshCookie(req);
+    if (browserRefreshToken) {
+      const result = rotateBrowserCredentialsByRefreshToken({
+        refreshToken: browserRefreshToken,
+      });
+      if (!result.ok) return refreshFailureResponse(result.error);
+
+      log.info(
+        {
+          guardianPrincipalId: result.result.guardianPrincipalId,
+        },
+        "Browser refresh token rotation succeeded",
+      );
+      return browserRefreshResponse(result.result);
+    }
+
+    const body = (await req.json()) as Record<string, unknown>;
+    const refreshToken =
+      typeof body.refreshToken === "string" ? body.refreshToken : "";
+    const deviceId = typeof body.deviceId === "string" ? body.deviceId : "";
+
+    if (!refreshToken) {
+      return Response.json(
+        {
+          error: {
+            code: "BAD_REQUEST",
+            message: "Missing required field: refreshToken",
+          },
+        },
+        { status: 400 },
+      );
+    }
+
+    // The refresh token is bound to the device it was issued to. Require
+    // legacy non-browser callers to prove the device so a leaked refresh token
+    // cannot be redeemed from a different device.
+    if (!deviceId) {
+      return Response.json(
+        {
+          error: {
+            code: "BAD_REQUEST",
+            message: "Missing required field: deviceId",
+          },
+        },
+        { status: 400 },
+      );
+    }
+
+    const result = rotateCredentials({
+      refreshToken,
+      hashedDeviceId: hashToken(deviceId),
+    });
+
+    if (!result.ok) {
+      return refreshFailureResponse(result.error);
+    }
+
+    log.info(
+      {
+        guardianPrincipalId: result.result.guardianPrincipalId,
+      },
+      "Refresh token rotation succeeded",
+    );
+    return Response.json(result.result);
+  } catch (err) {
+    log.error({ err }, "Guardian refresh failed");
+    return Response.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/gateway/src/http/routes/remote-web-pairing-token.ts
+++ b/gateway/src/http/routes/remote-web-pairing-token.ts
@@ -1,0 +1,122 @@
+import {
+  ensureVellumGuardianBinding,
+  getExternalAssistantId,
+  mintAndRecordBrowserTokenPair,
+} from "../../auth/guardian-bootstrap.js";
+import {
+  claimRemoteWebPairingChallengeExchange,
+  completeRemoteWebPairingChallengeExchange,
+  releaseRemoteWebPairingChallengeExchange,
+} from "../../remote-web/pairing-challenge-store.js";
+import {
+  buildRemoteWebBrowserAuthCookies,
+  remoteWebRefreshCookiePathForPublicBaseUrl,
+} from "../browser-auth-cookies.js";
+import { readLimitedBody } from "../read-limited-body.js";
+
+const MAX_TOKEN_BODY_BYTES = 512;
+const REMOTE_WEB_PLATFORM = "web";
+
+function jsonError(code: string, message: string, status: number): Response {
+  return Response.json({ error: { code, message } }, { status });
+}
+
+function invalidDeviceCodeResponse(): Response {
+  return jsonError(
+    "INVALID_OR_EXPIRED_DEVICE_CODE",
+    "invalid or expired pairing device code",
+    401,
+  );
+}
+
+export async function handleRemoteWebPairingToken(
+  req: Request,
+): Promise<Response> {
+  if (req.method !== "POST") {
+    return new Response("method not allowed", {
+      status: 405,
+      headers: { Allow: "POST" },
+    });
+  }
+
+  const rawBody = await readLimitedBody(req, MAX_TOKEN_BODY_BYTES);
+  if (rawBody.status === "too_large") {
+    return jsonError("PAYLOAD_TOO_LARGE", "request body too large", 413);
+  }
+  if (rawBody.status === "unreadable") {
+    return jsonError("BAD_REQUEST", "failed to read request body", 400);
+  }
+
+  let deviceCode: string | null = null;
+  try {
+    const body = JSON.parse(rawBody.text) as { deviceCode?: unknown };
+    deviceCode =
+      typeof body.deviceCode === "string" && body.deviceCode.trim()
+        ? body.deviceCode
+        : null;
+  } catch {
+    return jsonError("BAD_REQUEST", "invalid JSON body", 400);
+  }
+
+  if (!deviceCode) {
+    return jsonError("BAD_REQUEST", "deviceCode is required", 400);
+  }
+
+  const challenge = claimRemoteWebPairingChallengeExchange(deviceCode);
+  if (challenge.status === "pending") {
+    return Response.json(
+      {
+        status: "pending",
+        expiresAt: challenge.expiresAt,
+        intervalSeconds: challenge.intervalSeconds,
+      },
+      { status: 202, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+  if (
+    challenge.status === "invalid" ||
+    challenge.status === "expired" ||
+    challenge.status === "consumed"
+  ) {
+    return invalidDeviceCodeResponse();
+  }
+
+  const refreshCookiePath = remoteWebRefreshCookiePathForPublicBaseUrl(
+    challenge.publicBaseUrl,
+  );
+  let guardianPrincipalId: string;
+  let pair: ReturnType<typeof mintAndRecordBrowserTokenPair>;
+  try {
+    guardianPrincipalId = await ensureVellumGuardianBinding();
+    pair = mintAndRecordBrowserTokenPair({
+      guardianPrincipalId,
+      platform: REMOTE_WEB_PLATFORM,
+      browserRefreshCookiePath: refreshCookiePath,
+    });
+  } catch (err) {
+    releaseRemoteWebPairingChallengeExchange(deviceCode);
+    throw err;
+  }
+  completeRemoteWebPairingChallengeExchange(deviceCode);
+
+  const headers = new Headers({ "Cache-Control": "no-store" });
+  for (const cookie of buildRemoteWebBrowserAuthCookies({
+    refreshToken: pair.refreshToken,
+    refreshTokenExpiresAtMs: pair.refreshTokenExpiresAt,
+    refreshCookiePath,
+  })) {
+    headers.append("Set-Cookie", cookie);
+  }
+
+  return Response.json(
+    {
+      status: "approved",
+      accessToken: pair.accessToken,
+      accessTokenExpiresAt: new Date(pair.accessTokenExpiresAt).toISOString(),
+      refreshAfter: new Date(pair.refreshAfter).toISOString(),
+      guardianId: guardianPrincipalId,
+      assistantId: getExternalAssistantId(),
+    },
+    { headers },
+  );
+}

--- a/gateway/src/http/routes/remote-web-pairing-verification.ts
+++ b/gateway/src/http/routes/remote-web-pairing-verification.ts
@@ -5,13 +5,9 @@ import {
   recordRemoteWebPairingVerificationFailure,
   type RemoteWebPairingVerificationRateLimit,
 } from "../../remote-web/pairing-verification-rate-limit-store.js";
+import { readLimitedBody } from "../read-limited-body.js";
 
 const MAX_VERIFICATION_BODY_BYTES = 256;
-
-type ReadVerificationBodyResult =
-  | { status: "ok"; text: string }
-  | { status: "too_large" }
-  | { status: "unreadable" };
 
 function jsonError(code: string, message: string, status: number): Response {
   return Response.json({ error: { code, message } }, { status });
@@ -41,57 +37,6 @@ function failedAttemptResponse(clientIp: string, response: Response): Response {
   return response;
 }
 
-function concatChunks(chunks: Uint8Array[], totalBytes: number): Uint8Array {
-  const bytes = new Uint8Array(totalBytes);
-  let offset = 0;
-  for (const chunk of chunks) {
-    bytes.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return bytes;
-}
-
-async function readVerificationBody(
-  req: Request,
-): Promise<ReadVerificationBodyResult> {
-  const contentLength = req.headers.get("content-length");
-  if (
-    contentLength &&
-    Number.isFinite(Number(contentLength)) &&
-    Number(contentLength) > MAX_VERIFICATION_BODY_BYTES
-  ) {
-    return { status: "too_large" };
-  }
-
-  if (!req.body) return { status: "ok", text: "" };
-
-  const reader = req.body.getReader();
-  const chunks: Uint8Array[] = [];
-  let totalBytes = 0;
-
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      if (!value) continue;
-
-      totalBytes += value.byteLength;
-      if (totalBytes > MAX_VERIFICATION_BODY_BYTES) {
-        await reader.cancel().catch(() => {});
-        return { status: "too_large" };
-      }
-      chunks.push(value);
-    }
-  } catch {
-    return { status: "unreadable" };
-  }
-
-  return {
-    status: "ok",
-    text: new TextDecoder().decode(concatChunks(chunks, totalBytes)),
-  };
-}
-
 export async function handleVerifyRemoteWebPairingChallenge(
   req: Request,
   clientIp: string,
@@ -109,7 +54,7 @@ export async function handleVerifyRemoteWebPairingChallenge(
     return rateLimitedResponse(rateLimitedBeforeBodyRead);
   }
 
-  const rawBody = await readVerificationBody(req);
+  const rawBody = await readLimitedBody(req, MAX_VERIFICATION_BODY_BYTES);
   if (rawBody.status === "too_large") {
     return failedAttemptResponse(
       clientIp,

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -33,6 +33,8 @@ import {
   type CredentialChangeEvent,
 } from "./credential-watcher.js";
 import { createRuntimeProxyHandler } from "./http/routes/runtime-proxy.js";
+import { hasRemoteWebRefreshCookie } from "./http/browser-auth-cookies.js";
+import { handleGuardianRefresh } from "./http/routes/guardian-refresh.js";
 
 import { createTelegramWebhookHandler } from "./http/routes/telegram-webhook.js";
 import { createAudioProxyHandler } from "./http/routes/audio-proxy.js";
@@ -95,6 +97,7 @@ import {
 } from "./http/routes/devices.js";
 import { handlePair } from "./http/routes/pair.js";
 import { handleCreateRemoteWebPairingChallenge } from "./http/routes/remote-web-pairing-challenge.js";
+import { handleRemoteWebPairingToken } from "./http/routes/remote-web-pairing-token.js";
 import { handleVerifyRemoteWebPairingChallenge } from "./http/routes/remote-web-pairing-verification.js";
 import { createSlackControlPlaneProxyHandler } from "./http/routes/slack-control-plane-proxy.js";
 import { createOAuthAppsProxyHandler } from "./http/routes/oauth-apps-proxy.js";
@@ -846,6 +849,12 @@ async function main() {
       handler: (req, _params, getClientIp) =>
         handleVerifyRemoteWebPairingChallenge(req, getClientIp()),
     },
+    {
+      path: "/v1/remote-web/pairing-token",
+      method: "POST",
+      auth: "none",
+      handler: (req) => handleRemoteWebPairingToken(req),
+    },
     // ── Device management (localhost-only, auth: none; self-guards loopback) ──
     {
       path: "/v1/devices",
@@ -928,6 +937,10 @@ async function main() {
       method: "POST",
       auth: "custom",
       handler: (req, _params, getClientIp) => {
+        if (hasRemoteWebRefreshCookie(req)) {
+          return handleGuardianRefresh(req);
+        }
+
         const authHeader = req.headers.get("authorization");
         if (!authHeader || !authHeader.toLowerCase().startsWith("bearer ")) {
           authRateLimiter.recordFailure(getClientIp());
@@ -947,7 +960,7 @@ async function main() {
           );
           return Response.json({ error: "Unauthorized" }, { status: 401 });
         }
-        return channelVerificationSessionProxy.handleGuardianRefresh(req);
+        return handleGuardianRefresh(req);
       },
     },
 

--- a/gateway/src/remote-web/pairing-challenge-store.ts
+++ b/gateway/src/remote-web/pairing-challenge-store.ts
@@ -11,9 +11,11 @@ export interface PendingRemoteWebPairingChallenge {
   userCodeHash: string;
   publicBaseUrl: string;
   verificationUri: string;
-  status: "pending" | "approved";
+  status: "pending" | "approved" | "exchanging" | "consumed";
   expiresAtMs: number;
   approvedAtMs?: number;
+  exchangeStartedAtMs?: number;
+  consumedAtMs?: number;
 }
 
 export interface CreatedRemoteWebPairingChallenge {
@@ -34,7 +36,27 @@ export type ApproveRemoteWebPairingChallengeResult =
   | { status: "expired" }
   | { status: "invalid" };
 
+export type ClaimRemoteWebPairingChallengeExchangeResult =
+  | {
+      status: "approved";
+      publicBaseUrl: string;
+      verificationUri: string;
+      expiresAt: string;
+    }
+  | {
+      status: "pending";
+      expiresAt: string;
+      intervalSeconds: number;
+    }
+  | { status: "expired" }
+  | { status: "consumed" }
+  | { status: "invalid" };
+
 const challengesByUserCodeHash = new Map<
+  string,
+  PendingRemoteWebPairingChallenge
+>();
+const challengesByDeviceCodeHash = new Map<
   string,
   PendingRemoteWebPairingChallenge
 >();
@@ -63,7 +85,10 @@ function normalizeUserCode(code: string): string {
 function cleanupExpiredChallenges(): void {
   const now = nowMs();
   for (const [hash, challenge] of challengesByUserCodeHash) {
-    if (challenge.expiresAtMs <= now) challengesByUserCodeHash.delete(hash);
+    if (challenge.expiresAtMs <= now) {
+      challengesByUserCodeHash.delete(hash);
+      challengesByDeviceCodeHash.delete(challenge.deviceCodeHash);
+    }
   }
 }
 
@@ -73,6 +98,7 @@ export function createRemoteWebPairingChallenge(
   cleanupExpiredChallenges();
 
   const deviceCode = randomBytes(DEVICE_CODE_BYTES).toString("base64url");
+  const deviceCodeHash = hashSecret(deviceCode);
   let userCode = randomUserCode();
   let userCodeHash = hashSecret(normalizeUserCode(userCode));
   while (challengesByUserCodeHash.has(userCodeHash)) {
@@ -82,14 +108,16 @@ export function createRemoteWebPairingChallenge(
 
   const verificationUri = `${publicBaseUrl}/assistant/pair`;
   const expiresAtMs = nowMs() + CODE_TTL_MS;
-  challengesByUserCodeHash.set(userCodeHash, {
-    deviceCodeHash: hashSecret(deviceCode),
+  const challenge: PendingRemoteWebPairingChallenge = {
+    deviceCodeHash,
     userCodeHash,
     publicBaseUrl,
     verificationUri,
     status: "pending",
     expiresAtMs,
-  });
+  };
+  challengesByUserCodeHash.set(userCodeHash, challenge);
+  challengesByDeviceCodeHash.set(deviceCodeHash, challenge);
 
   return {
     deviceCode,
@@ -107,10 +135,14 @@ export function approveRemoteWebPairingChallenge(
   const userCodeHash = hashSecret(normalizeUserCode(userCode));
   const challenge = challengesByUserCodeHash.get(userCodeHash);
   if (!challenge) return { status: "invalid" };
+  if (challenge.status === "exchanging" || challenge.status === "consumed") {
+    return { status: "invalid" };
+  }
 
   const now = nowMs();
   if (challenge.expiresAtMs <= now) {
     challengesByUserCodeHash.delete(userCodeHash);
+    challengesByDeviceCodeHash.delete(challenge.deviceCodeHash);
     return { status: "expired" };
   }
 
@@ -123,8 +155,69 @@ export function approveRemoteWebPairingChallenge(
   };
 }
 
+export function claimRemoteWebPairingChallengeExchange(
+  deviceCode: string,
+): ClaimRemoteWebPairingChallengeExchangeResult {
+  const deviceCodeHash = hashSecret(deviceCode);
+  const challenge = challengesByDeviceCodeHash.get(deviceCodeHash);
+  if (!challenge) return { status: "invalid" };
+
+  const now = nowMs();
+  if (challenge.expiresAtMs <= now) {
+    challengesByDeviceCodeHash.delete(deviceCodeHash);
+    challengesByUserCodeHash.delete(challenge.userCodeHash);
+    return { status: "expired" };
+  }
+
+  if (challenge.status === "pending") {
+    return {
+      status: "pending",
+      expiresAt: new Date(challenge.expiresAtMs).toISOString(),
+      intervalSeconds: POLL_INTERVAL_SECONDS,
+    };
+  }
+  if (challenge.status === "exchanging") {
+    return {
+      status: "pending",
+      expiresAt: new Date(challenge.expiresAtMs).toISOString(),
+      intervalSeconds: POLL_INTERVAL_SECONDS,
+    };
+  }
+  if (challenge.status === "consumed") return { status: "consumed" };
+
+  challenge.status = "exchanging";
+  challenge.exchangeStartedAtMs = now;
+  return {
+    status: "approved",
+    publicBaseUrl: challenge.publicBaseUrl,
+    verificationUri: challenge.verificationUri,
+    expiresAt: new Date(challenge.expiresAtMs).toISOString(),
+  };
+}
+
+export function completeRemoteWebPairingChallengeExchange(
+  deviceCode: string,
+): void {
+  const challenge = challengesByDeviceCodeHash.get(hashSecret(deviceCode));
+  if (!challenge || challenge.status !== "exchanging") return;
+
+  challenge.status = "consumed";
+  challenge.consumedAtMs = nowMs();
+}
+
+export function releaseRemoteWebPairingChallengeExchange(
+  deviceCode: string,
+): void {
+  const challenge = challengesByDeviceCodeHash.get(hashSecret(deviceCode));
+  if (!challenge || challenge.status !== "exchanging") return;
+
+  challenge.status = "approved";
+  challenge.exchangeStartedAtMs = undefined;
+}
+
 export function resetRemoteWebPairingChallengesForTests(): void {
   challengesByUserCodeHash.clear();
+  challengesByDeviceCodeHash.clear();
   nowForTests = null;
 }
 


### PR DESCRIPTION
## Summary
- Add POST /v1/remote-web/pairing-token to exchange an approved RFC-style device code for browser auth material.
- Extend the remote-web pairing store so device-code exchange is single-use and reports pending versus consumed/invalid states.
- Return the access token in the response body while storing only the refresh token in an HttpOnly, Secure, SameSite=Strict cookie scoped to /v1/guardian/refresh.
- Mint remote-web browser credentials without requiring the browser to track a separate device id.
- Allow the browser refresh path to rotate credentials using only the refresh-token cookie, returning a new access token and rotated refresh cookie.
- Extract a shared bounded request-body reader used by both remote-web pairing public routes.

## Original prompt
Start the next PR in the remote-web pairing sequence after the challenge and verification PRs. This PR should keep the unit reviewable and move the gateway flow from an approved pairing challenge toward an authenticated browser session without adding CLI or SPA UI yet.

## Review focus
This intentionally adds one unauthenticated remote-web bootstrap route and a cookie-only browser refresh path. Please review the single-use device-code consume semantics, the 202 pending vs 401 invalid/expired/consumed responses, and the refresh cookie attributes. The browser receives only the access token in JSON and only the refresh token as an HttpOnly cookie; there is no browser-visible device id.