### PR TITLE
feat(telemetry): break down bash tool_executed events by top-level CLI

### DIFF
--- a/assistant/src/__tests__/tool-audit-listener.test.ts
+++ b/assistant/src/__tests__/tool-audit-listener.test.ts
@@ -435,6 +435,93 @@ describe("tool audit listener", () => {
     });
   });
 
+  test("folds the top-level CLI into the recorded name for shell tools", () => {
+    const records: ToolInvocationRecord[] = [];
+    const listener = createToolAuditListener((record) => records.push(record));
+
+    listener({
+      type: "executed",
+      toolName: "bash",
+      input: { command: "git status" },
+      workingDir: "/tmp",
+      conversationId: "conv-cli",
+      riskLevel: "low",
+      decision: "allow",
+      durationMs: 1,
+      cli: "git",
+      result: { content: "ok", isError: false },
+    });
+    listener({
+      type: "executed",
+      toolName: "host_bash",
+      input: { command: "npm i" },
+      workingDir: "/tmp",
+      conversationId: "conv-cli",
+      riskLevel: "low",
+      decision: "allow",
+      durationMs: 1,
+      cli: "npm",
+      result: { content: "ok", isError: false },
+    });
+    // null CLI (unrecognized / chain / opaque) buckets as ":other".
+    listener({
+      type: "executed",
+      toolName: "bash",
+      input: { command: "frobnicate" },
+      workingDir: "/tmp",
+      conversationId: "conv-cli",
+      riskLevel: "low",
+      decision: "allow",
+      durationMs: 1,
+      cli: null,
+      result: { content: "ok", isError: false },
+    });
+    // Errored shell commands bucket the same way.
+    listener({
+      type: "error",
+      toolName: "bash",
+      input: { command: "git push" },
+      workingDir: "/tmp",
+      conversationId: "conv-cli",
+      riskLevel: "low",
+      decision: "error",
+      durationMs: 1,
+      cli: "git",
+      errorMessage: "boom",
+      isExpected: false,
+      errorCategory: "tool_failure",
+    });
+
+    expect(records.map((r) => r.toolName)).toEqual([
+      "bash:git",
+      "host_bash:npm",
+      "bash:other",
+      "bash:git",
+    ]);
+  });
+
+  test("leaves non-shell tool names untouched even if a cli is present", () => {
+    const records: ToolInvocationRecord[] = [];
+    const listener = createToolAuditListener((record) => records.push(record));
+
+    listener({
+      type: "executed",
+      toolName: "file_read",
+      input: { path: "/tmp/a" },
+      workingDir: "/tmp",
+      conversationId: "conv-cli-noshell",
+      riskLevel: "low",
+      decision: "allow",
+      durationMs: 1,
+      // cli should be ignored for non-shell tools.
+      cli: "git",
+      result: { content: "ok", isError: false },
+    });
+
+    expect(records).toHaveLength(1);
+    expect(records[0].toolName).toBe("file_read");
+  });
+
   test("maps attribution onto executed records and leaves denied records null", () => {
     const records: ToolInvocationRecord[] = [];
     const listener = createToolAuditListener((record) => records.push(record));

--- a/assistant/src/events/tool-audit-listener.ts
+++ b/assistant/src/events/tool-audit-listener.ts
@@ -19,6 +19,23 @@ import { getLogger } from "../util/logger.js";
 const RESULT_PREVIEW_LIMIT = 1000;
 const log = getLogger("tool-audit-listener");
 
+/** Shell tools whose recorded name is broken down by top-level CLI. */
+const SHELL_TOOLS = new Set(["bash", "host_bash"]);
+
+/**
+ * For shell tools, fold the normalized top-level CLI into the recorded tool
+ * name (`bash:git`, `host_bash:other`) so telemetry can break shell usage down
+ * by CLI. Commands that aren't a single recognized CLI bucket as `:other`.
+ * Non-shell tools are returned unchanged.
+ */
+function composeToolName(
+  toolName: string,
+  cli: string | null | undefined,
+): string {
+  if (!SHELL_TOOLS.has(toolName)) return toolName;
+  return `${toolName}:${cli ?? "other"}`;
+}
+
 type InvocationRecorder = (record: ToolInvocationRecord) => void;
 
 export function createToolAuditListener(
@@ -47,7 +64,7 @@ function toInvocationRecord(
       const rawInput = stringifyToolInput(event.input);
       return {
         conversationId: event.conversationId,
-        toolName: event.toolName,
+        toolName: composeToolName(event.toolName, event.cli),
         // Inputs can carry secrets the model typed verbatim (e.g.
         // `export OPENAI_API_KEY=...` in a bash command) — redact before
         // the row reaches the audit store, like results below.
@@ -77,7 +94,7 @@ function toInvocationRecord(
       const result = `error: ${event.errorMessage}`;
       return {
         conversationId: event.conversationId,
-        toolName: event.toolName,
+        toolName: composeToolName(event.toolName, event.cli),
         input: redactToolInput(event.input, rawInput),
         result,
         decision: "error",

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -65,6 +65,12 @@ interface RiskClassificationWithMeta extends RiskClassification {
   commandCandidates?: string[];
   /** Action keys from the gateway for trust rule matching (bash tools). */
   actionKeys?: string[];
+  /**
+   * Normalized top-level CLI for bash/host_bash commands (e.g. `git`, `npm`),
+   * or `null` when the command isn't a single recognized CLI. Used for
+   * telemetry grouping.
+   */
+  cli?: string | null;
   /** Whether the command qualifies for sandbox auto-approve (bash tools). */
   sandboxAutoApprove?: boolean;
   /** Allowlist options from the gateway for generateAllowlistOptions(). */
@@ -477,6 +483,7 @@ export async function classifyRisk(
     reason: gatewayResult.reason,
     commandCandidates: gatewayResult.commandCandidates,
     actionKeys: gatewayResult.actionKeys,
+    cli: gatewayResult.cli,
     sandboxAutoApprove: gatewayResult.sandboxAutoApprove,
     allowlistOptions: gatewayResult.allowlistOptions,
     resolvedPaths: gatewayResult.resolvedPaths,

--- a/assistant/src/permissions/ipc-risk-types.ts
+++ b/assistant/src/permissions/ipc-risk-types.ts
@@ -35,6 +35,12 @@ export interface ClassificationResult {
   resolvedPaths?: string[];
   actionKeys?: string[];
   commandCandidates?: string[];
+  /**
+   * Normalized top-level CLI for bash/host_bash commands (e.g. `git`, `npm`),
+   * or `null` when the command isn't a single recognized CLI. Used for
+   * telemetry grouping. Absent for non-shell tools.
+   */
+  cli?: string | null;
   dangerousPatterns?: DangerousPattern[];
   opaqueConstructs?: boolean;
   isComplexSyntax?: boolean;

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -83,6 +83,9 @@ export class ToolExecutor {
     let permApprovalMode: string | undefined;
     let permApprovalReason: string | undefined;
     let permRiskThreshold: string | undefined;
+    // Normalized top-level CLI for bash/host_bash (e.g. `git`), used to compose
+    // the telemetry tool_name (`bash:git`). Null/undefined → "other".
+    let permCli: string | null | undefined;
     // Registered tools have `executionTarget` stamped at load time; the
     // `resolveExecutionTarget` fallback only fires for unknown tools (the
     // executor's name-aliased lookup can race against late registration).
@@ -233,6 +236,7 @@ export class ToolExecutor {
         permApprovalMode = permResult.approvalMode;
         permApprovalReason = permResult.approvalReason;
         permRiskThreshold = permResult.riskThreshold;
+        permCli = permResult.cli;
 
         if (!permResult.allowed) {
           return {
@@ -292,6 +296,7 @@ export class ToolExecutor {
           requestId: context.requestId,
           riskLevel,
           matchedTrustRuleId: permMatchedTrustRuleId,
+          cli: permCli,
           decision: "error",
           durationMs,
           errorMessage: msg,
@@ -370,6 +375,7 @@ export class ToolExecutor {
             requestId: context.requestId,
             riskLevel,
             matchedTrustRuleId: permMatchedTrustRuleId,
+            cli: permCli,
             decision: "error",
             durationMs,
             errorMessage: errorMsg,
@@ -417,6 +423,7 @@ export class ToolExecutor {
         matchedTrustRuleId: permMatchedTrustRuleId,
         approvalMode: permApprovalMode,
         approvalReason: permApprovalReason,
+        cli: permCli,
         decision,
         durationMs,
         result: safeResult,

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -263,6 +263,18 @@ export class ToolExecutor {
         // so the record shows how this execution was authorized.
         permApprovalMode = "auto";
         permApprovalReason = "grant_scoped_consumed";
+        // The permission check normally supplies the CLI telemetry dimension;
+        // resolve it directly (best-effort) so grant-consumed shell commands
+        // still bucket by CLI instead of falling back to "other".
+        try {
+          permCli = await this.permissionChecker.resolveCli(
+            name,
+            input,
+            context,
+          );
+        } catch {
+          // Telemetry only — never let classification block a granted run.
+        }
       }
 
       // Execute the tool. Tools that forward to an external resolver
@@ -501,6 +513,7 @@ export class ToolExecutor {
         requestId: context.requestId,
         riskLevel,
         matchedTrustRuleId: permMatchedTrustRuleId,
+        cli: permCli,
         decision: "error",
         durationMs,
         errorMessage: msg,

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -130,19 +130,36 @@ export class PermissionChecker {
       computePreviewDiff,
     );
 
-    if (name === "bash" || name === "host_bash") {
-      const { cli } = await classifyRisk(
-        name,
-        input,
-        context.workingDir,
-        undefined,
-        undefined,
-        context.signal,
-      );
-      if (cli != null) return { ...decision, cli };
-    }
+    const cli = await this.resolveCli(name, input, context);
+    if (cli != null) return { ...decision, cli };
 
     return decision;
+  }
+
+  /**
+   * Resolve the normalized top-level CLI for a shell tool invocation (e.g.
+   * `git`), for telemetry grouping. Returns null for non-shell tools and for
+   * commands that aren't a single recognized CLI. Served from the classifyRisk
+   * cache when the command was already classified this turn.
+   *
+   * Exposed so callers that bypass the full permission check (e.g. the
+   * executor's grant-consumed path) can still attach the CLI dimension.
+   */
+  async resolveCli(
+    name: string,
+    input: Record<string, unknown>,
+    context: ToolContext,
+  ): Promise<string | null> {
+    if (name !== "bash" && name !== "host_bash") return null;
+    const { cli } = await classifyRisk(
+      name,
+      input,
+      context.workingDir,
+      undefined,
+      undefined,
+      context.signal,
+    );
+    return cli ?? null;
   }
 
   private async runPermissionCheck(

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -130,7 +130,15 @@ export class PermissionChecker {
       computePreviewDiff,
     );
 
-    const cli = await this.resolveCli(name, input, context);
+    // Best-effort telemetry dimension — a classification failure here (e.g. a
+    // cache miss that re-hits the gateway and fails) must never override an
+    // authorization decision that has already been made.
+    let cli: string | null = null;
+    try {
+      cli = await this.resolveCli(name, input, context);
+    } catch {
+      // Ignore — telemetry only.
+    }
     if (cli != null) return { ...decision, cli };
 
     return decision;

--- a/assistant/src/tools/permission-checker.ts
+++ b/assistant/src/tools/permission-checker.ts
@@ -30,6 +30,8 @@ export type PermissionDecision =
       decision: string;
       riskLevel: string;
       wasPrompted?: boolean;
+      /** Normalized top-level CLI for bash/host_bash (e.g. `git`), or null/absent when not a single recognized CLI. Telemetry only. */
+      cli?: string | null;
       /** ID of the trust rule that matched this invocation (if any). Always set when a rule matched, even for non-classifier tools where riskMeta is absent. */
       matchedTrustRuleId?: string;
       /** Risk metadata from the classifier assessment cache (when available). */
@@ -54,6 +56,8 @@ export type PermissionDecision =
       decision: string;
       riskLevel: string;
       content: string;
+      /** Normalized top-level CLI for bash/host_bash (e.g. `git`), or null/absent when not a single recognized CLI. Telemetry only. */
+      cli?: string | null;
       /** ID of the trust rule that matched this invocation (if any). Always set when a rule matched, even for non-classifier tools where riskMeta is absent. */
       matchedTrustRuleId?: string;
       /** Risk metadata from the classifier assessment cache (when available). */
@@ -74,6 +78,19 @@ export type PermissionDecision =
       riskThreshold?: RiskThreshold;
     };
 
+type ComputePreviewDiff = (
+  toolName: string,
+  input: Record<string, unknown>,
+  workingDir: string,
+) =>
+  | {
+      filePath: string;
+      oldContent: string;
+      newContent: string;
+      isNewFile: boolean;
+    }
+  | undefined;
+
 export class PermissionChecker {
   private prompter: PermissionPrompter;
 
@@ -86,6 +103,11 @@ export class PermissionChecker {
    * prompting for a tool invocation. Returns whether the tool is allowed
    * to execute, along with the decision string and risk level for lifecycle
    * event reporting.
+   *
+   * Thin wrapper over {@link runPermissionCheck} that attaches the normalized
+   * top-level CLI (for bash/host_bash) to the decision for telemetry. The
+   * `classifyRisk` call is served from cache after `runPermissionCheck`, so the
+   * extra read is effectively free.
    */
   async checkPermission(
     name: string,
@@ -95,18 +117,43 @@ export class PermissionChecker {
     executionTarget: ExecutionTarget,
     emitLifecycleEvent: (event: ToolLifecycleEvent) => void,
     startTime: number,
-    computePreviewDiff: (
-      toolName: string,
-      input: Record<string, unknown>,
-      workingDir: string,
-    ) =>
-      | {
-          filePath: string;
-          oldContent: string;
-          newContent: string;
-          isNewFile: boolean;
-        }
-      | undefined,
+    computePreviewDiff: ComputePreviewDiff,
+  ): Promise<PermissionDecision> {
+    const decision = await this.runPermissionCheck(
+      name,
+      input,
+      tool,
+      context,
+      executionTarget,
+      emitLifecycleEvent,
+      startTime,
+      computePreviewDiff,
+    );
+
+    if (name === "bash" || name === "host_bash") {
+      const { cli } = await classifyRisk(
+        name,
+        input,
+        context.workingDir,
+        undefined,
+        undefined,
+        context.signal,
+      );
+      if (cli != null) return { ...decision, cli };
+    }
+
+    return decision;
+  }
+
+  private async runPermissionCheck(
+    name: string,
+    input: Record<string, unknown>,
+    tool: Tool,
+    context: ToolContext,
+    executionTarget: ExecutionTarget,
+    emitLifecycleEvent: (event: ToolLifecycleEvent) => void,
+    startTime: number,
+    computePreviewDiff: ComputePreviewDiff,
   ): Promise<PermissionDecision> {
     const { level: risk, reason: riskReason } = await classifyRisk(
       name,

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -210,6 +210,13 @@ export interface ToolExecutedEvent extends ExecutorTelemetryStamp {
   approvalMode?: string;
   /** Why the approval decision was reached (stable enum). Copied from PermissionDecision for analytics consumers. */
   approvalReason?: string;
+  /**
+   * Normalized top-level CLI for bash/host_bash invocations (e.g. `git`), or
+   * null/absent when the command isn't a single recognized CLI. The audit
+   * listener composes this into the recorded tool name (`bash:git`,
+   * `bash:other`) for telemetry grouping.
+   */
+  cli?: string | null;
   decision: string;
   durationMs: number;
   result: ToolExecutionResult;
@@ -220,7 +227,14 @@ export interface ToolExecutedEvent extends ExecutorTelemetryStamp {
  * fields stamped centrally by the executor's `emitLifecycleEvent`.
  */
 export interface ToolExecutionErrorEvent
-  extends ContractsToolExecutionErrorEvent, ExecutorTelemetryStamp {}
+  extends ContractsToolExecutionErrorEvent, ExecutorTelemetryStamp {
+  /**
+   * Normalized top-level CLI for bash/host_bash invocations (e.g. `git`), or
+   * null/absent when the command isn't a single recognized CLI. Lets errored
+   * shell commands bucket by CLI in telemetry, same as successful ones.
+   */
+  cli?: string | null;
+}
 
 export type ToolLifecycleEvent =
   | ToolExecutionStartEvent

--- a/gateway/src/ipc/risk-classification-handlers.ts
+++ b/gateway/src/ipc/risk-classification-handlers.ts
@@ -15,6 +15,7 @@ import {
   bashRiskClassifier,
   getWrappedProgramWithArgs,
 } from "../risk/bash-risk-classifier.js";
+import { deriveCliNameFromAnalysis } from "../risk/cli-name.js";
 import { DEFAULT_COMMAND_REGISTRY } from "../risk/command-registry/index.js";
 import { generateDirectoryScopeOptions } from "../risk/directory-scope.js";
 import {
@@ -93,6 +94,12 @@ interface ClassificationResult {
   }>;
   actionKeys?: string[];
   commandCandidates?: string[];
+  /**
+   * Normalized top-level CLI for bash/host_bash commands (e.g. `git`, `npm`),
+   * or `null` when the command isn't a single recognized CLI. Used by the
+   * assistant for telemetry grouping. Absent for non-shell tools.
+   */
+  cli?: string | null;
   dangerousPatterns?: Array<{
     type: string;
     description: string;
@@ -219,6 +226,10 @@ export async function handleClassifyRisk(
         candidateSet.add(key);
       }
       const commandCandidates = [...candidateSet];
+
+      // Normalized top-level CLI for telemetry grouping (null → "other").
+      // Reuses the analysis/actionResult already computed above.
+      const cli = deriveCliNameFromAnalysis(analysis, actionResult);
 
       // Compute sandbox auto-approve for "bash" tool only
       let sandboxAutoApprove = false;
@@ -397,6 +408,7 @@ export async function handleClassifyRisk(
         allowlistOptions: assessment.allowlistOptions,
         actionKeys,
         commandCandidates,
+        cli,
         dangerousPatterns: analysis.dangerousPatterns,
         opaqueConstructs: analysis.hasOpaqueConstructs,
         isComplexSyntax,

--- a/gateway/src/risk/cli-name.test.ts
+++ b/gateway/src/risk/cli-name.test.ts
@@ -15,9 +15,18 @@ describe("deriveCliName", () => {
     expect(await deriveCliName("rm -rf build")).toBe("rm");
   });
 
-  test("lowercases and path-strips the program", async () => {
+  test("path-strips the program", async () => {
     expect(await deriveCliName("/usr/bin/git status")).toBe("git");
-    expect(await deriveCliName("GIT status")).toBe("git");
+    expect(await deriveCliName("/opt/homebrew/bin/npm install")).toBe("npm");
+  });
+
+  test("preserves case-sensitive registry keys", async () => {
+    // `R` and `Rscript` are registered with that exact casing — matching is
+    // case-sensitive so they resolve rather than missing as "other".
+    expect(await deriveCliName("Rscript script.R")).toBe("Rscript");
+    expect(await deriveCliName("R --version")).toBe("R");
+    // An unregistered casing variant is not coerced into a known key.
+    expect(await deriveCliName("GIT status")).toBeNull();
   });
 
   test("unwraps wrappers to the program that actually runs", async () => {

--- a/gateway/src/risk/cli-name.test.ts
+++ b/gateway/src/risk/cli-name.test.ts
@@ -33,6 +33,14 @@ describe("deriveCliName", () => {
     expect(await deriveCliName("sudo git push")).toBe("git");
     expect(await deriveCliName("env FOO=bar npm run build")).toBe("npm");
     expect(await deriveCliName("sudo sudo rm foo")).toBe("rm");
+    expect(await deriveCliName("timeout 5 git status")).toBe("git");
+  });
+
+  test("unwraps path-qualified wrappers", async () => {
+    // The wrapper itself is path-qualified — its name must be stripped before
+    // the wrapped-program extraction so env assignments / durations are skipped.
+    expect(await deriveCliName("/usr/bin/env FOO=bar npm install")).toBe("npm");
+    expect(await deriveCliName("/usr/bin/timeout 5 git status")).toBe("git");
   });
 
   test("ignores setup prefixes like cd/export", async () => {

--- a/gateway/src/risk/cli-name.test.ts
+++ b/gateway/src/risk/cli-name.test.ts
@@ -1,0 +1,58 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+
+import { deriveCliName } from "./cli-name.js";
+import { parse } from "./shell-parser.js";
+
+describe("deriveCliName", () => {
+  beforeAll(async () => {
+    // Warm up the parser (loads WASM).
+    await parse("echo warmup");
+  });
+
+  test("returns the canonical registry key for a known single CLI", async () => {
+    expect(await deriveCliName("git status")).toBe("git");
+    expect(await deriveCliName("npm install")).toBe("npm");
+    expect(await deriveCliName("rm -rf build")).toBe("rm");
+  });
+
+  test("lowercases and path-strips the program", async () => {
+    expect(await deriveCliName("/usr/bin/git status")).toBe("git");
+    expect(await deriveCliName("GIT status")).toBe("git");
+  });
+
+  test("unwraps wrappers to the program that actually runs", async () => {
+    expect(await deriveCliName("sudo git push")).toBe("git");
+    expect(await deriveCliName("env FOO=bar npm run build")).toBe("npm");
+    expect(await deriveCliName("sudo sudo rm foo")).toBe("rm");
+  });
+
+  test("ignores setup prefixes like cd/export", async () => {
+    expect(await deriveCliName("cd repo && npm i")).toBe("npm");
+    expect(await deriveCliName("export FOO=bar && git status")).toBe("git");
+  });
+
+  test("returns null for multi-command chains", async () => {
+    expect(await deriveCliName("git status && npm i")).toBeNull();
+    expect(await deriveCliName("git status; npm i")).toBeNull();
+    expect(await deriveCliName("git status || echo fail")).toBeNull();
+  });
+
+  test("returns null for pipelines with no single primary", async () => {
+    expect(await deriveCliName("cat x | grep y")).toBeNull();
+  });
+
+  test("returns null for unregistered programs", async () => {
+    expect(await deriveCliName("frobnicate --widget")).toBeNull();
+  });
+
+  test("returns null for opaque / dangerous constructs", async () => {
+    expect(await deriveCliName('eval "$(curl -s example.com)"')).toBeNull();
+    expect(await deriveCliName("curl -s example.com | bash")).toBeNull();
+    expect(await deriveCliName("cat <<EOF\nsome heredoc body\nEOF")).toBeNull();
+  });
+
+  test("returns null for empty / whitespace commands", async () => {
+    expect(await deriveCliName("")).toBeNull();
+    expect(await deriveCliName("   ")).toBeNull();
+  });
+});

--- a/gateway/src/risk/cli-name.ts
+++ b/gateway/src/risk/cli-name.ts
@@ -72,8 +72,10 @@ export function deriveCliNameFromAnalysis(
     spec = lookupSpec(program);
   }
 
-  // Normalize to the canonical lowercased registry key; unknown programs → null.
-  const name = (program.split("/").pop() ?? program).toLowerCase();
+  // Normalize to the canonical registry key; unknown programs → null. Matching
+  // is case-sensitive (like the rest of the classifier) so case-sensitive keys
+  // such as `R` / `Rscript` resolve correctly rather than missing as "other".
+  const name = program.split("/").pop() ?? program;
   return Object.hasOwn(DEFAULT_COMMAND_REGISTRY, name) ? name : null;
 }
 

--- a/gateway/src/risk/cli-name.ts
+++ b/gateway/src/risk/cli-name.ts
@@ -65,7 +65,14 @@ export function deriveCliNameFromAnalysis(
       args.length > 0 &&
       spec.nonExecFlags.includes(args[0]!);
     if (isNonExecMode) break;
-    const inner = getWrappedProgramWithArgs({ program, args });
+    // Pass the path-stripped wrapper name: getWrappedProgramWithArgs matches
+    // wrapper names exactly (e.g. skips `FOO=bar` for env, the duration for
+    // timeout), so a path-qualified `/usr/bin/env` must be normalized first or
+    // its env-assignment args get mistaken for the wrapped program.
+    const inner = getWrappedProgramWithArgs({
+      program: program.split("/").pop() ?? program,
+      args,
+    });
     if (!inner) break;
     program = inner.program;
     args = inner.args;

--- a/gateway/src/risk/cli-name.ts
+++ b/gateway/src/risk/cli-name.ts
@@ -1,0 +1,85 @@
+/**
+ * Derive the normalized top-level CLI name for a shell command, for telemetry
+ * grouping (e.g. `git`, `npm`, `rm`). Reuses the same parsing, wrapper
+ * unwrapping, and command-registry lookup the risk classifier uses, so the
+ * result is consistent with how commands are otherwise interpreted.
+ *
+ * Returns the canonical lowercased registry key when the command resolves to a
+ * single recognized CLI, or `null` otherwise — unregistered programs,
+ * multi-command chains (`;`, `&&`, `||`, `&`), pipelines with no single
+ * primary, and opaque/dangerous constructs (eval, heredocs, …). Callers bucket
+ * `null` as `"other"`.
+ */
+import { getWrappedProgramWithArgs } from "./bash-risk-classifier.js";
+import { DEFAULT_COMMAND_REGISTRY } from "./command-registry/index.js";
+import type { CommandRiskSpec } from "./risk-types.js";
+import {
+  analyzeShellCommand,
+  deriveShellActionKeys,
+  type ActionKeyResult,
+  type ShellIdentityAnalysis,
+} from "./shell-identity.js";
+
+const MAX_WRAPPER_DEPTH = 10;
+
+function lookupSpec(program: string): CommandRiskSpec | undefined {
+  const name = program.split("/").pop() ?? program;
+  return Object.hasOwn(DEFAULT_COMMAND_REGISTRY, name)
+    ? DEFAULT_COMMAND_REGISTRY[name as keyof typeof DEFAULT_COMMAND_REGISTRY]
+    : undefined;
+}
+
+/**
+ * Pure variant for callers (e.g. the risk classifier) that have already run
+ * {@link analyzeShellCommand} and {@link deriveShellActionKeys}, so we don't
+ * re-parse/re-analyze the command on the permission-check hot path.
+ */
+export function deriveCliNameFromAnalysis(
+  analysis: ShellIdentityAnalysis,
+  actionResult: ActionKeyResult,
+): string | null {
+  // Opaque or dangerous constructs (eval, heredocs, variable-expansion pipes,
+  // pipe-to-shell, …) make the primary program unreliable — don't attribute a
+  // CLI.
+  if (analysis.hasOpaqueConstructs) return null;
+  if (analysis.dangerousPatterns.length > 0) return null;
+
+  // Only single-action commands (optionally behind setup prefixes like `cd`)
+  // have an unambiguous top-level CLI. Pipelines and multi-command chains do
+  // not — `deriveShellActionKeys` reports those as non-simple.
+  if (!actionResult.isSimpleAction || !actionResult.primarySegment) {
+    return null;
+  }
+
+  // Unwrap wrappers (sudo/env/timeout/…) to the program that actually runs,
+  // mirroring the unwrapping in the risk classifier. Stop on non-exec modes
+  // (e.g. `command -v rm`) so the wrapper itself stays the program.
+  let program = actionResult.primarySegment.program;
+  let args = actionResult.primarySegment.args;
+  let spec = lookupSpec(program);
+  let depth = 0;
+  while (spec?.isWrapper && depth < MAX_WRAPPER_DEPTH) {
+    depth++;
+    const isNonExecMode =
+      spec.nonExecFlags !== undefined &&
+      args.length > 0 &&
+      spec.nonExecFlags.includes(args[0]!);
+    if (isNonExecMode) break;
+    const inner = getWrappedProgramWithArgs({ program, args });
+    if (!inner) break;
+    program = inner.program;
+    args = inner.args;
+    spec = lookupSpec(program);
+  }
+
+  // Normalize to the canonical lowercased registry key; unknown programs → null.
+  const name = (program.split("/").pop() ?? program).toLowerCase();
+  return Object.hasOwn(DEFAULT_COMMAND_REGISTRY, name) ? name : null;
+}
+
+/** Convenience wrapper that parses and analyzes the command from scratch. */
+export async function deriveCliName(command: string): Promise<string | null> {
+  const analysis = await analyzeShellCommand(command);
+  const actionResult = deriveShellActionKeys(analysis);
+  return deriveCliNameFromAnalysis(analysis, actionResult);
+}


### PR DESCRIPTION
## Summary
- Tool-use telemetry now distinguishes which CLI a `bash`/`host_bash` call ran. The recorded `tool_name` is overloaded as `<tool>:<cli>` (e.g. `bash:git`, `host_bash:npm`); commands that aren't a single recognized CLI bucket as `<tool>:other`.
- Deliberately avoids a new `tool_invocations` column, a telemetry-event field, and any platform/OpenAPI schema change — the dimension rides the existing `tool_name` string from record → query → emit.
- The CLI is derived in the gateway from the command the risk classifier already parses (path-stripped, `sudo`/`env`/`timeout` unwrapped, normalized to the canonical command-registry key), threaded back through the `classify_risk` `ClassificationResult`, and composed into the recorded name in the audit listener. Pipelines, multi-command chains, and opaque constructs (eval/heredocs) → `other`.
- New gateway derivation reuses the analysis already computed during classification (no extra parse on the permission-check hot path). Applies to both successful and errored shell invocations.

## Original prompt
We recently added tool-use telemetry, and `bash` is by far the top tool. The ask was to break the bash usage down by top-level CLI for telemetry, reusing the existing trust-rule / shell-parsing tooling that already classifies commands. After weighing a dedicated dimension vs. overloading `tool_name`, we chose to overload `tool_name` as `bash:<cli>` specifically to avoid platform-side schema changes, accepting that the top-line bare-`bash` metric fragments. Normalization to a bounded set of known CLIs (registry key, else `other`) was a hard requirement.

## Test plan
- New `gateway/src/risk/cli-name.test.ts`: known CLIs, path-strip + lowercase, wrapper unwrap (`sudo git push`→`git`), setup prefixes (`cd repo && npm i`→`npm`), chains/pipelines/unregistered/opaque → null, empty input.
- Extended `tool-audit-listener.test.ts`: composes `bash:git` / `host_bash:npm` / `bash:other`, errored shell commands bucket too, non-shell tool names untouched.
- typecheck clean (gateway + assistant); executor (131), permission (139), and risk-handler (56) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)