### PR TITLE
[codex] Block edge-forwarded loopback auth fallback

### DIFF
--- a/gateway/src/__tests__/edge-auth.test.ts
+++ b/gateway/src/__tests__/edge-auth.test.ts
@@ -194,6 +194,17 @@ describe("requireEdgeAuth — JWT mode", () => {
     expect(mockValidateEdgeToken).not.toHaveBeenCalled();
   });
 
+  test("rejects edge-forwarded loopback requests when Authorization header is absent", async () => {
+    const { requireEdgeAuth } = makeMiddleware();
+    const res = await requireEdgeAuth(
+      makeReq({ "x-vellum-edge-forwarded": "1" }),
+      makeLoopbackServer(),
+    );
+    expect(res?.status).toBe(401);
+    expect(mockValidateEdgeToken).not.toHaveBeenCalled();
+    expect(loopbackFallbackCountTracker.snapshot()).toEqual([]);
+  });
+
   test("a loopback fallback is counted by (guard, path, failureKind)", async () => {
     const { requireEdgeAuth } = makeMiddleware();
     await requireEdgeAuth(makeReq(), makeLoopbackServer());
@@ -331,6 +342,18 @@ describe("requireEdgeAuthWithScope — JWT mode", () => {
     );
     expect(res).toBeNull();
     expect(mockValidateEdgeToken).not.toHaveBeenCalled();
+  });
+
+  test("rejects edge-forwarded loopback requests when scoped Authorization is absent", async () => {
+    const { requireEdgeAuthWithScope } = makeMiddleware();
+    const res = await requireEdgeAuthWithScope(
+      makeReq({ "x-vellum-edge-forwarded": "1" }),
+      "settings.write",
+      makeLoopbackServer(),
+    );
+    expect(res?.status).toBe(401);
+    expect(mockValidateEdgeToken).not.toHaveBeenCalled();
+    expect(loopbackFallbackCountTracker.snapshot()).toEqual([]);
   });
 
   test("403 when token's scope_profile lacks the required scope", async () => {

--- a/gateway/src/__tests__/edge-guardian-auth.test.ts
+++ b/gateway/src/__tests__/edge-guardian-auth.test.ts
@@ -181,6 +181,18 @@ describe("requireEdgeGuardianAuth — actor principal mode", () => {
     expect(mockFindVellumGuardian).not.toHaveBeenCalled();
   });
 
+  test("rejects edge-forwarded loopback requests when Authorization header is absent", async () => {
+    const { requireEdgeGuardianAuth } = makeMiddleware();
+    const res = await requireEdgeGuardianAuth(
+      makeReq({ "x-vellum-edge-forwarded": "1" }),
+      makeLoopbackServer(),
+    );
+    expect(res?.status).toBe(401);
+    expect(mockValidateEdgeToken).not.toHaveBeenCalled();
+    expect(mockFindVellumGuardian).not.toHaveBeenCalled();
+    expect(loopbackFallbackCountTracker.snapshot()).toEqual([]);
+  });
+
   test("invalid bearer token falls back to loopback", async () => {
     mockValidateEdgeToken = mock(() => ({ ok: false, reason: "expired" }));
     const { requireEdgeGuardianAuth } = makeMiddleware();

--- a/gateway/src/http/middleware/auth.ts
+++ b/gateway/src/http/middleware/auth.ts
@@ -13,6 +13,7 @@ import { credentialKey } from "../../credential-key.js";
 import { readCredential } from "../../credential-reader.js";
 import { getLogger } from "../../logger.js";
 import { isLoopbackPeer } from "../../util/is-loopback-address.js";
+import { requestArrivedViaEdgeProxy } from "../edge-forwarded-header.js";
 
 const log = getLogger("auth");
 
@@ -373,6 +374,8 @@ export function createAuthMiddleware(
     guard: string,
     extra?: Record<string, unknown>,
   ): boolean {
+    if (requestArrivedViaEdgeProxy(req)) return false;
+
     // When a trusted reverse proxy is declared, judge loopback-ness by the
     // real client IP (first X-Forwarded-For entry) rather than the raw socket
     // peer. A same-host proxy/tunnel always connects over 127.0.0.1, so without


### PR DESCRIPTION
## Summary

- Reject nginx edge-forwarded requests before allowing the legacy loopback auth fallback.
- Add regression coverage for plain edge auth, scoped edge auth, and edge-guardian auth.

## Root Cause

The nginx ingress already sets `X-Vellum-Edge-Forwarded`, but the shared gateway auth fallback only checked whether the TCP peer was loopback. Remote tunnel traffic forwarded by same-host nginx still has a loopback peer, so missing or invalid edge auth could incorrectly receive the legacy local fallback.

Codex finding: https://chatgpt.com/codex/cloud/security/findings/f9253854de4881919b28693699831bb4

## Validation

- `cd gateway && bun test src/__tests__/edge-auth.test.ts src/__tests__/edge-guardian-auth.test.ts`
- `cd gateway && bunx tsc --noEmit`
- `cd cli && bun test src/__tests__/nginx-ingress.test.ts`
- `git diff --check`
