### PR TITLE
polish(web): refine signup page video, header, and copy

### DIFF
--- a/apps/web/src/domains/account/components/signup-screen.tsx
+++ b/apps/web/src/domains/account/components/signup-screen.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router";
 
 import { AppleLogo } from "@/components/icons/apple-logo";
 import { GoogleLogo } from "@/components/icons/google-logo";
-import { PersonalPageShell } from "@/domains/account/components/personal-page-shell";
+import { SignupShell } from "@/domains/account/components/signup-shell";
 import { RotatingWord } from "@/domains/account/components/rotating-word";
 import {
   PROVIDER_ID,
@@ -51,7 +51,7 @@ const BUTTONS: ProviderButton[] = [
   { icon: EmailIcon, label: "Continue with Email" },
 ];
 
-interface PersonalPageSignupScreenProps {
+interface SignupScreenProps {
   returnTo: string | null;
 }
 
@@ -61,9 +61,9 @@ interface PersonalPageSignupScreenProps {
  * to the real WorkOS `startAuthFlow` (`intent: "signup"`); the post-OAuth
  * name/occupation step lives in `ProviderSignupPage`.
  */
-export function PersonalPageSignupScreen({
+export function SignupScreen({
   returnTo,
-}: PersonalPageSignupScreenProps) {
+}: SignupScreenProps) {
   const [error, setError] = useState<string | null>(null);
   const callbackUrl = buildProviderCallbackUrl(returnTo, {
     authIntent: "signup",
@@ -92,9 +92,9 @@ export function PersonalPageSignupScreen({
   };
 
   return (
-    <PersonalPageShell>
+    <SignupShell>
       <h1 className="signup__title">
-        Meet your own
+        Meet your new
         <br />
         <RotatingWord words={HEADLINE_WORDS} />
       </h1>
@@ -131,6 +131,6 @@ export function PersonalPageSignupScreen({
         <AppleLogo size={16} />
         Download for macOS
       </a>
-    </PersonalPageShell>
+    </SignupShell>
   );
 }

--- a/apps/web/src/domains/account/components/signup-shell.tsx
+++ b/apps/web/src/domains/account/components/signup-shell.tsx
@@ -3,7 +3,7 @@ import { type ReactNode } from "react";
 
 import { publicAsset } from "@/utils/public-asset";
 
-import "@/domains/account/components/personal-page-signup.css";
+import "@/domains/account/components/signup.css";
 
 /**
  * Two-column sign-up shell: brand + form on the left, a full-bleed looping
@@ -11,7 +11,7 @@ import "@/domains/account/components/personal-page-signup.css";
  * screen and the post-OAuth name/occupation step so the experience stays
  * visually consistent across the flow.
  */
-export function PersonalPageShell({ children }: { children: ReactNode }) {
+export function SignupShell({ children }: { children: ReactNode }) {
   return (
     // Force the dark palette regardless of the app theme — the demo always sits
     // on a dark surface. `data-theme="dark"` re-declares the design tokens for

--- a/apps/web/src/domains/account/components/signup.css
+++ b/apps/web/src/domains/account/components/signup.css
@@ -279,11 +279,21 @@
   min-width: 0;
   position: relative;
   overflow: hidden;
-  padding: 40px 40px 40px 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /* Reserve the top header band so the video always sits below the centered
+     logo — prevents the two from overlapping when the window gets short. */
+  padding: 88px 40px 40px 0;
 }
 .signup__video {
   width: 100%;
   height: 100%;
+  /* Cap the rendered box so the 1920x1080 source isn't upscaled past native
+     (avoids pixelation on retina). At 960x540 CSS px the source maps ~1:1 to
+     device pixels on a 2x display. 16:9 box keeps cover from cropping. */
+  max-width: 960px;
+  max-height: 540px;
   object-fit: cover;
   border-radius: var(--radius-xl);
 }

--- a/apps/web/src/domains/account/pages/provider-signup-page.tsx
+++ b/apps/web/src/domains/account/pages/provider-signup-page.tsx
@@ -7,7 +7,7 @@ import {
   AccountInput,
 } from "@/components/account/account-form";
 import { AccountShell } from "@/components/account/account-shell";
-import { PersonalPageShell } from "@/domains/account/components/personal-page-shell";
+import { SignupShell } from "@/domains/account/components/signup-shell";
 import {
   getProviderSignup,
   isConflict,
@@ -154,7 +154,7 @@ export function ProviderSignupPage() {
   if (email && username) {
     const canSubmit = occupation.trim().length > 0 && !isSubmitting;
     return (
-      <PersonalPageShell>
+      <SignupShell>
         <form onSubmit={onPersonalPageSubmit} className="signup-details__thread">
           <h2 className="signup-details__heading">
             Almost there,
@@ -217,7 +217,7 @@ export function ProviderSignupPage() {
             </button>
           </div>
         </form>
-      </PersonalPageShell>
+      </SignupShell>
     );
   }
 

--- a/apps/web/src/domains/account/pages/signup-page.tsx
+++ b/apps/web/src/domains/account/pages/signup-page.tsx
@@ -1,6 +1,6 @@
 import { useSearchParams } from "react-router";
 
-import { PersonalPageSignupScreen } from "@/domains/account/components/personal-page-signup-screen";
+import { SignupScreen } from "@/domains/account/components/signup-screen";
 
 /**
  * Signup entry. Renders the branded sign-up screen for everyone: a rotating
@@ -12,5 +12,5 @@ export function SignupPage() {
   const [searchParams] = useSearchParams();
   const returnTo = searchParams.get("returnTo");
 
-  return <PersonalPageSignupScreen returnTo={returnTo} />;
+  return <SignupScreen returnTo={returnTo} />;
 }


### PR DESCRIPTION
## What

Visual + naming polish on the universal signup page (`apps/web` account domain).

- **Video sizing** — cap the looping signup video at `960x540` and center it, so the 1920x1080 source isn't upscaled past native on retina displays. Fixes the pixelated/soft look at full-bleed size.
- **Header overlap** — reserve a top band on the video column (`padding-top: 88px`) so the video always sits below the centered Vellum logo. Previously the video covered the logo (and a `z-index` band-aid left the logo sitting *on top* of the video) when the window got short/narrow. Now they can't overlap at any size.
- **Rename** — `personal-page-*` signup files → `signup-*`, since this is now the signup screen everyone sees, not a personal-page-specific surface (`PersonalPageShell` → `SignupShell`, `PersonalPageSignupScreen` → `SignupScreen`, `personal-page-signup.css` → `signup.css`). Renames done via `git mv`; all importers updated.
- **Copy** — headline above the social buttons: "Meet your own" → "Meet your new".

## Notes

- No behavior/logic changes — styling, file names, and copy only.
- Renames touch `signup-page.tsx` and `provider-signup-page.tsx` (both consumers of the shell).
- Lint + typecheck pass via pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)