### PR TITLE
Update status banner colors

### DIFF
--- a/apps/web/src/components/status-banner.stories.tsx
+++ b/apps/web/src/components/status-banner.stories.tsx
@@ -34,7 +34,7 @@ const action = (
 
 export const Web: Story = {
   args: {
-    tone: "warning",
+    tone: "info",
     placement: "web",
     title: "Assistant is upgrading.",
     icon: <Info aria-hidden="true" />,
@@ -51,7 +51,7 @@ export const Web: Story = {
 
 export const Electron: Story = {
   args: {
-    tone: "warning",
+    tone: "info",
     placement: "electron",
     title: "Assistant is upgrading.",
     icon: <Info aria-hidden="true" />,
@@ -68,7 +68,7 @@ export const Electron: Story = {
 
 export const ElectronWorking: Story = {
   args: {
-    tone: "warning",
+    tone: "info",
     placement: "electron",
     title: "Assistant is upgrading.",
     icon: <LoaderCircle className="animate-spin" aria-hidden="true" />,

--- a/apps/web/src/components/status-banner.test.tsx
+++ b/apps/web/src/components/status-banner.test.tsx
@@ -213,6 +213,8 @@ describe("StatusBanner", () => {
 
     expect(html).toContain("Assistant is restarting");
     expect(html).toContain('data-tone="warning"');
+    expect(html).toContain("bg-[var(--system-mid-weak)]");
+    expect(html).toContain("text-[color:var(--system-mid-strong)]");
   });
 
   test("uses the full-width web banner sizing by default", () => {
@@ -267,9 +269,47 @@ describe("StatusBanner", () => {
 
       expect(html).toContain(title);
       expect(html).toContain('data-tone="error"');
+      expect(html).toContain("bg-[var(--system-negative-weak)]");
+      expect(html).toContain("lucide-triangle-alert");
       expect(html).toContain("Go to Doctor");
       expect(html).toContain("/assistant/settings/debug?tab=doctor");
     }
+  });
+
+  test("uses blue for platform activity states from the status guide", () => {
+    for (const state of [
+      "upgrading_assistant_version",
+      "resizing_machine",
+      "resizing_storage",
+      "initializing",
+      "provisioning",
+    ] as const) {
+      operationalStatusQueryMock = {
+        data: { state },
+        isError: false,
+      };
+
+      const html = renderToStaticMarkup(<StatusBanner />);
+
+      expect(html).toContain('data-tone="info"');
+      expect(html).toContain("bg-[var(--system-info-weak)]");
+      expect(html).toContain("text-[color:var(--system-info-strong)]");
+      expect(html).toContain("animate-spin");
+    }
+  });
+
+  test("uses a blue pulsing dot for waking", () => {
+    operationalStatusQueryMock = {
+      data: { state: "waking" },
+      isError: false,
+    };
+
+    const html = renderToStaticMarkup(<StatusBanner />);
+
+    expect(html).toContain("Assistant is waking");
+    expect(html).toContain('data-tone="info"');
+    expect(html).toContain("busy-indicator");
+    expect(html).not.toContain("animate-spin");
   });
 
   test("does not render Doctor action for local assistant operational errors", () => {
@@ -310,6 +350,7 @@ describe("StatusBanner", () => {
 
     expect(sleepingHtml).toContain("Assistant is sleeping");
     expect(sleepingHtml).toContain('data-tone="neutral"');
+    expect(sleepingHtml).toContain("bg-[var(--surface-active)]");
 
     operationalStatusQueryMock = {
       data: { state: "maintenance_mode" },
@@ -319,7 +360,7 @@ describe("StatusBanner", () => {
     const maintenanceHtml = renderToStaticMarkup(<StatusBanner />);
 
     expect(maintenanceHtml).toContain("Assistant is in maintenance mode");
-    expect(maintenanceHtml).toContain('data-tone="info"');
+    expect(maintenanceHtml).toContain('data-tone="warning"');
     expect(maintenanceHtml).toContain("Resume Assistant");
   });
 
@@ -333,7 +374,7 @@ describe("StatusBanner", () => {
     const html = renderToStaticMarkup(<StatusBanner />);
 
     expect(html).toContain("Assistant is in maintenance mode");
-    expect(html).toContain('data-tone="info"');
+    expect(html).toContain('data-tone="warning"');
     expect(html).toContain("Resume Assistant");
   });
 
@@ -380,6 +421,7 @@ describe("StatusBanner", () => {
       expect(html).toContain("Your assistant is asleep");
       expect(html).toContain("Wake up");
       expect(html).toContain('data-tone="neutral"');
+      expect(html).toContain("bg-[var(--surface-active)]");
       expect(html).toContain("items-center");
       expect(html).toContain("[&amp;_[data-slot=button]]:uppercase");
       expect(html).not.toContain(
@@ -469,7 +511,8 @@ describe("StatusBanner", () => {
 
       expect(html).toContain("Your assistant is waking up");
       expect(html).not.toContain("Wake up");
-      expect(html).toContain('data-tone="neutral"');
+      expect(html).toContain('data-tone="info"');
+      expect(html).toContain("busy-indicator");
     });
 
     test("renders a warning banner when the local assistant is unhealthy", () => {
@@ -489,6 +532,7 @@ describe("StatusBanner", () => {
       const html = renderToStaticMarkup(<StatusBanner />);
 
       expect(html).toContain("offline");
+      expect(html).toContain('data-tone="error"');
       expect(html).not.toContain("asleep");
     });
 
@@ -536,6 +580,7 @@ describe("StatusBanner", () => {
       const html = renderToStaticMarkup(<StatusBanner />);
 
       expect(html).toContain("offline");
+      expect(html).toContain('data-tone="error"');
       expect(html).not.toContain("crash looping");
     });
   });
@@ -559,6 +604,7 @@ describe("StatusBanner", () => {
       const html = renderToStaticMarkup(<StatusBanner />);
 
       expect(html).toContain("offline");
+      expect(html).toContain('data-tone="error"');
       expect(html).not.toContain("crash looping");
     });
 
@@ -574,6 +620,8 @@ describe("StatusBanner", () => {
 
       expect(html).toContain("Trying to reach Vellum");
       expect(html).toContain("Retry now");
+      expect(html).toContain('data-tone="error"');
+      expect(html).toContain("lucide-cloud-off");
       expect(html).not.toContain("crash looping");
     });
 

--- a/apps/web/src/components/status-banner.tsx
+++ b/apps/web/src/components/status-banner.tsx
@@ -5,7 +5,7 @@ import {
   Info,
   LoaderCircle,
   Moon,
-  OctagonX,
+  TriangleAlert,
   WifiOff,
   Wrench,
   type LucideIcon,
@@ -58,6 +58,7 @@ export type StatusBannerPlacement = "web" | "electron";
 
 interface StatusToneClasses {
   container: string;
+  content: string;
   icon: string;
   action: string;
   DefaultIcon: LucideIcon | null;
@@ -65,33 +66,38 @@ interface StatusToneClasses {
 
 const STATUS_TONE_CLASSES: Record<NoticeTone, StatusToneClasses> = {
   info: {
-    container: "bg-[var(--surface-overlay)]",
-    icon: "text-[color:var(--content-secondary)]",
-    action: "[--status-banner-action-color:var(--primary-base)]",
+    container: "bg-[var(--system-info-weak)]",
+    content: "text-[color:var(--system-info-strong)]",
+    icon: "text-[color:var(--system-info-strong)]",
+    action: "[--status-banner-action-color:var(--system-info-strong)]",
     DefaultIcon: Info,
   },
   success: {
     container: "bg-[var(--system-positive-weak)]",
+    content: "text-[color:var(--system-positive-strong)]",
     icon: "text-[color:var(--system-positive-strong)]",
     action: "[--status-banner-action-color:var(--system-positive-strong)]",
     DefaultIcon: CircleCheck,
   },
   warning: {
     container: "bg-[var(--system-mid-weak)]",
+    content: "text-[color:var(--system-mid-strong)]",
     icon: "text-[color:var(--system-mid-strong)]",
     action: "[--status-banner-action-color:var(--system-mid-strong)]",
     DefaultIcon: CircleAlert,
   },
   error: {
     container: "bg-[var(--system-negative-weak)]",
+    content: "text-[color:var(--system-negative-strong)]",
     icon: "text-[color:var(--system-negative-strong)]",
     action: "[--status-banner-action-color:var(--system-negative-strong)]",
-    DefaultIcon: OctagonX,
+    DefaultIcon: TriangleAlert,
   },
   neutral: {
-    container: "bg-[var(--surface-overlay)]",
+    container: "bg-[var(--surface-active)]",
+    content: "text-[color:var(--content-secondary)]",
     icon: "text-[color:var(--content-secondary)]",
-    action: "[--status-banner-action-color:var(--primary-base)]",
+    action: "[--status-banner-action-color:var(--content-secondary)]",
     DefaultIcon: null,
   },
 };
@@ -165,7 +171,8 @@ export function StatusBannerNotice({
         <div className="min-w-0">
           <div
             className={cn(
-              "truncate text-[color:var(--content-emphasised)]",
+              "truncate",
+              toneClasses.content,
               titleClassName,
             )}
           >
@@ -182,7 +189,7 @@ export function StatusBannerNotice({
       {actions ? (
         <div
           className={cn(
-            "flex shrink-0 items-center border-l border-[color-mix(in_srgb,var(--content-default)_14%,transparent)] text-label-medium-default",
+            "flex shrink-0 items-center border-l border-[color-mix(in_srgb,var(--status-banner-action-color)_22%,transparent)] text-label-medium-default",
             "text-[color:var(--status-banner-action-color)]",
             toneClasses.action,
             placement === "web"
@@ -225,10 +232,23 @@ const OPERATIONAL_STATUS_TITLES: Record<AssistantOperationalState, string> = {
 
 function maintenanceModeBannerConfig(): BannerConfig {
   return {
-    tone: "info",
+    tone: "warning",
     title: OPERATIONAL_STATUS_TITLES.maintenance_mode,
     icon: <Wrench className="h-4 w-4" aria-hidden="true" />,
   };
+}
+
+function spinnerIcon(): ReactNode {
+  return <LoaderCircle className="h-4 w-4 animate-spin" aria-hidden="true" />;
+}
+
+function wakingDotIcon(): ReactNode {
+  return (
+    <span
+      className="busy-indicator inline-block size-2 rounded-full bg-current"
+      aria-hidden="true"
+    />
+  );
 }
 
 function operationalStatusBannerConfig(
@@ -254,13 +274,35 @@ function operationalStatusBannerConfig(
       };
     case "maintenance_mode":
       return maintenanceModeBannerConfig();
+    case "upgrading_assistant_version":
+    case "resizing_machine":
+    case "resizing_storage":
+    case "initializing":
+    case "provisioning":
+      return {
+        tone: "info",
+        title: OPERATIONAL_STATUS_TITLES[status.state],
+        icon: spinnerIcon(),
+      };
+    case "waking":
+      return {
+        tone: "info",
+        title: OPERATIONAL_STATUS_TITLES[status.state],
+        icon: wakingDotIcon(),
+      };
+    case "restarting":
+    case "restoring_backup":
+    case "retiring":
+      return {
+        tone: "warning",
+        title: OPERATIONAL_STATUS_TITLES[status.state],
+        icon: spinnerIcon(),
+      };
     default:
       return {
         tone: "warning",
         title: OPERATIONAL_STATUS_TITLES[status.state],
-        icon: (
-          <LoaderCircle className="h-4 w-4 animate-spin" aria-hidden="true" />
-        ),
+        icon: spinnerIcon(),
       };
   }
 }
@@ -281,11 +323,9 @@ function localHealthBannerConfig(
       };
     case "starting":
       return {
-        tone: "neutral",
+        tone: "info",
         title: "Your assistant is waking up",
-        icon: (
-          <LoaderCircle className="h-4 w-4 animate-spin" aria-hidden="true" />
-        ),
+        icon: wakingDotIcon(),
       };
     case "crashed":
       return {
@@ -518,7 +558,7 @@ function useAssistantBannerConfig(): BannerConfig | null {
 
   if (electron && connectivityState === "device-offline") {
     return {
-      tone: "warning",
+      tone: "error",
       title: "You're offline",
       icon: <WifiOff className="h-4 w-4" aria-hidden="true" />,
     };
@@ -526,7 +566,7 @@ function useAssistantBannerConfig(): BannerConfig | null {
 
   if (!electron && isNative && !nativeConnected) {
     return {
-      tone: "warning",
+      tone: "error",
       title: "You're offline",
       icon: <WifiOff className="h-4 w-4" aria-hidden="true" />,
     };
@@ -566,7 +606,7 @@ function useAssistantBannerConfig(): BannerConfig | null {
 
   if (electron && connectivityState === "backend-unreachable") {
     return {
-      tone: "warning",
+      tone: "error",
       title: "Trying to reach Vellum…",
       icon: <CloudOff className="h-4 w-4" aria-hidden="true" />,
       actions: (


### PR DESCRIPTION
## Summary
- Map status banner tones to existing theme semantic colors for blue, yellow, red, green, and gray states.
- Route assistant and network states to the requested color/icon combinations, including blue waking dots, yellow maintenance/restart states, and red blocking/network failures.
- Refresh StatusBanner Storybook examples and tests to cover the new color routing.

## Original prompt
The user asked for the centralized Electron/web status banner colors to match Figma notification guidance while using existing theme colors and existing icons. The guide defines yellow for noteworthy progress, blue for general in-progress states, red for blocking failures/network loss, gray for neutral/asleep states, and green for positive states, with specific state-to-icon mappings for top-level assistant warnings.