### PR TITLE
ci(dev-release): remove legacy Swift macOS DMG build

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -22,7 +22,7 @@ jobs:
   # cancel the run when nothing has landed since the last *successful* dev
   # release. "Successful" is keyed off the register-release job conclusion —
   # the same anchor notify-dev-release uses for its changelog — so a run that
-  # registered a real release but failed in a later job (e.g. build-macos)
+  # registered a real release but failed in a later job (e.g. build-electron)
   # still counts as the last release. Manual workflow_dispatch runs always
   # proceed: the operator explicitly asked for a build.
   #
@@ -1213,7 +1213,7 @@ jobs:
   # Runs on every completed (non-cancelled) run. The dev release is considered
   # successful when the register-release job succeeded — the same signal the
   # changelog uses to anchor its diff — so a failure in a downstream job (e.g.
-  # build-macos) still posts the success changelog.
+  # build-electron) still posts the success changelog.
   #
   # On success: posts a single summary message. The top-level blocks carry the
   # header, the "*N commits* since the last dev release" line, and the action
@@ -1304,8 +1304,8 @@ jobs:
 
           # Find the SHA of the last actually-released dev build to diff against.
           # We key off the register-release JOB conclusion, not the overall run
-          # conclusion: register-release runs before downstream jobs (build-macos,
-          # upload-sparkle, …), so a later failure leaves a real release on a run
+          # conclusion: register-release runs before downstream jobs (build-electron,
+          # …), so a later failure leaves a real release on a run
           # whose conclusion is "failure". Keying off the run would then diff from
           # an older SHA and re-announce already-released commits. Walk recent
           # completed runs newest-first and pick the first whose register-release
@@ -1532,303 +1532,6 @@ jobs:
           name: dev-chrome-extension
           path: clients/chrome-extension/vellum-browser-relay.zip
           retention-days: 30
-
-  # ── macOS DMG ──────────────────────────────────────────────────────────
-
-  build-macos:
-    needs: [compute-version, ci-assistant, ci-gateway, ci-credential-executor]
-    runs-on: macos-15
-    timeout-minutes: 45
-    defaults:
-      run:
-        working-directory: clients/macos
-    env:
-      KEYCHAIN_NAME: build.keychain
-      KEYCHAIN_PASSWORD: temporary-ci-password
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Select Xcode 26.2
-        run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
-
-      - name: Import code-signing certificate
-        env:
-          CERT_P12: ${{ secrets.DEVID_CERTIFICATE_P12 }}
-          CERT_PASSWORD: ${{ secrets.DEVID_CERTIFICATE_PASSWORD }}
-        run: |
-          KEYCHAIN_PATH="$HOME/Library/Keychains/$KEYCHAIN_NAME-db"
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_NAME"
-          security set-keychain-settings -lut 3600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          echo "$CERT_P12" | base64 -D > /tmp/certificate.p12
-          security import /tmp/certificate.p12 \
-            -k "$KEYCHAIN_PATH" -P "$CERT_PASSWORD" \
-            -T /usr/bin/codesign -T /usr/bin/security
-          rm /tmp/certificate.p12
-          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
-          security default-keychain -s "$KEYCHAIN_PATH"
-          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
-
-      - name: Verify signing identity
-        run: |
-          security find-identity -v -p codesigning | grep -q "Developer ID Application" \
-            || { echo "::error::Developer ID Application identity not found"; exit 1; }
-
-      - name: Install Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: '1.3.11'
-
-      - name: Install nested package dependencies
-        working-directory: .
-        run: |
-          for dir in packages/*/ skills/*/; do
-            [ -f "${dir}/package.json" ] || continue
-            (cd "${dir}" && bun install --frozen-lockfile 2>/dev/null || bun install)
-          done
-
-      - name: Build binaries
-        run: |
-          DISPLAY_VERSION="${{ needs.compute-version.outputs.version }}" \
-          COMMIT_SHA="${{ github.sha }}" \
-          ./build.sh binaries
-
-      - name: Compute build version
-        id: version
-        run: |
-          BUILD_VERSION=$(date -u +%Y%m%d%H%M)
-          echo "build_version=$BUILD_VERSION" >> "$GITHUB_OUTPUT"
-          echo "Build version: $BUILD_VERSION"
-
-      - name: Build macOS app
-        timeout-minutes: 20
-        run: |
-          set -o pipefail
-          SKIP_BUN_REBUILD=1 \
-          BUNDLE_DISPLAY_NAME="Vellum Dev" \
-          DISPLAY_VERSION="${{ needs.compute-version.outputs.version }}" \
-          BUILD_VERSION="${{ steps.version.outputs.build_version }}" \
-          COMMIT_SHA="${{ github.sha }}" \
-          VELLUM_ENVIRONMENT=dev \
-          SU_PUBLIC_ED_KEY="${{ secrets.SPARKLE_ED_PUBLIC_KEY }}" \
-          SU_FEED_URL="https://storage.googleapis.com/vellum-nonprod-sparkle/dev/appcast.xml" \
-          SIGN_IDENTITY="Developer ID Application" \
-          RELEASE_ARCH_FLAGS="--arch arm64" \
-          ./build.sh release 2>&1 | while IFS= read -r line; do
-            echo "[$(date -u '+%H:%M:%S')] $line"
-          done
-
-      - name: Free disk space
-        run: |
-          rm -rf .build daemon-bin assistant-bin cli-bin gateway-bin ces-bin
-          rm -rf ../../assistant/node_modules ../../cli/node_modules ../../gateway/node_modules ../../credential-executor/node_modules
-          rm -rf ~/Library/Developer/Xcode/DerivedData 2>/dev/null || true
-          df -h .
-
-      - name: Cache Homebrew create-dmg
-        id: cache-create-dmg
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            /usr/local/Cellar/create-dmg
-            /opt/homebrew/Cellar/create-dmg
-          key: create-dmg-v1-${{ runner.os }}-${{ runner.arch }}
-
-      - name: Install create-dmg
-        if: steps.cache-create-dmg.outputs.cache-hit != 'true'
-        run: brew install create-dmg
-
-      - name: Link create-dmg
-        if: steps.cache-create-dmg.outputs.cache-hit == 'true'
-        run: brew link create-dmg 2>/dev/null || true
-
-      - name: Create DMG
-        run: |
-          DMG_STAGING="build/dmg-staging"
-          mkdir -p "$DMG_STAGING" build
-          cp -R "dist/Vellum Dev.app" "$DMG_STAGING/"
-          ln -s /Applications "$DMG_STAGING/Applications"
-
-          create-dmg \
-            --volname "Vellum Dev" \
-            --background "dmg/dmg-background@2x.png" \
-            --window-pos 200 120 \
-            --window-size 660 400 \
-            --icon-size 128 \
-            --text-size 10 \
-            --icon "Vellum Dev.app" 175 190 \
-            --icon "Applications" 530 190 \
-            --hide-extension "Vellum Dev.app" \
-            --no-internet-enable \
-            "build/vellum-assistant-dev.dmg" \
-            "$DMG_STAGING/" \
-          || {
-            EXIT_CODE=$?
-            if [ $EXIT_CODE -eq 2 ] && [ -f "build/vellum-assistant-dev.dmg" ]; then
-              echo "create-dmg exited with warning (code 2), but DMG was created"
-            else
-              exit $EXIT_CODE
-            fi
-          }
-          ls -lh "build/vellum-assistant-dev.dmg"
-
-      - name: Sign DMG
-        run: |
-          codesign --sign "Developer ID Application" --timestamp "build/vellum-assistant-dev.dmg"
-          codesign --verify --verbose "build/vellum-assistant-dev.dmg"
-
-      - name: Notarize DMG
-        env:
-          ASC_KEY_P8: ${{ secrets.ASC_KEY_P8 }}
-          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
-          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
-        run: |
-          mkdir -p ~/.private_keys
-          echo "$ASC_KEY_P8" > ~/.private_keys/AuthKey_${ASC_KEY_ID}.p8
-
-          echo "Submitting DMG for notarization..."
-          NOTARIZE_OUTPUT=$(xcrun notarytool submit "build/vellum-assistant-dev.dmg" \
-            --key ~/.private_keys/AuthKey_${ASC_KEY_ID}.p8 \
-            --key-id "$ASC_KEY_ID" \
-            --issuer "$ASC_ISSUER_ID" \
-            --wait \
-            --timeout 30m \
-            2>&1) || NOTARIZE_FAILED=true
-
-          echo "$NOTARIZE_OUTPUT"
-
-          SUBMISSION_ID=$(echo "$NOTARIZE_OUTPUT" | grep -oE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | head -1)
-
-          if [ "$NOTARIZE_FAILED" = "true" ] || echo "$NOTARIZE_OUTPUT" | grep -q "status: Invalid"; then
-            echo "::error::Notarization failed"
-            if [ -n "$SUBMISSION_ID" ]; then
-              xcrun notarytool log "$SUBMISSION_ID" \
-                --key ~/.private_keys/AuthKey_${ASC_KEY_ID}.p8 \
-                --key-id "$ASC_KEY_ID" \
-                --issuer "$ASC_ISSUER_ID" \
-                || echo "::warning::Could not fetch notarization log"
-            fi
-            exit 1
-          fi
-
-      - name: Staple notarization ticket
-        run: |
-          MAX_ATTEMPTS=10
-          WAIT_SECS=30
-          for i in $(seq 1 $MAX_ATTEMPTS); do
-            STAPLE_OUTPUT=$(xcrun stapler staple "build/vellum-assistant-dev.dmg" 2>&1)
-            STAPLE_EXIT=$?
-            if [ $STAPLE_EXIT -eq 0 ]; then
-              echo "Stapling succeeded on attempt $i"
-              break
-            fi
-            echo "::warning::Stapling attempt $i/$MAX_ATTEMPTS failed"
-            if [ "$i" -eq "$MAX_ATTEMPTS" ]; then
-              echo "::error::Stapling failed after $MAX_ATTEMPTS attempts"
-              exit 1
-            fi
-            sleep $WAIT_SECS
-            WAIT_SECS=$((WAIT_SECS + 15))
-          done
-          xcrun stapler validate "build/vellum-assistant-dev.dmg"
-
-      - name: Build ZIP for Sparkle auto-update
-        run: |
-          cd dist
-          ditto -c -k --keepParent "Vellum Dev.app" vellum-assistant-dev.zip
-          echo "Sparkle ZIP created:"
-          ls -lh vellum-assistant-dev.zip
-
-      - name: Cache Homebrew Sparkle
-        id: cache-sparkle
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            /usr/local/Caskroom/sparkle
-            /opt/homebrew/Caskroom/sparkle
-          key: sparkle-v1-${{ runner.os }}-${{ runner.arch }}
-
-      - name: Install Sparkle sign_update tool
-        run: |
-          if [ "${{ steps.cache-sparkle.outputs.cache-hit }}" != "true" ]; then
-            brew install sparkle
-          fi
-          SPARKLE_BIN=$(find /opt/homebrew/Caskroom/sparkle -name sign_update -type f 2>/dev/null | head -1)
-          if [ -z "$SPARKLE_BIN" ]; then
-            SPARKLE_BIN=$(find /usr/local/Caskroom/sparkle -name sign_update -type f 2>/dev/null | head -1)
-          fi
-          echo "Found sign_update at: $SPARKLE_BIN"
-          echo "$(dirname "$SPARKLE_BIN")" >> "$GITHUB_PATH"
-
-      - name: Generate appcast.xml
-        env:
-          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
-        run: |
-          VERSION="${{ needs.compute-version.outputs.version }}"
-          BUILD_VERSION="${{ steps.version.outputs.build_version }}"
-
-          ED_KEY_FILE=$(mktemp)
-          echo "$SPARKLE_ED_PRIVATE_KEY" > "$ED_KEY_FILE"
-          SIGN_OUTPUT=$(sign_update dist/vellum-assistant-dev.zip --ed-key-file "$ED_KEY_FILE") || {
-            echo "sign_update failed with exit code $?"
-            rm -f "$ED_KEY_FILE"
-            exit 1
-          }
-          rm -f "$ED_KEY_FILE"
-          echo "sign_update output: ${SIGN_OUTPUT:0:40}..."
-          SIGNATURE=$(echo "$SIGN_OUTPUT" | sed -n 's/.*sparkle:edSignature="\([^"]*\)".*/\1/p')
-          SIZE=$(echo "$SIGN_OUTPUT" | sed -n 's/.*length="\([^"]*\)".*/\1/p')
-          if [ -z "$SIGNATURE" ]; then
-            echo "ERROR: Failed to parse edSignature from sign_update output"
-            exit 1
-          fi
-          if [ -z "$SIZE" ]; then
-            SIZE=$(stat -f%z dist/vellum-assistant-dev.zip)
-          fi
-
-          REPO="${{ github.repository }}"
-          cat > dist/appcast.xml << EOF
-          <?xml version="1.0" encoding="utf-8"?>
-          <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
-            <channel>
-              <title>Vellum Dev</title>
-              <item>
-                <title>${VERSION}</title>
-                <sparkle:version>${BUILD_VERSION}</sparkle:version>
-                <sparkle:shortVersionString>${VERSION}</sparkle:shortVersionString>
-                <enclosure
-                  url="https://storage.googleapis.com/vellum-nonprod-sparkle/dev/vellum-assistant-dev.zip"
-                  sparkle:edSignature="${SIGNATURE}"
-                  length="${SIZE}"
-                  type="application/octet-stream" />
-              </item>
-            </channel>
-          </rss>
-          EOF
-          echo "Dev appcast generated (version=$VERSION, build=$BUILD_VERSION)"
-
-      - name: Upload DMG
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: dev-dmg
-          path: clients/macos/build/vellum-assistant-dev.dmg
-          retention-days: 30
-
-      - name: Upload Sparkle artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: dev-sparkle
-          path: |
-            clients/macos/dist/vellum-assistant-dev.zip
-            clients/macos/dist/appcast.xml
-          retention-days: 30
-
-      - name: Cleanup keychain
-        if: always()
-        run: |
-          KEYCHAIN_PATH="$HOME/Library/Keychains/$KEYCHAIN_NAME-db"
-          security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
 
   # ── Electron DMG ──────────────────────────────────────────────────────
 
@@ -2414,63 +2117,10 @@ jobs:
           fi
           npm publish --tag dev --access public --no-provenance
 
-  # ── Sparkle Rolling Release ────────────────────────────────────────────
-  # ── Upload Sparkle artifacts to GCS ───────────────────────────────────
-  # Push appcast.xml + ZIP to the public vellum-nonprod-sparkle GCS bucket.
-  # Dev macOS builds have SUFeedURL pointing here, so Sparkle auto-updates
-  # work without creating GitHub releases.
-
-  upload-sparkle:
-    needs: [compute-version, build-macos]
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    environment: dev
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Download Sparkle artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: dev-sparkle
-          path: sparkle-artifacts
-
-      - name: Download DMG
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: dev-dmg
-          path: dmg-artifacts
-
-      - name: Authenticate to GCP
-        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
-        with:
-          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
-
-      - name: Upload Sparkle artifacts to GCS
-        run: |
-          VERSION="${{ needs.compute-version.outputs.version }}"
-          BUCKET="vellum-nonprod-sparkle"
-
-          ZIP=$(find sparkle-artifacts -name "*.zip" -type f | head -1)
-          APPCAST=$(find sparkle-artifacts -name "appcast.xml" -type f | head -1)
-          DMG=$(find dmg-artifacts -name "*.dmg" -type f | head -1)
-
-          if [ -z "$ZIP" ] || [ -z "$APPCAST" ]; then
-            echo "::warning::Sparkle artifacts not found, skipping GCS upload"
-            exit 0
-          fi
-
-          gcloud storage cp "$ZIP" "gs://${BUCKET}/dev/vellum-assistant-dev.zip"
-          gcloud storage cp "$APPCAST" "gs://${BUCKET}/dev/appcast.xml"
-          [ -n "$DMG" ] && gcloud storage cp "$DMG" "gs://${BUCKET}/dev/vellum-assistant-dev.dmg"
-
-          echo "Uploaded Sparkle artifacts to gs://${BUCKET}/dev/ (version=${VERSION})"
-
   # ── iOS release (same-repo reusable workflow) ────────────────────────
 
   release-ios:
-    needs: [compute-version, register-release, upload-sparkle, build-chrome-extension]
+    needs: [compute-version, register-release, build-chrome-extension]
     uses: ./.github/workflows/release-ios.yaml
     with:
       environment: dev


### PR DESCRIPTION
## Summary
- Remove the legacy Swift macOS dev DMG build/sign/notarize/zip/appcast logic from dev-release.yaml.
- Preserve the Electron dev-release path and shared release logic.

Part of plan: remove-legacy-swift-macos.md (PR 2 of 13)