### PR TITLE
refactor(assistant): drop SwiftPM catalog mirror from sync scripts and parity tests

### DIFF
--- a/assistant/scripts/sync-llm-catalog.ts
+++ b/assistant/scripts/sync-llm-catalog.ts
@@ -3,19 +3,13 @@
  * Generate `llm-provider-catalog.json` from the canonical
  * `PROVIDER_CATALOG` in `assistant/src/providers/model-catalog.ts`.
  *
- * The JSON file is the client-facing catalog bundled into native clients
- * (macOS, web). Keeping it generated — rather than hand-mirrored — eliminates
- * the recurring "I edited model-catalog.ts and forgot the JSON" failure mode
- * that the parity test only catches after push.
+ * The JSON file is the client-facing catalog. Keeping it generated — rather
+ * than hand-mirrored — eliminates the recurring "I edited model-catalog.ts and
+ * forgot the JSON" failure mode that the parity test only catches after push.
  *
- * Two byte-identical copies are written:
+ * Output:
  *   - `meta/llm-provider-catalog.json` — primary checked-in artifact, read
- *      by web codegen (§D) and any non-Swift consumer.
- *   - `clients/shared/Resources/llm-provider-catalog.json` — SwiftPM resource
- *      bundled into `VellumAssistantShared`. SwiftPM cannot reach files
- *      outside a target's source directory, so this mirror is necessary;
- *      both files are produced by the same generator and asserted equal by
- *      the parity test, making drift impossible.
+ *      by web codegen (§D) and any downstream consumer.
  *
  * The projection drops daemon-only fields (today: `apiKeyUrl`, which clients
  * read from `credentialsGuide.url` instead) and pins field order so the
@@ -37,10 +31,7 @@ import {
 } from "../src/providers/model-catalog.js";
 
 const ROOT = resolve(import.meta.dir, "../..");
-const OUTPUT_PATHS = [
-  join(ROOT, "meta/llm-provider-catalog.json"),
-  join(ROOT, "clients/shared/Resources/llm-provider-catalog.json"),
-] as const;
+const OUTPUT_PATHS = [join(ROOT, "meta/llm-provider-catalog.json")] as const;
 
 /**
  * Bumped when the *shape* of the client catalog JSON changes in a way native

--- a/assistant/scripts/sync-web-search-catalog.ts
+++ b/assistant/scripts/sync-web-search-catalog.ts
@@ -4,7 +4,7 @@
  * canonical `SEARCH_PROVIDER_CATALOG` in
  * `assistant/src/providers/search-provider-catalog.ts`.
  *
- * Two byte-identical copies are written:
+ * Output:
  *   - `meta/web-search-provider-catalog.json` — primary checked-in artifact,
  *      consumed by:
  *        - `cli/src/__tests__/search-provider-env-var-parity.test.ts`
@@ -12,13 +12,8 @@
  *        - Downstream `vellum-assistant-platform/web/src/lib/generated/
  *          web-search-provider-catalog.json` (manually sync'd today; the
  *          scheduled sync workflow is a planned follow-up).
- *   - `clients/shared/Resources/web-search-provider-catalog.json` — SwiftPM
- *      resource bundled into `VellumAssistantShared`. SwiftPM cannot reach
- *      files outside a target's source directory, so this mirror is
- *      necessary; both files are produced by the same generator and
- *      asserted equal by the parity test, making drift impossible.
  *
- * Companion to `sync-llm-catalog.ts`; same dual-write pattern.
+ * Companion to `sync-llm-catalog.ts`.
  *
  * Usage:
  *   cd assistant && bun run scripts/sync-web-search-catalog.ts
@@ -37,7 +32,6 @@ import {
 const ROOT = resolve(import.meta.dir, "../..");
 const OUTPUT_PATHS = [
   join(ROOT, "meta/web-search-provider-catalog.json"),
-  join(ROOT, "clients/shared/Resources/web-search-provider-catalog.json"),
 ] as const;
 
 /**
@@ -108,9 +102,7 @@ async function main(): Promise<void> {
         continue;
       }
       if (existing !== next) {
-        console.error(
-          `${rel} is stale. Run: bun run sync:web-search-catalog`,
-        );
+        console.error(`${rel} is stale. Run: bun run sync:web-search-catalog`);
         anyStale = true;
         continue;
       }

--- a/assistant/src/__tests__/llm-catalog-parity.test.ts
+++ b/assistant/src/__tests__/llm-catalog-parity.test.ts
@@ -30,13 +30,6 @@ function getRepoRoot(): string {
 }
 
 const META_JSON_PATH = join(getRepoRoot(), "meta", "llm-provider-catalog.json");
-const SWIFTPM_MIRROR_PATH = join(
-  getRepoRoot(),
-  "clients",
-  "shared",
-  "Resources",
-  "llm-provider-catalog.json",
-);
 
 interface ClientCatalogCredentialsGuide {
   description: string;
@@ -456,20 +449,5 @@ describe("LLM catalog parity: daemon vs client", () => {
       longContextPricingThresholdTokens: 200000,
       longContextMode: "native-model",
     });
-  });
-
-  // -----------------------------------------------------------------------
-  // Mirror byte-equality
-  // -----------------------------------------------------------------------
-
-  test("SwiftPM mirror is byte-identical to meta/ copy", () => {
-    // `sync-llm-catalog.ts` writes both files from the same serializer; this
-    // guard catches any case where one copy is regenerated without the other.
-    // Byte equality is required because SwiftPM bundles the resource verbatim
-    // into `VellumAssistantShared` while the meta/ JSON is consumed as a
-    // cross-package artifact (web codegen, etc.).
-    const metaBytes = readFileSync(META_JSON_PATH);
-    const swiftPmBytes = readFileSync(SWIFTPM_MIRROR_PATH);
-    expect(swiftPmBytes.equals(metaBytes)).toBe(true);
   });
 });

--- a/assistant/src/__tests__/web-search-catalog-parity.test.ts
+++ b/assistant/src/__tests__/web-search-catalog-parity.test.ts
@@ -8,20 +8,15 @@ import {
 } from "../providers/search-provider-catalog.js";
 
 /**
- * Parity guard: daemon TS catalog vs the two generated JSON copies.
+ * Parity guard: daemon TS catalog vs the generated JSON copy.
  *
  * The daemon maintains its canonical search-provider catalog in
  * `assistant/src/providers/search-provider-catalog.ts`.
- * `assistant/scripts/sync-web-search-catalog.ts` writes two byte-identical
- * artifacts:
- *   - `meta/web-search-provider-catalog.json` — primary cross-package artifact.
- *   - `clients/shared/Resources/web-search-provider-catalog.json` — SwiftPM
- *     resource bundled into `VellumAssistantShared` (Swift cannot reach
- *     files outside a target's source directory).
+ * `assistant/scripts/sync-web-search-catalog.ts` writes
+ * `meta/web-search-provider-catalog.json` — the primary cross-package artifact.
  *
  * These tests enforce structural equality between the TS catalog and the
- * meta/ copy, plus byte equality between the meta/ copy and the SwiftPM
- * mirror. CI fails when any of the three drift.
+ * meta/ copy. CI fails when they drift.
  */
 
 interface JsonCatalogEntry {
@@ -46,11 +41,6 @@ const META_JSON_PATH = join(
   "..",
   "meta/web-search-provider-catalog.json",
 );
-const SWIFTPM_MIRROR_PATH = join(
-  process.cwd(),
-  "..",
-  "clients/shared/Resources/web-search-provider-catalog.json",
-);
 
 function loadJsonCatalog(): JsonCatalog {
   return JSON.parse(readFileSync(META_JSON_PATH, "utf-8"));
@@ -73,7 +63,8 @@ function entryToPlain(
   if (entry.apiKeyPrefix !== undefined) out.apiKeyPrefix = entry.apiKeyPrefix;
   if (entry.envVar !== undefined) out.envVar = entry.envVar;
   if (entry.secretKey !== undefined) out.secretKey = entry.secretKey;
-  if (entry.fallbackOrder !== undefined) out.fallbackOrder = entry.fallbackOrder;
+  if (entry.fallbackOrder !== undefined)
+    out.fallbackOrder = entry.fallbackOrder;
   if (entry.privacyPolicyUrl !== undefined) {
     out.privacyPolicyUrl = entry.privacyPolicyUrl;
   }
@@ -94,15 +85,5 @@ describe("web-search catalog parity (TS canonical vs meta/ JSON)", () => {
     expect(json.providers.map((p) => p.id)).toEqual(
       SEARCH_PROVIDER_CATALOG.map((p) => p.id),
     );
-  });
-
-  test("SwiftPM mirror is byte-identical to meta/ copy", () => {
-    // The generator writes both files from the same serializer; this guard
-    // catches any case where one copy is regenerated without the other.
-    // Byte equality is required because SwiftPM bundles the resource verbatim
-    // and the meta/ JSON is consumed as a cross-package artifact.
-    const metaBytes = readFileSync(META_JSON_PATH);
-    const swiftPmBytes = readFileSync(SWIFTPM_MIRROR_PATH);
-    expect(swiftPmBytes.equals(metaBytes)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- sync-llm-catalog.ts and sync-web-search-catalog.ts now write only the meta/ copy (drop the clients/shared SwiftPM mirror).
- Remove the SwiftPM byte-equality parity tests; keep all daemon-vs-meta parity tests.

Part of plan: remove-legacy-swift-macos.md (PR 4 of 13)