### PR TITLE
refactor(profiles): reconcile managed LLM profiles from code on every boot

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -692,6 +692,70 @@ describe("loadConfig startup behavior", () => {
     expect(raw.llm.activeProfile).toBe("balanced");
   });
 
+  test("on-platform managed profiles reconcile to the code template on every boot", () => {
+    // Headline behavior: on-platform installs now reconcile managed profile
+    // content from the code template on every boot (same as off-platform), so
+    // model/config updates ship in a release without a workspace migration.
+    process.env.IS_PLATFORM = "true";
+
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: {
+            source: "managed",
+            provider: "anthropic",
+            model: "old-model-from-previous-release",
+            maxTokens: 1,
+            provider_connection: "anthropic-managed",
+          },
+        },
+        activeProfile: "balanced",
+      },
+    });
+
+    // Non-hatch boot (no overlay). Content is refreshed from the template.
+    mergeDefaultConfigAndSeedInferenceProfiles();
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+
+    expect(raw.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
+    expect(raw.llm.profiles.balanced.maxTokens).toBe(16000);
+    expect(raw.llm.profiles.balanced.provider_connection).toBe(
+      "anthropic-managed",
+    );
+    expect(raw.llm.activeProfile).toBe("balanced");
+  });
+
+  test("on-platform reseed preserves user-edited label and status on managed profiles", () => {
+    // The only two fields a user may override on a managed profile — label and
+    // status — survive the on-platform reconcile, exactly as off-platform.
+    process.env.IS_PLATFORM = "true";
+
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: {
+            source: "managed",
+            provider: "anthropic",
+            model: "old-model-from-previous-release",
+            provider_connection: "anthropic-managed",
+            label: "My Default",
+            status: "disabled",
+          },
+        },
+        activeProfile: "balanced",
+      },
+    });
+
+    mergeDefaultConfigAndSeedInferenceProfiles();
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+
+    // Content refreshes from the template...
+    expect(raw.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
+    // ...but the user's label and status overrides are preserved.
+    expect(raw.llm.profiles.balanced.label).toBe("My Default");
+    expect(raw.llm.profiles.balanced.status).toBe("disabled");
+  });
+
   test("off-platform reseed preserves user-edited label on managed profiles (Codex P1 on PR #30362)", () => {
     // Simulate a user who renamed the managed "balanced" profile via
     // PUT /v1/config/llm/profiles/balanced { label: "My Default" }.
@@ -788,7 +852,13 @@ describe("loadConfig startup behavior", () => {
     expect("status" in raw.llm.profiles.balanced).toBe(false);
   });
 
-  test("platform-provided profile fragments are not polluted by managed seeds", () => {
+  test("platform overlay fragment wins its hatch boot, then content reconciles to the code template (label preserved)", () => {
+    // The overlay is authoritative for the boot it is supplied: its `balanced`
+    // fragment lands verbatim and is never polluted by template fields it omits
+    // (no maxTokens/thinking leak in). On the next boot — overlay archived —
+    // managed profile *content* reconciles to the code template, since the
+    // templates are the single source of truth for content. Only the
+    // user/overlay-set `label` survives the reconcile.
     process.env.IS_PLATFORM = "true";
 
     writeConfig({
@@ -842,6 +912,7 @@ describe("loadConfig startup behavior", () => {
     const config = loadConfig();
     const mainAgentConfig = resolveCallSiteConfig("mainAgent", config.llm);
 
+    // Hatch boot: overlay fragment is preserved verbatim (preserveProfileNames).
     expect(config.llm.activeProfile).toBe("balanced");
     expect(config.llm.profiles.balanced).toEqual({
       source: "managed",
@@ -862,16 +933,24 @@ describe("loadConfig startup behavior", () => {
     expect(raw.llm.profiles.balanced.maxTokens).toBeUndefined();
     expect(raw.llm.profiles.balanced.thinking).toBeUndefined();
 
+    // Next boot, no overlay: content reconciles to the anthropic-managed code
+    // template; only the overlay-set label is carried across.
     mergeDefaultConfigAndSeedInferenceProfiles();
 
     const afterRestart = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
     expect(afterRestart.llm.activeProfile).toBe("balanced");
-    expect(afterRestart.llm.profiles.balanced).toEqual({
-      source: "managed",
-      provider: "openai",
-      model: "gpt-5.4",
-      label: "Platform Balanced",
+    expect(afterRestart.llm.profiles.balanced.provider).toBe("anthropic");
+    expect(afterRestart.llm.profiles.balanced.provider_connection).toBe(
+      "anthropic-managed",
+    );
+    expect(afterRestart.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
+    expect(afterRestart.llm.profiles.balanced.maxTokens).toBe(16000);
+    expect(afterRestart.llm.profiles.balanced.thinking).toEqual({
+      enabled: true,
+      streamThinking: true,
     });
+    // The user/overlay-set label is the one field that survives the reconcile.
+    expect(afterRestart.llm.profiles.balanced.label).toBe("Platform Balanced");
   });
 
   test("quarantines corrupt config before merging hatch overlay", () => {

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -167,10 +167,13 @@ export type SeedInferenceProfilesOptions = {
  *
  * Runs on every daemon startup. Two responsibilities:
  *
- * 1. **Managed profiles** (`balanced`, `quality-optimized`, `cost-optimized`):
- *    overwritten on every boot so Vellum can push model/config updates to
- *    customers. Each carries `provider_connection: "anthropic-managed"`.
- *    Platform overlays (`preserveProfileNames`) take precedence.
+ * 1. **Managed profiles** (`balanced`, `quality-optimized`, `cost-optimized`,
+ *    `balanced-economy`): reconciled from the code templates on every boot —
+ *    on-platform and off-platform alike — so Vellum can push model/config
+ *    updates to customers in a release without a workspace migration. The
+ *    templates own all profile content; only `label` and `status` are
+ *    user-overridable and survive reseeds. Platform overlays
+ *    (`preserveProfileNames`) take precedence for the boot they are supplied.
  *
  * 2. **User profiles** (`custom-balanced`, `custom-quality-optimized`,
  *    `custom-cost-optimized`): materialized once at hatch time for
@@ -208,22 +211,25 @@ export function seedInferenceProfiles(
   // subsequent boot.
   const isByokMode = !isPlatform;
 
-  // 1. Managed profiles. Off-platform: overwrite on every boot so Vellum can
-  //    push model/config updates in new releases. On-platform: insert only if
-  //    absent — the platform controls profiles through overlays, and the
-  //    overlay fragment is authoritative even when it omits fields the local
-  //    template carries (e.g. an overlay supplying only provider/model/label
-  //    must not get its maxTokens/thinking polluted from the template). The
-  //    legacy migration-052 backfill that seeds label-less Anthropic
-  //    defaults is healed by workspace migration 082
-  //    (`backfill-managed-profile-labels`) rather than the seeder, so
-  //    this skip path stays simple.
+  // 1. Managed profiles. Reconciled from the code templates on every boot —
+  //    on-platform and off-platform alike — so Vellum can push model/config
+  //    updates in new releases just by editing `MANAGED_PROFILE_TEMPLATES` /
+  //    `model-intents.ts` and shipping a release, with no workspace migration.
+  //    The templates are the single source of truth for profile *content*
+  //    (model, maxTokens, effort, thinking, description, provider/connection).
   //
-  //    Two user-editable fields survive the overwrite: `label` (display
-  //    rename) and `status` (active/disabled toggle). The PUT route
-  //    `/v1/config/llm/profiles/:name` lets users patch these on managed
-  //    profiles without duplicating; we have to honor those edits across
-  //    reseeds or they'd silently revert on every boot. Carry by
+  //    Platform overlays (`preserveProfileNames`) still take precedence for the
+  //    boot they are supplied: a profile named in the overlay is skipped here so
+  //    the overlay fragment lands verbatim and is never polluted by template
+  //    fields it omits. The overlay is a one-time hatch input (archived after
+  //    its first merge), so on subsequent boots the templates reconcile content
+  //    as usual.
+  //
+  //    Two user-editable fields survive the reconcile: `label` (display
+  //    rename) and `status` (active/disabled toggle) — the only fields a user
+  //    may override. The PUT route `/v1/config/llm/profiles/:name` lets users
+  //    patch these on managed profiles without duplicating; we honor those
+  //    edits across reseeds or they'd silently revert on every boot. Carry by
   //    key-presence rather than truthiness so an explicit `null` (user
   //    cleared the label) survives too.
   //
@@ -249,7 +255,6 @@ export function seedInferenceProfiles(
 
   for (const [name, template] of Object.entries(MANAGED_PROFILE_TEMPLATES)) {
     if (preservedProfileNames.has(name)) continue;
-    if (isPlatform && readObject(profiles[name]) !== null) continue;
 
     const previous = readObject(profiles[name]);
     const effectiveTemplate: ManagedProfileTemplate = isByokMode


### PR DESCRIPTION
## Summary

- Remove the on-platform `insert-if-absent` skip in `seedInferenceProfiles` so managed profile content is reconciled from the code templates on **every** boot for platform installs too — matching the behavior off-platform (BYOK) installs already had.
- The code templates (`MANAGED_PROFILE_TEMPLATES` + `model-intents.ts`) are now the single source of truth for managed-profile **content** (model, maxTokens, effort, thinking, description, provider/connection) on all installs. Only `label` and `status` remain user-overridable and survive reseeds. Platform overlays still take precedence for the boot they are supplied (`preserveProfileNames`).
- **Result:** model/config updates to the 4 managed profiles ship in a release by editing code — no workspace migration required (the `096`/`097`/`100`/`101`/`103`/`104` migration pattern is no longer needed going forward).

## Notes for reviewers

- Confirmed in `vellum-assistant-platform` that the daemon overlay (`VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH`) never ships `llm.profiles` content — the only thing it writes is `gateway.unmappedPolicy` / `gateway.defaultAssistantId`. So nothing in production relied on the removed platform skip.
- **Migration behavior on first deploy:** existing on-platform installs will self-heal their managed-profile content to match the current code template on the next boot. Any drift between on-disk values and the template gets reconciled then. This is intended.
- Left workspace migrations `097`/`104` and `repairAdaptiveThinkingOnManagedProfiles` in place: the registry forbids removing migration entries (`Never reorder or remove entries`), and the runtime repair is now a harmless idempotent no-op that provides defense-in-depth during the transition.

## Original prompt

Move the 4 managed LLM profiles to being code-defined as the source of truth so updating them no longer requires a workspace migration, while keeping the user able to toggle each profile on/off and rename it. After investigation we found the profiles are already code-defined (`MANAGED_PROFILE_TEMPLATES`); the only thing forcing migrations was an on-platform skip that prevented the seeder from reconciling existing profiles. The user scoped user-overridable fields to exactly `label` and `status`, and asked to confirm against the platform repo that overlays don't ship profile content (confirmed).