### PR TITLE
fix(macos-build): drop dead preloaded-apps copy steps after personal-page removal

### DIFF
--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -747,8 +747,6 @@ build_binaries() {
     rm -rf "$SCRIPT_DIR/daemon-bin/node_modules"
     rm -rf "$SCRIPT_DIR/daemon-bin/bundled-skills"
     cp -R "$ASSISTANT_SRC_DIR/src/config/bundled-skills" "$SCRIPT_DIR/daemon-bin/bundled-skills"
-    rm -rf "$SCRIPT_DIR/daemon-bin/preloaded-apps"
-    cp -R "$ASSISTANT_SRC_DIR/src/config/preloaded-apps" "$SCRIPT_DIR/daemon-bin/preloaded-apps"
     rm -rf "$SCRIPT_DIR/daemon-bin/first-party-skills"
     rsync -a \
         --exclude='node_modules/' \
@@ -1262,14 +1260,6 @@ if [ -d "$ASSISTANT_SRC_DIR/src/config/bundled-skills" ]; then
     cp -R "$ASSISTANT_SRC_DIR/src/config/bundled-skills" "$SCRIPT_DIR/daemon-bin/bundled-skills"
 fi
 
-# Always refresh preloaded app templates from source (same reasoning: template
-# assets aren't tracked by the daemon binary staleness check)
-if [ -d "$ASSISTANT_SRC_DIR/src/config/preloaded-apps" ]; then
-    mkdir -p "$SCRIPT_DIR/daemon-bin"
-    rm -rf "$SCRIPT_DIR/daemon-bin/preloaded-apps"
-    cp -R "$ASSISTANT_SRC_DIR/src/config/preloaded-apps" "$SCRIPT_DIR/daemon-bin/preloaded-apps"
-fi
-
 # Always refresh first-party catalog skills from the repo-level skills/ dir
 # so the daemon can install catalog entries without a running platform.
 if [ -d "$SKILLS_SRC_DIR" ] && [ -f "$SKILLS_SRC_DIR/catalog.json" ]; then
@@ -1513,13 +1503,6 @@ fi
 if [ -d "$SCRIPT_DIR/daemon-bin/bundled-skills" ]; then
     rm -rf "$RESOURCES_DIR/bundled-skills"
     cp -R "$SCRIPT_DIR/daemon-bin/bundled-skills" "$RESOURCES_DIR/bundled-skills"
-fi
-
-# Always refresh preloaded app templates in app bundle (resolved via
-# resolveBundledDir → Contents/Resources/preloaded-apps by the daemon seeder)
-if [ -d "$SCRIPT_DIR/daemon-bin/preloaded-apps" ]; then
-    rm -rf "$RESOURCES_DIR/preloaded-apps"
-    cp -R "$SCRIPT_DIR/daemon-bin/preloaded-apps" "$RESOURCES_DIR/preloaded-apps"
 fi
 
 # Always refresh first-party catalog skills in the app bundle.


### PR DESCRIPTION
## Summary
- macOS CI 'Build binaries' step was failing with `cp: .../assistant/src/config/preloaded-apps: No such file or directory`.
- #35021 removed the personal-page preloaded app (untracked dir, deleted seeder + memory module, cleaned `release.yml`) but left three `preloaded-apps` copy blocks in `clients/macos/build.sh`. The parallel-build path copy was unguarded, so a clean checkout fails.
- Remove all three now-dead blocks (the other two were `-d`-guarded no-ops referencing a deleted feature).

## Original prompt
fix this CI issue: https://github.com/vellum-ai/vellum-assistant/actions/runs/27649652030

🤖 Generated with [Claude Code](https://claude.com/claude-code)