### PR TITLE
Show a Log In action wherever Log Out appears (no platform session)

### DIFF
--- a/apps/macos/src/main/command-palette-window.ts
+++ b/apps/macos/src/main/command-palette-window.ts
@@ -36,6 +36,7 @@ const payloadlessCommandKindSchema = z.enum([
   "shareFeedback",
   "find",
   "markAllRead",
+  "login",
   "logout",
   "rePair",
   "sidebarToggle",

--- a/apps/macos/src/main/commands.ts
+++ b/apps/macos/src/main/commands.ts
@@ -25,6 +25,7 @@ export const DEFAULT_ACCELERATORS: Record<VellumCommandKind, string> = {
   shareFeedback: "",
   find: "CmdOrCtrl+F",
   markAllRead: "",
+  login: "",
   logout: "",
   rePair: "",
   sidebarToggle: "CmdOrCtrl+\\",

--- a/apps/macos/src/main/menu.ts
+++ b/apps/macos/src/main/menu.ts
@@ -166,11 +166,15 @@ const buildTemplate = (): MenuItemConstructorOptions[] => {
         ...(cliItems.length > 0 ? [{ type: "separator" as const }] : []),
         { role: "services" },
         { type: "separator" },
-        {
-          label: "Log Out",
-          enabled: state.hasPlatformSession,
-          click: () => dispatchMenuCommand({ kind: "logout" }),
-        },
+        state.hasPlatformSession
+          ? {
+              label: "Log Out",
+              click: () => dispatchMenuCommand({ kind: "logout" }),
+            }
+          : {
+              label: "Log In",
+              click: () => dispatchMenuCommand({ kind: "login" }),
+            },
         { type: "separator" },
         { role: "hide" },
         { role: "hideOthers" },
@@ -305,7 +309,8 @@ const applyMenu = (): void => {
  * normal packaged build doesn't expose devtools to end users.
  *
  * Registers an IPC handler so the renderer can publish platform session
- * state, which gates the "Log Out" item in the app menu.
+ * state, which toggles the app menu between "Log Out" (session present) and
+ * "Log In" (no session).
  */
 let installed = false;
 export const installApplicationMenu = (): void => {

--- a/apps/web/src/components/layout/active-assistant-gate.tsx
+++ b/apps/web/src/components/layout/active-assistant-gate.tsx
@@ -5,8 +5,8 @@ import { Typography } from "@vellumai/design-library";
 import { Button } from "@vellumai/design-library/components/button";
 
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
+import { useOnboardingLogin } from "@/hooks/use-onboarding-login";
 import { handleLogout } from "@/lib/auth/handle-logout";
-import { isLocalMode } from "@/lib/local-mode";
 import { useHasPlatformSession } from "@/stores/auth-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 
@@ -47,10 +47,10 @@ export function ActiveAssistantGate() {
 
 function ActiveAssistantPlaceholder() {
   const navigate = useNavigate();
-  // Keep an escape hatch reachable while the assistant lifecycle is
-  // unresolved: hide in pure local mode unless a platform session exists.
+  // Keep an auth escape hatch reachable while the assistant lifecycle is
+  // unresolved: Log Out with a platform session, Log In without one.
   const hasPlatformSession = useHasPlatformSession();
-  const showLogout = !isLocalMode() || hasPlatformSession;
+  const { login } = useOnboardingLogin();
 
   return (
     <div
@@ -62,9 +62,13 @@ function ActiveAssistantPlaceholder() {
       <Typography variant="body-medium-default">
         Connecting to your assistant…
       </Typography>
-      {showLogout && (
+      {hasPlatformSession ? (
         <Button variant="ghost" onClick={() => void handleLogout(navigate)}>
           Log Out
+        </Button>
+      ) : (
+        <Button variant="ghost" onClick={() => void login()}>
+          Log In
         </Button>
       )}
     </div>

--- a/apps/web/src/domains/chat/hooks/use-electron-dock-sync.ts
+++ b/apps/web/src/domains/chat/hooks/use-electron-dock-sync.ts
@@ -1,18 +1,15 @@
 import { useEffect, useMemo, useState } from "react";
 
 import { setDockBadge } from "@/runtime/dock";
-import { setMenuPlatformSession } from "@/runtime/menu";
-import { useHasPlatformSession } from "@/stores/auth-store";
 import type { Conversation } from "@/types/conversation-types";
 import { contributesToUnreadCount } from "@/utils/conversation-predicates";
 import { getDeviceBool, watchDeviceSetting } from "@/utils/device-settings";
 
 /**
- * Publish the data the Electron Dock and app menu care about — unread
- * conversation count and platform-session state — to the main process
- * via the `window.vellum.dock.*` and `window.vellum.menu.*` bridges.
- * Both wrappers no-op on non-Electron hosts, so this hook is safe to
- * mount unconditionally inside `ChatLayout`.
+ * Publish the Electron Dock's unread conversation count to the main
+ * process via the `window.vellum.dock.*` bridge, which no-ops on
+ * non-Electron hosts so this hook is safe to mount unconditionally
+ * inside `ChatLayout`.
  *
  * Mount the hook once at a layout that already has the conversation
  * list in hand (currently `ChatLayout`, which subscribes to
@@ -22,12 +19,11 @@ import { getDeviceBool, watchDeviceSetting } from "@/utils/device-settings";
  * automated background / scheduled / archived threads don't contribute
  * to the badge.
  *
- * Signed-in state is owned by the main process (session-token-store)
- * and consumed by the dock module directly — the renderer does not
- * push it.
+ * The app menu's platform-session state is published separately from
+ * `RootLayout` (an always-mounted layer) so it stays correct on
+ * non-chat routes where `ChatLayout` isn't mounted.
  */
 export function useElectronDockSync(conversations: Conversation[]): void {
-  const hasPlatformSession = useHasPlatformSession();
   const [dockBadgesEnabled, setDockBadgesEnabled] = useState(() =>
     getDeviceBool("dockBadgesEnabled", true),
   );
@@ -52,8 +48,4 @@ export function useElectronDockSync(conversations: Conversation[]): void {
   useEffect(() => {
     setDockBadge(dockBadgesEnabled ? unreadCount : 0);
   }, [dockBadgesEnabled, unreadCount]);
-
-  useEffect(() => {
-    void setMenuPlatformSession(hasPlatformSession);
-  }, [hasPlatformSession]);
 }

--- a/apps/web/src/domains/settings/settings-layout.tsx
+++ b/apps/web/src/domains/settings/settings-layout.tsx
@@ -1,10 +1,10 @@
-import { LogOut } from "lucide-react";
+import { LogIn, LogOut } from "lucide-react";
 import { useMemo } from "react";
 import { Outlet, useLocation, useNavigate } from "react-router";
 
+import { useOnboardingLogin } from "@/hooks/use-onboarding-login";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { handleLogout } from "@/lib/auth/handle-logout";
-import { isLocalMode } from "@/lib/local-mode";
 import { isElectron } from "@/runtime/is-electron";
 import { useHasPlatformSession } from "@/stores/auth-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
@@ -28,9 +28,9 @@ export function SettingsLayout() {
   const billingGate = usePlatformGate();
   const { pathname } = useLocation();
   const navigate = useNavigate();
-  // Hide logout in pure local mode unless a platform session exists.
+  // Show Log Out when a platform session exists, Log In otherwise.
   const hasPlatformSession = useHasPlatformSession();
-  const showLogout = !isLocalMode() || hasPlatformSession;
+  const { login } = useOnboardingLogin();
 
   const filteredItems = useMemo(
     () =>
@@ -69,17 +69,24 @@ export function SettingsLayout() {
     if (settingsDeveloperNav) {
       items.push(...SETTINGS_SIDEBAR.filter((item) => item.id === "developer"));
     }
-    // Log Out is pinned to the very bottom of the nav as an action item.
-    if (showLogout) {
-      items.push({
-        id: "logout",
-        label: "Log Out",
-        icon: LogOut,
-        onSelect: () => void handleLogout(navigate),
-      });
-    }
+    // The auth action is pinned to the very bottom of the nav.
+    items.push(
+      hasPlatformSession
+        ? {
+            id: "logout",
+            label: "Log Out",
+            icon: LogOut,
+            onSelect: () => void handleLogout(navigate),
+          }
+        : {
+            id: "login",
+            label: "Log In",
+            icon: LogIn,
+            onSelect: () => void login(),
+          },
+    );
     return items;
-  }, [settingsDeveloperNav, showLogout, navigate]);
+  }, [settingsDeveloperNav, hasPlatformSession, navigate, login]);
 
   const pageTitle = useMemo(() => {
     if (pathname === routes.settings.root) return "Settings";

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -1,4 +1,4 @@
-import { lazy, useState } from "react";
+import { lazy, useEffect, useState } from "react";
 import { Outlet, useLocation, useNavigate } from "react-router";
 
 import { LazyBoundary } from "@/components/lazy-boundary";
@@ -17,6 +17,7 @@ import {
 import { handleLogout } from "@/lib/auth/handle-logout";
 import { getSelectedAssistant } from "@/lib/local-mode";
 import { useOnboardingLogin } from "@/hooks/use-onboarding-login";
+import { setMenuPlatformSession } from "@/runtime/menu";
 import { useVellumCommands } from "@/runtime/vellum-commands";
 
 import { routes } from "@/utils/routes";
@@ -96,6 +97,12 @@ export function RootLayout() {
   const sessionStatus = useAuthStore.use.sessionStatus();
   const isSessionInitializing = useIsSessionInitializing();
   const hasPlatformSession = useHasPlatformSession();
+  // Publish platform-session state to the Electron app menu from this
+  // always-mounted layer so the menu's Log In/Log Out toggle stays correct
+  // on non-chat routes (e.g. Settings) where ChatLayout isn't mounted.
+  useEffect(() => {
+    void setMenuPlatformSession(hasPlatformSession);
+  }, [hasPlatformSession]);
   useClientFeatureFlagSync(!isSessionInitializing);
   useAssistantLifecycle({
     sessionStatus,

--- a/apps/web/src/root-layout.tsx
+++ b/apps/web/src/root-layout.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/stores/auth-store";
 import { handleLogout } from "@/lib/auth/handle-logout";
 import { getSelectedAssistant } from "@/lib/local-mode";
+import { useOnboardingLogin } from "@/hooks/use-onboarding-login";
 import { useVellumCommands } from "@/runtime/vellum-commands";
 
 import { routes } from "@/utils/routes";
@@ -152,9 +153,14 @@ export function RootLayout() {
   // Whether the tray "New Assistant…" name-prompt dialog is open.
   const [createOpen, setCreateOpen] = useState(false);
 
+  const { login } = useOnboardingLogin();
+
   useVellumCommands({
     openSettings: () => {
       void navigate(routes.settings.root);
+    },
+    login: () => {
+      void login();
     },
     logout: () => {
       void handleLogout(navigate);

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -33,6 +33,7 @@ export type VellumCommand =
   | { kind: "shareFeedback" }
   | { kind: "find" }
   | { kind: "markAllRead" }
+  | { kind: "login" }
   | { kind: "logout" }
   | { kind: "rePair" }
   | { kind: "sidebarToggle" }


### PR DESCRIPTION
## Summary
- A self-hosted/local user with no Vellum platform session previously saw **nothing** where the Log Out action normally lives, leaving no in-app way to log into the platform. Now those surfaces show a **Log In** action that starts the platform login flow (via the existing `useOnboardingLogin` hook).
- The auth action is now always present and toggles purely on `useHasPlatformSession()` — **Log Out** when a session exists, **Log In** when it doesn't — across all three places that render logout: the **settings sidebar**, the **active-assistant loading gate**, and the **native macOS app menu**.
- Adds a `login` `VellumCommand` kind (contract + accelerator map + command-palette schema) and a renderer handler in `root-layout.tsx` so the macOS menu item can trigger the same login flow the web buttons use. Logout behavior is unchanged.

## Original prompt
The user asked, for the Electron app, when a self-hosted (locally-running) assistant user would see a platform login button. We established that logout already shows in settings whenever a platform session exists (even with a local active assistant), but there was no symmetric way to *log in* from those surfaces. The user asked to show a Log In button in the same places we show Log Out, under the same conditions, with the only difference being that the platform session decides Log In vs Log Out. Scope was confirmed as: web settings sidebar, the active-assistant gate, and the native macOS menu (with its IPC wiring).