### PR TITLE
ci: rename Electron workflows to pr-macos / ci-main-macos

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -1,17 +1,17 @@
-name: PR Electron Checks
+name: CI/CD Main macOS
 
 on:
-  pull_request:
-    types: [synchronize, opened, reopened]
+  push:
+    branches: [main]
     paths:
       - 'apps/macos/**'
       - 'packages/local-mode/**'
       - 'packages/environments/**'
-      - '.github/workflows/pr-electron.yaml'
+      - '.github/workflows/ci-main-macos.yaml'
       - '.github/actions/install-shared-packages/**'
 
 concurrency:
-  group: pr-electron-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -110,7 +110,7 @@ jobs:
           echo "Test:       $TEST"
           for r in "$TYPECHECK" "$BUILD" "$TEST"; do
             if [ "$r" != "success" ]; then
-              echo "::error::At least one electron CI job failed."
+              echo "::error::At least one macOS CI job failed."
               exit 1
             fi
           done

--- a/.github/workflows/pr-macos.yaml
+++ b/.github/workflows/pr-macos.yaml
@@ -1,17 +1,17 @@
-name: CI/CD Main Electron
+name: PR macOS Checks
 
 on:
-  push:
-    branches: [main]
+  pull_request:
+    types: [synchronize, opened, reopened]
     paths:
       - 'apps/macos/**'
       - 'packages/local-mode/**'
       - 'packages/environments/**'
-      - '.github/workflows/ci-main-electron.yaml'
+      - '.github/workflows/pr-macos.yaml'
       - '.github/actions/install-shared-packages/**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: pr-macos-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
@@ -110,7 +110,7 @@ jobs:
           echo "Test:       $TEST"
           for r in "$TYPECHECK" "$BUILD" "$TEST"; do
             if [ "$r" != "success" ]; then
-              echo "::error::At least one electron CI job failed."
+              echo "::error::At least one macOS CI job failed."
               exit 1
             fi
           done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 Bun + TypeScript monorepo with multiple packages:
 
-- `apps/` — End-user app surfaces: `apps/web/` (Vite + React Router v7 SPA), `apps/ios/` (Capacitor iOS shell that loads the web app in a WKWebView), and `apps/macos/` (Electron desktop shell that wraps `apps/web/`; daemon/gateway lifecycle is owned by the `vellum` CLI, which the app invokes as a subprocess; auto-update via `electron-updater`). CI workflow filenames are still `pr-electron.yaml` / `ci-main-electron.yaml` until the legacy Swift app's `ci-main-macos.yaml` retires. See [`apps/README.md`](apps/README.md) and [`apps/AGENTS.md`](apps/AGENTS.md).
+- `apps/` — End-user app surfaces: `apps/web/` (Vite + React Router v7 SPA), `apps/ios/` (Capacitor iOS shell that loads the web app in a WKWebView), and `apps/macos/` (Electron desktop shell that wraps `apps/web/`; daemon/gateway lifecycle is owned by the `vellum` CLI, which the app invokes as a subprocess; auto-update via `electron-updater`; CI workflows are `pr-macos.yaml` / `ci-main-macos.yaml`). See [`apps/README.md`](apps/README.md) and [`apps/AGENTS.md`](apps/AGENTS.md).
 - `assistant/` — Main backend service (Bun + TypeScript)
 - `cli/` — Multi-assistant management CLI (Bun + TypeScript). See `cli/AGENTS.md`.
 - `clients/` — Client apps (macOS, browser extension, etc). See `clients/AGENTS.md` and platform docs like `clients/macos/AGENTS.md`.

--- a/apps/README.md
+++ b/apps/README.md
@@ -29,9 +29,7 @@ desktop wrappers that users interact with directly.
 ## Notes
 
 - **macOS workflow filenames** — `apps/macos/` is the canonical platform-named
-  directory, but its CI workflow files are still named
-  `pr-electron.yaml` / `ci-main-electron.yaml` because
-  `.github/workflows/ci-main-macos.yaml` is taken by the legacy native Swift
-  app at `clients/macos/`.
+  directory, and its CI workflow files are `pr-macos.yaml` /
+  `ci-main-macos.yaml`.
 - **Chrome extension** — currently at `clients/chrome-extension/`; planned to
   move to `apps/chrome-extension/`.

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -57,12 +57,9 @@ Because the web UI is bundled locally, **web changes require an Electron
 release** to reach users. The update typically lands within hours (next
 app restart or the 4-hour poll), not instantly.
 
-> **Note on workflow filenames.** This directory is `apps/macos/` to match the
-> platform-named convention used by `apps/ios/`, but the CI workflow files are
-> still named `pr-electron.yaml` / `ci-main-electron.yaml` because
-> `.github/workflows/ci-main-macos.yaml` is already taken by the legacy
-> native Swift app at [`clients/macos/`](../../clients/macos/). The workflow
-> filenames will be renamed to `-macos.yaml` once `clients/macos/` retires.
+> **Workflow filenames.** This directory is `apps/macos/` to match the
+> platform-named convention used by `apps/ios/`, and its CI workflow files are
+> `pr-macos.yaml` / `ci-main-macos.yaml`.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- Rename ci-main-electron.yaml -> ci-main-macos.yaml and pr-electron.yaml -> pr-macos.yaml (the Electron app IS the macOS app now; legacy Swift workflows freed these names in Wave 1).
- Update internal name fields and doc references (apps/README.md, apps/macos/README.md, AGENTS.md).

⚠️ Branch-protection: required-status-check names change (ci-main-electron/pr-electron -> ci-main-macos/pr-macos). A repo admin must update branch protection rules after merge, or required checks will not match.

Part of plan: remove-legacy-swift-macos.md (PR 13 of 13, Wave 2)