### PR TITLE
fix(ui-surface): reject empty card ui_show instead of rendering a blank box

### DIFF
--- a/assistant/src/__tests__/dynamic-page-surface.test.ts
+++ b/assistant/src/__tests__/dynamic-page-surface.test.ts
@@ -207,6 +207,96 @@ describe("ui_show dynamic_page app substitute guard", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Empty card guard
+// ---------------------------------------------------------------------------
+
+describe("ui_show empty card guard", () => {
+  const context = (onProxy: () => void) => ({
+    conversationId: "conversation-123",
+    workingDir: "/tmp",
+    trustClass: "guardian" as const,
+    proxyToolResolver: async () => {
+      onProxy();
+      return { content: "proxied", isError: false };
+    },
+  });
+
+  test("rejects a card with empty data and does not proxy", async () => {
+    let proxied = false;
+
+    const result = await uiShowTool.execute(
+      {
+        surface_type: "card",
+        activity: "Showing progress",
+        data: {},
+      },
+      context(() => {
+        proxied = true;
+      }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("blank box");
+    expect(proxied).toBe(false);
+  });
+
+  test("rejects a card with blank-only fields and does not proxy", async () => {
+    let proxied = false;
+
+    const result = await uiShowTool.execute(
+      { surface_type: "card", data: { title: "   ", body: "" } },
+      context(() => {
+        proxied = true;
+      }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(proxied).toBe(false);
+  });
+
+  test("allows a task_progress card with templateData", async () => {
+    let proxied = false;
+
+    const result = await uiShowTool.execute(
+      {
+        surface_type: "card",
+        data: {
+          template: "task_progress",
+          templateData: {
+            title: "Working on X",
+            status: "in_progress",
+            steps: [{ label: "Step 1", status: "in_progress" }],
+          },
+        },
+      },
+      context(() => {
+        proxied = true;
+      }),
+    );
+
+    expect(result).toEqual({ content: "proxied", isError: false });
+    expect(proxied).toBe(true);
+  });
+
+  test("allows a plain card with a title and body", async () => {
+    let proxied = false;
+
+    const result = await uiShowTool.execute(
+      {
+        surface_type: "card",
+        data: { title: "Summary", body: "All done." },
+      },
+      context(() => {
+        proxied = true;
+      }),
+    );
+
+    expect(result).toEqual({ content: "proxied", isError: false });
+    expect(proxied).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // UiSurfaceShowDynamicPage structure
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -43,6 +43,14 @@ function proxyExecute(toolName: string) {
       };
     }
 
+    if (toolName === "ui_show" && isEmptyCard(input)) {
+      return {
+        content:
+          'Error: ui_show card requires content in `data` — a title/body, or a template with templateData (e.g. template "task_progress" with templateData.steps). The surface was not displayed because `data` carried no content; the user would see a blank box. Do not show an empty card and fill it in later with ui_update — resend ui_show with the content inline in `data`, or skip the card.',
+        isError: true,
+      };
+    }
+
     if (toolName === "ui_show" && isDynamicPageAppSubstitute(input)) {
       return {
         content:
@@ -68,6 +76,52 @@ function isEmptyDynamicPage(input: Record<string, unknown>): boolean {
   const data = asRecord(input.data);
   const html = data?.html;
   return typeof html !== "string" || html.trim().length === 0;
+}
+
+/**
+ * True when a `card` surface carries no renderable content. A card draws from
+ * `title`/`subtitle`/`body`/`metadata` or a `template` + `templateData`; with
+ * none of these present the client renders a blank box. Catches the common
+ * weak-model pattern of `ui_show({ surface_type: "card", data: {} })` followed
+ * by a deferred `ui_update`, which leaves an empty card visible in between.
+ */
+function isEmptyCard(input: Record<string, unknown>): boolean {
+  if (input.surface_type !== "card") {
+    return false;
+  }
+  const data = asRecord(input.data);
+  if (!data) {
+    return true;
+  }
+  const CONTENT_KEYS = [
+    "title",
+    "subtitle",
+    "body",
+    "metadata",
+    "template",
+    "templateData",
+  ];
+  return !CONTENT_KEYS.some((key) => hasMeaningfulValue(data[key]));
+}
+
+/**
+ * True when a value carries content: a non-blank string, a non-empty array, a
+ * non-empty object, or any non-nullish primitive.
+ */
+function hasMeaningfulValue(value: unknown): boolean {
+  if (value === undefined || value === null) {
+    return false;
+  }
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  if (typeof value === "object") {
+    return Object.keys(value as Record<string, unknown>).length > 0;
+  }
+  return true;
 }
 
 function isDynamicPageAppSubstitute(input: Record<string, unknown>): boolean {


### PR DESCRIPTION
## What

Extends the empty-surface guard in `ui_show` to reject a **card** with no renderable content in `data`, mirroring the existing `dynamic_page` guard from #34940. A card draws from `title`/`subtitle`/`body`/`metadata` or `template` + `templateData`; with none present the client renders a blank box.

## Why

Weaker open models (e.g. MiniMax M3) call `ui_show({ surface_type: "card", data: {} })` intending to fill the card in via a later `ui_update`. This leaves an empty card visible in between; in dogfooding the model then concluded *"Card is unreliable, dismissing and pushing the work forward"* and thrashed.

The guard returns a corrective error telling the model to inline the content in `data` (or skip the card) rather than show-empty-then-update — breaking the spiral **deterministically**. It's the backstop to the behavioral nudge in #35087 (which steers the model toward the right shape but is probabilistic).

## Behavior

- Rejects `data: {}`, missing `data`, and blank-only fields (`title: "   "`, `body: ""`).
- Allows real cards: `task_progress` (template + templateData), plain `title`/`body`, etc.
- Only affects `ui_show` cards; `ui_update` (merge) is untouched.

## Test

New `ui_show empty card guard` block in `dynamic-page-surface.test.ts` (reject empty / blank-only; allow task_progress + plain card). Full file 15 pass; related ui-surface suites green; `tsc --noEmit` clean.

## Related

Follow-up to #35087 (task-progress-nudge). Same dogfooding incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)