### PR TITLE
Add remote web SPA pairing flow

### DIFF
--- a/apps/web/src/assistant/lifecycle-service.test.ts
+++ b/apps/web/src/assistant/lifecycle-service.test.ts
@@ -52,12 +52,14 @@ mock.module("@/lib/auth/gateway-session", () => ({
 }));
 
 const isLocalModeMock = mock(() => false);
+const isRemoteGatewayModeMock = mock(() => false);
 const getSelectedAssistantMock = mock(
   (): { assistantId: string } | undefined => undefined,
 );
 const getLocalGatewayUrlMock = mock((): string | undefined => undefined);
 mock.module("@/lib/local-mode", () => ({
   isLocalMode: isLocalModeMock,
+  isRemoteGatewayMode: isRemoteGatewayModeMock,
   isLocalAssistant: () => false,
   isPlatformAssistant: () => false,
   getSelectedAssistant: getSelectedAssistantMock,
@@ -134,6 +136,7 @@ beforeEach(() => {
   // tests will silently inherit the previous test's stub.
   isGatewayAuthModeMock.mockImplementation(() => false);
   isLocalModeMock.mockImplementation(() => false);
+  isRemoteGatewayModeMock.mockImplementation(() => false);
   getSelectedAssistantMock.mockImplementation(() => undefined);
   getLocalGatewayUrlMock.mockImplementation(() => undefined);
   getAssistantMock.mockImplementation(async () => ({ ok: false, status: 404 }));
@@ -160,6 +163,7 @@ beforeEach(() => {
 
 afterEach(() => {
   lifecycleService.__resetForTesting();
+  window.history.pushState(null, "", "/");
 });
 
 describe("lifecycleService — server state projection", () => {
@@ -384,6 +388,30 @@ describe("lifecycleService — bootstrap branches", () => {
       const s = useAssistantLifecycleStore.getState().assistantState;
       return s.kind === "active" && s.health === "healthy";
     });
+  });
+
+  test("remote gateway short-circuit preserves a public path prefix", async () => {
+    isGatewayAuthModeMock.mockImplementation(() => true);
+    isRemoteGatewayModeMock.mockImplementation(() => true);
+    window.history.pushState(
+      null,
+      "",
+      "/assistant-123/assistant/conversations/self",
+    );
+
+    lifecycleService.setInputs({
+      ...baseInputs,
+      queryClient: makeQueryClient(),
+    });
+    await lifecycleService.respondToInputs();
+
+    expect(setSelfHostedConnectionMock).toHaveBeenCalledWith({
+      url: `${window.location.origin}/assistant-123`,
+      token: "token",
+    });
+    expect(useResolvedAssistantsStore.getState().activeAssistantId).toBe(
+      "self",
+    );
   });
 });
 

--- a/apps/web/src/assistant/lifecycle-service.ts
+++ b/apps/web/src/assistant/lifecycle-service.ts
@@ -53,6 +53,7 @@ import { isGatewayAuthMode, getGatewayToken } from "@/lib/auth/gateway-session";
 import {
   getSelectedAssistant,
   getLocalGatewayUrl,
+  isRemoteGatewayMode,
 } from "@/lib/local-mode";
 import { getLocalAssistantStatusHost } from "@/runtime/local-mode-host";
 import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
@@ -61,6 +62,15 @@ import { isAuthenticated, type SessionStatus } from "@/stores/session-status";
 const PROBE_RETRY_DELAY_MS = 4_000;
 const PROBE_RETRY_LIMIT_MS = 60_000;
 const LOCAL_HEALTH_POLL_MS = 5_000;
+
+function getRemoteGatewayIngressUrl(): string {
+  const match = /\/assistant(?:\/|$)/.exec(window.location.pathname);
+  const prefix =
+    match && match.index > 0
+      ? window.location.pathname.slice(0, match.index).replace(/\/+$/, "")
+      : "";
+  return `${window.location.origin}${prefix}`;
+}
 
 export interface LifecycleServiceInputs {
   sessionStatus: SessionStatus;
@@ -542,7 +552,9 @@ class AssistantLifecycleService {
     let ingressUrl = window.location.origin;
     let resolvedAssistantId = "self";
     const localGateway = getLocalGatewayUrl();
-    if (localGateway) {
+    if (isRemoteGatewayMode()) {
+      ingressUrl = getRemoteGatewayIngressUrl();
+    } else if (localGateway) {
       const assistant = getSelectedAssistant();
       ingressUrl = `${window.location.origin}${localGateway}`;
       resolvedAssistantId = assistant?.assistantId ?? resolvedAssistantId;

--- a/apps/web/src/domains/remote-web/pairing-page.test.tsx
+++ b/apps/web/src/domains/remote-web/pairing-page.test.tsx
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+
+let remoteGatewayMode = false;
+
+mock.module("@/lib/local-mode", () => ({
+  isRemoteGatewayMode: () => remoteGatewayMode,
+}));
+
+const exchangeRemoteWebPairingTokenMock = mock(
+  async (_deviceCode: string, _signal?: AbortSignal) => ({
+    status: "pending",
+    expiresAt: "2026-06-16T12:00:00.000Z",
+    intervalSeconds: 5,
+  }),
+);
+
+mock.module("@/lib/auth/remote-gateway-session", () => ({
+  activateRemoteGatewaySession: () => {},
+  exchangeRemoteWebPairingToken: exchangeRemoteWebPairingTokenMock,
+  parseRemoteWebPairingParams: (value: string) => {
+    const url = new URL(value, "http://localhost:3000");
+    return {
+      deviceCode: url.searchParams.get("deviceCode"),
+      userCode: url.searchParams.get("userCode"),
+    };
+  },
+  RemoteWebPairingError: class RemoteWebPairingError extends Error {
+    readonly status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+
+const { RemoteWebPairingPage } =
+  await import("@/domains/remote-web/pairing-page");
+
+afterEach(() => {
+  cleanup();
+  remoteGatewayMode = false;
+  exchangeRemoteWebPairingTokenMock.mockClear();
+});
+
+describe("RemoteWebPairingPage", () => {
+  test("renders NotFound outside remote-gateway mode", () => {
+    render(
+      <MemoryRouter
+        initialEntries={["/assistant/pair?deviceCode=device-1&userCode=ABCD"]}
+      >
+        <RemoteWebPairingPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Not found")).not.toBeNull();
+    expect(exchangeRemoteWebPairingTokenMock).not.toHaveBeenCalled();
+  });
+
+  test("polls for a token in remote-gateway mode", async () => {
+    remoteGatewayMode = true;
+
+    render(
+      <MemoryRouter
+        initialEntries={["/assistant/pair?deviceCode=device-1&userCode=ABCD"]}
+      >
+        <RemoteWebPairingPage />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Waiting for approval")).not.toBeNull();
+    expect(exchangeRemoteWebPairingTokenMock.mock.calls[0]?.[0]).toBe(
+      "device-1",
+    );
+    expect(exchangeRemoteWebPairingTokenMock.mock.calls[0]?.[1]).toBeInstanceOf(
+      AbortSignal,
+    );
+  });
+});

--- a/apps/web/src/domains/remote-web/pairing-page.tsx
+++ b/apps/web/src/domains/remote-web/pairing-page.tsx
@@ -1,0 +1,174 @@
+import { AlertCircle, CheckCircle2, LoaderCircle } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { useLocation, useNavigate } from "react-router";
+
+import { NotFound } from "@/components/not-found";
+import {
+  activateRemoteGatewaySession,
+  exchangeRemoteWebPairingToken,
+  parseRemoteWebPairingParams,
+  RemoteWebPairingError,
+} from "@/lib/auth/remote-gateway-session";
+import { isRemoteGatewayMode } from "@/lib/local-mode";
+import { routes } from "@/utils/routes";
+
+type PairingState =
+  | { kind: "missing" }
+  | { kind: "polling"; expiresAt: string | null }
+  | { kind: "approved" }
+  | { kind: "expired" }
+  | { kind: "error"; message: string };
+
+function statusCopy(state: PairingState): { title: string; body: string } {
+  switch (state.kind) {
+    case "missing":
+      return {
+        title: "Pairing link incomplete",
+        body: "Start a new web pairing from the local assistant and open the full link.",
+      };
+    case "approved":
+      return {
+        title: "Connected",
+        body: "Opening your assistant.",
+      };
+    case "expired":
+      return {
+        title: "Pairing expired",
+        body: "Start a new web pairing from the local assistant.",
+      };
+    case "error":
+      return {
+        title: "Pairing failed",
+        body: state.message,
+      };
+    case "polling":
+      return {
+        title: "Waiting for approval",
+        body: "Confirm this code on the machine running your assistant.",
+      };
+  }
+}
+
+function StatusIcon({ state }: { state: PairingState }) {
+  if (state.kind === "approved") {
+    return <CheckCircle2 className="h-5 w-5 text-green-600" aria-hidden />;
+  }
+  if (state.kind === "polling") {
+    return (
+      <LoaderCircle
+        className="h-5 w-5 animate-spin text-blue-600"
+        aria-hidden
+      />
+    );
+  }
+  return <AlertCircle className="h-5 w-5 text-red-600" aria-hidden />;
+}
+
+export function RemoteWebPairingPage() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const enabled = isRemoteGatewayMode();
+  const params = useMemo(
+    () =>
+      parseRemoteWebPairingParams(
+        `${location.pathname}${location.search}${location.hash}`,
+      ),
+    [location.pathname, location.search, location.hash],
+  );
+  const [state, setState] = useState<PairingState>(
+    params.deviceCode
+      ? { kind: "polling", expiresAt: null }
+      : { kind: "missing" },
+  );
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (!params.deviceCode) {
+      setState({ kind: "missing" });
+      return;
+    }
+
+    const controller = new AbortController();
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+
+    const poll = async () => {
+      try {
+        const result = await exchangeRemoteWebPairingToken(
+          params.deviceCode!,
+          controller.signal,
+        );
+        if (result.status === "pending") {
+          setState({ kind: "polling", expiresAt: result.expiresAt || null });
+          timeout = setTimeout(
+            () => void poll(),
+            Math.max(1, result.intervalSeconds) * 1000,
+          );
+          return;
+        }
+
+        activateRemoteGatewaySession(result);
+        setState({ kind: "approved" });
+        timeout = setTimeout(
+          () => navigate(routes.assistant, { replace: true }),
+          250,
+        );
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        if (err instanceof RemoteWebPairingError && err.status === 401) {
+          setState({ kind: "expired" });
+          return;
+        }
+        setState({
+          kind: "error",
+          message:
+            "The assistant could not complete pairing. Try starting a new pairing.",
+        });
+      }
+    };
+
+    void poll();
+
+    return () => {
+      controller.abort();
+      if (timeout) clearTimeout(timeout);
+    };
+  }, [enabled, params.deviceCode, navigate]);
+
+  if (!enabled) {
+    return <NotFound />;
+  }
+
+  const copy = statusCopy(state);
+
+  return (
+    <main className="flex min-h-svh items-center justify-center bg-[var(--background-default)] px-6 py-10 text-[var(--content-primary)]">
+      <section className="w-full max-w-md rounded-lg border border-[var(--border-default)] bg-[var(--background-surface)] p-8 shadow-sm">
+        <div className="mb-5 flex items-center gap-3">
+          <StatusIcon state={state} />
+          <h1 className="text-xl font-semibold">{copy.title}</h1>
+        </div>
+
+        {params.userCode ? (
+          <div className="mb-5 rounded-md border border-[var(--border-subtle)] bg-[var(--background-muted)] p-4 text-center">
+            <div className="text-xs font-medium uppercase text-[var(--content-secondary)]">
+              Pairing code
+            </div>
+            <div className="mt-2 font-mono text-3xl font-semibold tracking-[0.18em]">
+              {params.userCode}
+            </div>
+          </div>
+        ) : null}
+
+        <p className="text-sm leading-6 text-[var(--content-secondary)]">
+          {copy.body}
+        </p>
+
+        {state.kind === "polling" && state.expiresAt ? (
+          <p className="mt-4 text-xs text-[var(--content-tertiary)]">
+            Expires {new Date(state.expiresAt).toLocaleTimeString()}.
+          </p>
+        ) : null}
+      </section>
+    </main>
+  );
+}

--- a/apps/web/src/lib/auth/gateway-session.test.ts
+++ b/apps/web/src/lib/auth/gateway-session.test.ts
@@ -7,6 +7,7 @@ import {
   isGatewayAuthEnabled,
   isGatewayAuthMode,
   isRepairableGatewayTokenError,
+  setRemoteGatewayToken,
 } from "@/lib/auth/gateway-session";
 
 const realFetch = globalThis.fetch;
@@ -24,10 +25,17 @@ afterEach(() => {
 });
 
 describe("remote gateway mode", () => {
-  test("does not require a stored gateway token", () => {
+  test("is enabled but not active until an in-memory token exists", () => {
     window.__VELLUM_CONFIG__ = { mode: "remote-gateway" };
 
     expect(isGatewayAuthEnabled()).toBe(true);
+    expect(isGatewayAuthMode()).toBe(false);
+
+    setRemoteGatewayToken({
+      accessToken: "remote-token",
+      accessTokenExpiresAt: "2999-01-01T00:00:00.000Z",
+    });
+
     expect(isGatewayAuthMode()).toBe(true);
   });
 });

--- a/apps/web/src/lib/auth/gateway-session.ts
+++ b/apps/web/src/lib/auth/gateway-session.ts
@@ -51,6 +51,8 @@ const LEGACY_TOKEN_SOURCE_KEY = "gw:tokenSource";
 let cachedToken: string | null = null;
 let cachedExpiresAt: number = 0;
 let cachedTokenSource: string | null = null;
+let remoteGatewayToken: string | null = null;
+let remoteGatewayExpiresAt: number = 0;
 
 export function isGatewayAuthEnabled(): boolean {
   if (isRemoteGatewayMode()) return true;
@@ -58,7 +60,6 @@ export function isGatewayAuthEnabled(): boolean {
 }
 
 export function isGatewayAuthMode(): boolean {
-  if (isRemoteGatewayMode()) return true;
   return isGatewayAuthEnabled() && getGatewayToken() !== null;
 }
 
@@ -66,7 +67,32 @@ function isTokenExpired(expiresAt: number): boolean {
   return Date.now() / 1000 >= expiresAt - 60;
 }
 
+function toEpochSeconds(value: string | number): number {
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed / 1000 : 0;
+  }
+  return value > 1_000_000_000_000 ? value / 1000 : value;
+}
+
+export function setRemoteGatewayToken(params: {
+  accessToken: string;
+  accessTokenExpiresAt: string | number;
+}): void {
+  remoteGatewayToken = params.accessToken;
+  remoteGatewayExpiresAt = toEpochSeconds(params.accessTokenExpiresAt);
+}
+
 export function getGatewayToken(): string | null {
+  if (isRemoteGatewayMode()) {
+    if (remoteGatewayToken && !isTokenExpired(remoteGatewayExpiresAt)) {
+      return remoteGatewayToken;
+    }
+    remoteGatewayToken = null;
+    remoteGatewayExpiresAt = 0;
+    return null;
+  }
+
   if (cachedToken && !isTokenExpired(cachedExpiresAt)) {
     return cachedToken;
   }
@@ -154,6 +180,8 @@ export function clearGatewayToken(): void {
   cachedToken = null;
   cachedExpiresAt = 0;
   cachedTokenSource = null;
+  remoteGatewayToken = null;
+  remoteGatewayExpiresAt = 0;
   try {
     localStorage.removeItem(LS_TOKEN_KEY);
     localStorage.removeItem(LS_EXPIRES_KEY);

--- a/apps/web/src/lib/auth/remote-gateway-session.test.ts
+++ b/apps/web/src/lib/auth/remote-gateway-session.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { clearGatewayToken, getGatewayToken } from "@/lib/auth/gateway-session";
+import {
+  activateRemoteGatewaySession,
+  exchangeRemoteWebPairingToken,
+  parseRemoteWebPairingParams,
+  refreshRemoteGatewaySession,
+  remoteGatewayApiPath,
+  remoteGatewayPublicPathPrefix,
+} from "@/lib/auth/remote-gateway-session";
+import {
+  getSelfHostedActorToken,
+  getSelfHostedIngressUrl,
+  setSelfHostedConnection,
+} from "@/lib/self-hosted/connection";
+
+const realFetch = globalThis.fetch;
+
+function setLocation(path: string): void {
+  window.history.pushState(null, "", `http://localhost:3000${path}`);
+}
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  window.__VELLUM_CONFIG__ = undefined;
+  clearGatewayToken();
+  setSelfHostedConnection(null);
+  localStorage.clear();
+  setLocation("/assistant/pair");
+});
+
+describe("remote web pairing link parsing", () => {
+  test("accepts camelCase query parameters", () => {
+    const params = parseRemoteWebPairingParams(
+      "https://paired.example.com/assistant/pair?deviceCode=device-1&userCode=ABCD-EFGH",
+    );
+
+    expect(params).toEqual({
+      deviceCode: "device-1",
+      userCode: "ABCD-EFGH",
+    });
+  });
+
+  test("accepts snake_case hash parameters", () => {
+    const params = parseRemoteWebPairingParams(
+      "https://paired.example.com/assistant/pair#device_code=device-2&user_code=WXYZ-1234",
+    );
+
+    expect(params).toEqual({
+      deviceCode: "device-2",
+      userCode: "WXYZ-1234",
+    });
+  });
+});
+
+describe("remote gateway public prefix", () => {
+  test("uses bare gateway paths at /assistant", () => {
+    setLocation("/assistant/pair");
+
+    expect(remoteGatewayPublicPathPrefix()).toBe("");
+    expect(remoteGatewayApiPath("/v1/guardian/refresh")).toBe(
+      "/v1/guardian/refresh",
+    );
+  });
+
+  test("preserves a public path prefix before /assistant", () => {
+    setLocation("/assistant-123/assistant/pair");
+
+    expect(remoteGatewayPublicPathPrefix()).toBe("/assistant-123");
+    expect(remoteGatewayApiPath("/v1/guardian/refresh")).toBe(
+      "/assistant-123/v1/guardian/refresh",
+    );
+  });
+});
+
+describe("remote gateway token exchange", () => {
+  test("posts the device code with cookie credentials", async () => {
+    setLocation("/assistant-123/assistant/pair");
+    const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+    globalThis.fetch = mock(async (input, init) => {
+      calls.push({ input, init });
+      return Response.json(
+        {
+          status: "pending",
+          expiresAt: "2026-06-16T12:00:00.000Z",
+          intervalSeconds: 7,
+        },
+        { status: 202 },
+      );
+    }) as unknown as typeof fetch;
+
+    await expect(exchangeRemoteWebPairingToken("device-code")).resolves.toEqual(
+      {
+        status: "pending",
+        expiresAt: "2026-06-16T12:00:00.000Z",
+        intervalSeconds: 7,
+      },
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].input).toBe("/assistant-123/v1/remote-web/pairing-token");
+    expect(calls[0].init?.credentials).toBe("include");
+    expect(calls[0].init?.body).toBe(
+      JSON.stringify({ deviceCode: "device-code" }),
+    );
+  });
+
+  test("stores approved access tokens in memory and primes self-hosted routing", () => {
+    window.__VELLUM_CONFIG__ = { mode: "remote-gateway" };
+    setLocation("/assistant-123/assistant/pair");
+
+    activateRemoteGatewaySession({
+      status: "approved",
+      accessToken: "access-token",
+      accessTokenExpiresAt: "2999-01-01T00:00:00.000Z",
+      refreshAfter: "2999-01-01T00:00:00.000Z",
+    });
+
+    expect(getGatewayToken()).toBe("access-token");
+    expect(getSelfHostedIngressUrl()).toBe(
+      "http://localhost:3000/assistant-123",
+    );
+    expect(getSelfHostedActorToken()).toBe("access-token");
+    expect(localStorage.getItem("vellum:gw:token")).toBeNull();
+  });
+
+  test("does not rotate the refresh cookie before refreshAfter", async () => {
+    window.__VELLUM_CONFIG__ = { mode: "remote-gateway" };
+    setLocation("/assistant-123/assistant/conversations/self");
+    globalThis.fetch = mock(async () =>
+      Response.json({}),
+    ) as unknown as typeof fetch;
+
+    activateRemoteGatewaySession({
+      status: "approved",
+      accessToken: "access-token",
+      accessTokenExpiresAt: "2999-01-01T00:00:00.000Z",
+      refreshAfter: "2999-01-01T00:00:00.000Z",
+    });
+
+    await expect(refreshRemoteGatewaySession()).resolves.toBe(true);
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(getGatewayToken()).toBe("access-token");
+  });
+
+  test("refreshes from the HttpOnly cookie endpoint", async () => {
+    window.__VELLUM_CONFIG__ = { mode: "remote-gateway" };
+    setLocation("/assistant-123/assistant/conversations/self");
+    const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+    globalThis.fetch = mock(async (input, init) => {
+      calls.push({ input, init });
+      return Response.json({
+        guardianPrincipalId: "guardian-1",
+        accessToken: "refreshed-access-token",
+        accessTokenExpiresAt: Date.parse("2999-01-01T00:00:00.000Z"),
+        refreshAfter: Date.parse("2999-01-01T00:00:00.000Z"),
+      });
+    }) as unknown as typeof fetch;
+
+    await expect(refreshRemoteGatewaySession()).resolves.toBe(true);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].input).toBe("/assistant-123/v1/guardian/refresh");
+    expect(calls[0].init?.credentials).toBe("include");
+    expect(calls[0].init?.body).toBe("{}");
+    expect(getGatewayToken()).toBe("refreshed-access-token");
+  });
+
+  test("shares concurrent same-tab refresh attempts", async () => {
+    window.__VELLUM_CONFIG__ = { mode: "remote-gateway" };
+    setLocation("/assistant-123/assistant/conversations/self");
+    let releaseRefresh!: () => void;
+    const refreshGate = new Promise<void>((resolve) => {
+      releaseRefresh = resolve;
+    });
+    const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+    globalThis.fetch = mock(async (input, init) => {
+      calls.push({ input, init });
+      await refreshGate;
+      return Response.json({
+        guardianPrincipalId: "guardian-1",
+        accessToken: "shared-access-token",
+        accessTokenExpiresAt: Date.parse("2999-01-01T00:00:00.000Z"),
+        refreshAfter: Date.parse("2999-01-01T00:00:00.000Z"),
+      });
+    }) as unknown as typeof fetch;
+
+    const first = refreshRemoteGatewaySession();
+    const second = refreshRemoteGatewaySession();
+
+    expect(calls).toHaveLength(1);
+    releaseRefresh();
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
+
+    expect(calls).toHaveLength(1);
+    expect(getGatewayToken()).toBe("shared-access-token");
+  });
+});

--- a/apps/web/src/lib/auth/remote-gateway-session.ts
+++ b/apps/web/src/lib/auth/remote-gateway-session.ts
@@ -1,0 +1,302 @@
+import {
+  getGatewayToken,
+  setRemoteGatewayToken,
+} from "@/lib/auth/gateway-session";
+import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
+
+const PAIRING_TOKEN_PATH = "/v1/remote-web/pairing-token";
+const GUARDIAN_REFRESH_PATH = "/v1/guardian/refresh";
+const DEFAULT_POLL_INTERVAL_SECONDS = 5;
+const REFRESH_EARLY_MS = 5_000;
+const REFRESH_LOCK_KEY = "vellum:remote-gateway:refresh-lock";
+const REFRESH_LOCK_NAME = "vellum-remote-gateway-refresh";
+const REFRESH_LOCK_TTL_MS = 20_000;
+const REFRESH_LOCK_WAIT_MS = 20_000;
+const REFRESH_LOCK_POLL_MS = 100;
+
+type BrowserLocks = {
+  request<T>(name: string, callback: () => Promise<T>): Promise<T>;
+};
+
+type RefreshLockRecord = {
+  owner: string;
+  expiresAt: number;
+};
+
+let remoteGatewayRefreshAfterMs = 0;
+let refreshRemoteGatewaySessionPromise: Promise<boolean> | null = null;
+
+export interface RemoteWebPairingParams {
+  deviceCode: string | null;
+  userCode: string | null;
+}
+
+export interface RemoteWebPairingPending {
+  status: "pending";
+  expiresAt: string;
+  intervalSeconds: number;
+}
+
+export interface RemoteWebPairingApproved {
+  status: "approved";
+  accessToken: string;
+  accessTokenExpiresAt: string | number;
+  refreshAfter: string | number;
+  guardianId?: string;
+  assistantId?: string;
+}
+
+export type RemoteWebPairingTokenResult =
+  | RemoteWebPairingPending
+  | RemoteWebPairingApproved;
+
+export class RemoteWebPairingError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "RemoteWebPairingError";
+    this.status = status;
+  }
+}
+
+function stringParam(
+  params: URLSearchParams,
+  ...names: string[]
+): string | null {
+  for (const name of names) {
+    const value = params.get(name)?.trim();
+    if (value) return value;
+  }
+  return null;
+}
+
+function paramsFromUrl(url: URL): URLSearchParams {
+  const merged = new URLSearchParams(url.search);
+  const hash = url.hash.startsWith("#") ? url.hash.slice(1) : url.hash;
+  if (hash) {
+    const hashParams = new URLSearchParams(hash);
+    for (const [key, value] of hashParams) {
+      if (!merged.has(key)) merged.set(key, value);
+    }
+  }
+  return merged;
+}
+
+export function parseRemoteWebPairingParams(
+  value: string | URL,
+): RemoteWebPairingParams {
+  const url =
+    typeof value === "string" ? new URL(value, window.location.origin) : value;
+  const params = paramsFromUrl(url);
+  return {
+    deviceCode: stringParam(params, "deviceCode", "device_code"),
+    userCode: stringParam(params, "userCode", "user_code"),
+  };
+}
+
+export function remoteGatewayPublicPathPrefix(
+  location = window.location,
+): string {
+  const match = /\/assistant(?:\/|$)/.exec(location.pathname);
+  return match && match.index > 0
+    ? location.pathname.slice(0, match.index).replace(/\/+$/, "")
+    : "";
+}
+
+export function remoteGatewayApiPath(
+  path: string,
+  location = window.location,
+): string {
+  return `${remoteGatewayPublicPathPrefix(location)}${path}`;
+}
+
+function toEpochMilliseconds(value: string | number): number {
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return value > 1_000_000_000_000 ? value : value * 1000;
+}
+
+function shouldRefreshRemoteGatewaySession(): boolean {
+  if (!getGatewayToken()) return true;
+  if (remoteGatewayRefreshAfterMs <= 0) return true;
+  return Date.now() >= remoteGatewayRefreshAfterMs - REFRESH_EARLY_MS;
+}
+
+function isApprovedPayload(value: unknown): value is RemoteWebPairingApproved {
+  const payload = value as Partial<RemoteWebPairingApproved>;
+  return (
+    payload?.status === "approved" &&
+    typeof payload.accessToken === "string" &&
+    (typeof payload.accessTokenExpiresAt === "string" ||
+      typeof payload.accessTokenExpiresAt === "number") &&
+    (typeof payload.refreshAfter === "string" ||
+      typeof payload.refreshAfter === "number")
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function readRefreshLock(): RefreshLockRecord | null {
+  try {
+    const raw = localStorage.getItem(REFRESH_LOCK_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<RefreshLockRecord>;
+    if (
+      typeof parsed.owner !== "string" ||
+      typeof parsed.expiresAt !== "number"
+    ) {
+      return null;
+    }
+    return { owner: parsed.owner, expiresAt: parsed.expiresAt };
+  } catch {
+    return null;
+  }
+}
+
+function tryAcquireRefreshLock(owner: string): boolean {
+  try {
+    const current = readRefreshLock();
+    if (current && current.expiresAt > Date.now()) return false;
+    localStorage.setItem(
+      REFRESH_LOCK_KEY,
+      JSON.stringify({ owner, expiresAt: Date.now() + REFRESH_LOCK_TTL_MS }),
+    );
+    return readRefreshLock()?.owner === owner;
+  } catch {
+    return true;
+  }
+}
+
+function releaseRefreshLock(owner: string): void {
+  try {
+    if (readRefreshLock()?.owner === owner) {
+      localStorage.removeItem(REFRESH_LOCK_KEY);
+    }
+  } catch {
+    // localStorage unavailable
+  }
+}
+
+async function withLocalStorageRefreshLock<T>(
+  fn: () => Promise<T>,
+): Promise<T> {
+  const owner = `${Date.now()}:${Math.random().toString(36).slice(2)}`;
+  const waitUntil = Date.now() + REFRESH_LOCK_WAIT_MS;
+
+  while (!tryAcquireRefreshLock(owner)) {
+    if (Date.now() >= waitUntil) return fn();
+    await sleep(REFRESH_LOCK_POLL_MS);
+  }
+
+  try {
+    return await fn();
+  } finally {
+    releaseRefreshLock(owner);
+  }
+}
+
+async function withRefreshLock<T>(fn: () => Promise<T>): Promise<T> {
+  // Refresh tokens are single-use; serialize cookie refresh so multiple tabs
+  // do not replay the same cookie before the first Set-Cookie lands.
+  const locks =
+    typeof navigator !== "undefined"
+      ? ((navigator as Navigator & { locks?: BrowserLocks }).locks ?? null)
+      : null;
+  if (locks) return locks.request(REFRESH_LOCK_NAME, fn);
+  return withLocalStorageRefreshLock(fn);
+}
+
+export function activateRemoteGatewaySession(
+  session: RemoteWebPairingApproved,
+): void {
+  remoteGatewayRefreshAfterMs = toEpochMilliseconds(session.refreshAfter);
+  setRemoteGatewayToken({
+    accessToken: session.accessToken,
+    accessTokenExpiresAt: session.accessTokenExpiresAt,
+  });
+  setSelfHostedConnection({
+    url: `${window.location.origin}${remoteGatewayPublicPathPrefix()}`,
+    token: session.accessToken,
+  });
+}
+
+export async function exchangeRemoteWebPairingToken(
+  deviceCode: string,
+  signal?: AbortSignal,
+): Promise<RemoteWebPairingTokenResult> {
+  const response = await fetch(remoteGatewayApiPath(PAIRING_TOKEN_PATH), {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ deviceCode }),
+    signal,
+  });
+  const body = (await response.json()) as unknown;
+
+  if (response.status === 202) {
+    const pending = body as Partial<RemoteWebPairingPending>;
+    return {
+      status: "pending",
+      expiresAt: typeof pending.expiresAt === "string" ? pending.expiresAt : "",
+      intervalSeconds:
+        typeof pending.intervalSeconds === "number" &&
+        pending.intervalSeconds > 0
+          ? pending.intervalSeconds
+          : DEFAULT_POLL_INTERVAL_SECONDS,
+    };
+  }
+
+  if (!response.ok) {
+    throw new RemoteWebPairingError(
+      response.status,
+      `Pairing token exchange failed: ${response.status}`,
+    );
+  }
+
+  if (!isApprovedPayload(body)) {
+    throw new RemoteWebPairingError(
+      502,
+      "Pairing token exchange returned an invalid response",
+    );
+  }
+
+  return body;
+}
+
+async function refreshRemoteGatewaySessionOnce(): Promise<boolean> {
+  if (!shouldRefreshRemoteGatewaySession()) return true;
+
+  const response = await fetch(remoteGatewayApiPath(GUARDIAN_REFRESH_PATH), {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: "{}",
+  });
+
+  if (!response.ok) return false;
+  const body = (await response.json()) as unknown;
+  if (!isApprovedPayload({ ...(body as object), status: "approved" })) {
+    return false;
+  }
+  activateRemoteGatewaySession({
+    ...(body as Omit<RemoteWebPairingApproved, "status">),
+    status: "approved",
+  });
+  return true;
+}
+
+export async function refreshRemoteGatewaySession(): Promise<boolean> {
+  if (!shouldRefreshRemoteGatewaySession()) return true;
+
+  refreshRemoteGatewaySessionPromise ??= withRefreshLock(
+    refreshRemoteGatewaySessionOnce,
+  ).finally(() => {
+    refreshRemoteGatewaySessionPromise = null;
+  });
+  return refreshRemoteGatewaySessionPromise;
+}

--- a/apps/web/src/routes.test.ts
+++ b/apps/web/src/routes.test.ts
@@ -1,7 +1,17 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { matchRoutes } from "react-router";
 
-import { routeTree } from "@/routes";
+mock.module("@/generated/gateway/@tanstack/react-query.gen", () => ({
+  assistantFeatureFlagsGetOptions: () => ({ queryKey: ["assistant-flags"] }),
+  assistantFeatureFlagsGetQueryKey: () => ["assistant-flags"],
+}));
+
+const { getRouterBasename, routeTree } = await import("@/routes");
+
+afterEach(() => {
+  window.__VELLUM_CONFIG__ = undefined;
+  window.history.pushState(null, "", "/");
+});
 
 // Walk the matched route chain for `path` and report whether `AccountLayout`
 // is one of its layout components. Matching runs against the raw `routeTree`
@@ -13,6 +23,13 @@ function isUnderAccountLayout(path: string): boolean {
     (m) =>
       (m.route as { Component?: { name?: string } }).Component?.name ===
       "AccountLayout",
+  );
+}
+
+function hasRouteMiddleware(path: string, basename?: string): boolean {
+  const matches = matchRoutes(routeTree as never, path, basename) ?? [];
+  return matches.some((m) =>
+    Array.isArray((m.route as { middleware?: unknown }).middleware),
   );
 }
 
@@ -42,5 +59,28 @@ describe("account route compact-window grouping", () => {
     "/account/platform-callback",
   ])("%s is NOT sized by AccountLayout", (path) => {
     expect(isUnderAccountLayout(path)).toBe(false);
+  });
+});
+
+describe("remote web pairing route", () => {
+  test("stays outside the auth-protected assistant app tree", () => {
+    expect(hasRouteMiddleware("/assistant/pair?deviceCode=abc")).toBe(false);
+  });
+
+  test("uses the remote-gateway public path prefix as the router basename", () => {
+    window.__VELLUM_CONFIG__ = { mode: "remote-gateway" };
+    window.history.pushState(
+      null,
+      "",
+      "/assistant-123/assistant/pair?deviceCode=abc",
+    );
+
+    expect(getRouterBasename()).toBe("/assistant-123");
+    expect(
+      hasRouteMiddleware(
+        "/assistant-123/assistant/pair?deviceCode=abc",
+        "/assistant-123",
+      ),
+    ).toBe(false);
   });
 });

--- a/apps/web/src/routes.tsx
+++ b/apps/web/src/routes.tsx
@@ -14,6 +14,8 @@ import { NotFound } from "@/components/not-found";
 import { RouteErrorBoundary } from "@/components/route-error-boundary";
 import { RootHydrateFallback } from "@/components/root-hydrate-fallback";
 import { ActiveAssistantGate } from "@/components/layout/active-assistant-gate";
+import { remoteGatewayPublicPathPrefix } from "@/lib/auth/remote-gateway-session";
+import { isRemoteGatewayMode } from "@/lib/local-mode";
 import { routes } from "@/utils/routes";
 
 /**
@@ -32,7 +34,14 @@ function OAuthDesktopCompleteRedirect() {
   );
 }
 
-// Route tree — no basename, routes are absolute browser paths.
+export function getRouterBasename(): string | undefined {
+  if (!isRemoteGatewayMode()) return undefined;
+  return remoteGatewayPublicPathPrefix() || undefined;
+}
+
+// Route tree — no basename in normal app modes; remote-gateway mode adds the
+// public path prefix as the router basename so Velay-style URLs such as
+// `/assistant-123/assistant/pair` match the same `/assistant/*` route tree.
 // To view the full hierarchy at a glance:
 //   grep -n 'path:' apps/web/src/routes.tsx
 //
@@ -109,6 +118,11 @@ export const routeTree = [
     // bundle-confirmation BrowserWindow. No auth required so bundles can
     // be opened before the user logs in. Same sibling pattern as About.
     { path: "/assistant/bundle/confirm", ErrorBoundary: RouteErrorBoundary, HydrateFallback: RootHydrateFallback, lazy: { Component: () => import("@/pages/BundleConfirmPage").then((m) => m.BundleConfirmPage) } },
+
+    // Remote web pairing — standalone page for the RFC8628-style browser
+    // polling flow. It must stay outside the auth-protected app tree because
+    // its job is to obtain the first in-memory gateway access token.
+    { path: "/assistant/pair", ErrorBoundary: RouteErrorBoundary, HydrateFallback: RootHydrateFallback, lazy: { Component: () => import("@/domains/remote-web/pairing-page").then((m) => m.RemoteWebPairingPage) } },
 
     // Quick Input — lightweight input panel rendered inside the Electron
     // quick input BrowserWindow (a frameless, always-on-top panel invoked
@@ -329,5 +343,6 @@ export const routeTree = [
 ];
 
 export const router = createBrowserRouter(routeTree as never, {
+  basename: getRouterBasename(),
   future: { v8_middleware: true },
 });

--- a/apps/web/src/stores/auth-store.test.ts
+++ b/apps/web/src/stores/auth-store.test.ts
@@ -24,6 +24,7 @@ let mockIsLocalMode = false;
 let mockIsRemoteGatewayMode = false;
 let mockPlatformAssistants: unknown[] = [];
 let mockPrimeError: Error | null = null;
+let mockGatewayToken: string | null = null;
 const setSelectedAssistantMock = mock(async (_id: string | null) => {});
 const setFromApiMock = mock((_assistants: unknown) => {});
 const primeLocalGatewayConnectionMock = mock(async () => {
@@ -33,6 +34,7 @@ const primeLocalGatewayConnectionWithRepairMock = mock(async () => {
   if (mockPrimeError) throw mockPrimeError;
 });
 const ensureGatewayTokenMock = mock(async () => {});
+const refreshRemoteGatewaySessionMock = mock(async () => false);
 const restoreConsentForUserMock = mock((_userId: string | null) => ({
   tos: false,
   ai: false,
@@ -118,7 +120,12 @@ mock.module("@/lib/auth/gateway-session", () => ({
   isGatewayAuthMode: () => mockIsGatewayAuth,
   ensureGatewayToken: ensureGatewayTokenMock,
   clearGatewayToken: () => {},
+  getGatewayToken: () => mockGatewayToken,
   getLocalTokenUrl: () => "http://localhost/token",
+}));
+
+mock.module("@/lib/auth/remote-gateway-session", () => ({
+  refreshRemoteGatewaySession: refreshRemoteGatewaySessionMock,
 }));
 
 mock.module("@/lib/local-mode", () => ({
@@ -240,6 +247,21 @@ function resetAuthStore(): void {
   });
 }
 
+function authenticatedLocalUserForTest() {
+  return {
+    sessionStatus: "authenticated" as const,
+    user: {
+      id: "gateway-local",
+      username: "local",
+      email: null,
+      isStaff: false,
+      firstName: "Local",
+      lastName: "User",
+    },
+    platformSession: "absent" as const,
+  };
+}
+
 beforeEach(() => {
   sessionUser = null;
   getSessionCallCount = 0;
@@ -256,12 +278,14 @@ beforeEach(() => {
   mockIsNativePlatform = false;
   mockIsBiometricEnabled = false;
   mockBiometricToken = null;
+  mockGatewayToken = null;
   mockPrimeError = null;
   setSelectedAssistantMock.mockClear();
   setFromApiMock.mockClear();
   primeLocalGatewayConnectionMock.mockClear();
   primeLocalGatewayConnectionWithRepairMock.mockClear();
   ensureGatewayTokenMock.mockClear();
+  refreshRemoteGatewaySessionMock.mockClear();
   restoreConsentForUserMock.mockClear();
   persistConsentForUserMock.mockClear();
   resolveServerConsentMock.mockClear();
@@ -293,10 +317,12 @@ beforeEach(() => {
 describe("auth store onboarding flag reconciliation", () => {
   test("initSession treats remote-gateway mode as an authenticated local session", async () => {
     mockIsRemoteGatewayMode = true;
+    refreshRemoteGatewaySessionMock.mockImplementationOnce(async () => true);
 
     await useAuthStore.getState().initSession();
 
     expect(primeLocalGatewayConnectionMock).not.toHaveBeenCalled();
+    expect(refreshRemoteGatewaySessionMock).toHaveBeenCalledTimes(1);
     expect(getSessionCallCount).toBe(0);
     expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
     expect(useAuthStore.getState().user?.id).toBe("gateway-local");
@@ -306,12 +332,52 @@ describe("auth store onboarding flag reconciliation", () => {
   test("refreshSession keeps remote-gateway mode authenticated without minting a local token", async () => {
     mockIsRemoteGatewayMode = true;
     mockIsGatewayAuth = true;
+    refreshRemoteGatewaySessionMock.mockImplementationOnce(async () => true);
 
     await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
 
     expect(ensureGatewayTokenMock).not.toHaveBeenCalled();
+    expect(refreshRemoteGatewaySessionMock).toHaveBeenCalledTimes(1);
     expect(primeLocalGatewayConnectionMock).not.toHaveBeenCalled();
     expect(getSessionCallCount).toBe(0);
+    expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
+    expect(useAuthStore.getState().user?.id).toBe("gateway-local");
+    expect(useAuthStore.getState().platformSession).toBe("absent");
+  });
+
+  test("initSession leaves remote-gateway mode unauthenticated when cookie refresh fails and no token exists", async () => {
+    mockIsRemoteGatewayMode = true;
+
+    await useAuthStore.getState().initSession();
+
+    expect(refreshRemoteGatewaySessionMock).toHaveBeenCalledTimes(1);
+    expect(useAuthStore.getState().sessionStatus).toBe("unauthenticated");
+    expect(useAuthStore.getState().user).toBeNull();
+    expect(useAuthStore.getState().platformSession).toBe("absent");
+  });
+
+  test("refreshSession ends remote-gateway sessions when refresh fails and no token exists", async () => {
+    mockIsRemoteGatewayMode = true;
+    useAuthStore.setState({ ...authenticatedLocalUserForTest() });
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(false);
+
+    expect(refreshRemoteGatewaySessionMock).toHaveBeenCalledTimes(1);
+    expect(useAuthStore.getState().sessionStatus).toBe("unauthenticated");
+    expect(useAuthStore.getState().user).toBeNull();
+    expect(useAuthStore.getState().platformSession).toBe("absent");
+  });
+
+  test("refreshSession keeps remote-gateway sessions when refresh throws but a token is still valid", async () => {
+    mockIsRemoteGatewayMode = true;
+    mockGatewayToken = "access-token";
+    refreshRemoteGatewaySessionMock.mockImplementationOnce(async () => {
+      throw new TypeError("Failed to fetch");
+    });
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
+
+    expect(refreshRemoteGatewaySessionMock).toHaveBeenCalledTimes(1);
     expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
     expect(useAuthStore.getState().user?.id).toBe("gateway-local");
     expect(useAuthStore.getState().platformSession).toBe("absent");

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -37,8 +37,10 @@ import {
   isGatewayAuthMode,
   ensureGatewayToken,
   clearGatewayToken,
+  getGatewayToken,
   getLocalTokenUrl,
 } from "@/lib/auth/gateway-session";
+import { refreshRemoteGatewaySession } from "@/lib/auth/remote-gateway-session";
 import {
   isLocalMode,
   isRemoteGatewayMode,
@@ -452,6 +454,15 @@ function probePlatformSessionIfReachable(
   }
 }
 
+async function hasRemoteGatewaySessionAfterRefresh(): Promise<boolean> {
+  try {
+    if (await refreshRemoteGatewaySession()) return true;
+  } catch {
+    // A network failure says nothing about an already-valid in-memory token.
+  }
+  return getGatewayToken() !== null;
+}
+
 const useAuthStoreBase = create<AuthStore>()((set, get) => ({
   sessionStatus: "initializing",
   user: null,
@@ -459,7 +470,11 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
 
   initSession: async () => {
     if (isRemoteGatewayMode()) {
-      set({ ...authenticatedLocalUser(), platformSession: "absent" });
+      if (await hasRemoteGatewaySessionAfterRefresh()) {
+        set({ ...authenticatedLocalUser(), platformSession: "absent" });
+      } else {
+        set(sessionEnded());
+      }
       return;
     }
 
@@ -655,8 +670,12 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
 
   refreshSession: async () => {
     if (isRemoteGatewayMode()) {
-      set({ ...authenticatedLocalUser(), platformSession: "absent" });
-      return true;
+      if (await hasRemoteGatewaySessionAfterRefresh()) {
+        set({ ...authenticatedLocalUser(), platformSession: "absent" });
+        return true;
+      }
+      set(sessionEnded());
+      return false;
     }
 
     if (isGatewayAuthMode()) {

--- a/apps/web/src/utils/routes.ts
+++ b/apps/web/src/utils/routes.ts
@@ -1,10 +1,10 @@
 /**
  * Centralized URL registry for app-internal navigation.
  *
- * All paths are absolute browser paths — pass them directly to
- * `<Link to>`, `navigate()`, `window.location.href`, and pathname
- * comparisons. No React Router basename is in play; the router runs
- * at `/` and matches these paths as-is.
+ * All paths are absolute app paths — pass them directly to `<Link to>`,
+ * `navigate()`, `window.location.href`, and pathname comparisons. Normal app
+ * modes run the router at `/`; remote-gateway mode may add a public ingress
+ * prefix as the React Router basename while keeping these app paths unchanged.
  *
  * Captured paths (e.g. inputs to `sanitizeReturnTo`, query-string round-trips)
  * are values, not constants — do NOT rewrite those through this module.
@@ -47,6 +47,7 @@ export const routes = {
    * dedicated BrowserWindow.
    */
   bundleConfirm: r("/assistant/bundle/confirm"),
+  remotePair: r("/assistant/pair"),
   quickInput: r("/assistant/quick-input"),
   conversations: r("/assistant/conversations"),
   conversation: (key: string) => dyn(r("/assistant/conversations"), key),


### PR DESCRIPTION
## Summary
- Add a memory-only remote gateway access-token path for remote-gateway mode
- Add a standalone /assistant/pair page that polls the gateway pairing-token endpoint and primes self-hosted routing after approval
- Refresh remote-gateway sessions from the HttpOnly browser refresh cookie on app boot/resume

## Validation
- cd apps/web && TMPDIR=/private/tmp bun scripts/run-tests.ts src/lib/auth/remote-gateway-session.test.ts src/lib/auth/gateway-session.test.ts src/stores/auth-store.test.ts src/routes.test.ts
- pre-commit hook: web eslint, bun run openapi-ts, bunx tsc --noEmit