### PR TITLE
feat(web): actionable Log In button in platform-gate disabled notices

### DIFF
--- a/apps/web/src/components/platform-login-notice.tsx
+++ b/apps/web/src/components/platform-login-notice.tsx
@@ -1,0 +1,50 @@
+import { LogIn } from "lucide-react";
+import { type ReactNode } from "react";
+
+import { Button } from "@vellumai/design-library/components/button";
+import { Notice } from "@vellumai/design-library/components/notice";
+
+import { useOnboardingLogin } from "@/hooks/use-onboarding-login";
+
+interface PlatformLoginNoticeProps {
+  /**
+   * Why the surface needs a platform session — typically the existing
+   * "Log in to the Vellum platform to {action}." sentence.
+   */
+  children: ReactNode;
+  /** Forwarded to the underlying `Notice` (e.g. layout spacing). */
+  className?: string;
+}
+
+/**
+ * Info notice shown when `usePlatformGate()` returns `"disabled"`: the
+ * surface is meaningful but there is no platform session. Pairs the
+ * explanatory copy with an actionable "Log In" button (the shared
+ * `useOnboardingLogin` flow) so the prompt isn't a dead end.
+ *
+ * The button mirrors the affordance used in the settings sidebar and the
+ * active-assistant gate, including the loading → "Cancel" toggle.
+ */
+export function PlatformLoginNotice({
+  children,
+  className,
+}: PlatformLoginNoticeProps) {
+  const { loading, login, cancel } = useOnboardingLogin();
+  return (
+    <Notice
+      tone="info"
+      className={className}
+      actions={
+        <Button
+          variant="ghost"
+          leftIcon={loading ? undefined : <LogIn className="h-4 w-4" />}
+          onClick={loading ? cancel : () => void login()}
+        >
+          {loading ? "Cancel" : "Log In"}
+        </Button>
+      }
+    >
+      {children}
+    </Notice>
+  );
+}

--- a/apps/web/src/components/platform-login-notice.tsx
+++ b/apps/web/src/components/platform-login-notice.tsx
@@ -1,5 +1,6 @@
 import { LogIn } from "lucide-react";
 import { type ReactNode } from "react";
+import { useLocation } from "react-router";
 
 import { Button } from "@vellumai/design-library/components/button";
 import { Notice } from "@vellumai/design-library/components/notice";
@@ -29,7 +30,14 @@ export function PlatformLoginNotice({
   children,
   className,
 }: PlatformLoginNoticeProps) {
-  const { loading, login, cancel } = useOnboardingLogin();
+  // Return to the full current URL (including query/hash) after login so
+  // params these surfaces depend on — e.g. billing's `?session_id` /
+  // `?billing_status` — survive the auth round-trip. `useOnboardingLogin`
+  // otherwise derives the return target from `pathname` only.
+  const { pathname, search, hash } = useLocation();
+  const { loading, login, cancel } = useOnboardingLogin(
+    `${pathname}${search}${hash}`,
+  );
   return (
     <Notice
       tone="info"

--- a/apps/web/src/domains/chat/components/maintenance-mode-banner.tsx
+++ b/apps/web/src/domains/chat/components/maintenance-mode-banner.tsx
@@ -2,13 +2,13 @@
 import { AlertTriangle, Loader2 } from "lucide-react";
 import { useState } from "react";
 
+import { PlatformLoginNotice } from "@/components/platform-login-notice";
 import { assistantsMaintenanceModeExitCreate } from "@/generated/api/sdk.gen";
 import {
     useActiveAssistantLifecycleIsLoading,
     usePlatformGate,
 } from "@/hooks/use-platform-gate";
 import { Button } from "@vellumai/design-library";
-import { Notice } from "@vellumai/design-library/components/notice";
 
 interface MaintenanceModeBannerProps {
   assistantId: string;
@@ -90,9 +90,9 @@ export function MaintenanceModeBanner({
       </div>
       {showExitAction ? (
         platformGate === "disabled" ? (
-          <Notice tone="info">
+          <PlatformLoginNotice>
             Log in to the Vellum platform to exit Recovery Mode.
-          </Notice>
+          </PlatformLoginNotice>
         ) : (
           <Button
             variant="primary"

--- a/apps/web/src/domains/logs/pages/emails-page.tsx
+++ b/apps/web/src/domains/logs/pages/emails-page.tsx
@@ -1,10 +1,10 @@
 import { Navigate } from "react-router";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
+import { PlatformLoginNotice } from "@/components/platform-login-notice";
 import { EmailsTab } from "@/domains/logs/components/emails-tab";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { routes } from "@/utils/routes";
-import { Notice } from "@vellumai/design-library/components/notice";
 
 export function EmailsPage() {
   const platformGate = usePlatformGate();
@@ -16,9 +16,9 @@ export function EmailsPage() {
 
   if (platformGate === "disabled") {
     return (
-      <Notice tone="info">
+      <PlatformLoginNotice>
         Log in to the Vellum platform to view emails.
-      </Notice>
+      </PlatformLoginNotice>
     );
   }
 

--- a/apps/web/src/domains/logs/pages/system-events-page.tsx
+++ b/apps/web/src/domains/logs/pages/system-events-page.tsx
@@ -1,6 +1,7 @@
 import { Navigate } from "react-router";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
+import { PlatformLoginNotice } from "@/components/platform-login-notice";
 import { SystemEventsTab } from "@/domains/logs/components/system-events-tab";
 import {
     useActiveAssistantIsPlatformHosted,
@@ -20,9 +21,9 @@ export function SystemEventsPage() {
 
   if (platformGate === "disabled") {
     return (
-      <Notice tone="info">
+      <PlatformLoginNotice>
         Log in to the Vellum platform to view system events.
-      </Notice>
+      </PlatformLoginNotice>
     );
   }
 

--- a/apps/web/src/domains/settings/ai/email-service-card.tsx
+++ b/apps/web/src/domains/settings/ai/email-service-card.tsx
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
+import { PlatformLoginNotice } from "@/components/platform-login-notice";
 import {
     assistantsListOptions,
 } from "@/generated/api/@tanstack/react-query.gen";
@@ -19,7 +20,6 @@ import { useEnvironmentStore } from "@/stores/environment-store";
 import { shouldRetryDaemonError } from "@/utils/daemon-errors";
 import { getLocalSetting, setLocalSetting } from "@/utils/local-settings";
 import { Dropdown } from "@vellumai/design-library/components/dropdown";
-import { Notice } from "@vellumai/design-library/components/notice";
 import { toast } from "@vellumai/design-library/components/toast";
 
 import { ByoServiceCard, SaveButton, ServiceCard } from "@/domains/settings/ai/shared-ui";
@@ -194,9 +194,9 @@ export function EmailServiceCard() {
       {mode === "managed" ? (
         <div className="space-y-4">
           {platformGate === "disabled" ? (
-            <Notice tone="info">
+            <PlatformLoginNotice>
               Log in to the Vellum platform to manage email settings.
-            </Notice>
+            </PlatformLoginNotice>
           ) : (
             <EmailManagedContent
               assistantId={assistantId}

--- a/apps/web/src/domains/settings/billing/billing-page.tsx
+++ b/apps/web/src/domains/settings/billing/billing-page.tsx
@@ -5,6 +5,7 @@ import { Navigate, useNavigate, useSearchParams } from "react-router";
 
 import { useQueryClient } from "@tanstack/react-query";
 
+import { PlatformLoginNotice } from "@/components/platform-login-notice";
 import { BillingOnboardingModal } from "@/domains/settings/billing/pro-onboarding/billing-onboarding-modal";
 import { AdjustPlanModal } from "@/domains/settings/components/adjust-plan-modal";
 import { BillingPanel } from "@/domains/settings/components/billing-panel";
@@ -98,9 +99,9 @@ export function BillingPage() {
   if (billingGate === "disabled") {
     return (
       <div className="space-y-4">
-        <Notice tone="info">
+        <PlatformLoginNotice>
           Log in to the Vellum platform to manage billing and usage.
-        </Notice>
+        </PlatformLoginNotice>
       </div>
     );
   }

--- a/apps/web/src/domains/settings/billing/upgrade-cancel-page.tsx
+++ b/apps/web/src/domains/settings/billing/upgrade-cancel-page.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 
 import { Navigate, useNavigate } from "react-router";
 
+import { PlatformLoginNotice } from "@/components/platform-login-notice";
 import {
     useActiveAssistantIsPlatformHosted,
     useActiveAssistantLifecycleIsLoading,
@@ -69,9 +70,9 @@ export function UpgradeCancelPage() {
   if (platformGate === "disabled") {
     return (
       <div className="max-w-4xl space-y-6">
-        <Notice tone="info">
+        <PlatformLoginNotice>
           Log in to the Vellum platform to manage billing and usage.
-        </Notice>
+        </PlatformLoginNotice>
       </div>
     );
   }

--- a/apps/web/src/domains/settings/billing/upgrade-success-page.tsx
+++ b/apps/web/src/domains/settings/billing/upgrade-success-page.tsx
@@ -5,6 +5,7 @@ import { Navigate, useNavigate } from "react-router";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
+import { PlatformLoginNotice } from "@/components/platform-login-notice";
 import {
     organizationsBillingSubscriptionRetrieveOptions,
     organizationsBillingSubscriptionRetrieveQueryKey,
@@ -137,9 +138,9 @@ export function UpgradeSuccessPage() {
   if (platformGate === "disabled") {
     return (
       <div className="max-w-4xl space-y-6">
-        <Notice tone="info">
+        <PlatformLoginNotice>
           Log in to the Vellum platform to manage billing and usage.
-        </Notice>
+        </PlatformLoginNotice>
       </div>
     );
   }

--- a/apps/web/src/domains/settings/components/access-consent-setting.tsx
+++ b/apps/web/src/domains/settings/components/access-consent-setting.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
 
+import { PlatformLoginNotice } from "@/components/platform-login-notice";
 import {
     assistantsAccessConsentRetrieveOptions,
     assistantsAccessConsentRetrieveSetQueryData,
@@ -11,7 +12,6 @@ import {
     useActiveAssistantLifecycleIsLoading,
     usePlatformGate,
 } from "@/hooks/use-platform-gate";
-import { Notice } from "@vellumai/design-library/components/notice";
 import { toast } from "@vellumai/design-library/components/toast";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 
@@ -132,9 +132,9 @@ export function AccessConsentSetting() {
         </div>
       </div>
       {platformGate === "disabled" && (
-        <Notice tone="info" className="mt-3">
+        <PlatformLoginNotice className="mt-3">
           Log in to the Vellum platform to manage admin data access.
-        </Notice>
+        </PlatformLoginNotice>
       )}
     </div>
   );

--- a/apps/web/src/domains/settings/components/delete-account-section.tsx
+++ b/apps/web/src/domains/settings/components/delete-account-section.tsx
@@ -2,6 +2,7 @@ import { Loader2 } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { DetailCard } from "@/components/detail-card";
+import { PlatformLoginNotice } from "@/components/platform-login-notice";
 import { useUserDeletionRequestCreateMutation } from "@/generated/api/@tanstack/react-query.gen";
 import {
     useActiveAssistantLifecycleIsLoading,
@@ -13,7 +14,6 @@ import { clearConsentForUser } from "@/utils/onboarding-cleanup";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
-import { Notice } from "@vellumai/design-library/components/notice";
 import { toast } from "@vellumai/design-library/components/toast";
 
 export function DeleteAccountSection() {
@@ -81,9 +81,9 @@ export function DeleteAccountSection() {
         variant="danger"
       >
         {platformGate === "disabled" ? (
-          <Notice tone="info">
+          <PlatformLoginNotice>
             Log in to the Vellum platform to delete your account.
-          </Notice>
+          </PlatformLoginNotice>
         ) : (
           <div className="flex items-center gap-2">
             <Button

--- a/apps/web/src/domains/settings/components/integration-detail-modal.tsx
+++ b/apps/web/src/domains/settings/components/integration-detail-modal.tsx
@@ -11,10 +11,10 @@ import {
 import type { OAuthConnection } from "@/generated/api/types.gen";
 import { Button } from "@vellumai/design-library/components/button";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
-import { Notice } from "@vellumai/design-library/components/notice";
 import { toast } from "@vellumai/design-library/components/toast";
 
 import { IntegrationIcon } from "@/components/integrations/integration-icon";
+import { PlatformLoginNotice } from "@/components/platform-login-notice";
 import { useOAuthConnect } from "@/hooks/use-oauth-connect";
 import type { PlatformGateState } from "@/hooks/use-platform-gate";
 import { extractErrorMessage } from "@/utils/api-errors";
@@ -205,9 +205,9 @@ export function IntegrationDetailModal({
 
           {activeTab === "managed" && platformGate !== "gated" ? (
             platformGate === "disabled" ? (
-              <Notice tone="info">
+              <PlatformLoginNotice>
                 Log in to the Vellum platform to manage OAuth connections.
-              </Notice>
+              </PlatformLoginNotice>
             ) : (
               <ManagedTab
                 displayName={displayName}

--- a/apps/web/src/domains/settings/components/panels/assistant-terminal-panel.tsx
+++ b/apps/web/src/domains/settings/components/panels/assistant-terminal-panel.tsx
@@ -2,6 +2,7 @@ import { Terminal } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { getAssistant } from "@/assistant/api";
+import { PlatformLoginNotice } from "@/components/platform-login-notice";
 import { TerminalPanel } from "@/components/terminal-panel";
 import type { MaintenanceMode } from "@/generated/api/types.gen";
 import {
@@ -11,7 +12,6 @@ import {
 import { captureError } from "@/lib/sentry/capture-error";
 import { toast } from "@vellumai/design-library";
 import { Dropdown } from "@vellumai/design-library/components/dropdown";
-import { Notice } from "@vellumai/design-library/components/notice";
 
 type TerminalService = "assistant" | "gateway" | "credential-executor";
 
@@ -118,9 +118,9 @@ export function AssistantTerminalPanel() {
       </div>
 
       {platformGate === "disabled" ? (
-        <Notice tone="info">
+        <PlatformLoginNotice>
           Log in to the Vellum platform to open a terminal session.
-        </Notice>
+        </PlatformLoginNotice>
       ) : showLoading ? (
         <div className="flex items-center gap-2 text-body-medium-lighter text-[var(--content-tertiary)]">
           <span className="h-4 w-4 animate-spin rounded-full border-2 border-[var(--border-element)] border-t-[var(--content-secondary)]" />

--- a/apps/web/src/domains/settings/components/panels/debug-controls-panel.tsx
+++ b/apps/web/src/domains/settings/components/panels/debug-controls-panel.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 
 import { type Assistant, getAssistant } from "@/assistant/api";
+import { PlatformLoginNotice } from "@/components/platform-login-notice";
 import { AssistantBackups } from "@/domains/settings/components/assistant-backups";
 import { RecoveryModeControls } from "@/domains/settings/components/recovery-mode-controls";
 import { RestartAssistant } from "@/domains/settings/components/restart-assistant";
@@ -12,7 +13,6 @@ import { useAuthStore } from "@/stores/auth-store";
 import { clearConsentForUser } from "@/utils/onboarding-cleanup";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
-import { Notice } from "@vellumai/design-library/components/notice";
 import { toast } from "@vellumai/design-library/components/toast";
 
 function isInternalUser(email: string | null, isAdmin: boolean): boolean {
@@ -88,9 +88,9 @@ export function DebugControlsPanel() {
       ) : assistant ? (
         <div className="space-y-4">
           {platformGate === "disabled" && (
-            <Notice tone="info">
+            <PlatformLoginNotice>
               Log in to the Vellum platform to manage backups.
-            </Notice>
+            </PlatformLoginNotice>
           )}
           {platformGate !== "disabled" && (
             <div className="rounded-lg border border-[var(--border-base)] px-4 py-3 dark:border-[var(--border-base)]">

--- a/apps/web/src/domains/settings/components/recovery-mode-controls.tsx
+++ b/apps/web/src/domains/settings/components/recovery-mode-controls.tsx
@@ -1,6 +1,7 @@
 import { Loader2, Wrench } from "lucide-react";
 import { useCallback, useState } from "react";
 
+import { PlatformLoginNotice } from "@/components/platform-login-notice";
 import {
     assistantsMaintenanceModeEnterCreate,
     assistantsMaintenanceModeExitCreate,
@@ -144,9 +145,9 @@ export function RecoveryModeControls({
       </div>
 
       {platformGate === "disabled" && (
-        <Notice tone="info">
+        <PlatformLoginNotice>
           Log in to the Vellum platform to {isActive ? "exit" : "enter"} Recovery Mode.
-        </Notice>
+        </PlatformLoginNotice>
       )}
       {error && <Notice tone="error">{error}</Notice>}
     </div>

--- a/apps/web/src/domains/settings/pages/advanced-page.test.tsx
+++ b/apps/web/src/domains/settings/pages/advanced-page.test.tsx
@@ -19,6 +19,18 @@ mock.module("@/hooks/use-platform-gate", () => ({
   usePlatformGate: () => "hidden",
 }));
 
+// Stub the login hook so importing the page doesn't pull the auth-store →
+// assistant/api → daemon SDK chain into this unit test (the gate is mocked to
+// a non-"disabled" value, so PlatformLoginNotice never renders here anyway).
+mock.module("@/hooks/use-onboarding-login", () => ({
+  useOnboardingLogin: () => ({
+    loading: false,
+    error: null,
+    login: mock(async () => {}),
+    cancel: mock(() => {}),
+  }),
+}));
+
 mock.module("@/assistant/use-active-assistant-id", () => ({
   useActiveAssistantId: () => "assistant-1",
 }));

--- a/apps/web/src/domains/settings/pages/advanced-page.tsx
+++ b/apps/web/src/domains/settings/pages/advanced-page.tsx
@@ -2,12 +2,12 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { DetailCard } from "@/components/detail-card";
+import { PlatformLoginNotice } from "@/components/platform-login-notice";
 import { useAssistantWithHealthz } from "@/domains/settings/components/assistant-status-panel";
 import { UpdateWindowPolicy } from "@/domains/settings/components/update-window-policy";
 import { configGetOptions, configGetSetQueryData, useConfigPatchMutation } from "@/generated/daemon/@tanstack/react-query.gen";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { captureError } from "@/lib/sentry/capture-error";
-import { Notice } from "@vellumai/design-library/components/notice";
 import { toast } from "@vellumai/design-library/components/toast";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 
@@ -60,9 +60,9 @@ export function AdvancedPage() {
           title="Update Window"
           subtitle="Configure when automatic updates are applied."
         >
-          <Notice tone="info">
+          <PlatformLoginNotice>
             Log in to the Vellum platform to manage update window policy.
-          </Notice>
+          </PlatformLoginNotice>
         </DetailCard>
       )}
       {showMemoryOptOut ? (

--- a/apps/web/src/domains/settings/pages/devices-page.tsx
+++ b/apps/web/src/domains/settings/pages/devices-page.tsx
@@ -4,6 +4,7 @@ import { Navigate } from "react-router";
 import { useQuery } from "@tanstack/react-query";
 
 import { DetailCard } from "@/components/detail-card";
+import { PlatformLoginNotice } from "@/components/platform-login-notice";
 import { DeviceRow } from "@/domains/settings/components/device-row";
 import { assistantsListOptions } from "@/generated/api/@tanstack/react-query.gen";
 import type { Assistant } from "@/generated/api/types.gen";
@@ -34,9 +35,9 @@ export function DevicesPage() {
   if (platformGate === "disabled") {
     return (
       <div className="space-y-4">
-        <Notice tone="info">
+        <PlatformLoginNotice>
           Log in to the Vellum platform to manage self-hosted assistants.
-        </Notice>
+        </PlatformLoginNotice>
       </div>
     );
   }

--- a/apps/web/src/domains/settings/pages/general-page.tsx
+++ b/apps/web/src/domains/settings/pages/general-page.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from "react-router";
 import { useDiskPressureMonitor } from "@/assistant/use-disk-pressure-monitor";
 import { DetailCard } from "@/components/detail-card";
 import { DiskPressureBanner, type DiskPressureBannerMode } from "@/components/disk-pressure-banner";
+import { PlatformLoginNotice } from "@/components/platform-login-notice";
 import { ProfileCard } from "@/components/profile-card";
 import { AssistantPicker } from "@/domains/settings/components/assistant-picker";
 import { AssistantSleepPolicy } from "@/domains/settings/components/assistant-sleep-policy";
@@ -22,7 +23,6 @@ import { PreviewReleaseChannel } from "@/domains/settings/components/preview-rel
 import { ResizeCard } from "@/domains/settings/components/resize-card";
 import { RetireAssistant } from "@/domains/settings/components/retire-assistant";
 import { TimezonePicker } from "@/domains/settings/components/timezone-picker";
-import { Notice } from "@vellumai/design-library/components/notice";
 import { SegmentControl } from "@vellumai/design-library/components/segment-control";
 
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
@@ -296,9 +296,9 @@ export function GeneralPage() {
           title="Compute & Resources"
           subtitle="Monitor resource usage and manage your assistant's compute profile."
         >
-          <Notice tone="info">
+          <PlatformLoginNotice>
             Log in to the Vellum platform to manage compute resources.
-          </Notice>
+          </PlatformLoginNotice>
         </DetailCard>
       )}
 
@@ -332,9 +332,9 @@ export function GeneralPage() {
       )}
       {infraGate === "disabled" && (
         <DetailCard title="Software Updates">
-          <Notice tone="info">
+          <PlatformLoginNotice>
             Log in to the Vellum platform to manage software updates.
-          </Notice>
+          </PlatformLoginNotice>
         </DetailCard>
       )}
 
@@ -353,9 +353,9 @@ export function GeneralPage() {
           title="Sleep Policy"
           subtitle="Control how long this assistant stays awake when idle."
         >
-          <Notice tone="info">
+          <PlatformLoginNotice>
             Log in to the Vellum platform to manage sleep policy.
-          </Notice>
+          </PlatformLoginNotice>
         </DetailCard>
       )}
 
@@ -380,9 +380,9 @@ export function GeneralPage() {
           title="Retire Assistant"
           subtitle="Permanently retire this assistant and delete all associated data."
         >
-          <Notice tone="info">
+          <PlatformLoginNotice>
             Log in to the Vellum platform to retire this assistant.
-          </Notice>
+          </PlatformLoginNotice>
         </DetailCard>
       )}
 

--- a/apps/web/src/domains/settings/pages/notifications-page.tsx
+++ b/apps/web/src/domains/settings/pages/notifications-page.tsx
@@ -12,6 +12,7 @@ import { Navigate } from "react-router";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
+import { PlatformLoginNotice } from "@/components/platform-login-notice";
 import {
     SNOOZE_OPTIONS,
     formatRelativeDate,
@@ -587,9 +588,9 @@ export function NotificationsPage() {
             </p>
           </div>
         </div>
-        <Notice tone="info">
+        <PlatformLoginNotice>
           Log in to the Vellum platform to view notifications.
-        </Notice>
+        </PlatformLoginNotice>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- Add `PlatformLoginNotice` (`apps/web/src/components/platform-login-notice.tsx`): an info `Notice` whose `actions` slot holds a ghost **Log In** button wired to the shared `useOnboardingLogin` flow, with a leading `LogIn` icon and a `loading → Cancel` toggle — mirroring the affordance already used in the settings sidebar and active-assistant gate. No design-library changes (the `actions` slot already exists).
- Swap all **20** inline `usePlatformGate() === "disabled"` notices (settings, billing, logs, chat) from a plain-text `<Notice tone="info">` to `<PlatformLoginNotice>`, so every 'Log in to the Vellum platform to …' prompt now offers a one-click way to actually log in. Copy is unchanged; the only added prop is an optional `className` passthrough (used to preserve `mt-3` spacing on the access-consent notice).
- Removed the now-unused `Notice` import where a file no longer renders any other `Notice`; kept it where other-toned notices remain.

## Original prompt
While inventorying the surfaces that handle the `usePlatformGate` `"disabled"` state, we found ~20 notices that tell the user to 'Log in to the Vellum platform to {action}.' but give them nothing to click — a dead end. The ask was to make these actionable by including a real Log In button (consistent with the ghost Log In affordance shipped elsewhere), and to roll it out across all the disabled-branch notices via a shared component.