### PR TITLE
Add execution/attempt filtering to the heartbeat runs endpoint

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -11854,6 +11854,18 @@ paths:
           schema:
             type: integer
           description: "Cursor for older runs: pass the previous page's `nextCursor` to return runs strictly older than it."
+        - name: include
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - executions
+              - attempts
+              - all
+          description:
+            "Filter by run class: `executions` (ok/error/timeout), `attempts` (skipped/missed/superseded), or `all`
+            (default)."
       responses:
         "200":
           description: Successful response

--- a/assistant/src/heartbeat/__tests__/heartbeat-run-store.test.ts
+++ b/assistant/src/heartbeat/__tests__/heartbeat-run-store.test.ts
@@ -16,6 +16,8 @@ import { initializeDb } from "../../memory/db-init.js";
 import {
   completeHeartbeatRun,
   countCompletedHeartbeatRuns,
+  HEARTBEAT_ATTEMPT_STATUSES,
+  HEARTBEAT_EXECUTION_STATUSES,
   insertPendingHeartbeatRun,
   listHeartbeatRuns,
   markStaleRunningAsError,
@@ -235,6 +237,71 @@ describe("heartbeat-run-store", () => {
     completeHeartbeatRun(id4, { status: "ok", conversationId: "conv-2" });
 
     expect(countCompletedHeartbeatRuns()).toBe(2);
+  });
+
+  test("listHeartbeatRuns filters by status class", () => {
+    const now = Date.now();
+
+    // ok
+    const idOk = insertPendingHeartbeatRun(now);
+    startHeartbeatRun(idOk);
+    completeHeartbeatRun(idOk, { status: "ok", conversationId: "conv-ok" });
+
+    // error
+    const idError = insertPendingHeartbeatRun(now + 1);
+    startHeartbeatRun(idError);
+    completeHeartbeatRun(idError, { status: "error", error: "boom" });
+
+    // timeout
+    const idTimeout = insertPendingHeartbeatRun(now + 2);
+    startHeartbeatRun(idTimeout);
+    completeHeartbeatRun(idTimeout, { status: "timeout" });
+
+    // skipped
+    const idSkipped = insertPendingHeartbeatRun(now + 3);
+    skipHeartbeatRun(idSkipped, "disabled");
+
+    // superseded
+    const idSuperseded = insertPendingHeartbeatRun(now + 4);
+    supersedePendingRun(idSuperseded);
+
+    // missed (drive via the stale-pending sweep)
+    insertPendingHeartbeatRun(now - 10 * 60 * 1000);
+    markStaleRunsAsMissed(5 * 60 * 1000);
+
+    // in-flight rows (excluded from both classes)
+    insertPendingHeartbeatRun(now + 5);
+    const idRunning = insertPendingHeartbeatRun(now + 6);
+    startHeartbeatRun(idRunning);
+
+    const executionStatuses = listHeartbeatRuns(50, undefined, {
+      statuses: HEARTBEAT_EXECUTION_STATUSES,
+    })
+      .map((r) => r.status)
+      .sort();
+    expect(executionStatuses).toEqual(["error", "ok", "timeout"]);
+
+    const attemptStatuses = listHeartbeatRuns(50, undefined, {
+      statuses: HEARTBEAT_ATTEMPT_STATUSES,
+    })
+      .map((r) => r.status)
+      .sort();
+    expect(attemptStatuses).toEqual(["missed", "skipped", "superseded"]);
+
+    // No opts → everything, including in-flight rows.
+    const allStatuses = listHeartbeatRuns(50)
+      .map((r) => r.status)
+      .sort();
+    expect(allStatuses).toEqual([
+      "error",
+      "missed",
+      "ok",
+      "pending",
+      "running",
+      "skipped",
+      "superseded",
+      "timeout",
+    ]);
   });
 
   test("countCompletedHeartbeatRuns returns 0 when no ok rows exist", () => {

--- a/assistant/src/heartbeat/heartbeat-run-store.ts
+++ b/assistant/src/heartbeat/heartbeat-run-store.ts
@@ -1,4 +1,4 @@
-import { desc, eq, lt, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, lt, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getDb } from "../memory/db-connection.js";
@@ -18,6 +18,21 @@ export type HeartbeatRunStatus =
   | "skipped"
   | "missed"
   | "superseded";
+
+/**
+ * Statuses that represent a billed heartbeat execution (a conversation actually ran).
+ */
+export const HEARTBEAT_EXECUTION_STATUSES = ["ok", "error", "timeout"] as const;
+
+/**
+ * Statuses that represent a no-op attempt (no conversation ran).
+ * `pending`/`running` are in-flight and excluded from both classes.
+ */
+export const HEARTBEAT_ATTEMPT_STATUSES = [
+  "skipped",
+  "missed",
+  "superseded",
+] as const;
 
 export type HeartbeatSkipReason =
   | "disabled"
@@ -278,12 +293,17 @@ export function countRecentConsecutiveRuns(maxToCheck: number): number {
 export function listHeartbeatRuns(
   limit = 20,
   before?: number,
+  opts?: { statuses?: readonly HeartbeatRunStatus[] },
 ): HeartbeatRunRecord[] {
   const db = getDb();
+  const conditions = [
+    before != null ? lt(heartbeatRuns.scheduledFor, before) : undefined,
+    opts?.statuses ? inArray(heartbeatRuns.status, opts.statuses) : undefined,
+  ].filter((c) => c != null);
   const rows = db
     .select()
     .from(heartbeatRuns)
-    .where(before != null ? lt(heartbeatRuns.scheduledFor, before) : undefined)
+    .where(conditions.length > 0 ? and(...conditions) : undefined)
     .orderBy(desc(heartbeatRuns.scheduledFor))
     .limit(limit)
     .all();

--- a/assistant/src/runtime/routes/heartbeat-routes.ts
+++ b/assistant/src/runtime/routes/heartbeat-routes.ts
@@ -16,7 +16,12 @@ import {
   loadRawConfig,
   saveRawConfig,
 } from "../../config/loader.js";
-import { listHeartbeatRuns } from "../../heartbeat/heartbeat-run-store.js";
+import {
+  HEARTBEAT_ATTEMPT_STATUSES,
+  HEARTBEAT_EXECUTION_STATUSES,
+  type HeartbeatRunStatus,
+  listHeartbeatRuns,
+} from "../../heartbeat/heartbeat-run-store.js";
 import { HeartbeatService } from "../../heartbeat/heartbeat-service.js";
 import { getConversation } from "../../memory/conversation-crud.js";
 import { getUsageCostForConversationWindow } from "../../memory/llm-usage-store.js";
@@ -40,12 +45,26 @@ const log = getLogger("heartbeat-routes");
 // Handlers (transport-agnostic)
 // ---------------------------------------------------------------------------
 
+function resolveIncludeStatuses(
+  include: string | undefined,
+): readonly HeartbeatRunStatus[] | undefined {
+  switch (include) {
+    case "executions":
+      return HEARTBEAT_EXECUTION_STATUSES;
+    case "attempts":
+      return HEARTBEAT_ATTEMPT_STATUSES;
+    default:
+      return undefined;
+  }
+}
+
 function handleListRuns(queryParams: Record<string, string>) {
   const limit = parseRunsLimit(queryParams, 20);
   const before = parseRunsBeforeCursor(queryParams);
+  const statuses = resolveIncludeStatuses(queryParams.include);
 
   const { rows, nextCursor } = paginateRuns(
-    listHeartbeatRuns(limit + 1, before),
+    listHeartbeatRuns(limit + 1, before, { statuses }),
     limit,
     (r) => r.scheduledFor,
   );
@@ -123,7 +142,19 @@ export const ROUTES: RouteDefinition[] = [
     summary: "List heartbeat runs",
     description: "Return recent heartbeat conversation runs.",
     tags: ["heartbeat"],
-    queryParams: RUNS_PAGINATION_QUERY_PARAMS(20),
+    queryParams: [
+      ...RUNS_PAGINATION_QUERY_PARAMS(20),
+      {
+        name: "include",
+        schema: {
+          type: "string",
+          enum: ["executions", "attempts", "all"],
+        },
+        description:
+          "Filter by run class: `executions` (ok/error/timeout), " +
+          "`attempts` (skipped/missed/superseded), or `all` (default).",
+      },
+    ],
     responseBody: z.object({
       runs: z
         .array(


### PR DESCRIPTION
## Summary
- Add HEARTBEAT_EXECUTION_STATUSES / HEARTBEAT_ATTEMPT_STATUSES classes and an optional status filter to listHeartbeatRuns
- GET /v1/heartbeat/runs accepts ?include=executions|attempts|all (default all, backwards compatible)
- Regenerate openapi.yaml; add run-store filter tests

Part of plan: schedule-details-edit.md (PR 1 of 10)