### PR TITLE
Accept maxConsecutiveRuns and maxDailyRuns in the heartbeat config endpoint

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -11701,6 +11701,14 @@ paths:
                     anyOf:
                       - type: string
                       - type: "null"
+                  maxConsecutiveRuns:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  maxDailyRuns:
+                    anyOf:
+                      - type: number
+                      - type: "null"
                   nextRunAt:
                     anyOf:
                       - type: number
@@ -11718,6 +11726,8 @@ paths:
                   - activeHoursEnd
                   - cronExpression
                   - timezone
+                  - maxConsecutiveRuns
+                  - maxDailyRuns
                   - nextRunAt
                   - lastRunAt
                   - success
@@ -11761,6 +11771,20 @@ paths:
                   anyOf:
                     - type: string
                     - type: "null"
+                maxConsecutiveRuns:
+                  description: Max consecutive heartbeats without a guardian message, or null for unlimited
+                  anyOf:
+                    - type: integer
+                      exclusiveMinimum: 0
+                      maximum: 9007199254740991
+                    - type: "null"
+                maxDailyRuns:
+                  description: Max heartbeats per calendar day, or null for unlimited
+                  anyOf:
+                    - type: integer
+                      exclusiveMinimum: 0
+                      maximum: 9007199254740991
+                    - type: "null"
       responses:
         "200":
           description: Successful response
@@ -11789,6 +11813,14 @@ paths:
                     anyOf:
                       - type: string
                       - type: "null"
+                  maxConsecutiveRuns:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  maxDailyRuns:
+                    anyOf:
+                      - type: number
+                      - type: "null"
                   nextRunAt:
                     anyOf:
                       - type: number
@@ -11806,6 +11838,8 @@ paths:
                   - activeHoursEnd
                   - cronExpression
                   - timezone
+                  - maxConsecutiveRuns
+                  - maxDailyRuns
                   - nextRunAt
                   - lastRunAt
                   - success

--- a/assistant/src/runtime/routes/__tests__/heartbeat-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/heartbeat-routes.test.ts
@@ -15,11 +15,16 @@ import type { RouteDefinition } from "../types.js";
 
 // ─── Module mocks ──────────────────────────────────────────────────────────
 
-// Stub the heartbeat service so the response-path's getInstance() returns
-// undefined (no scheduler running in tests).
+// Stub the heartbeat service so the response-path's getInstance() returns a
+// reconfigure spy and surfaces no scheduler-derived values.
+const reconfigureSpy = mock(() => {});
 mock.module("../../../heartbeat/heartbeat-service.js", () => ({
   HeartbeatService: {
-    getInstance: () => undefined,
+    getInstance: () => ({
+      reconfigure: reconfigureSpy,
+      nextRunAt: null,
+      lastRunAt: null,
+    }),
   },
 }));
 
@@ -29,10 +34,14 @@ let workspaceDir: string;
 let origWorkspaceDir: string | undefined;
 let configPath: string;
 
-function findHandler(operationId: string): RouteDefinition["handler"] {
+function findRoute(operationId: string): RouteDefinition {
   const route = ROUTES.find((r) => r.operationId === operationId);
   if (!route) throw new Error(`Route ${operationId} not found`);
-  return route.handler;
+  return route;
+}
+
+function findHandler(operationId: string): RouteDefinition["handler"] {
+  return findRoute(operationId).handler;
 }
 
 function readConfig(): Record<string, unknown> {
@@ -108,5 +117,60 @@ describe("setHeartbeatConfig handler", () => {
     expect(onDisk).toEqual({
       heartbeat: { intervalMs: 60000, enabled: true },
     });
+  });
+});
+
+describe("heartbeat run caps", () => {
+  test("PUT persists maxDailyRuns and GET reflects it", async () => {
+    writeFileSync(configPath, JSON.stringify({}, null, 2) + "\n");
+
+    const put = findHandler("updateHeartbeatConfig");
+    const putResult = (await put({ body: { maxDailyRuns: 6 } })) as {
+      maxDailyRuns: number | null;
+    };
+    expect(putResult.maxDailyRuns).toBe(6);
+
+    expect(readConfig()).toEqual({ heartbeat: { maxDailyRuns: 6 } });
+
+    const get = findHandler("getHeartbeatConfig");
+    const getResult = (await get({})) as { maxDailyRuns: number | null };
+    expect(getResult.maxDailyRuns).toBe(6);
+  });
+
+  test("PUT with null clears maxConsecutiveRuns (unbounded)", async () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify({ heartbeat: { maxConsecutiveRuns: 5 } }, null, 2) + "\n",
+    );
+
+    const put = findHandler("updateHeartbeatConfig");
+    const putResult = (await put({
+      body: { maxConsecutiveRuns: null },
+    })) as { maxConsecutiveRuns: number | null };
+    expect(putResult.maxConsecutiveRuns).toBeNull();
+
+    expect(readConfig()).toEqual({ heartbeat: { maxConsecutiveRuns: null } });
+  });
+
+  test("request schema rejects non-positive and non-integer cap values", () => {
+    const requestBody = findRoute("updateHeartbeatConfig").requestBody;
+    if (!requestBody || !("parse" in requestBody)) {
+      throw new Error("expected a zod requestBody schema");
+    }
+    expect(() => requestBody.parse({ maxDailyRuns: 0 })).toThrow();
+    expect(() => requestBody.parse({ maxConsecutiveRuns: -1 })).toThrow();
+    expect(() => requestBody.parse({ maxDailyRuns: 1.5 })).toThrow();
+    expect(() => requestBody.parse({ maxDailyRuns: 3 })).not.toThrow();
+    expect(() => requestBody.parse({ maxConsecutiveRuns: null })).not.toThrow();
+  });
+
+  test("reconfigure() is invoked after a successful write", async () => {
+    writeFileSync(configPath, JSON.stringify({}, null, 2) + "\n");
+    reconfigureSpy.mockClear();
+
+    const put = findHandler("updateHeartbeatConfig");
+    await put({ body: { maxDailyRuns: 4 } });
+
+    expect(reconfigureSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/assistant/src/runtime/routes/__tests__/heartbeat-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/heartbeat-routes.test.ts
@@ -152,16 +152,41 @@ describe("heartbeat run caps", () => {
     expect(readConfig()).toEqual({ heartbeat: { maxConsecutiveRuns: null } });
   });
 
-  test("request schema rejects non-positive and non-integer cap values", () => {
-    const requestBody = findRoute("updateHeartbeatConfig").requestBody;
-    if (!requestBody || !("parse" in requestBody)) {
-      throw new Error("expected a zod requestBody schema");
-    }
-    expect(() => requestBody.parse({ maxDailyRuns: 0 })).toThrow();
-    expect(() => requestBody.parse({ maxConsecutiveRuns: -1 })).toThrow();
-    expect(() => requestBody.parse({ maxDailyRuns: 1.5 })).toThrow();
-    expect(() => requestBody.parse({ maxDailyRuns: 3 })).not.toThrow();
-    expect(() => requestBody.parse({ maxConsecutiveRuns: null })).not.toThrow();
+  test("PUT handler rejects invalid cap values instead of coercing to null", async () => {
+    writeFileSync(configPath, JSON.stringify({}, null, 2) + "\n");
+    const put = findHandler("updateHeartbeatConfig");
+
+    // A string must be rejected, not silently coerced to null (which the
+    // heartbeat service treats as "unlimited", disabling the cost cap).
+    await expect(put({ body: { maxDailyRuns: "6" } })).rejects.toThrow(
+      /maxDailyRuns/,
+    );
+    await expect(put({ body: { maxConsecutiveRuns: "5" } })).rejects.toThrow(
+      /maxConsecutiveRuns/,
+    );
+    await expect(put({ body: { maxDailyRuns: 0 } })).rejects.toThrow();
+    await expect(put({ body: { maxConsecutiveRuns: -1 } })).rejects.toThrow();
+    await expect(put({ body: { maxDailyRuns: 1.5 } })).rejects.toThrow();
+
+    // No invalid write should have reached disk.
+    expect(readConfig()).toEqual({});
+  });
+
+  test("PUT handler accepts a positive integer and null cap values", async () => {
+    writeFileSync(configPath, JSON.stringify({}, null, 2) + "\n");
+    const put = findHandler("updateHeartbeatConfig");
+
+    const okResult = (await put({ body: { maxDailyRuns: 6 } })) as {
+      maxDailyRuns: number | null;
+    };
+    expect(okResult.maxDailyRuns).toBe(6);
+    expect(readConfig()).toEqual({ heartbeat: { maxDailyRuns: 6 } });
+
+    const nullResult = (await put({ body: { maxDailyRuns: null } })) as {
+      maxDailyRuns: number | null;
+    };
+    expect(nullResult.maxDailyRuns).toBeNull();
+    expect(readConfig()).toEqual({ heartbeat: { maxDailyRuns: null } });
   });
 
   test("reconfigure() is invoked after a successful write", async () => {

--- a/assistant/src/runtime/routes/heartbeat-routes.ts
+++ b/assistant/src/runtime/routes/heartbeat-routes.ts
@@ -40,6 +40,21 @@ const log = getLogger("heartbeat-routes");
 // Handlers (transport-agnostic)
 // ---------------------------------------------------------------------------
 
+/**
+ * Validate a heartbeat run-cap value from a PUT body. A cap is either `null`
+ * (clears the cap — unlimited) or a positive integer. The HTTP adapter does
+ * not enforce the route's zod `requestBody` schema at runtime, so any present
+ * value must be checked here rather than coerced — coercing an invalid value
+ * to `null` would silently disable a cost cap.
+ */
+function validateRunCap(field: string, value: unknown): number | null {
+  if (value === null) return null;
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    throw new BadRequestError(`${field} must be a positive integer or null`);
+  }
+  return value;
+}
+
 function handleListRuns(queryParams: Record<string, string>) {
   const limit = parseRunsLimit(queryParams, 20);
   const before = parseRunsBeforeCursor(queryParams);
@@ -318,13 +333,15 @@ export const ROUTES: RouteDefinition[] = [
         heartbeatPatch.timezone =
           typeof body.timezone === "string" ? body.timezone : null;
       if ("maxConsecutiveRuns" in body)
-        heartbeatPatch.maxConsecutiveRuns =
-          typeof body.maxConsecutiveRuns === "number"
-            ? body.maxConsecutiveRuns
-            : null;
+        heartbeatPatch.maxConsecutiveRuns = validateRunCap(
+          "maxConsecutiveRuns",
+          body.maxConsecutiveRuns,
+        );
       if ("maxDailyRuns" in body)
-        heartbeatPatch.maxDailyRuns =
-          typeof body.maxDailyRuns === "number" ? body.maxDailyRuns : null;
+        heartbeatPatch.maxDailyRuns = validateRunCap(
+          "maxDailyRuns",
+          body.maxDailyRuns,
+        );
 
       try {
         const raw = loadRawConfig();

--- a/assistant/src/runtime/routes/heartbeat-routes.ts
+++ b/assistant/src/runtime/routes/heartbeat-routes.ts
@@ -203,6 +203,8 @@ export const ROUTES: RouteDefinition[] = [
       activeHoursEnd: z.number().nullable(),
       cronExpression: z.string().nullable(),
       timezone: z.string().nullable(),
+      maxConsecutiveRuns: z.number().nullable(),
+      maxDailyRuns: z.number().nullable(),
       nextRunAt: z.number().nullable(),
       lastRunAt: z.number().nullable(),
       success: z.boolean(),
@@ -217,6 +219,8 @@ export const ROUTES: RouteDefinition[] = [
         activeHoursEnd: config.activeHoursEnd ?? null,
         cronExpression: config.cronExpression ?? null,
         timezone: config.timezone ?? null,
+        maxConsecutiveRuns: config.maxConsecutiveRuns ?? null,
+        maxDailyRuns: config.maxDailyRuns ?? null,
         nextRunAt: svc?.nextRunAt ?? null,
         lastRunAt: svc?.lastRunAt ?? null,
         success: true,
@@ -259,6 +263,22 @@ export const ROUTES: RouteDefinition[] = [
         .nullable()
         .optional()
         .describe("Timezone for cron evaluation"),
+      maxConsecutiveRuns: z
+        .number()
+        .int()
+        .positive()
+        .nullable()
+        .optional()
+        .describe(
+          "Max consecutive heartbeats without a guardian message, or null for unlimited",
+        ),
+      maxDailyRuns: z
+        .number()
+        .int()
+        .positive()
+        .nullable()
+        .optional()
+        .describe("Max heartbeats per calendar day, or null for unlimited"),
     }),
     responseBody: z.object({
       enabled: z.boolean(),
@@ -267,6 +287,8 @@ export const ROUTES: RouteDefinition[] = [
       activeHoursEnd: z.number().nullable(),
       cronExpression: z.string().nullable(),
       timezone: z.string().nullable(),
+      maxConsecutiveRuns: z.number().nullable(),
+      maxDailyRuns: z.number().nullable(),
       nextRunAt: z.number().nullable(),
       lastRunAt: z.number().nullable(),
       success: z.boolean(),
@@ -295,6 +317,14 @@ export const ROUTES: RouteDefinition[] = [
       if ("timezone" in body)
         heartbeatPatch.timezone =
           typeof body.timezone === "string" ? body.timezone : null;
+      if ("maxConsecutiveRuns" in body)
+        heartbeatPatch.maxConsecutiveRuns =
+          typeof body.maxConsecutiveRuns === "number"
+            ? body.maxConsecutiveRuns
+            : null;
+      if ("maxDailyRuns" in body)
+        heartbeatPatch.maxDailyRuns =
+          typeof body.maxDailyRuns === "number" ? body.maxDailyRuns : null;
 
       try {
         const raw = loadRawConfig();
@@ -324,6 +354,8 @@ export const ROUTES: RouteDefinition[] = [
         activeHoursEnd: heartbeat.activeHoursEnd ?? null,
         cronExpression: heartbeat.cronExpression ?? null,
         timezone: heartbeat.timezone ?? null,
+        maxConsecutiveRuns: heartbeat.maxConsecutiveRuns ?? null,
+        maxDailyRuns: heartbeat.maxDailyRuns ?? null,
         nextRunAt: svc?.nextRunAt ?? null,
         lastRunAt: svc?.lastRunAt ?? null,
         success: true,


### PR DESCRIPTION
## Summary
- PUT/GET /v1/heartbeat/config now expose maxConsecutiveRuns and maxDailyRuns (null clears)
- Regenerate openapi.yaml; add route tests for caps editing + validation

Part of plan: schedule-details-edit.md (PR 5 of 10)