### PR TITLE
Add a pure next-eligible-run calculator for predictable heartbeat guards

### DIFF
--- a/assistant/src/heartbeat/__tests__/next-eligible-run.test.ts
+++ b/assistant/src/heartbeat/__tests__/next-eligible-run.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  computeNextEligibleRunAt,
+  type NextEligibleInput,
+} from "../next-eligible-run.js";
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_START = Date.UTC(2026, 0, 1, 0, 0, 0); // a known midnight baseline
+
+/** Resolve the local hour as UTC-hours offset from DAY_START — deterministic. */
+function utcHourFor(ms: number): number {
+  return new Date(ms).getUTCHours();
+}
+
+function baseInput(
+  overrides: Partial<NextEligibleInput> = {},
+): NextEligibleInput {
+  return {
+    from: DAY_START + 9 * HOUR_MS, // 09:00
+    intervalMs: HOUR_MS,
+    activeHoursStart: null,
+    activeHoursEnd: null,
+    timezone: null,
+    dailyCapReached: false,
+    getHourFor: utcHourFor,
+    ...overrides,
+  };
+}
+
+describe("computeNextEligibleRunAt", () => {
+  test("plain interval advance inside active hours", () => {
+    const from = DAY_START + 9 * HOUR_MS; // 09:00
+    const result = computeNextEligibleRunAt(
+      baseInput({
+        from,
+        activeHoursStart: 8,
+        activeHoursEnd: 18,
+      }),
+    );
+    // 10:00 is inside [8,18) — naive next interval is eligible.
+    expect(result).toBe(from + HOUR_MS);
+  });
+
+  test("no active-hours window returns from + intervalMs", () => {
+    const from = DAY_START + 3 * HOUR_MS;
+    const result = computeNextEligibleRunAt(baseInput({ from }));
+    expect(result).toBe(from + HOUR_MS);
+  });
+
+  test("jumps to next morning when interval lands after activeHoursEnd", () => {
+    const from = DAY_START + 17 * HOUR_MS; // 17:00
+    const result = computeNextEligibleRunAt(
+      baseInput({
+        from,
+        activeHoursStart: 8,
+        activeHoursEnd: 18,
+      }),
+    );
+    // 18:00 is outside [8,18); next opening is 08:00 the following day.
+    expect(utcHourFor(result)).toBe(8);
+    expect(result).toBe(DAY_START + (24 + 8) * HOUR_MS);
+    expect(result).toBeGreaterThan(from);
+  });
+
+  test("overnight window (22 -> 6) keeps late-night hours eligible", () => {
+    const from = DAY_START + 23 * HOUR_MS; // 23:00
+    const result = computeNextEligibleRunAt(
+      baseInput({
+        from,
+        activeHoursStart: 22,
+        activeHoursEnd: 6,
+      }),
+    );
+    // 00:00 next day is inside the overnight window 22..6.
+    expect(result).toBe(from + HOUR_MS);
+    expect(utcHourFor(result)).toBe(0);
+  });
+
+  test("overnight window skips the daytime gap to next opening", () => {
+    const from = DAY_START + 9 * HOUR_MS; // 09:00
+    const result = computeNextEligibleRunAt(
+      baseInput({
+        from,
+        activeHoursStart: 22,
+        activeHoursEnd: 6,
+      }),
+    );
+    // 10:00 is outside 22..6; next opening is 22:00 same day.
+    expect(utcHourFor(result)).toBe(22);
+    expect(result).toBe(DAY_START + 22 * HOUR_MS);
+  });
+
+  test("daily-cap-reached jumps to next local midnight when no window", () => {
+    const from = DAY_START + 14 * HOUR_MS; // 14:00
+    const result = computeNextEligibleRunAt(
+      baseInput({
+        from,
+        dailyCapReached: true,
+      }),
+    );
+    // Cap resets at local midnight — next day's 00:00.
+    expect(utcHourFor(result)).toBe(0);
+    expect(result).toBe(DAY_START + 24 * HOUR_MS);
+  });
+
+  test("daily-cap-reached jumps to next day's active-hours opening", () => {
+    const from = DAY_START + 14 * HOUR_MS; // 14:00
+    const result = computeNextEligibleRunAt(
+      baseInput({
+        from,
+        activeHoursStart: 8,
+        activeHoursEnd: 18,
+        dailyCapReached: true,
+      }),
+    );
+    // Cap resets at midnight, then the window nudges to 08:00.
+    expect(utcHourFor(result)).toBe(8);
+    expect(result).toBe(DAY_START + (24 + 8) * HOUR_MS);
+  });
+
+  test("timezone-driven hour extraction via injected getHourFor", () => {
+    const from = DAY_START + 17 * HOUR_MS;
+    // A resolver that reports every step as inside the window proves the
+    // injected hour source — not wall-clock — drives the decision.
+    const result = computeNextEligibleRunAt(
+      baseInput({
+        from,
+        activeHoursStart: 8,
+        activeHoursEnd: 18,
+        timezone: "America/New_York",
+        getHourFor: () => 10, // always "10:00", always inside [8,18)
+      }),
+    );
+    expect(result).toBe(from + HOUR_MS);
+  });
+
+  test("never returns a value <= from", () => {
+    const from = DAY_START + 5 * HOUR_MS;
+    const result = computeNextEligibleRunAt(
+      baseInput({
+        from,
+        intervalMs: HOUR_MS,
+        activeHoursStart: 8,
+        activeHoursEnd: 18,
+      }),
+    );
+    expect(result).toBeGreaterThan(from);
+  });
+});

--- a/assistant/src/heartbeat/__tests__/next-eligible-run.test.ts
+++ b/assistant/src/heartbeat/__tests__/next-eligible-run.test.ts
@@ -119,6 +119,22 @@ describe("computeNextEligibleRunAt", () => {
     expect(result).toBe(DAY_START + (24 + 8) * HOUR_MS);
   });
 
+  test("daily-cap-reached returns current midnight when candidate already lands on it", () => {
+    const from = DAY_START + 23 * HOUR_MS; // 23:00, local hour 23
+    const result = computeNextEligibleRunAt(
+      baseInput({
+        from,
+        intervalMs: HOUR_MS, // candidate = 00:00, exactly local midnight
+        dailyCapReached: true,
+      }),
+    );
+    // The cap resets at this midnight, so 00:00 itself is eligible — the
+    // calculator must return it, not skip a full day to midnight + 24h.
+    expect(utcHourFor(result)).toBe(0);
+    expect(result).toBe(DAY_START + 24 * HOUR_MS);
+    expect(result).not.toBe(DAY_START + 48 * HOUR_MS);
+  });
+
   test("timezone-driven hour extraction via injected getHourFor", () => {
     const from = DAY_START + 17 * HOUR_MS;
     // A resolver that reports every step as inside the window proves the

--- a/assistant/src/heartbeat/next-eligible-run.ts
+++ b/assistant/src/heartbeat/next-eligible-run.ts
@@ -104,6 +104,11 @@ function advanceToNextLocalMidnight(
   hourFor: (ms: number) => number,
 ): number {
   let cursor = ms;
+  // Already at local midnight (the daily cap has just reset), so this instant is
+  // itself the start of the next local day — return it without skipping ahead.
+  if (hourFor(cursor) === 0) {
+    return cursor;
+  }
   // Step forward until the hour wraps to 0. Bounded to one full day.
   for (let i = 0; i < 24; i++) {
     cursor += HOUR_MS;

--- a/assistant/src/heartbeat/next-eligible-run.ts
+++ b/assistant/src/heartbeat/next-eligible-run.ts
@@ -1,0 +1,115 @@
+/**
+ * Pure, side-effect-free calculator for the next time the heartbeat scheduler
+ * should wake. It mirrors the predictable guards in `heartbeat-service.ts`
+ * (active-hours window and daily-cap reset at local midnight) so the scheduler
+ * can sleep until the next genuinely eligible run instead of waking each
+ * interval only to record a skip.
+ *
+ * All inputs are passed in — no DB, config, or clock access — so the result is
+ * deterministic given its arguments.
+ */
+
+const HOUR_MS = 60 * 60 * 1000;
+
+export interface NextEligibleInput {
+  /** Base timestamp (ms), usually Date.now(). */
+  from: number;
+  intervalMs: number;
+  /** Inclusive start hour [0-23] of the active window, or null when unset. */
+  activeHoursStart: number | null;
+  /** Exclusive end hour [0-23] of the active window, or null when unset. */
+  activeHoursEnd: number | null;
+  /** IANA timezone for hour extraction; null => local time (Date#getHours). */
+  timezone: string | null;
+  /** True when countCompletedRunsToday() >= maxDailyRuns. */
+  dailyCapReached: boolean;
+  /** Injectable hour resolver for deterministic tests. */
+  getHourFor?: (ms: number) => number;
+}
+
+/**
+ * Match `isWithinActiveHours` in heartbeat-service.ts: the window is `[start, end)`,
+ * with overnight windows (e.g. 22→6) wrapping past midnight.
+ */
+function isWithinActiveHours(
+  hour: number,
+  start: number,
+  end: number,
+): boolean {
+  if (start <= end) {
+    return hour >= start && hour < end;
+  }
+  return hour >= start || hour < end;
+}
+
+export function computeNextEligibleRunAt(input: NextEligibleInput): number {
+  const {
+    from,
+    intervalMs,
+    activeHoursStart,
+    activeHoursEnd,
+    timezone,
+    dailyCapReached,
+  } = input;
+
+  const hourFor =
+    input.getHourFor ??
+    ((ms: number): number => {
+      if (timezone) {
+        const parts = new Intl.DateTimeFormat("en-US", {
+          timeZone: timezone,
+          hourCycle: "h23",
+          hour: "numeric",
+        }).formatToParts(new Date(ms));
+        return Number(parts.find((p) => p.type === "hour")!.value);
+      }
+      return new Date(ms).getHours();
+    });
+
+  const hasWindow = activeHoursStart != null && activeHoursEnd != null;
+
+  let candidate = from + intervalMs;
+
+  // Daily cap resets at local midnight, so the earliest the next run can happen
+  // is the start of the next local day. Advance hour-by-hour until the local
+  // hour wraps to 0 (midnight). The window guard below then nudges to the first
+  // active hour when a window is configured.
+  if (dailyCapReached) {
+    candidate = advanceToNextLocalMidnight(candidate, hourFor);
+  }
+
+  // Active-hours guard: advance to the next time the candidate's local hour
+  // falls inside the [start, end) window, mirroring heartbeat-service.ts.
+  if (hasWindow) {
+    let guard = 0;
+    while (
+      !isWithinActiveHours(hourFor(candidate), activeHoursStart, activeHoursEnd)
+    ) {
+      candidate += HOUR_MS;
+      // Worst case a full day of hours; the bound guards against a runaway loop
+      // if the resolver never reports an in-window hour.
+      if (++guard > 24) break;
+    }
+  }
+
+  return candidate > from ? candidate : from + intervalMs;
+}
+
+/**
+ * Advance `ms` to the start of the next local-day boundary (midnight), detected
+ * as the first hour step where the resolved local hour is 0.
+ */
+function advanceToNextLocalMidnight(
+  ms: number,
+  hourFor: (ms: number) => number,
+): number {
+  let cursor = ms;
+  // Step forward until the hour wraps to 0. Bounded to one full day.
+  for (let i = 0; i < 24; i++) {
+    cursor += HOUR_MS;
+    if (hourFor(cursor) === 0) {
+      return cursor;
+    }
+  }
+  return cursor;
+}


### PR DESCRIPTION
## Summary
- Pure computeNextEligibleRunAt() handling active-hours and daily-cap lookahead
- Injectable hour resolver for deterministic tests; no I/O

Part of plan: schedule-details-edit.md (PR 3 of 10)