### PR TITLE
Add a reusable inference-profile picker for schedule detail pages

### DIFF
--- a/apps/web/src/domains/settings/components/model-profile-select.tsx
+++ b/apps/web/src/domains/settings/components/model-profile-select.tsx
@@ -1,0 +1,49 @@
+import { Dropdown } from "@vellumai/design-library/components/dropdown";
+
+import { useProfileOptions } from "@/domains/settings/hooks/use-profile-options";
+
+/**
+ * Sentinel value standing in for the `null` "Default" option, since
+ * `Dropdown` keys options by non-empty string and uses `""` for "no
+ * selection". The leading Default option carries `value: null`, so it maps
+ * to this sentinel on the way in and back to `null` on the way out.
+ */
+const DEFAULT_OPTION_VALUE = "__default__";
+
+export interface ModelProfileSelectProps {
+  assistantId: string;
+  /** Selected profile key, or `null` for the "Default" (cleared override) option. */
+  value: string | null;
+  onChange: (profileKey: string | null) => void;
+  disabled?: boolean;
+  isSaving?: boolean;
+}
+
+/**
+ * Controlled inference-profile picker built from {@link useProfileOptions}.
+ * Reports the selected profile key — or `null` for the leading "Default"
+ * option that clears an override — through `onChange`.
+ */
+export function ModelProfileSelect({
+  assistantId,
+  value,
+  onChange,
+  disabled = false,
+  isSaving = false,
+}: ModelProfileSelectProps) {
+  const options = useProfileOptions(assistantId).map((option) => ({
+    value: option.value ?? DEFAULT_OPTION_VALUE,
+    label: option.label,
+  }));
+
+  return (
+    <Dropdown
+      value={value ?? DEFAULT_OPTION_VALUE}
+      onChange={(selected) =>
+        onChange(selected === DEFAULT_OPTION_VALUE ? null : selected)
+      }
+      options={options}
+      disabled={disabled || isSaving}
+    />
+  );
+}

--- a/apps/web/src/domains/settings/hooks/use-profile-options.test.ts
+++ b/apps/web/src/domains/settings/hooks/use-profile-options.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildProfileOptions } from "@/domains/settings/hooks/use-profile-options";
+
+import type { ConfigGetResponse } from "@/generated/daemon/types.gen";
+
+type LlmConfig = NonNullable<ConfigGetResponse["llm"]>;
+
+const llm: LlmConfig = {
+  profileOrder: ["smart", "fast", "legacy"],
+  profiles: {
+    fast: { label: "Fast" },
+    smart: { label: "Smart" },
+    legacy: { label: "Legacy", status: "disabled" },
+    // Present in `profiles` but absent from `profileOrder`; appended last.
+    extra: {},
+  },
+} as LlmConfig;
+
+describe("buildProfileOptions", () => {
+  test("orders by profileOrder, omits disabled, maps labels, prepends null Default", () => {
+    expect(buildProfileOptions(llm)).toEqual([
+      { value: null, label: "Default" },
+      { value: "smart", label: "Smart" },
+      { value: "fast", label: "Fast" },
+      // `legacy` is disabled and dropped.
+      { value: "extra", label: "extra" },
+    ]);
+  });
+
+  test("falls back to the profile key when no label is set", () => {
+    const config = {
+      profileOrder: ["bare"],
+      profiles: { bare: {} },
+    } as LlmConfig;
+    expect(buildProfileOptions(config)).toEqual([
+      { value: null, label: "Default" },
+      { value: "bare", label: "bare" },
+    ]);
+  });
+
+  test("returns just the Default option when config is missing", () => {
+    expect(buildProfileOptions(undefined)).toEqual([
+      { value: null, label: "Default" },
+    ]);
+  });
+});

--- a/apps/web/src/domains/settings/hooks/use-profile-options.ts
+++ b/apps/web/src/domains/settings/hooks/use-profile-options.ts
@@ -1,0 +1,57 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+import { buildOrderedProfiles } from "@/domains/settings/ai/utils";
+import { configGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
+import { profilePickerLabel } from "@/assistant/profile-pickers";
+
+import type { ConfigGetResponse } from "@/generated/daemon/types.gen";
+
+type LlmConfig = ConfigGetResponse["llm"];
+
+export interface ProfileOption {
+  /** Profile key, or `null` for the leading "Default" option that clears an override. */
+  readonly value: string | null;
+  readonly label: string;
+}
+
+/**
+ * Builds the ordered option list for an editable inference-profile picker.
+ *
+ * Respects `llm.profileOrder` (via `buildOrderedProfiles`), drops
+ * `status === "disabled"` profiles, maps each label to `profile.label ?? key`,
+ * and prepends a `value: null` "Default" option that clears any override.
+ *
+ * Pure (no React) so it is unit-testable without a render harness.
+ */
+export function buildProfileOptions(llm: LlmConfig | undefined): ProfileOption[] {
+  const profiles = llm?.profiles ?? {};
+  const profileOrder = llm?.profileOrder ?? [];
+
+  const options: ProfileOption[] = buildOrderedProfiles(profiles, profileOrder)
+    .filter((profile) => profile.status !== "disabled")
+    .map((profile) => ({
+      value: profile.name,
+      label: profilePickerLabel(profile),
+    }));
+
+  return [{ value: null, label: "Default" }, ...options];
+}
+
+/**
+ * Reads daemon config via the shared `configGetOptions()` query and returns an
+ * ordered list of `{ value, label }` options for an editable profile picker.
+ * See {@link buildProfileOptions} for ordering/filtering semantics.
+ */
+export function useProfileOptions(assistantId: string): ProfileOption[] {
+  const { data: daemonConfig } = useQuery({
+    ...configGetOptions({ path: { assistant_id: assistantId } }),
+    enabled: Boolean(assistantId),
+    staleTime: 60_000,
+  });
+
+  return useMemo(
+    () => buildProfileOptions(daemonConfig?.llm),
+    [daemonConfig?.llm],
+  );
+}


### PR DESCRIPTION
## Summary
- useProfileOptions hook (+ pure buildProfileOptions helper) ordering/filtering profiles for a picker
- ModelProfileSelect controlled dropdown with a null Default option; read-only ModelProfileRow unchanged

Part of plan: schedule-details-edit.md (PR 7 of 10)