### PR TITLE
fix(skills): make skill_execute envelope robust for weak models

### DIFF
--- a/assistant/src/__tests__/skill-execute-input.test.ts
+++ b/assistant/src/__tests__/skill-execute-input.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { resolveSkillExecuteInput } from "../tools/skills/execute.js";
+import {
+  augmentSkillExecuteError,
+  resolveSkillExecuteInput,
+} from "../tools/skills/execute.js";
 
 describe("resolveSkillExecuteInput", () => {
   test("returns a correctly nested object unchanged", () => {
@@ -81,5 +84,47 @@ describe("resolveSkillExecuteInput", () => {
       foo: "bar",
     });
     expect(result).toEqual({ foo: "bar" });
+  });
+});
+
+describe("augmentSkillExecuteError", () => {
+  test("appends envelope guidance when an empty-input call errors", () => {
+    // The subagent_spawn failure: empty input, tool rejects with a field-level
+    // message that says nothing about the skill_execute envelope.
+    const result = augmentSkillExecuteError(
+      "subagent_spawn",
+      {},
+      { content: 'Both "label" and "objective" are required.', isError: true },
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain(
+      'Both "label" and "objective" are required.',
+    );
+    expect(result.content).toContain("carried no parameters");
+    expect(result.content).toContain('"tool": "subagent_spawn"');
+    expect(result.content).toContain("inside `input`");
+  });
+
+  test("leaves errors untouched when parameters were resolved", () => {
+    // A non-empty resolved input means the model structured the call; any error
+    // is a real tool-level failure, not an envelope-shape mistake.
+    const original = {
+      content: "Subagent quota exceeded.",
+      isError: true,
+    };
+    const result = augmentSkillExecuteError(
+      "subagent_spawn",
+      { label: "x", objective: "y" },
+      original,
+    );
+    expect(result).toBe(original);
+  });
+
+  test("leaves successful empty-input calls untouched", () => {
+    // Tools that legitimately accept no parameters (e.g. subagent_status) must
+    // not have guidance appended to their successful results.
+    const original = { content: "No subagents running.", isError: false };
+    const result = augmentSkillExecuteError("subagent_status", {}, original);
+    expect(result).toBe(original);
   });
 });

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -26,7 +26,10 @@ import {
   ACTIVITY_SKIP_SET,
   injectActivityField,
 } from "../tools/schema-transforms.js";
-import { resolveSkillExecuteInput } from "../tools/skills/execute.js";
+import {
+  augmentSkillExecuteError,
+  resolveSkillExecuteInput,
+} from "../tools/skills/execute.js";
 import { resolveToolInvocationAlias } from "../tools/tool-name-aliases.js";
 import {
   isDiskPressureCleanupToolName,
@@ -320,7 +323,12 @@ export function createToolExecutor(
       const innerRejection = rejectNonAllowlistedTool(toolName);
       if (innerRejection) return innerRejection;
 
-      const result = await executor.execute(toolName, toolInput, toolContext);
+      const rawResult = await executor.execute(
+        toolName,
+        toolInput,
+        toolContext,
+      );
+      const result = augmentSkillExecuteError(toolName, toolInput, rawResult);
       if (toolContext.approvedViaPrompt) {
         ctx.approvedViaPromptThisTurn = true;
       }

--- a/assistant/src/tools/skills/execute.ts
+++ b/assistant/src/tools/skills/execute.ts
@@ -62,6 +62,40 @@ export function resolveSkillExecuteInput(
   return {};
 }
 
+/**
+ * Augment an inner-tool error with `skill_execute` envelope guidance when the
+ * call carried no inner parameters.
+ *
+ * {@link resolveSkillExecuteInput} rescues *misplaced* parameters (siblings, a
+ * JSON-encoded string). It cannot rescue a genuinely empty call — there is
+ * nothing to relocate — so the inner tool runs with `{}` and rejects it with a
+ * field-level message ("<field> is required") that says nothing about the
+ * envelope. Weak models then retry the identical empty shape, oscillating over
+ * whether parameters belong under `input`, as siblings, or as a JSON string.
+ *
+ * Appending the canonical envelope shape gives the next attempt a concrete
+ * template. Fires only when the resolved inner input was empty AND the tool
+ * errored, so well-formed calls and tools that legitimately accept no
+ * parameters are untouched.
+ */
+export function augmentSkillExecuteError(
+  toolName: string,
+  resolvedInput: Record<string, unknown>,
+  result: ToolExecutionResult,
+): ToolExecutionResult {
+  if (!result.isError || Object.keys(resolvedInput).length > 0) return result;
+
+  const guidance =
+    `\n\nThis skill_execute call carried no parameters for "${toolName}". ` +
+    `Put the tool's parameters inside \`input\` as a JSON object — not as ` +
+    `siblings of \`tool\`, and not as a JSON-encoded string. For example: ` +
+    `{"tool": "${toolName}", "input": { /* the tool's parameters */ }, ` +
+    `"activity": "..."}. The skill's instructions (from skill_load) list ` +
+    `"${toolName}"'s required fields.`;
+
+  return { ...result, content: result.content + guidance };
+}
+
 export const skillExecuteTool = {
   name: "skill_execute",
   description:


### PR DESCRIPTION
## Problem

Weak open models (e.g. MiniMax M3 on `balanced-economy`) routinely mis-shape the `skill_execute` envelope and then **retry the identical malformed call** until they give up.

A dogfood trace (conversation `00c7d5c6`) asking M3 to spawn subagents shows ~4 attempts oscillating over whether `subagent_spawn`'s parameters belong:
- under `input` (the correct place),
- as siblings of `tool`/`activity`, or
- as a JSON-encoded string,

— repeatedly dispatching **empty input** and getting back the terse `Both "label" and "objective" are required.` (from the inner tool), which says nothing about the `skill_execute` envelope. The model eventually recovered, so this is an **optimization**, not a hard failure — but the thrash is avoidable.

## Fix

Two complementary, mechanical fixes at the dispatch layer (`conversation-tool-setup.ts` → `tools/skills/execute.ts`):

- **`resolveSkillExecuteInput`** rescues *misplaced* parameters — `input` as a JSON-encoded string, or params spread as top-level siblings with `input` absent/empty — so a well-meaning but mis-shaped call **succeeds** instead of failing schema validation.
- **`augmentSkillExecuteError`** handles the case the rescue cannot: a *genuinely empty* call. When the resolved inner input is empty **and** the inner tool errors, it appends the canonical envelope template to the error so the model's next attempt has a concrete shape to copy. Fires only on empty-input + error, so well-formed calls and no-parameter tools (e.g. `subagent_status`) are untouched.

Both are generic across all skill tools, and there are **no system-prompt additions** (per System Prompt Minimalism).

## Testing

- `bun test src/__tests__/skill-execute-input.test.ts` — 11 pass (3 added for `augmentSkillExecuteError`)
- `bun test subagent-tools subagent-spawn-tool-fork` — 76 pass (dispatch path unregressed)
- `bunx tsc --noEmit` — clean; lint + prettier clean (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)