### PR TITLE
feat(cli): make vellum backup export timeout 5min and configurable

### DIFF
--- a/cli/src/__tests__/backup.test.ts
+++ b/cli/src/__tests__/backup.test.ts
@@ -245,6 +245,69 @@ describe("vellum backup <local>: guardian bootstrap secret", () => {
   });
 });
 
+describe("vellum backup: --export-timeout flag", () => {
+  test("rejects a non-numeric value before any lookup", async () => {
+    setArgv("my-local", "--export-timeout", "soon");
+
+    const consoleErrorSpy = spyOn(console, "error").mockImplementation(
+      () => undefined,
+    );
+    try {
+      await expect(backup()).rejects.toThrow("process.exit:1");
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("--export-timeout must be a positive number"),
+      );
+      expect(findAssistantByNameMock).not.toHaveBeenCalled();
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  test("rejects a non-positive value", async () => {
+    setArgv("my-local", "--export-timeout", "0");
+
+    const consoleErrorSpy = spyOn(console, "error").mockImplementation(
+      () => undefined,
+    );
+    try {
+      await expect(backup()).rejects.toThrow("process.exit:1");
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("--export-timeout must be a positive number"),
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  test("accepts a valid override and completes the local export", async () => {
+    const localEntry = {
+      assistantId: "local-assistant",
+      runtimeUrl: "http://127.0.0.1:7830",
+      cloud: "local",
+      guardianBootstrapSecret: "bootstrap-secret-value",
+    } satisfies assistantConfig.AssistantEntry;
+    findAssistantByNameMock.mockReturnValue(localEntry);
+    setArgv(
+      "my-local",
+      "--export-timeout",
+      "600",
+      "--output",
+      "/tmp/local-backup.vbundle",
+    );
+
+    globalThis.fetch = mock(async () => {
+      return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+
+    await backup();
+
+    expect(writeFileSyncMock).toHaveBeenCalledTimes(1);
+    expect(writeFileSyncMock.mock.calls[0]![0]).toBe(
+      "/tmp/local-backup.vbundle",
+    );
+  });
+});
+
 describe("vellum backup <platform-managed>: GCS happy path", () => {
   test("requests upload URL → kicks off runtime export → polls → downloads from GCS → writes file", async () => {
     findAssistantByNameMock.mockReturnValue(VELLUM_ENTRY);

--- a/cli/src/commands/backup.ts
+++ b/cli/src/commands/backup.ts
@@ -18,23 +18,32 @@ import {
 } from "../lib/platform-client.js";
 import { loopbackSafeFetch } from "../lib/loopback-fetch.js";
 
+// Default timeout for the runtime-direct export request. Overridable via
+// --export-timeout.
+const DEFAULT_EXPORT_TIMEOUT_MS = 300_000;
+
 export async function backup(): Promise<void> {
   const args = process.argv.slice(3);
 
   if (args.includes("--help") || args.includes("-h")) {
-    console.log("Usage: vellum backup <name> [--output <path>]");
+    console.log(
+      "Usage: vellum backup <name> [--output <path>] [--export-timeout <seconds>]",
+    );
     console.log("");
     console.log(
       "Export a backup of a running assistant as a .vbundle archive.",
     );
     console.log("");
     console.log("Arguments:");
-    console.log("  <name>              Name of the assistant to back up");
+    console.log("  <name>                   Name of the assistant to back up");
     console.log("");
     console.log("Options:");
-    console.log("  --output <path>     Path to save the .vbundle file");
+    console.log("  --output <path>          Path to save the .vbundle file");
     console.log(
-      "                      (default: ~/.local/share/vellum/backups/<name>-<timestamp>.vbundle)",
+      "                           (default: ~/.local/share/vellum/backups/<name>-<timestamp>.vbundle)",
+    );
+    console.log(
+      `  --export-timeout <secs>  Export request timeout in seconds (default: ${DEFAULT_EXPORT_TIMEOUT_MS / 1000})`,
     );
     console.log("");
     console.log("Examples:");
@@ -42,21 +51,33 @@ export async function backup(): Promise<void> {
     console.log(
       "  vellum backup my-assistant --output ~/Desktop/backup.vbundle",
     );
+    console.log("  vellum backup my-assistant --export-timeout 600");
     process.exit(0);
   }
 
   const name = args[0];
   if (!name || name.startsWith("-")) {
-    console.error("Usage: vellum backup <name> [--output <path>]");
+    console.error(
+      "Usage: vellum backup <name> [--output <path>] [--export-timeout <seconds>]",
+    );
     process.exit(1);
   }
 
-  // Parse --output flag
+  // Parse flags
   let outputArg: string | undefined;
+  let exportTimeoutMs = DEFAULT_EXPORT_TIMEOUT_MS;
   for (let i = 1; i < args.length; i++) {
     if (args[i] === "--output" && args[i + 1]) {
       outputArg = args[i + 1];
-      break;
+    } else if (args[i] === "--export-timeout" && args[i + 1]) {
+      const seconds = Number(args[i + 1]);
+      if (!Number.isFinite(seconds) || seconds <= 0) {
+        console.error(
+          `Error: --export-timeout must be a positive number of seconds (got '${args[i + 1]}').`,
+        );
+        process.exit(1);
+      }
+      exportTimeoutMs = seconds * 1000;
     }
   }
 
@@ -120,7 +141,7 @@ export async function backup(): Promise<void> {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({ description: "CLI backup" }),
-      signal: AbortSignal.timeout(120_000),
+      signal: AbortSignal.timeout(exportTimeoutMs),
     });
 
     // Retry once with a fresh token on 401 — the cached token may be stale
@@ -146,13 +167,15 @@ export async function backup(): Promise<void> {
             "Content-Type": "application/json",
           },
           body: JSON.stringify({ description: "CLI backup" }),
-          signal: AbortSignal.timeout(120_000),
+          signal: AbortSignal.timeout(exportTimeoutMs),
         });
       }
     }
   } catch (err) {
     if (err instanceof Error && err.name === "TimeoutError") {
-      console.error("Error: Export request timed out after 2 minutes.");
+      console.error(
+        `Error: Export request timed out after ${exportTimeoutMs / 1000} seconds.`,
+      );
       process.exit(1);
     }
     const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- Bump the runtime-direct `/v1/migrations/export` request timeout from 2 minutes to 5 minutes (new `DEFAULT_EXPORT_TIMEOUT_MS` constant).
- Add a `--export-timeout <seconds>` CLI flag to override it, with validation that the value is a positive finite number.
- Surface the configured timeout in the help text, an example, and the timeout error message.
- Platform-managed (`cloud="vellum"`) backup and the 60-minute job-polling timeout are intentionally untouched.

## Original prompt
Investigating timeouts in the `vellum backup` CLI surfaced a hardcoded 2-minute timeout on the initial runtime-direct export request. The ask was to raise that default to 5 minutes and add a CLI argument so users can override it for slow/large exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)