### PR TITLE
fix(surfaces): reject empty ui_update payloads so progress cards can't freeze

### DIFF
--- a/assistant/src/__tests__/dynamic-page-surface.test.ts
+++ b/assistant/src/__tests__/dynamic-page-surface.test.ts
@@ -5,7 +5,7 @@ import type {
   UiSurfaceShowDynamicPage,
 } from "../daemon/message-protocol.js";
 import { INTERACTIVE_SURFACE_TYPES } from "../daemon/message-protocol.js";
-import { uiShowTool } from "../tools/ui-surface/definitions.js";
+import { uiShowTool, uiUpdateTool } from "../tools/ui-surface/definitions.js";
 
 // ---------------------------------------------------------------------------
 // DynamicPageSurfaceData shape
@@ -290,6 +290,106 @@ describe("ui_show empty card guard", () => {
         actions: [{ id: "ok", label: "OK" }],
         data: {},
       },
+      makeCtx(() => {
+        proxied = true;
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(proxied).toBe(true);
+  });
+});
+
+describe("ui_update empty payload guard", () => {
+  function makeCtx(onProxy: () => void) {
+    return {
+      conversationId: "conversation-123",
+      workingDir: "/tmp",
+      trustClass: "guardian" as const,
+      proxyToolResolver: async () => {
+        onProxy();
+        return { content: "Surface updated", isError: false };
+      },
+    };
+  }
+
+  test("rejects an empty data object and does not proxy", async () => {
+    let proxied = false;
+    const result = await uiUpdateTool.execute(
+      { surface_id: "surf-1", data: {} },
+      makeCtx(() => {
+        proxied = true;
+      }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("empty `data` payload");
+    expect(proxied).toBe(false);
+  });
+
+  test("rejects missing data and does not proxy", async () => {
+    let proxied = false;
+    const result = await uiUpdateTool.execute(
+      { surface_id: "surf-1" },
+      makeCtx(() => {
+        proxied = true;
+      }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(proxied).toBe(false);
+  });
+
+  test("rejects data containing only nested empty objects", async () => {
+    let proxied = false;
+    const result = await uiUpdateTool.execute(
+      { surface_id: "surf-1", data: { templateData: {} } },
+      makeCtx(() => {
+        proxied = true;
+      }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(proxied).toBe(false);
+  });
+
+  test("rejects a task_progress update with an empty steps array", async () => {
+    let proxied = false;
+    const result = await uiUpdateTool.execute(
+      { surface_id: "surf-1", data: { templateData: { steps: [] } } },
+      makeCtx(() => {
+        proxied = true;
+      }),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(proxied).toBe(false);
+  });
+
+  test("allows a task_progress step update", async () => {
+    let proxied = false;
+    const result = await uiUpdateTool.execute(
+      {
+        surface_id: "surf-1",
+        data: {
+          templateData: {
+            steps: [{ label: "Read memo", status: "completed" }],
+          },
+        },
+      },
+      makeCtx(() => {
+        proxied = true;
+      }),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(proxied).toBe(true);
+  });
+
+  test("allows a status-only update without resending steps", async () => {
+    let proxied = false;
+    const result = await uiUpdateTool.execute(
+      { surface_id: "surf-1", data: { templateData: { status: "completed" } } },
       makeCtx(() => {
         proxied = true;
       }),

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -59,6 +59,14 @@ function proxyExecute(toolName: string) {
       };
     }
 
+    if (toolName === "ui_update" && isEmptyUpdate(input)) {
+      return {
+        content:
+          'Error: ui_update received an empty `data` payload, so the surface was unchanged — the user still sees its previous state. The provided data is merged into the surface\'s current data, and merging nothing is a no-op. To advance a task_progress card, send the full step list: ui_update { surface_id: "<id>", data: { templateData: { steps: [{ label: "<step>", status: "completed" }, { label: "<step>", status: "in_progress" }] } } }. Resend ui_update with the fields you intend to change under `data`.',
+        isError: true,
+      };
+    }
+
     if (!context.proxyToolResolver) {
       return {
         content: `No proxy resolver configured for proxy tool "${toolName}". This tool requires an external resolver (e.g. a connected macOS client).`,
@@ -96,6 +104,36 @@ function isTaskProgressCardShow(input: Record<string, unknown>): boolean {
   }
   const data = asRecord(input.data);
   return data?.template === "task_progress";
+}
+
+/**
+ * A `ui_update` whose `data` merge would change nothing: missing, not an
+ * object, or containing only (recursively) empty objects. Merging such a
+ * payload is a silent no-op — the surface keeps its prior state while the
+ * client still reports "Surface updated" — so the model never learns its
+ * update was hollow and a live card (e.g. task_progress) appears frozen.
+ * Arrays (e.g. `templateData.steps`) and any non-empty primitive leaf count
+ * as content.
+ */
+function isEmptyUpdate(input: Record<string, unknown>): boolean {
+  const data = asRecord(input.data);
+  return data === null || !hasContent(data);
+}
+
+function hasContent(value: unknown): boolean {
+  if (value === null || value === undefined) {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  if (typeof value === "object") {
+    return Object.values(value).some(hasContent);
+  }
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+  return true;
 }
 
 function isEmptyDynamicPage(input: Record<string, unknown>): boolean {
@@ -311,7 +349,7 @@ export const uiShowTool = {
 // ui_update
 // ---------------------------------------------------------------------------
 
-const uiUpdateTool = {
+export const uiUpdateTool = {
   name: "ui_update",
   description:
     "Update an existing surface's data. The provided data object is merged into the surface's current data.\n" +


### PR DESCRIPTION
## Problem

A user reported a `task_progress` card that never advanced — the step bars stayed frozen at step 1 (`in_progress`) with the rest `pending`.

Reconstructed from the feedback logs (main agent: **minimax-m3**):

1. The model created the card with `ui_show` → `task_progress` (step 1 `in_progress`, steps 2–5 `pending`). Rendered fine.
2. It received the worked update hint we append on success (`TASK_PROGRESS_UPDATE_HINT`).
3. It then issued **exactly one** `ui_update`, with `data: {}` — empty (confirmed against the raw model output, not a provider parse-mangle).
4. `ui_update` merges `data` into the surface's current data. Merging `{}` is a **no-op**, but the proxy returned `"Surface updated", isError: false` — a **false success**. The model got no signal its update changed nothing.
5. The turn then paused on an `ask_question`, leaving the card frozen forever.

The root gap: `ui_update` had **no empty-payload guard**, unlike `ui_show`, which already rejects empty cards and empty dynamic_pages (`isEmptyCard` / `isEmptyDynamicPage`). The update path silently accepted no-ops and reported success.

## Fix

Add an empty-payload guard to `ui_update` in `proxyExecute`, symmetric to the existing `ui_show` guards. When the `data` merge would change nothing (missing, `{}`, or only nested empty objects), return an error envelope showing the correct `data.templateData.steps` shape instead of proxying.

- Real step updates and status-only updates (e.g. `{ templateData: { status: "completed" } }`) pass through unchanged.
- Arrays and non-empty primitive leaves count as content; empty strings and empty arrays do not.

This is the same fix-class as the `ui_show` empty-card and `skill_execute` empty-input envelopes — turn a weak model's silent false-success into a loud, actionable error it can retry on.

## Test

Adds an `ui_update empty payload guard` suite to `dynamic-page-surface.test.ts` covering: empty object, missing data, nested-empty-only, empty steps array (all rejected, not proxied), plus a real step update and a status-only update (both pass through). 26/26 in the file pass; tsc + lint clean.