### PR TITLE
fix(memory-v3): self-heal capability rows so runtime-enabled skills reach v3 retrieval

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/maintain-job.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/maintain-job.test.ts
@@ -71,6 +71,7 @@ describe("maintainJob", () => {
         return makeIndex(slugs);
       },
       readPageBody: async (slug) => `body for ${slug}`,
+      readCapabilityBody: async (slug) => `capability body for ${slug}`,
       deleteSectionsForArticle: async (_config, article) => {
         calls.deleted.push(article);
       },
@@ -283,6 +284,9 @@ describe("maintainJob", () => {
     const { deps: d, calls } = deps({
       loadCoreSet: () => ["page-live", "page-gone", "skills/example"],
       listIndexedSlugs: async () => ["page-live", "skills/example"],
+      // The capability row is already in the store, so the reconcile stage
+      // no-ops here and this test exercises core-validation in isolation.
+      listSectionArticles: async () => ["skills/example"],
     });
     const outcome = await maintainJob(JOB, CONFIG, d);
 
@@ -317,8 +321,9 @@ describe("maintainJob", () => {
     });
     const outcome = await maintainJob(JOB, CONFIG, d);
     expect(outcome.danglingCoreSlugs).toEqual([]);
-    // The prune stage reads the index once; the core stage adds no second read.
-    expect(indexReads).toBe(1);
+    // The reconcile and prune stages each read the index once; the empty core
+    // stage adds no further read.
+    expect(indexReads).toBe(2);
   });
 
   test("a thrown core-validation stage is contained and does not abort lane invalidation", async () => {
@@ -350,6 +355,53 @@ describe("maintainJob", () => {
     // Invalidation still runs after a thrown prune stage.
     expect(calls.invalidate).toBe(1);
     expect(outcome.invalidated).toBe(true);
+  });
+
+  test("reconciles capability rows missing from the section store", async () => {
+    setOverridesForTesting({ [FLAG_SHADOW]: true });
+    // The index lists a real page and three capability rows; the store already
+    // holds one of the caps. The change-delta excludes capability rows, so
+    // without this stage a skill enabled after the one-time backfill never
+    // reaches the dense lane. selectChangedPages stays empty so `calls.built`
+    // reflects reconcile embeds only.
+    const { deps: d, calls } = deps({
+      selectChangedPages: async () => [],
+      listIndexedSlugs: async () => [
+        "page-a",
+        "skills/already",
+        "skills/workflows",
+        "skills/another",
+      ],
+      listSectionArticles: async () => ["page-a", "skills/already"],
+    });
+    const outcome = await maintainJob(JOB, CONFIG, d);
+
+    // Only the caps missing from the store are embedded; the real page (handled
+    // by the change-delta stage) and the already-stored cap are left alone.
+    expect(outcome.capabilitiesReconciled).toBe(2);
+    expect(outcome.reconcileFailures).toBe(0);
+    expect(calls.built).toEqual([["skills/workflows"], ["skills/another"]]);
+    expect(calls.deleted).toEqual(["skills/workflows", "skills/another"]);
+    expect(calls.upserted.flat().map((s) => s.article)).toEqual([
+      "skills/workflows",
+      "skills/another",
+    ]);
+  });
+
+  test("skips a cold capability row (empty body) without deleting its points", async () => {
+    setOverridesForTesting({ [FLAG_SHADOW]: true });
+    const { deps: d, calls } = deps({
+      listIndexedSlugs: async () => ["skills/cold"],
+      listSectionArticles: async () => [],
+      readCapabilityBody: async () => "", // capability store not seeded yet
+    });
+    const outcome = await maintainJob(JOB, CONFIG, d);
+
+    expect(outcome.capabilitiesReconciled).toBe(0);
+    expect(outcome.reconcileFailures).toBe(0);
+    // Never replace good points with a blank: no delete, no upsert.
+    expect(calls.deleted).toEqual([]);
+    expect(calls.upserted).toEqual([]);
   });
 });
 

--- a/assistant/src/plugins/defaults/memory-v3-shadow/maintain-job.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/maintain-job.ts
@@ -2,7 +2,7 @@
  * Memory v3 — `memory_v3_maintain` job handler.
  *
  * A flag-gated, best-effort self-maintenance pass over the v3 section dense
- * store and the in-memory lanes. It runs four independent stages, in order:
+ * store and the in-memory lanes. It runs five independent stages, in order:
  *
  *   1. **Section re-embed** — diff the page index by `modifiedAt` against the
  *      last successful pass (the high-water mark below), and for every page that
@@ -15,19 +15,26 @@
  *      captured before any potential mtime bumps) so a page is not re-embedded
  *      forever, yet a page whose embed failed (and whose sections were therefore
  *      left deleted) stays above the mark and is retried next pass.
- *   2. **Deleted-page prune** — diff the dense store's stored articles
+ *   2. **Capability reconcile** — embed capability rows (synthetic skill/CLI
+ *      slugs) present in the page index but missing from the section store. The
+ *      re-embed delta above EXCLUDES capability rows (they have `modifiedAt` 0,
+ *      no mtime to diff), so the only other embedder is the one-time
+ *      `backfillAllSections`. Without this stage a skill enabled AFTER that
+ *      backfill (e.g. a flag-gated skill flipped on at runtime) lands in the
+ *      index but never reaches the dense lane. See {@link reconcileCapabilityRows}.
+ *   3. **Deleted-page prune** — diff the dense store's stored articles
  *      (`listSectionArticles`) against the live page-index slugs and
  *      `deleteSectionsForArticle` for any article that is no longer in the
  *      index. A deleted page's slug never reaches the re-embed delta selector
  *      (it only names live pages), so without this its section points would
  *      linger in Qdrant and the dense lane could still surface the deleted page.
  *      Synthetic capability rows are in the page index, so they are never pruned.
- *   3. **Core-set validation** — load the maintainer-curated core set
+ *   4. **Core-set validation** — load the maintainer-curated core set
  *      (`memory/core-pages.md`) and report entries whose page no longer exists
  *      in the page index (dangling slugs) via the log + outcome. The file is
  *      maintainer-owned, so this stage NEVER edits it — the maintainer fixes
  *      dangling entries at the next consolidation pass.
- *   4. **Lane invalidation** — `invalidateLanes()` so the next turn rebuilds the
+ *   5. **Lane invalidation** — `invalidateLanes()` so the next turn rebuilds the
  *      in-memory section index, needle, and edge graph from the freshly-updated
  *      pages.
  *
@@ -110,6 +117,13 @@ export interface MaintainJobDeps {
   buildSectionIndex: typeof realBuildSectionIndex;
   /** Read a page's frontmatter-stripped body for `buildSectionIndex`. */
   readPageBody: (slug: Slug) => Promise<string>;
+  /**
+   * Capability-aware body reader for the reconcile stage: synthetic skill/CLI
+   * slugs resolve their rendered capability content; real pages read from disk.
+   * The re-embed stage uses `readPageBody` (disk-only) since it only processes
+   * real pages — the reconcile stage needs capability bodies.
+   */
+  readCapabilityBody: (slug: Slug) => Promise<string>;
   /** Clear an article's stale section points before re-upserting. */
   deleteSectionsForArticle: typeof realDeleteSectionsForArticle;
   /** Embed + upsert an article's current sections into the dense store. */
@@ -198,6 +212,15 @@ export interface MaintainOutcome {
   reembedded: number;
   /** Pages whose re-embed threw (and was contained). */
   reembedFailures: number;
+  /**
+   * Capability rows (skills/CLI) present in the index but missing from the
+   * section store that were embedded this pass — how a skill enabled after the
+   * one-time backfill reaches the dense lane (the re-embed delta excludes
+   * capability rows).
+   */
+  capabilitiesReconciled: number;
+  /** Capability reconcile embeds that threw (and were contained). */
+  reconcileFailures: number;
   /**
    * Deleted-page articles whose lingering section points were pruned this pass
    * (present in the dense store but absent from the page index).
@@ -302,6 +325,8 @@ function defaultDeps(config: AssistantConfig): MaintainJobDeps {
     selectChangedPages: () => selectChangedPagesFromWorkspace(workspaceDir),
     buildSectionIndex: realBuildSectionIndex,
     readPageBody: (slug) => readPageBodyFromWorkspace(workspaceDir, slug),
+    readCapabilityBody: (slug) =>
+      backfillPageBodyFromWorkspace(workspaceDir, slug),
     deleteSectionsForArticle: realDeleteSectionsForArticle,
     upsertSections: realUpsertSections,
     commitEmbedHighWater,
@@ -355,6 +380,58 @@ async function reembedChangedPages(
     }
   }
   return { reembedded, reembedFailures };
+}
+
+/**
+ * Embed capability rows (synthetic skill/CLI slugs) present in the page index
+ * but missing from the section dense store. The incremental re-embed selector
+ * ({@link computeChangedPages}) excludes capability rows — they have no on-disk
+ * mtime to delta against — so the ONLY other embedder is the one-time
+ * {@link backfillAllSections}. Without this, a skill enabled AFTER that backfill
+ * (e.g. a flag-gated skill flipped on at runtime) lands in the page index but
+ * never reaches the dense lane. This stage makes the periodic maintain pass
+ * self-heal: diff the live capability slugs against the stored section articles
+ * and embed the missing ones.
+ *
+ * Each row is independent: a single build/upsert throw is logged and counted in
+ * `reconcileFailures` without aborting the rest. A capability row whose body
+ * resolves empty (its store has not seeded yet) is skipped WITHOUT deleting any
+ * points — never replace good points with a blank — and is retried next pass.
+ */
+async function reconcileCapabilityRows(
+  deps: MaintainJobDeps,
+): Promise<{ capabilitiesReconciled: number; reconcileFailures: number }> {
+  const [indexedSlugs, storedArticles] = await Promise.all([
+    deps.listIndexedSlugs(),
+    deps.listSectionArticles(),
+  ]);
+  const stored = new Set(storedArticles);
+  const missing = indexedSlugs.filter(
+    (slug) => isCapabilitySlug(slug) && !stored.has(slug),
+  );
+
+  let capabilitiesReconciled = 0;
+  let reconcileFailures = 0;
+  for (const slug of missing) {
+    try {
+      const body = await deps.readCapabilityBody(slug);
+      if (body.trim().length === 0) continue; // store cold — retry next pass
+      const index = await deps.buildSectionIndex(
+        [slug],
+        deps.readCapabilityBody,
+      );
+      await deps.deleteSectionsForArticle(deps.config, slug);
+      await deps.upsertSections(deps.config, index.sections);
+      capabilitiesReconciled += 1;
+    } catch (err) {
+      reconcileFailures += 1;
+      log.warn(
+        { slug, err: err instanceof Error ? err.message : String(err) },
+        "memory-v3 maintain: capability reconcile embed failed (non-fatal)",
+      );
+    }
+  }
+  return { capabilitiesReconciled, reconcileFailures };
 }
 
 /**
@@ -537,6 +614,8 @@ export async function maintainJob(
     disabled: false,
     reembedded: 0,
     reembedFailures: 0,
+    capabilitiesReconciled: 0,
+    reconcileFailures: 0,
     pruned: 0,
     pruneFailures: 0,
     danglingCoreSlugs: [],
@@ -587,7 +666,26 @@ export async function maintainJob(
     );
   }
 
-  // Stage 2: prune section points for pages deleted from the index. A deleted
+  // Stage 2: embed capability rows (skills/CLI) present in the index but missing
+  // from the section store. They have modifiedAt 0, so computeChangedPages never
+  // selects them; the one-time backfill is otherwise their only embedder, so a
+  // skill enabled after that backfill stays invisible to the dense lane until
+  // this self-heals it. Contained: a failure is logged + recorded without
+  // aborting later stages.
+  try {
+    const { capabilitiesReconciled, reconcileFailures } =
+      await reconcileCapabilityRows(deps);
+    outcome.capabilitiesReconciled = capabilitiesReconciled;
+    outcome.reconcileFailures = reconcileFailures;
+  } catch (err) {
+    outcome.failures.push("capability-reconcile");
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "memory-v3 maintain: capability reconcile failed (non-fatal)",
+    );
+  }
+
+  // Stage 3: prune section points for pages deleted from the index. A deleted
   // page's slug never appears in `selectChangedPages` (the delta selector only
   // names live pages), so its lingering points are cleared by diffing the dense
   // store's stored articles against the live page-index slugs. Contained: a
@@ -604,7 +702,7 @@ export async function maintainJob(
     );
   }
 
-  // Stage 3: validate the maintainer-curated core set. Diff `core-pages.md`
+  // Stage 4: validate the maintainer-curated core set. Diff `core-pages.md`
   // entries against the live page-index slugs and REPORT dangling entries
   // (pages that were renamed or deleted) through the log + outcome — the file
   // is maintainer-owned, so it is never auto-edited; the maintainer fixes it at
@@ -632,7 +730,7 @@ export async function maintainJob(
     );
   }
 
-  // Stage 4: rebuild section index + needle + edge graph on the next turn.
+  // Stage 5: rebuild section index + needle + edge graph on the next turn.
   try {
     deps.invalidateLanes();
     outcome.invalidated = true;
@@ -648,6 +746,8 @@ export async function maintainJob(
     {
       reembedded: outcome.reembedded,
       reembedFailures: outcome.reembedFailures,
+      capabilitiesReconciled: outcome.capabilitiesReconciled,
+      reconcileFailures: outcome.reconcileFailures,
       pruned: outcome.pruned,
       pruneFailures: outcome.pruneFailures,
       danglingCoreSlugs: outcome.danglingCoreSlugs,


### PR DESCRIPTION
## Problem
A flag-gated skill enabled at runtime is seeded into the v2 concept-page collection but **never** into the v3 section dense store (\`memory_v3_sections\`), so it is invisible to v3 retrieval — it never surfaces in the \`### Skills You Can Use\` injection.

**Root cause:** capability rows (synthetic \`skills/<id>\` / \`cli-commands/<name>\`) have \`modifiedAt: 0\`, so the incremental \`memory_v3_maintain\` re-embed delta (\`computeChangedPages\`) explicitly excludes them. The ONLY embedder of capability rows is the one-time \`backfillAllSections\` (operator transition pass). Any skill enabled *after* that backfill is stuck out of the dense lane permanently — the periodic maintain job never self-heals it.

Verified live: a newly-enabled skill was present in \`memory_v2_concept_pages\` but absent from \`memory_v3_sections\` (which held 90 other skills); fan-out queries never surfaced it.

## Fix
Add a **capability-reconcile** stage to \`maintainJob\`: diff the live capability slugs (page index) against the stored section articles and embed any that are missing. The periodic maintain pass now self-heals capability rows — handling every future runtime-enabled skill without a manual full backfill.

- New \`reconcileCapabilityRows\` stage + capability-aware \`readCapabilityBody\` dep.
- Cold rows (capability store not yet seeded → empty body) are skipped *without* deleting points and retried next pass (mirrors the backfill's cold guard).
- Tests: reconcile embeds only the caps missing from the store (real pages handled by the change-delta stage, and already-stored caps, are left alone); cold rows skipped without mutation.

## Deploy note
After this lands, the next maintain pass embeds any already-enabled-but-unseeded skill automatically. For an immediate one-off, \`POST memory/v3/backfill-sections\` still works.