### PR TITLE
fix(workflows): default workflowLeaf to the workspace default profile, not cost-optimized

### DIFF
--- a/assistant/src/__tests__/llm-callsite-catalog.test.ts
+++ b/assistant/src/__tests__/llm-callsite-catalog.test.ts
@@ -54,9 +54,7 @@ describe("LLM call-site catalog", () => {
 
   test("CALL_SITE_DEFAULTS covers every LLMCallSite enum value", () => {
     const defaultIds = new Set(Object.keys(CALL_SITE_DEFAULTS));
-    const missing = LLMCallSiteEnum.options.filter(
-      (id) => !defaultIds.has(id),
-    );
+    const missing = LLMCallSiteEnum.options.filter((id) => !defaultIds.has(id));
     expect(missing).toEqual([]);
   });
 
@@ -68,11 +66,12 @@ describe("LLM call-site catalog", () => {
     expect(extra).toEqual([]);
   });
 
-  test("every CALL_SITE_DEFAULTS entry has a profile field", () => {
+  test("every CALL_SITE_DEFAULTS profile, when present, is a non-empty string", () => {
     for (const [, config] of Object.entries(CALL_SITE_DEFAULTS)) {
-      expect(config.profile).toBeDefined();
+      // A call site may omit `profile` to inherit the workspace default config.
+      if (config.profile === undefined) continue;
       expect(typeof config.profile).toBe("string");
-      expect(config.profile!.length).toBeGreaterThan(0);
+      expect(config.profile.length).toBeGreaterThan(0);
     }
   });
 });

--- a/assistant/src/__tests__/llm-resolver.test.ts
+++ b/assistant/src/__tests__/llm-resolver.test.ts
@@ -670,30 +670,6 @@ describe("resolveCallSiteConfig", () => {
     expect(resolved.effort).toBe("medium");
   });
 
-  test("workflowLeaf defaults to the cost-optimized profile", () => {
-    const llm = LLMSchema.parse({
-      default: fullDefault,
-      profiles: {
-        balanced: {
-          model: "claude-sonnet-4-7",
-          effort: "medium",
-        },
-        "cost-optimized": {
-          model: "claude-haiku-4-5-20251001",
-          effort: "low",
-        },
-      },
-    });
-
-    expect(resolveDefaultProfileKey("workflowLeaf", llm)).toBe(
-      "cost-optimized",
-    );
-    const resolved = resolveCallSiteConfig("workflowLeaf", llm);
-    expect(resolved.model).toBe("claude-haiku-4-5-20251001");
-    expect(resolved.effort).toBe("low");
-    expect(resolved.thinking.enabled).toBe(false);
-  });
-
   test("explicit callSites config overrides CALL_SITE_DEFAULTS", () => {
     const llm = LLMSchema.parse({
       default: fullDefault,
@@ -1435,5 +1411,54 @@ describe("resolveCallSiteConfig logitBias provenance", () => {
       activeProfile: "plain",
     });
     expect(resolveCallSiteConfig("mainAgent", llm).logitBias).toBeUndefined();
+  });
+});
+
+describe("resolveCallSiteConfig — workflowLeaf default", () => {
+  test("inherits the workspace default config rather than pinning cost-optimized", () => {
+    const llm = LLMSchema.parse({
+      default: fullDefault,
+      profiles: {
+        "cost-optimized": {
+          provider: "anthropic",
+          model: "claude-haiku-4-5-20251001",
+        },
+      },
+    });
+    const resolved = resolveCallSiteConfig("workflowLeaf", llm);
+    // No pinned profile → the model comes from llm.default, NOT the
+    // `cost-optimized` profile (which is uncredentialed on a BYOK install).
+    expect(resolved.model).toBe("claude-opus-4-7");
+    // Call-site tuning still applies.
+    expect(resolved.effort).toBe("low");
+    expect(resolved.thinking?.enabled).toBe(false);
+    // The call site has no implicit default profile key.
+    expect(resolveDefaultProfileKey("workflowLeaf", llm)).toBeUndefined();
+  });
+
+  test("honors an explicit workflowLeaf call-site override", () => {
+    const llm = LLMSchema.parse({
+      default: fullDefault,
+      profiles: {
+        cheap: { provider: "anthropic", model: "claude-haiku-4-5-20251001" },
+      },
+      callSites: { workflowLeaf: { profile: "cheap" } },
+    });
+    expect(resolveCallSiteConfig("workflowLeaf", llm).model).toBe(
+      "claude-haiku-4-5-20251001",
+    );
+  });
+
+  test("honors a per-call override profile (an explicit per-leaf profile)", () => {
+    const llm = LLMSchema.parse({
+      default: fullDefault,
+      profiles: {
+        fancy: { provider: "anthropic", model: "claude-sonnet-4-7" },
+      },
+    });
+    expect(
+      resolveCallSiteConfig("workflowLeaf", llm, { overrideProfile: "fancy" })
+        .model,
+    ).toBe("claude-sonnet-4-7");
   });
 });

--- a/assistant/src/config/call-site-defaults.ts
+++ b/assistant/src/config/call-site-defaults.ts
@@ -1,7 +1,13 @@
 import { type LLMCallSite } from "./schemas/llm.js";
 
 type CallSiteDefaultConfig = {
-  profile: string;
+  /**
+   * Named profile the call site resolves to. Omit to inherit the workspace
+   * default config (`llm.default`, with the active profile applied) — used for
+   * call sites that must resolve to a credentialed provider on every install
+   * rather than pinning a profile that may be unavailable.
+   */
+  profile?: string;
   maxTokens?: number;
   effort?: "none" | "low" | "medium" | "high" | "xhigh" | "max";
   temperature?: number | null;
@@ -125,8 +131,12 @@ export const CALL_SITE_DEFAULTS: Record<LLMCallSite, CallSiteDefaultConfig> = {
     thinking: { enabled: false },
     disableCache: true,
   },
+  // Anonymous and schema leaves inherit the workspace default config (no pinned
+  // profile) so they always resolve to a credentialed provider. Pinning a
+  // managed profile like `cost-optimized` breaks BYOK installs where the managed
+  // profiles are uncredentialed. A per-leaf `profile` option or a `workflowLeaf`
+  // call-site override still takes precedence for cost control.
   workflowLeaf: {
-    profile: "cost-optimized",
     effort: "low",
     thinking: { enabled: false },
   },


### PR DESCRIPTION
## Summary
- Anonymous/schema workflow leaves run on the `workflowLeaf` call-site, which pinned the `cost-optimized` profile. On BYOK installs that profile maps to an uncredentialed managed connection, so every anonymous leaf failed (returned `null`). Make `CALL_SITE_DEFAULTS.profile` optional and drop the pin so `workflowLeaf` inherits the workspace default config (`llm.default`, with the active profile applied) — always credentialed.
- A per-leaf `profile` or a `llm.callSites.workflowLeaf` override still takes precedence (cost control). Supersedes #34973.
- Resolver + catalog tests updated for the optional-profile invariant.

## Original prompt
Second of the two GA PRs. After removing the `workflows` flag, anonymous leaves still failed on BYOK/self-hosted installs (incl. the persona instance) because the shipped `workflowLeaf` default pinned `cost-optimized`, which is uncredentialed there. The chosen fix: default to the base default profile instead of cost-optimized so fan-out works out of the box, while still honoring explicit per-leaf / call-site overrides.