### PR TITLE
fix(gateway): push feature-flag changes inline from the PATCH handler

### DIFF
--- a/gateway/src/__tests__/feature-flags-route.test.ts
+++ b/gateway/src/__tests__/feature-flags-route.test.ts
@@ -475,7 +475,8 @@ describe("GET /v1/feature-flags handler", () => {
 
   test("string flag uses registry default when no override exists", async () => {
     if (existsSync(featureFlagStorePath)) rmSync(featureFlagStorePath);
-    if (existsSync(remoteFeatureFlagStorePath)) rmSync(remoteFeatureFlagStorePath);
+    if (existsSync(remoteFeatureFlagStorePath))
+      rmSync(remoteFeatureFlagStorePath);
     clearFeatureFlagStoreCache();
     clearRemoteFeatureFlagStoreCache();
 
@@ -892,5 +893,61 @@ describe("PATCH /v1/feature-flags/:flagKey handler", () => {
     for (const key of flagKeys) {
       expect(persisted[key]).toBe(false);
     }
+  });
+
+  test("invokes onFlagChanged once after a successful write", async () => {
+    let calls = 0;
+    const handler = createFeatureFlagsPatchHandler(() => {
+      calls += 1;
+    });
+    const res = await handler(
+      new Request("http://gateway.test/v1/feature-flags/browser", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabled: false }),
+      }),
+      "browser",
+    );
+
+    expect(res.status).toBe(200);
+    expect(calls).toBe(1);
+  });
+
+  test("does not invoke onFlagChanged when the request is rejected", async () => {
+    let calls = 0;
+    const handler = createFeatureFlagsPatchHandler(() => {
+      calls += 1;
+    });
+    const res = await handler(
+      new Request("http://gateway.test/v1/feature-flags/totally-unknown-flag", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabled: true }),
+      }),
+      "totally-unknown-flag",
+    );
+
+    expect(res.status).toBe(400);
+    expect(calls).toBe(0);
+  });
+
+  test("a throwing onFlagChanged does not fail an already-committed write", async () => {
+    const handler = createFeatureFlagsPatchHandler(() => {
+      throw new Error("notification boom");
+    });
+    const res = await handler(
+      new Request("http://gateway.test/v1/feature-flags/browser", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabled: false }),
+      }),
+      "browser",
+    );
+
+    expect(res.status).toBe(200);
+
+    clearFeatureFlagStoreCache();
+    const persisted = readPersistedFeatureFlags();
+    expect(persisted["browser"]).toBe(false);
   });
 });

--- a/gateway/src/http/routes/feature-flags.ts
+++ b/gateway/src/http/routes/feature-flags.ts
@@ -112,7 +112,7 @@ export function createFeatureFlagsGetHandler() {
   };
 }
 
-export function createFeatureFlagsPatchHandler() {
+export function createFeatureFlagsPatchHandler(onFlagChanged?: () => void) {
   return async (req: Request, flagKey: string): Promise<Response> => {
     // Validate flagKey is non-empty and matches allowed key charset
     if (!flagKey) {
@@ -169,11 +169,24 @@ export function createFeatureFlagsPatchHandler() {
 
     try {
       writeFeatureFlag(flagKey, enabled);
-      log.info({ flagKey, enabled }, "Feature flag updated");
-      return Response.json({ key: flagKey, enabled });
     } catch (err) {
       log.error({ err, flagKey }, "Failed to update feature flag");
       return Response.json({ error: "Internal server error" }, { status: 500 });
     }
+
+    log.info({ flagKey, enabled }, "Feature flag updated");
+
+    // Notify connected clients synchronously with the write. The
+    // FeatureFlagWatcher also fires on the file change, but its fs.watch +
+    // debounce can lag or miss atomic-rename writes, so emitting here is the
+    // reliable path for API-driven flips. A notification failure must not fail
+    // an already-committed write, so it is logged and swallowed.
+    try {
+      onFlagChanged?.();
+    } catch (err) {
+      log.warn({ err, flagKey }, "Feature flag change notification failed");
+    }
+
+    return Response.json({ key: flagKey, enabled });
   };
 }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -506,7 +506,13 @@ async function main() {
   const handleLogExport = createLogExportHandler(config);
   const handleLogTail = createLogTailHandler(config);
   const handleFeatureFlagsGet = createFeatureFlagsGetHandler();
-  const handleFeatureFlagsPatch = createFeatureFlagsPatchHandler();
+  // Assigned once `ipcServer` exists (see `emitFlagChanged` below). Passing a
+  // thunk lets the PATCH handler push flag changes to connected clients the
+  // moment a write commits, rather than waiting on the FeatureFlagWatcher.
+  let emitFlagChanged: () => void = () => {};
+  const handleFeatureFlagsPatch = createFeatureFlagsPatchHandler(() =>
+    emitFlagChanged(),
+  );
   const handlePrivacyConfigGet = createPrivacyConfigGetHandler();
   const handlePrivacyConfigPatch = createPrivacyConfigPatchHandler();
   const handleGlobalThresholdGet = createGlobalThresholdGetHandler();
@@ -2397,7 +2403,7 @@ async function main() {
     assistantRuntimeBaseUrl: config.assistantRuntimeBaseUrl,
   });
 
-  const emitFlagChanged = () => {
+  emitFlagChanged = () => {
     ipcServer.emit("feature_flags_changed");
     // A `voice-mode` flip (e.g. after a warm-pool claim syncs the assistant's
     // flags) should bring up the Velay tunnel so web live voice can connect


### PR DESCRIPTION
## Summary

- The feature-flag PATCH handler now invokes an injected `onFlagChanged` callback after a successful write, wired to `emitFlagChanged` (`ipcServer.emit("feature_flags_changed")` → daemon `sync_changed` SSE). CLI (`vellum flags set`) and in-app flag flips reach connected clients immediately instead of waiting on the `FeatureFlagWatcher` fs.watch + 500ms debounce, which can lag or miss atomic-rename writes.
- The watcher stays as a backstop for external file edits and remote-sync writes. Notification failures are logged and swallowed so they can never fail an already-committed write.
- Wired via a callback parameter (a forward-declared thunk in `index.ts`) rather than reaching into module globals; the handler factory stays pure.

## Original prompt

While debugging why the LLM call inspector button had vanished in the local Electron app (a stale client-cached `settings-developer-nav` flag), we traced the live flag-propagation path and found the gateway's PATCH handler writes the flag file and returns with no inline notification — propagation depends entirely on a fragile fs.watch → IPC → daemon SSE chain. This makes the PATCH path emit the flag-change notification inline so API-driven flips propagate to clients immediately, while keeping the file watcher as a backstop for external/remote changes.