### PR TITLE
fix(web): render LLM Context Inspector prose as literal text, not markdown

### DIFF
--- a/clients/web/src/domains/chat/inspector/components/tabs/prompt-tab.test.tsx
+++ b/clients/web/src/domains/chat/inspector/components/tabs/prompt-tab.test.tsx
@@ -1,10 +1,11 @@
 /**
  * Tests for the PromptTab section rendering. Renders to static markup
  * (no DOM), mirroring `compaction-tab.test.tsx`, and asserts that prose
- * sections (system prompt, user and assistant messages) render as Markdown
- * while structured payloads, tool-call arguments, and tool results render as
- * code-style `<pre>` text. Literal `<tag>`-style prompt delimiters stay
- * visible as text.
+ * sections (system prompt, user and assistant messages) render as the
+ * literal text the model receives — markdown markers and `<tag>`-style
+ * delimiters stay visible rather than being formatted — while structured
+ * payloads, tool-call arguments, and tool results render as code-style
+ * `<pre>` text.
  */
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -44,7 +45,7 @@ function render(sections: LLMContextSection[]): string {
 }
 
 describe("PromptTab", () => {
-  test("renders text sections as Markdown", () => {
+  test("renders prose sections as literal text, not Markdown", () => {
     const html = render([
       {
         kind: "message",
@@ -56,11 +57,12 @@ describe("PromptTab", () => {
       },
     ]);
 
-    // Markdown syntax is formatted: the heading and emphasis become real
-    // elements rather than literal `#`/`**` characters.
-    expect(html).toContain("<h1");
-    expect(html).toContain("Heading");
-    expect(html).toContain("<strong");
+    // Prose renders the literal characters the model receives: the `#`/`**`
+    // markers stay visible and are not turned into heading/emphasis elements.
+    expect(html).not.toContain("<h1");
+    expect(html).not.toContain("<strong");
+    expect(html).toContain("# Heading");
+    expect(html).toContain("**bold** prose");
   });
 
   test("preserves XML-style prompt delimiters as literal text", () => {

--- a/clients/web/src/domains/chat/inspector/components/tabs/prompt-tab.tsx
+++ b/clients/web/src/domains/chat/inspector/components/tabs/prompt-tab.tsx
@@ -1,7 +1,6 @@
 import { ChevronRight, Copy } from "lucide-react";
 import { useState, type ReactNode } from "react";
 
-import { FileMarkdown } from "@/components/file-markdown";
 import { CacheBreakpointMapCard } from "@/domains/chat/inspector/components/cache-breakpoint-map-card";
 import { CacheDiffCard } from "@/domains/chat/inspector/components/cache-diff-card";
 import { CacheHealthCard } from "@/domains/chat/inspector/components/cache-health-card";
@@ -25,9 +24,10 @@ interface PromptTabProps {
  * the bottom of the tab. Sections start expanded and can be folded
  * individually or all at once so a reader can skip a long prompt and jump
  * to the cache breakdown. Prose sections (system prompt, user and
- * assistant messages) render as Markdown with literal `<tag>`-style
- * delimiters preserved; structured payloads and tool output render as
- * code-style `<pre>` text in a capped scroll box (they can be huge). Tool
+ * assistant messages) render as the literal text the model receives, with
+ * whitespace preserved and uncapped for inline reading; structured payloads
+ * and tool output render as code-style `<pre>` text in a capped scroll box
+ * (they can be huge). Tool
  * definitions render as an expandable per-tool breakdown. The raw provider
  * JSON lives on the Raw tab. The cache-diff panel names the block that
  * diverged from the previous turn's request, and the breakpoint map shows
@@ -171,8 +171,8 @@ function PromptSectionItem({
   // Sections backed by structured `data` (tool-call arguments, JSON payloads)
   // and tool results are program output, not prose, and can be huge — render
   // them as code-style text in a capped scroll box. Prose sections (system
-  // prompt, messages, reasoning) render as Markdown, uncapped for inline
-  // reading.
+  // prompt, messages, reasoning) render as the literal text the model
+  // receives, uncapped for inline reading.
   const renderAsCode = section.data != null || isToolResultKind(section.kind);
 
   return (
@@ -242,14 +242,10 @@ function PromptSectionItem({
           </pre>
         ) : (
           <div
-            className="min-w-0 break-words px-4 pb-4"
+            className="min-w-0 select-text whitespace-pre-wrap break-words px-4 pb-4 text-body-medium-default"
             style={{ color: "var(--content-default)" }}
           >
-            <FileMarkdown
-              content={text}
-              stripFrontmatter={false}
-              parseHtml={false}
-            />
+            {text}
           </div>
         )}
       </Collapsible.Content>


### PR DESCRIPTION
## Summary

- The LLM Context Inspector's Prompt tab rendered prose sections (system prompt, user/assistant messages, reasoning) through `FileMarkdown`, which formatted the literal `#`/`**`/`*` characters the model actually receives into headings, bold, and italics — misleading in a tool whose job is wire-fidelity.
- Prose sections now render as literal text in a `whitespace-pre-wrap` container (proportional font, newlines preserved, uncapped for inline reading). Structured `data` payloads and tool output are unchanged — they keep their capped code-style `<pre>` rendering.
- Removed the now-unused `FileMarkdown` import and updated the doc comments and the section-rendering test to assert literal-text output.

## Original prompt

In the Electron desktop app's LLM Context Inspector, prompt message content (e.g. a `<memory>` block) was being rendered as formatted markdown instead of the literal text the model receives. The ask was to render prose prompt sections as actual text. Scope and style were confirmed: apply to all prose sections, using plain proportional text with whitespace preserved (no monospace box, no scroll cap). No personal data in the PR, comments, or test fixtures.