### PR TITLE
fix(macos): float bundled CLI to vellum@latest by default

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -278,9 +278,6 @@ jobs:
           jq --arg v "$VERSION" '.version = $v' clients/chrome-extension/manifest.json > tmp && mv tmp clients/chrome-extension/manifest.json
           jq --arg v "$VERSION" '.version = $v' clients/chrome-extension/package.json > tmp && mv tmp clients/chrome-extension/package.json
 
-          # Stamp pinned CLI version in macOS app
-          sed -i "s/export const PINNED_CLI_VERSION = \".*\"/export const PINNED_CLI_VERSION = \"$VERSION\"/" clients/macos/src/main/cli-installer.ts
-
           # Regenerate OpenAPI spec with the new version
           cd assistant && bun run generate:openapi && cd ..
 

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1636,11 +1636,6 @@ jobs:
       - name: Stamp dev version into package.json
         run: jq --arg v "${{ needs.compute-version.outputs.version }}" '.version = $v' package.json > package.json.tmp && mv package.json.tmp package.json
 
-      - name: Stamp PINNED_CLI_VERSION for dev
-        run: |
-          VERSION="${{ needs.compute-version.outputs.version }}"
-          sed -i '' "s/export const PINNED_CLI_VERSION = \".*\"/export const PINNED_CLI_VERSION = \"$VERSION\"/" src/main/cli-installer.ts
-
       - name: Build and package Electron app
         env:
           CSC_NAME: Developer ID Application

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2074,11 +2074,6 @@ jobs:
       - name: Stamp release version into package.json
         run: jq --arg v "${{ needs.extract-version.outputs.version }}" '.version = $v' package.json > package.json.tmp && mv package.json.tmp package.json
 
-      - name: Stamp PINNED_CLI_VERSION
-        run: |
-          VERSION="${{ needs.extract-version.outputs.version }}"
-          sed -i '' "s/export const PINNED_CLI_VERSION = \".*\"/export const PINNED_CLI_VERSION = \"$VERSION\"/" src/main/cli-installer.ts
-
       - name: Build and package Electron app
         env:
           CSC_NAME: Developer ID Application

--- a/clients/macos/scripts/generate-cli-lockfile.sh
+++ b/clients/macos/scripts/generate-cli-lockfile.sh
@@ -11,10 +11,9 @@ SEED_DIR="$APP_DIR/resources/cli-lockfile"
 VERSION=$(grep -o 'PINNED_CLI_VERSION = "[^"]*"' "$APP_DIR/src/main/cli-installer.ts" \
   | sed 's/PINNED_CLI_VERSION = "//;s/"//')
 
-if [ -z "$VERSION" ]; then
-  echo "ERROR: could not read PINNED_CLI_VERSION from cli-installer.ts" >&2
-  exit 1
-fi
+# Empty PINNED_CLI_VERSION is the default (unpinned): seed a lockfile resolved
+# to build-time latest so the runtime has an offline fallback.
+SPEC="${VERSION:-latest}"
 
 # Local builds drive the repo CLI source directly (see getLocalCliEntry in
 # cli-installer.ts) and never install from npm. Ship an empty seed dir so
@@ -26,13 +25,13 @@ if [ "${VELLUM_ENVIRONMENT:-local}" = "local" ]; then
   exit 0
 fi
 
-echo "Generating CLI lockfile for vellum@$VERSION ..."
+echo "Generating CLI lockfile for vellum@$SPEC ..."
 
 rm -rf "$SEED_DIR"
 mkdir -p "$SEED_DIR"
 
 cat > "$SEED_DIR/package.json" <<EOF
-{"dependencies":{"vellum":"$VERSION"}}
+{"dependencies":{"vellum":"$SPEC"}}
 EOF
 
 (cd "$SEED_DIR" && bun install --ignore-scripts)

--- a/clients/macos/scripts/generate-cli-lockfile.sh
+++ b/clients/macos/scripts/generate-cli-lockfile.sh
@@ -11,10 +11,6 @@ SEED_DIR="$APP_DIR/resources/cli-lockfile"
 VERSION=$(grep -o 'PINNED_CLI_VERSION = "[^"]*"' "$APP_DIR/src/main/cli-installer.ts" \
   | sed 's/PINNED_CLI_VERSION = "//;s/"//')
 
-# Empty PINNED_CLI_VERSION is the default (unpinned): seed a lockfile resolved
-# to build-time latest so the runtime has an offline fallback.
-SPEC="${VERSION:-latest}"
-
 # Local builds drive the repo CLI source directly (see getLocalCliEntry in
 # cli-installer.ts) and never install from npm. Ship an empty seed dir so
 # electron-builder's extraResources mapping still resolves.
@@ -24,6 +20,16 @@ if [ "${VELLUM_ENVIRONMENT:-local}" = "local" ]; then
   mkdir -p "$SEED_DIR"
   exit 0
 fi
+
+# Empty PINNED_CLI_VERSION is the default (unpinned): seed a lockfile resolved
+# to the environment's dist-tag so the runtime offline fallback matches the
+# online install. Keep in sync with getCliDistTag in cli-installer.ts.
+case "$VELLUM_ENVIRONMENT" in
+  dev) DEFAULT_TAG="dev" ;;
+  staging) DEFAULT_TAG="staging" ;;
+  *) DEFAULT_TAG="latest" ;;
+esac
+SPEC="${VERSION:-$DEFAULT_TAG}"
 
 echo "Generating CLI lockfile for vellum@$SPEC ..."
 

--- a/clients/macos/src/main/cli-installer.test.ts
+++ b/clients/macos/src/main/cli-installer.test.ts
@@ -109,7 +109,12 @@ const {
 const seedPkgPath = `${mockResourcesPath}/cli-lockfile/package.json`;
 const seedLockPath = `${mockResourcesPath}/cli-lockfile/bun.lock`;
 const locatorPath = `${userDataPath}/cli/locator.sh`;
-const cliBinPath = `${userDataPath}/cli/${PINNED_CLI_VERSION}/node_modules/.bin/vellum`;
+// Default (unpinned) install dir when nothing exists yet.
+const latestInstallDir = `${userDataPath}/cli/latest`;
+const cliBinPath = `${latestInstallDir}/node_modules/.bin/vellum`;
+/** Bin path for an install dir under `cli/`. */
+const binPathFor = (name: string) =>
+  `${userDataPath}/cli/${name}/node_modules/.bin/vellum`;
 
 afterEach(() => {
   existsSyncDefault = false;
@@ -130,19 +135,39 @@ afterEach(() => {
 
 // --- Path helpers ---
 
+describe("PINNED_CLI_VERSION", () => {
+  test("is empty by default (unpinned: float to latest)", () => {
+    expect(PINNED_CLI_VERSION).toBe("");
+  });
+});
+
 describe("getCliInstallDir", () => {
-  test("returns <userData>/cli/<version>", () => {
-    expect(getCliInstallDir()).toBe(
-      `${userDataPath}/cli/${PINNED_CLI_VERSION}`,
-    );
+  test("unpinned with no existing install → cli/latest", () => {
+    readdirSyncReturn = [];
+    expect(getCliInstallDir()).toBe(latestInstallDir);
+  });
+
+  test("unpinned adopts the newest existing install", () => {
+    readdirSyncReturn = [dirEntry("0.8.5"), dirEntry("0.10.0")];
+    existsSyncByPath[binPathFor("0.8.5")] = true;
+    existsSyncByPath[binPathFor("0.10.0")] = true;
+
+    expect(getCliInstallDir()).toBe(`${userDataPath}/cli/0.10.0`);
+  });
+
+  test("unpinned prefers an existing cli/latest over a versioned dir", () => {
+    readdirSyncReturn = [dirEntry("0.9.0"), dirEntry("latest")];
+    existsSyncByPath[binPathFor("0.9.0")] = true;
+    existsSyncByPath[cliBinPath] = true;
+
+    expect(getCliInstallDir()).toBe(latestInstallDir);
   });
 });
 
 describe("getCliBinPath", () => {
   test("returns <installDir>/node_modules/.bin/vellum", () => {
-    expect(getCliBinPath()).toBe(
-      `${userDataPath}/cli/${PINNED_CLI_VERSION}/node_modules/.bin/vellum`,
-    );
+    readdirSyncReturn = [];
+    expect(getCliBinPath()).toBe(cliBinPath);
   });
 });
 
@@ -217,9 +242,7 @@ describe("writeCliLocator", () => {
 
     const content = writeFileSyncCalls[0][1];
     expect(content).toContain(`VELLUM_BUN='${mockResourcesPath}/bun'\n`);
-    expect(content).toContain(
-      `VELLUM_CLI_BIN='${userDataPath}/cli/${PINNED_CLI_VERSION}/node_modules/.bin/vellum'\n`,
-    );
+    expect(content).toContain(`VELLUM_CLI_BIN='${cliBinPath}'\n`);
     expect(content.endsWith("\n")).toBe(true);
     expect(content.startsWith("#!")).toBe(false);
   });
@@ -275,7 +298,20 @@ describe("ensureCliInstalled", () => {
     await expect(ensureCliInstalled()).resolves.toBeUndefined();
   });
 
-  test("falls back to bun add --ignore-scripts when no seed lockfile exists", async () => {
+  test("adopts an existing install without spawning", async () => {
+    existsSyncDefault = false;
+    readdirSyncReturn = [dirEntry("0.9.0")];
+    existsSyncByPath[binPathFor("0.9.0")] = true;
+
+    await ensureCliInstalled();
+
+    // The adopted dir is used as-is — no install, no cleanup.
+    expect(spawnCalls).toHaveLength(0);
+    expect(rmSyncCalls).toHaveLength(0);
+    expect(renameSyncCalls).toEqual([[`${locatorPath}.tmp`, locatorPath]]);
+  });
+
+  test("fresh unpinned install spawns bun add vellum@latest", async () => {
     existsSyncDefault = false;
 
     const promise = ensureCliInstalled();
@@ -286,23 +322,26 @@ describe("ensureCliInstalled", () => {
     expect(spawnCalls).toHaveLength(1);
     const [cmd, args, opts] = spawnCalls[0];
     expect(cmd).toBe(`${mockResourcesPath}/bun`);
-    expect(args).toEqual(["add", `vellum@${PINNED_CLI_VERSION}`, "--ignore-scripts"]);
-    expect((opts as { cwd: string }).cwd).toBe(
-      `${userDataPath}/cli/${PINNED_CLI_VERSION}`,
-    );
+    expect(args).toEqual(["add", "vellum@latest", "--ignore-scripts"]);
+    expect((opts as { cwd: string }).cwd).toBe(latestInstallDir);
     const env = (opts as { env: NodeJS.ProcessEnv }).env;
     expect(env).toBeDefined();
     expect(env!.PATH).toContain("/opt/homebrew/bin");
     expect(env!.PATH).toContain("/usr/local/bin");
   });
 
-  test("uses bun install --frozen-lockfile --ignore-scripts when seed lockfile exists", async () => {
+  test("offline fallback: latest fails → seeded frozen-lockfile retry", async () => {
     existsSyncDefault = false;
     existsSyncByPath[seedPkgPath] = true;
     existsSyncByPath[seedLockPath] = true;
 
     const promise = ensureCliInstalled();
 
+    // `bun add vellum@latest` fails (e.g. registry unreachable).
+    lastChild.stderr.emit("data", Buffer.from("network error"));
+    lastChild.emit("close", 1);
+    // The retry spawns against the seeded frozen lockfile.
+    await Promise.resolve();
     lastChild.emit("close", 0);
     await promise;
 
@@ -310,10 +349,25 @@ describe("ensureCliInstalled", () => {
     expect(copyFileSyncCalls[0][0]).toBe(seedPkgPath);
     expect(copyFileSyncCalls[1][0]).toBe(seedLockPath);
 
+    expect(spawnCalls).toHaveLength(2);
+    expect(spawnCalls[0][1]).toEqual(["add", "vellum@latest", "--ignore-scripts"]);
+    expect(spawnCalls[1][1]).toEqual([
+      "install",
+      "--frozen-lockfile",
+      "--ignore-scripts",
+    ]);
+  });
+
+  test("offline fallback rethrows when no seed lockfile is available", async () => {
+    existsSyncDefault = false;
+
+    const promise = ensureCliInstalled();
+    lastChild.stderr.emit("data", Buffer.from("network error"));
+    lastChild.emit("close", 1);
+
+    await expect(promise).rejects.toThrow(/Package install failed/);
+    // No seed → no frozen-lockfile retry.
     expect(spawnCalls).toHaveLength(1);
-    const [cmd, args] = spawnCalls[0];
-    expect(cmd).toBe(`${mockResourcesPath}/bun`);
-    expect(args).toEqual(["install", "--frozen-lockfile", "--ignore-scripts"]);
   });
 
   test("creates the install directory before spawning", async () => {
@@ -324,7 +378,7 @@ describe("ensureCliInstalled", () => {
     await promise;
 
     const [dir, opts] = mkdirSyncCalls[0];
-    expect(dir).toBe(`${userDataPath}/cli/${PINNED_CLI_VERSION}`);
+    expect(dir).toBe(latestInstallDir);
     expect(opts).toEqual({ recursive: true });
   });
 
@@ -379,19 +433,18 @@ describe("ensureCliInstalled", () => {
 
   test("calls cleanupOldVersions after successful install", async () => {
     existsSyncDefault = false;
-    readdirSyncReturn = [dirEntry("0.8.5"), dirEntry(PINNED_CLI_VERSION)];
+    readdirSyncReturn = [dirEntry("0.8.5"), dirEntry("latest")];
 
     const promise = ensureCliInstalled();
     lastChild.emit("close", 0);
     await promise;
 
     // cleanupOldVersions should have been called — verify it tried to
-    // remove 0.8.5 but not the pinned version.
+    // remove 0.8.5 but not the current (latest) install dir.
     expect(rmSyncCalls.length).toBeGreaterThanOrEqual(1);
     const removedPaths = rmSyncCalls.map(([p]) => p);
     expect(removedPaths).toContain(`${userDataPath}/cli/0.8.5`);
-    const pinnedPath = `${userDataPath}/cli/${PINNED_CLI_VERSION}`;
-    expect(removedPaths).not.toContain(pinnedPath);
+    expect(removedPaths).not.toContain(latestInstallDir);
   });
 
   test("concurrent calls share a single install", async () => {
@@ -448,16 +501,25 @@ describe("buildInstallEnv", () => {
 // --- cleanupOldVersions ---
 
 describe("cleanupOldVersions", () => {
-  test("deletes sibling directories that are not the pinned version", () => {
-    readdirSyncReturn = [dirEntry("0.8.5"), dirEntry(PINNED_CLI_VERSION)];
+  test("deletes sibling directories that are not the current install dir", () => {
+    readdirSyncReturn = [dirEntry("0.8.5"), dirEntry("latest")];
 
     cleanupOldVersions();
 
     const removedPaths = rmSyncCalls.map(([p]) => p);
     expect(removedPaths).toContain(`${userDataPath}/cli/0.8.5`);
-    expect(removedPaths).not.toContain(
-      `${userDataPath}/cli/${PINNED_CLI_VERSION}`,
-    );
+    expect(removedPaths).not.toContain(latestInstallDir);
+  });
+
+  test("keeps an adopted versioned install dir", () => {
+    readdirSyncReturn = [dirEntry("0.9.0"), dirEntry("0.8.5")];
+    existsSyncByPath[binPathFor("0.9.0")] = true;
+
+    cleanupOldVersions();
+
+    const removedPaths = rmSyncCalls.map(([p]) => p);
+    expect(removedPaths).toContain(`${userDataPath}/cli/0.8.5`);
+    expect(removedPaths).not.toContain(`${userDataPath}/cli/0.9.0`);
   });
 
   test("passes recursive and force options to rmSync", () => {

--- a/clients/macos/src/main/cli-installer.ts
+++ b/clients/macos/src/main/cli-installer.ts
@@ -15,12 +15,30 @@ import path from "node:path";
 
 import log from "./logger";
 
-// Empty by default: the happy path floats to vellum@latest. Set by hand to
-// pin the bundled CLI to an exact version (no longer auto-stamped by CI).
+// Empty by default: the happy path floats to the environment's dist-tag.
+// Set by hand to pin the bundled CLI to an exact version.
 export const PINNED_CLI_VERSION = "";
 
 // Install dir for fresh, unpinned installs.
 const LATEST_INSTALL_DIR = "latest";
+
+// Injected by `electron.vite.config.ts` at build time.
+declare const __VELLUM_ENVIRONMENT__: string;
+const VELLUM_ENVIRONMENT =
+  typeof __VELLUM_ENVIRONMENT__ === "string"
+    ? __VELLUM_ENVIRONMENT__
+    : "production";
+
+/**
+ * npm dist-tag the unpinned CLI install floats to. Dev and staging builds run
+ * their own published CLI (`--tag dev` / `--tag staging`); everything else
+ * tracks production `latest`. Keep in sync with generate-cli-lockfile.sh.
+ */
+function getCliDistTag(): string {
+  if (VELLUM_ENVIRONMENT === "dev") return "dev";
+  if (VELLUM_ENVIRONMENT === "staging") return "staging";
+  return "latest";
+}
 
 // Baked by electron.vite.config.ts: the repo CLI entry for local builds,
 // empty for release builds (and absent under bun test).
@@ -282,14 +300,15 @@ async function bunInstallCli(): Promise<void> {
     return;
   }
 
-  // Unpinned: float to latest, falling back to the seeded frozen lockfile
-  // (resolved to build-time latest) when the registry is unreachable.
+  // Unpinned: float to the environment's dist-tag, falling back to the seeded
+  // frozen lockfile (resolved at build time) when the registry is unreachable.
+  const spec = `vellum@${getCliDistTag()}`;
   try {
-    await runBun(["add", "vellum@latest", "--ignore-scripts"], installDir);
+    await runBun(["add", spec, "--ignore-scripts"], installDir);
   } catch (err) {
     if (!seedCliLockfile(installDir)) throw err;
     log.warn(
-      "[cli-installer] `bun add vellum@latest` failed; falling back to seeded lockfile:",
+      `[cli-installer] \`bun add ${spec}\` failed; falling back to seeded lockfile:`,
       err,
     );
     await runBun(["install", "--frozen-lockfile", "--ignore-scripts"], installDir);

--- a/clients/macos/src/main/cli-installer.ts
+++ b/clients/macos/src/main/cli-installer.ts
@@ -15,8 +15,12 @@ import path from "node:path";
 
 import log from "./logger";
 
-// Auto-stamped by create-release-branch workflow.
-export const PINNED_CLI_VERSION = "0.9.0";
+// Empty by default: the happy path floats to vellum@latest. Set by hand to
+// pin the bundled CLI to an exact version (no longer auto-stamped by CI).
+export const PINNED_CLI_VERSION = "";
+
+// Install dir for fresh, unpinned installs.
+const LATEST_INSTALL_DIR = "latest";
 
 // Baked by electron.vite.config.ts: the repo CLI entry for local builds,
 // empty for release builds (and absent under bun test).
@@ -40,9 +44,67 @@ export function getLocalCliEntry(): string | null {
     : null;
 }
 
-/** Directory where the pinned CLI version is installed. */
+/** Root directory holding every CLI install: `<userData>/cli`. */
+export function getCliRootDir(): string {
+  return path.join(app.getPath("userData"), "cli");
+}
+
+/** The `vellum` bin path within an install directory. */
+function binPathIn(dir: string): string {
+  return path.join(dir, "node_modules", ".bin", "vellum");
+}
+
+/** Compare two version-like dir names numerically (so 0.10.0 > 0.9.0). */
+function compareVersions(a: string, b: string): number {
+  const pa = a.split(".").map((n) => parseInt(n, 10) || 0);
+  const pb = b.split(".").map((n) => parseInt(n, 10) || 0);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+/**
+ * Newest existing install under `cli/` whose `vellum` bin is present: prefer
+ * `cli/latest`, otherwise the highest semver-named dir (including an old
+ * pinned dir like `cli/0.9.0`). Returns `null` when nothing is installed.
+ */
+export function findExistingInstallDir(): string | null {
+  const cliRoot = getCliRootDir();
+
+  let entries: Array<{ name: string; isDirectory: () => boolean }>;
+  try {
+    entries = readdirSync(cliRoot, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+
+  const installed = entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => existsSync(binPathIn(path.join(cliRoot, name))));
+
+  if (installed.length === 0) return null;
+
+  if (installed.includes(LATEST_INSTALL_DIR)) {
+    return path.join(cliRoot, LATEST_INSTALL_DIR);
+  }
+
+  const newest = installed.sort(compareVersions).at(-1)!;
+  return path.join(cliRoot, newest);
+}
+
+/**
+ * Directory where the CLI is (or will be) installed. When `PINNED_CLI_VERSION`
+ * is set, the exact pinned dir; otherwise reuse any existing install, falling
+ * back to `cli/latest` for a fresh install.
+ */
 export function getCliInstallDir(): string {
-  return path.join(app.getPath("userData"), "cli", PINNED_CLI_VERSION);
+  const cliRoot = getCliRootDir();
+  if (PINNED_CLI_VERSION) return path.join(cliRoot, PINNED_CLI_VERSION);
+  return findExistingInstallDir() ?? path.join(cliRoot, LATEST_INSTALL_DIR);
 }
 
 /**
@@ -52,10 +114,7 @@ export function getCliInstallDir(): string {
  * this, so local builds never touch the npm install path.
  */
 export function getCliBinPath(): string {
-  return (
-    getLocalCliEntry() ??
-    path.join(getCliInstallDir(), "node_modules", ".bin", "vellum")
-  );
+  return getLocalCliEntry() ?? binPathIn(getCliInstallDir());
 }
 
 /** Absolute path to the bun runtime bundled inside the app resources. */
@@ -63,14 +122,14 @@ export function getBundledBunPath(): string {
   return path.join(process.resourcesPath, "bun");
 }
 
-/** Whether the pinned CLI version is already installed on disk. */
+/** Whether the CLI is already installed on disk. */
 export function isCliInstalled(): boolean {
   return existsSync(getCliBinPath());
 }
 
 /** Path to the shell-sourceable locator file consumed by the PATH wrapper. */
 export function getCliLocatorPath(): string {
-  return path.join(app.getPath("userData"), "cli", "locator.sh");
+  return path.join(getCliRootDir(), "locator.sh");
 }
 
 /** Single-quote a value for safe interpolation into a shell script. */
@@ -96,8 +155,8 @@ export function writeFileAtomicSync(
  * every launch so app moves and version bumps self-heal. Non-fatal —
  * failures are logged but never block app startup.
  *
- * No-ops when the pinned CLI bin isn't installed yet (e.g. first launch
- * after a version bump) so the wrapper is never pointed at a missing binary.
+ * No-ops when the CLI bin isn't installed yet (e.g. first launch) so the
+ * wrapper is never pointed at a missing binary.
  */
 export function writeCliLocator(): void {
   if (!isCliInstalled()) return;
@@ -170,22 +229,12 @@ function seedCliLockfile(installDir: string): boolean {
   return true;
 }
 
-function bunInstallCli(): Promise<void> {
-  const installDir = getCliInstallDir();
-  mkdirSync(installDir, { recursive: true });
-
+/** Spawn the bundled bun with `args` in `cwd` and await its exit. */
+function runBun(args: string[], cwd: string): Promise<void> {
   const bunPath = getBundledBunPath();
-  const seeded = seedCliLockfile(installDir);
-
-  const args = seeded
-    ? ["install", "--frozen-lockfile", "--ignore-scripts"]
-    : ["add", `vellum@${PINNED_CLI_VERSION}`, "--ignore-scripts"];
 
   return new Promise<void>((resolve, reject) => {
-    const child = spawn(bunPath, args, {
-      cwd: installDir,
-      env: buildInstallEnv(),
-    });
+    const child = spawn(bunPath, args, { cwd, env: buildInstallEnv() });
 
     let stdout = "";
     let stderr = "";
@@ -200,9 +249,7 @@ function bunInstallCli(): Promise<void> {
 
     child.on("error", (err: Error) => {
       reject(
-        new Error(
-          `Failed to spawn bun for package install: ${err.message}`,
-        ),
+        new Error(`Failed to spawn bun for package install: ${err.message}`),
       );
     });
 
@@ -221,6 +268,34 @@ function bunInstallCli(): Promise<void> {
   });
 }
 
+async function bunInstallCli(): Promise<void> {
+  const installDir = getCliInstallDir();
+  mkdirSync(installDir, { recursive: true });
+
+  if (PINNED_CLI_VERSION) {
+    // Pinned: prefer the seeded frozen lockfile, else resolve the exact version.
+    const seeded = seedCliLockfile(installDir);
+    const args = seeded
+      ? ["install", "--frozen-lockfile", "--ignore-scripts"]
+      : ["add", `vellum@${PINNED_CLI_VERSION}`, "--ignore-scripts"];
+    await runBun(args, installDir);
+    return;
+  }
+
+  // Unpinned: float to latest, falling back to the seeded frozen lockfile
+  // (resolved to build-time latest) when the registry is unreachable.
+  try {
+    await runBun(["add", "vellum@latest", "--ignore-scripts"], installDir);
+  } catch (err) {
+    if (!seedCliLockfile(installDir)) throw err;
+    log.warn(
+      "[cli-installer] `bun add vellum@latest` failed; falling back to seeded lockfile:",
+      err,
+    );
+    await runBun(["install", "--frozen-lockfile", "--ignore-scripts"], installDir);
+  }
+}
+
 // Singleton promise prevents concurrent installs from corrupting node_modules.
 let cliInstallPromise: Promise<void> | null = null;
 
@@ -230,7 +305,7 @@ export function _resetInstallLock(): void {
 }
 
 /**
- * Install the pinned vellum meta-package if it isn't already present.
+ * Install the vellum meta-package if it isn't already present.
  *
  * Packaged builds ship a pre-resolved lockfile so `bun install
  * --frozen-lockfile` pins the exact dependency graph from build time;
@@ -259,18 +334,20 @@ export async function ensureCliInstalled(): Promise<void> {
 }
 
 /**
- * Remove CLI versions other than the currently pinned one.
+ * Remove CLI installs other than the one currently in use.
  *
- * Non-fatal — cleanup errors are logged but never thrown so a stale
+ * Runs only after a fresh install, so an adopted existing install is never
+ * touched. Non-fatal — cleanup errors are logged but never thrown so a stale
  * directory doesn't block the app from starting.
  */
 export function cleanupOldVersions(): void {
   try {
-    const cliRoot = path.join(app.getPath("userData"), "cli");
+    const cliRoot = getCliRootDir();
+    const keep = path.basename(getCliInstallDir());
     const entries = readdirSync(cliRoot, { withFileTypes: true });
 
     for (const entry of entries) {
-      if (entry.name === PINNED_CLI_VERSION) continue;
+      if (entry.name === keep) continue;
       if (!entry.isDirectory()) continue;
 
       try {


### PR DESCRIPTION
## Summary

- Make the macOS client's bundled `vellum` CLI float to `latest` by default: `PINNED_CLI_VERSION` now ships empty (set by hand to pin an exact version, no longer auto-stamped by CI).
- Unpinned installs adopt any existing on-disk install (newest of `cli/latest` or highest semver-named dir, including an old pinned dir) and otherwise install `vellum@latest` into `cli/latest`; on registry failure they fall back to the seeded frozen lockfile.
- Stop CI from stamping the constant (`create-release-branch.yml`, `release.yml`, `dev-release.yaml`); the lockfile generator seeds `vellum@latest` when the constant is empty so the offline fallback still ships. `cleanupOldVersions` now preserves whichever dir is actually in use.

## Original prompt

Today the macOS client hard-pins the bundled `vellum` CLI to an exact version that CI auto-stamps on every release, so there is no "just use the newest" path and an unspecified version fails closed. The goal is to make the happy path float to `latest` while keeping `PINNED_CLI_VERSION` as a supported manual override: an empty constant reuses any existing install or installs `vellum@latest`, with the seeded lockfile kept as an offline fallback and no auto-upgrade of an already-installed CLI. CI stops stamping the constant so it ships empty.