### PR TITLE
ci: parallelize electron and prod npm builds in release pipelines

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1754,8 +1754,10 @@ jobs:
   # its own path: mac-electron/dev/{arch}/.
 
   upload-electron-updates:
-    needs: [compute-version, build-electron]
-    if: ${{ needs.build-electron.result == 'success' }}
+    # Gate the GCS update-feed publish (an external side effect) on the dev meta
+    # publish: never offer an auto-update for a release that didn't publish.
+    needs: [compute-version, build-electron, publish-meta-dev]
+    if: ${{ always() && !cancelled() && needs.build-electron.result == 'success' && needs.publish-meta-dev.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: dev

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1536,7 +1536,8 @@ jobs:
   # ── Electron DMG ──────────────────────────────────────────────────────
 
   build-electron:
-    needs: [compute-version, publish-meta-dev]
+    # No publish dep: the bundled CLI floats to the `dev` dist-tag at runtime.
+    needs: [compute-version]
     runs-on: macos-26
     timeout-minutes: 30
     continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1269,8 +1269,9 @@ jobs:
   # here with no token; `npm publish <tarball>` below does not re-run prepack, so
   # no build/dependency code executes alongside the credential.
   build-npm-prod:
-    needs: [extract-version, ci-cli, ci-gateway, ci-playwright, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image]
-    if: ${{ always() && !cancelled() && needs.extract-version.outputs.is_staging != 'true' && needs.ci-cli.result == 'success' && needs.ci-gateway.result == 'success' && (needs.ci-playwright.result == 'success' || inputs.playwright_blocks_release != true) && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' }}
+    # Build has no side effects; release-ordering gates live on publish-npm-prod.
+    needs: [extract-version, ci-cli, ci-gateway]
+    if: ${{ always() && !cancelled() && needs.extract-version.outputs.is_staging != 'true' && needs.ci-cli.result == 'success' && needs.ci-gateway.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -1318,8 +1319,9 @@ jobs:
           retention-days: 1
 
   publish-npm-prod:
-    needs: [extract-version, build-npm-prod]
-    if: ${{ always() && !cancelled() && needs.build-npm-prod.result == 'success' }}
+    # Don't publish until backend images are live and playwright is green.
+    needs: [extract-version, build-npm-prod, ci-playwright, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image]
+    if: ${{ always() && !cancelled() && needs.build-npm-prod.result == 'success' && (needs.ci-playwright.result == 'success' || inputs.playwright_blocks_release != true) && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -1369,8 +1371,9 @@ jobs:
   # own build/publish pair rather than a slot in the npm matrix. Published in
   # lockstep with the assistant version the loader's peerDependency gate expects.
   build-plugin-api-prod:
-    needs: [extract-version, ci-cli, ci-gateway, ci-playwright, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image]
-    if: ${{ always() && !cancelled() && needs.extract-version.outputs.is_staging != 'true' && needs.ci-cli.result == 'success' && needs.ci-gateway.result == 'success' && (needs.ci-playwright.result == 'success' || inputs.playwright_blocks_release != true) && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' }}
+    # Build has no side effects; release-ordering gates live on publish-plugin-api-prod.
+    needs: [extract-version, ci-cli, ci-gateway]
+    if: ${{ always() && !cancelled() && needs.extract-version.outputs.is_staging != 'true' && needs.ci-cli.result == 'success' && needs.ci-gateway.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -1419,8 +1422,9 @@ jobs:
           retention-days: 1
 
   publish-plugin-api-prod:
-    needs: [extract-version, build-plugin-api-prod]
-    if: ${{ always() && !cancelled() && needs.build-plugin-api-prod.result == 'success' }}
+    # Don't publish until backend images are live and playwright is green.
+    needs: [extract-version, build-plugin-api-prod, ci-playwright, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image]
+    if: ${{ always() && !cancelled() && needs.build-plugin-api-prod.result == 'success' && (needs.ci-playwright.result == 'success' || inputs.playwright_blocks_release != true) && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -1816,8 +1820,9 @@ jobs:
 
   build-web-prod:
     name: build-npm-prod (web)
-    needs: [extract-version, ci-cli, ci-gateway, ci-playwright, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image]
-    if: ${{ always() && !cancelled() && needs.extract-version.outputs.is_staging != 'true' && needs.ci-cli.result == 'success' && needs.ci-gateway.result == 'success' && (needs.ci-playwright.result == 'success' || inputs.playwright_blocks_release != true) && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' }}
+    # Build has no side effects; release-ordering gates live on publish-web-prod.
+    needs: [extract-version, ci-cli, ci-gateway]
+    if: ${{ always() && !cancelled() && needs.extract-version.outputs.is_staging != 'true' && needs.ci-cli.result == 'success' && needs.ci-gateway.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -1885,8 +1890,9 @@ jobs:
 
   publish-web-prod:
     name: publish-npm-prod (web)
-    needs: [extract-version, build-web-prod]
-    if: ${{ always() && !cancelled() && needs.build-web-prod.result == 'success' }}
+    # Don't publish until backend images are live and playwright is green.
+    needs: [extract-version, build-web-prod, ci-playwright, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image]
+    if: ${{ always() && !cancelled() && needs.build-web-prod.result == 'success' && (needs.ci-playwright.result == 'success' || inputs.playwright_blocks_release != true) && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -1974,8 +1980,8 @@ jobs:
   # notarizes, and uploads as release assets. A failure on either arch fails
   # this job and blocks the release.
   build-electron:
-    needs: [extract-version, publish-meta-prod, publish-meta-staging]
-    if: ${{ always() && !cancelled() && (needs.publish-meta-prod.result == 'success' || needs.publish-meta-staging.result == 'success') }}
+    # No publish dep: the bundled CLI floats to the `staging`/`latest` dist-tag at runtime.
+    needs: [extract-version]
     runs-on: macos-26
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2203,10 +2203,12 @@ jobs:
   # its own path: mac-electron/{channel}/{arch}/.
 
   upload-electron-updates:
-    needs: [extract-version, build-electron]
-    # always() disables the implicit success(), which would always skip this
-    # job: one of build-electron's needs (publish-meta-prod/-staging) is skipped.
-    if: ${{ always() && !cancelled() && needs.build-electron.result == 'success' }}
+    # Gate the GCS update-feed publish (an external side effect) on the channel's
+    # meta publish: never offer an auto-update for a release that didn't publish.
+    needs: [extract-version, build-electron, publish-meta-prod, publish-meta-staging]
+    # always() disables the implicit success(): publish-meta-prod/-staging is
+    # skipped on the other channel.
+    if: ${{ always() && !cancelled() && needs.build-electron.result == 'success' && (needs.publish-meta-prod.result == 'success' || needs.publish-meta-staging.result == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: ${{ needs.extract-version.outputs.is_staging == 'true' && 'staging' || 'production' }}


### PR DESCRIPTION
## Summary
- **Electron decoupled from publishing** (`release.yml` + `dev-release.yaml`): `build-electron` no longer depends on `publish-meta-*`. Since the bundled CLI now floats to its dist-tag at runtime (per #35119), the build doesn't need this run's npm publish to have landed — the long-pole electron build (build + sign + notarize + staple) now starts immediately and runs in parallel with the npm/docker pipeline.
- **Prod artifact builds decoupled from the docker pipeline** (`release.yml`): `build-{npm,web,plugin-api}-prod` drop the docker-manifest + dockerhub + playwright gates. Those jobs produce artifacts with no external side effects, so they only need source CI + the version. The release-ordering gates (backend images live, playwright green) move down to the matching `publish-*-prod` jobs, which is exactly the pattern already used for `build-chrome-extension` / `publish-chrome-extension`.
- **Invariants preserved**: nothing publishes before backend images are live and playwright is green; the only consumers of the prod build jobs are their publish counterparts, and the final `release` job still gates on the full publish set.

## Tradeoff
The electron offline-fallback lockfile (`generate-cli-lockfile.sh`) now resolves whatever the dist-tag points at *at build time* — i.e. the previous release until this run's publish lands. This only affects a brand-new install that is offline on its very first launch; online installs always float to the latest dist-tag at runtime.

## Original prompt
Following the merge of #35119 (bundled CLI floats to `vellum@latest` by default), revisit the step sequencing in `release.yml` and `dev-release.yaml`. Electron build steps were previously serialized near the end to guarantee they ran after the pinned npm packages were published; with float-to-latest that pinning constraint is gone, so the goal was to identify and unlock parallelism. We landed on fully decoupling `build-electron` from the publish chain, plus moving the docker/playwright gates off the prod artifact *build* jobs (which have no side effects) and onto the *publish* jobs.