### PR TITLE
fix(web): stream the Thought process side drawer live

### DIFF
--- a/clients/web/src/domains/chat/components/multi-activity-group/multi-activity-group.test.tsx
+++ b/clients/web/src/domains/chat/components/multi-activity-group/multi-activity-group.test.tsx
@@ -946,4 +946,36 @@ describe("MultiActivityGroup — thinking pill", () => {
     expect(detail?.thinkingText).toBe(LONG_THINKING);
     expect(useViewerStore.getState().mainView).toBe("tool-detail");
   });
+
+  test("carries the (message, group, segment) identity into the payload when threaded", () => {
+    const toolCalls = [
+      makeToolCall({
+        id: "tc-1",
+        name: "bash",
+        status: "running",
+        input: { command: "ls" },
+      }),
+    ];
+    // `thinking → tool → thinking` interleaves two reasoning segments in one
+    // group, so the second pill must carry segment index 1.
+    const items: ToolCallCardItem[] = [
+      { kind: "thinking", text: "first reasoning segment" },
+      { kind: "toolCall", toolCall: toolCalls[0]! },
+      { kind: "thinking", text: "second reasoning segment" },
+    ];
+    useChatSessionStore.setState({ expandedCardIds: new Map([["tc-1", true]]) });
+    const { getAllByLabelText } = renderCard(toolCalls, {
+      items,
+      messageId: "m1",
+      groupIndex: 3,
+    });
+    const pills = getAllByLabelText("View thinking");
+    fireEvent.click(pills[1]!);
+    const detail = useViewerStore.getState().activeToolDetail;
+    expect(detail?.messageId).toBe("m1");
+    expect(detail?.thinkingGroupIndex).toBe(3);
+    expect(detail?.thinkingItemIndex).toBe(1);
+    // The snapshot text still rides along as the fallback.
+    expect(detail?.thinkingText).toBe("second reasoning segment");
+  });
 });

--- a/clients/web/src/domains/chat/components/multi-activity-group/multi-activity-group.tsx
+++ b/clients/web/src/domains/chat/components/multi-activity-group/multi-activity-group.tsx
@@ -20,7 +20,7 @@ import {
   ToolProgressCardShell,
   type ToolProgressCardState,
 } from "@/domains/chat/components/tool-progress-card/tool-progress-card-shell";
-import { useViewerStore } from "@/stores/viewer-store";
+import { sameThinkingTarget, useViewerStore } from "@/stores/viewer-store";
 import {
   toolDetailPayloadFromToolCall,
   type ToolCallCardData,
@@ -81,6 +81,14 @@ export interface MultiActivityGroupProps {
   // Unknown nudge props (pass-through)
   unknownNudgeToolCallIds?: Set<string>;
   onDismissUnknownNudge?: (toolCallId: string) => void;
+  /**
+   * Identity of the owning message + this group's index in
+   * `groupContentBlocks`. Carried into each thinking pill's drawer payload so
+   * the open panel re-derives that segment's live text (paired with the step's
+   * `thinkingItemIndex`) instead of freezing the snapshot.
+   */
+  messageId?: string;
+  groupIndex?: number;
   /**
    * Ordered (thinking | toolCall) items driving the expanded body. When
    * supplied, the card interleaves thinking steps between tool steps in the
@@ -345,6 +353,8 @@ function UnifiedMultiActivityGroup({
   onOpenRuleEditor,
   unknownNudgeToolCallIds,
   onDismissUnknownNudge,
+  messageId,
+  groupIndex,
 }: MultiActivityGroupProps & {
   cardData: ToolCallCardData;
   expanded: boolean;
@@ -353,9 +363,9 @@ function UnifiedMultiActivityGroup({
   // Pills TOGGLE the shared tool-detail drawer: clicking an open pill closes
   // its drawer, clicking another switches to it.
   const toggleToolDetail = useViewerStore.use.toggleToolDetail();
-  // The active drawer payload drives the pill's selected state. For tool pills
-  // we match on `toolCallId`; for thinking pills (which carry an empty
-  // `toolCallId`) we match on the thinking text instead.
+  // The active drawer payload drives the pill's selected state. Tool pills match
+  // on `toolCallId`; thinking pills (which carry an empty `toolCallId`) match on
+  // the threaded (message, group, segment) identity — see the thinking branch.
   const activeDetail = useViewerStore.use.activeToolDetail();
   // Drives the tool pill's active state — the pill whose detail drawer is
   // currently open renders selected. `null` when the drawer is closed or
@@ -467,9 +477,22 @@ function UnifiedMultiActivityGroup({
             // Thinking steps render as a clickable, brain-branded pill that
             // opens the full reasoning in the shared tool-detail drawer.
             if (step.kind === "thinking") {
+              // Genuine reasoning segments carry a `thinkingItemIndex` and a
+              // threaded message identity, so the drawer streams live and the
+              // pill highlight holds while the text grows. Web-synthesized
+              // thinking steps ("Reading …") have no backing reasoning item, so
+              // they fall back to the snapshot/text-keyed path.
+              const target =
+                messageId != null && step.thinkingItemIndex != null
+                  ? {
+                      messageId,
+                      thinkingGroupIndex: groupIndex,
+                      thinkingItemIndex: step.thinkingItemIndex,
+                    }
+                  : { thinkingText: step.text };
               const active =
                 activeDetail?.kind === "thinking" &&
-                activeDetail.thinkingText === step.text;
+                sameThinkingTarget(activeDetail, target);
               return (
                 <ToolStepPill
                   iconName="brain"
@@ -492,6 +515,7 @@ function UnifiedMultiActivityGroup({
                       input: {},
                       status: "completed",
                       thinkingText: step.text,
+                      ...target,
                     });
                   }}
                 />

--- a/clients/web/src/domains/chat/components/single-activity/single-activity.test.tsx
+++ b/clients/web/src/domains/chat/components/single-activity/single-activity.test.tsx
@@ -164,6 +164,59 @@ describe("SingleActivity — thinking variant", () => {
       getByTestId("thought-process-link").getAttribute("data-active"),
     ).toBe("true");
   });
+
+  test("carries the (message, group) identity into the drawer payload", () => {
+    const { getByLabelText } = render(
+      <SingleActivity
+        variant="thinking"
+        content={CONTENT}
+        messageId="m1"
+        groupIndex={2}
+      />,
+    );
+
+    fireEvent.click(getByLabelText("View thinking"));
+
+    const detail = useViewerStore.getState().activeToolDetail;
+    expect(detail?.messageId).toBe("m1");
+    expect(detail?.thinkingGroupIndex).toBe(2);
+    // The bare panel shows the whole group's reasoning, so it carries no segment
+    // index — that drives `useLiveThinkingText` to return the combined text.
+    expect(detail?.thinkingItemIndex).toBeUndefined();
+  });
+
+  test("stays active by identity while the reasoning streams past the snapshot", () => {
+    // The drawer was opened earlier in the turn (shorter snapshot); the live
+    // link has since grown. Identity keying keeps the highlight on rather than
+    // dropping it the moment the text diverges from the snapshot.
+    useViewerStore.setState({
+      mainView: "tool-detail",
+      activeToolDetail: {
+        kind: "thinking",
+        toolCallId: "",
+        toolName: "",
+        title: "Thought process",
+        activity: "",
+        input: {},
+        status: "completed",
+        thinkingText: "earlier shorter snapshot",
+        messageId: "m1",
+        thinkingGroupIndex: 0,
+      },
+    });
+
+    const { getByTestId } = render(
+      <SingleActivity
+        variant="thinking"
+        content={`${CONTENT} ...and more reasoning`}
+        messageId="m1"
+        groupIndex={0}
+      />,
+    );
+    expect(
+      getByTestId("thought-process-link").getAttribute("data-active"),
+    ).toBe("true");
+  });
 });
 
 describe("SingleActivity — tool variant", () => {

--- a/clients/web/src/domains/chat/components/single-activity/single-activity.tsx
+++ b/clients/web/src/domains/chat/components/single-activity/single-activity.tsx
@@ -56,7 +56,7 @@ import {
 } from "@/domains/chat/components/web-search/web-search-step-row";
 import { WebsiteCarousel } from "@/domains/chat/components/web-search/website-carousel";
 import { SiteFavicon } from "@/domains/chat/components/web-search/site-favicon";
-import { useViewerStore } from "@/stores/viewer-store";
+import { sameThinkingTarget, useViewerStore } from "@/stores/viewer-store";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { WebSearchResultItem } from "@/assistant/web-activity-types";
 
@@ -67,6 +67,13 @@ export type SingleActivityProps =
       content: string;
       /** Whether the reasoning is still streaming in (drives the glyph + label). */
       isStreaming?: boolean;
+      /**
+       * Stable identity of this reasoning run (the owning message id + its
+       * group index in `groupContentBlocks`). Carried into the drawer payload so
+       * the open panel re-derives live text instead of freezing `content`.
+       */
+      messageId?: string;
+      groupIndex?: number;
     }
   | {
       variant: "tool";
@@ -211,7 +218,7 @@ export function SingleActivity(props: SingleActivityProps) {
   let view: ResolvedView;
 
   if (props.variant === "thinking") {
-    const { content, isStreaming = false } = props;
+    const { content, isStreaming = false, messageId, groupIndex } = props;
     // While streaming, render even before any reasoning text has landed so this
     // link can be the single thinking affordance from the start of the turn.
     // Once settled, an empty thought process has nothing to show, so collapse it.
@@ -229,11 +236,17 @@ export function SingleActivity(props: SingleActivityProps) {
       ),
       label: isStreaming ? "Thinking" : "Thought process",
       tone: "default",
-      // Thinking payloads carry an empty `toolCallId`, so we match on the
-      // thinking text instead (mirrors the in-card thinking pill).
+      // Thinking payloads carry an empty `toolCallId`; the bare panel addresses
+      // the whole group (no segment index), so match on its (message, group)
+      // identity — `sameThinkingTarget` holds the highlight while the reasoning
+      // streams, and falls back to text for identity-less callers.
       active:
         activeDetail?.kind === "thinking" &&
-        activeDetail.thinkingText === content,
+        sameThinkingTarget(activeDetail, {
+          messageId,
+          thinkingGroupIndex: groupIndex,
+          thinkingText: content,
+        }),
       onClick: () =>
         toggleToolDetail({
           kind: "thinking",
@@ -244,6 +257,8 @@ export function SingleActivity(props: SingleActivityProps) {
           input: {},
           status: "completed",
           thinkingText: content,
+          messageId,
+          thinkingGroupIndex: groupIndex,
         }),
     };
   } else {

--- a/clients/web/src/domains/chat/components/tool-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.test.tsx
@@ -6,10 +6,32 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
 
-import { ToolDetailPanel } from "@/domains/chat/components/tool-detail-panel";
+// `ToolDetailPanel`'s thinking variant subscribes to the chat-session store,
+// which transitively pulls in the generated daemon SDK. Stub every endpoint it
+// exports so the module loads, then import dynamically so the mock is registered
+// first. Mirrors the comprehensive mock in `multi-activity-group.test.tsx`.
+const sdkStub = async () => ({ data: undefined });
+const realSdkPath = new URL(
+  "../../../generated/daemon/sdk.gen.ts",
+  import.meta.url,
+).pathname;
+const sdkSource = await Bun.file(realSdkPath).text();
+const exportNames = [...sdkSource.matchAll(/^export const (\w+)/gm)].map(
+  (m) => m[1]!,
+);
+const sdkMock = Object.fromEntries(exportNames.map((n) => [n, sdkStub]));
+mock.module("@/generated/daemon/sdk.gen", () => sdkMock);
+
+const { ToolDetailPanel } = await import(
+  "@/domains/chat/components/tool-detail-panel"
+);
+const { useChatSessionStore } = await import(
+  "@/domains/chat/chat-session-store"
+);
 import type { ToolDetailPayload } from "@/stores/viewer-store";
+import type { DisplayMessage } from "@/domains/chat/types/types";
 
 const noop = () => {};
 
@@ -39,6 +61,9 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  act(() => {
+    useChatSessionStore.setState({ messages: [] });
+  });
 });
 
 describe("ToolDetailPanel", () => {
@@ -148,5 +173,97 @@ describe("ToolDetailPanel", () => {
 
     fireEvent.click(getByLabelText("Close tool details"));
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("thinking variant streams live reasoning from the chat-session store", () => {
+    act(() => {
+      useChatSessionStore.setState({
+        messages: [
+          {
+            id: "m1",
+            role: "assistant",
+            contentBlocks: [{ type: "thinking", thinking: "live reasoning" }],
+          },
+        ] as DisplayMessage[],
+      });
+    });
+    const detail = makeDetail({
+      kind: "thinking",
+      title: "Thought process",
+      messageId: "m1",
+      thinkingGroupIndex: 0,
+      thinkingText: "stale snapshot",
+    });
+    const { getByText, queryByText } = render(
+      <ToolDetailPanel detail={detail} onClose={noop} />,
+    );
+
+    // The live store text wins over the open-time snapshot.
+    expect(getByText("live reasoning")).toBeDefined();
+    expect(queryByText("stale snapshot")).toBeNull();
+
+    // Growing the store message updates the already-open drawer.
+    act(() => {
+      useChatSessionStore.setState({
+        messages: [
+          {
+            id: "m1",
+            role: "assistant",
+            contentBlocks: [
+              { type: "thinking", thinking: "live reasoning, extended" },
+            ],
+          },
+        ] as DisplayMessage[],
+      });
+    });
+    expect(getByText("live reasoning, extended")).toBeDefined();
+  });
+
+  test("thinking variant falls back to the snapshot when the message is absent", () => {
+    const detail = makeDetail({
+      kind: "thinking",
+      title: "Thought process",
+      messageId: "missing",
+      thinkingGroupIndex: 0,
+      thinkingText: "snapshot fallback",
+    });
+    const { getByText } = render(
+      <ToolDetailPanel detail={detail} onClose={noop} />,
+    );
+    expect(getByText("snapshot fallback")).toBeDefined();
+  });
+
+  test("thinking variant selects a single reasoning segment by item index", () => {
+    act(() => {
+      useChatSessionStore.setState({
+        messages: [
+          {
+            id: "m1",
+            role: "assistant",
+            contentBlocks: [
+              { type: "thinking", thinking: "segment one" },
+              {
+                type: "tool_use",
+                toolCall: { id: "t1", name: "bash", input: {} },
+              },
+              { type: "thinking", thinking: "segment two" },
+            ],
+          },
+        ] as DisplayMessage[],
+      });
+    });
+    const detail = makeDetail({
+      kind: "thinking",
+      title: "Thinking",
+      messageId: "m1",
+      thinkingGroupIndex: 0,
+      thinkingItemIndex: 1,
+      thinkingText: "ignored snapshot",
+    });
+    const { getByText, queryByText } = render(
+      <ToolDetailPanel detail={detail} onClose={noop} />,
+    );
+    expect(getByText("segment two")).toBeDefined();
+    expect(queryByText("segment one")).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/components/tool-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.tsx
@@ -4,8 +4,10 @@
  * `SubagentDetailPanel` shell (outer container, header with leading icon /
  * title / risk badge / close, scrollable body with sections).
  *
- * Driven by the `ToolDetailPayload` opened into `viewer-store`. Purely
- * presentational: it reads the payload and reports `onClose`.
+ * Driven by the `ToolDetailPayload` opened into `viewer-store`. The tool
+ * variant is purely presentational; the thinking variant additionally
+ * subscribes to the chat-session store so the reasoning text streams live
+ * (see `ThinkingDetailBody`).
  */
 
 import {
@@ -30,6 +32,7 @@ import { Button, Typography } from "@vellumai/design-library";
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
 import { RiskBadge } from "@/domains/chat/components/risk-badge";
 import { titleCaseToolName } from "@/domains/chat/components/tool-call-chip/utils";
+import { useLiveThinkingText } from "@/domains/chat/hooks/use-live-thinking-text";
 import {
     deriveStepLabelFromName,
     type IconName,
@@ -168,6 +171,35 @@ function DetailShell({
   );
 }
 
+/**
+ * Thinking variant body. Reuses the shared shell but renders the reasoning
+ * markdown live: it re-derives the text from the chat-session store via the
+ * payload's stable identity so an open drawer streams as deltas land, falling
+ * back to the open-time `thinkingText` snapshot when the source can't be
+ * resolved (e.g. message paged out, or an identity-less payload).
+ */
+function ThinkingDetailBody({
+  detail,
+  onClose,
+}: {
+  detail: ToolDetailPayload;
+  onClose: () => void;
+}) {
+  const live = useLiveThinkingText(
+    detail.messageId,
+    detail.thinkingGroupIndex,
+    detail.thinkingItemIndex,
+  );
+  return (
+    <DetailShell Glyph={Brain} title={detail.title} onClose={onClose}>
+      <ChatMarkdownMessage
+        content={live ?? detail.thinkingText ?? ""}
+        hardLineBreaks
+      />
+    </DetailShell>
+  );
+}
+
 export function ToolDetailPanel({
   detail,
   onClose,
@@ -180,11 +212,7 @@ export function ToolDetailPanel({
   // Thinking variant — reuse the same shell/header but render the full
   // reasoning markdown with no input/output sections and no risk badge.
   if (detail.kind === "thinking") {
-    return (
-      <DetailShell Glyph={Brain} title={detail.title} onClose={onClose}>
-        <ChatMarkdownMessage content={detail.thinkingText ?? ""} hardLineBreaks />
-      </DetailShell>
-    );
+    return <ThinkingDetailBody detail={detail} onClose={onClose} />;
   }
 
   const { iconName } = deriveStepLabelFromName(detail.toolName, detail.input);

--- a/clients/web/src/domains/chat/hooks/use-live-thinking-text.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-live-thinking-text.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * Tests for `useLiveThinkingText` — the selector that re-derives a thinking
+ * drawer's reasoning text from the live chat-session store so an open drawer
+ * streams instead of freezing its open-time snapshot.
+ *
+ * The chat-session store transitively pulls in the generated daemon SDK. Stub
+ * every endpoint it exports so the module loads; nothing here invokes them.
+ * Mirrors the comprehensive mock in `multi-activity-group.test.tsx`.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+const sdkStub = async () => ({ data: undefined });
+const realSdkPath = new URL(
+  "../../../generated/daemon/sdk.gen.ts",
+  import.meta.url,
+).pathname;
+const sdkSource = await Bun.file(realSdkPath).text();
+const exportNames = [...sdkSource.matchAll(/^export const (\w+)/gm)].map(
+  (m) => m[1]!,
+);
+const sdkMock = Object.fromEntries(exportNames.map((n) => [n, sdkStub]));
+mock.module("@/generated/daemon/sdk.gen", () => sdkMock);
+
+const { useLiveThinkingText } = await import(
+  "@/domains/chat/hooks/use-live-thinking-text"
+);
+const { useChatSessionStore } = await import(
+  "@/domains/chat/chat-session-store"
+);
+import type { DisplayMessage } from "@/domains/chat/types/types";
+
+function seed(messages: DisplayMessage[]) {
+  act(() => {
+    useChatSessionStore.setState({ messages });
+  });
+}
+
+function msg(overrides: Partial<DisplayMessage>): DisplayMessage {
+  return { id: "m1", role: "assistant", ...overrides } as DisplayMessage;
+}
+
+afterEach(() => {
+  cleanup();
+  act(() => {
+    useChatSessionStore.setState({ messages: [] });
+  });
+});
+
+describe("useLiveThinkingText", () => {
+  test("returns null without a message id or group index", () => {
+    seed([msg({ contentBlocks: [{ type: "thinking", thinking: "a" }] })]);
+    expect(renderHook(() => useLiveThinkingText(undefined, 0)).result.current).toBeNull();
+    expect(renderHook(() => useLiveThinkingText("m1", undefined)).result.current).toBeNull();
+  });
+
+  test("returns null when the message is absent", () => {
+    seed([]);
+    const { result } = renderHook(() => useLiveThinkingText("missing", 0));
+    expect(result.current).toBeNull();
+  });
+
+  test("returns the group's combined thinking when no item index is given", () => {
+    // A `thinking → tool → thinking` run groups into ONE activity group whose
+    // two reasoning segments are newline-joined for the combined panel.
+    seed([
+      msg({
+        contentBlocks: [
+          { type: "thinking", thinking: "first" },
+          { type: "tool_use", toolCall: { id: "t1", name: "bash", input: {} } },
+          { type: "thinking", thinking: "second" },
+        ],
+      }),
+    ]);
+    const { result } = renderHook(() => useLiveThinkingText("m1", 0));
+    expect(result.current).toBe("first\nsecond");
+  });
+
+  test("selects a single reasoning segment by item index", () => {
+    seed([
+      msg({
+        contentBlocks: [
+          { type: "thinking", thinking: "first" },
+          { type: "tool_use", toolCall: { id: "t1", name: "bash", input: {} } },
+          { type: "thinking", thinking: "second" },
+        ],
+      }),
+    ]);
+    expect(renderHook(() => useLiveThinkingText("m1", 0, 0)).result.current).toBe(
+      "first",
+    );
+    expect(renderHook(() => useLiveThinkingText("m1", 0, 1)).result.current).toBe(
+      "second",
+    );
+  });
+
+  test("returns null for an out-of-range item index", () => {
+    seed([msg({ contentBlocks: [{ type: "thinking", thinking: "only" }] })]);
+    const { result } = renderHook(() => useLiveThinkingText("m1", 0, 5));
+    expect(result.current).toBeNull();
+  });
+
+  test("resolves the second activity group by its index", () => {
+    // A text block closes the first activity group, so the second reasoning run
+    // lands at group index 2.
+    seed([
+      msg({
+        contentBlocks: [
+          { type: "thinking", thinking: "run-A" },
+          { type: "text", text: "interlude" },
+          { type: "thinking", thinking: "run-B" },
+        ],
+      }),
+    ]);
+    expect(renderHook(() => useLiveThinkingText("m1", 0)).result.current).toBe(
+      "run-A",
+    );
+    expect(renderHook(() => useLiveThinkingText("m1", 2)).result.current).toBe(
+      "run-B",
+    );
+  });
+
+  test("updates live as the store's thinking grows", () => {
+    seed([msg({ contentBlocks: [{ type: "thinking", thinking: "partial" }] })]);
+    const { result } = renderHook(() => useLiveThinkingText("m1", 0));
+    expect(result.current).toBe("partial");
+
+    seed([
+      msg({ contentBlocks: [{ type: "thinking", thinking: "partial and more" }] }),
+    ]);
+    expect(result.current).toBe("partial and more");
+  });
+
+  test("resolves a message by a merged alias id", () => {
+    seed([
+      msg({
+        id: "server-id",
+        mergedMessageIds: ["optimistic-id"],
+        contentBlocks: [{ type: "thinking", thinking: "aliased" }],
+      }),
+    ]);
+    const { result } = renderHook(() =>
+      useLiveThinkingText("optimistic-id", 0),
+    );
+    expect(result.current).toBe("aliased");
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-live-thinking-text.ts
+++ b/clients/web/src/domains/chat/hooks/use-live-thinking-text.ts
@@ -1,0 +1,45 @@
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import { groupContentBlocks } from "@/domains/chat/transcript/message-content";
+
+/**
+ * Live reasoning text for a thinking detail drawer, re-derived from the
+ * chat-session store on every render so an OPEN drawer streams as
+ * `assistant_thinking_delta` events land — instead of freezing the snapshot
+ * captured when the drawer was opened.
+ *
+ * The drawer target is identified by `(messageId, groupIndex)` plus an optional
+ * `thinkingItemIndex`. With no item index the combined reasoning of the whole
+ * activity group is returned (the bare "Thought process" panel, whose group
+ * holds a single reasoning run); with an item index the matching segment is
+ * returned (an in-card "Thinking" pill within a `thinking → tool → thinking`
+ * run). Reuses {@link groupContentBlocks} so the panel text cannot drift from
+ * the inline activity view it mirrors.
+ *
+ * Returns a primitive string so Zustand's `Object.is` comparison re-renders the
+ * caller only when the text actually grows. Returns `null` when the message or
+ * group can't be found (e.g. paged out of the transcript) so callers fall back
+ * to the open-time snapshot.
+ */
+export function useLiveThinkingText(
+  messageId: string | undefined,
+  groupIndex: number | undefined,
+  thinkingItemIndex?: number,
+): string | null {
+  return useChatSessionStore((s) => {
+    if (!messageId || groupIndex == null) return null;
+    const message = s.messages.find(
+      (m) => m.id === messageId || m.mergedMessageIds?.includes(messageId),
+    );
+    if (!message) return null;
+    const groups = groupContentBlocks(message.contentBlocks ?? [], {
+      splitInlineThinking: message.role !== "user",
+    });
+    const group = groups[groupIndex];
+    if (!group || group.type !== "activity") return null;
+    const segments = group.items.flatMap((item) =>
+      item.type === "thinking" && item.thinking ? [item.thinking] : [],
+    );
+    if (thinkingItemIndex == null) return segments.join("\n");
+    return segments[thinkingItemIndex] ?? null;
+  });
+}

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -220,6 +220,7 @@ export function TranscriptMessageBody({
     items: ContentBlockActivityItem[],
     key: string,
     isLastGroup: boolean,
+    groupIndex: number,
   ): ReactNode => {
     const cardItems: ToolCallCardItem[] = [];
     const groupToolCalls: ChatMessageToolCall[] = [];
@@ -270,6 +271,8 @@ export function TranscriptMessageBody({
             <MultiActivityGroup
               toolCalls={groupToolCalls}
               items={cardItems}
+              messageId={message.id}
+              groupIndex={groupIndex}
               onOpenRuleEditor={onOpenRuleEditor}
               onConfirmationSubmit={onConfirmationSubmit}
               onAllowAndCreateRule={onAllowAndCreateRule}
@@ -293,6 +296,8 @@ export function TranscriptMessageBody({
             variant="thinking"
             content={combinedThinking}
             isStreaming={isStreaming && isLastGroup}
+            messageId={message.id}
+            groupIndex={groupIndex}
           />
         )}
         {renderInlineSubagentCards(groupToolCalls)}
@@ -365,7 +370,7 @@ export function TranscriptMessageBody({
     if (group.type === "surface") {
       return renderSurfaceNode(group.surface, `b-surface-${gi}`);
     }
-    return renderActivityGroup(group.items, `b-activity-${gi}`, gi === lastGroupIndex);
+    return renderActivityGroup(group.items, `b-activity-${gi}`, gi === lastGroupIndex, gi);
   };
 
   const wrapperClass = `group/msg flex ${isUser ? "justify-end" : "justify-start"}`;

--- a/clients/web/src/domains/chat/utils/tool-call-card-utils.ts
+++ b/clients/web/src/domains/chat/utils/tool-call-card-utils.ts
@@ -62,6 +62,14 @@ export type ToolCallCardStep =
       startedAt?: number;
       /** Epoch-ms end of the reasoning run, when known. */
       completedAt?: number;
+      /**
+       * Ordinal of this reasoning segment among the group's GENUINE thinking
+       * items (0-based, in render order). Carried into the drawer payload so the
+       * open panel re-derives this exact segment's live text. Omitted for
+       * web-synthesized thinking steps (e.g. `web_fetch` "Reading …"), which
+       * have no backing reasoning item and keep the snapshot path.
+       */
+      thinkingItemIndex?: number;
     }
   | {
       kind: "web_search";
@@ -764,6 +772,10 @@ export function computeToolCallCardDataFromItems(
   // flowing through the tool/web header derivation, so we don't promote them
   // to a "Thinking" header.
   let trailingThinkingText: string | null = null;
+  // Ordinal of each genuine reasoning segment, in render order. Stamped onto its
+  // step so the drawer can re-derive that exact segment's live text. Mirrors the
+  // segment order `useLiveThinkingText` walks (truthy thinking items only).
+  let thinkingItemIndex = 0;
   for (const item of items) {
     if (item.kind === "thinking") {
       if (item.text) {
@@ -773,6 +785,7 @@ export function computeToolCallCardDataFromItems(
           text: item.text,
           startedAt: item.startedAt,
           completedAt: item.completedAt,
+          thinkingItemIndex: thinkingItemIndex++,
         });
         trailingThinkingText = item.text;
       }

--- a/clients/web/src/stores/viewer-store.ts
+++ b/clients/web/src/stores/viewer-store.ts
@@ -138,8 +138,51 @@ export interface ToolDetailPayload {
    * renders `thinkingText` as markdown with no input/output sections.
    */
   kind?: "tool" | "thinking";
-  /** Full reasoning markdown rendered when `kind === "thinking"`. */
+  /**
+   * Reasoning markdown captured when the drawer was opened. Used as the
+   * fallback when the live source (below) can't be resolved.
+   */
   thinkingText?: string;
+  /**
+   * Stable identity of the reasoning run this drawer mirrors. When present, the
+   * panel re-derives live text from the chat-session store (via
+   * `useLiveThinkingText`) so an open drawer streams instead of freezing
+   * `thinkingText`. `messageId` + `thinkingGroupIndex` locate the activity
+   * group; `thinkingItemIndex` selects a single segment within it (omitted for
+   * the bare combined "Thought process" panel).
+   */
+  messageId?: string;
+  thinkingGroupIndex?: number;
+  thinkingItemIndex?: number;
+}
+
+/** The identity fields a thinking drawer target is matched on. */
+type ThinkingTarget = Pick<
+  ToolDetailPayload,
+  "messageId" | "thinkingGroupIndex" | "thinkingItemIndex" | "thinkingText"
+>;
+
+/**
+ * Whether `active` addresses the same reasoning as `target`. Keys on the stable
+ * (message, group, segment) identity when `target` carries one — so the match
+ * holds while the reasoning text streams — and falls back to text equality for
+ * identity-less targets (web-synthesized "Reading…" steps, stories/tests).
+ *
+ * Single source of truth for the inline thinking affordances' selected state
+ * (`SingleActivity`, `MultiActivityGroup`) and the drawer toggle below.
+ */
+export function sameThinkingTarget(
+  active: ThinkingTarget,
+  target: ThinkingTarget,
+): boolean {
+  if (target.messageId != null) {
+    return (
+      active.messageId === target.messageId &&
+      active.thinkingGroupIndex === target.thinkingGroupIndex &&
+      active.thinkingItemIndex === target.thinkingItemIndex
+    );
+  }
+  return active.thinkingText === target.thinkingText;
 }
 
 // ---------------------------------------------------------------------------
@@ -378,8 +421,7 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
       state.mainView === "tool-detail" &&
       active != null &&
       (payload.kind === "thinking"
-        ? active.kind === "thinking" &&
-          active.thinkingText === payload.thinkingText
+        ? active.kind === "thinking" && sameThinkingTarget(active, payload)
         : active.kind !== "thinking" &&
           active.toolCallId === payload.toolCallId);
     if (isSameTarget) {


### PR DESCRIPTION
## Summary
- The Thought process side drawer rendered a frozen snapshot of the reasoning captured at open-time (`viewer-store.activeToolDetail.thinkingText`), so it never updated as `assistant_thinking_delta` events streamed in — unlike the main message bubble. The drawer now carries a stable identity (message id + group index + optional segment index) and re-derives its text live from the chat-session store via a new `useLiveThinkingText` hook, mirroring how the transcript already streams.
- Fixes both entry points that open the drawer: the bare "Thought process" link (`SingleActivity`) and the in-card "Thinking" pill (`MultiActivityGroup`). The tool-call card projection stamps each genuine reasoning segment with a `thinkingItemIndex` so a pill resolves its exact segment; web-synthesized "Reading…" steps keep the snapshot path.
- Centralizes the "match by stable identity, else by text" rule in one `sameThinkingTarget` helper (used by the drawer toggle and both affordances), so the active-highlight and toggle-to-close stay correct while the text streams. Falls back to the open-time snapshot when the message can't be resolved.

## Original prompt
The Thought process side panel in the Electron app didn't stream — its reasoning text appeared frozen instead of growing token-by-token like the main response. Investigation found the daemon streams thinking deltas fine and the inline affordances already update live; only the opened side drawer was decoupled, reading a one-time snapshot from the viewer store. The task was to plan and implement a fix so the drawer streams live, covering both the bare panel and the in-card thinking pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)