### PR TITLE
feat(web): LogRocket session replay + combined product-improvement consent

### DIFF
--- a/clients/web/bun.lock
+++ b/clients/web/bun.lock
@@ -46,6 +46,7 @@
         "clsx": "2.1.1",
         "jszip": "3.10.1",
         "katex": "0.17.0",
+        "logrocket": "12.1.1",
         "lucide-react": "1.16.0",
         "motion": "12.39.0",
         "pdfjs-dist": "5.7.284",
@@ -1245,6 +1246,8 @@
     "linkifyjs": ["linkifyjs@4.3.3", "", {}, "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "logrocket": ["logrocket@12.1.1", "", {}, "sha512-l7z9ii5nNV6NZ3nzEqbB3xJAqFJC6QdRYDK8DeCC6JKwzuI8nyUezUJAotgMyClrqB6eV/Bo0i/KihQlXSRDKw=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -69,6 +69,7 @@
     "clsx": "2.1.1",
     "jszip": "3.10.1",
     "katex": "0.17.0",
+    "logrocket": "12.1.1",
     "lucide-react": "1.16.0",
     "motion": "12.39.0",
     "pdfjs-dist": "5.7.284",

--- a/clients/web/src/domains/account/profile.ts
+++ b/clients/web/src/domains/account/profile.ts
@@ -15,6 +15,7 @@ export interface UserConsent {
   ai_data_sharing_accepted_at: string | null;
   share_analytics: boolean;
   share_diagnostics: boolean;
+  share_product_improvement: boolean;
 }
 
 export type ConsentPatch = Partial<

--- a/clients/web/src/domains/onboarding/onboarding-store.ts
+++ b/clients/web/src/domains/onboarding/onboarding-store.ts
@@ -1,9 +1,10 @@
 /**
  * Zustand store for onboarding boolean preferences.
  *
- * **Device-persisted fields** (`shareAnalytics`, `shareDiagnostics`) are
- * written to `device:` localStorage keys on every setter call and synced
- * across tabs via `watchSetting`. They survive logout.
+ * **Device-persisted fields** (`shareAnalytics`, `shareDiagnostics`,
+ * `shareProductImprovement`) are written to `device:` localStorage keys on
+ * every setter call and synced across tabs via `watchSetting`. They survive
+ * logout.
  *
  * **In-memory-only fields** (`tosAccepted`, `aiDataConsent`) start `false`
  * and are populated by `restoreConsentForUser` (called from the auth store
@@ -29,6 +30,7 @@ import { deviceKey } from "@/utils/device-settings";
 
 const KEY_SHARE_ANALYTICS = deviceKey("shareAnalytics");
 const KEY_SHARE_DIAGNOSTICS = deviceKey("shareDiagnostics");
+const KEY_SHARE_PRODUCT_IMPROVEMENT = deviceKey("shareProductImprovement");
 
 // ---------------------------------------------------------------------------
 // State + Actions
@@ -37,6 +39,7 @@ const KEY_SHARE_DIAGNOSTICS = deviceKey("shareDiagnostics");
 export interface OnboardingState {
   shareAnalytics: boolean;
   shareDiagnostics: boolean;
+  shareProductImprovement: boolean;
   tosAccepted: boolean;
   aiDataConsent: boolean;
 }
@@ -44,6 +47,7 @@ export interface OnboardingState {
 export interface OnboardingActions {
   setShareAnalytics: (value: boolean) => void;
   setShareDiagnostics: (value: boolean) => void;
+  setShareProductImprovement: (value: boolean) => void;
   setTosAccepted: (value: boolean) => void;
   setAiDataConsent: (value: boolean) => void;
 }
@@ -57,6 +61,7 @@ export type OnboardingStore = OnboardingState & OnboardingActions;
 const useOnboardingStoreBase = create<OnboardingStore>()((set) => ({
   shareAnalytics: getLocalBool(KEY_SHARE_ANALYTICS, true),
   shareDiagnostics: getLocalBool(KEY_SHARE_DIAGNOSTICS, true),
+  shareProductImprovement: getLocalBool(KEY_SHARE_PRODUCT_IMPROVEMENT, true),
   tosAccepted: false,
   aiDataConsent: false,
 
@@ -67,6 +72,10 @@ const useOnboardingStoreBase = create<OnboardingStore>()((set) => ({
   setShareDiagnostics: (value) => {
     set({ shareDiagnostics: value });
     setLocalBool(KEY_SHARE_DIAGNOSTICS, value);
+  },
+  setShareProductImprovement: (value) => {
+    set({ shareProductImprovement: value });
+    setLocalBool(KEY_SHARE_PRODUCT_IMPROVEMENT, value);
   },
   setTosAccepted: (value) => {
     set({ tosAccepted: value });
@@ -85,11 +94,13 @@ export const useOnboardingStore = createSelectors(useOnboardingStoreBase);
 const SYNCED_KEYS: ReadonlyMap<string, keyof OnboardingState> = new Map([
   [KEY_SHARE_ANALYTICS, "shareAnalytics"],
   [KEY_SHARE_DIAGNOSTICS, "shareDiagnostics"],
+  [KEY_SHARE_PRODUCT_IMPROVEMENT, "shareProductImprovement"],
 ]);
 
 const SYNCED_DEFAULTS: Record<string, boolean> = {
   shareAnalytics: true,
   shareDiagnostics: true,
+  shareProductImprovement: true,
 };
 
 for (const [key, field] of SYNCED_KEYS) {

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
@@ -14,11 +14,13 @@ mock.module("react-router", () => ({
 // Consent setters — spied so we can assert they are NOT persisted in preview.
 const setShareAnalytics = mock((_next: boolean) => {});
 const setShareDiagnostics = mock((_next: boolean) => {});
+const setShareProductImprovement = mock((_next: boolean) => {});
 const setTosAccepted = mock((_next: boolean) => {});
 const setAiDataConsent = mock((_next: boolean) => {});
 mock.module("@/domains/onboarding/prefs", () => ({
   useShareAnalytics: () => [false, setShareAnalytics],
   useShareDiagnostics: () => [false, setShareDiagnostics],
+  useShareProductImprovement: () => [true, setShareProductImprovement],
   useTosAccepted: () => [true, setTosAccepted],
   useAiDataConsent: () => [true, setAiDataConsent],
 }));

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -15,6 +15,7 @@ import {
     useAiDataConsent,
     useShareAnalytics,
     useShareDiagnostics,
+    useShareProductImprovement,
     useTosAccepted,
 } from "@/domains/onboarding/prefs";
 import { isElectron } from "@/runtime/is-electron";
@@ -79,6 +80,8 @@ export function PrivacyScreen() {
     onboardingFunnelVariantFromExperiment(preChatExperimentArm);
   const [shareAnalytics, setShareAnalyticsReal] = useShareAnalytics();
   const [shareDiagnostics, setShareDiagnosticsReal] = useShareDiagnostics();
+  const [shareProductImprovement, setShareProductImprovementReal] =
+    useShareProductImprovement();
   const [tosAccepted, setTosAcceptedReal] = useTosAccepted();
   const [aiDataConsent, setAiDataConsentReal] = useAiDataConsent();
   const hasPlatformSession = useHasPlatformSession();
@@ -93,6 +96,9 @@ export function PrivacyScreen() {
   const noop = useCallback((_next: boolean) => {}, []);
   const setShareAnalytics = isPreview ? noop : setShareAnalyticsReal;
   const setShareDiagnostics = isPreview ? noop : setShareDiagnosticsReal;
+  const setShareProductImprovement = isPreview
+    ? noop
+    : setShareProductImprovementReal;
   const setTosAccepted = isPreview ? noop : setTosAcceptedReal;
   const setAiDataConsent = isPreview ? noop : setAiDataConsentReal;
 
@@ -106,7 +112,7 @@ export function PrivacyScreen() {
       return;
     }
 
-    saveConsent({ userId, tos: tosAccepted, ai: aiDataConsent, shareAnalytics, shareDiagnostics, hasPlatformSession });
+    saveConsent({ userId, tos: tosAccepted, ai: aiDataConsent, shareAnalytics, shareDiagnostics, shareProductImprovement, hasPlatformSession });
     if (!isNative) {
       const variant = resolveOnboardingFunnelVariant(preferredFunnelVariant);
       emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
@@ -130,6 +136,7 @@ export function PrivacyScreen() {
     searchParams,
     shareAnalytics,
     shareDiagnostics,
+    shareProductImprovement,
     tosAccepted,
     userId,
   ]);
@@ -220,8 +227,18 @@ export function PrivacyScreen() {
             <div className="h-px bg-[var(--surface-active)] dark:bg-[var(--surface-lift)]" />
             <div className="flex items-center gap-2 text-body-small-default text-[var(--content-tertiary)]">
               <EyeOff className="h-4 w-4 shrink-0" />
-              <span>Your conversations and personal data are never included.</span>
+              <span>
+                Share Analytics and Share Diagnostics never include your
+                conversations or personal data.
+              </span>
             </div>
+            <div className="h-px bg-[var(--surface-active)] dark:bg-[var(--surface-lift)]" />
+            <SettingRow
+              label="Help improve Vellum"
+              helperText="Enables web session recording and collection of conversation and agent-execution traces to debug issues and improve the product. Unlike the options above, this can include your conversation content. On by default; opt out anytime here or in Settings."
+              checked={shareProductImprovement}
+              onChange={setShareProductImprovement}
+            />
           </div>
         </Card>
 

--- a/clients/web/src/domains/onboarding/pages/review-terms-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/review-terms-screen.tsx
@@ -6,6 +6,7 @@ import {
     useAiDataConsent,
     useShareAnalytics,
     useShareDiagnostics,
+    useShareProductImprovement,
     useTosAccepted,
 } from "@/domains/onboarding/prefs";
 import { hardNavigate } from "@/lib/auth/hard-navigate";
@@ -32,9 +33,10 @@ export function ReviewTermsScreen() {
   const [aiDataConsent, setAiDataConsent] = useAiDataConsent();
   const [shareAnalytics] = useShareAnalytics();
   const [shareDiagnostics] = useShareDiagnostics();
+  const [shareProductImprovement] = useShareProductImprovement();
 
   const onContinue = useCallback(() => {
-    saveConsent({ userId, tos: tosAccepted, ai: aiDataConsent, shareAnalytics, shareDiagnostics, hasPlatformSession });
+    saveConsent({ userId, tos: tosAccepted, ai: aiDataConsent, shareAnalytics, shareDiagnostics, shareProductImprovement, hasPlatformSession });
 
     const destination = sanitizeReturnTo(searchParams.get("returnTo"), routes.assistant);
     void navigate(destination, { replace: true });
@@ -45,6 +47,7 @@ export function ReviewTermsScreen() {
     searchParams,
     shareAnalytics,
     shareDiagnostics,
+    shareProductImprovement,
     tosAccepted,
     userId,
   ]);

--- a/clients/web/src/domains/onboarding/prefs.ts
+++ b/clients/web/src/domains/onboarding/prefs.ts
@@ -64,6 +64,19 @@ export function useShareDiagnostics(): [boolean, (next: boolean) => void] {
   return [value, setter];
 }
 
+/**
+ * Help improve Vellum. Defaults to `true`. A single combined opt-out that
+ * gates both web session replay (LogRocket) and conversation/agent trace
+ * collection. Backed by the SAME localStorage key as `/settings/privacy`.
+ */
+export function useShareProductImprovement(): [boolean, (next: boolean) => void] {
+  const value = useOnboardingStore.use.shareProductImprovement();
+  const setter = useCallback((next: boolean) => {
+    useOnboardingStore.getState().setShareProductImprovement(next);
+  }, []);
+  return [value, setter];
+}
+
 /** Whether the user accepted Terms of Service during onboarding. Defaults to `false`. */
 export function useTosAccepted(): [boolean, (next: boolean) => void] {
   const value = useOnboardingStore.use.tosAccepted();

--- a/clients/web/src/domains/settings/pages/privacy-page.tsx
+++ b/clients/web/src/domains/settings/pages/privacy-page.tsx
@@ -72,6 +72,9 @@ export function PrivacyPage() {
   const [shareDiagnostics, setShareDiagnostics] = useState(
     () => getDeviceBool("shareDiagnostics", true),
   );
+  const [shareProductImprovement, setShareProductImprovement] = useState(
+    () => getDeviceBool("shareProductImprovement", true),
+  );
   const [retentionId, setRetentionId] = useState(() =>
     getDeviceSetting("llmLogRetention", DEFAULT_RETENTION_ID),
   );
@@ -86,6 +89,12 @@ export function PrivacyPage() {
     const next = !shareDiagnostics;
     setShareDiagnostics(next);
     savePreferenceToggle("share_diagnostics", next, hasPlatformSession);
+  };
+
+  const handleProductImprovementToggle = () => {
+    const next = !shareProductImprovement;
+    setShareProductImprovement(next);
+    savePreferenceToggle("share_product_improvement", next, hasPlatformSession);
   };
 
   const handleRetentionChange = (value: string) => {
@@ -113,6 +122,13 @@ export function PrivacyPage() {
             helperText="Send crash reports and performance metrics. Your conversations and personal data are never included."
             checked={shareDiagnostics}
             onChange={handleDiagnosticsToggle}
+          />
+          <Divider />
+          <SettingRow
+            label="Help improve Vellum"
+            helperText="Enables web session recording and collection of conversation and agent-execution traces to debug issues and improve the product. Unlike the options above, this can include your conversation content. On by default; opt out anytime."
+            checked={shareProductImprovement}
+            onChange={handleProductImprovementToggle}
           />
           <Divider />
           <AccessConsentSetting />

--- a/clients/web/src/env.d.ts
+++ b/clients/web/src/env.d.ts
@@ -14,6 +14,12 @@ interface ImportMetaEnv {
   readonly VITE_SENTRY_DSN?: string;
   /** Sentry environment tag (e.g. "production", "staging"). */
   readonly VITE_SENTRY_ENVIRONMENT?: string;
+  /**
+   * LogRocket application id (`org/app`) for session replay. Injected by the
+   * CI/CD pipeline. When unset, LogRocket is never initialized — the feature
+   * stays dark without this value.
+   */
+  readonly VITE_LOGROCKET_APP_ID?: string;
   /** Stripe publishable key for payment forms. Injected by CI/CD pipeline. */
   readonly VITE_STRIPE_PUBLISHABLE_KEY?: string;
   /** App version stamp for diagnostic reporting. */

--- a/clients/web/src/lib/logrocket/logrocket-control.test.ts
+++ b/clients/web/src/lib/logrocket/logrocket-control.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// LogRocket SDK — capture init/identify calls without loading the real SDK.
+const initMock = mock((_appId: string, _options: unknown) => {});
+const identifyMock = mock((_uid: string) => {});
+mock.module("logrocket", () => ({
+  default: { init: initMock, identify: identifyMock },
+}));
+
+// Consent inputs: the device toggle and the onboarding store's
+// version-accepted flags. Driven per-test.
+let toggleOn = false;
+let storeState = { tosAccepted: false, aiDataConsent: false };
+const watchers: Array<() => void> = [];
+const storeSubscribers: Array<() => void> = [];
+
+mock.module("@/utils/device-settings", () => ({
+  getDeviceBool: (_name: string, fallback: boolean) =>
+    _name === "shareProductImprovement" ? toggleOn : fallback,
+  watchDeviceSetting: (_name: string, cb: () => void) => {
+    watchers.push(cb);
+    return () => {};
+  },
+}));
+
+mock.module("@/domains/onboarding/onboarding-store", () => ({
+  useOnboardingStore: {
+    getState: () => storeState,
+    subscribe: (cb: () => void) => {
+      storeSubscribers.push(cb);
+      return () => {};
+    },
+  },
+}));
+
+let userId: string | null = null;
+mock.module("@/stores/auth-store", () => ({
+  useAuthStore: { getState: () => ({ user: userId ? { id: userId } : null }) },
+}));
+
+const {
+  logRocketConsentGranted,
+  syncLogRocketClient,
+  installLogRocketControlListeners,
+} = await import("@/lib/logrocket/logrocket-control");
+
+const APP_ID = "org/app";
+const OPTIONS = {} as Parameters<typeof syncLogRocketClient>[1];
+
+beforeEach(() => {
+  initMock.mockClear();
+  identifyMock.mockClear();
+  toggleOn = false;
+  storeState = { tosAccepted: false, aiDataConsent: false };
+  userId = null;
+  watchers.length = 0;
+  storeSubscribers.length = 0;
+});
+
+describe("logRocketConsentGranted", () => {
+  test("requires both the toggle and current-version acceptance", () => {
+    toggleOn = false;
+    storeState = { tosAccepted: true, aiDataConsent: true };
+    expect(logRocketConsentGranted()).toBe(false);
+
+    toggleOn = true;
+    storeState = { tosAccepted: false, aiDataConsent: false };
+    expect(logRocketConsentGranted()).toBe(false);
+
+    // tos accepted but AI consent missing — still not the current version.
+    storeState = { tosAccepted: true, aiDataConsent: false };
+    expect(logRocketConsentGranted()).toBe(false);
+
+    storeState = { tosAccepted: true, aiDataConsent: true };
+    expect(logRocketConsentGranted()).toBe(true);
+  });
+});
+
+// The control module holds a one-time `initialized` flag (the LogRocket SDK
+// has no re-init/teardown). It is not resettable between tests, so the full
+// init lifecycle is asserted in a single ordered test rather than split
+// across cases that would each need a fresh flag.
+describe("syncLogRocketClient + listeners (init lifecycle)", () => {
+  test("gates the one-time init on consent, then initializes lazily on opt-in", () => {
+    // No app id → no-op even with consent.
+    toggleOn = true;
+    storeState = { tosAccepted: true, aiDataConsent: true };
+    syncLogRocketClient("", OPTIONS);
+    expect(initMock).not.toHaveBeenCalled();
+
+    // App id present but consent withdrawn → still no init.
+    toggleOn = false;
+    syncLogRocketClient(APP_ID, OPTIONS);
+    expect(initMock).not.toHaveBeenCalled();
+
+    // Listeners installed while consent is absent — nothing initializes yet.
+    installLogRocketControlListeners(APP_ID, OPTIONS);
+    expect(initMock).not.toHaveBeenCalled();
+    expect(watchers.length).toBe(1);
+    expect(storeSubscribers.length).toBe(1);
+
+    // User opts in (toggle on AND current version accepted) and the watcher
+    // fires → lazy one-time init + identify.
+    toggleOn = true;
+    storeState = { tosAccepted: true, aiDataConsent: true };
+    userId = "user-1";
+    watchers[0]!();
+    expect(initMock).toHaveBeenCalledTimes(1);
+    expect(initMock).toHaveBeenCalledWith(APP_ID, OPTIONS);
+    expect(identifyMock).toHaveBeenCalledWith("user-1");
+
+    // Idempotent — further syncs must not re-init or re-identify.
+    syncLogRocketClient(APP_ID, OPTIONS);
+    expect(initMock).toHaveBeenCalledTimes(1);
+    expect(identifyMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/web/src/lib/logrocket/logrocket-control.ts
+++ b/clients/web/src/lib/logrocket/logrocket-control.ts
@@ -1,0 +1,108 @@
+import LogRocket from "logrocket";
+
+import { useAuthStore } from "@/stores/auth-store";
+import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
+import { getDeviceBool, watchDeviceSetting } from "@/utils/device-settings";
+
+/**
+ * The LogRocket SDK declares its option/request/response shapes in an
+ * ambient `LR` namespace that `export =` does not re-export, so they are
+ * derived from the SDK's own method signatures instead of referenced by
+ * name. This keeps the call sites strongly typed without depending on the
+ * unexported namespace.
+ */
+export type LogRocketOptions = NonNullable<Parameters<typeof LogRocket.init>[1]>;
+export type LogRocketRequest = Parameters<
+  NonNullable<NonNullable<LogRocketOptions["network"]>["requestSanitizer"]>
+>[0];
+export type LogRocketResponse = Parameters<
+  NonNullable<NonNullable<LogRocketOptions["network"]>["responseSanitizer"]>
+>[0];
+
+/**
+ * Gates the browser-side LogRocket session-replay client on the user's
+ * "Help improve Vellum" toggle (`device:share_product_improvement`) AND
+ * acceptance of the current privacy-policy version.
+ *
+ * Strict opt-in semantics — recording starts only when BOTH hold:
+ *   - the toggle is explicitly `true` (absent / `false` → OFF), and
+ *   - the user has accepted the current `CONSENT_VERSION` (mirrored into the
+ *     onboarding store as `tosAccepted && aiDataConsent`, which are set true
+ *     only when the accepted versions equal `CONSENT_VERSION`).
+ *
+ * Unlike Sentry, the LogRocket SDK exposes no public teardown; its supported
+ * runtime gate is the `shouldSendData()` callback, consulted live before each
+ * upload. `init()` therefore runs at most once (guarded by `initialized`);
+ * opting out reactively stops uploads via `shouldSendData()` returning false,
+ * and opting back in resumes them without re-initializing.
+ *
+ * Reference: https://docs.logrocket.com/reference/init
+ */
+
+let initialized = false;
+let identifiedUserId: string | null = null;
+
+/** True only when the user has accepted the current privacy-policy version. */
+function currentVersionAccepted(): boolean {
+  const state = useOnboardingStore.getState();
+  return state.tosAccepted && state.aiDataConsent;
+}
+
+/**
+ * Live consent check used both to gate the first `init()` and as the SDK's
+ * per-upload `shouldSendData()` callback. Reads localStorage and the
+ * onboarding store directly so a toggle flip or a fresh re-accept takes
+ * effect immediately, without re-initializing.
+ */
+export function logRocketConsentGranted(): boolean {
+  return getDeviceBool("shareProductImprovement", false) && currentVersionAccepted();
+}
+
+/** Identify the active session with the platform user id (id only). */
+function identifyCurrentUser(): void {
+  const userId = useAuthStore.getState().user?.id ?? null;
+  if (!userId || userId === identifiedUserId) return;
+  LogRocket.identify(userId);
+  identifiedUserId = userId;
+}
+
+/**
+ * Apply the current consent value to the LogRocket client — initialize once
+ * when consent is granted, then keep the identified user in sync. When
+ * consent is not granted, `shouldSendData()` already suppresses uploads, so
+ * there is nothing to tear down. Idempotent.
+ */
+export function syncLogRocketClient(appId: string, options: LogRocketOptions): void {
+  if (!appId) return;
+  if (!logRocketConsentGranted()) return;
+  if (!initialized) {
+    LogRocket.init(appId, options);
+    initialized = true;
+  }
+  identifyCurrentUser();
+}
+
+/**
+ * Install listeners so LogRocket initializes / re-identifies whenever the
+ * user flips the "Help improve Vellum" toggle (cross-tab `storage` event and
+ * same-tab `vellum:pref-changed` event) or completes a fresh privacy-policy
+ * acceptance (onboarding store update). Uploads are gated live by
+ * `shouldSendData()`, so opt-out needs no listener-driven teardown.
+ *
+ * Returns a cleanup function that removes both subscriptions.
+ */
+export function installLogRocketControlListeners(
+  appId: string,
+  options: LogRocketOptions,
+): () => void {
+  const unwatchToggle = watchDeviceSetting("shareProductImprovement", () => {
+    syncLogRocketClient(appId, options);
+  });
+  const unsubscribeStore = useOnboardingStore.subscribe(() => {
+    syncLogRocketClient(appId, options);
+  });
+  return () => {
+    unwatchToggle();
+    unsubscribeStore();
+  };
+}

--- a/clients/web/src/lib/logrocket/logrocket-init.test.ts
+++ b/clients/web/src/lib/logrocket/logrocket-init.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, mock, test } from "bun:test";
+
+// Avoid loading the real LogRocket UMD bundle (and the store/device-settings
+// dependencies it pulls in) when importing the init module under test.
+mock.module("logrocket", () => ({
+  default: { init: () => {}, identify: () => {} },
+}));
+mock.module("@/lib/logrocket/logrocket-control", () => ({
+  installLogRocketControlListeners: () => () => {},
+  logRocketConsentGranted: () => false,
+  syncLogRocketClient: () => {},
+}));
+
+const { requestSanitizer, responseSanitizer } = await import(
+  "@/lib/logrocket/logrocket-init"
+);
+
+const REDACTED = "[REDACTED]";
+
+describe("requestSanitizer", () => {
+  test("redacts credential headers and token-shaped body fields, sanitizes the url", () => {
+    const out = requestSanitizer({
+      reqId: "1",
+      method: "POST",
+      url: "https://api.vellum.ai/v1/oauth/callback?code=abc123&keep=ok",
+      headers: {
+        Authorization: "Bearer secret-token",
+        Cookie: "sessionid=xyz",
+        "X-Api-Key": "k-123",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        username: "alice",
+        password: "hunter2",
+        access_token: "tok-abc",
+        nested: { refresh_token: "r-1", note: "keep" },
+      }),
+    });
+
+    // URL: the `code` auth param is scrubbed, the benign one preserved.
+    expect(out.url).toContain("code=%5BREDACTED%5D");
+    expect(out.url).toContain("keep=ok");
+
+    // Headers: credentials redacted, benign header preserved.
+    expect(out.headers.Authorization).toBe(REDACTED);
+    expect(out.headers.Cookie).toBe(REDACTED);
+    expect(out.headers["X-Api-Key"]).toBe(REDACTED);
+    expect(out.headers["Content-Type"]).toBe("application/json");
+
+    // Body: token-shaped fields redacted (incl. nested), benign fields kept.
+    const body = JSON.parse(out.body!);
+    expect(body.username).toBe("alice");
+    expect(body.password).toBe(REDACTED);
+    expect(body.access_token).toBe(REDACTED);
+    expect(body.nested.refresh_token).toBe(REDACTED);
+    expect(body.nested.note).toBe("keep");
+  });
+
+  test("leaves a non-JSON body untouched", () => {
+    const out = requestSanitizer({
+      reqId: "2",
+      method: "GET",
+      url: "https://api.vellum.ai/v1/feed",
+      headers: {},
+      body: "not json",
+    });
+    expect(out.body).toBe("not json");
+  });
+});
+
+describe("responseSanitizer", () => {
+  test("redacts credential headers and token-shaped body fields", () => {
+    const out = responseSanitizer({
+      reqId: "3",
+      method: "POST",
+      status: 200,
+      url: "https://api.vellum.ai/v1/oauth/token?token=leak",
+      headers: { "Set-Cookie": "sessionid=xyz", "X-Trace": "ok" },
+      body: JSON.stringify({ id_token: "jwt", ok: true }),
+    });
+
+    expect(out.url).toContain("token=%5BREDACTED%5D");
+    expect(out.headers["Set-Cookie"]).toBe(REDACTED);
+    expect(out.headers["X-Trace"]).toBe("ok");
+
+    const body = JSON.parse(out.body!);
+    expect(body.id_token).toBe(REDACTED);
+    expect(body.ok).toBe(true);
+  });
+});

--- a/clients/web/src/lib/logrocket/logrocket-init.ts
+++ b/clients/web/src/lib/logrocket/logrocket-init.ts
@@ -1,0 +1,167 @@
+import {
+  installLogRocketControlListeners,
+  logRocketConsentGranted,
+  syncLogRocketClient,
+  type LogRocketOptions,
+  type LogRocketRequest,
+  type LogRocketResponse,
+} from "@/lib/logrocket/logrocket-control";
+import { sanitizeUrl } from "@/lib/sentry/url-sanitize";
+
+/**
+ * Browser-side LogRocket session-replay initialization, gated on the user's
+ * "Help improve Vellum" consent toggle AND acceptance of the current
+ * privacy-policy version (see `logrocket-control.ts`).
+ *
+ * Session replay records the screen, console, and network traffic, so the
+ * sanitizers below run inside the SDK before anything is uploaded:
+ *
+ *   - `dom.inputSanitizer` masks the *content* of every `<input>` /
+ *     `<textarea>` so typed secrets (passwords, tokens, API keys) are never
+ *     captured. `dom.textSanitizer` is intentionally left off so the
+ *     conversation UI remains legible — replay's debugging value.
+ *   - `browser.urlSanitizer` and the request/response URL fields reuse the
+ *     Sentry `sanitizeUrl` helper to strip auth codes, invite tokens, and
+ *     OAuth fragment tokens from recorded URLs.
+ *   - The network request/response sanitizers redact credential-bearing
+ *     headers (`Authorization`, cookies, API-key headers) and scrub bodies
+ *     that carry token-shaped JSON fields.
+ *   - `shouldCaptureIP` is disabled — IP/GeoIP is unnecessary for product
+ *     debugging and broadens the PII surface.
+ *
+ * Reference: https://docs.logrocket.com/reference/network
+ * Reference: https://docs.logrocket.com/reference/dom
+ */
+
+const REDACTED = "[REDACTED]";
+
+// Header names whose values are credentials and must never be recorded.
+// Matched case-insensitively against the recorded header keys.
+const SENSITIVE_HEADER_KEYS = new Set([
+  "authorization",
+  "proxy-authorization",
+  "cookie",
+  "set-cookie",
+  "x-api-key",
+  "x-auth-token",
+  "x-csrf-token",
+  "x-csrftoken",
+  "x-xsrf-token",
+  "vellum-api-key",
+]);
+
+// JSON body keys whose values are credentials/tokens. Matched
+// case-insensitively against object keys before re-serializing.
+const SENSITIVE_BODY_KEYS = new Set([
+  "access_token",
+  "accesstoken",
+  "api_key",
+  "apikey",
+  "authorization",
+  "client_secret",
+  "code",
+  "id_token",
+  "password",
+  "private_key",
+  "refresh_token",
+  "secret",
+  "session",
+  "token",
+]);
+
+type HeaderBag = { [key: string]: string | null | undefined };
+
+function scrubHeaders(headers: HeaderBag): HeaderBag {
+  const next: HeaderBag = {};
+  for (const [key, value] of Object.entries(headers)) {
+    next[key] = SENSITIVE_HEADER_KEYS.has(key.toLowerCase()) ? REDACTED : value;
+  }
+  return next;
+}
+
+function scrubJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(scrubJsonValue);
+  if (value && typeof value === "object") {
+    const next: Record<string, unknown> = {};
+    for (const [key, inner] of Object.entries(value as Record<string, unknown>)) {
+      next[key] = SENSITIVE_BODY_KEYS.has(key.toLowerCase())
+        ? REDACTED
+        : scrubJsonValue(inner);
+    }
+    return next;
+  }
+  return value;
+}
+
+/**
+ * Redact token-shaped fields from a recorded body. Only JSON bodies are
+ * deep-scrubbed; non-JSON bodies are left as-is (URLs and headers are the
+ * primary credential carriers and are handled separately). A body that
+ * fails to round-trip through JSON is dropped entirely to fail closed.
+ */
+function scrubBody(body: string | undefined): string | undefined {
+  if (!body) return body;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return body;
+  }
+  try {
+    return JSON.stringify(scrubJsonValue(parsed));
+  } catch {
+    return REDACTED;
+  }
+}
+
+/**
+ * Exported for unit testing. Strips credential-bearing headers, scrubs
+ * token-shaped JSON body fields, and sanitizes the URL before a recorded
+ * request enters a LogRocket session.
+ */
+export function requestSanitizer(request: LogRocketRequest): LogRocketRequest {
+  request.url = sanitizeUrl(request.url);
+  request.headers = scrubHeaders(request.headers);
+  request.body = scrubBody(request.body);
+  return request;
+}
+
+/** Exported for unit testing. Response counterpart to {@link requestSanitizer}. */
+export function responseSanitizer(response: LogRocketResponse): LogRocketResponse {
+  if (typeof response.url === "string") response.url = sanitizeUrl(response.url);
+  response.headers = scrubHeaders(response.headers);
+  response.body = scrubBody(response.body);
+  return response;
+}
+
+const options: LogRocketOptions = {
+  release: import.meta.env.VITE_APP_VERSION,
+  shouldCaptureIP: false,
+  // Authoritative per-upload consent gate. `init()` runs at most once, but
+  // this is consulted live before each send, so flipping the toggle off (or
+  // a stale consent version) stops uploads without a teardown API.
+  shouldSendData: () => logRocketConsentGranted(),
+  dom: {
+    inputSanitizer: true,
+  },
+  browser: {
+    urlSanitizer: (url: string) => sanitizeUrl(url),
+  },
+  network: {
+    requestSanitizer,
+    responseSanitizer,
+  },
+};
+
+/**
+ * Bootstrap LogRocket consent gating. Must be called after
+ * `migrateDeviceSettings()` so the `device:share_product_improvement` key is
+ * available when the consent gate reads localStorage. No-ops entirely when
+ * `VITE_LOGROCKET_APP_ID` is unset (the feature stays dark).
+ */
+export function initLogRocket(): void {
+  const appId = import.meta.env.VITE_LOGROCKET_APP_ID;
+  if (!appId) return;
+  syncLogRocketClient(appId, options);
+  installLogRocketControlListeners(appId, options);
+}

--- a/clients/web/src/main.tsx
+++ b/clients/web/src/main.tsx
@@ -12,6 +12,7 @@ import { AppProviders } from "@/components/providers";
 import { WindowDragRegion } from "@/components/window-drag-region";
 import { isChunkLoadError } from "@/lib/chunk-errors";
 import { isLocalMode, loadLockfile } from "@/lib/local-mode";
+import { initLogRocket } from "@/lib/logrocket/logrocket-init";
 import { initSentry } from "@/lib/sentry/sentry-init";
 import { setupAuthListeners, useAuthStore } from "@/stores/auth-store";
 import { setupOrganizationStore } from "@/stores/organization-store";
@@ -27,6 +28,7 @@ async function boot() {
   initInputModality();
   await initSafeAreaBridge();
   initSentry();
+  initLogRocket();
 
   setupOrganizationStore();
   if (isLocalMode()) {

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -47,6 +47,7 @@ const resolveServerConsentMock = mock((_consent: unknown) => ({
   ai: false,
   shareAnalytics: null,
   shareDiagnostics: null,
+  shareProductImprovement: null,
 }));
 
 let mockFetchMeResult: unknown = {
@@ -170,7 +171,7 @@ mock.module("@/utils/onboarding-cleanup", () => ({
   restoreConsentForUser: restoreConsentForUserMock,
   persistConsentForUser: persistConsentForUserMock,
   resolveServerConsent: resolveServerConsentMock,
-  CONSENT_VERSION: "2026-06-08",
+  CONSENT_VERSION: "2026-06-16",
 }));
 
 mock.module("@/domains/onboarding/onboarding-store", () => ({
@@ -180,6 +181,7 @@ mock.module("@/domains/onboarding/onboarding-store", () => ({
       setAiDataConsent: () => {},
       setShareAnalytics: () => {},
       setShareDiagnostics: () => {},
+      setShareProductImprovement: () => {},
     }),
   },
 }));

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -255,6 +255,8 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
           store.setShareAnalytics(resolved.shareAnalytics);
         if (resolved.shareDiagnostics !== null)
           store.setShareDiagnostics(resolved.shareDiagnostics);
+        if (resolved.shareProductImprovement !== null)
+          store.setShareProductImprovement(resolved.shareProductImprovement);
         persistConsentForUser(nextUserId, resolved.tos, resolved.ai);
         syncOrganizationState(nextUserId);
         return;

--- a/clients/web/src/utils/device-settings.ts
+++ b/clients/web/src/utils/device-settings.ts
@@ -33,6 +33,7 @@ const DEVICE_SETTINGS = {
   theme: { key: "device:theme", legacy: "vellum_theme" },
   shareAnalytics: { key: "device:share_analytics", legacy: "vellum_share_analytics" },
   shareDiagnostics: { key: "device:share_diagnostics", legacy: "vellum_share_diagnostics" },
+  shareProductImprovement: { key: "device:share_product_improvement", legacy: "vellum_share_product_improvement" },
   biometricEnabled: { key: "device:biometric_enabled", legacy: "vellum_biometric_enabled" },
   llmLogRetention: { key: "device:llm_log_retention", legacy: "vellum_llm_log_retention" },
   timezone: { key: "device:timezone", legacy: "vellum_timezone" },

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -21,7 +21,7 @@ import { setDeviceBool } from "@/utils/device-settings";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 import { patchConsent, type UserConsent } from "@/domains/account/profile";
 
-export const CONSENT_VERSION = "2026-06-08";
+export const CONSENT_VERSION = "2026-06-16";
 
 function consentKey(field: string, userId: string): string {
   return `device:consent:${field}:v${CONSENT_VERSION}:${userId}`;
@@ -83,14 +83,29 @@ export function clearConsentForUser(userId: string | null): void {
 
 export function resolveServerConsent(
   consent: UserConsent | null | undefined,
-): { tos: boolean; ai: boolean; shareAnalytics: boolean | null; shareDiagnostics: boolean | null } {
-  if (!consent) return { tos: false, ai: false, shareAnalytics: null, shareDiagnostics: null };
+): {
+  tos: boolean;
+  ai: boolean;
+  shareAnalytics: boolean | null;
+  shareDiagnostics: boolean | null;
+  shareProductImprovement: boolean | null;
+} {
+  if (!consent) {
+    return {
+      tos: false,
+      ai: false,
+      shareAnalytics: null,
+      shareDiagnostics: null,
+      shareProductImprovement: null,
+    };
+  }
   return {
     tos: consent.tos_accepted_version === CONSENT_VERSION
       && consent.privacy_policy_accepted_version === CONSENT_VERSION,
     ai: consent.ai_data_sharing_accepted_version === CONSENT_VERSION,
     shareAnalytics: consent.share_analytics,
     shareDiagnostics: consent.share_diagnostics,
+    shareProductImprovement: consent.share_product_improvement,
   };
 }
 
@@ -104,6 +119,7 @@ export function saveConsent(opts: {
   ai: boolean;
   shareAnalytics: boolean;
   shareDiagnostics: boolean;
+  shareProductImprovement: boolean;
   hasPlatformSession: boolean;
 }): void {
   const store = useOnboardingStore.getState();
@@ -111,6 +127,7 @@ export function saveConsent(opts: {
   store.setAiDataConsent(opts.ai);
   store.setShareAnalytics(opts.shareAnalytics);
   store.setShareDiagnostics(opts.shareDiagnostics);
+  store.setShareProductImprovement(opts.shareProductImprovement);
 
   persistConsentForUser(opts.userId, opts.tos, opts.ai);
 
@@ -121,12 +138,13 @@ export function saveConsent(opts: {
       ai_data_sharing_accepted_version: opts.ai ? CONSENT_VERSION : "",
       share_analytics: opts.shareAnalytics,
       share_diagnostics: opts.shareDiagnostics,
+      share_product_improvement: opts.shareProductImprovement,
     }).catch(() => {});
   }
 }
 
 export function savePreferenceToggle(
-  field: "share_analytics" | "share_diagnostics",
+  field: "share_analytics" | "share_diagnostics" | "share_product_improvement",
   value: boolean,
   hasPlatformSession: boolean,
 ): void {
@@ -134,9 +152,12 @@ export function savePreferenceToggle(
   if (field === "share_analytics") {
     store.setShareAnalytics(value);
     setDeviceBool("shareAnalytics", value);
-  } else {
+  } else if (field === "share_diagnostics") {
     store.setShareDiagnostics(value);
     setDeviceBool("shareDiagnostics", value);
+  } else {
+    store.setShareProductImprovement(value);
+    setDeviceBool("shareProductImprovement", value);
   }
 
   if (hasPlatformSession) {


### PR DESCRIPTION
## Summary

Adds web session replay (**LogRocket**) and a single combined opt-out consent toggle — **"Help improve Vellum"** (`share_product_improvement`, default on) — that gates both LogRocket *and* the in-house conversation/agent **trace collection**. This is Section C (web SPA) of the LogRocket + trace-collection effort; it mirrors the existing Sentry consent-gating pattern and the `shareAnalytics` / `shareDiagnostics` plumbing end-to-end.

### LogRocket (`clients/web/src/lib/logrocket/`)
- `logrocket-init.ts` + `logrocket-control.ts`, mirroring `lib/sentry/{sentry-init,sentry-control}.ts`.
- Init is gated on `getDeviceBool("shareProductImprovement", false)` **AND** current-`CONSENT_VERSION` acceptance (read from the onboarding store's `tosAccepted && aiDataConsent`, which are true only when the accepted versions equal `CONSENT_VERSION`).
- The LogRocket SDK exposes no public teardown, so `init()` runs **at most once**; ongoing uploads are gated **live** via the SDK's `shouldSendData()` callback. Opting out reactively stops uploads; opting in mid-session inits lazily via a `watchDeviceSetting` listener + an onboarding-store subscription (covers a fresh re-accept).
- Network request/response sanitizers redact credential headers (`Authorization`, cookies, API-key headers), scrub token-shaped JSON body fields, and sanitize URLs by **reusing the Sentry `lib/sentry/url-sanitize` helper**. `dom.inputSanitizer` masks typed input content; `shouldCaptureIP` is disabled.
- `LogRocket.identify(userId)` — id only (matches how Sentry sets the user id), so the id lines up with the Django GDPR-delete client.
- App id from `import.meta.env.VITE_LOGROCKET_APP_ID`; **no-op when unset** → the feature is fully dark without config.
- `logrocket` pinned exact at `12.1.1`.

### Combined-toggle plumbing (mirrors `shareAnalytics`/`shareDiagnostics`)
- `utils/device-settings.ts`: register `shareProductImprovement` → `device:share_product_improvement` (+ legacy alias).
- `domains/onboarding/onboarding-store.ts`: field + setter + `SYNCED_KEYS`.
- `domains/onboarding/prefs.ts`: `useShareProductImprovement` hook.
- `utils/onboarding-cleanup.ts`: `resolveServerConsent`, `saveConsent`, `savePreferenceToggle`, and the `patchConsent({...})` body.
- `domains/account/profile.ts`: `share_product_improvement: boolean` on the hand-written `UserConsent` type (no cross-repo client regen needed).
- `stores/auth-store.ts`: applies the resolved server value on session sync.
- `main.tsx`: `initLogRocket()` next to `initSentry()`, after the device-settings migration.

### UI
- "Help improve Vellum" toggle on **both** the onboarding privacy screen and the settings privacy page. Helper text discloses that it enables **web session recording + conversation/agent-execution traces** to debug/improve the product, that — unlike Share Analytics/Diagnostics — it can include conversation content, that it's on by default, and that you can opt out anytime. Onboarding's accept handler (`saveConsent`) now includes `shareProductImprovement`.

### Re-accept
- **Bumps `CONSENT_VERSION` `2026-06-08` → `2026-06-16`** to force re-accept under the updated policy, so collection only begins after the new policy is accepted.

## Checks
- `bunx tsc --noEmit` — clean.
- `bun run lint` — 0 errors (only pre-existing warnings, none in touched files).
- Tests (run isolated via `scripts/run-tests.ts`, the CI path): new LogRocket consent-gate + redaction-sanitizer tests; updated `privacy-screen` / `auth-store` mocks. 5/5 touched test files pass.

## Rollout / merge order
- **DO NOT MERGE yet.** Per the plan, this lands **last** — after the policy-copy PR (constitution / TOS / privacy / data-sharing / docs) is live and after the Django PR (consent field + trace ingest + deletion + LogRocket GDPR client), so the re-accept prompt shows the updated copy and the server accepts `share_product_improvement`.
- Requires `VITE_LOGROCKET_APP_ID` in the web build env (and the LogRocket org/app + signed DPA) before collection is active; without it LogRocket stays dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)