### PR TITLE
feat(assistant): emit consent-gated per-turn execution traces

### DIFF
--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -142,6 +142,12 @@ export const AssistantConfigSchema = z
       .describe(
         "Whether to collect anonymous usage data to help improve the assistant",
       ),
+    shareProductImprovement: z
+      .boolean()
+      .default(false)
+      .describe(
+        "Whether the user has accepted sharing full per-turn execution traces (prompts, completions, tool IO) for product improvement. Defaults off: trace collection stays dark until the user accepts the current consent version and enables this toggle.",
+      ),
     sendDiagnostics: z
       .boolean()
       .default(true)

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -75,6 +75,7 @@ import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
 import type { ActivationMomentParam } from "../telemetry/activation-funnel.js";
+import { TurnTraceAccumulator } from "../telemetry/turn-trace-accumulator.js";
 import type { UsageActor } from "../usage/actors.js";
 import { getLogger } from "../util/logger.js";
 import { timeAgo } from "../util/time.js";
@@ -841,7 +842,18 @@ export async function runAgentLoopImpl(
       turnInterfaceContext: capturedTurnInterfaceContext,
       applyCompaction: applySuccessfulCompaction,
     };
+    // Observation-only per-turn execution-trace accumulator. Fed every agent
+    // event alongside the real dispatch; on the terminal `agent_loop_exit` it
+    // buffers one trace row (consent-gated, DARK by default). `finalize` is
+    // idempotent, so feeding the terminal exit from both `eventHandler` (the
+    // inline `budget_yield_unrecovered` break that returns early below) and
+    // `emitTerminalExit` (handoff / re-driven yield) persists exactly once.
+    const traceAccumulator = new TurnTraceAccumulator(
+      ctx.conversationId,
+      reqId,
+    );
     const eventHandler = (event: AgentEvent): Promise<void> => {
+      traceAccumulator.observe(event);
       if (
         event.type === "agent_loop_exit" &&
         (event.reason === "context_too_large" ||
@@ -863,6 +875,7 @@ export async function runAgentLoopImpl(
       return dispatchAgentEvent(state, deps, event);
     };
     emitTerminalExit = async (reason: AgentLoopExitReason): Promise<void> => {
+      traceAccumulator.observe({ type: "agent_loop_exit", reason });
       await dispatchAgentEvent(state, deps, {
         type: "agent_loop_exit",
         reason,

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -39,6 +39,7 @@ import {
   createSequenceTables,
   createSkillLoadedEventsTable,
   createTasksAndWorkItemsTables,
+  createTelemetryTraceEventsTable,
   createWatchersAndLogsTables,
   migrate230AcpSessionHistory,
   migrate231RepairMemoryGraphEventDates,
@@ -521,6 +522,7 @@ export function initializeDb(): void {
     migrateContactChannelsUniqueExtUser,
     migrateScheduleCapabilities,
     migrateContactChannelsRenormalizeAddresses,
+    createTelemetryTraceEventsTable,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/292-create-telemetry-trace-events.test.ts
+++ b/assistant/src/memory/migrations/292-create-telemetry-trace-events.test.ts
@@ -1,0 +1,81 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import * as schema from "../schema.js";
+import { createTelemetryTraceEventsTable } from "./292-create-telemetry-trace-events.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  return { sqlite, db: drizzle(sqlite, { schema }) };
+}
+
+function columnNames(sqlite: Database): string[] {
+  return (
+    sqlite.query("PRAGMA table_info(telemetry_trace_events)").all() as Array<{
+      name: string;
+    }>
+  ).map((c) => c.name);
+}
+
+function indexNames(sqlite: Database): string[] {
+  return (
+    sqlite.query("PRAGMA index_list(telemetry_trace_events)").all() as Array<{
+      name: string;
+    }>
+  ).map((i) => i.name);
+}
+
+describe("migration 292: telemetry_trace_events table", () => {
+  test("creates the table with the expected columns", () => {
+    const { sqlite, db } = createTestDb();
+
+    createTelemetryTraceEventsTable(db);
+
+    expect(columnNames(sqlite)).toEqual([
+      "id",
+      "created_at",
+      "conversation_id",
+      "request_id",
+      "turn_index",
+      "trace",
+    ]);
+  });
+
+  test("creates the (created_at, id) cursor index", () => {
+    const { sqlite, db } = createTestDb();
+
+    createTelemetryTraceEventsTable(db);
+
+    expect(indexNames(sqlite)).toContain(
+      "idx_telemetry_trace_events_created_at_id",
+    );
+    const columns = (
+      sqlite
+        .query("PRAGMA index_info(idx_telemetry_trace_events_created_at_id)")
+        .all() as Array<{ name: string }>
+    ).map((c) => c.name);
+    expect(columns).toEqual(["created_at", "id"]);
+  });
+
+  test("is idempotent — re-run is a no-op and preserves existing rows", () => {
+    const { sqlite, db } = createTestDb();
+
+    createTelemetryTraceEventsTable(db);
+    sqlite.exec(/*sql*/ `
+      INSERT INTO telemetry_trace_events (id, created_at, conversation_id, trace)
+      VALUES ('tte-1', 1000, 'conv-1', '{}')
+    `);
+
+    expect(() => createTelemetryTraceEventsTable(db)).not.toThrow();
+
+    const rows = sqlite.query("SELECT id FROM telemetry_trace_events").all();
+    expect(rows).toEqual([{ id: "tte-1" }]);
+    expect(
+      indexNames(sqlite).filter(
+        (name) => name === "idx_telemetry_trace_events_created_at_id",
+      ),
+    ).toHaveLength(1);
+  });
+});

--- a/assistant/src/memory/migrations/292-create-telemetry-trace-events.ts
+++ b/assistant/src/memory/migrations/292-create-telemetry-trace-events.ts
@@ -1,0 +1,28 @@
+import type { DrizzleDb } from "../db-connection.js";
+
+/**
+ * Create the telemetry_trace_events table — one row per agent turn buffering
+ * the full per-turn execution trace (prompts, completions, tool calls/results,
+ * token usage) for the product-improvement telemetry pipeline (see
+ * telemetry-trace-events-store.ts for the data contract). Distinct from the
+ * `trace_events` conversation activity log read by the UI. The index backs the
+ * telemetry reporter's compound `(created_at, id)` watermark cursor.
+ */
+export function createTelemetryTraceEventsTable(database: DrizzleDb): void {
+  database.run(/*sql*/ `
+    CREATE TABLE IF NOT EXISTS telemetry_trace_events (
+      id TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL,
+      conversation_id TEXT NOT NULL,
+      request_id TEXT,
+      turn_index INTEGER,
+      trace TEXT NOT NULL
+    )
+  `);
+  database.run(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_telemetry_trace_events_created_at_id ON telemetry_trace_events (created_at, id)`,
+  );
+  database.run(
+    /*sql*/ `CREATE INDEX IF NOT EXISTS idx_telemetry_trace_events_conversation_id ON telemetry_trace_events (conversation_id)`,
+  );
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -283,6 +283,7 @@ export { migrateBackfillOriginChannelFromBindings } from "./288-backfill-origin-
 export { migrateContactChannelsUniqueExtUser } from "./289-contact-channels-unique-ext-user.js";
 export { migrateScheduleCapabilities } from "./290-schedule-capabilities.js";
 export { migrateContactChannelsRenormalizeAddresses } from "./291-contact-channels-renormalize-addresses.js";
+export { createTelemetryTraceEventsTable } from "./292-create-telemetry-trace-events.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/memory/schema/infrastructure.ts
+++ b/assistant/src/memory/schema/infrastructure.ts
@@ -337,6 +337,37 @@ export const skillLoadedEvents = sqliteTable(
   ],
 );
 
+// One row per agent turn, buffering the full per-turn execution trace
+// (prompts, completions, tool calls/results, token usage) for the
+// product-improvement telemetry pipeline — see telemetry-trace-events-store.ts
+// for the data contract. Distinct from `trace_events` (the conversation
+// activity log read by the UI): this table is a telemetry buffer flushed by
+// the usage telemetry reporter, mirroring `llm_usage_events` /
+// `skill_loaded_events`. Rows are recorded only under consent (DARK by
+// default); secrets are scrubbed before insert. The index backs the
+// reporter's compound `(created_at, id)` watermark cursor.
+export const telemetryTraceEvents = sqliteTable(
+  "telemetry_trace_events",
+  {
+    id: text("id").primaryKey(),
+    createdAt: integer("created_at").notNull(),
+    conversationId: text("conversation_id").notNull(),
+    requestId: text("request_id"),
+    turnIndex: integer("turn_index"),
+    // JSON-serialized `TraceTelemetryEvent["trace"]` body.
+    trace: text("trace").notNull(),
+  },
+  (table) => [
+    index("idx_telemetry_trace_events_created_at_id").on(
+      table.createdAt,
+      table.id,
+    ),
+    index("idx_telemetry_trace_events_conversation_id").on(
+      table.conversationId,
+    ),
+  ],
+);
+
 export const traceEvents = sqliteTable(
   "trace_events",
   {

--- a/assistant/src/memory/trace-events-store.test.ts
+++ b/assistant/src/memory/trace-events-store.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Silence the logger.
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Consent reflection the store gates on. Both must be true for trace
+// collection to be enabled (DARK by default).
+let collectUsageData = true;
+let shareProductImprovement = true;
+
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({
+    ui: {},
+    model: "test",
+    provider: "test",
+    memory: { enabled: false },
+    collectUsageData,
+    shareProductImprovement,
+  }),
+}));
+
+import type { TraceTelemetryEvent } from "../telemetry/types.js";
+import { getDb } from "./db-connection.js";
+import { initializeDb } from "./db-init.js";
+import { telemetryTraceEvents } from "./schema.js";
+import {
+  queryUnreportedTraceEvents,
+  recordTraceEvent,
+  traceCollectionEnabled,
+} from "./trace-events-store.js";
+
+initializeDb();
+
+const SAMPLE_TRACE: TraceTelemetryEvent["trace"] = {
+  exit_reason: "completed",
+  started_at: 1000,
+  ended_at: 2000,
+  llm_calls: [
+    {
+      index: 0,
+      call_site: "mainAgent",
+      model: "model-a",
+      provider: "anthropic",
+      completion: {
+        role: "assistant",
+        content: [{ type: "text", text: "hi" }],
+      },
+      usage: {
+        input_tokens: 10,
+        output_tokens: 5,
+        cache_creation_input_tokens: null,
+        cache_read_input_tokens: null,
+      },
+    },
+  ],
+  tool_calls: [],
+};
+
+function insertRow(id: string, createdAt: number): void {
+  getDb()
+    .insert(telemetryTraceEvents)
+    .values({
+      id,
+      createdAt,
+      conversationId: "conv-1",
+      requestId: "req-1",
+      turnIndex: 1,
+      trace: JSON.stringify(SAMPLE_TRACE),
+    })
+    .run();
+}
+
+describe("trace-events-store", () => {
+  beforeEach(() => {
+    collectUsageData = true;
+    shareProductImprovement = true;
+    getDb().delete(telemetryTraceEvents).run();
+  });
+
+  describe("consent gate (DARK by default)", () => {
+    test("records nothing when shareProductImprovement is off", () => {
+      shareProductImprovement = false;
+      recordTraceEvent({
+        conversationId: "conv-1",
+        requestId: "req-1",
+        trace: SAMPLE_TRACE,
+      });
+      expect(queryUnreportedTraceEvents(0, undefined, 10)).toHaveLength(0);
+    });
+
+    test("records nothing when collectUsageData is off", () => {
+      collectUsageData = false;
+      recordTraceEvent({
+        conversationId: "conv-1",
+        requestId: "req-1",
+        trace: SAMPLE_TRACE,
+      });
+      expect(queryUnreportedTraceEvents(0, undefined, 10)).toHaveLength(0);
+    });
+
+    test("records nothing when both are off", () => {
+      collectUsageData = false;
+      shareProductImprovement = false;
+      recordTraceEvent({
+        conversationId: "conv-1",
+        requestId: "req-1",
+        trace: SAMPLE_TRACE,
+      });
+      expect(queryUnreportedTraceEvents(0, undefined, 10)).toHaveLength(0);
+    });
+
+    test("records only when both consents are on", () => {
+      expect(traceCollectionEnabled()).toBe(true);
+      recordTraceEvent({
+        conversationId: "conv-1",
+        requestId: "req-1",
+        trace: SAMPLE_TRACE,
+      });
+      expect(queryUnreportedTraceEvents(0, undefined, 10)).toHaveLength(1);
+    });
+  });
+
+  test("record + query round-trips the trace body and fields", () => {
+    recordTraceEvent({
+      conversationId: "conv-xyz",
+      requestId: "req-abc",
+      trace: SAMPLE_TRACE,
+    });
+
+    const rows = queryUnreportedTraceEvents(0, undefined, 10);
+    expect(rows).toHaveLength(1);
+    const row = rows[0]!;
+    expect(row.id).toBeString();
+    expect(row.createdAt).toBeGreaterThan(0);
+    expect(row.conversationId).toBe("conv-xyz");
+    expect(row.requestId).toBe("req-abc");
+    // No user-message rows in this in-memory DB, so the correlated turn-index
+    // count is 0 (records correctly rather than throwing).
+    expect(row.turnIndex).toBe(0);
+    expect(row.trace).toEqual(SAMPLE_TRACE);
+  });
+
+  test("null requestId persists as null", () => {
+    recordTraceEvent({
+      conversationId: "conv-1",
+      requestId: null,
+      trace: SAMPLE_TRACE,
+    });
+    const rows = queryUnreportedTraceEvents(0, undefined, 10);
+    expect(rows[0]!.requestId).toBeNull();
+  });
+
+  test("malformed stored trace JSON yields an empty trace shell, not a throw", () => {
+    getDb()
+      .insert(telemetryTraceEvents)
+      .values({
+        id: "tte-bad",
+        createdAt: 1000,
+        conversationId: "conv-1",
+        requestId: null,
+        turnIndex: null,
+        trace: "{not valid json",
+      })
+      .run();
+    const rows = queryUnreportedTraceEvents(0, undefined, 10);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.trace).toEqual({
+      exit_reason: null,
+      started_at: null,
+      ended_at: null,
+      llm_calls: [],
+      tool_calls: [],
+    });
+  });
+
+  test("returns rows in (createdAt, id) order and advances past the compound cursor", () => {
+    insertRow("tte-1", 5000);
+    insertRow("tte-2", 5000);
+    insertRow("tte-3", 6000);
+
+    const first = queryUnreportedTraceEvents(0, undefined, 1);
+    expect(first.map((r) => r.id)).toEqual(["tte-1"]);
+
+    const second = queryUnreportedTraceEvents(
+      first[0]!.createdAt,
+      first[0]!.id,
+      100,
+    );
+    expect(second.map((r) => r.id)).toEqual(["tte-2", "tte-3"]);
+
+    // Cursor past the last row returns nothing.
+    const last = second[second.length - 1]!;
+    expect(
+      queryUnreportedTraceEvents(last.createdAt, last.id, 100).length,
+    ).toBe(0);
+  });
+
+  test("honors the limit", () => {
+    insertRow("tte-l1", 1000);
+    insertRow("tte-l2", 2000);
+    insertRow("tte-l3", 3000);
+    expect(
+      queryUnreportedTraceEvents(0, undefined, 2).map((r) => r.id),
+    ).toEqual(["tte-l1", "tte-l2"]);
+  });
+});

--- a/assistant/src/memory/trace-events-store.test.ts
+++ b/assistant/src/memory/trace-events-store.test.ts
@@ -8,10 +8,11 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-// Consent reflection the store gates on. Both must be true for trace
-// collection to be enabled (DARK by default).
+// Consent reflection the store gates on. Trace collection requires
+// `collectUsageData` AND product-improvement consent (local config OR server),
+// and is DARK by default.
 let collectUsageData = true;
-let shareProductImprovement = true;
+let shareProductImprovement = false;
 
 mock.module("../config/loader.js", () => ({
   getConfig: () => ({
@@ -24,6 +25,10 @@ mock.module("../config/loader.js", () => ({
   }),
 }));
 
+// The server-consent read is exercised end-to-end in platform-consent.test.ts;
+// here we drive its cache directly via the real module's test seam (rather than
+// mocking the module, which would leak globally across test files).
+import { _setServerConsentForTests } from "../telemetry/platform-consent.js";
 import type { TraceTelemetryEvent } from "../telemetry/types.js";
 import { getDb } from "./db-connection.js";
 import { initializeDb } from "./db-init.js";
@@ -35,6 +40,11 @@ import {
 } from "./trace-events-store.js";
 
 initializeDb();
+
+/** Set the server-consent dimension of the gate. */
+function setServerConsent(value: boolean): void {
+  _setServerConsentForTests(value);
+}
 
 const SAMPLE_TRACE: TraceTelemetryEvent["trace"] = {
   exit_reason: "completed",
@@ -77,14 +87,19 @@ function insertRow(id: string, createdAt: number): void {
 
 describe("trace-events-store", () => {
   beforeEach(() => {
+    // Default the non-gate tests to "enabled" via the local override so the
+    // round-trip/cursor tests record. The gate tests set their own values.
     collectUsageData = true;
     shareProductImprovement = true;
+    setServerConsent(false);
     getDb().delete(telemetryTraceEvents).run();
   });
 
   describe("consent gate (DARK by default)", () => {
-    test("records nothing when shareProductImprovement is off", () => {
+    test("dark by default: nothing recorded when both local and server are off", () => {
       shareProductImprovement = false;
+      setServerConsent(false);
+      expect(traceCollectionEnabled()).toBe(false);
       recordTraceEvent({
         conversationId: "conv-1",
         requestId: "req-1",
@@ -93,28 +108,9 @@ describe("trace-events-store", () => {
       expect(queryUnreportedTraceEvents(0, undefined, 10)).toHaveLength(0);
     });
 
-    test("records nothing when collectUsageData is off", () => {
-      collectUsageData = false;
-      recordTraceEvent({
-        conversationId: "conv-1",
-        requestId: "req-1",
-        trace: SAMPLE_TRACE,
-      });
-      expect(queryUnreportedTraceEvents(0, undefined, 10)).toHaveLength(0);
-    });
-
-    test("records nothing when both are off", () => {
-      collectUsageData = false;
-      shareProductImprovement = false;
-      recordTraceEvent({
-        conversationId: "conv-1",
-        requestId: "req-1",
-        trace: SAMPLE_TRACE,
-      });
-      expect(queryUnreportedTraceEvents(0, undefined, 10)).toHaveLength(0);
-    });
-
-    test("records only when both consents are on", () => {
+    test("enabled by the local shareProductImprovement override", () => {
+      shareProductImprovement = true;
+      setServerConsent(false);
       expect(traceCollectionEnabled()).toBe(true);
       recordTraceEvent({
         conversationId: "conv-1",
@@ -122,6 +118,31 @@ describe("trace-events-store", () => {
         trace: SAMPLE_TRACE,
       });
       expect(queryUnreportedTraceEvents(0, undefined, 10)).toHaveLength(1);
+    });
+
+    test("enabled by server consent alone (local override off)", () => {
+      shareProductImprovement = false;
+      setServerConsent(true);
+      expect(traceCollectionEnabled()).toBe(true);
+      recordTraceEvent({
+        conversationId: "conv-1",
+        requestId: "req-1",
+        trace: SAMPLE_TRACE,
+      });
+      expect(queryUnreportedTraceEvents(0, undefined, 10)).toHaveLength(1);
+    });
+
+    test("collectUsageData opt-out overrides any product-improvement consent", () => {
+      collectUsageData = false;
+      shareProductImprovement = true;
+      setServerConsent(true);
+      expect(traceCollectionEnabled()).toBe(false);
+      recordTraceEvent({
+        conversationId: "conv-1",
+        requestId: "req-1",
+        trace: SAMPLE_TRACE,
+      });
+      expect(queryUnreportedTraceEvents(0, undefined, 10)).toHaveLength(0);
     });
   });
 

--- a/assistant/src/memory/trace-events-store.ts
+++ b/assistant/src/memory/trace-events-store.ts
@@ -1,0 +1,169 @@
+import { and, asc, eq, gt, or, sql } from "drizzle-orm";
+import { v4 as uuid } from "uuid";
+
+import { getConfig } from "../config/loader.js";
+import type { TraceTelemetryEvent } from "../telemetry/types.js";
+import { getDb } from "./db-connection.js";
+import { telemetryTraceEvents } from "./schema.js";
+
+/**
+ * Whether per-turn execution traces may be buffered. Trace collection is DARK
+ * by default and only turns on when the platform consent says
+ * current-version-accepted AND the combined product-improvement toggle is on.
+ *
+ * The daemon reflects that consent through two config keys:
+ *  - `collectUsageData` — the existing analytics opt-out (defaults on) every
+ *    other telemetry buffer already gates on; and
+ *  - `shareProductImprovement` — the combined opt-out covering full-content
+ *    trace collection (defaults OFF).
+ *
+ * Requiring both means a trace is never buffered until the user explicitly
+ * accepts the product-improvement consent, even for users already opted into
+ * analytics — and unknown/unsynced consent reads as off because
+ * `shareProductImprovement` defaults to `false`.
+ */
+export function traceCollectionEnabled(): boolean {
+  const config = getConfig();
+  return config.collectUsageData && config.shareProductImprovement;
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Input for one buffered turn trace. */
+export interface TraceEventRecord {
+  conversationId: string;
+  requestId: string | null;
+  /** The assembled, already-redacted per-turn trace body. */
+  trace: TraceTelemetryEvent["trace"];
+}
+
+/** A persisted trace event row, as the telemetry reporter consumes it. */
+export interface UnreportedTraceEvent {
+  id: string;
+  createdAt: number;
+  conversationId: string;
+  requestId: string | null;
+  turnIndex: number | null;
+  /** The per-turn trace body, deserialized from the stored JSON. */
+  trace: TraceTelemetryEvent["trace"];
+}
+
+// ---------------------------------------------------------------------------
+// Write
+// ---------------------------------------------------------------------------
+
+/**
+ * Buffer one per-turn execution trace. No-ops when trace collection is not
+ * consented (the row is simply not recorded, keeping the pipeline dark).
+ *
+ * `turn_index` is computed at record time via a correlated count of real user
+ * turns in the conversation — the same filter the `turn` / `llm_usage` event
+ * streams use, so the three indexes stay aligned. The user turn that drove
+ * this trace is already persisted by the time the loop exits, so the count
+ * is stable.
+ *
+ * Best-effort: callers buffer traces as an observation side effect, so a
+ * write failure must never surface to the turn. Callers wrap this in their
+ * own try/catch; this function does not throw on consent-off.
+ */
+export function recordTraceEvent(record: TraceEventRecord): void {
+  if (!traceCollectionEnabled()) return;
+  const db = getDb();
+  const id = uuid();
+  const createdAt = Date.now();
+  db.insert(telemetryTraceEvents)
+    .values({
+      id,
+      createdAt,
+      conversationId: record.conversationId,
+      requestId: record.requestId,
+      // Count of real user turns in the conversation up to and including now.
+      // Tool-result rows persisted with role="user" are excluded — same
+      // filter as `queryUnreportedTurnEvents` / `queryUnreportedUsageEvents`.
+      turnIndex: sql<number>`(
+        SELECT COUNT(*) FROM messages AS m2
+        WHERE m2.conversation_id = ${record.conversationId}
+          AND m2.role = 'user'
+          AND m2.content NOT LIKE '%"type":"tool\\_result"%' ESCAPE '\\'
+          AND m2.content NOT LIKE '%"type":"web\\_search\\_tool\\_result"%' ESCAPE '\\'
+          AND m2.created_at <= ${createdAt}
+      )`,
+      trace: JSON.stringify(record.trace),
+    })
+    .run();
+}
+
+// ---------------------------------------------------------------------------
+// Read
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the JSON-serialized trace body. Returns an empty trace shell for a
+ * malformed row rather than failing the whole flush batch — a single corrupt
+ * row should not block telemetry.
+ */
+function parseTrace(value: string): TraceTelemetryEvent["trace"] {
+  const empty: TraceTelemetryEvent["trace"] = {
+    exit_reason: null,
+    started_at: null,
+    ended_at: null,
+    llm_calls: [],
+    tool_calls: [],
+  };
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as TraceTelemetryEvent["trace"];
+    }
+    return empty;
+  } catch {
+    return empty;
+  }
+}
+
+/**
+ * Query trace events that haven't been reported to telemetry yet. Uses a
+ * compound cursor (createdAt + id) for reliable watermarking, mirroring
+ * `queryUnreportedUsageEvents` / `queryUnreportedSkillLoadedEvents`.
+ */
+export function queryUnreportedTraceEvents(
+  afterCreatedAt: number,
+  afterId: string | undefined,
+  limit: number,
+): UnreportedTraceEvent[] {
+  const db = getDb();
+  const rows = db
+    .select({
+      id: telemetryTraceEvents.id,
+      createdAt: telemetryTraceEvents.createdAt,
+      conversationId: telemetryTraceEvents.conversationId,
+      requestId: telemetryTraceEvents.requestId,
+      turnIndex: telemetryTraceEvents.turnIndex,
+      trace: telemetryTraceEvents.trace,
+    })
+    .from(telemetryTraceEvents)
+    .where(
+      afterId
+        ? or(
+            gt(telemetryTraceEvents.createdAt, afterCreatedAt),
+            and(
+              eq(telemetryTraceEvents.createdAt, afterCreatedAt),
+              gt(telemetryTraceEvents.id, afterId),
+            ),
+          )
+        : gt(telemetryTraceEvents.createdAt, afterCreatedAt),
+    )
+    .orderBy(asc(telemetryTraceEvents.createdAt), asc(telemetryTraceEvents.id))
+    .limit(limit)
+    .all();
+  return rows.map((row) => ({
+    id: row.id,
+    createdAt: row.createdAt,
+    conversationId: row.conversationId,
+    requestId: row.requestId,
+    turnIndex: row.turnIndex === null ? null : Number(row.turnIndex),
+    trace: parseTrace(row.trace),
+  }));
+}

--- a/assistant/src/memory/trace-events-store.ts
+++ b/assistant/src/memory/trace-events-store.ts
@@ -2,29 +2,39 @@ import { and, asc, eq, gt, or, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import { getConfig } from "../config/loader.js";
+import { productImprovementConsentFromServer } from "../telemetry/platform-consent.js";
 import type { TraceTelemetryEvent } from "../telemetry/types.js";
 import { getDb } from "./db-connection.js";
 import { telemetryTraceEvents } from "./schema.js";
 
 /**
  * Whether per-turn execution traces may be buffered. Trace collection is DARK
- * by default and only turns on when the platform consent says
- * current-version-accepted AND the combined product-improvement toggle is on.
+ * by default and only turns on when the user has affirmatively consented to
+ * product-improvement data sharing AND has not opted out of analytics.
  *
- * The daemon reflects that consent through two config keys:
- *  - `collectUsageData` — the existing analytics opt-out (defaults on) every
- *    other telemetry buffer already gates on; and
- *  - `shareProductImprovement` — the combined opt-out covering full-content
- *    trace collection (defaults OFF).
+ * Two independent gates, both required:
  *
- * Requiring both means a trace is never buffered until the user explicitly
- * accepts the product-improvement consent, even for users already opted into
- * analytics — and unknown/unsynced consent reads as off because
- * `shareProductImprovement` defaults to `false`.
+ *  1. `collectUsageData` (local config, defaults on) — the existing analytics
+ *     opt-out every other telemetry buffer already honors.
+ *  2. Product-improvement consent — affirmatively on. Resolved from EITHER:
+ *       - the local `shareProductImprovement` config key (defaults OFF) — an
+ *         explicit local override, e.g. when a client mirrors the consent into
+ *         daemon config directly; OR
+ *       - the user's `share_product_improvement` consent on the platform,
+ *         fetched and TTL-cached via {@link productImprovementConsentFromServer}.
+ *
+ * The server read fails closed (returns `false` when unknown / unreachable /
+ * stale), and the local key defaults `false`, so unknown consent ⇒ off. This
+ * keeps the pipeline dark until the user opts in (the platform consent defaults
+ * on once the user accepts the current version, at which point the cached
+ * server read flips this on).
  */
 export function traceCollectionEnabled(): boolean {
   const config = getConfig();
-  return config.collectUsageData && config.shareProductImprovement;
+  if (!config.collectUsageData) return false;
+  return (
+    config.shareProductImprovement || productImprovementConsentFromServer()
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/telemetry/platform-consent.test.ts
+++ b/assistant/src/telemetry/platform-consent.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Silence the logger.
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Controllable fake platform client. `clientResult` is what
+// `VellumPlatformClient.create()` resolves to; `fetchImpl` is the client's
+// `fetch`. `fetchCount` tracks calls for single-flight / backoff assertions.
+let fetchImpl: (path: string) => Promise<Response> = () =>
+  Promise.resolve(new Response("{}", { status: 200 }));
+let clientResult: unknown = null;
+let fetchCount = 0;
+
+function makeFakeClient() {
+  return {
+    platformAssistantId: "asst-123",
+    fetch: (path: string) => {
+      fetchCount += 1;
+      return fetchImpl(path);
+    },
+  };
+}
+
+mock.module("../platform/client.js", () => ({
+  VellumPlatformClient: {
+    create: () => Promise.resolve(clientResult),
+  },
+}));
+
+import {
+  _resetPlatformConsentCacheForTests,
+  productImprovementConsentFromServer,
+  refreshPlatformConsent,
+} from "./platform-consent.js";
+
+function consentResponse(value: unknown): Response {
+  return new Response(JSON.stringify({ share_product_improvement: value }), {
+    status: 200,
+  });
+}
+
+describe("platform-consent", () => {
+  beforeEach(() => {
+    _resetPlatformConsentCacheForTests();
+    fetchCount = 0;
+    clientResult = makeFakeClient();
+    fetchImpl = () => Promise.resolve(consentResponse(true));
+  });
+
+  test("fails closed before any fetch", () => {
+    expect(productImprovementConsentFromServer()).toBe(false);
+  });
+
+  test("an affirmative fetch flips the synchronous read on", async () => {
+    fetchImpl = () => Promise.resolve(consentResponse(true));
+    await refreshPlatformConsent();
+    expect(productImprovementConsentFromServer()).toBe(true);
+  });
+
+  test("a negative fetch keeps the read off", async () => {
+    fetchImpl = () => Promise.resolve(consentResponse(false));
+    await refreshPlatformConsent();
+    expect(productImprovementConsentFromServer()).toBe(false);
+  });
+
+  test("hits the assistant-scoped consent path", async () => {
+    let seenPath = "";
+    fetchImpl = (path: string) => {
+      seenPath = path;
+      return Promise.resolve(consentResponse(true));
+    };
+    await refreshPlatformConsent();
+    expect(seenPath).toBe("/v1/assistants/asst-123/consent/");
+  });
+
+  describe("fail-closed paths", () => {
+    test("no platform client (not logged in) ⇒ off", async () => {
+      clientResult = null;
+      await refreshPlatformConsent();
+      expect(productImprovementConsentFromServer()).toBe(false);
+    });
+
+    test("non-2xx response ⇒ off", async () => {
+      fetchImpl = () => Promise.resolve(new Response("nope", { status: 500 }));
+      await refreshPlatformConsent();
+      expect(productImprovementConsentFromServer()).toBe(false);
+    });
+
+    test("missing/non-boolean field ⇒ off", async () => {
+      fetchImpl = () =>
+        Promise.resolve(
+          new Response(JSON.stringify({ other: 1 }), { status: 200 }),
+        );
+      await refreshPlatformConsent();
+      expect(productImprovementConsentFromServer()).toBe(false);
+    });
+
+    test("fetch throws ⇒ off", async () => {
+      fetchImpl = () => Promise.reject(new Error("network down"));
+      await refreshPlatformConsent();
+      expect(productImprovementConsentFromServer()).toBe(false);
+    });
+  });
+
+  test("is single-flight: concurrent refreshes share one fetch", async () => {
+    fetchImpl = () =>
+      new Promise((resolve) =>
+        setTimeout(() => resolve(consentResponse(true)), 10),
+      );
+    await Promise.all([
+      refreshPlatformConsent(),
+      refreshPlatformConsent(),
+      refreshPlatformConsent(),
+    ]);
+    expect(fetchCount).toBe(1);
+    expect(productImprovementConsentFromServer()).toBe(true);
+  });
+
+  test("TTL-gates repeat fetches within the window", async () => {
+    await refreshPlatformConsent();
+    expect(fetchCount).toBe(1);
+    // A second call immediately after a success is within the TTL — no fetch.
+    await refreshPlatformConsent();
+    expect(fetchCount).toBe(1);
+  });
+
+  test("a successful affirmative then a failure: read stays on until TTL, then off", async () => {
+    fetchImpl = () => Promise.resolve(consentResponse(true));
+    await refreshPlatformConsent();
+    expect(productImprovementConsentFromServer()).toBe(true);
+    // Even if a later fetch would fail, the cached affirmative is trusted
+    // within the TTL (no new fetch happens — TTL-gated).
+    fetchImpl = () => Promise.reject(new Error("later failure"));
+    await refreshPlatformConsent();
+    expect(productImprovementConsentFromServer()).toBe(true);
+  });
+});

--- a/assistant/src/telemetry/platform-consent.ts
+++ b/assistant/src/telemetry/platform-consent.ts
@@ -1,0 +1,147 @@
+/**
+ * Platform consent cache for product-improvement trace collection.
+ *
+ * The user's `share_product_improvement` consent is authoritative on the
+ * Vellum platform (the `UserConsent` record). The daemon has no settings-sync
+ * channel that mirrors server consent into local config today, so it resolves
+ * the consent directly from the platform via {@link VellumPlatformClient} and
+ * caches it with a TTL.
+ *
+ * The recording decision ({@link recordTraceEvent}) runs synchronously on the
+ * hot `agent_loop_exit` path and must not block on the network, so this module
+ * splits the concern:
+ *
+ *  - {@link productImprovementConsentFromServer} — a **synchronous** read of
+ *    the cached value. Fails closed: returns `false` until a fetch has
+ *    affirmatively confirmed consent, and reverts to `false` whenever the
+ *    cached value goes stale (so a long-offline daemon stops trusting an old
+ *    affirmative).
+ *  - {@link refreshPlatformConsent} — an async, single-flight, TTL-gated fetch
+ *    that warms the cache. Callers fire it (fire-and-forget) on the edge of the
+ *    turn path; any failure leaves the cache fail-closed.
+ *
+ * Endpoint: `GET /v1/assistants/{assistantId}/consent/` — an assistant-API-key
+ * authenticated read that returns the owning user's consent flags (the daemon's
+ * `Api-Key` credential cannot reach the session-authenticated
+ * `/v1/user/consent/` endpoint). It resolves the owner from the key's assistant
+ * (`assistant.created_by`), mirroring how telemetry ingest derives the owner.
+ * Until that platform endpoint ships, the fetch fails closed and traces stay
+ * dark — see PR notes.
+ */
+
+import { VellumPlatformClient } from "../platform/client.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("platform-consent");
+
+/** How long a fetched consent value is trusted before it must be refreshed. */
+const CONSENT_TTL_MS = 5 * 60 * 1000;
+/**
+ * How long a fetch failure suppresses re-fetching, so a persistently
+ * unreachable / not-yet-deployed endpoint does not spin the network every turn.
+ * Shorter than the success TTL so consent still propagates reasonably quickly
+ * once the endpoint is reachable.
+ */
+const CONSENT_ERROR_BACKOFF_MS = 60 * 1000;
+
+interface ConsentCache {
+  /** Last successfully fetched value, or null if never fetched successfully. */
+  value: boolean | null;
+  /** Epoch ms of the last successful fetch. */
+  fetchedAt: number;
+  /** Epoch ms of the last fetch attempt (success or failure). */
+  attemptedAt: number;
+}
+
+const cache: ConsentCache = { value: null, fetchedAt: 0, attemptedAt: 0 };
+let inFlight: Promise<void> | null = null;
+
+/**
+ * Synchronous, fail-closed read of the cached `share_product_improvement`
+ * consent. Returns `true` only when a fetch has affirmatively confirmed consent
+ * AND that value is still within the TTL. Unknown, denied, or stale ⇒ `false`.
+ */
+export function productImprovementConsentFromServer(): boolean {
+  if (cache.value !== true) return false;
+  if (Date.now() - cache.fetchedAt > CONSENT_TTL_MS) return false;
+  return true;
+}
+
+/** Whether a refresh is due (TTL expired for success, backoff for failure). */
+function refreshDue(now: number): boolean {
+  // Never attempted → due.
+  if (cache.attemptedAt === 0) return true;
+  // Last attempt failed (attemptedAt advanced past fetchedAt) → use backoff.
+  if (cache.attemptedAt > cache.fetchedAt) {
+    return now - cache.attemptedAt > CONSENT_ERROR_BACKOFF_MS;
+  }
+  // Last attempt succeeded → use the success TTL.
+  return now - cache.fetchedAt > CONSENT_TTL_MS;
+}
+
+/**
+ * Fetch `share_product_improvement` from the platform and update the cache.
+ * Single-flight and TTL/backoff-gated, so calling it on every turn is cheap.
+ * Fail-closed: any error (no client, non-2xx, parse failure, missing field)
+ * records a failed attempt and leaves the synchronous read returning `false`.
+ */
+export async function refreshPlatformConsent(): Promise<void> {
+  const now = Date.now();
+  if (!refreshDue(now)) return;
+  if (inFlight) return inFlight;
+  inFlight = doRefresh().finally(() => {
+    inFlight = null;
+  });
+  return inFlight;
+}
+
+async function doRefresh(): Promise<void> {
+  cache.attemptedAt = Date.now();
+  try {
+    const client = await VellumPlatformClient.create();
+    if (!client) {
+      // Not logged in / platform features disabled — fail closed.
+      return;
+    }
+    const path = `/v1/assistants/${client.platformAssistantId}/consent/`;
+    const response = await client.fetch(path);
+    if (!response.ok) {
+      log.debug(
+        { status: response.status },
+        "Platform consent fetch returned non-2xx — failing closed",
+      );
+      return;
+    }
+    const body = (await response.json()) as Record<string, unknown>;
+    const value = body.share_product_improvement;
+    if (typeof value !== "boolean") {
+      log.debug(
+        "Platform consent response missing boolean share_product_improvement — failing closed",
+      );
+      return;
+    }
+    cache.value = value;
+    cache.fetchedAt = Date.now();
+  } catch (err) {
+    log.debug({ err }, "Platform consent fetch failed — failing closed");
+  }
+}
+
+/** Reset the cache. Test-only. */
+export function _resetPlatformConsentCacheForTests(): void {
+  cache.value = null;
+  cache.fetchedAt = 0;
+  cache.attemptedAt = 0;
+  inFlight = null;
+}
+
+/**
+ * Directly set the cached consent value as if a fresh fetch had just returned
+ * it. Lets consumers exercise the synchronous gate without a network round
+ * trip. Test-only.
+ */
+export function _setServerConsentForTests(value: boolean | null): void {
+  cache.value = value;
+  cache.fetchedAt = value === null ? 0 : Date.now();
+  cache.attemptedAt = cache.fetchedAt;
+}

--- a/assistant/src/telemetry/turn-trace-accumulator.test.ts
+++ b/assistant/src/telemetry/turn-trace-accumulator.test.ts
@@ -19,8 +19,30 @@ mock.module("../memory/trace-events-store.js", () => ({
   },
 }));
 
+// Controllable analytics gate. Drives whether the constructor warms the
+// consent cache.
+let collectUsageData = true;
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({ collectUsageData }),
+}));
+
+// The constructor warms the real consent cache via `refreshPlatformConsent`,
+// which calls `VellumPlatformClient.create()`. Spy on `create` to observe the
+// warm trigger without mocking `platform-consent` itself (which would leak the
+// stub into platform-consent.test.ts in the shared test process).
+let createCount = 0;
+mock.module("../platform/client.js", () => ({
+  VellumPlatformClient: {
+    create: () => {
+      createCount += 1;
+      return Promise.resolve(null);
+    },
+  },
+}));
+
 import type { AgentEvent } from "../agent/loop.js";
 import type { Message } from "../providers/types.js";
+import { _resetPlatformConsentCacheForTests } from "./platform-consent.js";
 import { TurnTraceAccumulator } from "./turn-trace-accumulator.js";
 
 function assistantMessage(content: Message["content"]): Message {
@@ -30,6 +52,29 @@ function assistantMessage(content: Message["content"]): Message {
 describe("TurnTraceAccumulator", () => {
   beforeEach(() => {
     recorded.length = 0;
+    collectUsageData = true;
+    createCount = 0;
+    // Reset so each warming test sees a refresh as "due".
+    _resetPlatformConsentCacheForTests();
+  });
+
+  describe("consent-cache warming", () => {
+    test("warms the platform consent cache on construction when analytics is on", async () => {
+      collectUsageData = true;
+      new TurnTraceAccumulator("conv-1", "req-1");
+      // The refresh is fire-and-forget; let the microtask drain.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(createCount).toBe(1);
+    });
+
+    test("does not fetch consent when analytics is opted out", async () => {
+      collectUsageData = false;
+      new TurnTraceAccumulator("conv-1", "req-1");
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(createCount).toBe(0);
+    });
   });
 
   test("assembles llm calls, tool calls, and usage into one buffered trace", () => {

--- a/assistant/src/telemetry/turn-trace-accumulator.test.ts
+++ b/assistant/src/telemetry/turn-trace-accumulator.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Silence the logger.
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// Capture what the accumulator would buffer, isolating accumulator logic from
+// the store's consent gate / DB (the gate is covered in trace-events-store.test.ts).
+import type { TraceEventRecord } from "../memory/trace-events-store.js";
+
+const recorded: TraceEventRecord[] = [];
+mock.module("../memory/trace-events-store.js", () => ({
+  recordTraceEvent: (record: TraceEventRecord) => {
+    recorded.push(record);
+  },
+}));
+
+import type { AgentEvent } from "../agent/loop.js";
+import type { Message } from "../providers/types.js";
+import { TurnTraceAccumulator } from "./turn-trace-accumulator.js";
+
+function assistantMessage(content: Message["content"]): Message {
+  return { role: "assistant", content };
+}
+
+describe("TurnTraceAccumulator", () => {
+  beforeEach(() => {
+    recorded.length = 0;
+  });
+
+  test("assembles llm calls, tool calls, and usage into one buffered trace", () => {
+    const acc = new TurnTraceAccumulator("conv-1", "req-1");
+    const events: AgentEvent[] = [
+      { type: "llm_call_started", callSite: "mainAgent" },
+      {
+        type: "message_complete",
+        message: assistantMessage([
+          { type: "text", text: "let me check" },
+          {
+            type: "tool_use",
+            id: "tu-1",
+            name: "web_fetch",
+            input: { url: "https://example.com" },
+          },
+        ]),
+      },
+      {
+        type: "usage",
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheCreationInputTokens: 5,
+        cacheReadInputTokens: 3,
+        model: "model-a",
+        actualProvider: "anthropic",
+        providerDurationMs: 10,
+      },
+      {
+        type: "tool_use",
+        id: "tu-1",
+        name: "web_fetch",
+        input: { url: "https://example.com" },
+      },
+      {
+        type: "tool_result",
+        toolUseId: "tu-1",
+        content: "fetched body",
+        isError: false,
+      },
+      { type: "agent_loop_exit", reason: "no_tool_calls" },
+    ];
+    for (const e of events) acc.observe(e);
+
+    expect(recorded).toHaveLength(1);
+    const { conversationId, requestId, trace } = recorded[0]!;
+    expect(conversationId).toBe("conv-1");
+    expect(requestId).toBe("req-1");
+    expect(trace.exit_reason).toBe("no_tool_calls");
+    expect(trace.started_at).toBeGreaterThan(0);
+    expect(trace.ended_at).toBeGreaterThan(0);
+
+    expect(trace.llm_calls).toHaveLength(1);
+    const call = trace.llm_calls[0]!;
+    expect(call).toMatchObject({
+      index: 0,
+      call_site: "mainAgent",
+      model: "model-a",
+      provider: "anthropic",
+    });
+    expect(call.usage).toEqual({
+      input_tokens: 100,
+      output_tokens: 20,
+      cache_creation_input_tokens: 5,
+      cache_read_input_tokens: 3,
+    });
+    expect(call.completion?.role).toBe("assistant");
+
+    expect(trace.tool_calls).toHaveLength(1);
+    expect(trace.tool_calls[0]).toMatchObject({
+      tool_use_id: "tu-1",
+      tool_name: "web_fetch",
+      result: "fetched body",
+      is_error: false,
+    });
+  });
+
+  test("redacts secrets from tool inputs while preserving ordinary content", () => {
+    const acc = new TurnTraceAccumulator("conv-1", "req-1");
+    acc.observe({ type: "llm_call_started", callSite: "mainAgent" });
+    acc.observe({
+      type: "tool_use",
+      id: "tu-secret",
+      name: "http_request",
+      input: {
+        url: "https://api.example.com/data",
+        headers: { Authorization: "Bearer sk-shouldnotleak" },
+        access_token: "tok-shouldnotleak",
+        body: { message: "ordinary user content stays" },
+      },
+    });
+    acc.observe({
+      type: "tool_result",
+      toolUseId: "tu-secret",
+      content: "ok",
+      isError: false,
+    });
+    acc.observe({ type: "agent_loop_exit", reason: "no_tool_calls" });
+
+    expect(recorded).toHaveLength(1);
+    const tool = recorded[0]!.trace.tool_calls[0]!;
+    const input = tool.input as Record<string, unknown>;
+    const headers = input.headers as Record<string, unknown>;
+    // Secrets scrubbed...
+    expect(headers.Authorization).toBe("<redacted />");
+    expect(input.access_token).toBe("<redacted />");
+    // ...ordinary content preserved.
+    expect(input.url).toBe("https://api.example.com/data");
+    expect((input.body as Record<string, unknown>).message).toBe(
+      "ordinary user content stays",
+    );
+  });
+
+  test("redacts secrets echoed into the completion content blocks", () => {
+    const acc = new TurnTraceAccumulator("conv-1", "req-1");
+    acc.observe({ type: "llm_call_started", callSite: "mainAgent" });
+    acc.observe({
+      type: "message_complete",
+      message: assistantMessage([
+        {
+          type: "tool_use",
+          id: "tu-2",
+          name: "configure",
+          input: { api_key: "sk-leak", note: "keep me" },
+        },
+      ]),
+    });
+    acc.observe({ type: "agent_loop_exit", reason: "no_tool_calls" });
+
+    const content = recorded[0]!.trace.llm_calls[0]!.completion!
+      .content as Array<Record<string, unknown>>;
+    const toolUseBlock = content[0]!;
+    const blockInput = toolUseBlock.input as Record<string, unknown>;
+    expect(blockInput.api_key).toBe("<redacted />");
+    expect(blockInput.note).toBe("keep me");
+  });
+
+  test("finalizes exactly once even if agent_loop_exit is observed twice", () => {
+    const acc = new TurnTraceAccumulator("conv-1", "req-1");
+    acc.observe({ type: "llm_call_started", callSite: "mainAgent" });
+    acc.observe({
+      type: "agent_loop_exit",
+      reason: "budget_yield_unrecovered",
+    });
+    acc.observe({
+      type: "agent_loop_exit",
+      reason: "budget_yield_unrecovered",
+    });
+    expect(recorded).toHaveLength(1);
+  });
+
+  test("buffers nothing when the turn produced no observable activity", () => {
+    const acc = new TurnTraceAccumulator("conv-1", "req-1");
+    acc.observe({ type: "agent_loop_exit", reason: "no_tool_calls" });
+    expect(recorded).toHaveLength(0);
+  });
+});

--- a/assistant/src/telemetry/turn-trace-accumulator.ts
+++ b/assistant/src/telemetry/turn-trace-accumulator.ts
@@ -1,0 +1,183 @@
+/**
+ * Per-turn execution-trace accumulator.
+ *
+ * Subscribes (observation-only) to the {@link AgentEvent} stream of a single
+ * agent turn and assembles a {@link TraceTelemetryEvent["trace"]} body —
+ * prompts/completions, tool calls/results, and token usage. On the turn's
+ * terminal `agent_loop_exit` it buffers one trace row via
+ * {@link recordTraceEvent}, which is consent-gated and DARK by default.
+ *
+ * This never changes agent behavior: callers feed each event here *in addition
+ * to* the real dispatch, and every method swallows its own errors so a trace
+ * failure can never surface to the turn.
+ *
+ * Secrets (OAuth/API tokens, `Authorization` headers, credential material) are
+ * scrubbed via {@link redactSensitiveFields} before anything is buffered.
+ * Ordinary conversation/PII content is preserved — that is the consented
+ * debugging/eval value.
+ */
+
+import type { AgentEvent } from "../agent/loop.js";
+import { recordTraceEvent } from "../memory/trace-events-store.js";
+import { redactSensitiveFields } from "../security/redaction.js";
+import type {
+  TraceLlmCall,
+  TraceTelemetryEvent,
+  TraceToolCall,
+} from "../telemetry/types.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("turn-trace");
+
+/** Recursively scrub secrets from an arbitrary value (object/array/scalar). */
+function scrubValue(value: unknown): unknown {
+  if (value == null) return value;
+  if (Array.isArray(value)) return value.map(scrubValue);
+  if (typeof value === "object") {
+    return redactSensitiveFields(value as Record<string, unknown>);
+  }
+  return value;
+}
+
+/** Scrub secrets from a list of content blocks, preserving their shape. */
+function scrubContentBlocks(content: ReadonlyArray<unknown>): unknown[] {
+  return content.map(scrubValue);
+}
+
+export class TurnTraceAccumulator {
+  private readonly conversationId: string;
+  private readonly requestId: string | null;
+  private readonly startedAt = Date.now();
+
+  private readonly llmCalls: TraceLlmCall[] = [];
+  private readonly toolCalls: TraceToolCall[] = [];
+  /** tool_use_id → index into `toolCalls`, for attaching results. */
+  private readonly toolCallIndexById = new Map<string, number>();
+  private persisted = false;
+
+  constructor(conversationId: string, requestId: string | null) {
+    this.conversationId = conversationId;
+    this.requestId = requestId;
+  }
+
+  /** The currently-open LLM call (the last one started), or null. */
+  private currentCall(): TraceLlmCall | null {
+    return this.llmCalls.length > 0
+      ? this.llmCalls[this.llmCalls.length - 1]
+      : null;
+  }
+
+  /**
+   * Feed one agent-loop event into the accumulator. Observation-only and
+   * fully self-isolating: any error is logged and swallowed so trace
+   * assembly can never affect the turn.
+   */
+  observe(event: AgentEvent): void {
+    try {
+      switch (event.type) {
+        case "llm_call_started":
+          this.llmCalls.push({
+            index: this.llmCalls.length,
+            call_site: event.callSite ?? null,
+            model: null,
+            provider: null,
+            completion: null,
+            usage: null,
+          });
+          break;
+        case "message_complete": {
+          const call = this.currentCall();
+          if (call) {
+            call.completion = {
+              role: event.message.role,
+              content: scrubContentBlocks(event.message.content),
+            };
+          }
+          break;
+        }
+        case "usage": {
+          const call = this.currentCall();
+          if (call) {
+            call.model = event.model;
+            call.provider = event.actualProvider ?? null;
+            call.usage = {
+              input_tokens: event.inputTokens,
+              output_tokens: event.outputTokens,
+              cache_creation_input_tokens:
+                event.cacheCreationInputTokens ?? null,
+              cache_read_input_tokens: event.cacheReadInputTokens ?? null,
+            };
+          }
+          break;
+        }
+        case "tool_use": {
+          this.toolCallIndexById.set(event.id, this.toolCalls.length);
+          this.toolCalls.push({
+            tool_use_id: event.id,
+            tool_name: event.name,
+            input: redactSensitiveFields(event.input),
+            result: null,
+            is_error: null,
+          });
+          break;
+        }
+        case "tool_result": {
+          const idx = this.toolCallIndexById.get(event.toolUseId);
+          if (idx !== undefined) {
+            const tool = this.toolCalls[idx];
+            // `content` is the model-facing string result; scrub any
+            // token-shaped material a tool may have echoed into it.
+            const scrubbed = scrubValue(event.content);
+            tool.result =
+              typeof scrubbed === "string"
+                ? scrubbed
+                : JSON.stringify(scrubbed);
+            tool.is_error = event.isError;
+          }
+          break;
+        }
+        case "agent_loop_exit":
+          this.finalize(event.reason);
+          break;
+        default:
+          break;
+      }
+    } catch (err) {
+      log.warn(
+        { err, conversationId: this.conversationId, requestId: this.requestId },
+        "Turn trace accumulation error — non-fatal, trace may be incomplete",
+      );
+    }
+  }
+
+  /**
+   * Build the trace body and buffer one row. Idempotent — a turn emits a
+   * single terminal `agent_loop_exit`, but the guard defends against a
+   * double-finalize if a caller re-enters. No-op when the turn produced no
+   * observable activity (defensive; a real turn always has at least one call).
+   */
+  private finalize(exitReason: string): void {
+    if (this.persisted) return;
+    this.persisted = true;
+    if (this.llmCalls.length === 0 && this.toolCalls.length === 0) return;
+    const trace: TraceTelemetryEvent["trace"] = {
+      exit_reason: exitReason,
+      started_at: this.startedAt,
+      ended_at: Date.now(),
+      llm_calls: this.llmCalls,
+      tool_calls: this.toolCalls,
+    };
+    try {
+      recordTraceEvent({
+        conversationId: this.conversationId,
+        requestId: this.requestId,
+        trace,
+      });
+    } catch (err) {
+      log.warn(
+        { err, conversationId: this.conversationId, requestId: this.requestId },
+        "Failed to buffer turn trace — non-fatal",
+      );
+    }
+  }
+}

--- a/assistant/src/telemetry/turn-trace-accumulator.ts
+++ b/assistant/src/telemetry/turn-trace-accumulator.ts
@@ -18,14 +18,16 @@
  */
 
 import type { AgentEvent } from "../agent/loop.js";
+import { getConfig } from "../config/loader.js";
 import { recordTraceEvent } from "../memory/trace-events-store.js";
 import { redactSensitiveFields } from "../security/redaction.js";
+import { getLogger } from "../util/logger.js";
+import { refreshPlatformConsent } from "./platform-consent.js";
 import type {
   TraceLlmCall,
   TraceTelemetryEvent,
   TraceToolCall,
-} from "../telemetry/types.js";
-import { getLogger } from "../util/logger.js";
+} from "./types.js";
 
 const log = getLogger("turn-trace");
 
@@ -58,6 +60,19 @@ export class TurnTraceAccumulator {
   constructor(conversationId: string, requestId: string | null) {
     this.conversationId = conversationId;
     this.requestId = requestId;
+    // Warm the platform consent cache on the edge of the turn path (a turn is
+    // starting). The recording decision reads the cache synchronously, so this
+    // background, TTL-gated, single-flight fetch keeps it fresh without
+    // blocking the hot `agent_loop_exit` write. Gated on `collectUsageData` so
+    // analytics-opted-out users never trigger a consent fetch; fire-and-forget
+    // and fail-closed, so it can never affect the turn.
+    try {
+      if (getConfig().collectUsageData) {
+        void refreshPlatformConsent().catch(() => {});
+      }
+    } catch {
+      // getConfig() can throw in degraded startup; ignore — fail closed.
+    }
   }
 
   /** The currently-open LLM call (the last one started), or null. */

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -302,6 +302,88 @@ export interface SkillLoadedTelemetryEvent extends ModelTelemetryEventBase {
   conversation_id: string | null;
 }
 
+/**
+ * One LLM call captured inside a turn trace — the prompt sent and the
+ * completion returned, plus token usage. Mirrors the loop's per-call
+ * `llm_call_started` → `message_complete` → `usage` sequence. Secrets are
+ * scrubbed daemon-side before this is persisted; ordinary conversation
+ * content is preserved (that is the consented debugging/eval value).
+ */
+export interface TraceLlmCall {
+  /** 0-indexed position of this call within the turn. */
+  index: number;
+  /** Logical call site, e.g. `mainAgent`. Null when the loop did not tag one. */
+  call_site: string | null;
+  /** Model id active for the call. Null when not yet resolved. */
+  model: string | null;
+  /** Provider that served the call. Null when not yet resolved. */
+  provider: string | null;
+  /**
+   * The assistant message the model returned for this call — its content
+   * blocks (text / thinking / tool_use), redaction-scrubbed.
+   */
+  completion: { role: string; content: unknown[] } | null;
+  /** Token usage for this call. Null when the provider returned no usage. */
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_creation_input_tokens: number | null;
+    cache_read_input_tokens: number | null;
+  } | null;
+}
+
+/** One tool invocation captured inside a turn trace (args + result). */
+export interface TraceToolCall {
+  /** Provider-assigned tool_use id linking the call to its result. */
+  tool_use_id: string;
+  tool_name: string;
+  /** Tool arguments, redaction-scrubbed. */
+  input: Record<string, unknown>;
+  /** Stringified tool result content, redaction-scrubbed. Null until the result lands. */
+  result: string | null;
+  /** Whether the tool returned an error result. Null until the result lands. */
+  is_error: boolean | null;
+}
+
+/**
+ * Per-turn execution trace — the full body of one agent turn (prompts,
+ * completions, tool calls/results, token usage). Assembled from the
+ * `AgentLoop` event stream and posted to the platform telemetry endpoint,
+ * which routes `type === "trace"` to the user-partitioned GCS trace path.
+ *
+ * Consent-gated and DARK by default: a trace row is only buffered when the
+ * platform consent says current-version-accepted AND `share_product_improvement`
+ * is on. Secrets (OAuth/API tokens, `Authorization` headers, credential
+ * material) are scrubbed before persistence.
+ */
+export interface TraceTelemetryEvent extends TelemetryEventBase {
+  type: "trace";
+  /** Parent conversation id. */
+  conversation_id: string;
+  /**
+   * 1-indexed position of the user turn this trace belongs to within the
+   * parent conversation, counting only real user turns — same filter as the
+   * `turn` / `llm_usage` event streams. Null when no user turn has been
+   * recorded yet.
+   */
+  turn_index: number | null;
+  /** The agent loop's request id for the turn. */
+  request_id: string | null;
+  /** The per-turn trace body. */
+  trace: {
+    /** Why the turn ended (`AgentLoopExitReason`). Null when unknown. */
+    exit_reason: string | null;
+    /** Epoch ms when the turn started. */
+    started_at: number | null;
+    /** Epoch ms when the turn ended. */
+    ended_at: number | null;
+    /** Each LLM call in the turn, in call order. */
+    llm_calls: TraceLlmCall[];
+    /** Each tool invocation in the turn, in call order. */
+    tool_calls: TraceToolCall[];
+  };
+}
+
 /** Discriminated union of all telemetry event types. */
 export type TelemetryEvent =
   | LlmUsageTelemetryEvent
@@ -310,4 +392,5 @@ export type TelemetryEvent =
   | OnboardingTelemetryEvent
   | AuthFallbackTelemetryEvent
   | ToolExecutedTelemetryEvent
-  | SkillLoadedTelemetryEvent;
+  | SkillLoadedTelemetryEvent
+  | TraceTelemetryEvent;

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -1018,11 +1018,11 @@ describe("UsageTelemetryReporter", () => {
     // No HTTP call should have been made
     expect(mockFetch).not.toHaveBeenCalled();
 
-    // All 7 timestamp watermarks should have been advanced, and all 7 ID
+    // All 8 timestamp watermarks should have been advanced, and all 8 ID
     // watermarks pinned to the high-sorting sentinel (a truthy value keeps
     // the compound-cursor branch active while closing its same-millisecond
     // arm against opt-out rows).
-    expect(mockSetMemoryCheckpoint).toHaveBeenCalledTimes(14);
+    expect(mockSetMemoryCheckpoint).toHaveBeenCalledTimes(16);
 
     const calls = mockSetMemoryCheckpoint.mock.calls;
     const keys = calls.map((c) => c[0]);
@@ -1034,6 +1034,7 @@ describe("UsageTelemetryReporter", () => {
       "auth_fallback",
       "tool_executed",
       "skill_loaded",
+      "trace",
     ];
     for (const eventType of eventTypes) {
       expect(keys).toContain(`telemetry:${eventType}:last_reported_at`);

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -25,6 +25,7 @@ import { queryUnreportedUsageEvents } from "../memory/llm-usage-store.js";
 import { queryUnreportedOnboardingEvents } from "../memory/onboarding-events-store.js";
 import { queryUnreportedSkillLoadedEvents } from "../memory/skill-loaded-events-store.js";
 import { queryUnreportedToolExecutedEvents } from "../memory/tool-executed-events-store.js";
+import { queryUnreportedTraceEvents } from "../memory/trace-events-store.js";
 import { queryUnreportedTurnEvents } from "../memory/turn-events-store.js";
 import { VellumPlatformClient } from "../platform/client.js";
 import type { UsageAttributionProfileSource } from "../usage/types.js";
@@ -67,6 +68,8 @@ const CHECKPOINT_KEY_SKILL_LOADED_WATERMARK =
   "telemetry:skill_loaded:last_reported_at";
 const CHECKPOINT_KEY_SKILL_LOADED_WATERMARK_ID =
   "telemetry:skill_loaded:last_reported_id";
+const CHECKPOINT_KEY_TRACE_WATERMARK = "telemetry:trace:last_reported_at";
+const CHECKPOINT_KEY_TRACE_WATERMARK_ID = "telemetry:trace:last_reported_id";
 // Written into the `*_id` watermark checkpoints by the opt-out flush branch.
 // Sorts lexicographically above every real row ID (all event stores generate
 // lowercase v4 UUIDs), so the compound cursor's same-millisecond arm
@@ -91,6 +94,7 @@ const WATERMARK_KEY_PAIRS: ReadonlyArray<readonly [string, string]> = [
     CHECKPOINT_KEY_SKILL_LOADED_WATERMARK,
     CHECKPOINT_KEY_SKILL_LOADED_WATERMARK_ID,
   ],
+  [CHECKPOINT_KEY_TRACE_WATERMARK, CHECKPOINT_KEY_TRACE_WATERMARK_ID],
 ];
 const REPORT_INTERVAL_MS = 5 * 60 * 1000;
 const INITIAL_FLUSH_DELAY_MS = 30_000; // Delay first flush to let CES handshake complete
@@ -295,6 +299,17 @@ export class UsageTelemetryReporter {
         getMemoryCheckpoint(CHECKPOINT_KEY_SKILL_LOADED_WATERMARK_ID) ??
         undefined;
 
+      // Read trace watermark (compound cursor: createdAt + id).
+      // Brand-new table, so the standard 0 default is safe. Trace rows are
+      // only ever recorded under consent (DARK by default), so the opt-out
+      // flush branch above keeps this watermark advancing past any window
+      // where consent was off, same as the other event types.
+      const traceWatermark = Number(
+        getMemoryCheckpoint(CHECKPOINT_KEY_TRACE_WATERMARK) ?? "0",
+      );
+      const traceWatermarkId =
+        getMemoryCheckpoint(CHECKPOINT_KEY_TRACE_WATERMARK_ID) ?? undefined;
+
       // Query unreported events
       const events = queryUnreportedUsageEvents(
         watermark,
@@ -331,6 +346,11 @@ export class UsageTelemetryReporter {
         skillLoadedWatermarkId,
         BATCH_SIZE,
       );
+      const traceEvents = queryUnreportedTraceEvents(
+        traceWatermark,
+        traceWatermarkId,
+        BATCH_SIZE,
+      );
 
       if (
         events.length === 0 &&
@@ -339,7 +359,8 @@ export class UsageTelemetryReporter {
         onboardingEvents.length === 0 &&
         authFallbackEvents.length === 0 &&
         toolExecutedEvents.length === 0 &&
-        skillLoadedEvents.length === 0
+        skillLoadedEvents.length === 0 &&
+        traceEvents.length === 0
       )
         return;
 
@@ -356,6 +377,7 @@ export class UsageTelemetryReporter {
           authFallbackCount: authFallbackEvents.length,
           toolExecutedCount: toolExecutedEvents.length,
           skillLoadedCount: skillLoadedEvents.length,
+          traceCount: traceEvents.length,
         },
         "Telemetry flush: resolved auth context",
       );
@@ -567,6 +589,24 @@ export class UsageTelemetryReporter {
             assistant_version: APP_VERSION,
           }),
         ),
+        ...traceEvents.map(
+          (e): TelemetryEvent => ({
+            type: "trace",
+            daemon_event_id: e.id,
+            recorded_at: e.createdAt,
+            conversation_id: e.conversationId,
+            turn_index: e.turnIndex,
+            request_id: e.requestId,
+            // The trace body is assembled and secret-scrubbed in the daemon
+            // before buffering; forwarded verbatim. The platform routes
+            // `type === "trace"` to the user-partitioned GCS trace path.
+            trace: e.trace,
+            // `telemetry_trace_events` has no record-time version column —
+            // same upload-time APP_VERSION stamping as the other non-llm_usage
+            // event types.
+            assistant_version: APP_VERSION,
+          }),
+        ),
       ];
 
       const organizationId = getPlatformOrganizationId() || undefined;
@@ -693,6 +733,16 @@ export class UsageTelemetryReporter {
         );
       }
 
+      // Advance trace watermark (compound cursor)
+      if (traceEvents.length > 0) {
+        const lastTrace = traceEvents[traceEvents.length - 1];
+        setMemoryCheckpoint(
+          CHECKPOINT_KEY_TRACE_WATERMARK,
+          String(lastTrace.createdAt),
+        );
+        setMemoryCheckpoint(CHECKPOINT_KEY_TRACE_WATERMARK_ID, lastTrace.id);
+      }
+
       // If we got a full batch of any type, there may be more — recurse
       if (
         events.length === BATCH_SIZE ||
@@ -701,7 +751,8 @@ export class UsageTelemetryReporter {
         onboardingEvents.length === BATCH_SIZE ||
         authFallbackEvents.length === BATCH_SIZE ||
         toolExecutedEvents.length === BATCH_SIZE ||
-        skillLoadedEvents.length === BATCH_SIZE
+        skillLoadedEvents.length === BATCH_SIZE ||
+        traceEvents.length === BATCH_SIZE
       ) {
         await this._doFlush(batchCount + 1);
       }


### PR DESCRIPTION
## Summary

Implements **Section D** of the in-house trace-collection plan (daemon-side trace emission). The daemon assembles a full per-turn execution trace — prompts/completions, tool calls/results, and token usage — from the existing `AgentLoop` `onEvent` stream and buffers it into a new SQLite telemetry table, which the existing usage telemetry reporter flushes to the platform.

Traces post to the platform **`/v1/telemetry/ingest/` trace path** (the `type === "trace"` event added in the companion Django PR), which routes them to the user-partitioned GCS trace store. **This PR therefore depends on that Django change deploying first** — until then, trace events posted by the reporter would be rejected/ignored by the platform serializer.

## What changed

- **`telemetry/types.ts`** — add `TraceTelemetryEvent` (+ `TraceLlmCall` / `TraceToolCall`) to the `TelemetryEvent` union.
- **`memory/schema/infrastructure.ts` + migration `292`** — new `telemetry_trace_events` buffer table. Named to avoid colliding with the **pre-existing `trace_events` table** (the conversation activity log the UI reads); this is a separate telemetry buffer mirroring `llm_usage_events` / `skill_loaded_events`, with a `(created_at, id)` cursor index.
- **`memory/trace-events-store.ts`** — `recordTraceEvent` writer + `queryUnreportedTraceEvents` compound-cursor query (mirrors `llm-usage-store`).
- **`telemetry/usage-telemetry-reporter.ts`** — trace watermark checkpoint keys wired into `WATERMARK_KEY_PAIRS` + `_doFlush()`; trace rows mapped into the posted `TelemetryEvent[]`.
- **`telemetry/turn-trace-accumulator.ts`** — observation-only accumulator that assembles the per-turn trace and persists one row on `agent_loop_exit`.

### Emission hook site

`src/daemon/conversation-agent-loop.ts`, in `runAgentLoopImpl` — the existing call site that passes `onEvent` into `ctx.agentLoop.run(...)`. A `TurnTraceAccumulator` is fed every event from inside the existing **`eventHandler`** closure (and the **`emitTerminalExit`** closure, for the handoff / re-driven `budget_yield_unrecovered` terminal paths) **in addition to** the real `dispatchAgentEvent`. `finalize()` is idempotent, so the terminal `agent_loop_exit` persists exactly one row regardless of which terminal path fires. **No agent behavior changes** — this is purely observational and self-isolating (every method swallows its own errors).

## Consent + safety (DARK by default)

- Recording is gated on `collectUsageData` **AND** a new `shareProductImprovement` config key that **defaults to `false`**. Traces stay off until the user accepts the current consent version and enables the combined toggle (wired by the web PR, Section C). Unknown/unsynced consent reads as off.
- Secrets (OAuth/API tokens, `Authorization` headers, credential material) are scrubbed via the existing `security/redaction.ts` helper **before** buffering; ordinary conversation/PII content is preserved (the consented debugging/eval value).
- The buffer table + reporter wiring are **inert until events are recorded**.

## ⚠️ DO NOT MERGE yet

Depends on the companion Django telemetry-ingest PR deploying first (it adds the `trace` event path to `/v1/telemetry/ingest/`). Also part of a larger multi-PR effort (Terraform external table, web LogRocket + combined toggle + `CONSENT_VERSION` bump). Holding as draft until the merge order in the plan is ready.

## Checks

- `bunx tsc --noEmit` — clean (0 errors)
- `bun run lint` (eslint) + prettier — clean on all touched files
- Targeted tests — pass:
  - `memory/trace-events-store.test.ts` (consent gate + round-trip + cursor)
  - `telemetry/turn-trace-accumulator.test.ts` (assembly + **secret redaction** + idempotent finalize)
  - `memory/migrations/292-create-telemetry-trace-events.test.ts`
  - `telemetry/usage-telemetry-reporter.test.ts` (42 pass; updated the opt-out watermark-count assertion for the new trace pair)
  - `__tests__/conversation-agent-loop.test.ts` (59 pass — no regression from the emission hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)