### PR TITLE
fix(web): align thinking-step test assertions with computeToolCallCardData output

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-tool-call-card-data.test.ts
@@ -377,12 +377,18 @@ describe("computeToolCallCardDataFromItems — interleaved ordering", () => {
       kind: "thinking",
       durationLabel: "",
       text: "first I reason",
+      startedAt: undefined,
+      completedAt: undefined,
+      thinkingItemIndex: 0,
     });
     expect(data.steps[1]!.kind).toBe("tool");
     expect(data.steps[2]).toEqual({
       kind: "thinking",
       durationLabel: "",
       text: "then I reason again",
+      startedAt: undefined,
+      completedAt: undefined,
+      thinkingItemIndex: 1,
     });
     expect(data.stepCount).toBe("3 steps");
   });
@@ -415,6 +421,7 @@ describe("computeToolCallCardDataFromItems — interleaved ordering", () => {
       text: "stamped reasoning",
       startedAt: 1_000,
       completedAt: 4_000,
+      thinkingItemIndex: 0,
     });
     // AND the unstamped step hides its duration, exactly as a tool with no timing
     expect(data.steps[1]).toEqual({
@@ -423,6 +430,7 @@ describe("computeToolCallCardDataFromItems — interleaved ordering", () => {
       text: "unstamped reasoning",
       startedAt: undefined,
       completedAt: undefined,
+      thinkingItemIndex: 1,
     });
   });
 


### PR DESCRIPTION
## Summary

- Align four stale `toEqual` assertions in `use-tool-call-card-data.test.ts` with the actual output of `computeToolCallCardDataFromItems`, which stamps every genuine thinking step with `startedAt`, `completedAt`, and a `thinkingItemIndex` ordinal.
- Fixes the two failing cases in the **Test** job of Main Web CI (`interleaves thinking between tool steps…` and `derives a thinking step's duration label…`). The `thinkingItemIndex` field is load-bearing — consumed by the thinking-drawer wiring in `multi-activity-group.tsx` and asserted by other passing tests — so the test was stale, not the implementation.

## Original prompt

Fix only the specific CI failure in the Main Web `Test` job (run 27661310225). Two unit tests in `use-tool-call-card-data.test.ts` were failing on main because their `toEqual` assertions didn't expect the `thinkingItemIndex` / timestamp fields the implementation emits on thinking steps. Scope the change to just that one failing job.