### PR TITLE
feat(memory-v3): always-candidate skills + richer workflows card

### DIFF
--- a/assistant/src/__tests__/skills.test.ts
+++ b/assistant/src/__tests__/skills.test.ts
@@ -691,6 +691,57 @@ describe("category frontmatter parsing", () => {
   });
 });
 
+describe("always-candidate frontmatter parsing", () => {
+  beforeEach(() => {
+    mkdirSync(join(TEST_DIR, "skills"), { recursive: true });
+  });
+
+  afterEach(() => {
+    const skillsDir = join(TEST_DIR, "skills");
+    if (existsSync(skillsDir))
+      rmSync(skillsDir, { recursive: true, force: true });
+  });
+
+  function writeSkillWithAlwaysCandidate(skillId: string, value: string): void {
+    const skillDir = join(TEST_DIR, "skills", skillId);
+    mkdirSync(skillDir, { recursive: true });
+    const metadata = `{"vellum":{"always-candidate":${value}}}`;
+    writeFileSync(
+      join(skillDir, "SKILL.md"),
+      `---\nname: "${skillId}"\ndescription: "test"\nmetadata: ${metadata}\n---\n\nBody.\n`,
+    );
+  }
+
+  test("parses always-candidate: true from metadata.vellum", () => {
+    writeSkillWithAlwaysCandidate("pinned", "true");
+    const skill = loadUserSkillCatalog().find((s) => s.id === "pinned");
+    expect(skill!.alwaysCandidate).toBe(true);
+  });
+
+  test("parses always-candidate: false", () => {
+    writeSkillWithAlwaysCandidate("unpinned", "false");
+    const skill = loadUserSkillCatalog().find((s) => s.id === "unpinned");
+    expect(skill!.alwaysCandidate).toBe(false);
+  });
+
+  test("returns undefined for a non-boolean always-candidate", () => {
+    writeSkillWithAlwaysCandidate("bad", '"yes"');
+    const skill = loadUserSkillCatalog().find((s) => s.id === "bad");
+    expect(skill!.alwaysCandidate).toBeUndefined();
+  });
+
+  test("skill without always-candidate has undefined", () => {
+    writeSkill("plain", "Plain", "Test");
+    const skill = loadUserSkillCatalog().find((s) => s.id === "plain");
+    expect(skill!.alwaysCandidate).toBeUndefined();
+  });
+
+  test("the bundled workflows skill is flagged always-candidate", () => {
+    const wf = loadSkillCatalog().find((s) => s.id === "workflows");
+    expect(wf?.alwaysCandidate).toBe(true);
+  });
+});
+
 describe("bundled skill categories", () => {
   test("every bundled skill declares a valid category slug", () => {
     const yamlPath = join(

--- a/assistant/src/config/bundled-skills/workflows/SKILL.md
+++ b/assistant/src/config/bundled-skills/workflows/SKILL.md
@@ -1,18 +1,22 @@
 ---
 name: workflows
-description: Author and run autonomous multi-agent workflows that fan work across parallel leaf agents
+description: Delegate a big or high-stakes job to a fleet of parallel subagents, orchestrated deterministically; runs unattended and reports back
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "⚙️"
   vellum:
     display-name: "Workflows"
     category: "system"
+    always-candidate: true
     activation-hints:
-      - "A task decomposes into many similar sub-tasks that can run concurrently (score every item, extract a field from each of many documents, draft-then-verify a batch)"
-      - "You want fan-out orchestrated deterministically and the result reported back when the whole run finishes"
+      - "Batch — apply one operation to each of MANY items (score / rate / rank / classify / extract / summarize each of a large set)"
+      - "Comprehensive coverage — exhaustively sweep, audit, or find EVERY instance across a large surface"
+      - "Research & synthesize — gather across many sources or pages and combine into one answer"
+      - "Confidence — generate several independent attempts and judge them, or adversarially verify findings before trusting the result"
+      - "Scale — work too large to finish well in one inline pass"
     avoid-when:
-      - "The task is a single tool call or a quick lookup — do it inline"
-      - "The work needs interactive, conversational back-and-forth rather than unattended fan-out"
+      - "A single inline answer, a quick lookup, or a small one-off"
+      - "Interactive, conversational back-and-forth rather than unattended fan-out"
 ---
 
 A workflow is a short JS/TS script you author that runs in a sandbox and fans work
@@ -21,8 +25,11 @@ one with `run_workflow` (inline `script` OR saved `name`, exactly one). It retur
 `runId` immediately; the run is asynchronous and you are notified in this
 conversation when it completes — **do NOT poll**.
 
-Reach for one when a task decomposes into many similar small sub-tasks that can run
-concurrently. For a single task or a quick lookup, do it inline.
+Reach for one when a job is too big, too parallel, or too important for one inline
+pass. That is more than batch/map-reduce over many items — it also covers exhaustively
+sweeping or auditing a large surface, researching across many sources and synthesizing,
+and generating several independent attempts to judge or adversarially verify before
+trusting the result. For a single task or a quick lookup, do it inline.
 
 ## The script model
 

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -47,6 +47,7 @@ const VellumMetadataSchema = z
     "activation-hints": z.array(z.string()).optional(),
     "avoid-when": z.array(z.string()).optional(),
     category: z.string().optional(),
+    "always-candidate": z.boolean().optional(),
   })
   .passthrough();
 
@@ -109,6 +110,13 @@ export interface SkillSummary {
   avoidWhen?: string[];
   /** Category slug declared in frontmatter, used as a fallback when the skill is not in the Vellum catalog. */
   category?: string;
+  /**
+   * When true, this skill is pinned into the memory-v3 selector's stable-prefix
+   * candidate pool every turn (so the selector can choose it even when no
+   * retrieval lane surfaces it). For cross-cutting capabilities whose relevance
+   * the model must judge, not embedding similarity.
+   */
+  alwaysCandidate?: boolean;
   /** Parsed inline command expansion descriptors (`!\`command\``) found in the skill body. */
   inlineCommandExpansions?: InlineCommandExpansion[];
 }
@@ -227,6 +235,7 @@ interface ParsedFrontmatter {
   activationHints?: string[];
   avoidWhen?: string[];
   category?: string;
+  alwaysCandidate?: boolean;
   inlineCommandExpansions?: InlineCommandExpansion[];
 }
 
@@ -342,6 +351,11 @@ function parseFrontmatter(
       ? vellum.category.trim()
       : undefined;
 
+  const alwaysCandidate =
+    typeof vellum?.["always-candidate"] === "boolean"
+      ? vellum["always-candidate"]
+      : undefined;
+
   const strippedBody = stripCommentLines(body);
 
   // Parse inline command expansions from the body (after frontmatter/comment stripping)
@@ -366,6 +380,7 @@ function parseFrontmatter(
     activationHints,
     avoidWhen,
     category,
+    alwaysCandidate,
     inlineCommandExpansions,
   };
 }
@@ -523,6 +538,7 @@ function readSkillFromDirectory(
       activationHints: parsed.activationHints,
       avoidWhen: parsed.avoidWhen,
       category: parsed.category,
+      alwaysCandidate: parsed.alwaysCandidate,
       inlineCommandExpansions: parsed.inlineCommandExpansions,
     };
   } catch (err) {
@@ -576,6 +592,7 @@ function readBundledSkillFromDirectory(
       activationHints: parsed.activationHints,
       avoidWhen: parsed.avoidWhen,
       category: parsed.category,
+      alwaysCandidate: parsed.alwaysCandidate,
       inlineCommandExpansions: parsed.inlineCommandExpansions,
     };
   } catch (err) {
@@ -637,6 +654,7 @@ function loadBundledSkills(): SkillSummary[] {
       activationHints: skill.activationHints,
       avoidWhen: skill.avoidWhen,
       category: skill.category,
+      alwaysCandidate: skill.alwaysCandidate,
       inlineCommandExpansions: skill.inlineCommandExpansions,
     });
   }
@@ -764,6 +782,7 @@ function skillSummaryFromDefinition(
     activationHints: skill.activationHints,
     avoidWhen: skill.avoidWhen,
     category: skill.category,
+    alwaysCandidate: skill.alwaysCandidate,
     inlineCommandExpansions: skill.inlineCommandExpansions,
   };
 }
@@ -818,6 +837,7 @@ export function loadSkillCatalog(
             activationHints: parsed.activationHints,
             avoidWhen: parsed.avoidWhen,
             category: parsed.category,
+            alwaysCandidate: parsed.alwaysCandidate,
             inlineCommandExpansions: parsed.inlineCommandExpansions,
           });
         } catch (err) {
@@ -954,6 +974,7 @@ export function loadSkillCatalog(
           activationHints: parsed.activationHints,
           avoidWhen: parsed.avoidWhen,
           category: parsed.category,
+          alwaysCandidate: parsed.alwaysCandidate,
           inlineCommandExpansions: parsed.inlineCommandExpansions,
         };
 

--- a/assistant/src/memory/v2/__tests__/skill-content.test.ts
+++ b/assistant/src/memory/v2/__tests__/skill-content.test.ts
@@ -45,6 +45,36 @@ describe("buildSkillContent", () => {
     const out = buildSkillContent(input);
     expect(out.length).toBeLessThanOrEqual(500);
   });
+
+  test("respects a larger maxChars budget", async () => {
+    const { buildSkillContent } = await import("../skill-content.js");
+    const input: SkillCapabilityInput = {
+      id: "example-skill",
+      displayName: "Example Skill",
+      description: "x".repeat(1000),
+    };
+    const out = buildSkillContent(input, 900);
+    expect(out.length).toBeLessThanOrEqual(900);
+    expect(out.length).toBeGreaterThan(500);
+  });
+
+  test("renders hints as a bulleted list when the budget is enlarged", async () => {
+    const { buildSkillContent } = await import("../skill-content.js");
+    const input: SkillCapabilityInput = {
+      id: "wf",
+      displayName: "Workflows",
+      description: "Delegate a big job",
+      activationHints: ["Batch many items", "Exhaustive sweep"],
+      avoidWhen: ["A single lookup"],
+    };
+    const rich = buildSkillContent(input, 900);
+    expect(rich).toContain("Use when:\n- Batch many items\n- Exhaustive sweep");
+    expect(rich).toContain("Avoid when:\n- A single lookup");
+    // The default (500) budget keeps the compact inline form.
+    expect(buildSkillContent(input)).toContain(
+      "Use when: Batch many items; Exhaustive sweep.",
+    );
+  });
 });
 
 describe("augmentMcpSetupDescription", () => {

--- a/assistant/src/memory/v2/skill-content.ts
+++ b/assistant/src/memory/v2/skill-content.ts
@@ -2,21 +2,39 @@ import { getConfig } from "../../config/loader.js";
 import type { SkillCapabilityInput } from "../../skills/skill-memory.js";
 
 /**
+ * Character budget for an always-candidate skill's capability statement. Larger
+ * than the default so a cross-cutting skill (pinned into the selector pool every
+ * turn) can describe its full range of uses rather than a single mode — see
+ * `buildSkillContent`'s `maxChars` and `skill-store.ts`'s seeding loop.
+ */
+export const ALWAYS_CANDIDATE_CARD_CHARS = 900;
+
+/**
  * Render the prose-style capability statement embedded into the unified
  * `memory_v2_concept_pages` Qdrant collection (under the `skills/<id>` slug
- * prefix) and rendered in `### Skills You Can Use`. Capped at 500 chars to
- * match v1's behavior.
+ * prefix) and rendered in `### Skills You Can Use` / the memory-v3 selector
+ * card. Capped at `maxChars` (default 500). A larger budget switches the hints
+ * to a bulleted list — easier for the selector to parse one mode per line — so
+ * always-candidate skills can carry a fuller, multi-mode description.
  */
-export function buildSkillContent(input: SkillCapabilityInput): string {
+export function buildSkillContent(
+  input: SkillCapabilityInput,
+  maxChars = 500,
+): string {
+  const list = maxChars > 500;
   let content = `The "${input.displayName}" skill (${input.id}) is available. ${input.description}.`;
   if (input.activationHints && input.activationHints.length > 0) {
-    content += ` Use when: ${input.activationHints.join("; ")}.`;
+    content += list
+      ? `\nUse when:\n${input.activationHints.map((h) => `- ${h}`).join("\n")}`
+      : ` Use when: ${input.activationHints.join("; ")}.`;
   }
   if (input.avoidWhen && input.avoidWhen.length > 0) {
-    content += ` Avoid when: ${input.avoidWhen.join("; ")}.`;
+    content += list
+      ? `\nAvoid when:\n${input.avoidWhen.map((a) => `- ${a}`).join("\n")}`
+      : ` Avoid when: ${input.avoidWhen.join("; ")}.`;
   }
-  if (content.length > 500) {
-    content = content.slice(0, 500);
+  if (content.length > maxChars) {
+    content = content.slice(0, maxChars);
   }
   return content;
 }

--- a/assistant/src/memory/v2/skill-store.ts
+++ b/assistant/src/memory/v2/skill-store.ts
@@ -41,6 +41,7 @@ import {
   upsertConceptPageEmbedding,
 } from "./qdrant.js";
 import {
+  ALWAYS_CANDIDATE_CARD_CHARS,
   augmentMcpSetupDescription,
   buildSkillContent,
 } from "./skill-content.js";
@@ -188,7 +189,12 @@ async function runSeedV2SkillEntries(generation: number): Promise<void> {
       if (flagKey && !isAssistantFeatureFlagEnabled(flagKey, config)) continue;
 
       const augmented = augmentMcpSetupDescription(fromSkillSummary(summary));
-      const content = buildSkillContent(augmented);
+      // Always-candidate skills are pinned into the selector pool every turn, so
+      // they get a larger budget for a fuller, multi-mode capability statement.
+      const content = buildSkillContent(
+        augmented,
+        summary.alwaysCandidate ? ALWAYS_CANDIDATE_CARD_CHARS : undefined,
+      );
       seeds.push({ id: summary.id, content });
     }
 

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/orchestrate.test.ts
@@ -128,11 +128,11 @@ function depsOf(
   const coreSlugs = overrides.coreSlugs ?? [];
   const hotSlugs = overrides.hotSlugs ?? [];
   const freshSlugs = overrides.freshSlugs ?? [];
+  const alwaysCandidateSlugs = overrides.alwaysCandidateSlugs ?? [];
   const prefixCards = new Map<Slug, string>(
-    [...coreSlugs, ...hotSlugs, ...freshSlugs].map((slug) => [
-      slug,
-      renderCard(slug, RAW[slug] ?? ""),
-    ]),
+    [...coreSlugs, ...hotSlugs, ...freshSlugs, ...alwaysCandidateSlugs].map(
+      (slug) => [slug, renderCard(slug, RAW[slug] ?? "")],
+    ),
   );
   return {
     sectionIndex: lanes.sectionIndex,
@@ -305,6 +305,33 @@ describe("orchestrate — candidate pool composition", () => {
     // The needle ranked the capability page on the "kumquat" term, so it is in
     // the candidate pool.
     expect(lastPool).toContain(CAP);
+  });
+
+  test("always-candidate slugs are pinned into the stable prefix and are selectable", async () => {
+    const lanes = await buildLanes();
+    const WF: Slug = "skills/workflows";
+    // No retrieval lane surfaces WF for "apple" (hits topic-a/b/d) — it reaches
+    // the selector ONLY because it is an always-candidate.
+    providerStub = selectProvider([WF]);
+    const result = await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, { alwaysCandidateSlugs: [WF] }),
+    );
+
+    expect(lastPool).toContain(WF);
+    expect(result.selections.map((s) => s.slug)).toContain(WF);
+  });
+
+  test("an always-candidate slug already in core is not double-listed", async () => {
+    const lanes = await buildLanes();
+    const WF: Slug = "skills/workflows";
+    providerStub = selectProvider([]);
+    await orchestrate(
+      makeTurn(1, "apple"),
+      depsOf(lanes, { coreSlugs: [WF], alwaysCandidateSlugs: [WF] }),
+    );
+
+    expect(lastPool.filter((s) => s === WF)).toHaveLength(1);
   });
 
   test("edge curated link description becomes the edge candidate's descriptor", async () => {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/orchestrate.ts
@@ -18,9 +18,10 @@
  *      Each lane only ever ADDS candidates, so the pool is recall-safe by
  *      construction.
  *   2. Build the candidate pool in CACHE ORDER: the stable prefix —
- *      `[...core (file order), ...hot (score order), ...fresh (recency
- *      order)]`, all computed at lane init — followed by the finder
- *      candidates (needle → dense → edge surfacing order). The stable prefix
+ *      `[...core (file order), ...hot (score order), ...fresh (recency order),
+ *      ...always-candidate (skills pinned every turn)]`, all computed at lane
+ *      init — followed by the finder candidates (needle → dense → edge
+ *      surfacing order). The stable prefix
  *      is identical across consecutive turns while the lanes are unchanged
  *      (lane invalidation at consolidation is the recompute cadence), so the
  *      selector input's leading segment rides the provider KV cache (the
@@ -82,6 +83,10 @@ export interface OrchestrateDeps {
   /** The modification-recency fresh set in recency order (computed at lane
    *  init with core and hot excluded). Follows hot in the stable prefix. */
   freshSlugs: Slug[];
+  /** Skills pinned into the candidate pool every turn regardless of retrieval
+   *  (existence-filtered and core/hot/fresh-excluded at lane init). Follow fresh
+   *  in the stable prefix so the selector always sees them. */
+  alwaysCandidateSlugs?: Slug[];
   /** Pre-rendered FULL cards for the stable-prefix slugs, keyed by slug.
    *  Rendered ONCE at lane init so the selector's stable prefix is
    *  byte-identical across turns (the cache contract). Every core/hot/fresh
@@ -172,14 +177,19 @@ export async function orchestrate(
   const { sections } = deps.sectionIndex;
 
   // The stable prefix: core (file order), hot (score order), fresh (recency
-  // order). Hot is computed with core excluded at lane init, fresh with both
-  // excluded; the filters here are a cheap defensive dedup so a misbehaving
-  // lane can never double-list a slug.
+  // order), then always-candidate skills. Hot is computed with core excluded at
+  // lane init, fresh with both excluded, always-candidate with all three
+  // excluded; the filters here are a cheap defensive dedup so a misbehaving lane
+  // can never double-list a slug.
   const core = deps.coreSlugs;
   const hot = deps.hotSlugs.filter((slug) => !core.includes(slug));
   const coreHot = new Set<Slug>([...core, ...hot]);
   const fresh = deps.freshSlugs.filter((slug) => !coreHot.has(slug));
-  const stablePrefix = new Set<Slug>([...coreHot, ...fresh]);
+  const coreHotFresh = new Set<Slug>([...coreHot, ...fresh]);
+  const always = (deps.alwaysCandidateSlugs ?? []).filter(
+    (slug) => !coreHotFresh.has(slug),
+  );
+  const stablePrefix = new Set<Slug>([...coreHotFresh, ...always]);
 
   // Step 1: needle (sync BM25) and dense (async embed + Qdrant) lanes run in
   // parallel. Both return distinct articles each tagged with their best-scoring
@@ -342,19 +352,21 @@ export async function orchestrate(
   // its own snippet line so its CURRENT relevance stays visible; `selectPool`
   // dedupes selections by slug. Finder candidates with no match text fall
   // back to the page's lead-section snippet.
-  const stable: StableCandidate[] = [...core, ...hot, ...fresh].map((slug) => {
-    const card = deps.prefixCards.get(slug);
-    if (card === undefined) {
-      // Lane init renders a card for every core/hot slug; a hole here means
-      // the lanes and the card map are out of sync. Throw rather than render
-      // a degraded card — the caller (observeTurn) logs and skips the turn,
-      // which is better than silently breaking the byte-stable prefix.
-      throw new Error(
-        `memory-v3: no pre-rendered card for stable-prefix slug "${slug}"`,
-      );
-    }
-    return { slug, card };
-  });
+  const stable: StableCandidate[] = [...core, ...hot, ...fresh, ...always].map(
+    (slug) => {
+      const card = deps.prefixCards.get(slug);
+      if (card === undefined) {
+        // Lane init renders a card for every core/hot slug; a hole here means
+        // the lanes and the card map are out of sync. Throw rather than render
+        // a degraded card — the caller (observeTurn) logs and skips the turn,
+        // which is better than silently breaking the byte-stable prefix.
+        throw new Error(
+          `memory-v3: no pre-rendered card for stable-prefix slug "${slug}"`,
+        );
+      }
+      return { slug, card };
+    },
+  );
   const finderTail: PoolCandidate[] = finder.map((c) => ({
     slug: c.slug,
     lane: c.lane,

--- a/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
@@ -34,6 +34,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { isAssistantFeatureFlagEnabled } from "../../../config/assistant-feature-flags.js";
 import { getConfig } from "../../../config/loader.js";
 import type { AssistantConfig } from "../../../config/schema.js";
+import { loadSkillCatalog } from "../../../config/skills.js";
 import { getMessages } from "../../../memory/conversation-crud.js";
 import { getDb, getSqliteFrom } from "../../../memory/db-connection.js";
 import { stringifyMessageContent } from "../../../memory/message-content.js";
@@ -107,6 +108,9 @@ export interface ShadowLanes {
   /** Modification-recency fresh set in recency order: core and hot excluded,
    *  filtered to pages in the section index. */
   freshSlugs: string[];
+  /** Skills pinned into the stable prefix every turn (`always-candidate: true`
+   *  in SKILL.md), existence-filtered and core/hot/fresh-excluded. */
+  alwaysCandidateSlugs: string[];
   /** Learned-edge graph: co-selection NPMI associations over the selection
    *  log, rebuilt with the lanes (the consolidation cadence). */
   learnedGraph: EdgeGraph;
@@ -216,6 +220,18 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
     excludeSlugs: new Set([...coreSlugs, ...hotSlugs]),
   }).filter((slug) => sectionIndex.byArticle.has(slug));
 
+  // Always-candidate skills are pinned into the stable prefix every turn so the
+  // selector can choose a cross-cutting capability (e.g. workflows) even when no
+  // retrieval lane surfaces it — its relevance is a judgment the model makes,
+  // not something embedding similarity finds. Filtered to skills present in the
+  // section index and excluded from core/hot/fresh so the prefix never
+  // double-lists a slug.
+  const prefixSet = new Set([...coreSlugs, ...hotSlugs, ...freshSlugs]);
+  const alwaysCandidateSlugs = loadSkillCatalog()
+    .filter((summary) => summary.alwaysCandidate === true)
+    .map((summary) => `skills/${summary.id}`)
+    .filter((slug) => sectionIndex.byArticle.has(slug) && !prefixSet.has(slug));
+
   // Pre-render the stable-prefix cards ONCE per lane build: the selector's
   // stable prefix must be byte-identical across turns to ride the provider KV
   // cache, so the cards are frozen here (lane invalidation at consolidation is
@@ -228,7 +244,10 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
   const modifiedAtBySlug = new Map(
     pageIndex.entries.map((entry) => [entry.slug, entry.modifiedAt]),
   );
-  const laneAnnotation = (slug: Slug, lane: "core" | "hot" | "fresh") => {
+  const laneAnnotation = (
+    slug: Slug,
+    lane: "core" | "hot" | "fresh" | "always",
+  ) => {
     if (lane !== "fresh") return `[lane: ${lane}]`;
     const modifiedAt = modifiedAtBySlug.get(slug);
     if (
@@ -249,6 +268,7 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
     ["core", coreSlugs],
     ["hot", hotSlugs],
     ["fresh", freshSlugs],
+    ["always", alwaysCandidateSlugs],
   ] as const) {
     for (const slug of slugs) {
       const raw = await capabilityOrDiskBody(
@@ -303,6 +323,7 @@ async function initLanes(config: AssistantConfig): Promise<ShadowLanes> {
     coreSlugs,
     hotSlugs,
     freshSlugs,
+    alwaysCandidateSlugs,
     prefixCards,
   };
 }
@@ -545,6 +566,7 @@ export async function observeTurn(
       coreSlugs: lanes.coreSlugs,
       hotSlugs: lanes.hotSlugs,
       freshSlugs: lanes.freshSlugs,
+      alwaysCandidateSlugs: lanes.alwaysCandidateSlugs,
       prefixCards: lanes.prefixCards,
       needleK: v3.needleK,
       denseK: v3.denseK,


### PR DESCRIPTION
## Summary
- The memory-v3 selector now pins **always-candidate** skills into its stable-prefix candidate pool every turn, so the LLM selector can choose a cross-cutting capability (workflows) even when no retrieval lane surfaces it. Dense retrieval gates workflows out — it matches a query's *subject*, not the orchestration *mechanism* — but the selector picks it correctly when it's a candidate. Capability cards are byte-0 in the prune accounting, so this adds zero stable-prefix footprint.
- Adds `always-candidate: true` SKILL.md metadata (threaded through the catalog → v3 lane init), and a larger card budget (`buildSkillContent` `maxChars`, bulleted layout for rich cards) so an always-candidate skill can describe its full range rather than one mode. Other skills are unchanged (default 500-char/inline).
- Rewrites the workflows SKILL.md to a 5-mode framing (batch / exhaustive sweep / research-and-synthesize / judge-and-verify / scale) — it was underselling the engine as map/reduce.

Validated against the live v3 selector: ~84% combined recall (batch 83% / rich 86%) with clean precision (only the inherent two-item "compare" false positives), vs 0/6 for dense retrieval alone. 8 test files + tsc pass locally.

## Original prompt
We established that the workflows skill — though GA'd — is undiscoverable: dense retrieval never surfaces it for fan-out tasks because it matches the subject, not the mechanism. We proved the v3 LLM selector *does* pick workflows when it's a candidate, so the fix is to always include it as a selector candidate (a retrieval-config change, not a system-prompt line, per System-Prompt-Minimalism) and give it a card reflecting the whole engine instead of underselling it as map/reduce. This implements that — always-candidate metadata + lane, a richer multi-mode card, and the SKILL.md rewrite — and validates the rendered card against the live selector before shipping.