### PR TITLE
fix(web): make /clean and info slash-commands local, non-turn operations

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -7041,6 +7041,71 @@ paths:
       responses:
         "202":
           description: Successful response
+  /v1/conversations/{id}/slash:
+    post:
+      operationId: conversations_by_id_slash_post
+      summary: Resolve a local meta slash command
+      description:
+        "Run a local meta slash command (/clean, /status, /commands, /models) without starting a turn: no messages
+        are persisted and no turn events are emitted. /clean also strips runtime injections from the history. Returns
+        the text to render and, for /clean, the post-strip context usage."
+      tags:
+        - conversations
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                command:
+                  type: string
+                  description: The slash command text, e.g. `/clean` or `/status`.
+              required:
+                - command
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  kind:
+                    type: string
+                    enum:
+                      - clean
+                      - info
+                  text:
+                    type: string
+                  contextUsage:
+                    type: object
+                    properties:
+                      tokens:
+                        type: number
+                      maxTokens:
+                        anyOf:
+                          - type: number
+                          - type: "null"
+                      fillRatio:
+                        anyOf:
+                          - type: number
+                          - type: "null"
+                    required:
+                      - tokens
+                      - maxTokens
+                      - fillRatio
+                    additionalProperties: false
+                required:
+                  - kind
+                  - text
+                additionalProperties: false
   /v1/conversations/{id}/surface:
     post:
       operationId: conversations_by_id_surface_post

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -153,7 +153,7 @@ function resolveQueuedTurnInterfaceContext(
 }
 
 /** Build a SlashContext from the current conversation state and config. */
-function buildSlashContext(
+export function buildSlashContext(
   content: string,
   conversation: Conversation,
 ): SlashContext | undefined {

--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -5,12 +5,18 @@ import { resolveConversationId } from "../../memory/conversation-key-store.js";
 import { broadcastMessage } from "../../runtime/assistant-event-hub.js";
 import { getSubagentManager } from "../../subagent/index.js";
 import { createAbortReason } from "../../util/abort-reasons.js";
+import { UserError } from "../../util/errors.js";
 import { truncate } from "../../util/truncate.js";
 import { regenerate } from "../conversation-history.js";
+import {
+  buildSlashContext,
+  formatCleanResult,
+} from "../conversation-process.js";
 import {
   conversationEntries,
   findConversation,
 } from "../conversation-registry.js";
+import { resolveSlash } from "../conversation-slash.js";
 import {
   clearAllActiveConversations,
   getOrCreateConversation,
@@ -118,6 +124,69 @@ export async function undoLastMessage(
   const removedCount = conversation.undo();
   return { removedCount };
 }
+
+export interface MetaSlashCommandResult {
+  kind: "clean" | "info";
+  /** User-facing text to render (clean stats card or info listing). */
+  text: string;
+  /** Present for `/clean`: the post-strip context-window usage. */
+  contextUsage?: {
+    tokens: number;
+    maxTokens: number | null;
+    fillRatio: number | null;
+  };
+}
+
+/**
+ * Resolve a local meta slash command (`/clean`, `/status`, `/commands`,
+ * `/models`) for a conversation without running a turn: no user/assistant
+ * messages are persisted and no streaming/turn events are emitted. `/clean`
+ * additionally strips runtime injections via `forceClean`.
+ *
+ * Returns null if the conversation cannot be resolved. Throws `UserError` for
+ * commands that are not local meta commands (`/compact`, passthrough) — those
+ * must be sent as a normal message so they run a real turn.
+ */
+export async function resolveMetaSlashCommand(
+  conversationId: string,
+  command: string,
+): Promise<MetaSlashCommandResult | null> {
+  const resolvedId = resolveConversationId(conversationId);
+  if (!resolvedId) {
+    return null;
+  }
+  const conversation = await getOrCreateConversation(resolvedId);
+  touchConversation(resolvedId);
+
+  const slashResult = await resolveSlash(
+    command,
+    buildSlashContext(command, conversation),
+  );
+
+  if (slashResult.kind === "clean") {
+    const result = await conversation.forceClean();
+    return {
+      kind: "clean",
+      text: formatCleanResult(result),
+      contextUsage: {
+        tokens: result.estimatedInputTokens,
+        maxTokens: result.maxInputTokens,
+        fillRatio:
+          result.maxInputTokens > 0
+            ? result.estimatedInputTokens / result.maxInputTokens
+            : null,
+      },
+    };
+  }
+
+  if (slashResult.kind === "unknown") {
+    return { kind: "info", text: slashResult.message };
+  }
+
+  // `compact` / `passthrough` are real turns, not local meta commands.
+  throw new UserError(`\`${command.trim()}\` is not a local meta command.`);
+}
+
 /**
  * Regenerate the last assistant response for a conversation. The caller provides
  * a `sendEvent` callback for delivering streaming events via HTTP/SSE.

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -26,6 +26,7 @@ import {
   cancelGeneration,
   clearAllConversations,
   regenerateResponse,
+  resolveMetaSlashCommand,
   switchConversation,
   undoLastMessage,
 } from "../../daemon/handlers/conversations.js";
@@ -452,6 +453,29 @@ async function handleUndoLastMessage({ pathParams = {} }: RouteHandlerArgs) {
   };
 }
 
+async function handleResolveMetaSlashCommand({
+  pathParams = {},
+  body = {},
+}: RouteHandlerArgs) {
+  const command = body.command as string | undefined;
+  if (!command || typeof command !== "string") {
+    throw new BadRequestError("Missing command");
+  }
+  let result: Awaited<ReturnType<typeof resolveMetaSlashCommand>>;
+  try {
+    result = await resolveMetaSlashCommand(pathParams.id!, command);
+  } catch (err) {
+    if (err instanceof UserError) {
+      throw new BadRequestError(err.message);
+    }
+    throw err;
+  }
+  if (!result) {
+    throw new NotFoundError(`No conversation for ${pathParams.id}`);
+  }
+  return result;
+}
+
 async function handleRegenerateResponse({ pathParams = {} }: RouteHandlerArgs) {
   const conversationId = pathParams.id!;
   try {
@@ -819,6 +843,40 @@ export const ROUTES: RouteDefinition[] = [
       conversationId: z.string(),
     }),
     handler: handleUndoLastMessage,
+  },
+  {
+    operationId: "resolveConversationSlashCommand",
+    endpoint: "conversations/:id/slash",
+    method: "POST",
+    policy: {
+      requiredScopes: ["chat.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Resolve a local meta slash command",
+    description:
+      "Run a local meta slash command (/clean, /status, /commands, /models) " +
+      "without starting a turn: no messages are persisted and no turn events " +
+      "are emitted. /clean also strips runtime injections from the history. " +
+      "Returns the text to render and, for /clean, the post-strip context usage.",
+    tags: ["conversations"],
+    pathParams: [{ name: "id", type: "uuid" }],
+    requestBody: z.object({
+      command: z
+        .string()
+        .describe("The slash command text, e.g. `/clean` or `/status`."),
+    }),
+    responseBody: z.object({
+      kind: z.enum(["clean", "info"]),
+      text: z.string(),
+      contextUsage: z
+        .object({
+          tokens: z.number(),
+          maxTokens: z.number().nullable(),
+          fillRatio: z.number().nullable(),
+        })
+        .optional(),
+    }),
+    handler: handleResolveMetaSlashCommand,
   },
   {
     operationId: "regenerateResponse",

--- a/clients/web/src/domains/chat/chat-session-store.ts
+++ b/clients/web/src/domains/chat/chat-session-store.ts
@@ -29,7 +29,10 @@ import { useTurnStore } from "@/domains/chat/turn-store";
 import { useInteractionStore } from "@/domains/chat/interaction-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useComposerStore } from "@/domains/chat/composer-store";
-import type { DisplayMessage } from "@/domains/chat/types/types";
+import type {
+  DisplayMessage,
+  EphemeralMetaResult,
+} from "@/domains/chat/types/types";
 import type { ChatError } from "@/domains/chat/types";
 import type { ContextWindowUsage } from "@/domains/chat/components/context-window-indicator";
 import type { TranscriptPaginationState } from "@/domains/chat/transcript/types";
@@ -50,6 +53,12 @@ export interface ChatSessionState {
 
   // --- Context window ---
   contextWindowUsage: ContextWindowUsage | null;
+
+  // --- Ephemeral local meta-command results ---
+  // Results of local meta slash commands (/clean, /status, /commands, /models),
+  // rendered as cards at the transcript tail. Never persisted; cleared on the
+  // next real send, conversation switch, or reload.
+  ephemeralMetaResults: EphemeralMetaResult[];
 
   // --- Circuit breaker ---
   compactionCircuitOpenUntil: Date | null;
@@ -164,6 +173,10 @@ export interface ChatSessionActions {
   // --- Context window cache ---
   setContextWindowUsageForConversation: (conversationId: string, usage: ContextWindowUsage) => void;
 
+  // --- Ephemeral meta-command results ---
+  addEphemeralMetaResult: (result: EphemeralMetaResult) => void;
+  clearEphemeralMetaResults: () => void;
+
   // --- Data-apply coordination ---
   consumeSwitchReset: () => void;
   setLastAppliedDataTimestamp: (ts: number) => void;
@@ -193,6 +206,7 @@ function initialState(): ChatSessionState {
     isLoadingHistory: true,
     transcriptPagination: { ...INITIAL_PAGINATION },
     contextWindowUsage: null,
+    ephemeralMetaResults: [],
     compactionCircuitOpenUntil: null,
     dismissedSurfaceIds: new Set(),
     streamingMessageIds: new Set(),
@@ -314,6 +328,7 @@ const useChatSessionStoreBase = create<ChatSessionStore>()((set, get) => ({
 
     set({
       messages: [],
+      ephemeralMetaResults: [],
       error: shouldSuppressGenericChatErrorNotice(state.error) ? state.error : null,
       isLoadingHistory: true,
       transcriptPagination: { ...INITIAL_PAGINATION },
@@ -453,6 +468,19 @@ const useChatSessionStoreBase = create<ChatSessionStore>()((set, get) => ({
       next.set(conversationId, usage);
       return { contextWindowUsageByConversation: next };
     }),
+
+  // --- Ephemeral meta-command results ---
+  addEphemeralMetaResult: (result) =>
+    set((s) => ({
+      ephemeralMetaResults: [...s.ephemeralMetaResults, result],
+    })),
+
+  clearEphemeralMetaResults: () =>
+    set((s) =>
+      s.ephemeralMetaResults.length === 0
+        ? s
+        : { ephemeralMetaResults: [] },
+    ),
 
   // --- Data-apply coordination ---
   consumeSwitchReset: () =>

--- a/clients/web/src/domains/chat/components/chat-composer/slash-command-catalog.test.ts
+++ b/clients/web/src/domains/chat/components/chat-composer/slash-command-catalog.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+
+import { isLocalMetaCommand } from "@/domains/chat/components/chat-composer/slash-command-catalog";
+
+describe("isLocalMetaCommand", () => {
+  test("recognises the local meta commands", () => {
+    for (const cmd of ["/clean", "/status", "/commands", "/models"]) {
+      expect(isLocalMetaCommand(cmd)).toBe(true);
+    }
+  });
+
+  test("tolerates surrounding whitespace, trailing args, and case", () => {
+    expect(isLocalMetaCommand("  /clean  ")).toBe(true);
+    expect(isLocalMetaCommand("/clean foo")).toBe(true);
+    expect(isLocalMetaCommand("/CLEAN")).toBe(true);
+  });
+
+  test("excludes turn commands and lookalikes", () => {
+    // /compact runs the LLM (a real turn); /model switches the profile (a
+    // side-effecting command); the rest are non-commands or prefixes.
+    for (const cmd of [
+      "/compact",
+      "/btw",
+      "/model",
+      "/cleanup",
+      "/clean-context",
+      "hello",
+      "/",
+    ]) {
+      expect(isLocalMetaCommand(cmd)).toBe(false);
+    }
+  });
+});

--- a/clients/web/src/domains/chat/components/chat-composer/slash-command-catalog.ts
+++ b/clients/web/src/domains/chat/components/chat-composer/slash-command-catalog.ts
@@ -20,6 +20,25 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: "btw", description: "Ask a side question while the assistant is working", selectionBehavior: "insertTrailingSpace" },
 ];
 
+/**
+ * Slash commands handled locally without starting an assistant turn. They are
+ * resolved via the daemon's meta-command endpoint and rendered as an ephemeral
+ * card at the transcript tail. `/compact` is intentionally excluded — it runs
+ * the LLM (summarization) and is a real turn.
+ */
+const LOCAL_META_COMMAND_NAMES = new Set([
+  "clean",
+  "status",
+  "commands",
+  "models",
+]);
+
+/** True when `input` invokes a local meta command (e.g. `/clean`, `/status`). */
+export function isLocalMetaCommand(input: string): boolean {
+  const match = input.trim().match(/^\/([a-z]+)(?:\s|$)/i);
+  return match ? LOCAL_META_COMMAND_NAMES.has(match[1].toLowerCase()) : false;
+}
+
 /** Returns commands whose name starts with `filter` (case-insensitive). Empty filter returns all. */
 export function filteredCommands(filter: string): SlashCommand[] {
   if (!filter) return SLASH_COMMANDS;

--- a/clients/web/src/domains/chat/hooks/use-send-message.ts
+++ b/clients/web/src/domains/chat/hooks/use-send-message.ts
@@ -18,7 +18,12 @@ import {
 } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router";
+import { toast } from "@vellumai/design-library/components/toast";
 import { routes } from "@/utils/routes";
+import { conversationsByIdSlashPost } from "@/generated/daemon/sdk.gen";
+import { isLocalMetaCommand } from "@/domains/chat/components/chat-composer/slash-command-catalog";
+import { saveContextWindowUsage } from "@/domains/chat/utils/context-window-storage";
+import type { ContextWindowUsage } from "@/domains/chat/components/context-window-indicator";
 
 import type {
   DisplayAttachment,
@@ -546,6 +551,50 @@ export function useSendMessage({
   );
 
   // -------------------------------------------------------------------------
+  // runLocalMetaCommand — resolve a local meta slash command without a turn
+  // -------------------------------------------------------------------------
+  const runLocalMetaCommand = useCallback(
+    async (
+      command: string,
+      conversationId: string,
+      activeAssistantId: string,
+    ) => {
+      try {
+        const { data, error } = await conversationsByIdSlashPost({
+          path: { assistant_id: activeAssistantId, id: conversationId },
+          body: { command: command.trim() },
+          throwOnError: false,
+        });
+        if (error || !data) {
+          toast.error("Couldn't run that command. Please try again.");
+          return;
+        }
+        useChatSessionStore.getState().addEphemeralMetaResult({
+          id: crypto.randomUUID(),
+          kind: data.kind,
+          text: data.text,
+        });
+        if (data.contextUsage) {
+          const usage: ContextWindowUsage = {
+            tokens: data.contextUsage.tokens,
+            maxTokens: data.contextUsage.maxTokens,
+            fillRatio: data.contextUsage.fillRatio,
+          };
+          useChatSessionStore
+            .getState()
+            .setContextWindowUsageForConversation(conversationId, usage);
+          useChatSessionStore.getState().setContextWindowUsage(usage);
+          saveContextWindowUsage(activeAssistantId, conversationId, usage);
+        }
+      } catch (err) {
+        captureError(err, { context: "run_local_meta_command" });
+        toast.error("Couldn't run that command. Please try again.");
+      }
+    },
+    [],
+  );
+
+  // -------------------------------------------------------------------------
   // sendMessage — high-level send with UI state, queuing, draft resolution
   // -------------------------------------------------------------------------
   const sendMessage = useCallback(
@@ -573,6 +622,14 @@ export function useSendMessage({
         return;
       }
       setError(null);
+      // Local meta commands (/clean, /status, /commands, /models) never start a
+      // turn: resolve them via the daemon and render an ephemeral card.
+      if (isLocalMetaCommand(content)) {
+        await runLocalMetaCommand(content, activeConversationId, assistantId);
+        return;
+      }
+      // A real send supersedes any ephemeral meta-command cards.
+      useChatSessionStore.getState().clearEphemeralMetaResults();
       useInteractionStore.getState().resetSecretAndConfirmation();
       useChatSessionStore.getState().clearConfirmationToolCallMap();
       // Clear pending confirmations and dismiss interactive surfaces in a
@@ -811,6 +868,7 @@ export function useSendMessage({
       activeConversationId,
       assistantId,
       diskPressureChatBlockReason,
+      runLocalMetaCommand,
       sendMessageViaStream,
       refreshConversations,
       revertQueuedMessage,

--- a/clients/web/src/domains/chat/hooks/use-transcript-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-transcript-data.ts
@@ -51,6 +51,7 @@ export function useTranscriptData({
 }: UseTranscriptDataParams): TranscriptData {
   // --- Store reads --------------------------------------------------------
   const messages = useChatSessionStore.use.messages();
+  const ephemeralMetaResults = useChatSessionStore.use.ephemeralMetaResults();
 
   const pendingSecret = useInteractionStore.use.pendingSecret();
   const pendingConfirmation = useInteractionStore.use.pendingConfirmation();
@@ -105,6 +106,7 @@ export function useTranscriptData({
         isThinking: showThinking,
         thinkingLabel,
         autoRoutedProfileLabel,
+        ephemeralMetaResults,
         showOnboardingChoice,
       }),
     [
@@ -116,6 +118,7 @@ export function useTranscriptData({
       showThinking,
       thinkingLabel,
       autoRoutedProfileLabel,
+      ephemeralMetaResults,
       showOnboardingChoice,
     ],
   );

--- a/clients/web/src/domains/chat/transcript/build-items.test.ts
+++ b/clients/web/src/domains/chat/transcript/build-items.test.ts
@@ -64,6 +64,25 @@ describe("buildTranscriptItems", () => {
     expect(items).toEqual([]);
   });
 
+  test("projects ephemeralMetaResults as tail cards after messages", () => {
+    const user = makeMessage({ id: "m1", role: "user", ...textBody("Hi") });
+
+    const items = buildTranscriptItems({
+      ...emptyInput(),
+      messages: [user],
+      ephemeralMetaResults: [
+        { id: "e1", kind: "clean", text: "Context Cleaned" },
+        { id: "e2", kind: "info", text: "Available models" },
+      ],
+    });
+
+    expect(items).toHaveLength(3);
+    expect(items[0]).toMatchObject({ kind: "message", key: "m1" });
+    expect(items[1]).toMatchObject({ kind: "ephemeralMeta", key: "meta-e1" });
+    expect(items[2]).toMatchObject({ kind: "ephemeralMeta", key: "meta-e2" });
+    expectDistinctNonEmptyKeys(items);
+  });
+
   test("surfaces on messages are rendered within the message item (no standalone rows)", () => {
     const user = makeMessage({ id: "m1", role: "user", ...textBody("Hi"),  });
     const surface = makeSurface({

--- a/clients/web/src/domains/chat/transcript/build-items.ts
+++ b/clients/web/src/domains/chat/transcript/build-items.ts
@@ -3,7 +3,10 @@
 // messages + interaction state and emits a flat item array that the
 // Transcript component renders via a virtualised list.
 
-import type { DisplayMessage } from "@/domains/chat/types/types";
+import type {
+  DisplayMessage,
+  EphemeralMetaResult,
+} from "@/domains/chat/types/types";
 import type {
   MessageItem,
   PendingContactRequestItem,
@@ -27,6 +30,9 @@ export interface BuildTranscriptItemsInput {
   thinkingLabel?: string | null;
   /** Human-readable label when the daemon auto-routed to a different inference profile. */
   autoRoutedProfileLabel?: string | null;
+  /** Ephemeral local meta-command results (e.g. /clean, /status), rendered at
+   *  the transcript tail. Not persisted; cleared on the next send/switch. */
+  ephemeralMetaResults?: EphemeralMetaResult[];
   showOnboardingChoice?: boolean;
 }
 
@@ -82,6 +88,14 @@ export function buildTranscriptItems(
       message,
     };
     items.push(messageItem);
+  }
+
+  for (const result of input.ephemeralMetaResults ?? []) {
+    items.push({
+      kind: "ephemeralMeta",
+      key: `meta-${result.id}`,
+      result,
+    });
   }
 
   if (input.autoRoutedProfileLabel) {

--- a/clients/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-row.tsx
@@ -1,6 +1,7 @@
 
 import { memo, type ReactNode } from "react";
 
+import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
 import { SurfaceRouter } from "@/domains/chat/components/surfaces/surface-router";
 import type { TranscriptItem } from "@/domains/chat/transcript/types";
 
@@ -166,6 +167,15 @@ export const TranscriptRow = memo(function TranscriptRow({
 
     case "pendingContactRequest":
       return <PendingContactRequestRow />;
+
+    case "ephemeralMeta":
+      return (
+        <div className="flex justify-start">
+          <div className="max-w-full rounded-[var(--radius-lg)] bg-[var(--surface-overlay)] px-4 py-3 text-body-small-default text-[var(--content-secondary)]">
+            <ChatMarkdownMessage content={item.result.text} hardLineBreaks />
+          </div>
+        </div>
+      );
 
     case "onboardingChoice":
       if (renderOnboardingChoice) {

--- a/clients/web/src/domains/chat/transcript/types.ts
+++ b/clients/web/src/domains/chat/transcript/types.ts
@@ -2,7 +2,11 @@
 // React / DOM imports so `buildTranscriptItems` and `partitionLatestTurn`
 // can be unit-tested under `bun test` without a Node test runner.
 
-import type { DisplayMessage, Surface } from "@/domains/chat/types/types";
+import type {
+  DisplayMessage,
+  EphemeralMetaResult,
+  Surface,
+} from "@/domains/chat/types/types";
 import type { RuntimeSubagentNotification } from "@/domains/chat/api/messages";
 
 export type TranscriptItemKind =
@@ -13,6 +17,7 @@ export type TranscriptItemKind =
   | "pendingConfirmation"
   | "pendingContactRequest"
   | "surface"
+  | "ephemeralMeta"
   | "onboardingChoice";
 
 export interface TranscriptItemBase {
@@ -67,6 +72,11 @@ export interface OnboardingChoiceItem extends TranscriptItemBase {
   kind: "onboardingChoice";
 }
 
+export interface EphemeralMetaItem extends TranscriptItemBase {
+  kind: "ephemeralMeta";
+  result: EphemeralMetaResult;
+}
+
 export type TranscriptItem =
   | MessageItem
   | ThinkingItem
@@ -75,6 +85,7 @@ export type TranscriptItem =
   | PendingConfirmationItem
   | PendingContactRequestItem
   | SurfaceItem
+  | EphemeralMetaItem
   | OnboardingChoiceItem;
 
 /** Result of splitting the transcript into stable history and the

--- a/clients/web/src/domains/chat/types/types.ts
+++ b/clients/web/src/domains/chat/types/types.ts
@@ -40,6 +40,19 @@ export interface SlackRuntimeMessage {
   threadLink?: SlackMessageLink;
 }
 
+/**
+ * Result of a local meta slash command (`/clean`, `/status`, `/commands`,
+ * `/models`). Rendered as an ephemeral card at the transcript tail — never
+ * persisted, cleared on the next real send, conversation switch, or reload.
+ */
+export interface EphemeralMetaResult {
+  /** Stable key for the transcript row. */
+  id: string;
+  kind: "clean" | "info";
+  /** User-facing text to render (clean stats card or info listing). */
+  text: string;
+}
+
 export interface DisplayMessage {
   /**
    * Row identity. Server-assigned message id for confirmed rows; a


### PR DESCRIPTION
## Summary
- Sending `/clean` (and the info commands `/status`, `/commands`, `/models`) in the web/Electron app no longer starts an assistant turn. They're intercepted in `sendMessage`, resolved via a new daemon route `POST /conversations/:id/slash`, and rendered as an ephemeral card at the transcript tail — no persisted user/assistant messages, no "thinking" turn lifecycle. `/clean` also refreshes the context-window ring from the returned usage. `/compact` still runs the LLM and stays a turn.
- Daemon: new `resolveMetaSlashCommand` handler (mirrors `undoLastMessage`) reuses `resolveSlash` + `forceClean` + `formatCleanResult` without persisting messages or emitting turn events. The existing message-path `/clean` handling is kept for the CLI and other channels.
- Client: ephemeral results live in a new chat-session-store slice (cleared on the next real send, conversation switch, or reload) and render via the existing `ChatMarkdownMessage`. Adds unit tests for `isLocalMetaCommand` and the transcript projection.

## Original prompt
Sending `/clean` in the Electron app was triggering a new assistant turn instead of just stripping the `<memory>` tags from old messages. Investigation showed the daemon does no LLM work for `/clean` — the client was sending it through the normal message-send path, which drove the full turn lifecycle (a "thinking" state plus a persisted user/assistant exchange). The fix routes `/clean` and the sibling non-LLM info commands through a dedicated non-turn path that renders an ephemeral inline card; `/compact` (which genuinely runs the LLM) stays a turn.