### PR TITLE
fix(memory-v3): surface forked turns' memory injections in the inspector

### DIFF
--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/selection-log-store.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/selection-log-store.test.ts
@@ -7,7 +7,9 @@
  *     is robust against v2/v3 turn-counter drift and does not match rows that
  *     predate the message-id backfill;
  *   - null for a null turn, empty message ids, or no matching rows;
- *   - NO fallback to another turn/message;
+ *   - NO blind fallback to a neighbouring turn/message;
+ *   - the fork fallback: a turn inherited from a fork resolves to the parent's
+ *     rows via the message's `forkSourceMessageId` back-pointer;
  *   - source/pinned/section mapping and the rendered `<memory>` block;
  *   - `live` / `shadow` reflect the flag resolver.
  *
@@ -45,6 +47,9 @@ function makeDb() {
   const db = drizzle(testSqlite, { schema });
   migrateAddMemoryV3Selections(db);
   migrateMemoryV3SelectionsMessageIdAndSections(db);
+  // The fork-source fallback reads `messages.metadata.forkSourceMessageId`; the
+  // inspector store touches only these two columns, so a minimal table suffices.
+  testSqlite.exec(`CREATE TABLE messages (id TEXT PRIMARY KEY, metadata TEXT)`);
   return db;
 }
 
@@ -79,6 +84,15 @@ function seed(
       r.sectionTitle ?? null,
     );
   }
+}
+
+function seedMessage(id: string, forkSourceMessageId?: string): void {
+  const metadata = JSON.stringify(
+    forkSourceMessageId != null ? { forkSourceMessageId } : {},
+  );
+  testSqlite
+    .query(`INSERT INTO messages (id, metadata) VALUES (?, ?)`)
+    .run(id, metadata);
 }
 
 mock.module("../../../../config/assistant-feature-flags.js", () => ({
@@ -279,6 +293,64 @@ describe("getMemoryV3SelectionForInspectorByMessageIds", () => {
     seed("conv-m", 0, [{ slug: "domain-a/page-1", source: "needle" }]); // message_id null
     expect(
       await getMemoryV3SelectionForInspectorByMessageIds(["any"]),
+    ).toBeNull();
+  });
+
+  test("falls back to the parent's selection for a forked (inherited) turn", async () => {
+    // The parent logged its selection under the parent assistant message id.
+    seed(
+      "conv-parent",
+      4,
+      [{ slug: "domain-a/page-1", source: "needle" }],
+      "parent-msg",
+    );
+    // The fork copied that message under a fresh id with a back-pointer and has
+    // no selection rows of its own.
+    seedMessage("fork-msg", "parent-msg");
+
+    const log = await getMemoryV3SelectionForInspectorByMessageIds([
+      "fork-msg",
+    ]);
+    expect(log?.selections.map((s) => s.slug)).toEqual(["domain-a/page-1"]);
+  });
+
+  test("walks a fork-of-a-fork chain to the original selection", async () => {
+    seed(
+      "conv-orig",
+      2,
+      [{ slug: "domain-b/page-2", source: "core" }],
+      "orig-msg",
+    );
+    // The mid fork copied orig; the second fork copied mid. Neither carries its
+    // own rows, so resolution must hop twice to reach orig.
+    seedMessage("mid-msg", "orig-msg");
+    seedMessage("fork2-msg", "mid-msg");
+
+    const log = await getMemoryV3SelectionForInspectorByMessageIds([
+      "fork2-msg",
+    ]);
+    expect(log?.selections.map((s) => s.slug)).toEqual(["domain-b/page-2"]);
+  });
+
+  test("prefers the message's own rows over the fork-source fallback", async () => {
+    // A post-fork native turn has its own rows AND a back-pointer; the direct
+    // rows must win so a native turn is never misattributed to the parent.
+    seed("conv-parent", 4, [{ slug: "parent/page", source: "needle" }], "src");
+    seed("conv-fork", 0, [{ slug: "own/page", source: "core" }], "native-msg");
+    seedMessage("native-msg", "src");
+
+    const log = await getMemoryV3SelectionForInspectorByMessageIds([
+      "native-msg",
+    ]);
+    expect(log?.selections.map((s) => s.slug)).toEqual(["own/page"]);
+  });
+
+  test("returns null for a fork copy whose ancestors logged nothing", async () => {
+    // A fork copy (has a back-pointer) where neither it nor its source ever
+    // logged a v3 selection.
+    seedMessage("fork-msg", "parent-msg");
+    expect(
+      await getMemoryV3SelectionForInspectorByMessageIds(["fork-msg"]),
     ).toBeNull();
   });
 });

--- a/assistant/src/plugins/defaults/memory-v3-shadow/selection-log-store.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/selection-log-store.ts
@@ -74,6 +74,52 @@ function rowsForMessageIds(messageIds: string[]): SelectionRow[] {
     .all(...messageIds) as SelectionRow[];
 }
 
+const MAX_FORK_HOPS = 64;
+
+/**
+ * Read the `forkSourceMessageId` back-pointer that `cloneForkMessageMetadata`
+ * stamps onto every message a fork copies, for the given message ids.
+ */
+function forkSourceIdsOf(messageIds: string[]): string[] {
+  if (messageIds.length === 0) return [];
+  const placeholders = messageIds.map(() => "?").join(", ");
+  const rows = getSqliteFrom(getDb())
+    .query(
+      /*sql*/ `
+      SELECT json_extract(metadata, '$.forkSourceMessageId') AS src
+      FROM messages
+      WHERE id IN (${placeholders})
+    `,
+    )
+    .all(...messageIds) as Array<{ src: string | null }>;
+  return rows
+    .map((r) => r.src)
+    .filter((src): src is string => typeof src === "string" && src.length > 0);
+}
+
+/**
+ * A fork copies the parent's messages under fresh ids but does not copy their
+ * `memory_v3_selections` rows, so an inherited turn has no rows under its own
+ * message ids. Each copied message preserves a `forkSourceMessageId` pointer to
+ * the message it was cloned from; walk that chain (a fork of a fork chains it
+ * again) to the nearest ancestor generation that logged selections and return
+ * those rows. Returns `[]` when no ancestor has v3 rows (or the ids aren't fork
+ * copies).
+ */
+function rowsViaForkSource(messageIds: string[]): SelectionRow[] {
+  let frontier = messageIds;
+  const visited = new Set(messageIds);
+  for (let hop = 0; hop < MAX_FORK_HOPS; hop++) {
+    const sources = forkSourceIdsOf(frontier).filter((id) => !visited.has(id));
+    if (sources.length === 0) return [];
+    for (const id of sources) visited.add(id);
+    const rows = rowsForMessageIds(sources);
+    if (rows.length > 0) return rows;
+    frontier = sources;
+  }
+  return [];
+}
+
 /**
  * Resolve each selection's persisted matched section `(slug, ordinal)` to the
  * concrete `Section` in the CURRENT page, so the injected block renders the
@@ -150,13 +196,20 @@ async function buildSelectionLog(
  * conversation with no v3 data). Message ids are globally unique, so no
  * conversation scope is needed.
  *
+ * For turns inherited from a fork, the copied messages carry fresh ids with no
+ * selection rows of their own, so the lookup falls back to the parent's rows by
+ * following each message's `forkSourceMessageId` back-pointer.
+ *
  * Selection rows are stored in selection order, so rendering them in row order
  * reproduces the block v3 would inject.
  */
 export async function getMemoryV3SelectionForInspectorByMessageIds(
   messageIds: string[],
 ): Promise<MemoryV3SelectionLog | null> {
-  return buildSelectionLog(rowsForMessageIds(messageIds));
+  const rows = rowsForMessageIds(messageIds);
+  return buildSelectionLog(
+    rows.length > 0 ? rows : rowsViaForkSource(messageIds),
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

- The LLM context inspector's **memory** tab was blank for turns inherited from a fork. `forkConversation` copies the parent's messages under fresh ids without copying their `memory_v3_selections` rows, and the inspector keys selections strictly by `message_id` (`getMemoryV3SelectionForInspectorByMessageIds` → `WHERE message_id IN (…)`).
- When the direct per-message lookup returns nothing, the inspector now falls back to the parent's rows by following each message's `forkSourceMessageId` back-pointer — a bounded walk that chains through forks of forks to the ancestor generation that actually logged the selections.
- Read-side only: **no DB migration**, no change to fork or retrieval write paths, and it fixes every existing fork immediately. Added unit coverage for single-hop, multi-hop, direct-hit-wins (native post-fork turn), and no-ancestor cases.

## Original prompt

Investigated why Velissa's "Romantic Banter (Fork)" conversation showed no memory-v3 injections for its first ~32 turns in the LLM context inspector's memory tab. Root-caused it to forking: the inherited turns' copied messages get new ids and their selection rows aren't carried over, while the inspector looks up selections purely by `message_id`. Chose the read-side fallback over copy-at-fork + migration to avoid the `(conversation_id, turn, slug)` primary-key collision and to fix existing forks with no data migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)