### PR TITLE
fix(assistant): hydrate conversation history before resolving meta slash commands

### DIFF
--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -157,6 +157,11 @@ export async function resolveMetaSlashCommand(
   }
   const conversation = await getOrCreateConversation(resolvedId);
   touchConversation(resolvedId);
+  // Hydrate persisted history before stripping/inspecting: a registry
+  // conversation the daemon holds but hasn't run a turn on can have an empty
+  // in-memory `messages` array, which would make `/clean` report 0 preserved
+  // and `/status` report 0 messages. Mirrors `processMessage`'s turn setup.
+  await conversation.ensureActorScopedHistory();
 
   const slashResult = await resolveSlash(
     command,


### PR DESCRIPTION
## Summary
- `resolveMetaSlashCommand` now calls `conversation.ensureActorScopedHistory()` before stripping/inspecting, so `/clean` and `/status` operate on the loaded message history. Previously, when the daemon held a registry `Conversation` that hadn't run a turn (e.g. created on client subscribe), `this.messages` was empty — so a second `/clean` on an already-cleaned conversation reported "0 reclaimed / 0 preserved" even though the conversation had messages on disk. Mirrors `processMessage`'s turn setup; the call loads when the scope is unhydrated and no-ops otherwise.

## Original prompt
Running `/clean` a second time on the same conversation showed "Tokens: 23,422 → 23,422 (0 reclaimed), Messages: 0 preserved", which is wrong — the conversation had 75 messages persisted. The new meta-command endpoint (#35127) resolved the conversation but never hydrated its in-memory history, unlike the message-send path which calls `ensureActorScopedHistory()` first, so `forceClean`/`buildSlashContext` saw an empty message array.