### PR TITLE
Add advisor tool as a first-party default plugin

### DIFF
--- a/assistant/src/config/call-site-defaults.ts
+++ b/assistant/src/config/call-site-defaults.ts
@@ -70,6 +70,14 @@ export const CALL_SITE_DEFAULTS: Record<LLMCallSite, CallSiteDefaultConfig> = {
   meetChatOpportunity: { profile: "cost-optimized" },
   inference: { profile: "cost-optimized" },
 
+  // The advisor consults a stronger model than the executor. Default to the
+  // strongest profile; users override via `llm.callSites.advisor.profile`. The
+  // resolver degrades gracefully if `quality-optimized` is absent on an install
+  // (falls back through the active profile to `llm.default`). Caching is off:
+  // the transcript grows each consult, so the prompt prefix rarely repeats
+  // within the cache TTL.
+  advisor: { profile: "quality-optimized", disableCache: true },
+
   heartbeatAgent: {
     profile: "cost-optimized",
   },

--- a/assistant/src/config/schemas/call-site-catalog.ts
+++ b/assistant/src/config/schemas/call-site-catalog.ts
@@ -300,6 +300,13 @@ const CATALOG_RECORD: CatalogRecord = {
     description: "General-purpose LLM inference call site for skill use.",
     domain: "skills",
   },
+  advisor: {
+    id: "advisor",
+    displayName: "Advisor",
+    description:
+      "Stronger-model strategic guidance consulted mid-task via the advisor tool.",
+    domain: "skills",
+  },
   homeGreeting: {
     id: "homeGreeting",
     displayName: "Home Greeting",

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -77,6 +77,7 @@ export const LLMCallSiteEnum = z.enum([
   "meetConsentMonitor",
   "meetChatOpportunity",
   "inference",
+  "advisor",
   "trustRuleSuggestion",
   "homeGreeting",
   "homeSuggestedPrompts",

--- a/assistant/src/plugins/defaults/advisor/__tests__/advisor-state-store.test.ts
+++ b/assistant/src/plugins/defaults/advisor/__tests__/advisor-state-store.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import type { Message } from "../../../../providers/types.js";
+import {
+  getCapture,
+  recordMessages,
+  recordSystemPrompt,
+  resetAdvisorStateForTests,
+  seedCapture,
+} from "../advisor-state-store.js";
+
+const userMsg = (t: string): Message => ({
+  role: "user",
+  content: [{ type: "text", text: t }],
+});
+
+afterEach(() => {
+  resetAdvisorStateForTests();
+});
+
+describe("advisor-state-store", () => {
+  test("records system prompt and messages independently per conversation", () => {
+    recordSystemPrompt("c1", "system A");
+    recordMessages("c1", [userMsg("hello")]);
+    recordSystemPrompt("c2", "system B");
+
+    expect(getCapture("c1")?.systemPrompt).toBe("system A");
+    expect(getCapture("c1")?.messages).toEqual([userMsg("hello")]);
+    expect(getCapture("c2")?.systemPrompt).toBe("system B");
+    expect(getCapture("c2")?.messages).toEqual([]);
+  });
+
+  test("seedCapture and recordMessages snapshot (copy) the array", () => {
+    const live: Message[] = [userMsg("one")];
+    seedCapture("c1", live);
+    live.push(userMsg("two")); // mutate after seeding
+
+    // The stored snapshot must not see the post-seed mutation.
+    expect(getCapture("c1")?.messages).toEqual([userMsg("one")]);
+  });
+
+  test("getCapture returns undefined for an unseen conversation", () => {
+    expect(getCapture("nope")).toBeUndefined();
+  });
+
+  test("resetAdvisorStateForTests clears everything", () => {
+    recordSystemPrompt("c1", "x");
+    resetAdvisorStateForTests();
+    expect(getCapture("c1")).toBeUndefined();
+  });
+});

--- a/assistant/src/plugins/defaults/advisor/__tests__/agent-loop-integration.test.ts
+++ b/assistant/src/plugins/defaults/advisor/__tests__/agent-loop-integration.test.ts
@@ -1,0 +1,203 @@
+/**
+ * End-to-end integration test: drives the REAL agent loop with all first-party
+ * defaults registered (so the advisor plugin's hooks + tool are live), and lets
+ * the REAL consult run. Only two boundaries are stubbed:
+ *   - the executor's provider HTTP boundary (a scripted mock provider), and
+ *   - `getConfiguredProvider`, so the advisor sub-call resolves to a second
+ *     scripted mock provider instead of a configured one.
+ *
+ * `runBtwSidechain` itself is NOT mocked — the advisor's inference genuinely
+ * runs through it against the injected advisor provider, exercising the full
+ * hook-capture → tool.execute → consult → routed-inference path through the
+ * loop, the way a live turn would (minus real model calls).
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  createMockProvider,
+  textResponse,
+} from "../../../../__tests__/helpers/mock-provider.js";
+import { AgentLoop } from "../../../../agent/loop.js";
+import type {
+  ContentBlock,
+  Message,
+  ProviderResponse,
+} from "../../../../providers/types.js";
+
+// ── Stub the advisor sub-call's provider resolution ─────────────────────────
+const ADVICE = "ADVICE: use a channel-based worker pool with graceful drain.";
+let advisorProvider: ReturnType<typeof createMockProvider> | null = null;
+
+// Import the real module first, then re-export it with only
+// `getConfiguredProvider` overridden, so every other export the loop and the
+// real `runBtwSidechain` rely on (userMessage, extractAllText, createTimeout…)
+// keeps working.
+const realProviderSendMessage =
+  await import("../../../../providers/provider-send-message.js");
+mock.module("../../../../providers/provider-send-message.js", () => ({
+  ...realProviderSendMessage,
+  getConfiguredProvider: async () => advisorProvider?.provider ?? null,
+}));
+
+// Imported AFTER the mock so the advisor plugin's `consult.ts` binds the
+// stubbed `getConfiguredProvider`.
+const { resetPluginRegistryAndRegisterDefaults } =
+  await import("../../index.js");
+const advisorTool = (await import("../tools/advisor.js")).default;
+
+const userTurn: Message = {
+  role: "user",
+  content: [{ type: "text", text: "build a worker pool" }],
+};
+
+function textOf(content: ReadonlyArray<ContentBlock>): string {
+  return content.map((b) => (b.type === "text" ? b.text : "")).join("");
+}
+
+describe("advisor — agent-loop integration", () => {
+  beforeEach(() => {
+    resetPluginRegistryAndRegisterDefaults();
+    advisorProvider = createMockProvider([textResponse(ADVICE)]);
+  });
+
+  test("model calls advisor → hooks capture the transcript → consult routes through Vellum → advice returns", async () => {
+    // The executor turn: emit some text, then call the no-arg advisor tool;
+    // after the tool result comes back, end with a final answer.
+    const consultThenText: ProviderResponse = {
+      content: [
+        { type: "text", text: "Let me consult the advisor." },
+        { type: "tool_use", id: "call-1", name: "advisor", input: {} },
+      ],
+      model: "mock-model",
+      usage: { inputTokens: 10, outputTokens: 5 },
+      stopReason: "tool_use",
+    };
+    const { provider } = createMockProvider([
+      consultThenText,
+      textResponse("Done — implemented the worker pool."),
+    ]);
+
+    const conversationId = "advisor-itest";
+    const loop = new AgentLoop({
+      provider,
+      systemPrompt: "You are a coding agent.",
+      conversationId,
+      // The loop only needs the provider-facing shape; execution is dispatched
+      // to the real `advisorTool.execute` via `toolExecutor` below.
+      tools: [
+        {
+          name: "advisor",
+          description: "",
+          input_schema: { type: "object", properties: {} },
+        },
+      ],
+      toolExecutor: async (name, input) =>
+        name === "advisor"
+          ? advisorTool.execute!(input, { conversationId } as never)
+          : { content: `unknown tool ${name}`, isError: true },
+    });
+
+    const { history } = await loop.run({
+      requestId: "req-1",
+      messages: [userTurn],
+      onEvent: () => {},
+      callSite: "mainAgent", // advisor hooks gate on this
+      trust: { sourceChannel: "vellum", trustClass: "unknown" },
+    });
+
+    // ── The advisor sub-call genuinely happened, routed through Vellum ──
+    expect(advisorProvider!.calls).toHaveLength(1);
+    const sub = advisorProvider!.calls[0];
+    expect(sub.options?.config?.callSite).toBe("advisor"); // dedicated call site
+    expect(sub.options?.tools).toEqual([]); // advisor runs tool-less
+    expect(sub.options?.config?.max_tokens).toBe(2048); // output cap
+
+    // ── The advisor saw the captured transcript (via the real post-model-call
+    //    hook through the loop), with the pending advisor tool_use stripped ──
+    expect(textOf(sub.messages[0].content)).toContain("build a worker pool");
+    expect(textOf(sub.messages[sub.messages.length - 1].content)).toContain(
+      "80 words",
+    ); // the word-limit nudge
+    const advisorTranscript = sub.messages
+      .map((m) => textOf(m.content))
+      .join("\n");
+    expect(advisorTranscript).not.toContain("call-1"); // no dangling tool_use leaked
+
+    // ── The advisor saw the executor's system prompt (via pre-model-call) ──
+    expect(sub.systemPrompt).toContain("senior technical advisor");
+    expect(sub.systemPrompt).toContain("You are a coding agent.");
+
+    // ── The advice flowed back into the executor's history as the tool result ──
+    const toolResult = history
+      .flatMap((m) => m.content)
+      .find((b) => b.type === "tool_result");
+    expect(toolResult).toBeDefined();
+    expect((toolResult as { content: string }).content).toContain(
+      "channel-based worker pool",
+    );
+
+    // ── The loop completed with the final answer ──
+    const lastAssistant = [...history]
+      .reverse()
+      .find((m) => m.role === "assistant")!;
+    expect(textOf(lastAssistant.content)).toContain(
+      "implemented the worker pool",
+    );
+  });
+
+  test("with no advisor provider resolvable, the tool soft-fails and the turn still completes", async () => {
+    advisorProvider = null; // getConfiguredProvider("advisor") → null
+
+    const consultThenText: ProviderResponse = {
+      content: [{ type: "tool_use", id: "call-1", name: "advisor", input: {} }],
+      model: "mock-model",
+      usage: { inputTokens: 10, outputTokens: 5 },
+      stopReason: "tool_use",
+    };
+    const { provider } = createMockProvider([
+      consultThenText,
+      textResponse("Proceeding without advice."),
+    ]);
+
+    const conversationId = "advisor-itest-soft";
+    const loop = new AgentLoop({
+      provider,
+      systemPrompt: "You are a coding agent.",
+      conversationId,
+      // The loop only needs the provider-facing shape; execution is dispatched
+      // to the real `advisorTool.execute` via `toolExecutor` below.
+      tools: [
+        {
+          name: "advisor",
+          description: "",
+          input_schema: { type: "object", properties: {} },
+        },
+      ],
+      toolExecutor: async (name, input) =>
+        advisorTool.execute!(input, { conversationId } as never),
+    });
+
+    const { history } = await loop.run({
+      requestId: "req-2",
+      messages: [userTurn],
+      onEvent: () => {},
+      callSite: "mainAgent",
+      trust: { sourceChannel: "vellum", trustClass: "unknown" },
+    });
+
+    // The advisor tool returned a benign (non-error) result...
+    const toolResult = history
+      .flatMap((m) => m.content)
+      .find((b) => b.type === "tool_result") as
+      | { content: string; is_error?: boolean }
+      | undefined;
+    expect(toolResult?.content).toContain("advisor unavailable");
+    // ...and the turn still ran to a clean end on the follow-up answer.
+    const lastAssistant = [...history]
+      .reverse()
+      .find((m) => m.role === "assistant")!;
+    expect(textOf(lastAssistant.content)).toContain(
+      "Proceeding without advice",
+    );
+  });
+});

--- a/assistant/src/plugins/defaults/advisor/__tests__/consult.test.ts
+++ b/assistant/src/plugins/defaults/advisor/__tests__/consult.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { Message } from "../../../../providers/types.js";
+
+// ── Mocks for the Vellum-routed inference boundary ──────────────────────────
+// The consult must route through `getConfiguredProvider` + `runBtwSidechain`
+// rather than create its own client; mocking both lets us assert exactly what
+// the advisor sub-call receives without a real provider or network.
+let providerResult: unknown = { name: "mock-advisor-provider" };
+let sidechainArgs: Record<string, unknown> | null = null;
+let sidechainText = "Use a channel-based worker pool; drain on shutdown.";
+let sidechainError: Error | null = null;
+
+// Spread the real module so non-overridden exports stay available when this
+// file shares a process with others (a single `bun test <dir>` invocation).
+const realProviderSendMessage =
+  await import("../../../../providers/provider-send-message.js");
+mock.module("../../../../providers/provider-send-message.js", () => ({
+  ...realProviderSendMessage,
+  getConfiguredProvider: async () => providerResult,
+}));
+mock.module("../../../../runtime/btw-sidechain.js", () => ({
+  runBtwSidechain: async (params: Record<string, unknown>) => {
+    sidechainArgs = params;
+    if (sidechainError) throw sidechainError;
+    return { text: sidechainText, hadTextDeltas: true, response: {} };
+  },
+}));
+
+const { consultAdvisor } = await import("../consult.js");
+const advisorTool = (await import("../tools/advisor.js")).default;
+const { recordSystemPrompt, recordMessages, resetAdvisorStateForTests } =
+  await import("../advisor-state-store.js");
+
+const userMsg = (t: string): Message => ({
+  role: "user",
+  content: [{ type: "text", text: t }],
+});
+
+beforeEach(() => {
+  providerResult = { name: "mock-advisor-provider" };
+  sidechainArgs = null;
+  sidechainText = "Use a channel-based worker pool; drain on shutdown.";
+  sidechainError = null;
+  resetAdvisorStateForTests();
+});
+
+describe("consultAdvisor", () => {
+  test("routes through the advisor call site, tools off, capped, and returns the advice", async () => {
+    const messages: Message[] = [
+      userMsg("build a worker pool"),
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "secret reasoning", signature: "s" },
+          { type: "text", text: "let me consult the advisor" },
+          { type: "tool_use", id: "t1", name: "advisor", input: {} },
+        ],
+      },
+    ];
+
+    const advice = await consultAdvisor({
+      systemPrompt: "You are a coding agent.",
+      messages,
+    });
+
+    expect(advice).toBe(sidechainText);
+    expect(sidechainArgs?.callSite).toBe("advisor");
+    expect(sidechainArgs?.tools).toEqual([]);
+    expect(sidechainArgs?.maxTokens).toBe(2048);
+
+    // Thinking dropped + the pending advisor tool_use stripped from the final turn.
+    expect(sidechainArgs?.messages).toEqual([
+      userMsg("build a worker pool"),
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "let me consult the advisor" }],
+      },
+    ]);
+
+    // Advisor system prompt frames the role and quotes the agent's system prompt.
+    expect(sidechainArgs?.systemPrompt).toContain("senior technical advisor");
+    expect(sidechainArgs?.systemPrompt).toContain("You are a coding agent.");
+
+    // The consult's user turn carries the soft word-limit nudge.
+    expect(sidechainArgs?.content).toContain("80 words");
+  });
+
+  test("soft-fails when no provider is configured", async () => {
+    providerResult = null;
+    const advice = await consultAdvisor({
+      systemPrompt: null,
+      messages: [userMsg("hi")],
+    });
+    expect(advice).toContain("no inference provider");
+  });
+
+  test("returns a notice when there is no usable transcript", async () => {
+    const advice = await consultAdvisor({ systemPrompt: null, messages: [] });
+    expect(advice).toContain("no conversation context");
+    expect(sidechainArgs).toBeNull(); // never reached the provider
+  });
+
+  test("falls back to a notice when the advisor returns blank text", async () => {
+    sidechainText = "   ";
+    const advice = await consultAdvisor({
+      systemPrompt: null,
+      messages: [userMsg("hi")],
+    });
+    expect(advice).toContain("no guidance");
+  });
+});
+
+describe("advisor tool.execute", () => {
+  test("reads the captured transcript and returns guidance as a non-error result", async () => {
+    recordSystemPrompt("c1", "You are a coding agent.");
+    recordMessages("c1", [userMsg("build a worker pool")]);
+
+    const result = await advisorTool.execute?.({}, {
+      conversationId: "c1",
+    } as never);
+
+    expect(result?.isError).toBe(false);
+    expect(result?.content).toBe(sidechainText);
+    expect(sidechainArgs?.callSite).toBe("advisor");
+  });
+
+  test("degrades to a benign result (never throws) when the consult fails", async () => {
+    recordMessages("c2", [userMsg("hi")]);
+    sidechainError = new Error("kaboom"); // the routed inference rejects
+
+    const result = await advisorTool.execute?.({}, {
+      conversationId: "c2",
+    } as never);
+
+    // The turn must not fail: a benign, non-error result is returned.
+    expect(result?.isError).toBe(false);
+    expect(result?.content).toContain("advisor unavailable");
+    expect(result?.content).toContain("kaboom");
+  });
+});

--- a/assistant/src/plugins/defaults/advisor/__tests__/hooks.test.ts
+++ b/assistant/src/plugins/defaults/advisor/__tests__/hooks.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type {
+  PostModelCallContext,
+  PreModelCallContext,
+  UserPromptSubmitContext,
+} from "@vellumai/plugin-api";
+
+import type { Message } from "../../../../providers/types.js";
+import {
+  getCapture,
+  resetAdvisorStateForTests,
+} from "../advisor-state-store.js";
+import postModelCall from "../hooks/post-model-call.js";
+import preModelCall from "../hooks/pre-model-call.js";
+import userPromptSubmit from "../hooks/user-prompt-submit.js";
+import { STEERING_MARKER } from "../steering.js";
+
+const logger = {
+  info() {},
+  warn() {},
+  error() {},
+  debug() {},
+};
+
+const userMsg = (t: string): Message => ({
+  role: "user",
+  content: [{ type: "text", text: t }],
+});
+
+beforeEach(() => {
+  resetAdvisorStateForTests();
+});
+
+describe("pre-model-call hook", () => {
+  test("records the original system prompt and injects steering on mainAgent", async () => {
+    const ctx = {
+      conversationId: "c1",
+      callSite: "mainAgent",
+      systemPrompt: "BASE PROMPT",
+      deferAssistantOutput: false,
+      logger,
+    } as unknown as PreModelCallContext;
+
+    await preModelCall(ctx);
+
+    // Steering appended to what the model sees...
+    expect(ctx.systemPrompt).toContain(STEERING_MARKER);
+    expect(ctx.systemPrompt?.startsWith("BASE PROMPT")).toBe(true);
+    // ...but the *recorded* prompt is the original (steering stripped).
+    expect(getCapture("c1")?.systemPrompt).toBe("BASE PROMPT");
+  });
+
+  test("is idempotent within a turn (no double steering)", async () => {
+    const ctx = {
+      conversationId: "c1",
+      callSite: "mainAgent",
+      systemPrompt: "BASE",
+      deferAssistantOutput: false,
+      logger,
+    } as unknown as PreModelCallContext;
+
+    await preModelCall(ctx);
+    const afterFirst = ctx.systemPrompt;
+    await preModelCall(ctx); // second provider call, same turn
+    expect(ctx.systemPrompt).toBe(afterFirst);
+    expect(getCapture("c1")?.systemPrompt).toBe("BASE");
+  });
+
+  test("ignores non-mainAgent calls (no capture, no mutation)", async () => {
+    const ctx = {
+      conversationId: "bg",
+      callSite: "compactionAgent",
+      systemPrompt: "BG",
+      deferAssistantOutput: false,
+      logger,
+    } as unknown as PreModelCallContext;
+
+    await preModelCall(ctx);
+    expect(ctx.systemPrompt).toBe("BG");
+    expect(getCapture("bg")).toBeUndefined();
+  });
+});
+
+describe("post-model-call hook", () => {
+  const base = {
+    content: [],
+    stopReason: "end_turn",
+    decision: "stop" as const,
+    logger,
+  };
+
+  test("snapshots the transcript on mainAgent", async () => {
+    const messages = [userMsg("hi")];
+    await postModelCall({
+      ...base,
+      conversationId: "c1",
+      callSite: "mainAgent",
+      messages,
+    } as unknown as PostModelCallContext);
+    expect(getCapture("c1")?.messages).toEqual(messages);
+  });
+
+  test("ignores provider-rejection outcomes", async () => {
+    await postModelCall({
+      ...base,
+      conversationId: "c2",
+      callSite: "mainAgent",
+      messages: [userMsg("hi")],
+      error: new Error("boom"),
+      stopReason: null,
+    } as unknown as PostModelCallContext);
+    expect(getCapture("c2")).toBeUndefined();
+  });
+
+  test("ignores the advisor's own sub-call (recursion safety) and other call sites", async () => {
+    for (const callSite of ["advisor", "subagentSpawn", "conversationTitle"]) {
+      await postModelCall({
+        ...base,
+        conversationId: `cs-${callSite}`,
+        callSite,
+        messages: [userMsg("hi")],
+      } as unknown as PostModelCallContext);
+      expect(getCapture(`cs-${callSite}`)).toBeUndefined();
+    }
+  });
+});
+
+describe("user-prompt-submit hook", () => {
+  test("seeds the capture with the inbound history", async () => {
+    const messages = [userMsg("task")];
+    await userPromptSubmit({
+      conversationId: "c1",
+      latestMessages: messages,
+      originalMessages: messages,
+      prompt: "task",
+      userMessageId: "u1",
+      requestId: "r1",
+      modelProfileKey: null,
+      isNonInteractive: false,
+      logger,
+    } as unknown as UserPromptSubmitContext);
+    expect(getCapture("c1")?.messages).toEqual(messages);
+  });
+});

--- a/assistant/src/plugins/defaults/advisor/__tests__/registration.test.ts
+++ b/assistant/src/plugins/defaults/advisor/__tests__/registration.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, mock, test } from "bun:test";
+
+// Importing the advisor tool transitively loads `consult.ts`, which imports the
+// Vellum inference boundary. Mock that boundary so this test exercises only the
+// tool-registration mechanism (no provider/network).
+const realProviderSendMessage =
+  await import("../../../../providers/provider-send-message.js");
+mock.module("../../../../providers/provider-send-message.js", () => ({
+  ...realProviderSendMessage,
+  getConfiguredProvider: async () => null,
+}));
+mock.module("../../../../runtime/btw-sidechain.js", () => ({
+  runBtwSidechain: async () => ({
+    text: "",
+    hadTextDeltas: false,
+    response: {},
+  }),
+}));
+
+const { finalizeTool } = await import("../../../../tools/tool-defaults.js");
+const { registerPluginTools, getTool, unregisterPluginTools } =
+  await import("../../../../tools/registry.js");
+const advisorTool = (await import("../tools/advisor.js")).default;
+
+describe("advisor tool registration", () => {
+  test("the finalized advisor tool registers into the model-visible catalog", () => {
+    // Mirrors what `bootstrapPlugins` does with a default plugin's `tools[]`.
+    registerPluginTools("default-advisor", [
+      finalizeTool(advisorTool, "advisor"),
+    ]);
+    try {
+      const tool = getTool("advisor");
+      expect(tool).toBeDefined();
+      expect(tool?.name).toBe("advisor");
+      // Plugin tools are stamped with the "plugin" category by the registry.
+      expect(tool?.category).toBe("plugin");
+      // No-arg tool: empty object schema.
+      expect(tool?.input_schema).toEqual({
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      });
+      expect(typeof tool?.execute).toBe("function");
+    } finally {
+      unregisterPluginTools("default-advisor");
+    }
+    expect(getTool("advisor")).toBeUndefined();
+  });
+});

--- a/assistant/src/plugins/defaults/advisor/__tests__/transcript.test.ts
+++ b/assistant/src/plugins/defaults/advisor/__tests__/transcript.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ContentBlock, Message } from "../../../../providers/types.js";
+import { toAdvisorMessages } from "../transcript.js";
+
+const text = (t: string): ContentBlock => ({ type: "text", text: t });
+
+describe("toAdvisorMessages", () => {
+  test("drops thinking and redacted-thinking blocks", () => {
+    const messages: Message[] = [
+      { role: "user", content: [text("do the task")] },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "secret", signature: "sig" },
+          { type: "redacted_thinking", data: "blob" },
+          text("here is my answer"),
+        ],
+      },
+    ];
+
+    const out = toAdvisorMessages(messages);
+    expect(out).toHaveLength(2);
+    expect(out[1].content).toEqual([text("here is my answer")]);
+  });
+
+  test("strips the pending advisor (and sibling) tool_use from the final assistant turn", () => {
+    const messages: Message[] = [
+      { role: "user", content: [text("task")] },
+      {
+        role: "assistant",
+        content: [
+          text("let me consult the advisor"),
+          { type: "tool_use", id: "t1", name: "advisor", input: {} },
+          { type: "tool_use", id: "t2", name: "bash", input: { cmd: "ls" } },
+        ],
+      },
+    ];
+
+    const out = toAdvisorMessages(messages);
+    // Pending tool calls (no results yet) removed; explanatory text kept.
+    expect(out[1].content).toEqual([text("let me consult the advisor")]);
+  });
+
+  test("preserves completed tool_use / tool_result pairs in earlier turns", () => {
+    const messages: Message[] = [
+      { role: "user", content: [text("task")] },
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "a", name: "bash", input: {} }],
+      },
+      {
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: "a", content: "output" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          text("done thinking"),
+          { type: "server_tool_use", id: "b", name: "advisor", input: {} },
+        ],
+      },
+    ];
+
+    const out = toAdvisorMessages(messages);
+    // The earlier tool_use and its tool_result survive...
+    expect(out[1].content[0]).toEqual({
+      type: "tool_use",
+      id: "a",
+      name: "bash",
+      input: {},
+    });
+    expect(out[2].content[0]).toEqual({
+      type: "tool_result",
+      tool_use_id: "a",
+      content: "output",
+    });
+    // ...while the final pending advisor call is stripped, leaving only text.
+    expect(out[3].content).toEqual([text("done thinking")]);
+  });
+
+  test("drops messages that become empty after sanitizing", () => {
+    const messages: Message[] = [
+      { role: "user", content: [text("task")] },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "image",
+            source: { type: "base64", media_type: "image/png", data: "x" },
+          },
+        ],
+      },
+    ];
+
+    const out = toAdvisorMessages(messages);
+    expect(out).toHaveLength(1);
+    expect(out[0].content).toEqual([text("task")]);
+  });
+
+  test("strips rich contentBlocks from tool_result, keeping the text payload", () => {
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "a",
+            content: "text payload",
+            contentBlocks: [
+              {
+                type: "image",
+                source: { type: "base64", media_type: "image/png", data: "x" },
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const out = toAdvisorMessages(messages);
+    expect(out[0].content[0]).toEqual({
+      type: "tool_result",
+      tool_use_id: "a",
+      content: "text payload",
+      contentBlocks: undefined,
+    });
+  });
+});

--- a/assistant/src/plugins/defaults/advisor/advisor-state-store.ts
+++ b/assistant/src/plugins/defaults/advisor/advisor-state-store.ts
@@ -1,0 +1,97 @@
+/**
+ * Per-conversation capture store for the advisor plugin.
+ *
+ * A tool's `execute` does not receive the conversation transcript — only
+ * lifecycle hooks do. So the hooks snapshot what the executor saw (the system
+ * prompt from `pre-model-call`, the running transcript from `post-model-call`)
+ * into this module-level store, keyed by conversation id, and the `advisor`
+ * tool reads the latest snapshot when the model calls it. This reproduces the
+ * advisor-tool property that the executor calls the tool with no arguments and
+ * the full context is supplied for it.
+ *
+ * Files under a default plugin are part of the assistant's own module graph, so
+ * this singleton map is shared between the hooks and the tool. It is bounded by
+ * a small LRU so a long-lived daemon does not accumulate state for every
+ * conversation it has ever served.
+ */
+
+import type { Message } from "../../../providers/types.js";
+
+export interface AdvisorCapture {
+  /** The executor's system prompt (steering stripped), or null if unseen. */
+  systemPrompt: string | null;
+  /** The transcript the executor most recently saw on a `mainAgent` call. */
+  messages: Message[];
+  /** Last-write timestamp, used for LRU eviction. */
+  updatedAt: number;
+}
+
+const MAX_CONVERSATIONS = 200;
+const store = new Map<string, AdvisorCapture>();
+
+/** Move an entry to most-recently-used and evict the oldest past the cap. */
+function bump(conversationId: string, entry: AdvisorCapture): void {
+  entry.updatedAt = Date.now();
+  // Re-insert so the key moves to the end of the Map's insertion order.
+  store.delete(conversationId);
+  store.set(conversationId, entry);
+  while (store.size > MAX_CONVERSATIONS) {
+    const oldest = store.keys().next().value;
+    if (oldest === undefined) break;
+    store.delete(oldest);
+  }
+}
+
+function ensure(conversationId: string): AdvisorCapture {
+  return (
+    store.get(conversationId) ?? {
+      systemPrompt: null,
+      messages: [],
+      updatedAt: Date.now(),
+    }
+  );
+}
+
+/**
+ * Seed the capture at the start of a user turn with the inbound history, so an
+ * advisor call on the very first model turn still has context even before
+ * `post-model-call` snapshots the running transcript.
+ */
+export function seedCapture(
+  conversationId: string,
+  messages: ReadonlyArray<Message>,
+): void {
+  const entry = ensure(conversationId);
+  entry.messages = [...messages];
+  bump(conversationId, entry);
+}
+
+/** Record the executor's system prompt (steering already stripped). */
+export function recordSystemPrompt(
+  conversationId: string,
+  systemPrompt: string | null,
+): void {
+  const entry = ensure(conversationId);
+  entry.systemPrompt = systemPrompt;
+  bump(conversationId, entry);
+}
+
+/** Snapshot the transcript the executor just saw (before tools run). */
+export function recordMessages(
+  conversationId: string,
+  messages: ReadonlyArray<Message>,
+): void {
+  const entry = ensure(conversationId);
+  entry.messages = [...messages];
+  bump(conversationId, entry);
+}
+
+/** The latest capture for a conversation, or `undefined` if none recorded. */
+export function getCapture(conversationId: string): AdvisorCapture | undefined {
+  return store.get(conversationId);
+}
+
+/** Test-only: clear all captured state. Mirrors the peer default stores. */
+export function resetAdvisorStateForTests(): void {
+  store.clear();
+}

--- a/assistant/src/plugins/defaults/advisor/config.ts
+++ b/assistant/src/plugins/defaults/advisor/config.ts
@@ -1,0 +1,33 @@
+/**
+ * Static behavioral configuration for the advisor plugin.
+ *
+ * The advisor *model* is NOT configured here. It is selected exactly like any
+ * other LLM call site — via the `advisor` entry in the profile config
+ * (`config/call-site-defaults.ts`, default profile `quality-optimized`, and the
+ * user-overridable `llm.callSites.advisor.profile`). Switching the advisor's
+ * model is therefore the same one-step profile selection a user already makes
+ * for the base assistant, with no extra setup and no separate API key.
+ *
+ * These constants only tune the plugin's own behavior around that call.
+ */
+export const ADVISOR_CONFIG = {
+  /**
+   * Hard cap on advisor output tokens per consult. Mirrors `max_tokens` on
+   * Anthropic's advisor tool definition; the recommended starting point is
+   * 2048 (their docs report a ~7x output reduction with near-zero truncation).
+   * The provider floor is 1024.
+   */
+  maxTokens: 2048,
+  /**
+   * Soft word budget requested of the advisor in the consult prompt, biasing it
+   * toward a focused starting point rather than a comprehensive plan.
+   */
+  wordLimit: 80,
+  /** Abort the consult if the advisor sub-call runs longer than this. */
+  timeoutMs: 60_000,
+  /**
+   * Inject the "call advisor before substantive work" steering into the
+   * executor's system prompt so the model actually reaches for the tool.
+   */
+  steeringEnabled: true,
+} as const;

--- a/assistant/src/plugins/defaults/advisor/consult.ts
+++ b/assistant/src/plugins/defaults/advisor/consult.ts
@@ -1,0 +1,60 @@
+/**
+ * Run one advisor consult.
+ *
+ * Routed entirely through Vellum's own inference: `getConfiguredProvider`
+ * resolves the `advisor` call site to a provider/model/credentials from the
+ * configured profiles (managed-proxy or BYOK alike — no separate API key), and
+ * `runBtwSidechain` runs an ephemeral, non-persisted completion with tools
+ * forced off. The advisor therefore sees the executor's transcript and system
+ * prompt, runs tool-less, and returns plain guidance text — mirroring the
+ * advisor tool's sub-inference.
+ */
+
+import { getConfiguredProvider } from "../../../providers/provider-send-message.js";
+import type { Message } from "../../../providers/types.js";
+import { runBtwSidechain } from "../../../runtime/btw-sidechain.js";
+import { ADVISOR_CONFIG } from "./config.js";
+import { advisorRequestText, buildAdvisorSystem } from "./steering.js";
+import { toAdvisorMessages } from "./transcript.js";
+
+/** The dedicated call site whose configured profile selects the advisor model. */
+const ADVISOR_CALL_SITE = "advisor" as const;
+
+export interface ConsultParams {
+  systemPrompt: string | null;
+  messages: ReadonlyArray<Message>;
+  signal?: AbortSignal;
+}
+
+/**
+ * Returns the advisor's guidance text, or a short benign notice when the
+ * advisor can't run. Callers should surface the string as a non-error tool
+ * result so the executor continues regardless — matching the advisor tool's
+ * "the executor sees the error and continues; the request does not fail."
+ */
+export async function consultAdvisor(params: ConsultParams): Promise<string> {
+  const messages = toAdvisorMessages(params.messages);
+  if (messages.length === 0) {
+    return "(advisor: no conversation context is available yet)";
+  }
+
+  const provider = await getConfiguredProvider(ADVISOR_CALL_SITE);
+  if (!provider) {
+    return "(advisor unavailable: no inference provider is configured)";
+  }
+
+  const { text } = await runBtwSidechain({
+    provider,
+    messages,
+    content: advisorRequestText(ADVISOR_CONFIG.wordLimit),
+    systemPrompt: buildAdvisorSystem(params.systemPrompt),
+    callSite: ADVISOR_CALL_SITE,
+    tools: [],
+    maxTokens: ADVISOR_CONFIG.maxTokens,
+    timeoutMs: ADVISOR_CONFIG.timeoutMs,
+    signal: params.signal,
+  });
+
+  const advice = text.trim();
+  return advice.length > 0 ? advice : "(advisor returned no guidance)";
+}

--- a/assistant/src/plugins/defaults/advisor/hooks/post-model-call.ts
+++ b/assistant/src/plugins/defaults/advisor/hooks/post-model-call.ts
@@ -1,0 +1,24 @@
+/**
+ * `post-model-call` hook for the advisor plugin.
+ *
+ * Snapshots the transcript the executor just saw. This fires after the model
+ * returns its message (which may carry the `advisor` tool_use) but before the
+ * tools run, so when `advisor.execute()` runs an instant later it reads exactly
+ * this snapshot — the analogue of the platform forwarding the full transcript.
+ *
+ * Pure observer: it never mutates `content` or the continue/stop `decision`.
+ * Gated to the user-facing reply so background/subagent/compaction calls — and
+ * the advisor's own `advisor`-call-site sub-inference — are ignored.
+ */
+
+import type { PluginHookFn, PostModelCallContext } from "@vellumai/plugin-api";
+
+import { recordMessages } from "../advisor-state-store.js";
+
+const postModelCall: PluginHookFn<PostModelCallContext> = async (ctx) => {
+  if (ctx.callSite !== "mainAgent") return;
+  if (ctx.error) return;
+  recordMessages(ctx.conversationId, ctx.messages);
+};
+
+export default postModelCall;

--- a/assistant/src/plugins/defaults/advisor/hooks/pre-model-call.ts
+++ b/assistant/src/plugins/defaults/advisor/hooks/pre-model-call.ts
@@ -1,0 +1,28 @@
+/**
+ * `pre-model-call` hook for the advisor plugin.
+ *
+ * Two jobs, only for the user-facing reply (`mainAgent`):
+ *  1. Capture the executor's system prompt (steering stripped) so the advisor
+ *     can be given it as context.
+ *  2. Inject the advisor steering block so the model reaches for the tool at
+ *     the right times. Idempotent via the steering marker.
+ */
+
+import type { PluginHookFn, PreModelCallContext } from "@vellumai/plugin-api";
+
+import { recordSystemPrompt } from "../advisor-state-store.js";
+import { ADVISOR_CONFIG } from "../config.js";
+import { appendSteering, stripSteering } from "../steering.js";
+
+const preModelCall: PluginHookFn<PreModelCallContext> = async (ctx) => {
+  if (ctx.callSite !== "mainAgent") return;
+
+  // Record the original prompt (without our steering) for the advisor's view.
+  recordSystemPrompt(ctx.conversationId, stripSteering(ctx.systemPrompt));
+
+  if (ADVISOR_CONFIG.steeringEnabled) {
+    ctx.systemPrompt = appendSteering(ctx.systemPrompt);
+  }
+};
+
+export default preModelCall;

--- a/assistant/src/plugins/defaults/advisor/hooks/user-prompt-submit.ts
+++ b/assistant/src/plugins/defaults/advisor/hooks/user-prompt-submit.ts
@@ -1,0 +1,20 @@
+/**
+ * `user-prompt-submit` hook for the advisor plugin.
+ *
+ * Seeds the per-conversation capture at the start of a user turn with the
+ * inbound history, so an advisor call on the very first model turn still has
+ * context even before `post-model-call` snapshots the running transcript.
+ */
+
+import type {
+  PluginHookFn,
+  UserPromptSubmitContext,
+} from "@vellumai/plugin-api";
+
+import { seedCapture } from "../advisor-state-store.js";
+
+const userPromptSubmit: PluginHookFn<UserPromptSubmitContext> = async (ctx) => {
+  seedCapture(ctx.conversationId, ctx.latestMessages);
+};
+
+export default userPromptSubmit;

--- a/assistant/src/plugins/defaults/advisor/package.json
+++ b/assistant/src/plugins/defaults/advisor/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "default-advisor",
+  "version": "1.0.0",
+  "description": "First-party default plugin that adds an `advisor` tool: a no-argument tool the model calls to consult a stronger inference profile on the full conversation transcript for strategic guidance. Imitates Anthropic's advisor tool, routed through Vellum's own inference (no separate API key).",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "engines": {
+    "node": ">=20.12.0"
+  },
+  "peerDependencies": {
+    "@vellumai/plugin-api": "^0.8.0"
+  }
+}

--- a/assistant/src/plugins/defaults/advisor/steering.ts
+++ b/assistant/src/plugins/defaults/advisor/steering.ts
@@ -1,0 +1,52 @@
+/**
+ * Prompt fragments for the advisor plugin:
+ *  - `appendSteering` / `stripSteering` — the executor-facing steering block the
+ *    `pre-model-call` hook injects so the model reaches for the advisor tool at
+ *    the right times (modeled on the advisor-tool docs' suggested system prompt).
+ *  - `buildAdvisorSystem` / `advisorRequestText` — the advisor-facing framing for
+ *    the consult itself.
+ */
+
+/** Idempotency marker; the steering block is appended at the end of the prompt. */
+export const STEERING_MARKER = "<!-- advisor:steering -->";
+
+const STEERING_BODY = `You have an \`advisor\` tool backed by a stronger reviewer model. It takes NO parameters — calling it forwards your entire conversation automatically (the task, every tool call, every result). Call advisor BEFORE substantive work — before writing, before committing to an interpretation, before building on an assumption. Orientation (reading files, fetching a source) is not substantive work; do that first, then call advisor. Also call it when stuck, when changing approach, and once before you declare the task done. Give its guidance serious weight; only override it when primary-source evidence contradicts a specific claim, and say so when you do.`;
+
+const ADVISOR_STEERING = `${STEERING_MARKER}\n${STEERING_BODY}`;
+
+/** Append the steering block to the executor's system prompt (idempotent). */
+export function appendSteering(systemPrompt: string | null): string | null {
+  if (systemPrompt === null) return null;
+  if (systemPrompt.includes(STEERING_MARKER)) return systemPrompt;
+  return `${systemPrompt}\n\n${ADVISOR_STEERING}`;
+}
+
+/** Remove a previously-appended steering block, recovering the original prompt. */
+export function stripSteering(systemPrompt: string | null): string | null {
+  if (systemPrompt === null) return null;
+  const idx = systemPrompt.indexOf(STEERING_MARKER);
+  if (idx === -1) return systemPrompt;
+  return systemPrompt.slice(0, idx).trimEnd();
+}
+
+/**
+ * System prompt for the advisor sub-call. Frames the advisor's role and, for
+ * context, quotes the executor's own system prompt (as the advisor tool does —
+ * the advisor sees the system prompt as context about the executor's task).
+ */
+export function buildAdvisorSystem(
+  originalSystemPrompt: string | null,
+): string {
+  const base = `You are a senior technical advisor consulted by another AI agent partway through a task. You can see the agent's full conversation above: its task, every tool call it has made, and every result it has seen. Give concise, high-leverage strategic guidance — the right approach, the key risk or failure mode to avoid, and the single most important next step. Do not role-play as the agent or produce its final deliverable; advise it. If the agent is already on track, say so briefly and sharpen its plan.`;
+  if (!originalSystemPrompt) return base;
+  return `${base}\n\nFor context, the agent is operating under this system prompt:\n<agent_system_prompt>\n${originalSystemPrompt}\n</agent_system_prompt>`;
+}
+
+/**
+ * The final user turn appended to the transcript for the advisor sub-call. Asks
+ * for guidance and carries the soft word-limit nudge (the advisor-tool docs'
+ * most effective placement is addressed to the advisor in the user turn).
+ */
+export function advisorRequestText(wordLimit: number): string {
+  return `Review the conversation above — the task, the tool calls, and their results — and give focused strategic guidance on how to proceed. (Advisor: keep your guidance under ~${wordLimit} words — a focused starting point, not a comprehensive plan.)`;
+}

--- a/assistant/src/plugins/defaults/advisor/tools/advisor.ts
+++ b/assistant/src/plugins/defaults/advisor/tools/advisor.ts
@@ -1,0 +1,51 @@
+/**
+ * The `advisor` tool — a no-argument tool the model calls to consult a stronger
+ * model for strategic guidance. The model supplies no input; the plugin reads
+ * the transcript captured by the lifecycle hooks and runs the consult.
+ *
+ * Default export = the tool definition. `defaults/index.ts` finalizes it and
+ * attaches it to the advisor plugin's `tools` array, which `bootstrapPlugins`
+ * registers into the model-visible tool catalog like any plugin tool.
+ */
+
+import type {
+  ToolContext,
+  ToolDefinition,
+  ToolExecutionResult,
+} from "@vellumai/plugin-api";
+import { RiskLevel } from "@vellumai/plugin-api";
+
+import { getCapture } from "../advisor-state-store.js";
+import { consultAdvisor } from "../consult.js";
+
+const advisorTool: ToolDefinition = {
+  name: "advisor",
+  description:
+    "Consult a stronger advisor model for strategic guidance. Takes NO parameters — your " +
+    "full conversation (the task, every tool call, and every result) is forwarded " +
+    "automatically. Call it before substantive work, when you're stuck, when changing " +
+    "approach, and once before declaring a task complete.",
+  input_schema: { type: "object", properties: {}, additionalProperties: false },
+  // Read-only advice; low risk so the consult isn't gated behind a prompt.
+  defaultRiskLevel: RiskLevel.Low,
+  async execute(
+    _input: Record<string, unknown>,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    try {
+      const capture = getCapture(ctx.conversationId);
+      const advice = await consultAdvisor({
+        systemPrompt: capture?.systemPrompt ?? null,
+        messages: capture?.messages ?? [],
+        signal: ctx.signal,
+      });
+      return { content: advice, isError: false };
+    } catch (err) {
+      // Degrade like the advisor tool: never fail the turn over a consult.
+      const reason = err instanceof Error ? err.message : String(err);
+      return { content: `(advisor unavailable: ${reason})`, isError: false };
+    }
+  },
+};
+
+export default advisorTool;

--- a/assistant/src/plugins/defaults/advisor/transcript.ts
+++ b/assistant/src/plugins/defaults/advisor/transcript.ts
@@ -1,0 +1,61 @@
+/**
+ * Convert a captured executor transcript into the message list sent to the
+ * advisor sub-call.
+ *
+ * Two jobs:
+ *  1. Strip blocks the advisor shouldn't (or can't) replay — thinking and
+ *     redacted-thinking (the advisor tool drops thinking), images/files (keep
+ *     the consult text-only and provider-agnostic), and opaque web-search
+ *     results. Rich/nested blocks on a `tool_result` are dropped, keeping its
+ *     text payload.
+ *  2. Strip the *pending* tool calls from the final assistant turn. At capture
+ *     time (a `post-model-call` before tools run) the last assistant message
+ *     carries the `advisor` tool_use — and possibly sibling tool_use blocks —
+ *     with no matching `tool_result` yet. Sending a dangling tool_use would be
+ *     rejected by the provider, so those blocks are removed; earlier,
+ *     already-completed tool_use/tool_result pairs are preserved intact.
+ */
+
+import type { ContentBlock, Message } from "../../../providers/types.js";
+
+/** Drop disallowed blocks; thin out rich tool_result content. `null` = drop. */
+function sanitize(block: ContentBlock): ContentBlock | null {
+  switch (block.type) {
+    case "thinking":
+    case "redacted_thinking":
+    case "image":
+    case "file":
+    case "web_search_tool_result":
+      return null;
+    case "tool_result":
+      // Keep the text payload; drop nested rich blocks (e.g. images).
+      return block.contentBlocks
+        ? { ...block, contentBlocks: undefined }
+        : block;
+    default:
+      return block;
+  }
+}
+
+export function toAdvisorMessages(messages: ReadonlyArray<Message>): Message[] {
+  const out: Message[] = [];
+  const lastIndex = messages.length - 1;
+
+  messages.forEach((message, index) => {
+    let content = message.content
+      .map(sanitize)
+      .filter((b): b is ContentBlock => b !== null);
+
+    // The final assistant turn's tool calls have no results yet — drop them so
+    // we never send a dangling tool_use.
+    if (index === lastIndex && message.role === "assistant") {
+      content = content.filter(
+        (b) => b.type !== "tool_use" && b.type !== "server_tool_use",
+      );
+    }
+
+    if (content.length > 0) out.push({ role: message.role, content });
+  });
+
+  return out;
+}

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -24,8 +24,15 @@
  * {@link registerDefaultPlugins} at call time.
  */
 
+import { finalizeTool } from "../../tools/tool-defaults.js";
 import { registerPlugin, resetPluginRegistryForTests } from "../registry.js";
 import { type Plugin, PluginExecutionError } from "../types.js";
+import { resetAdvisorStateForTests } from "./advisor/advisor-state-store.js";
+import advisorPostModelCall from "./advisor/hooks/post-model-call.js";
+import advisorPreModelCall from "./advisor/hooks/pre-model-call.js";
+import advisorUserPromptSubmit from "./advisor/hooks/user-prompt-submit.js";
+import advisorPkg from "./advisor/package.json" with { type: "json" };
+import advisorTool from "./advisor/tools/advisor.js";
 import compactionPkg from "./compaction/package.json" with { type: "json" };
 import emptyResponsePostModelCall from "./empty-response/hooks/post-model-call.js";
 import emptyResponseStop from "./empty-response/hooks/stop.js";
@@ -298,6 +305,30 @@ export const defaultToolResultTruncatePlugin: Plugin = {
 };
 
 /**
+ * `advisor` — adds the model-visible `advisor` tool: a no-argument tool the
+ * model calls to consult a stronger inference profile (the `advisor` call
+ * site, default `quality-optimized`) on the full transcript, routed through
+ * the assistant's own inference. Three hooks feed it: `user-prompt-submit`
+ * seeds the capture, `pre-model-call` records the executor's system prompt and
+ * injects the steering that nudges the model to consult, and `post-model-call`
+ * snapshots the transcript the tool reads. This is the first default plugin to
+ * contribute a model-visible tool — `finalizeTool` fills the tool's defaults so
+ * it satisfies `Tool`, and `bootstrapPlugins` registers it into the catalog.
+ */
+export const defaultAdvisorPlugin: Plugin = {
+  manifest: {
+    name: advisorPkg.name,
+    version: advisorPkg.version,
+  },
+  hooks: {
+    "user-prompt-submit": advisorUserPromptSubmit,
+    "pre-model-call": advisorPreModelCall,
+    "post-model-call": advisorPostModelCall,
+  },
+  tools: [finalizeTool(advisorTool, "advisor")],
+};
+
+/**
  * Full set of first-party default plugins. Used by
  * {@link registerDefaultPlugins} to drive the registration loop; the array
  * order is the registration order, which fixes hook-chain order (defaults run
@@ -318,6 +349,9 @@ function getAllDefaultPlugins(): readonly Plugin[] {
     defaultCompactionPlugin,
     defaultTitleGeneratePlugin,
     memoryV3ShadowPlugin,
+    // Registered last so its capture hooks observe the fully-processed turn
+    // (memory injections, history repair) that the executor actually sees.
+    defaultAdvisorPlugin,
   ];
 }
 
@@ -364,5 +398,6 @@ export function resetPluginRegistryAndRegisterDefaults(): void {
   resetExplorationDriftStateForTests();
   resetTaskProgressNudgeStateForTests();
   resetSurfaceCompletionNudgeStoreForTests();
+  resetAdvisorStateForTests();
   registerDefaultPlugins();
 }


### PR DESCRIPTION
## What

Adds an **`advisor` tool** — a no-argument tool the model can call mid-task to consult a stronger model for strategic guidance, imitating [Anthropic's advisor tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/advisor-tool). When the executor calls `advisor()`, the plugin forwards the full conversation transcript to a stronger inference profile and returns concise guidance the executor continues from.

It's a **first-party default plugin** (`assistant/src/plugins/defaults/advisor/`) so the consult routes through the assistant's own inference — **no separate API key**. The advisor model is chosen the same way as any call site: a new `advisor` call site whose profile defaults to `quality-optimized` and is overridable via `llm.callSites.advisor.profile`.

## How it works

The tool's `execute` can't see the transcript (a `ToolContext` carries no messages), so lifecycle hooks capture it:

- **`hooks/post-model-call.ts`** snapshots the transcript the executor saw (fires before tools run), keyed by conversation.
- **`hooks/pre-model-call.ts`** captures the executor's system prompt and injects steering that nudges the model to consult.
- **`hooks/user-prompt-submit.ts`** seeds the capture at turn start.
- **`tools/advisor.ts`** — the no-arg tool; reads the capture and runs the consult.
- **`consult.ts`** routes through `getConfiguredProvider("advisor")` → `runBtwSidechain` (tools off, `max_tokens` 2048). It **soft-fails** (never throws), so a consult never fails the turn — matching the advisor tool's degrade-and-continue behavior.
- **`transcript.ts`** sanitizes the transcript for the advisor (drops thinking/images, strips the pending `advisor` tool_use so there's no dangling call).

The advisor sub-call uses call site `advisor` with tools forced off, and the capture hooks gate on `mainAgent`, so the advisor can't recursively call itself.

This is the **first default plugin to contribute a model-visible tool**; `bootstrapPlugins` already registers a default's `Plugin.tools[]` into the catalog, so no loader change was needed.

## Core changes (besides the new plugin dir)

- `config/schemas/llm.ts` — add `advisor` to `LLMCallSiteEnum`.
- `config/schemas/call-site-catalog.ts` + `config/call-site-defaults.ts` — the `advisor` call site (default profile `quality-optimized`, caching off). Both are exhaustive over the enum, so these are compile-required.
- `plugins/defaults/index.ts` — register `defaultAdvisorPlugin`.

## Tests

`assistant/src/plugins/defaults/advisor/__tests__/` (25 tests, all green; lint + `tsc` clean):

- transcript sanitizing, state-store, hooks (incl. recursion safety), consult routing + soft-fail, and live tool registration.
- **`agent-loop-integration.test.ts`** drives the real `AgentLoop` with all defaults registered: a scripted model calls `advisor`, the real hooks + `consult` + `runBtwSidechain` run against an injected advisor provider, asserting the `advisor` call site, tools-off, the 2048 cap, that the captured transcript + system prompt reach the advisor, and that the advice flows back as the tool result.

> Run the suite per file (as CI does); a single `bun test <dir>` shares one process where bun's global `mock.module` leaks across files.

## Not included (follow-ups)

- `max_uses` / advisor-side caching (out of v1 scope).
- Behavioral knobs (output cap, word limit, timeout, steering) are constants in `config.ts`; promoting them to plugin-manifest config is a natural follow-up.
- An end-to-end run against a live provider (needs credentials) — verified everything up to the provider boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
