### PR TITLE
fix(assistant): apply guardian trust before hydrating history for meta slash commands

### DIFF
--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -2,6 +2,7 @@ import { v4 as uuid } from "uuid";
 
 import { clearAll, getConversation } from "../../memory/conversation-crud.js";
 import { resolveConversationId } from "../../memory/conversation-key-store.js";
+import { isUntrustedTrustClass } from "../../runtime/actor-trust-resolver.js";
 import { broadcastMessage } from "../../runtime/assistant-event-hub.js";
 import { getSubagentManager } from "../../subagent/index.js";
 import { createAbortReason } from "../../util/abort-reasons.js";
@@ -24,6 +25,7 @@ import {
 } from "../conversation-store.js";
 import type { ConfirmationResponse } from "../message-protocol.js";
 import { normalizeConversationType } from "../message-protocol.js";
+import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../trust-context.js";
 import { log } from "./shared.js";
 
 export function handleConfirmationResponse(msg: ConfirmationResponse): void {
@@ -157,10 +159,14 @@ export async function resolveMetaSlashCommand(
   }
   const conversation = await getOrCreateConversation(resolvedId);
   touchConversation(resolvedId);
-  // Hydrate persisted history before stripping/inspecting: a registry
-  // conversation the daemon holds but hasn't run a turn on can have an empty
-  // in-memory `messages` array, which would make `/clean` report 0 preserved
-  // and `/status` report 0 messages. Mirrors `processMessage`'s turn setup.
+  // Local meta commands are owner-initiated self-maintenance. Without a trusted
+  // context, `loadFromDb` filters history to non-guardian provenance — so for a
+  // guardian-authored conversation `/clean` reports 0 preserved and `/status` 0
+  // messages. Apply the guardian context before hydrating so the owner operates
+  // on the full history. A real turn re-resolves trust per-actor afterward.
+  if (isUntrustedTrustClass(conversation.trustContext?.trustClass)) {
+    conversation.setTrustContext(INTERNAL_GUARDIAN_TRUST_CONTEXT);
+  }
   await conversation.ensureActorScopedHistory();
 
   const slashResult = await resolveSlash(


### PR DESCRIPTION
## Summary
- The local meta-command endpoint (`/clean`, `/status`, …, #35127) ran `getOrCreateConversation` + `forceClean` with no trust context. Since an absent trust class is treated as untrusted (`isUntrustedTrustClass(undefined) === true`), `loadFromDb` filtered history to non-guardian provenance — and for an owner's own guardian-authored conversation that drops *every* message. So `/clean` reported "0 reclaimed / 0 preserved" and the context fell to the bare system-prompt baseline. The fix applies the guardian context (`INTERNAL_GUARDIAN_TRUST_CONTEXT`) before hydrating whenever the current context would be untrusted, so the owner operates on the full history. A subsequent real turn still re-resolves trust per-actor.

## Original prompt
After restarting the daemon, `/clean` still showed "Tokens: 15,793 → 15,793 (0 reclaimed), Messages: 0 preserved" on a conversation with ~79 persisted messages. Root cause confirmed against the live DB: the messages are guardian-provenance, and the meta endpoint hydrated history with no trust context (→ untrusted), so `filterMessagesForUntrustedActor` dropped all of them. The earlier `ensureActorScopedHistory` fix (#35129) couldn't help because the load itself was filtering everything out — this sets the guardian context first.