### PR TITLE
feat(logs): surface system schedules in the usage breakdown

### DIFF
--- a/clients/web/src/components/system-schedules-usage-section.tsx
+++ b/clients/web/src/components/system-schedules-usage-section.tsx
@@ -1,0 +1,48 @@
+import { useNavigate } from "react-router";
+
+import { SystemTasksSection } from "@/domains/settings/components/system-tasks-section";
+import { useSystemTasks } from "@/domains/settings/hooks/use-system-tasks";
+import { SYSTEM_TASK_URL_IDS } from "@/domains/settings/utils/schedule-formatters";
+import { routes } from "@/utils/routes";
+import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
+
+/**
+ * Top-level wrapper so the `logs` Usage tab can surface the system-schedules
+ * accordion (heartbeat / consolidation / memory retrospective) without
+ * importing `@/domains/settings/...` directly — the cross-domain lint rule
+ * forbids `logs` → `settings`, so the shared composition lives here. The
+ * system tasks own their detail views under the settings schedules route, so
+ * rows navigate there.
+ */
+export function SystemSchedulesUsageSection({
+  assistantId,
+}: {
+  assistantId: string;
+}) {
+  const navigate = useNavigate();
+  const tz = useEffectiveTimezone();
+  const systemTasks = useSystemTasks(assistantId, tz);
+
+  return (
+    <SystemTasksSection
+      heartbeatConfig={systemTasks.heartbeatConfig}
+      consolidationConfig={systemTasks.consolidationConfig}
+      retrospectiveConfig={systemTasks.retrospectiveConfig}
+      heartbeatUsage={systemTasks.heartbeatUsage}
+      consolidationUsage={systemTasks.consolidationUsage}
+      retrospectiveUsage={systemTasks.retrospectiveUsage}
+      isLoading={systemTasks.isLoading}
+      hasError={systemTasks.hasError}
+      onRetry={systemTasks.refetchAll}
+      onSelectHeartbeat={() =>
+        navigate(routes.settings.schedule(SYSTEM_TASK_URL_IDS.heartbeat))
+      }
+      onSelectConsolidation={() =>
+        navigate(routes.settings.schedule(SYSTEM_TASK_URL_IDS.consolidation))
+      }
+      onSelectRetrospective={() =>
+        navigate(routes.settings.schedule(SYSTEM_TASK_URL_IDS.retrospective))
+      }
+    />
+  );
+}

--- a/clients/web/src/domains/logs/components/usage-tab.tsx
+++ b/clients/web/src/domains/logs/components/usage-tab.tsx
@@ -5,6 +5,7 @@ import { useNavigate, useSearchParams } from "react-router";
 
 import { Dropdown } from "@vellumai/design-library";
 
+import { SystemSchedulesUsageSection } from "@/components/system-schedules-usage-section";
 import { buildCallSiteMetadataMap } from "@/domains/logs/call-site-metadata";
 import {
     UsageTrendChart,
@@ -424,6 +425,8 @@ export function UsageTab({ assistantId }: UsageTabProps) {
         query={breakdownQuery}
         groups={decoratedBreakdown}
       />
+
+      <SystemSchedulesUsageSection assistantId={assistantId} />
 
       <CostAssistantSection
         onAnalyze={() => startCostConversation(COST_ANALYSIS_PROMPT)}

--- a/clients/web/src/domains/settings/pages/schedules-page.tsx
+++ b/clients/web/src/domains/settings/pages/schedules-page.tsx
@@ -13,7 +13,6 @@ import { ScheduleDetailView } from "@/domains/settings/components/schedule-detai
 import { ScheduleRow } from "@/domains/settings/components/schedule-row";
 import { ScheduleListColumnsHeader } from "@/domains/settings/components/schedule-shared-ui";
 import { SystemTaskDetailView } from "@/domains/settings/components/system-task-detail-view";
-import { SystemTasksSection } from "@/domains/settings/components/system-tasks-section";
 import { useSystemTasks } from "@/domains/settings/hooks/use-system-tasks";
 import {
   consolidationSubtitle,
@@ -22,7 +21,6 @@ import {
   pastOneTimeStatus,
   RETROSPECTIVE_SUBTITLE,
   scheduleUsageSummaryQueryOptions,
-  SYSTEM_TASK_URL_IDS,
   systemTaskKindFromUrlId,
   type ScheduleRowUsage,
   zeroScheduleUsageSummary,
@@ -458,27 +456,6 @@ export function SchedulesPage() {
           </div>
         </DetailCard>
       )}
-
-      <SystemTasksSection
-        heartbeatConfig={systemTasks.heartbeatConfig}
-        consolidationConfig={systemTasks.consolidationConfig}
-        retrospectiveConfig={systemTasks.retrospectiveConfig}
-        heartbeatUsage={systemTasks.heartbeatUsage}
-        consolidationUsage={systemTasks.consolidationUsage}
-        retrospectiveUsage={systemTasks.retrospectiveUsage}
-        isLoading={systemTasks.isLoading}
-        hasError={systemTasks.hasError}
-        onRetry={systemTasks.refetchAll}
-        onSelectHeartbeat={() =>
-          navigateToSchedule(SYSTEM_TASK_URL_IDS.heartbeat)
-        }
-        onSelectConsolidation={() =>
-          navigateToSchedule(SYSTEM_TASK_URL_IDS.consolidation)
-        }
-        onSelectRetrospective={() =>
-          navigateToSchedule(SYSTEM_TASK_URL_IDS.retrospective)
-        }
-      />
 
       {assistantId ? (
         <CreateScheduleModal


### PR DESCRIPTION
## What

Move the **System schedules** accordion (Heartbeat / Consolidation / Memory retrospective) out of **Settings → Schedules** and into the **Logs → Usage** tab, rendered as a collapsible accordion **below the Breakdown section**.

## Why

These system-managed schedules are usage/cost-bearing jobs, so surfacing them next to the usage breakdown (with their 7-day cost total) keeps spend visibility in one place.

## How

- New top-level `clients/web/src/components/system-schedules-usage-section.tsx` composes the existing settings `useSystemTasks` hook + `SystemTasksSection`, so the `logs` domain can reuse them **without a cross-domain import** (`logs` → `settings` is forbidden by `no-cross-domain-imports`). Mirrors the existing `profile-quick-add-provider.tsx` pattern.
- `logs/components/usage-tab.tsx` renders `<SystemSchedulesUsageSection>` below the Breakdown, above the Cost assistant.
- `settings/pages/schedules-page.tsx` no longer renders the section. The system-task **detail views** still live under the settings schedules route, so rows in the Usage breakdown navigate there.

## Behavior

- "System" accordion is collapsed by default, shows per-job usage cost, auto-hides when no system tasks are available.
- Clicking a row opens that job's detail view (under the existing settings schedules route).

## Checks

- `tsc --noEmit` clean
- eslint clean (no cross-domain violations)
- 43 tests pass (`schedules-page` + `usage-tab`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)