### PR TITLE
fix(schedules): default recurring schedules to a fresh conversation per fire

### DIFF
--- a/assistant/src/__tests__/scheduler-reuse-conversation.test.ts
+++ b/assistant/src/__tests__/scheduler-reuse-conversation.test.ts
@@ -210,10 +210,13 @@ describe("scheduler conversation reuse", () => {
     expect(runs2[0].conversationId).toBe(firstConversationId);
   });
 
-  test("recurring schedule defaults to reuseConversation=true", async () => {
+  test("recurring schedule defaults to reuseConversation=false", async () => {
     /**
      * When no explicit reuseConversation is provided, recurring schedules
-     * default to true — subsequent runs reuse the same conversation.
+     * default to false — each run gets a fresh conversation. This keeps a
+     * weak model's per-run context bounded instead of accumulating a long,
+     * self-similar transcript that primes it to repeat or drift; durable
+     * cross-run state belongs in workspace files and memory, not history.
      */
 
     // GIVEN a recurring schedule with no explicit reuseConversation
@@ -224,7 +227,7 @@ describe("scheduler conversation reuse", () => {
       message: "Default reuse message",
       syntax: "rrule",
       expression: rruleExpr,
-      // no explicit reuseConversation — should default to true for recurring
+      // no explicit reuseConversation — should default to false
     });
 
     // WHEN the schedule fires for the first time
@@ -250,9 +253,9 @@ describe("scheduler conversation reuse", () => {
     await new Promise((resolve) => setTimeout(resolve, 500));
     scheduler2.stop();
 
-    // THEN the same conversation is reused
+    // THEN a fresh conversation is created instead of reusing the first
     expect(processedMessages).toHaveLength(1);
-    expect(processedMessages[0].conversationId).toBe(firstConversationId);
+    expect(processedMessages[0].conversationId).not.toBe(firstConversationId);
   });
 
   test("recurring schedule with reuseConversation=false creates new conversation each run", async () => {

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -196,6 +196,7 @@ import {
   migrateRenameVerificationTable,
   migrateRenameVoiceToPhone,
   migrateScheduleCapabilities,
+  migrateScheduleDefaultNoReuseConversation,
   migrateScheduleDescription,
   migrateScheduleInferenceProfile,
   migrateScheduleOneShotRouting,
@@ -521,6 +522,7 @@ export function initializeDb(): void {
     migrateContactChannelsUniqueExtUser,
     migrateScheduleCapabilities,
     migrateContactChannelsRenormalizeAddresses,
+    migrateScheduleDefaultNoReuseConversation,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/292-schedule-default-no-reuse-conversation.test.ts
+++ b/assistant/src/memory/migrations/292-schedule-default-no-reuse-conversation.test.ts
@@ -1,0 +1,67 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import * as schema from "../schema.js";
+import { migrateScheduleDefaultNoReuseConversation } from "./292-schedule-default-no-reuse-conversation.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  // Post-210 shape: reuse_conversation column present (trimmed to the columns
+  // the migration and assertions touch).
+  sqlite.exec(/*sql*/ `
+    CREATE TABLE cron_jobs (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      message TEXT NOT NULL,
+      next_run_at INTEGER NOT NULL,
+      created_by TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      reuse_conversation INTEGER NOT NULL DEFAULT 0
+    )
+  `);
+  return { sqlite, db: drizzle(sqlite, { schema }) };
+}
+
+function insertJob(sqlite: Database, id: string, reuse: number) {
+  sqlite
+    .query(
+      /*sql*/ `INSERT INTO cron_jobs
+        (id, name, message, next_run_at, created_by, created_at, updated_at, reuse_conversation)
+        VALUES (?, ?, 'msg', 1000, 'agent', 1000, 1000, ?)`,
+    )
+    .run(id, id, reuse);
+}
+
+function reuseValue(sqlite: Database, id: string): number {
+  return (
+    sqlite
+      .query("SELECT reuse_conversation FROM cron_jobs WHERE id = ?")
+      .get(id) as { reuse_conversation: number }
+  ).reuse_conversation;
+}
+
+describe("migration 292: schedules default to no conversation reuse", () => {
+  test("flips existing reuse_conversation=1 rows to 0", () => {
+    const { sqlite, db } = createTestDb();
+    insertJob(sqlite, "reusing", 1);
+    insertJob(sqlite, "already-fresh", 0);
+
+    migrateScheduleDefaultNoReuseConversation(db);
+
+    expect(reuseValue(sqlite, "reusing")).toBe(0);
+    expect(reuseValue(sqlite, "already-fresh")).toBe(0);
+  });
+
+  test("is idempotent — re-run is a no-op", () => {
+    const { sqlite, db } = createTestDb();
+    insertJob(sqlite, "reusing", 1);
+
+    migrateScheduleDefaultNoReuseConversation(db);
+    expect(() => migrateScheduleDefaultNoReuseConversation(db)).not.toThrow();
+
+    expect(reuseValue(sqlite, "reusing")).toBe(0);
+  });
+});

--- a/assistant/src/memory/migrations/292-schedule-default-no-reuse-conversation.ts
+++ b/assistant/src/memory/migrations/292-schedule-default-no-reuse-conversation.ts
@@ -1,0 +1,25 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Disable conversation reuse on all existing schedules.
+ *
+ * Recurring schedules previously defaulted to `reuse_conversation = 1`, so
+ * every fire appended to one long-lived conversation. That unbounded,
+ * self-similar transcript is a drift hazard for weaker models (it primes them
+ * to repeat or extend the prior run) and grows per-fire token cost without
+ * adding correctness — durable cross-run state already lives in workspace files
+ * and memory. Schedules now default to a fresh conversation per fire; this
+ * aligns existing rows with that contract.
+ *
+ * Idempotent: the guarded UPDATE matches nothing once every row is already 0.
+ */
+export function migrateScheduleDefaultNoReuseConversation(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+  raw
+    .query(
+      /*sql*/ `UPDATE cron_jobs SET reuse_conversation = 0 WHERE reuse_conversation != 0`,
+    )
+    .run();
+}

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -283,6 +283,7 @@ export { migrateBackfillOriginChannelFromBindings } from "./288-backfill-origin-
 export { migrateContactChannelsUniqueExtUser } from "./289-contact-channels-unique-ext-user.js";
 export { migrateScheduleCapabilities } from "./290-schedule-capabilities.js";
 export { migrateContactChannelsRenormalizeAddresses } from "./291-contact-channels-renormalize-addresses.js";
+export { migrateScheduleDefaultNoReuseConversation } from "./292-schedule-default-no-reuse-conversation.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/schedule/schedule-store.ts
+++ b/assistant/src/schedule/schedule-store.ts
@@ -158,7 +158,7 @@ export function createSchedule(params: {
   const routingIntent = params.routingIntent ?? "all_channels";
   const routingHints = params.routingHints ?? {};
   const quiet = params.quiet ?? false;
-  const reuseConversation = params.reuseConversation ?? !isOneShot;
+  const reuseConversation = params.reuseConversation ?? false;
   const maxRetries = params.maxRetries ?? 3;
   const retryBackoffMs = params.retryBackoffMs ?? 60000;
   const timeoutMs = params.timeoutMs ?? null;


### PR DESCRIPTION
## Problem

Recurring schedules default to `reuseConversation=true`, so every fire appends to **one long-lived conversation**. Over weeks that becomes an unbounded, self-similar transcript, which has two costs:

- **Drift hazard for weaker models.** A long "trigger → run → done" history primes the model to *continue the pattern* — repeat or extend the prior run instead of stopping.
- **Per-fire token cost that climbs** with no added correctness. Durable cross-run state already lives in workspace files (`NOW.md`, `pkb/`) and memory, so the conversation history duplicates that role less reliably.

### Motivating incident

A daily Brex expense-report schedule running on a weak model (MiniMax M3) finished the correct report for the day, recorded "last run done" to memory, then — reading its own breadcrumb as "today is behind me" — **re-ran the whole pipeline for the *next* day**, posting a zero-transaction report to a shared Slack channel against a date that hadn't happened yet. The scheduler fired exactly once; the duplicate was entirely model-driven, and the reused conversation was the substrate that enabled it.

## Change

1. **Flip the `createSchedule` default to `false`** (`schedule-store.ts`). `reuseConversation` stays a real field, so callers that genuinely need continuity can still pass `true` explicitly. Recurring schedules now get a **fresh conversation per fire**.
2. **Migration 292** sets `reuse_conversation = 0` on existing rows so live schedules adopt the new contract on their next fire (idempotent).

One-shot, `wake`, and `notify` schedules are unaffected (already `false` / don't thread conversations).

## Reviewer note ⚠️

This also flips **recurring task schedules** (`task-scheduler.ts`, which omits the flag) to fresh-per-run. That's intentional and consistent — recurring tasks carry the same drift exposure — but it's a behavior change beyond the expense-report job, so calling it out. `defer` (wake, one-shot) is untouched.

## Verification

- `tsc --noEmit` clean, `bun run lint` clean.
- New migration test (flip + idempotency) and updated `scheduler-reuse-conversation` default test pass (12/12).
- `schedule-store` / `schedule-routes` / `schedule-tools` / `task-scheduler` / CLI schedules suites pass individually.
- Note: running the 6 schedule test files *together* shows 19 failures, but that's **pre-existing cross-file test pollution** — identical 250/19 on baseline `main` — not introduced here. Worth a separate isolation-cleanup ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)