### PR TITLE
plugin-api: expose getConfiguredProvider for user-installable plugins

### DIFF
--- a/assistant/src/__tests__/plugin-api-provider.test.ts
+++ b/assistant/src/__tests__/plugin-api-provider.test.ts
@@ -1,0 +1,24 @@
+/**
+ * `getConfiguredProvider` is part of the public `@vellumai/plugin-api` runtime
+ * surface, so a user-installable plugin can run inference through the
+ * workspace's configured profiles/credentials (managed-proxy or BYOK) without
+ * supplying its own API key.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { PLUGIN_API_EXPORTS } from "../embedded/plugin-api.js";
+import * as pluginApi from "../plugin-api/index.js";
+
+describe("plugin-api provider access", () => {
+  test("getConfiguredProvider is exported as a runtime value", () => {
+    expect(typeof pluginApi.getConfiguredProvider).toBe("function");
+  });
+
+  test("getConfiguredProvider is in the shim-rebound runtime surface", () => {
+    // The boot-time shim re-binds every name in PLUGIN_API_EXPORTS from the
+    // globalThis-parked namespace, so a plugin importing the bare specifier
+    // gets the assistant's real resolver (bound to its initialized provider
+    // registry), not a disjoint, uninitialized module copy.
+    expect(PLUGIN_API_EXPORTS).toContain("getConfiguredProvider");
+  });
+});

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -34,6 +34,9 @@
  * - {@link getSecureKeyAsync} — read a secret from secure storage
  * - {@link getModelProfiles} — list the workspace inference profiles a plugin
  *   can route to (e.g. a model router building its category → profile map)
+ * - {@link getConfiguredProvider} — resolve a {@link Provider} for a call site
+ *   (optionally overriding the profile) and run inference through the
+ *   workspace's configured profiles and credentials — no plugin-supplied API key
  *
  * - {@link PluginInitContext} — passed to `init` hook at bootstrap
  * - {@link PluginShutdownContext} — passed to `shutdown` hook at teardown
@@ -80,6 +83,20 @@ export type {
   ToolUseContent,
   WebSearchToolResultContent,
 } from "../providers/types.js";
+// Provider + inference types. A plugin that runs its own inference through
+// `getConfiguredProvider` names these to type the provider handle it gets back,
+// the request options it passes to `sendMessage`, and the response.
+export type {
+  Provider,
+  ProviderEvent,
+  ProviderResponse,
+  SendMessageConfig,
+  SendMessageOptions,
+} from "../providers/types.js";
+// Call-site identifier accepted by `getConfiguredProvider`. Plugins typically
+// pass `"inference"` (the general-purpose call site) and pick the model via the
+// `overrideProfile` option.
+export type { LLMCallSite } from "../config/schemas/llm.js";
 export type {
   AgentLoopExitReason,
   ModelProfileInfo,
@@ -115,3 +132,9 @@ export type {
 export { assistantEventHub } from "../runtime/assistant-event-hub.js";
 export { getSecureKeyAsync } from "../security/secure-keys.js";
 export { getModelProfiles } from "./model-profiles.js";
+// Resolve a provider for a call site (optionally overriding the profile) so a
+// plugin can run inference through the workspace's configured profiles and
+// credentials — managed-proxy or BYOK — without supplying its own API key.
+// Pair with `getModelProfiles` to pick a profile. Returns `null` when no
+// provider is configured.
+export { getConfiguredProvider } from "../providers/provider-send-message.js";


### PR DESCRIPTION
## What

Exposes **`getConfiguredProvider`** (plus the provider/inference types it needs) on the public `@vellumai/plugin-api` surface, so a **user-installable plugin** can run inference through the workspace's configured profiles and credentials — managed-proxy or BYOK — **without supplying its own API key**.

This is the first plugin-api gap surfaced while building the advisor as a user-installable plugin. Today an installable plugin can `getModelProfiles()` to *list* profiles but has no way to *run* one; this closes that gap.

## Change

`assistant/src/plugin-api/index.ts`:
- `export { getConfiguredProvider }` from `providers/provider-send-message.js` — a runtime handle, same pattern as `assistantEventHub` / `getSecureKeyAsync` / `getModelProfiles`. The boot-time shim re-binds it from the `globalThis`-parked namespace (it re-binds `Object.keys(pluginApi)`), so a plugin gets the assistant's real resolver bound to the initialized provider registry — not a disjoint module copy.
- Export the supporting types: `Provider`, `ProviderResponse`, `SendMessageOptions`, `SendMessageConfig`, `ProviderEvent`, `LLMCallSite`. (`Message` was already exported.)
- Test: `getConfiguredProvider` is a runtime export and is in `PLUGIN_API_EXPORTS` (so the shim re-binds it for plugins).

## Usage (from a plugin)

```ts
import { getConfiguredProvider, type Message } from "@vellumai/plugin-api";

const provider = await getConfiguredProvider("inference", {
  overrideProfile: "quality-optimized", // pick the model via getModelProfiles()
});
const res = await provider.sendMessage(messages, {
  systemPrompt,
  config: { callSite: "inference", tool_choice: { type: "none" }, max_tokens: 2048 },
});
// read text from res.content
```

## Open questions for review

- **Direct re-export vs. wrapper.** I matched the `getSecureKeyAsync`/`getModelProfiles` runtime-handle pattern. Happy to wrap it instead (à la `model-profiles.ts`) to narrow the surface — e.g. hide `Provider`/`SendMessageOptions` and expose a `runInference({ profile, messages, systemPrompt }) → text` helper. Which do you prefer?
- **`LLMCallSite`.** Exporting it makes the `callSite` arg typeable but commits the internal call-site taxonomy publicly. Could accept a looser `string` instead.
- **`runBtwSidechain`.** Left out — the advisor only needs text, which `provider.sendMessage(… tool_choice: none)` gives directly, so no separate import is needed.

No new circular deps (verified); lint + tsc clean.

Next: rework the advisor as a user-installable plugin on top of this, referenced from `plugins/marketplace.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
