### PR TITLE
plugins: add advisor to the marketplace (draft — depends on #35143)

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -64,6 +64,18 @@
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/model-router",
       "license": "MIT"
+    },
+    {
+      "name": "advisor",
+      "source": {
+        "source": "github",
+        "repo": "vellum-ai/advisor",
+        "ref": "02e81acd298c7516d25f20f402c80003453a9fc9"
+      },
+      "description": "Consult a stronger inference profile mid-task via an advisor tool, routed through the workspace's own inference (no API key).",
+      "category": "developer",
+      "homepage": "https://github.com/vellum-ai/advisor",
+      "license": "MIT"
     }
   ]
 }


### PR DESCRIPTION
## What

Adds the **advisor** plugin to the marketplace — a user-installable plugin that adds a no-argument `advisor` tool: the model calls it mid-task and the plugin consults a stronger inference profile on the full transcript, routed through the workspace's own inference (no separate API key). Repo: [vellum-ai/advisor](https://github.com/vellum-ai/advisor) (public).

## Status — gates cleared ✅

- **#35143** (plugin-api `getConfiguredProvider`) — **merged**, so the consult resolves a provider at runtime via the shim.
- **vellum-ai/advisor** — **public**.
- Supersedes **#35130** (the default-plugin attempt) — closed.
- Pinned to commit `02e81ac` (full SHA, per the marketplace rules).

The plugin imports only `@vellumai/plugin-api`; the consult resolves a provider via `getConfiguredProvider("inference", { overrideProfile })` and runs a tool-less `sendMessage`.

> Note: `@vellumai/plugin-api` may need an npm release for the plugin repo's own standalone CI to typecheck against the published package — this doesn't affect runtime, where the assistant's shim provides `getConfiguredProvider`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
