### PR TITLE
fix(ui-surface): show a loading affordance for content-free dynamic_page surfaces

### DIFF
--- a/clients/web/src/domains/chat/components/surfaces/dynamic-page-surface.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/dynamic-page-surface.test.tsx
@@ -76,6 +76,31 @@ describe("DynamicPageSurface", () => {
     expect(isOpenAppEnabled(rendered)).toBe(false);
   });
 
+  test("shows a loading affordance instead of a blank iframe for empty content", () => {
+    const rendered = renderToStaticMarkup(
+      <DynamicPageSurface
+        surface={surface({})}
+        onAction={() => undefined}
+      />,
+    );
+
+    expect(rendered).not.toContain("<iframe");
+    expect(rendered).toContain("animate-spin");
+    expect(rendered).toContain("Surface title");
+  });
+
+  test("renders the iframe (not the affordance) once inline HTML arrives", () => {
+    const rendered = renderToStaticMarkup(
+      <DynamicPageSurface
+        surface={surface({ html: "<html><body>Hello</body></html>" })}
+        onAction={() => undefined}
+      />,
+    );
+
+    expect(rendered).toContain("<iframe");
+    expect(rendered).not.toContain("animate-spin");
+  });
+
   test("opens snake_case persisted app ids through the app viewer", () => {
     const rendered = renderToStaticMarkup(
       <DynamicPageSurface

--- a/clients/web/src/domains/chat/components/surfaces/dynamic-page-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/dynamic-page-surface.tsx
@@ -1,4 +1,4 @@
-import { Minimize2 } from "lucide-react";
+import { Loader2, Minimize2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { AppCard } from "@/components/app-card";
@@ -187,6 +187,24 @@ export function DynamicPageSurface({
           onOpen={isToolCallComplete ? onOpenPreview : undefined}
           onPin={onPin}
         />
+      </div>
+    );
+  }
+
+  // A dynamic_page the model has shown but not populated (e.g. `data: {}` from
+  // a weak model, or an empty payload from a daemon predating the empty-surface
+  // guard) carries no HTML to render. Rather than a blank ~400px iframe, show a
+  // loading affordance until real content arrives — mirroring the content-free
+  // card placeholder. A completed surface is terminal and falls through.
+  if (inlineHtml == null && !surface.completed) {
+    return (
+      <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-lift)] px-4 py-3">
+        <div className="flex items-center gap-2.5">
+          <Loader2 className="h-4 w-4 shrink-0 animate-spin text-[var(--content-tertiary)]" />
+          <span className="text-body-medium-default text-[var(--content-tertiary)]">
+            {surface.title || "Working…"}
+          </span>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## What

A `ui_show dynamic_page` with `data: {}` (no `data.html`) renders in the web client as the surface title over a blank ~400px iframe. This adds a client-side empty-state: a spinner + title loading affordance until inline HTML arrives — mirroring the content-free `card` affordance from #34994.

## Repro (from dogfood feedback)

A weak model (MiniMax M3, balanced economy) emitted:

```json
ui_show { "surface_type": "dynamic_page", "title": "Fable 5 vs MiniMax M3", "data": {} }
```

Daemon log confirms the surface was forwarded with empty data and **zero errors**:

```
[conversation-surfaces] Sending ui_surface_show to client
    surfaceType: "dynamic_page"   dataKeys: []
[tool-profiler] "ui_show": { count: 1, errors: 0 }
```

The web client then rendered the title over a blank iframe (`srcdoc = injectBridge("", …)`) → the empty widget the user saw.

## Root cause

Two layers:

1. **Model**: M3 sent `dynamic_page` with no HTML.
2. **Daemon deployment lag**: the `isEmptyDynamicPage` guard (#34940, landed 06-15) rejects exactly this input on current `main`, but the daemon serving the session predated it (its DB carried "migration checkpoints from a newer version"), so the empty surface reached the client.

The daemon side is already fixed on `main`; this PR adds the **missing client-side defense-in-depth** so an empty `dynamic_page` reaching the client (older daemon, race, mid-stream) shows a clear loading state instead of a mysterious blank box. This is symmetric to the gap #34994 closed for `card` surfaces.

## Change

- `dynamic-page-surface.tsx`: when a surface has no inline HTML and is not completed, render a spinner + title affordance instead of the blank iframe. Once inline HTML arrives, the iframe renders as before. A `completed` surface is terminal and falls through.
- Tests: empty `data` → affordance, no iframe; inline HTML present → iframe, no affordance.

## Risk

Low — client-only, scoped to the previously-blank empty path. `bunx tsc --noEmit` clean; surface tests pass (7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)