### PR TITLE
fix(web): make the local gateway the sole session authority (fixes Preferences missing on first hatch)

### DIFF
--- a/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -59,6 +59,7 @@ const queryClientMock = {
   invalidateQueries: invalidateQueriesMock,
 };
 const writeSelectedVersionMock = mock(() => {});
+const connectLocalAssistantMock = mock(async (_assistantId: string) => {});
 
 type TestOnboardingRecipe = {
   cohort: string;
@@ -78,6 +79,7 @@ let isMacOSWeb = false;
 let iosAppDownloaded = true;
 let macOsAppDownloaded = true;
 let isLocalModeValue = false;
+let localGatewayUrlValue: string | undefined = undefined;
 let platformSessionValue: PlatformSessionStatus = "absent";
 let fetchOnboardingRecipeImpl: () => Promise<TestOnboardingRecipe | null> =
   async () => null;
@@ -216,7 +218,7 @@ mock.module("@/lib/local-mode", () => ({
   setActiveLockfileAssistant: async () => {},
   saveLockfileAssistant: async () => {},
   primeLocalGatewayConnection: async () => {},
-  getLocalGatewayUrl: () => undefined,
+  getLocalGatewayUrl: () => localGatewayUrlValue,
 }));
 
 mock.module("@/runtime/local-mode-host", () => ({
@@ -269,6 +271,7 @@ mock.module("@/stores/auth-store", () => ({
       sessionStatus: () => "authenticated",
       platformSession: () => platformSessionValue,
     },
+    getState: () => ({ connectLocalAssistant: connectLocalAssistantMock }),
   },
   useIsAuthenticated: () => true,
   useIsSessionInitializing: () => false,
@@ -413,12 +416,14 @@ beforeEach(() => {
   iosAppDownloaded = true;
   macOsAppDownloaded = true;
   isLocalModeValue = false;
+  localGatewayUrlValue = undefined;
   platformSessionValue = "absent";
   fetchOnboardingRecipeImpl = async () => null;
   sessionStorage.clear();
   localStorage.clear();
 
   navigateMock.mockClear();
+  connectLocalAssistantMock.mockClear();
   checkAssistantMock.mockClear();
   hatchAssistantMock.mockClear();
   getAssistantMock.mockClear();
@@ -456,6 +461,36 @@ describe("onboarding lifecycle sync", () => {
         replace: true,
       }),
     );
+  });
+
+  // Regression: a freshly hatched local assistant must establish an
+  // authenticated session before handing off to chat. Without it, a session
+  // refresh fired during the hatch window leaves `sessionStatus` stuck at
+  // "unauthenticated", hiding auth-gated UI (the Preferences menu) until a
+  // full reload. The hatch flow must drive the same `connectLocalAssistant`
+  // primitive the returning-user connect path uses.
+  test("local hatch establishes the authenticated session via connectLocalAssistant", async () => {
+    isLocalModeValue = true;
+    localGatewayUrlValue = "http://127.0.0.1:7821";
+    searchParams = new URLSearchParams("hosting=local");
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async () => ({
+      ok: true,
+      json: async () => ({ status: "ok" }),
+    })) as unknown as typeof fetch;
+
+    try {
+      render(<HatchingScreen />);
+
+      await waitFor(
+        () =>
+          expect(connectLocalAssistantMock).toHaveBeenCalledWith("local-1"),
+        { timeout: 5_000 },
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   test("pre-chat completion refreshes the root assistant lifecycle before entering chat", async () => {

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -102,11 +102,9 @@ export function HatchingScreen() {
   const electron = isElectron();
   const useLocalHatch = isLocalMode() && hostingParam !== null && hostingParam !== "vellum-cloud";
   const sessionStatus = useAuthStore.use.sessionStatus();
-  // The local hatch flow drives `sessionStatus` itself — the connect handoff
-  // below flips it to "authenticated" — so a local hatch keys its effect on
-  // settled-ness alone; an authenticated↔unauthenticated flip must not tear
-  // down and restart the in-flight hatch. Platform hatches still react to the
-  // raw status so a session lost mid-hatch redirects to login.
+  // Local hatches drive `sessionStatus` themselves (the connect handoff below
+  // flips it), so they gate on settled-ness to avoid self-restarting; platform
+  // hatches react to the raw status so a mid-hatch session loss redirects to login.
   const sessionGateKey = useLocalHatch
     ? isSessionSettled(sessionStatus)
     : sessionStatus;

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -30,6 +30,7 @@ import { setSelectedAssistant } from "@/assistant/selection";
 import { useAuthStore } from "@/stores/auth-store";
 import { useOrganizationStore } from "@/stores/organization-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { isSessionSettled } from "@/stores/session-status";
 import type { CharacterTraits } from "@/types/avatar";
 import { extractErrorMessage } from "@/utils/api-errors";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
@@ -101,6 +102,14 @@ export function HatchingScreen() {
   const electron = isElectron();
   const useLocalHatch = isLocalMode() && hostingParam !== null && hostingParam !== "vellum-cloud";
   const sessionStatus = useAuthStore.use.sessionStatus();
+  // The local hatch flow drives `sessionStatus` itself — the connect handoff
+  // below flips it to "authenticated" — so a local hatch keys its effect on
+  // settled-ness alone; an authenticated↔unauthenticated flip must not tear
+  // down and restart the in-flight hatch. Platform hatches still react to the
+  // raw status so a session lost mid-hatch redirects to login.
+  const sessionGateKey = useLocalHatch
+    ? isSessionSettled(sessionStatus)
+    : sessionStatus;
   const [hatchTraits] = useState<CharacterTraits>(() =>
     randomCharacterTraits(BUNDLED_COMPONENTS),
   );
@@ -324,17 +333,10 @@ export function HatchingScreen() {
           }
           if (cancelled) return;
 
-          // The gateway is ready and its token is minted, but the hatch flow
-          // has not yet established an authenticated session. Drive the same
-          // canonical connect primitive the returning-user picker and the
-          // re-pair flow use, so `sessionStatus` is "authenticated" before we
-          // hand off to chat. Without this, a session refresh that fires
-          // during the long hatch window — while the gateway is "enabled"
-          // (the lockfile has its URL) but its token isn't minted yet, so
-          // `isGatewayAuthMode()` is false — re-derives the session from the
-          // platform probe, gets a settled 401 on a local-only machine, and
-          // leaves `sessionStatus` stuck at "unauthenticated". That hides
-          // auth-gated UI such as the Preferences menu until a full reload.
+          // Assert an authenticated local session via the same canonical
+          // connect primitive the returning-user picker and re-pair flow use,
+          // so `sessionStatus` is "authenticated" at hand-off to chat. This
+          // keeps auth-gated UI such as the Preferences menu visible.
           if (result.assistantId) {
             await useAuthStore
               .getState()
@@ -517,7 +519,7 @@ export function HatchingScreen() {
     attempt,
     failParam,
     hatchTraits,
-    sessionStatus,
+    sessionGateKey,
     navigate,
     queryClient,
     transitionPhase,

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -324,6 +324,23 @@ export function HatchingScreen() {
           }
           if (cancelled) return;
 
+          // The gateway is ready and its token is minted, but the hatch flow
+          // has not yet established an authenticated session. Drive the same
+          // canonical connect primitive the returning-user picker and the
+          // re-pair flow use, so `sessionStatus` is "authenticated" before we
+          // hand off to chat. Without this, a session refresh that fires
+          // during the long hatch window — while the gateway is "enabled"
+          // (the lockfile has its URL) but its token isn't minted yet, so
+          // `isGatewayAuthMode()` is false — re-derives the session from the
+          // platform probe, gets a settled 401 on a local-only machine, and
+          // leaves `sessionStatus` stuck at "unauthenticated". That hides
+          // auth-gated UI such as the Preferences menu until a full reload.
+          if (result.assistantId) {
+            await useAuthStore
+              .getState()
+              .connectLocalAssistant(result.assistantId);
+          }
+
           // Apply the model-provider key collected on the API-key step to the
           // freshly hatched assistant. Non-blocking on failure — onboarding
           // proceeds and the user can fix it in Settings.

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -383,21 +383,39 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(useAuthStore.getState().platformSession).toBe("absent");
   });
 
-  test("refreshSession preserves a local session when the gateway is enabled but its token is not yet minted", async () => {
-    // The local gateway is the auth source (enabled) but its token isn't minted
-    // yet — the gateway is still starting during hatch, or the token was just
-    // cleared/expired. The platform is not the authority on a local-only
-    // machine, so refreshSession must not probe it and settle "unauthenticated".
+  test("refreshSession keeps a local gateway session alive when the platform probe settles negative", async () => {
+    // Local gateway is the auth source (enabled) but its token isn't minted yet
+    // (cold-start hatch, or token just cleared/expired). The platform probe
+    // still runs, but a settled 401 must NOT end the local session — the
+    // platform is not the authority on a local-only machine.
     mockIsLocalMode = true;
     mockIsGatewayAuth = true; // isGatewayAuthEnabled() === true
     mockGatewayToken = null; // isGatewayAuthMode() === false (token not minted)
+    sessionUser = null; // platform probe settles 401
     useAuthStore.setState({ sessionStatus: "authenticated" });
 
     await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
 
-    expect(getSessionCallCount).toBe(0); // platform never probed
-    expect(ensureGatewayTokenMock).not.toHaveBeenCalled();
+    expect(getSessionCallCount).toBe(1); // probe ran — a success could still update the store
+    expect(useAuthStore.getState().sessionStatus).toBe("authenticated"); // not ended
+  });
+
+  test("refreshSession in gateway mode still adopts a successful platform session", async () => {
+    // A local user who also signs into the platform (e.g. ProviderCallbackPage
+    // after an allauth login) must have the successful probe update the store,
+    // even while the gateway token isn't minted.
+    mockIsLocalMode = true;
+    mockIsGatewayAuth = true;
+    mockGatewayToken = null;
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    useAuthStore.setState({ platformSession: "absent" });
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
+
+    expect(getSessionCallCount).toBe(1);
     expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
+    expect(useAuthStore.getState().user?.id).toBe("user-1");
+    expect(useAuthStore.getState().platformSession).toBe("present");
   });
 
   test("initSession uses server consent when server has a consent record", async () => {

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -117,7 +117,7 @@ mock.module("@/runtime/session-token", () => ({
 
 mock.module("@/lib/auth/gateway-session", () => ({
   isGatewayAuthEnabled: () => mockIsGatewayAuth,
-  isGatewayAuthMode: () => mockIsGatewayAuth,
+  isGatewayAuthMode: () => mockIsGatewayAuth && mockGatewayToken !== null,
   ensureGatewayToken: ensureGatewayTokenMock,
   clearGatewayToken: () => {},
   getGatewayToken: () => mockGatewayToken,
@@ -383,6 +383,23 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(useAuthStore.getState().platformSession).toBe("absent");
   });
 
+  test("refreshSession preserves a local session when the gateway is enabled but its token is not yet minted", async () => {
+    // The local gateway is the auth source (enabled) but its token isn't minted
+    // yet — the gateway is still starting during hatch, or the token was just
+    // cleared/expired. The platform is not the authority on a local-only
+    // machine, so refreshSession must not probe it and settle "unauthenticated".
+    mockIsLocalMode = true;
+    mockIsGatewayAuth = true; // isGatewayAuthEnabled() === true
+    mockGatewayToken = null; // isGatewayAuthMode() === false (token not minted)
+    useAuthStore.setState({ sessionStatus: "authenticated" });
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
+
+    expect(getSessionCallCount).toBe(0); // platform never probed
+    expect(ensureGatewayTokenMock).not.toHaveBeenCalled();
+    expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
+  });
+
   test("initSession uses server consent when server has a consent record", async () => {
     sessionUser = { id: "user-1", email: "user@example.com" };
     mockFetchMeResult = {
@@ -592,6 +609,7 @@ describe("session cleanup on logout", () => {
   // active state mid-logout.
   test("gateway logout resets the lifecycle before clearing the selection", async () => {
     mockIsGatewayAuth = true;
+    mockGatewayToken = "access-token";
     useAuthStore.setState({ sessionStatus: "authenticated" });
     const order: string[] = [];
     lifecycleResetForLogoutMock.mockImplementationOnce(() => {
@@ -630,6 +648,7 @@ describe("platform session probe resolution", () => {
   // consumers don't flicker mid-session.
   test("a re-run gateway probe retains the last status until it settles", async () => {
     mockIsGatewayAuth = true;
+    mockGatewayToken = "access-token";
     mockIsLocalMode = false;
     sessionUser = { id: "user-1", email: "user@example.com" };
     useAuthStore.setState({ platformSession: "absent" });
@@ -655,6 +674,7 @@ describe("platform session probe resolution", () => {
   // probe's outcome.
   test("a stale probe completing after a newer one does not change status", async () => {
     mockIsGatewayAuth = true;
+    mockGatewayToken = "access-token";
     mockIsLocalMode = false;
     sessionUser = { id: "user-1", email: "user@example.com" };
     useAuthStore.setState({ platformSession: "absent" });

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -383,21 +383,45 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(useAuthStore.getState().platformSession).toBe("absent");
   });
 
-  test("refreshSession keeps a local gateway session alive when the platform probe settles negative", async () => {
-    // Local gateway is the auth source (enabled) but its token isn't minted yet
-    // (cold-start hatch, or token just cleared/expired). The platform probe
-    // still runs, but a settled 401 must NOT end the local session — the
-    // platform is not the authority on a local-only machine.
+  test("refreshSession keeps the local gateway session but clears stale platform state on a settled 401", async () => {
+    // Local gateway is the auth source (enabled) but its token isn't minted yet.
+    // The user had also signed into the platform; the platform session now
+    // settles negative (401). The local session stays authenticated, but the
+    // stale platform user and "present" status are cleared.
     mockIsLocalMode = true;
     mockIsGatewayAuth = true; // isGatewayAuthEnabled() === true
     mockGatewayToken = null; // isGatewayAuthMode() === false (token not minted)
     sessionUser = null; // platform probe settles 401
-    useAuthStore.setState({ sessionStatus: "authenticated" });
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      platformSession: "present",
+    });
 
     await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
 
     expect(getSessionCallCount).toBe(1); // probe ran — a success could still update the store
-    expect(useAuthStore.getState().sessionStatus).toBe("authenticated"); // not ended
+    expect(useAuthStore.getState().sessionStatus).toBe("authenticated"); // local session not ended
+    expect(useAuthStore.getState().user?.id).toBe("gateway-local"); // demoted to local user
+    expect(useAuthStore.getState().platformSession).toBe("absent"); // stale platform state cleared
+  });
+
+  test("refreshSession leaves an unauthenticated session untouched in the gateway window", async () => {
+    // Mid cold-start hatch: gateway enabled, token not minted, session not yet
+    // established. A settled 401 must not promote to authenticated — the gateway
+    // settles the session once its token mints (via connectLocalAssistant).
+    mockIsLocalMode = true;
+    mockIsGatewayAuth = true;
+    mockGatewayToken = null;
+    sessionUser = null;
+    useAuthStore.setState({
+      sessionStatus: "unauthenticated",
+      user: null,
+      platformSession: "absent",
+    });
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(false);
+
+    expect(useAuthStore.getState().sessionStatus).toBe("unauthenticated"); // not promoted
   });
 
   test("refreshSession in gateway mode still adopts a successful platform session", async () => {

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -731,14 +731,22 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
     if (isInconclusiveProbe(result)) {
       return isAuthenticated(get().sessionStatus);
     }
-    // A settled "no platform session" (401) must not end a local gateway
-    // session: on a local-only machine the gateway is the auth source, not the
-    // platform. The successful probe above still adopts the platform user and
-    // marks `platformSession` present (so platform sign-in via the provider
-    // callback updates the store); only this negative outcome is scoped to
-    // platform mode.
+    // A settled "no platform session" (401) ends the platform session, not the
+    // local gateway session. When the gateway is the auth source, demote an
+    // authenticated session to the local user and mark the platform session
+    // absent — dropping the now-stale platform user and offline snapshot so
+    // platform-gated surfaces stop treating it as signed in — while keeping
+    // `sessionStatus` "authenticated"; a 401 must not log a local-only user out.
+    // (The successful probe above still adopts the platform user, so provider
+    // sign-in keeps working.) An unauthenticated session — e.g. mid cold-start
+    // hatch — is left for the gateway to settle once its token mints.
     if (isGatewayAuthEnabled()) {
-      return isAuthenticated(get().sessionStatus);
+      const wasAuthenticated = isAuthenticated(get().sessionStatus);
+      if (wasAuthenticated) {
+        clearUserSnapshot();
+        set({ ...authenticatedLocalUser(), platformSession: "absent" });
+      }
+      return wasAuthenticated;
     }
     clearUserSnapshot();
     await syncUserScopedState(null);

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -690,16 +690,6 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
       return true;
     }
 
-    // Gateway is the auth source but its token isn't minted yet — the local
-    // gateway is still starting (first hatch), or its token was just cleared or
-    // expired. The platform is not the authority in gateway mode, so don't probe
-    // it and settle "unauthenticated"; preserve the current state. The gateway
-    // settles the session once its token is minted (initSession on reload, the
-    // hatch flow via connectLocalAssistant).
-    if (isGatewayAuthEnabled()) {
-      return isAuthenticated(get().sessionStatus);
-    }
-
     let result: Awaited<ReturnType<typeof getSession>> | null = null;
     try {
       result = await getSession();
@@ -739,6 +729,15 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
     // the next resume/online refresh revalidates for real, and a settled
     // "no session" answer below still ends the session normally.
     if (isInconclusiveProbe(result)) {
+      return isAuthenticated(get().sessionStatus);
+    }
+    // A settled "no platform session" (401) must not end a local gateway
+    // session: on a local-only machine the gateway is the auth source, not the
+    // platform. The successful probe above still adopts the platform user and
+    // marks `platformSession` present (so platform sign-in via the provider
+    // callback updates the store); only this negative outcome is scoped to
+    // platform mode.
+    if (isGatewayAuthEnabled()) {
       return isAuthenticated(get().sessionStatus);
     }
     clearUserSnapshot();

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -690,6 +690,16 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
       return true;
     }
 
+    // Gateway is the auth source but its token isn't minted yet — the local
+    // gateway is still starting (first hatch), or its token was just cleared or
+    // expired. The platform is not the authority in gateway mode, so don't probe
+    // it and settle "unauthenticated"; preserve the current state. The gateway
+    // settles the session once its token is minted (initSession on reload, the
+    // hatch flow via connectLocalAssistant).
+    if (isGatewayAuthEnabled()) {
+      return isAuthenticated(get().sessionStatus);
+    }
+
     let result: Awaited<ReturnType<typeof getSession>> | null = null;
     try {
       result = await getSession();


### PR DESCRIPTION
## Problem

When you first run the Electron app via `vel up` and hatch a **local** assistant, the **Preferences** item is missing from the left sidebar. It only appears after a full app reload.

## Root cause

The Preferences sidebar item (`preferences-menu.tsx`, wired as the sidebar `footerAction`) is the only nav item gated on `useIsAuthenticated()` — i.e. `sessionStatus === "authenticated"` in the Zustand auth store.

The first-time **local-hatch** flow (`hatching-screen.tsx`) primes the gateway but **never asserts an authenticated local session** — unlike the returning-user picker (`select-assistant-screen.tsx`) and the re-pair flow (`root-layout.tsx`), which both connect via `connectLocalAssistant()` (which calls `set(authenticatedLocalUser())`). The first-hatch path is the only local-connect path that skips this primitive.

During the hatch, once the lockfile has the assistant's gateway URL, `isGatewayAuthEnabled()` is `true` but the token isn't minted yet, so `isGatewayAuthMode()` is `false`. Any session refresh fired in that window — the global `app.resume` listener fans in page-visible / `window.online` / native-active — re-derives the session from the platform `getSession()` probe, gets a **settled 401** on a local-only machine (no platform login), and flips `sessionStatus` to `"unauthenticated"` via `sessionEnded()`. Nothing re-asserts it, so Preferences stays hidden until a reload re-runs `initSession()` down the now-enabled gateway branch and restores `authenticated`.

On a cold first `vel up` the hatch window is long (daemon cold start, polled up to `MAX_HATCH_WAIT_MS = 300_000`), so a resume event almost always lands in it — which is why it reproduces consistently.

## Fix (part 1) — assert the local session at hand-off

Once the gateway is ready, drive the same canonical `connectLocalAssistant()` primitive every other local-connect path uses, so `sessionStatus` is `"authenticated"` at hand-off to chat. This removes the first-hatch path's divergence — the missing establishment step — rather than only patching the symptom.

## Fix (part 2) — the root cause, one level up (session authority)

Part 1 makes first-hatch correct, but the underlying window still exists: during the cold-start hatch a session refresh could still transiently flip, and the same trap affects **any** local path whose gateway token is briefly absent (token expiry, guardian repair, the `clearGatewayToken()` that precedes every re-prime).

The deeper cause is an asymmetry in the auth store. `initSession()` branches on `isGatewayAuthEnabled()` (the gateway is the auth source) and establishes via the gateway, but `refreshSession()` branched on `isGatewayAuthMode()` (token *already* minted) and otherwise **fell through to the platform `getSession()` probe** — settling `"unauthenticated"` on a 401. On a local-only machine the platform is never the authority for the *local* session, so that fall-through is the actual bug.

The fix makes `refreshSession()` respect the same boundary `initSession()` does — **the gateway owns the local session; the platform owns only `platformSession`** — without throwing away the legitimate platform path:

- The platform `getSession()` probe **still runs**, so a successful platform sign-in (e.g. `ProviderCallbackPage` after an allauth login) still adopts the platform user and marks `platformSession: "present"`. A local user can hold both a local and a platform session at once; this keeps that working.
- A **settled 401 no longer ends the local session**. When the gateway is the auth source, it instead **demotes an authenticated session to the local user and marks `platformSession: "absent"`** (dropping the now-stale platform user + offline snapshot), keeping `sessionStatus: "authenticated"` — so a 401 clears the *cloud* layer but never logs a local-only user out.
- An **unauthenticated** session (e.g. mid cold-start hatch) is left untouched, so it isn't prematurely promoted; the gateway settles it once its token mints.

This closes the window for every local-connect path and removes the broader "platform 401 logs out a local user / stale platform state survives a 401" class of bug.

## Testing

- `onboarding-lifecycle-sync.test.tsx`: a successful local hatch invokes `connectLocalAssistant` with the hatched assistant id (fails without part 1, passes with it). 16/16 pass.
- `auth-store.test.ts` (45/45 pass): a settled 401 in gateway mode keeps the session `authenticated` but demotes to the local user and marks `platformSession: "absent"`; an unauthenticated session is **not** promoted; a successful platform probe in gateway mode still adopts the platform user and marks `platformSession: "present"`. The test mock was made faithful (`isGatewayAuthMode = enabled && token`), with the three established-session tests carrying a token to match.
- `tsc --noEmit` clean; `eslint` clean on changed files (the one `exhaustive-deps` warning is pre-existing and unrelated).

## Risk

🟡 **Part 1** is additive and directionally safe: it only asserts the `authenticated` state a reload already produces, so worst case it shows Preferences (correct) — it cannot wrongly hide anything.

🔴 **Part 2** touches the session-authority boundary, so it was reviewed adversarially. Platform/cloud mode is unaffected — the guard is scoped to `isGatewayAuthEnabled()` (local mode with a selected gateway), so platform users still get logged out on a real 401, and no caller depends on `refreshSession`'s return value. The intentional behavior changes are all local-mode: (1) a platform 401 demotes a local user to the local session and clears stale platform state instead of logging them out toward a nonexistent cloud login; (2) a successful platform refresh still registers; (3) a genuinely *dead* gateway leaves the user authenticated locally — correct for a local-only machine, where the gateway is the sole auth source and recovery is via reconnect/repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
