### PR TITLE
fix(assistant): rehydrate turnCount on conversation load

### DIFF
--- a/assistant/src/__tests__/conversation-load-history-repair.test.ts
+++ b/assistant/src/__tests__/conversation-load-history-repair.test.ts
@@ -552,3 +552,104 @@ describe("loadFromDb history repair", () => {
     ]);
   });
 });
+
+describe("loadFromDb turn-count rehydration", () => {
+  beforeEach(() => {
+    nextMockMessageId = 1;
+    mockConversation = {
+      id: "conv-1",
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+    };
+  });
+
+  const userText = (text: string) => ({
+    role: "user",
+    content: JSON.stringify([{ type: "text", text }]),
+  });
+  const assistantText = (text: string) => ({
+    role: "assistant",
+    content: JSON.stringify([{ type: "text", text }]),
+  });
+  const assistantToolUse = (id: string) => ({
+    role: "assistant",
+    content: JSON.stringify([
+      { type: "tool_use", id, name: "bash", input: { cmd: "ls" } },
+    ]),
+  });
+  const toolResult = (id: string) => ({
+    role: "user",
+    content: JSON.stringify([
+      { type: "tool_result", tool_use_id: id, content: "ok" },
+    ]),
+  });
+  const withIds = (msgs: Array<{ role: string; content: string }>) =>
+    msgs.map((m, i) => ({ id: `m${i}`, ...m }));
+
+  test("restores turnCount from persisted history rather than resetting to 0", async () => {
+    // Three completed human turns persisted before this conversation object
+    // was (re)created — e.g. after an idle eviction or daemon restart.
+    mockDbMessages = withIds([
+      userText("Hello"),
+      assistantText("Hi"),
+      userText("How are you?"),
+      assistantText("Good"),
+      userText("Bye"),
+      assistantText("Later"),
+    ]);
+
+    const conversation = makeConversation();
+    // Fresh object starts at 0 (the bug: it would stay 0 after reload).
+    expect(conversation.turnCount).toBe(0);
+
+    await conversation.loadFromDb();
+
+    expect(conversation.turnCount).toBe(3);
+  });
+
+  test("counts a multi-iteration tool-use turn as a single turn", async () => {
+    // One real user message; the tool_result user messages are continuations
+    // within the same turn, not new turns.
+    mockDbMessages = withIds([
+      userText("convert the voice memo"),
+      assistantToolUse("tu_1"),
+      toolResult("tu_1"),
+      assistantToolUse("tu_2"),
+      toolResult("tu_2"),
+      assistantText("done"),
+    ]);
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+
+    expect(conversation.turnCount).toBe(1);
+  });
+
+  test("counts only real user turns when tool iterations are interleaved", async () => {
+    mockDbMessages = withIds([
+      userText("q1"),
+      assistantToolUse("tu_1"),
+      toolResult("tu_1"),
+      assistantText("a1"),
+      userText("q2"),
+      assistantText("a2"),
+    ]);
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+
+    expect(conversation.turnCount).toBe(2);
+  });
+
+  test("empty history yields turnCount 0", async () => {
+    mockDbMessages = [];
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+
+    expect(conversation.turnCount).toBe(0);
+  });
+});

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -175,6 +175,36 @@ import { TraceEmitter } from "./trace-emitter.js";
 
 const log = getLogger("conversation");
 
+/**
+ * Whether a persisted message starts a new conversation turn. A turn is
+ * delimited by a "real" user message; a user message whose content is entirely
+ * tool_result blocks is a continuation within the current turn, and assistant
+ * messages never start one. Mirrors the turn-boundary definition used by
+ * `getAssistantMessageIdsInTurn`/`getTurnTimeBounds` and the agent loop's
+ * per-turn `turnCount++`, so counting these reconstructs `turnCount` on load.
+ */
+function startsNewTurn(role: string, content: string): boolean {
+  if (role !== "user") return false;
+  try {
+    const parsed = JSON.parse(content);
+    if (
+      Array.isArray(parsed) &&
+      parsed.length > 0 &&
+      parsed.every(
+        (block: unknown) =>
+          block != null &&
+          typeof block === "object" &&
+          (block as { type?: unknown }).type === "tool_result",
+      )
+    ) {
+      return false;
+    }
+  } catch {
+    // Non-JSON content is a plain user message — a turn boundary.
+  }
+  return true;
+}
+
 export interface CleanResult {
   previousEstimatedInputTokens: number;
   estimatedInputTokens: number;
@@ -828,6 +858,20 @@ export class Conversation {
     const dbMessages = isUntrustedTrustClass(trustClass)
       ? filterMessagesForUntrustedActor(allDbMessages)
       : allDbMessages;
+
+    // Rehydrate the in-memory turn counter from persisted history. `turnCount`
+    // is otherwise a fresh-zero field, so a reloaded conversation (eviction,
+    // restart, fork) would restart its turn numbering at 0 and the next turn
+    // would reuse `turnIndex` 0 — colliding with the conversation's first turn.
+    // The memory-v3 selector memoizes per (conversationId, turnIndex) for the
+    // life of the daemon process, so a collided turnIndex serves a stale
+    // selection and skips retrieval. One turn per real (turn-starting) user
+    // message, matching the agent loop's per-turn `turnCount++`. Counted from
+    // the full unsliced history so it survives compaction and is independent of
+    // the viewer's trust class.
+    this.turnCount = allDbMessages.filter((m) =>
+      startsNewTurn(m.role, m.content),
+    ).length;
 
     const conv = getConversation(this.conversationId);
     this.conversationType = conv?.conversationType ?? undefined;


### PR DESCRIPTION
## Summary

- Rehydrate `Conversation.turnCount` from persisted history in `loadFromDb()` (one per real, turn-starting user message) so it stays monotonic across eviction, daemon restart, and fork instead of resetting to 0.
- Fixes a silent memory-v3 regression: after the 30-minute idle eviction, a recreated conversation's next turn reused `turnIndex` 0, colliding with the first turn in the process-lifetime `observeTurnOnce` memo — so the selector reused a stale selection and skipped retrieval. Memory still rode forward via carry-forward, but no fresh selection ran and no `memory_v3_selections` rows were written, surfacing as "No memory data" in the LLM context inspector and frozen retrieval on resumed turns.
- Add `loadFromDb` turn-count rehydration tests: multi-turn restore (not 0), a multi-iteration tool-use turn counts as one, interleaved tool results, and empty history.

## Original prompt

Started from "why is there no memory information in the LLM context inspector for this turn?" in a conversation that resumed after a long idle gap. The investigation showed memory was actually present (carried forward), but the per-turn selection record was missing because the memory-v3 selector never re-ran for that turn. Root cause: `turnCount` resets to 0 when a conversation is reloaded after the 30-minute idle eviction, colliding `turnIndex` with the first turn and making the selector's in-memory `observeTurnOnce` memo serve a stale selection. This PR rehydrates `turnCount` from persisted history so it survives eviction/restart/fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)