### PR TITLE
fix(ui-surface): steer weak models off empty dynamic_page to declarative surfaces

### DIFF
--- a/assistant/src/__tests__/dynamic-page-surface.test.ts
+++ b/assistant/src/__tests__/dynamic-page-surface.test.ts
@@ -151,6 +151,57 @@ describe("ui_show dynamic_page app substitute guard", () => {
     expect(proxied).toBe(false);
   });
 
+  test("redirects a weak open model to a declarative surface, not 'resend HTML'", async () => {
+    let proxied = false;
+
+    const result = await uiShowTool.execute(
+      {
+        surface_type: "dynamic_page",
+        title: "Fable 5 vs MiniMax M3",
+        data: {},
+      },
+      {
+        conversationId: "conversation-123",
+        workingDir: "/tmp",
+        trustClass: "guardian",
+        attribution: {
+          resolvedModel: "accounts/fireworks/models/minimax-m3",
+        } as never,
+        proxyToolResolver: async () => {
+          proxied = true;
+          return { content: "proxied", isError: false };
+        },
+      },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('surface_type: "table"');
+    expect(result.content).toContain("work_result");
+    expect(result.content).not.toContain("Resend ui_show with the full HTML");
+    expect(proxied).toBe(false);
+  });
+
+  test("keeps the resend-HTML hint for a capable model", async () => {
+    const result = await uiShowTool.execute(
+      {
+        surface_type: "dynamic_page",
+        title: "Fable 5 vs MiniMax M3",
+        data: {},
+      },
+      {
+        conversationId: "conversation-123",
+        workingDir: "/tmp",
+        trustClass: "guardian",
+        attribution: { resolvedModel: "claude-opus-4-8" } as never,
+        proxyToolResolver: async () => ({ content: "proxied", isError: false }),
+      },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Resend ui_show with the full HTML");
+    expect(result.content).not.toContain('surface_type: "table"');
+  });
+
   test("rejects dynamic_page with whitespace-only html and does not proxy", async () => {
     let proxied = false;
 

--- a/assistant/src/__tests__/task-progress-nudge-hook.test.ts
+++ b/assistant/src/__tests__/task-progress-nudge-hook.test.ts
@@ -104,7 +104,7 @@ function currentResponse(toolUseId: string): ToolResultContent {
   };
 }
 
-/** A weak-model id that matches WEAK_MODEL_PATTERN (the gated population). */
+/** A weak-model id that matches WEAK_OPEN_MODEL_PATTERN (the gated population). */
 const WEAK_MODEL = "minimax/minimax-m3";
 
 function makeCtx(

--- a/assistant/src/__tests__/weak-open-model.test.ts
+++ b/assistant/src/__tests__/weak-open-model.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+
+import { isWeakOpenModel } from "../providers/weak-open-model.js";
+
+describe("isWeakOpenModel", () => {
+  test("matches weak open models across provider naming conventions", () => {
+    for (const model of [
+      "accounts/fireworks/models/minimax-m3",
+      "minimax/minimax-m3",
+      "moonshotai/kimi-k2.6",
+      "accounts/fireworks/models/kimi-k2p6",
+      "deepseek/deepseek-chat",
+    ]) {
+      expect(isWeakOpenModel(model)).toBe(true);
+    }
+  });
+
+  test("does not match capable models", () => {
+    for (const model of ["claude-opus-4-8", "claude-sonnet-4-6", "gpt-5.5"]) {
+      expect(isWeakOpenModel(model)).toBe(false);
+    }
+  });
+
+  test("is false for null/undefined/empty", () => {
+    expect(isWeakOpenModel(null)).toBe(false);
+    expect(isWeakOpenModel(undefined)).toBe(false);
+    expect(isWeakOpenModel("")).toBe(false);
+  });
+});

--- a/assistant/src/plugins/defaults/task-progress-nudge/hooks/post-tool-use.ts
+++ b/assistant/src/plugins/defaults/task-progress-nudge/hooks/post-tool-use.ts
@@ -48,6 +48,7 @@
 import type { PluginHookFn, PostToolUseContext } from "@vellumai/plugin-api";
 
 import type { ContentBlock, Message } from "../../../../providers/types.js";
+import { isWeakOpenModel } from "../../../../providers/weak-open-model.js";
 
 /**
  * Canonical nudge notice. Module-level constant so tests and wrapping plugins
@@ -65,17 +66,6 @@ export const TASK_PROGRESS_NUDGE_TEXT =
  * nudged, and only once. Lower from telemetry if cards still arrive too late.
  */
 export const TASK_PROGRESS_NUDGE_ROUND_THRESHOLD = 3;
-
-/**
- * Weaker open models that disregard the static progress-card instruction and
- * so get the mid-turn nudge: Kimi, DeepSeek, and MiniMax. Family-level matching
- * spans provider naming conventions (OpenRouter `moonshotai/kimi-k2.6`,
- * `deepseek/deepseek-chat`, `minimax/minimax-m3`; Fireworks
- * `accounts/fireworks/models/minimax-m3`, `kimi-k2p6`). Extend as other models
- * show the same gap. Capable models (Claude, GPT) follow the prompt and are
- * intentionally excluded.
- */
-const WEAK_MODEL_PATTERN = /kimi|deepseek|minimax/i;
 
 /**
  * Round count at the last nudge, per conversation. A non-zero entry means the
@@ -145,7 +135,7 @@ function scanTurn(messages: ReadonlyArray<Message>): {
 }
 
 const postToolUse: PluginHookFn<PostToolUseContext> = async (ctx) => {
-  if (!WEAK_MODEL_PATTERN.test(ctx.model)) return;
+  if (!isWeakOpenModel(ctx.model)) return;
 
   const { rounds, taskProgressShown } = scanTurn(ctx.messages);
 

--- a/assistant/src/providers/weak-open-model.ts
+++ b/assistant/src/providers/weak-open-model.ts
@@ -1,0 +1,22 @@
+/**
+ * Family-level classification of "weak open models" — open-weight models
+ * (Kimi, DeepSeek, MiniMax) that disregard static instructions and have
+ * capability gaps that capable models (Claude, GPT) do not. Used by harness
+ * levers that coach or redirect these models without touching capable-model
+ * behavior: the task-progress-nudge plugin and the empty-dynamic_page surface
+ * redirect.
+ *
+ * Family-level matching spans provider naming conventions: OpenRouter
+ * `moonshotai/kimi-k2.6`, `deepseek/deepseek-chat`, `minimax/minimax-m3`;
+ * Fireworks `accounts/fireworks/models/minimax-m3`, `kimi-k2p6`. Extend the
+ * pattern as other open models show the same gaps.
+ *
+ * Distinct from exploration-drift's narrower `LOOP_PRONE_MODEL_PATTERN`, which
+ * targets specific loop-prone versions rather than the whole capability family.
+ */
+export const WEAK_OPEN_MODEL_PATTERN = /kimi|deepseek|minimax/i;
+
+/** True when `model` is a weak open model (see {@link WEAK_OPEN_MODEL_PATTERN}). */
+export function isWeakOpenModel(model: string | null | undefined): boolean {
+  return typeof model === "string" && WEAK_OPEN_MODEL_PATTERN.test(model);
+}

--- a/assistant/src/tools/ui-surface/definitions.ts
+++ b/assistant/src/tools/ui-surface/definitions.ts
@@ -8,6 +8,7 @@
  */
 
 import { RiskLevel } from "../../permissions/types.js";
+import { isWeakOpenModel } from "../../providers/weak-open-model.js";
 import { ACTIVATION_MOMENT_PARAMS } from "../../telemetry/activation-funnel.js";
 import type {
   ToolContext,
@@ -37,8 +38,9 @@ function proxyExecute(toolName: string) {
   ): Promise<ToolExecutionResult> => {
     if (toolName === "ui_show" && isEmptyDynamicPage(input)) {
       return {
-        content:
-          "Error: ui_show dynamic_page requires non-empty HTML in `data.html`. The surface was not displayed because no content was provided — the user would see a blank box. Resend ui_show with the full HTML markup in `data.html`.",
+        content: isWeakOpenModel(context.attribution?.resolvedModel)
+          ? EMPTY_DYNAMIC_PAGE_DECLARATIVE_REDIRECT
+          : EMPTY_DYNAMIC_PAGE_HTML_HINT,
         isError: true,
       };
     }
@@ -88,6 +90,27 @@ function proxyExecute(toolName: string) {
     return result;
   };
 }
+
+/**
+ * Rejection envelope for an empty `dynamic_page` ui_show from a capable model:
+ * the surface carried no `data.html`, so it would render as a blank box. These
+ * models reliably author HTML, so the fix is simply to resend it inline.
+ */
+const EMPTY_DYNAMIC_PAGE_HTML_HINT =
+  "Error: ui_show dynamic_page requires non-empty HTML in `data.html`. The surface was not displayed because no content was provided — the user would see a blank box. Resend ui_show with the full HTML markup in `data.html`.";
+
+/**
+ * Rejection envelope for an empty `dynamic_page` ui_show from a weak open model.
+ * Authoring full HTML inline is the generation task these models fail at (an
+ * empty `data: {}` here, or broken markup otherwise), so steering them to
+ * "resend the HTML" just repeats the failure. Most widget requests are really
+ * structured data — comparisons, results, metrics — which render reliably via a
+ * field-based surface the model populates without writing any HTML, and which
+ * cannot render blank. dynamic_page stays available for genuinely custom visual
+ * HTML.
+ */
+const EMPTY_DYNAMIC_PAGE_DECLARATIVE_REDIRECT =
+  'Error: ui_show dynamic_page was not displayed — `data.html` was empty, so the user would see a blank box. Authoring full HTML inline is error-prone; for data, comparisons, results, or metrics prefer a structured surface, which you fill with fields (no HTML) and which never renders blank. Re-show the content as one of: a `table` (ui_show { surface_type: "table", data: { columns: [{ id, label }], rows: [{ id, cells: { <columnId>: "<value>" } }] } }), a `card` ({ title, body, metadata: [{ label, value }] }), or `work_result` ({ summary, metrics: [{ label, value }] }). Only use dynamic_page when you genuinely need custom visual HTML, in which case include the complete markup in `data.html` now.';
 
 /**
  * Worked ui_update example, appended to a successful task_progress `ui_show`


### PR DESCRIPTION
## Problem

`dynamic_page` is a **freehand-HTML-authoring surface** — the model must emit complete, correct HTML into one `data.html` field, one-shot, no scaffolding. That's the generation task weak open models (MiniMax M3, Kimi, DeepSeek) fail at: they send an empty `data: {}` (renders a blank box) or broken markup.

From dogfood feedback (`019ed37f`): on balanced-economy (MiniMax M3), "can we build a widget here in chat instead of a png" produced `ui_show { surface_type: "dynamic_page", title: "Fable 5 vs MiniMax M3", data: {} }` → a blank box.

The existing empty-surface guard (#34940) tells the model to *"resend with the full HTML markup"* — i.e. redo the exact thing it just failed at. For a weak model that's a recipe for a second empty/broken attempt.

## Change

Make the empty-`dynamic_page` rejection **model-aware**. For weak open models the envelope redirects to a **declarative surface** (`table` / `card` / `work_result`) — which the model populates with *fields* rather than HTML (reliable for weak models) and which **cannot render blank**. `dynamic_page` stays available for genuinely custom visual HTML.

This is the open-weight-only behavior lever, chosen over routing to app-builder because: (1) app-builder is a multi-step skill workflow — the highest-thrash terrain for M3; (2) declarative is one tool call with fields; (3) it matches the "widget *here in chat*" intent better than a heavier app artifact. The existing `isDynamicPageAppSubstitute` app-builder steer is left intact for the case where M3 actually emits substantial interactive HTML.

### Capable models are provably unaffected

- The branch lives in the **tool executor's error path**, not the shared tool **description** — so Claude/GPT pay zero extra context and never hit it in practice.
- It gates on `attribution.resolvedModel` matching the weak-open-model family (`/kimi|deepseek|minimax/i`) — the same gate `task-progress-nudge` / `exploration-drift` already use.
- Reading the **ground-truth resolved model** (not the workspace active profile) means it correctly covers per-conversation model overrides — the blind spot that a `pre-model-call` prompt hook would miss (and the reason #34956's approach didn't fit).

### Why reactive, not a prompt nudge

A `pre-model-call` nudge is the #34956 shape (prose-adherence weakness + the profile blind spot above). A deterministic guard-redirect that sees the resolved model is more reliable and costs no prompt bytes.

## Refactor

New `providers/weak-open-model.ts` — single home for the broad weak-open-model family gate (`isWeakOpenModel`), consumed by the surface guard and by `task-progress-nudge` (de-dups the identical regex it carried). `exploration-drift`'s intentionally-narrower loop-prone pattern is left alone.

## Honest limitations

Reactive — fires *after* the empty call, so it changes M3's recovery trajectory, not its first attempt; and it only helps if the daemon carrying it is deployed (the incident itself was partly a daemon-deployment-lag issue: the managed daemon predated #34940). It can't catch broken-but-non-empty HTML. The deeper question — whether M3 should be the main-agent model for generation tasks at all — is the model-swap decision, not this guard.

## Tests / checks

`bunx tsc --noEmit` clean; lint clean; 42 tests pass across the three affected files. New `weak-open-model.test.ts` covers family matching across provider naming conventions; new guard tests assert weak models get the declarative redirect and capable models keep the resend-HTML hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)