### PR TITLE
fix(conversation): count web_search_tool_result as a turn continuation

### DIFF
--- a/assistant/src/daemon/conversation-history.ts
+++ b/assistant/src/daemon/conversation-history.ts
@@ -23,7 +23,7 @@ const log = getLogger("conversation-history");
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
-function isToolResultBlock(
+export function isToolResultBlock(
   block: ContentBlock | Record<string, unknown>,
 ): boolean {
   return (

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -107,7 +107,7 @@ import {
   runAgentLoopImpl,
 } from "./conversation-agent-loop.js";
 import type { HistoryConversationContext } from "./conversation-history.js";
-import { undo as undoImpl } from "./conversation-history.js";
+import { isToolResultBlock, undo as undoImpl } from "./conversation-history.js";
 import {
   abortConversation,
   disposeConversation,
@@ -194,7 +194,7 @@ function startsNewTurn(role: string, content: string): boolean {
         (block: unknown) =>
           block != null &&
           typeof block === "object" &&
-          (block as { type?: unknown }).type === "tool_result",
+          isToolResultBlock(block as Record<string, unknown>),
       )
     ) {
       return false;


### PR DESCRIPTION
## Why

**`main` is currently red.** #35153 added `startsNewTurn` (turnCount rehydration on load), which classifies a user message as a turn *continuation* only when **every** block is a raw `tool_result`. A turn whose continuation carries web-search results (`web_search_tool_result` blocks) is misread as a *new* turn, inflating the reconstructed `turnCount`. The `web_search_tool_result` structural guard (`conversation-history-web-search.test.ts`) catches exactly this and is failing on main:

```
Violations:
  - daemon/conversation.ts:197: (block as { type?: unknown }).type === "tool_result",
```

## Fix

Use the canonical `isToolResultBlock()` — now exported from `conversation-history.ts` — which already counts both `tool_result` and `web_search_tool_result`. One-liner, the guard's preferred remedy (option 1).

## Verification

- `conversation-history-web-search.test.ts` guard: 8/8 pass (was failing).
- `conversation-load-history-repair.test.ts` turnCount-rehydration suite (#35153's own tests): 15/15 pass.
- `tsc --noEmit` / lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)