### PR TITLE
refactor(notifications): unify access-request card projection across Slack + Surface renderers

### DIFF
--- a/assistant/src/__tests__/access-request-card-view.test.ts
+++ b/assistant/src/__tests__/access-request-card-view.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildAccessRequestCardView,
+  parseAccessRequestPayload,
+} from "../notifications/access-request-copy.js";
+
+function view(raw: Record<string, unknown>) {
+  return buildAccessRequestCardView(parseAccessRequestPayload(raw));
+}
+
+const TAB = String.fromCharCode(9);
+
+describe("buildAccessRequestCardView", () => {
+  test("prefers actorDisplayName, falls back to senderIdentifier then 'Someone'", () => {
+    expect(
+      view({ actorDisplayName: "Alice", senderIdentifier: "U999" }).displayName,
+    ).toBe("Alice");
+    expect(view({ senderIdentifier: "U999" }).displayName).toBe("U999");
+    expect(view({}).displayName).toBe("Someone");
+  });
+
+  test("sanitizes identity fields (strips control characters)", () => {
+    const v = view({
+      actorDisplayName: `Al${TAB}ice`,
+      actorUsername: `a${TAB}lice`,
+      actorExternalId: `U9${TAB}99`,
+    });
+    expect(v.displayName).toBe("Al ice");
+    expect(v.username).toBe("a lice");
+    expect(v.externalId).toBe("U9 99");
+  });
+
+  test("username and externalId are undefined when absent", () => {
+    const v = view({ actorDisplayName: "Alice" });
+    expect(v.username).toBeUndefined();
+    expect(v.externalId).toBeUndefined();
+  });
+
+  test("detects Slack DM conversations", () => {
+    expect(
+      view({ sourceChannel: "slack", conversationExternalId: "D01XYZ" })
+        .isSlackDm,
+    ).toBe(true);
+    expect(
+      view({ sourceChannel: "slack", conversationExternalId: "C01ABC" })
+        .isSlackDm,
+    ).toBe(false);
+    expect(
+      view({ sourceChannel: "telegram", conversationExternalId: "D01XYZ" })
+        .isSlackDm,
+    ).toBe(false);
+  });
+
+  test("builds a Slack permalink only with slack source + conversation + ts", () => {
+    expect(
+      view({
+        sourceChannel: "slack",
+        conversationExternalId: "C01ABC",
+        messageTs: "1700000000.000100",
+      }).messagePermalink,
+    ).toBe("https://slack.com/archives/C01ABC/p1700000000000100");
+    expect(
+      view({ sourceChannel: "slack", conversationExternalId: "C01ABC" })
+        .messagePermalink,
+    ).toBeUndefined();
+    expect(
+      view({
+        sourceChannel: "telegram",
+        conversationExternalId: "C01ABC",
+        messageTs: "1.2",
+      }).messagePermalink,
+    ).toBeUndefined();
+  });
+
+  test("sanitizes message preview and yields undefined when blank after sanitizing", () => {
+    expect(view({ messagePreview: "  hello  " }).messagePreview).toBe("hello");
+    // Blank / control-character-only previews sanitize to empty → undefined
+    // (no empty quote block is rendered downstream).
+    expect(view({ messagePreview: "" }).messagePreview).toBeUndefined();
+    expect(view({ messagePreview: "   " }).messagePreview).toBeUndefined();
+    expect(view({}).messagePreview).toBeUndefined();
+  });
+
+  test("collects trust/security warnings", () => {
+    const v = view({
+      isStranger: true,
+      isRestricted: true,
+      previousMemberStatus: "revoked",
+    });
+    expect(v.warnings).toEqual([
+      "This user was previously revoked.",
+      "External Slack user (not in this workspace).",
+      "Guest / restricted account.",
+    ]);
+    expect(view({}).warnings).toEqual([]);
+  });
+});

--- a/assistant/src/__tests__/slack-notification-approval-card.test.ts
+++ b/assistant/src/__tests__/slack-notification-approval-card.test.ts
@@ -6,11 +6,10 @@ import type { ChannelDeliveryPayload } from "../notifications/types.js";
 import type { ApprovalUIMetadata } from "../runtime/channel-approval-types.js";
 
 /**
- * Characterization tests for the Slack approval-card block output.
- *
- * The Slack notification card builders had no direct coverage; these lock in
- * the exact block shapes so the refactor that routes them through
- * `buildAccessRequestCardView` stays behavior-preserving.
+ * Pins the Slack approval-card block contract: the title, identity subtitle,
+ * quoted-preview body, action callback ids, source/permalink and requester-id
+ * context blocks, warning subtext, and guardian verification note that
+ * `buildApprovalNotificationBlocks` emits for an access request.
  */
 
 const APPROVAL: ApprovalUIMetadata = {

--- a/assistant/src/__tests__/slack-notification-approval-card.test.ts
+++ b/assistant/src/__tests__/slack-notification-approval-card.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseAccessRequestPayload } from "../notifications/access-request-copy.js";
+import { buildApprovalNotificationBlocks } from "../notifications/adapters/slack.js";
+import type { ChannelDeliveryPayload } from "../notifications/types.js";
+import type { ApprovalUIMetadata } from "../runtime/channel-approval-types.js";
+
+/**
+ * Characterization tests for the Slack approval-card block output.
+ *
+ * The Slack notification card builders had no direct coverage; these lock in
+ * the exact block shapes so the refactor that routes them through
+ * `buildAccessRequestCardView` stays behavior-preserving.
+ */
+
+const APPROVAL: ApprovalUIMetadata = {
+  requestId: "req-123",
+  actions: [
+    { id: "approve_once", label: "Approve once" },
+    { id: "reject", label: "Reject" },
+  ],
+  plainTextFallback: 'Reply "ABC123 approve" or "ABC123 reject"',
+};
+
+function buildPayload(
+  raw: Record<string, unknown>,
+  approval: ApprovalUIMetadata = APPROVAL,
+): ChannelDeliveryPayload {
+  return {
+    sourceEventName: "ingress.access_request",
+    copy: { title: "Access Request", body: "Someone is requesting access" },
+    urgency: "high",
+    approvalContext: approval,
+    accessRequestContext: parseAccessRequestPayload(raw),
+  };
+}
+
+type Block = Record<string, unknown>;
+
+function card(blocks: unknown[]): Block {
+  const c = (blocks as Block[]).find((b) => b.type === "card");
+  if (!c) throw new Error("no card block");
+  return c;
+}
+
+function contextTexts(blocks: unknown[]): string[] {
+  return (blocks as Block[])
+    .filter((b) => b.type === "context")
+    .map((b) => {
+      const elements = b.elements as Array<{ text: string }>;
+      return elements.map((e) => e.text).join("");
+    });
+}
+
+function text(node: unknown): string {
+  return (node as { text: string }).text;
+}
+
+const BASE: Record<string, unknown> = {
+  requestId: "req-123",
+  requestCode: "ABC123",
+  sourceChannel: "slack",
+  conversationExternalId: "C01ABC",
+  actorExternalId: "U999",
+  actorDisplayName: "Alice",
+  actorUsername: "alice",
+  senderIdentifier: "U999",
+  messagePreview: "Hello, I need help with something",
+  messageTs: "1700000000.000100",
+};
+
+describe("Slack access-request card blocks", () => {
+  test("card carries title, identity subtitle, and quoted preview body", () => {
+    const c = card(buildApprovalNotificationBlocks(buildPayload(BASE), "msg"));
+    expect(text(c.title)).toBe("Access Request");
+    expect(text(c.subtitle)).toBe("Alice (@alice) via slack");
+    expect(text(c.body)).toBe('> _"Hello, I need help with something"_');
+  });
+
+  test("card actions encode the apr:<requestId>:<action> callback ids", () => {
+    const c = card(buildApprovalNotificationBlocks(buildPayload(BASE), "msg"));
+    const actions = c.actions as Array<Record<string, unknown>>;
+    expect(actions).toHaveLength(2);
+    expect(actions[0].action_id).toBe("apr:req-123:approve_once");
+    expect(actions[0].style).toBe("primary");
+    expect(actions[1].action_id).toBe("apr:req-123:reject");
+    expect(actions[1].style).toBe("danger");
+  });
+
+  test("source context renders a channel mention with permalink", () => {
+    const texts = contextTexts(
+      buildApprovalNotificationBlocks(buildPayload(BASE), "msg"),
+    );
+    expect(texts).toContain(
+      "Source: Slack — <#C01ABC> · <https://slack.com/archives/C01ABC/p1700000000000100|View message>",
+    );
+  });
+
+  test("DM source renders as Direct message", () => {
+    const blocks = buildApprovalNotificationBlocks(
+      buildPayload({ ...BASE, conversationExternalId: "D01XYZ" }),
+      "msg",
+    );
+    expect(contextTexts(blocks)).toContain(
+      "Source: Slack — Direct message · <https://slack.com/archives/D01XYZ/p1700000000000100|View message>",
+    );
+  });
+
+  test("requester id block appears when external id adds info", () => {
+    const texts = contextTexts(
+      buildApprovalNotificationBlocks(buildPayload(BASE), "msg"),
+    );
+    expect(texts).toContain("ID: U999");
+  });
+
+  test("invite directive context block is always present", () => {
+    const texts = contextTexts(
+      buildApprovalNotificationBlocks(buildPayload(BASE), "msg"),
+    );
+    expect(texts).toContain(
+      'Reply "open invite flow" to start Trusted Contacts invite flow.',
+    );
+  });
+
+  test("warnings render in the card subtext", () => {
+    const c = card(
+      buildApprovalNotificationBlocks(
+        buildPayload({
+          ...BASE,
+          isStranger: true,
+          isRestricted: true,
+          previousMemberStatus: "revoked",
+        }),
+        "msg",
+      ),
+    );
+    const subtext = text(c.subtext);
+    expect(subtext).toContain(":warning: This user was previously revoked.");
+    expect(subtext).toContain(
+      ":warning: External Slack user (not in this workspace).",
+    );
+    expect(subtext).toContain(":warning: Guest / restricted account.");
+  });
+
+  test("no subtext when there are no warnings", () => {
+    const c = card(buildApprovalNotificationBlocks(buildPayload(BASE), "msg"));
+    expect(c.subtext).toBeUndefined();
+  });
+
+  test("body falls back to a default label when no preview", () => {
+    const c = card(
+      buildApprovalNotificationBlocks(
+        buildPayload({ ...BASE, messagePreview: undefined }),
+        "msg",
+      ),
+    );
+    expect(text(c.body)).toBe("Requesting access to the assistant");
+  });
+
+  test("guardian verification note appears for fallback guardian resolution", () => {
+    const texts = contextTexts(
+      buildApprovalNotificationBlocks(
+        buildPayload({ ...BASE, guardianResolutionSource: "vellum-anchor" }),
+        "msg",
+      ),
+    );
+    expect(
+      texts.some((t) => t.includes("haven't verified your identity on slack")),
+    ).toBe(true);
+  });
+});

--- a/assistant/src/notifications/access-request-copy.ts
+++ b/assistant/src/notifications/access-request-copy.ts
@@ -312,6 +312,92 @@ export function buildAccessRequestContractText(
   return lines.join("\n");
 }
 
+// ── Card view model ─────────────────────────────────────────────────────────
+
+/**
+ * Display-ready projection of an access request, shared by every renderer
+ * (the Vellum Surface card and the Slack Card block). It carries the
+ * sanitized, pre-computed facts each renderer needs — identity sanitizing,
+ * warnings, permalink, DM detection, preview sanitizing — so that projection
+ * lives in exactly one place. Renderers lay these facts out in their
+ * channel-native shape without re-deriving them.
+ */
+export interface AccessRequestCardView {
+  /** Sanitized display name (actorDisplayName ?? senderIdentifier, else "Someone"). */
+  displayName: string;
+  /** Sanitized username, without the leading `@`. */
+  username: string | undefined;
+  /** Sanitized external ID. */
+  externalId: string | undefined;
+  sourceChannel: string | undefined;
+  conversationExternalId: string | undefined;
+  /** Whether the source Slack conversation is a DM. */
+  isSlackDm: boolean;
+  /** Slack permalink — present only for a slack source with conversation + ts. */
+  messagePermalink: string | undefined;
+  /** Sanitized message preview, or undefined when blank after sanitizing. */
+  messagePreview: string | undefined;
+  /** Human-readable trust/security warnings. */
+  warnings: string[];
+  guardianResolutionSource: string | undefined;
+  requestId: string | undefined;
+}
+
+/**
+ * Project a parsed access-request payload into display-ready card facts.
+ *
+ * The payload is parsed once upstream — the broadcaster resolves
+ * `accessRequestContext`, and the Surface seed path parses the raw payload —
+ * so this takes the parsed payload rather than re-parsing it.
+ */
+export function buildAccessRequestCardView(
+  p: ParsedAccessRequestPayload,
+): AccessRequestCardView {
+  const rawName = nonEmpty(p.actorDisplayName) ?? nonEmpty(p.senderIdentifier);
+  const displayName = rawName ? sanitizeIdentityField(rawName) : "Someone";
+
+  const rawUsername = nonEmpty(p.actorUsername);
+  const username = rawUsername ? sanitizeIdentityField(rawUsername) : undefined;
+
+  const rawExternalId = nonEmpty(p.actorExternalId);
+  const externalId = rawExternalId
+    ? sanitizeIdentityField(rawExternalId)
+    : undefined;
+
+  const sourceChannel = nonEmpty(p.sourceChannel);
+  const conversationExternalId = nonEmpty(p.conversationExternalId);
+  const messageTs = nonEmpty(p.messageTs);
+
+  const isSlackDm =
+    sourceChannel === "slack" && conversationExternalId != null
+      ? isSlackDmConversation(conversationExternalId)
+      : false;
+
+  const messagePermalink =
+    sourceChannel === "slack" && conversationExternalId && messageTs
+      ? buildSlackMessagePermalink(conversationExternalId, messageTs)
+      : undefined;
+
+  const rawPreview = nonEmpty(p.messagePreview);
+  const messagePreview = rawPreview
+    ? sanitizeMessagePreview(rawPreview) || undefined
+    : undefined;
+
+  return {
+    displayName,
+    username,
+    externalId,
+    sourceChannel,
+    conversationExternalId,
+    isSlackDm,
+    messagePermalink,
+    messagePreview,
+    warnings: buildAccessRequestWarnings(p),
+    guardianResolutionSource: nonEmpty(p.guardianResolutionSource),
+    requestId: nonEmpty(p.requestId),
+  };
+}
+
 // ── Seed content blocks (Surface-based rendering) ───────────────────────────
 
 /**
@@ -324,47 +410,38 @@ export function buildAccessRequestContractText(
 export function buildAccessRequestSeedContentBlocks(
   payload: Record<string, unknown>,
 ): unknown[] {
-  const p = parseAccessRequestPayload(payload);
-
-  const rawName = nonEmpty(p.actorDisplayName) ?? nonEmpty(p.senderIdentifier);
-  const displayName = rawName ? sanitizeIdentityField(rawName) : "Someone";
+  const view = buildAccessRequestCardView(parseAccessRequestPayload(payload));
 
   const metadata: Array<{ label: string; value: string }> = [];
 
-  if (p.actorUsername) {
+  if (view.username) {
     metadata.push({
       label: "Username",
-      value: `@${sanitizeIdentityField(p.actorUsername)}`,
+      value: `@${view.username}`,
     });
   }
 
-  if (p.sourceChannel === "slack" && p.conversationExternalId) {
-    const isDm = isSlackDmConversation(p.conversationExternalId);
+  if (view.sourceChannel === "slack" && view.conversationExternalId) {
     metadata.push({
       label: "Source",
-      value: isDm
+      value: view.isSlackDm
         ? "Slack — Direct message"
-        : `Slack — #${p.conversationExternalId}`,
+        : `Slack — #${view.conversationExternalId}`,
     });
-  } else if (p.sourceChannel) {
-    metadata.push({ label: "Source", value: p.sourceChannel });
+  } else if (view.sourceChannel) {
+    metadata.push({ label: "Source", value: view.sourceChannel });
   }
 
-  const warnings = buildAccessRequestWarnings(p);
   const bodyParts: string[] = [];
 
-  if (p.messagePreview) {
-    bodyParts.push(`> "${sanitizeMessagePreview(p.messagePreview)}"`);
+  if (view.messagePreview) {
+    bodyParts.push(`> "${view.messagePreview}"`);
   }
-  for (const w of warnings) {
+  for (const w of view.warnings) {
     bodyParts.push(`⚠️ ${w}`);
   }
-  if (p.sourceChannel === "slack" && p.conversationExternalId && p.messageTs) {
-    const permalink = buildSlackMessagePermalink(
-      p.conversationExternalId,
-      p.messageTs,
-    );
-    bodyParts.push(`[View message](${permalink})`);
+  if (view.messagePermalink) {
+    bodyParts.push(`[View message](${view.messagePermalink})`);
   }
 
   const body =
@@ -375,11 +452,11 @@ export function buildAccessRequestSeedContentBlocks(
   return buildApprovalCardBlocks({
     surfaceIdPrefix: "access-request",
     cardTitle: "Access Request",
-    requesterName: displayName,
+    requesterName: view.displayName,
     subtitle: "Requesting access to the assistant",
     body,
     metadata,
-    requestId: p.requestId,
+    requestId: view.requestId,
     fallbackText: buildAccessRequestContractText(payload),
   });
 }

--- a/assistant/src/notifications/adapters/slack.ts
+++ b/assistant/src/notifications/adapters/slack.ts
@@ -16,18 +16,11 @@ import { sendSlackReply } from "../../messaging/providers/slack/send.js";
 import type { ApprovalUIMetadata } from "../../runtime/channel-approval-types.js";
 import { getLogger } from "../../util/logger.js";
 import {
+  type AccessRequestCardView,
+  buildAccessRequestCardView,
   buildAccessRequestInviteDirective,
-  buildAccessRequestWarnings,
-  buildSlackMessagePermalink,
-  isSlackDmConversation,
-  type ParsedAccessRequestPayload,
 } from "../access-request-copy.js";
-import {
-  nonEmpty,
-  sanitizeIdentityField,
-  sanitizeMessagePreview,
-  truncate,
-} from "../notification-utils.js";
+import { truncate } from "../notification-utils.js";
 import type {
   ChannelAdapter,
   ChannelDeliveryPayload,
@@ -61,57 +54,48 @@ function buildCardActions(approval: ApprovalUIMetadata): unknown[] {
 // ---------------------------------------------------------------------------
 
 /** Concise requester identity for the card subtitle (≤150 chars). */
-function buildAccessRequestSubtitle(p: ParsedAccessRequestPayload): string {
-  const rawName = nonEmpty(p.actorDisplayName) ?? nonEmpty(p.senderIdentifier);
-  const displayName = rawName ? sanitizeIdentityField(rawName) : "Someone";
-  const parts = [displayName];
+function buildAccessRequestSubtitle(view: AccessRequestCardView): string {
+  const parts = [view.displayName];
 
-  const username = nonEmpty(p.actorUsername);
-  if (username) {
-    const safe = sanitizeIdentityField(username);
-    if (safe !== displayName) parts.push(`(@${safe})`);
+  if (view.username && view.username !== view.displayName) {
+    parts.push(`(@${view.username})`);
   }
 
-  if (p.sourceChannel) parts.push(`via ${p.sourceChannel}`);
+  if (view.sourceChannel) parts.push(`via ${view.sourceChannel}`);
 
   return truncate(parts.join(" "), 150);
 }
 
 /** Card body: message preview when available, otherwise a default label. */
-function buildAccessRequestBody(p: ParsedAccessRequestPayload): string {
-  if (p.messagePreview) {
-    const sanitized = sanitizeMessagePreview(p.messagePreview);
-    if (sanitized) {
-      // Truncate content before wrapping so formatting chars stay balanced.
-      // Wrapper `> _"..."_` is 6 chars; reserve space for them.
-      const trimmed = truncate(sanitized, 200 - 6);
-      return `> _"${trimmed}"_`;
-    }
+function buildAccessRequestBody(view: AccessRequestCardView): string {
+  if (view.messagePreview) {
+    // Truncate content before wrapping so formatting chars stay balanced.
+    // Wrapper `> _"..."_` is 6 chars; reserve space for them.
+    const trimmed = truncate(view.messagePreview, 200 - 6);
+    return `> _"${trimmed}"_`;
   }
   return "Requesting access to the assistant";
 }
 
 /** Source-channel context block with Slack permalink when available. */
 function buildSourceContextBlock(
-  p: ParsedAccessRequestPayload,
+  view: AccessRequestCardView,
 ): unknown | undefined {
-  if (p.sourceChannel !== "slack" || !p.conversationExternalId) {
+  if (view.sourceChannel !== "slack" || !view.conversationExternalId) {
     return undefined;
   }
 
-  const permalink = p.messageTs
-    ? buildSlackMessagePermalink(p.conversationExternalId, p.messageTs)
-    : undefined;
+  const permalink = view.messagePermalink;
 
   let sourceText: string;
-  if (isSlackDmConversation(p.conversationExternalId)) {
+  if (view.isSlackDm) {
     sourceText = permalink
       ? `Source: Slack — Direct message · <${permalink}|View message>`
       : "Source: Slack — Direct message";
   } else {
     sourceText = permalink
-      ? `Source: Slack — <#${p.conversationExternalId}> · <${permalink}|View message>`
-      : `Source: Slack — <#${p.conversationExternalId}>`;
+      ? `Source: Slack — <#${view.conversationExternalId}> · <${permalink}|View message>`
+      : `Source: Slack — <#${view.conversationExternalId}>`;
   }
 
   return {
@@ -122,27 +106,12 @@ function buildSourceContextBlock(
 
 /** Stable requester identifier context block (external ID when it adds info). */
 function buildRequesterIdBlock(
-  p: ParsedAccessRequestPayload,
+  view: AccessRequestCardView,
 ): unknown | undefined {
-  const safeExternalId = nonEmpty(
-    p.actorExternalId ? sanitizeIdentityField(p.actorExternalId) : undefined,
-  );
+  const safeExternalId = view.externalId;
   if (!safeExternalId) return undefined;
 
-  const displayedName = nonEmpty(
-    p.actorDisplayName
-      ? sanitizeIdentityField(p.actorDisplayName)
-      : p.senderIdentifier
-        ? sanitizeIdentityField(p.senderIdentifier)
-        : undefined,
-  );
-  const displayedUsername = nonEmpty(
-    p.actorUsername ? sanitizeIdentityField(p.actorUsername) : undefined,
-  );
-  if (
-    safeExternalId === displayedName ||
-    safeExternalId === displayedUsername
-  ) {
+  if (safeExternalId === view.displayName || safeExternalId === view.username) {
     return undefined;
   }
 
@@ -166,16 +135,15 @@ function buildAccessRequestCardBlocks(
   payload: ChannelDeliveryPayload,
 ): unknown[] {
   const approval = payload.approvalContext!;
-  const p = payload.accessRequestContext!;
+  const view = buildAccessRequestCardView(payload.accessRequestContext!);
   const blocks: unknown[] = [];
 
-  const subtitle = buildAccessRequestSubtitle(p);
-  const body = buildAccessRequestBody(p);
+  const subtitle = buildAccessRequestSubtitle(view);
+  const body = buildAccessRequestBody(view);
 
-  const warnings = buildAccessRequestWarnings(p);
   const subtext =
-    warnings.length > 0
-      ? truncate(warnings.map((w) => `:warning: ${w}`).join(" · "), 200)
+    view.warnings.length > 0
+      ? truncate(view.warnings.map((w) => `:warning: ${w}`).join(" · "), 200)
       : undefined;
 
   const card: Record<string, unknown> = {
@@ -188,10 +156,10 @@ function buildAccessRequestCardBlocks(
   if (subtext) card.subtext = { type: "mrkdwn", text: subtext };
   blocks.push(card);
 
-  const sourceContext = buildSourceContextBlock(p);
+  const sourceContext = buildSourceContextBlock(view);
   if (sourceContext) blocks.push(sourceContext);
 
-  const idBlock = buildRequesterIdBlock(p);
+  const idBlock = buildRequesterIdBlock(view);
   if (idBlock) blocks.push(idBlock);
 
   blocks.push({
@@ -200,16 +168,16 @@ function buildAccessRequestCardBlocks(
   });
 
   if (
-    (p.guardianResolutionSource === "vellum-anchor" ||
-      p.guardianResolutionSource === "none") &&
-    p.sourceChannel
+    (view.guardianResolutionSource === "vellum-anchor" ||
+      view.guardianResolutionSource === "none") &&
+    view.sourceChannel
   ) {
     blocks.push({
       type: "context",
       elements: [
         {
           type: "mrkdwn",
-          text: `_You haven't verified your identity on ${p.sourceChannel} yet. If this was you trying to message your assistant, say "help me verify as guardian on ${p.sourceChannel}" to set up direct access._`,
+          text: `_You haven't verified your identity on ${view.sourceChannel} yet. If this was you trying to message your assistant, say "help me verify as guardian on ${view.sourceChannel}" to set up direct access._`,
         },
       ],
     });
@@ -280,8 +248,10 @@ function buildToolApprovalCardBlocks(
 /**
  * Build Slack blocks for any notification carrying approval context.
  * Dispatches to the appropriate card builder based on source event type.
+ *
+ * Exported for characterization tests of the approval-card block output.
  */
-function buildApprovalNotificationBlocks(
+export function buildApprovalNotificationBlocks(
   payload: ChannelDeliveryPayload,
   messageText: string,
 ): unknown[] {


### PR DESCRIPTION
## Context

Follow-up to closing #34916 (LUM-2416). That PR's headline goals — centralize `contextPayload` parsing and stop the Slack adapter from re-parsing it — already landed on `main` via #35049 / #35053 / #35057, so #34916 was closed as superseded. This PR realizes the **one** piece those PRs didn't cover, against the current schema-first pipeline, and **without** adding a third overlapping typed field.

## Problem

The Slack Card adapter (`adapters/slack.ts`) and the Vellum Surface card (`access-request-copy.ts → buildAccessRequestSeedContentBlocks`) each independently derived the same access-request display facts from the parsed payload:

- sanitized display name (`actorDisplayName ?? senderIdentifier`, else "Someone")
- sanitized username / external id
- trust/security warnings
- Slack permalink + DM detection
- sanitized message preview

They shared the *leaf* helpers (`buildAccessRequestWarnings`, `buildSlackMessagePermalink`, `isSlackDmConversation`, `sanitize*`) but each re-assembled the projection — a drift surface, especially for the security warnings.

## Change

Introduce **`buildAccessRequestCardView()`** in `access-request-copy.ts`: a single projection from the already-parsed payload to display-ready facts (`AccessRequestCardView`). Both renderers now consume the view and only lay the facts out in their channel-native shape.

- **Single-parse preserved.** The view takes a *parsed* payload, so each path keeps its existing parse count — Slack uses the broadcaster's pre-parsed `payload.accessRequestContext`; the Surface seed path parses the raw payload once as before. No re-parsing was introduced.
- **No third payload field.** Rather than reviving #34916's `approvalCardData` field on `ChannelDeliveryPayload` (which would overlap the existing `accessRequestContext` / `approvalContext`), the view lives in the access-request domain module and is built on demand. The Slack adapter no longer needs the leaf helpers at all (net simpler).

### Scope

Intentionally limited to **access requests**, where the Slack and Surface renderers share inputs cleanly. Left as-is:

- **Tool-approval cards** — the Slack path only receives `approvalContext.permissionDetails` while the Surface path has the full guardian payload; unifying would force a re-parse or thread more context. Not worth it here.
- **The plain-text contract (`buildAccessRequestContractText`)** — bespoke phone-aware identity line and directive logic; different output, well-tested, left untouched.

## Minor fix

Previews that sanitize to empty (control-char / whitespace only) no longer render an empty `> ""` blockquote in the Surface card — the view returns `undefined` for a blank preview, matching the Slack path's existing guard.

## Tests

- **New characterization tests** for the Slack approval card (`slack-notification-approval-card.test.ts`) — this output had **no** direct coverage before; written and confirmed green against the pre-refactor code, then kept green through the refactor.
- **New unit tests** for `buildAccessRequestCardView` (`access-request-card-view.test.ts`).
- Existing `access-request-seed-content-blocks` / `tool-approval-seed-content-blocks` suites stay green.
- `bun run typecheck` and `bun run lint` clean; pre-commit + pre-push hooks pass.

> Note: several notification test files share global state and fail when run together in one `bun test` process (reproducible on `main`); each affected file passes in isolation, which is how CI runs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjGZaPm7boZy527GsEHcqQ)_