### PR TITLE
fix(web): subagent panel content clipping + redundant chat side-panel divider

### DIFF
--- a/clients/web/src/domains/chat/components/chat-content-layout.tsx
+++ b/clients/web/src/domains/chat/components/chat-content-layout.tsx
@@ -161,6 +161,7 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
     return (
       <ResizablePanel
         storageKey="appEditPanelWidth"
+        hideDivider
         defaultRightWidth={400}
         minLeftWidth={300}
         minRightWidth={400}
@@ -217,6 +218,7 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
     return (
       <ResizablePanel
         storageKey="documentPanelWidth"
+        hideDivider
         defaultRightWidth={400}
         minLeftWidth={300}
         minRightWidth={400}
@@ -248,6 +250,7 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
       return (
         <ResizablePanel
           storageKey="subagentDetailPanelWidth"
+          hideDivider
           defaultRightWidth={400}
           minLeftWidth={300}
           minRightWidth={400}

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -167,6 +167,7 @@ export function SubagentDetailPanel({
         )}
         <Typography
           variant="title-medium"
+          title={entry.label}
           className="min-w-0 shrink truncate text-[var(--content-default)]"
         >
           {entry.label}
@@ -233,7 +234,7 @@ export function SubagentDetailPanel({
             <Typography
               variant="body-medium-lighter"
               as="p"
-              className="whitespace-pre-wrap leading-relaxed text-[var(--content-default)]"
+              className="whitespace-pre-wrap break-words leading-relaxed text-[var(--content-default)]"
             >
               {entry.objective}
             </Typography>

--- a/clients/web/src/domains/chat/components/subagent-timeline.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-timeline.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * Tool-call timeline rows must let long, unbreakable content (file paths,
+ * URLs, long identifiers) wrap instead of overflowing the card and being
+ * clipped at the panel edge.
+ *
+ * The tool-call row lays `toolName` + `content` out as flex children, so each
+ * needs `min-w-0` (to shrink below its intrinsic min-content width — flex
+ * children default to `min-width: auto`) plus `break-words` (to actually break
+ * the long token once shrunk). Regression guard for the cut-off bug.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { SubagentTimeline } from "@/domains/chat/components/subagent-timeline";
+import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
+
+const LONG_PATH =
+  "/workspaces/worktrees/p3-fixup-fork/clients/web/src/domains/channel/handler-inbound-admission.test.ts";
+
+function toolCallEvent(
+  overrides: Partial<SubagentTimelineEvent> = {},
+): SubagentTimelineEvent {
+  return {
+    id: "evt-1",
+    type: "tool_call",
+    content: LONG_PATH,
+    toolName: "Read",
+    timestamp: 0,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SubagentTimeline — tool_call content wrapping", () => {
+  test("long content carries wrapping classes so it can't overflow the card", () => {
+    render(<SubagentTimeline events={[toolCallEvent()]} />);
+
+    const content = screen.getByText(LONG_PATH);
+    expect(content.className).toContain("min-w-0");
+    expect(content.className).toContain("break-words");
+  });
+
+  test("tool name carries wrapping classes too", () => {
+    const longName = "some_extremely_long_tool_name_identifier_that_could_overflow";
+    render(<SubagentTimeline events={[toolCallEvent({ toolName: longName })]} />);
+
+    const name = screen.getByText(longName);
+    expect(name.className).toContain("min-w-0");
+    expect(name.className).toContain("break-words");
+  });
+});

--- a/clients/web/src/domains/chat/components/subagent-timeline.tsx
+++ b/clients/web/src/domains/chat/components/subagent-timeline.tsx
@@ -200,7 +200,7 @@ function TimelineEventRow({
             {event.toolName && (
               <Typography
                 variant="body-medium-lighter"
-                className="text-[var(--content-tertiary)]"
+                className="min-w-0 break-words text-[var(--content-tertiary)]"
               >
                 {event.toolName}
               </Typography>
@@ -208,7 +208,7 @@ function TimelineEventRow({
             {event.content && (
               <Typography
                 variant="body-medium-lighter"
-                className="text-[var(--content-tertiary)]"
+                className="min-w-0 break-words text-[var(--content-tertiary)]"
               >
                 {event.content}
               </Typography>


### PR DESCRIPTION
Two related fixes for the chat side panels. (Folds in #35165.)

---

## 1. Subagent detail panel content was clipped at the edge

**Problem:** Long tool-call content in the subagent detail panel was cut off at the panel edge — file paths in the "Tool Call" timeline rows got clipped.

**Root cause:** In `subagent-timeline.tsx`, the `tool_call` branch renders `toolName` + `content` as **flex children** of `flex flex-wrap items-baseline`:
- A flex child defaults to `min-width: auto` = its content's **min-content** size. For an unbreakable token (a path like `/workspaces/.../handler-inbound-admission.test` from `summarizeToolInput`) that's the full path width, so the item refused to shrink.
- The branch also had **no wrapping rule** (`break-words`), unlike every *other* content branch in the file (Response / Tool Result / Error all wrap).

Result: the content overflowed the card and was clipped by the panel's `overflow-hidden` edge.

**Fix (CSS-only):**
- Timeline `tool_call` `toolName` + `content`: add `min-w-0 break-words` (`min-w-0` lets the flex child shrink; `break-words` then breaks the long token).
- Objective block: add `break-words` (block context, same overflow risk).
- Header label: add a `title` tooltip so the deliberately-truncated subagent name stays recoverable on hover.
- New `subagent-timeline.test.tsx` regression guard for the wrapping classes.

Mobile is covered automatically — `MobileSubagentDetailOverlay` reuses `SubagentDetailPanel`.

*Why `break-words` + `min-w-0` (not `wrap-anywhere` alone):* the "prefer `anywhere`" guidance only applies when you don't set `min-width: 0`. Since we set `min-w-0`, the item shrinks and `break-words` breaks it — equivalent here and consistent with the file's existing pattern.

---

## 2. Redundant resize divider next to every chat side panel

**Problem:** A 1px vertical line ran down the edge of every chat side panel (subagent detail, document viewer, app editor) — a redundant extra border since each panel already has its own rounded chrome.

**Root cause:** `ResizablePanel`'s separator draws an always-visible 1px line:
```tsx
<div className={cn("h-full w-px", hideDivider ? "bg-transparent" : "bg-[var(--border-base)]")} />
```
The component already exposes a `hideDivider` prop for exactly this case. The home page and the tool-detail drawer (`AnimatedRightDrawer`) already use the hidden-divider look; the three chat `ResizablePanel` side panels never passed it.

**Fix:** Pass `hideDivider` on the app-editing, document, and subagent-detail panels in `chat-content-layout.tsx`. Only the static line goes transparent — the drag hit-area and hover grab handle are untouched, so resizing still works. No design-library default changed, so no other `ResizablePanel` consumer is affected.

---

## Verification
- `eslint` ✅
- `tsc --noEmit` ✅
- `bun scripts/run-tests.ts` (per-file isolation) — new + existing panel tests pass ✅

## Risk
🟢 Green — CSS / prop-only, single domain, no logic/API/type changes. Short content unaffected; only long content now wraps. Orthogonal to #35151 (the LUM-2476 `Notice` login-banner fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)