### PR TITLE
fix(web): hide redundant resize divider next to chat side panels

### DIFF
--- a/clients/web/src/domains/chat/components/chat-content-layout.tsx
+++ b/clients/web/src/domains/chat/components/chat-content-layout.tsx
@@ -161,6 +161,7 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
     return (
       <ResizablePanel
         storageKey="appEditPanelWidth"
+        hideDivider
         defaultRightWidth={400}
         minLeftWidth={300}
         minRightWidth={400}
@@ -217,6 +218,7 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
     return (
       <ResizablePanel
         storageKey="documentPanelWidth"
+        hideDivider
         defaultRightWidth={400}
         minLeftWidth={300}
         minRightWidth={400}
@@ -248,6 +250,7 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
       return (
         <ResizablePanel
           storageKey="subagentDetailPanelWidth"
+          hideDivider
           defaultRightWidth={400}
           minLeftWidth={300}
           minRightWidth={400}


### PR DESCRIPTION
## Problem

A thin vertical line runs down the edge of every chat side panel (subagent detail, document viewer, app editor) — see screenshot. It reads as a redundant extra border because each side panel already has its own rounded container chrome.

## Root cause

`ResizablePanel`'s separator draws an always-visible 1px line:

```tsx
<div className={cn("h-full w-px", hideDivider ? "bg-transparent" : "bg-[var(--border-base)]")} />
```

The component already exposes a `hideDivider` prop (its doc comment: *"Useful when the right pane already has its own container chrome … and the separator line reads as a redundant extra border."*). The home page and the tool-detail drawer (`AnimatedRightDrawer`) already use the hidden-divider look, but the three chat `ResizablePanel` side panels never passed it.

## Fix

Pass `hideDivider` on the three chat side panels in `chat-content-layout.tsx`:
- app-editing split
- document viewer
- subagent detail

Now every side panel is consistent. Only the static line goes transparent — the drag hit-area (`cursor-col-resize`) and the hover grab handle are untouched, so resizing still works exactly as before.

## Verification

- `eslint` ✅
- `tsc --noEmit` ✅

## Risk

🟢 Green — three one-line prop additions using an existing, purpose-built prop; no behavior change beyond the visual. No design-library default was changed, so no other `ResizablePanel` consumer is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)