### PR TITLE
feat(profiles): let seedInferenceProfiles accept injected managed templates

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -75,7 +75,11 @@ import {
   loadConfig,
   mergeDefaultWorkspaceConfig,
 } from "../config/loader.js";
-import { seedInferenceProfiles } from "../config/seed-inference-profiles.js";
+import {
+  MANAGED_PROFILE_TEMPLATES,
+  type ManagedProfileTemplate,
+  seedInferenceProfiles,
+} from "../config/seed-inference-profiles.js";
 import type { DrizzleDb } from "../memory/db-connection.js";
 import { migrateCreateProviderConnections } from "../memory/migrations/243-provider-connections.js";
 import { migrateProviderConnectionStatusLabel } from "../memory/migrations/244-provider-connection-status-label.js";
@@ -1378,5 +1382,109 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
     expect(config.llm.profiles.balanced?.status).toBe("active");
     // Label is still suffixed (Vellum can push label updates).
     expect(config.llm.profiles.balanced?.label).toBe("Balanced (Managed)");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: injected managed profile templates. seedInferenceProfiles accepts an
+// optional `managedProfileTemplates` map (supplied by the platform
+// model-profiles endpoint). When present it overrides the SEEDED content of the
+// known managed keys; when omitted the built-in MANAGED_PROFILE_TEMPLATES are
+// used and behavior is byte-for-byte the same as before.
+// ---------------------------------------------------------------------------
+
+describe("seedInferenceProfiles injected managed templates", () => {
+  beforeEach(() => {
+    ensureTestDir();
+    const resetPaths = [
+      CONFIG_PATH,
+      join(WORKSPACE_DIR, "default-config.json"),
+      join(WORKSPACE_DIR, "hatch-overlay.json"),
+      join(WORKSPACE_DIR, "keys.enc"),
+      join(WORKSPACE_DIR, "data"),
+      join(WORKSPACE_DIR, "data", "memory"),
+    ];
+    for (const path of resetPaths) {
+      if (existsSync(path)) {
+        rmSync(path, { recursive: true, force: true });
+      }
+    }
+    ensureTestDir();
+    setStorePathForTesting(join(WORKSPACE_DIR, "keys.enc"));
+    delete process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
+    delete process.env.IS_PLATFORM;
+    invalidateConfigCache();
+  });
+
+  afterEach(() => {
+    setStorePathForTesting(null);
+    delete process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
+    delete process.env.IS_PLATFORM;
+    invalidateConfigCache();
+  });
+
+  function cloneBuiltInTemplates(): Record<string, ManagedProfileTemplate> {
+    return structuredClone(MANAGED_PROFILE_TEMPLATES);
+  }
+
+  test("seeds overridden content from an injected template map", () => {
+    process.env.IS_PLATFORM = "true";
+    writeConfig({});
+
+    const templates = cloneBuiltInTemplates();
+    templates.balanced.label = "Remote Balanced";
+    templates.balanced.maxTokens = 12345;
+
+    mergeDefaultWorkspaceConfig();
+    seedInferenceProfiles({ managedProfileTemplates: templates });
+    const config = loadConfig();
+
+    expect(config.llm.profiles.balanced?.label).toBe("Remote Balanced");
+    expect(config.llm.profiles.balanced?.maxTokens).toBe(12345);
+    // Untouched managed keys still seed their built-in content.
+    expect(config.llm.profiles["quality-optimized"]?.label).toBe("Quality");
+  });
+
+  test("omitting the option produces the same result as the built-in defaults", () => {
+    process.env.IS_PLATFORM = "true";
+
+    // Seed once with the option omitted.
+    writeConfig({});
+    mergeDefaultWorkspaceConfig();
+    seedInferenceProfiles();
+    const withoutOption = readFileSync(CONFIG_PATH, "utf-8");
+
+    // Reset and seed again, explicitly injecting a verbatim clone of the
+    // built-ins. The result must be byte-for-byte identical.
+    rmSync(CONFIG_PATH, { force: true });
+    invalidateConfigCache();
+    writeConfig({});
+    mergeDefaultWorkspaceConfig();
+    seedInferenceProfiles({ managedProfileTemplates: cloneBuiltInTemplates() });
+    const withClonedOption = readFileSync(CONFIG_PATH, "utf-8");
+
+    expect(withClonedOption).toBe(withoutOption);
+  });
+
+  test("injected templates resolve model via resolveModelIntent (fireworks/balanced)", () => {
+    process.env.IS_PLATFORM = "true";
+    writeConfig({});
+
+    const templates = cloneBuiltInTemplates();
+    // balanced-economy is fireworks + balanced intent; its model must resolve
+    // from the catalog, not be carried verbatim from the template.
+    templates["balanced-economy"].label = "Remote Economy";
+
+    mergeDefaultWorkspaceConfig();
+    seedInferenceProfiles({ managedProfileTemplates: templates });
+    const config = loadConfig();
+
+    expect(config.llm.profiles["balanced-economy"]?.provider).toBe("fireworks");
+    expect(config.llm.profiles["balanced-economy"]?.model).toBe(
+      "accounts/fireworks/models/minimax-m3",
+    );
+    expect(config.llm.profiles["balanced-economy"]?.label).toBe(
+      "Remote Economy",
+    );
   });
 });

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -23,7 +23,7 @@ const log = getLogger("seed-inference-profiles");
  * resolved at seed time from `PROVIDER_MODEL_INTENTS` so the catalog stays the
  * single source of truth for "which model does this intent map to?".
  */
-type ManagedProfileTemplate = Omit<
+export type ManagedProfileTemplate = Omit<
   ProfileEntry,
   "provider" | "model" | "provider_connection"
 > & {
@@ -37,58 +37,67 @@ type ManagedProfileTemplate = Omit<
  * model/config updates to customers in new releases. Platform overlays
  * (`preserveProfileNames`) take precedence when present.
  */
-const MANAGED_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
-  balanced: {
-    intent: "balanced",
-    provider: "anthropic",
-    connectionName: "anthropic-managed",
-    source: "managed",
-    label: "Balanced",
-    description: "Good balance of quality, cost, and speed",
-    maxTokens: 16000,
-    effort: "high",
-    thinking: { enabled: true, streamThinking: true },
-    contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
-  },
-  "quality-optimized": {
-    intent: "quality-optimized",
-    provider: "anthropic",
-    connectionName: "anthropic-managed",
-    source: "managed",
-    label: "Quality",
-    description: "Best results with the most capable model",
-    maxTokens: 32000,
-    effort: "high",
-    thinking: { enabled: true, streamThinking: true },
-    contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
-  },
-  "cost-optimized": {
-    intent: "latency-optimized",
-    provider: "anthropic",
-    connectionName: "anthropic-managed",
-    source: "managed",
-    label: "Speed",
-    description: "Fastest responses at lower cost",
-    maxTokens: 8192,
-    effort: "low",
-    thinking: { enabled: false, streamThinking: false },
-    contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
-  },
-  // Open-weight economy option: MiniMax M3 served by Fireworks via managed
-  // platform inference.
-  "balanced-economy": {
-    intent: "balanced",
-    provider: "fireworks",
-    connectionName: "fireworks-managed",
-    source: "managed",
-    label: "Balanced Economy",
-    description: "Strong open model (MiniMax M3) at a lower price point",
-    maxTokens: 32000,
-    effort: "high",
-    thinking: { enabled: true, streamThinking: true },
-    contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
-  },
-};
+export const MANAGED_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> =
+  {
+    balanced: {
+      intent: "balanced",
+      provider: "anthropic",
+      connectionName: "anthropic-managed",
+      source: "managed",
+      label: "Balanced",
+      description: "Good balance of quality, cost, and speed",
+      maxTokens: 16000,
+      effort: "high",
+      thinking: { enabled: true, streamThinking: true },
+      contextWindow: {
+        maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
+      },
+    },
+    "quality-optimized": {
+      intent: "quality-optimized",
+      provider: "anthropic",
+      connectionName: "anthropic-managed",
+      source: "managed",
+      label: "Quality",
+      description: "Best results with the most capable model",
+      maxTokens: 32000,
+      effort: "high",
+      thinking: { enabled: true, streamThinking: true },
+      contextWindow: {
+        maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
+      },
+    },
+    "cost-optimized": {
+      intent: "latency-optimized",
+      provider: "anthropic",
+      connectionName: "anthropic-managed",
+      source: "managed",
+      label: "Speed",
+      description: "Fastest responses at lower cost",
+      maxTokens: 8192,
+      effort: "low",
+      thinking: { enabled: false, streamThinking: false },
+      contextWindow: {
+        maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
+      },
+    },
+    // Open-weight economy option: MiniMax M3 served by Fireworks via managed
+    // platform inference.
+    "balanced-economy": {
+      intent: "balanced",
+      provider: "fireworks",
+      connectionName: "fireworks-managed",
+      source: "managed",
+      label: "Balanced Economy",
+      description: "Strong open model (MiniMax M3) at a lower price point",
+      maxTokens: 32000,
+      effort: "high",
+      thinking: { enabled: true, streamThinking: true },
+      contextWindow: {
+        maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
+      },
+    },
+  };
 
 /**
  * User profile templates. Materialized at hatch time for off-platform
@@ -160,6 +169,14 @@ export type SeedInferenceProfilesOptions = {
   isHatch?: boolean;
   /** DB handle for creating user provider connections at hatch time. */
   db?: DrizzleDb;
+  /**
+   * Managed profile templates to seed instead of the built-in
+   * MANAGED_PROFILE_TEMPLATES. Supplied by the platform (model-profiles
+   * endpoint) when available; when omitted the hardcoded templates are used.
+   * Keys MUST be a subset of the built-in managed profile names — callers are
+   * responsible for validating that before passing them here.
+   */
+  managedProfileTemplates?: Record<string, ManagedProfileTemplate>;
 };
 
 /**
@@ -253,7 +270,14 @@ export function seedInferenceProfiles(
     options,
   );
 
-  for (const [name, template] of Object.entries(MANAGED_PROFILE_TEMPLATES)) {
+  // Injected templates (from the platform model-profiles endpoint) override the
+  // seeded content of the known managed keys; the key set itself is unchanged
+  // (v1 scope guard — callers validate that the keys are a subset of the
+  // built-ins). When omitted, the built-in templates are the source of truth.
+  const managedTemplates =
+    options.managedProfileTemplates ?? MANAGED_PROFILE_TEMPLATES;
+
+  for (const [name, template] of Object.entries(managedTemplates)) {
     if (preservedProfileNames.has(name)) continue;
 
     const previous = readObject(profiles[name]);


### PR DESCRIPTION
## Summary
- Export `ManagedProfileTemplate` and `MANAGED_PROFILE_TEMPLATES` from seed-inference-profiles
- Add optional `managedProfileTemplates` option to `SeedInferenceProfilesOptions`; materialization loop uses injected map when present, else built-ins
- Add tests covering injection, default-equivalence, and intent resolution

Part of plan: remote-managed-model-profiles.md (PR 1 of 3)