### PR TITLE
spike: research-onboarding flow (behind research-onboarding flag)

### DIFF
--- a/clients/web/src/domains/chat/active-chat-view.tsx
+++ b/clients/web/src/domains/chat/active-chat-view.tsx
@@ -59,6 +59,7 @@ import { useDeepLinkApp } from "@/domains/chat/hooks/use-deep-link-app";
 import { useScrollToMessageParam } from "@/domains/chat/hooks/use-scroll-to-message";
 import { lifecycleService } from "@/assistant/lifecycle-service";
 import { isSending, useTurnStore } from "@/domains/chat/turn-store";
+import { useOnboardingFocusStore } from "@/stores/onboarding-focus-store";
 import { Button } from "@vellumai/design-library/components/button";
 
 const AddCreditsModal = lazy(() =>
@@ -299,6 +300,18 @@ export function ActiveChatView() {
       message: "Connection lost. Please try again.",
     });
   }, [reachability.state.phase]);
+
+  // Focused research-onboarding "deeper dive": the results overlay (rendered
+  // by ChatLayout, outside this component) stages a follow-up message; send it
+  // through the real pipeline once the current turn is idle, then clear it.
+  const pendingFollowupMessage =
+    useOnboardingFocusStore.use.pendingFollowupMessage();
+  useEffect(() => {
+    if (!pendingFollowupMessage) return;
+    if (isSending(useTurnStore.getState().phase)) return;
+    useOnboardingFocusStore.getState().clearFollowup();
+    void sendMessage(pendingFollowupMessage);
+  }, [pendingFollowupMessage, sendMessage]);
 
   // Post-hatch "Connecting…" overlay lifecycle — pre-chat detector,
   // messages-arrived clear, safety timer, conversation-switch clear.

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -48,6 +48,7 @@ import { openPopoutWindow } from "@/runtime/popout-window";
 import { useVellumCommands } from "@/runtime/vellum-commands";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useConversationStore } from "@/stores/conversation-store";
+import { useOnboardingFocusStore } from "@/stores/onboarding-focus-store";
 import { useViewerStore } from "@/stores/viewer-store";
 import type { Conversation } from "@/types/conversation-types";
 import { requestComposerFocus } from "./composer-focus";
@@ -58,6 +59,7 @@ import { AssistantSideMenu } from "@/domains/chat/components/assistant-side-menu
 import { PreferencesMenu } from "@/domains/chat/components/preferences-menu";
 import { useCommandPaletteOrchestrator } from "@/domains/chat/hooks/use-command-palette-orchestrator";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+import { ResearchResultsOverlay } from "@/domains/chat/onboarding-research/research-results-overlay";
 import { ChatConversationHeader } from "./chat-conversation-header";
 import { ChatLayoutHeader } from "./chat-layout-header";
 import { RenameDialogFromStore } from "./rename-dialog-from-store";
@@ -116,6 +118,14 @@ export function ChatLayout() {
   // persistent layout route — it stays mounted when child routes change, so
   // this initial value remains stable for the window's lifetime.
   const [isPopout] = useState(() => location.search.includes("popout=1"));
+
+  // SPIKE — research-onboarding focused presentation. When set, a full-viewport
+  // overlay (rendered below, on top of this layout) covers the chrome so the
+  // handoff chat reads as a focused step. Kept as an overlay rather than a
+  // separate render branch so `ActiveChatView` never remounts when focus
+  // toggles — otherwise a suggestion click's navigate + `?prompt=` auto-send
+  // gets raced by the remount and the message is lost.
+  const isFocused = useOnboardingFocusStore.use.focused();
 
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
   const assistantStateKind = useAssistantLifecycleStore(
@@ -661,6 +671,13 @@ export function ChatLayout() {
           </main>
         </div>
       )}
+
+      {/* Focused research-onboarding results — a full-viewport layer ON TOP of
+          the normal layout (not a separate render branch), so `ActiveChatView`
+          stays continuously mounted. Toggling focus only adds/removes this
+          overlay; it never remounts the chat, so a suggestion click's
+          navigate + `?prompt=` auto-send isn't raced by a remount. */}
+      {isFocused ? <ResearchResultsOverlay /> : null}
 
       <RenameDialogFromStore assistantId={assistantId} />
       {commandPalette.isOpen ? (

--- a/clients/web/src/domains/chat/onboarding-research/deeper-dive-prompt.ts
+++ b/clients/web/src/domains/chat/onboarding-research/deeper-dive-prompt.ts
@@ -1,0 +1,65 @@
+/**
+ * Background follow-up messages for the research-onboarding results step.
+ *
+ * SPIKE — research-onboarding flow.
+ *
+ * Lives in the chat domain (next to the overlay that sends these) rather than
+ * with the initial prompt in `@/domains/onboarding`, to respect domain
+ * boundaries. Shares the `{ claims, suggestions }` output contract documented
+ * in `@/domains/onboarding/research-prompt.ts`.
+ *
+ * Both builders fold in the claims the user removed (with optional reason) so
+ * the assistant learns what was wrong — `buildDeeperDivePrompt` when the user
+ * digs deeper (also asks for a richer, overwriting result), `buildRemovalNote`
+ * as a fire-and-forget correction when the user accepts what's there.
+ */
+
+import {
+  REMOVAL_REASON_LABELS,
+  type RemovalReason,
+} from "@/domains/chat/onboarding-research/research-facts";
+
+export interface RemovedClaim {
+  claim: string;
+  reason: RemovalReason | null;
+}
+
+function formatRemoved(removed: RemovedClaim[]): string {
+  return removed
+    .map((r) => {
+      const label = r.reason ? REMOVAL_REASON_LABELS[r.reason].toLowerCase() : null;
+      return `- ${r.claim}${label ? ` (${label})` : ""}`;
+    })
+    .join("\n");
+}
+
+const REMOVED_PREAMBLE =
+  "I removed these — they're not accurate about me, so disregard them:";
+
+export function buildDeeperDivePrompt(removed: RemovedClaim[] = []): string {
+  const lines: string[] = [];
+  if (removed.length > 0) {
+    lines.push(REMOVED_PREAMBLE, formatRemoved(removed), "");
+  }
+  lines.push(
+    "Go deeper. Run more searches and read further to sharpen what you know",
+    "about me — confirm the uncertain guesses, correct anything off, and find",
+    "more specific, useful details.",
+    "",
+    'Reply with ONLY the same JSON object as before ({ "claims": [...],',
+    '"suggestions": [...] }), updated and overwritten with what you now know.',
+    "Same rules: at most 5 short claims with confidence + sources, exactly 4",
+    "short verb-first suggestions, no prose, no code fence.",
+  );
+  return lines.join("\n");
+}
+
+/** Fire-and-forget correction sent when the user accepts the current result. */
+export function buildRemovalNote(removed: RemovedClaim[]): string {
+  return [
+    "Quick correction on what you found about me — please disregard these and",
+    "don't treat them as true:",
+    "",
+    formatRemoved(removed),
+  ].join("\n");
+}

--- a/clients/web/src/domains/chat/onboarding-research/research-activity-feed.tsx
+++ b/clients/web/src/domains/chat/onboarding-research/research-activity-feed.tsx
@@ -1,0 +1,163 @@
+/**
+ * Live research activity feed for the focused-onboarding loading state.
+ *
+ * SPIKE — research-onboarding flow.
+ *
+ * While the assistant researches, the turn store streams structured web
+ * activity (`liveWebActivity`, keyed by tool-call id) and a human-readable
+ * `statusText`. This renders that activity as cards that fly in — the searches
+ * it runs and the pages it reads — so the wait reads as visible progress
+ * instead of a spinner. Cohesive with how the transcript surfaces tool
+ * activity, just in a focused, single-column presentation.
+ *
+ * Lives in the chat domain because it reads chat-domain (turn) state.
+ */
+
+import { useEffect, useState } from "react";
+import { Search } from "lucide-react";
+
+import type {
+  ToolActivityMetadata,
+  WebSearchResultItem,
+} from "@/assistant/web-activity-types";
+import { useTurnStore } from "@/domains/chat/turn-store";
+import { SourceFavicon } from "@/domains/chat/onboarding-research/source-favicon";
+
+interface SearchItem {
+  kind: "search";
+  id: string;
+  query: string;
+  results: WebSearchResultItem[];
+}
+
+interface FetchItem {
+  kind: "fetch";
+  id: string;
+  title: string;
+  domain: string;
+  faviconUrl?: string;
+}
+
+type FeedItem = SearchItem | FetchItem;
+
+function toFeedItems(
+  activity: Record<string, ToolActivityMetadata>,
+): FeedItem[] {
+  const items: FeedItem[] = [];
+  for (const [id, meta] of Object.entries(activity)) {
+    if (meta.webSearch) {
+      items.push({
+        kind: "search",
+        id,
+        query: meta.webSearch.query,
+        results: meta.webSearch.results ?? [],
+      });
+    } else if (meta.webFetch) {
+      const f = meta.webFetch;
+      items.push({
+        kind: "fetch",
+        id,
+        title: f.title?.trim() || f.domain,
+        domain: f.domain,
+        faviconUrl: f.faviconUrl,
+      });
+    }
+  }
+  return items;
+}
+
+/** Reassurance copy that escalates as the research runs long. */
+function useElapsedHint(): string | null {
+  const [elapsed, setElapsed] = useState(0);
+  useEffect(() => {
+    const started = Date.now();
+    const t = setInterval(() => setElapsed(Date.now() - started), 1000);
+    return () => clearInterval(t);
+  }, []);
+  if (elapsed > 150_000) return "Still going — deep research can take a couple of minutes.";
+  if (elapsed > 60_000) return "Digging a little deeper…";
+  return null;
+}
+
+export function ResearchActivityFeed() {
+  const liveWebActivity = useTurnStore((s) => s.liveWebActivity);
+  const statusText = useTurnStore((s) => s.statusText);
+  const elapsedHint = useElapsedHint();
+
+  const items = toFeedItems(liveWebActivity);
+
+  return (
+    <div className="flex w-full flex-col gap-6">
+      <div className="flex flex-col gap-1">
+        <h2 className="text-xl font-medium text-[var(--content-default)]">
+          Getting to know you…
+        </h2>
+        <p className="text-body-medium-lighter text-[var(--content-secondary)]">
+          {statusText ?? "Searching the web to get to know you."}
+        </p>
+        {elapsedHint ? (
+          <p className="text-body-small-default text-[var(--content-tertiary)]">
+            {elapsedHint}
+          </p>
+        ) : null}
+      </div>
+
+      {items.length === 0 ? (
+        <div className="flex items-center gap-3 rounded-xl border border-[var(--border-base)] bg-[var(--surface-lift)] px-5 py-4">
+          <Search className="size-4 shrink-0 animate-pulse text-[var(--content-tertiary)]" />
+          <span className="text-base text-[var(--content-secondary)]">
+            Warming up the search…
+          </span>
+        </div>
+      ) : (
+        <ul className="flex flex-col gap-3">
+          {items.map((item) => (
+            <li
+              key={item.id}
+              className="rounded-xl border border-[var(--border-base)] bg-[var(--surface-lift)] px-5 py-4"
+              style={{ animation: "fadeInUp 0.35s ease-out both" }}
+            >
+              {item.kind === "search" ? (
+                <div className="flex flex-col gap-3">
+                  <div className="flex items-center gap-3">
+                    <Search className="size-4 shrink-0 text-[var(--content-secondary)]" />
+                    <span className="text-base text-[var(--content-default)]">
+                      Searching for{" "}
+                      <span className="font-medium">“{item.query}”</span>
+                    </span>
+                  </div>
+                  {item.results.length > 0 ? (
+                    <div className="flex flex-wrap gap-2 pl-7">
+                      {item.results.slice(0, 5).map((r) => (
+                        <span
+                          key={`${item.id}-${r.rank}-${r.url}`}
+                          className="flex items-center gap-1.5 rounded-full border border-[var(--border-element)] bg-[var(--surface-base)] px-2.5 py-1 text-label-small-default text-[var(--content-secondary)]"
+                          title={r.title}
+                          style={{ animation: "fadeInUp 0.3s ease-out both" }}
+                        >
+                          <SourceFavicon src={r.faviconUrl} domain={r.domain} />
+                          {r.domain}
+                        </span>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+              ) : (
+                <div className="flex items-center gap-3">
+                  <SourceFavicon src={item.faviconUrl} domain={item.domain} />
+                  <span className="min-w-0 text-base text-[var(--content-default)]">
+                    Reading <span className="font-medium">{item.title}</span>
+                    <span className="text-[var(--content-tertiary)]">
+                      {" "}
+                      · {item.domain}
+                    </span>
+                  </span>
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/onboarding-research/research-facts-card.tsx
+++ b/clients/web/src/domains/chat/onboarding-research/research-facts-card.tsx
@@ -1,0 +1,210 @@
+/**
+ * Editable "Here's what I know about you" card.
+ *
+ * SPIKE — research-onboarding flow.
+ *
+ * Presentational: renders research facts as rows with a confidence badge.
+ * Removing a claim doesn't delete it — the row greys out (so it isn't abrupt)
+ * and the remove control opens a popover for an optional reason ("Not me" /
+ * "Stale or irrelevant") or to keep it. The parent tracks removals (and reasons)
+ * so it can tell the assistant about them on deeper-dive / continue. Rows with
+ * sources expand on click to reveal source links below. Owns only per-row
+ * expand + popover-open UI state.
+ */
+
+import { useState } from "react";
+import { Ban } from "lucide-react";
+
+import { Popover } from "@vellumai/design-library/components/popover";
+import { Tag } from "@vellumai/design-library/components/tag";
+
+import {
+  confidenceBadge,
+  domainFromUrl,
+  REMOVAL_REASON_LABELS,
+  type RemovalReason,
+  type ResearchFact,
+} from "@/domains/chat/onboarding-research/research-facts";
+import { SourceFavicon } from "@/domains/chat/onboarding-research/source-favicon";
+
+export interface ResearchFactItem {
+  fact: ResearchFact;
+  /** Stable index into the streamed fact array — the removal/remove key. */
+  index: number;
+}
+
+interface ResearchFactsCardProps {
+  items: ResearchFactItem[];
+  /** Indices currently removed → the reason given (null if none chosen yet). */
+  removals: ReadonlyMap<number, RemovalReason | null>;
+  onRemove: (index: number) => void;
+  onSetReason: (index: number, reason: RemovalReason) => void;
+  onRestore: (index: number) => void;
+  /** Heading copy (differs between streaming and settled states). */
+  title: string;
+  /** Resolve a favicon URL for a source domain. */
+  resolveFavicon: (domain: string) => string;
+}
+
+/** Distinct {domain, url} sources for a claim (first url per domain wins). */
+function sourceLinks(sources: string[]): { domain: string; url: string }[] {
+  const byDomain = new Map<string, string>();
+  for (const url of sources) {
+    const domain = domainFromUrl(url);
+    if (domain && !byDomain.has(domain)) byDomain.set(domain, url);
+  }
+  return [...byDomain].map(([domain, url]) => ({ domain, url }));
+}
+
+const REASONS: RemovalReason[] = ["not_me", "not_relevant"];
+
+function ClaimRow({
+  fact,
+  removed,
+  onRemove,
+  onSetReason,
+  onRestore,
+  resolveFavicon,
+}: {
+  fact: ResearchFact;
+  removed: boolean;
+  onRemove: () => void;
+  onSetReason: (reason: RemovalReason) => void;
+  onRestore: () => void;
+  resolveFavicon: (domain: string) => string;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const badge = confidenceBadge(fact.confidence);
+  const links = sourceLinks(fact.sources);
+  const hasSources = links.length > 0;
+  const canExpand = hasSources && !removed;
+
+  return (
+    <li
+      className={`group flex flex-col rounded-lg border border-[var(--border-base)] bg-[var(--surface-lift)] transition-opacity ${
+        removed ? "opacity-50" : ""
+      }`}
+      style={{ animation: "fadeInUp 0.35s ease-out both" }}
+    >
+      <div
+        className={`flex items-center gap-2.5 px-4 py-2.5 ${
+          canExpand ? "cursor-pointer" : ""
+        }`}
+        onClick={canExpand ? () => setExpanded((v) => !v) : undefined}
+      >
+        <span
+          className={`text-[15px] leading-snug text-[var(--content-default)] ${
+            removed ? "line-through" : ""
+          }`}
+        >
+          {fact.claim}
+        </span>
+        <Tag tone={badge.tone}>{badge.label}</Tag>
+
+        <Popover.Root
+          open={popoverOpen}
+          onOpenChange={(open) => {
+            setPopoverOpen(open);
+            // Opening from an active row marks it removed immediately; a reason
+            // is optional and can be chosen (or skipped) from the popover.
+            if (open && !removed) onRemove();
+          }}
+        >
+          <Popover.Trigger asChild>
+            <button
+              type="button"
+              aria-label={removed ? "Edit removal" : "Remove"}
+              onClick={(e) => e.stopPropagation()}
+              className={`ml-auto shrink-0 cursor-pointer text-[var(--content-tertiary)] transition-opacity hover:text-[var(--content-default)] focus-visible:opacity-100 ${
+                removed ? "opacity-100" : "opacity-0 group-hover:opacity-100"
+              }`}
+            >
+              <Ban className="size-[18px]" />
+            </button>
+          </Popover.Trigger>
+          <Popover.Content align="end" className="flex w-52 flex-col gap-0.5">
+            <p className="px-2 pb-1 pt-1 text-label-small-default text-[var(--content-tertiary)]">
+              Why remove this?
+            </p>
+            {REASONS.map((reason) => (
+              <button
+                key={reason}
+                type="button"
+                onClick={() => {
+                  onSetReason(reason);
+                  setPopoverOpen(false);
+                }}
+                className="rounded-md px-2 py-1.5 text-left text-sm text-[var(--content-default)] transition-colors hover:bg-[var(--surface-base)]"
+              >
+                {REMOVAL_REASON_LABELS[reason]}
+              </button>
+            ))}
+            <button
+              type="button"
+              onClick={() => {
+                onRestore();
+                setPopoverOpen(false);
+              }}
+              className="mt-0.5 rounded-md border-t border-[var(--border-base)] px-2 pt-2 pb-1 text-left text-sm text-[var(--content-secondary)] transition-colors hover:text-[var(--content-default)]"
+            >
+              Keep it
+            </button>
+          </Popover.Content>
+        </Popover.Root>
+      </div>
+
+      {expanded && canExpand ? (
+        <div className="flex flex-col gap-1.5 border-t border-[var(--border-base)] px-4 py-2.5">
+          <span className="text-label-small-default uppercase tracking-wide text-[var(--content-tertiary)]">
+            Sources
+          </span>
+          {links.map(({ domain, url }) => (
+            <a
+              key={domain}
+              href={url}
+              target="_blank"
+              rel="noreferrer"
+              className="flex items-center gap-2 text-sm text-[var(--content-secondary)] transition-colors hover:text-[var(--content-default)]"
+            >
+              <SourceFavicon src={resolveFavicon(domain)} domain={domain} />
+              {domain}
+            </a>
+          ))}
+        </div>
+      ) : null}
+    </li>
+  );
+}
+
+export function ResearchFactsCard({
+  items,
+  removals,
+  onRemove,
+  onSetReason,
+  onRestore,
+  title,
+  resolveFavicon,
+}: ResearchFactsCardProps) {
+  return (
+    <div className="flex w-full flex-col gap-3">
+      <h2 className="text-lg font-medium text-[var(--content-secondary)]">
+        {title}
+      </h2>
+
+      <ul className="flex flex-col gap-2">
+        {items.map(({ fact, index }) => (
+          <ClaimRow
+            key={`${index}-${fact.claim}`}
+            fact={fact}
+            removed={removals.has(index)}
+            onRemove={() => onRemove(index)}
+            onSetReason={(reason) => onSetReason(index, reason)}
+            onRestore={() => onRestore(index)}
+            resolveFavicon={resolveFavicon}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/onboarding-research/research-facts.ts
+++ b/clients/web/src/domains/chat/onboarding-research/research-facts.ts
@@ -1,0 +1,240 @@
+/**
+ * Research-fact types + streaming-tolerant parsing for the focused-onboarding
+ * overlay.
+ *
+ * SPIKE — research-onboarding flow.
+ *
+ * The assistant replies with ONLY a JSON array of `{ claim, confidence,
+ * sources }` (see the prompt in `@/domains/onboarding/research-prompt.ts`).
+ * Because we render claims as they arrive, the parser is incremental: it pulls
+ * every *complete* `{...}` object out of the (possibly unterminated) array so a
+ * claim surfaces the moment its object closes, mid-stream — no waiting for the
+ * full payload.
+ *
+ * Lives in the chat domain because the overlay that uses it reads chat state.
+ */
+
+import type { DisplayMessage } from "@/domains/chat/types/types";
+
+export type ResearchConfidence = "confident" | "maybe" | "guessing";
+
+/** Optional reason a user gives when removing a claim. */
+export type RemovalReason = "not_me" | "not_relevant";
+
+export const REMOVAL_REASON_LABELS: Record<RemovalReason, string> = {
+  not_me: "Not me",
+  not_relevant: "Not relevant",
+};
+
+export interface ResearchFact {
+  claim: string;
+  confidence: ResearchConfidence;
+  /** Source URLs the assistant cited as evidence (rendered as proof favicons). */
+  sources: string[];
+}
+
+/** Flatten a transcript message to its plain text (text blocks, then legacy segments). */
+export function extractMessageText(message: DisplayMessage): string {
+  const blocks = message.contentBlocks;
+  if (blocks && blocks.length > 0) {
+    const text = blocks
+      .filter(
+        (b): b is Extract<typeof b, { type: "text" }> => b.type === "text",
+      )
+      .map((b) => b.text)
+      .join("\n")
+      .trim();
+    if (text) return text;
+  }
+  return (message.textSegments ?? []).join("\n").trim();
+}
+
+/** The latest non-user (assistant) message in the transcript, or null. */
+export function latestAssistantMessage(
+  messages: DisplayMessage[],
+): DisplayMessage | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m && m.role !== "user") return m;
+  }
+  return null;
+}
+
+/** Bare registrable domain from a URL (www stripped), or null if unparseable. */
+export function domainFromUrl(url: string): string | null {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return null;
+  }
+}
+
+function normalizeConfidence(raw: unknown): ResearchConfidence {
+  const v = typeof raw === "string" ? raw.trim().toLowerCase() : "";
+  if (v.startsWith("conf")) return "confident";
+  if (v.startsWith("guess")) return "guessing";
+  return "maybe";
+}
+
+function normalizeSources(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((s): s is string => typeof s === "string" && s.trim().length > 0);
+}
+
+/** Strip a (possibly unterminated) ```json fence so the body is raw JSON-ish. */
+function stripFence(text: string): string {
+  const fenceStart = text.search(/```(?:json)?/i);
+  if (fenceStart === -1) return text;
+  const afterFence = text.slice(fenceStart).replace(/^```(?:json)?/i, "");
+  const closeIdx = afterFence.indexOf("```");
+  return closeIdx === -1 ? afterFence : afterFence.slice(0, closeIdx);
+}
+
+/**
+ * Extract every complete top-level `{...}` object from a JSON-array body,
+ * tolerating a missing closing `]` and a half-written trailing object. Brace
+ * counting is string-aware so braces inside quoted values don't confuse depth.
+ */
+function extractCompleteObjects(body: string): unknown[] {
+  const objects: unknown[] = [];
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+
+  for (let i = 0; i < body.length; i++) {
+    const c = body[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (c === "\\") escaped = true;
+      else if (c === '"') inString = false;
+      continue;
+    }
+    if (c === '"') {
+      inString = true;
+    } else if (c === "{") {
+      if (depth === 0) start = i;
+      depth++;
+    } else if (c === "}") {
+      depth--;
+      if (depth === 0 && start >= 0) {
+        try {
+          objects.push(JSON.parse(body.slice(start, i + 1)));
+        } catch {
+          // Shouldn't happen for a balanced slice, but stay defensive.
+        }
+        start = -1;
+      }
+    }
+  }
+  return objects;
+}
+
+function toFact(entry: unknown): ResearchFact | null {
+  if (!entry || typeof entry !== "object") return null;
+  const claim = (entry as { claim?: unknown }).claim;
+  if (typeof claim !== "string" || !claim.trim()) return null;
+  return {
+    claim: claim.trim(),
+    confidence: normalizeConfidence((entry as { confidence?: unknown }).confidence),
+    sources: normalizeSources((entry as { sources?: unknown }).sources),
+  };
+}
+
+/**
+ * Extract every complete top-level quoted string from an array body, tolerating
+ * a missing closing `]` and a half-written trailing string. Used for the flat
+ * `suggestions` string array.
+ */
+function extractCompleteStrings(body: string): string[] {
+  const out: string[] = [];
+  let i = 0;
+  while (i < body.length) {
+    const c = body[i];
+    if (c === "]") break; // end of the array
+    if (c === '"') {
+      let j = i + 1;
+      let escaped = false;
+      for (; j < body.length; j++) {
+        const d = body[j];
+        if (escaped) escaped = false;
+        else if (d === "\\") escaped = true;
+        else if (d === '"') break;
+      }
+      if (j >= body.length) break; // incomplete trailing string — stop
+      try {
+        const value = JSON.parse(body.slice(i, j + 1));
+        if (typeof value === "string" && value.trim()) out.push(value);
+      } catch {
+        // Defensive — a balanced slice should parse.
+      }
+      i = j + 1;
+      continue;
+    }
+    i++;
+  }
+  return out;
+}
+
+/** Body after a `"key": [` opening, or null if that array isn't present yet. */
+function arrayScopeFor(body: string, key: string): string | null {
+  const k = body.indexOf(`"${key}"`);
+  if (k === -1) return null;
+  const open = body.indexOf("[", k);
+  return open === -1 ? null : body.slice(open + 1);
+}
+
+export interface ResearchResult {
+  claims: ResearchFact[];
+  /** Concrete actions the assistant proposes it could do for the user. */
+  suggestions: string[];
+}
+
+/**
+ * Parse the assistant's `{ claims, suggestions }` object incrementally. Both
+ * arrays surface complete elements as they stream (append-only, order-stable —
+ * callers can key remove-state by index). Falls back to treating a bare
+ * top-level array as `claims` for back-compat.
+ */
+export function parseResearchResultStreaming(text: string): ResearchResult {
+  if (!text) return { claims: [], suggestions: [] };
+  const body = stripFence(text);
+
+  const claimsScope = arrayScopeFor(body, "claims");
+  const claimsBody =
+    claimsScope ??
+    (() => {
+      const open = body.indexOf("[");
+      return open === -1 ? null : body.slice(open + 1);
+    })();
+  const claims =
+    claimsBody === null
+      ? []
+      : extractCompleteObjects(claimsBody)
+          .map(toFact)
+          .filter((f): f is ResearchFact => f !== null);
+
+  const suggestionsScope = arrayScopeFor(body, "suggestions");
+  const suggestions =
+    suggestionsScope === null ? [] : extractCompleteStrings(suggestionsScope);
+
+  return { claims, suggestions };
+}
+
+interface ConfidenceBadge {
+  label: string;
+  tone: "positive" | "warning" | "neutral";
+}
+
+/** Map a confidence tier to its card badge label + Tag tone. */
+export function confidenceBadge(confidence: ResearchConfidence): ConfidenceBadge {
+  switch (confidence) {
+    case "confident":
+      return { label: "Confident", tone: "positive" };
+    case "guessing":
+      return { label: "Guessing", tone: "neutral" };
+    case "maybe":
+    default:
+      return { label: "Maybe-ish", tone: "warning" };
+  }
+}

--- a/clients/web/src/domains/chat/onboarding-research/research-mock-page.tsx
+++ b/clients/web/src/domains/chat/onboarding-research/research-mock-page.tsx
@@ -1,0 +1,156 @@
+/**
+ * Mock harness for the research-onboarding results UI.
+ *
+ * SPIKE — research-onboarding flow. Route: /assistant/onboarding/research-mock
+ *
+ * Renders the exact same `ResearchResultsView` as the live overlay, driven by
+ * static fixtures + local state instead of the chat/turn stores — so we can
+ * iterate on layout, copy, and the remove / deeper-dive / suggestion-click
+ * interactions instantly, without running the real (slow) research job.
+ *
+ * Suggestion clicks use the real navigation path, so this also reproduces the
+ * "start a new conversation with the message sent" behavior in isolation.
+ */
+
+import { useState } from "react";
+import { Navigate, useNavigate } from "react-router";
+
+import { Button } from "@vellumai/design-library/components/button";
+
+import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+import { useConversationStore } from "@/stores/conversation-store";
+import { routes } from "@/utils/routes";
+import { ResearchResultsView } from "@/domains/chat/onboarding-research/research-results-view";
+import type {
+  RemovalReason,
+  ResearchFact,
+} from "@/domains/chat/onboarding-research/research-facts";
+
+// Fictional fixture — no real names/handles/identifying data (root AGENTS.md);
+// this file is bundled into a public client chunk. Shaped to exercise the UI:
+// varied confidence, claims with one / multiple / no sources, and a long claim
+// that wraps. Real domains are used only for favicon variety.
+const MOCK_CLAIMS: ResearchFact[] = [
+  {
+    claim: "Software engineer based in Austin, TX",
+    confidence: "confident",
+    sources: ["https://github.com/example-dev"],
+  },
+  {
+    claim: "Product engineer at an early-stage AI startup",
+    confidence: "confident",
+    sources: ["https://example.com/team"],
+  },
+  {
+    claim:
+      "Maintains an open-source CLI tool for local LLM evaluation and tooling",
+    confidence: "confident",
+    sources: ["https://github.com/example-dev", "https://example.com/project"],
+  },
+  {
+    claim: "Primarily writes TypeScript and Go",
+    confidence: "confident",
+    sources: ["https://github.com/example-dev"],
+  },
+  {
+    claim: "Came up through a coding bootcamp rather than a CS degree",
+    confidence: "maybe",
+    sources: [],
+  },
+];
+
+const MOCK_SUGGESTIONS = [
+  "Summarize this week's AI model releases for me",
+  "Draft a technical blog post from your latest notes",
+  "Build a tracker for competitor product launches",
+  "Analyze a CSV of metrics and surface the trends",
+];
+
+function faviconService(domain: string): string {
+  return `https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}&sz=64`;
+}
+
+type Mode = "loading" | "results" | "empty";
+
+export function ResearchMockPage() {
+  const navigate = useNavigate();
+  const enabled = useClientFeatureFlagStore.use.researchOnboarding();
+  const [mode, setMode] = useState<Mode>("results");
+  const [removals, setRemovals] = useState<Map<number, RemovalReason | null>>(
+    () => new Map(),
+  );
+  const [deeperDiveResolved, setDeeperDiveResolved] = useState(false);
+
+  const items = MOCK_CLAIMS.map((fact, index) => ({ fact, index }));
+
+  const handleSuggestionClick = (suggestion: string) => {
+    const draftId = createDraftConversationId();
+    useConversationStore.getState().setActiveConversationId(draftId);
+    void navigate(
+      `${routes.conversation(draftId)}?prompt=${encodeURIComponent(suggestion)}`,
+    );
+  };
+
+  if (!enabled) {
+    return <Navigate to={routes.assistant} replace />;
+  }
+
+  return (
+    <div className="relative h-screen w-screen">
+      {/* Dev-only state switcher — not part of the real flow. */}
+      <div className="absolute left-1/2 top-3 z-50 flex -translate-x-1/2 gap-1 rounded-full border border-[var(--border-base)] bg-[var(--surface-lift)] p-1">
+        {(["loading", "results", "empty"] as Mode[]).map((m) => (
+          <Button
+            key={m}
+            variant={mode === m ? "primary" : "ghost"}
+            size="compact"
+            onClick={() => setMode(m)}
+          >
+            {m}
+          </Button>
+        ))}
+      </div>
+
+      <ResearchResultsView
+        mode={mode}
+        loadingContent={
+          <div className="text-[var(--content-secondary)]">
+            <p className="text-lg">Getting to know you…</p>
+            <p className="text-body-medium-lighter">
+              (mock — the live flow shows the search activity feed here)
+            </p>
+          </div>
+        }
+        items={items}
+        removals={removals}
+        suggestions={MOCK_SUGGESTIONS}
+        resultsTitle="Here's what I know about you. You can remove any that aren't true:"
+        showDeeperDiveCard={!deeperDiveResolved}
+        showSuggestions={deeperDiveResolved}
+        canContinue
+        resolveFavicon={faviconService}
+        onRemove={(index) =>
+          setRemovals((prev) =>
+            prev.has(index) ? prev : new Map(prev).set(index, null),
+          )
+        }
+        onSetReason={(index, reason) =>
+          setRemovals((prev) => new Map(prev).set(index, reason))
+        }
+        onRestore={(index) =>
+          setRemovals((prev) => {
+            if (!prev.has(index)) return prev;
+            const next = new Map(prev);
+            next.delete(index);
+            return next;
+          })
+        }
+        onDeeperDive={() => setDeeperDiveResolved(true)}
+        onGoodForNow={() => setDeeperDiveResolved(true)}
+        onSuggestionClick={handleSuggestionClick}
+        onContinue={() => navigate(routes.assistant)}
+      />
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/onboarding-research/research-results-overlay.tsx
+++ b/clients/web/src/domains/chat/onboarding-research/research-results-overlay.tsx
@@ -1,0 +1,235 @@
+/**
+ * Focused-onboarding results overlay.
+ *
+ * SPIKE — research-onboarding flow.
+ *
+ * Rendered by `ChatLayout` (over the live `ActiveChatView`, which drives the
+ * hatch → mint → auto-send → stream pipeline) whenever the onboarding focus
+ * flag is set. It reads the conversation transcript from the chat session
+ * store and parses the assistant's `{ claims, suggestions }` reply
+ * *incrementally* — each claim and suggestion surfaces as its element finishes
+ * streaming. A "dig deeper" action sends a follow-up research turn whose result
+ * overwrites both. Source favicons resolve from the live web-search results.
+ *
+ * The underlying chat is intentionally covered; Continue lands the user on the
+ * same conversation. Lives in the chat domain because it reads chat state.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router";
+
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
+import { isSending, useTurnStore } from "@/domains/chat/turn-store";
+import { useConversationStore } from "@/stores/conversation-store";
+import { useOnboardingFocusStore } from "@/stores/onboarding-focus-store";
+import { routes } from "@/utils/routes";
+import { ResearchActivityFeed } from "@/domains/chat/onboarding-research/research-activity-feed";
+import { ResearchResultsView } from "@/domains/chat/onboarding-research/research-results-view";
+import {
+  buildDeeperDivePrompt,
+  buildRemovalNote,
+  type RemovedClaim,
+} from "@/domains/chat/onboarding-research/deeper-dive-prompt";
+import {
+  extractMessageText,
+  latestAssistantMessage,
+  parseResearchResultStreaming,
+  type RemovalReason,
+  type ResearchFact,
+} from "@/domains/chat/onboarding-research/research-facts";
+
+/** Most claims to show — keeps the card from becoming a wall of text. */
+const MAX_CLAIMS = 5;
+/** Settled-with-nothing must persist this long before we show the empty state,
+ *  so a transient idle (e.g. the gap before `turn_started`) can't flash it. */
+const EMPTY_DEBOUNCE_MS = 2500;
+
+function faviconService(domain: string): string {
+  return `https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}&sz=64`;
+}
+
+export function ResearchResultsOverlay() {
+  const messages = useChatSessionStore((s) => s.messages);
+  const turnPhase = useTurnStore((s) => s.phase);
+  const liveWebActivity = useTurnStore((s) => s.liveWebActivity);
+  const exitFocus = useOnboardingFocusStore.use.exitFocus();
+  const requestFollowup = useOnboardingFocusStore.use.requestFollowup();
+  const navigate = useNavigate();
+
+  const processing = isSending(turnPhase);
+
+  // The auto-send fires a beat after mount, so at first paint the turn is still
+  // `idle` with no facts. Track whether a turn has actually started (sticky).
+  const [started, setStarted] = useState(false);
+  useEffect(() => {
+    if (processing) setStarted(true);
+  }, [processing]);
+
+  // Assistant reply text so far ("" until the assistant actually streams).
+  const assistantText = useMemo(() => {
+    const assistant = latestAssistantMessage(messages);
+    return assistant ? extractMessageText(assistant) : "";
+  }, [messages]);
+  const hasAssistantText = assistantText.trim().length > 0;
+
+  // Incremental parse of `{ claims, suggestions }` — grows as each streams in.
+  const live = useMemo(
+    () => parseResearchResultStreaming(assistantText),
+    [assistantText],
+  );
+
+  // Frozen snapshot — set when the user accepts the result ("This is good for
+  // now"). The follow-up correction we then send gets a non-JSON reply that
+  // would otherwise re-parse to nothing and wipe the card, so once frozen we
+  // render the snapshot instead of the live parse.
+  const [frozen, setFrozen] = useState<{
+    claims: ResearchFact[];
+    suggestions: string[];
+  } | null>(null);
+  const claims = frozen ? frozen.claims : live.claims;
+  const suggestions = frozen ? frozen.suggestions : live.suggestions;
+  const hasFacts = claims.length > 0;
+
+  // Removed claims: index → reason (null until/unless one is chosen). Rows stay
+  // visible but greyed — nothing is filtered out, so removal isn't abrupt.
+  const [removals, setRemovals] = useState<Map<number, RemovalReason | null>>(
+    () => new Map(),
+  );
+  const handleRemove = (index: number) =>
+    setRemovals((prev) => {
+      if (prev.has(index)) return prev;
+      return new Map(prev).set(index, null);
+    });
+  const handleSetReason = (index: number, reason: RemovalReason) =>
+    setRemovals((prev) => new Map(prev).set(index, reason));
+  const handleRestore = (index: number) =>
+    setRemovals((prev) => {
+      if (!prev.has(index)) return prev;
+      const next = new Map(prev);
+      next.delete(index);
+      return next;
+    });
+  const visibleItems = claims
+    .map((fact, index) => ({ fact, index }))
+    .slice(0, MAX_CLAIMS);
+
+  // Removed claims as a structured list for the background correction.
+  const collectRemoved = (): RemovedClaim[] =>
+    [...removals.entries()]
+      .filter(([index]) => index < claims.length)
+      .map(([index, reason]) => ({ claim: claims[index]!.claim, reason }));
+
+  // Accumulate real favicons (domain → url) from live search/fetch activity.
+  const [faviconByDomain, setFaviconByDomain] = useState<Record<string, string>>(
+    {},
+  );
+  useEffect(() => {
+    setFaviconByDomain((prev) => {
+      const next = { ...prev };
+      let changed = false;
+      const add = (domain?: string, fav?: string) => {
+        if (domain && fav && !next[domain]) {
+          next[domain] = fav;
+          changed = true;
+        }
+      };
+      for (const meta of Object.values(liveWebActivity)) {
+        meta.webSearch?.results?.forEach((r) => add(r.domain, r.faviconUrl));
+        if (meta.webFetch) add(meta.webFetch.domain, meta.webFetch.faviconUrl);
+      }
+      return changed ? next : prev;
+    });
+  }, [liveWebActivity]);
+  const resolveFavicon = (domain: string) =>
+    faviconByDomain[domain] ?? faviconService(domain);
+
+  // Empty state requires the assistant to have actually produced text (so the
+  // warm-up / pre-stream gap never counts), debounced against transient idles.
+  const emptyCandidate =
+    started && !processing && !hasFacts && hasAssistantText;
+  const [showEmpty, setShowEmpty] = useState(false);
+  useEffect(() => {
+    if (!emptyCandidate) {
+      setShowEmpty(false);
+      return;
+    }
+    const t = setTimeout(() => setShowEmpty(true), EMPTY_DEBOUNCE_MS);
+    return () => clearTimeout(t);
+  }, [emptyCandidate]);
+
+  // The deeper-dive prompt is resolved once the user picks either option; the
+  // card then goes away for good and the suggestions are revealed. Sticky.
+  const [deeperDiveResolved, setDeeperDiveResolved] = useState(false);
+
+  // Deeper-dive: bridge the gap between click and the turn actually starting so
+  // the button can't be double-fired.
+  const [divePending, setDivePending] = useState(false);
+  useEffect(() => {
+    if (processing) setDivePending(false);
+  }, [processing]);
+  const handleDeeperDive = () => {
+    if (processing || divePending) return;
+    const removed = collectRemoved();
+    setDivePending(true);
+    setDeeperDiveResolved(true);
+    setRemovals(new Map()); // a fresh result set is coming — drop stale removals
+    requestFollowup(buildDeeperDivePrompt(removed));
+  };
+  const handleGoodForNow = () => {
+    const removed = collectRemoved();
+    // Lock the current result so the correction's reply can't wipe it.
+    setFrozen({ claims: live.claims, suggestions: live.suggestions });
+    setDeeperDiveResolved(true);
+    if (removed.length > 0) requestFollowup(buildRemovalNote(removed));
+  };
+
+  // Clicking a suggestion starts a fresh conversation with that message sent on
+  // the user's behalf, then drops them out of the focused flow into it.
+  const handleSuggestionClick = (suggestion: string) => {
+    const draftId = createDraftConversationId();
+    useConversationStore.getState().setActiveConversationId(draftId);
+    void navigate(
+      `${routes.conversation(draftId)}?prompt=${encodeURIComponent(suggestion)}`,
+    );
+    exitFocus();
+  };
+
+  const settled = started && !processing && !divePending;
+  // Once frozen (accepted) the result is final even while the background
+  // correction turn runs, so show the settled title and allow continue.
+  const locked = frozen != null;
+  const mode: "loading" | "results" | "empty" = hasFacts
+    ? "results"
+    : showEmpty
+      ? "empty"
+      : "loading";
+
+  return (
+    <div className="fixed inset-0 z-50">
+      <ResearchResultsView
+        mode={mode}
+        loadingContent={<ResearchActivityFeed />}
+        items={visibleItems}
+        removals={removals}
+        suggestions={suggestions}
+        resultsTitle={
+          settled || locked
+            ? "Here's what I know about you. You can remove any that aren't true:"
+            : "Getting to know you…"
+        }
+        showDeeperDiveCard={settled && !deeperDiveResolved}
+        showSuggestions={deeperDiveResolved && suggestions.length > 0}
+        canContinue={!processing || locked}
+        resolveFavicon={resolveFavicon}
+        onRemove={handleRemove}
+        onSetReason={handleSetReason}
+        onRestore={handleRestore}
+        onDeeperDive={handleDeeperDive}
+        onGoodForNow={handleGoodForNow}
+        onSuggestionClick={handleSuggestionClick}
+        onContinue={exitFocus}
+      />
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/onboarding-research/research-results-view.tsx
+++ b/clients/web/src/domains/chat/onboarding-research/research-results-view.tsx
@@ -1,0 +1,130 @@
+/**
+ * Pure presentational layout for the research-onboarding results step.
+ *
+ * SPIKE — research-onboarding flow.
+ *
+ * Store-free and side-effect-free: every piece of data and every action is a
+ * prop. Shared by the live overlay (`research-results-overlay.tsx`, which wires
+ * the chat/turn stores in) and the mock harness page
+ * (`research-mock-page.tsx`, which wires static fixtures + local state in) so
+ * the two can't drift while we iterate on UI/UX.
+ */
+
+import type { ReactNode } from "react";
+
+import { Button } from "@vellumai/design-library/components/button";
+
+import {
+  ResearchFactsCard,
+  type ResearchFactItem,
+} from "@/domains/chat/onboarding-research/research-facts-card";
+import { ResearchSuggestions } from "@/domains/chat/onboarding-research/research-suggestions";
+import type { RemovalReason } from "@/domains/chat/onboarding-research/research-facts";
+
+export interface ResearchResultsViewProps {
+  mode: "loading" | "results" | "empty";
+  /** What to render in the loading state (live activity feed, or a mock). */
+  loadingContent: ReactNode;
+  items: ResearchFactItem[];
+  removals: ReadonlyMap<number, RemovalReason | null>;
+  suggestions: string[];
+  resultsTitle: string;
+  showDeeperDiveCard: boolean;
+  showSuggestions: boolean;
+  canContinue: boolean;
+  resolveFavicon: (domain: string) => string;
+  onRemove: (index: number) => void;
+  onSetReason: (index: number, reason: RemovalReason) => void;
+  onRestore: (index: number) => void;
+  onDeeperDive: () => void;
+  onGoodForNow: () => void;
+  onSuggestionClick: (suggestion: string) => void;
+  onContinue: () => void;
+}
+
+export function ResearchResultsView({
+  mode,
+  loadingContent,
+  items,
+  removals,
+  suggestions,
+  resultsTitle,
+  showDeeperDiveCard,
+  showSuggestions,
+  canContinue,
+  resolveFavicon,
+  onRemove,
+  onSetReason,
+  onRestore,
+  onDeeperDive,
+  onGoodForNow,
+  onSuggestionClick,
+  onContinue,
+}: ResearchResultsViewProps) {
+  return (
+    <div className="flex h-full w-full flex-col overflow-y-auto bg-[var(--surface-base)]">
+      <div className="mx-auto flex min-h-full w-full max-w-2xl flex-col gap-8 px-6 py-12">
+        <div className="flex flex-1 flex-col justify-start gap-8 pt-4">
+          {mode === "results" ? (
+            <>
+              <ResearchFactsCard
+                items={items}
+                removals={removals}
+                onRemove={onRemove}
+                onSetReason={onSetReason}
+                onRestore={onRestore}
+                resolveFavicon={resolveFavicon}
+                title={resultsTitle}
+              />
+              {showDeeperDiveCard ? (
+                <div className="flex flex-col items-start gap-3 rounded-xl border border-[var(--border-base)] bg-[var(--surface-lift)] px-5 py-4">
+                  <p className="text-[15px] text-[var(--content-secondary)]">
+                    I can search more, just didn&apos;t want to be too intrusive.
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    <Button variant="primary" size="regular" onClick={onDeeperDive}>
+                      Yes, do a deeper dive
+                    </Button>
+                    <Button variant="outlined" size="regular" onClick={onGoodForNow}>
+                      This is good for now
+                    </Button>
+                  </div>
+                </div>
+              ) : null}
+              {showSuggestions ? (
+                <ResearchSuggestions
+                  suggestions={suggestions}
+                  onSelect={onSuggestionClick}
+                />
+              ) : null}
+            </>
+          ) : mode === "empty" ? (
+            <div className="flex flex-col items-center gap-3 text-center text-[var(--content-secondary)]">
+              <p className="text-lg text-[var(--content-default)]">
+                Let&apos;s just dive in.
+              </p>
+              <p className="text-body-medium-lighter">
+                I couldn&apos;t pull together a clean profile this time — we can
+                get to know each other as we go.
+              </p>
+            </div>
+          ) : (
+            loadingContent
+          )}
+        </div>
+
+        <div className="flex shrink-0 justify-end">
+          <Button
+            variant="primary"
+            size="regular"
+            onClick={onContinue}
+            disabled={!canContinue}
+            className="h-11 px-6 text-base"
+          >
+            Continue
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/onboarding-research/research-suggestions.tsx
+++ b/clients/web/src/domains/chat/onboarding-research/research-suggestions.tsx
@@ -1,0 +1,47 @@
+/**
+ * Assistant-proposed actions surfaced alongside the research claims.
+ *
+ * SPIKE — research-onboarding flow.
+ *
+ * Presentational: renders the (up to 4) things the assistant suggests it could
+ * do for the user. Cards fly in as they stream and are overwritten wholesale
+ * when a deeper-dive run returns a richer set.
+ */
+
+import { Sparkles } from "lucide-react";
+
+interface ResearchSuggestionsProps {
+  suggestions: string[];
+  /** Start a new conversation with this suggestion sent on the user's behalf. */
+  onSelect: (suggestion: string) => void;
+}
+
+export function ResearchSuggestions({
+  suggestions,
+  onSelect,
+}: ResearchSuggestionsProps) {
+  if (suggestions.length === 0) return null;
+  return (
+    <div className="flex w-full flex-col gap-3">
+      <h2 className="text-lg font-medium text-[var(--content-secondary)]">
+        Here&apos;s how I could help to start:
+      </h2>
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        {suggestions.slice(0, 4).map((suggestion, index) => (
+          <button
+            key={`${index}-${suggestion}`}
+            type="button"
+            onClick={() => onSelect(suggestion)}
+            className="flex cursor-pointer items-center gap-2.5 rounded-lg border border-[var(--border-base)] bg-[var(--surface-lift)] px-4 py-3 text-left transition-colors hover:border-[var(--border-element)] hover:bg-[var(--surface-base)]"
+            style={{ animation: "fadeInUp 0.35s ease-out both" }}
+          >
+            <Sparkles className="size-4 shrink-0 text-[var(--content-tertiary)]" />
+            <span className="text-[15px] leading-snug text-[var(--content-default)]">
+              {suggestion}
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/onboarding-research/source-favicon.tsx
+++ b/clients/web/src/domains/chat/onboarding-research/source-favicon.tsx
@@ -1,0 +1,41 @@
+/**
+ * Small favicon with a graceful globe fallback.
+ *
+ * SPIKE — research-onboarding flow. Shared by the activity feed (search
+ * result chips) and the results card (per-claim source "proof").
+ */
+
+import { useState } from "react";
+import { Globe } from "lucide-react";
+
+interface SourceFaviconProps {
+  src?: string;
+  /** For the title/alt + as a hint; not required. */
+  domain?: string;
+  className?: string;
+}
+
+export function SourceFavicon({ src, domain, className }: SourceFaviconProps) {
+  const [failed, setFailed] = useState(false);
+  const size = className ?? "size-4";
+  if (!src || failed) {
+    return (
+      <span
+        className={`flex ${size} items-center justify-center text-[var(--content-tertiary)]`}
+      >
+        <Globe className="size-3.5" />
+      </span>
+    );
+  }
+  return (
+    <img
+      src={src}
+      alt=""
+      title={domain}
+      width={16}
+      height={16}
+      className={`${size} shrink-0 rounded-sm object-contain`}
+      onError={() => setFailed(true)}
+    />
+  );
+}

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -1,0 +1,97 @@
+/**
+ * Route wrapper for the research-onboarding front door.
+ *
+ * SPIKE — research-onboarding flow.
+ *
+ * Collects first/last/occupation, stages a pre-chat context whose
+ * `initialMessage` is the "research me" prompt, flips on the focused
+ * presentation flag, and hands off to the existing
+ * `/assistant?onboarding=1` pipeline. From there the standard machinery
+ * hatches the assistant, mints a conversation, auto-sends the research
+ * prompt, and streams the reply — rendered chrome-less by `ChatLayout`
+ * because the focus flag is set. The user reads the output, then clicks
+ * "Continue" (in `ChatLayout`) to drop into the full workspace on the
+ * very same conversation.
+ */
+
+import { useEffect } from "react";
+import { Navigate, useNavigate } from "react-router";
+
+import { lifecycleService } from "@/assistant/lifecycle-service";
+import { useAuthStore } from "@/stores/auth-store";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+import { routes } from "@/utils/routes";
+import { DEFAULT_GROUP_ID } from "@/domains/onboarding/prechat-names";
+import {
+  setPendingPreChatContext,
+  type PreChatOnboardingContext,
+} from "@/domains/onboarding/prechat";
+import { buildResearchPrompt } from "@/domains/onboarding/research-prompt";
+import { useOnboardingFocusStore } from "@/stores/onboarding-focus-store";
+import {
+  ResearchOnboardingScreen,
+  type ResearchOnboardingValues,
+} from "@/domains/onboarding/screens/research-onboarding-screen";
+
+export function ResearchOnboardingRoute() {
+  const navigate = useNavigate();
+  const user = useAuthStore.use.user();
+  const enterFocus = useOnboardingFocusStore.use.enterFocus();
+  const exitFocus = useOnboardingFocusStore.use.exitFocus();
+  // Belt-and-suspenders gate: the spike lives at a dedicated path AND behind
+  // this flag (off by default; enable locally via the feature-flags panel).
+  const enabled = useClientFeatureFlagStore.use.researchOnboarding();
+
+  // Landing on the form means a fresh run — clear any stale focus state left
+  // behind by an abandoned previous attempt so the form itself never renders
+  // chrome-less.
+  useEffect(() => {
+    exitFocus();
+  }, [exitFocus]);
+
+  function handleSubmit({
+    firstName,
+    lastName,
+    occupation,
+  }: ResearchOnboardingValues) {
+    const fullName = [firstName.trim(), lastName.trim()]
+      .filter(Boolean)
+      .join(" ");
+
+    const context: PreChatOnboardingContext = {
+      // Required handoff fields — no tool/task/tone collection in this flow.
+      tools: [],
+      tasks: [],
+      tone: DEFAULT_GROUP_ID,
+      ...(fullName ? { userName: fullName } : {}),
+      ...(occupation.trim() ? { occupation: occupation.trim() } : {}),
+      // The auto-sent first message: kick off the research pass.
+      initialMessage: buildResearchPrompt({ firstName, lastName, occupation }),
+    };
+
+    setPendingPreChatContext(context);
+
+    // Render the handoff chat chrome-less until the user continues out.
+    enterFocus();
+
+    // Mirror `PreChatFlow.completeFlow`: tell the lifecycle service to expect a
+    // first message (drives the auto-greet gate), refresh the assistant, then
+    // hand off to the onboarding chat pipeline.
+    lifecycleService.markExpectingFirstMessage();
+    void lifecycleService.checkAssistant().finally(() => {
+      void navigate(`${routes.assistant}?onboarding=1`, { replace: true });
+    });
+  }
+
+  if (!enabled) {
+    return <Navigate to={routes.assistant} replace />;
+  }
+
+  return (
+    <ResearchOnboardingScreen
+      initialFirstName={user?.firstName ?? ""}
+      initialLastName={user?.lastName ?? ""}
+      onSubmit={handleSubmit}
+    />
+  );
+}

--- a/clients/web/src/domains/onboarding/research-prompt.ts
+++ b/clients/web/src/domains/onboarding/research-prompt.ts
@@ -1,0 +1,105 @@
+/**
+ * Builds the "research me" message auto-sent to the assistant at the end of
+ * the research-onboarding flow.
+ *
+ * SPIKE — research-onboarding flow.
+ *
+ * This message becomes `PreChatOnboardingContext.initialMessage`, which the
+ * existing onboarding auto-send pipeline fires as the user's first message
+ * once the assistant is reachable. The assistant does a web-research pass on
+ * the person described by the collected fields and returns a structured list
+ * of inferred facts (each with a confidence tier) as a fenced JSON block. The
+ * focused-onboarding overlay parses that block and renders the editable
+ * "Here's what I know about you" card.
+ *
+ * The output contract here MUST stay in sync with the parser in
+ * `@/domains/chat/onboarding-research/research-facts.ts`.
+ *
+ * NOTE(alex): first-draft prompt (the original was lost). Tune the wording /
+ * claim count / confidence rubric freely — only the trailing JSON contract is
+ * load-bearing for the UI.
+ */
+
+export interface ResearchSubject {
+  firstName: string;
+  lastName: string;
+  occupation: string;
+}
+
+export function buildResearchPrompt({
+  firstName,
+  lastName,
+  occupation,
+}: ResearchSubject): string {
+  const fullName = [firstName.trim(), lastName.trim()]
+    .filter(Boolean)
+    .join(" ");
+  const role = occupation.trim();
+
+  const identity = [
+    fullName ? `My name is ${fullName}.` : "",
+    role ? `I work as ${role}.` : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return [
+    identity ||
+      "I'd like you to get to know me before we start working together.",
+    "",
+    "Before we dive in, get to know me. Search the web for what's publicly",
+    "known about the person matching my name and role, and infer a handful of",
+    "things about who I am — what I do, my role, where I'm based, what I'm into,",
+    "anything that would help you assist me better. Lean on public sources",
+    "(LinkedIn, company pages, social profiles, articles). It's fine to make",
+    "reasonable inferences and label them honestly.",
+    "",
+    "CRITICAL — your final reply must be ONLY a JSON object. No preamble, no",
+    "explanation, no prose, nothing before or after it. Do your thinking and",
+    "searching, then respond with exactly this shape and nothing else:",
+    "",
+    "{",
+    '  "claims": [',
+    '    { "claim": "Software engineer in Columbus, OH", "confidence": "confident", "sources": ["https://github.com/you"] },',
+    '    { "claim": "You climb outdoors", "confidence": "maybe", "sources": [] },',
+    '    { "claim": "Head of growth at Vellum", "confidence": "guessing", "sources": ["https://example.com/about"] }',
+    "  ],",
+    '  "suggestions": [',
+    '    "Draft your weekly GTM update",',
+    '    "Summarize competitor launches each Monday",',
+    '    "Turn your notes into polished posts",',
+    '    "Track your team\'s OKRs"',
+    "  ]",
+    "}",
+    "",
+    "Rules for \"claims\":",
+    "- AT MOST 5 claims — the strongest, most useful ones only.",
+    "- Each claim must be SHORT: a few words to one brief line. No multi-clause",
+    "  sentences, no em-dash asides, no explanations. Think headline, not bio.",
+    '  Good: "Contributed to Chirps (vector-DB security)". Bad: "You\'ve done',
+    '  real work in vector database security — you contributed to Chirps, a',
+    '  tool for scanning vector DBs for sensitive data".',
+    "- Each claim independently true-or-false so I can remove ones that are wrong.",
+    '- Phrase them directly ("You\'re…", "You climb outdoors", "Head of growth',
+    '  at Vellum").',
+    '- "confidence" is one of: "confident" (well supported by what you found),',
+    '  "maybe" (plausible but unverified), "guessing" (a hunch from limited',
+    "  signal).",
+    '- "sources": 0–3 URLs you actually used as evidence for that specific',
+    "  claim (the pages you read). Use [] for pure inferences.",
+    "",
+    "Rules for \"suggestions\":",
+    "- EXACTLY 4 suggestions. These TEACH a brand-new user what you can do —",
+    "  each should showcase a DIFFERENT capability of yours (e.g. research &",
+    "  summarize, draft & write, automate a recurring task, analyze data,",
+    "  build something), made relevant to my work and role.",
+    "- Phrase each as a short, inviting action I can click to try right now,",
+    '  starting with a verb (e.g. "Summarize this week\'s LLM releases for me",',
+    '  "Draft a launch post from your notes"). No explanations.',
+    "- Make them feel concrete and immediately runnable, not generic.",
+    "",
+    "Don't include anything sensitive or private. If you found very little,",
+    'lean on "guessing" claims and broadly useful suggestions for my role.',
+    "Output ONLY the JSON object — no code fence, no extra text.",
+  ].join("\n");
+}

--- a/clients/web/src/domains/onboarding/screens/research-onboarding-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-onboarding-screen.tsx
@@ -1,0 +1,118 @@
+/**
+ * Research-onboarding front door — collects first name, last name, and
+ * occupation, then hands off to the assistant to research the person.
+ *
+ * SPIKE — research-onboarding flow.
+ *
+ * Presentational only: owns local field state and validation, delegates the
+ * context build + handoff navigation to the caller via `onSubmit`.
+ */
+
+import { useState } from "react";
+
+import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
+import { Button } from "@vellumai/design-library/components/button";
+import { Input } from "@vellumai/design-library/components/input";
+
+export interface ResearchOnboardingValues {
+  firstName: string;
+  lastName: string;
+  occupation: string;
+}
+
+interface ResearchOnboardingScreenProps {
+  initialFirstName?: string;
+  initialLastName?: string;
+  onSubmit: (values: ResearchOnboardingValues) => void;
+}
+
+export function ResearchOnboardingScreen({
+  initialFirstName = "",
+  initialLastName = "",
+  onSubmit,
+}: ResearchOnboardingScreenProps) {
+  const [firstName, setFirstName] = useState(initialFirstName);
+  const [lastName, setLastName] = useState(initialLastName);
+  const [occupation, setOccupation] = useState("");
+
+  // First name + occupation are the minimum signal worth researching on.
+  const canSubmit =
+    firstName.trim().length > 0 && occupation.trim().length > 0;
+
+  function handleSubmit() {
+    if (!canSubmit) return;
+    onSubmit({ firstName, lastName, occupation });
+  }
+
+  return (
+    <OnboardingLayout showCreatureFooter={false}>
+      <form
+        className="mx-auto flex min-h-screen w-full max-w-md flex-col px-6 pb-40 text-[var(--content-default)]"
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleSubmit();
+        }}
+      >
+        <div className="flex flex-1 flex-col items-center pt-16">
+          <h1
+            className="text-center text-3xl font-semibold tracking-tight"
+            style={{ animation: "fadeInUp 0.3s ease-out 0.1s both" }}
+          >
+            Let&apos;s start with you.
+          </h1>
+
+          <p
+            className="mt-2 text-center text-body-medium-lighter text-[var(--content-secondary)]"
+            style={{ animation: "fadeInUp 0.3s ease-out 0.15s both" }}
+          >
+            A few details so I can get to know you before we dive in.
+          </p>
+
+          <div
+            className="mt-8 flex w-full flex-col gap-6"
+            style={{ animation: "fadeInUp 0.3s ease-out 0.3s both" }}
+          >
+            <Input
+              label="First name"
+              placeholder="First name"
+              value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+              autoFocus
+              fullWidth
+            />
+            <Input
+              label="Last name"
+              placeholder="Last name"
+              value={lastName}
+              onChange={(e) => setLastName(e.target.value)}
+              fullWidth
+            />
+            <Input
+              label="What do you do?"
+              placeholder="e.g. Product designer at a fintech startup"
+              value={occupation}
+              onChange={(e) => setOccupation(e.target.value)}
+              fullWidth
+            />
+          </div>
+        </div>
+
+        <div
+          className="flex w-full flex-col gap-2 pb-4"
+          style={{ animation: "fadeInUp 0.3s ease-out 0.3s both" }}
+        >
+          <Button
+            type="submit"
+            variant="primary"
+            size="regular"
+            fullWidth
+            disabled={!canSubmit}
+            className="h-11 text-base"
+          >
+            Continue
+          </Button>
+        </div>
+      </form>
+    </OnboardingLayout>
+  );
+}

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -24,7 +24,10 @@
       "label": "Pre-chat Onboarding Experiment 2026-06-06",
       "description": "Pre-chat onboarding experiment with control and variant-a arms. Control shows the full funnel; variant-a shows the condensed pared-down flow.",
       "defaultEnabled": "control",
-      "values": ["control", "variant-a"]
+      "values": [
+        "control",
+        "variant-a"
+      ]
     },
     {
       "id": "experiment-activation-flow-2026-06-03",
@@ -33,7 +36,11 @@
       "label": "Activation Flow Experiment 2026-06-03",
       "description": "Multivariate activation-flow experiment. control = standard flow; variant-a = activation rail; personal-page = new sign-up-page variant (front-end only). Targeted via LaunchDarkly.",
       "defaultEnabled": "control",
-      "values": ["control", "variant-a", "personal-page"]
+      "values": [
+        "control",
+        "variant-a",
+        "personal-page"
+      ]
     },
     {
       "id": "local-docker-enabled",
@@ -401,6 +408,14 @@
       "key": "self-intro-greeting",
       "label": "Self-intro first message",
       "description": "On the first conversation, send a natural self-introduction (e.g. \"Hi Vela, I'm alex. Nice to meet you.\") on the user's behalf and route it through real LLM inference, instead of serving the canned first greeting. Names come from the onboarding context; falls back to the canned greeting when no name is known. Exposed to clients so pre-hatch onboarding can compute the source-of-truth initial message, and to the assistant so older clients can still be gated server-side. See assistant/src/daemon/first-greeting.ts (buildSelfIntroMessage).",
+      "defaultEnabled": false
+    },
+    {
+      "id": "research-onboarding",
+      "scope": "client",
+      "key": "research-onboarding",
+      "label": "Research onboarding (spike)",
+      "description": "Spike: replace pre-chat onboarding with a web-research \"here's what I know about you\" flow. Gates the /assistant/onboarding/research route and its mock harness. Off by default; enable locally via the feature-flags panel.",
       "defaultEnabled": false
     }
   ]

--- a/clients/web/src/routes.tsx
+++ b/clients/web/src/routes.tsx
@@ -178,6 +178,20 @@ export const routeTree = [
           path: "select-assistant",
           lazy: { Component: () => import("@/domains/onboarding/pages/select-assistant-screen").then((m) => m.SelectAssistantScreen) },
         },
+        // SPIKE — research-onboarding front door. Placed here (not in the
+        // onboarding funnel block) so it's reachable on demand behind auth
+        // alone, without the onboarding-completed guard bouncing already-
+        // onboarded users away. Visit `/assistant/onboarding/research`.
+        {
+          path: "onboarding/research",
+          lazy: { Component: () => import("@/domains/onboarding/pages/research-onboarding-route").then((m) => m.ResearchOnboardingRoute) },
+        },
+        // SPIKE — mock harness for iterating on the research results UI without
+        // running the real job. Static fixtures + local state.
+        {
+          path: "onboarding/research-mock",
+          lazy: { Component: () => import("@/domains/chat/onboarding-research/research-mock-page").then((m) => m.ResearchMockPage) },
+        },
         {
           path: "review-terms",
           lazy: { Component: () => import("@/domains/onboarding/pages/review-terms-screen").then((m) => m.ReviewTermsScreen) },

--- a/clients/web/src/stores/onboarding-focus-store.ts
+++ b/clients/web/src/stores/onboarding-focus-store.ts
@@ -1,0 +1,59 @@
+/**
+ * Focused-onboarding presentation flag.
+ *
+ * SPIKE — research-onboarding flow.
+ *
+ * Lives at top-level `stores/` (not `domains/onboarding/`) because it is read
+ * by the `chat` domain (`ChatLayout`) and written by the `onboarding` domain;
+ * cross-domain shared state belongs at the top level per CONVENTIONS.md.
+ *
+ * The research-onboarding front door (`/assistant/onboarding/research`) stages
+ * a pre-chat context whose `initialMessage` is the "research me" prompt, then
+ * hands off to the existing `/assistant?onboarding=1` pipeline. We want the
+ * resulting chat to render in a distraction-free "focused" presentation (no
+ * sidebar / header) until the user explicitly continues into their workspace.
+ *
+ * A URL query flag (`?focused=1`) can't carry that intent: the onboarding
+ * orchestrator immediately `navigate(routes.conversation(draftId), {replace})`
+ * to swap the draft id into the path, stripping any query param before
+ * `ChatLayout` can read it (see `use-onboarding-orchestrator.ts`). A reactive
+ * store flag, set before the handoff navigation, survives those internal
+ * client-side redirects and is read by the persistent `ChatLayout`.
+ *
+ * Lifetime: `enterFocus()` on submit of the research form, `exitFocus()` when
+ * the user clicks "Continue" out of the focused chat (or remounts the form).
+ */
+
+import { create } from "zustand";
+
+import { createSelectors } from "@/utils/create-selectors";
+
+interface OnboardingFocusState {
+  /** When true, `ChatLayout` renders chrome-less with a Continue affordance. */
+  focused: boolean;
+  enterFocus: () => void;
+  exitFocus: () => void;
+  /**
+   * A follow-up message the focused results overlay wants sent into the same
+   * conversation (e.g. the "deeper dive" research request). The overlay lives
+   * outside `ActiveChatView`, which owns `sendMessage`; ActiveChatView watches
+   * this and sends it through the real pipeline, then clears it. Null when
+   * nothing is pending.
+   */
+  pendingFollowupMessage: string | null;
+  requestFollowup: (message: string) => void;
+  clearFollowup: () => void;
+}
+
+const useOnboardingFocusStoreBase = create<OnboardingFocusState>((set) => ({
+  focused: false,
+  enterFocus: () => set({ focused: true }),
+  exitFocus: () => set({ focused: false, pendingFollowupMessage: null }),
+  pendingFollowupMessage: null,
+  requestFollowup: (message) => set({ pendingFollowupMessage: message }),
+  clearFollowup: () => set({ pendingFollowupMessage: null }),
+}));
+
+export const useOnboardingFocusStore = createSelectors(
+  useOnboardingFocusStoreBase,
+);

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -24,7 +24,10 @@
       "label": "Pre-chat Onboarding Experiment 2026-06-06",
       "description": "Pre-chat onboarding experiment with control and variant-a arms. Control shows the full funnel; variant-a shows the condensed pared-down flow.",
       "defaultEnabled": "control",
-      "values": ["control", "variant-a"]
+      "values": [
+        "control",
+        "variant-a"
+      ]
     },
     {
       "id": "experiment-activation-flow-2026-06-03",
@@ -33,7 +36,11 @@
       "label": "Activation Flow Experiment 2026-06-03",
       "description": "Multivariate activation-flow experiment. control = standard flow; variant-a = activation rail; personal-page = new sign-up-page variant (front-end only). Targeted via LaunchDarkly.",
       "defaultEnabled": "control",
-      "values": ["control", "variant-a", "personal-page"]
+      "values": [
+        "control",
+        "variant-a",
+        "personal-page"
+      ]
     },
     {
       "id": "local-docker-enabled",
@@ -401,6 +408,14 @@
       "key": "self-intro-greeting",
       "label": "Self-intro first message",
       "description": "On the first conversation, send a natural self-introduction (e.g. \"Hi Vela, I'm alex. Nice to meet you.\") on the user's behalf and route it through real LLM inference, instead of serving the canned first greeting. Names come from the onboarding context; falls back to the canned greeting when no name is known. Exposed to clients so pre-hatch onboarding can compute the source-of-truth initial message, and to the assistant so older clients can still be gated server-side. See assistant/src/daemon/first-greeting.ts (buildSelfIntroMessage).",
+      "defaultEnabled": false
+    },
+    {
+      "id": "research-onboarding",
+      "scope": "client",
+      "key": "research-onboarding",
+      "label": "Research onboarding (spike)",
+      "description": "Spike: replace pre-chat onboarding with a web-research \"here's what I know about you\" flow. Gates the /assistant/onboarding/research route and its mock harness. Off by default; enable locally via the feature-flags panel.",
       "defaultEnabled": false
     }
   ]


### PR DESCRIPTION
**Spike — not for merge.** Replaces the pre-chat onboarding with a web-research "here's what I know about you" flow. Fully isolated: dedicated routes + a default-off feature flag. No Linear ticket (throwaway spike).

## Try it
1. Enable the **`research-onboarding`** client flag locally (feature-flags settings panel, or `localStorage`). Default is **off**; both routes redirect to the app when off.
2. **UI harness (no research job):** `/assistant/onboarding/research-mock` — static fixtures + a loading/results/empty toggle. Best for fast UI/UX iteration.
3. **Live flow:** `/assistant/onboarding/research` — collects first/last/occupation, then runs the real research turn.

## Flow
- Collect first/last/occupation → hand off to the existing `?onboarding=1` chat pipeline with the research prompt as the auto-sent first message.
- Focused full-viewport overlay over the live chat (keeps `ActiveChatView` mounted): live search **activity feed** → claims **stream in** incrementally (`{ claims, suggestions }` JSON, parsed tolerantly) → editable results card.
- **Claims:** confidence badges, click a row to expand source "proof" links, hover ⊘ to remove. Removal greys the row (not abrupt) + optional reason popover ("Not me" / "Not relevant" / "Keep it").
- **Deeper dive / "This is good for now":** reveals 4 capability-showcasing **suggestions** (each click starts a fresh conversation with that message sent). Removed claims are sent to the assistant — folded into the deeper-dive prompt, or as a correction note on accept.
- **Continue** drops into the workspace on the same conversation.

## Architecture notes
- New code under `clients/web/src/domains/chat/onboarding-research/` (reads chat state) + `domains/onboarding/` (front door) + `stores/onboarding-focus-store.ts`. Store-free `ResearchResultsView` is shared by the live overlay and the mock page so they don't drift.
- Flag registered in `meta/feature-flags/feature-flag-registry.json` (client scope, default off).

## Known limitations / next
- LaunchDarkly **targeting not wired** for deployed envs (the platform-terraform half) — local-only flag for now.
- Claim removals are flushed to the assistant only via the deeper-dive buttons (not on Continue).
- Suggestion click starts a **separate** conversation (research context stays in the original thread).
- `Remove`/persistence is conversational only — no profile-file persistence yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)