### PR TITLE
feat(memory): default memory-v3 on for new assistants (config-gated)

### DIFF
--- a/assistant/src/__tests__/agent-loop-mutable-latest-user-message.test.ts
+++ b/assistant/src/__tests__/agent-loop-mutable-latest-user-message.test.ts
@@ -1,14 +1,14 @@
 /**
- * Verifies that the `memory-v3-live` cache-anchor signal surfaces on every
- * `SendMessageOptions.config` the loop emits. When the flag is on, the latest
+ * Verifies that the memory-v3-live cache-anchor signal surfaces on every
+ * `SendMessageOptions.config` the loop emits. When v3-live is on, the latest
  * user message carries a volatile `<memory>` block, so the loop sets
  * `providerConfig.mutableLatestUserMessage` to tell the provider to anchor its
  * long-TTL cache breakpoint on the most recent STABLE message instead.
  *
- * The loop reads the flag directly where it assembles `providerConfig`, so the
- * signal is sourced from the flag rather than a run option. When the flag is
- * off the field is omitted (not `false`/`undefined`) so the wire stays
- * byte-identical to today.
+ * The loop reads `config.memory.v3.live` directly where it assembles
+ * `providerConfig`, so the signal is sourced from config rather than a run
+ * option. When v3-live is off the field is omitted (not `false`/`undefined`) so
+ * the wire stays byte-identical to today.
  */
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
@@ -19,11 +19,14 @@ mock.module("../util/logger.js", () => ({
   getLogger: () => makeMockLogger(),
 }));
 
+// AgentLoop reads the v3-live gate (`config.memory.v3.live`) via
+// `isMemoryV3Live` to decide the cache-anchor signal; drive it per-test.
+let memoryV3LiveSlot = false;
+mock.module("../config/memory-v3-gate.js", () => ({
+  isMemoryV3Live: () => memoryV3LiveSlot,
+}));
+
 import { AgentLoop } from "../agent/loop.js";
-import {
-  clearCachedOverrides,
-  setCachedOverrides,
-} from "../config/feature-flag-cache.js";
 import type {
   Message,
   Provider,
@@ -82,12 +85,12 @@ function makeRecordingProvider(responses: ProviderResponse[]): {
 
 describe("AgentLoop.run — mutableLatestUserMessage from memory-v3-live", () => {
   afterEach(() => {
-    clearCachedOverrides();
+    memoryV3LiveSlot = false;
   });
 
   test("sets mutableLatestUserMessage on every LLM call when memory-v3-live is on (multi-turn)", async () => {
     // GIVEN memory-v3-live is enabled
-    setCachedOverrides({ "memory-v3-live": true }, { fromGateway: true });
+    memoryV3LiveSlot = true;
 
     // AND a provider that records the config of each LLM call across a tool round-trip
     const { provider, configs } = makeRecordingProvider([
@@ -131,7 +134,7 @@ describe("AgentLoop.run — mutableLatestUserMessage from memory-v3-live", () =>
 
   test("omits mutableLatestUserMessage when memory-v3-live is off (flag-off byte-identity)", async () => {
     // GIVEN memory-v3-live is off (no override; registry default is false)
-    clearCachedOverrides();
+    memoryV3LiveSlot = false;
 
     // AND a provider that records the config of each LLM call
     const { provider, configs } = makeRecordingProvider([textResponse("hi")]);

--- a/assistant/src/__tests__/injector-v3-suppression.test.ts
+++ b/assistant/src/__tests__/injector-v3-suppression.test.ts
@@ -2,7 +2,7 @@
  * Tests for the memory-v3 step-0 branch in `applyRuntimeInjections`:
  * spotlight strip + v2 tail suppression.
  *
- * When the `memory-v3-live` flag is on AND the v3 injector (id `memory-v3`,
+ * When `memory.v3.live` is on AND the v3 injector (id `memory-v3`,
  * placement `after-memory-prefix`) produces a block — possibly EMPTY-TEXT on
  * an all-repeat turn — runtime assembly strips the v2 `<memory>` prefix from
  * the TAIL user message only before splicing the v3 block. Historical user
@@ -16,10 +16,11 @@
  * block lands at the tail.
  *
  * v2 suppression stays keyed off whether v3 produced a block, NOT off the
- * flag alone: a v3 failure (`produce()` → null) leaves v2's block intact
- * (fallback-to-v2). The flag-off path must be byte-for-byte identical to
+ * gate alone: a v3 failure (`produce()` → null) leaves v2's block intact
+ * (fallback-to-v2). The v3-off path must be byte-for-byte identical to
  * today — that is the load-bearing regression guard. `applyRuntimeInjections`
- * reads the flag itself, so these tests drive it through the override cache.
+ * reads the v3-live gate itself, so these tests drive it through the
+ * `isMemoryV3Live` mock slot.
  *
  * The strip discriminates v2's dynamic block by IDENTITY, not by prefix: v2's
  * `INJECTION_HEADER` and v3's `V3_CARDS_INJECTION_HEADER` are deliberately
@@ -42,7 +43,6 @@ import type {
   TurnContext,
 } from "../plugins/types.js";
 import type { Message } from "../providers/types.js";
-import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
 
 // Drive the suppression branch by controlling the static injector chain that
 // `applyRuntimeInjections` walks. The slot is mutated per-test to stand in for
@@ -50,6 +50,13 @@ import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
 const injectorChainSlot: Injector[] = [];
 mock.module("../plugins/defaults/memory-retrieval/injector-chain.js", () => ({
   getInjectorChain: () => injectorChainSlot,
+}));
+
+// `applyRuntimeInjections` reads the v3-live gate (`config.memory.v3.live`)
+// via `isMemoryV3Live`; drive it directly through this slot per-test.
+let memoryV3LiveSlot = false;
+mock.module("../config/memory-v3-gate.js", () => ({
+  isMemoryV3Live: () => memoryV3LiveSlot,
 }));
 
 const { applyRuntimeInjections } =
@@ -141,9 +148,9 @@ function tailTexts(messages: Message[]): string[] {
 describe("memory-v3-live v2 suppression", () => {
   beforeEach(() => {
     injectorChainSlot.length = 0;
-    // Clean baseline: no overrides → `memory-v3-live` resolves to its registry
-    // default (off). Each test seeds the flag it needs.
-    setOverridesForTesting({});
+    // Clean baseline: v3-live off (registry/config default). Each test seeds
+    // the gate value it needs.
+    memoryV3LiveSlot = false;
   });
 
   afterEach(() => {
@@ -152,7 +159,7 @@ describe("memory-v3-live v2 suppression", () => {
   });
 
   test("flag ON + v3 produced a block → TAIL v2 stripped, historical memory blocks frozen in place", async () => {
-    setOverridesForTesting({ "memory-v3-live": true });
+    memoryV3LiveSlot = true;
     injectorChainSlot.push(v3Injector("net-new cards"));
     seedV2Identity("fresh recalled fact");
 
@@ -194,7 +201,7 @@ describe("memory-v3-live v2 suppression", () => {
   });
 
   test("flag ON + EMPTY-TEXT v3 block (all-repeat turn) → tail v2 stripped, nothing attached", async () => {
-    setOverridesForTesting({ "memory-v3-live": true });
+    memoryV3LiveSlot = true;
     injectorChainSlot.push(v3Injector(""));
     seedV2Identity("fresh recalled fact");
 
@@ -217,7 +224,7 @@ describe("memory-v3-live v2 suppression", () => {
   });
 
   test("stale spotlight blocks are stripped from EVERY user message; the new spotlight lands at the tail", async () => {
-    setOverridesForTesting({ "memory-v3-live": true });
+    memoryV3LiveSlot = true;
     injectorChainSlot.push(v3Injector(""), spotlightInjector("fresh sections"));
 
     const staleSpotlight = {
@@ -253,7 +260,7 @@ describe("memory-v3-live v2 suppression", () => {
   });
 
   test("convergence re-entry: a tail leading with this turn's frozen v3 cards (and <info>) is NOT stripped", async () => {
-    setOverridesForTesting({ "memory-v3-live": true });
+    memoryV3LiveSlot = true;
     // Re-entry shape: the memo returns the same selections, every slug is now
     // in the everInjected store, so the injector produces an EMPTY block —
     // while the tail still carries the v3 card block frozen on first entry
@@ -292,7 +299,7 @@ describe("memory-v3-live v2 suppression", () => {
   });
 
   test("first entry with a v2 prefix AND a frozen v3 block strips ONLY the v2 block", async () => {
-    setOverridesForTesting({ "memory-v3-live": true });
+    memoryV3LiveSlot = true;
     injectorChainSlot.push(v3Injector(""));
     seedV2Identity("fresh recalled fact");
 
@@ -319,7 +326,7 @@ describe("memory-v3-live v2 suppression", () => {
   });
 
   test("REGRESSION: a v2 block leading with the REAL summary header (byte-identical to v3's) is stripped; v3 cards and <info> survive (first entry)", async () => {
-    setOverridesForTesting({ "memory-v3-live": true });
+    memoryV3LiveSlot = true;
     injectorChainSlot.push(v3Injector(""));
 
     // The collision this guards: v2's router block leads with
@@ -358,7 +365,7 @@ describe("memory-v3-live v2 suppression", () => {
   });
 
   test("REGRESSION: re-entry with a header-bearing v2 identity keeps the first entry's frozen v3 cards", async () => {
-    setOverridesForTesting({ "memory-v3-live": true });
+    memoryV3LiveSlot = true;
     // Re-entry: produce() returns the EMPTY block (cards already claimed by
     // the store) while the tail carries the FIRST entry's v3 block — and the
     // graph handle still holds the summary-bearing v2 identity from this
@@ -391,7 +398,7 @@ describe("memory-v3-live v2 suppression", () => {
   });
 
   test("v2 memory-image groups and legacy <memory __injected> blocks are stripped even without an identity", async () => {
-    setOverridesForTesting({ "memory-v3-live": true });
+    memoryV3LiveSlot = true;
     injectorChainSlot.push(v3Injector("net-new cards"));
     // No live graph handle: identity unknown (null). Image groups and legacy
     // blocks are unambiguously v2's and are stripped regardless; the shared
@@ -430,7 +437,7 @@ describe("memory-v3-live v2 suppression", () => {
   });
 
   test("the v3 block's attachment-commit callback fires on a user tail", async () => {
-    setOverridesForTesting({ "memory-v3-live": true });
+    memoryV3LiveSlot = true;
     const commit = mock(() => {});
     injectorChainSlot.push(v3Injector("net-new cards", commit));
 
@@ -443,7 +450,7 @@ describe("memory-v3-live v2 suppression", () => {
   });
 
   test("the commit callback is SKIPPED when the tail is not a user message (block never attaches)", async () => {
-    setOverridesForTesting({ "memory-v3-live": true });
+    memoryV3LiveSlot = true;
     const commit = mock(() => {});
     injectorChainSlot.push(v3Injector("net-new cards", commit));
 
@@ -465,7 +472,7 @@ describe("memory-v3-live v2 suppression", () => {
   });
 
   test("flag ON but v3 produced NOTHING → v2 block left intact (fallback-to-v2)", async () => {
-    setOverridesForTesting({ "memory-v3-live": true });
+    memoryV3LiveSlot = true;
     injectorChainSlot.push(v3Injector(null));
 
     const runMessages: Message[] = [
@@ -524,7 +531,7 @@ describe("memory-v3-live v2 suppression", () => {
   test("no v3 injector registered + flag ON → no stripping, messages untouched", async () => {
     // No injector named memory-v3 at all (e.g. plugin not loaded): the
     // suppression branch keys off the produced block, so nothing is stripped.
-    setOverridesForTesting({ "memory-v3-live": true });
+    memoryV3LiveSlot = true;
     expect(injectorChainSlot).toHaveLength(0);
 
     const runMessages: Message[] = [

--- a/assistant/src/__tests__/workspace-migration-105-enable-memory-v3-live-for-new-workspaces.test.ts
+++ b/assistant/src/__tests__/workspace-migration-105-enable-memory-v3-live-for-new-workspaces.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for workspace migration `105-enable-memory-v3-live-for-new-workspaces`.
+ *
+ * The schema default for `memory.v3.live` is false so existing assistants stay
+ * on v2. The migration persists `memory.v3.live = true` for FRESH workspaces
+ * only (switching new assistants onto memory-v3 at creation), creating
+ * `config.json` when it does not exist, leaving existing workspaces and
+ * explicit values untouched, and being idempotent.
+ */
+
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { MemoryV3ConfigSchema } from "../config/schemas/memory-v3.js";
+import { enableMemoryV3LiveForNewWorkspacesMigration } from "../workspace/migrations/105-enable-memory-v3-live-for-new-workspaces.js";
+import type { MigrationRunContext } from "../workspace/migrations/types.js";
+
+const NEW_WORKSPACE_CTX: MigrationRunContext = { isNewWorkspace: true };
+const UPGRADE_CTX: MigrationRunContext = { isNewWorkspace: false };
+
+let workspaceDir: string;
+let configPath: string;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-migration-105-test-"));
+  configPath = join(workspaceDir, "config.json");
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(configPath, "utf-8"));
+}
+
+describe("105-enable-memory-v3-live-for-new-workspaces migration", () => {
+  test("has correct id and description", () => {
+    expect(enableMemoryV3LiveForNewWorkspacesMigration.id).toBe(
+      "105-enable-memory-v3-live-for-new-workspaces",
+    );
+    expect(enableMemoryV3LiveForNewWorkspacesMigration.description).toContain(
+      "memory.v3.live",
+    );
+  });
+
+  test("schema default is off so existing assistants stay on v2", () => {
+    expect(MemoryV3ConfigSchema.parse({}).live).toBe(false);
+  });
+
+  test("creates config.json with memory.v3.live=true for a fresh workspace", () => {
+    enableMemoryV3LiveForNewWorkspacesMigration.run(
+      workspaceDir,
+      NEW_WORKSPACE_CTX,
+    );
+
+    expect(readConfig()).toEqual({ memory: { v3: { live: true } } });
+  });
+
+  test("adds memory.v3.live to a fresh workspace's existing config, preserving siblings", () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify({ name: "Assistant", memory: { enabled: true } }),
+      "utf-8",
+    );
+
+    enableMemoryV3LiveForNewWorkspacesMigration.run(
+      workspaceDir,
+      NEW_WORKSPACE_CTX,
+    );
+
+    expect(readConfig()).toEqual({
+      name: "Assistant",
+      memory: { enabled: true, v3: { live: true } },
+    });
+  });
+
+  test("skips existing workspaces so they stay on v2 (no config written)", () => {
+    enableMemoryV3LiveForNewWorkspacesMigration.run(workspaceDir, UPGRADE_CTX);
+
+    expect(existsSync(configPath)).toBe(false);
+  });
+
+  test("treats a missing context as an existing workspace", () => {
+    enableMemoryV3LiveForNewWorkspacesMigration.run(workspaceDir);
+
+    expect(existsSync(configPath)).toBe(false);
+  });
+
+  test("leaves an explicit memory.v3.live value untouched on a fresh workspace", () => {
+    const original = JSON.stringify({ memory: { v3: { live: false } } });
+    writeFileSync(configPath, original, "utf-8");
+
+    enableMemoryV3LiveForNewWorkspacesMigration.run(
+      workspaceDir,
+      NEW_WORKSPACE_CTX,
+    );
+
+    expect(readFileSync(configPath, "utf-8")).toBe(original);
+  });
+
+  test("leaves malformed config.json untouched", () => {
+    writeFileSync(configPath, "{ not json", "utf-8");
+
+    enableMemoryV3LiveForNewWorkspacesMigration.run(
+      workspaceDir,
+      NEW_WORKSPACE_CTX,
+    );
+
+    expect(readFileSync(configPath, "utf-8")).toBe("{ not json");
+  });
+
+  test("is idempotent", () => {
+    enableMemoryV3LiveForNewWorkspacesMigration.run(
+      workspaceDir,
+      NEW_WORKSPACE_CTX,
+    );
+    const afterFirst = readFileSync(configPath, "utf-8");
+
+    enableMemoryV3LiveForNewWorkspacesMigration.run(
+      workspaceDir,
+      NEW_WORKSPACE_CTX,
+    );
+
+    expect(readFileSync(configPath, "utf-8")).toBe(afterFirst);
+  });
+
+  test("down is a no-op", () => {
+    enableMemoryV3LiveForNewWorkspacesMigration.run(
+      workspaceDir,
+      NEW_WORKSPACE_CTX,
+    );
+    const before = readFileSync(configPath, "utf-8");
+
+    enableMemoryV3LiveForNewWorkspacesMigration.down(workspaceDir);
+
+    expect(readFileSync(configPath, "utf-8")).toBe(before);
+  });
+});

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/node";
 
-import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
+import { isMemoryV3Live } from "../config/memory-v3-gate.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import { recordEstimate } from "../context/estimator-calibration.js";
 import {
@@ -1271,7 +1271,7 @@ export class AgentLoop {
         // volatile latest one. Read here alongside the rest of the provider
         // config; only set when true so the wire/config stays byte-identical
         // when off.
-        if (isAssistantFeatureFlagEnabled("memory-v3-live", getConfig())) {
+        if (isMemoryV3Live(getConfig())) {
           providerConfig.mutableLatestUserMessage = true;
         }
 

--- a/assistant/src/config/memory-v3-gate.ts
+++ b/assistant/src/config/memory-v3-gate.ts
@@ -1,0 +1,11 @@
+import type { AssistantConfig } from "./schema.js";
+
+/**
+ * Whether memory-v3 is the live injected memory source for this assistant,
+ * suppressing v2 injection. Gated by workspace config (`memory.v3.live`): new
+ * assistants are switched on at creation via a workspace migration, while
+ * existing assistants stay on v2 until the value is set explicitly.
+ */
+export function isMemoryV3Live(config: AssistantConfig): boolean {
+  return config.memory.v3.live === true;
+}

--- a/assistant/src/config/schemas/__tests__/memory-v3.test.ts
+++ b/assistant/src/config/schemas/__tests__/memory-v3.test.ts
@@ -6,6 +6,7 @@ describe("MemoryV3ConfigSchema", () => {
   test("parses an empty object to documented defaults", () => {
     const parsed = MemoryV3ConfigSchema.parse({});
     expect(parsed).toEqual({
+      live: false,
       prune: { maxResidentBytes: 393216, targetResidentBytes: 262144 },
       hotSet: { k: 40, halfLifeDays: 14 },
       freshSet: { k: 100 },

--- a/assistant/src/config/schemas/memory-v3.ts
+++ b/assistant/src/config/schemas/memory-v3.ts
@@ -220,6 +220,12 @@ export const MemoryV3PruneSchema = z
 // so legacy configs keep parsing. Do not make this object `.strict()`.
 export const MemoryV3ConfigSchema = z
   .object({
+    live: z
+      .boolean({ error: "memory.v3.live must be a boolean" })
+      .default(false)
+      .describe(
+        "Whether memory-v3 is the live injected memory source, suppressing v2 injection. Off by default; brand-new assistants are switched on at creation via a workspace migration, while existing assistants stay on v2 until explicitly enabled.",
+      ),
     prune: MemoryV3PruneSchema.default(MemoryV3PruneSchema.parse({})),
     hotSet: MemoryV3HotSetSchema.default(MemoryV3HotSetSchema.parse({})),
     freshSet: MemoryV3FreshSetSchema.default(MemoryV3FreshSetSchema.parse({})),

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -9,9 +9,9 @@ import { statSync } from "node:fs";
 import { join } from "node:path";
 
 import { type ChannelId, parseInterfaceId } from "../channels/types.js";
-import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
+import { isMemoryV3Live } from "../config/memory-v3-gate.js";
 import type { LLMCallSite, LLMConfig } from "../config/schemas/llm.js";
 import {
   NOW_SCRATCHPAD_STRIP_PREFIXES,
@@ -1536,8 +1536,8 @@ export interface RuntimeInjectionBlocks {
    */
   memoryV3InjectedBlock?: string;
   /**
-   * True when memory-v3 superseded v2 as this turn's `<memory>` source — the
-   * `memory-v3-live` flag is on AND the v3 injector produced a block (possibly
+   * True when memory-v3 superseded v2 as this turn's `<memory>` source —
+   * `memory.v3.live` is on AND the v3 injector produced a block (possibly
    * empty-text on an all-repeat turn), i.e. exactly when assembly stripped
    * v2's fresh tail block. The user-prompt-submit hook keys v2's
    * `memoryInjectedBlock` metadata persist off this so a stripped v2 block is
@@ -2177,7 +2177,7 @@ export async function applyRuntimeInjections(
   // no-op, keeping the v2 path bit-for-bit identical.
   let runMessagesForAssembly = stripSpotlightInjections(runMessages);
 
-  // v2 suppression: when the `memory-v3-live` flag is on AND the v3 injector
+  // v2 suppression: when `memory.v3.live` is on AND the v3 injector
   // produced a block this turn (possibly empty-text on an all-repeat turn), v3
   // owns the `<memory>` layer. v2's `prepareMemory` already prepended its own
   // fresh `<memory>` block to the tail user message — strip the TAIL's v2
@@ -2196,10 +2196,7 @@ export async function applyRuntimeInjections(
   // (`produce()` → null) leaves v2's block intact — fallback rather than a
   // memory-less turn. Idempotent: re-injection sites that already stripped
   // see no change. Flag off → bit-for-bit identical to the v2 path.
-  const suppressV2MemoryForV3 = isAssistantFeatureFlagEnabled(
-    "memory-v3-live",
-    getConfig(),
-  );
+  const suppressV2MemoryForV3 = isMemoryV3Live(getConfig());
   const v3ProducedBlock = afterMemory.some((b) => b.id === MEMORY_V3_BLOCK_ID);
   const memoryV3Active = suppressV2MemoryForV3 && v3ProducedBlock;
   if (memoryV3Active) {

--- a/assistant/src/memory/jobs-worker.ts
+++ b/assistant/src/memory/jobs-worker.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
+import { isMemoryV3Live } from "../config/memory-v3-gate.js";
 import type { AssistantConfig } from "../config/types.js";
 import {
   checkDiskPressureBackgroundGate,
@@ -852,7 +853,7 @@ export function maybeEnqueueGraphMaintenanceJobs(
   // this guard is belt-and-suspenders that also avoids a wasted enqueue.
   if (
     isAssistantFeatureFlagEnabled("memory-v3-shadow", config) ||
-    isAssistantFeatureFlagEnabled("memory-v3-live", config)
+    isMemoryV3Live(config)
   ) {
     schedule.push({
       key: GRAPH_MAINTENANCE_CHECKPOINTS.memoryV3Maintain,

--- a/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
+++ b/assistant/src/memory/v2/__tests__/consolidation-job.test.ts
@@ -117,6 +117,14 @@ mock.module("../../../config/assistant-feature-flags.js", () => ({
   isAssistantFeatureFlagEnabled: (key: string) => flagStates[key] ?? v3FlagOn,
 }));
 
+// The v3-live gate moved to config (`config.memory.v3.live`), read via
+// `isMemoryV3Live`. Mirror the flag mock so the shadow-vs-live tests keep
+// driving live through `flagStates["memory-v3-live"]` (and `v3FlagOn` toggles
+// it alongside shadow for the existing on/off tests).
+mock.module("../../../config/memory-v3-gate.js", () => ({
+  isMemoryV3Live: () => flagStates["memory-v3-live"] ?? v3FlagOn,
+}));
+
 // ── Workspace pin ───────────────────────────────────────────────────
 let tmpWorkspace: string;
 let previousWorkspaceEnv: string | undefined;

--- a/assistant/src/memory/v2/consolidation-job.ts
+++ b/assistant/src/memory/v2/consolidation-job.ts
@@ -65,6 +65,7 @@ import {
 import { dirname, join } from "node:path";
 
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
+import { isMemoryV3Live } from "../../config/memory-v3-gate.js";
 import type { AssistantConfig } from "../../config/types.js";
 import { runBackgroundJob } from "../../runtime/background-job-runner.js";
 import { getLogger } from "../../util/logger.js";
@@ -89,7 +90,6 @@ const JOB_NAME = "memory.consolidate";
  * post-consolidation follow-up. These gate the v3 plugin itself.
  */
 const MEMORY_V3_SHADOW = "memory-v3-shadow" as const;
-const MEMORY_V3_LIVE = "memory-v3-live" as const;
 
 /**
  * Hard timeout for the consolidation run. Consolidation reads the buffer,
@@ -269,7 +269,7 @@ export async function memoryV2ConsolidateJob(
     // The article SHAPE is keyed on the live flag alone: under shadow, live
     // prompts are still assembled by v2's injection model, so consolidation
     // must keep producing `summary:`-bearing fragment pages until the flip.
-    const memoryV3Live = isAssistantFeatureFlagEnabled(MEMORY_V3_LIVE, config);
+    const memoryV3Live = isMemoryV3Live(config);
     const memoryV3Active =
       isAssistantFeatureFlagEnabled(MEMORY_V3_SHADOW, config) || memoryV3Live;
     const prompt = resolveConsolidationPrompt(

--- a/assistant/src/plugins/defaults/memory-retrieval/hooks/user-prompt-submit.ts
+++ b/assistant/src/plugins/defaults/memory-retrieval/hooks/user-prompt-submit.ts
@@ -32,8 +32,8 @@ import type {
   UserPromptSubmitContext,
 } from "@vellumai/plugin-api";
 
-import { isAssistantFeatureFlagEnabled } from "../../../../config/assistant-feature-flags.js";
 import { getConfig } from "../../../../config/loader.js";
+import { isMemoryV3Live } from "../../../../config/memory-v3-gate.js";
 import { findConversationOrSubagent } from "../../../../daemon/conversation-registry.js";
 import {
   applyRuntimeInjections,
@@ -273,7 +273,7 @@ const userPromptSubmitMemoryRetrieval: PluginHookFn<
   // presence checks stay inline so the block below narrows. NOTE: this removes
   // the v2 fallback — under v3-live, a v3 empty/failed selection yields no NEW
   // injected memory that turn (prior turns' frozen v3 cards still ride history).
-  const memoryV3Live = isAssistantFeatureFlagEnabled("memory-v3-live", config);
+  const memoryV3Live = isMemoryV3Live(config);
   let v2BlockPersisted = false;
   if (
     shouldRunV2Retrieval({ isTrustedActor, memoryV3Live }) &&

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/carry-integration.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/carry-integration.test.ts
@@ -172,6 +172,7 @@ mock.module("../../../../config/loader.js", () => ({
       ? {
           memory: {
             v3: {
+              live: true,
               spotlight: {
                 n: SPOTLIGHT_N,
                 windowTurns: SPOTLIGHT_WINDOW_TURNS,

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/injection.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/injection.test.ts
@@ -130,6 +130,7 @@ mock.module("../../../../config/loader.js", () => ({
           memory: {
             enabled: memoryEnabled,
             v3: {
+              live: liveEnabled,
               spotlight: spotlightConfig,
               prune: pruneConfig ?? undefined,
             },

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/maintain-job.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/maintain-job.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import { setOverridesForTesting } from "../../../../__tests__/feature-flag-test-helpers.js";
 import type { AssistantConfig } from "../../../../config/types.js";
@@ -16,12 +16,17 @@ import { buildSectionIndex } from "../sections.js";
 import type { Section, SectionIndex, Slug } from "../types.js";
 
 const FLAG_SHADOW = "memory-v3-shadow";
-const FLAG_LIVE = "memory-v3-live";
 
-// The flag resolver ignores the passed config and reads the override cache; the
-// config arg only satisfies the signature. Flags are driven via
-// `setOverridesForTesting` below.
+// The shadow flag resolver ignores the passed config and reads the override
+// cache; the config arg only satisfies the signature. Shadow is driven via
+// `setOverridesForTesting`; v3-live (now config-gated) is driven through the
+// `isMemoryV3Live` mock slot below.
 const CONFIG = {} as AssistantConfig;
+
+let memoryV3LiveSlot = false;
+mock.module("../../../../config/memory-v3-gate.js", () => ({
+  isMemoryV3Live: () => memoryV3LiveSlot,
+}));
 
 function makeSection(article: Slug, ordinal: number): Section {
   return {
@@ -44,6 +49,7 @@ const JOB = { id: "job-1", type: "memory_v3_maintain" } as unknown as MemoryJob;
 describe("maintainJob", () => {
   afterEach(() => {
     setOverridesForTesting({});
+    memoryV3LiveSlot = false;
   });
 
   function deps(overrides: Partial<MaintainJobDeps> = {}): {
@@ -96,7 +102,7 @@ describe("maintainJob", () => {
   }
 
   test("no-op when both v3 flags are off", async () => {
-    setOverridesForTesting({ [FLAG_SHADOW]: false, [FLAG_LIVE]: false });
+    setOverridesForTesting({ [FLAG_SHADOW]: false });
     const { deps: d, calls } = deps({
       selectChangedPages: async () => ["page-a"],
     });
@@ -130,7 +136,7 @@ describe("maintainJob", () => {
   });
 
   test("runs when only the live flag is on", async () => {
-    setOverridesForTesting({ [FLAG_LIVE]: true });
+    memoryV3LiveSlot = true;
     const { deps: d, calls } = deps({
       selectChangedPages: async () => ["page-a"],
     });
@@ -452,6 +458,7 @@ describe("computeChangedPages", () => {
 describe("backfillAllSections", () => {
   afterEach(() => {
     setOverridesForTesting({});
+    memoryV3LiveSlot = false;
   });
 
   function deps(overrides: Partial<BackfillJobDeps> = {}): {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/selection-log-store.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/selection-log-store.test.ts
@@ -114,7 +114,10 @@ mock.module("../../../../config/assistant-feature-flags.js", () => ({
 
 mock.module("../../../../config/loader.js", () => ({
   ...realLoader,
-  getConfig: () => (storeMockActive ? {} : realLoader.getConfig()),
+  getConfig: () =>
+    storeMockActive
+      ? { memory: { v3: { live: liveEnabled } } }
+      : realLoader.getConfig(),
 }));
 
 mock.module("../../../../memory/db-connection.js", () => ({

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/shadow-plugin.test.ts
@@ -189,6 +189,7 @@ mock.module("../../../../config/loader.js", () => ({
     memory: {
       enabled: memoryEnabled,
       v3: {
+        live: liveEnabled,
         hotSet: { k: 40, halfLifeDays: 14 },
         freshSet: { k: 50 },
         spotlight: { n: 6, windowTurns: 2 },

--- a/assistant/src/plugins/defaults/memory-v3-shadow/injector.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/injector.ts
@@ -41,9 +41,9 @@
  *    block id only); it is never persisted to metadata, so the frozen card
  *    prefix it follows stays byte-stable and cached regardless.
  *
- * Flag gating is unchanged: `memory-v3-live` attaches blocks; `memory-v3-shadow`
- * (live off) logs what WOULD inject (net-new slugs + bytes + spotlight refs)
- * and attaches nothing; both off → no orchestration.
+ * Gating: `memory.v3.live` (config) attaches blocks; the `memory-v3-shadow`
+ * flag (live off) logs what WOULD inject (net-new slugs + bytes + spotlight
+ * refs) and attaches nothing; both off → no orchestration.
  *
  * Both injectors apply the same personal-memory trust gate as v2
  * ({@link isPersonalMemoryAllowed}): an untrusted remote actor's turn
@@ -62,6 +62,7 @@
 
 import { isAssistantFeatureFlagEnabled } from "../../../config/assistant-feature-flags.js";
 import { getConfig } from "../../../config/loader.js";
+import { isMemoryV3Live } from "../../../config/memory-v3-gate.js";
 import { isPersonalMemoryAllowed } from "../../../daemon/trust-context.js";
 import {
   wrapMemoryBlock,
@@ -85,11 +86,7 @@ import {
   renderSpotlightInner,
   type SpotlightEntry,
 } from "./render-injection.js";
-import {
-  MEMORY_V3_LIVE,
-  MEMORY_V3_SHADOW,
-  observeTurn,
-} from "./shadow-plugin.js";
+import { MEMORY_V3_SHADOW, observeTurn } from "./shadow-plugin.js";
 import {
   MEMORY_V3_BLOCK_ID,
   MEMORY_V3_COMMIT_META_KEY,
@@ -239,7 +236,7 @@ export const memoryV3Injector: Injector = {
   async produce(ctx: TurnContext): Promise<InjectionBlock | null> {
     const config = getConfig();
     if (config.memory.enabled === false) return null;
-    const live = isAssistantFeatureFlagEnabled(MEMORY_V3_LIVE, config);
+    const live = isMemoryV3Live(config);
     const shadow = isAssistantFeatureFlagEnabled(MEMORY_V3_SHADOW, config);
     if (!live && !shadow) return null;
     if (!isPersonalMemoryAllowed(ctx.trust)) return null;
@@ -378,7 +375,7 @@ export const memoryV3SpotlightInjector: Injector = {
     // Live-only: shadow mode logs spotlight refs from the cards injector and
     // must keep the turn untouched (no ring state either, so a later
     // live-flag flip starts from a clean window).
-    if (!isAssistantFeatureFlagEnabled(MEMORY_V3_LIVE, config)) return null;
+    if (!isMemoryV3Live(config)) return null;
     if (!isPersonalMemoryAllowed(ctx.trust)) return null;
 
     try {

--- a/assistant/src/plugins/defaults/memory-v3-shadow/maintain-job.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/maintain-job.ts
@@ -42,8 +42,8 @@
  * logged and recorded in the outcome but does NOT abort the others. A single
  * page whose embed fails does not abort the rest of the re-embed stage, and a
  * single prune delete that throws does not abort the rest of the prune stage.
- * The job is a no-op (returns a disabled outcome) unless `memory-v3-shadow` OR
- * `memory-v3-live` is enabled — the same flags that gate the v3 plugin.
+ * The job is a no-op (returns a disabled outcome) unless the `memory-v3-shadow`
+ * flag OR `memory.v3.live` (config) is enabled — the same gates as the v3 plugin.
  *
  * Dependency-injectable: `deps` lets tests substitute the page-index reader,
  * section builder, dense-store ops (including the prune-stage
@@ -52,6 +52,7 @@
  */
 
 import { isAssistantFeatureFlagEnabled } from "../../../config/assistant-feature-flags.js";
+import { isMemoryV3Live } from "../../../config/memory-v3-gate.js";
 import type { AssistantConfig } from "../../../config/types.js";
 import {
   getMemoryCheckpoint,
@@ -75,7 +76,6 @@ import { invalidateLanes as realInvalidateLanes } from "./shadow-plugin.js";
 import type { Slug } from "./types.js";
 
 const MEMORY_V3_SHADOW = "memory-v3-shadow" as const;
-const MEMORY_V3_LIVE = "memory-v3-live" as const;
 
 /**
  * Durable checkpoint holding the epoch-ms high-water mark of the last successful
@@ -625,7 +625,7 @@ export async function maintainJob(
 
   const enabled =
     isAssistantFeatureFlagEnabled(MEMORY_V3_SHADOW, config) ||
-    isAssistantFeatureFlagEnabled(MEMORY_V3_LIVE, config);
+    isMemoryV3Live(config);
   if (!enabled) {
     outcome.disabled = true;
     return outcome;

--- a/assistant/src/plugins/defaults/memory-v3-shadow/selection-log-store.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/selection-log-store.ts
@@ -19,6 +19,7 @@
 import type { MemoryV3SelectionLog } from "../../../api/responses/memory-v3-selection-log.js";
 import { isAssistantFeatureFlagEnabled } from "../../../config/assistant-feature-flags.js";
 import { getConfig } from "../../../config/loader.js";
+import { isMemoryV3Live } from "../../../config/memory-v3-gate.js";
 import { getDb, getSqliteFrom } from "../../../memory/db-connection.js";
 import { readPage } from "../../../memory/v2/page-store.js";
 import { getWorkspaceDir } from "../../../util/platform.js";
@@ -35,7 +36,6 @@ import {
 } from "./types.js";
 
 const MEMORY_V3_SHADOW = "memory-v3-shadow" as const;
-const MEMORY_V3_LIVE = "memory-v3-live" as const;
 
 interface SelectionRow {
   turn: number;
@@ -179,7 +179,7 @@ async function buildSelectionLog(
 
   return {
     turn: rows[0]!.turn,
-    live: isAssistantFeatureFlagEnabled(MEMORY_V3_LIVE, config),
+    live: isMemoryV3Live(config),
     shadow: isAssistantFeatureFlagEnabled(MEMORY_V3_SHADOW, config),
     selections,
     injectedText,

--- a/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/shadow-plugin.ts
@@ -69,7 +69,6 @@ import {
 } from "./types.js";
 
 export const MEMORY_V3_SHADOW = "memory-v3-shadow" as const;
-export const MEMORY_V3_LIVE = "memory-v3-live" as const;
 
 const log = getLogger("memory-v3-shadow");
 

--- a/assistant/src/workspace/migrations/105-enable-memory-v3-live-for-new-workspaces.ts
+++ b/assistant/src/workspace/migrations/105-enable-memory-v3-live-for-new-workspaces.ts
@@ -1,0 +1,63 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { MigrationRunContext, WorkspaceMigration } from "./types.js";
+
+/**
+ * Switch brand-new assistants onto memory-v3 (the live injected memory source)
+ * at creation by persisting `memory.v3.live = true`.
+ *
+ * The schema default is `false`, so existing assistants keep running v2 on
+ * upgrade — this migration writes the value only for freshly-created
+ * workspaces. The value gates v3 via `isMemoryV3Live`; existing assistants are
+ * switched on deliberately, never automatically. Covers every surface (local,
+ * Docker, managed) uniformly because all run workspace migrations on first boot.
+ */
+export const enableMemoryV3LiveForNewWorkspacesMigration: WorkspaceMigration = {
+  id: "105-enable-memory-v3-live-for-new-workspaces",
+  description:
+    "Persist memory.v3.live=true for brand-new workspaces so new assistants run memory-v3 from creation",
+
+  run(workspaceDir: string, ctx?: MigrationRunContext): void {
+    // Only switch new assistants on. Existing workspaces fall through to the
+    // schema default (false) and keep running v2 until enabled explicitly.
+    // Without a context (older callers) treat the workspace as existing.
+    if (!ctx?.isNewWorkspace) return;
+
+    const configPath = join(workspaceDir, "config.json");
+
+    // A fresh workspace may have no config.json yet (schema defaults are
+    // applied in memory at load); create one so the live default persists.
+    let config: Record<string, unknown> = {};
+    if (existsSync(configPath)) {
+      try {
+        const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+        if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+        config = raw as Record<string, unknown>;
+      } catch {
+        return;
+      }
+    }
+
+    if (config.memory === undefined) config.memory = {};
+    const memory = config.memory;
+    if (!memory || typeof memory !== "object" || Array.isArray(memory)) return;
+    const memoryConfig = memory as Record<string, unknown>;
+
+    if (memoryConfig.v3 === undefined) memoryConfig.v3 = {};
+    const v3 = memoryConfig.v3;
+    if (!v3 || typeof v3 !== "object" || Array.isArray(v3)) return;
+    const v3Config = v3 as Record<string, unknown>;
+
+    // Respect an explicit value already present (idempotent re-runs, or a
+    // hatch-time override that set it deliberately).
+    if ("live" in v3Config) return;
+
+    v3Config.live = true;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+
+  down(_workspaceDir: string): void {
+    // Forward-only: cannot distinguish a user's explicit choice from this seed.
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -102,6 +102,7 @@ import { upgradeBalancedEconomyToMinimaxM3Migration } from "./101-upgrade-balanc
 import { preserveHeartbeatEnabledForExistingWorkspacesMigration } from "./102-preserve-heartbeat-enabled-for-existing-workspaces.js";
 import { upgradeQualityProfileToOpus48Migration } from "./103-upgrade-quality-profile-to-opus-4-8.js";
 import { recheckAdaptiveThinkingModelImpliedAnthropicMigration } from "./104-recheck-adaptive-thinking-model-implied-anthropic.js";
+import { enableMemoryV3LiveForNewWorkspacesMigration } from "./105-enable-memory-v3-live-for-new-workspaces.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -215,4 +216,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   preserveHeartbeatEnabledForExistingWorkspacesMigration,
   upgradeQualityProfileToOpus48Migration,
   recheckAdaptiveThinkingModelImpliedAnthropicMigration,
+  enableMemoryV3LiveForNewWorkspacesMigration,
 ];


### PR DESCRIPTION
## Summary
- Moves the memory-v3 *live* gate from the `memory-v3-live` feature flag to a workspace-config boolean `memory.v3.live` (schema default `false`), read via a new `isMemoryV3Live(config)` helper at all 9 call sites.
- Adds workspace migration `105` that sets `memory.v3.live = true` for **brand-new workspaces only** (`ctx.isNewWorkspace`), so new assistants on every surface (local, Docker, managed) run memory-v3 from creation while existing assistants stay on v2.
- Migrates the v3-live test suite from feature-flag overrides to driving the config gate; adds a migration-105 test. tsc + lint clean; all affected test files pass individually.

## Notes / follow-ups
- The `memory-v3-live` feature flag is now unused. It is left declared in the registry to keep this PR focused; full removal (+ the LaunchDarkly/Terraform entry, which per `PENDING_PLATFORM_PRS.md` was never opened) is a follow-up. `memory-v3-shadow` remains a flag (telemetry).
- **Before deploying to any assistant currently running v3 via the flag (Velissa):** set `memory.v3.live = true` in its config first, or it drops to v2 on upgrade — the old flag state is not auto-migrated (migrations cannot reliably read flags at startup).

## Original prompt
Make memory-v3 on by default for brand-new assistants without auto-switching existing ones. Investigation found the v3-live gate was the `memory-v3-live` feature flag (the `memory.v3.enabled` key in config.json was dead/legacy). The chosen approach moves the gate to config so a single workspace migration switches new assistants on uniformly across all surfaces while existing ones keep their behavior; the one existing flag-on instance (Velissa) is preserved by setting its config manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)