### PR TITLE
feat(profiles): use platform managed profiles when seeding at boot

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -18,7 +18,9 @@ import {
   validateEnv,
 } from "../config/env.js";
 import { loadConfig, mergeDefaultWorkspaceConfig } from "../config/loader.js";
+import { fetchManagedProfileTemplates } from "../config/managed-profiles-remote.js";
 import type { AssistantConfig } from "../config/schema.js";
+import type { ManagedProfileTemplate } from "../config/seed-inference-profiles.js";
 import { seedInferenceProfiles } from "../config/seed-inference-profiles.js";
 import type { CesClient } from "../credential-execution/client.js";
 import { createCesClient } from "../credential-execution/client.js";
@@ -189,6 +191,26 @@ export interface CesStartupResult {
   processManager: CesProcessManager | undefined;
   clientPromise: Promise<CesClient | undefined> | undefined;
   abortController: AbortController | undefined;
+}
+
+/**
+ * Resolve the managed profile templates used when seeding inference profiles at
+ * boot. Awaits the bounded, non-throwing platform fetch and normalizes its
+ * `null` failure result (kill-switch set, platform disabled/unreachable, or an
+ * unrecognized payload) to `undefined` so the seeder falls back to its built-in
+ * templates. This never throws and never blocks startup.
+ */
+export async function resolveManagedTemplatesForSeeding(): Promise<
+  Record<string, ManagedProfileTemplate> | undefined
+> {
+  const remoteManagedTemplates = await fetchManagedProfileTemplates();
+  if (remoteManagedTemplates) {
+    log.info(
+      { count: Object.keys(remoteManagedTemplates).length },
+      "Using platform-provided managed model profiles for seeding",
+    );
+  }
+  return remoteManagedTemplates ?? undefined;
 }
 
 /**
@@ -579,11 +601,13 @@ export async function runDaemon(): Promise<void> {
     // Off-platform hatches additionally create user profiles + a personal
     // provider connection for the hatch provider.
     try {
+      const managedProfileTemplates = await resolveManagedTemplatesForSeeding();
       seedInferenceProfiles({
         preserveProfileNames: defaultConfigMerge.providedLlmProfileNames,
         preserveActiveProfile: defaultConfigMerge.providedLlmActiveProfile,
         isHatch: defaultConfigMerge.hadOverlay,
         db: dbReady ? getDb() : undefined,
+        managedProfileTemplates,
       });
       log.info("Inference profile seeding complete");
     } catch (err) {

--- a/assistant/src/daemon/resolve-managed-templates.test.ts
+++ b/assistant/src/daemon/resolve-managed-templates.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { ManagedProfileTemplate } from "../config/seed-inference-profiles.js";
+
+// ---------------------------------------------------------------------------
+// Mutable mock state
+// ---------------------------------------------------------------------------
+
+let mockFetchResult: Record<string, ManagedProfileTemplate> | null = null;
+
+// ---------------------------------------------------------------------------
+// Module mocks (must be registered before importing the module under test)
+// ---------------------------------------------------------------------------
+
+mock.module("../config/managed-profiles-remote.js", () => ({
+  fetchManagedProfileTemplates: async () => mockFetchResult,
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test (after mocks)
+// ---------------------------------------------------------------------------
+
+import { resolveManagedTemplatesForSeeding } from "./lifecycle.js";
+
+function templateMap(): Record<string, ManagedProfileTemplate> {
+  return {
+    balanced: {
+      intent: "balanced",
+      provider: "anthropic",
+      connectionName: "anthropic-managed",
+      source: "managed",
+      label: "Balanced",
+      description: "Good balance",
+      maxTokens: 16000,
+      effort: "high",
+      thinking: { enabled: true, streamThinking: true },
+      contextWindow: { maxInputTokens: 200000 },
+    },
+  };
+}
+
+describe("resolveManagedTemplatesForSeeding", () => {
+  beforeEach(() => {
+    mockFetchResult = null;
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("returns the fetched template map when the platform provides one", async () => {
+    const expected = templateMap();
+    mockFetchResult = expected;
+
+    const result = await resolveManagedTemplatesForSeeding();
+
+    expect(result).toEqual(expected);
+  });
+
+  test("returns undefined (falls back to built-ins) when the fetch returns null", async () => {
+    mockFetchResult = null;
+
+    const result = await resolveManagedTemplatesForSeeding();
+
+    expect(result).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Daemon boot now awaits the bounded, non-throwing `fetchManagedProfileTemplates()` before seeding and passes the result into `seedInferenceProfiles` via the `managedProfileTemplates` option
- Falls back to built-in templates when the fetch returns null (platform disabled/unreachable/kill-switch/unrecognized payload); startup is never blocked
- Platform overlay preservation (`preserveProfileNames`) is unchanged

Part of plan: remote-managed-model-profiles.md (PR 3 of 3)