### PR TITLE
fix(cli): forward remote-model-profiles kill-switch to the packaged daemon

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -963,6 +963,7 @@ export async function startLocalDaemon(
         "VELLUM_DEV",
         "VELLUM_DESKTOP_APP",
         "VELLUM_DISABLE_PLATFORM",
+        "VELLUM_DISABLE_REMOTE_MODEL_PROFILES",
         "VELLUM_WORKSPACE_DIR",
       ]) {
         if (process.env[key]) {


### PR DESCRIPTION
## Summary
Fixes gap from plan review for remote-managed-model-profiles.md.

**Gap:** The VELLUM_DISABLE_REMOTE_MODEL_PROFILES kill-switch was stripped on the packaged-binary daemon launch path (cli/src/lib/local.ts forwards an explicit env allowlist that included VELLUM_DISABLE_PLATFORM but not the new var), making the documented kill-switch a no-op for shipped users.
**Fix:** add VELLUM_DISABLE_REMOTE_MODEL_PROFILES to the daemon env allowlist next to VELLUM_DISABLE_PLATFORM.