### PR TITLE
feat(skills): add memory v2-to-v3 migration skill

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -15202,6 +15202,43 @@ paths:
                 additionalProperties: false
         "409":
           description: Another memory item with this content already exists
+  /v1/memory/eval/run:
+    post:
+      operationId: memory_eval_run_post
+      summary: Build blinded A/B retrieval-eval packets over two concept corpora (snapshot vs staged wiki)
+      tags:
+        - memory
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  turnsMined:
+                    type: number
+                  packetsWritten:
+                    type: number
+                  packetsPath:
+                    type: string
+                  keyPath:
+                    type: string
+                  snapshotPages:
+                    type: number
+                  stagingPages:
+                    type: number
+                  dense:
+                    type: boolean
+                required:
+                  - turnsMined
+                  - packetsWritten
+                  - packetsPath
+                  - keyPath
+                  - snapshotPages
+                  - stagingPages
+                  - dense
+                additionalProperties: false
   /v1/memory/v2/backfill:
     post:
       operationId: memory_v2_backfill_post

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -15208,6 +15208,44 @@ paths:
       summary: Build blinded A/B retrieval-eval packets over two concept corpora (snapshot vs staged wiki)
       tags:
         - memory
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                stagingDir:
+                  type: string
+                  minLength: 1
+                snapshotDir:
+                  type: string
+                  minLength: 1
+                outDir:
+                  type: string
+                  minLength: 1
+                turns:
+                  type: integer
+                  exclusiveMinimum: 0
+                  maximum: 9007199254740991
+                perConversationCap:
+                  type: integer
+                  exclusiveMinimum: 0
+                  maximum: 9007199254740991
+                k:
+                  type: integer
+                  exclusiveMinimum: 0
+                  maximum: 9007199254740991
+                dense:
+                  type: boolean
+                seed:
+                  type: integer
+                  minimum: -9007199254740991
+                  maximum: 9007199254740991
+              required:
+                - stagingDir
+                - snapshotDir
+                - outDir
       responses:
         "200":
           description: Successful response

--- a/assistant/src/cli/commands/__tests__/memory-v3.test.ts
+++ b/assistant/src/cli/commands/__tests__/memory-v3.test.ts
@@ -144,7 +144,7 @@ describe("subcommand registration", () => {
     const v3 = memory!.commands.find((c) => c.name() === "v3");
     expect(v3).toBeDefined();
     const subcommandNames = v3!.commands.map((c) => c.name()).sort();
-    expect(subcommandNames).toEqual(["backfill-sections", "rebuild-index"]);
+    expect(subcommandNames).toEqual(["backfill-sections", "eval", "rebuild-index"]);
   });
 });
 

--- a/assistant/src/cli/commands/memory-v3.ts
+++ b/assistant/src/cli/commands/memory-v3.ts
@@ -18,6 +18,7 @@
 import type { Command } from "commander";
 
 import { cliIpcCall } from "../../ipc/cli-client.js";
+import type { MemoryEvalRunResult } from "../../runtime/routes/memory-eval-routes.js";
 import type {
   MemoryV3BackfillSectionsResult,
   MemoryV3RebuildIndexResult,
@@ -33,6 +34,13 @@ import { log } from "../logger.js";
  * keeps working.
  */
 const BACKFILL_IPC_TIMEOUT_MS = 30 * 60 * 1000;
+
+/**
+ * IPC timeout for `eval`. Embedding both corpora's sections runs through the
+ * embedder and easily outlasts the default 60s, so allow the same generous
+ * ceiling as the backfill.
+ */
+const EVAL_IPC_TIMEOUT_MS = 30 * 60 * 1000;
 
 export function registerMemoryV3Command(program: Command): void {
   // Reuse an existing `memory` parent if some other registrar attached to it
@@ -134,6 +142,91 @@ Examples:
                 : "."),
           );
         });
+
+      // ── eval ──────────────────────────────────────────────────────────────
+
+      v3.command("eval")
+        .description(
+          "Build blinded A/B retrieval-eval packets (snapshot corpus vs staged wiki)",
+        )
+        .requiredOption(
+          "--staging <dir>",
+          "Staged v3 wiki dir (relative to the workspace, or absolute)",
+        )
+        .requiredOption(
+          "--snapshot <dir>",
+          "Read-only v2 snapshot dir (relative to the workspace, or absolute)",
+        )
+        .requiredOption("--out <dir>", "Output dir for packets.json + key.json")
+        .option("--turns <n>", "Number of recent turns to mine", "30")
+        .option("--k <n>", "Pages per memory set", "8")
+        .option(
+          "--seed <n>",
+          "Blinding seed (reproducible A/B assignment)",
+          "1",
+        )
+        .option(
+          "--no-dense",
+          "Needle-only: skip section embedding (fast, cheaper, lower fidelity)",
+        )
+        .option("--json", "Emit raw JSON instead of a formatted summary")
+        .addHelpText(
+          "after",
+          `
+Mines recent user turns, retrieves the top pages from each corpus per turn, and
+writes blinded A/B packets (plus a separate unblinding key) for a blind-judge
+workflow. Both corpora are read in memory — nothing in the live lanes or Qdrant
+is touched. With the dense lane on (default) it embeds every section of both
+corpora, which can take a while on a large corpus; use --no-dense for a fast
+lexical-only pass.
+
+Examples:
+  $ assistant memory v3 eval --snapshot .mv3/snapshot/concepts --staging .mv3/staging --out .mv3/eval
+  $ assistant memory v3 eval --snapshot .mv3/snapshot/concepts --staging .mv3/staging --out .mv3/eval --turns 50 --no-dense`,
+        )
+        .action(
+          async (opts: {
+            staging: string;
+            snapshot: string;
+            out: string;
+            turns: string;
+            k: string;
+            seed: string;
+            dense: boolean;
+            json?: boolean;
+          }) => {
+            const result = await cliIpcCall<MemoryEvalRunResult>(
+              "memory_eval_run",
+              {
+                body: {
+                  stagingDir: opts.staging,
+                  snapshotDir: opts.snapshot,
+                  outDir: opts.out,
+                  turns: Number(opts.turns),
+                  k: Number(opts.k),
+                  seed: Number(opts.seed),
+                  dense: opts.dense,
+                },
+              },
+              { timeoutMs: EVAL_IPC_TIMEOUT_MS },
+            );
+            if (!result.ok) {
+              log.error(result.error ?? "Failed to build eval packets");
+              process.exitCode = 1;
+              return;
+            }
+            const payload = result.result!;
+            if (opts.json === true) {
+              log.info(JSON.stringify(payload, null, 2));
+              return;
+            }
+            log.info(
+              `Wrote ${payload.packetsWritten} packets from ${payload.turnsMined} turns ` +
+                `(snapshot ${payload.snapshotPages} pages vs staged ${payload.stagingPages} pages, ` +
+                `dense=${payload.dense}).\n  packets: ${payload.packetsPath}\n  key:     ${payload.keyPath}`,
+            );
+          },
+        );
     },
   });
 }

--- a/assistant/src/memory/v3-eval/__tests__/eval-packets.test.ts
+++ b/assistant/src/memory/v3-eval/__tests__/eval-packets.test.ts
@@ -10,6 +10,7 @@ import {
   pairTurns,
   type RawMsgRow,
   renderMemorySet,
+  resolveDir,
 } from "../eval-packets.js";
 
 /** Build a stored content-block JSON string the way the DB holds it. */
@@ -227,5 +228,21 @@ describe("primitives", () => {
     const a = mulberry32(7);
     const b = mulberry32(7);
     expect([a(), a(), a()]).toEqual([b(), b(), b()]);
+  });
+});
+
+describe("resolveDir", () => {
+  test("resolves a relative path under the workspace", () => {
+    expect(resolveDir("/ws", ".mv3/staging")).toBe("/ws/.mv3/staging");
+  });
+  test("rejects an absolute path outside the workspace", () => {
+    expect(() => resolveDir("/ws", "/etc/passwd")).toThrow(
+      /within the workspace/,
+    );
+  });
+  test("rejects a relative path that escapes the workspace", () => {
+    expect(() => resolveDir("/ws", "../outside")).toThrow(
+      /within the workspace/,
+    );
   });
 });

--- a/assistant/src/memory/v3-eval/__tests__/eval-packets.test.ts
+++ b/assistant/src/memory/v3-eval/__tests__/eval-packets.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildPackets,
+  buildRetriever,
+  type Corpus,
+  dot,
+  type EmbedAll,
+  mulberry32,
+  pairTurns,
+  type RawMsgRow,
+  renderMemorySet,
+} from "../eval-packets.js";
+
+/** Build a stored content-block JSON string the way the DB holds it. */
+function block(text: string): string {
+  return JSON.stringify([{ type: "text", text }]);
+}
+
+/** A tiny bag-of-words embedder so dense cosine is meaningful in tests. */
+const VOCAB = ["alice", "bob", "laptop", "coffee", "dog", "paris"];
+const fakeEmbed: EmbedAll = async (texts) =>
+  texts.map((t) => {
+    const lower = t.toLowerCase();
+    return VOCAB.map(
+      (w) => (lower.match(new RegExp(`\\b${w}\\b`, "g")) ?? []).length,
+    );
+  });
+
+function page(title: string, body: string): { raw: string; body: string } {
+  const fullBody = `# ${title}\n\n${body}`;
+  return { raw: `---\ntitle: ${title}\n---\n${fullBody}`, body: fullBody };
+}
+
+function makeCorpus(): Corpus {
+  const slugs = ["alice", "coffee-ritual", "dog"];
+  const rawBySlug = new Map<string, string>();
+  const bodyBySlug = new Map<string, string>();
+  const pages: Record<string, { raw: string; body: string }> = {
+    alice: page("Alice", "## laptop\nAlice works on her laptop in Paris."),
+    "coffee-ritual": page(
+      "Coffee ritual",
+      "## morning\nBob makes coffee every morning.",
+    ),
+    dog: page("Dog", "## rex\nThe dog Rex is a golden retriever."),
+  };
+  for (const slug of slugs) {
+    rawBySlug.set(slug, pages[slug]!.raw);
+    bodyBySlug.set(slug, pages[slug]!.body);
+  }
+  return { slugs, rawBySlug, bodyBySlug };
+}
+
+describe("pairTurns", () => {
+  const rows: RawMsgRow[] = [
+    {
+      conversationId: "c1",
+      id: "m1",
+      role: "user",
+      content: block("hello alice"),
+      createdAt: 100,
+    },
+    {
+      conversationId: "c1",
+      id: "m2",
+      role: "assistant",
+      content: block("Here is a long enough reply about Alice and her laptop."),
+      createdAt: 101,
+    },
+    {
+      conversationId: "c1",
+      id: "m3",
+      role: "user",
+      content: block("and bob?"),
+      createdAt: 102,
+    },
+    {
+      conversationId: "c1",
+      id: "m4",
+      role: "assistant",
+      content: block("Bob prefers coffee in the morning, every single day."),
+      createdAt: 103,
+    },
+    {
+      conversationId: "c2",
+      id: "m5",
+      role: "user",
+      content: block("dog?"),
+      createdAt: 200,
+    },
+    {
+      conversationId: "c2",
+      id: "m6",
+      role: "assistant",
+      content: block("short"),
+      createdAt: 201,
+    },
+    {
+      conversationId: "c2",
+      id: "m7",
+      role: "user",
+      content: block("tell me about the dog please"),
+      createdAt: 202,
+    },
+    {
+      conversationId: "c2",
+      id: "m8",
+      role: "assistant",
+      content: block(
+        "The dog is a golden retriever named Rex who loves walks.",
+      ),
+      createdAt: 203,
+    },
+  ];
+
+  test("pairs user→next-assistant, drops short replies, ranks by recency", () => {
+    const turns = pairTurns(rows, { limit: 10, perConversationCap: 10 });
+    expect(turns.map((t) => t.turn)).toEqual(["c2:202", "c1:102", "c1:100"]);
+    // m5/m6 dropped: the reply "short" is under the 40-char floor.
+    expect(turns.find((t) => t.turn === "c2:202")?.userText).toBe(
+      "tell me about the dog please",
+    );
+    expect(turns.find((t) => t.turn === "c2:202")?.replyText).toContain(
+      "golden retriever",
+    );
+  });
+
+  test("context carries the previous reply in the same conversation", () => {
+    const turns = pairTurns(rows, { limit: 10, perConversationCap: 10 });
+    expect(turns.find((t) => t.turn === "c1:100")?.context).toBe(""); // first turn, no prior reply
+    expect(turns.find((t) => t.turn === "c1:102")?.context).toContain(
+      "Alice and her laptop",
+    );
+  });
+
+  test("per-conversation cap keeps the most recent within each conversation", () => {
+    const turns = pairTurns(rows, { limit: 10, perConversationCap: 1 });
+    expect(turns.map((t) => t.turn).sort()).toEqual(["c1:102", "c2:202"]);
+  });
+});
+
+describe("buildRetriever + retrieve", () => {
+  test("needle-only retrieves the lexically relevant page", async () => {
+    const retriever = await buildRetriever(makeCorpus(), fakeEmbed, false);
+    const hits = retriever.retrieve("alice laptop paris", null, 3);
+    expect(hits[0]?.slug).toBe("alice");
+  });
+
+  test("dense lane retrieves by embedding similarity", async () => {
+    const retriever = await buildRetriever(makeCorpus(), fakeEmbed, true);
+    const [queryVec] = await fakeEmbed(["coffee"]);
+    const hits = retriever.retrieve("coffee", queryVec!, 3);
+    expect(hits.map((h) => h.slug)).toContain("coffee-ritual");
+  });
+});
+
+describe("renderMemorySet", () => {
+  test("renders cards + matched sections, and a sentinel for empty", async () => {
+    const retriever = await buildRetriever(makeCorpus(), fakeEmbed, false);
+    const hits = retriever.retrieve("alice laptop", null, 2);
+    const set = renderMemorySet(retriever, hits, 1200);
+    expect(set).toContain("memory/concepts/alice.md");
+    expect(set).toContain("Alice works on her laptop");
+    expect(renderMemorySet(retriever, [], 1200)).toBe("(no pages retrieved)");
+  });
+});
+
+describe("buildPackets", () => {
+  const turns = [
+    {
+      turn: "c1:100",
+      conversationId: "c1",
+      userText: "alice laptop",
+      replyText: "reply one",
+      context: "",
+      createdAt: 100,
+    },
+    {
+      turn: "c2:200",
+      conversationId: "c2",
+      userText: "coffee",
+      replyText: "reply two",
+      context: "",
+      createdAt: 200,
+    },
+  ];
+
+  test("produces one blinded packet per turn with a consistent, reproducible key", async () => {
+    const snapshot = await buildRetriever(makeCorpus(), fakeEmbed, false);
+    const staging = await buildRetriever(makeCorpus(), fakeEmbed, false);
+    const opts = { dense: false, seed: 42, k: 4, sectionCharCap: 1200 };
+
+    const { packets, key } = await buildPackets(
+      turns,
+      snapshot,
+      staging,
+      fakeEmbed,
+      opts,
+    );
+    expect(packets).toHaveLength(2);
+    expect(key).toHaveLength(2);
+    for (let i = 0; i < packets.length; i++) {
+      expect(packets[i]!.turn).toBe(turns[i]!.turn);
+      expect(packets[i]!.userMessage).toBe(turns[i]!.userText);
+      expect(packets[i]!.reply).toBe(turns[i]!.replyText);
+      expect(packets[i]!.setA.length).toBeGreaterThan(0);
+      expect(packets[i]!.setB.length).toBeGreaterThan(0);
+      // a/b are the two corpora, never the same side twice.
+      expect(new Set([key[i]!.a, key[i]!.b])).toEqual(
+        new Set(["snapshot", "staging"]),
+      );
+    }
+
+    // Same seed → identical blinding assignment.
+    const rerun = await buildPackets(turns, snapshot, staging, fakeEmbed, opts);
+    expect(rerun.key).toEqual(key);
+  });
+});
+
+describe("primitives", () => {
+  test("dot is cosine on unit vectors", () => {
+    expect(dot([1, 0], [1, 0])).toBeCloseTo(1);
+    expect(dot([1, 0], [0, 1])).toBeCloseTo(0);
+  });
+
+  test("mulberry32 is deterministic for a seed", () => {
+    const a = mulberry32(7);
+    const b = mulberry32(7);
+    expect([a(), a(), a()]).toEqual([b(), b(), b()]);
+  });
+});

--- a/assistant/src/memory/v3-eval/eval-packets.ts
+++ b/assistant/src/memory/v3-eval/eval-packets.ts
@@ -1,0 +1,535 @@
+/**
+ * Memory-v3 corpus eval: build blinded A/B judge packets comparing retrieval
+ * over two on-disk concept corpora (e.g. a pre-migration v2 snapshot vs a staged
+ * v3 wiki) on the same mined historical turns.
+ *
+ * The two corpora are a pure reorganization of the same knowledge (the staged
+ * wiki is authored FROM the snapshot), so the comparison measures retrieval
+ * *shape*, not knowledge — no per-turn time-gating is needed: both sides hold
+ * the same information, so a page encoding post-turn knowledge is reachable in
+ * both and cannot bias one side. The blind judge (a separate workflow) scores
+ * each packet on coverage; this module only produces the packets.
+ *
+ * Retrieval mirrors the live section-lane engine's cheap lanes: a BM25F needle
+ * over sections, optionally unioned with dense cosine over section embeddings.
+ * Everything runs in memory — no Qdrant writes, no live-lane mutation — which is
+ * why it is safe to run against arbitrary staging/snapshot directories.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { isAbsolute, join } from "node:path";
+
+import { and, desc, eq, sql } from "drizzle-orm";
+
+import type { AssistantConfig } from "../../config/types.js";
+import { renderCard } from "../../plugins/defaults/memory-v3-shadow/card.js";
+import { buildSectionNeedle } from "../../plugins/defaults/memory-v3-shadow/section-needle.js";
+import { buildSectionIndex } from "../../plugins/defaults/memory-v3-shadow/sections.js";
+import type {
+  SectionIndex,
+  Slug,
+} from "../../plugins/defaults/memory-v3-shadow/types.js";
+import {
+  FRONTMATTER_REGEX,
+  parseFrontmatterFields,
+} from "../../skills/frontmatter.js";
+import type { getDb } from "../db-connection.js";
+import { embedWithRetry } from "../embed.js";
+import { stringifyMessageContent } from "../message-content.js";
+import { conversations, messages } from "../schema.js";
+import { injectedConceptHeader } from "../v2/injected-block-slugs.js";
+import { slugFromConceptPath } from "../v2/page-store.js";
+
+type DrizzleDb = ReturnType<typeof getDb>;
+
+/** A text-embedding function returning one vector per input, in order. */
+export type EmbedAll = (texts: string[]) => Promise<number[][]>;
+
+// ---------------------------------------------------------------------------
+// Corpus loading (arbitrary directory of `.md` concept pages)
+// ---------------------------------------------------------------------------
+
+export interface Corpus {
+  /** Flat slugs (path under `dir`, minus `.md`, forward-slashed). */
+  slugs: Slug[];
+  /** slug -> full file text (frontmatter included; the card renderer strips it). */
+  rawBySlug: Map<Slug, string>;
+  /** slug -> frontmatter-stripped body (what the section index chunks). */
+  bodyBySlug: Map<Slug, string>;
+}
+
+/** Read every `.md` page under `dir` into a {@link Corpus}. */
+export function loadCorpus(dir: string): Corpus {
+  if (!existsSync(dir)) {
+    throw new Error(`corpus directory does not exist: ${dir}`);
+  }
+  const slugs: Slug[] = [];
+  const rawBySlug = new Map<Slug, string>();
+  const bodyBySlug = new Map<Slug, string>();
+
+  for (const rel of readdirSync(dir, { recursive: true })) {
+    const relPath = typeof rel === "string" ? rel : String(rel);
+    if (!relPath.endsWith(".md")) continue;
+    const full = join(dir, relPath);
+    const raw = readFileSync(full, "utf8");
+    const slug = slugFromConceptPath(dir, full);
+    const parsed = parseFrontmatterFields(raw);
+    const body = parsed ? parsed.body : raw.replace(FRONTMATTER_REGEX, "");
+    slugs.push(slug);
+    rawBySlug.set(slug, raw);
+    bodyBySlug.set(slug, body);
+  }
+  return { slugs, rawBySlug, bodyBySlug };
+}
+
+// ---------------------------------------------------------------------------
+// Vector helpers
+// ---------------------------------------------------------------------------
+
+function normalize(v: number[]): number[] {
+  let sumSq = 0;
+  for (const x of v) sumSq += x * x;
+  const norm = Math.sqrt(sumSq) || 1;
+  return v.map((x) => x / norm);
+}
+
+/** Dot product; on unit-normalized vectors this is cosine similarity. */
+export function dot(a: number[], b: number[]): number {
+  let sum = 0;
+  const n = Math.min(a.length, b.length);
+  for (let i = 0; i < n; i++) sum += a[i]! * b[i]!;
+  return sum;
+}
+
+// ---------------------------------------------------------------------------
+// Retriever (needle ∪ dense, in memory)
+// ---------------------------------------------------------------------------
+
+export interface RetrievalHit {
+  slug: Slug;
+  /** Index into `SectionIndex.sections` of the matched section. */
+  sectionIdx: number;
+}
+
+export interface Retriever {
+  index: SectionIndex;
+  rawBySlug: Map<Slug, string>;
+  /** Top-`k` distinct articles (needle ∪ dense), each with a matched section. */
+  retrieve(
+    queryText: string,
+    queryVec: number[] | null,
+    k: number,
+  ): RetrievalHit[];
+}
+
+/**
+ * Build a retriever over a corpus. When `dense` is true, every section is
+ * embedded (via `embedAll`) and stored unit-normalized for cosine search.
+ */
+export async function buildRetriever(
+  corpus: Corpus,
+  embedAll: EmbedAll,
+  dense: boolean,
+): Promise<Retriever> {
+  const index = await buildSectionIndex(
+    corpus.slugs,
+    async (slug) => corpus.bodyBySlug.get(slug) ?? "",
+  );
+  const needle = buildSectionNeedle(index);
+
+  let sectionVecs: number[][] | null = null;
+  if (dense && index.sections.length > 0) {
+    const raw = await embedAll(index.sections.map((s) => s.text));
+    sectionVecs = raw.map(normalize);
+  }
+
+  function denseHits(queryVec: number[], k: number): RetrievalHit[] {
+    if (!sectionVecs) return [];
+    const scored = sectionVecs.map((sv, i) => ({
+      i,
+      score: dot(queryVec, sv),
+    }));
+    scored.sort((a, b) => b.score - a.score || a.i - b.i);
+    const seen = new Set<Slug>();
+    const hits: RetrievalHit[] = [];
+    for (const { i } of scored) {
+      const slug = index.sections[i]!.article;
+      if (seen.has(slug)) continue;
+      seen.add(slug);
+      hits.push({ slug, sectionIdx: i });
+      if (hits.length >= k) break;
+    }
+    return hits;
+  }
+
+  function retrieve(
+    queryText: string,
+    queryVec: number[] | null,
+    k: number,
+  ): RetrievalHit[] {
+    const lexical: RetrievalHit[] = needle
+      .query(queryText, k)
+      .map((h) => ({ slug: h.article, sectionIdx: h.section }));
+    const semantic = queryVec ? denseHits(queryVec, k) : [];
+
+    // Round-robin interleave the two lanes so neither dominates, dedupe by
+    // article, keep the section from whichever lane surfaced it first.
+    const merged: RetrievalHit[] = [];
+    const seen = new Set<Slug>();
+    for (let i = 0; i < Math.max(lexical.length, semantic.length); i++) {
+      for (const hit of [lexical[i], semantic[i]]) {
+        if (!hit || seen.has(hit.slug)) continue;
+        seen.add(hit.slug);
+        merged.push(hit);
+        if (merged.length >= k) return merged;
+      }
+    }
+    return merged;
+  }
+
+  return { index, rawBySlug: corpus.rawBySlug, retrieve };
+}
+
+/**
+ * Render the retrieved pages as one "memory set" string: each page's live-style
+ * card (lead + section TOC) followed by its matched section in full, mirroring
+ * what the model sees (accumulated cards + spotlighted section).
+ */
+export function renderMemorySet(
+  retriever: Retriever,
+  hits: RetrievalHit[],
+  sectionCharCap: number,
+): string {
+  if (hits.length === 0) return "(no pages retrieved)";
+  const parts: string[] = [];
+  for (const hit of hits) {
+    const raw = retriever.rawBySlug.get(hit.slug) ?? "";
+    const card = renderCard(hit.slug, raw);
+    const section = retriever.index.sections[hit.sectionIdx];
+    if (section) {
+      const body = section.text.trim().slice(0, sectionCharCap);
+      parts.push(`${card}\n\n${injectedConceptHeader(hit.slug)}\n${body}`);
+    } else {
+      parts.push(card);
+    }
+  }
+  return parts.join("\n\n---\n\n");
+}
+
+// ---------------------------------------------------------------------------
+// Turn mining
+// ---------------------------------------------------------------------------
+
+export interface RawMsgRow {
+  conversationId: string;
+  id: string;
+  role: string;
+  content: string;
+  createdAt: number;
+}
+
+export interface MinedTurn {
+  /** Stable id: `${conversationId}:${createdAt}`. */
+  turn: string;
+  conversationId: string;
+  userText: string;
+  replyText: string;
+  /** The preceding reply in the same conversation (truncated), or "". */
+  context: string;
+  createdAt: number;
+}
+
+/**
+ * Pair each user message with the next assistant reply in the same conversation,
+ * cap per conversation, and keep the most recent `limit` turns. Pure over `rows`
+ * (which must be chronological per conversation) so it is unit-testable.
+ */
+export function pairTurns(
+  rows: RawMsgRow[],
+  opts: { limit: number; perConversationCap: number; contextCharCap?: number },
+): MinedTurn[] {
+  const contextCap = opts.contextCharCap ?? 600;
+  const byConversation: MinedTurn[][] = [];
+  const indexOfConversation = new Map<string, number>();
+
+  let pendingUser: RawMsgRow | null = null;
+  let lastReply = "";
+  let currentConversation = "";
+
+  for (const m of rows) {
+    if (m.conversationId !== currentConversation) {
+      currentConversation = m.conversationId;
+      pendingUser = null;
+      lastReply = "";
+    }
+    if (m.role === "user") {
+      pendingUser = m;
+    } else if (m.role === "assistant" && pendingUser) {
+      const userText = stringifyMessageContent(pendingUser.content);
+      const replyText = stringifyMessageContent(m.content);
+      if (userText.length > 0 && replyText.length >= 40) {
+        let bucket = indexOfConversation.get(m.conversationId);
+        if (bucket === undefined) {
+          bucket = byConversation.length;
+          indexOfConversation.set(m.conversationId, bucket);
+          byConversation.push([]);
+        }
+        byConversation[bucket]!.push({
+          turn: `${m.conversationId}:${pendingUser.createdAt}`,
+          conversationId: m.conversationId,
+          userText,
+          replyText,
+          context: lastReply.slice(0, contextCap),
+          createdAt: pendingUser.createdAt,
+        });
+      }
+      lastReply = replyText;
+      pendingUser = null;
+    }
+  }
+
+  // Cap per conversation (keep the most recent within each), then globally rank
+  // by recency and take `limit`.
+  const capped: MinedTurn[] = [];
+  for (const turns of byConversation) {
+    capped.push(...turns.slice(-opts.perConversationCap));
+  }
+  capped.sort((a, b) => b.createdAt - a.createdAt);
+  return capped.slice(0, opts.limit);
+}
+
+/** Read recent user→assistant turns from the live DB (read-only). */
+export function mineTurns(
+  db: DrizzleDb,
+  opts: { limit: number; perConversationCap: number; maxScan?: number },
+): MinedTurn[] {
+  const maxScan = opts.maxScan ?? 6000;
+  const recent = db
+    .select({
+      conversationId: messages.conversationId,
+      id: messages.id,
+      role: messages.role,
+      content: messages.content,
+      createdAt: messages.createdAt,
+    })
+    .from(messages)
+    .innerJoin(conversations, eq(messages.conversationId, conversations.id))
+    .where(
+      and(
+        sql`COALESCE(${conversations.source}, 'user') = 'user'`,
+        sql`${conversations.scheduleJobId} IS NULL`,
+      ),
+    )
+    .orderBy(desc(messages.createdAt), desc(messages.id))
+    .limit(maxScan)
+    .all() as RawMsgRow[];
+
+  // Re-sort ascending and group so the pairing walks each conversation in order.
+  recent.sort(
+    (a, b) =>
+      a.conversationId.localeCompare(b.conversationId) ||
+      a.createdAt - b.createdAt ||
+      a.id.localeCompare(b.id),
+  );
+  return pairTurns(recent, opts);
+}
+
+// ---------------------------------------------------------------------------
+// Packet assembly (with seeded blinding)
+// ---------------------------------------------------------------------------
+
+export interface EvalPacket {
+  turn: string;
+  context: string;
+  userMessage: string;
+  reply: string;
+  setA: string;
+  setB: string;
+}
+
+export interface EvalKeyEntry {
+  turn: string;
+  a: "snapshot" | "staging";
+  b: "snapshot" | "staging";
+}
+
+/** Deterministic PRNG so the A/B assignment is reproducible from a seed. */
+export function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export async function buildPackets(
+  turns: MinedTurn[],
+  snapshot: Retriever,
+  staging: Retriever,
+  embedAll: EmbedAll,
+  opts: { dense: boolean; seed: number; k: number; sectionCharCap: number },
+): Promise<{ packets: EvalPacket[]; key: EvalKeyEntry[] }> {
+  const queryVecs: (number[] | null)[] = opts.dense
+    ? (await embedAll(turns.map((t) => t.userText))).map(normalize)
+    : turns.map(() => null);
+
+  const rng = mulberry32(opts.seed);
+  const packets: EvalPacket[] = [];
+  const key: EvalKeyEntry[] = [];
+
+  for (let i = 0; i < turns.length; i++) {
+    const t = turns[i]!;
+    const qVec = queryVecs[i] ?? null;
+    const snapSet = renderMemorySet(
+      snapshot,
+      snapshot.retrieve(t.userText, qVec, opts.k),
+      opts.sectionCharCap,
+    );
+    const stageSet = renderMemorySet(
+      staging,
+      staging.retrieve(t.userText, qVec, opts.k),
+      opts.sectionCharCap,
+    );
+    const stagingIsA = rng() < 0.5;
+    packets.push({
+      turn: t.turn,
+      context: t.context,
+      userMessage: t.userText,
+      reply: t.replyText,
+      setA: stagingIsA ? stageSet : snapSet,
+      setB: stagingIsA ? snapSet : stageSet,
+    });
+    key.push({
+      turn: t.turn,
+      a: stagingIsA ? "staging" : "snapshot",
+      b: stagingIsA ? "snapshot" : "staging",
+    });
+  }
+  return { packets, key };
+}
+
+// ---------------------------------------------------------------------------
+// Top-level run
+// ---------------------------------------------------------------------------
+
+export interface EvalParams {
+  /** Staged v3 wiki dir (relative to workspace, or absolute). */
+  stagingDir: string;
+  /** Read-only v2 snapshot dir (relative to workspace, or absolute). */
+  snapshotDir: string;
+  /** Output dir for packets.json + key.json (relative to workspace, or absolute). */
+  outDir: string;
+  turns?: number;
+  perConversationCap?: number;
+  /** Pages per memory set. */
+  k?: number;
+  /** Include the dense lane (embeds both corpora). Off = needle-only, no embeds. */
+  dense?: boolean;
+  seed?: number;
+  sectionCharCap?: number;
+}
+
+export interface EvalResult {
+  turnsMined: number;
+  packetsWritten: number;
+  packetsPath: string;
+  keyPath: string;
+  snapshotPages: number;
+  stagingPages: number;
+  dense: boolean;
+}
+
+export interface EvalDeps {
+  config: AssistantConfig;
+  workspaceDir: string;
+  db: DrizzleDb;
+  /** Embed one batch of texts. Defaults to the live embedding backend. */
+  embed?: EmbedAll;
+}
+
+/** Chunk an embed function so a large corpus never overruns provider batch limits. */
+function chunkedEmbed(embed: EmbedAll, batchSize = 96): EmbedAll {
+  return async (texts: string[]) => {
+    const out: number[][] = [];
+    for (let i = 0; i < texts.length; i += batchSize) {
+      out.push(...(await embed(texts.slice(i, i + batchSize))));
+    }
+    return out;
+  };
+}
+
+function resolveDir(workspaceDir: string, p: string): string {
+  return isAbsolute(p) ? p : join(workspaceDir, p);
+}
+
+/**
+ * Run the full eval: load both corpora, mine turns, retrieve both sides, and
+ * write blinded packets + the unblinding key. Returns counts.
+ */
+export async function runMemoryEval(
+  params: EvalParams,
+  deps: EvalDeps,
+): Promise<EvalResult> {
+  const dense = params.dense ?? true;
+  const k = params.k ?? 8;
+  const seed = params.seed ?? 1;
+  const sectionCharCap = params.sectionCharCap ?? 1200;
+
+  const snapshotDir = resolveDir(deps.workspaceDir, params.snapshotDir);
+  const stagingDir = resolveDir(deps.workspaceDir, params.stagingDir);
+  const outDir = resolveDir(deps.workspaceDir, params.outDir);
+
+  const baseEmbed: EmbedAll =
+    deps.embed ??
+    (async (texts) => (await embedWithRetry(deps.config, texts)).vectors);
+  const embedAll = chunkedEmbed(baseEmbed);
+
+  const snapshotCorpus = loadCorpus(snapshotDir);
+  const stagingCorpus = loadCorpus(stagingDir);
+
+  const snapshot = await buildRetriever(snapshotCorpus, embedAll, dense);
+  const staging = await buildRetriever(stagingCorpus, embedAll, dense);
+
+  const turns = mineTurns(deps.db, {
+    limit: params.turns ?? 30,
+    perConversationCap: params.perConversationCap ?? 4,
+  });
+
+  const { packets, key } = await buildPackets(
+    turns,
+    snapshot,
+    staging,
+    embedAll,
+    {
+      dense,
+      seed,
+      k,
+      sectionCharCap,
+    },
+  );
+
+  mkdirSync(outDir, { recursive: true });
+  const packetsPath = join(outDir, "packets.json");
+  const keyPath = join(outDir, "key.json");
+  writeFileSync(packetsPath, JSON.stringify(packets, null, 2));
+  writeFileSync(keyPath, JSON.stringify(key, null, 2));
+
+  return {
+    turnsMined: turns.length,
+    packetsWritten: packets.length,
+    packetsPath,
+    keyPath,
+    snapshotPages: snapshotCorpus.slugs.length,
+    stagingPages: stagingCorpus.slugs.length,
+    dense,
+  };
+}

--- a/assistant/src/memory/v3-eval/eval-packets.ts
+++ b/assistant/src/memory/v3-eval/eval-packets.ts
@@ -23,7 +23,7 @@ import {
   readFileSync,
   writeFileSync,
 } from "node:fs";
-import { isAbsolute, join } from "node:path";
+import { join, resolve, sep } from "node:path";
 
 import { and, desc, eq, sql } from "drizzle-orm";
 
@@ -467,8 +467,19 @@ function chunkedEmbed(embed: EmbedAll, batchSize = 96): EmbedAll {
   };
 }
 
-function resolveDir(workspaceDir: string, p: string): string {
-  return isAbsolute(p) ? p : join(workspaceDir, p);
+/**
+ * Resolve a corpus/output path against the workspace, rejecting anything that
+ * escapes it. The route is in the shared table (HTTP + IPC), so an actor caller
+ * could otherwise pass an absolute path to read/write arbitrary trees — these
+ * dirs must stay under the workspace.
+ */
+export function resolveDir(workspaceDir: string, p: string): string {
+  const root = resolve(workspaceDir);
+  const resolved = resolve(root, p);
+  if (resolved !== root && !resolved.startsWith(root + sep)) {
+    throw new Error(`eval path must stay within the workspace: ${p}`);
+  }
+  return resolved;
 }
 
 /**

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -90,6 +90,7 @@ import { ROUTES as INTERNAL_TWILIO_ROUTES } from "./internal-twilio-routes.js";
 import { ROUTES as LLM_CALL_SITES_ROUTES } from "./llm-call-sites-routes.js";
 import { ROUTES as LOG_EXPORT_ROUTES } from "./log-export-routes.js";
 import { ROUTES as MCP_AUTH_ROUTES } from "./mcp-auth-routes.js";
+import { ROUTES as MEMORY_EVAL_ROUTES } from "./memory-eval-routes.js";
 import { ROUTES as MEMORY_ITEM_ROUTES } from "./memory-item-routes.js";
 import { ROUTES as MEMORY_V2_ROUTES } from "./memory-v2-routes.js";
 import { ROUTES as MEMORY_V3_ROUTES } from "./memory-v3-routes.js";
@@ -222,6 +223,7 @@ export const ROUTES: RouteDefinition[] = [
   ...INTERNAL_TWILIO_ROUTES,
   ...LOG_EXPORT_ROUTES,
   ...LLM_CALL_SITES_ROUTES,
+  ...MEMORY_EVAL_ROUTES,
   ...MEMORY_ITEM_ROUTES,
   ...MEMORY_V2_ROUTES,
   ...MEMORY_V3_ROUTES,

--- a/assistant/src/runtime/routes/memory-eval-routes.ts
+++ b/assistant/src/runtime/routes/memory-eval-routes.ts
@@ -1,0 +1,86 @@
+/**
+ * Memory retrieval-eval route — builds blinded A/B judge packets comparing
+ * retrieval over two on-disk concept corpora (e.g. a v2 snapshot vs a staged v3
+ * wiki) on the same mined historical turns. Drives the corpus-reform eval gate:
+ * the packets feed a blind-judge workflow that decides whether the staged wiki
+ * retrieves at least as well as the current corpus before cutover.
+ *
+ * Runs in-daemon (like the other v3 maintenance verbs) because embedding needs
+ * the live config + credential store; the work is otherwise read-only over the
+ * DB and the two corpus dirs, and writes only the packets/key files.
+ */
+
+import { z } from "zod";
+
+import { getConfig } from "../../config/loader.js";
+import type { AssistantConfig } from "../../config/types.js";
+import { getDb } from "../../memory/db-connection.js";
+import { runMemoryEval } from "../../memory/v3-eval/eval-packets.js";
+import { getLogger } from "../../util/logger.js";
+import { getWorkspaceDir } from "../../util/platform.js";
+import { ACTOR_PRINCIPALS, type RoutePolicy } from "../auth/route-policy.js";
+import type { RouteDefinition } from "./types.js";
+
+const log = getLogger("memory-eval-routes");
+
+const MemoryEvalRunParamsSchema = z.object({
+  /** Staged v3 wiki dir (relative to the workspace, or absolute). */
+  stagingDir: z.string().min(1),
+  /** Read-only v2 snapshot dir (relative to the workspace, or absolute). */
+  snapshotDir: z.string().min(1),
+  /** Output dir for `packets.json` + `key.json` (relative to the workspace, or absolute). */
+  outDir: z.string().min(1),
+  turns: z.number().int().positive().optional(),
+  perConversationCap: z.number().int().positive().optional(),
+  k: z.number().int().positive().optional(),
+  dense: z.boolean().optional(),
+  seed: z.number().int().optional(),
+});
+
+const MemoryEvalRunResultSchema = z.object({
+  turnsMined: z.number(),
+  packetsWritten: z.number(),
+  packetsPath: z.string(),
+  keyPath: z.string(),
+  snapshotPages: z.number(),
+  stagingPages: z.number(),
+  dense: z.boolean(),
+});
+export type MemoryEvalRunResult = z.infer<typeof MemoryEvalRunResultSchema>;
+
+/**
+ * Build the eval packets. `config` is injectable for tests; production resolves
+ * the live config (and through it the embedding backend + DB).
+ */
+export async function handleMemoryEvalRun(
+  body: unknown,
+  config: AssistantConfig = getConfig(),
+): Promise<MemoryEvalRunResult> {
+  const params = MemoryEvalRunParamsSchema.parse(body ?? {});
+  const result = await runMemoryEval(params, {
+    config,
+    workspaceDir: getWorkspaceDir(),
+    db: getDb(),
+  });
+  log.info(result, "memory eval packets written");
+  return result;
+}
+
+const WRITE_POLICY: RoutePolicy = {
+  requiredScopes: ["settings.write"],
+  allowedPrincipalTypes: ACTOR_PRINCIPALS,
+};
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "memory_eval_run",
+    method: "POST",
+    policy: WRITE_POLICY,
+    endpoint: "memory/eval/run",
+    handler: ({ body }) => handleMemoryEvalRun(body),
+    summary:
+      "Build blinded A/B retrieval-eval packets over two concept corpora (snapshot vs staged wiki)",
+    tags: ["memory"],
+    responseBody: MemoryEvalRunResultSchema,
+  },
+];

--- a/assistant/src/runtime/routes/memory-eval-routes.ts
+++ b/assistant/src/runtime/routes/memory-eval-routes.ts
@@ -81,6 +81,7 @@ export const ROUTES: RouteDefinition[] = [
     summary:
       "Build blinded A/B retrieval-eval packets over two concept corpora (snapshot vs staged wiki)",
     tags: ["memory"],
+    requestBody: MemoryEvalRunParamsSchema,
     responseBody: MemoryEvalRunResultSchema,
   },
 ];

--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -166,6 +166,7 @@ const ASSISTANT_SUPPORTED_COMMAND_PATHS = [
   "memory v3",
   "memory v3 rebuild-index",
   "memory v3 backfill-sections",
+  "memory v3 eval",
   "notifications",
   "notifications send",
   "notifications list",
@@ -499,6 +500,12 @@ const riskOverrides: AssistantRiskOverride[] = [
     risk: "medium",
     reason:
       "Embeds every page's sections into the v3 dense store and advances the maintain checkpoint",
+  },
+  {
+    path: "memory v3 eval",
+    risk: "medium",
+    reason:
+      "Reads recent conversation turns and memory contents and writes them to eval packet/key files",
   },
   {
     path: "memory v3 rebuild-index",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1015,16 +1015,16 @@
           "user-invocable": "true",
           "activation-hints": [
             "When the user asks to migrate the memory wiki to v3 / the section-grain format",
-            "When memory-v3 retrieval is available but /workspace/memory/concepts/ is still v2-shaped (flat bullet pages, class folders, summary: frontmatter)"
+            "When memory-v3 retrieval is available but memory/concepts/ is still v2-shaped (flat bullet pages, class folders, summary: frontmatter)"
           ],
           "avoid-when": [
             "When the corpus is already in v3 article shape (leads + ## sections, no summary:) and memory.v3.live is already true",
-            "When /workspace/memory/concepts/ is empty or near-empty (run vellum-memory-v2-migration first — there is nothing to reform)"
+            "When memory/concepts/ is empty or near-empty (run vellum-memory-v2-migration first — there is nothing to reform)"
           ]
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-18T00:42:54.000Z"
+      "updatedAt": "2026-06-18T01:04:56.000Z"
     },
     {
       "id": "vellum-oauth-integrations",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1024,7 +1024,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-17T23:05:29.000Z"
+      "updatedAt": "2026-06-17T23:39:04.000Z"
     },
     {
       "id": "vellum-oauth-integrations",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1004,6 +1004,29 @@
       "updatedAt": "2026-06-03T03:10:07.000Z"
     },
     {
+      "id": "vellum-memory-v3-migration",
+      "name": "vellum-memory-v3-migration",
+      "description": "One-time migration of an existing memory-v2 concept corpus into the memory-v3 section-grain \"wiki\" — topical articles with a stand-alone lead and queryable sections — with loss-proof staging, assistant-reviewed authoring, and a retrieval-eval gate before cutover.",
+      "metadata": {
+        "emoji": "🗂️",
+        "vellum": {
+          "category": "system",
+          "display-name": "Memory v3 Migration",
+          "user-invocable": "true",
+          "activation-hints": [
+            "When the user asks to migrate the memory wiki to v3 / the section-grain format",
+            "When memory-v3 retrieval is available but /workspace/memory/concepts/ is still v2-shaped (flat bullet pages, class folders, summary: frontmatter)"
+          ],
+          "avoid-when": [
+            "When the corpus is already in v3 article shape (leads + ## sections, no summary:) and memory-v3-live is on",
+            "When /workspace/memory/concepts/ is empty or near-empty (run vellum-memory-v2-migration first — there is nothing to reform)"
+          ]
+        }
+      },
+      "compatibility": "Designed for Vellum personal assistants",
+      "updatedAt": "2026-06-17T23:05:29.000Z"
+    },
+    {
       "id": "vellum-oauth-integrations",
       "name": "vellum-oauth-integrations",
       "description": "Act on behalf of your user in any third-party software that supports OAuth 2.0",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1018,13 +1018,13 @@
             "When memory-v3 retrieval is available but /workspace/memory/concepts/ is still v2-shaped (flat bullet pages, class folders, summary: frontmatter)"
           ],
           "avoid-when": [
-            "When the corpus is already in v3 article shape (leads + ## sections, no summary:) and memory-v3-live is on",
+            "When the corpus is already in v3 article shape (leads + ## sections, no summary:) and memory.v3.live is already true",
             "When /workspace/memory/concepts/ is empty or near-empty (run vellum-memory-v2-migration first — there is nothing to reform)"
           ]
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-17T23:39:04.000Z"
+      "updatedAt": "2026-06-17T23:59:08.000Z"
     },
     {
       "id": "vellum-oauth-integrations",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1024,7 +1024,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-18T00:15:08.000Z"
+      "updatedAt": "2026-06-18T00:42:54.000Z"
     },
     {
       "id": "vellum-oauth-integrations",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1024,7 +1024,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-17T23:59:08.000Z"
+      "updatedAt": "2026-06-18T00:15:08.000Z"
     },
     {
       "id": "vellum-oauth-integrations",

--- a/skills/vellum-memory-v3-migration/SKILL.md
+++ b/skills/vellum-memory-v3-migration/SKILL.md
@@ -12,7 +12,7 @@ metadata:
       - "When the user asks to migrate the memory wiki to v3 / the section-grain format"
       - "When memory-v3 retrieval is available but /workspace/memory/concepts/ is still v2-shaped (flat bullet pages, class folders, summary: frontmatter)"
     avoid-when:
-      - "When the corpus is already in v3 article shape (leads + ## sections, no summary:) and memory-v3-live is on"
+      - "When the corpus is already in v3 article shape (leads + ## sections, no summary:) and memory.v3.live is already true"
       - "When /workspace/memory/concepts/ is empty or near-empty (run vellum-memory-v2-migration first — there is nothing to reform)"
 ---
 
@@ -52,14 +52,13 @@ assistant memory v3 --help
 
 Expect at least `backfill-sections` and `rebuild-index` (used at cutover, Step 8). If absent, the binary predates v3 — upgrade before proceeding.
 
-**(2) Retrieval engine + flag mechanism.** Determine how memory-v3 is gated on this install and how you would flip it, _without flipping anything yet_. Probe in order and record what works:
+**(2) Cutover switch.** Memory-v3 is gated by the workspace config `memory.v3.live` (a boolean the assistant sets directly — no feature flag, no operator hand-off). Confirm you can read it now, _without changing it_:
 
 ```
-assistant config get memory 2>/dev/null
-assistant flags get memory-v3-live 2>/dev/null || vellum flags get memory-v3-live 2>/dev/null
+assistant config get memory.v3.live    # expect: false — you flip it at cutover (Step 9)
 ```
 
-The `memory-v3-live` flag is gateway-owned; on some installs the assistant can flip it via its own CLI, on others it is an **operator action**. If you cannot find a flip mechanism you control, that is fine — you will stage a complete cutover and hand the final flip to the user/operator in Step 9. Note which case you're in now.
+If `assistant config get/set memory.v3.live` errors, the binary predates the config gate — upgrade before proceeding. This is also the `assistant config set` path you use to pause consolidation in Step 1.
 
 **(3) Workflow engine.** The heavy authoring + auditing fans out through the native workflow engine. Confirm it's reachable: the `run_workflow` tool should be available (load the `workflows` skill if needed). If workflows are unavailable, you can still run this skill **inline** for a small corpus (Step 5 branches on size) — but a large corpus without workflows will be slow and is not recommended.
 
@@ -86,12 +85,19 @@ assistant ui confirm "I'll snapshot the memory wiki, rewrite every page into the
 
 If the user declines, stop — no snapshot, no work. If `assistant ui confirm` is unavailable, ask in conversation.
 
-### Step 1 — Snapshot + sentinel commit (loss-proof staging)
+### Step 1 — Freeze consolidation + snapshot (loss-proof staging)
 
-`/workspace` is a git repo. Establish the paper trail and the read-only baseline:
+First **pause consolidation** so nothing writes to the live corpus while you reform it. Consolidation is the only process that writes `memory/concepts/`; if it fires mid-migration it adds pages that aren't in your snapshot (so they never get reformed) and that the cutover would then clobber. Setting `memory.v2.enabled false` makes the consolidation job bail — it also pauses v2 retrieval/injection for the duration, which is fine for a focused migration. You restore it at cutover (Step 9).
 
 ```
 cd /workspace
+assistant config set memory.v2.enabled false   # pause consolidation — the only live-corpus writer
+assistant config get memory.v2.enabled         # expect: false
+```
+
+Then establish the paper trail and the read-only baseline:
+
+```
 git add -A && git commit -m "memory-v3-migration: start" --allow-empty
 cp -R memory/concepts .mv3/snapshot/concepts          # read-only baseline — NEVER edit
 mkdir -p .mv3/staging .mv3/provenance .mv3/audit .mv3/eval
@@ -159,9 +165,9 @@ assistant memory v3 eval --snapshot .mv3/snapshot/concepts --staging .mv3/stagin
 
 That writes `.mv3/eval/packets.json` (blinded A/B memory sets per turn) and `.mv3/eval/key.json` (the unblinding map). Then launch the **blind-judge workflow** (adapt `references/workflows.md` §3, pass `packets.json` as `args.packets`) to score each turn on coverage, map the verdicts back through `key.json`, and tally. The gate: the wiki must **win or tie**. If it loses, the losing turns name the clusters that under-retrieve (thin lead, over-merged article, missing link) — repair, re-run `eval`, re-judge. Do **not** cut over on a losing or unrun eval. See `references/eval-gate.md` for the methodology. (Embedding both corpora can take a while on a large corpus; `--no-dense` gives a fast lexical-only pass for iteration.)
 
-### Step 9 — Cutover (deploy + flip)
+### Step 9 — Cutover (deploy + go live)
 
-Coupled, in one window — staged articles have no `summary:`, so live v2 degrades the moment they land; deploy and flip must not be separated.
+Coupled, in one window — staged articles have no `summary:`, so live retrieval degrades the moment they land; deploy and go-live must not be separated.
 
 ```
 cd /workspace
@@ -169,9 +175,12 @@ cp -R memory/concepts .mv3/backup-concepts.$(date +%Y%m%d-%H%M%S)   # rollback p
 rsync -a --delete .mv3/staging/ memory/concepts/                     # deploy the reviewed wiki (flat)
 assistant memory v3 backfill-sections                                # seed section embeddings; verify non-zero
 assistant memory v3 rebuild-index                                    # invalidate lanes so next turn rebuilds
+assistant config set memory.v3.live true                             # v3 becomes the live injected source
+assistant config set memory.v2.enabled true                          # resume consolidation (now writes v3-shape pages)
+assistant config get memory.v3.live                                  # expect: true
 ```
 
-Then flip `memory-v3-live` via the mechanism you identified in Step 0.5(2). If that's an operator action you don't control, **stop here and hand off**: report that the wiki is deployed and embedded, and the only remaining step is flipping `memory-v3-live` (with the exact command or operator instruction). Keep `.mv3/backup-concepts.*` and `.mv3/snapshot/` until the user confirms the live wiki is good — rollback is `rsync -a --delete` from the backup, then flag off.
+`memory.v3.live` is plain workspace config the assistant owns — no feature flag, no operator hand-off. **Order matters:** set `memory.v3.live true` _before_ re-enabling consolidation, so it resumes in v3 shape, not v2. Keep `.mv3/backup-concepts.*` and `.mv3/snapshot/` until the user confirms the live wiki is good. **Rollback:** `rsync -a --delete` from the backup over `memory/concepts/`, then `assistant config set memory.v3.live false` (leave `memory.v2.enabled true` so v2-shape consolidation resumes on the restored corpus).
 
 ```
 git add -A && git commit -m "memory-v3-migration: complete (wiki deployed, sections backfilled)" --allow-empty
@@ -179,7 +188,7 @@ git add -A && git commit -m "memory-v3-migration: complete (wiki deployed, secti
 
 ### Step 10 — Close out
 
-Close the inference session if you opened one (`assistant inference session close`). Report: cluster + article counts, over-fragmentation collapse ratio, loss-audit result (load-bearing drops found + patched, drop-check clean), eval verdict (wiki vs v2), cutover state (deployed / flipped / handed-off), the backup path, and the three `memory-v3-migration:` sentinel commits. Note anything deferred (known-dangling links, unrouted pages).
+Close the inference session if you opened one (`assistant inference session close`). Report: cluster + article counts, over-fragmentation collapse ratio, loss-audit result (load-bearing drops found + patched, drop-check clean), eval verdict (wiki vs v2), cutover state (deployed, `memory.v3.live=true`, consolidation resumed), the backup path, and the three `memory-v3-migration:` sentinel commits. Note anything deferred (known-dangling links, unrouted pages).
 
 ## Hard rules
 
@@ -190,6 +199,7 @@ Close the inference session if you opened one (`assistant inference session clos
 - **Editorial judgment is the assistant's.** Taxonomy (Step 3) and final review (Step 7) are the assistant's calls; fan-out leaves draft, they never mark an article final.
 - **Cluster-grain authoring.** One agent per topic cluster, not per page — keeps the run under the engine's 500-agent cap and keeps topical judgment coherent.
 - **No eval, no cutover.** The wiki ships only after the blind judge says it retrieves ≥ the v2 corpus.
+- **Pause consolidation, then go live by config.** Set `memory.v2.enabled false` before the snapshot (Step 1) — consolidation is the only live-corpus writer. At cutover (Step 9) set `memory.v3.live true` _then_ `memory.v2.enabled true`; the order keeps the resumed consolidation in v3 shape.
 - **Lowercase, dash-separated flat slugs.** `the-cutover.md`, not `Arcs/The-Cutover.md`. v3 slugs are flat; hubs organize via `main:`/`links:`, not folders.
 - **Three sentinel commits**, all prefixed `memory-v3-migration:` — start / staged+audited / complete.
 

--- a/skills/vellum-memory-v3-migration/SKILL.md
+++ b/skills/vellum-memory-v3-migration/SKILL.md
@@ -87,20 +87,37 @@ If the user declines, stop — no snapshot, no work. If `assistant ui confirm` i
 
 ### Step 1 — Freeze consolidation + snapshot (loss-proof staging)
 
-First **pause consolidation** so nothing writes to the live corpus while you reform it. Consolidation is the only process that writes `memory/concepts/`; if it fires mid-migration it adds pages that aren't in your snapshot (so they never get reformed) and that the cutover would then clobber. Setting `memory.v2.enabled false` makes the consolidation job bail — it also pauses v2 retrieval/injection for the duration, which is fine for a focused migration. You restore it at cutover (Step 9).
+Consolidation is the **only** process that writes `memory/concepts/`. If it fires mid-migration it adds pages absent from your snapshot (never reformed) that the cutover then clobbers. Freeze it in two parts — disable the triggers, then wait out any run already in flight — before you snapshot. This leaves v2 retrieval live (unlike disabling `memory.v2.enabled` wholesale).
+
+**(a) Record, then disable, both triggers.** Consolidation fires on a size trigger (`consolidation_max_buffer_lines`) and a time trigger (`consolidation_interval_hours`) — those are the only two paths. Capture the current values first so you can restore them at cutover:
 
 ```
 cd /workspace
-assistant config set memory.v2.enabled false   # pause consolidation — the only live-corpus writer
-assistant config get memory.v2.enabled         # expect: false
+assistant config get memory.v2.consolidation_max_buffer_lines   # record (default 100)
+assistant config get memory.v2.consolidation_interval_hours     # record (default 4)
+assistant config set memory.v2.consolidation_max_buffer_lines null     # size trigger off
+assistant config set memory.v2.consolidation_interval_hours 876000     # time trigger off (~100y)
 ```
 
-Then establish the paper trail and the read-only baseline:
+**(b) Wait out any in-flight run.** A run holds `memory/.v2-state/consolidation.lock` (`<pid> <ms>`) while working (hard-capped at 15 min) and removes it when done. The triggers are off now, so no new run can start — just wait for the lock to clear:
+
+```
+LOCK=memory/.v2-state/consolidation.lock
+for _ in $(seq 1 80); do
+  [ -f "$LOCK" ] || { echo "consolidation idle"; break; }
+  PID=$(awk '{print $1}' "$LOCK" 2>/dev/null)
+  kill -0 "$PID" 2>/dev/null || { echo "stale lock (pid $PID dead) — proceeding"; break; }
+  echo "consolidation in progress (pid $PID) — waiting…"; sleep 15
+done
+```
+
+**(c) Snapshot** — paper trail + read-only baseline:
 
 ```
 git add -A && git commit -m "memory-v3-migration: start" --allow-empty
 cp -R memory/concepts .mv3/snapshot/concepts          # read-only baseline — NEVER edit
 mkdir -p .mv3/staging .mv3/provenance .mv3/audit .mv3/eval
+[ -f "$LOCK" ] && echo "WARN: a run started during the copy — re-snapshot"   # sanity
 ```
 
 `.mv3/` is your scratch tree, separate from live `memory/`. All authoring writes to `.mv3/staging/`. You commit again at two milestones (mid — after authoring + audit, Step 7; complete — after cutover, Step 9). All sentinels use the exact prefix `memory-v3-migration:` so `git log --grep` finds them as one set. See `references/loss-proofing.md` for the full contract.
@@ -176,11 +193,13 @@ rsync -a --delete .mv3/staging/ memory/concepts/                     # deploy th
 assistant memory v3 backfill-sections                                # seed section embeddings; verify non-zero
 assistant memory v3 rebuild-index                                    # invalidate lanes so next turn rebuilds
 assistant config set memory.v3.live true                             # v3 becomes the live injected source
-assistant config set memory.v2.enabled true                          # resume consolidation (now writes v3-shape pages)
+# restore the two triggers to the values you recorded in Step 1 (defaults shown — use YOUR recorded values):
+assistant config set memory.v2.consolidation_max_buffer_lines 100    # re-enable size trigger
+assistant config set memory.v2.consolidation_interval_hours 4        # re-enable time trigger
 assistant config get memory.v3.live                                  # expect: true
 ```
 
-`memory.v3.live` is plain workspace config the assistant owns — no feature flag, no operator hand-off. **Order matters:** set `memory.v3.live true` _before_ re-enabling consolidation, so it resumes in v3 shape, not v2. Keep `.mv3/backup-concepts.*` and `.mv3/snapshot/` until the user confirms the live wiki is good. **Rollback:** `rsync -a --delete` from the backup over `memory/concepts/`, then `assistant config set memory.v3.live false` (leave `memory.v2.enabled true` so v2-shape consolidation resumes on the restored corpus).
+`memory.v3.live` is plain workspace config the assistant owns — no feature flag, no operator hand-off. **Order matters:** set `memory.v3.live true` _before_ restoring the triggers, so the next consolidation is v3-shape, not v2. (`memory.v2.enabled` stayed `true` throughout — retrieval was never interrupted; only the triggers were paused.) Keep `.mv3/backup-concepts.*` and `.mv3/snapshot/` until the user confirms the live wiki is good. **Rollback:** `rsync -a --delete` from the backup over `memory/concepts/`, then `assistant config set memory.v3.live false` (the restored triggers then run v2-shape consolidation on the restored corpus).
 
 ```
 git add -A && git commit -m "memory-v3-migration: complete (wiki deployed, sections backfilled)" --allow-empty
@@ -199,7 +218,7 @@ Close the inference session if you opened one (`assistant inference session clos
 - **Editorial judgment is the assistant's.** Taxonomy (Step 3) and final review (Step 7) are the assistant's calls; fan-out leaves draft, they never mark an article final.
 - **Cluster-grain authoring.** One agent per topic cluster, not per page — keeps the run under the engine's 500-agent cap and keeps topical judgment coherent.
 - **No eval, no cutover.** The wiki ships only after the blind judge says it retrieves ≥ the v2 corpus.
-- **Pause consolidation, then go live by config.** Set `memory.v2.enabled false` before the snapshot (Step 1) — consolidation is the only live-corpus writer. At cutover (Step 9) set `memory.v3.live true` _then_ `memory.v2.enabled true`; the order keeps the resumed consolidation in v3 shape.
+- **Freeze consolidation, then go live by config.** Before the snapshot (Step 1) disable both consolidation triggers (`consolidation_max_buffer_lines: null`, `consolidation_interval_hours` huge) and wait out any in-flight run via `memory/.v2-state/consolidation.lock` — consolidation is the only live-corpus writer. At cutover (Step 9) set `memory.v3.live true` _then_ restore the triggers; the order keeps the next consolidation in v3 shape.
 - **Lowercase, dash-separated flat slugs.** `the-cutover.md`, not `Arcs/The-Cutover.md`. v3 slugs are flat; hubs organize via `main:`/`links:`, not folders.
 - **Three sentinel commits**, all prefixed `memory-v3-migration:` — start / staged+audited / complete.
 

--- a/skills/vellum-memory-v3-migration/SKILL.md
+++ b/skills/vellum-memory-v3-migration/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: vellum-memory-v3-migration
+description: One-time migration of an existing memory-v2 concept corpus into the memory-v3 section-grain "wiki" — topical articles with a stand-alone lead and queryable sections — with loss-proof staging, assistant-reviewed authoring, and a retrieval-eval gate before cutover.
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "🗂️"
+  vellum:
+    category: "system"
+    display-name: "Memory v3 Migration"
+    user-invocable: true
+    activation-hints:
+      - "When the user asks to migrate the memory wiki to v3 / the section-grain format"
+      - "When memory-v3 retrieval is available but /workspace/memory/concepts/ is still v2-shaped (flat bullet pages, class folders, summary: frontmatter)"
+    avoid-when:
+      - "When the corpus is already in v3 article shape (leads + ## sections, no summary:) and memory-v3-live is on"
+      - "When /workspace/memory/concepts/ is empty or near-empty (run vellum-memory-v2-migration first — there is nothing to reform)"
+---
+
+# Memory v3 Migration
+
+Reform an **existing** memory-v2 corpus into the memory-v3 wiki: a cross-linked set of topical articles where each article's **lead is its retrieval card** and each `## ` section is an independently retrievable unit. The assistant is the sole reader and editor of this knowledge base; the goal is a clean, well-organized wiki optimized for retrieval.
+
+This skill is the **successor** to `vellum-memory-v2-migration`. That skill backfills an empty corpus from scratch; this one **reorganizes a populated one**. If `concepts/` is empty, stop and run that skill instead.
+
+## What actually changes, and why it's two jobs
+
+The mechanical cutover is cheap and mostly automatic: v3 reads the same `memory/concepts/*.md` tree, the schema is shared, the DB tables already exist, and section embeddings backfill on demand. **The work is the reform.** v3 retrieval is section-grain: it shows a compact **card** (the article's lead + its section names) and spotlights the single best-matching `## ` section. A flat v2 page — bullets, no `## ` headings, a `summary:` field v3 ignores — collapses under v3 into **one giant lead with no sections**: a bloated card that starves the card budget and exposes no section to match. So this skill does two things at once:
+
+1. **Reshape each surviving page** into the v3 article skeleton (lead + sections, flat slug, `links:` not `edges:`, optional `current:`).
+2. **Re-organize the corpus** — merge over-fragmented pages into topical articles under hubs, so the wiki is navigable, not a pile of stubs.
+
+> ⚠️ **Prime directive: loss-proof.** You are rewriting memory you cannot regenerate. Every stage runs against a **read-only snapshot**, writes to a **separate staging tree**, and carries **provenance**. The live corpus is never edited until a verified cutover. "Loss-proof" is a property you *verify* (Step 7), not one you intend.
+
+## Procedure
+
+### Step 0 — Read the principles
+
+Read `references/v3-wiki-principles.md` end-to-end first. It defines the v3 article skeleton, the lead-is-the-card rule, the event-vs-topic distinction, hubs (`kind: index`), section discipline, the card budget, and the banned content shapes. It owns *what a good v3 article is*; this SKILL.md owns *what order to do things in*.
+
+Then read `references/loss-proofing.md` — the snapshot/staging/provenance/verify contract that every later step depends on.
+
+### Step 0.5 — Preflight
+
+Resolve each before touching anything; if a check fails, stop and fix it.
+
+**(1) CLI surface.** Confirm the v3 subcommands exist:
+
+```
+assistant --version
+assistant memory v3 --help
+```
+
+Expect at least `backfill-sections` and `rebuild-index` (used at cutover, Step 8). If absent, the binary predates v3 — upgrade before proceeding.
+
+**(2) Retrieval engine + flag mechanism.** Determine how memory-v3 is gated on this install and how you would flip it, *without flipping anything yet*. Probe in order and record what works:
+
+```
+assistant config get memory 2>/dev/null
+assistant flags get memory-v3-live 2>/dev/null || vellum flags get memory-v3-live 2>/dev/null
+```
+
+The `memory-v3-live` flag is gateway-owned; on some installs the assistant can flip it via its own CLI, on others it is an **operator action**. If you cannot find a flip mechanism you control, that is fine — you will stage a complete cutover and hand the final flip to the user/operator in Step 9. Note which case you're in now.
+
+**(3) Workflow engine.** The heavy authoring + auditing fans out through the native workflow engine. Confirm it's reachable: the `run_workflow` tool should be available (load the `workflows` skill if needed). If workflows are unavailable, you can still run this skill **inline** for a small corpus (Step 5 branches on size) — but a large corpus without workflows will be slow and is not recommended.
+
+**(4) Pin a high-quality model.** Reform is judgment-heavy. If the CLI exposes inference sessions, pin one for the duration:
+
+```
+assistant inference session open quality-optimized --ttl 4h
+```
+
+If `quality-optimized` isn't a profile, `assistant config get llm.profiles` and open against the highest-quality one. If the command doesn't exist, proceed unpinned (and skip the close in Step 10).
+
+**(5) Size the job + confirm.** Count the corpus and tell the user what they're signing up for:
+
+```
+find /workspace/memory/concepts -name '*.md' | wc -l
+du -sh /workspace/memory/concepts
+```
+
+Reform of a multi-thousand-page corpus is many millions of tokens and real money. Use the CLI gate:
+
+```
+assistant ui confirm "I'll snapshot the memory wiki, rewrite every page into the v3 shape, re-organize it into topical articles, verify nothing was lost, prove it retrieves at least as well as today, and only then cut over. This is judgment-heavy LLM work and scales with corpus size — it can take a while and cost real money. The live corpus stays untouched until the final step. Proceed?"
+```
+
+If the user declines, stop — no snapshot, no work. If `assistant ui confirm` is unavailable, ask in conversation.
+
+### Step 1 — Snapshot + sentinel commit (loss-proof staging)
+
+`/workspace` is a git repo. Establish the paper trail and the read-only baseline:
+
+```
+cd /workspace
+git add -A && git commit -m "memory-v3-migration: start" --allow-empty
+cp -R memory/concepts .mv3/snapshot/concepts          # read-only baseline — NEVER edit
+mkdir -p .mv3/staging .mv3/provenance .mv3/audit .mv3/eval
+```
+
+`.mv3/` is your scratch tree, separate from live `memory/`. All authoring writes to `.mv3/staging/`. You commit again at two milestones (mid — after authoring + audit, Step 7; complete — after cutover, Step 9). All sentinels use the exact prefix `memory-v3-migration:` so `git log --grep` finds them as one set. See `references/loss-proofing.md` for the full contract.
+
+### Step 2 — Inventory + analyze
+
+Classify the snapshot mechanically before designing anything. For each page note: class (from its folder/`edges:` — episodic / operational / phrase / person / hub), in-degree (how many pages edge to it), and rough size. The goal is to find the **over-fragmentation factor**: how many tiny pages should collapse into one topical article. Read the densest and most-linked pages end-to-end — they anchor the taxonomy.
+
+For a large corpus, this analysis pass itself can be a workflow (fan out one reader per chunk → structured class/size/in-degree rows). For a small one, do it inline.
+
+### Step 3 — Design the topical taxonomy (the assistant's editorial call)
+
+This is the judgment the reform turns on — make it deliberately, not via a cold agent. Decide:
+
+- **Hubs** (`kind: index`) — the 5–15 topic clusters everything files under (the user, the assistant itself, major projects, domains, key people, systems). A hub routes; it does not hold body content.
+- **Cluster membership** — which snapshot pages merge into which article under which hub. Over-fragmented siblings merge; genuinely distinct topics stay separate.
+- **Event vs topic** split per cluster — what HAPPENED (recorded in full) vs what IS (queryable, terse).
+
+Bottom-up auto-clustering produces a re-shaped pile, not a wiki — design the hubs top-down from what you know matters, then route pages into them. Write the taxonomy to `.mv3/taxonomy.md` (hubs + cluster→source-pages map). This is the routing manifest the authoring step consumes.
+
+### Step 4 — Route fragments → clusters (provenance)
+
+Turn `.mv3/taxonomy.md` into a machine-readable routing manifest: `.mv3/provenance/routing.json` = `[{ cluster, hubSlug, sourcePaths: [snapshot paths] }]`. Every snapshot page must appear in exactly one cluster's `sourcePaths` (a page may be cross-linked later, but it has one canonical home). A page that fits nowhere goes to an explicit `unrouted` bucket — never dropped. The loss-audit (Step 7) checks every snapshot path against this manifest.
+
+### Step 5 — Author the wiki (the fan-out)
+
+Author **one cluster at a time, at cluster grain** — a single agent reads all of a cluster's source pages and writes that cluster's whole article set (hub + leaves) into `.mv3/staging/`. Cluster-grain (not page-grain) keeps the agent count low and the topical judgment coherent.
+
+**Branch on size:**
+
+- **Small corpus / few clusters (≲ ~30 clusters):** author inline, cluster by cluster, yourself.
+- **Large corpus:** fan out via the workflow engine. Adapt the author-cluster template in `references/workflows.md` (§1) and launch it with `run_workflow`, passing the routing manifest as `args`. Author leaves read their cluster's source pages, and the run declares **`file_write`** scoped to `.mv3/staging/`. One leaf per cluster keeps ~dozens of leaves — well under the engine's 500-agent cap. If clusters exceed a few hundred, shard across multiple `run_workflow` launches (≤3 concurrent); the engine's resume replays completed clusters if a run is interrupted, so a deploy mid-run loses nothing.
+
+Each authored cluster emits `.mv3/provenance/<cluster>.json` mapping every staged article slug → the snapshot source paths it consumed. No article is marked final by a fan-out leaf — leave a `status: draft` marker; you review in Step 7.
+
+### Step 6 — Link repair
+
+Resolve cross-references. Walk every staged article's `links:` and inline `[[wikilinks]]`; repair targets against the new flat slugs using the provenance map (old path → new slug). Classify anything still dangling (missing target / intended-but-unwritten leaf / external ref) into `.mv3/audit/dangling-links.md` for review. Aim to resolve the large majority; a known-dangling link is acceptable only if recorded.
+
+### Step 7 — Loss audit + review (MANDATORY)
+
+This is what makes loss-proof real. Two passes (see `references/loss-proofing.md`):
+
+1. **Mechanical quote-screen** — extract quoted strings, dates, and numbers from each snapshot source; confirm each appears in the staged article that claims it (frontmatter stripped). A stdlib helper does this; flag misses.
+2. **Semantic reader panel** — fan out one reader per cluster (anonymous **schema** leaves — cheap, impartial, no persona) that reads source-vs-staged in full and lists substance present in the source but absent/weakened in the draft, tagged `[load-bearing]` / `[secondary]` / `[incidental]`. Adapt the loss-audit template in `references/workflows.md` (§2).
+
+**Patch every `[load-bearing]` drop back verbatim** into the right section. Also confirm the drop-check: every snapshot path appears as a source in some staged article's provenance (or in `unrouted`). Then **review and approve** each cluster (`status: draft → final`) — you are reading content that is already verified whole.
+
+Mid commit:
+
+```
+cd /workspace && git add -A && git commit -m "memory-v3-migration: staged wiki + loss audit" --allow-empty
+```
+
+### Step 8 — Eval gate (prove it before cutover)
+
+Prove the staged wiki retrieves at least as well as today's corpus before cutting over. The `assistant memory v3 eval` command does the mechanical half — it mines recent real turns, retrieves the top pages from BOTH the snapshot and the staged wiki per turn (needle + dense, in memory, nothing live touched), and writes blinded A/B packets:
+
+```
+assistant memory v3 eval --snapshot .mv3/snapshot/concepts --staging .mv3/staging --out .mv3/eval
+```
+
+That writes `.mv3/eval/packets.json` (blinded A/B memory sets per turn) and `.mv3/eval/key.json` (the unblinding map). Then launch the **blind-judge workflow** (adapt `references/workflows.md` §3, pass `packets.json` as `args.packets`) to score each turn on coverage, map the verdicts back through `key.json`, and tally. The gate: the wiki must **win or tie**. If it loses, the losing turns name the clusters that under-retrieve (thin lead, over-merged article, missing link) — repair, re-run `eval`, re-judge. Do **not** cut over on a losing or unrun eval. See `references/eval-gate.md` for the methodology. (Embedding both corpora can take a while on a large corpus; `--no-dense` gives a fast lexical-only pass for iteration.)
+
+### Step 9 — Cutover (deploy + flip)
+
+Coupled, in one window — staged articles have no `summary:`, so live v2 degrades the moment they land; deploy and flip must not be separated.
+
+```
+cd /workspace
+cp -R memory/concepts .mv3/backup-concepts.$(date +%Y%m%d-%H%M%S)   # rollback point
+rsync -a --delete .mv3/staging/ memory/concepts/                     # deploy the reviewed wiki (flat)
+assistant memory v3 backfill-sections                                # seed section embeddings; verify non-zero
+assistant memory v3 rebuild-index                                    # invalidate lanes so next turn rebuilds
+```
+
+Then flip `memory-v3-live` via the mechanism you identified in Step 0.5(2). If that's an operator action you don't control, **stop here and hand off**: report that the wiki is deployed and embedded, and the only remaining step is flipping `memory-v3-live` (with the exact command or operator instruction). Keep `.mv3/backup-concepts.*` and `.mv3/snapshot/` until the user confirms the live wiki is good — rollback is `rsync -a --delete` from the backup, then flag off.
+
+```
+git add -A && git commit -m "memory-v3-migration: complete (wiki deployed, sections backfilled)" --allow-empty
+```
+
+### Step 10 — Close out
+
+Close the inference session if you opened one (`assistant inference session close`). Report: cluster + article counts, over-fragmentation collapse ratio, loss-audit result (load-bearing drops found + patched, drop-check clean), eval verdict (wiki vs v2), cutover state (deployed / flipped / handed-off), the backup path, and the three `memory-v3-migration:` sentinel commits. Note anything deferred (known-dangling links, unrouted pages).
+
+## Hard rules
+
+- **Never edit live `memory/concepts/` until Step 9.** All work is snapshot → staging. The live corpus is the safety net.
+- **`.mv3/snapshot/` is read-only.** It is the loss-audit baseline and the eval comparator. Never write to it.
+- **Provenance on every article.** Every staged article records the snapshot paths it consumed. No provenance → it cannot be loss-audited → it cannot ship.
+- **Loss-proof is verified, not intended.** The mechanical drop-check + load-bearing patch (Step 7) is mandatory. Patch drops **verbatim**.
+- **Editorial judgment is the assistant's.** Taxonomy (Step 3) and final review (Step 7) are the assistant's calls; fan-out leaves draft, they never mark an article final.
+- **Cluster-grain authoring.** One agent per topic cluster, not per page — keeps the run under the engine's 500-agent cap and keeps topical judgment coherent.
+- **No eval, no cutover.** The wiki ships only after the blind judge says it retrieves ≥ the v2 corpus.
+- **Lowercase, dash-separated flat slugs.** `the-cutover.md`, not `Arcs/The-Cutover.md`. v3 slugs are flat; hubs organize via `main:`/`links:`, not folders.
+- **Three sentinel commits**, all prefixed `memory-v3-migration:` — start / staged+audited / complete.
+
+## References
+
+- `references/v3-wiki-principles.md` — the v3 article skeleton and the principles every article obeys. Read first.
+- `references/loss-proofing.md` — the snapshot/staging/provenance/verify contract.
+- `references/eval-gate.md` — the blind-judge methodology and the ship gate.
+- `references/workflows.md` — the three fan-out templates the assistant adapts and launches via `run_workflow`: §1 author-clusters (write staged articles + provenance), §2 loss-audit (schema-leaf reader panel), §3 blind-judge (A/B content judge over mined turns).

--- a/skills/vellum-memory-v3-migration/SKILL.md
+++ b/skills/vellum-memory-v3-migration/SKILL.md
@@ -10,10 +10,10 @@ metadata:
     user-invocable: true
     activation-hints:
       - "When the user asks to migrate the memory wiki to v3 / the section-grain format"
-      - "When memory-v3 retrieval is available but /workspace/memory/concepts/ is still v2-shaped (flat bullet pages, class folders, summary: frontmatter)"
+      - "When memory-v3 retrieval is available but memory/concepts/ is still v2-shaped (flat bullet pages, class folders, summary: frontmatter)"
     avoid-when:
       - "When the corpus is already in v3 article shape (leads + ## sections, no summary:) and memory.v3.live is already true"
-      - "When /workspace/memory/concepts/ is empty or near-empty (run vellum-memory-v2-migration first — there is nothing to reform)"
+      - "When memory/concepts/ is empty or near-empty (run vellum-memory-v2-migration first — there is nothing to reform)"
 ---
 
 # Memory v3 Migration
@@ -73,8 +73,8 @@ If `quality-optimized` isn't a profile, `assistant config get llm.profiles` and 
 **(5) Size the job + confirm.** Count the corpus and tell the user what they're signing up for:
 
 ```
-find /workspace/memory/concepts -name '*.md' | wc -l
-du -sh /workspace/memory/concepts
+find "$VELLUM_WORKSPACE_DIR/memory/concepts" -name '*.md' | wc -l
+du -sh "$VELLUM_WORKSPACE_DIR/memory/concepts"
 ```
 
 Reform of a multi-thousand-page corpus is many millions of tokens and real money. Use the CLI gate:
@@ -92,7 +92,7 @@ Consolidation is the **only** process that writes `memory/concepts/`. If it fire
 **(a) Record, then disable, both triggers.** Consolidation fires on a size trigger (`consolidation_max_buffer_lines`) and a time trigger (`consolidation_interval_hours`) — those are the only two paths. Capture the current values first so you can restore them at cutover:
 
 ```
-cd /workspace
+cd "$VELLUM_WORKSPACE_DIR"   # the workspace root — NOT /workspace on local installs
 assistant config get memory.v2.consolidation_max_buffer_lines   # record (default 100)
 assistant config get memory.v2.consolidation_interval_hours     # record (default 4)
 assistant config set memory.v2.consolidation_max_buffer_lines null     # size trigger off
@@ -102,6 +102,7 @@ assistant config set memory.v2.consolidation_interval_hours 876000     # time tr
 **(b) Wait out any in-flight run.** A run holds `memory/.v2-state/consolidation.lock` (`<pid> <ms>`) while working (hard-capped at 15 min) and removes it when done. The triggers are off now, so no new run can start — just wait for the lock to clear:
 
 ```
+cd "$VELLUM_WORKSPACE_DIR"
 LOCK=memory/.v2-state/consolidation.lock
 for _ in $(seq 1 80); do
   [ -f "$LOCK" ] || { echo "consolidation idle"; break; }
@@ -114,10 +115,11 @@ done
 **(c) Snapshot** — paper trail + read-only baseline:
 
 ```
+cd "$VELLUM_WORKSPACE_DIR"
 git add -A && git commit -m "memory-v3-migration: start" --allow-empty
 mkdir -p .mv3/snapshot .mv3/staging .mv3/provenance .mv3/audit .mv3/eval
 cp -R memory/concepts .mv3/snapshot/concepts          # read-only baseline — NEVER edit
-[ -f "$LOCK" ] && echo "WARN: a run started during the copy — re-snapshot"   # sanity
+[ -f memory/.v2-state/consolidation.lock ] && echo "WARN: a run started during the copy — re-snapshot"
 ```
 
 `.mv3/` is your scratch tree, separate from live `memory/`. All authoring writes to `.mv3/staging/`. You commit again at two milestones (mid — after authoring + audit, Step 7; complete — after cutover, Step 9). All sentinels use the exact prefix `memory-v3-migration:` so `git log --grep` finds them as one set. See `references/loss-proofing.md` for the full contract.
@@ -169,7 +171,7 @@ This is what makes loss-proof real. Two passes (see `references/loss-proofing.md
 Mid commit:
 
 ```
-cd /workspace && git add -A && git commit -m "memory-v3-migration: staged wiki + loss audit" --allow-empty
+cd "$VELLUM_WORKSPACE_DIR" && git add -A && git commit -m "memory-v3-migration: staged wiki + loss audit" --allow-empty
 ```
 
 ### Step 8 — Eval gate (prove it before cutover)
@@ -187,7 +189,7 @@ That writes `.mv3/eval/packets.json` (blinded A/B memory sets per turn) and `.mv
 Coupled, in one window — staged articles have no `summary:`, so live retrieval degrades the moment they land; deploy and go-live must not be separated.
 
 ```
-cd /workspace
+cd "$VELLUM_WORKSPACE_DIR"
 cp -R memory/concepts .mv3/backup-concepts.$(date +%Y%m%d-%H%M%S)   # rollback point
 rsync -a --delete .mv3/staging/ memory/concepts/                     # deploy the reviewed wiki (flat)
 assistant memory v3 backfill-sections                                # seed section embeddings; verify non-zero

--- a/skills/vellum-memory-v3-migration/SKILL.md
+++ b/skills/vellum-memory-v3-migration/SKILL.md
@@ -29,13 +29,13 @@ The mechanical cutover is cheap and mostly automatic: v3 reads the same `memory/
 1. **Reshape each surviving page** into the v3 article skeleton (lead + sections, flat slug, `links:` not `edges:`, optional `current:`).
 2. **Re-organize the corpus** — merge over-fragmented pages into topical articles under hubs, so the wiki is navigable, not a pile of stubs.
 
-> ⚠️ **Prime directive: loss-proof.** You are rewriting memory you cannot regenerate. Every stage runs against a **read-only snapshot**, writes to a **separate staging tree**, and carries **provenance**. The live corpus is never edited until a verified cutover. "Loss-proof" is a property you *verify* (Step 7), not one you intend.
+> ⚠️ **Prime directive: loss-proof.** You are rewriting memory you cannot regenerate. Every stage runs against a **read-only snapshot**, writes to a **separate staging tree**, and carries **provenance**. The live corpus is never edited until a verified cutover. "Loss-proof" is a property you _verify_ (Step 7), not one you intend.
 
 ## Procedure
 
 ### Step 0 — Read the principles
 
-Read `references/v3-wiki-principles.md` end-to-end first. It defines the v3 article skeleton, the lead-is-the-card rule, the event-vs-topic distinction, hubs (`kind: index`), section discipline, the card budget, and the banned content shapes. It owns *what a good v3 article is*; this SKILL.md owns *what order to do things in*.
+Read `references/v3-wiki-principles.md` end-to-end first. It defines the v3 article skeleton, the lead-is-the-card rule, the event-vs-topic distinction, hubs (`kind: index`), section discipline, the card budget, and the banned content shapes. It owns _what a good v3 article is_; this SKILL.md owns _what order to do things in_.
 
 Then read `references/loss-proofing.md` — the snapshot/staging/provenance/verify contract that every later step depends on.
 
@@ -52,7 +52,7 @@ assistant memory v3 --help
 
 Expect at least `backfill-sections` and `rebuild-index` (used at cutover, Step 8). If absent, the binary predates v3 — upgrade before proceeding.
 
-**(2) Retrieval engine + flag mechanism.** Determine how memory-v3 is gated on this install and how you would flip it, *without flipping anything yet*. Probe in order and record what works:
+**(2) Retrieval engine + flag mechanism.** Determine how memory-v3 is gated on this install and how you would flip it, _without flipping anything yet_. Probe in order and record what works:
 
 ```
 assistant config get memory 2>/dev/null

--- a/skills/vellum-memory-v3-migration/SKILL.md
+++ b/skills/vellum-memory-v3-migration/SKILL.md
@@ -80,7 +80,7 @@ du -sh /workspace/memory/concepts
 Reform of a multi-thousand-page corpus is many millions of tokens and real money. Use the CLI gate:
 
 ```
-assistant ui confirm "I'll snapshot the memory wiki, rewrite every page into the v3 shape, re-organize it into topical articles, verify nothing was lost, prove it retrieves at least as well as today, and only then cut over. This is judgment-heavy LLM work and scales with corpus size — it can take a while and cost real money. The live corpus stays untouched until the final step. Proceed?"
+assistant ui confirm --message "I'll snapshot the memory wiki, rewrite every page into the v3 shape, re-organize it into topical articles, verify nothing was lost, prove it retrieves at least as well as today, and only then cut over. This is judgment-heavy LLM work and scales with corpus size — it can take a while and cost real money. The live corpus stays untouched until the final step. Proceed?"
 ```
 
 If the user declines, stop — no snapshot, no work. If `assistant ui confirm` is unavailable, ask in conversation.
@@ -115,8 +115,8 @@ done
 
 ```
 git add -A && git commit -m "memory-v3-migration: start" --allow-empty
+mkdir -p .mv3/snapshot .mv3/staging .mv3/provenance .mv3/audit .mv3/eval
 cp -R memory/concepts .mv3/snapshot/concepts          # read-only baseline — NEVER edit
-mkdir -p .mv3/staging .mv3/provenance .mv3/audit .mv3/eval
 [ -f "$LOCK" ] && echo "WARN: a run started during the copy — re-snapshot"   # sanity
 ```
 

--- a/skills/vellum-memory-v3-migration/references/eval-gate.md
+++ b/skills/vellum-memory-v3-migration/references/eval-gate.md
@@ -4,7 +4,7 @@ Before cutover you must prove the staged wiki retrieves **at least as well** as 
 
 ## Why a blind content judge, not a recall metric
 
-The obvious metric — "did the wiki retrieve the same page slugs the v2 corpus did?" — **structurally penalizes the reform**, because the wiki deliberately renames and merges pages. A page judged "missing" is often present under a new slug with the same content. So the gate is a **blind content judge**: for each turn, two memory sets (v2 vs wiki) are scored 0–10 on *"does this cover what the reply actually needed?"*, blind to which is which, coverage-dominant. The reply is the ground truth for what memory was needed (it was written with memory help). See `workflows.md` §3.
+The obvious metric — "did the wiki retrieve the same page slugs the v2 corpus did?" — **structurally penalizes the reform**, because the wiki deliberately renames and merges pages. A page judged "missing" is often present under a new slug with the same content. So the gate is a **blind content judge**: for each turn, two memory sets (v2 vs wiki) are scored 0–10 on _"does this cover what the reply actually needed?"_, blind to which is which, coverage-dominant. The reply is the ground truth for what memory was needed (it was written with memory help). See `workflows.md` §3.
 
 ## Building the packets — `assistant memory v3 eval`
 
@@ -18,7 +18,7 @@ It writes `.mv3/eval/packets.json` (per turn: `{turn, context, userMessage, repl
 
 - **Mines recent real user→assistant turns** from the message store, excluding scheduled/cron turns, capped per conversation.
 - **Retrieves both sides identically** — a BM25F section needle unioned with dense cosine over freshly-embedded section vectors (the same section grain the live engine uses), top-`k` pages per corpus, rendered as the model sees them (card + matched section). Everything is in memory; the live lanes and Qdrant are untouched.
-- **No time-gating is needed.** The staged wiki is a pure reorganization of the snapshot — both corpora hold the *same knowledge*, so a page encoding post-turn information is reachable in both and can't bias either side. The eval cleanly measures retrieval **shape**, which is exactly the question.
+- **No time-gating is needed.** The staged wiki is a pure reorganization of the snapshot — both corpora hold the _same knowledge_, so a page encoding post-turn information is reachable in both and can't bias either side. The eval cleanly measures retrieval **shape**, which is exactly the question.
 
 Use `--no-dense` for a fast lexical-only pass while iterating; the full run embeds every section of both corpora and can take a while on a large corpus. Re-run after fixing staged articles.
 
@@ -32,5 +32,5 @@ Run the blind-judge workflow over the packets, map A/B back to v2/wiki via the k
 ## Honesty caveats
 
 - **The judge has variance.** Run a small panel per turn, or repeat the set with different `--seed` values; don't ship on a one-vote margin.
-- **This eval tests on-disk corpus shape, not the whole live engine.** It exercises the needle + dense lanes over the two corpora; it does not replicate every live lane (learned-edges, carry-forward accumulation, capability rows). It answers the reform's actual risk — *"does the reshaped corpus retrieve its own content at least as well?"* — not *"is the live system byte-identical post-cutover."*
+- **This eval tests on-disk corpus shape, not the whole live engine.** It exercises the needle + dense lanes over the two corpora; it does not replicate every live lane (learned-edges, carry-forward accumulation, capability rows). It answers the reform's actual risk — _"does the reshaped corpus retrieve its own content at least as well?"_ — not _"is the live system byte-identical post-cutover."_
 - **No eval, no cutover** is a hard rule (SKILL.md). An unrun gate is a failed gate.

--- a/skills/vellum-memory-v3-migration/references/eval-gate.md
+++ b/skills/vellum-memory-v3-migration/references/eval-gate.md
@@ -1,0 +1,36 @@
+# The eval gate
+
+Before cutover you must prove the staged wiki retrieves **at least as well** as the current v2 corpus. Not by intuition — by a blind comparison on real historical turns. This gate exists because a plausible-looking reform can quietly lose retrieval: renamed slugs, leads that don't carry the card, sections that don't match.
+
+## Why a blind content judge, not a recall metric
+
+The obvious metric — "did the wiki retrieve the same page slugs the v2 corpus did?" — **structurally penalizes the reform**, because the wiki deliberately renames and merges pages. A page judged "missing" is often present under a new slug with the same content. So the gate is a **blind content judge**: for each turn, two memory sets (v2 vs wiki) are scored 0–10 on *"does this cover what the reply actually needed?"*, blind to which is which, coverage-dominant. The reply is the ground truth for what memory was needed (it was written with memory help). See `workflows.md` §3.
+
+## Building the packets — `assistant memory v3 eval`
+
+Workflow leaves have no embedding/retrieval tool, so retrieval happens **outside** the workflow. One command does the whole mechanical half — mine turns, embed both corpora, retrieve both sides per turn, blind, and write the packets:
+
+```
+assistant memory v3 eval --snapshot .mv3/snapshot/concepts --staging .mv3/staging --out .mv3/eval
+```
+
+It writes `.mv3/eval/packets.json` (per turn: `{turn, context, userMessage, reply, setA, setB}`, A/B order shuffled by a seeded PRNG) and `.mv3/eval/key.json` (the unblinding map the judge never sees). Under the hood:
+
+- **Mines recent real user→assistant turns** from the message store, excluding scheduled/cron turns, capped per conversation.
+- **Retrieves both sides identically** — a BM25F section needle unioned with dense cosine over freshly-embedded section vectors (the same section grain the live engine uses), top-`k` pages per corpus, rendered as the model sees them (card + matched section). Everything is in memory; the live lanes and Qdrant are untouched.
+- **No time-gating is needed.** The staged wiki is a pure reorganization of the snapshot — both corpora hold the *same knowledge*, so a page encoding post-turn information is reachable in both and can't bias either side. The eval cleanly measures retrieval **shape**, which is exactly the question.
+
+Use `--no-dense` for a fast lexical-only pass while iterating; the full run embeds every section of both corpora and can take a while on a large corpus. Re-run after fixing staged articles.
+
+## The gate
+
+Run the blind-judge workflow over the packets, map A/B back to v2/wiki via the key, and tally. **Ship only if the wiki wins or ties** across the set. If it loses:
+
+- The losing turns name the clusters that under-retrieve. Read those packets — usually a thin lead (the card doesn't carry), an over-merged article (the matched section is buried), or a missing cross-link.
+- Fix the staged articles, re-embed the changed ones, re-judge. Iterate until the gate is green.
+
+## Honesty caveats
+
+- **The judge has variance.** Run a small panel per turn, or repeat the set with different `--seed` values; don't ship on a one-vote margin.
+- **This eval tests on-disk corpus shape, not the whole live engine.** It exercises the needle + dense lanes over the two corpora; it does not replicate every live lane (learned-edges, carry-forward accumulation, capability rows). It answers the reform's actual risk — *"does the reshaped corpus retrieve its own content at least as well?"* — not *"is the live system byte-identical post-cutover."*
+- **No eval, no cutover** is a hard rule (SKILL.md). An unrun gate is a failed gate.

--- a/skills/vellum-memory-v3-migration/references/loss-proofing.md
+++ b/skills/vellum-memory-v3-migration/references/loss-proofing.md
@@ -4,11 +4,11 @@ You are rewriting memory that cannot be regenerated. Loss-proof is a property yo
 
 ## The three trees
 
-| Tree | Role | Rule |
-|---|---|---|
-| `memory/concepts/` (live) | the safety net | **never edited until cutover** (SKILL.md Step 9) |
+| Tree                      | Role               | Rule                                                       |
+| ------------------------- | ------------------ | ---------------------------------------------------------- |
+| `memory/concepts/` (live) | the safety net     | **never edited until cutover** (SKILL.md Step 9)           |
 | `.mv3/snapshot/concepts/` | read-only baseline | the audit comparator + eval comparator — **never written** |
-| `.mv3/staging/` | the work | all authoring writes here |
+| `.mv3/staging/`           | the work           | all authoring writes here                                  |
 
 Plus `.mv3/provenance/` (per-cluster source maps), `.mv3/audit/` (drop reports, dangling links), `.mv3/eval/` (packets, verdicts). `.mv3/` is git-tracked in `/workspace` so every milestone is a recoverable commit; the snapshot copy is belt-and-suspenders on top of git.
 
@@ -26,7 +26,7 @@ For each staged article, extract quoted strings, dates, and numbers from its pro
 
 ## The semantic pass (reader panel)
 
-The mechanical checks catch missing strings; they miss *weakened* substance (a passage flattened, an implication dropped). The reader-panel workflow (`workflows.md` §2) reads source-vs-staged in full and tags drops `[load-bearing]` / `[secondary]` / `[incidental]`. **Patch every `[load-bearing]` drop back verbatim** into the right section. `[secondary]`/`[incidental]` are judgment calls — patch when cheap, record when not.
+The mechanical checks catch missing strings; they miss _weakened_ substance (a passage flattened, an implication dropped). The reader-panel workflow (`workflows.md` §2) reads source-vs-staged in full and tags drops `[load-bearing]` / `[secondary]` / `[incidental]`. **Patch every `[load-bearing]` drop back verbatim** into the right section. `[secondary]`/`[incidental]` are judgment calls — patch when cheap, record when not.
 
 ## Review gate
 

--- a/skills/vellum-memory-v3-migration/references/loss-proofing.md
+++ b/skills/vellum-memory-v3-migration/references/loss-proofing.md
@@ -35,5 +35,5 @@ No fan-out leaf marks an article as final. Authoring leaves write `status: draft
 ## Recovery
 
 - Mid-run interruption (crash, deploy): the authoring workflow's resume replays completed clusters; re-launch the same `run_workflow` with the same `args`.
-- Bad cutover: `.mv3/backup-concepts.<timestamp>/` is the rollback point. `rsync -a --delete` it back over `memory/concepts/`, flip `memory-v3-live` off, restart. Keep the backup and snapshot until the user confirms the live wiki is good.
+- Bad cutover: `.mv3/backup-concepts.<timestamp>/` is the rollback point. `rsync -a --delete` it back over `memory/concepts/`, then `assistant config set memory.v3.live false` (leave `memory.v2.enabled true`). Keep the backup and snapshot until the user confirms the live wiki is good.
 - Nothing is deleted on the live side until the user confirms — archive, never delete.

--- a/skills/vellum-memory-v3-migration/references/loss-proofing.md
+++ b/skills/vellum-memory-v3-migration/references/loss-proofing.md
@@ -10,7 +10,7 @@ You are rewriting memory that cannot be regenerated. Loss-proof is a property yo
 | `.mv3/snapshot/concepts/` | read-only baseline | the audit comparator + eval comparator — **never written** |
 | `.mv3/staging/`           | the work           | all authoring writes here                                  |
 
-Plus `.mv3/provenance/` (per-cluster source maps), `.mv3/audit/` (drop reports, dangling links), `.mv3/eval/` (packets, verdicts). `.mv3/` is git-tracked in `/workspace` so every milestone is a recoverable commit; the snapshot copy is belt-and-suspenders on top of git.
+Plus `.mv3/provenance/` (per-cluster source maps), `.mv3/audit/` (drop reports, dangling links), `.mv3/eval/` (packets, verdicts). `.mv3/` is git-tracked in the workspace so every milestone is a recoverable commit; the snapshot copy is belt-and-suspenders on top of git.
 
 ## Provenance is mandatory
 

--- a/skills/vellum-memory-v3-migration/references/loss-proofing.md
+++ b/skills/vellum-memory-v3-migration/references/loss-proofing.md
@@ -1,0 +1,39 @@
+# Loss-proofing contract
+
+You are rewriting memory that cannot be regenerated. Loss-proof is a property you **verify**, not one you intend. Every stage obeys this contract.
+
+## The three trees
+
+| Tree | Role | Rule |
+|---|---|---|
+| `memory/concepts/` (live) | the safety net | **never edited until cutover** (SKILL.md Step 9) |
+| `.mv3/snapshot/concepts/` | read-only baseline | the audit comparator + eval comparator — **never written** |
+| `.mv3/staging/` | the work | all authoring writes here |
+
+Plus `.mv3/provenance/` (per-cluster source maps), `.mv3/audit/` (drop reports, dangling links), `.mv3/eval/` (packets, verdicts). `.mv3/` is git-tracked in `/workspace` so every milestone is a recoverable commit; the snapshot copy is belt-and-suspenders on top of git.
+
+## Provenance is mandatory
+
+Every staged article records the snapshot paths it consumed: `.mv3/provenance/<cluster>.json` = `[{ slug, sources: [...] }]`. Provenance is what makes loss measurable and the reform reversible. An article with no provenance cannot be audited and must not ship.
+
+## The drop-check (mechanical, must be clean)
+
+Every path in `.mv3/snapshot/concepts/` must appear as a `source` in some staged article's provenance, **or** under an explicit `unrouted` bucket. Build the set of all snapshot paths, subtract the set of all provenance sources, and the remainder must be empty (or knowingly `unrouted`). A silently missing path is a silently lost page. A tiny stdlib script does this — no `yaml` module in the sandbox, so parse frontmatter by hand or operate on raw paths.
+
+## The quote-screen (mechanical)
+
+For each staged article, extract quoted strings, dates, and numbers from its provenance sources and confirm each appears in the article body (frontmatter stripped). Misses are candidate drops for the semantic pass to confirm. A byte-ratio sanity check helps: if a staged cluster is far smaller than the union of its sources (e.g. < 0.7×), that's a compression tell — investigate before trusting it. Relocation should roughly conserve or expand, not shrink.
+
+## The semantic pass (reader panel)
+
+The mechanical checks catch missing strings; they miss *weakened* substance (a passage flattened, an implication dropped). The reader-panel workflow (`workflows.md` §2) reads source-vs-staged in full and tags drops `[load-bearing]` / `[secondary]` / `[incidental]`. **Patch every `[load-bearing]` drop back verbatim** into the right section. `[secondary]`/`[incidental]` are judgment calls — patch when cheap, record when not.
+
+## Review gate
+
+No fan-out leaf marks an article as final. Authoring leaves write `status: draft`. You flip `draft → final` yourself in Step 7, reading content that the audit has already proven whole. This editorial sign-off is the assistant's own call.
+
+## Recovery
+
+- Mid-run interruption (crash, deploy): the authoring workflow's resume replays completed clusters; re-launch the same `run_workflow` with the same `args`.
+- Bad cutover: `.mv3/backup-concepts.<timestamp>/` is the rollback point. `rsync -a --delete` it back over `memory/concepts/`, flip `memory-v3-live` off, restart. Keep the backup and snapshot until the user confirms the live wiki is good.
+- Nothing is deleted on the live side until the user confirms — archive, never delete.

--- a/skills/vellum-memory-v3-migration/references/loss-proofing.md
+++ b/skills/vellum-memory-v3-migration/references/loss-proofing.md
@@ -35,5 +35,5 @@ No fan-out leaf marks an article as final. Authoring leaves write `status: draft
 ## Recovery
 
 - Mid-run interruption (crash, deploy): the authoring workflow's resume replays completed clusters; re-launch the same `run_workflow` with the same `args`.
-- Bad cutover: `.mv3/backup-concepts.<timestamp>/` is the rollback point. `rsync -a --delete` it back over `memory/concepts/`, then `assistant config set memory.v3.live false` (leave `memory.v2.enabled true`). Keep the backup and snapshot until the user confirms the live wiki is good.
+- Bad cutover: `.mv3/backup-concepts.<timestamp>/` is the rollback point. `rsync -a --delete` it back over `memory/concepts/`, then `assistant config set memory.v3.live false`; the restored triggers run v2-shape consolidation on the restored corpus. Keep the backup and snapshot until the user confirms the live wiki is good.
 - Nothing is deleted on the live side until the user confirms — archive, never delete.

--- a/skills/vellum-memory-v3-migration/references/v3-wiki-principles.md
+++ b/skills/vellum-memory-v3-migration/references/v3-wiki-principles.md
@@ -1,0 +1,99 @@
+# v3 Wiki Principles
+
+What a good memory-v3 article *is*. The SKILL.md owns ordering; this owns shape. Retrieval is **section-grain**: search runs over individual `## ` sections, and what rides into context per article is a compact **card** — the article's lead plus its section names — with the single best-matching section spotlighted in full. Three consequences drive everything below.
+
+## The article skeleton
+
+```
+---
+title: Display Title — Subtitle If It Earns One
+slug: the-flat-slug
+tags: [topic-area, another-tag]
+main: parent-hub-slug
+links:
+  - "sibling-or-child-slug — one line on why this link exists"
+  - "another-slug — what future-you finds there"
+---
+# Display Title — Subtitle If It Earns One
+
+The lead. One to three short paragraphs that orient completely: what this is, the
+one or two identifying facts, where it sits in the cluster. This is the card —
+write it to stand alone. Reference other articles inline with [[wikilinks]].
+
+## first section name
+
+Prose-first. Bold the load-bearing fact; fold the implication into the sentence.
+Bullets only where a list is genuinely a list.
+
+## second section name
+
+...
+```
+
+- **`slug`** — filename minus `.md`. Flat, kebab-case, specific (`bloodwork-2026-trend`, not `health-stuff`). No folders.
+- **`main`** — the one hub this article belongs to. Every leaf has a parent; a hub's `main` is itself.
+- **`links`** — directed see-also refs, each annotated `"target — why"`. Directed: listing B here pulls B toward A's readers, not the reverse.
+- **`tags`** — flat cluster labels. Hubs also carry `kind: index`.
+- **No `summary:`** — the lead *is* the summary. v3 ignores `summary:`. Writing a good lead is writing the retrieval surface.
+- **`current:`** — optional ONE-LINE live state (open items, deadlines, what's pending), as-of dated in the text. Rendered on the card so status questions ("what's on my plate") select the page. Maintain like state: update when it moves, **delete the field the moment nothing is live**. Most pages never carry one.
+
+## The three consequences
+
+1. **The lead IS the card.** Write every lead as standalone orientation. If it only makes sense after reading the sections, the card is useless. One to three short paragraphs.
+2. **Section names are navigation.** They appear on the card as a table of contents. Name a section so future-you can tell from the name alone whether the answer lives there.
+3. **Sections are the unit of retrieval and growth.** A fact filed in the right section is findable; a fact buried mid-paragraph in an overlong lead is not.
+
+## Two article shapes
+
+- **Event articles** — what HAPPENED (a meeting, an incident, a launch, a decision, a procedure worked out under pressure). Recorded plainly and in full: dates, who and what, the concrete outcome. Keep the specifics — they are the receipts.
+- **Topic articles** — what IS (the current state of a thing you would query directly: a roster, a service's config, a project's status, a person's details). Factual and terse; these exist to answer queries cleanly.
+
+The same source can update both: a new result updates a topic article AND the relevant event article, in parallel.
+
+## Hubs — `kind: index`
+
+Some articles organize a whole cluster. Mark them `kind: index`. A hub is a **routing layer in article form**: its lead states the cluster's shape, its `links:` enumerate the children with one-line annotations, its sections carry only the summary-level through-line. Body content lives on the children — like an encyclopedia's "United States" article not trying to *be* the article on each state. Hubs balloon without discipline: if you're adding a content section to a hub, stop, file it on a child, add the child to the hub's `links:`.
+
+## Stubs are fine
+
+Real wikis are mostly stubs that grow. Cost of missing a topic ≫ cost of a thin stub. A stub is a lead and maybe one section. Spawn liberally for named things — objects, phrases, people, events, projects, places, services, habits, rules. A topic that doesn't exist won't be retrieved when it's needed; a thin stub can be demoted later.
+
+## One fact, one home
+
+Each fact gets exactly one place. Before shipping an article:
+
+- Does the lead restate what a section says? The lead orients; the section carries the detail. Don't duplicate upward.
+- Do two sections restate each other from different analytic angles? That's one section pretending to be two. Merge.
+- Does the page name a fact 3+ times? It lives in zero places that matter. Consolidate.
+
+Duplication *across* articles is fine when a fact is genuinely load-bearing for two topics. Duplication *within* a page is the bug. **Route, don't restate:** if a fact lives on a linked article, the link is enough — retrieval follows the graph.
+
+## The card budget
+
+Every conversation accumulates a bounded bundle of cards. **Bloated leads starve other articles' cards.** Optimize for orientation density in the lead and fact density in the sections — not completeness. Watch for over-investment: the pages that feel most important tend to attract the most bytes, but byte count should track *retrieval need*, not how significant the topic feels. When a page grows long, the fix is section discipline — split detail into named sections — not a longer lead.
+
+## Sections you never write
+
+- `## why it's load-bearing` — the article arguing for its own existence. Fold the implication into prose.
+- `## carry-forward` — write it AS a sentence where it belongs.
+- `## related` / `## see also` — duplicates `links:`. Frontmatter is the routing layer; inline `[[wikilinks]]` are editorial pointers.
+
+## Banned content shapes (low-value text hiding in paragraphs)
+
+- **archaeology** — "first surfaced <date>, rewritten during reorg." Metadata about when the page was written. Drop.
+- **hub-restating** — a leaf enumerating its hub's other children. The hub holds it.
+- **editorializing** — restating facts as commentary ("what this really shows"). Keep the fact; cut the gloss.
+- **cross-reference lists in prose** — `links:` and `recall` handle this.
+- **instructions to self** — "do X next time / handle this differently." A wiki records what is, not what to do. Cut.
+
+If a passage falls into one of these, ask: *would a future search need this exact fact, or is it editorializing/instruction/restating?* If the second — cut.
+
+## Reform-specific notes
+
+You are converting v2 pages, not writing from a blank buffer:
+
+- **Folders → flat slugs.** A v2 `people/alice` becomes `alice` with `main:` pointing at the relevant hub. Mixing folder-slugs and flat-slugs confuses retrieval — convert the whole corpus.
+- **`edges:` → `links:`.** v2 `edges:` are bare slugs; v3 `links:` are annotated `"target — why"`. Carry the topology, add the annotations.
+- **Bullets → lead + sections.** A v2 page's `summary:` seeds the lead; its bullets distribute into named sections by *kind of thing*, not by chronology.
+- **Merge over-fragmentation.** Many v2 pages are one-fact stubs that should be sections of a topical article, not standalone pages. The taxonomy (SKILL.md Step 3) decides which collapse.
+- **Preserve, don't compress.** Storage is cheap. When unsure whether to keep a specific fact/quote/date, keep it (in the right section). The loss-audit checks you did.

--- a/skills/vellum-memory-v3-migration/references/v3-wiki-principles.md
+++ b/skills/vellum-memory-v3-migration/references/v3-wiki-principles.md
@@ -1,6 +1,6 @@
 # v3 Wiki Principles
 
-What a good memory-v3 article *is*. The SKILL.md owns ordering; this owns shape. Retrieval is **section-grain**: search runs over individual `## ` sections, and what rides into context per article is a compact **card** — the article's lead plus its section names — with the single best-matching section spotlighted in full. Three consequences drive everything below.
+What a good memory-v3 article _is_. The SKILL.md owns ordering; this owns shape. Retrieval is **section-grain**: search runs over individual `## ` sections, and what rides into context per article is a compact **card** — the article's lead plus its section names — with the single best-matching section spotlighted in full. Three consequences drive everything below.
 
 ## The article skeleton
 
@@ -34,7 +34,7 @@ Bullets only where a list is genuinely a list.
 - **`main`** — the one hub this article belongs to. Every leaf has a parent; a hub's `main` is itself.
 - **`links`** — directed see-also refs, each annotated `"target — why"`. Directed: listing B here pulls B toward A's readers, not the reverse.
 - **`tags`** — flat cluster labels. Hubs also carry `kind: index`.
-- **No `summary:`** — the lead *is* the summary. v3 ignores `summary:`. Writing a good lead is writing the retrieval surface.
+- **No `summary:`** — the lead _is_ the summary. v3 ignores `summary:`. Writing a good lead is writing the retrieval surface.
 - **`current:`** — optional ONE-LINE live state (open items, deadlines, what's pending), as-of dated in the text. Rendered on the card so status questions ("what's on my plate") select the page. Maintain like state: update when it moves, **delete the field the moment nothing is live**. Most pages never carry one.
 
 ## The three consequences
@@ -52,7 +52,7 @@ The same source can update both: a new result updates a topic article AND the re
 
 ## Hubs — `kind: index`
 
-Some articles organize a whole cluster. Mark them `kind: index`. A hub is a **routing layer in article form**: its lead states the cluster's shape, its `links:` enumerate the children with one-line annotations, its sections carry only the summary-level through-line. Body content lives on the children — like an encyclopedia's "United States" article not trying to *be* the article on each state. Hubs balloon without discipline: if you're adding a content section to a hub, stop, file it on a child, add the child to the hub's `links:`.
+Some articles organize a whole cluster. Mark them `kind: index`. A hub is a **routing layer in article form**: its lead states the cluster's shape, its `links:` enumerate the children with one-line annotations, its sections carry only the summary-level through-line. Body content lives on the children — like an encyclopedia's "United States" article not trying to _be_ the article on each state. Hubs balloon without discipline: if you're adding a content section to a hub, stop, file it on a child, add the child to the hub's `links:`.
 
 ## Stubs are fine
 
@@ -66,11 +66,11 @@ Each fact gets exactly one place. Before shipping an article:
 - Do two sections restate each other from different analytic angles? That's one section pretending to be two. Merge.
 - Does the page name a fact 3+ times? It lives in zero places that matter. Consolidate.
 
-Duplication *across* articles is fine when a fact is genuinely load-bearing for two topics. Duplication *within* a page is the bug. **Route, don't restate:** if a fact lives on a linked article, the link is enough — retrieval follows the graph.
+Duplication _across_ articles is fine when a fact is genuinely load-bearing for two topics. Duplication _within_ a page is the bug. **Route, don't restate:** if a fact lives on a linked article, the link is enough — retrieval follows the graph.
 
 ## The card budget
 
-Every conversation accumulates a bounded bundle of cards. **Bloated leads starve other articles' cards.** Optimize for orientation density in the lead and fact density in the sections — not completeness. Watch for over-investment: the pages that feel most important tend to attract the most bytes, but byte count should track *retrieval need*, not how significant the topic feels. When a page grows long, the fix is section discipline — split detail into named sections — not a longer lead.
+Every conversation accumulates a bounded bundle of cards. **Bloated leads starve other articles' cards.** Optimize for orientation density in the lead and fact density in the sections — not completeness. Watch for over-investment: the pages that feel most important tend to attract the most bytes, but byte count should track _retrieval need_, not how significant the topic feels. When a page grows long, the fix is section discipline — split detail into named sections — not a longer lead.
 
 ## Sections you never write
 
@@ -86,7 +86,7 @@ Every conversation accumulates a bounded bundle of cards. **Bloated leads starve
 - **cross-reference lists in prose** — `links:` and `recall` handle this.
 - **instructions to self** — "do X next time / handle this differently." A wiki records what is, not what to do. Cut.
 
-If a passage falls into one of these, ask: *would a future search need this exact fact, or is it editorializing/instruction/restating?* If the second — cut.
+If a passage falls into one of these, ask: _would a future search need this exact fact, or is it editorializing/instruction/restating?_ If the second — cut.
 
 ## Reform-specific notes
 
@@ -94,6 +94,6 @@ You are converting v2 pages, not writing from a blank buffer:
 
 - **Folders → flat slugs.** A v2 `people/alice` becomes `alice` with `main:` pointing at the relevant hub. Mixing folder-slugs and flat-slugs confuses retrieval — convert the whole corpus.
 - **`edges:` → `links:`.** v2 `edges:` are bare slugs; v3 `links:` are annotated `"target — why"`. Carry the topology, add the annotations.
-- **Bullets → lead + sections.** A v2 page's `summary:` seeds the lead; its bullets distribute into named sections by *kind of thing*, not by chronology.
+- **Bullets → lead + sections.** A v2 page's `summary:` seeds the lead; its bullets distribute into named sections by _kind of thing_, not by chronology.
 - **Merge over-fragmentation.** Many v2 pages are one-fact stubs that should be sections of a topical article, not standalone pages. The taxonomy (SKILL.md Step 3) decides which collapse.
 - **Preserve, don't compress.** Storage is cheap. When unsure whether to keep a specific fact/quote/date, keep it (in the right section). The loss-audit checks you did.

--- a/skills/vellum-memory-v3-migration/references/workflows.md
+++ b/skills/vellum-memory-v3-migration/references/workflows.md
@@ -21,7 +21,8 @@ Launch with `capabilities: { tools: ["file_write"] }`. One leaf per cluster — 
 ```ts
 export const meta = {
   name: "memory-v3-author-clusters",
-  description: "Author one v3 wiki article-set per topic cluster into the staging tree, with provenance.",
+  description:
+    "Author one v3 wiki article-set per topic cluster into the staging tree, with provenance.",
   phases: [{ title: "author" }],
 };
 
@@ -72,7 +73,8 @@ Read-only — no `file_write`. A cheap, impartial reader panel; launch with no s
 ```ts
 export const meta = {
   name: "memory-v3-loss-audit",
-  description: "Per-cluster reader panel: list substance present in the v2 sources but missing/weakened in the staged wiki.",
+  description:
+    "Per-cluster reader panel: list substance present in the v2 sources but missing/weakened in the staged wiki.",
   phases: [{ title: "audit" }],
 };
 
@@ -85,10 +87,20 @@ const DROP_SCHEMA = {
       items: {
         type: "object",
         properties: {
-          fact: { type: "string", description: "the specific quote/date/number/detail that is missing or weakened" },
-          severity: { type: "string", enum: ["load-bearing", "secondary", "incidental"] },
+          fact: {
+            type: "string",
+            description:
+              "the specific quote/date/number/detail that is missing or weakened",
+          },
+          severity: {
+            type: "string",
+            enum: ["load-bearing", "secondary", "incidental"],
+          },
           sourcePath: { type: "string" },
-          shouldLiveOn: { type: "string", description: "staged slug + section where it belongs" },
+          shouldLiveOn: {
+            type: "string",
+            description: "staged slug + section where it belongs",
+          },
         },
         required: ["fact", "severity", "sourcePath", "shouldLiveOn"],
       },
@@ -117,7 +129,9 @@ const audited = map(args.clusters, (cluster) =>
 
 const reports = audited.filter(Boolean);
 return {
-  loadBearingDrops: reports.flatMap((r) => r.drops.filter((d) => d.severity === "load-bearing")),
+  loadBearingDrops: reports.flatMap((r) =>
+    r.drops.filter((d) => d.severity === "load-bearing"),
+  ),
   allReports: reports,
 };
 ```
@@ -131,7 +145,8 @@ Decides whether the wiki retrieves ≥ the v2 corpus. The two memory sets per tu
 ```ts
 export const meta = {
   name: "memory-v3-blind-judge",
-  description: "Blind A/B content judge: per mined turn, score which memory set better covers what the reply needed.",
+  description:
+    "Blind A/B content judge: per mined turn, score which memory set better covers what the reply needed.",
   phases: [{ title: "judge" }],
 };
 

--- a/skills/vellum-memory-v3-migration/references/workflows.md
+++ b/skills/vellum-memory-v3-migration/references/workflows.md
@@ -1,0 +1,180 @@
+# Workflow templates
+
+The heavy stages — authoring, loss-audit, blind-judge — fan out through the native workflow engine. These are **templates the assistant adapts and passes to the `run_workflow` tool**; the skill does not (and cannot) launch a workflow itself. Read the engine's own `workflows` skill before launching, then adapt the prompt wording to your taxonomy.
+
+## Engine contract (violating any of these fails the run silently)
+
+- The script is **synchronous** — never `await`. Host calls (`agent`/`leaf`/`map`/`parallel`/`pipeline`) return their value directly; an `async` script deadlocks on its second host call.
+- `meta` must be a **pure literal** — no variables, calls, or template strings. It's parsed statically.
+- The body must **`return`** its result (it runs as a function body; a bare trailing expression is discarded).
+- No `Date.now()` / `Math.random()` / argless `new Date()` — they throw in the sandbox. Pass timestamps/seeds via `args`.
+- Leaves get `file_read` / `file_list` / `recall` as baseline. `file_write` is granted only if you declare it in `capabilities.tools`, and resolves relative to the workspace dir.
+- A failed leaf inside `map`/`parallel` comes back as `null` (the batch survives); an `agent()` call throws and fails the whole run. Use `map` + `.filter(Boolean)` so one bad cluster doesn't sink the run.
+- Caps: 500 leaves/run, 6 concurrent, 3 runs concurrent (config, no flag). Cluster-grain keeps you well under. Shard across runs only if clusters exceed a few hundred; resume replays completed leaves after an interruption.
+
+---
+
+## 1. Author clusters (write staged articles)
+
+Launch with `capabilities: { tools: ["file_write"] }`. One leaf per cluster — each reads its cluster's source pages and writes that cluster's whole article set into `.mv3/staging/`. (If the assistant has an established writing style worth preserving, add `persona: true` to the leaf opts and the run capabilities — but most migrations don't need it, and it is the more expensive path.)
+
+```ts
+export const meta = {
+  name: "memory-v3-author-clusters",
+  description: "Author one v3 wiki article-set per topic cluster into the staging tree, with provenance.",
+  phases: [{ title: "author" }],
+};
+
+phase("author");
+
+const results = map(args.clusters, (cluster) =>
+  leaf(
+    [
+      "You are reorganizing a cluster of old memory pages into the v3 wiki format. Convert one topic cluster",
+      "of old v2 pages into v3 articles. This is a RELOCATION, not a fresh summary: preserve every",
+      "distinct fact, quote, date, and detail; merge only co-located near-verbatim restatements.",
+      "",
+      `## Cluster: ${cluster.id}   (hub: ${cluster.hubSlug})`,
+      "Source pages (read each in full with file_read before writing):",
+      ...cluster.sourcePaths.map((p) => `  - ${p}`),
+      "",
+      "## The v3 article shape you must produce",
+      args.principles, // paste references/v3-wiki-principles.md (or its load-bearing rules)
+      "",
+      "## Output",
+      `Write the cluster's full article set into ${args.stagingDir}/ as flat-slug .md files (a hub`,
+      "article with kind:index if needed, plus one article per topic/event). Every article: lead-as-card",
+      "+ named ## sections, flat slug, main: = the hub, links: annotated, NO summary:, status: draft.",
+      `Then write provenance to ${args.provenanceDir}/${cluster.id}.json as`,
+      '  [{ "slug": "<staged slug>", "sources": ["<snapshot path>", ...] }]',
+      'Every source path for this cluster must appear under some article (or slug "unrouted").',
+      "Return one-line JSON: { cluster, articlesWritten, sourcesConsumed }.",
+    ].join("\n"),
+    { label: `author:${cluster.id}` },
+  ),
+);
+
+const authored = results.filter(Boolean);
+return {
+  clustersRequested: args.clusters.length,
+  clustersAuthored: authored.length,
+  failed: args.clusters.map((c) => c.id).filter((_, i) => results[i] === null),
+  summaries: authored,
+};
+```
+
+---
+
+## 2. Loss audit (schema leaves, read-only)
+
+Read-only — no `file_write`. A cheap, impartial reader panel; launch with no side-effecting capabilities. One leaf per cluster reads source-vs-staged and reports drops; you patch `[load-bearing]` drops verbatim afterward.
+
+```ts
+export const meta = {
+  name: "memory-v3-loss-audit",
+  description: "Per-cluster reader panel: list substance present in the v2 sources but missing/weakened in the staged wiki.",
+  phases: [{ title: "audit" }],
+};
+
+const DROP_SCHEMA = {
+  type: "object",
+  properties: {
+    cluster: { type: "string" },
+    drops: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          fact: { type: "string", description: "the specific quote/date/number/detail that is missing or weakened" },
+          severity: { type: "string", enum: ["load-bearing", "secondary", "incidental"] },
+          sourcePath: { type: "string" },
+          shouldLiveOn: { type: "string", description: "staged slug + section where it belongs" },
+        },
+        required: ["fact", "severity", "sourcePath", "shouldLiveOn"],
+      },
+    },
+  },
+  required: ["cluster", "drops"],
+};
+
+phase("audit");
+
+const audited = map(args.clusters, (cluster) =>
+  leaf(
+    [
+      `Audit cluster "${cluster.id}" for information loss. Read each SOURCE page and each STAGED article`,
+      "in full. List every substantive fact, quote, date, number, or detail that is present in a source",
+      "but absent or materially weakened in the staged articles. Be strict; err toward listing.",
+      "",
+      "Sources:",
+      ...cluster.sourcePaths.map((p) => `  - ${p}`),
+      "Staged:",
+      ...cluster.stagedPaths.map((p) => `  - ${p}`),
+    ].join("\n"),
+    { label: `audit:${cluster.id}`, schema: DROP_SCHEMA },
+  ),
+);
+
+const reports = audited.filter(Boolean);
+return {
+  loadBearingDrops: reports.flatMap((r) => r.drops.filter((d) => d.severity === "load-bearing")),
+  allReports: reports,
+};
+```
+
+---
+
+## 3. Blind judge (schema leaves, the ship gate)
+
+Decides whether the wiki retrieves ≥ the v2 corpus. The two memory sets per turn are built **outside** the workflow (the retrieval/eval step — see `eval-gate.md`), then passed in as blinded packets. Each leaf judges one turn without knowing which side is which.
+
+```ts
+export const meta = {
+  name: "memory-v3-blind-judge",
+  description: "Blind A/B content judge: per mined turn, score which memory set better covers what the reply needed.",
+  phases: [{ title: "judge" }],
+};
+
+const VERDICT_SCHEMA = {
+  type: "object",
+  properties: {
+    turn: { type: "string" },
+    winner: { type: "string", enum: ["A", "B", "tie"] },
+    scoreA: { type: "number" },
+    scoreB: { type: "number" },
+    why: { type: "string" },
+  },
+  required: ["turn", "winner", "scoreA", "scoreB", "why"],
+};
+
+phase("judge");
+
+// args.packets: [{ turn, context, userMessage, reply, setA, setB }]
+// A/B are pre-shuffled per turn outside the workflow; the unblinding key is kept separately.
+const verdicts = map(args.packets, (p) =>
+  leaf(
+    [
+      "You are a blind judge. Score each memory set 0-10 on ONE question: does this content cover what",
+      "the reply actually needed? Credit the specific facts, named concepts, verbatim quotes, dates, and",
+      "details the reply used or echoed. Coverage dominates; never prefer a smaller set that",
+      "is missing needed content over a larger one that has it. Tie-break on noise. Ignore formatting and",
+      "page-vs-section shape. You do not know which system produced which set.",
+      "",
+      `### turn ${p.turn}`,
+      `Recent context:\n${p.context}`,
+      `User:\n${p.userMessage}`,
+      `Reply (ground truth for what memory was needed):\n${p.reply}`,
+      `\n--- Memory set A ---\n${p.setA}`,
+      `\n--- Memory set B ---\n${p.setB}`,
+    ].join("\n"),
+    { label: `judge:${p.turn}`, schema: VERDICT_SCHEMA },
+  ),
+);
+
+const v = verdicts.filter(Boolean);
+return {
+  judged: v.length,
+  // Caller maps A/B back to v2/wiki via the unblinding key, then tallies wins.
+  verdicts: v,
+};
+```

--- a/skills/vellum-memory-v3-migration/references/workflows.md
+++ b/skills/vellum-memory-v3-migration/references/workflows.md
@@ -5,7 +5,7 @@ The heavy stages — authoring, loss-audit, blind-judge — fan out through the 
 ## Engine contract (violating any of these fails the run silently)
 
 - The script is **synchronous** — never `await`. Host calls (`agent`/`leaf`/`map`/`parallel`/`pipeline`) return their value directly; an `async` script deadlocks on its second host call.
-- `meta` must be a **pure literal** — no variables, calls, or template strings. It's parsed statically.
+- `meta` must be a **pure literal with only `name` + `description`** — no variables, calls, template strings, or nested objects/arrays. The extractor captures up to the **first `}`**, so any nested brace (e.g. a `phases:` array) truncates the literal and the run fails to launch before any leaf runs. Show progress with `phase(...)` calls in the body, not in `meta`.
 - The body must **`return`** its result (it runs as a function body; a bare trailing expression is discarded).
 - No `Date.now()` / `Math.random()` / argless `new Date()` — they throw in the sandbox. Pass timestamps/seeds via `args`.
 - Leaves get `file_read` / `file_list` / `recall` as baseline. `file_write` is granted only if you declare it in `capabilities.tools`, and resolves relative to the workspace dir.
@@ -23,7 +23,6 @@ export const meta = {
   name: "memory-v3-author-clusters",
   description:
     "Author one v3 wiki article-set per topic cluster into the staging tree, with provenance.",
-  phases: [{ title: "author" }],
 };
 
 phase("author");
@@ -75,7 +74,6 @@ export const meta = {
   name: "memory-v3-loss-audit",
   description:
     "Per-cluster reader panel: list substance present in the v2 sources but missing/weakened in the staged wiki.",
-  phases: [{ title: "audit" }],
 };
 
 const DROP_SCHEMA = {
@@ -147,7 +145,6 @@ export const meta = {
   name: "memory-v3-blind-judge",
   description:
     "Blind A/B content judge: per mined turn, score which memory set better covers what the reply needed.",
-  phases: [{ title: "judge" }],
 };
 
 const VERDICT_SCHEMA = {


### PR DESCRIPTION
## Summary

Adds a portable, instruction-only skill — `skills/vellum-memory-v3-migration/` — that lets any assistant reorganize an existing **memory-v2** concept corpus into the **memory-v3** section-grain "wiki": topical articles with a stand-alone lead (the retrieval card) and queryable `## ` sections. Plus the daemon-side `assistant memory v3 eval` command that powers the skill's pre-cutover eval gate.

Successor to `vellum-memory-v2-migration` (which backfills an *empty* corpus); this *reorganizes a populated one* (folders → flat slugs, `edges:` → annotated `links:`, bullets → lead + sections, over-fragmented stubs → topical articles under `kind: index` hubs).

## Why

Under v3, retrieval is section-grain: the model sees a compact card (lead + section names) plus a spotlighted matching section. A flat v2 page — no `## ` headings, a `summary:` field v3 ignores — collapses into one oversized lead with no sections: a bloated card that exposes nothing to match. v3 *reads* v2 pages but retrieves them poorly until they are reshaped. This skill is that reshape, done loss-proof.

## How it works

- **Skill = playbook, assistant = orchestrator.** A skill can't call `run_workflow` (no SkillHost facet + the import guard), so the SKILL.md instructs the assistant to launch the native workflow engine for the fan-out (one leaf per topic cluster keeps a large corpus under the engine's 500-agent-per-run cap).
- **Loss-proof by construction:** read-only snapshot → separate staging tree → provenance on every article → mandatory drop-check + verbatim patch → retrieval-eval gate → backed-up, reversible cutover. Live `memory/concepts/` is never touched until a verified cutover.
- **Eval gate:** `assistant memory v3 eval` mines recent user turns, retrieves the top pages from both corpora per turn (BM25F section needle ∪ dense cosine over freshly-embedded section vectors), and writes blinded A/B packets for a blind-judge workflow to score on coverage. In memory only — no Qdrant writes, no live-lane mutation. Because the staged corpus is a pure reorganization of the snapshot, the comparison needs no time-gating; it measures retrieval shape.

## What's in this PR

- `skills/vellum-memory-v3-migration/` — `SKILL.md` (10-step playbook, spec-clean per `lint-skill-spec`) + `references/` (article principles, loss-proofing contract, eval methodology, and three `run_workflow` templates).
- `assistant/src/memory/v3-eval/` + `runtime/routes/memory-eval-routes.ts` + the `memory v3 eval` CLI subcommand — the in-daemon eval handler, with unit tests (turn pairing, needle/dense retrieval, rendering, reproducible blinding).

## Status & follow-ups

The skill is spec-clean and the eval command is tested, but the pipeline hasn't been run end-to-end against a real corpus. Intentional follow-ups: a persistent section-vector cache so eval re-runs don't re-embed; the stdlib drop-check/provenance helpers; and a dry-run rehearsal.

## Risk

Low: a new, isolated, `user-invocable` skill directory + an additive, read-only-by-default CLI command (reads the DB + two corpus dirs, writes only the eval packet files). No existing behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
