### PR TITLE
Update Slack thinking status copy

### DIFF
--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
@@ -845,7 +845,7 @@ describe("Slack thinking status timing", () => {
           channel: channelId,
           threadTs,
           status: expect.any(String),
-          loadingMessages: ["Working on it..."],
+          loadingMessages: ["Thinking..."],
         },
       );
       const threadStatus = deliveredChannelReplies[0]!.payload
@@ -948,13 +948,13 @@ describe("Slack thinking status timing", () => {
         channel: channelId,
         threadTs,
         status: expect.any(String),
-        loadingMessages: ["Working on it..."],
+        loadingMessages: ["Thinking..."],
       },
       {
         channel: channelId,
         threadTs,
         status: expect.any(String),
-        loadingMessages: ["Working on it..."],
+        loadingMessages: ["Thinking..."],
       },
       {
         channel: channelId,

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -577,7 +577,7 @@ function createSlackThinkingStatusController(params: {
 }
 
 const SLACK_THINKING_MAX_DURATION_MS = 120_000;
-const SLACK_GENERIC_LOADING_MESSAGES = ["Working on it..."] as const;
+const SLACK_GENERIC_LOADING_MESSAGES = ["Thinking..."] as const;
 const SLACK_THINKING_STATUSES = ["is on it", "is working hard"] as const;
 
 function getRandomSlackThinkingStatus(): string {


### PR DESCRIPTION
## Summary

- Update Slack Assistants API loading message copy from "Working on it..." to "Thinking...".
- Adjust Slack thinking-status tests to expect the new copy.

## Original prompt

The user asked to update Slack status copy to say "Thinking..." instead of "Working on it..." and open a PR.