### PR TITLE
fix(cli): forward remote-model-profiles kill-switch on the Docker hatch path

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -616,6 +616,16 @@ export async function hatch(): Promise<void> {
     flagEnvVars.VELLUM_DISABLE_PLATFORM = "true";
   }
 
+  // Ambient-env-only kill-switch (no CLI flag): inject into flagEnvVars so the
+  // docker hatch path carries it into the assistant container, mirroring
+  // VELLUM_DISABLE_PLATFORM above.
+  const disableRemoteModelProfiles =
+    process.env.VELLUM_DISABLE_REMOTE_MODEL_PROFILES;
+  if (disableRemoteModelProfiles) {
+    flagEnvVars.VELLUM_DISABLE_REMOTE_MODEL_PROFILES =
+      disableRemoteModelProfiles;
+  }
+
   if (watch && remote !== "local" && remote !== "docker") {
     console.error(
       "Error: --watch is only supported for local and docker hatch targets.",

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -1390,6 +1390,10 @@ export async function hatchDocker(params: HatchDockerParams): Promise<void> {
       extraAssistantEnv.VELLUM_DISABLE_PLATFORM =
         flagEnvVars.VELLUM_DISABLE_PLATFORM;
     }
+    if (flagEnvVars.VELLUM_DISABLE_REMOTE_MODEL_PROFILES) {
+      extraAssistantEnv.VELLUM_DISABLE_REMOTE_MODEL_PROFILES =
+        flagEnvVars.VELLUM_DISABLE_REMOTE_MODEL_PROFILES;
+    }
     const hostDeviceId = getOrCreateHostDeviceId();
     extraAssistantEnv.VELLUM_DEVICE_ID = hostDeviceId;
     const extraGatewayEnv = {


### PR DESCRIPTION
## Summary
Fixes a second-launch-path gap from plan review for remote-managed-model-profiles.md.

**Gap:** VELLUM_DISABLE_REMOTE_MODEL_PROFILES was forwarded only on the packaged-binary path (local.ts, round-1 fix); the containerized/Docker hatch path (docker.ts extraAssistantEnv) mirrored only VELLUM_DISABLE_PLATFORM, so the kill-switch was a no-op for Docker deployments.
**Fix:** mirror the VELLUM_DISABLE_PLATFORM plumbing for VELLUM_DISABLE_REMOTE_MODEL_PROFILES so it reaches getDisableRemoteModelProfiles() inside the assistant container.