### PR TITLE
fix(profiles): getHatchSelectedManagedConnection reads the injected template source

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -1487,4 +1487,51 @@ describe("seedInferenceProfiles injected managed templates", () => {
       "Remote Economy",
     );
   });
+
+  test("hatch disable resolves the selected managed connection from the injected template source", () => {
+    // Source-of-truth guard: when an injected template changes a managed
+    // profile's connectionName (still a canonical managed connection, just a
+    // different one), the hatch "keep the selected managed connection active"
+    // decision must read that connection from the SAME injected map the
+    // materialization loop uses — not the built-in MANAGED_PROFILE_TEMPLATES.
+    //
+    // Setup: BYOK hatch (off-platform, isHatch + preserveActiveProfile) with
+    // activeProfile=balanced but no provider_connection on the on-disk entry,
+    // so the helper falls back to the template connectionName. The injected
+    // balanced template points at "gemini-managed" instead of the built-in
+    // "anthropic-managed". The materialization loop seeds balanced with
+    // gemini-managed, so balanced is the selected connection and must stay
+    // enabled; the other managed profiles get disabled.
+    const templates = cloneBuiltInTemplates();
+    templates.balanced.connectionName = "gemini-managed";
+
+    writeConfig({
+      llm: {
+        default: { provider: "anthropic", model: "claude-opus-4-7" },
+        profiles: {
+          // No provider_connection → forces the template-source fallback.
+          balanced: { source: "managed", provider: "anthropic" },
+        },
+        activeProfile: "balanced",
+      },
+    });
+
+    seedInferenceProfiles({
+      managedProfileTemplates: templates,
+      isHatch: true,
+      preserveActiveProfile: true,
+    });
+    const config = loadConfig();
+
+    expect(config.llm.profiles.balanced?.provider_connection).toBe(
+      "gemini-managed",
+    );
+    // Selected managed connection stays enabled because the helper resolved
+    // gemini-managed from the injected map (pre-fix it read anthropic-managed
+    // from the built-ins and balanced would have been disabled).
+    expect("status" in (config.llm.profiles.balanced ?? {})).toBe(false);
+    // Unselected managed profiles are disabled on the BYOK hatch.
+    expect(config.llm.profiles["quality-optimized"]?.status).toBe("disabled");
+    expect(config.llm.profiles["cost-optimized"]?.status).toBe("disabled");
+  });
 });

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -264,18 +264,19 @@ export function seedInferenceProfiles(
   //        boots and existing installs are never auto-disabled. A user
   //        re-enable persists across boots via the key-presence preservation
   //        below.
-  const hatchSelectedManagedConnection = getHatchSelectedManagedConnection(
-    llm,
-    profiles,
-    options,
-  );
-
   // Injected templates (from the platform model-profiles endpoint) override the
   // seeded content of the known managed keys; the key set itself is unchanged
   // (v1 scope guard — callers validate that the keys are a subset of the
   // built-ins). When omitted, the built-in templates are the source of truth.
   const managedTemplates =
     options.managedProfileTemplates ?? MANAGED_PROFILE_TEMPLATES;
+
+  const hatchSelectedManagedConnection = getHatchSelectedManagedConnection(
+    llm,
+    profiles,
+    options,
+    managedTemplates,
+  );
 
   for (const [name, template] of Object.entries(managedTemplates)) {
     if (preservedProfileNames.has(name)) continue;
@@ -462,6 +463,7 @@ function getHatchSelectedManagedConnection(
   llm: Record<string, unknown>,
   profiles: Record<string, Record<string, unknown>>,
   options: SeedInferenceProfilesOptions,
+  managedTemplates: Record<string, ManagedProfileTemplate>,
 ): string | undefined {
   if (!options.isHatch || options.preserveActiveProfile !== true) {
     return undefined;
@@ -487,8 +489,7 @@ function getHatchSelectedManagedConnection(
       : undefined;
   }
 
-  const templateConnection =
-    MANAGED_PROFILE_TEMPLATES[activeProfile]?.connectionName;
+  const templateConnection = managedTemplates[activeProfile]?.connectionName;
   return templateConnection && MANAGED_CONNECTION_NAMES.has(templateConnection)
     ? templateConnection
     : undefined;


### PR DESCRIPTION
## Summary
Fixes a source-of-truth coupling from plan review for remote-managed-model-profiles.md.

**Gap:** getHatchSelectedManagedConnection resolved the fallback connection from the built-in MANAGED_PROFILE_TEMPLATES while the materialization loop used the injected managedTemplates, so a remote payload changing a profile's connectionName could make the two disagree (inert in v1 but a latent coupling).
**Fix:** thread the resolved managedTemplates into the helper so both read from a single source of truth; behavior unchanged when no templates are injected.