### PR TITLE
fix(cli): forward remote-model-profiles kill-switch on the teleport-Docker path

### DIFF
--- a/cli/src/commands/hatch.ts
+++ b/cli/src/commands/hatch.ts
@@ -616,16 +616,6 @@ export async function hatch(): Promise<void> {
     flagEnvVars.VELLUM_DISABLE_PLATFORM = "true";
   }
 
-  // Ambient-env-only kill-switch (no CLI flag): inject into flagEnvVars so the
-  // docker hatch path carries it into the assistant container, mirroring
-  // VELLUM_DISABLE_PLATFORM above.
-  const disableRemoteModelProfiles =
-    process.env.VELLUM_DISABLE_REMOTE_MODEL_PROFILES;
-  if (disableRemoteModelProfiles) {
-    flagEnvVars.VELLUM_DISABLE_REMOTE_MODEL_PROFILES =
-      disableRemoteModelProfiles;
-  }
-
   if (watch && remote !== "local" && remote !== "docker") {
     console.error(
       "Error: --watch is only supported for local and docker hatch targets.",

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -1390,9 +1390,16 @@ export async function hatchDocker(params: HatchDockerParams): Promise<void> {
       extraAssistantEnv.VELLUM_DISABLE_PLATFORM =
         flagEnvVars.VELLUM_DISABLE_PLATFORM;
     }
-    if (flagEnvVars.VELLUM_DISABLE_REMOTE_MODEL_PROFILES) {
+    // Resolve the remote-model-profiles kill-switch from the ambient env here
+    // (not just flagEnvVars) because hatchDocker has callers — notably the
+    // Docker teleport path in teleport.ts — that don't pre-populate flagEnvVars.
+    // Resolving in this shared path forwards the switch for every caller.
+    const disableRemoteModelProfiles =
+      flagEnvVars.VELLUM_DISABLE_REMOTE_MODEL_PROFILES ??
+      process.env.VELLUM_DISABLE_REMOTE_MODEL_PROFILES;
+    if (disableRemoteModelProfiles) {
       extraAssistantEnv.VELLUM_DISABLE_REMOTE_MODEL_PROFILES =
-        flagEnvVars.VELLUM_DISABLE_REMOTE_MODEL_PROFILES;
+        disableRemoteModelProfiles;
     }
     const hostDeviceId = getOrCreateHostDeviceId();
     extraAssistantEnv.VELLUM_DEVICE_ID = hostDeviceId;


### PR DESCRIPTION
## Summary
Fixes a third-launch-path gap from plan review for remote-managed-model-profiles.md.

**Gap:** hatchDocker is also invoked by the Docker teleport path (teleport.ts) without flagEnvVars, so VELLUM_DISABLE_REMOTE_MODEL_PROFILES was dropped there.
**Fix:** resolve the kill-switch from the ambient env directly in the shared docker.ts launch path (flagEnvVars value, else process.env), so it reaches the assistant container for all hatchDocker callers (hatch + teleport). Removed the now-redundant hatch.ts pre-population.