### PR TITLE
fix(memory): guard isMemoryV3Live against configs missing the memory block

### DIFF
--- a/assistant/src/config/memory-v3-gate.ts
+++ b/assistant/src/config/memory-v3-gate.ts
@@ -7,5 +7,5 @@ import type { AssistantConfig } from "./schema.js";
  * existing assistants stay on v2 until the value is set explicitly.
  */
 export function isMemoryV3Live(config: AssistantConfig): boolean {
-  return config.memory.v3.live === true;
+  return config.memory?.v3?.live === true;
 }


### PR DESCRIPTION
## Summary
- `isMemoryV3Live` dereferenced `config.memory.v3.live` directly; when a config lacks the `memory` block it threw a `TypeError`. That throw fires at `loop.ts:1274` in the hot path of every agent-loop turn (before the provider call), so the loop aborts the turn and the provider's `sendMessage` is never invoked — the "zero calls / zero usage / empty content" failure signature.
- Optional-chain the gate (`config.memory?.v3?.live === true`) so a missing `memory`/`v3` returns `false` — matching the schema default and the pre-#35173 flag-absent behavior, and restoring the robustness the old `isAssistantFeatureFlagEnabled` path had. Behavior is byte-identical in production, where the config is always fully schema-parsed. Mirrors the existing `config.memory?.segmentation` convention in `schema.ts`.
- Fixes the main-branch CI "Test" job failures across 10 files (agent-loop override/callsite/overflow, leaf-runner, memory-retrieval-hook, workspace-injection, etc.) at the single chokepoint, with zero test churn.

## Original prompt
Fix the specific CI failure in the "Test" job of CI Main Assistant Checks (run 27720798068, job 82005426491). Investigation traced it to #35173, which moved the memory-v3 live gate to `config.memory.v3.live` via a new `isMemoryV3Live` helper that — unlike the feature-flag check it replaced — throws when a config omits the `memory` block, breaking every AgentLoop-based test that mocks a partial config. Scope was limited to fixing that one failing job.