### PR TITLE
feat(llm): add GLM-5.2 via OpenRouter

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -1148,6 +1148,18 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsToolUse: false,
         pricing: { inputPer1mTokens: 0.2, outputPer1mTokens: 1.1 },
       },
+      // Z.ai
+      {
+        id: "z-ai/glm-5.2",
+        displayName: "GLM-5.2",
+        contextWindowTokens: 1048576,
+        maxOutputTokens: 131072,
+        supportsThinking: true,
+        supportsCaching: false,
+        supportsVision: false,
+        supportsToolUse: true,
+        pricing: { inputPer1mTokens: 1.4, outputPer1mTokens: 4.4 },
+      },
       // Mistral
       {
         id: "mistralai/mistral-medium-3",

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -511,6 +511,14 @@ export const MODELS_BY_PROVIDER = {
       maxOutputTokens: 1_000_000,
     },
     {
+      id: "z-ai/glm-5.2",
+      displayName: "GLM-5.2",
+      contextWindowTokens: 1_048_576,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 131_072,
+      supportsThinking: true,
+    },
+    {
       id: "mistralai/mistral-medium-3",
       displayName: "Mistral Medium 3",
       contextWindowTokens: 131_072,

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -1187,6 +1187,22 @@
           }
         },
         {
+          "id": "z-ai/glm-5.2",
+          "displayName": "GLM-5.2",
+          "contextWindowTokens": 1048576,
+          "maxOutputTokens": 131072,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": false,
+          "supportsVision": false,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 1.4,
+            "outputPer1mTokens": 4.4
+          }
+        },
+        {
           "id": "mistralai/mistral-medium-3",
           "displayName": "Mistral Medium 3",
           "contextWindowTokens": 131072,


### PR DESCRIPTION
## Summary
- Add `z-ai/glm-5.2` to the OpenRouter provider in the daemon model catalog: 1M context window (`1048576`), `131072` max output, reasoning (`high`/`xhigh`) and tool use enabled, text-only, priced at $1.40 in / $4.40 out per 1M tokens (OpenRouter list rates).
- Follows the existing non-Anthropic OpenRouter convention: `supportsCaching: false` (the OpenAI-compat path Vellum uses for non-`anthropic/*` slugs emits no cache_control breakpoints) and no `maxEffort` (OpenRouter's provider-wide `xhigh` ceiling already matches GLM-5.2's documented cap, and no sibling sets it).
- Regenerate `meta/llm-provider-catalog.json` via `sync:llm-catalog` and mirror the entry into the hand-maintained web client catalog so both parity guards (`llm-catalog-parity.test.ts`, `llm-model-catalog.test.ts`) stay green.

## Original prompt
Add support for GLM-5.2 (Z.ai's reasoning model, OpenRouter slug `z-ai/glm-5.2`) so it's selectable as an OpenRouter-served model. Specs sourced from the OpenRouter model page / API: 1M context, reasoning + tool use, text-only, $1.40/$4.40 per 1M. The codebase is catalog-driven, so this is a data addition (no provider/routing code changes needed).

## Verification
- `bun test src/__tests__/llm-catalog-parity.test.ts` (daemon) — 16 pass; includes pricing.ts resolution for the new model.
- `bun test src/assistant/llm-model-catalog.test.ts` (web) — 26 pass; enforces exact id/order/field parity.
- `bunx tsc --noEmit` (assistant) — clean.