### PR TITLE
fix(web/assistant): gate lifecycle reset on the assistant's own authority

### DIFF
--- a/clients/web/src/assistant/lifecycle-service.test.ts
+++ b/clients/web/src/assistant/lifecycle-service.test.ts
@@ -463,6 +463,79 @@ describe("lifecycleService — bootstrap branches", () => {
     });
   });
 
+  test("gateway-auth mode does NOT reset on a platform sessionStatus flip to unauthenticated", async () => {
+    // Local (gateway) and platform are independent session authorities:
+    // a platform identity loss must not tear down a local lifecycle.
+    isGatewayAuthModeMock.mockImplementation(() => true);
+
+    // Drive into the gateway-auth active (self-hosted/local) state.
+    lifecycleService.setInputs({
+      ...baseInputs,
+      queryClient: makeQueryClient(),
+    });
+    await lifecycleService.respondToInputs();
+    const activeBefore = useResolvedAssistantsStore.getState().activeAssistantId;
+    expect(useAssistantLifecycleStore.getState().assistantState.kind).toBe(
+      "active",
+    );
+
+    // Flip the platform session unauthenticated and reconcile — the
+    // gateway authority drives the lifecycle, so no reset happens.
+    lifecycleService.setInputs({
+      ...baseInputs,
+      sessionStatus: "unauthenticated",
+      queryClient: makeQueryClient(),
+    });
+    await lifecycleService.respondToInputs();
+
+    expect(getAssistantMock).not.toHaveBeenCalled();
+    const state = useAssistantLifecycleStore.getState().assistantState;
+    expect(state.kind).toBe("active");
+    if (state.kind === "active") {
+      expect(state.isLocal).toBe(true);
+    }
+    expect(useResolvedAssistantsStore.getState().activeAssistantId).toBe(
+      activeBefore,
+    );
+  });
+
+  test("platform mode (not gateway-auth) still resets on a sessionStatus flip to unauthenticated", async () => {
+    // Drive into an active state through the platform path.
+    getAssistantMock.mockImplementationOnce(async () => ({
+      ok: true,
+      status: 200,
+      data: {
+        id: "asst-platform-reset",
+        status: "active",
+        is_local: false,
+        maintenance_mode: { enabled: false },
+      },
+    }));
+    lifecycleService.setInputs({
+      ...baseInputs,
+      queryClient: makeQueryClient(),
+    });
+    await lifecycleService.checkAssistant();
+    expect(useAssistantLifecycleStore.getState().assistantState.kind).toBe(
+      "active",
+    );
+
+    // Platform identity loss (not gateway-auth) still resets the lifecycle.
+    lifecycleService.setInputs({
+      ...baseInputs,
+      sessionStatus: "unauthenticated",
+      queryClient: makeQueryClient(),
+    });
+    await lifecycleService.respondToInputs();
+
+    expect(
+      useResolvedAssistantsStore.getState().activeAssistantId,
+    ).toBeNull();
+    expect(useAssistantLifecycleStore.getState().assistantState).toEqual({
+      kind: "loading",
+    });
+  });
+
   test("remote gateway short-circuit preserves a public path prefix", async () => {
     isGatewayAuthModeMock.mockImplementation(() => true);
     isRemoteGatewayModeMock.mockImplementation(() => true);

--- a/clients/web/src/assistant/lifecycle-service.ts
+++ b/clients/web/src/assistant/lifecycle-service.ts
@@ -229,6 +229,16 @@ class AssistantLifecycleService {
    */
   async respondToInputs(): Promise<void> {
     if (!this.ready) return;
+    // Local (gateway) and platform are independent session authorities —
+    // a platform-session loss must not reset a local lifecycle. The
+    // gateway authority is evaluated before the platform-identity reset
+    // below so a `sessionStatus` flip to `"unauthenticated"` can't tear
+    // down a local assistant; gateway-auth drives the lifecycle from its
+    // own token.
+    if (isGatewayAuthMode()) {
+      this.applyGatewayAuthShortCircuit();
+      return;
+    }
     if (!isAuthenticated(this.inputs.sessionStatus)) {
       // Logout / pre-auth boot — same reset as `resetForLogout` but
       // reachable from the input-driven path for token-expiry style
@@ -237,10 +247,6 @@ class AssistantLifecycleService {
       return;
     }
 
-    if (isGatewayAuthMode()) {
-      this.applyGatewayAuthShortCircuit();
-      return;
-    }
     if (this.inputs.hasPlatformSession) {
       setSelfHostedConnection(null);
     }


### PR DESCRIPTION
## Summary
- Reorder lifecycle `respondToInputs()` so gateway-auth (local) is evaluated before the platform `isAuthenticated` reset.
- A platform-session loss can no longer reset a local assistant lifecycle — structural generalization of PR #35152.

Part of plan: auth-session-slices.md (PR 2 of 8)