### PR TITLE
feat(web/auth): add per-assistant canReachAssistant connection predicate

### DIFF
--- a/clients/web/src/assistant/can-reach-assistant.test.ts
+++ b/clients/web/src/assistant/can-reach-assistant.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { LockfileAssistant } from "@/lib/local-mode";
+import type { PlatformSessionStatus } from "@/stores/session-status";
+
+// The hosting-mode functions read runtime config (injected globals, env), so
+// drive them off plain flags the tests set per-case. `isLocalAssistant` /
+// `isPlatformAssistant` keep the real classification logic over the fixture's
+// `cloud`/`resources` fields, matching the auth-store test's mock style.
+let mockIsLocalMode = false;
+let mockIsRemoteGatewayMode = false;
+
+mock.module("@/lib/local-mode", () => ({
+  isLocalMode: () => mockIsLocalMode,
+  isRemoteGatewayMode: () => mockIsRemoteGatewayMode,
+  isLocalAssistant: (a: {
+    cloud?: string;
+    resources?: { gatewayPort?: number };
+  }) => a.cloud !== "vellum" && a.resources?.gatewayPort != null,
+  isPlatformAssistant: (a: { cloud?: string }) => a.cloud === "vellum",
+}));
+
+const { canReachAssistant } = await import("@/assistant/can-reach-assistant");
+
+const localAssistant: LockfileAssistant = {
+  assistantId: "local-a",
+  cloud: "local",
+  resources: { gatewayPort: 51234, daemonPort: 51235 },
+};
+
+const platformAssistant: LockfileAssistant = {
+  assistantId: "platform-a",
+  cloud: "vellum",
+};
+
+function reach(
+  a: LockfileAssistant,
+  gatewayTokenPresent: boolean,
+  platformSession: PlatformSessionStatus = "absent",
+): boolean {
+  return canReachAssistant(a, { gatewayTokenPresent, platformSession });
+}
+
+beforeEach(() => {
+  mockIsLocalMode = false;
+  mockIsRemoteGatewayMode = false;
+});
+
+describe("canReachAssistant", () => {
+  describe("local mode + local assistant", () => {
+    beforeEach(() => {
+      mockIsLocalMode = true;
+    });
+
+    test("reachable with a gateway token", () => {
+      expect(reach(localAssistant, true)).toBe(true);
+    });
+
+    test("unreachable without a gateway token", () => {
+      expect(reach(localAssistant, false)).toBe(false);
+    });
+  });
+
+  describe("remote-gateway mode", () => {
+    beforeEach(() => {
+      mockIsRemoteGatewayMode = true;
+    });
+
+    test("reachable with a gateway token", () => {
+      expect(reach(localAssistant, true)).toBe(true);
+    });
+
+    test("unreachable without a gateway token", () => {
+      expect(reach(localAssistant, false)).toBe(false);
+    });
+  });
+
+  describe("platform-hosted assistant", () => {
+    test("reachable when the platform session is present", () => {
+      expect(reach(platformAssistant, false, "present")).toBe(true);
+    });
+
+    // A gateway token must never stand in for a platform session: with no live
+    // session the assistant is unreachable regardless of the token.
+    test.each<PlatformSessionStatus>(["absent", "unknown"])(
+      "never reachable for platformSession %s",
+      (status) => {
+        expect(reach(platformAssistant, true, status)).toBe(false);
+        expect(reach(platformAssistant, false, status)).toBe(false);
+      },
+    );
+  });
+
+  // A platform-hosted assistant while the app is in local mode: local mode does
+  // not short-circuit it (the local branch only matches local assistants), so
+  // it still falls through to the platform-session check.
+  describe("platform-hosted assistant in local mode", () => {
+    beforeEach(() => {
+      mockIsLocalMode = true;
+    });
+
+    test("reachable when the platform session is present", () => {
+      expect(reach(platformAssistant, false, "present")).toBe(true);
+    });
+
+    test("unreachable when the platform session is absent", () => {
+      expect(reach(platformAssistant, false, "absent")).toBe(false);
+    });
+  });
+});

--- a/clients/web/src/assistant/can-reach-assistant.ts
+++ b/clients/web/src/assistant/can-reach-assistant.ts
@@ -1,0 +1,38 @@
+import {
+  isLocalAssistant,
+  isLocalMode,
+  isPlatformAssistant,
+  isRemoteGatewayMode,
+  type LockfileAssistant,
+} from "@/lib/local-mode";
+import {
+  hasLivePlatformSession,
+  type PlatformSessionStatus,
+} from "@/stores/session-status";
+
+/**
+ * The connection signals `canReachAssistant` reasons over, passed in rather
+ * than read from a store so the predicate stays pure and unit-testable and can
+ * be called from imperative paths.
+ */
+export interface ReachabilitySignals {
+  /** `getGatewayToken() !== null` — a minted gateway token is present. */
+  gatewayTokenPresent: boolean;
+  platformSession: PlatformSessionStatus;
+}
+
+/**
+ * Can the app currently reach this assistant? The credential depends on hosting
+ * type: a gateway token for local / remote-gateway assistants, a live platform
+ * session for platform-hosted ones. Mirrors the interceptor routing in
+ * `api-interceptors.ts`.
+ */
+export function canReachAssistant(
+  a: LockfileAssistant,
+  s: ReachabilitySignals,
+): boolean {
+  if (isRemoteGatewayMode()) return s.gatewayTokenPresent;
+  if (isLocalMode() && isLocalAssistant(a)) return s.gatewayTokenPresent;
+  if (isPlatformAssistant(a)) return hasLivePlatformSession(s.platformSession);
+  return false;
+}

--- a/clients/web/src/assistant/can-reach-assistant.ts
+++ b/clients/web/src/assistant/can-reach-assistant.ts
@@ -16,7 +16,14 @@ import {
  * be called from imperative paths.
  */
 export interface ReachabilitySignals {
-  /** `getGatewayToken() !== null` — a minted gateway token is present. */
+  /**
+   * Whether the gateway token currently valid for THIS target assistant is
+   * present. Callers MUST supply a per-assistant signal: a bare
+   * `getGatewayToken() !== null` is incorrect when multiple local assistants
+   * exist, because a token minted for a different assistant would make this
+   * assistant report reachable. The reactive `useCanReachAssistant` hook
+   * derives this from the per-assistant lifecycle connection state.
+   */
   gatewayTokenPresent: boolean;
   platformSession: PlatformSessionStatus;
 }


### PR DESCRIPTION
## Summary
- Add pure `canReachAssistant(assistant, signals)` predicate: gateway token for local/remote-gateway, platform session for platform-hosted.
- Additive only — no consumers yet, zero behavior change. First primitive of the auth identity/connection split.

Part of plan: auth-session-slices.md (PR 1 of 8)