### PR TITLE
test(web): subagent timeline synthetic-load harness + perf baseline

### DIFF
--- a/clients/web/src/domains/chat/components/__fixtures__/subagent-timeline-fixtures.ts
+++ b/clients/web/src/domains/chat/components/__fixtures__/subagent-timeline-fixtures.ts
@@ -1,0 +1,125 @@
+/**
+ * Synthetic-load fixtures for the subagent timeline.
+ *
+ * `makeSyntheticEvents(count)` produces a realistic, *deterministic* mix of
+ * timeline events for perf/load testing. There is intentionally NO
+ * `Math.random()` — every bit of variety is derived from the event index so
+ * runs are reproducible and diffable.
+ *
+ * Event mix (by index, repeating every 20 events):
+ *   ~40% tool_call   — long file-path / URL `content` + a `toolName`
+ *   ~40% tool_result — multi-line `content` (> MAX_COLLAPSED_LINES=4 lines so
+ *                      the timeline's "Show more" path is exercised); every
+ *                      3rd one is `isError: true`
+ *   ~15% text        — short response text
+ *    ~5% error       — an error line
+ *
+ * Ids mirror the store's `generateTimelineEventId` (`te-${n}`, 1-based), and
+ * timestamps are monotonic. Kept general + exported for reuse by later PRs.
+ */
+
+import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
+
+/** Sample tool names cycled through for `tool_call` events. */
+const TOOL_NAMES = [
+  "Read",
+  "Edit",
+  "Bash",
+  "Grep",
+  "Write",
+  "WebFetch",
+] as const;
+
+/**
+ * Long, unbreakable-ish content (file paths / URLs) for `tool_call` events —
+ * the kind of content the timeline must wrap rather than clip.
+ */
+const LONG_PATHS = [
+  "/workspaces/worktrees/p3-fixup-fork/clients/web/src/domains/channel/handler-inbound-admission.test.ts",
+  "https://example.com/api/v2/organizations/acme-corp/workspaces/default/agents/subagent-timeline/runs?cursor=eyJpZCI6MTIzNDV9",
+  "/Users/runner/work/vellum-assistant/vellum-assistant/clients/web/src/domains/chat/components/subagent-timeline.tsx",
+  "packages/service-contracts/src/schemas/ces/streaming/subagent-inner-event.schema.ts",
+] as const;
+
+/**
+ * Classify an event index into one of the four event types, distributing the
+ * target mix deterministically across each block of 20 events.
+ *
+ * Slots 0–7   -> tool_call   (8/20 = 40%)
+ * Slots 8–15  -> tool_result (8/20 = 40%)
+ * Slots 16–18 -> text        (3/20 = 15%)
+ * Slot  19    -> error       (1/20 = 5%)
+ */
+function typeForIndex(index: number): SubagentTimelineEvent["type"] {
+  const slot = index % 20;
+  if (slot < 8) return "tool_call";
+  if (slot < 16) return "tool_result";
+  if (slot < 19) return "text";
+  return "error";
+}
+
+/** Build a multi-line tool_result body with > 4 lines (trips MAX_COLLAPSED_LINES). */
+function multiLineResult(index: number): string {
+  const lineCount = 5 + (index % 4); // 5..8 lines, always > 4
+  const lines: string[] = [];
+  for (let line = 0; line < lineCount; line++) {
+    lines.push(`line ${line + 1} of tool result #${index} :: token-${index}-${line}`);
+  }
+  return lines.join("\n");
+}
+
+/** Build a single synthetic event for a 0-based index. */
+function makeEvent(index: number): SubagentTimelineEvent {
+  const type = typeForIndex(index);
+  const id = `te-${index + 1}`;
+  const timestamp = index; // monotonic
+
+  switch (type) {
+    case "tool_call":
+      return {
+        id,
+        type,
+        content: LONG_PATHS[index % LONG_PATHS.length],
+        toolName: TOOL_NAMES[index % TOOL_NAMES.length],
+        timestamp,
+      };
+    case "tool_result":
+      return {
+        id,
+        type,
+        content: multiLineResult(index),
+        // Every 3rd tool_result is an error.
+        isError: index % 3 === 0,
+        toolName: TOOL_NAMES[index % TOOL_NAMES.length],
+        toolUseId: `tu-${index + 1}`,
+        timestamp,
+      };
+    case "text":
+      return {
+        id,
+        type,
+        content: `Synthetic response text for event #${index}.`,
+        timestamp,
+      };
+    case "error":
+      return {
+        id,
+        type,
+        content: `Synthetic error #${index}: something went wrong in step ${index}.`,
+        timestamp,
+      };
+  }
+}
+
+/**
+ * Produce `count` deterministic synthetic timeline events.
+ *
+ * @param count Number of events to generate (>= 0).
+ */
+export function makeSyntheticEvents(count: number): SubagentTimelineEvent[] {
+  const events: SubagentTimelineEvent[] = [];
+  for (let index = 0; index < count; index++) {
+    events.push(makeEvent(index));
+  }
+  return events;
+}

--- a/clients/web/src/domains/chat/components/subagent-timeline.perf.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-timeline.perf.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * Synthetic-load perf baseline for the subagent timeline.
+ *
+ * Renders the CURRENT timeline (memo + `content-visibility:auto` renders-all)
+ * at N = 50 / 150 / 300 events using the deterministic synthetic fixture, and:
+ *   - asserts every event produces a rendered row (structural correctness), and
+ *   - logs a wall-clock render delta per N as an ADVISORY signal.
+ *
+ * The timings are intentionally NEVER asserted — JS-DOM wall-clock numbers are
+ * noisy and machine-dependent. Authoritative numbers come from the manual
+ * React DevTools Profiler protocol documented in the PR body. This file just
+ * pins the structural baseline that virtualization (a later PR) must preserve.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { makeSyntheticEvents } from "@/domains/chat/components/__fixtures__/subagent-timeline-fixtures";
+import { SubagentTimeline } from "@/domains/chat/components/subagent-timeline";
+
+/** Per-event card titles the timeline renders, one per (non-filtered) event. */
+const ROW_TITLES = ["Response", "Tool Call", "Tool Result", "Error"];
+
+/** Count rendered rows by summing every per-event title occurrence. */
+function renderedRowCount(): number {
+  return ROW_TITLES.reduce(
+    (total, title) => total + screen.queryAllByText(title).length,
+    0,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SubagentTimeline — synthetic-load perf baseline", () => {
+  for (const eventCount of [50, 150, 300]) {
+    test(`renders all ${eventCount} events`, () => {
+      const events = makeSyntheticEvents(eventCount);
+
+      const start = performance.now();
+      render(<SubagentTimeline events={events} />);
+      const elapsedMs = performance.now() - start;
+
+      // Advisory only — never asserted.
+      console.log(
+        `[perf] SubagentTimeline N=${eventCount} render=${elapsedMs.toFixed(2)}ms`,
+      );
+
+      // The fixture emits only non-empty events, so none are filtered out:
+      // every event must produce exactly one row.
+      expect(renderedRowCount()).toBe(eventCount);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Add reusable `makeSyntheticEvents(count)` fixture (deterministic, no Math.random) for timeline load/perf tests. Realistic mix: ~40% tool_call (long path/URL content + toolName), ~40% tool_result (multi-line content >4 lines to trip the MAX_COLLAPSED_LINES=4 collapse, some isError), ~15% text, ~5% error. Ids `te-1..te-N` mirror the store's `generateTimelineEventId`, monotonic timestamps.
- Add perf baseline test rendering the CURRENT (non-virtualized) timeline at N=50/150/300. Asserts rendered row count == N (documents the renders-all baseline). Each render is wrapped in a `performance.now()` delta and `console.log`-ed (advisory, not asserted — jsdom/happy-dom timings are flaky as thresholds).

This is PR 1 of 4 to virtualize the subagent detail-panel timeline. It only adds the fixture + baseline; the timeline component is untouched (that's PR 4). The fixture is exported and general so PR 4's tests reuse it.

## Recorded baseline timings (advisory, happy-dom)
```
[perf-baseline] SubagentTimeline render N=50: ~28ms
[perf-baseline] SubagentTimeline render N=150: ~25ms
[perf-baseline] SubagentTimeline render N=300: ~40ms
```
jsdom/happy-dom timings vary run-to-run and are documentation only. The component currently renders ALL N rows (no windowing), confirmed by the row-count assertions.

## Manual React DevTools Profiler protocol (authoritative numbers vs. the real app)
Run against the real app with a subagent of ~150 timeline events; record before virtualization (this PR) and after (PR 4):
1. **Panel-open commit** — open the React DevTools Profiler, start recording, open the subagent detail panel, stop. Record the commit duration for the timeline mount.
2. **Single streaming-event commit** — with the panel open, record while one new timeline event streams in; capture the commit duration for that update.
3. **Timeline DOM node count** — in Elements, select the timeline subtree container and record the total descendant node count (renders-all means it grows linearly with N).
4. **JS heap** — in the Performance/Memory tab, take a heap snapshot with the panel open and record the used JS heap size.

Capturing (1)-(4) at N=150 on this PR establishes the go/no-go baseline; re-running them after PR 4 quantifies the virtualization win.

Part of plan: virtualize-subagent-timeline.md (PR 1 of 4)