### PR TITLE
feat(web/auth): reactive useCanReachAssistant derived from lifecycle state

### DIFF
--- a/clients/web/src/assistant/can-reach-assistant.test.ts
+++ b/clients/web/src/assistant/can-reach-assistant.test.ts
@@ -4,13 +4,17 @@ import type { LockfileAssistant } from "@/lib/local-mode";
 import type { PlatformSessionStatus } from "@/stores/session-status";
 
 // The hosting-mode functions read runtime config (injected globals, env), so
-// drive them off plain flags the tests set per-case. `isLocalAssistant` /
-// `isPlatformAssistant` keep the real classification logic over the fixture's
-// `cloud`/`resources` fields, matching the auth-store test's mock style.
+// drive them off plain flags the tests set per-case. Spread the real module so
+// every other `@/lib/local-mode` export the dependency graph pulls in (via the
+// auth store, which `can-reach-assistant` imports for the reactive hook) stays
+// available; only the four functions the predicate branches on are overridden.
 let mockIsLocalMode = false;
 let mockIsRemoteGatewayMode = false;
 
+const localModeActual = await import("@/lib/local-mode");
+
 mock.module("@/lib/local-mode", () => ({
+  ...localModeActual,
   isLocalMode: () => mockIsLocalMode,
   isRemoteGatewayMode: () => mockIsRemoteGatewayMode,
   isLocalAssistant: (a: {

--- a/clients/web/src/assistant/can-reach-assistant.test.tsx
+++ b/clients/web/src/assistant/can-reach-assistant.test.tsx
@@ -31,6 +31,9 @@ const { useAssistantLifecycleStore } = await import(
   "@/assistant/lifecycle-store"
 );
 const { useAuthStore } = await import("@/stores/auth-store");
+const { useResolvedAssistantsStore } = await import(
+  "@/stores/resolved-assistants-store"
+);
 
 const initialLifecycleState = useAssistantLifecycleStore.getState();
 const initialAuthState = useAuthStore.getState();
@@ -39,6 +42,14 @@ const localAssistant: LockfileAssistant = {
   assistantId: "local-a",
   cloud: "local",
   resources: { gatewayPort: 51234, daemonPort: 51235 },
+};
+
+// A second local assistant, distinct from `localAssistant`, used to prove that
+// the lifecycle's single connection only makes the *active* assistant reachable.
+const localAssistantB: LockfileAssistant = {
+  assistantId: "local-b",
+  cloud: "local",
+  resources: { gatewayPort: 61234, daemonPort: 61235 },
 };
 
 const platformAssistant: LockfileAssistant = {
@@ -55,6 +66,12 @@ function setLifecycle(assistantState: AssistantState): void {
   });
 }
 
+function setActiveAssistantId(activeAssistantId: string | null): void {
+  act(() => {
+    useResolvedAssistantsStore.setState({ activeAssistantId });
+  });
+}
+
 function setPlatformSession(platformSession: PlatformSessionStatus): void {
   act(() => {
     useAuthStore.setState({ ...initialAuthState, platformSession }, true);
@@ -66,6 +83,10 @@ beforeEach(() => {
   mockIsRemoteGatewayMode = false;
   useAssistantLifecycleStore.setState(initialLifecycleState, true);
   useAuthStore.setState(initialAuthState, true);
+  // Default the active assistant to the one the local-mode cases query, so the
+  // lifecycle connection is attributed to it; cases that need a mismatch (a
+  // non-active local assistant) override this explicitly.
+  setActiveAssistantId(localAssistant.assistantId);
 });
 
 afterEach(() => {
@@ -115,6 +136,60 @@ describe("useCanReachAssistant", () => {
       setPlatformSession("present");
       const { result } = renderHook(() => useCanReachAssistant(localAssistant));
       expect(result.current).toBe(false);
+    });
+
+    // The lifecycle store describes ONE active connection. When assistant A is
+    // the active assistant with a healthy connection, querying a *different*
+    // local assistant B must report unreachable — B has no primed connection,
+    // so the lifecycle signal (which belongs to A) must not leak to it.
+    test("a non-active local assistant is unreachable even when the active one is healthy", () => {
+      setActiveAssistantId(localAssistant.assistantId);
+      setLifecycle({ kind: "self_hosted", health: "healthy" });
+
+      const active = renderHook(() => useCanReachAssistant(localAssistant));
+      expect(active.result.current).toBe(true);
+
+      const nonActive = renderHook(() =>
+        useCanReachAssistant(localAssistantB),
+      );
+      expect(nonActive.result.current).toBe(false);
+    });
+
+    // Re-targeting the active assistant flips reachability: the same healthy
+    // lifecycle connection now belongs to B, so B becomes reachable.
+    test("re-renders to reachable when the queried assistant becomes the active one", () => {
+      setActiveAssistantId(localAssistant.assistantId);
+      setLifecycle({ kind: "self_hosted", health: "healthy" });
+      const { result } = renderHook(() =>
+        useCanReachAssistant(localAssistantB),
+      );
+      expect(result.current).toBe(false);
+
+      setActiveAssistantId(localAssistantB.assistantId);
+      expect(result.current).toBe(true);
+    });
+
+    // P2 #2: a self-hosted daemon that answered `/healthz` with a non-healthy
+    // status gets `health: "unhealthy"`. The lifecycle service treats that as
+    // reachable for active local states, so this hook must agree.
+    test("self_hosted health 'unhealthy' is reachable (degraded-but-responsive)", () => {
+      setLifecycle({ kind: "self_hosted", health: "unhealthy" });
+      const { result } = renderHook(() => useCanReachAssistant(localAssistant));
+      expect(result.current).toBe(true);
+    });
+
+    // ...but `unreachable` (the probe could not reach the daemon at all) is not.
+    test("self_hosted health 'unreachable' is not reachable", () => {
+      setLifecycle({ kind: "self_hosted", health: "unreachable" });
+      const { result } = renderHook(() => useCanReachAssistant(localAssistant));
+      expect(result.current).toBe(false);
+    });
+
+    // The same `unhealthy`-is-reachable semantics for an active local state.
+    test("active local health 'unhealthy' is reachable", () => {
+      setLifecycle({ kind: "active", isLocal: true, health: "unhealthy" });
+      const { result } = renderHook(() => useCanReachAssistant(localAssistant));
+      expect(result.current).toBe(true);
     });
   });
 

--- a/clients/web/src/assistant/can-reach-assistant.test.tsx
+++ b/clients/web/src/assistant/can-reach-assistant.test.tsx
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+import type { AssistantState } from "@/assistant/types";
+import type { LockfileAssistant } from "@/lib/local-mode";
+import type { PlatformSessionStatus } from "@/stores/session-status";
+
+// Hosting-mode functions read runtime config (injected globals, env), so drive
+// them off plain flags the tests set per-case — matching the pure predicate
+// test's mock style. Spread the real module so the auth-store dependency graph
+// (pulled in transitively by the hook) keeps every other `@/lib/local-mode`
+// export; only the four functions the predicate branches on are overridden.
+let mockIsLocalMode = true;
+let mockIsRemoteGatewayMode = false;
+
+const localModeActual = await import("@/lib/local-mode");
+
+mock.module("@/lib/local-mode", () => ({
+  ...localModeActual,
+  isLocalMode: () => mockIsLocalMode,
+  isRemoteGatewayMode: () => mockIsRemoteGatewayMode,
+  isLocalAssistant: (a: {
+    cloud?: string;
+    resources?: { gatewayPort?: number };
+  }) => a.cloud !== "vellum" && a.resources?.gatewayPort != null,
+  isPlatformAssistant: (a: { cloud?: string }) => a.cloud === "vellum",
+}));
+
+const { useCanReachAssistant } = await import("@/assistant/can-reach-assistant");
+const { useAssistantLifecycleStore } = await import(
+  "@/assistant/lifecycle-store"
+);
+const { useAuthStore } = await import("@/stores/auth-store");
+
+const initialLifecycleState = useAssistantLifecycleStore.getState();
+const initialAuthState = useAuthStore.getState();
+
+const localAssistant: LockfileAssistant = {
+  assistantId: "local-a",
+  cloud: "local",
+  resources: { gatewayPort: 51234, daemonPort: 51235 },
+};
+
+const platformAssistant: LockfileAssistant = {
+  assistantId: "platform-a",
+  cloud: "vellum",
+};
+
+function setLifecycle(assistantState: AssistantState): void {
+  act(() => {
+    useAssistantLifecycleStore.setState(
+      { ...initialLifecycleState, assistantState },
+      true,
+    );
+  });
+}
+
+function setPlatformSession(platformSession: PlatformSessionStatus): void {
+  act(() => {
+    useAuthStore.setState({ ...initialAuthState, platformSession }, true);
+  });
+}
+
+beforeEach(() => {
+  mockIsLocalMode = true;
+  mockIsRemoteGatewayMode = false;
+  useAssistantLifecycleStore.setState(initialLifecycleState, true);
+  useAuthStore.setState(initialAuthState, true);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useCanReachAssistant", () => {
+  describe("local assistant in local mode", () => {
+    test("reachable when lifecycle settled a healthy self_hosted connection", () => {
+      setLifecycle({ kind: "self_hosted", health: "healthy" });
+      const { result } = renderHook(() => useCanReachAssistant(localAssistant));
+      expect(result.current).toBe(true);
+    });
+
+    test("reachable when lifecycle is active + local and not flagged unreachable", () => {
+      setLifecycle({ kind: "active", isLocal: true, reachable: true });
+      const { result } = renderHook(() => useCanReachAssistant(localAssistant));
+      expect(result.current).toBe(true);
+    });
+
+    test.each<AssistantState>([
+      { kind: "loading" },
+      { kind: "initializing" },
+      { kind: "self_hosted", health: "unreachable" },
+      { kind: "active", isLocal: true, reachable: false },
+      { kind: "active", isLocal: true, health: "unreachable" },
+      { kind: "error", message: "boom" },
+    ])("unreachable for lifecycle state %o", (state) => {
+      setLifecycle(state);
+      const { result } = renderHook(() => useCanReachAssistant(localAssistant));
+      expect(result.current).toBe(false);
+    });
+
+    test("re-renders to reachable when the lifecycle connection resolves", () => {
+      setLifecycle({ kind: "initializing" });
+      const { result } = renderHook(() => useCanReachAssistant(localAssistant));
+      expect(result.current).toBe(false);
+
+      setLifecycle({ kind: "self_hosted", health: "healthy" });
+      expect(result.current).toBe(true);
+    });
+
+    // A platform session for THIS assistant must not stand in for the local
+    // connection: a local assistant is reachable only off its lifecycle state.
+    test("platformSession does not make a local assistant reachable", () => {
+      setLifecycle({ kind: "self_hosted", health: "unreachable" });
+      setPlatformSession("present");
+      const { result } = renderHook(() => useCanReachAssistant(localAssistant));
+      expect(result.current).toBe(false);
+    });
+  });
+
+  describe("remote-gateway mode", () => {
+    beforeEach(() => {
+      mockIsLocalMode = false;
+      mockIsRemoteGatewayMode = true;
+    });
+
+    test("reachable when the lifecycle resolved a healthy connection", () => {
+      setLifecycle({ kind: "self_hosted", health: "healthy" });
+      const { result } = renderHook(() => useCanReachAssistant(localAssistant));
+      expect(result.current).toBe(true);
+    });
+
+    test("unreachable before the lifecycle resolves", () => {
+      setLifecycle({ kind: "loading" });
+      const { result } = renderHook(() => useCanReachAssistant(localAssistant));
+      expect(result.current).toBe(false);
+    });
+  });
+
+  describe("platform-hosted assistant", () => {
+    beforeEach(() => {
+      mockIsLocalMode = false;
+    });
+
+    test("reachable when the platform session is present", () => {
+      setPlatformSession("present");
+      const { result } = renderHook(() =>
+        useCanReachAssistant(platformAssistant),
+      );
+      expect(result.current).toBe(true);
+    });
+
+    test.each<PlatformSessionStatus>(["absent", "unknown"])(
+      "unreachable when platformSession is %s",
+      (status) => {
+        setPlatformSession(status);
+        const { result } = renderHook(() =>
+          useCanReachAssistant(platformAssistant),
+        );
+        expect(result.current).toBe(false);
+      },
+    );
+
+    test("re-renders when the platform session changes", () => {
+      setPlatformSession("absent");
+      const { result } = renderHook(() =>
+        useCanReachAssistant(platformAssistant),
+      );
+      expect(result.current).toBe(false);
+
+      setPlatformSession("present");
+      expect(result.current).toBe(true);
+    });
+
+    // The lifecycle connection signal must not stand in for a platform session:
+    // a resolved local lifecycle cannot make a platform assistant reachable.
+    test("lifecycle connection does not make a platform assistant reachable", () => {
+      setLifecycle({ kind: "self_hosted", health: "healthy" });
+      setPlatformSession("absent");
+      const { result } = renderHook(() =>
+        useCanReachAssistant(platformAssistant),
+      );
+      expect(result.current).toBe(false);
+    });
+  });
+});

--- a/clients/web/src/assistant/can-reach-assistant.ts
+++ b/clients/web/src/assistant/can-reach-assistant.ts
@@ -8,6 +8,7 @@ import {
   type LockfileAssistant,
 } from "@/lib/local-mode";
 import { useAuthStore } from "@/stores/auth-store";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import {
   hasLivePlatformSession,
   type PlatformSessionStatus,
@@ -60,12 +61,26 @@ export function canReachAssistant(
  * connection for the *one* active assistant, so deriving from it keeps the
  * signal per-assistant.
  *
- * The connection counts as resolved when the lifecycle has settled a healthy
- * self-hosted phase, or an active local phase that has not been flagged
- * unreachable.
+ * The connection counts as resolved when the lifecycle has settled a
+ * self-hosted phase, or an active local phase, that has not been flagged
+ * unreachable. A degraded-but-responsive daemon reports `health:
+ * "unhealthy"` (the probe reached `/healthz` but it returned a non-healthy
+ * status) — the lifecycle service still treats that as reachable for active
+ * local states (`reachable = health === "healthy" || health === "unhealthy"`
+ * in `lifecycle-service.ts`), so this signal must agree: reachable unless the
+ * probe could not reach the daemon at all (`health === "unreachable"`, the
+ * only value `deriveLocalAssistantHealth` returns when the probe fails). The
+ * `sleeping` / `starting` / `crashed` statuses come only from the
+ * local-status fallback, never the self-hosted/active heartbeat path that
+ * feeds this signal, so excluding `"unreachable"` matches the service's
+ * active-local reachability exactly.
+ *
+ * Gating by active id happens in the hook (see {@link useCanReachAssistant}):
+ * the lifecycle store describes the *one* active connection, so this signal is
+ * only meaningful for the active assistant.
  */
 function lifecycleLocalReachable(state: AssistantState): boolean {
-  if (state.kind === "self_hosted") return state.health === "healthy";
+  if (state.kind === "self_hosted") return state.health !== "unreachable";
   if (state.kind === "active") {
     return (
       state.isLocal &&
@@ -82,12 +97,30 @@ function lifecycleLocalReachable(state: AssistantState): boolean {
  * pure predicate so the routing logic lives in exactly one place. The hook only
  * supplies the reactive signals — the local one from the lifecycle state, not
  * `getGatewayToken()` (see {@link lifecycleLocalReachable}).
+ *
+ * The lifecycle store describes only the *one* active connection (its token /
+ * primed gateway belong to whichever assistant the lifecycle last activated),
+ * and the active assistant id is tracked separately in the resolved-assistants
+ * store. So the lifecycle signal is meaningful for local reachability only when
+ * the queried assistant *is* the active assistant: querying a different local
+ * assistant must report `false`, because we hold no primed connection for it.
+ * The id gate applies to local mode; remote-gateway mode has a single shared
+ * gateway (active id `"self"`), so its branch keeps using the lifecycle signal
+ * directly.
  */
 export function useCanReachAssistant(a: LockfileAssistant): boolean {
   const platformSession = useAuthStore.use.platformSession();
   const assistantState = useAssistantLifecycleStore.use.assistantState();
+  const activeAssistantId = useResolvedAssistantsStore.use.activeAssistantId();
+  // In local mode the lifecycle's single connection belongs to the active
+  // assistant only; a non-active local assistant has no primed connection, so
+  // its lifecycle-derived local reachability must be false.
+  const lifecycleBelongsToTarget =
+    isRemoteGatewayMode() || activeAssistantId === a.assistantId;
   return canReachAssistant(a, {
-    gatewayTokenPresent: lifecycleLocalReachable(assistantState),
+    gatewayTokenPresent: lifecycleBelongsToTarget
+      ? lifecycleLocalReachable(assistantState)
+      : false,
     platformSession,
   });
 }

--- a/clients/web/src/assistant/can-reach-assistant.ts
+++ b/clients/web/src/assistant/can-reach-assistant.ts
@@ -1,3 +1,5 @@
+import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
+import type { AssistantState } from "@/assistant/types";
 import {
   isLocalAssistant,
   isLocalMode,
@@ -5,6 +7,7 @@ import {
   isRemoteGatewayMode,
   type LockfileAssistant,
 } from "@/lib/local-mode";
+import { useAuthStore } from "@/stores/auth-store";
 import {
   hasLivePlatformSession,
   type PlatformSessionStatus,
@@ -42,4 +45,49 @@ export function canReachAssistant(
   if (isLocalMode() && isLocalAssistant(a)) return s.gatewayTokenPresent;
   if (isPlatformAssistant(a)) return hasLivePlatformSession(s.platformSession);
   return false;
+}
+
+/**
+ * Per-assistant local reachability derived from the reactive lifecycle state —
+ * the `gatewayTokenPresent` signal `canReachAssistant` reasons over for the
+ * local / remote-gateway branches.
+ *
+ * Read from the lifecycle store rather than `getGatewayToken()`, which is
+ * non-reactive module/localStorage state: a hook reading it would not re-render
+ * when the connection comes or goes. Just as importantly, the token is global,
+ * so a bare `getGatewayToken() !== null` would make assistant B report reachable
+ * off a token minted for assistant A. The lifecycle store tracks the reachable
+ * connection for the *one* active assistant, so deriving from it keeps the
+ * signal per-assistant.
+ *
+ * The connection counts as resolved when the lifecycle has settled a healthy
+ * self-hosted phase, or an active local phase that has not been flagged
+ * unreachable.
+ */
+function lifecycleLocalReachable(state: AssistantState): boolean {
+  if (state.kind === "self_hosted") return state.health === "healthy";
+  if (state.kind === "active") {
+    return (
+      state.isLocal &&
+      state.reachable !== false &&
+      state.health !== "unreachable"
+    );
+  }
+  return false;
+}
+
+/**
+ * Reactive `canReachAssistant`: subscribes to the per-assistant lifecycle state
+ * and the platform identity, then delegates the hosting-branch decision to the
+ * pure predicate so the routing logic lives in exactly one place. The hook only
+ * supplies the reactive signals — the local one from the lifecycle state, not
+ * `getGatewayToken()` (see {@link lifecycleLocalReachable}).
+ */
+export function useCanReachAssistant(a: LockfileAssistant): boolean {
+  const platformSession = useAuthStore.use.platformSession();
+  const assistantState = useAssistantLifecycleStore.use.assistantState();
+  return canReachAssistant(a, {
+    gatewayTokenPresent: lifecycleLocalReachable(assistantState),
+    platformSession,
+  });
 }


### PR DESCRIPTION
## Summary
- Add `useCanReachAssistant` reactive hook: platform reachability from `platformSession`, local reachability from per-assistant lifecycle `AssistantState` (not a global token).
- Delegates hosting-branch logic to the pure `canReachAssistant`. Structurally resolves the per-assistant-token concern raised on PR #35197.

Part of plan: auth-session-slices.md (PR 3 of 8)