### PR TITLE
fix(web/auth): route protection admits on app access (local users reach the app)

### DIFF
--- a/clients/web/src/lib/auth/auth-middleware.test.ts
+++ b/clients/web/src/lib/auth/auth-middleware.test.ts
@@ -1,20 +1,77 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type { LockfileAssistant } from "@/lib/local-mode";
+
 const isLocalModeMock = mock(() => true);
 const hasAssistantsMock = mock(() => false);
+let mockSelectedAssistant: LockfileAssistant | undefined;
+
+// Spread the real module so the resolvers the route fork pulls in
+// (`getSelectedAssistant`/`isLocalAssistant`/…) stay available; override only
+// the hosting-mode flags and the selected-assistant resolver per case.
+const localModeActual = await import("@/lib/local-mode");
 mock.module("@/lib/local-mode", () => ({
+  ...localModeActual,
   isLocalMode: isLocalModeMock,
   hasAssistants: hasAssistantsMock,
   getLocalGatewayUrl: () => undefined,
+  getSelectedAssistant: () => mockSelectedAssistant,
+  getActiveAssistant: () => mockSelectedAssistant,
+  isLocalAssistant: (a: {
+    cloud?: string;
+    resources?: { gatewayPort?: number };
+  }) => a.cloud !== "vellum" && a.resources?.gatewayPort != null,
+  isPlatformAssistant: (a: { cloud?: string }) => a.cloud === "vellum",
+  isRemoteGatewayMode: () => false,
+}));
+
+// Drive the non-reactive gateway token off a flag.
+let mockGatewayTokenPresent = false;
+const gatewaySessionActual = await import("@/lib/auth/gateway-session");
+mock.module("@/lib/auth/gateway-session", () => ({
+  ...gatewaySessionActual,
+  getGatewayToken: () => (mockGatewayTokenPresent ? "gw-token" : null),
+  isGatewayAuthMode: () => false,
 }));
 
 import { authMiddleware } from "./auth-middleware";
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { useAuthStore, type AuthUser } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
 
 const initialAuthState = useAuthStore.getState();
 const fakeUser = { id: "user-123" } as AuthUser;
+
+const localAssistant: LockfileAssistant = {
+  assistantId: "local-a",
+  cloud: "local",
+  resources: { gatewayPort: 51234, daemonPort: 51235 },
+};
+
+/**
+ * Run the middleware and report whether it admitted (called `next`) or threw a
+ * redirect Response — so admit-path assertions don't have to special-case the
+ * thrown-Response contract.
+ */
+async function runMiddlewareOutcome(
+  pathname: string,
+): Promise<{ admitted: true } | { admitted: false; response: Response }> {
+  const args = {
+    request: new Request(`http://localhost${pathname}`),
+    context: { set: () => {}, get: () => null },
+  } as unknown as Parameters<typeof authMiddleware>[0];
+  const next = (async () => new Response()) as Parameters<
+    typeof authMiddleware
+  >[1];
+  try {
+    await authMiddleware(args, next);
+    return { admitted: true };
+  } catch (thrown) {
+    if (thrown instanceof Response) return { admitted: false, response: thrown };
+    throw thrown;
+  }
+}
 
 async function runMiddleware(pathname: string): Promise<Response> {
   const args = {
@@ -40,7 +97,10 @@ const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
 beforeEach(() => {
   isLocalModeMock.mockImplementation(() => true);
   hasAssistantsMock.mockImplementation(() => false);
+  mockSelectedAssistant = undefined;
+  mockGatewayTokenPresent = false;
   useAuthStore.setState(initialAuthState, true);
+  useResolvedAssistantsStore.setState({ assistants: [] });
   useAssistantLifecycleStore.setState({ assistantState: { kind: "error", message: "no assistant" } });
 });
 
@@ -97,5 +157,75 @@ describe("authMiddleware — local-mode onboarding fork", () => {
     const res = await runMiddleware(routes.home);
     expect(res.status).toBe(302);
     expect(res.headers.get("Location")).toBe(routes.onboarding.hosting);
+  });
+});
+
+describe("authMiddleware — app-access admit gate", () => {
+  // A local user with at least one assistant resolved and a reachable gateway
+  // connection, but no platform identity.
+  function makeLocalUserReachable(): void {
+    hasAssistantsMock.mockImplementation(() => true);
+    mockSelectedAssistant = localAssistant;
+    mockGatewayTokenPresent = true;
+    useResolvedAssistantsStore.setState({
+      assistants: [localAssistant] as never[],
+    });
+  }
+
+  test("admits a local-only user (no platform identity) instead of redirecting to login", async () => {
+    makeLocalUserReachable();
+    // No platform identity: the session probe settled with no live session and
+    // the status is not 'authenticated'.
+    useAuthStore.setState({
+      sessionStatus: "unauthenticated",
+      user: null,
+      platformSession: "absent",
+    });
+
+    const outcome = await runMiddlewareOutcome(routes.home);
+    expect(outcome.admitted).toBe(true);
+  });
+
+  test("a simulated platform 401 mid-session does not redirect a local user", async () => {
+    makeLocalUserReachable();
+    // Start admitted as a local user.
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      user: null,
+      platformSession: "present",
+    });
+    expect((await runMiddlewareOutcome(routes.home)).admitted).toBe(true);
+
+    // Platform getSession() returns 401 mid-session: platformSession flips to
+    // absent and the status flips to unauthenticated, but the gateway
+    // connection to the selected local assistant is unchanged.
+    useAuthStore.setState({
+      sessionStatus: "unauthenticated",
+      platformSession: "absent",
+    });
+
+    const outcome = await runMiddlewareOutcome(routes.home);
+    expect(outcome.admitted).toBe(true);
+  });
+
+  test("still redirects a logged-out platform user with no reachable assistant to login", async () => {
+    isLocalModeMock.mockImplementation(() => false);
+    hasAssistantsMock.mockImplementation(() => false);
+    mockSelectedAssistant = undefined;
+    mockGatewayTokenPresent = false;
+    useAuthStore.setState({
+      sessionStatus: "unauthenticated",
+      user: null,
+      platformSession: "absent",
+    });
+
+    const outcome = await runMiddlewareOutcome("/assistant/home");
+    expect(outcome.admitted).toBe(false);
+    if (!outcome.admitted) {
+      expect(outcome.response.status).toBe(302);
+      expect(outcome.response.headers.get("Location")).toBe(
+        `${routes.account.login}?returnTo=${encodeURIComponent("/assistant/home")}`,
+      );
+    }
   });
 });

--- a/clients/web/src/lib/auth/auth-middleware.ts
+++ b/clients/web/src/lib/auth/auth-middleware.ts
@@ -18,6 +18,9 @@ const PLATFORM_SESSION_PROBE_TIMEOUT_MS = 5_000;
 export const authMiddleware: MiddlewareFunction = async ({ request, context }, next) => {
   const url = new URL(request.url);
 
+  // `buildNavigationState` folds app access into the admit decision, so the
+  // settle waits below remain the only identity/probe gates — they keep us from
+  // routing mid-probe.
   const state = buildNavigationState();
 
   const decision = resolveNavigation(state, {

--- a/clients/web/src/lib/navigation/build-state.test.ts
+++ b/clients/web/src/lib/navigation/build-state.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { LockfileAssistant } from "@/lib/local-mode";
+
+// Spread the real `@/lib/local-mode` so every other export the dependency
+// graph pulls in stays available; override only the hosting-mode flags and the
+// selected-assistant resolver the route fork branches on.
+let mockIsLocalMode = true;
+let mockIsRemoteGatewayMode = false;
+let mockSelectedAssistant: LockfileAssistant | undefined;
+
+const localModeActual = await import("@/lib/local-mode");
+
+mock.module("@/lib/local-mode", () => ({
+  ...localModeActual,
+  isLocalMode: () => mockIsLocalMode,
+  isRemoteGatewayMode: () => mockIsRemoteGatewayMode,
+  isLocalAssistant: (a: {
+    cloud?: string;
+    resources?: { gatewayPort?: number };
+  }) => a.cloud !== "vellum" && a.resources?.gatewayPort != null,
+  isPlatformAssistant: (a: { cloud?: string }) => a.cloud === "vellum",
+  getSelectedAssistant: () => mockSelectedAssistant,
+  getActiveAssistant: () => mockSelectedAssistant,
+}));
+
+// The gateway token is non-reactive module state; drive it off a flag.
+let mockGatewayTokenPresent = false;
+const gatewaySessionActual = await import("@/lib/auth/gateway-session");
+mock.module("@/lib/auth/gateway-session", () => ({
+  ...gatewaySessionActual,
+  getGatewayToken: () => (mockGatewayTokenPresent ? "gw-token" : null),
+  isGatewayAuthMode: () => false,
+}));
+
+// Consent prefs read storage; pin them so the access decision is isolated.
+mock.module("@/domains/onboarding/prefs", () => ({
+  readTosAccepted: () => true,
+  readAiDataConsent: () => true,
+}));
+
+const { buildNavigationState } = await import("./build-state");
+const { useAuthStore } = await import("@/stores/auth-store");
+const { useResolvedAssistantsStore } = await import(
+  "@/stores/resolved-assistants-store"
+);
+
+const localAssistant: LockfileAssistant = {
+  assistantId: "local-a",
+  cloud: "local",
+  resources: { gatewayPort: 51234, daemonPort: 51235 },
+};
+const platformAssistant: LockfileAssistant = {
+  assistantId: "platform-a",
+  cloud: "vellum",
+};
+
+const initialAuthState = useAuthStore.getState();
+
+beforeEach(() => {
+  mockIsLocalMode = true;
+  mockIsRemoteGatewayMode = false;
+  mockSelectedAssistant = undefined;
+  mockGatewayTokenPresent = false;
+  useAuthStore.setState(initialAuthState, true);
+  useResolvedAssistantsStore.setState({ assistants: [] });
+});
+
+afterEach(() => {
+  useAuthStore.setState(initialAuthState, true);
+});
+
+describe("buildNavigationState — app-access admit predicate", () => {
+  test("a local-only user (no platform session, gateway-reachable assistant) is admitted", () => {
+    // No platform identity at all: the probe settled absent and the session
+    // status is not 'authenticated'.
+    mockSelectedAssistant = localAssistant;
+    mockGatewayTokenPresent = true;
+    useAuthStore.setState({
+      sessionStatus: "unauthenticated",
+      platformSession: "absent",
+    });
+
+    expect(buildNavigationState().isAuthenticated).toBe(true);
+  });
+
+  test("a platform 401 mid-session does not evict a local user (session flips, token stays)", () => {
+    // Simulate the platform getSession() 401: platformSession drops to absent
+    // and sessionStatus flips to unauthenticated, but the gateway connection to
+    // the selected local assistant is still live.
+    mockSelectedAssistant = localAssistant;
+    mockGatewayTokenPresent = true;
+    useAuthStore.setState({
+      sessionStatus: "unauthenticated",
+      platformSession: "absent",
+    });
+
+    expect(buildNavigationState().isAuthenticated).toBe(true);
+  });
+
+  test("a logged-out user with no reachable assistant is not admitted", () => {
+    // No platform identity, no gateway token, and no resolvable assistant.
+    mockSelectedAssistant = undefined;
+    mockGatewayTokenPresent = false;
+    useAuthStore.setState({
+      sessionStatus: "unauthenticated",
+      platformSession: "absent",
+    });
+
+    expect(buildNavigationState().isAuthenticated).toBe(false);
+  });
+
+  test("a logged-out user whose only assistant is platform-hosted (no live session) is not admitted", () => {
+    mockSelectedAssistant = platformAssistant;
+    mockGatewayTokenPresent = true; // gateway token irrelevant for platform host
+    useAuthStore.setState({
+      sessionStatus: "unauthenticated",
+      platformSession: "absent",
+    });
+
+    expect(buildNavigationState().isAuthenticated).toBe(false);
+  });
+
+  test("a local user without a gateway token yet is not admitted on reachability alone", () => {
+    mockSelectedAssistant = localAssistant;
+    mockGatewayTokenPresent = false;
+    useAuthStore.setState({
+      sessionStatus: "unauthenticated",
+      platformSession: "absent",
+    });
+
+    expect(buildNavigationState().isAuthenticated).toBe(false);
+  });
+
+  test("a platform user with a live session is admitted exactly as today", () => {
+    mockIsLocalMode = false;
+    mockSelectedAssistant = platformAssistant;
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      platformSession: "present",
+    });
+
+    expect(buildNavigationState().isAuthenticated).toBe(true);
+  });
+
+  test("a platform user whose session has not settled keeps today's authenticated read", () => {
+    // sessionStatus authenticated but probe unsettled: bare identity still
+    // admits, so the OR must not regress this to a redirect.
+    mockIsLocalMode = false;
+    mockSelectedAssistant = platformAssistant;
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      platformSession: "unknown",
+    });
+
+    expect(buildNavigationState().isAuthenticated).toBe(true);
+  });
+
+  test("platformSession is still surfaced verbatim for the onboarding fork", () => {
+    // The route fork's onboarding wait keys off platformSession === 'unknown';
+    // folding app-access into isAuthenticated must not disturb that field.
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      platformSession: "unknown",
+    });
+
+    expect(buildNavigationState().platformSession).toBe("unknown");
+  });
+});

--- a/clients/web/src/lib/navigation/build-state.ts
+++ b/clients/web/src/lib/navigation/build-state.ts
@@ -1,7 +1,18 @@
 import { useAuthStore } from "@/stores/auth-store";
-import { isSessionSettled, isAuthenticated } from "@/stores/session-status";
-import { isGatewayAuthMode } from "@/lib/auth/gateway-session";
-import { isLocalMode } from "@/lib/local-mode";
+import {
+  isSessionSettled,
+  isAuthenticated,
+  hasAppAccess,
+  hasLivePlatformSession,
+  type PlatformSessionStatus,
+} from "@/stores/session-status";
+import { canReachAssistant } from "@/assistant/can-reach-assistant";
+import { isGatewayAuthMode, getGatewayToken } from "@/lib/auth/gateway-session";
+import {
+  isLocalMode,
+  getSelectedAssistant,
+  getActiveAssistant,
+} from "@/lib/local-mode";
 import {
   readTosAccepted,
   readAiDataConsent,
@@ -9,16 +20,44 @@ import {
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import type { NavigationState } from "./navigation-resolver";
 
+/**
+ * Whether the selected assistant is reachable right now, composed imperatively
+ * (no hooks) for the middleware/route-resolver context. Mirrors the reactive
+ * `useCanReachAssistant`, but reads the gateway token and the selected
+ * assistant directly: the route guard runs once per navigation rather than
+ * across renders, so it can read the non-reactive sources. Returns false when
+ * no assistant resolves.
+ */
+function canReachSelectedAssistant(
+  platformSession: PlatformSessionStatus,
+): boolean {
+  const selected = getSelectedAssistant() ?? getActiveAssistant();
+  if (!selected) return false;
+  return canReachAssistant(selected, {
+    gatewayTokenPresent: getGatewayToken() !== null,
+    platformSession,
+  });
+}
+
 export function buildNavigationState(
   overrides?: Partial<NavigationState>,
 ): NavigationState {
   const { sessionStatus, platformSession } = useAuthStore.getState();
+  // The route guard admits on app access — a real platform identity OR a
+  // reachable selected assistant — not on bare platform identity. So a
+  // local-only user (no platform session, gateway-reachable assistant) is
+  // admitted, and a platform `getSession()` 401 that drops `platformSession`
+  // cannot redirect them to login while their assistant is still reachable.
+  const canAccessApp = hasAppAccess({
+    hasPlatformIdentity: hasLivePlatformSession(platformSession),
+    canReachSelected: canReachSelectedAssistant(platformSession),
+  });
   return {
     isLocalMode: isLocalMode(),
     isGatewayAuth: isGatewayAuthMode(),
     hasAssistants: useResolvedAssistantsStore.getState().assistants.length > 0,
     sessionSettled: isSessionSettled(sessionStatus),
-    isAuthenticated: isAuthenticated(sessionStatus),
+    isAuthenticated: isAuthenticated(sessionStatus) || canAccessApp,
     platformSession,
     tosAccepted: readTosAccepted(),
     aiDataConsent: readAiDataConsent(),

--- a/clients/web/src/lib/navigation/build-state.ts
+++ b/clients/web/src/lib/navigation/build-state.ts
@@ -57,6 +57,16 @@ export function buildNavigationState(
     isGatewayAuth: isGatewayAuthMode(),
     hasAssistants: useResolvedAssistantsStore.getState().assistants.length > 0,
     sessionSettled: isSessionSettled(sessionStatus),
+    // Route admission ORs in app access, but in-app auth consumers (the
+    // QueryClient cache scope in providers.tsx, gated UI like PreferencesMenu)
+    // read `useIsAuthenticated()` directly. These never disagree: a reachable
+    // session is always `sessionStatus: "authenticated"` — the gateway is the
+    // sole authority for a local session, and a platform user without a session
+    // has `canReachSelected === false`. So `canAccessApp` implies authenticated
+    // today; the OR is a forward-looking guard. If local sessions ever stop
+    // being authenticated (the `user: null` follow-up), those in-app consumers
+    // must move onto app access too — otherwise an admitted user falls into the
+    // anonymous cache scope with gated UI hidden.
     isAuthenticated: isAuthenticated(sessionStatus) || canAccessApp,
     platformSession,
     tosAccepted: readTosAccepted(),


### PR DESCRIPTION
## Summary
- Route-protection middleware admits on `hasAppAccess` (platform identity OR selected-assistant reachable); a local-only user is no longer redirected to login, and a platform 401 cannot evict them.
- Identity-settle wait and the onboarding platform-session-settle wait are preserved; platform-user behavior unchanged.

Part of plan: auth-session-slices.md (PR 5 of 8)