### PR TITLE
refactor(web/auth): explicit identity kind — distinguish platform login from local gateway access

### DIFF
--- a/clients/web/src/domains/chat/inspector/access.test.ts
+++ b/clients/web/src/domains/chat/inspector/access.test.ts
@@ -5,6 +5,7 @@ import type { AuthUser } from "@/stores/auth-store";
 
 function user(overrides: Partial<AuthUser>): AuthUser {
   return {
+    kind: "platform",
     id: "user-123",
     username: null,
     email: "user@example.com",

--- a/clients/web/src/lib/auth/user-snapshot.ts
+++ b/clients/web/src/lib/auth/user-snapshot.ts
@@ -32,6 +32,10 @@ export function readUserSnapshot(): AuthUser | null {
     // Field-by-field coercion so a malformed or stale-schema snapshot
     // degrades to safe defaults instead of poisoning the auth state.
     return {
+      // Only platform users are ever snapshotted, so a restored user is always
+      // a platform identity — including legacy snapshots written before `kind`
+      // existed, which default here so old snapshots keep restoring correctly.
+      kind: "platform",
       id: typeof parsed.id === "string" ? parsed.id : null,
       username: typeof parsed.username === "string" ? parsed.username : null,
       email: typeof parsed.email === "string" ? parsed.email : null,

--- a/clients/web/src/lib/auth/user-snapshot.ts
+++ b/clients/web/src/lib/auth/user-snapshot.ts
@@ -32,9 +32,9 @@ export function readUserSnapshot(): AuthUser | null {
     // Field-by-field coercion so a malformed or stale-schema snapshot
     // degrades to safe defaults instead of poisoning the auth state.
     return {
-      // Only platform users are ever snapshotted, so a restored user is always
-      // a platform identity — including legacy snapshots written before `kind`
-      // existed, which default here so old snapshots keep restoring correctly.
+      // Only platform users are snapshotted, so a restored user is always a
+      // platform identity. Defaulted here (not read from the snapshot) so a
+      // snapshot missing this field still coerces to a valid platform identity.
       kind: "platform",
       id: typeof parsed.id === "string" ? parsed.id : null,
       username: typeof parsed.username === "string" ? parsed.username : null,

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -248,8 +248,12 @@ mock.module("@/assistant/api", () => ({
   listAssistants: listAssistantsMock,
 }));
 
-const { useAuthStore, useHasAppAccess } = await import("@/stores/auth-store");
-const { hasAppAccess } = await import("@/stores/session-status");
+const { useAuthStore, useHasAppAccess, useIsPlatformIdentity } = await import(
+  "@/stores/auth-store"
+);
+const { hasAppAccess, isPlatformIdentity } = await import(
+  "@/stores/session-status"
+);
 const { useAssistantLifecycleStore } = await import(
   "@/assistant/lifecycle-store"
 );
@@ -269,6 +273,7 @@ function authenticatedLocalUserForTest() {
   return {
     sessionStatus: "authenticated" as const,
     user: {
+      kind: "local" as const,
       id: "gateway-local",
       username: "local",
       email: null,
@@ -917,6 +922,11 @@ describe("offline session restore (LUM-2412)", () => {
 
     expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
     expect(useAuthStore.getState().user?.id).toBe("user-cached");
+    // The legacy snapshot `seedSnapshot()` writes carries no `kind` field;
+    // the restore must default it to a platform identity (only platform users
+    // are ever snapshotted), so old snapshots keep restoring correctly.
+    expect(useAuthStore.getState().user?.kind).toBe("platform");
+    expect(isPlatformIdentity(useAuthStore.getState().user)).toBe(true);
     // The snapshot only exists for a confirmed platform session, and no
     // probe runs offline to settle an "unknown" — so the restore settles
     // "present" (believed state); reconnect revalidation corrects it.
@@ -1065,6 +1075,77 @@ describe("offline session restore (LUM-2412)", () => {
     await useAuthStore.getState().initSession();
 
     expect(useAuthStore.getState().sessionStatus).toBe("unauthenticated");
+  });
+});
+
+// The `kind` discriminator separates a real platform account from local
+// gateway access. Local keeps its stable `gateway-local` id (storage
+// namespacing) yet is not a platform identity; platform users are.
+describe("identity kind (platform vs local gateway access)", () => {
+  test("a local gateway session is kind 'local' and not a platform identity, but keeps its stable id", async () => {
+    mockIsLocalMode = true;
+    mockPlatformAssistants = [];
+
+    await useAuthStore.getState().initSession();
+
+    const user = useAuthStore.getState().user;
+    expect(user?.kind).toBe("local");
+    expect(user?.id).toBe("gateway-local");
+    expect(isPlatformIdentity(user)).toBe(false);
+    // A local session stays authenticated — the discriminator does not change
+    // session semantics.
+    expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
+  });
+
+  test("a platform session is kind 'platform' and is a platform identity", async () => {
+    sessionUser = { id: "user-1", email: "user@example.com" };
+
+    await useAuthStore.getState().initSession();
+
+    const user = useAuthStore.getState().user;
+    expect(user?.kind).toBe("platform");
+    expect(user?.id).toBe("user-1");
+    expect(isPlatformIdentity(user)).toBe(true);
+  });
+
+  test("an offline-restored user is a platform identity (legacy snapshot defaults to platform)", async () => {
+    // `seedSnapshot()` writes a legacy snapshot with no `kind` field.
+    getSessionThrows = true;
+    mockElectronSessionToken = "tok-1";
+    seedSnapshot();
+
+    await useAuthStore.getState().initSession();
+
+    const user = useAuthStore.getState().user;
+    expect(user?.kind).toBe("platform");
+    expect(isPlatformIdentity(user)).toBe(true);
+  });
+
+  test("isPlatformIdentity(null) is false", () => {
+    expect(isPlatformIdentity(null)).toBe(false);
+  });
+
+  test("useIsPlatformIdentity is false for a local user, true for a platform user", () => {
+    act(() => {
+      useAuthStore.setState({ ...authenticatedLocalUserForTest() });
+    });
+    const local = renderHook(() => useIsPlatformIdentity());
+    expect(local.result.current).toBe(false);
+
+    act(() => {
+      useAuthStore.setState({
+        user: {
+          kind: "platform",
+          id: "user-1",
+          username: "test",
+          email: "user@example.com",
+          isStaff: false,
+          firstName: "",
+          lastName: "",
+        },
+      });
+    });
+    expect(local.result.current).toBe(true);
   });
 });
 

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -22,6 +22,7 @@ import {
   isSettledSessionRejection,
   hasLivePlatformSession,
   hasAppAccess,
+  isPlatformIdentity,
   type PlatformSessionStatus,
   type SessionStatus,
 } from "@/stores/session-status";
@@ -85,6 +86,13 @@ import {
 } from "@/runtime/native-biometric";
 
 export interface AuthUser {
+  /**
+   * Distinguishes a real platform account from local gateway access. Both
+   * carry a stable `id` (local's is the synthetic `"gateway-local"`, kept for
+   * storage namespacing), so consumers that mean "real platform account" must
+   * read `kind` rather than assuming any non-null user is a platform user.
+   */
+  kind: "platform" | "local";
   id: string | null;
   username: string | null;
   email: string | null;
@@ -109,6 +117,7 @@ function resolveUserId(user: RawSessionUser | null): string | null {
 function toAuthUser(raw: RawSessionUser | null): AuthUser | null {
   if (!raw) return null;
   return {
+    kind: "platform",
     id: resolveUserId(raw),
     username: raw.username ?? null,
     email: raw.email ?? null,
@@ -148,6 +157,7 @@ let broadcastChannel: BroadcastChannel | null = null;
 let suppressPlatformProbe = false;
 
 const GATEWAY_LOCAL_USER: AuthUser = {
+  kind: "local",
   id: "gateway-local",
   username: "local",
   email: null,
@@ -822,6 +832,14 @@ export const useIsSessionInitializing = (): boolean =>
 
 export const useHasPlatformSession = (): boolean =>
   hasLivePlatformSession(useAuthStore.use.platformSession());
+
+/**
+ * Is the current user a real platform account (vs. local gateway access)? Reads
+ * the `user.kind` discriminator rather than treating any non-null user as a
+ * platform identity, so the synthetic local gateway user answers `false`.
+ */
+export const useIsPlatformIdentity = (): boolean =>
+  isPlatformIdentity(useAuthStore.use.user());
 
 /**
  * Resolve the currently selected assistant reactively as a `LockfileAssistant`.

--- a/clients/web/src/stores/session-status.ts
+++ b/clients/web/src/stores/session-status.ts
@@ -2,17 +2,18 @@
  * Session state as discriminated unions, plus the pure predicates that answer
  * each session-state question in one place.
  *
- * This module is intentionally dependency-free: it imports nothing, so any
- * module — including ones the auth store itself depends on (e.g. the assistant
- * lifecycle service) — can read session meaning without creating an import
- * cycle through the store. `import type` could not break that cycle because
- * the predicates are runtime values, not just types.
+ * This module is intentionally dependency-free at runtime: it imports no
+ * runtime values, so any module — including ones the auth store itself depends
+ * on (e.g. the assistant lifecycle service) — can read session meaning without
+ * creating an import cycle through the store. The lone `import type` of
+ * `AuthUser` is erased at compile time, so it introduces no runtime edge.
  *
  * Imperative readers (middleware, lifecycle, route resolvers) call these
  * predicates directly with a status value. Reactive components read the
  * matching hooks (`useIsAuthenticated`, `useHasPlatformSession`) from the auth
  * store, which compose these predicates over the store's atomic selectors.
  */
+import type { AuthUser } from "@/stores/auth-store";
 
 /**
  * Platform-session liveness as a single tri-state.
@@ -65,6 +66,16 @@ export const isSessionSettled = (status: SessionStatus): boolean =>
 export const hasLivePlatformSession = (
   status: PlatformSessionStatus,
 ): boolean => status === "present";
+
+/**
+ * Is this a real platform account, as opposed to local gateway access? The
+ * local gateway user is a synthetic, platform-shaped identity kept for storage
+ * namespacing; consumers that mean "real platform account" (staff/email checks,
+ * billing/account surfaces) read this instead of assuming any non-null user is
+ * a platform user. A null user is never a platform identity.
+ */
+export const isPlatformIdentity = (user: AuthUser | null): boolean =>
+  user?.kind === "platform";
 
 /**
  * The two orthogonal authorities behind app access: a real platform identity


### PR DESCRIPTION
## Summary
- Add `AuthUser.kind: "platform" | "local"` + `isPlatformIdentity`/`useIsPlatformIdentity` so identity readers can tell a real platform account from local gateway access.
- Local user keeps its stable `gateway-local` id (storage namespacing) and stays `sessionStatus: authenticated`; offline restore yields platform-kind, legacy snapshots default to platform.

Part of plan: auth-session-slices.md (PR 7 of 8)