### PR TITLE
refactor(web/auth): document the #35152 guards as still load-bearing (verification pass)

### DIFF
--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -102,9 +102,14 @@ export function HatchingScreen() {
   const electron = isElectron();
   const useLocalHatch = isLocalMode() && hostingParam !== null && hostingParam !== "vellum-cloud";
   const sessionStatus = useAuthStore.use.sessionStatus();
-  // Local hatches drive `sessionStatus` themselves (the connect handoff below
-  // flips it), so they gate on settled-ness to avoid self-restarting; platform
-  // hatches react to the raw status so a mid-hatch session loss redirects to login.
+  // Local hatches drive `sessionStatus` themselves: `connectLocalAssistant`
+  // below flips it `unauthenticated` → `authenticated` mid-handoff. Keying the
+  // hatch effect on settled-ness (true for both settled states) keeps that flip
+  // out of the effect's dependency, so it does not tear down the navigation
+  // timer and re-spawn the hatch. The route access gate admits the screen but
+  // does not stabilize this in-effect flip, so the settled-ness key is the only
+  // thing preventing the self-restart. Platform hatches react to the raw status
+  // so a mid-hatch session loss redirects to login.
   const sessionGateKey = useLocalHatch
     ? isSessionSettled(sessionStatus)
     : sessionStatus;

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -755,6 +755,14 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
     // (The successful probe above still adopts the platform user, so provider
     // sign-in keeps working.) An unauthenticated session — e.g. mid cold-start
     // hatch — is left for the gateway to settle once its token mints.
+    //
+    // Holding `sessionStatus` "authenticated" here is load-bearing for in-app
+    // consumers that read `useIsAuthenticated()` directly: the QueryClient cache
+    // scope in `components/providers.tsx` and gated UI such as
+    // `domains/chat/components/preferences-menu.tsx`. Ending the session drops
+    // them into the anonymous cache scope and hides gated UI. The gateway is the
+    // sole authority for a local session, so this demotion and the route
+    // admission OR (`hasAppAccess`) agree: a local user keeps app access here.
     if (isGatewayAuthEnabled()) {
       const wasAuthenticated = isAuthenticated(get().sessionStatus);
       if (wasAuthenticated) {


### PR DESCRIPTION
## Summary
- Verified both #35152 defensive guards are still load-bearing after PRs 1-7; removed nothing. The slice split (per-assistant connection, `hasAppAccess` route-admission OR) realigned *route admission* but in-app auth consumers (`components/providers.tsx` cache scope, `domains/chat/components/preferences-menu.tsx` gated UI) still read `useIsAuthenticated()` directly — the consumer realignment is deferred to the `user: null` follow-up. So a settled-401 demotion that keeps a local session `authenticated` is still what those consumers depend on.
- `refreshSession()` settled-401 guard (auth-store.ts): KEPT. Proven by experiment — removing it fails the regression test `refreshSession keeps the local gateway session but clears stale platform state on a settled 401` (sessionStatus flips to unauthenticated → providers.tsx anonymous cache scope + Preferences hidden = the #35152 bug at the consumer layer). Added a present-tense comment naming the load-bearing consumers.
- hatching-screen `sessionGateKey` guard: KEPT. git history shows PRs 1-7 never touched hatching-screen.tsx (last change was #35152 itself), so nothing made its self-restart protection redundant: `connectLocalAssistant` still flips `sessionStatus` mid-effect, and keying the hatch effect on settled-ness is the only thing stopping a re-hatch loop. Clarified the comment.
- #35152 regression tests pass: auth-store.test.ts 58/58, onboarding-lifecycle-sync.test.tsx 16/16, tsc clean.

Part of plan: auth-session-slices.md (PR 8 of 8)