### PR TITLE
fix(web/auth): self-review cleanup — dead fallback + comment wording

### DIFF
--- a/clients/web/src/assistant/can-reach-assistant.test.tsx
+++ b/clients/web/src/assistant/can-reach-assistant.test.tsx
@@ -169,9 +169,9 @@ describe("useCanReachAssistant", () => {
       expect(result.current).toBe(true);
     });
 
-    // P2 #2: a self-hosted daemon that answered `/healthz` with a non-healthy
-    // status gets `health: "unhealthy"`. The lifecycle service treats that as
-    // reachable for active local states, so this hook must agree.
+    // A self-hosted daemon that answered `/healthz` with a non-healthy status
+    // gets `health: "unhealthy"`. The lifecycle service treats that as reachable
+    // for active local states, so this hook must agree.
     test("self_hosted health 'unhealthy' is reachable (degraded-but-responsive)", () => {
       setLifecycle({ kind: "self_hosted", health: "unhealthy" });
       const { result } = renderHook(() => useCanReachAssistant(localAssistant));

--- a/clients/web/src/lib/navigation/build-state.ts
+++ b/clients/web/src/lib/navigation/build-state.ts
@@ -8,11 +8,7 @@ import {
 } from "@/stores/session-status";
 import { canReachAssistant } from "@/assistant/can-reach-assistant";
 import { isGatewayAuthMode, getGatewayToken } from "@/lib/auth/gateway-session";
-import {
-  isLocalMode,
-  getSelectedAssistant,
-  getActiveAssistant,
-} from "@/lib/local-mode";
+import { isLocalMode, getSelectedAssistant } from "@/lib/local-mode";
 import {
   readTosAccepted,
   readAiDataConsent,
@@ -31,7 +27,9 @@ import type { NavigationState } from "./navigation-resolver";
 function canReachSelectedAssistant(
   platformSession: PlatformSessionStatus,
 ): boolean {
-  const selected = getSelectedAssistant() ?? getActiveAssistant();
+  // getSelectedAssistant() already falls back to the active assistant when no
+  // valid selection is stored, so it is the single resolver here.
+  const selected = getSelectedAssistant();
   if (!selected) return false;
   return canReachAssistant(selected, {
     gatewayTokenPresent: getGatewayToken() !== null,


### PR DESCRIPTION
## Summary
- Remove the unreachable `?? getActiveAssistant()` fallback (and its dead import) in build-state.ts — `getSelectedAssistant()` already falls back to the active assistant internally.
- Drop a leftover `P2 #2:` review-history prefix from a can-reach-assistant test comment (AGENTS.md present-tense rule).

Self-review remediation for plan: auth-session-slices.md