### PR TITLE
refactor(assistant): gate archive-by-sender via canArchiveBySender capability

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-archive-by-sender.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-archive-by-sender.ts
@@ -1,3 +1,4 @@
+import { resolveCapabilities } from "../../../../runtime/capabilities.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -9,7 +10,8 @@ export async function run(
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
   const userApproved =
-    input.user_approved === true && context.trustClass === "guardian";
+    input.user_approved === true &&
+    resolveCapabilities(context.trustClass).canArchiveBySender;
   if (
     !context.triggeredBySurfaceAction &&
     !context.batchAuthorizedByTask &&


### PR DESCRIPTION
## Summary
- Replace context.trustClass === guardian term in messaging-archive-by-sender with resolveCapabilities(...).canArchiveBySender.
- Behavior-preserving: archive requires user_approved AND guardian.

Part of plan: trust-class-capabilities-migration.md (PR 5 of 13)