### PR TITLE
refactor(assistant): gate shell sandbox via unsandboxedShell capability

### DIFF
--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -5,7 +5,7 @@ import { bridgeCesApproval } from "../credential-execution/approval-bridge.js";
 import { isCesShellLockdownEnabled } from "../credential-execution/feature-gates.js";
 import { PermissionPrompter } from "../permissions/prompter.js";
 import { RiskLevel } from "../permissions/types.js";
-import { isUntrustedTrustClass } from "../runtime/actor-trust-resolver.js";
+import { resolveCapabilities } from "../runtime/capabilities.js";
 import { redactSensitiveFields } from "../security/redaction.js";
 import { getCesClient } from "../security/secure-keys.js";
 import { TokenExpiredError } from "../security/token-manager.js";
@@ -129,7 +129,7 @@ export class ToolExecutor {
       if (
         name === "host_bash" &&
         isCesShellLockdownEnabled(getConfig()) &&
-        isUntrustedTrustClass(context.trustClass)
+        !resolveCapabilities(context.trustClass).unsandboxedShell
       ) {
         context.forcePromptSideEffects = true;
       }

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -23,9 +23,9 @@ import { getConfig } from "../../config/loader.js";
 import { isCesShellLockdownEnabled } from "../../credential-execution/feature-gates.js";
 import { HostBashProxy } from "../../daemon/host-bash-proxy.js";
 import { RiskLevel } from "../../permissions/types.js";
-import { isUntrustedTrustClass } from "../../runtime/actor-trust-resolver.js";
 import { wakeAgentForOpportunity } from "../../runtime/agent-wake.js";
 import { assistantEventHub } from "../../runtime/assistant-event-hub.js";
+import { resolveCapabilities } from "../../runtime/capabilities.js";
 import { redactSecrets } from "../../security/secret-scanner.js";
 import { getLogger } from "../../util/logger.js";
 import {
@@ -206,7 +206,7 @@ export const hostShellTool = {
     // because execute() is called after permissions have already been evaluated.
     const hostLockdownActive =
       isCesShellLockdownEnabled(config) &&
-      isUntrustedTrustClass(context.trustClass);
+      !resolveCapabilities(context.trustClass).unsandboxedShell;
 
     // Guard: non-host-proxy interfaces need an explicit target when multiple
     // capable clients are connected to avoid ambiguous untargeted broadcasts.

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -4,8 +4,8 @@ import { spawn } from "node:child_process";
 import { getConfig } from "../../config/loader.js";
 import { isCesShellLockdownEnabled } from "../../credential-execution/feature-gates.js";
 import { RiskLevel } from "../../permissions/types.js";
-import { isUntrustedTrustClass } from "../../runtime/actor-trust-resolver.js";
 import { wakeAgentForOpportunity } from "../../runtime/agent-wake.js";
+import { resolveCapabilities } from "../../runtime/capabilities.js";
 import { redactSecrets } from "../../security/secret-scanner.js";
 import { getLogger } from "../../util/logger.js";
 import { getDataDir } from "../../util/platform.js";
@@ -119,7 +119,7 @@ export const shellTool = {
     const config = getConfig();
     const shellLockdownActive =
       isCesShellLockdownEnabled(config) &&
-      isUntrustedTrustClass(context.trustClass);
+      !resolveCapabilities(context.trustClass).unsandboxedShell;
 
     const networkMode: "off" | "proxied" =
       input.network_mode === "proxied" ? "proxied" : "off";


### PR DESCRIPTION
## Summary
- Replace inline isUntrustedTrustClass sandbox/CES-lockdown checks with !resolveCapabilities(...).unsandboxedShell in executor, host-shell, and terminal shell.
- Behavior-preserving: guardian shells unsandboxed; all other classes sandboxed.

Part of plan: trust-class-capabilities-migration.md (PR 3 of 13)