### PR TITLE
refactor(assistant): gate privileged document ops via capability

### DIFF
--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -13,11 +13,13 @@ import {
   searchDocumentsByTitle,
   updateDocumentContent,
 } from "../../documents/document-store.js";
+import { resolveCapabilities } from "../../runtime/capabilities.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 
 function isPrivilegedDocumentActor(context: ToolContext): boolean {
   return (
-    context.trustClass === "guardian" || context.executionChannel === "vellum"
+    resolveCapabilities(context.trustClass).canAccessPrivilegedDocuments ||
+    context.executionChannel === "vellum"
   );
 }
 


### PR DESCRIPTION
## Summary
- Migrate document-tool guardian check to resolveCapabilities(...).canAccessPrivilegedDocuments, keeping the vellum-channel override as a composition.
- Behavior-preserving.

Part of plan: trust-class-capabilities-migration.md (PR 7 of 13)