### PR TITLE
refactor(assistant): gate memory access via canAccessMemory capability

### DIFF
--- a/assistant/src/context/compactor.ts
+++ b/assistant/src/context/compactor.ts
@@ -37,10 +37,8 @@ import type {
   ProviderResponse,
   ToolDefinition,
 } from "../providers/types.js";
-import {
-  isUntrustedTrustClass,
-  type TrustClass,
-} from "../runtime/actor-trust-resolver.js";
+import { type TrustClass } from "../runtime/actor-trust-resolver.js";
+import { resolveCapabilities } from "../runtime/capabilities.js";
 import { getLogger } from "../util/logger.js";
 import { stripInjectionsForCompaction } from "./strip-injections.js";
 import {
@@ -387,7 +385,7 @@ export function collectImageManifest(
   actorTrustClass?: TrustClass,
 ): ManifestEntry[] {
   const allRows = getMessages(conversationId);
-  const rows = isUntrustedTrustClass(actorTrustClass)
+  const rows = !resolveCapabilities(actorTrustClass).canAccessMemory
     ? filterMessagesForUntrustedActor(allRows)
     : allRows;
   const entries: ManifestEntry[] = [];

--- a/assistant/src/memory/auto-analysis-enqueue.ts
+++ b/assistant/src/memory/auto-analysis-enqueue.ts
@@ -1,9 +1,7 @@
 import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getConfig } from "../config/loader.js";
-import {
-  isUntrustedTrustClass,
-  type TrustClass,
-} from "../runtime/actor-trust-resolver.js";
+import { type TrustClass } from "../runtime/actor-trust-resolver.js";
+import { resolveCapabilities } from "../runtime/capabilities.js";
 import { getLogger } from "../util/logger.js";
 import { isAutoAnalysisConversation } from "./auto-analysis-guard.js";
 import { isMemoryEnabled, upsertAutoAnalysisJob } from "./jobs-store.js";
@@ -118,7 +116,7 @@ export function enqueueAutoAnalysisOnCompaction(
   conversationId: string,
   trustClass: TrustClass | undefined,
 ): void {
-  if (isUntrustedTrustClass(trustClass)) {
+  if (!resolveCapabilities(trustClass).canAccessMemory) {
     return;
   }
   try {

--- a/assistant/src/memory/memory-retrospective-enqueue.ts
+++ b/assistant/src/memory/memory-retrospective-enqueue.ts
@@ -13,10 +13,8 @@
 // after the corresponding signal settles; `interval` and `message_count`
 // fire immediately.
 
-import {
-  isUntrustedTrustClass,
-  type TrustClass,
-} from "../runtime/actor-trust-resolver.js";
+import { type TrustClass } from "../runtime/actor-trust-resolver.js";
+import { resolveCapabilities } from "../runtime/capabilities.js";
 import { getLogger } from "../util/logger.js";
 import { getConversationSource } from "./conversation-crud.js";
 import { isMemoryEnabled, upsertMemoryRetrospectiveJob } from "./jobs-store.js";
@@ -86,7 +84,7 @@ export function enqueueMemoryRetrospectiveOnCompaction(
   conversationId: string,
   trustClass: TrustClass | undefined,
 ): void {
-  if (isUntrustedTrustClass(trustClass)) {
+  if (!resolveCapabilities(trustClass).canAccessMemory) {
     return;
   }
   try {

--- a/assistant/src/tools/memory/register.ts
+++ b/assistant/src/tools/memory/register.ts
@@ -10,7 +10,7 @@ import {
   graphRememberDefinition,
 } from "../../memory/graph/tools.js";
 import { RiskLevel } from "../../permissions/types.js";
-import { isUntrustedTrustClass } from "../../runtime/actor-trust-resolver.js";
+import { resolveCapabilities } from "../../runtime/capabilities.js";
 import type {
   ToolContext,
   ToolDefinition,
@@ -60,7 +60,7 @@ export const recallTool = {
     input: Record<string, unknown>,
     context: ToolContext,
   ): Promise<ToolExecutionResult> {
-    if (isUntrustedTrustClass(context.trustClass)) {
+    if (!resolveCapabilities(context.trustClass).canAccessMemory) {
       return {
         content:
           "Recall is only available to the guardian because it can read sensitive local context.",


### PR DESCRIPTION
## Summary
- Replace inline isUntrustedTrustClass memory gates with resolveCapabilities(...).canAccessMemory across auto-analysis, retrospective, recall, and compaction.
- Behavior-preserving: guardian gets memory work; all other classes skip it.

Part of plan: trust-class-capabilities-migration.md (PR 2 of 13)