### PR TITLE
refactor(assistant): gate verification control-plane via capability

### DIFF
--- a/assistant/src/tools/verification-control-plane-policy.ts
+++ b/assistant/src/tools/verification-control-plane-policy.ts
@@ -10,7 +10,6 @@
  *   /v1/channel-verification-sessions/revoke
  */
 
-import type { TrustClass } from "../runtime/actor-trust-resolver.js";
 import { resolveCapabilities } from "../runtime/capabilities.js";
 
 const VERIFICATION_ENDPOINT_PATHS = [
@@ -131,15 +130,7 @@ export function enforceVerificationControlPlanePolicy(
     return { denied: false };
   }
 
-  const tc: TrustClass | undefined =
-    trustClass === "guardian" ||
-    trustClass === "trusted_contact" ||
-    trustClass === "unverified_contact" ||
-    trustClass === "unknown"
-      ? trustClass
-      : undefined;
-
-  if (resolveCapabilities(tc).canUseVerificationControlPlane) {
+  if (resolveCapabilities(trustClass).canUseVerificationControlPlane) {
     return { denied: false };
   }
 

--- a/assistant/src/tools/verification-control-plane-policy.ts
+++ b/assistant/src/tools/verification-control-plane-policy.ts
@@ -10,6 +10,9 @@
  *   /v1/channel-verification-sessions/revoke
  */
 
+import type { TrustClass } from "../runtime/actor-trust-resolver.js";
+import { resolveCapabilities } from "../runtime/capabilities.js";
+
 const VERIFICATION_ENDPOINT_PATHS = [
   "/v1/channel-verification-sessions",
   "/v1/channel-verification-sessions/resend",
@@ -128,7 +131,15 @@ export function enforceVerificationControlPlanePolicy(
     return { denied: false };
   }
 
-  if (trustClass === "guardian") {
+  const tc: TrustClass | undefined =
+    trustClass === "guardian" ||
+    trustClass === "trusted_contact" ||
+    trustClass === "unverified_contact" ||
+    trustClass === "unknown"
+      ? trustClass
+      : undefined;
+
+  if (resolveCapabilities(tc).canUseVerificationControlPlane) {
     return { denied: false };
   }
 


### PR DESCRIPTION
## Summary
- Gate verification control-plane access via resolveCapabilities(...).canUseVerificationControlPlane.
- Normalizes/​tightens the trust-class input so only guardian passes; no accidental allow.

Part of plan: trust-class-capabilities-migration.md (PR 6 of 13)