### PR TITLE
refactor(assistant): gate tool approval via sensitiveToolApproval capability

### DIFF
--- a/assistant/src/runtime/confirmation-request-guardian-bridge.ts
+++ b/assistant/src/runtime/confirmation-request-guardian-bridge.ts
@@ -21,6 +21,7 @@ import { emitNotificationSignal } from "../notifications/emit-signal.js";
 import { canonicalizeInboundIdentity } from "../util/canonicalize-identity.js";
 import { getLogger } from "../util/logger.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "./assistant-scope.js";
+import { resolveCapabilities } from "./capabilities.js";
 import { getGuardianBinding } from "./channel-verification-service.js";
 
 const log = getLogger("confirmation-request-guardian-bridge");
@@ -79,12 +80,12 @@ export function bridgeConfirmationRequestToGuardian(
     assistantId = DAEMON_INTERNAL_ASSISTANT_ID,
   } = params;
 
-  // Only bridge for identity-known non-guardian sessions (trusted_contact and
-  // unverified_contact). Guardians self-approve and unknown actors are
-  // fail-closed by the routing layer.
+  // Only bridge for actors whose sensitive tool approval escalates-and-waits.
+  // Guardians self-approve and unknown actors are fail-closed by the routing
+  // layer, so neither needs a guardian bridge.
   if (
-    trustContext.trustClass !== "trusted_contact" &&
-    trustContext.trustClass !== "unverified_contact"
+    resolveCapabilities(trustContext.trustClass).sensitiveToolApproval !==
+    "escalate-and-wait"
   ) {
     return { skipped: true, reason: "not_bridgeable_trust_class" };
   }

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -9,7 +9,7 @@ import {
   isUnparseableToolArgs,
   unparseableToolArgsMessage,
 } from "../providers/unparseable-tool-args.js";
-import { isUntrustedTrustClass } from "../runtime/actor-trust-resolver.js";
+import { resolveCapabilities } from "../runtime/capabilities.js";
 import { createOrReuseToolGrantRequest } from "../runtime/tool-grant-request-helper.js";
 import { redactSecrets } from "../security/secret-scanner.js";
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
@@ -176,7 +176,7 @@ function guardianApprovalDeniedMessage(
   trustClass: ToolContext["trustClass"],
   toolName: string,
 ): string {
-  if (trustClass === "unknown") {
+  if (resolveCapabilities(trustClass).sensitiveToolApproval === "deny") {
     return `Permission denied for "${toolName}": this action requires guardian approval from a verified channel identity.`;
   }
   return `Permission denied for "${toolName}": this action requires guardian approval and the current actor is not the guardian.`;
@@ -322,7 +322,11 @@ export class ToolApprovalHandler {
       executionTarget,
     );
 
-    if (isUntrustedTrustClass(context.trustClass) && guardianApprovalRequired) {
+    if (
+      resolveCapabilities(context.trustClass).sensitiveToolApproval !==
+        "self" &&
+      guardianApprovalRequired
+    ) {
       const inputDigest = computeToolApprovalDigest(name, input);
       needsGrantConsumption = true;
       deferredConsumeParams = {
@@ -540,8 +544,8 @@ export class ToolApprovalHandler {
       // Actors with no identity (unknown) remain fail-closed with no
       // escalation or wait.
       if (
-        (context.trustClass === "trusted_contact" ||
-          context.trustClass === "unverified_contact") &&
+        resolveCapabilities(context.trustClass).sensitiveToolApproval ===
+          "escalate-and-wait" &&
         context.assistantId &&
         context.executionChannel &&
         context.requesterExternalUserId


### PR DESCRIPTION
## Summary
- Replace tool-approval-handler trust-class branches with resolveCapabilities(...).sensitiveToolApproval (self/escalate-and-wait/deny).
- Gate the guardian-bridge notification on sensitiveToolApproval === escalate-and-wait (contacts only).
- Behavior-preserving.

Part of plan: trust-class-capabilities-migration.md (PR 9 of 13)