### PR TITLE
refactor(assistant): remove isUntrustedTrustClass shim

### DIFF
--- a/assistant/src/__tests__/conversation-lifecycle.test.ts
+++ b/assistant/src/__tests__/conversation-lifecycle.test.ts
@@ -674,7 +674,7 @@ describe("loadFromDb metadata injection rehydration", () => {
   });
 
   test("internal-channel trusted_contact view still rehydrates memoryV2StaticBlock", async () => {
-    // Regression: the prior `!isUntrustedTrustClass(trustClass)` gate
+    // Regression: the prior `resolveCapabilities(trustClass).canAccessMemory` gate
     // blocked any non-guardian view from rehydrating personal memory,
     // including legitimate internal flows (e.g. trusted_contact actors
     // arriving over the internal `"vellum"` channel). Injection time

--- a/assistant/src/__tests__/credential-execution-shell-lockdown.test.ts
+++ b/assistant/src/__tests__/credential-execution-shell-lockdown.test.ts
@@ -11,31 +11,33 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { isUntrustedTrustClass } from "../runtime/actor-trust-resolver.js";
+import { resolveCapabilities } from "../runtime/capabilities.js";
 
 // ---------------------------------------------------------------------------
 // Trust class categorization (foundational for lockdown decisions)
 // ---------------------------------------------------------------------------
 
 describe("trust class categorization for CES lockdown", () => {
-  test("guardian is not untrusted", () => {
-    expect(isUntrustedTrustClass("guardian")).toBe(false);
+  test("guardian runs an unsandboxed shell", () => {
+    expect(resolveCapabilities("guardian").unsandboxedShell).toBe(true);
   });
 
-  test("trusted_contact is untrusted", () => {
-    expect(isUntrustedTrustClass("trusted_contact")).toBe(true);
+  test("trusted_contact shell is sandboxed", () => {
+    expect(resolveCapabilities("trusted_contact").unsandboxedShell).toBe(false);
   });
 
-  test("unverified_contact is untrusted", () => {
-    expect(isUntrustedTrustClass("unverified_contact")).toBe(true);
+  test("unverified_contact shell is sandboxed", () => {
+    expect(resolveCapabilities("unverified_contact").unsandboxedShell).toBe(
+      false,
+    );
   });
 
-  test("unknown is untrusted", () => {
-    expect(isUntrustedTrustClass("unknown")).toBe(true);
+  test("unknown shell is sandboxed", () => {
+    expect(resolveCapabilities("unknown").unsandboxedShell).toBe(false);
   });
 
-  test("undefined is untrusted", () => {
-    expect(isUntrustedTrustClass(undefined)).toBe(true);
+  test("undefined shell is sandboxed", () => {
+    expect(resolveCapabilities(undefined).unsandboxedShell).toBe(false);
   });
 });
 
@@ -95,7 +97,7 @@ describe("VELLUM_UNTRUSTED_SHELL env flag", () => {
 describe("CES shell lockdown activation", () => {
   test("lockdown is active only when both flag is enabled AND actor is untrusted", () => {
     // Simulates the condition used in shell.ts:
-    // const shellLockdownActive = isCesShellLockdownEnabled(config) && isUntrustedTrustClass(context.trustClass);
+    // const shellLockdownActive = isCesShellLockdownEnabled(config) && !resolveCapabilities(context.trustClass).unsandboxedShell;
     const cases: Array<{
       flagEnabled: boolean;
       trustClass: "guardian" | "trusted_contact" | "unknown";
@@ -110,7 +112,8 @@ describe("CES shell lockdown activation", () => {
     ];
 
     for (const { flagEnabled, trustClass, expected } of cases) {
-      const active = flagEnabled && isUntrustedTrustClass(trustClass);
+      const active =
+        flagEnabled && !resolveCapabilities(trustClass).unsandboxedShell;
       expect(active).toBe(expected);
     }
   });

--- a/assistant/src/daemon/__tests__/conversation-lifecycle-auto-analyze.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-lifecycle-auto-analyze.test.ts
@@ -236,8 +236,9 @@ describe("disposeConversation — auto-analysis enqueue", () => {
 
   test("untrusted conversation — enqueues neither graph_extract nor conversation_analyze", () => {
     // `unknown` is the trust class used for untrusted actors. The disposal
-    // code short-circuits on `isUntrustedTrustClass()` so neither enqueue
-    // path should fire. This preserves the memory trust boundary.
+    // code short-circuits when `resolveCapabilities(trustClass).canAccessMemory`
+    // is false, so neither enqueue path should fire. This preserves the
+    // memory trust boundary.
     const ctx = makeDisposeContext({
       conversationId: "conv-untrusted",
       trustClass: "unknown",

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -70,9 +70,9 @@ import type { UserPromptSubmitContext } from "../plugin-api/types.js";
 import { runHook } from "../plugins/pipeline.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 import type { Provider } from "../providers/types.js";
-import { isUntrustedTrustClass } from "../runtime/actor-trust-resolver.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
+import { resolveCapabilities } from "../runtime/capabilities.js";
 import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
 import type { ActivationMomentParam } from "../telemetry/activation-funnel.js";
 import type { UsageActor } from "../usage/actors.js";
@@ -1604,9 +1604,9 @@ export async function applyCompactionResult(
   // in-context boundary rather than the raw mirror so the persisted count
   // stays consistent with what the new summary represents and never
   // double-counts an unsliced untrusted view.
-  const inContextCompactedCount = isUntrustedTrustClass(
+  const inContextCompactedCount = !resolveCapabilities(
     ctx.trustContext?.trustClass,
-  )
+  ).canAccessMemory
     ? 0
     : ctx.contextCompactedMessageCount;
   ctx.contextCompactedMessageCount =

--- a/assistant/src/daemon/conversation-lifecycle.ts
+++ b/assistant/src/daemon/conversation-lifecycle.ts
@@ -16,10 +16,8 @@ import type { PermissionPrompter } from "../permissions/prompter.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
 import { disposeContextWindowManager } from "../plugins/defaults/compaction/manager-store.js";
 import type { ContentBlock, Message } from "../providers/types.js";
-import {
-  isUntrustedTrustClass,
-  type TrustClass,
-} from "../runtime/actor-trust-resolver.js";
+import { type TrustClass } from "../runtime/actor-trust-resolver.js";
+import { resolveCapabilities } from "../runtime/capabilities.js";
 import { unregisterConversationSender } from "../tools/browser/browser-screencast.js";
 import { type AbortReason, createAbortReason } from "../util/abort-reasons.js";
 import { getLogger } from "../util/logger.js";
@@ -147,7 +145,7 @@ export function disposeConversation(ctx: DisposeContext): void {
   // Trigger graph extraction for end-of-conversation sweep.
   // Only extract from guardian conversations to preserve the memory trust
   // boundary — untrusted content must not influence future memory retrieval.
-  if (!isUntrustedTrustClass(ctx.trustContext?.trustClass)) {
+  if (resolveCapabilities(ctx.trustContext?.trustClass).canAccessMemory) {
     // Recursion guard: skip graph_extract for auto-analysis conversations.
     // The analysis agent writes memory directly via tools, so extracting
     // from its reflective musings would double-write into the memory graph.

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -62,11 +62,11 @@ import type {
 import type { ContentBlock, Message } from "../providers/types.js";
 import {
   type ActorTrustContext,
-  isUntrustedTrustClass,
   resolveActorTrust,
   type TrustClass,
 } from "../runtime/actor-trust-resolver.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
+import { resolveCapabilities } from "../runtime/capabilities.js";
 import { channelStatusToMemberStatus } from "../runtime/routes/inbound-stages/acl-enforcement.js";
 import { getSubagentManager } from "../subagent/index.js";
 import type { SubagentState } from "../subagent/types.js";
@@ -916,7 +916,7 @@ function filterSlackConversationRowsForActor(
   rows: MessageRow[],
   trustClass: TrustClass | undefined,
 ): MessageRow[] {
-  if (!isUntrustedTrustClass(trustClass)) return rows;
+  if (resolveCapabilities(trustClass).canAccessMemory) return rows;
   const nonSlackVisibleRows = filterMessagesForUntrustedActor(rows);
   const nonSlackVisibleIds = new Set(nonSlackVisibleRows.map((row) => row.id));
   return rows.filter((row) => {
@@ -1323,9 +1323,9 @@ export function loadSlackChronologicalContext(
     options,
   );
   return assembleSlackChronologicalContext(rows, capabilities, {
-    contextSummary: isUntrustedTrustClass(options.trustClass)
-      ? null
-      : options.contextSummary,
+    contextSummary: resolveCapabilities(options.trustClass).canAccessMemory
+      ? options.contextSummary
+      : null,
   });
 }
 

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -80,12 +80,10 @@ import {
 } from "../prompts/system-prompt.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 import type { Provider } from "../providers/types.js";
-import {
-  isUntrustedTrustClass,
-  type TrustClass,
-} from "../runtime/actor-trust-resolver.js";
+import { type TrustClass } from "../runtime/actor-trust-resolver.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import type { AuthContext } from "../runtime/auth/types.js";
+import { resolveCapabilities } from "../runtime/capabilities.js";
 import type { InteractiveUiResult } from "../runtime/interactive-ui.js";
 import { publishSyncInvalidation } from "../runtime/sync/sync-publisher.js";
 import {
@@ -854,10 +852,11 @@ export class Conversation {
 
   async loadFromDb(): Promise<void> {
     const trustClass = this.trustContext?.trustClass;
+    const canAccessMemory = resolveCapabilities(trustClass).canAccessMemory;
     const allDbMessages = getMessages(this.conversationId);
-    const dbMessages = isUntrustedTrustClass(trustClass)
-      ? filterMessagesForUntrustedActor(allDbMessages)
-      : allDbMessages;
+    const dbMessages = canAccessMemory
+      ? allDbMessages
+      : filterMessagesForUntrustedActor(allDbMessages);
 
     // Rehydrate the in-memory turn counter from persisted history. `turnCount`
     // is otherwise a fresh-zero field, so a reloaded conversation (eviction,
@@ -899,12 +898,12 @@ export class Conversation {
     // than exist. Slack chronological context is a separate consumer that
     // applies its own trust filtering downstream, so it reads the raw
     // mirrored count rather than this in-context boundary.
-    const inContextCompactedCount = isUntrustedTrustClass(trustClass)
-      ? 0
-      : Math.min(this.contextCompactedMessageCount, dbMessages.length);
-    const contextSummaryForHistory = isUntrustedTrustClass(trustClass)
-      ? null
-      : this.contextSummary?.trim() || null;
+    const inContextCompactedCount = canAccessMemory
+      ? Math.min(this.contextCompactedMessageCount, dbMessages.length)
+      : 0;
+    const contextSummaryForHistory = canAccessMemory
+      ? this.contextSummary?.trim() || null
+      : null;
 
     // Every injection-strip event (`/clean` or compaction) updates
     // `historyStrippedAt`. Messages older than this should skip metadata

--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -2,8 +2,8 @@ import { v4 as uuid } from "uuid";
 
 import { clearAll, getConversation } from "../../memory/conversation-crud.js";
 import { resolveConversationId } from "../../memory/conversation-key-store.js";
-import { isUntrustedTrustClass } from "../../runtime/actor-trust-resolver.js";
 import { broadcastMessage } from "../../runtime/assistant-event-hub.js";
+import { resolveCapabilities } from "../../runtime/capabilities.js";
 import { getSubagentManager } from "../../subagent/index.js";
 import { createAbortReason } from "../../util/abort-reasons.js";
 import { UserError } from "../../util/errors.js";
@@ -184,7 +184,7 @@ export async function resolveMetaSlashCommand(
   // Temporarily apply the guardian context for hydration and restore it
   // afterward so the elevated class never leaks into a later turn's snapshot.
   const priorTrustContext = conversation.trustContext;
-  if (isUntrustedTrustClass(priorTrustContext?.trustClass)) {
+  if (!resolveCapabilities(priorTrustContext?.trustClass).canAccessMemory) {
     conversation.setTrustContext(INTERNAL_GUARDIAN_TRUST_CONTEXT);
   }
   try {

--- a/assistant/src/memory/__tests__/auto-analysis-enqueue.test.ts
+++ b/assistant/src/memory/__tests__/auto-analysis-enqueue.test.ts
@@ -76,17 +76,6 @@ mock.module("../jobs-store.js", () => ({
   },
 }));
 
-// Mirror production semantics from `isUntrustedTrustClass` in
-// actor-trust-resolver.ts: anything that isn't `guardian` is untrusted.
-// Keeping these in sync guards the compaction trust boundary — a drifting
-// mock would let regressions pass as false positives.
-mock.module("../../runtime/actor-trust-resolver.js", () => ({
-  isUntrustedTrustClass: (trustClass: string | undefined) =>
-    trustClass === "trusted_contact" ||
-    trustClass === "unknown" ||
-    trustClass === undefined,
-}));
-
 import {
   enqueueAutoAnalysisIfEnabled,
   enqueueAutoAnalysisOnCompaction,
@@ -315,9 +304,9 @@ describe("enqueueAutoAnalysisOnCompaction", () => {
   });
 
   test("undefined trust class — skips (fail-closed when trust is unresolved)", () => {
-    // `isUntrustedTrustClass(undefined)` is true in production, so
-    // compaction-triggered analysis must NOT fire when the caller cannot
-    // establish a trust class.
+    // `resolveCapabilities(undefined).canAccessMemory` is false in
+    // production, so compaction-triggered analysis must NOT fire when the
+    // caller cannot establish a trust class.
     enqueueAutoAnalysisOnCompaction("c1", undefined);
 
     expect(enqueueCalls).toHaveLength(0);
@@ -332,8 +321,8 @@ describe("enqueueAutoAnalysisOnCompaction", () => {
   });
 
   test("trusted_contact trust class — skips (only guardian is trusted)", () => {
-    // trusted_contact is in the untrusted set per production
-    // `isUntrustedTrustClass`, so compaction-triggered analysis must NOT
+    // trusted_contact lacks `canAccessMemory` per production
+    // `resolveCapabilities`, so compaction-triggered analysis must NOT
     // fire. Only `guardian` passes the gate.
     enqueueAutoAnalysisOnCompaction("c1", "trusted_contact");
 

--- a/assistant/src/memory/__tests__/jobs-store-enqueue-gate.test.ts
+++ b/assistant/src/memory/__tests__/jobs-store-enqueue-gate.test.ts
@@ -48,11 +48,6 @@ mock.module("../../config/assistant-feature-flags.js", () => ({
   isAssistantFeatureFlagEnabled: () => true,
 }));
 
-// Stub trust resolver — never claim the actor is untrusted in tests.
-mock.module("../../runtime/actor-trust-resolver.js", () => ({
-  isUntrustedTrustClass: () => false,
-}));
-
 // Stub the conversation-source lookup so the recursion guards in the
 // retrospective and auto-analysis paths fall through to the enqueue.
 mock.module("../conversation-crud.js", () => ({

--- a/assistant/src/memory/__tests__/memory-retrospective-enqueue.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-enqueue.test.ts
@@ -31,13 +31,6 @@ mock.module("../jobs-store.js", () => ({
   },
 }));
 
-mock.module("../../runtime/actor-trust-resolver.js", () => ({
-  isUntrustedTrustClass: (trustClass: string | undefined) =>
-    trustClass === "trusted_contact" ||
-    trustClass === "unknown" ||
-    trustClass === undefined,
-}));
-
 import {
   enqueueMemoryRetrospectiveIfEnabled,
   enqueueMemoryRetrospectiveOnCompaction,

--- a/assistant/src/runtime/actor-trust-resolver.ts
+++ b/assistant/src/runtime/actor-trust-resolver.ts
@@ -73,18 +73,6 @@ export const TRUST_CLASS_RANK: Record<TrustClass, number> = {
   unknown: 1,
 };
 
-/** Returns `true` for actors that are not fully trusted (i.e. not the guardian). */
-export function isUntrustedTrustClass(
-  trustClass: TrustClass | undefined,
-): boolean {
-  return (
-    trustClass === "trusted_contact" ||
-    trustClass === "unverified_contact" ||
-    trustClass === "unknown" ||
-    trustClass === undefined
-  );
-}
-
 /**
  * Fully resolved trust context from the actor trust resolver.
  *

--- a/assistant/src/runtime/capabilities.ts
+++ b/assistant/src/runtime/capabilities.ts
@@ -3,9 +3,9 @@
  *
  * Separates *what an actor can do* (capabilities/permissions) from *who the
  * actor is* (`TrustClass`, their role/level). Today the ~40+ decision sites
- * re-derive permissions inline from the raw class (`trustClass === "guardian"`,
- * `isUntrustedTrustClass(...)`). This resolves the class to a named capability
- * set in one place so call sites read a capability instead of re-deriving it.
+ * re-derive permissions inline from the raw class (`trustClass === "guardian"`).
+ * This resolves the class to a named capability set in one place so call sites
+ * read a capability instead of re-deriving it.
  *
  * Stateless / derive-on-read: capabilities are derived from the already-resolved
  * (and already-persisted) `trustClass` at point of use. Nothing here is stored;


### PR DESCRIPTION
## Summary
- Migrate the remaining daemon conversation/memory trust-class gates to resolveCapabilities(...).canAccessMemory (and unsandboxedShell where appropriate).
- Convert/clean tests that referenced isUntrustedTrustClass; remove dead mocks.
- Delete the now-unused isUntrustedTrustClass helper.

Part of plan: trust-class-capabilities-migration.md (PR 13 of 13)