### PR TITLE
feat(plugins): expose forceOverrideProfile on getConfiguredProvider

### DIFF
--- a/assistant/src/__tests__/provider-send-message-override-profile.test.ts
+++ b/assistant/src/__tests__/provider-send-message-override-profile.test.ts
@@ -261,3 +261,79 @@ describe("SendMessageOptions.config.overrideProfile", () => {
     expect(captured?.overrideProfile).toBeUndefined();
   });
 });
+
+describe("SendMessageOptions.config.forceOverrideProfile", () => {
+  test("CallSiteConfiguredProvider forwards forceOverrideProfile into the send config", async () => {
+    let captured: SendMessageOptions | undefined;
+    const inner: Provider = {
+      name: "anthropic",
+      async sendMessage(
+        _messages: Message[],
+        options?: SendMessageOptions,
+      ): Promise<ProviderResponse> {
+        captured = options;
+        return makeResponse("anthropic");
+      },
+    };
+
+    const provider = new CallSiteConfiguredProvider(
+      inner,
+      "inference",
+      "strong",
+      true,
+    );
+    await provider.sendMessage(DUMMY_MESSAGES, {});
+
+    expect(captured?.config).toMatchObject({
+      callSite: "inference",
+      overrideProfile: "strong",
+      forceOverrideProfile: true,
+    });
+  });
+
+  test("forceOverrideProfile floats the override above a call-site profile pin", async () => {
+    // The advisor scenario in miniature: the `inference` call site is pinned to
+    // a cheap profile, but a caller forces a stronger profile for its own send.
+    setLlmConfig({
+      default: { provider: "anthropic", model: "claude-opus-4-7" },
+      profiles: {
+        cheap: { provider: "anthropic", model: "claude-haiku-4-5-20251001" },
+        strong: { provider: "anthropic", model: "claude-opus-4-8" },
+      },
+      callSites: { inference: { profile: "cheap" } },
+    });
+
+    const send = async (force: boolean) => {
+      let captured: Record<string, unknown> | undefined;
+      const inner: Provider = {
+        name: "anthropic",
+        async sendMessage(
+          _messages: Message[],
+          options?: SendMessageOptions,
+        ): Promise<ProviderResponse> {
+          captured = options?.config as Record<string, unknown> | undefined;
+          return makeResponse("anthropic");
+        },
+      };
+      const provider = new RetryProvider(inner);
+      await provider.sendMessage(DUMMY_MESSAGES, {
+        config: {
+          callSite: "inference",
+          overrideProfile: "strong",
+          ...(force ? { forceOverrideProfile: true } : {}),
+        },
+      });
+      return captured;
+    };
+
+    // Without the flag, the call-site pin (`cheap`) outranks `overrideProfile`.
+    expect((await send(false))?.model).toBe("claude-haiku-4-5-20251001");
+
+    // With the flag, the forced `strong` profile wins over the call-site pin.
+    const forced = await send(true);
+    expect(forced?.model).toBe("claude-opus-4-8");
+    // The routing keys are stripped before the provider wire request.
+    expect(forced?.overrideProfile).toBeUndefined();
+    expect(forced?.forceOverrideProfile).toBeUndefined();
+  });
+});

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -136,5 +136,9 @@ export { getModelProfiles } from "./model-profiles.js";
 // plugin can run inference through the workspace's configured profiles and
 // credentials — managed-proxy or BYOK — without supplying its own API key.
 // Pair with `getModelProfiles` to pick a profile. Returns `null` when no
-// provider is configured.
+// provider is configured. By default `overrideProfile` layers below any
+// per-call-site config the workspace has pinned (e.g. a cheap `inference`
+// profile), so it loses to that pin; pass `forceOverrideProfile: true` to
+// float the chosen profile above the call-site layers when the plugin must
+// run on a specific profile regardless of workspace tuning.
 export { getConfiguredProvider } from "../providers/provider-send-message.js";

--- a/assistant/src/providers/provider-send-message.ts
+++ b/assistant/src/providers/provider-send-message.ts
@@ -48,6 +48,7 @@ export class CallSiteConfiguredProvider implements Provider {
     private readonly inner: Provider,
     private readonly callSite: LLMCallSite,
     private readonly overrideProfile?: string,
+    private readonly forceOverrideProfile?: boolean,
   ) {
     this.name = inner.name;
     this.tokenEstimationProvider = inner.tokenEstimationProvider;
@@ -71,6 +72,10 @@ export class CallSiteConfiguredProvider implements Provider {
         this.overrideProfile !== undefined
           ? { overrideProfile: this.overrideProfile }
           : {}),
+        ...(config?.forceOverrideProfile === undefined &&
+        this.forceOverrideProfile !== undefined
+          ? { forceOverrideProfile: this.forceOverrideProfile }
+          : {}),
       },
     });
   }
@@ -88,13 +93,15 @@ export class CallSiteConfiguredProvider implements Provider {
  * matching call-site identifier from `LLMCallSiteEnum` when adding a new
  * caller. Pass `opts.overrideProfile` to apply a per-call ad-hoc profile
  * override (e.g. a per-conversation pinned profile) on top of any workspace
- * `activeProfile`.
+ * `activeProfile`. Pass `opts.forceOverrideProfile` to float that override
+ * above the call-site layers (named site profile + call-site override) for
+ * non-main-agent call sites — see `ResolveCallSiteOpts.forceOverrideProfile`.
  *
  * Returns `null` when no providers are available at all.
  */
 export async function resolveConfiguredProvider(
   callSite: LLMCallSite,
-  opts: { overrideProfile?: string } = {},
+  opts: { overrideProfile?: string; forceOverrideProfile?: boolean } = {},
 ): Promise<ConfiguredProviderResult | null> {
   const config = getConfig();
 
@@ -174,6 +181,7 @@ export async function resolveConfiguredProvider(
       connectionProvider,
       callSite,
       opts.overrideProfile,
+      opts.forceOverrideProfile,
     ),
     configuredProviderName: inferenceProvider,
   };
@@ -189,7 +197,7 @@ export async function resolveConfiguredProvider(
  */
 export async function getConfiguredProvider(
   callSite: LLMCallSite,
-  opts: { overrideProfile?: string } = {},
+  opts: { overrideProfile?: string; forceOverrideProfile?: boolean } = {},
 ): Promise<Provider | null> {
   const result = await resolveConfiguredProvider(callSite, opts);
   return result?.provider ?? null;


### PR DESCRIPTION
## Summary
- Thread an optional `forceOverrideProfile` through the plugin-facing `getConfiguredProvider` / `resolveConfiguredProvider` entry points and `CallSiteConfiguredProvider`, so a plugin's `overrideProfile` can float above a workspace's per-call-site profile pin. The deep resolver/routing layers (`llm-resolver`, `call-site-routing`, `retry`) already honored the flag — only the public entry points dropped it.
- Backward-compatible: new optional field, default-undefined preserves today's "call-site override wins" behavior.
- Document the option on the `@vellumai/plugin-api` `getConfiguredProvider` re-export, and add wrapper + end-to-end resolver tests reproducing the pinned-call-site scenario.

## Original prompt
While enabling a marketplace plugin (advisor) for a heavily-tuned assistant, we found it consults through the shared `inference` call site using `overrideProfile` — but that call site was pinned to a cheap profile, and a call-site override outranks `overrideProfile`, so the plugin would silently run on the cheap model regardless of its configured profile. The `forceOverrideProfile` escape hatch that fixes this existed in the resolver but was not reachable from the plugin-facing provider API. Expose it so a plugin can force its profile above ambient workspace tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)