### PR TITLE
feat(gateway): expose channel admission policy over IPC

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -192,6 +192,7 @@ import {
 import { GatewayIpcServer } from "./ipc/server.js";
 import { contactRoutes } from "./ipc/contact-handlers.js";
 import { featureFlagRoutes } from "./ipc/feature-flag-handlers.js";
+import { admissionPolicyRoutes } from "./ipc/admission-policy-handlers.js";
 import { createLogTailRoutes } from "./ipc/log-tail-handlers.js";
 import { slackThreadRoutes } from "./ipc/slack-thread-handlers.js";
 import { thresholdRoutes } from "./ipc/threshold-handlers.js";
@@ -2480,6 +2481,7 @@ async function main() {
     ...contactRoutes,
     ...slackThreadRoutes,
     ...thresholdRoutes,
+    ...admissionPolicyRoutes,
     ...riskClassificationRoutes,
     ...createLogTailRoutes(config),
     ...trustRulesRoutes,

--- a/gateway/src/ipc/__tests__/admission-policy-handlers.test.ts
+++ b/gateway/src/ipc/__tests__/admission-policy-handlers.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests for the gateway channel admission policy IPC route.
+ *
+ * The handler is driven directly with a stubbed feature-flag resolver and an
+ * injected admission-policy cache, following the existing gateway IPC handler
+ * test patterns (see trust-rules-handlers.test.ts).
+ */
+
+import type { AdmissionPolicy } from "@vellumai/gateway-client";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let flagEnabled = true;
+const policiesByChannel = new Map<string, AdmissionPolicy>();
+
+mock.module("../../feature-flag-resolver.js", () => ({
+  isFeatureFlagEnabled: (_key: string) => flagEnabled,
+}));
+
+mock.module("../../risk/admission-policy-cache.js", () => ({
+  getAdmissionPolicyCache: () => ({
+    get: (channelType: string): AdmissionPolicy =>
+      policiesByChannel.get(channelType) ?? "trusted_contacts",
+  }),
+}));
+
+import { admissionPolicyRoutes } from "../admission-policy-handlers.js";
+
+function getPolicy(channelType: string) {
+  return admissionPolicyRoutes[0].handler({ channelType });
+}
+
+beforeEach(() => {
+  flagEnabled = true;
+  policiesByChannel.clear();
+});
+
+describe("admissionPolicyRoutes", () => {
+  test("registers get_channel_admission_policy with a channelType schema", () => {
+    const route = admissionPolicyRoutes[0];
+
+    expect(route.method).toBe("get_channel_admission_policy");
+    expect(route.schema?.safeParse({ channelType: "slack" }).success).toBe(
+      true,
+    );
+    expect(route.schema?.safeParse({ channelType: "" }).success).toBe(false);
+    expect(route.schema?.safeParse({}).success).toBe(false);
+  });
+
+  test("returns null policy when the flag is off", () => {
+    flagEnabled = false;
+    policiesByChannel.set("slack", "strangers");
+
+    expect(getPolicy("slack")).toEqual({ policy: null });
+  });
+
+  test("returns null policy for exempt channels", () => {
+    expect(getPolicy("phone")).toEqual({ policy: null });
+    expect(getPolicy("platform")).toEqual({ policy: null });
+    expect(getPolicy("a2a")).toEqual({ policy: null });
+  });
+
+  test("returns null policy for unknown channel strings", () => {
+    expect(getPolicy("not-a-channel")).toEqual({ policy: null });
+  });
+
+  test("returns the resolved policy for an enforced channel", () => {
+    policiesByChannel.set("slack", "any_contact");
+
+    expect(getPolicy("slack")).toEqual({ policy: "any_contact" });
+  });
+
+  test("falls back to the cache default for an enforced channel without an override", () => {
+    expect(getPolicy("slack")).toEqual({ policy: "trusted_contacts" });
+  });
+});

--- a/gateway/src/ipc/admission-policy-handlers.ts
+++ b/gateway/src/ipc/admission-policy-handlers.ts
@@ -1,0 +1,35 @@
+/**
+ * IPC route definitions for gateway-owned channel admission policy reads.
+ *
+ * Exposes the resolved per-channel admission policy to the assistant daemon
+ * over the IPC socket. Returns `null` when the channel-trust-floors flag is
+ * off, the channel is exempt, or the channel type is unknown.
+ */
+
+import { isAdmissionPolicyExemptChannel } from "@vellumai/gateway-client";
+import { z } from "zod";
+
+import { isChannelId } from "../channels/types.js";
+import { isFeatureFlagEnabled } from "../feature-flag-resolver.js";
+import { getAdmissionPolicyCache } from "../risk/admission-policy-cache.js";
+import type { IpcRoute } from "./server.js";
+
+const GetChannelAdmissionPolicySchema = z.object({
+  channelType: z.string().min(1),
+});
+
+export const admissionPolicyRoutes: IpcRoute[] = [
+  {
+    method: "get_channel_admission_policy",
+    schema: GetChannelAdmissionPolicySchema,
+    handler: (params?: Record<string, unknown>) => {
+      const { channelType } = GetChannelAdmissionPolicySchema.parse(params);
+
+      if (!isFeatureFlagEnabled("channel-trust-floors")) return { policy: null };
+      if (isAdmissionPolicyExemptChannel(channelType)) return { policy: null };
+      if (!isChannelId(channelType)) return { policy: null };
+
+      return { policy: getAdmissionPolicyCache().get(channelType) };
+    },
+  },
+];


### PR DESCRIPTION
## Summary
- Add `get_channel_admission_policy` IPC route returning the resolved per-channel admission policy, or null when the channel-trust-floors flag is off / the channel is exempt / unknown.
- Register the route on the gateway IPC server.

Part of plan: voice-admission.md (PR 1 of 6)