### PR TITLE
feat(gateway): enforce no_one kill switch on inbound Twilio voice

### DIFF
--- a/gateway/src/http/routes/twilio-voice-webhook.test.ts
+++ b/gateway/src/http/routes/twilio-voice-webhook.test.ts
@@ -9,6 +9,14 @@
  * - Outbound calls (callSessionId present) do not resolve or forward an assistantId.
  * - Validation failures are propagated as responses.
  * - Assistant IDs are NOT forwarded to the daemon (daemon uses internal scope).
+ * - The `no_one` admission kill switch rejects inbound voice with <Reject> TwiML.
+ *
+ * Kill-switch testing note: `phone` is still in the admission-policy exempt set
+ * (removed in PR 6 of the voice-admission plan). To exercise the kill switch in
+ * isolation here, the tests mock `isAdmissionPolicyExemptChannel` to force
+ * `phone` enforced and mock the admission-policy cache directly, rather than
+ * standing up a real store. The end-to-end (non-mocked exempt set) `no_one`
+ * assertion lands with PR 6's test updates.
  */
 import { describe, test, expect, mock, beforeEach } from "bun:test";
 import { resolvePublicBaseWssUrl } from "../../runtime/client.js";
@@ -58,6 +66,28 @@ mock.module("../../logger.js", () => ({
 mock.module("../../voice/verification.js", () => ({
   findPendingPhoneSession: async () => null,
   gatherVerificationTwiml: () => "<Response/>",
+}));
+
+// ── Admission-policy mocks (kill switch) ───────────────────────────────
+// Mutable knobs so individual tests can flip the flag / exempt state /
+// resolved policy without re-mocking. Defaults keep the kill switch a no-op
+// (flag off) so the pre-existing routing tests are unaffected.
+let flagEnabled = false;
+let phoneExempt = true;
+let phonePolicy = "everyone";
+
+mock.module("../../feature-flag-resolver.js", () => ({
+  isFeatureFlagEnabled: (flag: string) =>
+    flag === "channel-trust-floors" ? flagEnabled : false,
+}));
+
+mock.module("@vellumai/gateway-client", () => ({
+  isAdmissionPolicyExemptChannel: (channel: string) =>
+    channel === "phone" ? phoneExempt : false,
+}));
+
+mock.module("../../risk/admission-policy-cache.js", () => ({
+  getAdmissionPolicyCache: () => ({ get: () => phonePolicy }),
 }));
 
 import { createTwilioVoiceWebhookHandler } from "./twilio-voice-webhook.js";
@@ -130,6 +160,9 @@ describe("twilio voice webhook handler", () => {
     lastForwardedParams = undefined;
     _lastForwardedOriginalUrl = undefined;
     forwardCalled = false;
+    flagEnabled = false;
+    phoneExempt = true;
+    phonePolicy = "everyone";
   });
 
   test("inbound call resolves assistant by To number and forwards to daemon", async () => {
@@ -280,6 +313,95 @@ describe("twilio voice webhook handler", () => {
       From: "+14155551234",
       To: "+15550001111",
     });
+
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    expect(forwardCalled).toBe(true);
+  });
+
+  test("inbound call is rejected when phone admission policy is no_one (flag on, enforced)", async () => {
+    flagEnabled = true;
+    phoneExempt = false; // PR 6 removes phone from the exempt set; forced here.
+    phonePolicy = "no_one";
+
+    const handler = createTwilioVoiceWebhookHandler(
+      baseConfig,
+      makeCachesWithPhoneNumbers(),
+    );
+    const req = makeVoiceRequest({
+      CallSid: "CA_no_one",
+      From: "+14155551234",
+      To: "+15550001111",
+    });
+
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("<Reject");
+    expect(forwardCalled).toBe(false);
+  });
+
+  test("inbound call falls through to forwarding when policy is not no_one (flag on, enforced)", async () => {
+    flagEnabled = true;
+    phoneExempt = false;
+    phonePolicy = "everyone";
+
+    const handler = createTwilioVoiceWebhookHandler(
+      baseConfig,
+      makeCachesWithPhoneNumbers(),
+    );
+    const req = makeVoiceRequest({
+      CallSid: "CA_everyone",
+      From: "+14155551234",
+      To: "+15550001111",
+    });
+
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    expect(forwardCalled).toBe(true);
+  });
+
+  test("kill switch is a no-op while phone remains exempt even with policy no_one", async () => {
+    flagEnabled = true;
+    phoneExempt = true; // current state: phone exempt → kill switch skipped
+    phonePolicy = "no_one";
+
+    const handler = createTwilioVoiceWebhookHandler(
+      baseConfig,
+      makeCachesWithPhoneNumbers(),
+    );
+    const req = makeVoiceRequest({
+      CallSid: "CA_exempt",
+      From: "+14155551234",
+      To: "+15550001111",
+    });
+
+    const res = await handler(req);
+
+    expect(res.status).toBe(200);
+    expect(forwardCalled).toBe(true);
+  });
+
+  test("outbound call (callSessionId present) is never kill-switched", async () => {
+    flagEnabled = true;
+    phoneExempt = false;
+    phonePolicy = "no_one";
+
+    const handler = createTwilioVoiceWebhookHandler(
+      baseConfig,
+      makeCachesWithPhoneNumbers(),
+    );
+    const req = makeVoiceRequest(
+      {
+        CallSid: "CA_outbound_no_one",
+        From: "+15550001111",
+        To: "+14155559999",
+      },
+      "?callSessionId=existing-session-id",
+    );
 
     const res = await handler(req);
 

--- a/gateway/src/http/routes/twilio-voice-webhook.ts
+++ b/gateway/src/http/routes/twilio-voice-webhook.ts
@@ -1,7 +1,10 @@
+import { isAdmissionPolicyExemptChannel } from "@vellumai/gateway-client";
 import type { ConfigFileCache } from "../../config-file-cache.js";
 import type { GatewayConfig } from "../../config.js";
 import { credentialKey } from "../../credential-key.js";
+import { isFeatureFlagEnabled } from "../../feature-flag-resolver.js";
 import { getLogger } from "../../logger.js";
+import { getAdmissionPolicyCache } from "../../risk/admission-policy-cache.js";
 import {
   CircuitBreakerOpenError,
   forwardTwilioVoiceWebhook,
@@ -59,6 +62,25 @@ export function createTwilioVoiceWebhookHandler(
     let assistantId: string | undefined;
 
     if (!hasCallSessionId) {
+      // `no_one` kill switch — mirrors handle-inbound.ts. Only inbound is
+      // gated; outbound assistant-initiated calls are never kill-switched.
+      // No-op while `phone` stays in the admission exempt set (removed in PR 6).
+      const phonePolicy =
+        !isFeatureFlagEnabled("channel-trust-floors") ||
+        isAdmissionPolicyExemptChannel("phone")
+          ? null
+          : getAdmissionPolicyCache().get("phone");
+      if (phonePolicy === "no_one") {
+        log.info(
+          { callSid: params.CallSid, from: params.From, to: params.To },
+          "Inbound voice call hard-denied by admission policy 'no_one'",
+        );
+        return new Response(REJECT_TWIML, {
+          status: 200,
+          headers: TWIML_HEADERS,
+        });
+      }
+
       const phoneRouting = params.To
         ? resolveAssistantByPhoneNumber(config, params.To, caches?.configFile)
         : undefined;


### PR DESCRIPTION
## Summary
- Reject inbound Twilio voice calls when the phone channel admission floor is `no_one`, mirroring the text-path kill switch.
- Gated on the channel-trust-floors flag + exempt check, so it is a no-op until phone leaves the exempt set (PR 6).

Part of plan: voice-admission.md (PR 2 of 6)