### PR TITLE
fix(memory-v3): backfill aborts on a down embedding backend instead of wiping the dense lane

### DIFF
--- a/assistant/src/memory/embedding-backend.ts
+++ b/assistant/src/memory/embedding-backend.ts
@@ -497,6 +497,20 @@ export async function getMemoryBackendStatus(config: AssistantConfig): Promise<{
   };
 }
 
+/**
+ * Thrown by {@link embedWithBackend} when no embedding backend is configured or
+ * available. This is a PROCESS-WIDE condition (backend selection is effectively
+ * cached for the run), so a caller embedding many items should treat the first
+ * occurrence as fatal to the whole batch rather than a per-item failure — see
+ * `backfillAllSections`, which aborts on it instead of churning through deletes.
+ */
+export class EmbeddingBackendUnavailableError extends Error {
+  constructor(message = "No memory embedding backend configured") {
+    super(message);
+    this.name = "EmbeddingBackendUnavailableError";
+  }
+}
+
 export async function embedWithBackend(
   config: AssistantConfig,
   inputs: EmbeddingInput[],
@@ -514,7 +528,7 @@ export async function embedWithBackend(
 
   const selection = await selectEmbeddingBackend(config);
   if (!selection.backend) {
-    throw new Error(
+    throw new EmbeddingBackendUnavailableError(
       selection.reason ?? "No memory embedding backend configured",
     );
   }

--- a/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/maintain-job.test.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/__tests__/maintain-job.test.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import { setOverridesForTesting } from "../../../../__tests__/feature-flag-test-helpers.js";
 import type { AssistantConfig } from "../../../../config/types.js";
+import { EmbeddingBackendUnavailableError } from "../../../../memory/embedding-backend.js";
+import { EmbeddingBillingBlockError } from "../../../../memory/embedding-billing-breaker.js";
 import type { MemoryJob } from "../../../../memory/jobs-store.js";
 import { renderCapabilityContent } from "../capabilities.js";
 import {
@@ -469,6 +471,7 @@ describe("backfillAllSections", () => {
       deleted: string[];
       upserted: Section[][];
       committed: number[];
+      probed: number;
     };
   } {
     const calls = {
@@ -477,6 +480,7 @@ describe("backfillAllSections", () => {
       deleted: [] as string[],
       upserted: [] as Section[][],
       committed: [] as number[],
+      probed: 0,
     };
     const base: BackfillJobDeps = {
       config: CONFIG,
@@ -501,6 +505,9 @@ describe("backfillAllSections", () => {
         calls.committed.push(ms);
       },
       nowMs: () => 4242,
+      embedProbe: async () => {
+        calls.probed += 1;
+      },
     };
     return { deps: { ...base, ...overrides }, calls };
   }
@@ -575,6 +582,60 @@ describe("backfillAllSections", () => {
     // delete-then-upsert'd (sections gone), so advancing past its mtime would
     // hide it from the incremental selector forever. Holding the mark lets the
     // next pass re-embed it.
+    expect(calls.committed).toEqual([]);
+  });
+
+  test("aborts before any write when the pre-flight embed probe fails", async () => {
+    const { deps: d, calls } = deps({
+      selectAllPages: async () => ["page-a", "page-b"],
+      embedProbe: async () => {
+        throw new EmbeddingBackendUnavailableError();
+      },
+    });
+    await expect(backfillAllSections(CONFIG, d)).rejects.toThrow(
+      EmbeddingBackendUnavailableError,
+    );
+    // Nothing deleted, upserted, or committed — the corpus is untouched.
+    expect(calls.deleted).toEqual([]);
+    expect(calls.upserted).toEqual([]);
+    expect(calls.committed).toEqual([]);
+  });
+
+  test("aborts the run when the embedding backend goes down mid-loop (does not delete the rest of the corpus)", async () => {
+    // Healthy for the probe and the first article, then down. Without the abort,
+    // every remaining article would be delete-then-failed (the original
+    // incident): the backend-down state is process-wide.
+    let upserts = 0;
+    const { deps: d, calls } = deps({
+      selectAllPages: async () => ["page-1", "page-2", "page-3", "page-4"],
+      upsertSections: async (_config, sections) => {
+        upserts += 1;
+        if (upserts >= 2) throw new EmbeddingBackendUnavailableError();
+        calls.upserted.push(sections);
+      },
+    });
+    await expect(backfillAllSections(CONFIG, d)).rejects.toThrow(
+      EmbeddingBackendUnavailableError,
+    );
+    // page-1 embedded; page-2's delete ran then its embed threw → ABORT. page-3
+    // and page-4 are never touched, so their existing points stay intact.
+    expect(calls.deleted).toEqual(["page-1", "page-2"]);
+    expect(calls.upserted.flat().map((s) => s.article)).toEqual(["page-1"]);
+    expect(calls.committed).toEqual([]);
+  });
+
+  test("aborts the run on a billing-breaker error mid-loop", async () => {
+    const { deps: d, calls } = deps({
+      selectAllPages: async () => ["page-1", "page-2"],
+      upsertSections: async () => {
+        throw new EmbeddingBillingBlockError();
+      },
+    });
+    await expect(backfillAllSections(CONFIG, d)).rejects.toThrow(
+      EmbeddingBillingBlockError,
+    );
+    // First article's delete ran, its embed threw → abort. Second never touched.
+    expect(calls.deleted).toEqual(["page-1"]);
     expect(calls.committed).toEqual([]);
   });
 

--- a/assistant/src/plugins/defaults/memory-v3-shadow/maintain-job.ts
+++ b/assistant/src/plugins/defaults/memory-v3-shadow/maintain-job.ts
@@ -58,6 +58,11 @@ import {
   getMemoryCheckpoint,
   setMemoryCheckpoint,
 } from "../../../memory/checkpoints.js";
+import {
+  EmbeddingBackendUnavailableError,
+  embedWithBackend,
+} from "../../../memory/embedding-backend.js";
+import { EmbeddingBillingBlockError } from "../../../memory/embedding-billing-breaker.js";
 import type { MemoryJob } from "../../../memory/jobs-store.js";
 import { getPageIndex } from "../../../memory/v2/page-index.js";
 import { readPage } from "../../../memory/v2/page-store.js";
@@ -192,6 +197,13 @@ export interface BackfillJobDeps {
   nowMs: () => number;
   /** Active assistant config (for the dense-store/embedding calls). */
   config: AssistantConfig;
+  /**
+   * Smoke-test the embedding backend before any destructive write. Throws when
+   * the backend is unavailable, so the backfill aborts BEFORE deleting any
+   * article's points (each article is processed delete-then-upsert). Injectable
+   * for tests.
+   */
+  embedProbe: () => Promise<void>;
 }
 
 /** Counts surfaced by {@link backfillAllSections}. */
@@ -350,6 +362,9 @@ function defaultBackfillDeps(config: AssistantConfig): BackfillJobDeps {
     commitEmbedHighWater,
     nowMs: () => Date.now(),
     config,
+    embedProbe: async () => {
+      await embedWithBackend(config, ["memory-v3 backfill preflight"]);
+    },
   };
 }
 
@@ -521,6 +536,13 @@ export async function backfillAllSections(
   const slugs = await deps.selectAllPages();
   await deps.ensureSectionCollection(deps.config);
 
+  // Pre-flight: smoke-test the embedding backend BEFORE any delete. Each article
+  // is processed delete-then-upsert, so starting a full backfill against a down
+  // backend would delete every article's points and re-embed none of them. A
+  // throw here aborts with nothing deleted; the high-water mark stays put, so a
+  // later run retries once the backend is healthy.
+  await deps.embedProbe();
+
   let articles = 0;
   let sections = 0;
   let failures = 0;
@@ -543,6 +565,17 @@ export async function backfillAllSections(
       sections += index.sections.length;
       return "embedded";
     } catch (err) {
+      // A down embedding backend (unconfigured, or billing breaker open) fails
+      // EVERY article — the condition is process-wide — and each article is
+      // delete-then-upsert, so continuing would delete the rest of the corpus
+      // and re-embed none of it. Abort the run; the high-water mark is never
+      // advanced, so the next pass retries from here once the backend recovers.
+      if (
+        err instanceof EmbeddingBackendUnavailableError ||
+        err instanceof EmbeddingBillingBlockError
+      ) {
+        throw err;
+      }
       failures += 1;
       log.warn(
         { slug, err: err instanceof Error ? err.message : String(err) },


### PR DESCRIPTION
## Summary
- `backfillAllSections` processes each article **delete-then-upsert**, and the "no embedding backend configured" / billing-breaker conditions are **process-wide**. So a backend that goes down mid-run (e.g. a CES flap) made every *remaining* article delete-then-fail — wiping the dense lane (the real incident: ~9.5k sections → ~2.3k in one run). This makes the backfill fail-closed-**safe**:
  - **Pre-flight smoke embed** before the loop — a backend that's down at start aborts the run with **nothing deleted**.
  - **Abort on a backend-unavailable error mid-loop** — `EmbeddingBackendUnavailableError` / `EmbeddingBillingBlockError` re-throw and stop the run instead of being swallowed as per-article "non-fatal" failures, bounding blast radius to **≤1 article** (the in-flight one) instead of the rest of the corpus.
  - The high-water checkpoint stays put on abort, so the next pass retries once the backend recovers.
- Introduces a typed `EmbeddingBackendUnavailableError` (replacing the generic `Error` for the unconfigured case) for robust detection — message preserved, so it's backward-compatible.
- Per-article (non-backend) errors stay non-fatal exactly as before. **Embed-before-delete** (zero loss even for the in-flight article) is a noted fast-follow.

Tests: pre-flight failure aborts before any write; mid-loop backend-down + billing-breaker both abort without churning the corpus; the existing per-article-failure test confirms non-backend errors stay non-fatal. maintain-job 33/0, embed-concept-page 16/0, section-dense-store 19/0, tsc clean.

## Original prompt
Follow-up to the backfill incident: a `memory v3 backfill-sections` run during a CES flap gutted the dense lane because the op is delete-then-upsert per article and the "backend not configured" state caches process-wide — once the flap hit, every remaining article was deleted then failed to re-embed. We agreed the durable fix is to make the backfill fail-closed-*safe* in code: pre-flight smoke-test the embedding backend and abort the whole run on a process-wide backend-unavailable error rather than churning through destructive deletes, shrinking the blast radius from the whole corpus to ≤1 article. Embed-before-delete (zero loss) is left as a fast-follow.