### PR TITLE
feat(gateway): hide vellum and whatsapp from Channel Trust Floors API

### DIFF
--- a/clients/web/src/components/channel-policy/channel-policy-card.tsx
+++ b/clients/web/src/components/channel-policy/channel-policy-card.tsx
@@ -1,10 +1,10 @@
 /**
  * `ChannelPolicyCard` — settings card surface for the per-channel
  * admission floor (§8.1). Lists every client-controllable channel with a
- * dropdown for its floor. Internal channels (`vellum`/`platform`/`a2a`)
- * are filtered out by `fetchChannelPolicies` and never rendered here, so
- * the user can't accidentally lock themselves out of the local desktop or
- * platform connection.
+ * dropdown for its floor. Internal channels (`platform`/`a2a`) and hidden
+ * channels (`vellum`/`whatsapp`) are filtered out by `fetchChannelPolicies`
+ * and never rendered here, so the user can't accidentally lock themselves
+ * out of the local desktop or platform connection.
  */
 
 import { ShieldAlert } from "lucide-react";

--- a/clients/web/src/components/channel-policy/channel-policy-card.tsx
+++ b/clients/web/src/components/channel-policy/channel-policy-card.tsx
@@ -18,7 +18,6 @@ import {
 } from "@/lib/channel-admission-policy/api";
 import {
   ADMISSION_POLICY_VALUES,
-  isKillSwitchForbiddenChannel,
   POLICY_DESCRIPTIONS,
   POLICY_LABELS,
   type AdmissionPolicy,
@@ -32,16 +31,6 @@ const DROPDOWN_OPTIONS = ADMISSION_POLICY_VALUES.map((value) => ({
   value,
   label: POLICY_LABELS[value],
 }));
-
-/**
- * Options for a channel's dropdown. Kill-switch-forbidden channels (e.g.
- * `vellum`, the local client) omit `no_one` so the guardian can't lock
- * themselves out — mirrored by the gateway's 422 on a `no_one` write.
- */
-function optionsForChannel(channelType: string) {
-  if (!isKillSwitchForbiddenChannel(channelType)) return DROPDOWN_OPTIONS;
-  return DROPDOWN_OPTIONS.filter((o) => o.value !== "no_one");
-}
 
 function humaniseChannel(channelType: string): string {
   // Map known channel ids to display labels; fall back to a Title-Case
@@ -205,7 +194,7 @@ export function ChannelPolicyCard() {
               <Dropdown<AdmissionPolicy>
                 value={policy.policy}
                 onChange={(next) => handleChange(policy.channelType, next)}
-                options={optionsForChannel(policy.channelType)}
+                options={DROPDOWN_OPTIONS}
                 disabled={savingChannel === policy.channelType}
                 aria-label={`Floor for ${humaniseChannel(policy.channelType)}`}
                 data-testid={`channel-policy-dropdown-${policy.channelType}`}

--- a/clients/web/src/lib/channel-admission-policy/api.test.ts
+++ b/clients/web/src/lib/channel-admission-policy/api.test.ts
@@ -59,9 +59,10 @@ describe("isInternalChannel", () => {
 });
 
 describe("fetchChannelPolicies", () => {
-  test("filters internal channels out of the gateway response", async () => {
-    // §8.1: even if the gateway forgets to omit internal channels, the
-    // client double-filters so the UI never offers a way to lock them.
+  test("filters internal and hidden channels out of the gateway response", async () => {
+    // Even if the gateway forgets to omit internal (platform/a2a) or hidden
+    // (vellum/whatsapp) channels, the client double-filters so the UI never
+    // surfaces them.
     mockGet = mock(async () =>
       ok({
         policies: [
@@ -73,6 +74,12 @@ describe("fetchChannelPolicies", () => {
           },
           {
             channelType: "vellum",
+            policy: "trusted_contacts",
+            note: null,
+            updatedAt: null,
+          },
+          {
+            channelType: "whatsapp",
             policy: "trusted_contacts",
             note: null,
             updatedAt: null,
@@ -101,11 +108,10 @@ describe("fetchChannelPolicies", () => {
 
     const policies = await fetchChannelPolicies("asst-1");
 
-    // platform/a2a are filtered; vellum is client-controllable and kept.
+    // platform/a2a (internal) and vellum/whatsapp (hidden) are filtered.
     expect(policies.map((p) => p.channelType).sort()).toEqual([
       "email",
       "slack",
-      "vellum",
     ]);
   });
 

--- a/clients/web/src/lib/channel-admission-policy/api.ts
+++ b/clients/web/src/lib/channel-admission-policy/api.ts
@@ -4,10 +4,10 @@
  *
  * Mirrors the Swift `ChannelAdmissionPolicyClient` in
  * `clients/shared/Network/ChannelAdmissionPolicyClient.swift` so naming
- * stays in lockstep across surfaces. Internal channels (vellum/platform/a2a)
- * are filtered client-side per §8.1 — the gateway is already supposed to
- * omit them from the list response, but we double-filter so a future
- * gateway regression can't leak them into the UI.
+ * stays in lockstep across surfaces. Internal channels (platform/a2a) and
+ * hidden channels (vellum/whatsapp) are filtered client-side — the gateway is
+ * already supposed to omit them from the list response, but we double-filter
+ * so a future gateway regression can't leak them into the UI.
  */
 
 import { client } from "@/generated/api/client.gen";
@@ -20,6 +20,7 @@ import {
 import {
   ADMISSION_POLICY_VALUES,
   INTERNAL_CHANNELS,
+  isHiddenChannel,
   type AdmissionPolicy,
   type ChannelPolicyView,
 } from "./types";
@@ -48,8 +49,9 @@ export function isInternalChannel(channelType: string): boolean {
 /**
  * List every client-controllable channel's admission floor.
  *
- * Channels in {@link INTERNAL_CHANNELS} are filtered out before returning,
- * so callers can render the result directly without re-filtering.
+ * Channels in {@link INTERNAL_CHANNELS} and {@link isHiddenChannel} are
+ * filtered out before returning, so callers can render the result directly
+ * without re-filtering.
  */
 export async function fetchChannelPolicies(
   assistantId: string,
@@ -68,7 +70,10 @@ export async function fetchChannelPolicies(
   }
   const policies = data?.policies ?? [];
   return policies
-    .filter((p) => !isInternalChannel(p.channelType))
+    .filter(
+      (p) =>
+        !isInternalChannel(p.channelType) && !isHiddenChannel(p.channelType),
+    )
     .map((p) => ({
       ...p,
       policy: isAdmissionPolicy(p.policy) ? p.policy : "trusted_contacts",

--- a/clients/web/src/lib/channel-admission-policy/types.ts
+++ b/clients/web/src/lib/channel-admission-policy/types.ts
@@ -25,6 +25,19 @@ export const ADMISSION_POLICY_DEFAULT: AdmissionPolicy = "trusted_contacts";
 export const INTERNAL_CHANNELS = new Set<string>(["platform", "a2a"]);
 
 /**
+ * Channels that are still enforced at runtime but intentionally hidden from the
+ * Channel Trust Floors list. The gateway already omits them from the GET
+ * response; we double-filter here so a future gateway regression can't leak
+ * them into the UI. Mirrors `ADMISSION_POLICY_HIDDEN_CHANNELS` in
+ * `packages/gateway-client/src/admission-policy-contract.ts`.
+ */
+export const HIDDEN_CHANNELS = new Set<string>(["vellum", "whatsapp"]);
+
+export function isHiddenChannel(channelType: string): boolean {
+  return HIDDEN_CHANNELS.has(channelType);
+}
+
+/**
  * Channels that are configurable but may not be set to `no_one`. `vellum` is
  * the local desktop/web client surface — a `no_one` kill switch there would
  * lock the guardian out of their own app, so the picker omits that option.

--- a/clients/web/src/lib/channel-admission-policy/types.ts
+++ b/clients/web/src/lib/channel-admission-policy/types.ts
@@ -19,8 +19,8 @@ export const ADMISSION_POLICY_DEFAULT: AdmissionPolicy = "trusted_contacts";
 /**
  * Channels the user cannot configure at all. `platform` is the vembda-managed
  * control plane, `a2a` is peer-to-peer assistant traffic — neither has a
- * human-trust model. (`vellum` IS configurable; see
- * {@link KILL_SWITCH_FORBIDDEN_CHANNELS}.)
+ * human-trust model. (`vellum` is enforced at runtime but hidden from the UI;
+ * see {@link HIDDEN_CHANNELS}.)
  */
 export const INTERNAL_CHANNELS = new Set<string>(["platform", "a2a"]);
 
@@ -35,17 +35,6 @@ export const HIDDEN_CHANNELS = new Set<string>(["vellum", "whatsapp"]);
 
 export function isHiddenChannel(channelType: string): boolean {
   return HIDDEN_CHANNELS.has(channelType);
-}
-
-/**
- * Channels that are configurable but may not be set to `no_one`. `vellum` is
- * the local desktop/web client surface — a `no_one` kill switch there would
- * lock the guardian out of their own app, so the picker omits that option.
- */
-export const KILL_SWITCH_FORBIDDEN_CHANNELS = new Set<string>(["vellum"]);
-
-export function isKillSwitchForbiddenChannel(channelType: string): boolean {
-  return KILL_SWITCH_FORBIDDEN_CHANNELS.has(channelType);
 }
 
 export interface ChannelPolicyView {

--- a/gateway/AGENTS.md
+++ b/gateway/AGENTS.md
@@ -87,7 +87,13 @@ A default row per enforced channel is **seeded at startup** (`seedAdmissionPolic
 - `a2a` — assistant-to-assistant peer traffic (out of human-trust model).
 - `phone` — exempt until voice ingress reads the policy (§8.4).
 
-For exempt ids, `PUT /v1/assistants/:id/channel-admission-policy/:channelType` returns **403**, the GET list omits them, and the runtime short-circuits `admitted: true` in `admission-policy.ts` (defense in depth). `vellum` is **not** exempt — it is configurable, but can never be set to `no_one`: the PUT route returns **422** and the picker omits the option, so the guardian (always max-rank on `vellum`) can't lock themselves out. Codex finding from #35006 review: exemption checks must live in *both* the gateway route handler AND the runtime stage — single-side enforcement creates a misuse wedge.
+For exempt ids, `PUT /v1/assistants/:id/channel-admission-policy/:channelType` returns **403**, the GET list omits them, and the runtime short-circuits `admitted: true` in `admission-policy.ts` (defense in depth). Codex finding from #35006 review: exemption checks must live in *both* the gateway route handler AND the runtime stage — single-side enforcement creates a misuse wedge.
+
+**Hidden channels** (`ADMISSION_POLICY_HIDDEN_CHANNELS` = `vellum`, `whatsapp`) — managed automatically, **not** user-configurable, but (unlike exempt channels) **still enforced at runtime**:
+
+- The GET list omits them, and `PUT`/`DELETE` return **403** (`isAdmissionPolicyHiddenChannel`).
+- They are **not** exempt — the runtime still evaluates rank-vs-floor, so a real inbound channel like `whatsapp` keeps its admission floor.
+- Their floor is pinned to the seed default; `seedAdmissionPolicyDefaults` **overwrites** any drifted/legacy row at startup (e.g. a stale `whatsapp = no_one`), so a stranded floor can't silently block a channel the user can no longer see or reset. The guardian is always max-rank on `vellum`, so its `guardian_only` seed default never locks them out — there is **no** `no_one` picker or 422 kill-switch path for hidden channels.
 
 Only the **assistant-scoped** routes (`/v1/assistants/:id/channel-admission-policy/...`) exist; admission policy is gateway-global so the id is matched and discarded. (The flat `/v1/channel-admission-policy/...` variants were removed with the CLI that used them.)
 
@@ -100,6 +106,8 @@ Only the **assistant-scoped** routes (`/v1/assistants/:id/channel-admission-poli
 **Adding a new policy**: extend the `AdmissionPolicy` union in `packages/gateway-client/src/admission-policy-contract.ts`, add its floor in `ADMISSION_FLOOR`, update the openapi schema, and update `gateway/src/__tests__/channel-admission-policy-routes.test.ts` + `assistant/src/runtime/routes/inbound-stages/admission-policy.test.ts`. Do not add a 6th floor without also bumping the `TRUST_CLASS_RANK` ceiling to match.
 
 **Adding a new exempt channel**: update `ADMISSION_POLICY_EXEMPT_CHANNELS` in `packages/gateway-client/src/admission-policy-contract.ts` AND `EXEMPT_CHANNEL_TYPES` in `gateway/src/db/admission-policy-store.ts`. The gateway route (403), GET-list omission, runtime short-circuit, and seed-skip all read from these — symmetric enforcement is required so a stray runtime call (test harness, internal IPC) can't bypass the floor.
+
+**Hiding a channel from the UI (still enforced)**: add it to `ADMISSION_POLICY_HIDDEN_CHANNELS` in `packages/gateway-client/src/admission-policy-contract.ts` (and the web mirror `HIDDEN_CHANNELS` in `clients/web/src/lib/channel-admission-policy/types.ts`). The GET-list omission, `PUT`/`DELETE` 403, and seed re-pin all read from this set. Use this — **not** the exempt set — for a channel that must keep enforcing a floor but should not be user-configurable, so its admission check is never short-circuited.
 
 ### Trust Classes → Capabilities (what an actor may do)
 

--- a/gateway/src/__tests__/channel-admission-policy-routes.test.ts
+++ b/gateway/src/__tests__/channel-admission-policy-routes.test.ts
@@ -10,6 +10,7 @@ import {
   getAdmissionPolicyCache,
 } from "../risk/admission-policy-cache.js";
 import {
+  createChannelAdmissionPolicyDeleteHandler,
   createChannelAdmissionPolicyListHandler,
   createChannelAdmissionPolicySetHandler,
 } from "../http/routes/channel-admission-policy.js";
@@ -227,11 +228,11 @@ describe("PUT /v1/channel-admission-policy/:channelType", () => {
     const handler = createChannelAdmissionPolicySetHandler();
     const res = await handler(
       jsonRequest(
-        "http://localhost/v1/channel-admission-policy/whatsapp",
+        "http://localhost/v1/channel-admission-policy/telegram",
         "PUT",
         { policy: "any_contact" },
       ),
-      "whatsapp",
+      "telegram",
     );
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
@@ -240,32 +241,26 @@ describe("PUT /v1/channel-admission-policy/:channelType", () => {
     expect(body.policy.note).toBeNull();
   });
 
-  test("allows configuring `vellum` to a non-kill-switch policy", async () => {
+  test("rejects PUT for hidden channels (`vellum`, `whatsapp`) with 403", async () => {
+    // Hidden channels are managed automatically and not user-configurable;
+    // even a non-kill-switch policy must be rejected so no stranded row forms.
     const handler = createChannelAdmissionPolicySetHandler();
-    const res = await handler(
-      jsonRequest("http://localhost/v1/channel-admission-policy/vellum", "PUT", {
-        policy: "guardian_only",
-      }),
-      "vellum",
-    );
-    expect(res.status).toBe(200);
-    expect(store.get("vellum")).toBe("guardian_only");
-  });
-
-  test("rejects setting `vellum` to `no_one` with 422 (kill-switch forbidden)", async () => {
-    const handler = createChannelAdmissionPolicySetHandler();
-    const res = await handler(
-      jsonRequest("http://localhost/v1/channel-admission-policy/vellum", "PUT", {
-        policy: "no_one",
-      }),
-      "vellum",
-    );
-    expect(res.status).toBe(422);
-    const body = (await res.json()) as { error: string; channelType: string };
-    expect(body.error).toMatch(/cannot be set to "no_one"/);
-    expect(body.channelType).toBe("vellum");
-    // Nothing was persisted.
-    expect(store.get("vellum")).toBe(ADMISSION_POLICY_DEFAULT);
+    for (const channel of ["vellum", "whatsapp"] as const) {
+      const res = await handler(
+        jsonRequest(
+          `http://localhost/v1/channel-admission-policy/${channel}`,
+          "PUT",
+          { policy: "guardian_only" },
+        ),
+        channel,
+      );
+      expect(res.status).toBe(403);
+      const body = (await res.json()) as { error: string; channelType: string };
+      expect(body.channelType).toBe(channel);
+      expect(body.error).toMatch(/managed automatically/);
+      // Nothing was persisted.
+      expect(store.get(channel)).toBe(ADMISSION_POLICY_DEFAULT);
+    }
   });
 
   test("§8.1: rejects PUT for exempt channel `a2a` with 403", async () => {
@@ -291,6 +286,41 @@ describe("PUT /v1/channel-admission-policy/:channelType", () => {
     expect(res.status).toBe(403);
     // Nothing was persisted.
     expect(store.get("phone")).toBe(ADMISSION_POLICY_DEFAULT);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /v1/channel-admission-policy/:channelType
+// ---------------------------------------------------------------------------
+
+describe("DELETE /v1/channel-admission-policy/:channelType", () => {
+  test("removes a configurable channel's row, resetting it to the default", async () => {
+    store.set("slack", "guardian_only");
+    const handler = createChannelAdmissionPolicyDeleteHandler();
+    const res = await handler(
+      jsonRequest("http://localhost/v1/channel-admission-policy/slack", "DELETE"),
+      "slack",
+    );
+    expect(res.status).toBe(200);
+    expect(store.get("slack")).toBe(ADMISSION_POLICY_DEFAULT);
+  });
+
+  test("rejects DELETE for hidden channels (`vellum`, `whatsapp`) with 403", async () => {
+    store.set("whatsapp", "no_one");
+    const handler = createChannelAdmissionPolicyDeleteHandler();
+    for (const channel of ["vellum", "whatsapp"] as const) {
+      const res = await handler(
+        jsonRequest(
+          `http://localhost/v1/channel-admission-policy/${channel}`,
+          "DELETE",
+        ),
+        channel,
+      );
+      expect(res.status).toBe(403);
+    }
+    // The persisted whatsapp row is left untouched by the rejected delete;
+    // the startup seed (not DELETE) is what resets stranded hidden rows.
+    expect(store.get("whatsapp")).toBe("no_one");
   });
 });
 

--- a/gateway/src/__tests__/channel-admission-policy-routes.test.ts
+++ b/gateway/src/__tests__/channel-admission-policy-routes.test.ts
@@ -14,11 +14,18 @@ import {
   createChannelAdmissionPolicySetHandler,
 } from "../http/routes/channel-admission-policy.js";
 import { CHANNEL_IDS } from "../channels/types.js";
-import { isAdmissionPolicyExemptChannel } from "@vellumai/gateway-client";
+import {
+  isAdmissionPolicyExemptChannel,
+  isAdmissionPolicyHiddenChannel,
+} from "@vellumai/gateway-client";
 import "./test-preload.js";
 
-const NON_EXEMPT_CHANNEL_IDS = CHANNEL_IDS.filter(
-  (channel) => !isAdmissionPolicyExemptChannel(channel),
+// Channels the GET list is expected to return: neither exempt (no runtime
+// admission model) nor hidden (`vellum`/`whatsapp`, enforced but not shown).
+const VISIBLE_CHANNEL_IDS = CHANNEL_IDS.filter(
+  (channel) =>
+    !isAdmissionPolicyExemptChannel(channel) &&
+    !isAdmissionPolicyHiddenChannel(channel),
 );
 
 // ---------------------------------------------------------------------------
@@ -64,7 +71,7 @@ function jsonRequest(url: string, method: string, body?: unknown): Request {
 // ---------------------------------------------------------------------------
 
 describe("GET /v1/channel-admission-policy", () => {
-  test("returns every non-exempt channel id, with defaults for unconfigured channels", async () => {
+  test("returns every visible channel id, with defaults for unconfigured channels", async () => {
     const handler = createChannelAdmissionPolicyListHandler();
     const res = await handler(
       jsonRequest("http://localhost/v1/channel-admission-policy", "GET"),
@@ -79,14 +86,14 @@ describe("GET /v1/channel-admission-policy", () => {
         updatedAt: number | null;
       }>;
     };
-    expect(body.policies).toHaveLength(NON_EXEMPT_CHANNEL_IDS.length);
+    expect(body.policies).toHaveLength(VISIBLE_CHANNEL_IDS.length);
     for (const p of body.policies) {
       expect(p.policy).toBe(ADMISSION_POLICY_DEFAULT);
       expect(p.note).toBeNull();
       expect(p.updatedAt).toBeNull();
     }
     const seen = new Set(body.policies.map((p) => p.channelType));
-    for (const channel of NON_EXEMPT_CHANNEL_IDS) {
+    for (const channel of VISIBLE_CHANNEL_IDS) {
       expect(seen.has(channel)).toBe(true);
     }
   });
@@ -106,7 +113,7 @@ describe("GET /v1/channel-admission-policy", () => {
         updatedAt: number | null;
       }>;
     };
-    expect(body.policies).toHaveLength(NON_EXEMPT_CHANNEL_IDS.length);
+    expect(body.policies).toHaveLength(VISIBLE_CHANNEL_IDS.length);
     const tg = body.policies.find((p) => p.channelType === "telegram");
     expect(tg?.policy).toBe("no_one");
     expect(tg?.note).toBe("off");
@@ -117,11 +124,13 @@ describe("GET /v1/channel-admission-policy", () => {
     expect(phone).toBeUndefined();
   });
 
-  test("omits exempt channels (`a2a`, `phone`) but includes the configurable `vellum`", async () => {
-    // a2a/phone stay exempt (filtered out); vellum is configurable and must
-    // surface so the client can manage it.
+  test("omits exempt channels (`a2a`, `phone`) and hidden channels (`vellum`, `whatsapp`)", async () => {
+    // a2a/phone stay exempt (no runtime admission model). vellum/whatsapp are
+    // still enforced at runtime but hidden from the Channel Trust Floors UI,
+    // so they must not surface in the list even when a row is persisted.
     store.set("a2a", "guardian_only");
     store.set("vellum", "guardian_only");
+    store.set("whatsapp", "guardian_only");
 
     const handler = createChannelAdmissionPolicyListHandler();
     const res = await handler(
@@ -133,7 +142,12 @@ describe("GET /v1/channel-admission-policy", () => {
     const seen = new Set(body.policies.map((p) => p.channelType));
     expect(seen.has("a2a")).toBe(false);
     expect(seen.has("phone")).toBe(false);
-    expect(seen.has("vellum")).toBe(true);
+    expect(seen.has("vellum")).toBe(false);
+    expect(seen.has("whatsapp")).toBe(false);
+    // Visible channels still surface.
+    expect(seen.has("telegram")).toBe(true);
+    expect(seen.has("slack")).toBe(true);
+    expect(seen.has("email")).toBe(true);
   });
 });
 

--- a/gateway/src/__tests__/seed-admission-policy.test.ts
+++ b/gateway/src/__tests__/seed-admission-policy.test.ts
@@ -39,16 +39,28 @@ describe("seedAdmissionPolicyDefaults", () => {
     expect(seen.has("phone")).toBe(false);
   });
 
-  test("is idempotent and never overwrites a user-configured row", () => {
+  test("is idempotent and never overwrites a configurable channel's row", () => {
     store.set("slack", "strangers", "user choice");
-    store.set("vellum", "trusted_contacts", "user widened vellum");
+    store.set("telegram", "any_contact", "user widened telegram");
 
     seedAdmissionPolicyDefaults(store);
     seedAdmissionPolicyDefaults(store); // second run is a no-op
 
     expect(store.get("slack")).toBe("strangers");
-    expect(store.get("vellum")).toBe("trusted_contacts");
+    expect(store.get("telegram")).toBe("any_contact");
     // A channel the user never touched still gets its seeded default.
     expect(store.get("email")).toBe("trusted_contacts");
+  });
+
+  test("resets a stranded hidden-channel row back to its default", () => {
+    // A legacy/stale row on a now-hidden channel must not strand the channel
+    // at a floor the user can no longer see or reset in the UI.
+    store.set("whatsapp", "no_one", "legacy kill switch");
+    store.set("vellum", "any_contact", "legacy widened vellum");
+
+    seedAdmissionPolicyDefaults(store);
+
+    expect(store.get("whatsapp")).toBe("trusted_contacts");
+    expect(store.get("vellum")).toBe("guardian_only");
   });
 });

--- a/gateway/src/db/admission-policy-store.ts
+++ b/gateway/src/db/admission-policy-store.ts
@@ -61,8 +61,9 @@ export interface AdmissionPolicyRow {
  * ADMISSION_POLICY_EXEMPT_CHANNELS in `packages/gateway-client`.
  *
  * `phone` is exempt until Twilio voice ingress reads AdmissionPolicyStore.
- * `vellum` is NOT exempt — it is client-configurable (see
- * KILL_SWITCH_FORBIDDEN_CHANNELS), so it is intentionally absent here.
+ * `vellum` is NOT exempt — its floor is still enforced at runtime — but it is
+ * hidden from the configurable UI (see ADMISSION_POLICY_HIDDEN_CHANNELS), so it
+ * is intentionally absent here.
  */
 export const EXEMPT_CHANNEL_TYPES = new Set<string>(["platform", "a2a", "phone"]);
 

--- a/gateway/src/db/seed-admission-policy.ts
+++ b/gateway/src/db/seed-admission-policy.ts
@@ -9,7 +9,11 @@
  * user-configured row is never overwritten (ON CONFLICT DO NOTHING).
  */
 
-import { ADMISSION_POLICY_DEFAULT, type AdmissionPolicy } from "@vellumai/gateway-client";
+import {
+  ADMISSION_POLICY_DEFAULT,
+  isAdmissionPolicyHiddenChannel,
+  type AdmissionPolicy,
+} from "@vellumai/gateway-client";
 import { CHANNEL_IDS, type ChannelId } from "../channels/types.js";
 import { AdmissionPolicyStore, isExemptChannelType } from "./admission-policy-store.js";
 
@@ -28,13 +32,27 @@ export const CHANNEL_ADMISSION_DEFAULTS: Partial<Record<ChannelId, AdmissionPoli
 /**
  * Insert a default row for every enforced channel that has none. Exempt
  * channels (`platform`/`a2a`/`phone`) are skipped — they carry no floor.
+ *
+ * Hidden channels (`vellum`/`whatsapp`) are not surfaced in the Channel Trust
+ * Floors UI, so a legacy or stale row would strand the channel at a floor the
+ * user can no longer see or reset. They are pinned to their default here,
+ * overwriting any drifted row — unlike the non-destructive `seedDefault` used
+ * for configurable channels.
  */
 export function seedAdmissionPolicyDefaults(store: AdmissionPolicyStore): void {
   for (const channelType of CHANNEL_IDS) {
     if (isExemptChannelType(channelType)) continue;
-    store.seedDefault(
-      channelType,
-      CHANNEL_ADMISSION_DEFAULTS[channelType] ?? ADMISSION_POLICY_DEFAULT,
-    );
+    const policy =
+      CHANNEL_ADMISSION_DEFAULTS[channelType] ?? ADMISSION_POLICY_DEFAULT;
+    store.seedDefault(channelType, policy);
+    // Hidden channels aren't surfaced in the UI, so a legacy/stale row would
+    // strand them at a floor the user can't reset. `seedDefault` above is
+    // non-destructive, so overwrite any drift back to the default here.
+    if (
+      isAdmissionPolicyHiddenChannel(channelType) &&
+      store.get(channelType) !== policy
+    ) {
+      store.set(channelType, policy);
+    }
   }
 }

--- a/gateway/src/http/routes/channel-admission-policy.ts
+++ b/gateway/src/http/routes/channel-admission-policy.ts
@@ -13,6 +13,7 @@
 import { z } from "zod";
 import {
   isAdmissionPolicyExemptChannel,
+  isAdmissionPolicyHiddenChannel,
   isKillSwitchForbiddenChannel,
 } from "@vellumai/gateway-client";
 import {
@@ -80,11 +81,17 @@ export function createChannelAdmissionPolicyListHandler() {
         rows.map((r) => [r.channelType, r]),
       );
 
-      // §8.1: internal channels (`vellum`, `platform`, `a2a`) are not
+      // §8.1: internal channels (`platform`, `a2a`, `phone`) are not
       // policy-configurable. Omit them from the client-facing list so the
       // UI never surfaces a control that would 403 on PUT anyway.
+      //
+      // Hidden channels (`vellum`, `whatsapp`) are still enforced at runtime
+      // but intentionally not shown in the Channel Trust Floors UI, so omit
+      // them too.
       const policies: PolicyView[] = CHANNEL_IDS.filter(
-        (channel) => !isAdmissionPolicyExemptChannel(channel),
+        (channel) =>
+          !isAdmissionPolicyExemptChannel(channel) &&
+          !isAdmissionPolicyHiddenChannel(channel),
       ).map((channel) => {
         const row = byChannel.get(channel);
         return row ? rowToView(row) : defaultView(channel);

--- a/gateway/src/http/routes/channel-admission-policy.ts
+++ b/gateway/src/http/routes/channel-admission-policy.ts
@@ -14,7 +14,6 @@ import { z } from "zod";
 import {
   isAdmissionPolicyExemptChannel,
   isAdmissionPolicyHiddenChannel,
-  isKillSwitchForbiddenChannel,
 } from "@vellumai/gateway-client";
 import {
   ADMISSION_POLICY_DEFAULT,
@@ -126,6 +125,20 @@ export function createChannelAdmissionPolicySetHandler() {
       );
     }
 
+    // Hidden channels (`vellum`, `whatsapp`) are managed automatically at their
+    // default floor and not user-configurable. Reject writes so a stale row
+    // can't strand them outside the (hidden) Channel Trust Floors UI — the
+    // startup seed also resets any drift, this just blocks new drift at the door.
+    if (isAdmissionPolicyHiddenChannel(channelType)) {
+      return Response.json(
+        {
+          error: `Channel "${channelType}" is managed automatically and not user-configurable.`,
+          channelType,
+        },
+        { status: 403 },
+      );
+    }
+
     if (!isChannelId(channelType)) {
       return Response.json(
         {
@@ -153,21 +166,6 @@ export function createChannelAdmissionPolicySetHandler() {
           issues: parsed.error.issues,
         },
         { status: 400 },
-      );
-    }
-
-    // `vellum` is client-configurable but must never be the `no_one` kill
-    // switch — that would lock the guardian out of their own local client.
-    if (
-      isKillSwitchForbiddenChannel(channelType) &&
-      parsed.data.policy === "no_one"
-    ) {
-      return Response.json(
-        {
-          error: `Channel "${channelType}" cannot be set to "no_one".`,
-          channelType,
-        },
-        { status: 422 },
       );
     }
 
@@ -206,7 +204,19 @@ export function createChannelAdmissionPolicyDeleteHandler() {
     if (isExemptChannelType(channelType)) {
       return Response.json(
         {
-          error: `Channel "${channelType}" is internal (vellum/platform/a2a) and is not user-configurable.`,
+          error: `Channel "${channelType}" is internal (platform/a2a/phone) and is not user-configurable.`,
+        },
+        { status: 403 },
+      );
+    }
+
+    // Hidden channels (`vellum`, `whatsapp`) are managed automatically — a
+    // delete would just drop the row and let the next seed re-pin the default,
+    // so reject it rather than imply the user can reset the floor here.
+    if (isAdmissionPolicyHiddenChannel(channelType)) {
+      return Response.json(
+        {
+          error: `Channel "${channelType}" is managed automatically and not user-configurable.`,
         },
         { status: 403 },
       );

--- a/packages/gateway-client/src/admission-policy-contract.ts
+++ b/packages/gateway-client/src/admission-policy-contract.ts
@@ -49,8 +49,7 @@ export const ADMISSION_FLOOR: Record<AdmissionPolicy, number> = {
 
 /**
  * Hard-exempt internal channels — never subject to PUT policy, omitted from
- * GET list, runtime admission stage short-circuits without floor check,
- * gateway kill switch skips the `no_one` check.
+ * GET list, runtime admission stage short-circuits without floor check.
  *
  * `platform` / `a2a` are peer/internal channels with no human-trust model.
  *
@@ -61,8 +60,8 @@ export const ADMISSION_FLOOR: Record<AdmissionPolicy, number> = {
  * until voice ingress is wired in a follow-up PR. Remove `"phone"` from this
  * set once the voice path enforces admission.
  *
- * `vellum` is intentionally NOT exempt — it is client-configurable, with the
- * single restriction in {@link KILL_SWITCH_FORBIDDEN_CHANNELS}.
+ * `vellum` is NOT exempt — its floor is still enforced at runtime — but it is
+ * hidden from the configurable UI; see {@link ADMISSION_POLICY_HIDDEN_CHANNELS}.
  */
 export const ADMISSION_POLICY_EXEMPT_CHANNELS: ReadonlySet<string> = new Set([
   "platform",
@@ -75,25 +74,16 @@ export function isAdmissionPolicyExemptChannel(channelType: string): boolean {
 }
 
 /**
- * Channels that are configurable but may never be set to `no_one` (the kill
- * switch). `vellum` is the local desktop/web client channel; allowing `no_one`
- * there would let the guardian lock themselves out of their own client. The
- * guardian is always classified `guardian` (max rank) on vellum, so every
- * floor except `no_one` still admits them — only the kill switch is forbidden.
- */
-export const KILL_SWITCH_FORBIDDEN_CHANNELS: ReadonlySet<string> = new Set([
-  "vellum",
-]);
-
-export function isKillSwitchForbiddenChannel(channelType: string): boolean {
-  return KILL_SWITCH_FORBIDDEN_CHANNELS.has(channelType);
-}
-
-/**
- * Channels omitted from the Channel Trust Floors list (GET) but — unlike
- * {@link ADMISSION_POLICY_EXEMPT_CHANNELS} — still enforced at runtime. Kept
- * distinct from the exempt set so hiding a real inbound channel like
- * `whatsapp` never silently disables its admission floor check.
+ * Channels omitted from the Channel Trust Floors list (GET) and rejected on
+ * PUT/DELETE — managed automatically at their seed default, not user
+ * configurable. Unlike {@link ADMISSION_POLICY_EXEMPT_CHANNELS} they are still
+ * enforced at runtime, so hiding a real inbound channel like `whatsapp` never
+ * silently disables its admission floor check. The startup seed re-pins any
+ * drifted row so a stale floor (e.g. a legacy `no_one`) can't strand a channel
+ * the user can no longer see.
+ *
+ * `vellum` is the local desktop/web client surface; the guardian is always
+ * max-rank there, so the seed default admits them regardless of the floor.
  */
 export const ADMISSION_POLICY_HIDDEN_CHANNELS: ReadonlySet<string> = new Set([
   "vellum",

--- a/packages/gateway-client/src/admission-policy-contract.ts
+++ b/packages/gateway-client/src/admission-policy-contract.ts
@@ -89,6 +89,21 @@ export function isKillSwitchForbiddenChannel(channelType: string): boolean {
   return KILL_SWITCH_FORBIDDEN_CHANNELS.has(channelType);
 }
 
+/**
+ * Channels omitted from the Channel Trust Floors list (GET) but — unlike
+ * {@link ADMISSION_POLICY_EXEMPT_CHANNELS} — still enforced at runtime. Kept
+ * distinct from the exempt set so hiding a real inbound channel like
+ * `whatsapp` never silently disables its admission floor check.
+ */
+export const ADMISSION_POLICY_HIDDEN_CHANNELS: ReadonlySet<string> = new Set([
+  "vellum",
+  "whatsapp",
+]);
+
+export function isAdmissionPolicyHiddenChannel(channelType: string): boolean {
+  return ADMISSION_POLICY_HIDDEN_CHANNELS.has(channelType);
+}
+
 export function isAdmissionPolicy(value: unknown): value is AdmissionPolicy {
   return (
     typeof value === "string" &&

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -56,7 +56,7 @@ export type { IpcRequest, IpcResponse, Logger } from "./types.js";
 
 export { noopLogger } from "./types.js";
 
-// Admission policy contract (gateway → daemon) — Zod schemas + derived types + exempt channels
+// Admission policy contract (gateway → daemon) — Zod schemas + derived types + channel sets
 export {
   ADMISSION_FLOOR,
   ADMISSION_POLICY_DEFAULT,
@@ -67,8 +67,6 @@ export {
   isAdmissionPolicy,
   isAdmissionPolicyExemptChannel,
   isAdmissionPolicyHiddenChannel,
-  isKillSwitchForbiddenChannel,
-  KILL_SWITCH_FORBIDDEN_CHANNELS,
 } from "./admission-policy-contract.js";
 
 export type { AdmissionPolicy } from "./admission-policy-contract.js";

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -61,10 +61,12 @@ export {
   ADMISSION_FLOOR,
   ADMISSION_POLICY_DEFAULT,
   ADMISSION_POLICY_EXEMPT_CHANNELS,
+  ADMISSION_POLICY_HIDDEN_CHANNELS,
   ADMISSION_POLICY_VALUES,
   AdmissionPolicySchema,
   isAdmissionPolicy,
   isAdmissionPolicyExemptChannel,
+  isAdmissionPolicyHiddenChannel,
   isKillSwitchForbiddenChannel,
   KILL_SWITCH_FORBIDDEN_CHANNELS,
 } from "./admission-policy-contract.js";


### PR DESCRIPTION
## Summary
- Add `ADMISSION_POLICY_HIDDEN_CHANNELS` (`vellum`, `whatsapp`) to the gateway-client contract and filter them out of the `GET /v1/assistants/{id}/channel-admission-policy/` list that powers the Channel Trust Floors settings UI.
- Keep hidden channels **distinct from exempt channels**: hidden channels are still enforced at runtime (their admission floor still applies), they're just not user-configurable from this UI. This avoids silently disabling the floor check on a real inbound channel like `whatsapp`.
- Mirror the filter in the web client as defense-in-depth, matching the existing internal-channel double-filter, and update affected gateway + web tests.

## Original prompt
Exclude `vellum` and `whatsapp` from the API that powers the Channel Trust Floors settings UI, so they no longer appear as configurable rows. The data source is the gateway list endpoint; the change hides the two channels from that response while preserving their runtime admission enforcement (vellum/whatsapp aren't internal/exempt channels, so they must keep their floor checks).