### PR TITLE
feat(assistant): read channel admission policy from gateway over IPC

### DIFF
--- a/assistant/src/calls/__tests__/channel-admission-reader.test.ts
+++ b/assistant/src/calls/__tests__/channel-admission-reader.test.ts
@@ -90,10 +90,43 @@ describe("getChannelAdmissionPolicy", () => {
     expect(await getChannelAdmissionPolicy("telegram")).toBeNull();
   });
 
-  test("caches the negative (null) result within the TTL", async () => {
-    ipcHandlers.set(METHOD, () => undefined);
+  test("caches the explicit no-enforcement (null) answer within the TTL", async () => {
+    // The gateway successfully said "no enforcement" — a real, cacheable answer.
+    ipcHandlers.set(METHOD, () => ({ policy: null }));
     expect(await getChannelAdmissionPolicy("telegram")).toBeNull();
     expect(await getChannelAdmissionPolicy("telegram")).toBeNull();
     expect(countCalls(METHOD)).toBe(1);
+  });
+
+  test("does NOT cache a transport failure (undefined) — re-consults the gateway", async () => {
+    // First setup: gateway hiccup → fail open to null, NOT cached.
+    ipcHandlers.set(METHOD, () => undefined);
+    expect(await getChannelAdmissionPolicy("telegram")).toBeNull();
+
+    // Gateway recovers with a restrictive policy: the next setup must re-attempt
+    // the IPC (not serve a stale fail-open null) and honor the now-recovered floor.
+    ipcHandlers.set(METHOD, () => ({ policy: "guardian_only" }));
+    expect(await getChannelAdmissionPolicy("telegram")).toBe("guardian_only");
+    expect(countCalls(METHOD)).toBe(2);
+  });
+
+  test("does NOT cache a thrown IPC error — re-consults the gateway", async () => {
+    ipcHandlers.set(METHOD, () => {
+      throw new Error("socket exploded");
+    });
+    expect(await getChannelAdmissionPolicy("telegram")).toBeNull();
+
+    ipcHandlers.set(METHOD, () => ({ policy: "no_one" }));
+    expect(await getChannelAdmissionPolicy("telegram")).toBe("no_one");
+    expect(countCalls(METHOD)).toBe(2);
+  });
+
+  test("does NOT cache a malformed shape — re-consults the gateway", async () => {
+    ipcHandlers.set(METHOD, () => ({ policy: "definitely-not-a-policy" }));
+    expect(await getChannelAdmissionPolicy("telegram")).toBeNull();
+
+    ipcHandlers.set(METHOD, () => ({ policy: "guardian_only" }));
+    expect(await getChannelAdmissionPolicy("telegram")).toBe("guardian_only");
+    expect(countCalls(METHOD)).toBe(2);
   });
 });

--- a/assistant/src/calls/__tests__/channel-admission-reader.test.ts
+++ b/assistant/src/calls/__tests__/channel-admission-reader.test.ts
@@ -12,12 +12,19 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 type IpcHandler = (params?: Record<string, unknown>) => unknown;
 
 const ipcHandlers = new Map<string, IpcHandler>();
-const ipcCallLog: Array<{ method: string; params?: Record<string, unknown> }> =
-  [];
+const ipcCallLog: Array<{
+  method: string;
+  params?: Record<string, unknown>;
+  timeoutMs?: number;
+}> = [];
 
 mock.module("../../ipc/gateway-client.js", () => ({
-  ipcCall: async (method: string, params?: Record<string, unknown>) => {
-    ipcCallLog.push({ method, params });
+  ipcCall: async (
+    method: string,
+    params?: Record<string, unknown>,
+    timeoutMs?: number,
+  ) => {
+    ipcCallLog.push({ method, params, timeoutMs });
     const handler = ipcHandlers.get(method);
     return handler ? handler(params) : undefined;
   },
@@ -50,6 +57,15 @@ describe("getChannelAdmissionPolicy", () => {
     // Second call within TTL is served from cache — no extra IPC round-trip.
     expect(await getChannelAdmissionPolicy("telegram")).toBe("guardian_only");
     expect(countCalls(METHOD)).toBe(1);
+  });
+
+  test("bounds the IPC read with a short timeout so it fails open promptly", async () => {
+    ipcHandlers.set(METHOD, () => ({ policy: "guardian_only" }));
+
+    await getChannelAdmissionPolicy("telegram");
+
+    const call = ipcCallLog.find((c) => c.method === METHOD);
+    expect(call?.timeoutMs).toBe(1_000);
   });
 
   test("returns null when IPC transport fails (undefined)", async () => {

--- a/assistant/src/calls/__tests__/channel-admission-reader.test.ts
+++ b/assistant/src/calls/__tests__/channel-admission-reader.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for the gateway-backed channel admission policy reader.
+ *
+ * The reader fails open (returns null = admit) so a gateway IPC failure can
+ * never block a live call. These tests pin that contract plus the TTL cache.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Controllable IPC mock ────────────────────────────────────────────────────
+
+type IpcHandler = (params?: Record<string, unknown>) => unknown;
+
+const ipcHandlers = new Map<string, IpcHandler>();
+const ipcCallLog: Array<{ method: string; params?: Record<string, unknown> }> =
+  [];
+
+mock.module("../../ipc/gateway-client.js", () => ({
+  ipcCall: async (method: string, params?: Record<string, unknown>) => {
+    ipcCallLog.push({ method, params });
+    const handler = ipcHandlers.get(method);
+    return handler ? handler(params) : undefined;
+  },
+  ipcCallPersistent: async () => undefined,
+  resetPersistentClient: () => {},
+}));
+
+import {
+  _clearCacheForTesting,
+  getChannelAdmissionPolicy,
+} from "../channel-admission-reader.js";
+
+const METHOD = "get_channel_admission_policy";
+
+function countCalls(method: string): number {
+  return ipcCallLog.filter((c) => c.method === method).length;
+}
+
+describe("getChannelAdmissionPolicy", () => {
+  beforeEach(() => {
+    _clearCacheForTesting();
+    ipcHandlers.clear();
+    ipcCallLog.length = 0;
+  });
+
+  test("returns the gateway-resolved policy and caches it within the TTL", async () => {
+    ipcHandlers.set(METHOD, () => ({ policy: "guardian_only" }));
+
+    expect(await getChannelAdmissionPolicy("telegram")).toBe("guardian_only");
+    // Second call within TTL is served from cache — no extra IPC round-trip.
+    expect(await getChannelAdmissionPolicy("telegram")).toBe("guardian_only");
+    expect(countCalls(METHOD)).toBe(1);
+  });
+
+  test("returns null when IPC transport fails (undefined)", async () => {
+    ipcHandlers.set(METHOD, () => undefined);
+    expect(await getChannelAdmissionPolicy("telegram")).toBeNull();
+  });
+
+  test("returns null when the gateway explicitly resolves no policy", async () => {
+    ipcHandlers.set(METHOD, () => ({ policy: null }));
+    expect(await getChannelAdmissionPolicy("telegram")).toBeNull();
+  });
+
+  test("returns null when the IPC call throws", async () => {
+    ipcHandlers.set(METHOD, () => {
+      throw new Error("socket exploded");
+    });
+    expect(await getChannelAdmissionPolicy("telegram")).toBeNull();
+  });
+
+  test("returns null for an invalid policy string", async () => {
+    ipcHandlers.set(METHOD, () => ({ policy: "definitely-not-a-policy" }));
+    expect(await getChannelAdmissionPolicy("telegram")).toBeNull();
+  });
+
+  test("caches the negative (null) result within the TTL", async () => {
+    ipcHandlers.set(METHOD, () => undefined);
+    expect(await getChannelAdmissionPolicy("telegram")).toBeNull();
+    expect(await getChannelAdmissionPolicy("telegram")).toBeNull();
+    expect(countCalls(METHOD)).toBe(1);
+  });
+});

--- a/assistant/src/calls/channel-admission-reader.ts
+++ b/assistant/src/calls/channel-admission-reader.ts
@@ -22,6 +22,11 @@ import { ipcCall } from "../ipc/gateway-client.js";
 
 const CACHE_TTL_MS = 5_000;
 
+// Short IPC timeout so admission fails open PROMPTLY: a gateway that accepts
+// the socket but stalls must never delay a live call handshake. 1s is generous
+// under normal conditions yet far below ipcCall's 5s default.
+const ADMISSION_IPC_TIMEOUT_MS = 1_000;
+
 const cache = new Map<
   ChannelId,
   { policy: AdmissionPolicy | null; timestamp: number }
@@ -49,9 +54,11 @@ export async function getChannelAdmissionPolicy(
     // ipcCall() returns undefined on transport failure (socket not found,
     // timeout, parse error). Treat anything other than a valid policy as
     // "no enforcement" so a gateway hiccup can never block call setup.
-    const result = (await ipcCall("get_channel_admission_policy", {
-      channelType,
-    })) as { policy?: unknown } | null | undefined;
+    const result = (await ipcCall(
+      "get_channel_admission_policy",
+      { channelType },
+      ADMISSION_IPC_TIMEOUT_MS,
+    )) as { policy?: unknown } | null | undefined;
 
     if (result && isAdmissionPolicy(result.policy)) {
       policy = result.policy;

--- a/assistant/src/calls/channel-admission-reader.ts
+++ b/assistant/src/calls/channel-admission-reader.ts
@@ -1,0 +1,65 @@
+/**
+ * Gateway-backed channel admission policy reader.
+ *
+ * Reads a channel's resolved admission floor from the gateway via the
+ * `get_channel_admission_policy` IPC route. Admission must never break call
+ * setup, so this reader FAILS OPEN: any transport failure, malformed shape,
+ * or thrown error resolves to `null` (= admit, no enforcement). A policy is
+ * only returned when the gateway responds with `{ policy: <valid policy> }`.
+ *
+ * Caches per channelType with a short TTL, mirroring the conversation
+ * threshold cache in `../permissions/gateway-threshold-reader.ts`. This sits
+ * off the hot path, so a lighter cache without failure-coalescing is fine.
+ */
+
+import {
+  type AdmissionPolicy,
+  isAdmissionPolicy,
+} from "@vellumai/gateway-client";
+
+import type { ChannelId } from "../channels/types.js";
+import { ipcCall } from "../ipc/gateway-client.js";
+
+const CACHE_TTL_MS = 5_000;
+
+const cache = new Map<
+  ChannelId,
+  { policy: AdmissionPolicy | null; timestamp: number }
+>();
+
+/** Test-only: clear the policy cache. */
+export function _clearCacheForTesting(): void {
+  cache.clear();
+}
+
+/**
+ * Resolve a channel's admission policy from the gateway, or `null` on any
+ * failure / absence. `null` means admit with no enforcement.
+ */
+export async function getChannelAdmissionPolicy(
+  channelType: ChannelId,
+): Promise<AdmissionPolicy | null> {
+  const cached = cache.get(channelType);
+  if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
+    return cached.policy;
+  }
+
+  let policy: AdmissionPolicy | null = null;
+  try {
+    // ipcCall() returns undefined on transport failure (socket not found,
+    // timeout, parse error). Treat anything other than a valid policy as
+    // "no enforcement" so a gateway hiccup can never block call setup.
+    const result = (await ipcCall("get_channel_admission_policy", {
+      channelType,
+    })) as { policy?: unknown } | null | undefined;
+
+    if (result && isAdmissionPolicy(result.policy)) {
+      policy = result.policy;
+    }
+  } catch {
+    // Fail open — a thrown IPC error must never block call setup.
+  }
+
+  cache.set(channelType, { policy, timestamp: Date.now() });
+  return policy;
+}

--- a/assistant/src/calls/channel-admission-reader.ts
+++ b/assistant/src/calls/channel-admission-reader.ts
@@ -8,8 +8,12 @@
  * only returned when the gateway responds with `{ policy: <valid policy> }`.
  *
  * Caches per channelType with a short TTL, mirroring the conversation
- * threshold cache in `../permissions/gateway-threshold-reader.ts`. This sits
- * off the hot path, so a lighter cache without failure-coalescing is fine.
+ * threshold cache in `../permissions/gateway-threshold-reader.ts`. Only the
+ * result of a SUCCESSFUL gateway round-trip is cached (a valid policy, or an
+ * explicit `{ policy: null }` "no enforcement" answer); a transport failure /
+ * throw / malformed shape fails open to `null` WITHOUT caching, so a recovered
+ * gateway is re-consulted on the next call setup rather than skipping the
+ * admission floor for the rest of the TTL.
  */
 
 import {
@@ -38,8 +42,48 @@ export function _clearCacheForTesting(): void {
 }
 
 /**
+ * Outcome of a single gateway fetch. Only a SUCCESSFUL round-trip (a valid
+ * policy, or an explicit `{ policy: null }` "no enforcement" answer) is
+ * cacheable. A transport failure, thrown error, or malformed shape is NOT
+ * cached so a recovered gateway is re-consulted on the next call setup.
+ */
+type FetchResult =
+  | { ok: true; policy: AdmissionPolicy | null }
+  | { ok: false };
+
+async function fetchAdmissionPolicy(
+  channelType: ChannelId,
+): Promise<FetchResult> {
+  try {
+    // ipcCall() returns undefined on transport failure (socket not found,
+    // timeout, parse error). That, a throw, or a malformed shape is a FAILURE:
+    // fail open without caching so the next setup re-attempts the IPC.
+    const result = (await ipcCall(
+      "get_channel_admission_policy",
+      { channelType },
+      ADMISSION_IPC_TIMEOUT_MS,
+    )) as { policy?: unknown } | null | undefined;
+
+    if (result === undefined) return { ok: false };
+    if (result && isAdmissionPolicy(result.policy)) {
+      return { ok: true, policy: result.policy };
+    }
+    // Explicit "no enforcement" — the gateway successfully answered. Cacheable.
+    if (result && result.policy === null) return { ok: true, policy: null };
+    // Anything else (missing/invalid policy field) is a malformed shape.
+    return { ok: false };
+  } catch {
+    return { ok: false };
+  }
+}
+
+/**
  * Resolve a channel's admission policy from the gateway, or `null` on any
  * failure / absence. `null` means admit with no enforcement.
+ *
+ * Always fails open to `null` on failure, but only caches the result of a
+ * SUCCESSFUL gateway round-trip — a transient hiccup must not skip the
+ * admission floor for the rest of the TTL.
  */
 export async function getChannelAdmissionPolicy(
   channelType: ChannelId,
@@ -49,24 +93,12 @@ export async function getChannelAdmissionPolicy(
     return cached.policy;
   }
 
-  let policy: AdmissionPolicy | null = null;
-  try {
-    // ipcCall() returns undefined on transport failure (socket not found,
-    // timeout, parse error). Treat anything other than a valid policy as
-    // "no enforcement" so a gateway hiccup can never block call setup.
-    const result = (await ipcCall(
-      "get_channel_admission_policy",
-      { channelType },
-      ADMISSION_IPC_TIMEOUT_MS,
-    )) as { policy?: unknown } | null | undefined;
-
-    if (result && isAdmissionPolicy(result.policy)) {
-      policy = result.policy;
-    }
-  } catch {
-    // Fail open — a thrown IPC error must never block call setup.
+  const result = await fetchAdmissionPolicy(channelType);
+  if (!result.ok) {
+    // Fail open WITHOUT caching so a recovered gateway is re-consulted next time.
+    return null;
   }
 
-  cache.set(channelType, { policy, timestamp: Date.now() });
-  return policy;
+  cache.set(channelType, { policy: result.policy, timestamp: Date.now() });
+  return result.policy;
 }


### PR DESCRIPTION
## Summary
- Add `getChannelAdmissionPolicy` reader that fetches a channel's admission floor from the gateway over IPC, with a short TTL cache and fail-open (null) semantics so a gateway failure never blocks call setup.

Part of plan: voice-admission.md (PR 3 of 6)