### PR TITLE
refactor(assistant): centralize capability+context composition

### DIFF
--- a/assistant/src/config/bundled-skills/messaging/tools/messaging-archive-by-sender.ts
+++ b/assistant/src/config/bundled-skills/messaging/tools/messaging-archive-by-sender.ts
@@ -1,4 +1,4 @@
-import { resolveCapabilities } from "../../../../runtime/capabilities.js";
+import { isArchiveBySenderAuthorized } from "../../../../runtime/effective-capabilities.js";
 import type {
   ToolContext,
   ToolExecutionResult,
@@ -9,15 +9,14 @@ export async function run(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const userApproved =
-    input.user_approved === true &&
-    resolveCapabilities(context.trustClass).canSelfAuthorizeArchiveBySender;
-  if (
-    !context.triggeredBySurfaceAction &&
-    !context.batchAuthorizedByTask &&
-    !context.approvedViaPrompt &&
-    !userApproved
-  ) {
+  const authorized = isArchiveBySenderAuthorized({
+    trustClass: context.trustClass,
+    triggeredBySurfaceAction: context.triggeredBySurfaceAction,
+    batchAuthorizedByTask: context.batchAuthorizedByTask,
+    approvedViaPrompt: context.approvedViaPrompt,
+    userApproved: input.user_approved === true,
+  });
+  if (!authorized) {
     return err(
       "This tool requires either a surface action or a scheduled task run with this tool in required_tools. Present results in a selection table with action buttons and wait for the user to click before proceeding.",
     );

--- a/assistant/src/runtime/capabilities.ts
+++ b/assistant/src/runtime/capabilities.ts
@@ -17,8 +17,10 @@
  * is the "what they may do once inside" axis.
  *
  * Context-dependent decisions (interactivity routing, self-approval races,
- * channel-specific overrides) COMPOSE these primitives with runtime context at
- * the call site — they are not encoded in the table.
+ * channel-specific overrides) COMPOSE these primitives with runtime context.
+ * They are not encoded in the table; named composition helpers live in
+ * `effective-capabilities.ts` (and `resolveRoutingState` in
+ * `trust-context-resolver.ts`).
  */
 
 import type { TrustClass } from "./actor-trust-resolver.js";
@@ -76,8 +78,9 @@ export interface CapabilitySet {
    */
   canAccessMemory: boolean;
   /**
-   * May perform privileged (non-conversation-scoped) document operations.
-   * Composed at the call site with the `vellum`-channel override.
+   * May perform privileged (non-conversation-scoped) document operations from
+   * trust class alone. The effective decision also honors privileged channels —
+   * see `canActOnPrivilegedDocuments` in `effective-capabilities.ts`.
    */
   canAccessPrivilegedDocuments: boolean;
 

--- a/assistant/src/runtime/effective-capabilities.test.ts
+++ b/assistant/src/runtime/effective-capabilities.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  canActOnPrivilegedDocuments,
+  isArchiveBySenderAuthorized,
+  isUntrustedShellLockdownActive,
+} from "./effective-capabilities.js";
+
+describe("canActOnPrivilegedDocuments", () => {
+  test("guardian is privileged regardless of channel", () => {
+    expect(canActOnPrivilegedDocuments({ trustClass: "guardian" })).toBe(true);
+    expect(
+      canActOnPrivilegedDocuments({
+        trustClass: "guardian",
+        executionChannel: "telegram",
+      }),
+    ).toBe(true);
+  });
+
+  test("non-guardian is privileged only on a privileged channel", () => {
+    expect(
+      canActOnPrivilegedDocuments({
+        trustClass: "trusted_contact",
+        executionChannel: "telegram",
+      }),
+    ).toBe(false);
+    expect(
+      canActOnPrivilegedDocuments({
+        trustClass: "trusted_contact",
+        executionChannel: "vellum",
+      }),
+    ).toBe(true);
+  });
+
+  test("the vellum channel grants access even to unknown actors", () => {
+    expect(
+      canActOnPrivilegedDocuments({
+        trustClass: "unknown",
+        executionChannel: "vellum",
+      }),
+    ).toBe(true);
+    expect(canActOnPrivilegedDocuments({ trustClass: "unknown" })).toBe(false);
+  });
+});
+
+describe("isUntrustedShellLockdownActive", () => {
+  test("inactive when the lockdown flag is off", () => {
+    expect(
+      isUntrustedShellLockdownActive({
+        trustClass: "unknown",
+        lockdownEnabled: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("inactive for guardians even when the flag is on", () => {
+    expect(
+      isUntrustedShellLockdownActive({
+        trustClass: "guardian",
+        lockdownEnabled: true,
+      }),
+    ).toBe(false);
+  });
+
+  test("active for non-unsandboxed actors when the flag is on", () => {
+    expect(
+      isUntrustedShellLockdownActive({
+        trustClass: "trusted_contact",
+        lockdownEnabled: true,
+      }),
+    ).toBe(true);
+    expect(
+      isUntrustedShellLockdownActive({
+        trustClass: "unknown",
+        lockdownEnabled: true,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("isArchiveBySenderAuthorized", () => {
+  test("any non-self authorization path suffices", () => {
+    expect(
+      isArchiveBySenderAuthorized({
+        trustClass: "unknown",
+        triggeredBySurfaceAction: true,
+      }),
+    ).toBe(true);
+    expect(
+      isArchiveBySenderAuthorized({
+        trustClass: "unknown",
+        batchAuthorizedByTask: true,
+      }),
+    ).toBe(true);
+    expect(
+      isArchiveBySenderAuthorized({
+        trustClass: "unknown",
+        approvedViaPrompt: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("user_approved self-authorizes only for a permitted trust class", () => {
+    expect(
+      isArchiveBySenderAuthorized({
+        trustClass: "guardian",
+        userApproved: true,
+      }),
+    ).toBe(true);
+    expect(
+      isArchiveBySenderAuthorized({
+        trustClass: "trusted_contact",
+        userApproved: true,
+      }),
+    ).toBe(false);
+  });
+
+  test("unauthorized when no path applies", () => {
+    expect(isArchiveBySenderAuthorized({ trustClass: "guardian" })).toBe(false);
+    expect(
+      isArchiveBySenderAuthorized({
+        trustClass: "trusted_contact",
+        triggeredBySurfaceAction: false,
+        userApproved: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/assistant/src/runtime/effective-capabilities.ts
+++ b/assistant/src/runtime/effective-capabilities.ts
@@ -1,0 +1,84 @@
+/**
+ * Effective capabilities — trust-class capabilities COMPOSED with runtime context.
+ *
+ * `resolveCapabilities` (`capabilities.ts`) answers "what may this trust class
+ * do" from the actor's class alone, and stays deliberately pure (no context
+ * dependencies) so it remains the single fail-closed trust boundary. Some real
+ * decisions additionally depend on runtime context — the channel a request
+ * arrived on, surface actions, task authorization, a feature flag. Those
+ * compositions belong here, in named/testable helpers, rather than re-derived
+ * inline at each call site (which scatters a single policy across the codebase).
+ *
+ * Scope: this module composes capabilities with *actor/request* context. It does
+ * not read global config or feature flags itself — callers resolve those and
+ * pass the result in (e.g. `lockdownEnabled`), keeping this layer focused on the
+ * capability composition. `resolveRoutingState` in `trust-context-resolver.ts`
+ * is the same shape (capability + guardian-route context → `promptWaitingAllowed`)
+ * and predates this module; it stays where it is.
+ */
+import type { TrustClass } from "./actor-trust-resolver.js";
+import { resolveCapabilities } from "./capabilities.js";
+
+type RawTrustClass = TrustClass | (string & {}) | undefined;
+
+/**
+ * Channels that are themselves privileged document surfaces. Actors on these get
+ * privileged document access regardless of trust class — the `vellum` first-party
+ * console is the operator's own surface, not an external contact channel.
+ */
+const PRIVILEGED_DOCUMENT_CHANNELS = new Set<string>(["vellum"]);
+
+/**
+ * Whether an actor may perform privileged (non-conversation-scoped) document
+ * operations. True when the trust class grants it OR the request arrived on a
+ * privileged channel.
+ */
+export function canActOnPrivilegedDocuments(actor: {
+  trustClass: RawTrustClass;
+  executionChannel?: string;
+}): boolean {
+  return (
+    resolveCapabilities(actor.trustClass).canAccessPrivilegedDocuments ||
+    (actor.executionChannel != null &&
+      PRIVILEGED_DOCUMENT_CHANNELS.has(actor.executionChannel))
+  );
+}
+
+/**
+ * Whether the CES shell lockdown applies to this actor. Active when the lockdown
+ * flag is enabled AND the actor's trust class cannot run an unsandboxed shell.
+ * Callers resolve the flag (`isCesShellLockdownEnabled(config)`) and pass it in.
+ */
+export function isUntrustedShellLockdownActive(actor: {
+  trustClass: RawTrustClass;
+  lockdownEnabled: boolean;
+}): boolean {
+  return (
+    actor.lockdownEnabled &&
+    !resolveCapabilities(actor.trustClass).canRunUnsandboxedShell
+  );
+}
+
+/**
+ * Whether an archive-by-sender invocation is authorized. Any one of a surface
+ * action, a task-batch authorization, or an explicit prompt approval suffices.
+ * Absent those, the actor's own `user_approved` flag only counts when its trust
+ * class may self-authorize archive-by-sender.
+ */
+export function isArchiveBySenderAuthorized(args: {
+  trustClass: RawTrustClass;
+  triggeredBySurfaceAction?: boolean;
+  batchAuthorizedByTask?: boolean;
+  approvedViaPrompt?: boolean;
+  userApproved?: boolean;
+}): boolean {
+  const selfAuthorized =
+    args.userApproved === true &&
+    resolveCapabilities(args.trustClass).canSelfAuthorizeArchiveBySender;
+  return (
+    args.triggeredBySurfaceAction === true ||
+    args.batchAuthorizedByTask === true ||
+    args.approvedViaPrompt === true ||
+    selfAuthorized
+  );
+}

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -13,14 +13,11 @@ import {
   searchDocumentsByTitle,
   updateDocumentContent,
 } from "../../documents/document-store.js";
-import { resolveCapabilities } from "../../runtime/capabilities.js";
+import { canActOnPrivilegedDocuments } from "../../runtime/effective-capabilities.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 
 function isPrivilegedDocumentActor(context: ToolContext): boolean {
-  return (
-    resolveCapabilities(context.trustClass).canAccessPrivilegedDocuments ||
-    context.executionChannel === "vellum"
-  );
+  return canActOnPrivilegedDocuments(context);
 }
 
 export function documentNotFound(surfaceId: string): ToolExecutionResult {

--- a/assistant/src/tools/executor.ts
+++ b/assistant/src/tools/executor.ts
@@ -5,7 +5,7 @@ import { bridgeCesApproval } from "../credential-execution/approval-bridge.js";
 import { isCesShellLockdownEnabled } from "../credential-execution/feature-gates.js";
 import { PermissionPrompter } from "../permissions/prompter.js";
 import { RiskLevel } from "../permissions/types.js";
-import { resolveCapabilities } from "../runtime/capabilities.js";
+import { isUntrustedShellLockdownActive } from "../runtime/effective-capabilities.js";
 import { redactSensitiveFields } from "../security/redaction.js";
 import { getCesClient } from "../security/secure-keys.js";
 import { TokenExpiredError } from "../security/token-manager.js";
@@ -128,8 +128,10 @@ export class ToolExecutor {
       // skip this assignment entirely - defeating the lockdown.
       if (
         name === "host_bash" &&
-        isCesShellLockdownEnabled(getConfig()) &&
-        !resolveCapabilities(context.trustClass).canRunUnsandboxedShell
+        isUntrustedShellLockdownActive({
+          trustClass: context.trustClass,
+          lockdownEnabled: isCesShellLockdownEnabled(getConfig()),
+        })
       ) {
         context.forcePromptSideEffects = true;
       }

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -25,7 +25,7 @@ import { HostBashProxy } from "../../daemon/host-bash-proxy.js";
 import { RiskLevel } from "../../permissions/types.js";
 import { wakeAgentForOpportunity } from "../../runtime/agent-wake.js";
 import { assistantEventHub } from "../../runtime/assistant-event-hub.js";
-import { resolveCapabilities } from "../../runtime/capabilities.js";
+import { isUntrustedShellLockdownActive } from "../../runtime/effective-capabilities.js";
 import { redactSecrets } from "../../security/secret-scanner.js";
 import { getLogger } from "../../util/logger.js";
 import {
@@ -204,9 +204,10 @@ export const hostShellTool = {
     // NOTE: forcePromptSideEffects is set in executor.ts BEFORE the
     // permission check runs, not here. Setting it here would be too late
     // because execute() is called after permissions have already been evaluated.
-    const hostLockdownActive =
-      isCesShellLockdownEnabled(config) &&
-      !resolveCapabilities(context.trustClass).canRunUnsandboxedShell;
+    const hostLockdownActive = isUntrustedShellLockdownActive({
+      trustClass: context.trustClass,
+      lockdownEnabled: isCesShellLockdownEnabled(config),
+    });
 
     // Guard: non-host-proxy interfaces need an explicit target when multiple
     // capable clients are connected to avoid ambiguous untargeted broadcasts.

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -5,7 +5,7 @@ import { getConfig } from "../../config/loader.js";
 import { isCesShellLockdownEnabled } from "../../credential-execution/feature-gates.js";
 import { RiskLevel } from "../../permissions/types.js";
 import { wakeAgentForOpportunity } from "../../runtime/agent-wake.js";
-import { resolveCapabilities } from "../../runtime/capabilities.js";
+import { isUntrustedShellLockdownActive } from "../../runtime/effective-capabilities.js";
 import { redactSecrets } from "../../security/secret-scanner.js";
 import { getLogger } from "../../util/logger.js";
 import { getDataDir } from "../../util/platform.js";
@@ -117,9 +117,10 @@ export const shellTool = {
     }
 
     const config = getConfig();
-    const shellLockdownActive =
-      isCesShellLockdownEnabled(config) &&
-      !resolveCapabilities(context.trustClass).canRunUnsandboxedShell;
+    const shellLockdownActive = isUntrustedShellLockdownActive({
+      trustClass: context.trustClass,
+      lockdownEnabled: isCesShellLockdownEnabled(config),
+    });
 
     const networkMode: "off" | "proxied" =
       input.network_mode === "proxied" ? "proxied" : "off";


### PR DESCRIPTION
## Summary
- Add `runtime/effective-capabilities.ts` — a named, unit-tested home for decisions that compose a pure trust-class capability (`resolveCapabilities`) with runtime context. `resolveCapabilities` stays deliberately pure (no context deps) so it remains the single fail-closed trust boundary; composition lives one layer up, mirroring the existing `resolveRoutingState` helper.
- Migrate three compositions that were re-derived inline at call sites: `canActOnPrivilegedDocuments` (trust class OR `vellum` channel), `isUntrustedShellLockdownActive` (flag AND not `canRunUnsandboxedShell` — previously triplicated across executor.ts, shell.ts, host-shell.ts), and `isArchiveBySenderAuthorized` (surface/task/prompt, or self-authorization gated on trust class).
- Pure refactor — no behavior change. Updated `capabilities.ts` doc comments to point composed decisions at the new module instead of documenting 'composed at the call site' as the resting state. Added `effective-capabilities.test.ts` (9 cases).

The CES feature-flag read stays at the call site (callers pass `lockdownEnabled`); the module composes only actor/request context, not global config. The higher-blast-radius `canSelfApproveTools` / `sensitiveToolApproval` approval-path compositions are intentionally left as follow-ups rather than refactored blind.

## Original prompt
Following an audit of the trust-class capability system, the assessment flagged that capability decisions are often composed with runtime context (channel, surface action, feature flags) ad hoc at each call site, scattering a single policy across the codebase. The ask was to implement the recommended fix: give those compositions one named, testable home so `resolveCapabilities` can stay pure. This PR establishes that home and migrates the clean cases, deferring the security-critical approval-path compositions.