### PR TITLE
fix(web): route avatar image fetch through the daemon client

### DIFF
--- a/clients/web/src/assistant/avatar-api.test.ts
+++ b/clients/web/src/assistant/avatar-api.test.ts
@@ -20,7 +20,11 @@ import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import type { AvatarState } from "@/types/avatar";
 import { isAvatarState } from "@/types/avatar";
 
-import { fetchAvatarState, uploadAvatarImage } from "./avatar-api";
+import {
+  fetchAvatarImageUrl,
+  fetchAvatarState,
+  uploadAvatarImage,
+} from "./avatar-api";
 
 const CHARACTER_STATE: AvatarState = {
   kind: "character",
@@ -87,6 +91,8 @@ describe("isAvatarState", () => {
 type CapturedGetOptions = {
   url: string;
   path?: Record<string, unknown>;
+  query?: Record<string, unknown>;
+  parseAs?: string;
 };
 
 let captured: CapturedGetOptions | null = null;
@@ -173,6 +179,60 @@ describe("fetchAvatarState", () => {
     ) as typeof client.get;
 
     expect(await fetchAvatarState("asst-1")).toBeNull();
+  });
+});
+
+describe("fetchAvatarImageUrl", () => {
+  const originalCreateObjectURL = URL.createObjectURL;
+
+  afterEach(() => {
+    URL.createObjectURL = originalCreateObjectURL;
+  });
+
+  test("fetches the PNG via the daemon workspace file-content route as a blob", async () => {
+    URL.createObjectURL = mock(
+      () => "blob:avatar",
+    ) as typeof URL.createObjectURL;
+    stubGet({
+      data: new Blob([new Uint8Array([137, 80, 78, 71])], {
+        type: "image/png",
+      }),
+      error: undefined,
+      response: okResponse(),
+    });
+
+    const result = await fetchAvatarImageUrl("asst-1");
+
+    // Regression guard: the image must be fetched through the daemon client
+    // (the instance spied on here), not the platform `api` client. The latter
+    // issues a relative `/v1/...` URL that the dev proxy forwards to a
+    // different — and locally absent — backend, so the request never reaches
+    // the daemon and the avatar silently falls back to the default character.
+    expect(captured?.url).toBe(
+      "/v1/assistants/{assistant_id}/workspace/file/content",
+    );
+    expect(captured?.path).toEqual({ assistant_id: "asst-1" });
+    expect(captured?.query).toEqual({ path: "data/avatar/avatar-image.png" });
+    expect(captured?.parseAs).toBe("blob");
+    expect(result).toBe("blob:avatar");
+  });
+
+  test("returns null on a non-2xx response", async () => {
+    stubGet({
+      data: undefined,
+      error: { detail: "boom" },
+      response: errorResponse(404),
+    });
+
+    expect(await fetchAvatarImageUrl("asst-1")).toBeNull();
+  });
+
+  test("returns null on a transport throw", async () => {
+    client.get = mock(() =>
+      Promise.reject(new Error("network down")),
+    ) as typeof client.get;
+
+    expect(await fetchAvatarImageUrl("asst-1")).toBeNull();
   });
 });
 

--- a/clients/web/src/assistant/avatar-api.ts
+++ b/clients/web/src/assistant/avatar-api.ts
@@ -6,13 +6,13 @@
  * to `/v1/X` before forwarding to the daemon, which registers avatar
  * and workspace routes flat (`/v1/avatar/...`, `/v1/workspace/...`).
  */
-import { client } from "@/generated/api/client.gen";
 import {
   avatarCharactercomponentsGet,
   avatarImagePost,
   avatarRenderfromtraitsPost,
   avatarStateGet,
   workspaceDeletePost,
+  workspaceFileContentGet,
   workspaceFileGet,
   workspaceWritePost,
 } from "@/generated/daemon/sdk.gen";
@@ -177,15 +177,15 @@ export async function fetchAvatarImageUrl(
   assistantId: string,
 ): Promise<string | null> {
   try {
-    const { data, error, response } = await client.get({
-      url: "/v1/assistants/{assistant_id}/workspace/file/content/",
+    const { data, error, response } = await workspaceFileContentGet({
       path: { assistant_id: assistantId },
       query: { path: "data/avatar/avatar-image.png" },
       parseAs: "blob",
+      throwOnError: false,
     });
     assertHasResponse(response, error, "Failed to fetch avatar image");
     if (!response.ok || !data) return null;
-    return URL.createObjectURL(data as Blob);
+    return URL.createObjectURL(data);
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- `fetchAvatarImageUrl` fetched the custom avatar PNG through the platform `api` client (`@/generated/api/client.gen`) with a relative `/v1/...` URL. In the dev/Electron setup vite proxies `/v1` to `API_PROXY_TARGET` (default `http://localhost:8000`, the Django platform), which isn't running in a local daemon+gateway setup — so the request dies with `ECONNREFUSED`, never reaches the daemon, and the chat UI silently falls back to the default green-blob character.
- Switched it to the existing `workspaceFileContentGet` daemon SDK method (`@/generated/daemon/sdk.gen`), which targets the absolute gateway URL like every other avatar call in the file. Removed the now-unused `api` client import and the redundant `as Blob` cast.
- Added `fetchAvatarImageUrl` coverage pinning that the request goes through the daemon client at `/v1/assistants/{assistant_id}/workspace/file/content` with `parseAs: "blob"`, plus the null-on-error paths.

## Original prompt
A configured assistant avatar was rendering as the default green character in the Electron app instead of its custom uploaded image. Diagnosis traced it to `fetchAvatarImageUrl` being the only avatar fetcher using the platform `api` client (relative URL → vite `/v1` proxy → locally-absent `:8000` backend → `ECONNREFUSED`), while its siblings use the daemon SDK (absolute gateway URL) and the daemon itself serves the PNG correctly. The fix routes the image fetch through the daemon SDK like the rest of the file.