### PR TITLE
chore(plugins): bump advisor marketplace pin to fe8139f

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -70,7 +70,7 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/advisor",
-        "ref": "02e81acd298c7516d25f20f402c80003453a9fc9"
+        "ref": "fe8139fa6e14a84253d796afd3df7a1a15af851d"
       },
       "description": "Consult a stronger inference profile mid-task via an advisor tool, routed through the workspace's own inference (no API key).",
       "category": "developer",


### PR DESCRIPTION
## Summary
- Bump the `advisor` plugin pin in `plugins/marketplace.json` from `02e81ac` to `fe8139f`, releasing [vellum-ai/advisor#1](https://github.com/vellum-ai/advisor/pull/1): the advisor now forces its profile above any per-call-site `inference` pin (`forceOverrideProfile`), and its `@vellumai/plugin-api` peer range includes 0.9.x.

## Original prompt
Follow-up to enabling the advisor plugin on a workspace whose `inference` call site was pinned to a cheap profile — without `forceOverrideProfile` the advisor silently consulted the cheap model. The upstream fix is merged; this bumps the marketplace pin so new installs and `plugins upgrade advisor` pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)