### PR TITLE
fix(ipc): fall back to HTTP for binary responses over the IPC proxy

### DIFF
--- a/assistant/src/ipc/__tests__/binary-result-ipc.test.ts
+++ b/assistant/src/ipc/__tests__/binary-result-ipc.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for how `AssistantIpcServer.sendResult` handles a binary or
+ * streaming handler result over the IPC transport.
+ *
+ * A `RouteResponse` (or a bare `Uint8Array` / `ReadableStream` / `Blob`)
+ * wraps raw bytes that can't be carried as a JSON `result` field. Rather than
+ * silently serialize the body into garbage, the server reports a structured
+ * `BINARY_UNSUPPORTED_OVER_IPC` error; the gateway IPC proxy uses that signal
+ * to fall back to the HTTP proxy, which streams binary responses correctly.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { RouteResponse } from "../../runtime/routes/types.js";
+import { AssistantIpcServer } from "../assistant-server.js";
+
+/**
+ * `sendResult` is private; access it through an interface cast so the test
+ * exercises the real production path without a test-only API on the class.
+ */
+type PrivateApi = {
+  sendResult(
+    socket: unknown,
+    reader: unknown,
+    requestId: string,
+    value: unknown,
+  ): void;
+};
+
+/**
+ * Drive `sendResult` with a capturing socket in legacy (newline-delimited
+ * JSON) mode — the same wire shape the gateway's IPC client speaks — and
+ * return the parsed response envelope.
+ */
+function captureSendResult(value: unknown): Record<string, unknown> {
+  const server = new AssistantIpcServer() as unknown as PrivateApi;
+  const writes: string[] = [];
+  const socket = {
+    destroyed: false,
+    write: (chunk: string) => {
+      writes.push(chunk);
+      return true;
+    },
+  };
+  const reader = { isLegacy: true };
+
+  server.sendResult(socket, reader, "req-1", value);
+
+  expect(writes).toHaveLength(1);
+  return JSON.parse(writes[0]) as Record<string, unknown>;
+}
+
+describe("AssistantIpcServer.sendResult binary handling", () => {
+  test("a binary RouteResponse is reported as BINARY_UNSUPPORTED_OVER_IPC", () => {
+    const env = captureSendResult(
+      new RouteResponse(new Uint8Array([137, 80, 78, 71]), {
+        "content-type": "image/png",
+      }),
+    );
+
+    expect(env.id).toBe("req-1");
+    expect(env.statusCode).toBe(421);
+    expect(env.errorCode).toBe("BINARY_UNSUPPORTED_OVER_IPC");
+    // The binary body must never be JSON-serialized into a `result` field.
+    expect("result" in env).toBe(false);
+  });
+
+  test("a bare Uint8Array result is also reported as unsupported", () => {
+    const env = captureSendResult(new Uint8Array([1, 2, 3]));
+
+    expect(env.errorCode).toBe("BINARY_UNSUPPORTED_OVER_IPC");
+    expect("result" in env).toBe(false);
+  });
+
+  test("a plain JSON result still serializes into `result`", () => {
+    const env = captureSendResult({ ok: true, count: 2 });
+
+    expect(env.result).toEqual({ ok: true, count: 2 });
+    expect(env.errorCode).toBeUndefined();
+  });
+});

--- a/assistant/src/ipc/assistant-server.ts
+++ b/assistant/src/ipc/assistant-server.ts
@@ -31,10 +31,7 @@
 import { existsSync, unlinkSync } from "node:fs";
 import { createServer, type Server, type Socket } from "node:net";
 
-import {
-  ensureSocketDir,
-  SocketWatchdog,
-} from "@vellumai/ipc-server-utils";
+import { ensureSocketDir, SocketWatchdog } from "@vellumai/ipc-server-utils";
 
 import { findLocalGuardianPrincipalId } from "../runtime/local-actor-identity.js";
 import { RouteError } from "../runtime/routes/errors.js";
@@ -43,6 +40,7 @@ import type {
   RouteDefinition,
   RouteHandlerArgs,
 } from "../runtime/routes/types.js";
+import { RouteResponse } from "../runtime/routes/types.js";
 import { getLogger } from "../util/logger.js";
 import {
   type IpcEnvelope,
@@ -131,6 +129,26 @@ function isIpcBinaryResponse(value: unknown): value is IpcBinaryResponse {
     (value as IpcBinaryResponse).binary instanceof Uint8Array &&
     "headers" in value &&
     typeof (value as IpcBinaryResponse).headers === "object"
+  );
+}
+
+/**
+ * A handler result whose body is raw bytes or a stream rather than a JSON
+ * value — `RouteResponse` (e.g. `workspace/file/content` returns a
+ * `Bun.file`), or a bare `Uint8Array` / `ReadableStream` / `Blob`.
+ *
+ * These cannot be carried as a JSON `result` field, so over the IPC
+ * transport they are reported as a structured error rather than silently
+ * JSON-serialized into garbage. Distinct from the `IpcBinaryResponse` /
+ * `IpcStreamingResponse` wrappers, which are explicit binary envelopes the
+ * framing protocol does transmit.
+ */
+function isNonJsonIpcResult(value: unknown): boolean {
+  return (
+    value instanceof RouteResponse ||
+    value instanceof Uint8Array ||
+    value instanceof ReadableStream ||
+    value instanceof Blob
   );
 }
 
@@ -401,6 +419,8 @@ export class AssistantIpcServer {
    * Route a handler result to the appropriate send path:
    * - IpcStreamingResponse → chunked binary frames
    * - IpcBinaryResponse → single binary frame with content-length
+   * - A raw binary/stream result (RouteResponse, Uint8Array, ...) → structured
+   *   BINARY_UNSUPPORTED_OVER_IPC error (the transport can't carry it as JSON)
    * - Everything else → JSON response
    */
   private sendResult(
@@ -420,6 +440,19 @@ export class AssistantIpcServer {
         },
       };
       this.sendResponse(socket, reader, envelope, value.binary);
+    } else if (isNonJsonIpcResult(value)) {
+      // A binary/streaming handler result (e.g. a file-content RouteResponse
+      // wrapping a Bun.file) cannot be carried as a JSON `result`. Report a
+      // structured error instead of silently serializing it into garbage; the
+      // gateway IPC proxy treats this code as a signal to retry over HTTP,
+      // which streams binary correctly.
+      this.sendResponse(socket, reader, {
+        id: requestId,
+        error:
+          "Binary/streaming responses are not supported over the IPC transport; use HTTP",
+        statusCode: 421,
+        errorCode: "BINARY_UNSUPPORTED_OVER_IPC",
+      });
     } else {
       this.sendResponse(socket, reader, { id: requestId, result: value });
     }

--- a/gateway/src/http/routes/ipc-runtime-proxy.test.ts
+++ b/gateway/src/http/routes/ipc-runtime-proxy.test.ts
@@ -260,6 +260,28 @@ describe("tryIpcProxy", () => {
     expect(params.body).toEqual({ message: "hello" });
   });
 
+  test("falls back to HTTP (returns null) on BINARY_UNSUPPORTED_OVER_IPC", async () => {
+    // Binary/streaming routes can't be carried over the IPC transport. The
+    // daemon signals this with a structured error; the proxy must return null
+    // so the request falls through to the HTTP proxy rather than surfacing the
+    // error to the client.
+    ipcCallAssistantMock.mockImplementation((method: string) => {
+      if (method === "get_route_schema") return Promise.resolve(ROUTE_SCHEMA);
+      return Promise.reject(
+        new MockIpcHandlerError(
+          "Binary/streaming responses are not supported over the IPC transport; use HTTP",
+          421,
+          "BINARY_UNSUPPORTED_OVER_IPC",
+        ),
+      );
+    });
+
+    const req = makeRequest("/v1/apps/myapp/dist/bundle.js");
+    const result = await tryIpcProxy(req, makeConfig());
+
+    expect(result).toBeNull();
+  });
+
   test("only forwards X-Vellum-* headers", async () => {
     const req = makeRequest("/v1/health", {
       headers: {

--- a/gateway/src/http/routes/ipc-runtime-proxy.ts
+++ b/gateway/src/http/routes/ipc-runtime-proxy.ts
@@ -214,6 +214,26 @@ export async function tryIpcProxy(
   } catch (err) {
     const duration = Math.round(performance.now() - start);
 
+    // A binary/streaming route can't be carried over the IPC transport (the
+    // gateway IPC client speaks newline-delimited JSON). The daemon signals
+    // this with BINARY_UNSUPPORTED_OVER_IPC; return null so the caller falls
+    // through to the HTTP proxy, which streams binary responses correctly.
+    if (
+      err instanceof IpcHandlerError &&
+      err.code === "BINARY_UNSUPPORTED_OVER_IPC"
+    ) {
+      log.info(
+        {
+          method: req.method,
+          path: pathname,
+          operationId: match.operationId,
+          duration,
+        },
+        "IPC proxy falling back to HTTP for binary response",
+      );
+      return null;
+    }
+
     if (err instanceof IpcHandlerError) {
       log.warn(
         {


### PR DESCRIPTION
## Summary
- The daemon IPC server's `sendResult` only recognized `IpcBinaryResponse`/`IpcStreamingResponse` wrappers; binary route handlers actually return a `RouteResponse` (or a raw `Uint8Array`/`ReadableStream`/`Blob`), which fell through to JSON serialization and corrupted the bytes. The gateway's IPC client also speaks newline-delimited JSON and can't carry binary frames at all.
- The daemon now detects a non-JSON result at the send point and returns a structured `BINARY_UNSUPPORTED_OVER_IPC` error instead of serializing garbage. The gateway IPC proxy catches that code and returns `null`, falling through to the HTTP proxy — which already streams binary responses correctly.
- Runtime detection covers every current and future binary route (file content, attachments, app dist assets, PDFs, ...) without per-route flags or route-schema changes. Adds daemon unit tests for `sendResult` and a gateway test asserting the HTTP fall-through.

## Original prompt
While diagnosing why an assistant's avatar image fell back to a default green character (a separate client-side bug, fixed in its own PR), I flagged a latent issue: binary responses served through the gateway's IPC runtime proxy are silently corrupted. The proxy is gated behind the `X-Vellum-Proxy-Server: ipc` testing header and isn't active yet, but it would break avatar images, file content, attachments, and PDFs when the IPC cutover flips on. This hardens that path so binary always routes over HTTP.