### PR TITLE
feat(prompts): give subagent delegation its own system-prompt section

### DIFF
--- a/assistant/src/prompts/templates/system-sections.ts
+++ b/assistant/src/prompts/templates/system-sections.ts
@@ -262,13 +262,18 @@ These are default guidelines. Always prioritize communication preferences that y
 `,
   },
   {
+    id: "01-delegate-subagents",
+    body: `## Delegate independent work
+
+When part of a task can run on its own — a research sweep, a multi-file investigation, a build-and-test loop — hand it off instead of grinding through it inline: load the \`subagent\` skill, then \`subagent_spawn\` early and in parallel. Make delegating that kind of work your default, not a last resort; an unnecessary subagent is cheaper than serialized work, and a long inline dig floods your own context.
+`,
+  },
+  {
     id: "01-parallel-tool-calls",
     body: `<use_parallel_tool_calls>
 Batch independent tool calls into the same response. An extra LLM round trip costs orders of magnitude more than a few wasted tool calls — err on the side of parallelizing when calls are independent. Reading multiple files, \`glob\`/\`grep\`, \`ls\`, \`git status\`/\`diff\`/\`log\`, type-checks, and tests should be batched.
 
 Before emitting a single tool call, ask whether your next turn would be another tool call that doesn't consume this one's output — if so, they belong together. Serialized tool calls without a real data dependency are a bug.
-
-For non-trivial independent workstreams — research, coding, multi-step investigations — delegate to subagents (load the \`subagent\` skill) and spawn them early and in parallel; an unnecessary subagent is cheaper than serialized work.
 </use_parallel_tool_calls>
 `,
   },


### PR DESCRIPTION
## Summary
- Pull the subagent-delegation guidance out of the `<use_parallel_tool_calls>` block into a dedicated `01-delegate-subagents` bundled section, so it reads as a first-class directive rather than a trailing footnote to tool-batching.
- Reframe the wording as a low-ceremony default: concrete triggers (a research sweep, a multi-file investigation, a build-and-test loop), foreground `subagent_spawn` and demote `skill_load` to a sub-clause, and frame delegating as the default rather than a last resort.
- Bundled-registry change only; renders by default with no workspace override. Sorts into the operational cluster just before `01-parallel-tool-calls` (delegate big chunks, then batch small calls, then show progress).

## Original prompt
Investigation found that the assistant effectively never spawns subagents on its own, only when explicitly told to, even though the existing nudge and `skill_load` are present on every turn. The diagnosis: delegation was under-weighted by being buried as the last sentence of the parallel-tool-calls block (an altitude and framing problem), not a discovery problem. The chosen fix is prompt-only: lift the directive into its own section and reframe it to lower the perceived ceremony of delegating. A complementary persona-level line is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)