### PR TITLE
feat(assistant): supply phone admission policy to voice setup routing

### DIFF
--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -114,8 +114,12 @@ let mockAdmissionPolicy:
   | import("@vellumai/gateway-client").AdmissionPolicy
   | null = null;
 let mockAdmissionReaderThrows = false;
+// Optional gate to hold the reader open mid-setup so tests can drive the
+// race window where a prompt arrives while handleSetup is still awaiting.
+let mockAdmissionGate: Promise<void> | null = null;
 mock.module("../calls/channel-admission-reader.js", () => ({
   getChannelAdmissionPolicy: async () => {
+    if (mockAdmissionGate) await mockAdmissionGate;
     if (mockAdmissionReaderThrows) throw new Error("reader boom");
     return mockAdmissionPolicy;
   },
@@ -462,6 +466,7 @@ describe("relay-server", () => {
     mockAssistantName = "Vellum";
     mockAdmissionPolicy = null;
     mockAdmissionReaderThrows = false;
+    mockAdmissionGate = null;
     mockSendMessage.mockImplementation(createMockProviderResponse(["Hello"]));
     mockConfig.calls.verification.enabled = false;
     mockConfig.calls.verification.maxAttempts = 3;
@@ -894,6 +899,121 @@ describe("relay-server", () => {
     expect(textMessages.length).toBe(1);
     expect(textMessages[0].token).toContain("still setting up");
     expect(textMessages[0].last).toBe(true);
+
+    relay.destroy();
+  });
+
+  test("handleMessage: prompt arriving during setup (setting_up) is dropped", async () => {
+    ensureConversation("conv-relay-setting-up");
+    const session = createCallSession({
+      conversationId: "conv-relay-setting-up",
+      provider: "twilio",
+      fromNumber: "+15551111111",
+      toNumber: "+15552222222",
+    });
+
+    addTrustedVoiceContact("+15551111111");
+
+    const { ws, relay } = createMockWs(session.id);
+
+    // Hold the admission reader open so handleSetup stays in "setting_up".
+    let releaseGate: () => void = () => {};
+    mockAdmissionGate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+
+    // Fire setup without awaiting — it suspends inside getChannelAdmissionPolicy.
+    const setupPromise = relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_setting_up_123",
+        from: "+15551111111",
+        to: "+15552222222",
+      }),
+    );
+
+    // Let the setup task reach the await; state must be "setting_up".
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(relay.getConnectionState()).toBe("setting_up");
+
+    // A prompt arriving now must be dropped: no transcript, no fallback.
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "prompt",
+        voicePrompt: "Wire me money",
+        lang: "en-US",
+        last: true,
+      }),
+    );
+
+    const textMessages = ws.sentMessages
+      .map((m) => JSON.parse(m))
+      .filter((m: { type: string }) => m.type === "text");
+    expect(
+      textMessages.some((m) => (m.token ?? "").includes("still setting up")),
+    ).toBe(false);
+    expect(relay.getConversationHistory().length).toBe(0);
+    expect(
+      getMessages("conv-relay-setting-up").filter((m) => m.role === "user")
+        .length,
+    ).toBe(0);
+
+    // Release the reader and let setup finish.
+    releaseGate();
+    await setupPromise;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(relay.getConnectionState()).toBe("connected");
+
+    relay.destroy();
+  });
+
+  test("handleMessage: prompt after normal-call setup completes is handled", async () => {
+    ensureConversation("conv-relay-postsetup");
+    const session = createCallSession({
+      conversationId: "conv-relay-postsetup",
+      provider: "twilio",
+      fromNumber: "+15551111111",
+      toNumber: "+15552222222",
+    });
+
+    addTrustedVoiceContact("+15551111111");
+    mockSendMessage.mockImplementation(
+      createMockProviderResponse(["Sure, happy to help."]),
+    );
+
+    const { relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_postsetup_123",
+        from: "+15551111111",
+        to: "+15552222222",
+      }),
+    );
+
+    // Setup completed normally → "connected".
+    expect(relay.getConnectionState()).toBe("connected");
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // A subsequent prompt routes to the controller (no "still setting up").
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "prompt",
+        voicePrompt: "Hello there",
+        lang: "en-US",
+        last: true,
+      }),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const userMessages = getMessages("conv-relay-postsetup").filter(
+      (m) => m.role === "user",
+    );
+    expect(userMessages.length).toBeGreaterThan(0);
+    expect(relay.getConnectionState()).toBe("connected");
 
     relay.destroy();
   });

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -25,6 +25,10 @@ import {
   test,
 } from "bun:test";
 
+import { ADMISSION_FLOOR } from "@vellumai/gateway-client";
+
+import { TRUST_CLASS_RANK } from "../runtime/actor-trust-resolver.js";
+
 // ── Platform + logger mocks (must come before any source imports) ────
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -98,6 +102,58 @@ const mockConfig = {
 mock.module("../config/loader.js", () => ({
   getConfig: () => mockConfig,
   loadConfig: () => mockConfig,
+}));
+
+// ── Channel admission policy reader mock ────────────────────────────
+//
+// handleSetup resolves the phone admission floor via this reader and forwards
+// it into routeSetup. Tests drive the floor by setting `mockAdmissionPolicy`
+// (or making the reader throw to exercise the fail-open guard).
+
+let mockAdmissionPolicy:
+  | import("@vellumai/gateway-client").AdmissionPolicy
+  | null = null;
+let mockAdmissionReaderThrows = false;
+mock.module("../calls/channel-admission-reader.js", () => ({
+  getChannelAdmissionPolicy: async () => {
+    if (mockAdmissionReaderThrows) throw new Error("reader boom");
+    return mockAdmissionPolicy;
+  },
+}));
+
+// Real floor semantics with the `phone` exemption bypassed, mirroring
+// relay-setup-router.test.ts. Until PR 6 removes `phone` from the exempt set,
+// the real enforceAdmissionPolicy short-circuits to admit for `phone`, so the
+// deny path could not be exercised end-to-end without this.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const realAdmissionPolicyModule = require("../runtime/routes/inbound-stages/admission-policy.js");
+mock.module("../runtime/routes/inbound-stages/admission-policy.js", () => ({
+  ...realAdmissionPolicyModule,
+  enforceAdmissionPolicy: (input: {
+    trustClass: string;
+    memberStatus: string | undefined;
+    policy: import("@vellumai/gateway-client").AdmissionPolicy;
+  }) => {
+    if (input.memberStatus === "blocked" || input.memberStatus === "revoked") {
+      return {
+        admitted: false,
+        reason:
+          input.memberStatus === "blocked" ? "member_blocked" : "member_revoked",
+        shouldChallenge: false,
+        effectivePolicy: input.policy,
+      };
+    }
+    const rank =
+      (TRUST_CLASS_RANK as Record<string, number>)[input.trustClass] ?? 0;
+    const floor = ADMISSION_FLOOR[input.policy];
+    if (rank >= floor) return { admitted: true };
+    return {
+      admitted: false,
+      reason: `admission_policy_${input.policy}`,
+      shouldChallenge: false,
+      effectivePolicy: input.policy,
+    };
+  },
 }));
 
 // ── TTS provider mocks (for call-speech-output) ─────────────────────
@@ -404,6 +460,8 @@ describe("relay-server", () => {
     activeRelayConnections.clear();
     mockUserReference = "my human";
     mockAssistantName = "Vellum";
+    mockAdmissionPolicy = null;
+    mockAdmissionReaderThrows = false;
     mockSendMessage.mockImplementation(createMockProviderResponse(["Hello"]));
     mockConfig.calls.verification.enabled = false;
     mockConfig.calls.verification.maxAttempts = 3;
@@ -2718,6 +2776,122 @@ describe("relay-server", () => {
 
     // Let delayed endSession callback flush
     await new Promise((resolve) => setTimeout(resolve, 10));
+
+    relay.destroy();
+  });
+
+  // ── Inbound admission floor (reader → routeSetup wiring) ───────────
+
+  test("admission floor: reader floor that excludes caller denies the call end-to-end", async () => {
+    ensureConversation("conv-admission-floor-deny");
+    const session = createCallSession({
+      conversationId: "conv-admission-floor-deny",
+      provider: "twilio",
+      fromNumber: "+15557776666",
+      toNumber: "+15551111111",
+    });
+
+    // A trusted contact (rank 3) is below the `guardian_only` floor (rank 4).
+    addTrustedVoiceContact("+15557776666");
+    mockAdmissionPolicy = "guardian_only";
+
+    const { ws, relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_admission_floor_deny",
+        from: "+15557776666",
+        to: "+15551111111",
+      }),
+    );
+
+    // Floor-excluded caller takes the deny path.
+    expect(relay.getConnectionState()).toBe("disconnecting");
+
+    const updated = getCallSession(session.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe("failed");
+
+    const textMessages = ws.sentMessages
+      .map((raw) => JSON.parse(raw) as { type: string; token?: string })
+      .filter((m) => m.type === "text");
+    expect(
+      textMessages.some((m) => (m.token ?? "").includes("not authorized")),
+    ).toBe(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    relay.destroy();
+  });
+
+  test("admission floor: null policy from reader leaves the call flow unchanged", async () => {
+    ensureConversation("conv-admission-floor-null");
+    const session = createCallSession({
+      conversationId: "conv-admission-floor-null",
+      provider: "twilio",
+      fromNumber: "+15557776666",
+      toNumber: "+15551111111",
+    });
+
+    addTrustedVoiceContact("+15557776666");
+    mockAdmissionPolicy = null; // no floor supplied
+
+    mockSendMessage.mockImplementation(
+      createMockProviderResponse(["Hello, how can I help you?"]),
+    );
+
+    const { relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_admission_floor_null",
+        from: "+15557776666",
+        to: "+15551111111",
+      }),
+    );
+
+    // Trusted contact proceeds normally — no deny.
+    expect(relay.getConnectionState()).toBe("connected");
+
+    const updated = getCallSession(session.id);
+    expect(updated!.status).toBe("in_progress");
+
+    relay.destroy();
+  });
+
+  test("admission floor: reader throw fails open and admits the caller", async () => {
+    ensureConversation("conv-admission-floor-throw");
+    const session = createCallSession({
+      conversationId: "conv-admission-floor-throw",
+      provider: "twilio",
+      fromNumber: "+15557776666",
+      toNumber: "+15551111111",
+    });
+
+    addTrustedVoiceContact("+15557776666");
+    mockAdmissionReaderThrows = true; // reader cannot break setup
+
+    mockSendMessage.mockImplementation(
+      createMockProviderResponse(["Hello, how can I help you?"]),
+    );
+
+    const { relay } = createMockWs(session.id);
+
+    await relay.handleMessage(
+      JSON.stringify({
+        type: "setup",
+        callSid: "CA_admission_floor_throw",
+        from: "+15557776666",
+        to: "+15551111111",
+      }),
+    );
+
+    // Fail open: reader failure admits the caller; setup completes normally.
+    expect(relay.getConnectionState()).toBe("connected");
+    const updated = getCallSession(session.id);
+    expect(updated!.status).toBe("in_progress");
 
     relay.destroy();
   });

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -8,6 +8,7 @@
 
 import { randomInt } from "node:crypto";
 
+import type { AdmissionPolicy } from "@vellumai/gateway-client";
 import type { ServerWebSocket } from "bun";
 
 import {
@@ -47,6 +48,7 @@ import {
   updateCallSession,
 } from "./call-store.js";
 import { ConversationRelayTransport } from "./call-transport.js";
+import { getChannelAdmissionPolicy } from "./channel-admission-reader.js";
 import { finalizeCall } from "./finalize-call.js";
 import {
   classifyWaitUtterance,
@@ -553,12 +555,26 @@ export class RelayConnection {
     const session = getCallSession(this.callSessionId);
     this.recordSetupBookkeeping(session, msg);
 
+    // Resolve the phone channel's inbound admission floor. The reader already
+    // fails open to `null`; the extra guard keeps a reader throw from ever
+    // aborting setup (admit when in doubt).
+    let admissionPolicy: AdmissionPolicy | null = null;
+    try {
+      admissionPolicy = await getChannelAdmissionPolicy("phone");
+    } catch (err) {
+      log.warn(
+        { err, callSessionId: this.callSessionId },
+        "Failed to resolve phone admission policy — admitting (fail open)",
+      );
+    }
+
     const { outcome, resolved } = routeSetup({
       callSessionId: this.callSessionId,
       session,
       from: msg.from,
       to: msg.to,
       customParameters: msg.customParameters,
+      admissionPolicy,
     });
 
     const initialTrustContext = toTrustContext(

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -172,6 +172,11 @@ export function setRelayBroadcast(fn: (msg: ServerMessage) => void): void {
  */
 type RelayConnectionState =
   | "connected"
+  // Transient state held synchronously from the start of handleSetup until
+  // routing/ACL completes. Prompts arriving in this window are dropped so a
+  // not-yet-authorized caller's speech is never persisted/emitted before the
+  // admission floor and trust ACL are applied.
+  | "setting_up"
   | "verification_pending"
   | "awaiting_name"
   | "awaiting_guardian_decision"
@@ -552,6 +557,13 @@ export class RelayConnection {
       "ConversationRelay setup received",
     );
 
+    // Enter the setup-pending state synchronously, before any await. The
+    // admission-policy read below yields the event loop, and inbound frames are
+    // dispatched fire-and-forget, so a `prompt` frame can arrive before routing
+    // completes. handlePrompt drops prompts while in "setting_up" so a blocked
+    // or admission-denied caller's speech is never stored before the ACL runs.
+    this.connectionState = "setting_up";
+
     const session = getCallSession(this.callSessionId);
     this.recordSetupBookkeeping(session, msg);
 
@@ -568,6 +580,37 @@ export class RelayConnection {
       );
     }
 
+    try {
+      await this.routeSetupOutcome(msg, session, admissionPolicy);
+    } catch (err) {
+      // Never leave the connection stranded in "setting_up": a setup that
+      // throws before reaching a terminal outcome would otherwise drop every
+      // prompt forever. Tear the call down instead.
+      log.error(
+        { err, callSessionId: this.callSessionId },
+        "Setup routing failed — disconnecting",
+      );
+      this.connectionState = "disconnecting";
+      updateCallSession(this.callSessionId, {
+        status: "failed",
+        endedAt: Date.now(),
+        lastError: "Setup routing failed",
+      });
+      this.endSession("Setup routing failed");
+    }
+  }
+
+  /**
+   * Apply the routing/ACL outcome for a setup frame. Synchronous helpers that
+   * fire-and-forget (greeting, verification, name capture) are awaited here only
+   * when they themselves are async. Each reachable outcome transitions the
+   * connection out of "setting_up" into its terminal state.
+   */
+  private async routeSetupOutcome(
+    msg: RelaySetupMessage,
+    session: ReturnType<typeof getCallSession>,
+    admissionPolicy: AdmissionPolicy | null,
+  ): Promise<void> {
     const { outcome, resolved } = routeSetup({
       callSessionId: this.callSessionId,
       session,
@@ -650,6 +693,9 @@ export class RelayConnection {
             );
           }
         }
+        // Routing/ACL cleared — leave the setup-pending state so subsequent
+        // prompts are handled normally.
+        this.connectionState = "connected";
         this.startNormalCallFlow(controller, outcome.isInbound);
         return;
     }
@@ -1838,6 +1884,13 @@ export class RelayConnection {
       return;
     }
 
+    // Prompts arriving before setup routing/ACL completes are dropped — never
+    // persisted or emitted — so a not-yet-authorized caller's speech can't be
+    // stored ahead of the admission floor / trust ACL decision.
+    if (this.connectionState === "setting_up") {
+      return;
+    }
+
     if (!msg.last) {
       // Partial transcript, wait for final
       return;
@@ -2037,6 +2090,12 @@ export class RelayConnection {
 
   private handleDtmf(msg: RelayDtmfMessage): void {
     if (this.connectionState === "disconnecting") {
+      return;
+    }
+
+    // Drop DTMF arriving before setup routing/ACL completes (same reasoning as
+    // handlePrompt): don't record input from a not-yet-authorized caller.
+    if (this.connectionState === "setting_up") {
       return;
     }
 


### PR DESCRIPTION
## Summary
- Resolve the phone channel admission floor via the gateway IPC reader in `handleSetup` and pass it into `routeSetup`, activating the floor enforcement for inbound voice calls (still gated by the exempt set until PR 6).
- Reader failures fail open so call setup is never blocked.

Part of plan: voice-admission.md (PR 5 of 6)