### PR TITLE
refactor(web): make timeline row expand state survive unmount

### DIFF
--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -322,7 +322,15 @@ export function SubagentDetailPanel({
           >
             Timeline
           </Typography>
-          <SubagentTimeline events={timelineEvents} />
+          {/*
+           * Key by subagent id so the timeline (which now owns lifted
+           * expand/collapse state) remounts on subagent switch. Fetched
+           * detail event ids are renumbered per subagent (detail-1, detail-2,
+           * …) and the drawer keeps this component mounted across switches, so
+           * without a per-subagent reset an expanded `detail-N` would leak its
+           * expanded state onto the next subagent's `detail-N`.
+           */}
+          <SubagentTimeline key={entry.subagentId} events={timelineEvents} />
         </div>
       </div>
     </div>

--- a/clients/web/src/domains/chat/components/subagent-timeline.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-timeline.test.tsx
@@ -10,7 +10,7 @@
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 import { SubagentTimeline } from "@/domains/chat/components/subagent-timeline";
 import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
@@ -26,6 +26,24 @@ function toolCallEvent(
     type: "tool_call",
     content: LONG_PATH,
     toolName: "Read",
+    timestamp: 0,
+    ...overrides,
+  };
+}
+
+/** Multi-line content that exceeds the collapsed line limit, so the row
+ *  renders a collapsible "Show more" affordance. */
+function longLines(label: string): string {
+  return Array.from({ length: 8 }, (_, i) => `${label} line ${i}`).join("\n");
+}
+
+function toolResultEvent(
+  overrides: Partial<SubagentTimelineEvent> = {},
+): SubagentTimelineEvent {
+  return {
+    id: "evt-result",
+    type: "tool_result",
+    content: longLines("result"),
     timestamp: 0,
     ...overrides,
   };
@@ -51,5 +69,34 @@ describe("SubagentTimeline — tool_call content wrapping", () => {
     const name = screen.getByText(longName);
     expect(name.className).toContain("min-w-0");
     expect(name.className).toContain("break-words");
+  });
+});
+
+describe("SubagentTimeline — expand state keyed by event.id", () => {
+  test("expanding one row, then toggling another, leaves the first expanded", () => {
+    const first = toolResultEvent({ id: "evt-a", content: longLines("a") });
+    const second = toolResultEvent({ id: "evt-b", content: longLines("b") });
+    render(<SubagentTimeline events={[first, second]} />);
+
+    // Both rows start collapsed.
+    const toggles = screen.getAllByText("Show more");
+    expect(toggles).toHaveLength(2);
+
+    // Expand the first row.
+    fireEvent.click(toggles[0]!);
+
+    // First is now expanded ("Show less"), second still collapsed.
+    expect(screen.getByText("Show less")).toBeDefined();
+    expect(screen.getByText("Show more")).toBeDefined();
+    // The first row's last line is only visible once expanded.
+    expect(screen.getByText(/a line 7/)).toBeDefined();
+
+    // Toggle the second row (it's the remaining "Show more").
+    fireEvent.click(screen.getByText("Show more"));
+
+    // The first row's expansion must be unaffected — both now expanded.
+    expect(screen.getAllByText("Show less")).toHaveLength(2);
+    expect(screen.getByText(/a line 7/)).toBeDefined();
+    expect(screen.getByText(/b line 7/)).toBeDefined();
   });
 });

--- a/clients/web/src/domains/chat/components/subagent-timeline.tsx
+++ b/clients/web/src/domains/chat/components/subagent-timeline.tsx
@@ -5,7 +5,7 @@ import {
     TriangleAlert,
     Wrench,
 } from "lucide-react";
-import { memo, useMemo, useState } from "react";
+import { memo, useCallback, useMemo, useState } from "react";
 
 import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
 import { Typography } from "@vellumai/design-library";
@@ -131,8 +131,20 @@ function eventTitle(event: SubagentTimelineEvent): string {
 // Collapsible text content
 // ---------------------------------------------------------------------------
 
-function CollapsibleContent({ content }: { content: string }) {
-  const [expanded, setExpanded] = useState(false);
+/**
+ * Controlled collapsible text. Expand state is owned by {@link SubagentTimeline}
+ * (keyed by `event.id`) rather than held locally here, so it survives this
+ * component unmounting/remounting — the precondition for virtualizing the list.
+ */
+function CollapsibleContent({
+  content,
+  expanded,
+  onToggle,
+}: {
+  content: string;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
   const hasLongContent = isContentLong(content);
   const displayContent = hasLongContent && !expanded
     ? truncateContent(content)
@@ -150,7 +162,7 @@ function CollapsibleContent({ content }: { content: string }) {
       {hasLongContent && (
         <button
           type="button"
-          onClick={() => setExpanded((prev) => !prev)}
+          onClick={onToggle}
           className="mt-1 cursor-pointer hover:underline"
         >
           <Typography variant="body-small-default" className="text-[var(--content-default)]">
@@ -169,9 +181,18 @@ function CollapsibleContent({ content }: { content: string }) {
 const TimelineEventRow = memo(function TimelineEventRow({
   event,
   isLast,
+  expanded,
+  toggleExpand,
 }: {
   event: SubagentTimelineEvent;
   isLast: boolean;
+  expanded: boolean;
+  /**
+   * Stable across renders (see {@link SubagentTimeline}), so passing it through
+   * `memo` doesn't defeat the row's bail-out. The per-row closure is bound at
+   * the call site below rather than by the parent, to keep this prop stable.
+   */
+  toggleExpand: (id: string) => void;
 }) {
   return (
     // `content-visibility: auto` lets the browser skip layout/paint for rows
@@ -235,7 +256,11 @@ const TimelineEventRow = memo(function TimelineEventRow({
                 {event.content}
               </Typography>
             ) : (
-              <CollapsibleContent content={event.content} />
+              <CollapsibleContent
+                content={event.content}
+                expanded={expanded}
+                onToggle={() => toggleExpand(event.id)}
+              />
             )}
           </div>
         )}
@@ -270,6 +295,23 @@ export const SubagentTimeline = memo(function SubagentTimeline({
 }: SubagentTimelineProps) {
   const filteredEvents = useMemo(() => filterEvents(events), [events]);
 
+  // Expand/collapse state lives here, keyed by `event.id`, so it survives a row
+  // unmounting and remounting (e.g. when the list is virtualized). `toggleExpand`
+  // is stable across renders so it can be passed through the `memo`'d row without
+  // defeating its bail-out.
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(() => new Set());
+  const toggleExpand = useCallback((id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
   if (filteredEvents.length === 0) {
     return (
       <Typography
@@ -288,6 +330,8 @@ export const SubagentTimeline = memo(function SubagentTimeline({
           key={event.id}
           event={event}
           isLast={index === filteredEvents.length - 1}
+          expanded={expandedIds.has(event.id)}
+          toggleExpand={toggleExpand}
         />
       ))}
     </div>


### PR DESCRIPTION
## Summary
- Lift CollapsibleContent expand state into SubagentTimeline, keyed by event.id
- Make CollapsibleContent controlled (expanded + onToggle); preserves on-screen behavior
- Add regression test: expansion survives independent of row position

Part of plan: virtualize-subagent-timeline.md (PR 2 of 4)

> Note: the original head branch `run-plan/virtualize-timeline/pr-2` (PR #35199, closed) was repurposed for unrelated work and could not be fast-forwarded; this re-ships the same change from a fresh branch cleanly stacked on the base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)