### PR TITLE
feat: enable channel admission policy for phone (voice ingress wired)

### DIFF
--- a/assistant/src/__tests__/media-stream-server-integration.test.ts
+++ b/assistant/src/__tests__/media-stream-server-integration.test.ts
@@ -159,6 +159,16 @@ mock.module("../calls/relay-setup-router.js", () => ({
   routeSetup: jest.fn(() => mockRouteSetupResult),
 }));
 
+// Mock the channel admission reader. handleStart awaits this before routing;
+// tests override mockAdmissionPolicy to exercise floor enforcement. Returning
+// a resolved promise introduces a microtask hop, so tests await
+// session.whenSetupSettled() after sending the start frame.
+let mockAdmissionPolicy: unknown = null;
+const mockGetChannelAdmissionPolicy = jest.fn(async () => mockAdmissionPolicy);
+mock.module("../calls/channel-admission-reader.js", () => ({
+  getChannelAdmissionPolicy: mockGetChannelAdmissionPolicy,
+}));
+
 // Mock the actor trust resolver (used by handleStart to derive trust context)
 mock.module("../runtime/actor-trust-resolver.js", () => ({
   toTrustContext: jest.fn(() => ({
@@ -204,6 +214,7 @@ import {
   activeMediaStreamSessions,
   MediaStreamCallSession,
 } from "../calls/media-stream-server.js";
+import { routeSetup } from "../calls/relay-setup-router.js";
 
 // ---------------------------------------------------------------------------
 // Mock WebSocket factory
@@ -325,6 +336,9 @@ beforeEach(() => {
   (updateCallSession as jest.Mock).mockClear();
   (finalizeCall as jest.Mock).mockClear();
   (speakSystemPrompt as jest.Mock).mockClear();
+  (routeSetup as jest.Mock).mockClear();
+  mockGetChannelAdmissionPolicy.mockClear();
+  mockAdmissionPolicy = null;
   // Reset routeSetup to default normal_call
   mockRouteSetupResult = {
     outcome: { action: "normal_call" as const, isInbound: true },
@@ -359,7 +373,7 @@ describe("MediaStreamCallSession", () => {
   });
 
   describe("start event handling", () => {
-    test("start event registers a controller and records call_connected", () => {
+    test("start event registers a controller and records call_connected", async () => {
       const mock = createMockWs();
       // Set up a call session in the mock store
       mockSessions.set("call-1", {
@@ -373,6 +387,7 @@ describe("MediaStreamCallSession", () => {
 
       const session = new MediaStreamCallSession(mock.ws, "call-1");
       session.handleMessage(makeStartMessage());
+      await session.whenSetupSettled();
 
       // Controller should have been registered
       expect(registerCallController).toHaveBeenCalledWith(
@@ -484,7 +499,7 @@ describe("MediaStreamCallSession", () => {
   });
 
   describe("destroy", () => {
-    test("destroys the controller and marks output as closed", () => {
+    test("destroys the controller and marks output as closed", async () => {
       const mock = createMockWs();
       mockSessions.set("call-1", {
         id: "call-1",
@@ -498,6 +513,7 @@ describe("MediaStreamCallSession", () => {
       const session = new MediaStreamCallSession(mock.ws, "call-1");
       // Trigger start to create a controller
       session.handleMessage(makeStartMessage());
+      await session.whenSetupSettled();
 
       session.destroy();
       expect(mockDestroy).toHaveBeenCalled();
@@ -715,7 +731,7 @@ describe("media-stream output egress", () => {
     expect(clearMessages.length).toBeGreaterThanOrEqual(1);
   });
 
-  test("barge-in via speech start clears audio and interrupts controller", () => {
+  test("barge-in via speech start clears audio and interrupts controller", async () => {
     const mockWs = createMockWs();
     mockSessions.set("call-interrupt-1", {
       id: "call-interrupt-1",
@@ -728,6 +744,7 @@ describe("media-stream output egress", () => {
 
     const session = new MediaStreamCallSession(mockWs.ws, "call-interrupt-1");
     session.handleMessage(makeStartMessage());
+    await session.whenSetupSettled();
 
     // Verify the controller is created
     expect(session.getController()).not.toBeNull();
@@ -770,7 +787,7 @@ describe("activeMediaStreamSessions registry", () => {
 
 describe("media-stream setup outcome scenarios", () => {
   describe("deny outcome", () => {
-    test("deny outcome records inbound_acl_denied event and sets status to failed", () => {
+    test("deny outcome records inbound_acl_denied event and sets status to failed", async () => {
       mockRouteSetupResult = {
         outcome: {
           action: "deny",
@@ -798,6 +815,7 @@ describe("media-stream setup outcome scenarios", () => {
 
       const session = new MediaStreamCallSession(mockWs.ws, "call-deny-1");
       session.handleMessage(makeStartMessage());
+      await session.whenSetupSettled();
 
       // Should record an inbound_acl_denied event
       expect(recordCallEvent).toHaveBeenCalledWith(
@@ -821,7 +839,7 @@ describe("media-stream setup outcome scenarios", () => {
       expect(registerCallController).not.toHaveBeenCalled();
     });
 
-    test("deny outcome speaks the denial message", () => {
+    test("deny outcome speaks the denial message", async () => {
       mockRouteSetupResult = {
         outcome: {
           action: "deny",
@@ -852,6 +870,7 @@ describe("media-stream setup outcome scenarios", () => {
         "call-deny-speak-1",
       );
       session.handleMessage(makeStartMessage());
+      await session.whenSetupSettled();
 
       // speakSystemPrompt should be called with the denial message
       expect(speakSystemPrompt).toHaveBeenCalledWith(
@@ -860,7 +879,7 @@ describe("media-stream setup outcome scenarios", () => {
       );
     });
 
-    test("deny outcome runs finalization", () => {
+    test("deny outcome runs finalization", async () => {
       mockRouteSetupResult = {
         outcome: {
           action: "deny",
@@ -891,6 +910,7 @@ describe("media-stream setup outcome scenarios", () => {
         "call-deny-finalize-1",
       );
       session.handleMessage(makeStartMessage());
+      await session.whenSetupSettled();
 
       // finalizeCall should be called because early teardown runs it inline
       expect(finalizeCall).toHaveBeenCalledWith(
@@ -901,7 +921,7 @@ describe("media-stream setup outcome scenarios", () => {
   });
 
   describe("unsupported interactive setup flow", () => {
-    test("verification outcome records call_failed with preflight-bypass reason", () => {
+    test("verification outcome records call_failed with preflight-bypass reason", async () => {
       mockRouteSetupResult = {
         outcome: {
           action: "verification",
@@ -932,6 +952,7 @@ describe("media-stream setup outcome scenarios", () => {
         "call-unsup-verify-1",
       );
       session.handleMessage(makeStartMessage());
+      await session.whenSetupSettled();
 
       // Should record call_failed event with preflight-bypass note
       expect(recordCallEvent).toHaveBeenCalledWith(
@@ -956,7 +977,7 @@ describe("media-stream setup outcome scenarios", () => {
       expect(registerCallController).not.toHaveBeenCalled();
     });
 
-    test("name_capture outcome speaks generic apology and tears down", () => {
+    test("name_capture outcome speaks generic apology and tears down", async () => {
       mockRouteSetupResult = {
         outcome: {
           action: "name_capture",
@@ -987,6 +1008,7 @@ describe("media-stream setup outcome scenarios", () => {
         "call-unsup-name-1",
       );
       session.handleMessage(makeStartMessage());
+      await session.whenSetupSettled();
 
       // speakSystemPrompt should be called with the generic apology
       expect(speakSystemPrompt).toHaveBeenCalledWith(
@@ -1001,7 +1023,7 @@ describe("media-stream setup outcome scenarios", () => {
       );
     });
 
-    test("callee_verification outcome fails with explicit reason", () => {
+    test("callee_verification outcome fails with explicit reason", async () => {
       mockRouteSetupResult = {
         outcome: {
           action: "callee_verification",
@@ -1031,6 +1053,7 @@ describe("media-stream setup outcome scenarios", () => {
         "call-unsup-callee-1",
       );
       session.handleMessage(makeStartMessage());
+      await session.whenSetupSettled();
 
       // Should record the failure with the specific action
       expect(recordCallEvent).toHaveBeenCalledWith(
@@ -1048,7 +1071,7 @@ describe("media-stream setup outcome scenarios", () => {
       );
     });
 
-    test("normal_call after deny scenario still creates controller", () => {
+    test("normal_call after deny scenario still creates controller", async () => {
       // Verify that after a deny-scenario test, resetting to normal_call
       // properly creates a controller (no cross-test pollution).
       mockRouteSetupResult = {
@@ -1073,6 +1096,7 @@ describe("media-stream setup outcome scenarios", () => {
 
       const session = new MediaStreamCallSession(mockWs.ws, "call-reset-1");
       session.handleMessage(makeStartMessage());
+      await session.whenSetupSettled();
 
       // Controller should be registered for normal calls
       expect(registerCallController).toHaveBeenCalledWith(
@@ -1088,7 +1112,7 @@ describe("media-stream setup outcome scenarios", () => {
   // ── Barge-in regression ──────────────────────────────────────────
 
   describe("barge-in gating", () => {
-    test("immediate inbound audio after stream start does not trigger handleInterrupt", () => {
+    test("immediate inbound audio after stream start does not trigger handleInterrupt", async () => {
       const mockWs = createMockWs();
       mockSessions.set("call-bargein-1", {
         id: "call-bargein-1",
@@ -1103,6 +1127,7 @@ describe("media-stream setup outcome scenarios", () => {
 
       // Stream start bootstraps the controller
       session.handleMessage(makeStartMessage());
+      await session.whenSetupSettled();
       expect(mockStartInitialGreeting).toHaveBeenCalled();
 
       // Immediate inbound audio (speech-like payloads) — before the
@@ -1130,7 +1155,7 @@ describe("media-stream setup outcome scenarios", () => {
       session.destroy();
     });
 
-    test("barge-in is accepted when controller is speaking", () => {
+    test("barge-in is accepted when controller is speaking", async () => {
       // Configure mock to indicate the controller is speaking
       mockHandleBargeIn.mockReturnValue(true);
 
@@ -1146,6 +1171,7 @@ describe("media-stream setup outcome scenarios", () => {
 
       const session = new MediaStreamCallSession(mockWs.ws, "call-bargein-2");
       session.handleMessage(makeStartMessage());
+      await session.whenSetupSettled();
 
       // Simulate inbound speech audio while assistant is speaking.
       // Use a high-amplitude mu-law payload so speech detection triggers.
@@ -1162,7 +1188,7 @@ describe("media-stream setup outcome scenarios", () => {
   // ── E2E regression scenario ──────────────────────────────────────
 
   describe("end-to-end regression: connected call that stays active", () => {
-    test("stream connects, inbound audio starts, call remains active for a turn, controller only destroyed at stop/hangup", () => {
+    test("stream connects, inbound audio starts, call remains active for a turn, controller only destroyed at stop/hangup", async () => {
       const mockWs = createMockWs();
       mockSessions.set("call-e2e-1", {
         id: "call-e2e-1",
@@ -1177,6 +1203,7 @@ describe("media-stream setup outcome scenarios", () => {
 
       // 1. Stream connects — start event arrives
       session.handleMessage(makeStartMessage());
+      await session.whenSetupSettled();
       expect(registerCallController).toHaveBeenCalledWith(
         "call-e2e-1",
         expect.anything(),
@@ -1229,6 +1256,191 @@ describe("media-stream setup outcome scenarios", () => {
       // Now destroy
       session.destroy();
       expect(mockDestroy).toHaveBeenCalled();
+    });
+  });
+
+  // ── Admission floor enforcement on the media-stream transport ────────
+  // The phone channel is no longer exempt from per-channel admission, so the
+  // trust floor must be enforced on this transport too — not just the
+  // gateway's no_one kill switch. handleStart resolves the phone admission
+  // policy and threads it into routeSetup; a floor-denied caller (e.g.
+  // guardian_only vs a trusted_contact) produces a `deny` outcome here, which
+  // speaks a denial + tears down and never starts a normal call.
+
+  describe("admission floor enforcement", () => {
+    test("resolves the phone admission policy and threads it into routeSetup", async () => {
+      mockAdmissionPolicy = "guardian_only";
+
+      const mockWs = createMockWs();
+      mockSessions.set("call-floor-thread-1", {
+        id: "call-floor-thread-1",
+        conversationId: "conv-floor-thread-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        fromNumber: "+14155550000",
+        toNumber: "+15550001111",
+      });
+
+      const session = new MediaStreamCallSession(
+        mockWs.ws,
+        "call-floor-thread-1",
+      );
+      session.handleMessage(makeStartMessage());
+      await session.whenSetupSettled();
+
+      expect(mockGetChannelAdmissionPolicy).toHaveBeenCalledWith("phone");
+      expect(routeSetup).toHaveBeenCalledWith(
+        expect.objectContaining({
+          callSessionId: "call-floor-thread-1",
+          admissionPolicy: "guardian_only",
+        }),
+      );
+    });
+
+    test("guardian_only floor denies a trusted-contact caller — speaks denial, tears down, no controller", async () => {
+      mockAdmissionPolicy = "guardian_only";
+      // With the floor wired, the real router would return `deny` for a
+      // below-floor (trusted_contact) caller; the mock reflects that outcome.
+      mockRouteSetupResult = {
+        outcome: {
+          action: "deny",
+          message:
+            "This number is not authorized to reach the assistant right now.",
+          logReason: "Inbound voice admission floor: guardian_only",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+14155550000",
+          actorTrust: { trustClass: "trusted_contact", memberRecord: null },
+        },
+      };
+
+      const mockWs = createMockWs();
+      mockSessions.set("call-floor-deny-1", {
+        id: "call-floor-deny-1",
+        conversationId: "conv-floor-deny-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        fromNumber: "+14155550000",
+        toNumber: "+15550001111",
+      });
+
+      const session = new MediaStreamCallSession(
+        mockWs.ws,
+        "call-floor-deny-1",
+      );
+      session.handleMessage(makeStartMessage());
+      await session.whenSetupSettled();
+
+      // Policy was passed into routeSetup.
+      expect(routeSetup).toHaveBeenCalledWith(
+        expect.objectContaining({ admissionPolicy: "guardian_only" }),
+      );
+
+      // Denial spoken, session failed, no controller, finalization ran.
+      expect(speakSystemPrompt).toHaveBeenCalledWith(
+        expect.anything(),
+        "This number is not authorized to reach the assistant right now.",
+      );
+      expect(updateCallSession).toHaveBeenCalledWith(
+        "call-floor-deny-1",
+        expect.objectContaining({
+          status: "failed",
+          lastError: "Inbound voice admission floor: guardian_only",
+        }),
+      );
+      expect(registerCallController).not.toHaveBeenCalled();
+      expect(mockStartInitialGreeting).not.toHaveBeenCalled();
+      expect(finalizeCall).toHaveBeenCalledWith(
+        "call-floor-deny-1",
+        "conv-floor-deny-1",
+      );
+    });
+
+    test("null policy (no enforcement) leaves behavior unchanged — normal call proceeds", async () => {
+      mockAdmissionPolicy = null;
+      // routeSetup default is normal_call.
+
+      const mockWs = createMockWs();
+      mockSessions.set("call-floor-null-1", {
+        id: "call-floor-null-1",
+        conversationId: "conv-floor-null-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        fromNumber: "+14155550000",
+        toNumber: "+15550001111",
+      });
+
+      const session = new MediaStreamCallSession(
+        mockWs.ws,
+        "call-floor-null-1",
+      );
+      session.handleMessage(makeStartMessage());
+      await session.whenSetupSettled();
+
+      // Null policy is still threaded through (router skips the floor).
+      expect(routeSetup).toHaveBeenCalledWith(
+        expect.objectContaining({ admissionPolicy: null }),
+      );
+
+      // Normal call proceeds: controller registered + greeting fired.
+      expect(registerCallController).toHaveBeenCalledWith(
+        "call-floor-null-1",
+        expect.anything(),
+      );
+      expect(mockStartInitialGreeting).toHaveBeenCalled();
+    });
+
+    test("a floor-denied caller's transcript is dropped during setup routing", async () => {
+      mockAdmissionPolicy = "guardian_only";
+      mockRouteSetupResult = {
+        outcome: {
+          action: "deny",
+          message:
+            "This number is not authorized to reach the assistant right now.",
+          logReason: "Inbound voice admission floor: guardian_only",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+14155550000",
+          actorTrust: { trustClass: "trusted_contact", memberRecord: null },
+        },
+      };
+
+      const mockWs = createMockWs();
+      mockSessions.set("call-floor-drop-1", {
+        id: "call-floor-drop-1",
+        conversationId: "conv-floor-drop-1",
+        status: "initiated",
+        task: null,
+        startedAt: null,
+        fromNumber: "+14155550000",
+        toNumber: "+15550001111",
+      });
+
+      const session = new MediaStreamCallSession(
+        mockWs.ws,
+        "call-floor-drop-1",
+      );
+      session.handleMessage(makeStartMessage());
+      await session.whenSetupSettled();
+
+      // No controller exists for a denied caller, so even if a transcript
+      // arrived it could never reach handleCallerUtterance / be persisted.
+      expect(registerCallController).not.toHaveBeenCalled();
+      expect(mockHandleCallerUtterance).not.toHaveBeenCalled();
+      // No caller_spoke event recorded for the denied caller.
+      const callerSpoke = mockEvents.filter(
+        (e) =>
+          e.callSessionId === "call-floor-drop-1" &&
+          e.eventType === "caller_spoke",
+      );
+      expect(callerSpoke.length).toBe(0);
     });
   });
 });

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -125,10 +125,9 @@ mock.module("../calls/channel-admission-reader.js", () => ({
   },
 }));
 
-// Real floor semantics with the `phone` exemption bypassed, mirroring
-// relay-setup-router.test.ts. Until PR 6 removes `phone` from the exempt set,
-// the real enforceAdmissionPolicy short-circuits to admit for `phone`, so the
-// deny path could not be exercised end-to-end without this.
+// Real floor semantics, mirroring relay-setup-router.test.ts. The
+// enforceAdmissionPolicy mock omits the exempt-channel short-circuit so the
+// deny path can be exercised end-to-end regardless of channel.
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const realAdmissionPolicyModule = require("../runtime/routes/inbound-stages/admission-policy.js");
 mock.module("../runtime/routes/inbound-stages/admission-policy.js", () => ({

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -92,8 +92,21 @@ let mockRouteSetupResult: {
   },
 };
 
+// Captures the last context passed to routeSetup so preflight tests can
+// assert the resolved phone admission policy was threaded through.
+let lastRouteSetupCtx: Record<string, unknown> | null = null;
 mock.module("../calls/relay-setup-router.js", () => ({
-  routeSetup: () => mockRouteSetupResult,
+  routeSetup: (ctx: Record<string, unknown>) => {
+    lastRouteSetupCtx = ctx;
+    return mockRouteSetupResult;
+  },
+}));
+
+// Mock the phone channel admission reader used by the media-stream preflight.
+// Tests override mockAdmissionPolicy to exercise floor classification.
+let mockAdmissionPolicy: unknown = null;
+mock.module("../calls/channel-admission-reader.js", () => ({
+  getChannelAdmissionPolicy: async () => mockAdmissionPolicy,
 }));
 
 mock.module("../config/env.js", () => ({
@@ -454,6 +467,9 @@ describe("twilio webhook routes", () => {
     mockTwilioApiValidationBody = JSON.stringify({ sid: "AC_validated" });
     // Reset STT config to defaults between tests
     mockConfigObj.services.stt.provider = "deepgram" as any;
+    // Reset admission policy + captured routeSetup context between tests
+    mockAdmissionPolicy = null;
+    lastRouteSetupCtx = null;
     // Reset routeSetup mock to default normal_call
     mockRouteSetupResult = {
       outcome: { action: "normal_call", isInbound: true },
@@ -1223,6 +1239,70 @@ describe("twilio webhook routes", () => {
       const res = await handleVoiceWebhook(req);
       expect(res.status).toBe(200);
 
+      const twiml = await res.text();
+      expect(twiml).toContain("<Stream");
+      expect(twiml).not.toContain("<ConversationRelay");
+    });
+
+    test("media-stream: resolves the phone admission floor and threads it into the preflight routeSetup", async () => {
+      mockConfigObj.services.stt.provider = "openai-whisper" as any;
+      mockAdmissionPolicy = "guardian_only";
+      mockRouteSetupResult = {
+        outcome: { action: "normal_call", isInbound: true },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+15559998888",
+          actorTrust: { trustClass: "guardian", memberRecord: null },
+        },
+      };
+
+      const session = createTestSession("conv-ms-floor-1", "CA_ms_floor_1");
+      const req = makeVoiceRequest(session.id, { CallSid: "CA_ms_floor_1" });
+
+      const res = await handleVoiceWebhook(req);
+      expect(res.status).toBe(200);
+
+      // The resolved floor was passed into the preflight routeSetup so its
+      // classification matches the real stream-start enforcement.
+      expect(lastRouteSetupCtx).not.toBeNull();
+      expect(lastRouteSetupCtx?.admissionPolicy).toBe("guardian_only");
+    });
+
+    test("media-stream: floor-denied caller classified deny still produces Stream TwiML (deny handled at stream level)", async () => {
+      mockConfigObj.services.stt.provider = "openai-whisper" as any;
+      mockAdmissionPolicy = "guardian_only";
+      // With the floor wired, the real router returns `deny` for a
+      // below-floor trusted_contact caller; the mock reflects that.
+      mockRouteSetupResult = {
+        outcome: {
+          action: "deny",
+          message:
+            "This number is not authorized to reach the assistant right now.",
+          logReason: "Inbound voice admission floor: guardian_only",
+        },
+        resolved: {
+          assistantId: "self",
+          isInbound: true,
+          otherPartyNumber: "+14155550000",
+          actorTrust: { trustClass: "trusted_contact", memberRecord: null },
+        },
+      };
+
+      const session = createTestSession(
+        "conv-ms-floor-deny-1",
+        "CA_ms_floor_deny_1",
+      );
+      const req = makeVoiceRequest(session.id, {
+        CallSid: "CA_ms_floor_deny_1",
+      });
+
+      const res = await handleVoiceWebhook(req);
+      expect(res.status).toBe(200);
+
+      // Policy was threaded; deny is supported on media-stream, so Stream
+      // TwiML is still produced (denial spoken + torn down at stream start).
+      expect(lastRouteSetupCtx?.admissionPolicy).toBe("guardian_only");
       const twiml = await res.text();
       expect(twiml).toContain("<Stream");
       expect(twiml).not.toContain("<ConversationRelay");

--- a/assistant/src/calls/__tests__/relay-setup-router.test.ts
+++ b/assistant/src/calls/__tests__/relay-setup-router.test.ts
@@ -7,12 +7,10 @@
  * challenge, and active invites independently of any DB.
  *
  * The floor verdict is exercised through the REAL `enforceAdmissionPolicy`
- * floor tables (`TRUST_CLASS_RANK` × `ADMISSION_FLOOR`), but with the `phone`
- * exempt-channel short-circuit bypassed in the mock — `phone` is still exempt
- * in `@vellumai/gateway-client` until the activation PR, so calling the real
- * function with `sourceChannel: "phone"` would always admit. Bypassing only
- * the exemption lets these tests assert the true floor semantics that go live
- * once the channel is un-exempted.
+ * floor tables (`TRUST_CLASS_RANK` × `ADMISSION_FLOOR`), with the exempt-channel
+ * short-circuit bypassed in the mock so the tests assert the true floor
+ * semantics independent of any channel's exempt status (`phone` is now
+ * enforced).
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";

--- a/assistant/src/calls/media-stream-server.ts
+++ b/assistant/src/calls/media-stream-server.ts
@@ -31,6 +31,7 @@
  * - Media stream `stop` event / WebSocket close -> finalize call.
  */
 
+import type { AdmissionPolicy } from "@vellumai/gateway-client";
 import type { ServerWebSocket } from "bun";
 
 import { revokeScopedApprovalGrantsForContext } from "../memory/scoped-approval-grants.js";
@@ -50,6 +51,7 @@ import {
   recordCallEvent,
   updateCallSession,
 } from "./call-store.js";
+import { getChannelAdmissionPolicy } from "./channel-admission-reader.js";
 import { finalizeCall } from "./finalize-call.js";
 import { MediaStreamOutput } from "./media-stream-output.js";
 import { parseMediaStreamFrame } from "./media-stream-parser.js";
@@ -90,6 +92,18 @@ export class MediaStreamCallSession {
   private streamSid: string | null = null;
   private callSid: string | null = null;
   private disposed = false;
+  // True from the synchronous start of handleStart until setup routing
+  // completes. Resolving the admission floor yields the event loop, so
+  // transcripts/barge-in arriving in this window are ignored — a denied or
+  // not-yet-authorized caller's speech is never persisted before the floor
+  // and trust ACL are applied. The controller-existence checks below also
+  // gate persistence, but this guard makes the intent explicit and covers
+  // the brief async window before the controller is created.
+  private setupRouting = false;
+  // Resolves when the async setup routing kicked off by the `start` frame
+  // settles. Exposed via whenSetupSettled() for deterministic test awaiting,
+  // since handleStart now yields on the admission-policy read.
+  private setupSettled: Promise<void> = Promise.resolve();
 
   // ── Operational diagnostics counters ──────────────────────────────
   /** Number of barge-in attempts that were accepted (assistant was speaking). */
@@ -142,6 +156,14 @@ export class MediaStreamCallSession {
   }
 
   /**
+   * Resolves once the async setup routing started by the `start` frame has
+   * settled. Test-only convenience — production code does not await this.
+   */
+  whenSetupSettled(): Promise<void> {
+    return this.setupSettled;
+  }
+
+  /**
    * Feed a raw WebSocket message into the session.
    *
    * The message is parsed to intercept `start` events (for session
@@ -154,7 +176,16 @@ export class MediaStreamCallSession {
     // Intercept `start` to bootstrap the session before forwarding.
     const parseResult = parseMediaStreamFrame(raw);
     if (parseResult.ok && parseResult.event.event === "start") {
-      this.handleStart(parseResult.event);
+      // handleStart resolves the admission floor asynchronously; the
+      // setupRouting guard set synchronously at its top ensures inbound
+      // frames forwarded below are ignored until routing completes.
+      this.setupSettled = this.handleStart(parseResult.event).catch((err) => {
+        log.error(
+          { err, callSessionId: this.callSessionId },
+          "Media-stream setup routing failed",
+        );
+        this.setupRouting = false;
+      });
     }
 
     // Always forward to the STT session (it handles all event types).
@@ -296,7 +327,12 @@ export class MediaStreamCallSession {
 
   // ── Internal: media-stream event handlers ─────────────────────────
 
-  private handleStart(event: MediaStreamStartEvent): void {
+  private async handleStart(event: MediaStreamStartEvent): Promise<void> {
+    // Enter the setup-pending window synchronously, before any await. The
+    // admission-policy read below yields the event loop, so frames forwarded
+    // to the STT session can produce transcripts/barge-in before routing
+    // completes — those are dropped while setupRouting is true.
+    this.setupRouting = true;
     this.streamSid = event.streamSid;
     this.callSid = event.start.callSid;
 
@@ -337,12 +373,27 @@ export class MediaStreamCallSession {
     const from = session?.fromNumber ?? "";
     const to = session?.toNumber ?? "";
 
+    // Resolve the phone channel's inbound admission floor so the trust floor
+    // (e.g. guardian_only) is enforced on this transport too — not just the
+    // gateway webhook's no_one kill switch. The reader fails open to `null`;
+    // the guard keeps a reader throw from ever aborting setup (admit in doubt).
+    let admissionPolicy: AdmissionPolicy | null = null;
+    try {
+      admissionPolicy = await getChannelAdmissionPolicy("phone");
+    } catch (err) {
+      log.warn(
+        { err, callSessionId: this.callSessionId },
+        "Failed to resolve phone admission policy — admitting (fail open)",
+      );
+    }
+
     const { outcome, resolved } = routeSetup({
       callSessionId: this.callSessionId,
       session: session ?? null,
       from,
       to,
       customParameters: event.start.customParameters,
+      admissionPolicy,
     });
 
     log.info(
@@ -376,6 +427,10 @@ export class MediaStreamCallSession {
           },
         );
         registerCallController(this.callSessionId, this.controller);
+
+        // Routing/ACL cleared — leave the setup-pending window so subsequent
+        // transcripts and barge-in are handled normally.
+        this.setupRouting = false;
 
         // Fire the initial greeting.
         this.controller.startInitialGreeting().catch((err) => {
@@ -525,6 +580,18 @@ export class MediaStreamCallSession {
 
   private handleTranscriptFinal(text: string, _durationMs: number): void {
     if (!text.trim()) return;
+
+    // Drop transcripts arriving while setup routing is still pending so a
+    // not-yet-authorized / floor-denied caller's speech is never persisted
+    // before the admission floor and trust ACL are applied.
+    if (this.setupRouting) {
+      log.debug(
+        { callSessionId: this.callSessionId },
+        "Transcript received during setup routing — dropping",
+      );
+      return;
+    }
+
     this.transcriptFinalsProduced++;
 
     if (!this.controller) {

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -21,6 +21,7 @@
  *   server-side.
  */
 
+import type { AdmissionPolicy } from "@vellumai/gateway-client";
 import {
   buildTwilioMediaStreamUrl,
   buildTwilioRelayUrl,
@@ -54,6 +55,7 @@ import {
   releaseCallbackClaim,
   updateCallSession,
 } from "./call-store.js";
+import { getChannelAdmissionPolicy } from "./channel-admission-reader.js";
 import { routeSetup } from "./relay-setup-router.js";
 import { resolveCallHints } from "./stt-hints.js";
 import { resolveTelephonySttRouting } from "./telephony-stt-routing.js";
@@ -277,10 +279,10 @@ const TWIML_HEADERS = { "Content-Type": "text/xml" } as const;
  * query for outbound calls). Returns a TwiML string. Throws RouteError
  * subclasses on failure.
  */
-function processVoiceWebhook(
+async function processVoiceWebhook(
   params: Record<string, string>,
   callSessionId: string | null,
-): string {
+): Promise<string> {
   const callSid = params.CallSid ?? null;
   const callerFrom = params.From ?? "";
   const callerTo = params.To ?? "";
@@ -371,7 +373,7 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
   const params = Object.fromEntries(formBody.entries());
 
   try {
-    return twimlResponse(processVoiceWebhook(params, callSessionId));
+    return twimlResponse(await processVoiceWebhook(params, callSessionId));
   } catch (err) {
     if (err instanceof RouteError) {
       return new Response(err.message, { status: err.statusCode });
@@ -399,7 +401,7 @@ export async function handleVoiceWebhook(req: Request): Promise<Response> {
  * the Twilio setup payload. The persisted call session mode is the
  * primary signal for deterministic flow selection in the relay server.
  */
-function buildVoiceWebhookTwiml(
+async function buildVoiceWebhookTwiml(
   callSessionId: string,
   sessionContext: {
     task: string | null;
@@ -410,7 +412,7 @@ function buildVoiceWebhookTwiml(
     inviteGuardianName: string | null;
   } | null,
   verificationSessionId?: string | null,
-): string {
+): Promise<string> {
   const cfg = loadConfig();
   const profile = resolveVoiceQualityProfile(cfg);
 
@@ -476,11 +478,27 @@ function buildVoiceWebhookTwiml(
   const from = sessionContext?.fromNumber ?? "";
   const to = sessionContext?.toNumber ?? "";
 
+  // Resolve the phone channel's inbound admission floor so this preflight
+  // classification matches the real enforcement at stream start — a
+  // floor-denied caller is recognized as `deny` here, not `normal_call`.
+  // The reader fails open to `null`; the guard keeps a reader throw from
+  // ever aborting setup (admit when in doubt).
+  let admissionPolicy: AdmissionPolicy | null = null;
+  try {
+    admissionPolicy = await getChannelAdmissionPolicy("phone");
+  } catch (err) {
+    log.warn(
+      { err, callSessionId },
+      "Failed to resolve phone admission policy for media-stream preflight — admitting (fail open)",
+    );
+  }
+
   const { outcome } = routeSetup({
     callSessionId,
     session: session ?? null,
     from,
     to,
+    admissionPolicy,
   });
 
   // The media-stream transport supports normal_call and deny (which speaks
@@ -780,9 +798,9 @@ const EMPTY_TWIML = '<?xml version="1.0" encoding="UTF-8"?><Response/>';
  * Internal voice-webhook handler for gateway→runtime forwarding.
  * Accepts JSON body `{ params, originalUrl? }` from the gateway.
  */
-export function handleInternalVoiceWebhook({
+export async function handleInternalVoiceWebhook({
   body = {},
-}: RouteHandlerArgs): RouteResponse {
+}: RouteHandlerArgs): Promise<RouteResponse> {
   const { params = {}, originalUrl } = body as {
     params?: Record<string, string>;
     originalUrl?: string;
@@ -798,7 +816,7 @@ export function handleInternalVoiceWebhook({
     }
   }
 
-  const twiml = processVoiceWebhook(params, callSessionId);
+  const twiml = await processVoiceWebhook(params, callSessionId);
   return new RouteResponse(twiml, TWIML_HEADERS);
 }
 

--- a/assistant/src/runtime/routes/inbound-stages/admission-policy.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/admission-policy.test.ts
@@ -33,11 +33,13 @@ describe("enforceAdmissionPolicy — exempt channels", () => {
     expect(result.admitted).toBe(true);
   });
 
-  test("phone short-circuits to admitted (§8.4: voice ingress not wired)", () => {
+  test("phone is enforced (not exempt): the floor applies", () => {
+    // Voice ingress is wired, so `phone` is no longer exempt — an `unknown`
+    // caller is denied under `no_one`.
     const result = enforceAdmissionPolicy(
       makeInput({ sourceChannel: "phone", trustClass: "unknown", policy: "no_one" }),
     );
-    expect(result.admitted).toBe(true);
+    expect(result.admitted).toBe(false);
   });
 });
 

--- a/gateway/AGENTS.md
+++ b/gateway/AGENTS.md
@@ -85,7 +85,8 @@ A default row per enforced channel is **seeded at startup** (`seedAdmissionPolic
 
 - `platform` — internal platform control plane.
 - `a2a` — assistant-to-assistant peer traffic (out of human-trust model).
-- `phone` — exempt until voice ingress reads the policy (§8.4).
+
+`phone` is now an enforced channel (voice ingress reads the policy): it seeds the universal default `trusted_contacts` and accepts PUT like other enforced channels.
 
 For exempt ids, `PUT /v1/assistants/:id/channel-admission-policy/:channelType` returns **403**, the GET list omits them, and the runtime short-circuits `admitted: true` in `admission-policy.ts` (defense in depth). `vellum` is **not** exempt — it is configurable, but can never be set to `no_one`: the PUT route returns **422** and the picker omits the option, so the guardian (always max-rank on `vellum`) can't lock themselves out. Codex finding from #35006 review: exemption checks must live in *both* the gateway route handler AND the runtime stage — single-side enforcement creates a misuse wedge.
 

--- a/gateway/src/__tests__/channel-admission-policy-routes.test.ts
+++ b/gateway/src/__tests__/channel-admission-policy-routes.test.ts
@@ -112,14 +112,14 @@ describe("GET /v1/channel-admission-policy", () => {
     expect(tg?.note).toBe("off");
     expect(tg?.updatedAt).toBeGreaterThan(0);
 
-    // phone is now exempt (§8.4) — it must not appear in the list.
+    // phone is an enforced channel — it appears with its seeded default.
     const phone = body.policies.find((p) => p.channelType === "phone");
-    expect(phone).toBeUndefined();
+    expect(phone?.policy).toBe(ADMISSION_POLICY_DEFAULT);
   });
 
-  test("omits exempt channels (`a2a`, `phone`) but includes the configurable `vellum`", async () => {
-    // a2a/phone stay exempt (filtered out); vellum is configurable and must
-    // surface so the client can manage it.
+  test("omits exempt channel `a2a` but includes the configurable `vellum` and enforced `phone`", async () => {
+    // a2a stays exempt (filtered out); vellum is configurable and phone is now
+    // enforced — both must surface so the client can manage them.
     store.set("a2a", "guardian_only");
     store.set("vellum", "guardian_only");
 
@@ -132,7 +132,7 @@ describe("GET /v1/channel-admission-policy", () => {
     };
     const seen = new Set(body.policies.map((p) => p.channelType));
     expect(seen.has("a2a")).toBe(false);
-    expect(seen.has("phone")).toBe(false);
+    expect(seen.has("phone")).toBe(true);
     expect(seen.has("vellum")).toBe(true);
   });
 });
@@ -266,7 +266,7 @@ describe("PUT /v1/channel-admission-policy/:channelType", () => {
     expect(store.get("a2a")).toBe(ADMISSION_POLICY_DEFAULT);
   });
 
-  test("§8.4: rejects PUT for `phone` with 403 (voice ingress not yet wired)", async () => {
+  test("upserts `phone` like any enforced channel (voice ingress wired)", async () => {
     const handler = createChannelAdmissionPolicySetHandler();
     const res = await handler(
       jsonRequest("http://localhost/v1/channel-admission-policy/phone", "PUT", {
@@ -274,18 +274,17 @@ describe("PUT /v1/channel-admission-policy/:channelType", () => {
       }),
       "phone",
     );
-    expect(res.status).toBe(403);
-    // Nothing was persisted.
-    expect(store.get("phone")).toBe(ADMISSION_POLICY_DEFAULT);
+    expect(res.status).toBe(200);
+    expect(store.get("phone")).toBe("strangers");
   });
 });
 
 // ---------------------------------------------------------------------------
-// GET /v1/channel-admission-policy (phone exempt)
+// GET /v1/channel-admission-policy (phone enforced)
 // ---------------------------------------------------------------------------
 
-describe("GET /v1/channel-admission-policy — phone exempt §8.4", () => {
-  test("omits `phone` from the list response", async () => {
+describe("GET /v1/channel-admission-policy — phone enforced", () => {
+  test("includes `phone` in the list response", async () => {
     const handler = createChannelAdmissionPolicyListHandler();
     const res = await handler(
       jsonRequest("http://localhost/v1/channel-admission-policy", "GET"),
@@ -293,8 +292,8 @@ describe("GET /v1/channel-admission-policy — phone exempt §8.4", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { policies: Array<{ channelType: string }> };
     const seen = new Set(body.policies.map((p) => p.channelType));
-    expect(seen.has("phone")).toBe(false);
-    // Confirm non-exempt channels still appear.
+    expect(seen.has("phone")).toBe(true);
+    // Confirm other non-exempt channels still appear.
     expect(seen.has("telegram")).toBe(true);
     expect(seen.has("slack")).toBe(true);
   });

--- a/gateway/src/__tests__/handle-inbound-admission.test.ts
+++ b/gateway/src/__tests__/handle-inbound-admission.test.ts
@@ -2,7 +2,7 @@
  * Gateway-side admission policy tests for `handle-inbound.ts`:
  *
  *  - `no_one` kill switch hard-denies pre-forward (P3 §4.2)
- *  - Exempt channels (`platform`, `a2a`, `phone`) skip the kill switch; `vellum` is configurable
+ *  - Exempt channels (`platform`, `a2a`) skip the kill switch; `vellum` and `phone` are enforced
  *  - `admissionPolicy` flows into `sourceMetadata` on forward
  *  - Default `trusted_contacts` is attached when no row is persisted
  *
@@ -215,12 +215,27 @@ describe("handle-inbound admission policy", () => {
     ).toBeUndefined();
   });
 
-  test("§8.4: phone skips kill switch even when `no_one` is persisted (voice ingress not wired)", async () => {
-    // Storing a `no_one` policy for phone would have no runtime effect since
-    // the voice webhook path does not read AdmissionPolicyStore. Exempt it
-    // so the gateway kill-switch also skips phone, making the exemption
-    // consistent end-to-end.
+  test("phone `no_one` hard-denies (voice ingress wired, no longer exempt)", async () => {
+    // phone is now an enforced channel: a persisted `no_one` floor trips the
+    // kill switch and the event never reaches the runtime.
     store.set("phone", "no_one");
+    resetAdmissionPolicyCache();
+    initAdmissionPolicyCache();
+
+    const result = await handleInbound(
+      makeConfig(),
+      makeEvent({ sourceChannel: "phone" }),
+      { routingOverride: { assistantId: "asst-1", routeSource: "default" } },
+    );
+
+    expect(result.forwarded).toBe(false);
+    expect(result.rejected).toBe(true);
+    expect(result.rejectionReason).toBe("admission_no_one");
+    expect(forwardToRuntimeMock).toHaveBeenCalledTimes(0);
+  });
+
+  test("phone attaches its floor to sourceMetadata.admissionPolicy when not `no_one`", async () => {
+    store.set("phone", "guardian_only");
     resetAdmissionPolicyCache();
     initAdmissionPolicyCache();
 
@@ -232,9 +247,8 @@ describe("handle-inbound admission policy", () => {
 
     expect(result.forwarded).toBe(true);
     expect(forwardToRuntimeMock).toHaveBeenCalledTimes(1);
-    // No admissionPolicy attached for exempt channels.
-    expect(
-      runtimePayloads[0]!.sourceMetadata!.admissionPolicy,
-    ).toBeUndefined();
+    expect(runtimePayloads[0]!.sourceMetadata!.admissionPolicy).toBe(
+      "guardian_only",
+    );
   });
 });

--- a/gateway/src/__tests__/seed-admission-policy.test.ts
+++ b/gateway/src/__tests__/seed-admission-policy.test.ts
@@ -29,14 +29,15 @@ describe("seedAdmissionPolicyDefaults", () => {
     expect(byChannel.get("telegram")).toBe("trusted_contacts");
     expect(byChannel.get("whatsapp")).toBe("trusted_contacts");
     expect(byChannel.get("email")).toBe("trusted_contacts");
+    // phone is enforced and seeds with the universal default.
+    expect(byChannel.get("phone")).toBe("trusted_contacts");
   });
 
-  test("skips exempt channels (a2a, phone)", () => {
+  test("skips exempt channels (a2a)", () => {
     seedAdmissionPolicyDefaults(store);
 
     const seen = new Set(store.list().map((r) => r.channelType));
     expect(seen.has("a2a")).toBe(false);
-    expect(seen.has("phone")).toBe(false);
   });
 
   test("is idempotent and never overwrites a user-configured row", () => {

--- a/gateway/src/db/admission-policy-store.ts
+++ b/gateway/src/db/admission-policy-store.ts
@@ -60,11 +60,10 @@ export interface AdmissionPolicyRow {
  * Internal channels exempt from admission policy. Mirrors
  * ADMISSION_POLICY_EXEMPT_CHANNELS in `packages/gateway-client`.
  *
- * `phone` is exempt until Twilio voice ingress reads AdmissionPolicyStore.
  * `vellum` is NOT exempt — it is client-configurable (see
  * KILL_SWITCH_FORBIDDEN_CHANNELS), so it is intentionally absent here.
  */
-export const EXEMPT_CHANNEL_TYPES = new Set<string>(["platform", "a2a", "phone"]);
+export const EXEMPT_CHANNEL_TYPES = new Set<string>(["platform", "a2a"]);
 
 export function isExemptChannelType(channelType: string): boolean {
   return EXEMPT_CHANNEL_TYPES.has(channelType);

--- a/gateway/src/db/seed-admission-policy.ts
+++ b/gateway/src/db/seed-admission-policy.ts
@@ -20,6 +20,10 @@ import { AdmissionPolicyStore, isExemptChannelType } from "./admission-policy-st
  * `vellum` (the local desktop/web client) defaults to `guardian_only`: only
  * the guardian's own local client is admitted by default. The guardian is
  * always max-rank on vellum, so this never locks them out.
+ *
+ * `phone` is intentionally absent — it now seeds with the universal
+ * `ADMISSION_POLICY_DEFAULT` (`trusted_contacts`), default-denying unknown /
+ * unverified inbound callers.
  */
 export const CHANNEL_ADMISSION_DEFAULTS: Partial<Record<ChannelId, AdmissionPolicy>> = {
   vellum: "guardian_only",
@@ -27,7 +31,7 @@ export const CHANNEL_ADMISSION_DEFAULTS: Partial<Record<ChannelId, AdmissionPoli
 
 /**
  * Insert a default row for every enforced channel that has none. Exempt
- * channels (`platform`/`a2a`/`phone`) are skipped — they carry no floor.
+ * channels (`platform`/`a2a`) are skipped — they carry no floor.
  */
 export function seedAdmissionPolicyDefaults(store: AdmissionPolicyStore): void {
   for (const channelType of CHANNEL_IDS) {

--- a/gateway/src/http/routes/twilio-voice-webhook.test.ts
+++ b/gateway/src/http/routes/twilio-voice-webhook.test.ts
@@ -11,12 +11,10 @@
  * - Assistant IDs are NOT forwarded to the daemon (daemon uses internal scope).
  * - The `no_one` admission kill switch rejects inbound voice with <Reject> TwiML.
  *
- * Kill-switch testing note: `phone` is still in the admission-policy exempt set
- * (removed in PR 6 of the voice-admission plan). To exercise the kill switch in
- * isolation here, the tests mock `isAdmissionPolicyExemptChannel` to force
- * `phone` enforced and mock the admission-policy cache directly, rather than
- * standing up a real store. The end-to-end (non-mocked exempt set) `no_one`
- * assertion lands with PR 6's test updates.
+ * Kill-switch testing note: `phone` is an enforced admission channel. The
+ * tests mock `isAdmissionPolicyExemptChannel` and the admission-policy cache
+ * directly (rather than standing up a real store) so each test can flip the
+ * resolved floor / flag in isolation.
  */
 import { describe, test, expect, mock, beforeEach } from "bun:test";
 import { resolvePublicBaseWssUrl } from "../../runtime/client.js";
@@ -73,7 +71,7 @@ mock.module("../../voice/verification.js", () => ({
 // resolved policy without re-mocking. Defaults keep the kill switch a no-op
 // (flag off) so the pre-existing routing tests are unaffected.
 let flagEnabled = false;
-let phoneExempt = true;
+let phoneExempt = false;
 let phonePolicy = "everyone";
 
 mock.module("../../feature-flag-resolver.js", () => ({
@@ -161,7 +159,7 @@ describe("twilio voice webhook handler", () => {
     _lastForwardedOriginalUrl = undefined;
     forwardCalled = false;
     flagEnabled = false;
-    phoneExempt = true;
+    phoneExempt = false;
     phonePolicy = "everyone";
   });
 
@@ -322,7 +320,7 @@ describe("twilio voice webhook handler", () => {
 
   test("inbound call is rejected when phone admission policy is no_one (flag on, enforced)", async () => {
     flagEnabled = true;
-    phoneExempt = false; // PR 6 removes phone from the exempt set; forced here.
+    phoneExempt = false; // phone is enforced
     phonePolicy = "no_one";
 
     const handler = createTwilioVoiceWebhookHandler(
@@ -364,9 +362,9 @@ describe("twilio voice webhook handler", () => {
     expect(forwardCalled).toBe(true);
   });
 
-  test("kill switch is a no-op while phone remains exempt even with policy no_one", async () => {
+  test("kill switch is skipped if a channel is exempt even with policy no_one", async () => {
     flagEnabled = true;
-    phoneExempt = true; // current state: phone exempt → kill switch skipped
+    phoneExempt = true; // exercise the defensive exempt branch
     phonePolicy = "no_one";
 
     const handler = createTwilioVoiceWebhookHandler(

--- a/gateway/src/http/routes/twilio-voice-webhook.ts
+++ b/gateway/src/http/routes/twilio-voice-webhook.ts
@@ -64,7 +64,7 @@ export function createTwilioVoiceWebhookHandler(
     if (!hasCallSessionId) {
       // `no_one` kill switch — mirrors handle-inbound.ts. Only inbound is
       // gated; outbound assistant-initiated calls are never kill-switched.
-      // No-op while `phone` stays in the admission exempt set (removed in PR 6).
+      // The exempt check stays defensive; `phone` is now an enforced channel.
       const phonePolicy =
         !isFeatureFlagEnabled("channel-trust-floors") ||
         isAdmissionPolicyExemptChannel("phone")

--- a/gateway/src/ipc/__tests__/admission-policy-handlers.test.ts
+++ b/gateway/src/ipc/__tests__/admission-policy-handlers.test.ts
@@ -54,9 +54,14 @@ describe("admissionPolicyRoutes", () => {
   });
 
   test("returns null policy for exempt channels", () => {
-    expect(getPolicy("phone")).toEqual({ policy: null });
     expect(getPolicy("platform")).toEqual({ policy: null });
     expect(getPolicy("a2a")).toEqual({ policy: null });
+  });
+
+  test("returns the resolved policy for the enforced `phone` channel", () => {
+    policiesByChannel.set("phone", "guardian_only");
+
+    expect(getPolicy("phone")).toEqual({ policy: "guardian_only" });
   });
 
   test("returns null policy for unknown channel strings", () => {

--- a/packages/gateway-client/src/admission-policy-contract.ts
+++ b/packages/gateway-client/src/admission-policy-contract.ts
@@ -54,20 +54,12 @@ export const ADMISSION_FLOOR: Record<AdmissionPolicy, number> = {
  *
  * `platform` / `a2a` are peer/internal channels with no human-trust model.
  *
- * NOTE: `phone` is exempt because the Twilio voice-webhook path
- * (twilio-voice-webhook → relay-setup-router) does not yet read
- * AdmissionPolicyStore / sourceMetadata.admissionPolicy. Storing a policy for
- * `phone` would have no runtime effect, so we exclude it from the API surface
- * until voice ingress is wired in a follow-up PR. Remove `"phone"` from this
- * set once the voice path enforces admission.
- *
  * `vellum` is intentionally NOT exempt — it is client-configurable, with the
  * single restriction in {@link KILL_SWITCH_FORBIDDEN_CHANNELS}.
  */
 export const ADMISSION_POLICY_EXEMPT_CHANNELS: ReadonlySet<string> = new Set([
   "platform",
   "a2a",
-  "phone",
 ]);
 
 export function isAdmissionPolicyExemptChannel(channelType: string): boolean {


### PR DESCRIPTION
## Summary
- Remove `phone` from the admission-policy exempt sets, activating the per-channel trust floor + no_one kill switch for inbound Twilio voice (enforcement wired in PRs 1–5).
- `phone` now seeds with the universal default floor `trusted_contacts`, which default-denies unknown/unverified inbound callers (user-visible behavior change — they no longer reach name capture unless the guardian loosens the phone floor).
- The web Channel Trust Floors card now shows a Phone / SMS row (no web code change needed).

Part of plan: voice-admission.md (PR 6 of 6)