### PR TITLE
feat(web): add react-virtual + headless timeline virtualizer hook

### DIFF
--- a/clients/web/bun.lock
+++ b/clients/web/bun.lock
@@ -32,6 +32,7 @@
         "@stripe/react-stripe-js": "6.4.0",
         "@stripe/stripe-js": "9.6.0",
         "@tanstack/react-query": "5.90.21",
+        "@tanstack/react-virtual": "^3.14.3",
         "@tiptap/core": "3.23.5",
         "@tiptap/extension-bubble-menu": "3.23.5",
         "@tiptap/extension-link": "3.23.5",
@@ -653,6 +654,10 @@
     "@tanstack/query-core": ["@tanstack/query-core@5.90.20", "", {}, "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg=="],
 
     "@tanstack/react-query": ["@tanstack/react-query@5.90.21", "", { "dependencies": { "@tanstack/query-core": "5.90.20" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg=="],
+
+    "@tanstack/react-virtual": ["@tanstack/react-virtual@3.14.3", "", { "dependencies": { "@tanstack/virtual-core": "3.17.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-k/cnHPVaOfn46hSbiY6n4Dzf4QjCGWSF40zR5QIIYUqPAjpA6TN7InfYmcMiDVQGP2iUn9xsRbAl8u1v3UmeVQ=="],
+
+    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.17.1", "", {}, "sha512-VZyW2Uiml5tmBZwPGrSD3Sz73OxzljQMCmzYHsUTPEuTsERf5xwa+uWb01xEzkz3ZSYTjj8NEb/mKHvgKxyZdA=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -55,6 +55,7 @@
     "@stripe/react-stripe-js": "6.4.0",
     "@stripe/stripe-js": "9.6.0",
     "@tanstack/react-query": "5.90.21",
+    "@tanstack/react-virtual": "^3.14.3",
     "@tiptap/core": "3.23.5",
     "@tiptap/extension-bubble-menu": "3.23.5",
     "@tiptap/extension-link": "3.23.5",

--- a/clients/web/src/domains/chat/hooks/use-timeline-virtualizer.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-timeline-virtualizer.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Tests for `useTimelineVirtualizer` and its pure helpers.
+ *
+ * The pure `computeScrollMargin` is exercised directly (no DOM needed). The
+ * hook itself gets a light smoke test: given a scroll-element ref it returns a
+ * usable virtualizer object. Heavy DOM-measurement behavior is covered once a
+ * consumer wires the hook in a later PR.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+import { createRef } from "react";
+
+import {
+  computeScrollMargin,
+  DEFAULT_ROW_ESTIMATE,
+  OVERSCAN,
+  useTimelineVirtualizer,
+} from "@/domains/chat/hooks/use-timeline-virtualizer";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("computeScrollMargin", () => {
+  test("returns 0 for a null element", () => {
+    expect(computeScrollMargin(null)).toBe(0);
+  });
+
+  test("returns the element's offsetTop", () => {
+    const stub = { offsetTop: 120 } as HTMLElement;
+    expect(computeScrollMargin(stub)).toBe(120);
+  });
+});
+
+describe("module constants", () => {
+  test("expose sane defaults", () => {
+    expect(DEFAULT_ROW_ESTIMATE).toBe(96);
+    expect(OVERSCAN).toBe(6);
+  });
+});
+
+describe("useTimelineVirtualizer", () => {
+  test("returns a virtualizer with the expected shape", () => {
+    const scrollRef = createRef<HTMLElement>();
+    scrollRef.current = document.createElement("div");
+
+    const { result } = renderHook(() =>
+      useTimelineVirtualizer({
+        count: 3,
+        scrollRef,
+        getItemKey: (index) => `row-${index}`,
+      }),
+    );
+
+    expect(typeof result.current.getTotalSize).toBe("function");
+    expect(Array.isArray(result.current.getVirtualItems())).toBe(true);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-timeline-virtualizer.ts
+++ b/clients/web/src/domains/chat/hooks/use-timeline-virtualizer.ts
@@ -1,0 +1,74 @@
+/**
+ * Headless virtualizer for the subagent timeline.
+ *
+ * Thin wrapper around `@tanstack/react-virtual`'s `useVirtualizer` that wires
+ * up the conventions the timeline needs: an *external* scroll element (the
+ * panel's own scroll container, not the list itself), dynamic per-row
+ * measurement, a header offset via `scrollMargin`, and stable item keys.
+ *
+ * This is scaffolding — no component consumes it yet. A later PR will mount it
+ * inside `subagent-timeline.tsx`. The dependency lands in the lazily-loaded
+ * subagent-panel chunk (see `chat-content-layout.tsx`), not the main bundle.
+ */
+import {
+  measureElement,
+  useVirtualizer,
+  type Virtualizer,
+} from "@tanstack/react-virtual";
+import type { RefObject } from "react";
+
+/**
+ * Fallback row height (px) used before a row has been measured. A sane guess
+ * for a single-line-ish timeline row; real heights are measured on mount via
+ * the dynamic `measureElement` so this only affects the initial estimate.
+ */
+export const DEFAULT_ROW_ESTIMATE = 96;
+
+/** Rows to render beyond the visible window, on each side, to mask scrolling. */
+export const OVERSCAN = 6;
+
+/**
+ * Compute the `scrollMargin` for the virtualizer: the list's top offset within
+ * the scroll container, so virtual positions account for any header/content
+ * rendered above the list. Pure (no DOM API beyond reading `offsetTop`) so it
+ * is unit-testable without a real layout.
+ */
+export function computeScrollMargin(listEl: HTMLElement | null): number {
+  return listEl?.offsetTop ?? 0;
+}
+
+export interface UseTimelineVirtualizerParams {
+  /** Number of rows in the timeline. */
+  count: number;
+  /** Ref to the scroll container (the element that actually scrolls). */
+  scrollRef: RefObject<HTMLElement | null>;
+  /** Ref to the inner list element, used to offset virtual positions. */
+  listRef?: RefObject<HTMLElement | null>;
+  /** Stable key for a row index, so measurements survive reorders. */
+  getItemKey: (index: number) => string;
+  /** Initial per-row height guess (px); defaults to {@link DEFAULT_ROW_ESTIMATE}. */
+  estimateSize?: number;
+}
+
+/**
+ * Wrap `useVirtualizer` for the subagent timeline. The returned virtualizer's
+ * `measureElement` should be attached to each row's `ref` to enable dynamic
+ * measurement.
+ */
+export function useTimelineVirtualizer({
+  count,
+  scrollRef,
+  listRef,
+  getItemKey,
+  estimateSize,
+}: UseTimelineVirtualizerParams): Virtualizer<HTMLElement, HTMLElement> {
+  return useVirtualizer<HTMLElement, HTMLElement>({
+    count,
+    getScrollElement: () => scrollRef.current,
+    getItemKey,
+    estimateSize: () => estimateSize ?? DEFAULT_ROW_ESTIMATE,
+    measureElement,
+    overscan: OVERSCAN,
+    scrollMargin: computeScrollMargin(listRef?.current ?? null),
+  });
+}


### PR DESCRIPTION
## Summary
- Add @tanstack/react-virtual (v3, React 19-compatible) — same TanStack family as the existing react-query
- Add headless useTimelineVirtualizer hook (dynamic measureElement, external scroll element, scrollMargin header offset) — no consumer yet
- Unit-test the pure helpers + a hook smoke test

Bundle note: the subagent panel is already lazy-loaded, so the dep lands in the panel chunk when PR 4 consumes the hook, not the main bundle.

Part of plan: virtualize-subagent-timeline.md (PR 3 of 4)