### PR TITLE
fix(web): pin react-virtual + correct timeline scrollMargin

### DIFF
--- a/clients/web/bun.lock
+++ b/clients/web/bun.lock
@@ -32,7 +32,7 @@
         "@stripe/react-stripe-js": "6.4.0",
         "@stripe/stripe-js": "9.6.0",
         "@tanstack/react-query": "5.90.21",
-        "@tanstack/react-virtual": "^3.14.3",
+        "@tanstack/react-virtual": "3.14.3",
         "@tiptap/core": "3.23.5",
         "@tiptap/extension-bubble-menu": "3.23.5",
         "@tiptap/extension-link": "3.23.5",

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -55,7 +55,7 @@
     "@stripe/react-stripe-js": "6.4.0",
     "@stripe/stripe-js": "9.6.0",
     "@tanstack/react-query": "5.90.21",
-    "@tanstack/react-virtual": "^3.14.3",
+    "@tanstack/react-virtual": "3.14.3",
     "@tiptap/core": "3.23.5",
     "@tiptap/extension-bubble-menu": "3.23.5",
     "@tiptap/extension-link": "3.23.5",

--- a/clients/web/src/domains/chat/hooks/use-timeline-virtualizer.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-timeline-virtualizer.test.tsx
@@ -22,13 +22,29 @@ afterEach(() => {
 });
 
 describe("computeScrollMargin", () => {
-  test("returns 0 for a null element", () => {
-    expect(computeScrollMargin(null)).toBe(0);
+  /** Build a stub element with a fixed bounding-rect top. */
+  function elAt(top: number, scrollTop = 0): HTMLElement {
+    return {
+      getBoundingClientRect: () => ({ top }) as DOMRect,
+      scrollTop,
+    } as unknown as HTMLElement;
+  }
+
+  test("returns 0 when either element is missing", () => {
+    expect(computeScrollMargin(null, null)).toBe(0);
+    expect(computeScrollMargin(elAt(120), null)).toBe(0);
+    expect(computeScrollMargin(null, elAt(0))).toBe(0);
   });
 
-  test("returns the element's offsetTop", () => {
-    const stub = { offsetTop: 120 } as HTMLElement;
-    expect(computeScrollMargin(stub)).toBe(120);
+  test("returns the list top relative to the scroll element", () => {
+    // List 120px below the scroll container's top, container not scrolled.
+    expect(computeScrollMargin(elAt(120), elAt(0))).toBe(120);
+  });
+
+  test("accounts for the scroll container's current scrollTop", () => {
+    // Container scrolled 200px: the list box top has moved up by 200, so the
+    // on-screen gap is -80, but the stable offset within content is 120.
+    expect(computeScrollMargin(elAt(-80), elAt(0, 200))).toBe(120);
   });
 });
 

--- a/clients/web/src/domains/chat/hooks/use-timeline-virtualizer.ts
+++ b/clients/web/src/domains/chat/hooks/use-timeline-virtualizer.ts
@@ -29,12 +29,27 @@ export const OVERSCAN = 6;
 
 /**
  * Compute the `scrollMargin` for the virtualizer: the list's top offset within
- * the scroll container, so virtual positions account for any header/content
- * rendered above the list. Pure (no DOM API beyond reading `offsetTop`) so it
- * is unit-testable without a real layout.
+ * the scroll container's content, so virtual positions account for any header
+ * rendered above the list.
+ *
+ * Measured *relative to the scroll element* rather than via `offsetTop`:
+ * `offsetTop` is relative to the nearest positioned ancestor, which is often
+ * not the scroll container (the panel body is a static `overflow-y-auto` div),
+ * so using it would subtract the wrong margin and shift every row. The gap
+ * between the two box tops plus the container's current `scrollTop` gives the
+ * list's stable offset within the scrolled content. Returns 0 until both
+ * elements are mounted.
  */
-export function computeScrollMargin(listEl: HTMLElement | null): number {
-  return listEl?.offsetTop ?? 0;
+export function computeScrollMargin(
+  listEl: HTMLElement | null,
+  scrollEl: HTMLElement | null,
+): number {
+  if (!listEl || !scrollEl) return 0;
+  return (
+    listEl.getBoundingClientRect().top -
+    scrollEl.getBoundingClientRect().top +
+    scrollEl.scrollTop
+  );
 }
 
 export interface UseTimelineVirtualizerParams {
@@ -69,6 +84,6 @@ export function useTimelineVirtualizer({
     estimateSize: () => estimateSize ?? DEFAULT_ROW_ESTIMATE,
     measureElement,
     overscan: OVERSCAN,
-    scrollMargin: computeScrollMargin(listRef?.current ?? null),
+    scrollMargin: computeScrollMargin(listRef?.current ?? null, scrollRef.current),
   });
 }


### PR DESCRIPTION
## Summary
Remediation of two Codex P2s left on #35240 (merged before they were addressed):
- Pin `@tanstack/react-virtual` to exact `3.14.3` (repo policy forbids caret ranges in deps).
- `computeScrollMargin` measures the list top **relative to the scroll element** (bounding-rect delta + scrollTop) rather than `offsetTop`, which is relative to the nearest positioned ancestor (the panel body is a static overflow-y-auto div) and would shift every virtual row once consumed in PR 4.

Part of plan: virtualize-subagent-timeline.md (PR 3 remediation)