### PR TITLE
fix(web): route SSE event stream to the local gateway in self-hosted mode

### DIFF
--- a/clients/web/src/lib/api-interceptors.test.ts
+++ b/clients/web/src/lib/api-interceptors.test.ts
@@ -258,6 +258,23 @@ describe("api-interceptors / self-hosted rewriting", () => {
     expect(outUrl.search).toBe("?limit=50");
   });
 
+  test("rewrites the live events SSE stream to the ingress", async () => {
+    // The events stream opens through the platform client; in local /
+    // self-hosted mode it must route to the gateway like conversations
+    // rather than fall through to the platform proxy.
+    setSelfHostedConnection({ url: INGRESS, token: ACTOR_TOKEN });
+    const eventsPath = `/v1/assistants/${SELF_HOSTED_ID}/events/`;
+    const input = new Request(
+      `https://platform.test${eventsPath}?lastSeenSeq=42`,
+    );
+    const output = await requestInterceptor(input);
+    const outUrl = new URL(output.url);
+    expect(outUrl.origin).toBe(INGRESS);
+    expect(outUrl.pathname).toBe(eventsPath);
+    expect(outUrl.search).toBe("?lastSeenSeq=42");
+    expect(output.headers.get("Authorization")).toBe(`Bearer ${ACTOR_TOKEN}`);
+  });
+
   test("prepends the ingress path prefix when the ingress URL has a path", async () => {
     const prefixedIngress = "http://localhost:3000/__gateway/20100";
     setSelfHostedConnection({ url: prefixedIngress, token: ACTOR_TOKEN });

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -73,6 +73,10 @@ function getRendererTupleOrigin(): string {
 const RUNTIME_PROXIED_FIRST_SEGMENTS = new Set<string>([
   "conversations",
   "channel-admission-policy",
+  // Live SSE event stream — `subscribeEvents` opens it through the
+  // platform client, so it must be forwarded to the gateway in local /
+  // self-hosted mode like any other runtime route.
+  "events",
 ]);
 
 const ASSISTANT_PATH_RE =


### PR DESCRIPTION
## Summary
- Add `events` to `RUNTIME_PROXIED_FIRST_SEGMENTS` in `clients/web/src/lib/api-interceptors.ts` so the live SSE event stream (`/v1/assistants/{id}/events/`, opened through the platform client) is rewritten to the self-hosted gateway (`/assistant/__gateway/<port>/...`) with an `Authorization: Bearer` token in local / self-hosted mode.
- Without it, only `conversations` and `channel-admission-policy` were rewritten, so a local assistant's events stream stayed on the platform origin and hit the dead `:8000` proxy fallback — a perpetual `[vite] http proxy error … ECONNREFUSED` reconnect loop. REST calls worked; only the live stream broke.
- Add a regression test asserting the events path is rewritten to the ingress with the bearer token.

## Original prompt
Recurring `[vite] http proxy error … ECONNREFUSED` on `/v1/assistants/<id>/events/` in the local Electron dev app. Traced to the events SSE stream not routing to the local assistant's gateway — the `events` segment was missing from the platform client's runtime-proxy allowlist, so it fell through to the absent Django platform on `:8000`. Confirmed the local gateway streams events fine when reached with a gateway token; the fix is to add `events` to the allowlist so the interceptor rewrites it like other runtime routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)