### PR TITLE
perf(web): virtualize the subagent timeline list

### DIFF
--- a/clients/web/src/domains/chat/components/__fixtures__/subagent-timeline-harness.tsx
+++ b/clients/web/src/domains/chat/components/__fixtures__/subagent-timeline-harness.tsx
@@ -1,0 +1,94 @@
+/**
+ * Shared test harness for the virtualized subagent timeline.
+ *
+ * `@tanstack/react-virtual` measures each row via `offsetHeight` and derives the
+ * viewport from the scroll element's `offsetHeight`; jsdom/happy-dom report 0 for
+ * all layout, so without stubs every row collapses to 0px and the virtualizer
+ * over-fills the viewport. This module centralizes the two workarounds both
+ * timeline test files need:
+ *   - `installRowHeightStub()` — a fixed per-row `offsetHeight` on the prototype,
+ *     wired into `beforeAll`/`afterAll`.
+ *   - `TimelineHarness` — renders the timeline against a scroll container whose
+ *     height is stubbed. The scroll element lives in this parent while the
+ *     virtualizer's mount effect runs in the child (which fires before the
+ *     parent's ref attaches), so the node is held in state: attaching it
+ *     re-renders, letting the virtualizer re-read a now-populated `scrollRef`.
+ */
+
+import { useMemo, useState } from "react";
+
+import { afterAll, beforeAll } from "bun:test";
+import type { screen } from "@testing-library/react";
+
+import { SubagentTimeline } from "@/domains/chat/components/subagent-timeline";
+import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
+
+/** Default per-row height (px); mirrors the hook's `DEFAULT_ROW_ESTIMATE`. */
+export const ROW_HEIGHT = 96;
+
+/** Per-event card titles, one per (non-filtered) event. */
+export const ROW_TITLES = ["Response", "Tool Call", "Tool Result", "Error"];
+
+/** Count rendered timeline rows by summing every per-event title occurrence. */
+export function renderedRowCount(screenApi: typeof screen): number {
+  return ROW_TITLES.reduce(
+    (total, title) => total + screenApi.queryAllByText(title).length,
+    0,
+  );
+}
+
+/**
+ * Stub `HTMLElement.prototype.offsetHeight` to a fixed row height for the
+ * duration of the suite, restoring the original descriptor afterwards. Call at
+ * the top level of a `describe` (or file).
+ */
+export function installRowHeightStub(rowHeight = ROW_HEIGHT): void {
+  let original: PropertyDescriptor | undefined;
+  beforeAll(() => {
+    original = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "offsetHeight",
+    );
+    Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+      configurable: true,
+      get() {
+        return rowHeight;
+      },
+    });
+  });
+  afterAll(() => {
+    if (original) {
+      Object.defineProperty(HTMLElement.prototype, "offsetHeight", original);
+    } else {
+      delete (HTMLElement.prototype as unknown as Record<string, unknown>)
+        .offsetHeight;
+    }
+  });
+}
+
+/** Render the timeline against a scroll container with a stubbed viewport height. */
+export function TimelineHarness({
+  events,
+  viewportHeight = 800,
+}: {
+  events: SubagentTimelineEvent[];
+  viewportHeight?: number;
+}) {
+  const [node, setNode] = useState<HTMLDivElement | null>(null);
+  const setRef = (el: HTMLDivElement | null) => {
+    if (el) {
+      Object.defineProperty(el, "offsetHeight", {
+        configurable: true,
+        value: viewportHeight,
+      });
+    }
+    setNode(el);
+  };
+  // Stable ref-shaped object whose `.current` tracks the attached node.
+  const scrollRef = useMemo(() => ({ current: node }), [node]);
+  return (
+    <div ref={setRef} style={{ height: viewportHeight, overflowY: "auto" }}>
+      <SubagentTimeline scrollRef={scrollRef} events={events} />
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -222,6 +222,11 @@ export function SubagentDetailPanel({
     }
   }, [entry.subagentId, entry.conversationId, entry.events.length, onRequestDetail]);
 
+  // The scroll container forwarded to the virtualized timeline: the timeline
+  // virtualizes against this *external* scroll element (the panel body) rather
+  // than its own list, so the metrics/objective header scrolls with the rows.
+  const scrollRef = useRef<HTMLDivElement>(null);
+
   return (
     <div className="flex h-full flex-col overflow-hidden rounded-xl bg-[var(--surface-lift)]">
       {/* Header */}
@@ -270,7 +275,7 @@ export function SubagentDetailPanel({
       </div>
 
       {/* Scrollable body */}
-      <div className="flex-1 overflow-y-auto px-5 py-5">
+      <div ref={scrollRef} className="flex-1 overflow-y-auto px-5 py-5">
         {/* Metrics row */}
         <div className="mb-5 grid grid-cols-3 gap-3">
           <AnimatedMetricCard
@@ -330,7 +335,11 @@ export function SubagentDetailPanel({
            * without a per-subagent reset an expanded `detail-N` would leak its
            * expanded state onto the next subagent's `detail-N`.
            */}
-          <SubagentTimeline key={entry.subagentId} events={timelineEvents} />
+          <SubagentTimeline
+            key={entry.subagentId}
+            scrollRef={scrollRef}
+            events={timelineEvents}
+          />
         </div>
       </div>
     </div>

--- a/clients/web/src/domains/chat/components/subagent-timeline.perf.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-timeline.perf.test.tsx
@@ -1,55 +1,61 @@
 /**
- * Synthetic-load perf baseline for the subagent timeline.
+ * Synthetic-load perf signal for the (now virtualized) subagent timeline.
  *
- * Renders the CURRENT timeline (memo + `content-visibility:auto` renders-all)
- * at N = 50 / 150 / 300 events using the deterministic synthetic fixture, and:
- *   - asserts every event produces a rendered row (structural correctness), and
+ * Renders the timeline at N = 50 / 150 / 300 events using the deterministic
+ * synthetic fixture, and:
+ *   - asserts the list is WINDOWED — only O(window) rows are mounted, not all N,
+ *     while `getTotalSize`-driven layout still reserves space for the full list
+ *     (the spacer's pixel height grows with N), and
  *   - logs a wall-clock render delta per N as an ADVISORY signal.
  *
  * The timings are intentionally NEVER asserted — JS-DOM wall-clock numbers are
  * noisy and machine-dependent. Authoritative numbers come from the manual
- * React DevTools Profiler protocol documented in the PR body. This file just
- * pins the structural baseline that virtualization (a later PR) must preserve.
+ * React DevTools Profiler protocol documented in the PR body.
+ *
+ * The shared harness stubs a fixed per-row height plus the scroll-container
+ * height so the virtualizer has a real viewport in jsdom/happy-dom (which report
+ * 0 for all layout); the number of mounted rows then stays a small O(viewport)
+ * constant regardless of N.
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
 import { cleanup, render, screen } from "@testing-library/react";
 
 import { makeSyntheticEvents } from "@/domains/chat/components/__fixtures__/subagent-timeline-fixtures";
-import { SubagentTimeline } from "@/domains/chat/components/subagent-timeline";
+import {
+  installRowHeightStub,
+  renderedRowCount,
+  TimelineHarness,
+} from "@/domains/chat/components/__fixtures__/subagent-timeline-harness";
 
-/** Per-event card titles the timeline renders, one per (non-filtered) event. */
-const ROW_TITLES = ["Response", "Tool Call", "Tool Result", "Error"];
+/** Viewport small enough to keep the window a tight handful of rows. */
+const VIEWPORT_HEIGHT = 300;
 
-/** Count rendered rows by summing every per-event title occurrence. */
-function renderedRowCount(): number {
-  return ROW_TITLES.reduce(
-    (total, title) => total + screen.queryAllByText(title).length,
-    0,
-  );
-}
+installRowHeightStub();
 
 afterEach(() => {
   cleanup();
 });
 
-describe("SubagentTimeline — synthetic-load perf baseline", () => {
+describe("SubagentTimeline — synthetic-load windowing signal", () => {
   for (const eventCount of [50, 150, 300]) {
-    test(`renders all ${eventCount} events`, () => {
+    test(`windows ${eventCount} events to a small row count`, () => {
       const events = makeSyntheticEvents(eventCount);
 
       const start = performance.now();
-      render(<SubagentTimeline events={events} />);
+      render(<TimelineHarness events={events} viewportHeight={VIEWPORT_HEIGHT} />);
       const elapsedMs = performance.now() - start;
+      const rows = renderedRowCount(screen);
 
       // Advisory only — never asserted.
       console.log(
-        `[perf] SubagentTimeline N=${eventCount} render=${elapsedMs.toFixed(2)}ms`,
+        `[perf] SubagentTimeline N=${eventCount} render=${elapsedMs.toFixed(2)}ms rows=${rows}`,
       );
 
-      // The fixture emits only non-empty events, so none are filtered out:
-      // every event must produce exactly one row.
-      expect(renderedRowCount()).toBe(eventCount);
+      // Virtualization mounts only a window of rows, not all N: a non-zero
+      // handful (guarding against a vacuous pass) that stays far below 300.
+      expect(rows).toBeGreaterThan(0);
+      expect(rows).toBeLessThan(60);
     });
   }
 });

--- a/clients/web/src/domains/chat/components/subagent-timeline.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-timeline.test.tsx
@@ -12,8 +12,26 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
-import { SubagentTimeline } from "@/domains/chat/components/subagent-timeline";
+import { makeSyntheticEvents } from "@/domains/chat/components/__fixtures__/subagent-timeline-fixtures";
+import {
+  installRowHeightStub,
+  renderedRowCount,
+  TimelineHarness,
+} from "@/domains/chat/components/__fixtures__/subagent-timeline-harness";
 import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
+
+// jsdom/happy-dom report 0 for all layout; give rows a fixed measured height so
+// the virtualizer forms a real window (see the harness module for details).
+installRowHeightStub();
+
+function renderTimeline(
+  events: SubagentTimelineEvent[],
+  viewportHeight = 800,
+) {
+  return render(
+    <TimelineHarness events={events} viewportHeight={viewportHeight} />,
+  );
+}
 
 const LONG_PATH =
   "/workspaces/worktrees/p3-fixup-fork/clients/web/src/domains/channel/handler-inbound-admission.test.ts";
@@ -55,7 +73,7 @@ afterEach(() => {
 
 describe("SubagentTimeline — tool_call content wrapping", () => {
   test("long content carries wrapping classes so it can't overflow the card", () => {
-    render(<SubagentTimeline events={[toolCallEvent()]} />);
+    renderTimeline([toolCallEvent()]);
 
     const content = screen.getByText(LONG_PATH);
     expect(content.className).toContain("min-w-0");
@@ -64,7 +82,7 @@ describe("SubagentTimeline — tool_call content wrapping", () => {
 
   test("tool name carries wrapping classes too", () => {
     const longName = "some_extremely_long_tool_name_identifier_that_could_overflow";
-    render(<SubagentTimeline events={[toolCallEvent({ toolName: longName })]} />);
+    renderTimeline([toolCallEvent({ toolName: longName })]);
 
     const name = screen.getByText(longName);
     expect(name.className).toContain("min-w-0");
@@ -76,7 +94,7 @@ describe("SubagentTimeline — expand state keyed by event.id", () => {
   test("expanding one row, then toggling another, leaves the first expanded", () => {
     const first = toolResultEvent({ id: "evt-a", content: longLines("a") });
     const second = toolResultEvent({ id: "evt-b", content: longLines("b") });
-    render(<SubagentTimeline events={[first, second]} />);
+    renderTimeline([first, second]);
 
     // Both rows start collapsed.
     const toggles = screen.getAllByText("Show more");
@@ -98,5 +116,17 @@ describe("SubagentTimeline — expand state keyed by event.id", () => {
     expect(screen.getAllByText("Show less")).toHaveLength(2);
     expect(screen.getByText(/a line 7/)).toBeDefined();
     expect(screen.getByText(/b line 7/)).toBeDefined();
+  });
+});
+
+describe("SubagentTimeline — virtualization windows the list", () => {
+  test("mounts only a window of rows for a large list, not all of them", () => {
+    // A 300px viewport over ~96px rows windows to a handful of rows + overscan,
+    // so far fewer than all 300 events are in the DOM.
+    renderTimeline(makeSyntheticEvents(300), 300);
+
+    const rendered = renderedRowCount(screen);
+    expect(rendered).toBeGreaterThan(0); // guard: not a vacuous pass
+    expect(rendered).toBeLessThan(60);
   });
 });

--- a/clients/web/src/domains/chat/components/subagent-timeline.tsx
+++ b/clients/web/src/domains/chat/components/subagent-timeline.tsx
@@ -5,8 +5,10 @@ import {
     TriangleAlert,
     Wrench,
 } from "lucide-react";
-import { memo, useCallback, useMemo, useState } from "react";
+import { memo, useCallback, useMemo, useRef, useState } from "react";
+import type { RefObject } from "react";
 
+import { useTimelineVirtualizer } from "@/domains/chat/hooks/use-timeline-virtualizer";
 import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
 import { Typography } from "@vellumai/design-library";
 
@@ -24,6 +26,17 @@ const CONNECTOR_STYLE = {
   backgroundColor: "var(--border-subtle)",
   minHeight: 16,
 };
+
+/**
+ * Constant style fields shared by every absolutely-positioned virtual row; only
+ * the per-row `transform` is spread in at the call site, so these don't get
+ * reallocated per row.
+ */
+const VIRTUAL_ROW_STYLE = {
+  position: "absolute",
+  top: 0,
+  width: "100%",
+} as const;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -195,11 +208,12 @@ const TimelineEventRow = memo(function TimelineEventRow({
   toggleExpand: (id: string) => void;
 }) {
   return (
-    // `content-visibility: auto` lets the browser skip layout/paint for rows
-    // that are off-screen in the panel's scroll container; `contain-intrinsic-
-    // size: auto 72px` reserves a placeholder (and remembers each row's real
-    // size once measured) so the scrollbar doesn't jump.
-    <div className="relative flex gap-3 [content-visibility:auto] [contain-intrinsic-size:auto_72px]">
+    // The inter-row gap lives in this row's `pb-4` padding (not the card's
+    // margin): the virtualizer measures rows via `getBoundingClientRect`, which
+    // excludes margins, so a margin-based gap would make absolutely-positioned
+    // rows overlap. As padding it's part of the measured height, and the
+    // connector's `flex-1` fill still spans through it to the next row.
+    <div className="relative flex gap-3 pb-4">
       {/* Left: icon node + connector line */}
       <div className="flex flex-col items-center">
         <div
@@ -214,7 +228,7 @@ const TimelineEventRow = memo(function TimelineEventRow({
       </div>
 
       {/* Right: content card */}
-      <div className="mb-4 min-w-0 flex-1 rounded-lg bg-[var(--surface-overlay)] px-4 py-3">
+      <div className="min-w-0 flex-1 rounded-lg bg-[var(--surface-overlay)] px-4 py-3">
         <Typography
           variant="body-medium-default"
           className="text-[var(--content-default)]"
@@ -288,15 +302,22 @@ const TimelineEventRow = memo(function TimelineEventRow({
 
 export interface SubagentTimelineProps {
   events: SubagentTimelineEvent[];
+  /**
+   * The panel's scroll container. The list virtualizes against this *external*
+   * element (not its own box) so the metrics/objective header above the list
+   * scrolls together with the rows.
+   */
+  scrollRef: RefObject<HTMLElement | null>;
 }
 
 export const SubagentTimeline = memo(function SubagentTimeline({
   events,
+  scrollRef,
 }: SubagentTimelineProps) {
   const filteredEvents = useMemo(() => filterEvents(events), [events]);
 
   // Expand/collapse state lives here, keyed by `event.id`, so it survives a row
-  // unmounting and remounting (e.g. when the list is virtualized). `toggleExpand`
+  // unmounting and remounting as the virtualizer windows the list. `toggleExpand`
   // is stable across renders so it can be passed through the `memo`'d row without
   // defeating its bail-out.
   const [expandedIds, setExpandedIds] = useState<Set<string>>(() => new Set());
@@ -312,6 +333,22 @@ export const SubagentTimeline = memo(function SubagentTimeline({
     });
   }, []);
 
+  // The list element, used by the virtualizer to offset virtual positions
+  // (`scrollMargin`) relative to the scroll container's content.
+  const listRef = useRef<HTMLDivElement>(null);
+  // Memoized so the virtualizer's options don't churn on every render (e.g.
+  // expand/collapse); only reallocates when the event list itself changes.
+  const getItemKey = useCallback(
+    (index: number) => filteredEvents[index]!.id,
+    [filteredEvents],
+  );
+  const virtualizer = useTimelineVirtualizer({
+    count: filteredEvents.length,
+    scrollRef,
+    listRef,
+    getItemKey,
+  });
+
   if (filteredEvents.length === 0) {
     return (
       <Typography
@@ -324,16 +361,34 @@ export const SubagentTimeline = memo(function SubagentTimeline({
   }
 
   return (
-    <div className="flex flex-col">
-      {filteredEvents.map((event, index) => (
-        <TimelineEventRow
-          key={event.id}
-          event={event}
-          isLast={index === filteredEvents.length - 1}
-          expanded={expandedIds.has(event.id)}
-          toggleExpand={toggleExpand}
-        />
-      ))}
+    <div ref={listRef} className="flex flex-col">
+      {/* Spacer reserves the full list height (via `getTotalSize`) so the
+          scrollbar reflects all rows even though only a window is mounted. */}
+      <div style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
+        {virtualizer.getVirtualItems().map((vi) => {
+          const event = filteredEvents[vi.index]!;
+          return (
+            <div
+              key={vi.key}
+              data-index={vi.index}
+              ref={virtualizer.measureElement}
+              style={{
+                ...VIRTUAL_ROW_STYLE,
+                transform: `translateY(${vi.start - virtualizer.options.scrollMargin}px)`,
+              }}
+            >
+              <TimelineEventRow
+                event={event}
+                // Absolute index, not the position within the rendered window,
+                // so the connector is omitted only for the genuine last row.
+                isLast={vi.index === filteredEvents.length - 1}
+                expanded={expandedIds.has(event.id)}
+                toggleExpand={toggleExpand}
+              />
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 });


### PR DESCRIPTION
## Summary
- Virtualize the subagent timeline with useTimelineVirtualizer (windowed rows, dynamic measurement) using the panel body as the external scroll element
- Move inter-row gap from margin to padding so measured heights are gap-accurate; isLast by absolute index; connector stays continuous
- Remove the content-visibility/contain-intrinsic-size stand-in (real windowing replaces it); keep min-w-0/break-words and lifted expand state
- Flip the perf test to assert windowing (rows << N at N=300)

Part of plan: virtualize-subagent-timeline.md (PR 4 of 4)