### PR TITLE
refactor(gateway): consolidate admission-policy flag/exempt/cache resolution

### DIFF
--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -1,15 +1,11 @@
 import { existsSync } from "node:fs";
-import {
-  isAdmissionPolicyExemptChannel,
-  type SourceMetadata,
-} from "@vellumai/gateway-client";
+import type { SourceMetadata } from "@vellumai/gateway-client";
 import type { GatewayConfig } from "../config.js";
 import { ipcCallAssistant } from "../ipc/assistant-client.js";
 import { resolveIpcSocketPath } from "../ipc/socket-path.js";
 import { ContactStore } from "../db/contact-store.js";
 import { getLogger } from "../logger.js";
-import { isFeatureFlagEnabled } from "../feature-flag-resolver.js";
-import { getAdmissionPolicyCache } from "../risk/admission-policy-cache.js";
+import { resolveAdmissionPolicy } from "../risk/admission-policy-cache.js";
 import { canonicalizeInboundIdentity } from "../verification/identity.js";
 import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
 import type { RouteResult } from "../routing/types.js";
@@ -22,11 +18,6 @@ import type { GatewayInboundEvent } from "../types.js";
 import { tryTextVerificationIntercept } from "../verification/text-verification.js";
 
 const log = getLogger("handle-inbound");
-
-// Gates all per-channel admission enforcement (kill switch + floor). When off,
-// no admission policy is resolved or attached, so inbound falls back to the
-// pre-feature ACL-only behavior.
-const CHANNEL_TRUST_FLOORS_FLAG = "channel-trust-floors" as const;
 
 export type InboundResult = {
   forwarded: boolean;
@@ -85,11 +76,7 @@ export async function handleInbound(
   // check so a guardian can never lock themselves out of the desktop client
   // via the admission UI. The same exemption is enforced PUT-side in
   // channel-admission-policy.ts and at the runtime admission stage.
-  const admissionPolicy =
-    !isFeatureFlagEnabled(CHANNEL_TRUST_FLOORS_FLAG) ||
-    isAdmissionPolicyExemptChannel(event.sourceChannel)
-      ? null
-      : getAdmissionPolicyCache().get(event.sourceChannel);
+  const admissionPolicy = resolveAdmissionPolicy(event.sourceChannel);
   if (admissionPolicy === "no_one") {
     log.info(
       {

--- a/gateway/src/http/routes/twilio-voice-webhook.ts
+++ b/gateway/src/http/routes/twilio-voice-webhook.ts
@@ -1,10 +1,8 @@
-import { isAdmissionPolicyExemptChannel } from "@vellumai/gateway-client";
 import type { ConfigFileCache } from "../../config-file-cache.js";
 import type { GatewayConfig } from "../../config.js";
 import { credentialKey } from "../../credential-key.js";
-import { isFeatureFlagEnabled } from "../../feature-flag-resolver.js";
 import { getLogger } from "../../logger.js";
-import { getAdmissionPolicyCache } from "../../risk/admission-policy-cache.js";
+import { resolveAdmissionPolicy } from "../../risk/admission-policy-cache.js";
 import {
   CircuitBreakerOpenError,
   forwardTwilioVoiceWebhook,
@@ -64,12 +62,7 @@ export function createTwilioVoiceWebhookHandler(
     if (!hasCallSessionId) {
       // `no_one` kill switch — mirrors handle-inbound.ts. Only inbound is
       // gated; outbound assistant-initiated calls are never kill-switched.
-      // The exempt check stays defensive; `phone` is now an enforced channel.
-      const phonePolicy =
-        !isFeatureFlagEnabled("channel-trust-floors") ||
-        isAdmissionPolicyExemptChannel("phone")
-          ? null
-          : getAdmissionPolicyCache().get("phone");
+      const phonePolicy = resolveAdmissionPolicy("phone");
       if (phonePolicy === "no_one") {
         log.info(
           { callSid: params.CallSid, from: params.From, to: params.To },

--- a/gateway/src/ipc/admission-policy-handlers.ts
+++ b/gateway/src/ipc/admission-policy-handlers.ts
@@ -6,12 +6,9 @@
  * off, the channel is exempt, or the channel type is unknown.
  */
 
-import { isAdmissionPolicyExemptChannel } from "@vellumai/gateway-client";
 import { z } from "zod";
 
-import { isChannelId } from "../channels/types.js";
-import { isFeatureFlagEnabled } from "../feature-flag-resolver.js";
-import { getAdmissionPolicyCache } from "../risk/admission-policy-cache.js";
+import { resolveAdmissionPolicy } from "../risk/admission-policy-cache.js";
 import type { IpcRoute } from "./server.js";
 
 const GetChannelAdmissionPolicySchema = z.object({
@@ -24,12 +21,7 @@ export const admissionPolicyRoutes: IpcRoute[] = [
     schema: GetChannelAdmissionPolicySchema,
     handler: (params?: Record<string, unknown>) => {
       const { channelType } = GetChannelAdmissionPolicySchema.parse(params);
-
-      if (!isFeatureFlagEnabled("channel-trust-floors")) return { policy: null };
-      if (isAdmissionPolicyExemptChannel(channelType)) return { policy: null };
-      if (!isChannelId(channelType)) return { policy: null };
-
-      return { policy: getAdmissionPolicyCache().get(channelType) };
+      return { policy: resolveAdmissionPolicy(channelType) };
     },
   },
 ];

--- a/gateway/src/risk/admission-policy-cache.ts
+++ b/gateway/src/risk/admission-policy-cache.ts
@@ -3,7 +3,9 @@ import {
   AdmissionPolicyStore,
   type AdmissionPolicy,
 } from "../db/admission-policy-store.js";
-import type { ChannelId } from "../channels/types.js";
+import { isChannelId, type ChannelId } from "../channels/types.js";
+import { isAdmissionPolicyExemptChannel } from "@vellumai/gateway-client";
+import { isFeatureFlagEnabled } from "../feature-flag-resolver.js";
 
 // ---------------------------------------------------------------------------
 // Cache class
@@ -70,4 +72,28 @@ export function invalidateAdmissionPolicyCache(): void {
 
 export function resetAdmissionPolicyCache(): void {
   cache = null;
+}
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+// Gates all per-channel admission enforcement (kill switch + floor). When off,
+// no admission policy is resolved, so inbound falls back to the pre-feature
+// ACL-only behavior.
+export const CHANNEL_TRUST_FLOORS_FLAG = "channel-trust-floors" as const;
+
+/**
+ * Resolve a channel's admission policy, folding the feature-flag gate, the
+ * §8.1 exempt-channel skip, and the channel-id guard. Returns `null` when the
+ * flag is off, the channel is exempt, or the string is not a known channel —
+ * the single source of truth for every admission-policy call site.
+ */
+export function resolveAdmissionPolicy(
+  channelType: string,
+): AdmissionPolicy | null {
+  if (!isFeatureFlagEnabled(CHANNEL_TRUST_FLOORS_FLAG)) return null;
+  if (isAdmissionPolicyExemptChannel(channelType)) return null;
+  if (!isChannelId(channelType)) return null;
+  return getAdmissionPolicyCache().get(channelType);
 }


### PR DESCRIPTION
## Summary
Post-merge cleanup from voice-admission plan self-review.
- Add resolveAdmissionPolicy() helper in admission-policy-cache.ts folding the flag check, exempt check, channel guard, and cache lookup.
- Replace the triplicated inline resolution in handle-inbound.ts, twilio-voice-webhook.ts, and admission-policy-handlers.ts; single shared flag constant (no more raw 'channel-trust-floors' string literals).

Part of plan: voice-admission.md (self-review fix)