### PR TITLE
refactor(assistant): clean up voice-admission call sites

### DIFF
--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -113,14 +113,12 @@ mock.module("../config/loader.js", () => ({
 let mockAdmissionPolicy:
   | import("@vellumai/gateway-client").AdmissionPolicy
   | null = null;
-let mockAdmissionReaderThrows = false;
 // Optional gate to hold the reader open mid-setup so tests can drive the
 // race window where a prompt arrives while handleSetup is still awaiting.
 let mockAdmissionGate: Promise<void> | null = null;
 mock.module("../calls/channel-admission-reader.js", () => ({
   getChannelAdmissionPolicy: async () => {
     if (mockAdmissionGate) await mockAdmissionGate;
-    if (mockAdmissionReaderThrows) throw new Error("reader boom");
     return mockAdmissionPolicy;
   },
 }));
@@ -464,7 +462,6 @@ describe("relay-server", () => {
     mockUserReference = "my human";
     mockAssistantName = "Vellum";
     mockAdmissionPolicy = null;
-    mockAdmissionReaderThrows = false;
     mockAdmissionGate = null;
     mockSendMessage.mockImplementation(createMockProviderResponse(["Hello"]));
     mockConfig.calls.verification.enabled = false;
@@ -2974,41 +2971,6 @@ describe("relay-server", () => {
     // Trusted contact proceeds normally — no deny.
     expect(relay.getConnectionState()).toBe("connected");
 
-    const updated = getCallSession(session.id);
-    expect(updated!.status).toBe("in_progress");
-
-    relay.destroy();
-  });
-
-  test("admission floor: reader throw fails open and admits the caller", async () => {
-    ensureConversation("conv-admission-floor-throw");
-    const session = createCallSession({
-      conversationId: "conv-admission-floor-throw",
-      provider: "twilio",
-      fromNumber: "+15557776666",
-      toNumber: "+15551111111",
-    });
-
-    addTrustedVoiceContact("+15557776666");
-    mockAdmissionReaderThrows = true; // reader cannot break setup
-
-    mockSendMessage.mockImplementation(
-      createMockProviderResponse(["Hello, how can I help you?"]),
-    );
-
-    const { relay } = createMockWs(session.id);
-
-    await relay.handleMessage(
-      JSON.stringify({
-        type: "setup",
-        callSid: "CA_admission_floor_throw",
-        from: "+15557776666",
-        to: "+15551111111",
-      }),
-    );
-
-    // Fail open: reader failure admits the caller; setup completes normally.
-    expect(relay.getConnectionState()).toBe("connected");
     const updated = getCallSession(session.id);
     expect(updated!.status).toBe("in_progress");
 

--- a/assistant/src/calls/media-stream-server.ts
+++ b/assistant/src/calls/media-stream-server.ts
@@ -31,7 +31,6 @@
  * - Media stream `stop` event / WebSocket close -> finalize call.
  */
 
-import type { AdmissionPolicy } from "@vellumai/gateway-client";
 import type { ServerWebSocket } from "bun";
 
 import { revokeScopedApprovalGrantsForContext } from "../memory/scoped-approval-grants.js";
@@ -375,17 +374,9 @@ export class MediaStreamCallSession {
 
     // Resolve the phone channel's inbound admission floor so the trust floor
     // (e.g. guardian_only) is enforced on this transport too — not just the
-    // gateway webhook's no_one kill switch. The reader fails open to `null`;
-    // the guard keeps a reader throw from ever aborting setup (admit in doubt).
-    let admissionPolicy: AdmissionPolicy | null = null;
-    try {
-      admissionPolicy = await getChannelAdmissionPolicy("phone");
-    } catch (err) {
-      log.warn(
-        { err, callSessionId: this.callSessionId },
-        "Failed to resolve phone admission policy — admitting (fail open)",
-      );
-    }
+    // gateway webhook's no_one kill switch. The reader fails open to `null`
+    // by contract, so a transport hiccup admits the caller.
+    const admissionPolicy = await getChannelAdmissionPolicy("phone");
 
     const { outcome, resolved } = routeSetup({
       callSessionId: this.callSessionId,

--- a/assistant/src/calls/relay-server.ts
+++ b/assistant/src/calls/relay-server.ts
@@ -567,18 +567,9 @@ export class RelayConnection {
     const session = getCallSession(this.callSessionId);
     this.recordSetupBookkeeping(session, msg);
 
-    // Resolve the phone channel's inbound admission floor. The reader already
-    // fails open to `null`; the extra guard keeps a reader throw from ever
-    // aborting setup (admit when in doubt).
-    let admissionPolicy: AdmissionPolicy | null = null;
-    try {
-      admissionPolicy = await getChannelAdmissionPolicy("phone");
-    } catch (err) {
-      log.warn(
-        { err, callSessionId: this.callSessionId },
-        "Failed to resolve phone admission policy — admitting (fail open)",
-      );
-    }
+    // Resolve the phone channel's inbound admission floor. The reader fails
+    // open to `null` by contract, so a transport hiccup admits the caller.
+    const admissionPolicy = await getChannelAdmissionPolicy("phone");
 
     try {
       await this.routeSetupOutcome(msg, session, admissionPolicy);

--- a/assistant/src/calls/relay-setup-router.ts
+++ b/assistant/src/calls/relay-setup-router.ts
@@ -16,7 +16,10 @@ import {
 } from "../runtime/actor-trust-resolver.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../runtime/assistant-scope.js";
 import { getPendingSession } from "../runtime/channel-verification-service.js";
-import { enforceAdmissionPolicy } from "../runtime/routes/inbound-stages/admission-policy.js";
+import {
+  type AdmissionPolicyResult,
+  enforceAdmissionPolicy,
+} from "../runtime/routes/inbound-stages/admission-policy.js";
 import { getLogger } from "../util/logger.js";
 import type { CallSession } from "./types.js";
 
@@ -209,16 +212,15 @@ export function routeSetup(ctx: SetupContext): {
   // Floor-deny outcome shared by the unknown-caller and member-caller branches.
   // Live calls cannot await async re-verification, so the floor's
   // `shouldChallenge` upgrade UX is not surfaced — same rationale as `escalate`.
-  const floorDeny = () => {
-    const effectivePolicy = floorVerdict.admitted
-      ? undefined
-      : floorVerdict.effectivePolicy;
+  const floorDeny = (
+    denyVerdict: Extract<AdmissionPolicyResult, { admitted: false }>,
+  ) => {
     log.info(
       {
         callSessionId: ctx.callSessionId,
         from: ctx.from,
         trustClass: actorTrust.trustClass,
-        effectivePolicy,
+        effectivePolicy: denyVerdict.effectivePolicy,
       },
       "Inbound voice ACL: admission floor denied caller",
     );
@@ -227,7 +229,7 @@ export function routeSetup(ctx: SetupContext): {
         action: "deny" as const,
         message:
           "This number is not authorized to reach the assistant right now.",
-        logReason: `Inbound voice admission floor: ${effectivePolicy}`,
+        logReason: `Inbound voice admission floor: ${denyVerdict.effectivePolicy}`,
       },
       resolved,
     };
@@ -297,7 +299,7 @@ export function routeSetup(ctx: SetupContext): {
     // Admission floor: deny callers below the floor. Invites (handled above)
     // bypass the floor as an explicit grant; this runs after them.
     if (!floorVerdict.admitted) {
-      return floorDeny();
+      return floorDeny(floorVerdict);
     }
 
     // Known caller whose channel hasn't passed verification yet —
@@ -407,7 +409,7 @@ export function routeSetup(ctx: SetupContext): {
   // Admission floor: deny member/guardian callers below the floor (e.g.
   // `guardian_only` denies a trusted_contact).
   if (!floorVerdict.admitted) {
-    return floorDeny();
+    return floorDeny(floorVerdict);
   }
 
   // Guardian and trusted-contact callers proceed normally

--- a/assistant/src/calls/twilio-routes.ts
+++ b/assistant/src/calls/twilio-routes.ts
@@ -21,7 +21,6 @@
  *   server-side.
  */
 
-import type { AdmissionPolicy } from "@vellumai/gateway-client";
 import {
   buildTwilioMediaStreamUrl,
   buildTwilioRelayUrl,
@@ -481,17 +480,9 @@ async function buildVoiceWebhookTwiml(
   // Resolve the phone channel's inbound admission floor so this preflight
   // classification matches the real enforcement at stream start — a
   // floor-denied caller is recognized as `deny` here, not `normal_call`.
-  // The reader fails open to `null`; the guard keeps a reader throw from
-  // ever aborting setup (admit when in doubt).
-  let admissionPolicy: AdmissionPolicy | null = null;
-  try {
-    admissionPolicy = await getChannelAdmissionPolicy("phone");
-  } catch (err) {
-    log.warn(
-      { err, callSessionId },
-      "Failed to resolve phone admission policy for media-stream preflight — admitting (fail open)",
-    );
-  }
+  // The reader fails open to `null` by contract, so a transport hiccup
+  // admits the caller.
+  const admissionPolicy = await getChannelAdmissionPolicy("phone");
 
   const { outcome } = routeSetup({
     callSessionId,


### PR DESCRIPTION
## Summary
Post-merge cleanup from voice-admission plan self-review.
- Remove triplicated fail-open try/catch around getChannelAdmissionPolicy('phone') (the reader fails open by contract).
- Remove the unreachable admitted-branch ternary in floorDeny().
- Rewrite stale PR-history test comments to describe present behavior.

Part of plan: voice-admission.md (self-review fix)