### PR TITLE
fix(web): self-review remediation for timeline virtualization

### DIFF
--- a/clients/web/src/domains/chat/components/__fixtures__/subagent-timeline-fixtures.ts
+++ b/clients/web/src/domains/chat/components/__fixtures__/subagent-timeline-fixtures.ts
@@ -15,7 +15,8 @@
  *    ~5% error       — an error line
  *
  * Ids mirror the store's `generateTimelineEventId` (`te-${n}`, 1-based), and
- * timestamps are monotonic. Kept general + exported for reuse by later PRs.
+ * timestamps are monotonic. Shared by `subagent-timeline.test.tsx` and
+ * `subagent-timeline.perf.test.tsx`.
  */
 
 import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";

--- a/clients/web/src/domains/chat/components/__fixtures__/subagent-timeline-harness.tsx
+++ b/clients/web/src/domains/chat/components/__fixtures__/subagent-timeline-harness.tsx
@@ -23,11 +23,11 @@ import type { screen } from "@testing-library/react";
 import { SubagentTimeline } from "@/domains/chat/components/subagent-timeline";
 import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
 
-/** Default per-row height (px); mirrors the hook's `DEFAULT_ROW_ESTIMATE`. */
-export const ROW_HEIGHT = 96;
+/** Default per-row height (px); mirrors the hook's row-height estimate. */
+const ROW_HEIGHT = 96;
 
 /** Per-event card titles, one per (non-filtered) event. */
-export const ROW_TITLES = ["Response", "Tool Call", "Tool Result", "Error"];
+const ROW_TITLES = ["Response", "Tool Call", "Tool Result", "Error"];
 
 /** Count rendered timeline rows by summing every per-event title occurrence. */
 export function renderedRowCount(screenApi: typeof screen): number {
@@ -42,7 +42,7 @@ export function renderedRowCount(screenApi: typeof screen): number {
  * duration of the suite, restoring the original descriptor afterwards. Call at
  * the top level of a `describe` (or file).
  */
-export function installRowHeightStub(rowHeight = ROW_HEIGHT): void {
+export function installRowHeightStub(): void {
   let original: PropertyDescriptor | undefined;
   beforeAll(() => {
     original = Object.getOwnPropertyDescriptor(
@@ -52,7 +52,7 @@ export function installRowHeightStub(rowHeight = ROW_HEIGHT): void {
     Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
       configurable: true,
       get() {
-        return rowHeight;
+        return ROW_HEIGHT;
       },
     });
   });

--- a/clients/web/src/domains/chat/components/subagent-timeline.tsx
+++ b/clients/web/src/domains/chat/components/subagent-timeline.tsx
@@ -208,12 +208,14 @@ const TimelineEventRow = memo(function TimelineEventRow({
   toggleExpand: (id: string) => void;
 }) {
   return (
-    // The inter-row gap lives in this row's `pb-4` padding (not the card's
-    // margin): the virtualizer measures rows via `getBoundingClientRect`, which
-    // excludes margins, so a margin-based gap would make absolutely-positioned
-    // rows overlap. As padding it's part of the measured height, and the
-    // connector's `flex-1` fill still spans through it to the next row.
-    <div className="relative flex gap-3 pb-4">
+    // The inter-row gap is the card's bottom margin (`mb-4`). The card is a flex
+    // item, so its margin grows the flex line's cross-size: the left rail — and
+    // its `flex-1` connector — stretches to that height and visually spans the
+    // gap down to the next row's icon. The margin is also part of the measured
+    // row height: `measureElement` measures the wrapper around this whole flex
+    // row, and a descendant flex item's margin counts toward that wrapper's
+    // border box, so absolutely-positioned rows don't overlap.
+    <div className="relative flex gap-3">
       {/* Left: icon node + connector line */}
       <div className="flex flex-col items-center">
         <div
@@ -228,7 +230,7 @@ const TimelineEventRow = memo(function TimelineEventRow({
       </div>
 
       {/* Right: content card */}
-      <div className="min-w-0 flex-1 rounded-lg bg-[var(--surface-overlay)] px-4 py-3">
+      <div className="mb-4 min-w-0 flex-1 rounded-lg bg-[var(--surface-overlay)] px-4 py-3">
         <Typography
           variant="body-medium-default"
           className="text-[var(--content-default)]"

--- a/clients/web/src/domains/chat/hooks/use-timeline-virtualizer.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-timeline-virtualizer.test.tsx
@@ -3,8 +3,8 @@
  *
  * The pure `computeScrollMargin` is exercised directly (no DOM needed). The
  * hook itself gets a light smoke test: given a scroll-element ref it returns a
- * usable virtualizer object. Heavy DOM-measurement behavior is covered once a
- * consumer wires the hook in a later PR.
+ * usable virtualizer object. Heavy DOM-measurement behavior is covered by the
+ * consumer's tests (`subagent-timeline.test.tsx`).
  */
 import { afterEach, describe, expect, test } from "bun:test";
 import { cleanup, renderHook } from "@testing-library/react";
@@ -12,8 +12,6 @@ import { createRef } from "react";
 
 import {
   computeScrollMargin,
-  DEFAULT_ROW_ESTIMATE,
-  OVERSCAN,
   useTimelineVirtualizer,
 } from "@/domains/chat/hooks/use-timeline-virtualizer";
 
@@ -45,13 +43,6 @@ describe("computeScrollMargin", () => {
     // Container scrolled 200px: the list box top has moved up by 200, so the
     // on-screen gap is -80, but the stable offset within content is 120.
     expect(computeScrollMargin(elAt(-80), elAt(0, 200))).toBe(120);
-  });
-});
-
-describe("module constants", () => {
-  test("expose sane defaults", () => {
-    expect(DEFAULT_ROW_ESTIMATE).toBe(96);
-    expect(OVERSCAN).toBe(6);
   });
 });
 

--- a/clients/web/src/domains/chat/hooks/use-timeline-virtualizer.ts
+++ b/clients/web/src/domains/chat/hooks/use-timeline-virtualizer.ts
@@ -6,8 +6,7 @@
  * panel's own scroll container, not the list itself), dynamic per-row
  * measurement, a header offset via `scrollMargin`, and stable item keys.
  *
- * This is scaffolding — no component consumes it yet. A later PR will mount it
- * inside `subagent-timeline.tsx`. The dependency lands in the lazily-loaded
+ * Consumed by `subagent-timeline.tsx`. The dependency lands in the lazily-loaded
  * subagent-panel chunk (see `chat-content-layout.tsx`), not the main bundle.
  */
 import {
@@ -15,17 +14,17 @@ import {
   useVirtualizer,
   type Virtualizer,
 } from "@tanstack/react-virtual";
-import type { RefObject } from "react";
+import { useLayoutEffect, useState, type RefObject } from "react";
 
 /**
  * Fallback row height (px) used before a row has been measured. A sane guess
  * for a single-line-ish timeline row; real heights are measured on mount via
  * the dynamic `measureElement` so this only affects the initial estimate.
  */
-export const DEFAULT_ROW_ESTIMATE = 96;
+const DEFAULT_ROW_ESTIMATE = 96;
 
 /** Rows to render beyond the visible window, on each side, to mask scrolling. */
-export const OVERSCAN = 6;
+const OVERSCAN = 6;
 
 /**
  * Compute the `scrollMargin` for the virtualizer: the list's top offset within
@@ -52,7 +51,7 @@ export function computeScrollMargin(
   );
 }
 
-export interface UseTimelineVirtualizerParams {
+interface UseTimelineVirtualizerParams {
   /** Number of rows in the timeline. */
   count: number;
   /** Ref to the scroll container (the element that actually scrolls). */
@@ -61,8 +60,6 @@ export interface UseTimelineVirtualizerParams {
   listRef?: RefObject<HTMLElement | null>;
   /** Stable key for a row index, so measurements survive reorders. */
   getItemKey: (index: number) => string;
-  /** Initial per-row height guess (px); defaults to {@link DEFAULT_ROW_ESTIMATE}. */
-  estimateSize?: number;
 }
 
 /**
@@ -75,15 +72,36 @@ export function useTimelineVirtualizer({
   scrollRef,
   listRef,
   getItemKey,
-  estimateSize,
 }: UseTimelineVirtualizerParams): Virtualizer<HTMLElement, HTMLElement> {
+  // Resolve `scrollMargin` in a layout effect (not during render): it reads
+  // layout via `getBoundingClientRect`, and doing that on every render would
+  // force a synchronous reflow each scroll frame in a component whose whole
+  // point is rendering performance. Captured into state on mount and whenever
+  // the scroll/list elements resize, so the first committed paint already uses
+  // the correct offset instead of 0.
+  const [scrollMargin, setScrollMargin] = useState(0);
+  useLayoutEffect(() => {
+    const recompute = () =>
+      setScrollMargin(computeScrollMargin(listRef?.current ?? null, scrollRef.current));
+    recompute();
+    const scrollEl = scrollRef.current;
+    if (!scrollEl || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(recompute);
+    observer.observe(scrollEl);
+    const listEl = listRef?.current;
+    if (listEl) observer.observe(listEl);
+    return () => observer.disconnect();
+    // `count` is included so the margin recomputes when the list mounts/changes
+    // (e.g. the empty-state → populated transition mounts the list element).
+  }, [scrollRef, listRef, count]);
+
   return useVirtualizer<HTMLElement, HTMLElement>({
     count,
     getScrollElement: () => scrollRef.current,
     getItemKey,
-    estimateSize: () => estimateSize ?? DEFAULT_ROW_ESTIMATE,
+    estimateSize: () => DEFAULT_ROW_ESTIMATE,
     measureElement,
     overscan: OVERSCAN,
-    scrollMargin: computeScrollMargin(listRef?.current ?? null, scrollRef.current),
+    scrollMargin,
   });
 }


### PR DESCRIPTION
## Summary
Addresses self-review findings on the virtualization feature branch:
- **Connector regression (Pass 3):** revert the inter-row gap from `pb-4`-on-container back to the card's `mb-4`. The card is a flex item, so its margin grows the flex line's cross-size — the `flex-1` connector spans the gap to the next icon AND the margin is included in the measured row height (the measured wrapper contains the whole flex row), so rows don't overlap. (The original plan's step 5 was wrong about margins being excluded.)
- **scrollMargin reflow (Pass 3):** compute `scrollMargin` in a `useLayoutEffect` into state (recomputed on resize) instead of calling `getBoundingClientRect` during render — avoids a forced reflow every render and a first-paint origin shift.
- **Slop (Pass 4):** present-tense comments (no more "scaffolding/later PR"); drop the unused `estimateSize` param; make `DEFAULT_ROW_ESTIMATE`/`OVERSCAN`/`UseTimelineVirtualizerParams` module-local and remove the tautological constants test; un-export the test harness's internal constants and drop its unused `rowHeight` param.

Tests: hook + timeline + perf all green; ESLint 0 errors; tsc clean.

Part of plan: virtualize-subagent-timeline.md (self-review remediation)