### PR TITLE
perf(web): virtualize the subagent detail panel timeline (Phase 5)

### DIFF
--- a/clients/web/bun.lock
+++ b/clients/web/bun.lock
@@ -32,6 +32,7 @@
         "@stripe/react-stripe-js": "6.4.0",
         "@stripe/stripe-js": "9.6.0",
         "@tanstack/react-query": "5.90.21",
+        "@tanstack/react-virtual": "^3.14.3",
         "@tiptap/core": "3.23.5",
         "@tiptap/extension-bubble-menu": "3.23.5",
         "@tiptap/extension-link": "3.23.5",
@@ -653,6 +654,10 @@
     "@tanstack/query-core": ["@tanstack/query-core@5.90.20", "", {}, "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg=="],
 
     "@tanstack/react-query": ["@tanstack/react-query@5.90.21", "", { "dependencies": { "@tanstack/query-core": "5.90.20" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg=="],
+
+    "@tanstack/react-virtual": ["@tanstack/react-virtual@3.14.3", "", { "dependencies": { "@tanstack/virtual-core": "3.17.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-k/cnHPVaOfn46hSbiY6n4Dzf4QjCGWSF40zR5QIIYUqPAjpA6TN7InfYmcMiDVQGP2iUn9xsRbAl8u1v3UmeVQ=="],
+
+    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.17.1", "", {}, "sha512-VZyW2Uiml5tmBZwPGrSD3Sz73OxzljQMCmzYHsUTPEuTsERf5xwa+uWb01xEzkz3ZSYTjj8NEb/mKHvgKxyZdA=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 

--- a/clients/web/bun.lock
+++ b/clients/web/bun.lock
@@ -32,7 +32,7 @@
         "@stripe/react-stripe-js": "6.4.0",
         "@stripe/stripe-js": "9.6.0",
         "@tanstack/react-query": "5.90.21",
-        "@tanstack/react-virtual": "^3.14.3",
+        "@tanstack/react-virtual": "3.14.3",
         "@tiptap/core": "3.23.5",
         "@tiptap/extension-bubble-menu": "3.23.5",
         "@tiptap/extension-link": "3.23.5",

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -55,7 +55,7 @@
     "@stripe/react-stripe-js": "6.4.0",
     "@stripe/stripe-js": "9.6.0",
     "@tanstack/react-query": "5.90.21",
-    "@tanstack/react-virtual": "^3.14.3",
+    "@tanstack/react-virtual": "3.14.3",
     "@tiptap/core": "3.23.5",
     "@tiptap/extension-bubble-menu": "3.23.5",
     "@tiptap/extension-link": "3.23.5",

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -55,6 +55,7 @@
     "@stripe/react-stripe-js": "6.4.0",
     "@stripe/stripe-js": "9.6.0",
     "@tanstack/react-query": "5.90.21",
+    "@tanstack/react-virtual": "^3.14.3",
     "@tiptap/core": "3.23.5",
     "@tiptap/extension-bubble-menu": "3.23.5",
     "@tiptap/extension-link": "3.23.5",

--- a/clients/web/src/domains/chat/components/__fixtures__/subagent-timeline-fixtures.ts
+++ b/clients/web/src/domains/chat/components/__fixtures__/subagent-timeline-fixtures.ts
@@ -1,0 +1,125 @@
+/**
+ * Synthetic-load fixtures for the subagent timeline.
+ *
+ * `makeSyntheticEvents(count)` produces a realistic, *deterministic* mix of
+ * timeline events for perf/load testing. There is intentionally NO
+ * `Math.random()` — every bit of variety is derived from the event index so
+ * runs are reproducible and diffable.
+ *
+ * Event mix (by index, repeating every 20 events):
+ *   ~40% tool_call   — long file-path / URL `content` + a `toolName`
+ *   ~40% tool_result — multi-line `content` (> MAX_COLLAPSED_LINES=4 lines so
+ *                      the timeline's "Show more" path is exercised); every
+ *                      3rd one is `isError: true`
+ *   ~15% text        — short response text
+ *    ~5% error       — an error line
+ *
+ * Ids mirror the store's `generateTimelineEventId` (`te-${n}`, 1-based), and
+ * timestamps are monotonic. Kept general + exported for reuse by later PRs.
+ */
+
+import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
+
+/** Sample tool names cycled through for `tool_call` events. */
+const TOOL_NAMES = [
+  "Read",
+  "Edit",
+  "Bash",
+  "Grep",
+  "Write",
+  "WebFetch",
+] as const;
+
+/**
+ * Long, unbreakable-ish content (file paths / URLs) for `tool_call` events —
+ * the kind of content the timeline must wrap rather than clip.
+ */
+const LONG_PATHS = [
+  "/workspaces/worktrees/p3-fixup-fork/clients/web/src/domains/channel/handler-inbound-admission.test.ts",
+  "https://example.com/api/v2/organizations/acme-corp/workspaces/default/agents/subagent-timeline/runs?cursor=eyJpZCI6MTIzNDV9",
+  "/Users/runner/work/vellum-assistant/vellum-assistant/clients/web/src/domains/chat/components/subagent-timeline.tsx",
+  "packages/service-contracts/src/schemas/ces/streaming/subagent-inner-event.schema.ts",
+] as const;
+
+/**
+ * Classify an event index into one of the four event types, distributing the
+ * target mix deterministically across each block of 20 events.
+ *
+ * Slots 0–7   -> tool_call   (8/20 = 40%)
+ * Slots 8–15  -> tool_result (8/20 = 40%)
+ * Slots 16–18 -> text        (3/20 = 15%)
+ * Slot  19    -> error       (1/20 = 5%)
+ */
+function typeForIndex(index: number): SubagentTimelineEvent["type"] {
+  const slot = index % 20;
+  if (slot < 8) return "tool_call";
+  if (slot < 16) return "tool_result";
+  if (slot < 19) return "text";
+  return "error";
+}
+
+/** Build a multi-line tool_result body with > 4 lines (trips MAX_COLLAPSED_LINES). */
+function multiLineResult(index: number): string {
+  const lineCount = 5 + (index % 4); // 5..8 lines, always > 4
+  const lines: string[] = [];
+  for (let line = 0; line < lineCount; line++) {
+    lines.push(`line ${line + 1} of tool result #${index} :: token-${index}-${line}`);
+  }
+  return lines.join("\n");
+}
+
+/** Build a single synthetic event for a 0-based index. */
+function makeEvent(index: number): SubagentTimelineEvent {
+  const type = typeForIndex(index);
+  const id = `te-${index + 1}`;
+  const timestamp = index; // monotonic
+
+  switch (type) {
+    case "tool_call":
+      return {
+        id,
+        type,
+        content: LONG_PATHS[index % LONG_PATHS.length],
+        toolName: TOOL_NAMES[index % TOOL_NAMES.length],
+        timestamp,
+      };
+    case "tool_result":
+      return {
+        id,
+        type,
+        content: multiLineResult(index),
+        // Every 3rd tool_result is an error.
+        isError: index % 3 === 0,
+        toolName: TOOL_NAMES[index % TOOL_NAMES.length],
+        toolUseId: `tu-${index + 1}`,
+        timestamp,
+      };
+    case "text":
+      return {
+        id,
+        type,
+        content: `Synthetic response text for event #${index}.`,
+        timestamp,
+      };
+    case "error":
+      return {
+        id,
+        type,
+        content: `Synthetic error #${index}: something went wrong in step ${index}.`,
+        timestamp,
+      };
+  }
+}
+
+/**
+ * Produce `count` deterministic synthetic timeline events.
+ *
+ * @param count Number of events to generate (>= 0).
+ */
+export function makeSyntheticEvents(count: number): SubagentTimelineEvent[] {
+  const events: SubagentTimelineEvent[] = [];
+  for (let index = 0; index < count; index++) {
+    events.push(makeEvent(index));
+  }
+  return events;
+}

--- a/clients/web/src/domains/chat/components/__fixtures__/subagent-timeline-fixtures.ts
+++ b/clients/web/src/domains/chat/components/__fixtures__/subagent-timeline-fixtures.ts
@@ -15,7 +15,8 @@
  *    ~5% error       — an error line
  *
  * Ids mirror the store's `generateTimelineEventId` (`te-${n}`, 1-based), and
- * timestamps are monotonic. Kept general + exported for reuse by later PRs.
+ * timestamps are monotonic. Shared by `subagent-timeline.test.tsx` and
+ * `subagent-timeline.perf.test.tsx`.
  */
 
 import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";

--- a/clients/web/src/domains/chat/components/__fixtures__/subagent-timeline-harness.tsx
+++ b/clients/web/src/domains/chat/components/__fixtures__/subagent-timeline-harness.tsx
@@ -1,0 +1,94 @@
+/**
+ * Shared test harness for the virtualized subagent timeline.
+ *
+ * `@tanstack/react-virtual` measures each row via `offsetHeight` and derives the
+ * viewport from the scroll element's `offsetHeight`; jsdom/happy-dom report 0 for
+ * all layout, so without stubs every row collapses to 0px and the virtualizer
+ * over-fills the viewport. This module centralizes the two workarounds both
+ * timeline test files need:
+ *   - `installRowHeightStub()` — a fixed per-row `offsetHeight` on the prototype,
+ *     wired into `beforeAll`/`afterAll`.
+ *   - `TimelineHarness` — renders the timeline against a scroll container whose
+ *     height is stubbed. The scroll element lives in this parent while the
+ *     virtualizer's mount effect runs in the child (which fires before the
+ *     parent's ref attaches), so the node is held in state: attaching it
+ *     re-renders, letting the virtualizer re-read a now-populated `scrollRef`.
+ */
+
+import { useMemo, useState } from "react";
+
+import { afterAll, beforeAll } from "bun:test";
+import type { screen } from "@testing-library/react";
+
+import { SubagentTimeline } from "@/domains/chat/components/subagent-timeline";
+import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
+
+/** Default per-row height (px); mirrors the hook's `DEFAULT_ROW_ESTIMATE`. */
+export const ROW_HEIGHT = 96;
+
+/** Per-event card titles, one per (non-filtered) event. */
+export const ROW_TITLES = ["Response", "Tool Call", "Tool Result", "Error"];
+
+/** Count rendered timeline rows by summing every per-event title occurrence. */
+export function renderedRowCount(screenApi: typeof screen): number {
+  return ROW_TITLES.reduce(
+    (total, title) => total + screenApi.queryAllByText(title).length,
+    0,
+  );
+}
+
+/**
+ * Stub `HTMLElement.prototype.offsetHeight` to a fixed row height for the
+ * duration of the suite, restoring the original descriptor afterwards. Call at
+ * the top level of a `describe` (or file).
+ */
+export function installRowHeightStub(rowHeight = ROW_HEIGHT): void {
+  let original: PropertyDescriptor | undefined;
+  beforeAll(() => {
+    original = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "offsetHeight",
+    );
+    Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+      configurable: true,
+      get() {
+        return rowHeight;
+      },
+    });
+  });
+  afterAll(() => {
+    if (original) {
+      Object.defineProperty(HTMLElement.prototype, "offsetHeight", original);
+    } else {
+      delete (HTMLElement.prototype as unknown as Record<string, unknown>)
+        .offsetHeight;
+    }
+  });
+}
+
+/** Render the timeline against a scroll container with a stubbed viewport height. */
+export function TimelineHarness({
+  events,
+  viewportHeight = 800,
+}: {
+  events: SubagentTimelineEvent[];
+  viewportHeight?: number;
+}) {
+  const [node, setNode] = useState<HTMLDivElement | null>(null);
+  const setRef = (el: HTMLDivElement | null) => {
+    if (el) {
+      Object.defineProperty(el, "offsetHeight", {
+        configurable: true,
+        value: viewportHeight,
+      });
+    }
+    setNode(el);
+  };
+  // Stable ref-shaped object whose `.current` tracks the attached node.
+  const scrollRef = useMemo(() => ({ current: node }), [node]);
+  return (
+    <div ref={setRef} style={{ height: viewportHeight, overflowY: "auto" }}>
+      <SubagentTimeline scrollRef={scrollRef} events={events} />
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/__fixtures__/subagent-timeline-harness.tsx
+++ b/clients/web/src/domains/chat/components/__fixtures__/subagent-timeline-harness.tsx
@@ -23,11 +23,11 @@ import type { screen } from "@testing-library/react";
 import { SubagentTimeline } from "@/domains/chat/components/subagent-timeline";
 import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
 
-/** Default per-row height (px); mirrors the hook's `DEFAULT_ROW_ESTIMATE`. */
-export const ROW_HEIGHT = 96;
+/** Default per-row height (px); mirrors the hook's row-height estimate. */
+const ROW_HEIGHT = 96;
 
 /** Per-event card titles, one per (non-filtered) event. */
-export const ROW_TITLES = ["Response", "Tool Call", "Tool Result", "Error"];
+const ROW_TITLES = ["Response", "Tool Call", "Tool Result", "Error"];
 
 /** Count rendered timeline rows by summing every per-event title occurrence. */
 export function renderedRowCount(screenApi: typeof screen): number {
@@ -42,7 +42,7 @@ export function renderedRowCount(screenApi: typeof screen): number {
  * duration of the suite, restoring the original descriptor afterwards. Call at
  * the top level of a `describe` (or file).
  */
-export function installRowHeightStub(rowHeight = ROW_HEIGHT): void {
+export function installRowHeightStub(): void {
   let original: PropertyDescriptor | undefined;
   beforeAll(() => {
     original = Object.getOwnPropertyDescriptor(
@@ -52,7 +52,7 @@ export function installRowHeightStub(rowHeight = ROW_HEIGHT): void {
     Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
       configurable: true,
       get() {
-        return rowHeight;
+        return ROW_HEIGHT;
       },
     });
   });

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -198,12 +198,12 @@ export function SubagentDetailPanel({
   // Compute the avatar traits once per subagent instead of hashing the id
   // three separate times in the JSX below.
   const traits = useMemo(() => subagentTraits(entry.subagentId), [entry.subagentId]);
-  // The timeline renders `entry.events` directly (no `useDeferredValue`).
-  // Virtualization already bounds each render to the visible window, so the
-  // heavy full-list render that deferral once hid no longer exists. Deferring
-  // here would only re-introduce a failure mode: under sustained high-frequency
-  // streaming the low-priority deferred render keeps getting preempted and never
-  // commits, freezing the timeline on a stale snapshot until the stream slows.
+  // The timeline reads `entry.events` directly. Virtualization bounds each
+  // render to the visible window, so there is no expensive full-list render to
+  // defer. A `useDeferredValue` here is counterproductive: under sustained
+  // high-frequency streaming its low-priority render keeps getting preempted and
+  // never commits, freezing the timeline on a stale snapshot until the stream
+  // slows.
 
   useEffect(() => {
     if (onRequestDetail && entry.conversationId && entry.events.length === 0) {
@@ -317,12 +317,12 @@ export function SubagentDetailPanel({
             Timeline
           </Typography>
           {/*
-           * Key by subagent id so the timeline (which now owns lifted
-           * expand/collapse state) remounts on subagent switch. Fetched
-           * detail event ids are renumbered per subagent (detail-1, detail-2,
-           * …) and the drawer keeps this component mounted across switches, so
-           * without a per-subagent reset an expanded `detail-N` would leak its
-           * expanded state onto the next subagent's `detail-N`.
+           * Key by subagent id so the timeline remounts on subagent switch,
+           * resetting the expand/collapse state it holds. Fetched detail event
+           * ids are renumbered per subagent (detail-1, detail-2, …) and the
+           * drawer keeps this component mounted across switches, so without a
+           * per-subagent reset an expanded `detail-N` would leak its expanded
+           * state onto the next subagent's `detail-N`.
            */}
           <SubagentTimeline
             key={entry.subagentId}

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -9,7 +9,6 @@ import {
 
 import {
   type ReactNode,
-  useDeferredValue,
   useEffect,
   useMemo,
   useRef,
@@ -199,22 +198,12 @@ export function SubagentDetailPanel({
   // Compute the avatar traits once per subagent instead of hashing the id
   // three separate times in the JSX below.
   const traits = useMemo(() => subagentTraits(entry.subagentId), [entry.subagentId]);
-  // Defer the timeline's events so heavy streaming updates render at low
-  // priority (interruptible) and never block the panel-open animation or
-  // input. The memoized SubagentTimeline bails out on the urgent pass.
-  //
-  // The deferred value carries the subagent id alongside the events. The
-  // drawer stays mounted across subagent switches, so a bare deferred value
-  // can lag and render the previous subagent's timeline under the new
-  // subagent's header; when the deferred id doesn't match the current
-  // subagent, fall back to live events so the timeline is never mismatched.
-  const deferredInput = useMemo(
-    () => ({ id: entry.subagentId, events: entry.events }),
-    [entry.subagentId, entry.events],
-  );
-  const deferred = useDeferredValue(deferredInput);
-  const timelineEvents =
-    deferred.id === entry.subagentId ? deferred.events : entry.events;
+  // The timeline renders `entry.events` directly (no `useDeferredValue`).
+  // Virtualization already bounds each render to the visible window, so the
+  // heavy full-list render that deferral once hid no longer exists. Deferring
+  // here would only re-introduce a failure mode: under sustained high-frequency
+  // streaming the low-priority deferred render keeps getting preempted and never
+  // commits, freezing the timeline on a stale snapshot until the stream slows.
 
   useEffect(() => {
     if (onRequestDetail && entry.conversationId && entry.events.length === 0) {
@@ -338,7 +327,7 @@ export function SubagentDetailPanel({
           <SubagentTimeline
             key={entry.subagentId}
             scrollRef={scrollRef}
-            events={timelineEvents}
+            events={entry.events}
           />
         </div>
       </div>

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -222,6 +222,11 @@ export function SubagentDetailPanel({
     }
   }, [entry.subagentId, entry.conversationId, entry.events.length, onRequestDetail]);
 
+  // The scroll container forwarded to the virtualized timeline: the timeline
+  // virtualizes against this *external* scroll element (the panel body) rather
+  // than its own list, so the metrics/objective header scrolls with the rows.
+  const scrollRef = useRef<HTMLDivElement>(null);
+
   return (
     <div className="flex h-full flex-col overflow-hidden rounded-xl bg-[var(--surface-lift)]">
       {/* Header */}
@@ -270,7 +275,7 @@ export function SubagentDetailPanel({
       </div>
 
       {/* Scrollable body */}
-      <div className="flex-1 overflow-y-auto px-5 py-5">
+      <div ref={scrollRef} className="flex-1 overflow-y-auto px-5 py-5">
         {/* Metrics row */}
         <div className="mb-5 grid grid-cols-3 gap-3">
           <AnimatedMetricCard
@@ -330,7 +335,11 @@ export function SubagentDetailPanel({
            * without a per-subagent reset an expanded `detail-N` would leak its
            * expanded state onto the next subagent's `detail-N`.
            */}
-          <SubagentTimeline key={entry.subagentId} events={timelineEvents} />
+          <SubagentTimeline
+            key={entry.subagentId}
+            scrollRef={scrollRef}
+            events={timelineEvents}
+          />
         </div>
       </div>
     </div>

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -322,7 +322,15 @@ export function SubagentDetailPanel({
           >
             Timeline
           </Typography>
-          <SubagentTimeline events={timelineEvents} />
+          {/*
+           * Key by subagent id so the timeline (which now owns lifted
+           * expand/collapse state) remounts on subagent switch. Fetched
+           * detail event ids are renumbered per subagent (detail-1, detail-2,
+           * …) and the drawer keeps this component mounted across switches, so
+           * without a per-subagent reset an expanded `detail-N` would leak its
+           * expanded state onto the next subagent's `detail-N`.
+           */}
+          <SubagentTimeline key={entry.subagentId} events={timelineEvents} />
         </div>
       </div>
     </div>

--- a/clients/web/src/domains/chat/components/subagent-timeline.perf.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-timeline.perf.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * Synthetic-load perf baseline for the subagent timeline.
+ *
+ * Renders the CURRENT timeline (memo + `content-visibility:auto` renders-all)
+ * at N = 50 / 150 / 300 events using the deterministic synthetic fixture, and:
+ *   - asserts every event produces a rendered row (structural correctness), and
+ *   - logs a wall-clock render delta per N as an ADVISORY signal.
+ *
+ * The timings are intentionally NEVER asserted — JS-DOM wall-clock numbers are
+ * noisy and machine-dependent. Authoritative numbers come from the manual
+ * React DevTools Profiler protocol documented in the PR body. This file just
+ * pins the structural baseline that virtualization (a later PR) must preserve.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { makeSyntheticEvents } from "@/domains/chat/components/__fixtures__/subagent-timeline-fixtures";
+import { SubagentTimeline } from "@/domains/chat/components/subagent-timeline";
+
+/** Per-event card titles the timeline renders, one per (non-filtered) event. */
+const ROW_TITLES = ["Response", "Tool Call", "Tool Result", "Error"];
+
+/** Count rendered rows by summing every per-event title occurrence. */
+function renderedRowCount(): number {
+  return ROW_TITLES.reduce(
+    (total, title) => total + screen.queryAllByText(title).length,
+    0,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SubagentTimeline — synthetic-load perf baseline", () => {
+  for (const eventCount of [50, 150, 300]) {
+    test(`renders all ${eventCount} events`, () => {
+      const events = makeSyntheticEvents(eventCount);
+
+      const start = performance.now();
+      render(<SubagentTimeline events={events} />);
+      const elapsedMs = performance.now() - start;
+
+      // Advisory only — never asserted.
+      console.log(
+        `[perf] SubagentTimeline N=${eventCount} render=${elapsedMs.toFixed(2)}ms`,
+      );
+
+      // The fixture emits only non-empty events, so none are filtered out:
+      // every event must produce exactly one row.
+      expect(renderedRowCount()).toBe(eventCount);
+    });
+  }
+});

--- a/clients/web/src/domains/chat/components/subagent-timeline.perf.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-timeline.perf.test.tsx
@@ -1,55 +1,61 @@
 /**
- * Synthetic-load perf baseline for the subagent timeline.
+ * Synthetic-load perf signal for the (now virtualized) subagent timeline.
  *
- * Renders the CURRENT timeline (memo + `content-visibility:auto` renders-all)
- * at N = 50 / 150 / 300 events using the deterministic synthetic fixture, and:
- *   - asserts every event produces a rendered row (structural correctness), and
+ * Renders the timeline at N = 50 / 150 / 300 events using the deterministic
+ * synthetic fixture, and:
+ *   - asserts the list is WINDOWED — only O(window) rows are mounted, not all N,
+ *     while `getTotalSize`-driven layout still reserves space for the full list
+ *     (the spacer's pixel height grows with N), and
  *   - logs a wall-clock render delta per N as an ADVISORY signal.
  *
  * The timings are intentionally NEVER asserted — JS-DOM wall-clock numbers are
  * noisy and machine-dependent. Authoritative numbers come from the manual
- * React DevTools Profiler protocol documented in the PR body. This file just
- * pins the structural baseline that virtualization (a later PR) must preserve.
+ * React DevTools Profiler protocol documented in the PR body.
+ *
+ * The shared harness stubs a fixed per-row height plus the scroll-container
+ * height so the virtualizer has a real viewport in jsdom/happy-dom (which report
+ * 0 for all layout); the number of mounted rows then stays a small O(viewport)
+ * constant regardless of N.
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
 import { cleanup, render, screen } from "@testing-library/react";
 
 import { makeSyntheticEvents } from "@/domains/chat/components/__fixtures__/subagent-timeline-fixtures";
-import { SubagentTimeline } from "@/domains/chat/components/subagent-timeline";
+import {
+  installRowHeightStub,
+  renderedRowCount,
+  TimelineHarness,
+} from "@/domains/chat/components/__fixtures__/subagent-timeline-harness";
 
-/** Per-event card titles the timeline renders, one per (non-filtered) event. */
-const ROW_TITLES = ["Response", "Tool Call", "Tool Result", "Error"];
+/** Viewport small enough to keep the window a tight handful of rows. */
+const VIEWPORT_HEIGHT = 300;
 
-/** Count rendered rows by summing every per-event title occurrence. */
-function renderedRowCount(): number {
-  return ROW_TITLES.reduce(
-    (total, title) => total + screen.queryAllByText(title).length,
-    0,
-  );
-}
+installRowHeightStub();
 
 afterEach(() => {
   cleanup();
 });
 
-describe("SubagentTimeline — synthetic-load perf baseline", () => {
+describe("SubagentTimeline — synthetic-load windowing signal", () => {
   for (const eventCount of [50, 150, 300]) {
-    test(`renders all ${eventCount} events`, () => {
+    test(`windows ${eventCount} events to a small row count`, () => {
       const events = makeSyntheticEvents(eventCount);
 
       const start = performance.now();
-      render(<SubagentTimeline events={events} />);
+      render(<TimelineHarness events={events} viewportHeight={VIEWPORT_HEIGHT} />);
       const elapsedMs = performance.now() - start;
+      const rows = renderedRowCount(screen);
 
       // Advisory only — never asserted.
       console.log(
-        `[perf] SubagentTimeline N=${eventCount} render=${elapsedMs.toFixed(2)}ms`,
+        `[perf] SubagentTimeline N=${eventCount} render=${elapsedMs.toFixed(2)}ms rows=${rows}`,
       );
 
-      // The fixture emits only non-empty events, so none are filtered out:
-      // every event must produce exactly one row.
-      expect(renderedRowCount()).toBe(eventCount);
+      // Virtualization mounts only a window of rows, not all N: a non-zero
+      // handful (guarding against a vacuous pass) that stays far below 300.
+      expect(rows).toBeGreaterThan(0);
+      expect(rows).toBeLessThan(60);
     });
   }
 });

--- a/clients/web/src/domains/chat/components/subagent-timeline.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-timeline.test.tsx
@@ -12,8 +12,26 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
-import { SubagentTimeline } from "@/domains/chat/components/subagent-timeline";
+import { makeSyntheticEvents } from "@/domains/chat/components/__fixtures__/subagent-timeline-fixtures";
+import {
+  installRowHeightStub,
+  renderedRowCount,
+  TimelineHarness,
+} from "@/domains/chat/components/__fixtures__/subagent-timeline-harness";
 import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
+
+// jsdom/happy-dom report 0 for all layout; give rows a fixed measured height so
+// the virtualizer forms a real window (see the harness module for details).
+installRowHeightStub();
+
+function renderTimeline(
+  events: SubagentTimelineEvent[],
+  viewportHeight = 800,
+) {
+  return render(
+    <TimelineHarness events={events} viewportHeight={viewportHeight} />,
+  );
+}
 
 const LONG_PATH =
   "/workspaces/worktrees/p3-fixup-fork/clients/web/src/domains/channel/handler-inbound-admission.test.ts";
@@ -55,7 +73,7 @@ afterEach(() => {
 
 describe("SubagentTimeline — tool_call content wrapping", () => {
   test("long content carries wrapping classes so it can't overflow the card", () => {
-    render(<SubagentTimeline events={[toolCallEvent()]} />);
+    renderTimeline([toolCallEvent()]);
 
     const content = screen.getByText(LONG_PATH);
     expect(content.className).toContain("min-w-0");
@@ -64,7 +82,7 @@ describe("SubagentTimeline — tool_call content wrapping", () => {
 
   test("tool name carries wrapping classes too", () => {
     const longName = "some_extremely_long_tool_name_identifier_that_could_overflow";
-    render(<SubagentTimeline events={[toolCallEvent({ toolName: longName })]} />);
+    renderTimeline([toolCallEvent({ toolName: longName })]);
 
     const name = screen.getByText(longName);
     expect(name.className).toContain("min-w-0");
@@ -76,7 +94,7 @@ describe("SubagentTimeline — expand state keyed by event.id", () => {
   test("expanding one row, then toggling another, leaves the first expanded", () => {
     const first = toolResultEvent({ id: "evt-a", content: longLines("a") });
     const second = toolResultEvent({ id: "evt-b", content: longLines("b") });
-    render(<SubagentTimeline events={[first, second]} />);
+    renderTimeline([first, second]);
 
     // Both rows start collapsed.
     const toggles = screen.getAllByText("Show more");
@@ -98,5 +116,17 @@ describe("SubagentTimeline — expand state keyed by event.id", () => {
     expect(screen.getAllByText("Show less")).toHaveLength(2);
     expect(screen.getByText(/a line 7/)).toBeDefined();
     expect(screen.getByText(/b line 7/)).toBeDefined();
+  });
+});
+
+describe("SubagentTimeline — virtualization windows the list", () => {
+  test("mounts only a window of rows for a large list, not all of them", () => {
+    // A 300px viewport over ~96px rows windows to a handful of rows + overscan,
+    // so far fewer than all 300 events are in the DOM.
+    renderTimeline(makeSyntheticEvents(300), 300);
+
+    const rendered = renderedRowCount(screen);
+    expect(rendered).toBeGreaterThan(0); // guard: not a vacuous pass
+    expect(rendered).toBeLessThan(60);
   });
 });

--- a/clients/web/src/domains/chat/components/subagent-timeline.test.tsx
+++ b/clients/web/src/domains/chat/components/subagent-timeline.test.tsx
@@ -10,7 +10,7 @@
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 import { SubagentTimeline } from "@/domains/chat/components/subagent-timeline";
 import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
@@ -26,6 +26,24 @@ function toolCallEvent(
     type: "tool_call",
     content: LONG_PATH,
     toolName: "Read",
+    timestamp: 0,
+    ...overrides,
+  };
+}
+
+/** Multi-line content that exceeds the collapsed line limit, so the row
+ *  renders a collapsible "Show more" affordance. */
+function longLines(label: string): string {
+  return Array.from({ length: 8 }, (_, i) => `${label} line ${i}`).join("\n");
+}
+
+function toolResultEvent(
+  overrides: Partial<SubagentTimelineEvent> = {},
+): SubagentTimelineEvent {
+  return {
+    id: "evt-result",
+    type: "tool_result",
+    content: longLines("result"),
     timestamp: 0,
     ...overrides,
   };
@@ -51,5 +69,34 @@ describe("SubagentTimeline — tool_call content wrapping", () => {
     const name = screen.getByText(longName);
     expect(name.className).toContain("min-w-0");
     expect(name.className).toContain("break-words");
+  });
+});
+
+describe("SubagentTimeline — expand state keyed by event.id", () => {
+  test("expanding one row, then toggling another, leaves the first expanded", () => {
+    const first = toolResultEvent({ id: "evt-a", content: longLines("a") });
+    const second = toolResultEvent({ id: "evt-b", content: longLines("b") });
+    render(<SubagentTimeline events={[first, second]} />);
+
+    // Both rows start collapsed.
+    const toggles = screen.getAllByText("Show more");
+    expect(toggles).toHaveLength(2);
+
+    // Expand the first row.
+    fireEvent.click(toggles[0]!);
+
+    // First is now expanded ("Show less"), second still collapsed.
+    expect(screen.getByText("Show less")).toBeDefined();
+    expect(screen.getByText("Show more")).toBeDefined();
+    // The first row's last line is only visible once expanded.
+    expect(screen.getByText(/a line 7/)).toBeDefined();
+
+    // Toggle the second row (it's the remaining "Show more").
+    fireEvent.click(screen.getByText("Show more"));
+
+    // The first row's expansion must be unaffected — both now expanded.
+    expect(screen.getAllByText("Show less")).toHaveLength(2);
+    expect(screen.getByText(/a line 7/)).toBeDefined();
+    expect(screen.getByText(/b line 7/)).toBeDefined();
   });
 });

--- a/clients/web/src/domains/chat/components/subagent-timeline.tsx
+++ b/clients/web/src/domains/chat/components/subagent-timeline.tsx
@@ -5,7 +5,7 @@ import {
     TriangleAlert,
     Wrench,
 } from "lucide-react";
-import { memo, useMemo, useState } from "react";
+import { memo, useCallback, useMemo, useState } from "react";
 
 import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
 import { Typography } from "@vellumai/design-library";
@@ -131,8 +131,20 @@ function eventTitle(event: SubagentTimelineEvent): string {
 // Collapsible text content
 // ---------------------------------------------------------------------------
 
-function CollapsibleContent({ content }: { content: string }) {
-  const [expanded, setExpanded] = useState(false);
+/**
+ * Controlled collapsible text. Expand state is owned by {@link SubagentTimeline}
+ * (keyed by `event.id`) rather than held locally here, so it survives this
+ * component unmounting/remounting — the precondition for virtualizing the list.
+ */
+function CollapsibleContent({
+  content,
+  expanded,
+  onToggle,
+}: {
+  content: string;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
   const hasLongContent = isContentLong(content);
   const displayContent = hasLongContent && !expanded
     ? truncateContent(content)
@@ -150,7 +162,7 @@ function CollapsibleContent({ content }: { content: string }) {
       {hasLongContent && (
         <button
           type="button"
-          onClick={() => setExpanded((prev) => !prev)}
+          onClick={onToggle}
           className="mt-1 cursor-pointer hover:underline"
         >
           <Typography variant="body-small-default" className="text-[var(--content-default)]">
@@ -169,9 +181,18 @@ function CollapsibleContent({ content }: { content: string }) {
 const TimelineEventRow = memo(function TimelineEventRow({
   event,
   isLast,
+  expanded,
+  toggleExpand,
 }: {
   event: SubagentTimelineEvent;
   isLast: boolean;
+  expanded: boolean;
+  /**
+   * Stable across renders (see {@link SubagentTimeline}), so passing it through
+   * `memo` doesn't defeat the row's bail-out. The per-row closure is bound at
+   * the call site below rather than by the parent, to keep this prop stable.
+   */
+  toggleExpand: (id: string) => void;
 }) {
   return (
     // `content-visibility: auto` lets the browser skip layout/paint for rows
@@ -235,7 +256,11 @@ const TimelineEventRow = memo(function TimelineEventRow({
                 {event.content}
               </Typography>
             ) : (
-              <CollapsibleContent content={event.content} />
+              <CollapsibleContent
+                content={event.content}
+                expanded={expanded}
+                onToggle={() => toggleExpand(event.id)}
+              />
             )}
           </div>
         )}
@@ -270,6 +295,23 @@ export const SubagentTimeline = memo(function SubagentTimeline({
 }: SubagentTimelineProps) {
   const filteredEvents = useMemo(() => filterEvents(events), [events]);
 
+  // Expand/collapse state lives here, keyed by `event.id`, so it survives a row
+  // unmounting and remounting (e.g. when the list is virtualized). `toggleExpand`
+  // is stable across renders so it can be passed through the `memo`'d row without
+  // defeating its bail-out.
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(() => new Set());
+  const toggleExpand = useCallback((id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
   if (filteredEvents.length === 0) {
     return (
       <Typography
@@ -288,6 +330,8 @@ export const SubagentTimeline = memo(function SubagentTimeline({
           key={event.id}
           event={event}
           isLast={index === filteredEvents.length - 1}
+          expanded={expandedIds.has(event.id)}
+          toggleExpand={toggleExpand}
         />
       ))}
     </div>

--- a/clients/web/src/domains/chat/components/subagent-timeline.tsx
+++ b/clients/web/src/domains/chat/components/subagent-timeline.tsx
@@ -5,8 +5,10 @@ import {
     TriangleAlert,
     Wrench,
 } from "lucide-react";
-import { memo, useCallback, useMemo, useState } from "react";
+import { memo, useCallback, useMemo, useRef, useState } from "react";
+import type { RefObject } from "react";
 
+import { useTimelineVirtualizer } from "@/domains/chat/hooks/use-timeline-virtualizer";
 import type { SubagentTimelineEvent } from "@/domains/chat/subagent-store";
 import { Typography } from "@vellumai/design-library";
 
@@ -24,6 +26,17 @@ const CONNECTOR_STYLE = {
   backgroundColor: "var(--border-subtle)",
   minHeight: 16,
 };
+
+/**
+ * Constant style fields shared by every absolutely-positioned virtual row; only
+ * the per-row `transform` is spread in at the call site, so these don't get
+ * reallocated per row.
+ */
+const VIRTUAL_ROW_STYLE = {
+  position: "absolute",
+  top: 0,
+  width: "100%",
+} as const;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -195,11 +208,12 @@ const TimelineEventRow = memo(function TimelineEventRow({
   toggleExpand: (id: string) => void;
 }) {
   return (
-    // `content-visibility: auto` lets the browser skip layout/paint for rows
-    // that are off-screen in the panel's scroll container; `contain-intrinsic-
-    // size: auto 72px` reserves a placeholder (and remembers each row's real
-    // size once measured) so the scrollbar doesn't jump.
-    <div className="relative flex gap-3 [content-visibility:auto] [contain-intrinsic-size:auto_72px]">
+    // The inter-row gap lives in this row's `pb-4` padding (not the card's
+    // margin): the virtualizer measures rows via `getBoundingClientRect`, which
+    // excludes margins, so a margin-based gap would make absolutely-positioned
+    // rows overlap. As padding it's part of the measured height, and the
+    // connector's `flex-1` fill still spans through it to the next row.
+    <div className="relative flex gap-3 pb-4">
       {/* Left: icon node + connector line */}
       <div className="flex flex-col items-center">
         <div
@@ -214,7 +228,7 @@ const TimelineEventRow = memo(function TimelineEventRow({
       </div>
 
       {/* Right: content card */}
-      <div className="mb-4 min-w-0 flex-1 rounded-lg bg-[var(--surface-overlay)] px-4 py-3">
+      <div className="min-w-0 flex-1 rounded-lg bg-[var(--surface-overlay)] px-4 py-3">
         <Typography
           variant="body-medium-default"
           className="text-[var(--content-default)]"
@@ -288,15 +302,22 @@ const TimelineEventRow = memo(function TimelineEventRow({
 
 export interface SubagentTimelineProps {
   events: SubagentTimelineEvent[];
+  /**
+   * The panel's scroll container. The list virtualizes against this *external*
+   * element (not its own box) so the metrics/objective header above the list
+   * scrolls together with the rows.
+   */
+  scrollRef: RefObject<HTMLElement | null>;
 }
 
 export const SubagentTimeline = memo(function SubagentTimeline({
   events,
+  scrollRef,
 }: SubagentTimelineProps) {
   const filteredEvents = useMemo(() => filterEvents(events), [events]);
 
   // Expand/collapse state lives here, keyed by `event.id`, so it survives a row
-  // unmounting and remounting (e.g. when the list is virtualized). `toggleExpand`
+  // unmounting and remounting as the virtualizer windows the list. `toggleExpand`
   // is stable across renders so it can be passed through the `memo`'d row without
   // defeating its bail-out.
   const [expandedIds, setExpandedIds] = useState<Set<string>>(() => new Set());
@@ -312,6 +333,22 @@ export const SubagentTimeline = memo(function SubagentTimeline({
     });
   }, []);
 
+  // The list element, used by the virtualizer to offset virtual positions
+  // (`scrollMargin`) relative to the scroll container's content.
+  const listRef = useRef<HTMLDivElement>(null);
+  // Memoized so the virtualizer's options don't churn on every render (e.g.
+  // expand/collapse); only reallocates when the event list itself changes.
+  const getItemKey = useCallback(
+    (index: number) => filteredEvents[index]!.id,
+    [filteredEvents],
+  );
+  const virtualizer = useTimelineVirtualizer({
+    count: filteredEvents.length,
+    scrollRef,
+    listRef,
+    getItemKey,
+  });
+
   if (filteredEvents.length === 0) {
     return (
       <Typography
@@ -324,16 +361,34 @@ export const SubagentTimeline = memo(function SubagentTimeline({
   }
 
   return (
-    <div className="flex flex-col">
-      {filteredEvents.map((event, index) => (
-        <TimelineEventRow
-          key={event.id}
-          event={event}
-          isLast={index === filteredEvents.length - 1}
-          expanded={expandedIds.has(event.id)}
-          toggleExpand={toggleExpand}
-        />
-      ))}
+    <div ref={listRef} className="flex flex-col">
+      {/* Spacer reserves the full list height (via `getTotalSize`) so the
+          scrollbar reflects all rows even though only a window is mounted. */}
+      <div style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
+        {virtualizer.getVirtualItems().map((vi) => {
+          const event = filteredEvents[vi.index]!;
+          return (
+            <div
+              key={vi.key}
+              data-index={vi.index}
+              ref={virtualizer.measureElement}
+              style={{
+                ...VIRTUAL_ROW_STYLE,
+                transform: `translateY(${vi.start - virtualizer.options.scrollMargin}px)`,
+              }}
+            >
+              <TimelineEventRow
+                event={event}
+                // Absolute index, not the position within the rendered window,
+                // so the connector is omitted only for the genuine last row.
+                isLast={vi.index === filteredEvents.length - 1}
+                expanded={expandedIds.has(event.id)}
+                toggleExpand={toggleExpand}
+              />
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 });

--- a/clients/web/src/domains/chat/components/subagent-timeline.tsx
+++ b/clients/web/src/domains/chat/components/subagent-timeline.tsx
@@ -208,12 +208,14 @@ const TimelineEventRow = memo(function TimelineEventRow({
   toggleExpand: (id: string) => void;
 }) {
   return (
-    // The inter-row gap lives in this row's `pb-4` padding (not the card's
-    // margin): the virtualizer measures rows via `getBoundingClientRect`, which
-    // excludes margins, so a margin-based gap would make absolutely-positioned
-    // rows overlap. As padding it's part of the measured height, and the
-    // connector's `flex-1` fill still spans through it to the next row.
-    <div className="relative flex gap-3 pb-4">
+    // The inter-row gap is the card's bottom margin (`mb-4`). The card is a flex
+    // item, so its margin grows the flex line's cross-size: the left rail — and
+    // its `flex-1` connector — stretches to that height and visually spans the
+    // gap down to the next row's icon. The margin is also part of the measured
+    // row height: `measureElement` measures the wrapper around this whole flex
+    // row, and a descendant flex item's margin counts toward that wrapper's
+    // border box, so absolutely-positioned rows don't overlap.
+    <div className="relative flex gap-3">
       {/* Left: icon node + connector line */}
       <div className="flex flex-col items-center">
         <div
@@ -228,7 +230,7 @@ const TimelineEventRow = memo(function TimelineEventRow({
       </div>
 
       {/* Right: content card */}
-      <div className="min-w-0 flex-1 rounded-lg bg-[var(--surface-overlay)] px-4 py-3">
+      <div className="mb-4 min-w-0 flex-1 rounded-lg bg-[var(--surface-overlay)] px-4 py-3">
         <Typography
           variant="body-medium-default"
           className="text-[var(--content-default)]"

--- a/clients/web/src/domains/chat/hooks/use-timeline-virtualizer.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-timeline-virtualizer.test.tsx
@@ -22,13 +22,29 @@ afterEach(() => {
 });
 
 describe("computeScrollMargin", () => {
-  test("returns 0 for a null element", () => {
-    expect(computeScrollMargin(null)).toBe(0);
+  /** Build a stub element with a fixed bounding-rect top. */
+  function elAt(top: number, scrollTop = 0): HTMLElement {
+    return {
+      getBoundingClientRect: () => ({ top }) as DOMRect,
+      scrollTop,
+    } as unknown as HTMLElement;
+  }
+
+  test("returns 0 when either element is missing", () => {
+    expect(computeScrollMargin(null, null)).toBe(0);
+    expect(computeScrollMargin(elAt(120), null)).toBe(0);
+    expect(computeScrollMargin(null, elAt(0))).toBe(0);
   });
 
-  test("returns the element's offsetTop", () => {
-    const stub = { offsetTop: 120 } as HTMLElement;
-    expect(computeScrollMargin(stub)).toBe(120);
+  test("returns the list top relative to the scroll element", () => {
+    // List 120px below the scroll container's top, container not scrolled.
+    expect(computeScrollMargin(elAt(120), elAt(0))).toBe(120);
+  });
+
+  test("accounts for the scroll container's current scrollTop", () => {
+    // Container scrolled 200px: the list box top has moved up by 200, so the
+    // on-screen gap is -80, but the stable offset within content is 120.
+    expect(computeScrollMargin(elAt(-80), elAt(0, 200))).toBe(120);
   });
 });
 

--- a/clients/web/src/domains/chat/hooks/use-timeline-virtualizer.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-timeline-virtualizer.test.tsx
@@ -3,8 +3,8 @@
  *
  * The pure `computeScrollMargin` is exercised directly (no DOM needed). The
  * hook itself gets a light smoke test: given a scroll-element ref it returns a
- * usable virtualizer object. Heavy DOM-measurement behavior is covered once a
- * consumer wires the hook in a later PR.
+ * usable virtualizer object. Heavy DOM-measurement behavior is covered by the
+ * consumer's tests (`subagent-timeline.test.tsx`).
  */
 import { afterEach, describe, expect, test } from "bun:test";
 import { cleanup, renderHook } from "@testing-library/react";
@@ -12,8 +12,6 @@ import { createRef } from "react";
 
 import {
   computeScrollMargin,
-  DEFAULT_ROW_ESTIMATE,
-  OVERSCAN,
   useTimelineVirtualizer,
 } from "@/domains/chat/hooks/use-timeline-virtualizer";
 
@@ -45,13 +43,6 @@ describe("computeScrollMargin", () => {
     // Container scrolled 200px: the list box top has moved up by 200, so the
     // on-screen gap is -80, but the stable offset within content is 120.
     expect(computeScrollMargin(elAt(-80), elAt(0, 200))).toBe(120);
-  });
-});
-
-describe("module constants", () => {
-  test("expose sane defaults", () => {
-    expect(DEFAULT_ROW_ESTIMATE).toBe(96);
-    expect(OVERSCAN).toBe(6);
   });
 });
 

--- a/clients/web/src/domains/chat/hooks/use-timeline-virtualizer.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-timeline-virtualizer.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Tests for `useTimelineVirtualizer` and its pure helpers.
+ *
+ * The pure `computeScrollMargin` is exercised directly (no DOM needed). The
+ * hook itself gets a light smoke test: given a scroll-element ref it returns a
+ * usable virtualizer object. Heavy DOM-measurement behavior is covered once a
+ * consumer wires the hook in a later PR.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+import { createRef } from "react";
+
+import {
+  computeScrollMargin,
+  DEFAULT_ROW_ESTIMATE,
+  OVERSCAN,
+  useTimelineVirtualizer,
+} from "@/domains/chat/hooks/use-timeline-virtualizer";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("computeScrollMargin", () => {
+  test("returns 0 for a null element", () => {
+    expect(computeScrollMargin(null)).toBe(0);
+  });
+
+  test("returns the element's offsetTop", () => {
+    const stub = { offsetTop: 120 } as HTMLElement;
+    expect(computeScrollMargin(stub)).toBe(120);
+  });
+});
+
+describe("module constants", () => {
+  test("expose sane defaults", () => {
+    expect(DEFAULT_ROW_ESTIMATE).toBe(96);
+    expect(OVERSCAN).toBe(6);
+  });
+});
+
+describe("useTimelineVirtualizer", () => {
+  test("returns a virtualizer with the expected shape", () => {
+    const scrollRef = createRef<HTMLElement>();
+    scrollRef.current = document.createElement("div");
+
+    const { result } = renderHook(() =>
+      useTimelineVirtualizer({
+        count: 3,
+        scrollRef,
+        getItemKey: (index) => `row-${index}`,
+      }),
+    );
+
+    expect(typeof result.current.getTotalSize).toBe("function");
+    expect(Array.isArray(result.current.getVirtualItems())).toBe(true);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-timeline-virtualizer.ts
+++ b/clients/web/src/domains/chat/hooks/use-timeline-virtualizer.ts
@@ -29,12 +29,27 @@ export const OVERSCAN = 6;
 
 /**
  * Compute the `scrollMargin` for the virtualizer: the list's top offset within
- * the scroll container, so virtual positions account for any header/content
- * rendered above the list. Pure (no DOM API beyond reading `offsetTop`) so it
- * is unit-testable without a real layout.
+ * the scroll container's content, so virtual positions account for any header
+ * rendered above the list.
+ *
+ * Measured *relative to the scroll element* rather than via `offsetTop`:
+ * `offsetTop` is relative to the nearest positioned ancestor, which is often
+ * not the scroll container (the panel body is a static `overflow-y-auto` div),
+ * so using it would subtract the wrong margin and shift every row. The gap
+ * between the two box tops plus the container's current `scrollTop` gives the
+ * list's stable offset within the scrolled content. Returns 0 until both
+ * elements are mounted.
  */
-export function computeScrollMargin(listEl: HTMLElement | null): number {
-  return listEl?.offsetTop ?? 0;
+export function computeScrollMargin(
+  listEl: HTMLElement | null,
+  scrollEl: HTMLElement | null,
+): number {
+  if (!listEl || !scrollEl) return 0;
+  return (
+    listEl.getBoundingClientRect().top -
+    scrollEl.getBoundingClientRect().top +
+    scrollEl.scrollTop
+  );
 }
 
 export interface UseTimelineVirtualizerParams {
@@ -69,6 +84,6 @@ export function useTimelineVirtualizer({
     estimateSize: () => estimateSize ?? DEFAULT_ROW_ESTIMATE,
     measureElement,
     overscan: OVERSCAN,
-    scrollMargin: computeScrollMargin(listRef?.current ?? null),
+    scrollMargin: computeScrollMargin(listRef?.current ?? null, scrollRef.current),
   });
 }

--- a/clients/web/src/domains/chat/hooks/use-timeline-virtualizer.ts
+++ b/clients/web/src/domains/chat/hooks/use-timeline-virtualizer.ts
@@ -6,8 +6,7 @@
  * panel's own scroll container, not the list itself), dynamic per-row
  * measurement, a header offset via `scrollMargin`, and stable item keys.
  *
- * This is scaffolding — no component consumes it yet. A later PR will mount it
- * inside `subagent-timeline.tsx`. The dependency lands in the lazily-loaded
+ * Consumed by `subagent-timeline.tsx`. The dependency lands in the lazily-loaded
  * subagent-panel chunk (see `chat-content-layout.tsx`), not the main bundle.
  */
 import {
@@ -15,17 +14,17 @@ import {
   useVirtualizer,
   type Virtualizer,
 } from "@tanstack/react-virtual";
-import type { RefObject } from "react";
+import { useLayoutEffect, useState, type RefObject } from "react";
 
 /**
  * Fallback row height (px) used before a row has been measured. A sane guess
  * for a single-line-ish timeline row; real heights are measured on mount via
  * the dynamic `measureElement` so this only affects the initial estimate.
  */
-export const DEFAULT_ROW_ESTIMATE = 96;
+const DEFAULT_ROW_ESTIMATE = 96;
 
 /** Rows to render beyond the visible window, on each side, to mask scrolling. */
-export const OVERSCAN = 6;
+const OVERSCAN = 6;
 
 /**
  * Compute the `scrollMargin` for the virtualizer: the list's top offset within
@@ -52,7 +51,7 @@ export function computeScrollMargin(
   );
 }
 
-export interface UseTimelineVirtualizerParams {
+interface UseTimelineVirtualizerParams {
   /** Number of rows in the timeline. */
   count: number;
   /** Ref to the scroll container (the element that actually scrolls). */
@@ -61,8 +60,6 @@ export interface UseTimelineVirtualizerParams {
   listRef?: RefObject<HTMLElement | null>;
   /** Stable key for a row index, so measurements survive reorders. */
   getItemKey: (index: number) => string;
-  /** Initial per-row height guess (px); defaults to {@link DEFAULT_ROW_ESTIMATE}. */
-  estimateSize?: number;
 }
 
 /**
@@ -75,15 +72,36 @@ export function useTimelineVirtualizer({
   scrollRef,
   listRef,
   getItemKey,
-  estimateSize,
 }: UseTimelineVirtualizerParams): Virtualizer<HTMLElement, HTMLElement> {
+  // Resolve `scrollMargin` in a layout effect (not during render): it reads
+  // layout via `getBoundingClientRect`, and doing that on every render would
+  // force a synchronous reflow each scroll frame in a component whose whole
+  // point is rendering performance. Captured into state on mount and whenever
+  // the scroll/list elements resize, so the first committed paint already uses
+  // the correct offset instead of 0.
+  const [scrollMargin, setScrollMargin] = useState(0);
+  useLayoutEffect(() => {
+    const recompute = () =>
+      setScrollMargin(computeScrollMargin(listRef?.current ?? null, scrollRef.current));
+    recompute();
+    const scrollEl = scrollRef.current;
+    if (!scrollEl || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(recompute);
+    observer.observe(scrollEl);
+    const listEl = listRef?.current;
+    if (listEl) observer.observe(listEl);
+    return () => observer.disconnect();
+    // `count` is included so the margin recomputes when the list mounts/changes
+    // (e.g. the empty-state → populated transition mounts the list element).
+  }, [scrollRef, listRef, count]);
+
   return useVirtualizer<HTMLElement, HTMLElement>({
     count,
     getScrollElement: () => scrollRef.current,
     getItemKey,
-    estimateSize: () => estimateSize ?? DEFAULT_ROW_ESTIMATE,
+    estimateSize: () => DEFAULT_ROW_ESTIMATE,
     measureElement,
     overscan: OVERSCAN,
-    scrollMargin: computeScrollMargin(listRef?.current ?? null, scrollRef.current),
+    scrollMargin,
   });
 }

--- a/clients/web/src/domains/chat/hooks/use-timeline-virtualizer.ts
+++ b/clients/web/src/domains/chat/hooks/use-timeline-virtualizer.ts
@@ -1,0 +1,74 @@
+/**
+ * Headless virtualizer for the subagent timeline.
+ *
+ * Thin wrapper around `@tanstack/react-virtual`'s `useVirtualizer` that wires
+ * up the conventions the timeline needs: an *external* scroll element (the
+ * panel's own scroll container, not the list itself), dynamic per-row
+ * measurement, a header offset via `scrollMargin`, and stable item keys.
+ *
+ * This is scaffolding — no component consumes it yet. A later PR will mount it
+ * inside `subagent-timeline.tsx`. The dependency lands in the lazily-loaded
+ * subagent-panel chunk (see `chat-content-layout.tsx`), not the main bundle.
+ */
+import {
+  measureElement,
+  useVirtualizer,
+  type Virtualizer,
+} from "@tanstack/react-virtual";
+import type { RefObject } from "react";
+
+/**
+ * Fallback row height (px) used before a row has been measured. A sane guess
+ * for a single-line-ish timeline row; real heights are measured on mount via
+ * the dynamic `measureElement` so this only affects the initial estimate.
+ */
+export const DEFAULT_ROW_ESTIMATE = 96;
+
+/** Rows to render beyond the visible window, on each side, to mask scrolling. */
+export const OVERSCAN = 6;
+
+/**
+ * Compute the `scrollMargin` for the virtualizer: the list's top offset within
+ * the scroll container, so virtual positions account for any header/content
+ * rendered above the list. Pure (no DOM API beyond reading `offsetTop`) so it
+ * is unit-testable without a real layout.
+ */
+export function computeScrollMargin(listEl: HTMLElement | null): number {
+  return listEl?.offsetTop ?? 0;
+}
+
+export interface UseTimelineVirtualizerParams {
+  /** Number of rows in the timeline. */
+  count: number;
+  /** Ref to the scroll container (the element that actually scrolls). */
+  scrollRef: RefObject<HTMLElement | null>;
+  /** Ref to the inner list element, used to offset virtual positions. */
+  listRef?: RefObject<HTMLElement | null>;
+  /** Stable key for a row index, so measurements survive reorders. */
+  getItemKey: (index: number) => string;
+  /** Initial per-row height guess (px); defaults to {@link DEFAULT_ROW_ESTIMATE}. */
+  estimateSize?: number;
+}
+
+/**
+ * Wrap `useVirtualizer` for the subagent timeline. The returned virtualizer's
+ * `measureElement` should be attached to each row's `ref` to enable dynamic
+ * measurement.
+ */
+export function useTimelineVirtualizer({
+  count,
+  scrollRef,
+  listRef,
+  getItemKey,
+  estimateSize,
+}: UseTimelineVirtualizerParams): Virtualizer<HTMLElement, HTMLElement> {
+  return useVirtualizer<HTMLElement, HTMLElement>({
+    count,
+    getScrollElement: () => scrollRef.current,
+    getItemKey,
+    estimateSize: () => estimateSize ?? DEFAULT_ROW_ESTIMATE,
+    measureElement,
+    overscan: OVERSCAN,
+    scrollMargin: computeScrollMargin(listRef?.current ?? null),
+  });
+}


### PR DESCRIPTION
## Summary
Phase 5 of the side-panel perf work — stacked on #35183 (`jz/sidepanel-perf`). Replaces the `content-visibility:auto` stand-in in the subagent detail timeline with **real list virtualization** via `@tanstack/react-virtual`, so a subagent making tens-to-hundreds of tool calls mounts only a windowed set of rows (≈10 mounted at N=50/150/300) instead of all N.

Why this list specifically: unlike the main chat transcript (which is bounded by pagination + opening at the bottom), the subagent timeline loads **all** of `entry.events` and renders them on open — no pagination floor — so windowing is well justified here.

## What's in it
- **Baseline harness** (#35198): deterministic `makeSyntheticEvents` fixture + perf test.
- **Lift expand state** (#35238): collapse state moved out of per-row `useState` (survives row unmount) and reset per subagent via `key={subagentId}` (fixes a cross-subagent leak caught by Codex).
- **Dependency + hook** (#35240, pinned/corrected in #35241): `@tanstack/react-virtual@3.14.3` (exact) + headless `useTimelineVirtualizer` (external scroll element, dynamic `measureElement`, `scrollMargin` header offset computed relative to the scroll element).
- **Adoption** (#35243): virtualize the timeline against the panel's scroll container; connector/gap handled for absolute positioning; `content-visibility` stand-in removed; `min-w-0`/`break-words` overflow fix retained.
- **Self-review fixes** (#35247): connector restored via card `mb-4`; `scrollMargin` moved to `useLayoutEffect` (no reflow during render); slop cleanup.

## Self-review result
PASS. 4 fresh reviewers (external feedback, plan faithfulness, repo integration, slop); 1 remediation round; re-review of the two passes that found gaps came back PASS. All 3 Codex P2s (expand-state leak, exact-pin, scroll-element-relative `scrollMargin`) resolved.

### Notes / manual-QA
- Connector continuity is sound by CSS geometry but was not browser-verified — quick visual check of 3+ consecutive timeline rows recommended.
- Optional robustness follow-up: `scrollMargin` recomputes on scroll/list resize + count change; a header-height change with no count change could leave the *windowing range* briefly stale (rows never visually misalign — the transform cancels it; overscan + streaming absorb it). Low priority.

## PRs merged into this branch
- #35198, #35238, #35240, #35241, #35243, #35247 (#35199 superseded by #35238)

Part of plan: virtualize-subagent-timeline.md