### PR TITLE
feat(api): add workflow event + journal response wire schemas

### DIFF
--- a/assistant/src/api/events/workflow-completed.ts
+++ b/assistant/src/api/events/workflow-completed.ts
@@ -1,0 +1,51 @@
+/**
+ * `workflow_completed` SSE event.
+ *
+ * Server → client notification that a `run_workflow` run has reached a
+ * terminal state. Carries `runId`, the parent `conversationId`, the
+ * terminal `status`, cumulative `agentsSpawned`/`inputTokens`/
+ * `outputTokens` counters, and an optional human-readable `summary`.
+ *
+ * `conversationId` is present so clients can route the event to the
+ * originating conversation's inline workflow card.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+/**
+ * Lifecycle status of a `run_workflow` run. `running` is the live
+ * state; the remainder are terminal. `cap_exceeded` is reached when a
+ * run hits its configured agent/token cap; `interrupted` when the run
+ * is halted by an external signal.
+ */
+export const WorkflowRunStatusSchema = z.enum([
+  "running",
+  "completed",
+  "failed",
+  "aborted",
+  "cap_exceeded",
+  "interrupted",
+]);
+
+export type WorkflowRunStatus = z.infer<typeof WorkflowRunStatusSchema>;
+
+export const WorkflowCompletedEventSchema = z
+  .object({
+    type: z.literal("workflow_completed"),
+    runId: z.string(),
+    conversationId: z.string(),
+    status: WorkflowRunStatusSchema,
+    agentsSpawned: z.number(),
+    inputTokens: z.number(),
+    outputTokens: z.number(),
+    summary: z.string().optional(),
+  })
+  .strict();
+
+export type WorkflowCompletedEvent = z.infer<
+  typeof WorkflowCompletedEventSchema
+>;

--- a/assistant/src/api/events/workflow-leaf-finished.ts
+++ b/assistant/src/api/events/workflow-leaf-finished.ts
@@ -1,0 +1,38 @@
+/**
+ * `workflow_leaf_finished` SSE event.
+ *
+ * Server → client notification that a leaf agent within a
+ * `run_workflow` run has finished. Carries `runId`, the parent
+ * `conversationId`, the monotonic `seq` identifying the leaf within the
+ * run, the terminal `status`, optional `inputTokens`/`outputTokens`
+ * counters, and optional human-readable display fields (`label`,
+ * `resultSummary`).
+ *
+ * `conversationId` is present so clients can route the event to the
+ * originating conversation's inline workflow card and its live leaf
+ * tree.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const WorkflowLeafFinishedEventSchema = z
+  .object({
+    type: z.literal("workflow_leaf_finished"),
+    runId: z.string(),
+    conversationId: z.string(),
+    seq: z.number().int(),
+    status: z.enum(["completed", "failed"]),
+    label: z.string().optional(),
+    inputTokens: z.number().optional(),
+    outputTokens: z.number().optional(),
+    resultSummary: z.string().optional(),
+  })
+  .strict();
+
+export type WorkflowLeafFinishedEvent = z.infer<
+  typeof WorkflowLeafFinishedEventSchema
+>;

--- a/assistant/src/api/events/workflow-leaf-started.ts
+++ b/assistant/src/api/events/workflow-leaf-started.ts
@@ -1,0 +1,35 @@
+/**
+ * `workflow_leaf_started` SSE event.
+ *
+ * Server → client notification that a leaf agent within a
+ * `run_workflow` run has started. Carries `runId`, the parent
+ * `conversationId`, the monotonic `seq` identifying the leaf within the
+ * run, and optional human-readable display fields (`label`, `phase`,
+ * `promptSummary`).
+ *
+ * `conversationId` is present so clients can route the event to the
+ * originating conversation's inline workflow card and its live leaf
+ * tree.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const WorkflowLeafStartedEventSchema = z
+  .object({
+    type: z.literal("workflow_leaf_started"),
+    runId: z.string(),
+    conversationId: z.string(),
+    seq: z.number().int(),
+    label: z.string().optional(),
+    phase: z.string().optional(),
+    promptSummary: z.string().optional(),
+  })
+  .strict();
+
+export type WorkflowLeafStartedEvent = z.infer<
+  typeof WorkflowLeafStartedEventSchema
+>;

--- a/assistant/src/api/events/workflow-progress.ts
+++ b/assistant/src/api/events/workflow-progress.ts
@@ -1,0 +1,31 @@
+/**
+ * `workflow_progress` SSE event.
+ *
+ * Server → client incremental progress update for an in-flight
+ * `run_workflow` run. Carries `runId`, the parent `conversationId`, the
+ * running `agentsSpawned` count, and optional human-readable display
+ * fields (`phase`, `label`, `message`).
+ *
+ * `conversationId` is present so clients can route the event to the
+ * originating conversation's inline workflow card.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const WorkflowProgressEventSchema = z
+  .object({
+    type: z.literal("workflow_progress"),
+    runId: z.string(),
+    conversationId: z.string(),
+    agentsSpawned: z.number(),
+    phase: z.string().optional(),
+    label: z.string().optional(),
+    message: z.string().optional(),
+  })
+  .strict();
+
+export type WorkflowProgressEvent = z.infer<typeof WorkflowProgressEventSchema>;

--- a/assistant/src/api/events/workflow-started.ts
+++ b/assistant/src/api/events/workflow-started.ts
@@ -1,0 +1,31 @@
+/**
+ * `workflow_started` SSE event.
+ *
+ * Server → client notification that a `run_workflow` run has begun.
+ * Carries `runId`, the parent `conversationId`, an optional anchoring
+ * `toolUseId`, and an optional human-readable `label`.
+ *
+ * `conversationId` is present so clients can route the event to the
+ * originating conversation's inline workflow card. `toolUseId` (the
+ * `skill_execute` block id that launched the run) anchors that inline
+ * card to the exact spawn tool call, mirroring
+ * `subagent_spawned.parentToolUseId`.
+ *
+ * Canonical wire-contract source. Daemon code imports the type
+ * directly from this file; external consumers import via
+ * `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+export const WorkflowStartedEventSchema = z
+  .object({
+    type: z.literal("workflow_started"),
+    runId: z.string(),
+    conversationId: z.string(),
+    toolUseId: z.string().optional(),
+    label: z.string().optional(),
+  })
+  .strict();
+
+export type WorkflowStartedEvent = z.infer<typeof WorkflowStartedEventSchema>;

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -52,6 +52,11 @@ import { UISurfaceUpdateEventSchema } from "./events/ui-surface-update.js";
 import { UsageProgressEventSchema } from "./events/usage-progress.js";
 import { UsageUpdateEventSchema } from "./events/usage-update.js";
 import { UserMessageEchoEventSchema } from "./events/user-message-echo.js";
+import { WorkflowCompletedEventSchema } from "./events/workflow-completed.js";
+import { WorkflowLeafFinishedEventSchema } from "./events/workflow-leaf-finished.js";
+import { WorkflowLeafStartedEventSchema } from "./events/workflow-leaf-started.js";
+import { WorkflowProgressEventSchema } from "./events/workflow-progress.js";
+import { WorkflowStartedEventSchema } from "./events/workflow-started.js";
 
 export {
   CALL_SITE_COMPACTION_AGENT,
@@ -327,6 +332,28 @@ export {
   UserMessageEchoEventSchema,
 } from "./events/user-message-echo.js";
 export {
+  type WorkflowCompletedEvent,
+  WorkflowCompletedEventSchema,
+  type WorkflowRunStatus,
+  WorkflowRunStatusSchema,
+} from "./events/workflow-completed.js";
+export {
+  type WorkflowLeafFinishedEvent,
+  WorkflowLeafFinishedEventSchema,
+} from "./events/workflow-leaf-finished.js";
+export {
+  type WorkflowLeafStartedEvent,
+  WorkflowLeafStartedEventSchema,
+} from "./events/workflow-leaf-started.js";
+export {
+  type WorkflowProgressEvent,
+  WorkflowProgressEventSchema,
+} from "./events/workflow-progress.js";
+export {
+  type WorkflowStartedEvent,
+  WorkflowStartedEventSchema,
+} from "./events/workflow-started.js";
+export {
   type DictationContext,
   DictationContextSchema,
   type DictationRequest,
@@ -441,6 +468,12 @@ export {
   type SubagentDetailResponse,
   SubagentDetailResponseSchema,
 } from "./responses/subagent-detail.js";
+export {
+  type WorkflowJournalResponse,
+  WorkflowJournalResponseSchema,
+  type WorkflowLeaf,
+  WorkflowLeafSchema,
+} from "./responses/workflow-journal.js";
 
 /**
  * Canonical SSE event schema for the assistant runtime.
@@ -508,6 +541,11 @@ export const AssistantEventSchema = z.discriminatedUnion("type", [
   UsageProgressEventSchema,
   UsageUpdateEventSchema,
   UserMessageEchoEventSchema,
+  WorkflowCompletedEventSchema,
+  WorkflowLeafFinishedEventSchema,
+  WorkflowLeafStartedEventSchema,
+  WorkflowProgressEventSchema,
+  WorkflowStartedEventSchema,
 ]);
 
 /**

--- a/assistant/src/api/responses/workflow-journal.ts
+++ b/assistant/src/api/responses/workflow-journal.ts
@@ -1,0 +1,51 @@
+/**
+ * Wire contract for the workflow-journal REST endpoint. Returns a
+ * `run_workflow` run's live status, cumulative usage/agent counters,
+ * current phase, and the ordered list of leaf agents spawned by the
+ * run.
+ *
+ * Reuses the canonical `WorkflowRunStatusSchema` defined alongside the
+ * `workflow_completed` SSE event so the polled REST journal and the
+ * streamed lifecycle events share one status shape.
+ *
+ * Canonical wire-contract source. Assistant code imports the types
+ * directly from this file via relative paths; external consumers
+ * (web client, gateway, evals) import via `@vellumai/assistant-api`.
+ */
+
+import { z } from "zod";
+
+import { WorkflowRunStatusSchema } from "../events/workflow-completed.js";
+
+/**
+ * A single leaf within a workflow run. `kind` distinguishes a leaf
+ * agent from a nested workflow; `status` is an open string rather than
+ * a closed enum since it covers both lifecycle states and terminal
+ * results.
+ */
+export const WorkflowLeafSchema = z.object({
+  seq: z.number().int(),
+  kind: z.enum(["agent", "workflow"]),
+  label: z.string().optional(),
+  phase: z.string().optional(),
+  promptSummary: z.string().optional(),
+  status: z.string(),
+  resultSummary: z.string().optional(),
+  createdAt: z.number().nullable(),
+});
+
+export type WorkflowLeaf = z.infer<typeof WorkflowLeafSchema>;
+
+export const WorkflowJournalResponseSchema = z.object({
+  runId: z.string(),
+  status: WorkflowRunStatusSchema.optional(),
+  agentsSpawned: z.number().optional(),
+  inputTokens: z.number().optional(),
+  outputTokens: z.number().optional(),
+  phase: z.string().optional(),
+  leaves: z.array(WorkflowLeafSchema),
+});
+
+export type WorkflowJournalResponse = z.infer<
+  typeof WorkflowJournalResponseSchema
+>;


### PR DESCRIPTION
## Summary
- Add workflow_started / workflow_leaf_started / workflow_leaf_finished events + conversationId on workflow_progress/workflow_completed to the assistant-api wire schemas
- Add the workflow journal response schema
- Register the five events in AssistantEventSchema

Part of plan: workflow-inspector.md (PR 1 of 13)