### PR TITLE
feat(daemon): add conversationId + leaf/started workflow server messages

### DIFF
--- a/assistant/src/daemon/message-types/workflows.ts
+++ b/assistant/src/daemon/message-types/workflows.ts
@@ -18,6 +18,11 @@ import type { WorkflowRunStatus } from "../../workflows/journal-store.js";
 export interface WorkflowProgress {
   type: "workflow_progress";
   runId: string;
+  /**
+   * Originating conversation id; lets `broadcastMessage` auto-scope +
+   * seq-stamp the event to the conversation's SSE stream.
+   */
+  conversationId: string;
   /** Latest phase title, when this emission came from a `phase(...)` call. */
   phase?: string;
   /** Run label (the workflow's `meta.name`), for client display. */
@@ -36,6 +41,11 @@ export interface WorkflowProgress {
 export interface WorkflowCompleted {
   type: "workflow_completed";
   runId: string;
+  /**
+   * Originating conversation id; lets `broadcastMessage` auto-scope +
+   * seq-stamp the event to the conversation's SSE stream.
+   */
+  conversationId: string;
   status: WorkflowRunStatus;
   agentsSpawned: number;
   inputTokens: number;
@@ -44,6 +54,74 @@ export interface WorkflowCompleted {
   summary?: string;
 }
 
+/**
+ * A workflow run has started. Emitted once at launch, before any leaf events.
+ */
+export interface WorkflowStarted {
+  type: "workflow_started";
+  runId: string;
+  /**
+   * Originating conversation id; lets `broadcastMessage` auto-scope +
+   * seq-stamp the event to the conversation's SSE stream.
+   */
+  conversationId: string;
+  /**
+   * Tool-use id of the `skill_execute` block that launched this run, for
+   * anchoring the inline workflow card to the exact spawn tool call.
+   */
+  toolUseId?: string;
+  /** Run label (the workflow's `meta.name`), for client display. */
+  label?: string;
+}
+
+/**
+ * A leaf agent within a workflow run has started. `seq` orders leaves within
+ * the run for stable client-side tree placement.
+ */
+export interface WorkflowLeafStarted {
+  type: "workflow_leaf_started";
+  runId: string;
+  /**
+   * Originating conversation id; lets `broadcastMessage` auto-scope +
+   * seq-stamp the event to the conversation's SSE stream.
+   */
+  conversationId: string;
+  seq: number;
+  /** Leaf label, for client display. */
+  label?: string;
+  /** Phase the leaf belongs to, when the workflow declares phases. */
+  phase?: string;
+  /** Short summary of the leaf's prompt, for client display. */
+  promptSummary?: string;
+}
+
+/**
+ * A leaf agent within a workflow run has finished. `seq` matches the
+ * corresponding `workflow_leaf_started` event.
+ */
+export interface WorkflowLeafFinished {
+  type: "workflow_leaf_finished";
+  runId: string;
+  /**
+   * Originating conversation id; lets `broadcastMessage` auto-scope +
+   * seq-stamp the event to the conversation's SSE stream.
+   */
+  conversationId: string;
+  seq: number;
+  status: "completed" | "failed";
+  /** Leaf label, for client display. */
+  label?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  /** Short summary of the leaf's result, for client display. */
+  resultSummary?: string;
+}
+
 // --- Domain-level union aliases (consumed by the barrel file) ---
 
-export type _WorkflowsServerMessages = WorkflowProgress | WorkflowCompleted;
+export type _WorkflowsServerMessages =
+  | WorkflowProgress
+  | WorkflowCompleted
+  | WorkflowStarted
+  | WorkflowLeafStarted
+  | WorkflowLeafFinished;

--- a/assistant/src/workflows/run-manager.ts
+++ b/assistant/src/workflows/run-manager.ts
@@ -393,6 +393,7 @@ export class WorkflowRunManager {
           this.deps.broadcast({
             type: "workflow_progress",
             runId,
+            conversationId: ctx.conversationId ?? "",
             label,
             agentsSpawned,
             ...(event.type === "phase"
@@ -412,6 +413,7 @@ export class WorkflowRunManager {
       this.deps.broadcast({
         type: "workflow_completed",
         runId,
+        conversationId: ctx.conversationId ?? "",
         status: result.status,
         agentsSpawned: result.agentsSpawned,
         inputTokens: result.inputTokens,


### PR DESCRIPTION
## Summary
- Add conversationId to WorkflowProgress/WorkflowCompleted so broadcastMessage scopes them to the conversation
- Add WorkflowStarted, WorkflowLeafStarted, WorkflowLeafFinished server messages

Part of plan: workflow-inspector.md (PR 2 of 13)