### PR TITLE
feat(workflows): scope run events to the conversation + broadcast started/leaf events

### DIFF
--- a/assistant/src/tools/workflows/run-workflow.ts
+++ b/assistant/src/tools/workflows/run-workflow.ts
@@ -68,6 +68,7 @@ export async function executeRunWorkflow(
       args,
       manifest,
       conversationId: context.conversationId,
+      ...(context.toolUseId ? { toolUseId: context.toolUseId } : {}),
       ...(label ? { label } : {}),
       trustContext,
     });

--- a/assistant/src/workflows/run-manager.test.ts
+++ b/assistant/src/workflows/run-manager.test.ts
@@ -292,6 +292,7 @@ describe("WorkflowRunManager.abort", () => {
       scriptSource: "export const meta = { name: 'x', description: 'y' }",
       args: {},
       manifest: { tools: [], hostFunctions: [], persona: false },
+      conversationId: "conv-1",
       trustContext: TRUST,
     });
 
@@ -318,6 +319,7 @@ describe("WorkflowRunManager — progress events", () => {
       scriptSource: "export const meta = { name: 'x', description: 'y' }",
       args: {},
       manifest: { tools: [], hostFunctions: [], persona: false },
+      conversationId: "conv-1",
       label: "My Flow",
       trustContext: TRUST,
     });
@@ -330,13 +332,156 @@ describe("WorkflowRunManager — progress events", () => {
     expect(progress).toHaveLength(2);
     expect(progress[0]).toMatchObject({
       type: "workflow_progress",
+      conversationId: "conv-1",
       label: "My Flow",
       phase: "Gathering",
     });
     expect(progress[1]).toMatchObject({
       type: "workflow_progress",
+      conversationId: "conv-1",
       message: "step done",
     });
+  });
+
+  test("a run with no conversation broadcasts no progress events", () => {
+    const h = makeHarness();
+    h.manager.start({
+      scriptSource: "export const meta = { name: 'x', description: 'y' }",
+      args: {},
+      manifest: { tools: [], hostFunctions: [], persona: false },
+      label: "My Flow",
+      trustContext: TRUST,
+    });
+
+    const onProgress = h.executeCalls[0]!.onProgress!;
+    onProgress({ type: "phase", title: "Gathering" });
+    onProgress({ type: "log", message: "step done" });
+
+    expect(h.broadcasts.some((b) => b.type === "workflow_progress")).toBe(
+      false,
+    );
+  });
+
+  test("onLeaf start/finish are republished as scoped leaf events", () => {
+    const fakeEngine: WorkflowRunManagerDeps["executeWorkflow"] = (options) => {
+      options.onLeaf?.({
+        type: "leaf_started",
+        seq: 1,
+        label: "Research",
+        phase: "Gather",
+        promptSummary: "look it up",
+      });
+      options.onLeaf?.({
+        type: "leaf_finished",
+        seq: 1,
+        status: "completed",
+        label: "Research",
+        inputTokens: 30,
+        outputTokens: 12,
+        resultSummary: "found it",
+      });
+      return new Promise(() => {}) as ReturnType<
+        WorkflowRunManagerDeps["executeWorkflow"]
+      >;
+    };
+    const h = makeHarness({ engine: fakeEngine });
+
+    const { runId } = h.manager.start({
+      scriptSource: "export const meta = { name: 'x', description: 'y' }",
+      args: {},
+      manifest: { tools: [], hostFunctions: [], persona: false },
+      conversationId: "conv-1",
+      trustContext: TRUST,
+    });
+
+    const started = h.broadcasts.find(
+      (b) => b.type === "workflow_leaf_started",
+    );
+    expect(started).toMatchObject({
+      type: "workflow_leaf_started",
+      runId,
+      conversationId: "conv-1",
+      seq: 1,
+      label: "Research",
+      phase: "Gather",
+      promptSummary: "look it up",
+    });
+
+    const finished = h.broadcasts.find(
+      (b) => b.type === "workflow_leaf_finished",
+    );
+    expect(finished).toMatchObject({
+      type: "workflow_leaf_finished",
+      runId,
+      conversationId: "conv-1",
+      seq: 1,
+      status: "completed",
+      label: "Research",
+      inputTokens: 30,
+      outputTokens: 12,
+      resultSummary: "found it",
+    });
+  });
+
+  test("a run with no conversation gets no onLeaf callback", () => {
+    const h = makeHarness();
+    h.manager.start({
+      scriptSource: "export const meta = { name: 'x', description: 'y' }",
+      args: {},
+      manifest: { tools: [], hostFunctions: [], persona: false },
+      trustContext: TRUST,
+    });
+
+    expect(h.executeCalls[0]!.onLeaf).toBeUndefined();
+  });
+});
+
+describe("WorkflowRunManager.start — workflow_started", () => {
+  test("start with a conversation broadcasts workflow_started carrying toolUseId", () => {
+    const h = makeHarness();
+    const { runId } = h.manager.start({
+      scriptSource: "export const meta = { name: 'x', description: 'y' }",
+      args: {},
+      manifest: { tools: [], hostFunctions: [], persona: false },
+      conversationId: "conv-1",
+      toolUseId: "toolu-abc",
+      label: "My Flow",
+      trustContext: TRUST,
+    });
+
+    const started = h.broadcasts.find((b) => b.type === "workflow_started");
+    expect(started).toMatchObject({
+      type: "workflow_started",
+      runId,
+      conversationId: "conv-1",
+      toolUseId: "toolu-abc",
+      label: "My Flow",
+    });
+  });
+
+  test("start without a conversation broadcasts no workflow_started", () => {
+    const h = makeHarness();
+    h.manager.start({
+      scriptSource: "export const meta = { name: 'x', description: 'y' }",
+      args: {},
+      manifest: { tools: [], hostFunctions: [], persona: false },
+      trustContext: TRUST,
+    });
+
+    expect(h.broadcasts.some((b) => b.type === "workflow_started")).toBe(false);
+  });
+
+  test("resume never broadcasts workflow_started", () => {
+    const h = makeHarness({});
+    seedRun(h, {
+      id: "run-x",
+      status: "interrupted",
+      conversationId: "conv-1",
+    });
+
+    h.manager.resume("run-x");
+
+    expect(h.broadcasts.some((b) => b.type === "workflow_started")).toBe(false);
   });
 });
 
@@ -364,6 +509,7 @@ describe("WorkflowRunManager — completion", () => {
     expect(completed).toMatchObject({
       type: "workflow_completed",
       runId,
+      conversationId: "conv-1",
       status: "completed",
       agentsSpawned: 4,
       inputTokens: 100,
@@ -418,7 +564,7 @@ describe("WorkflowRunManager — completion", () => {
     expect(h.manager.status(runId)?.result).toBe(big);
   });
 
-  test("no conversationId → completion events fire but no wake", async () => {
+  test("no conversationId → no workflow broadcasts and no wake", async () => {
     const h = makeHarness();
     h.manager.start({
       scriptSource: "export const meta = { name: 'x', description: 'y' }",
@@ -435,9 +581,9 @@ describe("WorkflowRunManager — completion", () => {
       outputTokens: 1,
     });
 
-    expect(h.broadcasts.some((b) => b.type === "workflow_completed")).toBe(
-      true,
-    );
+    // A run with no originating conversation has no SSE stream to scope to:
+    // none of the workflow lifecycle events broadcast, and there's no wake.
+    expect(h.broadcasts).toHaveLength(0);
     expect(h.wakes).toHaveLength(0);
   });
 });

--- a/assistant/src/workflows/run-manager.ts
+++ b/assistant/src/workflows/run-manager.ts
@@ -114,6 +114,11 @@ interface StartWorkflowCommon {
    * scheduled run with no chat surface) — the summary is then events-only.
    */
   conversationId?: string;
+  /**
+   * The `skill_execute` tool-use block id that launched this run; forwarded on
+   * `workflow_started` so the client anchors the inline card to the spawn call.
+   */
+  toolUseId?: string;
   /** Human-readable label for display; defaults to the run id. */
   label?: string;
   /** Trust/auth context forwarded to every leaf. */
@@ -214,6 +219,19 @@ export class WorkflowRunManager {
 
     const controller = new AbortController();
     this.inflight.set(runId, controller);
+
+    // Announce the launch only when there's a conversation to scope it to (the
+    // same gate the in-flight/terminal broadcasts use). `resume` never emits
+    // this — the run already announced itself on its original `start`.
+    if (opts.conversationId) {
+      this.deps.broadcast({
+        type: "workflow_started",
+        runId,
+        conversationId: opts.conversationId,
+        ...(opts.toolUseId ? { toolUseId: opts.toolUseId } : {}),
+        label,
+      });
+    }
 
     // Fire-and-forget: the engine owns its own try/catch and always finishes
     // the run row. We never await it — `start` must return synchronously.
@@ -376,6 +394,9 @@ export class WorkflowRunManager {
     ctx: RunContext,
   ): Promise<void> {
     const config = this.deps.getConfig();
+    // A run with no originating conversation has no SSE stream to scope to, so
+    // it emits no live/terminal events at all (matching `injectCompletionSummary`).
+    const conversationId = ctx.conversationId;
     try {
       const result = await this.deps.executeWorkflow({
         runId,
@@ -388,12 +409,13 @@ export class WorkflowRunManager {
         trustContext: ctx.trustContext,
         signal: controller.signal,
         onProgress: (event) => {
+          if (!conversationId) return;
           const run = this.deps.journal.getRun(runId);
           const agentsSpawned = run?.agentsSpawned ?? 0;
           this.deps.broadcast({
             type: "workflow_progress",
             runId,
-            conversationId: ctx.conversationId ?? "",
+            conversationId,
             label,
             agentsSpawned,
             ...(event.type === "phase"
@@ -401,6 +423,41 @@ export class WorkflowRunManager {
               : { message: event.message }),
           });
         },
+        ...(conversationId
+          ? {
+              onLeaf: (event) => {
+                if (event.type === "leaf_started") {
+                  this.deps.broadcast({
+                    type: "workflow_leaf_started",
+                    runId,
+                    conversationId,
+                    seq: event.seq,
+                    ...(event.label !== undefined
+                      ? { label: event.label }
+                      : {}),
+                    ...(event.phase !== undefined
+                      ? { phase: event.phase }
+                      : {}),
+                    promptSummary: event.promptSummary,
+                  });
+                } else {
+                  this.deps.broadcast({
+                    type: "workflow_leaf_finished",
+                    runId,
+                    conversationId,
+                    seq: event.seq,
+                    status: event.status,
+                    ...(event.label !== undefined
+                      ? { label: event.label }
+                      : {}),
+                    inputTokens: event.inputTokens,
+                    outputTokens: event.outputTokens,
+                    resultSummary: event.resultSummary,
+                  });
+                }
+              },
+            }
+          : {}),
       });
 
       const summary = buildCompletionSummary(
@@ -410,16 +467,18 @@ export class WorkflowRunManager {
         this.deps.journal.getRun(runId),
       );
 
-      this.deps.broadcast({
-        type: "workflow_completed",
-        runId,
-        conversationId: ctx.conversationId ?? "",
-        status: result.status,
-        agentsSpawned: result.agentsSpawned,
-        inputTokens: result.inputTokens,
-        outputTokens: result.outputTokens,
-        summary,
-      });
+      if (conversationId) {
+        this.deps.broadcast({
+          type: "workflow_completed",
+          runId,
+          conversationId,
+          status: result.status,
+          agentsSpawned: result.agentsSpawned,
+          inputTokens: result.inputTokens,
+          outputTokens: result.outputTokens,
+          summary,
+        });
+      }
 
       await this.injectCompletionSummary(ctx, summary);
     } catch (err) {


### PR DESCRIPTION
## Summary
- Emit workflow_started (with the launching toolUseId) and per-leaf workflow_leaf_started/finished broadcasts
- Gate all workflow broadcasts on a present conversationId (replace the PR-2 empty-string sentinel)
- Thread context.toolUseId from run_workflow into start()

Part of plan: workflow-inspector.md (PR 4 of 13)