### PR TITLE
feat(web): workflow lifecycle store + journal fetch

### DIFF
--- a/clients/web/src/domains/chat/fetch-workflow-journal.ts
+++ b/clients/web/src/domains/chat/fetch-workflow-journal.ts
@@ -1,0 +1,39 @@
+/**
+ * Fetch a workflow run's journal from the daemon.
+ *
+ * The response is validated at the network boundary against the canonical
+ * `WorkflowJournalResponseSchema`, so consumers receive a typed, trusted
+ * shape instead of the SDK's pre-schema `unknown` payload.
+ */
+
+import { captureError } from "@/lib/sentry/capture-error";
+import {
+  WorkflowJournalResponseSchema,
+  type WorkflowJournalResponse,
+} from "@vellumai/assistant-api";
+
+import { workflowsRunsByIdJournalGet } from "@/generated/daemon/sdk.gen";
+
+export async function fetchWorkflowJournal(
+  assistantId: string,
+  runId: string,
+): Promise<WorkflowJournalResponse | null> {
+  try {
+    const { data, response } = await workflowsRunsByIdJournalGet({
+      path: { assistant_id: assistantId, id: runId },
+      throwOnError: false,
+    });
+    if (!response || !response.ok || !data) {
+      return null;
+    }
+    const parsed = WorkflowJournalResponseSchema.safeParse(data);
+    if (!parsed.success) {
+      captureError(parsed.error, { context: "fetchWorkflowJournal" });
+      return null;
+    }
+    return parsed.data;
+  } catch (err) {
+    captureError(err, { context: "fetchWorkflowJournal" });
+    return null;
+  }
+}

--- a/clients/web/src/domains/chat/workflow-store.test.ts
+++ b/clients/web/src/domains/chat/workflow-store.test.ts
@@ -1,0 +1,338 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { WorkflowJournalResponse } from "@vellumai/assistant-api";
+
+// Stub the journal fetch so fetchJournalIfNeeded is exercised without a
+// network boundary. The mock is reassigned per-test via `journalImpl`.
+let journalImpl: (
+  assistantId: string,
+  runId: string,
+) => Promise<WorkflowJournalResponse | null> = async () => null;
+
+mock.module("@/domains/chat/fetch-workflow-journal", () => ({
+  fetchWorkflowJournal: (assistantId: string, runId: string) =>
+    journalImpl(assistantId, runId),
+}));
+
+const { useWorkflowStore } = await import("@/domains/chat/workflow-store");
+
+function getState() {
+  return useWorkflowStore.getState();
+}
+
+const NOW = 1700000000000;
+
+beforeEach(() => {
+  getState().reset();
+  journalImpl = async () => null;
+});
+
+// ---------------------------------------------------------------------------
+// startRun
+// ---------------------------------------------------------------------------
+
+describe("startRun", () => {
+  it("creates a running entry and indexes byToolUseId", () => {
+    getState().startRun({
+      runId: "wf-1",
+      toolUseId: "tu-1",
+      label: "Build report",
+      timestamp: NOW,
+    });
+
+    const state = getState();
+    expect(state.orderedIds).toEqual(["wf-1"]);
+    const entry = state.byId["wf-1"]!;
+    expect(entry.status).toBe("running");
+    expect(entry.label).toBe("Build report");
+    expect(entry.toolUseId).toBe("tu-1");
+    expect(entry.startedAt).toBe(NOW);
+    expect(entry.leaves.size).toBe(0);
+    expect(state.byToolUseId.get("tu-1")).toBe("wf-1");
+  });
+
+  it("does not clone byToolUseId when no toolUseId is supplied", () => {
+    const before = getState().byToolUseId;
+    getState().startRun({ runId: "wf-2", timestamp: NOW });
+    expect(getState().byToolUseId).toBe(before);
+  });
+
+  it("fills missing label/toolUseId on a pre-existing shell entry", () => {
+    getState().applyProgress({ runId: "wf-3", phase: "planning" });
+    getState().startRun({
+      runId: "wf-3",
+      toolUseId: "tu-3",
+      label: "Late label",
+      timestamp: NOW,
+    });
+
+    const entry = getState().byId["wf-3"]!;
+    expect(entry.label).toBe("Late label");
+    expect(entry.toolUseId).toBe("tu-3");
+    expect(entry.phase).toBe("planning");
+    expect(getState().byToolUseId.get("tu-3")).toBe("wf-3");
+    // Not double-added to the ordered list.
+    expect(getState().orderedIds).toEqual(["wf-3"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyProgress
+// ---------------------------------------------------------------------------
+
+describe("applyProgress", () => {
+  it("upserts a shell entry when the run is unknown", () => {
+    getState().applyProgress({
+      runId: "wf-p",
+      phase: "spawning",
+      agentsSpawned: 3,
+    });
+
+    const entry = getState().byId["wf-p"]!;
+    expect(entry.status).toBe("running");
+    expect(entry.phase).toBe("spawning");
+    expect(entry.agentsSpawned).toBe(3);
+    expect(getState().orderedIds).toEqual(["wf-p"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Leaf lifecycle
+// ---------------------------------------------------------------------------
+
+describe("leaf lifecycle", () => {
+  it("upserts a seq-keyed running leaf", () => {
+    getState().startRun({ runId: "wf-l", timestamp: NOW });
+    getState().leafStarted({
+      runId: "wf-l",
+      seq: 0,
+      label: "Leaf A",
+      promptSummary: "do a thing",
+    });
+
+    const leaf = getState().byId["wf-l"]!.leaves.get(0)!;
+    expect(leaf.status).toBe("running");
+    expect(leaf.label).toBe("Leaf A");
+    expect(leaf.promptSummary).toBe("do a thing");
+  });
+
+  it("creates a shell run when leafStarted races ahead of startRun", () => {
+    getState().leafStarted({ runId: "wf-race", seq: 2, label: "Early leaf" });
+
+    const entry = getState().byId["wf-race"];
+    expect(entry).toBeDefined();
+    expect(entry!.status).toBe("running");
+    expect(entry!.leaves.get(2)!.status).toBe("running");
+    expect(getState().orderedIds).toEqual(["wf-race"]);
+  });
+
+  it("transitions a leaf to terminal and merges tokens, keeping the prior label", () => {
+    getState().leafStarted({ runId: "wf-f", seq: 0, label: "Leaf A" });
+    getState().leafFinished({
+      runId: "wf-f",
+      seq: 0,
+      status: "completed",
+      inputTokens: 100,
+      outputTokens: 50,
+      resultSummary: "done",
+    });
+
+    const leaf = getState().byId["wf-f"]!.leaves.get(0)!;
+    expect(leaf.status).toBe("completed");
+    expect(leaf.label).toBe("Leaf A");
+    expect(leaf.inputTokens).toBe(100);
+    expect(leaf.outputTokens).toBe(50);
+    expect(leaf.resultSummary).toBe("done");
+  });
+
+  it("never downgrades an already-terminal leaf back to running", () => {
+    getState().leafFinished({ runId: "wf-d", seq: 0, status: "completed" });
+    getState().leafStarted({ runId: "wf-d", seq: 0, label: "Stale start" });
+
+    expect(getState().byId["wf-d"]!.leaves.get(0)!.status).toBe("completed");
+  });
+
+  it("is idempotent when leafFinished repeats the same terminal status with no new data", () => {
+    getState().leafFinished({
+      runId: "wf-i",
+      seq: 0,
+      status: "completed",
+      inputTokens: 10,
+    });
+    const before = getState().byId["wf-i"]!.leaves;
+    getState().leafFinished({ runId: "wf-i", seq: 0, status: "completed" });
+    expect(getState().byId["wf-i"]!.leaves).toBe(before);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// completeRun
+// ---------------------------------------------------------------------------
+
+describe("completeRun", () => {
+  it("sets terminal run fields", () => {
+    getState().startRun({ runId: "wf-c", timestamp: NOW });
+    getState().completeRun({
+      runId: "wf-c",
+      status: "completed",
+      agentsSpawned: 4,
+      inputTokens: 1000,
+      outputTokens: 500,
+      summary: "all good",
+    });
+
+    const entry = getState().byId["wf-c"]!;
+    expect(entry.status).toBe("completed");
+    expect(entry.agentsSpawned).toBe(4);
+    expect(entry.inputTokens).toBe(1000);
+    expect(entry.outputTokens).toBe(500);
+    expect(entry.summary).toBe("all good");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// backfillFromJournal
+// ---------------------------------------------------------------------------
+
+describe("backfillFromJournal", () => {
+  it("inserts missing leaves and sets run counters", () => {
+    getState().startRun({ runId: "wf-bf", timestamp: NOW });
+    getState().backfillFromJournal("wf-bf", {
+      runId: "wf-bf",
+      status: "running",
+      agentsSpawned: 2,
+      inputTokens: 200,
+      outputTokens: 100,
+      phase: "executing",
+      leaves: [
+        {
+          seq: 0,
+          kind: "agent",
+          label: "Leaf 0",
+          status: "completed",
+          createdAt: NOW,
+        },
+        {
+          seq: 1,
+          kind: "agent",
+          label: "Leaf 1",
+          status: "failed",
+          createdAt: NOW,
+        },
+      ],
+    });
+
+    const entry = getState().byId["wf-bf"]!;
+    expect(entry.agentsSpawned).toBe(2);
+    expect(entry.inputTokens).toBe(200);
+    expect(entry.phase).toBe("executing");
+    expect(entry.leaves.get(0)!.status).toBe("completed");
+    expect(entry.leaves.get(1)!.status).toBe("failed");
+  });
+
+  it("does not regress a live terminal leaf when the journal reports it", () => {
+    getState().leafStarted({ runId: "wf-keep", seq: 0, label: "Live leaf" });
+    getState().leafFinished({
+      runId: "wf-keep",
+      seq: 0,
+      status: "completed",
+      resultSummary: "live result",
+    });
+
+    getState().backfillFromJournal("wf-keep", {
+      runId: "wf-keep",
+      leaves: [
+        {
+          seq: 0,
+          kind: "agent",
+          status: "failed",
+          resultSummary: "journal result",
+          createdAt: NOW,
+        },
+      ],
+    });
+
+    const leaf = getState().byId["wf-keep"]!.leaves.get(0)!;
+    // Live terminal wins: status and result are preserved.
+    expect(leaf.status).toBe("completed");
+    expect(leaf.resultSummary).toBe("live result");
+  });
+
+  it("lets a journal terminal status override a stale live running leaf", () => {
+    getState().leafStarted({ runId: "wf-win", seq: 0, label: "Running leaf" });
+
+    getState().backfillFromJournal("wf-win", {
+      runId: "wf-win",
+      leaves: [
+        {
+          seq: 0,
+          kind: "agent",
+          status: "completed",
+          resultSummary: "journal result",
+          createdAt: NOW,
+        },
+      ],
+    });
+
+    const leaf = getState().byId["wf-win"]!.leaves.get(0)!;
+    expect(leaf.status).toBe("completed");
+    expect(leaf.label).toBe("Running leaf");
+    expect(leaf.resultSummary).toBe("journal result");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchJournalIfNeeded
+// ---------------------------------------------------------------------------
+
+describe("fetchJournalIfNeeded", () => {
+  it("dedups a second call within the same startedAt", async () => {
+    getState().startRun({ runId: "wf-fetch", timestamp: NOW });
+
+    let calls = 0;
+    journalImpl = async (_assistantId, runId) => {
+      calls += 1;
+      return { runId, leaves: [] };
+    };
+
+    await getState().fetchJournalIfNeeded("asst-1", "wf-fetch");
+    await getState().fetchJournalIfNeeded("asst-1", "wf-fetch");
+
+    expect(calls).toBe(1);
+    expect(getState().fetchedAt.get("wf-fetch")).toBe(NOW);
+  });
+
+  it("clears the marker on failure so callers can retry", async () => {
+    getState().startRun({ runId: "wf-fail", timestamp: NOW });
+
+    journalImpl = async () => null;
+    await getState().fetchJournalIfNeeded("asst-1", "wf-fail");
+
+    expect(getState().fetchedAt.has("wf-fail")).toBe(false);
+  });
+
+  it("no-ops when the run is unknown", async () => {
+    let calls = 0;
+    journalImpl = async (_assistantId, runId) => {
+      calls += 1;
+      return { runId, leaves: [] };
+    };
+    await getState().fetchJournalIfNeeded("asst-1", "missing");
+    expect(calls).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reference stability
+// ---------------------------------------------------------------------------
+
+describe("reference stability", () => {
+  it("leaves another run's leaves Map reference unchanged on mutation", () => {
+    getState().startRun({ runId: "wf-a", timestamp: NOW });
+    getState().startRun({ runId: "wf-b", timestamp: NOW });
+    const bLeavesBefore = getState().byId["wf-b"]!.leaves;
+
+    getState().leafStarted({ runId: "wf-a", seq: 0, label: "A leaf" });
+
+    expect(getState().byId["wf-b"]!.leaves).toBe(bLeavesBefore);
+  });
+});

--- a/clients/web/src/domains/chat/workflow-store.ts
+++ b/clients/web/src/domains/chat/workflow-store.ts
@@ -1,0 +1,462 @@
+/**
+ * Zustand store for workflow (`run_workflow`) run lifecycle state.
+ *
+ * Maintains a map of WorkflowEntry records keyed by runId, with an
+ * ordered list of IDs for stable rendering and a `byToolUseId` index that
+ * anchors an inline transcript card to its spawning tool call. Direct
+ * named actions call `set()` to apply pure transitions so UI components
+ * can derive display state deterministically.
+ *
+ * Per-run leaves are tracked in a seq-keyed Map. Reference-stability
+ * discipline mirrors the subagent store: `byId`, `byToolUseId`, and a
+ * run's `leaves` Map are cloned only when the specific mutation touches
+ * them, so unrelated subscribers don't re-render.
+ *
+ * @see https://zustand.docs.pmnd.rs/guides/flux-inspired-practice
+ * @see https://zustand.docs.pmnd.rs/guides/updating-state
+ */
+
+import { create } from "zustand";
+
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { workflowsRunsByIdAbortPost } from "@/generated/daemon/sdk.gen";
+import { createSelectors } from "@/utils/create-selectors";
+import type {
+  WorkflowRunStatus,
+  WorkflowJournalResponse,
+} from "@vellumai/assistant-api";
+
+import { fetchWorkflowJournal } from "./fetch-workflow-journal";
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+export type WorkflowLeafStatus = "running" | "completed" | "failed";
+
+export interface WorkflowLeaf {
+  seq: number;
+  label?: string;
+  phase?: string;
+  promptSummary?: string;
+  status: WorkflowLeafStatus;
+  resultSummary?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+}
+
+export interface WorkflowEntry {
+  runId: string;
+  label?: string;
+  status: WorkflowRunStatus;
+  phase?: string;
+  agentsSpawned: number;
+  inputTokens: number;
+  outputTokens: number;
+  summary?: string;
+  startedAt: number;
+  /**
+   * Tool-use block ID of the spawning tool call in the parent conversation.
+   * Lets the transcript anchor the inline card to its exact spawn tool call
+   * regardless of optimistic→reconciled message id swaps. Indexed in
+   * `byToolUseId`. Optional — older daemons omit it.
+   */
+  toolUseId?: string;
+  /** Leaf agents/workflows spawned by this run, keyed by `seq`. */
+  leaves: Map<number, WorkflowLeaf>;
+}
+
+export interface WorkflowState {
+  byId: Record<string, WorkflowEntry>;
+  orderedIds: string[];
+  /**
+   * Index of spawning tool-use block id → runId. Populated when a
+   * `workflow_started` event carries `toolUseId`, letting the transcript
+   * anchor the inline card to its exact spawn tool call even after the
+   * optimistic streaming message id is reconciled away.
+   *
+   * The map reference is only replaced when a new `toolUseId` is indexed;
+   * unrelated mutations keep it stable so subscribers don't re-render.
+   */
+  byToolUseId: Map<string, string>;
+  /**
+   * Tracks which runs have had their journal fetched, keyed by
+   * runId → startedAt at fetch time. Prevents redundant network requests
+   * while still allowing re-fetches when store rebuilds produce a new
+   * startedAt.
+   */
+  fetchedAt: Map<string, number>;
+}
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+export interface WorkflowActions {
+  startRun: (params: {
+    runId: string;
+    conversationId?: string;
+    toolUseId?: string;
+    label?: string;
+    timestamp: number;
+  }) => void;
+
+  applyProgress: (params: {
+    runId: string;
+    phase?: string;
+    agentsSpawned?: number;
+    message?: string;
+    label?: string;
+  }) => void;
+
+  leafStarted: (params: {
+    runId: string;
+    seq: number;
+    label?: string;
+    phase?: string;
+    promptSummary?: string;
+  }) => void;
+
+  leafFinished: (params: {
+    runId: string;
+    seq: number;
+    status: "completed" | "failed";
+    label?: string;
+    inputTokens?: number;
+    outputTokens?: number;
+    resultSummary?: string;
+  }) => void;
+
+  completeRun: (params: {
+    runId: string;
+    status: WorkflowRunStatus;
+    agentsSpawned: number;
+    inputTokens: number;
+    outputTokens: number;
+    summary?: string;
+  }) => void;
+
+  backfillFromJournal: (runId: string, resp: WorkflowJournalResponse) => void;
+
+  /**
+   * Fetch the journal from the daemon for a single run if not already
+   * fetched (or if the entry was rebuilt with a newer startedAt).
+   * Dedup state lives in the store so it survives component lifecycle.
+   * Clears the marker on failure so callers can retry.
+   */
+  fetchJournalIfNeeded: (assistantId: string, runId: string) => Promise<void>;
+
+  /**
+   * Best-effort abort of a running workflow. Reads `assistantId` from the
+   * resolved-assistants store via `.getState()` so callers don't need to
+   * pass or close over that value.
+   */
+  abortRun: (runId: string) => Promise<void>;
+
+  reset: () => void;
+}
+
+export type WorkflowStore = WorkflowState & WorkflowActions;
+
+// ---------------------------------------------------------------------------
+// Initial state
+// ---------------------------------------------------------------------------
+
+const INITIAL_STATE: WorkflowState = {
+  byId: {},
+  orderedIds: [],
+  byToolUseId: new Map<string, string>(),
+  fetchedAt: new Map<string, number>(),
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a fresh run entry in the "running" state with no leaves. */
+function makeShellEntry(runId: string, startedAt: number): WorkflowEntry {
+  return {
+    runId,
+    status: "running",
+    agentsSpawned: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    startedAt,
+    leaves: new Map<number, WorkflowLeaf>(),
+  };
+}
+
+/** Map a journal leaf's open-string status to a live leaf status. */
+function mapJournalLeafStatus(status: string): WorkflowLeafStatus {
+  if (status === "failed") return "failed";
+  if (status === "running") return "running";
+  // The journal only records finished leaves, so an unknown status is
+  // treated as a terminal success.
+  return "completed";
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+const useWorkflowStoreBase = create<WorkflowStore>()((set, get) => ({
+  ...INITIAL_STATE,
+
+  startRun: (params) => {
+    const { byId, orderedIds, byToolUseId } = get();
+    const existing = byId[params.runId];
+
+    if (existing) {
+      // Fill in label/toolUseId if a prior shell entry (e.g. from a racing
+      // progress event) lacked them.
+      const nextLabel = existing.label ?? params.label;
+      const nextToolUseId = existing.toolUseId ?? params.toolUseId;
+      const labelChanged = nextLabel !== existing.label;
+      const toolUseIdChanged = nextToolUseId !== existing.toolUseId;
+      if (!labelChanged && !toolUseIdChanged) return;
+
+      const updated: WorkflowEntry = {
+        ...existing,
+        label: nextLabel,
+        toolUseId: nextToolUseId,
+      };
+      const nextByToolUseId =
+        toolUseIdChanged && params.toolUseId
+          ? new Map(byToolUseId).set(params.toolUseId, params.runId)
+          : byToolUseId;
+      set({
+        byId: { ...byId, [params.runId]: updated },
+        byToolUseId: nextByToolUseId,
+      });
+      return;
+    }
+
+    const entry: WorkflowEntry = {
+      ...makeShellEntry(params.runId, params.timestamp),
+      label: params.label,
+      toolUseId: params.toolUseId,
+    };
+    // Only clone the tool-use index when this start carries a `toolUseId`;
+    // otherwise keep the existing reference stable.
+    const nextByToolUseId = params.toolUseId
+      ? new Map(byToolUseId).set(params.toolUseId, params.runId)
+      : byToolUseId;
+    set({
+      byId: { ...byId, [params.runId]: entry },
+      orderedIds: [...orderedIds, params.runId],
+      byToolUseId: nextByToolUseId,
+    });
+  },
+
+  applyProgress: (params) => {
+    const { byId, orderedIds } = get();
+    const existing = byId[params.runId];
+
+    const base = existing ?? makeShellEntry(params.runId, Date.now());
+    const updated: WorkflowEntry = {
+      ...base,
+      phase: params.phase ?? base.phase,
+      agentsSpawned: params.agentsSpawned ?? base.agentsSpawned,
+      label: base.label ?? params.label,
+    };
+
+    set({
+      byId: { ...byId, [params.runId]: updated },
+      orderedIds: existing ? orderedIds : [...orderedIds, params.runId],
+    });
+  },
+
+  leafStarted: (params) => {
+    const { byId, orderedIds } = get();
+    const existing = byId[params.runId];
+    const base = existing ?? makeShellEntry(params.runId, Date.now());
+
+    const current = base.leaves.get(params.seq);
+    // Never downgrade an already-terminal leaf back to running.
+    if (current && current.status !== "running") return;
+
+    const leaf: WorkflowLeaf = {
+      seq: params.seq,
+      status: "running",
+      label: params.label ?? current?.label,
+      phase: params.phase ?? current?.phase,
+      promptSummary: params.promptSummary ?? current?.promptSummary,
+    };
+    const nextLeaves = new Map(base.leaves).set(params.seq, leaf);
+
+    set({
+      byId: { ...byId, [params.runId]: { ...base, leaves: nextLeaves } },
+      orderedIds: existing ? orderedIds : [...orderedIds, params.runId],
+    });
+  },
+
+  leafFinished: (params) => {
+    const { byId, orderedIds } = get();
+    const existing = byId[params.runId];
+    const base = existing ?? makeShellEntry(params.runId, Date.now());
+
+    // A leaf only exists on an already-present run, so `current` implies
+    // `existing`.
+    const current = base.leaves.get(params.seq);
+    const leaf: WorkflowLeaf = {
+      seq: params.seq,
+      status: params.status,
+      label: params.label ?? current?.label,
+      phase: current?.phase,
+      promptSummary: current?.promptSummary,
+      inputTokens: params.inputTokens ?? current?.inputTokens,
+      outputTokens: params.outputTokens ?? current?.outputTokens,
+      resultSummary: params.resultSummary ?? current?.resultSummary,
+    };
+
+    // Idempotent: skip the write when the leaf is already at this terminal
+    // status and the event carries no new data.
+    if (
+      current &&
+      current.status === leaf.status &&
+      current.label === leaf.label &&
+      current.inputTokens === leaf.inputTokens &&
+      current.outputTokens === leaf.outputTokens &&
+      current.resultSummary === leaf.resultSummary
+    ) {
+      return;
+    }
+
+    const nextLeaves = new Map(base.leaves).set(params.seq, leaf);
+
+    set({
+      byId: { ...byId, [params.runId]: { ...base, leaves: nextLeaves } },
+      orderedIds: existing ? orderedIds : [...orderedIds, params.runId],
+    });
+  },
+
+  completeRun: (params) => {
+    const { byId, orderedIds } = get();
+    const existing = byId[params.runId];
+    const base = existing ?? makeShellEntry(params.runId, Date.now());
+
+    const updated: WorkflowEntry = {
+      ...base,
+      status: params.status,
+      agentsSpawned: params.agentsSpawned,
+      inputTokens: params.inputTokens,
+      outputTokens: params.outputTokens,
+      summary: params.summary ?? base.summary,
+    };
+
+    set({
+      byId: { ...byId, [params.runId]: updated },
+      orderedIds: existing ? orderedIds : [...orderedIds, params.runId],
+    });
+  },
+
+  backfillFromJournal: (runId, resp) => {
+    const { byId, orderedIds } = get();
+    const existing = byId[runId];
+    const base = existing ?? makeShellEntry(runId, Date.now());
+
+    let leavesChanged = false;
+    let nextLeaves = base.leaves;
+    for (const journalLeaf of resp.leaves) {
+      const current = base.leaves.get(journalLeaf.seq);
+      const journalStatus = mapJournalLeafStatus(journalLeaf.status);
+
+      if (!current) {
+        if (!leavesChanged) {
+          nextLeaves = new Map(base.leaves);
+          leavesChanged = true;
+        }
+        nextLeaves.set(journalLeaf.seq, {
+          seq: journalLeaf.seq,
+          status: journalStatus,
+          label: journalLeaf.label,
+          phase: journalLeaf.phase,
+          promptSummary: journalLeaf.promptSummary,
+          resultSummary: journalLeaf.resultSummary,
+        });
+        continue;
+      }
+
+      // Never regress an already-terminal live leaf back to running, but a
+      // terminal journal status wins over a stale live "running" leaf (a
+      // missed finish event).
+      if (current.status === "running" && journalStatus !== "running") {
+        if (!leavesChanged) {
+          nextLeaves = new Map(base.leaves);
+          leavesChanged = true;
+        }
+        nextLeaves.set(journalLeaf.seq, {
+          ...current,
+          status: journalStatus,
+          label: current.label ?? journalLeaf.label,
+          phase: current.phase ?? journalLeaf.phase,
+          promptSummary: current.promptSummary ?? journalLeaf.promptSummary,
+          resultSummary: current.resultSummary ?? journalLeaf.resultSummary,
+        });
+      }
+    }
+
+    const updated: WorkflowEntry = {
+      ...base,
+      status: resp.status ?? base.status,
+      agentsSpawned: resp.agentsSpawned ?? base.agentsSpawned,
+      inputTokens: resp.inputTokens ?? base.inputTokens,
+      outputTokens: resp.outputTokens ?? base.outputTokens,
+      phase: resp.phase ?? base.phase,
+      leaves: nextLeaves,
+    };
+
+    set({
+      byId: { ...byId, [runId]: updated },
+      orderedIds: existing ? orderedIds : [...orderedIds, runId],
+    });
+  },
+
+  fetchJournalIfNeeded: async (assistantId, runId) => {
+    const { byId, fetchedAt } = get();
+    const entry = byId[runId];
+    if (!entry) return;
+
+    const prev = fetchedAt.get(runId);
+    if (prev !== undefined && prev >= entry.startedAt) return;
+
+    // Mark as fetched before the await to prevent concurrent duplicates.
+    const nextFetchedAt = new Map(fetchedAt);
+    nextFetchedAt.set(runId, entry.startedAt);
+    set({ fetchedAt: nextFetchedAt });
+
+    const resp = await fetchWorkflowJournal(assistantId, runId);
+
+    if (!resp) {
+      const next = new Map(get().fetchedAt);
+      next.delete(runId);
+      set({ fetchedAt: next });
+      return;
+    }
+
+    get().backfillFromJournal(runId, resp);
+  },
+
+  abortRun: async (runId) => {
+    const assistantId = useResolvedAssistantsStore.getState().activeAssistantId;
+    if (!assistantId) return;
+    try {
+      await workflowsRunsByIdAbortPost({
+        path: { assistant_id: assistantId, id: runId },
+        throwOnError: true,
+      });
+    } catch {
+      // Best-effort — the workflow may have already completed.
+    }
+  },
+
+  reset: () =>
+    set({
+      byId: {},
+      orderedIds: [],
+      byToolUseId: new Map<string, string>(),
+      fetchedAt: new Map<string, number>(),
+    }),
+}));
+
+export const useWorkflowStore = createSelectors(useWorkflowStoreBase);


### PR DESCRIPTION
## Summary
- Add a zustand workflow-store keyed by runId (byToolUseId anchor index, seq-keyed live leaves)
- Add fetch-workflow-journal for reload/late-open backfill
- Dedup rules: never downgrade a terminal leaf; journal wins over stale live running

Part of plan: workflow-inspector.md (PR 8 of 13)