### PR TITLE
feat(web): route workflow SSE events into the workflow store

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -67,6 +67,13 @@ import {
   handleSubagentStatusChanged,
   handleSubagentEvent,
 } from "@/domains/chat/utils/stream-handlers/subagent-handlers";
+import {
+  handleWorkflowStarted,
+  handleWorkflowProgress,
+  handleWorkflowLeafStarted,
+  handleWorkflowLeafFinished,
+  handleWorkflowCompleted,
+} from "@/domains/chat/utils/stream-handlers/workflow-handlers";
 import type { StreamHandlerContext } from "@/domains/chat/utils/stream-handlers/types";
 
 export type {
@@ -367,6 +374,22 @@ export function useStreamEventHandler(
           break;
         case "subagent_event":
           handleSubagentEvent(event, ctx);
+          break;
+
+        case "workflow_started":
+          handleWorkflowStarted(event, ctx);
+          break;
+        case "workflow_progress":
+          handleWorkflowProgress(event, ctx);
+          break;
+        case "workflow_leaf_started":
+          handleWorkflowLeafStarted(event, ctx);
+          break;
+        case "workflow_leaf_finished":
+          handleWorkflowLeafFinished(event, ctx);
+          break;
+        case "workflow_completed":
+          handleWorkflowCompleted(event, ctx);
           break;
         // Cross-domain events handled by bus subscribers mounted in
         // RootLayout (useAssistantResourceSync, useConversationSync,

--- a/clients/web/src/domains/chat/utils/stream-handlers/workflow-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/workflow-handlers.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it } from "bun:test";
+
+import { makeCtx } from "@/domains/chat/utils/stream-handlers/test-helpers";
+import { useWorkflowStore } from "@/domains/chat/workflow-store";
+import {
+  handleWorkflowStarted,
+  handleWorkflowProgress,
+  handleWorkflowLeafStarted,
+  handleWorkflowLeafFinished,
+  handleWorkflowCompleted,
+} from "@/domains/chat/utils/stream-handlers/workflow-handlers";
+
+afterEach(() => {
+  useWorkflowStore.getState().reset();
+});
+
+describe("handleWorkflowStarted", () => {
+  it("creates a running run entry", () => {
+    handleWorkflowStarted(
+      {
+        type: "workflow_started",
+        runId: "run-1",
+        conversationId: "conv-1",
+        toolUseId: "tool-1",
+        label: "Build feature",
+      },
+      makeCtx(),
+    );
+
+    const entry = useWorkflowStore.getState().byId["run-1"];
+    expect(entry).toBeDefined();
+    expect(entry?.status).toBe("running");
+    expect(entry?.label).toBe("Build feature");
+    expect(entry?.toolUseId).toBe("tool-1");
+    expect(useWorkflowStore.getState().byToolUseId.get("tool-1")).toBe("run-1");
+  });
+});
+
+describe("handleWorkflowProgress", () => {
+  it("applies phase and agentsSpawned to the run", () => {
+    handleWorkflowProgress(
+      {
+        type: "workflow_progress",
+        runId: "run-1",
+        conversationId: "conv-1",
+        agentsSpawned: 3,
+        phase: "fan-out",
+        label: "Build feature",
+        message: "spawning",
+      },
+      makeCtx(),
+    );
+
+    const entry = useWorkflowStore.getState().byId["run-1"];
+    expect(entry?.agentsSpawned).toBe(3);
+    expect(entry?.phase).toBe("fan-out");
+  });
+});
+
+describe("handleWorkflowLeafStarted", () => {
+  it("records a running leaf keyed by seq", () => {
+    handleWorkflowLeafStarted(
+      {
+        type: "workflow_leaf_started",
+        runId: "run-1",
+        conversationId: "conv-1",
+        seq: 0,
+        label: "Leaf A",
+        phase: "work",
+        promptSummary: "do a thing",
+      },
+      makeCtx(),
+    );
+
+    const leaf = useWorkflowStore.getState().byId["run-1"]?.leaves.get(0);
+    expect(leaf?.status).toBe("running");
+    expect(leaf?.label).toBe("Leaf A");
+    expect(leaf?.promptSummary).toBe("do a thing");
+  });
+});
+
+describe("handleWorkflowLeafFinished", () => {
+  it("marks the leaf terminal with token counts", () => {
+    const ctx = makeCtx();
+    handleWorkflowLeafStarted(
+      {
+        type: "workflow_leaf_started",
+        runId: "run-1",
+        conversationId: "conv-1",
+        seq: 0,
+        label: "Leaf A",
+      },
+      ctx,
+    );
+    handleWorkflowLeafFinished(
+      {
+        type: "workflow_leaf_finished",
+        runId: "run-1",
+        conversationId: "conv-1",
+        seq: 0,
+        status: "completed",
+        inputTokens: 10,
+        outputTokens: 20,
+        resultSummary: "done",
+      },
+      ctx,
+    );
+
+    const leaf = useWorkflowStore.getState().byId["run-1"]?.leaves.get(0);
+    expect(leaf?.status).toBe("completed");
+    expect(leaf?.inputTokens).toBe(10);
+    expect(leaf?.outputTokens).toBe(20);
+    expect(leaf?.resultSummary).toBe("done");
+  });
+});
+
+describe("handleWorkflowCompleted", () => {
+  it("sets the terminal run status and totals", () => {
+    handleWorkflowCompleted(
+      {
+        type: "workflow_completed",
+        runId: "run-1",
+        conversationId: "conv-1",
+        status: "completed",
+        agentsSpawned: 4,
+        inputTokens: 100,
+        outputTokens: 200,
+        summary: "all done",
+      },
+      makeCtx(),
+    );
+
+    const entry = useWorkflowStore.getState().byId["run-1"];
+    expect(entry?.status).toBe("completed");
+    expect(entry?.agentsSpawned).toBe(4);
+    expect(entry?.inputTokens).toBe(100);
+    expect(entry?.outputTokens).toBe(200);
+    expect(entry?.summary).toBe("all done");
+  });
+});

--- a/clients/web/src/domains/chat/utils/stream-handlers/workflow-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/workflow-handlers.ts
@@ -1,0 +1,78 @@
+import type {
+  WorkflowStartedEvent,
+  WorkflowProgressEvent,
+  WorkflowLeafStartedEvent,
+  WorkflowLeafFinishedEvent,
+  WorkflowCompletedEvent,
+} from "@vellumai/assistant-api";
+
+import { useWorkflowStore } from "@/domains/chat/workflow-store";
+import type { StreamHandlerContext } from "@/domains/chat/utils/stream-handlers/types";
+
+export function handleWorkflowStarted(
+  event: WorkflowStartedEvent,
+  _ctx: StreamHandlerContext,
+): void {
+  useWorkflowStore.getState().startRun({
+    runId: event.runId,
+    conversationId: event.conversationId,
+    toolUseId: event.toolUseId,
+    label: event.label,
+    timestamp: Date.now(),
+  });
+}
+
+export function handleWorkflowProgress(
+  event: WorkflowProgressEvent,
+  _ctx: StreamHandlerContext,
+): void {
+  useWorkflowStore.getState().applyProgress({
+    runId: event.runId,
+    phase: event.phase,
+    agentsSpawned: event.agentsSpawned,
+    message: event.message,
+    label: event.label,
+  });
+}
+
+export function handleWorkflowLeafStarted(
+  event: WorkflowLeafStartedEvent,
+  _ctx: StreamHandlerContext,
+): void {
+  useWorkflowStore.getState().leafStarted({
+    runId: event.runId,
+    seq: event.seq,
+    label: event.label,
+    phase: event.phase,
+    promptSummary: event.promptSummary,
+  });
+}
+
+export function handleWorkflowLeafFinished(
+  event: WorkflowLeafFinishedEvent,
+  _ctx: StreamHandlerContext,
+): void {
+  useWorkflowStore.getState().leafFinished({
+    runId: event.runId,
+    seq: event.seq,
+    status: event.status,
+    label: event.label,
+    inputTokens: event.inputTokens,
+    outputTokens: event.outputTokens,
+    resultSummary: event.resultSummary,
+  });
+}
+
+export function handleWorkflowCompleted(
+  event: WorkflowCompletedEvent,
+  _ctx: StreamHandlerContext,
+): void {
+  useWorkflowStore.getState().completeRun({
+    runId: event.runId,
+    status: event.status,
+    agentsSpawned: event.agentsSpawned,
+    inputTokens: event.inputTokens,
+    outputTokens: event.outputTokens,
+    summary: event.summary,
+  });
+}


### PR DESCRIPTION
## Summary
- Add workflow stream handlers + 5 cases in use-stream-event-handler (resolves the exhaustive never error)
- Treat workflow events as conversation-scoped

Part of plan: workflow-inspector.md (PR 9 of 13)