### PR TITLE
feat(web): workflow inline progress card for the transcript

### DIFF
--- a/clients/web/src/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card.test.tsx
+++ b/clients/web/src/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * Tests for `WorkflowInlineProgressCard`.
+ *
+ * Drives the Zustand workflow store with fixture runs/leaves and asserts
+ * the rendered shell's presence, step-count pill, the spawn-race `null`
+ * fallback, the stop affordance gating, and the header-click callback.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act } from "react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { WorkflowInlineProgressCard } from "@/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card";
+import { useWorkflowStore } from "@/domains/chat/workflow-store";
+
+const NOW = 1700000000000;
+
+beforeEach(() => {
+  useWorkflowStore.getState().reset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function startRun(runId: string, label = "Research workflow") {
+  useWorkflowStore.getState().startRun({ runId, label, timestamp: NOW });
+}
+
+function addLeaf(runId: string, seq: number, label: string) {
+  useWorkflowStore.getState().leafStarted({ runId, seq, label });
+}
+
+describe("WorkflowInlineProgressCard — spawn race", () => {
+  test("renders null when no entry exists in the store yet", () => {
+    const { container } = render(
+      <WorkflowInlineProgressCard runId="missing" />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("WorkflowInlineProgressCard — fixture run", () => {
+  test("renders the shell and the agent-count pill once an entry exists", () => {
+    startRun("wf-1");
+    addLeaf("wf-1", 0, "Agent A");
+    addLeaf("wf-1", 1, "Agent B");
+
+    const { getByText, getByTestId } = render(
+      <WorkflowInlineProgressCard runId="wf-1" />,
+    );
+
+    expect(getByTestId("workflow-inline-card-shell")).toBeTruthy();
+    expect(getByText("2 agents")).toBeTruthy();
+  });
+});
+
+describe("WorkflowInlineProgressCard — header action", () => {
+  test("clicking the header row invokes onWorkflowClick", () => {
+    startRun("wf-open");
+    const seen: string[] = [];
+    const { getByRole } = render(
+      <WorkflowInlineProgressCard
+        runId="wf-open"
+        onWorkflowClick={(id) => seen.push(id)}
+      />,
+    );
+    fireEvent.click(getByRole("button", { name: /open workflow/i }));
+    expect(seen).toEqual(["wf-open"]);
+  });
+});
+
+describe("WorkflowInlineProgressCard — stop affordance", () => {
+  test("stop button only renders while the run is in-flight", () => {
+    startRun("wf-stop");
+    addLeaf("wf-stop", 0, "Agent A");
+    const seen: string[] = [];
+    const { getByTestId, queryByTestId } = render(
+      <WorkflowInlineProgressCard
+        runId="wf-stop"
+        onStopWorkflow={(id) => seen.push(id)}
+      />,
+    );
+    fireEvent.click(getByTestId("workflow-inline-card-stop"));
+    expect(seen).toEqual(["wf-stop"]);
+
+    act(() => {
+      useWorkflowStore.getState().completeRun({
+        runId: "wf-stop",
+        status: "completed",
+        agentsSpawned: 1,
+        inputTokens: 0,
+        outputTokens: 0,
+      });
+    });
+    expect(queryByTestId("workflow-inline-card-stop")).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card.tsx
+++ b/clients/web/src/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card.tsx
@@ -1,0 +1,109 @@
+/**
+ * Inline workflow progress card rendered per-`run_workflow` run in the
+ * assistant transcript. Built on `ToolProgressCardShell` with a workflow
+ * glyph slotted into the leading-icon slot — workflows have no avatar.
+ *
+ * Subscribes to the workflow store via `useWorkflowCardData(runId)`.
+ * Returns `null` when the entry isn't in the store yet — handles the
+ * spawn race where the assistant message containing the inline card
+ * mounts a hair before the `workflow_started` SSE event lands. A later
+ * PR wires this into the transcript; this PR ships the component
+ * standalone.
+ *
+ * Interaction model mirrors the subagent inline card:
+ *   - Clicking anywhere on the header row opens the workflow's detail
+ *     panel via `onWorkflowClick`. There is no inline expand — the panel
+ *     is the only detail view.
+ *   - Stop is exposed via `onStopWorkflow`; the shell renders a small
+ *     stop chip in the right rail while the run is in-flight.
+ */
+
+import { Square, Workflow } from "lucide-react";
+import { useCallback, type MouseEvent } from "react";
+
+import { Button } from "@vellumai/design-library";
+
+import { PhaseGroupedStepList } from "@/domains/chat/components/tool-progress-card/phase-grouped-step-list";
+import { ToolProgressCardShell } from "@/domains/chat/components/tool-progress-card/tool-progress-card-shell";
+import { useWorkflowCardData } from "@/domains/chat/hooks/use-workflow-card-data";
+
+export interface WorkflowInlineProgressCardProps {
+  runId: string;
+  /**
+   * Invoked when the user activates the header row. Routes to the
+   * workflow detail panel.
+   */
+  onWorkflowClick?: (runId: string) => void;
+  /**
+   * Invoked when the user activates the stop button while the run is
+   * in-flight. Omitted callers hide the button entirely.
+   */
+  onStopWorkflow?: (runId: string) => void;
+}
+
+export function WorkflowInlineProgressCard({
+  runId,
+  onWorkflowClick,
+  onStopWorkflow,
+}: WorkflowInlineProgressCardProps) {
+  const data = useWorkflowCardData(runId);
+  // The shell's `loading` state is the live window where stopping the
+  // workflow is a meaningful action (see `deriveCardState`).
+  const isRunning = data?.state === "loading";
+
+  const handleHeaderClick = useCallback(() => {
+    onWorkflowClick?.(runId);
+  }, [onWorkflowClick, runId]);
+
+  const handleStop = useCallback(
+    (e: MouseEvent) => {
+      e.stopPropagation();
+      onStopWorkflow?.(runId);
+    },
+    [onStopWorkflow, runId],
+  );
+
+  // Spawn-race: assistant message references a run before the
+  // `workflow_started` event lands. Render `null` rather than a blank
+  // shell so the transcript doesn't flicker an empty card.
+  if (!data) return null;
+
+  const leadingIcon = <Workflow size={20} aria-hidden />;
+
+  const actionSlot =
+    onStopWorkflow && isRunning ? (
+      <Button
+        variant="dangerGhost"
+        size="compact"
+        iconOnly={<Square fill="currentColor" />}
+        aria-label="Stop workflow"
+        data-testid="workflow-inline-card-stop"
+        onClick={handleStop}
+      />
+    ) : undefined;
+
+  return (
+    <div className="w-full" data-testid="workflow-inline-progress-card">
+      <ToolProgressCardShell
+        data-testid="workflow-inline-card-shell"
+        statusIndicatorTestId="workflow-inline-card-status-indicator"
+        state={data.state}
+        leadingIcon={leadingIcon}
+        currentStepTitle={data.currentStepTitle}
+        currentStepInfo={data.currentStepInfo}
+        stepCount={data.stepCount}
+        // No inline timeline to reveal — the detail panel is the only
+        // detail view, so the expanded body stays disabled.
+        disableExpand
+        headerActionSlot={actionSlot}
+        onHeaderClick={onWorkflowClick ? handleHeaderClick : undefined}
+        headerAriaLabel={onWorkflowClick ? "Open workflow" : undefined}
+      >
+        {/* Children unused — `disableExpand` suppresses the body region. */}
+        <div className="hidden">
+          <PhaseGroupedStepList steps={data.steps} />
+        </div>
+      </ToolProgressCardShell>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/hooks/use-workflow-card-data.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-workflow-card-data.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests for `computeWorkflowCardData` — the pure projection that
+ * `useWorkflowCardData` wraps. Driving the pure function avoids the
+ * React + Zustand context plumbing and keeps coverage focused on the
+ * `WorkflowEntry → ToolCallCardData` mapping.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { computeWorkflowCardData } from "@/domains/chat/hooks/use-workflow-card-data";
+import type {
+  WorkflowEntry,
+  WorkflowLeaf,
+} from "@/domains/chat/workflow-store";
+
+const NOW = 1700000000000;
+
+function makeEntry(
+  overrides: Partial<Omit<WorkflowEntry, "leaves">> & {
+    leaves?: WorkflowLeaf[];
+  } = {},
+): WorkflowEntry {
+  const { leaves, ...rest } = overrides;
+  const leafMap = new Map<number, WorkflowLeaf>();
+  for (const leaf of leaves ?? []) leafMap.set(leaf.seq, leaf);
+  return {
+    runId: "wf-1",
+    status: "running",
+    agentsSpawned: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    startedAt: NOW,
+    leaves: leafMap,
+    ...rest,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// State derivation
+// ---------------------------------------------------------------------------
+
+describe("computeWorkflowCardData — state derivation", () => {
+  test("running entry → loading state", () => {
+    const data = computeWorkflowCardData(makeEntry({ status: "running" }));
+    expect(data.state).toBe("loading");
+  });
+
+  test("completed entry → complete state", () => {
+    const data = computeWorkflowCardData(makeEntry({ status: "completed" }));
+    expect(data.state).toBe("complete");
+  });
+
+  test("failed entry → error state", () => {
+    const data = computeWorkflowCardData(makeEntry({ status: "failed" }));
+    expect(data.state).toBe("error");
+  });
+
+  test("aborted entry → error state", () => {
+    const data = computeWorkflowCardData(makeEntry({ status: "aborted" }));
+    expect(data.state).toBe("error");
+  });
+
+  test("cap_exceeded entry → error state", () => {
+    const data = computeWorkflowCardData(makeEntry({ status: "cap_exceeded" }));
+    expect(data.state).toBe("error");
+  });
+
+  test("interrupted entry → error state", () => {
+    const data = computeWorkflowCardData(makeEntry({ status: "interrupted" }));
+    expect(data.state).toBe("error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Leaf → step mapping
+// ---------------------------------------------------------------------------
+
+describe("computeWorkflowCardData — leaf mapping", () => {
+  test("leaves project into tool steps sorted ascending by seq", () => {
+    const data = computeWorkflowCardData(
+      makeEntry({
+        leaves: [
+          { seq: 2, label: "Second", status: "running" },
+          { seq: 0, label: "Zeroth", status: "completed" },
+          { seq: 1, label: "First", status: "failed" },
+        ],
+      }),
+    );
+    expect(data.steps).toHaveLength(3);
+    expect(data.steps.map((s) => (s.kind === "tool" ? s.title : ""))).toEqual([
+      "Zeroth",
+      "First",
+      "Second",
+    ]);
+  });
+
+  test("leaf status maps to step status (running/failed/completed)", () => {
+    const data = computeWorkflowCardData(
+      makeEntry({
+        leaves: [
+          { seq: 0, label: "running leaf", status: "running" },
+          { seq: 1, label: "failed leaf", status: "failed" },
+          { seq: 2, label: "done leaf", status: "completed" },
+        ],
+      }),
+    );
+    const [a, b, c] = data.steps;
+    if (a?.kind === "tool") expect(a.status).toBe("running");
+    if (b?.kind === "tool") expect(b.status).toBe("error");
+    if (c?.kind === "tool") expect(c.status).toBe("completed");
+  });
+
+  test("label falls back to Leaf <seq> and info uses promptSummary", () => {
+    const data = computeWorkflowCardData(
+      makeEntry({
+        leaves: [
+          { seq: 7, status: "running", promptSummary: "find the tiger" },
+        ],
+      }),
+    );
+    const step = data.steps[0]!;
+    expect(step.kind).toBe("tool");
+    if (step.kind === "tool") {
+      expect(step.title).toBe("Leaf 7");
+      expect(step.info).toBe("find the tiger");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Header content
+// ---------------------------------------------------------------------------
+
+describe("computeWorkflowCardData — current step title/info", () => {
+  test("phase drives the header when set", () => {
+    const data = computeWorkflowCardData(
+      makeEntry({
+        phase: "Planning",
+        summary: "breaking down the goal",
+        leaves: [{ seq: 0, label: "leaf", status: "running" }],
+      }),
+    );
+    expect(data.currentStepTitle).toBe("Planning");
+    expect(data.currentStepInfo).toBe("breaking down the goal");
+  });
+
+  test("falls back to the latest leaf when no phase is set", () => {
+    const data = computeWorkflowCardData(
+      makeEntry({
+        leaves: [
+          { seq: 0, label: "First", status: "completed" },
+          { seq: 1, label: "Latest", status: "running", promptSummary: "go" },
+        ],
+      }),
+    );
+    expect(data.currentStepTitle).toBe("Latest");
+    expect(data.currentStepInfo).toBe("go");
+  });
+
+  test("falls back to the run label when there are no leaves or phase", () => {
+    const data = computeWorkflowCardData(
+      makeEntry({ label: "Research workflow" }),
+    );
+    expect(data.currentStepTitle).toBe("Research workflow");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Step count
+// ---------------------------------------------------------------------------
+
+describe("computeWorkflowCardData — step count", () => {
+  test("counts live leaves as agents", () => {
+    const data = computeWorkflowCardData(
+      makeEntry({
+        leaves: [
+          { seq: 0, status: "running" },
+          { seq: 1, status: "completed" },
+        ],
+      }),
+    );
+    expect(data.stepCount).toBe("2 agents");
+  });
+
+  test("singular pill for one agent", () => {
+    const data = computeWorkflowCardData(
+      makeEntry({ leaves: [{ seq: 0, status: "running" }] }),
+    );
+    expect(data.stepCount).toBe("1 agent");
+  });
+
+  test("falls back to agentsSpawned when no leaves are tracked", () => {
+    const data = computeWorkflowCardData(makeEntry({ agentsSpawned: 4 }));
+    expect(data.stepCount).toBe("4 agents");
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-workflow-card-data.ts
+++ b/clients/web/src/domains/chat/hooks/use-workflow-card-data.ts
@@ -1,0 +1,179 @@
+/**
+ * Builds the props for `WorkflowInlineProgressCard` from a single
+ * workflow run's store entry. Projects the run's leaves
+ * (`WorkflowLeaf[]`) into the unified `ToolCallCardStep[]` shape consumed
+ * by the shared tool-progress card chrome — the same shape the subagent
+ * inline card uses, so both share one renderer contract.
+ *
+ * The hook returns `null` when no entry exists for the given run yet —
+ * the spawn-race case where the assistant message containing the inline
+ * card mounts before the `workflow_started` event lands. The card renders
+ * `null` in that window so the transcript layout doesn't jiggle.
+ *
+ * Leaf-to-step mapping: each leaf becomes a `tool` step, sorted ascending
+ * by `seq`. The leaf status maps to the step status (`running` → running,
+ * `failed` → error, `completed` → completed). The run status maps to the
+ * card `state` (`running` → loading; `completed` → complete; everything
+ * terminal-but-not-clean → error).
+ */
+
+import { useMemo } from "react";
+
+import {
+  useWorkflowStore,
+  type WorkflowEntry,
+  type WorkflowLeaf,
+} from "@/domains/chat/workflow-store";
+import type { WorkflowRunStatus } from "@vellumai/assistant-api";
+import {
+  type ToolCallCardData,
+  type ToolCallCardStep,
+} from "@/domains/chat/utils/tool-call-card-utils";
+
+export type { ToolCallCardData, ToolCallCardStep };
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Translate a leaf status to the unified step-status enum. */
+function leafStepStatus(
+  status: WorkflowLeaf["status"],
+): Extract<ToolCallCardStep, { kind: "tool" }>["status"] {
+  switch (status) {
+    case "running":
+      return "running";
+    case "failed":
+      return "error";
+    case "completed":
+      return "completed";
+    default:
+      return "running";
+  }
+}
+
+/**
+ * Map a workflow leaf into a `tool` card step. The leaf carries no tool
+ * name or icon, so the step uses the workflow-leaf label/prompt summary
+ * directly and a neutral icon.
+ */
+function mapLeafToStep(leaf: WorkflowLeaf): ToolCallCardStep {
+  const title = leaf.label ?? `Leaf ${leaf.seq}`;
+  const info = leaf.promptSummary ?? "";
+  return {
+    kind: "tool",
+    durationLabel: "",
+    toolCallId: String(leaf.seq),
+    iconName: "bolt",
+    title,
+    info,
+    activity: "",
+    status: leafStepStatus(leaf.status),
+  };
+}
+
+/**
+ * Translate the run status to a shell-compatible visual state. `running`
+ * reads as in-flight; `completed` as a clean finish; every other terminal
+ * status (`failed`/`aborted`/`cap_exceeded`/`interrupted`) reads as an
+ * error so the card doesn't render as a clean completion.
+ */
+function deriveCardState(status: WorkflowRunStatus): ToolCallCardData["state"] {
+  switch (status) {
+    case "running":
+      return "loading";
+    case "completed":
+      return "complete";
+    case "failed":
+    case "aborted":
+    case "cap_exceeded":
+    case "interrupted":
+      return "error";
+    default:
+      return "loading";
+  }
+}
+
+/** Leaves sorted ascending by `seq` for stable render order. */
+function sortedLeaves(entry: WorkflowEntry): WorkflowLeaf[] {
+  return Array.from(entry.leaves.values()).sort((a, b) => a.seq - b.seq);
+}
+
+/**
+ * Derive the header `(title, info)` tuple. When the run carries a `phase`
+ * we surface it; otherwise we fall back to the latest leaf (the deepest
+ * `seq`), and finally to the run label.
+ */
+function deriveCurrentStep(
+  entry: WorkflowEntry,
+  leaves: WorkflowLeaf[],
+): { currentStepTitle: string; currentStepInfo: string } {
+  if (entry.phase) {
+    return {
+      currentStepTitle: entry.phase,
+      currentStepInfo: entry.summary ?? entry.label ?? "",
+    };
+  }
+
+  const latest = leaves[leaves.length - 1];
+  if (latest) {
+    return {
+      currentStepTitle: latest.label ?? `Leaf ${latest.seq}`,
+      currentStepInfo: latest.promptSummary ?? "",
+    };
+  }
+
+  return {
+    currentStepTitle: entry.label ?? "Workflow",
+    currentStepInfo: entry.summary ?? "",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Pure projection of (entry) → card props. Split from the hook so tests
+ * can drive it without instantiating the Zustand store.
+ */
+export function computeWorkflowCardData(
+  entry: WorkflowEntry,
+): ToolCallCardData {
+  const leaves = sortedLeaves(entry);
+  const steps = leaves.map(mapLeafToStep);
+
+  const state = deriveCardState(entry.status);
+  const { currentStepTitle, currentStepInfo } = deriveCurrentStep(
+    entry,
+    leaves,
+  );
+
+  // Step count reflects spawned agents, not generic "steps". Prefer the
+  // live leaf count, falling back to the run's reported `agentsSpawned`.
+  const count = entry.leaves.size || entry.agentsSpawned;
+  const stepCount = `${count} agent${count === 1 ? "" : "s"}`;
+
+  return {
+    state,
+    currentStepTitle,
+    currentStepInfo,
+    stepCount,
+    steps,
+    // Workflow cards don't use the web-search carousel.
+    carouselItems: [],
+  };
+}
+
+/**
+ * React hook: subscribe to the workflow store entry for `runId` and
+ * project it into `ToolCallCardData`. Returns `null` when no entry exists
+ * yet (spawn race) so callers can short-circuit rendering.
+ */
+export function useWorkflowCardData(runId: string): ToolCallCardData | null {
+  const entry = useWorkflowStore((state) => state.byId[runId]);
+  return useMemo(() => {
+    if (!entry) return null;
+    return computeWorkflowCardData(entry);
+  }, [entry]);
+}


### PR DESCRIPTION
## Summary
- Add use-workflow-card-data projecting a workflow run + leaves into card data
- Add the workflow inline progress card (live leaf steps), mirroring the subagent inline card

Part of plan: workflow-inspector.md (PR 10 of 13)