### PR TITLE
feat(web): workflow detail panel with a live leaf tree

### DIFF
--- a/clients/web/src/domains/chat/components/workflow-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/workflow-detail-panel.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * The detail panel renders the run header (label + status badge) and a live
+ * leaf tree. Each leaf row is keyed by `seq` and shows a status icon that
+ * resolves in place — a spinner while running, a check when completed, an
+ * alert when failed. When a run has no leaves yet, the panel asks its host to
+ * fetch the journal.
+ */
+
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+
+mock.module("@/domains/chat/components/workflow-status-badge", () => ({
+  WorkflowStatusBadge: ({ status }: { status: string }) => (
+    <div data-testid="status-badge" data-status={status} />
+  ),
+}));
+
+import { WorkflowDetailPanel } from "@/domains/chat/components/workflow-detail-panel";
+import type {
+  WorkflowEntry,
+  WorkflowLeaf,
+} from "@/domains/chat/workflow-store";
+
+const noop = () => {};
+
+function makeLeaf(overrides: Partial<WorkflowLeaf> & { seq: number }): WorkflowLeaf {
+  return {
+    status: "running",
+    ...overrides,
+  };
+}
+
+function makeEntry(overrides: Partial<WorkflowEntry> = {}): WorkflowEntry {
+  return {
+    runId: "run-1",
+    label: "Research workflow",
+    status: "running",
+    agentsSpawned: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    startedAt: Date.now(),
+    leaves: new Map(),
+    ...overrides,
+  };
+}
+
+function leafMap(leaves: WorkflowLeaf[]): Map<number, WorkflowLeaf> {
+  return new Map(leaves.map((leaf) => [leaf.seq, leaf]));
+}
+
+afterEach(() => {
+  cleanup();
+});
+afterAll(() => {
+  mock.restore();
+});
+
+describe("WorkflowDetailPanel", () => {
+  test("renders the header label and status badge", () => {
+    render(
+      <WorkflowDetailPanel
+        entry={makeEntry({ label: "Research workflow", status: "running" })}
+        onClose={noop}
+      />,
+    );
+
+    expect(screen.getByText("Research workflow")).toBeDefined();
+    const badge = screen.getByTestId("status-badge");
+    expect(badge.getAttribute("data-status")).toBe("running");
+  });
+
+  test("falls back to the runId when no label is set", () => {
+    render(
+      <WorkflowDetailPanel
+        entry={makeEntry({ label: undefined, runId: "run-xyz" })}
+        onClose={noop}
+      />,
+    );
+
+    expect(screen.getByText("run-xyz")).toBeDefined();
+  });
+
+  test("renders one row per leaf with the correct status icon", () => {
+    const { container } = render(
+      <WorkflowDetailPanel
+        entry={makeEntry({
+          leaves: leafMap([
+            makeLeaf({ seq: 0, label: "Running leaf", status: "running" }),
+            makeLeaf({ seq: 1, label: "Done leaf", status: "completed" }),
+            makeLeaf({ seq: 2, label: "Broken leaf", status: "failed" }),
+          ]),
+        })}
+        onClose={noop}
+      />,
+    );
+
+    expect(screen.getByText("Running leaf")).toBeDefined();
+    expect(screen.getByText("Done leaf")).toBeDefined();
+    expect(screen.getByText("Broken leaf")).toBeDefined();
+
+    // The running leaf shows a spinner.
+    expect(container.querySelectorAll(".animate-spin").length).toBe(1);
+  });
+
+  test("calls onRequestJournal when the run has no leaves", () => {
+    let requested: string | undefined;
+    render(
+      <WorkflowDetailPanel
+        entry={makeEntry({ runId: "run-empty", leaves: new Map() })}
+        onClose={noop}
+        onRequestJournal={(runId) => {
+          requested = runId;
+        }}
+      />,
+    );
+
+    expect(requested).toBe("run-empty");
+  });
+
+  test("does not call onRequestJournal when leaves are present", () => {
+    let called = false;
+    render(
+      <WorkflowDetailPanel
+        entry={makeEntry({ leaves: leafMap([makeLeaf({ seq: 0 })]) })}
+        onClose={noop}
+        onRequestJournal={() => {
+          called = true;
+        }}
+      />,
+    );
+
+    expect(called).toBe(false);
+  });
+
+  test("shows the Stop button only for an active run", () => {
+    const { rerender } = render(
+      <WorkflowDetailPanel
+        entry={makeEntry({ status: "running" })}
+        onClose={noop}
+        onStop={noop}
+      />,
+    );
+    expect(screen.queryByLabelText("Stop workflow")).not.toBeNull();
+
+    rerender(
+      <WorkflowDetailPanel
+        entry={makeEntry({ status: "completed" })}
+        onClose={noop}
+        onStop={noop}
+      />,
+    );
+    expect(screen.queryByLabelText("Stop workflow")).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/components/workflow-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/workflow-detail-panel.tsx
@@ -1,0 +1,356 @@
+
+import {
+    ArrowDownToLine,
+    ArrowUpFromLine,
+    CircleCheck,
+    Loader2,
+    TriangleAlert,
+    Users,
+    Workflow,
+    X,
+} from "lucide-react";
+
+import { type ReactNode, useEffect, useRef, useState } from "react";
+
+import { WorkflowStatusBadge } from "@/domains/chat/components/workflow-status-badge";
+import type { WorkflowEntry, WorkflowLeaf } from "@/domains/chat/workflow-store";
+import { isActiveStatus } from "@/utils/workflow-status";
+import { Button, Typography } from "@vellumai/design-library";
+
+/** Format a number compactly (e.g. 257400 -> "257.4K"). */
+function formatNumber(n: number): string {
+  if (n >= 1_000_000) {
+    const val = n / 1_000_000;
+    return `${val % 1 === 0 ? val.toFixed(0) : val.toFixed(1)}M`;
+  }
+  if (n >= 1_000) {
+    const val = n / 1_000;
+    return `${val % 1 === 0 ? val.toFixed(0) : val.toFixed(1)}K`;
+  }
+  return n.toLocaleString();
+}
+
+const ANIMATION_DURATION_MS = 300;
+
+function useAnimatedNumber(target: number): number {
+  const [displayed, setDisplayed] = useState(target);
+  const rafRef = useRef<number>(0);
+  const displayedRef = useRef(target);
+
+  useEffect(() => {
+    const from = displayedRef.current;
+    if (from === target) return;
+
+    cancelAnimationFrame(rafRef.current);
+    const start = performance.now();
+
+    const step = (now: number) => {
+      const elapsed = now - start;
+      const progress = Math.min(elapsed / ANIMATION_DURATION_MS, 1);
+      const eased = 1 - (1 - progress) ** 3;
+      const value = from + (target - from) * eased;
+      displayedRef.current = value;
+      setDisplayed(value);
+      if (progress < 1) {
+        rafRef.current = requestAnimationFrame(step);
+      }
+    };
+    rafRef.current = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [target]);
+
+  return displayed;
+}
+
+function MetricCard({
+  icon,
+  value,
+  label,
+}: {
+  icon: ReactNode;
+  value: string;
+  label: string;
+}) {
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] px-3 py-3">
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[var(--surface-base)]">
+        {icon}
+      </div>
+      <div className="min-w-0">
+        <Typography
+          variant="title-small"
+          className="block text-[var(--content-default)]"
+        >
+          {value}
+        </Typography>
+        <Typography
+          variant="body-small-default"
+          className="block text-[var(--content-secondary)]"
+        >
+          {label}
+        </Typography>
+      </div>
+    </div>
+  );
+}
+
+function AnimatedMetricCard({ icon, label, target, format }: {
+  icon: ReactNode; label: string; target: number; format: (n: number) => string;
+}) {
+  const animated = useAnimatedNumber(target);
+  return (
+    <MetricCard
+      icon={icon}
+      label={label}
+      value={format(animated)}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Leaf tree
+// ---------------------------------------------------------------------------
+
+function LeafStatusIcon({ status }: { status: WorkflowLeaf["status"] }) {
+  const baseClass = "h-3.5 w-3.5 shrink-0";
+  switch (status) {
+    case "completed":
+      return (
+        <CircleCheck
+          className={baseClass}
+          style={{ color: "var(--system-positive-strong)" }}
+        />
+      );
+    case "failed":
+      return (
+        <TriangleAlert
+          className={baseClass}
+          style={{ color: "var(--system-negative-strong)" }}
+        />
+      );
+    default:
+      return (
+        <Loader2
+          className={`${baseClass} animate-spin`}
+          style={{ color: "var(--primary-base)" }}
+        />
+      );
+  }
+}
+
+function LeafRow({ leaf }: { leaf: WorkflowLeaf }) {
+  const [expanded, setExpanded] = useState(false);
+  const hasDetail = Boolean(leaf.resultSummary);
+  const title = leaf.label ?? `Leaf ${leaf.seq}`;
+
+  return (
+    <div className="rounded-lg bg-[var(--surface-overlay)] px-4 py-3">
+      <button
+        type="button"
+        disabled={!hasDetail}
+        onClick={() => setExpanded((prev) => !prev)}
+        className="flex w-full items-center gap-2 text-left disabled:cursor-default"
+      >
+        <LeafStatusIcon status={leaf.status} />
+        <Typography
+          variant="body-medium-default"
+          className="min-w-0 flex-1 truncate text-[var(--content-default)]"
+        >
+          {title}
+        </Typography>
+        {hasDetail && (
+          <Typography
+            variant="body-small-default"
+            className="shrink-0 text-[var(--content-tertiary)]"
+          >
+            {expanded ? "Hide" : "Details"}
+          </Typography>
+        )}
+      </button>
+
+      {leaf.promptSummary && (
+        <Typography
+          variant="body-medium-lighter"
+          as="p"
+          className="mt-1 whitespace-pre-wrap break-words text-[var(--content-secondary)]"
+        >
+          {leaf.promptSummary}
+        </Typography>
+      )}
+
+      {hasDetail && expanded && (
+        <Typography
+          variant="body-medium-lighter"
+          as="p"
+          className="mt-2 whitespace-pre-wrap break-words text-[var(--content-secondary)]"
+        >
+          {leaf.resultSummary}
+        </Typography>
+      )}
+    </div>
+  );
+}
+
+function LeafTree({ leaves }: { leaves: Map<number, WorkflowLeaf> }) {
+  const sorted = [...leaves.values()].sort((a, b) => a.seq - b.seq);
+
+  if (sorted.length === 0) {
+    return (
+      <Typography
+        variant="body-small-default"
+        className="py-4 text-center text-[var(--content-tertiary)]"
+      >
+        No agents yet
+      </Typography>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {sorted.map((leaf) => (
+        <LeafRow key={leaf.seq} leaf={leaf} />
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface WorkflowDetailPanelProps {
+  entry: WorkflowEntry;
+  onClose: () => void;
+  onStop?: (runId: string) => void;
+  onRequestJournal?: (runId: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function WorkflowDetailPanel({
+  entry,
+  onClose,
+  onStop,
+  onRequestJournal,
+}: WorkflowDetailPanelProps) {
+  const isRunning = isActiveStatus(entry.status);
+  const title = entry.label ?? entry.runId;
+  const agentCount = entry.agentsSpawned || entry.leaves.size;
+
+  useEffect(() => {
+    if (onRequestJournal && entry.leaves.size === 0) {
+      onRequestJournal(entry.runId);
+    }
+  }, [entry.runId, entry.leaves.size, onRequestJournal]);
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden rounded-xl bg-[var(--surface-lift)]">
+      {/* Header */}
+      <div className="flex shrink-0 items-center gap-3 border-b border-[var(--border-base)] px-5 py-4">
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[var(--surface-overlay)]">
+          <Workflow className="h-4 w-4" style={{ color: "var(--content-secondary)" }} />
+        </div>
+        <Typography
+          variant="title-medium"
+          title={title}
+          className="min-w-0 shrink truncate text-[var(--content-default)]"
+        >
+          {title}
+        </Typography>
+        <WorkflowStatusBadge status={entry.status} />
+        <span className="flex-1" />
+        {isRunning && onStop && (
+          <button
+            type="button"
+            aria-label="Stop workflow"
+            onClick={() => onStop(entry.runId)}
+            className="flex shrink-0 cursor-pointer items-center gap-1.5 rounded-lg bg-[var(--system-negative-strong)] px-3 py-1.5 text-white transition-colors hover:bg-[color-mix(in_srgb,var(--system-negative-strong)_85%,black)]"
+          >
+            <Typography variant="label-small-default" className="text-white">
+              Stop
+            </Typography>
+          </button>
+        )}
+        <Button
+          variant="ghost"
+          iconOnly={<X />}
+          onClick={onClose}
+          aria-label="Close workflow detail"
+          tooltip="Close"
+          className="shrink-0"
+        />
+      </div>
+
+      {/* Scrollable body */}
+      <div className="flex-1 overflow-y-auto px-5 py-5">
+        {/* Metrics row */}
+        <div className="mb-5 grid grid-cols-3 gap-3">
+          <AnimatedMetricCard
+            icon={<ArrowDownToLine className="h-4 w-4 shrink-0" style={{ color: "var(--content-secondary)" }} />}
+            target={entry.inputTokens}
+            format={(n) => formatNumber(Math.round(n))}
+            label="Input"
+          />
+          <AnimatedMetricCard
+            icon={<ArrowUpFromLine className="h-4 w-4 shrink-0" style={{ color: "var(--content-secondary)" }} />}
+            target={entry.outputTokens}
+            format={(n) => formatNumber(Math.round(n))}
+            label="Output"
+          />
+          <AnimatedMetricCard
+            icon={<Users className="h-4 w-4 shrink-0" style={{ color: "var(--content-secondary)" }} />}
+            target={agentCount}
+            format={(n) => formatNumber(Math.round(n))}
+            label="Agents"
+          />
+        </div>
+
+        {/* Phase banner */}
+        {entry.phase && (
+          <div className="mb-5 rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] px-4 py-3">
+            <Typography
+              variant="body-medium-default"
+              className="text-[var(--content-default)]"
+            >
+              {entry.phase}
+            </Typography>
+          </div>
+        )}
+
+        {/* Summary section */}
+        {entry.summary && (
+          <div className="mb-5 rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] px-4 py-3">
+            <Typography
+              variant="body-medium-default"
+              as="h3"
+              className="mb-2 text-[var(--content-emphasised)]"
+            >
+              Summary
+            </Typography>
+            <Typography
+              variant="body-medium-lighter"
+              as="p"
+              className="whitespace-pre-wrap break-words leading-relaxed text-[var(--content-default)]"
+            >
+              {entry.summary}
+            </Typography>
+          </div>
+        )}
+
+        {/* Leaf tree section */}
+        <div>
+          <Typography
+            variant="title-medium"
+            as="h3"
+            className="mb-4 text-[var(--content-emphasised)]"
+          >
+            Agents
+          </Typography>
+          <LeafTree leaves={entry.leaves} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/workflow-status-badge.tsx
+++ b/clients/web/src/domains/chat/components/workflow-status-badge.tsx
@@ -1,0 +1,20 @@
+import type { WorkflowRunStatus } from "@vellumai/assistant-api";
+import {
+  statusColor,
+  statusLabel,
+} from "@/utils/workflow-status";
+
+export function WorkflowStatusBadge({ status }: { status: WorkflowRunStatus }) {
+  const color = statusColor(status);
+  return (
+    <span
+      className="inline-flex shrink-0 items-center gap-1 rounded-md px-2 py-0.5 text-label-small-default"
+      style={{
+        color,
+        backgroundColor: `color-mix(in srgb, ${color} 15%, transparent)`,
+      }}
+    >
+      {statusLabel(status)}
+    </span>
+  );
+}

--- a/clients/web/src/utils/workflow-status.ts
+++ b/clients/web/src/utils/workflow-status.ts
@@ -1,0 +1,47 @@
+/**
+ * Pure status-display helpers for workflow runs.
+ *
+ * Shared by workflow-detail-panel and workflow-status-badge.
+ */
+
+import type { WorkflowRunStatus } from "@vellumai/assistant-api";
+
+/** Whether the workflow run is in an active (non-terminal) state. */
+export function isActiveStatus(status: WorkflowRunStatus): boolean {
+  return status === "running";
+}
+
+/** Map a WorkflowRunStatus to a semantic color token. */
+export function statusColor(status: WorkflowRunStatus): string {
+  switch (status) {
+    case "completed":
+      return "var(--system-positive-strong)";
+    case "failed":
+    case "cap_exceeded":
+      return "var(--system-negative-strong)";
+    case "aborted":
+      return "var(--content-secondary)";
+    default:
+      return "var(--primary-base)";
+  }
+}
+
+/** Human-readable label for the status badge. */
+export function statusLabel(status: WorkflowRunStatus): string {
+  switch (status) {
+    case "running":
+      return "Running";
+    case "completed":
+      return "Completed";
+    case "failed":
+      return "Failed";
+    case "aborted":
+      return "Aborted";
+    case "cap_exceeded":
+      return "Cap Exceeded";
+    case "interrupted":
+      return "Interrupted";
+    default:
+      return "Unknown";
+  }
+}


### PR DESCRIPTION
## Summary
- Add workflow-status helpers + status badge
- Add the workflow detail panel: run header (status/tokens/phase) + a live seq-keyed leaf tree, mirroring the subagent detail panel

Part of plan: workflow-inspector.md (PR 11 of 13)