### PR TITLE
feat(web): mount the workflow detail panel + open/stop callbacks

### DIFF
--- a/clients/web/src/domains/chat/components/chat-content-layout.tsx
+++ b/clients/web/src/domains/chat/components/chat-content-layout.tsx
@@ -24,6 +24,7 @@ import { useConversationStore } from "@/stores/conversation-store";
 import { useDeployStore } from "@/stores/deploy-store";
 import { useViewerStore } from "@/stores/viewer-store";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
+import { useWorkflowStore } from "@/domains/chat/workflow-store";
 import { useEditApp } from "@/hooks/use-edit-app";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { routes } from "@/utils/routes";
@@ -31,6 +32,11 @@ import { routes } from "@/utils/routes";
 const SubagentDetailPanel = lazy(() =>
   import("@/domains/chat/components/subagent-detail-panel").then((m) => ({
     default: m.SubagentDetailPanel,
+  })),
+);
+const WorkflowDetailPanel = lazy(() =>
+  import("@/domains/chat/components/workflow-detail-panel").then((m) => ({
+    default: m.WorkflowDetailPanel,
   })),
 );
 const ToolDetailPanel = lazy(() =>
@@ -49,9 +55,11 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
   const openedDocumentState = useViewerStore.use.openedDocumentState();
   const editingConversationId = useConversationStore.use.editingConversationId();
   const activeSubagentId = useViewerStore.use.activeSubagentId();
+  const activeWorkflowRunId = useViewerStore.use.activeWorkflowRunId();
   const activeToolDetail = useViewerStore.use.activeToolDetail();
   const closeToolDetail = useViewerStore.use.closeToolDetail();
   const subagentById = useSubagentStore((s) => s.byId);
+  const workflowById = useWorkflowStore((s) => s.byId);
 
   const isSharing = useDeployStore.use.isSharing();
   const isDeploying = useDeployStore.use.isDeploying();
@@ -111,6 +119,21 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
     void useSubagentStore.getState().fetchDetailIfNeeded(aid, id);
   }, []);
 
+  const onCloseWorkflowDetail = useCallback(() => {
+    useViewerStore.getState().closeWorkflowDetail();
+  }, []);
+
+  const onStopWorkflow = useCallback(
+    (runId: string) => void useWorkflowStore.getState().abortRun(runId),
+    [],
+  );
+
+  const onRequestWorkflowJournal = useCallback((runId: string) => {
+    const aid = useResolvedAssistantsStore.getState().activeAssistantId;
+    if (!aid) return;
+    void useWorkflowStore.getState().fetchJournalIfNeeded(aid, runId);
+  }, []);
+
   // -------------------------------------------------------------------------
   // Escape closes whichever right-hand side panel is open (tool detail /
   // thought process, subagent detail, document viewer). Surfaces stacked
@@ -139,6 +162,9 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
           break;
         case "subagent-detail":
           viewer.closeSubagentDetail();
+          break;
+        case "workflow-detail":
+          viewer.closeWorkflowDetail();
           break;
         case "document":
           viewer.closeDocument();
@@ -262,6 +288,33 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
                 onClose={onCloseSubagentDetail}
                 onStop={onStopSubagent}
                 onRequestDetail={onRequestSubagentDetail}
+              />
+            </LazyBoundary>
+          }
+        />
+      );
+    }
+  }
+
+  // Workflow detail side panel
+  if (mainView === "workflow-detail" && activeWorkflowRunId && !isMobile) {
+    const activeEntry = workflowById[activeWorkflowRunId];
+    if (activeEntry) {
+      return (
+        <ResizablePanel
+          storageKey="workflowDetailPanelWidth"
+          hideDivider
+          defaultRightWidth={400}
+          minLeftWidth={300}
+          minRightWidth={400}
+          left={chatContent}
+          right={
+            <LazyBoundary>
+              <WorkflowDetailPanel
+                entry={activeEntry}
+                onClose={onCloseWorkflowDetail}
+                onStop={onStopWorkflow}
+                onRequestJournal={onRequestWorkflowJournal}
               />
             </LazyBoundary>
           }

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -58,6 +58,7 @@ import type { UIContext } from "@/domains/chat/turn-selectors";
 import { getDiskPressureChatBlockReason } from "@/assistant/disk-pressure";
 import { useActiveProfileModel } from "@/domains/chat/hooks/use-active-profile-model";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
+import { useWorkflowStore } from "@/domains/chat/workflow-store";
 import { isChannelConversation } from "@/domains/chat/utils/conversation-channel";
 import { useViewerStore } from "@/stores/viewer-store";
 import { cmdEnterToSend } from "@/utils/composer-settings";
@@ -266,6 +267,15 @@ export function ChatMainPanel({
 
   const onStopSubagent = useCallback(
     (subagentId: string) => void useSubagentStore.getState().abortSubagent(subagentId),
+    [],
+  );
+
+  const onWorkflowClick = useCallback((runId: string) => {
+    useViewerStore.getState().openWorkflowDetail(runId);
+  }, []);
+
+  const onStopWorkflow = useCallback(
+    (runId: string) => void useWorkflowStore.getState().abortRun(runId),
     [],
   );
 
@@ -714,6 +724,8 @@ export function ChatMainPanel({
     },
     onSubagentClick,
     onStopSubagent,
+    onWorkflowClick,
+    onStopWorkflow,
     renderOnboardingChoice,
   };
 

--- a/clients/web/src/domains/chat/transcript/transcript.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript.tsx
@@ -88,6 +88,11 @@ export interface TranscriptProps {
   onSubagentClick?: (subagentId: string) => void;
   /** Callback to abort/stop a running subagent from an inline card. */
   onStopSubagent?: (subagentId: string) => void;
+  /** Click handler when the user opens the workflow detail panel from an
+   *  inline workflow run card. */
+  onWorkflowClick?: (runId: string) => void;
+  /** Callback to abort/stop a running workflow from an inline card. */
+  onStopWorkflow?: (runId: string) => void;
   /** Optional render-prop that produces the chat avatar element to mount
    *  at the bottom of the conversation. Rendered inside the latest-edge
    *  region so the avatar pins to the bottom of the viewport while the


### PR DESCRIPTION
## Summary
- Lazy-mount WorkflowDetailPanel under mainView=workflow-detail in a resizable side panel
- Wire close/stop/request-journal + onWorkflowClick/onStopWorkflow callbacks, mirroring the subagent panel

Part of plan: workflow-inspector.md (PR 12 of 13)