### PR TITLE
feat(web): anchor the workflow inline card to the run_workflow tool call

### DIFF
--- a/clients/web/src/domains/chat/transcript/latest-turn-row.tsx
+++ b/clients/web/src/domains/chat/transcript/latest-turn-row.tsx
@@ -58,6 +58,11 @@ export interface LatestTurnRowProps {
   onSubagentClick?: (subagentId: string) => void;
   /** Callback to abort/stop a running subagent from an inline card. */
   onStopSubagent?: (subagentId: string) => void;
+  /** Click handler when the user clicks the open button on an inline workflow
+   *  progress card. */
+  onWorkflowClick?: (runId: string) => void;
+  /** Callback to abort/stop a running workflow from an inline card. */
+  onStopWorkflow?: (runId: string) => void;
 }
 
 export const LatestTurnRow = memo(function LatestTurnRow({
@@ -79,6 +84,8 @@ export const LatestTurnRow = memo(function LatestTurnRow({
   assistantId,
   onSubagentClick,
   onStopSubagent,
+  onWorkflowClick,
+  onStopWorkflow,
 }: LatestTurnRowProps) {
   // The response cluster is "streaming" whenever the turn is in flight. This
   // keeps each response message's last tool-call group expanded for the whole
@@ -106,6 +113,8 @@ export const LatestTurnRow = memo(function LatestTurnRow({
         assistantId={assistantId}
         onSubagentClick={onSubagentClick}
         onStopSubagent={onStopSubagent}
+        onWorkflowClick={onWorkflowClick}
+        onStopWorkflow={onStopWorkflow}
       />
       {responseItems.map((response) => (
         <Fragment key={response.key}>
@@ -127,6 +136,8 @@ export const LatestTurnRow = memo(function LatestTurnRow({
             assistantId={assistantId}
             onSubagentClick={onSubagentClick}
             onStopSubagent={onStopSubagent}
+            onWorkflowClick={onWorkflowClick}
+            onStopWorkflow={onStopWorkflow}
             isStreaming={isStreaming}
           />
         </Fragment>

--- a/clients/web/src/domains/chat/transcript/message-content.test.ts
+++ b/clients/web/src/domains/chat/transcript/message-content.test.ts
@@ -5,6 +5,7 @@ import type { Surface } from "@/domains/chat/types/types";
 import type { ConversationContentBlock } from "@vellumai/assistant-api";
 import {
   groupContentBlocks,
+  isRunWorkflowCall,
   isSubagentSpawnCall,
   isSuppressedUiTool,
   isTaskProgressSurface,
@@ -192,6 +193,35 @@ describe("isSubagentSpawnCall", () => {
     expect(isSubagentSpawnCall(toolCall({ id: "x", name: "bash" }))).toBe(false);
     expect(
       isSubagentSpawnCall(
+        toolCall({ id: "x", name: "skill_execute", input: { tool: "other" } }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("isRunWorkflowCall", () => {
+  test("matches bare run_workflow", () => {
+    expect(isRunWorkflowCall(toolCall({ id: "x", name: "run_workflow" }))).toBe(
+      true,
+    );
+  });
+
+  test("matches skill_execute with input.tool === run_workflow", () => {
+    expect(
+      isRunWorkflowCall(
+        toolCall({
+          id: "x",
+          name: "skill_execute",
+          input: { tool: "run_workflow" },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  test("does not match other tools or other skill_execute inputs", () => {
+    expect(isRunWorkflowCall(toolCall({ id: "x", name: "bash" }))).toBe(false);
+    expect(
+      isRunWorkflowCall(
         toolCall({ id: "x", name: "skill_execute", input: { tool: "other" } }),
       ),
     ).toBe(false);

--- a/clients/web/src/domains/chat/transcript/message-content.ts
+++ b/clients/web/src/domains/chat/transcript/message-content.ts
@@ -212,6 +212,22 @@ export function isSubagentSpawnCall(toolCall: ChatMessageToolCall): boolean {
 }
 
 /**
+ * Detect whether a tool call is a `run_workflow` invocation. Like
+ * `subagent_spawn`, the daemon exposes `run_workflow` as a bundled-skill tool,
+ * so the LLM emits a `skill_execute` call with `input.tool === "run_workflow"`
+ * — the `tool_use_start` event the frontend receives still carries
+ * `toolName: "skill_execute"`. Matching on the raw `toolName` alone would miss
+ * every launch and leave the inline workflow card unrendered.
+ */
+export function isRunWorkflowCall(toolCall: ChatMessageToolCall): boolean {
+  if (toolCall.name === "run_workflow") return true;
+  if (toolCall.name !== "skill_execute") return false;
+  const input = toolCall.input;
+  if (input == null || typeof input !== "object") return false;
+  return (input as Record<string, unknown>).tool === "run_workflow";
+}
+
+/**
  * Detect a task-progress card surface — `template === "task_progress"` with a
  * non-empty `steps` array. Single source of truth shared by `CardSurface`'s
  * render-detection and the activity-summary path's hoist-detection so the two

--- a/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
@@ -1,4 +1,7 @@
-import { isSubagentSpawnCall } from "@/domains/chat/transcript/message-content";
+import {
+  isRunWorkflowCall,
+  isSubagentSpawnCall,
+} from "@/domains/chat/transcript/message-content";
 import {
   EMPTY_SUBAGENT_ENTRIES,
   type SubagentEntry,
@@ -62,6 +65,11 @@ export interface TranscriptMessageBodyProps {
   onSubagentClick?: (subagentId: string) => void;
   /** Callback to abort/stop a running subagent from an inline card. */
   onStopSubagent?: (subagentId: string) => void;
+  /** Click handler when the user clicks a workflow's open button on an inline
+   *  workflow progress card. */
+  onWorkflowClick?: (runId: string) => void;
+  /** Callback to abort/stop a running workflow from an inline card. */
+  onStopWorkflow?: (runId: string) => void;
   /**
    * True when this message belongs to the turn that is actively streaming.
    * Set by `LatestTurnRow` for the in-progress response cluster; history
@@ -168,6 +176,62 @@ export function resolveSpawnedSubagentIds(
     if (next) {
       ids.push(next.subagentId);
       claimed.add(next.subagentId);
+    }
+  }
+
+  return ids;
+}
+
+/**
+ * Extract the launched `runId` from a `run_workflow` tool call's result. The
+ * daemon's workflow tool returns `JSON.stringify({ runId, status, message })`.
+ * Returns `null` when the result hasn't landed yet or the payload is malformed
+ * — callers fall back to the `byToolUseId` anchor so `running` workflows still
+ * render an inline card.
+ */
+function extractRunIdFromResult(toolCall: ChatMessageToolCall): string | null {
+  if (!isRunWorkflowCall(toolCall)) return null;
+  if (typeof toolCall.result !== "string" || !toolCall.result) return null;
+  try {
+    const parsed = JSON.parse(toolCall.result) as { runId?: unknown };
+    return typeof parsed.runId === "string" ? parsed.runId : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the launched `runId` for each `run_workflow` tool call in
+ * `toolCalls`. Resolution priority per tool call:
+ *
+ *  1. `byToolUseId.get(tc.id)` — the deterministic, reconcile-proof anchor
+ *     carried on the `workflow_started` event.
+ *  2. The id encoded in `toolCall.result` — present once the workflow tool
+ *     result has landed.
+ *
+ * The caller owns the `claimed` Set so it persists across every invocation
+ * within a single message, stopping two non-consecutive launch tool-call
+ * groups from both anchoring the same run id.
+ */
+export function resolveWorkflowRunIds(
+  toolCalls: ChatMessageToolCall[],
+  byToolUseId: Map<string, string>,
+  claimed: Set<string>,
+): string[] {
+  const ids: string[] = [];
+
+  for (const tc of toolCalls) {
+    if (!isRunWorkflowCall(tc)) continue;
+    const byId = byToolUseId.get(tc.id);
+    if (byId && !claimed.has(byId)) {
+      ids.push(byId);
+      claimed.add(byId);
+      continue;
+    }
+    const fromResult = extractRunIdFromResult(tc);
+    if (fromResult && !claimed.has(fromResult)) {
+      ids.push(fromResult);
+      claimed.add(fromResult);
     }
   }
 

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -13,6 +13,7 @@ import { MessageAttachments } from "@/domains/chat/components/chat-attachments/m
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
 import { MessageHoverActions } from "@/domains/chat/components/message-hover-actions/message-hover-actions";
 import { SubagentInlineProgressCard } from "@/domains/chat/components/subagent-inline-progress-card/subagent-inline-progress-card";
+import { WorkflowInlineProgressCard } from "@/domains/chat/components/workflow-inline-progress-card/workflow-inline-progress-card";
 import { SurfaceRouter } from "@/domains/chat/components/surfaces/surface-router";
 import { SingleActivity } from "@/domains/chat/components/single-activity/single-activity";
 import { MultiActivityGroup } from "@/domains/chat/components/multi-activity-group/multi-activity-group";
@@ -23,6 +24,7 @@ import {
 import {
   type ContentBlockActivityItem,
   groupContentBlocks,
+  isRunWorkflowCall,
   isSubagentSpawnCall,
   isSuppressedUiTool,
 } from "@/domains/chat/transcript/message-content";
@@ -31,12 +33,14 @@ import { getSlackLinkUrl } from "@/domains/chat/types/types";
 import { wireSurfaceToDisplay } from "@/domains/chat/utils/map-runtime-message";
 import { isPointerCoarse } from "@/utils/pointer";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
+import { useWorkflowStore } from "@/domains/chat/workflow-store";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { ConversationMessageSurface } from "@vellumai/assistant-api";
 import {
   isInteractiveClickTarget,
   lookupSubagentEntriesForMessage,
   resolveSpawnedSubagentIds,
+  resolveWorkflowRunIds,
   SlackMessageAttribution,
   type TranscriptMessageBodyProps,
 } from "@/domains/chat/transcript/transcript-message-body-shared";
@@ -69,6 +73,8 @@ export function TranscriptMessageBody({
   assistantId,
   onSubagentClick,
   onStopSubagent,
+  onWorkflowClick,
+  onStopWorkflow,
   isStreaming = false,
 }: TranscriptMessageBodyProps) {
   const isSlackMessage = Boolean(message.slackMessage);
@@ -135,7 +141,9 @@ export function TranscriptMessageBody({
     (s) => lookupSubagentEntriesForMessage(s.byParent, message),
   );
   const byToolUseId = useSubagentStore.use.byToolUseId();
+  const byToolUseIdWf = useWorkflowStore.use.byToolUseId();
   const claimedSpawnIds = new Set<string>();
+  const claimedWorkflowIds = new Set<string>();
 
   const renderTextWithInlineSurfaces = (text: string, key: string) => {
     const inlineSegments = parseInlineSurfaces(text);
@@ -196,6 +204,27 @@ export function TranscriptMessageBody({
     );
   };
 
+  const renderInlineWorkflowCards = (toolCalls: ChatMessageToolCall[]) => {
+    const runIds = resolveWorkflowRunIds(
+      toolCalls,
+      byToolUseIdWf,
+      claimedWorkflowIds,
+    );
+    if (runIds.length === 0) return null;
+    return (
+      <div className="flex w-full flex-col gap-1.5">
+        {runIds.map((runId) => (
+          <WorkflowInlineProgressCard
+            key={runId}
+            runId={runId}
+            onWorkflowClick={onWorkflowClick}
+            onStopWorkflow={onStopWorkflow}
+          />
+        ))}
+      </div>
+    );
+  };
+
   const renderSurfaceNode = (
     surface: ConversationMessageSurface,
     key: string,
@@ -246,7 +275,7 @@ export function TranscriptMessageBody({
       }
     }
     const renderableToolCalls = groupToolCalls.filter(
-      (tc) => !isSubagentSpawnCall(tc),
+      (tc) => !isSubagentSpawnCall(tc) && !isRunWorkflowCall(tc),
     );
     const loneTool =
       cardItems.length === 1 &&
@@ -261,6 +290,7 @@ export function TranscriptMessageBody({
         <Fragment key={key}>
           <SingleActivity variant="tool" toolCall={loneTool} />
           {renderInlineSubagentCards(groupToolCalls)}
+          {renderInlineWorkflowCards(groupToolCalls)}
         </Fragment>
       );
     }
@@ -281,6 +311,7 @@ export function TranscriptMessageBody({
             />
           </div>
           {renderInlineSubagentCards(groupToolCalls)}
+          {renderInlineWorkflowCards(groupToolCalls)}
         </Fragment>
       );
     }
@@ -301,6 +332,7 @@ export function TranscriptMessageBody({
           />
         )}
         {renderInlineSubagentCards(groupToolCalls)}
+        {renderInlineWorkflowCards(groupToolCalls)}
       </Fragment>
     );
   };

--- a/clients/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-row.tsx
@@ -64,6 +64,11 @@ export interface TranscriptRowProps {
   onSubagentClick?: (subagentId: string) => void;
   /** Callback to abort/stop a running subagent from an inline card. */
   onStopSubagent?: (subagentId: string) => void;
+  /** Click handler when the user clicks the open button on an inline workflow
+   *  progress card. */
+  onWorkflowClick?: (runId: string) => void;
+  /** Callback to abort/stop a running workflow from an inline card. */
+  onStopWorkflow?: (runId: string) => void;
   /** True when this row belongs to the actively-streaming turn. Forwarded to
    *  `TranscriptMessageBody` so the streaming message's last tool-call group
    *  defaults open. History rows leave it `false`. */
@@ -88,6 +93,8 @@ export const TranscriptRow = memo(function TranscriptRow({
   assistantId,
   onSubagentClick,
   onStopSubagent,
+  onWorkflowClick,
+  onStopWorkflow,
   isStreaming,
 }: TranscriptRowProps) {
   switch (item.kind) {
@@ -110,6 +117,8 @@ export const TranscriptRow = memo(function TranscriptRow({
           assistantId={assistantId}
           onSubagentClick={onSubagentClick}
           onStopSubagent={onStopSubagent}
+          onWorkflowClick={onWorkflowClick}
+          onStopWorkflow={onStopWorkflow}
           isStreaming={isStreaming}
         />
       );

--- a/clients/web/src/domains/chat/transcript/transcript.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript.tsx
@@ -252,6 +252,8 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
       assistantId: rest.assistantId,
       onSubagentClick: rest.onSubagentClick,
       onStopSubagent: rest.onStopSubagent,
+      onWorkflowClick: rest.onWorkflowClick,
+      onStopWorkflow: rest.onStopWorkflow,
     };
 
     return (


### PR DESCRIPTION
## Summary
- Render the workflow inline progress card in the transcript, anchored to the run_workflow (skill_execute) tool call via byToolUseId (result-parse fallback)
- Suppress the raw skill_execute chip for run_workflow

Part of plan: workflow-inspector.md (PR 13 of 13)