### PR TITLE
refactor(web): extract shared metric-card primitives

### DIFF
--- a/clients/web/src/domains/chat/components/metric-card.tsx
+++ b/clients/web/src/domains/chat/components/metric-card.tsx
@@ -1,0 +1,94 @@
+
+import { type ReactNode, useEffect, useRef, useState } from "react";
+
+import { Typography } from "@vellumai/design-library";
+
+/** Format a number compactly (e.g. 257400 -> "257.4K"). */
+export function formatNumber(n: number): string {
+  if (n >= 1_000_000) {
+    const val = n / 1_000_000;
+    return `${val % 1 === 0 ? val.toFixed(0) : val.toFixed(1)}M`;
+  }
+  if (n >= 1_000) {
+    const val = n / 1_000;
+    return `${val % 1 === 0 ? val.toFixed(0) : val.toFixed(1)}K`;
+  }
+  return n.toLocaleString();
+}
+
+export const ANIMATION_DURATION_MS = 300;
+
+export function useAnimatedNumber(target: number): number {
+  const [displayed, setDisplayed] = useState(target);
+  const rafRef = useRef<number>(0);
+  const displayedRef = useRef(target);
+
+  useEffect(() => {
+    const from = displayedRef.current;
+    if (from === target) return;
+
+    cancelAnimationFrame(rafRef.current);
+    const start = performance.now();
+
+    const step = (now: number) => {
+      const elapsed = now - start;
+      const progress = Math.min(elapsed / ANIMATION_DURATION_MS, 1);
+      const eased = 1 - (1 - progress) ** 3;
+      const value = from + (target - from) * eased;
+      displayedRef.current = value;
+      setDisplayed(value);
+      if (progress < 1) {
+        rafRef.current = requestAnimationFrame(step);
+      }
+    };
+    rafRef.current = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [target]);
+
+  return displayed;
+}
+
+export function MetricCard({
+  icon,
+  value,
+  label,
+}: {
+  icon: ReactNode;
+  value: string;
+  label: string;
+}) {
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] px-3 py-3">
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[var(--surface-base)]">
+        {icon}
+      </div>
+      <div className="min-w-0">
+        <Typography
+          variant="title-small"
+          className="block text-[var(--content-default)]"
+        >
+          {value}
+        </Typography>
+        <Typography
+          variant="body-small-default"
+          className="block text-[var(--content-secondary)]"
+        >
+          {label}
+        </Typography>
+      </div>
+    </div>
+  );
+}
+
+export function AnimatedMetricCard({ icon, label, target, format }: {
+  icon: ReactNode; label: string; target: number; format: (n: number) => string;
+}) {
+  const animated = useAnimatedNumber(target);
+  return (
+    <MetricCard
+      icon={icon}
+      label={label}
+      value={format(animated)}
+    />
+  );
+}

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -7,9 +7,13 @@ import {
     X,
 } from "lucide-react";
 
-import { type ReactNode, useEffect, useRef, useState } from "react";
+import { useEffect } from "react";
 
 import { AvatarRenderer } from "@/components/avatar-renderer";
+import {
+    AnimatedMetricCard,
+    formatNumber,
+} from "@/domains/chat/components/metric-card";
 import { StatusBadge } from "@/domains/chat/components/subagent-status-badge";
 import type { SubagentEntry } from "@/domains/chat/subagent-store";
 import { subagentTraits } from "@/utils/avatar-subagent";
@@ -18,19 +22,6 @@ import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-component
 import { Button, Typography } from "@vellumai/design-library";
 
 import { SubagentTimeline } from "@/domains/chat/components/subagent-timeline";
-
-/** Format a number compactly (e.g. 257400 -> "257.4K"). */
-function formatNumber(n: number): string {
-  if (n >= 1_000_000) {
-    const val = n / 1_000_000;
-    return `${val % 1 === 0 ? val.toFixed(0) : val.toFixed(1)}M`;
-  }
-  if (n >= 1_000) {
-    const val = n / 1_000;
-    return `${val % 1 === 0 ? val.toFixed(0) : val.toFixed(1)}K`;
-  }
-  return n.toLocaleString();
-}
 
 /** Format a cost value (e.g. 0.68 -> "0.68"). */
 function formatCost(cost: number): string {
@@ -41,83 +32,6 @@ function formatCost(cost: number): string {
     return cost.toFixed(4);
   }
   return cost.toFixed(2);
-}
-
-const ANIMATION_DURATION_MS = 300;
-
-function useAnimatedNumber(target: number): number {
-  const [displayed, setDisplayed] = useState(target);
-  const rafRef = useRef<number>(0);
-  const displayedRef = useRef(target);
-
-  useEffect(() => {
-    const from = displayedRef.current;
-    if (from === target) return;
-
-    cancelAnimationFrame(rafRef.current);
-    const start = performance.now();
-
-    const step = (now: number) => {
-      const elapsed = now - start;
-      const progress = Math.min(elapsed / ANIMATION_DURATION_MS, 1);
-      const eased = 1 - (1 - progress) ** 3;
-      const value = from + (target - from) * eased;
-      displayedRef.current = value;
-      setDisplayed(value);
-      if (progress < 1) {
-        rafRef.current = requestAnimationFrame(step);
-      }
-    };
-    rafRef.current = requestAnimationFrame(step);
-    return () => cancelAnimationFrame(rafRef.current);
-  }, [target]);
-
-  return displayed;
-}
-
-function MetricCard({
-  icon,
-  value,
-  label,
-}: {
-  icon: ReactNode;
-  value: string;
-  label: string;
-}) {
-  return (
-    <div className="flex items-center gap-3 rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] px-3 py-3">
-      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[var(--surface-base)]">
-        {icon}
-      </div>
-      <div className="min-w-0">
-        <Typography
-          variant="title-small"
-          className="block text-[var(--content-default)]"
-        >
-          {value}
-        </Typography>
-        <Typography
-          variant="body-small-default"
-          className="block text-[var(--content-secondary)]"
-        >
-          {label}
-        </Typography>
-      </div>
-    </div>
-  );
-}
-
-function AnimatedMetricCard({ icon, label, target, format }: {
-  icon: ReactNode; label: string; target: number; format: (n: number) => string;
-}) {
-  const animated = useAnimatedNumber(target);
-  return (
-    <MetricCard
-      icon={icon}
-      label={label}
-      value={format(animated)}
-    />
-  );
 }
 
 // ---------------------------------------------------------------------------

--- a/clients/web/src/domains/chat/components/workflow-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/workflow-detail-panel.tsx
@@ -10,102 +10,16 @@ import {
     X,
 } from "lucide-react";
 
-import { type ReactNode, useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
+import {
+    AnimatedMetricCard,
+    formatNumber,
+} from "@/domains/chat/components/metric-card";
 import { WorkflowStatusBadge } from "@/domains/chat/components/workflow-status-badge";
 import type { WorkflowEntry, WorkflowLeaf } from "@/domains/chat/workflow-store";
 import { isActiveStatus } from "@/utils/workflow-status";
 import { Button, Typography } from "@vellumai/design-library";
-
-/** Format a number compactly (e.g. 257400 -> "257.4K"). */
-function formatNumber(n: number): string {
-  if (n >= 1_000_000) {
-    const val = n / 1_000_000;
-    return `${val % 1 === 0 ? val.toFixed(0) : val.toFixed(1)}M`;
-  }
-  if (n >= 1_000) {
-    const val = n / 1_000;
-    return `${val % 1 === 0 ? val.toFixed(0) : val.toFixed(1)}K`;
-  }
-  return n.toLocaleString();
-}
-
-const ANIMATION_DURATION_MS = 300;
-
-function useAnimatedNumber(target: number): number {
-  const [displayed, setDisplayed] = useState(target);
-  const rafRef = useRef<number>(0);
-  const displayedRef = useRef(target);
-
-  useEffect(() => {
-    const from = displayedRef.current;
-    if (from === target) return;
-
-    cancelAnimationFrame(rafRef.current);
-    const start = performance.now();
-
-    const step = (now: number) => {
-      const elapsed = now - start;
-      const progress = Math.min(elapsed / ANIMATION_DURATION_MS, 1);
-      const eased = 1 - (1 - progress) ** 3;
-      const value = from + (target - from) * eased;
-      displayedRef.current = value;
-      setDisplayed(value);
-      if (progress < 1) {
-        rafRef.current = requestAnimationFrame(step);
-      }
-    };
-    rafRef.current = requestAnimationFrame(step);
-    return () => cancelAnimationFrame(rafRef.current);
-  }, [target]);
-
-  return displayed;
-}
-
-function MetricCard({
-  icon,
-  value,
-  label,
-}: {
-  icon: ReactNode;
-  value: string;
-  label: string;
-}) {
-  return (
-    <div className="flex items-center gap-3 rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] px-3 py-3">
-      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[var(--surface-base)]">
-        {icon}
-      </div>
-      <div className="min-w-0">
-        <Typography
-          variant="title-small"
-          className="block text-[var(--content-default)]"
-        >
-          {value}
-        </Typography>
-        <Typography
-          variant="body-small-default"
-          className="block text-[var(--content-secondary)]"
-        >
-          {label}
-        </Typography>
-      </div>
-    </div>
-  );
-}
-
-function AnimatedMetricCard({ icon, label, target, format }: {
-  icon: ReactNode; label: string; target: number; format: (n: number) => string;
-}) {
-  const animated = useAnimatedNumber(target);
-  return (
-    <MetricCard
-      icon={icon}
-      label={label}
-      value={format(animated)}
-    />
-  );
-}
 
 // ---------------------------------------------------------------------------
 // Leaf tree


### PR DESCRIPTION
## Summary
- Extract formatNumber/useAnimatedNumber/MetricCard/AnimatedMetricCard into a shared module
- Import from both the workflow and subagent detail panels (removes ~75 lines of verbatim duplication)

Addresses a self-review slop finding for plan: workflow-inspector.md