### PR TITLE
fix(web): mobile overlay for the workflow detail panel

### DIFF
--- a/clients/web/src/domains/chat/components/mobile-chat-overlays.tsx
+++ b/clients/web/src/domains/chat/components/mobile-chat-overlays.tsx
@@ -14,6 +14,7 @@ import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useDeployStore } from "@/stores/deploy-store";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
+import { useWorkflowStore } from "@/domains/chat/workflow-store";
 import { useViewerStore } from "@/stores/viewer-store";
 import { routes } from "@/utils/routes";
 
@@ -21,6 +22,7 @@ import { MobileAppOverlay } from "@/domains/chat/components/mobile-app-overlay";
 import { MobileDocumentOverlay } from "@/domains/chat/components/mobile-document-overlay";
 import { MobileSubagentDetailOverlay } from "@/domains/chat/components/mobile-subagent-detail-overlay";
 import { MobileToolDetailOverlay } from "@/domains/chat/components/mobile-tool-detail-overlay";
+import { MobileWorkflowDetailOverlay } from "@/domains/chat/components/mobile-workflow-detail-overlay";
 import { useMobileOverlayTarget } from "@/domains/chat/hooks/use-mobile-overlay-target";
 
 export function MobileChatOverlays() {
@@ -34,7 +36,9 @@ export function MobileChatOverlays() {
   const isAppMinimized = useViewerStore.use.isAppMinimized();
   const activeSubagentId = useViewerStore.use.activeSubagentId();
   const activeToolDetail = useViewerStore.use.activeToolDetail();
+  const activeWorkflowRunId = useViewerStore.use.activeWorkflowRunId();
   const subagentById = useSubagentStore.use.byId();
+  const workflowById = useWorkflowStore.use.byId();
   const isSharing = useDeployStore.use.isSharing();
   const isDeploying = useDeployStore.use.isDeploying();
   const handleCloseApp = useCallback(() => {
@@ -82,6 +86,21 @@ export function MobileChatOverlays() {
     void useSubagentStore.getState().fetchDetailIfNeeded(aid, subagentId);
   }, []);
 
+  const handleCloseWorkflowDetail = useCallback(() => {
+    useViewerStore.getState().closeWorkflowDetail();
+  }, []);
+
+  const handleStopWorkflow = useCallback(
+    (runId: string) => void useWorkflowStore.getState().abortRun(runId),
+    [],
+  );
+
+  const handleRequestWorkflowJournal = useCallback((runId: string) => {
+    const aid = useResolvedAssistantsStore.getState().activeAssistantId;
+    if (!aid) return;
+    void useWorkflowStore.getState().fetchJournalIfNeeded(aid, runId);
+  }, []);
+
   const handleCloseToolDetail = useCallback(() => {
     useViewerStore.getState().closeToolDetail();
   }, []);
@@ -122,6 +141,16 @@ export function MobileChatOverlays() {
         onClose={handleCloseSubagentDetail}
         onStop={handleStopSubagent}
         onRequestDetail={handleRequestSubagentDetail}
+      />
+      <MobileWorkflowDetailOverlay
+        entry={
+          mainView === "workflow-detail" && activeWorkflowRunId
+            ? workflowById[activeWorkflowRunId] ?? null
+            : null
+        }
+        onClose={handleCloseWorkflowDetail}
+        onStop={handleStopWorkflow}
+        onRequestJournal={handleRequestWorkflowJournal}
       />
       <MobileToolDetailOverlay
         detail={mainView === "tool-detail" ? activeToolDetail : null}

--- a/clients/web/src/domains/chat/components/mobile-workflow-detail-overlay.tsx
+++ b/clients/web/src/domains/chat/components/mobile-workflow-detail-overlay.tsx
@@ -1,0 +1,59 @@
+import { lazy } from "react";
+
+import { LazyBoundary } from "@/components/lazy-boundary";
+import type { WorkflowEntry } from "@/domains/chat/workflow-store";
+
+const WorkflowDetailPanel = lazy(() =>
+  import("@/domains/chat/components/workflow-detail-panel").then((m) => ({
+    default: m.WorkflowDetailPanel,
+  })),
+);
+
+interface MobileWorkflowDetailOverlayProps {
+  /** When `null`, the overlay renders nothing. */
+  entry: WorkflowEntry | null;
+  /** Closes the overlay. */
+  onClose: () => void;
+  /** Stop a running workflow. */
+  onStop?: (runId: string) => void;
+  /** Request journal fetch for a workflow run. */
+  onRequestJournal?: (runId: string) => void;
+}
+
+/**
+ * Mobile-only full-screen overlay that hosts the workflow detail panel.
+ *
+ * **Mounting constraint**: must render inside `RootLayout`'s
+ * `#viewport-overlays` portal, outside the main content wrapper.
+ */
+export function MobileWorkflowDetailOverlay({
+  entry,
+  onClose,
+  onStop,
+  onRequestJournal,
+}: MobileWorkflowDetailOverlayProps) {
+  if (!entry) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed inset-x-0 bottom-0 z-30 h-[100dvh]"
+      style={{
+        paddingTop: "var(--safe-area-inset-top, env(safe-area-inset-top, 0px))",
+        paddingBottom: "var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px))",
+        paddingLeft: "var(--safe-area-inset-left, env(safe-area-inset-left, 0px))",
+        paddingRight: "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))",
+      }}
+    >
+      <LazyBoundary>
+        <WorkflowDetailPanel
+          entry={entry}
+          onClose={onClose}
+          onStop={onStop}
+          onRequestJournal={onRequestJournal}
+        />
+      </LazyBoundary>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Render WorkflowDetailPanel as a mobile overlay on mainView=workflow-detail (mirrors the subagent mobile overlay)
- Fixes tapping a workflow card on mobile landing on a blank/stuck view

Addresses a self-review gap for plan: workflow-inspector.md