### PR TITLE
fix(web): workflow store lifecycle + dead-param cleanup

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-conversation-change-effects.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-change-effects.ts
@@ -15,6 +15,7 @@
 import { useEffect } from "react";
 
 import { useSubagentStore } from "@/domains/chat/subagent-store";
+import { useWorkflowStore } from "@/domains/chat/workflow-store";
 
 export function useConversationChangeEffects(
   assistantId: string | null,
@@ -26,6 +27,7 @@ export function useConversationChangeEffects(
   // This effect catches the URL-navigation path where wrappers don't run.
   useEffect(() => {
     useSubagentStore.getState().reset();
+    useWorkflowStore.getState().reset();
   }, [activeConversationId]);
 
   // Stable signal: changes only when the set of subagent IDs that need a

--- a/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
@@ -24,6 +24,7 @@ import { toast } from "@vellumai/design-library";
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { requestComposerFocus } from "@/domains/chat/composer-focus";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
+import { useWorkflowStore } from "@/domains/chat/workflow-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { haptic } from "@/utils/haptics";
 import { routes } from "@/utils/routes";
@@ -385,6 +386,7 @@ export function useConversationLoader({
   const switchConversation = useCallback(
     (key: string) => {
       useSubagentStore.getState().reset();
+      useWorkflowStore.getState().reset();
       useViewerStore.getState().setMainView("chat");
       if (key === useConversationStore.getState().activeConversationId) return;
       void navigate(routes.conversation(key));
@@ -399,6 +401,7 @@ export function useConversationLoader({
     ({ silent }: { silent?: boolean } = {}) => {
       if (!silent) haptic.light();
       useSubagentStore.getState().reset();
+      useWorkflowStore.getState().reset();
       useViewerStore.getState().setMainView("chat");
       const draftConversationId = createDraftConversationId();
       useConversationStore.getState().setActiveConversationId(draftConversationId);

--- a/clients/web/src/domains/chat/hooks/use-send-message.ts
+++ b/clients/web/src/domains/chat/hooks/use-send-message.ts
@@ -52,6 +52,7 @@ import {
 } from "@/utils/conversation-cache-mutations";
 import { findConversation, patchConversation } from "@/utils/conversation-cache";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
+import { useWorkflowStore } from "@/domains/chat/workflow-store";
 import {
   consumePendingPreChatContext,
   type PreChatOnboardingContext,
@@ -893,6 +894,7 @@ export function useSendMessage({
     setMessages(clearPendingConfirmationsFromMessages);
     useInteractionStore.getState().resetAll();
     useSubagentStore.getState().reset();
+    useWorkflowStore.getState().reset();
     useChatSessionStore.getState().clearConfirmationToolCallMap();
     try {
       await conversationsByIdCancelPost({

--- a/clients/web/src/domains/chat/utils/conversation-navigation.ts
+++ b/clients/web/src/domains/chat/utils/conversation-navigation.ts
@@ -6,6 +6,7 @@ import { routes } from "@/utils/routes";
 import { requestComposerFocus } from "@/domains/chat/composer-focus";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
+import { useWorkflowStore } from "@/domains/chat/workflow-store";
 import { useViewerStore } from "@/stores/viewer-store";
 import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
 import { getSoundManager } from "@/lib/sounds/sound-manager";
@@ -23,6 +24,7 @@ export function navigateToConversation(
   haptic.light();
   useViewerStore.getState().setMainView("chat");
   useSubagentStore.getState().reset();
+  useWorkflowStore.getState().reset();
   useConversationStore.getState().setActiveConversationId(conversationId);
   void navigate(routes.conversation(conversationId));
 }
@@ -47,6 +49,7 @@ export function navigateToNewConversation(
   }
   useViewerStore.getState().setMainView("chat");
   useSubagentStore.getState().reset();
+  useWorkflowStore.getState().reset();
   const draftId = createDraftConversationId();
   useConversationStore.getState().setActiveConversationId(draftId);
   void navigate(routes.conversation(draftId));

--- a/clients/web/src/domains/chat/utils/stream-handlers/workflow-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/workflow-handlers.ts
@@ -15,7 +15,6 @@ export function handleWorkflowStarted(
 ): void {
   useWorkflowStore.getState().startRun({
     runId: event.runId,
-    conversationId: event.conversationId,
     toolUseId: event.toolUseId,
     label: event.label,
     timestamp: Date.now(),
@@ -30,7 +29,6 @@ export function handleWorkflowProgress(
     runId: event.runId,
     phase: event.phase,
     agentsSpawned: event.agentsSpawned,
-    message: event.message,
     label: event.label,
   });
 }
@@ -43,7 +41,6 @@ export function handleWorkflowLeafStarted(
     runId: event.runId,
     seq: event.seq,
     label: event.label,
-    phase: event.phase,
     promptSummary: event.promptSummary,
   });
 }

--- a/clients/web/src/domains/chat/workflow-store.test.ts
+++ b/clients/web/src/domains/chat/workflow-store.test.ts
@@ -322,6 +322,25 @@ describe("fetchJournalIfNeeded", () => {
 });
 
 // ---------------------------------------------------------------------------
+// reset
+// ---------------------------------------------------------------------------
+
+describe("reset", () => {
+  it("clears all runs, ordering, and indexes", () => {
+    getState().startRun({ runId: "wf-r", toolUseId: "tu-r", timestamp: NOW });
+    getState().leafStarted({ runId: "wf-r", seq: 0, label: "Leaf" });
+
+    getState().reset();
+
+    const state = getState();
+    expect(state.byId).toEqual({});
+    expect(state.orderedIds).toEqual([]);
+    expect(state.byToolUseId.size).toBe(0);
+    expect(state.fetchedAt.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Reference stability
 // ---------------------------------------------------------------------------
 

--- a/clients/web/src/domains/chat/workflow-store.ts
+++ b/clients/web/src/domains/chat/workflow-store.ts
@@ -37,7 +37,6 @@ export type WorkflowLeafStatus = "running" | "completed" | "failed";
 export interface WorkflowLeaf {
   seq: number;
   label?: string;
-  phase?: string;
   promptSummary?: string;
   status: WorkflowLeafStatus;
   resultSummary?: string;
@@ -95,7 +94,6 @@ export interface WorkflowState {
 export interface WorkflowActions {
   startRun: (params: {
     runId: string;
-    conversationId?: string;
     toolUseId?: string;
     label?: string;
     timestamp: number;
@@ -105,7 +103,6 @@ export interface WorkflowActions {
     runId: string;
     phase?: string;
     agentsSpawned?: number;
-    message?: string;
     label?: string;
   }) => void;
 
@@ -113,7 +110,6 @@ export interface WorkflowActions {
     runId: string;
     seq: number;
     label?: string;
-    phase?: string;
     promptSummary?: string;
   }) => void;
 
@@ -279,7 +275,6 @@ const useWorkflowStoreBase = create<WorkflowStore>()((set, get) => ({
       seq: params.seq,
       status: "running",
       label: params.label ?? current?.label,
-      phase: params.phase ?? current?.phase,
       promptSummary: params.promptSummary ?? current?.promptSummary,
     };
     const nextLeaves = new Map(base.leaves).set(params.seq, leaf);
@@ -302,7 +297,6 @@ const useWorkflowStoreBase = create<WorkflowStore>()((set, get) => ({
       seq: params.seq,
       status: params.status,
       label: params.label ?? current?.label,
-      phase: current?.phase,
       promptSummary: current?.promptSummary,
       inputTokens: params.inputTokens ?? current?.inputTokens,
       outputTokens: params.outputTokens ?? current?.outputTokens,
@@ -370,7 +364,6 @@ const useWorkflowStoreBase = create<WorkflowStore>()((set, get) => ({
           seq: journalLeaf.seq,
           status: journalStatus,
           label: journalLeaf.label,
-          phase: journalLeaf.phase,
           promptSummary: journalLeaf.promptSummary,
           resultSummary: journalLeaf.resultSummary,
         });
@@ -389,7 +382,6 @@ const useWorkflowStoreBase = create<WorkflowStore>()((set, get) => ({
           ...current,
           status: journalStatus,
           label: current.label ?? journalLeaf.label,
-          phase: current.phase ?? journalLeaf.phase,
           promptSummary: current.promptSummary ?? journalLeaf.promptSummary,
           resultSummary: current.resultSummary ?? journalLeaf.resultSummary,
         });

--- a/clients/web/src/utils/workflow-status.ts
+++ b/clients/web/src/utils/workflow-status.ts
@@ -20,6 +20,7 @@ export function statusColor(status: WorkflowRunStatus): string {
     case "cap_exceeded":
       return "var(--system-negative-strong)";
     case "aborted":
+    case "interrupted":
       return "var(--content-secondary)";
     default:
       return "var(--primary-base)";


### PR DESCRIPTION
## Summary
- Reset useWorkflowStore on conversation change (mirror subagent store); clear stale workflow detail on switch
- Drop dead conversationId/message params and write-only WorkflowLeaf.phase
- statusColor: render interrupted as terminal/neutral (was active-blue)

Addresses self-review gaps for plan: workflow-inspector.md