### PR TITLE
fix(web): restore system schedules to the Activity page

### DIFF
--- a/clients/web/.cross-domain-allowlist.json
+++ b/clients/web/.cross-domain-allowlist.json
@@ -20,6 +20,9 @@
   "src/domains/home/components/schedule-detail-panel.tsx": [
     "settings"
   ],
+  "src/domains/home/components/system-task-detail-panel.tsx": [
+    "settings"
+  ],
   "src/domains/home/home-page.tsx": [
     "settings"
   ],

--- a/clients/web/src/domains/home/components/home-schedules-panel.tsx
+++ b/clients/web/src/domains/home/components/home-schedules-panel.tsx
@@ -1,4 +1,5 @@
 import { Calendar } from "lucide-react";
+import type { ReactNode } from "react";
 
 import { HomeEmptyState } from "@/domains/home/components/home-empty-state";
 import { HomeScheduleRow } from "@/domains/home/components/home-schedule-row";
@@ -20,6 +21,12 @@ export interface HomeSchedulesPanelProps {
   selectedScheduleId: string | null;
   onStartNewChat: () => void;
   onCreateSchedule: () => void;
+  /**
+   * Built-in system schedules (heartbeat, consolidation, memory retrospective),
+   * rendered below the user list so both share one scroll region. Self-hides
+   * when there are no system tasks to show.
+   */
+  systemTasksSlot?: ReactNode;
 }
 
 export function HomeSchedulesPanel({
@@ -34,6 +41,7 @@ export function HomeSchedulesPanel({
   selectedScheduleId,
   onStartNewChat,
   onCreateSchedule,
+  systemTasksSlot,
 }: HomeSchedulesPanelProps) {
   const renderScheduleRow = (schedule: Schedule) => (
     <HomeScheduleRow
@@ -126,6 +134,11 @@ export function HomeSchedulesPanel({
   };
 
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto">{renderBody()}</div>
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      {renderBody()}
+      {systemTasksSlot ? (
+        <div className="mt-[var(--app-spacing-lg)]">{systemTasksSlot}</div>
+      ) : null}
+    </div>
   );
 }

--- a/clients/web/src/domains/home/components/system-task-detail-panel.tsx
+++ b/clients/web/src/domains/home/components/system-task-detail-panel.tsx
@@ -1,0 +1,311 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { Loader2, Play, Settings, X } from "lucide-react";
+import { useNavigate } from "react-router";
+
+import { SCHEDULE_RUNS_PAGE_SIZE } from "@/domains/settings/api/schedules";
+import {
+  ModelProfileRow,
+  type ScheduleModelProfileCallSite,
+} from "@/domains/settings/components/model-profile-row";
+import { RecentRunsCard } from "@/domains/settings/components/recent-runs-card";
+import {
+  consolidationSubtitle,
+  flattenRunPages,
+  formatTimestamp,
+  heartbeatSubtitle,
+  RETROSPECTIVE_SUBTITLE,
+} from "@/domains/settings/utils/schedule-formatters";
+import { toScheduleRun } from "@/domains/settings/utils/system-task-run-transforms";
+import {
+  consolidationRunsGetInfiniteOptions,
+  heartbeatRunsGetInfiniteOptions,
+  retrospectiveRunsGetInfiniteOptions,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+import { routes } from "@/utils/routes";
+import { Button, Typography, cn } from "@vellumai/design-library";
+import { Notice } from "@vellumai/design-library/components/notice";
+import { Toggle } from "@vellumai/design-library/components/toggle";
+
+import type { SystemTaskKind } from "@/domains/settings/types/schedules";
+
+// Mirrors the private map in `system-task-detail-view.tsx`; redeclared here to
+// keep this change scoped to the home domain.
+const SYSTEM_TASK_PROFILE_CALL_SITES: Record<
+  SystemTaskKind,
+  ScheduleModelProfileCallSite
+> = {
+  heartbeat: "heartbeatAgent",
+  consolidation: "memoryV2Consolidation",
+  retrospective: "memoryRetrospective",
+};
+
+type SystemTasksData = ReturnType<
+  typeof import("@/domains/settings/hooks/use-system-tasks").useSystemTasks
+>;
+
+function SectionLabel({ children }: { children: string }) {
+  return (
+    <Typography
+      variant="label-small-default"
+      as="div"
+      className="mb-2 uppercase tracking-wider text-[var(--content-tertiary)]"
+    >
+      {children}
+    </Typography>
+  );
+}
+
+export interface SystemTaskDetailPanelProps {
+  kind: SystemTaskKind;
+  assistantId: string;
+  systemTasks: SystemTasksData;
+  canOpenMemorySettings: boolean;
+  isMobile?: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Inline detail for a built-in system task (heartbeat, consolidation, memory
+ * retrospective) shown in the home right pane. Mirrors `ScheduleDetailPanel`'s
+ * chrome so system and user schedules share one side-panel UX, while reusing
+ * the system-task config/runs/mutations from `useSystemTasks`.
+ */
+export function SystemTaskDetailPanel({
+  kind,
+  assistantId,
+  systemTasks,
+  canOpenMemorySettings,
+  isMobile,
+  onClose,
+}: SystemTaskDetailPanelProps) {
+  const navigate = useNavigate();
+  const { heartbeatConfig, consolidationConfig, retrospectiveConfig } =
+    systemTasks;
+
+  let name: string;
+  let subtitle: string;
+  let enabled: boolean;
+  let nextRunAt: number | null;
+  let lastRunAt: number | null;
+  let isRunning: boolean;
+  let onRunNow: (() => void) | undefined;
+
+  if (kind === "heartbeat") {
+    name = "Heartbeat";
+    subtitle = heartbeatConfig ? heartbeatSubtitle(heartbeatConfig) : "";
+    enabled = heartbeatConfig?.enabled ?? false;
+    nextRunAt = heartbeatConfig?.nextRunAt ?? null;
+    lastRunAt = heartbeatConfig?.lastRunAt ?? null;
+    isRunning = systemTasks.isHeartbeatRunning;
+    onRunNow = systemTasks.runHeartbeatNow;
+  } else if (kind === "consolidation") {
+    name = "Consolidation";
+    subtitle = consolidationConfig
+      ? consolidationSubtitle(consolidationConfig)
+      : "";
+    enabled = consolidationConfig?.enabled ?? false;
+    nextRunAt = consolidationConfig?.nextRunAt ?? null;
+    lastRunAt = consolidationConfig?.lastRunAt ?? null;
+    isRunning = systemTasks.isConsolidationRunning;
+    onRunNow = systemTasks.runConsolidationNow;
+  } else {
+    name = "Memory retrospective";
+    subtitle = RETROSPECTIVE_SUBTITLE;
+    enabled = retrospectiveConfig?.enabled ?? false;
+    // Event-driven: no global "next run".
+    nextRunAt = retrospectiveConfig?.nextRunAt ?? null;
+    lastRunAt = retrospectiveConfig?.lastRunAt ?? null;
+    isRunning = false;
+    onRunNow = undefined;
+  }
+
+  // Consolidation and retrospective are owned by Memory: no toggle of their
+  // own, paused when Memory is off. Retrospective additionally has no global
+  // schedule, so it hides Next run.
+  const isMemoryManaged = kind !== "heartbeat";
+  const isRetrospective = kind === "retrospective";
+  const isMemoryPaused = isMemoryManaged && !enabled;
+  const runNowDisabled = isRunning || isMemoryPaused;
+  const statusValue = isMemoryManaged
+    ? enabled
+      ? "On · Managed by Memory"
+      : "Paused"
+    : enabled
+      ? "Enabled"
+      : "Disabled";
+  const pausedNotice = isRetrospective
+    ? "Memory is off, so retrospectives are paused. Turn Memory back on to resume them."
+    : "Memory is off, so consolidation is paused. Turn Memory back on to resume consolidation.";
+  const showMemorySettings =
+    isMemoryManaged && enabled && canOpenMemorySettings;
+
+  const opts = {
+    path: { assistant_id: assistantId },
+    query: { limit: SCHEDULE_RUNS_PAGE_SIZE },
+  };
+
+  // Extract queryKey/queryFn individually — spreading the full options union
+  // triggers TS2769 because the three generated option types have subtly
+  // different `enabled` callback generics that don't unify.
+  const infiniteOpts =
+    kind === "heartbeat"
+      ? heartbeatRunsGetInfiniteOptions(opts)
+      : kind === "consolidation"
+        ? consolidationRunsGetInfiniteOptions(opts)
+        : retrospectiveRunsGetInfiniteOptions(opts);
+
+  const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteQuery({
+      queryKey: infiniteOpts.queryKey,
+      queryFn: infiniteOpts.queryFn,
+      initialPageParam: { path: opts.path, query: {} },
+      getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+      staleTime: 10_000,
+    });
+  const runs = flattenRunPages(
+    data?.pages.map((page) => ({
+      runs: page.runs.map((run) => toScheduleRun(run, kind)),
+    })),
+  );
+
+  return (
+    <div
+      className={cn(
+        "flex h-full flex-col bg-[var(--surface-overlay)]",
+        !isMobile &&
+          "rounded-[var(--radius-xl)] border border-[var(--border-base)]",
+      )}
+    >
+      {/* Header */}
+      <div className="flex shrink-0 items-center gap-3 border-b border-[var(--border-base)] p-[var(--app-spacing-lg)]">
+        <div className="min-w-0 flex-1">
+          <Typography
+            variant="title-small"
+            className="truncate text-[var(--content-default)]"
+          >
+            {name}
+          </Typography>
+          {subtitle ? (
+            <Typography
+              variant="body-small-default"
+              as="p"
+              className="truncate text-[var(--content-tertiary)]"
+            >
+              {subtitle}
+            </Typography>
+          ) : null}
+        </div>
+        <Button
+          variant="ghost"
+          iconOnly={<X />}
+          onClick={onClose}
+          aria-label="Close schedule details"
+          tooltip="Close"
+          className="shrink-0"
+        />
+      </div>
+
+      {/* Scrollable body */}
+      <div className="flex-1 space-y-6 overflow-y-auto px-[var(--app-spacing-lg)] py-[var(--app-spacing-lg)]">
+        <section>
+          <SectionLabel>Details</SectionLabel>
+          <div className="space-y-2 rounded-lg border border-[var(--border-base)] bg-[var(--surface-lift)] px-4 py-3 text-body-medium-lighter">
+            <ModelProfileRow
+              assistantId={assistantId}
+              defaultCallSite={SYSTEM_TASK_PROFILE_CALL_SITES[kind]}
+              fallbackLabel="Default (system task model)"
+              respectCallSiteOverride
+            />
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-[var(--content-secondary)]">Status</span>
+              <span className="flex items-center gap-2 text-[var(--content-default)]">
+                <span>{statusValue}</span>
+                {!isMemoryManaged ? (
+                  <Toggle
+                    checked={enabled}
+                    onChange={systemTasks.toggleHeartbeat}
+                    aria-label={`Toggle ${name}`}
+                  />
+                ) : null}
+              </span>
+            </div>
+            {!isRetrospective ? (
+              <div className="flex items-center justify-between gap-4">
+                <span className="text-[var(--content-secondary)]">
+                  Next run
+                </span>
+                <span className="text-[var(--content-default)]">
+                  {formatTimestamp(nextRunAt)}
+                </span>
+              </div>
+            ) : null}
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-[var(--content-secondary)]">Last run</span>
+              <span className="text-[var(--content-default)]">
+                {formatTimestamp(lastRunAt)}
+              </span>
+            </div>
+          </div>
+          {isMemoryPaused ? (
+            <Notice
+              tone="warning"
+              className="mt-4"
+              actions={
+                canOpenMemorySettings ? (
+                  <Button
+                    variant="outlined"
+                    size="compact"
+                    onClick={() => navigate(routes.settings.advanced)}
+                  >
+                    Turn on Memory
+                  </Button>
+                ) : undefined
+              }
+            >
+              {pausedNotice}
+            </Notice>
+          ) : null}
+        </section>
+
+        <RecentRunsCard
+          runs={runs}
+          isLoading={isLoading}
+          hasMore={hasNextPage}
+          isLoadingMore={isFetchingNextPage}
+          onLoadMore={() => void fetchNextPage()}
+        />
+      </div>
+
+      {/* Footer actions */}
+      {showMemorySettings || onRunNow ? (
+        <div className="flex shrink-0 items-center justify-end gap-2 border-t border-[var(--border-base)] p-[var(--app-spacing-lg)]">
+          {showMemorySettings ? (
+            <Button
+              variant="outlined"
+              leftIcon={<Settings className="h-3.5 w-3.5" />}
+              onClick={() => navigate(routes.settings.advanced)}
+            >
+              Memory settings
+            </Button>
+          ) : null}
+          {onRunNow ? (
+            <Button
+              variant="primary"
+              leftIcon={
+                isRunning ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Play className="h-3.5 w-3.5" />
+                )
+              }
+              onClick={onRunNow}
+              disabled={runNowDisabled}
+            >
+              {isRunning ? "Running…" : "Run now"}
+            </Button>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/clients/web/src/domains/home/home-page.tsx
+++ b/clients/web/src/domains/home/home-page.tsx
@@ -1,18 +1,26 @@
+import { useQuery } from "@tanstack/react-query";
 import { useCallback, useEffect, useState, type ReactNode } from "react";
 
+import { getAssistantHealthz } from "@/assistant/api";
 import { PageShell } from "@/components/page-shell";
 import { CreateScheduleModal } from "@/domains/settings/components/create-schedule-modal";
+import { SystemTasksSection } from "@/domains/settings/components/system-tasks-section";
+import { useSystemTasks } from "@/domains/settings/hooks/use-system-tasks";
 import { useIsMobile } from "@/hooks/use-is-mobile";
+import { useEffectiveTimezone } from "@/utils/use-effective-timezone";
 import type { FeedItem, FeedItemStatus } from "@vellumai/assistant-api";
 import { ResizablePanel, Tabs } from "@vellumai/design-library";
 import { HomeSchedulesPanel } from "./components/home-schedules-panel";
 import { ScheduleDetailPanel } from "./components/schedule-detail-panel";
+import { SystemTaskDetailPanel } from "./components/system-task-detail-panel";
 import { HomeDetailPanel } from "./detail-panel/home-detail-panel";
 import { HomeFeedList } from "./home-feed-list";
 import { HomeTopHeader } from "./home-top-header";
 import { useHomeSchedulesData } from "./hooks/use-home-schedules-data";
 import { useHomeFeedQuery } from "./hooks/use-home-feed-query";
 import { useHomeStateQuery } from "./hooks/use-home-state-query";
+
+import type { SystemTaskKind } from "@/domains/settings/types/schedules";
 
 function HomePageSkeleton() {
   return (
@@ -55,9 +63,23 @@ export function HomePage({
   onOpenConversation,
 }: HomePageProps) {
   const isMobile = useIsMobile();
+  const tz = useEffectiveTimezone();
   const feedQuery = useHomeFeedQuery(assistantId);
   useHomeStateQuery(assistantId);
   const schedules = useHomeSchedulesData(assistantId);
+  const systemTasks = useSystemTasks(assistantId, tz);
+
+  // Gates the consolidation/retrospective "Memory settings" link the same way
+  // the schedules surface always has.
+  const { data: canOpenMemorySettings = false } = useQuery({
+    queryKey: ["assistant-memory-opt-out-capability", assistantId],
+    queryFn: async () => {
+      const result = await getAssistantHealthz(assistantId);
+      return result.ok && result.data.capabilities?.memoryOptOut === true;
+    },
+    retry: false,
+    staleTime: 10_000,
+  });
 
   const [createScheduleOpen, setCreateScheduleOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<"schedules" | "notifications">(
@@ -67,6 +89,8 @@ export function HomePage({
   const [selectedScheduleId, setSelectedScheduleId] = useState<string | null>(
     null,
   );
+  const [selectedSystemTaskKind, setSelectedSystemTaskKind] =
+    useState<SystemTaskKind | null>(null);
 
   const selectedSchedule = selectedScheduleId
     ? (schedules.recurring.find((s) => s.id === selectedScheduleId) ??
@@ -79,16 +103,41 @@ export function HomePage({
     if (selectedScheduleId && !selectedSchedule) setSelectedScheduleId(null);
   }, [selectedScheduleId, selectedSchedule]);
 
-  // The right pane shows one detail at a time — selecting a schedule closes any
-  // open feed item, and vice versa.
+  const systemTaskAvailable =
+    selectedSystemTaskKind === "heartbeat"
+      ? systemTasks.heartbeatConfig != null
+      : selectedSystemTaskKind === "consolidation"
+        ? systemTasks.consolidationConfig?.available === true
+        : selectedSystemTaskKind === "retrospective"
+          ? systemTasks.retrospectiveConfig?.available === true
+          : false;
+
+  // Drop the selection if the task becomes unavailable (e.g. memory turned
+  // off), but only once its config has loaded so we don't clear mid-fetch.
+  useEffect(() => {
+    if (selectedSystemTaskKind && !systemTasks.isLoading && !systemTaskAvailable) {
+      setSelectedSystemTaskKind(null);
+    }
+  }, [selectedSystemTaskKind, systemTaskAvailable, systemTasks.isLoading]);
+
+  // The right pane shows one detail at a time — selecting one kind (user
+  // schedule, system task, or feed item) closes the others.
   const handleSelectSchedule = useCallback((scheduleId: string) => {
     setSelectedItem(null);
+    setSelectedSystemTaskKind(null);
     setSelectedScheduleId(scheduleId);
+  }, []);
+
+  const handleSelectSystemTask = useCallback((kind: SystemTaskKind) => {
+    setSelectedItem(null);
+    setSelectedScheduleId(null);
+    setSelectedSystemTaskKind(kind);
   }, []);
 
   const handleSelectItem = useCallback(
     (item: FeedItem) => {
       setSelectedScheduleId(null);
+      setSelectedSystemTaskKind(null);
       if (item.status === "new") {
         setSelectedItem({ ...item, status: "seen" });
         feedQuery.updateStatus.mutate({ itemId: item.id, status: "seen" });
@@ -183,10 +232,25 @@ export function HomePage({
     />
   ) : null;
 
+  const systemTaskDetail =
+    selectedSystemTaskKind && systemTaskAvailable ? (
+      <SystemTaskDetailPanel
+        kind={selectedSystemTaskKind}
+        assistantId={assistantId}
+        systemTasks={systemTasks}
+        canOpenMemorySettings={canOpenMemorySettings}
+        isMobile={isMobile}
+        onClose={() => setSelectedSystemTaskKind(null)}
+      />
+    ) : null;
+
+  // The schedules tab shows either a user-schedule or a system-task detail.
+  const scheduleAreaDetail = scheduleDetail ?? systemTaskDetail;
+
   // On mobile the detail takes over the whole screen (handled below). On
   // desktop it opens as a drawer nested under the active tab, so the Overview
   // title and the tabs stay fixed above it.
-  const mobileDetail = itemDetail ?? scheduleDetail;
+  const mobileDetail = itemDetail ?? scheduleAreaDetail;
 
   const withDrawer = (section: ReactNode, detail: ReactNode) =>
     detail && !isMobile ? (
@@ -221,6 +285,22 @@ export function HomePage({
       selectedScheduleId={selectedScheduleId}
       onStartNewChat={onStartNewChat}
       onCreateSchedule={() => setCreateScheduleOpen(true)}
+      systemTasksSlot={
+        <SystemTasksSection
+          heartbeatConfig={systemTasks.heartbeatConfig}
+          consolidationConfig={systemTasks.consolidationConfig}
+          retrospectiveConfig={systemTasks.retrospectiveConfig}
+          heartbeatUsage={systemTasks.heartbeatUsage}
+          consolidationUsage={systemTasks.consolidationUsage}
+          retrospectiveUsage={systemTasks.retrospectiveUsage}
+          isLoading={systemTasks.isLoading}
+          hasError={systemTasks.hasError}
+          onRetry={systemTasks.refetchAll}
+          onSelectHeartbeat={() => handleSelectSystemTask("heartbeat")}
+          onSelectConsolidation={() => handleSelectSystemTask("consolidation")}
+          onSelectRetrospective={() => handleSelectSystemTask("retrospective")}
+        />
+      }
     />
   );
 
@@ -269,7 +349,7 @@ export function HomePage({
         value="schedules"
         className="mt-[var(--app-spacing-lg)] flex min-h-0 flex-1 flex-col"
       >
-        {withDrawer(schedulesSection, scheduleDetail)}
+        {withDrawer(schedulesSection, scheduleAreaDetail)}
       </Tabs.Panel>
       <Tabs.Panel
         value="notifications"


### PR DESCRIPTION
## Summary
- When schedules moved from Settings to the Activity page, only user-created schedules were ported — the built-in **system schedules** (Heartbeat, Memory Consolidation, Memory Retrospective) silently dropped off. This wires the existing `useSystemTasks` hook and `SystemTasksSection` into the **Activity → Schedules** tab so they appear again below the user schedules, sharing one scroll region.
- Adds `SystemTaskDetailPanel` (home drawer chrome mirroring `ScheduleDetailPanel`) so clicking a system schedule opens status / heartbeat toggle / recent runs / Run now / Memory settings in the same right-side drawer as user schedules — mutually exclusive with the user-schedule and feed-item details, and full-screen on mobile. Reuses all settings data and presentation (`RecentRunsCard`, `ModelProfileRow`, per-kind runs query, run transforms) — no duplicated logic.
- Regenerates `.cross-domain-allowlist.json` (sanctioned generator) for the new home component — a direct sibling of the already-allowlisted `schedule-detail-panel.tsx`.

## Original prompt
After schedules were relocated from the Settings page to the new Activity page (Schedules / Notifications tabs), the system schedules — heartbeat, memory consolidation, and memory retrospectives — stopped appearing; only user-created schedules remained. The ask was to add the system schedules back into the Activity view. We surface them in the Schedules tab with a detail drawer matching the user-schedule UX, and leave removing the now-orphaned old Settings schedules page as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)