### PR TITLE
fix(web): handle workflow run-lifecycle events in the chat stream handler

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -368,6 +368,15 @@ export function useStreamEventHandler(
         case "subagent_event":
           handleSubagentEvent(event, ctx);
           break;
+        // Workflow run lifecycle (run_workflow orchestration). These carry a
+        // `conversationId` for routing to an inline workflow card; the web
+        // client does not surface workflow runs, so they are no-ops here.
+        case "workflow_started":
+        case "workflow_progress":
+        case "workflow_leaf_started":
+        case "workflow_leaf_finished":
+        case "workflow_completed":
+          break;
         // Cross-domain events handled by bus subscribers mounted in
         // RootLayout (useAssistantResourceSync, useConversationSync,
         // useNotificationIntentSync, useDocumentEditorSync) or


### PR DESCRIPTION
## Summary
- The chat stream handler's `switch (event.type)` ends in an exhaustive `never` guard. Five `workflow_*` run-lifecycle events (`workflow_started`, `workflow_progress`, `workflow_leaf_started`, `workflow_leaf_finished`, `workflow_completed`) flowed into the `AssistantEvent` union via `@vellumai/assistant-api` but had no `case`, breaking the clients/web type-check (TS2322 at the guard).
- Adds a no-op fall-through `case` group for the five events. No `src` code consumes workflow events (the inline workflow card isn't built in the web client yet), so they are intentionally ignored — matching the existing cross-domain / diagnostic no-op groups in the same switch. Restores a clean `bunx tsc --noEmit` for clients/web.

## Original prompt
While restoring system schedules in a prior change, `bunx tsc` surfaced a pre-existing error in `src/domains/chat/hooks/use-stream-event-handler.ts`: the exhaustive event switch didn't handle the new `workflow_*` events that had flowed into the `AssistantEvent` union from the API package. The ask was to fix that type error. Since no UI consumes workflow events yet, the fix is to add them as no-op cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)