### PR TITLE
fix(web): drop workflow_* switch cases absent from the AssistantEvent union

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
+++ b/clients/web/src/domains/chat/hooks/use-stream-event-handler.ts
@@ -368,15 +368,6 @@ export function useStreamEventHandler(
         case "subagent_event":
           handleSubagentEvent(event, ctx);
           break;
-        // Workflow run lifecycle (run_workflow orchestration). These carry a
-        // `conversationId` for routing to an inline workflow card; the web
-        // client does not surface workflow runs, so they are no-ops here.
-        case "workflow_started":
-        case "workflow_progress":
-        case "workflow_leaf_started":
-        case "workflow_leaf_finished":
-        case "workflow_completed":
-          break;
         // Cross-domain events handled by bus subscribers mounted in
         // RootLayout (useAssistantResourceSync, useConversationSync,
         // useNotificationIntentSync, useDocumentEditorSync) or


### PR DESCRIPTION
## Summary
- The clients/web `Type Check` CI job failed with five TS2678 errors: `use-stream-event-handler.ts` had `case "workflow_*"` labels for events that are **not** members of the committed `AssistantEvent` union (`@vellumai/assistant-api`, regenerated by CI from `assistant/src/api`, which has no workflow event schemas).
- Removed the five orphaned no-op cases. `workflow_*` are internal daemon broadcasts (`daemon/message-types/workflows.ts`), not public SSE wire-schema members — they already arrive on the wire as `UnknownEvent` and are absorbed by the existing `case "unknown"` no-op. All 52 real union members keep their cases, so the switch stays exhaustive at the `never` guard.
- Net-reverts #35268, which was validated against a **stale local generated copy** of `@vellumai/assistant-api` that still contained the workflow schemas (so a local `tsc` is misleading here — only CI's clean regen exposes the error).

## Original prompt
Fix the specific failing CI job only — the `Type Check` job in the "CI/CD Main Web" run for `clients/web` (run 27747237135, job 82088457964) — and nothing else. The job broke on `main` after #35268 added `workflow_*` handler cases for event types absent from the committed API. Scoped to that one job, auto-merged (`--yolo`, `--skip-ci`).