### PR TITLE
Remove Playwright step from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,6 @@ on:
         required: false
         type: string
         default: ''
-      playwright_blocks_release:
-        description: 'Whether Playwright test failures should block the production release'
-        required: false
-        type: boolean
-        default: false
 
 concurrency:
   group: release
@@ -377,7 +372,6 @@ jobs:
           CLIENT_SECRET: ${{ secrets.CWS_CLIENT_SECRET }}
           REFRESH_TOKEN: ${{ secrets.CWS_REFRESH_TOKEN }}
           PUBLISHER_ID: ${{ vars.CWS_PUBLISHER_ID }}
-          E2E_BLOCKS_RELEASE: ${{ inputs.playwright_blocks_release }}
         run: |
           # Extension has CRX Verified Uploads enabled — CWS requires a signed .crx
           UPLOAD_FILE=$(ls /tmp/chrome-extension/*.crx)
@@ -390,11 +384,7 @@ jobs:
           set -e
           echo "$OUTPUT"
           if [ $EXIT -ne 0 ] && echo "$OUTPUT" | grep -q "ITEM_NOT_UPDATABLE"; then
-            if [ "$E2E_BLOCKS_RELEASE" = "true" ]; then
-              echo "::error::CWS rejected upload with ITEM_NOT_UPDATABLE — this version was likely already pushed. e2e tests are gating this release; failing to surface divergence."
-              exit 1
-            fi
-            echo "::notice::CWS already has this version pending/published — skipping upload (e2e is non-blocking, treating as retry)."
+            echo "::notice::CWS already has this version pending/published — skipping upload (treating as retry)."
             exit 0
           fi
           exit $EXIT
@@ -1319,9 +1309,9 @@ jobs:
           retention-days: 1
 
   publish-npm-prod:
-    # Don't publish until backend images are live and playwright is green.
-    needs: [extract-version, build-npm-prod, ci-playwright, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image]
-    if: ${{ always() && !cancelled() && needs.build-npm-prod.result == 'success' && (needs.ci-playwright.result == 'success' || inputs.playwright_blocks_release != true) && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' }}
+    # Don't publish until backend images are live.
+    needs: [extract-version, build-npm-prod, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image]
+    if: ${{ always() && !cancelled() && needs.build-npm-prod.result == 'success' && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -1349,16 +1339,11 @@ jobs:
       - name: Publish package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          E2E_BLOCKS_RELEASE: ${{ inputs.playwright_blocks_release }}
         run: |
           PKG_NAME=$(cat /tmp/npm-dist/name)
           PKG_VERSION=$(cat /tmp/npm-dist/version)
           if npm view "$PKG_NAME@$PKG_VERSION" version >/dev/null 2>&1; then
-            if [ "$E2E_BLOCKS_RELEASE" = "true" ]; then
-              echo "::error::$PKG_NAME@$PKG_VERSION is already published, but e2e tests are gating this release. Bump the version — refusing to silently retry."
-              exit 1
-            fi
-            echo "::notice::$PKG_NAME@$PKG_VERSION already published; skipping (e2e is non-blocking, treating as retry)."
+            echo "::notice::$PKG_NAME@$PKG_VERSION already published; skipping (treating as retry)."
             exit 0
           fi
           npm publish /tmp/npm-dist/package.tgz --access public --no-provenance
@@ -1422,9 +1407,9 @@ jobs:
           retention-days: 1
 
   publish-plugin-api-prod:
-    # Don't publish until backend images are live and playwright is green.
-    needs: [extract-version, build-plugin-api-prod, ci-playwright, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image]
-    if: ${{ always() && !cancelled() && needs.build-plugin-api-prod.result == 'success' && (needs.ci-playwright.result == 'success' || inputs.playwright_blocks_release != true) && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' }}
+    # Don't publish until backend images are live.
+    needs: [extract-version, build-plugin-api-prod, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image]
+    if: ${{ always() && !cancelled() && needs.build-plugin-api-prod.result == 'success' && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -1446,16 +1431,11 @@ jobs:
       - name: Publish package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          E2E_BLOCKS_RELEASE: ${{ inputs.playwright_blocks_release }}
         run: |
           PKG_NAME=$(cat /tmp/npm-dist/name)
           PKG_VERSION=$(cat /tmp/npm-dist/version)
           if npm view "$PKG_NAME@$PKG_VERSION" version >/dev/null 2>&1; then
-            if [ "$E2E_BLOCKS_RELEASE" = "true" ]; then
-              echo "::error::$PKG_NAME@$PKG_VERSION is already published, but e2e tests are gating this release. Bump the version — refusing to silently retry."
-              exit 1
-            fi
-            echo "::notice::$PKG_NAME@$PKG_VERSION already published; skipping (e2e is non-blocking, treating as retry)."
+            echo "::notice::$PKG_NAME@$PKG_VERSION already published; skipping (treating as retry)."
             exit 0
           fi
           npm publish /tmp/npm-dist/package.tgz --access public --no-provenance
@@ -1890,9 +1870,9 @@ jobs:
 
   publish-web-prod:
     name: publish-npm-prod (web)
-    # Don't publish until backend images are live and playwright is green.
-    needs: [extract-version, build-web-prod, ci-playwright, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image]
-    if: ${{ always() && !cancelled() && needs.build-web-prod.result == 'success' && (needs.ci-playwright.result == 'success' || inputs.playwright_blocks_release != true) && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' }}
+    # Don't publish until backend images are live.
+    needs: [extract-version, build-web-prod, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image]
+    if: ${{ always() && !cancelled() && needs.build-web-prod.result == 'success' && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -1917,16 +1897,11 @@ jobs:
       - name: Publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          E2E_BLOCKS_RELEASE: ${{ inputs.playwright_blocks_release }}
         run: |
           PKG_NAME=$(cat /tmp/npm-dist/name)
           PKG_VERSION=$(cat /tmp/npm-dist/version)
           if npm view "$PKG_NAME@$PKG_VERSION" version >/dev/null 2>&1; then
-            if [ "$E2E_BLOCKS_RELEASE" = "true" ]; then
-              echo "::error::$PKG_NAME@$PKG_VERSION is already published, but e2e tests are gating this release. Bump the version — refusing to silently retry."
-              exit 1
-            fi
-            echo "::notice::$PKG_NAME@$PKG_VERSION already published; skipping (e2e is non-blocking, treating as retry)."
+            echo "::notice::$PKG_NAME@$PKG_VERSION already published; skipping (treating as retry)."
             exit 0
           fi
           npm publish /tmp/npm-dist/package.tgz --access public --no-provenance
@@ -1960,17 +1935,12 @@ jobs:
       - name: Publish meta-package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          E2E_BLOCKS_RELEASE: ${{ inputs.playwright_blocks_release }}
         run: |
           cd meta
           PKG_NAME=$(node -p "require('./package.json').name")
           PKG_VERSION=$(node -p "require('./package.json').version")
           if npm view "$PKG_NAME@$PKG_VERSION" version >/dev/null 2>&1; then
-            if [ "$E2E_BLOCKS_RELEASE" = "true" ]; then
-              echo "::error::$PKG_NAME@$PKG_VERSION is already published, but e2e tests are gating this release. Bump the version — refusing to silently retry."
-              exit 1
-            fi
-            echo "::notice::$PKG_NAME@$PKG_VERSION already published; skipping (e2e is non-blocking, treating as retry)."
+            echo "::notice::$PKG_NAME@$PKG_VERSION already published; skipping (treating as retry)."
             exit 0
           fi
           npm publish --access public --no-provenance
@@ -2288,8 +2258,8 @@ jobs:
           done
 
   release:
-    needs: [extract-version, publish-npm-prod, publish-web-prod, publish-meta-prod, publish-plugin-api-prod, build-electron, upload-electron-updates, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image, ci-playwright, build-chrome-extension]
-    if: ${{ always() && !cancelled() && needs.extract-version.outputs.is_staging != 'true' && needs.extract-version.result == 'success' && needs.publish-npm-prod.result == 'success' && needs.publish-web-prod.result == 'success' && needs.publish-meta-prod.result == 'success' && needs.publish-plugin-api-prod.result == 'success' && (needs.ci-playwright.result == 'success' || inputs.playwright_blocks_release != true) && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' && needs.build-electron.result == 'success' && needs.upload-electron-updates.result == 'success' }}
+    needs: [extract-version, publish-npm-prod, publish-web-prod, publish-meta-prod, publish-plugin-api-prod, build-electron, upload-electron-updates, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image, build-chrome-extension]
+    if: ${{ always() && !cancelled() && needs.extract-version.outputs.is_staging != 'true' && needs.extract-version.result == 'success' && needs.publish-npm-prod.result == 'success' && needs.publish-web-prod.result == 'success' && needs.publish-meta-prod.result == 'success' && needs.publish-plugin-api-prod.result == 'success' && needs.push-assistant-manifest.result == 'success' && needs.push-gateway-manifest.result == 'success' && needs.push-credential-executor-manifest.result == 'success' && needs.push-dockerhub-image.result == 'success' && needs.build-electron.result == 'success' && needs.upload-electron-updates.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -2694,102 +2664,10 @@ jobs:
         run: bun run test
         working-directory: credential-executor
 
-  ci-playwright:
-    name: Playwright Tests
-    needs: [extract-version]
-    if: ${{ !cancelled() && needs.extract-version.result == 'success' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-    outputs:
-      playwright-run-id: ${{ steps.wait.outputs.playwright-run-id }}
-    steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
-        with:
-          app-id: ${{ secrets.VELLUM_AUTOMATION_GITHUB_APP_ID }}
-          private-key: ${{ secrets.VELLUM_AUTOMATION_GITHUB_PRIVATE_KEY }}
-          owner: vellum-ai
-          repositories: vellum-assistant-platform
-
-      - name: Trigger Playwright workflow in platform repo
-        id: trigger
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PLAYWRIGHT_ENVIRONMENT: ${{ needs.extract-version.outputs.is_staging == 'true' && 'staging' || 'auto' }}
-        run: |
-          SOURCE="run:${{ github.run_id }}"
-          BEFORE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          echo "before=$BEFORE" >> "$GITHUB_OUTPUT"
-
-          curl -fsSL \
-            -X POST \
-            -H "Authorization: token $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/vellum-ai/vellum-assistant-platform/actions/workflows/playwright.yaml/dispatches" \
-            -d "{\"ref\":\"main\",\"inputs\":{\"source\":\"$SOURCE\",\"environment\":\"$PLAYWRIGHT_ENVIRONMENT\",\"shards\":\"4\",\"test_filter\":\"critical\"}}"
-
-          echo "Triggered playwright workflow with source $SOURCE and environment $PLAYWRIGHT_ENVIRONMENT"
-          sleep 15
-
-      - name: Wait for Playwright workflow result
-        id: wait
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          RUN_ID=""
-          for i in $(seq 1 30); do
-            RUN_ID=$(curl -fsSL \
-              -H "Authorization: token $GH_TOKEN" \
-              -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/vellum-ai/vellum-assistant-platform/actions/workflows/playwright.yaml/runs?created=>=${{ steps.trigger.outputs.before }}&event=workflow_dispatch&per_page=1" \
-              | python3 -c "import sys,json; runs=json.load(sys.stdin).get('workflow_runs',[]); print(runs[0]['id'] if runs else '')")
-
-            if [ -n "$RUN_ID" ]; then
-              echo "Found workflow run: $RUN_ID"
-              echo "playwright-run-id=$RUN_ID" >> "$GITHUB_OUTPUT"
-              RUN_URL="https://github.com/vellum-ai/vellum-assistant-platform/actions/runs/$RUN_ID"
-              echo "Run URL: $RUN_URL"
-              break
-            fi
-            echo "Waiting for run to appear... (attempt $i/30)"
-            sleep 10
-          done
-
-          if [ -z "$RUN_ID" ]; then
-            echo "::error::Could not find triggered workflow run after 5 minutes"
-            exit 1
-          fi
-
-          while true; do
-            RESPONSE=$(curl -fsSL \
-              -H "Authorization: token $GH_TOKEN" \
-              -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/vellum-ai/vellum-assistant-platform/actions/runs/$RUN_ID")
-
-            RUN_STATUS=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['status'])")
-            CONCLUSION=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin).get('conclusion') or '')")
-
-            echo "$(date -u +%H:%M:%S) Run $RUN_ID: status=$RUN_STATUS conclusion=$CONCLUSION"
-
-            if [ "$RUN_STATUS" = "completed" ]; then
-              RUN_URL="https://github.com/vellum-ai/vellum-assistant-platform/actions/runs/$RUN_ID"
-              if [ "$CONCLUSION" = "success" ]; then
-                echo "Playwright tests passed! $RUN_URL"
-                exit 0
-              else
-                echo "::error::Playwright tests failed (conclusion: $CONCLUSION). See: $RUN_URL"
-                exit 1
-              fi
-            fi
-
-            sleep 30
-          done
-
   notify-release:
     name: Slack Notification (Release)
     if: ${{ always() && !cancelled() }}
-    needs: [extract-version, publish-npm-prod, publish-web-prod, publish-meta-prod, publish-plugin-api-prod, build-electron, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image, register-release, release, merge-release-branch, update-platform, pack-cli, trigger-platform-qa, release-ios, ci-assistant, ci-cli, ci-credential-executor, ci-gateway, ci-playwright, build-chrome-extension, publish-chrome-extension]
+    needs: [extract-version, publish-npm-prod, publish-web-prod, publish-meta-prod, publish-plugin-api-prod, build-electron, push-assistant-manifest, push-gateway-manifest, push-credential-executor-manifest, push-dockerhub-image, register-release, release, merge-release-branch, update-platform, pack-cli, trigger-platform-qa, release-ios, ci-assistant, ci-cli, ci-credential-executor, ci-gateway, build-chrome-extension, publish-chrome-extension]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     continue-on-error: true
@@ -2860,7 +2738,6 @@ jobs:
           C=$(ci_icon "${{ needs.ci-cli.result }}")
           CE=$(ci_icon "${{ needs.ci-credential-executor.result }}")
           G=$(ci_icon "${{ needs.ci-gateway.result }}")
-          P=$(ci_icon "${{ needs.ci-playwright.result }}")
           DE=$(ci_icon "${{ needs.build-electron.result }}")
           AI=$(ci_icon "${{ needs.push-assistant-manifest.result }}")
           GI=$(ci_icon "${{ needs.push-gateway-manifest.result }}")
@@ -2876,17 +2753,8 @@ jobs:
           MB=$(ci_icon "$MERGE_OUTCOME")
 
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          PLAYWRIGHT_LINE=""
-          if [ "${{ needs.ci-playwright.result }}" != "success" ]; then
-            PLAYWRIGHT_RUN_ID="${{ needs.ci-playwright.outputs.playwright-run-id }}"
-            if [ -n "$PLAYWRIGHT_RUN_ID" ]; then
-              PLAYWRIGHT_LINE=" (<https://qa.vellum.ai/runs/${PLAYWRIGHT_RUN_ID}|view report>)"
-            else
-              PLAYWRIGHT_LINE=" (<${RUN_URL}#artifacts|view report>)"
-            fi
-          fi
 
-          CI_LINE=$(printf '*CI Checks:*\n• %s assistant\n• %s cli\n• %s credential-executor\n• %s gateway\n• %s playwright%s\n• %s desktop-electron\n• %s release-ios\n• %s chrome-extension\n• %s cws-publish\n• %s assistant-docker\n• %s gateway-docker\n• %s credential-executor-docker\n• %s dockerhub\n• %s register-release\n• %s pack-cli\n• %s trigger-platform-qa\n• %s merge-release-branch' "$A" "$C" "$CE" "$G" "$P" "$PLAYWRIGHT_LINE" "$DE" "$DI" "$CX" "$CXP" "$AI" "$GI" "$CEI" "$DH" "$RR" "$PC" "$TQ" "$MB")
+          CI_LINE=$(printf '*CI Checks:*\n• %s assistant\n• %s cli\n• %s credential-executor\n• %s gateway\n• %s desktop-electron\n• %s release-ios\n• %s chrome-extension\n• %s cws-publish\n• %s assistant-docker\n• %s gateway-docker\n• %s credential-executor-docker\n• %s dockerhub\n• %s register-release\n• %s pack-cli\n• %s trigger-platform-qa\n• %s merge-release-branch' "$A" "$C" "$CE" "$G" "$DE" "$DI" "$CX" "$CXP" "$AI" "$GI" "$CEI" "$DH" "$RR" "$PC" "$TQ" "$MB")
 
           if [ -n "$SLACK_USER_ID" ]; then
             TRIGGERED_BY="<@${SLACK_USER_ID}>"


### PR DESCRIPTION
Drops the ci-playwright job that dispatched the platform repo's
Playwright suite, along with the playwright_blocks_release input and
the now-dead E2E_BLOCKS_RELEASE gating in the publish jobs and the
playwright line in the release Slack notification.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01U5ur3csGEyVgLrHNfiruoH