### PR TITLE
feat(web): filter notifications by source-conversation type

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -12116,6 +12116,19 @@ paths:
                           propertyNames:
                             type: string
                           additionalProperties: {}
+                        sourceType:
+                          type: string
+                          enum:
+                            - heartbeat
+                            - memory_consolidation
+                            - schedule
+                            - auto_analysis
+                            - user
+                            - other
+                        sourceKey:
+                          type: string
+                        sourceLabel:
+                          type: string
                         createdAt:
                           type: string
                       required:
@@ -12296,6 +12309,19 @@ paths:
                     propertyNames:
                       type: string
                     additionalProperties: {}
+                  sourceType:
+                    type: string
+                    enum:
+                      - heartbeat
+                      - memory_consolidation
+                      - schedule
+                      - auto_analysis
+                      - user
+                      - other
+                  sourceKey:
+                    type: string
+                  sourceLabel:
+                    type: string
                   createdAt:
                     type: string
                 required:
@@ -12508,6 +12534,19 @@ paths:
                           propertyNames:
                             type: string
                           additionalProperties: {}
+                        sourceType:
+                          type: string
+                          enum:
+                            - heartbeat
+                            - memory_consolidation
+                            - schedule
+                            - auto_analysis
+                            - user
+                            - other
+                        sourceKey:
+                          type: string
+                        sourceLabel:
+                          type: string
                         createdAt:
                           type: string
                       required:
@@ -17936,6 +17975,19 @@ paths:
                         propertyNames:
                           type: string
                         additionalProperties: {}
+                      sourceType:
+                        type: string
+                        enum:
+                          - heartbeat
+                          - memory_consolidation
+                          - schedule
+                          - auto_analysis
+                          - user
+                          - other
+                      sourceKey:
+                        type: string
+                      sourceLabel:
+                        type: string
                       createdAt:
                         type: string
                     required:

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -385,6 +385,8 @@ export {
   FeedItemDetailPanelKindSchema,
   FeedItemDetailPanelSchema,
   FeedItemSchema,
+  type FeedItemSourceType,
+  FeedItemSourceTypeSchema,
   type FeedItemStatus,
   FeedItemStatusSchema,
   type FeedItemType,

--- a/assistant/src/api/responses/home.ts
+++ b/assistant/src/api/responses/home.ts
@@ -56,6 +56,25 @@ export const FeedItemCategorySchema = z.enum([
 export type FeedItemCategory = z.infer<typeof FeedItemCategorySchema>;
 
 /**
+ * Producer of a feed item's source conversation — lets clients filter the
+ * activity feed by what generated each notification: the periodic
+ * heartbeat, a memory-consolidation pass, a recurring schedule, an
+ * auto-analysis run, etc. Derived at read time from the source
+ * conversation's `source` column (see `home/feed-source-enrichment.ts`).
+ * Individual schedules are distinguished by `sourceKey`/`sourceLabel`, not
+ * this coarse type.
+ */
+export const FeedItemSourceTypeSchema = z.enum([
+  "heartbeat",
+  "memory_consolidation",
+  "schedule",
+  "auto_analysis",
+  "user",
+  "other",
+]);
+export type FeedItemSourceType = z.infer<typeof FeedItemSourceTypeSchema>;
+
+/**
  * A single action button attached to a feed item.
  *
  * `prompt` is the pre-seeded user message the action sends to the
@@ -120,6 +139,13 @@ export const FeedItemSchema = z.object({
   noteworthy: z.boolean().optional(),
   fromAssistant: z.boolean().optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
+  // Source-conversation classification, enriched at read time. `sourceKey`
+  // is the stable filter id — `schedule:<id>` for schedules so each filters
+  // separately, otherwise the `sourceType`. `sourceLabel` is the display
+  // string (a schedule's name, or a static label like "Heartbeat").
+  sourceType: FeedItemSourceTypeSchema.optional(),
+  sourceKey: z.string().optional(),
+  sourceLabel: z.string().optional(),
   createdAt: z.string(),
 });
 export type FeedItem = z.infer<typeof FeedItemSchema>;

--- a/assistant/src/home/feed-source-enrichment.test.ts
+++ b/assistant/src/home/feed-source-enrichment.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "bun:test";
+
+import { type FeedItem } from "../api/responses/home.js";
+import {
+  classifyConversationSource,
+  enrichFeedItemsWithSource,
+  type FeedSourceEnrichmentDeps,
+} from "./feed-source-enrichment.js";
+
+function makeItem(partial: Partial<FeedItem> & Pick<FeedItem, "id">): FeedItem {
+  return {
+    type: "notification",
+    priority: 50,
+    summary: "summary",
+    timestamp: "2026-06-18T00:00:00.000Z",
+    createdAt: "2026-06-18T00:00:00.000Z",
+    status: "new",
+    ...partial,
+  };
+}
+
+describe("classifyConversationSource", () => {
+  it("maps each known producer source to its coarse type", () => {
+    expect(classifyConversationSource("heartbeat")).toBe("heartbeat");
+    expect(classifyConversationSource("memory-retrospective")).toBe(
+      "memory_consolidation",
+    );
+    expect(classifyConversationSource("memory-retrospective-fork")).toBe(
+      "memory_consolidation",
+    );
+    expect(classifyConversationSource("schedule")).toBe("schedule");
+    expect(classifyConversationSource("auto-analysis")).toBe("auto_analysis");
+    expect(classifyConversationSource("user")).toBe("user");
+    expect(classifyConversationSource("home-feed")).toBe("user");
+  });
+
+  it("falls through to 'other' for unknown / paired-delivery / empty sources", () => {
+    expect(classifyConversationSource("notification")).toBe("other");
+    expect(classifyConversationSource("something-else")).toBe("other");
+    expect(classifyConversationSource(null)).toBe("other");
+    expect(classifyConversationSource(undefined)).toBe("other");
+  });
+});
+
+describe("enrichFeedItemsWithSource", () => {
+  const deps = (
+    conv: Record<string, { source: string; scheduleJobId: string | null }>,
+    schedules: Record<string, string> = {},
+  ): FeedSourceEnrichmentDeps => ({
+    getConversationRow: (id) => conv[id] ?? null,
+    getScheduleName: (id) => schedules[id] ?? null,
+  });
+
+  it("classifies a heartbeat item with a static label", () => {
+    const [item] = enrichFeedItemsWithSource(
+      [makeItem({ id: "n1", conversationId: "c1" })],
+      deps({ c1: { source: "heartbeat", scheduleJobId: null } }),
+    );
+    expect(item.sourceType).toBe("heartbeat");
+    expect(item.sourceKey).toBe("heartbeat");
+    expect(item.sourceLabel).toBe("Heartbeat");
+  });
+
+  it("classifies a memory-consolidation item", () => {
+    const [item] = enrichFeedItemsWithSource(
+      [makeItem({ id: "n2", conversationId: "c2" })],
+      deps({ c2: { source: "memory-retrospective", scheduleJobId: null } }),
+    );
+    expect(item.sourceType).toBe("memory_consolidation");
+    expect(item.sourceKey).toBe("memory_consolidation");
+    expect(item.sourceLabel).toBe("Memory consolidation");
+  });
+
+  it("gives distinct keys and names to two different schedules", () => {
+    const [a, b] = enrichFeedItemsWithSource(
+      [
+        makeItem({ id: "n3", conversationId: "cA" }),
+        makeItem({ id: "n4", conversationId: "cB" }),
+      ],
+      deps(
+        {
+          cA: { source: "schedule", scheduleJobId: "sched-A" },
+          cB: { source: "schedule", scheduleJobId: "sched-B" },
+        },
+        { "sched-A": "Morning digest", "sched-B": "Evening recap" },
+      ),
+    );
+    expect(a.sourceType).toBe("schedule");
+    expect(a.sourceKey).toBe("schedule:sched-A");
+    expect(a.sourceLabel).toBe("Morning digest");
+    // scheduleId recovered from the conversation row is surfaced in metadata.
+    expect(a.metadata?.scheduleId).toBe("sched-A");
+
+    expect(b.sourceKey).toBe("schedule:sched-B");
+    expect(b.sourceLabel).toBe("Evening recap");
+  });
+
+  it("prefers an explicit metadata.scheduleId over the conversation row", () => {
+    const [item] = enrichFeedItemsWithSource(
+      [
+        makeItem({
+          id: "n5",
+          conversationId: "cX",
+          metadata: { scheduleId: "from-payload" },
+        }),
+      ],
+      deps(
+        { cX: { source: "schedule", scheduleJobId: "from-row" } },
+        { "from-payload": "Payload schedule" },
+      ),
+    );
+    expect(item.sourceKey).toBe("schedule:from-payload");
+    expect(item.sourceLabel).toBe("Payload schedule");
+  });
+
+  it("labels a schedule with no resolvable name as 'Scheduled'", () => {
+    const [item] = enrichFeedItemsWithSource(
+      [makeItem({ id: "n6", conversationId: "cY" })],
+      deps({ cY: { source: "schedule", scheduleJobId: "gone" } }),
+    );
+    expect(item.sourceKey).toBe("schedule:gone");
+    expect(item.sourceLabel).toBe("Scheduled");
+  });
+
+  it("classifies items with no source conversation as 'other'", () => {
+    const [item] = enrichFeedItemsWithSource(
+      [makeItem({ id: "n7" })],
+      deps({}),
+    );
+    expect(item.sourceType).toBe("other");
+    expect(item.sourceKey).toBe("other");
+    expect(item.sourceLabel).toBe("Other");
+  });
+
+  it("resolves each distinct conversation at most once", () => {
+    const calls: string[] = [];
+    enrichFeedItemsWithSource(
+      [
+        makeItem({ id: "n8", conversationId: "dup" }),
+        makeItem({ id: "n9", conversationId: "dup" }),
+      ],
+      {
+        getConversationRow: (id) => {
+          calls.push(id);
+          return { source: "heartbeat", scheduleJobId: null };
+        },
+      },
+    );
+    expect(calls).toEqual(["dup"]);
+  });
+});

--- a/assistant/src/home/feed-source-enrichment.ts
+++ b/assistant/src/home/feed-source-enrichment.ts
@@ -1,0 +1,176 @@
+/**
+ * Read-time enrichment of home-feed items with their source-conversation
+ * classification.
+ *
+ * The activity feed surfaces notifications produced by many background
+ * flows — the periodic heartbeat, memory-consolidation passes, each
+ * recurring schedule, auto-analysis runs, etc. Clients let the user filter
+ * the feed by that producer, so every item is tagged with:
+ *
+ *   - `sourceType`  — coarse producer category.
+ *   - `sourceKey`   — stable filter id (`schedule:<id>` per schedule,
+ *                     otherwise the `sourceType`).
+ *   - `sourceLabel` — human-readable display (a schedule's name, or a
+ *                     static label such as "Heartbeat").
+ *
+ * The classification is derived from the source conversation's `source`
+ * column (and, for schedules, its name) rather than persisted onto the
+ * feed item. Resolving at read time keeps labels fresh across schedule
+ * renames and retroactively classifies items written before this feature
+ * existed, with no migration.
+ *
+ * The lookups are injectable so the enrichment can be unit-tested without
+ * a live database; production callers use the defaults.
+ */
+
+import {
+  type FeedItem,
+  type FeedItemSourceType,
+} from "../api/responses/home.js";
+import { AUTO_ANALYSIS_SOURCE } from "../memory/auto-analysis-constants.js";
+import { getConversation } from "../memory/conversation-crud.js";
+import {
+  MEMORY_RETROSPECTIVE_FORK_SOURCE,
+  MEMORY_RETROSPECTIVE_SOURCE,
+} from "../memory/memory-retrospective-constants.js";
+import { getSchedule } from "../schedule/schedule-store.js";
+
+/** Minimal source-conversation shape the enrichment needs. */
+interface ConversationSourceRow {
+  source: string;
+  scheduleJobId: string | null;
+}
+
+export interface FeedSourceEnrichmentDeps {
+  /** Resolve the source columns for a conversation, or null when missing. */
+  getConversationRow?: (id: string) => ConversationSourceRow | null;
+  /** Resolve a schedule's display name, or null when missing. */
+  getScheduleName?: (id: string) => string | null;
+}
+
+/**
+ * Map a conversation's `source` column to a coarse feed source type.
+ * Mechanical mapping over the known producer sources; anything else
+ * (including the broadcaster's paired `"notification"` delivery
+ * conversations) falls through to `"other"`.
+ */
+export function classifyConversationSource(
+  source: string | null | undefined,
+): FeedItemSourceType {
+  switch (source) {
+    case "heartbeat":
+      return "heartbeat";
+    case MEMORY_RETROSPECTIVE_SOURCE:
+    case MEMORY_RETROSPECTIVE_FORK_SOURCE:
+      return "memory_consolidation";
+    case "schedule":
+      return "schedule";
+    case AUTO_ANALYSIS_SOURCE:
+      return "auto_analysis";
+    case "user":
+    case "home-feed":
+      return "user";
+    default:
+      return "other";
+  }
+}
+
+/** Static display labels for non-schedule source types. */
+const STATIC_SOURCE_LABELS: Record<
+  Exclude<FeedItemSourceType, "schedule">,
+  string
+> = {
+  heartbeat: "Heartbeat",
+  memory_consolidation: "Memory consolidation",
+  auto_analysis: "Auto-analysis",
+  user: "Conversation",
+  other: "Other",
+};
+
+function defaultGetConversationRow(id: string): ConversationSourceRow | null {
+  try {
+    const row = getConversation(id);
+    return row
+      ? { source: row.source, scheduleJobId: row.scheduleJobId }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function defaultGetScheduleName(id: string): string | null {
+  try {
+    return getSchedule(id)?.name ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Return a copy of each feed item enriched with `sourceType`, `sourceKey`,
+ * and `sourceLabel`. Conversation and schedule lookups are memoized across
+ * the batch so each distinct source is resolved at most once.
+ */
+export function enrichFeedItemsWithSource(
+  items: FeedItem[],
+  deps: FeedSourceEnrichmentDeps = {},
+): FeedItem[] {
+  if (items.length === 0) return items;
+
+  const getConversationRow =
+    deps.getConversationRow ?? defaultGetConversationRow;
+  const getScheduleName = deps.getScheduleName ?? defaultGetScheduleName;
+
+  const convCache = new Map<string, ConversationSourceRow | null>();
+  const resolveConv = (id: string): ConversationSourceRow | null => {
+    if (!convCache.has(id)) convCache.set(id, getConversationRow(id));
+    return convCache.get(id) ?? null;
+  };
+
+  const scheduleNameCache = new Map<string, string | null>();
+  const resolveScheduleName = (id: string): string | null => {
+    if (!scheduleNameCache.has(id)) {
+      scheduleNameCache.set(id, getScheduleName(id));
+    }
+    return scheduleNameCache.get(id) ?? null;
+  };
+
+  return items.map((item) => {
+    const row = item.conversationId ? resolveConv(item.conversationId) : null;
+    const sourceType = classifyConversationSource(row?.source);
+
+    const metadataScheduleId =
+      typeof item.metadata?.scheduleId === "string"
+        ? item.metadata.scheduleId
+        : undefined;
+    const scheduleId = metadataScheduleId ?? row?.scheduleJobId ?? undefined;
+
+    let sourceKey: string;
+    let sourceLabel: string;
+    if (sourceType === "schedule" && scheduleId) {
+      sourceKey = `schedule:${scheduleId}`;
+      sourceLabel = resolveScheduleName(scheduleId) ?? "Scheduled";
+    } else if (sourceType === "schedule") {
+      sourceKey = "schedule";
+      sourceLabel = "Scheduled";
+    } else {
+      sourceKey = sourceType;
+      sourceLabel = STATIC_SOURCE_LABELS[sourceType];
+    }
+
+    // Surface the scheduleId in metadata when it was recovered from the
+    // source conversation so clients have a single place to read it.
+    const metadata =
+      scheduleId !== undefined && metadataScheduleId === undefined
+        ? { ...(item.metadata ?? {}), scheduleId }
+        : item.metadata;
+
+    return {
+      ...item,
+      sourceType,
+      sourceKey,
+      sourceLabel,
+      ...(metadata ? { metadata } : {}),
+    };
+  });
+}

--- a/assistant/src/runtime/routes/home-feed-routes.ts
+++ b/assistant/src/runtime/routes/home-feed-routes.ts
@@ -28,6 +28,7 @@ import {
   type FeedItemStatus,
   HomeFeedResponseSchema,
 } from "../../api/responses/home.js";
+import { enrichFeedItemsWithSource } from "../../home/feed-source-enrichment.js";
 import { patchFeedItemStatus, readHomeFeed } from "../../home/feed-writer.js";
 import { revalidateHomeContentInBackground } from "../../home/home-content-refresh.js";
 import { getPersonalizedGreeting } from "../../home/home-greeting.js";
@@ -135,8 +136,10 @@ export async function handleGetHomeFeed({
   // v2 schema dropped per-item `minTimeAway` gating; surface every item
   // and let the client decide what to render based on its own
   // session state. `timeAwaySeconds` survives only to feed the
-  // context-banner relative-time label.
-  const filtered = feed.items;
+  // context-banner relative-time label. Each item is enriched with its
+  // source-conversation classification (`sourceType`/`sourceKey`/
+  // `sourceLabel`) so clients can filter the feed by what produced it.
+  const filtered = enrichFeedItemsWithSource(feed.items);
 
   const now = new Date();
 
@@ -287,7 +290,9 @@ export function handleListHomeFeed({
   const total = filtered.length;
   const offset = params.offset ?? 0;
   const limit = params.limit ?? 20;
-  const items = filtered.slice(offset, offset + limit);
+  const items = enrichFeedItemsWithSource(
+    filtered.slice(offset, offset + limit),
+  );
 
   return {
     items,

--- a/clients/web/src/domains/home/home-feed-list.tsx
+++ b/clients/web/src/domains/home/home-feed-list.tsx
@@ -10,12 +10,15 @@ import type {
 } from "@vellumai/assistant-api";
 import { Collapsible, Typography } from "@vellumai/design-library";
 import { HomeFeedFilterBar } from "./home-feed-filter-bar";
+import { HomeFeedSourceFilter } from "./home-feed-source-filter";
 import { HomeRecapRow } from "./home-recap-row";
 import type { FeedTimeGroup } from "./utils";
 import {
     excludeHighUrgency,
     filterByCategory,
+    filterBySource,
     getPresentCategories,
+    getPresentSources,
     groupByTime,
     sortFeedItems,
 } from "./utils";
@@ -50,27 +53,39 @@ export function HomeFeedList({
   const [activeFilter, setActiveFilter] = useState<FeedItemCategory | null>(
     null,
   );
+  const [activeSource, setActiveSource] = useState<string | null>(null);
 
   const visible = items.filter((item) => item.status !== "dismissed");
   const eligible = excludeHighUrgency(visible);
   const presentCategories = getPresentCategories(eligible);
+  const presentSources = getPresentSources(eligible);
   const effectiveFilter =
     activeFilter && presentCategories.includes(activeFilter)
       ? activeFilter
       : null;
+  const effectiveSource =
+    activeSource && presentSources.some((s) => s.key === activeSource)
+      ? activeSource
+      : null;
 
-  // Reset stale activeFilter during render when its category disappears
-  // from the feed. Without this, the previously-selected filter would
-  // silently re-activate if the category later reappears (e.g. a new
-  // notification of that category arrives). React bails out when the
-  // next state equals the current, so this is safe and preferable to a
+  // Reset stale active filters during render when their value disappears
+  // from the feed. Without this, a previously-selected filter would
+  // silently re-activate if it later reappeared (e.g. a new notification
+  // of that category/source arrives). React bails out when the next state
+  // equals the current, so this is safe and preferable to a
   // synchronization Effect.
   // https://react.dev/reference/react/useState#storing-information-from-previous-renders
   if (activeFilter !== effectiveFilter) {
     setActiveFilter(effectiveFilter);
   }
+  if (activeSource !== effectiveSource) {
+    setActiveSource(effectiveSource);
+  }
 
-  const filtered = filterByCategory(eligible, effectiveFilter);
+  const filtered = filterBySource(
+    filterByCategory(eligible, effectiveFilter),
+    effectiveSource,
+  );
   const sorted = sortFeedItems(filtered);
   const grouped = groupByTime(sorted);
 
@@ -83,14 +98,23 @@ export function HomeFeedList({
 
   return (
     <div className="flex flex-col gap-[var(--app-spacing-lg)]">
-      <HomeFeedFilterBar
-        categories={presentCategories}
-        activeFilter={effectiveFilter}
-        onFilterChange={setActiveFilter}
-      />
+      {(presentCategories.length > 1 || presentSources.length > 1) && (
+        <div className="flex flex-wrap items-center gap-[var(--app-spacing-sm)]">
+          <HomeFeedFilterBar
+            categories={presentCategories}
+            activeFilter={effectiveFilter}
+            onFilterChange={setActiveFilter}
+          />
+          <HomeFeedSourceFilter
+            sources={presentSources}
+            activeSource={effectiveSource}
+            onSourceChange={setActiveSource}
+          />
+        </div>
+      )}
 
       {grouped.size === 0 ? (
-        effectiveFilter ? (
+        effectiveFilter || effectiveSource ? (
           <Typography
             variant="body-medium-lighter"
             className="py-[var(--app-spacing-xl)] text-center text-[var(--content-disabled)]"

--- a/clients/web/src/domains/home/home-feed-source-filter.tsx
+++ b/clients/web/src/domains/home/home-feed-source-filter.tsx
@@ -1,0 +1,86 @@
+import {
+  Activity,
+  Brain,
+  ChevronDown,
+  Circle,
+  Clock,
+  ListFilter,
+  MessageCircle,
+  Sparkles,
+} from "lucide-react";
+import { type ComponentType, type SVGProps } from "react";
+
+import type { FeedItemSourceType } from "@vellumai/assistant-api";
+import { Button, Menu } from "@vellumai/design-library";
+
+import type { FeedSource } from "./utils";
+
+type LucideIcon = ComponentType<SVGProps<SVGSVGElement>>;
+
+/** Icon per coarse source type — shown on the trigger for the active source. */
+const SOURCE_TYPE_ICONS: Record<FeedItemSourceType, LucideIcon> = {
+  heartbeat: Activity,
+  memory_consolidation: Brain,
+  schedule: Clock,
+  auto_analysis: Sparkles,
+  user: MessageCircle,
+  other: Circle,
+};
+
+const ALL_SOURCES = "all";
+
+export interface HomeFeedSourceFilterProps {
+  sources: FeedSource[];
+  activeSource: string | null;
+  onSourceChange: (sourceKey: string | null) => void;
+}
+
+/**
+ * Single-select dropdown that filters the notification feed by the producer
+ * of each item's source conversation (heartbeat, memory consolidation, a
+ * specific recurring schedule, …). Hidden when there is at most one source,
+ * mirroring the category filter bar.
+ */
+export function HomeFeedSourceFilter({
+  sources,
+  activeSource,
+  onSourceChange,
+}: HomeFeedSourceFilterProps) {
+  if (sources.length <= 1) return null;
+
+  const active = sources.find((s) => s.key === activeSource) ?? null;
+  const TriggerIcon = active ? SOURCE_TYPE_ICONS[active.type] : ListFilter;
+
+  return (
+    <Menu.Root>
+      <Menu.Trigger>
+        <Button
+          variant="outlined"
+          size="compact"
+          active={active !== null}
+          leftIcon={<TriggerIcon className="h-4 w-4" />}
+          rightIcon={<ChevronDown className="h-3.5 w-3.5" />}
+          aria-label="Filter notifications by source"
+        >
+          {active ? active.label : "All sources"}
+        </Button>
+      </Menu.Trigger>
+      <Menu.Content align="start" className="max-h-80 overflow-y-auto">
+        <Menu.RadioGroup
+          value={activeSource ?? ALL_SOURCES}
+          onValueChange={(value: string) =>
+            onSourceChange(value === ALL_SOURCES ? null : value)
+          }
+        >
+          <Menu.RadioItem value={ALL_SOURCES}>All sources</Menu.RadioItem>
+          <Menu.Separator />
+          {sources.map((source) => (
+            <Menu.RadioItem key={source.key} value={source.key}>
+              {source.label}
+            </Menu.RadioItem>
+          ))}
+        </Menu.RadioGroup>
+      </Menu.Content>
+    </Menu.Root>
+  );
+}

--- a/clients/web/src/domains/home/utils.ts
+++ b/clients/web/src/domains/home/utils.ts
@@ -1,4 +1,8 @@
-import type { FeedItem, FeedItemCategory } from "@vellumai/assistant-api";
+import type {
+  FeedItem,
+  FeedItemCategory,
+  FeedItemSourceType,
+} from "@vellumai/assistant-api";
 
 /**
  * Client-side grouping of feed items by recency. Not part of the wire
@@ -84,4 +88,59 @@ export function getPresentCategories(items: FeedItem[]): FeedItemCategory[] {
     categories.add(item.category ?? "system");
   }
   return [...categories];
+}
+
+/**
+ * A distinct producer of feed items, identified by `key`. Schedules each
+ * get their own key (`schedule:<id>`); other producers (heartbeat, memory
+ * consolidation, …) share a key per `type`. Used to build the source filter.
+ */
+export interface FeedSource {
+  key: string;
+  label: string;
+  type: FeedItemSourceType;
+}
+
+// Display order for the source filter: producer types first in a fixed
+// order, schedules grouped together and sorted by name within that band.
+const SOURCE_TYPE_ORDER: Record<FeedItemSourceType, number> = {
+  heartbeat: 0,
+  memory_consolidation: 1,
+  schedule: 2,
+  auto_analysis: 3,
+  user: 4,
+  other: 5,
+};
+
+/**
+ * Return the distinct sources present in the items, ordered for display.
+ * Items missing a `sourceKey` (e.g. not yet enriched) are skipped — they
+ * remain visible under the "All sources" option.
+ */
+export function getPresentSources(items: FeedItem[]): FeedSource[] {
+  const byKey = new Map<string, FeedSource>();
+  for (const item of items) {
+    const key = item.sourceKey;
+    if (!key || byKey.has(key)) continue;
+    byKey.set(key, {
+      key,
+      label: item.sourceLabel ?? key,
+      type: item.sourceType ?? "other",
+    });
+  }
+  return [...byKey.values()].sort((a, b) => {
+    const rankDiff = SOURCE_TYPE_ORDER[a.type] - SOURCE_TYPE_ORDER[b.type];
+    return rankDiff !== 0 ? rankDiff : a.label.localeCompare(b.label);
+  });
+}
+
+/**
+ * Filter items by source key. If sourceKey is null, return all items.
+ */
+export function filterBySource(
+  items: FeedItem[],
+  sourceKey: string | null,
+): FeedItem[] {
+  if (sourceKey === null) return items;
+  return items.filter((item) => item.sourceKey === sourceKey);
 }


### PR DESCRIPTION
## Summary
- Enrich each home-feed item server-side at read time with its source-conversation classification: `sourceType` (`heartbeat` / `memory_consolidation` / `schedule` / `auto_analysis` / `user` / `other`), a stable `sourceKey` (`schedule:<id>` so individual schedules filter separately, otherwise the `sourceType`), and a human-readable `sourceLabel` (a schedule's name, or a static label like "Heartbeat"). Derived from the source conversation's `source` column plus the schedule name — no migration, and historical items are classified too.
- Add a single-select **source** dropdown to the Activity → Notifications tab, alongside the existing category filter (the two combine with AND). Hidden when there is at most one source present, mirroring the category bar.
- Reuses `getConversation` / `getSchedule` and the existing producer source constants on the daemon side, and mirrors the existing `getPresentCategories` / `filterByCategory` client pattern. Enrichment memoizes conversation + schedule lookups so a feed load resolves each distinct source at most once.

## Original prompt
The user wanted to filter notifications on the Activity → Notifications tab by the type of their source conversation — heartbeat, memory consolidation, and each individual recurring schedule (schedule A vs schedule B). We confirmed the source filter should sit **alongside** the existing category filter (combined with AND) and be **single-select**, matching the current one-active-filter UX. The producer was recoverable from each item's source conversation (its `source` column, plus the schedule name for scheduled runs), so classification is enriched server-side at read time and filtering is applied client-side.

## Verification
- `assistant`: `bunx tsc --noEmit` clean; new `feed-source-enrichment.test.ts` (9 tests) covers the classifier and enrichment (distinct schedules, metadata fallback, no-source → "other", lookup memoization).
- `clients/web`: type-checked clean once `@vellumai/assistant-api` resolves to the branch source (the worktree's `node_modules` symlinks the older main repo, so a local tsc shows only stale-package artifacts that resolve in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)