### PR TITLE
feat(home): declutter and polish the Activity page

### DIFF
--- a/clients/web/src/domains/home/components/home-schedule-row.tsx
+++ b/clients/web/src/domains/home/components/home-schedule-row.tsx
@@ -42,31 +42,31 @@ function inlineUsage(usage: ScheduleRowUsage) {
 }
 
 /**
- * Homepage schedule row laid out to match the Figma "Scheduled Jobs" design:
- * toggle on the far left, then name + `cadence · timestamp` meta, then inline
- * cost · runs · mode tag · chevron on the right.
+ * Presentational row shared by `HomeScheduleRow` and `HomeHeartbeatRow` so the
+ * heartbeat entry is laid out identically to user schedules: toggle on the far
+ * left, then name + `cadence · timestamp` meta, then inline cost · runs ·
+ * chevron on the right. Matches the Figma "Scheduled Jobs" design.
  */
-export function HomeScheduleRow({
-  schedule,
+export function HomeScheduleRowShell({
+  name,
+  metaParts,
   usage,
+  enabled,
   selected,
   onClick,
   onToggle,
+  toggleAriaLabel,
 }: {
-  schedule: Schedule;
+  name: string;
+  metaParts: string[];
   usage: ScheduleRowUsage;
+  enabled: boolean;
   selected?: boolean;
   onClick: () => void;
-  onToggle: (enabled: boolean) => void;
+  /** Omit to render a read-only row (e.g. a past one-shot) with no toggle. */
+  onToggle?: (enabled: boolean) => void;
+  toggleAriaLabel?: string;
 }) {
-  const cadence = schedule.isOneShot
-    ? ""
-    : schedule.cadenceDescription.trim();
-  const runAt = schedule.lastRunAt ?? schedule.nextRunAt;
-  const metaParts = [cadence, runAt ? formatTimestamp(runAt) : ""].filter(
-    Boolean,
-  );
-
   return (
     <div
       className={`flex items-center gap-3 rounded-md px-2 py-3 transition-colors [&+&]:border-t [&+&]:border-[var(--border-base)] ${
@@ -75,11 +75,13 @@ export function HomeScheduleRow({
           : "hover:bg-[var(--surface-hover)]"
       }`}
     >
-      <Toggle
-        checked={schedule.enabled}
-        onChange={onToggle}
-        aria-label={`Toggle ${schedule.name}`}
-      />
+      {onToggle ? (
+        <Toggle
+          checked={enabled}
+          onChange={onToggle}
+          aria-label={toggleAriaLabel}
+        />
+      ) : null}
       <button
         type="button"
         onClick={onClick}
@@ -87,7 +89,7 @@ export function HomeScheduleRow({
       >
         <div className="flex min-w-0 flex-1 flex-col gap-1">
           <span className="truncate text-body-medium-default text-[var(--content-default)]">
-            {schedule.name}
+            {name}
           </span>
           {metaParts.length > 0 ? (
             <span className="flex min-w-0 items-center gap-2 text-label-small-default text-[var(--content-tertiary)]">
@@ -108,5 +110,41 @@ export function HomeScheduleRow({
         </div>
       </button>
     </div>
+  );
+}
+
+export function HomeScheduleRow({
+  schedule,
+  usage,
+  selected,
+  onClick,
+  onToggle,
+}: {
+  schedule: Schedule;
+  usage: ScheduleRowUsage;
+  selected?: boolean;
+  onClick: () => void;
+  /** Omit for read-only rows (past one-shots) — hides the enable/disable toggle. */
+  onToggle?: (enabled: boolean) => void;
+}) {
+  const cadence = schedule.isOneShot
+    ? ""
+    : schedule.cadenceDescription.trim();
+  const runAt = schedule.lastRunAt ?? schedule.nextRunAt;
+  const metaParts = [cadence, runAt ? formatTimestamp(runAt) : ""].filter(
+    Boolean,
+  );
+
+  return (
+    <HomeScheduleRowShell
+      name={schedule.name}
+      metaParts={metaParts}
+      usage={usage}
+      enabled={schedule.enabled}
+      selected={selected}
+      onClick={onClick}
+      onToggle={onToggle}
+      toggleAriaLabel={onToggle ? `Toggle ${schedule.name}` : undefined}
+    />
   );
 }

--- a/clients/web/src/domains/home/components/home-schedules-panel.tsx
+++ b/clients/web/src/domains/home/components/home-schedules-panel.tsx
@@ -1,9 +1,10 @@
-import { Calendar } from "lucide-react";
+import { Calendar, ChevronRight } from "lucide-react";
 import type { ReactNode } from "react";
 
 import { HomeEmptyState } from "@/domains/home/components/home-empty-state";
 import { HomeScheduleRow } from "@/domains/home/components/home-schedule-row";
 import { Button } from "@vellumai/design-library";
+import { Collapsible } from "@vellumai/design-library/components/collapsible";
 import { Notice } from "@vellumai/design-library/components/notice";
 
 import type { Schedule } from "@/domains/settings/types/schedules";
@@ -12,6 +13,8 @@ import type { ScheduleRowUsage } from "@/domains/settings/utils/schedule-formatt
 export interface HomeSchedulesPanelProps {
   recurring: Schedule[];
   oneTime: Schedule[];
+  /** One-shot schedules that have already fired — shown read-only in a collapsible. */
+  pastOneTime: Schedule[];
   usageForSchedule: (id: string) => ScheduleRowUsage;
   isLoading: boolean;
   isError: boolean;
@@ -21,6 +24,10 @@ export interface HomeSchedulesPanelProps {
   selectedScheduleId: string | null;
   onStartNewChat: () => void;
   onCreateSchedule: () => void;
+  /** Controlled open-state for the "Past" accordion (lifted so it survives the
+   * section remount when the detail drawer opens). */
+  pastOpen: boolean;
+  onPastOpenChange: (open: boolean) => void;
   /**
    * Built-in system schedules (heartbeat, consolidation, memory retrospective),
    * rendered below the user list so both share one scroll region. Self-hides
@@ -32,6 +39,7 @@ export interface HomeSchedulesPanelProps {
 export function HomeSchedulesPanel({
   recurring,
   oneTime,
+  pastOneTime,
   usageForSchedule,
   isLoading,
   isError,
@@ -41,6 +49,8 @@ export function HomeSchedulesPanel({
   selectedScheduleId,
   onStartNewChat,
   onCreateSchedule,
+  pastOpen,
+  onPastOpenChange,
   systemTasksSlot,
 }: HomeSchedulesPanelProps) {
   const renderScheduleRow = (schedule: Schedule) => (
@@ -53,6 +63,43 @@ export function HomeSchedulesPanel({
       onToggle={(enabled) => onToggle(schedule.id, enabled)}
     />
   );
+
+  // One-shots are read-only: no toggle. Upcoming ones fire once (nothing to
+  // pause/re-enable meaningfully); past ones have already fired.
+  const renderOneTimeRow = (schedule: Schedule) => (
+    <HomeScheduleRow
+      key={schedule.id}
+      schedule={schedule}
+      usage={usageForSchedule(schedule.id)}
+      selected={schedule.id === selectedScheduleId}
+      onClick={() => onSelectSchedule(schedule.id)}
+    />
+  );
+
+  const pastSection =
+    pastOneTime.length > 0 ? (
+      <Collapsible.Root
+        type="single"
+        collapsible
+        className="mt-3"
+        value={pastOpen ? "past" : ""}
+        onValueChange={(v) => onPastOpenChange(v === "past")}
+      >
+        <Collapsible.Item value="past">
+          <Collapsible.Trigger className="group gap-[var(--app-spacing-xs)] px-2 text-label-small-default text-[var(--content-tertiary)]">
+            <ChevronRight
+              size={14}
+              aria-hidden
+              className="shrink-0 transition-transform group-data-[state=open]:rotate-90"
+            />
+            <span>Past ({pastOneTime.length})</span>
+          </Collapsible.Trigger>
+          <Collapsible.Content>
+            <div className="pt-1">{pastOneTime.map(renderOneTimeRow)}</div>
+          </Collapsible.Content>
+        </Collapsible.Item>
+      </Collapsible.Root>
+    ) : null;
 
   const renderBody = () => {
     if (isLoading) {
@@ -87,7 +134,11 @@ export function HomeSchedulesPanel({
       );
     }
 
-    if (recurring.length === 0 && oneTime.length === 0) {
+    if (
+      recurring.length === 0 &&
+      oneTime.length === 0 &&
+      pastOneTime.length === 0
+    ) {
       return (
         <HomeEmptyState
           icon={Calendar}
@@ -126,9 +177,10 @@ export function HomeSchedulesPanel({
             <p className="mt-3 px-2 text-label-small-default text-[var(--content-tertiary)]">
               One-time
             </p>
-            {oneTime.map(renderScheduleRow)}
+            {oneTime.map(renderOneTimeRow)}
           </>
         ) : null}
+        {pastSection}
       </div>
     );
   };

--- a/clients/web/src/domains/home/home-feed-filter-bar.tsx
+++ b/clients/web/src/domains/home/home-feed-filter-bar.tsx
@@ -86,11 +86,12 @@ export function HomeFeedFilterBar({
   return (
     <SegmentControl<FilterValue>
       ariaLabel="Filter notifications"
-      iconOnly
       value={activeFilter ?? ALL_FILTER}
       onChange={(next) => onFilterChange(next === ALL_FILTER ? null : next)}
       items={items}
-      className="self-start"
+      // Labeled mode defaults to full width with flex-1 segments; keep it
+      // compact (sized to its content) by overriding both.
+      className="self-start !w-auto [&>*]:!flex-none"
     />
   );
 }

--- a/clients/web/src/domains/home/home-feed-list.tsx
+++ b/clients/web/src/domains/home/home-feed-list.tsx
@@ -29,6 +29,18 @@ const TIME_GROUP_LABELS: Record<FeedTimeGroup, string> = {
   older: "Older",
 };
 
+const READ_ARCHIVE_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * A notification the user has already read (seen or acted on — not "new")
+ * and that's older than ~7 days. These are folded into a collapsed accordion
+ * so the live feed stays focused on recent and unread activity.
+ */
+function isArchivedRead(item: FeedItem, now: number): boolean {
+  if (item.status === "new" || item.status === "dismissed") return false;
+  return now - new Date(item.createdAt).getTime() > READ_ARCHIVE_AGE_MS;
+}
+
 export interface HomeFeedListProps {
   items: FeedItem[];
   selectedItemId?: string | null;
@@ -38,6 +50,12 @@ export interface HomeFeedListProps {
   onRestoreItem: (itemId: string) => void;
   onToggleRead?: (itemId: string, newStatus: FeedItemStatus) => void;
   onGoToThread?: (conversationId: string) => void;
+  /** Controlled open-states for the archive accordions (lifted so they survive
+   * the section remount when the detail drawer opens). */
+  archivedOpen?: boolean;
+  onArchivedOpenChange?: (open: boolean) => void;
+  dismissedOpen?: boolean;
+  onDismissedOpenChange?: (open: boolean) => void;
 }
 
 export function HomeFeedList({
@@ -49,16 +67,31 @@ export function HomeFeedList({
   onRestoreItem,
   onToggleRead,
   onGoToThread,
+  archivedOpen,
+  onArchivedOpenChange,
+  dismissedOpen,
+  onDismissedOpenChange,
 }: HomeFeedListProps) {
   const [activeFilter, setActiveFilter] = useState<FeedItemCategory | null>(
     null,
   );
   const [activeSource, setActiveSource] = useState<string | null>(null);
+  // Stable per-mount "now" for the read-archive cutoff — calling Date.now()
+  // during render is impure (and flagged by react-hooks/purity).
+  const [now] = useState(() => Date.now());
 
   const visible = items.filter((item) => item.status !== "dismissed");
   const eligible = excludeHighUrgency(visible);
-  const presentCategories = getPresentCategories(eligible);
-  const presentSources = getPresentSources(eligible);
+
+  // Split off already-read items older than ~7 days into a collapsed archive,
+  // keeping the live feed (and its filters) focused on recent rows.
+  const recent = eligible.filter((item) => !isArchivedRead(item, now));
+  const archivedRead = sortFeedItems(
+    eligible.filter((item) => isArchivedRead(item, now)),
+  );
+
+  const presentCategories = getPresentCategories(recent);
+  const presentSources = getPresentSources(recent);
   const effectiveFilter =
     activeFilter && presentCategories.includes(activeFilter)
       ? activeFilter
@@ -83,7 +116,7 @@ export function HomeFeedList({
   }
 
   const filtered = filterBySource(
-    filterByCategory(eligible, effectiveFilter),
+    filterByCategory(recent, effectiveFilter),
     effectiveSource,
   );
   const sorted = sortFeedItems(filtered);
@@ -160,8 +193,49 @@ export function HomeFeedList({
         ))
       )}
 
+      {archivedRead.length > 0 && (
+        <Collapsible.Root
+          type="single"
+          collapsible
+          value={archivedOpen ? "archived-read" : ""}
+          onValueChange={(v) => onArchivedOpenChange?.(v === "archived-read")}
+        >
+          <Collapsible.Item value="archived-read">
+            <Collapsible.Trigger className="group gap-[var(--app-spacing-xs)] text-body-small-default text-[var(--content-tertiary)]">
+              <ChevronRight
+                size={14}
+                aria-hidden
+                className="shrink-0 transition-transform group-data-[state=open]:rotate-90"
+              />
+              <span>Earlier ({archivedRead.length})</span>
+            </Collapsible.Trigger>
+            <Collapsible.Content>
+              <div className="flex flex-col gap-[var(--app-spacing-xs)] pt-[var(--app-spacing-sm)]">
+                {archivedRead.map((item) => (
+                  <HomeRecapRow
+                    key={item.id}
+                    item={item}
+                    isActive={item.id === selectedItemId}
+                    validConversationIds={validConversationIds}
+                    onSelect={onSelectItem}
+                    onDismiss={onDismissItem}
+                    onToggleRead={onToggleRead}
+                    onGoToThread={onGoToThread}
+                  />
+                ))}
+              </div>
+            </Collapsible.Content>
+          </Collapsible.Item>
+        </Collapsible.Root>
+      )}
+
       {dismissed.length > 0 && (
-        <Collapsible.Root type="single" collapsible>
+        <Collapsible.Root
+          type="single"
+          collapsible
+          value={dismissedOpen ? "dismissed" : ""}
+          onValueChange={(v) => onDismissedOpenChange?.(v === "dismissed")}
+        >
           <Collapsible.Item value="dismissed">
             <Collapsible.Trigger className="group gap-[var(--app-spacing-xs)] text-body-small-default text-[var(--content-tertiary)]">
               <ChevronRight

--- a/clients/web/src/domains/home/home-page.tsx
+++ b/clients/web/src/domains/home/home-page.tsx
@@ -83,7 +83,7 @@ export function HomePage({
 
   const [createScheduleOpen, setCreateScheduleOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<"schedules" | "notifications">(
-    "schedules",
+    "notifications",
   );
   const [selectedItem, setSelectedItem] = useState<FeedItem | null>(null);
   const [selectedScheduleId, setSelectedScheduleId] = useState<string | null>(
@@ -91,10 +91,17 @@ export function HomePage({
   );
   const [selectedSystemTaskKind, setSelectedSystemTaskKind] =
     useState<SystemTaskKind | null>(null);
+  // Accordion open-states are lifted here so they survive the section remount
+  // that happens when the detail drawer opens (the section reparents into
+  // ResizablePanel). Otherwise opening a row collapses its own accordion.
+  const [pastSchedulesOpen, setPastSchedulesOpen] = useState(false);
+  const [archivedFeedOpen, setArchivedFeedOpen] = useState(false);
+  const [dismissedFeedOpen, setDismissedFeedOpen] = useState(false);
 
   const selectedSchedule = selectedScheduleId
     ? (schedules.recurring.find((s) => s.id === selectedScheduleId) ??
       schedules.oneTime.find((s) => s.id === selectedScheduleId) ??
+      schedules.pastOneTime.find((s) => s.id === selectedScheduleId) ??
       null)
     : null;
 
@@ -196,7 +203,8 @@ export function HomePage({
   const canViewSelectedItemSchedule =
     selectedItemScheduleId != null &&
     (schedules.recurring.some((s) => s.id === selectedItemScheduleId) ||
-      schedules.oneTime.some((s) => s.id === selectedItemScheduleId));
+      schedules.oneTime.some((s) => s.id === selectedItemScheduleId) ||
+      schedules.pastOneTime.some((s) => s.id === selectedItemScheduleId));
 
   const itemDetail = selectedItem ? (
     <HomeDetailPanel
@@ -252,7 +260,14 @@ export function HomePage({
   // title and the tabs stay fixed above it.
   const mobileDetail = itemDetail ?? scheduleAreaDetail;
 
-  const withDrawer = (section: ReactNode, detail: ReactNode) =>
+  // `detailKey` re-mounts the animated wrapper on each new selection so the
+  // slide-in replays when switching between schedules / system tasks / items
+  // (not just on the initial null → open transition).
+  const withDrawer = (
+    section: ReactNode,
+    detail: ReactNode,
+    detailKey?: string,
+  ) =>
     detail && !isMobile ? (
       <ResizablePanel
         className="min-h-0 flex-1"
@@ -266,7 +281,11 @@ export function HomePage({
             {section}
           </div>
         }
-        right={detail}
+        right={
+          <div key={detailKey} className="home-detail-drawer">
+            {detail}
+          </div>
+        }
       />
     ) : (
       section
@@ -276,6 +295,7 @@ export function HomePage({
     <HomeSchedulesPanel
       recurring={schedules.recurring}
       oneTime={schedules.oneTime}
+      pastOneTime={schedules.pastOneTime}
       usageForSchedule={schedules.usageForSchedule}
       isLoading={schedules.isLoading}
       isError={schedules.isError}
@@ -285,6 +305,8 @@ export function HomePage({
       selectedScheduleId={selectedScheduleId}
       onStartNewChat={onStartNewChat}
       onCreateSchedule={() => setCreateScheduleOpen(true)}
+      pastOpen={pastSchedulesOpen}
+      onPastOpenChange={setPastSchedulesOpen}
       systemTasksSlot={
         <SystemTasksSection
           heartbeatConfig={systemTasks.heartbeatConfig}
@@ -326,6 +348,10 @@ export function HomePage({
         onRestoreItem={handleRestoreItem}
         onToggleRead={handleUpdateStatus}
         onGoToThread={handleGoToThread}
+        archivedOpen={archivedFeedOpen}
+        onArchivedOpenChange={setArchivedFeedOpen}
+        dismissedOpen={dismissedFeedOpen}
+        onDismissedOpenChange={setDismissedFeedOpen}
       />
     </div>
   );
@@ -342,20 +368,24 @@ export function HomePage({
       className="flex min-h-0 flex-1 flex-col"
     >
       <Tabs.List className="shrink-0">
-        <Tabs.Trigger value="schedules">Schedules</Tabs.Trigger>
         <Tabs.Trigger value="notifications">Notifications</Tabs.Trigger>
+        <Tabs.Trigger value="schedules">Schedules</Tabs.Trigger>
       </Tabs.List>
-      <Tabs.Panel
-        value="schedules"
-        className="mt-[var(--app-spacing-lg)] flex min-h-0 flex-1 flex-col"
-      >
-        {withDrawer(schedulesSection, scheduleAreaDetail)}
-      </Tabs.Panel>
       <Tabs.Panel
         value="notifications"
         className="mt-[var(--app-spacing-lg)] flex min-h-0 flex-1 flex-col"
       >
-        {withDrawer(notificationsSection, itemDetail)}
+        {withDrawer(notificationsSection, itemDetail, selectedItem?.id)}
+      </Tabs.Panel>
+      <Tabs.Panel
+        value="schedules"
+        className="mt-[var(--app-spacing-lg)] flex min-h-0 flex-1 flex-col"
+      >
+        {withDrawer(
+          schedulesSection,
+          scheduleAreaDetail,
+          selectedScheduleId ?? selectedSystemTaskKind ?? undefined,
+        )}
       </Tabs.Panel>
     </Tabs.Root>
   );

--- a/clients/web/src/domains/home/hooks/use-home-schedules-data.ts
+++ b/clients/web/src/domains/home/hooks/use-home-schedules-data.ts
@@ -20,6 +20,8 @@ import { toast } from "@vellumai/design-library/components/toast";
 export interface HomeSchedulesData {
   recurring: Schedule[];
   oneTime: Schedule[];
+  /** One-shot schedules that have already fired (or been cancelled). */
+  pastOneTime: Schedule[];
   usageForSchedule: (id: string) => ScheduleRowUsage;
   handleToggle: (id: string, enabled: boolean) => Promise<void>;
   isLoading: boolean;
@@ -58,11 +60,12 @@ export function useHomeSchedulesData(
     isError: isUsageSummaryError,
   } = useQuery(scheduleUsageSummaryQueryOptions(assistantId, tz, true));
 
-  const { recurring, oneTime } = useMemo(() => {
+  const { recurring, oneTime, pastOneTime } = useMemo(() => {
     const grouped = groupSchedules(schedules ?? [], now);
     return {
       recurring: grouped.recurring,
-      oneTime: [...grouped.upcomingOneTime, ...grouped.pastOneTime],
+      oneTime: grouped.upcomingOneTime,
+      pastOneTime: grouped.pastOneTime,
     };
   }, [now, schedules]);
 
@@ -108,6 +111,7 @@ export function useHomeSchedulesData(
   return {
     recurring,
     oneTime,
+    pastOneTime,
     usageForSchedule,
     handleToggle,
     isLoading,

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -47,6 +47,19 @@ body {
   100% { transform: none; opacity: 1; }
 }
 
+/* Home Activity detail drawer (schedule / heartbeat / notification) sliding
+   in from the right. Ends at `transform: none` for the same containing-block
+   reason as fadeInUp above (the panel hosts fixed Dropdown/tooltip layers). */
+@keyframes drawer-slide-in {
+  0% { transform: translateX(16px); opacity: 0; }
+  100% { transform: none; opacity: 1; }
+}
+
+.home-detail-drawer {
+  animation: drawer-slide-in 0.2s ease-out both;
+  height: 100%;
+}
+
 @keyframes typing-dot-pulse {
   0%, 100% { opacity: 0.45; transform: scale(0.6); }
   50% { opacity: 1; transform: scale(1); }
@@ -283,5 +296,8 @@ body {
   .typing-dot {
     animation: none !important;
     opacity: 0.7 !important;
+  }
+  .home-detail-drawer {
+    animation: none;
   }
 }


### PR DESCRIPTION
## Summary

Decluttering + polish for the Activity page, layered on top of the **System-schedules work already on main** (heartbeat / consolidation / memory retrospective live in the "System" section — this PR does not re-add them). Rebased onto latest main; conflicts resolved by deferring heartbeat surfacing to main's `SystemTasksSection`/`SystemTaskDetailPanel`.

- **Notifications is the default + first tab** when opening Activity.
- **One-shot schedules are read-only** — no enable/disable toggle (you don't pause a single fire). Past one-shots fold into a collapsed **"Past"** accordion.
- **Old read notifications declutter the feed** — already-read items older than ~7 days fold into a collapsed **"Earlier"** accordion (mirrors the existing "Dismissed" one). The live feed + its category/source filters stay focused on recent activity.
- **Category filter shows labels**, kept compact (not full-width).
- **The right detail drawer animates open** (slide-in, respects `prefers-reduced-motion`) and replays when switching between a schedule / system task / notification.
- **Accordion state persists** when the drawer opens — open-states are lifted to `HomePage` so the active row's accordion no longer collapses out of view (the section remounts into `ResizablePanel` on open).

## Test plan

- [ ] Activity opens on Notifications; tab order is Notifications, Schedules.
- [ ] One-time schedules have no toggle; past one-shots live under a collapsed "Past" accordion; main's "System" section still renders below.
- [ ] Read notifications >7 days old appear under a collapsed "Earlier" accordion; filter bar shows compact labels alongside the source filter.
- [ ] Opening any detail animates the drawer and keeps its accordion expanded + the active row highlighted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)