### PR TITLE
feat(disk-usage): support local Docker volume capacity reporting

### DIFF
--- a/assistant/src/__tests__/disk-usage.test.ts
+++ b/assistant/src/__tests__/disk-usage.test.ts
@@ -6,6 +6,8 @@ const GIB = 1024 * MIB;
 let existingPaths = new Set<string>();
 const workspaceDir = "/workspace";
 let minikubeStorageSize: string | undefined;
+let isContainerized = false;
+let isPlatform = false;
 let statfsResult = {
   bsize: 4096,
   blocks: 0,
@@ -34,6 +36,8 @@ mock.module("node:child_process", () => ({
 
 mock.module("../config/env-registry.js", () => ({
   getMinikubeStorageSize: () => minikubeStorageSize,
+  getIsContainerized: () => isContainerized,
+  getIsPlatform: () => isPlatform,
 }));
 
 mock.module("../util/platform.js", () => ({
@@ -55,6 +59,8 @@ describe("disk usage sampler", () => {
   beforeEach(() => {
     existingPaths = new Set([workspaceDir]);
     minikubeStorageSize = undefined;
+    isContainerized = false;
+    isPlatform = false;
     statfsResult = statfsFor(100 * MIB, 25 * MIB);
     spawnResult = { status: 0, stdout: "" };
     spawnCalls = [];
@@ -116,6 +122,65 @@ describe("disk usage sampler", () => {
     expect(usage?.usedMb).toBe(120);
     expect(spawnCalls).toEqual([
       { command: "du", args: ["-sb", "/workspace", "/data"] },
+    ]);
+  });
+
+  test("measures workspace du usage on a local Docker hatch", () => {
+    isContainerized = true;
+    isPlatform = false;
+    statfsResult = statfsFor(100 * GIB, 40 * GIB);
+    spawnResult = {
+      status: 0,
+      stdout: `${2 * GIB}\t/workspace\n`,
+    };
+
+    const usage = getDiskUsageInfo();
+
+    // Used reflects only the workspace (du), free reflects the host headroom
+    // the volume can grow into, and total is their sum.
+    expect(usage).toEqual({
+      path: "/workspace",
+      totalMb: 2048 + 40960,
+      usedMb: 2048,
+      freeMb: 40960,
+    });
+    expect(spawnCalls).toEqual([
+      { command: "du", args: ["-sb", "/workspace"] },
+    ]);
+  });
+
+  test("does not use du for platform-managed containerized instances", () => {
+    isContainerized = true;
+    isPlatform = true;
+    statfsResult = statfsFor(10 * GIB, 6 * GIB);
+
+    const usage = getDiskUsageInfo();
+
+    expect(usage).toEqual({
+      path: "/workspace",
+      totalMb: 10240,
+      usedMb: 4096,
+      freeMb: 6144,
+    });
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  test("falls back to statfs when du fails on a local Docker hatch", () => {
+    isContainerized = true;
+    isPlatform = false;
+    statfsResult = statfsFor(100 * GIB, 40 * GIB);
+    spawnResult = { status: 1, stdout: "" };
+
+    const usage = getDiskUsageInfo();
+
+    expect(usage).toEqual({
+      path: "/workspace",
+      totalMb: 102400,
+      usedMb: 61440,
+      freeMb: 40960,
+    });
+    expect(spawnCalls).toEqual([
+      { command: "du", args: ["-sb", "/workspace"] },
     ]);
   });
 

--- a/assistant/src/util/disk-usage.ts
+++ b/assistant/src/util/disk-usage.ts
@@ -1,7 +1,11 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, statfsSync } from "node:fs";
 
-import { getMinikubeStorageSize } from "../config/env-registry.js";
+import {
+  getIsContainerized,
+  getIsPlatform,
+  getMinikubeStorageSize,
+} from "../config/env-registry.js";
 import { getWorkspaceDir } from "./platform.js";
 
 export interface DiskUsageInfo {
@@ -58,6 +62,57 @@ export function __resetDiskUsageCacheForTests(): void {
   duCachePaths = null;
 }
 
+/**
+ * How the workspace volume's capacity should be reported when statfsSync
+ * cannot see the volume directly.
+ *
+ * - `fixed-cap`: minikube hostPath PVC — the PVC request is the hard
+ *   capacity, so usage is measured with `du` and free space is whatever
+ *   remains within the quota.
+ * - `host-free`: local Docker named volume — the volume is backed by the
+ *   host (or Colima VM) filesystem and can grow into its free space, so
+ *   usage is measured with `du` and the effective capacity is current usage
+ *   plus the host's remaining headroom.
+ * - `none`: statfsSync already reports the volume accurately (bare metal, or
+ *   a platform-managed instance on a CSI-backed PVC), so use it directly.
+ */
+type WorkspaceVolumeReporting =
+  | { kind: "none" }
+  | { kind: "fixed-cap"; totalBytes: number }
+  | { kind: "host-free" };
+
+/**
+ * Decide how to report the workspace volume's capacity. Both minikube
+ * hostPath PVCs and local Docker named volumes are backed by the host
+ * filesystem, so statfsSync reports the host's entire disk rather than the
+ * workspace volume — in both cases we measure actual usage with `du` instead.
+ */
+function classifyWorkspaceVolume(
+  fsTotalBytes: number,
+): WorkspaceVolumeReporting {
+  // Minikube mode: the platform passes the PVC storage size so we can report
+  // accurate capacity. Detect the hostPath case by comparing filesystem size
+  // against the PVC size — if the filesystem is larger, statfsSync is seeing
+  // the host disk and we should measure the directory instead.
+  const storageSizeRaw = getMinikubeStorageSize();
+  if (storageSizeRaw) {
+    const pvcTotalBytes = parseK8sMemoryBytes(storageSizeRaw);
+    if (pvcTotalBytes !== null && fsTotalBytes > pvcTotalBytes * 1.1) {
+      return { kind: "fixed-cap", totalBytes: pvcTotalBytes };
+    }
+    return { kind: "none" };
+  }
+
+  // Local Docker hatch: the workspace is a Docker named volume backed by the
+  // host filesystem. Platform-managed remote instances run on CSI-backed PVCs
+  // where statfsSync already reports the volume, so they are excluded.
+  if (getIsContainerized() && !getIsPlatform()) {
+    return { kind: "host-free" };
+  }
+
+  return { kind: "none" };
+}
+
 export function getDiskUsageInfo(): DiskUsageInfo | null {
   try {
     const wsDir = getWorkspaceDir();
@@ -68,28 +123,28 @@ export function getDiskUsageInfo(): DiskUsageInfo | null {
     const bytesToMb = (b: number) =>
       Math.round((b / (1024 * 1024)) * 100) / 100;
 
-    // Minikube mode: the platform passes the PVC storage size so we can
-    // report accurate capacity. On hostPath-backed PVCs statfsSync reports
-    // the host's entire filesystem rather than the PVC. Detect this by
-    // comparing filesystem size against PVC size — if the filesystem is
-    // larger, measure actual directory usage with `du` instead.
-    const storageSizeRaw = getMinikubeStorageSize();
-    if (storageSizeRaw) {
-      const pvcTotalBytes = parseK8sMemoryBytes(storageSizeRaw);
-      if (pvcTotalBytes !== null && fsTotalBytes > pvcTotalBytes * 1.1) {
-        const volumePaths = [diskPath];
-        if (diskPath !== "/data" && existsSync("/data")) {
-          volumePaths.push("/data");
-        }
-        const usedBytes = getCachedDirectorySizeBytes(volumePaths);
-        if (usedBytes !== null) {
-          return {
-            path: diskPath,
-            totalMb: bytesToMb(pvcTotalBytes),
-            usedMb: bytesToMb(usedBytes),
-            freeMb: bytesToMb(Math.max(0, pvcTotalBytes - usedBytes)),
-          };
-        }
+    const reporting = classifyWorkspaceVolume(fsTotalBytes);
+    if (reporting.kind !== "none") {
+      const volumePaths = [diskPath];
+      if (diskPath !== "/data" && existsSync("/data")) {
+        volumePaths.push("/data");
+      }
+      const usedBytes = getCachedDirectorySizeBytes(volumePaths);
+      if (usedBytes !== null) {
+        const totalBytes =
+          reporting.kind === "fixed-cap"
+            ? reporting.totalBytes
+            : usedBytes + fsFreeBytes;
+        const freeBytes =
+          reporting.kind === "fixed-cap"
+            ? Math.max(0, reporting.totalBytes - usedBytes)
+            : fsFreeBytes;
+        return {
+          path: diskPath,
+          totalMb: bytesToMb(totalBytes),
+          usedMb: bytesToMb(usedBytes),
+          freeMb: bytesToMb(freeBytes),
+        };
       }
     }
 


### PR DESCRIPTION
## Prompt / plan
Extend disk usage reporting to handle local Docker named volumes in addition to existing minikube hostPath PVC support.

## Summary
This change refactors disk usage capacity reporting to support three distinct scenarios:

1. **Minikube hostPath PVCs** (`fixed-cap`): Uses the PVC storage size as the hard capacity limit, with actual usage measured via `du`
2. **Local Docker named volumes** (`host-free`): Measures actual usage via `du` and reports capacity as current usage plus available host filesystem headroom
3. **Platform-managed instances** (`none`): Uses `statfsSync` directly (CSI-backed PVCs or bare metal)

The logic is extracted into a new `classifyWorkspaceVolume()` function that determines which reporting mode to use based on:
- Whether a minikube storage size is configured
- Whether the environment is containerized
- Whether it's a platform-managed instance

This allows local Docker hatch environments to accurately report workspace volume capacity by accounting for the host filesystem's available space that the volume can grow into.

## Test plan
Added three new unit tests covering:
- Local Docker hatch with successful `du` measurement
- Platform-managed containerized instances (uses `statfsSync`, not `du`)
- Local Docker hatch with `du` failure (falls back to `statfsSync`)

All existing tests continue to pass.

https://claude.ai/code/session_011A4dbn9ujHZGJefdncGvJu