### PR TITLE
fix(telemetry): send usage telemetry authenticated-only, gated on VELLUM_DISABLE_PLATFORM

### DIFF
--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -305,6 +305,7 @@ beforeEach(() => {
   getDb().delete(toolInvocations).run();
   getDb().delete(skillLoadedEvents).run();
   delete process.env.VELLUM_DISABLE_PLATFORM;
+  delete process.env.IS_PLATFORM;
   mockGetPlatformBaseUrl.mockReset();
   mockGetDeviceId.mockReset();
   mockGetDeviceId.mockReturnValue("test-device-id");
@@ -337,6 +338,7 @@ beforeEach(() => {
 afterEach(() => {
   globalThis.fetch = originalFetch;
   delete process.env.VELLUM_DISABLE_PLATFORM;
+  delete process.env.IS_PLATFORM;
 });
 
 // ---------------------------------------------------------------------------
@@ -385,7 +387,7 @@ describe("UsageTelemetryReporter", () => {
     expect(watermarkCalls.length).toBe(0);
   });
 
-  test("flush is skipped when VELLUM_DISABLE_PLATFORM is set", async () => {
+  test("flush is skipped when VELLUM_DISABLE_PLATFORM is set in local mode", async () => {
     // The platform-disabled toggle suppresses the send. Unlike the opt-out
     // branch, watermarks are NOT advanced, so the backlog ships once the flag
     // is cleared.
@@ -402,6 +404,22 @@ describe("UsageTelemetryReporter", () => {
 
     expect(mockFetch).not.toHaveBeenCalled();
     expect(mockSetMemoryCheckpoint).not.toHaveBeenCalled();
+  });
+
+  test("VELLUM_DISABLE_PLATFORM is ignored when IS_PLATFORM is set (managed mode)", async () => {
+    // Platform-managed assistants always connect to the platform; an inherited
+    // VELLUM_DISABLE_PLATFORM must not suppress telemetry for them (matches
+    // arePlatformFeaturesEnabled / VellumPlatformClient.create()).
+    process.env.IS_PLATFORM = "true";
+    process.env.VELLUM_DISABLE_PLATFORM = "true";
+
+    const events = [makeUsageEvent()];
+    mockQueryUnreportedUsageEvents.mockReturnValue(events);
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
   test("watermark advances on successful upload", async () => {

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -1,8 +1,9 @@
 /**
  * Tests for UsageTelemetryReporter.
  *
- * Covers both auth modes (authenticated / anonymous), watermark advancement,
- * error handling, batch recursion, device ID resolution, and payload shape.
+ * Covers the authenticated send path (and the skip behavior when credentials
+ * are absent or the platform is disabled), watermark advancement, error
+ * handling, batch recursion, device ID resolution, and payload shape.
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -303,7 +304,7 @@ beforeEach(() => {
   getDb().delete(authFallbackEvents).run();
   getDb().delete(toolInvocations).run();
   getDb().delete(skillLoadedEvents).run();
-  mockPlatformClient = null;
+  delete process.env.VELLUM_DISABLE_PLATFORM;
   mockGetPlatformBaseUrl.mockReset();
   mockGetDeviceId.mockReset();
   mockGetDeviceId.mockReturnValue("test-device-id");
@@ -320,10 +321,22 @@ beforeEach(() => {
     Promise.resolve(new Response('{"accepted":0}', { status: 200 })),
   );
   globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+  // Default to an authenticated client whose fetch delegates to the mockFetch
+  // spy, so the existing payload/body assertions keep working. The reporter
+  // sends authenticated-only; tests that exercise the no-credentials path
+  // override this with `mockPlatformClient = null`.
+  mockPlatformClient = {
+    baseUrl: "https://test.vellum.ai",
+    assistantApiKey: "test-key",
+    platformAssistantId: "asst-123",
+    fetch: (path: string, init?: RequestInit) => mockFetch(path, init),
+  };
 });
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  delete process.env.VELLUM_DISABLE_PLATFORM;
 });
 
 // ---------------------------------------------------------------------------
@@ -354,26 +367,41 @@ describe("UsageTelemetryReporter", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  test("anonymous flush sends request without auth headers", async () => {
+  test("flush is skipped when no platform credentials are available", async () => {
+    // Authenticated-only: with no client, nothing is sent and the watermark is
+    // left intact so the backlog ships once credentials resolve.
     mockPlatformClient = null;
-    mockGetPlatformBaseUrl.mockReturnValue("https://platform.test.ai");
 
     const events = [makeUsageEvent()];
     mockQueryUnreportedUsageEvents.mockReturnValue(events);
-    mockFetch.mockImplementation(() =>
-      Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
-    );
 
     const reporter = new UsageTelemetryReporter();
     await reporter.flush();
 
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    const [url, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect(url).toStartWith("https://platform.test.ai");
-    expect(url).toEndWith("/telemetry/ingest/");
-    const headers = opts.headers as Record<string, string>;
-    expect(headers["Content-Type"]).toBe("application/json");
-    expect(headers["X-Telemetry-Token"]).toBeUndefined();
+    expect(mockFetch).not.toHaveBeenCalled();
+    const watermarkCalls = mockSetMemoryCheckpoint.mock.calls.filter(
+      (c) => c[0] === "telemetry:usage:last_reported_at",
+    );
+    expect(watermarkCalls.length).toBe(0);
+  });
+
+  test("flush is skipped when VELLUM_DISABLE_PLATFORM is set", async () => {
+    // The platform-disabled toggle suppresses the send. Unlike the opt-out
+    // branch, watermarks are NOT advanced, so the backlog ships once the flag
+    // is cleared.
+    process.env.VELLUM_DISABLE_PLATFORM = "true";
+
+    const events = [makeUsageEvent()];
+    mockQueryUnreportedUsageEvents.mockReturnValue(events);
+
+    const reporter = new UsageTelemetryReporter();
+    // Construction initializes the absent tool_executed watermark; clear that
+    // call so the assertion below covers only the flush.
+    mockSetMemoryCheckpoint.mockClear();
+    await reporter.flush();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockSetMemoryCheckpoint).not.toHaveBeenCalled();
   });
 
   test("watermark advances on successful upload", async () => {

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -6,14 +6,14 @@
  *
  * Authenticated-only: events are sent via the managed proxy context
  * (Api-Key header). When no platform credentials are available, or when
- * VELLUM_DISABLE_PLATFORM is set, the flush is skipped and retried next cycle.
+ * platform features are disabled (VELLUM_DISABLE_PLATFORM in local mode), the
+ * flush is skipped and retried next cycle.
  */
 
 import {
   getPlatformOrganizationId,
   getPlatformUserId,
 } from "../config/env.js";
-import { getDisablePlatform } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
 import { queryUnreportedAuthFallbackEvents } from "../memory/auth-fallback-events-store.js";
 import {
@@ -27,6 +27,7 @@ import { queryUnreportedSkillLoadedEvents } from "../memory/skill-loaded-events-
 import { queryUnreportedToolExecutedEvents } from "../memory/tool-executed-events-store.js";
 import { queryUnreportedTurnEvents } from "../memory/turn-events-store.js";
 import { VellumPlatformClient } from "../platform/client.js";
+import { arePlatformFeaturesEnabled } from "../platform/feature-gate.js";
 import type { UsageAttributionProfileSource } from "../usage/types.js";
 import { getDeviceId } from "../util/device-id.js";
 import { getLogger } from "../util/logger.js";
@@ -238,10 +239,12 @@ export class UsageTelemetryReporter {
         return;
       }
 
-      // Skip when platform calls are disabled. Unlike the opt-out branch above,
-      // watermarks are NOT advanced: this flag is a deployment/local-mode toggle
+      // Skip when platform features are disabled (VELLUM_DISABLE_PLATFORM in
+      // local mode; the flag is ignored when IS_PLATFORM is set, matching
+      // VellumPlatformClient.create()). Unlike the opt-out branch above,
+      // watermarks are NOT advanced: this is a deployment/local-mode toggle
       // (not a privacy opt-out), so the unsent backlog ships once it's cleared.
-      if (getDisablePlatform()) {
+      if (!arePlatformFeaturesEnabled()) {
         return;
       }
 

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -4,16 +4,16 @@
  * Periodically flushes LLM usage events and turn events (user messages) from
  * the local SQLite database and POSTs them to the platform telemetry endpoint.
  *
- * Two auth modes:
- * - Authenticated: Api-Key header via managed proxy context
- * - Anonymous: unauthenticated POST (telemetry endpoints are public)
+ * Authenticated-only: events are sent via the managed proxy context
+ * (Api-Key header). When no platform credentials are available, or when
+ * VELLUM_DISABLE_PLATFORM is set, the flush is skipped and retried next cycle.
  */
 
 import {
-  getPlatformBaseUrl,
   getPlatformOrganizationId,
   getPlatformUserId,
 } from "../config/env.js";
+import { getDisablePlatform } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
 import { queryUnreportedAuthFallbackEvents } from "../memory/auth-fallback-events-store.js";
 import {
@@ -162,7 +162,8 @@ export class UsageTelemetryReporter {
     // Delay the first flush to allow the credential infrastructure (CES
     // handshake) to complete. Without this delay, VellumPlatformClient.create()
     // returns null because the credential backend hasn't resolved yet, causing
-    // telemetry to fall back to anonymous mode permanently.
+    // the initial flush to be skipped (we send authenticated-only); the
+    // delay lets credentials resolve so the first flush can actually ship.
     this.initialFlushTimer = setTimeout(() => {
       this.initialFlushTimer = null;
       this.flush().catch((err) => {
@@ -234,6 +235,13 @@ export class UsageTelemetryReporter {
           setMemoryCheckpoint(timestampKey, now);
           setMemoryCheckpoint(idKey, OPT_OUT_WATERMARK_ID_SENTINEL);
         }
+        return;
+      }
+
+      // Skip when platform calls are disabled. Unlike the opt-out branch above,
+      // watermarks are NOT advanced: this flag is a deployment/local-mode toggle
+      // (not a privacy opt-out), so the unsent backlog ships once it's cleared.
+      if (getDisablePlatform()) {
         return;
       }
 
@@ -343,12 +351,19 @@ export class UsageTelemetryReporter {
       )
         return;
 
-      // Resolve auth context — authenticated path uses client, anonymous path
-      // sends unauthenticated (telemetry endpoints are public).
+      // Resolve auth context. We send authenticated-only: if no platform
+      // credentials are available yet, skip without advancing watermarks so the
+      // backlog ships on a later cycle once credentials resolve.
       const client = await VellumPlatformClient.create();
+      if (!client) {
+        log.debug(
+          { pendingEventCount: events.length + turnEvents.length },
+          "Telemetry flush: no platform credentials — skipping, will retry next cycle",
+        );
+        return;
+      }
       log.debug(
         {
-          authenticated: !!client,
           usageCount: events.length,
           turnCount: turnEvents.length,
           lifecycleCount: lifecycleEvents.length,
@@ -588,18 +603,12 @@ export class UsageTelemetryReporter {
         body: JSON.stringify(payload),
       };
 
-      let resp: Response;
-      if (client) {
-        resp = await client.fetch(TELEMETRY_PATH, fetchInit);
-      } else {
-        const url = `${getPlatformBaseUrl()}${TELEMETRY_PATH}`;
-        resp = await fetch(url, fetchInit);
-      }
+      const resp = await client.fetch(TELEMETRY_PATH, fetchInit);
 
       if (!resp.ok) {
         const body = await resp.text();
         log.warn(
-          { status: resp.status, authenticated: !!client, body },
+          { status: resp.status, body },
           "Usage telemetry POST failed — will retry next cycle",
         );
         return;


### PR DESCRIPTION
## Summary
- Remove the anonymous (unauthenticated) telemetry POST fallback. The reporter now sends usage telemetry **only** via the authenticated `VellumPlatformClient`; when no platform credentials are available, the flush is skipped (without advancing watermarks) and retried next cycle so the backlog ships once credentials resolve.
- Skip the flush entirely when `VELLUM_DISABLE_PLATFORM` is set. Unlike the `collectUsageData` opt-out branch, watermarks are **not** advanced here — this is a deployment/local-mode toggle, not a privacy opt-out, so the unsent backlog ships once the flag is cleared.
- Reworked the reporter tests to drive the authenticated client path and added coverage for the two new skip conditions (no credentials, platform disabled).

## Original prompt
Update the usage telemetry reporter so it stops doing the anonymous unauthenticated fetch — rely solely on authenticated requests via `VellumPlatformClient` and don't send at all if credentials are absent. Additionally, do not send telemetry when the platform is disabled (`VELLUM_DISABLE_PLATFORM`). Confirmed during the conversation that the gate should match the flag's documented meaning: skip sending when `VELLUM_DISABLE_PLATFORM` is truthy.