### PR TITLE
feat(consent): add share toggle version fields to UserConsent type

### DIFF
--- a/clients/web/src/domains/account/profile.ts
+++ b/clients/web/src/domains/account/profile.ts
@@ -15,10 +15,21 @@ export interface UserConsent {
   ai_data_sharing_accepted_at: string | null;
   share_analytics: boolean;
   share_diagnostics: boolean;
+  share_analytics_accepted_version: string;
+  share_analytics_accepted_at: string | null;
+  share_diagnostics_accepted_version: string;
+  share_diagnostics_accepted_at: string | null;
 }
 
 export type ConsentPatch = Partial<
-  Omit<UserConsent, "tos_accepted_at" | "privacy_policy_accepted_at" | "ai_data_sharing_accepted_at">
+  Omit<
+    UserConsent,
+    | "tos_accepted_at"
+    | "privacy_policy_accepted_at"
+    | "ai_data_sharing_accepted_at"
+    | "share_analytics_accepted_at"
+    | "share_diagnostics_accepted_at"
+  >
 >;
 
 export interface UserMe {


### PR DESCRIPTION
## Summary
- Add share_analytics/share_diagnostics _accepted_version and _accepted_at fields to the UserConsent interface
- Extend ConsentPatch to omit the two new server-stamped _at fields

Part of plan: consent-toggle-versioning.md (PR 2 of 7)