### PR TITLE
feat(consent): track toggle consent currency in onboarding store

### DIFF
--- a/clients/web/src/domains/onboarding/onboarding-store.ts
+++ b/clients/web/src/domains/onboarding/onboarding-store.ts
@@ -5,10 +5,12 @@
  * written to `device:` localStorage keys on every setter call and synced
  * across tabs via `watchSetting`. They survive logout.
  *
- * **In-memory-only fields** (`tosAccepted`, `aiDataConsent`) start `false`
- * and are populated by `restoreConsentForUser` (called from the auth store
- * once the user id is known). Persistence to durable per-user device keys
- * is handled by `persistConsentForUser` in `onboarding-cleanup.ts`.
+ * **In-memory-only fields** (`tosAccepted`, `aiDataConsent`,
+ * `analyticsConsentCurrent`, `diagnosticsConsentCurrent`) start `false` and
+ * are populated on session sync (e.g. `restoreConsentForUser`, called from
+ * the auth store once the user id is known). Persistence to durable per-user
+ * device keys is handled by `persistConsentForUser` in
+ * `onboarding-cleanup.ts`.
  *
  * Reference: {@link https://zustand.docs.pmnd.rs/}
  */
@@ -40,6 +42,8 @@ export interface OnboardingState {
   shareDiagnostics: boolean;
   tosAccepted: boolean;
   aiDataConsent: boolean;
+  analyticsConsentCurrent: boolean;
+  diagnosticsConsentCurrent: boolean;
 }
 
 export interface OnboardingActions {
@@ -47,6 +51,8 @@ export interface OnboardingActions {
   setShareDiagnostics: (value: boolean) => void;
   setTosAccepted: (value: boolean) => void;
   setAiDataConsent: (value: boolean) => void;
+  setAnalyticsConsentCurrent: (value: boolean) => void;
+  setDiagnosticsConsentCurrent: (value: boolean) => void;
 }
 
 export type OnboardingStore = OnboardingState & OnboardingActions;
@@ -60,6 +66,8 @@ const useOnboardingStoreBase = create<OnboardingStore>()((set) => ({
   shareDiagnostics: getLocalBool(KEY_SHARE_DIAGNOSTICS, true),
   tosAccepted: false,
   aiDataConsent: false,
+  analyticsConsentCurrent: false,
+  diagnosticsConsentCurrent: false,
 
   setShareAnalytics: (value) => {
     set({ shareAnalytics: value });
@@ -75,6 +83,12 @@ const useOnboardingStoreBase = create<OnboardingStore>()((set) => ({
   },
   setAiDataConsent: (value) => {
     set({ aiDataConsent: value });
+  },
+  setAnalyticsConsentCurrent: (value) => {
+    set({ analyticsConsentCurrent: value });
+  },
+  setDiagnosticsConsentCurrent: (value) => {
+    set({ diagnosticsConsentCurrent: value });
   },
 }));
 


### PR DESCRIPTION
## Summary
- Add in-memory analyticsConsentCurrent/diagnosticsConsentCurrent flags + setters to the onboarding store
- Flags default false and are populated on session sync, like tosAccepted/aiDataConsent (not device-persisted)

Part of plan: consent-toggle-versioning.md (PR 3 of 7)