### PR TITLE
fix(consent): use /v1/user/consent/ instead of dead /v1/user/me/ consent wiring

### DIFF
--- a/clients/web/src/domains/account/profile.ts
+++ b/clients/web/src/domains/account/profile.ts
@@ -27,7 +27,6 @@ export interface UserMe {
   email: string;
   first_name: string;
   last_name: string;
-  consent: UserConsent | null;
 }
 
 export type UsernameErrorCode =
@@ -133,10 +132,26 @@ export async function updateMe(patch: UpdateMePatch): Promise<UpdateMeResult> {
   };
 }
 
+export async function fetchConsent(): Promise<UserConsent> {
+  const { data, error, response } = await client.get<UserConsent, unknown>({
+    url: "/v1/user/consent/",
+    throwOnError: false,
+  });
+  assertHasResponse(response, error, "Failed to load consent.");
+  if (!response.ok || !data) {
+    throw new ApiError(
+      response.status,
+      extractErrorMessage(error, response, "Failed to load consent."),
+    );
+  }
+  return data;
+}
+
+// PUTs /v1/user/consent/ — partial bodies are accepted, no writable field is required.
 export async function patchConsent(consent: ConsentPatch): Promise<void> {
-  await client.patch({
-    url: "/v1/user/me/",
-    body: { consent },
+  await client.put({
+    url: "/v1/user/consent/",
+    body: consent,
     throwOnError: true,
   });
 }

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -42,12 +42,21 @@ const restoreConsentForUserMock = mock((_userId: string | null) => ({
 const persistConsentForUserMock = mock(
   (_userId: string | null, _tos: boolean, _ai: boolean) => {},
 );
-const resolveServerConsentMock = mock((_consent: unknown) => ({
-  tos: false,
-  ai: false,
-  shareAnalytics: null,
-  shareDiagnostics: null,
-}));
+const resolveServerConsentMock = mock(
+  (
+    _consent: unknown,
+  ): {
+    tos: boolean;
+    ai: boolean;
+    shareAnalytics: boolean | null;
+    shareDiagnostics: boolean | null;
+  } => ({
+    tos: false,
+    ai: false,
+    shareAnalytics: null,
+    shareDiagnostics: null,
+  }),
+);
 
 const EMPTY_CONSENT = {
   tos_accepted_version: "",

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -49,18 +49,21 @@ const resolveServerConsentMock = mock((_consent: unknown) => ({
   shareDiagnostics: null,
 }));
 
-let mockFetchMeResult: unknown = {
-  id: "user-1",
-  username: "test",
-  email: "test@example.com",
-  first_name: "",
-  last_name: "",
-  consent: null,
+const EMPTY_CONSENT = {
+  tos_accepted_version: "",
+  tos_accepted_at: null,
+  privacy_policy_accepted_version: "",
+  privacy_policy_accepted_at: null,
+  ai_data_sharing_accepted_version: "",
+  ai_data_sharing_accepted_at: null,
+  share_analytics: false,
+  share_diagnostics: false,
 };
-let mockFetchMeError: Error | null = null;
-const fetchMeMock = mock(async () => {
-  if (mockFetchMeError) throw mockFetchMeError;
-  return mockFetchMeResult;
+let mockFetchConsentResult: unknown = EMPTY_CONSENT;
+let mockFetchConsentError: Error | null = null;
+const fetchConsentMock = mock(async () => {
+  if (mockFetchConsentError) throw mockFetchConsentError;
+  return mockFetchConsentResult;
 });
 const clearOrganizationMock = mock(() => {});
 const logoutMock = mock(async () => {});
@@ -162,7 +165,7 @@ const clearUserScopedStorageMock = mock(() => {});
 const patchConsentMock = mock(async (_consent: unknown) => {});
 
 mock.module("@/domains/account/profile", () => ({
-  fetchMe: fetchMeMock,
+  fetchConsent: fetchConsentMock,
   patchConsent: patchConsentMock,
 }));
 
@@ -289,17 +292,10 @@ beforeEach(() => {
   restoreConsentForUserMock.mockClear();
   persistConsentForUserMock.mockClear();
   resolveServerConsentMock.mockClear();
-  fetchMeMock.mockClear();
+  fetchConsentMock.mockClear();
   patchConsentMock.mockClear();
-  mockFetchMeResult = {
-    id: "user-1",
-    username: "test",
-    email: "test@example.com",
-    first_name: "",
-    last_name: "",
-    consent: null,
-  };
-  mockFetchMeError = null;
+  mockFetchConsentResult = EMPTY_CONSENT;
+  mockFetchConsentError = null;
   clearOrganizationMock.mockClear();
   clearUserScopedStorageMock.mockClear();
   logoutMock.mockClear();
@@ -444,41 +440,43 @@ describe("auth store onboarding flag reconciliation", () => {
 
   test("initSession uses server consent when server has a consent record", async () => {
     sessionUser = { id: "user-1", email: "user@example.com" };
-    mockFetchMeResult = {
-      id: "user-1",
-      username: "test",
-      email: "test@example.com",
-      first_name: "",
-      last_name: "",
-      consent: {
-        tos_accepted_version: "2026-06-08",
-        privacy_policy_accepted_version: "2026-06-08",
-        ai_data_sharing_accepted_version: "2026-06-08",
-        share_analytics: true,
-        share_diagnostics: true,
-      },
+    mockFetchConsentResult = {
+      tos_accepted_version: "2026-06-08",
+      tos_accepted_at: "2026-06-08T00:00:00Z",
+      privacy_policy_accepted_version: "2026-06-08",
+      privacy_policy_accepted_at: "2026-06-08T00:00:00Z",
+      ai_data_sharing_accepted_version: "2026-06-08",
+      ai_data_sharing_accepted_at: "2026-06-08T00:00:00Z",
+      share_analytics: true,
+      share_diagnostics: true,
     };
+    resolveServerConsentMock.mockReturnValueOnce({
+      tos: true,
+      ai: true,
+      shareAnalytics: true,
+      shareDiagnostics: true,
+    });
 
     await useAuthStore.getState().initSession();
 
-    expect(fetchMeMock).toHaveBeenCalled();
+    expect(fetchConsentMock).toHaveBeenCalled();
     expect(resolveServerConsentMock).toHaveBeenCalled();
     expect(restoreConsentForUserMock).not.toHaveBeenCalled();
     expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
   });
 
-  test("initSession falls through to device keys when server consent is null", async () => {
+  test("initSession falls through to device keys when server versions are empty", async () => {
     sessionUser = { id: "user-1", email: "user@example.com" };
 
     await useAuthStore.getState().initSession();
 
-    expect(fetchMeMock).toHaveBeenCalled();
-    expect(resolveServerConsentMock).not.toHaveBeenCalled();
+    expect(fetchConsentMock).toHaveBeenCalled();
+    expect(resolveServerConsentMock).toHaveBeenCalled();
     expect(restoreConsentForUserMock).toHaveBeenCalledWith("user-1");
     expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
   });
 
-  test("initSession backfills server when device keys show prior consent and server has no record", async () => {
+  test("initSession backfills server when device keys show prior consent and server versions are empty", async () => {
     sessionUser = { id: "user-1", email: "user@example.com" };
     restoreConsentForUserMock.mockReturnValueOnce({ tos: true, ai: true });
 
@@ -487,13 +485,13 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(patchConsentMock).toHaveBeenCalled();
   });
 
-  test("initSession falls back to device keys when fetchMe fails", async () => {
+  test("initSession falls back to device keys when fetchConsent fails", async () => {
     sessionUser = { id: "user-1", email: "user@example.com" };
-    mockFetchMeError = new Error("Network error");
+    mockFetchConsentError = new Error("Network error");
 
     await useAuthStore.getState().initSession();
 
-    expect(fetchMeMock).toHaveBeenCalled();
+    expect(fetchConsentMock).toHaveBeenCalled();
     expect(restoreConsentForUserMock).toHaveBeenCalledWith("user-1");
     expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
   });
@@ -502,48 +500,40 @@ describe("auth store onboarding flag reconciliation", () => {
     mockIsLocalMode = true;
     sessionUser = { id: "user-1", email: "user@example.com" };
     mockPlatformAssistants = [{ assistantId: "p1", cloud: "vellum" }];
-    mockFetchMeResult = {
-      id: "user-1",
-      username: "test",
-      email: "test@example.com",
-      first_name: "",
-      last_name: "",
-      consent: {
-        tos_accepted_version: "2026-06-08",
-        privacy_policy_accepted_version: "2026-06-08",
-        ai_data_sharing_accepted_version: "2026-06-08",
-        share_analytics: true,
-        share_diagnostics: true,
-      },
+    mockFetchConsentResult = {
+      tos_accepted_version: "2026-06-08",
+      tos_accepted_at: "2026-06-08T00:00:00Z",
+      privacy_policy_accepted_version: "2026-06-08",
+      privacy_policy_accepted_at: "2026-06-08T00:00:00Z",
+      ai_data_sharing_accepted_version: "2026-06-08",
+      ai_data_sharing_accepted_at: "2026-06-08T00:00:00Z",
+      share_analytics: true,
+      share_diagnostics: true,
     };
 
     await useAuthStore.getState().initSession();
 
-    expect(fetchMeMock).toHaveBeenCalled();
+    expect(fetchConsentMock).toHaveBeenCalled();
     expect(resolveServerConsentMock).toHaveBeenCalled();
     expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
   });
 
   test("refreshSession fetches consent from server for platform users", async () => {
     sessionUser = { id: "user-2", email: "user@example.com" };
-    mockFetchMeResult = {
-      id: "user-2",
-      username: "test",
-      email: "user@example.com",
-      first_name: "",
-      last_name: "",
-      consent: {
-        tos_accepted_version: "2026-06-08",
-        privacy_policy_accepted_version: "2026-06-08",
-        ai_data_sharing_accepted_version: "2026-06-08",
-        share_analytics: true,
-        share_diagnostics: true,
-      },
+    mockFetchConsentResult = {
+      tos_accepted_version: "2026-06-08",
+      tos_accepted_at: "2026-06-08T00:00:00Z",
+      privacy_policy_accepted_version: "2026-06-08",
+      privacy_policy_accepted_at: "2026-06-08T00:00:00Z",
+      ai_data_sharing_accepted_version: "2026-06-08",
+      ai_data_sharing_accepted_at: "2026-06-08T00:00:00Z",
+      share_analytics: true,
+      share_diagnostics: true,
     };
 
     await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
 
-    expect(fetchMeMock).toHaveBeenCalled();
+    expect(fetchConsentMock).toHaveBeenCalled();
     expect(resolveServerConsentMock).toHaveBeenCalled();
     expect(useAuthStore.getState().user?.id).toBe("user-2");
   });

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -53,7 +53,7 @@ import {
 import { listAssistants } from "@/assistant/api";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { deleteBiometricToken } from "@/runtime/native-biometric";
-import { fetchMe, patchConsent } from "@/domains/account/profile";
+import { fetchConsent, patchConsent } from "@/domains/account/profile";
 import {
   restoreConsentForUser,
   persistConsentForUser,
@@ -245,32 +245,30 @@ function broadcastAuthChange(): void {
 async function syncUserScopedState(nextUserId: string | null): Promise<void> {
   if (nextUserId) {
     try {
-      const me = await fetchMe();
-      if (me.consent) {
-        const resolved = resolveServerConsent(me.consent);
-        const store = useOnboardingStore.getState();
-        store.setTosAccepted(resolved.tos);
-        store.setAiDataConsent(resolved.ai);
-        if (resolved.shareAnalytics !== null)
-          store.setShareAnalytics(resolved.shareAnalytics);
-        if (resolved.shareDiagnostics !== null)
-          store.setShareDiagnostics(resolved.shareDiagnostics);
-        persistConsentForUser(nextUserId, resolved.tos, resolved.ai);
-        syncOrganizationState(nextUserId);
-        return;
-      }
-      // Server has no consent record — fall through to device keys.
-      // If device keys show prior acceptance, backfill the server.
-      const deviceConsent = restoreConsentForUser(nextUserId);
+      const consent = await fetchConsent();
+      const resolved = resolveServerConsent(consent);
       const store = useOnboardingStore.getState();
-      store.setTosAccepted(deviceConsent.tos);
-      store.setAiDataConsent(deviceConsent.ai);
-      if (deviceConsent.tos && deviceConsent.ai) {
-        void patchConsent({
-          tos_accepted_version: CONSENT_VERSION,
-          privacy_policy_accepted_version: CONSENT_VERSION,
-          ai_data_sharing_accepted_version: CONSENT_VERSION,
-        }).catch(() => {});
+      store.setTosAccepted(resolved.tos);
+      store.setAiDataConsent(resolved.ai);
+      if (resolved.shareAnalytics !== null)
+        store.setShareAnalytics(resolved.shareAnalytics);
+      if (resolved.shareDiagnostics !== null)
+        store.setShareDiagnostics(resolved.shareDiagnostics);
+      persistConsentForUser(nextUserId, resolved.tos, resolved.ai);
+      // The endpoint always returns an object, so empty/stale versions
+      // (not a null record) are the "never accepted" signal. If device
+      // keys show prior acceptance, restore the flags and backfill the server.
+      if (!resolved.tos && !resolved.ai) {
+        const deviceConsent = restoreConsentForUser(nextUserId);
+        if (deviceConsent.tos && deviceConsent.ai) {
+          store.setTosAccepted(true);
+          store.setAiDataConsent(true);
+          void patchConsent({
+            tos_accepted_version: CONSENT_VERSION,
+            privacy_policy_accepted_version: CONSENT_VERSION,
+            ai_data_sharing_accepted_version: CONSENT_VERSION,
+          }).catch(() => {});
+        }
       }
       syncOrganizationState(nextUserId);
       return;


### PR DESCRIPTION
## Summary
- Add fetchConsent() (GET /v1/user/consent/) and switch patchConsent to PUT /v1/user/consent/ with an un-nested body
- Rework syncUserScopedState to read consent from the dedicated endpoint; the always-returned object means empty versions (not null) signal 'never accepted', with device-key backfill preserved
- Update auth-store tests to stub fetchConsent

Part of plan: consent-toggle-versioning.md (PR 1 of 7)