### PR TITLE
feat(consent): version share toggles in onboarding-cleanup

### DIFF
--- a/clients/web/src/utils/onboarding-cleanup.test.ts
+++ b/clients/web/src/utils/onboarding-cleanup.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Tests for the versioned share-toggle consent layer in `onboarding-cleanup`.
+ *
+ * Collaborators (`onboarding-store`, `auth-store`, `profile.patchConsent`,
+ * `device-settings`) are mocked so we exercise the per-user device-key
+ * read/write logic in isolation against an in-memory `localStorage`.
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import { installMemoryStorage } from "@/utils/memory-storage.test-helper";
+
+installMemoryStorage({ beforeAll, afterAll, beforeEach, afterEach });
+
+const storeState = {
+  setTosAccepted: mock(() => {}),
+  setAiDataConsent: mock(() => {}),
+  setShareAnalytics: mock(() => {}),
+  setShareDiagnostics: mock(() => {}),
+  setAnalyticsConsentCurrent: mock(() => {}),
+  setDiagnosticsConsentCurrent: mock(() => {}),
+};
+mock.module("@/domains/onboarding/onboarding-store", () => ({
+  useOnboardingStore: { getState: () => storeState },
+}));
+
+let authUserId: string | null = "user-1";
+mock.module("@/stores/auth-store", () => ({
+  useAuthStore: { getState: () => ({ user: authUserId ? { id: authUserId } : null }) },
+}));
+
+// `onboarding-cleanup` only needs `patchConsent`; the real `profile` module
+// pulls in the generated API client (unavailable in unit tests), so stub it.
+const patchConsentMock = mock(async () => {});
+mock.module("@/domains/account/profile", () => ({
+  patchConsent: patchConsentMock,
+}));
+mock.module("@/generated/api/client.gen", () => ({ client: {} }));
+
+const setDeviceBoolMock = mock(() => {});
+mock.module("@/utils/device-settings", () => ({
+  setDeviceBool: setDeviceBoolMock,
+}));
+
+import {
+  CONSENT_VERSION,
+  clearConsentForUser,
+  persistToggleConsent,
+  resolveServerConsent,
+  restoreConsentForUser,
+  saveConsent,
+  savePreferenceToggle,
+} from "@/utils/onboarding-cleanup";
+import type { UserConsent } from "@/domains/account/profile";
+
+function makeConsent(overrides: Partial<UserConsent> = {}): UserConsent {
+  return {
+    tos_accepted_version: CONSENT_VERSION,
+    tos_accepted_at: null,
+    privacy_policy_accepted_version: CONSENT_VERSION,
+    privacy_policy_accepted_at: null,
+    ai_data_sharing_accepted_version: CONSENT_VERSION,
+    ai_data_sharing_accepted_at: null,
+    share_analytics: true,
+    share_diagnostics: true,
+    share_analytics_accepted_version: CONSENT_VERSION,
+    share_analytics_accepted_at: null,
+    share_diagnostics_accepted_version: CONSENT_VERSION,
+    share_diagnostics_accepted_at: null,
+    ...overrides,
+  };
+}
+
+const analyticsKey = (userId: string) =>
+  `device:consent:share_analytics:v${CONSENT_VERSION}:${userId}`;
+const diagnosticsKey = (userId: string) =>
+  `device:consent:share_diagnostics:v${CONSENT_VERSION}:${userId}`;
+
+beforeEach(() => {
+  authUserId = "user-1";
+  storeState.setTosAccepted.mockReset();
+  storeState.setAiDataConsent.mockReset();
+  storeState.setShareAnalytics.mockReset();
+  storeState.setShareDiagnostics.mockReset();
+  storeState.setAnalyticsConsentCurrent.mockReset();
+  storeState.setDiagnosticsConsentCurrent.mockReset();
+  patchConsentMock.mockReset();
+  patchConsentMock.mockImplementation(async () => {});
+  setDeviceBoolMock.mockReset();
+});
+
+describe("resolveServerConsent", () => {
+  test("reports current toggles when versions match CONSENT_VERSION", () => {
+    const r = resolveServerConsent(makeConsent());
+    expect(r.analyticsCurrent).toBe(true);
+    expect(r.diagnosticsCurrent).toBe(true);
+  });
+
+  test("reports stale toggles for mismatched versions", () => {
+    const r = resolveServerConsent(
+      makeConsent({
+        share_analytics_accepted_version: "2020-01-01",
+        share_diagnostics_accepted_version: "2020-01-01",
+      }),
+    );
+    expect(r.analyticsCurrent).toBe(false);
+    expect(r.diagnosticsCurrent).toBe(false);
+  });
+
+  test("reports stale toggles for empty versions", () => {
+    const r = resolveServerConsent(
+      makeConsent({
+        share_analytics_accepted_version: "",
+        share_diagnostics_accepted_version: "",
+      }),
+    );
+    expect(r.analyticsCurrent).toBe(false);
+    expect(r.diagnosticsCurrent).toBe(false);
+  });
+
+  test("reports false for null/undefined consent", () => {
+    expect(resolveServerConsent(null).analyticsCurrent).toBe(false);
+    expect(resolveServerConsent(null).diagnosticsCurrent).toBe(false);
+    expect(resolveServerConsent(undefined).analyticsCurrent).toBe(false);
+    expect(resolveServerConsent(undefined).diagnosticsCurrent).toBe(false);
+  });
+
+  test("keeps the existing value/tos/ai fields", () => {
+    const r = resolveServerConsent(makeConsent({ share_analytics: false }));
+    expect(r.tos).toBe(true);
+    expect(r.ai).toBe(true);
+    expect(r.shareAnalytics).toBe(false);
+    expect(r.shareDiagnostics).toBe(true);
+  });
+});
+
+describe("persistToggleConsent + restoreConsentForUser round-trip", () => {
+  test("round-trips both ack keys", () => {
+    persistToggleConsent("user-1", { analyticsCurrent: true, diagnosticsCurrent: true });
+    const r = restoreConsentForUser("user-1");
+    expect(r.analyticsCurrent).toBe(true);
+    expect(r.diagnosticsCurrent).toBe(true);
+  });
+
+  test("only writes the provided field", () => {
+    persistToggleConsent("user-1", { analyticsCurrent: true });
+    expect(localStorage.getItem(analyticsKey("user-1"))).toBe("true");
+    expect(localStorage.getItem(diagnosticsKey("user-1"))).toBeNull();
+    const r = restoreConsentForUser("user-1");
+    expect(r.analyticsCurrent).toBe(true);
+    expect(r.diagnosticsCurrent).toBe(false);
+  });
+
+  test("no-ops without a userId", () => {
+    persistToggleConsent(null, { analyticsCurrent: true });
+    expect(localStorage.getItem(analyticsKey("user-1"))).toBeNull();
+  });
+
+  test("restore returns false for both with no userId", () => {
+    const r = restoreConsentForUser(null);
+    expect(r.analyticsCurrent).toBe(false);
+    expect(r.diagnosticsCurrent).toBe(false);
+  });
+});
+
+describe("saveConsent", () => {
+  test("stamps both toggle versions in the patch body", () => {
+    saveConsent({
+      userId: "user-1",
+      tos: true,
+      ai: true,
+      shareAnalytics: true,
+      shareDiagnostics: false,
+      hasPlatformSession: true,
+    });
+    expect(patchConsentMock).toHaveBeenCalledTimes(1);
+    const body = patchConsentMock.mock.calls[0][0];
+    expect(body.share_analytics_accepted_version).toBe(CONSENT_VERSION);
+    expect(body.share_diagnostics_accepted_version).toBe(CONSENT_VERSION);
+  });
+
+  test("sets both currency flags and writes both ack keys", () => {
+    saveConsent({
+      userId: "user-1",
+      tos: true,
+      ai: true,
+      shareAnalytics: true,
+      shareDiagnostics: true,
+      hasPlatformSession: false,
+    });
+    expect(storeState.setAnalyticsConsentCurrent).toHaveBeenCalledWith(true);
+    expect(storeState.setDiagnosticsConsentCurrent).toHaveBeenCalledWith(true);
+    expect(localStorage.getItem(analyticsKey("user-1"))).toBe("true");
+    expect(localStorage.getItem(diagnosticsKey("user-1"))).toBe("true");
+  });
+});
+
+describe("savePreferenceToggle", () => {
+  test("stamps the analytics version and sets its flag only", () => {
+    savePreferenceToggle("share_analytics", true, true);
+    expect(storeState.setAnalyticsConsentCurrent).toHaveBeenCalledWith(true);
+    expect(storeState.setDiagnosticsConsentCurrent).not.toHaveBeenCalled();
+    expect(localStorage.getItem(analyticsKey("user-1"))).toBe("true");
+    expect(localStorage.getItem(diagnosticsKey("user-1"))).toBeNull();
+    const body = patchConsentMock.mock.calls[0][0];
+    expect(body.share_analytics).toBe(true);
+    expect(body.share_analytics_accepted_version).toBe(CONSENT_VERSION);
+  });
+
+  test("stamps the diagnostics version and sets its flag only", () => {
+    savePreferenceToggle("share_diagnostics", false, true);
+    expect(storeState.setDiagnosticsConsentCurrent).toHaveBeenCalledWith(true);
+    expect(storeState.setAnalyticsConsentCurrent).not.toHaveBeenCalled();
+    const body = patchConsentMock.mock.calls[0][0];
+    expect(body.share_diagnostics).toBe(false);
+    expect(body.share_diagnostics_accepted_version).toBe(CONSENT_VERSION);
+  });
+});
+
+describe("clearConsentForUser", () => {
+  test("clears both toggle ack keys", () => {
+    persistToggleConsent("user-1", { analyticsCurrent: true, diagnosticsCurrent: true });
+    clearConsentForUser("user-1");
+    expect(localStorage.getItem(analyticsKey("user-1"))).toBeNull();
+    expect(localStorage.getItem(diagnosticsKey("user-1"))).toBeNull();
+  });
+});

--- a/clients/web/src/utils/onboarding-cleanup.test.ts
+++ b/clients/web/src/utils/onboarding-cleanup.test.ts
@@ -18,6 +18,7 @@ import {
 } from "bun:test";
 
 import { installMemoryStorage } from "@/utils/memory-storage.test-helper";
+import type { ConsentPatch } from "@/domains/account/profile";
 
 installMemoryStorage({ beforeAll, afterAll, beforeEach, afterEach });
 
@@ -40,7 +41,7 @@ mock.module("@/stores/auth-store", () => ({
 
 // `onboarding-cleanup` only needs `patchConsent`; the real `profile` module
 // pulls in the generated API client (unavailable in unit tests), so stub it.
-const patchConsentMock = mock(async () => {});
+const patchConsentMock = mock(async (_consent: ConsentPatch) => {});
 mock.module("@/domains/account/profile", () => ({
   patchConsent: patchConsentMock,
 }));

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -1,9 +1,13 @@
 /**
  * Versioned, per-user consent persistence.
  *
- * Consent flags live in `device:consent:{tos,ai}:v<VERSION>:<userId>`.
+ * Consent flags live in `device:consent:{tos,ai,share_analytics,share_diagnostics}:v<VERSION>:<userId>`.
  * The `device:` prefix survives logout; the userId makes them per-user;
  * the version lets us force re-consent by bumping CONSENT_VERSION.
+ *
+ * The `share_analytics`/`share_diagnostics` ack keys record the version under
+ * which the toggle was last confirmed (its currency), independent of the
+ * on/off value which lives in the unversioned `device:share_analytics` key.
  *
  * The onboarding Zustand store holds the in-memory state (`tosAccepted`,
  * `aiDataConsent`). This module handles the durable device-key layer
@@ -12,13 +16,15 @@
  * - `resolveServerConsent` — compare server consent versions against CONSENT_VERSION
  * - `saveConsent`          — unified write: store + device keys + server sync
  * - `savePreferenceToggle` — single-field write for settings page toggles
- * - `restoreConsentForUser` — read device keys, return {tos, ai}
- * - `persistConsentForUser` — write device keys
+ * - `restoreConsentForUser` — read device keys, return {tos, ai, toggle acks}
+ * - `persistConsentForUser` — write tos/ai device keys
+ * - `persistToggleConsent`  — write versioned share-toggle ack keys
  * - `clearConsentForUser`   — delete device keys + legacy active keys
  */
 import { removeLocalSetting, getLocalBool, setLocalBool } from "@/utils/local-settings";
 import { setDeviceBool } from "@/utils/device-settings";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
+import { useAuthStore } from "@/stores/auth-store";
 import { patchConsent, type UserConsent } from "@/domains/account/profile";
 
 export const CONSENT_VERSION = "2026-06-08";
@@ -27,12 +33,18 @@ function consentKey(field: string, userId: string): string {
   return `device:consent:${field}:v${CONSENT_VERSION}:${userId}`;
 }
 
-export function restoreConsentForUser(userId: string | null): { tos: boolean; ai: boolean } {
-  if (typeof window === "undefined" || !userId) return { tos: false, ai: false };
+export function restoreConsentForUser(
+  userId: string | null,
+): { tos: boolean; ai: boolean; analyticsCurrent: boolean; diagnosticsCurrent: boolean } {
+  if (typeof window === "undefined" || !userId) {
+    return { tos: false, ai: false, analyticsCurrent: false, diagnosticsCurrent: false };
+  }
   try {
+    const analyticsCurrent = getLocalBool(consentKey("share_analytics", userId), false);
+    const diagnosticsCurrent = getLocalBool(consentKey("share_diagnostics", userId), false);
     const tos = getLocalBool(consentKey("tos", userId), false);
     const ai = getLocalBool(consentKey("ai", userId), false);
-    if (tos || ai) return { tos, ai };
+    if (tos || ai) return { tos, ai, analyticsCurrent, diagnosticsCurrent };
 
     // One-time migration: users who accepted before the per-user device
     // key change still have consent in the legacy vellum: active keys.
@@ -41,12 +53,12 @@ export function restoreConsentForUser(userId: string | null): { tos: boolean; ai
     const legacyAi = getLocalBool("vellum:onboarding:aiDataConsent", false);
     if (legacyTos || legacyAi) {
       persistConsentForUser(userId, legacyTos, legacyAi);
-      return { tos: legacyTos, ai: legacyAi };
+      return { tos: legacyTos, ai: legacyAi, analyticsCurrent, diagnosticsCurrent };
     }
 
-    return { tos: false, ai: false };
+    return { tos: false, ai: false, analyticsCurrent, diagnosticsCurrent };
   } catch {
-    return { tos: false, ai: false };
+    return { tos: false, ai: false, analyticsCurrent: false, diagnosticsCurrent: false };
   }
 }
 
@@ -64,6 +76,23 @@ export function persistConsentForUser(
   }
 }
 
+export function persistToggleConsent(
+  userId: string | null,
+  acks: { analyticsCurrent?: boolean; diagnosticsCurrent?: boolean },
+): void {
+  if (typeof window === "undefined" || !userId) return;
+  try {
+    if (acks.analyticsCurrent !== undefined) {
+      setLocalBool(consentKey("share_analytics", userId), acks.analyticsCurrent);
+    }
+    if (acks.diagnosticsCurrent !== undefined) {
+      setLocalBool(consentKey("share_diagnostics", userId), acks.diagnosticsCurrent);
+    }
+  } catch {
+    // Storage unavailable.
+  }
+}
+
 export function clearConsentForUser(userId: string | null): void {
   removeLocalSetting("vellum:onboarding:tosAccepted");
   removeLocalSetting("vellum:onboarding:aiDataConsent");
@@ -72,6 +101,8 @@ export function clearConsentForUser(userId: string | null): void {
   try {
     removeLocalSetting(consentKey("tos", userId));
     removeLocalSetting(consentKey("ai", userId));
+    removeLocalSetting(consentKey("share_analytics", userId));
+    removeLocalSetting(consentKey("share_diagnostics", userId));
   } catch {
     // Storage unavailable.
   }
@@ -83,14 +114,32 @@ export function clearConsentForUser(userId: string | null): void {
 
 export function resolveServerConsent(
   consent: UserConsent | null | undefined,
-): { tos: boolean; ai: boolean; shareAnalytics: boolean | null; shareDiagnostics: boolean | null } {
-  if (!consent) return { tos: false, ai: false, shareAnalytics: null, shareDiagnostics: null };
+): {
+  tos: boolean;
+  ai: boolean;
+  shareAnalytics: boolean | null;
+  shareDiagnostics: boolean | null;
+  analyticsCurrent: boolean;
+  diagnosticsCurrent: boolean;
+} {
+  if (!consent) {
+    return {
+      tos: false,
+      ai: false,
+      shareAnalytics: null,
+      shareDiagnostics: null,
+      analyticsCurrent: false,
+      diagnosticsCurrent: false,
+    };
+  }
   return {
     tos: consent.tos_accepted_version === CONSENT_VERSION
       && consent.privacy_policy_accepted_version === CONSENT_VERSION,
     ai: consent.ai_data_sharing_accepted_version === CONSENT_VERSION,
     shareAnalytics: consent.share_analytics,
     shareDiagnostics: consent.share_diagnostics,
+    analyticsCurrent: consent.share_analytics_accepted_version === CONSENT_VERSION,
+    diagnosticsCurrent: consent.share_diagnostics_accepted_version === CONSENT_VERSION,
   };
 }
 
@@ -111,8 +160,11 @@ export function saveConsent(opts: {
   store.setAiDataConsent(opts.ai);
   store.setShareAnalytics(opts.shareAnalytics);
   store.setShareDiagnostics(opts.shareDiagnostics);
+  store.setAnalyticsConsentCurrent(true);
+  store.setDiagnosticsConsentCurrent(true);
 
   persistConsentForUser(opts.userId, opts.tos, opts.ai);
+  persistToggleConsent(opts.userId, { analyticsCurrent: true, diagnosticsCurrent: true });
 
   if (opts.hasPlatformSession) {
     void patchConsent({
@@ -121,6 +173,8 @@ export function saveConsent(opts: {
       ai_data_sharing_accepted_version: opts.ai ? CONSENT_VERSION : "",
       share_analytics: opts.shareAnalytics,
       share_diagnostics: opts.shareDiagnostics,
+      share_analytics_accepted_version: CONSENT_VERSION,
+      share_diagnostics_accepted_version: CONSENT_VERSION,
     }).catch(() => {});
   }
 }
@@ -131,15 +185,23 @@ export function savePreferenceToggle(
   hasPlatformSession: boolean,
 ): void {
   const store = useOnboardingStore.getState();
+  const userId = useAuthStore.getState().user?.id ?? null;
   if (field === "share_analytics") {
     store.setShareAnalytics(value);
     setDeviceBool("shareAnalytics", value);
+    store.setAnalyticsConsentCurrent(true);
+    persistToggleConsent(userId, { analyticsCurrent: true });
   } else {
     store.setShareDiagnostics(value);
     setDeviceBool("shareDiagnostics", value);
+    store.setDiagnosticsConsentCurrent(true);
+    persistToggleConsent(userId, { diagnosticsCurrent: true });
   }
 
   if (hasPlatformSession) {
-    void patchConsent({ [field]: value }).catch(() => {});
+    void patchConsent({
+      [field]: value,
+      [`${field}_accepted_version`]: CONSENT_VERSION,
+    }).catch(() => {});
   }
 }


### PR DESCRIPTION
## Summary
- resolveServerConsent now reports per-toggle currency vs CONSENT_VERSION
- saveConsent/savePreferenceToggle stamp toggle versions, write versioned ack keys, and set store currency flags
- restoreConsentForUser/clearConsentForUser read/clear the toggle ack keys

Part of plan: consent-toggle-versioning.md (PR 4 of 7)