### PR TITLE
fix: add abort watchdog to prevent wedged agent loop

### DIFF
--- a/assistant/src/__tests__/cancel-clears-processing.test.ts
+++ b/assistant/src/__tests__/cancel-clears-processing.test.ts
@@ -1,10 +1,14 @@
 /**
- * Regression test for the stuck "Thinking…" bug: a user cancel must drive the
- * conversation's processing flag to false even when the in-flight turn never
- * observes the AbortController signal (a wedged agent loop that never reaches
- * its `finally`). The processing flag is the authoritative source for the
- * client thinking indicator, so a latched-true flag pins every client on
- * "Thinking…" indefinitely.
+ * Cancel contract: a user cancel raises the conversation's AbortController and
+ * defers clearing the `processing` flag to the in-flight turn's `finally`.
+ *
+ * `cancelGeneration` no longer force-clears `processing` itself. Abort now
+ * propagates into the provider call and tool execution — and is backed by the
+ * agent loop's abort watchdog — so a cancelled turn always reaches its
+ * `finally` within a bounded time and tears down its own state there. The
+ * watchdog-driven path (turn reaches `finally`, processing clears) is covered
+ * by `conversation-agent-loop.test.ts`; this file pins the handler-side
+ * contract: cancel signals abort and leaves the flag to the turn.
  */
 import { afterEach, describe, expect, test } from "bun:test";
 
@@ -15,18 +19,18 @@ import {
 } from "../daemon/conversation-registry.js";
 import { cancelGeneration } from "../daemon/handlers/conversations.js";
 
-interface WedgedTurnConversation {
+interface CancelledConversation {
   isProcessing: () => boolean;
   setProcessingCalls: () => boolean[];
   abortCount: () => number;
 }
 
 /**
- * Register a conversation whose in-flight turn is wedged: it accepts the abort
- * signal but never unwinds, so it leaves the processing flag untouched. This
- * is the exact condition that latches `processing` true in production.
+ * Register a conversation whose in-flight turn is processing. The fake records
+ * abort calls and any `setProcessing` writes so the test can assert that
+ * `cancelGeneration` signals abort without flipping the flag itself.
  */
-function registerWedgedTurn(id: string): WedgedTurnConversation {
+function registerProcessingTurn(id: string): CancelledConversation {
   let processing = true;
   let abortCount = 0;
   const setProcessingCalls: boolean[] = [];
@@ -55,10 +59,9 @@ describe("cancelGeneration", () => {
     deleteConversation(conversationId);
   });
 
-  test("clears the processing flag when the in-flight turn ignores the abort signal", () => {
+  test("raises abort and defers clearing processing to the turn's finally", () => {
     // GIVEN a registered conversation that is processing
-    // AND whose in-flight turn ignores the abort signal (never clears processing)
-    const fake = registerWedgedTurn(conversationId);
+    const fake = registerProcessingTurn(conversationId);
     expect(fake.isProcessing()).toBe(true);
 
     // WHEN the user cancels generation
@@ -66,12 +69,12 @@ describe("cancelGeneration", () => {
 
     // THEN the cancel is acknowledged
     expect(cancelled).toBe(true);
-    // AND the abort signal is still raised on the conversation
+    // AND the abort signal is raised on the conversation
     expect(fake.abortCount()).toBe(1);
-    // AND the processing flag is cleared through setProcessing(false), which
-    // publishes the metadata sync invalidation that unblocks every client
-    expect(fake.setProcessingCalls()).toContain(false);
-    expect(fake.isProcessing()).toBe(false);
+    // AND cancelGeneration does NOT force-clear the flag itself — the in-flight
+    // turn's `finally` owns that teardown once abort drives it there.
+    expect(fake.setProcessingCalls()).not.toContain(false);
+    expect(fake.isProcessing()).toBe(true);
   });
 
   test("returns false for a conversation that is not registered", () => {

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -1749,55 +1749,62 @@ describe("session-agent-loop", () => {
       expect(drainReason).toBe("loop_complete");
     });
 
-    test("leaves a newer turn's state intact when superseded during unwind", async () => {
-      // GIVEN a fresh AbortController and request id that a newer turn installs
-      // (as persistUserMessage would once a user cancel released `processing`)
-      const newerTurnController = new AbortController();
-      let drained = false;
-
-      // AND a provider that, on this turn's single model call, simulates that
-      // newer turn taking ownership of the conversation before this turn
-      // reaches its finally
-      const ctxHolder: { conversation?: Conversation } = {};
+    test("abort watchdog drives a wedged turn to its finally", async () => {
+      // GIVEN a provider whose call wedges: it acknowledges the user cancel
+      // (aborts the signal) but its promise never settles and never observes
+      // the signal — the exact condition that latched `processing` true.
+      const events: ServerMessage[] = [];
+      const abortController = new AbortController();
+      let drainReason: string | undefined;
+      // The provider's call wedges on this promise. It settles only on test
+      // teardown so the abandoned `run()` can unwind cleanly instead of leaking
+      // background work (e.g. partial-persist debounce timers) into later tests.
+      let releaseHang: (reason: unknown) => void = () => {};
+      const hang = new Promise<never>((_, reject) => {
+        releaseHang = reject;
+      });
       const provider: Provider = {
         name: "mock-provider",
-        async sendMessage(_messages, options) {
-          const conversation = ctxHolder.conversation;
-          if (conversation) {
-            conversation.abortController = newerTurnController;
-            conversation.setProcessing(true);
-            conversation.currentRequestId = "newer-turn-req";
-          }
-          options?.onEvent?.({ type: "text_delta", text: "done" });
-          return {
-            content: [{ type: "text", text: "done" }],
-            model: "mock-model",
-            usage: { inputTokens: 0, outputTokens: 0 },
-            stopReason: "end_turn",
-          };
+        sendMessage(_messages, _options) {
+          abortController.abort();
+          // Never observes the signal — the exact condition that latched
+          // `processing` true before the watchdog existed.
+          return hang;
         },
       };
       const ctx = makeCtx({
         loopProvider: provider,
-        drainQueue: async () => {
-          drained = true;
+        abortController,
+        // Fire the watchdog quickly instead of the ~45s production default.
+        abortWatchdogMs: 30,
+        drainQueue: (reason: string) => {
+          drainReason = reason;
         },
-      });
-      ctxHolder.conversation = ctx;
+      } as unknown as Partial<Conversation>);
 
-      // WHEN the superseded turn runs to completion
-      await runAgentLoopImpl(ctx, "hi", "msg-1", () => {});
+      try {
+        // WHEN the orchestrator runs the turn
+        await runAgentLoopImpl(ctx, "hi", "msg-1", (msg) => events.push(msg));
 
-      // THEN the finally leaves the newer turn's per-turn state intact so it
-      // stays cancellable and visible
-      expect(ctx.abortController).toBe(newerTurnController);
-      expect(ctx.isProcessing()).toBe(true);
-      expect(ctx.currentRequestId).toBe("newer-turn-req");
-      // AND it does not drain the newer turn's queue out from under it
-      expect(drained).toBe(false);
-      // AND this turn's own finalization that does not touch shared state still
-      // runs (the turn is still counted)
-      expect(ctx.turnCount).toBe(1);
+        // THEN the watchdog forces the turn to its finally: processing clears,
+        // the abort controller is torn down, the queue drains, and the user
+        // sees a cancellation (not an error).
+        expect(ctx.isProcessing()).toBe(false);
+        expect(ctx.abortController).toBeNull();
+        expect(drainReason).toBe("loop_complete");
+        expect(
+          events.find((e) => e.type === "generation_cancelled"),
+        ).toBeDefined();
+        expect(
+          events.find((e) => e.type === "conversation_error"),
+        ).toBeUndefined();
+      } finally {
+        // Let the abandoned run() reject and unwind, then flush microtasks.
+        releaseHang(
+          new DOMException("The operation was aborted", "AbortError"),
+        );
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
     });
   });
 

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -187,6 +187,67 @@ export interface AssistantSurface {
   activationMoment?: ActivationMomentParam;
 }
 
+// ── abort watchdog ───────────────────────────────────────────────────
+
+/**
+ * Generous backstop that drives an aborted turn to its `finally` even if some
+ * awaited operation fails to observe the abort signal.
+ *
+ * Abort is otherwise cooperative and already wired into the slow paths: the
+ * provider call forwards the signal to its HTTP/streaming fetch, and tool
+ * execution races the signal so a stuck tool can't block cancellation. This
+ * watchdog only fires when a future code path silently ignores abort — without
+ * it, such a path would hang the loop forever and latch the conversation's
+ * `processing` flag true (the wedged "Thinking…" indicator). It is
+ * defense-in-depth, not the primary mechanism, so the timeout is deliberately
+ * generous; in the common case abort settles in-flight work well before it.
+ */
+const ABORT_WATCHDOG_MS = 45_000;
+
+/**
+ * Race `work` against an abort watchdog. The watchdog stays disarmed until the
+ * signal fires; once it does, the turn has `timeoutMs` to settle before the
+ * watchdog rejects with the signal's own abort reason so the caller unwinds to
+ * its `finally` and the reason classifies as a user cancellation downstream.
+ * The abandoned `work` promise keeps running detached — its eventual rejection
+ * is swallowed so it can't surface as an unhandled rejection.
+ */
+async function withAbortWatchdog<T>(
+  work: Promise<T>,
+  signal: AbortSignal,
+  timeoutMs: number,
+  onFire: () => void,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let onAbort: (() => void) | undefined;
+  const watchdog = new Promise<never>((_, reject) => {
+    const arm = () => {
+      timer = setTimeout(() => {
+        onFire();
+        // Propagate the signal's own reason (an `AbortReason` for daemon-owned
+        // cancels) so the loop's catch classifies this as a user cancellation;
+        // fall back to a tagged AbortError when the signal carries no reason.
+        reject(
+          signal.reason ??
+            new DOMException("The operation was aborted", "AbortError"),
+        );
+      }, timeoutMs);
+    };
+    if (signal.aborted) arm();
+    else {
+      onAbort = arm;
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+  });
+  try {
+    return await Promise.race([work, watchdog]);
+  } finally {
+    if (timer) clearTimeout(timer);
+    if (onAbort) signal.removeEventListener("abort", onAbort);
+    void work.catch(() => {});
+  }
+}
+
 // ── runAgentLoop ─────────────────────────────────────────────────────
 
 export async function runAgentLoopImpl(
@@ -902,22 +963,36 @@ export async function runAgentLoopImpl(
       msgs: Message[],
       compactInPlace = false,
     ): Promise<Message[]> => {
-      const { history, exitReason, newMessages } = await ctx.agentLoop.run({
-        messages: msgs,
-        onEvent: eventHandler,
-        signal: abortController.signal,
-        requestId: reqId,
-        onCheckpoint,
-        callSite: turnCallSite,
-        trust: loopTrust,
-        overrideProfile: turnOverrideProfile,
-        ...(forceOverrideProfile ? { forceOverrideProfile: true } : {}),
-        resolveOverrideProfile: resolveCurrentOverrideProfile,
-        resolveContextWindow,
-        compactInPlace,
-        isNonInteractive,
-        modelProfileKey,
-      });
+      const watchdogMs = ctx.abortWatchdogMs ?? ABORT_WATCHDOG_MS;
+      const { history, exitReason, newMessages } = await withAbortWatchdog(
+        ctx.agentLoop.run({
+          messages: msgs,
+          onEvent: eventHandler,
+          signal: abortController.signal,
+          requestId: reqId,
+          onCheckpoint,
+          callSite: turnCallSite,
+          trust: loopTrust,
+          overrideProfile: turnOverrideProfile,
+          ...(forceOverrideProfile ? { forceOverrideProfile: true } : {}),
+          resolveOverrideProfile: resolveCurrentOverrideProfile,
+          resolveContextWindow,
+          compactInPlace,
+          isNonInteractive,
+          modelProfileKey,
+        }),
+        abortController.signal,
+        watchdogMs,
+        () =>
+          rlog.error(
+            {
+              conversationId: ctx.conversationId,
+              requestId: reqId,
+              timeoutMs: watchdogMs,
+            },
+            "Abort watchdog fired — agent loop did not settle after cancel; forcing turn to finally",
+          ),
+      );
       lastRunNewMessages = newMessages;
       if (exitReason === "handoff") {
         yieldedForHandoff = true;
@@ -1450,46 +1525,37 @@ export async function runAgentLoopImpl(
 
     ctx.profiler.emitSummary(ctx.traceEmitter, reqId);
 
-    // A user cancel clears `processing` immediately so the UI unblocks even
-    // when this turn is slow to unwind, which lets a new turn start and install
-    // its own AbortController, processing flag, request id, and queued work
-    // before this turn reaches here. The shared per-turn state below belongs to
-    // whichever turn currently owns the conversation, so tear it down only while
-    // this turn is still the owner. Each turn captures its AbortController at
-    // start, so a newer turn having replaced `ctx.abortController` means it has
-    // taken ownership; in that case leave the state intact so the new turn stays
-    // cancellable and visible.
-    const supersededByNewerTurn =
-      ctx.abortController !== null && ctx.abortController !== abortController;
-    if (!supersededByNewerTurn) {
-      ctx.abortController = null;
-      ctx.setProcessing(false);
-      ctx.onConfirmationOutcome = undefined;
-      ctx.surfaceActionRequestIds.delete(ctx.currentRequestId ?? "");
-      ctx.approvedViaPromptThisTurn = false;
-      ctx.currentRequestId = undefined;
-      ctx.currentActiveSurfaceId = undefined;
-      ctx.allowedToolNames = undefined;
-      ctx.diskPressureCleanupModeActive = false;
-      ctx.preactivatedSkillIds = undefined;
-      ctx.currentTurnOverrideProfile = undefined;
-      // Channel command intents (e.g. Telegram /start) are single-turn metadata.
-      // Clear at turn end so they never leak into subsequent unrelated messages.
-      ctx.commandIntent = undefined;
-      // taskRunId scopes ephemeral task-run permissions to a single turn. Clear
-      // before drainQueue so queued/drained turns on a reused conversation can't
-      // inherit stale in-task-run scope from the turn that just finished.
-      ctx.taskRunId = undefined;
+    // Tear down this turn's per-turn state. Abort reliably drives the loop to
+    // this `finally` within a bounded time — cooperative signal propagation
+    // (provider fetch + tool race) backed by the abort watchdog — so a
+    // cancelled turn always unwinds before any resend can start a new one.
+    // There is therefore only ever one turn alive, and clearing the shared
+    // state below cannot clobber a concurrent turn.
+    ctx.abortController = null;
+    ctx.setProcessing(false);
+    ctx.onConfirmationOutcome = undefined;
+    ctx.surfaceActionRequestIds.delete(ctx.currentRequestId ?? "");
+    ctx.approvedViaPromptThisTurn = false;
+    ctx.currentRequestId = undefined;
+    ctx.currentActiveSurfaceId = undefined;
+    ctx.allowedToolNames = undefined;
+    ctx.diskPressureCleanupModeActive = false;
+    ctx.preactivatedSkillIds = undefined;
+    ctx.currentTurnOverrideProfile = undefined;
+    // Channel command intents (e.g. Telegram /start) are single-turn metadata.
+    // Clear at turn end so they never leak into subsequent unrelated messages.
+    ctx.commandIntent = undefined;
+    // taskRunId scopes ephemeral task-run permissions to a single turn. Clear
+    // before drainQueue so queued/drained turns on a reused conversation can't
+    // inherit stale in-task-run scope from the turn that just finished.
+    ctx.taskRunId = undefined;
 
-      // Consolidation deferred to compaction: keeping assistant + tool_result
-      // messages unconsolidated preserves the exact message structure sent to
-      // the API, enabling stable prefix caching across turns.  Compaction
-      // consolidates when it summarizes old messages (cache miss is expected).
+    // Consolidation deferred to compaction: keeping assistant + tool_result
+    // messages unconsolidated preserves the exact message structure sent to
+    // the API, enabling stable prefix caching across turns.  Compaction
+    // consolidates when it summarizes old messages (cache miss is expected).
 
-      ctx.drainQueue(
-        yieldedForHandoff ? "checkpoint_handoff" : "loop_complete",
-      );
-    }
+    ctx.drainQueue(yieldedForHandoff ? "checkpoint_handoff" : "loop_complete");
 
     // Clear conversation tags so they don't leak into unrelated error captures
     // (e.g. unhandledRejection from a different async chain).

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -367,6 +367,13 @@ export class Conversation {
   ) => Pick<WorkspaceGitService, "ensureInitialized">;
   /** @internal */ commitTurnChanges?: typeof commitTurnChanges;
   /**
+   * Abort-watchdog timeout (ms) for the agent loop's bounded-unwind backstop.
+   * Overridable in tests to fire the watchdog quickly; defaults to the
+   * production constant in the agent loop when unset.
+   * @internal
+   */
+  abortWatchdogMs?: number;
+  /**
    * The conversation's immutable creation type (`interactive`, `background`,
    * `scheduled`, …) as stored on the DB row. Cached on load (and set directly
    * for subagent conversations) so the runtime-assembly path can derive the

--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -106,14 +106,12 @@ export function cancelGeneration(conversationId: string): boolean {
   // being cancelled, so enqueuing synthetic messages would trigger
   // unwanted model activity after the user pressed stop.
   getSubagentManager().abortAllForParent(conversationId);
-  // Clear the processing flag so every client stops rendering the thinking
-  // indicator. abort() only signals the AbortController, so a turn that never
-  // observes the signal leaves `processing` latched true; clearing it here
-  // publishes the metadata sync invalidation that drives clients to the
-  // authoritative state. A turn that does eventually unwind tears down only the
-  // shared turn state it still owns, so this early clear neither double-fires
-  // the invalidation nor clobbers a turn started after the cancel.
-  conversation.setProcessing(false);
+  // The processing flag is cleared by the in-flight turn's `finally`, not here.
+  // Abort propagates into the provider call and tool execution (and is backed
+  // by the agent loop's abort watchdog), so the turn reaches its `finally`
+  // within a bounded time and tears down its own state there — which publishes
+  // the metadata sync invalidation that drives clients to the authoritative
+  // idle state.
   return true;
 }
 


### PR DESCRIPTION
## Prompt / plan
Implement a bounded-unwind backstop for the agent loop to prevent the "stuck Thinking…" bug where a cancelled turn fails to observe the abort signal and leaves the `processing` flag latched true indefinitely.

## Summary
This PR adds an abort watchdog mechanism to the agent loop that forces a cancelled turn to its `finally` block within a bounded time (45 seconds in production, configurable in tests). The watchdog is a defense-in-depth layer that backs up the primary abort propagation paths (provider fetch + tool execution race).

### Key changes:

1. **New `withAbortWatchdog` utility** (`conversation-agent-loop.ts`):
   - Races the agent loop's work against a timeout that fires once the abort signal is raised
   - Rejects with the signal's own abort reason (or a tagged AbortError) to classify the cancellation downstream
   - Cleans up timers and event listeners in a `finally` block
   - Swallows the abandoned work promise's rejection to prevent unhandled rejections

2. **Simplified turn teardown logic** (`conversation-agent-loop.ts`):
   - Removed the `supersededByNewerTurn` check that conditionally cleared per-turn state
   - With the watchdog guaranteeing bounded unwind, there is only ever one turn alive at a time
   - All turns now unconditionally tear down their state in the `finally` block

3. **Updated cancel contract** (`conversations.ts`):
   - `cancelGeneration` no longer force-clears the `processing` flag itself
   - The in-flight turn's `finally` block owns that teardown once abort drives it there
   - This prevents double-firing metadata sync invalidations and simplifies the state machine

4. **Test updates**:
   - Replaced the "superseded turn" test with a new test that verifies the watchdog drives a wedged turn to its `finally`
   - Updated `cancel-clears-processing.test.ts` to reflect the new contract: cancel signals abort and defers flag clearing to the turn

### Why this matters:
Before this change, if a provider's call acknowledged the abort signal but never settled (or never observed the signal), the turn would hang indefinitely and leave `processing` true, pinning every client on "Thinking…". The watchdog ensures that even in this pathological case, the turn unwinds within 45 seconds and clears the flag.

## Test plan
- Added unit test in `conversation-agent-loop.test.ts` that verifies the watchdog fires and drives a wedged turn to its `finally`
- Updated test in `cancel-clears-processing.test.ts` to verify the new cancel contract
- Existing agent loop tests continue to pass with the watchdog in place (it remains disarmed in the common case where abort settles quickly)

https://claude.ai/code/session_011VUPduNXezi72nA5BWS4ok