### PR TITLE
feat(platform): add getOwnerConsent to VellumPlatformClient

### DIFF
--- a/assistant/src/platform/client.test.ts
+++ b/assistant/src/platform/client.test.ts
@@ -178,4 +178,100 @@ describe("VellumPlatformClient", () => {
       });
     });
   });
+
+  describe("getOwnerConsent()", () => {
+    test("maps snake_case body to camelCase on 200", async () => {
+      globalThis.fetch = mock(async (url: string | URL | Request) => {
+        expect(String(url)).toBe(
+          "https://platform.example.com/v1/assistants/asst-123/owner-consent/",
+        );
+        return new Response(
+          JSON.stringify({ share_analytics: true, share_diagnostics: false }),
+          { status: 200 },
+        );
+      }) as unknown as typeof globalThis.fetch;
+
+      const client = await VellumPlatformClient.create();
+      const consent = await client!.getOwnerConsent();
+      expect(consent).toEqual({
+        shareAnalytics: true,
+        shareDiagnostics: false,
+      });
+    });
+
+    test("uses the authenticated Api-Key header", async () => {
+      globalThis.fetch = mock(
+        async (_url: string | URL | Request, init?: RequestInit) => {
+          const headers = new Headers(init?.headers);
+          expect(headers.get("Authorization")).toBe("Api-Key sk-test-key");
+          return new Response(
+            JSON.stringify({ share_analytics: true, share_diagnostics: true }),
+            { status: 200 },
+          );
+        },
+      ) as unknown as typeof globalThis.fetch;
+
+      const client = await VellumPlatformClient.create();
+      await client!.getOwnerConsent();
+    });
+
+    test("returns null on 404", async () => {
+      globalThis.fetch = mock(
+        async () => new Response("not found", { status: 404 }),
+      ) as unknown as typeof globalThis.fetch;
+
+      const client = await VellumPlatformClient.create();
+      expect(await client!.getOwnerConsent()).toBeNull();
+    });
+
+    test("returns null on 500", async () => {
+      globalThis.fetch = mock(
+        async () => new Response("error", { status: 500 }),
+      ) as unknown as typeof globalThis.fetch;
+
+      const client = await VellumPlatformClient.create();
+      expect(await client!.getOwnerConsent()).toBeNull();
+    });
+
+    test("returns null on network error", async () => {
+      globalThis.fetch = mock(async () => {
+        throw new Error("network down");
+      }) as unknown as typeof globalThis.fetch;
+
+      const client = await VellumPlatformClient.create();
+      expect(await client!.getOwnerConsent()).toBeNull();
+    });
+
+    test("returns null on malformed body (non-boolean fields)", async () => {
+      globalThis.fetch = mock(
+        async () =>
+          new Response(
+            JSON.stringify({ share_analytics: "yes", share_diagnostics: 1 }),
+            { status: 200 },
+          ),
+      ) as unknown as typeof globalThis.fetch;
+
+      const client = await VellumPlatformClient.create();
+      expect(await client!.getOwnerConsent()).toBeNull();
+    });
+
+    test("returns null without fetching when assistantId is empty", async () => {
+      mockAssistantId = "";
+      mockSecureKeys = {};
+
+      const fetchSpy = mock(
+        async () =>
+          new Response(
+            JSON.stringify({ share_analytics: true, share_diagnostics: true }),
+            { status: 200 },
+          ),
+      );
+      globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+      const client = await VellumPlatformClient.create();
+      expect(client!.platformAssistantId).toBe("");
+      expect(await client!.getOwnerConsent()).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/assistant/src/platform/client.ts
+++ b/assistant/src/platform/client.ts
@@ -16,6 +16,11 @@ const log = getLogger("platform-client");
 
 let _missingPrereqsWarned = false;
 
+export interface OwnerConsent {
+  shareAnalytics: boolean;
+  shareDiagnostics: boolean;
+}
+
 export class VellumPlatformClient {
   private readonly platformBaseUrl: string;
   private readonly apiKey: string;
@@ -107,6 +112,53 @@ export class VellumPlatformClient {
     headers.set("Authorization", `Api-Key ${this.apiKey}`);
 
     return fetch(url, { ...init, headers });
+  }
+
+  /**
+   * Fetch the platform owner's telemetry consent for this assistant.
+   *
+   * Returns `null` whenever the consent is unknown — missing assistant id,
+   * any non-2xx response (e.g. 404 before the endpoint is deployed), a
+   * malformed body, or a network error. Callers treat `null` as default-off.
+   * Never throws.
+   */
+  async getOwnerConsent(): Promise<OwnerConsent | null> {
+    if (!this.assistantId) {
+      return null;
+    }
+
+    try {
+      const res = await this.fetch(
+        `/v1/assistants/${this.assistantId}/owner-consent/`,
+      );
+      if (!res.ok) {
+        log.debug(
+          { status: res.status },
+          "owner-consent fetch returned non-2xx — treating as unknown",
+        );
+        return null;
+      }
+
+      const body = (await res.json()) as {
+        share_analytics?: unknown;
+        share_diagnostics?: unknown;
+      };
+      if (
+        typeof body.share_analytics !== "boolean" ||
+        typeof body.share_diagnostics !== "boolean"
+      ) {
+        log.debug("owner-consent body malformed — treating as unknown");
+        return null;
+      }
+
+      return {
+        shareAnalytics: body.share_analytics,
+        shareDiagnostics: body.share_diagnostics,
+      };
+    } catch (err) {
+      log.debug({ err }, "owner-consent fetch failed — treating as unknown");
+      return null;
+    }
   }
 
   get baseUrl(): string {


### PR DESCRIPTION
## Summary
- Add `getOwnerConsent()` to `VellumPlatformClient` that GETs `/v1/assistants/<id>/owner-consent/` and maps `{share_analytics, share_diagnostics}` to camelCase
- Returns null on any error / missing assistant id / malformed body (default-off), never throws

Part of plan: telemetry-consent-gating.md (PR 1 of 6)