### PR TITLE
feat(consent): redirect to review-terms when a toggle version is stale

### DIFF
--- a/clients/web/src/domains/onboarding/prefs.ts
+++ b/clients/web/src/domains/onboarding/prefs.ts
@@ -87,6 +87,32 @@ export function useAiDataConsent(): [boolean, (next: boolean) => void] {
   return [value, setter];
 }
 
+/**
+ * Whether the analytics consent the user accepted is for the current toggle
+ * version. Set on session sync by the auth store. A stale value means the user
+ * must re-review the terms.
+ */
+export function useAnalyticsConsentCurrent(): [boolean, (next: boolean) => void] {
+  const value = useOnboardingStore.use.analyticsConsentCurrent();
+  const setter = useCallback((next: boolean) => {
+    useOnboardingStore.getState().setAnalyticsConsentCurrent(next);
+  }, []);
+  return [value, setter];
+}
+
+/**
+ * Whether the diagnostics consent the user accepted is for the current toggle
+ * version. Set on session sync by the auth store. A stale value means the user
+ * must re-review the terms.
+ */
+export function useDiagnosticsConsentCurrent(): [boolean, (next: boolean) => void] {
+  const value = useOnboardingStore.use.diagnosticsConsentCurrent();
+  const setter = useCallback((next: boolean) => {
+    useOnboardingStore.getState().setDiagnosticsConsentCurrent(next);
+  }, []);
+  return [value, setter];
+}
+
 // ---------------------------------------------------------------------------
 // Non-hook readers (for gates/guards outside React render)
 // ---------------------------------------------------------------------------
@@ -110,6 +136,24 @@ export function readTosAccepted(): boolean {
  */
 export function readAiDataConsent(): boolean {
   return useOnboardingStore.getState().aiDataConsent;
+}
+
+/**
+ * SSR-safe, non-hook read of whether analytics consent is for the current
+ * toggle version. Used by the navigation guard to redirect platform users
+ * back to review-terms when their consent has gone stale.
+ */
+export function readAnalyticsConsentCurrent(): boolean {
+  return useOnboardingStore.getState().analyticsConsentCurrent;
+}
+
+/**
+ * SSR-safe, non-hook read of whether diagnostics consent is for the current
+ * toggle version. Used alongside `readAnalyticsConsentCurrent()` by the
+ * navigation guard.
+ */
+export function readDiagnosticsConsentCurrent(): boolean {
+  return useOnboardingStore.getState().diagnosticsConsentCurrent;
 }
 
 /**

--- a/clients/web/src/lib/navigation/build-state.ts
+++ b/clients/web/src/lib/navigation/build-state.ts
@@ -5,6 +5,8 @@ import { isLocalMode } from "@/lib/local-mode";
 import {
   readTosAccepted,
   readAiDataConsent,
+  readAnalyticsConsentCurrent,
+  readDiagnosticsConsentCurrent,
 } from "@/domains/onboarding/prefs";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import type { NavigationState } from "./navigation-resolver";
@@ -22,6 +24,8 @@ export function buildNavigationState(
     platformSession,
     tosAccepted: readTosAccepted(),
     aiDataConsent: readAiDataConsent(),
+    analyticsConsentCurrent: readAnalyticsConsentCurrent(),
+    diagnosticsConsentCurrent: readDiagnosticsConsentCurrent(),
     ...overrides,
   };
 }

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -16,6 +16,8 @@ const base: NavigationState = {
   platformSession: "present",
   tosAccepted: true,
   aiDataConsent: true,
+  analyticsConsentCurrent: true,
+  diagnosticsConsentCurrent: true,
 };
 
 function s(overrides: Partial<NavigationState>): NavigationState {
@@ -266,6 +268,47 @@ describe("resolveNavigation", () => {
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
     });
 
+    // -- stale consent toggles --------------------------------------------
+
+    test("redirects platform user with current tos/ai but stale analytics toggle to review-terms", () => {
+      expect(
+        guard(s({ isLocalMode: false, analyticsConsentCurrent: false })),
+      ).toEqual({ action: "redirect", to: "/assistant/review-terms?returnTo=%2Fassistant" });
+    });
+
+    test("redirects platform user with stale diagnostics toggle to review-terms", () => {
+      expect(
+        guard(s({ isLocalMode: false, diagnosticsConsentCurrent: false })),
+      ).toEqual({ action: "redirect", to: "/assistant/review-terms?returnTo=%2Fassistant" });
+    });
+
+    test("allows platform user when all four consent flags are current", () => {
+      expect(
+        guard(
+          s({
+            isLocalMode: false,
+            tosAccepted: true,
+            aiDataConsent: true,
+            analyticsConsentCurrent: true,
+            diagnosticsConsentCurrent: true,
+          }),
+        ),
+      ).toEqual(ALLOW);
+    });
+
+    test("does not redirect local-mode user with stale toggles", () => {
+      expect(
+        guard(
+          s({
+            isLocalMode: true,
+            hasAssistants: true,
+            analyticsConsentCurrent: false,
+            diagnosticsConsentCurrent: false,
+          }),
+        ),
+      ).toEqual(ALLOW);
+    });
+
     test("does not redirect local-mode user without consent (handled by step 5)", () => {
       expect(
         guard(s({ isLocalMode: true, hasAssistants: true, tosAccepted: false, aiDataConsent: false })),
@@ -315,6 +358,15 @@ describe("resolveNavigation", () => {
 
     test("allows when tos and consent accepted", () => {
       expect(intercept(s({ tosAccepted: true, aiDataConsent: true }), "/assistant")).toEqual(ALLOW);
+    });
+
+    test("stale toggles do not change onboarding-intercept (hasCompletedOnboarding only)", () => {
+      expect(
+        intercept(
+          s({ analyticsConsentCurrent: false, diagnosticsConsentCurrent: false }),
+          "/assistant",
+        ),
+      ).toEqual(ALLOW);
     });
 
     test("allows destination outside /assistant", () => {
@@ -406,6 +458,12 @@ describe("resolveNavigation", () => {
 
     test("allows with full consent", () => {
       expect(hatch(s({ tosAccepted: true, aiDataConsent: true }))).toEqual(ALLOW);
+    });
+
+    test("stale toggles do not change hatch-gate (hasCompletedOnboarding only)", () => {
+      expect(
+        hatch(s({ analyticsConsentCurrent: false, diagnosticsConsentCurrent: false })),
+      ).toEqual(ALLOW);
     });
   });
 

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -15,6 +15,8 @@ export interface NavigationState {
   platformSession: PlatformSessionStatus;
   tosAccepted: boolean;
   aiDataConsent: boolean;
+  analyticsConsentCurrent: boolean;
+  diagnosticsConsentCurrent: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -48,6 +50,19 @@ export type NavigationDecision =
 
 function hasCompletedOnboarding(state: NavigationState): boolean {
   return state.tosAccepted && state.aiDataConsent;
+}
+
+/**
+ * Onboarding is complete AND every consent toggle is for the current version.
+ * A stale toggle means the user must re-review the terms even though they
+ * already finished onboarding.
+ */
+function consentIsCurrent(state: NavigationState): boolean {
+  return (
+    hasCompletedOnboarding(state) &&
+    state.analyticsConsentCurrent &&
+    state.diagnosticsConsentCurrent
+  );
 }
 
 const ONBOARDING_PREFIX = `${routes.assistant}/onboarding`;
@@ -265,7 +280,7 @@ function requireConsent(
   _path: string,
   pathnameWithSearch: string,
 ): NavigationDecision | null {
-  if (state.isLocalMode || hasCompletedOnboarding(state)) return null;
+  if (state.isLocalMode || consentIsCurrent(state)) return null;
 
   const returnTo = encodeURIComponent(pathnameWithSearch);
   return { action: "redirect", to: `${routes.reviewTerms}?returnTo=${returnTo}` };


### PR DESCRIPTION
## Summary
- Add analyticsConsentCurrent/diagnosticsConsentCurrent to NavigationState + build-state, plus prefs hooks/readers
- requireConsent now redirects to review-terms when a toggle version is stale (hasCompletedOnboarding semantics unchanged)
- navigation-resolver tests cover stale-toggle redirect and unchanged onboarding flows

Part of plan: consent-toggle-versioning.md (PR 6 of 7)