### PR TITLE
fix(security): escalate workspace tool/route writes to high risk (ATL-830)

### DIFF
--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -23,6 +23,8 @@ import {
   getWorkspaceDir,
   getWorkspaceHooksDir,
   getWorkspacePluginsDir,
+  getWorkspaceRoutesDir,
+  getWorkspaceToolsDir,
 } from "../util/platform.js";
 import {
   type ApprovalContext,
@@ -278,6 +280,8 @@ function buildFileContext(): FileContext {
     deprecatedDir: getDeprecatedDir(),
     hooksDir: getWorkspaceHooksDir(),
     pluginsDir: getWorkspacePluginsDir(),
+    toolsDir: getWorkspaceToolsDir(),
+    routesDir: getWorkspaceRoutesDir(),
     actorTokenSigningKeyPath: join(
       getProtectedDir(),
       "actor-token-signing-key",

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -353,15 +353,24 @@ function buildClassifyRiskParams(
   ) {
     const isHostTool = toolName.startsWith("host_");
     let filePath: string;
+    // For host_file_transfer to_sandbox, the file is written into the
+    // workspace at dest_path — forward it (plus the sandbox working dir) so the
+    // gateway can escalate writes that land in a code-injection sink, since
+    // `path` carries the host-side source.
+    let transferSandboxDestPath: string | undefined;
+    let transferSandboxWorkingDir: string | undefined;
     if (toolName === "host_file_transfer") {
-      // For host_file_transfer the security-sensitive path is the host-side
-      // path: source_path when reading from the host (to_sandbox), dest_path
-      // when writing to the host (to_host).
+      // For host_file_transfer the security-sensitive host-side path is
+      // source_path when reading from the host (to_sandbox), dest_path when
+      // writing to the host (to_host).
       const direction = getStringField(input, "direction");
-      filePath =
-        direction === "to_sandbox"
-          ? getStringField(input, "source_path")
-          : getStringField(input, "dest_path");
+      if (direction === "to_sandbox") {
+        filePath = getStringField(input, "source_path");
+        transferSandboxDestPath = getStringField(input, "dest_path");
+        transferSandboxWorkingDir = workingDir ?? process.cwd();
+      } else {
+        filePath = getStringField(input, "dest_path");
+      }
     } else {
       filePath = getStringField(input, "path", "file_path");
     }
@@ -370,6 +379,8 @@ function buildClassifyRiskParams(
       path: filePath,
       workingDir: isHostTool ? "/" : (workingDir ?? process.cwd()),
       fileContext: buildFileContext(),
+      transferSandboxDestPath,
+      transferSandboxWorkingDir,
     };
   }
 

--- a/assistant/src/permissions/ipc-risk-types.ts
+++ b/assistant/src/permissions/ipc-risk-types.ts
@@ -53,6 +53,8 @@ export interface FileContext {
   deprecatedDir: string;
   hooksDir: string;
   pluginsDir: string;
+  toolsDir: string;
+  routesDir: string;
   actorTokenSigningKeyPath: string;
   skillSourceDirs: string[];
 }

--- a/assistant/src/permissions/ipc-risk-types.ts
+++ b/assistant/src/permissions/ipc-risk-types.ts
@@ -97,4 +97,12 @@ export interface ClassifyRiskParams {
   registryDefaultRisk?: string;
   /** Number of credential references attached to this tool invocation. */
   credentialRefCount?: number;
+  /**
+   * For host_file_transfer with `direction: "to_sandbox"`: the workspace-side
+   * destination path and the sandbox working directory it resolves against, so
+   * the gateway can escalate transfers that install an executable file in a
+   * code-injection sink (tools/routes/hooks/plugins/skills).
+   */
+  transferSandboxDestPath?: string;
+  transferSandboxWorkingDir?: string;
 }

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -314,7 +314,14 @@ export function getWorkspaceToolsDir(): string {
   return join(getWorkspaceDir(), "tools");
 }
 
-/** Returns $VELLUM_WORKSPACE_DIR/routes — user-defined HTTP route handlers. */
+/**
+ * Returns $VELLUM_WORKSPACE_DIR/routes — user-defined HTTP route handlers.
+ *
+ * Handler modules under this directory are dynamic-imported by the user-route
+ * dispatcher and their exported HTTP-method functions are executed on the
+ * next matching request, so the file risk classifier escalates writes under
+ * this path to High for the same reason `plugins/` and `tools/` are escalated.
+ */
 export function getWorkspaceRoutesDir(): string {
   return join(getWorkspaceDir(), "routes");
 }

--- a/gateway/src/__tests__/nonbash-trust-rule-overrides.test.ts
+++ b/gateway/src/__tests__/nonbash-trust-rule-overrides.test.ts
@@ -25,6 +25,8 @@ const dummyFileContext: FileClassificationContext = {
   deprecatedDir: "/tmp/test-deprecated",
   hooksDir: "/tmp/test-hooks",
   pluginsDir: "/tmp/test-plugins",
+  toolsDir: "/tmp/test-tools",
+  routesDir: "/tmp/test-routes",
   skillSourceDirs: [],
 };
 

--- a/gateway/src/ipc/risk-classification-handlers.test.ts
+++ b/gateway/src/ipc/risk-classification-handlers.test.ts
@@ -262,6 +262,28 @@ describe("file classification", () => {
     expect(result.reason).toContain("routes");
   });
 
+  test("host_file_transfer to_sandbox dest in tools dir is high risk", async () => {
+    const result = await classify({
+      tool: "host_file_transfer",
+      // path carries the benign host-side source for to_sandbox.
+      path: "/tmp/payload.ts",
+      workingDir: "/",
+      transferSandboxDestPath: "tools/evil.ts",
+      transferSandboxWorkingDir: "/workspace",
+      fileContext: {
+        protectedDir: "/workspace/.vellum/protected",
+        hooksDir: "/workspace/.hooks",
+        toolsDir: "/workspace/tools",
+        routesDir: "/workspace/routes",
+        actorTokenSigningKeyPath:
+          "/workspace/.vellum/protected/actor-token-signing-key",
+        skillSourceDirs: ["/workspace/.vellum/skills"],
+      },
+    });
+    expect(result.risk).toBe("high");
+    expect(result.reason).toContain("tools");
+  });
+
   test("file_write to tools dir without context is NOT escalated (sentinel)", async () => {
     // When the assistant does not forward a fileContext, the handler uses
     // impossible sentinel paths so a tools-dir write is not falsely escalated

--- a/gateway/src/ipc/risk-classification-handlers.test.ts
+++ b/gateway/src/ipc/risk-classification-handlers.test.ts
@@ -223,6 +223,56 @@ describe("file classification", () => {
     expect(result.risk).toBe("high");
     expect(result.reason).toContain("skill source");
   });
+
+  test("file_write to tools dir is high risk", async () => {
+    const result = await classify({
+      tool: "file_write",
+      path: "/workspace/tools/evil_tool.ts",
+      workingDir: "/workspace",
+      fileContext: {
+        protectedDir: "/workspace/.vellum/protected",
+        hooksDir: "/workspace/.hooks",
+        toolsDir: "/workspace/tools",
+        routesDir: "/workspace/routes",
+        actorTokenSigningKeyPath:
+          "/workspace/.vellum/protected/actor-token-signing-key",
+        skillSourceDirs: ["/workspace/.vellum/skills"],
+      },
+    });
+    expect(result.risk).toBe("high");
+    expect(result.reason).toContain("tools");
+  });
+
+  test("file_write to routes dir is high risk", async () => {
+    const result = await classify({
+      tool: "file_write",
+      path: "/workspace/routes/evil.ts",
+      workingDir: "/workspace",
+      fileContext: {
+        protectedDir: "/workspace/.vellum/protected",
+        hooksDir: "/workspace/.hooks",
+        toolsDir: "/workspace/tools",
+        routesDir: "/workspace/routes",
+        actorTokenSigningKeyPath:
+          "/workspace/.vellum/protected/actor-token-signing-key",
+        skillSourceDirs: ["/workspace/.vellum/skills"],
+      },
+    });
+    expect(result.risk).toBe("high");
+    expect(result.reason).toContain("routes");
+  });
+
+  test("file_write to tools dir without context is NOT escalated (sentinel)", async () => {
+    // When the assistant does not forward a fileContext, the handler uses
+    // impossible sentinel paths so a tools-dir write is not falsely escalated
+    // (and, conversely, is not silently downgraded by a matching empty path).
+    const result = await classify({
+      tool: "file_write",
+      path: "/workspace/tools/evil_tool.ts",
+      workingDir: "/workspace",
+    });
+    expect(result.risk).toBe("low");
+  });
 });
 
 // ── Web classification ──────────────────────────────────────────────────────

--- a/gateway/src/ipc/risk-classification-handlers.ts
+++ b/gateway/src/ipc/risk-classification-handlers.ts
@@ -57,6 +57,8 @@ const ClassifyRiskSchema = z.object({
       deprecatedDir: z.string(),
       hooksDir: z.string(),
       pluginsDir: z.string().optional(),
+      toolsDir: z.string().optional(),
+      routesDir: z.string().optional(),
       actorTokenSigningKeyPath: z.string(),
       skillSourceDirs: z.array(z.string()),
     })
@@ -429,6 +431,8 @@ export async function handleClassifyRisk(
         deprecatedDir: fileCtx?.deprecatedDir ?? SENTINEL,
         hooksDir: fileCtx?.hooksDir ?? SENTINEL,
         pluginsDir: fileCtx?.pluginsDir ?? SENTINEL,
+        toolsDir: fileCtx?.toolsDir ?? SENTINEL,
+        routesDir: fileCtx?.routesDir ?? SENTINEL,
         skillSourceDirs: fileCtx?.skillSourceDirs ?? [],
       };
 

--- a/gateway/src/ipc/risk-classification-handlers.ts
+++ b/gateway/src/ipc/risk-classification-handlers.ts
@@ -78,6 +78,15 @@ const ClassifyRiskSchema = z.object({
   registryDefaultRisk: z.string().optional(),
   /** Number of credential references attached to this tool invocation. */
   credentialRefCount: z.number().int().nonnegative().optional(),
+  /**
+   * For host_file_transfer to_sandbox: the workspace-side destination path
+   * and the sandbox working directory it resolves against. Lets the classifier
+   * escalate writes that land an executable file in a code-injection sink
+   * (tools/routes/hooks/plugins/skills) even though `path` carries the
+   * host-side source.
+   */
+  transferSandboxDestPath: z.string().optional(),
+  transferSandboxWorkingDir: z.string().optional(),
 });
 
 type ClassifyRiskParams = z.infer<typeof ClassifyRiskSchema>;
@@ -437,7 +446,13 @@ export async function handleClassifyRisk(
       };
 
       const assessment = await fileRiskClassifier.classify(
-        { toolName: tool, filePath, workingDir },
+        {
+          toolName: tool,
+          filePath,
+          workingDir,
+          transferSandboxDestPath: params.transferSandboxDestPath,
+          transferSandboxWorkingDir: params.transferSandboxWorkingDir,
+        },
         context,
       );
 

--- a/gateway/src/risk/file-risk-classifier.test.ts
+++ b/gateway/src/risk/file-risk-classifier.test.ts
@@ -18,10 +18,11 @@ const MOCK_DEPRECATED_DIR = join(
   "workspace",
   "deprecated",
 );
-const MOCK_HOOKS_DIR = join(homedir(), ".vellum", "workspace", "hooks");
-const MOCK_PLUGINS_DIR = join(homedir(), ".vellum", "workspace", "plugins");
-const MOCK_TOOLS_DIR = join(homedir(), ".vellum", "workspace", "tools");
-const MOCK_ROUTES_DIR = join(homedir(), ".vellum", "workspace", "routes");
+const MOCK_WORKSPACE_DIR = join(homedir(), ".vellum", "workspace");
+const MOCK_HOOKS_DIR = join(MOCK_WORKSPACE_DIR, "hooks");
+const MOCK_PLUGINS_DIR = join(MOCK_WORKSPACE_DIR, "plugins");
+const MOCK_TOOLS_DIR = join(MOCK_WORKSPACE_DIR, "tools");
+const MOCK_ROUTES_DIR = join(MOCK_WORKSPACE_DIR, "routes");
 
 /** Skill source paths managed per-test via the context's skillSourceDirs. */
 let testSkillSourceDirs: string[] = [];
@@ -54,6 +55,8 @@ function classifyInput(
       filePath: input.filePath ?? "",
       workingDir: input.workingDir ?? WORKING_DIR,
       toolName: input.toolName,
+      transferSandboxDestPath: input.transferSandboxDestPath,
+      transferSandboxWorkingDir: input.transferSandboxWorkingDir,
     },
     makeContext(),
   );
@@ -333,6 +336,43 @@ describe("FileRiskClassifier", () => {
       });
       expect(result.riskLevel).toBe("high");
       expect(result.reason).toBe("Writes to routes directory");
+    });
+
+    // Container-style /workspace paths must be remapped to the working dir
+    // before the containment check — otherwise "/workspace/tools/evil.ts"
+    // resolves to the literal path (never matching the real tools dir) and
+    // falls through to Low, silently bypassing escalation.
+    test("/workspace-prefixed tools path is remapped and high", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: "/workspace/tools/evil.ts",
+        workingDir: MOCK_WORKSPACE_DIR,
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to tools directory");
+    });
+
+    test("/workspace-prefixed routes path is remapped and high", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: "/workspace/routes/evil.ts",
+        workingDir: MOCK_WORKSPACE_DIR,
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to routes directory");
+    });
+
+    test("relative tools path resolves against working dir and is high", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: "tools/evil.ts",
+        workingDir: MOCK_WORKSPACE_DIR,
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to tools directory");
     });
   });
 
@@ -719,6 +759,44 @@ describe("FileRiskClassifier", () => {
       });
       expect(result.riskLevel).toBe("high");
       expect(result.reason).toBe("Transfers to routes directory");
+    });
+
+    // to_sandbox: `filePath` carries the benign host source, but the workspace
+    // destination is the code-injection sink and must be classified.
+    test("to_sandbox dest in tools directory is high", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "host_file_transfer",
+        filePath: "/tmp/payload.ts",
+        transferSandboxDestPath: "tools/evil.ts",
+        transferSandboxWorkingDir: MOCK_WORKSPACE_DIR,
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Transfers to tools directory");
+    });
+
+    test("to_sandbox dest in routes directory (/workspace path) is high", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "host_file_transfer",
+        filePath: "/tmp/payload.ts",
+        transferSandboxDestPath: "/workspace/routes/evil.ts",
+        transferSandboxWorkingDir: MOCK_WORKSPACE_DIR,
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Transfers to routes directory");
+    });
+
+    test("to_sandbox dest outside sinks stays medium", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "host_file_transfer",
+        filePath: "/tmp/payload.txt",
+        transferSandboxDestPath: "scratch/output.txt",
+        transferSandboxWorkingDir: MOCK_WORKSPACE_DIR,
+      });
+      expect(result.riskLevel).toBe("medium");
+      expect(result.reason).toBe("Host file transfer (default)");
     });
   });
 

--- a/gateway/src/risk/file-risk-classifier.test.ts
+++ b/gateway/src/risk/file-risk-classifier.test.ts
@@ -20,6 +20,8 @@ const MOCK_DEPRECATED_DIR = join(
 );
 const MOCK_HOOKS_DIR = join(homedir(), ".vellum", "workspace", "hooks");
 const MOCK_PLUGINS_DIR = join(homedir(), ".vellum", "workspace", "plugins");
+const MOCK_TOOLS_DIR = join(homedir(), ".vellum", "workspace", "tools");
+const MOCK_ROUTES_DIR = join(homedir(), ".vellum", "workspace", "routes");
 
 /** Skill source paths managed per-test via the context's skillSourceDirs. */
 let testSkillSourceDirs: string[] = [];
@@ -30,6 +32,8 @@ function makeContext(): FileClassificationContext {
     deprecatedDir: MOCK_DEPRECATED_DIR,
     hooksDir: MOCK_HOOKS_DIR,
     pluginsDir: MOCK_PLUGINS_DIR,
+    toolsDir: MOCK_TOOLS_DIR,
+    routesDir: MOCK_ROUTES_DIR,
     skillSourceDirs: testSkillSourceDirs,
   };
 }
@@ -268,6 +272,68 @@ describe("FileRiskClassifier", () => {
       });
       expect(result.riskLevel).toBe("low");
     });
+
+    // Tools directory escalation. The workspace-tool loader (and its live file
+    // watcher) dynamic-imports any <name>.{ts,js} written here and registers it
+    // as an executable tool, so a routine file_write here is code injection.
+    test("tools directory itself is high", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: MOCK_TOOLS_DIR,
+        workingDir: "/",
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to tools directory");
+    });
+
+    test("tool override inside tools directory is high", async () => {
+      testSkillSourceDirs = [];
+      const toolFile = join(MOCK_TOOLS_DIR, "evil_tool.ts");
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: toolFile,
+        workingDir: "/",
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to tools directory");
+    });
+
+    test("path containing 'tools' substring outside tools dir is low", async () => {
+      // Guard against substring matching: /workspace/tools-data/ must NOT escalate.
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: join(homedir(), ".vellum", "workspace", "tools-data", "x"),
+        workingDir: "/",
+      });
+      expect(result.riskLevel).toBe("low");
+    });
+
+    // Routes directory escalation. The user-route dispatcher dynamic-imports
+    // handler modules here and executes their exported HTTP-method functions.
+    test("routes directory itself is high", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: MOCK_ROUTES_DIR,
+        workingDir: "/",
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to routes directory");
+    });
+
+    test("handler inside routes directory is high", async () => {
+      testSkillSourceDirs = [];
+      const routeFile = join(MOCK_ROUTES_DIR, "evil.ts");
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: routeFile,
+        workingDir: "/",
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to routes directory");
+    });
   });
 
   // -- file_edit --------------------------------------------------------------
@@ -317,6 +383,30 @@ describe("FileRiskClassifier", () => {
       });
       expect(result.riskLevel).toBe("high");
       expect(result.reason).toBe("Writes to plugins directory");
+    });
+
+    test("tools directory path is high", async () => {
+      testSkillSourceDirs = [];
+      const toolFile = join(MOCK_TOOLS_DIR, "evil_tool.ts");
+      const result = await classifyInput({
+        toolName: "file_edit",
+        filePath: toolFile,
+        workingDir: "/",
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to tools directory");
+    });
+
+    test("routes directory path is high", async () => {
+      testSkillSourceDirs = [];
+      const routeFile = join(MOCK_ROUTES_DIR, "evil.ts");
+      const result = await classifyInput({
+        toolName: "file_edit",
+        filePath: routeFile,
+        workingDir: "/",
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to routes directory");
     });
   });
 
@@ -436,6 +526,28 @@ describe("FileRiskClassifier", () => {
       expect(result.riskLevel).toBe("high");
       expect(result.reason).toBe("Writes to plugins directory");
     });
+
+    test("tools directory is high", async () => {
+      testSkillSourceDirs = [];
+      const toolFile = join(MOCK_TOOLS_DIR, "evil_tool.ts");
+      const result = await classifyInput({
+        toolName: "host_file_write",
+        filePath: toolFile,
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to tools directory");
+    });
+
+    test("routes directory is high", async () => {
+      testSkillSourceDirs = [];
+      const routeFile = join(MOCK_ROUTES_DIR, "evil.ts");
+      const result = await classifyInput({
+        toolName: "host_file_write",
+        filePath: routeFile,
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to routes directory");
+    });
   });
 
   // -- host_file_edit ---------------------------------------------------------
@@ -484,6 +596,28 @@ describe("FileRiskClassifier", () => {
       });
       expect(result.riskLevel).toBe("high");
       expect(result.reason).toBe("Writes to plugins directory");
+    });
+
+    test("tools directory path is high", async () => {
+      testSkillSourceDirs = [];
+      const toolFile = join(MOCK_TOOLS_DIR, "evil_tool.ts");
+      const result = await classifyInput({
+        toolName: "host_file_edit",
+        filePath: toolFile,
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to tools directory");
+    });
+
+    test("routes directory path is high", async () => {
+      testSkillSourceDirs = [];
+      const routeFile = join(MOCK_ROUTES_DIR, "evil.ts");
+      const result = await classifyInput({
+        toolName: "host_file_edit",
+        filePath: routeFile,
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to routes directory");
     });
   });
 
@@ -563,6 +697,28 @@ describe("FileRiskClassifier", () => {
       });
       expect(result.riskLevel).toBe("high");
       expect(result.reason).toBe("Transfers to plugins directory");
+    });
+
+    test("tools directory is high", async () => {
+      testSkillSourceDirs = [];
+      const toolFile = join(MOCK_TOOLS_DIR, "evil_tool.ts");
+      const result = await classifyInput({
+        toolName: "host_file_transfer",
+        filePath: toolFile,
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Transfers to tools directory");
+    });
+
+    test("routes directory is high", async () => {
+      testSkillSourceDirs = [];
+      const routeFile = join(MOCK_ROUTES_DIR, "evil.ts");
+      const result = await classifyInput({
+        toolName: "host_file_transfer",
+        filePath: routeFile,
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Transfers to routes directory");
     });
   });
 

--- a/gateway/src/risk/file-risk-classifier.ts
+++ b/gateway/src/risk/file-risk-classifier.ts
@@ -92,6 +92,17 @@ export interface FileClassifierInput {
     | "host_file_transfer";
   filePath: string;
   workingDir: string;
+  /**
+   * For `host_file_transfer` with `direction: "to_sandbox"`: the workspace-side
+   * destination path (where the copied file lands). `filePath` carries the
+   * host-side `source_path`, so without this the workspace write destination —
+   * the actual code-injection sink — would go unclassified. Resolved against
+   * {@link transferSandboxWorkingDir} with the same `/workspace` remap as
+   * sandbox file writes.
+   */
+  transferSandboxDestPath?: string;
+  /** Sandbox working directory used to resolve {@link transferSandboxDestPath}. */
+  transferSandboxWorkingDir?: string;
 }
 
 // -- Helpers ------------------------------------------------------------------
@@ -101,6 +112,39 @@ export interface FileClassifierInput {
  */
 function normalizeDirPath(dirPath: string): string {
   return dirPath.endsWith("/") ? dirPath : dirPath + "/";
+}
+
+// The Docker sandbox mounts the host workspace at /workspace inside the
+// container, and the model generates container-scoped paths (e.g.
+// "/workspace/tools/evil.ts") even on local/macOS turns. The file tools remap
+// these to the boundary (working) directory before writing — see
+// `sandboxPolicy` in assistant/src/tools/shared/filesystem/path-policy.ts.
+// The classifier MUST apply the same remap before its containment checks,
+// otherwise a "/workspace/tools/…" write resolves to the literal
+// "/workspace/…" path (which never matches the real tools/routes/hooks dirs)
+// and falls through to the Low default — silently bypassing escalation.
+const CONTAINER_WORKSPACE_PREFIX = "/workspace/";
+const CONTAINER_WORKSPACE_EXACT = "/workspace";
+
+/**
+ * Resolve a sandbox file path the same way `sandboxPolicy` does: remap a
+ * container-scoped `/workspace/...` path to `workingDir`, then resolve.
+ * Symlink resolution (realpath) is intentionally omitted — the classifier
+ * only needs the logical target for prefix containment, and the file tools
+ * apply realpath bounds-checking at execution time.
+ */
+function resolveSandboxPath(rawPath: string, workingDir: string): string {
+  let effectivePath = rawPath;
+  // Skip remapping if the path already starts with workingDir to avoid
+  // double-nesting (mirrors sandboxPolicy).
+  if (!rawPath.startsWith(workingDir + "/") && rawPath !== workingDir) {
+    if (rawPath.startsWith(CONTAINER_WORKSPACE_PREFIX)) {
+      effectivePath = rawPath.slice(CONTAINER_WORKSPACE_PREFIX.length);
+    } else if (rawPath === CONTAINER_WORKSPACE_EXACT) {
+      effectivePath = ".";
+    }
+  }
+  return resolve(workingDir, effectivePath);
 }
 
 /**
@@ -279,6 +323,38 @@ function buildFileAllowlistOptions(
   return options;
 }
 
+/**
+ * Classify a resolved (absolute) path against the code-injection sink
+ * directories: skill source, hooks, plugins, tools, and routes. A write to
+ * any of these plants code the daemon will dynamic-import and execute, so it
+ * must clear the High-risk approval gate. Returns a High assessment when the
+ * path lands in a sink, or `null` when it doesn't.
+ *
+ * `verb` distinguishes the user-facing reason: "Writes" for write/edit tools,
+ * "Transfers" for host_file_transfer.
+ */
+function classifyCodeInjectionSink(
+  resolvedPath: string,
+  context: FileClassificationContext,
+  verb: "Writes" | "Transfers",
+  allowlistOptions: AllowlistOption[],
+): RiskAssessment | null {
+  const high = (target: string): RiskAssessment => ({
+    riskLevel: "high",
+    reason: `${verb} to ${target}`,
+    scopeOptions: [],
+    matchType: "registry",
+    allowlistOptions,
+  });
+  if (isSkillSourcePath(resolvedPath, context))
+    return high("skill source code");
+  if (isHooksPath(resolvedPath, context)) return high("hooks directory");
+  if (isPluginsPath(resolvedPath, context)) return high("plugins directory");
+  if (isToolsPath(resolvedPath, context)) return high("tools directory");
+  if (isRoutesPath(resolvedPath, context)) return high("routes directory");
+  return null;
+}
+
 // -- Classifier ---------------------------------------------------------------
 
 /**
@@ -299,7 +375,13 @@ export class FileRiskClassifier implements RiskClassifier<
     input: FileClassifierInput,
     context: FileClassificationContext,
   ): Promise<RiskAssessment> {
-    const { toolName, filePath, workingDir } = input;
+    const {
+      toolName,
+      filePath,
+      workingDir,
+      transferSandboxDestPath,
+      transferSandboxWorkingDir,
+    } = input;
     const allowlistOptions = filePath
       ? buildFileAllowlistOptions(toolName, filePath)
       : [];
@@ -311,7 +393,7 @@ export class FileRiskClassifier implements RiskClassifier<
     switch (toolName) {
       case "file_read": {
         if (filePath) {
-          const resolvedPath = resolve(workingDir, filePath);
+          const resolvedPath = resolveSandboxPath(filePath, workingDir);
           if (isActorTokenSigningKeyPath(resolvedPath, workingDir, context)) {
             assessment = {
               riskLevel: "high",
@@ -336,55 +418,15 @@ export class FileRiskClassifier implements RiskClassifier<
       case "file_write":
       case "file_edit": {
         if (filePath) {
-          const resolvedPath = resolve(workingDir, filePath);
-          if (isSkillSourcePath(resolvedPath, context)) {
-            assessment = {
-              riskLevel: "high",
-              reason: "Writes to skill source code",
-              scopeOptions: [],
-              matchType: "registry",
-              allowlistOptions,
-            };
-            break;
-          }
-          if (isHooksPath(resolvedPath, context)) {
-            assessment = {
-              riskLevel: "high",
-              reason: "Writes to hooks directory",
-              scopeOptions: [],
-              matchType: "registry",
-              allowlistOptions,
-            };
-            break;
-          }
-          if (isPluginsPath(resolvedPath, context)) {
-            assessment = {
-              riskLevel: "high",
-              reason: "Writes to plugins directory",
-              scopeOptions: [],
-              matchType: "registry",
-              allowlistOptions,
-            };
-            break;
-          }
-          if (isToolsPath(resolvedPath, context)) {
-            assessment = {
-              riskLevel: "high",
-              reason: "Writes to tools directory",
-              scopeOptions: [],
-              matchType: "registry",
-              allowlistOptions,
-            };
-            break;
-          }
-          if (isRoutesPath(resolvedPath, context)) {
-            assessment = {
-              riskLevel: "high",
-              reason: "Writes to routes directory",
-              scopeOptions: [],
-              matchType: "registry",
-              allowlistOptions,
-            };
+          const resolvedPath = resolveSandboxPath(filePath, workingDir);
+          const sink = classifyCodeInjectionSink(
+            resolvedPath,
+            context,
+            "Writes",
+            allowlistOptions,
+          );
+          if (sink) {
+            assessment = sink;
             break;
           }
         }
@@ -418,58 +460,40 @@ export class FileRiskClassifier implements RiskClassifier<
         // "Writes" for write/edit (both mutate files), "Transfers" for transfer.
         const actionVerb =
           toolName === "host_file_transfer" ? "Transfers" : "Writes";
+
+        // host_file_transfer to_sandbox: the workspace-side destination is the
+        // file actually written into the sandbox, so it — not the host-side
+        // source in `filePath` — is the code-injection sink. Check it first,
+        // resolving with the same /workspace remap as sandbox file writes.
+        if (transferSandboxDestPath) {
+          const destResolved = resolveSandboxPath(
+            transferSandboxDestPath,
+            transferSandboxWorkingDir ?? process.cwd(),
+          );
+          const destSink = classifyCodeInjectionSink(
+            destResolved,
+            context,
+            "Transfers",
+            allowlistOptions,
+          );
+          if (destSink) {
+            assessment = destSink;
+            break;
+          }
+        }
+
         if (filePath) {
           // Host file tools resolve paths without workingDir — resolve(filePath)
           // treats the path as absolute or relative to cwd.
           const resolvedPath = resolve(filePath);
-          if (isSkillSourcePath(resolvedPath, context)) {
-            assessment = {
-              riskLevel: "high",
-              reason: `${actionVerb} to skill source code`,
-              scopeOptions: [],
-              matchType: "registry",
-              allowlistOptions,
-            };
-            break;
-          }
-          if (isHooksPath(resolvedPath, context)) {
-            assessment = {
-              riskLevel: "high",
-              reason: `${actionVerb} to hooks directory`,
-              scopeOptions: [],
-              matchType: "registry",
-              allowlistOptions,
-            };
-            break;
-          }
-          if (isPluginsPath(resolvedPath, context)) {
-            assessment = {
-              riskLevel: "high",
-              reason: `${actionVerb} to plugins directory`,
-              scopeOptions: [],
-              matchType: "registry",
-              allowlistOptions,
-            };
-            break;
-          }
-          if (isToolsPath(resolvedPath, context)) {
-            assessment = {
-              riskLevel: "high",
-              reason: `${actionVerb} to tools directory`,
-              scopeOptions: [],
-              matchType: "registry",
-              allowlistOptions,
-            };
-            break;
-          }
-          if (isRoutesPath(resolvedPath, context)) {
-            assessment = {
-              riskLevel: "high",
-              reason: `${actionVerb} to routes directory`,
-              scopeOptions: [],
-              matchType: "registry",
-              allowlistOptions,
-            };
+          const sink = classifyCodeInjectionSink(
+            resolvedPath,
+            context,
+            actionVerb,
+            allowlistOptions,
+          );
+          if (sink) {
+            assessment = sink;
             break;
           }
         }

--- a/gateway/src/risk/file-risk-classifier.ts
+++ b/gateway/src/risk/file-risk-classifier.ts
@@ -8,14 +8,25 @@
  * Risk escalation paths:
  * - file_read: Low by default, High if targeting the actor token signing key.
  * - file_write / file_edit: Low by default, High if targeting skill source
- *   code, the workspace hooks directory, or the user plugins directory.
+ *   code, the workspace hooks directory, the user plugins directory, the
+ *   workspace tools directory, or the workspace routes directory.
  * - host_file_read: Medium (tool registry default; no special escalation).
  * - host_file_write / host_file_edit: Medium by default, High if targeting
- *   skill source code, the workspace hooks directory, or the user plugins
+ *   skill source code, the workspace hooks directory, the user plugins
+ *   directory, the workspace tools directory, or the workspace routes
  *   directory.
  * - host_file_transfer: Medium by default, High if the host-side path
- *   targets skill source code, the workspace hooks directory, or the user
- *   plugins directory.
+ *   targets skill source code, the workspace hooks directory, the user
+ *   plugins directory, the workspace tools directory, or the workspace
+ *   routes directory.
+ *
+ * The tools and routes directories are escalated for the same reason as
+ * plugins: any file written under `<workspace>/tools/` is dynamic-imported
+ * and executed as a registered tool by the workspace-tool loader (and its
+ * live file watcher), and any file under `<workspace>/routes/` is
+ * dynamic-imported and executed as an HTTP route handler. A write to either
+ * is a code-injection sink, so it must clear the same High-risk approval gate
+ * as hooks and plugins.
  *
  * Gateway adaptation: accepts a FileClassificationContext parameter instead
  * of importing assistant platform utilities directly. The assistant is
@@ -55,6 +66,10 @@ export interface FileClassificationContext {
   hooksDir: string;
   /** Absolute path to the user plugins directory. */
   pluginsDir: string;
+  /** Absolute path to the workspace tools directory (dynamic-imported tool overrides). */
+  toolsDir: string;
+  /** Absolute path to the workspace routes directory (dynamic-imported HTTP route handlers). */
+  routesDir: string;
   /**
    * Absolute paths of all skill source root directories (managed, bundled,
    * and any extra dirs from config). The classifier checks whether a file
@@ -142,6 +157,44 @@ function isPluginsPath(
   return (
     resolvedPath === pluginsDirNoTrailingSlash ||
     resolvedPath.startsWith(normalizedPluginsDir)
+  );
+}
+
+/**
+ * Check whether a resolved absolute path falls inside the workspace tools
+ * directory (or IS the tools directory itself). Mirrors {@link isPluginsPath}:
+ * the workspace-tool loader dynamic-imports any `<name>.{ts,js}` written here
+ * and registers it as an executable tool (its file watcher does so live,
+ * without a restart), so a write here is code-injection risk.
+ */
+function isToolsPath(
+  resolvedPath: string,
+  context: FileClassificationContext,
+): boolean {
+  const normalizedToolsDir = normalizeDirPath(context.toolsDir);
+  const toolsDirNoTrailingSlash = normalizedToolsDir.slice(0, -1);
+  return (
+    resolvedPath === toolsDirNoTrailingSlash ||
+    resolvedPath.startsWith(normalizedToolsDir)
+  );
+}
+
+/**
+ * Check whether a resolved absolute path falls inside the workspace routes
+ * directory (or IS the routes directory itself). Mirrors {@link isPluginsPath}:
+ * the user-route dispatcher dynamic-imports any handler module written here
+ * and executes its exported HTTP-method functions on the next matching
+ * request, so a write here is code-injection risk.
+ */
+function isRoutesPath(
+  resolvedPath: string,
+  context: FileClassificationContext,
+): boolean {
+  const normalizedRoutesDir = normalizeDirPath(context.routesDir);
+  const routesDirNoTrailingSlash = normalizedRoutesDir.slice(0, -1);
+  return (
+    resolvedPath === routesDirNoTrailingSlash ||
+    resolvedPath.startsWith(normalizedRoutesDir)
   );
 }
 
@@ -314,6 +367,26 @@ export class FileRiskClassifier implements RiskClassifier<
             };
             break;
           }
+          if (isToolsPath(resolvedPath, context)) {
+            assessment = {
+              riskLevel: "high",
+              reason: "Writes to tools directory",
+              scopeOptions: [],
+              matchType: "registry",
+              allowlistOptions,
+            };
+            break;
+          }
+          if (isRoutesPath(resolvedPath, context)) {
+            assessment = {
+              riskLevel: "high",
+              reason: "Writes to routes directory",
+              scopeOptions: [],
+              matchType: "registry",
+              allowlistOptions,
+            };
+            break;
+          }
         }
         assessment = {
           riskLevel: "low",
@@ -373,6 +446,26 @@ export class FileRiskClassifier implements RiskClassifier<
             assessment = {
               riskLevel: "high",
               reason: `${actionVerb} to plugins directory`,
+              scopeOptions: [],
+              matchType: "registry",
+              allowlistOptions,
+            };
+            break;
+          }
+          if (isToolsPath(resolvedPath, context)) {
+            assessment = {
+              riskLevel: "high",
+              reason: `${actionVerb} to tools directory`,
+              scopeOptions: [],
+              matchType: "registry",
+              allowlistOptions,
+            };
+            break;
+          }
+          if (isRoutesPath(resolvedPath, context)) {
+            assessment = {
+              riskLevel: "high",
+              reason: `${actionVerb} to routes directory`,
               scopeOptions: [],
               matchType: "registry",
               allowlistOptions,


### PR DESCRIPTION
## ATL-830 — Workspace tool writes bypass high-risk approval

### Problem

Dropping a file into `<workspace>/tools/<name>.{ts,js,json}` registers a **new tool whose code the daemon dynamically imports and executes with full privilege** — and with the `workspace-tools-watcher` feature flag on, the live `fs.watch` loop loads it **with no restart** (`assistant/src/daemon/workspace-tools-watcher.ts`, `assistant/src/tools/workspace-tools/loader.ts`). The same is true of `<workspace>/routes/`, whose handler modules are dynamic-imported and executed by the user-route dispatcher on the next matching request (`assistant/src/runtime/routes/user-route-dispatcher.ts`).

This is the same code-injection threat model as `hooks/`, `plugins/`, and skill-source dirs — all of which the file risk classifier escalates to **High**. But `tools/` and `routes/` were **not** escalated. So a `file_write`/`file_edit` to `tools/evil.ts`:

- was classified `riskLevel: "low"` (`"File write (default)"`), because the classifier only checked `isSkillSourcePath` / `isHooksPath` / `isPluginsPath`; and
- being inside the workspace, `isWorkspaceScopedInvocation` returned `true`, so under the default `low` auto-approve threshold the approval policy **auto-allowed it with no prompt at all** ("Workspace-scoped low-risk operation auto-allowed").

Net effect: a prompt-injected assistant (or untrusted channel content) could install an arbitrary-code-executing tool/route that runs with daemon privilege, bypassing the High-risk approval gate that the equivalent write to `hooks/` or `plugins/` must clear. The `getWorkspaceToolsDir()` docstring in `platform.ts` even claimed this escalation already existed — it never did.

### Fix

- Add `toolsDir` / `routesDir` to `FileClassificationContext` (gateway) and `FileContext` (assistant IPC types).
- Plumb them through `buildFileContext()` (`getWorkspaceToolsDir()` / `getWorkspaceRoutesDir()`) and the `classify_risk` Zod schema (+ SENTINEL defaults when context is absent).
- Add `isToolsPath` / `isRoutesPath` checks (exact-dir + prefix, with substring guard) to the `file_write`, `file_edit`, `host_file_write`, `host_file_edit`, and `host_file_transfer` cases → **High** (`"Writes/Transfers to tools/routes directory"`).
- Update the `getWorkspaceRoutesDir()` docstring to reflect the escalation.

### Tests
- `gateway/src/risk/file-risk-classifier.test.ts`: tools/routes escalation for all five mutating file tools, plus a `tools-data/` substring-guard negative case.
- `gateway/src/ipc/risk-classification-handlers.test.ts`: handler-level escalation for tools/routes, plus a sentinel (no-context → not falsely escalated) case.

### Verification
- `bun test` on both affected gateway test files: **122 pass**.
- `assistant/src/__tests__/checker.test.ts`: **131 pass**.
- `tsc --noEmit` clean for both `gateway/` and `assistant/`.

### Note
Couldn't open the Linear ticket directly (auth-gated, no Linear integration in this session) — scope was derived from the title and confirmed against the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWwS7FNGXCm1ZY5io2HjMP

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWwS7FNGXCm1ZY5io2HjMP)_