### PR TITLE
feat(consent): surface stale share toggles in review-terms

### DIFF
--- a/clients/web/src/domains/onboarding/components/setting-row.tsx
+++ b/clients/web/src/domains/onboarding/components/setting-row.tsx
@@ -1,0 +1,30 @@
+import { useId } from "react";
+
+import { Toggle } from "@vellumai/design-library/components/toggle";
+
+export function SettingRow({
+  label,
+  helperText,
+  checked,
+  onChange,
+}: {
+  label: string;
+  helperText: string;
+  checked: boolean;
+  onChange: (next: boolean) => void;
+}) {
+  const toggleId = useId();
+  return (
+    <div className="flex items-start gap-4">
+      <Toggle checked={checked} onChange={onChange} id={toggleId} />
+      <label htmlFor={toggleId} className="min-w-0 flex-1 cursor-pointer">
+        <span className="block text-body-medium-default text-[var(--content-default)]">
+          {label}
+        </span>
+        <span className="mt-1 block text-body-small-default text-[var(--content-tertiary)]">
+          {helperText}
+        </span>
+      </label>
+    </div>
+  );
+}

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
@@ -21,6 +21,8 @@ mock.module("@/domains/onboarding/prefs", () => ({
   useShareDiagnostics: () => [false, setShareDiagnostics],
   useTosAccepted: () => [true, setTosAccepted],
   useAiDataConsent: () => [true, setAiDataConsent],
+  useAnalyticsConsentCurrent: () => [true, mock(() => {})],
+  useDiagnosticsConsentCurrent: () => [true, mock(() => {})],
 }));
 
 const saveConsentMock = mock((_args: unknown) => {});

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -1,8 +1,9 @@
 import { EyeOff } from "lucide-react";
-import { useCallback, useEffect, useId, type ReactNode } from "react";
+import { useCallback, useEffect, type ReactNode } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
+import { SettingRow } from "@/domains/onboarding/components/setting-row";
 import { StepIndicatorDots } from "@/domains/onboarding/components/step-indicator-dots";
 import {
     emitOnboardingFunnelStepCompleted,
@@ -26,38 +27,6 @@ import { legalUrl, routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 import { Card } from "@vellumai/design-library/components/card";
 import { Checkbox } from "@vellumai/design-library/components/checkbox";
-import { Toggle } from "@vellumai/design-library/components/toggle";
-
-function SettingRow({
-  label,
-  helperText,
-  checked,
-  onChange,
-}: {
-  label: string;
-  helperText: string;
-  checked: boolean;
-  onChange: (next: boolean) => void;
-}) {
-  const toggleId = useId();
-  return (
-    <div className="flex items-start gap-4">
-      <Toggle
-        checked={checked}
-        onChange={onChange}
-        id={toggleId}
-      />
-      <label htmlFor={toggleId} className="min-w-0 flex-1 cursor-pointer">
-        <span className="block text-body-medium-default text-[var(--content-default)]">
-          {label}
-        </span>
-        <span className="mt-1 block text-body-small-default text-[var(--content-tertiary)]">
-          {helperText}
-        </span>
-      </label>
-    </div>
-  );
-}
 
 // Consent checkboxes mirror the primary button: the checked fill uses
 // --primary-base and the check uses --content-inset (the on-primary

--- a/clients/web/src/domains/onboarding/pages/review-terms-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/review-terms-screen.test.tsx
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+// react-router: capture navigate() targets.
+const navigateMock = mock((..._args: unknown[]) => {});
+let searchParamsValue = new URLSearchParams();
+mock.module("react-router", () => ({
+  useNavigate: () => navigateMock,
+  useSearchParams: () => [searchParamsValue, mock(() => {})],
+}));
+
+// Prefs hooks — mutable per-test so we can model each staleness combination.
+let tosAccepted = true;
+let aiDataConsent = true;
+let shareAnalytics = true;
+let shareDiagnostics = true;
+let analyticsConsentCurrent = true;
+let diagnosticsConsentCurrent = true;
+const setTosAccepted = mock((next: boolean) => {
+  tosAccepted = next;
+});
+const setAiDataConsent = mock((next: boolean) => {
+  aiDataConsent = next;
+});
+const setShareAnalytics = mock((next: boolean) => {
+  shareAnalytics = next;
+});
+const setShareDiagnostics = mock((next: boolean) => {
+  shareDiagnostics = next;
+});
+mock.module("@/domains/onboarding/prefs", () => ({
+  useTosAccepted: () => [tosAccepted, setTosAccepted],
+  useAiDataConsent: () => [aiDataConsent, setAiDataConsent],
+  useShareAnalytics: () => [shareAnalytics, setShareAnalytics],
+  useShareDiagnostics: () => [shareDiagnostics, setShareDiagnostics],
+  useAnalyticsConsentCurrent: () => [analyticsConsentCurrent, mock(() => {})],
+  useDiagnosticsConsentCurrent: () => [diagnosticsConsentCurrent, mock(() => {})],
+}));
+
+const saveConsentMock = mock((_args: unknown) => {});
+mock.module("@/utils/onboarding-cleanup", () => ({
+  saveConsent: saveConsentMock,
+}));
+
+mock.module("@/lib/auth/hard-navigate", () => ({
+  hardNavigate: mock(() => {}),
+}));
+mock.module("@/runtime/is-electron", () => ({ isElectron: () => true }));
+mock.module("@/stores/auth-store", () => ({
+  useAuthStore: { use: { user: () => ({ id: "user-1" }), logout: () => mock(async () => {}) } },
+  useHasPlatformSession: () => true,
+}));
+
+// Light passthroughs for layout/design-library so the screen renders in happy-dom.
+mock.module("@/domains/onboarding/components/onboarding-layout", () => ({
+  OnboardingLayout: ({ children }: { children: React.ReactNode }) => children,
+}));
+mock.module("@vellumai/design-library/components/button", () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+mock.module("@vellumai/design-library/components/checkbox", () => ({
+  Checkbox: ({
+    checked,
+    onCheckedChange,
+    "aria-label": ariaLabel,
+  }: {
+    checked: boolean;
+    onCheckedChange: (next: boolean) => void;
+    "aria-label"?: string;
+  }) => (
+    <input
+      type="checkbox"
+      aria-label={ariaLabel}
+      checked={checked}
+      onChange={(e) => onCheckedChange(e.target.checked)}
+    />
+  ),
+}));
+mock.module("@vellumai/design-library/components/toggle", () => ({
+  Toggle: ({
+    checked,
+    onChange,
+    id,
+  }: {
+    checked: boolean;
+    onChange: (next: boolean) => void;
+    id?: string;
+  }) => (
+    <input
+      type="checkbox"
+      role="switch"
+      id={id}
+      checked={checked}
+      onChange={(e) => onChange(e.target.checked)}
+    />
+  ),
+}));
+
+const { ReviewTermsScreen } = await import(
+  "@/domains/onboarding/pages/review-terms-screen"
+);
+
+const TOS_LABEL = "I agree to the Terms of Service and Privacy Policy";
+const AI_LABEL = "I agree to the AI Data Sharing Policy";
+
+function continueButton(): HTMLButtonElement {
+  return screen.getByText("Continue") as HTMLButtonElement;
+}
+
+describe("ReviewTermsScreen", () => {
+  beforeEach(() => {
+    navigateMock.mockClear();
+    saveConsentMock.mockClear();
+    setShareAnalytics.mockClear();
+    searchParamsValue = new URLSearchParams();
+    tosAccepted = true;
+    aiDataConsent = true;
+    shareAnalytics = true;
+    shareDiagnostics = true;
+    analyticsConsentCurrent = true;
+    diagnosticsConsentCurrent = true;
+  });
+  afterEach(cleanup);
+
+  test("toggle-only staleness renders the toggle, no legal checkboxes, and Continue enabled", () => {
+    analyticsConsentCurrent = false; // analytics stale; tos/ai current
+    render(<ReviewTermsScreen />);
+
+    // The analytics toggle is shown.
+    expect(screen.getByRole("switch")).toBeTruthy();
+    // No legal checkboxes.
+    expect(screen.queryByLabelText(TOS_LABEL)).toBeNull();
+    expect(screen.queryByLabelText(AI_LABEL)).toBeNull();
+    // Continue is enabled.
+    expect(continueButton().disabled).toBe(false);
+  });
+
+  test("flipping a toggle then Continue calls saveConsent with the chosen value", () => {
+    analyticsConsentCurrent = false;
+    shareAnalytics = true;
+    const { rerender } = render(<ReviewTermsScreen />);
+
+    fireEvent.click(screen.getByRole("switch"));
+    expect(setShareAnalytics).toHaveBeenCalledWith(false);
+
+    // Re-render so the component picks up the new store value before Continue.
+    rerender(<ReviewTermsScreen />);
+    fireEvent.click(continueButton());
+
+    expect(saveConsentMock).toHaveBeenCalledTimes(1);
+    expect(saveConsentMock.mock.calls[0]?.[0]).toMatchObject({
+      shareAnalytics: false,
+    });
+  });
+
+  test("stale TOS renders its checkbox and gates Continue until checked", () => {
+    tosAccepted = false; // tos stale
+    const { rerender } = render(<ReviewTermsScreen />);
+
+    const tosCheckbox = screen.getByLabelText(TOS_LABEL);
+    expect(tosCheckbox).toBeTruthy();
+    expect(continueButton().disabled).toBe(true);
+
+    fireEvent.click(tosCheckbox);
+    expect(setTosAccepted).toHaveBeenCalledWith(true);
+
+    rerender(<ReviewTermsScreen />);
+    expect(continueButton().disabled).toBe(false);
+  });
+});

--- a/clients/web/src/domains/onboarding/pages/review-terms-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/review-terms-screen.tsx
@@ -2,8 +2,11 @@ import { useCallback, type ReactNode } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
+import { SettingRow } from "@/domains/onboarding/components/setting-row";
 import {
     useAiDataConsent,
+    useAnalyticsConsentCurrent,
+    useDiagnosticsConsentCurrent,
     useShareAnalytics,
     useShareDiagnostics,
     useTosAccepted,
@@ -30,8 +33,16 @@ export function ReviewTermsScreen() {
 
   const [tosAccepted, setTosAccepted] = useTosAccepted();
   const [aiDataConsent, setAiDataConsent] = useAiDataConsent();
-  const [shareAnalytics] = useShareAnalytics();
-  const [shareDiagnostics] = useShareDiagnostics();
+  const [shareAnalytics, setShareAnalytics] = useShareAnalytics();
+  const [shareDiagnostics, setShareDiagnostics] = useShareDiagnostics();
+  const [analyticsConsentCurrent] = useAnalyticsConsentCurrent();
+  const [diagnosticsConsentCurrent] = useDiagnosticsConsentCurrent();
+
+  const tosStale = !tosAccepted;
+  const aiStale = !aiDataConsent;
+  const analyticsStale = !analyticsConsentCurrent;
+  const diagnosticsStale = !diagnosticsConsentCurrent;
+  const onlyTogglesStale = !tosStale && !aiStale;
 
   const onContinue = useCallback(() => {
     saveConsent({ userId, tos: tosAccepted, ai: aiDataConsent, shareAnalytics, shareDiagnostics, hasPlatformSession });
@@ -91,6 +102,10 @@ export function ReviewTermsScreen() {
     </span>
   );
 
+  // Only shown legal checkboxes gate Continue. Toggles never block — off is a
+  // valid choice — so when only toggles are stale Continue is enabled.
+  const continueDisabled = (tosStale && !tosAccepted) || (aiStale && !aiDataConsent);
+
   return (
     <OnboardingLayout showCreatureFooter={false}>
       <div
@@ -100,40 +115,70 @@ export function ReviewTermsScreen() {
           className={electron ? "text-title-large" : "text-3xl font-semibold tracking-tight"}
           style={{ animation: "fadeInUp 0.5s ease-out 0.1s both" }}
         >
-          Updated Terms
+          {onlyTogglesStale ? "Review your privacy preferences" : "Updated Terms"}
         </h1>
         <p
           className={`text-center text-body-medium-lighter text-[var(--content-tertiary)] ${electron ? "mt-3.5" : "mt-4"}`}
           style={{ animation: "fadeInUp 0.5s ease-out 0.3s both" }}
         >
-          We&apos;ve updated our terms. Please review and re-accept to continue.
+          {onlyTogglesStale
+            ? "We've updated our privacy preferences. Please review them to continue."
+            : "We've updated our terms. Please review and re-accept to continue."}
         </p>
 
-        <div
-          className="mt-8 flex w-full items-start"
-          style={{ animation: "fadeInUp 0.5s ease-out 0.4s both" }}
-        >
-          <Checkbox
-            checked={aiDataConsent}
-            onCheckedChange={(next) => setAiDataConsent(next === true)}
-            label={aiConsentLabel}
-            aria-label="I agree to the AI Data Sharing Policy"
-            className={CONSENT_CHECKBOX_CLASS}
-          />
-        </div>
+        {(analyticsStale || diagnosticsStale) && (
+          <div
+            className="mt-8 flex w-full flex-col gap-4"
+            style={{ animation: "fadeInUp 0.5s ease-out 0.4s both" }}
+          >
+            {analyticsStale && (
+              <SettingRow
+                label="Share Analytics"
+                helperText="Send anonymous product usage data."
+                checked={shareAnalytics}
+                onChange={setShareAnalytics}
+              />
+            )}
+            {diagnosticsStale && (
+              <SettingRow
+                label="Share Diagnostics"
+                helperText="Send crash reports and performance metrics."
+                checked={shareDiagnostics}
+                onChange={setShareDiagnostics}
+              />
+            )}
+          </div>
+        )}
 
-        <div
-          className={`flex w-full items-start ${electron ? "mt-2" : "mt-4"}`}
-          style={{ animation: "fadeInUp 0.5s ease-out 0.45s both" }}
-        >
-          <Checkbox
-            checked={tosAccepted}
-            onCheckedChange={(next) => setTosAccepted(next === true)}
-            label={tosLabel}
-            aria-label="I agree to the Terms of Service and Privacy Policy"
-            className={CONSENT_CHECKBOX_CLASS}
-          />
-        </div>
+        {aiStale && (
+          <div
+            className="mt-8 flex w-full items-start"
+            style={{ animation: "fadeInUp 0.5s ease-out 0.45s both" }}
+          >
+            <Checkbox
+              checked={aiDataConsent}
+              onCheckedChange={(next) => setAiDataConsent(next === true)}
+              label={aiConsentLabel}
+              aria-label="I agree to the AI Data Sharing Policy"
+              className={CONSENT_CHECKBOX_CLASS}
+            />
+          </div>
+        )}
+
+        {tosStale && (
+          <div
+            className={`flex w-full items-start ${electron ? "mt-2" : "mt-4"}`}
+            style={{ animation: "fadeInUp 0.5s ease-out 0.5s both" }}
+          >
+            <Checkbox
+              checked={tosAccepted}
+              onCheckedChange={(next) => setTosAccepted(next === true)}
+              label={tosLabel}
+              aria-label="I agree to the Terms of Service and Privacy Policy"
+              className={CONSENT_CHECKBOX_CLASS}
+            />
+          </div>
+        )}
 
         <div
           className={`mt-8 flex w-full flex-col ${electron ? "gap-2.5" : "gap-2"}`}
@@ -143,7 +188,7 @@ export function ReviewTermsScreen() {
             variant="primary"
             size="regular"
             fullWidth
-            disabled={!tosAccepted || !aiDataConsent}
+            disabled={continueDisabled}
             onClick={onContinue}
             className={electron ? undefined : "h-11 text-base"}
           >


### PR DESCRIPTION
## Summary
- review-terms renders each consent section (TOS, AI, analytics, diagnostics) only when that item is stale
- toggles are editable and never block Continue; stale legal checkboxes still gate Continue
- Continue calls saveConsent, which re-stamps all versions current

Part of plan: consent-toggle-versioning.md (PR 7 of 7)