### PR TITLE
fix(security): resolve symlinks before file risk classification (ATL-872)

### DIFF
--- a/assistant/src/__tests__/path-policy.test.ts
+++ b/assistant/src/__tests__/path-policy.test.ts
@@ -12,6 +12,7 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import {
   hostPolicy,
+  resolveRealPath,
   sandboxPolicy,
 } from "../tools/shared/filesystem/path-policy.js";
 
@@ -235,6 +236,39 @@ describe("hostPolicy", () => {
     if (result.ok) {
       expect(result.resolved).toBe("/");
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveRealPath
+// ---------------------------------------------------------------------------
+
+describe("resolveRealPath", () => {
+  test("resolves an existing file's symlink to its real target", () => {
+    const dir = makeTempDir();
+    const target = join(dir, "real.txt");
+    writeFileSync(target, "x");
+    const link = join(dir, "link.txt");
+    symlinkSync(target, link);
+
+    expect(resolveRealPath(link)).toBe(target);
+  });
+
+  test("follows a symlinked ancestor for a not-yet-existing path", () => {
+    const real = makeTempDir();
+    const linkParent = makeTempDir();
+    const link = join(linkParent, "link-dir");
+    symlinkSync(real, link);
+
+    // The leaf does not exist yet; the symlinked ancestor must still resolve.
+    expect(resolveRealPath(join(link, "new-file.txt"))).toBe(
+      join(real, "new-file.txt"),
+    );
+  });
+
+  test("falls back to the lexical path when nothing on it exists", () => {
+    const phantom = join(tmpdir(), "definitely-not-here-12345", "nope.txt");
+    expect(resolveRealPath(phantom)).toBe(phantom);
   });
 });
 

--- a/assistant/src/permissions/checker.test.ts
+++ b/assistant/src/permissions/checker.test.ts
@@ -126,6 +126,16 @@ mock.module("../ipc/gateway-client.js", () => ({
 // ── Import the module under test AFTER mocks are set up ──────────────────────
 
 import {
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
   check,
   classifyRisk,
   generateAllowlistOptions,
@@ -229,6 +239,47 @@ describe("Permission Checker (gateway IPC)", () => {
       const result2 = await classifyRisk("file_read", { path: "/tmp/a.txt" });
       expect(result2.level).toBe(RiskLevel.Low);
       expect(result2.reason).toBe("Cached test");
+    });
+
+    test("file-tool cache misses when a symlink target is retargeted", async () => {
+      // File risk depends on filesystem state: the cache key folds in the
+      // symlink-resolved target, so the same raw input must NOT return a stale
+      // cached result after the symlink is pointed somewhere new.
+      const dir = mkdtempSync(join(tmpdir(), "risk-cache-symlink-"));
+      try {
+        const benign = join(dir, "benign.txt");
+        const other = join(dir, "other.txt");
+        writeFileSync(benign, "ok");
+        writeFileSync(other, "ok");
+        const link = join(dir, "link.txt");
+        symlinkSync(benign, link);
+
+        mockIpcClassifyRiskResult = {
+          risk: "low",
+          reason: "benign",
+          matchType: "registry",
+          scopeOptions: [],
+        };
+        const first = await classifyRisk("file_read", { path: link });
+        expect(first.level).toBe(RiskLevel.Low);
+
+        // Retarget the symlink to a different real file; raw input unchanged.
+        unlinkSync(link);
+        symlinkSync(other, link);
+
+        mockIpcClassifyRiskResult = {
+          risk: "high",
+          reason: "now sensitive",
+          matchType: "registry",
+          scopeOptions: [],
+        };
+        const second = await classifyRisk("file_read", { path: link });
+        // Cache must have missed and re-classified against the new target.
+        expect(second.level).toBe(RiskLevel.High);
+        expect(second.reason).toBe("now sensitive");
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
     });
 
     test("preserves commandCandidates from gateway response", async () => {

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 import { getIsContainerized } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
@@ -16,6 +16,7 @@ import {
   looksLikePathOnlyInput,
 } from "../tools/network/url-safety.js";
 import { getTool, getToolOwner } from "../tools/registry.js";
+import { resolveRealPath } from "../tools/shared/filesystem/path-policy.js";
 import type { Tool } from "../tools/types.js";
 import {
   getDeprecatedDir,
@@ -273,17 +274,50 @@ import type {
 
 function buildFileContext(): FileContext {
   const config = getConfig();
+  // Canonicalize the protected directories via realpath so that a symlinked
+  // component anywhere in their path still prefix-matches the canonicalized
+  // target path computed in buildClassifyRiskParams. Both sides must be
+  // symlink-resolved for the gateway's lexical prefix checks to be sound.
+  const protectedDir = resolveRealPath(getProtectedDir());
   return {
-    protectedDir: getProtectedDir(),
-    deprecatedDir: getDeprecatedDir(),
-    hooksDir: getWorkspaceHooksDir(),
-    pluginsDir: getWorkspacePluginsDir(),
-    actorTokenSigningKeyPath: join(
-      getProtectedDir(),
-      "actor-token-signing-key",
+    protectedDir,
+    deprecatedDir: resolveRealPath(getDeprecatedDir()),
+    hooksDir: resolveRealPath(getWorkspaceHooksDir()),
+    pluginsDir: resolveRealPath(getWorkspacePluginsDir()),
+    actorTokenSigningKeyPath: join(protectedDir, "actor-token-signing-key"),
+    skillSourceDirs: getSkillRoots(config.skills.load.extraDirs).map(
+      resolveRealPath,
     ),
-    skillSourceDirs: getSkillRoots(config.skills.load.extraDirs),
   };
+}
+
+/**
+ * Canonicalize the security-sensitive path of a file tool invocation by
+ * resolving symlinks before it is sent to the gateway risk classifier.
+ *
+ * The gateway classifies file risk by lexically prefix-matching the target
+ * path against protected directories (skill source, hooks, plugins, the actor
+ * token signing key). Lexical resolution alone does not follow symlinks, so a
+ * symlink whose name looks benign but whose real target is a protected
+ * directory would be under-classified and could skip the High-risk approval
+ * prompt. Resolving symlinks here — on the daemon, which owns the workspace
+ * filesystem — closes that gap while keeping the gateway free of filesystem
+ * access (it cannot see the workspace in Docker mode).
+ *
+ * `resolveRealPath` falls back to the lexical path when the target lives on a
+ * filesystem this process cannot see (e.g. host_file paths proxied to a remote
+ * client), so this never regresses below today's lexical behavior.
+ */
+function resolveClassificationPath(
+  filePath: string,
+  workingDir: string,
+  isHostTool: boolean,
+): string | undefined {
+  if (!filePath) return undefined;
+  // Mirror the gateway classifier's lexical base: host tools resolve the path
+  // as absolute/relative-to-cwd; sandbox tools resolve against workingDir.
+  const base = isHostTool ? resolve(filePath) : resolve(workingDir, filePath);
+  return resolveRealPath(base);
 }
 
 function resolveSkillMetadata(selector: string): SkillMetadata | undefined {
@@ -361,10 +395,18 @@ function buildClassifyRiskParams(
     } else {
       filePath = getStringField(input, "path", "file_path");
     }
+    const effectiveWorkingDir = isHostTool
+      ? "/"
+      : (workingDir ?? process.cwd());
     return {
       tool: toolName,
       path: filePath,
-      workingDir: isHostTool ? "/" : (workingDir ?? process.cwd()),
+      resolvedPath: resolveClassificationPath(
+        filePath,
+        effectiveWorkingDir,
+        isHostTool,
+      ),
+      workingDir: effectiveWorkingDir,
       fileContext: buildFileContext(),
     };
   }

--- a/assistant/src/permissions/checker.ts
+++ b/assistant/src/permissions/checker.ts
@@ -102,6 +102,7 @@ function riskCacheKey(
   input: Record<string, unknown>,
   workingDir?: string,
   manifestOverride?: ManifestOverride,
+  fsStateKey?: string,
 ): string {
   // Strip `reason` and `activity` before computing the cache key — they are
   // cosmetic status text that varies per invocation even for identical tool
@@ -114,8 +115,29 @@ function riskCacheKey(
     .update(workingDir ?? "")
     .update("\0")
     .update(manifestOverride ? JSON.stringify(manifestOverride) : "")
+    // For file tools, fold in the symlink-resolved target path(s). File risk
+    // depends on filesystem state (a symlink can be retargeted under a
+    // protected dir between calls), so the same raw input must miss the cache
+    // when its canonicalized target changes.
+    .update("\0")
+    .update(fsStateKey ?? "")
     .digest("hex");
   return `${toolName}\0${hash}`;
+}
+
+/**
+ * Compute the filesystem-state component of the risk cache key for file tools:
+ * the symlink-resolved target path(s). Returns `undefined` for non-file tools
+ * (whose risk does not depend on filesystem state).
+ */
+function fileToolFsStateKey(
+  toolName: string,
+  input: Record<string, unknown>,
+  workingDir?: string,
+): string | undefined {
+  if (!FILE_TOOL_NAMES.has(toolName)) return undefined;
+  const resolved = resolveFileToolPaths(toolName, input, workingDir);
+  return `${resolved.resolvedPath ?? ""}\0${resolved.resolvedTransferDestPath ?? ""}`;
 }
 
 /** Clear the risk classification cache. Called when trust rules change. Exported for test setup. */
@@ -347,6 +369,85 @@ function resolveClassificationPath(
   return resolveRealPath(base);
 }
 
+const FILE_TOOL_NAMES = new Set([
+  "file_read",
+  "file_write",
+  "file_edit",
+  "host_file_read",
+  "host_file_write",
+  "host_file_edit",
+  "host_file_transfer",
+]);
+
+interface FileToolResolution {
+  filePath: string;
+  effectiveWorkingDir: string;
+  isHostTool: boolean;
+  resolvedPath?: string;
+  transferSandboxDestPath?: string;
+  transferSandboxWorkingDir?: string;
+  resolvedTransferDestPath?: string;
+}
+
+/**
+ * Resolve the security-sensitive path(s) of a file tool invocation, including
+ * symlink canonicalization. Shared by the IPC param builder and the risk cache
+ * key so both observe the same filesystem state — file risk now depends on
+ * symlink targets, so the cache must key on the canonicalized path, not just
+ * the raw tool input.
+ */
+function resolveFileToolPaths(
+  toolName: string,
+  input: Record<string, unknown>,
+  workingDir?: string,
+): FileToolResolution {
+  const isHostTool = toolName.startsWith("host_");
+  let filePath: string;
+  // For host_file_transfer to_sandbox, the file is written into the workspace
+  // at dest_path — capture it (plus the sandbox working dir) so the gateway can
+  // escalate writes that land in a code-injection sink, since `path` carries
+  // the host-side source.
+  let transferSandboxDestPath: string | undefined;
+  let transferSandboxWorkingDir: string | undefined;
+  if (toolName === "host_file_transfer") {
+    // The security-sensitive host-side path is source_path when reading from
+    // the host (to_sandbox), dest_path when writing to the host (to_host).
+    const direction = getStringField(input, "direction");
+    if (direction === "to_sandbox") {
+      filePath = getStringField(input, "source_path");
+      transferSandboxDestPath = getStringField(input, "dest_path");
+      transferSandboxWorkingDir = workingDir ?? process.cwd();
+    } else {
+      filePath = getStringField(input, "dest_path");
+    }
+  } else {
+    filePath = getStringField(input, "path", "file_path");
+  }
+  const effectiveWorkingDir = isHostTool ? "/" : (workingDir ?? process.cwd());
+  return {
+    filePath,
+    effectiveWorkingDir,
+    isHostTool,
+    resolvedPath: resolveClassificationPath(
+      filePath,
+      effectiveWorkingDir,
+      isHostTool,
+    ),
+    transferSandboxDestPath,
+    transferSandboxWorkingDir,
+    // The to_sandbox destination is a workspace write — symlink-resolve it too
+    // so it can't mask a code-injection sink.
+    resolvedTransferDestPath:
+      transferSandboxDestPath != null
+        ? resolveClassificationPath(
+            transferSandboxDestPath,
+            transferSandboxWorkingDir ?? process.cwd(),
+            false,
+          )
+        : undefined,
+  };
+}
+
 function resolveSkillMetadata(selector: string): SkillMetadata | undefined {
   const resolved = resolveSkillIdAndHash(selector);
   if (!resolved) return undefined;
@@ -408,54 +509,16 @@ function buildClassifyRiskParams(
       "host_file_transfer",
     ].includes(toolName)
   ) {
-    const isHostTool = toolName.startsWith("host_");
-    let filePath: string;
-    // For host_file_transfer to_sandbox, the file is written into the
-    // workspace at dest_path — forward it (plus the sandbox working dir) so the
-    // gateway can escalate writes that land in a code-injection sink, since
-    // `path` carries the host-side source.
-    let transferSandboxDestPath: string | undefined;
-    let transferSandboxWorkingDir: string | undefined;
-    if (toolName === "host_file_transfer") {
-      // For host_file_transfer the security-sensitive host-side path is
-      // source_path when reading from the host (to_sandbox), dest_path when
-      // writing to the host (to_host).
-      const direction = getStringField(input, "direction");
-      if (direction === "to_sandbox") {
-        filePath = getStringField(input, "source_path");
-        transferSandboxDestPath = getStringField(input, "dest_path");
-        transferSandboxWorkingDir = workingDir ?? process.cwd();
-      } else {
-        filePath = getStringField(input, "dest_path");
-      }
-    } else {
-      filePath = getStringField(input, "path", "file_path");
-    }
-    const effectiveWorkingDir = isHostTool
-      ? "/"
-      : (workingDir ?? process.cwd());
+    const resolved = resolveFileToolPaths(toolName, input, workingDir);
     return {
       tool: toolName,
-      path: filePath,
-      resolvedPath: resolveClassificationPath(
-        filePath,
-        effectiveWorkingDir,
-        isHostTool,
-      ),
-      workingDir: effectiveWorkingDir,
+      path: resolved.filePath,
+      resolvedPath: resolved.resolvedPath,
+      workingDir: resolved.effectiveWorkingDir,
       fileContext: buildFileContext(),
-      transferSandboxDestPath,
-      transferSandboxWorkingDir,
-      // The to_sandbox destination is a workspace write — symlink-resolve it
-      // too so it can't mask a code-injection sink.
-      resolvedTransferDestPath:
-        transferSandboxDestPath != null
-          ? resolveClassificationPath(
-              transferSandboxDestPath,
-              transferSandboxWorkingDir ?? process.cwd(),
-              false,
-            )
-          : undefined,
+      transferSandboxDestPath: resolved.transferSandboxDestPath,
+      transferSandboxWorkingDir: resolved.transferSandboxWorkingDir,
+      resolvedTransferDestPath: resolved.resolvedTransferDestPath,
     };
   }
 
@@ -538,7 +601,13 @@ export async function classifyRisk(
   signal?.throwIfAborted();
 
   // Check cache first.
-  const cacheKey = riskCacheKey(toolName, input, workingDir, manifestOverride);
+  const cacheKey = riskCacheKey(
+    toolName,
+    input,
+    workingDir,
+    manifestOverride,
+    fileToolFsStateKey(toolName, input, workingDir),
+  );
   const cached = riskCache.get(cacheKey);
   if (cached !== undefined) {
     // LRU refresh

--- a/assistant/src/permissions/ipc-risk-types.ts
+++ b/assistant/src/permissions/ipc-risk-types.ts
@@ -81,6 +81,13 @@ export interface ClassifyRiskParams {
   command?: string;
   url?: string;
   path?: string;
+  /**
+   * The file tool's target path with symlinks resolved (canonicalized by the
+   * daemon, which owns the workspace filesystem). The gateway uses this for its
+   * security escalation prefix checks so a symlink cannot mask a write into a
+   * protected directory. Falls back to lexical `path` resolution when absent.
+   */
+  resolvedPath?: string;
   skill?: string;
   mode?: string;
   script?: string;

--- a/assistant/src/tools/shared/filesystem/path-policy.ts
+++ b/assistant/src/tools/shared/filesystem/path-policy.ts
@@ -32,6 +32,40 @@ const CONTAINER_WORKSPACE_PREFIX = "/workspace/";
 const CONTAINER_WORKSPACE_EXACT = "/workspace";
 
 // ---------------------------------------------------------------------------
+// Symlink resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve symlinks in an absolute path.
+ *
+ * For an existing path, returns its `realpathSync`. For a path that does not
+ * exist yet (e.g. a `file_write` target), walks up to the nearest existing
+ * ancestor, resolves that ancestor via `realpathSync`, then re-appends the
+ * trailing (non-existent) components — so a symlink anywhere in the existing
+ * prefix is still followed. Falls back to the lexical input when nothing on
+ * the path resolves (e.g. the path lives on a filesystem this process cannot
+ * see, as with host_file paths proxied to a remote client).
+ *
+ * Used both for sandbox-boundary enforcement and to canonicalize paths before
+ * security risk classification, so a symlink cannot mask the true target of a
+ * file operation.
+ */
+export function resolveRealPath(absolutePath: string): string {
+  let current = absolutePath;
+  const trailing: string[] = [];
+  while (current !== dirname(current)) {
+    try {
+      const real = realpathSync(current);
+      return trailing.length > 0 ? join(real, ...trailing) : real;
+    } catch {
+      trailing.unshift(basename(current));
+      current = dirname(current);
+    }
+  }
+  return absolutePath;
+}
+
+// ---------------------------------------------------------------------------
 // Sandbox policy
 // ---------------------------------------------------------------------------
 
@@ -82,18 +116,7 @@ export function sandboxPolicy(
       realResolved = resolved;
     }
   } else {
-    let current = resolved;
-    const trailing: string[] = [];
-    while (current !== dirname(current)) {
-      try {
-        const real = realpathSync(current);
-        realResolved = trailing.length > 0 ? join(real, ...trailing) : real;
-        break;
-      } catch {
-        trailing.unshift(basename(current));
-        current = dirname(current);
-      }
-    }
+    realResolved = resolveRealPath(resolved);
   }
 
   // Resolve the boundary directory's real path too (in case it's a symlink)
@@ -115,7 +138,10 @@ export function sandboxPolicy(
 
   // Check both the logical path and the symlink-resolved path so a symlink
   // with a non-denied name pointing at a denied file is still caught.
-  if (DENIED_BASENAMES.has(basename(resolved)) || DENIED_BASENAMES.has(basename(realResolved))) {
+  if (
+    DENIED_BASENAMES.has(basename(resolved)) ||
+    DENIED_BASENAMES.has(basename(realResolved))
+  ) {
     return {
       ok: false,
       reason: "denied",

--- a/gateway/src/ipc/risk-classification-handlers.ts
+++ b/gateway/src/ipc/risk-classification-handlers.ts
@@ -42,6 +42,10 @@ const ClassifyRiskSchema = z.object({
   command: z.string().optional(),
   url: z.string().optional(),
   path: z.string().optional(),
+  // Symlink-resolved target path for file tools, canonicalized by the daemon.
+  // Used for security escalation checks so a symlink cannot mask the real
+  // target. Falls back to lexical resolution of `path` when absent.
+  resolvedPath: z.string().optional(),
   skill: z.string().optional(),
   mode: z.string().optional(),
   script: z.string().optional(),
@@ -433,7 +437,12 @@ export async function handleClassifyRisk(
       };
 
       const assessment = await fileRiskClassifier.classify(
-        { toolName: tool, filePath, workingDir },
+        {
+          toolName: tool,
+          filePath,
+          workingDir,
+          resolvedPath: params.resolvedPath,
+        },
         context,
       );
 

--- a/gateway/src/risk/file-risk-classifier.test.ts
+++ b/gateway/src/risk/file-risk-classifier.test.ts
@@ -50,6 +50,7 @@ function classifyInput(
       filePath: input.filePath ?? "",
       workingDir: input.workingDir ?? WORKING_DIR,
       toolName: input.toolName,
+      resolvedPath: input.resolvedPath,
     },
     makeContext(),
   );
@@ -563,6 +564,110 @@ describe("FileRiskClassifier", () => {
       });
       expect(result.riskLevel).toBe("high");
       expect(result.reason).toBe("Transfers to plugins directory");
+    });
+  });
+
+  // -- Symlink resolution (resolvedPath) --------------------------------------
+  //
+  // The classifier escalates risk by lexically prefix-matching the target path
+  // against protected directories. Lexical resolution does not follow symlinks,
+  // so a symlink whose name looks benign but whose real target is a protected
+  // directory would be under-classified. The daemon canonicalizes the target
+  // with realpath and forwards it as `resolvedPath`; the classifier escalates
+  // on that resolved path instead of the lexical one.
+  describe("symlink resolution via resolvedPath", () => {
+    test("file_write escalates when resolvedPath lands in hooks dir", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_write",
+        // Benign-looking name in the workspace…
+        filePath: "notes.txt",
+        workingDir: WORKING_DIR,
+        // …but it is a symlink whose real target is inside the hooks dir.
+        resolvedPath: join(MOCK_HOOKS_DIR, "pre-tool-use.sh"),
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to hooks directory");
+    });
+
+    test("file_write escalates when resolvedPath lands in plugins dir", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: "innocent.json",
+        workingDir: WORKING_DIR,
+        resolvedPath: join(MOCK_PLUGINS_DIR, "evil-plugin", "register.ts"),
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to plugins directory");
+    });
+
+    test("file_edit escalates when resolvedPath lands in skill source", async () => {
+      const skillDir = "/home/user/skills/victim-skill";
+      testSkillSourceDirs = [skillDir];
+      const result = await classifyInput({
+        toolName: "file_edit",
+        filePath: "scratch.ts",
+        workingDir: WORKING_DIR,
+        resolvedPath: join(skillDir, "index.ts"),
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to skill source code");
+      testSkillSourceDirs = [];
+    });
+
+    test("file_read escalates when resolvedPath is the signing key", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_read",
+        filePath: "harmless.txt",
+        workingDir: WORKING_DIR,
+        resolvedPath: join(MOCK_PROTECTED_DIR, "actor-token-signing-key"),
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Reads actor token signing key");
+    });
+
+    test("host_file_write escalates when resolvedPath lands in hooks dir", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "host_file_write",
+        filePath: "/tmp/notes.txt",
+        resolvedPath: join(MOCK_HOOKS_DIR, "pre-tool-use.sh"),
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to hooks directory");
+    });
+
+    test("resolvedPath takes precedence over a benign lexical path", async () => {
+      // Without resolvedPath this same lexical path would be low; the resolved
+      // path is what drives escalation.
+      testSkillSourceDirs = [];
+      const benign = await classifyInput({
+        toolName: "file_write",
+        filePath: "notes.txt",
+        workingDir: WORKING_DIR,
+      });
+      expect(benign.riskLevel).toBe("low");
+
+      const escalated = await classifyInput({
+        toolName: "file_write",
+        filePath: "notes.txt",
+        workingDir: WORKING_DIR,
+        resolvedPath: join(MOCK_HOOKS_DIR, "evil.sh"),
+      });
+      expect(escalated.riskLevel).toBe("high");
+    });
+
+    test("a benign resolvedPath does not escalate", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: "notes.txt",
+        workingDir: WORKING_DIR,
+        resolvedPath: "/home/user/project/notes.txt",
+      });
+      expect(result.riskLevel).toBe("low");
     });
   });
 

--- a/gateway/src/risk/file-risk-classifier.test.ts
+++ b/gateway/src/risk/file-risk-classifier.test.ts
@@ -904,6 +904,45 @@ describe("FileRiskClassifier", () => {
       });
       expect(result.riskLevel).toBe("low");
     });
+
+    // Reverse symlink: the path is lexically INSIDE a protected dir but its
+    // real target is outside. The loader still executes the file through the
+    // protected location, so escalation must fire on the lexical path even
+    // though resolvedPath points elsewhere (union of lexical + real).
+    test("file_write escalates when lexical path is in hooks dir but resolvedPath points out", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_write",
+        filePath: join(MOCK_HOOKS_DIR, "pre-tool-use.sh"),
+        workingDir: "/",
+        resolvedPath: "/tmp/elsewhere.sh",
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to hooks directory");
+    });
+
+    test("file_read escalates when lexical path is the signing key but resolvedPath points out", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "file_read",
+        filePath: join(MOCK_PROTECTED_DIR, "actor-token-signing-key"),
+        workingDir: "/",
+        resolvedPath: "/tmp/elsewhere",
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Reads actor token signing key");
+    });
+
+    test("host_file_write escalates when lexical path is in plugins dir but resolvedPath points out", async () => {
+      testSkillSourceDirs = [];
+      const result = await classifyInput({
+        toolName: "host_file_write",
+        filePath: join(MOCK_PLUGINS_DIR, "evil", "register.ts"),
+        resolvedPath: "/tmp/elsewhere.ts",
+      });
+      expect(result.riskLevel).toBe("high");
+      expect(result.reason).toBe("Writes to plugins directory");
+    });
   });
 
   // -- Singleton export -------------------------------------------------------

--- a/gateway/src/risk/file-risk-classifier.ts
+++ b/gateway/src/risk/file-risk-classifier.ts
@@ -77,6 +77,16 @@ export interface FileClassifierInput {
     | "host_file_transfer";
   filePath: string;
   workingDir: string;
+  /**
+   * The target path with symlinks resolved, canonicalized by the caller (the
+   * daemon, which owns the workspace filesystem). When present, this is used
+   * for the security escalation prefix checks instead of a lexical
+   * resolve(workingDir, filePath) — so a symlink whose name looks benign but
+   * whose real target is a protected directory is still escalated. When absent
+   * (e.g. caller could not access the filesystem), classification falls back to
+   * lexical resolution.
+   */
+  resolvedPath?: string;
 }
 
 // -- Helpers ------------------------------------------------------------------
@@ -246,7 +256,7 @@ export class FileRiskClassifier implements RiskClassifier<
     input: FileClassifierInput,
     context: FileClassificationContext,
   ): Promise<RiskAssessment> {
-    const { toolName, filePath, workingDir } = input;
+    const { toolName, filePath, workingDir, resolvedPath } = input;
     const allowlistOptions = filePath
       ? buildFileAllowlistOptions(toolName, filePath)
       : [];
@@ -258,8 +268,8 @@ export class FileRiskClassifier implements RiskClassifier<
     switch (toolName) {
       case "file_read": {
         if (filePath) {
-          const resolvedPath = resolve(workingDir, filePath);
-          if (isActorTokenSigningKeyPath(resolvedPath, workingDir, context)) {
+          const escalationPath = resolvedPath ?? resolve(workingDir, filePath);
+          if (isActorTokenSigningKeyPath(escalationPath, workingDir, context)) {
             assessment = {
               riskLevel: "high",
               reason: "Reads actor token signing key",
@@ -283,8 +293,8 @@ export class FileRiskClassifier implements RiskClassifier<
       case "file_write":
       case "file_edit": {
         if (filePath) {
-          const resolvedPath = resolve(workingDir, filePath);
-          if (isSkillSourcePath(resolvedPath, context)) {
+          const escalationPath = resolvedPath ?? resolve(workingDir, filePath);
+          if (isSkillSourcePath(escalationPath, context)) {
             assessment = {
               riskLevel: "high",
               reason: "Writes to skill source code",
@@ -294,7 +304,7 @@ export class FileRiskClassifier implements RiskClassifier<
             };
             break;
           }
-          if (isHooksPath(resolvedPath, context)) {
+          if (isHooksPath(escalationPath, context)) {
             assessment = {
               riskLevel: "high",
               reason: "Writes to hooks directory",
@@ -304,7 +314,7 @@ export class FileRiskClassifier implements RiskClassifier<
             };
             break;
           }
-          if (isPluginsPath(resolvedPath, context)) {
+          if (isPluginsPath(escalationPath, context)) {
             assessment = {
               riskLevel: "high",
               reason: "Writes to plugins directory",
@@ -347,9 +357,10 @@ export class FileRiskClassifier implements RiskClassifier<
           toolName === "host_file_transfer" ? "Transfers" : "Writes";
         if (filePath) {
           // Host file tools resolve paths without workingDir — resolve(filePath)
-          // treats the path as absolute or relative to cwd.
-          const resolvedPath = resolve(filePath);
-          if (isSkillSourcePath(resolvedPath, context)) {
+          // treats the path as absolute or relative to cwd. Prefer the
+          // symlink-resolved path from the caller when available.
+          const escalationPath = resolvedPath ?? resolve(filePath);
+          if (isSkillSourcePath(escalationPath, context)) {
             assessment = {
               riskLevel: "high",
               reason: `${actionVerb} to skill source code`,
@@ -359,7 +370,7 @@ export class FileRiskClassifier implements RiskClassifier<
             };
             break;
           }
-          if (isHooksPath(resolvedPath, context)) {
+          if (isHooksPath(escalationPath, context)) {
             assessment = {
               riskLevel: "high",
               reason: `${actionVerb} to hooks directory`,
@@ -369,7 +380,7 @@ export class FileRiskClassifier implements RiskClassifier<
             };
             break;
           }
-          if (isPluginsPath(resolvedPath, context)) {
+          if (isPluginsPath(escalationPath, context)) {
             assessment = {
               riskLevel: "high",
               reason: `${actionVerb} to plugins directory`,

--- a/gateway/src/risk/file-risk-classifier.ts
+++ b/gateway/src/risk/file-risk-classifier.ts
@@ -371,6 +371,33 @@ function classifyCodeInjectionSink(
   return null;
 }
 
+/**
+ * Run {@link classifyCodeInjectionSink} against both the lexical and the
+ * symlink-resolved path, escalating if EITHER lands in a sink. A symlink can
+ * mask a protected target two ways — a benign name pointing into a protected
+ * dir (caught by the real path), or a path lexically inside a protected dir
+ * pointing elsewhere, where the loader still executes the file through the
+ * protected location (caught by the lexical path). When the two paths are
+ * equal the check runs once.
+ */
+function classifyCodeInjectionSinkEither(
+  lexicalPath: string,
+  realPath: string,
+  context: FileClassificationContext,
+  verb: "Writes" | "Transfers",
+  allowlistOptions: AllowlistOption[],
+): RiskAssessment | null {
+  const lexicalSink = classifyCodeInjectionSink(
+    lexicalPath,
+    context,
+    verb,
+    allowlistOptions,
+  );
+  if (lexicalSink) return lexicalSink;
+  if (realPath === lexicalPath) return null;
+  return classifyCodeInjectionSink(realPath, context, verb, allowlistOptions);
+}
+
 // -- Classifier ---------------------------------------------------------------
 
 /**
@@ -411,9 +438,18 @@ export class FileRiskClassifier implements RiskClassifier<
     switch (toolName) {
       case "file_read": {
         if (filePath) {
-          const escalationPath =
-            resolvedPath ?? resolveSandboxPath(filePath, workingDir);
-          if (isActorTokenSigningKeyPath(escalationPath, workingDir, context)) {
+          // Check BOTH the lexical path and the symlink-resolved path. A
+          // symlink can mask a protected target two ways: a benign-looking
+          // name that points into a protected dir (caught by the real path),
+          // or a path lexically inside a protected dir that points elsewhere
+          // (caught by the lexical path — the loader still reads it through the
+          // protected location). Escalate if either matches.
+          const lexicalPath = resolveSandboxPath(filePath, workingDir);
+          const realPath = resolvedPath ?? lexicalPath;
+          if (
+            isActorTokenSigningKeyPath(lexicalPath, workingDir, context) ||
+            isActorTokenSigningKeyPath(realPath, workingDir, context)
+          ) {
             assessment = {
               riskLevel: "high",
               reason: "Reads actor token signing key",
@@ -437,10 +473,11 @@ export class FileRiskClassifier implements RiskClassifier<
       case "file_write":
       case "file_edit": {
         if (filePath) {
-          const escalationPath =
-            resolvedPath ?? resolveSandboxPath(filePath, workingDir);
-          const sink = classifyCodeInjectionSink(
-            escalationPath,
+          const lexicalPath = resolveSandboxPath(filePath, workingDir);
+          const realPath = resolvedPath ?? lexicalPath;
+          const sink = classifyCodeInjectionSinkEither(
+            lexicalPath,
+            realPath,
             context,
             "Writes",
             allowlistOptions,
@@ -486,14 +523,14 @@ export class FileRiskClassifier implements RiskClassifier<
         // source in `filePath` — is the code-injection sink. Check it first,
         // resolving with the same /workspace remap as sandbox file writes.
         if (transferSandboxDestPath) {
-          const destResolved =
-            resolvedTransferDestPath ??
-            resolveSandboxPath(
-              transferSandboxDestPath,
-              transferSandboxWorkingDir ?? process.cwd(),
-            );
-          const destSink = classifyCodeInjectionSink(
-            destResolved,
+          const lexicalDest = resolveSandboxPath(
+            transferSandboxDestPath,
+            transferSandboxWorkingDir ?? process.cwd(),
+          );
+          const realDest = resolvedTransferDestPath ?? lexicalDest;
+          const destSink = classifyCodeInjectionSinkEither(
+            lexicalDest,
+            realDest,
             context,
             "Transfers",
             allowlistOptions,
@@ -506,11 +543,13 @@ export class FileRiskClassifier implements RiskClassifier<
 
         if (filePath) {
           // Host file tools resolve paths without workingDir — resolve(filePath)
-          // treats the path as absolute or relative to cwd. Prefer the
-          // symlink-resolved path from the caller when available.
-          const escalationPath = resolvedPath ?? resolve(filePath);
-          const sink = classifyCodeInjectionSink(
-            escalationPath,
+          // treats the path as absolute or relative to cwd. Check both the
+          // lexical path and the symlink-resolved path from the caller.
+          const lexicalPath = resolve(filePath);
+          const realPath = resolvedPath ?? lexicalPath;
+          const sink = classifyCodeInjectionSinkEither(
+            lexicalPath,
+            realPath,
             context,
             actionVerb,
             allowlistOptions,


### PR DESCRIPTION
## Summary

Fixes **ATL-872** — the file risk classifier resolved paths lexically, so a symlink could mask a write into a protected directory and skip the High-risk approval prompt.

The gateway's `FileRiskClassifier` escalates risk by lexically prefix-matching a file tool's target path against protected directories: skill source code, the workspace hooks dir, the user plugins dir, and the actor token signing key. `node:path`'s `resolve()` only normalizes `.`/`..` — **it does not follow symlinks**. So a symlink whose name looks benign but whose real target is a protected directory was under-classified (e.g. Medium instead of High), and the subsequent file write would follow the symlink into the protected location — achieving code injection (hooks/plugins/skill source executed at next load) or signing-key tampering without the approval prompt the escalation exists to force.

Host file tools (`host_file_write`/`edit`/`transfer`) were the most exposed: their `hostPolicy` has no symlink defense or boundary at all, so lexical classification was the only gate.

## Approach

The gateway has **no filesystem access in Docker mode** (it can't see the workspace), so symlink canonicalization must happen on the daemon, which owns the workspace filesystem:

- **Extract `resolveRealPath()`** in `path-policy.ts` — the nearest-existing-ancestor realpath logic already used inline by `sandboxPolicy` (so not-yet-created `file_write` targets still get symlinked ancestors resolved) — and export it.
- **Daemon permission checker** (`checker.ts`): canonicalize the file tool's target path and the protected directories via realpath before sending them to the gateway, forwarding the resolved path as a new `resolvedPath` IPC field.
- **Gateway classifier**: use `resolvedPath` for its escalation prefix checks when present; fall back to lexical resolution otherwise.

`resolveRealPath` falls back to the lexical path when the target lives on a filesystem the daemon can't see (e.g. `host_file` paths proxied to a remote macOS client), so **there is no regression below today's behavior**.

### Known limitation / follow-up

For `host_file_*` in managed mode with a remote host client, the file lives on the user's Mac, which the cloud daemon can't realpath — so canonicalization falls back to lexical there (same as today). Fully closing that path would require resolving symlinks on the host-proxy side; tracked as follow-up. The local/laptop `host_file` path **is** covered.

## Tests

- `gateway/src/risk/file-risk-classifier.test.ts`: new `symlink resolution via resolvedPath` block — escalation via `resolvedPath` into hooks/plugins/skill-source/signing-key for sandbox and host tools, precedence over a benign lexical path, and no false-positive on a benign resolved path.
- `assistant/src/__tests__/path-policy.test.ts`: `resolveRealPath` unit tests (existing-file symlink, symlinked ancestor for a non-existent leaf, lexical fallback).

All affected suites pass; both packages typecheck clean; lint/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vo8URLPw9C3AbgStrZkjHF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vo8URLPw9C3AbgStrZkjHF)_