### PR TITLE
feat(platform): add consent cache with synchronous accessor

### DIFF
--- a/assistant/src/platform/consent-cache.test.ts
+++ b/assistant/src/platform/consent-cache.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { OwnerConsent } from "./client.js";
+
+// ---------------------------------------------------------------------------
+// Mutable mock state
+// ---------------------------------------------------------------------------
+
+let mockClient: { getOwnerConsent: () => Promise<OwnerConsent | null> } | null =
+  null;
+let createCallCount = 0;
+
+// ---------------------------------------------------------------------------
+// Module mocks (must precede the import under test)
+// ---------------------------------------------------------------------------
+
+mock.module("./client.js", () => ({
+  VellumPlatformClient: {
+    create: async () => {
+      createCallCount += 1;
+      return mockClient;
+    },
+  },
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test (after mocks)
+// ---------------------------------------------------------------------------
+
+import {
+  __setCachedShareAnalyticsForTest,
+  getCachedShareAnalytics,
+  refreshConsentCache,
+  startConsentRefresh,
+  stopConsentRefresh,
+} from "./consent-cache.js";
+
+function makeClient(consent: OwnerConsent | null) {
+  return { getOwnerConsent: async () => consent };
+}
+
+describe("consent-cache", () => {
+  beforeEach(() => {
+    mockClient = null;
+    createCallCount = 0;
+    __setCachedShareAnalyticsForTest(false);
+  });
+
+  afterEach(async () => {
+    await stopConsentRefresh();
+  });
+
+  test("defaults to false before any refresh", () => {
+    expect(getCachedShareAnalytics()).toBe(false);
+  });
+
+  test("stays false when no platform client is available", async () => {
+    mockClient = null;
+    await refreshConsentCache();
+    expect(getCachedShareAnalytics()).toBe(false);
+  });
+
+  test("becomes true after a successful fetch reporting shareAnalytics: true", async () => {
+    mockClient = makeClient({ shareAnalytics: true, shareDiagnostics: false });
+    await refreshConsentCache();
+    expect(getCachedShareAnalytics()).toBe(true);
+  });
+
+  test("a null fetch keeps the last known value", async () => {
+    mockClient = makeClient({ shareAnalytics: true, shareDiagnostics: false });
+    await refreshConsentCache();
+    expect(getCachedShareAnalytics()).toBe(true);
+
+    // Transient failure: consent endpoint returns null.
+    mockClient = makeClient(null);
+    await refreshConsentCache();
+    expect(getCachedShareAnalytics()).toBe(true);
+  });
+
+  test("a missing client flips a prior opt-in back to false", async () => {
+    __setCachedShareAnalyticsForTest(true);
+    mockClient = null;
+    await refreshConsentCache();
+    expect(getCachedShareAnalytics()).toBe(false);
+  });
+
+  test("a fetch reporting shareAnalytics: false turns the cache off", async () => {
+    __setCachedShareAnalyticsForTest(true);
+    mockClient = makeClient({ shareAnalytics: false, shareDiagnostics: true });
+    await refreshConsentCache();
+    expect(getCachedShareAnalytics()).toBe(false);
+  });
+
+  test("startConsentRefresh is idempotent and runs an immediate refresh", async () => {
+    mockClient = makeClient({ shareAnalytics: true, shareDiagnostics: false });
+
+    startConsentRefresh();
+    startConsentRefresh(); // no-op: timer already running
+    // Let the fire-and-forget immediate refresh settle.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(getCachedShareAnalytics()).toBe(true);
+    // One immediate refresh from the first call; the second is a no-op.
+    expect(createCallCount).toBe(1);
+  });
+
+  test("stopConsentRefresh clears the timer (start can run again)", async () => {
+    startConsentRefresh();
+    await stopConsentRefresh();
+    // A fresh start after stop performs another immediate refresh.
+    mockClient = makeClient({ shareAnalytics: true, shareDiagnostics: false });
+    startConsentRefresh();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(getCachedShareAnalytics()).toBe(true);
+  });
+});

--- a/assistant/src/platform/consent-cache.ts
+++ b/assistant/src/platform/consent-cache.ts
@@ -1,0 +1,90 @@
+/**
+ * In-memory cache of the platform owner's `share_analytics` consent.
+ *
+ * Record-time telemetry gates need a synchronous, I/O-free read, so this module
+ * owns the consent value and refreshes it periodically in the background.
+ * Default-off until the first successful fetch: an absent session, a disabled
+ * platform, or a transient fetch failure all leave the value untouched (initial
+ * `false`), so we never report analytics without a confirmed opt-in.
+ */
+
+import { getLogger } from "../util/logger.js";
+import { VellumPlatformClient } from "./client.js";
+
+const log = getLogger("consent-cache");
+
+const REFRESH_INTERVAL_MS = 5 * 60_000; // refresh consent every 5 min
+
+let cachedShareAnalytics = false; // default-off until first success
+let refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Synchronous hot-path accessor for the cached `share_analytics` consent.
+ * Never does I/O; returns `false` until a successful refresh proves otherwise.
+ */
+export function getCachedShareAnalytics(): boolean {
+  return cachedShareAnalytics;
+}
+
+/**
+ * Refresh the cached consent from the platform.
+ *
+ * No platform session / features disabled (`create()` is null) → default-off.
+ * A successful fetch adopts the reported value. A `null` fetch (transient
+ * failure / undeployed endpoint) leaves the previous value unchanged so a known
+ * opt-in is not flipped off mid-session.
+ */
+export async function refreshConsentCache(): Promise<void> {
+  const client = await VellumPlatformClient.create();
+  if (!client) {
+    setCachedShareAnalytics(false);
+    return;
+  }
+
+  const consent = await client.getOwnerConsent();
+  if (consent) {
+    setCachedShareAnalytics(consent.shareAnalytics);
+  }
+}
+
+function setCachedShareAnalytics(value: boolean): void {
+  if (value !== cachedShareAnalytics) {
+    log.debug(
+      { from: cachedShareAnalytics, to: value },
+      "share_analytics consent changed",
+    );
+    cachedShareAnalytics = value;
+  }
+}
+
+/**
+ * Begin periodic consent refresh. Idempotent — a second call is a no-op while a
+ * timer is already running. Runs one immediate refresh, then every 5 minutes.
+ */
+export function startConsentRefresh(): void {
+  if (refreshTimer) {
+    return;
+  }
+
+  refreshConsentCache().catch((err) => {
+    log.debug({ err }, "initial consent refresh failed");
+  });
+  refreshTimer = setInterval(() => {
+    refreshConsentCache().catch((err) => {
+      log.debug({ err }, "consent refresh failed");
+    });
+  }, REFRESH_INTERVAL_MS);
+}
+
+/** Stop periodic consent refresh and clear the timer. */
+export async function stopConsentRefresh(): Promise<void> {
+  if (refreshTimer) {
+    clearInterval(refreshTimer);
+    refreshTimer = null;
+  }
+}
+
+/** Test-only: override the cached value without going through a refresh. */
+export function __setCachedShareAnalyticsForTest(value: boolean): void {
+  cachedShareAnalytics = value;
+}


### PR DESCRIPTION
## Summary
- Add `consent-cache.ts`: in-memory `share_analytics` consent cache, default-off until first successful fetch
- `getCachedShareAnalytics()` synchronous hot-path accessor; `startConsentRefresh()`/`stopConsentRefresh()` manage a 5-min refresh timer
- Transient fetch failures keep the last known value; no platform session keeps it off

Part of plan: telemetry-consent-gating.md (PR 2 of 6)