### PR TITLE
fix(acp): cancel in-flight ACP sessions on parent cancel; tighten abort watchdog to 5s

### DIFF
--- a/assistant/src/acp/__tests__/session-manager.test.ts
+++ b/assistant/src/acp/__tests__/session-manager.test.ts
@@ -8,6 +8,10 @@ import { describe, expect, mock, test } from "bun:test";
 
 import type { AcpSessionState } from "../types.js";
 
+// Records every `cancel(protocolSessionId)` the manager dispatches to a fake
+// process, so tests can assert which sessions were cancelled.
+const cancelCalls: string[] = [];
+
 // Stub the agent-process module so spawn() does not actually launch a child
 // process. Each fake instance records the cwd it was spawned in and resolves
 // every protocol method synchronously. The mock is process-global (Bun's
@@ -30,7 +34,9 @@ mock.module("../agent-process.js", () => ({
       // the duration of the test so cleanup logic doesn't tear it down.
       return new Promise(() => {});
     }
-    async cancel(): Promise<void> {}
+    async cancel(sessionId: string): Promise<void> {
+      cancelCalls.push(sessionId);
+    }
     kill(): void {}
   },
 }));
@@ -79,5 +85,70 @@ describe("AcpSessionManager — parentConversationId population", () => {
     const states = manager.getStatus() as AcpSessionState[];
     const parents = states.map((s) => s.parentConversationId).sort();
     expect(parents).toEqual(["conv-parent-1", "conv-parent-2"]);
+  });
+});
+
+describe("AcpSessionManager — cancelForParent", () => {
+  const noopSend = () => {};
+
+  test("cancels only the sessions spawned by the given parent", async () => {
+    cancelCalls.length = 0;
+    const manager = new AcpSessionManager(5);
+
+    const a1 = await manager.spawn(
+      "agent-a1",
+      { command: "echo", args: ["hi"] },
+      "task",
+      "/tmp",
+      "parent-A",
+      noopSend,
+    );
+    const a2 = await manager.spawn(
+      "agent-a2",
+      { command: "echo", args: ["hi"] },
+      "task",
+      "/tmp",
+      "parent-A",
+      noopSend,
+    );
+    const b1 = await manager.spawn(
+      "agent-b1",
+      { command: "echo", args: ["hi"] },
+      "task",
+      "/tmp",
+      "parent-B",
+      noopSend,
+    );
+
+    // WHEN parent-A is cancelled
+    const count = manager.cancelForParent("parent-A");
+
+    // THEN it reports the two parent-A sessions and leaves parent-B alone
+    expect(count).toBe(2);
+
+    // Let the detached per-session cancels settle (each awaits a protocol
+    // notification before flipping status).
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect((manager.getStatus(a1.acpSessionId) as AcpSessionState).status).toBe(
+      "cancelled",
+    );
+    expect((manager.getStatus(a2.acpSessionId) as AcpSessionState).status).toBe(
+      "cancelled",
+    );
+    expect((manager.getStatus(b1.acpSessionId) as AcpSessionState).status).toBe(
+      "running",
+    );
+
+    // AND the cancel reached each parent-A agent process exactly once.
+    expect(cancelCalls.sort()).toEqual(["proto-agent-a1", "proto-agent-a2"]);
+  });
+
+  test("returns 0 and dispatches nothing when the parent has no sessions", () => {
+    cancelCalls.length = 0;
+    const manager = new AcpSessionManager(5);
+
+    expect(manager.cancelForParent("parent-with-nothing")).toBe(0);
+    expect(cancelCalls).toEqual([]);
   });
 });

--- a/assistant/src/acp/index.ts
+++ b/assistant/src/acp/index.ts
@@ -19,6 +19,16 @@ export function getAcpSessionManager(): AcpSessionManager {
 }
 
 /**
+ * Returns the existing AcpSessionManager singleton, or null when none has been
+ * created yet. Use this on cleanup hot paths (e.g. cancelling a conversation)
+ * that must not spin up a manager just to discover there are no sessions to
+ * act on.
+ */
+export function peekAcpSessionManager(): AcpSessionManager | null {
+  return manager;
+}
+
+/**
  * Disposes the singleton AcpSessionManager and nulls the reference.
  */
 export function disposeAcpSessionManager(): void {

--- a/assistant/src/acp/session-manager.ts
+++ b/assistant/src/acp/session-manager.ts
@@ -692,6 +692,41 @@ export class AcpSessionManager {
   }
 
   /**
+   * Cancels every in-flight session spawned by `parentConversationId`.
+   *
+   * Mirrors the subagent manager's `abortAllForParent`: when the user cancels
+   * a turn, the ACP agents it launched should stop rather than keep running in
+   * the background — holding a child process — and then, on completion, enqueue
+   * a follow-up message into the conversation the user just stopped. Cancelling
+   * settles each in-flight prompt down its `"cancelled"` path, which sends a
+   * client event but does NOT notify the parent, so no model activity follows
+   * the stop.
+   *
+   * Each session's `cancel()` runs detached (it awaits a protocol notification
+   * to the child) so callers on the cancel hot path never block on an
+   * unresponsive agent; failures are logged. Session ids are snapshotted before
+   * dispatch so concurrent teardown can't disturb the iteration. Returns the
+   * number of sessions a cancel was kicked off for.
+   */
+  cancelForParent(parentConversationId: string): number {
+    const ids: string[] = [];
+    for (const [acpSessionId, entry] of this.sessions) {
+      if (entry.parentConversationId === parentConversationId) {
+        ids.push(acpSessionId);
+      }
+    }
+    for (const acpSessionId of ids) {
+      void this.cancel(acpSessionId).catch((err) => {
+        log.warn(
+          { acpSessionId, parentConversationId, err },
+          "Failed to cancel ACP session on parent cancel",
+        );
+      });
+    }
+    return ids.length;
+  }
+
+  /**
    * Kills the agent process and removes the session from tracking.
    *
    * Persists the buffered event log first so abort paths

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -190,8 +190,8 @@ export interface AssistantSurface {
 // ── abort watchdog ───────────────────────────────────────────────────
 
 /**
- * Generous backstop that drives an aborted turn to its `finally` even if some
- * awaited operation fails to observe the abort signal.
+ * Backstop that drives an aborted turn to its `finally` even if some awaited
+ * operation fails to observe the abort signal.
  *
  * Abort is otherwise cooperative and already wired into the slow paths: the
  * provider call forwards the signal to its HTTP/streaming fetch, and tool
@@ -199,10 +199,11 @@ export interface AssistantSurface {
  * watchdog only fires when a future code path silently ignores abort — without
  * it, such a path would hang the loop forever and latch the conversation's
  * `processing` flag true (the wedged "Thinking…" indicator). It is
- * defense-in-depth, not the primary mechanism, so the timeout is deliberately
- * generous; in the common case abort settles in-flight work well before it.
+ * defense-in-depth, not the primary mechanism: in the common case abort settles
+ * in-flight work in well under a second, so a few seconds is ample headroom for
+ * a cooperative unwind while still releasing a genuinely wedged turn promptly.
  */
-const ABORT_WATCHDOG_MS = 45_000;
+const ABORT_WATCHDOG_MS = 5_000;
 
 /**
  * Race `work` against an abort watchdog. The watchdog stays disarmed until the

--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -1,5 +1,6 @@
 import { v4 as uuid } from "uuid";
 
+import { peekAcpSessionManager } from "../../acp/index.js";
 import { clearAll, getConversation } from "../../memory/conversation-crud.js";
 import { resolveConversationId } from "../../memory/conversation-key-store.js";
 import { broadcastMessage } from "../../runtime/assistant-event-hub.js";
@@ -106,6 +107,12 @@ export function cancelGeneration(conversationId: string): boolean {
   // being cancelled, so enqueuing synthetic messages would trigger
   // unwanted model activity after the user pressed stop.
   getSubagentManager().abortAllForParent(conversationId);
+  // Cancel any in-flight ACP agent sessions this conversation spawned, for the
+  // same reason: a backgrounded ACP prompt would otherwise keep running (and
+  // holding a child process) past the stop and, on completion, enqueue a
+  // follow-up message back into the conversation the user just cancelled. Peek
+  // the singleton so a conversation that never used ACP doesn't spin one up.
+  peekAcpSessionManager()?.cancelForParent(conversationId);
   // The processing flag is cleared by the in-flight turn's `finally`, not here.
   // Abort propagates into the provider call and tool execution (and is backed
   // by the agent loop's abort watchdog), so the turn reaches its `finally`


### PR DESCRIPTION
Cancel the ACP agent sessions a conversation spawned when the user cancels it, so they stop instead of finishing in the background — holding a child process and then enqueuing a follow-up message into the just-stopped conversation. Also lowers the agent-loop abort watchdog from 45s to 5s now that abort propagation is complete.

---

Follow-up to #35281 (now merged), addressing **Item 2** of the original handoff ("abort doesn't cover all tool types") plus watchdog-timeout tuning.

### What & why

1. **ACP sessions stop on parent cancel.** Adds `AcpSessionManager.cancelForParent(parentConversationId)` and calls it from `cancelGeneration`, alongside the existing `getSubagentManager().abortAllForParent(...)`. A backgrounded ACP prompt (`firePromptInBackground`) otherwise keeps running past a user stop — holding a child agent process — and on completion enqueues a `[ACP agent … completed]` message back into the conversation, triggering exactly the "unwanted model activity after the user pressed stop" the subagent abort already guards against. Cancelling settles the prompt down its `"cancelled"` path, which emits a client event but does **not** notify the parent, so no model activity follows the stop.

2. **Watchdog 45s → 5s.** Cooperative abort (provider fetch + tool race, both already wired) settles in-flight work in well under a second, so a few seconds is ample headroom for a clean unwind while releasing a genuinely wedged turn far more promptly than 45s.

### Design note — why parent-scoped, not per-call signal threading

The handoff suggested threading `ToolContext.signal` into `manager.steer()`/`steerOrResume()`. `ToolContext.signal` is already wired, but threading it into the steer call itself doesn't help: `steer()` fires the prompt in the **background** and returns immediately, so the tool's awaited call completes *before* a later cancel. A parent-scoped cancel is both simpler and more correct: ACP prompts routinely outlive the turn that launched them (they notify the parent in a later turn), and the user's intent on Stop is "halt this conversation's ACP activity," not "halt only what the currently-aborting turn launched." It also mirrors the established `abortAllForParent` pattern and covers `spawn` and `steer` uniformly. `peekAcpSessionManager()` avoids spinning up the singleton for conversations that never used ACP.

### Testing
- New `AcpSessionManager — cancelForParent` tests: cancels only the target parent's sessions (status → `cancelled`, `process.cancel` reached each once), leaves other parents `running`, and returns `0` / dispatches nothing when the parent has none.
- Adjacent suites green: `session-manager` (4), `session-manager-resume` (24), `acp/steer` (8), `conversation-agent-loop` (60), `cancel-clears-processing` (2).
- `bunx tsc --noEmit` + `bun run lint` clean.

### Backwards compatibility
Daemon-internal only — no wire formats, IPC schemas, or route shapes change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011VUPduNXezi72nA5BWS4ok

---
_Generated by [Claude Code](https://claude.ai/code/session_011VUPduNXezi72nA5BWS4ok)_