### PR TITLE
feat(plugins): expose live registered hooks/tools via new surfaces route

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -19594,12 +19594,39 @@ paths:
                             description:
                               Registered tool names from `tools/<name>.{ts,js}` (filenames derived to tool names, e.g. `create-issue` →
                               `create_issue`).
+                          registered:
+                            anyOf:
+                              - type: object
+                                properties:
+                                  hooks:
+                                    type: array
+                                    items:
+                                      type: string
+                                    description: Hook names registered in the daemon's plugin registry for this plugin.
+                                  tools:
+                                    type: array
+                                    items:
+                                      type: string
+                                    description:
+                                      Tool names registered in the daemon's tool registry owned by this plugin (their real registered names,
+                                      including any an exported `tool.name` overrode).
+                                required:
+                                  - hooks
+                                  - tools
+                                additionalProperties: false
+                                description: The subset of a plugin's hook/tool surfaces actually live in the daemon's in-memory registries.
+                              - type: "null"
+                            description:
+                              The subset of `hooks`/`tools` actually registered in the running daemon; null when the daemon could not be
+                              consulted (an object of empty arrays means the daemon is running but has nothing
+                              registered for this plugin).
                         required:
                           - skills
                           - hooks
                           - tools
+                          - registered
                         additionalProperties: false
-                        description: Surfaces the installed copy contributes, read from its on-disk tree.
+                        description: Surfaces the installed copy contributes (read from its on-disk tree), plus the subset live in the daemon.
                       - type: "null"
                     description: Surfaces the installed copy contributes (skills, hooks, tools); null when the plugin is not installed.
                 required:
@@ -19615,6 +19642,52 @@ paths:
           description: The plugin name failed sanitization (e.g. contained slashes, dots, or uppercase letters).
         "404":
           description: No installed copy and no catalog entry claims the given name.
+  /v1/plugins/{name}/surfaces:
+    get:
+      operationId: plugins_by_name_surfaces_get
+      summary: List a plugin's live registered surfaces
+      description:
+        Report the subset of a plugin's hooks and tools actually registered in the running daemon's in-memory
+        registries — what the runtime has *loaded*, as opposed to what the install tree *ships* (the latter is `plugins
+        inspect`'s on-disk walk). Reads the plugin and tool registries directly, so a hook that failed to load is absent
+        and a tool that renamed itself via an exported `name` appears under its real registered name. An unregistered
+        plugin (not loaded, or installed on disk but never booted) returns empty arrays rather than 404. Powers the
+        registration annotations in `assistant plugins inspect <name>`.
+      tags:
+        - plugins
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  hooks:
+                    type: array
+                    items:
+                      type: string
+                    description: Hook names registered in the daemon's plugin registry for this plugin.
+                  tools:
+                    type: array
+                    items:
+                      type: string
+                    description:
+                      Tool names registered in the daemon's tool registry owned by this plugin (their real registered names,
+                      including any an exported `tool.name` overrode).
+                required:
+                  - hooks
+                  - tools
+                additionalProperties: false
+                description: The subset of a plugin's hook/tool surfaces actually live in the daemon's in-memory registries.
+        "400":
+          description: The plugin name failed sanitization (e.g. contained slashes, dots, or uppercase letters).
   /v1/plugins/{name}/upgrade:
     post:
       operationId: plugins_by_name_upgrade_post

--- a/assistant/src/cli/commands/plugins.ts
+++ b/assistant/src/cli/commands/plugins.ts
@@ -31,6 +31,7 @@ import {
 import { listInstalledPlugins } from "../lib/list-installed-plugins.js";
 import type { FingerprintComparison } from "../lib/plugin-fingerprint.js";
 import { registerCommand } from "../lib/register-command.js";
+import { fetchRegisteredPluginSurfaces } from "../lib/registered-plugin-surfaces.js";
 import {
   InvalidSearchPatternError,
   searchPlugins,
@@ -187,7 +188,13 @@ Examples:
           try {
             const inspection = await inspectPlugin(
               { name },
-              { fetch: globalThis.fetch.bind(globalThis) },
+              {
+                fetch: globalThis.fetch.bind(globalThis),
+                // Ask the running daemon which of the on-disk hooks/tools it
+                // actually has registered; best-effort, so inspect still works
+                // when the daemon is down (the registered view shows as unknown).
+                readRegisteredSurfaces: fetchRegisteredPluginSurfaces,
+              },
             );
 
             if (opts.json) {
@@ -563,6 +570,31 @@ function formatInspection(inspection: PluginInspection): string[] {
     lines.push(label);
     for (const item of items) lines.push(`  ${item}`);
   };
+  // A surface block for hooks/tools, annotated with what the running daemon
+  // actually has registered. `registered === null` means the daemon could not
+  // be consulted (offline inspect), so items render unannotated and a note is
+  // emitted once below. When it is consulted, each name is marked registered or
+  // not — and a name registered under one the disk walk could not predict (a
+  // tool that renamed itself) still appears, sourced from the live registry.
+  const liveSurfaceBlock = (
+    label: string,
+    contributed: readonly string[],
+    registered: readonly string[] | null,
+  ) => {
+    const names = [...new Set([...contributed, ...(registered ?? [])])].sort();
+    if (names.length === 0) return;
+    lines.push(label);
+    if (registered === null) {
+      for (const name of names) lines.push(`  ${name}`);
+      return;
+    }
+    const registeredSet = new Set(registered);
+    const width = Math.max(...names.map((n) => n.length));
+    for (const name of names) {
+      const mark = registeredSet.has(name) ? "registered" : "not registered";
+      lines.push(`  ${name.padEnd(width)}  ${mark}`);
+    }
+  };
 
   topRow("status", statusLine(status));
 
@@ -599,8 +631,24 @@ function formatInspection(inspection: PluginInspection): string[] {
 
   if (surfaces) {
     surfaceBlock("skills", surfaces.skills);
-    surfaceBlock("hooks", surfaces.hooks);
-    surfaceBlock("tools", surfaces.tools);
+    liveSurfaceBlock(
+      "hooks",
+      surfaces.hooks,
+      surfaces.registered?.hooks ?? null,
+    );
+    liveSurfaceBlock(
+      "tools",
+      surfaces.tools,
+      surfaces.registered?.tools ?? null,
+    );
+    if (
+      surfaces.registered === null &&
+      (surfaces.hooks.length > 0 || surfaces.tools.length > 0)
+    ) {
+      lines.push(
+        "  (assistant unreachable — live hook/tool registration unknown)",
+      );
+    }
   }
 
   for (const issue of local?.issues ?? []) topRow("issue", issue);

--- a/assistant/src/cli/lib/__tests__/inspect-plugin.test.ts
+++ b/assistant/src/cli/lib/__tests__/inspect-plugin.test.ts
@@ -398,12 +398,67 @@ describe("inspectPlugin", () => {
       { fetch, workspacePluginsDir: workspace },
     );
 
-    // THEN the contributed surfaces are listed (sorted) and tools is empty
+    // THEN the contributed surfaces are listed (sorted) and tools is empty;
+    // with no registered-surface reader, the live subset is unknown (null)
     expect(result.surfaces).toEqual({
       skills: ["first-skill", "second-skill"],
       hooks: ["init", "post-model-call"],
       tools: [],
+      registered: null,
     });
+  });
+
+  test("threads the daemon's registered surfaces onto the contributed listing", async () => {
+    // GIVEN an installed plugin shipping two hooks and one tool on disk
+    installPlugin(workspace, "level-up", {
+      sidecar: { commit: SHA_A },
+      surfaces: { hooks: ["init", "post-model-call"], tools: ["summarize"] },
+    });
+    const fetch = makeFetch({ marketplace: manifestWith("level-up", SHA_A) });
+
+    // AND a reader reporting only a subset is live in the daemon
+    const result = await inspectPlugin(
+      { name: "level-up" },
+      {
+        fetch,
+        workspacePluginsDir: workspace,
+        readRegisteredSurfaces: async (name) => {
+          expect(name).toBe("level-up");
+          return { hooks: ["init"], tools: ["summarize"] };
+        },
+      },
+    );
+
+    // THEN the contributed listing is unchanged and the live subset is attached
+    expect(result.surfaces).toEqual({
+      skills: [],
+      hooks: ["init", "post-model-call"],
+      tools: ["summarize"],
+      registered: { hooks: ["init"], tools: ["summarize"] },
+    });
+  });
+
+  test("leaves registered null when the daemon cannot be consulted", async () => {
+    // GIVEN an installed plugin and a reader that signals the daemon is down
+    installPlugin(workspace, "level-up", {
+      sidecar: { commit: SHA_A },
+      surfaces: { hooks: ["init"] },
+    });
+    const fetch = makeFetch({ marketplace: manifestWith("level-up", SHA_A) });
+
+    // WHEN it is inspected with a reader that returns null (unreachable)
+    const result = await inspectPlugin(
+      { name: "level-up" },
+      {
+        fetch,
+        workspacePluginsDir: workspace,
+        readRegisteredSurfaces: async () => null,
+      },
+    );
+
+    // THEN the disk listing still stands and the live subset is unknown
+    expect(result.surfaces?.hooks).toEqual(["init"]);
+    expect(result.surfaces?.registered).toBeNull();
   });
 
   test("leaves surfaces null when the plugin is not installed", async () => {

--- a/assistant/src/cli/lib/inspect-plugin.ts
+++ b/assistant/src/cli/lib/inspect-plugin.ts
@@ -39,6 +39,7 @@ import {
 import {
   detectPluginSurfaces,
   type PluginSurfaces,
+  type RegisteredPluginSurfaces,
 } from "./plugin-surfaces.js";
 
 /** Full commit SHA (40 hex SHA-1 or 64 hex SHA-256). */
@@ -137,8 +138,10 @@ export interface PluginInspection {
   readonly remoteError: string | null;
   /**
    * Surfaces the installed copy contributes (skills, hooks, tools), read from
-   * its on-disk tree. `null` when the plugin is not installed — there is no
-   * tree to inspect, and the marketplace metadata does not enumerate surfaces.
+   * its on-disk tree, plus the subset actually registered in the running daemon
+   * (`surfaces.registered`) when {@link InspectPluginDeps.readRegisteredSurfaces}
+   * resolves it. `null` when the plugin is not installed — there is no tree to
+   * inspect, and the marketplace metadata does not enumerate surfaces.
    */
   readonly surfaces: PluginSurfaces | null;
 }
@@ -165,6 +168,16 @@ export interface InspectPluginDeps {
   readonly fetch: FetchLike;
   /** Override the workspace plugins directory. Falls back to the live workspace. */
   readonly workspacePluginsDir?: string;
+  /**
+   * Resolve the subset of a plugin's hooks/tools actually registered in the
+   * running daemon, keyed by install name. The CLI passes an IPC-backed reader
+   * (best-effort: it returns `null` when the daemon is unreachable so offline
+   * inspection still works); the daemon route passes one that reads its own
+   * in-process registries. Omitted entirely → `surfaces.registered` is `null`.
+   */
+  readonly readRegisteredSurfaces?: (
+    name: string,
+  ) => Promise<RegisteredPluginSurfaces | null>;
 }
 
 function readLocal(
@@ -276,7 +289,18 @@ export async function inspectPlugin(
   });
   const installed = entry !== null;
   const local = entry ? readLocal(entry, readInstallMeta(entry.target)) : null;
-  const surfaces = entry ? detectPluginSurfaces(entry.target) : null;
+  // Surfaces pair the on-disk contribution walk with the live registered subset.
+  // The registered view is best-effort: a missing reader (or one that returns
+  // null because the daemon is unreachable) leaves `registered: null` without
+  // failing the inspection — the disk listing still stands on its own.
+  let surfaces: PluginSurfaces | null = null;
+  if (entry) {
+    const contributed = detectPluginSurfaces(entry.target);
+    const registered = deps.readRegisteredSurfaces
+      ? await deps.readRegisteredSurfaces(name)
+      : null;
+    surfaces = { ...contributed, registered };
+  }
 
   let remote: PluginRemoteInfo | null = null;
   let remoteError: string | null = null;

--- a/assistant/src/cli/lib/plugin-surfaces.ts
+++ b/assistant/src/cli/lib/plugin-surfaces.ts
@@ -21,8 +21,12 @@
 import { existsSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
-/** The surfaces an installed plugin contributes, each sorted and de-duplicated. */
-export interface PluginSurfaces {
+/**
+ * The surfaces an installed plugin contributes, read from its on-disk tree —
+ * each list sorted and de-duplicated. This is a pure filesystem view: it says
+ * what the plugin *ships*, not what the running daemon actually loaded.
+ */
+export interface PluginContributedSurfaces {
   /** Skill ids shipped at `skills/<id>/SKILL.md`. */
   readonly skills: readonly string[];
   /** Lifecycle hook names from `hooks/<name>.{ts,js}` (e.g. `pre-model-call`). */
@@ -33,9 +37,40 @@ export interface PluginSurfaces {
    * `create-issue.ts` registers as `create_issue`), so the derived form is
    * reported rather than the raw basename. A tool module that overrides its own
    * name via an exported `name` is not reflected here: that would require
-   * importing and executing untrusted plugin code, which inspection avoids.
+   * importing and executing untrusted plugin code, which the disk walk avoids
+   * (the live {@link PluginSurfaces.registered} view does reflect it).
    */
   readonly tools: readonly string[];
+}
+
+/**
+ * The subset of a plugin's hook/tool surfaces that are actually live in the
+ * running daemon's in-memory registries — read straight from the registries,
+ * not the disk tree. Authoritative for "what does the runtime currently
+ * expose": a hook file that failed to load is absent here, and a tool that
+ * renamed itself via an exported `name` appears under its real registered name.
+ */
+export interface RegisteredPluginSurfaces {
+  /** Hook names registered in the daemon's plugin registry for this plugin. */
+  readonly hooks: readonly string[];
+  /** Tool names registered in the daemon's tool registry owned by this plugin. */
+  readonly tools: readonly string[];
+}
+
+/**
+ * The inspection view of a plugin's surfaces: what it contributes on disk, plus
+ * the subset actually registered in the live daemon when one could be consulted.
+ */
+export interface PluginSurfaces extends PluginContributedSurfaces {
+  /**
+   * The subset of {@link PluginContributedSurfaces.hooks} and
+   * {@link PluginContributedSurfaces.tools} actually registered in the running
+   * daemon's in-memory registries, or `null` when the daemon could not be
+   * consulted (e.g. it is not running, or this view was produced offline).
+   * `null` means "unknown", distinct from an object of empty arrays, which
+   * means "the daemon is running but has nothing registered for this plugin".
+   */
+  readonly registered: RegisteredPluginSurfaces | null;
 }
 
 /**
@@ -88,11 +123,15 @@ function listSkillIds(skillsDir: string): string[] {
 }
 
 /**
- * Detect the {@link PluginSurfaces} an installed plugin contributes by walking
- * its install tree at `pluginDir`. Surface types with no contributions come
- * back as empty arrays; callers omit empty types from the rendered output.
+ * Detect the {@link PluginContributedSurfaces} an installed plugin contributes
+ * by walking its install tree at `pluginDir`. Surface types with no
+ * contributions come back as empty arrays; callers omit empty types from the
+ * rendered output. This is the disk view only — pairing it with the live
+ * {@link RegisteredPluginSurfaces} is the caller's job (see `inspectPlugin`).
  */
-export function detectPluginSurfaces(pluginDir: string): PluginSurfaces {
+export function detectPluginSurfaces(
+  pluginDir: string,
+): PluginContributedSurfaces {
   const toolNames = listModuleBasenames(join(pluginDir, "tools")).map(
     deriveToolName,
   );

--- a/assistant/src/cli/lib/registered-plugin-surfaces.ts
+++ b/assistant/src/cli/lib/registered-plugin-surfaces.ts
@@ -1,0 +1,35 @@
+/**
+ * CLI-side reader for a plugin's live registered surfaces.
+ *
+ * `plugins inspect` runs locally (disk walk + marketplace fetch) so it keeps
+ * working when the daemon is down. The "which hooks/tools are actually
+ * registered" question, however, can only be answered by the running daemon —
+ * the registries live in its memory. This bridges that gap over IPC: it calls
+ * the daemon's `plugins_surfaces` route and adapts the result into the shape
+ * `inspectPlugin` expects for {@link PluginSurfaces.registered}.
+ *
+ * Best-effort by contract: any failure (daemon not running, route error,
+ * timeout) resolves to `null` — "unknown", not an error — so the surrounding
+ * inspection still renders its offline-derived data.
+ */
+
+import { cliIpcCall } from "../../ipc/cli-client.js";
+import type { RegisteredPluginSurfaces } from "./plugin-surfaces.js";
+
+/**
+ * Fetch the daemon's live registered hooks/tools for the plugin installed under
+ * `name`, or `null` when the daemon could not be consulted. Suitable to pass
+ * directly as `inspectPlugin`'s `readRegisteredSurfaces` dependency.
+ */
+export async function fetchRegisteredPluginSurfaces(
+  name: string,
+): Promise<RegisteredPluginSurfaces | null> {
+  const res = await cliIpcCall<RegisteredPluginSurfaces>("plugins_surfaces", {
+    pathParams: { name },
+  });
+  if (!res.ok || !res.result) return null;
+  // Defend against a malformed payload: only adopt arrays, else report unknown.
+  const { hooks, tools } = res.result;
+  if (!Array.isArray(hooks) || !Array.isArray(tools)) return null;
+  return { hooks, tools };
+}

--- a/assistant/src/runtime/__tests__/registered-plugin-surfaces.test.ts
+++ b/assistant/src/runtime/__tests__/registered-plugin-surfaces.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for {@link readRegisteredPluginSurfaces}.
+ *
+ * The helper reads the daemon's two in-memory registries (plugin registry for
+ * hooks, tool registry for tools), so the fixtures register real plugins and
+ * plugin tools and assert the snapshot reflects only what is live and only
+ * what belongs to the named plugin.
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+import { RiskLevel } from "../../permissions/types.js";
+import {
+  registerPlugin,
+  resetPluginRegistryForTests,
+} from "../../plugins/registry.js";
+import type { Plugin, PluginHooks } from "../../plugins/types.js";
+import {
+  __resetRegistryForTesting,
+  registerPluginTools,
+} from "../../tools/registry.js";
+import type {
+  Tool,
+  ToolContext,
+  ToolExecutionResult,
+} from "../../tools/types.js";
+import { readRegisteredPluginSurfaces } from "../registered-plugin-surfaces.js";
+
+afterAll(() => {
+  __resetRegistryForTesting();
+  resetPluginRegistryForTests();
+});
+
+beforeEach(() => {
+  __resetRegistryForTesting();
+  resetPluginRegistryForTests();
+});
+
+afterEach(() => {
+  __resetRegistryForTesting();
+  resetPluginRegistryForTests();
+});
+
+function makeTool(name: string): Tool {
+  return {
+    name,
+    description: `Fake ${name}`,
+    category: "test",
+    defaultRiskLevel: RiskLevel.Low,
+    executionTarget: "sandbox",
+    input_schema: { type: "object", properties: {}, required: [] },
+    async execute(
+      _input: Record<string, unknown>,
+      _context: ToolContext,
+    ): Promise<ToolExecutionResult> {
+      return { content: "ok", isError: false };
+    },
+  };
+}
+
+function makePlugin(name: string, hookNames: string[]): Plugin {
+  const hooks: PluginHooks = {};
+  for (const hook of hookNames) hooks[hook] = async () => {};
+  return { manifest: { name, version: "0.1.0" }, hooks };
+}
+
+describe("readRegisteredPluginSurfaces", () => {
+  test("reports the plugin's registered hooks and tools, sorted", () => {
+    // GIVEN a plugin registered with two hooks and two tools
+    registerPlugin(makePlugin("level-up", ["init", "pre-model-call"]));
+    registerPluginTools("level-up", [
+      makeTool("summarize"),
+      makeTool("expand"),
+    ]);
+
+    // WHEN its live surfaces are read
+    const surfaces = readRegisteredPluginSurfaces("level-up");
+
+    // THEN both lists reflect the registries, sorted
+    expect(surfaces.hooks).toEqual(["init", "pre-model-call"]);
+    expect(surfaces.tools).toEqual(["expand", "summarize"]);
+  });
+
+  test("includes only tools owned by the named plugin", () => {
+    // GIVEN two plugins each contributing a tool
+    registerPlugin(makePlugin("level-up", []));
+    registerPlugin(makePlugin("other", []));
+    registerPluginTools("level-up", [makeTool("summarize")]);
+    registerPluginTools("other", [makeTool("translate")]);
+
+    // WHEN one plugin's surfaces are read
+    const surfaces = readRegisteredPluginSurfaces("level-up");
+
+    // THEN the other plugin's tool is excluded
+    expect(surfaces.tools).toEqual(["summarize"]);
+  });
+
+  test("returns empty arrays for a plugin that is not registered", () => {
+    // GIVEN nothing registered under this name
+    // WHEN its live surfaces are read
+    const surfaces = readRegisteredPluginSurfaces("ghost");
+
+    // THEN the answer is "nothing live", not an error
+    expect(surfaces).toEqual({ hooks: [], tools: [] });
+  });
+});

--- a/assistant/src/runtime/registered-plugin-surfaces.ts
+++ b/assistant/src/runtime/registered-plugin-surfaces.ts
@@ -1,0 +1,46 @@
+/**
+ * Read the subset of a plugin's hook/tool surfaces that are actually live in
+ * the daemon's in-memory registries.
+ *
+ * `plugins inspect`'s on-disk surface walk (`cli/lib/plugin-surfaces.ts`)
+ * reports what a plugin *ships*; this reports what the running daemon actually
+ * *loaded*. The two can diverge: a hook or tool file that failed to load is on
+ * disk but never registered, and a tool that renames itself via an exported
+ * `name` registers under a name the filename walk cannot predict. The registries
+ * are authoritative for the live runtime, so this reads them directly:
+ *
+ * - hooks  → the keys of the plugin's `hooks` record in the plugin registry.
+ * - tools  → every tool in the tool registry whose recorded owner is this
+ *            plugin (`{ kind: "plugin", id: name }`).
+ *
+ * This module lives in daemon-land (it imports the registries) and is consumed
+ * by the plugin routes; the CLI reaches the same data over IPC rather than
+ * importing the registries, which it is forbidden from doing.
+ */
+
+import type { RegisteredPluginSurfaces } from "../cli/lib/plugin-surfaces.js";
+import { getRegisteredPlugin } from "../plugins/registry.js";
+import { getAllTools, getToolOwner } from "../tools/registry.js";
+
+/**
+ * Snapshot the live registered hooks and tools for the plugin installed under
+ * `name`. Both lists are sorted for a deterministic listing. A plugin that is
+ * not currently registered (e.g. it failed to load, or is installed on disk but
+ * was never booted) yields empty arrays — never `null`; the in-process daemon
+ * is always an authoritative answer, so "unknown" is reserved for callers that
+ * could not reach the daemon at all.
+ */
+export function readRegisteredPluginSurfaces(
+  name: string,
+): RegisteredPluginSurfaces {
+  const plugin = getRegisteredPlugin(name);
+  const hooks = plugin?.hooks ? Object.keys(plugin.hooks).sort() : [];
+  const tools = getAllTools()
+    .map((tool) => tool.name)
+    .filter((toolName) => {
+      const owner = getToolOwner(toolName);
+      return owner?.kind === "plugin" && owner.id === name;
+    })
+    .sort();
+  return { hooks, tools };
+}

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -224,6 +224,7 @@ const uninstallHandler = findHandler("plugins_uninstall");
 const getHandler = findHandler("plugins_get");
 const installHandler = findHandler("plugins_install");
 const inspectHandler = findHandler("plugins_inspect");
+const surfacesHandler = findHandler("plugins_surfaces");
 const upgradeHandler = findHandler("plugins_upgrade");
 const diffHandler = findHandler("plugins_diff");
 
@@ -1004,7 +1005,12 @@ function inspection(
     remoteError: overrides.remoteError ?? null,
     surfaces:
       overrides.surfaces === undefined
-        ? { skills: [], hooks: ["post-model-call"], tools: [] }
+        ? {
+            skills: [],
+            hooks: ["post-model-call"],
+            tools: [],
+            registered: null,
+          }
         : overrides.surfaces,
   };
 }
@@ -1085,6 +1091,28 @@ describe("GET /v1/plugins/:name/inspect", () => {
     }
     expect(caught).toBeInstanceOf(InternalError);
     expect((caught as Error).message).toContain("EUNEXPECTED");
+  });
+});
+
+describe("GET /v1/plugins/:name/surfaces", () => {
+  // The registry-reading logic is unit-tested in
+  // registered-plugin-surfaces.test.ts; here we only assert the route wiring —
+  // name sanitization and the live-snapshot shape — without mutating the shared
+  // global registries this file's other suites rely on.
+
+  test("returns empty arrays for a plugin with nothing registered", () => {
+    const result = surfacesHandler({ pathParams: { name: "ghost" } });
+    expect(result).toEqual({ hooks: [], tools: [] });
+  });
+
+  test("InvalidPluginNameError → BadRequestError (400)", () => {
+    expect(() =>
+      surfacesHandler({ pathParams: { name: "../escape" } }),
+    ).toThrow(BadRequestError);
+  });
+
+  test("a missing name is rejected as a bad request", () => {
+    expect(() => surfacesHandler({})).toThrow(BadRequestError);
   });
 });
 

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -40,6 +40,7 @@ import {
   PluginAlreadyInstalledError,
   PluginNotFoundError,
   PluginSourceUnavailableError,
+  sanitizePluginName,
 } from "../../cli/lib/install-from-github.js";
 import {
   type InstalledPluginInfo,
@@ -68,6 +69,7 @@ import {
   upgradePlugin,
 } from "../../cli/lib/upgrade-plugin.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import { readRegisteredPluginSurfaces } from "../registered-plugin-surfaces.js";
 import {
   BadRequestError,
   ConflictError,
@@ -372,6 +374,23 @@ const pluginRemoteInfoSchema = z
   })
   .describe("The marketplace's current pin and advertised metadata.");
 
+const registeredPluginSurfacesSchema = z
+  .object({
+    hooks: z
+      .array(z.string())
+      .describe(
+        "Hook names registered in the daemon's plugin registry for this plugin.",
+      ),
+    tools: z
+      .array(z.string())
+      .describe(
+        "Tool names registered in the daemon's tool registry owned by this plugin (their real registered names, including any an exported `tool.name` overrode).",
+      ),
+  })
+  .describe(
+    "The subset of a plugin's hook/tool surfaces actually live in the daemon's in-memory registries.",
+  );
+
 const pluginSurfacesSchema = z
   .object({
     skills: z
@@ -387,9 +406,14 @@ const pluginSurfacesSchema = z
       .describe(
         "Registered tool names from `tools/<name>.{ts,js}` (filenames derived to tool names, e.g. `create-issue` \u2192 `create_issue`).",
       ),
+    registered: registeredPluginSurfacesSchema
+      .nullable()
+      .describe(
+        "The subset of `hooks`/`tools` actually registered in the running daemon; null when the daemon could not be consulted (an object of empty arrays means the daemon is running but has nothing registered for this plugin).",
+      ),
   })
   .describe(
-    "Surfaces the installed copy contributes, read from its on-disk tree.",
+    "Surfaces the installed copy contributes (read from its on-disk tree), plus the subset live in the daemon.",
   );
 
 const pluginInspectResponseSchema = z.object({
@@ -831,7 +855,13 @@ async function handleInspectPlugin({ pathParams = {} }: RouteHandlerArgs) {
     // message in `remoteError`. It only throws when there is nothing to show.
     return await inspectPlugin(
       { name: rawName },
-      { fetch: globalThis.fetch.bind(globalThis) },
+      {
+        fetch: globalThis.fetch.bind(globalThis),
+        // This handler runs inside the daemon, so the registries are in
+        // process — read them directly rather than round-tripping over IPC.
+        readRegisteredSurfaces: async (name) =>
+          readRegisteredPluginSurfaces(name),
+      },
     );
   } catch (err) {
     if (err instanceof InvalidPluginNameError) {
@@ -844,6 +874,27 @@ async function handleInspectPlugin({ pathParams = {} }: RouteHandlerArgs) {
       err instanceof Error ? err.message : "plugin inspect failed",
     );
   }
+}
+
+// ---------------------------------------------------------------------------
+// Handler — registered surfaces (live daemon registries)
+// ---------------------------------------------------------------------------
+
+function handlePluginSurfaces({ pathParams = {} }: RouteHandlerArgs) {
+  let name: string;
+  try {
+    name = sanitizePluginName(pathParams.name ?? "");
+  } catch (err) {
+    if (err instanceof InvalidPluginNameError) {
+      throw new BadRequestError(err.message);
+    }
+    throw err;
+  }
+  // Authoritative snapshot of what the running daemon has registered for this
+  // plugin. Unlike inspect's disk walk, this never 404s on a missing install
+  // tree — an unregistered plugin simply yields empty arrays, which is the
+  // honest answer for "what is live right now".
+  return readRegisteredPluginSurfaces(name);
 }
 
 // ---------------------------------------------------------------------------
@@ -1149,6 +1200,35 @@ export const ROUTES: RouteDefinition[] = [
       },
     },
     handler: handleInspectPlugin,
+  },
+  {
+    operationId: "plugins_surfaces",
+    endpoint: "plugins/:name/surfaces",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "List a plugin's live registered surfaces",
+    description:
+      "Report the subset of a plugin's hooks and tools actually registered in the running daemon's in-memory registries — what the runtime has *loaded*, as opposed to what the install tree *ships* (the latter is `plugins inspect`'s on-disk walk). Reads the plugin and tool registries directly, so a hook that failed to load is absent and a tool that renamed itself via an exported `name` appears under its real registered name. An unregistered plugin (not loaded, or installed on disk but never booted) returns empty arrays rather than 404. Powers the registration annotations in `assistant plugins inspect <name>`.",
+    tags: ["plugins"],
+    pathParams: [
+      {
+        name: "name",
+        type: "string",
+        description:
+          "Install name. Must match the kebab-case name accepted by `assistant plugins install`.",
+      },
+    ],
+    responseBody: registeredPluginSurfacesSchema,
+    additionalResponses: {
+      "400": {
+        description:
+          "The plugin name failed sanitization (e.g. contained slashes, dots, or uppercase letters).",
+      },
+    },
+    handler: handlePluginSurfaces,
   },
   {
     operationId: "plugins_diff",


### PR DESCRIPTION
## Prompt / plan
Add a new daemon route and CLI integration to expose which hooks and tools a plugin actually has registered in the running daemon's in-memory registries, distinct from what it ships on disk. This enables `plugins inspect` to annotate surfaces with their live registration status.

## Changes

### New daemon route: `GET /v1/plugins/:name/surfaces`
- Returns the authoritative snapshot of what the running daemon has registered for a plugin
- Reads directly from the plugin and tool registries (no disk walk)
- Returns empty arrays for unregistered plugins rather than 404 (honest answer for "what is live now")
- Handles name sanitization and returns 400 for invalid names

### New module: `runtime/registered-plugin-surfaces.ts`
- `readRegisteredPluginSurfaces(name)`: reads plugin registry for hooks and tool registry for tools owned by the plugin
- Both lists are sorted for deterministic output
- Reflects real registered names (e.g., tools that renamed themselves via exported `name`)

### CLI integration
- New module `cli/lib/registered-plugin-surfaces.ts` with `fetchRegisteredPluginSurfaces()` that calls the daemon route over IPC
- Best-effort: returns `null` when daemon is unreachable, allowing offline inspection to still work
- Updated `inspectPlugin()` to accept optional `readRegisteredSurfaces` dependency and attach result to `surfaces.registered`
- Updated `plugins inspect` command to fetch and display live registration status, annotating each hook/tool as "registered" or "not registered"
- When daemon is unreachable, displays a note that live registration is unknown

### Type updates
- Split `PluginSurfaces` into `PluginContributedSurfaces` (disk view) and `RegisteredPluginSurfaces` (live view)
- `PluginSurfaces` now extends contributed surfaces and adds `registered: RegisteredPluginSurfaces | null`
- Updated OpenAPI schema to reflect new `registered` field in inspect response and new surfaces endpoint

## Test plan
- Added comprehensive unit tests in `registered-plugin-surfaces.test.ts` covering:
  - Reporting sorted hooks and tools from registries
  - Filtering tools to only those owned by the named plugin
  - Returning empty arrays for unregistered plugins
- Updated existing `inspect-plugin.test.ts` to verify:
  - Surfaces include `registered: null` when no reader provided
  - Reader is called and result is threaded onto surfaces
  - `registered: null` when reader returns null (daemon unreachable)
- Added route wiring tests in `plugins-routes.test.ts` for name sanitization and empty registry case
- Existing CLI and route tests updated to expect new `registered` field in surfaces

## CLI verb checklist
- [x] This route is internal-only, consumed by `plugins inspect` over IPC; no new CLI verb needed

https://claude.ai/code/session_01GA6hBLPYtnrCFfatWLFSWB