### PR TITLE
refactor(telemetry): gate record-time emitters on cached consent

### DIFF
--- a/assistant/src/__tests__/auth-fallback-events-store.test.ts
+++ b/assistant/src/__tests__/auth-fallback-events-store.test.ts
@@ -7,18 +7,10 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-let collectUsageData = true;
+let shareAnalytics = true;
 
-mock.module("../config/loader.js", () => ({
-  getConfig: () => ({
-    ui: {},
-    model: "test",
-    provider: "test",
-    memory: { enabled: false },
-    rateLimit: { maxRequestsPerMinute: 0 },
-    secretDetection: { enabled: false },
-    collectUsageData,
-  }),
+mock.module("../platform/consent-cache.js", () => ({
+  getCachedShareAnalytics: () => shareAnalytics,
 }));
 
 import {
@@ -53,7 +45,7 @@ const SAMPLE: AuthFallbackCount[] = [
 
 describe("auth-fallback-events-store", () => {
   beforeEach(() => {
-    collectUsageData = true;
+    shareAnalytics = true;
     resetTable();
   });
 
@@ -78,8 +70,8 @@ describe("auth-fallback-events-store", () => {
     });
   });
 
-  test("honors the collectUsageData opt-out (records nothing)", () => {
-    collectUsageData = false;
+  test("honors the share_analytics opt-out (records nothing)", () => {
+    shareAnalytics = false;
     const recorded = recordAuthFallbackCounts(1000, 2000, SAMPLE);
     expect(recorded).toBe(0);
     expect(queryUnreportedAuthFallbackEvents(0, undefined, 100).length).toBe(0);

--- a/assistant/src/__tests__/conversation-surfaces-activation-emit.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-activation-emit.test.ts
@@ -10,9 +10,11 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-// Usage-data collection is enabled so recordActivationEvent writes rows.
-mock.module("../config/loader.js", () => ({
-  getConfig: () => ({ collectUsageData: true }),
+// Analytics consent is granted so recordActivationEvent writes rows.
+let shareAnalytics = true;
+
+mock.module("../platform/consent-cache.js", () => ({
+  getCachedShareAnalytics: () => shareAnalytics,
 }));
 
 let broadcastedMessages: ServerMessage[] = [];
@@ -117,6 +119,7 @@ async function showTaggedChoice(
 
 describe("activation moment emission from ui_show surface commits", () => {
   beforeEach(() => {
+    shareAnalytics = true;
     broadcastedMessages = [];
     resetTables();
   });

--- a/assistant/src/__tests__/internal-telemetry-routes.test.ts
+++ b/assistant/src/__tests__/internal-telemetry-routes.test.ts
@@ -7,23 +7,15 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-// Toggle for the collectUsageData opt-out the real store consults. The store
+// Toggle for the share_analytics opt-out the real store consults. The store
 // module is intentionally NOT mocked here — it has its own DB-backed tests, and
 // Bun's `mock.module` is process-global, so mocking it would leak into those
 // tests when files share an invocation. Exercising the real store keeps every
 // auth-fallback test order-independent.
-let collectUsageData = true;
+let shareAnalytics = true;
 
-mock.module("../config/loader.js", () => ({
-  getConfig: () => ({
-    ui: {},
-    model: "test",
-    provider: "test",
-    memory: { enabled: false },
-    rateLimit: { maxRequestsPerMinute: 0 },
-    secretDetection: { enabled: false },
-    collectUsageData,
-  }),
+mock.module("../platform/consent-cache.js", () => ({
+  getCachedShareAnalytics: () => shareAnalytics,
 }));
 
 import { queryUnreportedAuthFallbackEvents } from "../memory/auth-fallback-events-store.js";
@@ -61,7 +53,7 @@ const VALID_BODY = {
 
 describe("internal-telemetry-routes: auth-fallback", () => {
   beforeEach(() => {
-    collectUsageData = true;
+    shareAnalytics = true;
     getDb().delete(authFallbackEvents).run();
   });
 
@@ -90,7 +82,7 @@ describe("internal-telemetry-routes: auth-fallback", () => {
   });
 
   test("returns skipped and persists nothing under the opt-out", () => {
-    collectUsageData = false;
+    shareAnalytics = false;
     expect(call(VALID_BODY)).toEqual({ skipped: true });
     expect(queryUnreportedAuthFallbackEvents(0, undefined, 100).length).toBe(0);
   });

--- a/assistant/src/__tests__/tool-audit-listener.test.ts
+++ b/assistant/src/__tests__/tool-audit-listener.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-// Toggle for the collectUsageData opt-out gate the listener consults when
+// Toggle for the share_analytics opt-out gate the listener consults when
 // populating the telemetry columns.
-let collectUsageData = true;
+let shareAnalytics = true;
 
-mock.module("../config/loader.js", () => ({
-  getConfig: () => ({ collectUsageData }),
+mock.module("../platform/consent-cache.js", () => ({
+  getCachedShareAnalytics: () => shareAnalytics,
 }));
 
 import { createToolAuditListener } from "../events/tool-audit-listener.js";
@@ -17,7 +17,7 @@ import {
 
 describe("tool audit listener", () => {
   beforeEach(() => {
-    collectUsageData = true;
+    shareAnalytics = true;
   });
 
   test("records executed events with truncated output", () => {
@@ -361,8 +361,8 @@ describe("tool audit listener", () => {
     );
   });
 
-  test("persists NULL telemetry columns when usage data collection is opted out", () => {
-    collectUsageData = false;
+  test("persists NULL telemetry columns when share_analytics is opted out", () => {
+    shareAnalytics = false;
     const records: ToolInvocationRecord[] = [];
     const listener = createToolAuditListener((record) => records.push(record));
 

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -34,9 +34,6 @@ const mockConfig = {
   permissions: {
     mode: "workspace" as const,
   },
-  // The audit listener nulls the telemetry columns when this is false; the
-  // end-to-end listener tests below assert the opted-in sizing behavior.
-  collectUsageData: true,
 };
 
 let checkerDecision: "allow" | "prompt" | "deny" = "allow";
@@ -54,6 +51,12 @@ mock.module("../config/loader.js", () => ({
   saveRawConfig: () => {},
   getNestedValue: () => undefined,
   setNestedValue: () => {},
+}));
+
+// Analytics consent is granted so the audit listener populates the telemetry
+// columns; the end-to-end listener tests below assert the opted-in sizing.
+mock.module("../platform/consent-cache.js", () => ({
+  getCachedShareAnalytics: () => true,
 }));
 
 mock.module("../util/logger.js", () => ({

--- a/assistant/src/events/tool-audit-listener.ts
+++ b/assistant/src/events/tool-audit-listener.ts
@@ -1,8 +1,8 @@
-import { getConfig } from "../config/loader.js";
 import {
   recordToolInvocation,
   type ToolInvocationRecord,
 } from "../memory/tool-usage-store.js";
+import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 import { redactJsonStringLeaves } from "../security/redact-json.js";
 import { redactSecrets } from "../security/secret-scanner.js";
 import {
@@ -168,7 +168,7 @@ function telemetryColumns(
   rawInput: string,
   resultBytes: number,
 ): TelemetryColumns {
-  if (!getConfig().collectUsageData) return NULL_TELEMETRY_COLUMNS;
+  if (!getCachedShareAnalytics()) return NULL_TELEMETRY_COLUMNS;
   return {
     argBytes: event.inputBytes ?? Buffer.byteLength(rawInput, "utf8"),
     resultBytes,

--- a/assistant/src/memory/__tests__/onboarding-events-store.test.ts
+++ b/assistant/src/memory/__tests__/onboarding-events-store.test.ts
@@ -8,10 +8,10 @@ mock.module("../../util/logger.js", () => ({
     }),
 }));
 
-// Mutable usage-data gate, flipped per-test.
-let collectUsageData = true;
-mock.module("../../config/loader.js", () => ({
-  getConfig: () => ({ collectUsageData }),
+// Mutable consent gate, flipped per-test.
+let shareAnalytics = true;
+mock.module("../../platform/consent-cache.js", () => ({
+  getCachedShareAnalytics: () => shareAnalytics,
 }));
 
 import { getDb } from "../db-connection.js";
@@ -30,7 +30,7 @@ function resetTable(): void {
 
 describe("onboarding-events-store: recordActivationEvent", () => {
   beforeEach(() => {
-    collectUsageData = true;
+    shareAnalytics = true;
     resetTable();
   });
 
@@ -66,8 +66,8 @@ describe("onboarding-events-store: recordActivationEvent", () => {
     expect(rows[0]!.stepIndex).toBe(2);
   });
 
-  test("returns null and writes no row when collectUsageData is disabled", () => {
-    collectUsageData = false;
+  test("returns null and writes no row when share_analytics is disabled", () => {
+    shareAnalytics = false;
     const event = recordActivationEvent({
       stepName: "activation_moment_1_complete",
       sessionId: "conv-3",

--- a/assistant/src/memory/auth-fallback-events-store.ts
+++ b/assistant/src/memory/auth-fallback-events-store.ts
@@ -1,7 +1,7 @@
 import { and, asc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getConfig } from "../config/loader.js";
+import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 import { getDb } from "./db-connection.js";
 import { authFallbackEvents } from "./schema.js";
 
@@ -36,7 +36,7 @@ export function recordAuthFallbackCounts(
   windowEnd: number,
   counts: AuthFallbackCount[],
 ): number {
-  if (!getConfig().collectUsageData) return 0;
+  if (!getCachedShareAnalytics()) return 0;
   if (counts.length === 0) return 0;
   const db = getDb();
   const createdAt = Date.now();

--- a/assistant/src/memory/lifecycle-events-store.ts
+++ b/assistant/src/memory/lifecycle-events-store.ts
@@ -1,7 +1,7 @@
 import { and, asc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getConfig } from "../config/loader.js";
+import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 import { getDb } from "./db-connection.js";
 import { lifecycleEvents } from "./schema.js";
 
@@ -13,7 +13,7 @@ export interface LifecycleEvent {
 
 /** Record a lifecycle event (e.g. app_open, hatch). Returns null when usage data collection is disabled. */
 export function recordLifecycleEvent(eventName: string): LifecycleEvent | null {
-  if (!getConfig().collectUsageData) return null;
+  if (!getCachedShareAnalytics()) return null;
   const db = getDb();
   const event: LifecycleEvent = {
     id: uuid(),

--- a/assistant/src/memory/onboarding-events-store.ts
+++ b/assistant/src/memory/onboarding-events-store.ts
@@ -1,7 +1,7 @@
 import { and, asc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getConfig } from "../config/loader.js";
+import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 import {
   ACTIVATION_AB_VARIANT,
   ACTIVATION_FUNNEL_VERSION,
@@ -58,7 +58,7 @@ function insertOnboardingEvent(event: OnboardingEvent): OnboardingEvent {
 export function recordOnboardingEvent(
   params: RecordOnboardingEventParams,
 ): OnboardingEvent | null {
-  if (!getConfig().collectUsageData) return null;
+  if (!getCachedShareAnalytics()) return null;
   return insertOnboardingEvent({
     id: uuid(),
     createdAt: Date.now(),
@@ -93,7 +93,7 @@ export function recordActivationEvent(params: {
   userId?: string | null;
   abVariant?: string;
 }): OnboardingEvent | null {
-  if (!getConfig().collectUsageData) return null;
+  if (!getCachedShareAnalytics()) return null;
   const createdAt = Date.now();
   return insertOnboardingEvent({
     id: uuid(),

--- a/assistant/src/memory/skill-loaded-events-store.test.ts
+++ b/assistant/src/memory/skill-loaded-events-store.test.ts
@@ -8,18 +8,10 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-let collectUsageData = true;
+let shareAnalytics = true;
 
-mock.module("../config/loader.js", () => ({
-  getConfig: () => ({
-    ui: {},
-    model: "test",
-    provider: "test",
-    memory: { enabled: false },
-    rateLimit: { maxRequestsPerMinute: 0 },
-    secretDetection: { enabled: false },
-    collectUsageData,
-  }),
+mock.module("../platform/consent-cache.js", () => ({
+  getCachedShareAnalytics: () => shareAnalytics,
 }));
 
 import { getDb } from "./db-connection.js";
@@ -42,12 +34,12 @@ function insertEvent(
 
 describe("skill-loaded-events-store", () => {
   beforeEach(() => {
-    collectUsageData = true;
+    shareAnalytics = true;
     getDb().delete(skillLoadedEvents).run();
   });
 
-  test("honors the collectUsageData opt-out (records nothing)", () => {
-    collectUsageData = false;
+  test("honors the share_analytics opt-out (records nothing)", () => {
+    shareAnalytics = false;
     recordSkillLoadedEvent({ skillName: "web-research" });
     expect(queryUnreportedSkillLoadedEvents(0, undefined, 10)).toHaveLength(0);
   });

--- a/assistant/src/memory/skill-loaded-events-store.ts
+++ b/assistant/src/memory/skill-loaded-events-store.ts
@@ -1,7 +1,7 @@
 import { and, asc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getConfig } from "../config/loader.js";
+import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 import type { UsageAttributionColumns } from "../usage/attribution.js";
 import { getDb } from "./db-connection.js";
 import { skillLoadedEvents } from "./schema.js";
@@ -38,7 +38,7 @@ export interface SkillLoadedEvent {
  * opt-out, matching the rest of telemetry).
  */
 export function recordSkillLoadedEvent(record: SkillLoadedEventRecord): void {
-  if (!getConfig().collectUsageData) return;
+  if (!getCachedShareAnalytics()) return;
   const db = getDb();
   db.insert(skillLoadedEvents)
     .values({

--- a/assistant/src/memory/tool-executed-events-store.test.ts
+++ b/assistant/src/memory/tool-executed-events-store.test.ts
@@ -8,12 +8,12 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-// Toggle for the collectUsageData opt-out gate the audit listener consults
+// Toggle for the share_analytics opt-out gate the audit listener consults
 // when populating the telemetry columns.
-let collectUsageData = true;
+let shareAnalytics = true;
 
-mock.module("../config/loader.js", () => ({
-  getConfig: () => ({ collectUsageData }),
+mock.module("../platform/consent-cache.js", () => ({
+  getCachedShareAnalytics: () => shareAnalytics,
 }));
 
 import {
@@ -43,7 +43,7 @@ function insertInvocation(
 
 describe("tool-executed-events-store", () => {
   beforeEach(() => {
-    collectUsageData = true;
+    shareAnalytics = true;
     getDb().delete(toolInvocations).run();
   });
 
@@ -136,10 +136,10 @@ describe("tool-executed-events-store", () => {
 
     listener(executedEvent("t-opted-in-before"));
 
-    collectUsageData = false;
+    shareAnalytics = false;
     listener(executedEvent("t-opted-out"));
 
-    collectUsageData = true;
+    shareAnalytics = true;
     listener(executedEvent("t-opted-in-after"));
 
     // Mid-session opt-out flip: only rows recorded while opted in project.


### PR DESCRIPTION
## Summary
- Replace `getConfig().collectUsageData` with `getCachedShareAnalytics()` in the 5 record-time emitters (onboarding, lifecycle, skill-loaded, auth-fallback event stores + tool-audit listener)
- Preserves no-local-storage-when-opted-out behavior

Part of plan: telemetry-consent-gating.md (PR 4 of 6)