### PR TITLE
fix(consent): gate hatching path on stale toggle consent

### DIFF
--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -343,6 +343,38 @@ describe("resolveNavigation", () => {
         to: "/assistant/onboarding/hatching",
       });
     });
+
+    test("redirects consented platform user with stale analytics toggle and no assistant to review-terms, not hatching", () => {
+      expect(
+        guard(s({ hasAssistants: false, analyticsConsentCurrent: false })),
+      ).toEqual({
+        action: "redirect",
+        to: "/assistant/review-terms?returnTo=%2Fassistant",
+      });
+    });
+
+    test("redirects consented platform user with stale diagnostics toggle and no assistant to review-terms", () => {
+      expect(
+        guard(s({ hasAssistants: false, diagnosticsConsentCurrent: false }), "/assistant/home"),
+      ).toEqual({
+        action: "redirect",
+        to: "/assistant/review-terms?returnTo=%2Fassistant%2Fhome",
+      });
+    });
+
+    test("redirects brand-new platform user with no assistant to privacy, unaffected by stale-toggle gate", () => {
+      expect(
+        guard(
+          s({
+            hasAssistants: false,
+            tosAccepted: false,
+            aiDataConsent: false,
+            analyticsConsentCurrent: false,
+            diagnosticsConsentCurrent: false,
+          }),
+        ),
+      ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -460,9 +492,21 @@ describe("resolveNavigation", () => {
       expect(hatch(s({ tosAccepted: true, aiDataConsent: true }))).toEqual(ALLOW);
     });
 
-    test("stale toggles do not change hatch-gate (hasCompletedOnboarding only)", () => {
+    test("redirects platform user with stale analytics toggle to review-terms", () => {
       expect(
-        hatch(s({ analyticsConsentCurrent: false, diagnosticsConsentCurrent: false })),
+        hatch(s({ analyticsConsentCurrent: false })),
+      ).toEqual({ action: "redirect", to: "/assistant/review-terms" });
+    });
+
+    test("redirects platform user with stale diagnostics toggle to review-terms", () => {
+      expect(
+        hatch(s({ diagnosticsConsentCurrent: false })),
+      ).toEqual({ action: "redirect", to: "/assistant/review-terms" });
+    });
+
+    test("does not gate local-mode user on stale toggles", () => {
+      expect(
+        hatch(s({ isLocalMode: true, analyticsConsentCurrent: false, diagnosticsConsentCurrent: false })),
       ).toEqual(ALLOW);
     });
   });

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -257,7 +257,11 @@ function allowSetupRoutes(
   return null;
 }
 
-function requireAssistant(state: NavigationState): NavigationDecision | null {
+function requireAssistant(
+  state: NavigationState,
+  _path: string,
+  pathnameWithSearch: string,
+): NavigationDecision | null {
   if (state.hasAssistants) return null;
 
   if (state.isLocalMode) {
@@ -270,6 +274,11 @@ function requireAssistant(state: NavigationState): NavigationDecision | null {
 
   if (!hasCompletedOnboarding(state)) {
     return { action: "redirect", to: routes.onboarding.privacy };
+  }
+  // A stale toggle must be re-reviewed before provisioning an assistant.
+  if (!consentIsCurrent(state)) {
+    const returnTo = encodeURIComponent(pathnameWithSearch);
+    return { action: "redirect", to: `${routes.reviewTerms}?returnTo=${returnTo}` };
   }
   // A consented user with no assistant goes to the standard hatching screen.
   return { action: "redirect", to: routes.onboarding.hatching };
@@ -319,6 +328,10 @@ function resolveHatchGate(state: NavigationState): NavigationDecision {
   }
   if (!hasCompletedOnboarding(state)) {
     return { action: "redirect", to: onboardingEntrypoint(state.isLocalMode) };
+  }
+  // A stale toggle must be re-reviewed before hatching, even via direct navigation.
+  if (!state.isLocalMode && !consentIsCurrent(state)) {
+    return { action: "redirect", to: routes.reviewTerms };
   }
   return { action: "allow" };
 }


### PR DESCRIPTION
## Summary
Fixes gap from plan review for consent-toggle-versioning.md.

A consented platform user (TOS/AI current) with a stale share toggle and no assistant was routed to hatching before requireConsent ran, bypassing the stale-toggle gate. requireAssistant and the hatch-gate now divert such users to review-terms. Brand-new-user onboarding routing is unchanged.