### PR TITLE
refactor(consent): break onboarding-cleanup<->auth-store import cycle

### DIFF
--- a/clients/web/src/domains/settings/pages/privacy-page.tsx
+++ b/clients/web/src/domains/settings/pages/privacy-page.tsx
@@ -9,7 +9,7 @@ import { RiskToleranceSettings } from "@/domains/settings/components/risk-tolera
 import { TrustRules } from "@/domains/settings/components/trust-rules/trust-rules";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
-import { useHasPlatformSession } from "@/stores/auth-store";
+import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
 import {
     getDeviceBool,
     getDeviceSetting,
@@ -69,6 +69,7 @@ export function PrivacyPage() {
   const platformGate = usePlatformGate({ platformHostedOnly: true });
   const channelTrustFloors = useAssistantFeatureFlagStore.use.channelTrustFloors();
   const hasPlatformSession = useHasPlatformSession();
+  const userId = useAuthStore.use.user()?.id ?? null;
   const [shareAnalytics, setShareAnalytics] = useState(
     () => getDeviceBool("shareAnalytics", true),
   );
@@ -82,13 +83,13 @@ export function PrivacyPage() {
   const handleAnalyticsToggle = () => {
     const next = !shareAnalytics;
     setShareAnalytics(next);
-    savePreferenceToggle("share_analytics", next, hasPlatformSession);
+    savePreferenceToggle("share_analytics", next, { userId, hasPlatformSession });
   };
 
   const handleDiagnosticsToggle = () => {
     const next = !shareDiagnostics;
     setShareDiagnostics(next);
-    savePreferenceToggle("share_diagnostics", next, hasPlatformSession);
+    savePreferenceToggle("share_diagnostics", next, { userId, hasPlatformSession });
   };
 
   const handleRetentionChange = (value: string) => {

--- a/clients/web/src/utils/onboarding-cleanup.test.ts
+++ b/clients/web/src/utils/onboarding-cleanup.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for the versioned share-toggle consent layer in `onboarding-cleanup`.
  *
- * Collaborators (`onboarding-store`, `auth-store`, `profile.patchConsent`,
+ * Collaborators (`onboarding-store`, `profile.patchConsent`,
  * `device-settings`) are mocked so we exercise the per-user device-key
  * read/write logic in isolation against an in-memory `localStorage`.
  */
@@ -32,11 +32,6 @@ const storeState = {
 };
 mock.module("@/domains/onboarding/onboarding-store", () => ({
   useOnboardingStore: { getState: () => storeState },
-}));
-
-let authUserId: string | null = "user-1";
-mock.module("@/stores/auth-store", () => ({
-  useAuthStore: { getState: () => ({ user: authUserId ? { id: authUserId } : null }) },
 }));
 
 // `onboarding-cleanup` only needs `patchConsent`; the real `profile` module
@@ -87,7 +82,6 @@ const diagnosticsKey = (userId: string) =>
   `device:consent:share_diagnostics:v${CONSENT_VERSION}:${userId}`;
 
 beforeEach(() => {
-  authUserId = "user-1";
   storeState.setTosAccepted.mockReset();
   storeState.setAiDataConsent.mockReset();
   storeState.setShareAnalytics.mockReset();
@@ -207,7 +201,7 @@ describe("saveConsent", () => {
 
 describe("savePreferenceToggle", () => {
   test("stamps the analytics version and sets its flag only", () => {
-    savePreferenceToggle("share_analytics", true, true);
+    savePreferenceToggle("share_analytics", true, { userId: "user-1", hasPlatformSession: true });
     expect(storeState.setAnalyticsConsentCurrent).toHaveBeenCalledWith(true);
     expect(storeState.setDiagnosticsConsentCurrent).not.toHaveBeenCalled();
     expect(localStorage.getItem(analyticsKey("user-1"))).toBe("true");
@@ -218,7 +212,7 @@ describe("savePreferenceToggle", () => {
   });
 
   test("stamps the diagnostics version and sets its flag only", () => {
-    savePreferenceToggle("share_diagnostics", false, true);
+    savePreferenceToggle("share_diagnostics", false, { userId: "user-1", hasPlatformSession: true });
     expect(storeState.setDiagnosticsConsentCurrent).toHaveBeenCalledWith(true);
     expect(storeState.setAnalyticsConsentCurrent).not.toHaveBeenCalled();
     const body = patchConsentMock.mock.calls[0][0];

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -24,7 +24,6 @@
 import { removeLocalSetting, getLocalBool, setLocalBool } from "@/utils/local-settings";
 import { setDeviceBool } from "@/utils/device-settings";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
-import { useAuthStore } from "@/stores/auth-store";
 import { patchConsent, type UserConsent } from "@/domains/account/profile";
 
 export const CONSENT_VERSION = "2026-06-08";
@@ -182,10 +181,10 @@ export function saveConsent(opts: {
 export function savePreferenceToggle(
   field: "share_analytics" | "share_diagnostics",
   value: boolean,
-  hasPlatformSession: boolean,
+  opts: { userId: string | null; hasPlatformSession: boolean },
 ): void {
   const store = useOnboardingStore.getState();
-  const userId = useAuthStore.getState().user?.id ?? null;
+  const { userId, hasPlatformSession } = opts;
   if (field === "share_analytics") {
     store.setShareAnalytics(value);
     setDeviceBool("shareAnalytics", value);


### PR DESCRIPTION
## Summary
Fixes gap from plan review for consent-toggle-versioning.md.

savePreferenceToggle no longer imports useAuthStore (which created a cycle with auth-store importing onboarding-cleanup). It now takes userId as a parameter, supplied by the settings privacy-page caller.