### PR TITLE
feat(consent): version share_analytics & share_diagnostics toggles

### DIFF
--- a/clients/web/src/domains/account/profile.ts
+++ b/clients/web/src/domains/account/profile.ts
@@ -15,10 +15,21 @@ export interface UserConsent {
   ai_data_sharing_accepted_at: string | null;
   share_analytics: boolean;
   share_diagnostics: boolean;
+  share_analytics_accepted_version: string;
+  share_analytics_accepted_at: string | null;
+  share_diagnostics_accepted_version: string;
+  share_diagnostics_accepted_at: string | null;
 }
 
 export type ConsentPatch = Partial<
-  Omit<UserConsent, "tos_accepted_at" | "privacy_policy_accepted_at" | "ai_data_sharing_accepted_at">
+  Omit<
+    UserConsent,
+    | "tos_accepted_at"
+    | "privacy_policy_accepted_at"
+    | "ai_data_sharing_accepted_at"
+    | "share_analytics_accepted_at"
+    | "share_diagnostics_accepted_at"
+  >
 >;
 
 export interface UserMe {

--- a/clients/web/src/domains/account/profile.ts
+++ b/clients/web/src/domains/account/profile.ts
@@ -27,7 +27,6 @@ export interface UserMe {
   email: string;
   first_name: string;
   last_name: string;
-  consent: UserConsent | null;
 }
 
 export type UsernameErrorCode =
@@ -133,10 +132,26 @@ export async function updateMe(patch: UpdateMePatch): Promise<UpdateMeResult> {
   };
 }
 
+export async function fetchConsent(): Promise<UserConsent> {
+  const { data, error, response } = await client.get<UserConsent, unknown>({
+    url: "/v1/user/consent/",
+    throwOnError: false,
+  });
+  assertHasResponse(response, error, "Failed to load consent.");
+  if (!response.ok || !data) {
+    throw new ApiError(
+      response.status,
+      extractErrorMessage(error, response, "Failed to load consent."),
+    );
+  }
+  return data;
+}
+
+// PUTs /v1/user/consent/ — partial bodies are accepted, no writable field is required.
 export async function patchConsent(consent: ConsentPatch): Promise<void> {
-  await client.patch({
-    url: "/v1/user/me/",
-    body: { consent },
+  await client.put({
+    url: "/v1/user/consent/",
+    body: consent,
     throwOnError: true,
   });
 }

--- a/clients/web/src/domains/onboarding/components/setting-row.tsx
+++ b/clients/web/src/domains/onboarding/components/setting-row.tsx
@@ -1,0 +1,30 @@
+import { useId } from "react";
+
+import { Toggle } from "@vellumai/design-library/components/toggle";
+
+export function SettingRow({
+  label,
+  helperText,
+  checked,
+  onChange,
+}: {
+  label: string;
+  helperText: string;
+  checked: boolean;
+  onChange: (next: boolean) => void;
+}) {
+  const toggleId = useId();
+  return (
+    <div className="flex items-start gap-4">
+      <Toggle checked={checked} onChange={onChange} id={toggleId} />
+      <label htmlFor={toggleId} className="min-w-0 flex-1 cursor-pointer">
+        <span className="block text-body-medium-default text-[var(--content-default)]">
+          {label}
+        </span>
+        <span className="mt-1 block text-body-small-default text-[var(--content-tertiary)]">
+          {helperText}
+        </span>
+      </label>
+    </div>
+  );
+}

--- a/clients/web/src/domains/onboarding/onboarding-store.ts
+++ b/clients/web/src/domains/onboarding/onboarding-store.ts
@@ -5,10 +5,12 @@
  * written to `device:` localStorage keys on every setter call and synced
  * across tabs via `watchSetting`. They survive logout.
  *
- * **In-memory-only fields** (`tosAccepted`, `aiDataConsent`) start `false`
- * and are populated by `restoreConsentForUser` (called from the auth store
- * once the user id is known). Persistence to durable per-user device keys
- * is handled by `persistConsentForUser` in `onboarding-cleanup.ts`.
+ * **In-memory-only fields** (`tosAccepted`, `aiDataConsent`,
+ * `analyticsConsentCurrent`, `diagnosticsConsentCurrent`) start `false` and
+ * are populated on session sync (e.g. `restoreConsentForUser`, called from
+ * the auth store once the user id is known). Persistence to durable per-user
+ * device keys is handled by `persistConsentForUser` in
+ * `onboarding-cleanup.ts`.
  *
  * Reference: {@link https://zustand.docs.pmnd.rs/}
  */
@@ -40,6 +42,8 @@ export interface OnboardingState {
   shareDiagnostics: boolean;
   tosAccepted: boolean;
   aiDataConsent: boolean;
+  analyticsConsentCurrent: boolean;
+  diagnosticsConsentCurrent: boolean;
 }
 
 export interface OnboardingActions {
@@ -47,6 +51,8 @@ export interface OnboardingActions {
   setShareDiagnostics: (value: boolean) => void;
   setTosAccepted: (value: boolean) => void;
   setAiDataConsent: (value: boolean) => void;
+  setAnalyticsConsentCurrent: (value: boolean) => void;
+  setDiagnosticsConsentCurrent: (value: boolean) => void;
 }
 
 export type OnboardingStore = OnboardingState & OnboardingActions;
@@ -60,6 +66,8 @@ const useOnboardingStoreBase = create<OnboardingStore>()((set) => ({
   shareDiagnostics: getLocalBool(KEY_SHARE_DIAGNOSTICS, true),
   tosAccepted: false,
   aiDataConsent: false,
+  analyticsConsentCurrent: false,
+  diagnosticsConsentCurrent: false,
 
   setShareAnalytics: (value) => {
     set({ shareAnalytics: value });
@@ -75,6 +83,12 @@ const useOnboardingStoreBase = create<OnboardingStore>()((set) => ({
   },
   setAiDataConsent: (value) => {
     set({ aiDataConsent: value });
+  },
+  setAnalyticsConsentCurrent: (value) => {
+    set({ analyticsConsentCurrent: value });
+  },
+  setDiagnosticsConsentCurrent: (value) => {
+    set({ diagnosticsConsentCurrent: value });
   },
 }));
 

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
@@ -21,6 +21,8 @@ mock.module("@/domains/onboarding/prefs", () => ({
   useShareDiagnostics: () => [false, setShareDiagnostics],
   useTosAccepted: () => [true, setTosAccepted],
   useAiDataConsent: () => [true, setAiDataConsent],
+  useAnalyticsConsentCurrent: () => [true, mock(() => {})],
+  useDiagnosticsConsentCurrent: () => [true, mock(() => {})],
 }));
 
 const saveConsentMock = mock((_args: unknown) => {});

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -1,8 +1,9 @@
 import { EyeOff } from "lucide-react";
-import { useCallback, useEffect, useId, type ReactNode } from "react";
+import { useCallback, useEffect, type ReactNode } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
+import { SettingRow } from "@/domains/onboarding/components/setting-row";
 import { StepIndicatorDots } from "@/domains/onboarding/components/step-indicator-dots";
 import {
     emitOnboardingFunnelStepCompleted,
@@ -26,38 +27,6 @@ import { legalUrl, routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 import { Card } from "@vellumai/design-library/components/card";
 import { Checkbox } from "@vellumai/design-library/components/checkbox";
-import { Toggle } from "@vellumai/design-library/components/toggle";
-
-function SettingRow({
-  label,
-  helperText,
-  checked,
-  onChange,
-}: {
-  label: string;
-  helperText: string;
-  checked: boolean;
-  onChange: (next: boolean) => void;
-}) {
-  const toggleId = useId();
-  return (
-    <div className="flex items-start gap-4">
-      <Toggle
-        checked={checked}
-        onChange={onChange}
-        id={toggleId}
-      />
-      <label htmlFor={toggleId} className="min-w-0 flex-1 cursor-pointer">
-        <span className="block text-body-medium-default text-[var(--content-default)]">
-          {label}
-        </span>
-        <span className="mt-1 block text-body-small-default text-[var(--content-tertiary)]">
-          {helperText}
-        </span>
-      </label>
-    </div>
-  );
-}
 
 // Consent checkboxes mirror the primary button: the checked fill uses
 // --primary-base and the check uses --content-inset (the on-primary

--- a/clients/web/src/domains/onboarding/pages/review-terms-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/review-terms-screen.test.tsx
@@ -177,6 +177,25 @@ describe("ReviewTermsScreen", () => {
     expect(setTosAccepted).toHaveBeenCalledWith(true);
 
     rerender(<ReviewTermsScreen />);
+    // Staleness is snapshotted at mount, so the checkbox stays visible (now
+    // showing the checked state) instead of unmounting the instant it's checked.
+    const checkedTos = screen.getByLabelText(TOS_LABEL) as HTMLInputElement;
+    expect(checkedTos).toBeTruthy();
+    expect(checkedTos.checked).toBe(true);
     expect(continueButton().disabled).toBe(false);
+  });
+
+  test("heading stays on 'Updated Terms' after the last legal box is checked", () => {
+    tosAccepted = false; // tos stale -> "Updated Terms" heading
+    const { rerender } = render(<ReviewTermsScreen />);
+
+    expect(screen.getByText("Updated Terms")).toBeTruthy();
+
+    fireEvent.click(screen.getByLabelText(TOS_LABEL));
+    rerender(<ReviewTermsScreen />);
+
+    // Heading must not flip mid-flow once the box is checked.
+    expect(screen.getByText("Updated Terms")).toBeTruthy();
+    expect(screen.queryByText("Review your privacy preferences")).toBeNull();
   });
 });

--- a/clients/web/src/domains/onboarding/pages/review-terms-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/review-terms-screen.test.tsx
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+// react-router: capture navigate() targets.
+const navigateMock = mock((..._args: unknown[]) => {});
+let searchParamsValue = new URLSearchParams();
+mock.module("react-router", () => ({
+  useNavigate: () => navigateMock,
+  useSearchParams: () => [searchParamsValue, mock(() => {})],
+}));
+
+// Prefs hooks — mutable per-test so we can model each staleness combination.
+let tosAccepted = true;
+let aiDataConsent = true;
+let shareAnalytics = true;
+let shareDiagnostics = true;
+let analyticsConsentCurrent = true;
+let diagnosticsConsentCurrent = true;
+const setTosAccepted = mock((next: boolean) => {
+  tosAccepted = next;
+});
+const setAiDataConsent = mock((next: boolean) => {
+  aiDataConsent = next;
+});
+const setShareAnalytics = mock((next: boolean) => {
+  shareAnalytics = next;
+});
+const setShareDiagnostics = mock((next: boolean) => {
+  shareDiagnostics = next;
+});
+mock.module("@/domains/onboarding/prefs", () => ({
+  useTosAccepted: () => [tosAccepted, setTosAccepted],
+  useAiDataConsent: () => [aiDataConsent, setAiDataConsent],
+  useShareAnalytics: () => [shareAnalytics, setShareAnalytics],
+  useShareDiagnostics: () => [shareDiagnostics, setShareDiagnostics],
+  useAnalyticsConsentCurrent: () => [analyticsConsentCurrent, mock(() => {})],
+  useDiagnosticsConsentCurrent: () => [diagnosticsConsentCurrent, mock(() => {})],
+}));
+
+const saveConsentMock = mock((_args: unknown) => {});
+mock.module("@/utils/onboarding-cleanup", () => ({
+  saveConsent: saveConsentMock,
+}));
+
+mock.module("@/lib/auth/hard-navigate", () => ({
+  hardNavigate: mock(() => {}),
+}));
+mock.module("@/runtime/is-electron", () => ({ isElectron: () => true }));
+mock.module("@/stores/auth-store", () => ({
+  useAuthStore: { use: { user: () => ({ id: "user-1" }), logout: () => mock(async () => {}) } },
+  useHasPlatformSession: () => true,
+}));
+
+// Light passthroughs for layout/design-library so the screen renders in happy-dom.
+mock.module("@/domains/onboarding/components/onboarding-layout", () => ({
+  OnboardingLayout: ({ children }: { children: React.ReactNode }) => children,
+}));
+mock.module("@vellumai/design-library/components/button", () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+mock.module("@vellumai/design-library/components/checkbox", () => ({
+  Checkbox: ({
+    checked,
+    onCheckedChange,
+    "aria-label": ariaLabel,
+  }: {
+    checked: boolean;
+    onCheckedChange: (next: boolean) => void;
+    "aria-label"?: string;
+  }) => (
+    <input
+      type="checkbox"
+      aria-label={ariaLabel}
+      checked={checked}
+      onChange={(e) => onCheckedChange(e.target.checked)}
+    />
+  ),
+}));
+mock.module("@vellumai/design-library/components/toggle", () => ({
+  Toggle: ({
+    checked,
+    onChange,
+    id,
+  }: {
+    checked: boolean;
+    onChange: (next: boolean) => void;
+    id?: string;
+  }) => (
+    <input
+      type="checkbox"
+      role="switch"
+      id={id}
+      checked={checked}
+      onChange={(e) => onChange(e.target.checked)}
+    />
+  ),
+}));
+
+const { ReviewTermsScreen } = await import(
+  "@/domains/onboarding/pages/review-terms-screen"
+);
+
+const TOS_LABEL = "I agree to the Terms of Service and Privacy Policy";
+const AI_LABEL = "I agree to the AI Data Sharing Policy";
+
+function continueButton(): HTMLButtonElement {
+  return screen.getByText("Continue") as HTMLButtonElement;
+}
+
+describe("ReviewTermsScreen", () => {
+  beforeEach(() => {
+    navigateMock.mockClear();
+    saveConsentMock.mockClear();
+    setShareAnalytics.mockClear();
+    searchParamsValue = new URLSearchParams();
+    tosAccepted = true;
+    aiDataConsent = true;
+    shareAnalytics = true;
+    shareDiagnostics = true;
+    analyticsConsentCurrent = true;
+    diagnosticsConsentCurrent = true;
+  });
+  afterEach(cleanup);
+
+  test("toggle-only staleness renders the toggle, no legal checkboxes, and Continue enabled", () => {
+    analyticsConsentCurrent = false; // analytics stale; tos/ai current
+    render(<ReviewTermsScreen />);
+
+    // The analytics toggle is shown.
+    expect(screen.getByRole("switch")).toBeTruthy();
+    // No legal checkboxes.
+    expect(screen.queryByLabelText(TOS_LABEL)).toBeNull();
+    expect(screen.queryByLabelText(AI_LABEL)).toBeNull();
+    // Continue is enabled.
+    expect(continueButton().disabled).toBe(false);
+  });
+
+  test("flipping a toggle then Continue calls saveConsent with the chosen value", () => {
+    analyticsConsentCurrent = false;
+    shareAnalytics = true;
+    const { rerender } = render(<ReviewTermsScreen />);
+
+    fireEvent.click(screen.getByRole("switch"));
+    expect(setShareAnalytics).toHaveBeenCalledWith(false);
+
+    // Re-render so the component picks up the new store value before Continue.
+    rerender(<ReviewTermsScreen />);
+    fireEvent.click(continueButton());
+
+    expect(saveConsentMock).toHaveBeenCalledTimes(1);
+    expect(saveConsentMock.mock.calls[0]?.[0]).toMatchObject({
+      shareAnalytics: false,
+    });
+  });
+
+  test("stale TOS renders its checkbox and gates Continue until checked", () => {
+    tosAccepted = false; // tos stale
+    const { rerender } = render(<ReviewTermsScreen />);
+
+    const tosCheckbox = screen.getByLabelText(TOS_LABEL);
+    expect(tosCheckbox).toBeTruthy();
+    expect(continueButton().disabled).toBe(true);
+
+    fireEvent.click(tosCheckbox);
+    expect(setTosAccepted).toHaveBeenCalledWith(true);
+
+    rerender(<ReviewTermsScreen />);
+    expect(continueButton().disabled).toBe(false);
+  });
+});

--- a/clients/web/src/domains/onboarding/pages/review-terms-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/review-terms-screen.tsx
@@ -2,8 +2,11 @@ import { useCallback, type ReactNode } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
+import { SettingRow } from "@/domains/onboarding/components/setting-row";
 import {
     useAiDataConsent,
+    useAnalyticsConsentCurrent,
+    useDiagnosticsConsentCurrent,
     useShareAnalytics,
     useShareDiagnostics,
     useTosAccepted,
@@ -30,8 +33,16 @@ export function ReviewTermsScreen() {
 
   const [tosAccepted, setTosAccepted] = useTosAccepted();
   const [aiDataConsent, setAiDataConsent] = useAiDataConsent();
-  const [shareAnalytics] = useShareAnalytics();
-  const [shareDiagnostics] = useShareDiagnostics();
+  const [shareAnalytics, setShareAnalytics] = useShareAnalytics();
+  const [shareDiagnostics, setShareDiagnostics] = useShareDiagnostics();
+  const [analyticsConsentCurrent] = useAnalyticsConsentCurrent();
+  const [diagnosticsConsentCurrent] = useDiagnosticsConsentCurrent();
+
+  const tosStale = !tosAccepted;
+  const aiStale = !aiDataConsent;
+  const analyticsStale = !analyticsConsentCurrent;
+  const diagnosticsStale = !diagnosticsConsentCurrent;
+  const onlyTogglesStale = !tosStale && !aiStale;
 
   const onContinue = useCallback(() => {
     saveConsent({ userId, tos: tosAccepted, ai: aiDataConsent, shareAnalytics, shareDiagnostics, hasPlatformSession });
@@ -91,6 +102,10 @@ export function ReviewTermsScreen() {
     </span>
   );
 
+  // Only shown legal checkboxes gate Continue. Toggles never block — off is a
+  // valid choice — so when only toggles are stale Continue is enabled.
+  const continueDisabled = (tosStale && !tosAccepted) || (aiStale && !aiDataConsent);
+
   return (
     <OnboardingLayout showCreatureFooter={false}>
       <div
@@ -100,40 +115,70 @@ export function ReviewTermsScreen() {
           className={electron ? "text-title-large" : "text-3xl font-semibold tracking-tight"}
           style={{ animation: "fadeInUp 0.5s ease-out 0.1s both" }}
         >
-          Updated Terms
+          {onlyTogglesStale ? "Review your privacy preferences" : "Updated Terms"}
         </h1>
         <p
           className={`text-center text-body-medium-lighter text-[var(--content-tertiary)] ${electron ? "mt-3.5" : "mt-4"}`}
           style={{ animation: "fadeInUp 0.5s ease-out 0.3s both" }}
         >
-          We&apos;ve updated our terms. Please review and re-accept to continue.
+          {onlyTogglesStale
+            ? "We've updated our privacy preferences. Please review them to continue."
+            : "We've updated our terms. Please review and re-accept to continue."}
         </p>
 
-        <div
-          className="mt-8 flex w-full items-start"
-          style={{ animation: "fadeInUp 0.5s ease-out 0.4s both" }}
-        >
-          <Checkbox
-            checked={aiDataConsent}
-            onCheckedChange={(next) => setAiDataConsent(next === true)}
-            label={aiConsentLabel}
-            aria-label="I agree to the AI Data Sharing Policy"
-            className={CONSENT_CHECKBOX_CLASS}
-          />
-        </div>
+        {(analyticsStale || diagnosticsStale) && (
+          <div
+            className="mt-8 flex w-full flex-col gap-4"
+            style={{ animation: "fadeInUp 0.5s ease-out 0.4s both" }}
+          >
+            {analyticsStale && (
+              <SettingRow
+                label="Share Analytics"
+                helperText="Send anonymous product usage data."
+                checked={shareAnalytics}
+                onChange={setShareAnalytics}
+              />
+            )}
+            {diagnosticsStale && (
+              <SettingRow
+                label="Share Diagnostics"
+                helperText="Send crash reports and performance metrics."
+                checked={shareDiagnostics}
+                onChange={setShareDiagnostics}
+              />
+            )}
+          </div>
+        )}
 
-        <div
-          className={`flex w-full items-start ${electron ? "mt-2" : "mt-4"}`}
-          style={{ animation: "fadeInUp 0.5s ease-out 0.45s both" }}
-        >
-          <Checkbox
-            checked={tosAccepted}
-            onCheckedChange={(next) => setTosAccepted(next === true)}
-            label={tosLabel}
-            aria-label="I agree to the Terms of Service and Privacy Policy"
-            className={CONSENT_CHECKBOX_CLASS}
-          />
-        </div>
+        {aiStale && (
+          <div
+            className="mt-8 flex w-full items-start"
+            style={{ animation: "fadeInUp 0.5s ease-out 0.45s both" }}
+          >
+            <Checkbox
+              checked={aiDataConsent}
+              onCheckedChange={(next) => setAiDataConsent(next === true)}
+              label={aiConsentLabel}
+              aria-label="I agree to the AI Data Sharing Policy"
+              className={CONSENT_CHECKBOX_CLASS}
+            />
+          </div>
+        )}
+
+        {tosStale && (
+          <div
+            className={`flex w-full items-start ${electron ? "mt-2" : "mt-4"}`}
+            style={{ animation: "fadeInUp 0.5s ease-out 0.5s both" }}
+          >
+            <Checkbox
+              checked={tosAccepted}
+              onCheckedChange={(next) => setTosAccepted(next === true)}
+              label={tosLabel}
+              aria-label="I agree to the Terms of Service and Privacy Policy"
+              className={CONSENT_CHECKBOX_CLASS}
+            />
+          </div>
+        )}
 
         <div
           className={`mt-8 flex w-full flex-col ${electron ? "gap-2.5" : "gap-2"}`}
@@ -143,7 +188,7 @@ export function ReviewTermsScreen() {
             variant="primary"
             size="regular"
             fullWidth
-            disabled={!tosAccepted || !aiDataConsent}
+            disabled={continueDisabled}
             onClick={onContinue}
             className={electron ? undefined : "h-11 text-base"}
           >

--- a/clients/web/src/domains/onboarding/pages/review-terms-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/review-terms-screen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, type ReactNode } from "react";
+import { useCallback, useState, type ReactNode } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
@@ -38,11 +38,14 @@ export function ReviewTermsScreen() {
   const [analyticsConsentCurrent] = useAnalyticsConsentCurrent();
   const [diagnosticsConsentCurrent] = useDiagnosticsConsentCurrent();
 
-  const tosStale = !tosAccepted;
-  const aiStale = !aiDataConsent;
-  const analyticsStale = !analyticsConsentCurrent;
-  const diagnosticsStale = !diagnosticsConsentCurrent;
-  const onlyTogglesStale = !tosStale && !aiStale;
+  // Snapshot staleness at mount: these are the sections the user was routed
+  // here to address. Gating render on live values would unmount a checkbox the
+  // instant it's checked, so the user never sees the checked state.
+  const [tosStaleAtMount] = useState(() => !tosAccepted);
+  const [aiStaleAtMount] = useState(() => !aiDataConsent);
+  const [analyticsStaleAtMount] = useState(() => !analyticsConsentCurrent);
+  const [diagnosticsStaleAtMount] = useState(() => !diagnosticsConsentCurrent);
+  const onlyTogglesStaleAtMount = !tosStaleAtMount && !aiStaleAtMount;
 
   const onContinue = useCallback(() => {
     saveConsent({ userId, tos: tosAccepted, ai: aiDataConsent, shareAnalytics, shareDiagnostics, hasPlatformSession });
@@ -102,9 +105,10 @@ export function ReviewTermsScreen() {
     </span>
   );
 
-  // Only shown legal checkboxes gate Continue. Toggles never block — off is a
-  // valid choice — so when only toggles are stale Continue is enabled.
-  const continueDisabled = (tosStale && !tosAccepted) || (aiStale && !aiDataConsent);
+  // Only the legal checkboxes shown at mount gate Continue, driven by their
+  // live checked values. Toggles never block — off is a valid choice.
+  const continueDisabled =
+    (tosStaleAtMount && !tosAccepted) || (aiStaleAtMount && !aiDataConsent);
 
   return (
     <OnboardingLayout showCreatureFooter={false}>
@@ -115,23 +119,23 @@ export function ReviewTermsScreen() {
           className={electron ? "text-title-large" : "text-3xl font-semibold tracking-tight"}
           style={{ animation: "fadeInUp 0.5s ease-out 0.1s both" }}
         >
-          {onlyTogglesStale ? "Review your privacy preferences" : "Updated Terms"}
+          {onlyTogglesStaleAtMount ? "Review your privacy preferences" : "Updated Terms"}
         </h1>
         <p
           className={`text-center text-body-medium-lighter text-[var(--content-tertiary)] ${electron ? "mt-3.5" : "mt-4"}`}
           style={{ animation: "fadeInUp 0.5s ease-out 0.3s both" }}
         >
-          {onlyTogglesStale
+          {onlyTogglesStaleAtMount
             ? "We've updated our privacy preferences. Please review them to continue."
             : "We've updated our terms. Please review and re-accept to continue."}
         </p>
 
-        {(analyticsStale || diagnosticsStale) && (
+        {(analyticsStaleAtMount || diagnosticsStaleAtMount) && (
           <div
             className="mt-8 flex w-full flex-col gap-4"
             style={{ animation: "fadeInUp 0.5s ease-out 0.4s both" }}
           >
-            {analyticsStale && (
+            {analyticsStaleAtMount && (
               <SettingRow
                 label="Share Analytics"
                 helperText="Send anonymous product usage data."
@@ -139,7 +143,7 @@ export function ReviewTermsScreen() {
                 onChange={setShareAnalytics}
               />
             )}
-            {diagnosticsStale && (
+            {diagnosticsStaleAtMount && (
               <SettingRow
                 label="Share Diagnostics"
                 helperText="Send crash reports and performance metrics."
@@ -150,7 +154,7 @@ export function ReviewTermsScreen() {
           </div>
         )}
 
-        {aiStale && (
+        {aiStaleAtMount && (
           <div
             className="mt-8 flex w-full items-start"
             style={{ animation: "fadeInUp 0.5s ease-out 0.45s both" }}
@@ -165,7 +169,7 @@ export function ReviewTermsScreen() {
           </div>
         )}
 
-        {tosStale && (
+        {tosStaleAtMount && (
           <div
             className={`flex w-full items-start ${electron ? "mt-2" : "mt-4"}`}
             style={{ animation: "fadeInUp 0.5s ease-out 0.5s both" }}

--- a/clients/web/src/domains/onboarding/prefs.ts
+++ b/clients/web/src/domains/onboarding/prefs.ts
@@ -87,6 +87,32 @@ export function useAiDataConsent(): [boolean, (next: boolean) => void] {
   return [value, setter];
 }
 
+/**
+ * Whether the analytics consent the user accepted is for the current toggle
+ * version. Set on session sync by the auth store. A stale value means the user
+ * must re-review the terms.
+ */
+export function useAnalyticsConsentCurrent(): [boolean, (next: boolean) => void] {
+  const value = useOnboardingStore.use.analyticsConsentCurrent();
+  const setter = useCallback((next: boolean) => {
+    useOnboardingStore.getState().setAnalyticsConsentCurrent(next);
+  }, []);
+  return [value, setter];
+}
+
+/**
+ * Whether the diagnostics consent the user accepted is for the current toggle
+ * version. Set on session sync by the auth store. A stale value means the user
+ * must re-review the terms.
+ */
+export function useDiagnosticsConsentCurrent(): [boolean, (next: boolean) => void] {
+  const value = useOnboardingStore.use.diagnosticsConsentCurrent();
+  const setter = useCallback((next: boolean) => {
+    useOnboardingStore.getState().setDiagnosticsConsentCurrent(next);
+  }, []);
+  return [value, setter];
+}
+
 // ---------------------------------------------------------------------------
 // Non-hook readers (for gates/guards outside React render)
 // ---------------------------------------------------------------------------
@@ -110,6 +136,24 @@ export function readTosAccepted(): boolean {
  */
 export function readAiDataConsent(): boolean {
   return useOnboardingStore.getState().aiDataConsent;
+}
+
+/**
+ * SSR-safe, non-hook read of whether analytics consent is for the current
+ * toggle version. Used by the navigation guard to redirect platform users
+ * back to review-terms when their consent has gone stale.
+ */
+export function readAnalyticsConsentCurrent(): boolean {
+  return useOnboardingStore.getState().analyticsConsentCurrent;
+}
+
+/**
+ * SSR-safe, non-hook read of whether diagnostics consent is for the current
+ * toggle version. Used alongside `readAnalyticsConsentCurrent()` by the
+ * navigation guard.
+ */
+export function readDiagnosticsConsentCurrent(): boolean {
+  return useOnboardingStore.getState().diagnosticsConsentCurrent;
 }
 
 /**

--- a/clients/web/src/domains/settings/pages/privacy-page.tsx
+++ b/clients/web/src/domains/settings/pages/privacy-page.tsx
@@ -9,7 +9,7 @@ import { RiskToleranceSettings } from "@/domains/settings/components/risk-tolera
 import { TrustRules } from "@/domains/settings/components/trust-rules/trust-rules";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
-import { useHasPlatformSession } from "@/stores/auth-store";
+import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
 import {
     getDeviceBool,
     getDeviceSetting,
@@ -69,6 +69,7 @@ export function PrivacyPage() {
   const platformGate = usePlatformGate({ platformHostedOnly: true });
   const channelTrustFloors = useAssistantFeatureFlagStore.use.channelTrustFloors();
   const hasPlatformSession = useHasPlatformSession();
+  const userId = useAuthStore.use.user()?.id ?? null;
   const [shareAnalytics, setShareAnalytics] = useState(
     () => getDeviceBool("shareAnalytics", true),
   );
@@ -82,13 +83,13 @@ export function PrivacyPage() {
   const handleAnalyticsToggle = () => {
     const next = !shareAnalytics;
     setShareAnalytics(next);
-    savePreferenceToggle("share_analytics", next, hasPlatformSession);
+    savePreferenceToggle("share_analytics", next, { userId, hasPlatformSession });
   };
 
   const handleDiagnosticsToggle = () => {
     const next = !shareDiagnostics;
     setShareDiagnostics(next);
-    savePreferenceToggle("share_diagnostics", next, hasPlatformSession);
+    savePreferenceToggle("share_diagnostics", next, { userId, hasPlatformSession });
   };
 
   const handleRetentionChange = (value: string) => {

--- a/clients/web/src/lib/navigation/build-state.ts
+++ b/clients/web/src/lib/navigation/build-state.ts
@@ -5,6 +5,8 @@ import { isLocalMode } from "@/lib/local-mode";
 import {
   readTosAccepted,
   readAiDataConsent,
+  readAnalyticsConsentCurrent,
+  readDiagnosticsConsentCurrent,
 } from "@/domains/onboarding/prefs";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import type { NavigationState } from "./navigation-resolver";
@@ -22,6 +24,8 @@ export function buildNavigationState(
     platformSession,
     tosAccepted: readTosAccepted(),
     aiDataConsent: readAiDataConsent(),
+    analyticsConsentCurrent: readAnalyticsConsentCurrent(),
+    diagnosticsConsentCurrent: readDiagnosticsConsentCurrent(),
     ...overrides,
   };
 }

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -343,6 +343,38 @@ describe("resolveNavigation", () => {
         to: "/assistant/onboarding/hatching",
       });
     });
+
+    test("redirects consented platform user with stale analytics toggle and no assistant to review-terms, not hatching", () => {
+      expect(
+        guard(s({ hasAssistants: false, analyticsConsentCurrent: false })),
+      ).toEqual({
+        action: "redirect",
+        to: "/assistant/review-terms?returnTo=%2Fassistant",
+      });
+    });
+
+    test("redirects consented platform user with stale diagnostics toggle and no assistant to review-terms", () => {
+      expect(
+        guard(s({ hasAssistants: false, diagnosticsConsentCurrent: false }), "/assistant/home"),
+      ).toEqual({
+        action: "redirect",
+        to: "/assistant/review-terms?returnTo=%2Fassistant%2Fhome",
+      });
+    });
+
+    test("redirects brand-new platform user with no assistant to privacy, unaffected by stale-toggle gate", () => {
+      expect(
+        guard(
+          s({
+            hasAssistants: false,
+            tosAccepted: false,
+            aiDataConsent: false,
+            analyticsConsentCurrent: false,
+            diagnosticsConsentCurrent: false,
+          }),
+        ),
+      ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -460,9 +492,21 @@ describe("resolveNavigation", () => {
       expect(hatch(s({ tosAccepted: true, aiDataConsent: true }))).toEqual(ALLOW);
     });
 
-    test("stale toggles do not change hatch-gate (hasCompletedOnboarding only)", () => {
+    test("redirects platform user with stale analytics toggle to review-terms", () => {
       expect(
-        hatch(s({ analyticsConsentCurrent: false, diagnosticsConsentCurrent: false })),
+        hatch(s({ analyticsConsentCurrent: false })),
+      ).toEqual({ action: "redirect", to: "/assistant/review-terms" });
+    });
+
+    test("redirects platform user with stale diagnostics toggle to review-terms", () => {
+      expect(
+        hatch(s({ diagnosticsConsentCurrent: false })),
+      ).toEqual({ action: "redirect", to: "/assistant/review-terms" });
+    });
+
+    test("does not gate local-mode user on stale toggles", () => {
+      expect(
+        hatch(s({ isLocalMode: true, analyticsConsentCurrent: false, diagnosticsConsentCurrent: false })),
       ).toEqual(ALLOW);
     });
   });

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -16,6 +16,8 @@ const base: NavigationState = {
   platformSession: "present",
   tosAccepted: true,
   aiDataConsent: true,
+  analyticsConsentCurrent: true,
+  diagnosticsConsentCurrent: true,
 };
 
 function s(overrides: Partial<NavigationState>): NavigationState {
@@ -266,6 +268,47 @@ describe("resolveNavigation", () => {
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
     });
 
+    // -- stale consent toggles --------------------------------------------
+
+    test("redirects platform user with current tos/ai but stale analytics toggle to review-terms", () => {
+      expect(
+        guard(s({ isLocalMode: false, analyticsConsentCurrent: false })),
+      ).toEqual({ action: "redirect", to: "/assistant/review-terms?returnTo=%2Fassistant" });
+    });
+
+    test("redirects platform user with stale diagnostics toggle to review-terms", () => {
+      expect(
+        guard(s({ isLocalMode: false, diagnosticsConsentCurrent: false })),
+      ).toEqual({ action: "redirect", to: "/assistant/review-terms?returnTo=%2Fassistant" });
+    });
+
+    test("allows platform user when all four consent flags are current", () => {
+      expect(
+        guard(
+          s({
+            isLocalMode: false,
+            tosAccepted: true,
+            aiDataConsent: true,
+            analyticsConsentCurrent: true,
+            diagnosticsConsentCurrent: true,
+          }),
+        ),
+      ).toEqual(ALLOW);
+    });
+
+    test("does not redirect local-mode user with stale toggles", () => {
+      expect(
+        guard(
+          s({
+            isLocalMode: true,
+            hasAssistants: true,
+            analyticsConsentCurrent: false,
+            diagnosticsConsentCurrent: false,
+          }),
+        ),
+      ).toEqual(ALLOW);
+    });
+
     test("does not redirect local-mode user without consent (handled by step 5)", () => {
       expect(
         guard(s({ isLocalMode: true, hasAssistants: true, tosAccepted: false, aiDataConsent: false })),
@@ -315,6 +358,15 @@ describe("resolveNavigation", () => {
 
     test("allows when tos and consent accepted", () => {
       expect(intercept(s({ tosAccepted: true, aiDataConsent: true }), "/assistant")).toEqual(ALLOW);
+    });
+
+    test("stale toggles do not change onboarding-intercept (hasCompletedOnboarding only)", () => {
+      expect(
+        intercept(
+          s({ analyticsConsentCurrent: false, diagnosticsConsentCurrent: false }),
+          "/assistant",
+        ),
+      ).toEqual(ALLOW);
     });
 
     test("allows destination outside /assistant", () => {
@@ -406,6 +458,12 @@ describe("resolveNavigation", () => {
 
     test("allows with full consent", () => {
       expect(hatch(s({ tosAccepted: true, aiDataConsent: true }))).toEqual(ALLOW);
+    });
+
+    test("stale toggles do not change hatch-gate (hasCompletedOnboarding only)", () => {
+      expect(
+        hatch(s({ analyticsConsentCurrent: false, diagnosticsConsentCurrent: false })),
+      ).toEqual(ALLOW);
     });
   });
 

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -257,7 +257,11 @@ function allowSetupRoutes(
   return null;
 }
 
-function requireAssistant(state: NavigationState): NavigationDecision | null {
+function requireAssistant(
+  state: NavigationState,
+  _path: string,
+  pathnameWithSearch: string,
+): NavigationDecision | null {
   if (state.hasAssistants) return null;
 
   if (state.isLocalMode) {
@@ -270,6 +274,11 @@ function requireAssistant(state: NavigationState): NavigationDecision | null {
 
   if (!hasCompletedOnboarding(state)) {
     return { action: "redirect", to: routes.onboarding.privacy };
+  }
+  // A stale toggle must be re-reviewed before provisioning an assistant.
+  if (!consentIsCurrent(state)) {
+    const returnTo = encodeURIComponent(pathnameWithSearch);
+    return { action: "redirect", to: `${routes.reviewTerms}?returnTo=${returnTo}` };
   }
   // A consented user with no assistant goes to the standard hatching screen.
   return { action: "redirect", to: routes.onboarding.hatching };
@@ -319,6 +328,10 @@ function resolveHatchGate(state: NavigationState): NavigationDecision {
   }
   if (!hasCompletedOnboarding(state)) {
     return { action: "redirect", to: onboardingEntrypoint(state.isLocalMode) };
+  }
+  // A stale toggle must be re-reviewed before hatching, even via direct navigation.
+  if (!state.isLocalMode && !consentIsCurrent(state)) {
+    return { action: "redirect", to: routes.reviewTerms };
   }
   return { action: "allow" };
 }

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -15,6 +15,8 @@ export interface NavigationState {
   platformSession: PlatformSessionStatus;
   tosAccepted: boolean;
   aiDataConsent: boolean;
+  analyticsConsentCurrent: boolean;
+  diagnosticsConsentCurrent: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -48,6 +50,19 @@ export type NavigationDecision =
 
 function hasCompletedOnboarding(state: NavigationState): boolean {
   return state.tosAccepted && state.aiDataConsent;
+}
+
+/**
+ * Onboarding is complete AND every consent toggle is for the current version.
+ * A stale toggle means the user must re-review the terms even though they
+ * already finished onboarding.
+ */
+function consentIsCurrent(state: NavigationState): boolean {
+  return (
+    hasCompletedOnboarding(state) &&
+    state.analyticsConsentCurrent &&
+    state.diagnosticsConsentCurrent
+  );
 }
 
 const ONBOARDING_PREFIX = `${routes.assistant}/onboarding`;
@@ -265,7 +280,7 @@ function requireConsent(
   _path: string,
   pathnameWithSearch: string,
 ): NavigationDecision | null {
-  if (state.isLocalMode || hasCompletedOnboarding(state)) return null;
+  if (state.isLocalMode || consentIsCurrent(state)) return null;
 
   const returnTo = encodeURIComponent(pathnameWithSearch);
   return { action: "redirect", to: `${routes.reviewTerms}?returnTo=${returnTo}` };

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -69,6 +69,7 @@ const resolveServerConsentMock = mock(
     shareDiagnostics: boolean | null;
     analyticsCurrent: boolean;
     diagnosticsCurrent: boolean;
+    hasServerRecord: boolean;
   } => ({
     tos: false,
     ai: false,
@@ -76,6 +77,7 @@ const resolveServerConsentMock = mock(
     shareDiagnostics: null,
     analyticsCurrent: false,
     diagnosticsCurrent: false,
+    hasServerRecord: false,
   }),
 );
 
@@ -211,6 +213,10 @@ const setAnalyticsConsentCurrentMock = mock((_value: boolean) => {});
 const setDiagnosticsConsentCurrentMock = mock((_value: boolean) => {});
 const setShareAnalyticsMock = mock((_value: boolean) => {});
 const setShareDiagnosticsMock = mock((_value: boolean) => {});
+// Mirror the store's device-initialized share values; the backfill reads these
+// to send the device opt-out value alongside the accepted version.
+let mockStoreShareAnalytics = true;
+let mockStoreShareDiagnostics = true;
 
 mock.module("@/domains/onboarding/onboarding-store", () => ({
   useOnboardingStore: {
@@ -221,6 +227,8 @@ mock.module("@/domains/onboarding/onboarding-store", () => ({
       setShareDiagnostics: setShareDiagnosticsMock,
       setAnalyticsConsentCurrent: setAnalyticsConsentCurrentMock,
       setDiagnosticsConsentCurrent: setDiagnosticsConsentCurrentMock,
+      shareAnalytics: mockStoreShareAnalytics,
+      shareDiagnostics: mockStoreShareDiagnostics,
     }),
   },
 }));
@@ -335,6 +343,8 @@ beforeEach(() => {
   setDiagnosticsConsentCurrentMock.mockClear();
   setShareAnalyticsMock.mockClear();
   setShareDiagnosticsMock.mockClear();
+  mockStoreShareAnalytics = true;
+  mockStoreShareDiagnostics = true;
   fetchConsentMock.mockClear();
   patchConsentMock.mockClear();
   mockFetchConsentResult = EMPTY_CONSENT;
@@ -500,6 +510,7 @@ describe("auth store onboarding flag reconciliation", () => {
       shareDiagnostics: true,
       analyticsCurrent: true,
       diagnosticsCurrent: true,
+      hasServerRecord: true,
     });
 
     await useAuthStore.getState().initSession();
@@ -568,6 +579,51 @@ describe("auth store onboarding flag reconciliation", () => {
     // device-local choices the store already holds.
     expect(setShareAnalyticsMock).not.toHaveBeenCalled();
     expect(setShareDiagnosticsMock).not.toHaveBeenCalled();
+  });
+
+  test("backfill patch carries the device share VALUE alongside the accepted version (opt-out preserved)", async () => {
+    // Truly-empty server record (hasServerRecord=false), device legal consent
+    // current, and a device analytics opt-out. The backfill must send the
+    // share value so the next fetch can't read the API default (true) and
+    // overwrite the opt-out.
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    mockStoreShareAnalytics = false;
+    restoreConsentForUserMock.mockReturnValueOnce({
+      tos: true,
+      ai: true,
+      analyticsCurrent: true,
+      diagnosticsCurrent: true,
+    });
+
+    await useAuthStore.getState().initSession();
+
+    expect(patchConsentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        share_analytics_accepted_version: "2026-06-08",
+        share_analytics: false,
+      }),
+    );
+  });
+
+  test("stale-but-real record keeps server share values and skips the device fallback", async () => {
+    // hasServerRecord=true but legal consent is stale (tos=false). The server's
+    // share opt-out is authoritative and must be applied; the device fallback
+    // must NOT run (its values are not authoritative for a real record).
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    resolveServerConsentMock.mockReturnValueOnce({
+      tos: false,
+      ai: false,
+      shareAnalytics: false,
+      shareDiagnostics: true,
+      analyticsCurrent: false,
+      diagnosticsCurrent: false,
+      hasServerRecord: true,
+    });
+
+    await useAuthStore.getState().initSession();
+
+    expect(setShareAnalyticsMock).toHaveBeenCalledWith(false);
+    expect(restoreConsentForUserMock).not.toHaveBeenCalled();
   });
 
   test("initSession falls back to device keys when fetchConsent fails", async () => {

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -35,12 +35,29 @@ const primeLocalGatewayConnectionWithRepairMock = mock(async () => {
 });
 const ensureGatewayTokenMock = mock(async () => {});
 const refreshRemoteGatewaySessionMock = mock(async () => false);
-const restoreConsentForUserMock = mock((_userId: string | null) => ({
-  tos: false,
-  ai: false,
-}));
+const restoreConsentForUserMock = mock(
+  (
+    _userId: string | null,
+  ): {
+    tos: boolean;
+    ai: boolean;
+    analyticsCurrent: boolean;
+    diagnosticsCurrent: boolean;
+  } => ({
+    tos: false,
+    ai: false,
+    analyticsCurrent: false,
+    diagnosticsCurrent: false,
+  }),
+);
 const persistConsentForUserMock = mock(
   (_userId: string | null, _tos: boolean, _ai: boolean) => {},
+);
+const persistToggleConsentMock = mock(
+  (
+    _userId: string | null,
+    _acks: { analyticsCurrent?: boolean; diagnosticsCurrent?: boolean },
+  ) => {},
 );
 const resolveServerConsentMock = mock(
   (
@@ -50,11 +67,15 @@ const resolveServerConsentMock = mock(
     ai: boolean;
     shareAnalytics: boolean | null;
     shareDiagnostics: boolean | null;
+    analyticsCurrent: boolean;
+    diagnosticsCurrent: boolean;
   } => ({
     tos: false,
     ai: false,
     shareAnalytics: null,
     shareDiagnostics: null,
+    analyticsCurrent: false,
+    diagnosticsCurrent: false,
   }),
 );
 
@@ -181,9 +202,13 @@ mock.module("@/domains/account/profile", () => ({
 mock.module("@/utils/onboarding-cleanup", () => ({
   restoreConsentForUser: restoreConsentForUserMock,
   persistConsentForUser: persistConsentForUserMock,
+  persistToggleConsent: persistToggleConsentMock,
   resolveServerConsent: resolveServerConsentMock,
   CONSENT_VERSION: "2026-06-08",
 }));
+
+const setAnalyticsConsentCurrentMock = mock((_value: boolean) => {});
+const setDiagnosticsConsentCurrentMock = mock((_value: boolean) => {});
 
 mock.module("@/domains/onboarding/onboarding-store", () => ({
   useOnboardingStore: {
@@ -192,6 +217,8 @@ mock.module("@/domains/onboarding/onboarding-store", () => ({
       setAiDataConsent: () => {},
       setShareAnalytics: () => {},
       setShareDiagnostics: () => {},
+      setAnalyticsConsentCurrent: setAnalyticsConsentCurrentMock,
+      setDiagnosticsConsentCurrent: setDiagnosticsConsentCurrentMock,
     }),
   },
 }));
@@ -300,7 +327,10 @@ beforeEach(() => {
   refreshRemoteGatewaySessionMock.mockClear();
   restoreConsentForUserMock.mockClear();
   persistConsentForUserMock.mockClear();
+  persistToggleConsentMock.mockClear();
   resolveServerConsentMock.mockClear();
+  setAnalyticsConsentCurrentMock.mockClear();
+  setDiagnosticsConsentCurrentMock.mockClear();
   fetchConsentMock.mockClear();
   patchConsentMock.mockClear();
   mockFetchConsentResult = EMPTY_CONSENT;
@@ -464,6 +494,8 @@ describe("auth store onboarding flag reconciliation", () => {
       ai: true,
       shareAnalytics: true,
       shareDiagnostics: true,
+      analyticsCurrent: true,
+      diagnosticsCurrent: true,
     });
 
     await useAuthStore.getState().initSession();
@@ -471,6 +503,13 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(fetchConsentMock).toHaveBeenCalled();
     expect(resolveServerConsentMock).toHaveBeenCalled();
     expect(restoreConsentForUserMock).not.toHaveBeenCalled();
+    // Currency flags hydrate from the resolved server consent.
+    expect(setAnalyticsConsentCurrentMock).toHaveBeenCalledWith(true);
+    expect(setDiagnosticsConsentCurrentMock).toHaveBeenCalledWith(true);
+    expect(persistToggleConsentMock).toHaveBeenCalledWith("user-1", {
+      analyticsCurrent: true,
+      diagnosticsCurrent: true,
+    });
     expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
   });
 
@@ -487,21 +526,44 @@ describe("auth store onboarding flag reconciliation", () => {
 
   test("initSession backfills server when device keys show prior consent and server versions are empty", async () => {
     sessionUser = { id: "user-1", email: "user@example.com" };
-    restoreConsentForUserMock.mockReturnValueOnce({ tos: true, ai: true });
+    restoreConsentForUserMock.mockReturnValueOnce({
+      tos: true,
+      ai: true,
+      analyticsCurrent: true,
+      diagnosticsCurrent: true,
+    });
 
     await useAuthStore.getState().initSession();
 
     expect(patchConsentMock).toHaveBeenCalled();
+    // The backfill branch hydrates the currency flags from the device acks.
+    expect(setAnalyticsConsentCurrentMock).toHaveBeenCalledWith(true);
+    expect(setDiagnosticsConsentCurrentMock).toHaveBeenCalledWith(true);
+    // Acks are persisted from the device-restored values, not the empty
+    // server values — otherwise the fallback would clobber its own input.
+    expect(persistToggleConsentMock).toHaveBeenLastCalledWith("user-1", {
+      analyticsCurrent: true,
+      diagnosticsCurrent: true,
+    });
   });
 
   test("initSession falls back to device keys when fetchConsent fails", async () => {
     sessionUser = { id: "user-1", email: "user@example.com" };
     mockFetchConsentError = new Error("Network error");
+    restoreConsentForUserMock.mockReturnValueOnce({
+      tos: true,
+      ai: true,
+      analyticsCurrent: true,
+      diagnosticsCurrent: true,
+    });
 
     await useAuthStore.getState().initSession();
 
     expect(fetchConsentMock).toHaveBeenCalled();
     expect(restoreConsentForUserMock).toHaveBeenCalledWith("user-1");
+    // A fully offline restore still reflects prior toggle acks.
+    expect(setAnalyticsConsentCurrentMock).toHaveBeenCalledWith(true);
+    expect(setDiagnosticsConsentCurrentMock).toHaveBeenCalledWith(true);
     expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
   });
 

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -42,25 +42,37 @@ const restoreConsentForUserMock = mock((_userId: string | null) => ({
 const persistConsentForUserMock = mock(
   (_userId: string | null, _tos: boolean, _ai: boolean) => {},
 );
-const resolveServerConsentMock = mock((_consent: unknown) => ({
-  tos: false,
-  ai: false,
-  shareAnalytics: null,
-  shareDiagnostics: null,
-}));
+const resolveServerConsentMock = mock(
+  (
+    _consent: unknown,
+  ): {
+    tos: boolean;
+    ai: boolean;
+    shareAnalytics: boolean | null;
+    shareDiagnostics: boolean | null;
+  } => ({
+    tos: false,
+    ai: false,
+    shareAnalytics: null,
+    shareDiagnostics: null,
+  }),
+);
 
-let mockFetchMeResult: unknown = {
-  id: "user-1",
-  username: "test",
-  email: "test@example.com",
-  first_name: "",
-  last_name: "",
-  consent: null,
+const EMPTY_CONSENT = {
+  tos_accepted_version: "",
+  tos_accepted_at: null,
+  privacy_policy_accepted_version: "",
+  privacy_policy_accepted_at: null,
+  ai_data_sharing_accepted_version: "",
+  ai_data_sharing_accepted_at: null,
+  share_analytics: false,
+  share_diagnostics: false,
 };
-let mockFetchMeError: Error | null = null;
-const fetchMeMock = mock(async () => {
-  if (mockFetchMeError) throw mockFetchMeError;
-  return mockFetchMeResult;
+let mockFetchConsentResult: unknown = EMPTY_CONSENT;
+let mockFetchConsentError: Error | null = null;
+const fetchConsentMock = mock(async () => {
+  if (mockFetchConsentError) throw mockFetchConsentError;
+  return mockFetchConsentResult;
 });
 const clearOrganizationMock = mock(() => {});
 const logoutMock = mock(async () => {});
@@ -162,7 +174,7 @@ const clearUserScopedStorageMock = mock(() => {});
 const patchConsentMock = mock(async (_consent: unknown) => {});
 
 mock.module("@/domains/account/profile", () => ({
-  fetchMe: fetchMeMock,
+  fetchConsent: fetchConsentMock,
   patchConsent: patchConsentMock,
 }));
 
@@ -289,17 +301,10 @@ beforeEach(() => {
   restoreConsentForUserMock.mockClear();
   persistConsentForUserMock.mockClear();
   resolveServerConsentMock.mockClear();
-  fetchMeMock.mockClear();
+  fetchConsentMock.mockClear();
   patchConsentMock.mockClear();
-  mockFetchMeResult = {
-    id: "user-1",
-    username: "test",
-    email: "test@example.com",
-    first_name: "",
-    last_name: "",
-    consent: null,
-  };
-  mockFetchMeError = null;
+  mockFetchConsentResult = EMPTY_CONSENT;
+  mockFetchConsentError = null;
   clearOrganizationMock.mockClear();
   clearUserScopedStorageMock.mockClear();
   logoutMock.mockClear();
@@ -444,41 +449,43 @@ describe("auth store onboarding flag reconciliation", () => {
 
   test("initSession uses server consent when server has a consent record", async () => {
     sessionUser = { id: "user-1", email: "user@example.com" };
-    mockFetchMeResult = {
-      id: "user-1",
-      username: "test",
-      email: "test@example.com",
-      first_name: "",
-      last_name: "",
-      consent: {
-        tos_accepted_version: "2026-06-08",
-        privacy_policy_accepted_version: "2026-06-08",
-        ai_data_sharing_accepted_version: "2026-06-08",
-        share_analytics: true,
-        share_diagnostics: true,
-      },
+    mockFetchConsentResult = {
+      tos_accepted_version: "2026-06-08",
+      tos_accepted_at: "2026-06-08T00:00:00Z",
+      privacy_policy_accepted_version: "2026-06-08",
+      privacy_policy_accepted_at: "2026-06-08T00:00:00Z",
+      ai_data_sharing_accepted_version: "2026-06-08",
+      ai_data_sharing_accepted_at: "2026-06-08T00:00:00Z",
+      share_analytics: true,
+      share_diagnostics: true,
     };
+    resolveServerConsentMock.mockReturnValueOnce({
+      tos: true,
+      ai: true,
+      shareAnalytics: true,
+      shareDiagnostics: true,
+    });
 
     await useAuthStore.getState().initSession();
 
-    expect(fetchMeMock).toHaveBeenCalled();
+    expect(fetchConsentMock).toHaveBeenCalled();
     expect(resolveServerConsentMock).toHaveBeenCalled();
     expect(restoreConsentForUserMock).not.toHaveBeenCalled();
     expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
   });
 
-  test("initSession falls through to device keys when server consent is null", async () => {
+  test("initSession falls through to device keys when server versions are empty", async () => {
     sessionUser = { id: "user-1", email: "user@example.com" };
 
     await useAuthStore.getState().initSession();
 
-    expect(fetchMeMock).toHaveBeenCalled();
-    expect(resolveServerConsentMock).not.toHaveBeenCalled();
+    expect(fetchConsentMock).toHaveBeenCalled();
+    expect(resolveServerConsentMock).toHaveBeenCalled();
     expect(restoreConsentForUserMock).toHaveBeenCalledWith("user-1");
     expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
   });
 
-  test("initSession backfills server when device keys show prior consent and server has no record", async () => {
+  test("initSession backfills server when device keys show prior consent and server versions are empty", async () => {
     sessionUser = { id: "user-1", email: "user@example.com" };
     restoreConsentForUserMock.mockReturnValueOnce({ tos: true, ai: true });
 
@@ -487,13 +494,13 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(patchConsentMock).toHaveBeenCalled();
   });
 
-  test("initSession falls back to device keys when fetchMe fails", async () => {
+  test("initSession falls back to device keys when fetchConsent fails", async () => {
     sessionUser = { id: "user-1", email: "user@example.com" };
-    mockFetchMeError = new Error("Network error");
+    mockFetchConsentError = new Error("Network error");
 
     await useAuthStore.getState().initSession();
 
-    expect(fetchMeMock).toHaveBeenCalled();
+    expect(fetchConsentMock).toHaveBeenCalled();
     expect(restoreConsentForUserMock).toHaveBeenCalledWith("user-1");
     expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
   });
@@ -502,48 +509,40 @@ describe("auth store onboarding flag reconciliation", () => {
     mockIsLocalMode = true;
     sessionUser = { id: "user-1", email: "user@example.com" };
     mockPlatformAssistants = [{ assistantId: "p1", cloud: "vellum" }];
-    mockFetchMeResult = {
-      id: "user-1",
-      username: "test",
-      email: "test@example.com",
-      first_name: "",
-      last_name: "",
-      consent: {
-        tos_accepted_version: "2026-06-08",
-        privacy_policy_accepted_version: "2026-06-08",
-        ai_data_sharing_accepted_version: "2026-06-08",
-        share_analytics: true,
-        share_diagnostics: true,
-      },
+    mockFetchConsentResult = {
+      tos_accepted_version: "2026-06-08",
+      tos_accepted_at: "2026-06-08T00:00:00Z",
+      privacy_policy_accepted_version: "2026-06-08",
+      privacy_policy_accepted_at: "2026-06-08T00:00:00Z",
+      ai_data_sharing_accepted_version: "2026-06-08",
+      ai_data_sharing_accepted_at: "2026-06-08T00:00:00Z",
+      share_analytics: true,
+      share_diagnostics: true,
     };
 
     await useAuthStore.getState().initSession();
 
-    expect(fetchMeMock).toHaveBeenCalled();
+    expect(fetchConsentMock).toHaveBeenCalled();
     expect(resolveServerConsentMock).toHaveBeenCalled();
     expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
   });
 
   test("refreshSession fetches consent from server for platform users", async () => {
     sessionUser = { id: "user-2", email: "user@example.com" };
-    mockFetchMeResult = {
-      id: "user-2",
-      username: "test",
-      email: "user@example.com",
-      first_name: "",
-      last_name: "",
-      consent: {
-        tos_accepted_version: "2026-06-08",
-        privacy_policy_accepted_version: "2026-06-08",
-        ai_data_sharing_accepted_version: "2026-06-08",
-        share_analytics: true,
-        share_diagnostics: true,
-      },
+    mockFetchConsentResult = {
+      tos_accepted_version: "2026-06-08",
+      tos_accepted_at: "2026-06-08T00:00:00Z",
+      privacy_policy_accepted_version: "2026-06-08",
+      privacy_policy_accepted_at: "2026-06-08T00:00:00Z",
+      ai_data_sharing_accepted_version: "2026-06-08",
+      ai_data_sharing_accepted_at: "2026-06-08T00:00:00Z",
+      share_analytics: true,
+      share_diagnostics: true,
     };
 
     await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
 
-    expect(fetchMeMock).toHaveBeenCalled();
+    expect(fetchConsentMock).toHaveBeenCalled();
     expect(resolveServerConsentMock).toHaveBeenCalled();
     expect(useAuthStore.getState().user?.id).toBe("user-2");
   });

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -545,6 +545,21 @@ describe("auth store onboarding flag reconciliation", () => {
       analyticsCurrent: true,
       diagnosticsCurrent: true,
     });
+    // Legal consent is persisted with the restored (true) values, after the
+    // fallback — never the empty server values that would erase device acks.
+    expect(persistConsentForUserMock).toHaveBeenLastCalledWith(
+      "user-1",
+      true,
+      true,
+    );
+    // The backfill patch carries the current toggle versions so the next
+    // server fetch doesn't re-mark them stale and re-route to review-terms.
+    expect(patchConsentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        share_analytics_accepted_version: expect.any(String),
+        share_diagnostics_accepted_version: expect.any(String),
+      }),
+    );
   });
 
   test("initSession falls back to device keys when fetchConsent fails", async () => {

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -209,14 +209,16 @@ mock.module("@/utils/onboarding-cleanup", () => ({
 
 const setAnalyticsConsentCurrentMock = mock((_value: boolean) => {});
 const setDiagnosticsConsentCurrentMock = mock((_value: boolean) => {});
+const setShareAnalyticsMock = mock((_value: boolean) => {});
+const setShareDiagnosticsMock = mock((_value: boolean) => {});
 
 mock.module("@/domains/onboarding/onboarding-store", () => ({
   useOnboardingStore: {
     getState: () => ({
       setTosAccepted: () => {},
       setAiDataConsent: () => {},
-      setShareAnalytics: () => {},
-      setShareDiagnostics: () => {},
+      setShareAnalytics: setShareAnalyticsMock,
+      setShareDiagnostics: setShareDiagnosticsMock,
       setAnalyticsConsentCurrent: setAnalyticsConsentCurrentMock,
       setDiagnosticsConsentCurrent: setDiagnosticsConsentCurrentMock,
     }),
@@ -331,6 +333,8 @@ beforeEach(() => {
   resolveServerConsentMock.mockClear();
   setAnalyticsConsentCurrentMock.mockClear();
   setDiagnosticsConsentCurrentMock.mockClear();
+  setShareAnalyticsMock.mockClear();
+  setShareDiagnosticsMock.mockClear();
   fetchConsentMock.mockClear();
   patchConsentMock.mockClear();
   mockFetchConsentResult = EMPTY_CONSENT;
@@ -560,6 +564,10 @@ describe("auth store onboarding flag reconciliation", () => {
         share_diagnostics_accepted_version: expect.any(String),
       }),
     );
+    // The empty server record's default share booleans must NOT overwrite the
+    // device-local choices the store already holds.
+    expect(setShareAnalyticsMock).not.toHaveBeenCalled();
+    expect(setShareDiagnosticsMock).not.toHaveBeenCalled();
   });
 
   test("initSession falls back to device keys when fetchConsent fails", async () => {

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -53,7 +53,7 @@ import {
 import { listAssistants } from "@/assistant/api";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { deleteBiometricToken } from "@/runtime/native-biometric";
-import { fetchMe, patchConsent } from "@/domains/account/profile";
+import { fetchConsent, patchConsent } from "@/domains/account/profile";
 import {
   restoreConsentForUser,
   persistConsentForUser,
@@ -245,32 +245,30 @@ function broadcastAuthChange(): void {
 async function syncUserScopedState(nextUserId: string | null): Promise<void> {
   if (nextUserId) {
     try {
-      const me = await fetchMe();
-      if (me.consent) {
-        const resolved = resolveServerConsent(me.consent);
-        const store = useOnboardingStore.getState();
-        store.setTosAccepted(resolved.tos);
-        store.setAiDataConsent(resolved.ai);
-        if (resolved.shareAnalytics !== null)
-          store.setShareAnalytics(resolved.shareAnalytics);
-        if (resolved.shareDiagnostics !== null)
-          store.setShareDiagnostics(resolved.shareDiagnostics);
-        persistConsentForUser(nextUserId, resolved.tos, resolved.ai);
-        syncOrganizationState(nextUserId);
-        return;
-      }
-      // Server has no consent record — fall through to device keys.
-      // If device keys show prior acceptance, backfill the server.
-      const deviceConsent = restoreConsentForUser(nextUserId);
+      const consent = await fetchConsent();
+      const resolved = resolveServerConsent(consent);
       const store = useOnboardingStore.getState();
-      store.setTosAccepted(deviceConsent.tos);
-      store.setAiDataConsent(deviceConsent.ai);
-      if (deviceConsent.tos && deviceConsent.ai) {
-        void patchConsent({
-          tos_accepted_version: CONSENT_VERSION,
-          privacy_policy_accepted_version: CONSENT_VERSION,
-          ai_data_sharing_accepted_version: CONSENT_VERSION,
-        }).catch(() => {});
+      store.setTosAccepted(resolved.tos);
+      store.setAiDataConsent(resolved.ai);
+      if (resolved.shareAnalytics !== null)
+        store.setShareAnalytics(resolved.shareAnalytics);
+      if (resolved.shareDiagnostics !== null)
+        store.setShareDiagnostics(resolved.shareDiagnostics);
+      persistConsentForUser(nextUserId, resolved.tos, resolved.ai);
+      // The endpoint always returns an object, so empty/stale versions
+      // (not a null record) are the "never accepted" signal. If device
+      // keys show prior acceptance, restore the flags and backfill the server.
+      if (!resolved.tos && !resolved.ai) {
+        const deviceConsent = restoreConsentForUser(nextUserId);
+        if (deviceConsent.tos && deviceConsent.ai) {
+          store.setTosAccepted(true);
+          store.setAiDataConsent(true);
+          void patchConsent({
+            tos_accepted_version: CONSENT_VERSION,
+            privacy_policy_accepted_version: CONSENT_VERSION,
+            ai_data_sharing_accepted_version: CONSENT_VERSION,
+          }).catch(() => {});
+        }
       }
       syncOrganizationState(nextUserId);
       return;

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -249,41 +249,51 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
       const consent = await fetchConsent();
       const resolved = resolveServerConsent(consent);
       const store = useOnboardingStore.getState();
-      store.setTosAccepted(resolved.tos);
-      store.setAiDataConsent(resolved.ai);
       if (resolved.shareAnalytics !== null)
         store.setShareAnalytics(resolved.shareAnalytics);
       if (resolved.shareDiagnostics !== null)
         store.setShareDiagnostics(resolved.shareDiagnostics);
-      persistConsentForUser(nextUserId, resolved.tos, resolved.ai);
 
-      // Toggle currency comes from the server unless it has no acceptance on
-      // record, in which case device acks are authoritative. Resolve the final
-      // values BEFORE persisting so the empty-server fallback reads device ack
-      // keys that haven't yet been overwritten.
+      // Resolve the FINAL consent values before persisting or mutating the
+      // store. The endpoint always returns an object, so empty/stale versions
+      // (not a null record) are the "never accepted" signal; when the server
+      // has nothing on record the device ack keys are authoritative. Persisting
+      // first would overwrite those keys with the empty server values before the
+      // fallback below reads them.
+      let tos = resolved.tos;
+      let ai = resolved.ai;
       let analyticsCurrent = resolved.analyticsCurrent;
       let diagnosticsCurrent = resolved.diagnosticsCurrent;
 
-      // The endpoint always returns an object, so empty/stale versions
-      // (not a null record) are the "never accepted" signal. If device
-      // keys show prior acceptance, restore the flags and backfill the server.
       if (!resolved.tos && !resolved.ai) {
         const deviceConsent = restoreConsentForUser(nextUserId);
         analyticsCurrent = deviceConsent.analyticsCurrent;
         diagnosticsCurrent = deviceConsent.diagnosticsCurrent;
         if (deviceConsent.tos && deviceConsent.ai) {
-          store.setTosAccepted(true);
-          store.setAiDataConsent(true);
+          tos = true;
+          ai = true;
+          // Backfill the server from the device acks. Include any toggle
+          // versions whose device ack is current so the next fetch doesn't
+          // re-mark them stale and bounce the user back to review-terms.
           void patchConsent({
             tos_accepted_version: CONSENT_VERSION,
             privacy_policy_accepted_version: CONSENT_VERSION,
             ai_data_sharing_accepted_version: CONSENT_VERSION,
+            ...(analyticsCurrent
+              ? { share_analytics_accepted_version: CONSENT_VERSION }
+              : {}),
+            ...(diagnosticsCurrent
+              ? { share_diagnostics_accepted_version: CONSENT_VERSION }
+              : {}),
           }).catch(() => {});
         }
       }
 
+      store.setTosAccepted(tos);
+      store.setAiDataConsent(ai);
       store.setAnalyticsConsentCurrent(analyticsCurrent);
       store.setDiagnosticsConsentCurrent(diagnosticsCurrent);
+      persistConsentForUser(nextUserId, tos, ai);
       persistToggleConsent(nextUserId, { analyticsCurrent, diagnosticsCurrent });
       syncOrganizationState(nextUserId);
       return;

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -249,10 +249,16 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
       const consent = await fetchConsent();
       const resolved = resolveServerConsent(consent);
       const store = useOnboardingStore.getState();
-      if (resolved.shareAnalytics !== null)
-        store.setShareAnalytics(resolved.shareAnalytics);
-      if (resolved.shareDiagnostics !== null)
-        store.setShareDiagnostics(resolved.shareDiagnostics);
+      // Only adopt the server's share-preference booleans when the server has a
+      // real consent record. For an empty record they're just the API defaults
+      // and would clobber the device-local `device:share_*` choices that the
+      // fallback below relies on (the store already holds them from init).
+      if (resolved.tos || resolved.ai) {
+        if (resolved.shareAnalytics !== null)
+          store.setShareAnalytics(resolved.shareAnalytics);
+        if (resolved.shareDiagnostics !== null)
+          store.setShareDiagnostics(resolved.shareDiagnostics);
+      }
 
       // Resolve the FINAL consent values before persisting or mutating the
       // store. The endpoint always returns an object, so empty/stale versions

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -57,6 +57,7 @@ import { fetchConsent, patchConsent } from "@/domains/account/profile";
 import {
   restoreConsentForUser,
   persistConsentForUser,
+  persistToggleConsent,
   resolveServerConsent,
   CONSENT_VERSION,
 } from "@/utils/onboarding-cleanup";
@@ -255,11 +256,21 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
       if (resolved.shareDiagnostics !== null)
         store.setShareDiagnostics(resolved.shareDiagnostics);
       persistConsentForUser(nextUserId, resolved.tos, resolved.ai);
+
+      // Toggle currency comes from the server unless it has no acceptance on
+      // record, in which case device acks are authoritative. Resolve the final
+      // values BEFORE persisting so the empty-server fallback reads device ack
+      // keys that haven't yet been overwritten.
+      let analyticsCurrent = resolved.analyticsCurrent;
+      let diagnosticsCurrent = resolved.diagnosticsCurrent;
+
       // The endpoint always returns an object, so empty/stale versions
       // (not a null record) are the "never accepted" signal. If device
       // keys show prior acceptance, restore the flags and backfill the server.
       if (!resolved.tos && !resolved.ai) {
         const deviceConsent = restoreConsentForUser(nextUserId);
+        analyticsCurrent = deviceConsent.analyticsCurrent;
+        diagnosticsCurrent = deviceConsent.diagnosticsCurrent;
         if (deviceConsent.tos && deviceConsent.ai) {
           store.setTosAccepted(true);
           store.setAiDataConsent(true);
@@ -270,6 +281,10 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
           }).catch(() => {});
         }
       }
+
+      store.setAnalyticsConsentCurrent(analyticsCurrent);
+      store.setDiagnosticsConsentCurrent(diagnosticsCurrent);
+      persistToggleConsent(nextUserId, { analyticsCurrent, diagnosticsCurrent });
       syncOrganizationState(nextUserId);
       return;
     } catch {
@@ -281,6 +296,8 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
   const store = useOnboardingStore.getState();
   store.setTosAccepted(consent.tos);
   store.setAiDataConsent(consent.ai);
+  store.setAnalyticsConsentCurrent(consent.analyticsCurrent);
+  store.setDiagnosticsConsentCurrent(consent.diagnosticsCurrent);
   syncOrganizationState(nextUserId);
 }
 

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -252,8 +252,10 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
       // Only adopt the server's share-preference booleans when the server has a
       // real consent record. For an empty record they're just the API defaults
       // and would clobber the device-local `device:share_*` choices that the
-      // fallback below relies on (the store already holds them from init).
-      if (resolved.tos || resolved.ai) {
+      // fallback below relies on (the store already holds them from init). A
+      // real record's share values are authoritative even when its legal
+      // consent versions are stale (the nav layer routes to review-terms).
+      if (resolved.hasServerRecord) {
         if (resolved.shareAnalytics !== null)
           store.setShareAnalytics(resolved.shareAnalytics);
         if (resolved.shareDiagnostics !== null)
@@ -271,25 +273,34 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
       let analyticsCurrent = resolved.analyticsCurrent;
       let diagnosticsCurrent = resolved.diagnosticsCurrent;
 
-      if (!resolved.tos && !resolved.ai) {
+      // Only fall back to device keys for a TRULY empty record. A stale-but-real
+      // record's server values are authoritative and must not be overwritten;
+      // the nav layer routes the user to review-terms for the stale legal consent.
+      if (!resolved.hasServerRecord) {
         const deviceConsent = restoreConsentForUser(nextUserId);
         analyticsCurrent = deviceConsent.analyticsCurrent;
         diagnosticsCurrent = deviceConsent.diagnosticsCurrent;
         if (deviceConsent.tos && deviceConsent.ai) {
           tos = true;
           ai = true;
-          // Backfill the server from the device acks. Include any toggle
-          // versions whose device ack is current so the next fetch doesn't
-          // re-mark them stale and bounce the user back to review-terms.
+          // Backfill the server from the device acks. Stamp any toggle version
+          // whose device ack is current AND send the device share value so the
+          // next fetch can't overwrite a device opt-out with the API default.
           void patchConsent({
             tos_accepted_version: CONSENT_VERSION,
             privacy_policy_accepted_version: CONSENT_VERSION,
             ai_data_sharing_accepted_version: CONSENT_VERSION,
             ...(analyticsCurrent
-              ? { share_analytics_accepted_version: CONSENT_VERSION }
+              ? {
+                  share_analytics_accepted_version: CONSENT_VERSION,
+                  share_analytics: store.shareAnalytics,
+                }
               : {}),
             ...(diagnosticsCurrent
-              ? { share_diagnostics_accepted_version: CONSENT_VERSION }
+              ? {
+                  share_diagnostics_accepted_version: CONSENT_VERSION,
+                  share_diagnostics: store.shareDiagnostics,
+                }
               : {}),
           }).catch(() => {});
         }

--- a/clients/web/src/utils/onboarding-cleanup.test.ts
+++ b/clients/web/src/utils/onboarding-cleanup.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Tests for the versioned share-toggle consent layer in `onboarding-cleanup`.
+ *
+ * Collaborators (`onboarding-store`, `auth-store`, `profile.patchConsent`,
+ * `device-settings`) are mocked so we exercise the per-user device-key
+ * read/write logic in isolation against an in-memory `localStorage`.
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import { installMemoryStorage } from "@/utils/memory-storage.test-helper";
+import type { ConsentPatch } from "@/domains/account/profile";
+
+installMemoryStorage({ beforeAll, afterAll, beforeEach, afterEach });
+
+const storeState = {
+  setTosAccepted: mock(() => {}),
+  setAiDataConsent: mock(() => {}),
+  setShareAnalytics: mock(() => {}),
+  setShareDiagnostics: mock(() => {}),
+  setAnalyticsConsentCurrent: mock(() => {}),
+  setDiagnosticsConsentCurrent: mock(() => {}),
+};
+mock.module("@/domains/onboarding/onboarding-store", () => ({
+  useOnboardingStore: { getState: () => storeState },
+}));
+
+let authUserId: string | null = "user-1";
+mock.module("@/stores/auth-store", () => ({
+  useAuthStore: { getState: () => ({ user: authUserId ? { id: authUserId } : null }) },
+}));
+
+// `onboarding-cleanup` only needs `patchConsent`; the real `profile` module
+// pulls in the generated API client (unavailable in unit tests), so stub it.
+const patchConsentMock = mock(async (_consent: ConsentPatch) => {});
+mock.module("@/domains/account/profile", () => ({
+  patchConsent: patchConsentMock,
+}));
+mock.module("@/generated/api/client.gen", () => ({ client: {} }));
+
+const setDeviceBoolMock = mock(() => {});
+mock.module("@/utils/device-settings", () => ({
+  setDeviceBool: setDeviceBoolMock,
+}));
+
+import {
+  CONSENT_VERSION,
+  clearConsentForUser,
+  persistToggleConsent,
+  resolveServerConsent,
+  restoreConsentForUser,
+  saveConsent,
+  savePreferenceToggle,
+} from "@/utils/onboarding-cleanup";
+import type { UserConsent } from "@/domains/account/profile";
+
+function makeConsent(overrides: Partial<UserConsent> = {}): UserConsent {
+  return {
+    tos_accepted_version: CONSENT_VERSION,
+    tos_accepted_at: null,
+    privacy_policy_accepted_version: CONSENT_VERSION,
+    privacy_policy_accepted_at: null,
+    ai_data_sharing_accepted_version: CONSENT_VERSION,
+    ai_data_sharing_accepted_at: null,
+    share_analytics: true,
+    share_diagnostics: true,
+    share_analytics_accepted_version: CONSENT_VERSION,
+    share_analytics_accepted_at: null,
+    share_diagnostics_accepted_version: CONSENT_VERSION,
+    share_diagnostics_accepted_at: null,
+    ...overrides,
+  };
+}
+
+const analyticsKey = (userId: string) =>
+  `device:consent:share_analytics:v${CONSENT_VERSION}:${userId}`;
+const diagnosticsKey = (userId: string) =>
+  `device:consent:share_diagnostics:v${CONSENT_VERSION}:${userId}`;
+
+beforeEach(() => {
+  authUserId = "user-1";
+  storeState.setTosAccepted.mockReset();
+  storeState.setAiDataConsent.mockReset();
+  storeState.setShareAnalytics.mockReset();
+  storeState.setShareDiagnostics.mockReset();
+  storeState.setAnalyticsConsentCurrent.mockReset();
+  storeState.setDiagnosticsConsentCurrent.mockReset();
+  patchConsentMock.mockReset();
+  patchConsentMock.mockImplementation(async () => {});
+  setDeviceBoolMock.mockReset();
+});
+
+describe("resolveServerConsent", () => {
+  test("reports current toggles when versions match CONSENT_VERSION", () => {
+    const r = resolveServerConsent(makeConsent());
+    expect(r.analyticsCurrent).toBe(true);
+    expect(r.diagnosticsCurrent).toBe(true);
+  });
+
+  test("reports stale toggles for mismatched versions", () => {
+    const r = resolveServerConsent(
+      makeConsent({
+        share_analytics_accepted_version: "2020-01-01",
+        share_diagnostics_accepted_version: "2020-01-01",
+      }),
+    );
+    expect(r.analyticsCurrent).toBe(false);
+    expect(r.diagnosticsCurrent).toBe(false);
+  });
+
+  test("reports stale toggles for empty versions", () => {
+    const r = resolveServerConsent(
+      makeConsent({
+        share_analytics_accepted_version: "",
+        share_diagnostics_accepted_version: "",
+      }),
+    );
+    expect(r.analyticsCurrent).toBe(false);
+    expect(r.diagnosticsCurrent).toBe(false);
+  });
+
+  test("reports false for null/undefined consent", () => {
+    expect(resolveServerConsent(null).analyticsCurrent).toBe(false);
+    expect(resolveServerConsent(null).diagnosticsCurrent).toBe(false);
+    expect(resolveServerConsent(undefined).analyticsCurrent).toBe(false);
+    expect(resolveServerConsent(undefined).diagnosticsCurrent).toBe(false);
+  });
+
+  test("keeps the existing value/tos/ai fields", () => {
+    const r = resolveServerConsent(makeConsent({ share_analytics: false }));
+    expect(r.tos).toBe(true);
+    expect(r.ai).toBe(true);
+    expect(r.shareAnalytics).toBe(false);
+    expect(r.shareDiagnostics).toBe(true);
+  });
+});
+
+describe("persistToggleConsent + restoreConsentForUser round-trip", () => {
+  test("round-trips both ack keys", () => {
+    persistToggleConsent("user-1", { analyticsCurrent: true, diagnosticsCurrent: true });
+    const r = restoreConsentForUser("user-1");
+    expect(r.analyticsCurrent).toBe(true);
+    expect(r.diagnosticsCurrent).toBe(true);
+  });
+
+  test("only writes the provided field", () => {
+    persistToggleConsent("user-1", { analyticsCurrent: true });
+    expect(localStorage.getItem(analyticsKey("user-1"))).toBe("true");
+    expect(localStorage.getItem(diagnosticsKey("user-1"))).toBeNull();
+    const r = restoreConsentForUser("user-1");
+    expect(r.analyticsCurrent).toBe(true);
+    expect(r.diagnosticsCurrent).toBe(false);
+  });
+
+  test("no-ops without a userId", () => {
+    persistToggleConsent(null, { analyticsCurrent: true });
+    expect(localStorage.getItem(analyticsKey("user-1"))).toBeNull();
+  });
+
+  test("restore returns false for both with no userId", () => {
+    const r = restoreConsentForUser(null);
+    expect(r.analyticsCurrent).toBe(false);
+    expect(r.diagnosticsCurrent).toBe(false);
+  });
+});
+
+describe("saveConsent", () => {
+  test("stamps both toggle versions in the patch body", () => {
+    saveConsent({
+      userId: "user-1",
+      tos: true,
+      ai: true,
+      shareAnalytics: true,
+      shareDiagnostics: false,
+      hasPlatformSession: true,
+    });
+    expect(patchConsentMock).toHaveBeenCalledTimes(1);
+    const body = patchConsentMock.mock.calls[0][0];
+    expect(body.share_analytics_accepted_version).toBe(CONSENT_VERSION);
+    expect(body.share_diagnostics_accepted_version).toBe(CONSENT_VERSION);
+  });
+
+  test("sets both currency flags and writes both ack keys", () => {
+    saveConsent({
+      userId: "user-1",
+      tos: true,
+      ai: true,
+      shareAnalytics: true,
+      shareDiagnostics: true,
+      hasPlatformSession: false,
+    });
+    expect(storeState.setAnalyticsConsentCurrent).toHaveBeenCalledWith(true);
+    expect(storeState.setDiagnosticsConsentCurrent).toHaveBeenCalledWith(true);
+    expect(localStorage.getItem(analyticsKey("user-1"))).toBe("true");
+    expect(localStorage.getItem(diagnosticsKey("user-1"))).toBe("true");
+  });
+});
+
+describe("savePreferenceToggle", () => {
+  test("stamps the analytics version and sets its flag only", () => {
+    savePreferenceToggle("share_analytics", true, true);
+    expect(storeState.setAnalyticsConsentCurrent).toHaveBeenCalledWith(true);
+    expect(storeState.setDiagnosticsConsentCurrent).not.toHaveBeenCalled();
+    expect(localStorage.getItem(analyticsKey("user-1"))).toBe("true");
+    expect(localStorage.getItem(diagnosticsKey("user-1"))).toBeNull();
+    const body = patchConsentMock.mock.calls[0][0];
+    expect(body.share_analytics).toBe(true);
+    expect(body.share_analytics_accepted_version).toBe(CONSENT_VERSION);
+  });
+
+  test("stamps the diagnostics version and sets its flag only", () => {
+    savePreferenceToggle("share_diagnostics", false, true);
+    expect(storeState.setDiagnosticsConsentCurrent).toHaveBeenCalledWith(true);
+    expect(storeState.setAnalyticsConsentCurrent).not.toHaveBeenCalled();
+    const body = patchConsentMock.mock.calls[0][0];
+    expect(body.share_diagnostics).toBe(false);
+    expect(body.share_diagnostics_accepted_version).toBe(CONSENT_VERSION);
+  });
+});
+
+describe("clearConsentForUser", () => {
+  test("clears both toggle ack keys", () => {
+    persistToggleConsent("user-1", { analyticsCurrent: true, diagnosticsCurrent: true });
+    clearConsentForUser("user-1");
+    expect(localStorage.getItem(analyticsKey("user-1"))).toBeNull();
+    expect(localStorage.getItem(diagnosticsKey("user-1"))).toBeNull();
+  });
+});

--- a/clients/web/src/utils/onboarding-cleanup.test.ts
+++ b/clients/web/src/utils/onboarding-cleanup.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for the versioned share-toggle consent layer in `onboarding-cleanup`.
  *
- * Collaborators (`onboarding-store`, `auth-store`, `profile.patchConsent`,
+ * Collaborators (`onboarding-store`, `profile.patchConsent`,
  * `device-settings`) are mocked so we exercise the per-user device-key
  * read/write logic in isolation against an in-memory `localStorage`.
  */
@@ -32,11 +32,6 @@ const storeState = {
 };
 mock.module("@/domains/onboarding/onboarding-store", () => ({
   useOnboardingStore: { getState: () => storeState },
-}));
-
-let authUserId: string | null = "user-1";
-mock.module("@/stores/auth-store", () => ({
-  useAuthStore: { getState: () => ({ user: authUserId ? { id: authUserId } : null }) },
 }));
 
 // `onboarding-cleanup` only needs `patchConsent`; the real `profile` module
@@ -87,7 +82,6 @@ const diagnosticsKey = (userId: string) =>
   `device:consent:share_diagnostics:v${CONSENT_VERSION}:${userId}`;
 
 beforeEach(() => {
-  authUserId = "user-1";
   storeState.setTosAccepted.mockReset();
   storeState.setAiDataConsent.mockReset();
   storeState.setShareAnalytics.mockReset();
@@ -207,7 +201,7 @@ describe("saveConsent", () => {
 
 describe("savePreferenceToggle", () => {
   test("stamps the analytics version and sets its flag only", () => {
-    savePreferenceToggle("share_analytics", true, true);
+    savePreferenceToggle("share_analytics", true, { userId: "user-1", hasPlatformSession: true });
     expect(storeState.setAnalyticsConsentCurrent).toHaveBeenCalledWith(true);
     expect(storeState.setDiagnosticsConsentCurrent).not.toHaveBeenCalled();
     expect(localStorage.getItem(analyticsKey("user-1"))).toBe("true");
@@ -218,7 +212,7 @@ describe("savePreferenceToggle", () => {
   });
 
   test("stamps the diagnostics version and sets its flag only", () => {
-    savePreferenceToggle("share_diagnostics", false, true);
+    savePreferenceToggle("share_diagnostics", false, { userId: "user-1", hasPlatformSession: true });
     expect(storeState.setDiagnosticsConsentCurrent).toHaveBeenCalledWith(true);
     expect(storeState.setAnalyticsConsentCurrent).not.toHaveBeenCalled();
     const body = patchConsentMock.mock.calls[0][0];

--- a/clients/web/src/utils/onboarding-cleanup.test.ts
+++ b/clients/web/src/utils/onboarding-cleanup.test.ts
@@ -136,6 +136,73 @@ describe("resolveServerConsent", () => {
     expect(r.shareAnalytics).toBe(false);
     expect(r.shareDiagnostics).toBe(true);
   });
+
+  test("hasServerRecord is false for an all-defaults response", () => {
+    const r = resolveServerConsent(
+      makeConsent({
+        tos_accepted_version: "",
+        privacy_policy_accepted_version: "",
+        ai_data_sharing_accepted_version: "",
+        share_analytics_accepted_version: "",
+        share_diagnostics_accepted_version: "",
+        share_analytics: true,
+        share_diagnostics: true,
+      }),
+    );
+    expect(r.hasServerRecord).toBe(false);
+  });
+
+  test("hasServerRecord is false for null/undefined consent", () => {
+    expect(resolveServerConsent(null).hasServerRecord).toBe(false);
+    expect(resolveServerConsent(undefined).hasServerRecord).toBe(false);
+  });
+
+  test("hasServerRecord is true when any version is non-empty", () => {
+    const allDefaults = {
+      tos_accepted_version: "",
+      privacy_policy_accepted_version: "",
+      ai_data_sharing_accepted_version: "",
+      share_analytics_accepted_version: "",
+      share_diagnostics_accepted_version: "",
+      share_analytics: true,
+      share_diagnostics: true,
+    };
+    expect(
+      resolveServerConsent(
+        makeConsent({ ...allDefaults, tos_accepted_version: CONSENT_VERSION }),
+      ).hasServerRecord,
+    ).toBe(true);
+    expect(
+      resolveServerConsent(
+        makeConsent({
+          ...allDefaults,
+          ai_data_sharing_accepted_version: CONSENT_VERSION,
+        }),
+      ).hasServerRecord,
+    ).toBe(true);
+  });
+
+  test("hasServerRecord is true when a share boolean is false", () => {
+    const allDefaults = {
+      tos_accepted_version: "",
+      privacy_policy_accepted_version: "",
+      ai_data_sharing_accepted_version: "",
+      share_analytics_accepted_version: "",
+      share_diagnostics_accepted_version: "",
+      share_analytics: true,
+      share_diagnostics: true,
+    };
+    expect(
+      resolveServerConsent(
+        makeConsent({ ...allDefaults, share_analytics: false }),
+      ).hasServerRecord,
+    ).toBe(true);
+    expect(
+      resolveServerConsent(
+        makeConsent({ ...allDefaults, share_diagnostics: false }),
+      ).hasServerRecord,
+    ).toBe(true);
+  });
 });
 
 describe("persistToggleConsent + restoreConsentForUser round-trip", () => {

--- a/clients/web/src/utils/onboarding-cleanup.test.ts
+++ b/clients/web/src/utils/onboarding-cleanup.test.ts
@@ -152,6 +152,23 @@ describe("resolveServerConsent", () => {
     expect(r.hasServerRecord).toBe(false);
   });
 
+  test("hasServerRecord is false when share-version fields are omitted (older backend)", () => {
+    // Simulate a rollout-window response that predates the share-version
+    // fields: they are absent (undefined), not empty strings.
+    const legacy = makeConsent({
+      tos_accepted_version: "",
+      privacy_policy_accepted_version: "",
+      ai_data_sharing_accepted_version: "",
+      share_analytics: true,
+      share_diagnostics: true,
+    }) as unknown as Record<string, unknown>;
+    delete legacy.share_analytics_accepted_version;
+    delete legacy.share_diagnostics_accepted_version;
+    expect(
+      resolveServerConsent(legacy as unknown as UserConsent).hasServerRecord,
+    ).toBe(false);
+  });
+
   test("hasServerRecord is false for null/undefined consent", () => {
     expect(resolveServerConsent(null).hasServerRecord).toBe(false);
     expect(resolveServerConsent(undefined).hasServerRecord).toBe(false);

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -137,12 +137,16 @@ export function resolveServerConsent(
   // returns the API defaults (empty versions, share booleans true). Any
   // non-empty version or any `false` share boolean can only have come from a
   // real stored row, so it proves a record whose data is worth preserving.
+  // Truthiness (not `!== ""`) so a response that OMITS the newer
+  // share-version fields — e.g. an older backend during rollout — reads as
+  // absent rather than as record evidence. `undefined` and `""` both mean
+  // "no version on record".
   const hasServerRecord =
-    consent.tos_accepted_version !== "" ||
-    consent.privacy_policy_accepted_version !== "" ||
-    consent.ai_data_sharing_accepted_version !== "" ||
-    consent.share_analytics_accepted_version !== "" ||
-    consent.share_diagnostics_accepted_version !== "" ||
+    !!consent.tos_accepted_version ||
+    !!consent.privacy_policy_accepted_version ||
+    !!consent.ai_data_sharing_accepted_version ||
+    !!consent.share_analytics_accepted_version ||
+    !!consent.share_diagnostics_accepted_version ||
     consent.share_analytics === false ||
     consent.share_diagnostics === false;
   return {

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -1,9 +1,13 @@
 /**
  * Versioned, per-user consent persistence.
  *
- * Consent flags live in `device:consent:{tos,ai}:v<VERSION>:<userId>`.
+ * Consent flags live in `device:consent:{tos,ai,share_analytics,share_diagnostics}:v<VERSION>:<userId>`.
  * The `device:` prefix survives logout; the userId makes them per-user;
  * the version lets us force re-consent by bumping CONSENT_VERSION.
+ *
+ * The `share_analytics`/`share_diagnostics` ack keys record the version under
+ * which the toggle was last confirmed (its currency), independent of the
+ * on/off value which lives in the unversioned `device:share_analytics` key.
  *
  * The onboarding Zustand store holds the in-memory state (`tosAccepted`,
  * `aiDataConsent`). This module handles the durable device-key layer
@@ -12,13 +16,15 @@
  * - `resolveServerConsent` — compare server consent versions against CONSENT_VERSION
  * - `saveConsent`          — unified write: store + device keys + server sync
  * - `savePreferenceToggle` — single-field write for settings page toggles
- * - `restoreConsentForUser` — read device keys, return {tos, ai}
- * - `persistConsentForUser` — write device keys
+ * - `restoreConsentForUser` — read device keys, return {tos, ai, toggle acks}
+ * - `persistConsentForUser` — write tos/ai device keys
+ * - `persistToggleConsent`  — write versioned share-toggle ack keys
  * - `clearConsentForUser`   — delete device keys + legacy active keys
  */
 import { removeLocalSetting, getLocalBool, setLocalBool } from "@/utils/local-settings";
 import { setDeviceBool } from "@/utils/device-settings";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
+import { useAuthStore } from "@/stores/auth-store";
 import { patchConsent, type UserConsent } from "@/domains/account/profile";
 
 export const CONSENT_VERSION = "2026-06-08";
@@ -27,12 +33,18 @@ function consentKey(field: string, userId: string): string {
   return `device:consent:${field}:v${CONSENT_VERSION}:${userId}`;
 }
 
-export function restoreConsentForUser(userId: string | null): { tos: boolean; ai: boolean } {
-  if (typeof window === "undefined" || !userId) return { tos: false, ai: false };
+export function restoreConsentForUser(
+  userId: string | null,
+): { tos: boolean; ai: boolean; analyticsCurrent: boolean; diagnosticsCurrent: boolean } {
+  if (typeof window === "undefined" || !userId) {
+    return { tos: false, ai: false, analyticsCurrent: false, diagnosticsCurrent: false };
+  }
   try {
+    const analyticsCurrent = getLocalBool(consentKey("share_analytics", userId), false);
+    const diagnosticsCurrent = getLocalBool(consentKey("share_diagnostics", userId), false);
     const tos = getLocalBool(consentKey("tos", userId), false);
     const ai = getLocalBool(consentKey("ai", userId), false);
-    if (tos || ai) return { tos, ai };
+    if (tos || ai) return { tos, ai, analyticsCurrent, diagnosticsCurrent };
 
     // One-time migration: users who accepted before the per-user device
     // key change still have consent in the legacy vellum: active keys.
@@ -41,12 +53,12 @@ export function restoreConsentForUser(userId: string | null): { tos: boolean; ai
     const legacyAi = getLocalBool("vellum:onboarding:aiDataConsent", false);
     if (legacyTos || legacyAi) {
       persistConsentForUser(userId, legacyTos, legacyAi);
-      return { tos: legacyTos, ai: legacyAi };
+      return { tos: legacyTos, ai: legacyAi, analyticsCurrent, diagnosticsCurrent };
     }
 
-    return { tos: false, ai: false };
+    return { tos: false, ai: false, analyticsCurrent, diagnosticsCurrent };
   } catch {
-    return { tos: false, ai: false };
+    return { tos: false, ai: false, analyticsCurrent: false, diagnosticsCurrent: false };
   }
 }
 
@@ -64,6 +76,23 @@ export function persistConsentForUser(
   }
 }
 
+export function persistToggleConsent(
+  userId: string | null,
+  acks: { analyticsCurrent?: boolean; diagnosticsCurrent?: boolean },
+): void {
+  if (typeof window === "undefined" || !userId) return;
+  try {
+    if (acks.analyticsCurrent !== undefined) {
+      setLocalBool(consentKey("share_analytics", userId), acks.analyticsCurrent);
+    }
+    if (acks.diagnosticsCurrent !== undefined) {
+      setLocalBool(consentKey("share_diagnostics", userId), acks.diagnosticsCurrent);
+    }
+  } catch {
+    // Storage unavailable.
+  }
+}
+
 export function clearConsentForUser(userId: string | null): void {
   removeLocalSetting("vellum:onboarding:tosAccepted");
   removeLocalSetting("vellum:onboarding:aiDataConsent");
@@ -72,6 +101,8 @@ export function clearConsentForUser(userId: string | null): void {
   try {
     removeLocalSetting(consentKey("tos", userId));
     removeLocalSetting(consentKey("ai", userId));
+    removeLocalSetting(consentKey("share_analytics", userId));
+    removeLocalSetting(consentKey("share_diagnostics", userId));
   } catch {
     // Storage unavailable.
   }
@@ -83,14 +114,32 @@ export function clearConsentForUser(userId: string | null): void {
 
 export function resolveServerConsent(
   consent: UserConsent | null | undefined,
-): { tos: boolean; ai: boolean; shareAnalytics: boolean | null; shareDiagnostics: boolean | null } {
-  if (!consent) return { tos: false, ai: false, shareAnalytics: null, shareDiagnostics: null };
+): {
+  tos: boolean;
+  ai: boolean;
+  shareAnalytics: boolean | null;
+  shareDiagnostics: boolean | null;
+  analyticsCurrent: boolean;
+  diagnosticsCurrent: boolean;
+} {
+  if (!consent) {
+    return {
+      tos: false,
+      ai: false,
+      shareAnalytics: null,
+      shareDiagnostics: null,
+      analyticsCurrent: false,
+      diagnosticsCurrent: false,
+    };
+  }
   return {
     tos: consent.tos_accepted_version === CONSENT_VERSION
       && consent.privacy_policy_accepted_version === CONSENT_VERSION,
     ai: consent.ai_data_sharing_accepted_version === CONSENT_VERSION,
     shareAnalytics: consent.share_analytics,
     shareDiagnostics: consent.share_diagnostics,
+    analyticsCurrent: consent.share_analytics_accepted_version === CONSENT_VERSION,
+    diagnosticsCurrent: consent.share_diagnostics_accepted_version === CONSENT_VERSION,
   };
 }
 
@@ -111,8 +160,11 @@ export function saveConsent(opts: {
   store.setAiDataConsent(opts.ai);
   store.setShareAnalytics(opts.shareAnalytics);
   store.setShareDiagnostics(opts.shareDiagnostics);
+  store.setAnalyticsConsentCurrent(true);
+  store.setDiagnosticsConsentCurrent(true);
 
   persistConsentForUser(opts.userId, opts.tos, opts.ai);
+  persistToggleConsent(opts.userId, { analyticsCurrent: true, diagnosticsCurrent: true });
 
   if (opts.hasPlatformSession) {
     void patchConsent({
@@ -121,6 +173,8 @@ export function saveConsent(opts: {
       ai_data_sharing_accepted_version: opts.ai ? CONSENT_VERSION : "",
       share_analytics: opts.shareAnalytics,
       share_diagnostics: opts.shareDiagnostics,
+      share_analytics_accepted_version: CONSENT_VERSION,
+      share_diagnostics_accepted_version: CONSENT_VERSION,
     }).catch(() => {});
   }
 }
@@ -131,15 +185,23 @@ export function savePreferenceToggle(
   hasPlatformSession: boolean,
 ): void {
   const store = useOnboardingStore.getState();
+  const userId = useAuthStore.getState().user?.id ?? null;
   if (field === "share_analytics") {
     store.setShareAnalytics(value);
     setDeviceBool("shareAnalytics", value);
+    store.setAnalyticsConsentCurrent(true);
+    persistToggleConsent(userId, { analyticsCurrent: true });
   } else {
     store.setShareDiagnostics(value);
     setDeviceBool("shareDiagnostics", value);
+    store.setDiagnosticsConsentCurrent(true);
+    persistToggleConsent(userId, { diagnosticsCurrent: true });
   }
 
   if (hasPlatformSession) {
-    void patchConsent({ [field]: value }).catch(() => {});
+    void patchConsent({
+      [field]: value,
+      [`${field}_accepted_version`]: CONSENT_VERSION,
+    }).catch(() => {});
   }
 }

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -24,7 +24,6 @@
 import { removeLocalSetting, getLocalBool, setLocalBool } from "@/utils/local-settings";
 import { setDeviceBool } from "@/utils/device-settings";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
-import { useAuthStore } from "@/stores/auth-store";
 import { patchConsent, type UserConsent } from "@/domains/account/profile";
 
 export const CONSENT_VERSION = "2026-06-08";
@@ -182,10 +181,10 @@ export function saveConsent(opts: {
 export function savePreferenceToggle(
   field: "share_analytics" | "share_diagnostics",
   value: boolean,
-  hasPlatformSession: boolean,
+  opts: { userId: string | null; hasPlatformSession: boolean },
 ): void {
   const store = useOnboardingStore.getState();
-  const userId = useAuthStore.getState().user?.id ?? null;
+  const { userId, hasPlatformSession } = opts;
   if (field === "share_analytics") {
     store.setShareAnalytics(value);
     setDeviceBool("shareAnalytics", value);

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -120,6 +120,7 @@ export function resolveServerConsent(
   shareDiagnostics: boolean | null;
   analyticsCurrent: boolean;
   diagnosticsCurrent: boolean;
+  hasServerRecord: boolean;
 } {
   if (!consent) {
     return {
@@ -129,8 +130,21 @@ export function resolveServerConsent(
       shareDiagnostics: null,
       analyticsCurrent: false,
       diagnosticsCurrent: false,
+      hasServerRecord: false,
     };
   }
+  // The endpoint always returns an object; for a user with no stored row it
+  // returns the API defaults (empty versions, share booleans true). Any
+  // non-empty version or any `false` share boolean can only have come from a
+  // real stored row, so it proves a record whose data is worth preserving.
+  const hasServerRecord =
+    consent.tos_accepted_version !== "" ||
+    consent.privacy_policy_accepted_version !== "" ||
+    consent.ai_data_sharing_accepted_version !== "" ||
+    consent.share_analytics_accepted_version !== "" ||
+    consent.share_diagnostics_accepted_version !== "" ||
+    consent.share_analytics === false ||
+    consent.share_diagnostics === false;
   return {
     tos: consent.tos_accepted_version === CONSENT_VERSION
       && consent.privacy_policy_accepted_version === CONSENT_VERSION,
@@ -139,6 +153,7 @@ export function resolveServerConsent(
     shareDiagnostics: consent.share_diagnostics,
     analyticsCurrent: consent.share_analytics_accepted_version === CONSENT_VERSION,
     diagnosticsCurrent: consent.share_diagnostics_accepted_version === CONSENT_VERSION,
+    hasServerRecord,
   };
 }
 


### PR DESCRIPTION
## Summary
Adds consent versioning to the two preference toggles (`share_analytics`, `share_diagnostics`), mirroring the existing versioned legal-consent fields. A toggle whose stored `*_accepted_version` no longer matches `CONSENT_VERSION` is surfaced in the review-terms screen for reconfirmation. Also fixes a pre-existing wiring bug: the client now reads/writes consent via the purpose-built `GET`/`PUT /v1/user/consent/` endpoint instead of the dead `PATCH /v1/user/me/` path (which the backend silently ignored).

## ⚠️ Cross-repo deploy ordering (read before merging/deploying)
This is the **frontend half** of a cross-repo feature. The toggle-staleness **gating** (PR #35283) must NOT reach production until the **backend** serializer returns the new `share_*_accepted_version` fields (the separate `vellum-assistant-platform` plan, not yet executed). Until the API returns those fields, the client reads them as undefined → "stale" → every user is routed to review-terms. The backend changes are additive and must ship first. The endpoint-repoint PR (#35278) is independently safe and already correct against the live `/v1/user/consent/` endpoint.

## Self-review result
PASS. Round-1 self-review found 3 gaps; all fixed across 3 fix PRs and verified PASS in round 2.

## PRs merged into this feature branch
- #35277 — add toggle consent currency flags to onboarding store
- #35278 — use /v1/user/consent/ instead of dead /v1/user/me/ consent wiring
- #35276 — add share toggle version fields to UserConsent type
- #35279 — version share toggles in onboarding-cleanup
- #35280 — hydrate toggle currency flags from server consent
- #35283 — redirect to review-terms when a toggle version is stale
- #35285 — surface stale share toggles in review-terms

### Fix PRs (from self-review)
- #35293 — gate the hatching path on toggle consent currency (no-assistant users were bypassing the gate)
- #35294 — snapshot review-terms staleness at mount so checked boxes stay visible
- #35295 — pass userId to savePreferenceToggle to break an onboarding-cleanup↔auth-store import cycle

## Known follow-up (out of scope)
A separate, pre-existing `SettingRow` in `src/domains/settings/pages/privacy-page.tsx` could be consolidated with the shared `components/setting-row.tsx` — not introduced by this feature.

Part of plan: consent-toggle-versioning.md