### PR TITLE
refactor(telemetry): remove collectUsageData config key

### DIFF
--- a/assistant/docs/activation-funnel-telemetry.md
+++ b/assistant/docs/activation-funnel-telemetry.md
@@ -50,8 +50,9 @@ Flow, end to end:
      `assistant/src/telemetry/activation-funnel.ts`;
    - emission is best-effort (wrapped in try/catch) and never blocks or alters
      the surface-action flow;
-   - `recordActivationEvent` respects the `getConfig().collectUsageData` opt-out
-     gate (returns `null` / no row when disabled).
+   - `recordActivationEvent` respects the platform `share_analytics` consent gate
+     via `getCachedShareAnalytics()` (returns `null` / no row when the platform
+     user has not consented; default-off when there is no platform session).
 2. **Reporter flushes** every ~5 min: `usage-telemetry-reporter.ts`
    (`REPORT_INTERVAL_MS = 5 * 60 * 1000`, with a one-time
    `INITIAL_FLUSH_DELAY_MS = 30_000` after startup) POSTs unreported onboarding
@@ -172,22 +173,24 @@ When the flag is ON, the web prechat context selects
 `BOOTSTRAP-ACTIVATION-RAIL.md` as the bootstrap template, and the daemon marks
 the conversation in `activation_sessions` on first build of the system prompt.
 
-### 5.2 Confirm usage-data collection is enabled — and do NOT run in dev mode
+### 5.2 Confirm share_analytics consent is on — and do NOT run in dev mode
 
 Two gates must both be satisfied or no rows reach BigQuery:
 
-1. `recordActivationEvent` no-ops when `config.collectUsageData` is false, so the
-   dev build/config must have usage-data collection enabled, or no rows are
-   written to SQLite.
-2. **Dev mode disables the flush entirely.** `assistant/src/daemon/lifecycle.ts`
-   computes the effective setting as `collectUsageData = !isDevMode &&
-config.collectUsageData`, so when the daemon runs in dev mode (`VELLUM_DEV=1`)
-   the `UsageTelemetryReporter` is never started — rows accumulate in SQLite but
-   are never POSTed, and the "wait/restart for flush" steps below will never
-   reach BigQuery. For an end-to-end smoke test, run the daemon **outside dev
-   mode** (so the reporter starts), or explicitly invoke the reporter's
-   `flush()` via a dev hook. The SQLite rows can still be inspected directly in
-   dev mode, but the BigQuery verification (§6) requires a real flush.
+1. `recordActivationEvent` no-ops when the platform `share_analytics` consent is
+   off (it reads `getCachedShareAnalytics()`), and the consent is **default-off
+   when there is no platform session**. So the dev session must be signed in to
+   the platform with `share_analytics` consent enabled, or no rows are written to
+   SQLite. The consent cache is refreshed by `startConsentRefresh()` in
+   `assistant/src/daemon/lifecycle.ts`.
+2. **Dev mode disables the flush entirely.** When the daemon runs in dev mode
+   (`VELLUM_DEV=1`), `assistant/src/daemon/lifecycle.ts` never starts the
+   `UsageTelemetryReporter` — rows accumulate in SQLite but are never POSTed, and
+   the "wait/restart for flush" steps below will never reach BigQuery. For an
+   end-to-end smoke test, run the daemon **outside dev mode** (so the reporter
+   starts), or explicitly invoke the reporter's `flush()` via a dev hook. The
+   SQLite rows can still be inspected directly in dev mode, but the BigQuery
+   verification (§6) requires a real flush.
 
 ### 5.3 Start a fresh activation conversation and capture its id
 

--- a/assistant/src/__tests__/workspace-migration-add-send-diagnostics.test.ts
+++ b/assistant/src/__tests__/workspace-migration-add-send-diagnostics.test.ts
@@ -49,7 +49,7 @@ describe("005-add-send-diagnostics migration", () => {
   test("runs without error on existing config (no-op)", () => {
     existsSyncFn.mockImplementation(() => true);
     readFileSyncFn.mockImplementation(() =>
-      JSON.stringify({ collectUsageData: true }),
+      JSON.stringify({ sendDiagnostics: true }),
     );
 
     addSendDiagnosticsMigration.run(WORKSPACE_DIR);

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -136,12 +136,6 @@ export const AssistantConfigSchema = z
       .describe(
         "Per-plugin configuration keyed by plugin name. Validated downstream by each plugin's manifest.config validator at bootstrap.",
       ),
-    collectUsageData: z
-      .boolean()
-      .default(true)
-      .describe(
-        "Whether to collect anonymous usage data to help improve the assistant",
-      ),
     sendDiagnostics: z
       .boolean()
       .default(true)

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -642,9 +642,9 @@ export async function runDaemon(): Promise<void> {
     }
 
     // Privacy gating: Sentry crash/error reporting is gated by sendDiagnostics,
-    // while the usage telemetry reporter re-checks collectUsageData on every
-    // flush. Both are disabled in dev mode. Early-startup crashes before this
-    // point are still captured.
+    // while the usage telemetry reporter re-checks the platform share_analytics
+    // consent on every flush. Both are disabled in dev mode. Early-startup
+    // crashes before this point are still captured.
     const isDevMode = process.env.VELLUM_DEV === "1";
     const sendDiagnostics = !isDevMode && config.sendDiagnostics;
     if (!sendDiagnostics) {
@@ -652,11 +652,12 @@ export async function runDaemon(): Promise<void> {
     }
 
     // Construct and start the reporter even when usage collection is disabled:
-    // flush() re-checks collectUsageData each cycle and, when opted out, sends
-    // nothing but advances all watermarks (including the final flush in
-    // stop()). New opted-out tool_invocations rows are already unreportable by
-    // construction — the audit listener persists NULL telemetry columns for
-    // them, which the tool_executed projection filters out — so the opted-out
+    // flush() re-checks the platform share_analytics consent each cycle and,
+    // when opted out, sends nothing but advances all watermarks (including the
+    // final flush in stop()). New opted-out tool_invocations rows are already
+    // unreportable by construction — the audit listener persists NULL telemetry
+    // columns for them, which the tool_executed projection filters out — so the
+    // opted-out
     // flushes are defense in depth there (covering rows recorded under builds
     // that predate that write-time gate) and remain the primary guard for the
     // always-on tables without a write-time gate (llm_usage, turn events).
@@ -670,10 +671,7 @@ export async function runDaemon(): Promise<void> {
       telemetryReporter = new UsageTelemetryReporter();
       setUsageTelemetryReporter(telemetryReporter);
       telemetryReporter.start();
-      log.info(
-        { collectUsageData: config.collectUsageData },
-        "Usage telemetry reporter started",
-      );
+      log.info("Usage telemetry reporter started");
 
       // Fire-and-forget: startConsentRefresh() runs an immediate non-blocking
       // refresh, so the startup hot path is never blocked.

--- a/assistant/src/runtime/routes/internal-telemetry-routes.ts
+++ b/assistant/src/runtime/routes/internal-telemetry-routes.ts
@@ -53,7 +53,7 @@ function handleRecordAuthFallback({ body }: RouteHandlerArgs) {
 
   const recorded = recordAuthFallbackCounts(window_start, window_end, mapped);
   if (recorded === 0) {
-    // collectUsageData disabled — counts dropped to honor the opt-out.
+    // share_analytics consent off — counts dropped to honor the opt-out.
     return { skipped: true };
   }
   log.debug({ recorded }, "Recorded auth-fallback counts");

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -1627,8 +1627,8 @@ describe("UsageTelemetryReporter", () => {
 
     // Rows accumulated before any flush ever advanced the watermark — e.g.
     // an opt-out period under an older build that gated reporter
-    // construction on collectUsageData while the always-on audit listener
-    // kept writing.
+    // construction on the usage-data opt-out while the always-on audit
+    // listener kept writing.
     seedToolInvocation({
       id: "ti-opt-out-window",
       createdAt: Date.now() - 60_000,

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -129,7 +129,7 @@ export class UsageTelemetryReporter {
     // reporter shipping its rows: an absent watermark means no flush (opted
     // in or out) has ever advanced it, so rows recorded before this build —
     // including any opted-out period under older builds that gated the
-    // reporter on collectUsageData — would otherwise ship retroactively.
+    // reporter on the usage-data opt-out — would otherwise ship retroactively.
     // Initialize an absent watermark to "now" at construction. Construction
     // happens during daemon startup before any tool runs, so no legitimate
     // row falls behind the watermark — initializing at first FLUSH instead
@@ -138,8 +138,8 @@ export class UsageTelemetryReporter {
     // absent and re-initialize later. An EXISTING watermark is never touched:
     // opted-out sessions keep it advancing via the opt-out flush branch, and
     // overwriting it here would drop a legitimate unshipped backlog.
-    // `skill_loaded` needs no init: recording is gated on collectUsageData,
-    // so opt-out rows never exist and its standard 0 default is safe.
+    // `skill_loaded` needs no init: recording is gated on share_analytics
+    // consent, so opt-out rows never exist and its standard 0 default is safe.
     //
     // Best-effort: DB init failures are tolerated at daemon startup (degraded
     // mode), so this must never throw out of the constructor — matching

--- a/assistant/src/watcher/telemetry.ts
+++ b/assistant/src/watcher/telemetry.ts
@@ -4,8 +4,8 @@
  * ahead of the planned watcher → skills-and-schedules migration.
  *
  * Both event shapes ship through the existing lifecycle-event telemetry
- * pipeline, so they inherit its `collectUsageData` opt-out gate and need
- * no wire-contract or platform-side changes:
+ * pipeline, so they inherit its platform `share_analytics` consent gate and
+ * need no wire-contract or platform-side changes:
  *
  * - `watcher_enabled:<providerId>` — one per enabled watcher, at most
  *   once per 24h per daemon. Counts devices that have watchers

--- a/assistant/src/workspace/migrations/106-drop-collect-usage-data.ts
+++ b/assistant/src/workspace/migrations/106-drop-collect-usage-data.ts
@@ -1,0 +1,38 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Drop the now-unused `collectUsageData` config key. Usage-telemetry gating is
+ * governed solely by the platform `share_analytics` consent cache, so the key
+ * is dead. The schema strips unknown keys on the next save, so a stale value is
+ * harmless; this migration removes it for cleanliness.
+ */
+export const dropCollectUsageDataMigration: WorkspaceMigration = {
+  id: "106-drop-collect-usage-data",
+  description:
+    "Remove the unused collectUsageData config key (telemetry is now gated by platform share_analytics consent)",
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return; // Malformed config — skip
+    }
+
+    if (!("collectUsageData" in config)) return;
+
+    delete config.collectUsageData;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(_workspaceDir: string): void {
+    // No-op: the forward migration only drops a now-unknown key, and the schema
+    // field no longer exists, so there is nothing to restore.
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -103,6 +103,7 @@ import { preserveHeartbeatEnabledForExistingWorkspacesMigration } from "./102-pr
 import { upgradeQualityProfileToOpus48Migration } from "./103-upgrade-quality-profile-to-opus-4-8.js";
 import { recheckAdaptiveThinkingModelImpliedAnthropicMigration } from "./104-recheck-adaptive-thinking-model-implied-anthropic.js";
 import { enableMemoryV3LiveForNewWorkspacesMigration } from "./105-enable-memory-v3-live-for-new-workspaces.js";
+import { dropCollectUsageDataMigration } from "./106-drop-collect-usage-data.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -217,4 +218,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   upgradeQualityProfileToOpus48Migration,
   recheckAdaptiveThinkingModelImpliedAnthropicMigration,
   enableMemoryV3LiveForNewWorkspacesMigration,
+  dropCollectUsageDataMigration,
 ];


### PR DESCRIPTION
## Summary
- Delete the `collectUsageData` schema key; telemetry gating is now governed solely by the platform `share_analytics` consent cache
- Add workspace migration 106 to drop the key from existing config.json (down is a documented no-op)
- Clean up the lifecycle log/comment and the activation-funnel-telemetry doc

Part of plan: telemetry-consent-gating.md (PR 6 of 6)