### PR TITLE
fix(telemetry): consent cache fails closed on missing assistant identity

### DIFF
--- a/assistant/src/platform/consent-cache.test.ts
+++ b/assistant/src/platform/consent-cache.test.ts
@@ -6,8 +6,10 @@ import type { OwnerConsent } from "./client.js";
 // Mutable mock state
 // ---------------------------------------------------------------------------
 
-let mockClient: { getOwnerConsent: () => Promise<OwnerConsent | null> } | null =
-  null;
+let mockClient: {
+  platformAssistantId: string;
+  getOwnerConsent: () => Promise<OwnerConsent | null>;
+} | null = null;
 let createCallCount = 0;
 
 // ---------------------------------------------------------------------------
@@ -42,8 +44,11 @@ import {
   stopConsentRefresh,
 } from "./consent-cache.js";
 
-function makeClient(consent: OwnerConsent | null) {
-  return { getOwnerConsent: async () => consent };
+function makeClient(consent: OwnerConsent | null, assistantId = "asst_1") {
+  return {
+    platformAssistantId: assistantId,
+    getOwnerConsent: async () => consent,
+  };
 }
 
 describe("consent-cache", () => {
@@ -87,6 +92,19 @@ describe("consent-cache", () => {
   test("a missing client flips a prior opt-in back to false", async () => {
     __setCachedShareAnalyticsForTest(true);
     mockClient = null;
+    await refreshConsentCache();
+    expect(getCachedShareAnalytics()).toBe(false);
+  });
+
+  test("a client without a resolvable assistant identity fails closed", async () => {
+    __setCachedShareAnalyticsForTest(true);
+    // Identity cleared mid-session (e.g. assistantId emptied while base URL +
+    // API key persist). getOwnerConsent must not be relied upon to preserve the
+    // prior opt-in here — fail closed instead.
+    mockClient = makeClient(
+      { shareAnalytics: true, shareDiagnostics: false },
+      "",
+    );
     await refreshConsentCache();
     expect(getCachedShareAnalytics()).toBe(false);
   });

--- a/assistant/src/platform/consent-cache.ts
+++ b/assistant/src/platform/consent-cache.ts
@@ -30,13 +30,20 @@ export function getCachedShareAnalytics(): boolean {
  * Refresh the cached consent from the platform.
  *
  * No platform session / features disabled (`create()` is null) → default-off.
- * A successful fetch adopts the reported value. A `null` fetch (transient
- * failure / undeployed endpoint) leaves the previous value unchanged so a known
- * opt-in is not flipped off mid-session.
+ * No resolvable assistant identity (no owner whose consent we can attest to) →
+ * fail closed. A successful fetch adopts the reported value. A `null` fetch
+ * (transient failure / undeployed endpoint) leaves the previous value unchanged
+ * so a known opt-in is not flipped off mid-session.
  */
 export async function refreshConsentCache(): Promise<void> {
   const client = await VellumPlatformClient.create();
   if (!client) {
+    setCachedShareAnalytics(false);
+    return;
+  }
+
+  // No resolvable owner identity → fail closed (don't ride a stale opt-in).
+  if (!client.platformAssistantId) {
     setCachedShareAnalytics(false);
     return;
   }


### PR DESCRIPTION
## Summary
Fixes gap from plan review (telemetry-consent-gating.md): refreshConsentCache kept the prior cached value on any getOwnerConsent() null, but null also means 'no resolvable assistant identity'. Now fails closed (sets share_analytics false) when platformAssistantId is empty; preserves the keep-prior-value behavior only for genuine transient fetch failures with an identity present.