### PR TITLE
fix(daemon): refresh consent cache regardless of dev mode

### DIFF
--- a/assistant/docs/activation-funnel-telemetry.md
+++ b/assistant/docs/activation-funnel-telemetry.md
@@ -173,23 +173,26 @@ When the flag is ON, the web prechat context selects
 `BOOTSTRAP-ACTIVATION-RAIL.md` as the bootstrap template, and the daemon marks
 the conversation in `activation_sessions` on first build of the system prompt.
 
-### 5.2 Confirm share_analytics consent is on — and do NOT run in dev mode
+### 5.2 Confirm share_analytics consent is on — and pick the right daemon mode
 
-Two gates must both be satisfied or no rows reach BigQuery:
+Two distinct concerns: whether record-time rows reach SQLite (consent gate), and
+whether those rows reach BigQuery (flush gate, dev-disabled).
 
 1. `recordActivationEvent` no-ops when the platform `share_analytics` consent is
    off (it reads `getCachedShareAnalytics()`), and the consent is **default-off
    when there is no platform session**. So the dev session must be signed in to
    the platform with `share_analytics` consent enabled, or no rows are written to
    SQLite. The consent cache is refreshed by `startConsentRefresh()` in
-   `assistant/src/daemon/lifecycle.ts`.
+   `assistant/src/daemon/lifecycle.ts`, which runs **regardless of dev mode** — so
+   a dev session signed in with `share_analytics` consent enabled writes
+   record-time rows to SQLite, where they can be inspected directly.
 2. **Dev mode disables the flush entirely.** When the daemon runs in dev mode
    (`VELLUM_DEV=1`), `assistant/src/daemon/lifecycle.ts` never starts the
-   `UsageTelemetryReporter` — rows accumulate in SQLite but are never POSTed, and
-   the "wait/restart for flush" steps below will never reach BigQuery. For an
-   end-to-end smoke test, run the daemon **outside dev mode** (so the reporter
-   starts), or explicitly invoke the reporter's `flush()` via a dev hook. The
-   SQLite rows can still be inspected directly in dev mode, but the BigQuery
+   `UsageTelemetryReporter` — rows accumulate in SQLite (consent permitting) but
+   are never POSTed, and the "wait/restart for flush" steps below will never reach
+   BigQuery. For an end-to-end smoke test, run the daemon **outside dev mode** (so
+   the reporter starts), or explicitly invoke the reporter's `flush()` via a dev
+   hook. The SQLite rows can be inspected directly in dev mode, but the BigQuery
    verification (§6) requires a real flush.
 
 ### 5.3 Start a fresh activation conversation and capture its id

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -672,12 +672,15 @@ export async function runDaemon(): Promise<void> {
       setUsageTelemetryReporter(telemetryReporter);
       telemetryReporter.start();
       log.info("Usage telemetry reporter started");
-
-      // Fire-and-forget: startConsentRefresh() runs an immediate non-blocking
-      // refresh, so the startup hot path is never blocked.
-      startConsentRefresh();
-      registerShutdownHook("consent-cache", () => stopConsentRefresh());
     }
+
+    // Refresh the consent cache regardless of dev mode so record-time telemetry
+    // writes (gated on getCachedShareAnalytics()) work in dev too. The reporter
+    // flush stays dev-gated above, so dev still never sends telemetry to the
+    // platform. Fire-and-forget: startConsentRefresh() runs an immediate
+    // non-blocking refresh, so the startup hot path is never blocked.
+    startConsentRefresh();
+    registerShutdownHook("consent-cache", () => stopConsentRefresh());
 
     // CES lifecycle — kick off early so CES handshake runs concurrently with
     // provider/tool initialization. The CES sidecar accepts exactly one


### PR DESCRIPTION
## Summary
Fixes gap from plan review (telemetry-consent-gating.md): startConsentRefresh() was gated behind !isDevMode, so the consent cache stayed false in dev and no record-time telemetry rows were written, breaking the activation-funnel SQLite dev workflow. Move the consent-refresh start/stop wiring out of the dev gate (the reporter flush stays dev-gated, so dev still never sends telemetry). Update activation-funnel-telemetry.md to match.