### PR TITLE
Drive usage-telemetry gating off platform share_analytics consent (replace collectUsageData)

### DIFF
--- a/assistant/docs/activation-funnel-telemetry.md
+++ b/assistant/docs/activation-funnel-telemetry.md
@@ -50,8 +50,9 @@ Flow, end to end:
      `assistant/src/telemetry/activation-funnel.ts`;
    - emission is best-effort (wrapped in try/catch) and never blocks or alters
      the surface-action flow;
-   - `recordActivationEvent` respects the `getConfig().collectUsageData` opt-out
-     gate (returns `null` / no row when disabled).
+   - `recordActivationEvent` respects the platform `share_analytics` consent gate
+     via `getCachedShareAnalytics()` (returns `null` / no row when the platform
+     user has not consented; default-off when there is no platform session).
 2. **Reporter flushes** every ~5 min: `usage-telemetry-reporter.ts`
    (`REPORT_INTERVAL_MS = 5 * 60 * 1000`, with a one-time
    `INITIAL_FLUSH_DELAY_MS = 30_000` after startup) POSTs unreported onboarding
@@ -172,22 +173,24 @@ When the flag is ON, the web prechat context selects
 `BOOTSTRAP-ACTIVATION-RAIL.md` as the bootstrap template, and the daemon marks
 the conversation in `activation_sessions` on first build of the system prompt.
 
-### 5.2 Confirm usage-data collection is enabled — and do NOT run in dev mode
+### 5.2 Confirm share_analytics consent is on — and do NOT run in dev mode
 
 Two gates must both be satisfied or no rows reach BigQuery:
 
-1. `recordActivationEvent` no-ops when `config.collectUsageData` is false, so the
-   dev build/config must have usage-data collection enabled, or no rows are
-   written to SQLite.
-2. **Dev mode disables the flush entirely.** `assistant/src/daemon/lifecycle.ts`
-   computes the effective setting as `collectUsageData = !isDevMode &&
-config.collectUsageData`, so when the daemon runs in dev mode (`VELLUM_DEV=1`)
-   the `UsageTelemetryReporter` is never started — rows accumulate in SQLite but
-   are never POSTed, and the "wait/restart for flush" steps below will never
-   reach BigQuery. For an end-to-end smoke test, run the daemon **outside dev
-   mode** (so the reporter starts), or explicitly invoke the reporter's
-   `flush()` via a dev hook. The SQLite rows can still be inspected directly in
-   dev mode, but the BigQuery verification (§6) requires a real flush.
+1. `recordActivationEvent` no-ops when the platform `share_analytics` consent is
+   off (it reads `getCachedShareAnalytics()`), and the consent is **default-off
+   when there is no platform session**. So the dev session must be signed in to
+   the platform with `share_analytics` consent enabled, or no rows are written to
+   SQLite. The consent cache is refreshed by `startConsentRefresh()` in
+   `assistant/src/daemon/lifecycle.ts`.
+2. **Dev mode disables the flush entirely.** When the daemon runs in dev mode
+   (`VELLUM_DEV=1`), `assistant/src/daemon/lifecycle.ts` never starts the
+   `UsageTelemetryReporter` — rows accumulate in SQLite but are never POSTed, and
+   the "wait/restart for flush" steps below will never reach BigQuery. For an
+   end-to-end smoke test, run the daemon **outside dev mode** (so the reporter
+   starts), or explicitly invoke the reporter's `flush()` via a dev hook. The
+   SQLite rows can still be inspected directly in dev mode, but the BigQuery
+   verification (§6) requires a real flush.
 
 ### 5.3 Start a fresh activation conversation and capture its id
 

--- a/assistant/docs/activation-funnel-telemetry.md
+++ b/assistant/docs/activation-funnel-telemetry.md
@@ -173,23 +173,26 @@ When the flag is ON, the web prechat context selects
 `BOOTSTRAP-ACTIVATION-RAIL.md` as the bootstrap template, and the daemon marks
 the conversation in `activation_sessions` on first build of the system prompt.
 
-### 5.2 Confirm share_analytics consent is on — and do NOT run in dev mode
+### 5.2 Confirm share_analytics consent is on — and pick the right daemon mode
 
-Two gates must both be satisfied or no rows reach BigQuery:
+Two distinct concerns: whether record-time rows reach SQLite (consent gate), and
+whether those rows reach BigQuery (flush gate, dev-disabled).
 
 1. `recordActivationEvent` no-ops when the platform `share_analytics` consent is
    off (it reads `getCachedShareAnalytics()`), and the consent is **default-off
    when there is no platform session**. So the dev session must be signed in to
    the platform with `share_analytics` consent enabled, or no rows are written to
    SQLite. The consent cache is refreshed by `startConsentRefresh()` in
-   `assistant/src/daemon/lifecycle.ts`.
+   `assistant/src/daemon/lifecycle.ts`, which runs **regardless of dev mode** — so
+   a dev session signed in with `share_analytics` consent enabled writes
+   record-time rows to SQLite, where they can be inspected directly.
 2. **Dev mode disables the flush entirely.** When the daemon runs in dev mode
    (`VELLUM_DEV=1`), `assistant/src/daemon/lifecycle.ts` never starts the
-   `UsageTelemetryReporter` — rows accumulate in SQLite but are never POSTed, and
-   the "wait/restart for flush" steps below will never reach BigQuery. For an
-   end-to-end smoke test, run the daemon **outside dev mode** (so the reporter
-   starts), or explicitly invoke the reporter's `flush()` via a dev hook. The
-   SQLite rows can still be inspected directly in dev mode, but the BigQuery
+   `UsageTelemetryReporter` — rows accumulate in SQLite (consent permitting) but
+   are never POSTed, and the "wait/restart for flush" steps below will never reach
+   BigQuery. For an end-to-end smoke test, run the daemon **outside dev mode** (so
+   the reporter starts), or explicitly invoke the reporter's `flush()` via a dev
+   hook. The SQLite rows can be inspected directly in dev mode, but the BigQuery
    verification (§6) requires a real flush.
 
 ### 5.3 Start a fresh activation conversation and capture its id

--- a/assistant/src/__tests__/auth-fallback-events-store.test.ts
+++ b/assistant/src/__tests__/auth-fallback-events-store.test.ts
@@ -7,18 +7,10 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-let collectUsageData = true;
+let shareAnalytics = true;
 
-mock.module("../config/loader.js", () => ({
-  getConfig: () => ({
-    ui: {},
-    model: "test",
-    provider: "test",
-    memory: { enabled: false },
-    rateLimit: { maxRequestsPerMinute: 0 },
-    secretDetection: { enabled: false },
-    collectUsageData,
-  }),
+mock.module("../platform/consent-cache.js", () => ({
+  getCachedShareAnalytics: () => shareAnalytics,
 }));
 
 import {
@@ -53,7 +45,7 @@ const SAMPLE: AuthFallbackCount[] = [
 
 describe("auth-fallback-events-store", () => {
   beforeEach(() => {
-    collectUsageData = true;
+    shareAnalytics = true;
     resetTable();
   });
 
@@ -78,8 +70,8 @@ describe("auth-fallback-events-store", () => {
     });
   });
 
-  test("honors the collectUsageData opt-out (records nothing)", () => {
-    collectUsageData = false;
+  test("honors the share_analytics opt-out (records nothing)", () => {
+    shareAnalytics = false;
     const recorded = recordAuthFallbackCounts(1000, 2000, SAMPLE);
     expect(recorded).toBe(0);
     expect(queryUnreportedAuthFallbackEvents(0, undefined, 100).length).toBe(0);

--- a/assistant/src/__tests__/conversation-surfaces-activation-emit.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-activation-emit.test.ts
@@ -10,9 +10,11 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-// Usage-data collection is enabled so recordActivationEvent writes rows.
-mock.module("../config/loader.js", () => ({
-  getConfig: () => ({ collectUsageData: true }),
+// Analytics consent is granted so recordActivationEvent writes rows.
+let shareAnalytics = true;
+
+mock.module("../platform/consent-cache.js", () => ({
+  getCachedShareAnalytics: () => shareAnalytics,
 }));
 
 let broadcastedMessages: ServerMessage[] = [];
@@ -117,6 +119,7 @@ async function showTaggedChoice(
 
 describe("activation moment emission from ui_show surface commits", () => {
   beforeEach(() => {
+    shareAnalytics = true;
     broadcastedMessages = [];
     resetTables();
   });

--- a/assistant/src/__tests__/internal-telemetry-routes.test.ts
+++ b/assistant/src/__tests__/internal-telemetry-routes.test.ts
@@ -7,23 +7,15 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-// Toggle for the collectUsageData opt-out the real store consults. The store
+// Toggle for the share_analytics opt-out the real store consults. The store
 // module is intentionally NOT mocked here — it has its own DB-backed tests, and
 // Bun's `mock.module` is process-global, so mocking it would leak into those
 // tests when files share an invocation. Exercising the real store keeps every
 // auth-fallback test order-independent.
-let collectUsageData = true;
+let shareAnalytics = true;
 
-mock.module("../config/loader.js", () => ({
-  getConfig: () => ({
-    ui: {},
-    model: "test",
-    provider: "test",
-    memory: { enabled: false },
-    rateLimit: { maxRequestsPerMinute: 0 },
-    secretDetection: { enabled: false },
-    collectUsageData,
-  }),
+mock.module("../platform/consent-cache.js", () => ({
+  getCachedShareAnalytics: () => shareAnalytics,
 }));
 
 import { queryUnreportedAuthFallbackEvents } from "../memory/auth-fallback-events-store.js";
@@ -61,7 +53,7 @@ const VALID_BODY = {
 
 describe("internal-telemetry-routes: auth-fallback", () => {
   beforeEach(() => {
-    collectUsageData = true;
+    shareAnalytics = true;
     getDb().delete(authFallbackEvents).run();
   });
 
@@ -90,7 +82,7 @@ describe("internal-telemetry-routes: auth-fallback", () => {
   });
 
   test("returns skipped and persists nothing under the opt-out", () => {
-    collectUsageData = false;
+    shareAnalytics = false;
     expect(call(VALID_BODY)).toEqual({ skipped: true });
     expect(queryUnreportedAuthFallbackEvents(0, undefined, 100).length).toBe(0);
   });

--- a/assistant/src/__tests__/tool-audit-listener.test.ts
+++ b/assistant/src/__tests__/tool-audit-listener.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-// Toggle for the collectUsageData opt-out gate the listener consults when
+// Toggle for the share_analytics opt-out gate the listener consults when
 // populating the telemetry columns.
-let collectUsageData = true;
+let shareAnalytics = true;
 
-mock.module("../config/loader.js", () => ({
-  getConfig: () => ({ collectUsageData }),
+mock.module("../platform/consent-cache.js", () => ({
+  getCachedShareAnalytics: () => shareAnalytics,
 }));
 
 import { createToolAuditListener } from "../events/tool-audit-listener.js";
@@ -17,7 +17,7 @@ import {
 
 describe("tool audit listener", () => {
   beforeEach(() => {
-    collectUsageData = true;
+    shareAnalytics = true;
   });
 
   test("records executed events with truncated output", () => {
@@ -361,8 +361,8 @@ describe("tool audit listener", () => {
     );
   });
 
-  test("persists NULL telemetry columns when usage data collection is opted out", () => {
-    collectUsageData = false;
+  test("persists NULL telemetry columns when share_analytics is opted out", () => {
+    shareAnalytics = false;
     const records: ToolInvocationRecord[] = [];
     const listener = createToolAuditListener((record) => records.push(record));
 

--- a/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
+++ b/assistant/src/__tests__/tool-executor-lifecycle-events.test.ts
@@ -34,9 +34,6 @@ const mockConfig = {
   permissions: {
     mode: "workspace" as const,
   },
-  // The audit listener nulls the telemetry columns when this is false; the
-  // end-to-end listener tests below assert the opted-in sizing behavior.
-  collectUsageData: true,
 };
 
 let checkerDecision: "allow" | "prompt" | "deny" = "allow";
@@ -54,6 +51,12 @@ mock.module("../config/loader.js", () => ({
   saveRawConfig: () => {},
   getNestedValue: () => undefined,
   setNestedValue: () => {},
+}));
+
+// Analytics consent is granted so the audit listener populates the telemetry
+// columns; the end-to-end listener tests below assert the opted-in sizing.
+mock.module("../platform/consent-cache.js", () => ({
+  getCachedShareAnalytics: () => true,
 }));
 
 mock.module("../util/logger.js", () => ({

--- a/assistant/src/__tests__/workspace-migration-add-send-diagnostics.test.ts
+++ b/assistant/src/__tests__/workspace-migration-add-send-diagnostics.test.ts
@@ -49,7 +49,7 @@ describe("005-add-send-diagnostics migration", () => {
   test("runs without error on existing config (no-op)", () => {
     existsSyncFn.mockImplementation(() => true);
     readFileSyncFn.mockImplementation(() =>
-      JSON.stringify({ collectUsageData: true }),
+      JSON.stringify({ sendDiagnostics: true }),
     );
 
     addSendDiagnosticsMigration.run(WORKSPACE_DIR);

--- a/assistant/src/__tests__/workspace-migration-drop-collect-usage-data.test.ts
+++ b/assistant/src/__tests__/workspace-migration-drop-collect-usage-data.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+const existsSyncFn = mock((_path: string): boolean => false);
+const readFileSyncFn = mock((_path: string, _encoding: string): string => "");
+const writeFileSyncFn = mock((_path: string, _data: string): void => undefined);
+
+// ---------------------------------------------------------------------------
+// Mock modules — before importing module under test
+// ---------------------------------------------------------------------------
+
+mock.module("node:fs", () => ({
+  existsSync: existsSyncFn,
+  readFileSync: readFileSyncFn,
+  writeFileSync: writeFileSyncFn,
+}));
+
+// Import after mocking
+import { dropCollectUsageDataMigration } from "../workspace/migrations/106-drop-collect-usage-data.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const WORKSPACE_DIR = "/tmp/test-workspace";
+const CONFIG_PATH = `${WORKSPACE_DIR}/config.json`;
+
+function setupConfigExists(config: unknown) {
+  existsSyncFn.mockImplementation((path: string) => path === CONFIG_PATH);
+  readFileSyncFn.mockImplementation(() => JSON.stringify(config));
+}
+
+function getWrittenConfig(): Record<string, unknown> {
+  expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
+  const [path, data] = writeFileSyncFn.mock.calls[0] as [string, string];
+  expect(path).toBe(CONFIG_PATH);
+  return JSON.parse(data) as Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("106-drop-collect-usage-data migration", () => {
+  beforeEach(() => {
+    existsSyncFn.mockClear();
+    readFileSyncFn.mockClear();
+    writeFileSyncFn.mockClear();
+  });
+
+  test("no-op when config.json is absent", () => {
+    existsSyncFn.mockImplementation(() => false);
+
+    dropCollectUsageDataMigration.run(WORKSPACE_DIR);
+
+    expect(readFileSyncFn).not.toHaveBeenCalled();
+    expect(writeFileSyncFn).not.toHaveBeenCalled();
+  });
+
+  test("explicit opt-out is preserved as legacyTelemetryOptOut", () => {
+    setupConfigExists({ collectUsageData: false, someSetting: "value" });
+
+    dropCollectUsageDataMigration.run(WORKSPACE_DIR);
+
+    const written = getWrittenConfig();
+    expect(written.collectUsageData).toBeUndefined();
+    expect(written.legacyTelemetryOptOut).toBe(true);
+    expect(written.someSetting).toBe("value");
+  });
+
+  test("collectUsageData: true is removed without setting the marker", () => {
+    setupConfigExists({ collectUsageData: true });
+
+    dropCollectUsageDataMigration.run(WORKSPACE_DIR);
+
+    const written = getWrittenConfig();
+    expect(written.collectUsageData).toBeUndefined();
+    expect(written.legacyTelemetryOptOut).toBeUndefined();
+  });
+
+  test("non-false value is removed without setting the marker", () => {
+    setupConfigExists({ collectUsageData: "yes" });
+
+    dropCollectUsageDataMigration.run(WORKSPACE_DIR);
+
+    const written = getWrittenConfig();
+    expect(written.collectUsageData).toBeUndefined();
+    expect(written.legacyTelemetryOptOut).toBeUndefined();
+  });
+
+  test("no-op when collectUsageData is absent (no marker)", () => {
+    setupConfigExists({ someSetting: "value" });
+
+    dropCollectUsageDataMigration.run(WORKSPACE_DIR);
+
+    expect(writeFileSyncFn).not.toHaveBeenCalled();
+  });
+
+  test("malformed config is handled gracefully", () => {
+    existsSyncFn.mockImplementation((path: string) => path === CONFIG_PATH);
+    readFileSyncFn.mockImplementation(() => "not valid json {{{");
+
+    dropCollectUsageDataMigration.run(WORKSPACE_DIR);
+
+    expect(writeFileSyncFn).not.toHaveBeenCalled();
+  });
+
+  test("no-op when config is an array", () => {
+    setupConfigExists([1, 2, 3]);
+
+    dropCollectUsageDataMigration.run(WORKSPACE_DIR);
+
+    expect(writeFileSyncFn).not.toHaveBeenCalled();
+  });
+});

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -140,6 +140,12 @@ export const AssistantConfigSchema = z
       .boolean()
       .default(true)
       .describe("Whether to send diagnostic/crash reports"),
+    legacyTelemetryOptOut: z
+      .boolean()
+      .optional()
+      .describe(
+        "Fail-closed telemetry marker: set for a workspace that had an explicit local usage-data opt-out before telemetry moved to platform share_analytics consent. While set, usage telemetry stays disabled regardless of platform consent.",
+      ),
     maxStepsPerSession: z
       .number({ error: "maxStepsPerSession must be a number" })
       .int("maxStepsPerSession must be an integer")

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -136,12 +136,6 @@ export const AssistantConfigSchema = z
       .describe(
         "Per-plugin configuration keyed by plugin name. Validated downstream by each plugin's manifest.config validator at bootstrap.",
       ),
-    collectUsageData: z
-      .boolean()
-      .default(true)
-      .describe(
-        "Whether to collect anonymous usage data to help improve the assistant",
-      ),
     sendDiagnostics: z
       .boolean()
       .default(true)

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -672,12 +672,15 @@ export async function runDaemon(): Promise<void> {
       setUsageTelemetryReporter(telemetryReporter);
       telemetryReporter.start();
       log.info("Usage telemetry reporter started");
-
-      // Fire-and-forget: startConsentRefresh() runs an immediate non-blocking
-      // refresh, so the startup hot path is never blocked.
-      startConsentRefresh();
-      registerShutdownHook("consent-cache", () => stopConsentRefresh());
     }
+
+    // Refresh the consent cache regardless of dev mode so record-time telemetry
+    // writes (gated on getCachedShareAnalytics()) work in dev too. The reporter
+    // flush stays dev-gated above, so dev still never sends telemetry to the
+    // platform. Fire-and-forget: startConsentRefresh() runs an immediate
+    // non-blocking refresh, so the startup hot path is never blocked.
+    startConsentRefresh();
+    registerShutdownHook("consent-cache", () => stopConsentRefresh());
 
     // CES lifecycle — kick off early so CES handshake runs concurrently with
     // provider/tool initialization. The CES sidecar accepts exactly one

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -60,6 +60,10 @@ import { sweepConceptPageFrontmatter } from "../memory/v2/frontmatter-sweep.js";
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
 import { backfillManualTokenConnections } from "../oauth/manual-token-connection.js";
 import { seedOAuthProviders } from "../oauth/seed-providers.js";
+import {
+  startConsentRefresh,
+  stopConsentRefresh,
+} from "../platform/consent-cache.js";
 import { ensurePromptFiles } from "../prompts/system-prompt.js";
 import { runProviderConnectionsBackfill } from "../providers/inference/backfill.js";
 import { resolveManagedProxyContext } from "../providers/platform-proxy/context.js";
@@ -130,6 +134,7 @@ import {
 } from "./providers-setup.js";
 import { DaemonServer } from "./server.js";
 import { installShutdownHandlers } from "./shutdown-handlers.js";
+import { registerShutdownHook } from "./shutdown-registry.js";
 import { refreshSkillCapabilityMemories } from "./skill-memory-refresh.js";
 
 const log = getLogger("lifecycle");
@@ -669,6 +674,11 @@ export async function runDaemon(): Promise<void> {
         { collectUsageData: config.collectUsageData },
         "Usage telemetry reporter started",
       );
+
+      // Fire-and-forget: startConsentRefresh() runs an immediate non-blocking
+      // refresh, so the startup hot path is never blocked.
+      startConsentRefresh();
+      registerShutdownHook("consent-cache", () => stopConsentRefresh());
     }
 
     // CES lifecycle — kick off early so CES handshake runs concurrently with

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -642,9 +642,9 @@ export async function runDaemon(): Promise<void> {
     }
 
     // Privacy gating: Sentry crash/error reporting is gated by sendDiagnostics,
-    // while the usage telemetry reporter re-checks collectUsageData on every
-    // flush. Both are disabled in dev mode. Early-startup crashes before this
-    // point are still captured.
+    // while the usage telemetry reporter re-checks the platform share_analytics
+    // consent on every flush. Both are disabled in dev mode. Early-startup
+    // crashes before this point are still captured.
     const isDevMode = process.env.VELLUM_DEV === "1";
     const sendDiagnostics = !isDevMode && config.sendDiagnostics;
     if (!sendDiagnostics) {
@@ -652,11 +652,12 @@ export async function runDaemon(): Promise<void> {
     }
 
     // Construct and start the reporter even when usage collection is disabled:
-    // flush() re-checks collectUsageData each cycle and, when opted out, sends
-    // nothing but advances all watermarks (including the final flush in
-    // stop()). New opted-out tool_invocations rows are already unreportable by
-    // construction — the audit listener persists NULL telemetry columns for
-    // them, which the tool_executed projection filters out — so the opted-out
+    // flush() re-checks the platform share_analytics consent each cycle and,
+    // when opted out, sends nothing but advances all watermarks (including the
+    // final flush in stop()). New opted-out tool_invocations rows are already
+    // unreportable by construction — the audit listener persists NULL telemetry
+    // columns for them, which the tool_executed projection filters out — so the
+    // opted-out
     // flushes are defense in depth there (covering rows recorded under builds
     // that predate that write-time gate) and remain the primary guard for the
     // always-on tables without a write-time gate (llm_usage, turn events).
@@ -670,10 +671,7 @@ export async function runDaemon(): Promise<void> {
       telemetryReporter = new UsageTelemetryReporter();
       setUsageTelemetryReporter(telemetryReporter);
       telemetryReporter.start();
-      log.info(
-        { collectUsageData: config.collectUsageData },
-        "Usage telemetry reporter started",
-      );
+      log.info("Usage telemetry reporter started");
 
       // Fire-and-forget: startConsentRefresh() runs an immediate non-blocking
       // refresh, so the startup hot path is never blocked.

--- a/assistant/src/events/tool-audit-listener.ts
+++ b/assistant/src/events/tool-audit-listener.ts
@@ -1,8 +1,8 @@
-import { getConfig } from "../config/loader.js";
 import {
   recordToolInvocation,
   type ToolInvocationRecord,
 } from "../memory/tool-usage-store.js";
+import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 import { redactJsonStringLeaves } from "../security/redact-json.js";
 import { redactSecrets } from "../security/secret-scanner.js";
 import {
@@ -168,7 +168,7 @@ function telemetryColumns(
   rawInput: string,
   resultBytes: number,
 ): TelemetryColumns {
-  if (!getConfig().collectUsageData) return NULL_TELEMETRY_COLUMNS;
+  if (!getCachedShareAnalytics()) return NULL_TELEMETRY_COLUMNS;
   return {
     argBytes: event.inputBytes ?? Buffer.byteLength(rawInput, "utf8"),
     resultBytes,

--- a/assistant/src/memory/__tests__/onboarding-events-store.test.ts
+++ b/assistant/src/memory/__tests__/onboarding-events-store.test.ts
@@ -8,10 +8,10 @@ mock.module("../../util/logger.js", () => ({
     }),
 }));
 
-// Mutable usage-data gate, flipped per-test.
-let collectUsageData = true;
-mock.module("../../config/loader.js", () => ({
-  getConfig: () => ({ collectUsageData }),
+// Mutable consent gate, flipped per-test.
+let shareAnalytics = true;
+mock.module("../../platform/consent-cache.js", () => ({
+  getCachedShareAnalytics: () => shareAnalytics,
 }));
 
 import { getDb } from "../db-connection.js";
@@ -30,7 +30,7 @@ function resetTable(): void {
 
 describe("onboarding-events-store: recordActivationEvent", () => {
   beforeEach(() => {
-    collectUsageData = true;
+    shareAnalytics = true;
     resetTable();
   });
 
@@ -66,8 +66,8 @@ describe("onboarding-events-store: recordActivationEvent", () => {
     expect(rows[0]!.stepIndex).toBe(2);
   });
 
-  test("returns null and writes no row when collectUsageData is disabled", () => {
-    collectUsageData = false;
+  test("returns null and writes no row when share_analytics is disabled", () => {
+    shareAnalytics = false;
     const event = recordActivationEvent({
       stepName: "activation_moment_1_complete",
       sessionId: "conv-3",

--- a/assistant/src/memory/auth-fallback-events-store.ts
+++ b/assistant/src/memory/auth-fallback-events-store.ts
@@ -1,7 +1,7 @@
 import { and, asc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getConfig } from "../config/loader.js";
+import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 import { getDb } from "./db-connection.js";
 import { authFallbackEvents } from "./schema.js";
 
@@ -36,7 +36,7 @@ export function recordAuthFallbackCounts(
   windowEnd: number,
   counts: AuthFallbackCount[],
 ): number {
-  if (!getConfig().collectUsageData) return 0;
+  if (!getCachedShareAnalytics()) return 0;
   if (counts.length === 0) return 0;
   const db = getDb();
   const createdAt = Date.now();

--- a/assistant/src/memory/lifecycle-events-store.ts
+++ b/assistant/src/memory/lifecycle-events-store.ts
@@ -1,7 +1,7 @@
 import { and, asc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getConfig } from "../config/loader.js";
+import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 import { getDb } from "./db-connection.js";
 import { lifecycleEvents } from "./schema.js";
 
@@ -13,7 +13,7 @@ export interface LifecycleEvent {
 
 /** Record a lifecycle event (e.g. app_open, hatch). Returns null when usage data collection is disabled. */
 export function recordLifecycleEvent(eventName: string): LifecycleEvent | null {
-  if (!getConfig().collectUsageData) return null;
+  if (!getCachedShareAnalytics()) return null;
   const db = getDb();
   const event: LifecycleEvent = {
     id: uuid(),

--- a/assistant/src/memory/onboarding-events-store.ts
+++ b/assistant/src/memory/onboarding-events-store.ts
@@ -1,7 +1,7 @@
 import { and, asc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getConfig } from "../config/loader.js";
+import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 import {
   ACTIVATION_AB_VARIANT,
   ACTIVATION_FUNNEL_VERSION,
@@ -58,7 +58,7 @@ function insertOnboardingEvent(event: OnboardingEvent): OnboardingEvent {
 export function recordOnboardingEvent(
   params: RecordOnboardingEventParams,
 ): OnboardingEvent | null {
-  if (!getConfig().collectUsageData) return null;
+  if (!getCachedShareAnalytics()) return null;
   return insertOnboardingEvent({
     id: uuid(),
     createdAt: Date.now(),
@@ -93,7 +93,7 @@ export function recordActivationEvent(params: {
   userId?: string | null;
   abVariant?: string;
 }): OnboardingEvent | null {
-  if (!getConfig().collectUsageData) return null;
+  if (!getCachedShareAnalytics()) return null;
   const createdAt = Date.now();
   return insertOnboardingEvent({
     id: uuid(),

--- a/assistant/src/memory/skill-loaded-events-store.test.ts
+++ b/assistant/src/memory/skill-loaded-events-store.test.ts
@@ -8,18 +8,10 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-let collectUsageData = true;
+let shareAnalytics = true;
 
-mock.module("../config/loader.js", () => ({
-  getConfig: () => ({
-    ui: {},
-    model: "test",
-    provider: "test",
-    memory: { enabled: false },
-    rateLimit: { maxRequestsPerMinute: 0 },
-    secretDetection: { enabled: false },
-    collectUsageData,
-  }),
+mock.module("../platform/consent-cache.js", () => ({
+  getCachedShareAnalytics: () => shareAnalytics,
 }));
 
 import { getDb } from "./db-connection.js";
@@ -42,12 +34,12 @@ function insertEvent(
 
 describe("skill-loaded-events-store", () => {
   beforeEach(() => {
-    collectUsageData = true;
+    shareAnalytics = true;
     getDb().delete(skillLoadedEvents).run();
   });
 
-  test("honors the collectUsageData opt-out (records nothing)", () => {
-    collectUsageData = false;
+  test("honors the share_analytics opt-out (records nothing)", () => {
+    shareAnalytics = false;
     recordSkillLoadedEvent({ skillName: "web-research" });
     expect(queryUnreportedSkillLoadedEvents(0, undefined, 10)).toHaveLength(0);
   });

--- a/assistant/src/memory/skill-loaded-events-store.ts
+++ b/assistant/src/memory/skill-loaded-events-store.ts
@@ -1,7 +1,7 @@
 import { and, asc, eq, gt, or } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
-import { getConfig } from "../config/loader.js";
+import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 import type { UsageAttributionColumns } from "../usage/attribution.js";
 import { getDb } from "./db-connection.js";
 import { skillLoadedEvents } from "./schema.js";
@@ -38,7 +38,7 @@ export interface SkillLoadedEvent {
  * opt-out, matching the rest of telemetry).
  */
 export function recordSkillLoadedEvent(record: SkillLoadedEventRecord): void {
-  if (!getConfig().collectUsageData) return;
+  if (!getCachedShareAnalytics()) return;
   const db = getDb();
   db.insert(skillLoadedEvents)
     .values({

--- a/assistant/src/memory/tool-executed-events-store.test.ts
+++ b/assistant/src/memory/tool-executed-events-store.test.ts
@@ -8,12 +8,12 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-// Toggle for the collectUsageData opt-out gate the audit listener consults
+// Toggle for the share_analytics opt-out gate the audit listener consults
 // when populating the telemetry columns.
-let collectUsageData = true;
+let shareAnalytics = true;
 
-mock.module("../config/loader.js", () => ({
-  getConfig: () => ({ collectUsageData }),
+mock.module("../platform/consent-cache.js", () => ({
+  getCachedShareAnalytics: () => shareAnalytics,
 }));
 
 import {
@@ -43,7 +43,7 @@ function insertInvocation(
 
 describe("tool-executed-events-store", () => {
   beforeEach(() => {
-    collectUsageData = true;
+    shareAnalytics = true;
     getDb().delete(toolInvocations).run();
   });
 
@@ -136,10 +136,10 @@ describe("tool-executed-events-store", () => {
 
     listener(executedEvent("t-opted-in-before"));
 
-    collectUsageData = false;
+    shareAnalytics = false;
     listener(executedEvent("t-opted-out"));
 
-    collectUsageData = true;
+    shareAnalytics = true;
     listener(executedEvent("t-opted-in-after"));
 
     // Mid-session opt-out flip: only rows recorded while opted in project.

--- a/assistant/src/platform/client.test.ts
+++ b/assistant/src/platform/client.test.ts
@@ -178,4 +178,100 @@ describe("VellumPlatformClient", () => {
       });
     });
   });
+
+  describe("getOwnerConsent()", () => {
+    test("maps snake_case body to camelCase on 200", async () => {
+      globalThis.fetch = mock(async (url: string | URL | Request) => {
+        expect(String(url)).toBe(
+          "https://platform.example.com/v1/assistants/asst-123/owner-consent/",
+        );
+        return new Response(
+          JSON.stringify({ share_analytics: true, share_diagnostics: false }),
+          { status: 200 },
+        );
+      }) as unknown as typeof globalThis.fetch;
+
+      const client = await VellumPlatformClient.create();
+      const consent = await client!.getOwnerConsent();
+      expect(consent).toEqual({
+        shareAnalytics: true,
+        shareDiagnostics: false,
+      });
+    });
+
+    test("uses the authenticated Api-Key header", async () => {
+      globalThis.fetch = mock(
+        async (_url: string | URL | Request, init?: RequestInit) => {
+          const headers = new Headers(init?.headers);
+          expect(headers.get("Authorization")).toBe("Api-Key sk-test-key");
+          return new Response(
+            JSON.stringify({ share_analytics: true, share_diagnostics: true }),
+            { status: 200 },
+          );
+        },
+      ) as unknown as typeof globalThis.fetch;
+
+      const client = await VellumPlatformClient.create();
+      await client!.getOwnerConsent();
+    });
+
+    test("returns null on 404", async () => {
+      globalThis.fetch = mock(
+        async () => new Response("not found", { status: 404 }),
+      ) as unknown as typeof globalThis.fetch;
+
+      const client = await VellumPlatformClient.create();
+      expect(await client!.getOwnerConsent()).toBeNull();
+    });
+
+    test("returns null on 500", async () => {
+      globalThis.fetch = mock(
+        async () => new Response("error", { status: 500 }),
+      ) as unknown as typeof globalThis.fetch;
+
+      const client = await VellumPlatformClient.create();
+      expect(await client!.getOwnerConsent()).toBeNull();
+    });
+
+    test("returns null on network error", async () => {
+      globalThis.fetch = mock(async () => {
+        throw new Error("network down");
+      }) as unknown as typeof globalThis.fetch;
+
+      const client = await VellumPlatformClient.create();
+      expect(await client!.getOwnerConsent()).toBeNull();
+    });
+
+    test("returns null on malformed body (non-boolean fields)", async () => {
+      globalThis.fetch = mock(
+        async () =>
+          new Response(
+            JSON.stringify({ share_analytics: "yes", share_diagnostics: 1 }),
+            { status: 200 },
+          ),
+      ) as unknown as typeof globalThis.fetch;
+
+      const client = await VellumPlatformClient.create();
+      expect(await client!.getOwnerConsent()).toBeNull();
+    });
+
+    test("returns null without fetching when assistantId is empty", async () => {
+      mockAssistantId = "";
+      mockSecureKeys = {};
+
+      const fetchSpy = mock(
+        async () =>
+          new Response(
+            JSON.stringify({ share_analytics: true, share_diagnostics: true }),
+            { status: 200 },
+          ),
+      );
+      globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+      const client = await VellumPlatformClient.create();
+      expect(client!.platformAssistantId).toBe("");
+      expect(await client!.getOwnerConsent()).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/assistant/src/platform/client.ts
+++ b/assistant/src/platform/client.ts
@@ -16,6 +16,11 @@ const log = getLogger("platform-client");
 
 let _missingPrereqsWarned = false;
 
+export interface OwnerConsent {
+  shareAnalytics: boolean;
+  shareDiagnostics: boolean;
+}
+
 export class VellumPlatformClient {
   private readonly platformBaseUrl: string;
   private readonly apiKey: string;
@@ -107,6 +112,53 @@ export class VellumPlatformClient {
     headers.set("Authorization", `Api-Key ${this.apiKey}`);
 
     return fetch(url, { ...init, headers });
+  }
+
+  /**
+   * Fetch the platform owner's telemetry consent for this assistant.
+   *
+   * Returns `null` whenever the consent is unknown — missing assistant id,
+   * any non-2xx response (e.g. 404 before the endpoint is deployed), a
+   * malformed body, or a network error. Callers treat `null` as default-off.
+   * Never throws.
+   */
+  async getOwnerConsent(): Promise<OwnerConsent | null> {
+    if (!this.assistantId) {
+      return null;
+    }
+
+    try {
+      const res = await this.fetch(
+        `/v1/assistants/${this.assistantId}/owner-consent/`,
+      );
+      if (!res.ok) {
+        log.debug(
+          { status: res.status },
+          "owner-consent fetch returned non-2xx — treating as unknown",
+        );
+        return null;
+      }
+
+      const body = (await res.json()) as {
+        share_analytics?: unknown;
+        share_diagnostics?: unknown;
+      };
+      if (
+        typeof body.share_analytics !== "boolean" ||
+        typeof body.share_diagnostics !== "boolean"
+      ) {
+        log.debug("owner-consent body malformed — treating as unknown");
+        return null;
+      }
+
+      return {
+        shareAnalytics: body.share_analytics,
+        shareDiagnostics: body.share_diagnostics,
+      };
+    } catch (err) {
+      log.debug({ err }, "owner-consent fetch failed — treating as unknown");
+      return null;
+    }
   }
 
   get baseUrl(): string {

--- a/assistant/src/platform/consent-cache.test.ts
+++ b/assistant/src/platform/consent-cache.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { OwnerConsent } from "./client.js";
+
+// ---------------------------------------------------------------------------
+// Mutable mock state
+// ---------------------------------------------------------------------------
+
+let mockClient: { getOwnerConsent: () => Promise<OwnerConsent | null> } | null =
+  null;
+let createCallCount = 0;
+
+// ---------------------------------------------------------------------------
+// Module mocks (must precede the import under test)
+// ---------------------------------------------------------------------------
+
+mock.module("./client.js", () => ({
+  VellumPlatformClient: {
+    create: async () => {
+      createCallCount += 1;
+      return mockClient;
+    },
+  },
+}));
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, {
+      get: () => () => {},
+    }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import under test (after mocks)
+// ---------------------------------------------------------------------------
+
+import {
+  __setCachedShareAnalyticsForTest,
+  getCachedShareAnalytics,
+  refreshConsentCache,
+  startConsentRefresh,
+  stopConsentRefresh,
+} from "./consent-cache.js";
+
+function makeClient(consent: OwnerConsent | null) {
+  return { getOwnerConsent: async () => consent };
+}
+
+describe("consent-cache", () => {
+  beforeEach(() => {
+    mockClient = null;
+    createCallCount = 0;
+    __setCachedShareAnalyticsForTest(false);
+  });
+
+  afterEach(async () => {
+    await stopConsentRefresh();
+  });
+
+  test("defaults to false before any refresh", () => {
+    expect(getCachedShareAnalytics()).toBe(false);
+  });
+
+  test("stays false when no platform client is available", async () => {
+    mockClient = null;
+    await refreshConsentCache();
+    expect(getCachedShareAnalytics()).toBe(false);
+  });
+
+  test("becomes true after a successful fetch reporting shareAnalytics: true", async () => {
+    mockClient = makeClient({ shareAnalytics: true, shareDiagnostics: false });
+    await refreshConsentCache();
+    expect(getCachedShareAnalytics()).toBe(true);
+  });
+
+  test("a null fetch keeps the last known value", async () => {
+    mockClient = makeClient({ shareAnalytics: true, shareDiagnostics: false });
+    await refreshConsentCache();
+    expect(getCachedShareAnalytics()).toBe(true);
+
+    // Transient failure: consent endpoint returns null.
+    mockClient = makeClient(null);
+    await refreshConsentCache();
+    expect(getCachedShareAnalytics()).toBe(true);
+  });
+
+  test("a missing client flips a prior opt-in back to false", async () => {
+    __setCachedShareAnalyticsForTest(true);
+    mockClient = null;
+    await refreshConsentCache();
+    expect(getCachedShareAnalytics()).toBe(false);
+  });
+
+  test("a fetch reporting shareAnalytics: false turns the cache off", async () => {
+    __setCachedShareAnalyticsForTest(true);
+    mockClient = makeClient({ shareAnalytics: false, shareDiagnostics: true });
+    await refreshConsentCache();
+    expect(getCachedShareAnalytics()).toBe(false);
+  });
+
+  test("startConsentRefresh is idempotent and runs an immediate refresh", async () => {
+    mockClient = makeClient({ shareAnalytics: true, shareDiagnostics: false });
+
+    startConsentRefresh();
+    startConsentRefresh(); // no-op: timer already running
+    // Let the fire-and-forget immediate refresh settle.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(getCachedShareAnalytics()).toBe(true);
+    // One immediate refresh from the first call; the second is a no-op.
+    expect(createCallCount).toBe(1);
+  });
+
+  test("stopConsentRefresh clears the timer (start can run again)", async () => {
+    startConsentRefresh();
+    await stopConsentRefresh();
+    // A fresh start after stop performs another immediate refresh.
+    mockClient = makeClient({ shareAnalytics: true, shareDiagnostics: false });
+    startConsentRefresh();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(getCachedShareAnalytics()).toBe(true);
+  });
+});

--- a/assistant/src/platform/consent-cache.test.ts
+++ b/assistant/src/platform/consent-cache.test.ts
@@ -6,8 +6,10 @@ import type { OwnerConsent } from "./client.js";
 // Mutable mock state
 // ---------------------------------------------------------------------------
 
-let mockClient: { getOwnerConsent: () => Promise<OwnerConsent | null> } | null =
-  null;
+let mockClient: {
+  platformAssistantId: string;
+  getOwnerConsent: () => Promise<OwnerConsent | null>;
+} | null = null;
 let createCallCount = 0;
 
 // ---------------------------------------------------------------------------
@@ -42,8 +44,11 @@ import {
   stopConsentRefresh,
 } from "./consent-cache.js";
 
-function makeClient(consent: OwnerConsent | null) {
-  return { getOwnerConsent: async () => consent };
+function makeClient(consent: OwnerConsent | null, assistantId = "asst_1") {
+  return {
+    platformAssistantId: assistantId,
+    getOwnerConsent: async () => consent,
+  };
 }
 
 describe("consent-cache", () => {
@@ -87,6 +92,19 @@ describe("consent-cache", () => {
   test("a missing client flips a prior opt-in back to false", async () => {
     __setCachedShareAnalyticsForTest(true);
     mockClient = null;
+    await refreshConsentCache();
+    expect(getCachedShareAnalytics()).toBe(false);
+  });
+
+  test("a client without a resolvable assistant identity fails closed", async () => {
+    __setCachedShareAnalyticsForTest(true);
+    // Identity cleared mid-session (e.g. assistantId emptied while base URL +
+    // API key persist). getOwnerConsent must not be relied upon to preserve the
+    // prior opt-in here — fail closed instead.
+    mockClient = makeClient(
+      { shareAnalytics: true, shareDiagnostics: false },
+      "",
+    );
     await refreshConsentCache();
     expect(getCachedShareAnalytics()).toBe(false);
   });

--- a/assistant/src/platform/consent-cache.test.ts
+++ b/assistant/src/platform/consent-cache.test.ts
@@ -11,6 +11,9 @@ let mockClient: {
   getOwnerConsent: () => Promise<OwnerConsent | null>;
 } | null = null;
 let createCallCount = 0;
+// Legacy fail-closed opt-out marker surfaced via getConfigReadOnly(). Default
+// off/absent so existing behavior is unchanged.
+let mockLegacyTelemetryOptOut: boolean | undefined = false;
 
 // ---------------------------------------------------------------------------
 // Module mocks (must precede the import under test)
@@ -23,6 +26,12 @@ mock.module("./client.js", () => ({
       return mockClient;
     },
   },
+}));
+
+mock.module("../config/loader.js", () => ({
+  getConfigReadOnly: () => ({
+    legacyTelemetryOptOut: mockLegacyTelemetryOptOut,
+  }),
 }));
 
 mock.module("../util/logger.js", () => ({
@@ -55,6 +64,7 @@ describe("consent-cache", () => {
   beforeEach(() => {
     mockClient = null;
     createCallCount = 0;
+    mockLegacyTelemetryOptOut = false;
     __setCachedShareAnalyticsForTest(false);
   });
 
@@ -106,6 +116,14 @@ describe("consent-cache", () => {
       "",
     );
     await refreshConsentCache();
+    expect(getCachedShareAnalytics()).toBe(false);
+  });
+
+  test("legacy opt-out marker keeps analytics off despite platform opt-in", async () => {
+    mockLegacyTelemetryOptOut = true;
+    mockClient = makeClient({ shareAnalytics: true, shareDiagnostics: false });
+    await refreshConsentCache();
+    // Platform reports opt-in, but the fail-closed marker forces off.
     expect(getCachedShareAnalytics()).toBe(false);
   });
 

--- a/assistant/src/platform/consent-cache.ts
+++ b/assistant/src/platform/consent-cache.ts
@@ -1,0 +1,90 @@
+/**
+ * In-memory cache of the platform owner's `share_analytics` consent.
+ *
+ * Record-time telemetry gates need a synchronous, I/O-free read, so this module
+ * owns the consent value and refreshes it periodically in the background.
+ * Default-off until the first successful fetch: an absent session, a disabled
+ * platform, or a transient fetch failure all leave the value untouched (initial
+ * `false`), so we never report analytics without a confirmed opt-in.
+ */
+
+import { getLogger } from "../util/logger.js";
+import { VellumPlatformClient } from "./client.js";
+
+const log = getLogger("consent-cache");
+
+const REFRESH_INTERVAL_MS = 5 * 60_000; // refresh consent every 5 min
+
+let cachedShareAnalytics = false; // default-off until first success
+let refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Synchronous hot-path accessor for the cached `share_analytics` consent.
+ * Never does I/O; returns `false` until a successful refresh proves otherwise.
+ */
+export function getCachedShareAnalytics(): boolean {
+  return cachedShareAnalytics;
+}
+
+/**
+ * Refresh the cached consent from the platform.
+ *
+ * No platform session / features disabled (`create()` is null) → default-off.
+ * A successful fetch adopts the reported value. A `null` fetch (transient
+ * failure / undeployed endpoint) leaves the previous value unchanged so a known
+ * opt-in is not flipped off mid-session.
+ */
+export async function refreshConsentCache(): Promise<void> {
+  const client = await VellumPlatformClient.create();
+  if (!client) {
+    setCachedShareAnalytics(false);
+    return;
+  }
+
+  const consent = await client.getOwnerConsent();
+  if (consent) {
+    setCachedShareAnalytics(consent.shareAnalytics);
+  }
+}
+
+function setCachedShareAnalytics(value: boolean): void {
+  if (value !== cachedShareAnalytics) {
+    log.debug(
+      { from: cachedShareAnalytics, to: value },
+      "share_analytics consent changed",
+    );
+    cachedShareAnalytics = value;
+  }
+}
+
+/**
+ * Begin periodic consent refresh. Idempotent — a second call is a no-op while a
+ * timer is already running. Runs one immediate refresh, then every 5 minutes.
+ */
+export function startConsentRefresh(): void {
+  if (refreshTimer) {
+    return;
+  }
+
+  refreshConsentCache().catch((err) => {
+    log.debug({ err }, "initial consent refresh failed");
+  });
+  refreshTimer = setInterval(() => {
+    refreshConsentCache().catch((err) => {
+      log.debug({ err }, "consent refresh failed");
+    });
+  }, REFRESH_INTERVAL_MS);
+}
+
+/** Stop periodic consent refresh and clear the timer. */
+export async function stopConsentRefresh(): Promise<void> {
+  if (refreshTimer) {
+    clearInterval(refreshTimer);
+    refreshTimer = null;
+  }
+}
+
+/** Test-only: override the cached value without going through a refresh. */
+export function __setCachedShareAnalyticsForTest(value: boolean): void {
+  cachedShareAnalytics = value;
+}

--- a/assistant/src/platform/consent-cache.ts
+++ b/assistant/src/platform/consent-cache.ts
@@ -30,13 +30,20 @@ export function getCachedShareAnalytics(): boolean {
  * Refresh the cached consent from the platform.
  *
  * No platform session / features disabled (`create()` is null) → default-off.
- * A successful fetch adopts the reported value. A `null` fetch (transient
- * failure / undeployed endpoint) leaves the previous value unchanged so a known
- * opt-in is not flipped off mid-session.
+ * No resolvable assistant identity (no owner whose consent we can attest to) →
+ * fail closed. A successful fetch adopts the reported value. A `null` fetch
+ * (transient failure / undeployed endpoint) leaves the previous value unchanged
+ * so a known opt-in is not flipped off mid-session.
  */
 export async function refreshConsentCache(): Promise<void> {
   const client = await VellumPlatformClient.create();
   if (!client) {
+    setCachedShareAnalytics(false);
+    return;
+  }
+
+  // No resolvable owner identity → fail closed (don't ride a stale opt-in).
+  if (!client.platformAssistantId) {
     setCachedShareAnalytics(false);
     return;
   }

--- a/assistant/src/platform/consent-cache.ts
+++ b/assistant/src/platform/consent-cache.ts
@@ -8,6 +8,7 @@
  * `false`), so we never report analytics without a confirmed opt-in.
  */
 
+import { getConfigReadOnly } from "../config/loader.js";
 import { getLogger } from "../util/logger.js";
 import { VellumPlatformClient } from "./client.js";
 
@@ -16,14 +17,21 @@ const log = getLogger("consent-cache");
 const REFRESH_INTERVAL_MS = 5 * 60_000; // refresh consent every 5 min
 
 let cachedShareAnalytics = false; // default-off until first success
+// Fail-closed marker for a workspace that locally opted out of usage data
+// before telemetry moved to platform `share_analytics` consent (migration 106).
+// While set, telemetry stays off regardless of platform consent. Cleared by a
+// future cross-repo reconciliation once the platform exposes an explicit
+// re-consent signal; not auto-cleared here.
+let legacyOptOut = false;
 let refreshTimer: ReturnType<typeof setInterval> | null = null;
 
 /**
- * Synchronous hot-path accessor for the cached `share_analytics` consent.
- * Never does I/O; returns `false` until a successful refresh proves otherwise.
+ * Synchronous hot-path accessor for the effective `share_analytics` consent.
+ * Never does I/O; returns `false` until a successful refresh proves otherwise,
+ * and stays `false` while the legacy fail-closed opt-out marker is set.
  */
 export function getCachedShareAnalytics(): boolean {
-  return cachedShareAnalytics;
+  return cachedShareAnalytics && !legacyOptOut;
 }
 
 /**
@@ -36,6 +44,8 @@ export function getCachedShareAnalytics(): boolean {
  * so a known opt-in is not flipped off mid-session.
  */
 export async function refreshConsentCache(): Promise<void> {
+  legacyOptOut = getConfigReadOnly().legacyTelemetryOptOut === true;
+
   const client = await VellumPlatformClient.create();
   if (!client) {
     setCachedShareAnalytics(false);

--- a/assistant/src/runtime/routes/internal-telemetry-routes.ts
+++ b/assistant/src/runtime/routes/internal-telemetry-routes.ts
@@ -53,7 +53,7 @@ function handleRecordAuthFallback({ body }: RouteHandlerArgs) {
 
   const recorded = recordAuthFallbackCounts(window_start, window_end, mapped);
   if (recorded === 0) {
-    // collectUsageData disabled — counts dropped to honor the opt-out.
+    // share_analytics consent off — counts dropped to honor the opt-out.
     return { skipped: true };
   }
   log.debug({ recorded }, "Recorded auth-fallback counts");

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -1627,8 +1627,8 @@ describe("UsageTelemetryReporter", () => {
 
     // Rows accumulated before any flush ever advanced the watermark — e.g.
     // an opt-out period under an older build that gated reporter
-    // construction on collectUsageData while the always-on audit listener
-    // kept writing.
+    // construction on the usage-data opt-out while the always-on audit
+    // listener kept writing.
     seedToolInvocation({
       id: "ti-opt-out-window",
       createdAt: Date.now() - 60_000,

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -1084,6 +1084,27 @@ describe("UsageTelemetryReporter", () => {
     }
   });
 
+  test("platform disabled takes precedence over consent off — watermarks NOT advanced", async () => {
+    // VELLUM_DISABLE_PLATFORM keeps the consent cache false (the consent
+    // refresh can't create a platform client), so both gates would fire. The
+    // platform-disabled gate runs first and returns without advancing
+    // watermarks, preserving the backlog until the flag is cleared — a
+    // deployment toggle must not be treated as a privacy opt-out.
+    process.env.VELLUM_DISABLE_PLATFORM = "true";
+    mockGetCachedShareAnalytics.mockReturnValue(false);
+    const events = [makeUsageEvent()];
+    mockQueryUnreportedUsageEvents.mockReturnValue(events);
+
+    const reporter = new UsageTelemetryReporter();
+    // Construction initializes the absent tool_executed watermark; clear that
+    // call so the assertion below covers only the flush.
+    mockSetMemoryCheckpoint.mockClear();
+    await reporter.flush();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockSetMemoryCheckpoint).not.toHaveBeenCalled();
+  });
+
   test("events sent normally after re-granting share_analytics consent", async () => {
     // First flush with opt-out — watermarks advance, nothing sent
     mockGetCachedShareAnalytics.mockReturnValue(false);

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -92,18 +92,10 @@ mock.module("../version.js", () => ({
   APP_VERSION: "1.2.3-test",
 }));
 
-let mockCollectUsageData = true;
+const mockGetCachedShareAnalytics = mock(() => true);
 
-mock.module("../config/loader.js", () => ({
-  getConfig: () => ({
-    ui: {},
-    model: "test",
-    provider: "test",
-    memory: { enabled: false },
-    rateLimit: { maxRequestsPerMinute: 0 },
-    secretDetection: { enabled: false },
-    collectUsageData: mockCollectUsageData,
-  }),
+mock.module("../platform/consent-cache.js", () => ({
+  getCachedShareAnalytics: mockGetCachedShareAnalytics,
 }));
 
 const mockQueryUnreportedLifecycleEvents = mock(
@@ -291,7 +283,9 @@ let mockFetch: ReturnType<typeof mock>;
 
 beforeEach(() => {
   eventIdCounter = 0;
-  mockCollectUsageData = true;
+  // Default consent ON so the happy-path send tests exercise the flush.
+  mockGetCachedShareAnalytics.mockReset();
+  mockGetCachedShareAnalytics.mockReturnValue(true);
   mockGetMemoryCheckpoint.mockReset();
   mockSetMemoryCheckpoint.mockReset();
   mockQueryUnreportedUsageEvents.mockReset();
@@ -1047,8 +1041,8 @@ describe("UsageTelemetryReporter", () => {
     });
   });
 
-  test("flush is skipped and watermarks advanced when collectUsageData is false", async () => {
-    mockCollectUsageData = false;
+  test("flush is skipped and watermarks advanced when share_analytics consent is off", async () => {
+    mockGetCachedShareAnalytics.mockReturnValue(false);
     const events = [makeUsageEvent()];
     mockQueryUnreportedUsageEvents.mockReturnValue(events);
     mockFetch.mockImplementation(() =>
@@ -1090,16 +1084,16 @@ describe("UsageTelemetryReporter", () => {
     }
   });
 
-  test("events sent normally after re-enabling collectUsageData", async () => {
+  test("events sent normally after re-granting share_analytics consent", async () => {
     // First flush with opt-out — watermarks advance, nothing sent
-    mockCollectUsageData = false;
+    mockGetCachedShareAnalytics.mockReturnValue(false);
     const reporter = new UsageTelemetryReporter();
     await reporter.flush();
     expect(mockFetch).not.toHaveBeenCalled();
     mockSetMemoryCheckpoint.mockReset();
 
-    // Re-enable and flush with new events
-    mockCollectUsageData = true;
+    // Re-grant consent and flush with new events
+    mockGetCachedShareAnalytics.mockReturnValue(true);
     const events = [makeUsageEvent({ id: "evt-after-reenable" })];
     mockQueryUnreportedUsageEvents.mockReturnValue(events);
     mockFetch.mockImplementation(() =>
@@ -1713,7 +1707,7 @@ describe("UsageTelemetryReporter", () => {
     // constructs and runs the reporter; the always-on audit listener keeps
     // writing rows. Every opted-out flush (5-minute cycle plus the final
     // flush in stop()) advances the watermark past them without sending.
-    mockCollectUsageData = false;
+    mockGetCachedShareAnalytics.mockReturnValue(false);
     const optOutRowCreatedAt = Date.now() - 5_000;
     seedToolInvocation({
       id: "ti-opt-out-window",
@@ -1729,7 +1723,7 @@ describe("UsageTelemetryReporter", () => {
 
     // Session 2: the user opts back in and restarts. Only rows recorded
     // after the opt-out epoch ship — the opt-out-window row never does.
-    mockCollectUsageData = true;
+    mockGetCachedShareAnalytics.mockReturnValue(true);
     seedToolInvocation({ id: "ti-after-opt-in", createdAt: advanced + 1000 });
     const reporter = new UsageTelemetryReporter();
     await reporter.flush();
@@ -1754,7 +1748,7 @@ describe("UsageTelemetryReporter", () => {
 
     // Opted-out flush: advances the timestamp watermark to Date.now() and
     // must also pin the ID watermark to the high-sorting sentinel.
-    mockCollectUsageData = false;
+    mockGetCachedShareAnalytics.mockReturnValue(false);
     const optedOutReporter = new UsageTelemetryReporter();
     await optedOutReporter.flush();
     expect(mockFetch).not.toHaveBeenCalled();
@@ -1772,7 +1766,7 @@ describe("UsageTelemetryReporter", () => {
     });
 
     // Re-opt-in: only rows strictly after the opt-out epoch ship.
-    mockCollectUsageData = true;
+    mockGetCachedShareAnalytics.mockReturnValue(true);
     seedToolInvocation({ id: "ti-after-opt-in", createdAt: watermark + 1000 });
     const reporter = new UsageTelemetryReporter();
     await reporter.flush();

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -129,7 +129,7 @@ export class UsageTelemetryReporter {
     // reporter shipping its rows: an absent watermark means no flush (opted
     // in or out) has ever advanced it, so rows recorded before this build —
     // including any opted-out period under older builds that gated the
-    // reporter on collectUsageData — would otherwise ship retroactively.
+    // reporter on the usage-data opt-out — would otherwise ship retroactively.
     // Initialize an absent watermark to "now" at construction. Construction
     // happens during daemon startup before any tool runs, so no legitimate
     // row falls behind the watermark — initializing at first FLUSH instead
@@ -138,8 +138,8 @@ export class UsageTelemetryReporter {
     // absent and re-initialize later. An EXISTING watermark is never touched:
     // opted-out sessions keep it advancing via the opt-out flush branch, and
     // overwriting it here would drop a legitimate unshipped backlog.
-    // `skill_loaded` needs no init: recording is gated on collectUsageData,
-    // so opt-out rows never exist and its standard 0 default is safe.
+    // `skill_loaded` needs no init: recording is gated on share_analytics
+    // consent, so opt-out rows never exist and its standard 0 default is safe.
     //
     // Best-effort: DB init failures are tolerated at daemon startup (degraded
     // mode), so this must never throw out of the constructor — matching

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -14,7 +14,6 @@ import {
   getPlatformOrganizationId,
   getPlatformUserId,
 } from "../config/env.js";
-import { getConfig } from "../config/loader.js";
 import { queryUnreportedAuthFallbackEvents } from "../memory/auth-fallback-events-store.js";
 import {
   getMemoryCheckpoint,
@@ -27,6 +26,7 @@ import { queryUnreportedSkillLoadedEvents } from "../memory/skill-loaded-events-
 import { queryUnreportedToolExecutedEvents } from "../memory/tool-executed-events-store.js";
 import { queryUnreportedTurnEvents } from "../memory/turn-events-store.js";
 import { VellumPlatformClient } from "../platform/client.js";
+import { getCachedShareAnalytics } from "../platform/consent-cache.js";
 import { arePlatformFeaturesEnabled } from "../platform/feature-gate.js";
 import type { UsageAttributionProfileSource } from "../usage/types.js";
 import { getDeviceId } from "../util/device-id.js";
@@ -207,22 +207,23 @@ export class UsageTelemetryReporter {
     try {
       if (batchCount >= MAX_CONSECUTIVE_BATCHES) return;
 
-      // Respect opt-out: if the user has disabled usage data collection, skip
-      // the flush and advance watermarks so events recorded during the
-      // opt-out window are never sent retroactively. The daemon runs the
-      // reporter even when opted out specifically so this branch keeps
-      // executing — every cycle plus the final flush in stop() — which is
-      // what lets a later opt-in (runtime or via restart) resume from a
-      // watermark that already covers the opt-out window. One caveat: a
-      // RUNTIME false→true flip can still ship up to one flush interval
-      // (≤5 min) of pre-toggle rows recorded since the last opted-out flush;
+      // Respect opt-out: if the platform owner has not granted
+      // `share_analytics` consent, skip the flush and advance watermarks so
+      // events recorded during the opt-out window are never sent
+      // retroactively. The daemon runs the reporter even when opted out
+      // specifically so this branch keeps executing — every cycle plus the
+      // final flush in stop() — which is what lets a later opt-in (runtime or
+      // via restart) resume from a watermark that already covers the opt-out
+      // window. One caveat: a RUNTIME false→true flip can still ship up to one
+      // flush interval (≤5 min) of pre-toggle rows recorded since the last
+      // opted-out flush;
       // the restart path is fully covered by the final flush in stop(). The
       // caveat applies to the always-on tables without a write-time opt-out
       // gate (llm_usage, turn events) and to tool_invocations rows recorded
       // under builds predating the audit listener's write-time gate — new
       // opted-out tool_invocations rows persist NULL telemetry columns and
       // are unreportable by construction regardless of watermark timing.
-      if (!getConfig().collectUsageData) {
+      if (!getCachedShareAnalytics()) {
         // Advance the timestamp watermarks and pin the ID watermarks to a
         // sentinel that sorts above any real UUID. The sentinel (rather than
         // "") keeps the compound-cursor branch active — a falsy ID would

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -207,6 +207,15 @@ export class UsageTelemetryReporter {
     try {
       if (batchCount >= MAX_CONSECUTIVE_BATCHES) return;
 
+      // Skip when platform features are disabled (VELLUM_DISABLE_PLATFORM in
+      // local mode; the flag is ignored when IS_PLATFORM is set, matching
+      // VellumPlatformClient.create()). Watermarks are NOT advanced here: this
+      // is a deployment/local-mode toggle, not a privacy opt-out, so the unsent
+      // backlog ships once the flag is cleared.
+      if (!arePlatformFeaturesEnabled()) {
+        return;
+      }
+
       // Respect opt-out: if the platform owner has not granted
       // `share_analytics` consent, skip the flush and advance watermarks so
       // events recorded during the opt-out window are never sent
@@ -237,15 +246,6 @@ export class UsageTelemetryReporter {
           setMemoryCheckpoint(timestampKey, now);
           setMemoryCheckpoint(idKey, OPT_OUT_WATERMARK_ID_SENTINEL);
         }
-        return;
-      }
-
-      // Skip when platform features are disabled (VELLUM_DISABLE_PLATFORM in
-      // local mode; the flag is ignored when IS_PLATFORM is set, matching
-      // VellumPlatformClient.create()). Unlike the opt-out branch above,
-      // watermarks are NOT advanced: this is a deployment/local-mode toggle
-      // (not a privacy opt-out), so the unsent backlog ships once it's cleared.
-      if (!arePlatformFeaturesEnabled()) {
         return;
       }
 

--- a/assistant/src/watcher/telemetry.ts
+++ b/assistant/src/watcher/telemetry.ts
@@ -4,8 +4,8 @@
  * ahead of the planned watcher → skills-and-schedules migration.
  *
  * Both event shapes ship through the existing lifecycle-event telemetry
- * pipeline, so they inherit its `collectUsageData` opt-out gate and need
- * no wire-contract or platform-side changes:
+ * pipeline, so they inherit its platform `share_analytics` consent gate and
+ * need no wire-contract or platform-side changes:
  *
  * - `watcher_enabled:<providerId>` — one per enabled watcher, at most
  *   once per 24h per daemon. Counts devices that have watchers

--- a/assistant/src/workspace/migrations/106-drop-collect-usage-data.ts
+++ b/assistant/src/workspace/migrations/106-drop-collect-usage-data.ts
@@ -4,15 +4,15 @@ import { join } from "node:path";
 import type { WorkspaceMigration } from "./types.js";
 
 /**
- * Drop the now-unused `collectUsageData` config key. Usage-telemetry gating is
- * governed solely by the platform `share_analytics` consent cache, so the key
- * is dead. The schema strips unknown keys on the next save, so a stale value is
- * harmless; this migration removes it for cleanliness.
+ * Drops the `collectUsageData` config key from config.json (gating is governed
+ * by the platform `share_analytics` consent). The schema strips unknown keys on
+ * the next save, so a stale value is harmless; this migration removes it for
+ * cleanliness.
  */
 export const dropCollectUsageDataMigration: WorkspaceMigration = {
   id: "106-drop-collect-usage-data",
   description:
-    "Remove the unused collectUsageData config key (telemetry is now gated by platform share_analytics consent)",
+    "Remove the unused collectUsageData config key (telemetry is gated by platform share_analytics consent)",
   run(workspaceDir: string): void {
     const configPath = join(workspaceDir, "config.json");
     if (!existsSync(configPath)) return;
@@ -32,7 +32,7 @@ export const dropCollectUsageDataMigration: WorkspaceMigration = {
     writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
   },
   down(_workspaceDir: string): void {
-    // No-op: the forward migration only drops a now-unknown key, and the schema
-    // field no longer exists, so there is nothing to restore.
+    // No-op: the forward migration only removes a key, so there is nothing to
+    // restore.
   },
 };

--- a/assistant/src/workspace/migrations/106-drop-collect-usage-data.ts
+++ b/assistant/src/workspace/migrations/106-drop-collect-usage-data.ts
@@ -4,15 +4,18 @@ import { join } from "node:path";
 import type { WorkspaceMigration } from "./types.js";
 
 /**
- * Drops the `collectUsageData` config key from config.json (gating is governed
- * by the platform `share_analytics` consent). The schema strips unknown keys on
- * the next save, so a stale value is harmless; this migration removes it for
- * cleanliness.
+ * Drops the `collectUsageData` config key (gating is governed by the platform
+ * `share_analytics` consent). An explicit local opt-out (`collectUsageData:
+ * false`) is preserved as `legacyTelemetryOptOut: true` so telemetry stays off
+ * regardless of platform consent, which defaults to opt-in and cannot be
+ * written by the daemon. A `true`/non-false value carries no opt-out intent, so
+ * the key is removed without setting the marker. The schema strips unknown keys
+ * on the next save, so a stale value is otherwise harmless.
  */
 export const dropCollectUsageDataMigration: WorkspaceMigration = {
   id: "106-drop-collect-usage-data",
   description:
-    "Remove the unused collectUsageData config key (telemetry is gated by platform share_analytics consent)",
+    "Drop collectUsageData; preserve an explicit opt-out as legacyTelemetryOptOut (telemetry is gated by platform share_analytics consent)",
   run(workspaceDir: string): void {
     const configPath = join(workspaceDir, "config.json");
     if (!existsSync(configPath)) return;
@@ -28,11 +31,17 @@ export const dropCollectUsageDataMigration: WorkspaceMigration = {
 
     if (!("collectUsageData" in config)) return;
 
+    // An explicit opt-out is preserved as a fail-closed marker; any non-false
+    // value carries no opt-out intent.
+    if (config.collectUsageData === false) {
+      config.legacyTelemetryOptOut = true;
+    }
+
     delete config.collectUsageData;
     writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
   },
   down(_workspaceDir: string): void {
-    // No-op: the forward migration only removes a key, so there is nothing to
-    // restore.
+    // No-op: the forward migration only removes a key and sets a fail-closed
+    // marker, so there is nothing to restore.
   },
 };

--- a/assistant/src/workspace/migrations/106-drop-collect-usage-data.ts
+++ b/assistant/src/workspace/migrations/106-drop-collect-usage-data.ts
@@ -1,0 +1,38 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Drop the now-unused `collectUsageData` config key. Usage-telemetry gating is
+ * governed solely by the platform `share_analytics` consent cache, so the key
+ * is dead. The schema strips unknown keys on the next save, so a stale value is
+ * harmless; this migration removes it for cleanliness.
+ */
+export const dropCollectUsageDataMigration: WorkspaceMigration = {
+  id: "106-drop-collect-usage-data",
+  description:
+    "Remove the unused collectUsageData config key (telemetry is now gated by platform share_analytics consent)",
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return; // Malformed config — skip
+    }
+
+    if (!("collectUsageData" in config)) return;
+
+    delete config.collectUsageData;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(_workspaceDir: string): void {
+    // No-op: the forward migration only drops a now-unknown key, and the schema
+    // field no longer exists, so there is nothing to restore.
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -103,6 +103,7 @@ import { preserveHeartbeatEnabledForExistingWorkspacesMigration } from "./102-pr
 import { upgradeQualityProfileToOpus48Migration } from "./103-upgrade-quality-profile-to-opus-4-8.js";
 import { recheckAdaptiveThinkingModelImpliedAnthropicMigration } from "./104-recheck-adaptive-thinking-model-implied-anthropic.js";
 import { enableMemoryV3LiveForNewWorkspacesMigration } from "./105-enable-memory-v3-live-for-new-workspaces.js";
+import { dropCollectUsageDataMigration } from "./106-drop-collect-usage-data.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -217,4 +218,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   upgradeQualityProfileToOpus48Migration,
   recheckAdaptiveThinkingModelImpliedAnthropicMigration,
   enableMemoryV3LiveForNewWorkspacesMigration,
+  dropCollectUsageDataMigration,
 ];

--- a/gateway/src/__tests__/privacy-config-route.test.ts
+++ b/gateway/src/__tests__/privacy-config-route.test.ts
@@ -53,7 +53,6 @@ describe("GET /v1/config/privacy handler", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toEqual({
-      collectUsageData: true,
       sendDiagnostics: true,
       llmRequestLogRetentionMs: DEFAULT_RETENTION_MS,
     });
@@ -65,7 +64,6 @@ describe("GET /v1/config/privacy handler", () => {
     writeFileSync(
       configPath,
       JSON.stringify({
-        collectUsageData: false,
         sendDiagnostics: false,
         memory: {
           cleanup: {
@@ -83,7 +81,6 @@ describe("GET /v1/config/privacy handler", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toEqual({
-      collectUsageData: false,
       sendDiagnostics: false,
       llmRequestLogRetentionMs: 3 * 24 * 60 * 60 * 1000,
     });
@@ -93,7 +90,6 @@ describe("GET /v1/config/privacy handler", () => {
     writeFileSync(
       configPath,
       JSON.stringify({
-        collectUsageData: true,
         sendDiagnostics: true,
         memory: {
           cleanup: {
@@ -134,15 +130,13 @@ describe("GET /v1/config/privacy handler", () => {
     const body = await res.json();
     expect(body.llmRequestLogRetentionMs).toBe(0);
     // Other fields fall back to their schema defaults.
-    expect(body.collectUsageData).toBe(true);
     expect(body.sendDiagnostics).toBe(true);
   });
 
-  test("falls back to defaults when collectUsageData/sendDiagnostics are non-boolean", async () => {
+  test("falls back to defaults when sendDiagnostics is non-boolean", async () => {
     writeFileSync(
       configPath,
       JSON.stringify({
-        collectUsageData: "yes",
         sendDiagnostics: 1,
       }),
     );
@@ -154,7 +148,6 @@ describe("GET /v1/config/privacy handler", () => {
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.collectUsageData).toBe(true);
     expect(body.sendDiagnostics).toBe(true);
   });
 
@@ -206,7 +199,7 @@ describe("GET /v1/config/privacy handler", () => {
     writeFileSync(
       configPath,
       JSON.stringify({
-        collectUsageData: false,
+        sendDiagnostics: false,
       }),
     );
 
@@ -218,8 +211,7 @@ describe("GET /v1/config/privacy handler", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toEqual({
-      collectUsageData: false,
-      sendDiagnostics: true,
+      sendDiagnostics: false,
       llmRequestLogRetentionMs: DEFAULT_RETENTION_MS,
     });
   });
@@ -256,7 +248,6 @@ describe("GET /v1/config/privacy handler", () => {
     writeFileSync(
       configPath,
       JSON.stringify({
-        collectUsageData: false,
         sendDiagnostics: false,
       }),
     );
@@ -270,7 +261,6 @@ describe("GET /v1/config/privacy handler", () => {
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.collectUsageData).toBe(false);
     expect(body.sendDiagnostics).toBe(false);
     expect(body.llmRequestLogRetentionMs).toBe(DEFAULT_RETENTION_MS);
   });
@@ -294,7 +284,6 @@ describe("GET /v1/config/privacy handler", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.llmRequestLogRetentionMs).toBeNull();
-    expect(body.collectUsageData).toBe(true);
     expect(body.sendDiagnostics).toBe(true);
   });
 });
@@ -346,22 +335,22 @@ describe("PATCH /v1/config/privacy handler — llmRequestLogRetentionMs", () => 
     expect(cleanup.llmRequestLogRetentionMs).toBe(max);
   });
 
-  test("mixed payload: collectUsageData + llmRequestLogRetentionMs updates both without clobbering", async () => {
+  test("mixed payload: sendDiagnostics + llmRequestLogRetentionMs updates both without clobbering", async () => {
     const handler = createPrivacyConfigPatchHandler();
     const res = await handler(
       makePatch({
-        collectUsageData: true,
+        sendDiagnostics: true,
         llmRequestLogRetentionMs: 3_600_000,
       }),
     );
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.collectUsageData).toBe(true);
+    expect(body.sendDiagnostics).toBe(true);
     expect(body.llmRequestLogRetentionMs).toBe(3_600_000);
 
     const config = readConfig();
-    expect(config.collectUsageData).toBe(true);
+    expect(config.sendDiagnostics).toBe(true);
     const cleanup = (config.memory as Record<string, unknown>)
       .cleanup as Record<string, unknown>;
     expect(cleanup.llmRequestLogRetentionMs).toBe(3_600_000);
@@ -387,7 +376,7 @@ describe("PATCH /v1/config/privacy handler — llmRequestLogRetentionMs", () => 
   test("preserves pre-existing unrelated nested keys under memory.*", async () => {
     // Pre-seed a config with an unrelated nested key under memory
     const preExisting = {
-      collectUsageData: false,
+      sendDiagnostics: false,
       memory: {
         segmentation: {
           targetTokens: 2000,
@@ -405,7 +394,7 @@ describe("PATCH /v1/config/privacy handler — llmRequestLogRetentionMs", () => 
     const config = readConfig();
 
     // Previous top-level key preserved
-    expect(config.collectUsageData).toBe(false);
+    expect(config.sendDiagnostics).toBe(false);
 
     // Previous nested memory.segmentation preserved
     const memory = config.memory as Record<string, unknown>;
@@ -501,9 +490,8 @@ describe("PATCH /v1/config/privacy handler — llmRequestLogRetentionMs", () => 
     expect(body2.llmRequestLogRetentionMs).toBeNull();
   });
 
-  test("when only llmRequestLogRetentionMs is provided, existing collectUsageData/sendDiagnostics are unchanged", async () => {
+  test("when only llmRequestLogRetentionMs is provided, existing sendDiagnostics is unchanged", async () => {
     const preExisting = {
-      collectUsageData: true,
       sendDiagnostics: true,
     };
     writeFileSync(configPath, JSON.stringify(preExisting, null, 2));
@@ -513,7 +501,6 @@ describe("PATCH /v1/config/privacy handler — llmRequestLogRetentionMs", () => 
 
     expect(res.status).toBe(200);
     const config = readConfig();
-    expect(config.collectUsageData).toBe(true);
     expect(config.sendDiagnostics).toBe(true);
     const cleanup = (config.memory as Record<string, unknown>)
       .cleanup as Record<string, unknown>;
@@ -552,25 +539,20 @@ describe("PATCH /v1/config/privacy handler — llmRequestLogRetentionMs", () => 
 });
 
 describe("PATCH /v1/config/privacy handler — existing behavior (regression guard)", () => {
-  test("PATCH with only collectUsageData still works and response includes default llmRequestLogRetentionMs", async () => {
+  test("PATCH with only collectUsageData (now an unrecognized field) returns 400 and writes nothing", async () => {
+    // collectUsageData is no longer a recognized privacy-config field: usage
+    // telemetry is gated by the platform `share_analytics` consent. A PATCH
+    // that only contains it has no recognized fields and is rejected.
     const handler = createPrivacyConfigPatchHandler();
     const res = await handler(makePatch({ collectUsageData: true }));
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.collectUsageData).toBe(true);
-    // Gap B fix: the PATCH response shape is unified with GET — the
-    // `llmRequestLogRetentionMs` field is ALWAYS included, sourced from the
-    // post-write config with a fallback to the daemon schema default. The
-    // pre-existing config.json in this test has no retention value, so the
-    // response should return the daemon default (1 day in ms).
-    expect(body.llmRequestLogRetentionMs).toBe(DEFAULT_RETENTION_MS);
+    expect(body.error).toContain("sendDiagnostics");
+    expect(body.error).toContain("llmRequestLogRetentionMs");
 
-    const config = readConfig();
-    expect(config.collectUsageData).toBe(true);
-    // We did NOT pass llmRequestLogRetentionMs in the PATCH body, so no
-    // memory.cleanup entry should have been written.
-    expect(config.memory).toBeUndefined();
+    // Nothing was written to disk.
+    expect(existsSync(configPath)).toBe(false);
   });
 
   test("PATCH with only sendDiagnostics still works", async () => {
@@ -582,7 +564,7 @@ describe("PATCH /v1/config/privacy handler — existing behavior (regression gua
     expect(config.sendDiagnostics).toBe(false);
   });
 
-  test("PATCH with both booleans still works", async () => {
+  test("PATCH ignores an unrecognized collectUsageData key alongside sendDiagnostics", async () => {
     const handler = createPrivacyConfigPatchHandler();
     const res = await handler(
       makePatch({ collectUsageData: false, sendDiagnostics: true }),
@@ -592,19 +574,21 @@ describe("PATCH /v1/config/privacy handler — existing behavior (regression gua
     const body = await res.json();
     // Gap B: PATCH response always includes llmRequestLogRetentionMs.
     expect(body.llmRequestLogRetentionMs).toBe(DEFAULT_RETENTION_MS);
+    // collectUsageData is no longer part of the privacy-config surface.
+    expect(body).not.toHaveProperty("collectUsageData");
 
     const config = readConfig();
-    expect(config.collectUsageData).toBe(false);
+    // The unrecognized key is ignored, not written to disk.
+    expect(config.collectUsageData).toBeUndefined();
     expect(config.sendDiagnostics).toBe(true);
   });
 
-  test("PATCH with only booleans echoes pre-existing llmRequestLogRetentionMs from config.json", async () => {
+  test("PATCH with only sendDiagnostics echoes pre-existing llmRequestLogRetentionMs from config.json", async () => {
     // Pre-seed a config that already has a non-default retention value.
     const preExistingRetention = 3 * 24 * 60 * 60 * 1000; // 3 days
     writeFileSync(
       configPath,
       JSON.stringify({
-        collectUsageData: true,
         sendDiagnostics: true,
         memory: {
           cleanup: {
@@ -615,12 +599,11 @@ describe("PATCH /v1/config/privacy handler — existing behavior (regression gua
     );
 
     const handler = createPrivacyConfigPatchHandler();
-    const res = await handler(makePatch({ collectUsageData: false }));
+    const res = await handler(makePatch({ sendDiagnostics: false }));
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.collectUsageData).toBe(false);
-    expect(body.sendDiagnostics).toBe(true);
+    expect(body.sendDiagnostics).toBe(false);
     // Gap B: the response echoes the post-write retention value, even when
     // the PATCH body did not touch it.
     expect(body.llmRequestLogRetentionMs).toBe(preExistingRetention);
@@ -656,13 +639,16 @@ describe("PATCH /v1/config/privacy handler — existing behavior (regression gua
     expect(body.error).toContain("valid JSON");
   });
 
-  test("PATCH with non-boolean collectUsageData still returns 400", async () => {
+  test("PATCH containing only the removed collectUsageData field returns 400", async () => {
     const handler = createPrivacyConfigPatchHandler();
     const res = await handler(makePatch({ collectUsageData: "yes" }));
 
+    // collectUsageData is no longer recognized, so a body with no other
+    // fields fails the "at least one of" check.
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toContain("collectUsageData");
+    expect(body.error).toContain("sendDiagnostics");
+    expect(body.error).toContain("llmRequestLogRetentionMs");
   });
 
   test("PATCH with non-boolean sendDiagnostics still returns 400", async () => {
@@ -675,16 +661,15 @@ describe("PATCH /v1/config/privacy handler — existing behavior (regression gua
   });
 });
 
-// Gap 2a-1: the PATCH response must always include collectUsageData and
-// sendDiagnostics — even when config.json lacks the keys — because the
-// OpenAPI schema marks both as `required`. Previously the PATCH handler read
-// the booleans directly from the post-write config, producing `undefined`
-// values that Response.json() silently drops. These regression tests fix the
-// on-disk config to be "empty" before the PATCH and assert the response
-// still has both booleans populated from defaults.
+// Gap 2a-1: the PATCH response must always include sendDiagnostics — even when
+// config.json lacks the key — because the OpenAPI schema marks it `required`.
+// Previously the PATCH handler read the boolean directly from the post-write
+// config, producing an `undefined` value that Response.json() silently drops.
+// These regression tests fix the on-disk config to be "empty" before the PATCH
+// and assert the response still has sendDiagnostics populated from defaults.
 describe("PATCH /v1/config/privacy handler — Gap 2a-1 boolean defaults in response", () => {
-  test("PATCH with only llmRequestLogRetentionMs returns both booleans as defaults when config.json lacks them", async () => {
-    // Empty config.json — no collectUsageData, no sendDiagnostics.
+  test("PATCH with only llmRequestLogRetentionMs returns sendDiagnostics as default when config.json lacks it", async () => {
+    // Empty config.json — no sendDiagnostics.
     writeFileSync(configPath, JSON.stringify({}));
 
     const handler = createPrivacyConfigPatchHandler();
@@ -693,30 +678,14 @@ describe("PATCH /v1/config/privacy handler — Gap 2a-1 boolean defaults in resp
     expect(res.status).toBe(200);
     const body = await res.json();
     // The schema contract: these fields are always present in the response.
-    expect(body).toHaveProperty("collectUsageData");
     expect(body).toHaveProperty("sendDiagnostics");
     expect(body).toHaveProperty("llmRequestLogRetentionMs");
-    expect(body.collectUsageData).toBe(true);
+    expect(body).not.toHaveProperty("collectUsageData");
     expect(body.sendDiagnostics).toBe(true);
     expect(body.llmRequestLogRetentionMs).toBe(60_000);
   });
 
-  test("PATCH with only collectUsageData returns sendDiagnostics as default when config.json lacks it", async () => {
-    writeFileSync(configPath, JSON.stringify({}));
-
-    const handler = createPrivacyConfigPatchHandler();
-    const res = await handler(makePatch({ collectUsageData: false }));
-
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.collectUsageData).toBe(false);
-    // Default from daemon schema.
-    expect(body.sendDiagnostics).toBe(true);
-    // Default from daemon schema when memory.cleanup is missing.
-    expect(body.llmRequestLogRetentionMs).toBe(DEFAULT_RETENTION_MS);
-  });
-
-  test("PATCH with only sendDiagnostics returns collectUsageData as default when config.json lacks it", async () => {
+  test("PATCH with only sendDiagnostics returns retention default when config.json lacks it", async () => {
     writeFileSync(configPath, JSON.stringify({}));
 
     const handler = createPrivacyConfigPatchHandler();
@@ -724,19 +693,18 @@ describe("PATCH /v1/config/privacy handler — Gap 2a-1 boolean defaults in resp
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    // Default from daemon schema.
-    expect(body.collectUsageData).toBe(true);
     expect(body.sendDiagnostics).toBe(false);
+    // Default from daemon schema when memory.cleanup is missing.
+    expect(body.llmRequestLogRetentionMs).toBe(DEFAULT_RETENTION_MS);
   });
 
-  test("PATCH with only llmRequestLogRetentionMs returns default booleans when config.json has non-boolean values", async () => {
+  test("PATCH with only llmRequestLogRetentionMs returns default sendDiagnostics when config.json has a non-boolean value", async () => {
     // A user (or an older version of the code) wrote garbage into the
-    // booleans. We should still respond with valid booleans so the UI
+    // boolean. We should still respond with a valid boolean so the UI
     // doesn't choke on a missing field.
     writeFileSync(
       configPath,
       JSON.stringify({
-        collectUsageData: "yes",
         sendDiagnostics: 1,
       }),
     );
@@ -746,8 +714,7 @@ describe("PATCH /v1/config/privacy handler — Gap 2a-1 boolean defaults in resp
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    // Fall back to schema defaults.
-    expect(body.collectUsageData).toBe(true);
+    // Fall back to schema default.
     expect(body.sendDiagnostics).toBe(true);
     expect(body.llmRequestLogRetentionMs).toBe(60_000);
   });
@@ -834,7 +801,7 @@ describe("GET /v1/config/privacy handler — Gap 2a-2 out-of-range clamp", () =>
 });
 
 describe("PATCH /v1/config/privacy handler — Gap 2a-2 out-of-range clamp in response", () => {
-  test("PATCH with only collectUsageData against out-of-range config.json clamps retention in response", async () => {
+  test("PATCH with only sendDiagnostics against out-of-range config.json clamps retention in response", async () => {
     const tooBig = 365 * 24 * 60 * 60 * 1000 + 1;
     writeFileSync(
       configPath,
@@ -848,7 +815,7 @@ describe("PATCH /v1/config/privacy handler — Gap 2a-2 out-of-range clamp in re
     );
 
     const handler = createPrivacyConfigPatchHandler();
-    const res = await handler(makePatch({ collectUsageData: false }));
+    const res = await handler(makePatch({ sendDiagnostics: false }));
 
     expect(res.status).toBe(200);
     const body = await res.json();
@@ -856,8 +823,8 @@ describe("PATCH /v1/config/privacy handler — Gap 2a-2 out-of-range clamp in re
     // (the PATCH did not touch it), the response must echo the clamped
     // default. The gateway never serves an out-of-range value to clients.
     expect(body.llmRequestLogRetentionMs).toBe(DEFAULT_RETENTION_MS);
-    // collectUsageData was updated, should echo.
-    expect(body.collectUsageData).toBe(false);
+    // sendDiagnostics was updated, should echo.
+    expect(body.sendDiagnostics).toBe(false);
 
     // Sanity: the on-disk value is untouched. We only sanitize on read;
     // we never silently rewrite user data on a PATCH that didn't ask for it.

--- a/gateway/src/__tests__/privacy-config-route.test.ts
+++ b/gateway/src/__tests__/privacy-config-route.test.ts
@@ -539,8 +539,8 @@ describe("PATCH /v1/config/privacy handler — llmRequestLogRetentionMs", () => 
 });
 
 describe("PATCH /v1/config/privacy handler — existing behavior (regression guard)", () => {
-  test("PATCH with only collectUsageData (now an unrecognized field) returns 400 and writes nothing", async () => {
-    // collectUsageData is no longer a recognized privacy-config field: usage
+  test("PATCH with only the unrecognized collectUsageData field returns 400 and writes nothing", async () => {
+    // collectUsageData is not a recognized privacy-config field; usage
     // telemetry is gated by the platform `share_analytics` consent. A PATCH
     // that only contains it has no recognized fields and is rejected.
     const handler = createPrivacyConfigPatchHandler();
@@ -574,7 +574,7 @@ describe("PATCH /v1/config/privacy handler — existing behavior (regression gua
     const body = await res.json();
     // Gap B: PATCH response always includes llmRequestLogRetentionMs.
     expect(body.llmRequestLogRetentionMs).toBe(DEFAULT_RETENTION_MS);
-    // collectUsageData is no longer part of the privacy-config surface.
+    // collectUsageData is not part of the privacy-config surface.
     expect(body).not.toHaveProperty("collectUsageData");
 
     const config = readConfig();
@@ -639,11 +639,11 @@ describe("PATCH /v1/config/privacy handler — existing behavior (regression gua
     expect(body.error).toContain("valid JSON");
   });
 
-  test("PATCH containing only the removed collectUsageData field returns 400", async () => {
+  test("PATCH containing only the unrecognized collectUsageData field returns 400", async () => {
     const handler = createPrivacyConfigPatchHandler();
     const res = await handler(makePatch({ collectUsageData: "yes" }));
 
-    // collectUsageData is no longer recognized, so a body with no other
+    // collectUsageData is not recognized, so a body with no other
     // fields fails the "at least one of" check.
     expect(res.status).toBe(400);
     const body = await res.json();
@@ -663,10 +663,10 @@ describe("PATCH /v1/config/privacy handler — existing behavior (regression gua
 
 // Gap 2a-1: the PATCH response must always include sendDiagnostics — even when
 // config.json lacks the key — because the OpenAPI schema marks it `required`.
-// Previously the PATCH handler read the boolean directly from the post-write
-// config, producing an `undefined` value that Response.json() silently drops.
-// These regression tests fix the on-disk config to be "empty" before the PATCH
-// and assert the response still has sendDiagnostics populated from defaults.
+// The PATCH response always includes sendDiagnostics, falling back to the
+// schema default when the post-write config lacks a valid boolean.
+// These regression tests seed an "empty" on-disk config before the PATCH and
+// assert the response still has sendDiagnostics populated from defaults.
 describe("PATCH /v1/config/privacy handler — Gap 2a-1 boolean defaults in response", () => {
   test("PATCH with only llmRequestLogRetentionMs returns sendDiagnostics as default when config.json lacks it", async () => {
     // Empty config.json — no sendDiagnostics.

--- a/gateway/src/http/routes/privacy-config.ts
+++ b/gateway/src/http/routes/privacy-config.ts
@@ -4,10 +4,12 @@ import { mutateConfigFile, readConfigFile } from "../../config-file-utils.js";
 const log = getLogger("privacy-config");
 
 // These defaults MUST match the daemon's Zod schema defaults. See
-// `assistant/src/config/schema.ts` (collectUsageData, sendDiagnostics) and
+// `assistant/src/config/schema.ts` (sendDiagnostics) and
 // `assistant/src/config/schemas/memory-lifecycle.ts`
 // (memory.cleanup.llmRequestLogRetentionMs). Keep them in sync.
-const DEFAULT_COLLECT_USAGE_DATA = true;
+//
+// Usage-analytics consent is NOT part of this endpoint: it lives in the
+// platform `share_analytics` consent (an in-memory cache), not config.json.
 const DEFAULT_SEND_DIAGNOSTICS = true;
 const DEFAULT_LLM_REQUEST_LOG_RETENTION_MS = 1 * 60 * 60 * 1000;
 
@@ -71,12 +73,12 @@ function parseNestedNullableNumber(
  * Resolve a privacy-config boolean field from the post-read/post-write config,
  * falling back to the daemon schema default when the on-disk value is missing
  * or not a boolean. Shared by GET and PATCH so the OpenAPI contract
- * (`collectUsageData` and `sendDiagnostics` are both `required`) is honored
- * regardless of whether config.json has the keys set.
+ * (`sendDiagnostics` is `required`) is honored regardless of whether
+ * config.json has the key set.
  */
 function resolveBoolean(
   config: Record<string, unknown>,
-  key: "collectUsageData" | "sendDiagnostics",
+  key: "sendDiagnostics",
   defaultValue: boolean,
 ): boolean {
   const raw = config[key];
@@ -102,35 +104,21 @@ export function createPrivacyConfigPatchHandler() {
       );
     }
 
-    const { collectUsageData, sendDiagnostics, llmRequestLogRetentionMs } =
-      body as {
-        collectUsageData?: unknown;
-        sendDiagnostics?: unknown;
-        llmRequestLogRetentionMs?: unknown;
-      };
+    const { sendDiagnostics, llmRequestLogRetentionMs } = body as {
+      sendDiagnostics?: unknown;
+      llmRequestLogRetentionMs?: unknown;
+    };
 
-    const hasCollectUsageData = "collectUsageData" in (body as object);
     const hasSendDiagnostics = "sendDiagnostics" in (body as object);
     const hasLlmRequestLogRetentionMs =
       "llmRequestLogRetentionMs" in (body as object);
 
-    if (
-      !hasCollectUsageData &&
-      !hasSendDiagnostics &&
-      !hasLlmRequestLogRetentionMs
-    ) {
+    if (!hasSendDiagnostics && !hasLlmRequestLogRetentionMs) {
       return Response.json(
         {
           error:
-            'At least one of "collectUsageData", "sendDiagnostics", or "llmRequestLogRetentionMs" must be provided',
+            'At least one of "sendDiagnostics" or "llmRequestLogRetentionMs" must be provided',
         },
-        { status: 400 },
-      );
-    }
-
-    if (hasCollectUsageData && typeof collectUsageData !== "boolean") {
-      return Response.json(
-        { error: '"collectUsageData" must be a boolean' },
         { status: 400 },
       );
     }
@@ -179,9 +167,6 @@ export function createPrivacyConfigPatchHandler() {
 
     try {
       const result = await mutateConfigFile((config) => {
-        if (hasCollectUsageData) {
-          config.collectUsageData = collectUsageData;
-        }
         if (hasSendDiagnostics) {
           config.sendDiagnostics = sendDiagnostics;
         }
@@ -203,19 +188,13 @@ export function createPrivacyConfigPatchHandler() {
           config.memory = memory;
         }
 
-        // Always include all three fields in the response so GET and PATCH
+        // Always include both fields in the response so GET and PATCH
         // share the same shape and match the OpenAPI schema contract
-        // (`required: [collectUsageData, sendDiagnostics,
-        // llmRequestLogRetentionMs]`). Source each value from the
-        // post-write config via the same fallback logic as the GET handler
-        // so a fresh or manually-edited config.json that lacks any of
-        // these keys still produces a well-formed response.
+        // (`required: [sendDiagnostics, llmRequestLogRetentionMs]`). Source
+        // each value from the post-write config via the same fallback logic
+        // as the GET handler so a fresh or manually-edited config.json that
+        // lacks any of these keys still produces a well-formed response.
         const responseData = {
-          collectUsageData: resolveBoolean(
-            config,
-            "collectUsageData",
-            DEFAULT_COLLECT_USAGE_DATA,
-          ),
           sendDiagnostics: resolveBoolean(
             config,
             "sendDiagnostics",
@@ -263,12 +242,6 @@ export function createPrivacyConfigGetHandler() {
 
     const config = result.data;
 
-    const collectUsageData = resolveBoolean(
-      config,
-      "collectUsageData",
-      DEFAULT_COLLECT_USAGE_DATA,
-    );
-
     const sendDiagnostics = resolveBoolean(
       config,
       "sendDiagnostics",
@@ -288,7 +261,6 @@ export function createPrivacyConfigGetHandler() {
     );
 
     return Response.json({
-      collectUsageData,
       sendDiagnostics,
       llmRequestLogRetentionMs,
     });

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -2625,7 +2625,7 @@ export function buildSchema(): Record<string, unknown> {
         get: {
           summary: "Get privacy config",
           description:
-            "Scope-protected gateway endpoint that returns the current privacy configuration (collectUsageData, sendDiagnostics, llmRequestLogRetentionMs). Missing or malformed values fall back to the daemon schema defaults. Requires a bearer token with `settings.read` scope.",
+            "Scope-protected gateway endpoint that returns the current privacy configuration (sendDiagnostics, llmRequestLogRetentionMs). Missing or malformed values fall back to the daemon schema defaults. Requires a bearer token with `settings.read` scope.",
           operationId: "privacyConfigGet",
           security: [{ BearerAuth: [] }],
           responses: {
@@ -2636,7 +2636,6 @@ export function buildSchema(): Record<string, unknown> {
                   schema: {
                     type: "object",
                     properties: {
-                      collectUsageData: { type: "boolean" },
                       sendDiagnostics: { type: "boolean" },
                       llmRequestLogRetentionMs: {
                         type: ["integer", "null"],
@@ -2646,11 +2645,7 @@ export function buildSchema(): Record<string, unknown> {
                           "Retention period for LLM request/response logs in milliseconds. null keeps forever, 0 prunes immediately. Maximum is 365 days (31536000000 ms); server-side clamping enforces this cap on reads.",
                       },
                     },
-                    required: [
-                      "collectUsageData",
-                      "sendDiagnostics",
-                      "llmRequestLogRetentionMs",
-                    ],
+                    required: ["sendDiagnostics", "llmRequestLogRetentionMs"],
                   },
                 },
               },
@@ -2665,7 +2660,7 @@ export function buildSchema(): Record<string, unknown> {
         patch: {
           summary: "Update privacy config",
           description:
-            "Scope-protected gateway endpoint that updates privacy configuration (collectUsageData, sendDiagnostics, llmRequestLogRetentionMs). Requires a bearer token with `settings.write` scope.",
+            "Scope-protected gateway endpoint that updates privacy configuration (sendDiagnostics, llmRequestLogRetentionMs). Requires a bearer token with `settings.write` scope.",
           operationId: "privacyConfigPatch",
           security: [{ BearerAuth: [] }],
           requestBody: {
@@ -2675,7 +2670,6 @@ export function buildSchema(): Record<string, unknown> {
                 schema: {
                   type: "object",
                   properties: {
-                    collectUsageData: { type: "boolean" },
                     sendDiagnostics: { type: "boolean" },
                     llmRequestLogRetentionMs: {
                       type: ["integer", "null"],
@@ -2686,7 +2680,6 @@ export function buildSchema(): Record<string, unknown> {
                     },
                   },
                   anyOf: [
-                    { required: ["collectUsageData"] },
                     { required: ["sendDiagnostics"] },
                     { required: ["llmRequestLogRetentionMs"] },
                   ],
@@ -2702,7 +2695,6 @@ export function buildSchema(): Record<string, unknown> {
                   schema: {
                     type: "object",
                     properties: {
-                      collectUsageData: { type: "boolean" },
                       sendDiagnostics: { type: "boolean" },
                       llmRequestLogRetentionMs: {
                         type: ["integer", "null"],
@@ -2712,11 +2704,7 @@ export function buildSchema(): Record<string, unknown> {
                           "Retention window for LLM request logs, in milliseconds. null keeps logs forever, 0 prunes immediately. Maximum is 365 days (31536000000 ms).",
                       },
                     },
-                    required: [
-                      "collectUsageData",
-                      "sendDiagnostics",
-                      "llmRequestLogRetentionMs",
-                    ],
+                    required: ["sendDiagnostics", "llmRequestLogRetentionMs"],
                   },
                 },
               },
@@ -2800,7 +2788,7 @@ export function buildSchema(): Record<string, unknown> {
         get: {
           summary: "Get privacy config (assistant-scoped)",
           description:
-            "Assistant-scoped variant of the privacy config read endpoint. Returns the current privacy configuration (collectUsageData, sendDiagnostics, llmRequestLogRetentionMs). Missing or malformed values fall back to the daemon schema defaults. Requires a bearer token with `settings.read` scope.",
+            "Assistant-scoped variant of the privacy config read endpoint. Returns the current privacy configuration (sendDiagnostics, llmRequestLogRetentionMs). Missing or malformed values fall back to the daemon schema defaults. Requires a bearer token with `settings.read` scope.",
           operationId: "assistantPrivacyConfigGet",
           security: [{ BearerAuth: [] }],
           parameters: [
@@ -2820,7 +2808,6 @@ export function buildSchema(): Record<string, unknown> {
                   schema: {
                     type: "object",
                     properties: {
-                      collectUsageData: { type: "boolean" },
                       sendDiagnostics: { type: "boolean" },
                       llmRequestLogRetentionMs: {
                         type: ["integer", "null"],
@@ -2830,11 +2817,7 @@ export function buildSchema(): Record<string, unknown> {
                           "Retention period for LLM request/response logs in milliseconds. null keeps forever, 0 prunes immediately. Maximum is 365 days (31536000000 ms); server-side clamping enforces this cap on reads.",
                       },
                     },
-                    required: [
-                      "collectUsageData",
-                      "sendDiagnostics",
-                      "llmRequestLogRetentionMs",
-                    ],
+                    required: ["sendDiagnostics", "llmRequestLogRetentionMs"],
                   },
                 },
               },
@@ -2868,7 +2851,6 @@ export function buildSchema(): Record<string, unknown> {
                 schema: {
                   type: "object",
                   properties: {
-                    collectUsageData: { type: "boolean" },
                     sendDiagnostics: { type: "boolean" },
                     llmRequestLogRetentionMs: {
                       type: ["integer", "null"],
@@ -2879,7 +2861,6 @@ export function buildSchema(): Record<string, unknown> {
                     },
                   },
                   anyOf: [
-                    { required: ["collectUsageData"] },
                     { required: ["sendDiagnostics"] },
                     { required: ["llmRequestLogRetentionMs"] },
                   ],
@@ -2895,7 +2876,6 @@ export function buildSchema(): Record<string, unknown> {
                   schema: {
                     type: "object",
                     properties: {
-                      collectUsageData: { type: "boolean" },
                       sendDiagnostics: { type: "boolean" },
                       llmRequestLogRetentionMs: {
                         type: ["integer", "null"],
@@ -2905,11 +2885,7 @@ export function buildSchema(): Record<string, unknown> {
                           "Retention window for LLM request logs, in milliseconds. null keeps logs forever, 0 prunes immediately. Maximum is 365 days (31536000000 ms).",
                       },
                     },
-                    required: [
-                      "collectUsageData",
-                      "sendDiagnostics",
-                      "llmRequestLogRetentionMs",
-                    ],
+                    required: ["sendDiagnostics", "llmRequestLogRetentionMs"],
                   },
                 },
               },


### PR DESCRIPTION
## Summary
- Replace the daemon's `collectUsageData` config key with the platform user's `share_analytics` consent, fetched from the new platform endpoint `GET /v1/assistants/<id>/owner-consent/` (platform side merged separately in vellum-assistant-platform#8520).
- New `VellumPlatformClient.getOwnerConsent()` + an in-memory `consent-cache.ts` (synchronous `getCachedShareAnalytics()`, default-off, 5-min refresh, fails closed when no platform session / no resolvable assistant identity). Wired into the daemon lifecycle; refreshes in dev too (the reporter flush stays dev-gated).
- All former `getConfig().collectUsageData` gates (5 record-time emitters + the reporter flush) now read the consent cache. `collectUsageData` removed from the config schema (migration 106 drops it) and from the gateway privacy-config endpoint.

## Self-review result
PASS — 1 round of gaps found and fixed across 4 fix PRs: gateway dead-key removal (#35302), consent-cache fail-closed on missing identity (#35299), dev-mode consent refresh + doc (#35300), plus a present-tense test-wording cleanup (#35304).

## PRs merged into feature branch
- #35282: feat(platform): add getOwnerConsent to VellumPlatformClient (PR 1)
- #35287: feat(platform): add consent cache with synchronous accessor (PR 2)
- #35290: feat(daemon): wire consent cache refresh into lifecycle (PR 3)
- #35291: refactor(telemetry): gate record-time emitters on cached consent (PR 4)
- #35292: refactor(telemetry): gate reporter flush on cached consent (PR 5)
- #35298: refactor(telemetry): remove collectUsageData config key (PR 6)

### Fix PRs (self-review remediation)
- #35299: fix(telemetry): consent cache fails closed on missing assistant identity
- #35300: fix(daemon): refresh consent cache regardless of dev mode
- #35302: fix(gateway): remove dead collectUsageData from privacy-config
- #35304: test(gateway): present-tense wording in privacy-config tests

Part of plan: telemetry-consent-gating.md