### PR TITLE
marketplace: remove installable advisor plugin entry

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -64,18 +64,6 @@
       "category": "productivity",
       "homepage": "https://github.com/AnitaKirkovska/model-router",
       "license": "MIT"
-    },
-    {
-      "name": "advisor",
-      "source": {
-        "source": "github",
-        "repo": "vellum-ai/advisor",
-        "ref": "fe8139fa6e14a84253d796afd3df7a1a15af851d"
-      },
-      "description": "Consult a stronger inference profile mid-task via an advisor tool, routed through the workspace's own inference (no API key).",
-      "category": "developer",
-      "homepage": "https://github.com/vellum-ai/advisor",
-      "license": "MIT"
     }
   ]
 }


### PR DESCRIPTION
Removes the `advisor` entry from `plugins/marketplace.json` so the marketplace catalog no longer offers the standalone, user-installable advisor plugin.

## Why
The advisor now ships as a **compiled-in first-party default plugin** (#35308, default-on for all users), which supersedes the installable version. Keeping both is redundant.

## Scope
- Only the marketplace JSON entry is removed (5 plugins remain; JSON validated with `jq`).
- Archiving the `vellum-ai/advisor` repo is a **separate follow-up**, not done here.

## ⚠️ Merge timing
The marketplace catalog is fetched **live from `main`** by all assistant binaries (including prod), whereas the compiled-in default only reaches prod via a release branch. Merging this removes the installable advisor from every catalog immediately — before #35308 lands in prod. Recommend merging **after** #35308 has been deployed to prod (or accept the brief gap; the standalone entry was dogfooding-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)