### PR TITLE
feat(platform): add managed-profiles fetch client for the model-profiles endpoint

### DIFF
--- a/assistant/src/platform/__tests__/managed-profiles.test.ts
+++ b/assistant/src/platform/__tests__/managed-profiles.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+interface MockPlatformClient {
+  platformAssistantId: string;
+  fetch: ReturnType<typeof mock>;
+}
+
+let mockClient: MockPlatformClient | null = null;
+
+mock.module("../client.js", () => ({
+  VellumPlatformClient: {
+    create: async () => mockClient,
+  },
+}));
+
+import { fetchManagedProfiles } from "../managed-profiles.js";
+
+function makeProfile(key: string) {
+  return {
+    key,
+    intent: "general",
+    provider: "anthropic",
+    connection_name: "default",
+    source: "platform",
+    label: `Label ${key}`,
+    description: `Description ${key}`,
+    max_tokens: 8192,
+    effort: "medium",
+    thinking: { enabled: true, stream_thinking: false },
+    context_window: { max_input_tokens: 200000 },
+  };
+}
+
+function okBody(schemaVersion = 1, count = 4) {
+  return {
+    schema_version: schemaVersion,
+    profiles: Array.from({ length: count }, (_, i) => makeProfile(`p${i}`)),
+  };
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("fetchManagedProfiles", () => {
+  beforeEach(() => {
+    mockClient = {
+      platformAssistantId: "asst-123",
+      fetch: mock(async () => jsonResponse(okBody())),
+    };
+  });
+
+  afterEach(() => {
+    mockClient = null;
+  });
+
+  test("returns no-connection when no platform client", async () => {
+    mockClient = null;
+    expect(await fetchManagedProfiles()).toEqual({ status: "no-connection" });
+  });
+
+  test("returns ok with parsed profiles on a valid 200", async () => {
+    const result = await fetchManagedProfiles();
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(result.profiles).toHaveLength(4);
+      expect(result.profiles[0].key).toBe("p0");
+    }
+    expect(mockClient!.fetch.mock.calls[0][0]).toBe(
+      "/v1/assistants/asst-123/model-profiles/",
+    );
+  });
+
+  test("returns error when assistant ID is missing", async () => {
+    mockClient!.platformAssistantId = "";
+    expect(await fetchManagedProfiles()).toEqual({ status: "error" });
+    expect(mockClient!.fetch).not.toHaveBeenCalled();
+  });
+
+  test("returns error on HTTP 500", async () => {
+    mockClient!.fetch = mock(async () => jsonResponse({}, 500));
+    expect(await fetchManagedProfiles()).toEqual({ status: "error" });
+  });
+
+  test("returns error on malformed body", async () => {
+    mockClient!.fetch = mock(async () =>
+      jsonResponse({ profiles: [{ key: 123 }] }),
+    );
+    expect(await fetchManagedProfiles()).toEqual({ status: "error" });
+  });
+
+  test("returns error on unsupported schema_version", async () => {
+    mockClient!.fetch = mock(async () => jsonResponse(okBody(2)));
+    expect(await fetchManagedProfiles()).toEqual({ status: "error" });
+  });
+
+  test("returns error when the fetch throws / aborts", async () => {
+    mockClient!.fetch = mock(async () => {
+      throw new DOMException("aborted", "AbortError");
+    });
+    expect(await fetchManagedProfiles()).toEqual({ status: "error" });
+  });
+});

--- a/assistant/src/platform/managed-profiles.ts
+++ b/assistant/src/platform/managed-profiles.ts
@@ -1,0 +1,112 @@
+/**
+ * Fetch managed model profiles from the platform.
+ *
+ * Hits `GET /v1/assistants/{id}/model-profiles/` and validates the response
+ * against the Django serializer contract. The discriminated result lets
+ * callers distinguish a missing platform connection ("no-connection" — safe to
+ * prune local profiles) from a transient failure ("error" — preserve whatever
+ * is on disk so a blip never wipes profiles).
+ */
+
+import { z } from "zod";
+
+import { getLogger } from "../util/logger.js";
+import { VellumPlatformClient } from "./client.js";
+
+const log = getLogger("managed-profiles");
+
+const PlatformManagedProfileSchema = z.object({
+  key: z.string(),
+  intent: z.string(),
+  provider: z.string(),
+  connection_name: z.string(),
+  source: z.string(),
+  label: z.string(),
+  description: z.string(),
+  max_tokens: z.number(),
+  effort: z.string(),
+  thinking: z.object({ enabled: z.boolean(), stream_thinking: z.boolean() }),
+  context_window: z.object({ max_input_tokens: z.number() }),
+});
+
+const PlatformManagedProfilesResponseSchema = z.object({
+  schema_version: z.number(),
+  profiles: z.array(PlatformManagedProfileSchema),
+});
+
+export type PlatformManagedProfile = z.infer<
+  typeof PlatformManagedProfileSchema
+>;
+
+/**
+ * Result of {@link fetchManagedProfiles}.
+ *
+ * - `no-connection`: no platform client (not platform-hosted / missing creds).
+ *   Callers may safely prune local managed profiles.
+ * - `ok`: profiles fetched and validated.
+ * - `error`: any HTTP/parse/timeout/schema-version failure. Callers should
+ *   preserve on-disk profiles rather than prune.
+ */
+export type FetchManagedProfilesResult =
+  | { status: "no-connection" }
+  | { status: "ok"; profiles: PlatformManagedProfile[] }
+  | { status: "error" };
+
+/**
+ * Fetch the assistant's managed model profiles from the platform.
+ *
+ * Best-effort: never throws to the caller. Uses a bounded timeout so a hung
+ * platform never stalls the caller.
+ */
+export async function fetchManagedProfiles(): Promise<FetchManagedProfilesResult> {
+  const client = await VellumPlatformClient.create();
+  if (!client) {
+    return { status: "no-connection" };
+  }
+
+  const assistantId = client.platformAssistantId;
+  if (!assistantId) {
+    // We have a connection but cannot address the assistant — do not prune.
+    log.warn("No platform assistant ID configured — cannot fetch profiles");
+    return { status: "error" };
+  }
+
+  try {
+    const resp = await client.fetch(
+      `/v1/assistants/${encodeURIComponent(assistantId)}/model-profiles/`,
+      { signal: AbortSignal.timeout(15_000) },
+    );
+
+    if (!resp.ok) {
+      log.warn(
+        { status: resp.status, assistantId },
+        "Failed to fetch managed profiles from platform",
+      );
+      return { status: "error" };
+    }
+
+    const json = await resp.json();
+    const parsed = PlatformManagedProfilesResponseSchema.safeParse(json);
+    if (!parsed.success) {
+      log.warn(
+        { err: parsed.error, assistantId },
+        "Managed profiles response failed validation",
+      );
+      return { status: "error" };
+    }
+
+    if (parsed.data.schema_version !== 1) {
+      // An unknown schema version must never overwrite or prune on-disk profiles.
+      log.warn(
+        { schemaVersion: parsed.data.schema_version, assistantId },
+        "Unsupported managed profiles schema version",
+      );
+      return { status: "error" };
+    }
+
+    return { status: "ok", profiles: parsed.data.profiles };
+  } catch (err) {
+    log.warn({ err, assistantId }, "Error fetching managed profiles");
+    return { status: "error" };
+  }
+}


### PR DESCRIPTION
## Summary
- Add fetchManagedProfiles() hitting GET /v1/assistants/{id}/model-profiles/
- Discriminated result (no-connection | ok | error) so callers distinguish prune vs preserve
- Bounded timeout, zod-validated response, schema_version guard

Part of plan: platform-managed-profiles.md (PR 1 of 5)