### PR TITLE
refactor(config): derive MANAGED_PROFILE_NAMES from a static key list

### DIFF
--- a/assistant/src/config/__tests__/seed-inference-profiles.test.ts
+++ b/assistant/src/config/__tests__/seed-inference-profiles.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+
+import { MANAGED_PROFILE_NAMES } from "../seed-inference-profiles.js";
+
+describe("MANAGED_PROFILE_NAMES", () => {
+  test("contains exactly the managed profile keys plus the auto key", () => {
+    expect(new Set(MANAGED_PROFILE_NAMES)).toEqual(
+      new Set([
+        "balanced",
+        "quality-optimized",
+        "cost-optimized",
+        "balanced-economy",
+        "auto",
+      ]),
+    );
+  });
+});

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -144,8 +144,18 @@ const USER_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
  */
 export const AUTO_PROFILE_KEY = "auto";
 
-export const MANAGED_PROFILE_NAMES = new Set([
-  ...Object.keys(MANAGED_PROFILE_TEMPLATES),
+/** Stable keys of the platform-managed profiles. The profile *content* now
+ *  comes from the platform model-profiles endpoint; only the key set lives
+ *  in code, so route validation and pruning can recognise managed profiles. */
+export const MANAGED_PROFILE_KEYS = [
+  "balanced",
+  "quality-optimized",
+  "cost-optimized",
+  "balanced-economy",
+] as const;
+
+export const MANAGED_PROFILE_NAMES = new Set<string>([
+  ...MANAGED_PROFILE_KEYS,
   AUTO_PROFILE_KEY,
 ]);
 


### PR DESCRIPTION
## Summary
- Add static MANAGED_PROFILE_KEYS constant
- Derive MANAGED_PROFILE_NAMES from it instead of Object.keys(MANAGED_PROFILE_TEMPLATES)
- No behavioral change; locks the managed key set with a test assertion

Part of plan: platform-managed-profiles.md (PR 2 of 5)