### PR TITLE
fix(sidebar): consistent section spacing + stable pinned order

### DIFF
--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -482,7 +482,7 @@ export function AssistantSideMenu({
         <SideMenu.Separator />
       </SideMenu.Header>
 
-      <SideMenu.Body className="gap-1 pt-3 max-md:pt-4">
+      <SideMenu.Body className="gap-[2px] pt-3 max-md:pt-4">
         {collapsed && variant === "rail" ? (
           <div className="flex flex-col items-center gap-1">
             {headerActions}

--- a/clients/web/src/domains/chat/utils/group-conversations.test.ts
+++ b/clients/web/src/domains/chat/utils/group-conversations.test.ts
@@ -461,23 +461,62 @@ describe("groupConversations · displayOrder for pinned and custom groups", () =
     ]);
   });
 
-  test("pinned conversations without displayOrder fall back to lastMessageAt desc", () => {
+  test("pinned conversations without displayOrder fall back to createdAt desc, ignoring activity", () => {
+    // lastMessageAt is the REVERSE of createdAt to prove the fallback keys on
+    // immutable creation time, not recency — pinned rows must not reorder
+    // themselves based on activity.
     const result = groupConversations([
       makeConversation({
-        conversationId: "old",
+        conversationId: "older",
         isPinned: true,
-        lastMessageAt: 1704067200000,
+        createdAt: 1704067200000,
+        lastMessageAt: 1704412800000, // most recent activity
       }),
       makeConversation({
-        conversationId: "new",
+        conversationId: "newer",
         isPinned: true,
-        lastMessageAt: 1704412800000,
+        createdAt: 1704412800000,
+        lastMessageAt: 1704067200000, // least recent activity
       }),
     ]);
     expect(result.pinned.map((c) => c.conversationId)).toEqual([
-      "new",
-      "old",
+      "newer",
+      "older",
     ]);
+  });
+
+  test("pinned order is stable when a pinned conversation receives new activity", () => {
+    const base = [
+      makeConversation({
+        conversationId: "a",
+        isPinned: true,
+        createdAt: 3000,
+        lastMessageAt: 100,
+      }),
+      makeConversation({
+        conversationId: "b",
+        isPinned: true,
+        createdAt: 2000,
+        lastMessageAt: 100,
+      }),
+      makeConversation({
+        conversationId: "c",
+        isPinned: true,
+        createdAt: 1000,
+        lastMessageAt: 100,
+      }),
+    ];
+    const before = groupConversations(base).pinned.map((c) => c.conversationId);
+    expect(before).toEqual(["a", "b", "c"]);
+
+    // "c" gets a brand-new message — its lastMessageAt jumps far ahead. The
+    // pinned order must not change.
+    const after = groupConversations(
+      base.map((c) =>
+        c.conversationId === "c" ? { ...c, lastMessageAt: 9_999_999 } : c,
+      ),
+    ).pinned.map((c) => c.conversationId);
+    expect(after).toEqual(before);
   });
 
   test("displayOrder rows come before rows without displayOrder", () => {

--- a/clients/web/src/domains/chat/utils/group-conversations.ts
+++ b/clients/web/src/domains/chat/utils/group-conversations.ts
@@ -82,22 +82,42 @@ function parseLastMessageAt(conversation: Conversation): number {
 }
 
 /**
+ * Stable fallback order for pinned / custom-group rows that have no
+ * server-assigned `displayOrder`, and the tie-breaker when two rows share a
+ * `displayOrder`.
+ *
+ * Keyed on the immutable `createdAt` (newest-created first) — deliberately NOT
+ * `lastMessageAt`. Pinning sends no `displayOrder` (the daemon stores it as
+ * NULL until the user drag-reorders), so without this every pinned row would
+ * sort by recency and jump to the top whenever a new message landed in it.
+ * Pinned rows should hold their position regardless of activity, so we sort by
+ * creation time, which never changes. `conversationId` is the final
+ * tie-breaker so the order stays fully deterministic when `createdAt` is equal
+ * or missing.
+ */
+function compareByCreatedAt(a: Conversation, b: Conversation): number {
+  const byCreated = (b.createdAt ?? 0) - (a.createdAt ?? 0);
+  if (byCreated !== 0) return byCreated;
+  return a.conversationId.localeCompare(b.conversationId);
+}
+
+/**
  * Comparator for buckets where the user can manually drag-reorder rows
  * (pinned, custom groups). Conversations with a server-provided
  * `displayOrder` come first in ascending order; ties and rows without
- * `displayOrder` fall back to `lastMessageAt` newest-first so freshly-pinned
- * conversations land near the top until the server assigns them an order.
+ * `displayOrder` fall back to a stable creation-time order so pinned rows
+ * never reshuffle when activity arrives (see {@link compareByCreatedAt}).
  */
 function compareByDisplayOrder(a: Conversation, b: Conversation): number {
   const aOrder = a.displayOrder;
   const bOrder = b.displayOrder;
   if (aOrder != null && bOrder != null) {
     if (aOrder !== bOrder) return aOrder - bOrder;
-    return parseLastMessageAt(b) - parseLastMessageAt(a);
+    return compareByCreatedAt(a, b);
   }
   if (aOrder != null) return -1;
   if (bOrder != null) return 1;
-  return parseLastMessageAt(b) - parseLastMessageAt(a);
+  return compareByCreatedAt(a, b);
 }
 
 /**


### PR DESCRIPTION
Two small assistant-sidebar tweaks.

## 1. Consistent section spacing

The gap between the **Pinned** section and the **Conversations** section was `gap-1` (4px) on `SideMenu.Body`, while conversation rows sit `gap-[2px]` (2px) apart. That made the space above the "Conversations" header read as noticeably larger than the spacing between conversations.

Matched the section-to-section gap to the inter-item gap (2px) so the rhythm is consistent.

- `clients/web/src/domains/chat/components/assistant-side-menu.tsx`: `SideMenu.Body` `gap-1` → `gap-[2px]`.

## 2. Pinned conversations no longer reorder on activity

Pinned rows were jumping to the top whenever a new message arrived. Root cause: pinning sends only `isPinned`/`groupId` and **no `displayOrder`**, so the daemon stores `display_order = NULL`. Until a row is manually drag-reordered, the client fell back to sorting pinned rows by `lastMessageAt` (recency) — which changes with every message.

Changed the fallback for pinned / custom-group rows to sort by the **immutable `createdAt`** (newest-created first) instead of `lastMessageAt`, with `conversationId` as a deterministic tie-breaker. Pinned rows now hold their position regardless of activity. An explicit drag-reorder (`displayOrder`) still takes precedence.

- `clients/web/src/domains/chat/utils/group-conversations.ts`: new `compareByCreatedAt`; `compareByDisplayOrder` fallback + tie-break now use it.

### Trade-off
Freshly pinning a brand-new conversation still lands it near the top (high `createdAt`). Pinning an *older* conversation now lands it by creation time rather than at the top — the intended consequence of no longer ordering by activity.

## Testing
- `bun test src/domains/chat/utils/group-conversations.test.ts` — updated the old "fall back to lastMessageAt desc" case and added a test proving pinned order is stable when a pinned conversation receives new activity. 34 pass.
- `bun test src/domains/chat/components/assistant-side-menu.test.tsx` — 14 pass.
- `bunx tsc --noEmit` — clean. ESLint — clean.

The spacing change is purely visual; happy to drop a screenshot or fine-tune the exact value before this leaves draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UNP1EM8Hu9dmJM8nFpeir3

---
_Generated by [Claude Code](https://claude.ai/code/session_01UNP1EM8Hu9dmJM8nFpeir3)_