### PR TITLE
fix(plugin-detail): navigate to list after removing plugin

### DIFF
--- a/clients/web/src/domains/intelligence/plugin-detail-page.remove.test.tsx
+++ b/clients/web/src/domains/intelligence/plugin-detail-page.remove.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * Tests for the plugin detail page's remove flow: confirming a removal
+ * fires the delete mutation and, on success, navigates back to the
+ * plugins list rather than stranding the user on the now-empty detail
+ * page (which would render a "We couldn't load this plugin" error once
+ * the deleted plugin's detail query refetches).
+ *
+ * Mounted via `@testing-library/react` (happy-dom — see `test-setup.ts`)
+ * so the click → confirm-dialog → mutation → navigation flow can be
+ * exercised. The detail query is pre-seeded into the React Query cache
+ * (with an infinite stale time) so it doesn't refetch on mount, and the
+ * delete SDK call is spied so confirming never touches the network. The
+ * feature-flag store and active assistant id are stubbed, matching the
+ * sibling `plugin-detail-page.test.tsx`.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+
+import type { Options } from "@/generated/daemon/sdk.gen";
+import type {
+  PluginsByNameGetData,
+  PluginsByNameGetResponse,
+} from "@/generated/daemon/types.gen";
+
+const ASSISTANT_ID = "asst-1";
+
+mock.module("@/stores/assistant-feature-flag-store", () => ({
+  useAssistantFeatureFlagStore: {
+    use: {
+      hasHydrated: () => true,
+      externalPlugins: () => true,
+    },
+  },
+}));
+
+mock.module("@/assistant/use-active-assistant-id", () => ({
+  useActiveAssistantId: () => ASSISTANT_ID,
+}));
+
+// Spy the delete SDK call so confirming a removal resolves locally
+// instead of hitting the daemon. Spread the real module so the rest of
+// the generated client (used by the seeded query) stays intact.
+const sdkActual = await import("@/generated/daemon/sdk.gen");
+const okResponse = { response: new Response(), error: undefined };
+const deleteSpy = mock(
+  async (_options: { path: { assistant_id: string; name: string } }) => ({
+    data: undefined,
+    ...okResponse,
+  }),
+);
+// The success path invalidates the list / search / detail / inspect
+// queries, which refetch on the next tick. Stub those reads so the
+// refetch resolves locally instead of hitting an absent daemon (which
+// would log ECONNREFUSED). The body is irrelevant — nothing asserts on
+// the refetched data.
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...sdkActual,
+  pluginsByNameDelete: deleteSpy,
+  pluginsGet: mock(async () => ({ data: { plugins: [] }, ...okResponse })),
+  pluginsSearchGet: mock(async () => ({ data: { matches: [] }, ...okResponse })),
+  pluginsByNameGet: mock(async (options: { path: { name: string } }) => ({
+    data: installedDetail(options.path.name),
+    ...okResponse,
+  })),
+  // The installed-plugin drift check fires on mount; stub it so it
+  // resolves locally instead of dialing an absent daemon.
+  pluginsByNameInspectGet: mock(async (options: { path: { name: string } }) => ({
+    data: {
+      name: options.path.name,
+      installed: true,
+      status: "up-to-date",
+      local: null,
+      remote: null,
+      remoteError: null,
+      surfaces: null,
+    },
+    ...okResponse,
+  })),
+}));
+
+const { pluginsByNameGetQueryKey } = await import(
+  "@/generated/daemon/@tanstack/react-query.gen"
+);
+const { PluginDetailPage } = await import(
+  "@/domains/intelligence/plugin-detail-page"
+);
+
+function installedDetail(name: string): PluginsByNameGetResponse {
+  return {
+    name,
+    installed: true,
+    description: "Converts Telegram voice notes into text.",
+    homepage: null,
+    license: "MIT",
+    version: "0.1.0",
+    source: {
+      kind: "github",
+      repo: "vellum-ai/telegram-voice-transcribe",
+      ref: "main",
+    },
+    readme: "# Telegram Voice Transcribe",
+    ref: "main",
+    artifact: null,
+  };
+}
+
+function renderDetail(name: string): void {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Number.POSITIVE_INFINITY },
+    },
+  });
+  client.setQueryData(
+    pluginsByNameGetQueryKey({
+      path: { assistant_id: ASSISTANT_ID, name },
+    } as Options<PluginsByNameGetData>),
+    installedDetail(name),
+  );
+  render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[`/assistant/plugins/${name}`]}>
+        <Routes>
+          <Route
+            path="/assistant/plugins/:name"
+            element={<PluginDetailPage />}
+          />
+          {/* A sentinel for the list route so the test can prove the
+              page navigated here after the removal succeeded. */}
+          <Route
+            path="/assistant/plugins"
+            element={<div>Plugins list landing</div>}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  deleteSpy.mockClear();
+});
+
+describe("PluginDetailPage remove flow", () => {
+  test("removing a plugin navigates back to the plugins list", async () => {
+    // GIVEN an installed plugin's detail page
+    renderDetail("telegram-voice-transcribe");
+    expect(screen.queryByText("Plugins list landing")).toBeNull();
+
+    // WHEN the user clicks Remove and confirms in the dialog. Both the
+    // header action and the dialog's confirm button read "Remove", so
+    // scope the confirm click to the dialog.
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: "Remove" }));
+
+    // THEN the delete runs
+    await waitFor(() => expect(deleteSpy).toHaveBeenCalledTimes(1));
+    expect(deleteSpy.mock.calls[0]?.[0]).toMatchObject({
+      path: { assistant_id: ASSISTANT_ID, name: "telegram-voice-transcribe" },
+    });
+
+    // AND the user lands on the plugins list rather than staying on the
+    // now-stale detail page
+    await waitFor(() =>
+      expect(screen.getByText("Plugins list landing")).toBeDefined(),
+    );
+  });
+});

--- a/clients/web/src/domains/intelligence/plugin-detail-page.tsx
+++ b/clients/web/src/domains/intelligence/plugin-detail-page.tsx
@@ -10,7 +10,7 @@ import {
     TriangleAlert,
 } from "lucide-react";
 import { useCallback, useState } from "react";
-import { Link, Navigate, useParams } from "react-router";
+import { Link, Navigate, useNavigate, useParams } from "react-router";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { FileMarkdown } from "@/components/file-markdown";
@@ -59,6 +59,7 @@ export function PluginDetailPage() {
   const externalPlugins = useAssistantFeatureFlagStore.use.externalPlugins();
   const assistantId = useActiveAssistantId();
   const { name } = useParams<{ name: string }>();
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [confirmingRemove, setConfirmingRemove] = useState(false);
   const [confirmingUpgrade, setConfirmingUpgrade] = useState(false);
@@ -109,7 +110,13 @@ export function PluginDetailPage() {
   });
 
   const removeMutation = usePluginsByNameDeleteMutation({
-    onSuccess: invalidate,
+    onSuccess: () => {
+      invalidate();
+      // The detail page has nothing left to show once the plugin is gone,
+      // so return to the plugins list rather than stranding the user on a
+      // "We couldn't load this plugin" error.
+      void navigate(routes.plugins);
+    },
   });
 
   const upgradeMutation = usePluginsByNameUpgradePostMutation({


### PR DESCRIPTION
## Prompt / plan
Fix the plugin removal flow to navigate back to the plugins list after successful deletion, preventing the user from being stranded on a stale detail page that would show a "We couldn't load this plugin" error.

## Changes
- Updated `PluginDetailPage` to import and use `useNavigate` from react-router
- Modified the `removeMutation` success callback to navigate to the plugins list route after invalidating queries
- Added comprehensive test coverage for the removal flow via `plugin-detail-page.remove.test.tsx`

The test suite validates that:
1. Clicking Remove and confirming in the dialog triggers the delete mutation
2. The delete mutation is called with correct parameters (assistant ID and plugin name)
3. After successful deletion, the user is navigated to the plugins list rather than remaining on the detail page

## Test plan
Added unit tests in `plugin-detail-page.remove.test.tsx` that exercise the full removal flow: confirming deletion via dialog, verifying the mutation fires with correct parameters, and asserting navigation to the plugins list occurs on success. The test pre-seeds the detail query and stubs SDK calls to avoid network dependencies.

https://claude.ai/code/session_018orYp9axX6wDK1QKCUppW7