### PR TITLE
feat(onboarding): set an explicit title on the research-onboarding conversation

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -16854,6 +16854,12 @@ paths:
                       type: array
                       items:
                         type: string
+                    title:
+                      description:
+                        Explicit title for the conversation minted on this first message. Persisted as a user-set title (never
+                        overwritten by the auto-titler). Used by onboarding flows that mint a conversation behind the
+                        scenes.
+                      type: string
                   required:
                     - tools
                     - tasks

--- a/assistant/src/memory/conversation-key-store.ts
+++ b/assistant/src/memory/conversation-key-store.ts
@@ -12,10 +12,7 @@ import { v4 as uuid } from "uuid";
 
 import { cleanupBootstrapFiles } from "../prompts/bootstrap-cleanup.js";
 import { initConversationDir } from "./conversation-disk-view.js";
-import {
-  AUTO_TITLE_LLM,
-  GENERATING_TITLE,
-} from "./conversation-title-service.js";
+import { GENERATING_TITLE } from "./conversation-title-service.js";
 import { getDb } from "./db-connection.js";
 import { conversationKeys, conversations } from "./schema.js";
 
@@ -219,17 +216,17 @@ export function getOrCreateConversation(
     const conversationId = uuid();
     const customTitle = opts?.title?.trim();
     const title = customTitle || GENERATING_TITLE;
-    // A caller-supplied title is user-set: mark it non-auto (0) so the async
-    // LLM title generator's `canReplaceTitle` check won't overwrite it. With no
-    // custom title, fall back to the auto-generated placeholder flow.
-    const isAutoTitle = customTitle ? 0 : AUTO_TITLE_LLM;
     const memoryScopeId = "default";
 
     tx.insert(conversations)
       .values({
         id: conversationId,
         title,
-        isAutoTitle,
+        // A caller-supplied title is user-set: mark it non-auto (0) so the
+        // async LLM title generator's `canReplaceTitle` check won't overwrite
+        // it. Without one, omit the column so it takes its default
+        // (AUTO_TITLE_LLM) and follows the auto-generated placeholder flow.
+        ...(customTitle ? { isAutoTitle: 0 } : {}),
         createdAt: now,
         updatedAt: now,
         totalInputTokens: 0,

--- a/assistant/src/memory/conversation-key-store.ts
+++ b/assistant/src/memory/conversation-key-store.ts
@@ -12,7 +12,10 @@ import { v4 as uuid } from "uuid";
 
 import { cleanupBootstrapFiles } from "../prompts/bootstrap-cleanup.js";
 import { initConversationDir } from "./conversation-disk-view.js";
-import { GENERATING_TITLE } from "./conversation-title-service.js";
+import {
+  AUTO_TITLE_LLM,
+  GENERATING_TITLE,
+} from "./conversation-title-service.js";
 import { getDb } from "./db-connection.js";
 import { conversationKeys, conversations } from "./schema.js";
 
@@ -135,7 +138,16 @@ export function resolveConversationId(idOrKey: string): string | null {
  */
 export function getOrCreateConversation(
   conversationKey: string,
-  opts?: { conversationType?: "standard" },
+  opts?: {
+    conversationType?: "standard";
+    /**
+     * Caller-supplied title for the conversation, used only when this call
+     * actually creates the row. Treated as a user-set title (`isAutoTitle = 0`)
+     * so the async LLM title generator's safe-overwrite check leaves it
+     * untouched. Ignored when the conversation already exists.
+     */
+    title?: string;
+  },
 ): {
   conversationId: string;
   conversationType: string;
@@ -205,13 +217,19 @@ export function getOrCreateConversation(
 
     const now = Date.now();
     const conversationId = uuid();
-    const title = GENERATING_TITLE;
+    const customTitle = opts?.title?.trim();
+    const title = customTitle || GENERATING_TITLE;
+    // A caller-supplied title is user-set: mark it non-auto (0) so the async
+    // LLM title generator's `canReplaceTitle` check won't overwrite it. With no
+    // custom title, fall back to the auto-generated placeholder flow.
+    const isAutoTitle = customTitle ? 0 : AUTO_TITLE_LLM;
     const memoryScopeId = "default";
 
     tx.insert(conversations)
       .values({
         id: conversationId,
         title,
+        isAutoTitle,
         createdAt: now,
         updatedAt: now,
         totalInputTokens: 0,

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1133,6 +1133,7 @@ export async function handleSendMessage(
       bootstrapTemplate?: string;
       initialMessage?: string;
       skills?: string[];
+      title?: string;
     };
   };
 
@@ -1310,8 +1311,13 @@ export async function handleSendMessage(
         : sourceChannel === "vellum"
           ? crypto.randomUUID()
           : `default:${sourceChannel}:${sourceInterface}`;
+    // An onboarding flow may supply an explicit title for the conversation it
+    // mints behind the scenes (e.g. the research pass) so it isn't left with an
+    // auto-generated title. Applied only when this call creates the row.
+    const onboardingTitle = body.onboarding?.title?.trim() || undefined;
     mapping = getOrCreateConversation(resolvedConversationKey, {
       conversationType: "standard",
+      title: onboardingTitle,
     });
   }
 
@@ -2717,6 +2723,12 @@ export const ROUTES: RouteDefinition[] = [
           bootstrapTemplate: z.string().optional(),
           initialMessage: z.string().optional(),
           skills: z.array(z.string()).optional(),
+          title: z
+            .string()
+            .optional()
+            .describe(
+              "Explicit title for the conversation minted on this first message. Persisted as a user-set title (never overwritten by the auto-titler). Used by onboarding flows that mint a conversation behind the scenes.",
+            ),
         })
         .describe("PreChat onboarding context, sent on the first message only")
         .optional(),

--- a/clients/web/src/domains/chat/api/messages.ts
+++ b/clients/web/src/domains/chat/api/messages.ts
@@ -518,6 +518,8 @@ export async function postChatMessage(
       onboardingDict.initialMessage = normalizedOnboarding.initialMessage;
     if (normalizedOnboarding.skills !== undefined)
       onboardingDict.skills = normalizedOnboarding.skills;
+    if (normalizedOnboarding.title !== undefined)
+      onboardingDict.title = normalizedOnboarding.title;
     body.onboarding = onboardingDict;
   }
   if (normalizedOnboarding) {

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -63,6 +63,8 @@ export function ResearchOnboardingRoute() {
       .filter(Boolean)
       .join(" ");
 
+    const trimmedFirstName = firstName.trim();
+
     const context: PreChatOnboardingContext = {
       // Required handoff fields — no tool/task/tone collection in this flow.
       tools: [],
@@ -72,6 +74,11 @@ export function ResearchOnboardingRoute() {
       ...(occupation.trim() ? { occupation: occupation.trim() } : {}),
       // The auto-sent first message: kick off the research pass.
       initialMessage: buildResearchPrompt({ firstName, lastName, occupation }),
+      // Set an explicit, friendly title on the behind-the-scenes research
+      // conversation so it isn't left with an auto-generated one.
+      title: trimmedFirstName
+        ? `Getting to know ${trimmedFirstName}`
+        : "Getting to know you",
     };
 
     setPendingPreChatContext(context);

--- a/clients/web/src/domains/onboarding/prechat.ts
+++ b/clients/web/src/domains/onboarding/prechat.ts
@@ -53,6 +53,13 @@ export interface PreChatOnboardingContext {
   bootstrapTemplate?: string;
   /** Skills to eagerly load. */
   skills?: string[];
+  /**
+   * Explicit title for the conversation minted on the first message. When set,
+   * the daemon persists it as a user-set title (never overwritten by the
+   * auto-titler). Used by flows like research onboarding that mint a
+   * conversation behind the scenes and don't want an auto-generated title.
+   */
+  title?: string;
 }
 
 export const DEFAULT_PRECHAT_INITIAL_MESSAGE = "Wake up, my friend!";
@@ -267,6 +274,9 @@ function isPreChatOnboardingContext(
   if (candidate.skills !== undefined) {
     if (!Array.isArray(candidate.skills)) return false;
     if (!candidate.skills.every((s) => typeof s === "string")) return false;
+  }
+  if (candidate.title !== undefined && typeof candidate.title !== "string") {
+    return false;
   }
   return true;
 }


### PR DESCRIPTION
## Problem

The behind-the-scenes research conversation minted by the `/onboarding/research` flow was always left with an auto-generated ("ugly") title produced by the async LLM titler. There was no way to set a conversation title at creation time.

## Change

**Daemon — generic capability**
- `getOrCreateConversation()` now accepts an optional `title`. On the create path it uses that title and sets `isAutoTitle = 0` (user-set), so the title generator's `canReplaceTitle()` safe-overwrite check leaves it untouched. No custom title → unchanged placeholder/auto-title flow.
- Added `title` to the `onboarding` object on the `POST /v1/messages` request schema + handler, threaded into `getOrCreateConversation` on the mint path.
- Regenerated `assistant/openapi.yaml`.

**Web — wire it through + use it**
- Added `title?` to `PreChatOnboardingContext` (+ hand-rolled validator and wire serialization in `postChatMessage`).
- The research-onboarding route sets the title to **`Getting to know {firstName}`** (falls back to `Getting to know you` with no first name).

## Why it sticks
A caller-supplied title is persisted with `isAutoTitle = 0`. The async LLM titler's `canReplaceTitle()` only overwrites placeholder/deterministic titles, so an explicit title is never clobbered.

## Verification
- Confirmed the web research flow mints the row via `POST /v1/messages` (server-mint, `conversationId: null`) — not via an earlier SSE-subscribe draft — so the title lands at creation.
- Typecheck clean on daemon + web (web runs codegen first).
- `conversation-key-store` + `conversation-title-service` tests pass (16/16).

## ⚠️ No Linear ticket
This was opened without a Linear ticket per the author's go-ahead. **A ticket should be added before merge** so it auto-links/closes. The macOS `PreChatOnboardingContext` Swift model was intentionally left untouched (this flow is web-only) — flag if parity is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)