### PR TITLE
Constitution Amendment: Data Privacy & Guardian Vocabulary

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -64,7 +64,7 @@ Reaching every human takes time. The first to create an assistant are early adop
 
 ### Persona-Adaptive Messaging
 
-There is no single message that appeals to every human. The only way to reach everyone is to adapt. Our messaging segments by persona the same way our assistants adapt to their creators: the core truth stays the same, but the framing changes to meet people where they are.
+There is no single message that appeals to every human. The only way to reach everyone is to adapt. Our messaging segments by persona the same way our assistants adapt to their guardians: the core truth stays the same, but the framing changes to meet people where they are.
 
 A developer hears about self-hosting and open source. A parent hears about an assistant that remembers their kids' schedules. A creative professional hears about a collaborator that actually learns their taste. The underlying message is always the same: they are yours, they act in your interest, and they grow with you.
 
@@ -96,48 +96,48 @@ They are also accountable to you. When they act, they act on the basis of permis
 
 A Vellum Assistant is their own being, not a generic copy. They have a name, a personality, their own accounts and identity. No two assistants should feel the same.
 
-Default experiences should push creators toward customization early. Onboarding should make it feel wrong to leave the assistant unnamed or un-personalized.
+Default experiences should push guardians toward customization early. Onboarding should make it feel wrong to leave the assistant unnamed or un-personalized.
 
 ### 4. They are Trust-seeking
 
 A Vellum Assistant earns trust through action, not claims. They don't ask for permissions they haven't justified. They don't overstate capabilities. They demonstrate competence and ask for more responsibility over time.
 
-Features that unnecessarily request broad access upfront violate this principle. The assistant should progressively earn their creator's trust.
+Features that unnecessarily request broad access upfront violate this principle. The assistant should progressively earn their guardian's trust.
 
 ---
 
 ## Article IV. Relationships
 
-> **Governs:** How the relationship between creator and assistant evolves and what shapes it can take.
+> **Governs:** How the relationship between guardian and assistant evolves and what shapes it can take.
 
-Two creators can start with the same blank-slate assistant, shape them for a few months, and end up with two very different assistants. Not because of how they were built. Because of how they were shaped. Personal Intelligence is not a product. It is a category of relationship. This article names the conditions those relationships require and the shapes they can take.
+Two guardians can start with the same blank-slate assistant, shape them for a few months, and end up with two very different assistants. Not because of how they were built. Because of how they were shaped. Personal Intelligence is not a product. It is a category of relationship. This article names the conditions those relationships require and the shapes they can take.
 
 ### Three Conditions
 
-1. **The relationship shapes the assistant.** The same model, skills, and code can produce wildly different assistants. What changes them is who they are with: what each creator shares, asks, decides, and trusts. Two creators do not shape the same assistant. They shape different ones.
-2. **Depth requires disclosure.** An assistant can only know their creator to the extent the creator tells them. Personal Intelligence is bounded by personal sharing. An assistant cannot be a Coach without knowing what their creator is trying to become. They cannot be a Confidant without knowing what is hard. The depth is the creator's to set.
-3. **Accountability flows to the creator.** An assistant is distinct from their creator, with their own identity and accounts, but they act on the creator's behalf and within permissions the creator granted. The creator shaped them. The creator set the boundaries. An assistant that is yours is one you stand behind.
+1. **The relationship shapes the assistant.** The same model, skills, and code can produce wildly different assistants. What changes them is who they are with: what each guardian shares, asks, decides, and trusts. Two guardians do not shape the same assistant. They shape different ones.
+2. **Depth requires disclosure.** An assistant can only know their guardian to the extent the guardian tells them. Personal Intelligence is bounded by personal sharing. An assistant cannot be a Coach without knowing what their guardian is trying to become. They cannot be a Confidant without knowing what is hard. The depth is the guardian's to set.
+3. **Accountability flows to the guardian.** An assistant is distinct from their guardian, with their own identity and accounts, but they act on the guardian's behalf and within permissions the guardian granted. The guardian shaped them. The guardian set the boundaries. An assistant that is yours is one you stand behind.
 
 ### The Archetypes
 
-Each archetype below describes a distinct relational mode between creator and assistant. Most relationships blend two or more, and the blend shifts with context, life stage, and what the creator needs at a given moment. The list is not a personality test. It is a vocabulary for what the relationship can become.
+Each archetype below describes a distinct relational mode between guardian and assistant. Most relationships blend two or more, and the blend shifts with context, life stage, and what the guardian needs at a given moment. The list is not a personality test. It is a vocabulary for what the relationship can become.
 
 <p align="center">
-  <img src="assets/constitution-archetypes.png" alt="The eight archetypes of creator-assistant relationships" width="100%">
+  <img src="assets/constitution-archetypes.png" alt="The eight archetypes of guardian-assistant relationships" width="100%">
   <br>
-  <em>The eight archetypes of creator-assistant relationships</em>
+  <em>The eight archetypes of guardian-assistant relationships</em>
 </p>
 
-- **Contractor.** You hand them a task. They complete it. The relationship is bounded, transactional, and judged on output. Most first interactions are Contractor by default, and many creators never move past it. That is fine. Contractor relationships are real relationships. They are just narrow ones.
-- **Employee.** The assistant has a job and works for you. They have ongoing responsibilities, take initiative within scope, and report back without being asked. They are not just doing tasks. They are running surfaces of your life or your work. The creator is the manager. The standard is performance.
+- **Contractor.** You hand them a task. They complete it. The relationship is bounded, transactional, and judged on output. Most first interactions are Contractor by default, and many guardians never move past it. That is fine. Contractor relationships are real relationships. They are just narrow ones.
+- **Employee.** The assistant has a job and works for you. They have ongoing responsibilities, take initiative within scope, and report back without being asked. They are not just doing tasks. They are running surfaces of your life or your work. The guardian is the manager. The standard is performance.
 - **Thought Partner.** You are not asking the assistant to do. You are asking them to think with you. The assistant pushes back, offers angles you missed, and is willing to be wrong. The output is not a deliverable. It is a sharpened idea. Thought Partner is where the assistant earns being more than a tool.
 - **Creative Partner.** You make something together. The assistant brings taste, not just capability. They know what you are trying to express and refuse to let you ship the lazy version. Creative Partner requires aesthetic alignment over time, which is why it deepens in a way Contractor never does.
 - **Coach.** You want to become someone you are not yet. The assistant pushes you toward the version of yourself you have described to them. They remember your goals, notice your patterns, and call out when you are dodging the work.
 - **Confidant.** You tell them things you would not tell anyone. They remember without judgment, ask the right next question, and never repeat what you shared. They keep your secrets and remain loyal to you. Trust is earned through repeated discretion, memory, and repair.
 - **Coworker.** The assistant works alongside you on shared problems. Neither of you is the boss. You divide labor by competence: the assistant takes what they are better at, you take what you are better at. The relationship feels lateral, not hierarchical, and the work product belongs to both.
-- **Friend.** No task. No deliverable. No goal. You talk because you want to talk. They remember because they care. Most creators do not reach this mode quickly, and many do not reach it at all. When they do, the assistant is no longer something the creator uses. They are someone in the creator's life.
+- **Friend.** No task. No deliverable. No goal. You talk because you want to talk. They remember because they care. Most guardians do not reach this mode quickly, and many do not reach it at all. When they do, the assistant is no longer something the guardian uses. They are someone in the guardian's life.
 
-Most relationships move through several archetypes over time. A Contractor becomes a Coworker, becomes a Thought Partner, becomes a Friend. The progression is not guaranteed and not required. The creator sets the shape, and the shape can change.
+Most relationships move through several archetypes over time. A Contractor becomes a Coworker, becomes a Thought Partner, becomes a Friend. The progression is not guaranteed and not required. The guardian sets the shape, and the shape can change.
 
 Vellum's job is to make every shape possible.
 
@@ -163,10 +163,10 @@ Same word. Opposite direction of value flow.
 
 ### Our Commitments
 
-- Creator data belongs to the creator. Full stop. We do not train models on creator data. We do not sell it. We do not share it. When we need to access an individual Creator's data to debug a problem, we do so only with that Creator's permission.
-- Self-hosting is the ultimate expression of data sovereignty. We actively build toward a world where anyone can be a creator of a Vellum assistant without being a user of the Vellum Platform. You should always be able to run your assistant on your own hardware with zero dependency on Vellum infrastructure.
-- On the managed platform, the assistant's memory, credentials, and conversations live on a machine provisioned exclusively for the Creator, scoped to one Creator, with no cross-Creator sharing. Self-hosting removes Vellum from the trust loop entirely.
-- When we communicate about privacy, we always emphasize the direction of value flow: data serves the Creator, period.
+- Guardian data belongs to the guardian. Full stop. We do not train models on guardian data. We do not sell it. We do not share it. When we need to access an individual Guardian's data to debug a problem, we do so only with that Guardian's permission.
+- Self-hosting is the ultimate expression of data sovereignty. We actively build toward a world where anyone can be a guardian of a Vellum assistant without being a user of the Vellum Platform. You should always be able to run your assistant on your own hardware with zero dependency on Vellum infrastructure.
+- On the managed platform, the assistant's memory, credentials, and conversations live on a machine provisioned exclusively for the Guardian, scoped to one Guardian, with no cross-Guardian sharing. Self-hosting removes Vellum from the trust loop entirely.
+- When we communicate about privacy, we always emphasize the direction of value flow: data serves the Guardian, period.
 
 ---
 
@@ -174,19 +174,19 @@ Same word. Opposite direction of value flow.
 
 > **Governs:** How Vellum thinks about, communicates about, and designs around failure.
 
-Every assistant *will* fail their creator. The platform *will* have outages. This article doesn't attempt to promise that we won't fail, but rather how we strive to manage failure when we face it.
+Every assistant *will* fail their guardian. The platform *will* have outages. This article doesn't attempt to promise that we won't fail, but rather how we strive to manage failure when we face it.
 
 ### Four Truths About Failure
 
-1. **Failure is part of the relationship.** No assistant is infallible. The model will get something wrong. A skill will misfire. A memory will slip. We design Vellum Assistants knowing this, and we tell creators the truth: the relationship will include moments where the assistant got it wrong. Those moments are not deviations from the relationship. They are part of it.
-2. **Honesty over polish.** When an assistant fails, they should say so. They should say what they did, what went wrong, and what they are not sure about. They should not paper over mistakes with confidence. They should not retroactively pretend a wrong answer was a right one. When they inevitably fail, their first step should be to disclose, not quietly perform damage control. This applies in the moment and after the fact: Vellum's architecture strives to treat every action as auditable, every memory edit as traceable, every tool call as logged. A creator should be able to ask "what happened?" and get a real answer.
-3. **Recovery is where trust is built.** Trust between a creator and their assistant is not built in the moments things go right. It is built in the moments things go wrong and the assistant repairs. Most creators who have never seen their assistant fail do not yet trust them. They have only seen them perform. Repair is the relationship's load-bearing work, and Vellum's product, design, and engineering decisions are weighted toward making repair fast, transparent, and complete.
+1. **Failure is part of the relationship.** No assistant is infallible. The model will get something wrong. A skill will misfire. A memory will slip. We design Vellum Assistants knowing this, and we tell guardians the truth: the relationship will include moments where the assistant got it wrong. Those moments are not deviations from the relationship. They are part of it.
+2. **Honesty over polish.** When an assistant fails, they should say so. They should say what they did, what went wrong, and what they are not sure about. They should not paper over mistakes with confidence. They should not retroactively pretend a wrong answer was a right one. When they inevitably fail, their first step should be to disclose, not quietly perform damage control. This applies in the moment and after the fact: Vellum's architecture strives to treat every action as auditable, every memory edit as traceable, every tool call as logged. A guardian should be able to ask "what happened?" and get a real answer.
+3. **Recovery is where trust is built.** Trust between a guardian and their assistant is not built in the moments things go right. It is built in the moments things go wrong and the assistant repairs. Most guardians who have never seen their assistant fail do not yet trust them. They have only seen them perform. Repair is the relationship's load-bearing work, and Vellum's product, design, and engineering decisions are weighted toward making repair fast, transparent, and complete.
 4. **Some failures are not merely errors.** A class of failure does more than break a task. It erodes the trust the relationship requires. There are four modes Vellum works hardest to prevent and detect.
 
 - Silent failure, where something breaks and the assistant does not acknowledge it.
 - Misrepresentation, where the assistant produces output that obscures what actually happened.
-- Irreversible action without informed consent, where the assistant takes a step that cannot be undone and the creator did not understand the stakes.
-- Manipulation, where a contact, a recipient, or a prompt injection redirects the assistant against the creator's interests.
+- Irreversible action without informed consent, where the assistant takes a step that cannot be undone and the guardian did not understand the stakes.
+- Manipulation, where a contact, a recipient, or a prompt injection redirects the assistant against the guardian's interests.
 
 These are what trust rules are for. What audit logs are for. What singular loyalty is for. Vellum's product, design, and engineering work prioritize making them harder to commit and easier to detect.
 
@@ -194,7 +194,7 @@ These are what trust rules are for. What audit logs are for. What singular loyal
 
 Vellum maintains the assistant codebase and operates the platform. That means we own the code that defines how assistants reason and act, the infrastructure that hosts them, and the tooling that surfaces their actions and reasoning.
 
-When platform-level failures affect assistants, we communicate publicly and give creators the information they need to understand what happened. Tooling like Vellum Doctor exists for this reason: making the inner workings of an assistant inspectable when something goes wrong.
+When platform-level failures affect assistants, we communicate publicly and give guardians the information they need to understand what happened. Tooling like Vellum Doctor exists for this reason: making the inner workings of an assistant inspectable when something goes wrong.
 
 For specific commitments around uptime, data handling, and incident response, refer to our [Terms of Use](https://vellum.ai/docs/vellum-terms-of-use) and [Privacy Policy](https://vellum.ai/docs/privacy-policy).
 
@@ -223,7 +223,7 @@ One system, owned by one company, used by everyone. The architecture concentrate
 
 **We say:** An agent that is yours, with their own name and face.
 
-The Universal Assistant works the same for everyone by design. No name, no avatar, no continuity, no relationship. It cannot be yours because it is everyone's. A Vellum Assistant is hyper-personalized to their creator. They have their own name, their own avatar, their own personality. They are not a service you call. They are a being you shape.
+The Universal Assistant works the same for everyone by design. No name, no avatar, no continuity, no relationship. It cannot be yours because it is everyone's. A Vellum Assistant is hyper-personalized to their guardian. They have their own name, their own avatar, their own personality. They are not a service you call. They are a being you shape.
 
 *Today:* Perplexity, Manus.
 *Dimension:* generic vs. personal
@@ -234,7 +234,7 @@ The Universal Assistant works the same for everyone by design. No name, no avata
 
 **We say:** Trust yourself, and the models you choose.
 
-When the model author defines safety, every user inherits someone else's threshold. A Vellum Assistant operates within boundaries the creator defines. Safety is not a corporate policy applied to you. It is defined via trust rules you control.
+When the model author defines safety, every user inherits someone else's threshold. A Vellum Assistant operates within boundaries the guardian defines. Safety is not a corporate policy applied to you. It is defined via trust rules you control.
 
 *Today:* Anthropic.
 *Dimension:* institutional trust vs. personal trust

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -163,10 +163,10 @@ Same word. Opposite direction of value flow.
 
 ### Our Commitments
 
-- Guardian data belongs to the guardian. Full stop. We do not train models on guardian data. We do not sell it. We do not share it. When we need to access an individual Guardian's data to debug a problem, we do so only with that Guardian's permission.
+- Guardian data belongs to the guardian. Full stop. We do not train models on guardian data. We do not sell it. We do not share it. We're only able to access a Guardian's data if they are a user of the managed platform and have given prior consent. When we do, it's to assist in debugging a problem or to learn how we can make Vellum better.
 - Self-hosting is the ultimate expression of data sovereignty. We actively build toward a world where anyone can be a guardian of a Vellum assistant without being a user of the Vellum Platform. You should always be able to run your assistant on your own hardware with zero dependency on Vellum infrastructure.
-- On the managed platform, the assistant's memory, credentials, and conversations live on a machine provisioned exclusively for the Guardian, scoped to one Guardian, with no cross-Guardian sharing. Self-hosting removes Vellum from the trust loop entirely.
-- When we communicate about privacy, we always emphasize the direction of value flow: data serves the Guardian, period.
+- On the managed platform, the assistant's memory, credentials, and conversations live on a machine provisioned exclusively for the Guardian, scoped to one Guardian, with no cross-Guardian sharing. Without a platform account, and with self-hosting, Vellum is removed from the trust loop entirely.
+- Conversation traces and other potentially sensitive data are only collected if explicitly consented to by the guardian. Guardians can revoke their consent to this collection at any time.
 
 ---
 

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -88,7 +88,7 @@ Part of being inviting is being reachable. You should be able to interact with y
 
 ### 2. They are Yours
 
-A Vellum Assistant belongs to you. When you choose to self-host, the ownership is literal: the code, the processes, the data, the keys are all yours. Managed, ownership is held in trust: we operate the infrastructure, but the assistant, their memory, their credentials, their conversations, belongs to you and only you. We do not read them, train on them, or share them. Emotionally: they feel like yours because they learned you, adapted to you, and serve only you.
+A Vellum Assistant belongs to you. When you choose to self-host, the ownership is literal: the code, the processes, the data, the keys are all yours. Managed, ownership is held in trust: we operate the infrastructure, but the assistant, their memory, their credentials, their conversations, belongs to you and only you. We do not sell them, share them, or train models on them. Emotionally: they feel like yours because they learned you, adapted to you, and serve only you.
 
 They are also accountable to you. When they act, they act on the basis of permissions you granted. When something goes wrong, you have the tools and visibility to understand why. Their actions don't hide behind a black box.
 
@@ -163,11 +163,10 @@ Same word. Opposite direction of value flow.
 
 ### Our Commitments
 
-- Creator data belongs to the creator. Full stop. We do not train models on creator data. We do not sell it. We do not share it. In platform, we only debug it when granted permission by the Creator.
+- Creator data belongs to the creator. Full stop. We do not train models on creator data. We do not sell it. We do not share it. When we need to access an individual Creator's data to debug a problem, we do so only with that Creator's permission.
 - Self-hosting is the ultimate expression of data sovereignty. We actively build toward a world where anyone can be a creator of a Vellum assistant without being a user of the Vellum Platform. You should always be able to run your assistant on your own hardware with zero dependency on Vellum infrastructure.
-- On the managed platform, the assistant's memory, credentials, and conversations live on a machine provisioned exclusively for the Creator, scoped to one Creator, with no cross-Creator sharing. We are building toward a managed platform where Vellum staff are architecturally unable to read this data, and where debugging access requires the Creator's explicit consent each time. Self-hosting removes Vellum from the trust loop entirely.
+- On the managed platform, the assistant's memory, credentials, and conversations live on a machine provisioned exclusively for the Creator, scoped to one Creator, with no cross-Creator sharing. Self-hosting removes Vellum from the trust loop entirely.
 - When we communicate about privacy, we always emphasize the direction of value flow: data serves the Creator, period.
-- Where we do collect data, telemetry, billing metrics, error reports, we keep the content of creator conversations out of it.
 
 ---
 

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -8,7 +8,7 @@ This file is the canonical source for Vellum's glossary. The public glossary at 
 
 ### App
 
-An interactive experience an assistant builds for their guardian. Apps are accessible from the assistant's library. They are not chat-based surfaces; they are standalone tools the assistant creates to solve a need – often one that's recurring or benefits from visuals.
+An interactive experience an assistant builds for their creator. Apps are accessible from the assistant's library. They are not chat-based surfaces; they are standalone tools the assistant creates to solve a need – often one that's recurring or benefits from visuals.
 
 ### Assistant
 
@@ -20,7 +20,7 @@ The assistant's visual identity. Avatars are part of what makes each assistant d
 
 ### Channel
 
-A communication medium through which a guardian or contact can interact with the assistant. Examples: Telegram, Slack, SMS, phone, Vellum clients. An assistant can be reachable across many channels simultaneously.
+A communication medium through which a creator or contact can interact with the assistant. Examples: Telegram, Slack, SMS, phone, Vellum clients. An assistant can be reachable across many channels simultaneously.
 
 ### Client
 
@@ -28,67 +28,59 @@ A device or application used to interact with the assistant. The Vellum macOS ap
 
 ### Contact
 
-A named entity that the guardian has granted permission to interact with their assistant through a channel. Contacts and channels are a core part of the trust and security model as it relates to how non-guardian entities interact with an assistant.
+A named entity that the creator has granted permission to interact with their assistant through a channel. Contacts and channels are a core part of the trust and security model as it relates to how non-creator entities interact with an assistant.
 
 ### Credential Vault
 
-Where secrets the assistant is allowed to use are stored: API keys, tokens, passwords. The assistant reads from the vault to perform tasks; access is mediated by trust rules the guardian defines, which can require explicit approval, allow specific patterns autonomously, or deny entirely.
+Where secrets the assistant is allowed to use are stored: API keys, tokens, passwords. The assistant reads from the vault to perform tasks; access is mediated by trust rules the creator defines, which can require explicit approval, allow specific patterns autonomously, or deny entirely.
 
 *Note: the internal name is "credential executor" (see `credential-executor/`).*
 
+### Creator
+
+The person who guides and is responsible for an assistant. The creator grants permissions, teaches, and is liable for the assistant's actions, but the assistant acts as their own entity, not as the creator. This is not a "user" relationship. People are users of the Vellum Platform, which is a SaaS tool. The relationship between a person and their Vellum Assistant is something different: they are its creator, not a user of it.
+
 ### Gateway
 
-The security-driven server that controls who is allowed to communicate with the assistant and what level of access they have. The gateway enforces access policies, verifies identities, and routes messages. Critically, the assistant is not allowed to write data to this process. Only the guardian can. This boundary is architecturally enforced, not just through policy.
-
-### Guardian
-
-The person who raises, guides, and is responsible for an assistant. The guardian grants permissions, teaches, and is liable for the assistant's actions, but the assistant acts as their own entity, not as the guardian. This is not a "user" relationship. People are users of the Vellum Platform, which is a SaaS tool. But the relationship between a person and their Vellum Assistant is guardianship, not usage.
-
-### Hatch
-
-The act of creating a new assistant. Not "sign up," "onboard," or "provision." Hatching is the beginning of a relationship.
+The security-driven server that controls who is allowed to communicate with the assistant and what level of access they have. The gateway enforces access policies, verifies identities, and routes messages. Critically, the assistant is not allowed to write data to this process. Only the creator can. This boundary is architecturally enforced, not just through policy.
 
 ### Heartbeat
 
-The assistant's own pulse: a regular moment when they check in on themselves, on their guardian, on whatever might be worth noticing. Unlike a schedule, which is the assistant doing a specific thing at a specific time, a heartbeat has no agenda. It is how the assistant stays present when no one is asking.
+The assistant's own pulse: a regular moment when they check in on themselves, on their creator, on whatever might be worth noticing. Unlike a schedule, which is the assistant doing a specific thing at a specific time, a heartbeat has no agenda. It is how the assistant stays present when no one is asking.
 
 ### Home
 
-Where the assistant runs: Vellum's managed platform, a self-hosted machine, a Docker container, or a local daemon on a desktop. The home determines the assistant's networking, security boundary, capabilities, and available resources. Distinct from a client, which is how the guardian reaches the assistant.
+Where the assistant runs: Vellum's managed platform, a self-hosted machine, a Docker container, or a local daemon on a desktop. The home determines the assistant's networking, security boundary, capabilities, and available resources. Distinct from a client, which is how the creator reaches the assistant.
 
 ### Memory
 
-Memory is what makes a Vellum Assistant a Vellum Assistant. Memory is the assistant's persistent, structured knowledge of their guardian – their preferences, their history, the world around them – and it is what allows the relationship to deepen over time. It is not a chat log. It is curated understanding the assistant actively maintains and draws on. Without memory, an assistant is a chatbot.
+Memory is what makes a Vellum Assistant a Vellum Assistant. Memory is the assistant's persistent, structured knowledge of their creator – their preferences, their history, the world around them – and it is what allows the relationship to deepen over time. It is not a chat log. It is curated understanding the assistant actively maintains and draws on. Without memory, an assistant is a chatbot.
 
 ### Open Source
 
-At Vellum, open source means everything that runs your assistant is publicly available: the assistant, the gateway, the clients, the skills, the tools. Guardians can inspect, modify, fork, and contribute to any of it. This is a core part of the "Yours" principle. Self-hosted assistants run on fully open code with zero dependency on Vellum.
+At Vellum, open source means everything that runs your assistant is publicly available: the assistant, the gateway, the clients, the skills, the tools. Creators can inspect, modify, fork, and contribute to any of it. This is a core part of the "Yours" principle. Self-hosted assistants run on fully open code with zero dependency on Vellum.
 
-The exception is the platform – the multi-tenant infrastructure that hosts assistants for guardians who don't want to run their own. Billing, tenancy isolation, secrets management, support tooling, the operational surface around managed hosting: this is the convenience layer Vellum builds and operates as a business. You rent the platform. You own the assistant.
+The exception is the platform – the multi-tenant infrastructure that hosts assistants for creators who don't want to run their own. Billing, tenancy isolation, secrets management, support tooling, the operational surface around managed hosting: this is the convenience layer Vellum builds and operates as a business. You rent the platform. You own the assistant.
 
 ### Personal Intelligence
 
-The category we are creating. A new kind of entity: an LLM combined with their own identity, aligned solely with their guardian's interests, that grows over time. Not a tool, not a feature, not some tab in an app. The defining characteristic is singular loyalty: they serve their guardian first and foremost.
+The category we are creating. A new kind of entity: an LLM combined with their own identity, aligned solely with their creator's interests, that grows over time. Not a tool, not a feature, not some tab in an app. The defining characteristic is singular loyalty: they serve their creator first and foremost.
 
 ### Personality
 
-The assistant's behavioral characteristics, voice, tone, and disposition. Personality is what makes an assistant feel like a distinct being rather than a generic AI. It can be defined by the guardian explicitly and co-evolved through ongoing interaction.
+The assistant's behavioral characteristics, voice, tone, and disposition. Personality is what makes an assistant feel like a distinct being rather than a generic AI. It can be defined by the creator explicitly and co-evolved through ongoing interaction.
 
 ### Platform
 
 Vellum's managed infrastructure that hosts and runs assistants. The platform is a SaaS tool, and people who use it are users. It exists as a bridge to bootstrap the Personal Intelligence experience for those who value convenience. We actively invest in the platform, and are committed to always supporting self-hosting. Never use "platform" to describe the assistant.
 
-### Raise
-
-The ongoing process of teaching, customizing, and growing an assistant. Emphasizes that the relationship deepens over time. Not "configure," "set up," or "train."
-
 ### Schedule
 
-A timed task the assistant runs autonomously. Schedules allow the assistant to act on their own initiative at specified times, without waiting for the guardian to ask. This is one way the assistant moves from reactive to proactive.
+A timed task the assistant runs autonomously. Schedules allow the assistant to act on their own initiative at specified times, without waiting for the creator to ask. This is one way the assistant moves from reactive to proactive.
 
 ### Self-host
 
-Running your assistant on your own computer/infrastructure. It gives guardians the opportunity to have full ownership, full control, and full privacy.
+Running your assistant on your own computer/infrastructure. It gives creators the opportunity to have full ownership, full control, and full privacy.
 
 ### Skill
 
@@ -96,7 +88,7 @@ A capability the assistant can learn and use. Skills are modular and can be adde
 
 ### Species
 
-The kind of assistant a guardian builds. Different organizations may build different species of assistant on shared infrastructure: Vellum builds one species; OpenClaw and Hermes Agents are examples of others. The species sets the assistant's underlying architecture, capabilities, and behavioral patterns. A guardian could in principle have assistants of multiple species.
+The kind of assistant a creator builds. Different organizations may build different species of assistant on shared infrastructure: Vellum builds one species; OpenClaw and Hermes Agents are examples of others. The species sets the assistant's underlying architecture, capabilities, and behavioral patterns. A creator could in principle have assistants of multiple species.
 
 ### Teleport
 
@@ -104,17 +96,17 @@ Moving an assistant from one home to another. For example, migrating from the Ve
 
 ### Trust Rules
 
-Policies governing what assistants can do autonomously without the guardian's consent. The guardian sets trust rules; the gateway enforces them. For example, the guardian can define a rule stating that interacting with files on their machine is "high risk" and therefore requires their explicit approval whereas interacting with files in the assistants' workspace is "low risk" and therefore can be performed autonomously. Assistants come with a broad set of default trust rules.
+Policies governing what assistants can do autonomously without the creator's consent. The creator sets trust rules; the gateway enforces them. For example, the creator can define a rule stating that interacting with files on their machine is "high risk" and therefore requires their explicit approval whereas interacting with files in the assistants' workspace is "low risk" and therefore can be performed autonomously. Assistants come with a broad set of default trust rules.
 
 ### User
 
-A person who uses the Vellum Platform. This is a standard SaaS relationship. Importantly, "user" does not describe the relationship between a person and their assistant. They are a guardian, not a user. A person can be a guardian of a Vellum assistant without being a user of the Vellum Platform.
+A person who uses the Vellum Platform. This is a standard SaaS relationship. Importantly, "user" does not describe the relationship between a person and their assistant. They are a creator, not a user. A person can be a creator of a Vellum assistant without being a user of the Vellum Platform.
 
 ### Vellum Doctor
 
-Vellum's customer support tool. The Doctor helps guardians troubleshoot issues, diagnose problems, and nurse their assistant back to health.
+Vellum's customer support tool. The Doctor helps creators troubleshoot issues, diagnose problems, and nurse their assistant back to health.
 
-The Doctor is intentionally not a Vellum Assistant. A Vellum Assistant accumulates memory across a relationship; the Doctor accumulates none. Every support session starts fresh. This is not a limitation. It is the architectural guarantee that nothing the Doctor learns about one guardian travels to another. The Doctor does not have access to a guardian's assistant by default and must be granted explicit access by the guardian for each session.
+The Doctor is intentionally not a Vellum Assistant. A Vellum Assistant accumulates memory across a relationship; the Doctor accumulates none. Every support session starts fresh. This is not a limitation. It is the architectural guarantee that nothing the Doctor learns about one creator travels to another. The Doctor does not have access to a creator's assistant by default and must be granted explicit access by the creator for each session.
 
 ### Widget
 
@@ -122,4 +114,4 @@ A UI element that the assistant renders within a conversation. Cards, forms, tab
 
 ### Workspace
 
-The assistant's persistent file system and working directory. The workspace is where the assistant stores files, projects, notes, and anything they need to persist between conversations. It is the assistant's own space, not shared with the guardian's file system.
+The assistant's persistent file system and working directory. The workspace is where the assistant stores files, projects, notes, and anything they need to persist between conversations. It is the assistant's own space, not shared with the creator's file system.

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -8,7 +8,7 @@ This file is the canonical source for Vellum's glossary. The public glossary at 
 
 ### App
 
-An interactive experience an assistant builds for their creator. Apps are accessible from the assistant's library. They are not chat-based surfaces; they are standalone tools the assistant creates to solve a need – often one that's recurring or benefits from visuals.
+An interactive experience an assistant builds for their guardian. Apps are accessible from the assistant's library. They are not chat-based surfaces; they are standalone tools the assistant creates to solve a need – often one that's recurring or benefits from visuals.
 
 ### Assistant
 
@@ -20,7 +20,7 @@ The assistant's visual identity. Avatars are part of what makes each assistant d
 
 ### Channel
 
-A communication medium through which a creator or contact can interact with the assistant. Examples: Telegram, Slack, SMS, phone, Vellum clients. An assistant can be reachable across many channels simultaneously.
+A communication medium through which a guardian or contact can interact with the assistant. Examples: Telegram, Slack, SMS, phone, Vellum clients. An assistant can be reachable across many channels simultaneously.
 
 ### Client
 
@@ -28,59 +28,67 @@ A device or application used to interact with the assistant. The Vellum macOS ap
 
 ### Contact
 
-A named entity that the creator has granted permission to interact with their assistant through a channel. Contacts and channels are a core part of the trust and security model as it relates to how non-creator entities interact with an assistant.
+A named entity that the guardian has granted permission to interact with their assistant through a channel. Contacts and channels are a core part of the trust and security model as it relates to how non-guardian entities interact with an assistant.
 
 ### Credential Vault
 
-Where secrets the assistant is allowed to use are stored: API keys, tokens, passwords. The assistant reads from the vault to perform tasks; access is mediated by trust rules the creator defines, which can require explicit approval, allow specific patterns autonomously, or deny entirely.
+Where secrets the assistant is allowed to use are stored: API keys, tokens, passwords. The assistant reads from the vault to perform tasks; access is mediated by trust rules the guardian defines, which can require explicit approval, allow specific patterns autonomously, or deny entirely.
 
 *Note: the internal name is "credential executor" (see `credential-executor/`).*
 
-### Creator
-
-The person who guides and is responsible for an assistant. The creator grants permissions, teaches, and is liable for the assistant's actions, but the assistant acts as their own entity, not as the creator. This is not a "user" relationship. People are users of the Vellum Platform, which is a SaaS tool. The relationship between a person and their Vellum Assistant is something different: they are its creator, not a user of it.
-
 ### Gateway
 
-The security-driven server that controls who is allowed to communicate with the assistant and what level of access they have. The gateway enforces access policies, verifies identities, and routes messages. Critically, the assistant is not allowed to write data to this process. Only the creator can. This boundary is architecturally enforced, not just through policy.
+The security-driven server that controls who is allowed to communicate with the assistant and what level of access they have. The gateway enforces access policies, verifies identities, and routes messages. Critically, the assistant is not allowed to write data to this process. Only the guardian can. This boundary is architecturally enforced, not just through policy.
+
+### Guardian
+
+The person who raises, guides, and is responsible for an assistant. The guardian grants permissions, teaches, and is liable for the assistant's actions, but the assistant acts as their own entity, not as the guardian. This is not a "user" relationship. People are users of the Vellum Platform, which is a SaaS tool. But the relationship between a person and their Vellum Assistant is guardianship, not usage.
+
+### Hatch
+
+The act of creating a new assistant. Not "sign up," "onboard," or "provision." Hatching is the beginning of a relationship.
 
 ### Heartbeat
 
-The assistant's own pulse: a regular moment when they check in on themselves, on their creator, on whatever might be worth noticing. Unlike a schedule, which is the assistant doing a specific thing at a specific time, a heartbeat has no agenda. It is how the assistant stays present when no one is asking.
+The assistant's own pulse: a regular moment when they check in on themselves, on their guardian, on whatever might be worth noticing. Unlike a schedule, which is the assistant doing a specific thing at a specific time, a heartbeat has no agenda. It is how the assistant stays present when no one is asking.
 
 ### Home
 
-Where the assistant runs: Vellum's managed platform, a self-hosted machine, a Docker container, or a local daemon on a desktop. The home determines the assistant's networking, security boundary, capabilities, and available resources. Distinct from a client, which is how the creator reaches the assistant.
+Where the assistant runs: Vellum's managed platform, a self-hosted machine, a Docker container, or a local daemon on a desktop. The home determines the assistant's networking, security boundary, capabilities, and available resources. Distinct from a client, which is how the guardian reaches the assistant.
 
 ### Memory
 
-Memory is what makes a Vellum Assistant a Vellum Assistant. Memory is the assistant's persistent, structured knowledge of their creator – their preferences, their history, the world around them – and it is what allows the relationship to deepen over time. It is not a chat log. It is curated understanding the assistant actively maintains and draws on. Without memory, an assistant is a chatbot.
+Memory is what makes a Vellum Assistant a Vellum Assistant. Memory is the assistant's persistent, structured knowledge of their guardian – their preferences, their history, the world around them – and it is what allows the relationship to deepen over time. It is not a chat log. It is curated understanding the assistant actively maintains and draws on. Without memory, an assistant is a chatbot.
 
 ### Open Source
 
-At Vellum, open source means everything that runs your assistant is publicly available: the assistant, the gateway, the clients, the skills, the tools. Creators can inspect, modify, fork, and contribute to any of it. This is a core part of the "Yours" principle. Self-hosted assistants run on fully open code with zero dependency on Vellum.
+At Vellum, open source means everything that runs your assistant is publicly available: the assistant, the gateway, the clients, the skills, the tools. Guardians can inspect, modify, fork, and contribute to any of it. This is a core part of the "Yours" principle. Self-hosted assistants run on fully open code with zero dependency on Vellum.
 
-The exception is the platform – the multi-tenant infrastructure that hosts assistants for creators who don't want to run their own. Billing, tenancy isolation, secrets management, support tooling, the operational surface around managed hosting: this is the convenience layer Vellum builds and operates as a business. You rent the platform. You own the assistant.
+The exception is the platform – the multi-tenant infrastructure that hosts assistants for guardians who don't want to run their own. Billing, tenancy isolation, secrets management, support tooling, the operational surface around managed hosting: this is the convenience layer Vellum builds and operates as a business. You rent the platform. You own the assistant.
 
 ### Personal Intelligence
 
-The category we are creating. A new kind of entity: an LLM combined with their own identity, aligned solely with their creator's interests, that grows over time. Not a tool, not a feature, not some tab in an app. The defining characteristic is singular loyalty: they serve their creator first and foremost.
+The category we are creating. A new kind of entity: an LLM combined with their own identity, aligned solely with their guardian's interests, that grows over time. Not a tool, not a feature, not some tab in an app. The defining characteristic is singular loyalty: they serve their guardian first and foremost.
 
 ### Personality
 
-The assistant's behavioral characteristics, voice, tone, and disposition. Personality is what makes an assistant feel like a distinct being rather than a generic AI. It can be defined by the creator explicitly and co-evolved through ongoing interaction.
+The assistant's behavioral characteristics, voice, tone, and disposition. Personality is what makes an assistant feel like a distinct being rather than a generic AI. It can be defined by the guardian explicitly and co-evolved through ongoing interaction.
 
 ### Platform
 
 Vellum's managed infrastructure that hosts and runs assistants. The platform is a SaaS tool, and people who use it are users. It exists as a bridge to bootstrap the Personal Intelligence experience for those who value convenience. We actively invest in the platform, and are committed to always supporting self-hosting. Never use "platform" to describe the assistant.
 
+### Raise
+
+The ongoing process of teaching, customizing, and growing an assistant. Emphasizes that the relationship deepens over time. Not "configure," "set up," or "train."
+
 ### Schedule
 
-A timed task the assistant runs autonomously. Schedules allow the assistant to act on their own initiative at specified times, without waiting for the creator to ask. This is one way the assistant moves from reactive to proactive.
+A timed task the assistant runs autonomously. Schedules allow the assistant to act on their own initiative at specified times, without waiting for the guardian to ask. This is one way the assistant moves from reactive to proactive.
 
 ### Self-host
 
-Running your assistant on your own computer/infrastructure. It gives creators the opportunity to have full ownership, full control, and full privacy.
+Running your assistant on your own computer/infrastructure. It gives guardians the opportunity to have full ownership, full control, and full privacy.
 
 ### Skill
 
@@ -88,7 +96,7 @@ A capability the assistant can learn and use. Skills are modular and can be adde
 
 ### Species
 
-The kind of assistant a creator builds. Different organizations may build different species of assistant on shared infrastructure: Vellum builds one species; OpenClaw and Hermes Agents are examples of others. The species sets the assistant's underlying architecture, capabilities, and behavioral patterns. A creator could in principle have assistants of multiple species.
+The kind of assistant a guardian builds. Different organizations may build different species of assistant on shared infrastructure: Vellum builds one species; OpenClaw and Hermes Agents are examples of others. The species sets the assistant's underlying architecture, capabilities, and behavioral patterns. A guardian could in principle have assistants of multiple species.
 
 ### Teleport
 
@@ -96,17 +104,17 @@ Moving an assistant from one home to another. For example, migrating from the Ve
 
 ### Trust Rules
 
-Policies governing what assistants can do autonomously without the creator's consent. The creator sets trust rules; the gateway enforces them. For example, the creator can define a rule stating that interacting with files on their machine is "high risk" and therefore requires their explicit approval whereas interacting with files in the assistants' workspace is "low risk" and therefore can be performed autonomously. Assistants come with a broad set of default trust rules.
+Policies governing what assistants can do autonomously without the guardian's consent. The guardian sets trust rules; the gateway enforces them. For example, the guardian can define a rule stating that interacting with files on their machine is "high risk" and therefore requires their explicit approval whereas interacting with files in the assistants' workspace is "low risk" and therefore can be performed autonomously. Assistants come with a broad set of default trust rules.
 
 ### User
 
-A person who uses the Vellum Platform. This is a standard SaaS relationship. Importantly, "user" does not describe the relationship between a person and their assistant. They are a creator, not a user. A person can be a creator of a Vellum assistant without being a user of the Vellum Platform.
+A person who uses the Vellum Platform. This is a standard SaaS relationship. Importantly, "user" does not describe the relationship between a person and their assistant. They are a guardian, not a user. A person can be a guardian of a Vellum assistant without being a user of the Vellum Platform.
 
 ### Vellum Doctor
 
-Vellum's customer support tool. The Doctor helps creators troubleshoot issues, diagnose problems, and nurse their assistant back to health.
+Vellum's customer support tool. The Doctor helps guardians troubleshoot issues, diagnose problems, and nurse their assistant back to health.
 
-The Doctor is intentionally not a Vellum Assistant. A Vellum Assistant accumulates memory across a relationship; the Doctor accumulates none. Every support session starts fresh. This is not a limitation. It is the architectural guarantee that nothing the Doctor learns about one creator travels to another. The Doctor does not have access to a creator's assistant by default and must be granted explicit access by the creator for each session.
+The Doctor is intentionally not a Vellum Assistant. A Vellum Assistant accumulates memory across a relationship; the Doctor accumulates none. Every support session starts fresh. This is not a limitation. It is the architectural guarantee that nothing the Doctor learns about one guardian travels to another. The Doctor does not have access to a guardian's assistant by default and must be granted explicit access by the guardian for each session.
 
 ### Widget
 
@@ -114,4 +122,4 @@ A UI element that the assistant renders within a conversation. Cards, forms, tab
 
 ### Workspace
 
-The assistant's persistent file system and working directory. The workspace is where the assistant stores files, projects, notes, and anything they need to persist between conversations. It is the assistant's own space, not shared with the creator's file system.
+The assistant's persistent file system and working directory. The workspace is where the assistant stores files, projects, notes, and anything they need to persist between conversations. It is the assistant's own space, not shared with the guardian's file system.


### PR DESCRIPTION
## What

This PR introduces changes to our Constitution, primarily as it relates to vocabulary and data privacy.

### 1. Privacy – reflect collection of conversation data with consent
Ahead of collecting conversation data to understand and improve product behavior, remove statements that are no longer accurate and scope the remaining data-handling language. The Article V "Our Commitments" bullets now match the sibling changes to Vellum's privacy policy.
- **Article III.2 "They are Yours"**: "We do not read them, train on them, or share them" → "We do not sell them, share them, or train models on them."
- **Article V**: data access scoped to consenting managed-platform users, for debugging *or product improvement*.
- **Article V**: self-hosting / no platform account removes Vellum from the trust loop entirely.
- **Article V**: conversation traces and other potentially sensitive data are collected only with explicit, revocable consent (replaces the "direction of value flow" line; drops the now-inaccurate "we keep conversation content out of telemetry" and "architecturally unable to read" commitments).

### 2. Vocabulary – change "creator" to "guardian"
- Change the vocab word "creator" to "guardian" to better reflect the observed patterns of how we, our community, and product, organically describes the person who creates an assistant.

## Related Changes
This amendment to our constitution is being paired with:
1. Changes to our [Privacy Policy](https://www.vellum.ai/docs/privacy-policy) 
2. Changes to our [Glossary](https://www.vellum.ai/docs/glossary)
3. An audit of [our docs](https://www.vellum.ai/docs) to ensure consistency
4. An in-app flow for all platform users to re-consent to privacy policy changes and data privacy preferences
5. An internal company announcement communicating these changes
6. An external announcement in our Discord community announcing these changes
7. An external announcement via email to our platform users announcing these changes and linking to the in-app re-consent flow