### PR TITLE
Rename Phone / SMS channel trust floor label to Phone

### DIFF
--- a/clients/web/src/components/channel-policy/channel-policy-card.tsx
+++ b/clients/web/src/components/channel-policy/channel-policy-card.tsx
@@ -37,7 +37,7 @@ function humaniseChannel(channelType: string): string {
   // version of the id so future channels render OK without a code change.
   const LABELS: Record<string, string> = {
     telegram: "Telegram",
-    phone: "Phone / SMS",
+    phone: "Phone",
     whatsapp: "WhatsApp",
     slack: "Slack",
     email: "Email",


### PR DESCRIPTION
## Summary
- The Channel Trust Floors settings card labelled the `phone` channel as "Phone / SMS". Shorten it to just "Phone".

## Original prompt
While verifying the newly-shipped phone channel trust floor (#35246), the "Phone / SMS" row label looked off — the user asked to update the copy to say just "Phone" and drop the "/ SMS" suffix.