### PR TITLE
feat(onboarding): title the Google Calendar check-in conversation

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6152,6 +6152,12 @@ paths:
                   description: Only standard conversations are created by this endpoint
                   type: string
                   const: standard
+                title:
+                  description:
+                    Explicit title for the conversation. When provided on creation, it is persisted as a user-set title (never
+                    overwritten by the auto-titler). Used by flows that mint a conversation up-front and don't want an
+                    auto-generated title.
+                  type: string
       responses:
         "200":
           description: Successful response

--- a/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
@@ -26,6 +26,8 @@ mock.module("../../assistant-event-hub.js", () => ({
   broadcastMessage: () => {},
 }));
 
+import { eq } from "drizzle-orm";
+
 import { getDb } from "../../../memory/db-connection.js";
 import { initializeDb } from "../../../memory/db-init.js";
 import { conversations } from "../../../memory/schema.js";
@@ -71,6 +73,10 @@ function findHandler(routes: RouteDefinition[], operationId: string) {
   return route.handler;
 }
 
+const createHandler = findHandler(
+  CONVERSATION_MANAGEMENT_ROUTES,
+  "createConversation",
+);
 const putHandler = findHandler(
   CONVERSATION_MANAGEMENT_ROUTES,
   "setConversationInferenceProfile",
@@ -111,6 +117,58 @@ function seedConversation(id: string): void {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+describe("POST /v1/conversations (createConversation)", () => {
+  beforeEach(() => {
+    clearConversations();
+  });
+
+  function readConversation(id: string) {
+    return getDb()
+      .select({
+        title: conversations.title,
+        isAutoTitle: conversations.isAutoTitle,
+      })
+      .from(conversations)
+      .where(eq(conversations.id, id))
+      .get();
+  }
+
+  test("with a title → persists it as a user-set title (isAutoTitle = 0)", async () => {
+    const result = (await createHandler({
+      body: { conversationType: "standard", title: "Setting up your check-in" },
+    })) as { id: string; created: boolean };
+
+    expect(result.created).toBe(true);
+    const row = readConversation(result.id);
+    expect(row?.title).toBe("Setting up your check-in");
+    // isAutoTitle = 0 keeps the async LLM titler from overwriting it.
+    expect(row?.isAutoTitle).toBe(0);
+  });
+
+  test("blank title falls back to the replaceable 'New Conversation' placeholder", async () => {
+    const result = (await createHandler({
+      body: { conversationType: "standard", title: "   " },
+    })) as { id: string; created: boolean };
+
+    expect(result.created).toBe(true);
+    const row = readConversation(result.id);
+    expect(row?.title).toBe("New Conversation");
+    // Default auto-title flag (1) leaves it replaceable by the auto-titler.
+    expect(row?.isAutoTitle).toBe(1);
+  });
+
+  test("no title → 'New Conversation' placeholder", async () => {
+    const result = (await createHandler({
+      body: { conversationType: "standard" },
+    })) as { id: string; created: boolean };
+
+    expect(result.created).toBe(true);
+    const row = readConversation(result.id);
+    expect(row?.title).toBe("New Conversation");
+    expect(row?.isAutoTitle).toBe(1);
+  });
+});
 
 describe("PUT /v1/conversations/:id/inference-profile", () => {
   beforeEach(() => {

--- a/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
@@ -168,6 +168,15 @@ describe("POST /v1/conversations (createConversation)", () => {
     expect(row?.title).toBe("New Conversation");
     expect(row?.isAutoTitle).toBe(1);
   });
+
+  test("non-string title → BadRequestError (not a 500), no row created", () => {
+    // The shared route adapter doesn't runtime-validate the body, so the
+    // handler must reject a malformed title before `.trim()` throws.
+    expect(() =>
+      createHandler({ body: { conversationType: "standard", title: 123 } }),
+    ).toThrow(/title must be a string/);
+    expect(getDb().select().from(conversations).all()).toHaveLength(0);
+  });
 });
 
 describe("PUT /v1/conversations/:id/inference-profile", () => {

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -94,11 +94,20 @@ function cancelScheduleIfLast(conversationId: string): void {
 function handleCreateConversation({ body = {}, headers }: RouteHandlerArgs) {
   const conversationKey =
     (body.conversationKey as string | undefined) ?? crypto.randomUUID();
+  const customTitle = (body.title as string | undefined)?.trim() || undefined;
   const result = getOrCreateConversation(conversationKey, {
     conversationType: "standard",
   });
   if (result.created) {
-    updateConversationTitle(result.conversationId, "New Conversation");
+    // A caller-supplied title is user-set: persist it with isAutoTitle = 0 so
+    // the async LLM titler's safe-overwrite check leaves it untouched. Without
+    // one, fall back to the neutral "New Conversation" placeholder, which stays
+    // replaceable by the auto-titler once messages arrive.
+    if (customTitle) {
+      updateConversationTitle(result.conversationId, customTitle, 0);
+    } else {
+      updateConversationTitle(result.conversationId, "New Conversation");
+    }
     publishConversationListAndMetadataChanged(
       "created",
       result.conversationId,
@@ -550,6 +559,12 @@ export const ROUTES: RouteDefinition[] = [
         .literal("standard")
         .optional()
         .describe("Only standard conversations are created by this endpoint"),
+      title: z
+        .string()
+        .optional()
+        .describe(
+          "Explicit title for the conversation. When provided on creation, it is persisted as a user-set title (never overwritten by the auto-titler). Used by flows that mint a conversation up-front and don't want an auto-generated title.",
+        ),
     }),
     responseBody: z.object({
       id: z

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -94,7 +94,13 @@ function cancelScheduleIfLast(conversationId: string): void {
 function handleCreateConversation({ body = {}, headers }: RouteHandlerArgs) {
   const conversationKey =
     (body.conversationKey as string | undefined) ?? crypto.randomUUID();
-  const customTitle = (body.title as string | undefined)?.trim() || undefined;
+  // The shared route adapter does not runtime-validate the body against the
+  // Zod requestBody (it's codegen-only), so guard the type before trimming —
+  // a malformed `{ title: 123 }` would otherwise throw on `.trim()` and 500.
+  if (body.title !== undefined && typeof body.title !== "string") {
+    throw new BadRequestError("title must be a string");
+  }
+  const customTitle = body.title?.trim() || undefined;
   const result = getOrCreateConversation(conversationKey, {
     conversationType: "standard",
   });

--- a/clients/web/src/domains/onboarding/checkin-scheduler.ts
+++ b/clients/web/src/domains/onboarding/checkin-scheduler.ts
@@ -18,10 +18,7 @@
  * from onboarding.
  */
 
-import {
-  conversationsPost,
-  messagesPost,
-} from "@/generated/daemon/sdk.gen";
+import { conversationsPost, messagesPost } from "@/generated/daemon/sdk.gen";
 import type { MessagesPostData } from "@/generated/daemon/types.gen";
 
 import { buildCheckinPrompt } from "@/domains/onboarding/checkin-prompt";
@@ -45,7 +42,7 @@ export async function scheduleCheckin({
   try {
     const conversation = await conversationsPost({
       path: { assistant_id: assistantId },
-      body: { conversationType: "standard" },
+      body: { conversationType: "standard", title: "Setting up your check-in" },
       throwOnError: false,
     });
     const conversationId = conversation.data?.id;


### PR DESCRIPTION
## Problem

When a user connects Google Calendar during onboarding, `scheduleCheckin()` mints a dedicated conversation and fires the "Day 2 Check-in" prompt into it (to book a check-in event). That conversation was left with an auto-generated title — the async LLM titler named it from the "create a calendar event" prompt.

## Why the research-flow approach doesn't apply here

The recently-shipped research-onboarding titling (#35318) works by passing `onboarding.title` on the **first message**, because that flow server-mints the conversation inside `handleSendMessage`. The check-in flow is different: `scheduleCheckin()` creates the conversation **up-front** via `conversationsPost()` (`handleCreateConversation`), then sends the message into the existing row. By the time the message is sent, the row already exists — so the title has to be set on the **create** endpoint.

## Change

- `createConversation` (`POST /v1/conversations`) now accepts an optional `title`.
- `handleCreateConversation` persists a supplied title with `isAutoTitle = 0` (user-set) via the existing `updateConversationTitle(id, title, isAutoTitle)`, in place of the neutral `"New Conversation"` placeholder. With no title (or blank), it keeps the placeholder, which stays replaceable by the auto-titler.
- `scheduleCheckin()` passes **"Setting up your check-in"**.
- Regenerated `assistant/openapi.yaml`.

## Tests
- Added 3 regression tests for the create endpoint: title → persisted with `isAutoTitle = 0`; blank title → `"New Conversation"` (auto-title 1); no title → `"New Conversation"` (auto-title 1).
- Full management-routes suite green (10/10). Typecheck clean on daemon + web.

## ⚠️ No Linear ticket
Opened without a Linear ticket per the author's go-ahead — **add one before merge** so it auto-links/closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)