### PR TITLE
Add one-shot consent-resolved hook to the consent cache

### DIFF
--- a/assistant/src/platform/consent-cache.test.ts
+++ b/assistant/src/platform/consent-cache.test.ts
@@ -46,8 +46,10 @@ mock.module("../util/logger.js", () => ({
 // ---------------------------------------------------------------------------
 
 import {
+  __resetConsentResolutionForTest,
   __setCachedShareAnalyticsForTest,
   getCachedShareAnalytics,
+  onConsentResolved,
   refreshConsentCache,
   startConsentRefresh,
   stopConsentRefresh,
@@ -66,10 +68,12 @@ describe("consent-cache", () => {
     createCallCount = 0;
     mockLegacyTelemetryOptOut = false;
     __setCachedShareAnalyticsForTest(false);
+    __resetConsentResolutionForTest();
   });
 
   afterEach(async () => {
     await stopConsentRefresh();
+    __resetConsentResolutionForTest();
   });
 
   test("defaults to false before any refresh", () => {
@@ -155,5 +159,99 @@ describe("consent-cache", () => {
     startConsentRefresh();
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(getCachedShareAnalytics()).toBe(true);
+  });
+});
+
+describe("onConsentResolved", () => {
+  beforeEach(() => {
+    mockClient = null;
+    createCallCount = 0;
+    mockLegacyTelemetryOptOut = false;
+    __setCachedShareAnalyticsForTest(false);
+    __resetConsentResolutionForTest();
+  });
+
+  afterEach(async () => {
+    await stopConsentRefresh();
+    __resetConsentResolutionForTest();
+  });
+
+  function setConsent(consent: OwnerConsent | null) {
+    mockClient = makeClient(consent);
+  }
+
+  test("fires once on the first successful fetch with the resolved consent", async () => {
+    const consent: OwnerConsent = {
+      shareAnalytics: true,
+      shareDiagnostics: false,
+    };
+    let received: OwnerConsent | null = null;
+    let calls = 0;
+    onConsentResolved((c) => {
+      received = c;
+      calls += 1;
+    });
+
+    setConsent(consent);
+    await refreshConsentCache();
+
+    expect(calls).toBe(1);
+    expect(received).toEqual(consent);
+  });
+
+  test("does not fire again on a second successful fetch (one-shot)", async () => {
+    let calls = 0;
+    onConsentResolved(() => {
+      calls += 1;
+    });
+
+    setConsent({ shareAnalytics: true, shareDiagnostics: false });
+    await refreshConsentCache();
+    setConsent({ shareAnalytics: false, shareDiagnostics: true });
+    await refreshConsentCache();
+
+    expect(calls).toBe(1);
+  });
+
+  test("a listener registered after resolution fires immediately with the last consent", async () => {
+    const consent: OwnerConsent = {
+      shareAnalytics: false,
+      shareDiagnostics: true,
+    };
+    setConsent(consent);
+    await refreshConsentCache();
+
+    let received: OwnerConsent | null = null;
+    let calls = 0;
+    onConsentResolved((c) => {
+      received = c;
+      calls += 1;
+    });
+
+    expect(calls).toBe(1);
+    expect(received).toEqual(consent);
+  });
+
+  test("a null fetch never fires; a later successful fetch does", async () => {
+    let received: OwnerConsent | null = null;
+    let calls = 0;
+    onConsentResolved((c) => {
+      received = c;
+      calls += 1;
+    });
+
+    setConsent(null);
+    await refreshConsentCache();
+    expect(calls).toBe(0);
+
+    const consent: OwnerConsent = {
+      shareAnalytics: true,
+      shareDiagnostics: true,
+    };
+    setConsent(consent);
+    await refreshConsentCache();
+
+    expect(calls).toBe(1);
+    expect(received).toEqual(consent);
   });
 });

--- a/assistant/src/platform/consent-cache.test.ts
+++ b/assistant/src/platform/consent-cache.test.ts
@@ -185,18 +185,13 @@ describe("onConsentResolved", () => {
       shareAnalytics: true,
       shareDiagnostics: false,
     };
-    let received: OwnerConsent | null = null;
-    let calls = 0;
-    onConsentResolved((c) => {
-      received = c;
-      calls += 1;
-    });
+    const received: OwnerConsent[] = [];
+    onConsentResolved((c) => received.push(c));
 
     setConsent(consent);
     await refreshConsentCache();
 
-    expect(calls).toBe(1);
-    expect(received).toEqual(consent);
+    expect(received).toEqual([consent]);
   });
 
   test("does not fire again on a second successful fetch (one-shot)", async () => {
@@ -221,28 +216,19 @@ describe("onConsentResolved", () => {
     setConsent(consent);
     await refreshConsentCache();
 
-    let received: OwnerConsent | null = null;
-    let calls = 0;
-    onConsentResolved((c) => {
-      received = c;
-      calls += 1;
-    });
+    const received: OwnerConsent[] = [];
+    onConsentResolved((c) => received.push(c));
 
-    expect(calls).toBe(1);
-    expect(received).toEqual(consent);
+    expect(received).toEqual([consent]);
   });
 
   test("a null fetch never fires; a later successful fetch does", async () => {
-    let received: OwnerConsent | null = null;
-    let calls = 0;
-    onConsentResolved((c) => {
-      received = c;
-      calls += 1;
-    });
+    const received: OwnerConsent[] = [];
+    onConsentResolved((c) => received.push(c));
 
     setConsent(null);
     await refreshConsentCache();
-    expect(calls).toBe(0);
+    expect(received).toEqual([]);
 
     const consent: OwnerConsent = {
       shareAnalytics: true,
@@ -251,7 +237,6 @@ describe("onConsentResolved", () => {
     setConsent(consent);
     await refreshConsentCache();
 
-    expect(calls).toBe(1);
-    expect(received).toEqual(consent);
+    expect(received).toEqual([consent]);
   });
 });

--- a/assistant/src/platform/consent-cache.ts
+++ b/assistant/src/platform/consent-cache.ts
@@ -10,7 +10,7 @@
 
 import { getConfigReadOnly } from "../config/loader.js";
 import { getLogger } from "../util/logger.js";
-import { VellumPlatformClient } from "./client.js";
+import { VellumPlatformClient, type OwnerConsent } from "./client.js";
 
 const log = getLogger("consent-cache");
 
@@ -24,6 +24,12 @@ let cachedShareAnalytics = false; // default-off until first success
 // re-consent signal; not auto-cleared here.
 let legacyOptOut = false;
 let refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+// One-shot consent-resolved hook state. `firstConsentResolved` flips on the
+// first successful fetch; `lastResolvedConsent` retains it for late registrants.
+let firstConsentResolved = false;
+let lastResolvedConsent: OwnerConsent | null = null;
+const consentResolvedListeners: Array<(consent: OwnerConsent) => void> = [];
 
 /**
  * Synchronous hot-path accessor for the effective `share_analytics` consent.
@@ -61,7 +67,29 @@ export async function refreshConsentCache(): Promise<void> {
   const consent = await client.getOwnerConsent();
   if (consent) {
     setCachedShareAnalytics(consent.shareAnalytics);
+    lastResolvedConsent = consent;
+    if (!firstConsentResolved) {
+      firstConsentResolved = true;
+      const listeners = consentResolvedListeners.splice(0);
+      for (const l of listeners) l(consent);
+    }
   }
+}
+
+/**
+ * One-shot hook fired on the FIRST successful platform consent fetch. Lets
+ * one-time startup decisions (e.g. Sentry) gate on consent without doing I/O on
+ * the hot path. Registrants after the first resolution fire synchronously with
+ * the last resolved consent; null fetches never trigger it.
+ */
+export function onConsentResolved(
+  listener: (consent: OwnerConsent) => void,
+): void {
+  if (firstConsentResolved && lastResolvedConsent) {
+    listener(lastResolvedConsent);
+    return;
+  }
+  consentResolvedListeners.push(listener);
 }
 
 function setCachedShareAnalytics(value: boolean): void {
@@ -104,4 +132,11 @@ export async function stopConsentRefresh(): Promise<void> {
 /** Test-only: override the cached value without going through a refresh. */
 export function __setCachedShareAnalyticsForTest(value: boolean): void {
   cachedShareAnalytics = value;
+}
+
+/** Test-only: clear one-shot consent-resolved hook state. */
+export function __resetConsentResolutionForTest(): void {
+  firstConsentResolved = false;
+  lastResolvedConsent = null;
+  consentResolvedListeners.length = 0;
 }

--- a/assistant/src/platform/consent-cache.ts
+++ b/assistant/src/platform/consent-cache.ts
@@ -10,7 +10,7 @@
 
 import { getConfigReadOnly } from "../config/loader.js";
 import { getLogger } from "../util/logger.js";
-import { VellumPlatformClient, type OwnerConsent } from "./client.js";
+import { type OwnerConsent,VellumPlatformClient } from "./client.js";
 
 const log = getLogger("consent-cache");
 


### PR DESCRIPTION
## Summary
- Add `onConsentResolved` one-shot hook to the consent cache, fired on the first successful platform consent fetch (and immediately for late registrants).
- Track `lastResolvedConsent`; null fetches never mark resolution.
- Add `__resetConsentResolutionForTest` + tests.

Part of plan: diagnostics-consent-gating.md (PR 1 of 5)