### PR TITLE
fix(inbound): don't run Slack reactions through ingress access control

### DIFF
--- a/assistant/src/__tests__/channel-inbound-disk-pressure.test.ts
+++ b/assistant/src/__tests__/channel-inbound-disk-pressure.test.ts
@@ -236,7 +236,7 @@ describe("channel inbound disk pressure gate", () => {
     expect(db.select().from(messages).all()).toHaveLength(0);
   });
 
-  test("blocks non-guardian Slack reactions before persistence while locked", async () => {
+  test("blocks non-guardian Slack reactions silently (no reply) before persistence while locked", async () => {
     upsertContact({
       displayName: "Example Slack User",
       channels: [
@@ -274,18 +274,10 @@ describe("channel inbound disk pressure gate", () => {
       reason: "trusted-contact",
     });
     expect(processMessage).not.toHaveBeenCalled();
-    expect(deliverChannelReplyMock.mock.calls).toEqual([
-      [
-        "https://gateway.test/deliver/slack",
-        {
-          chatId: "slack-channel-1",
-          text: expectedRemoteBlockReply,
-          assistantId: "self",
-          ephemeral: true,
-          user: "slack-user-1",
-        },
-      ],
-    ]);
+    // Reactions are blocked silently during disk pressure: a passive signal
+    // has nothing to "try again", so no block reply is delivered (unlike the
+    // message path, which does reply).
+    expect(deliverChannelReplyMock).not.toHaveBeenCalled();
 
     const db = getDb();
     const event = db

--- a/assistant/src/__tests__/reaction-persistence.test.ts
+++ b/assistant/src/__tests__/reaction-persistence.test.ts
@@ -59,7 +59,7 @@ import * as pendingInteractions from "../runtime/pending-interactions.js";
 import {
   isSlackReactionEvent,
   parseSlackReactionCallbackData,
-} from "../runtime/routes/inbound-message-handler.js";
+} from "../runtime/routes/inbound-stages/reaction-intercept.js";
 import { handleChannelInbound } from "./helpers/channel-test-adapter.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
 
@@ -573,5 +573,114 @@ describe("guardian approval-by-reaction integration via handleChannelInbound", (
       }
     });
     expect(reactionRows.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reaction access-control regression (LUM-2489)
+// ---------------------------------------------------------------------------
+//
+// A reaction is a passive signal, not an access attempt. Because reactions are
+// dispatched before the ingress pipeline, an unknown user's 👍 must never run
+// ACL (no trusted-contact verification handshake), create a conversation, or
+// write a binding — it is dropped as channel noise. A known contact's reaction
+// is recorded; neither triggers a verification challenge.
+
+describe("reaction access control (no verification handshake)", () => {
+  const STRANGER_USER_ID = "U_REACTION_STRANGER";
+  const CONTACT_USER_ID = "U_REACTION_CONTACT";
+  // Guardian's approval channel is a DM, distinct from the public channel the
+  // reaction lands in (mirroring production). Reusing the public channel id
+  // would let a reactor match the guardian's channel via findContactChannel's
+  // externalChatId fallback and mask the bug.
+  const GUARDIAN_DM_CHAT = "D_GUARDIAN_DM";
+
+  function tableCount(table: string): number {
+    return (
+      getDb().$client.prepare(`SELECT COUNT(*) AS n FROM ${table}`).get() as {
+        n: number;
+      }
+    ).n;
+  }
+
+  beforeEach(() => {
+    resetState();
+    getDb().run("DELETE FROM channel_verification_sessions");
+    // The assistant has a guardian (as in production); the reactors below are
+    // different users.
+    createGuardianBinding({
+      channel: "slack",
+      guardianExternalUserId: GUARDIAN_USER_ID,
+      guardianDeliveryChatId: GUARDIAN_DM_CHAT,
+      guardianPrincipalId: GUARDIAN_USER_ID,
+    });
+    msgCounter = 0;
+  });
+
+  test("stranger's reaction is dropped — no challenge, session, conversation, or row", async () => {
+    let agentDispatched = false;
+    const processMessage = async (): Promise<{ messageId: string }> => {
+      agentDispatched = true;
+      return { messageId: "should-not-be-called" };
+    };
+
+    const req = buildReactionRequest("reaction:thumbsup", {
+      actorExternalId: STRANGER_USER_ID,
+      actorDisplayName: "Outside Reactor",
+      actorUsername: "outsider",
+    });
+    const resp = await handleChannelInbound(
+      req,
+      processMessage,
+      TEST_BEARER_TOKEN,
+    );
+    const json = (await resp.json()) as Record<string, unknown>;
+
+    // Accepted as a passive signal — never denied or turned into a challenge.
+    expect(json.accepted).toBe(true);
+    expect(json.denied).not.toBe(true);
+    expect(json.reason).not.toBe("verification_challenge_sent");
+    expect(json.verificationSessionId).toBeUndefined();
+    expect(agentDispatched).toBe(false);
+
+    // No verification handshake, and no side effects: a dropped reaction leaves
+    // no transcript row, no conversation, and no binding.
+    expect(tableCount("channel_verification_sessions")).toBe(0);
+    expect(readPersistedMessages().length).toBe(0);
+    expect(tableCount("conversations")).toBe(0);
+    expect(tableCount("external_conversation_bindings")).toBe(0);
+  });
+
+  test("known contact's reaction is recorded — no challenge", async () => {
+    // A pending contact classifies as `unverified_contact` — a known tier, so
+    // its reactions are recorded. On a real message it would be re-challenged,
+    // but a reaction must not trigger that.
+    upsertContactChannel({
+      sourceChannel: "slack",
+      externalUserId: CONTACT_USER_ID,
+      externalChatId: SLACK_CHANNEL_ID,
+      status: "pending",
+      policy: "allow",
+      displayName: "Pending Contact",
+    });
+
+    const req = buildReactionRequest("reaction:tada", {
+      actorExternalId: CONTACT_USER_ID,
+      actorDisplayName: "Pending Contact",
+      actorUsername: "pending_contact",
+    });
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = (await resp.json()) as Record<string, unknown>;
+
+    expect(json.denied).not.toBe(true);
+    expect(json.reason).not.toBe("verification_challenge_sent");
+    expect(tableCount("channel_verification_sessions")).toBe(0);
+
+    const rows = readPersistedMessages();
+    expect(rows.length).toBe(1);
+    const envelope = JSON.parse(rows[0].metadata!) as Record<string, unknown>;
+    const slackMeta = readSlackMetadata(envelope.slackMeta as string);
+    expect(slackMeta?.eventKind).toBe("reaction");
+    expect(slackMeta?.reaction?.emoji).toBe("tada");
   });
 });

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -59,7 +59,6 @@ import {
 import {
   clearPayload,
   findMessageBySourceId,
-  linkMessage,
   recordInbound,
 } from "../../memory/delivery-crud.js";
 import { markProcessed } from "../../memory/delivery-status.js";
@@ -108,6 +107,10 @@ import { handleEditIntercept } from "./inbound-stages/edit-intercept.js";
 import { handleEscalationIntercept } from "./inbound-stages/escalation-intercept.js";
 import { handleGuardianActivationIntercept } from "./inbound-stages/guardian-activation-intercept.js";
 import { handleGuardianReplyIntercept } from "./inbound-stages/guardian-reply-intercept.js";
+import {
+  handleSlackReactionIntercept,
+  isSlackReactionEvent,
+} from "./inbound-stages/reaction-intercept.js";
 import { runSecretIngressCheck } from "./inbound-stages/secret-ingress-check.js";
 import { tryTranscribeAudioAttachments } from "./inbound-stages/transcribe-audio.js";
 import type { RouteHandlerArgs } from "./types.js";
@@ -401,6 +404,35 @@ export async function handleChannelInbound({
     externalMessageId,
   });
   if (guardianActivationResponse) return guardianActivationResponse;
+
+  // ── Slack reaction handling ──
+  // Reactions are passive channel signals — not messages, and not access
+  // attempts. Dispatch them to a dedicated interceptor BEFORE the message
+  // pipeline (ACL, admission floor, disk-pressure, conversation binding) so a
+  // 👍 never triggers a verification handshake or an access-request
+  // notification, and a stranger's reaction creates no conversation/binding.
+  // The interceptor drops strangers, records known contacts' reactions as
+  // transcript signals, and routes a guardian's reaction on an approval card
+  // through the canonical guardian decision pipeline. Reactions never drive an
+  // agent turn.
+  if (isSlackReactionEvent(body)) {
+    return handleSlackReactionIntercept({
+      callbackData: body.callbackData!,
+      sourceChannel,
+      sourceInterface,
+      conversationExternalId,
+      externalMessageId,
+      canonicalAssistantId,
+      rawSenderId,
+      canonicalSenderId,
+      actorDisplayName: body.actorDisplayName,
+      actorUsername: body.actorUsername,
+      replyCallbackUrl: body.replyCallbackUrl,
+      sourceMetadata: body.sourceMetadata,
+      slackChannelName,
+      approvalConversationGenerator,
+    });
+  }
 
   // ── Admission policy pre-computation ──
   // Resolve the effective policy before ACL so it can skip its hard-deny
@@ -897,128 +929,6 @@ export async function handleChannelInbound({
     };
   }
 
-  // ── Slack reaction handling ──
-  // Reactions arrive as regular `SlackInboundEvent`s with `callbackData`
-  // prefixed `reaction:` (added) or `reaction_removed:` (removed).
-  //
-  // Two paths from here:
-  //   1. Guardian approval-by-reaction. A `reaction:` (added) event from
-  //      the guardian on an active approval prompt is consumed by
-  //      `handleApprovalInterception` to apply the decision. In that case
-  //      we do NOT persist the reaction as a transcript line — resolved
-  //      guardian approval reactions have no transcript representation.
-  //   2. All other reactions (non-guardian, no pending approval, stale,
-  //      and any `reaction_removed:` event regardless of actor) fall
-  //      through to `persistSlackReactionAsMessage` so Slack transcript
-  //      rendering can surface them inline. Reactions never trigger an
-  //      agent response, so we short-circuit before escalation and
-  //      agent-loop dispatch in both cases.
-  if (isSlackReactionEvent(body)) {
-    // Approval interception runs only for reactions (added) — `reaction_removed`
-    // never expresses an approval intent, so un-reacting is left as a pure
-    // transcript signal. Gated by the same `replyCallbackUrl && !duplicate`
-    // preconditions used by the standard approval interception call below.
-    const isReactionAdded = body.callbackData?.startsWith("reaction:") === true;
-    if (isReactionAdded && replyCallbackUrl && !result.duplicate) {
-      const trustCtxForReaction: TrustContext = attachSlackRequesterTimezone(
-        resolveTrustContext({
-          assistantId: canonicalAssistantId,
-          sourceChannel,
-          conversationExternalId,
-          actorExternalId: rawSenderId,
-          actorUsername: body.actorUsername,
-          actorDisplayName: body.actorDisplayName,
-        }),
-        slackActorTimezone,
-      );
-
-      const approvalMessageTs =
-        typeof sourceMetadata?.messageId === "string"
-          ? sourceMetadata.messageId
-          : undefined;
-
-      // Route the reaction through the canonical guardian decision pipeline,
-      // exactly like button presses and text replies. The router maps the
-      // emoji to an action and recovers the target request from the reacted
-      // card's delivery record (`reactedMessageTs`), so it disambiguates
-      // precisely even when several cards are pending in the chat.
-      const reactionIntercept = await handleGuardianReplyIntercept({
-        isDuplicate: result.duplicate,
-        trimmedContent: "",
-        hasCallbackData: true,
-        callbackData: body.callbackData,
-        reactedMessageTs: approvalMessageTs,
-        rawSenderId,
-        canonicalSenderId,
-        canonicalAssistantId,
-        sourceChannel,
-        conversationExternalId,
-        conversationId: result.conversationId,
-        eventId: result.eventId,
-        replyCallbackUrl,
-        trustClass: trustCtxForReaction.trustClass,
-        guardianPrincipalId: trustCtxForReaction.guardianPrincipalId,
-        approvalConversationGenerator,
-      });
-
-      // The reaction was consumed as a guardian decision (applied, or a
-      // surfaced failure such as already-resolved / no-permission delivered as
-      // an ephemeral reply). Short-circuit so we do not also persist it as a
-      // transcript line. Reactions that are NOT approval decisions (unknown
-      // emoji, a non-approval message, or a non-guardian actor) return no
-      // response and fall through to persistence — they must never trigger an
-      // agent turn (JARVIS-734).
-      if (reactionIntercept.response) {
-        return reactionIntercept.response;
-      }
-    }
-
-    const reactedMessageTs =
-      typeof sourceMetadata?.messageId === "string"
-        ? sourceMetadata.messageId
-        : undefined;
-    if (!reactedMessageTs) {
-      log.debug(
-        { conversationId: result.conversationId, eventId: result.eventId },
-        "Skipping reaction persistence: missing sourceMetadata.messageId",
-      );
-      return {
-        accepted: result.accepted,
-        duplicate: result.duplicate,
-        eventId: result.eventId,
-      };
-    }
-
-    const threadTs =
-      typeof sourceMetadata?.threadId === "string"
-        ? sourceMetadata.threadId
-        : undefined;
-
-    try {
-      await persistSlackReactionAsMessage({
-        conversationId: result.conversationId,
-        conversationExternalId,
-        eventId: result.eventId,
-        callbackData: body.callbackData!,
-        actorDisplayName: body.actorDisplayName,
-        threadTs,
-        reactedMessageTs,
-        duplicate: result.duplicate,
-      });
-    } catch (err) {
-      log.error(
-        { err, conversationId: result.conversationId, eventId: result.eventId },
-        "Failed to persist Slack reaction event",
-      );
-    }
-
-    return {
-      accepted: result.accepted,
-      duplicate: result.duplicate,
-      eventId: result.eventId,
-    };
-  }
-
   // ── Ingress escalation ──
   const escalationResponse = handleEscalationIntercept({
     resolvedMember,
@@ -1479,117 +1389,6 @@ export async function handleChannelInbound({
     duplicate: result.duplicate,
     eventId: result.eventId,
   };
-}
-
-/**
- * Detect a Slack reaction event by inspecting the inbound payload's
- * `callbackData` prefix. The gateway encodes reactions as a unified
- * `SlackInboundEvent` with `callbackData` of the form
- * `reaction:<emoji>` (added) or `reaction_removed:<emoji>` (removed) —
- * see `gateway/src/slack/normalize.ts`. This helper centralizes that
- * convention so the daemon can route reactions to a dedicated persistence
- * branch instead of the agent-response pipeline.
- */
-export function isSlackReactionEvent(body: {
-  sourceChannel?: string;
-  callbackData?: string;
-}): boolean {
-  if (body.sourceChannel !== "slack") return false;
-  const cb = body.callbackData;
-  if (typeof cb !== "string") return false;
-  return cb.startsWith("reaction:") || cb.startsWith("reaction_removed:");
-}
-
-/**
- * Parse a reaction `callbackData` string into its op (added/removed) and
- * emoji name. Returns `null` when the input is not a reaction prefix or
- * when the emoji portion is empty.
- */
-export function parseSlackReactionCallbackData(
-  callbackData: string,
-): { op: "added" | "removed"; emoji: string } | null {
-  let op: "added" | "removed";
-  let emoji: string;
-  if (callbackData.startsWith("reaction_removed:")) {
-    op = "removed";
-    emoji = callbackData.slice("reaction_removed:".length);
-  } else if (callbackData.startsWith("reaction:")) {
-    op = "added";
-    emoji = callbackData.slice("reaction:".length);
-  } else {
-    return null;
-  }
-  if (emoji.length === 0) return null;
-  return { op, emoji };
-}
-
-/**
- * Persist a Slack reaction event as a `messages` row with `slackMeta`
- * envelope so the renderer can surface it inline in the chronological
- * transcript. Reactions do not trigger an agent response — the row is
- * written and the inbound event is linked, but the agent loop is not
- * dispatched.
- *
- * The caller is expected to have run `recordInbound` already so that
- * deduplication and conversation resolution have happened. Duplicate
- * inbound events are skipped here to keep persistence idempotent.
- */
-async function persistSlackReactionAsMessage(params: {
-  conversationId: string;
-  conversationExternalId: string;
-  eventId: string;
-  callbackData: string;
-  actorDisplayName?: string;
-  threadTs?: string;
-  reactedMessageTs: string;
-  duplicate: boolean;
-}): Promise<void> {
-  if (params.duplicate) return;
-
-  const parsed = parseSlackReactionCallbackData(params.callbackData);
-  if (!parsed) {
-    log.debug(
-      {
-        conversationId: params.conversationId,
-        callbackData: params.callbackData,
-      },
-      "Skipping reaction persistence: unparseable callbackData",
-    );
-    return;
-  }
-
-  const slackMeta: SlackMessageMetadata = {
-    source: "slack",
-    channelId: params.conversationExternalId,
-    channelTs: params.reactedMessageTs,
-    eventKind: "reaction",
-    ...(params.threadTs ? { threadTs: params.threadTs } : {}),
-    ...(params.actorDisplayName
-      ? { displayName: params.actorDisplayName }
-      : {}),
-    reaction: {
-      emoji: parsed.emoji,
-      targetChannelTs: params.reactedMessageTs,
-      op: parsed.op,
-      ...(params.actorDisplayName
-        ? { actorDisplayName: params.actorDisplayName }
-        : {}),
-    },
-  };
-
-  // Sentinel content — Slack transcript renderers read `slackMeta` to format
-  // the reaction line; the literal text is never displayed to the model.
-  const persisted = await addMessage(
-    params.conversationId,
-    "user",
-    "[reaction]",
-    {
-      metadata: { slackMeta: writeSlackMetadata(slackMeta) },
-      skipIndexing: true,
-    },
-  );
-  linkMessage(params.eventId, persisted.id);
-  markProcessed(params.eventId);
 }
 
 /**

--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
@@ -1,0 +1,387 @@
+/**
+ * Slack reaction intercept stage.
+ *
+ * Reactions are passive channel signals — not messages, and not access
+ * attempts. They are dispatched here *before* the message pipeline (ACL,
+ * admission floor, disk-pressure block, conversation binding) so that:
+ *
+ *   - a 👍 never triggers an ingress access challenge / verification handshake
+ *     or an access-request notification (LUM-2489),
+ *   - a stranger's reaction creates no conversation, binding, or transcript
+ *     row — it is dropped as channel noise,
+ *   - a known contact's reaction is recorded as an inline transcript signal,
+ *   - a guardian's reaction on an approval card is routed through the canonical
+ *     guardian decision pipeline (the same path as buttons and text replies).
+ *
+ * Reactions never drive an agent turn.
+ */
+import type { SourceMetadata } from "@vellumai/gateway-client";
+
+import type { ChannelId, InterfaceId } from "../../../channels/types.js";
+import { getDiskPressureStatus } from "../../../daemon/disk-pressure-guard.js";
+import { classifyDiskPressureTurnPolicy } from "../../../daemon/disk-pressure-policy.js";
+import { addMessage } from "../../../memory/conversation-crud.js";
+import {
+  clearPayload,
+  linkMessage,
+  recordInbound,
+} from "../../../memory/delivery-crud.js";
+import { markProcessed } from "../../../memory/delivery-status.js";
+import { upsertBinding } from "../../../memory/external-conversation-store.js";
+import {
+  type SlackMessageMetadata,
+  writeSlackMetadata,
+} from "../../../messaging/providers/slack/message-metadata.js";
+import { getLogger } from "../../../util/logger.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../assistant-scope.js";
+import { deliverChannelReply } from "../../gateway-client.js";
+import type { ApprovalConversationGenerator } from "../../http-types.js";
+import { resolveTrustContext } from "../../trust-context-resolver.js";
+import { handleGuardianReplyIntercept } from "./guardian-reply-intercept.js";
+
+const log = getLogger("runtime-http");
+
+// Mirrors the message-pipeline disk-pressure block reply (see
+// inbound-message-handler.ts) so a reaction blocked during cleanup gets the
+// same ephemeral notice.
+const DISK_PRESSURE_REMOTE_BLOCK_REPLY =
+  "Storage is critically low, so remote messages are ignored until the guardian frees enough space. Please try again later.";
+
+/**
+ * Detect a Slack reaction event by inspecting the inbound payload's
+ * `callbackData` prefix. The gateway encodes reactions as a unified
+ * `SlackInboundEvent` with `callbackData` of the form `reaction:<emoji>`
+ * (added) or `reaction_removed:<emoji>` (removed) — see
+ * `gateway/src/slack/normalize.ts`. This helper centralizes that convention
+ * so the daemon can route reactions to this dedicated stage instead of the
+ * agent-response pipeline.
+ */
+export function isSlackReactionEvent(body: {
+  sourceChannel?: string;
+  callbackData?: string;
+}): boolean {
+  if (body.sourceChannel !== "slack") return false;
+  const cb = body.callbackData;
+  if (typeof cb !== "string") return false;
+  return cb.startsWith("reaction:") || cb.startsWith("reaction_removed:");
+}
+
+/**
+ * Parse a reaction `callbackData` string into its op (added/removed) and
+ * emoji name. Returns `null` when the input is not a reaction prefix or
+ * when the emoji portion is empty.
+ */
+export function parseSlackReactionCallbackData(
+  callbackData: string,
+): { op: "added" | "removed"; emoji: string } | null {
+  let op: "added" | "removed";
+  let emoji: string;
+  if (callbackData.startsWith("reaction_removed:")) {
+    op = "removed";
+    emoji = callbackData.slice("reaction_removed:".length);
+  } else if (callbackData.startsWith("reaction:")) {
+    op = "added";
+    emoji = callbackData.slice("reaction:".length);
+  } else {
+    return null;
+  }
+  if (emoji.length === 0) return null;
+  return { op, emoji };
+}
+
+export interface ReactionInterceptParams {
+  /** The reaction callbackData (`reaction:<emoji>` / `reaction_removed:<emoji>`). */
+  callbackData: string;
+  sourceChannel: ChannelId;
+  sourceInterface: InterfaceId | undefined;
+  conversationExternalId: string;
+  externalMessageId: string;
+  canonicalAssistantId: string;
+  rawSenderId: string | undefined;
+  canonicalSenderId: string | null;
+  actorDisplayName: string | undefined;
+  actorUsername: string | undefined;
+  replyCallbackUrl: string | undefined;
+  sourceMetadata: SourceMetadata | undefined;
+  /** Slack channel display name, for the conversation binding. */
+  slackChannelName: string | null;
+  approvalConversationGenerator: ApprovalConversationGenerator | undefined;
+}
+
+/**
+ * Handle a Slack reaction event end to end. Always consumes the event (the
+ * caller dispatches here only for `isSlackReactionEvent`), returning the
+ * response the top-level handler should short-circuit with.
+ */
+export async function handleSlackReactionIntercept(
+  params: ReactionInterceptParams,
+): Promise<Record<string, unknown>> {
+  const {
+    callbackData,
+    sourceChannel,
+    sourceInterface,
+    conversationExternalId,
+    externalMessageId,
+    canonicalAssistantId,
+    rawSenderId,
+    canonicalSenderId,
+    actorDisplayName,
+    actorUsername,
+    replyCallbackUrl,
+    sourceMetadata,
+    slackChannelName,
+    approvalConversationGenerator,
+  } = params;
+
+  // Classify the reactor. No timezone enrichment — reactions never drive an
+  // agent turn, so only the trust class / guardian principal matter.
+  const trustCtx = resolveTrustContext({
+    assistantId: canonicalAssistantId,
+    sourceChannel,
+    conversationExternalId,
+    actorExternalId: rawSenderId,
+    actorUsername,
+    actorDisplayName,
+  });
+
+  // Drop strangers before any write. `unknown` covers no contact record and
+  // blocked/revoked contacts — a reaction from them is channel noise. Dropping
+  // here (before recordInbound/upsertBinding) means no empty conversation or
+  // binding is created on their behalf.
+  if (trustCtx.trustClass === "unknown") {
+    log.debug(
+      { sourceChannel, conversationExternalId },
+      "Dropping reaction from unknown actor",
+    );
+    return { accepted: true, reaction: "dropped_unknown_actor" };
+  }
+
+  const reactedMessageTs =
+    typeof sourceMetadata?.messageId === "string"
+      ? sourceMetadata.messageId
+      : undefined;
+  const threadTs =
+    typeof sourceMetadata?.threadId === "string" &&
+    sourceMetadata.threadId.trim().length > 0
+      ? sourceMetadata.threadId.trim()
+      : undefined;
+
+  // Record for dedup + conversation resolution (known contacts only — strangers
+  // were dropped above).
+  const result = recordInbound(
+    sourceChannel,
+    conversationExternalId,
+    externalMessageId,
+    {
+      sourceMessageId: reactedMessageTs,
+      assistantId: canonicalAssistantId,
+      sourceThreadId: threadTs,
+    },
+  );
+
+  // Respect disk-pressure cleanup: a reaction that would write a row is blocked
+  // like any remote ingress, so reactions don't bypass storage protection.
+  // Guardians resolve to `allow-cleanup-mode` (not `block`), so a guardian's
+  // approval-by-reaction still flows. Mirrors the message-pipeline block —
+  // clear the stored payload, mark the event processed, and deliver the
+  // ephemeral notice — then stop before binding/persistence.
+  const diskPressure = classifyDiskPressureTurnPolicy(getDiskPressureStatus(), {
+    sourceChannel,
+    sourceInterface,
+    trustContext: {
+      sourceChannel: trustCtx.sourceChannel,
+      trustClass: trustCtx.trustClass,
+    },
+  });
+  if (diskPressure.action === "block") {
+    if (!result.duplicate) {
+      clearPayload(result.eventId);
+      markProcessed(result.eventId);
+    }
+    if (replyCallbackUrl && !result.duplicate) {
+      const replyPayload: Parameters<typeof deliverChannelReply>[1] = {
+        chatId: conversationExternalId,
+        text: DISK_PRESSURE_REMOTE_BLOCK_REPLY,
+        assistantId: canonicalAssistantId,
+      };
+      if (sourceChannel === "slack" && (canonicalSenderId ?? rawSenderId)) {
+        replyPayload.ephemeral = true;
+        replyPayload.user = (canonicalSenderId ?? rawSenderId)!;
+      }
+      try {
+        await deliverChannelReply(replyCallbackUrl, replyPayload);
+      } catch (err) {
+        log.warn(
+          {
+            err,
+            conversationId: result.conversationId,
+            eventId: result.eventId,
+          },
+          "Failed to deliver disk-pressure block reply for reaction",
+        );
+      }
+    }
+    return {
+      accepted: true,
+      duplicate: result.duplicate,
+      eventId: result.eventId,
+      diskPressure: "blocked",
+      reason: diskPressure.reason,
+    };
+  }
+
+  // Maintain the conversation binding, matching the message pipeline. Scoped to
+  // the daemon's own assistant so assistant-scoped legacy routes don't clobber
+  // each other's binding metadata.
+  if (canonicalAssistantId === DAEMON_INTERNAL_ASSISTANT_ID) {
+    upsertBinding({
+      conversationId: result.conversationId,
+      sourceChannel,
+      externalChatId: conversationExternalId,
+      externalChatName: slackChannelName,
+      externalThreadId: threadTs ?? null,
+      externalUserId: canonicalSenderId ?? rawSenderId ?? null,
+      displayName: actorDisplayName ?? null,
+      username: actorUsername ?? null,
+    });
+  }
+
+  // Guardian approval-by-reaction → canonical decision pipeline, exactly like
+  // buttons and text replies. Only `reaction:` (added) expresses intent;
+  // `reaction_removed:` never does. `handleGuardianReplyIntercept` self-gates
+  // on `trustClass === "guardian"`, so a contact's reaction returns no response
+  // and falls through to persistence.
+  const isReactionAdded = callbackData.startsWith("reaction:");
+  if (isReactionAdded && replyCallbackUrl && !result.duplicate) {
+    const reactionIntercept = await handleGuardianReplyIntercept({
+      isDuplicate: result.duplicate,
+      trimmedContent: "",
+      hasCallbackData: true,
+      callbackData,
+      reactedMessageTs,
+      rawSenderId,
+      canonicalSenderId,
+      canonicalAssistantId,
+      sourceChannel,
+      conversationExternalId,
+      conversationId: result.conversationId,
+      eventId: result.eventId,
+      replyCallbackUrl,
+      trustClass: trustCtx.trustClass,
+      guardianPrincipalId: trustCtx.guardianPrincipalId,
+      approvalConversationGenerator,
+    });
+    // Consumed as a guardian decision (applied, or a surfaced failure delivered
+    // as an ephemeral reply). Short-circuit so we do not also persist a
+    // transcript row.
+    if (reactionIntercept.response) {
+      return reactionIntercept.response;
+    }
+  }
+
+  // Record the reaction as an inline transcript signal. Requires the reacted
+  // message ts to anchor the rendering.
+  if (!reactedMessageTs) {
+    log.debug(
+      { conversationId: result.conversationId, eventId: result.eventId },
+      "Skipping reaction persistence: missing sourceMetadata.messageId",
+    );
+    return {
+      accepted: result.accepted,
+      duplicate: result.duplicate,
+      eventId: result.eventId,
+    };
+  }
+
+  try {
+    await persistSlackReactionAsMessage({
+      conversationId: result.conversationId,
+      conversationExternalId,
+      eventId: result.eventId,
+      callbackData,
+      actorDisplayName,
+      threadTs,
+      reactedMessageTs,
+      duplicate: result.duplicate,
+    });
+  } catch (err) {
+    log.error(
+      { err, conversationId: result.conversationId, eventId: result.eventId },
+      "Failed to persist Slack reaction event",
+    );
+  }
+
+  return {
+    accepted: result.accepted,
+    duplicate: result.duplicate,
+    eventId: result.eventId,
+  };
+}
+
+/**
+ * Persist a Slack reaction event as a `messages` row with a `slackMeta`
+ * envelope so the renderer can surface it inline in the chronological
+ * transcript. Reactions do not trigger an agent response — the row is written
+ * and the inbound event is linked, but the agent loop is not dispatched.
+ *
+ * The caller is expected to have run `recordInbound` already so that
+ * deduplication and conversation resolution have happened. Duplicate inbound
+ * events are skipped here to keep persistence idempotent.
+ */
+async function persistSlackReactionAsMessage(params: {
+  conversationId: string;
+  conversationExternalId: string;
+  eventId: string;
+  callbackData: string;
+  actorDisplayName?: string;
+  threadTs?: string;
+  reactedMessageTs: string;
+  duplicate: boolean;
+}): Promise<void> {
+  if (params.duplicate) return;
+
+  const parsed = parseSlackReactionCallbackData(params.callbackData);
+  if (!parsed) {
+    log.debug(
+      {
+        conversationId: params.conversationId,
+        callbackData: params.callbackData,
+      },
+      "Skipping reaction persistence: unparseable callbackData",
+    );
+    return;
+  }
+
+  const slackMeta: SlackMessageMetadata = {
+    source: "slack",
+    channelId: params.conversationExternalId,
+    channelTs: params.reactedMessageTs,
+    eventKind: "reaction",
+    ...(params.threadTs ? { threadTs: params.threadTs } : {}),
+    ...(params.actorDisplayName
+      ? { displayName: params.actorDisplayName }
+      : {}),
+    reaction: {
+      emoji: parsed.emoji,
+      targetChannelTs: params.reactedMessageTs,
+      op: parsed.op,
+      ...(params.actorDisplayName
+        ? { actorDisplayName: params.actorDisplayName }
+        : {}),
+    },
+  };
+
+  // Sentinel content — Slack transcript renderers read `slackMeta` to format
+  // the reaction line; the literal text is never displayed to the model.
+  const persisted = await addMessage(
+    params.conversationId,
+    "user",
+    "[reaction]",
+    {
+      metadata: { slackMeta: writeSlackMetadata(slackMeta) },
+      skipIndexing: true,
+    },
+  );
+  linkMessage(params.eventId, persisted.id);
+  markProcessed(params.eventId);
+}

--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
@@ -34,18 +34,11 @@ import {
 } from "../../../messaging/providers/slack/message-metadata.js";
 import { getLogger } from "../../../util/logger.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../../assistant-scope.js";
-import { deliverChannelReply } from "../../gateway-client.js";
 import type { ApprovalConversationGenerator } from "../../http-types.js";
 import { resolveTrustContext } from "../../trust-context-resolver.js";
 import { handleGuardianReplyIntercept } from "./guardian-reply-intercept.js";
 
 const log = getLogger("runtime-http");
-
-// Mirrors the message-pipeline disk-pressure block reply (see
-// inbound-message-handler.ts) so a reaction blocked during cleanup gets the
-// same ephemeral notice.
-const DISK_PRESSURE_REMOTE_BLOCK_REPLY =
-  "Storage is critically low, so remote messages are ignored until the guardian frees enough space. Please try again later.";
 
 /**
  * Detect a Slack reaction event by inspecting the inbound payload's
@@ -179,12 +172,9 @@ export async function handleSlackReactionIntercept(
     },
   );
 
-  // Respect disk-pressure cleanup: a reaction that would write a row is blocked
-  // like any remote ingress, so reactions don't bypass storage protection.
-  // Guardians resolve to `allow-cleanup-mode` (not `block`), so a guardian's
-  // approval-by-reaction still flows. Mirrors the message-pipeline block —
-  // clear the stored payload, mark the event processed, and deliver the
-  // ephemeral notice — then stop before binding/persistence.
+  // Respect disk-pressure cleanup so reactions don't bypass storage
+  // protection. Guardians resolve to `allow-cleanup-mode` (not `block`), so a
+  // guardian's approval-by-reaction still flows.
   const diskPressure = classifyDiskPressureTurnPolicy(getDiskPressureStatus(), {
     sourceChannel,
     sourceInterface,
@@ -194,32 +184,13 @@ export async function handleSlackReactionIntercept(
     },
   });
   if (diskPressure.action === "block") {
+    // Block silently: a reaction is a passive signal, so the message
+    // pipeline's "storage is low, try again" notice is meaningless for an
+    // emoji — there is nothing to retry. Mark the event processed and stop
+    // before binding/persistence.
     if (!result.duplicate) {
       clearPayload(result.eventId);
       markProcessed(result.eventId);
-    }
-    if (replyCallbackUrl && !result.duplicate) {
-      const replyPayload: Parameters<typeof deliverChannelReply>[1] = {
-        chatId: conversationExternalId,
-        text: DISK_PRESSURE_REMOTE_BLOCK_REPLY,
-        assistantId: canonicalAssistantId,
-      };
-      if (sourceChannel === "slack" && (canonicalSenderId ?? rawSenderId)) {
-        replyPayload.ephemeral = true;
-        replyPayload.user = (canonicalSenderId ?? rawSenderId)!;
-      }
-      try {
-        await deliverChannelReply(replyCallbackUrl, replyPayload);
-      } catch (err) {
-        log.warn(
-          {
-            err,
-            conversationId: result.conversationId,
-            eventId: result.eventId,
-          },
-          "Failed to deliver disk-pressure block reply for reaction",
-        );
-      }
     }
     return {
       accepted: true,


### PR DESCRIPTION
Closes [LUM-2489](https://linear.app/vellum/issue/LUM-2489/slack-emoji-reaction-on-a-public-channel-message-triggers-a)

Builds on #35344 (LUM-2488, merged) — that PR routed guardian approval-by-reaction through the canonical decision pipeline; this one fixes the orthogonal access-control bug and moves reactions to their own stage.

## Symptom

Reacting (e.g. 👍) to a message in a Slack channel the assistant participates in could trigger a trusted-contact **verification-handshake DM** to the reactor — *"I don't recognize you yet!… reply here with [the 6-digit code]."*

## Root cause

Reactions were processed **inside the message pipeline, after ingress ACL**. The gateway normalizes a reaction into an ordinary inbound event (`callbackData: "reaction:<emoji>"`), so a reaction from a user with no contact record hit `enforceIngressAcl` *first* and was treated as an access attempt — firing `initiateSlackVerificationChallenge` and creating a verification session. Reactions also ran `recordInbound`/`upsertBinding` (creating an empty conversation and writing the reactor into the binding) and the disk-pressure stage.

## Fix — the right altitude, not a carve-out

The handler already dispatches every other non-message event kind (edits, deletes, guardian activation) as an **early interceptor**; reactions were the one kind misplaced inside the message pipeline, which is why neutralizing the bug stage-by-stage was whack-a-mole. So reactions move into a dedicated `inbound-stages/reaction-intercept.ts`, dispatched **before ACL**. The interceptor:

- **drops a stranger's reaction** (`unknown` trust: no contact record, or blocked/revoked) before any write — no challenge, conversation, binding, or row;
- **records a known contact's reaction** (`unverified` / `trusted` / `guardian`) as an inline transcript signal;
- **routes a guardian's reaction** on an approval card through the canonical pipeline (`handleGuardianReplyIntercept`) — unchanged from #35344;
- **respects disk-pressure cleanup**, blocking **silently** (clear payload, mark processed, *no* reply — a 👍 has nothing to "try again") so reactions don't bypass storage protection.

Net: `handleChannelInbound` **shrinks** (the inline reaction block + helpers move out), and the per-stage carve-outs disappear because reactions never reach those stages.

## Trust tiers (`actor-trust-resolver`)

| Class | Means | Reaction |
|---|---|---|
| `guardian` | active guardian binding | recorded / routes approval |
| `trusted_contact` | active contact channel | recorded |
| `unverified_contact` | `pending`/`unverified` contact | recorded |
| `unknown` | no contact record, or blocked/revoked | **dropped** |

## Tests

`reaction-persistence.test.ts`: a stranger's reaction is dropped (no challenge, session, conversation, binding, or row) — verified to fail without the carve-out (the log shows `Slack verification challenge initiated for unknown contact`); a pending contact's reaction is recorded with no challenge. Existing reaction persistence and canonical approval-by-reaction (#35344) preserved; the disk-pressure reaction test now asserts the silent block. Local: `tsc` + eslint + prettier clean; suites green in isolation (a pre-existing cross-file `mock.module` contamination between `thread-backfill` and `inbound-slack-persistence` reproduces on clean main and is unrelated).

## Review findings

- Stranger → `upsertBinding` (Devin/Codex): resolved — strangers are dropped before any write.
- Disk-pressure reply to a reactor (Devin): fixed — reactions are now blocked **silently** (no confusing "try again" notice), which also deletes the duplicated reply constant/logic.
- Tautological `approvalConversationGenerator` assertion (Devin): pre-existing in the shared test adapter — filed [LUM-2509](https://linear.app/vellum/issue/LUM-2509) rather than pull shared test-infra into this PR.

## Follow-up

[LUM-2493](https://linear.app/vellum/issue/LUM-2493) — the broader typed event-kind dispatcher (retiring the `callbackData` string discriminators across all kinds). Reactions are the first kind migrated to a clean early stage; the rest is deliberate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwsiJAT1jnm65v3pnr9yQK