### PR TITLE
fix(gateway/slack): unify DM classification so DM thread-replies aren't dropped (LUM-2485)

### DIFF
--- a/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
@@ -84,10 +84,8 @@ const { clearChannelInfoCache, clearUserInfoCache, resolveSlackUser } =
   await import("../slack/normalize.js");
 const { handleInbound } = await import("../handlers/handle-inbound.js");
 const { initGatewayDb, resetGatewayDb } = await import("../db/connection.js");
-const {
-  initAdmissionPolicyCache,
-  resetAdmissionPolicyCache,
-} = await import("../risk/admission-policy-cache.js");
+const { initAdmissionPolicyCache, resetAdmissionPolicyCache } =
+  await import("../risk/admission-policy-cache.js");
 import type { SlackSocketModeConfig } from "../slack/socket-mode.js";
 
 type SocketModeHarness = {
@@ -1317,6 +1315,171 @@ describe("SlackSocketModeClient thread tracking", () => {
       expect(emitted[0].event.message.conversationExternalId).toBe("D-direct");
       expect(emitted[0].threadTs).toBeUndefined();
       expect(emitted[0].event.source.threadId).toBeUndefined();
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("emits a DM thread reply that omits channel_type via the DM path", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+
+    try {
+      await resolveSlackUser("U-dm", "xoxb-test");
+
+      // A reply inside a DM thread (e.g. answering an async/cron message the
+      // assistant posted). Slack omits `channel_type` on this sub-event and
+      // the thread was never armed, so DM-ness must come from the "D" channel
+      // ID prefix — otherwise the reply is silently dropped.
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-dm-thread",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-dm-thread",
+            event: {
+              type: "message",
+              user: "U-dm",
+              text: "yes, go ahead",
+              ts: "1700000000.000600",
+              channel: "D-direct",
+              thread_ts: "1700000000.000500",
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0].event.source.updateId).toBe("Ev-dm-thread");
+      expect(emitted[0].event.source.chatType).toBe("im");
+      expect(emitted[0].event.message.conversationExternalId).toBe("D-direct");
+      expect(emitted[0].threadTs).toBe("1700000000.000500");
+      expect(emitted[0].event.source.threadId).toBe("1700000000.000500");
+      // DMs route to the default assistant even when the channel is unmapped.
+      expect(emitted[0].routing).toEqual({
+        assistantId: "ast-default",
+        routeSource: "default",
+      });
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("emits a top-level DM that omits channel_type via the DM path", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+
+    try {
+      await resolveSlackUser("U-dm", "xoxb-test");
+
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-dm-no-type",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-dm-no-type",
+            event: {
+              type: "message",
+              user: "U-dm",
+              text: "hello from dm",
+              ts: "1700000000.000700",
+              channel: "D-direct",
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0].event.source.updateId).toBe("Ev-dm-no-type");
+      expect(emitted[0].event.source.chatType).toBe("im");
+      expect(emitted[0].threadTs).toBeUndefined();
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("admits a DM message edit that omits channel_type", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+
+    try {
+      await resolveSlackUser("U-dm", "xoxb-test");
+
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-dm-edit",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-dm-edit",
+            event: {
+              type: "message",
+              subtype: "message_changed",
+              channel: "D-direct",
+              message: {
+                user: "U-dm",
+                text: "edited in a dm",
+                ts: "1700000000.000800",
+              },
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0].event.source.updateId).toBe("Ev-dm-edit");
+      expect(emitted[0].event.message.isEdit).toBe(true);
+    } finally {
+      rawDb.close();
+    }
+  });
+
+  test("admits a DM message delete that omits channel_type", async () => {
+    const { rawDb, store } = createSlackStore();
+    const emitted: NormalizedSlackEvent[] = [];
+    const client = createHarness(store, (event) => emitted.push(event));
+    const ws = makeOpenSocket();
+
+    try {
+      await resolveSlackUser("U-dm", "xoxb-test");
+
+      client.handleMessage(
+        JSON.stringify({
+          envelope_id: "env-dm-delete",
+          type: "events_api",
+          payload: {
+            event_id: "Ev-dm-delete",
+            event: {
+              type: "message",
+              subtype: "message_deleted",
+              channel: "D-direct",
+              deleted_ts: "1700000000.000900",
+              previous_message: {
+                user: "U-dm",
+                text: "deleted in a dm",
+                ts: "1700000000.000900",
+              },
+            },
+          },
+        }),
+        ws,
+      );
+      await flushAsyncEventEmission();
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0].event.source.updateId).toBe("Ev-dm-delete");
+      expect(emitted[0].event.message.callbackData).toBe("message_deleted");
     } finally {
       rawDb.close();
     }

--- a/gateway/src/slack/channel.test.ts
+++ b/gateway/src/slack/channel.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import { isSlackDmChannel } from "./channel.js";
+
+describe("isSlackDmChannel", () => {
+  it("classifies an explicit im channel_type as a DM", () => {
+    expect(isSlackDmChannel("C0123ABCD", "im")).toBe(true);
+    expect(isSlackDmChannel("D0123ABCD", "im")).toBe(true);
+  });
+
+  it("classifies a D-prefixed conversation ID as a DM even without channel_type", () => {
+    expect(isSlackDmChannel("D0123ABCD")).toBe(true);
+    expect(isSlackDmChannel("D0123ABCD", undefined)).toBe(true);
+  });
+
+  it("does not classify channels or private groups as DMs", () => {
+    expect(isSlackDmChannel("C0123ABCD")).toBe(false);
+    expect(isSlackDmChannel("G0123ABCD", "mpim")).toBe(false);
+    expect(isSlackDmChannel("C0123ABCD", "channel")).toBe(false);
+  });
+
+  it("is not a DM when neither signal identifies one", () => {
+    expect(isSlackDmChannel(undefined)).toBe(false);
+    expect(isSlackDmChannel("")).toBe(false);
+  });
+});

--- a/gateway/src/slack/channel.ts
+++ b/gateway/src/slack/channel.ts
@@ -1,0 +1,35 @@
+/**
+ * Canonical classification of Slack conversations by kind.
+ *
+ * The Slack ingress path (`socket-mode.ts` event filters and `normalize.ts`
+ * normalizers) repeatedly needs to decide whether a conversation is a 1:1
+ * direct message, because DMs route to the default assistant and carry an
+ * `im` chat type. That decision is centralized here so every call site
+ * answers it identically — a DM that one filter recognizes and another does
+ * not is silently dropped.
+ */
+
+/**
+ * True when a Slack conversation is a 1:1 direct message (IM).
+ *
+ * Two independent signals each prove a DM, and either is sufficient:
+ *   - `channel_type === "im"` — reliable when Slack sends it, but Slack omits
+ *     it on message edits, deletes, and thread replies, and never sends it on
+ *     reaction or interactive payloads.
+ *   - a `D`-prefixed conversation ID — always present; only 1:1 IMs are
+ *     prefixed `D` (public channels are `C`, private channels and
+ *     multi-person IMs are `G` — https://api.slack.com/types/conversation).
+ *
+ * Gating on `channel_type` alone is what silently drops DM events that omit
+ * it; the ID prefix is the always-present fallback. Pass `channelType` only
+ * where the payload actually carries one.
+ */
+export function isSlackDmChannel(
+  channelId: string | undefined,
+  channelType?: string,
+): boolean {
+  return (
+    channelType === "im" ||
+    (typeof channelId === "string" && channelId.startsWith("D"))
+  );
+}

--- a/gateway/src/slack/normalize.ts
+++ b/gateway/src/slack/normalize.ts
@@ -1,5 +1,6 @@
 import { renderSlackTextForModel } from "@vellumai/slack-text";
 import { createHash } from "node:crypto";
+import { isSlackDmChannel } from "./channel.js";
 import type { GatewayConfig } from "../config.js";
 import { fetchImpl } from "../fetch.js";
 import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
@@ -816,7 +817,7 @@ export function normalizeSlackBlockActions(
   if (
     isRejection(routing) &&
     config.defaultAssistantId &&
-    channelId.startsWith("D")
+    isSlackDmChannel(channelId)
   ) {
     routing = {
       assistantId: config.defaultAssistantId,
@@ -888,7 +889,7 @@ function normalizeSlackReaction(
   if (
     isRejection(routing) &&
     config.defaultAssistantId &&
-    channel.startsWith("D")
+    isSlackDmChannel(channel)
   ) {
     routing = {
       assistantId: config.defaultAssistantId,
@@ -999,13 +1000,9 @@ export function normalizeSlackMessageEdit(
   // user is required for routing
   if (!edited.user) return null;
 
-  // Try channel routing, fall back to default for DMs. Slack's
-  // `message_changed` payload can omit `channel_type`, but DM channel IDs
-  // always start with "D" — fall back to the ID prefix so edits in DMs still
+  // Try channel routing, fall back to default for DMs so edits in DMs still
   // take the defaultAssistantId routing branch.
-  const isDm =
-    event.channel_type === "im" ||
-    (event.channel_type === undefined && event.channel.startsWith("D"));
+  const isDm = isSlackDmChannel(event.channel, event.channel_type);
   let routing = resolveAssistant(config, event.channel, edited.user);
   if (isRejection(routing) && isDm && config.defaultAssistantId) {
     routing = {
@@ -1081,12 +1078,9 @@ export function normalizeSlackMessageDelete(
   // back to a synthetic identifier so routing/trust still has something to key on.
   const actorId = event.previous_message?.user ?? "slack-system";
 
-  // Slack's `message_deleted` payload frequently omits `channel_type`, but DM
-  // channel IDs always start with "D". Fall back to the ID prefix so deletes
-  // from DMs still take the defaultAssistantId routing branch.
-  const isDm =
-    event.channel_type === "im" ||
-    (event.channel_type === undefined && event.channel.startsWith("D"));
+  // Fall back to the default assistant for DMs so deletes from DMs still take
+  // the defaultAssistantId routing branch.
+  const isDm = isSlackDmChannel(event.channel, event.channel_type);
   let routing = resolveAssistant(config, event.channel, actorId);
   if (isRejection(routing) && isDm && config.defaultAssistantId) {
     routing = {

--- a/gateway/src/slack/socket-mode.ts
+++ b/gateway/src/slack/socket-mode.ts
@@ -18,6 +18,7 @@ import {
   runWithConcurrency,
   type SlackHistoryMessage,
 } from "./slack-web.js";
+import { isSlackDmChannel } from "./channel.js";
 import {
   normalizeSlackAppMention,
   normalizeSlackDirectMessage,
@@ -860,7 +861,10 @@ export class SlackSocketModeClient {
       );
     const isMessageChanged =
       isMessageChangedRaw &&
-      (messageChangedEvent.channel_type === "im" ||
+      (isSlackDmChannel(
+        messageChangedEvent.channel,
+        messageChangedEvent.channel_type,
+      ) ||
         (!!messageChangedEvent.message?.thread_ts &&
           this.store.hasThread(messageChangedEvent.message.thread_ts)) ||
         (!!messageChangedEvent.message?.ts &&
@@ -874,7 +878,10 @@ export class SlackSocketModeClient {
       event.type === "message" &&
       messageDeletedEvent.subtype === "message_deleted" &&
       !!messageDeletedEvent.deleted_ts &&
-      (messageDeletedEvent.channel_type === "im" ||
+      (isSlackDmChannel(
+        messageDeletedEvent.channel,
+        messageDeletedEvent.channel_type,
+      ) ||
         (!!messageDeletedEvent.previous_message?.thread_ts &&
           this.store.hasThread(
             messageDeletedEvent.previous_message.thread_ts,
@@ -891,7 +898,7 @@ export class SlackSocketModeClient {
       event.type === "message" &&
       !isMessageChanged &&
       !isMessageDeleted &&
-      dmEvent.channel_type === "im";
+      isSlackDmChannel(dmEvent.channel, dmEvent.channel_type);
     const mentionsBot = channelEvent.text?.includes(`<@${botUserId}>`);
     const isActiveThreadReply =
       event.type === "message" &&
@@ -915,7 +922,7 @@ export class SlackSocketModeClient {
     const reactionTargetChannel = reactionEvent.item?.channel;
     const reactionAdmitChannel =
       !!reactionTargetChannel &&
-      (reactionTargetChannel.startsWith("D") ||
+      (isSlackDmChannel(reactionTargetChannel) ||
         this.isChannelSubscribed(reactionTargetChannel) ||
         (!!reactionEvent.item?.ts &&
           this.store.hasThread(reactionEvent.item.ts)));
@@ -1539,14 +1546,15 @@ export class SlackSocketModeClient {
     }
 
     const mentionsBot = msg.text?.includes(`<@${botUserId}>`) ?? false;
-    const isDm = channel.startsWith("D");
-    // DMs are always delivered as `type: "message"` with `channel_type: "im"`
-    // by live Slack, even when the bot is `<@U…>`-mentioned in the body —
-    // Slack only emits `app_mention` for non-DM channels. Synthesizing a DM
-    // as `app_mention` would route through `normalizeSlackAppMention`, which
-    // (intentionally) lacks the DM default-assistant fallback that
-    // `normalizeSlackDirectMessage` provides, so an unrouted DM @-mention
-    // would silently drop in `unmappedPolicy: "reject"` deployments.
+    // `conversations.history`/`replies` carry no `channel_type`, so classify
+    // DMs by the conversation ID prefix.
+    const isDm = isSlackDmChannel(channel);
+    // Slack only emits `app_mention` in non-DM channels, even when the bot is
+    // `<@U…>`-mentioned in a DM body. Synthesizing a DM as `app_mention` would
+    // route through `normalizeSlackAppMention`, which (intentionally) lacks the
+    // DM default-assistant fallback that `normalizeSlackDirectMessage`
+    // provides, so an unrouted DM @-mention would silently drop in
+    // `unmappedPolicy: "reject"` deployments.
     const eventType: "app_mention" | "message" =
       mentionsBot && !isDm ? "app_mention" : "message";
 


### PR DESCRIPTION
## Summary

A thread-reply inside a Slack DM with the assistant was **silently dropped** — no error, no agent loop — so async/cron flows that DM the user and expect a reply-in-thread were effectively one-way (LUM-2485).

## Root cause

"Is this conversation a DM?" was answered **nine different ways across two files, with three different implementations:**

| Implementation | Sites | Correct when `channel_type` absent? |
|---|---|---|
| `channel_type === "im"` only | `isDm`, `isMessageChanged`, `isMessageDeleted` filters (`socket-mode.ts`) | ❌ drops the event |
| `channel.startsWith("D")` only | reaction-admit, replay-synthesis (`socket-mode.ts`); block_actions, reaction normalizer (`normalize.ts`) | ✓ |
| `im \|\| (undefined && D)` hybrid | edit, delete normalizers (`normalize.ts`) | ✓ |

Slack omits `channel_type` on a large fraction of message events (it's "frequently" absent on edits/deletes and unreliable on thread-replies — documented, server-side-confirmed field gaps). When a DM thread-reply arrived without `channel_type`, the live `isDm` filter said "not a DM", and since an async/cron DM posts a *top-level* message that never arms a thread, the active-thread filter didn't catch it either. Net result: the event never reached a normalizer, routing, or the agent loop.

The Linear issue pointed at `normalizeSlackChannelMessage` and the "arming never loosens forwarding" guard — those are a symptom site and an unrelated (channel-thread) mechanism. The real defect is upstream: **forked channel classification.**

## The fix

Introduce one canonical classifier, `gateway/src/slack/channel.ts`:

```ts
isSlackDmChannel(channelId, channelType?) // trusts explicit channel_type; falls back to the D… ID prefix
```

and route **all nine sites** through it. The six prefix/hybrid sites are **behavior-preserving**; the three `channel_type`-only sites (`isDm` + the edit/delete filters) gain the prefix fallback — that's the fix, and it falls out of unification rather than being bolted on. This matches the gateway's existing single-source-of-truth conventions (e.g. the canonical `TrustClass` classifier — "no fork").

## Behavioral change (called out)

DM messages — top-level **and** thread-replies — plus DM edits/deletes that omit `channel_type` are now classified as DMs and routed to `normalizeSlackDirectMessage` / the edit/delete normalizers (which already set `chatType: "im"` and apply the default-assistant fallback). Only IMs are prefixed `D` (public `C`, private/mpim `G`), and an explicit non-`im` `channel_type` is never overridden — so no channel/group message can be misclassified.

## Tests

- `channel.test.ts` — classifier truth table.
- `slack-socket-mode-thread-tracking.test.ts` — integration regressions: DM thread-reply, top-level DM, and DM edit/delete that all omit `channel_type` are emitted/admitted.
- Full Slack + downstream (`handle-inbound-admission`, `resolve-assistant`) suites pass; typecheck/eslint/prettier clean.

## Out of scope (surfaced, not bundled)

- **Dispatch shape:** `processEventPayload` computes eight booleans threaded through `normalizeAndEmit(…)`. A `classifySlackEvent → discriminated-union + switch` is the from-scratch-ideal dispatch, but rewriting a race-sensitive ingress state machine inside a bugfix mixes concerns — recommend a dedicated follow-up.
- **Reconnect catch-up gap:** DM thread-replies arriving during a socket reconnect aren't recovered (`conversations.history` returns top-level only; DM threads aren't armed). Narrower (reconnect-window only) — its own ticket.
- **Daemon `startsWith("D")` sites (4):** outbound delivery/notification addressing in `assistant/`; only a stored chat ID is available (no `channel_type` to reconcile), correct as-is, different package.

Closes LUM-2485.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBeXq7TEG2Whk8bZPpwKsP

---
_Generated by [Claude Code](https://claude.ai/code/session_01JBeXq7TEG2Whk8bZPpwKsP)_