### PR TITLE
feat(fetch): web-fetch provider abstraction + Firecrawl /scrape

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -16287,6 +16287,11 @@ paths:
                                         type: string
                                       finalUrl:
                                         type: string
+                                      provider:
+                                        type: string
+                                        enum:
+                                          - default
+                                          - firecrawl
                                       status:
                                         type: number
                                       contentType:
@@ -16670,6 +16675,11 @@ paths:
                                                 type: string
                                               finalUrl:
                                                 type: string
+                                              provider:
+                                                type: string
+                                                enum:
+                                                  - default
+                                                  - firecrawl
                                               status:
                                                 type: number
                                               contentType:
@@ -28770,6 +28780,16 @@ components:
                       type: string
                   additionalProperties: {}
                 - type: "null"
+            web-fetch:
+              anyOf:
+                - type: object
+                  properties:
+                    mode:
+                      $ref: "#/components/schemas/ServiceMode"
+                    provider:
+                      type: string
+                  additionalProperties: {}
+                - type: "null"
             image-generation:
               anyOf:
                 - type: object
@@ -29499,6 +29519,14 @@ components:
           type: object
           properties:
             web-search:
+              type: object
+              properties:
+                mode:
+                  $ref: "#/components/schemas/ServiceMode"
+                provider:
+                  type: string
+              additionalProperties: {}
+            web-fetch:
               type: object
               properties:
                 mode:

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -156,6 +156,29 @@ describe("AssistantConfigSchema", () => {
     expect(result.services["web-search"].mode).toBe("your-own");
   });
 
+  test("defaults the web-fetch provider to the built-in fetcher", () => {
+    const result = AssistantConfigSchema.parse({});
+    expect(result.services["web-fetch"].provider).toBe("default");
+  });
+
+  test("accepts Firecrawl as a web fetch provider", () => {
+    const result = AssistantConfigSchema.parse({
+      services: {
+        "web-fetch": { mode: "your-own", provider: "firecrawl" },
+      },
+    });
+
+    expect(result.services["web-fetch"].provider).toBe("firecrawl");
+  });
+
+  test("rejects an unknown web-fetch provider", () => {
+    expect(() =>
+      AssistantConfigSchema.parse({
+        services: { "web-fetch": { provider: "nope" } },
+      }),
+    ).toThrow();
+  });
+
   test("accepts valid complete config", () => {
     const input = {
       llm: {

--- a/assistant/src/api/events/tool-result.ts
+++ b/assistant/src/api/events/tool-result.ts
@@ -52,6 +52,10 @@ export const WebSearchProviderIdSchema = z.enum([
 
 export type WebSearchProviderId = z.infer<typeof WebSearchProviderIdSchema>;
 
+export const WebFetchProviderIdSchema = z.enum(["default", "firecrawl"]);
+
+export type WebFetchProviderId = z.infer<typeof WebFetchProviderIdSchema>;
+
 export const WebSearchResultItemSchema = z.object({
   rank: z.number(),
   title: z.string(),
@@ -79,6 +83,7 @@ export type WebSearchMetadata = z.infer<typeof WebSearchMetadataSchema>;
 export const WebFetchMetadataSchema = z.object({
   url: z.string(),
   finalUrl: z.string(),
+  provider: WebFetchProviderIdSchema.optional(),
   status: z.number(),
   contentType: z.string().optional(),
   byteCount: z.number(),

--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { DEFAULT_IMAGE_MODEL } from "../../media/image-models.js";
+import { FETCH_PROVIDER_IDS } from "../../providers/fetch-provider-catalog.js";
 import { SEARCH_PROVIDER_IDS } from "../../providers/search-provider-catalog.js";
 import { SttServiceSchema } from "./stt.js";
 import { TtsServiceSchema } from "./tts.js";
@@ -27,6 +28,13 @@ const VALID_IMAGE_GEN_PROVIDERS = ["gemini", "openai"] as const;
  * here required.
  */
 const VALID_WEB_SEARCH_PROVIDERS = SEARCH_PROVIDER_IDS;
+
+/**
+ * Derived from `FETCH_PROVIDER_CATALOG`. Adding a new web-fetch provider
+ * to the catalog automatically extends the config-schema enum — no edit
+ * here required.
+ */
+const VALID_WEB_FETCH_PROVIDERS = FETCH_PROVIDER_IDS;
 
 const BaseServiceSchema = z.object({
   mode: ServiceModeSchema.default("your-own"),
@@ -56,6 +64,15 @@ const WebSearchServiceSchema = BaseServiceSchema.extend({
   provider: z
     .enum(VALID_WEB_SEARCH_PROVIDERS)
     .default("inference-provider-native"),
+});
+
+const WebFetchServiceSchema = BaseServiceSchema.extend({
+  // Provider that backs the `web_fetch` tool. `default` is the daemon's
+  // built-in HTTP fetch + extract path (no key). BYOK providers (e.g.
+  // `firecrawl`) scrape via their hosted API and reuse the same stored key as
+  // their web-search counterpart. The `mode` field is inherited from
+  // `BaseServiceSchema` for symmetry; web-fetch has no managed proxy today.
+  provider: z.enum(VALID_WEB_FETCH_PROVIDERS).default("default"),
 });
 
 const GoogleOAuthServiceSchema = BaseServiceSchema.extend({
@@ -142,6 +159,7 @@ export const ServicesSchema = z.object({
   "web-search": WebSearchServiceSchema.default(
     WebSearchServiceSchema.parse({}),
   ),
+  "web-fetch": WebFetchServiceSchema.default(WebFetchServiceSchema.parse({})),
   stt: SttServiceSchema.default({
     mode: "your-own" as const,
     provider: "deepgram" as const,

--- a/assistant/src/daemon/message-types/web-activity.ts
+++ b/assistant/src/daemon/message-types/web-activity.ts
@@ -12,6 +12,9 @@ export type WebSearchProviderId =
   | "tavily"
   | "firecrawl";
 
+/** Provider that backed a `web_fetch` call. `default` is the built-in fetcher. */
+export type WebFetchProviderId = "default" | "firecrawl";
+
 export interface WebSearchResultItem {
   rank: number; // 1-indexed
   title: string;
@@ -36,6 +39,8 @@ export interface WebSearchMetadata {
 export interface WebFetchMetadata {
   url: string;
   finalUrl: string;
+  /** Provider that served the fetch. Defaults to the built-in fetcher. */
+  provider?: WebFetchProviderId;
   status: number;
   contentType?: string;
   byteCount: number;

--- a/assistant/src/providers/fetch-provider-catalog.ts
+++ b/assistant/src/providers/fetch-provider-catalog.ts
@@ -1,0 +1,85 @@
+/**
+ * Canonical catalog of built-in web-fetch providers.
+ *
+ * This is the single source of truth that drives the config-schema enum
+ * (`VALID_WEB_FETCH_PROVIDERS` in `assistant/src/config/schemas/services.ts`)
+ * and the client picker mirror in
+ * `clients/web/src/assistant/generated/web-fetch-provider-catalog.gen.ts`.
+ *
+ * Mirrors `search-provider-catalog.ts`. Where web-search distinguishes
+ * `managed` (platform proxy) from `byok` (user key), web-fetch has no managed
+ * proxy yet, so the two kinds are:
+ *
+ *   - `builtin` — the daemon's own HTTP fetch + extract path (`default`). No
+ *     key, always available, the default.
+ *   - `byok`    — an external provider that needs a user-supplied key (e.g.
+ *     `firecrawl`, which scrapes via its hosted API and returns clean
+ *     markdown, including for JavaScript-rendered pages the builtin fetcher
+ *     can't see).
+ *
+ * BYOK fetch providers intentionally reuse the SAME bare-name credential as
+ * their search counterpart (e.g. `firecrawl` → `FIRECRAWL_API_KEY`), so a
+ * single stored key powers both `web_search` and `web_fetch`. The key is
+ * already registered in `API_KEY_PROVIDERS` via `SEARCH_PROVIDER_CATALOG`;
+ * this catalog deliberately does NOT re-register it.
+ */
+
+export type FetchProviderKind = "builtin" | "byok";
+
+export interface FetchProviderCatalogEntry {
+  /** Stable provider identifier. Matches config values. */
+  readonly id: string;
+  /** Short display name used by picker UIs. */
+  readonly displayName: string;
+  /** Optional long display name for prose contexts. */
+  readonly displayNameLong?: string;
+  /** `builtin` (no key) or `byok` (user-supplied key). */
+  readonly kind: FetchProviderKind;
+  /** Placeholder shown in the API-key input. BYOK providers only. */
+  readonly apiKeyPrefix?: string;
+  /** Environment variable name carrying the API key. BYOK providers only. */
+  readonly envVar?: string;
+  /** Secret-catalog key (the bare provider name accepted by
+   *  `getProviderKeyAsync`). BYOK providers only. */
+  readonly secretKey?: string;
+  /** Privacy-policy URL surfaced in marketing data-sharing docs.
+   *  BYOK providers only. */
+  readonly privacyPolicyUrl?: string;
+}
+
+export const FETCH_PROVIDER_CATALOG: readonly FetchProviderCatalogEntry[] = [
+  {
+    id: "default",
+    displayName: "Built-in",
+    displayNameLong: "Built-in fetcher",
+    kind: "builtin",
+  },
+  {
+    id: "firecrawl",
+    displayName: "Firecrawl",
+    kind: "byok",
+    apiKeyPrefix: "fc-...",
+    envVar: "FIRECRAWL_API_KEY",
+    secretKey: "firecrawl",
+    privacyPolicyUrl: "https://www.firecrawl.dev/privacy-policy",
+  },
+];
+
+/** Provider ids accepted by the web-fetch config schema. */
+export const FETCH_PROVIDER_IDS: readonly string[] =
+  FETCH_PROVIDER_CATALOG.map((p) => p.id);
+
+/** Catalog entries that require a user-supplied API key. */
+export const BYOK_FETCH_PROVIDERS: readonly FetchProviderCatalogEntry[] =
+  FETCH_PROVIDER_CATALOG.filter((p) => p.kind === "byok");
+
+/** BYOK fetch-provider ids. */
+export const BYOK_FETCH_PROVIDER_IDS: readonly string[] =
+  BYOK_FETCH_PROVIDERS.map((p) => p.id);
+
+/** Look up a single catalog entry by id. Returns `undefined` if unknown. */
+export function getFetchProvider(
+  id: string,
+): FetchProviderCatalogEntry | undefined {
+  return FETCH_PROVIDER_CATALOG.find((p) => p.id === id);
+}

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -536,6 +536,13 @@ const ConfigGetResponseSchema = z
           })
           .passthrough()
           .optional(),
+        "web-fetch": z
+          .object({
+            mode: ServiceModeSchema.optional(),
+            provider: z.string().optional(),
+          })
+          .passthrough()
+          .optional(),
         "image-generation": z
           .object({ mode: ServiceModeSchema.optional() })
           .passthrough()
@@ -626,6 +633,14 @@ const ConfigPatchRequestSchema = z
     services: z
       .object({
         "web-search": z
+          .object({
+            mode: ServiceModeSchema.optional(),
+            provider: z.string().optional(),
+          })
+          .passthrough()
+          .nullable()
+          .optional(),
+        "web-fetch": z
           .object({
             mode: ServiceModeSchema.optional(),
             provider: z.string().optional(),

--- a/assistant/src/tools/network/__tests__/web-fetch-firecrawl.test.ts
+++ b/assistant/src/tools/network/__tests__/web-fetch-firecrawl.test.ts
@@ -1,0 +1,360 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// --- Mutable mock state (per test) -----------------------------------------
+let mockWebFetchProvider: string | undefined = "default";
+let mockFirecrawlSecureKey: string | undefined;
+
+// Capture the registered tool so we can exercise provider dispatch.
+let capturedTool: any = null;
+
+mock.module("../../registry.js", () => ({
+  registerTool: (tool: any) => {
+    capturedTool = tool;
+  },
+}));
+
+mock.module("../../../config/loader.js", () => ({
+  getConfig: () => ({
+    services: {
+      "web-fetch": { mode: "your-own", provider: mockWebFetchProvider },
+    },
+  }),
+}));
+
+mock.module("../../../security/secure-keys.js", () => ({
+  getProviderKeyAsync: async (provider: string) =>
+    provider === "firecrawl" ? mockFirecrawlSecureKey : undefined,
+}));
+
+const realLogger = await import("../../../util/logger.js");
+mock.module("../../../util/logger.js", () => ({
+  ...realLogger,
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+mock.module("../../../permissions/types.js", () => ({
+  RiskLevel: { Low: "low", Medium: "medium", High: "high" },
+}));
+
+// Keep real url-safety helpers (parseUrl, sanitize*, isPrivateOrLocalHost,
+// resolveRequestAddress) but stub DNS resolution. The returned address list is
+// mutable per test: an empty list makes the built-in fallback path
+// short-circuit ("Unable to resolve host") before any socket is opened, while a
+// public address lets a Firecrawl-routed request through the dispatcher's DNS
+// safety gate. A private address exercises the "don't leak to Firecrawl" guard.
+let mockResolveAddresses: string[] = [];
+const realUrlSafety = await import("../url-safety.js");
+mock.module("../url-safety.js", () => ({
+  ...realUrlSafety,
+  resolveHostAddresses: async () => mockResolveAddresses,
+}));
+
+const { executeFirecrawlScrape } = await import("../web-fetch.js");
+
+const SCRAPE_URL = "api.firecrawl.dev/v2/scrape";
+
+function scrapeResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("executeFirecrawlScrape", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("returns markdown content + metadata on success", async () => {
+    globalThis.fetch = (async () =>
+      scrapeResponse({
+        success: true,
+        data: {
+          markdown: "# Example\n\nHello from Firecrawl.",
+          metadata: {
+            title: "Example Domain",
+            description: "An example page",
+            url: "https://example.com/",
+            statusCode: 200,
+            contentType: "text/html",
+          },
+        },
+      })) as any;
+
+    const result = await executeFirecrawlScrape(
+      { url: "https://example.com" },
+      { apiKey: "fc-test-key" },
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Hello from Firecrawl.");
+    expect(result.content).toContain("Mode: markdown");
+    expect(result.content).toContain("Title: Example Domain");
+    const meta = result.activityMetadata?.webFetch;
+    expect(meta?.provider).toBe("firecrawl");
+    expect(meta?.status).toBe(200);
+    expect(meta?.title).toBe("Example Domain");
+    expect(meta?.finalUrl).toContain("example.com");
+  });
+
+  test("sends the correct request shape", async () => {
+    let capturedUrl = "";
+    let capturedBody: any = null;
+    let capturedHeaders: Headers | null = null;
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      capturedUrl = url;
+      capturedBody = JSON.parse(init?.body as string);
+      capturedHeaders = new Headers(init?.headers);
+      return scrapeResponse({ success: true, data: { markdown: "ok" } });
+    }) as any;
+
+    await executeFirecrawlScrape(
+      { url: "https://example.com/docs" },
+      { apiKey: "fc-test-key" },
+    );
+
+    expect(capturedUrl).toContain(SCRAPE_URL);
+    expect(capturedBody.url).toBe("https://example.com/docs");
+    expect(capturedBody.formats).toEqual(["markdown"]);
+    expect(capturedBody.onlyMainContent).toBe(true);
+    expect(capturedHeaders!.get("authorization")).toBe("Bearer fc-test-key");
+    expect(capturedHeaders!.get("x-client-source")).toBe("vellum-assistant");
+  });
+
+  test("honors max_chars windowing and emits a truncation notice", async () => {
+    globalThis.fetch = (async () =>
+      scrapeResponse({
+        success: true,
+        data: { markdown: "abcdefghij", metadata: { statusCode: 200 } },
+      })) as any;
+
+    const result = await executeFirecrawlScrape(
+      { url: "https://example.com", max_chars: 4 },
+      { apiKey: "fc-key" },
+    );
+    expect(result.isError).toBe(false);
+    expect(result.activityMetadata?.webFetch?.truncated).toBe(true);
+    expect(result.status).toContain("truncated");
+  });
+
+  test("empty markdown yields a no-content marker, not an error", async () => {
+    globalThis.fetch = (async () =>
+      scrapeResponse({ success: true, data: { markdown: "" } })) as any;
+
+    const result = await executeFirecrawlScrape(
+      { url: "https://example.com" },
+      { apiKey: "fc-key" },
+    );
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("<no_content />");
+  });
+
+  test("rejects URLs with embedded credentials instead of forwarding them", async () => {
+    let hit = false;
+    globalThis.fetch = (async () => {
+      hit = true;
+      return scrapeResponse({ success: true, data: { markdown: "x" } });
+    }) as any;
+
+    const result = await executeFirecrawlScrape(
+      { url: "https://user:secret@example.com/page" },
+      { apiKey: "fc-key" },
+    );
+    expect(hit).toBe(false); // never sent to Firecrawl
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("embedded credentials");
+    // The secret must not leak into the surfaced url/metadata.
+    expect(result.content).not.toContain("secret");
+  });
+
+  test("surfaces a payload-level failure on a 200 (success:false / error)", async () => {
+    globalThis.fetch = (async () =>
+      scrapeResponse({
+        success: false,
+        error: "This website is no longer supported",
+        data: {},
+      })) as any;
+
+    const result = await executeFirecrawlScrape(
+      { url: "https://example.com" },
+      { apiKey: "fc-key" },
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("no longer supported");
+  });
+
+  test("surfaces invalid JSON as a clean error", async () => {
+    globalThis.fetch = (async () =>
+      new Response("<html>not json</html>", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as any;
+
+    const result = await executeFirecrawlScrape(
+      { url: "https://example.com" },
+      { apiKey: "fc-key" },
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("invalid JSON");
+  });
+
+  test.each([401, 403])("surfaces %d as an invalid-key error", async (status) => {
+    globalThis.fetch = (async () =>
+      new Response("Unauthorized", { status })) as any;
+
+    const result = await executeFirecrawlScrape(
+      { url: "https://example.com" },
+      { apiKey: "bad-key" },
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Invalid or expired Firecrawl API key");
+    expect(result.activityMetadata?.webFetch?.provider).toBe("firecrawl");
+  });
+
+  test("retries 429 then surfaces a rate-limit error", async () => {
+    let callCount = 0;
+    globalThis.fetch = (async () => {
+      callCount++;
+      return new Response("Too Many Requests", {
+        status: 429,
+        headers: { "retry-after": "0" },
+      });
+    }) as any;
+
+    const result = await executeFirecrawlScrape(
+      { url: "https://example.com" },
+      { apiKey: "fc-key" },
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("rate limit");
+    expect(callCount).toBe(4); // 1 + DEFAULT_MAX_RETRIES
+  });
+});
+
+describe("web_fetch provider dispatch", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  const execute = (input: Record<string, unknown>, ctx: any = {}) =>
+    capturedTool.execute(input, ctx);
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    mockWebFetchProvider = "default";
+    mockFirecrawlSecureKey = undefined;
+    mockResolveAddresses = [];
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("routes to Firecrawl when provider=firecrawl and a key is set", async () => {
+    mockWebFetchProvider = "firecrawl";
+    mockFirecrawlSecureKey = "fc-key";
+    mockResolveAddresses = ["93.184.216.34"]; // public → passes the DNS safety gate
+    let hitUrl = "";
+    globalThis.fetch = (async (url: string) => {
+      hitUrl = url;
+      return scrapeResponse({
+        success: true,
+        data: { markdown: "routed", metadata: { statusCode: 200 } },
+      });
+    }) as any;
+
+    const result = await execute({ url: "https://example.com" });
+    expect(hitUrl).toContain(SCRAPE_URL);
+    expect(result.activityMetadata?.webFetch?.provider).toBe("firecrawl");
+  });
+
+  test("falls back to the built-in fetcher when provider=firecrawl but no key", async () => {
+    mockWebFetchProvider = "firecrawl";
+    mockFirecrawlSecureKey = undefined;
+    let firecrawlHit = false;
+    globalThis.fetch = (async (url: string) => {
+      if (typeof url === "string" && url.includes(SCRAPE_URL)) {
+        firecrawlHit = true;
+      }
+      return new Response("", { status: 200 });
+    }) as any;
+
+    const result = await execute({ url: "https://example.com" });
+    // Built-in path runs (DNS stubbed to empty → resolve error), Firecrawl not hit.
+    expect(firecrawlHit).toBe(false);
+    expect(result.activityMetadata?.webFetch?.provider).toBe("default");
+  });
+
+  test("provider=default never touches Firecrawl", async () => {
+    mockWebFetchProvider = "default";
+    mockFirecrawlSecureKey = "fc-key";
+    let firecrawlHit = false;
+    globalThis.fetch = (async (url: string) => {
+      if (typeof url === "string" && url.includes(SCRAPE_URL)) {
+        firecrawlHit = true;
+      }
+      return new Response("", { status: 200 });
+    }) as any;
+
+    const result = await execute({ url: "https://example.com" });
+    expect(firecrawlHit).toBe(false);
+    expect(result.activityMetadata?.webFetch?.provider).toBe("default");
+  });
+
+  test("private/local targets bypass Firecrawl and use the built-in fetcher", async () => {
+    mockWebFetchProvider = "firecrawl";
+    mockFirecrawlSecureKey = "fc-key";
+    let firecrawlHit = false;
+    globalThis.fetch = (async (url: string) => {
+      if (typeof url === "string" && url.includes(SCRAPE_URL)) {
+        firecrawlHit = true;
+      }
+      return new Response("", { status: 200 });
+    }) as any;
+
+    const result = await execute({ url: "http://localhost:8080/admin" });
+    expect(firecrawlHit).toBe(false);
+    expect(result.isError).toBe(true);
+    expect(result.content.toLowerCase()).toContain("private");
+    expect(result.activityMetadata?.webFetch?.provider).toBe("default");
+  });
+
+  test("a public host that DNS-resolves to a private IP is not sent to Firecrawl", async () => {
+    mockWebFetchProvider = "firecrawl";
+    mockFirecrawlSecureKey = "fc-key";
+    mockResolveAddresses = ["10.0.0.5"]; // public name, private address → blocked
+    let firecrawlHit = false;
+    globalThis.fetch = (async (url: string) => {
+      if (typeof url === "string" && url.includes(SCRAPE_URL)) {
+        firecrawlHit = true;
+      }
+      return new Response("", { status: 200 });
+    }) as any;
+
+    const result = await execute({ url: "https://internal.example/secret?token=abc" });
+    expect(firecrawlHit).toBe(false); // internal URL never leaked to Firecrawl
+    expect(result.isError).toBe(true);
+    expect(result.activityMetadata?.webFetch?.provider).toBe("default");
+  });
+
+  test("non-http(s) schemes are not sent to Firecrawl", async () => {
+    mockWebFetchProvider = "firecrawl";
+    mockFirecrawlSecureKey = "fc-key";
+    mockResolveAddresses = ["93.184.216.34"];
+    let firecrawlHit = false;
+    globalThis.fetch = (async (url: string) => {
+      if (typeof url === "string" && url.includes(SCRAPE_URL)) {
+        firecrawlHit = true;
+      }
+      return new Response("", { status: 200 });
+    }) as any;
+
+    const result = await execute({ url: "ftp://example.com/file" });
+    expect(firecrawlHit).toBe(false);
+    expect(result.isError).toBe(true);
+    expect(result.activityMetadata?.webFetch?.provider).toBe("default");
+  });
+});

--- a/assistant/src/tools/network/web-fetch.ts
+++ b/assistant/src/tools/network/web-fetch.ts
@@ -5,11 +5,22 @@ import {
 } from "node:https";
 import { Readable } from "node:stream";
 
-import type { WebFetchMetadata } from "../../daemon/message-types/web-activity.js";
+import { getConfig } from "../../config/loader.js";
+import type {
+  WebFetchMetadata,
+  WebFetchProviderId,
+} from "../../daemon/message-types/web-activity.js";
 import { RiskLevel } from "../../permissions/types.js";
+import { getProviderKeyAsync } from "../../security/secure-keys.js";
 import { wrapUntrustedContent } from "../../security/untrusted-content.js";
 import { faviconUrlForDomain } from "../../util/favicon.js";
 import { getLogger } from "../../util/logger.js";
+import {
+  DEFAULT_BASE_DELAY_MS,
+  DEFAULT_MAX_RETRIES,
+  getHttpRetryDelay,
+  sleep,
+} from "../../util/retry.js";
 import { safeStringSlice } from "../../util/unicode.js";
 import { registerTool } from "../registry.js";
 import type {
@@ -34,6 +45,8 @@ import {
 } from "./url-safety.js";
 
 const log = getLogger("web-fetch");
+
+const FIRECRAWL_SCRAPE_API_URL = "https://api.firecrawl.dev/v2/scrape";
 
 const DEFAULT_TIMEOUT_SECONDS = 20;
 const MAX_TIMEOUT_SECONDS = 60;
@@ -614,6 +627,7 @@ export async function executeWebFetch(
         webFetch: {
           url: safeUrl,
           finalUrl: safeFinalUrl,
+          provider: "default",
           status: meta.status ?? 0,
           contentType: meta.contentType,
           byteCount: 0,
@@ -972,6 +986,7 @@ export async function executeWebFetch(
     const meta: WebFetchMetadata = {
       url: safeRequestedUrl,
       finalUrl: sanitizeUrlForOutput(currentUrl),
+      provider: "default",
       status: getUpstreamStatus(response),
       contentType: contentType || undefined,
       byteCount: body.bytesRead,
@@ -1029,6 +1044,349 @@ export async function executeWebFetch(
   }
 }
 
+// ----------------------------------------------------------------------------
+// Provider abstraction
+//
+// `web_fetch` defaults to the built-in fetcher above (`executeWebFetch`). When
+// `services.web-fetch.provider` selects a BYOK provider (e.g. `firecrawl`),
+// the tool routes through that provider's hosted API instead — which can read
+// JavaScript-rendered pages the static fetcher can't. The provider's stored
+// key is shared with its web-search counterpart (one `firecrawl` key powers
+// both tools). The dispatcher falls back to the built-in fetcher when the
+// provider has no key, or when the target is a private/local host the hosted
+// scraper can't reach.
+// ----------------------------------------------------------------------------
+
+interface FirecrawlScrapeMetadata {
+  title?: string;
+  description?: string;
+  sourceURL?: string;
+  url?: string;
+  statusCode?: number;
+  contentType?: string;
+  error?: string;
+}
+
+interface FirecrawlScrapeResponse {
+  success?: boolean;
+  data?: {
+    markdown?: string;
+    metadata?: FirecrawlScrapeMetadata;
+    warning?: string | null;
+  };
+  warning?: string | null;
+  error?: string;
+}
+
+function getWebFetchProvider(): WebFetchProviderId {
+  const configured = getConfig().services["web-fetch"]?.provider ?? "default";
+  return configured === "firecrawl" ? "firecrawl" : "default";
+}
+
+/**
+ * Decide whether a request may be routed to the hosted Firecrawl provider.
+ *
+ * Posting a URL to Firecrawl sends its path + query (which can hold secrets) to
+ * a third party, so we apply the SAME safety gate as the built-in fetcher
+ * BEFORE dispatching — not just the lexical host check:
+ *   - only http(s) URLs (Firecrawl can't do other schemes anyway),
+ *   - never `allow_private_network` requests (those are intentionally local;
+ *     Firecrawl can't reach them and the built-in path owns that mode),
+ *   - and a DNS resolution check so a public hostname that resolves to a
+ *     private/blocked address (e.g. `internal.example` → 10.x.x.x) is NOT
+ *     leaked to Firecrawl.
+ * Anything that fails falls back to the built-in fetcher, which enforces its
+ * own SSRF rules and returns the appropriate error.
+ */
+async function canRouteToFirecrawl(
+  input: Record<string, unknown>,
+): Promise<boolean> {
+  if (input.allow_private_network === true) return false;
+  const parsed = parseUrl(input.url);
+  if (!parsed) return false;
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
+  if (isPrivateOrLocalHost(parsed.hostname)) return false;
+  try {
+    const resolution = await resolveRequestAddress(
+      parsed.hostname,
+      resolveHostAddresses,
+      false,
+    );
+    if (resolution.blockedAddress || resolution.addresses.length === 0) {
+      return false;
+    }
+  } catch {
+    return false;
+  }
+  return true;
+}
+
+function firecrawlErrorResult(
+  requestedUrl: string,
+  startedAt: number,
+  errorMessage: string,
+  status = 0,
+): ToolExecutionResult {
+  const domain = extractDomain(requestedUrl);
+  return {
+    content: `Error: ${errorMessage}`,
+    isError: true,
+    activityMetadata: {
+      webFetch: {
+        url: requestedUrl,
+        finalUrl: requestedUrl,
+        provider: "firecrawl",
+        status,
+        byteCount: 0,
+        charCount: 0,
+        truncated: false,
+        domain,
+        faviconUrl: faviconUrlForDomain(domain),
+        redirectCount: 0,
+        durationMs: Date.now() - startedAt,
+        errorMessage,
+      },
+    },
+  };
+}
+
+/**
+ * Fetch a page via Firecrawl's hosted `/v2/scrape` endpoint, returning clean
+ * markdown. Mirrors the built-in fetcher's output shape (same
+ * {@link formatWebFetchOutput} and {@link WebFetchMetadata}) so the model and
+ * client UIs can't tell which backend served the page apart from
+ * `metadata.provider`.
+ *
+ * Exported for direct unit testing; the registered tool dispatches here via
+ * {@link getWebFetchProvider}.
+ */
+export async function executeFirecrawlScrape(
+  input: Record<string, unknown>,
+  options: { apiKey: string; signal?: AbortSignal },
+): Promise<ToolExecutionResult> {
+  const startedAt = Date.now();
+  const parsedUrl = parseUrl(input.url);
+  const targetUrl =
+    parsedUrl?.href ?? (typeof input.url === "string" ? input.url : "");
+  const safeRequestedUrl = parsedUrl
+    ? sanitizeUrlForOutput(parsedUrl)
+    : sanitizeUrlStringForOutput(targetUrl);
+
+  if (!targetUrl) {
+    return firecrawlErrorResult(
+      safeRequestedUrl,
+      startedAt,
+      "url is required and must be a valid HTTP(S) URL",
+    );
+  }
+
+  // Never forward URL-embedded credentials (user:password@host) to the hosted
+  // Firecrawl API. The built-in fetcher turns them into a Basic-auth header to
+  // the target; Firecrawl can't, so reject rather than leak them to a third
+  // party.
+  if (parsedUrl?.username || parsedUrl?.password) {
+    return firecrawlErrorResult(
+      safeRequestedUrl,
+      startedAt,
+      "URLs with embedded credentials are not supported by the Firecrawl provider. Remove the user:password@ portion of the URL.",
+    );
+  }
+
+  const maxChars = clampInteger(
+    input.max_chars,
+    DEFAULT_MAX_CHARS,
+    1,
+    MAX_MAX_CHARS,
+  );
+  const startIndex = clampInteger(input.start_index, 0, 0, 10_000_000);
+  const timeoutSeconds = clampInteger(
+    input.timeout_seconds,
+    DEFAULT_TIMEOUT_SECONDS,
+    1,
+    MAX_TIMEOUT_SECONDS,
+  );
+
+  const requestBody = {
+    url: targetUrl,
+    formats: ["markdown"],
+    onlyMainContent: true,
+    timeout: timeoutSeconds * 1000,
+  };
+
+  for (let attempt = 0; attempt <= DEFAULT_MAX_RETRIES; attempt++) {
+    let response: Response;
+    try {
+      response = await fetch(FIRECRAWL_SCRAPE_API_URL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${options.apiKey}`,
+          "X-Client-Source": "vellum-assistant",
+        },
+        body: JSON.stringify(requestBody),
+        signal: options.signal,
+      });
+    } catch (err) {
+      if (
+        options.signal?.aborted ||
+        (err instanceof Error && err.name === "AbortError")
+      ) {
+        return firecrawlErrorResult(
+          safeRequestedUrl,
+          startedAt,
+          "web fetch was cancelled",
+        );
+      }
+      const msg = err instanceof Error ? err.message : String(err);
+      return firecrawlErrorResult(
+        safeRequestedUrl,
+        startedAt,
+        `Firecrawl scrape failed: ${msg}`,
+      );
+    }
+
+    if (response.ok) {
+      let json: FirecrawlScrapeResponse;
+      try {
+        json = (await response.json()) as FirecrawlScrapeResponse;
+      } catch {
+        return firecrawlErrorResult(
+          safeRequestedUrl,
+          startedAt,
+          "Firecrawl scrape returned an invalid JSON payload.",
+          response.status,
+        );
+      }
+      const data = json.data ?? {};
+      const fcMeta = data.metadata ?? {};
+      // A 200 can still carry a payload-level failure (success:false, a
+      // top-level error, or a per-page error in data.metadata). Surface it
+      // instead of treating an empty body as a successful "no content" scrape.
+      const payloadError = json.error ?? fcMeta.error;
+      if (json.success === false || payloadError) {
+        return firecrawlErrorResult(
+          safeRequestedUrl,
+          startedAt,
+          payloadError ?? "Firecrawl scrape failed.",
+          response.status,
+        );
+      }
+      const processed = normalizeMarkdown(
+        (data.markdown ?? "").replace(/\0/g, ""),
+      );
+
+      const safeStart = Math.min(startIndex, processed.length);
+      const safeEnd = Math.min(processed.length, safeStart + maxChars);
+      const sliced = processed.slice(safeStart, safeEnd);
+      const bytesRead = Buffer.byteLength(processed, "utf8");
+
+      const finalUrlRaw = fcMeta.url ?? fcMeta.sourceURL ?? targetUrl;
+      const finalUrl = sanitizeUrlStringForOutput(finalUrlRaw);
+      const status = fcMeta.statusCode ?? 200;
+      const contentType = fcMeta.contentType ?? "text/markdown";
+
+      const notices: string[] = [];
+      const warning = data.warning ?? json.warning;
+      if (warning) notices.push(`Firecrawl: ${warning}`);
+      if (safeEnd < processed.length) {
+        notices.push(`Output truncated by max_chars=${maxChars}.`);
+      }
+      if (startIndex > processed.length) {
+        notices.push(
+          `start_index (${startIndex}) exceeded available content length (${processed.length}).`,
+        );
+      }
+
+      const content = formatWebFetchOutput({
+        requestedUrl: safeRequestedUrl,
+        finalUrl,
+        status,
+        statusText: "",
+        contentType,
+        bytesRead,
+        totalChars: processed.length,
+        startIndex: safeStart,
+        endIndex: safeEnd,
+        content: sliced,
+        title: fcMeta.title,
+        description: fcMeta.description,
+        notices,
+        raw: false,
+        markdown: true,
+      });
+
+      const finalDomain = extractDomain(finalUrl);
+      const meta: WebFetchMetadata = {
+        url: safeRequestedUrl,
+        finalUrl,
+        provider: "firecrawl",
+        status,
+        contentType,
+        byteCount: bytesRead,
+        charCount: sliced.length,
+        truncated: safeEnd < processed.length,
+        title: fcMeta.title,
+        domain: finalDomain,
+        faviconUrl: faviconUrlForDomain(finalDomain),
+        redirectCount: 0,
+        durationMs: Date.now() - startedAt,
+      };
+
+      return {
+        content,
+        isError: false,
+        status: notices.length > 0 ? notices.join("\n") : undefined,
+        activityMetadata: { webFetch: meta },
+      };
+    }
+
+    const bodyText = await response.text();
+
+    if (response.status === 401 || response.status === 403) {
+      return firecrawlErrorResult(
+        safeRequestedUrl,
+        startedAt,
+        "Invalid or expired Firecrawl API key",
+        response.status,
+      );
+    }
+
+    if (response.status === 429 && attempt < DEFAULT_MAX_RETRIES) {
+      const delayMs = getHttpRetryDelay(response, attempt, DEFAULT_BASE_DELAY_MS);
+      log.warn(
+        { attempt: attempt + 1, delayMs },
+        "Firecrawl scrape rate limited, retrying",
+      );
+      await sleep(delayMs);
+      continue;
+    }
+
+    log.warn(
+      { status: response.status, body: safeStringSlice(bodyText, 0, 200) },
+      "Firecrawl scrape API error",
+    );
+    const errorMessage =
+      response.status === 429
+        ? "Firecrawl scrape rate limit exceeded after retries. Try again shortly."
+        : response.status === 402
+          ? "Firecrawl scrape failed: account balance/credits exhausted."
+          : `Firecrawl scrape API returned status ${response.status}`;
+    return firecrawlErrorResult(
+      safeRequestedUrl,
+      startedAt,
+      errorMessage,
+      response.status,
+    );
+  }
+
+  return firecrawlErrorResult(
+    safeRequestedUrl,
+    startedAt,
+    "Firecrawl scrape rate limit exceeded after retries. Try again shortly.",
+    429,
+  );
+}
+
 export const webFetchTool = {
   name: "web_fetch",
   description:
@@ -1076,6 +1434,19 @@ export const webFetchTool = {
     input: Record<string, unknown>,
     context: ToolContext,
   ): Promise<ToolExecutionResult> {
+    if (getWebFetchProvider() === "firecrawl" && (await canRouteToFirecrawl(input))) {
+      const apiKey = await getProviderKeyAsync("firecrawl");
+      if (apiKey) {
+        return executeFirecrawlScrape(input, {
+          apiKey,
+          signal: context.signal,
+        });
+      }
+      log.info(
+        "web_fetch provider is firecrawl but no API key is configured; falling back to the built-in fetcher",
+      );
+      // Fall through to the built-in fetcher.
+    }
     return executeWebFetch(input, { signal: context.signal });
   },
 } satisfies ToolDefinition;

--- a/clients/web/src/assistant/generated/web-fetch-provider-catalog.gen.ts
+++ b/clients/web/src/assistant/generated/web-fetch-provider-catalog.gen.ts
@@ -1,0 +1,34 @@
+// Static catalog of web fetch providers available in the AI settings page.
+// Mirrors assistant/src/providers/fetch-provider-catalog.ts — keep in sync.
+
+/** Ordered list of provider ids — drives the picker option order. */
+export const WEB_FETCH_PROVIDER_IDS: readonly string[] = ["default", "firecrawl"];
+
+/** Short display name used in picker UI. */
+export const WEB_FETCH_PROVIDER_DISPLAY_NAMES: Readonly<
+  Record<string, string>
+> = {
+  default: "Built-in",
+  firecrawl: "Firecrawl",
+};
+
+/** Placeholder hint shown in the API-key input. BYOK providers only. */
+export const WEB_FETCH_PROVIDER_KEY_PLACEHOLDERS: Readonly<
+  Record<string, string>
+> = {
+  firecrawl: "fc-...",
+};
+
+/**
+ * localStorage key used to persist each BYOK provider's user-supplied key.
+ * Firecrawl intentionally shares the same key slot as web search — one stored
+ * `firecrawl` credential powers both `web_search` and `web_fetch`.
+ */
+export const WEB_FETCH_PROVIDER_KEY_STORAGE: Readonly<Record<string, string>> = {
+  firecrawl: "vellum:ai:firecrawlKey",
+};
+
+/** Provider ids that require a user-supplied API key. */
+export const WEB_FETCH_BYOK_PROVIDER_IDS: ReadonlySet<string> = new Set([
+  "firecrawl",
+]);

--- a/clients/web/src/assistant/web-activity-types.ts
+++ b/clients/web/src/assistant/web-activity-types.ts
@@ -7,6 +7,8 @@ export type WebSearchProviderId =
   | "tavily"
   | "firecrawl";
 
+export type WebFetchProviderId = "default" | "firecrawl";
+
 export interface WebSearchResultItem {
   rank: number;
   title: string;
@@ -30,6 +32,7 @@ export interface WebSearchMetadata {
 export interface WebFetchMetadata {
   url: string;
   finalUrl: string;
+  provider?: WebFetchProviderId;
   status: number;
   contentType?: string;
   byteCount: number;

--- a/clients/web/src/domains/settings/ai/ai-page.tsx
+++ b/clients/web/src/domains/settings/ai/ai-page.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 
 import { LanguageModelCard } from "@/domains/settings/ai/language-model-card";
 import { WebSearchCard } from "@/domains/settings/ai/web-search-card";
+import { WebFetchCard } from "@/domains/settings/ai/web-fetch-card";
 import { EmailServiceCard } from "@/domains/settings/ai/email-service-card";
 import { ImageGenerationCard } from "@/domains/settings/ai/image-generation-card";
 import { TextToSpeechCard } from "@/domains/settings/ai/text-to-speech-card";
@@ -44,6 +45,7 @@ export function AiPage() {
 
       <LanguageModelCard />
       <WebSearchCard />
+      <WebFetchCard />
       <EmailServiceCard />
       <ImageGenerationCard />
       <TextToSpeechCard />

--- a/clients/web/src/domains/settings/ai/local-storage-keys.ts
+++ b/clients/web/src/domains/settings/ai/local-storage-keys.ts
@@ -10,6 +10,7 @@ export const LS_IMAGE_GEN_MODE = "vellum:ai:imageGenMode";
 export const LS_IMAGE_GEN_MODEL = "vellum:ai:imageGenModel";
 export const LS_WEB_SEARCH_MODE = "vellum:ai:webSearchMode";
 export const LS_WEB_SEARCH_PROVIDER = "vellum:ai:webSearchProvider";
+export const LS_WEB_FETCH_PROVIDER = "vellum:ai:webFetchProvider";
 export const LS_EMAIL_MODE = "vellum:ai:emailMode";
 export const LS_EMAIL_BYO_PROVIDER = "vellum:ai:emailByoProvider";
 

--- a/clients/web/src/domains/settings/ai/utils.ts
+++ b/clients/web/src/domains/settings/ai/utils.ts
@@ -1,4 +1,5 @@
 import type { LlmCatalogModel } from "@/assistant/llm-model-catalog";
+import { WEB_FETCH_PROVIDER_KEY_STORAGE } from "@/assistant/generated/web-fetch-provider-catalog.gen";
 import {
   WEB_SEARCH_PROVIDER_KEY_STORAGE,
 } from "@/assistant/generated/web-search-provider-catalog.gen";
@@ -141,4 +142,8 @@ export function getLongContextPricingHint(
  */
 export function getWebSearchProviderKeyStorage(provider: string): string {
   return WEB_SEARCH_PROVIDER_KEY_STORAGE[provider] ?? "";
+}
+
+export function getWebFetchProviderKeyStorage(provider: string): string {
+  return WEB_FETCH_PROVIDER_KEY_STORAGE[provider] ?? "";
 }

--- a/clients/web/src/domains/settings/ai/web-fetch-card.stories.tsx
+++ b/clients/web/src/domains/settings/ai/web-fetch-card.stories.tsx
@@ -1,0 +1,41 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { WebFetchCard } from "@/domains/settings/ai/web-fetch-card";
+
+// No network in Storybook — disable retries so the config query falls back to
+// localStorage defaults (provider = "default") instead of spinning.
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: false, refetchOnWindowFocus: false, staleTime: Infinity },
+  },
+});
+
+const meta: Meta<typeof WebFetchCard> = {
+  title: "Settings/AI/WebFetchCard",
+  component: WebFetchCard,
+  decorators: [
+    (Story) => {
+      // The card reads the active assistant id from the resolved-assistants
+      // store; seed it so `useActiveAssistantId()` doesn't throw.
+      useResolvedAssistantsStore.setState({ activeAssistantId: "story-assistant" });
+      return (
+        <QueryClientProvider client={queryClient}>
+          <div style={{ maxWidth: 640, padding: 24 }}>
+            <Story />
+          </div>
+        </QueryClientProvider>
+      );
+    },
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof WebFetchCard>;
+
+/**
+ * Default state: provider picker defaults to the built-in fetcher. Selecting
+ * "Firecrawl" reveals the API-key input (BYOK).
+ */
+export const Default: Story = {};

--- a/clients/web/src/domains/settings/ai/web-fetch-card.tsx
+++ b/clients/web/src/domains/settings/ai/web-fetch-card.tsx
@@ -1,0 +1,198 @@
+import { Loader2 } from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
+
+import {
+    WEB_FETCH_BYOK_PROVIDER_IDS,
+    WEB_FETCH_PROVIDER_DISPLAY_NAMES,
+    WEB_FETCH_PROVIDER_IDS,
+    WEB_FETCH_PROVIDER_KEY_PLACEHOLDERS,
+} from "@/assistant/generated/web-fetch-provider-catalog.gen";
+import { secretPlaceholder } from "@/domains/settings/ai/secret-placeholder";
+import { captureError } from "@/lib/sentry/capture-error";
+import {
+    getLocalSetting,
+    removeLocalSetting,
+    setLocalSetting,
+} from "@/utils/local-settings";
+import { useQueryClient } from "@tanstack/react-query";
+import { Dropdown } from "@vellumai/design-library/components/dropdown";
+import { Input } from "@vellumai/design-library/components/input";
+import { toast } from "@vellumai/design-library/components/toast";
+
+import { ByoServiceCard, ResetButton, SaveButton } from "@/domains/settings/ai/shared-ui";
+import { LS_WEB_FETCH_PROVIDER } from "@/domains/settings/ai/local-storage-keys";
+import { getWebFetchProviderKeyStorage } from "@/domains/settings/ai/utils";
+import { useProvisionProviderKey } from "@/domains/settings/ai/use-daemon-config";
+import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
+import { configGetOptions, configGetSetQueryData, useConfigPatchMutation } from "@/generated/daemon/@tanstack/react-query.gen";
+import { useQuery } from "@tanstack/react-query";
+import { useDraftOverride } from "@/domains/settings/ai/use-draft-override";
+import { credentialPresenceQueryKey, useStoredCredentialPresence } from "@/domains/settings/ai/use-stored-credential-presence";
+
+const DEFAULT_PROVIDER = "default";
+
+/**
+ * Web Fetch service card. Unlike Web Search there is no managed proxy, so the
+ * card is mode-less (`ByoServiceCard`): pick the built-in fetcher or a BYOK
+ * provider (Firecrawl) that scrapes via its hosted API. Firecrawl reuses the
+ * same stored credential as Web Search.
+ */
+export function WebFetchCard() {
+  const assistantId = useActiveAssistantId();
+  const queryClient = useQueryClient();
+
+  const { data: daemonConfig } = useQuery({
+    ...configGetOptions({ path: { assistant_id: assistantId } }),
+    staleTime: 30_000,
+  });
+
+  const configMutation = useConfigPatchMutation({
+    onSuccess: (data) => {
+      configGetSetQueryData(queryClient, { path: { assistant_id: assistantId } }, data);
+    },
+  });
+  const provisionProviderKey = useProvisionProviderKey();
+
+  // Server value derived from daemon config, falling back to localStorage.
+  const serverWebFetchProvider = useMemo((): string => {
+    if (!daemonConfig) {
+      return getLocalSetting(LS_WEB_FETCH_PROVIDER, DEFAULT_PROVIDER);
+    }
+    const service = daemonConfig.services?.["web-fetch"];
+    return service?.provider || getLocalSetting(LS_WEB_FETCH_PROVIDER, DEFAULT_PROVIDER);
+  }, [daemonConfig]);
+
+  const [saving, setSaving] = useState(false);
+  const [webFetchProvider, setDraftWebFetchProvider] = useDraftOverride(serverWebFetchProvider);
+  const [webFetchApiKey, setWebFetchApiKey] = useState("");
+
+  const requiresProviderCredential = WEB_FETCH_BYOK_PROVIDER_IDS.has(webFetchProvider);
+  const { hasStoredCredential: webFetchHasStoredKey } =
+    useStoredCredentialPresence({
+      assistantId,
+      credentialKind: "api_key",
+      credentialName: webFetchProvider,
+      enabled: requiresProviderCredential,
+    });
+
+  // --- Derived state ---
+  const hasNewApiKey = webFetchApiKey.trim().length > 0;
+  const configChanged = webFetchProvider !== serverWebFetchProvider;
+  const needsKeyBeforeSave =
+    requiresProviderCredential && !webFetchHasStoredKey && !hasNewApiKey;
+  const saveDisabled =
+    saving || needsKeyBeforeSave || (!configChanged && !hasNewApiKey);
+  const apiKeyPlaceholder = secretPlaceholder(
+    WEB_FETCH_PROVIDER_KEY_PLACEHOLDERS[webFetchProvider] ?? "Enter your API key",
+    webFetchHasStoredKey,
+  );
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    const trimmed = webFetchApiKey.trim();
+    const hasUserKey = requiresProviderCredential && trimmed.length > 0;
+    try {
+      if (hasUserKey) {
+        await provisionProviderKey(webFetchProvider, trimmed);
+      }
+      await configMutation.mutateAsync({
+        path: { assistant_id: assistantId },
+        body: {
+          services: {
+            "web-fetch": { provider: webFetchProvider },
+          },
+        },
+      }).catch((error) => {
+        toast.error("Failed to update assistant configuration. Please try again.");
+        captureError(error, { context: "patch_daemon_config" });
+        throw error;
+      });
+    } catch {
+      setSaving(false);
+      return;
+    }
+    setSaving(false);
+    try {
+      setLocalSetting(LS_WEB_FETCH_PROVIDER, webFetchProvider);
+      if (hasUserKey) {
+        const storageKey = getWebFetchProviderKeyStorage(webFetchProvider);
+        if (storageKey) {
+          setLocalSetting(storageKey, trimmed);
+        }
+        const presenceKey = credentialPresenceQueryKey(
+          assistantId,
+          "api_key",
+          webFetchProvider,
+        );
+        queryClient.setQueryData(presenceKey, true);
+        void queryClient.invalidateQueries({ queryKey: presenceKey });
+        setWebFetchApiKey("");
+      }
+      toast.success("Web fetch settings saved.");
+    } catch (err) {
+      captureError(err, { context: "settings-ai-web-fetch-persist-local" });
+      toast.error("Saved, but local preferences could not be written.");
+    }
+  }, [
+    requiresProviderCredential,
+    configMutation,
+    provisionProviderKey,
+    queryClient,
+    assistantId,
+    webFetchApiKey,
+    webFetchProvider,
+  ]);
+
+  const handleReset = useCallback(() => {
+    const storageKey = getWebFetchProviderKeyStorage(webFetchProvider);
+    if (storageKey) {
+      removeLocalSetting(storageKey);
+    }
+    setWebFetchApiKey("");
+    setDraftWebFetchProvider(DEFAULT_PROVIDER);
+    setLocalSetting(LS_WEB_FETCH_PROVIDER, DEFAULT_PROVIDER);
+  }, [webFetchProvider, setDraftWebFetchProvider]);
+
+  return (
+    <ByoServiceCard
+      id="web-fetch"
+      title="Web Fetch"
+      subtitle="Configure how your assistant reads individual web pages"
+    >
+      <div className="space-y-4">
+        <div className="space-y-1">
+          <label className="block text-body-small-default text-[var(--content-tertiary)]">
+            Provider
+          </label>
+          <Dropdown
+            value={webFetchProvider}
+            onChange={setDraftWebFetchProvider}
+            options={WEB_FETCH_PROVIDER_IDS.map((p) => ({
+              value: p,
+              label: WEB_FETCH_PROVIDER_DISPLAY_NAMES[p] ?? p,
+            }))}
+          />
+        </div>
+
+        {requiresProviderCredential && (
+          <Input
+            label="API Key"
+            type="password"
+            value={webFetchApiKey}
+            onChange={(e) => setWebFetchApiKey(e.target.value)}
+            placeholder={apiKeyPlaceholder}
+            fullWidth
+          />
+        )}
+
+        <div className="flex items-center gap-2">
+          <SaveButton onClick={handleSave} disabled={saveDisabled} />
+          {saving && <Loader2 className="h-4 w-4 animate-spin text-[var(--content-disabled)]" />}
+          {requiresProviderCredential && (
+            <ResetButton onClick={handleReset} filled />
+          )}
+        </div>
+      </div>
+    </ByoServiceCard>
+  );
+}


### PR DESCRIPTION
Closes #35339

> **Draft. Stacked on #35172** (Firecrawl web search). Because the web-search branch doesn't exist in this repo, this PR targets `main`, so its diff currently **includes #35172's commits**. Review/merge #35172 first; I'll then rebase this so it shows only the web-fetch delta. The web-fetch-specific commits are: `d01f8c4`, `1eca126`, `62d17a4`, `14944c4`, `db5efb4`.

## Prompt / plan

`web_fetch` had **no provider seam** — it was a single hardcoded local fetcher (static HTTP GET + HTML→text extraction). This adds a provider abstraction and wires **Firecrawl `/v2/scrape`** as the first BYOK fetch provider, mirroring the web-search provider design from #35172.

**Why:** the built-in fetcher already detects when it likely missed JavaScript-rendered content (it appends a "content may be JavaScript-rendered" notice). Firecrawl `/scrape` renders server-side and returns clean markdown — closing exactly that gap. It **reuses the same stored `firecrawl` key** as web search, so one credential powers both tools.

## Touched layers

- **`providers/fetch-provider-catalog.ts`** (new) — single source of truth: `default` (builtin) + `firecrawl` (byok). Drives the config-schema enum. Deliberately does not re-register the `firecrawl` key (already in `API_KEY_PROVIDERS` via the search catalog).
- **Config schema** — new `services.web-fetch` block (`provider`, default `"default"`; `mode` inherited from `BaseServiceSchema`). Typed on both `ConfigGetResponseSchema` and `ConfigPatchRequestSchema`.
- **`tools/network/web-fetch.ts`** — `executeFirecrawlScrape` (POST `/v2/scrape`, `formats:["markdown"]`, `onlyMainContent:true`, `X-Client-Source: vellum-assistant`, shared retry/backoff + 401/403/402 handling), mapped onto the existing `formatWebFetchOutput`/`WebFetchMetadata` shape. Tool `execute` dispatches via `getWebFetchProvider()`; falls back to the built-in fetcher when there's no key, the URL is unparseable, or the target is private/local (the built-in path keeps owning SSRF / `allow_private_network`). Built-in fetcher tags metadata `provider: "default"`.
- **`WebFetchMetadata.provider`** added to the daemon type + web client mirror.
- **Web UI** — new mode-less `WebFetchCard` in Settings → Models & Services, so the provider + key are configurable from the UI (verified live against a local assistant).

## Notes for reviewers

- **No new migration.** An earlier revision added a `release-notes-*` workspace migration; the `workspace-release-notes-feature-flag-guard` correctly rejects those (the `UPDATES.md` consumer was removed). Dropped — new installs still get Firecrawl via the provider catalogs/UI.
- **SSRF:** routing through `/scrape` runs the fetch on Firecrawl's servers; private/local targets are explicitly kept on the built-in path so existing guards apply. URL-embedded credentials are rejected rather than forwarded to the hosted API.
- All CodeRabbit findings on the fork PR addressed (credential leak, payload/JSON validation, GET/PATCH schema symmetry).

## Test plan

- `cd assistant && bun run test` — green for everything this change touches; the new `web-fetch-firecrawl.test.ts` (14 cases: request shape, markdown→content mapping, metadata, `max_chars`, empty body, credential rejection, payload-failure + invalid-JSON surfacing, 401/403, 429 retry, provider dispatch + fallback) passes, plus `config-schema`, route, and release-notes-guard suites. Remaining failures in the full run are environmental (git/keychain/qdrant/sandbox).
- `cd cli && bun run test` — green (1 unrelated environmental `recover` failure).
- `bun run lint` + `bunx tsc --noEmit` clean in `assistant/` and `clients/web/`.
- Manual: local assistant (`vellum hatch`/`wake`, no Docker) + web UI → Settings shows the Web Fetch card with Built-in/Firecrawl; selecting Firecrawl + Save persists `services.web-fetch.provider=firecrawl` to the daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
