### PR TITLE
docs(migrations): refresh stale comments referencing deleted MANAGED_PROFILE_TEMPLATES / adaptive-thinking-repair

### DIFF
--- a/assistant/src/workspace/migrations/082-backfill-managed-profile-labels.ts
+++ b/assistant/src/workspace/migrations/082-backfill-managed-profile-labels.ts
@@ -52,12 +52,13 @@ const log = getLogger(
 );
 
 /**
- * Bare template labels for the canonical managed profile triplet. Kept in
- * sync with `MANAGED_PROFILE_TEMPLATES` in
- * `assistant/src/config/seed-inference-profiles.ts`. Duplicated here
+ * Bare template labels for the canonical managed profile triplet. Managed
+ * profiles are sourced from the platform model-profiles endpoint
+ * (`GET /v1/assistants/{id}/model-profiles/`); these labels mirror that
+ * triplet for off-platform installs that never receive them. Duplicated here
  * intentionally — migrations are forward-only and self-contained per the
- * workspace migrations AGENTS contract; future renames in the seeder
- * must NOT retroactively change the data this migration writes.
+ * workspace migrations AGENTS contract; future label changes upstream must
+ * NOT retroactively change the data this migration writes.
  */
 const CANONICAL_MANAGED_PROFILE_LABELS: Record<string, string> = {
   balanced: "Balanced",

--- a/assistant/src/workspace/migrations/097-enable-adaptive-thinking-managed-profiles.ts
+++ b/assistant/src/workspace/migrations/097-enable-adaptive-thinking-managed-profiles.ts
@@ -6,14 +6,13 @@ import type { WorkspaceMigration } from "./types.js";
 // Enable adaptive thinking on the managed "balanced" and "quality-optimized"
 // profiles for existing platform instances.
 //
-// The assistant-side seed defaults (MANAGED_PROFILE_TEMPLATES in
-// seed-inference-profiles.ts) already ship thinking: { enabled: true,
+// The managed profiles served from the platform model-profiles endpoint
+// (GET /v1/assistants/{id}/model-profiles/) ship thinking: { enabled: true,
 // streamThinking: true } for both profiles, which normalizes to
-// { type: "adaptive" } on the wire. Off-platform (BYOK) instances pick this
-// up on every boot because the seeder overwrites managed profiles. On-platform
-// instances preserve existing profiles (the platform overlay is authoritative),
-// so instances that were hatched before thinking was enabled in the templates
-// are stuck with thinking disabled or absent.
+// { type: "adaptive" } on the wire. On-platform instances preserve existing
+// profiles (the platform overlay is authoritative), so instances that were
+// hatched before thinking was enabled in the managed profiles are stuck with
+// thinking disabled or absent.
 //
 // This migration patches the on-disk config for both profiles, adding
 // thinking: { enabled: true, streamThinking: true } where it's missing or

--- a/assistant/src/workspace/migrations/104-recheck-adaptive-thinking-model-implied-anthropic.ts
+++ b/assistant/src/workspace/migrations/104-recheck-adaptive-thinking-model-implied-anthropic.ts
@@ -15,9 +15,6 @@ import type { WorkspaceMigration } from "./types.js";
 // Anthropic from the model id. 097's frozen copy was later corrected to imply
 // the provider from the model, but workspaces that already ran 097 have it
 // checkpointed as completed, so the corrected logic never re-runs for them.
-// At the time this migration was authored a live startup repair re-ran the fix,
-// but only behind the hatch overlay, which is archived after hatch, so
-// already-hatched platform instances were not covered either.
 //
 // This migration re-applies the corrected repair once for those checkpointed
 // workspaces. It is idempotent: profiles that already have thinking enabled are


### PR DESCRIPTION
## Summary
- Reword comments in migrations 082, 097, 104 that referenced the deleted MANAGED_PROFILE_TEMPLATES constant / adaptive-thinking-repair module
- Comments only; no migration logic changed

Part of plan: platform-managed-profiles.md (review remediation)