### PR TITLE
feat(contacts-web): let guardian manually verify a contact's channel

### DIFF
--- a/clients/web/src/domains/contacts/components/contact-channels-section.tsx
+++ b/clients/web/src/domains/contacts/components/contact-channels-section.tsx
@@ -62,6 +62,10 @@ export function getChannelActionState(
   if (verified) {
     return { kind: "verified" };
   }
+  // Don't offer to verify a blocked channel — verifying flips it to active and clears the ban.
+  if (existing?.status === "blocked") {
+    return { kind: "none" };
+  }
   if (existing && existing.status !== "revoked") {
     return { kind: "unverified" };
   }

--- a/clients/web/src/domains/contacts/components/contact-channels-section.tsx
+++ b/clients/web/src/domains/contacts/components/contact-channels-section.tsx
@@ -113,6 +113,7 @@ interface ContactChannelsSectionProps {
   a2aEnabled?: boolean;
   setupLabel?: string;
   verifyLoading?: boolean;
+  verifySubject?: "self" | "contact";
   onSetupChannel?: (type: string) => void;
   onVerifyChannel?: (type: string) => void;
   onRevokeChannel?: (channelId: string, type: string) => void;
@@ -151,6 +152,7 @@ export function ContactChannelsSection({
   a2aEnabled,
   setupLabel = "Invite",
   verifyLoading,
+  verifySubject = "self",
   onSetupChannel,
   onVerifyChannel,
   onRevokeChannel,
@@ -230,7 +232,11 @@ export function ContactChannelsSection({
         <ConfirmDialog
           open={true}
           title={`Verify ${verifyPending.label}`}
-          message={`This will mark your ${verifyPending.label} channel as verified. Your assistant will recognize you when you reach out from it.`}
+          message={
+            verifySubject === "contact"
+              ? `This will mark this contact's ${verifyPending.label} channel as verified. Your assistant will recognize them when they reach out from it.`
+              : `This will mark your ${verifyPending.label} channel as verified. Your assistant will recognize you when you reach out from it.`
+          }
           confirmLabel="Verify"
           onConfirm={handleVerifyConfirm}
           onCancel={() => setVerifyPending(null)}

--- a/clients/web/src/domains/contacts/components/contact-detail-view.tsx
+++ b/clients/web/src/domains/contacts/components/contact-detail-view.tsx
@@ -13,6 +13,7 @@ interface ContactDetailViewProps {
   contact: ContactPayload;
   savePending: boolean;
   deletePending: boolean;
+  verifyPending?: boolean;
   mergePending?: boolean;
   canMerge?: boolean;
   availableChannels?: ChannelInfo[];
@@ -21,6 +22,7 @@ interface ContactDetailViewProps {
   onDelete: () => Promise<void>;
   onMerge?: () => void;
   onSetupChannel?: (type: string) => void;
+  onVerifyChannel?: (type: string) => void;
   onRevokeChannel?: (channelId: string, type: string) => void;
 }
 
@@ -32,6 +34,7 @@ function ContactDetailViewInner({
   contact,
   savePending,
   deletePending,
+  verifyPending,
   mergePending = false,
   canMerge = false,
   availableChannels,
@@ -40,6 +43,7 @@ function ContactDetailViewInner({
   onDelete,
   onMerge,
   onSetupChannel,
+  onVerifyChannel,
   onRevokeChannel,
 }: ContactDetailViewProps) {
   const isNewContactDraft = contact.displayName === "New Contact";
@@ -158,7 +162,10 @@ function ContactDetailViewInner({
           contactChannels={contact.channels}
           availableChannels={availableChannels}
           a2aEnabled={a2aEnabled}
+          verifyLoading={verifyPending}
+          verifySubject="contact"
           onSetupChannel={onSetupChannel}
+          onVerifyChannel={onVerifyChannel}
           onRevokeChannel={onRevokeChannel}
         />
       </DetailCard>

--- a/clients/web/src/domains/contacts/contacts-page.tsx
+++ b/clients/web/src/domains/contacts/contacts-page.tsx
@@ -535,7 +535,7 @@ export function ContactsPage({
     },
   });
 
-  const handleGuardianVerifyChannel = useCallback(
+  const handleVerifyChannel = useCallback(
     (type: string) => {
       if (!selectedContact) return;
       const channel = selectedContact.channels.find(
@@ -661,7 +661,7 @@ export function ContactsPage({
               onSetupChannel={
                 onStartSetupConversation ? handleGuardianEnableChannel : undefined
               }
-              onVerifyChannel={handleGuardianVerifyChannel}
+              onVerifyChannel={handleVerifyChannel}
               onRevokeChannel={handleRevokeChannel}
               onGenerateInviteLink={a2aChannel ? handleOpenInviteLink : undefined}
             />
@@ -670,6 +670,7 @@ export function ContactsPage({
               contact={optimisticContact}
               savePending={updateMutation.isPending}
               deletePending={deleteMutation.isPending}
+              verifyPending={verifyChannelMutation.isPending}
               mergePending={mergeMutation.isPending}
               canMerge={canMerge}
               availableChannels={availableChannels}
@@ -687,6 +688,7 @@ export function ContactsPage({
               onSetupChannel={
                 onStartSetupConversation ? handleContactSetupChannel : undefined
               }
+              onVerifyChannel={handleVerifyChannel}
               onRevokeChannel={handleRevokeChannel}
             />
           )


### PR DESCRIPTION
## Summary
- Wire `onVerifyChannel` + `verifyPending` through `ContactDetailView` so a guardian can manually mark a regular contact's channel as verified — the gateway endpoint (`POST /v1/contact-channels/:id/verify`) already supported this; only the UI was missing the control for non-guardian contacts.
- Reuse the existing verify handler (renamed `handleGuardianVerifyChannel` → `handleVerifyChannel`) for both the guardian and contact detail views.
- Parameterize the shared `ContactChannelsSection` verify confirm dialog copy via a `verifySubject` prop so it reads correctly for a contact ("this contact's…") vs. the guardian's own channel ("your…").

## Original prompt
Investigation found the gateway API for a guardian to manually mark a contact as verified already exists, and the web UI exposes a "Verify" control — but only on the guardian's *own* channels (`GuardianDetailView`), not on regular contacts (`ContactDetailView` had no `onVerifyChannel` prop). The ask was to close that gap by threading the verify wiring through `ContactDetailView` the same way it's done for the guardian, so a guardian can verify a contact's channel from the UI.