### PR TITLE
fix(approvals): auto-deliver Slack access-request verification code to the requester (LUM-2486)

### DIFF
--- a/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
+++ b/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
@@ -1088,3 +1088,147 @@ describe("cross-milestone integration checks", () => {
   });
 });
 
+// ===========================================================================
+// (g) access_request resolver: requester verification-code delivery
+//
+// On approval the requester must receive the 6-digit code so the guardian
+// never has to relay it by hand. On Slack the code is DM'd straight to the
+// requester (a private path is guaranteed via their user ID); other channels
+// keep the courier message because a private path to the requester is not
+// guaranteed there (e.g. a group chat would leak the secret).
+// ===========================================================================
+
+describe("(g) access_request resolver: requester code delivery", () => {
+  const REQUESTER_UID = "U_REQUESTER";
+  const GUARDIAN_UID = "U_GUARDIAN";
+
+  function createAccessRequest(overrides: Record<string, unknown> = {}) {
+    return createCanonicalGuardianRequest({
+      id: `access-req-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      kind: "access_request",
+      sourceType: "channel",
+      sourceChannel: "slack",
+      conversationId: "conv-access-slack",
+      requesterExternalUserId: REQUESTER_UID,
+      requesterChatId: "C_SHARED_CHANNEL",
+      guardianExternalUserId: GUARDIAN_UID,
+      guardianPrincipalId: "test-principal-id",
+      toolName: "ingress_access_request",
+      expiresAt: Date.now() + 60_000,
+      ...overrides,
+    });
+  }
+
+  beforeEach(() => {
+    resetTables();
+    deliveredReplies.length = 0;
+    emittedSignals.length = 0;
+  });
+
+  test("on-channel Slack approval DMs the verification code to the requester", async () => {
+    const req = createAccessRequest();
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: "approve_once",
+      actorContext: guardianActor({
+        channel: "slack",
+        actorExternalUserId: GUARDIAN_UID,
+      }),
+      channelDeliveryContext: {
+        replyCallbackUrl:
+          "http://localhost:3000/deliver/slack?threadTs=111.222",
+        guardianChatId: "C_SHARED_CHANNEL",
+        assistantId: "self",
+      },
+    });
+
+    expect(result.applied).toBe(true);
+
+    // The requester receives the actual code in their DM (chatId = user ID),
+    // not a "ask the guardian" courier message.
+    const requesterCodeReply = deliveredReplies.find(
+      (r) =>
+        r.payload.chatId === REQUESTER_UID &&
+        typeof r.payload.text === "string" &&
+        (r.payload.text as string).includes("123456"),
+    );
+    expect(requesterCodeReply).toBeDefined();
+    expect(requesterCodeReply!.payload.text).toContain(
+      "your access request was approved",
+    );
+    // The code DM is durable, never ephemeral.
+    expect(requesterCodeReply!.payload.ephemeral).toBeUndefined();
+    // threadTs (the guardian's channel thread) is stripped for the DM.
+    expect(requesterCodeReply!.url).not.toContain("threadTs");
+
+    // No courier "receive from the guardian" message goes to the requester.
+    const courier = deliveredReplies.find(
+      (r) =>
+        typeof r.payload.text === "string" &&
+        (r.payload.text as string).includes("receive from the guardian"),
+    );
+    expect(courier).toBeUndefined();
+  });
+
+  test("desktop-decided approval DMs the code to the Slack requester via the deliver path", async () => {
+    const req = createAccessRequest();
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: "approve_once",
+      // Desktop decision: no channelDeliveryContext, actor on the vellum channel.
+      actorContext: guardianActor({
+        channel: "vellum",
+        actorExternalUserId: undefined,
+      }),
+    });
+
+    expect(result.applied).toBe(true);
+
+    const requesterCodeReply = deliveredReplies.find(
+      (r) =>
+        r.payload.chatId === REQUESTER_UID &&
+        typeof r.payload.text === "string" &&
+        (r.payload.text as string).includes("123456"),
+    );
+    expect(requesterCodeReply).toBeDefined();
+    expect(requesterCodeReply!.url).toContain("/deliver/slack");
+    expect(requesterCodeReply!.payload.text).toContain(
+      "your access request was approved",
+    );
+  });
+
+  test("non-Slack channel keeps the courier message and never delivers the code to the requester chat", async () => {
+    const req = createAccessRequest({
+      sourceChannel: "telegram",
+      requesterChatId: "requester-chat-1",
+      conversationId: "conv-access-telegram",
+    });
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: "approve_once",
+      actorContext: guardianActor({
+        channel: "telegram",
+        actorExternalUserId: GUARDIAN_UID,
+      }),
+      channelDeliveryContext: {
+        replyCallbackUrl: "http://localhost:3000/deliver/telegram",
+        guardianChatId: "guardian-chat-1",
+        assistantId: "self",
+      },
+    });
+
+    expect(result.applied).toBe(true);
+
+    // The requester is told to expect the code from the guardian; the secret is
+    // never delivered to the requester's (possibly group) chat.
+    const requesterReply = deliveredReplies.find(
+      (r) => r.payload.chatId === "requester-chat-1",
+    );
+    expect(requesterReply).toBeDefined();
+    expect(requesterReply!.payload.text).toContain("receive from the guardian");
+    expect(requesterReply!.payload.text).not.toContain("123456");
+  });
+});

--- a/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
+++ b/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
@@ -157,6 +157,7 @@ mock.module("../config/env.js", () => ({
 import { applyCanonicalGuardianDecision } from "../approvals/guardian-decision-primitive.js";
 import type { ActorContext } from "../approvals/guardian-request-resolvers.js";
 import { getResolver } from "../approvals/guardian-request-resolvers.js";
+import { upsertContactChannel } from "../contacts/contacts-write.js";
 import type { TrustContext } from "../daemon/trust-context.js";
 import {
   createCanonicalGuardianRequest,
@@ -1275,5 +1276,32 @@ describe("(g) access_request resolver: requester code delivery", () => {
     expect(courier!.payload.chatId).toBe("C_SHARED_CHANNEL");
     expect(courier!.payload.ephemeral).toBe(true);
     expect(courier!.payload.user).toBe(REQUESTER_UID);
+  });
+
+  test("guardian-facing reply uses the requester's display name, not the raw ID", async () => {
+    // Seed a contact so the resolver can resolve a display name.
+    upsertContactChannel({
+      sourceChannel: "slack",
+      externalUserId: REQUESTER_UID,
+      displayName: "Alice",
+      status: "unverified",
+    });
+
+    const req = createAccessRequest();
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: "approve_once",
+      // Desktop decision → resolver returns guardianReplyText for assertion.
+      actorContext: guardianActor({
+        channel: "vellum",
+        actorExternalUserId: undefined,
+      }),
+    });
+
+    expect(result.applied).toBe(true);
+    const replyText = result.applied ? result.resolverReplyText : undefined;
+    expect(replyText).toContain("Alice");
+    expect(replyText).not.toContain(REQUESTER_UID);
   });
 });

--- a/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
+++ b/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
@@ -92,7 +92,7 @@ mock.module("../runtime/channel-verification-service.js", () => ({
     return null;
   },
   createOutboundSession: () => ({
-    conversationId: "test-session",
+    sessionId: "test-session",
     secret: "123456",
   }),
   bindSessionIdentity: () => {},
@@ -108,16 +108,23 @@ mock.module("../runtime/channel-verification-service.js", () => ({
   }),
 }));
 
-// Mock gateway client — capture delivery calls
+// Mock gateway client — capture delivery calls. `failDeliveryWhen` lets a test
+// simulate a delivery failure for a specific payload (e.g. a DM that can't be
+// opened) so fallback paths can be exercised.
 const deliveredReplies: Array<{
   url: string;
   payload: Record<string, unknown>;
 }> = [];
+let failDeliveryWhen: ((payload: Record<string, unknown>) => boolean) | null =
+  null;
 mock.module("../runtime/gateway-client.js", () => ({
   deliverChannelReply: async (
     url: string,
     payload: Record<string, unknown>,
   ) => {
+    if (failDeliveryWhen?.(payload)) {
+      throw new Error("simulated delivery failure");
+    }
     deliveredReplies.push({ url, payload });
     return { ok: true };
   },
@@ -1123,6 +1130,7 @@ describe("(g) access_request resolver: requester code delivery", () => {
     resetTables();
     deliveredReplies.length = 0;
     emittedSignals.length = 0;
+    failDeliveryWhen = null;
   });
 
   test("on-channel Slack approval DMs the verification code to the requester", async () => {
@@ -1230,5 +1238,42 @@ describe("(g) access_request resolver: requester code delivery", () => {
     expect(requesterReply).toBeDefined();
     expect(requesterReply!.payload.text).toContain("receive from the guardian");
     expect(requesterReply!.payload.text).not.toContain("123456");
+  });
+
+  test("Slack shared-channel fallback posts an ephemeral notice to the channel when the DM fails", async () => {
+    const req = createAccessRequest();
+
+    // Make the direct DM (to the U... user ID) fail so the courier fallback runs.
+    failDeliveryWhen = (payload) => payload.chatId === REQUESTER_UID;
+
+    const result = await applyCanonicalGuardianDecision({
+      requestId: req.id,
+      action: "approve_once",
+      actorContext: guardianActor({
+        channel: "slack",
+        actorExternalUserId: GUARDIAN_UID,
+      }),
+      channelDeliveryContext: {
+        replyCallbackUrl:
+          "http://localhost:3000/deliver/slack?threadTs=111.222",
+        guardianChatId: "C_SHARED_CHANNEL",
+        assistantId: "self",
+      },
+    });
+
+    expect(result.applied).toBe(true);
+
+    // The courier notice falls back to an ephemeral message targeting the
+    // originating channel (C...), since chat.postEphemeral needs a channel ID —
+    // not the requester's user ID.
+    const courier = deliveredReplies.find(
+      (r) =>
+        typeof r.payload.text === "string" &&
+        (r.payload.text as string).includes("receive from the guardian"),
+    );
+    expect(courier).toBeDefined();
+    expect(courier!.payload.chatId).toBe("C_SHARED_CHANNEL");
+    expect(courier!.payload.ephemeral).toBe(true);
+    expect(courier!.payload.user).toBe(REQUESTER_UID);
   });
 });

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -723,11 +723,15 @@ const accessRequestResolver: GuardianRequestResolver = {
                 "Please enter the 6-digit verification code you receive from the guardian.",
               assistantId,
             };
-            // On Slack shared channels, deliver as ephemeral so only the requester sees
+            // On Slack shared channels, deliver the courier notice as an
+            // ephemeral message in the originating channel. chat.postEphemeral
+            // needs the channel ID (`C…`), so target requesterChatId rather
+            // than the requester's user ID.
             if (
               shouldUseEphemeral(channel, requesterChatId) &&
               requesterExternalUserId
             ) {
+              approvalPayload.chatId = requesterChatId;
               approvalPayload.ephemeral = true;
               approvalPayload.user = requesterExternalUserId;
             }
@@ -753,6 +757,7 @@ const accessRequestResolver: GuardianRequestResolver = {
             shouldUseEphemeral(channel, requesterChatId) &&
             requesterExternalUserId
           ) {
+            failurePayload.chatId = requesterChatId;
             failurePayload.ephemeral = true;
             failurePayload.user = requesterExternalUserId;
           }

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -106,6 +106,36 @@ async function deliverVerificationCodeToSlackRequester(params: {
   }
 }
 
+/**
+ * Build a requester-facing channel notice (approval/denial/courier text).
+ *
+ * Posts to the originating chat. On a Slack shared channel it goes out as an
+ * ephemeral message visible only to the requester — and because
+ * `chat.postEphemeral` needs a channel ID, `chatId` stays the channel
+ * (`requesterChatId`), never the requester's `U…` user ID.
+ */
+function buildRequesterChannelNotice(params: {
+  channel: string;
+  requesterChatId: string;
+  requesterExternalUserId: string;
+  text: string;
+  assistantId: string;
+}): Parameters<typeof deliverChannelReply>[1] {
+  const payload: Parameters<typeof deliverChannelReply>[1] = {
+    chatId: params.requesterChatId,
+    text: params.text,
+    assistantId: params.assistantId,
+  };
+  if (
+    shouldUseEphemeral(params.channel, params.requesterChatId) &&
+    params.requesterExternalUserId
+  ) {
+    payload.ephemeral = true;
+    payload.user = params.requesterExternalUserId;
+  }
+  return payload;
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -414,8 +444,6 @@ const accessRequestResolver: GuardianRequestResolver = {
     const requesterExternalUserId = request.requesterExternalUserId ?? "";
     const requesterChatId =
       request.requesterChatId ?? request.requesterExternalUserId ?? "";
-    const requesterLabel =
-      requesterExternalUserId || requesterChatId || "the requester";
     const decidedByExternalUserId = ctx.actor.actorExternalUserId ?? "";
     const assistantId = DAEMON_INTERNAL_ASSISTANT_ID;
     const desktopDeliverUrl = resolveDeliverCallbackUrlForChannel(channel);
@@ -429,6 +457,13 @@ const accessRequestResolver: GuardianRequestResolver = {
       : null;
     const requesterDisplayName =
       requesterContactResult?.contact.displayName ?? null;
+
+    // Guardian-facing label prefers the contact display name over the raw ID.
+    const requesterLabel =
+      requesterDisplayName ||
+      requesterExternalUserId ||
+      requesterChatId ||
+      "the requester";
 
     const decidedByContactResult = decidedByExternalUserId
       ? findContactChannel({
@@ -448,22 +483,15 @@ const accessRequestResolver: GuardianRequestResolver = {
       // Deliver denial notification and lifecycle signals when channel context is available
       if (channelDeliveryContext) {
         try {
-          const denialPayload: Parameters<typeof deliverChannelReply>[1] = {
-            chatId: requesterChatId,
-            text: "Your access request has been denied.",
-            assistantId,
-          };
-          // On Slack shared channels, deliver as ephemeral so only the requester sees the denial
-          if (
-            shouldUseEphemeral(channel, requesterChatId) &&
-            requesterExternalUserId
-          ) {
-            denialPayload.ephemeral = true;
-            denialPayload.user = requesterExternalUserId;
-          }
           await deliverChannelReply(
             channelDeliveryContext.replyCallbackUrl,
-            denialPayload,
+            buildRequesterChannelNotice({
+              channel,
+              requesterChatId,
+              requesterExternalUserId,
+              text: "Your access request has been denied.",
+              assistantId,
+            }),
           );
         } catch (err) {
           log.error(
@@ -614,7 +642,7 @@ const accessRequestResolver: GuardianRequestResolver = {
 
       // Deliver verification code to guardian
       const codeText =
-        `You approved access for ${requesterExternalUserId}. ` +
+        `You approved access for ${requesterLabel}. ` +
         `Give them this verification code: \`${session.secret}\`. ` +
         `The code expires in 10 minutes.`;
       try {
@@ -680,12 +708,8 @@ const accessRequestResolver: GuardianRequestResolver = {
         }
       }
 
-      // Notify the requester. For Slack, route to DM via the user ID and
-      // strip threadTs (which belongs to the guardian's channel thread).
-      const requesterTargetChatId =
-        channel === "slack" && requesterExternalUserId
-          ? requesterExternalUserId
-          : requesterChatId;
+      // Strip threadTs from the requester reply URL — it belongs to the
+      // guardian's channel thread and would cause thread_not_found in a DM.
       let requesterCallbackUrl = channelDeliveryContext.replyCallbackUrl;
       if (channel === "slack" && requesterExternalUserId) {
         try {
@@ -716,26 +740,18 @@ const accessRequestResolver: GuardianRequestResolver = {
           requesterNotified = true;
         } else {
           try {
-            const approvalPayload: Parameters<typeof deliverChannelReply>[1] = {
-              chatId: requesterTargetChatId,
-              text:
-                "Your access request has been approved! " +
-                "Please enter the 6-digit verification code you receive from the guardian.",
-              assistantId,
-            };
-            // On Slack shared channels, deliver the courier notice as an
-            // ephemeral message in the originating channel. chat.postEphemeral
-            // needs the channel ID (`C…`), so target requesterChatId rather
-            // than the requester's user ID.
-            if (
-              shouldUseEphemeral(channel, requesterChatId) &&
-              requesterExternalUserId
-            ) {
-              approvalPayload.chatId = requesterChatId;
-              approvalPayload.ephemeral = true;
-              approvalPayload.user = requesterExternalUserId;
-            }
-            await deliverChannelReply(requesterCallbackUrl, approvalPayload);
+            await deliverChannelReply(
+              requesterCallbackUrl,
+              buildRequesterChannelNotice({
+                channel,
+                requesterChatId,
+                requesterExternalUserId,
+                text:
+                  "Your access request has been approved! " +
+                  "Please enter the 6-digit verification code you receive from the guardian.",
+                assistantId,
+              }),
+            );
             requesterNotified = true;
           } catch (err) {
             log.error(
@@ -746,22 +762,18 @@ const accessRequestResolver: GuardianRequestResolver = {
         }
       } else {
         try {
-          const failurePayload: Parameters<typeof deliverChannelReply>[1] = {
-            chatId: requesterTargetChatId,
-            text:
-              "Your access request was approved, but we were unable to " +
-              "deliver the verification code. Please try again later.",
-            assistantId,
-          };
-          if (
-            shouldUseEphemeral(channel, requesterChatId) &&
-            requesterExternalUserId
-          ) {
-            failurePayload.chatId = requesterChatId;
-            failurePayload.ephemeral = true;
-            failurePayload.user = requesterExternalUserId;
-          }
-          await deliverChannelReply(requesterCallbackUrl, failurePayload);
+          await deliverChannelReply(
+            requesterCallbackUrl,
+            buildRequesterChannelNotice({
+              channel,
+              requesterChatId,
+              requesterExternalUserId,
+              text:
+                "Your access request was approved, but we were unable to " +
+                "deliver the verification code. Please try again later.",
+              assistantId,
+            }),
+          );
         } catch (err) {
           log.error(
             { err, requesterChatId },

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -55,6 +55,57 @@ function shouldUseEphemeral(sourceChannel: string, chatId: string): boolean {
   return sourceChannel === "slack" && chatId.startsWith("C");
 }
 
+/**
+ * Deliver the verification code straight to the requester's Slack DM so the
+ * guardian is never an out-of-band courier for the secret.
+ *
+ * Slack is the only channel with a guaranteed private path to the requester:
+ * posting to their user ID (`U…`) opens a 1:1 DM. The `threadTs` query param is
+ * dropped because it points at the guardian's channel thread and would raise
+ * `thread_not_found` in the DM. The code is sent as a durable (non-ephemeral)
+ * message the requester can refer back to when verifying.
+ *
+ * The verification session is identity-bound to the requester, so delivering
+ * the code to them directly does not widen who can consume it — it only removes
+ * the guardian relay step.
+ *
+ * Returns whether the code was delivered.
+ */
+async function deliverVerificationCodeToSlackRequester(params: {
+  replyCallbackUrl: string;
+  requesterExternalUserId: string;
+  verificationCode: string;
+  assistantId: string;
+}): Promise<boolean> {
+  let callbackUrl = params.replyCallbackUrl;
+  try {
+    const url = new URL(params.replyCallbackUrl);
+    url.searchParams.delete("threadTs");
+    callbackUrl = url.toString();
+  } catch {
+    // Relative path (e.g. the desktop "/deliver/slack" target) — use as-is;
+    // it carries no threadTs to strip.
+  }
+
+  try {
+    await deliverChannelReply(callbackUrl, {
+      chatId: params.requesterExternalUserId,
+      text:
+        "Great news — your access request was approved! " +
+        `Your verification code is: \`${params.verificationCode}\`. ` +
+        "Reply with it here to complete verification. The code expires in 10 minutes.",
+      assistantId: params.assistantId,
+    });
+    return true;
+  } catch (err) {
+    log.error(
+      { err, requesterExternalUserId: params.requesterExternalUserId },
+      "Failed to auto-deliver verification code to Slack requester",
+    );
+    return false;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -647,29 +698,47 @@ const accessRequestResolver: GuardianRequestResolver = {
       }
 
       if (codeDelivered) {
-        try {
-          const approvalPayload: Parameters<typeof deliverChannelReply>[1] = {
-            chatId: requesterTargetChatId,
-            text:
-              "Your access request has been approved! " +
-              "Please enter the 6-digit verification code you receive from the guardian.",
-            assistantId,
-          };
-          // On Slack shared channels, deliver as ephemeral so only the requester sees
-          if (
-            shouldUseEphemeral(channel, requesterChatId) &&
-            requesterExternalUserId
-          ) {
-            approvalPayload.ephemeral = true;
-            approvalPayload.user = requesterExternalUserId;
-          }
-          await deliverChannelReply(requesterCallbackUrl, approvalPayload);
+        // On Slack, deliver the code straight to the requester's DM so the
+        // guardian doesn't have to relay it. Other channels (and a failed Slack
+        // delivery) fall back to the courier notice — there is no guaranteed
+        // private path to the requester elsewhere (e.g. group chats).
+        const requesterCodeDelivered =
+          channel === "slack" && requesterExternalUserId
+            ? await deliverVerificationCodeToSlackRequester({
+                replyCallbackUrl: channelDeliveryContext.replyCallbackUrl,
+                requesterExternalUserId,
+                verificationCode: session.secret,
+                assistantId,
+              })
+            : false;
+
+        if (requesterCodeDelivered) {
           requesterNotified = true;
-        } catch (err) {
-          log.error(
-            { err, requesterChatId },
-            "Failed to notify requester of access request approval",
-          );
+        } else {
+          try {
+            const approvalPayload: Parameters<typeof deliverChannelReply>[1] = {
+              chatId: requesterTargetChatId,
+              text:
+                "Your access request has been approved! " +
+                "Please enter the 6-digit verification code you receive from the guardian.",
+              assistantId,
+            };
+            // On Slack shared channels, deliver as ephemeral so only the requester sees
+            if (
+              shouldUseEphemeral(channel, requesterChatId) &&
+              requesterExternalUserId
+            ) {
+              approvalPayload.ephemeral = true;
+              approvalPayload.user = requesterExternalUserId;
+            }
+            await deliverChannelReply(requesterCallbackUrl, approvalPayload);
+            requesterNotified = true;
+          } catch (err) {
+            log.error(
+              { err, requesterChatId },
+              "Failed to notify requester of access request approval",
+            );
+          }
         }
       } else {
         try {
@@ -721,26 +790,43 @@ const accessRequestResolver: GuardianRequestResolver = {
         });
       }
     } else if (desktopDeliverUrl && requesterChatId) {
-      // For Slack, route to DM via requesterExternalUserId (user ID) instead
-      // of requesterChatId (channel ID) to avoid posting in public channels.
-      const targetChatId =
+      // Guardian decided off-channel (e.g. desktop) but the requester is on a
+      // deliverable channel. On Slack, DM the code directly (parity with the
+      // on-channel path); otherwise fall back to the courier notice.
+      const requesterCodeDelivered =
         channel === "slack" && requesterExternalUserId
-          ? requesterExternalUserId
-          : requesterChatId;
-      try {
-        await deliverChannelReply(desktopDeliverUrl, {
-          chatId: targetChatId,
-          text:
-            "Your access request has been approved! " +
-            "Please enter the 6-digit verification code you receive from the guardian.",
-          assistantId,
-        });
+          ? await deliverVerificationCodeToSlackRequester({
+              replyCallbackUrl: desktopDeliverUrl,
+              requesterExternalUserId,
+              verificationCode: session.secret,
+              assistantId,
+            })
+          : false;
+
+      if (requesterCodeDelivered) {
         requesterNotified = true;
-      } catch (err) {
-        log.error(
-          { err, requesterChatId },
-          "Failed to notify requester of access request approval (desktop decision path)",
-        );
+      } else {
+        // For Slack, route to DM via requesterExternalUserId (user ID) instead
+        // of requesterChatId (channel ID) to avoid posting in public channels.
+        const targetChatId =
+          channel === "slack" && requesterExternalUserId
+            ? requesterExternalUserId
+            : requesterChatId;
+        try {
+          await deliverChannelReply(desktopDeliverUrl, {
+            chatId: targetChatId,
+            text:
+              "Your access request has been approved! " +
+              "Please enter the 6-digit verification code you receive from the guardian.",
+            assistantId,
+          });
+          requesterNotified = true;
+        } catch (err) {
+          log.error(
+            { err, requesterChatId },
+            "Failed to notify requester of access request approval (desktop decision path)",
+          );
+        }
       }
     }
 


### PR DESCRIPTION
## Problem

When a guardian approves a Slack **access request**, the canonical resolver (`accessRequestResolver`) minted the 6-digit code, delivered it to the **guardian**, and told the **requester** to "enter the 6-digit verification code you receive from the guardian." The code was never sent to the requester — the guardian had to copy/paste it into Slack by hand (a courier step). [LUM-2486]

This affected **both** live decision paths into the resolver:
- **on-channel** — guardian decides from Slack (`channelDeliveryContext` present)
- **off-channel** — guardian decides from the desktop app (`guardian-action-service.ts` passes no `channelDeliveryContext`, so the requester is reached via `/deliver/slack`)

## Root cause

EPD-2481 shipped auto-delivery (`deliverVerificationCodeToRequester`) for the **legacy** decision path (`access-request-decision.ts`). The canonical migration then made that legacy path **dead code** — access requests are created only via `createCanonicalGuardianRequest`, and nothing creates legacy `ingress_access_request` approval rows, so EPD-2481's fix never runs. The canonical resolver was never given the equivalent behavior and kept the old courier copy.

## Fix

Deliver the code straight to the requester's Slack DM on both branches, via one `deliverVerificationCodeToSlackRequester()` helper:
- posts to the requester's user-ID DM (private), strips `threadTs`, sends a **durable, non-ephemeral** message
- falls back to the existing courier message if the DM delivery fails

**Slack-only by design.** Non-Slack channels keep the courier message: Slack is the only channel with a guaranteed *private* path to the requester (user-ID DM). On Telegram/WhatsApp the requester chat can be a group, where posting the code would leak the secret. The verification session is identity-bound (`createOutboundSession` → `expectedExternalUserId`), so direct delivery does **not** widen who can consume it.

Guardian-facing delivery behavior is unchanged (the guardian still receives the code as a record/fallback; the desktop `guardianReplyText` carrying the code — LUM-444 — is preserved).

## Review follow-ups (later commits)

- **Codex (P2):** the ephemeral courier fallback targeted the requester's `U…` user ID, which `chat.postEphemeral` rejects (`channel_not_found`). Fixed to target the originating channel; the sibling delivery-failure branch had the same bug and is fixed too.
- **Refactor:** extracted `buildRequesterChannelNotice()` so the `chatId`/`ephemeral`/`user` pattern lives in one place instead of being hand-rolled at 3 sites — the divergence between those copies is what let the ephemeral bug exist in some and not others. Behavior-preserving.
- **Correctness:** guardian-facing messages now use the resolved **display name** instead of the raw external ID (matches the card-path behavior from LUM-2380).
- **Devin:** test mock returned `conversationId`; corrected to `sessionId` to match `CreateOutboundSessionResult`.

## Considered but deliberately NOT in this PR (flagging for review)

1. **`verification_sent` asymmetry** — it's emitted on the on-channel branch but not the desktop branch. It's a *suppression* toggle (`visibleInSourceNow: true` makes the decision engine drop the notification), so getting it wrong silently hides a real notification. Whether the desktop path even produces a redundant notification needs an end-to-end trace I didn't want to guess at. Left as-is.
2. **Guardian-confirmation UX** — on Slack the guardian still gets "give them this code" *and* the requester now gets it directly. Arguably the guardian should get a confirmation ("they've been sent a code") with the code only as a fallback. But the guardian seeing the code is a defensible record/fallback (it's what EPD-2481 deliberately kept), so this is a **product call**, not a bug — happy to do it if we want it.

## Tests

New cases in `trusted-contact-inline-approval-integration.test.ts`:
- on-channel Slack approval → requester DM receives the code (non-ephemeral, `threadTs` stripped); no courier message
- desktop-decided approval → requester DM receives the code via `/deliver/slack`
- non-Slack (Telegram) → courier message preserved, code never sent to the requester chat
- shared-channel fallback when the DM fails → ephemeral notice posts to the channel with `user` = requester
- guardian reply uses the display name, not the raw ID

`tsc`, `eslint`, and adjacent suites all green.

## Out of scope (filed/flagged separately)

- **LUM-2494** (new) — delete the now-dead legacy access-request decision path.
- **LUM-2382 / LUM-2378** (commented) — `approve_trusted` must be built on the canonical resolver, not the dead legacy path.

Closes LUM-2486

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015B2dK2YjCb5E5Yz7XmnWAB