### PR TITLE
Drop sendDiagnostics config key + migration 107

### DIFF
--- a/assistant/src/__tests__/workspace-migration-drop-send-diagnostics.test.ts
+++ b/assistant/src/__tests__/workspace-migration-drop-send-diagnostics.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mock state
+// ---------------------------------------------------------------------------
+
+const existsSyncFn = mock((_path: string): boolean => false);
+const readFileSyncFn = mock((_path: string, _encoding: string): string => "");
+const writeFileSyncFn = mock((_path: string, _data: string): void => undefined);
+
+// ---------------------------------------------------------------------------
+// Mock modules — before importing module under test
+// ---------------------------------------------------------------------------
+
+mock.module("node:fs", () => ({
+  existsSync: existsSyncFn,
+  readFileSync: readFileSyncFn,
+  writeFileSync: writeFileSyncFn,
+}));
+
+// Import after mocking
+import { dropSendDiagnosticsMigration } from "../workspace/migrations/107-drop-send-diagnostics.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const WORKSPACE_DIR = "/tmp/test-workspace";
+const CONFIG_PATH = `${WORKSPACE_DIR}/config.json`;
+
+function setupConfigExists(config: unknown) {
+  existsSyncFn.mockImplementation((path: string) => path === CONFIG_PATH);
+  readFileSyncFn.mockImplementation(() => JSON.stringify(config));
+}
+
+function getWrittenConfig(): Record<string, unknown> {
+  expect(writeFileSyncFn).toHaveBeenCalledTimes(1);
+  const [path, data] = writeFileSyncFn.mock.calls[0] as [string, string];
+  expect(path).toBe(CONFIG_PATH);
+  return JSON.parse(data) as Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("107-drop-send-diagnostics migration", () => {
+  beforeEach(() => {
+    existsSyncFn.mockClear();
+    readFileSyncFn.mockClear();
+    writeFileSyncFn.mockClear();
+  });
+
+  test("no-op when config.json is absent", () => {
+    existsSyncFn.mockImplementation(() => false);
+
+    dropSendDiagnosticsMigration.run(WORKSPACE_DIR);
+
+    expect(readFileSyncFn).not.toHaveBeenCalled();
+    expect(writeFileSyncFn).not.toHaveBeenCalled();
+  });
+
+  test("explicit opt-out is preserved as legacyDiagnosticsOptOut", () => {
+    setupConfigExists({ sendDiagnostics: false, someSetting: "value" });
+
+    dropSendDiagnosticsMigration.run(WORKSPACE_DIR);
+
+    const written = getWrittenConfig();
+    expect(written.sendDiagnostics).toBeUndefined();
+    expect(written.legacyDiagnosticsOptOut).toBe(true);
+    expect(written.someSetting).toBe("value");
+  });
+
+  test("sendDiagnostics: true is removed without setting the marker", () => {
+    setupConfigExists({ sendDiagnostics: true });
+
+    dropSendDiagnosticsMigration.run(WORKSPACE_DIR);
+
+    const written = getWrittenConfig();
+    expect(written.sendDiagnostics).toBeUndefined();
+    expect(written.legacyDiagnosticsOptOut).toBeUndefined();
+  });
+
+  test("non-false value is removed without setting the marker", () => {
+    setupConfigExists({ sendDiagnostics: "yes" });
+
+    dropSendDiagnosticsMigration.run(WORKSPACE_DIR);
+
+    const written = getWrittenConfig();
+    expect(written.sendDiagnostics).toBeUndefined();
+    expect(written.legacyDiagnosticsOptOut).toBeUndefined();
+  });
+
+  test("no-op when sendDiagnostics is absent (no marker)", () => {
+    setupConfigExists({ someSetting: "value" });
+
+    dropSendDiagnosticsMigration.run(WORKSPACE_DIR);
+
+    expect(writeFileSyncFn).not.toHaveBeenCalled();
+  });
+
+  test("malformed config is handled gracefully", () => {
+    existsSyncFn.mockImplementation((path: string) => path === CONFIG_PATH);
+    readFileSyncFn.mockImplementation(() => "not valid json {{{");
+
+    dropSendDiagnosticsMigration.run(WORKSPACE_DIR);
+
+    expect(writeFileSyncFn).not.toHaveBeenCalled();
+  });
+
+  test("no-op when config is an array", () => {
+    setupConfigExists([1, 2, 3]);
+
+    dropSendDiagnosticsMigration.run(WORKSPACE_DIR);
+
+    expect(writeFileSyncFn).not.toHaveBeenCalled();
+  });
+});

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -136,10 +136,6 @@ export const AssistantConfigSchema = z
       .describe(
         "Per-plugin configuration keyed by plugin name. Validated downstream by each plugin's manifest.config validator at bootstrap.",
       ),
-    sendDiagnostics: z
-      .boolean()
-      .default(true)
-      .describe("Whether to send diagnostic/crash reports"),
     legacyTelemetryOptOut: z
       .boolean()
       .optional()

--- a/assistant/src/workspace/migrations/107-drop-send-diagnostics.ts
+++ b/assistant/src/workspace/migrations/107-drop-send-diagnostics.ts
@@ -1,0 +1,47 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Drops the `sendDiagnostics` config key (crash reporting is governed by the
+ * platform `share_diagnostics` consent). An explicit local opt-out
+ * (`sendDiagnostics: false`) is preserved as `legacyDiagnosticsOptOut: true` so
+ * Sentry stays off regardless of platform consent, which defaults to opt-in and
+ * cannot be written by the daemon. A `true`/non-false value carries no opt-out
+ * intent, so the key is removed without setting the marker. The schema strips
+ * unknown keys on the next save, so a stale value is otherwise harmless.
+ */
+export const dropSendDiagnosticsMigration: WorkspaceMigration = {
+  id: "107-drop-send-diagnostics",
+  description:
+    "Drop sendDiagnostics; preserve an explicit opt-out as legacyDiagnosticsOptOut (crash reporting is gated by platform share_diagnostics consent)",
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return; // Malformed config — skip
+    }
+
+    if (!("sendDiagnostics" in config)) return;
+
+    // An explicit opt-out is preserved as a fail-closed marker; any non-false
+    // value carries no opt-out intent.
+    if (config.sendDiagnostics === false) {
+      config.legacyDiagnosticsOptOut = true;
+    }
+
+    delete config.sendDiagnostics;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(_workspaceDir: string): void {
+    // No-op: the forward migration only removes a key and sets a fail-closed
+    // marker, so there is nothing to restore.
+  },
+};

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -104,6 +104,7 @@ import { upgradeQualityProfileToOpus48Migration } from "./103-upgrade-quality-pr
 import { recheckAdaptiveThinkingModelImpliedAnthropicMigration } from "./104-recheck-adaptive-thinking-model-implied-anthropic.js";
 import { enableMemoryV3LiveForNewWorkspacesMigration } from "./105-enable-memory-v3-live-for-new-workspaces.js";
 import { dropCollectUsageDataMigration } from "./106-drop-collect-usage-data.js";
+import { dropSendDiagnosticsMigration } from "./107-drop-send-diagnostics.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -219,4 +220,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   recheckAdaptiveThinkingModelImpliedAnthropicMigration,
   enableMemoryV3LiveForNewWorkspacesMigration,
   dropCollectUsageDataMigration,
+  dropSendDiagnosticsMigration,
 ];


### PR DESCRIPTION
## Summary
- Remove the `sendDiagnostics` config schema key (Sentry is now gated by platform `share_diagnostics` consent).
- Add workspace migration 107 dropping `sendDiagnostics`, preserving an explicit `false` opt-out as the fail-closed `legacyDiagnosticsOptOut` marker. Mirrors migration 106.

Part of plan: diagnostics-consent-gating.md (PR 4 of 5)