### PR TITLE
fix(macos): self-heal CLI install lock so a missing bin recovers without restart

### DIFF
--- a/clients/macos/src/main/cli-installer.test.ts
+++ b/clients/macos/src/main/cli-installer.test.ts
@@ -316,6 +316,7 @@ describe("ensureCliInstalled", () => {
 
     const promise = ensureCliInstalled();
 
+    existsSyncByPath[cliBinPath] = true;
     lastChild.emit("close", 0);
     await promise;
 
@@ -342,6 +343,7 @@ describe("ensureCliInstalled", () => {
     lastChild.emit("close", 1);
     // The retry spawns against the seeded frozen lockfile.
     await Promise.resolve();
+    existsSyncByPath[cliBinPath] = true;
     lastChild.emit("close", 0);
     await promise;
 
@@ -374,6 +376,7 @@ describe("ensureCliInstalled", () => {
     existsSyncDefault = false;
 
     const promise = ensureCliInstalled();
+    existsSyncByPath[cliBinPath] = true;
     lastChild.emit("close", 0);
     await promise;
 
@@ -436,6 +439,7 @@ describe("ensureCliInstalled", () => {
     readdirSyncReturn = [dirEntry("0.8.5"), dirEntry("latest")];
 
     const promise = ensureCliInstalled();
+    existsSyncByPath[cliBinPath] = true;
     lastChild.emit("close", 0);
     await promise;
 
@@ -456,6 +460,7 @@ describe("ensureCliInstalled", () => {
     // Only one spawn should have occurred.
     expect(spawnCalls).toHaveLength(1);
 
+    existsSyncByPath[cliBinPath] = true;
     lastChild.emit("close", 0);
     await Promise.all([p1, p2]);
   });
@@ -472,8 +477,48 @@ describe("ensureCliInstalled", () => {
     // Second attempt should spawn a new process.
     const p2 = ensureCliInstalled();
     expect(spawnCalls).toHaveLength(2);
+    existsSyncByPath[cliBinPath] = true;
     lastChild.emit("close", 0);
     await p2;
+  });
+
+  test("self-heals when the installed bin disappears mid-session", async () => {
+    existsSyncDefault = false;
+
+    // First install succeeds and links the bin.
+    const p1 = ensureCliInstalled();
+    existsSyncByPath[cliBinPath] = true;
+    lastChild.emit("close", 0);
+    await p1;
+    expect(spawnCalls).toHaveLength(1);
+
+    // node_modules gets clobbered mid-session — the bin is gone again.
+    delete existsSyncByPath[cliBinPath];
+
+    // A later call must reinstall rather than short-circuit on the resolved
+    // promise from the first install.
+    const p2 = ensureCliInstalled();
+    expect(spawnCalls).toHaveLength(2);
+    existsSyncByPath[cliBinPath] = true;
+    lastChild.emit("close", 0);
+    await p2;
+  });
+
+  test("throws when the install completes but links no bin", async () => {
+    existsSyncDefault = false;
+
+    const promise = ensureCliInstalled();
+    // bun exits 0 without ever creating node_modules/.bin/vellum.
+    lastChild.emit("close", 0);
+
+    await expect(promise).rejects.toThrow(/no vellum binary was found/);
+
+    // The lock is cleared, so a subsequent attempt reinstalls from scratch.
+    const retry = ensureCliInstalled();
+    expect(spawnCalls).toHaveLength(2);
+    existsSyncByPath[cliBinPath] = true;
+    lastChild.emit("close", 0);
+    await retry;
   });
 });
 

--- a/clients/macos/src/main/cli-installer.ts
+++ b/clients/macos/src/main/cli-installer.ts
@@ -336,19 +336,28 @@ export async function ensureCliInstalled(): Promise<void> {
     return;
   }
 
-  if (cliInstallPromise) return cliInstallPromise;
+  // Clear the lock once the install settles (success or failure) so a later
+  // call never short-circuits on a stale resolved promise — otherwise a bin
+  // that goes missing mid-session wedges every retry until an app restart.
+  if (!cliInstallPromise) {
+    cliInstallPromise = (async () => {
+      try {
+        await bunInstallCli();
+        writeCliLocator();
+        cleanupOldVersions();
+      } finally {
+        cliInstallPromise = null;
+      }
+    })();
+  }
+  await cliInstallPromise;
 
-  cliInstallPromise = (async () => {
-    await bunInstallCli();
-    writeCliLocator();
-    cleanupOldVersions();
-  })();
-
-  try {
-    await cliInstallPromise;
-  } catch (err) {
-    cliInstallPromise = null;
-    throw err;
+  // Fail loudly on an exit-0 install that linked no bin, rather than letting
+  // it surface downstream as a cryptic `bun run` "Module not found".
+  if (!isCliInstalled()) {
+    throw new Error(
+      `CLI install reported success but no vellum binary was found at ${getCliBinPath()}.`,
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- `ensureCliInstalled()` only reset its singleton install promise on failure, so a *successful* install left a resolved promise cached forever. If the installed `vellum` bin later went missing mid-session (e.g. a clobbered `cli/latest/node_modules` in an unpinned `macos-dev` build tracking the constantly-republished `vellum@dev` tag), every subsequent `ensureCliInstalled()` call short-circuited on the stale promise and skipped the reinstall — `hatch` then ran `bun run` against the now-missing bin and surfaced bun's cryptic `error: Module not found "…/cli/latest/node_modules/.bin/vellum"`. Only a full app restart (which resets the module-level promise) recovered, so the in-app "Try again" button did nothing.
- Clear the lock whenever the install settles — success or failure — via `try/finally`, so a later call re-checks and reinstalls instead of returning a stale resolved promise.
- After awaiting the install, verify the bin actually exists; throw a clear error when an exit-0 install linked no bin, instead of letting it fail downstream as an opaque `bun run` error.
- Added tests for mid-session self-heal and the no-bin-after-install guard; updated existing install tests to mark the bin present on a simulated successful install.

## Original prompt
Investigated a "Something went wrong — error: Module not found …/cli/latest/node_modules/.bin/vellum" error users hit when hatching a locally hosted assistant from the Electron macOS dev app. Root-caused it to the install singleton in `cli-installer.ts` never resetting on success, which wedges the session (and makes "Try again" useless) whenever the installed bin goes missing. This PR is the agreed hardening: reset the lock on success too and add a post-await bin re-check so a clobbered `cli/latest` self-heals without an app restart.