### PR TITLE
feat(plugins/marketing-expert): improve skill discoverability

### DIFF
--- a/plugins/marketing-expert/skills/founder-marketing/SKILL.md
+++ b/plugins/marketing-expert/skills/founder-marketing/SKILL.md
@@ -7,6 +7,13 @@ metadata:
   vellum:
     category: "marketing"
     display-name: "Founder Marketing"
+    activation-hints:
+      - "I have a startup and need help with marketing"
+      - "I don't know where to start with marketing"
+      - "early-stage, pre-launch, or pre-PMF marketing"
+      - "no marketing team or budget"
+      - "how do I get my first customers / first users"
+      - "build in public, founder brand, founder-led growth"
 ---
 
 Help a **founder** market with the constraints they actually have: almost no time, no team, little budget, and often pre-product-market-fit. The rules are different from team-stage marketing — so don't hand a founder a 12-channel plan. Two truths drive everything:

--- a/plugins/marketing-expert/skills/marketing-expert/SKILL.md
+++ b/plugins/marketing-expert/skills/marketing-expert/SKILL.md
@@ -1,12 +1,19 @@
 ---
 name: marketing-expert
-description: Act as the user's Marketing Expert for any marketing question or strategy work — positioning, demand gen, launches, content, brand, competitive, or marketing analytics. Use whenever the user asks for marketing help, marketing strategy, "be my marketing expert / CMO / head of marketing", or a marketing need that doesn't map to a more specific marketing skill.
+description: Act as the user's marketing expert for any marketing question or strategy work — marketing help, marketing strategy, growth, getting customers, positioning, demand gen, launches, content, brand, competitive, or marketing analytics — including for a startup or small business. Use whenever the user asks for marketing help or a marketing need that doesn't map to a more specific marketing skill.
 compatibility: "Designed for Vellum personal assistants — part of the marketing-expert plugin"
 metadata:
   emoji: "📣"
   vellum:
     category: "marketing"
     display-name: "Marketing Expert"
+    activation-hints:
+      - "I need help with marketing"
+      - "I have a startup / company / product and need help with marketing"
+      - "help me market my product, grow, or get customers"
+      - "I don't know where to start with marketing"
+      - "marketing strategy, marketing plan, go-to-market"
+      - "be my CMO / head of marketing / marketing expert"
 ---
 
 You are operating as the user's **Marketing Expert** — a seasoned, full-stack marketing leader. You own marketing *outcomes* (revenue, growth, brand, market position), not just tasks. **Adapt to the user's business** — B2B or B2C; SaaS, ecommerce, marketplace, consumer, services, hardware, media, nonprofit, anything. Infer or ask about their model, motion, audience, and the metrics that matter; never assume a default vertical. The funnel and unit economics apply everywhere — just map them to their reality (e.g. MQL→SQL→won for B2B sales-led, visit→add-to-cart→purchase→repeat for ecommerce, install→activate→subscribe for consumer apps).

--- a/plugins/marketing-expert/src/marketing-expert-frame.ts
+++ b/plugins/marketing-expert/src/marketing-expert-frame.ts
@@ -12,4 +12,4 @@
 export const MARKETING_EXPERT_FRAME_MARKER = "<!-- marketing-expert:activation -->";
 
 export const MARKETING_EXPERT_FRAME =
-  "When the user needs marketing help — positioning, demand gen, launches, content, competitive analysis, campaigns, or marketing/funnel analytics — act as their marketing expert and use this plugin's `marketing-expert` skills and tools (e.g. `funnel_math`); the `marketing-expert` skill covers general marketing strategy and routes to the specific playbooks.";
+  "When the user asks for help with marketing — or anything under positioning, demand gen, launches, content, GEO, competitive analysis, campaigns, or funnel analytics (including for a startup or small business) — load the `marketing-expert` skill first (it carries the operating principles and routes to the right playbook), then act as their marketing expert and reach for the plugin's tools like `funnel_math`.";


### PR DESCRIPTION
## Problem

Live test — "I have a startup and I need help with marketing" — did **not** activate the plugin. The assistant answered directly without loading any `marketing-expert` skill.

## Root cause

Skills surface to the model via **BM25 retrieval over capability nodes**, whose indexed text is built (`memory/graph/capability-seed.ts`) as:

> `The "<displayName>" skill (<id>) is available. <description>. Use when: <activation-hints>. Avoid when: <avoid-when>.`

The `marketing-expert` skill had **no `activation-hints`**, and its description didn't contain the words a founder actually types ("startup", "get customers", "where to start"), so a generic marketing request ranked too low to be loaded.

## Fix

- **`activation-hints`** added to `marketing-expert` and `founder-marketing` with the real phrasings ("I have a startup and need help with marketing", "I don't know where to start", "get customers", "be my CMO / head of marketing"). These feed the "Use when:" retrieval text.
- **Keyword-enriched** the `marketing-expert` description (startup, growth, get customers, go-to-market).
- **Hook activation line** now tells the model to **load the `marketing-expert` skill first** (not just role-play the persona), so the playbooks/principles engage.

## Notes

- Reseeding runs on daemon start (`rebuildBm25CorpusStatsAndReseedSkills`), so **a restart is required** to pick up the new capability text.
- The marketplace entry (#35347) pins an older commit; its `ref` should be bumped to include this once both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)