### PR TITLE
docs(config): fix temporal wording in MANAGED_PROFILE_KEYS comment

### DIFF
--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -92,9 +92,9 @@ const USER_PROFILE_TEMPLATES: Record<string, UserProfileTemplate> = {
  */
 export const AUTO_PROFILE_KEY = "auto";
 
-/** Stable keys of the platform-managed profiles. The profile *content* now
- *  comes from the platform model-profiles endpoint; only the key set lives
- *  in code, so route validation and pruning can recognise managed profiles. */
+/** Stable keys of the platform-managed profiles. The profile *content* comes
+ *  from the platform model-profiles endpoint; only the key set lives in code,
+ *  so route validation and pruning can recognise managed profiles. */
 const MANAGED_PROFILE_KEYS = [
   "balanced",
   "quality-optimized",


### PR DESCRIPTION
## Summary
- Reword the MANAGED_PROFILE_KEYS doc comment to present tense per AGENTS.md (no "now" temporal language)

Part of plan: platform-managed-profiles.md (review remediation, round 2)