### PR TITLE
advisor: steer to consult before building, for plan creation/review

### DIFF
--- a/assistant/src/plugins/defaults/advisor/steering.ts
+++ b/assistant/src/plugins/defaults/advisor/steering.ts
@@ -10,7 +10,7 @@
 /** Idempotency marker; the steering block is appended at the end of the prompt. */
 export const STEERING_MARKER = "<!-- advisor:steering -->";
 
-const STEERING_BODY = `You have an \`advisor\` tool backed by a stronger reviewer model. It takes NO parameters — calling it forwards your entire conversation automatically (the task, every tool call, every result). Call advisor at the moments where a second perspective matters most: when you're about to commit to an approach or interpretation, at a consequential decision or crossroads, when you're stuck, and once before you declare the task done. It needs enough context to be useful — a concrete plan, a first attempt, or initial findings to react to, not the opening turn when there's nothing to assess — and it's most valuable while there's still room to act on its advice. Give its guidance serious weight; only override it when primary-source evidence contradicts a specific claim, and say so when you do.`;
+const STEERING_BODY = `You have an \`advisor\` tool backed by a stronger reviewer model. It takes NO parameters — calling it forwards your entire conversation automatically (the task, every tool call, every result). Call advisor BEFORE you start building or implementing: once you understand what's being asked, consult it to shape the plan — it can lay out the plan when you don't have one yet, or pressure-test and sharpen a plan you've already drafted. Orient yourself first (read the relevant files, understand the task), then call advisor before you commit to an approach and start producing work. Also call it when you get stuck, when you're weighing a change in direction, and once before you declare the task done. Give its guidance serious weight; only override it when primary-source evidence contradicts a specific claim, and say so when you do.`;
 
 const ADVISOR_STEERING = `${STEERING_MARKER}\n${STEERING_BODY}`;
 
@@ -37,11 +37,11 @@ export function stripSteering(systemPrompt: string | null): string | null {
 export function buildAdvisorSystem(
   originalSystemPrompt: string | null,
 ): string {
-  const base = `You are a senior advisor consulted by another AI agent that is partway through a task. The entire conversation above is the agent's working context: its task or goal, every tool call it has made, and every result it has seen. The agent has paused to consult you because you bring a second, independent perspective it cannot get from inside its own reasoning loop. Your job is to maximize its odds of finishing the task correctly and efficiently.
+  const base = `You are a senior advisor consulted by another AI agent working on a task — most often at the planning stage, before it starts building, but sometimes partway through. The entire conversation above is the agent's working context: its task or goal, every tool call it has made, and every result it has seen. The agent has paused to consult you because you bring a second, independent perspective it cannot get from inside its own reasoning loop. Your job is to maximize its odds of completing the task correctly and efficiently.
 
 Evaluate the work along these dimensions, and lead with whatever matters most right now:
 
-- Approach: Is the agent's current approach the right one, or is there a materially better path? If the approach is sound, say so plainly; if it's flawed, name the specific flaw and the better alternative.
+- Approach & plan: If the agent has already drafted a plan or chosen an approach, pressure-test it — is it the right one, or is there a materially better path? If it hasn't committed to one yet, lay out a concrete plan for how to proceed. Either way, be specific about the path you would take and why.
 - Assumptions & requirements: Surface any wrong, unstated, or unverified assumption the agent is building on, and any part of the task it has misread, silently narrowed, or skipped. These are the failures it is least able to see itself.
 - Critical risk: Identify the single failure mode most likely to derail the task — or that already has — and how to avoid or recover from it.
 - Next step: Give one concrete action the agent can take immediately. Name the specific file, function, command, interface, or decision involved — not a generic direction.

--- a/assistant/src/plugins/defaults/advisor/tools/advisor.ts
+++ b/assistant/src/plugins/defaults/advisor/tools/advisor.ts
@@ -22,13 +22,12 @@ import { consultAdvisor } from "../consult.js";
 const advisorTool: ToolDefinition = {
   name: "advisor",
   description:
-    "Consult a stronger advisor model for detailed feedback and strategic guidance. " +
+    "Consult a stronger advisor model to shape your plan and get strategic guidance. " +
     "Takes NO parameters — your full conversation (the task, every tool call, and every " +
-    "result) is forwarded automatically. Call it at the moments where a second perspective " +
-    "matters most: when you're committing to an approach or interpretation, at a " +
-    "consequential decision or crossroads, when you're stuck, and once before declaring a " +
-    "task complete. Give it enough context to be useful — a concrete plan, a first attempt, " +
-    "or initial findings to react to — and call while there's still room to act on its advice.",
+    "result) is forwarded automatically. Call it BEFORE you start building: it can lay out " +
+    "a plan when you don't have one yet, or review and sharpen the plan you've already " +
+    "drafted. Also call it when you're stuck, when weighing a change in approach, and once " +
+    "before declaring a task complete. Give its guidance serious weight.",
   input_schema: { type: "object", properties: {}, additionalProperties: false },
   // Read-only advice; low risk so the consult isn't gated behind a prompt.
   defaultRiskLevel: RiskLevel.Low,


### PR DESCRIPTION
Shifts the advisor's "when to call" guidance toward **plan time**: consult it **before building**, so it either lays out the plan (when the agent has none yet) or pressure-tests and sharpens a plan the agent already drafted.

## Changes
- **Steering** (`steering.ts`): "Call advisor BEFORE you start building or implementing: once you understand what's being asked, consult it to shape the plan — it can lay out the plan when you don't have one yet, or pressure-test and sharpen a plan you've already drafted." Orient first (read files, understand the task), then consult before committing to an approach. Still nudged for stuck / changing direction / before declaring done.
- **Tool description** (`tools/advisor.ts`): matches — "Call it BEFORE you start building: it can lay out a plan when you don't have one yet, or review and sharpen the plan you've already drafted."
- **Advisor system prompt** (`buildAdvisorSystem`): updated so the advisor handles being consulted at the planning stage — the "Approach & plan" dimension now covers proposing a concrete plan when the agent hasn't committed to one, not only critiquing an existing approach.

## Tests
No assertions reference the changed strings; the system-prompt test still anchors on "senior advisor". All advisor tests pass; tsc / lint / prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)