### PR TITLE
feat(onboarding): rewrite the research-onboarding kickoff prompt

### DIFF
--- a/clients/web/src/domains/onboarding/research-prompt.ts
+++ b/clients/web/src/domains/onboarding/research-prompt.ts
@@ -15,9 +15,9 @@
  * The output contract here MUST stay in sync with the parser in
  * `@/domains/chat/onboarding-research/research-facts.ts`.
  *
- * NOTE(alex): first-draft prompt (the original was lost). Tune the wording /
- * claim count / confidence rubric freely — only the trailing JSON contract is
- * load-bearing for the UI.
+ * NOTE(alex): the wording / claim count / confidence rubric / suggestion
+ * guidance are all tunable — only the trailing JSON contract (`claims` +
+ * `suggestions` shape) is load-bearing for the UI.
  */
 
 export interface ResearchSubject {
@@ -36,70 +36,51 @@ export function buildResearchPrompt({
     .join(" ");
   const role = occupation.trim();
 
-  const identity = [
-    fullName ? `My name is ${fullName}.` : "",
-    role ? `I work as ${role}.` : "",
-  ]
-    .filter(Boolean)
-    .join(" ");
+  const identity =
+    [
+      fullName ? `My name is ${fullName}.` : "",
+      role ? `I work as ${role}.` : "",
+    ]
+      .filter(Boolean)
+      .join(" ") ||
+    "I'd like you to get to know me before we start working together.";
 
-  return [
-    identity ||
-      "I'd like you to get to know me before we start working together.",
-    "",
-    "Before we dive in, get to know me. Search the web for what's publicly",
-    "known about the person matching my name and role, and infer a handful of",
-    "things about who I am — what I do, my role, where I'm based, what I'm into,",
-    "anything that would help you assist me better. Lean on public sources",
-    "(LinkedIn, company pages, social profiles, articles). It's fine to make",
-    "reasonable inferences and label them honestly.",
-    "",
-    "CRITICAL — your final reply must be ONLY a JSON object. No preamble, no",
-    "explanation, no prose, nothing before or after it. Do your thinking and",
-    "searching, then respond with exactly this shape and nothing else:",
-    "",
-    "{",
-    '  "claims": [',
-    '    { "claim": "Software engineer in Columbus, OH", "confidence": "confident", "sources": ["https://github.com/you"] },',
-    '    { "claim": "You climb outdoors", "confidence": "maybe", "sources": [] },',
-    '    { "claim": "Head of growth at Vellum", "confidence": "guessing", "sources": ["https://example.com/about"] }',
-    "  ],",
-    '  "suggestions": [',
-    '    "Draft your weekly GTM update",',
-    '    "Summarize competitor launches each Monday",',
-    '    "Turn your notes into polished posts",',
-    '    "Track your team\'s OKRs"',
-    "  ]",
-    "}",
-    "",
-    "Rules for \"claims\":",
-    "- AT MOST 5 claims — the strongest, most useful ones only.",
-    "- Each claim must be SHORT: a few words to one brief line. No multi-clause",
-    "  sentences, no em-dash asides, no explanations. Think headline, not bio.",
-    '  Good: "Contributed to Chirps (vector-DB security)". Bad: "You\'ve done',
-    '  real work in vector database security — you contributed to Chirps, a',
-    '  tool for scanning vector DBs for sensitive data".',
-    "- Each claim independently true-or-false so I can remove ones that are wrong.",
-    '- Phrase them directly ("You\'re…", "You climb outdoors", "Head of growth',
-    '  at Vellum").',
-    '- "confidence" is one of: "confident" (well supported by what you found),',
-    '  "maybe" (plausible but unverified), "guessing" (a hunch from limited',
-    "  signal).",
-    '- "sources": 0–3 URLs you actually used as evidence for that specific',
-    "  claim (the pages you read). Use [] for pure inferences.",
-    "",
-    "Rules for \"suggestions\":",
-    "- EXACTLY 4 suggestions. These TEACH a brand-new user what you can do —",
-    "  each should showcase a DIFFERENT capability of yours (e.g. research &",
-    "  summarize, draft & write, automate a recurring task, analyze data,",
-    "  build something), made relevant to my work and role.",
-    "- Phrase each as a short, inviting action I can click to try right now,",
-    '  starting with a verb (e.g. "Summarize this week\'s LLM releases for me",',
-    '  "Draft a launch post from your notes"). No explanations.',
-    "- Make them feel concrete and immediately runnable, not generic.",
-    "",
-    "Don't include anything sensitive or private. If you found very little,",
-    'lean on "guessing" claims and broadly useful suggestions for my role.',
-    "Output ONLY the JSON object — no code fence, no extra text.",
-  ].join("\n");
+  return `${identity}
+
+Before we dive in, get to know me. Search the web for what's publicly known about the person matching my name and role, and infer a handful of things about who I am — what I do, my role, where I'm based, what I'm into, anything that would help you assist me better. Lean on public sources (LinkedIn, company pages, social profiles, articles). It's fine to make reasonable inferences and label them honestly.
+
+CRITICAL — your final reply must be ONLY a JSON object. No preamble, no explanation, no prose, nothing before or after it. Do your thinking and searching, then respond with exactly this shape and nothing else:
+
+{
+  "claims": [
+    { "claim": "Software engineer in Columbus, OH", "confidence": "confident", "sources": ["https://github.com/you"] },
+    { "claim": "You climb outdoors", "confidence": "maybe", "sources": [] },
+    { "claim": "Head of growth at Vellum", "confidence": "guessing", "sources": ["https://example.com/about"] }
+  ],
+  "suggestions": [
+    "Build a live dashboard to track your prompt eval runs across models",
+    "Set up a weekly monitor that flags new LLM releases every Monday morning",
+    "Write a deep-dive doc on your team's current evals setup in the live editor",
+    "Connect Linear and auto-triage new bugs into your team's backlog"
+  ]
+}
+
+Rules for "claims":
+- AT MOST 5 claims — the strongest, most useful ones only.
+- Each claim must be SHORT: a few words to one brief line. No multi-clause sentences, no em-dash asides, no explanations. Think headline, not bio.
+  Good: "Contributed to Chirps (vector-DB security)". Bad: "You've done real work in vector database security — you contributed to Chirps, a tool for scanning vector DBs for sensitive data".
+- Each claim independently true-or-false so I can remove ones that are wrong.
+- Phrase them directly ("You're…", "You climb outdoors", "Head of growth at Vellum").
+- "confidence" is one of: "confident" (well supported by what you found), "maybe" (plausible but unverified), "guessing" (a hunch from limited signal).
+- "sources": 0–3 URLs you actually used as evidence for that specific claim (the pages you read). Use [] for pure inferences.
+
+Rules for "suggestions":
+- EXACTLY 4 suggestions. These TEACH me what you can do — each should showcase a DIFFERENT, non-obvious capability that would make me say "wait, you can do that?" Concrete capabilities to draw from: build an interactive app or dashboard (tracker, calculator, visualizer); write a long-form document in a live rich-text editor; set up a heartbeat or scheduled monitor to watch for something on a recurring basis; use integrations to act on Gmail, Google Calendar, Slack, or Linear.
+- Map each suggestion to a different category from the list above so the four suggestions cover distinct capabilities. Avoid generic things like "summarize" or "draft a post" — those are expected. Favor the surprising ones.
+- Use what you learned about me during research to make each suggestion feel specific to me — my role, my stack, my industry. Not "build a tracker" but something grounded in what you actually found. The research phase exists partly to make this possible.
+- Phrase each as a short, inviting action I can click to try right now, starting with a verb. No explanations.
+- Make them feel concrete and immediately runnable, not generic.
+
+Don't include anything sensitive or private. If you found very little, lean on "guessing" claims and broadly useful suggestions for my role.
+Output ONLY the JSON object — no code fence, no extra text.`;
 }


### PR DESCRIPTION
## What

Updates the message auto-sent on the user's behalf that kicks off the research turn (the one that researches the user and surfaces the editable "here's what I know about you" card).

`buildResearchPrompt` in `clients/web/src/domains/onboarding/research-prompt.ts`:
- Reworks the **`suggestions`** guidance so each of the four suggestions showcases a **different, non-obvious capability** — interactive app/dashboard, live-editor long-form doc, scheduled monitor/heartbeat, or an integration on Gmail/Calendar/Slack/Linear — grounded in what research surfaced, rather than generic summarize/draft actions. Adds a "map each suggestion to a different category" rule.
- Refreshes the example `suggestions` to match (previously the examples modeled the exact generic actions the rules said to avoid — a contradiction this fixes).
- Tightens the overall wording and switches the body to a template literal so the prompt reads as plain prose instead of hard-wrapped mid-sentence newlines.

## Contract

The trailing JSON output contract is **unchanged** — `{ claims: [{ claim, confidence, sources }], suggestions: [...] }` with confidence `confident|maybe|guessing`. The streaming parser in `research-facts.ts` and the onboarding overlay are unaffected.

## Verification

- Rendered the prompt with sample input: `[NAME]`/`[ROLE]` substitution correct, graceful fallback line preserved when name/role are absent.
- Prettier, typecheck, and lint clean. No tests reference this prompt (none snapshot the wording).

## No Linear ticket
Opened without one per the author's go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)