### PR TITLE
chore(plugins): align marketing-expert marketplace ref + description

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -70,9 +70,9 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/marketing-expert",
-        "ref": "2d52c6ccc689507f775f542b4d0cf13bbb680bc2"
+        "ref": "bd35992c151a0d62274f7693d8043633fd05ed53"
       },
-      "description": "Acts as a full-stack marketing expert for any business (B2B or B2C): an on-demand persona plus playbook skills (positioning, demand plan, launch, content, GEO, competitive teardown, board report) and deterministic funnel/positioning/GTM/competitive tools.",
+      "description": "Acts as a full-stack marketing expert for any business (B2B or B2C): an on-demand persona plus playbook skills (positioning, demand planning, launches, content & copywriting, brand voice, email sequences, SEO & GEO, competitive teardown, board reporting) and deterministic funnel/positioning/GTM/competitive tools.",
       "category": "marketing",
       "homepage": "https://github.com/vellum-ai/marketing-expert",
       "license": "MIT"


### PR DESCRIPTION
Follow-up to #35354, which merged at an earlier revision of its branch (force-push/merge race). `main` landed on `ref 2d52c6c` with the pre-refresh description.

This aligns it to the standalone repo's current `main`:
- **ref** `2d52c6c` → `bd35992c` (same four new skills, plus the refreshed README pinned).
- **description** updated to mention content & copywriting, brand voice, email sequences, and SEO.

Functionally `2d52c6c` already included the four new skills, so this is a consistency/cosmetic fix (pinned README + catalog blurb), not a functional one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)