### PR TITLE
fix(approvals): mint scoped grant for canonical tool approvals (LUM-2496)

### DIFF
--- a/assistant/src/__tests__/canonical-confirmation-grant-digest.test.ts
+++ b/assistant/src/__tests__/canonical-confirmation-grant-digest.test.ts
@@ -1,0 +1,113 @@
+/**
+ * `createCanonicalRequestForConfirmation` must pin an `inputDigest` on the
+ * canonical tool_approval request — `mintCanonicalRequestGrant` no-ops without
+ * one, so the channel tool approval would mint no scoped grant.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+  truncateForLog: (value: string) => value,
+}));
+
+// A channel confirmation with a bound guardian principal — the store refuses to
+// create a decisionable tool_approval request without a guardianPrincipalId.
+mock.module("../daemon/conversation-registry.js", () => ({
+  findConversation: () => ({
+    assistantId: "self",
+    trustContext: {
+      sourceChannel: "slack",
+      guardianPrincipalId: "principal-1",
+      guardianExternalUserId: "guardian-1",
+      requesterExternalUserId: "requester-1",
+      requesterChatId: "chat-1",
+    },
+  }),
+}));
+
+// Stub the guardian bridge so creating the request doesn't pull in the
+// notification pipeline — this test only asserts the persisted request's digest.
+mock.module("../runtime/confirmation-request-guardian-bridge.js", () => ({
+  bridgeConfirmationRequestToGuardian: () => {},
+}));
+
+import { getCanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
+import { getDb } from "../memory/db-connection.js";
+import { initializeDb } from "../memory/db-init.js";
+import { broadcastMessage } from "../runtime/assistant-event-hub.js";
+import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
+
+initializeDb();
+
+function resetTables(): void {
+  const db = getDb();
+  db.run("DELETE FROM canonical_guardian_deliveries");
+  db.run("DELETE FROM canonical_guardian_requests");
+}
+
+/** Poll for the fire-and-forget canonical request the producer creates. */
+async function waitForCanonicalRequest(requestId: string) {
+  for (let i = 0; i < 50; i++) {
+    const req = getCanonicalGuardianRequest(requestId);
+    if (req) return req;
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  return getCanonicalGuardianRequest(requestId);
+}
+
+function emitConfirmation(
+  requestId: string,
+  toolName: string,
+  input: Record<string, unknown>,
+  conversationId = "conv-digest-1",
+): void {
+  broadcastMessage(
+    {
+      type: "confirmation_request",
+      requestId,
+      toolName,
+      input,
+      riskLevel: "high",
+      executionTarget: "host",
+      allowlistOptions: [],
+      scopeOptions: [],
+      conversationId,
+      persistentDecisionsAllowed: false,
+    } as Parameters<typeof broadcastMessage>[0],
+    conversationId,
+  );
+}
+
+describe("canonical tool-approval request inputDigest (LUM-2496)", () => {
+  beforeEach(() => resetTables());
+
+  test("createCanonicalRequestForConfirmation pins the tool-input digest", async () => {
+    const requestId = "req-digest-1";
+    const toolName = "execute_shell";
+    const input = { command: "rm -rf /tmp/build-cache" };
+
+    emitConfirmation(requestId, toolName, input);
+    const req = await waitForCanonicalRequest(requestId);
+
+    expect(req).not.toBeNull();
+    expect(req!.kind).toBe("tool_approval");
+    // Digest is set and equals what the tool-approval handler computes for this
+    // (unredacted) input.
+    expect(req!.inputDigest).toBe(computeToolApprovalDigest(toolName, input));
+    expect(req!.inputDigest).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  test("a different tool input yields a different digest", async () => {
+    const toolName = "execute_shell";
+
+    emitConfirmation("req-digest-a", toolName, { command: "ls" });
+    emitConfirmation("req-digest-b", toolName, { command: "whoami" });
+    const a = await waitForCanonicalRequest("req-digest-a");
+    const b = await waitForCanonicalRequest("req-digest-b");
+
+    expect(a!.inputDigest).toBeTruthy();
+    expect(b!.inputDigest).toBeTruthy();
+    expect(a!.inputDigest).not.toBe(b!.inputDigest);
+  });
+});

--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -708,6 +708,7 @@ async function createCanonicalRequestForConfirmation(
       { summarizeToolInput },
       { DAEMON_INTERNAL_ASSISTANT_ID },
       { bridgeConfirmationRequestToGuardian },
+      { computeToolApprovalDigest },
     ] = await Promise.all([
       import("../daemon/conversation-registry.js"),
       import("../memory/canonical-guardian-store.js"),
@@ -715,6 +716,7 @@ async function createCanonicalRequestForConfirmation(
       import("../tools/tool-input-summary.js"),
       import("./assistant-scope.js"),
       import("./confirmation-request-guardian-bridge.js"),
+      import("../security/tool-approval-digest.js"),
     ]);
 
     const conversation = findConversation(conversationId);
@@ -737,6 +739,9 @@ async function createCanonicalRequestForConfirmation(
       guardianExternalUserId: trustContext?.guardianExternalUserId,
       guardianPrincipalId: trustContext?.guardianPrincipalId ?? undefined,
       toolName: msg.toolName,
+      // Lets an approval mint a tool_signature grant the tool-approval handler
+      // can consume on an identical retry.
+      inputDigest: computeToolApprovalDigest(msg.toolName, inputRecord),
       commandPreview:
         redactSecrets(summarizeToolInput(msg.toolName, inputRecord)) ||
         undefined,


### PR DESCRIPTION
## Summary

Fixes [LUM-2496](https://linear.app/vellum/issue/LUM-2496). Canonical tool-approval decisions stopped minting scoped grants, so after a guardian approved a channel tool, an identical immediate retry re-prompted instead of being covered by the short-lived (5 min) `tool_signature` grant.

## Root cause

`createCanonicalRequestForConfirmation` (`runtime/assistant-event-hub.ts`) created canonical `tool_approval` requests **without** `inputDigest`. `mintCanonicalRequestGrant` (called by `applyCanonicalGuardianDecision`) early-returns when `!request.inputDigest`, so no grant was minted for channel tool approvals — buttons, text, or reactions. Pre-existing; surfaced while implementing LUM-2488 (#35344).

This is a **parity gap, not a deliberate omission**: grant-minting is a documented duty of the guardian decision primitive (`approvals/CLAUDE.md`), and the **voice producer already sets `inputDigest` the same way** (`calls/guardian-dispatch.ts:117-127`). The channel confirmation producer was simply the only canonical `tool_approval` producer not setting it.

## Fix

Set `inputDigest` at the producer — one line, matching the voice precedent:

```ts
inputDigest: computeToolApprovalDigest(msg.toolName, inputRecord),
```

The digest matches what the tool-approval handler computes at run time (`tools/tool-approval-handler.ts`), so an approval mints a grant that covers the identical retry. The grant is tightly scoped (tool + input + channel + conversation + requester + guardian) — the same model desktop and voice already use, validated by `scoped-grant-security-matrix`.

(The digest is over the confirmation input, where sensitive fields are redacted — so it covers the common case where no input field is redacted, consistent with the rest of the canonical pipeline. No special-casing.)

## Testing

- New `canonical-confirmation-grant-digest.test.ts` (2 tests): the producer pins `computeToolApprovalDigest(toolName, input)`; distinct inputs → distinct digests.
- Green in isolation (CI-style): `assistant-event-hub`, `guardian-grant-minting`, `guardian-decision-primitive-canonical`. Typecheck + lint + format clean.

## Coordination

Independent of the in-flight approval PRs — touches only `assistant-event-hub.ts`, which #35342 / #35330 / #35338 don't modify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1W9LbPepaSrwUvgMTMahN