### PR TITLE
fix(web): gate local-mode host transport on availability (LUM-2501)

### DIFF
--- a/clients/web/src/components/status-banner.test.tsx
+++ b/clients/web/src/components/status-banner.test.tsx
@@ -52,6 +52,7 @@ let refetchOperationalStatusMock = mock(async () => {});
 let wakeLocalAssistantHostMock = mock(async (_assistantId: string) => ({
   ok: true,
 }));
+let isLocalModeHostAvailableMock = true;
 let StatusBanner: ComponentType<{
   className?: string;
   placement?: "web" | "electron";
@@ -118,6 +119,7 @@ mock.module("@/assistant/local-health", () => ({
 mock.module("@/runtime/local-mode-host", () => ({
   wakeLocalAssistantHost: (assistantId: string) =>
     wakeLocalAssistantHostMock(assistantId),
+  isLocalModeHostAvailable: () => isLocalModeHostAvailableMock,
 }));
 
 mock.module("@/assistant/lifecycle-store", () => ({
@@ -180,6 +182,7 @@ beforeEach(() => {
   wakeLocalAssistantHostMock = mock(async (_assistantId: string) => ({
     ok: true,
   }));
+  isLocalModeHostAvailableMock = true;
 });
 
 afterEach(() => {
@@ -462,6 +465,21 @@ describe("StatusBanner", () => {
       expect(html).toContain("Wake up");
       expect(html).toContain('data-tone="neutral"');
       expect(html).not.toContain("Your assistant is unreachable");
+    });
+
+    test("shows an informative, action-free banner when no local-mode host is available", () => {
+      // Managed web / remote-web tunnel: a local assistant surfaces via the
+      // platform `is_local` flag, but there's no `/assistant/__local/*` to wake
+      // it through, so the banner must not offer a "Wake up" button (LUM-2501).
+      localHealthMock = "unreachable";
+      isLocalModeHostAvailableMock = false;
+
+      const html = renderToStaticMarkup(<StatusBanner />);
+
+      expect(html).toContain("Your assistant runs locally");
+      expect(html).toContain("Open the Vellum desktop app");
+      expect(html).not.toContain("Wake up");
+      expect(html).toContain('data-tone="neutral"');
     });
 
     test("wakes the active local assistant from the banner action", async () => {

--- a/clients/web/src/components/status-banner.test.tsx
+++ b/clients/web/src/components/status-banner.test.tsx
@@ -53,6 +53,7 @@ let wakeLocalAssistantHostMock = mock(async (_assistantId: string) => ({
   ok: true,
 }));
 let isLocalModeHostAvailableMock = true;
+let isCliWakeableMock = true;
 let StatusBanner: ComponentType<{
   className?: string;
   placement?: "web" | "electron";
@@ -122,6 +123,10 @@ mock.module("@/runtime/local-mode-host", () => ({
   isLocalModeHostAvailable: () => isLocalModeHostAvailableMock,
 }));
 
+mock.module("@/lib/local-mode", () => ({
+  isCliWakeableAssistant: () => isCliWakeableMock,
+}));
+
 mock.module("@/assistant/lifecycle-store", () => ({
   useAssistantLifecycleStore: {
     use: {
@@ -183,6 +188,7 @@ beforeEach(() => {
     ok: true,
   }));
   isLocalModeHostAvailableMock = true;
+  isCliWakeableMock = true;
 });
 
 afterEach(() => {
@@ -479,6 +485,20 @@ describe("StatusBanner", () => {
       expect(html).toContain("Open the Vellum desktop app");
       expect(html).not.toContain("Wake up");
       expect(html).toContain('data-tone="neutral"');
+    });
+
+    test("hides the Wake up button for an assistant vellum wake can't start (e.g. Docker)", () => {
+      // Capable host, but the active assistant isn't CLI-wakeable (Docker /
+      // apple-container) — offering "Wake up" would call `vellum wake`, which
+      // refuses those. Show status without the button.
+      localHealthMock = "unreachable";
+      isLocalModeHostAvailableMock = true;
+      isCliWakeableMock = false;
+
+      const html = renderToStaticMarkup(<StatusBanner />);
+
+      expect(html).toContain("Your assistant is asleep");
+      expect(html).not.toContain("Wake up");
     });
 
     test("wakes the active local assistant from the banner action", async () => {

--- a/clients/web/src/components/status-banner.test.tsx
+++ b/clients/web/src/components/status-banner.test.tsx
@@ -468,9 +468,8 @@ describe("StatusBanner", () => {
     });
 
     test("shows an informative, action-free banner when no local-mode host is available", () => {
-      // Managed web / remote-web tunnel: a local assistant surfaces via the
-      // platform `is_local` flag, but there's no `/assistant/__local/*` to wake
-      // it through, so the banner must not offer a "Wake up" button.
+      // Where local-mode operations aren't available, the banner must not offer
+      // a "Wake up" button that can't work.
       localHealthMock = "unreachable";
       isLocalModeHostAvailableMock = false;
 

--- a/clients/web/src/components/status-banner.test.tsx
+++ b/clients/web/src/components/status-banner.test.tsx
@@ -470,7 +470,7 @@ describe("StatusBanner", () => {
     test("shows an informative, action-free banner when no local-mode host is available", () => {
       // Managed web / remote-web tunnel: a local assistant surfaces via the
       // platform `is_local` flag, but there's no `/assistant/__local/*` to wake
-      // it through, so the banner must not offer a "Wake up" button (LUM-2501).
+      // it through, so the banner must not offer a "Wake up" button.
       localHealthMock = "unreachable";
       isLocalModeHostAvailableMock = false;
 

--- a/clients/web/src/components/status-banner.tsx
+++ b/clients/web/src/components/status-banner.tsx
@@ -603,11 +603,11 @@ function useAssistantBannerConfig(): BannerConfig | null {
   }
 
   // A local / self-hosted assistant can surface on a host that has no local-mode
-  // transport — the managed web build and the remote-web tunnel both expose it
+  // transport: the managed web build and the remote-web tunnel both expose it
   // via the platform `is_local` flag but can't reach the local daemon from here
-  // (no `/assistant/__local/*`; see runtime/local-mode-host.ts). Waking is
-  // impossible from this host, so show an informative, action-free banner rather
-  // than a "Wake up" button that would 405 (LUM-2501).
+  // (no `/assistant/__local/*`; see runtime/local-mode-host.ts). Waking isn't
+  // possible from this host, so the banner is informative and action-free — the
+  // daemon is started from the desktop app or the CLI.
   if (!isLocalModeHostAvailable() && canWakeLocalHealth(localHealth)) {
     return {
       tone: "neutral",

--- a/clients/web/src/components/status-banner.tsx
+++ b/clients/web/src/components/status-banner.tsx
@@ -38,7 +38,10 @@ import { useConnectivityState } from "@/hooks/use-connectivity-state";
 import { useNetworkStatus } from "@/hooks/use-network-status";
 import { captureError } from "@/lib/sentry/capture-error";
 import { isElectron } from "@/runtime/is-electron";
-import { wakeLocalAssistantHost } from "@/runtime/local-mode-host";
+import {
+  isLocalModeHostAvailable,
+  wakeLocalAssistantHost,
+} from "@/runtime/local-mode-host";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { cn } from "@/utils/misc";
@@ -596,6 +599,22 @@ function useAssistantBannerConfig(): BannerConfig | null {
       tone: "error",
       title: "You're offline",
       icon: <WifiOff className="h-4 w-4" aria-hidden="true" />,
+    };
+  }
+
+  // A local / self-hosted assistant can surface on a host that has no local-mode
+  // transport — the managed web build and the remote-web tunnel both expose it
+  // via the platform `is_local` flag but can't reach the local daemon from here
+  // (no `/assistant/__local/*`; see runtime/local-mode-host.ts). Waking is
+  // impossible from this host, so show an informative, action-free banner rather
+  // than a "Wake up" button that would 405 (LUM-2501).
+  if (!isLocalModeHostAvailable() && canWakeLocalHealth(localHealth)) {
+    return {
+      tone: "neutral",
+      title: "Your assistant runs locally",
+      icon: <Moon className="h-4 w-4" aria-hidden="true" />,
+      children:
+        "Open the Vellum desktop app or run vellum wake in your terminal to start it.",
     };
   }
 

--- a/clients/web/src/components/status-banner.tsx
+++ b/clients/web/src/components/status-banner.tsx
@@ -36,6 +36,7 @@ import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import { assistantsMaintenanceModeExitCreate } from "@/generated/api/sdk.gen";
 import { useConnectivityState } from "@/hooks/use-connectivity-state";
 import { useNetworkStatus } from "@/hooks/use-network-status";
+import { isCliWakeableAssistant } from "@/lib/local-mode";
 import { captureError } from "@/lib/sentry/capture-error";
 import { isElectron } from "@/runtime/is-electron";
 import {
@@ -620,8 +621,12 @@ function useAssistantBannerConfig(): BannerConfig | null {
     canWakeLocalHealth(localHealth)
       ? "starting"
       : localHealth;
+  // Only offer "Wake up" when the CLI can actually start this assistant —
+  // `vellum wake` works on plain local entries, not Docker/apple-container.
   const localWakeAction =
-    canWakeLocalHealth(effectiveLocalHealth) ? (
+    canWakeLocalHealth(effectiveLocalHealth) &&
+    !!activeAssistantId &&
+    isCliWakeableAssistant(activeAssistantId) ? (
       <Button
         variant="outlined"
         size="compact"

--- a/clients/web/src/components/status-banner.tsx
+++ b/clients/web/src/components/status-banner.tsx
@@ -602,12 +602,9 @@ function useAssistantBannerConfig(): BannerConfig | null {
     };
   }
 
-  // A local / self-hosted assistant can surface on a host that has no local-mode
-  // transport: the managed web build and the remote-web tunnel both expose it
-  // via the platform `is_local` flag but can't reach the local daemon from here
-  // (no `/assistant/__local/*`; see runtime/local-mode-host.ts). Waking isn't
-  // possible from this host, so the banner is informative and action-free — the
-  // daemon is started from the desktop app or the CLI.
+  // A local / self-hosted assistant can surface where local-mode operations
+  // aren't available (managed web, remote-web tunnel). There's no transport to
+  // wake it from here, so the banner is informative and action-free.
   if (!isLocalModeHostAvailable() && canWakeLocalHealth(localHealth)) {
     return {
       tone: "neutral",

--- a/clients/web/src/lib/auth/remote-gateway-session.test.ts
+++ b/clients/web/src/lib/auth/remote-gateway-session.test.ts
@@ -9,6 +9,7 @@ import {
   refreshRemoteGatewaySession,
   remoteGatewayApiPath,
   remoteGatewayPublicPathPrefix,
+  RemoteWebPairingError,
 } from "@/lib/auth/remote-gateway-session";
 import {
   getSelfHostedActorToken,
@@ -110,6 +111,38 @@ describe("remote gateway token exchange", () => {
         publicBaseUrl: "http://localhost:3000/assistant-123",
       }),
     );
+  });
+
+  test("surfaces a non-JSON challenge error as a RemoteWebPairingError, not a parse error", async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response("<html><body>502</body></html>", {
+          status: 502,
+          headers: { "Content-Type": "text/html" },
+        }),
+    ) as unknown as typeof fetch;
+
+    const error = await createRemoteWebPairingChallenge().catch(
+      (e: unknown) => e,
+    );
+    expect(error).toBeInstanceOf(RemoteWebPairingError);
+    expect((error as RemoteWebPairingError).status).toBe(502);
+  });
+
+  test("surfaces a non-JSON token-exchange error as a RemoteWebPairingError, not a parse error", async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response("<html><body>502</body></html>", {
+          status: 502,
+          headers: { "Content-Type": "text/html" },
+        }),
+    ) as unknown as typeof fetch;
+
+    const error = await exchangeRemoteWebPairingToken("device-code").catch(
+      (e: unknown) => e,
+    );
+    expect(error).toBeInstanceOf(RemoteWebPairingError);
+    expect((error as RemoteWebPairingError).status).toBe(502);
   });
 
   test("posts the device code with cookie credentials", async () => {

--- a/clients/web/src/lib/auth/remote-gateway-session.ts
+++ b/clients/web/src/lib/auth/remote-gateway-session.ts
@@ -264,10 +264,12 @@ export async function exchangeRemoteWebPairingToken(
     body: JSON.stringify({ deviceCode }),
     signal,
   });
-  const body = (await response.json()) as unknown;
+  // A non-JSON body (e.g. an HTML error page) resolves to null and falls
+  // through to the status / shape checks below.
+  const body = (await response.json().catch(() => null)) as unknown;
 
   if (response.status === 202) {
-    const pending = body as Partial<RemoteWebPairingPending>;
+    const pending = (body ?? {}) as Partial<RemoteWebPairingPending>;
     return {
       status: "pending",
       expiresAt: typeof pending.expiresAt === "string" ? pending.expiresAt : "",
@@ -306,7 +308,7 @@ export async function createRemoteWebPairingChallenge(
     body: JSON.stringify({ publicBaseUrl: remoteGatewayPublicBaseUrl() }),
     signal,
   });
-  const body = (await response.json()) as unknown;
+  const body = (await response.json().catch(() => null)) as unknown;
 
   if (!response.ok) {
     throw new RemoteWebPairingError(
@@ -336,7 +338,7 @@ async function refreshRemoteGatewaySessionOnce(): Promise<boolean> {
   });
 
   if (!response.ok) return false;
-  const body = (await response.json()) as unknown;
+  const body = (await response.json().catch(() => null)) as unknown;
   if (!isApprovedPayload({ ...(body as object), status: "approved" })) {
     return false;
   }

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -328,19 +328,26 @@ export function isPlatformAssistant(a: LockfileAssistant): boolean {
 }
 
 /**
- * True when the CLI's `wake --repair-guardian` can actually re-provision this
- * assistant's guardian token. Only plain local entries reach the repair
- * block — `wake` returns early for Docker containers and refuses
- * apple-container entries — so recovery UI must not offer repair for those.
- * `cloud` is optional in the lockfile contract; legacy entries omit it and
- * the CLI treats them as local, so they stay repairable here too.
+ * A plain local assistant the vellum CLI can start directly: cloud `"local"` or
+ * unset (legacy entries the CLI treats as local), with a gateway port. `vellum
+ * wake` operates only on these — it returns early for Docker containers and
+ * refuses apple-container entries — so the "Wake up" affordance and
+ * guardian-repair recovery must both be limited to them.
  */
-export function isGuardianRepairable(assistantId: string): boolean {
+export function isCliWakeableAssistant(assistantId: string): boolean {
   const entry = getLockfile().assistants.find(
     (a) => a.assistantId === assistantId,
   );
   if (!entry || !isLocalAssistant(entry)) return false;
   return entry.cloud == null || entry.cloud === "local";
+}
+
+/**
+ * True when the CLI's `wake --repair-guardian` can re-provision this assistant's
+ * guardian token — the same plain-local set `vellum wake` operates on.
+ */
+export function isGuardianRepairable(assistantId: string): boolean {
+  return isCliWakeableAssistant(assistantId);
 }
 
 export function getLocalAssistants(): LockfileAssistant[] {

--- a/clients/web/src/runtime/local-mode-host.test.ts
+++ b/clients/web/src/runtime/local-mode-host.test.ts
@@ -435,11 +435,11 @@ describe("isLocalModeHostAvailable", () => {
   });
 });
 
-describe("web/dev transport resilience (LUM-2501)", () => {
-  // The managed host answers a POST to /assistant/__local/* with a 405 and a
-  // non-JSON body, so Safari's Response.json() throws
-  // "SyntaxError: The string did not match the expected pattern." The seam must
-  // fold that into its result contract, never let it escape as a throw.
+describe("web/dev transport resilience", () => {
+  // A host without the local-mode transport answers a POST to /assistant/__local/*
+  // with a 405 and a non-JSON body, so Safari's Response.json() throws
+  // "SyntaxError: The string did not match the expected pattern." The seam folds
+  // that into its result contract rather than letting it escape as a throw.
   const nonJsonResponse = () =>
     mock(async () => ({
       status: 405,

--- a/clients/web/src/runtime/local-mode-host.test.ts
+++ b/clients/web/src/runtime/local-mode-host.test.ts
@@ -27,9 +27,8 @@ type WindowWithConfig = {
 };
 
 beforeEach(() => {
-  // The dev server and `vellum client` inject this config; its presence is how
-  // the seam knows a local-mode host backs the web/dev branch. Set it so the
-  // HTTP transport runs instead of short-circuiting as "unavailable".
+  // Injected config marks the web/dev branch as an available local-mode host,
+  // so the HTTP transport runs rather than short-circuiting.
   (window as WindowWithConfig).__VELLUM_CONFIG__ = {};
 });
 
@@ -436,10 +435,8 @@ describe("isLocalModeHostAvailable", () => {
 });
 
 describe("web/dev transport resilience", () => {
-  // A host without the local-mode transport answers a POST to /assistant/__local/*
-  // with a 405 and a non-JSON body, so Safari's Response.json() throws
-  // "SyntaxError: The string did not match the expected pattern." The seam folds
-  // that into its result contract rather than letting it escape as a throw.
+  // A non-JSON error body makes Response.json() throw; the seam resolves to
+  // `{ ok: false }` rather than letting it escape as a throw.
   const nonJsonResponse = () =>
     mock(async () => ({
       status: 405,

--- a/clients/web/src/runtime/local-mode-host.test.ts
+++ b/clients/web/src/runtime/local-mode-host.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 // Control the host branch directly so each case exercises one transport.
 let runningInElectron = false;
@@ -16,14 +16,28 @@ const {
   wakeLocalAssistantHost,
   getLocalAssistantStatusHost,
   fetchGuardianTokenHost,
+  isLocalModeHostAvailable,
 } = await import("./local-mode-host");
 
 const realFetch = globalThis.fetch;
+
+type WindowWithConfig = {
+  vellum?: unknown;
+  __VELLUM_CONFIG__?: { mode?: string };
+};
+
+beforeEach(() => {
+  // The dev server and `vellum client` inject this config; its presence is how
+  // the seam knows a local-mode host backs the web/dev branch. Set it so the
+  // HTTP transport runs instead of short-circuiting as "unavailable".
+  (window as WindowWithConfig).__VELLUM_CONFIG__ = {};
+});
 
 afterEach(() => {
   runningInElectron = false;
   globalThis.fetch = realFetch;
   delete (window as { vellum?: unknown }).vellum;
+  delete (window as WindowWithConfig).__VELLUM_CONFIG__;
 });
 
 describe("hatchLocalAssistant", () => {
@@ -395,5 +409,87 @@ describe("fetchGuardianTokenHost", () => {
     expect(err).toBeInstanceOf(GuardianTokenError);
     expect((err as InstanceType<typeof GuardianTokenError>).status).toBe(500);
     expect((err as Error).message).toBe("refresh failed");
+  });
+});
+
+describe("isLocalModeHostAvailable", () => {
+  test("true on the Electron host regardless of injected config", () => {
+    runningInElectron = true;
+    delete (window as WindowWithConfig).__VELLUM_CONFIG__;
+    expect(isLocalModeHostAvailable()).toBe(true);
+  });
+
+  test("true on a web/dev host that injects runtime config", () => {
+    (window as WindowWithConfig).__VELLUM_CONFIG__ = {};
+    expect(isLocalModeHostAvailable()).toBe(true);
+  });
+
+  test("false on the managed static build (no injected config)", () => {
+    delete (window as WindowWithConfig).__VELLUM_CONFIG__;
+    expect(isLocalModeHostAvailable()).toBe(false);
+  });
+
+  test("false in remote-gateway mode — the ingress 404s /assistant/__local/*", () => {
+    (window as WindowWithConfig).__VELLUM_CONFIG__ = { mode: "remote-gateway" };
+    expect(isLocalModeHostAvailable()).toBe(false);
+  });
+});
+
+describe("web/dev transport resilience (LUM-2501)", () => {
+  // The managed host answers a POST to /assistant/__local/* with a 405 and a
+  // non-JSON body, so Safari's Response.json() throws
+  // "SyntaxError: The string did not match the expected pattern." The seam must
+  // fold that into its result contract, never let it escape as a throw.
+  const nonJsonResponse = () =>
+    mock(async () => ({
+      status: 405,
+      json: async () => {
+        throw new SyntaxError("The string did not match the expected pattern.");
+      },
+    })) as unknown as typeof fetch;
+
+  test("wake returns a failure result instead of throwing on a non-JSON body", async () => {
+    globalThis.fetch = nonJsonResponse();
+    const result = await wakeLocalAssistantHost("a-1");
+    expect(result.ok).toBe(false);
+  });
+
+  test("wake short-circuits without a request when no local-mode host is available", async () => {
+    delete (window as WindowWithConfig).__VELLUM_CONFIG__;
+    const fetchMock = mock(async () => {
+      throw new Error("fetch must not run when the host is unavailable");
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await wakeLocalAssistantHost("a-1");
+    expect(result.ok).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("wake returns a failure result when the fetch itself rejects", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new TypeError("Load failed");
+    }) as unknown as typeof fetch;
+
+    const result = await wakeLocalAssistantHost("a-1");
+    expect(result.ok).toBe(false);
+  });
+
+  test("status returns a failure result instead of throwing on a non-JSON body", async () => {
+    globalThis.fetch = nonJsonResponse();
+    const result = await getLocalAssistantStatusHost("a-1");
+    expect(result.ok).toBe(false);
+  });
+
+  test("status short-circuits without a request when no local-mode host is available", async () => {
+    delete (window as WindowWithConfig).__VELLUM_CONFIG__;
+    const fetchMock = mock(async () => {
+      throw new Error("fetch must not run when the host is unavailable");
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await getLocalAssistantStatusHost("a-1");
+    expect(result.ok).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/runtime/local-mode-host.ts
+++ b/clients/web/src/runtime/local-mode-host.ts
@@ -113,6 +113,87 @@ export function requiresGuardianReprovision(error: unknown): boolean {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Transport availability
+// ---------------------------------------------------------------------------
+
+/**
+ * Default failure for a local-mode operation that can't run because no
+ * local-mode host backs this runtime. Wake passes its own actionable variant.
+ */
+const LOCAL_HOST_UNAVAILABLE_ERROR =
+  "The local assistant host isn't available here.";
+
+function readInjectedConfig(): { mode?: string } | undefined {
+  if (typeof window === "undefined") return undefined;
+  return (window as unknown as { __VELLUM_CONFIG__?: { mode?: string } })
+    .__VELLUM_CONFIG__;
+}
+
+/**
+ * Whether this runtime is backed by a host that can actually perform local-mode
+ * host operations — i.e. one that serves `/assistant/__local/*`: the Electron
+ * IPC bridge, the Vite dev server, or the `vellum client` CLI server.
+ *
+ * It is deliberately NOT available on:
+ *   - the managed web build (a static GCS bucket — POSTs to `/assistant/__local/*`
+ *     get a `405` with a non-JSON body), or
+ *   - the remote-web tunnel (whose nginx ingress returns `404` for
+ *     `/assistant/__local/*`; see `cli/src/lib/nginx-ingress.ts`).
+ *
+ * Both still surface local / self-hosted assistants through the platform
+ * `is_local` flag, so callers and UI MUST consult this before offering a local
+ * action (wake / hatch / retire). It is the single source of truth that
+ * replaces the old "not Electron ⇒ the dev middleware exists" assumption, which
+ * turned a doomed request into an opaque `Response.json()` parse error
+ * (LUM-2501).
+ *
+ * The signal is the runtime config those capable hosts inject — the dev plugin
+ * (`vite-plugin-local-mode.ts`) and `vellum client` set `window.__VELLUM_CONFIG__`,
+ * while the managed build ships none — minus remote-gateway mode, where the
+ * ingress strips the local routes even though config is injected.
+ */
+export function isLocalModeHostAvailable(): boolean {
+  if (isElectron()) return true;
+  const config = readInjectedConfig();
+  if (!config) return false;
+  if (config.mode === "remote-gateway") return false;
+  return true;
+}
+
+/**
+ * POST a local-mode command to the dev / CLI host and read back its
+ * `{ ok, ... }` result, upholding the seam's never-throw contract.
+ *
+ * Two failure modes are folded into the result instead of thrown:
+ *   1. No local-mode host backs this runtime — short-circuit, no doomed request.
+ *   2. The host answered with a non-JSON body (a static host's `405`/HTML page,
+ *      a proxy `502`). `Response.json()` rejects with an opaque
+ *      `SyntaxError: The string did not match the expected pattern.` in that
+ *      case (LUM-2501) — catch it and surface a structured failure.
+ */
+async function postLocalCommand<T extends { ok: boolean }>(
+  path: string,
+  body: unknown,
+  unavailableError: string,
+): Promise<T | { ok: false; error: string }> {
+  if (!isLocalModeHostAvailable()) {
+    return { ok: false, error: unavailableError };
+  }
+  let res: Response;
+  try {
+    res = await fetch(path, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch {
+    return { ok: false, error: unavailableError };
+  }
+  const parsed = (await res.json().catch(() => null)) as T | null;
+  return parsed ?? { ok: false, error: unavailableError };
+}
+
 /**
  * Provision a local assistant for the requested species.
  *
@@ -130,12 +211,11 @@ export async function hatchLocalAssistant(
     return window.vellum!.localMode.hatch(species, remote);
   }
 
-  const res = await fetch("/assistant/__local/hatch", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ species, remote }),
-  });
-  return res.json() as Promise<LocalHatchResult>;
+  return postLocalCommand<LocalHatchResult>(
+    "/assistant/__local/hatch",
+    { species, remote },
+    LOCAL_HOST_UNAVAILABLE_ERROR,
+  );
 }
 
 /**
@@ -170,12 +250,11 @@ export async function saveLockfileAssistantHost(
     );
   }
 
-  const res = await fetch("/assistant/__local/lockfile", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ assistant, activeAssistant }),
-  });
-  return res.json() as Promise<LockfileWriteResult>;
+  return postLocalCommand<LockfileWriteResult>(
+    "/assistant/__local/lockfile",
+    { assistant, activeAssistant },
+    LOCAL_HOST_UNAVAILABLE_ERROR,
+  );
 }
 
 /**
@@ -196,12 +275,11 @@ export async function replacePlatformAssistantsHost(
     );
   }
 
-  const res = await fetch("/assistant/__local/lockfile", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ syncPlatform: true, platformAssistants, organizationId }),
-  });
-  return res.json() as Promise<LockfileWriteResult>;
+  return postLocalCommand<LockfileWriteResult>(
+    "/assistant/__local/lockfile",
+    { syncPlatform: true, platformAssistants, organizationId },
+    LOCAL_HOST_UNAVAILABLE_ERROR,
+  );
 }
 
 /**
@@ -215,12 +293,11 @@ export async function retireLocalAssistantHost(
     return window.vellum!.localMode.retire(assistantId);
   }
 
-  const res = await fetch("/assistant/__local/retire", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ assistantId }),
-  });
-  return res.json() as Promise<LocalRetireResult>;
+  return postLocalCommand<LocalRetireResult>(
+    "/assistant/__local/retire",
+    { assistantId },
+    LOCAL_HOST_UNAVAILABLE_ERROR,
+  );
 }
 
 /**
@@ -239,12 +316,11 @@ export async function sleepLocalAssistantHost(
     return sleep(assistantId);
   }
 
-  const res = await fetch("/assistant/__local/sleep", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ assistantId }),
-  });
-  return res.json() as Promise<LocalSleepResult>;
+  return postLocalCommand<LocalSleepResult>(
+    "/assistant/__local/sleep",
+    { assistantId },
+    LOCAL_HOST_UNAVAILABLE_ERROR,
+  );
 }
 
 /**
@@ -277,15 +353,11 @@ export async function wakeLocalAssistantHost(
     return wake(assistantId, options);
   }
 
-  const res = await fetch("/assistant/__local/wake", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      assistantId,
-      repairGuardian: options?.repairGuardian,
-    }),
-  });
-  return res.json() as Promise<LocalWakeResult>;
+  return postLocalCommand<LocalWakeResult>(
+    "/assistant/__local/wake",
+    { assistantId, repairGuardian: options?.repairGuardian },
+    "Wake failed. Try running vellum wake in your terminal.",
+  );
 }
 
 export async function getLocalAssistantStatusHost(
@@ -303,10 +375,23 @@ export async function getLocalAssistantStatusHost(
     return status(assistantId);
   }
 
-  const res = await fetch(
-    `/assistant/__local/status/${encodeURIComponent(assistantId)}`,
+  if (!isLocalModeHostAvailable()) {
+    return { ok: false, status: 0, error: LOCAL_HOST_UNAVAILABLE_ERROR };
+  }
+  let res: Response;
+  try {
+    res = await fetch(
+      `/assistant/__local/status/${encodeURIComponent(assistantId)}`,
+    );
+  } catch {
+    return { ok: false, status: 0, error: LOCAL_HOST_UNAVAILABLE_ERROR };
+  }
+  const parsed = (await res
+    .json()
+    .catch(() => null)) as LocalAssistantStatusResult | null;
+  return (
+    parsed ?? { ok: false, status: res.status, error: LOCAL_HOST_UNAVAILABLE_ERROR }
   );
-  return res.json() as Promise<LocalAssistantStatusResult>;
 }
 
 /**

--- a/clients/web/src/runtime/local-mode-host.ts
+++ b/clients/web/src/runtime/local-mode-host.ts
@@ -117,10 +117,7 @@ export function requiresGuardianReprovision(error: unknown): boolean {
 // Transport availability
 // ---------------------------------------------------------------------------
 
-/**
- * Default failure for a local-mode operation that can't run because no
- * local-mode host backs this runtime. Wake passes its own actionable variant.
- */
+/** Failure surfaced when no local-mode host backs this runtime. */
 const LOCAL_HOST_UNAVAILABLE_ERROR =
   "The local assistant host isn't available here.";
 
@@ -131,25 +128,15 @@ function readInjectedConfig(): { mode?: string } | undefined {
 }
 
 /**
- * Whether this runtime is backed by a host that can actually perform local-mode
- * host operations — i.e. one that serves `/assistant/__local/*`: the Electron
- * IPC bridge, the Vite dev server, or the `vellum client` CLI server.
+ * Whether a local-mode host (the Electron IPC bridge, the Vite dev server, or
+ * the `vellum client` CLI server) backs this runtime and can serve
+ * `/assistant/__local/*`. The managed web build and the remote-web tunnel
+ * cannot, yet both still surface local / self-hosted assistants via the platform
+ * `is_local` flag — so callers and UI MUST consult this before offering a local
+ * action (wake / hatch / retire).
  *
- * It is deliberately NOT available on:
- *   - the managed web build (a static GCS bucket — POSTs to `/assistant/__local/*`
- *     get a `405` with a non-JSON body), or
- *   - the remote-web tunnel (whose nginx ingress returns `404` for
- *     `/assistant/__local/*`; see `cli/src/lib/nginx-ingress.ts`).
- *
- * Both still surface local / self-hosted assistants through the platform
- * `is_local` flag, so callers and UI MUST consult this before offering a local
- * action (wake / hatch / retire). It is the single source of truth for whether
- * the local-mode transport is reachable from this host.
- *
- * The signal is the runtime config those capable hosts inject — the dev plugin
- * (`vite-plugin-local-mode.ts`) and `vellum client` set `window.__VELLUM_CONFIG__`,
- * while the managed build ships none — minus remote-gateway mode, where the
- * ingress strips the local routes even though config is injected.
+ * Detected from the runtime config the capable hosts inject
+ * (`window.__VELLUM_CONFIG__`), excluding remote-gateway mode.
  */
 export function isLocalModeHostAvailable(): boolean {
   if (isElectron()) return true;
@@ -160,14 +147,9 @@ export function isLocalModeHostAvailable(): boolean {
 }
 
 /**
- * POST a local-mode command to the dev / CLI host and read back its
- * `{ ok, ... }` result. Always resolves to a result; never throws.
- *
- * Two cases resolve to a structured `{ ok: false }`:
- *   1. No local-mode host backs this runtime — short-circuits without a request.
- *   2. The host answers with a non-JSON body (a static host's `405`/HTML page, a
- *      proxy `502`), so `Response.json()` rejects with a parse error — caught
- *      and returned as a failure result.
+ * POST a local-mode command and read back its `{ ok, ... }` result. Always
+ * resolves, never throws: an unavailable host (no request sent) and a non-JSON
+ * response both resolve to `{ ok: false }`.
  */
 async function postLocalCommand<T extends { ok: boolean }>(
   path: string,

--- a/clients/web/src/runtime/local-mode-host.ts
+++ b/clients/web/src/runtime/local-mode-host.ts
@@ -143,10 +143,8 @@ function readInjectedConfig(): { mode?: string } | undefined {
  *
  * Both still surface local / self-hosted assistants through the platform
  * `is_local` flag, so callers and UI MUST consult this before offering a local
- * action (wake / hatch / retire). It is the single source of truth that
- * replaces the old "not Electron ⇒ the dev middleware exists" assumption, which
- * turned a doomed request into an opaque `Response.json()` parse error
- * (LUM-2501).
+ * action (wake / hatch / retire). It is the single source of truth for whether
+ * the local-mode transport is reachable from this host.
  *
  * The signal is the runtime config those capable hosts inject — the dev plugin
  * (`vite-plugin-local-mode.ts`) and `vellum client` set `window.__VELLUM_CONFIG__`,
@@ -163,14 +161,13 @@ export function isLocalModeHostAvailable(): boolean {
 
 /**
  * POST a local-mode command to the dev / CLI host and read back its
- * `{ ok, ... }` result, upholding the seam's never-throw contract.
+ * `{ ok, ... }` result. Always resolves to a result; never throws.
  *
- * Two failure modes are folded into the result instead of thrown:
- *   1. No local-mode host backs this runtime — short-circuit, no doomed request.
- *   2. The host answered with a non-JSON body (a static host's `405`/HTML page,
- *      a proxy `502`). `Response.json()` rejects with an opaque
- *      `SyntaxError: The string did not match the expected pattern.` in that
- *      case (LUM-2501) — catch it and surface a structured failure.
+ * Two cases resolve to a structured `{ ok: false }`:
+ *   1. No local-mode host backs this runtime — short-circuits without a request.
+ *   2. The host answers with a non-JSON body (a static host's `405`/HTML page, a
+ *      proxy `502`), so `Response.json()` rejects with a parse error — caught
+ *      and returned as a failure result.
  */
 async function postLocalCommand<T extends { ok: boolean }>(
   path: string,


### PR DESCRIPTION
## Summary

Fixes [LUM-2501](https://linear.app/vellum/issue/LUM-2501) / Sentry `VELLUM-ASSISTANT-WEB-4T` — `SyntaxError: The string did not match the expected pattern.` on `www.vellum.ai/assistant/contacts` (Safari).

Also fixes the same wake-banner crash reported from a Chrome user as `Unexpected token '<', "<html>...`:

Fixes VELLUM-ASSISTANT-WEB-4J

(Same `context: wake_local_assistant_status_banner`, same managed host — only the browser's JSON-parse wording differs.)

### Root cause

A local / self-hosted assistant surfaces on the **managed web build** and the **remote-web tunnel** via the platform `is_local` flag — but neither host serves `/assistant/__local/*` (managed GCS → 405 with a non-JSON body; remote-web nginx ingress → 404, `cli/src/lib/nginx-ingress.ts:268`). The status banner still offered "Wake up" there, and `wakeLocalAssistantHost` called `Response.json()` on the non-JSON body → `SyntaxError` (the Safari/Chrome wording differs), surfacing to Sentry.

The deeper issue: the transport seam decided its backend from `isElectron()` alone, **assuming every non-Electron host serves the dev `/assistant/__local/*` middleware** — false for the managed build and the tunnel.

### The fix

- **Capability is the single source of truth** — `isLocalModeHostAvailable()` (`local-mode-host.ts`) answers whether a host that actually serves `/assistant/__local/*` (Electron IPC, Vite dev, or `vellum client`) backs this runtime, derived from the injected `window.__VELLUM_CONFIG__` minus remote-gateway mode. Verified correct across every host, **including the OSS self-hoster hybrid** (running the stack locally via `vellum client` in a browser, signed into the platform): config is injected there → capability is `true` → local actions are *not* suppressed. Only the managed static build and the tunnel (which genuinely can't reach `__local`) resolve to `false`.
- **Seam never throws** — every result-contract web/dev helper (`wake`/`hatch`/`save`/`replace`/`retire`/`sleep`/`status`) short-circuits to a typed `{ ok: false }` when unavailable and parses defensively otherwise. This also makes restart/retire on the tunnel fail gracefully instead of crashing.
- **Banner** — on a host without local transport, show an informative, action-free banner instead of a doomed "Wake up" button.
- **"Wake up" only when CLI-wakeable** — `vellum wake` only starts plain local assistants (it returns early for Docker, refuses apple-container; see `isGuardianRepairable`'s doc). The button (and its `vellum wake` hint) is now gated on the assistant actually being CLI-wakeable via the extracted `isCliWakeableAssistant` predicate, which `isGuardianRepairable` now delegates to (one predicate, two call sites).
- **Remote-web pairing** (`lib/auth/remote-gateway-session.ts`) — the same `Response.json()`-before-`response.ok` footgun in `exchangeRemoteWebPairingToken` / `createRemoteWebPairingChallenge` now parses defensively.
- **Tests** — the capability across host shapes, the non-JSON / unavailable / fetch-reject transport paths, the banner states (informative + Docker/non-wakeable), and the pairing flow.

### Deliberately NOT changed (verified, not oversight)
- **`vellum client` does not implement `__local` `wake`/`sleep`/`status` endpoints** (only lockfile/hatch/retire/guardian-token). The wake button there 404s, but the seam degrades it to "Wake failed. Try running `vellum wake` in your terminal." — correct, actionable advice for a user who is by definition at a terminal. Adding those CLI endpoints is unnecessary surface; left as-is.
- **The local-health heartbeat still runs for `is_local` on managed** (one residual `/v1/.../healthz` 404 poll). Keeping it is what lets the banner distinguish a *reachable* self-hosted assistant (no banner) from an unreachable one; gating it would wrongly show "runs locally" for a reachable self-hosted assistant. Net cost is a poll in a rare scenario.
- The capability is derived from injected-config presence; an explicit `__VELLUM_CONFIG__.localMode` flag was considered and rejected (it reintroduces version-skew between `vellum client` and the served bundle without being more robust).

### Testing
- `clients/web`: `tsc --noEmit` ✅, `eslint` ✅, `audit:cross-domain` ✅
- Full web suite (per-file isolation runner): **380 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLeN6mWBq3CBbG9N72Y7Kk