### PR TITLE
chore(plugins): bump marketing-expert ref (long output → Document Writer)

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -70,7 +70,7 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/marketing-expert",
-        "ref": "bd35992c151a0d62274f7693d8043633fd05ed53"
+        "ref": "15d1f38c2e3c82b8f206ea8009fb158c5ba4746f"
       },
       "description": "Acts as a full-stack marketing expert for any business (B2B or B2C): an on-demand persona plus playbook skills (positioning, demand planning, launches, content & copywriting, brand voice, email sequences, SEO & GEO, competitive teardown, board reporting) and deterministic funnel/positioning/GTM/competitive tools.",
       "category": "marketing",


### PR DESCRIPTION
Re-pins the `marketing-expert` marketplace entry to [`15d1f38`](https://github.com/vellum-ai/marketing-expert/commit/15d1f38c2e3c82b8f206ea8009fb158c5ba4746f).

**Change:** `draft-content` and `competitive-teardown` were dumping long-form output as a wall of text in chat. They now open the bundled **`document-editor`** (Document Writer) — `document_create` to open the editor, then streamed `document_update` (`append`) — leaving only a short summary / headline options in the conversation. Mirrors the existing `geo-writing` pattern.

Skills/tools content lives in `vellum-ai/marketing-expert`; this is just the pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)