### PR TITLE
[LUM-2508] fix(web): render attachment text/markdown previews without WASM

### DIFF
--- a/clients/web/bun.lock
+++ b/clients/web/bun.lock
@@ -59,7 +59,6 @@
         "rehype-sanitize": "6.0.0",
         "remark-gfm": "4.0.1",
         "remark-math": "6.0.0",
-        "shiki": "4.1.0",
         "sonner": "2.0.7",
         "tailwind-merge": "3.6.0",
         "tiptap-markdown": "0.9.0",
@@ -572,22 +571,6 @@
     "@sentry/rollup-plugin": ["@sentry/rollup-plugin@5.3.0", "", { "dependencies": { "@sentry/bundler-plugin-core": "5.3.0", "magic-string": "~0.30.8" }, "peerDependencies": { "rollup": ">=3.2.0" }, "optionalPeers": ["rollup"] }, "sha512-hgPGPYdQJ/G1cGYOxAb7d4z3V+/k/E5/P/5TFPEEBLuIbFFk+JG0CISUDJdzXJjO382Lb99PBJuXGbueBmO79w=="],
 
     "@sentry/vite-plugin": ["@sentry/vite-plugin@5.3.0", "", { "dependencies": { "@sentry/bundler-plugin-core": "5.3.0", "@sentry/rollup-plugin": "5.3.0" } }, "sha512-qcoSzo4n2MulVQ70UUPLq6dTleb2a2HwL2wuwvAgWhPChrYTuk6A6mDg6aQb9fairPAwFPiU9PzOANpoDJcz1A=="],
-
-    "@shikijs/core": ["@shikijs/core@4.1.0", "", { "dependencies": { "@shikijs/primitive": "4.1.0", "@shikijs/types": "4.1.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-jLJtSJeuFffqX6/inRE1zqU5aFv2hrszvYgq3OjbAgFRZiWv7abKMDdQzYxuSDfmUPQozZvI/kuy6VMTvnvqTQ=="],
-
-    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.1.0", "", { "dependencies": { "@shikijs/types": "4.1.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.6" } }, "sha512-YquhawCUgaBfhsS72e2Y/dI59gCBNPHu3fEO/tvLaXrTssxZrY5ddjtNLTwndrMgPo8b3IscE+xoICDzpTmlFQ=="],
-
-    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.1.0", "", { "dependencies": { "@shikijs/types": "4.1.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-axLpjVs45YBvvINa+dJF+NPW+KtFkNXsFr4SDw2BMj9GdeMnGxVB9PQb2xXlJYovslt/nz6giedAyOANkfc7hg=="],
-
-    "@shikijs/langs": ["@shikijs/langs@4.1.0", "", { "dependencies": { "@shikijs/types": "4.1.0" } }, "sha512-nwOMruEkbgdZfQ/b8CgpNBVOpvG1k0N5tbmgiFeqsan401+x3ILqlzZJowSla4Agmq4hG2Uf2wh5jLTEhR8VSg=="],
-
-    "@shikijs/primitive": ["@shikijs/primitive@4.1.0", "", { "dependencies": { "@shikijs/types": "4.1.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-zx2/2Uwj2q9X3KSyYREEhXO23xBw5WUhP4orK2lE4r+t9JGITmEe0JH+wPmJhqHpOT2bRRs6lAL945+LDvOAGw=="],
-
-    "@shikijs/themes": ["@shikijs/themes@4.1.0", "", { "dependencies": { "@shikijs/types": "4.1.0" } }, "sha512-emCcTnUM7yO2wltYbaxm+yLvcCI4+h8XBKc4KmJ7EZUXoSGjcCHifkI//R4OFit9ewpg7H2/9tjOuXrT2v/Knw=="],
-
-    "@shikijs/types": ["@shikijs/types@4.1.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA=="],
-
-    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -1113,8 +1096,6 @@
 
     "hast-util-sanitize": ["hast-util-sanitize@5.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "unist-util-position": "^5.0.0" } }, "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg=="],
 
-    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
-
     "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
 
     "hast-util-to-parse5": ["hast-util-to-parse5@8.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA=="],
@@ -1403,10 +1384,6 @@
 
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
 
-    "oniguruma-parser": ["oniguruma-parser@0.12.2", "", {}, "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw=="],
-
-    "oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
-
     "open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
@@ -1543,12 +1520,6 @@
 
     "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
-    "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
-
-    "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
-
-    "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
-
     "rehype-katex": ["rehype-katex@7.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/katex": "^0.16.0", "hast-util-from-html-isomorphic": "^2.0.0", "hast-util-to-text": "^4.0.0", "katex": "^0.16.0", "unist-util-visit-parents": "^6.0.0", "vfile": "^6.0.0" } }, "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA=="],
 
     "rehype-raw": ["rehype-raw@7.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-raw": "^9.0.0", "vfile": "^6.0.0" } }, "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww=="],
@@ -1592,8 +1563,6 @@
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
-
-    "shiki": ["shiki@4.1.0", "", { "dependencies": { "@shikijs/core": "4.1.0", "@shikijs/engine-javascript": "4.1.0", "@shikijs/engine-oniguruma": "4.1.0", "@shikijs/langs": "4.1.0", "@shikijs/themes": "4.1.0", "@shikijs/types": "4.1.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-l/ABZPUR5v70jI10EzqfMS/I96vjSGv2y0ihUV+WYFzv0EfvW4s54m0Lg8wCrrL+2IkwBzFTuxkZjPf8b2NX9Q=="],
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -82,7 +82,6 @@
     "rehype-sanitize": "6.0.0",
     "remark-gfm": "4.0.1",
     "remark-math": "6.0.0",
-    "shiki": "4.1.0",
     "sonner": "2.0.7",
     "tailwind-merge": "3.6.0",
     "tiptap-markdown": "0.9.0",

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
@@ -7,6 +7,7 @@ import { attachmentsByIdContentGet } from "@/generated/daemon/sdk.gen";
 import { Button, Typography } from "@vellumai/design-library";
 
 import { PdfPreview } from "@/domains/chat/components/chat-attachments/pdf-preview";
+import { PreviewMessageCard } from "@/domains/chat/components/chat-attachments/preview-message-card";
 import { TextPreview } from "@/domains/chat/components/chat-attachments/text-preview";
 import { formatAttachmentSize } from "@/domains/chat/components/chat-attachments/utils";
 
@@ -208,22 +209,12 @@ export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
 
     if (previewError) {
       return (
-        <div className="w-full max-w-sm rounded-lg border border-white/15 bg-white/[0.08] p-8 text-center">
-          <p className="text-body-medium-lighter text-white/80">
-            {previewError}
-          </p>
-          <Button
-            variant="ghost"
-            leftIcon={<Download />}
-            onClick={handleDownload}
-            disabled={!effectiveUrl}
-            aria-label={`Download ${attachment.filename}`}
-            className="mt-4 text-white/70 hover:bg-white/10 hover:text-white max-md:bg-transparent"
-            tintColor="currentColor"
-          >
-            Download
-          </Button>
-        </div>
+        <PreviewMessageCard
+          message={previewError}
+          filename={attachment.filename}
+          onDownload={handleDownload}
+          downloadDisabled={!effectiveUrl}
+        />
       );
     }
 

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
@@ -10,9 +10,8 @@ import { PdfPreview } from "@/domains/chat/components/chat-attachments/pdf-previ
 import { TextPreview } from "@/domains/chat/components/chat-attachments/text-preview";
 import { formatAttachmentSize } from "@/domains/chat/components/chat-attachments/utils";
 
-// File extensions we route to the TextPreview branch even when the upstream
-// MIME type is something generic like application/octet-stream. Keep in sync
-// with the language map inside `_TextPreview.tsx`.
+// File extensions routed to the inline text preview even when the upstream
+// MIME type is generic (e.g. application/octet-stream).
 const TEXT_PREVIEW_EXTENSIONS = new Set([
   "ts",
   "tsx",

--- a/clients/web/src/domains/chat/components/chat-attachments/preview-message-card.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/preview-message-card.tsx
@@ -1,0 +1,42 @@
+import { Download } from "lucide-react";
+
+import { Button } from "@vellumai/design-library";
+
+interface PreviewMessageCardProps {
+  message: string;
+  filename: string;
+  onDownload: () => void;
+  /** Disable the download affordance when there is no fetchable URL yet. */
+  downloadDisabled?: boolean;
+}
+
+/**
+ * Centered "can't show it inline — here's a download" card used by the
+ * attachment preview modal and its text preview (load failure, file too large,
+ * unsupported type). White tints are intentional and theme-independent: this
+ * always renders on the modal's fixed `bg-black/80` backdrop, so design-token
+ * surfaces aren't needed for legibility.
+ */
+export function PreviewMessageCard({
+  message,
+  filename,
+  onDownload,
+  downloadDisabled = false,
+}: PreviewMessageCardProps) {
+  return (
+    <div className="w-full max-w-sm rounded-lg border border-white/15 bg-white/[0.08] p-8 text-center">
+      <p className="text-body-medium-lighter text-white/80">{message}</p>
+      <Button
+        variant="ghost"
+        leftIcon={<Download />}
+        onClick={onDownload}
+        disabled={downloadDisabled}
+        aria-label={`Download ${filename}`}
+        className="mt-4 text-white/70 hover:bg-white/10 hover:text-white max-md:bg-transparent"
+        tintColor="currentColor"
+      >
+        Download
+      </Button>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/chat-attachments/text-preview.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/text-preview.test.tsx
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+
+import { TextPreviewBody } from "@/domains/chat/components/chat-attachments/text-preview";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("TextPreviewBody", () => {
+  test("renders markdown files as formatted document content", () => {
+    const { container, queryByText } = render(
+      <TextPreviewBody
+        text={"# Heading\n\nSome **bold** body."}
+        filename="design.md"
+        mimeType="text/markdown"
+      />,
+    );
+
+    expect(container.querySelector("h1")?.textContent).toBe("Heading");
+    expect(container.querySelector("strong")?.textContent).toBe("bold");
+    // The raw markdown source must not leak through as literal text.
+    expect(queryByText("# Heading")).toBeNull();
+  });
+
+  test("treats .md as markdown even when the mime type is generic", () => {
+    const { container } = render(
+      <TextPreviewBody
+        text={"## Subheading"}
+        filename="notes.md"
+        mimeType="application/octet-stream"
+      />,
+    );
+
+    expect(container.querySelector("h2")?.textContent).toBe("Subheading");
+  });
+
+  test("renders non-markdown text as verbatim monospace source", () => {
+    const source = "const answer = 42;";
+    const { container } = render(
+      <TextPreviewBody
+        text={source}
+        filename="snippet.ts"
+        mimeType="text/plain"
+      />,
+    );
+
+    const pre = container.querySelector("pre");
+    expect(pre).not.toBeNull();
+    expect(pre?.textContent).toBe(source);
+    // Source must not be interpreted as markdown.
+    expect(container.querySelector("h1")).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/components/chat-attachments/text-preview.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/text-preview.tsx
@@ -1,9 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
-import { Download, Loader2 } from "lucide-react";
-
-import { Button } from "@vellumai/design-library";
+import { Loader2 } from "lucide-react";
 
 import { FileMarkdown, isMarkdown } from "@/components/file-markdown";
+import { PreviewMessageCard } from "@/domains/chat/components/chat-attachments/preview-message-card";
 import { captureError } from "@/lib/sentry/capture-error";
 
 /**
@@ -78,7 +77,7 @@ export function TextPreview({ url, filename, mimeType }: TextPreviewProps) {
 
   if (error) {
     return (
-      <TextPreviewFallback
+      <PreviewMessageCard
         message={
           error instanceof TextTooLargeError
             ? "File too large to preview inline."
@@ -130,33 +129,5 @@ export function TextPreviewBody({
     <pre className="whitespace-pre-wrap break-words font-mono text-body-small-default">
       {text}
     </pre>
-  );
-}
-
-interface TextPreviewFallbackProps {
-  message: string;
-  filename: string;
-  onDownload: () => void;
-}
-
-function TextPreviewFallback({
-  message,
-  filename,
-  onDownload,
-}: TextPreviewFallbackProps) {
-  return (
-    <div className="w-full max-w-sm rounded-lg border border-white/15 bg-white/[0.08] p-8 text-center">
-      <p className="text-body-medium-lighter text-white/80">{message}</p>
-      <Button
-        variant="ghost"
-        leftIcon={<Download />}
-        onClick={onDownload}
-        aria-label={`Download ${filename}`}
-        className="mt-4 text-white/70 hover:bg-white/10 hover:text-white"
-        tintColor="currentColor"
-      >
-        Download
-      </Button>
-    </div>
   );
 }

--- a/clients/web/src/domains/chat/components/chat-attachments/text-preview.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/text-preview.tsx
@@ -1,71 +1,33 @@
-
-import type { Highlighter } from "shiki";
-
+import { useQuery } from "@tanstack/react-query";
 import { Download, Loader2 } from "lucide-react";
-import type { FC, ReactNode } from "react";
-import { useEffect, useState } from "react";
 
 import { Button } from "@vellumai/design-library";
 
+import { FileMarkdown, isMarkdown } from "@/components/file-markdown";
+import { captureError } from "@/lib/sentry/capture-error";
+
 /**
- * Hard cap on the number of text bytes we render inline. Anything beyond this
- * triggers the "too large" fallback — Shiki tokenizing megabytes of text on
- * the main thread will lock the UI.
+ * Largest text payload rendered inline. Larger files fall back to a download
+ * affordance so a multi-megabyte file can't block the main thread while it
+ * parses.
  */
 export const MAX_TEXT_PREVIEW_BYTES = 200 * 1024;
 
-const BUNDLED_LANGUAGES = [
-  "typescript",
-  "javascript",
-  "python",
-  "json",
-  "markdown",
-  "bash",
-  "html",
-  "css",
-  "yaml",
-] as const;
+/** Signals that a file is past {@link MAX_TEXT_PREVIEW_BYTES} — an expected
+ *  outcome shown to the user, not a fault worth reporting to telemetry. */
+class TextTooLargeError extends Error {}
 
-const FALLBACK_LANGUAGE = "text";
-
-const EXTENSION_TO_LANGUAGE: Record<string, (typeof BUNDLED_LANGUAGES)[number]> = {
-  ts: "typescript",
-  tsx: "typescript",
-  js: "javascript",
-  jsx: "javascript",
-  py: "python",
-  json: "json",
-  md: "markdown",
-  sh: "bash",
-  bash: "bash",
-  html: "html",
-  css: "css",
-  yaml: "yaml",
-  yml: "yaml",
-};
-
-const inferLanguage = (filename: string): string => {
-  const dot = filename.lastIndexOf(".");
-  if (dot === -1 || dot === filename.length - 1) return FALLBACK_LANGUAGE;
-  const ext = filename.slice(dot + 1).toLowerCase();
-  return EXTENSION_TO_LANGUAGE[ext] ?? FALLBACK_LANGUAGE;
-};
-
-// Singleton highlighter — Shiki ships ~100KB+ of WASM/grammar payload, and
-// `createHighlighter` reparses it on every call. One per page-load is plenty.
-let highlighterPromise: Promise<Highlighter> | null = null;
-
-const getHighlighter = async (): Promise<Highlighter> => {
-  if (!highlighterPromise) {
-    highlighterPromise = import("shiki").then(({ createHighlighter }) =>
-      createHighlighter({
-        langs: [...BUNDLED_LANGUAGES],
-        themes: ["github-dark", "github-light"],
-      }),
-    );
+async function loadText(url: string): Promise<string> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to load file: ${response.status}`);
   }
-  return highlighterPromise;
-};
+  const blob = await response.blob();
+  if (blob.size > MAX_TEXT_PREVIEW_BYTES) {
+    throw new TextTooLargeError();
+  }
+  return blob.text();
+}
 
 interface TextPreviewProps {
   url: string;
@@ -74,107 +36,37 @@ interface TextPreviewProps {
 }
 
 /**
- * Inline preview for text/code attachments. Fetches the file, picks a Shiki
- * language identifier from the file extension, and renders the highlighted
- * HTML inside a scrollable monospace container.
- *
- * Reads `prefers-color-scheme` once on mount to choose between the
- * `github-dark` and `github-light` Shiki themes.
- *
- * Files larger than `MAX_TEXT_PREVIEW_BYTES` short-circuit to a download
- * fallback to keep the UI thread responsive.
+ * Inline preview for a text attachment inside the full-screen preview modal.
+ * Markdown renders as formatted document content; every other text type
+ * renders as monospace source. Content sits on a themed surface so it stays
+ * legible on the modal's dark backdrop across light, dark, and velvet themes.
  */
-export const TextPreview: FC<TextPreviewProps> = ({ url, filename, mimeType: _mimeType }) => {
-  const [html, setHtml] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [tooLarge, setTooLarge] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    const load = async () => {
-      setIsLoading(true);
-      setError(null);
-      setHtml(null);
-      setTooLarge(false);
-
+export function TextPreview({ url, filename, mimeType }: TextPreviewProps) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["attachment-text-preview", url],
+    queryFn: async () => {
       try {
-        const response = await fetch(url);
-        if (!response.ok) {
-          throw new Error(`Failed to load file: ${response.statusText}`);
+        return await loadText(url);
+      } catch (err) {
+        if (!(err instanceof TextTooLargeError)) {
+          captureError(err, {
+            context: "attachment-text-preview",
+            bestEffort: true,
+          });
         }
-
-        const blob = await response.blob();
-        if (cancelled) return;
-
-        if (blob.size > MAX_TEXT_PREVIEW_BYTES) {
-          setTooLarge(true);
-          setIsLoading(false);
-          return;
-        }
-
-        const text = await blob.text();
-        if (cancelled) return;
-
-        const prefersDark =
-          typeof window !== "undefined" &&
-          typeof window.matchMedia === "function" &&
-          window.matchMedia("(prefers-color-scheme: dark)").matches;
-        const theme = prefersDark ? "github-dark" : "github-light";
-
-        const highlighter = await getHighlighter();
-        if (cancelled) return;
-
-        const lang = inferLanguage(filename);
-        const highlighted = highlighter.codeToHtml(text, { lang, theme });
-        if (cancelled) return;
-
-        setHtml(highlighted);
-      } catch {
-        if (!cancelled) {
-          setError("Failed to load preview.");
-        }
-      } finally {
-        if (!cancelled) {
-          setIsLoading(false);
-        }
+        throw err;
       }
-    };
-
-    void load();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [url, filename]);
+    },
+    // Attachment bytes are immutable for a given URL, so a successful read
+    // never needs revalidating.
+    staleTime: Infinity,
+    retry: false,
+  });
 
   const handleDownload = async () => {
     const { saveFile } = await import("@/runtime/native-file");
     await saveFile(url, filename);
   };
-
-  const renderFallbackCard = (message: string): ReactNode => (
-    <div
-      className="w-full max-w-sm rounded-lg border p-8 text-center"
-      style={{
-        borderColor: "var(--border-base)",
-        backgroundColor: "var(--surface-lift)",
-      }}
-    >
-      <p className="text-body-medium-lighter text-white/80">{message}</p>
-      <Button
-        variant="ghost"
-        leftIcon={<Download />}
-        onClick={handleDownload}
-        aria-label={`Download ${filename}`}
-        className="mt-4 text-white/70 hover:bg-white/10 hover:text-white"
-        tintColor="currentColor"
-      >
-        Download
-      </Button>
-    </div>
-  );
 
   if (isLoading) {
     return (
@@ -184,15 +76,87 @@ export const TextPreview: FC<TextPreviewProps> = ({ url, filename, mimeType: _mi
     );
   }
 
-  if (tooLarge) return renderFallbackCard("File too large to preview inline.");
-  if (error) return renderFallbackCard(error);
+  if (error) {
+    return (
+      <TextPreviewFallback
+        message={
+          error instanceof TextTooLargeError
+            ? "File too large to preview inline."
+            : "Failed to load preview."
+        }
+        filename={filename}
+        onDownload={handleDownload}
+      />
+    );
+  }
+
+  if (data == null) {
+    return null;
+  }
 
   return (
     <div
-      // typography: off-scale — verbatim source code rendering
-       
-      className="max-h-[80vh] max-w-[90vw] overflow-auto rounded bg-[var(--surface-base)] p-4 font-mono text-xs"
-      dangerouslySetInnerHTML={html ? { __html: html } : undefined}
-    />
+      className="max-h-[80vh] w-[min(90vw,800px)] overflow-auto rounded-lg p-6"
+      style={{
+        backgroundColor: "var(--surface-overlay)",
+        color: "var(--content-default)",
+      }}
+    >
+      <TextPreviewBody text={data} filename={filename} mimeType={mimeType} />
+    </div>
   );
-};
+}
+
+interface TextPreviewBodyProps {
+  text: string;
+  filename: string;
+  mimeType: string;
+}
+
+/**
+ * Resolved-content renderer: formatted markdown for markdown files, monospace
+ * source for everything else. Pure and exported so the markdown-vs-source
+ * decision can be unit-tested without the surrounding data fetch.
+ */
+export function TextPreviewBody({
+  text,
+  filename,
+  mimeType,
+}: TextPreviewBodyProps) {
+  if (isMarkdown(filename, mimeType)) {
+    return <FileMarkdown content={text} />;
+  }
+  return (
+    <pre className="whitespace-pre-wrap break-words font-mono text-body-small-default">
+      {text}
+    </pre>
+  );
+}
+
+interface TextPreviewFallbackProps {
+  message: string;
+  filename: string;
+  onDownload: () => void;
+}
+
+function TextPreviewFallback({
+  message,
+  filename,
+  onDownload,
+}: TextPreviewFallbackProps) {
+  return (
+    <div className="w-full max-w-sm rounded-lg border border-white/15 bg-white/[0.08] p-8 text-center">
+      <p className="text-body-medium-lighter text-white/80">{message}</p>
+      <Button
+        variant="ghost"
+        leftIcon={<Download />}
+        onClick={onDownload}
+        aria-label={`Download ${filename}`}
+        className="mt-4 text-white/70 hover:bg-white/10 hover:text-white"
+        tintColor="currentColor"
+      >
+        Download
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## What this means for you

- **What you'll notice** — Open a file attachment in the desktop app (a markdown doc, `.txt`, `.json`, or a code file) and you now actually see its contents. Markdown renders as a clean, formatted document — headings, bold, lists, tables — instead of raw text, and the blank white box is gone.
- **Why we're doing it** — Clicking an attachment to preview it was showing a blank box in the Mac app. The whole point of a preview is to glance at a file *without* downloading it, and that was silently broken.
- **Why it's needed** — This wasn't a rare edge case: *every* text, code, and markdown attachment failed to preview in the packaged Mac app — the way most people run it. It only looked fine in the browser/dev build, which is why it slipped through, and a user reported it directly ("File preview fails to load. In the mac app").
- **Why it's safe** — We reuse the *same* rendering the app already uses for workspace and skill files (battle-tested and sanitized against malicious content), and we **removed** the problematic piece rather than loosening any security setting. Image, video, and PDF previews are untouched, and the change is covered by tests. The worst case for a code file is plain, uncolored text — still fully readable, and strictly better than a blank box.

---

## Problem

Clicking a markdown (or any text) attachment in the full-screen preview shows a blank white box in the packaged macOS app.

**Root cause.** The preview highlighted text with **Shiki**, whose default highlighter uses the **Oniguruma WASM engine** (`createOnigurumaEngine(import("shiki/wasm"))` → `WebAssembly.instantiate(...)`). The packaged renderer's CSP (`clients/macos/src/main/csp.ts`) is `script-src 'self' 'unsafe-inline'` — **no `wasm-unsafe-eval`** — so Chromium/Electron blocks WebAssembly compilation and `createHighlighter()` throws. Two failures stack:

1. **Functional** — *all* text/code/markdown previews fail in the packaged app (WASM blocked). Markdown was just the file under test. Works in the browser/dev where no CSP is applied, which is why it looked fine outside the desktop build.
2. **Visual** — the resulting error card used `var(--surface-lift)` (`#FFFFFF` in light mode) with `text-white/80` text → white-on-white → an invisible message, i.e. the blank box.

Corroborated by a #user-feedback report ("File preview fails to load. In the mac app", 2026-05-06).

Note: the rewritten fetch path stays CSP-safe — `connect-src` already allows `data:` and `blob:` (`csp.ts`), so `TextPreview`'s `fetch()` of the data-URI/object-URL works; only Shiki's WASM (governed by `script-src`) was the blocker.

## Why this fix (first principles, not a workaround)

Shiki+WASM here was a lone architectural outlier. The app **already** previews files consistently in two places — `workspace-file-viewer.tsx` and `skill-file-content.tsx` — using `FileMarkdown` (react-markdown + remark-gfm + rehype-raw + rehype-sanitize, **rendered & XSS-safe**) for markdown and a plain `<pre>` for everything else, and it deliberately doesn't syntax-highlight code anywhere. From scratch we'd reuse that, not add a WASM highlighter that fights our own CSP.

So this PR makes the attachment preview match the rest of the app:
- **Markdown** → `FileMarkdown` (rendered — what you actually want when you open a `.md`).
- **Other text** → monospace `<pre>` source.
- **Remove the `shiki` dependency** (used nowhere else) — eliminates the WASM/CSP conflict at the source and drops a multi-MB grammar/WASM payload from the bundle. No CSP relaxation.

Alternatives rejected: add `wasm-unsafe-eval` (weakens a deliberately-strict CSP app-wide for syntax highlighting); swap Shiki to its JS engine (keeps an outlier dep and still shows markdown as *source*, not rendered); Prism/highlight.js (new parallel highlighter, still no rendered markdown).

## Also addressed in the rewritten path
- Content loads via **TanStack Query** instead of a hand-rolled `fetch`-in-`useEffect` + `useState` with a bare `catch` (per `STATE_MANAGEMENT.md` / `CONVENTIONS.md`). Unexpected failures go to `captureError` (best-effort); the expected "too large" case does not.
- Content and loading/error states render on a **themed surface** (`--surface-overlay` / `--content-default`) with a white-tint fallback, so they stay legible on the modal's dark backdrop across light, dark, and velvet — the previous fallback was theme-broken.
- Rendering now follows the **app theme** via CSS tokens automatically, replacing the old `prefers-color-scheme` JS that could mismatch the in-app theme.
- **De-duplicated the fallback card** (review-time cleanup, separate commit). The text preview's `TextPreviewFallback` was a third near-identical copy of the modal's "message + Download" card, with subtle drift (`disabled` / `max-md:bg-transparent`). Both the modal's preview-error branch and the text preview now share one `PreviewMessageCard`; behavior preserved.

## Risk
Low. `FileMarkdown` is already battle-tested in workspace + skills and is sanitized. Shiki removal is a single import site. The modal's image/video/PDF paths are **untouched** (the only modal change is routing its existing text-error card through the shared component). `bubble-attachments.test.tsx` still passes; `text-preview.test.tsx` is added for the markdown-vs-source decision. One intentional behavior change: code files render as plain monospace (matching the rest of the app) — a strict improvement over today's blank box.

## Follow-ups (surfaced, not silently skipped)
- The modal's image/video/PDF content fetch still uses a hand-rolled `fetch`-in-`useEffect` with a bare `catch` (no `captureError`); migrate it to TanStack Query (mirrors `workspace-file-viewer`'s `useQuery` + object-URL effect). Kept out of this PR to avoid touching working media previews.
- `TextPreview`'s query key is the full `effectiveUrl`, which for inline attachments is the entire base64 `data:` URI (`display-attachments.ts`). Functionally correct (dedupes fine) but inelegant; keying by `attachment.id` would avoid multi-hundred-KB cache keys. Deferred — needs an `id` threaded through, marginal real benefit.
- Markdown frontmatter is stripped by `FileMarkdown`'s default (cleaner reading, and *not* stripping would mangle it into a setext heading). Byte-faithful frontmatter display would be a separate change (render it as a fenced block).
- Deeper: attachment content has two sources of truth — inline base64 (`data:` URIs embedded by `toDisplayAttachments` / `runtimeAttachmentsToDisplay`) and the daemon `/content` endpoint. Collapsing to the daemon endpoint as the single source would remove the `previewUrl ?? objectUrl` dance, but touches image rendering + history/reconcile (LUM-1413), so it deserves its own change.

## Test plan
- [x] `bun test …/text-preview.test.tsx` — markdown renders formatted; `.md` with octet-stream mime still markdown; non-md stays verbatim monospace
- [x] `bun test …/bubble-attachments.test.tsx` — no regression (13 pass across the attachment + file-markdown suites)
- [x] `tsc --noEmit` clean; `eslint` clean on changed files
- [ ] Manual: packaged macOS build — open `.md`, `.ts`, `.json` attachments (CSP only applies in the packaged shell)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzBCQ9QFqa9Tw9pqv4PtPb