### PR TITLE
[codex] Require same-origin fetch metadata for browser refresh

### DIFF
--- a/gateway/src/__tests__/remote-web-pairing-token.test.ts
+++ b/gateway/src/__tests__/remote-web-pairing-token.test.ts
@@ -47,12 +47,51 @@ function makeTokenRequest(body: unknown): Request {
   });
 }
 
-function makeRefreshRequest(refreshToken: string): Request {
+function makeRefreshRequest(
+  refreshToken: string,
+  opts: {
+    origin?: string | null;
+    referer?: string | null;
+    secFetchSite?: string | null;
+    url?: string;
+  } = {},
+): Request {
+  const headers: Record<string, string> = {
+    cookie: `vellum_web_refresh=${encodeURIComponent(refreshToken)}`,
+  };
+  const secFetchSite = Object.prototype.hasOwnProperty.call(
+    opts,
+    "secFetchSite",
+  )
+    ? opts.secFetchSite
+    : "same-origin";
+  if (typeof secFetchSite === "string") {
+    headers["sec-fetch-site"] = secFetchSite;
+  }
+  if (typeof opts.origin === "string") {
+    headers.origin = opts.origin;
+  }
+  if (typeof opts.referer === "string") {
+    headers.referer = opts.referer;
+  }
+
+  return new Request(
+    opts.url ?? "https://paired.example.com/v1/guardian/refresh",
+    {
+      method: "POST",
+      headers,
+    },
+  );
+}
+
+function makeDeviceRefreshRequest(params: {
+  refreshToken: string;
+  deviceId: string;
+}): Request {
   return new Request("https://paired.example.com/v1/guardian/refresh", {
     method: "POST",
-    headers: {
-      cookie: `vellum_web_refresh=${encodeURIComponent(refreshToken)}`,
-    },
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(params),
   });
 }
 
@@ -223,6 +262,163 @@ describe("remote web pairing token exchange", () => {
       hashToken(rotatedRefreshToken),
     );
     expect(activeTokens()).toHaveLength(1);
+  });
+
+  test("browser refresh rejects non-same-origin fetch metadata", async () => {
+    const challenge = createRemoteWebPairingChallenge(PUBLIC_BASE_URL);
+    expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
+      "approved",
+    );
+
+    const exchange = await handleRemoteWebPairingToken(
+      makeTokenRequest({ deviceCode: challenge.deviceCode }),
+    );
+    const originalRefreshToken = cookieValue(
+      setCookies(exchange),
+      "vellum_web_refresh",
+    );
+
+    for (const secFetchSite of ["cross-site", "same-site", "none"]) {
+      const refresh = await handleGuardianRefresh(
+        makeRefreshRequest(originalRefreshToken, {
+          origin: PUBLIC_BASE_URL,
+          secFetchSite,
+        }),
+      );
+
+      expect(refresh.status).toBe(403);
+      expect(await refresh.json()).toEqual({
+        error: {
+          code: "FORBIDDEN",
+          message: "Browser refresh requires a same-origin request",
+        },
+      });
+      expect(setCookies(refresh)).toHaveLength(0);
+    }
+
+    expect(activeRefreshTokens()).toHaveLength(1);
+    expect(activeRefreshTokens()[0].tokenHash).toBe(
+      hashToken(originalRefreshToken),
+    );
+  });
+
+  test("browser refresh falls back to same-origin request headers when fetch metadata is missing", async () => {
+    const challenge = createRemoteWebPairingChallenge(PUBLIC_BASE_URL);
+    expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
+      "approved",
+    );
+
+    const originExchange = await handleRemoteWebPairingToken(
+      makeTokenRequest({ deviceCode: challenge.deviceCode }),
+    );
+    const originRefreshToken = cookieValue(
+      setCookies(originExchange),
+      "vellum_web_refresh",
+    );
+
+    const originRefresh = await handleGuardianRefresh(
+      makeRefreshRequest(originRefreshToken, {
+        origin: PUBLIC_BASE_URL,
+        secFetchSite: null,
+        url: "http://paired.example.com/v1/guardian/refresh",
+      }),
+    );
+
+    expect(originRefresh.status).toBe(200);
+    expect(
+      cookieValue(setCookies(originRefresh), "vellum_web_refresh"),
+    ).not.toBe(originRefreshToken);
+
+    const refererChallenge = createRemoteWebPairingChallenge(PUBLIC_BASE_URL);
+    expect(
+      approveRemoteWebPairingChallenge(refererChallenge.userCode).status,
+    ).toBe("approved");
+    const refererExchange = await handleRemoteWebPairingToken(
+      makeTokenRequest({ deviceCode: refererChallenge.deviceCode }),
+    );
+    const refererRefreshToken = cookieValue(
+      setCookies(refererExchange),
+      "vellum_web_refresh",
+    );
+
+    const refererRefresh = await handleGuardianRefresh(
+      makeRefreshRequest(refererRefreshToken, {
+        referer: `${PUBLIC_BASE_URL}/assistant/`,
+        secFetchSite: null,
+      }),
+    );
+
+    expect(refererRefresh.status).toBe(200);
+    expect(
+      cookieValue(setCookies(refererRefresh), "vellum_web_refresh"),
+    ).not.toBe(refererRefreshToken);
+  });
+
+  test("browser refresh rejects missing fetch metadata without a same-origin fallback", async () => {
+    const challenge = createRemoteWebPairingChallenge(PUBLIC_BASE_URL);
+    expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
+      "approved",
+    );
+
+    const exchange = await handleRemoteWebPairingToken(
+      makeTokenRequest({ deviceCode: challenge.deviceCode }),
+    );
+    const originalRefreshToken = cookieValue(
+      setCookies(exchange),
+      "vellum_web_refresh",
+    );
+
+    for (const opts of [
+      { secFetchSite: null },
+      {
+        origin: "https://attacker.example.com",
+        secFetchSite: null,
+      },
+      {
+        referer: "https://attacker.example.com/assistant/",
+        secFetchSite: null,
+      },
+    ]) {
+      const refresh = await handleGuardianRefresh(
+        makeRefreshRequest(originalRefreshToken, opts),
+      );
+
+      expect(refresh.status).toBe(403);
+      expect(await refresh.json()).toEqual({
+        error: {
+          code: "FORBIDDEN",
+          message: "Browser refresh requires a same-origin request",
+        },
+      });
+      expect(setCookies(refresh)).toHaveLength(0);
+    }
+
+    expect(activeRefreshTokens()).toHaveLength(1);
+    expect(activeRefreshTokens()[0].tokenHash).toBe(
+      hashToken(originalRefreshToken),
+    );
+  });
+
+  test("device-bound refresh path does not require fetch metadata", async () => {
+    const pair = mintAndRecordDeviceBoundTokenPair({
+      guardianPrincipalId: GUARDIAN_ID,
+      deviceId: "legacy-device",
+      platform: "cli",
+    });
+
+    const refresh = await handleGuardianRefresh(
+      makeDeviceRefreshRequest({
+        refreshToken: pair.refreshToken,
+        deviceId: "legacy-device",
+      }),
+    );
+
+    expect(refresh.status).toBe(200);
+    const body = (await refresh.json()) as Record<string, unknown>;
+    expect(typeof body.accessToken).toBe("string");
+    expect(typeof body.refreshToken).toBe("string");
+    expect(typeof body.refreshAfter).toBe("number");
+    expect(setCookies(refresh)).toHaveLength(0);
   });
 
   test("path-prefixed public base URLs keep refresh cookies on the public refresh path", async () => {

--- a/gateway/src/http/routes/guardian-refresh.ts
+++ b/gateway/src/http/routes/guardian-refresh.ts
@@ -11,6 +11,13 @@ import {
 } from "../browser-auth-cookies.js";
 
 const log = getLogger("guardian-refresh-route");
+const REQUIRED_BROWSER_REFRESH_FETCH_SITE = "same-origin";
+const BROWSER_REFRESH_FORBIDDEN_RESPONSE = {
+  error: {
+    code: "FORBIDDEN",
+    message: "Browser refresh requires a same-origin request",
+  },
+};
 
 function refreshFailureResponse(error: RefreshErrorCode): Response {
   // 403 for tokens that are valid-but-forbidden (revoked, reused, or presented
@@ -52,10 +59,51 @@ function browserRefreshResponse(
   );
 }
 
+function parseHttpUrl(value: string | null): URL | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+function sameEffectiveOrigin(req: Request, url: URL): boolean {
+  const target = new URL(req.url);
+  if (url.host !== target.host) return false;
+  if (url.protocol === target.protocol) return true;
+  return target.protocol === "http:" && url.protocol === "https:";
+}
+
+function browserRefreshOriginFallbackAllows(req: Request): boolean {
+  const origin = parseHttpUrl(req.headers.get("origin"));
+  if (origin && sameEffectiveOrigin(req, origin)) return true;
+
+  const referer = parseHttpUrl(req.headers.get("referer"));
+  return !!referer && sameEffectiveOrigin(req, referer);
+}
+
+function browserRefreshFetchMetadataGuard(req: Request): Response | null {
+  const fetchSite = req.headers.get("sec-fetch-site");
+  if (fetchSite) {
+    if (fetchSite === REQUIRED_BROWSER_REFRESH_FETCH_SITE) return null;
+    return Response.json(BROWSER_REFRESH_FORBIDDEN_RESPONSE, { status: 403 });
+  }
+
+  if (browserRefreshOriginFallbackAllows(req)) return null;
+
+  return Response.json(BROWSER_REFRESH_FORBIDDEN_RESPONSE, { status: 403 });
+}
+
 export async function handleGuardianRefresh(req: Request): Promise<Response> {
   try {
     const browserRefreshToken = getRemoteWebRefreshCookie(req);
     if (browserRefreshToken) {
+      const metadataError = browserRefreshFetchMetadataGuard(req);
+      if (metadataError) return metadataError;
+
       const result = rotateBrowserCredentialsByRefreshToken({
         refreshToken: browserRefreshToken,
       });


### PR DESCRIPTION
## Summary
- Require Sec-Fetch-Site: same-origin on the browser-cookie branch of POST /v1/guardian/refresh.
- Leave the existing device-bound refresh path unchanged.
- Add regression coverage for missing, cross-site, same-site, and none fetch metadata values.

## Why
Browser refresh is cookie-authenticated, so it should reject refresh attempts that do not originate from the exact remote web origin. SameSite=Strict remains defense in depth, while Sec-Fetch-Site: same-origin covers same-site-but-cross-origin tunnel/provider cases.

## Validation
- bun test src/__tests__/remote-web-pairing-token.test.ts
- bun run lint src/http/routes/guardian-refresh.ts src/__tests__/remote-web-pairing-token.test.ts
- bunx tsc --noEmit