### PR TITLE
feat(profiles): consolidate Balanced Economy into the managed Balanced profile

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -480,9 +480,11 @@ describe("loadConfig startup behavior", () => {
       "anthropic-personal",
     );
     // Managed profiles exist as well.
-    expect(config.llm.profiles.balanced?.model).toBe("claude-sonnet-4-6");
+    expect(config.llm.profiles.balanced?.model).toBe(
+      "accounts/fireworks/models/minimax-m3",
+    );
     expect(config.llm.profiles.balanced?.provider_connection).toBe(
-      "anthropic-managed",
+      "fireworks-managed",
     );
 
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
@@ -491,7 +493,9 @@ describe("loadConfig startup behavior", () => {
       model: "claude-opus-4-7",
     });
     expect(raw.llm.activeProfile).toBe("custom-balanced");
-    expect(raw.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
+    expect(raw.llm.profiles.balanced.model).toBe(
+      "accounts/fireworks/models/minimax-m3",
+    );
   });
 
   test("on-platform hatch seeds only managed profiles", () => {
@@ -519,9 +523,11 @@ describe("loadConfig startup behavior", () => {
     const config = loadConfig();
 
     expect(config.llm.activeProfile).toBe("balanced");
-    expect(config.llm.profiles.balanced?.model).toBe("claude-sonnet-4-6");
+    expect(config.llm.profiles.balanced?.model).toBe(
+      "accounts/fireworks/models/minimax-m3",
+    );
     expect(config.llm.profiles.balanced?.provider_connection).toBe(
-      "anthropic-managed",
+      "fireworks-managed",
     );
     // No user profiles created on platform.
     expect(config.llm.profiles["custom-balanced"]).toBeUndefined();
@@ -563,10 +569,10 @@ describe("loadConfig startup behavior", () => {
     expect(raw.llm.profiles["custom-balanced"].provider_connection).toBe(
       "anthropic-personal",
     );
-    // Managed balanced profile is seeded for anthropic-managed.
-    expect(raw.llm.profiles.balanced.provider).toBe("anthropic");
+    // Managed balanced profile is seeded for fireworks-managed (MiniMax M3).
+    expect(raw.llm.profiles.balanced.provider).toBe("fireworks");
     expect(raw.llm.profiles.balanced.provider_connection).toBe(
-      "anthropic-managed",
+      "fireworks-managed",
     );
   });
 
@@ -600,9 +606,9 @@ describe("loadConfig startup behavior", () => {
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
     // On-platform: no user profiles created, active resets to managed balanced.
     expect(raw.llm.activeProfile).toBe("balanced");
-    expect(raw.llm.profiles.balanced.provider).toBe("anthropic");
+    expect(raw.llm.profiles.balanced.provider).toBe("fireworks");
     expect(raw.llm.profiles.balanced.provider_connection).toBe(
-      "anthropic-managed",
+      "fireworks-managed",
     );
     // The old custom-balanced is preserved on disk but no longer active.
     expect(raw.llm.profiles["custom-balanced"].provider).toBe("openai");
@@ -654,10 +660,10 @@ describe("loadConfig startup behavior", () => {
       "gpt-5.4-nano",
     );
 
-    // Managed profiles are also seeded (balanced uses Anthropic).
-    expect(raw.llm.profiles.balanced.provider).toBe("anthropic");
+    // Managed profiles are also seeded (balanced uses Fireworks/MiniMax M3).
+    expect(raw.llm.profiles.balanced.provider).toBe("fireworks");
     expect(raw.llm.profiles.balanced.provider_connection).toBe(
-      "anthropic-managed",
+      "fireworks-managed",
     );
     expect(raw.llm.profiles.balanced.source).toBe("managed");
     expect(raw.llm.profiles["quality-optimized"].provider).toBe("anthropic");
@@ -685,9 +691,11 @@ describe("loadConfig startup behavior", () => {
     mergeDefaultConfigAndSeedInferenceProfiles();
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
-    expect(raw.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
+    expect(raw.llm.profiles.balanced.model).toBe(
+      "accounts/fireworks/models/minimax-m3",
+    );
     expect(raw.llm.profiles.balanced.provider_connection).toBe(
-      "anthropic-managed",
+      "fireworks-managed",
     );
     expect(raw.llm.activeProfile).toBe("balanced");
   });
@@ -717,10 +725,12 @@ describe("loadConfig startup behavior", () => {
     mergeDefaultConfigAndSeedInferenceProfiles();
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
-    expect(raw.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
-    expect(raw.llm.profiles.balanced.maxTokens).toBe(16000);
+    expect(raw.llm.profiles.balanced.model).toBe(
+      "accounts/fireworks/models/minimax-m3",
+    );
+    expect(raw.llm.profiles.balanced.maxTokens).toBe(32000);
     expect(raw.llm.profiles.balanced.provider_connection).toBe(
-      "anthropic-managed",
+      "fireworks-managed",
     );
     expect(raw.llm.activeProfile).toBe("balanced");
   });
@@ -750,7 +760,9 @@ describe("loadConfig startup behavior", () => {
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
     // Content refreshes from the template...
-    expect(raw.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
+    expect(raw.llm.profiles.balanced.model).toBe(
+      "accounts/fireworks/models/minimax-m3",
+    );
     // ...but the user's label and status overrides are preserved.
     expect(raw.llm.profiles.balanced.label).toBe("My Default");
     expect(raw.llm.profiles.balanced.status).toBe("disabled");
@@ -778,7 +790,9 @@ describe("loadConfig startup behavior", () => {
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
     // Model still gets the new template value (provider-controlled).
-    expect(raw.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
+    expect(raw.llm.profiles.balanced.model).toBe(
+      "accounts/fireworks/models/minimax-m3",
+    );
     // But the user's label override is preserved across the reseed.
     expect(raw.llm.profiles.balanced.label).toBe("My Default");
   });
@@ -806,7 +820,9 @@ describe("loadConfig startup behavior", () => {
 
     expect(raw.llm.profiles.balanced.status).toBe("disabled");
     // Model still refreshes — only label/status are user-owned.
-    expect(raw.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
+    expect(raw.llm.profiles.balanced.model).toBe(
+      "accounts/fireworks/models/minimax-m3",
+    );
   });
 
   test("off-platform reseed preserves an explicit null label (user cleared it)", () => {
@@ -847,7 +863,9 @@ describe("loadConfig startup behavior", () => {
     const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
 
     expect(raw.llm.profiles.balanced.label).toBe("Balanced (Managed)");
-    expect(raw.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
+    expect(raw.llm.profiles.balanced.model).toBe(
+      "accounts/fireworks/models/minimax-m3",
+    );
     // Status is unset by default — must not appear as `undefined`.
     expect("status" in raw.llm.profiles.balanced).toBe(false);
   });
@@ -933,18 +951,20 @@ describe("loadConfig startup behavior", () => {
     expect(raw.llm.profiles.balanced.maxTokens).toBeUndefined();
     expect(raw.llm.profiles.balanced.thinking).toBeUndefined();
 
-    // Next boot, no overlay: content reconciles to the anthropic-managed code
+    // Next boot, no overlay: content reconciles to the fireworks-managed code
     // template; only the overlay-set label is carried across.
     mergeDefaultConfigAndSeedInferenceProfiles();
 
     const afterRestart = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
     expect(afterRestart.llm.activeProfile).toBe("balanced");
-    expect(afterRestart.llm.profiles.balanced.provider).toBe("anthropic");
+    expect(afterRestart.llm.profiles.balanced.provider).toBe("fireworks");
     expect(afterRestart.llm.profiles.balanced.provider_connection).toBe(
-      "anthropic-managed",
+      "fireworks-managed",
     );
-    expect(afterRestart.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
-    expect(afterRestart.llm.profiles.balanced.maxTokens).toBe(16000);
+    expect(afterRestart.llm.profiles.balanced.model).toBe(
+      "accounts/fireworks/models/minimax-m3",
+    );
+    expect(afterRestart.llm.profiles.balanced.maxTokens).toBe(32000);
     expect(afterRestart.llm.profiles.balanced.thinking).toEqual({
       enabled: true,
       streamThinking: true,
@@ -989,7 +1009,9 @@ describe("loadConfig startup behavior", () => {
     // Off-platform hatch: user profiles are active.
     expect(raw.llm.activeProfile).toBe("custom-balanced");
     expect(raw.llm.profiles["custom-balanced"].provider).toBe("anthropic");
-    expect(raw.llm.profiles.balanced.model).toBe("claude-sonnet-4-6");
+    expect(raw.llm.profiles.balanced.model).toBe(
+      "accounts/fireworks/models/minimax-m3",
+    );
   });
 
   test("still quarantines corrupt JSON", () => {
@@ -1133,7 +1155,7 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
 
     expect(raw.llm.activeProfile).toBe("balanced");
     expect(raw.llm.profiles.balanced.provider_connection).toBe(
-      "anthropic-managed",
+      "fireworks-managed",
     );
     expect("status" in raw.llm.profiles.balanced).toBe(false);
     // Connections exist (status is no longer a connection-level concept).

--- a/assistant/src/__tests__/workspace-migration-108-drop-balanced-economy-profile.test.ts
+++ b/assistant/src/__tests__/workspace-migration-108-drop-balanced-economy-profile.test.ts
@@ -121,6 +121,20 @@ describe("108-drop-balanced-economy-profile migration", () => {
     expect(readLlm().activeProfile).toBe("balanced");
   });
 
+  test("repoints advisorProfile from balanced-economy to balanced", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: { ...managedBalanced },
+          "balanced-economy": { ...managedEconomy },
+        },
+        advisorProfile: "balanced-economy",
+      },
+    });
+    dropBalancedEconomyProfileMigration.run(workspaceDir);
+    expect(readLlm().advisorProfile).toBe("balanced");
+  });
+
   test("re-enables a disabled balanced when it becomes the active selection", () => {
     // Supported state: user disabled the old balanced profile while actively
     // using balanced-economy. After consolidation the active selection lands
@@ -223,6 +237,7 @@ describe("108-drop-balanced-economy-profile migration", () => {
         profileOrder: ["auto", "balanced", "balanced-economy"],
         callSites: { memoryRouter: { profile: "balanced-economy" } },
         activeProfile: "balanced-economy",
+        advisorProfile: "balanced-economy",
       },
     };
     writeConfig(original);

--- a/assistant/src/__tests__/workspace-migration-108-drop-balanced-economy-profile.test.ts
+++ b/assistant/src/__tests__/workspace-migration-108-drop-balanced-economy-profile.test.ts
@@ -1,0 +1,270 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { dropBalancedEconomyProfileMigration } from "../workspace/migrations/108-drop-balanced-economy-profile.js";
+
+let workspaceDir: string;
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+function readLlm(): Record<string, unknown> {
+  return readConfig().llm as Record<string, unknown>;
+}
+
+function readProfiles(): Record<string, Record<string, unknown>> {
+  return readLlm().profiles as Record<string, Record<string, unknown>>;
+}
+
+const managedBalanced = {
+  provider: "fireworks",
+  provider_connection: "fireworks-managed",
+  model: "accounts/fireworks/models/minimax-m3",
+  source: "managed",
+  label: "Balanced",
+  description: "Good balance of quality, cost, and speed",
+  maxTokens: 32000,
+};
+
+const managedEconomy = {
+  provider: "fireworks",
+  provider_connection: "fireworks-managed",
+  model: "accounts/fireworks/models/minimax-m3",
+  source: "managed",
+  label: "Balanced Economy",
+  description: "Strong open model (MiniMax M3) at a lower price point",
+  maxTokens: 32000,
+};
+
+beforeEach(() => {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-107-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("108-drop-balanced-economy-profile migration", () => {
+  test("no-op when config.json does not exist", () => {
+    dropBalancedEconomyProfileMigration.run(workspaceDir);
+    expect(existsSync(join(workspaceDir, "config.json"))).toBe(false);
+  });
+
+  test("no-op when config has no llm", () => {
+    const original = { something: "else" };
+    writeConfig(original);
+    dropBalancedEconomyProfileMigration.run(workspaceDir);
+    expect(readConfig()).toEqual(original);
+  });
+
+  test("gracefully handles invalid JSON", () => {
+    writeFileSync(join(workspaceDir, "config.json"), "not-valid-json");
+    dropBalancedEconomyProfileMigration.run(workspaceDir);
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+      "not-valid-json",
+    );
+  });
+
+  test("drops balanced-economy, prunes profileOrder, leaves balanced alone", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: { ...managedBalanced },
+          "balanced-economy": { ...managedEconomy },
+        },
+        profileOrder: ["auto", "balanced", "balanced-economy"],
+        activeProfile: "balanced",
+      },
+    });
+    dropBalancedEconomyProfileMigration.run(workspaceDir);
+
+    const profiles = readProfiles();
+    expect("balanced-economy" in profiles).toBe(false);
+    // The seeder owns balanced's content; the migration must not touch it.
+    expect(profiles.balanced).toEqual(managedBalanced);
+    expect(readLlm().profileOrder).toEqual(["auto", "balanced"]);
+  });
+
+  test("repoints activeProfile from balanced-economy to balanced", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: { ...managedBalanced },
+          "balanced-economy": { ...managedEconomy },
+        },
+        activeProfile: "balanced-economy",
+      },
+    });
+    dropBalancedEconomyProfileMigration.run(workspaceDir);
+    expect(readLlm().activeProfile).toBe("balanced");
+  });
+
+  test("re-enables a disabled balanced when it becomes the active selection", () => {
+    // Supported state: user disabled the old balanced profile while actively
+    // using balanced-economy. After consolidation the active selection lands
+    // on balanced, which must be enabled or the user is left with no route.
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: { ...managedBalanced, status: "disabled" },
+          "balanced-economy": { ...managedEconomy },
+        },
+        activeProfile: "balanced-economy",
+      },
+    });
+    dropBalancedEconomyProfileMigration.run(workspaceDir);
+
+    expect(readLlm().activeProfile).toBe("balanced");
+    expect("status" in readProfiles().balanced!).toBe(false);
+  });
+
+  test("leaves a disabled balanced alone when it was not the active selection", () => {
+    // The user deliberately disabled balanced while active on a different
+    // profile — dropping balanced-economy must not silently re-enable it.
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: { ...managedBalanced, status: "disabled" },
+          quality: { source: "managed", provider: "anthropic", status: "ok" },
+          "balanced-economy": { ...managedEconomy },
+        },
+        activeProfile: "quality",
+      },
+    });
+    dropBalancedEconomyProfileMigration.run(workspaceDir);
+
+    expect(readLlm().activeProfile).toBe("quality");
+    expect(readProfiles().balanced!.status).toBe("disabled");
+  });
+
+  test("repoints call-site profile overrides to balanced", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: { ...managedBalanced },
+          "balanced-economy": { ...managedEconomy },
+        },
+        callSites: {
+          memoryRouter: { profile: "balanced-economy" },
+          replySuggestion: { profile: "cost-optimized" },
+        },
+        activeProfile: "balanced",
+      },
+    });
+    dropBalancedEconomyProfileMigration.run(workspaceDir);
+
+    const callSites = readLlm().callSites as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(callSites.memoryRouter!.profile).toBe("balanced");
+    expect(callSites.replySuggestion!.profile).toBe("cost-optimized");
+  });
+
+  test("repoints mix-profile arms to balanced", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: { ...managedBalanced },
+          "balanced-economy": { ...managedEconomy },
+          "my-mix": {
+            source: "user",
+            mix: [
+              { profile: "balanced-economy", weight: 1 },
+              { profile: "quality-optimized", weight: 1 },
+            ],
+          },
+        },
+        activeProfile: "my-mix",
+      },
+    });
+    dropBalancedEconomyProfileMigration.run(workspaceDir);
+
+    const mix = readProfiles()["my-mix"]!.mix as Array<Record<string, unknown>>;
+    expect(mix[0]!.profile).toBe("balanced");
+    expect(mix[1]!.profile).toBe("quality-optimized");
+  });
+
+  test("leaves a user-owned balanced-economy profile and its references untouched", () => {
+    // The ownership guard covers references too: a user profile sharing the
+    // name keeps its profileOrder slot, active selection, and call-site pins.
+    const original = {
+      llm: {
+        profiles: {
+          balanced: { ...managedBalanced },
+          "balanced-economy": {
+            provider: "fireworks",
+            model: "accounts/fireworks/models/minimax-m3",
+            source: "user",
+          },
+        },
+        profileOrder: ["auto", "balanced", "balanced-economy"],
+        callSites: { memoryRouter: { profile: "balanced-economy" } },
+        activeProfile: "balanced-economy",
+      },
+    };
+    writeConfig(original);
+    dropBalancedEconomyProfileMigration.run(workspaceDir);
+    expect(readConfig()).toEqual(original);
+  });
+
+  test("prunes a dangling balanced-economy reference even when the profile is absent", () => {
+    writeConfig({
+      llm: {
+        profiles: { balanced: { ...managedBalanced } },
+        profileOrder: ["auto", "balanced", "balanced-economy"],
+        callSites: { memoryRouter: { profile: "balanced-economy" } },
+        activeProfile: "balanced-economy",
+      },
+    });
+    dropBalancedEconomyProfileMigration.run(workspaceDir);
+
+    const llm = readLlm();
+    expect(llm.profileOrder).toEqual(["auto", "balanced"]);
+    expect(llm.activeProfile).toBe("balanced");
+    expect(
+      (llm.callSites as Record<string, Record<string, unknown>>).memoryRouter!
+        .profile,
+    ).toBe("balanced");
+  });
+
+  test("idempotency: no-op once balanced-economy is gone (no writes)", () => {
+    writeConfig({
+      llm: {
+        profiles: { balanced: { ...managedBalanced } },
+        profileOrder: ["auto", "balanced"],
+        activeProfile: "balanced",
+      },
+    });
+    const beforeContent = readFileSync(
+      join(workspaceDir, "config.json"),
+      "utf-8",
+    );
+    dropBalancedEconomyProfileMigration.run(workspaceDir);
+    expect(readFileSync(join(workspaceDir, "config.json"), "utf-8")).toBe(
+      beforeContent,
+    );
+  });
+});

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -38,14 +38,16 @@ type ManagedProfileTemplate = Omit<
  * (`preserveProfileNames`) take precedence when present.
  */
 const MANAGED_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
+  // Served by MiniMax M3 on Fireworks via managed platform inference: a strong
+  // open model at a lower price point than the managed Anthropic route.
   balanced: {
     intent: "balanced",
-    provider: "anthropic",
-    connectionName: "anthropic-managed",
+    provider: "fireworks",
+    connectionName: "fireworks-managed",
     source: "managed",
     label: "Balanced",
     description: "Good balance of quality, cost, and speed",
-    maxTokens: 16000,
+    maxTokens: 32000,
     effort: "high",
     thinking: { enabled: true, streamThinking: true },
     contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
@@ -75,20 +77,6 @@ const MANAGED_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
     maxTokens: 8192,
     effort: "low",
     thinking: { enabled: false, streamThinking: false },
-    contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
-  },
-  // Open-weight economy option: MiniMax M3 served by Fireworks via managed
-  // platform inference.
-  "balanced-economy": {
-    intent: "balanced",
-    provider: "fireworks",
-    connectionName: "fireworks-managed",
-    source: "managed",
-    label: "Balanced Economy",
-    description: "Strong open model (MiniMax M3) at a lower price point",
-    maxTokens: 32000,
-    effort: "high",
-    thinking: { enabled: true, streamThinking: true },
     contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
   },
 };
@@ -170,8 +158,8 @@ export type SeedInferenceProfilesOptions = {
  *
  * Runs on every daemon startup. Two responsibilities:
  *
- * 1. **Managed profiles** (`balanced`, `quality-optimized`, `cost-optimized`,
- *    `balanced-economy`): reconciled from the code templates on every boot —
+ * 1. **Managed profiles** (`balanced`, `quality-optimized`,
+ *    `cost-optimized`): reconciled from the code templates on every boot —
  *    on-platform and off-platform alike — so Vellum can push model/config
  *    updates to customers in a release without a workspace migration. The
  *    templates own all profile content; only `label` and `status` are

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -197,6 +197,7 @@ import {
   migrateRenameVerificationSessionIdColumn,
   migrateRenameVerificationTable,
   migrateRenameVoiceToPhone,
+  migrateRewriteBalancedEconomyProfilePins,
   migrateScheduleCapabilities,
   migrateScheduleDefaultNoReuseConversation,
   migrateScheduleDescription,
@@ -529,6 +530,7 @@ export function initializeDb(): void {
     migrateWorkflowJournalLeafTokens,
     migrateDropExternalUserId,
     dropApprovalPromptTsTrackerTable,
+    migrateRewriteBalancedEconomyProfilePins,
   ];
 
   // Run each migration step, catching and logging individual failures so one

--- a/assistant/src/memory/migrations/296-rewrite-balanced-economy-profile-pins.test.ts
+++ b/assistant/src/memory/migrations/296-rewrite-balanced-economy-profile-pins.test.ts
@@ -1,0 +1,69 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import * as schema from "../schema.js";
+import { migrateRewriteBalancedEconomyProfilePins } from "./296-rewrite-balanced-economy-profile-pins.js";
+
+function createTestDb(withColumns = true) {
+  const sqlite = new Database(":memory:");
+  sqlite.exec(/*sql*/ `
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY
+      ${withColumns ? ", inference_profile TEXT" : ""}
+    )
+  `);
+  sqlite.exec(/*sql*/ `
+    CREATE TABLE cron_jobs (
+      id TEXT PRIMARY KEY
+      ${withColumns ? ", inference_profile TEXT" : ""}
+    )
+  `);
+  return { sqlite, db: drizzle(sqlite, { schema }) };
+}
+
+function pin(sqlite: Database, table: string, id: string): string | null {
+  return (
+    sqlite
+      .query(`SELECT inference_profile FROM ${table} WHERE id = ?`)
+      .get(id) as { inference_profile: string | null }
+  ).inference_profile;
+}
+
+describe("migration 296: rewrite balanced-economy profile pins", () => {
+  test("rewrites balanced-economy pins to balanced on conversations and schedules", () => {
+    const { sqlite, db } = createTestDb();
+    sqlite.run(
+      `INSERT INTO conversations (id, inference_profile) VALUES ('c1', 'balanced-economy'), ('c2', 'quality-optimized'), ('c3', NULL)`,
+    );
+    sqlite.run(
+      `INSERT INTO cron_jobs (id, inference_profile) VALUES ('j1', 'balanced-economy'), ('j2', 'balanced')`,
+    );
+
+    migrateRewriteBalancedEconomyProfilePins(db);
+
+    expect(pin(sqlite, "conversations", "c1")).toBe("balanced");
+    // Unrelated pins and NULLs are left untouched.
+    expect(pin(sqlite, "conversations", "c2")).toBe("quality-optimized");
+    expect(pin(sqlite, "conversations", "c3")).toBeNull();
+    expect(pin(sqlite, "cron_jobs", "j1")).toBe("balanced");
+    expect(pin(sqlite, "cron_jobs", "j2")).toBe("balanced");
+  });
+
+  test("is idempotent — re-run is a no-op", () => {
+    const { sqlite, db } = createTestDb();
+    sqlite.run(
+      `INSERT INTO conversations (id, inference_profile) VALUES ('c1', 'balanced-economy')`,
+    );
+
+    migrateRewriteBalancedEconomyProfilePins(db);
+    expect(() => migrateRewriteBalancedEconomyProfilePins(db)).not.toThrow();
+    expect(pin(sqlite, "conversations", "c1")).toBe("balanced");
+  });
+
+  test("skips a table that has no inference_profile column", () => {
+    const { db } = createTestDb(false);
+    expect(() => migrateRewriteBalancedEconomyProfilePins(db)).not.toThrow();
+  });
+});

--- a/assistant/src/memory/migrations/296-rewrite-balanced-economy-profile-pins.test.ts
+++ b/assistant/src/memory/migrations/296-rewrite-balanced-economy-profile-pins.test.ts
@@ -1,10 +1,21 @@
+import { existsSync, rmSync, writeFileSync } from "node:fs";
 import { Database } from "bun:sqlite";
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
+import { getWorkspaceConfigPath } from "../../util/platform.js";
 import * as schema from "../schema.js";
 import { migrateRewriteBalancedEconomyProfilePins } from "./296-rewrite-balanced-economy-profile-pins.js";
+
+function writeWorkspaceConfig(config: Record<string, unknown>): void {
+  writeFileSync(getWorkspaceConfigPath(), JSON.stringify(config));
+}
+
+afterEach(() => {
+  const path = getWorkspaceConfigPath();
+  if (existsSync(path)) rmSync(path);
+});
 
 function createTestDb(withColumns = true) {
   const sqlite = new Database(":memory:");
@@ -65,5 +76,35 @@ describe("migration 296: rewrite balanced-economy profile pins", () => {
   test("skips a table that has no inference_profile column", () => {
     const { db } = createTestDb(false);
     expect(() => migrateRewriteBalancedEconomyProfilePins(db)).not.toThrow();
+  });
+
+  test("leaves pins alone when balanced-economy is a user-owned profile", () => {
+    // The workspace migration keeps a user-owned profile of this name, so its
+    // pins still resolve and must not be switched to balanced.
+    writeWorkspaceConfig({
+      llm: { profiles: { "balanced-economy": { source: "user" } } },
+    });
+    const { sqlite, db } = createTestDb();
+    sqlite.run(
+      `INSERT INTO conversations (id, inference_profile) VALUES ('c1', 'balanced-economy')`,
+    );
+
+    migrateRewriteBalancedEconomyProfilePins(db);
+
+    expect(pin(sqlite, "conversations", "c1")).toBe("balanced-economy");
+  });
+
+  test("rewrites pins when balanced-economy is the managed profile in config", () => {
+    writeWorkspaceConfig({
+      llm: { profiles: { "balanced-economy": { source: "managed" } } },
+    });
+    const { sqlite, db } = createTestDb();
+    sqlite.run(
+      `INSERT INTO conversations (id, inference_profile) VALUES ('c1', 'balanced-economy')`,
+    );
+
+    migrateRewriteBalancedEconomyProfilePins(db);
+
+    expect(pin(sqlite, "conversations", "c1")).toBe("balanced");
   });
 });

--- a/assistant/src/memory/migrations/296-rewrite-balanced-economy-profile-pins.ts
+++ b/assistant/src/memory/migrations/296-rewrite-balanced-economy-profile-pins.ts
@@ -1,0 +1,45 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+
+const OLD_PROFILE = "balanced-economy";
+const NEW_PROFILE = "balanced";
+
+// Active inference-profile pin columns: the per-conversation override and the
+// per-schedule override. Audit/telemetry tables (tool_invocations,
+// llm_usage_events, skill_loaded_events) also carry an `inference_profile`, but
+// those record what actually ran and must keep their historical value.
+const PIN_TABLES = ["conversations", "cron_jobs"] as const;
+
+/**
+ * Rewrite persisted `balanced-economy` inference-profile pins to `balanced`.
+ *
+ * The managed `balanced-economy` profile folds into `balanced` (both resolve to
+ * MiniMax M3 on Fireworks). The workspace-config migration removes the profile
+ * definition, but a profile key can also be pinned outside config.json — on a
+ * conversation (`conversations.inference_profile`) or a schedule
+ * (`cron_jobs.inference_profile`). Left unrewritten those pins dangle, and
+ * `resolveCallSiteConfig` treats an unresolvable override as a silent
+ * fall-through to the active/default profile — dropping the user's intended
+ * MiniMax route. `balanced-economy` is a reserved managed-profile key, so every
+ * persisted pin refers to the now-folded profile.
+ *
+ * Idempotent: the WHERE clause matches nothing once rewritten. The PRAGMA guard
+ * skips a table an install hasn't created the column on yet.
+ */
+export function migrateRewriteBalancedEconomyProfilePins(
+  database: DrizzleDb,
+): void {
+  const raw = getSqliteFrom(database);
+
+  for (const table of PIN_TABLES) {
+    const cols = raw.prepare(`PRAGMA table_info(${table})`).all() as {
+      name: string;
+    }[];
+    if (!cols.some((c) => c.name === "inference_profile")) continue;
+
+    raw
+      .prepare(
+        `UPDATE ${table} SET inference_profile = ? WHERE inference_profile = ?`,
+      )
+      .run(NEW_PROFILE, OLD_PROFILE);
+  }
+}

--- a/assistant/src/memory/migrations/296-rewrite-balanced-economy-profile-pins.ts
+++ b/assistant/src/memory/migrations/296-rewrite-balanced-economy-profile-pins.ts
@@ -1,3 +1,4 @@
+import { loadRawConfig } from "../../config/loader.js";
 import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
 
 const OLD_PROFILE = "balanced-economy";
@@ -22,12 +23,21 @@ const PIN_TABLES = ["conversations", "cron_jobs"] as const;
  * MiniMax route. `balanced-economy` is a reserved managed-profile key, so every
  * persisted pin refers to the now-folded profile.
  *
+ * Ownership guard: the companion workspace migration keeps a `balanced-economy`
+ * profile the user owns (`source !== "managed"`) intact, so its pins still
+ * resolve and must not be touched. Memory migrations run before workspace
+ * migrations on boot, so the profile is still in config here either way; gate on
+ * its source rather than its presence. A reserved managed key (or no profile at
+ * all) means every pin is stale and safe to rewrite.
+ *
  * Idempotent: the WHERE clause matches nothing once rewritten. The PRAGMA guard
  * skips a table an install hasn't created the column on yet.
  */
 export function migrateRewriteBalancedEconomyProfilePins(
   database: DrizzleDb,
 ): void {
+  if (isUserOwnedEconomyProfile()) return;
+
   const raw = getSqliteFrom(database);
 
   for (const table of PIN_TABLES) {
@@ -42,4 +52,17 @@ export function migrateRewriteBalancedEconomyProfilePins(
       )
       .run(NEW_PROFILE, OLD_PROFILE);
   }
+}
+
+/** True when `balanced-economy` exists in config as a user-owned profile. */
+function isUserOwnedEconomyProfile(): boolean {
+  const llm = asObject(loadRawConfig().llm);
+  const profile = asObject(asObject(llm?.profiles)?.[OLD_PROFILE]);
+  return profile !== null && profile.source !== "managed";
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
 }

--- a/assistant/src/memory/migrations/index.ts
+++ b/assistant/src/memory/migrations/index.ts
@@ -287,6 +287,7 @@ export { migrateScheduleDefaultNoReuseConversation } from "./292-schedule-defaul
 export { migrateWorkflowJournalLeafTokens } from "./293-workflow-journal-leaf-tokens.js";
 export { migrateDropExternalUserId } from "./294-drop-external-user-id.js";
 export { dropApprovalPromptTsTrackerTable } from "./295-drop-approval-prompt-ts-tracker.js";
+export { migrateRewriteBalancedEconomyProfilePins } from "./296-rewrite-balanced-economy-profile-pins.js";
 export {
   MIGRATION_REGISTRY,
   type MigrationRegistryEntry,

--- a/assistant/src/workspace/migrations/108-drop-balanced-economy-profile.ts
+++ b/assistant/src/workspace/migrations/108-drop-balanced-economy-profile.ts
@@ -7,10 +7,11 @@ import type { WorkspaceMigration } from "./types.js";
 // MiniMax-M3-on-Fireworks config lives on `balanced`, whose content the seeder
 // reconciles from the templates on every boot; the seeder never deletes a
 // profile, so this migration deletes the managed `balanced-economy` object and
-// repoints every reference to it — its `profileOrder` entry, an `activeProfile`
-// selection, and any call-site `profile` override — onto `balanced`, which
-// resolves to the same MiniMax M3 route. A `balanced-economy` profile that the
-// user owns (`source !== "managed"`) is left fully intact, references included.
+// repoints every reference to it — its `profileOrder` entry, the `activeProfile`
+// and `advisorProfile` selections, call-site `profile` overrides, and mix-profile
+// arms — onto `balanced`, which resolves to the same MiniMax M3 route. A
+// `balanced-economy` profile that the user owns (`source !== "managed"`) is left
+// fully intact, references included.
 
 const ECONOMY = "balanced-economy";
 const REPLACEMENT = "balanced";
@@ -100,6 +101,14 @@ export const dropBalancedEconomyProfileMigration: WorkspaceMigration = {
       if (balanced !== null && balanced.status === "disabled") {
         delete balanced.status;
       }
+    }
+
+    // The advisor selection is the other top-level profile reference
+    // `LLMSchema.superRefine` validates against `llm.profiles`; an unresolvable
+    // value invalidates the config and is stripped at load.
+    if (llm.advisorProfile === ECONOMY) {
+      llm.advisorProfile = REPLACEMENT;
+      changed = true;
     }
 
     if (!changed) return;

--- a/assistant/src/workspace/migrations/108-drop-balanced-economy-profile.ts
+++ b/assistant/src/workspace/migrations/108-drop-balanced-economy-profile.ts
@@ -1,0 +1,120 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { WorkspaceMigration } from "./types.js";
+
+// Reclaim the managed `balanced-economy` inference profile. Its
+// MiniMax-M3-on-Fireworks config lives on `balanced`, whose content the seeder
+// reconciles from the templates on every boot; the seeder never deletes a
+// profile, so this migration deletes the managed `balanced-economy` object and
+// repoints every reference to it — its `profileOrder` entry, an `activeProfile`
+// selection, and any call-site `profile` override — onto `balanced`, which
+// resolves to the same MiniMax M3 route. A `balanced-economy` profile that the
+// user owns (`source !== "managed"`) is left fully intact, references included.
+
+const ECONOMY = "balanced-economy";
+const REPLACEMENT = "balanced";
+
+export const dropBalancedEconomyProfileMigration: WorkspaceMigration = {
+  id: "108-drop-balanced-economy-profile",
+  description:
+    "Remove the managed Balanced Economy profile and repoint its references to Balanced",
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) return;
+
+    let config: Record<string, unknown>;
+    try {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) return;
+      config = raw as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const llm = readObject(config.llm);
+    if (llm === null) return;
+
+    const profiles = readObject(llm.profiles);
+    const economy = profiles !== null ? readObject(profiles[ECONOMY]) : null;
+
+    // A user-owned profile that happens to use this name keeps everything,
+    // references included — only the managed profile is reclaimed.
+    if (economy !== null && economy.source !== "managed") return;
+
+    let changed = false;
+
+    if (economy !== null && profiles !== null) {
+      delete profiles[ECONOMY];
+      changed = true;
+    }
+
+    if (Array.isArray(llm.profileOrder)) {
+      const order = llm.profileOrder as unknown[];
+      const pruned = order.filter((name) => name !== ECONOMY);
+      if (pruned.length !== order.length) {
+        llm.profileOrder = pruned;
+        changed = true;
+      }
+    }
+
+    // Repoint call-site overrides — LLMSchema strips a profile name absent from
+    // `llm.profiles` at load, which would drop the equivalent MiniMax route.
+    const callSites = readObject(llm.callSites);
+    if (callSites !== null) {
+      for (const value of Object.values(callSites)) {
+        const site = readObject(value);
+        if (site !== null && site.profile === ECONOMY) {
+          site.profile = REPLACEMENT;
+          changed = true;
+        }
+      }
+    }
+
+    // Repoint mix-profile arms — LLMSchema.superRefine rejects a mix arm whose
+    // referenced profile is absent, failing config validation at load.
+    if (profiles !== null) {
+      for (const value of Object.values(profiles)) {
+        const entry = readObject(value);
+        if (entry === null || !Array.isArray(entry.mix)) continue;
+        for (const arm of entry.mix) {
+          const armObj = readObject(arm);
+          if (armObj !== null && armObj.profile === ECONOMY) {
+            armObj.profile = REPLACEMENT;
+            changed = true;
+          }
+        }
+      }
+    }
+
+    if (llm.activeProfile === ECONOMY) {
+      llm.activeProfile = REPLACEMENT;
+      changed = true;
+
+      // The replaced selection was an enabled profile, so `balanced` must be
+      // usable: a disabled profile is skipped by the resolver and rejected by
+      // validation. Clearing the status sticks because the seeder preserves
+      // whatever status is on disk.
+      const balanced =
+        profiles !== null ? readObject(profiles[REPLACEMENT]) : null;
+      if (balanced !== null && balanced.status === "disabled") {
+        delete balanced.status;
+      }
+    }
+
+    if (!changed) return;
+
+    config.llm = llm;
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+  },
+  down(_workspaceDir: string): void {
+    // Forward-only.
+  },
+};
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -105,6 +105,7 @@ import { recheckAdaptiveThinkingModelImpliedAnthropicMigration } from "./104-rec
 import { enableMemoryV3LiveForNewWorkspacesMigration } from "./105-enable-memory-v3-live-for-new-workspaces.js";
 import { dropCollectUsageDataMigration } from "./106-drop-collect-usage-data.js";
 import { dropSendDiagnosticsMigration } from "./107-drop-send-diagnostics.js";
+import { dropBalancedEconomyProfileMigration } from "./108-drop-balanced-economy-profile.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -221,4 +222,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   enableMemoryV3LiveForNewWorkspacesMigration,
   dropCollectUsageDataMigration,
   dropSendDiagnosticsMigration,
+  dropBalancedEconomyProfileMigration,
 ];


### PR DESCRIPTION
## Summary
- Repoint the managed `balanced` profile to MiniMax M3 on Fireworks (`fireworks-managed`, 32K max output) — adopting the former `balanced-economy` config — while keeping the "Balanced" label/description per request. Only the technical config (provider, connection, model, maxTokens) swaps.
- Remove `balanced-economy` from the managed profile templates. New installs and reseeded installs no longer get it.
- The seeder reconciles managed profile **content** from the templates on every boot (on-platform and off-platform), so existing `balanced` profiles repoint to MiniMax M3 automatically. The seeder only upserts templates that still exist, so a profile **dropped** from the templates lingers on disk and nothing else prunes it.
- **Workspace migration `107-drop-balanced-economy-profile`** removes the orphaned managed `balanced-economy` and repoints every config reference `LLMSchema.superRefine` validates — `profileOrder`, `activeProfile` (re-enabling `balanced` if it was disabled), call-site `profile` overrides, and mix-profile arms — under an ownership guard that leaves a user-owned profile of the same name fully intact.
- **Memory migration `296-rewrite-balanced-economy-profile-pins`** rewrites profile pins persisted *outside* config.json — the active per-conversation pin (`conversations.inference_profile`) and per-schedule pin (`cron_jobs.inference_profile`) — from `balanced-economy` to `balanced`. Audit/telemetry columns (`tool_invocations`, `llm_usage_events`, `skill_loaded_events`) are deliberately left untouched so historical records keep their value.
- Updates `config-loader-backfill` seed assertions to the new Fireworks/MiniMax-M3 managed balanced; adds migration tests.

## Original prompt
Delete the managed "balanced economy" inference profile and give the managed "balanced" profile the same config it had. The surviving `balanced` keeps its "Balanced" label and "Good balance of quality, cost, and speed" description — only the model/provider/connection/maxTokens swap to MiniMax M3 on Fireworks. The seeder reconciles `balanced`'s content every boot, so the cleanup migrations are scoped to removing the `balanced-economy` profile and repointing every reference to it (config refs + persisted conversation/schedule pins) that the seeder can't.
