### PR TITLE
fix(slack): edit in place on invalid_blocks instead of posting a duplicate reply

### DIFF
--- a/assistant/src/messaging/providers/slack/send.test.ts
+++ b/assistant/src/messaging/providers/slack/send.test.ts
@@ -20,12 +20,19 @@ mock.module("./api.js", () => ({
   callSlackApiForm: async () => ({}),
   completeSlackUpload: async () => {},
   SlackApiError: class SlackApiError extends Error {
-    slackError?: string;
+    readonly slackError: string | undefined;
+
+    constructor(slackError: string | undefined) {
+      super(slackError ?? "unknown");
+      this.slackError = slackError;
+    }
   },
   uploadToSlackUrl: async () => {},
 }));
 
-import { sendSlackAssistantThreadStatus } from "./send.js";
+const { SlackApiError } = await import("./api.js");
+const { sendSlackAssistantThreadStatus, sendSlackReply } =
+  await import("./send.js");
 
 describe("sendSlackAssistantThreadStatus", () => {
   beforeEach(() => {
@@ -72,6 +79,111 @@ describe("sendSlackAssistantThreadStatus", () => {
       channel: "C123",
       name: "eyes",
       timestamp: "1700000000.000100",
+    });
+  });
+});
+
+describe("sendSlackReply update path", () => {
+  const messageTs = "1700000000.000100";
+  const blocks = [
+    { type: "section", text: { type: "mrkdwn", text: "Final reply" } },
+  ];
+
+  beforeEach(() => {
+    callSlackApiMock.mockReset();
+    callSlackApiMock.mockImplementation(async () => ({ ok: true }));
+  });
+
+  test("retries chat.update without blocks on invalid_blocks instead of posting a duplicate", async () => {
+    callSlackApiMock
+      .mockImplementationOnce(async () => {
+        throw new SlackApiError("invalid_blocks");
+      })
+      .mockImplementationOnce(async () => ({ ok: true, ts: messageTs }));
+
+    const result = await sendSlackReply("C123", "Final reply", {
+      messageTs,
+      threadTs: "1700000000.000001",
+      blocks,
+    });
+
+    expect(result).toEqual({ ok: true, ts: messageTs });
+    // Two chat.update calls (with then without blocks); never chat.postMessage,
+    // so the placeholder is edited in place rather than duplicated.
+    expect(callSlackApiMock).toHaveBeenCalledTimes(2);
+    expect(callSlackApiMock).toHaveBeenNthCalledWith(1, "chat.update", {
+      channel: "C123",
+      text: "Final reply",
+      ts: messageTs,
+      blocks,
+    });
+    expect(callSlackApiMock).toHaveBeenNthCalledWith(2, "chat.update", {
+      channel: "C123",
+      text: "Final reply",
+      ts: messageTs,
+    });
+    const postMessageCalls = callSlackApiMock.mock.calls.filter(
+      (call) => call[0] === "chat.postMessage",
+    );
+    expect(postMessageCalls).toHaveLength(0);
+  });
+
+  test("falls back to chat.postMessage only after the no-block update retry also fails", async () => {
+    callSlackApiMock
+      .mockImplementationOnce(async () => {
+        throw new SlackApiError("invalid_blocks");
+      })
+      .mockImplementationOnce(async () => {
+        throw new SlackApiError("message_not_found");
+      })
+      .mockImplementationOnce(async () => ({
+        ok: true,
+        ts: "1700000000.000200",
+      }));
+
+    const result = await sendSlackReply("C123", "Final reply", {
+      messageTs,
+      threadTs: "1700000000.000001",
+      blocks,
+    });
+
+    expect(result).toEqual({ ok: true, ts: "1700000000.000200" });
+    expect(callSlackApiMock).toHaveBeenCalledTimes(3);
+    expect(callSlackApiMock.mock.calls[0]?.[0]).toBe("chat.update");
+    expect(callSlackApiMock.mock.calls[1]?.[0]).toBe("chat.update");
+    // The post fallback drops the rejected blocks.
+    expect(callSlackApiMock).toHaveBeenNthCalledWith(3, "chat.postMessage", {
+      channel: "C123",
+      text: "Final reply",
+      thread_ts: "1700000000.000001",
+    });
+  });
+
+  test("non-invalid_blocks update failure still falls back to chat.postMessage", async () => {
+    callSlackApiMock
+      .mockImplementationOnce(async () => {
+        throw new SlackApiError("internal_error");
+      })
+      .mockImplementationOnce(async () => ({
+        ok: true,
+        ts: "1700000000.000200",
+      }));
+
+    const result = await sendSlackReply("C123", "Final reply", {
+      messageTs,
+      threadTs: "1700000000.000001",
+      blocks,
+    });
+
+    expect(result).toEqual({ ok: true, ts: "1700000000.000200" });
+    // One failed chat.update, then a single chat.postMessage (no extra retry).
+    expect(callSlackApiMock).toHaveBeenCalledTimes(2);
+    expect(callSlackApiMock.mock.calls[0]?.[0]).toBe("chat.update");
+    expect(callSlackApiMock).toHaveBeenNthCalledWith(2, "chat.postMessage", {
+      channel: "C123",
+      text: "Final reply",
+      thread_ts: "1700000000.000001",
+      blocks,
     });
   });
 });

--- a/assistant/src/messaging/providers/slack/send.ts
+++ b/assistant/src/messaging/providers/slack/send.ts
@@ -165,15 +165,38 @@ export async function sendSlackReply(
       );
       return { ok: true, ts: result.ts };
     } catch (err) {
-      if (err instanceof SlackApiError && err.slackError === "invalid_blocks") {
-        log.warn(
-          { chatId, messageTs: options!.messageTs },
-          "chat.update returned invalid_blocks; falling back to chat.postMessage without blocks",
-        );
-        delete slackBody.blocks;
+      if (
+        err instanceof SlackApiError &&
+        err.slackError === "invalid_blocks" &&
+        Array.isArray(updateBody.blocks) &&
+        updateBody.blocks.length > 0
+      ) {
+        // `invalid_blocks` means Slack rejected the Block Kit payload, not the
+        // target message — the message still exists. Retry the update without
+        // blocks so it is edited in place. Posting a fresh message here would
+        // leave the original alongside a duplicate ("ghost") reply.
+        const retryBody: Record<string, unknown> = {
+          channel: chatId,
+          text,
+          ts: options!.messageTs,
+        };
+        try {
+          const retryResult = await callSlackApi("chat.update", retryBody);
+          log.info(
+            { chatId, messageTs: options!.messageTs },
+            "Slack message updated without blocks after invalid_blocks",
+          );
+          return { ok: true, ts: retryResult.ts };
+        } catch (retryErr) {
+          log.warn(
+            { err: retryErr, chatId, messageTs: options!.messageTs },
+            "Slack chat.update without blocks failed, falling back to chat.postMessage",
+          );
+          delete slackBody.blocks;
+        }
       } else {
         log.warn(
-          { chatId, messageTs: options!.messageTs },
+          { err, chatId, messageTs: options!.messageTs },
           "Slack chat.update failed, falling back to chat.postMessage",
         );
       }


### PR DESCRIPTION
## Summary

When the assistant delivers its final reply by **updating the "thinking…" placeholder** message, a `chat.update` rejected with `invalid_blocks` fell through to a fresh `chat.postMessage`. But `invalid_blocks` means Slack rejected the **Block Kit payload**, not that the target message is gone — so the placeholder stayed *and* a second message was posted: a duplicate **"ghost" reply**.

## Fix

In `sendSlackReply`'s update path, on `invalid_blocks` **retry `chat.update` without blocks** so the message is edited in place. Only if that retry also fails (e.g. the target is genuinely gone) do we fall back to `chat.postMessage`. The retry builds a **fresh body** rather than mutating the already-dispatched update payload (avoids aliasing the in-flight request). Non-`invalid_blocks` update failures are unchanged.

```
chat.update(blocks)  ──fails invalid_blocks──▶  chat.update(no blocks)   ◀── edits in place, no duplicate
                                                      │ also fails
                                                      ▼
                                                chat.postMessage (last resort)
```

## Tests

`send.test.ts` — three `sendSlackReply` cases:
- `invalid_blocks` → retries `chat.update` without blocks, **never** calls `chat.postMessage` (no duplicate).
- `invalid_blocks` then the no-block retry also fails → falls back to `chat.postMessage` (blocks dropped).
- a non-`invalid_blocks` update failure → unchanged single `chat.postMessage` fallback.

Local: `bun test send.test.ts` (5/5), `tsc --noEmit`, eslint, prettier all clean.

## Scope (surfaced, not bundled)

This fixes the **deterministic** ghost — the one case where the target message provably still exists. A `chat.update` that fails for a **transient** reason (rate limit, `internal_error`) while the message still exists can still post a duplicate. Eliminating that requires *failing the delivery into the channel retry/dead-letter sweep* instead of posting — a larger reliability change that's the remaining slice of the stale **#33212** ("Slack Messaging Reliability"). Happy to file that as a follow-up ticket.

This lifts the one piece of #33212 that is both still live on `main` and decoupled from the in-flight thread-mode/permissions work, so #33212 can be closed/superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBeXq7TEG2Whk8bZPpwKsP

---
_Generated by [Claude Code](https://claude.ai/code/session_01JBeXq7TEG2Whk8bZPpwKsP)_