### PR TITLE
fix(skills): make catalog.json deterministic by dropping git-date updatedAt

### DIFF
--- a/assistant/src/__tests__/conversation-skill-tools.test.ts
+++ b/assistant/src/__tests__/conversation-skill-tools.test.ts
@@ -30,8 +30,6 @@ let mockVersionHashes: Record<string, string> = {};
 let mockVersionHashErrors: Set<string> = new Set();
 /** Install metadata by skill id (readInstallMeta derives the id from the directory path). */
 let mockInstallMetas: Record<string, SkillInstallMeta | null> = {};
-/** Merged catalog entries returned by getCachedCatalogSync. */
-let mockCachedCatalog: Array<{ id: string; updatedAt?: string }> = [];
 /** skill_loaded events captured by the mocked store. */
 let recordedSkillLoadedEvents: SkillLoadedEventRecord[] = [];
 /** When true, recordSkillLoadedEvent throws (simulates a store failure). */
@@ -249,10 +247,6 @@ mock.module("../skills/install-meta.js", () => ({
     const skillId = parts[parts.length - 1];
     return mockInstallMetas[skillId] ?? null;
   },
-}));
-
-mock.module("../skills/catalog-cache.js", () => ({
-  getCachedCatalogSync: () => mockCachedCatalog,
 }));
 
 mock.module("../memory/skill-loaded-events-store.js", () => ({
@@ -788,17 +782,15 @@ describe("skill_loaded telemetry recording", () => {
     mockVersionHashes = {};
     mockVersionHashErrors = new Set();
     mockInstallMetas = {};
-    mockCachedCatalog = [];
     recordedSkillLoadedEvents = [];
     mockRecordSkillLoadedFailure = false;
     mockRegisterFailures = new Set();
     sessionState = new Map<string, string>();
   });
 
-  test("bundled skill activation records an event with attribution and catalog updatedAt", () => {
+  test("bundled skill activation records an event with attribution", () => {
     mockCatalog = [makeSkill("notes", undefined, "bundled")];
     mockManifests = { notes: makeManifest(["notes_add"]) };
-    mockCachedCatalog = [{ id: "notes", updatedAt: "2026-01-02T03:04:05Z" }];
 
     const history: Message[] = [
       ...skillLoadMessages('<loaded_skill id="notes" />'),
@@ -812,7 +804,7 @@ describe("skill_loaded telemetry recording", () => {
     expect(recordedSkillLoadedEvents[0]).toEqual({
       conversationId: "conv-xyz",
       skillName: "notes",
-      skillUpdatedAt: "2026-01-02T03:04:05Z",
+      skillUpdatedAt: undefined,
       provider: "test-provider",
       model: "test-model",
       inferenceProfile: "balanced",
@@ -990,10 +982,9 @@ describe("skill_loaded telemetry recording", () => {
     expect(mockUnregisteredSkillIds).toEqual([]);
   });
 
-  test("catalog miss yields undefined skillUpdatedAt (persisted as null)", () => {
+  test("skill_updated_at is not populated (reserved field persists as null)", () => {
     mockCatalog = [makeSkill("notes", undefined, "bundled")];
     mockManifests = { notes: makeManifest(["notes_add"]) };
-    mockCachedCatalog = []; // no merged-catalog entry for "notes"
 
     const history: Message[] = [
       ...skillLoadMessages('<loaded_skill id="notes" />'),
@@ -1052,7 +1043,6 @@ describe("skill_loaded telemetry recording", () => {
   test("instruction-only bundled skill (no TOOLS.json) records exactly one event", () => {
     mockCatalog = [makeSkill("guides", undefined, "bundled")];
     // No manifest registered for "guides" — instruction-only skill.
-    mockCachedCatalog = [{ id: "guides", updatedAt: "2026-02-03T04:05:06Z" }];
 
     const history: Message[] = [
       ...skillLoadMessages('<loaded_skill id="guides" />'),
@@ -1066,7 +1056,7 @@ describe("skill_loaded telemetry recording", () => {
     expect(recordedSkillLoadedEvents[0]).toEqual({
       conversationId: "conv-xyz",
       skillName: "guides",
-      skillUpdatedAt: "2026-02-03T04:05:06Z",
+      skillUpdatedAt: undefined,
       provider: "test-provider",
       model: "test-model",
       inferenceProfile: "balanced",

--- a/assistant/src/daemon/conversation-skill-tools.ts
+++ b/assistant/src/daemon/conversation-skill-tools.ts
@@ -20,7 +20,6 @@ import { recordSkillLoadedEvent } from "../memory/skill-loaded-events-store.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
 import type { ActiveSkillEntry } from "../skills/active-skill-tools.js";
 import { deriveActiveSkills } from "../skills/active-skill-tools.js";
-import { getCachedCatalogSync } from "../skills/catalog-cache.js";
 import { readInstallMeta } from "../skills/install-meta.js";
 import { parseToolManifestFile } from "../skills/tool-manifest.js";
 import { computeSkillVersionHash } from "../skills/version-hash.js";
@@ -167,9 +166,13 @@ function isVellumProducedSkill(skill: SkillSummary): boolean {
 /**
  * Record a `skill_loaded` telemetry event for a newly-activated Vellum-produced
  * skill. Metadata only — never skill output or conversation content.
- * `skill_updated_at` comes from the cached merged catalog (sync accessor —
- * this runs on the hot tool-projection path). Failures are swallowed at
- * debug level: recording must never break tool projection.
+ *
+ * `skill_updated_at` is intentionally left unset: the catalog's former per-skill
+ * `updatedAt` was a git commit date (not a function of skill content, and it
+ * drifted on every merge), so it has been dropped. The field is retained as
+ * nullable for telemetry wire compatibility; a real skill-version identity, if
+ * needed, belongs in a separate, platform-coordinated change. Failures are
+ * swallowed at debug level: recording must never break tool projection.
  */
 function recordSkillLoadedTelemetry(
   skill: SkillSummary,
@@ -178,11 +181,9 @@ function recordSkillLoadedTelemetry(
   if (!telemetry) return;
   try {
     if (!isVellumProducedSkill(skill)) return;
-    const catalogEntry = getCachedCatalogSync().find((s) => s.id === skill.id);
     recordSkillLoadedEvent({
       conversationId: telemetry.conversationId,
       skillName: skill.id,
-      skillUpdatedAt: catalogEntry?.updatedAt,
       ...toAttributionColumns(telemetry.attribution),
     });
   } catch (err) {

--- a/assistant/src/memory/skill-loaded-events-store.ts
+++ b/assistant/src/memory/skill-loaded-events-store.ts
@@ -15,7 +15,11 @@ import { skillLoadedEvents } from "./schema.js";
 export interface SkillLoadedEventRecord extends Partial<UsageAttributionColumns> {
   conversationId?: string;
   skillName: string;
-  /** ISO 8601 timestamp from the merged skill catalog, when known. */
+  /**
+   * Reserved skill-version field, currently unset (persists as null). Kept for
+   * telemetry wire compatibility after the catalog's git-date `updatedAt` — the
+   * prior source — was removed.
+   */
   skillUpdatedAt?: string;
 }
 

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -295,8 +295,10 @@ export interface SkillLoadedTelemetryEvent extends ModelTelemetryEventBase {
   type: "skill_loaded";
   skill_name: string;
   /**
-   * ISO 8601 timestamp — the catalog's `updatedAt`, effectively the
-   * skill version. Null when the catalog carries no timestamp.
+   * Reserved skill-version field, currently always null. The catalog's former
+   * git-date `updatedAt` (the prior source) was not a function of skill content
+   * and has been removed; the field is kept (nullable) for telemetry wire
+   * compatibility.
    */
   skill_updated_at: string | null;
   conversation_id: string | null;

--- a/scripts/skills/generate-catalog.mjs
+++ b/scripts/skills/generate-catalog.mjs
@@ -10,7 +10,6 @@
  *   node scripts/skills/generate-catalog.mjs
  */
 
-import { execSync } from "node:child_process";
 import { readdirSync, readFileSync, writeFileSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -20,25 +19,6 @@ import { parseFrontmatter } from "./parse-skill-yaml.mjs";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SKILLS_DIR = resolve(__dirname, "../../skills");
 const CATALOG_PATH = join(SKILLS_DIR, "catalog.json");
-
-/**
- * Get the last git commit date for a directory (ISO 8601).
- * Falls back to null if git is unavailable or the directory has no history.
- */
-function getGitUpdatedAt(dirPath) {
-  try {
-    const date = execSync(
-      `git log -1 --format=%aI -- "${dirPath}"`,
-      { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
-    ).trim();
-    if (!date) return null;
-    // Normalize to canonical ISO 8601 via Date to avoid +00:00 vs Z
-    // discrepancies between git versions / environments.
-    return new Date(date).toISOString();
-  } catch {
-    return null;
-  }
-}
 
 /**
  * Build a catalog entry from a skill directory.
@@ -76,12 +56,6 @@ function buildEntry(skillName) {
   // Extract compatibility
   if (frontmatter.compatibility && typeof frontmatter.compatibility === "string") {
     entry.compatibility = frontmatter.compatibility;
-  }
-
-  // Last modified date from git history
-  const updatedAt = getGitUpdatedAt(skillDir);
-  if (updatedAt) {
-    entry.updatedAt = updatedAt;
   }
 
   return entry;

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -17,8 +17,7 @@
           ]
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "api-mapping",
@@ -32,8 +31,7 @@
           "display-name": "API Mapping"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "assistant-migration",
@@ -59,8 +57,7 @@
           ]
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T21:08:24.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "chatgpt-import",
@@ -73,8 +70,7 @@
           "display-name": "ChatGPT Import"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "cli-discover",
@@ -87,8 +83,7 @@
           "display-name": "CLI Discovery"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "conversation-launcher",
@@ -101,8 +96,7 @@
           "display-name": "Conversation Launcher"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "deploy-fullstack-vercel",
@@ -115,8 +109,7 @@
           "display-name": "Deploy Fullstack to Vercel"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "discord-app-setup",
@@ -130,8 +123,7 @@
           "display-name": "Discord App Setup"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "doordash",
@@ -145,8 +137,7 @@
           "display-name": "DoorDash"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "elevenlabs-voice",
@@ -160,8 +151,7 @@
           "display-name": "ElevenLabs Voice"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T21:08:24.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "email-setup",
@@ -174,8 +164,7 @@
           "display-name": "Email Setup"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "fish-audio",
@@ -188,8 +177,7 @@
           "display-name": "Fish Audio TTS"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T21:08:24.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "frontend-design",
@@ -211,8 +199,7 @@
           ]
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-05T17:22:35.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "geo-audit",
@@ -235,8 +222,7 @@
             "User wants GEO measurement, strategy, or cadence advice rather than a technical site scan — route to geo-operator"
           ]
         }
-      },
-      "updatedAt": "2026-06-10T20:12:38.000Z"
+      }
     },
     {
       "id": "geo-writing",
@@ -253,8 +239,7 @@
           ]
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "gmail",
@@ -269,8 +254,7 @@
           "user-invocable": "true"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-04T21:30:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "google-calendar",
@@ -285,8 +269,7 @@
           "user-invocable": "true"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "guardian-verify-setup",
@@ -307,8 +290,7 @@
           ]
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-13T01:05:59.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "headless-claude-code",
@@ -321,8 +303,7 @@
           "display-name": "Headless Claude Code"
         }
       },
-      "compatibility": "Any environment running Claude Code headlessly",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Any environment running Claude Code headlessly"
     },
     {
       "id": "inbox-cleanup",
@@ -348,8 +329,7 @@
           ]
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-05T23:44:29.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "inbox-management",
@@ -377,8 +357,7 @@
           ]
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "influencer",
@@ -394,8 +373,7 @@
           ]
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "linear-app-setup",
@@ -410,8 +388,7 @@
           "user-invocable": "true"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T21:08:24.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "llm-cost-optimizer",
@@ -423,8 +400,7 @@
           "category": "development",
           "display-name": "LLM Cost Optimizer"
         }
-      },
-      "updatedAt": "2026-06-15T21:08:24.000Z"
+      }
     },
     {
       "id": "macos-automation",
@@ -444,8 +420,7 @@
           ]
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "mailgun-setup",
@@ -460,8 +435,7 @@
           "user-invocable": "true"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "mcp-setup",
@@ -474,8 +448,7 @@
           "display-name": "MCP Setup"
         }
       },
-      "compatibility": "Works on both the Vellum desktop app (local daemon) and the Vellum web app (platform-hosted). Auth flow differs by environment.",
-      "updatedAt": "2026-06-12T18:05:36.000Z"
+      "compatibility": "Works on both the Vellum desktop app (local daemon) and the Vellum web app (platform-hosted). Auth flow differs by environment."
     },
     {
       "id": "meet-join",
@@ -489,8 +462,7 @@
           "display-name": "Meet Join",
           "feature-flag": "meet"
         }
-      },
-      "updatedAt": "2026-06-12T18:05:36.000Z"
+      }
     },
     {
       "id": "meme-generator",
@@ -515,8 +487,7 @@
           ]
         }
       },
-      "compatibility": "Requires curl and python3. Works on macOS and Linux.",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Requires curl and python3. Works on macOS and Linux."
     },
     {
       "id": "notifications",
@@ -529,8 +500,7 @@
           "display-name": "Notifications"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-12T18:05:36.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "notion",
@@ -553,8 +523,7 @@
           ]
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T22:50:32.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "oura",
@@ -570,8 +539,7 @@
           ]
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T21:08:24.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "oura-setup",
@@ -584,8 +552,7 @@
           "display-name": "Oura Ring Setup"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T21:08:24.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "outlook",
@@ -600,8 +567,7 @@
           "user-invocable": "true"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-04T15:23:46.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "outlook-calendar",
@@ -616,8 +582,7 @@
           "user-invocable": "true"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "plugin-builder",
@@ -643,8 +608,7 @@
           ]
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-16T19:50:46.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "public-ingress",
@@ -664,8 +628,7 @@
           ]
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T21:08:24.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "resend-setup",
@@ -679,8 +642,7 @@
           "user-invocable": "true"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "restaurant-reservation",
@@ -696,8 +658,7 @@
           ]
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "screen-recording",
@@ -710,8 +671,7 @@
           "display-name": "Screen Recording"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "self-upgrade",
@@ -724,8 +684,7 @@
           "display-name": "Self Upgrade"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "sentry-app-setup",
@@ -740,8 +699,7 @@
           "user-invocable": "true"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "slack",
@@ -755,8 +713,7 @@
           "display-name": "Slack"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-12T18:05:36.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "slack-app-setup",
@@ -781,8 +738,7 @@
           ]
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T21:08:24.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "start-the-day",
@@ -796,8 +752,7 @@
           "display-name": "Start the Day"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "stripe-app-setup",
@@ -812,8 +767,7 @@
           "user-invocable": "true"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "stripe-link-wallet",
@@ -827,8 +781,7 @@
           "display-name": "Stripe Link Wallet"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "telegram-setup",
@@ -849,8 +802,7 @@
           ]
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T21:08:24.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "time-based-actions",
@@ -863,8 +815,7 @@
           "display-name": "Time-Based Actions"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "twilio-setup",
@@ -881,8 +832,7 @@
           ]
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T21:08:24.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "typescript-eval",
@@ -895,8 +845,7 @@
           "display-name": "TypeScript Evaluation"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "vellum-avatar",
@@ -909,8 +858,7 @@
           "display-name": "Avatar"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "vellum-browser-use",
@@ -926,8 +874,7 @@
           ]
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "vellum-conversation-management",
@@ -940,8 +887,7 @@
           "display-name": "Conversations"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "vellum-github-app-setup",
@@ -957,8 +903,7 @@
           "display-name": "GitHub App Setup"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants. Requires Python 3, bun, and the assistant credentials CLI.",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants. Requires Python 3, bun, and the assistant credentials CLI."
     },
     {
       "id": "vellum-heartbeat",
@@ -977,8 +922,7 @@
           ]
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "vellum-memory-v2-migration",
@@ -1000,8 +944,7 @@
           ]
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "vellum-memory-v3-migration",
@@ -1023,8 +966,7 @@
           ]
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-18T01:04:56.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "vellum-oauth-integrations",
@@ -1037,8 +979,7 @@
           "display-name": "Vellum OAuth Integrations"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T21:08:24.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "vellum-self-knowledge",
@@ -1060,8 +1001,7 @@
           ]
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "vellum-skills-catalog",
@@ -1085,8 +1025,7 @@
           ]
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "vellum-sounds",
@@ -1099,8 +1038,7 @@
           "display-name": "Sounds"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "vellum-terminal-sessions",
@@ -1126,8 +1064,7 @@
           ]
         }
       },
-      "compatibility": "Sandbox mode works without any host dependencies. Host mode requires tmux installed on the user's machine. Works on macOS and Linux.",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Sandbox mode works without any host dependencies. Host mode requires tmux installed on the user's machine. Works on macOS and Linux."
     },
     {
       "id": "vercel-token-setup",
@@ -1144,8 +1081,7 @@
           ]
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T21:08:24.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "voice-setup",
@@ -1169,8 +1105,7 @@
           ]
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T21:08:24.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "watch-together",
@@ -1183,8 +1118,7 @@
           "display-name": "Watch Together",
           "emoji": "📺"
         }
-      },
-      "updatedAt": "2026-06-12T18:05:36.000Z"
+      }
     },
     {
       "id": "watcher",
@@ -1197,8 +1131,7 @@
           "display-name": "Watcher"
         }
       },
-      "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "compatibility": "Designed for Vellum personal assistants"
     },
     {
       "id": "weather",
@@ -1210,8 +1143,7 @@
         "vellum": {
           "category": "productivity"
         }
-      },
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Problem

`Check catalog.json is up to date` fails with **zero skill content changes**. Each entry's `updatedAt` was derived from `git log` author dates — "the last commit that touched the skill's directory" — which **isn't a function of skill content**. The date moves when any later commit brushes the dir or a squash-merge restamps it, so regenerating diverges from the committed file.

**Reproduced against full history** (not a shallow-clone artifact): the `vellum-memory-v3-migration` skill is committed as `2026-06-18T01:04:56` but regenerates to `2026-06-18T03:26:43` — same content, later git timestamp.

Generating in CI doesn't help: `check-catalog` already runs with `fetch-depth: 0` (full history) and still fails, because the value is git-derived, not content-derived.

## Fix (minimal)

Stop deriving a date from git. `generate-catalog.mjs` no longer shells out to git, so `catalog.json` is a pure function of each `SKILL.md`'s frontmatter — **byte-stable** in shallow clones, full clones, and after merges. (`check-catalog.mjs` unchanged.)

`updatedAt`'s only consumer was the `skill_loaded` telemetry event (`skill_updated_at`). Since that value was an unreliable drifting date, it's no longer populated; the nullable field is **retained for wire compatibility**. The event still records skill / conversation / attribution.

A real per-skill version for telemetry, if ever wanted, is a **separate, platform-coordinated change** — and would use the install-metadata-excluding content hash, not a git date.

## Addressing review feedback

An earlier revision recorded a content hash (`computeSkillVersionHash`) into `skill_updated_at`. Two automated reviews correctly flagged that as out-of-scope, and it has been **removed**:
- **Codex** — `computeSkillVersionHash` includes `install-meta.json` (per-install `installedAt`/`installedBy`), so managed skills would report per-install versions. Moot now (no hash recorded).
- **Devin** — putting `v1:<sha>` on the `skill_updated_at` wire field changes a date field's semantics and needs platform coordination. Moot now (the field is left null, unchanged on the wire).

The platform-provided `updatedAt` passthrough in `normalizeCatalogEntry` is left intact (covered by `catalog-install-normalize.test.ts`).

## Files (6)

`scripts/skills/generate-catalog.mjs`, `skills/catalog.json` (regenerated, dates removed), `assistant/src/daemon/conversation-skill-tools.ts` (telemetry no longer reads/records a version), `assistant/src/telemetry/types.ts` + `assistant/src/memory/skill-loaded-events-store.ts` (field doc'd as reserved/null), `assistant/src/__tests__/conversation-skill-tools.test.ts`.

## Verification

`check-catalog` passes; regenerating twice is byte-identical; confirmed against full (unshallowed) history. `conversation-skill-tools.test.ts` 80 pass. `tsc`/eslint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5iT9Uhe91fCcbfm3TU2EQ