### PR TITLE
Split consent version into TOS + privacy, restructure onboarding checkboxes

### DIFF
--- a/clients/web/src/domains/onboarding/components/consent-controls.tsx
+++ b/clients/web/src/domains/onboarding/components/consent-controls.tsx
@@ -1,0 +1,175 @@
+import type { CSSProperties } from "react";
+
+import { SettingRow } from "@/components/setting-row";
+import { legalUrl, routes } from "@/utils/routes";
+import { Card } from "@vellumai/design-library/components/card";
+import { Checkbox } from "@vellumai/design-library/components/checkbox";
+
+/**
+ * Consent controls shared by the onboarding privacy screen and the
+ * review-terms screen so both surfaces present the toggles and legal
+ * agreements identically.
+ *
+ * - `PrivacyPreferencesCard` — the Share Analytics / Share Diagnostics toggles.
+ * - `AgreementsCard`         — the legal consent checkboxes.
+ */
+
+// Consent checkboxes mirror the primary button: the checked fill uses
+// --primary-base and the check uses --content-inset (the on-primary
+// foreground). Unchecked, the design-library default bg/border both resolve to
+// the Card surface and disappear, so a recessed fill + visible border keep the
+// box legible against the card.
+const CONSENT_CHECKBOX_CLASS = [
+  "[&_button[data-state=checked]]:bg-[var(--primary-base)]",
+  "[&_svg]:text-[var(--content-inset)]",
+  "[&_button[data-state=unchecked]]:bg-[var(--surface-base)]",
+  "[&_button[data-state=unchecked]]:border-[var(--border-element)]",
+].join(" ");
+
+const SECTION_LABEL_CLASS =
+  "mb-2.5 ml-1 text-body-small-default font-medium uppercase tracking-wider text-[var(--content-tertiary)]";
+
+const CONSENT_LINKS = {
+  privacy: {
+    href: routes.docs.legal.privacyPolicy,
+    text: "Privacy and AI Data Sharing Policy",
+    aria: "I agree to the Privacy and AI Data Sharing Policy",
+  },
+  tos: {
+    href: routes.docs.legal.termsOfUse,
+    text: "Terms of Service",
+    aria: "I agree to the Terms of Service",
+  },
+} as const;
+
+function ConsentCheckbox({
+  kind,
+  checked,
+  onChange,
+}: {
+  kind: keyof typeof CONSENT_LINKS;
+  checked: boolean;
+  onChange: (next: boolean) => void;
+}) {
+  const link = CONSENT_LINKS[kind];
+  return (
+    <Checkbox
+      checked={checked}
+      onCheckedChange={(next) => onChange(next === true)}
+      label={
+        <span className="text-body-medium-lighter text-[var(--content-default)]">
+          I agree to the{" "}
+          <a
+            href={legalUrl(link.href)}
+            target="_blank"
+            rel="noreferrer"
+            className="underline"
+          >
+            {link.text}
+          </a>
+        </span>
+      }
+      aria-label={link.aria}
+      className={CONSENT_CHECKBOX_CLASS}
+    />
+  );
+}
+
+function Divider() {
+  return <div className="h-px bg-[var(--surface-active)] dark:bg-[var(--surface-lift)]" />;
+}
+
+export function PrivacyPreferencesCard({
+  electron,
+  showAnalytics = true,
+  showDiagnostics = true,
+  shareAnalytics,
+  shareDiagnostics,
+  onShareAnalyticsChange,
+  onShareDiagnosticsChange,
+  className,
+  style,
+}: {
+  electron: boolean;
+  showAnalytics?: boolean;
+  showDiagnostics?: boolean;
+  shareAnalytics: boolean;
+  shareDiagnostics: boolean;
+  onShareAnalyticsChange: (next: boolean) => void;
+  onShareDiagnosticsChange: (next: boolean) => void;
+  className?: string;
+  style?: CSSProperties;
+}) {
+  return (
+    <section className={className} style={style}>
+      <p className={SECTION_LABEL_CLASS}>Privacy preferences</p>
+      <Card padding={electron ? "sm" : "md"} className="w-full">
+        <div className={`flex flex-col ${electron ? "gap-3" : "gap-4"}`}>
+          {showAnalytics && (
+            <SettingRow
+              label="Share Analytics"
+              helperText="Send anonymous product usage data."
+              checked={shareAnalytics}
+              onChange={onShareAnalyticsChange}
+            />
+          )}
+          {showAnalytics && showDiagnostics && <Divider />}
+          {showDiagnostics && (
+            <SettingRow
+              label="Share Diagnostics"
+              helperText="Send crash reports and performance metrics."
+              checked={shareDiagnostics}
+              onChange={onShareDiagnosticsChange}
+            />
+          )}
+        </div>
+      </Card>
+    </section>
+  );
+}
+
+export function AgreementsCard({
+  electron,
+  showPrivacy = true,
+  showTos = true,
+  privacyConsent,
+  tosAccepted,
+  onPrivacyChange,
+  onTosChange,
+  className,
+  style,
+}: {
+  electron: boolean;
+  showPrivacy?: boolean;
+  showTos?: boolean;
+  privacyConsent: boolean;
+  tosAccepted: boolean;
+  onPrivacyChange: (next: boolean) => void;
+  onTosChange: (next: boolean) => void;
+  className?: string;
+  style?: CSSProperties;
+}) {
+  return (
+    <section className={className} style={style}>
+      <p className={SECTION_LABEL_CLASS}>Agreements</p>
+      <Card padding={electron ? "sm" : "md"} className="w-full">
+        <div className={`flex flex-col ${electron ? "gap-3.5" : "gap-4"}`}>
+          {showPrivacy && (
+            <ConsentCheckbox
+              kind="privacy"
+              checked={privacyConsent}
+              onChange={onPrivacyChange}
+            />
+          )}
+          {showTos && (
+            <ConsentCheckbox
+              kind="tos"
+              checked={tosAccepted}
+              onChange={onTosChange}
+            />
+          )}
+        </div>
+      </Card>
+    </section>
+  );
+}

--- a/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
+++ b/clients/web/src/domains/onboarding/onboarding-lifecycle-sync.test.tsx
@@ -171,7 +171,7 @@ mock.module("@sentry/react", () => ({
 }));
 
 mock.module("@/domains/onboarding/prefs", () => ({
-  readAiDataConsent: () => true,
+  readPrivacyConsent: () => true,
   readSelectedVersion: () => null,
   readShareAnalytics: () => true,
   readTosAccepted: () => true,
@@ -195,7 +195,7 @@ mock.module("@/lib/navigation/build-state", () => ({
     isAuthenticated: true,
     platformSession: platformSessionValue,
     tosAccepted: true,
-    aiDataConsent: true,
+    privacyConsent: true,
     ...overrides,
   }),
 }));

--- a/clients/web/src/domains/onboarding/onboarding-store.ts
+++ b/clients/web/src/domains/onboarding/onboarding-store.ts
@@ -5,7 +5,7 @@
  * written to `device:` localStorage keys on every setter call and synced
  * across tabs via `watchSetting`. They survive logout.
  *
- * **In-memory-only fields** (`tosAccepted`, `aiDataConsent`,
+ * **In-memory-only fields** (`tosAccepted`, `privacyConsent`,
  * `analyticsConsentCurrent`, `diagnosticsConsentCurrent`) start `false` and
  * are populated on session sync (e.g. `restoreConsentForUser`, called from
  * the auth store once the user id is known). Persistence to durable per-user
@@ -41,7 +41,7 @@ export interface OnboardingState {
   shareAnalytics: boolean;
   shareDiagnostics: boolean;
   tosAccepted: boolean;
-  aiDataConsent: boolean;
+  privacyConsent: boolean;
   analyticsConsentCurrent: boolean;
   diagnosticsConsentCurrent: boolean;
 }
@@ -50,7 +50,7 @@ export interface OnboardingActions {
   setShareAnalytics: (value: boolean) => void;
   setShareDiagnostics: (value: boolean) => void;
   setTosAccepted: (value: boolean) => void;
-  setAiDataConsent: (value: boolean) => void;
+  setPrivacyConsent: (value: boolean) => void;
   setAnalyticsConsentCurrent: (value: boolean) => void;
   setDiagnosticsConsentCurrent: (value: boolean) => void;
 }
@@ -65,7 +65,7 @@ const useOnboardingStoreBase = create<OnboardingStore>()((set) => ({
   shareAnalytics: getLocalBool(KEY_SHARE_ANALYTICS, true),
   shareDiagnostics: getLocalBool(KEY_SHARE_DIAGNOSTICS, true),
   tosAccepted: false,
-  aiDataConsent: false,
+  privacyConsent: false,
   analyticsConsentCurrent: false,
   diagnosticsConsentCurrent: false,
 
@@ -81,8 +81,8 @@ const useOnboardingStoreBase = create<OnboardingStore>()((set) => ({
   setTosAccepted: (value) => {
     set({ tosAccepted: value });
   },
-  setAiDataConsent: (value) => {
-    set({ aiDataConsent: value });
+  setPrivacyConsent: (value) => {
+    set({ privacyConsent: value });
   },
   setAnalyticsConsentCurrent: (value) => {
     set({ analyticsConsentCurrent: value });

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
@@ -15,12 +15,12 @@ mock.module("react-router", () => ({
 const setShareAnalytics = mock((_next: boolean) => {});
 const setShareDiagnostics = mock((_next: boolean) => {});
 const setTosAccepted = mock((_next: boolean) => {});
-const setAiDataConsent = mock((_next: boolean) => {});
+const setPrivacyConsent = mock((_next: boolean) => {});
 mock.module("@/domains/onboarding/prefs", () => ({
   useShareAnalytics: () => [false, setShareAnalytics],
   useShareDiagnostics: () => [false, setShareDiagnostics],
   useTosAccepted: () => [true, setTosAccepted],
-  useAiDataConsent: () => [true, setAiDataConsent],
+  usePrivacyConsent: () => [true, setPrivacyConsent],
   useAnalyticsConsentCurrent: () => [true, mock(() => {})],
   useDiagnosticsConsentCurrent: () => [true, mock(() => {})],
 }));

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -1,8 +1,10 @@
-import { EyeOff } from "lucide-react";
-import { useCallback, useEffect, type ReactNode } from "react";
+import { useCallback, useEffect } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
-import { SettingRow } from "@/components/setting-row";
+import {
+    AgreementsCard,
+    PrivacyPreferencesCard,
+} from "@/domains/onboarding/components/consent-controls";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
 import { StepIndicatorDots } from "@/domains/onboarding/components/step-indicator-dots";
 import {
@@ -13,7 +15,7 @@ import {
     resolveOnboardingFunnelVariant,
 } from "@/domains/onboarding/funnel-events";
 import {
-    useAiDataConsent,
+    usePrivacyConsent,
     useShareAnalytics,
     useShareDiagnostics,
     useTosAccepted,
@@ -23,18 +25,8 @@ import { useIsNativePlatform } from "@/runtime/native-auth";
 import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { saveConsent } from "@/utils/onboarding-cleanup";
-import { legalUrl, routes } from "@/utils/routes";
+import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
-import { Card } from "@vellumai/design-library/components/card";
-import { Checkbox } from "@vellumai/design-library/components/checkbox";
-
-// Consent checkboxes mirror the primary button: the checked fill uses
-// --primary-base and the check uses --content-inset (the on-primary
-// foreground). This stays correct in every theme — dark fill + white check in
-// light mode, white fill + dark check in dark mode — whereas the design
-// library's hardcoded white check vanishes on the near-white dark-mode fill.
-const CONSENT_CHECKBOX_CLASS =
-  "[&_button[data-state=checked]]:bg-[var(--primary-base)] [&_svg]:text-[var(--content-inset)]";
 
 export function PrivacyScreen() {
   const navigate = useNavigate();
@@ -49,7 +41,7 @@ export function PrivacyScreen() {
   const [shareAnalytics, setShareAnalyticsReal] = useShareAnalytics();
   const [shareDiagnostics, setShareDiagnosticsReal] = useShareDiagnostics();
   const [tosAccepted, setTosAcceptedReal] = useTosAccepted();
-  const [aiDataConsent, setAiDataConsentReal] = useAiDataConsent();
+  const [privacyConsent, setPrivacyConsentReal] = usePrivacyConsent();
   const hasPlatformSession = useHasPlatformSession();
 
   useEffect(() => {
@@ -63,7 +55,7 @@ export function PrivacyScreen() {
   const setShareAnalytics = isPreview ? noop : setShareAnalyticsReal;
   const setShareDiagnostics = isPreview ? noop : setShareDiagnosticsReal;
   const setTosAccepted = isPreview ? noop : setTosAcceptedReal;
-  const setAiDataConsent = isPreview ? noop : setAiDataConsentReal;
+  const setPrivacyConsent = isPreview ? noop : setPrivacyConsentReal;
 
   const onStart = useCallback(() => {
     if (isPreview) {
@@ -75,7 +67,7 @@ export function PrivacyScreen() {
       return;
     }
 
-    saveConsent({ userId, tos: tosAccepted, ai: aiDataConsent, shareAnalytics, shareDiagnostics, hasPlatformSession });
+    saveConsent({ userId, tos: tosAccepted, privacy: privacyConsent, shareAnalytics, shareDiagnostics, hasPlatformSession });
     if (!isNative) {
       const variant = resolveOnboardingFunnelVariant(preferredFunnelVariant);
       emitOnboardingFunnelStepCompleted(ONBOARDING_FUNNEL_STEPS.privacyTos, {
@@ -90,7 +82,7 @@ export function PrivacyScreen() {
     const qs = params.toString();
     void navigate(`${routes.onboarding.hatching}${qs ? `?${qs}` : ""}`);
   }, [
-    aiDataConsent,
+    privacyConsent,
     hasPlatformSession,
     isNative,
     isPreview,
@@ -102,43 +94,6 @@ export function PrivacyScreen() {
     tosAccepted,
     userId,
   ]);
-
-  const tosLabel: ReactNode = (
-    <span className="text-body-medium-lighter text-[var(--content-default)]">
-      I agree to the{" "}
-      <a
-        href={legalUrl(routes.docs.legal.termsOfUse)}
-        target="_blank"
-        rel="noreferrer"
-        className="underline"
-      >
-        Terms of Service
-      </a>{" "}
-      and{" "}
-      <a
-        href={legalUrl(routes.docs.legal.privacyPolicy)}
-        target="_blank"
-        rel="noreferrer"
-        className="underline"
-      >
-        Privacy Policy
-      </a>
-    </span>
-  );
-
-  const aiConsentLabel: ReactNode = (
-    <span className="text-body-medium-lighter text-[var(--content-default)]">
-      I agree to the{" "}
-      <a
-        href={legalUrl(routes.docs.legal.dataSharing)}
-        target="_blank"
-        rel="noreferrer"
-        className="underline"
-      >
-        AI Data Sharing Policy
-      </a>
-    </span>
-  );
 
   return (
     <OnboardingLayout>
@@ -167,58 +122,25 @@ export function PrivacyScreen() {
           Settings.
         </p>
 
-        <Card
-          padding={electron ? "sm" : "md"}
+        <PrivacyPreferencesCard
+          electron={electron}
+          shareAnalytics={shareAnalytics}
+          shareDiagnostics={shareDiagnostics}
+          onShareAnalyticsChange={setShareAnalytics}
+          onShareDiagnosticsChange={setShareDiagnostics}
           className="mt-8 w-full"
           style={{ animation: "fadeInUp 0.5s ease-out 0.4s both" }}
-        >
-          <div className={`flex flex-col ${electron ? "gap-3" : "gap-4"}`}>
-            <SettingRow
-              label="Share Analytics"
-              helperText="Send anonymous product usage data."
-              checked={shareAnalytics}
-              onChange={setShareAnalytics}
-            />
-            <div className="h-px bg-[var(--surface-active)] dark:bg-[var(--surface-lift)]" />
-            <SettingRow
-              label="Share Diagnostics"
-              helperText="Send crash reports and performance metrics."
-              checked={shareDiagnostics}
-              onChange={setShareDiagnostics}
-            />
-            <div className="h-px bg-[var(--surface-active)] dark:bg-[var(--surface-lift)]" />
-            <div className="flex items-center gap-2 text-body-small-default text-[var(--content-tertiary)]">
-              <EyeOff className="h-4 w-4 shrink-0" />
-              <span>Your conversations and personal data are never included.</span>
-            </div>
-          </div>
-        </Card>
+        />
 
-        <div
-          className={`flex w-full items-start ${electron ? "mt-4" : "mt-6"}`}
-          style={{ animation: "fadeInUp 0.5s ease-out 0.45s both" }}
-        >
-          <Checkbox
-            checked={aiDataConsent}
-            onCheckedChange={(next) => setAiDataConsent(next === true)}
-            label={aiConsentLabel}
-            aria-label="I agree to the AI Data Sharing Policy"
-            className={CONSENT_CHECKBOX_CLASS}
-          />
-        </div>
-
-        <div
-          className={`flex w-full items-start ${electron ? "mt-2" : "mt-4"}`}
+        <AgreementsCard
+          electron={electron}
+          privacyConsent={privacyConsent}
+          tosAccepted={tosAccepted}
+          onPrivacyChange={setPrivacyConsent}
+          onTosChange={setTosAccepted}
+          className="mt-6 w-full"
           style={{ animation: "fadeInUp 0.5s ease-out 0.5s both" }}
-        >
-          <Checkbox
-            checked={tosAccepted}
-            onCheckedChange={(next) => setTosAccepted(next === true)}
-            label={tosLabel}
-            aria-label="I agree to the Terms of Service and Privacy Policy"
-            className={CONSENT_CHECKBOX_CLASS}
-          />
-        </div>
+        />
 
         <div
           className={`mt-8 flex w-full flex-col ${electron ? "gap-2.5" : "gap-2"}`}
@@ -228,7 +150,7 @@ export function PrivacyScreen() {
             variant="primary"
             size="regular"
             fullWidth
-            disabled={!tosAccepted || !aiDataConsent}
+            disabled={!tosAccepted || !privacyConsent}
             onClick={onStart}
             className={electron ? undefined : "h-11 text-base"}
           >

--- a/clients/web/src/domains/onboarding/pages/review-terms-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/review-terms-screen.test.tsx
@@ -11,7 +11,7 @@ mock.module("react-router", () => ({
 
 // Prefs hooks — mutable per-test so we can model each staleness combination.
 let tosAccepted = true;
-let aiDataConsent = true;
+let privacyConsent = true;
 let shareAnalytics = true;
 let shareDiagnostics = true;
 let analyticsConsentCurrent = true;
@@ -19,8 +19,8 @@ let diagnosticsConsentCurrent = true;
 const setTosAccepted = mock((next: boolean) => {
   tosAccepted = next;
 });
-const setAiDataConsent = mock((next: boolean) => {
-  aiDataConsent = next;
+const setPrivacyConsent = mock((next: boolean) => {
+  privacyConsent = next;
 });
 const setShareAnalytics = mock((next: boolean) => {
   shareAnalytics = next;
@@ -30,7 +30,7 @@ const setShareDiagnostics = mock((next: boolean) => {
 });
 mock.module("@/domains/onboarding/prefs", () => ({
   useTosAccepted: () => [tosAccepted, setTosAccepted],
-  useAiDataConsent: () => [aiDataConsent, setAiDataConsent],
+  usePrivacyConsent: () => [privacyConsent, setPrivacyConsent],
   useShareAnalytics: () => [shareAnalytics, setShareAnalytics],
   useShareDiagnostics: () => [shareDiagnostics, setShareDiagnostics],
   useAnalyticsConsentCurrent: () => [analyticsConsentCurrent, mock(() => {})],
@@ -112,8 +112,8 @@ const { ReviewTermsScreen } = await import(
   "@/domains/onboarding/pages/review-terms-screen"
 );
 
-const TOS_LABEL = "I agree to the Terms of Service and Privacy Policy";
-const AI_LABEL = "I agree to the AI Data Sharing Policy";
+const TOS_LABEL = "I agree to the Terms of Service";
+const AI_LABEL = "I agree to the Privacy and AI Data Sharing Policy";
 
 function continueButton(): HTMLButtonElement {
   return screen.getByText("Continue") as HTMLButtonElement;
@@ -126,13 +126,30 @@ describe("ReviewTermsScreen", () => {
     setShareAnalytics.mockClear();
     searchParamsValue = new URLSearchParams();
     tosAccepted = true;
-    aiDataConsent = true;
+    privacyConsent = true;
     shareAnalytics = true;
     shareDiagnostics = true;
     analyticsConsentCurrent = true;
     diagnosticsConsentCurrent = true;
   });
   afterEach(cleanup);
+
+  test("nothing stale (direct navigation) renders all sections and enables Continue", () => {
+    // All consent current — e.g. the user typed /assistant/review-terms directly.
+    render(<ReviewTermsScreen />);
+
+    // Every section is shown rather than an empty page.
+    expect(screen.getByLabelText(TOS_LABEL)).toBeTruthy();
+    expect(screen.getByLabelText(AI_LABEL)).toBeTruthy();
+    expect(screen.getAllByRole("switch").length).toBe(2);
+    // Copy is the neutral review variant, not the "we've updated" wording.
+    expect(screen.getByText("Terms & privacy")).toBeTruthy();
+    expect(
+      screen.getByText("Review your terms and privacy preferences anytime."),
+    ).toBeTruthy();
+    // Already-accepted consent means Continue is enabled immediately.
+    expect(continueButton().disabled).toBe(false);
+  });
 
   test("toggle-only staleness renders the toggle, no legal checkboxes, and Continue enabled", () => {
     analyticsConsentCurrent = false; // analytics stale; tos/ai current
@@ -185,17 +202,17 @@ describe("ReviewTermsScreen", () => {
     expect(continueButton().disabled).toBe(false);
   });
 
-  test("heading stays on 'Updated Terms' after the last legal box is checked", () => {
-    tosAccepted = false; // tos stale -> "Updated Terms" heading
+  test("heading stays on 'Updated terms' after the last legal box is checked", () => {
+    tosAccepted = false; // tos stale -> "Updated terms" heading
     const { rerender } = render(<ReviewTermsScreen />);
 
-    expect(screen.getByText("Updated Terms")).toBeTruthy();
+    expect(screen.getByText("Updated terms")).toBeTruthy();
 
     fireEvent.click(screen.getByLabelText(TOS_LABEL));
     rerender(<ReviewTermsScreen />);
 
     // Heading must not flip mid-flow once the box is checked.
-    expect(screen.getByText("Updated Terms")).toBeTruthy();
+    expect(screen.getByText("Updated terms")).toBeTruthy();
     expect(screen.queryByText("Review your privacy preferences")).toBeNull();
   });
 });

--- a/clients/web/src/domains/onboarding/pages/review-terms-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/review-terms-screen.tsx
@@ -1,12 +1,16 @@
-import { useCallback, useState, type ReactNode } from "react";
+import { ShieldCheck } from "lucide-react";
+import { useCallback, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
-import { SettingRow } from "@/components/setting-row";
+import {
+    AgreementsCard,
+    PrivacyPreferencesCard,
+} from "@/domains/onboarding/components/consent-controls";
 import { OnboardingLayout } from "@/domains/onboarding/components/onboarding-layout";
 import {
-    useAiDataConsent,
     useAnalyticsConsentCurrent,
     useDiagnosticsConsentCurrent,
+    usePrivacyConsent,
     useShareAnalytics,
     useShareDiagnostics,
     useTosAccepted,
@@ -16,12 +20,8 @@ import { isElectron } from "@/runtime/is-electron";
 import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
 import { saveConsent } from "@/utils/onboarding-cleanup";
 import { sanitizeReturnTo } from "@/utils/return-to";
-import { legalUrl, routes } from "@/utils/routes";
+import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
-import { Checkbox } from "@vellumai/design-library/components/checkbox";
-
-const CONSENT_CHECKBOX_CLASS =
-  "[&_button[data-state=checked]]:bg-[var(--primary-base)] [&_svg]:text-[var(--content-inset)]";
 
 export function ReviewTermsScreen() {
   const navigate = useNavigate();
@@ -32,7 +32,7 @@ export function ReviewTermsScreen() {
   const hasPlatformSession = useHasPlatformSession();
 
   const [tosAccepted, setTosAccepted] = useTosAccepted();
-  const [aiDataConsent, setAiDataConsent] = useAiDataConsent();
+  const [privacyConsent, setPrivacyConsent] = usePrivacyConsent();
   const [shareAnalytics, setShareAnalytics] = useShareAnalytics();
   const [shareDiagnostics, setShareDiagnostics] = useShareDiagnostics();
   const [analyticsConsentCurrent] = useAnalyticsConsentCurrent();
@@ -42,18 +42,43 @@ export function ReviewTermsScreen() {
   // here to address. Gating render on live values would unmount a checkbox the
   // instant it's checked, so the user never sees the checked state.
   const [tosStaleAtMount] = useState(() => !tosAccepted);
-  const [aiStaleAtMount] = useState(() => !aiDataConsent);
+  const [privacyStaleAtMount] = useState(() => !privacyConsent);
   const [analyticsStaleAtMount] = useState(() => !analyticsConsentCurrent);
   const [diagnosticsStaleAtMount] = useState(() => !diagnosticsConsentCurrent);
-  const onlyTogglesStaleAtMount = !tosStaleAtMount && !aiStaleAtMount;
+
+  // Direct navigation to this route with everything already current would
+  // otherwise render an empty page. Treat that as a full review surface: show
+  // every section so the page is meaningful and re-confirmable.
+  const nothingStaleAtMount =
+    !tosStaleAtMount &&
+    !privacyStaleAtMount &&
+    !analyticsStaleAtMount &&
+    !diagnosticsStaleAtMount;
+  const showTos = tosStaleAtMount || nothingStaleAtMount;
+  const showPrivacy = privacyStaleAtMount || nothingStaleAtMount;
+  const showAnalytics = analyticsStaleAtMount || nothingStaleAtMount;
+  const showDiagnostics = diagnosticsStaleAtMount || nothingStaleAtMount;
+  const onlyTogglesStaleAtMount =
+    !nothingStaleAtMount && !tosStaleAtMount && !privacyStaleAtMount;
+
+  const heading = nothingStaleAtMount
+    ? "Terms & privacy"
+    : onlyTogglesStaleAtMount
+      ? "Review your privacy preferences"
+      : "Updated terms";
+  const subheading = nothingStaleAtMount
+    ? "Review your terms and privacy preferences anytime."
+    : onlyTogglesStaleAtMount
+      ? "Confirm your privacy preferences to continue."
+      : "We've updated our terms. Please review and accept to continue.";
 
   const onContinue = useCallback(() => {
-    saveConsent({ userId, tos: tosAccepted, ai: aiDataConsent, shareAnalytics, shareDiagnostics, hasPlatformSession });
+    saveConsent({ userId, tos: tosAccepted, privacy: privacyConsent, shareAnalytics, shareDiagnostics, hasPlatformSession });
 
     const destination = sanitizeReturnTo(searchParams.get("returnTo"), routes.assistant);
     void navigate(destination, { replace: true });
   }, [
-    aiDataConsent,
+    privacyConsent,
     hasPlatformSession,
     navigate,
     searchParams,
@@ -68,125 +93,69 @@ export function ReviewTermsScreen() {
     hardNavigate(routes.account.login);
   }, [logout]);
 
-  const tosLabel: ReactNode = (
-    <span className="text-body-medium-lighter text-[var(--content-default)]">
-      I agree to the{" "}
-      <a
-        href={legalUrl(routes.docs.legal.termsOfUse)}
-        target="_blank"
-        rel="noreferrer"
-        className="underline"
-      >
-        Terms of Service
-      </a>{" "}
-      and{" "}
-      <a
-        href={legalUrl(routes.docs.legal.privacyPolicy)}
-        target="_blank"
-        rel="noreferrer"
-        className="underline"
-      >
-        Privacy Policy
-      </a>
-    </span>
-  );
-
-  const aiConsentLabel: ReactNode = (
-    <span className="text-body-medium-lighter text-[var(--content-default)]">
-      I agree to the{" "}
-      <a
-        href={legalUrl(routes.docs.legal.dataSharing)}
-        target="_blank"
-        rel="noreferrer"
-        className="underline"
-      >
-        AI Data Sharing Policy
-      </a>
-    </span>
-  );
-
   // Only the legal checkboxes shown at mount gate Continue, driven by their
   // live checked values. Toggles never block — off is a valid choice.
   const continueDisabled =
-    (tosStaleAtMount && !tosAccepted) || (aiStaleAtMount && !aiDataConsent);
+    (showTos && !tosAccepted) || (showPrivacy && !privacyConsent);
 
   return (
     <OnboardingLayout showCreatureFooter={false}>
       <div
         className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-21 pb-4 electron-prechat-type" : "px-6 py-16"} text-[var(--content-default)]`}
       >
-        <h1
-          className={electron ? "text-title-large" : "text-3xl font-semibold tracking-tight"}
-          style={{ animation: "fadeInUp 0.5s ease-out 0.1s both" }}
+        <div
+          className="flex h-12 w-12 items-center justify-center rounded-full border border-[var(--border-subtle)] bg-[var(--surface-lift)]"
+          style={{ animation: "fadeInUp 0.5s ease-out 0.05s both" }}
         >
-          {onlyTogglesStaleAtMount ? "Review your privacy preferences" : "Updated Terms"}
+          <ShieldCheck
+            className="h-6 w-6 text-[var(--content-secondary)]"
+            strokeWidth={1.75}
+          />
+        </div>
+        <h1
+          className={`mt-5 ${electron ? "text-title-large" : "text-3xl font-semibold tracking-tight"}`}
+          style={{ animation: "fadeInUp 0.5s ease-out 0.12s both" }}
+        >
+          {heading}
         </h1>
         <p
-          className={`text-center text-body-medium-lighter text-[var(--content-tertiary)] ${electron ? "mt-3.5" : "mt-4"}`}
-          style={{ animation: "fadeInUp 0.5s ease-out 0.3s both" }}
+          className={`text-center text-body-medium-lighter text-[var(--content-tertiary)] ${electron ? "mt-3" : "mt-3.5"}`}
+          style={{ animation: "fadeInUp 0.5s ease-out 0.2s both" }}
         >
-          {onlyTogglesStaleAtMount
-            ? "We've updated our privacy preferences. Please review them to continue."
-            : "We've updated our terms. Please review and re-accept to continue."}
+          {subheading}
         </p>
 
-        {(analyticsStaleAtMount || diagnosticsStaleAtMount) && (
-          <div
-            className="mt-8 flex w-full flex-col gap-4"
-            style={{ animation: "fadeInUp 0.5s ease-out 0.4s both" }}
-          >
-            {analyticsStaleAtMount && (
-              <SettingRow
-                label="Share Analytics"
-                helperText="Send anonymous product usage data."
-                checked={shareAnalytics}
-                onChange={setShareAnalytics}
-              />
-            )}
-            {diagnosticsStaleAtMount && (
-              <SettingRow
-                label="Share Diagnostics"
-                helperText="Send crash reports and performance metrics."
-                checked={shareDiagnostics}
-                onChange={setShareDiagnostics}
-              />
-            )}
-          </div>
+        {(showAnalytics || showDiagnostics) && (
+          <PrivacyPreferencesCard
+            electron={electron}
+            showAnalytics={showAnalytics}
+            showDiagnostics={showDiagnostics}
+            shareAnalytics={shareAnalytics}
+            shareDiagnostics={shareDiagnostics}
+            onShareAnalyticsChange={setShareAnalytics}
+            onShareDiagnosticsChange={setShareDiagnostics}
+            className="mt-9 w-full"
+            style={{ animation: "fadeInUp 0.5s ease-out 0.28s both" }}
+          />
         )}
 
-        {aiStaleAtMount && (
-          <div
-            className="mt-8 flex w-full items-start"
-            style={{ animation: "fadeInUp 0.5s ease-out 0.45s both" }}
-          >
-            <Checkbox
-              checked={aiDataConsent}
-              onCheckedChange={(next) => setAiDataConsent(next === true)}
-              label={aiConsentLabel}
-              aria-label="I agree to the AI Data Sharing Policy"
-              className={CONSENT_CHECKBOX_CLASS}
-            />
-          </div>
-        )}
-
-        {tosStaleAtMount && (
-          <div
-            className={`flex w-full items-start ${electron ? "mt-2" : "mt-4"}`}
-            style={{ animation: "fadeInUp 0.5s ease-out 0.5s both" }}
-          >
-            <Checkbox
-              checked={tosAccepted}
-              onCheckedChange={(next) => setTosAccepted(next === true)}
-              label={tosLabel}
-              aria-label="I agree to the Terms of Service and Privacy Policy"
-              className={CONSENT_CHECKBOX_CLASS}
-            />
-          </div>
+        {(showPrivacy || showTos) && (
+          <AgreementsCard
+            electron={electron}
+            showPrivacy={showPrivacy}
+            showTos={showTos}
+            privacyConsent={privacyConsent}
+            tosAccepted={tosAccepted}
+            onPrivacyChange={setPrivacyConsent}
+            onTosChange={setTosAccepted}
+            className="mt-6 w-full"
+            style={{ animation: "fadeInUp 0.5s ease-out 0.36s both" }}
+          />
         )}
 
         <div
-          className={`mt-8 flex w-full flex-col ${electron ? "gap-2.5" : "gap-2"}`}
-          style={{ animation: "fadeInUp 0.5s ease-out 0.5s both" }}
+          className={`mt-9 flex w-full flex-col ${electron ? "gap-2.5" : "gap-2"}`}
+          style={{ animation: "fadeInUp 0.5s ease-out 0.44s both" }}
         >
           <Button
             variant="primary"

--- a/clients/web/src/domains/onboarding/prefs.ts
+++ b/clients/web/src/domains/onboarding/prefs.ts
@@ -2,7 +2,7 @@
  * Onboarding preference public API.
  *
  * Boolean preferences (`shareAnalytics`, `shareDiagnostics`, `tosAccepted`,
- * `aiDataConsent`) are owned by `useOnboardingStore` — a
+ * `privacyConsent`) are owned by `useOnboardingStore` — a
  * Zustand store with a custom per-key `persist` adapter that maps each
  * field to its existing localStorage key. This file exposes the hook +
  * non-React shim around the store, plus the non-store helpers for the
@@ -74,15 +74,15 @@ export function useTosAccepted(): [boolean, (next: boolean) => void] {
 }
 
 /**
- * Whether the user has explicitly acknowledged that conversation data is
- * sent to third-party AI providers. Defaults to `false`. Tracked separately
+ * Whether the user accepted the Privacy Policy and AI Data Sharing Policy
+ * (the second onboarding checkbox). Defaults to `false`. Tracked separately
  * from `useTosAccepted` so the consent surface remains specific (Apple
  * Guideline 5.1.2(i)).
  */
-export function useAiDataConsent(): [boolean, (next: boolean) => void] {
-  const value = useOnboardingStore.use.aiDataConsent();
+export function usePrivacyConsent(): [boolean, (next: boolean) => void] {
+  const value = useOnboardingStore.use.privacyConsent();
   const setter = useCallback((next: boolean) => {
-    useOnboardingStore.getState().setAiDataConsent(next);
+    useOnboardingStore.getState().setPrivacyConsent(next);
   }, []);
   return [value, setter];
 }
@@ -127,15 +127,15 @@ export function readTosAccepted(): boolean {
 }
 
 /**
- * SSR-safe, non-hook read of the AI data sharing consent flag. Used
- * alongside `readTosAccepted()` by the hatching gate so a user who
+ * SSR-safe, non-hook read of the Privacy Policy + AI Data Sharing consent
+ * flag. Used alongside `readTosAccepted()` by the hatching gate so a user who
  * somehow has only one of the two acknowledgments persisted (storage
  * race, partial restore from a sync mechanism) is bounced back through
  * the privacy screen rather than allowed to provision an assistant
- * without explicit AI consent.
+ * without explicit privacy consent.
  */
-export function readAiDataConsent(): boolean {
-  return useOnboardingStore.getState().aiDataConsent;
+export function readPrivacyConsent(): boolean {
+  return useOnboardingStore.getState().privacyConsent;
 }
 
 /**

--- a/clients/web/src/domains/onboarding/use-prechat-consent-gate.ts
+++ b/clients/web/src/domains/onboarding/use-prechat-consent-gate.ts
@@ -2,14 +2,14 @@
  * Consent readiness gate for the pre-chat onboarding flow.
  *
  * Auth is already enforced by `authMiddleware` on the `/assistant` route
- * tree, so this hook only handles consent: it reads ToS + AI-data consent
+ * tree, so this hook only handles consent: it reads ToS + privacy consent
  * from localStorage and redirects to the privacy screen when missing
  * (web only — native defers consent to the downstream privacy screen).
  */
 import { useEffect } from "react";
 import { useNavigate } from "react-router";
 
-import { readAiDataConsent, readTosAccepted } from "@/domains/onboarding/prefs";
+import { readPrivacyConsent, readTosAccepted } from "@/domains/onboarding/prefs";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { routes } from "@/utils/routes";
 
@@ -25,7 +25,7 @@ export function usePreChatConsentGate(): boolean {
   const navigate = useNavigate();
   const isNative = useIsNativePlatform();
 
-  const consentOk = readTosAccepted() && readAiDataConsent();
+  const consentOk = readTosAccepted() && readPrivacyConsent();
 
   useEffect(() => {
     if (!consentOk && !isNative) {

--- a/clients/web/src/domains/settings/pages/privacy-page.tsx
+++ b/clients/web/src/domains/settings/pages/privacy-page.tsx
@@ -82,7 +82,7 @@ export function PrivacyPage() {
         <div className="space-y-4">
           <SettingRow
             label="Share Analytics"
-            helperText="Send anonymous product usage data. Your conversations and personal data are never included."
+            helperText="Send anonymous product usage data."
             checked={shareAnalytics}
             onChange={handleAnalyticsToggle}
             variant="toggle-trailing"
@@ -90,7 +90,7 @@ export function PrivacyPage() {
           <Divider />
           <SettingRow
             label="Share Diagnostics"
-            helperText="Send crash reports and performance metrics. Your conversations and personal data are never included."
+            helperText="Send crash reports and performance metrics."
             checked={shareDiagnostics}
             onChange={handleDiagnosticsToggle}
             variant="toggle-trailing"

--- a/clients/web/src/lib/navigation/build-state.ts
+++ b/clients/web/src/lib/navigation/build-state.ts
@@ -2,10 +2,10 @@ import { useAuthStore } from "@/stores/auth-store";
 import { isSessionSettled, isAuthenticated } from "@/stores/session-status";
 import { isGatewayAuthMode } from "@/lib/auth/gateway-session";
 import { remoteGatewayPublicPathPrefix } from "@/lib/auth/remote-gateway-session";
-import { isLocalMode, isRemoteGatewayMode } from "@/lib/local-mode";
+import { isLocalMode, isPlatformDisabled, isRemoteGatewayMode } from "@/lib/local-mode";
 import {
   readTosAccepted,
-  readAiDataConsent,
+  readPrivacyConsent,
   readAnalyticsConsentCurrent,
   readDiagnosticsConsentCurrent,
 } from "@/domains/onboarding/prefs";
@@ -19,6 +19,7 @@ export function buildNavigationState(
   const isRemoteGateway = isRemoteGatewayMode();
   return {
     isLocalMode: isLocalMode(),
+    isPlatformDisabled: isPlatformDisabled(),
     isRemoteGateway,
     remoteGatewayPublicPathPrefix: isRemoteGateway
       ? remoteGatewayPublicPathPrefix()
@@ -29,7 +30,7 @@ export function buildNavigationState(
     isAuthenticated: isAuthenticated(sessionStatus),
     platformSession,
     tosAccepted: readTosAccepted(),
-    aiDataConsent: readAiDataConsent(),
+    privacyConsent: readPrivacyConsent(),
     analyticsConsentCurrent: readAnalyticsConsentCurrent(),
     diagnosticsConsentCurrent: readDiagnosticsConsentCurrent(),
     ...overrides,

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -9,6 +9,7 @@ import {
 
 const base: NavigationState = {
   isLocalMode: false,
+  isPlatformDisabled: false,
   isRemoteGateway: false,
   remoteGatewayPublicPathPrefix: "",
   isGatewayAuth: false,
@@ -17,7 +18,7 @@ const base: NavigationState = {
   isAuthenticated: true,
   platformSession: "present",
   tosAccepted: true,
-  aiDataConsent: true,
+  privacyConsent: true,
   analyticsConsentCurrent: true,
   diagnosticsConsentCurrent: true,
 };
@@ -159,7 +160,7 @@ describe("resolveNavigation", () => {
       ).toEqual(ALLOW);
       expect(
         guard(
-          s({ hasAssistants: false, tosAccepted: true, aiDataConsent: true }),
+          s({ hasAssistants: false, tosAccepted: true, privacyConsent: true }),
           "/assistant/onboarding/hatching?hosting=local",
         ),
       ).toEqual(ALLOW);
@@ -210,7 +211,7 @@ describe("resolveNavigation", () => {
     test("redirects user from hatching to privacy when consent missing", () => {
       expect(
         guard(
-          s({ tosAccepted: false, aiDataConsent: false }),
+          s({ tosAccepted: false, privacyConsent: false }),
           "/assistant/onboarding/hatching",
         ),
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
@@ -219,7 +220,7 @@ describe("resolveNavigation", () => {
     test("allows user on hatching when consent present", () => {
       expect(
         guard(
-          s({ tosAccepted: true, aiDataConsent: true }),
+          s({ tosAccepted: true, privacyConsent: true }),
           "/assistant/onboarding/hatching",
         ),
       ).toEqual(ALLOW);
@@ -228,7 +229,7 @@ describe("resolveNavigation", () => {
     test("redirects user from hatching to privacy with partial consent", () => {
       expect(
         guard(
-          s({ tosAccepted: true, aiDataConsent: false }),
+          s({ tosAccepted: true, privacyConsent: false }),
           "/assistant/onboarding/hatching",
         ),
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
@@ -237,7 +238,7 @@ describe("resolveNavigation", () => {
     test("redirects from hatching without consent to privacy when no assistants", () => {
       expect(
         guard(
-          s({ hasAssistants: false, tosAccepted: false, aiDataConsent: false }),
+          s({ hasAssistants: false, tosAccepted: false, privacyConsent: false }),
           "/assistant/onboarding/hatching",
         ),
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
@@ -246,7 +247,7 @@ describe("resolveNavigation", () => {
     test("redirects from hatching without consent in local mode", () => {
       expect(
         guard(
-          s({ isLocalMode: true, tosAccepted: false, aiDataConsent: false }),
+          s({ isLocalMode: true, tosAccepted: false, privacyConsent: false }),
           "/assistant/onboarding/hatching",
         ),
       ).toEqual({ action: "redirect", to: "/assistant/welcome" });
@@ -255,7 +256,7 @@ describe("resolveNavigation", () => {
     test("allows hatching with consent when no assistants", () => {
       expect(
         guard(
-          s({ hasAssistants: false, tosAccepted: true, aiDataConsent: true }),
+          s({ hasAssistants: false, tosAccepted: true, privacyConsent: true }),
           "/assistant/onboarding/hatching",
         ),
       ).toEqual(ALLOW);
@@ -289,19 +290,19 @@ describe("resolveNavigation", () => {
 
     test("redirects platform-mode user without consent to review-terms with returnTo", () => {
       expect(
-        guard(s({ isLocalMode: false, tosAccepted: false, aiDataConsent: false })),
+        guard(s({ isLocalMode: false, tosAccepted: false, privacyConsent: false })),
       ).toEqual({ action: "redirect", to: "/assistant/review-terms?returnTo=%2Fassistant" });
     });
 
     test("redirects platform-mode user with partial consent to review-terms with returnTo", () => {
       expect(
-        guard(s({ isLocalMode: false, tosAccepted: true, aiDataConsent: false })),
+        guard(s({ isLocalMode: false, tosAccepted: true, privacyConsent: false })),
       ).toEqual({ action: "redirect", to: "/assistant/review-terms?returnTo=%2Fassistant" });
     });
 
     test("redirects platform-mode user without consent and no assistants to privacy, not hatching", () => {
       expect(
-        guard(s({ isLocalMode: false, tosAccepted: false, aiDataConsent: false, hasAssistants: false })),
+        guard(s({ isLocalMode: false, tosAccepted: false, privacyConsent: false, hasAssistants: false })),
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
     });
 
@@ -325,7 +326,7 @@ describe("resolveNavigation", () => {
           s({
             isLocalMode: false,
             tosAccepted: true,
-            aiDataConsent: true,
+            privacyConsent: true,
             analyticsConsentCurrent: true,
             diagnosticsConsentCurrent: true,
           }),
@@ -333,12 +334,30 @@ describe("resolveNavigation", () => {
       ).toEqual(ALLOW);
     });
 
-    test("does not redirect local-mode user with stale toggles", () => {
+    test("redirects local-mode user with a platform session and stale consent to review-terms", () => {
+      // Consent is gated on the platform session, NOT isLocalMode: a local-mode
+      // client logged into the platform still re-reviews stale terms.
       expect(
         guard(
           s({
             isLocalMode: true,
             hasAssistants: true,
+            platformSession: "present",
+            tosAccepted: false,
+            privacyConsent: false,
+          }),
+        ),
+      ).toEqual({ action: "redirect", to: "/assistant/review-terms?returnTo=%2Fassistant" });
+    });
+
+    test("does not enforce consent when the platform session is absent", () => {
+      expect(
+        guard(
+          s({
+            hasAssistants: true,
+            platformSession: "absent",
+            tosAccepted: false,
+            privacyConsent: false,
             analyticsConsentCurrent: false,
             diagnosticsConsentCurrent: false,
           }),
@@ -346,9 +365,17 @@ describe("resolveNavigation", () => {
       ).toEqual(ALLOW);
     });
 
-    test("does not redirect local-mode user without consent (handled by step 5)", () => {
+    test("does not enforce consent when the platform is disabled", () => {
       expect(
-        guard(s({ isLocalMode: true, hasAssistants: true, tosAccepted: false, aiDataConsent: false })),
+        guard(
+          s({
+            isPlatformDisabled: true,
+            hasAssistants: true,
+            platformSession: "present",
+            tosAccepted: false,
+            privacyConsent: false,
+          }),
+        ),
       ).toEqual(ALLOW);
     });
 
@@ -405,7 +432,7 @@ describe("resolveNavigation", () => {
           s({
             hasAssistants: false,
             tosAccepted: false,
-            aiDataConsent: false,
+            privacyConsent: false,
             analyticsConsentCurrent: false,
             diagnosticsConsentCurrent: false,
           }),
@@ -426,7 +453,7 @@ describe("resolveNavigation", () => {
     });
 
     test("allows when tos and consent accepted", () => {
-      expect(intercept(s({ tosAccepted: true, aiDataConsent: true }), "/assistant")).toEqual(ALLOW);
+      expect(intercept(s({ tosAccepted: true, privacyConsent: true }), "/assistant")).toEqual(ALLOW);
     });
 
     test("stale toggles do not change onboarding-intercept (hasCompletedOnboarding only)", () => {
@@ -439,23 +466,23 @@ describe("resolveNavigation", () => {
     });
 
     test("allows destination outside /assistant", () => {
-      expect(intercept(s({ tosAccepted: false, aiDataConsent: false }), "/account/login")).toEqual(ALLOW);
+      expect(intercept(s({ tosAccepted: false, privacyConsent: false }), "/account/login")).toEqual(ALLOW);
     });
 
     test("allows destination in /assistant/onboarding", () => {
       expect(
-        intercept(s({ tosAccepted: false, aiDataConsent: false }), "/assistant/onboarding/privacy"),
+        intercept(s({ tosAccepted: false, privacyConsent: false }), "/assistant/onboarding/privacy"),
       ).toEqual(ALLOW);
     });
 
     test("redirects to welcome in local mode", () => {
       expect(
-        intercept(s({ isLocalMode: true, hasAssistants: false, tosAccepted: false, aiDataConsent: false }), "/assistant"),
+        intercept(s({ isLocalMode: true, hasAssistants: false, tosAccepted: false, privacyConsent: false }), "/assistant"),
       ).toEqual({ action: "redirect", to: "/assistant/welcome" });
     });
 
     test("redirects to privacy in platform mode", () => {
-      expect(intercept(s({ tosAccepted: false, aiDataConsent: false }), "/assistant")).toEqual({
+      expect(intercept(s({ tosAccepted: false, privacyConsent: false }), "/assistant")).toEqual({
         action: "redirect",
         to: "/assistant/onboarding/privacy",
       });
@@ -463,19 +490,19 @@ describe("resolveNavigation", () => {
 
     test("handles absolute URL destinations", () => {
       expect(
-        intercept(s({ tosAccepted: false, aiDataConsent: false }), "https://assistant.vellum.ai/assistant"),
+        intercept(s({ tosAccepted: false, privacyConsent: false }), "https://assistant.vellum.ai/assistant"),
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
     });
 
     test("handles protocol-relative URL destinations", () => {
       expect(
-        intercept(s({ tosAccepted: false, aiDataConsent: false }), "//assistant.vellum.ai/assistant"),
+        intercept(s({ tosAccepted: false, privacyConsent: false }), "//assistant.vellum.ai/assistant"),
       ).toEqual({ action: "redirect", to: "/assistant/onboarding/privacy" });
     });
 
     test("allows absolute URL outside /assistant", () => {
       expect(
-        intercept(s({ tosAccepted: false, aiDataConsent: false }), "https://vellum.ai/account"),
+        intercept(s({ tosAccepted: false, privacyConsent: false }), "https://vellum.ai/account"),
       ).toEqual(ALLOW);
     });
   });
@@ -499,21 +526,21 @@ describe("resolveNavigation", () => {
     });
 
     test("redirects unauthenticated local-mode user without consent to welcome", () => {
-      expect(hatch(s({ isAuthenticated: false, isLocalMode: true, tosAccepted: false, aiDataConsent: false }))).toEqual({
+      expect(hatch(s({ isAuthenticated: false, isLocalMode: true, tosAccepted: false, privacyConsent: false }))).toEqual({
         action: "redirect",
         to: "/assistant/welcome",
       });
     });
 
     test("redirects when missing consent", () => {
-      expect(hatch(s({ tosAccepted: false, aiDataConsent: false }))).toEqual({
+      expect(hatch(s({ tosAccepted: false, privacyConsent: false }))).toEqual({
         action: "redirect",
         to: "/assistant/onboarding/privacy",
       });
     });
 
     test("redirects when missing ai data consent only", () => {
-      expect(hatch(s({ tosAccepted: true, aiDataConsent: false }))).toEqual({
+      expect(hatch(s({ tosAccepted: true, privacyConsent: false }))).toEqual({
         action: "redirect",
         to: "/assistant/onboarding/privacy",
       });
@@ -521,12 +548,12 @@ describe("resolveNavigation", () => {
 
     test("redirects to welcome in local mode when missing consent", () => {
       expect(
-        hatch(s({ isLocalMode: true, tosAccepted: false, aiDataConsent: false })),
+        hatch(s({ isLocalMode: true, tosAccepted: false, privacyConsent: false })),
       ).toEqual({ action: "redirect", to: "/assistant/welcome" });
     });
 
     test("allows with full consent", () => {
-      expect(hatch(s({ tosAccepted: true, aiDataConsent: true }))).toEqual(ALLOW);
+      expect(hatch(s({ tosAccepted: true, privacyConsent: true }))).toEqual(ALLOW);
     });
 
     test("redirects platform user with stale analytics toggle to review-terms", () => {

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -8,6 +8,7 @@ import { routes } from "@/utils/routes";
 
 export interface NavigationState {
   isLocalMode: boolean;
+  isPlatformDisabled: boolean;
   isRemoteGateway: boolean;
   remoteGatewayPublicPathPrefix: string;
   isGatewayAuth: boolean;
@@ -16,7 +17,7 @@ export interface NavigationState {
   isAuthenticated: boolean;
   platformSession: PlatformSessionStatus;
   tosAccepted: boolean;
-  aiDataConsent: boolean;
+  privacyConsent: boolean;
   analyticsConsentCurrent: boolean;
   diagnosticsConsentCurrent: boolean;
 }
@@ -51,7 +52,7 @@ export type NavigationDecision =
 // ---------------------------------------------------------------------------
 
 function hasCompletedOnboarding(state: NavigationState): boolean {
-  return state.tosAccepted && state.aiDataConsent;
+  return state.tosAccepted && state.privacyConsent;
 }
 
 /**
@@ -319,7 +320,18 @@ function requireConsent(
   _path: string,
   pathnameWithSearch: string,
 ): NavigationDecision | null {
-  if (state.isLocalMode || consentIsCurrent(state)) return null;
+  // Consent is a platform-account concern: only enforce it when there is a
+  // live platform session to consent against. A disabled platform or an
+  // absent/unknown session has no server consent record to gate on. Note this
+  // is NOT gated on isLocalMode — a local-mode client with a platform session
+  // still re-reviews stale terms.
+  if (
+    state.isPlatformDisabled ||
+    state.platformSession !== "present" ||
+    consentIsCurrent(state)
+  ) {
+    return null;
+  }
 
   const returnTo = encodeURIComponent(pathnameWithSearch);
   return { action: "redirect", to: `${routes.reviewTerms}?returnTo=${returnTo}` };

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -40,18 +40,18 @@ const restoreConsentForUserMock = mock(
     _userId: string | null,
   ): {
     tos: boolean;
-    ai: boolean;
+    privacy: boolean;
     analyticsCurrent: boolean;
     diagnosticsCurrent: boolean;
   } => ({
     tos: false,
-    ai: false,
+    privacy: false,
     analyticsCurrent: false,
     diagnosticsCurrent: false,
   }),
 );
 const persistConsentForUserMock = mock(
-  (_userId: string | null, _tos: boolean, _ai: boolean) => {},
+  (_userId: string | null, _tos: boolean, _privacy: boolean) => {},
 );
 const persistToggleConsentMock = mock(
   (
@@ -64,7 +64,7 @@ const resolveServerConsentMock = mock(
     _consent: unknown,
   ): {
     tos: boolean;
-    ai: boolean;
+    privacy: boolean;
     shareAnalytics: boolean | null;
     shareDiagnostics: boolean | null;
     analyticsCurrent: boolean;
@@ -72,7 +72,7 @@ const resolveServerConsentMock = mock(
     hasServerRecord: boolean;
   } => ({
     tos: false,
-    ai: false,
+    privacy: false,
     shareAnalytics: null,
     shareDiagnostics: null,
     analyticsCurrent: false,
@@ -206,7 +206,8 @@ mock.module("@/utils/onboarding-cleanup", () => ({
   persistConsentForUser: persistConsentForUserMock,
   persistToggleConsent: persistToggleConsentMock,
   resolveServerConsent: resolveServerConsentMock,
-  CONSENT_VERSION: "2026-06-08",
+  TOS_CONSENT_VERSION: "2026-06-08",
+  PRIVACY_CONSENT_VERSION: "2026-06-08",
 }));
 
 const setAnalyticsConsentCurrentMock = mock((_value: boolean) => {});
@@ -222,7 +223,7 @@ mock.module("@/domains/onboarding/onboarding-store", () => ({
   useOnboardingStore: {
     getState: () => ({
       setTosAccepted: () => {},
-      setAiDataConsent: () => {},
+      setPrivacyConsent: () => {},
       setShareAnalytics: setShareAnalyticsMock,
       setShareDiagnostics: setShareDiagnosticsMock,
       setAnalyticsConsentCurrent: setAnalyticsConsentCurrentMock,
@@ -505,7 +506,7 @@ describe("auth store onboarding flag reconciliation", () => {
     };
     resolveServerConsentMock.mockReturnValueOnce({
       tos: true,
-      ai: true,
+      privacy: true,
       shareAnalytics: true,
       shareDiagnostics: true,
       analyticsCurrent: true,
@@ -543,7 +544,7 @@ describe("auth store onboarding flag reconciliation", () => {
     sessionUser = { id: "user-1", email: "user@example.com" };
     restoreConsentForUserMock.mockReturnValueOnce({
       tos: true,
-      ai: true,
+      privacy: true,
       analyticsCurrent: true,
       diagnosticsCurrent: true,
     });
@@ -590,7 +591,7 @@ describe("auth store onboarding flag reconciliation", () => {
     mockStoreShareAnalytics = false;
     restoreConsentForUserMock.mockReturnValueOnce({
       tos: true,
-      ai: true,
+      privacy: true,
       analyticsCurrent: true,
       diagnosticsCurrent: true,
     });
@@ -612,7 +613,7 @@ describe("auth store onboarding flag reconciliation", () => {
     sessionUser = { id: "user-1", email: "user@example.com" };
     resolveServerConsentMock.mockReturnValueOnce({
       tos: false,
-      ai: false,
+      privacy: false,
       shareAnalytics: false,
       shareDiagnostics: true,
       analyticsCurrent: false,
@@ -631,7 +632,7 @@ describe("auth store onboarding flag reconciliation", () => {
     mockFetchConsentError = new Error("Network error");
     restoreConsentForUserMock.mockReturnValueOnce({
       tos: true,
-      ai: true,
+      privacy: true,
       analyticsCurrent: true,
       diagnosticsCurrent: true,
     });

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -59,7 +59,8 @@ import {
   persistConsentForUser,
   persistToggleConsent,
   resolveServerConsent,
-  CONSENT_VERSION,
+  TOS_CONSENT_VERSION,
+  PRIVACY_CONSENT_VERSION,
 } from "@/utils/onboarding-cleanup";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 import {
@@ -269,7 +270,7 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
       // first would overwrite those keys with the empty server values before the
       // fallback below reads them.
       let tos = resolved.tos;
-      let ai = resolved.ai;
+      let privacy = resolved.privacy;
       let analyticsCurrent = resolved.analyticsCurrent;
       let diagnosticsCurrent = resolved.diagnosticsCurrent;
 
@@ -280,25 +281,25 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
         const deviceConsent = restoreConsentForUser(nextUserId);
         analyticsCurrent = deviceConsent.analyticsCurrent;
         diagnosticsCurrent = deviceConsent.diagnosticsCurrent;
-        if (deviceConsent.tos && deviceConsent.ai) {
+        if (deviceConsent.tos && deviceConsent.privacy) {
           tos = true;
-          ai = true;
+          privacy = true;
           // Backfill the server from the device acks. Stamp any toggle version
           // whose device ack is current AND send the device share value so the
           // next fetch can't overwrite a device opt-out with the API default.
           void patchConsent({
-            tos_accepted_version: CONSENT_VERSION,
-            privacy_policy_accepted_version: CONSENT_VERSION,
-            ai_data_sharing_accepted_version: CONSENT_VERSION,
+            tos_accepted_version: TOS_CONSENT_VERSION,
+            privacy_policy_accepted_version: PRIVACY_CONSENT_VERSION,
+            ai_data_sharing_accepted_version: PRIVACY_CONSENT_VERSION,
             ...(analyticsCurrent
               ? {
-                  share_analytics_accepted_version: CONSENT_VERSION,
+                  share_analytics_accepted_version: PRIVACY_CONSENT_VERSION,
                   share_analytics: store.shareAnalytics,
                 }
               : {}),
             ...(diagnosticsCurrent
               ? {
-                  share_diagnostics_accepted_version: CONSENT_VERSION,
+                  share_diagnostics_accepted_version: PRIVACY_CONSENT_VERSION,
                   share_diagnostics: store.shareDiagnostics,
                 }
               : {}),
@@ -307,10 +308,10 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
       }
 
       store.setTosAccepted(tos);
-      store.setAiDataConsent(ai);
+      store.setPrivacyConsent(privacy);
       store.setAnalyticsConsentCurrent(analyticsCurrent);
       store.setDiagnosticsConsentCurrent(diagnosticsCurrent);
-      persistConsentForUser(nextUserId, tos, ai);
+      persistConsentForUser(nextUserId, tos, privacy);
       persistToggleConsent(nextUserId, { analyticsCurrent, diagnosticsCurrent });
       syncOrganizationState(nextUserId);
       return;
@@ -322,7 +323,7 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
   const consent = restoreConsentForUser(nextUserId);
   const store = useOnboardingStore.getState();
   store.setTosAccepted(consent.tos);
-  store.setAiDataConsent(consent.ai);
+  store.setPrivacyConsent(consent.privacy);
   store.setAnalyticsConsentCurrent(consent.analyticsCurrent);
   store.setDiagnosticsConsentCurrent(consent.diagnosticsCurrent);
   syncOrganizationState(nextUserId);

--- a/clients/web/src/utils/onboarding-cleanup.test.ts
+++ b/clients/web/src/utils/onboarding-cleanup.test.ts
@@ -284,6 +284,20 @@ describe("persistToggleConsent + restoreConsentForUser round-trip", () => {
     expect(r.analyticsCurrent).toBe(false);
     expect(r.diagnosticsCurrent).toBe(false);
   });
+
+  test("migrates the previous version's per-user 'ai' key into 'privacy'", () => {
+    // An existing offline user consented under the old field name.
+    const legacyAiKey = `device:consent:ai:v${PRIVACY_CONSENT_VERSION}:user-1`;
+    const privacyKey = `device:consent:privacy:v${PRIVACY_CONSENT_VERSION}:user-1`;
+    localStorage.setItem(legacyAiKey, "true");
+
+    const r = restoreConsentForUser("user-1");
+
+    expect(r.privacy).toBe(true);
+    // The old key is promoted to the new one and removed.
+    expect(localStorage.getItem(privacyKey)).toBe("true");
+    expect(localStorage.getItem(legacyAiKey)).toBeNull();
+  });
 });
 
 describe("saveConsent", () => {

--- a/clients/web/src/utils/onboarding-cleanup.test.ts
+++ b/clients/web/src/utils/onboarding-cleanup.test.ts
@@ -24,7 +24,7 @@ installMemoryStorage({ beforeAll, afterAll, beforeEach, afterEach });
 
 const storeState = {
   setTosAccepted: mock(() => {}),
-  setAiDataConsent: mock(() => {}),
+  setPrivacyConsent: mock(() => {}),
   setShareAnalytics: mock(() => {}),
   setShareDiagnostics: mock(() => {}),
   setAnalyticsConsentCurrent: mock(() => {}),
@@ -48,7 +48,8 @@ mock.module("@/utils/device-settings", () => ({
 }));
 
 import {
-  CONSENT_VERSION,
+  TOS_CONSENT_VERSION,
+  PRIVACY_CONSENT_VERSION,
   clearConsentForUser,
   persistToggleConsent,
   resolveServerConsent,
@@ -60,30 +61,30 @@ import type { UserConsent } from "@/domains/account/profile";
 
 function makeConsent(overrides: Partial<UserConsent> = {}): UserConsent {
   return {
-    tos_accepted_version: CONSENT_VERSION,
+    tos_accepted_version: TOS_CONSENT_VERSION,
     tos_accepted_at: null,
-    privacy_policy_accepted_version: CONSENT_VERSION,
+    privacy_policy_accepted_version: PRIVACY_CONSENT_VERSION,
     privacy_policy_accepted_at: null,
-    ai_data_sharing_accepted_version: CONSENT_VERSION,
+    ai_data_sharing_accepted_version: PRIVACY_CONSENT_VERSION,
     ai_data_sharing_accepted_at: null,
     share_analytics: true,
     share_diagnostics: true,
-    share_analytics_accepted_version: CONSENT_VERSION,
+    share_analytics_accepted_version: PRIVACY_CONSENT_VERSION,
     share_analytics_accepted_at: null,
-    share_diagnostics_accepted_version: CONSENT_VERSION,
+    share_diagnostics_accepted_version: PRIVACY_CONSENT_VERSION,
     share_diagnostics_accepted_at: null,
     ...overrides,
   };
 }
 
 const analyticsKey = (userId: string) =>
-  `device:consent:share_analytics:v${CONSENT_VERSION}:${userId}`;
+  `device:consent:share_analytics:v${PRIVACY_CONSENT_VERSION}:${userId}`;
 const diagnosticsKey = (userId: string) =>
-  `device:consent:share_diagnostics:v${CONSENT_VERSION}:${userId}`;
+  `device:consent:share_diagnostics:v${PRIVACY_CONSENT_VERSION}:${userId}`;
 
 beforeEach(() => {
   storeState.setTosAccepted.mockReset();
-  storeState.setAiDataConsent.mockReset();
+  storeState.setPrivacyConsent.mockReset();
   storeState.setShareAnalytics.mockReset();
   storeState.setShareDiagnostics.mockReset();
   storeState.setAnalyticsConsentCurrent.mockReset();
@@ -94,7 +95,7 @@ beforeEach(() => {
 });
 
 describe("resolveServerConsent", () => {
-  test("reports current toggles when versions match CONSENT_VERSION", () => {
+  test("reports current toggles when versions match PRIVACY_CONSENT_VERSION", () => {
     const r = resolveServerConsent(makeConsent());
     expect(r.analyticsCurrent).toBe(true);
     expect(r.diagnosticsCurrent).toBe(true);
@@ -129,12 +130,46 @@ describe("resolveServerConsent", () => {
     expect(resolveServerConsent(undefined).diagnosticsCurrent).toBe(false);
   });
 
-  test("keeps the existing value/tos/ai fields", () => {
+  test("keeps the existing value/tos/privacy fields", () => {
     const r = resolveServerConsent(makeConsent({ share_analytics: false }));
     expect(r.tos).toBe(true);
-    expect(r.ai).toBe(true);
+    expect(r.privacy).toBe(true);
     expect(r.shareAnalytics).toBe(false);
     expect(r.shareDiagnostics).toBe(true);
+  });
+
+  test("tos tracks only the ToS version, independent of the privacy artifacts", () => {
+    // A privacy-version bump leaves privacy_policy/ai_data_sharing stale but
+    // must NOT mark the standalone ToS checkbox stale.
+    const r = resolveServerConsent(
+      makeConsent({
+        privacy_policy_accepted_version: "2020-01-01",
+        ai_data_sharing_accepted_version: "2020-01-01",
+      }),
+    );
+    expect(r.tos).toBe(true);
+    expect(r.privacy).toBe(false);
+  });
+
+  test("privacy requires BOTH privacy policy and AI data sharing to be current", () => {
+    expect(
+      resolveServerConsent(
+        makeConsent({ ai_data_sharing_accepted_version: "2020-01-01" }),
+      ).privacy,
+    ).toBe(false);
+    expect(
+      resolveServerConsent(
+        makeConsent({ privacy_policy_accepted_version: "2020-01-01" }),
+      ).privacy,
+    ).toBe(false);
+  });
+
+  test("a stale ToS version does not affect privacy currency", () => {
+    const r = resolveServerConsent(
+      makeConsent({ tos_accepted_version: "2020-01-01" }),
+    );
+    expect(r.tos).toBe(false);
+    expect(r.privacy).toBe(true);
   });
 
   test("hasServerRecord is false for an all-defaults response", () => {
@@ -186,14 +221,14 @@ describe("resolveServerConsent", () => {
     };
     expect(
       resolveServerConsent(
-        makeConsent({ ...allDefaults, tos_accepted_version: CONSENT_VERSION }),
+        makeConsent({ ...allDefaults, tos_accepted_version: TOS_CONSENT_VERSION }),
       ).hasServerRecord,
     ).toBe(true);
     expect(
       resolveServerConsent(
         makeConsent({
           ...allDefaults,
-          ai_data_sharing_accepted_version: CONSENT_VERSION,
+          ai_data_sharing_accepted_version: PRIVACY_CONSENT_VERSION,
         }),
       ).hasServerRecord,
     ).toBe(true);
@@ -256,22 +291,53 @@ describe("saveConsent", () => {
     saveConsent({
       userId: "user-1",
       tos: true,
-      ai: true,
+      privacy: true,
       shareAnalytics: true,
       shareDiagnostics: false,
       hasPlatformSession: true,
     });
     expect(patchConsentMock).toHaveBeenCalledTimes(1);
     const body = patchConsentMock.mock.calls[0][0];
-    expect(body.share_analytics_accepted_version).toBe(CONSENT_VERSION);
-    expect(body.share_diagnostics_accepted_version).toBe(CONSENT_VERSION);
+    expect(body.share_analytics_accepted_version).toBe(PRIVACY_CONSENT_VERSION);
+    expect(body.share_diagnostics_accepted_version).toBe(PRIVACY_CONSENT_VERSION);
+  });
+
+  test("ToS stamps the ToS version; the privacy checkbox stamps privacy policy + AI data sharing", () => {
+    saveConsent({
+      userId: "user-1",
+      tos: true,
+      privacy: false,
+      shareAnalytics: true,
+      shareDiagnostics: true,
+      hasPlatformSession: true,
+    });
+    const body = patchConsentMock.mock.calls[0][0];
+    expect(body.tos_accepted_version).toBe(TOS_CONSENT_VERSION);
+    // privacy=false clears both privacy artifacts together.
+    expect(body.privacy_policy_accepted_version).toBe("");
+    expect(body.ai_data_sharing_accepted_version).toBe("");
+  });
+
+  test("the privacy checkbox stamps both privacy policy and AI data sharing versions", () => {
+    saveConsent({
+      userId: "user-1",
+      tos: false,
+      privacy: true,
+      shareAnalytics: true,
+      shareDiagnostics: true,
+      hasPlatformSession: true,
+    });
+    const body = patchConsentMock.mock.calls[0][0];
+    expect(body.tos_accepted_version).toBe("");
+    expect(body.privacy_policy_accepted_version).toBe(PRIVACY_CONSENT_VERSION);
+    expect(body.ai_data_sharing_accepted_version).toBe(PRIVACY_CONSENT_VERSION);
   });
 
   test("sets both currency flags and writes both ack keys", () => {
     saveConsent({
       userId: "user-1",
       tos: true,
-      ai: true,
+      privacy: true,
       shareAnalytics: true,
       shareDiagnostics: true,
       hasPlatformSession: false,
@@ -292,7 +358,7 @@ describe("savePreferenceToggle", () => {
     expect(localStorage.getItem(diagnosticsKey("user-1"))).toBeNull();
     const body = patchConsentMock.mock.calls[0][0];
     expect(body.share_analytics).toBe(true);
-    expect(body.share_analytics_accepted_version).toBe(CONSENT_VERSION);
+    expect(body.share_analytics_accepted_version).toBe(PRIVACY_CONSENT_VERSION);
   });
 
   test("stamps the diagnostics version and sets its flag only", () => {
@@ -301,7 +367,7 @@ describe("savePreferenceToggle", () => {
     expect(storeState.setAnalyticsConsentCurrent).not.toHaveBeenCalled();
     const body = patchConsentMock.mock.calls[0][0];
     expect(body.share_diagnostics).toBe(false);
-    expect(body.share_diagnostics_accepted_version).toBe(CONSENT_VERSION);
+    expect(body.share_diagnostics_accepted_version).toBe(PRIVACY_CONSENT_VERSION);
   });
 });
 

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -1,23 +1,26 @@
 /**
  * Versioned, per-user consent persistence.
  *
- * Consent flags live in `device:consent:{tos,ai,share_analytics,share_diagnostics}:v<VERSION>:<userId>`.
+ * Consent flags live in `device:consent:{tos,privacy,share_analytics,share_diagnostics}:v<VERSION>:<userId>`.
  * The `device:` prefix survives logout; the userId makes them per-user;
- * the version lets us force re-consent by bumping CONSENT_VERSION.
+ * the version lets us force re-consent by bumping the relevant version
+ * constant. The ToS legal terms version independently from the privacy
+ * artifacts (privacy policy, AI data sharing, the share toggles), so each can
+ * be re-reviewed without forcing the other.
  *
  * The `share_analytics`/`share_diagnostics` ack keys record the version under
  * which the toggle was last confirmed (its currency), independent of the
  * on/off value which lives in the unversioned `device:share_analytics` key.
  *
  * The onboarding Zustand store holds the in-memory state (`tosAccepted`,
- * `aiDataConsent`). This module handles the durable device-key layer
+ * `privacyConsent`). This module handles the durable device-key layer
  * and the unified read/write API for all consent state:
  *
- * - `resolveServerConsent` — compare server consent versions against CONSENT_VERSION
+ * - `resolveServerConsent` — compare server consent versions against the ToS/privacy versions
  * - `saveConsent`          — unified write: store + device keys + server sync
  * - `savePreferenceToggle` — single-field write for settings page toggles
- * - `restoreConsentForUser` — read device keys, return {tos, ai, toggle acks}
- * - `persistConsentForUser` — write tos/ai device keys
+ * - `restoreConsentForUser` — read device keys, return {tos, privacy, toggle acks}
+ * - `persistConsentForUser` — write tos/privacy device keys
  * - `persistToggleConsent`  — write versioned share-toggle ack keys
  * - `clearConsentForUser`   — delete device keys + legacy active keys
  */
@@ -26,50 +29,61 @@ import { setDeviceBool } from "@/utils/device-settings";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 import { patchConsent, type UserConsent } from "@/domains/account/profile";
 
-export const CONSENT_VERSION = "2026-06-08";
+export const TOS_CONSENT_VERSION = "2026-06-08";
+export const PRIVACY_CONSENT_VERSION = "2026-06-08";
 
-function consentKey(field: string, userId: string): string {
-  return `device:consent:${field}:v${CONSENT_VERSION}:${userId}`;
+// Version stamp embedded in each field's device-cache key. ToS tracks its own
+// version; the privacy checkbox (privacy policy + AI data sharing) and the two
+// share toggles track the privacy version.
+const CONSENT_KEY_VERSION = {
+  tos: TOS_CONSENT_VERSION,
+  privacy: PRIVACY_CONSENT_VERSION,
+  share_analytics: PRIVACY_CONSENT_VERSION,
+  share_diagnostics: PRIVACY_CONSENT_VERSION,
+} as const;
+
+function consentKey(field: keyof typeof CONSENT_KEY_VERSION, userId: string): string {
+  return `device:consent:${field}:v${CONSENT_KEY_VERSION[field]}:${userId}`;
 }
 
 export function restoreConsentForUser(
   userId: string | null,
-): { tos: boolean; ai: boolean; analyticsCurrent: boolean; diagnosticsCurrent: boolean } {
+): { tos: boolean; privacy: boolean; analyticsCurrent: boolean; diagnosticsCurrent: boolean } {
   if (typeof window === "undefined" || !userId) {
-    return { tos: false, ai: false, analyticsCurrent: false, diagnosticsCurrent: false };
+    return { tos: false, privacy: false, analyticsCurrent: false, diagnosticsCurrent: false };
   }
   try {
     const analyticsCurrent = getLocalBool(consentKey("share_analytics", userId), false);
     const diagnosticsCurrent = getLocalBool(consentKey("share_diagnostics", userId), false);
     const tos = getLocalBool(consentKey("tos", userId), false);
-    const ai = getLocalBool(consentKey("ai", userId), false);
-    if (tos || ai) return { tos, ai, analyticsCurrent, diagnosticsCurrent };
+    const privacy = getLocalBool(consentKey("privacy", userId), false);
+    if (tos || privacy) return { tos, privacy, analyticsCurrent, diagnosticsCurrent };
 
     // One-time migration: users who accepted before the per-user device
     // key change still have consent in the legacy vellum: active keys.
     // Promote to the new keys so they aren't re-prompted.
     const legacyTos = getLocalBool("vellum:onboarding:tosAccepted", false);
-    const legacyAi = getLocalBool("vellum:onboarding:aiDataConsent", false);
-    if (legacyTos || legacyAi) {
-      persistConsentForUser(userId, legacyTos, legacyAi);
-      return { tos: legacyTos, ai: legacyAi, analyticsCurrent, diagnosticsCurrent };
+    const legacyPrivacy = getLocalBool("vellum:onboarding:aiDataConsent", false);
+    if (legacyTos || legacyPrivacy) {
+      persistConsentForUser(userId, legacyTos, legacyPrivacy);
+      return { tos: legacyTos, privacy: legacyPrivacy, analyticsCurrent, diagnosticsCurrent };
     }
 
-    return { tos: false, ai: false, analyticsCurrent, diagnosticsCurrent };
+    return { tos: false, privacy: false, analyticsCurrent, diagnosticsCurrent };
   } catch {
-    return { tos: false, ai: false, analyticsCurrent: false, diagnosticsCurrent: false };
+    return { tos: false, privacy: false, analyticsCurrent: false, diagnosticsCurrent: false };
   }
 }
 
 export function persistConsentForUser(
   userId: string | null,
   tos: boolean,
-  ai: boolean,
+  privacy: boolean,
 ): void {
   if (typeof window === "undefined" || !userId) return;
   try {
     setLocalBool(consentKey("tos", userId), tos);
-    setLocalBool(consentKey("ai", userId), ai);
+    setLocalBool(consentKey("privacy", userId), privacy);
   } catch {
     // Storage unavailable.
   }
@@ -99,7 +113,7 @@ export function clearConsentForUser(userId: string | null): void {
   if (typeof window === "undefined" || !userId) return;
   try {
     removeLocalSetting(consentKey("tos", userId));
-    removeLocalSetting(consentKey("ai", userId));
+    removeLocalSetting(consentKey("privacy", userId));
     removeLocalSetting(consentKey("share_analytics", userId));
     removeLocalSetting(consentKey("share_diagnostics", userId));
   } catch {
@@ -115,7 +129,7 @@ export function resolveServerConsent(
   consent: UserConsent | null | undefined,
 ): {
   tos: boolean;
-  ai: boolean;
+  privacy: boolean;
   shareAnalytics: boolean | null;
   shareDiagnostics: boolean | null;
   analyticsCurrent: boolean;
@@ -125,7 +139,7 @@ export function resolveServerConsent(
   if (!consent) {
     return {
       tos: false,
-      ai: false,
+      privacy: false,
       shareAnalytics: null,
       shareDiagnostics: null,
       analyticsCurrent: false,
@@ -150,13 +164,16 @@ export function resolveServerConsent(
     consent.share_analytics === false ||
     consent.share_diagnostics === false;
   return {
-    tos: consent.tos_accepted_version === CONSENT_VERSION
-      && consent.privacy_policy_accepted_version === CONSENT_VERSION,
-    ai: consent.ai_data_sharing_accepted_version === CONSENT_VERSION,
+    // The ToS checkbox covers only the Terms of Service. The privacy checkbox
+    // covers both the Privacy Policy and the AI Data Sharing Policy, so it is
+    // current only when BOTH versions match.
+    tos: consent.tos_accepted_version === TOS_CONSENT_VERSION,
+    privacy: consent.privacy_policy_accepted_version === PRIVACY_CONSENT_VERSION
+      && consent.ai_data_sharing_accepted_version === PRIVACY_CONSENT_VERSION,
     shareAnalytics: consent.share_analytics,
     shareDiagnostics: consent.share_diagnostics,
-    analyticsCurrent: consent.share_analytics_accepted_version === CONSENT_VERSION,
-    diagnosticsCurrent: consent.share_diagnostics_accepted_version === CONSENT_VERSION,
+    analyticsCurrent: consent.share_analytics_accepted_version === PRIVACY_CONSENT_VERSION,
+    diagnosticsCurrent: consent.share_diagnostics_accepted_version === PRIVACY_CONSENT_VERSION,
     hasServerRecord,
   };
 }
@@ -168,31 +185,31 @@ export function resolveServerConsent(
 export function saveConsent(opts: {
   userId: string | null;
   tos: boolean;
-  ai: boolean;
+  privacy: boolean;
   shareAnalytics: boolean;
   shareDiagnostics: boolean;
   hasPlatformSession: boolean;
 }): void {
   const store = useOnboardingStore.getState();
   store.setTosAccepted(opts.tos);
-  store.setAiDataConsent(opts.ai);
+  store.setPrivacyConsent(opts.privacy);
   store.setShareAnalytics(opts.shareAnalytics);
   store.setShareDiagnostics(opts.shareDiagnostics);
   store.setAnalyticsConsentCurrent(true);
   store.setDiagnosticsConsentCurrent(true);
 
-  persistConsentForUser(opts.userId, opts.tos, opts.ai);
+  persistConsentForUser(opts.userId, opts.tos, opts.privacy);
   persistToggleConsent(opts.userId, { analyticsCurrent: true, diagnosticsCurrent: true });
 
   if (opts.hasPlatformSession) {
     void patchConsent({
-      tos_accepted_version: opts.tos ? CONSENT_VERSION : "",
-      privacy_policy_accepted_version: opts.tos ? CONSENT_VERSION : "",
-      ai_data_sharing_accepted_version: opts.ai ? CONSENT_VERSION : "",
+      tos_accepted_version: opts.tos ? TOS_CONSENT_VERSION : "",
+      privacy_policy_accepted_version: opts.privacy ? PRIVACY_CONSENT_VERSION : "",
+      ai_data_sharing_accepted_version: opts.privacy ? PRIVACY_CONSENT_VERSION : "",
       share_analytics: opts.shareAnalytics,
       share_diagnostics: opts.shareDiagnostics,
-      share_analytics_accepted_version: CONSENT_VERSION,
-      share_diagnostics_accepted_version: CONSENT_VERSION,
+      share_analytics_accepted_version: PRIVACY_CONSENT_VERSION,
+      share_diagnostics_accepted_version: PRIVACY_CONSENT_VERSION,
     }).catch(() => {});
   }
 }
@@ -219,7 +236,7 @@ export function savePreferenceToggle(
   if (hasPlatformSession) {
     void patchConsent({
       [field]: value,
-      [`${field}_accepted_version`]: CONSENT_VERSION,
+      [`${field}_accepted_version`]: PRIVACY_CONSENT_VERSION,
     }).catch(() => {});
   }
 }

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -46,6 +46,14 @@ function consentKey(field: keyof typeof CONSENT_KEY_VERSION, userId: string): st
   return `device:consent:${field}:v${CONSENT_KEY_VERSION[field]}:${userId}`;
 }
 
+// The previous release stored this consent under a field named "ai" (now folded
+// into "privacy"). Read at the same version the old key was written under so an
+// existing offline user with only the old key migrates cleanly instead of
+// reading privacy=false and being re-routed through onboarding.
+function legacyPrivacyConsentKey(userId: string): string {
+  return `device:consent:ai:v${PRIVACY_CONSENT_VERSION}:${userId}`;
+}
+
 export function restoreConsentForUser(
   userId: string | null,
 ): { tos: boolean; privacy: boolean; analyticsCurrent: boolean; diagnosticsCurrent: boolean } {
@@ -56,7 +64,17 @@ export function restoreConsentForUser(
     const analyticsCurrent = getLocalBool(consentKey("share_analytics", userId), false);
     const diagnosticsCurrent = getLocalBool(consentKey("share_diagnostics", userId), false);
     const tos = getLocalBool(consentKey("tos", userId), false);
-    const privacy = getLocalBool(consentKey("privacy", userId), false);
+    let privacy = getLocalBool(consentKey("privacy", userId), false);
+
+    // Migrate the previous version's "ai"-named key into "privacy" so a renamed-
+    // key user isn't read as un-consented (which the empty-server fallback would
+    // turn into an onboarding re-route).
+    if (!privacy && getLocalBool(legacyPrivacyConsentKey(userId), false)) {
+      privacy = true;
+      setLocalBool(consentKey("privacy", userId), true);
+      removeLocalSetting(legacyPrivacyConsentKey(userId));
+    }
+
     if (tos || privacy) return { tos, privacy, analyticsCurrent, diagnosticsCurrent };
 
     // One-time migration: users who accepted before the per-user device
@@ -114,6 +132,7 @@ export function clearConsentForUser(userId: string | null): void {
   try {
     removeLocalSetting(consentKey("tos", userId));
     removeLocalSetting(consentKey("privacy", userId));
+    removeLocalSetting(legacyPrivacyConsentKey(userId));
     removeLocalSetting(consentKey("share_analytics", userId));
     removeLocalSetting(consentKey("share_diagnostics", userId));
   } catch {


### PR DESCRIPTION
## What

Splits the single `CONSENT_VERSION` into two independent version constants and restructures the onboarding/review-terms consent checkboxes to match.

### Version split
- `TOS_CONSENT_VERSION` — tracks only `tos_accepted_version`.
- `PRIVACY_CONSENT_VERSION` — tracks `privacy_policy_accepted_version`, `ai_data_sharing_accepted_version`, and both share toggles (`share_analytics`/`share_diagnostics`).

This lets us force re-review of the Terms of Service without re-prompting the privacy artifacts, and vice versa. (Both constants are seeded to the same `2026-06-08` value, so current behavior is unchanged until one is bumped.)

### Checkbox restructure
Previously two checkboxes: **(ToS + Privacy Policy)** and **(AI Data Sharing)**. Now:
- **Checkbox 1** — Terms of Service only → `TOS_CONSENT_VERSION`
- **Checkbox 2** — Privacy Policy **and** AI Data Sharing Policy → `PRIVACY_CONSENT_VERSION`

`resolveServerConsent` now reports `tos` current from `tos_accepted_version` alone, and `privacy` current only when **both** the privacy policy and AI data sharing versions match.

### Rename
The onboarding state `aiDataConsent` → `privacyConsent` everywhere it represents the second checkbox: store, prefs hooks/readers (`usePrivacyConsent`/`readPrivacyConsent`), `NavigationState`, the resolved-consent shape (`.ai` → `.privacy`), and the device-cache key (`device:consent:ai:*` → `device:consent:privacy:*`). Legacy localStorage migration key strings (`vellum:onboarding:aiDataConsent`) are intentionally left untouched.

## Testing
- `bunx tsc --noEmit` — clean
- `eslint` on all changed source files — clean
- All consent-related test suites pass (onboarding-cleanup, auth-store, navigation-resolver, review-terms-screen, privacy-screen, onboarding-lifecycle-sync), including new coverage for the independent version tracking and the combined privacy checkbox stamping both privacy-policy + AI-data-sharing versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)