### PR TITLE
fix: fail-closed Sentry diagnostics gating + self-review cleanups

### DIFF
--- a/assistant/src/config/schemas/memory-lifecycle.ts
+++ b/assistant/src/config/schemas/memory-lifecycle.ts
@@ -133,13 +133,9 @@ export const MemoryCleanupConfigSchema = z
       .nonnegative(
         "memory.cleanup.llmRequestLogRetentionMs must be non-negative",
       )
-      // Upper bound must match gateway MAX_LLM_REQUEST_LOG_RETENTION_MS in
-      // gateway/src/http/routes/privacy-config.ts. If a manually edited
-      // config.json sets a value larger than this, the gateway GET would
-      // return it and the macOS picker would snap it to its largest known
-      // option, and the next PATCH would silently truncate the value —
-      // causing quiet data loss. Enforcing the same cap here prevents the
-      // daemon from accepting out-of-range values in the first place.
+      // Cap retention at 365 days. Enforced daemon-side only: the cleanup jobs
+      // honor this bound, so a manually edited config.json with a larger value
+      // is rejected here rather than silently retained.
       .max(
         365 * 24 * 60 * 60 * 1000,
         "memory.cleanup.llmRequestLogRetentionMs must be <= 365 days in ms",

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -36,7 +36,12 @@ import {
 import { FilingService } from "../filing/filing-service.js";
 import { HeartbeatService } from "../heartbeat/heartbeat-service.js";
 import { backfillRelationshipStateIfMissing } from "../home/relationship-state-writer.js";
-import { closeSentry, initSentry, setSentryDeviceId } from "../instrument.js";
+import {
+  closeSentry,
+  initSentry,
+  setDiagnosticsConsented,
+  setSentryDeviceId,
+} from "../instrument.js";
 import {
   startGatewayFlagListener,
   stopGatewayFlagListener,
@@ -290,9 +295,10 @@ export async function runDaemon(): Promise<void> {
   log.info({ version: APP_VERSION }, "Daemon starting");
 
   try {
-    // Initialize crash reporting eagerly so early startup failures are
-    // captured. After config loads we check the opt-out flag and call
-    // closeSentry() if the user has disabled it.
+    // Initialize crash reporting eagerly so the Sentry client is ready before
+    // early startup failures occur. Events are dropped (beforeSend) until the
+    // consent gate below confirms share_diagnostics opt-in; dev mode and the
+    // legacy local opt-out hard-disable via closeSentry().
     initSentry();
 
     ensureDataDir();
@@ -645,23 +651,20 @@ export async function runDaemon(): Promise<void> {
     // Privacy gating: Sentry crash/error reporting follows the platform owner's
     // share_diagnostics consent; the usage telemetry reporter re-checks
     // share_analytics on every flush. Both are disabled in dev mode. Sentry was
-    // initialized early so pre-config crashes are captured; here we close it once
-    // the consent decision is known.
+    // initialized early, but beforeSend drops events until consent confirms
+    // opt-in, so pre-config crashes are held back rather than captured.
     const isDevMode = process.env.VELLUM_DEV === "1";
     if (isDevMode || config.legacyDiagnosticsOptOut === true) {
       // Dev mode and a preserved legacy local opt-out both disable Sentry
       // unconditionally, without waiting on platform consent.
       await closeSentry();
     } else {
-      // Otherwise leave Sentry in its initialized state (capturing early-startup
-      // crashes) until the first successful consent fetch; close it then if the
-      // owner has not consented to diagnostics. Evaluated once — later consent
-      // changes are not applied mid-session (matches the prior one-shot config
-      // gate). startConsentRefresh() below drives the fetch that fires this.
+      // Fail closed: Sentry events are dropped (beforeSend) until the first
+      // successful consent fetch confirms share_diagnostics opt-in. An absent
+      // session, missing identity, or failed fetch leaves crash reporting off,
+      // mirroring the share_analytics posture. Evaluated once (option 1).
       onConsentResolved((consent) => {
-        if (!consent.shareDiagnostics) {
-          void closeSentry();
-        }
+        setDiagnosticsConsented(consent.shareDiagnostics);
       });
     }
 

--- a/assistant/src/instrument.ts
+++ b/assistant/src/instrument.ts
@@ -9,6 +9,15 @@ import {
 } from "./config/env.js";
 import { APP_VERSION, COMMIT_SHA } from "./version.js";
 
+// Fail closed: drop all Sentry events until a successful platform consent fetch
+// confirms share_diagnostics opt-in (set via setDiagnosticsConsented).
+let diagnosticsConsented = false;
+
+/** Gate Sentry event delivery on the platform share_diagnostics consent. */
+export function setDiagnosticsConsented(consented: boolean): void {
+  diagnosticsConsented = consented;
+}
+
 /** Patterns that match sensitive data in Sentry event values. */
 const PII_PATTERNS = [
   /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g,
@@ -41,9 +50,10 @@ function redactObject(obj: unknown): unknown {
 /**
  * Call after dotenv has loaded so SENTRY_DSN_ASSISTANT is available.
  * Initializes Sentry when the DSN is set; no-ops when empty/unset so
- * local dev builds don't send crash reports. If the user later opts out
- * via the sendDiagnostics config key (or VELLUM_DEV=1), call closeSentry()
- * after config is loaded to stop future event capturing.
+ * local dev builds don't send crash reports. Events are dropped by
+ * beforeSend until the platform share_diagnostics consent confirms opt-in
+ * (see setDiagnosticsConsented); VELLUM_DEV=1 and legacyDiagnosticsOptOut
+ * hard-disable via closeSentry() after config loads.
  */
 export function initSentry(): void {
   const dsn = getSentryDsn();
@@ -77,6 +87,7 @@ export function initSentry(): void {
       },
     },
     beforeSend(event) {
+      if (!diagnosticsConsented) return null;
       if (event.exception?.values) {
         event.exception.values = event.exception.values.map((ex) => ({
           ...ex,
@@ -101,9 +112,9 @@ export function initSentry(): void {
 }
 
 /**
- * Stop capturing future Sentry events. Called after config loads when the
- * user has disabled sendDiagnostics so that early-startup crashes are
- * still captured but subsequent events are suppressed.
+ * Stop capturing future Sentry events. Called after config loads for the
+ * legacyDiagnosticsOptOut local opt-out (or VELLUM_DEV=1) to hard-disable
+ * crash reporting independent of the share_diagnostics consent gate.
  */
 export async function closeSentry(): Promise<void> {
   await Sentry.close();

--- a/assistant/src/platform/consent-cache.test.ts
+++ b/assistant/src/platform/consent-cache.test.ts
@@ -222,6 +222,23 @@ describe("onConsentResolved", () => {
     expect(received).toEqual([consent]);
   });
 
+  test("a throwing listener does not starve other listeners", async () => {
+    const received: OwnerConsent[] = [];
+    onConsentResolved(() => {
+      throw new Error("boom");
+    });
+    onConsentResolved((c) => received.push(c));
+
+    const consent: OwnerConsent = {
+      shareAnalytics: true,
+      shareDiagnostics: true,
+    };
+    setConsent(consent);
+    await refreshConsentCache();
+
+    expect(received).toEqual([consent]);
+  });
+
   test("a null fetch never fires; a later successful fetch does", async () => {
     const received: OwnerConsent[] = [];
     onConsentResolved((c) => received.push(c));

--- a/assistant/src/platform/consent-cache.ts
+++ b/assistant/src/platform/consent-cache.ts
@@ -71,7 +71,13 @@ export async function refreshConsentCache(): Promise<void> {
     if (!firstConsentResolved) {
       firstConsentResolved = true;
       const listeners = consentResolvedListeners.splice(0);
-      for (const l of listeners) l(consent);
+      for (const l of listeners) {
+        try {
+          l(consent);
+        } catch (err) {
+          log.debug({ err }, "consent-resolved listener failed");
+        }
+      }
     }
   }
 }

--- a/scripts/service-communication/__tests__/generate-matrix.test.ts
+++ b/scripts/service-communication/__tests__/generate-matrix.test.ts
@@ -187,10 +187,7 @@ describe("service communication matrix", () => {
      * Add to this list — with a comment — whenever a new file legitimately
      * matches the proxy patterns but is NOT a callsite.
      */
-    const ALLOWLIST = new Set<string>([
-      // Reads/writes config.json locally; never proxies to assistant.
-      "gateway/src/http/routes/privacy-config.ts",
-    ]);
+    const ALLOWLIST = new Set<string>([]);
 
     // Collect all callerGlobs from gateway->assistant entries.
     const gatewayToAssistantEntries = MATRIX_ENTRIES.filter(


### PR DESCRIPTION
## Summary
Addresses self-review findings for diagnostics-consent-gating.md:
- **Fail closed**: Sentry drops events (via beforeSend consent gate) until a successful fetch confirms share_diagnostics opt-in; off-platform/missing-identity/failed-fetch now leave crash reporting off, mirroring share_analytics.
- Isolate consent-resolved listeners from throwing (try/catch per listener).
- Drop stale comment referencing the deleted gateway privacy-config route; refresh instrument.ts comments to reference platform consent.
- Remove stale ALLOWLIST entry for the deleted gateway file.