### PR TITLE
Retry fallback conversation title generation

### DIFF
--- a/assistant/src/__tests__/conversation-title-service.test.ts
+++ b/assistant/src/__tests__/conversation-title-service.test.ts
@@ -69,10 +69,38 @@ import {
 describe("conversation-title-service", () => {
   beforeEach(() => {
     mockRunBtwSidechain.mockClear();
+    mockRunBtwSidechain.mockImplementation(
+      async (_params: Record<string, unknown>) => ({
+        text: "Project kickoff",
+        hadTextDeltas: true,
+        response: {
+          content: [{ type: "text", text: "Project kickoff" }],
+          model: "test-model",
+          usage: { inputTokens: 10, outputTokens: 5 },
+          stopReason: "end_turn",
+        },
+      }),
+    );
     mockGetConversation.mockClear();
+    mockGetConversation.mockImplementation(
+      (_conversationId: string) =>
+        ({
+          title: "Generating title...",
+          isAutoTitle: 1,
+        }) as {
+          title: string;
+          isAutoTitle: number;
+        },
+    );
     mockGetMessages.mockClear();
+    mockGetMessages.mockImplementation(() => [
+      { role: "user", content: "first message" },
+      { role: "assistant", content: "first reply" },
+      { role: "user", content: "follow-up" },
+    ]);
     mockUpdateConversationTitle.mockClear();
     mockGetConfiguredProvider.mockClear();
+    mockGetConfiguredProvider.mockImplementation(async () => null);
     mockPublishConversationTitleChanged.mockClear();
   });
 
@@ -230,6 +258,30 @@ describe("conversation-title-service", () => {
       "Project kickoff",
       1,
     );
+  });
+
+  test("fallback retry skips regeneration after a successful initial title", async () => {
+    mockGetConversation.mockReturnValueOnce({
+      title: "Project kickoff",
+      isAutoTitle: 1,
+    });
+
+    const provider = {
+      name: "test-provider",
+      sendMessage: mock(async () => {
+        throw new Error("should not call directly");
+      }),
+    };
+
+    const result = await regenerateConversationTitle({
+      conversationId: "conv-1",
+      provider,
+      onlyIfReplaceable: true,
+    });
+
+    expect(result).toEqual({ title: "Project kickoff", updated: false });
+    expect(mockRunBtwSidechain).not.toHaveBeenCalled();
+    expect(mockUpdateConversationTitle).not.toHaveBeenCalled();
   });
 
   test("rejects meta-failure outputs like 'Missing Context' and uses fallback", async () => {
@@ -482,6 +534,16 @@ describe("conversation-title-service", () => {
 
     // Both calls went through — failure didn't break the chain
     expect(mockRunBtwSidechain).toHaveBeenCalledTimes(2);
+    const firstUpdate = (
+      mockUpdateConversationTitle.mock.calls as unknown as Array<
+        [string, string, number?]
+      >
+    ).find((c) => c[0] === "conv-1");
+    expect(firstUpdate).toEqual([
+      "conv-1",
+      "Untitled Conversation",
+      AUTO_TITLE_DETERMINISTIC,
+    ]);
     // Second conversation got a proper title
     const secondUpdate = (
       mockUpdateConversationTitle.mock.calls as unknown as string[][]

--- a/assistant/src/__tests__/title-generate-hook.test.ts
+++ b/assistant/src/__tests__/title-generate-hook.test.ts
@@ -273,6 +273,23 @@ describe("title-generate stop hook", () => {
     });
   });
 
+  test("preserves the third-turn retitle when the title is still replaceable", async () => {
+    mockGetConversation.mockReturnValueOnce({
+      title: "Untitled Conversation",
+      isAutoTitle: 2,
+      conversationType: "standard",
+    });
+    const ctx = makeStopCtx({ messages: historyWithUserTurns(3) });
+
+    await stop(ctx);
+    await flushMacrotasks();
+
+    expect(queueRegenerateConversationTitleMock).toHaveBeenCalledTimes(1);
+    const call = queueRegenerateConversationTitleMock.mock.calls[0]?.[0];
+    expect(call?.conversationId).toBe("conv-1");
+    expect(call).not.toHaveProperty("onlyIfReplaceable");
+  });
+
   test("fallback title retry is not blocked by the retitling opt-out", async () => {
     skipAutoRetitling = true;
     mockGetConversation.mockReturnValueOnce({

--- a/assistant/src/__tests__/title-generate-hook.test.ts
+++ b/assistant/src/__tests__/title-generate-hook.test.ts
@@ -7,8 +7,8 @@
  * - `user-prompt-submit` — first-pass generation from the submitted prompt,
  *   scheduled on a later macrotask so the main agent-loop LLM request is
  *   issued first.
- * - `stop` — second-pass regeneration once the conversation reaches its third
- *   user turn (turn count derived from the user prompts in history).
+ * - `stop` — fallback retry for replaceable titles and second-pass
+ *   regeneration once the conversation reaches its third user turn.
  *
  * Both let the title service resolve the provider, persist the title, and
  * broadcast the resulting `conversation_title_updated` / `sync_changed`
@@ -31,11 +31,40 @@ const queueGenerateConversationTitleMock = mock(
   }): void => undefined,
 );
 const queueRegenerateConversationTitleMock = mock(
-  (_params: { conversationId: string; provider?: unknown }): void => undefined,
+  (_params: {
+    conversationId: string;
+    provider?: unknown;
+    onlyIfReplaceable?: boolean;
+  }): void => undefined,
 );
 mock.module("../memory/conversation-title-service.js", () => ({
+  AUTO_TITLE_DETERMINISTIC: 2,
+  isReplaceableTitle: (title: string | null) =>
+    title == null ||
+    title === "" ||
+    title === "Generating title..." ||
+    title === "New Conversation" ||
+    title === "Untitled" ||
+    title === "Untitled Conversation" ||
+    title.startsWith("Runtime: "),
   queueGenerateConversationTitle: queueGenerateConversationTitleMock,
   queueRegenerateConversationTitle: queueRegenerateConversationTitleMock,
+}));
+
+const mockGetConversation = mock(
+  (_conversationId: string) =>
+    ({
+      title: "Existing Title",
+      isAutoTitle: 1,
+      conversationType: "standard",
+    }) as {
+      title: string;
+      isAutoTitle: number;
+      conversationType: string;
+    },
+);
+mock.module("../memory/conversation-crud.js", () => ({
+  getConversation: mockGetConversation,
 }));
 
 // The `stop` hook reads `conversations.skipAutoRetitling`; stub the loader so
@@ -192,6 +221,19 @@ describe("title-generate stop hook", () => {
     resetPluginRegistryForTests();
     queueRegenerateConversationTitleMock.mockReset();
     queueRegenerateConversationTitleMock.mockImplementation(() => undefined);
+    mockGetConversation.mockReset();
+    mockGetConversation.mockImplementation(
+      (_conversationId: string) =>
+        ({
+          title: "Existing Title",
+          isAutoTitle: 1,
+          conversationType: "standard",
+        }) as {
+          title: string;
+          isAutoTitle: number;
+          conversationType: string;
+        },
+    );
     skipAutoRetitling = false;
   });
 
@@ -210,6 +252,44 @@ describe("title-generate stop hook", () => {
     expect(call?.conversationId).toBe("conv-1");
     expect(call).not.toHaveProperty("provider");
     expect(call).not.toHaveProperty("signal");
+    expect(call).not.toHaveProperty("onlyIfReplaceable");
+  });
+
+  test("retries a replaceable fallback title after a successful turn", async () => {
+    mockGetConversation.mockReturnValueOnce({
+      title: "Untitled Conversation",
+      isAutoTitle: 2,
+      conversationType: "standard",
+    });
+    const ctx = makeStopCtx({ messages: historyWithUserTurns(1) });
+
+    await stop(ctx);
+    await flushMacrotasks();
+
+    expect(queueRegenerateConversationTitleMock).toHaveBeenCalledTimes(1);
+    expect(queueRegenerateConversationTitleMock).toHaveBeenCalledWith({
+      conversationId: "conv-1",
+      onlyIfReplaceable: true,
+    });
+  });
+
+  test("fallback title retry is not blocked by the retitling opt-out", async () => {
+    skipAutoRetitling = true;
+    mockGetConversation.mockReturnValueOnce({
+      title: "Generating title...",
+      isAutoTitle: 1,
+      conversationType: "standard",
+    });
+    const ctx = makeStopCtx({ messages: historyWithUserTurns(1) });
+
+    await stop(ctx);
+    await flushMacrotasks();
+
+    expect(queueRegenerateConversationTitleMock).toHaveBeenCalledTimes(1);
+    expect(queueRegenerateConversationTitleMock).toHaveBeenCalledWith({
+      conversationId: "conv-1",
+      onlyIfReplaceable: true,
+    });
   });
 
   test("defers the regeneration so the completed turn is persisted first", async () => {

--- a/assistant/src/memory/conversation-title-service.ts
+++ b/assistant/src/memory/conversation-title-service.ts
@@ -166,6 +166,7 @@ export async function generateAndPersistConversationTitle(
     const fallback = deriveFallbackTitle(context) ?? UNTITLED_FALLBACK;
     updateConversationTitle(conversationId, fallback, AUTO_TITLE_DETERMINISTIC);
     publishConversationTitleChanged(conversationId, fallback);
+    logRetryableFallback(params, "no_provider");
     return { title: fallback, updated: true };
   }
 
@@ -206,6 +207,7 @@ export async function generateAndPersistConversationTitle(
   const fallback = deriveFallbackTitle(context) ?? UNTITLED_FALLBACK;
   updateConversationTitle(conversationId, fallback, AUTO_TITLE_DETERMINISTIC);
   publishConversationTitleChanged(conversationId, fallback);
+  logRetryableFallback(params, "empty_output");
   return { title: fallback, updated: true };
 }
 
@@ -230,7 +232,7 @@ export const titleMutex = new Mutex();
 /**
  * Fire-and-forget wrapper for title generation. Failures are logged
  * but do not propagate. On failure, replaces loading placeholder with
- * a stable fallback title so loading state is never permanent.
+ * a retryable fallback title so loading state is never permanent.
  *
  * Calls are serialized via {@link titleMutex} so burst conversation
  * creation does not overwhelm the LLM provider.
@@ -244,16 +246,20 @@ export function queueGenerateConversationTitle(
     })
     .catch((err) => {
       log.warn(
-        { err, conversationId: params.conversationId },
-        "Failed to generate conversation title (non-fatal)",
+        retryableFallbackLogFields(params, "generation_error", err),
+        "Conversation title generation used retryable fallback",
       );
-      // Replace loading placeholder with stable fallback
+      // Replace loading placeholder with a retryable fallback.
       try {
         const conversation = getConversation(params.conversationId);
         if (conversation && conversation.title === GENERATING_TITLE) {
           const fallback =
             deriveFallbackTitle(params.context) ?? UNTITLED_FALLBACK;
-          updateConversationTitle(params.conversationId, fallback);
+          updateConversationTitle(
+            params.conversationId,
+            fallback,
+            AUTO_TITLE_DETERMINISTIC,
+          );
           publishConversationTitleChanged(params.conversationId, fallback);
         }
       } catch {
@@ -268,6 +274,11 @@ export interface RegenerateTitleParams {
   conversationId: string;
   provider?: Provider;
   signal?: AbortSignal;
+  /**
+   * Limit regeneration to placeholder or deterministic titles. Used for retrying
+   * failed initial generation without racing against a successful initial title.
+   */
+  onlyIfReplaceable?: boolean;
 }
 
 /**
@@ -278,11 +289,14 @@ export interface RegenerateTitleParams {
 export async function regenerateConversationTitle(
   params: RegenerateTitleParams,
 ): Promise<{ title: string; updated: boolean }> {
-  const { conversationId, signal } = params;
+  const { conversationId, onlyIfReplaceable, signal } = params;
 
   const conversation = getConversation(conversationId);
   if (!conversation || !conversation.isAutoTitle) {
     return { title: conversation?.title ?? UNTITLED_FALLBACK, updated: false };
+  }
+  if (onlyIfReplaceable && !canReplaceTitle(conversation)) {
+    return { title: conversation.title ?? UNTITLED_FALLBACK, updated: false };
   }
 
   const provider =
@@ -317,7 +331,11 @@ export async function regenerateConversationTitle(
   if (title) {
     // Re-check isAutoTitle before persisting (race guard against manual rename)
     const current = getConversation(conversationId);
-    if (!current || !current.isAutoTitle) {
+    if (
+      !current ||
+      !current.isAutoTitle ||
+      (onlyIfReplaceable && !canReplaceTitle(current))
+    ) {
       return { title: current?.title ?? UNTITLED_FALLBACK, updated: false };
     }
 
@@ -406,6 +424,45 @@ function buildTitlePrompt(
   }
 
   return parts.join("\n");
+}
+
+function titleGenerationLogFields(params: GenerateTitleParams) {
+  return {
+    conversationId: params.conversationId,
+    contextOrigin: params.context?.origin,
+    hasContext: Boolean(params.context),
+    userMessageLength: params.userMessage?.length ?? 0,
+    assistantResponseLength: params.assistantResponse?.length ?? 0,
+  };
+}
+
+type TitleGenerationFallbackReason =
+  | "no_provider"
+  | "empty_output"
+  | "generation_error";
+
+function retryableFallbackLogFields(
+  params: GenerateTitleParams,
+  reason: TitleGenerationFallbackReason,
+  err?: unknown,
+): Record<string, unknown> {
+  const fields: Record<string, unknown> = {
+    ...titleGenerationLogFields(params),
+    reason,
+    fallbackSource: params.context ? "context" : "untitled",
+  };
+  if (err) fields.err = err;
+  return fields;
+}
+
+function logRetryableFallback(
+  params: GenerateTitleParams,
+  reason: TitleGenerationFallbackReason,
+): void {
+  log.warn(
+    retryableFallbackLogFields(params, reason),
+    "Conversation title generation used retryable fallback",
+  );
 }
 
 const META_FAILURE_TITLES = new Set([

--- a/assistant/src/plugins/defaults/title-generate/hooks/stop.ts
+++ b/assistant/src/plugins/defaults/title-generate/hooks/stop.ts
@@ -1,16 +1,16 @@
 /**
- * Default `stop` hook: triggers the second-pass conversation-title
- * regeneration once a conversation has accumulated enough context.
+ * Default `stop` hook: triggers conversation-title retry/regeneration once a
+ * conversation has accumulated useful context.
  *
  * The first title is generated from the opening prompt alone (see
  * `./user-prompt-submit.ts`). After a few exchanges the conversation's real
  * topic is usually clearer, so a single second pass re-titles using the most
- * recent messages. This hook is the trigger — it fires the regeneration when
- * the conversation reaches its third user turn — and delegates the title
- * itself to the service (`memory/conversation-title-service.ts`), which
- * re-checks that the title is still auto-generated, resolves the title
- * provider, persists, and broadcasts the `conversation_title_updated` /
- * `sync_changed` events.
+ * recent messages. This hook is the trigger — it retries placeholder titles
+ * after successful turns and fires the second-pass regeneration when the
+ * conversation reaches its third user turn. The service
+ * (`memory/conversation-title-service.ts`) re-checks that the title is still
+ * auto-generated, resolves the title provider, persists, and broadcasts the
+ * `conversation_title_updated` / `sync_changed` events.
  *
  * Turn count is read from history rather than an external counter: the number
  * of genuine user prompts — user-role messages that aren't purely tool results
@@ -22,7 +22,11 @@ import type { PluginHookFn, StopContext } from "@vellumai/plugin-api";
 
 import { getConfig } from "../../../../config/loader.js";
 import { getConversation } from "../../../../memory/conversation-crud.js";
-import { queueRegenerateConversationTitle } from "../../../../memory/conversation-title-service.js";
+import {
+  AUTO_TITLE_DETERMINISTIC,
+  isReplaceableTitle,
+  queueRegenerateConversationTitle,
+} from "../../../../memory/conversation-title-service.js";
 import type { Message } from "../../../../providers/types.js";
 
 /**
@@ -50,27 +54,56 @@ function countUserTurns(messages: ReadonlyArray<Message>): number {
   return turns;
 }
 
+function shouldRetryFallbackTitle(conversation: {
+  title: string | null;
+  isAutoTitle: number;
+}): boolean {
+  if (!conversation.isAutoTitle) return false;
+  return (
+    isReplaceableTitle(conversation.title) ||
+    conversation.isAutoTitle === AUTO_TITLE_DETERMINISTIC
+  );
+}
+
 const stop: PluginHookFn<StopContext> = async (ctx) => {
   // Re-title only at a genuine successful turn end (the model returned a reply
   // with no tool calls). Any other terminal — a provider rejection, abort, or
   // an output-limit cutoff — produced no new topic to re-title from.
   if (ctx.exitReason !== "no_tool_calls") return;
 
-  if (getConfig().conversations.skipAutoRetitling) return;
-
-  if (countUserTurns(ctx.messages) !== SECOND_PASS_USER_TURN) return;
+  const userTurns = countUserTurns(ctx.messages);
+  if (userTurns === 0) return;
 
   // System conversations (background/scheduled) keep their deterministic
   // bootstrap title — multi-prompt background jobs can reach three user-role
   // turns with no human present, and a refined LLM title isn't worth the
   // tokens there. The lookup fails open: on a read error the hook behaves as
   // before (queues regeneration; the service re-checks isAutoTitle).
+  let retryFallbackTitle = false;
   try {
     const conversation = getConversation(ctx.conversationId);
     if (conversation && conversation.conversationType !== "standard") return;
+    retryFallbackTitle = conversation
+      ? shouldRetryFallbackTitle(conversation)
+      : false;
   } catch {
     // Fall through to queueing.
   }
+
+  if (retryFallbackTitle) {
+    const { conversationId } = ctx;
+    setTimeout(() => {
+      queueRegenerateConversationTitle({
+        conversationId,
+        onlyIfReplaceable: true,
+      });
+    }, 0);
+    return;
+  }
+
+  if (getConfig().conversations.skipAutoRetitling) return;
+
+  if (userTurns !== SECOND_PASS_USER_TURN) return;
 
   const { conversationId } = ctx;
   // Deferred to a later macrotask so the just-completed turn's persistence

--- a/assistant/src/plugins/defaults/title-generate/hooks/stop.ts
+++ b/assistant/src/plugins/defaults/title-generate/hooks/stop.ts
@@ -90,6 +90,22 @@ const stop: PluginHookFn<StopContext> = async (ctx) => {
     // Fall through to queueing.
   }
 
+  if (
+    userTurns === SECOND_PASS_USER_TURN &&
+    !getConfig().conversations.skipAutoRetitling
+  ) {
+    const { conversationId } = ctx;
+    // Deferred to a later macrotask so the just-completed turn's persistence
+    // settles first. The service regenerates from the most recent stored
+    // messages, so it must run after the reply is persisted to reflect it. The
+    // service is itself fire-and-forget and re-checks replaceability, owning
+    // provider resolution, persistence, and the resulting broadcast.
+    setTimeout(() => {
+      queueRegenerateConversationTitle({ conversationId });
+    }, 0);
+    return;
+  }
+
   if (retryFallbackTitle) {
     const { conversationId } = ctx;
     setTimeout(() => {
@@ -100,20 +116,6 @@ const stop: PluginHookFn<StopContext> = async (ctx) => {
     }, 0);
     return;
   }
-
-  if (getConfig().conversations.skipAutoRetitling) return;
-
-  if (userTurns !== SECOND_PASS_USER_TURN) return;
-
-  const { conversationId } = ctx;
-  // Deferred to a later macrotask so the just-completed turn's persistence
-  // settles first. The service regenerates from the most recent stored
-  // messages, so it must run after the reply is persisted to reflect it. The
-  // service is itself fire-and-forget and re-checks replaceability, owning
-  // provider resolution, persistence, and the resulting broadcast.
-  setTimeout(() => {
-    queueRegenerateConversationTitle({ conversationId });
-  }, 0);
 };
 
 export default stop;


### PR DESCRIPTION
## Summary
- Retry replaceable fallback conversation titles after successful turns while preserving the existing third-turn retitle pass.
- Guard fallback retries so they do not overwrite an initial title that succeeded first.
- Add structured fallback diagnostics and focused regression tests.

## Original prompt
Investigate a report where conversation titles stayed as `Untitled Conversation`, then harden the title-setting path and open a PR.