### PR TITLE
fix(sentry): suppress background Sentry traffic before diagnostics consent

### DIFF
--- a/assistant/src/instrument.ts
+++ b/assistant/src/instrument.ts
@@ -64,6 +64,14 @@ export function initSentry(): void {
     dist: COMMIT_SHA,
     environment: process.env.VELLUM_ENVIRONMENT ?? "production",
     sendDefaultPii: false,
+    // Fail-closed: suppress client-report pings (discarded-event counts) so an
+    // assistant with unconfirmed share_diagnostics consent stays network-silent.
+    sendClientReports: false,
+    // Drop the default ProcessSession integration: it starts a release-health
+    // session on init and flushes a session envelope on process exit (a network
+    // request not covered by the beforeSend event gate), violating fail-closed.
+    integrations: (defaults) =>
+      defaults.filter((i) => i.name !== "ProcessSession"),
     serverName: hostname(),
     initialScope: {
       tags: {

--- a/assistant/src/platform/consent-cache.ts
+++ b/assistant/src/platform/consent-cache.ts
@@ -10,7 +10,7 @@
 
 import { getConfigReadOnly } from "../config/loader.js";
 import { getLogger } from "../util/logger.js";
-import { type OwnerConsent,VellumPlatformClient } from "./client.js";
+import { type OwnerConsent, VellumPlatformClient } from "./client.js";
 
 const log = getLogger("consent-cache");
 


### PR DESCRIPTION
## Summary
- Set `sendClientReports: false` so an assistant with unconfirmed `share_diagnostics` consent makes no Sentry client-report network requests (completes the fail-closed posture; beforeSend already drops event payloads).
- Drop the default `ProcessSession` integration: in @sentry/node v10.43.0 it starts a release-health session on init and flushes a session envelope on process exit (`beforeExit`) via `sendSession()` — a network request NOT covered by the `beforeSend` event gate. v10 removed the legacy `autoSessionTracking`/`enableAutoSessionTracking` option, so filtering the default integration (the supported `integrations` callback form) is the correct v10 mechanism.
- Fix a cosmetic import-spacing nit in consent-cache.ts.

### Session/release-health verification
@sentry/node v10.43.0 enables `processSessionIntegration` in its default integrations; `setupOnce` calls `startSession()` and registers a `beforeExit` handler that sends a session envelope unconditionally (no consent gate). There is no top-level `autoSessionTracking`/`releaseHealth` option in v10's `options.d.ts`, so the integration filter is the minimal valid fix.