### PR TITLE
fix(slack): in-place edits never post a duplicate on transient failure (LUM-2511)

### DIFF
--- a/assistant/src/messaging/providers/slack/send.test.ts
+++ b/assistant/src/messaging/providers/slack/send.test.ts
@@ -85,9 +85,15 @@ describe("sendSlackAssistantThreadStatus", () => {
 
 describe("sendSlackReply update path", () => {
   const messageTs = "1700000000.000100";
+  const threadTs = "1700000000.000001";
   const blocks = [
     { type: "section", text: { type: "mrkdwn", text: "Final reply" } },
   ];
+
+  const postMessageCalls = () =>
+    callSlackApiMock.mock.calls.filter(
+      (call) => call[0] === "chat.postMessage",
+    );
 
   beforeEach(() => {
     callSlackApiMock.mockReset();
@@ -103,13 +109,13 @@ describe("sendSlackReply update path", () => {
 
     const result = await sendSlackReply("C123", "Final reply", {
       messageTs,
-      threadTs: "1700000000.000001",
+      threadTs,
       blocks,
     });
 
     expect(result).toEqual({ ok: true, ts: messageTs });
     // Two chat.update calls (with then without blocks); never chat.postMessage,
-    // so the placeholder is edited in place rather than duplicated.
+    // so the message is edited in place rather than duplicated.
     expect(callSlackApiMock).toHaveBeenCalledTimes(2);
     expect(callSlackApiMock).toHaveBeenNthCalledWith(1, "chat.update", {
       channel: "C123",
@@ -122,68 +128,107 @@ describe("sendSlackReply update path", () => {
       text: "Final reply",
       ts: messageTs,
     });
-    const postMessageCalls = callSlackApiMock.mock.calls.filter(
-      (call) => call[0] === "chat.postMessage",
-    );
-    expect(postMessageCalls).toHaveLength(0);
+    expect(postMessageCalls()).toHaveLength(0);
   });
 
-  test("falls back to chat.postMessage only after the no-block update retry also fails", async () => {
+  test("throws when the no-block update retry also fails, never posting a duplicate", async () => {
     callSlackApiMock
       .mockImplementationOnce(async () => {
         throw new SlackApiError("invalid_blocks");
       })
       .mockImplementationOnce(async () => {
         throw new SlackApiError("message_not_found");
-      })
-      .mockImplementationOnce(async () => ({
-        ok: true,
-        ts: "1700000000.000200",
-      }));
+      });
 
-    const result = await sendSlackReply("C123", "Final reply", {
-      messageTs,
-      threadTs: "1700000000.000001",
-      blocks,
-    });
+    await expect(
+      sendSlackReply("C123", "Final reply", { messageTs, threadTs, blocks }),
+    ).rejects.toThrow();
 
-    expect(result).toEqual({ ok: true, ts: "1700000000.000200" });
-    expect(callSlackApiMock).toHaveBeenCalledTimes(3);
-    expect(callSlackApiMock.mock.calls[0]?.[0]).toBe("chat.update");
-    expect(callSlackApiMock.mock.calls[1]?.[0]).toBe("chat.update");
-    // The post fallback drops the rejected blocks.
-    expect(callSlackApiMock).toHaveBeenNthCalledWith(3, "chat.postMessage", {
-      channel: "C123",
-      text: "Final reply",
-      thread_ts: "1700000000.000001",
-    });
-  });
-
-  test("non-invalid_blocks update failure still falls back to chat.postMessage", async () => {
-    callSlackApiMock
-      .mockImplementationOnce(async () => {
-        throw new SlackApiError("internal_error");
-      })
-      .mockImplementationOnce(async () => ({
-        ok: true,
-        ts: "1700000000.000200",
-      }));
-
-    const result = await sendSlackReply("C123", "Final reply", {
-      messageTs,
-      threadTs: "1700000000.000001",
-      blocks,
-    });
-
-    expect(result).toEqual({ ok: true, ts: "1700000000.000200" });
-    // One failed chat.update, then a single chat.postMessage (no extra retry).
+    // Two in-place chat.update attempts (with then without blocks), then give
+    // up — it must not fall back to chat.postMessage and duplicate the message.
     expect(callSlackApiMock).toHaveBeenCalledTimes(2);
     expect(callSlackApiMock.mock.calls[0]?.[0]).toBe("chat.update");
-    expect(callSlackApiMock).toHaveBeenNthCalledWith(2, "chat.postMessage", {
-      channel: "C123",
-      text: "Final reply",
-      thread_ts: "1700000000.000001",
+    expect(callSlackApiMock.mock.calls[1]?.[0]).toBe("chat.update");
+    expect(postMessageCalls()).toHaveLength(0);
+  });
+
+  test("throws on a transient chat.update failure instead of posting a duplicate", async () => {
+    callSlackApiMock.mockImplementationOnce(async () => {
+      throw new SlackApiError("internal_error");
+    });
+
+    await expect(
+      sendSlackReply("C123", "Final reply", { messageTs, threadTs, blocks }),
+    ).rejects.toThrow();
+
+    // A single failed chat.update, no chat.postMessage fallback: a transient
+    // failure must not spawn a "ghost" reply beside the message we failed to
+    // edit. Re-delivery is the delivery layer's job.
+    expect(callSlackApiMock).toHaveBeenCalledTimes(1);
+    expect(callSlackApiMock.mock.calls[0]?.[0]).toBe("chat.update");
+    expect(postMessageCalls()).toHaveLength(0);
+  });
+
+  test("throws when the edit target is gone rather than re-posting it", async () => {
+    // Even when the target message no longer exists, this function does not
+    // post a fresh one — re-delivery is owned by the delivery layer, which
+    // would otherwise double-post.
+    callSlackApiMock.mockImplementationOnce(async () => {
+      throw new SlackApiError("message_not_found");
+    });
+
+    await expect(
+      sendSlackReply("C123", "Final reply", { messageTs, threadTs, blocks }),
+    ).rejects.toThrow();
+
+    expect(callSlackApiMock).toHaveBeenCalledTimes(1);
+    expect(callSlackApiMock.mock.calls[0]?.[0]).toBe("chat.update");
+    expect(postMessageCalls()).toHaveLength(0);
+  });
+});
+
+describe("sendSlackReply post path", () => {
+  const threadTs = "1700000000.000001";
+  const blocks = [
+    { type: "section", text: { type: "mrkdwn", text: "Fresh reply" } },
+  ];
+
+  beforeEach(() => {
+    callSlackApiMock.mockReset();
+    callSlackApiMock.mockImplementation(async () => ({ ok: true }));
+  });
+
+  test("retries chat.postMessage without blocks on invalid_blocks", async () => {
+    callSlackApiMock
+      .mockImplementationOnce(async () => {
+        throw new SlackApiError("invalid_blocks");
+      })
+      .mockImplementationOnce(async () => ({
+        ok: true,
+        ts: "1700000000.000200",
+      }));
+
+    const result = await sendSlackReply("C123", "Fresh reply", {
+      threadTs,
       blocks,
     });
+
+    expect(result).toEqual({ ok: true, ts: "1700000000.000200" });
+    // Two chat.postMessage calls (with then without blocks); never chat.update.
+    expect(callSlackApiMock).toHaveBeenCalledTimes(2);
+    expect(callSlackApiMock).toHaveBeenNthCalledWith(1, "chat.postMessage", {
+      channel: "C123",
+      text: "Fresh reply",
+      thread_ts: threadTs,
+      blocks,
+    });
+    expect(callSlackApiMock).toHaveBeenNthCalledWith(2, "chat.postMessage", {
+      channel: "C123",
+      text: "Fresh reply",
+      thread_ts: threadTs,
+    });
+    expect(
+      callSlackApiMock.mock.calls.filter((call) => call[0] === "chat.update"),
+    ).toHaveLength(0);
   });
 });

--- a/assistant/src/messaging/providers/slack/send.test.ts
+++ b/assistant/src/messaging/providers/slack/send.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-type CallSlackApi = (
-  method: string,
-  body: Record<string, unknown>,
-) => Promise<Record<string, unknown>>;
+// Derive the mock signature from the real export so it cannot drift from the
+// production response shape (`SlackApiResponse`). A hand-rolled
+// `Promise<Record<string, unknown>>` here would let a test pass against a
+// response shape production never actually returns.
+type CallSlackApi = typeof import("./api.js").callSlackApi;
 
 const callSlackApiMock = mock<CallSlackApi>(async () => ({ ok: true }));
 

--- a/assistant/src/messaging/providers/slack/send.ts
+++ b/assistant/src/messaging/providers/slack/send.ts
@@ -125,7 +125,50 @@ export interface SlackSendResult {
 }
 
 /**
+ * Call a Slack message API once, retrying a single time without Block Kit
+ * blocks if Slack rejects the payload with `invalid_blocks`.
+ *
+ * `invalid_blocks` faults the Block Kit payload, not the target — the retry
+ * repeats the *same* operation (same `chat.update` ts, same `chat.postMessage`
+ * thread) without blocks, so it edits/posts in place rather than spawning a
+ * second message. Any other error propagates to the caller.
+ */
+async function sendWithBlockFallback(
+  method: string,
+  baseBody: Record<string, unknown>,
+  blocks: unknown[],
+  options: { fallbackWithoutBlocks: boolean },
+): Promise<SlackSendResult> {
+  try {
+    const result = await callSlackApi(
+      method,
+      blocks.length > 0 ? { ...baseBody, blocks } : baseBody,
+    );
+    return { ok: true, ts: result.ts };
+  } catch (err) {
+    if (
+      options.fallbackWithoutBlocks &&
+      blocks.length > 0 &&
+      err instanceof SlackApiError &&
+      err.slackError === "invalid_blocks"
+    ) {
+      log.warn({ method }, "Slack rejected blocks; retrying without blocks");
+      const result = await callSlackApi(method, baseBody);
+      return { ok: true, ts: result.ts };
+    }
+    throw err;
+  }
+}
+
+/**
  * Send a Slack text message with optional Block Kit formatting.
+ *
+ * When `messageTs` is set this is strictly an in-place edit (`chat.update`),
+ * mirroring `editMessage()` in ./withdraw.ts: a failed edit throws and is
+ * never converted into a fresh `chat.postMessage`. Posting on failure would
+ * leave the original message beside a duplicate ("ghost") reply; re-delivery
+ * after a transient failure is the delivery layer's responsibility, not this
+ * function's.
  */
 export async function sendSlackReply(
   chatId: string,
@@ -139,107 +182,45 @@ export async function sendSlackReply(
     options?.useBlocks,
   );
 
-  const slackBody: Record<string, unknown> = {
-    channel: chatId,
-    text,
-  };
-  if (blocks.length > 0) slackBody.blocks = blocks;
-  if (options?.threadTs) slackBody.thread_ts = options.threadTs;
-
-  const isUpdate =
-    typeof options?.messageTs === "string" && options.messageTs.length > 0;
-
-  if (isUpdate) {
-    const updateBody: Record<string, unknown> = {
-      channel: chatId,
-      text,
-      ts: options!.messageTs,
-    };
-    if (blocks.length > 0) updateBody.blocks = blocks;
-
-    try {
-      const result = await callSlackApi("chat.update", updateBody);
-      log.info(
-        { chatId, messageTs: options!.messageTs },
-        "Slack message updated",
-      );
-      return { ok: true, ts: result.ts };
-    } catch (err) {
-      if (
-        err instanceof SlackApiError &&
-        err.slackError === "invalid_blocks" &&
-        Array.isArray(updateBody.blocks) &&
-        updateBody.blocks.length > 0
-      ) {
-        // `invalid_blocks` means Slack rejected the Block Kit payload, not the
-        // target message — the message still exists. Retry the update without
-        // blocks so it is edited in place. Posting a fresh message here would
-        // leave the original alongside a duplicate ("ghost") reply.
-        const retryBody: Record<string, unknown> = {
-          channel: chatId,
-          text,
-          ts: options!.messageTs,
-        };
-        try {
-          const retryResult = await callSlackApi("chat.update", retryBody);
-          log.info(
-            { chatId, messageTs: options!.messageTs },
-            "Slack message updated without blocks after invalid_blocks",
-          );
-          return { ok: true, ts: retryResult.ts };
-        } catch (retryErr) {
-          log.warn(
-            { err: retryErr, chatId, messageTs: options!.messageTs },
-            "Slack chat.update without blocks failed, falling back to chat.postMessage",
-          );
-          delete slackBody.blocks;
-        }
-      } else {
-        log.warn(
-          { err, chatId, messageTs: options!.messageTs },
-          "Slack chat.update failed, falling back to chat.postMessage",
-        );
-      }
-    }
+  const messageTs = options?.messageTs;
+  if (typeof messageTs === "string" && messageTs.length > 0) {
+    const result = await sendWithBlockFallback(
+      "chat.update",
+      { channel: chatId, text, ts: messageTs },
+      blocks,
+      { fallbackWithoutBlocks: true },
+    );
+    log.info({ chatId, messageTs }, "Slack message updated");
+    return result;
   }
+
+  const postBase: Record<string, unknown> = { channel: chatId, text };
+  if (options?.threadTs) postBase.thread_ts = options.threadTs;
 
   if (options?.ephemeral) {
     if (!options.user)
       throw new Error("user is required for ephemeral messages");
     const result = await callSlackApi("chat.postEphemeral", {
-      ...slackBody,
+      ...postBase,
+      ...(blocks.length > 0 ? { blocks } : {}),
       user: options.user,
     });
     return { ok: true, ts: result.ts };
   }
 
-  try {
-    const result = await callSlackApi("chat.postMessage", slackBody);
-    log.info(
-      { chatId, hasThreadTs: !!options?.threadTs },
-      "Slack message sent",
-    );
-    return { ok: true, ts: result.ts };
-  } catch (err) {
-    // Retry without blocks for invalid_blocks errors
-    if (
-      err instanceof SlackApiError &&
-      err.slackError === "invalid_blocks" &&
-      !options?.approval &&
-      !options?.ephemeral &&
-      Array.isArray(slackBody.blocks) &&
-      (slackBody.blocks as unknown[]).length > 0
-    ) {
-      log.warn(
-        { chatId },
-        "Retrying Slack delivery without blocks after invalid_blocks",
-      );
-      delete slackBody.blocks;
-      const result = await callSlackApi("chat.postMessage", slackBody);
-      return { ok: true, ts: result.ts };
-    }
-    throw err;
-  }
+  // Approval prompts carry their action buttons in `blocks`; dropping them on
+  // `invalid_blocks` would post a card with no way to respond, so only
+  // non-approval posts fall back to a block-free retry.
+  const result = await sendWithBlockFallback(
+    "chat.postMessage",
+    postBase,
+    blocks,
+    {
+      fallbackWithoutBlocks: !options?.approval,
+    },
+  );
+  log.info({ chatId, hasThreadTs: !!options?.threadTs }, "Slack message sent");
+  return result;
 }
 
 /**

--- a/assistant/src/messaging/providers/slack/send.ts
+++ b/assistant/src/messaging/providers/slack/send.ts
@@ -121,7 +121,6 @@ export interface SlackSendOptions {
 export interface SlackSendResult {
   ok: boolean;
   ts?: string;
-  placeholderTs?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

`sendSlackReply`'s **update path** (when `messageTs` is set) fell back to `chat.postMessage` on **any** `chat.update` failure. Because `messageTs` always references a message that **already exists**, a *transient* failure (rate limit, network, Slack `internal_error`/5xx) posted a fresh message beside the one it failed to edit — a duplicate **"ghost" reply**, which the retry/dead-letter sweep then compounded.

This is the transient slice that #35365 fixed only for `invalid_blocks` and explicitly surfaced as the remaining work (LUM-2511).

## Root cause

The update path treated "I couldn't edit the message" as "the message isn't there, so post a new one." But a failed edit does **not** mean the target is gone:

| `chat.update` outcome | Target message | Old behavior | Result |
|---|---|---|---|
| transient (`internal_error`, rate limit, 5xx) | still exists | post fresh | **duplicate** |
| `cant_update_message` / edit window closed | still exists | post fresh | **duplicate** |
| `message_not_found` | gone | post fresh | delivery layer also re-delivers → **double** |

Only `message_not_found` is even arguably a "post fresh" case — and even there, re-delivery is already owned by the delivery layer, so posting here races/doubles it.

## The fix

Make the update path **strictly in-place**, mirroring `editMessage()` in `slack/withdraw.ts` ("strictly an in-place edit … it never posts a new message"): a failed `chat.update` **throws** and is never converted into a `chat.postMessage`. Recovery after a transient failure is the delivery layer's responsibility, not this function's.

Every `messageTs` (update) caller already tolerates a throw — audited:
- **Notification update** (`SlackAdapter.update`) — `try/catch` → `{ success: false }`; it's semantically an edit and never wants a fresh post.
- **Approval-card edits** (`editSlackApprovalMessage` / `editStaleSlackApprovalMessage`) — `.catch(log)` fire-and-forget; a fresh post here is precisely the duplicate-card ghost.
- **Finalize / retry sweep** — records the failure and re-delivers from the **persisted segment baseline** (no `messageTs`), resuming rather than re-posting an already-delivered segment.

The `invalid_blocks` retry (#35365) is preserved as an **in-place** edit (retry `chat.update` without blocks) and unified with the post path's identical retry into a single `sendWithBlockFallback` helper, so the block-fallback logic lives in one place instead of two divergent copies. Request bodies are rebuilt fresh per call (never mutated), so an in-flight payload is never aliased.

```
messageTs set ─▶ chat.update ──invalid_blocks──▶ chat.update (no blocks)   ◀── in place, no duplicate
                     │                                  │ any failure
                     │ any other failure                ▼
                     └──────────────────────────────▶ throw  (never chat.postMessage)
```

## Tests

`send.test.ts`:
- **update** `invalid_blocks` → retries `chat.update` without blocks, never `chat.postMessage` (unchanged).
- **update** transient (`internal_error`) → **throws**; single `chat.update`, no `chat.postMessage`.
- **update** target gone (`message_not_found`) → **throws**; no `chat.postMessage`.
- **update** `invalid_blocks` then the no-block retry also fails → **throws**; two `chat.update`, no `chat.postMessage`.
- **post** `invalid_blocks` → retries `chat.postMessage` without blocks (locks the unified helper on the post path).

Local: `bun test send.test.ts` (7/7), `tsc --noEmit`, eslint, prettier all clean.

Closes LUM-2511.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBeXq7TEG2Whk8bZPpwKsP

---
_Generated by [Claude Code](https://claude.ai/code/session_01JBeXq7TEG2Whk8bZPpwKsP)_