### PR TITLE
fix(daemon): honor diagnostics revocations via periodic consent refresh

### DIFF
--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -36,12 +36,7 @@ import {
 import { FilingService } from "../filing/filing-service.js";
 import { HeartbeatService } from "../heartbeat/heartbeat-service.js";
 import { backfillRelationshipStateIfMissing } from "../home/relationship-state-writer.js";
-import {
-  closeSentry,
-  initSentry,
-  setDiagnosticsConsented,
-  setSentryDeviceId,
-} from "../instrument.js";
+import { closeSentry, initSentry, setSentryDeviceId } from "../instrument.js";
 import {
   startGatewayFlagListener,
   stopGatewayFlagListener,
@@ -66,7 +61,6 @@ import { emitNotificationSignal } from "../notifications/emit-signal.js";
 import { backfillManualTokenConnections } from "../oauth/manual-token-connection.js";
 import { seedOAuthProviders } from "../oauth/seed-providers.js";
 import {
-  onConsentResolved,
   startConsentRefresh,
   stopConsentRefresh,
 } from "../platform/consent-cache.js";
@@ -651,21 +645,15 @@ export async function runDaemon(): Promise<void> {
     // Privacy gating: Sentry crash/error reporting follows the platform owner's
     // share_diagnostics consent; the usage telemetry reporter re-checks
     // share_analytics on every flush. Both are disabled in dev mode. Sentry was
-    // initialized early, but beforeSend drops events until consent confirms
-    // opt-in, so pre-config crashes are held back rather than captured.
+    // initialized early, but beforeSend re-reads getCachedShareDiagnostics() on
+    // every event, so it drops events until consent confirms opt-in and honors a
+    // later revocation within one refresh cycle (the cache is refreshed by
+    // startConsentRefresh() below, mirroring the share_analytics posture).
     const isDevMode = process.env.VELLUM_DEV === "1";
     if (isDevMode || config.legacyDiagnosticsOptOut === true) {
       // Dev mode and a preserved legacy local opt-out both disable Sentry
       // unconditionally, without waiting on platform consent.
       await closeSentry();
-    } else {
-      // Fail closed: Sentry events are dropped (beforeSend) until the first
-      // successful consent fetch confirms share_diagnostics opt-in. An absent
-      // session, missing identity, or failed fetch leaves crash reporting off,
-      // mirroring the share_analytics posture. Evaluated once (option 1).
-      onConsentResolved((consent) => {
-        setDiagnosticsConsented(consent.shareDiagnostics);
-      });
     }
 
     // Construct and start the reporter even when usage collection is disabled:

--- a/assistant/src/instrument.ts
+++ b/assistant/src/instrument.ts
@@ -7,16 +7,8 @@ import {
   getPlatformUserId,
   getSentryDsn,
 } from "./config/env.js";
+import { getCachedShareDiagnostics } from "./platform/consent-cache.js";
 import { APP_VERSION, COMMIT_SHA } from "./version.js";
-
-// Fail closed: drop all Sentry events until a successful platform consent fetch
-// confirms share_diagnostics opt-in (set via setDiagnosticsConsented).
-let diagnosticsConsented = false;
-
-/** Gate Sentry event delivery on the platform share_diagnostics consent. */
-export function setDiagnosticsConsented(consented: boolean): void {
-  diagnosticsConsented = consented;
-}
 
 /** Patterns that match sensitive data in Sentry event values. */
 const PII_PATTERNS = [
@@ -52,7 +44,8 @@ function redactObject(obj: unknown): unknown {
  * Initializes Sentry when the DSN is set; no-ops when empty/unset so
  * local dev builds don't send crash reports. Events are dropped by
  * beforeSend until the platform share_diagnostics consent confirms opt-in
- * (see setDiagnosticsConsented); VELLUM_DEV=1 and legacyDiagnosticsOptOut
+ * (re-read from the consent cache per event, so a revocation takes effect
+ * within one refresh cycle); VELLUM_DEV=1 and legacyDiagnosticsOptOut
  * hard-disable via closeSentry() after config loads.
  */
 export function initSentry(): void {
@@ -95,7 +88,7 @@ export function initSentry(): void {
       },
     },
     beforeSend(event) {
-      if (!diagnosticsConsented) return null;
+      if (!getCachedShareDiagnostics()) return null;
       if (event.exception?.values) {
         event.exception.values = event.exception.values.map((ex) => ({
           ...ex,

--- a/assistant/src/platform/consent-cache.test.ts
+++ b/assistant/src/platform/consent-cache.test.ts
@@ -46,10 +46,10 @@ mock.module("../util/logger.js", () => ({
 // ---------------------------------------------------------------------------
 
 import {
-  __resetConsentResolutionForTest,
   __setCachedShareAnalyticsForTest,
+  __setCachedShareDiagnosticsForTest,
   getCachedShareAnalytics,
-  onConsentResolved,
+  getCachedShareDiagnostics,
   refreshConsentCache,
   startConsentRefresh,
   stopConsentRefresh,
@@ -68,12 +68,11 @@ describe("consent-cache", () => {
     createCallCount = 0;
     mockLegacyTelemetryOptOut = false;
     __setCachedShareAnalyticsForTest(false);
-    __resetConsentResolutionForTest();
+    __setCachedShareDiagnosticsForTest(false);
   });
 
   afterEach(async () => {
     await stopConsentRefresh();
-    __resetConsentResolutionForTest();
   });
 
   test("defaults to false before any refresh", () => {
@@ -160,100 +159,53 @@ describe("consent-cache", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(getCachedShareAnalytics()).toBe(true);
   });
-});
 
-describe("onConsentResolved", () => {
-  beforeEach(() => {
+  // share_diagnostics tracks the same refresh as share_analytics; Sentry's
+  // beforeSend re-reads it per event so a revocation is honored within a cycle.
+  test("diagnostics defaults to false before any refresh", () => {
+    expect(getCachedShareDiagnostics()).toBe(false);
+  });
+
+  test("diagnostics becomes true after a fetch reporting shareDiagnostics: true", async () => {
+    mockClient = makeClient({ shareAnalytics: false, shareDiagnostics: true });
+    await refreshConsentCache();
+    expect(getCachedShareDiagnostics()).toBe(true);
+  });
+
+  test("a later fetch reporting shareDiagnostics: false honors the revocation", async () => {
+    mockClient = makeClient({ shareAnalytics: false, shareDiagnostics: true });
+    await refreshConsentCache();
+    expect(getCachedShareDiagnostics()).toBe(true);
+
+    mockClient = makeClient({ shareAnalytics: false, shareDiagnostics: false });
+    await refreshConsentCache();
+    expect(getCachedShareDiagnostics()).toBe(false);
+  });
+
+  test("a null diagnostics fetch keeps the last known value", async () => {
+    mockClient = makeClient({ shareAnalytics: false, shareDiagnostics: true });
+    await refreshConsentCache();
+    expect(getCachedShareDiagnostics()).toBe(true);
+
+    mockClient = makeClient(null);
+    await refreshConsentCache();
+    expect(getCachedShareDiagnostics()).toBe(true);
+  });
+
+  test("a missing client flips a prior diagnostics opt-in back to false", async () => {
+    __setCachedShareDiagnosticsForTest(true);
     mockClient = null;
-    createCallCount = 0;
-    mockLegacyTelemetryOptOut = false;
-    __setCachedShareAnalyticsForTest(false);
-    __resetConsentResolutionForTest();
+    await refreshConsentCache();
+    expect(getCachedShareDiagnostics()).toBe(false);
   });
 
-  afterEach(async () => {
-    await stopConsentRefresh();
-    __resetConsentResolutionForTest();
-  });
-
-  function setConsent(consent: OwnerConsent | null) {
-    mockClient = makeClient(consent);
-  }
-
-  test("fires once on the first successful fetch with the resolved consent", async () => {
-    const consent: OwnerConsent = {
-      shareAnalytics: true,
-      shareDiagnostics: false,
-    };
-    const received: OwnerConsent[] = [];
-    onConsentResolved((c) => received.push(c));
-
-    setConsent(consent);
+  test("a client without a resolvable assistant identity fails diagnostics closed", async () => {
+    __setCachedShareDiagnosticsForTest(true);
+    mockClient = makeClient(
+      { shareAnalytics: false, shareDiagnostics: true },
+      "",
+    );
     await refreshConsentCache();
-
-    expect(received).toEqual([consent]);
-  });
-
-  test("does not fire again on a second successful fetch (one-shot)", async () => {
-    let calls = 0;
-    onConsentResolved(() => {
-      calls += 1;
-    });
-
-    setConsent({ shareAnalytics: true, shareDiagnostics: false });
-    await refreshConsentCache();
-    setConsent({ shareAnalytics: false, shareDiagnostics: true });
-    await refreshConsentCache();
-
-    expect(calls).toBe(1);
-  });
-
-  test("a listener registered after resolution fires immediately with the last consent", async () => {
-    const consent: OwnerConsent = {
-      shareAnalytics: false,
-      shareDiagnostics: true,
-    };
-    setConsent(consent);
-    await refreshConsentCache();
-
-    const received: OwnerConsent[] = [];
-    onConsentResolved((c) => received.push(c));
-
-    expect(received).toEqual([consent]);
-  });
-
-  test("a throwing listener does not starve other listeners", async () => {
-    const received: OwnerConsent[] = [];
-    onConsentResolved(() => {
-      throw new Error("boom");
-    });
-    onConsentResolved((c) => received.push(c));
-
-    const consent: OwnerConsent = {
-      shareAnalytics: true,
-      shareDiagnostics: true,
-    };
-    setConsent(consent);
-    await refreshConsentCache();
-
-    expect(received).toEqual([consent]);
-  });
-
-  test("a null fetch never fires; a later successful fetch does", async () => {
-    const received: OwnerConsent[] = [];
-    onConsentResolved((c) => received.push(c));
-
-    setConsent(null);
-    await refreshConsentCache();
-    expect(received).toEqual([]);
-
-    const consent: OwnerConsent = {
-      shareAnalytics: true,
-      shareDiagnostics: true,
-    };
-    setConsent(consent);
-    await refreshConsentCache();
-
-    expect(received).toEqual([consent]);
+    expect(getCachedShareDiagnostics()).toBe(false);
   });
 });

--- a/assistant/src/platform/consent-cache.ts
+++ b/assistant/src/platform/consent-cache.ts
@@ -1,22 +1,25 @@
 /**
- * In-memory cache of the platform owner's `share_analytics` consent.
+ * In-memory cache of the platform owner's `share_analytics` and
+ * `share_diagnostics` consent.
  *
- * Record-time telemetry gates need a synchronous, I/O-free read, so this module
- * owns the consent value and refreshes it periodically in the background.
- * Default-off until the first successful fetch: an absent session, a disabled
- * platform, or a transient fetch failure all leave the value untouched (initial
- * `false`), so we never report analytics without a confirmed opt-in.
+ * Hot-path gates (record-time telemetry writes, Sentry `beforeSend`) need a
+ * synchronous, I/O-free read, so this module owns both consent values and
+ * refreshes them periodically in the background. Default-off until the first
+ * successful fetch: an absent session, a disabled platform, or a transient
+ * fetch failure all leave the values untouched (initial `false`), so we never
+ * report analytics or send crash diagnostics without a confirmed opt-in.
  */
 
 import { getConfigReadOnly } from "../config/loader.js";
 import { getLogger } from "../util/logger.js";
-import { type OwnerConsent, VellumPlatformClient } from "./client.js";
+import { VellumPlatformClient } from "./client.js";
 
 const log = getLogger("consent-cache");
 
 const REFRESH_INTERVAL_MS = 5 * 60_000; // refresh consent every 5 min
 
 let cachedShareAnalytics = false; // default-off until first success
+let cachedShareDiagnostics = false; // default-off until first success
 // Fail-closed marker for a workspace that locally opted out of usage data
 // before telemetry moved to platform `share_analytics` consent (migration 106).
 // While set, telemetry stays off regardless of platform consent. Cleared by a
@@ -24,12 +27,6 @@ let cachedShareAnalytics = false; // default-off until first success
 // re-consent signal; not auto-cleared here.
 let legacyOptOut = false;
 let refreshTimer: ReturnType<typeof setInterval> | null = null;
-
-// One-shot consent-resolved hook state. `firstConsentResolved` flips on the
-// first successful fetch; `lastResolvedConsent` retains it for late registrants.
-let firstConsentResolved = false;
-let lastResolvedConsent: OwnerConsent | null = null;
-const consentResolvedListeners: Array<(consent: OwnerConsent) => void> = [];
 
 /**
  * Synchronous hot-path accessor for the effective `share_analytics` consent.
@@ -41,13 +38,23 @@ export function getCachedShareAnalytics(): boolean {
 }
 
 /**
+ * Synchronous hot-path accessor for the `share_diagnostics` consent (read by
+ * Sentry `beforeSend`). Never does I/O; returns `false` until a successful
+ * refresh proves otherwise. Because every Sentry event re-reads this, a
+ * mid-session opt-out is honored within one refresh cycle.
+ */
+export function getCachedShareDiagnostics(): boolean {
+  return cachedShareDiagnostics;
+}
+
+/**
  * Refresh the cached consent from the platform.
  *
  * No platform session / features disabled (`create()` is null) → default-off.
  * No resolvable assistant identity (no owner whose consent we can attest to) →
- * fail closed. A successful fetch adopts the reported value. A `null` fetch
- * (transient failure / undeployed endpoint) leaves the previous value unchanged
- * so a known opt-in is not flipped off mid-session.
+ * fail closed. A successful fetch adopts the reported values. A `null` fetch
+ * (transient failure / undeployed endpoint) leaves the previous values
+ * unchanged so a known opt-in is not flipped off mid-session.
  */
 export async function refreshConsentCache(): Promise<void> {
   legacyOptOut = getConfigReadOnly().legacyTelemetryOptOut === true;
@@ -55,47 +62,22 @@ export async function refreshConsentCache(): Promise<void> {
   const client = await VellumPlatformClient.create();
   if (!client) {
     setCachedShareAnalytics(false);
+    setCachedShareDiagnostics(false);
     return;
   }
 
   // No resolvable owner identity → fail closed (don't ride a stale opt-in).
   if (!client.platformAssistantId) {
     setCachedShareAnalytics(false);
+    setCachedShareDiagnostics(false);
     return;
   }
 
   const consent = await client.getOwnerConsent();
   if (consent) {
     setCachedShareAnalytics(consent.shareAnalytics);
-    lastResolvedConsent = consent;
-    if (!firstConsentResolved) {
-      firstConsentResolved = true;
-      const listeners = consentResolvedListeners.splice(0);
-      for (const l of listeners) {
-        try {
-          l(consent);
-        } catch (err) {
-          log.debug({ err }, "consent-resolved listener failed");
-        }
-      }
-    }
+    setCachedShareDiagnostics(consent.shareDiagnostics);
   }
-}
-
-/**
- * One-shot hook fired on the FIRST successful platform consent fetch. Lets
- * one-time startup decisions (e.g. Sentry) gate on consent without doing I/O on
- * the hot path. Registrants after the first resolution fire synchronously with
- * the last resolved consent; null fetches never trigger it.
- */
-export function onConsentResolved(
-  listener: (consent: OwnerConsent) => void,
-): void {
-  if (firstConsentResolved && lastResolvedConsent) {
-    listener(lastResolvedConsent);
-    return;
-  }
-  consentResolvedListeners.push(listener);
 }
 
 function setCachedShareAnalytics(value: boolean): void {
@@ -105,6 +87,16 @@ function setCachedShareAnalytics(value: boolean): void {
       "share_analytics consent changed",
     );
     cachedShareAnalytics = value;
+  }
+}
+
+function setCachedShareDiagnostics(value: boolean): void {
+  if (value !== cachedShareDiagnostics) {
+    log.debug(
+      { from: cachedShareDiagnostics, to: value },
+      "share_diagnostics consent changed",
+    );
+    cachedShareDiagnostics = value;
   }
 }
 
@@ -135,14 +127,12 @@ export async function stopConsentRefresh(): Promise<void> {
   }
 }
 
-/** Test-only: override the cached value without going through a refresh. */
+/** Test-only: override the cached analytics value without going through a refresh. */
 export function __setCachedShareAnalyticsForTest(value: boolean): void {
   cachedShareAnalytics = value;
 }
 
-/** Test-only: clear one-shot consent-resolved hook state. */
-export function __resetConsentResolutionForTest(): void {
-  firstConsentResolved = false;
-  lastResolvedConsent = null;
-  consentResolvedListeners.length = 0;
+/** Test-only: override the cached diagnostics value without going through a refresh. */
+export function __setCachedShareDiagnosticsForTest(value: boolean): void {
+  cachedShareDiagnostics = value;
 }


### PR DESCRIPTION
## Summary
- Sentry crash reporting now follows the platform owner's *current* `share_diagnostics` consent: `beforeSend` re-reads a synchronous `getCachedShareDiagnostics()` accessor on every event, and the existing 5-minute `startConsentRefresh()` keeps it current — so a mid-session opt-out is honored within one refresh cycle instead of only on daemon restart.
- Removes the one-shot `onConsentResolved` hook (`firstConsentResolved`/`lastResolvedConsent`/listener machinery) and the `setDiagnosticsConsented` setter; `share_diagnostics` is now cached and refreshed exactly like `share_analytics` (mirrors #35306). Fail-closed posture is preserved: missing client/identity → false, null fetch → keep last value, default-off until first success. Dev mode and `legacyDiagnosticsOptOut` still hard-disable via `closeSentry()`.

## Original prompt
Follow-up to PR #35375 to address Codex's P1 review comment ("Honor diagnostics revocations during refresh"). The original design evaluated diagnostics consent once (option 1), so an owner turning Share Diagnostics off mid-session kept Sentry reporting until restart. Update the daemon to periodically refresh the consent cache the same way #35306 did for `share_analytics`, so revocations are honored.

Addresses: https://github.com/vellum-ai/vellum-assistant/pull/35375#discussion_r3439520510