### PR TITLE
refactor(approvals): replace pendingRequestIds tri-state with explicit GuardianPendingScope (LUM-2504 §3)

### DIFF
--- a/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
+++ b/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
@@ -222,13 +222,16 @@ describe("handleSendMessage canonical guardian reply interception", () => {
     const routerCall = (routeGuardianReplyMock as any).mock
       .calls[0][0] as Record<string, unknown>;
     expect(routerCall.messageText).toBe("05BECB approve");
-    expect(routerCall.pendingRequestIds).toEqual(["access-req-1"]);
+    expect(routerCall.pendingScope).toEqual({
+      mode: "scoped",
+      requestIds: ["access-req-1"],
+    });
     expect(addMessageMock).toHaveBeenCalledTimes(2);
     expect(persistUserMessage).toHaveBeenCalledTimes(0);
     expect(runAgentLoop).toHaveBeenCalledTimes(0);
   });
 
-  test("passes empty pendingRequestIds array when no canonical hints are found", async () => {
+  test("passes a blocked scope when no canonical hints are found", async () => {
     listPendingByDestinationMock.mockReturnValue([]);
     listCanonicalMock.mockReturnValue([]);
     routeGuardianReplyMock.mockResolvedValue({
@@ -301,7 +304,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
     expect(routeGuardianReplyMock).toHaveBeenCalledTimes(1);
     const routerCall = (routeGuardianReplyMock as any).mock
       .calls[0][0] as Record<string, unknown>;
-    expect(routerCall.pendingRequestIds).toEqual([]);
+    expect(routerCall.pendingScope).toEqual({ mode: "blocked" });
     expect(persistUserMessage).toHaveBeenCalledTimes(1);
     expect(runAgentLoop).toHaveBeenCalledTimes(1);
   });
@@ -384,15 +387,15 @@ describe("handleSendMessage canonical guardian reply interception", () => {
     expect(routeGuardianReplyMock).toHaveBeenCalledTimes(1);
     const routerCall = (routeGuardianReplyMock as any).mock
       .calls[0][0] as Record<string, unknown>;
-    expect(routerCall.pendingRequestIds).toEqual([
-      "tool-approval-live",
-      "access-req-1",
-    ]);
-    expect(
-      (routerCall.pendingRequestIds as string[]).includes(
-        "tool-approval-stale",
-      ),
-    ).toBe(false);
+    const scope = routerCall.pendingScope as {
+      mode: string;
+      requestIds: string[];
+    };
+    expect(scope).toEqual({
+      mode: "scoped",
+      requestIds: ["tool-approval-live", "access-req-1"],
+    });
+    expect(scope.requestIds.includes("tool-approval-stale")).toBe(false);
   });
 
   test("text fallback: request-code approve routes through guardian reply router", async () => {

--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -897,6 +897,38 @@ describe("routing invariant: disambiguation stays fail-closed", () => {
     expect(result.decisionApplied).toBe(false);
   });
 
+  test("explicit request code still resolves under a blocked scope (cross-chat carve-out)", async () => {
+    // The Slack cross-chat guard blocks identity fallback, but an explicit
+    // request code carries its own target and must still resolve — otherwise a
+    // guardian could not approve-by-code from a chat where no card was delivered.
+    const req = createCanonicalGuardianRequest({
+      kind: "tool_approval",
+      sourceType: "channel",
+      conversationId: "conv-other",
+      guardianExternalUserId: "guardian-1",
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      requestCode: "ABC123",
+      toolName: "shell",
+      expiresAt: Date.now() + 60_000,
+    });
+    registerPendingToolApprovalInteraction(req.id, "conv-other", "shell");
+
+    const result = await routeGuardianReply(
+      replyCtx({
+        messageText: "ABC123 approve",
+        actor: trustedActor(),
+        conversationId: "conv-unrelated",
+        pendingScope: { mode: "blocked" },
+        approvalConversationGenerator: undefined,
+      }),
+    );
+
+    expect(result.consumed).toBe(true);
+    expect(result.requestId).toBe(req.id);
+    expect(result.decisionApplied).toBe(true);
+    expect(getCanonicalGuardianRequest(req.id)!.status).toBe("approved");
+  });
+
   test("multiple hinted pending requests with plain-text approve returns disambiguation", async () => {
     const req1 = createCanonicalGuardianRequest({
       kind: "tool_approval",

--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -828,7 +828,7 @@ describe("routing invariant: disambiguation stays fail-closed", () => {
       replyCtx({
         messageText: "approve",
         conversationId: "conv-guardian-conversation",
-        pendingRequestIds: [req.id],
+        pendingScope: { mode: "scoped", requestIds: [req.id] },
         approvalConversationGenerator: undefined,
       }),
     );
@@ -857,7 +857,7 @@ describe("routing invariant: disambiguation stays fail-closed", () => {
       replyCtx({
         messageText: "ok, what is this for?",
         conversationId: "conv-guardian-conversation",
-        pendingRequestIds: [req.id],
+        pendingScope: { mode: "scoped", requestIds: [req.id] },
         approvalConversationGenerator: undefined,
       }),
     );
@@ -870,7 +870,7 @@ describe("routing invariant: disambiguation stays fail-closed", () => {
     expect(unchanged!.status).toBe("pending");
   });
 
-  test("explicit empty pendingRequestIds hint stays fail-closed for desktop actors", async () => {
+  test("explicit blocked scope stays fail-closed for desktop actors", async () => {
     createCanonicalGuardianRequest({
       kind: "tool_approval",
       sourceType: "channel",
@@ -887,7 +887,7 @@ describe("routing invariant: disambiguation stays fail-closed", () => {
         messageText: "approve",
         actor: trustedActor(),
         conversationId: "conv-unrelated",
-        pendingRequestIds: [],
+        pendingScope: { mode: "blocked" },
         approvalConversationGenerator: undefined,
       }),
     );
@@ -924,7 +924,7 @@ describe("routing invariant: disambiguation stays fail-closed", () => {
       replyCtx({
         messageText: "approve",
         conversationId: "conv-guardian-conversation",
-        pendingRequestIds: [req1.id, req2.id],
+        pendingScope: { mode: "scoped", requestIds: [req1.id, req2.id] },
         approvalConversationGenerator: undefined,
       }),
     );
@@ -977,7 +977,7 @@ describe("routing invariant: disambiguation stays fail-closed", () => {
       replyCtx({
         messageText: "yes approve it",
         conversationId: "conv-1",
-        pendingRequestIds: [req1.id, req2.id],
+        pendingScope: { mode: "scoped", requestIds: [req1.id, req2.id] },
         approvalConversationGenerator: mockGenerator as any,
       }),
     );
@@ -1031,7 +1031,10 @@ describe("routing invariant: disambiguation stays fail-closed", () => {
       replyCtx({
         messageText: "approve",
         conversationId: "conv-guardian-conversation",
-        pendingRequestIds: [answerRequest.id, approvalRequest.id],
+        pendingScope: {
+          mode: "scoped",
+          requestIds: [answerRequest.id, approvalRequest.id],
+        },
         approvalConversationGenerator: undefined,
       }),
     );
@@ -1075,7 +1078,7 @@ describe("routing invariant: disambiguation stays fail-closed", () => {
       replyCtx({
         messageText: "yes",
         conversationId: "conv-1",
-        pendingRequestIds: [req.id],
+        pendingScope: { mode: "scoped", requestIds: [req.id] },
         approvalConversationGenerator: mockGenerator as any,
       }),
     );
@@ -1104,7 +1107,7 @@ describe("routing invariant: disambiguation stays fail-closed", () => {
       replyCtx({
         messageText: "go for it",
         conversationId: "conv-1",
-        pendingRequestIds: [req.id],
+        pendingScope: { mode: "scoped", requestIds: [req.id] },
         approvalConversationGenerator: undefined,
       }),
     );
@@ -1117,7 +1120,7 @@ describe("routing invariant: disambiguation stays fail-closed", () => {
     expect(resolved!.status).toBe("approved");
   });
 
-  test("code-based routing is constrained to caller-provided pendingRequestIds scope", async () => {
+  test("code-based routing is constrained to caller-provided scope", async () => {
     const inScope = createCanonicalGuardianRequest({
       kind: "tool_approval",
       sourceType: "channel",
@@ -1145,7 +1148,7 @@ describe("routing invariant: disambiguation stays fail-closed", () => {
       replyCtx({
         messageText: "222BBB approve",
         conversationId: "conv-guardian-conversation",
-        pendingRequestIds: [inScope.id],
+        pendingScope: { mode: "scoped", requestIds: [inScope.id] },
         approvalConversationGenerator: undefined,
       }),
     );
@@ -1438,7 +1441,7 @@ describe("routing invariant: directResolve interactions resolve via guardian dec
 describe("routing invariant: destination hints do not bypass tool_approval principal binding", () => {
   beforeEach(() => resetTables());
 
-  test("explicit pendingRequestIds still fail closed when guardianPrincipalId does not match", async () => {
+  test("explicit scope still fails closed when guardianPrincipalId does not match", async () => {
     // Voice-originated tool approval with a different principal than the actor.
     const req = createCanonicalGuardianRequest({
       kind: "tool_approval",
@@ -1452,15 +1455,15 @@ describe("routing invariant: destination hints do not bypass tool_approval princ
     });
     registerPendingToolApprovalInteraction(req.id, "conv-voice-1", "shell");
 
-    // The channel inbound router would compute pendingRequestIds from
-    // delivery-scoped lookup and pass them here. Simulate that.
+    // The channel inbound router would compute the pending scope from
+    // delivery-scoped lookup and pass it here. Simulate that.
     const result = await routeGuardianReply(
       replyCtx({
         messageText: "approve",
         channel: "telegram",
         actor: guardianActor({ guardianPrincipalId: "different-principal" }),
         conversationId: "conv-guardian-chat",
-        pendingRequestIds: [req.id],
+        pendingScope: { mode: "scoped", requestIds: [req.id] },
         approvalConversationGenerator: undefined,
       }),
     );
@@ -1486,7 +1489,7 @@ describe("routing invariant: destination hints do not bypass tool_approval princ
       expiresAt: Date.now() + 60_000,
     });
 
-    // No pendingRequestIds passed — identity-based fallback uses
+    // No pendingScope passed — identity-based fallback uses
     // actor.actorExternalUserId which does not match any request's
     // guardianExternalUserId (since it's null).
     const result = await routeGuardianReply(
@@ -1495,7 +1498,7 @@ describe("routing invariant: destination hints do not bypass tool_approval princ
         channel: "telegram",
         actor: guardianActor({ actorExternalUserId: "guardian-tg-user" }),
         conversationId: "conv-guardian-chat",
-        // pendingRequestIds: undefined — no delivery hints
+        // pendingScope omitted — no delivery hints
         approvalConversationGenerator: undefined,
       }),
     );
@@ -1534,7 +1537,7 @@ describe("routing invariant: invite handoff bypass for access requests", () => {
       replyCtx({
         messageText: "open invite flow",
         conversationId: "conv-guardian-conversation",
-        pendingRequestIds: [req.id],
+        pendingScope: { mode: "scoped", requestIds: [req.id] },
         approvalConversationGenerator: undefined,
       }),
     );
@@ -1569,7 +1572,7 @@ describe("routing invariant: invite handoff bypass for access requests", () => {
         replyCtx({
           messageText: phrase,
           conversationId: "conv-test",
-          pendingRequestIds: [req.id],
+          pendingScope: { mode: "scoped", requestIds: [req.id] },
           approvalConversationGenerator: undefined,
         }),
       );
@@ -1595,7 +1598,7 @@ describe("routing invariant: invite handoff bypass for access requests", () => {
       replyCtx({
         messageText: "open invite flow",
         conversationId: "conv-guardian-conversation",
-        pendingRequestIds: [req.id],
+        pendingScope: { mode: "scoped", requestIds: [req.id] },
         approvalConversationGenerator: undefined,
       }),
     );
@@ -1625,7 +1628,7 @@ describe("routing invariant: invite handoff bypass for access requests", () => {
       replyCtx({
         messageText: "A00B01 approve",
         conversationId: "conv-guardian-conversation",
-        pendingRequestIds: [req.id],
+        pendingScope: { mode: "scoped", requestIds: [req.id] },
         approvalConversationGenerator: undefined,
       }),
     );
@@ -1655,7 +1658,7 @@ describe("routing invariant: invite handoff bypass for access requests", () => {
       channel: "vellum",
       actor: trustedActor({ channel: "vellum" }),
       conversationId: "conv-guardian-conversation",
-      pendingRequestIds: [req.id],
+      pendingScope: { mode: "scoped", requestIds: [req.id] },
       approvalConversationGenerator: undefined,
     });
 
@@ -1694,7 +1697,7 @@ describe("routing invariant: invite handoff bypass for access requests", () => {
       channel: "vellum",
       actor: trustedActor({ channel: "vellum" }),
       conversationId: "conv-guardian-conversation",
-      pendingRequestIds: [req.id],
+      pendingScope: { mode: "scoped", requestIds: [req.id] },
       approvalConversationGenerator: approvalConversationGenerator as any,
     });
 
@@ -1746,7 +1749,7 @@ describe("routing invariant: expired requests are excluded from pending discover
       replyCtx({
         messageText: "approve",
         conversationId: "conv-guardian-conversation",
-        pendingRequestIds: [expired.id, active.id],
+        pendingScope: { mode: "scoped", requestIds: [expired.id, active.id] },
         approvalConversationGenerator: undefined,
       }),
     );
@@ -1781,7 +1784,7 @@ describe("routing invariant: expired requests are excluded from pending discover
       replyCtx({
         messageText: "`approve`",
         conversationId: "conv-guardian-conversation",
-        pendingRequestIds: [req.id],
+        pendingScope: { mode: "scoped", requestIds: [req.id] },
         approvalConversationGenerator: undefined,
       }),
     );
@@ -1821,7 +1824,10 @@ describe("routing invariant: expired requests are excluded from pending discover
       replyCtx({
         messageText: "approve",
         conversationId: "conv-guardian-conversation",
-        pendingRequestIds: [expired1.id, expired2.id],
+        pendingScope: {
+          mode: "scoped",
+          requestIds: [expired1.id, expired2.id],
+        },
         approvalConversationGenerator: undefined,
       }),
     );

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -28,7 +28,10 @@ import {
 import { extractPreferences } from "../notifications/preference-extractor.js";
 import { createPreference } from "../notifications/preferences-store.js";
 import type { ContextWindowResult } from "../plugins/defaults/compaction/window-manager.js";
-import { routeGuardianReply } from "../runtime/guardian-reply-router.js";
+import {
+  type GuardianPendingScope,
+  routeGuardianReply,
+} from "../runtime/guardian-reply-router.js";
 import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
 import { getLogger } from "../util/logger.js";
 import type { CleanResult, Conversation } from "./conversation.js";
@@ -1407,9 +1410,14 @@ export async function processMessage(
           "vellum",
         ).map((request) => request.id)
       : [];
-  const canonicalPendingRequestIdsForConversation =
+  // Empty hints → leave the scope unset (identity-fallback): the desktop
+  // guardian can still resolve their pending work by identity/principal.
+  const pendingScope: GuardianPendingScope | undefined =
     canonicalPendingRequestHintIdsForConversation.length > 0
-      ? canonicalPendingRequestHintIdsForConversation
+      ? {
+          mode: "scoped",
+          requestIds: canonicalPendingRequestHintIdsForConversation,
+        }
       : undefined;
 
   // ── Canonical guardian reply router (desktop/conversation path) ──
@@ -1428,7 +1436,7 @@ export async function processMessage(
           conversation.trustContext?.guardianPrincipalId ?? undefined,
       },
       conversationId: conversation.conversationId,
-      pendingRequestIds: canonicalPendingRequestIdsForConversation,
+      pendingScope,
       // Desktop path: disable NL classification to avoid consuming non-decision
       // messages while a tool confirmation is pending. Deterministic code-prefix
       // and callback parsing remain active.

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -58,10 +58,8 @@ const log = getLogger("guardian-reply-router");
 
 /**
  * How to scope a guardian's pending requests when resolving an inbound reply.
- *
- * Replaces a `string[] | undefined` tri-state whose `[]` (fail-closed) was too
- * easy to conflate with `undefined` (identity fallback) — the conflation that
- * would re-open the Slack cross-chat reply-hijack vector (#30377 / JARVIS-650).
+ * The three states are mutually exclusive and named so the security-critical
+ * `blocked` cannot be confused with the absence of a hint:
  *
  *   - `scoped`: resolve only these request ids, and constrain request-code
  *     routing to this set (delivery-/conversation-scoped hints).
@@ -242,7 +240,7 @@ function findPendingCanonicalRequests(
   conversationId?: string,
 ): CanonicalGuardianRequest[] {
   // `blocked` fails closed: no pending requests and no identity fallback — the
-  // Slack cross-chat hijack guard (#30377 / JARVIS-650).
+  // Slack cross-chat hijack guard.
   if (scope.mode === "blocked") {
     return [];
   }

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -56,6 +56,28 @@ const log = getLogger("guardian-reply-router");
 // Types
 // ---------------------------------------------------------------------------
 
+/**
+ * How to scope a guardian's pending requests when resolving an inbound reply.
+ *
+ * Replaces a `string[] | undefined` tri-state whose `[]` (fail-closed) was too
+ * easy to conflate with `undefined` (identity fallback) — the conflation that
+ * would re-open the Slack cross-chat reply-hijack vector (#30377 / JARVIS-650).
+ *
+ *   - `scoped`: resolve only these request ids, and constrain request-code
+ *     routing to this set (delivery-/conversation-scoped hints).
+ *   - `blocked`: fail closed — no pending requests and no identity fallback.
+ *     The Slack cross-chat guard: a guardian's unrelated message in a chat
+ *     where no card was delivered must not resolve a request delivered
+ *     elsewhere. Explicit callbacks and request codes still work (they carry
+ *     their own request id).
+ *   - `identity-fallback`: discover pending requests by guardian identity,
+ *     conversation, or principal. The default when no scope is supplied.
+ */
+export type GuardianPendingScope =
+  | { mode: "scoped"; requestIds: string[] }
+  | { mode: "blocked" }
+  | { mode: "identity-fallback" };
+
 /** Context for an inbound message that may be a guardian reply. */
 export interface GuardianReplyContext {
   /** The raw message text (trimmed). */
@@ -74,8 +96,12 @@ export interface GuardianReplyContext {
    * attached to. Used to recover the target request from its delivery record.
    */
   reactedMessageTs?: string;
-  /** IDs of known pending canonical requests for this guardian. */
-  pendingRequestIds?: string[];
+  /**
+   * How to scope this guardian's pending requests (see {@link
+   * GuardianPendingScope}). Omitted is equivalent to
+   * `{ mode: "identity-fallback" }`.
+   */
+  pendingScope?: GuardianPendingScope;
   /** Conversation generator for NL classification (injected by daemon). */
   approvalConversationGenerator?: ApprovalConversationGenerator;
   /** Optional channel delivery context for resolver-driven side effects. */
@@ -212,30 +238,33 @@ function parseRequestCode(
 /** Find all pending canonical requests for a guardian actor. */
 function findPendingCanonicalRequests(
   actor: ActorContext,
-  pendingRequestIds?: string[],
+  scope: GuardianPendingScope,
   conversationId?: string,
 ): CanonicalGuardianRequest[] {
+  // `blocked` fails closed: no pending requests and no identity fallback — the
+  // Slack cross-chat hijack guard (#30377 / JARVIS-650).
+  if (scope.mode === "blocked") {
+    return [];
+  }
+
   let results: CanonicalGuardianRequest[];
 
-  // When explicit IDs are provided, look them up directly
-  if (pendingRequestIds) {
-    if (pendingRequestIds.length === 0) {
-      return [];
-    }
-    results = pendingRequestIds
+  if (scope.mode === "scoped") {
+    // Resolve exactly the supplied ids.
+    results = scope.requestIds
       .map(getCanonicalGuardianRequest)
       .filter((r): r is CanonicalGuardianRequest => r?.status === "pending");
   } else if (actor.actorExternalUserId) {
-    // Query by guardian identity when available
+    // identity-fallback: query by guardian identity when available
     results = listCanonicalGuardianRequests({
       status: "pending",
       guardianExternalUserId: actor.actorExternalUserId,
     });
   } else if (conversationId) {
-    // Actors without an actorExternalUserId: scope by conversationId so the NL
-    // path can discover pending requests bound to this conversation.
-    // Include guardianPrincipalId filter when available so the guardian only
-    // sees requests they are authorized to act on.
+    // identity-fallback without an actorExternalUserId: scope by conversationId
+    // so the NL path can discover pending requests bound to this conversation.
+    // Include guardianPrincipalId when available so the guardian only sees
+    // requests they are authorized to act on.
     results = listCanonicalGuardianRequests({
       status: "pending",
       conversationId,
@@ -244,9 +273,8 @@ function findPendingCanonicalRequests(
         : {}),
     });
   } else if (actor.guardianPrincipalId) {
-    // Actors with a guardianPrincipalId but no actorExternalUserId or
-    // conversationId: query by principal so desktop sessions can still
-    // discover pending guardian work via their bound principal.
+    // identity-fallback by principal: desktop sessions discover pending
+    // guardian work via their bound principal.
     results = listCanonicalGuardianRequests({
       status: "pending",
       guardianPrincipalId: actor.guardianPrincipalId,
@@ -342,15 +370,18 @@ export async function routeGuardianReply(
     );
   }
 
+  const pendingScope: GuardianPendingScope = ctx.pendingScope ?? {
+    mode: "identity-fallback",
+  };
   const pendingRequests = findPendingCanonicalRequests(
     actor,
-    ctx.pendingRequestIds,
+    pendingScope,
     conversationId,
   );
+  // Request codes carry their own id, so constrain them only under an explicit
+  // scope; under blocked/identity-fallback they still resolve cross-chat.
   const scopedPendingRequestIds =
-    ctx.pendingRequestIds && ctx.pendingRequestIds.length > 0
-      ? new Set(ctx.pendingRequestIds)
-      : null;
+    pendingScope.mode === "scoped" ? new Set(pendingScope.requestIds) : null;
 
   // ── 1. Deterministic callback parsing (button presses) ──
   // No conversationId scoping here — the guardian's reply comes from a

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -120,7 +120,10 @@ import { assistantEventHub, broadcastMessage } from "../assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { getPersistedSeq } from "../assistant-stream-state.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
-import { routeGuardianReply } from "../guardian-reply-router.js";
+import {
+  type GuardianPendingScope,
+  routeGuardianReply,
+} from "../guardian-reply-router.js";
 import { healGuardianBindingDrift } from "../guardian-vellum-migration.js";
 import type {
   ApprovalConversationGenerator,
@@ -486,12 +489,14 @@ async function tryConsumeCanonicalGuardianReply(params: {
     sourceChannel,
     conversation,
   );
-  // Always pass the hints array (even when empty) so
-  // findPendingCanonicalRequests respects the in-memory staleness filter
-  // applied by collectCanonicalGuardianRequestHintIds. Converting empty
-  // hints to `undefined` caused the router to fall through to raw DB
-  // queries that rediscovered stale canonical requests.
-  const pendingRequestIds = pendingRequestHintIds;
+  // An empty hint set is `blocked`, not absence: the in-memory staleness
+  // filter in collectCanonicalGuardianRequestHintIds found no live requests,
+  // so the router must not fall back to identity/DB lookup (which rediscovered
+  // stale canonical requests). A non-empty set scopes resolution to it.
+  const pendingScope: GuardianPendingScope =
+    pendingRequestHintIds.length > 0
+      ? { mode: "scoped", requestIds: pendingRequestHintIds }
+      : { mode: "blocked" };
 
   const routerResult = await routeGuardianReply({
     messageText: trimmedContent,
@@ -503,7 +508,7 @@ async function tryConsumeCanonicalGuardianReply(params: {
       guardianPrincipalId: verifiedActorPrincipalId,
     },
     conversationId,
-    pendingRequestIds,
+    pendingScope,
     approvalConversationGenerator,
     emissionContext: {
       source: "inline_nl",

--- a/assistant/src/runtime/routes/inbound-stages/guardian-reply-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-reply-intercept.test.ts
@@ -85,7 +85,7 @@ describe("handleGuardianReplyIntercept", () => {
     deliverChannelReplyCalls = [];
   });
 
-  test("passes empty pendingRequestIds when Slack guardian sends message in non-delivery chat", async () => {
+  test("passes a blocked scope when Slack guardian sends message in non-delivery chat", async () => {
     // No delivery-scoped requests for this chat
     mockDeliveryScopedRequests = [];
     // Identity-based lookup would find a pending request in a different chat
@@ -95,8 +95,8 @@ describe("handleGuardianReplyIntercept", () => {
 
     expect(routeGuardianReplyCalls).toHaveLength(1);
     const ctx = routeGuardianReplyCalls[0] as Record<string, unknown>;
-    // Must be [] (empty array), NOT undefined — blocks identity fallback
-    expect(ctx.pendingRequestIds).toEqual([]);
+    // Must be a blocked scope, NOT undefined — blocks identity fallback
+    expect(ctx.pendingScope).toEqual({ mode: "blocked" });
   });
 
   test("preserves identity fallback for non-Slack channels when no deliveries exist", async () => {
@@ -110,11 +110,11 @@ describe("handleGuardianReplyIntercept", () => {
 
     expect(routeGuardianReplyCalls).toHaveLength(1);
     const ctx = routeGuardianReplyCalls[0] as Record<string, unknown>;
-    // Must be undefined — identity-based fallback stays active
-    expect(ctx.pendingRequestIds).toBeUndefined();
+    // Must be unset — identity-based fallback stays active
+    expect(ctx.pendingScope).toBeUndefined();
   });
 
-  test("includes identity-unioned pendingRequestIds when Slack guardian is in delivery chat", async () => {
+  test("passes an identity-unioned scoped set when Slack guardian is in delivery chat", async () => {
     mockDeliveryScopedRequests = [{ id: "delivered-req" }];
     mockIdentityRequests = [
       { id: "delivered-req" },
@@ -125,7 +125,7 @@ describe("handleGuardianReplyIntercept", () => {
 
     expect(routeGuardianReplyCalls).toHaveLength(1);
     const ctx = routeGuardianReplyCalls[0] as Record<string, unknown>;
-    const ids = ctx.pendingRequestIds as string[];
+    const ids = (ctx.pendingScope as { requestIds: string[] }).requestIds;
     expect(ids).toContain("delivered-req");
     expect(ids).toContain("identity-only-req");
   });

--- a/assistant/src/runtime/routes/inbound-stages/guardian-reply-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-reply-intercept.ts
@@ -16,7 +16,10 @@ import {
 } from "../../../memory/canonical-guardian-store.js";
 import { getLogger } from "../../../util/logger.js";
 import { deliverChannelReply } from "../../gateway-client.js";
-import { routeGuardianReply } from "../../guardian-reply-router.js";
+import {
+  type GuardianPendingScope,
+  routeGuardianReply,
+} from "../../guardian-reply-router.js";
 import type { ApprovalConversationGenerator } from "../../http-types.js";
 
 const log = getLogger("runtime-http");
@@ -109,16 +112,16 @@ export async function handleGuardianReplyIntercept(
   // based pending requests so that requests without delivery rows (e.g.
   // tool_approval requests created inline) are not silently excluded.
   //
-  // On Slack, when no delivery-scoped results exist for the current
-  // chat, pass [] (empty array) instead of undefined. This prevents the
-  // router's identity-based fallback from intercepting unrelated
+  // On Slack, when no delivery-scoped results exist for the current chat,
+  // use `{ mode: "blocked" }` rather than identity-fallback. This prevents
+  // the router's identity-based fallback from intercepting unrelated
   // messages in other channels/threads — a cross-chat hijacking vector
   // unique to Slack where a single guardian is active in many threaded
   // contexts. Explicit callbacks (apr:<id>:<action>) and request codes
   // still work cross-chat because they carry specific request
-  // identifiers and bypass the pendingRequests list.
+  // identifiers and bypass the pending-request scope.
   //
-  // Non-Slack channels (Telegram, WhatsApp) keep undefined so the
+  // Non-Slack channels (Telegram, WhatsApp) leave the scope unset so the
   // identity-based fallback stays active. On those channels, delivery
   // rows are created asynchronously (fire-and-forget .then()) so the
   // guardian can reply before the row is persisted. Cross-chat
@@ -128,7 +131,7 @@ export async function handleGuardianReplyIntercept(
   // so they bypass the pending-request list scoping that the text/NL paths
   // need — the router's reaction branch resolves the target directly.
   const isReaction = callbackData?.startsWith("reaction:") === true;
-  let pendingRequestIds: string[] | undefined;
+  let pendingScope: GuardianPendingScope | undefined;
   if (!isReaction) {
     const deliveryScopedPendingRequests =
       listPendingCanonicalGuardianRequestsByDestinationChat(
@@ -148,11 +151,11 @@ export async function handleGuardianReplyIntercept(
       for (const r of identityPending) {
         deliveryIds.add(r.id);
       }
-      pendingRequestIds = [...deliveryIds];
+      pendingScope = { mode: "scoped", requestIds: [...deliveryIds] };
     } else if (sourceChannel === "slack") {
       // Block identity-based fallback on Slack to prevent cross-chat
       // NL/free-text interception. See comment above for rationale.
-      pendingRequestIds = [];
+      pendingScope = { mode: "blocked" };
     }
   }
 
@@ -168,7 +171,7 @@ export async function handleGuardianReplyIntercept(
     conversationId,
     callbackData,
     reactedMessageTs,
-    pendingRequestIds,
+    pendingScope,
     approvalConversationGenerator,
     channelDeliveryContext: {
       replyCallbackUrl,


### PR DESCRIPTION
## What this is

[LUM-2504](https://linear.app/vellum/issue/LUM-2504) **§3 — harden the `pendingRequestIds` tri-state** into an explicit, named input. Pure type-and-clarity hardening; **zero runtime behavior change**. Independent of §1 (router decomposition, sequenced after LUM-2497) and §2 (delivery-recording, already merged).

## Problem (with full provenance)

`routeGuardianReply` scoped a guardian's pending requests via a `string[] | undefined` tri-state, read by **two** consumers that interpret it differently:

| value | `findPendingCanonicalRequests` (NL/free-text) | code-path scoping |
|---|---|---|
| `[ids]` | resolve only these | constrain codes to these |
| `[]` | **return none — fail closed** | no constraint (codes still work) |
| `undefined` | identity-based fallback | no constraint |

The fail-closed `[]` is a **shipped security control** — traced via full git history to **#30377 (JARVIS-650)**, *"prevent cross-chat guardian reply hijacking on Slack"*:
> On Slack, block identity-based pending request fallback in chats where no approval was delivered. This prevents unrelated messages in other channels/threads from being intercepted by the canonical guardian reply router. Explicit callbacks and request codes still work cross-chat.

Defending that vector with an "empty array vs `undefined`" distinction is one careless `empty ? [] : undefined` edit away from silently re-opening it — and the three producers don't even agree on what "empty" means (Slack→`[]`/block, conversation-routes→`[]`/block-to-avoid-stale-rediscovery, desktop→`undefined`/fallback), an intent that's invisible in the type.

## Change — a named discriminated union

```ts
export type GuardianPendingScope =
  | { mode: "scoped"; requestIds: string[] } // resolve only these
  | { mode: "blocked" }                       // fail closed — no requests, no identity fallback (the Slack guard)
  | { mode: "identity-fallback" };            // discover by identity / conversation / principal
```

- `GuardianReplyContext.pendingScope` (omitted ≡ `identity-fallback`) replaces `pendingRequestIds`. `blocked` is now an **unmistakable named mode** that cannot be conflated with the absence of a hint — closing the conflation that would re-open #30377.
- Both consumers `switch` on `mode` explicitly. The producers each map to the **exact mode they produced before**, so each surface's deliberate "empty" policy is now spelled out instead of accidental.

## Behavior-preserving (verified line-by-line)

| producer | before | after |
|---|---|---|
| `guardian-reply-intercept` (Slack, no delivery) | `[]` | `{ mode: "blocked" }` |
| `guardian-reply-intercept` (non-Slack, no delivery) | `undefined` | unset → `identity-fallback` |
| `conversation-routes` (empty hints) | `[]` | `{ mode: "blocked" }` |
| `conversation-process` (desktop, empty hints) | `undefined` | unset → `identity-fallback` |
| any (non-empty hints) | `[ids]` | `{ mode: "scoped", requestIds }` |

No runtime change — this only makes the existing intent explicit and unconflatable.

## Test plan

- `guardian-routing-invariants.test.ts` (71 tests, incl. the fail-closed / cross-chat / desktop invariants) — green, call sites remapped to the union.
- Affected sweep green (~270 tests): `conversation-routes-guardian-reply`, `guardian-reply-intercept`, `slack-reaction-canonical-approval`, `channel-approval(-routes)`, `reaction-persistence`, `trusted-contact-inline-approval-integration`, `conversation-confirmation-signals`, `access-request-decision`, `guardian-dispatch`, `guardian-grant-minting`, `conversation-routes-slash-commands`, `http-user-message-parity`, `secret-ingress-http`.
- `tsc --noEmit`, `eslint`, `prettier --check` clean; pre-commit hooks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SotQoy6MgxeY4aRnQVBf6N)_