### PR TITLE
fix(web): gate Share consent toggles + browser Sentry on a live platform session

### DIFF
--- a/clients/macos/src/main/sentry.test.ts
+++ b/clients/macos/src/main/sentry.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+/**
+ * Unit coverage for the main-process Sentry consent gate. The key contract:
+ * main starts fail-closed (no init from the persisted value, since main boots
+ * before the renderer can apply the live-session gate) and only enables when
+ * the renderer pushes the effective consent over IPC — applied directly so an
+ * unchanged persisted value still enforces the gate.
+ *
+ * `@sentry/node`, `electron`, and `./settings` are mocked so the module runs
+ * without an Electron runtime. Each test file runs in its own process
+ * (scripts/run-tests.ts), so these `mock.module` overrides don't leak.
+ */
+
+// Build-time globals injected by the bundler; define them so resolveOptions
+// produces a non-null options object.
+(globalThis as Record<string, unknown>).__SENTRY_DSN_MACOS__ =
+  "https://public@example.test/1";
+(globalThis as Record<string, unknown>).__VELLUM_ENVIRONMENT__ = "test";
+(globalThis as Record<string, unknown>).__VELLUM_BUILD_SHA__ = "test-sha";
+
+let sentryClient:
+  | { getOptions: () => { enabled?: boolean }; close: () => Promise<boolean> }
+  | undefined;
+
+const initMock = mock((_opts: Record<string, unknown>) => {});
+const setTagMock = mock((_k: string, _v: unknown) => {});
+const setClientMock = mock((_c: unknown) => {});
+const captureMessageMock = mock((_m: string, _o?: unknown) => {});
+
+mock.module("@sentry/node", () => ({
+  init: initMock,
+  getClient: () => sentryClient,
+  getCurrentScope: () => ({ setClient: setClientMock }),
+  setTag: setTagMock,
+  captureMessage: captureMessageMock,
+}));
+
+mock.module("electron", () => ({
+  app: {
+    isPackaged: false,
+    on: mock(() => {}),
+  },
+}));
+
+let settingChangeCb: ((newValue: boolean | undefined) => void) | null = null;
+const writeSettingMock = mock((_key: string, _value: unknown) => {});
+
+mock.module("./settings", () => ({
+  onSettingChange: (_key: string, cb: (v: boolean | undefined) => void) => {
+    settingChangeCb = cb;
+    return () => {
+      settingChangeCb = null;
+    };
+  },
+  writeSetting: writeSettingMock,
+}));
+
+const { initSentryMain, setShareDiagnostics } = await import("./sentry");
+
+beforeEach(() => {
+  initMock.mockReset();
+  setTagMock.mockReset();
+  setClientMock.mockReset();
+  writeSettingMock.mockReset();
+  sentryClient = undefined;
+  settingChangeCb = null;
+});
+
+describe("initSentryMain", () => {
+  test("starts fail-closed: does not initialize Sentry at boot", () => {
+    initSentryMain();
+    expect(initMock).not.toHaveBeenCalled();
+    // ...but it does register the mid-session watcher.
+    expect(settingChangeCb).not.toBeNull();
+  });
+});
+
+describe("setShareDiagnostics", () => {
+  test("persists and enables Sentry directly, even when the watcher would not fire", () => {
+    initSentryMain();
+    initMock.mockReset();
+
+    setShareDiagnostics(true);
+
+    expect(writeSettingMock).toHaveBeenCalledWith("shareDiagnostics", true);
+    // Enabled via the direct apply path, not the (unfired) change watcher.
+    expect(initMock).toHaveBeenCalledTimes(1);
+    expect(initMock.mock.calls[0][0]).toMatchObject({ enabled: true });
+  });
+
+  test("disabling closes a running client", () => {
+    initSentryMain();
+    const closeMock = mock(() => Promise.resolve(true));
+    sentryClient = { getOptions: () => ({ enabled: true }), close: closeMock };
+
+    setShareDiagnostics(false);
+
+    expect(writeSettingMock).toHaveBeenCalledWith("shareDiagnostics", false);
+    expect(closeMock).toHaveBeenCalled();
+    expect(setClientMock).toHaveBeenCalledWith(undefined);
+  });
+});
+
+describe("mid-session toggle watcher", () => {
+  test("flipping the stored value on enables, off closes", () => {
+    initSentryMain();
+
+    settingChangeCb?.(true);
+    expect(initMock).toHaveBeenCalledTimes(1);
+
+    sentryClient = {
+      getOptions: () => ({ enabled: true }),
+      close: () => Promise.resolve(true),
+    };
+    settingChangeCb?.(false);
+    expect(setClientMock).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/clients/macos/src/main/sentry.ts
+++ b/clients/macos/src/main/sentry.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/node";
 import { app } from "electron";
 
-import { onSettingChange, readSetting, writeSetting } from "./settings";
+import { onSettingChange, writeSetting } from "./settings";
 
 declare const __VELLUM_BUILD_SHA__: string;
 declare const __VELLUM_ENVIRONMENT__: string;
@@ -79,48 +79,43 @@ function tryClose(): void {
   Sentry.getCurrentScope().setClient(undefined);
 }
 
-/**
- * Read consent from electron-store. Strict opt-in: absent or false → OFF.
- */
-function readConsent(): boolean {
-  return readSetting("shareDiagnostics") === true;
+let cachedOptions: Sentry.NodeOptions | null = null;
+
+function applyConsent(enabled: boolean): void {
+  if (!cachedOptions) return;
+  if (enabled) {
+    tryInit(cachedOptions);
+  } else {
+    tryClose();
+  }
 }
 
 /**
- * Initialize Sentry for the Electron main process, gated on the user's
- * Share Diagnostics consent stored in electron-store. The renderer syncs
- * its localStorage `device:share_diagnostics` value to main via the
- * `vellum:diagnostics:setShareDiagnostics` IPC channel.
- *
- * Strict opt-in semantics (matching the renderer's `sentry-control.ts`):
- *   - stored `true`  → Sentry ON  (explicit consent)
- *   - stored `false` → Sentry OFF (explicit opt-out)
- *   - absent         → Sentry OFF (no consent on record yet)
- *
- * Also installs an electron-store watcher so flipping the toggle
- * mid-session immediately enables/disables Sentry without restart.
+ * Prepare main-process Sentry consent gating, starting fail-closed: Sentry is
+ * NOT initialized from the persisted `shareDiagnostics` value, because main
+ * boots before any renderer exists and the persisted value can be a stale
+ * opt-in from a prior signed-in run. The renderer owns the live-session gate
+ * and pushes the effective consent over the
+ * `vellum:diagnostics:setShareDiagnostics` IPC channel; until it does, main
+ * stays silent. An electron-store watcher keeps Sentry in sync with later
+ * mid-session toggles.
  */
 export function initSentryMain(): void {
-  const options = resolveOptions();
-  if (!options) return;
-
-  if (readConsent()) {
-    tryInit(options);
-  }
+  cachedOptions = resolveOptions();
+  if (!cachedOptions) return;
 
   onSettingChange("shareDiagnostics", (newValue) => {
-    if (newValue === true) {
-      tryInit(options);
-    } else {
-      tryClose();
-    }
+    applyConsent(newValue === true);
   });
 }
 
 /**
- * Update the persisted diagnostics consent from the renderer's IPC call.
- * Triggers the `onSettingChange` watcher which handles Sentry lifecycle.
+ * Apply the renderer's effective (session-gated) diagnostics consent: persist
+ * it and enable/disable Sentry immediately. Applied directly rather than via
+ * the change watcher so an unchanged persisted value still enforces the gate
+ * (electron-store's `onDidChange` does not fire when the value is unchanged).
  */
 export function setShareDiagnostics(enabled: boolean): void {
   writeSetting("shareDiagnostics", enabled);
+  applyConsent(enabled);
 }

--- a/clients/web/src/domains/onboarding/onboarding-store.ts
+++ b/clients/web/src/domains/onboarding/onboarding-store.ts
@@ -74,9 +74,8 @@ const useOnboardingStoreBase = create<OnboardingStore>()((set) => ({
   },
   setShareDiagnostics: (value) => {
     set({ shareDiagnostics: value });
-    // The device-key write fires the watcher in `sentry-control.ts`, which
-    // re-syncs both Sentry clients with the session gate applied — so the
-    // main-process sync is centralized there, not forced un-gated from here.
+    // Writing the device key fires the `sentry-control.ts` watcher, which
+    // applies the live-session gate and syncs both Sentry clients.
     setLocalBool(KEY_SHARE_DIAGNOSTICS, value);
   },
   setTosAccepted: (value) => {

--- a/clients/web/src/domains/onboarding/onboarding-store.ts
+++ b/clients/web/src/domains/onboarding/onboarding-store.ts
@@ -17,7 +17,6 @@
 
 import { create } from "zustand";
 
-import { syncDiagnosticsToMain } from "@/runtime/diagnostics";
 import { createSelectors } from "@/utils/create-selectors";
 import {
   getLocalBool,
@@ -75,8 +74,10 @@ const useOnboardingStoreBase = create<OnboardingStore>()((set) => ({
   },
   setShareDiagnostics: (value) => {
     set({ shareDiagnostics: value });
+    // The device-key write fires the watcher in `sentry-control.ts`, which
+    // re-syncs both Sentry clients with the session gate applied — so the
+    // main-process sync is centralized there, not forced un-gated from here.
     setLocalBool(KEY_SHARE_DIAGNOSTICS, value);
-    syncDiagnosticsToMain(value);
   },
   setTosAccepted: (value) => {
     set({ tosAccepted: value });

--- a/clients/web/src/domains/settings/pages/privacy-page.tsx
+++ b/clients/web/src/domains/settings/pages/privacy-page.tsx
@@ -9,6 +9,7 @@ import { BiometricSettingsCard } from "@/domains/settings/components/biometric-s
 import { RiskToleranceSettings } from "@/domains/settings/components/risk-tolerance-settings";
 import { TrustRules } from "@/domains/settings/components/trust-rules/trust-rules";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
+import { isPlatformDisabled } from "@/lib/local-mode";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
 import {
@@ -43,6 +44,10 @@ export function PrivacyPage() {
   const platformGate = usePlatformGate({ platformHostedOnly: true });
   const channelTrustFloors = useAssistantFeatureFlagStore.use.channelTrustFloors();
   const hasPlatformSession = useHasPlatformSession();
+  // Share consent is a platform-account concern: only surface the toggles when
+  // there's a live session to record against, mirroring the navigation-resolver
+  // `requireConsent` predicate. Offline/self-hosted, telemetry is fail-closed.
+  const showShareConsent = !isPlatformDisabled() && hasPlatformSession;
   const userId = useAuthStore.use.user()?.id ?? null;
   const [shareAnalytics, setShareAnalytics] = useState(
     () => getDeviceBool("shareAnalytics", true),
@@ -80,22 +85,26 @@ export function PrivacyPage() {
       <RiskToleranceSettings />
       <DetailCard title="Privacy">
         <div className="space-y-4">
-          <SettingRow
-            label="Share Analytics"
-            helperText="Send anonymous product usage data."
-            checked={shareAnalytics}
-            onChange={handleAnalyticsToggle}
-            variant="toggle-trailing"
-          />
-          <Divider />
-          <SettingRow
-            label="Share Diagnostics"
-            helperText="Send crash reports and performance metrics."
-            checked={shareDiagnostics}
-            onChange={handleDiagnosticsToggle}
-            variant="toggle-trailing"
-          />
-          <Divider />
+          {showShareConsent && (
+            <>
+              <SettingRow
+                label="Share Analytics"
+                helperText="Send anonymous product usage data."
+                checked={shareAnalytics}
+                onChange={handleAnalyticsToggle}
+                variant="toggle-trailing"
+              />
+              <Divider />
+              <SettingRow
+                label="Share Diagnostics"
+                helperText="Send crash reports and performance metrics."
+                checked={shareDiagnostics}
+                onChange={handleDiagnosticsToggle}
+                variant="toggle-trailing"
+              />
+              <Divider />
+            </>
+          )}
           <AccessConsentSetting />
           {/*
             `AccessConsentSetting` returns null when gated (self-hosted

--- a/clients/web/src/domains/settings/pages/privacy-page.tsx
+++ b/clients/web/src/domains/settings/pages/privacy-page.tsx
@@ -10,7 +10,10 @@ import { RiskToleranceSettings } from "@/domains/settings/components/risk-tolera
 import { TrustRules } from "@/domains/settings/components/trust-rules/trust-rules";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
-import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
+import {
+  useAuthStore,
+  useHasConfirmedPlatformSession,
+} from "@/stores/auth-store";
 import {
     getDeviceBool,
     getDeviceSetting,
@@ -42,10 +45,12 @@ export function PrivacyPage() {
   // `AccessConsentSetting` exactly.
   const platformGate = usePlatformGate({ platformHostedOnly: true });
   const channelTrustFloors = useAssistantFeatureFlagStore.use.channelTrustFloors();
-  const hasPlatformSession = useHasPlatformSession();
   // The Share toggles control telemetry (browser Sentry, daemon analytics) that
-  // only runs with a live platform session, so only surface them when there is
-  // one — matching the consent gate in `sentry-control.ts`.
+  // only runs with a probe-confirmed live platform session, so gate both the
+  // visibility and the consent write on it — matching `sentry-control.ts`. A
+  // believed offline restore (LUM-2412) is not live, so the toggles hide and a
+  // flip can't stamp version-currency offline.
+  const hasPlatformSession = useHasConfirmedPlatformSession();
   const showShareConsent = hasPlatformSession;
   const userId = useAuthStore.use.user()?.id ?? null;
   const [shareAnalytics, setShareAnalytics] = useState(

--- a/clients/web/src/domains/settings/pages/privacy-page.tsx
+++ b/clients/web/src/domains/settings/pages/privacy-page.tsx
@@ -9,7 +9,6 @@ import { BiometricSettingsCard } from "@/domains/settings/components/biometric-s
 import { RiskToleranceSettings } from "@/domains/settings/components/risk-tolerance-settings";
 import { TrustRules } from "@/domains/settings/components/trust-rules/trust-rules";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
-import { isPlatformDisabled } from "@/lib/local-mode";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
 import {
@@ -44,10 +43,10 @@ export function PrivacyPage() {
   const platformGate = usePlatformGate({ platformHostedOnly: true });
   const channelTrustFloors = useAssistantFeatureFlagStore.use.channelTrustFloors();
   const hasPlatformSession = useHasPlatformSession();
-  // Share consent is a platform-account concern: only surface the toggles when
-  // there's a live session to record against, mirroring the navigation-resolver
-  // `requireConsent` predicate. Offline/self-hosted, telemetry is fail-closed.
-  const showShareConsent = !isPlatformDisabled() && hasPlatformSession;
+  // The Share toggles control telemetry (browser Sentry, daemon analytics) that
+  // only runs with a live platform session, so only surface them when there is
+  // one — matching the consent gate in `sentry-control.ts`.
+  const showShareConsent = hasPlatformSession;
   const userId = useAuthStore.use.user()?.id ?? null;
   const [shareAnalytics, setShareAnalytics] = useState(
     () => getDeviceBool("shareAnalytics", true),

--- a/clients/web/src/lib/sentry/sentry-control.test.ts
+++ b/clients/web/src/lib/sentry/sentry-control.test.ts
@@ -9,9 +9,14 @@ let platformSession = "absent";
 let mockClient:
   | { getOptions: () => { enabled?: boolean }; close: () => Promise<boolean> }
   | undefined;
+let deviceWatchCallback: (() => void) | null = null;
+let authSubscriber:
+  | ((state: { platformSession: string }, prev: { platformSession: string }) => void)
+  | null = null;
 
 const initMock = mock((_opts: Record<string, unknown>) => {});
 const setClientMock = mock((_client: unknown) => {});
+const syncDiagnosticsToMainMock = mock((_enabled: boolean) => {});
 
 mock.module("@sentry/react", () => ({
   init: initMock,
@@ -21,26 +26,60 @@ mock.module("@sentry/react", () => ({
 
 mock.module("@/utils/device-settings", () => ({
   getDeviceBool: (_key: string, _dflt: boolean) => deviceDiagnostics,
-  watchDeviceSetting: () => () => {},
+  watchDeviceSetting: (_name: string, cb: () => void) => {
+    deviceWatchCallback = cb;
+    return () => {
+      deviceWatchCallback = null;
+    };
+  },
+}));
+
+mock.module("@/runtime/diagnostics", () => ({
+  syncDiagnosticsToMain: syncDiagnosticsToMainMock,
 }));
 
 mock.module("@/stores/auth-store", () => ({
   useAuthStore: {
     getState: () => ({ platformSession }),
-    subscribe: () => () => {},
+    subscribe: (cb: typeof authSubscriber) => {
+      authSubscriber = cb;
+      return () => {
+        authSubscriber = null;
+      };
+    },
   },
 }));
 
-const { syncSentryClient } = await import("@/lib/sentry/sentry-control");
+const { syncSentryClient, diagnosticsConsentGranted, installSentryControlListeners } =
+  await import("@/lib/sentry/sentry-control");
 
 const OPTIONS = { dsn: "https://public@example.test/1" };
 
 beforeEach(() => {
   initMock.mockReset();
   setClientMock.mockReset();
+  syncDiagnosticsToMainMock.mockReset();
   mockClient = undefined;
   deviceDiagnostics = false;
   platformSession = "absent";
+  deviceWatchCallback = null;
+  authSubscriber = null;
+});
+
+describe("diagnosticsConsentGranted", () => {
+  test("false without a live platform session even when the toggle is on", () => {
+    deviceDiagnostics = true;
+    platformSession = "absent";
+    expect(diagnosticsConsentGranted()).toBe(false);
+  });
+
+  test("true only with a live session and the toggle on", () => {
+    platformSession = "present";
+    deviceDiagnostics = true;
+    expect(diagnosticsConsentGranted()).toBe(true);
+    deviceDiagnostics = false;
+    expect(diagnosticsConsentGranted()).toBe(false);
+  });
 });
 
 describe("syncSentryClient consent gate", () => {
@@ -78,5 +117,41 @@ describe("syncSentryClient consent gate", () => {
     syncSentryClient(OPTIONS);
     expect(initMock).not.toHaveBeenCalled();
     expect(closeMock).toHaveBeenCalled();
+  });
+});
+
+describe("installSentryControlListeners drives the Electron main process", () => {
+  test("device toggle change syncs main with the session-gated value", () => {
+    platformSession = "present";
+    deviceDiagnostics = true;
+    const stop = installSentryControlListeners(OPTIONS);
+
+    syncDiagnosticsToMainMock.mockReset();
+    deviceWatchCallback?.();
+    expect(syncDiagnosticsToMainMock).toHaveBeenCalledWith(true);
+
+    // Offline, the same toggle value tells main to disable.
+    platformSession = "absent";
+    syncDiagnosticsToMainMock.mockReset();
+    deviceWatchCallback?.();
+    expect(syncDiagnosticsToMainMock).toHaveBeenCalledWith(false);
+
+    stop();
+  });
+
+  test("a platform-session transition re-syncs both clients", () => {
+    deviceDiagnostics = true;
+    platformSession = "absent";
+    const stop = installSentryControlListeners(OPTIONS);
+
+    initMock.mockReset();
+    syncDiagnosticsToMainMock.mockReset();
+    platformSession = "present";
+    authSubscriber?.({ platformSession: "present" }, { platformSession: "absent" });
+
+    expect(initMock).toHaveBeenCalled();
+    expect(syncDiagnosticsToMainMock).toHaveBeenCalledWith(true);
+
+    stop();
   });
 });

--- a/clients/web/src/lib/sentry/sentry-control.test.ts
+++ b/clients/web/src/lib/sentry/sentry-control.test.ts
@@ -6,12 +6,16 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 let deviceDiagnostics = false;
 let platformSession = "absent";
+let restoredOffline = false;
 let mockClient:
   | { getOptions: () => { enabled?: boolean }; close: () => Promise<boolean> }
   | undefined;
 let deviceWatchCallback: (() => void) | null = null;
 let authSubscriber:
-  | ((state: { platformSession: string }, prev: { platformSession: string }) => void)
+  | ((
+      state: { platformSession: string; platformSessionRestoredOffline: boolean },
+      prev: { platformSession: string; platformSessionRestoredOffline: boolean },
+    ) => void)
   | null = null;
 
 const initMock = mock((_opts: Record<string, unknown>) => {});
@@ -40,7 +44,10 @@ mock.module("@/runtime/diagnostics", () => ({
 
 mock.module("@/stores/auth-store", () => ({
   useAuthStore: {
-    getState: () => ({ platformSession }),
+    getState: () => ({
+      platformSession,
+      platformSessionRestoredOffline: restoredOffline,
+    }),
     subscribe: (cb: typeof authSubscriber) => {
       authSubscriber = cb;
       return () => {
@@ -62,6 +69,7 @@ beforeEach(() => {
   mockClient = undefined;
   deviceDiagnostics = false;
   platformSession = "absent";
+  restoredOffline = false;
   deviceWatchCallback = null;
   authSubscriber = null;
 });
@@ -73,8 +81,16 @@ describe("diagnosticsConsentGranted", () => {
     expect(diagnosticsConsentGranted()).toBe(false);
   });
 
-  test("true only with a live session and the toggle on", () => {
+  test("false for a believed offline restore even when present + toggle on", () => {
+    deviceDiagnostics = true;
     platformSession = "present";
+    restoredOffline = true;
+    expect(diagnosticsConsentGranted()).toBe(false);
+  });
+
+  test("true only with a confirmed-live session and the toggle on", () => {
+    platformSession = "present";
+    restoredOffline = false;
     deviceDiagnostics = true;
     expect(diagnosticsConsentGranted()).toBe(true);
     deviceDiagnostics = false;
@@ -90,7 +106,7 @@ describe("syncSentryClient consent gate", () => {
     expect(initMock).not.toHaveBeenCalled();
   });
 
-  test("live session + toggle on: inits the client enabled", () => {
+  test("confirmed-live session + toggle on: inits the client enabled", () => {
     deviceDiagnostics = true;
     platformSession = "present";
     syncSentryClient(OPTIONS);
@@ -147,7 +163,31 @@ describe("installSentryControlListeners drives the Electron main process", () =>
     initMock.mockReset();
     syncDiagnosticsToMainMock.mockReset();
     platformSession = "present";
-    authSubscriber?.({ platformSession: "present" }, { platformSession: "absent" });
+    authSubscriber?.(
+      { platformSession: "present", platformSessionRestoredOffline: false },
+      { platformSession: "absent", platformSessionRestoredOffline: false },
+    );
+
+    expect(initMock).toHaveBeenCalled();
+    expect(syncDiagnosticsToMainMock).toHaveBeenCalledWith(true);
+
+    stop();
+  });
+
+  test("a restored-offline → confirmed transition (present unchanged) re-syncs", () => {
+    deviceDiagnostics = true;
+    platformSession = "present";
+    restoredOffline = true; // believed offline restore: telemetry off
+    const stop = installSentryControlListeners(OPTIONS);
+
+    initMock.mockReset();
+    syncDiagnosticsToMainMock.mockReset();
+    // A live probe confirms the session: present is unchanged, only the marker flips.
+    restoredOffline = false;
+    authSubscriber?.(
+      { platformSession: "present", platformSessionRestoredOffline: false },
+      { platformSession: "present", platformSessionRestoredOffline: true },
+    );
 
     expect(initMock).toHaveBeenCalled();
     expect(syncDiagnosticsToMainMock).toHaveBeenCalledWith(true);

--- a/clients/web/src/lib/sentry/sentry-control.test.ts
+++ b/clients/web/src/lib/sentry/sentry-control.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Controllable mock state
+// ---------------------------------------------------------------------------
+
+let deviceDiagnostics = false;
+let platformSession = "absent";
+let mockClient:
+  | { getOptions: () => { enabled?: boolean }; close: () => Promise<boolean> }
+  | undefined;
+
+const initMock = mock((_opts: Record<string, unknown>) => {});
+const setClientMock = mock((_client: unknown) => {});
+
+mock.module("@sentry/react", () => ({
+  init: initMock,
+  getClient: () => mockClient,
+  getCurrentScope: () => ({ setClient: setClientMock }),
+}));
+
+mock.module("@/utils/device-settings", () => ({
+  getDeviceBool: (_key: string, _dflt: boolean) => deviceDiagnostics,
+  watchDeviceSetting: () => () => {},
+}));
+
+mock.module("@/stores/auth-store", () => ({
+  useAuthStore: {
+    getState: () => ({ platformSession }),
+    subscribe: () => () => {},
+  },
+}));
+
+const { syncSentryClient } = await import("@/lib/sentry/sentry-control");
+
+const OPTIONS = { dsn: "https://public@example.test/1" };
+
+beforeEach(() => {
+  initMock.mockReset();
+  setClientMock.mockReset();
+  mockClient = undefined;
+  deviceDiagnostics = false;
+  platformSession = "absent";
+});
+
+describe("syncSentryClient consent gate", () => {
+  test("no live platform session: does not init even when the device toggle is on", () => {
+    deviceDiagnostics = true;
+    platformSession = "absent";
+    syncSentryClient(OPTIONS);
+    expect(initMock).not.toHaveBeenCalled();
+  });
+
+  test("live session + toggle on: inits the client enabled", () => {
+    deviceDiagnostics = true;
+    platformSession = "present";
+    syncSentryClient(OPTIONS);
+    expect(initMock).toHaveBeenCalledTimes(1);
+    expect(initMock.mock.calls[0][0]).toMatchObject({ enabled: true });
+  });
+
+  test("live session + toggle off: closes a running client", () => {
+    deviceDiagnostics = false;
+    platformSession = "present";
+    const closeMock = mock(() => Promise.resolve(true));
+    mockClient = { getOptions: () => ({ enabled: true }), close: closeMock };
+    syncSentryClient(OPTIONS);
+    expect(initMock).not.toHaveBeenCalled();
+    expect(closeMock).toHaveBeenCalled();
+    expect(setClientMock).toHaveBeenCalledWith(undefined);
+  });
+
+  test("session lost while toggle on: closes the client (fail-closed offline)", () => {
+    deviceDiagnostics = true;
+    platformSession = "absent";
+    const closeMock = mock(() => Promise.resolve(true));
+    mockClient = { getOptions: () => ({ enabled: true }), close: closeMock };
+    syncSentryClient(OPTIONS);
+    expect(initMock).not.toHaveBeenCalled();
+    expect(closeMock).toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/lib/sentry/sentry-control.ts
+++ b/clients/web/src/lib/sentry/sentry-control.ts
@@ -3,15 +3,16 @@ import * as Sentry from "@sentry/react";
 import { getDeviceBool, watchDeviceSetting } from "@/utils/device-settings";
 import { syncDiagnosticsToMain } from "@/runtime/diagnostics";
 import { useAuthStore } from "@/stores/auth-store";
-import { hasLivePlatformSession } from "@/stores/session-status";
+import { isConfirmedPlatformSession } from "@/stores/session-status";
 
 /**
  * Gates Sentry on BOTH the user's Share Diagnostics toggle
- * (`device:share_diagnostics`) AND a live platform session. Diagnostics are
- * recorded against a platform account, so an offline / self-hosted client with
- * no session stays fail-closed regardless of the device toggle — matching the
- * daemon's consent posture. The same gate drives the browser client and, via
- * `syncDiagnosticsToMain`, the Electron main-process client.
+ * (`device:share_diagnostics`) AND a probe-confirmed live platform session.
+ * Diagnostics are recorded against a platform account, so an offline /
+ * self-hosted client — including a believed offline restore (LUM-2412) that no
+ * live probe has revalidated — stays fail-closed regardless of the device
+ * toggle, matching the daemon's consent posture. The same gate drives the
+ * browser client and, via `syncDiagnosticsToMain`, the Electron main client.
  *
  * Strict opt-in semantics for the device toggle (when a session is live):
  *   - stored "true"  → Sentry ON  (explicit consent)
@@ -22,7 +23,9 @@ import { hasLivePlatformSession } from "@/stores/session-status";
  */
 
 export function diagnosticsConsentGranted(): boolean {
-  if (!hasLivePlatformSession(useAuthStore.getState().platformSession)) {
+  const { platformSession, platformSessionRestoredOffline } =
+    useAuthStore.getState();
+  if (!isConfirmedPlatformSession(platformSession, platformSessionRestoredOffline)) {
     return false;
   }
   return getDeviceBool("shareDiagnostics", false);
@@ -72,7 +75,13 @@ export function installSentryControlListeners(
   };
   const stopDeviceWatch = watchDeviceSetting("shareDiagnostics", sync);
   const stopSessionWatch = useAuthStore.subscribe((state, prevState) => {
-    if (state.platformSession !== prevState.platformSession) sync();
+    if (
+      state.platformSession !== prevState.platformSession ||
+      state.platformSessionRestoredOffline !==
+        prevState.platformSessionRestoredOffline
+    ) {
+      sync();
+    }
   });
   return () => {
     stopDeviceWatch();

--- a/clients/web/src/lib/sentry/sentry-control.ts
+++ b/clients/web/src/lib/sentry/sentry-control.ts
@@ -1,12 +1,17 @@
 import * as Sentry from "@sentry/react";
 
 import { getDeviceBool, watchDeviceSetting } from "@/utils/device-settings";
+import { useAuthStore } from "@/stores/auth-store";
+import { hasLivePlatformSession } from "@/stores/session-status";
 
 /**
- * Gates the browser-side Sentry client on the user's Share Diagnostics
- * toggle (`device:share_diagnostics`), matching the macOS app's behavior.
+ * Gates the browser-side Sentry client on BOTH the user's Share Diagnostics
+ * toggle (`device:share_diagnostics`) AND a live platform session. Diagnostics
+ * are recorded against a platform account, so an offline / self-hosted client
+ * with no session stays fail-closed regardless of the device toggle — matching
+ * the daemon's consent posture.
  *
- * Strict opt-in semantics:
+ * Strict opt-in semantics for the device toggle (when a session is live):
  *   - stored "true"  → Sentry ON  (explicit consent)
  *   - stored "false" → Sentry OFF (explicit opt-out)
  *   - absent         → Sentry OFF (no consent on record yet)
@@ -15,6 +20,9 @@ import { getDeviceBool, watchDeviceSetting } from "@/utils/device-settings";
  */
 
 function readConsent(): boolean {
+  if (!hasLivePlatformSession(useAuthStore.getState().platformSession)) {
+    return false;
+  }
   return getDeviceBool("shareDiagnostics", false);
 }
 
@@ -46,17 +54,26 @@ export function syncSentryClient(options: Sentry.BrowserOptions): void {
 }
 
 /**
- * Install listeners so the Sentry client turns on/off whenever the user
- * flips the Share Diagnostics toggle — covering cross-tab writes (via the
- * native `storage` event) and same-tab writes (via the custom event
- * dispatched by `setLocalSetting`).
+ * Install listeners so the Sentry client turns on/off whenever the gate
+ * changes: the user flipping the Share Diagnostics toggle (cross-tab via the
+ * native `storage` event, same-tab via the custom event from `setLocalSetting`)
+ * or the platform session transitioning in/out of "present".
  *
  * Returns a cleanup function that removes both listeners.
  */
 export function installSentryControlListeners(
   options: Sentry.BrowserOptions,
 ): () => void {
-  return watchDeviceSetting("shareDiagnostics", () => {
+  const stopDeviceWatch = watchDeviceSetting("shareDiagnostics", () => {
     syncSentryClient(options);
   });
+  const stopSessionWatch = useAuthStore.subscribe((state, prevState) => {
+    if (state.platformSession !== prevState.platformSession) {
+      syncSentryClient(options);
+    }
+  });
+  return () => {
+    stopDeviceWatch();
+    stopSessionWatch();
+  };
 }

--- a/clients/web/src/lib/sentry/sentry-control.ts
+++ b/clients/web/src/lib/sentry/sentry-control.ts
@@ -1,15 +1,17 @@
 import * as Sentry from "@sentry/react";
 
 import { getDeviceBool, watchDeviceSetting } from "@/utils/device-settings";
+import { syncDiagnosticsToMain } from "@/runtime/diagnostics";
 import { useAuthStore } from "@/stores/auth-store";
 import { hasLivePlatformSession } from "@/stores/session-status";
 
 /**
- * Gates the browser-side Sentry client on BOTH the user's Share Diagnostics
- * toggle (`device:share_diagnostics`) AND a live platform session. Diagnostics
- * are recorded against a platform account, so an offline / self-hosted client
- * with no session stays fail-closed regardless of the device toggle — matching
- * the daemon's consent posture.
+ * Gates Sentry on BOTH the user's Share Diagnostics toggle
+ * (`device:share_diagnostics`) AND a live platform session. Diagnostics are
+ * recorded against a platform account, so an offline / self-hosted client with
+ * no session stays fail-closed regardless of the device toggle — matching the
+ * daemon's consent posture. The same gate drives the browser client and, via
+ * `syncDiagnosticsToMain`, the Electron main-process client.
  *
  * Strict opt-in semantics for the device toggle (when a session is live):
  *   - stored "true"  → Sentry ON  (explicit consent)
@@ -19,7 +21,7 @@ import { hasLivePlatformSession } from "@/stores/session-status";
  * Reference: https://docs.sentry.io/platforms/javascript/guides/react/configuration/options/
  */
 
-function readConsent(): boolean {
+export function diagnosticsConsentGranted(): boolean {
   if (!hasLivePlatformSession(useAuthStore.getState().platformSession)) {
     return false;
   }
@@ -46,7 +48,7 @@ function tryClose(): void {
  */
 export function syncSentryClient(options: Sentry.BrowserOptions): void {
   if (!options.dsn) return;
-  if (readConsent()) {
+  if (diagnosticsConsentGranted()) {
     tryInit(options);
   } else {
     tryClose();
@@ -54,23 +56,23 @@ export function syncSentryClient(options: Sentry.BrowserOptions): void {
 }
 
 /**
- * Install listeners so the Sentry client turns on/off whenever the gate
- * changes: the user flipping the Share Diagnostics toggle (cross-tab via the
- * native `storage` event, same-tab via the custom event from `setLocalSetting`)
- * or the platform session transitioning in/out of "present".
+ * Install listeners so both Sentry clients (browser + Electron main) re-apply
+ * the gate whenever it changes: the user flipping the Share Diagnostics toggle
+ * (cross-tab via the native `storage` event, same-tab via the custom event from
+ * `setLocalSetting`) or the platform session transitioning in/out of "present".
  *
  * Returns a cleanup function that removes both listeners.
  */
 export function installSentryControlListeners(
   options: Sentry.BrowserOptions,
 ): () => void {
-  const stopDeviceWatch = watchDeviceSetting("shareDiagnostics", () => {
+  const sync = () => {
     syncSentryClient(options);
-  });
+    syncDiagnosticsToMain(diagnosticsConsentGranted());
+  };
+  const stopDeviceWatch = watchDeviceSetting("shareDiagnostics", sync);
   const stopSessionWatch = useAuthStore.subscribe((state, prevState) => {
-    if (state.platformSession !== prevState.platformSession) {
-      syncSentryClient(options);
-    }
+    if (state.platformSession !== prevState.platformSession) sync();
   });
   return () => {
     stopDeviceWatch();

--- a/clients/web/src/lib/sentry/sentry-init.ts
+++ b/clients/web/src/lib/sentry/sentry-init.ts
@@ -1,12 +1,12 @@
 import type { BrowserOptions } from "@sentry/react";
 
 import {
+  diagnosticsConsentGranted,
   installSentryControlListeners,
   syncSentryClient,
 } from "@/lib/sentry/sentry-control";
 import { syncDiagnosticsToMain } from "@/runtime/diagnostics";
 import { sanitizeUrl } from "@/lib/sentry/url-sanitize";
-import { getDeviceBool } from "@/utils/device-settings";
 
 /**
  * Browser-side Sentry initialization, gated on the user's Share Diagnostics
@@ -104,13 +104,13 @@ const options: BrowserOptions = {
 /**
  * Bootstrap Sentry consent gating. Must be called after
  * `migrateDeviceSettings()` so the `device:share_diagnostics` key
- * is available when `readConsent()` reads localStorage.
+ * is available when the consent gate reads localStorage.
  *
- * Also syncs the current consent state to the Electron main process
- * (no-op on web/iOS) so the main-process Sentry client matches.
+ * Also syncs the effective (session-gated) consent to the Electron main
+ * process (no-op on web/iOS) so the main-process Sentry client matches.
  */
 export function initSentry(): void {
   syncSentryClient(options);
   installSentryControlListeners(options);
-  syncDiagnosticsToMain(getDeviceBool("shareDiagnostics", false));
+  syncDiagnosticsToMain(diagnosticsConsentGranted());
 }

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -490,6 +490,8 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
     expect(useAuthStore.getState().user?.id).toBe("user-1");
     expect(useAuthStore.getState().platformSession).toBe("present");
+    // A live probe confirmed it — not a believed offline restore.
+    expect(useAuthStore.getState().platformSessionRestoredOffline).toBe(false);
   });
 
   test("initSession uses server consent when server has a consent record", async () => {
@@ -1036,6 +1038,8 @@ describe("offline session restore (LUM-2412)", () => {
     // probe runs offline to settle an "unknown" — so the restore settles
     // "present" (believed state); reconnect revalidation corrects it.
     expect(useAuthStore.getState().platformSession).toBe("present");
+    // ...but it is flagged as a believed restore, so telemetry stays fail-closed.
+    expect(useAuthStore.getState().platformSessionRestoredOffline).toBe(true);
   });
 
   test("transport-failed boot (proxy 502) with token + snapshot settles authenticated from cache", async () => {

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -21,6 +21,7 @@ import {
   isSessionSettled,
   isSettledSessionRejection,
   hasLivePlatformSession,
+  isConfirmedPlatformSession,
   type PlatformSessionStatus,
   type SessionStatus,
 } from "@/stores/session-status";
@@ -119,6 +120,10 @@ interface AuthState {
   sessionStatus: SessionStatus;
   user: AuthUser | null;
   platformSession: PlatformSessionStatus;
+  // True while `platformSession: "present"` is a believed offline restore
+  // (LUM-2412) rather than a session a live probe confirmed. Telemetry gates on
+  // a confirmed-live session, so it must not treat the restored state as live.
+  platformSessionRestoredOffline: boolean;
 }
 
 interface AuthActions {
@@ -173,6 +178,8 @@ const authenticatedPlatformUser = (
     sessionStatus: "authenticated",
     user,
     platformSession: "present",
+    // Confirmed by a live probe; `restoreOfflineSession` overrides this to true.
+    platformSessionRestoredOffline: false,
   };
 };
 
@@ -229,7 +236,10 @@ async function restoreOfflineSession(set: AuthSet): Promise<boolean> {
   // Consent/org sync falls back to device-cached keys when the server
   // fetch fails (it will, offline) — same continuity as an online boot.
   await syncUserScopedState(cached.id);
-  set(authenticatedPlatformUser(cached));
+  set({
+    ...authenticatedPlatformUser(cached),
+    platformSessionRestoredOffline: true,
+  });
   return true;
 }
 
@@ -427,7 +437,11 @@ function probePlatformSession(
           }
         }
         if (isStale()) return;
-        set({ platformSession: "present", ...userUpdate });
+        set({
+          platformSession: "present",
+          platformSessionRestoredOffline: false,
+          ...userUpdate,
+        });
       } else if (options.clearOnFailure) {
         set({ platformSession: "absent" });
       }
@@ -510,6 +524,7 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
   sessionStatus: "initializing",
   user: null,
   platformSession: "unknown",
+  platformSessionRestoredOffline: false,
 
   initSession: async () => {
     if (isRemoteGatewayMode()) {
@@ -860,6 +875,17 @@ export const useIsSessionInitializing = (): boolean =>
 
 export const useHasPlatformSession = (): boolean =>
   hasLivePlatformSession(useAuthStore.use.platformSession());
+
+/**
+ * A platform session a live probe confirmed — excludes the believed offline
+ * restore (LUM-2412). Telemetry consent gates on this, not the routing-oriented
+ * {@link useHasPlatformSession}, so it never enables offline.
+ */
+export const useHasConfirmedPlatformSession = (): boolean =>
+  isConfirmedPlatformSession(
+    useAuthStore.use.platformSession(),
+    useAuthStore.use.platformSessionRestoredOffline(),
+  );
 
 /**
  * Subscribe to app-resume signals on the layout-scoped event bus and to

--- a/clients/web/src/stores/session-status.ts
+++ b/clients/web/src/stores/session-status.ts
@@ -67,6 +67,17 @@ export const hasLivePlatformSession = (
 ): boolean => status === "present";
 
 /**
+ * A platform session a live probe confirmed — `"present"` AND not a believed
+ * offline restore (LUM-2412). Stricter than {@link hasLivePlatformSession}:
+ * telemetry consent gates on this so it never enables on a restored-offline
+ * launch that no live probe has revalidated.
+ */
+export const isConfirmedPlatformSession = (
+  status: PlatformSessionStatus,
+  restoredOffline: boolean,
+): boolean => status === "present" && !restoredOffline;
+
+/**
  * Statuses where the server itself said "no session": allauth's 401 for
  * an unauthenticated probe, a 403, or 410 Gone (session invalidated).
  */

--- a/clients/web/src/utils/onboarding-cleanup.test.ts
+++ b/clients/web/src/utils/onboarding-cleanup.test.ts
@@ -383,6 +383,17 @@ describe("savePreferenceToggle", () => {
     expect(body.share_diagnostics).toBe(false);
     expect(body.share_diagnostics_accepted_version).toBe(PRIVACY_CONSENT_VERSION);
   });
+
+  test("offline persists the on/off value but skips the currency stamp, ack key, and server patch", () => {
+    savePreferenceToggle("share_analytics", true, { userId: "user-1", hasPlatformSession: false });
+    // The chosen value is still recorded device-locally...
+    expect(storeState.setShareAnalytics).toHaveBeenCalledWith(true);
+    expect(setDeviceBoolMock).toHaveBeenCalledWith("shareAnalytics", true);
+    // ...but no version-currency is stamped without a session to record against.
+    expect(storeState.setAnalyticsConsentCurrent).not.toHaveBeenCalled();
+    expect(localStorage.getItem(analyticsKey("user-1"))).toBeNull();
+    expect(patchConsentMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("clearConsentForUser", () => {

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -240,16 +240,24 @@ export function savePreferenceToggle(
 ): void {
   const store = useOnboardingStore.getState();
   const { userId, hasPlatformSession } = opts;
+  // The on/off value is always device-persisted, but the version-currency ack
+  // ("confirmed under the current terms version") is only earned with a live
+  // platform session to record it against — offline it would stamp a currency
+  // the user never reviewed terms for.
   if (field === "share_analytics") {
     store.setShareAnalytics(value);
     setDeviceBool("shareAnalytics", value);
-    store.setAnalyticsConsentCurrent(true);
-    persistToggleConsent(userId, { analyticsCurrent: true });
+    if (hasPlatformSession) {
+      store.setAnalyticsConsentCurrent(true);
+      persistToggleConsent(userId, { analyticsCurrent: true });
+    }
   } else {
     store.setShareDiagnostics(value);
     setDeviceBool("shareDiagnostics", value);
-    store.setDiagnosticsConsentCurrent(true);
-    persistToggleConsent(userId, { diagnosticsCurrent: true });
+    if (hasPlatformSession) {
+      store.setDiagnosticsConsentCurrent(true);
+      persistToggleConsent(userId, { diagnosticsCurrent: true });
+    }
   }
 
   if (hasPlatformSession) {


### PR DESCRIPTION
## Summary
Diagnostics/telemetry consent is a platform-account concern, but the renderer **and** Electron main Sentry clients were gated only on a device key — running offline/self-hosted with the Settings toggle as the sole off-switch. This makes all telemetry fail-closed without a **probe-confirmed live** platform session, and hides the Settings toggles when there's nothing to control.

- **Browser Sentry** (`sentry-control.ts`): gated on `diagnosticsConsentGranted()` = device toggle **AND** `isConfirmedPlatformSession`, re-synced on device-toggle and session/restore-marker changes.
- **Electron main Sentry** (`clients/macos/src/main/sentry.ts`): starts **fail-closed** (no boot init from the persisted value — main boots before the renderer can apply the session gate). The renderer pushes the effective (session-gated) consent over IPC, applied directly so an unchanged persisted value still enforces the gate.
- **Confirmed-live session** (`auth-store.ts`): `platformSession: "present"` is set both by a live probe and by `restoreOfflineSession` (LUM-2412), so an additive `platformSessionRestoredOffline` marker distinguishes them. `isConfirmedPlatformSession = present && !restoredOffline`. Routing consumers keep using `platformSession` unchanged.
- **Settings → Privacy Share rows**: shown only with a confirmed-live session (`useHasConfirmedPlatformSession`); the device-local log-retention control and other rows stay available offline.
- **`savePreferenceToggle`**: still device-persists the on/off value, but the version-currency ack + server PATCH only happen with a confirmed-live session — no offline currency stamping.

## Scope note (maintainer decision)
A confirmed + opted-in account keeps telemetry through a **transient** connectivity loss (Sentry buffers and uploads on reconnect — standard, consent-consistent behavior). We intentionally do **not** suspend telemetry on every transport-failed refresh, to avoid fighting the LUM-2412 offline-resume continuity and flapping telemetry with connectivity. Reconnect revalidation still ends the session + drops telemetry on a settled "no session".

## Tests
- `sentry-control.test.ts` — browser gate, effective-consent predicate (incl. restored-offline → off), main-process sync, session/restore-marker transitions.
- `clients/macos/src/main/sentry.test.ts` — fail-closed boot, direct IPC enable/disable, mid-session watcher.
- `auth-store.test.ts` — `platformSessionRestoredOffline` true after offline restore, false after a confirmed probe.
- `onboarding-cleanup.test.ts` — offline `savePreferenceToggle` skips the currency stamp.

## Review history
Addressed 5 consecutive Codex P1s (browser gate → main-process sync → main boot race → restored-offline session semantics) + a P2 comment-style fix. The 6th item (suspend telemetry on transient offline for an already-confirmed user) was resolved as intended behavior per the scope note above.

## Original prompt
Follow-up to the onboarding/privacy vs. `/review-terms` analysis. The telemetry toggles were reachable offline via Settings → Privacy and `savePreferenceToggle` stamped consent-currency without a session. Per the maintainer's call to gate Sentry behind a live platform session, the scope became: gate both Sentry clients (browser + Electron main) on a probe-confirmed live session (fail-closed offline), gate the Settings Share rows on it, and skip the offline currency stamp.