### PR TITLE
refactor(web): introduce Sentry flavor abstraction; decouple control from @sentry/react

### DIFF
--- a/clients/web/src/lib/sentry/flavor-react.ts
+++ b/clients/web/src/lib/sentry/flavor-react.ts
@@ -1,0 +1,24 @@
+import * as Sentry from "@sentry/react";
+
+import type { SentryFlavor } from "@/lib/sentry/flavor";
+
+/**
+ * `SentryFlavor` backed by `@sentry/react`, the browser SDK used on the web
+ * app and the Electron renderer. Behavior mirrors the inlined init/close that
+ * previously lived in `sentry-control.ts`.
+ */
+export const reactFlavor: SentryFlavor = {
+  init(options) {
+    Sentry.init({ ...options, enabled: true });
+  },
+  close() {
+    const client = Sentry.getClient();
+    if (!client) return;
+    void client.close(2000);
+    Sentry.getCurrentScope().setClient(undefined);
+  },
+  getClientEnabled() {
+    const client = Sentry.getClient();
+    return client !== undefined && client.getOptions().enabled !== false;
+  },
+};

--- a/clients/web/src/lib/sentry/flavor-react.ts
+++ b/clients/web/src/lib/sentry/flavor-react.ts
@@ -4,8 +4,7 @@ import type { SentryFlavor } from "@/lib/sentry/flavor";
 
 /**
  * `SentryFlavor` backed by `@sentry/react`, the browser SDK used on the web
- * app and the Electron renderer. Behavior mirrors the inlined init/close that
- * previously lived in `sentry-control.ts`.
+ * app and the Electron renderer.
  */
 export const reactFlavor: SentryFlavor = {
   init(options) {

--- a/clients/web/src/lib/sentry/flavor.ts
+++ b/clients/web/src/lib/sentry/flavor.ts
@@ -18,13 +18,9 @@ export interface SentryFlavor {
 }
 
 /**
- * Pick the Sentry flavor for the current runtime.
- *
- * For now this always returns the `@sentry/react` flavor — the only surface
- * shipping the browser SDK today (web + Electron renderer). Later PRs add
- * branches here for the Electron renderer (IPC bridge) and the Capacitor
- * native platform; insert those `isElectron()` / `isNativePlatform()` checks
- * above the react fallback.
+ * Pick the Sentry flavor for the current runtime. The single place host-based
+ * selection lives; returns the `@sentry/react` flavor for the browser SDK
+ * surfaces (web + Electron renderer).
  */
 export function selectSentryFlavor(): SentryFlavor {
   return reactFlavor;

--- a/clients/web/src/lib/sentry/flavor.ts
+++ b/clients/web/src/lib/sentry/flavor.ts
@@ -1,0 +1,31 @@
+import type { BrowserOptions } from "@sentry/react";
+
+import { reactFlavor } from "@/lib/sentry/flavor-react";
+
+/**
+ * A thin seam over the Sentry SDK so consent gating in `sentry-control.ts`
+ * can dispatch through a single interface instead of importing a concrete
+ * SDK directly. Each surface (web/electron renderer, capacitor) provides its
+ * own implementation; `selectSentryFlavor()` picks the right one at runtime.
+ */
+export interface SentryFlavor {
+  /** Initialize the SDK with the given options (enabling the client). */
+  init(options: BrowserOptions): void;
+  /** Tear down the active client, if any. */
+  close(): Promise<void> | void;
+  /** Whether an enabled client is currently installed. */
+  getClientEnabled(): boolean;
+}
+
+/**
+ * Pick the Sentry flavor for the current runtime.
+ *
+ * For now this always returns the `@sentry/react` flavor — the only surface
+ * shipping the browser SDK today (web + Electron renderer). Later PRs add
+ * branches here for the Electron renderer (IPC bridge) and the Capacitor
+ * native platform; insert those `isElectron()` / `isNativePlatform()` checks
+ * above the react fallback.
+ */
+export function selectSentryFlavor(): SentryFlavor {
+  return reactFlavor;
+}

--- a/clients/web/src/lib/sentry/sentry-control.test.ts
+++ b/clients/web/src/lib/sentry/sentry-control.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { BrowserOptions } from "@sentry/react";
+
+import type { SentryFlavor } from "@/lib/sentry/flavor";
+
+const initMock = mock((_options: BrowserOptions) => {});
+const closeMock = mock(() => {});
+let clientEnabled = false;
+
+const flavor: SentryFlavor = {
+  init: initMock,
+  close: closeMock,
+  getClientEnabled: () => clientEnabled,
+};
+const selectSentryFlavorMock = mock(() => flavor);
+
+mock.module("@/lib/sentry/flavor", () => ({
+  selectSentryFlavor: selectSentryFlavorMock,
+}));
+
+let consent = false;
+const watchCallbacks: Array<() => void> = [];
+const unwatchMock = mock(() => {});
+
+mock.module("@/utils/device-settings", () => ({
+  getDeviceBool: (_name: string, fallback: boolean) =>
+    consent ? true : fallback,
+  watchDeviceSetting: (_name: string, callback: () => void) => {
+    watchCallbacks.push(callback);
+    return unwatchMock;
+  },
+}));
+
+const { syncSentryClient, installSentryControlListeners } = await import(
+  "@/lib/sentry/sentry-control"
+);
+
+const options: BrowserOptions = { dsn: "https://public@example.com/1" };
+
+beforeEach(() => {
+  initMock.mockClear();
+  closeMock.mockClear();
+  selectSentryFlavorMock.mockClear();
+  unwatchMock.mockClear();
+  watchCallbacks.length = 0;
+  consent = false;
+  clientEnabled = false;
+});
+
+describe("syncSentryClient", () => {
+  test("dispatches through the selected flavor", () => {
+    consent = true;
+    syncSentryClient(options);
+    expect(selectSentryFlavorMock).toHaveBeenCalled();
+  });
+
+  test("no-ops when dsn is absent (never touches the flavor)", () => {
+    consent = true;
+    syncSentryClient({});
+    expect(initMock).not.toHaveBeenCalled();
+    expect(closeMock).not.toHaveBeenCalled();
+  });
+
+  test("inits the flavor when consented and no client is enabled", () => {
+    consent = true;
+    clientEnabled = false;
+    syncSentryClient(options);
+    expect(initMock).toHaveBeenCalledTimes(1);
+    expect(initMock.mock.calls[0]![0]).toBe(options);
+    expect(closeMock).not.toHaveBeenCalled();
+  });
+
+  test("does not re-init when consented and a client is already enabled", () => {
+    consent = true;
+    clientEnabled = true;
+    syncSentryClient(options);
+    expect(initMock).not.toHaveBeenCalled();
+  });
+
+  test("closes the flavor when consent is absent", () => {
+    consent = false;
+    syncSentryClient(options);
+    expect(closeMock).toHaveBeenCalledTimes(1);
+    expect(initMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("installSentryControlListeners", () => {
+  test("re-syncs through the flavor when the toggle changes", () => {
+    const cleanup = installSentryControlListeners(options);
+    expect(watchCallbacks).toHaveLength(1);
+
+    consent = true;
+    watchCallbacks[0]!();
+    expect(initMock).toHaveBeenCalledTimes(1);
+
+    expect(cleanup).toBe(unwatchMock);
+  });
+});

--- a/clients/web/src/lib/sentry/sentry-control.ts
+++ b/clients/web/src/lib/sentry/sentry-control.ts
@@ -1,5 +1,6 @@
-import * as Sentry from "@sentry/react";
+import type { BrowserOptions } from "@sentry/react";
 
+import { selectSentryFlavor } from "@/lib/sentry/flavor";
 import { getDeviceBool, watchDeviceSetting } from "@/utils/device-settings";
 
 /**
@@ -11,6 +12,9 @@ import { getDeviceBool, watchDeviceSetting } from "@/utils/device-settings";
  *   - stored "false" → Sentry OFF (explicit opt-out)
  *   - absent         → Sentry OFF (no consent on record yet)
  *
+ * SDK access is dispatched through `selectSentryFlavor()` so each surface
+ * (web/electron renderer, capacitor) can supply its own implementation.
+ *
  * Reference: https://docs.sentry.io/platforms/javascript/guides/react/configuration/options/
  */
 
@@ -18,17 +22,14 @@ function readConsent(): boolean {
   return getDeviceBool("shareDiagnostics", false);
 }
 
-function tryInit(options: Sentry.BrowserOptions): void {
-  const existing = Sentry.getClient();
-  if (existing && existing.getOptions().enabled !== false) return;
-  Sentry.init({ ...options, enabled: true });
+function tryInit(options: BrowserOptions): void {
+  const flavor = selectSentryFlavor();
+  if (flavor.getClientEnabled()) return;
+  flavor.init(options);
 }
 
 function tryClose(): void {
-  const client = Sentry.getClient();
-  if (!client) return;
-  void client.close(2000);
-  Sentry.getCurrentScope().setClient(undefined);
+  void selectSentryFlavor().close();
 }
 
 /**
@@ -36,7 +37,7 @@ function tryClose(): void {
  * and not yet running, close if not consented and currently running.
  * Idempotent when consent matches the current client state.
  */
-export function syncSentryClient(options: Sentry.BrowserOptions): void {
+export function syncSentryClient(options: BrowserOptions): void {
   if (!options.dsn) return;
   if (readConsent()) {
     tryInit(options);
@@ -54,7 +55,7 @@ export function syncSentryClient(options: Sentry.BrowserOptions): void {
  * Returns a cleanup function that removes both listeners.
  */
 export function installSentryControlListeners(
-  options: Sentry.BrowserOptions,
+  options: BrowserOptions,
 ): () => void {
   return watchDeviceSetting("shareDiagnostics", () => {
     syncSentryClient(options);


### PR DESCRIPTION
## Summary
- Adds SentryFlavor seam (init/close/getClientEnabled) with a react implementation
- sentry-control no longer imports @sentry/react directly; dispatches via selectSentryFlavor()
- No behavior change; foundation for electron/capacitor flavors

Part of plan: sentry-overhaul.md (PR 4 of 12)