### PR TITLE
chore(ci): reuse vellum-assistant-macos for renderer; add vellum-assistant-ios DSN

### DIFF
--- a/.github/workflows/deploy-platform-web-spa.yaml
+++ b/.github/workflows/deploy-platform-web-spa.yaml
@@ -87,6 +87,9 @@ jobs:
         env:
           VITE_PLATFORM_MODE: "true"
           VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
+          # Baked into the deployed SPA so the iOS webview (which loads this
+          # bundle via `server.url`) reports to the mobile Sentry project.
+          VITE_SENTRY_DSN_MOBILE: ${{ secrets.SENTRY_DSN_MOBILE }}
           VITE_SENTRY_ENVIRONMENT: ${{ vars.VITE_SENTRY_ENVIRONMENT }}
           VITE_STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
           VITE_VELAY_HOST: ${{ vars.VITE_VELAY_HOST }}

--- a/.github/workflows/deploy-platform-web-spa.yaml
+++ b/.github/workflows/deploy-platform-web-spa.yaml
@@ -88,8 +88,8 @@ jobs:
           VITE_PLATFORM_MODE: "true"
           VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
           # Baked into the deployed SPA so the iOS webview (which loads this
-          # bundle via `server.url`) reports to the mobile Sentry project.
-          VITE_SENTRY_DSN_MOBILE: ${{ secrets.SENTRY_DSN_MOBILE }}
+          # bundle via `server.url`) reports to the vellum-assistant-ios project.
+          VITE_SENTRY_DSN_IOS: ${{ secrets.SENTRY_DSN_IOS }}
           VITE_SENTRY_ENVIRONMENT: ${{ vars.VITE_SENTRY_ENVIRONMENT }}
           VITE_STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
           VITE_VELAY_HOST: ${{ vars.VITE_VELAY_HOST }}

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1628,12 +1628,9 @@ jobs:
         env:
           CSC_NAME: Developer ID Application
           SENTRY_DSN_MACOS: ${{ secrets.SENTRY_DSN_MACOS }}
-          # Dedicated `vellum-desktop` Sentry project DSN: main-process define
-          # (SENTRY_DSN_DESKTOP) + renderer (VITE_SENTRY_DSN_DESKTOP).
-          SENTRY_DSN_DESKTOP: ${{ secrets.SENTRY_DSN_DESKTOP }}
           VITE_PLATFORM_MODE: "false"
           VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
-          VITE_SENTRY_DSN_DESKTOP: ${{ secrets.SENTRY_DSN_DESKTOP }}
+          VITE_SENTRY_DSN_MACOS: ${{ secrets.SENTRY_DSN_MACOS }}
           VITE_SENTRY_ENVIRONMENT: dev
         run: bun run pack --environment dev
 

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1628,8 +1628,12 @@ jobs:
         env:
           CSC_NAME: Developer ID Application
           SENTRY_DSN_MACOS: ${{ secrets.SENTRY_DSN_MACOS }}
+          # Dedicated `vellum-desktop` Sentry project DSN: main-process define
+          # (SENTRY_DSN_DESKTOP) + renderer (VITE_SENTRY_DSN_DESKTOP).
+          SENTRY_DSN_DESKTOP: ${{ secrets.SENTRY_DSN_DESKTOP }}
           VITE_PLATFORM_MODE: "false"
           VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
+          VITE_SENTRY_DSN_DESKTOP: ${{ secrets.SENTRY_DSN_DESKTOP }}
           VITE_SENTRY_ENVIRONMENT: dev
         run: bun run pack --environment dev
 

--- a/.github/workflows/pr-web.yaml
+++ b/.github/workflows/pr-web.yaml
@@ -157,8 +157,8 @@ jobs:
           VITE_PLATFORM_MODE: "true"
           VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
           # Baked into the deployed SPA so the iOS webview (which loads this
-          # bundle via `server.url`) reports to the mobile Sentry project.
-          VITE_SENTRY_DSN_MOBILE: ${{ secrets.SENTRY_DSN_MOBILE }}
+          # bundle via `server.url`) reports to the vellum-assistant-ios project.
+          VITE_SENTRY_DSN_IOS: ${{ secrets.SENTRY_DSN_IOS }}
           VITE_SENTRY_ENVIRONMENT: ${{ vars.VITE_SENTRY_ENVIRONMENT }}
           VITE_APP_VERSION: ${{ github.sha }}
         run: bun run build

--- a/.github/workflows/pr-web.yaml
+++ b/.github/workflows/pr-web.yaml
@@ -156,6 +156,9 @@ jobs:
         env:
           VITE_PLATFORM_MODE: "true"
           VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
+          # Baked into the deployed SPA so the iOS webview (which loads this
+          # bundle via `server.url`) reports to the mobile Sentry project.
+          VITE_SENTRY_DSN_MOBILE: ${{ secrets.SENTRY_DSN_MOBILE }}
           VITE_SENTRY_ENVIRONMENT: ${{ vars.VITE_SENTRY_ENVIRONMENT }}
           VITE_APP_VERSION: ${{ github.sha }}
         run: bun run build

--- a/.github/workflows/release-ios.yaml
+++ b/.github/workflows/release-ios.yaml
@@ -102,8 +102,9 @@ jobs:
         working-directory: clients/web
         env:
           VELLUM_ENVIRONMENT: ${{ steps.config.outputs.vellum_env }}
-          # PR 9 wires the mobile Sentry DSN into the Capacitor build here:
-          # VITE_SENTRY_DSN_MOBILE: ${{ secrets.SENTRY_DSN_MOBILE }}
+          # No Sentry DSN here: this build bundles no web assets. The iOS app
+          # loads the deployed web SPA via `server.url`, so the mobile DSN is
+          # baked into the SPA bundle by the web-SPA deploy workflow.
         run: bunx cap sync ios
 
       - name: Install XcodeGen

--- a/.github/workflows/release-ios.yaml
+++ b/.github/workflows/release-ios.yaml
@@ -102,6 +102,8 @@ jobs:
         working-directory: clients/web
         env:
           VELLUM_ENVIRONMENT: ${{ steps.config.outputs.vellum_env }}
+          # PR 9 wires the mobile Sentry DSN into the Capacitor build here:
+          # VITE_SENTRY_DSN_MOBILE: ${{ secrets.SENTRY_DSN_MOBILE }}
         run: bunx cap sync ios
 
       - name: Install XcodeGen

--- a/.github/workflows/release-ios.yaml
+++ b/.github/workflows/release-ios.yaml
@@ -103,8 +103,10 @@ jobs:
         env:
           VELLUM_ENVIRONMENT: ${{ steps.config.outputs.vellum_env }}
           # No Sentry DSN here: this build bundles no web assets. The iOS app
-          # loads the deployed web SPA via `server.url`, so the mobile DSN is
-          # baked into the SPA bundle by the web-SPA deploy workflow.
+          # runs the deployed web SPA via `server.url`, so its Sentry DSN
+          # (SENTRY_DSN_IOS → VITE_SENTRY_DSN_IOS, vellum-assistant-ios) is baked
+          # into the SPA bundle by the web-SPA deploy workflow and selected at
+          # runtime on iOS.
         run: bunx cap sync ios
 
       - name: Install XcodeGen

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2041,12 +2041,9 @@ jobs:
         env:
           CSC_NAME: Developer ID Application
           SENTRY_DSN_MACOS: ${{ secrets.SENTRY_DSN_MACOS }}
-          # Dedicated `vellum-desktop` Sentry project DSN: main-process define
-          # (SENTRY_DSN_DESKTOP) + renderer (VITE_SENTRY_DSN_DESKTOP).
-          SENTRY_DSN_DESKTOP: ${{ secrets.SENTRY_DSN_DESKTOP }}
           VITE_PLATFORM_MODE: "false"
           VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
-          VITE_SENTRY_DSN_DESKTOP: ${{ secrets.SENTRY_DSN_DESKTOP }}
+          VITE_SENTRY_DSN_MACOS: ${{ secrets.SENTRY_DSN_MACOS }}
           VITE_SENTRY_ENVIRONMENT: ${{ needs.extract-version.outputs.is_staging == 'true' && 'staging' || 'production' }}
         run: bun run pack --environment "${{ needs.extract-version.outputs.is_staging == 'true' && 'staging' || 'production' }}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2041,8 +2041,12 @@ jobs:
         env:
           CSC_NAME: Developer ID Application
           SENTRY_DSN_MACOS: ${{ secrets.SENTRY_DSN_MACOS }}
+          # Dedicated `vellum-desktop` Sentry project DSN: main-process define
+          # (SENTRY_DSN_DESKTOP) + renderer (VITE_SENTRY_DSN_DESKTOP).
+          SENTRY_DSN_DESKTOP: ${{ secrets.SENTRY_DSN_DESKTOP }}
           VITE_PLATFORM_MODE: "false"
           VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
+          VITE_SENTRY_DSN_DESKTOP: ${{ secrets.SENTRY_DSN_DESKTOP }}
           VITE_SENTRY_ENVIRONMENT: ${{ needs.extract-version.outputs.is_staging == 'true' && 'staging' || 'production' }}
         run: bun run pack --environment "${{ needs.extract-version.outputs.is_staging == 'true' && 'staging' || 'production' }}"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,16 +283,17 @@ Error reporting uses Sentry. The daemon/runtime (Node) project's DSN is configur
 
 ### Sentry projects & DSNs
 
-Each surface has its own Sentry project. The target DSN-to-secret map below records which secret feeds which surface; a per-host runtime selector in the shared clients/web bundle is being wired up incrementally, so today `sentry-init.ts` still initializes every renderer host with `VITE_SENTRY_DSN`. An empty DSN no-ops.
+Surfaces map onto Sentry projects as below. The Electron renderer moves from the web project onto the macOS project, sharing the existing `SENTRY_DSN_MACOS` secret with the main process. The per-host runtime DSN selector in the shared clients/web bundle is being wired up incrementally, so today `sentry-init.ts` still initializes every renderer host with `VITE_SENTRY_DSN`. An empty DSN no-ops.
 
-| Surface | DSN env var | Build-time var | Delivered via |
+| Surface | Project | DSN source | Delivered via |
 | --- | --- | --- | --- |
-| Web | `VITE_SENTRY_DSN` | `VITE_SENTRY_DSN` | web SPA build |
-| Desktop | `SENTRY_DSN_DESKTOP` | `VITE_SENTRY_DSN_DESKTOP` | macOS app build (bundles its own web build) |
-| Mobile | `SENTRY_DSN_MOBILE` | `VITE_SENTRY_DSN_MOBILE` | web SPA build (the iOS webview loads the deployed SPA and selects this DSN at runtime) |
-| Assistant | `SENTRY_DSN_ASSISTANT` | — | daemon/runtime (Node) |
+| Web SPA | `vellum-assistant-web` | `VITE_SENTRY_DSN` (vars) | web build |
+| Electron main | `vellum-assistant-macos` | `SENTRY_DSN_MACOS` (secret) → `__SENTRY_DSN_MACOS__` | macOS build define |
+| Electron renderer | `vellum-assistant-macos` | `SENTRY_DSN_MACOS` (secret) → `VITE_SENTRY_DSN_MACOS` | macOS build |
+| iOS webview + native | `vellum-assistant-ios` | `SENTRY_DSN_IOS` (secret) → `VITE_SENTRY_DSN_IOS` | web-SPA build (loaded at runtime on iOS) |
+| Assistant daemon | (unchanged) | `SENTRY_DSN_ASSISTANT` | runtime env |
 
-The mobile DSN is baked into the deployed web SPA bundle rather than the iOS build, because the iOS app runs the deployed SPA via `server.url` (see `clients/web/capacitor.config.ts`) and bundles no web assets at `cap sync`. The desktop DSN is injected build-time in the macOS app, which bundles its own web build.
+The iOS DSN is baked into the deployed web SPA bundle rather than the iOS build, because the iOS app runs the deployed SPA via `server.url` (see `clients/web/capacitor.config.ts`) and bundles no web assets at `cap sync`.
 
 **Sentry CLI**: Use the newer `sentry` CLI (not the legacy `sentry-cli`). Install from `https://cli.sentry.dev/install`. Authenticate with `sentry auth login`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,6 +281,19 @@ When making changes that could affect the cloud platform, review the sibling `..
 
 Error reporting uses Sentry. The daemon/runtime (Node) project's DSN is configured via the `SENTRY_DSN_ASSISTANT` environment variable — see `.env.example`.
 
+### Sentry projects & DSNs
+
+Each surface reports to its own Sentry project via a dedicated DSN (injected at build time by CI; an empty DSN no-ops):
+
+| Surface | DSN env var | Notes |
+| --- | --- | --- |
+| Web | `VITE_SENTRY_DSN` | clients/web browser bundle |
+| Desktop | `SENTRY_DSN_DESKTOP` | Electron main process + renderer (`VITE_SENTRY_DSN_DESKTOP`) |
+| Mobile | `SENTRY_DSN_MOBILE` | Capacitor renderer (`VITE_SENTRY_DSN_MOBILE`) |
+| Assistant | `SENTRY_DSN_ASSISTANT` | daemon/runtime (Node) |
+
+The shared clients/web bundle resolves its renderer DSN per host: web → `VITE_SENTRY_DSN`, Electron → `VITE_SENTRY_DSN_DESKTOP`, Capacitor → `VITE_SENTRY_DSN_MOBILE`.
+
 **Sentry CLI**: Use the newer `sentry` CLI (not the legacy `sentry-cli`). Install from `https://cli.sentry.dev/install`. Authenticate with `sentry auth login`.
 
 ## CLI ↔ Daemon Communication

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,16 +283,16 @@ Error reporting uses Sentry. The daemon/runtime (Node) project's DSN is configur
 
 ### Sentry projects & DSNs
 
-Each surface reports to its own Sentry project via a dedicated DSN (injected at build time by CI; an empty DSN no-ops):
+Each surface has its own Sentry project. The target DSN-to-secret map below records which secret feeds which surface; a per-host runtime selector in the shared clients/web bundle is being wired up incrementally, so today `sentry-init.ts` still initializes every renderer host with `VITE_SENTRY_DSN`. An empty DSN no-ops.
 
-| Surface | DSN env var | Notes |
-| --- | --- | --- |
-| Web | `VITE_SENTRY_DSN` | clients/web browser bundle |
-| Desktop | `SENTRY_DSN_DESKTOP` | Electron main process + renderer (`VITE_SENTRY_DSN_DESKTOP`) |
-| Mobile | `SENTRY_DSN_MOBILE` | Capacitor renderer (`VITE_SENTRY_DSN_MOBILE`) |
-| Assistant | `SENTRY_DSN_ASSISTANT` | daemon/runtime (Node) |
+| Surface | DSN env var | Build-time var | Delivered via |
+| --- | --- | --- | --- |
+| Web | `VITE_SENTRY_DSN` | `VITE_SENTRY_DSN` | web SPA build |
+| Desktop | `SENTRY_DSN_DESKTOP` | `VITE_SENTRY_DSN_DESKTOP` | macOS app build (bundles its own web build) |
+| Mobile | `SENTRY_DSN_MOBILE` | `VITE_SENTRY_DSN_MOBILE` | web SPA build (the iOS webview loads the deployed SPA and selects this DSN at runtime) |
+| Assistant | `SENTRY_DSN_ASSISTANT` | — | daemon/runtime (Node) |
 
-The shared clients/web bundle resolves its renderer DSN per host: web → `VITE_SENTRY_DSN`, Electron → `VITE_SENTRY_DSN_DESKTOP`, Capacitor → `VITE_SENTRY_DSN_MOBILE`.
+The mobile DSN is baked into the deployed web SPA bundle rather than the iOS build, because the iOS app runs the deployed SPA via `server.url` (see `clients/web/capacitor.config.ts`) and bundles no web assets at `cap sync`. The desktop DSN is injected build-time in the macOS app, which bundles its own web build.
 
 **Sentry CLI**: Use the newer `sentry` CLI (not the legacy `sentry-cli`). Install from `https://cli.sentry.dev/install`. Authenticate with `sentry auth login`.
 

--- a/clients/macos/electron.vite.config.ts
+++ b/clients/macos/electron.vite.config.ts
@@ -65,8 +65,6 @@ const BUILD_DEFINES = {
       process.env.VELLUM_ENABLE_CHROME_DEVTOOLS === "1",
   ),
   __SENTRY_DSN_MACOS__: JSON.stringify(process.env.SENTRY_DSN_MACOS || ""),
-  // Dedicated `vellum-desktop` Sentry project DSN.
-  __SENTRY_DSN_DESKTOP__: JSON.stringify(process.env.SENTRY_DSN_DESKTOP || ""),
 };
 
 export default defineConfig({

--- a/clients/macos/electron.vite.config.ts
+++ b/clients/macos/electron.vite.config.ts
@@ -65,8 +65,7 @@ const BUILD_DEFINES = {
       process.env.VELLUM_ENABLE_CHROME_DEVTOOLS === "1",
   ),
   __SENTRY_DSN_MACOS__: JSON.stringify(process.env.SENTRY_DSN_MACOS || ""),
-  // Dedicated `vellum-desktop` Sentry project DSN. PR 6 migrates the main
-  // process off __SENTRY_DSN_MACOS__ onto this; both are defined meanwhile.
+  // Dedicated `vellum-desktop` Sentry project DSN.
   __SENTRY_DSN_DESKTOP__: JSON.stringify(process.env.SENTRY_DSN_DESKTOP || ""),
 };
 

--- a/clients/macos/electron.vite.config.ts
+++ b/clients/macos/electron.vite.config.ts
@@ -65,6 +65,9 @@ const BUILD_DEFINES = {
       process.env.VELLUM_ENABLE_CHROME_DEVTOOLS === "1",
   ),
   __SENTRY_DSN_MACOS__: JSON.stringify(process.env.SENTRY_DSN_MACOS || ""),
+  // Dedicated `vellum-desktop` Sentry project DSN. PR 6 migrates the main
+  // process off __SENTRY_DSN_MACOS__ onto this; both are defined meanwhile.
+  __SENTRY_DSN_DESKTOP__: JSON.stringify(process.env.SENTRY_DSN_DESKTOP || ""),
 };
 
 export default defineConfig({

--- a/clients/web/.env.example
+++ b/clients/web/.env.example
@@ -13,8 +13,10 @@
 # VITE_PLATFORM_MODE=true
 
 # Sentry DSNs are build-time, host-selected: the shared web bundle picks one per host.
-#   web → VITE_SENTRY_DSN, Electron → VITE_SENTRY_DSN_DESKTOP, Capacitor → VITE_SENTRY_DSN_MOBILE.
+#   web → VITE_SENTRY_DSN (vellum-assistant-web),
+#   Electron renderer → VITE_SENTRY_DSN_MACOS (vellum-assistant-macos),
+#   iOS → VITE_SENTRY_DSN_IOS (vellum-assistant-ios, baked into the SPA build).
 # Injected by CI/CD; leave unset locally (Sentry no-ops on an empty DSN).
 # VITE_SENTRY_DSN=
-# VITE_SENTRY_DSN_DESKTOP=
-# VITE_SENTRY_DSN_MOBILE=
+# VITE_SENTRY_DSN_MACOS=
+# VITE_SENTRY_DSN_IOS=

--- a/clients/web/.env.example
+++ b/clients/web/.env.example
@@ -11,3 +11,10 @@
 # Set to enable platform (cloud-hosted) mode. When unset, the app defaults to local mode,
 # reading the assistant lockfile from the CLI daemon via /__local/lockfile.
 # VITE_PLATFORM_MODE=true
+
+# Sentry DSNs are build-time, host-selected: the shared web bundle picks one per host.
+#   web → VITE_SENTRY_DSN, Electron → VITE_SENTRY_DSN_DESKTOP, Capacitor → VITE_SENTRY_DSN_MOBILE.
+# Injected by CI/CD; leave unset locally (Sentry no-ops on an empty DSN).
+# VITE_SENTRY_DSN=
+# VITE_SENTRY_DSN_DESKTOP=
+# VITE_SENTRY_DSN_MOBILE=

--- a/clients/web/src/env.d.ts
+++ b/clients/web/src/env.d.ts
@@ -10,8 +10,18 @@
  * Reference: https://vite.dev/guide/env-and-mode#intellisense-for-typescript
  */
 interface ImportMetaEnv {
-  /** Sentry DSN for browser error reporting. Injected by CI/CD pipeline. */
+  /**
+   * Sentry DSN for browser error reporting. Injected by CI/CD pipeline.
+   *
+   * DSN-selection contract: the shared clients/web bundle resolves its Sentry
+   * DSN per host — web → `VITE_SENTRY_DSN`, Electron → `VITE_SENTRY_DSN_DESKTOP`,
+   * Capacitor → `VITE_SENTRY_DSN_MOBILE`.
+   */
   readonly VITE_SENTRY_DSN?: string;
+  /** Sentry DSN for the Electron (desktop) renderer. See DSN-selection contract above. */
+  readonly VITE_SENTRY_DSN_DESKTOP?: string;
+  /** Sentry DSN for the Capacitor (mobile) renderer. See DSN-selection contract above. */
+  readonly VITE_SENTRY_DSN_MOBILE?: string;
   /** Sentry environment tag (e.g. "production", "staging"). */
   readonly VITE_SENTRY_ENVIRONMENT?: string;
   /** Stripe publishable key for payment forms. Injected by CI/CD pipeline. */

--- a/clients/web/src/env.d.ts
+++ b/clients/web/src/env.d.ts
@@ -14,14 +14,16 @@ interface ImportMetaEnv {
    * Sentry DSN for browser error reporting. Injected by CI/CD pipeline.
    *
    * DSN-selection contract: the shared clients/web bundle resolves its Sentry
-   * DSN per host — web → `VITE_SENTRY_DSN`, Electron → `VITE_SENTRY_DSN_DESKTOP`,
-   * Capacitor → `VITE_SENTRY_DSN_MOBILE`.
+   * DSN per host — web → `VITE_SENTRY_DSN` (vellum-assistant-web), Electron →
+   * `VITE_SENTRY_DSN_MACOS` (vellum-assistant-macos), iOS →
+   * `VITE_SENTRY_DSN_IOS` (vellum-assistant-ios). The runtime selector is wired
+   * up incrementally and does not yet consume these.
    */
   readonly VITE_SENTRY_DSN?: string;
-  /** Sentry DSN for the Electron (desktop) renderer. See DSN-selection contract above. */
-  readonly VITE_SENTRY_DSN_DESKTOP?: string;
-  /** Sentry DSN for the Capacitor (mobile) renderer. See DSN-selection contract above. */
-  readonly VITE_SENTRY_DSN_MOBILE?: string;
+  /** Sentry DSN for the Electron renderer (vellum-assistant-macos). See DSN-selection contract above. */
+  readonly VITE_SENTRY_DSN_MACOS?: string;
+  /** Sentry DSN for the iOS webview (vellum-assistant-ios). See DSN-selection contract above. */
+  readonly VITE_SENTRY_DSN_IOS?: string;
   /** Sentry environment tag (e.g. "production", "staging"). */
   readonly VITE_SENTRY_ENVIRONMENT?: string;
   /** Stripe publishable key for payment forms. Injected by CI/CD pipeline. */


### PR DESCRIPTION
## Summary
- Moves the Electron renderer onto the existing `vellum-assistant-macos` Sentry project (reusing `secrets.SENTRY_DSN_MACOS`) via a new `VITE_SENTRY_DSN_MACOS` build var in the macOS build jobs. The main-process `__SENTRY_DSN_MACOS__` define and existing `VITE_SENTRY_DSN` wiring are untouched.
- Adds the iOS surface to a new `vellum-assistant-ios` Sentry project via `secrets.SENTRY_DSN_IOS` → `VITE_SENTRY_DSN_IOS`, baked into the deployed web SPA build (iOS runs the deployed SPA via `server.url` and bundles no web assets).
- Adds `env.d.ts` typings for `VITE_SENTRY_DSN_MACOS` / `VITE_SENTRY_DSN_IOS` and documents the final per-surface DSN map in AGENTS.md. The runtime per-host DSN selector is being wired up incrementally; `sentry-init.ts` still uses `VITE_SENTRY_DSN` today.

## Manual prerequisites (human)
- Create the new Sentry project `vellum-assistant-ios` and add the GitHub secret `SENTRY_DSN_IOS`; enable server-side Advanced Data Scrubbing on it.
- Desktop reuses the existing `vellum-assistant-macos` project / `SENTRY_DSN_MACOS` secret — nothing to create.

Part of plan: sentry-overhaul.md (PR 5 of 12)