### PR TITLE
feat(web): single version-aware, direction-asymmetric diagnostics-consent mirror chokepoint

### DIFF
--- a/clients/web/src/domains/onboarding/onboarding-store.ts
+++ b/clients/web/src/domains/onboarding/onboarding-store.ts
@@ -17,7 +17,6 @@
 
 import { create } from "zustand";
 
-import { syncDiagnosticsToMain } from "@/runtime/diagnostics";
 import { createSelectors } from "@/utils/create-selectors";
 import {
   getLocalBool,
@@ -76,7 +75,6 @@ const useOnboardingStoreBase = create<OnboardingStore>()((set) => ({
   setShareDiagnostics: (value) => {
     set({ shareDiagnostics: value });
     setLocalBool(KEY_SHARE_DIAGNOSTICS, value);
-    syncDiagnosticsToMain(value);
   },
   setTosAccepted: (value) => {
     set({ tosAccepted: value });

--- a/clients/web/src/lib/consent/diagnostics-consent.test.ts
+++ b/clients/web/src/lib/consent/diagnostics-consent.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Matrix tests for the diagnostics-consent chokepoint.
+ *
+ * The function is pure over its inputs and a single `setShareDiagnostics`
+ * applier, so we exercise the version-invalidation + direction-asymmetry policy
+ * with a mock applier — no localStorage or store needed.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import { applyResolvedDiagnosticsConsent } from "./diagnostics-consent";
+
+describe("applyResolvedDiagnosticsConsent", () => {
+  test("real record + true + current → true (writes mirror)", () => {
+    const setShareDiagnostics = mock((_: boolean) => {});
+    const result = applyResolvedDiagnosticsConsent(
+      {
+        shareDiagnostics: true,
+        diagnosticsVersionCurrent: true,
+        hasServerRecord: true,
+      },
+      setShareDiagnostics,
+    );
+    expect(result).toBe(true);
+    expect(setShareDiagnostics).toHaveBeenCalledTimes(1);
+    expect(setShareDiagnostics).toHaveBeenCalledWith(true);
+  });
+
+  test("real record + true + stale version → false (invalidated)", () => {
+    const setShareDiagnostics = mock((_: boolean) => {});
+    const result = applyResolvedDiagnosticsConsent(
+      {
+        shareDiagnostics: true,
+        diagnosticsVersionCurrent: false,
+        hasServerRecord: true,
+      },
+      setShareDiagnostics,
+    );
+    expect(result).toBe(false);
+    expect(setShareDiagnostics).toHaveBeenCalledWith(false);
+  });
+
+  test("real record + false → false (explicit revoke)", () => {
+    const setShareDiagnostics = mock((_: boolean) => {});
+    const result = applyResolvedDiagnosticsConsent(
+      {
+        shareDiagnostics: false,
+        diagnosticsVersionCurrent: true,
+        hasServerRecord: true,
+      },
+      setShareDiagnostics,
+    );
+    expect(result).toBe(false);
+    expect(setShareDiagnostics).toHaveBeenCalledWith(false);
+  });
+
+  test("null + no record → unchanged (mirror not written)", () => {
+    const setShareDiagnostics = mock((_: boolean) => {});
+    const result = applyResolvedDiagnosticsConsent(
+      {
+        shareDiagnostics: null,
+        diagnosticsVersionCurrent: false,
+        hasServerRecord: false,
+      },
+      setShareDiagnostics,
+    );
+    expect(result).toBeNull();
+    expect(setShareDiagnostics).not.toHaveBeenCalled();
+  });
+
+  test("null grant with a server record → unchanged (never flips on)", () => {
+    const setShareDiagnostics = mock((_: boolean) => {});
+    const result = applyResolvedDiagnosticsConsent(
+      {
+        shareDiagnostics: null,
+        diagnosticsVersionCurrent: true,
+        hasServerRecord: true,
+      },
+      setShareDiagnostics,
+    );
+    expect(result).toBeNull();
+    expect(setShareDiagnostics).not.toHaveBeenCalled();
+  });
+
+  test("true grant but no server record → unchanged (unknown, never flips on)", () => {
+    const setShareDiagnostics = mock((_: boolean) => {});
+    const result = applyResolvedDiagnosticsConsent(
+      {
+        shareDiagnostics: true,
+        diagnosticsVersionCurrent: true,
+        hasServerRecord: false,
+      },
+      setShareDiagnostics,
+    );
+    expect(result).toBeNull();
+    expect(setShareDiagnostics).not.toHaveBeenCalled();
+  });
+
+  test("explicit false with no prior mirror → false (eager revoke even without record)", () => {
+    const setShareDiagnostics = mock((_: boolean) => {});
+    const result = applyResolvedDiagnosticsConsent(
+      {
+        shareDiagnostics: false,
+        diagnosticsVersionCurrent: false,
+        hasServerRecord: false,
+      },
+      setShareDiagnostics,
+    );
+    expect(result).toBe(false);
+    expect(setShareDiagnostics).toHaveBeenCalledWith(false);
+  });
+});

--- a/clients/web/src/lib/consent/diagnostics-consent.test.ts
+++ b/clients/web/src/lib/consent/diagnostics-consent.test.ts
@@ -1,17 +1,46 @@
 /**
  * Matrix tests for the diagnostics-consent chokepoint.
  *
- * The function is pure over its inputs and a single `setShareDiagnostics`
- * applier, so we exercise the version-invalidation + direction-asymmetry policy
- * with a mock applier — no localStorage or store needed.
+ * The chokepoint splits two values: the SAVED PREFERENCE
+ * (`device:share_diagnostics`, applied via the `setShareDiagnostics` mock) and
+ * the EFFECTIVE GATE (`device:diagnostics_reporting` + the main-process sync,
+ * written by `setDiagnosticsReportingGate`). The preference tracks the server's
+ * share value direction-asymmetrically; the gate is `preference && version`.
+ *
+ * `@/runtime/diagnostics` and `@/utils/device-settings` are mocked so the gate
+ * writes are observable without a DOM/localStorage.
  */
 
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { applyResolvedDiagnosticsConsent } from "./diagnostics-consent";
+const setDeviceBool = mock((_name: string, _value: boolean) => {});
+const syncDiagnosticsToMain = mock((_enabled: boolean) => {});
 
-describe("applyResolvedDiagnosticsConsent", () => {
-  test("real record + true + current → true (writes mirror)", () => {
+// Mock the full surface this module touches; `mock.module` is process-global,
+// so a partial mock would strip exports other test files import.
+mock.module("@/utils/device-settings", () => ({
+  setDeviceBool,
+  getDeviceBool: (_name: string, fallback: boolean) => fallback,
+  watchDeviceSetting: () => () => {},
+}));
+mock.module("@/runtime/diagnostics", () => ({ syncDiagnosticsToMain }));
+
+const { applyResolvedDiagnosticsConsent, setDiagnosticsReportingGate } =
+  await import("./diagnostics-consent");
+
+beforeEach(() => {
+  setDeviceBool.mockClear();
+  syncDiagnosticsToMain.mockClear();
+});
+
+/** Asserts the effective gate was written (device bool + main sync) with `value`. */
+function expectGate(value: boolean): void {
+  expect(setDeviceBool).toHaveBeenCalledWith("diagnosticsReporting", value);
+  expect(syncDiagnosticsToMain).toHaveBeenCalledWith(value);
+}
+
+describe("applyResolvedDiagnosticsConsent — saved preference", () => {
+  test("real record + true + current → preference true, gate true", () => {
     const setShareDiagnostics = mock((_: boolean) => {});
     const result = applyResolvedDiagnosticsConsent(
       {
@@ -22,11 +51,14 @@ describe("applyResolvedDiagnosticsConsent", () => {
       setShareDiagnostics,
     );
     expect(result).toBe(true);
-    expect(setShareDiagnostics).toHaveBeenCalledTimes(1);
     expect(setShareDiagnostics).toHaveBeenCalledWith(true);
+    expectGate(true);
   });
 
-  test("real record + true + stale version → false (invalidated)", () => {
+  // KEY REGRESSION: a stale-version opt-in must PRESERVE the preference as
+  // `true` (so the re-consent UI can't silently drop it) while turning the
+  // effective gate OFF.
+  test("real record + true + STALE version → preference PRESERVED true, gate false", () => {
     const setShareDiagnostics = mock((_: boolean) => {});
     const result = applyResolvedDiagnosticsConsent(
       {
@@ -36,11 +68,13 @@ describe("applyResolvedDiagnosticsConsent", () => {
       },
       setShareDiagnostics,
     );
-    expect(result).toBe(false);
-    expect(setShareDiagnostics).toHaveBeenCalledWith(false);
+    expect(result).toBe(true);
+    expect(setShareDiagnostics).toHaveBeenCalledWith(true);
+    expect(setShareDiagnostics).not.toHaveBeenCalledWith(false);
+    expectGate(false);
   });
 
-  test("real record + false → false (explicit revoke)", () => {
+  test("real record + false → preference false, gate false", () => {
     const setShareDiagnostics = mock((_: boolean) => {});
     const result = applyResolvedDiagnosticsConsent(
       {
@@ -52,9 +86,10 @@ describe("applyResolvedDiagnosticsConsent", () => {
     );
     expect(result).toBe(false);
     expect(setShareDiagnostics).toHaveBeenCalledWith(false);
+    expectGate(false);
   });
 
-  test("null + no record → unchanged (mirror not written)", () => {
+  test("null + no record → preference unchanged, gate not forced on", () => {
     const setShareDiagnostics = mock((_: boolean) => {});
     const result = applyResolvedDiagnosticsConsent(
       {
@@ -66,9 +101,10 @@ describe("applyResolvedDiagnosticsConsent", () => {
     );
     expect(result).toBeNull();
     expect(setShareDiagnostics).not.toHaveBeenCalled();
+    expectGate(false);
   });
 
-  test("null grant with a server record → unchanged (never flips on)", () => {
+  test("null grant with a server record → preference unchanged, gate false", () => {
     const setShareDiagnostics = mock((_: boolean) => {});
     const result = applyResolvedDiagnosticsConsent(
       {
@@ -80,9 +116,10 @@ describe("applyResolvedDiagnosticsConsent", () => {
     );
     expect(result).toBeNull();
     expect(setShareDiagnostics).not.toHaveBeenCalled();
+    expectGate(false);
   });
 
-  test("true grant but no server record → unchanged (unknown, never flips on)", () => {
+  test("true grant but no server record → preference unchanged, gate false", () => {
     const setShareDiagnostics = mock((_: boolean) => {});
     const result = applyResolvedDiagnosticsConsent(
       {
@@ -94,9 +131,10 @@ describe("applyResolvedDiagnosticsConsent", () => {
     );
     expect(result).toBeNull();
     expect(setShareDiagnostics).not.toHaveBeenCalled();
+    expectGate(false);
   });
 
-  test("explicit false with no prior mirror → false (eager revoke even without record)", () => {
+  test("explicit false with no prior record → preference false (eager revoke), gate false", () => {
     const setShareDiagnostics = mock((_: boolean) => {});
     const result = applyResolvedDiagnosticsConsent(
       {
@@ -108,5 +146,19 @@ describe("applyResolvedDiagnosticsConsent", () => {
     );
     expect(result).toBe(false);
     expect(setShareDiagnostics).toHaveBeenCalledWith(false);
+    expectGate(false);
+  });
+});
+
+describe("setDiagnosticsReportingGate", () => {
+  test("writes the device bool AND the main-process sync with the effective value", () => {
+    setDiagnosticsReportingGate(true);
+    expectGate(true);
+
+    setDeviceBool.mockClear();
+    syncDiagnosticsToMain.mockClear();
+
+    setDiagnosticsReportingGate(false);
+    expectGate(false);
   });
 });

--- a/clients/web/src/lib/consent/diagnostics-consent.ts
+++ b/clients/web/src/lib/consent/diagnostics-consent.ts
@@ -1,0 +1,75 @@
+/**
+ * The single, version-aware, direction-asymmetric decision point for the
+ * `device:share_diagnostics` mirror.
+ *
+ * The mirror is the boolean that gates diagnostics reporting (Sentry). Every
+ * non-onboarding path that learns a diagnostics-consent value from the server
+ * must route the decision through {@link applyResolvedDiagnosticsConsent} so the
+ * policy lives in exactly one place:
+ *
+ * - **Version invalidation** — a `share_diagnostics` acceptance recorded under a
+ *   stale `PRIVACY_CONSENT_VERSION` (`diagnosticsVersionCurrent === false`) never
+ *   keeps diagnostics on. It resolves to `false` regardless of the stored share
+ *   boolean.
+ * - **Direction asymmetry** — diagnostics only turn ON for a confident, current
+ *   grant (`hasServerRecord && shareDiagnostics === true && diagnosticsVersionCurrent`).
+ *   An "unknown" input (`shareDiagnostics === null`, or no server record) never
+ *   flips the mirror on and leaves the existing value untouched; an explicit
+ *   revoke (`shareDiagnostics === false`) eagerly writes `false`.
+ *
+ * The resolved decision is applied via `setShareDiagnostics` (the single writer
+ * of the `device:share_diagnostics` key and the main-process diagnostics sync);
+ * an unchanged decision is skipped. The function returns the resolved boolean —
+ * or `null` when the mirror was left unchanged — so callers can log/telemeter
+ * the transition.
+ */
+
+export interface ResolvedDiagnosticsConsent {
+  /** The server's `share_diagnostics` value; `null` when unknown/absent. */
+  shareDiagnostics: boolean | null;
+  /** Whether the server's accepted version equals `PRIVACY_CONSENT_VERSION`. */
+  diagnosticsVersionCurrent: boolean;
+  /** Whether the server returned a real consent record (not API defaults). */
+  hasServerRecord: boolean;
+}
+
+/**
+ * Decide the diagnostics mirror value from a resolved server-consent input, and
+ * apply it via `setShareDiagnostics` unless the input is an unknown grant.
+ *
+ * @returns `true`/`false` when the mirror was written to that value, or `null`
+ * when the input is an unknown grant and the mirror was left unchanged.
+ */
+export function applyResolvedDiagnosticsConsent(
+  resolved: ResolvedDiagnosticsConsent,
+  setShareDiagnostics: (value: boolean) => void,
+): boolean | null {
+  const decision = resolveDiagnosticsConsent(resolved);
+  if (decision !== null) setShareDiagnostics(decision);
+  return decision;
+}
+
+/**
+ * Pure policy: resolve the diagnostics mirror value, or `null` for "leave the
+ * existing mirror untouched". The single home of the version-invalidation +
+ * direction-asymmetry rules.
+ */
+function resolveDiagnosticsConsent(
+  resolved: ResolvedDiagnosticsConsent,
+): boolean | null {
+  const { shareDiagnostics, diagnosticsVersionCurrent, hasServerRecord } =
+    resolved;
+
+  // Explicit revoke — eagerly turn diagnostics OFF (even on an unknown record).
+  if (shareDiagnostics === false) return false;
+
+  // Confident grant only turns diagnostics ON when its version is current;
+  // a stale-version acceptance never keeps it on.
+  if (hasServerRecord && shareDiagnostics === true) {
+    return diagnosticsVersionCurrent;
+  }
+
+  // Unknown grant (`null`, or no server record) — never flip ON; leave the
+  // existing mirror value untouched.
+  return null;
+}

--- a/clients/web/src/lib/consent/diagnostics-consent.ts
+++ b/clients/web/src/lib/consent/diagnostics-consent.ts
@@ -1,28 +1,31 @@
 /**
- * The single, version-aware, direction-asymmetric decision point for the
- * `device:share_diagnostics` mirror.
+ * The single, version-aware, direction-asymmetric decision point for the two
+ * diagnostics-consent values:
  *
- * The mirror is the boolean that gates diagnostics reporting (Sentry). Every
- * non-onboarding path that learns a diagnostics-consent value from the server
- * must route the decision through {@link applyResolvedDiagnosticsConsent} so the
- * policy lives in exactly one place:
+ * - **Saved preference** (`device:share_diagnostics`) — the user's opt-in/out,
+ *   shown and re-submitted by the re-consent screen. It always tracks the
+ *   server's `share_diagnostics` value (direction-asymmetric writes), never the
+ *   privacy-consent version, so a stale-version record can't silently lose a
+ *   prior opt-in.
+ * - **Effective reporting gate** (`device:diagnostics_reporting`) — what
+ *   actually turns Sentry on. It is `preference && versionCurrent`, so a
+ *   stale-version acceptance stops reporting until the user re-accepts.
  *
- * - **Version invalidation** — a `share_diagnostics` acceptance recorded under a
- *   stale `PRIVACY_CONSENT_VERSION` (`diagnosticsVersionCurrent === false`) never
- *   keeps diagnostics on. It resolves to `false` regardless of the stored share
- *   boolean.
- * - **Direction asymmetry** — diagnostics only turn ON for a confident, current
- *   grant (`hasServerRecord && shareDiagnostics === true && diagnosticsVersionCurrent`).
- *   An "unknown" input (`shareDiagnostics === null`, or no server record) never
- *   flips the mirror on and leaves the existing value untouched; an explicit
- *   revoke (`shareDiagnostics === false`) eagerly writes `false`.
+ * Every non-onboarding path that learns a diagnostics-consent value from the
+ * server routes through {@link applyResolvedDiagnosticsConsent} so this policy
+ * lives in exactly one place.
  *
- * The resolved decision is applied via `setShareDiagnostics` (the single writer
- * of the `device:share_diagnostics` key and the main-process diagnostics sync);
- * an unchanged decision is skipped. The function returns the resolved boolean —
- * or `null` when the mirror was left unchanged — so callers can log/telemeter
- * the transition.
+ * - **Preference (direction-asymmetric)** — a confident grant
+ *   (`hasServerRecord && shareDiagnostics === true`) writes `true` even on a
+ *   stale version; an explicit revoke (`shareDiagnostics === false`) writes
+ *   `false`; an unknown input (`null` / no record) leaves the preference
+ *   untouched.
+ * - **Gate** — opens only for a confident, current grant
+ *   (`hasServerRecord && shareDiagnostics === true && diagnosticsVersionCurrent`).
  */
+
+import { setDeviceBool } from "@/utils/device-settings";
+import { syncDiagnosticsToMain } from "@/runtime/diagnostics";
 
 export interface ResolvedDiagnosticsConsent {
   /** The server's `share_diagnostics` value; `null` when unknown/absent. */
@@ -34,42 +37,60 @@ export interface ResolvedDiagnosticsConsent {
 }
 
 /**
- * Decide the diagnostics mirror value from a resolved server-consent input, and
- * apply it via `setShareDiagnostics` unless the input is an unknown grant.
+ * Write the effective Sentry reporting gate: the `diagnosticsReporting` device
+ * bool AND the main-process diagnostics sync, both with the same effective
+ * value. This is the single writer of the gate.
+ */
+export function setDiagnosticsReportingGate(enabled: boolean): void {
+  setDeviceBool("diagnosticsReporting", enabled);
+  syncDiagnosticsToMain(enabled);
+}
+
+/**
+ * Apply a resolved server-consent input to both diagnostics values:
  *
- * @returns `true`/`false` when the mirror was written to that value, or `null`
- * when the input is an unknown grant and the mirror was left unchanged.
+ * 1. The saved preference, via `setShareDiagnostics` — written only for a
+ *    confident grant or explicit revoke; an unknown input leaves it untouched.
+ * 2. The effective reporting gate, via {@link setDiagnosticsReportingGate} —
+ *    always set to `preference && versionCurrent`.
+ *
+ * @returns the saved-preference decision: `true`/`false` when the preference was
+ * written to that value, or `null` when the input is an unknown grant and the
+ * preference was left unchanged.
  */
 export function applyResolvedDiagnosticsConsent(
   resolved: ResolvedDiagnosticsConsent,
   setShareDiagnostics: (value: boolean) => void,
 ): boolean | null {
-  const decision = resolveDiagnosticsConsent(resolved);
-  if (decision !== null) setShareDiagnostics(decision);
-  return decision;
+  const preference = resolvePreference(resolved);
+  if (preference !== null) setShareDiagnostics(preference);
+
+  const { shareDiagnostics, diagnosticsVersionCurrent, hasServerRecord } =
+    resolved;
+  setDiagnosticsReportingGate(
+    hasServerRecord && shareDiagnostics === true && diagnosticsVersionCurrent,
+  );
+
+  return preference;
 }
 
 /**
- * Pure policy: resolve the diagnostics mirror value, or `null` for "leave the
- * existing mirror untouched". The single home of the version-invalidation +
- * direction-asymmetry rules.
+ * Pure policy: resolve the SAVED PREFERENCE value, or `null` for "leave the
+ * existing preference untouched". Direction-asymmetric and version-independent
+ * — the preference always tracks the server's share value so the re-consent UI
+ * never loses it.
  */
-function resolveDiagnosticsConsent(
+function resolvePreference(
   resolved: ResolvedDiagnosticsConsent,
 ): boolean | null {
-  const { shareDiagnostics, diagnosticsVersionCurrent, hasServerRecord } =
-    resolved;
+  const { shareDiagnostics, hasServerRecord } = resolved;
 
-  // Explicit revoke — eagerly turn diagnostics OFF (even on an unknown record).
+  // Explicit revoke — eagerly write the opt-out (even on an unknown record).
   if (shareDiagnostics === false) return false;
 
-  // Confident grant only turns diagnostics ON when its version is current;
-  // a stale-version acceptance never keeps it on.
-  if (hasServerRecord && shareDiagnostics === true) {
-    return diagnosticsVersionCurrent;
-  }
+  // Confident grant — adopt the server's opt-in, regardless of version.
+  if (hasServerRecord && shareDiagnostics === true) return true;
 
-  // Unknown grant (`null`, or no server record) — never flip ON; leave the
-  // existing mirror value untouched.
+  // Unknown grant (`null`, or no server record) — leave the preference untouched.
   return null;
 }

--- a/clients/web/src/lib/sentry/sentry-control.test.ts
+++ b/clients/web/src/lib/sentry/sentry-control.test.ts
@@ -20,13 +20,18 @@ mock.module("@/lib/sentry/flavor", () => ({
 }));
 
 let consent = false;
+const readNames: string[] = [];
+const watchedNames: string[] = [];
 const watchCallbacks: Array<() => void> = [];
 const unwatchMock = mock(() => {});
 
 mock.module("@/utils/device-settings", () => ({
-  getDeviceBool: (_name: string, fallback: boolean) =>
-    consent ? true : fallback,
-  watchDeviceSetting: (_name: string, callback: () => void) => {
+  getDeviceBool: (name: string, fallback: boolean) => {
+    readNames.push(name);
+    return consent ? true : fallback;
+  },
+  watchDeviceSetting: (name: string, callback: () => void) => {
+    watchedNames.push(name);
     watchCallbacks.push(callback);
     return unwatchMock;
   },
@@ -44,6 +49,8 @@ beforeEach(() => {
   selectSentryFlavorMock.mockClear();
   unwatchMock.mockClear();
   watchCallbacks.length = 0;
+  readNames.length = 0;
+  watchedNames.length = 0;
   consent = false;
   clientEnabled = false;
 });
@@ -53,6 +60,12 @@ describe("syncSentryClient", () => {
     consent = true;
     syncSentryClient(options);
     expect(selectSentryFlavorMock).toHaveBeenCalled();
+  });
+
+  test("gates off the effective diagnosticsReporting key, not the preference", () => {
+    syncSentryClient(options);
+    expect(readNames).toContain("diagnosticsReporting");
+    expect(readNames).not.toContain("shareDiagnostics");
   });
 
   test("no-ops when dsn is absent (never touches the flavor)", () => {
@@ -90,6 +103,7 @@ describe("installSentryControlListeners", () => {
   test("re-syncs through the flavor when the toggle changes", () => {
     const cleanup = installSentryControlListeners(options);
     expect(watchCallbacks).toHaveLength(1);
+    expect(watchedNames).toEqual(["diagnosticsReporting"]);
 
     consent = true;
     watchCallbacks[0]!();

--- a/clients/web/src/lib/sentry/sentry-control.ts
+++ b/clients/web/src/lib/sentry/sentry-control.ts
@@ -4,12 +4,17 @@ import { selectSentryFlavor } from "@/lib/sentry/flavor";
 import { getDeviceBool, watchDeviceSetting } from "@/utils/device-settings";
 
 /**
- * Gates the browser-side Sentry client on the user's Share Diagnostics
- * toggle (`device:share_diagnostics`), matching the macOS app's behavior.
+ * Gates the browser-side Sentry client on the effective diagnostics-reporting
+ * gate (`device:diagnostics_reporting`), matching the macOS app's behavior.
+ *
+ * The gate is the saved Share Diagnostics preference AND a current privacy-
+ * consent version, so a stale-version record stops reporting until re-accept
+ * without losing the saved opt-in. It is written by the consent-resolution
+ * paths (`setDiagnosticsReportingGate`).
  *
  * Strict opt-in semantics:
- *   - stored "true"  → Sentry ON  (explicit consent)
- *   - stored "false" → Sentry OFF (explicit opt-out)
+ *   - stored "true"  → Sentry ON  (current consent)
+ *   - stored "false" → Sentry OFF (opt-out or stale version)
  *   - absent         → Sentry OFF (no consent on record yet)
  *
  * SDK access is dispatched through `selectSentryFlavor()` so each surface
@@ -19,7 +24,7 @@ import { getDeviceBool, watchDeviceSetting } from "@/utils/device-settings";
  */
 
 function readConsent(): boolean {
-  return getDeviceBool("shareDiagnostics", false);
+  return getDeviceBool("diagnosticsReporting", false);
 }
 
 function tryInit(options: BrowserOptions): void {
@@ -47,17 +52,17 @@ export function syncSentryClient(options: BrowserOptions): void {
 }
 
 /**
- * Install listeners so the Sentry client turns on/off whenever the user
- * flips the Share Diagnostics toggle — covering cross-tab writes (via the
- * native `storage` event) and same-tab writes (via the custom event
- * dispatched by `setLocalSetting`).
+ * Install listeners so the Sentry client turns on/off whenever the effective
+ * reporting gate changes — covering cross-tab writes (via the native `storage`
+ * event) and same-tab writes (via the custom event dispatched by
+ * `setLocalSetting`).
  *
  * Returns a cleanup function that removes both listeners.
  */
 export function installSentryControlListeners(
   options: BrowserOptions,
 ): () => void {
-  return watchDeviceSetting("shareDiagnostics", () => {
+  return watchDeviceSetting("diagnosticsReporting", () => {
     syncSentryClient(options);
   });
 }

--- a/clients/web/src/lib/sentry/sentry-init.ts
+++ b/clients/web/src/lib/sentry/sentry-init.ts
@@ -103,14 +103,14 @@ const options: BrowserOptions = {
 
 /**
  * Bootstrap Sentry consent gating. Must be called after
- * `migrateDeviceSettings()` so the `device:share_diagnostics` key
+ * `migrateDeviceSettings()` so the `device:diagnostics_reporting` key
  * is available when `readConsent()` reads localStorage.
  *
- * Also syncs the current consent state to the Electron main process
+ * Also syncs the effective reporting gate to the Electron main process
  * (no-op on web/iOS) so the main-process Sentry client matches.
  */
 export function initSentry(): void {
   syncSentryClient(options);
   installSentryControlListeners(options);
-  syncDiagnosticsToMain(getDeviceBool("shareDiagnostics", false));
+  syncDiagnosticsToMain(getDeviceBool("diagnosticsReporting", false));
 }

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -63,6 +63,7 @@ import {
   PRIVACY_CONSENT_VERSION,
 } from "@/utils/onboarding-cleanup";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
+import { applyResolvedDiagnosticsConsent } from "@/lib/consent/diagnostics-consent";
 import {
   clearOrganization,
   useOrganizationStore,
@@ -250,18 +251,27 @@ async function syncUserScopedState(nextUserId: string | null): Promise<void> {
       const consent = await fetchConsent();
       const resolved = resolveServerConsent(consent);
       const store = useOnboardingStore.getState();
-      // Only adopt the server's share-preference booleans when the server has a
-      // real consent record. For an empty record they're just the API defaults
-      // and would clobber the device-local `device:share_*` choices that the
-      // fallback below relies on (the store already holds them from init). A
-      // real record's share values are authoritative even when its legal
-      // consent versions are stale (the nav layer routes to review-terms).
-      if (resolved.hasServerRecord) {
-        if (resolved.shareAnalytics !== null)
-          store.setShareAnalytics(resolved.shareAnalytics);
-        if (resolved.shareDiagnostics !== null)
-          store.setShareDiagnostics(resolved.shareDiagnostics);
+      // Only adopt the server's share-analytics boolean when the server has a
+      // real consent record. For an empty record it's just the API default and
+      // would clobber the device-local `device:share_analytics` choice that the
+      // fallback below relies on (the store already holds it from init). A real
+      // record's share value is authoritative even when its legal consent
+      // versions are stale (the nav layer routes to review-terms).
+      if (resolved.hasServerRecord && resolved.shareAnalytics !== null) {
+        store.setShareAnalytics(resolved.shareAnalytics);
       }
+
+      // Diagnostics routes through the single version-aware, direction-
+      // asymmetric chokepoint: a stale-version acceptance never keeps
+      // diagnostics on, and an unknown grant leaves the mirror untouched.
+      applyResolvedDiagnosticsConsent(
+        {
+          shareDiagnostics: resolved.shareDiagnostics,
+          diagnosticsVersionCurrent: resolved.diagnosticsCurrent,
+          hasServerRecord: resolved.hasServerRecord,
+        },
+        store.setShareDiagnostics,
+      );
 
       // Resolve the FINAL consent values before persisting or mutating the
       // store. The endpoint always returns an object, so empty/stale versions

--- a/clients/web/src/utils/device-settings.ts
+++ b/clients/web/src/utils/device-settings.ts
@@ -33,6 +33,11 @@ const DEVICE_SETTINGS = {
   theme: { key: "device:theme", legacy: "vellum_theme" },
   shareAnalytics: { key: "device:share_analytics", legacy: "vellum_share_analytics" },
   shareDiagnostics: { key: "device:share_diagnostics", legacy: "vellum_share_diagnostics" },
+  // Effective Sentry reporting gate: the saved diagnostics preference AND a
+  // current privacy-consent version. Decoupled from `shareDiagnostics` (the
+  // saved preference) so a stale-version record stops reporting without losing
+  // the user's opt-in. No legacy key — introduced after the migration cutover.
+  diagnosticsReporting: { key: "device:diagnostics_reporting", legacy: "vellum_diagnostics_reporting" },
   biometricEnabled: { key: "device:biometric_enabled", legacy: "vellum_biometric_enabled" },
   llmLogRetention: { key: "device:llm_log_retention", legacy: "vellum_llm_log_retention" },
   timezone: { key: "device:timezone", legacy: "vellum_timezone" },

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -26,6 +26,7 @@
  */
 import { removeLocalSetting, getLocalBool, setLocalBool } from "@/utils/local-settings";
 import { setDeviceBool } from "@/utils/device-settings";
+import { setDiagnosticsReportingGate } from "@/lib/consent/diagnostics-consent";
 import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 import { patchConsent, type UserConsent } from "@/domains/account/profile";
 
@@ -216,6 +217,8 @@ export function saveConsent(opts: {
   store.setShareDiagnostics(opts.shareDiagnostics);
   store.setAnalyticsConsentCurrent(true);
   store.setDiagnosticsConsentCurrent(true);
+  // Version is current by construction here, so the gate equals the preference.
+  setDiagnosticsReportingGate(opts.shareDiagnostics);
 
   persistConsentForUser(opts.userId, opts.tos, opts.privacy);
   persistToggleConsent(opts.userId, { analyticsCurrent: true, diagnosticsCurrent: true });
@@ -249,6 +252,8 @@ export function savePreferenceToggle(
     store.setShareDiagnostics(value);
     setDeviceBool("shareDiagnostics", value);
     store.setDiagnosticsConsentCurrent(true);
+    // Version is current by construction here, so the gate equals the preference.
+    setDiagnosticsReportingGate(value);
     persistToggleConsent(userId, { diagnosticsCurrent: true });
   }
 


### PR DESCRIPTION
## Summary
- Adds applyResolvedDiagnosticsConsent as the single chokepoint for the device:share_diagnostics mirror
- Version-invalidation (stale PRIVACY_CONSENT_VERSION never keeps diagnostics on) + direction-asymmetry (never grant on unknown, eagerly revoke)
- Refactors syncUserScopedState to delegate the decision

Part of plan: sentry-overhaul.md (PR 1 of 12)