### PR TITLE
fix(slack): render guardian access-request warnings (drop non-schema card.subtext)

### DIFF
--- a/assistant/src/__tests__/slack-notification-approval-card.test.ts
+++ b/assistant/src/__tests__/slack-notification-approval-card.test.ts
@@ -8,8 +8,9 @@ import type { ApprovalUIMetadata } from "../runtime/channel-approval-types.js";
 /**
  * Pins the Slack approval-card block contract: the title, identity subtitle,
  * quoted-preview body, action callback ids, source/permalink and requester-id
- * context blocks, warning subtext, and guardian verification note that
- * `buildApprovalNotificationBlocks` emits for an access request.
+ * context blocks, the security-warning context block, and guardian
+ * verification note that `buildApprovalNotificationBlocks` emits for an
+ * access request.
  */
 
 const APPROVAL: ApprovalUIMetadata = {
@@ -121,29 +122,34 @@ describe("Slack access-request card blocks", () => {
     );
   });
 
-  test("warnings render in the card subtext", () => {
-    const c = card(
-      buildApprovalNotificationBlocks(
-        buildPayload({
-          ...BASE,
-          isStranger: true,
-          isRestricted: true,
-          previousMemberStatus: "revoked",
-        }),
-        "msg",
-      ),
+  test("warnings render in a context block under the card", () => {
+    const blocks = buildApprovalNotificationBlocks(
+      buildPayload({
+        ...BASE,
+        isStranger: true,
+        isRestricted: true,
+        previousMemberStatus: "revoked",
+      }),
+      "msg",
     );
-    const subtext = text(c.subtext);
-    expect(subtext).toContain(":warning: This user was previously revoked.");
-    expect(subtext).toContain(
+    // `subtext` is not a Slack card field; warnings must live in a real block
+    // or Slack drops them and the guardian never sees them.
+    expect(card(blocks).subtext).toBeUndefined();
+    const warning = contextTexts(blocks).find((t) => t.includes(":warning:"));
+    expect(warning).toBeDefined();
+    expect(warning).toContain(":warning: This user was previously revoked.");
+    expect(warning).toContain(
       ":warning: External Slack user (not in this workspace).",
     );
-    expect(subtext).toContain(":warning: Guest / restricted account.");
+    expect(warning).toContain(":warning: Guest / restricted account.");
   });
 
-  test("no subtext when there are no warnings", () => {
-    const c = card(buildApprovalNotificationBlocks(buildPayload(BASE), "msg"));
-    expect(c.subtext).toBeUndefined();
+  test("no warning context block when there are no warnings", () => {
+    const blocks = buildApprovalNotificationBlocks(buildPayload(BASE), "msg");
+    expect(card(blocks).subtext).toBeUndefined();
+    expect(contextTexts(blocks).some((t) => t.includes(":warning:"))).toBe(
+      false,
+    );
   });
 
   test("body falls back to a default label when no preview", () => {

--- a/assistant/src/notifications/adapters/slack.ts
+++ b/assistant/src/notifications/adapters/slack.ts
@@ -125,7 +125,8 @@ function buildRequesterIdBlock(
  * Build Slack blocks for an access request using a native Card block.
  *
  * Layout:
- *   Card — title + subtitle (identity) + body (preview) + actions + subtext (warnings)
+ *   Card — title + subtitle (identity) + body (preview) + actions
+ *   Context — security warnings (revoked/restricted/stranger), when present
  *   Context — source permalink (when the request is from Slack)
  *   Context — stable requester ID (when it adds info beyond subtitle)
  *   Context — invite directive
@@ -141,20 +142,31 @@ function buildAccessRequestCardBlocks(
   const subtitle = buildAccessRequestSubtitle(view);
   const body = buildAccessRequestBody(view);
 
-  const subtext =
+  const warningsText =
     view.warnings.length > 0
       ? truncate(view.warnings.map((w) => `:warning: ${w}`).join(" · "), 200)
       : undefined;
 
   const card: Record<string, unknown> = {
     type: "card",
-    title: { type: "plain_text", text: "Access Request" },
+    title: { type: "mrkdwn", text: "Access Request" },
     subtitle: { type: "mrkdwn", text: subtitle },
     body: { type: "mrkdwn", text: body },
     actions: buildCardActions(approval),
   };
-  if (subtext) card.subtext = { type: "mrkdwn", text: subtext };
   blocks.push(card);
+
+  // Security warnings (revoked / restricted / stranger). These previously sat
+  // in a `card.subtext` field, which is not part of Slack's card block schema
+  // (https://docs.slack.dev/reference/block-kit/blocks/card-block) — Slack
+  // silently dropped it, so guardians never saw the warnings. Render them in a
+  // context block under the card so they are actually delivered.
+  if (warningsText) {
+    blocks.push({
+      type: "context",
+      elements: [{ type: "mrkdwn", text: warningsText }],
+    });
+  }
 
   const sourceContext = buildSourceContextBlock(view);
   if (sourceContext) blocks.push(sourceContext);
@@ -217,7 +229,7 @@ function buildToolApprovalCardBlocks(
   const card: Record<string, unknown> = {
     type: "card",
     title: {
-      type: "plain_text",
+      type: "mrkdwn",
       text: details ? "Tool Approval" : "Approval Request",
     },
     body: {

--- a/assistant/src/notifications/adapters/slack.ts
+++ b/assistant/src/notifications/adapters/slack.ts
@@ -156,11 +156,11 @@ function buildAccessRequestCardBlocks(
   };
   blocks.push(card);
 
-  // Security warnings (revoked / restricted / stranger). These previously sat
-  // in a `card.subtext` field, which is not part of Slack's card block schema
-  // (https://docs.slack.dev/reference/block-kit/blocks/card-block) — Slack
-  // silently dropped it, so guardians never saw the warnings. Render them in a
-  // context block under the card so they are actually delivered.
+  // Security warnings (revoked / restricted / stranger) render in a context
+  // block under the card. Slack's card block schema has no field for them
+  // (https://docs.slack.dev/reference/block-kit/blocks/card-block) and Slack
+  // silently drops unknown card fields, so a dedicated block is needed to
+  // surface them to the guardian.
   if (warningsText) {
     blocks.push({
       type: "context",


### PR DESCRIPTION
## Summary

The guardian **access-request approval card** put its security warnings — *previously revoked*, *guest / restricted account*, *external Slack user* — in a `card.subtext` field. **`subtext` is not part of Slack's [card block schema](https://docs.slack.dev/reference/block-kit/blocks/card-block/)** (corroborated by `@slack/types`, which has no such field). Slack silently drops unknown card fields, so **these warnings were never rendered to the guardian** — they were deciding on access requests without seeing the risk flags. The card `title` also used a `plain_text` object where the schema specifies `mrkdwn`.

## Root cause

The card was hand-built against an assumed schema. `subtext` either never existed or was misread from the doc; it's absent from both the live reference and Slack's own published types. And the test (`slack-notification-approval-card.test.ts`) only asserted that `card.subtext` was **constructed** — never that Slack would **render** it — so a green test masked the dropped-warnings bug.

## Fix

- **Render the warnings in a `context` block** immediately under the card, so Slack actually delivers them.
- **Switch both card titles** (`Access Request`, `Tool Approval` / `Approval Request`) from `plain_text` to `mrkdwn` per the schema.
- Approval routing is **untouched** — the action buttons (`apr:<requestId>:<action>`) live in `actions`, which doesn't change; buttons keep working.

## Tests

`slack-notification-approval-card.test.ts`:
- "warnings render in a context block under the card" — asserts the warnings appear in a real block **and** that the non-schema `subtext` field is never emitted.
- "no warning context block when there are no warnings" — asserts no stray `:warning:` context (and still no `subtext`).

Local: card test 10/10, sibling access-request tests 16/16 + 7/7, `tsc --noEmit`, eslint, prettier all clean.

## Scope

Standalone guardian-facing bug fix. A broader follow-up will adopt `@slack/types` end-to-end (unifying the duplicated gateway/assistant block builders + the wire contract) so this whole class of "hand-built block diverges from the real schema" becomes a compile error rather than a silent runtime drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBeXq7TEG2Whk8bZPpwKsP

---
_Generated by [Claude Code](https://claude.ai/code/session_01JBeXq7TEG2Whk8bZPpwKsP)_