### PR TITLE
feat(web): refresh diagnostics consent on visibility/focus + long-interval backstop

### DIFF
--- a/clients/web/src/lib/consent/consent-refresh.test.ts
+++ b/clients/web/src/lib/consent/consent-refresh.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for the visibility/focus diagnostics-consent refresh.
+ *
+ * `fetchConsent`, the diagnostics chokepoint, and both stores are mocked so the
+ * refresh trigger logic is observable without a server, DOM storage, or Sentry.
+ * `resolveServerConsent` runs for real — it's a pure mapping over the fetched
+ * record, so asserting what reaches the chokepoint exercises the real shape.
+ */
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  setSystemTime,
+  test,
+} from "bun:test";
+
+import type { UserConsent } from "@/domains/account/profile";
+
+let consentResult: Promise<UserConsent>;
+const fetchConsent = mock(() => consentResult);
+// `mock.module` is process-global and replaces the whole module, so re-export
+// `patchConsent` (imported transitively by onboarding-cleanup).
+mock.module("@/domains/account/profile", () => ({
+  fetchConsent,
+  patchConsent: mock(() => Promise.resolve()),
+}));
+
+// The refresh floor reads a module-level timestamp; advance the fake clock far
+// past the floor on each test so a prior test's refresh can't debounce the next.
+let clock = new Date("2026-06-18T00:00:00Z").getTime();
+const FLOOR_CLEAR_MS = 5 * 60_000;
+
+type Resolved = {
+  shareDiagnostics: boolean | null;
+  diagnosticsVersionCurrent: boolean;
+  hasServerRecord: boolean;
+};
+const applyResolvedDiagnosticsConsent = mock(
+  (_resolved: Resolved, _set: (v: boolean) => void): boolean | null => null,
+);
+mock.module("@/lib/consent/diagnostics-consent", () => ({
+  applyResolvedDiagnosticsConsent,
+  setDiagnosticsReportingGate: mock(() => {}),
+}));
+
+let currentUser: { id: string } | null = { id: "u1" };
+mock.module("@/stores/auth-store", () => ({
+  useAuthStore: { getState: () => ({ user: currentUser }) },
+}));
+
+const setShareDiagnostics = mock((_v: boolean) => {});
+mock.module("@/domains/onboarding/onboarding-store", () => ({
+  useOnboardingStore: { getState: () => ({ setShareDiagnostics }) },
+}));
+
+const { PRIVACY_CONSENT_VERSION } = await import("@/utils/onboarding-cleanup");
+const { refreshDiagnosticsConsent, installConsentRefreshListeners } =
+  await import("./consent-refresh");
+
+function consentRecord(overrides: Partial<UserConsent> = {}): UserConsent {
+  return {
+    tos_accepted_version: "",
+    tos_accepted_at: null,
+    privacy_policy_accepted_version: "",
+    privacy_policy_accepted_at: null,
+    ai_data_sharing_accepted_version: "",
+    ai_data_sharing_accepted_at: null,
+    share_analytics: true,
+    share_diagnostics: true,
+    share_analytics_accepted_version: "",
+    share_analytics_accepted_at: null,
+    share_diagnostics_accepted_version: "",
+    share_diagnostics_accepted_at: null,
+    ...overrides,
+  };
+}
+
+/** A confident, current revoke (real record, share off, version current). */
+function revokeRecord(): UserConsent {
+  return consentRecord({
+    share_diagnostics: false,
+    share_diagnostics_accepted_version: PRIVACY_CONSENT_VERSION,
+  });
+}
+
+beforeEach(() => {
+  fetchConsent.mockClear();
+  applyResolvedDiagnosticsConsent.mockClear();
+  setShareDiagnostics.mockClear();
+  currentUser = { id: "u1" };
+  consentResult = Promise.resolve(consentRecord());
+  clock += FLOOR_CLEAR_MS;
+  setSystemTime(new Date(clock));
+});
+
+afterEach(() => {
+  setSystemTime();
+});
+
+/** Yield to the microtask queue so the fetch promise settles. */
+const flush = (): Promise<void> => Promise.resolve();
+
+describe("refreshDiagnosticsConsent", () => {
+  test("no-ops when unauthenticated", async () => {
+    currentUser = null;
+    await refreshDiagnosticsConsent();
+    expect(fetchConsent).not.toHaveBeenCalled();
+    expect(applyResolvedDiagnosticsConsent).not.toHaveBeenCalled();
+  });
+
+  test("routes a confirmed revoke through the chokepoint", async () => {
+    consentResult = Promise.resolve(revokeRecord());
+    await refreshDiagnosticsConsent();
+    expect(applyResolvedDiagnosticsConsent).toHaveBeenCalledTimes(1);
+    const resolved = applyResolvedDiagnosticsConsent.mock.calls[0]![0];
+    expect(resolved).toMatchObject({
+      shareDiagnostics: false,
+      diagnosticsVersionCurrent: true,
+      hasServerRecord: true,
+    });
+  });
+
+  test("swallows a thrown fetch and leaves state unchanged", async () => {
+    consentResult = Promise.reject(new Error("offline"));
+    await refreshDiagnosticsConsent();
+    expect(applyResolvedDiagnosticsConsent).not.toHaveBeenCalled();
+  });
+});
+
+describe("installConsentRefreshListeners", () => {
+  test("a visible visibilitychange triggers a refresh", async () => {
+    const cleanup = installConsentRefreshListeners();
+    document.dispatchEvent(new Event("visibilitychange"));
+    await flush();
+    expect(fetchConsent).toHaveBeenCalledTimes(1);
+    cleanup();
+  });
+
+  test("a window focus triggers a refresh", async () => {
+    const cleanup = installConsentRefreshListeners();
+    window.dispatchEvent(new Event("focus"));
+    await flush();
+    expect(fetchConsent).toHaveBeenCalledTimes(1);
+    cleanup();
+  });
+
+  test("the 60s floor coalesces rapid focus events", async () => {
+    const cleanup = installConsentRefreshListeners();
+    window.dispatchEvent(new Event("focus"));
+    window.dispatchEvent(new Event("focus"));
+    window.dispatchEvent(new Event("focus"));
+    await flush();
+    expect(fetchConsent).toHaveBeenCalledTimes(1);
+    cleanup();
+  });
+
+  test("refreshes again once the 60s floor has elapsed", async () => {
+    const cleanup = installConsentRefreshListeners();
+    window.dispatchEvent(new Event("focus"));
+    await flush();
+    expect(fetchConsent).toHaveBeenCalledTimes(1);
+
+    setSystemTime(new Date(clock + 61_000));
+    window.dispatchEvent(new Event("focus"));
+    await flush();
+    expect(fetchConsent).toHaveBeenCalledTimes(2);
+    cleanup();
+  });
+
+  test("cleanup removes listeners so later events do not refresh", async () => {
+    const cleanup = installConsentRefreshListeners();
+    cleanup();
+    window.dispatchEvent(new Event("focus"));
+    document.dispatchEvent(new Event("visibilitychange"));
+    await flush();
+    expect(fetchConsent).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/lib/consent/consent-refresh.ts
+++ b/clients/web/src/lib/consent/consent-refresh.ts
@@ -1,0 +1,81 @@
+/**
+ * Re-fetch platform diagnostics consent on visibility/focus + a long-interval
+ * backstop, so a platform-side revoke is picked up without a fresh login.
+ *
+ * Everything routes through {@link applyResolvedDiagnosticsConsent} — the single
+ * version-aware, direction-asymmetric chokepoint that writes the saved
+ * preference, the effective Sentry gate, and the Electron main-process mirror.
+ * A failed/timed-out fetch is swallowed and leaves all diagnostics state
+ * unchanged (never flips the gate on or off).
+ */
+import { fetchConsent } from "@/domains/account/profile";
+import { applyResolvedDiagnosticsConsent } from "@/lib/consent/diagnostics-consent";
+import { useAuthStore } from "@/stores/auth-store";
+import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
+import { resolveServerConsent } from "@/utils/onboarding-cleanup";
+
+// Skip a refresh that fires within this window of the last one, so rapid
+// focus/visibility events coalesce to one fetch.
+const MIN_REFRESH_INTERVAL_MS = 60_000;
+
+// Backstop poll so a revoke is eventually adopted even on a window that never
+// loses or regains focus.
+const BACKSTOP_INTERVAL_MS = 30 * 60_000;
+
+let lastRefreshAt = 0;
+
+/**
+ * When a user is authenticated, fetch the server consent and route it through
+ * the diagnostics chokepoint. No-op when unauthenticated; a thrown fetch leaves
+ * state unchanged.
+ */
+export async function refreshDiagnosticsConsent(): Promise<void> {
+  if (!useAuthStore.getState().user) return;
+  try {
+    const resolved = resolveServerConsent(await fetchConsent());
+    applyResolvedDiagnosticsConsent(
+      {
+        shareDiagnostics: resolved.shareDiagnostics,
+        diagnosticsVersionCurrent: resolved.diagnosticsCurrent,
+        hasServerRecord: resolved.hasServerRecord,
+      },
+      useOnboardingStore.getState().setShareDiagnostics,
+    );
+  } catch {
+    // Fetch failed/timed out — leave diagnostics state untouched.
+  }
+}
+
+function refreshIfDue(): void {
+  const now = Date.now();
+  if (now - lastRefreshAt < MIN_REFRESH_INTERVAL_MS) return;
+  lastRefreshAt = now;
+  void refreshDiagnosticsConsent();
+}
+
+/**
+ * Install visibility/focus refresh triggers plus the long-interval backstop.
+ * Safe to call once at startup — the triggers re-check auth at fire time, so
+ * this is a no-op while unauthenticated. Returns a cleanup that removes both
+ * listeners and clears the timer. Guards DOM access for SSR/no-window.
+ */
+export function installConsentRefreshListeners(): () => void {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return () => {};
+  }
+
+  const onVisibility = (): void => {
+    if (document.visibilityState === "visible") refreshIfDue();
+  };
+  const onFocus = (): void => refreshIfDue();
+
+  document.addEventListener("visibilitychange", onVisibility);
+  window.addEventListener("focus", onFocus);
+  const timer = setInterval(refreshIfDue, BACKSTOP_INTERVAL_MS);
+
+  return () => {
+    document.removeEventListener("visibilitychange", onVisibility);
+    window.removeEventListener("focus", onFocus);
+    clearInterval(timer);
+  };
+}

--- a/clients/web/src/main.tsx
+++ b/clients/web/src/main.tsx
@@ -11,6 +11,7 @@ import { RouterProvider } from "react-router";
 import { AppProviders } from "@/components/providers";
 import { WindowDragRegion } from "@/components/window-drag-region";
 import { isChunkLoadError } from "@/lib/chunk-errors";
+import { installConsentRefreshListeners } from "@/lib/consent/consent-refresh";
 import { isLocalMode, loadLockfile } from "@/lib/local-mode";
 import { initSentry } from "@/lib/sentry/sentry-init";
 import { setupAuthListeners, useAuthStore } from "@/stores/auth-store";
@@ -27,6 +28,7 @@ async function boot() {
   initInputModality();
   await initSafeAreaBridge();
   initSentry();
+  installConsentRefreshListeners();
 
   setupOrganizationStore();
   if (isLocalMode()) {


### PR DESCRIPTION
## Summary
- Re-fetches platform consent on visibility/focus + a 30-min backstop, routed through the PR 1 chokepoint (preference + effective gate + main sync)
- Direction-safe: a failed fetch never flips diagnostics on or off; rapid focus events coalesce
- Closes the gap where a platform-side revoke was only picked up at login

Part of plan: sentry-overhaul.md (PR 2 of 12)