### PR TITLE
fix(host_browser): tolerate flapping extension SSE; surface degraded clients

### DIFF
--- a/assistant/src/__tests__/headless-browser-mode.test.ts
+++ b/assistant/src/__tests__/headless-browser-mode.test.ts
@@ -75,6 +75,16 @@ mock.module("../tools/browser/cdp-client/factory.js", () => ({
   },
 }));
 
+// The real proxy is an always-present singleton; stub the grace wait so
+// extension-pinned acquisition doesn't poll for the full window here.
+mock.module("../daemon/host-browser-proxy.js", () => ({
+  HostBrowserProxy: {
+    get instance() {
+      return { waitForExtensionClient: async () => true };
+    },
+  },
+}));
+
 // ── Minimal browserManager stub ──────────────────────────────────────
 
 /** Mutable memo shared between mock methods and tests. */

--- a/assistant/src/__tests__/headless-browser-navigate.test.ts
+++ b/assistant/src/__tests__/headless-browser-navigate.test.ts
@@ -58,9 +58,14 @@ let mockExtensionAvailable = false;
 mock.module("../daemon/host-browser-proxy.js", () => ({
   HostBrowserProxy: {
     get instance() {
-      return mockExtensionAvailable
-        ? { isAvailable: () => true, request: mock(async () => ({})) }
-        : undefined;
+      // The real proxy is a lazily-created singleton that always exists;
+      // `isAvailable`/`waitForExtensionClient` reflect whether an extension
+      // is connected rather than the instance being absent.
+      return {
+        isAvailable: () => mockExtensionAvailable,
+        waitForExtensionClient: async () => mockExtensionAvailable,
+        request: mock(async () => ({})),
+      };
     },
   },
 }));

--- a/assistant/src/__tests__/host-browser-proxy.test.ts
+++ b/assistant/src/__tests__/host-browser-proxy.test.ts
@@ -108,6 +108,45 @@ describe("HostBrowserProxy", () => {
     pendingInteractions.clear();
   });
 
+  describe("waitForExtensionClient", () => {
+    const EXTENSION: MockClient = {
+      clientId: "ext-client",
+      interfaceId: "chrome-extension",
+      capabilities: ["host_browser"],
+    };
+
+    test("returns true immediately when an extension is connected", async () => {
+      mockClients = [EXTENSION];
+      expect(await proxy.waitForExtensionClient(undefined, 1_000)).toBe(true);
+    });
+
+    test("returns false after the timeout when none connects", async () => {
+      mockClients = [DEFAULT_CLIENT]; // macos only, no extension
+      expect(await proxy.waitForExtensionClient(undefined, 100)).toBe(false);
+    });
+
+    test("returns true when an extension appears within the window", async () => {
+      mockClients = [DEFAULT_CLIENT];
+      setTimeout(() => {
+        mockClients = [DEFAULT_CLIENT, EXTENSION];
+      }, 50);
+      expect(await proxy.waitForExtensionClient(undefined, 2_000)).toBe(true);
+    });
+
+    test("respects sourceActorPrincipalId", async () => {
+      mockClients = [
+        {
+          clientId: "other-actor-ext",
+          interfaceId: "chrome-extension",
+          actorPrincipalId: "actor-b",
+          capabilities: ["host_browser"],
+        },
+      ];
+      // Caller is actor-a; the connected extension belongs to actor-b.
+      expect(await proxy.waitForExtensionClient("actor-a", 100)).toBe(false);
+    });
+  });
+
   describe("request/resolve lifecycle (happy path)", () => {
     test("sends host_browser_request and resolves with content", async () => {
       const resultPromise = proxy.request(

--- a/assistant/src/__tests__/host-browser-proxy.test.ts
+++ b/assistant/src/__tests__/host-browser-proxy.test.ts
@@ -46,6 +46,8 @@ mock.module("../runtime/assistant-event-hub.js", () => ({
       mockClients.filter((c) => c.capabilities.includes(cap)),
     listClientsByInterface: (interfaceId: string) =>
       mockClients.filter((c) => c.interfaceId === interfaceId),
+    getClientById: (clientId: string) =>
+      mockClients.find((c) => c.clientId === clientId),
     getActorPrincipalIdForClient: (clientId: string) =>
       mockClients.find((c) => c.clientId === clientId)?.actorPrincipalId,
   },
@@ -117,12 +119,16 @@ describe("HostBrowserProxy", () => {
 
     test("returns true immediately when an extension is connected", async () => {
       mockClients = [EXTENSION];
-      expect(await proxy.waitForExtensionClient(undefined, 1_000)).toBe(true);
+      expect(await proxy.waitForExtensionClient(undefined, undefined, 1_000)).toBe(
+        true,
+      );
     });
 
     test("returns false after the timeout when none connects", async () => {
       mockClients = [DEFAULT_CLIENT]; // macos only, no extension
-      expect(await proxy.waitForExtensionClient(undefined, 100)).toBe(false);
+      expect(await proxy.waitForExtensionClient(undefined, undefined, 100)).toBe(
+        false,
+      );
     });
 
     test("returns true when an extension appears within the window", async () => {
@@ -130,7 +136,9 @@ describe("HostBrowserProxy", () => {
       setTimeout(() => {
         mockClients = [DEFAULT_CLIENT, EXTENSION];
       }, 50);
-      expect(await proxy.waitForExtensionClient(undefined, 2_000)).toBe(true);
+      expect(await proxy.waitForExtensionClient(undefined, undefined, 2_000)).toBe(
+        true,
+      );
     });
 
     test("respects sourceActorPrincipalId", async () => {
@@ -143,7 +151,47 @@ describe("HostBrowserProxy", () => {
         },
       ];
       // Caller is actor-a; the connected extension belongs to actor-b.
-      expect(await proxy.waitForExtensionClient("actor-a", 100)).toBe(false);
+      expect(await proxy.waitForExtensionClient("actor-a", undefined, 100)).toBe(
+        false,
+      );
+    });
+
+    test("with a targetClientId, waits for that exact client (not a sibling)", async () => {
+      // A sibling extension is connected, but the targeted client is not —
+      // the wait must not return early on the sibling's presence.
+      mockClients = [
+        {
+          clientId: "sibling-ext",
+          interfaceId: "chrome-extension",
+          capabilities: ["host_browser"],
+        },
+      ];
+      expect(
+        await proxy.waitForExtensionClient(undefined, "target-ext", 100),
+      ).toBe(false);
+    });
+
+    test("with a targetClientId, returns true once that client appears", async () => {
+      mockClients = [
+        {
+          clientId: "sibling-ext",
+          interfaceId: "chrome-extension",
+          capabilities: ["host_browser"],
+        },
+      ];
+      setTimeout(() => {
+        mockClients = [
+          ...mockClients,
+          {
+            clientId: "target-ext",
+            interfaceId: "chrome-extension",
+            capabilities: ["host_browser"],
+          },
+        ];
+      }, 50);
+      expect(
+        await proxy.waitForExtensionClient(undefined, "target-ext", 2_000),
+      ).toBe(true);
     });
   });
 

--- a/assistant/src/cli/commands/clients.ts
+++ b/assistant/src/cli/commands/clients.ts
@@ -13,6 +13,7 @@ interface ClientEntryJSON {
   machineName?: string;
   connectedAt: string;
   lastActiveAt: string;
+  degraded?: boolean;
 }
 
 interface ListClientsResponse {
@@ -111,6 +112,7 @@ Examples:
           "LABEL",
           "CONNECTED",
           "LAST ACTIVE",
+          "STATUS",
         ];
         const rows: string[][] = entries.map((e: ClientEntryJSON) => [
           e.clientId,
@@ -119,6 +121,7 @@ Examples:
           e.machineName ?? "—",
           formatRelativeTime(e.connectedAt),
           formatRelativeTime(e.lastActiveAt),
+          e.degraded ? "degraded" : "—",
         ]);
 
         // Calculate column widths

--- a/assistant/src/daemon/host-browser-proxy.ts
+++ b/assistant/src/daemon/host-browser-proxy.ts
@@ -9,6 +9,7 @@ import * as pendingInteractions from "../runtime/pending-interactions.js";
 import type { ToolExecutionResult } from "../tools/types.js";
 import { AssistantError, ErrorCode } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
+import { sleep } from "../util/retry.js";
 import type { HostBrowserRequest } from "./message-types/host-browser.js";
 
 /** Distributive omit that preserves union variant fields. */
@@ -23,6 +24,16 @@ export type HostBrowserInput = DistributiveOmit<
 >;
 
 const log = getLogger("host-browser-proxy");
+
+/**
+ * Grace window for a flapping extension SSE connection. The Chrome
+ * extension's stream can briefly drop and reconnect (MV3 service-worker
+ * churn); without a short wait, a dispatch landing in a "down" blip
+ * hard-fails even though the extension is effectively connected. Well
+ * under the request-layer timeout (default 30s).
+ */
+const EXTENSION_RECONNECT_GRACE_MS = 3_000;
+const EXTENSION_RECONNECT_POLL_MS = 250;
 
 /**
  * Extension-only pseudo-CDP methods (Vellum.listTabs, Vellum.selectTab,
@@ -194,6 +205,25 @@ export class HostBrowserProxy {
       assistantEventHub.listClientsByInterface("chrome-extension"),
       sourceActorPrincipalId,
     );
+  }
+
+  /**
+   * Poll until a Chrome Extension client is connected, or `timeoutMs`
+   * elapses. Absorbs brief SSE reconnect blips so extension-pinned
+   * dispatch doesn't hard-fail on a momentary gap. Returns the final
+   * availability; callers proceed to dispatch regardless (which still
+   * surfaces the typed "no Chrome Extension connected" error if absent).
+   */
+  async waitForExtensionClient(
+    sourceActorPrincipalId?: string,
+    timeoutMs = EXTENSION_RECONNECT_GRACE_MS,
+  ): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      if (this.hasExtensionClient(sourceActorPrincipalId)) return true;
+      if (Date.now() >= deadline) return false;
+      await sleep(EXTENSION_RECONNECT_POLL_MS);
+    }
   }
 
   /**

--- a/assistant/src/daemon/host-browser-proxy.ts
+++ b/assistant/src/daemon/host-browser-proxy.ts
@@ -208,19 +208,30 @@ export class HostBrowserProxy {
   }
 
   /**
-   * Poll until a Chrome Extension client is connected, or `timeoutMs`
-   * elapses. Absorbs brief SSE reconnect blips so extension-pinned
-   * dispatch doesn't hard-fail on a momentary gap. Returns the final
-   * availability; callers proceed to dispatch regardless (which still
-   * surfaces the typed "no Chrome Extension connected" error if absent).
+   * Poll until the extension client that dispatch will route to is
+   * connected, or `timeoutMs` elapses. Absorbs brief SSE reconnect blips
+   * so extension-pinned dispatch doesn't hard-fail on a momentary gap.
+   *
+   * When `targetClientId` is supplied, waits for that *exact* client —
+   * `request()` resolves the target by id, so waiting for any sibling
+   * extension (multi-install setups) would return early and still fail.
+   * Otherwise waits for any extension owned by the actor, matching the
+   * auto-resolution preference. Returns the final availability; callers
+   * proceed to dispatch regardless (which still surfaces the typed "no
+   * Chrome Extension connected" error if absent).
    */
   async waitForExtensionClient(
     sourceActorPrincipalId?: string,
+    targetClientId?: string,
     timeoutMs = EXTENSION_RECONNECT_GRACE_MS,
   ): Promise<boolean> {
+    const connected = () =>
+      targetClientId != null
+        ? assistantEventHub.getClientById(targetClientId) !== undefined
+        : this.hasExtensionClient(sourceActorPrincipalId);
     const deadline = Date.now() + timeoutMs;
     for (;;) {
-      if (this.hasExtensionClient(sourceActorPrincipalId)) return true;
+      if (connected()) return true;
       if (Date.now() >= deadline) return false;
       await sleep(EXTENSION_RECONNECT_POLL_MS);
     }

--- a/assistant/src/ipc/__tests__/clients-list-ipc.test.ts
+++ b/assistant/src/ipc/__tests__/clients-list-ipc.test.ts
@@ -166,4 +166,24 @@ describe("assistant clients list over IPC — same-user filter", () => {
     const ids = parsed.clients.map((c) => c.clientId).sort();
     expect(ids).toEqual(["client-other", "client-self"]);
   });
+
+  test("--json output carries the degraded flag (false for fresh clients)", async () => {
+    registerClient({
+      clientId: "client-self-1",
+      actorPrincipalId: "guardian-local",
+    });
+
+    await startServer();
+
+    const { stdout } = await runAssistantCommandFull(
+      "clients",
+      "list",
+      "--json",
+    );
+    const parsed = JSON.parse(stdout.trim()) as {
+      clients: Array<{ clientId: string; degraded?: boolean }>;
+    };
+    expect(parsed.clients).toHaveLength(1);
+    expect(parsed.clients[0].degraded).toBe(false);
+  });
 });

--- a/assistant/src/runtime/__tests__/client-health.test.ts
+++ b/assistant/src/runtime/__tests__/client-health.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+
+import { isClientDegraded } from "../client-health.js";
+
+const HEARTBEAT_MS = 7_000;
+
+describe("isClientDegraded", () => {
+  test("fresh connection is not degraded (first heartbeat not due yet)", () => {
+    const connectedAt = new Date(1_000_000);
+    const lastActiveAt = connectedAt; // never touched yet
+    const now = new Date(connectedAt.getTime() + 3_000); // 3s old
+    expect(isClientDegraded(connectedAt, lastActiveAt, now, HEARTBEAT_MS)).toBe(
+      false,
+    );
+  });
+
+  test("mature healthy connection (lastActiveAt advancing) is not degraded", () => {
+    const connectedAt = new Date(1_000_000);
+    const now = new Date(connectedAt.getTime() + 60_000); // 60s old
+    const lastActiveAt = new Date(now.getTime() - 2_000); // heartbeat 2s ago
+    expect(isClientDegraded(connectedAt, lastActiveAt, now, HEARTBEAT_MS)).toBe(
+      false,
+    );
+  });
+
+  test("registered-but-not-heartbeating connection is degraded", () => {
+    const connectedAt = new Date(1_000_000);
+    const lastActiveAt = connectedAt; // lastActiveAt never advanced
+    const now = new Date(connectedAt.getTime() + 30_000); // 30s old (> 2 * heartbeat)
+    expect(isClientDegraded(connectedAt, lastActiveAt, now, HEARTBEAT_MS)).toBe(
+      true,
+    );
+  });
+
+  test("boundary: just under 2 heartbeat intervals old is not yet degraded", () => {
+    const connectedAt = new Date(1_000_000);
+    const lastActiveAt = connectedAt;
+    const now = new Date(connectedAt.getTime() + 2 * HEARTBEAT_MS - 1);
+    expect(isClientDegraded(connectedAt, lastActiveAt, now, HEARTBEAT_MS)).toBe(
+      false,
+    );
+  });
+});

--- a/assistant/src/runtime/__tests__/client-health.test.ts
+++ b/assistant/src/runtime/__tests__/client-health.test.ts
@@ -5,39 +5,40 @@ import { isClientDegraded } from "../client-health.js";
 const HEARTBEAT_MS = 7_000;
 
 describe("isClientDegraded", () => {
-  test("fresh connection is not degraded (first heartbeat not due yet)", () => {
-    const connectedAt = new Date(1_000_000);
-    const lastActiveAt = connectedAt; // never touched yet
-    const now = new Date(connectedAt.getTime() + 3_000); // 3s old
-    expect(isClientDegraded(connectedAt, lastActiveAt, now, HEARTBEAT_MS)).toBe(
-      false,
-    );
+  test("fresh connection is not degraded", () => {
+    const now = new Date(1_000_000);
+    const lastActiveAt = now; // just connected
+    expect(isClientDegraded(lastActiveAt, now, HEARTBEAT_MS)).toBe(false);
   });
 
-  test("mature healthy connection (lastActiveAt advancing) is not degraded", () => {
-    const connectedAt = new Date(1_000_000);
-    const now = new Date(connectedAt.getTime() + 60_000); // 60s old
+  test("actively heartbeating connection is not degraded", () => {
+    const now = new Date(1_000_000);
     const lastActiveAt = new Date(now.getTime() - 2_000); // heartbeat 2s ago
-    expect(isClientDegraded(connectedAt, lastActiveAt, now, HEARTBEAT_MS)).toBe(
-      false,
-    );
+    expect(isClientDegraded(lastActiveAt, now, HEARTBEAT_MS)).toBe(false);
   });
 
-  test("registered-but-not-heartbeating connection is degraded", () => {
-    const connectedAt = new Date(1_000_000);
-    const lastActiveAt = connectedAt; // lastActiveAt never advanced
-    const now = new Date(connectedAt.getTime() + 30_000); // 30s old (> 2 * heartbeat)
-    expect(isClientDegraded(connectedAt, lastActiveAt, now, HEARTBEAT_MS)).toBe(
-      true,
-    );
+  test("never-heartbeating connection that has gone stale is degraded", () => {
+    const now = new Date(1_000_000);
+    const lastActiveAt = new Date(now.getTime() - 30_000); // 30s since any activity
+    expect(isClientDegraded(lastActiveAt, now, HEARTBEAT_MS)).toBe(true);
   });
 
-  test("boundary: just under 2 heartbeat intervals old is not yet degraded", () => {
-    const connectedAt = new Date(1_000_000);
-    const lastActiveAt = connectedAt;
-    const now = new Date(connectedAt.getTime() + 2 * HEARTBEAT_MS - 1);
-    expect(isClientDegraded(connectedAt, lastActiveAt, now, HEARTBEAT_MS)).toBe(
-      false,
-    );
+  test("heartbeated then froze is degraded (stale relative to now, not connectedAt)", () => {
+    const now = new Date(1_000_000);
+    // Connected long ago, heartbeated for a while, then stopped an hour ago.
+    const lastActiveAt = new Date(now.getTime() - 3_600_000);
+    expect(isClientDegraded(lastActiveAt, now, HEARTBEAT_MS)).toBe(true);
+  });
+
+  test("boundary: just under 2 heartbeat intervals stale is not degraded", () => {
+    const now = new Date(1_000_000);
+    const lastActiveAt = new Date(now.getTime() - (2 * HEARTBEAT_MS - 1));
+    expect(isClientDegraded(lastActiveAt, now, HEARTBEAT_MS)).toBe(false);
+  });
+
+  test("boundary: just over 2 heartbeat intervals stale is degraded", () => {
+    const now = new Date(1_000_000);
+    const lastActiveAt = new Date(now.getTime() - (2 * HEARTBEAT_MS + 1));
+    expect(isClientDegraded(lastActiveAt, now, HEARTBEAT_MS)).toBe(true);
   });
 });

--- a/assistant/src/runtime/client-health.ts
+++ b/assistant/src/runtime/client-health.ts
@@ -1,0 +1,31 @@
+/**
+ * Health heuristics for connected SSE clients.
+ */
+
+/** Keep-alive comment sent to idle clients every 7 s by default. */
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 7_000;
+
+/**
+ * Whether a client looks degraded: connected long enough that a
+ * heartbeat should have advanced `lastActiveAt`, yet it hasn't. This
+ * flags a registered-but-not-heartbeating connection (the symptom of a
+ * flapping extension SSE stream) without false-positiving on a healthy
+ * freshly-connected client whose first heartbeat hasn't fired yet.
+ *
+ * Limitation: a just-reconnected flapping client looks like a healthy
+ * new connection in a single snapshot — this is best-effort visibility,
+ * not a liveness guarantee.
+ */
+export function isClientDegraded(
+  connectedAt: Date,
+  lastActiveAt: Date,
+  now: Date,
+  heartbeatIntervalMs: number,
+): boolean {
+  const connectedForMs = now.getTime() - connectedAt.getTime();
+  const advancedByMs = lastActiveAt.getTime() - connectedAt.getTime();
+  return (
+    connectedForMs > 2 * heartbeatIntervalMs &&
+    advancedByMs < heartbeatIntervalMs
+  );
+}

--- a/assistant/src/runtime/client-health.ts
+++ b/assistant/src/runtime/client-health.ts
@@ -6,26 +6,21 @@
 export const DEFAULT_HEARTBEAT_INTERVAL_MS = 7_000;
 
 /**
- * Whether a client looks degraded: connected long enough that a
- * heartbeat should have advanced `lastActiveAt`, yet it hasn't. This
- * flags a registered-but-not-heartbeating connection (the symptom of a
- * flapping extension SSE stream) without false-positiving on a healthy
- * freshly-connected client whose first heartbeat hasn't fired yet.
+ * Whether a client looks degraded: its last heartbeat (`lastActiveAt`) is
+ * stale by more than two heartbeat intervals. This surfaces a
+ * registered-but-not-heartbeating connection — the symptom of a flapping
+ * extension SSE stream — whether it never heartbeated or heartbeated and
+ * then froze. A healthy client (fresh or actively heartbeating) has a
+ * recent `lastActiveAt` and is not flagged.
  *
- * Limitation: a just-reconnected flapping client looks like a healthy
- * new connection in a single snapshot — this is best-effort visibility,
- * not a liveness guarantee.
+ * Limitation: a just-reconnected flapping client has a fresh
+ * `lastActiveAt` and looks healthy in a single snapshot — this is
+ * best-effort visibility, not a liveness guarantee.
  */
 export function isClientDegraded(
-  connectedAt: Date,
   lastActiveAt: Date,
   now: Date,
   heartbeatIntervalMs: number,
 ): boolean {
-  const connectedForMs = now.getTime() - connectedAt.getTime();
-  const advancedByMs = lastActiveAt.getTime() - connectedAt.getTime();
-  return (
-    connectedForMs > 2 * heartbeatIntervalMs &&
-    advancedByMs < heartbeatIntervalMs
-  );
+  return now.getTime() - lastActiveAt.getTime() > 2 * heartbeatIntervalMs;
 }

--- a/assistant/src/runtime/routes/__tests__/client-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/client-routes.test.ts
@@ -51,6 +51,7 @@ type ListClientsResponse = {
     machineName?: string;
     connectedAt: string;
     lastActiveAt: string;
+    degraded?: boolean;
   }>;
 };
 
@@ -151,5 +152,17 @@ describe("list_clients route — same-user filter", () => {
 
     const ids = result.clients.map((c) => c.clientId).sort();
     expect(ids).toEqual(["client-A1", "client-B1", "client-noprincipal"]);
+  });
+
+  test("includes a degraded flag (false for a freshly connected client)", () => {
+    registerClient({ clientId: "client-A1", actorPrincipalId: "user-A" });
+
+    const handler = findHandler("list_clients");
+    const result = handler({
+      headers: { "x-vellum-actor-principal-id": "user-A" },
+    }) as ListClientsResponse;
+
+    expect(result.clients).toHaveLength(1);
+    expect(result.clients[0].degraded).toBe(false);
   });
 });

--- a/assistant/src/runtime/routes/browser-tabs-routes.ts
+++ b/assistant/src/runtime/routes/browser-tabs-routes.ts
@@ -8,6 +8,7 @@
 import { z } from "zod";
 
 import { findConversation } from "../../daemon/conversation-registry.js";
+import { HostBrowserProxy } from "../../daemon/host-browser-proxy.js";
 import { getCdpClient } from "../../tools/browser/cdp-client/factory.js";
 import {
   clearPinnedTab,
@@ -50,6 +51,13 @@ async function handleBrowserTabs({ body = {} }: RouteHandlerArgs) {
   } as unknown as ToolContext;
 
   const cdpOptions = { mode: "extension" as const, targetClientId };
+
+  // Every tabs command pins extension mode. Absorb a brief extension SSE
+  // reconnect blip so a flapping connection doesn't surface as a hard
+  // "no Chrome Extension connected" error.
+  await HostBrowserProxy.instance.waitForExtensionClient(
+    context.sourceActorPrincipalId,
+  );
 
   if (command === "list") {
     const cdp = getCdpClient(context, cdpOptions);

--- a/assistant/src/runtime/routes/browser-tabs-routes.ts
+++ b/assistant/src/runtime/routes/browser-tabs-routes.ts
@@ -57,6 +57,7 @@ async function handleBrowserTabs({ body = {} }: RouteHandlerArgs) {
   // "no Chrome Extension connected" error.
   await HostBrowserProxy.instance.waitForExtensionClient(
     context.sourceActorPrincipalId,
+    targetClientId,
   );
 
   if (command === "list") {

--- a/assistant/src/runtime/routes/client-routes.ts
+++ b/assistant/src/runtime/routes/client-routes.ts
@@ -80,7 +80,6 @@ export const ROUTES: RouteDefinition[] = [
             connectedAt: c.connectedAt,
             lastActiveAt: c.lastActiveAt,
             degraded: isClientDegraded(
-              c.connectedAt,
               c.lastActiveAt,
               now,
               DEFAULT_HEARTBEAT_INTERVAL_MS,

--- a/assistant/src/runtime/routes/client-routes.ts
+++ b/assistant/src/runtime/routes/client-routes.ts
@@ -12,6 +12,10 @@ import { isHttpAuthDisabled } from "../../config/env.js";
 import { datesToISO } from "../../util/json.js";
 import { assistantEventHub } from "../assistant-event-hub.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import {
+  DEFAULT_HEARTBEAT_INTERVAL_MS,
+  isClientDegraded,
+} from "../client-health.js";
 import { NotFoundError } from "./errors.js";
 import type { RouteDefinition } from "./types.js";
 
@@ -65,6 +69,7 @@ export const ROUTES: RouteDefinition[] = [
               c.actorPrincipalId === callerPrincipalId,
           );
 
+      const now = new Date();
       return {
         clients: filtered.map((c) =>
           datesToISO({
@@ -74,6 +79,12 @@ export const ROUTES: RouteDefinition[] = [
             machineName: c.machineName,
             connectedAt: c.connectedAt,
             lastActiveAt: c.lastActiveAt,
+            degraded: isClientDegraded(
+              c.connectedAt,
+              c.lastActiveAt,
+              now,
+              DEFAULT_HEARTBEAT_INTERVAL_MS,
+            ),
           }),
         ),
       };

--- a/assistant/src/runtime/routes/events-routes.ts
+++ b/assistant/src/runtime/routes/events-routes.ts
@@ -42,6 +42,7 @@ import {
 import type { ReplaySubscriber } from "../assistant-stream-state.js";
 import { getReplayWindow } from "../assistant-stream-state.js";
 import { ACTOR_PRINCIPALS, GATEWAY_PRINCIPALS } from "../auth/route-policy.js";
+import { DEFAULT_HEARTBEAT_INTERVAL_MS } from "../client-health.js";
 import { resolveActorPrincipalIdForLocalGuardian } from "../local-actor-identity.js";
 import {
   BadRequestError,
@@ -51,9 +52,6 @@ import {
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const log = getLogger("events-routes");
-
-/** Keep-alive comment sent to idle clients every 7 s by default. */
-const DEFAULT_HEARTBEAT_INTERVAL_MS = 7_000;
 
 /**
  * Resolution of the event-loop delay histogram, per

--- a/assistant/src/tools/browser/__tests__/browser-execution-acquire.test.ts
+++ b/assistant/src/tools/browser/__tests__/browser-execution-acquire.test.ts
@@ -54,7 +54,9 @@ const setPreferredBackendKindMock = mock(
   (_conversationId: string, _kind: CdpClientKind) => {},
 );
 const clearPreferredBackendKindMock = mock((_conversationId: string) => {});
-const waitForExtensionClientMock = mock(async (_actor?: string) => true);
+const waitForExtensionClientMock = mock(
+  async (_actor?: string, _targetClientId?: string) => true,
+);
 
 // ---------------------------------------------------------------------------
 // Module mocks (must be declared before dynamic import)
@@ -154,8 +156,13 @@ describe("acquireCdpClientWithMode: target_client_id overrides sticky backend mo
     );
 
     // The grace wait runs before backend selection so a flapping extension
-    // SSE reconnect doesn't hard-fail the dispatch.
+    // SSE reconnect doesn't hard-fail the dispatch, and it targets the exact
+    // requested client.
     expect(waitForExtensionClientMock).toHaveBeenCalledTimes(1);
+    expect(waitForExtensionClientMock).toHaveBeenCalledWith(
+      undefined,
+      "host-client-grace",
+    );
     expect(getCdpClientCalls[0].mode).toBe("extension");
   });
 

--- a/assistant/src/tools/browser/__tests__/browser-execution-acquire.test.ts
+++ b/assistant/src/tools/browser/__tests__/browser-execution-acquire.test.ts
@@ -54,6 +54,7 @@ const setPreferredBackendKindMock = mock(
   (_conversationId: string, _kind: CdpClientKind) => {},
 );
 const clearPreferredBackendKindMock = mock((_conversationId: string) => {});
+const waitForExtensionClientMock = mock(async (_actor?: string) => true);
 
 // ---------------------------------------------------------------------------
 // Module mocks (must be declared before dynamic import)
@@ -98,6 +99,7 @@ mock.module("../../../daemon/host-browser-proxy.js", () => ({
       return {
         isAvailable: () => false,
         hasExtensionClient: () => false,
+        waitForExtensionClient: waitForExtensionClientMock,
         request: () => Promise.reject(new Error("no extension")),
       };
     },
@@ -141,7 +143,29 @@ describe("acquireCdpClientWithMode: target_client_id overrides sticky backend mo
     getCdpClientMock.mockClear();
     setPreferredBackendKindMock.mockClear();
     clearPreferredBackendKindMock.mockClear();
+    waitForExtensionClientMock.mockClear();
     stickyKind = null;
+  });
+
+  test("extension-pinned acquisition awaits the reconnect grace window", async () => {
+    await executeBrowserAttach(
+      { target_client_id: "host-client-grace" },
+      makeContext("grace-window"),
+    );
+
+    // The grace wait runs before backend selection so a flapping extension
+    // SSE reconnect doesn't hard-fail the dispatch.
+    expect(waitForExtensionClientMock).toHaveBeenCalledTimes(1);
+    expect(getCdpClientCalls[0].mode).toBe("extension");
+  });
+
+  test("non-extension (sticky local, no target) does not wait on the extension", async () => {
+    stickyKind = "local";
+
+    await executeBrowserAttach({}, makeContext("no-grace-for-local"));
+
+    expect(waitForExtensionClientMock).not.toHaveBeenCalled();
+    expect(getCdpClientCalls[0].mode).toBe("local");
   });
 
   test("sticky local + target_client_id → getCdpClient receives mode:extension, not local", async () => {

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -419,6 +419,7 @@ async function acquireCdpClientWithMode(
   if (effectiveMode === "extension") {
     await HostBrowserProxy.instance.waitForExtensionClient(
       context.sourceActorPrincipalId,
+      targetClientId,
     );
   }
 

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -375,16 +375,17 @@ function isRestrictedChromePageProbeError(error: CdpError): boolean {
  * The returned client is wrapped so its first successful `send()`
  * writes the resolved kind back to the conversation memo.
  */
-function acquireCdpClientWithMode(
+async function acquireCdpClientWithMode(
   input: Record<string, unknown>,
   context: ToolContext,
-):
+): Promise<
   | {
       cdp: ReturnType<typeof getCdpClient>;
       browserMode: BrowserMode;
       errorResult?: never;
     }
-  | { cdp?: never; browserMode?: never; errorResult: ToolExecutionResult } {
+  | { cdp?: never; browserMode?: never; errorResult: ToolExecutionResult }
+> {
   const modeResult = parseBrowserMode(input);
   if (!modeResult.ok) {
     return {
@@ -411,6 +412,15 @@ function acquireCdpClientWithMode(
       : browserMode === "auto" && rememberedKind !== null
         ? rememberedKind
         : browserMode;
+
+  // Extension-pinned dispatch (explicit `--browser-mode extension` or a
+  // `target_client_id`) hard-fails when the extension is momentarily
+  // absent. Absorb a brief reconnect blip before selecting the backend.
+  if (effectiveMode === "extension") {
+    await HostBrowserProxy.instance.waitForExtensionClient(
+      context.sourceActorPrincipalId,
+    );
+  }
 
   try {
     const raw = getCdpClient(context, { mode: effectiveMode, targetClientId });
@@ -655,7 +665,7 @@ export async function executeBrowserNavigate(
   }
 
   // URL validation passed — acquire the CDP client.
-  const acquired = acquireCdpClientWithMode(input, context);
+  const acquired = await acquireCdpClientWithMode(input, context);
   if (acquired.errorResult) return acquired.errorResult;
   const { cdp, browserMode } = acquired;
 
@@ -1157,7 +1167,7 @@ export async function executeBrowserSnapshot(
   _input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const acquired = acquireCdpClientWithMode(_input, context);
+  const acquired = await acquireCdpClientWithMode(_input, context);
   if (acquired.errorResult) return acquired.errorResult;
   const { cdp, browserMode } = acquired;
 
@@ -1209,7 +1219,7 @@ export async function executeBrowserScreenshot(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const acquired = acquireCdpClientWithMode(input, context);
+  const acquired = await acquireCdpClientWithMode(input, context);
   if (acquired.errorResult) return acquired.errorResult;
   const { cdp, browserMode } = acquired;
   const fullPage = input.full_page === true;
@@ -1266,7 +1276,7 @@ export async function executeBrowserAttach(
   _input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const acquired = acquireCdpClientWithMode(_input, context);
+  const acquired = await acquireCdpClientWithMode(_input, context);
   if (acquired.errorResult) return acquired.errorResult;
   const cdp = acquired.cdp;
   try {
@@ -1319,7 +1329,7 @@ export async function executeBrowserDetach(
   _input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const acquired = acquireCdpClientWithMode(_input, context);
+  const acquired = await acquireCdpClientWithMode(_input, context);
   if (acquired.errorResult) return acquired.errorResult;
   const cdp = acquired.cdp;
   try {
@@ -1369,7 +1379,7 @@ export async function executeBrowserClose(
   input: Record<string, unknown>,
   context: ToolContext,
 ): Promise<ToolExecutionResult> {
-  const acquired = acquireCdpClientWithMode(input, context);
+  const acquired = await acquireCdpClientWithMode(input, context);
   if (acquired.errorResult) return acquired.errorResult;
   const cdp = acquired.cdp;
   try {
@@ -1440,7 +1450,7 @@ export async function executeBrowserClick(
   const { resolved, error } = resolveElement(context.conversationId, input);
   if (error) return { content: error, isError: true };
 
-  const acquired = acquireCdpClientWithMode(input, context);
+  const acquired = await acquireCdpClientWithMode(input, context);
   if (acquired.errorResult) return acquired.errorResult;
   const cdp = acquired.cdp;
   try {
@@ -1561,7 +1571,7 @@ export async function executeBrowserType(
       ? `element_id "${resolved!.eid}"`
       : resolved!.selector;
 
-  const acquired = acquireCdpClientWithMode(input, context);
+  const acquired = await acquireCdpClientWithMode(input, context);
   if (acquired.errorResult) return acquired.errorResult;
   const cdp = acquired.cdp;
   try {
@@ -1638,7 +1648,7 @@ export async function executeBrowserPressKey(
         : resolved!.selector;
   }
 
-  const acquired = acquireCdpClientWithMode(input, context);
+  const acquired = await acquireCdpClientWithMode(input, context);
   if (acquired.errorResult) return acquired.errorResult;
   const cdp = acquired.cdp;
   try {
@@ -1715,7 +1725,7 @@ export async function executeBrowserScroll(
       break;
   }
 
-  const acquired = acquireCdpClientWithMode(input, context);
+  const acquired = await acquireCdpClientWithMode(input, context);
   if (acquired.errorResult) return acquired.errorResult;
   const cdp = acquired.cdp;
   try {
@@ -1778,7 +1788,7 @@ export async function executeBrowserSelectOption(
       ? `element_id "${resolved!.eid}"`
       : resolved!.selector;
 
-  const acquired = acquireCdpClientWithMode(input, context);
+  const acquired = await acquireCdpClientWithMode(input, context);
   if (acquired.errorResult) return acquired.errorResult;
   const cdp = acquired.cdp;
   try {
@@ -1894,7 +1904,7 @@ export async function executeBrowserHover(
   const { resolved, error } = resolveElement(context.conversationId, input);
   if (error) return { content: error, isError: true };
 
-  const acquired = acquireCdpClientWithMode(input, context);
+  const acquired = await acquireCdpClientWithMode(input, context);
   if (acquired.errorResult) return acquired.errorResult;
   const cdp = acquired.cdp;
   try {
@@ -1988,7 +1998,7 @@ export async function executeBrowserWaitFor(
     return { content: `Waited ${waitMs}ms.`, isError: false };
   }
 
-  const acquired = acquireCdpClientWithMode(input, context);
+  const acquired = await acquireCdpClientWithMode(input, context);
   if (acquired.errorResult) return acquired.errorResult;
   const cdp = acquired.cdp;
   try {
@@ -2037,7 +2047,7 @@ export async function executeBrowserExtract(
 ): Promise<ToolExecutionResult> {
   const includeLinks = input.include_links === true;
 
-  const acquired = acquireCdpClientWithMode(input, context);
+  const acquired = await acquireCdpClientWithMode(input, context);
   if (acquired.errorResult) return acquired.errorResult;
   const cdp = acquired.cdp;
   try {
@@ -2120,7 +2130,7 @@ export async function executeBrowserFillCredential(
       ? `element_id "${resolved!.eid}"`
       : resolved!.selector;
 
-  const acquired = acquireCdpClientWithMode(input, context);
+  const acquired = await acquireCdpClientWithMode(input, context);
   if (acquired.errorResult) return acquired.errorResult;
   const cdp = acquired.cdp;
   try {


### PR DESCRIPTION
## Summary
- **Layer 2 (grace window):** `host_browser` extension dispatch no longer throws `Pinned mode "extension" unavailable: no Chrome Extension connected` on a momentary SSE reconnect. New `HostBrowserProxy.waitForExtensionClient()` polls for the extension (default 3s, well under the 30s request budget) and is awaited on the two extension-pinned paths — the `browser tabs` route and `acquireCdpClientWithMode` — before backend selection. The eager typed-error + sticky-fallback contract is preserved (the wait runs *before* the existing throw).
- **Layer 3 (degraded visibility):** `clients list` now shows a `STATUS` column and the `list_clients` response carries a `degraded` flag — true when a client has been connected for >2 heartbeat intervals but its `lastActiveAt` never advanced (a registered-but-not-heartbeating connection). Heuristic lives in a new `runtime/client-health.ts` (also now the single home for `DEFAULT_HEARTBEAT_INTERVAL_MS`).
- Tests: `waitForExtensionClient` (immediate/timeout/appears-mid-window/actor-scoped), extension-pinned acquire awaits the grace window, `isClientDegraded` boundaries, and `degraded` wiring through the route + CLI IPC.

## Original prompt
Investigating a user bug report ("Chrome extension client present in `clients list` but unreachable; `host_browser` … CDP dead"). A log-grounded deep dive (the feedback bundle showed the extension flickering present→absent→present across `clients list` calls seconds apart, `connectedAt === lastActiveAt`, and sub-7s SSE connection deaths) established the real cause: the extension's MV3-service-worker SSE connection flaps, and the dispatch's instantaneous presence check turns a brief gap into a hard error — not pin-mode, actor filtering, or CDP. The user approved a plan to ship **Layer 2** (bounded grace window in dispatch) and **Layer 3** (degraded indicator in `clients list`). The true client-side cure (host the SSE in a `chrome.offscreen` document so it survives MV3 termination) and a separate same-actor cleanup on the tabs route are intentionally **out of scope** here and noted as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)