### PR TITLE
merge: integrate #35380 live-platform-session gating into the Sentry overhaul

### DIFF
--- a/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
+++ b/assistant/src/__tests__/conversation-routes-guardian-reply.test.ts
@@ -222,13 +222,16 @@ describe("handleSendMessage canonical guardian reply interception", () => {
     const routerCall = (routeGuardianReplyMock as any).mock
       .calls[0][0] as Record<string, unknown>;
     expect(routerCall.messageText).toBe("05BECB approve");
-    expect(routerCall.pendingRequestIds).toEqual(["access-req-1"]);
+    expect(routerCall.pendingScope).toEqual({
+      mode: "scoped",
+      requestIds: ["access-req-1"],
+    });
     expect(addMessageMock).toHaveBeenCalledTimes(2);
     expect(persistUserMessage).toHaveBeenCalledTimes(0);
     expect(runAgentLoop).toHaveBeenCalledTimes(0);
   });
 
-  test("passes empty pendingRequestIds array when no canonical hints are found", async () => {
+  test("passes a blocked scope when no canonical hints are found", async () => {
     listPendingByDestinationMock.mockReturnValue([]);
     listCanonicalMock.mockReturnValue([]);
     routeGuardianReplyMock.mockResolvedValue({
@@ -301,7 +304,7 @@ describe("handleSendMessage canonical guardian reply interception", () => {
     expect(routeGuardianReplyMock).toHaveBeenCalledTimes(1);
     const routerCall = (routeGuardianReplyMock as any).mock
       .calls[0][0] as Record<string, unknown>;
-    expect(routerCall.pendingRequestIds).toEqual([]);
+    expect(routerCall.pendingScope).toEqual({ mode: "blocked" });
     expect(persistUserMessage).toHaveBeenCalledTimes(1);
     expect(runAgentLoop).toHaveBeenCalledTimes(1);
   });
@@ -384,15 +387,15 @@ describe("handleSendMessage canonical guardian reply interception", () => {
     expect(routeGuardianReplyMock).toHaveBeenCalledTimes(1);
     const routerCall = (routeGuardianReplyMock as any).mock
       .calls[0][0] as Record<string, unknown>;
-    expect(routerCall.pendingRequestIds).toEqual([
-      "tool-approval-live",
-      "access-req-1",
-    ]);
-    expect(
-      (routerCall.pendingRequestIds as string[]).includes(
-        "tool-approval-stale",
-      ),
-    ).toBe(false);
+    const scope = routerCall.pendingScope as {
+      mode: string;
+      requestIds: string[];
+    };
+    expect(scope).toEqual({
+      mode: "scoped",
+      requestIds: ["tool-approval-live", "access-req-1"],
+    });
+    expect(scope.requestIds.includes("tool-approval-stale")).toBe(false);
   });
 
   test("text fallback: request-code approve routes through guardian reply router", async () => {

--- a/assistant/src/__tests__/guardian-routing-invariants.test.ts
+++ b/assistant/src/__tests__/guardian-routing-invariants.test.ts
@@ -828,7 +828,7 @@ describe("routing invariant: disambiguation stays fail-closed", () => {
       replyCtx({
         messageText: "approve",
         conversationId: "conv-guardian-conversation",
-        pendingRequestIds: [req.id],
+        pendingScope: { mode: "scoped", requestIds: [req.id] },
         approvalConversationGenerator: undefined,
       }),
     );
@@ -857,7 +857,7 @@ describe("routing invariant: disambiguation stays fail-closed", () => {
       replyCtx({
         messageText: "ok, what is this for?",
         conversationId: "conv-guardian-conversation",
-        pendingRequestIds: [req.id],
+        pendingScope: { mode: "scoped", requestIds: [req.id] },
         approvalConversationGenerator: undefined,
       }),
     );
@@ -870,7 +870,7 @@ describe("routing invariant: disambiguation stays fail-closed", () => {
     expect(unchanged!.status).toBe("pending");
   });
 
-  test("explicit empty pendingRequestIds hint stays fail-closed for desktop actors", async () => {
+  test("explicit blocked scope stays fail-closed for desktop actors", async () => {
     createCanonicalGuardianRequest({
       kind: "tool_approval",
       sourceType: "channel",
@@ -887,7 +887,7 @@ describe("routing invariant: disambiguation stays fail-closed", () => {
         messageText: "approve",
         actor: trustedActor(),
         conversationId: "conv-unrelated",
-        pendingRequestIds: [],
+        pendingScope: { mode: "blocked" },
         approvalConversationGenerator: undefined,
       }),
     );
@@ -895,6 +895,38 @@ describe("routing invariant: disambiguation stays fail-closed", () => {
     expect(result.consumed).toBe(false);
     expect(result.type).toBe("not_consumed");
     expect(result.decisionApplied).toBe(false);
+  });
+
+  test("explicit request code still resolves under a blocked scope (cross-chat carve-out)", async () => {
+    // The Slack cross-chat guard blocks identity fallback, but an explicit
+    // request code carries its own target and must still resolve — otherwise a
+    // guardian could not approve-by-code from a chat where no card was delivered.
+    const req = createCanonicalGuardianRequest({
+      kind: "tool_approval",
+      sourceType: "channel",
+      conversationId: "conv-other",
+      guardianExternalUserId: "guardian-1",
+      guardianPrincipalId: TEST_PRINCIPAL_ID,
+      requestCode: "ABC123",
+      toolName: "shell",
+      expiresAt: Date.now() + 60_000,
+    });
+    registerPendingToolApprovalInteraction(req.id, "conv-other", "shell");
+
+    const result = await routeGuardianReply(
+      replyCtx({
+        messageText: "ABC123 approve",
+        actor: trustedActor(),
+        conversationId: "conv-unrelated",
+        pendingScope: { mode: "blocked" },
+        approvalConversationGenerator: undefined,
+      }),
+    );
+
+    expect(result.consumed).toBe(true);
+    expect(result.requestId).toBe(req.id);
+    expect(result.decisionApplied).toBe(true);
+    expect(getCanonicalGuardianRequest(req.id)!.status).toBe("approved");
   });
 
   test("multiple hinted pending requests with plain-text approve returns disambiguation", async () => {
@@ -924,7 +956,7 @@ describe("routing invariant: disambiguation stays fail-closed", () => {
       replyCtx({
         messageText: "approve",
         conversationId: "conv-guardian-conversation",
-        pendingRequestIds: [req1.id, req2.id],
+        pendingScope: { mode: "scoped", requestIds: [req1.id, req2.id] },
         approvalConversationGenerator: undefined,
       }),
     );
@@ -977,7 +1009,7 @@ describe("routing invariant: disambiguation stays fail-closed", () => {
       replyCtx({
         messageText: "yes approve it",
         conversationId: "conv-1",
-        pendingRequestIds: [req1.id, req2.id],
+        pendingScope: { mode: "scoped", requestIds: [req1.id, req2.id] },
         approvalConversationGenerator: mockGenerator as any,
       }),
     );
@@ -1031,7 +1063,10 @@ describe("routing invariant: disambiguation stays fail-closed", () => {
       replyCtx({
         messageText: "approve",
         conversationId: "conv-guardian-conversation",
-        pendingRequestIds: [answerRequest.id, approvalRequest.id],
+        pendingScope: {
+          mode: "scoped",
+          requestIds: [answerRequest.id, approvalRequest.id],
+        },
         approvalConversationGenerator: undefined,
       }),
     );
@@ -1075,7 +1110,7 @@ describe("routing invariant: disambiguation stays fail-closed", () => {
       replyCtx({
         messageText: "yes",
         conversationId: "conv-1",
-        pendingRequestIds: [req.id],
+        pendingScope: { mode: "scoped", requestIds: [req.id] },
         approvalConversationGenerator: mockGenerator as any,
       }),
     );
@@ -1104,7 +1139,7 @@ describe("routing invariant: disambiguation stays fail-closed", () => {
       replyCtx({
         messageText: "go for it",
         conversationId: "conv-1",
-        pendingRequestIds: [req.id],
+        pendingScope: { mode: "scoped", requestIds: [req.id] },
         approvalConversationGenerator: undefined,
       }),
     );
@@ -1117,7 +1152,7 @@ describe("routing invariant: disambiguation stays fail-closed", () => {
     expect(resolved!.status).toBe("approved");
   });
 
-  test("code-based routing is constrained to caller-provided pendingRequestIds scope", async () => {
+  test("code-based routing is constrained to caller-provided scope", async () => {
     const inScope = createCanonicalGuardianRequest({
       kind: "tool_approval",
       sourceType: "channel",
@@ -1145,7 +1180,7 @@ describe("routing invariant: disambiguation stays fail-closed", () => {
       replyCtx({
         messageText: "222BBB approve",
         conversationId: "conv-guardian-conversation",
-        pendingRequestIds: [inScope.id],
+        pendingScope: { mode: "scoped", requestIds: [inScope.id] },
         approvalConversationGenerator: undefined,
       }),
     );
@@ -1438,7 +1473,7 @@ describe("routing invariant: directResolve interactions resolve via guardian dec
 describe("routing invariant: destination hints do not bypass tool_approval principal binding", () => {
   beforeEach(() => resetTables());
 
-  test("explicit pendingRequestIds still fail closed when guardianPrincipalId does not match", async () => {
+  test("explicit scope still fails closed when guardianPrincipalId does not match", async () => {
     // Voice-originated tool approval with a different principal than the actor.
     const req = createCanonicalGuardianRequest({
       kind: "tool_approval",
@@ -1452,15 +1487,15 @@ describe("routing invariant: destination hints do not bypass tool_approval princ
     });
     registerPendingToolApprovalInteraction(req.id, "conv-voice-1", "shell");
 
-    // The channel inbound router would compute pendingRequestIds from
-    // delivery-scoped lookup and pass them here. Simulate that.
+    // The channel inbound router would compute the pending scope from
+    // delivery-scoped lookup and pass it here. Simulate that.
     const result = await routeGuardianReply(
       replyCtx({
         messageText: "approve",
         channel: "telegram",
         actor: guardianActor({ guardianPrincipalId: "different-principal" }),
         conversationId: "conv-guardian-chat",
-        pendingRequestIds: [req.id],
+        pendingScope: { mode: "scoped", requestIds: [req.id] },
         approvalConversationGenerator: undefined,
       }),
     );
@@ -1486,7 +1521,7 @@ describe("routing invariant: destination hints do not bypass tool_approval princ
       expiresAt: Date.now() + 60_000,
     });
 
-    // No pendingRequestIds passed — identity-based fallback uses
+    // No pendingScope passed — identity-based fallback uses
     // actor.actorExternalUserId which does not match any request's
     // guardianExternalUserId (since it's null).
     const result = await routeGuardianReply(
@@ -1495,7 +1530,7 @@ describe("routing invariant: destination hints do not bypass tool_approval princ
         channel: "telegram",
         actor: guardianActor({ actorExternalUserId: "guardian-tg-user" }),
         conversationId: "conv-guardian-chat",
-        // pendingRequestIds: undefined — no delivery hints
+        // pendingScope omitted — no delivery hints
         approvalConversationGenerator: undefined,
       }),
     );
@@ -1534,7 +1569,7 @@ describe("routing invariant: invite handoff bypass for access requests", () => {
       replyCtx({
         messageText: "open invite flow",
         conversationId: "conv-guardian-conversation",
-        pendingRequestIds: [req.id],
+        pendingScope: { mode: "scoped", requestIds: [req.id] },
         approvalConversationGenerator: undefined,
       }),
     );
@@ -1569,7 +1604,7 @@ describe("routing invariant: invite handoff bypass for access requests", () => {
         replyCtx({
           messageText: phrase,
           conversationId: "conv-test",
-          pendingRequestIds: [req.id],
+          pendingScope: { mode: "scoped", requestIds: [req.id] },
           approvalConversationGenerator: undefined,
         }),
       );
@@ -1595,7 +1630,7 @@ describe("routing invariant: invite handoff bypass for access requests", () => {
       replyCtx({
         messageText: "open invite flow",
         conversationId: "conv-guardian-conversation",
-        pendingRequestIds: [req.id],
+        pendingScope: { mode: "scoped", requestIds: [req.id] },
         approvalConversationGenerator: undefined,
       }),
     );
@@ -1625,7 +1660,7 @@ describe("routing invariant: invite handoff bypass for access requests", () => {
       replyCtx({
         messageText: "A00B01 approve",
         conversationId: "conv-guardian-conversation",
-        pendingRequestIds: [req.id],
+        pendingScope: { mode: "scoped", requestIds: [req.id] },
         approvalConversationGenerator: undefined,
       }),
     );
@@ -1655,7 +1690,7 @@ describe("routing invariant: invite handoff bypass for access requests", () => {
       channel: "vellum",
       actor: trustedActor({ channel: "vellum" }),
       conversationId: "conv-guardian-conversation",
-      pendingRequestIds: [req.id],
+      pendingScope: { mode: "scoped", requestIds: [req.id] },
       approvalConversationGenerator: undefined,
     });
 
@@ -1694,7 +1729,7 @@ describe("routing invariant: invite handoff bypass for access requests", () => {
       channel: "vellum",
       actor: trustedActor({ channel: "vellum" }),
       conversationId: "conv-guardian-conversation",
-      pendingRequestIds: [req.id],
+      pendingScope: { mode: "scoped", requestIds: [req.id] },
       approvalConversationGenerator: approvalConversationGenerator as any,
     });
 
@@ -1746,7 +1781,7 @@ describe("routing invariant: expired requests are excluded from pending discover
       replyCtx({
         messageText: "approve",
         conversationId: "conv-guardian-conversation",
-        pendingRequestIds: [expired.id, active.id],
+        pendingScope: { mode: "scoped", requestIds: [expired.id, active.id] },
         approvalConversationGenerator: undefined,
       }),
     );
@@ -1781,7 +1816,7 @@ describe("routing invariant: expired requests are excluded from pending discover
       replyCtx({
         messageText: "`approve`",
         conversationId: "conv-guardian-conversation",
-        pendingRequestIds: [req.id],
+        pendingScope: { mode: "scoped", requestIds: [req.id] },
         approvalConversationGenerator: undefined,
       }),
     );
@@ -1821,7 +1856,10 @@ describe("routing invariant: expired requests are excluded from pending discover
       replyCtx({
         messageText: "approve",
         conversationId: "conv-guardian-conversation",
-        pendingRequestIds: [expired1.id, expired2.id],
+        pendingScope: {
+          mode: "scoped",
+          requestIds: [expired1.id, expired2.id],
+        },
         approvalConversationGenerator: undefined,
       }),
     );

--- a/assistant/src/__tests__/slack-notification-approval-card.test.ts
+++ b/assistant/src/__tests__/slack-notification-approval-card.test.ts
@@ -8,8 +8,9 @@ import type { ApprovalUIMetadata } from "../runtime/channel-approval-types.js";
 /**
  * Pins the Slack approval-card block contract: the title, identity subtitle,
  * quoted-preview body, action callback ids, source/permalink and requester-id
- * context blocks, warning subtext, and guardian verification note that
- * `buildApprovalNotificationBlocks` emits for an access request.
+ * context blocks, the security-warning context block, and guardian
+ * verification note that `buildApprovalNotificationBlocks` emits for an
+ * access request.
  */
 
 const APPROVAL: ApprovalUIMetadata = {
@@ -121,29 +122,34 @@ describe("Slack access-request card blocks", () => {
     );
   });
 
-  test("warnings render in the card subtext", () => {
-    const c = card(
-      buildApprovalNotificationBlocks(
-        buildPayload({
-          ...BASE,
-          isStranger: true,
-          isRestricted: true,
-          previousMemberStatus: "revoked",
-        }),
-        "msg",
-      ),
+  test("warnings render in a context block under the card", () => {
+    const blocks = buildApprovalNotificationBlocks(
+      buildPayload({
+        ...BASE,
+        isStranger: true,
+        isRestricted: true,
+        previousMemberStatus: "revoked",
+      }),
+      "msg",
     );
-    const subtext = text(c.subtext);
-    expect(subtext).toContain(":warning: This user was previously revoked.");
-    expect(subtext).toContain(
+    // `subtext` is not a Slack card field; warnings must live in a real block
+    // or Slack drops them and the guardian never sees them.
+    expect(card(blocks).subtext).toBeUndefined();
+    const warning = contextTexts(blocks).find((t) => t.includes(":warning:"));
+    expect(warning).toBeDefined();
+    expect(warning).toContain(":warning: This user was previously revoked.");
+    expect(warning).toContain(
       ":warning: External Slack user (not in this workspace).",
     );
-    expect(subtext).toContain(":warning: Guest / restricted account.");
+    expect(warning).toContain(":warning: Guest / restricted account.");
   });
 
-  test("no subtext when there are no warnings", () => {
-    const c = card(buildApprovalNotificationBlocks(buildPayload(BASE), "msg"));
-    expect(c.subtext).toBeUndefined();
+  test("no warning context block when there are no warnings", () => {
+    const blocks = buildApprovalNotificationBlocks(buildPayload(BASE), "msg");
+    expect(card(blocks).subtext).toBeUndefined();
+    expect(contextTexts(blocks).some((t) => t.includes(":warning:"))).toBe(
+      false,
+    );
   });
 
   test("body falls back to a default label when no preview", () => {

--- a/assistant/src/daemon/conversation-process.ts
+++ b/assistant/src/daemon/conversation-process.ts
@@ -28,7 +28,10 @@ import {
 import { extractPreferences } from "../notifications/preference-extractor.js";
 import { createPreference } from "../notifications/preferences-store.js";
 import type { ContextWindowResult } from "../plugins/defaults/compaction/window-manager.js";
-import { routeGuardianReply } from "../runtime/guardian-reply-router.js";
+import {
+  type GuardianPendingScope,
+  routeGuardianReply,
+} from "../runtime/guardian-reply-router.js";
 import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
 import { getLogger } from "../util/logger.js";
 import type { CleanResult, Conversation } from "./conversation.js";
@@ -1407,9 +1410,14 @@ export async function processMessage(
           "vellum",
         ).map((request) => request.id)
       : [];
-  const canonicalPendingRequestIdsForConversation =
+  // Empty hints → leave the scope unset (identity-fallback): the desktop
+  // guardian can still resolve their pending work by identity/principal.
+  const pendingScope: GuardianPendingScope | undefined =
     canonicalPendingRequestHintIdsForConversation.length > 0
-      ? canonicalPendingRequestHintIdsForConversation
+      ? {
+          mode: "scoped",
+          requestIds: canonicalPendingRequestHintIdsForConversation,
+        }
       : undefined;
 
   // ── Canonical guardian reply router (desktop/conversation path) ──
@@ -1428,7 +1436,7 @@ export async function processMessage(
           conversation.trustContext?.guardianPrincipalId ?? undefined,
       },
       conversationId: conversation.conversationId,
-      pendingRequestIds: canonicalPendingRequestIdsForConversation,
+      pendingScope,
       // Desktop path: disable NL classification to avoid consuming non-decision
       // messages while a tool confirmation is pending. Deterministic code-prefix
       // and callback parsing remain active.

--- a/assistant/src/notifications/adapters/slack.ts
+++ b/assistant/src/notifications/adapters/slack.ts
@@ -125,7 +125,8 @@ function buildRequesterIdBlock(
  * Build Slack blocks for an access request using a native Card block.
  *
  * Layout:
- *   Card — title + subtitle (identity) + body (preview) + actions + subtext (warnings)
+ *   Card — title + subtitle (identity) + body (preview) + actions
+ *   Context — security warnings (revoked/restricted/stranger), when present
  *   Context — source permalink (when the request is from Slack)
  *   Context — stable requester ID (when it adds info beyond subtitle)
  *   Context — invite directive
@@ -141,20 +142,31 @@ function buildAccessRequestCardBlocks(
   const subtitle = buildAccessRequestSubtitle(view);
   const body = buildAccessRequestBody(view);
 
-  const subtext =
+  const warningsText =
     view.warnings.length > 0
       ? truncate(view.warnings.map((w) => `:warning: ${w}`).join(" · "), 200)
       : undefined;
 
   const card: Record<string, unknown> = {
     type: "card",
-    title: { type: "plain_text", text: "Access Request" },
+    title: { type: "mrkdwn", text: "Access Request" },
     subtitle: { type: "mrkdwn", text: subtitle },
     body: { type: "mrkdwn", text: body },
     actions: buildCardActions(approval),
   };
-  if (subtext) card.subtext = { type: "mrkdwn", text: subtext };
   blocks.push(card);
+
+  // Security warnings (revoked / restricted / stranger) render in a context
+  // block under the card. Slack's card block schema has no field for them
+  // (https://docs.slack.dev/reference/block-kit/blocks/card-block) and Slack
+  // silently drops unknown card fields, so a dedicated block is needed to
+  // surface them to the guardian.
+  if (warningsText) {
+    blocks.push({
+      type: "context",
+      elements: [{ type: "mrkdwn", text: warningsText }],
+    });
+  }
 
   const sourceContext = buildSourceContextBlock(view);
   if (sourceContext) blocks.push(sourceContext);
@@ -217,7 +229,7 @@ function buildToolApprovalCardBlocks(
   const card: Record<string, unknown> = {
     type: "card",
     title: {
-      type: "plain_text",
+      type: "mrkdwn",
       text: details ? "Tool Approval" : "Approval Request",
     },
     body: {

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -56,6 +56,26 @@ const log = getLogger("guardian-reply-router");
 // Types
 // ---------------------------------------------------------------------------
 
+/**
+ * How to scope a guardian's pending requests when resolving an inbound reply.
+ * The three states are mutually exclusive and named so the security-critical
+ * `blocked` cannot be confused with the absence of a hint:
+ *
+ *   - `scoped`: resolve only these request ids, and constrain request-code
+ *     routing to this set (delivery-/conversation-scoped hints).
+ *   - `blocked`: fail closed — no pending requests and no identity fallback.
+ *     The Slack cross-chat guard: a guardian's unrelated message in a chat
+ *     where no card was delivered must not resolve a request delivered
+ *     elsewhere. Explicit callbacks and request codes still work (they carry
+ *     their own request id).
+ *   - `identity-fallback`: discover pending requests by guardian identity,
+ *     conversation, or principal. The default when no scope is supplied.
+ */
+export type GuardianPendingScope =
+  | { mode: "scoped"; requestIds: string[] }
+  | { mode: "blocked" }
+  | { mode: "identity-fallback" };
+
 /** Context for an inbound message that may be a guardian reply. */
 export interface GuardianReplyContext {
   /** The raw message text (trimmed). */
@@ -74,8 +94,12 @@ export interface GuardianReplyContext {
    * attached to. Used to recover the target request from its delivery record.
    */
   reactedMessageTs?: string;
-  /** IDs of known pending canonical requests for this guardian. */
-  pendingRequestIds?: string[];
+  /**
+   * How to scope this guardian's pending requests (see {@link
+   * GuardianPendingScope}). Omitted is equivalent to
+   * `{ mode: "identity-fallback" }`.
+   */
+  pendingScope?: GuardianPendingScope;
   /** Conversation generator for NL classification (injected by daemon). */
   approvalConversationGenerator?: ApprovalConversationGenerator;
   /** Optional channel delivery context for resolver-driven side effects. */
@@ -212,30 +236,33 @@ function parseRequestCode(
 /** Find all pending canonical requests for a guardian actor. */
 function findPendingCanonicalRequests(
   actor: ActorContext,
-  pendingRequestIds?: string[],
+  scope: GuardianPendingScope,
   conversationId?: string,
 ): CanonicalGuardianRequest[] {
+  // `blocked` fails closed: no pending requests and no identity fallback — the
+  // Slack cross-chat hijack guard.
+  if (scope.mode === "blocked") {
+    return [];
+  }
+
   let results: CanonicalGuardianRequest[];
 
-  // When explicit IDs are provided, look them up directly
-  if (pendingRequestIds) {
-    if (pendingRequestIds.length === 0) {
-      return [];
-    }
-    results = pendingRequestIds
+  if (scope.mode === "scoped") {
+    // Resolve exactly the supplied ids.
+    results = scope.requestIds
       .map(getCanonicalGuardianRequest)
       .filter((r): r is CanonicalGuardianRequest => r?.status === "pending");
   } else if (actor.actorExternalUserId) {
-    // Query by guardian identity when available
+    // identity-fallback: query by guardian identity when available
     results = listCanonicalGuardianRequests({
       status: "pending",
       guardianExternalUserId: actor.actorExternalUserId,
     });
   } else if (conversationId) {
-    // Actors without an actorExternalUserId: scope by conversationId so the NL
-    // path can discover pending requests bound to this conversation.
-    // Include guardianPrincipalId filter when available so the guardian only
-    // sees requests they are authorized to act on.
+    // identity-fallback without an actorExternalUserId: scope by conversationId
+    // so the NL path can discover pending requests bound to this conversation.
+    // Include guardianPrincipalId when available so the guardian only sees
+    // requests they are authorized to act on.
     results = listCanonicalGuardianRequests({
       status: "pending",
       conversationId,
@@ -244,9 +271,8 @@ function findPendingCanonicalRequests(
         : {}),
     });
   } else if (actor.guardianPrincipalId) {
-    // Actors with a guardianPrincipalId but no actorExternalUserId or
-    // conversationId: query by principal so desktop sessions can still
-    // discover pending guardian work via their bound principal.
+    // identity-fallback by principal: desktop sessions discover pending
+    // guardian work via their bound principal.
     results = listCanonicalGuardianRequests({
       status: "pending",
       guardianPrincipalId: actor.guardianPrincipalId,
@@ -342,15 +368,18 @@ export async function routeGuardianReply(
     );
   }
 
+  const pendingScope: GuardianPendingScope = ctx.pendingScope ?? {
+    mode: "identity-fallback",
+  };
   const pendingRequests = findPendingCanonicalRequests(
     actor,
-    ctx.pendingRequestIds,
+    pendingScope,
     conversationId,
   );
+  // Request codes carry their own id, so constrain them only under an explicit
+  // scope; under blocked/identity-fallback they still resolve cross-chat.
   const scopedPendingRequestIds =
-    ctx.pendingRequestIds && ctx.pendingRequestIds.length > 0
-      ? new Set(ctx.pendingRequestIds)
-      : null;
+    pendingScope.mode === "scoped" ? new Set(pendingScope.requestIds) : null;
 
   // ── 1. Deterministic callback parsing (button presses) ──
   // No conversationId scoping here — the guardian's reply comes from a

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -120,7 +120,10 @@ import { assistantEventHub, broadcastMessage } from "../assistant-event-hub.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
 import { getPersistedSeq } from "../assistant-stream-state.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
-import { routeGuardianReply } from "../guardian-reply-router.js";
+import {
+  type GuardianPendingScope,
+  routeGuardianReply,
+} from "../guardian-reply-router.js";
 import { healGuardianBindingDrift } from "../guardian-vellum-migration.js";
 import type {
   ApprovalConversationGenerator,
@@ -486,12 +489,14 @@ async function tryConsumeCanonicalGuardianReply(params: {
     sourceChannel,
     conversation,
   );
-  // Always pass the hints array (even when empty) so
-  // findPendingCanonicalRequests respects the in-memory staleness filter
-  // applied by collectCanonicalGuardianRequestHintIds. Converting empty
-  // hints to `undefined` caused the router to fall through to raw DB
-  // queries that rediscovered stale canonical requests.
-  const pendingRequestIds = pendingRequestHintIds;
+  // An empty hint set is `blocked`, not absence: the in-memory staleness
+  // filter in collectCanonicalGuardianRequestHintIds found no live requests,
+  // so the router must not fall back to identity/DB lookup (which rediscovered
+  // stale canonical requests). A non-empty set scopes resolution to it.
+  const pendingScope: GuardianPendingScope =
+    pendingRequestHintIds.length > 0
+      ? { mode: "scoped", requestIds: pendingRequestHintIds }
+      : { mode: "blocked" };
 
   const routerResult = await routeGuardianReply({
     messageText: trimmedContent,
@@ -503,7 +508,7 @@ async function tryConsumeCanonicalGuardianReply(params: {
       guardianPrincipalId: verifiedActorPrincipalId,
     },
     conversationId,
-    pendingRequestIds,
+    pendingScope,
     approvalConversationGenerator,
     emissionContext: {
       source: "inline_nl",

--- a/assistant/src/runtime/routes/inbound-stages/guardian-reply-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-reply-intercept.test.ts
@@ -85,7 +85,7 @@ describe("handleGuardianReplyIntercept", () => {
     deliverChannelReplyCalls = [];
   });
 
-  test("passes empty pendingRequestIds when Slack guardian sends message in non-delivery chat", async () => {
+  test("passes a blocked scope when Slack guardian sends message in non-delivery chat", async () => {
     // No delivery-scoped requests for this chat
     mockDeliveryScopedRequests = [];
     // Identity-based lookup would find a pending request in a different chat
@@ -95,8 +95,8 @@ describe("handleGuardianReplyIntercept", () => {
 
     expect(routeGuardianReplyCalls).toHaveLength(1);
     const ctx = routeGuardianReplyCalls[0] as Record<string, unknown>;
-    // Must be [] (empty array), NOT undefined — blocks identity fallback
-    expect(ctx.pendingRequestIds).toEqual([]);
+    // Must be a blocked scope, NOT undefined — blocks identity fallback
+    expect(ctx.pendingScope).toEqual({ mode: "blocked" });
   });
 
   test("preserves identity fallback for non-Slack channels when no deliveries exist", async () => {
@@ -110,11 +110,11 @@ describe("handleGuardianReplyIntercept", () => {
 
     expect(routeGuardianReplyCalls).toHaveLength(1);
     const ctx = routeGuardianReplyCalls[0] as Record<string, unknown>;
-    // Must be undefined — identity-based fallback stays active
-    expect(ctx.pendingRequestIds).toBeUndefined();
+    // Must be unset — identity-based fallback stays active
+    expect(ctx.pendingScope).toBeUndefined();
   });
 
-  test("includes identity-unioned pendingRequestIds when Slack guardian is in delivery chat", async () => {
+  test("passes an identity-unioned scoped set when Slack guardian is in delivery chat", async () => {
     mockDeliveryScopedRequests = [{ id: "delivered-req" }];
     mockIdentityRequests = [
       { id: "delivered-req" },
@@ -125,7 +125,7 @@ describe("handleGuardianReplyIntercept", () => {
 
     expect(routeGuardianReplyCalls).toHaveLength(1);
     const ctx = routeGuardianReplyCalls[0] as Record<string, unknown>;
-    const ids = ctx.pendingRequestIds as string[];
+    const ids = (ctx.pendingScope as { requestIds: string[] }).requestIds;
     expect(ids).toContain("delivered-req");
     expect(ids).toContain("identity-only-req");
   });

--- a/assistant/src/runtime/routes/inbound-stages/guardian-reply-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-reply-intercept.ts
@@ -16,7 +16,10 @@ import {
 } from "../../../memory/canonical-guardian-store.js";
 import { getLogger } from "../../../util/logger.js";
 import { deliverChannelReply } from "../../gateway-client.js";
-import { routeGuardianReply } from "../../guardian-reply-router.js";
+import {
+  type GuardianPendingScope,
+  routeGuardianReply,
+} from "../../guardian-reply-router.js";
 import type { ApprovalConversationGenerator } from "../../http-types.js";
 
 const log = getLogger("runtime-http");
@@ -109,16 +112,16 @@ export async function handleGuardianReplyIntercept(
   // based pending requests so that requests without delivery rows (e.g.
   // tool_approval requests created inline) are not silently excluded.
   //
-  // On Slack, when no delivery-scoped results exist for the current
-  // chat, pass [] (empty array) instead of undefined. This prevents the
-  // router's identity-based fallback from intercepting unrelated
+  // On Slack, when no delivery-scoped results exist for the current chat,
+  // use `{ mode: "blocked" }` rather than identity-fallback. This prevents
+  // the router's identity-based fallback from intercepting unrelated
   // messages in other channels/threads — a cross-chat hijacking vector
   // unique to Slack where a single guardian is active in many threaded
   // contexts. Explicit callbacks (apr:<id>:<action>) and request codes
   // still work cross-chat because they carry specific request
-  // identifiers and bypass the pendingRequests list.
+  // identifiers and bypass the pending-request scope.
   //
-  // Non-Slack channels (Telegram, WhatsApp) keep undefined so the
+  // Non-Slack channels (Telegram, WhatsApp) leave the scope unset so the
   // identity-based fallback stays active. On those channels, delivery
   // rows are created asynchronously (fire-and-forget .then()) so the
   // guardian can reply before the row is persisted. Cross-chat
@@ -128,7 +131,7 @@ export async function handleGuardianReplyIntercept(
   // so they bypass the pending-request list scoping that the text/NL paths
   // need — the router's reaction branch resolves the target directly.
   const isReaction = callbackData?.startsWith("reaction:") === true;
-  let pendingRequestIds: string[] | undefined;
+  let pendingScope: GuardianPendingScope | undefined;
   if (!isReaction) {
     const deliveryScopedPendingRequests =
       listPendingCanonicalGuardianRequestsByDestinationChat(
@@ -148,11 +151,11 @@ export async function handleGuardianReplyIntercept(
       for (const r of identityPending) {
         deliveryIds.add(r.id);
       }
-      pendingRequestIds = [...deliveryIds];
+      pendingScope = { mode: "scoped", requestIds: [...deliveryIds] };
     } else if (sourceChannel === "slack") {
       // Block identity-based fallback on Slack to prevent cross-chat
       // NL/free-text interception. See comment above for rationale.
-      pendingRequestIds = [];
+      pendingScope = { mode: "blocked" };
     }
   }
 
@@ -168,7 +171,7 @@ export async function handleGuardianReplyIntercept(
     conversationId,
     callbackData,
     reactedMessageTs,
-    pendingRequestIds,
+    pendingScope,
     approvalConversationGenerator,
     channelDeliveryContext: {
       replyCallbackUrl,

--- a/clients/macos/src/main/sentry.test.ts
+++ b/clients/macos/src/main/sentry.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+/**
+ * Unit coverage for the main-process Sentry consent gate. The key contract:
+ * main starts fail-closed (no init from the persisted value, since main boots
+ * before the renderer can apply the live-session gate) and only enables when
+ * the renderer pushes the effective consent over IPC — applied directly so an
+ * unchanged persisted value still enforces the gate.
+ *
+ * `@sentry/node`, `electron`, and `./settings` are mocked so the module runs
+ * without an Electron runtime. Each test file runs in its own process
+ * (scripts/run-tests.ts), so these `mock.module` overrides don't leak.
+ */
+
+// Build-time globals injected by the bundler; define them so resolveOptions
+// produces a non-null options object.
+(globalThis as Record<string, unknown>).__SENTRY_DSN_MACOS__ =
+  "https://public@example.test/1";
+(globalThis as Record<string, unknown>).__VELLUM_ENVIRONMENT__ = "test";
+(globalThis as Record<string, unknown>).__VELLUM_BUILD_SHA__ = "test-sha";
+
+let sentryClient:
+  | { getOptions: () => { enabled?: boolean }; close: () => Promise<boolean> }
+  | undefined;
+
+const initMock = mock((_opts: Record<string, unknown>) => {});
+const setTagMock = mock((_k: string, _v: unknown) => {});
+const setClientMock = mock((_c: unknown) => {});
+const captureMessageMock = mock((_m: string, _o?: unknown) => {});
+
+mock.module("@sentry/node", () => ({
+  init: initMock,
+  getClient: () => sentryClient,
+  getCurrentScope: () => ({ setClient: setClientMock }),
+  setTag: setTagMock,
+  captureMessage: captureMessageMock,
+}));
+
+mock.module("electron", () => ({
+  app: {
+    isPackaged: false,
+    on: mock(() => {}),
+  },
+}));
+
+let settingChangeCb: ((newValue: boolean | undefined) => void) | null = null;
+const writeSettingMock = mock((_key: string, _value: unknown) => {});
+
+mock.module("./settings", () => ({
+  onSettingChange: (_key: string, cb: (v: boolean | undefined) => void) => {
+    settingChangeCb = cb;
+    return () => {
+      settingChangeCb = null;
+    };
+  },
+  writeSetting: writeSettingMock,
+}));
+
+const { initSentryMain, setShareDiagnostics } = await import("./sentry");
+
+beforeEach(() => {
+  initMock.mockReset();
+  setTagMock.mockReset();
+  setClientMock.mockReset();
+  writeSettingMock.mockReset();
+  sentryClient = undefined;
+  settingChangeCb = null;
+});
+
+describe("initSentryMain", () => {
+  test("starts fail-closed: does not initialize Sentry at boot", () => {
+    initSentryMain();
+    expect(initMock).not.toHaveBeenCalled();
+    // ...but it does register the mid-session watcher.
+    expect(settingChangeCb).not.toBeNull();
+  });
+});
+
+describe("setShareDiagnostics", () => {
+  test("persists and enables Sentry directly, even when the watcher would not fire", () => {
+    initSentryMain();
+    initMock.mockReset();
+
+    setShareDiagnostics(true);
+
+    expect(writeSettingMock).toHaveBeenCalledWith("shareDiagnostics", true);
+    // Enabled via the direct apply path, not the (unfired) change watcher.
+    expect(initMock).toHaveBeenCalledTimes(1);
+    expect(initMock.mock.calls[0][0]).toMatchObject({ enabled: true });
+  });
+
+  test("disabling closes a running client", () => {
+    initSentryMain();
+    const closeMock = mock(() => Promise.resolve(true));
+    sentryClient = { getOptions: () => ({ enabled: true }), close: closeMock };
+
+    setShareDiagnostics(false);
+
+    expect(writeSettingMock).toHaveBeenCalledWith("shareDiagnostics", false);
+    expect(closeMock).toHaveBeenCalled();
+    expect(setClientMock).toHaveBeenCalledWith(undefined);
+  });
+});
+
+describe("mid-session toggle watcher", () => {
+  test("flipping the stored value on enables, off closes", () => {
+    initSentryMain();
+
+    settingChangeCb?.(true);
+    expect(initMock).toHaveBeenCalledTimes(1);
+
+    sentryClient = {
+      getOptions: () => ({ enabled: true }),
+      close: () => Promise.resolve(true),
+    };
+    settingChangeCb?.(false);
+    expect(setClientMock).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/clients/macos/src/main/sentry.test.ts
+++ b/clients/macos/src/main/sentry.test.ts
@@ -1,12 +1,20 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 /**
- * Unit coverage for the main-process Sentry consent gate, now backed by
- * `@sentry/electron/main`. The key contract: strict opt-in from the persisted
- * `shareDiagnostics` value, with a mid-session watcher that inits/closes when
- * the renderer pushes a new effective gate over IPC. Native crash capture
- * (Crashpad minidumps, renderer/child process crashes) rides on the default
- * `@sentry/electron/main` integrations, so init alone configures it.
+ * Unit coverage for the main-process Sentry consent gate, backed by
+ * `@sentry/electron/main`.
+ *
+ * Two contracts compose here:
+ *  - Fail-closed boot: main does NOT init from the persisted `shareDiagnostics`
+ *    value, because it boots before any renderer can apply the live-session
+ *    gate; it only enables when the renderer pushes effective consent over IPC,
+ *    applied directly so an unchanged persisted value still enforces the gate.
+ *  - One-shot init: `@sentry/electron/main` init() starts Crashpad and installs
+ *    crash listeners that close() does NOT remove, so we init the SDK at most
+ *    once (lazily, on first consent) and thereafter gate JS event delivery via a
+ *    `beforeSend` that returns null while disabled — never close()/re-init.
+ * Native crash capture rides on the default `@sentry/electron/main`
+ * integrations, so init alone configures it.
  *
  * `@sentry/electron/main`, `electron`, and `./settings` are mocked so the
  * module runs without an Electron runtime. Each test file runs in its own
@@ -23,8 +31,13 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 let sentryClient:
   | { getOptions: () => { enabled?: boolean }; close: () => Promise<boolean> }
   | undefined;
+// Captures the options object passed to the last init() call so tests can
+// exercise the registered `beforeSend` consent gate.
+let lastInitOptions: Record<string, unknown> | undefined;
 
-const initMock = mock((_opts: Record<string, unknown>) => {});
+const initMock = mock((opts: Record<string, unknown>) => {
+  lastInitOptions = opts;
+});
 const setTagMock = mock((_k: string, _v: unknown) => {});
 const setClientMock = mock((_c: unknown) => {});
 
@@ -43,11 +56,9 @@ mock.module("electron", () => ({
 }));
 
 let settingChangeCb: ((newValue: boolean | undefined) => void) | null = null;
-let storedConsent: boolean | undefined;
 const writeSettingMock = mock((_key: string, _value: unknown) => {});
 
 mock.module("./settings", () => ({
-  readSetting: (_key: string) => storedConsent,
   onSettingChange: (_key: string, cb: (v: boolean | undefined) => void) => {
     settingChangeCb = cb;
     return () => {
@@ -59,34 +70,48 @@ mock.module("./settings", () => ({
 
 const { initSentryMain, setShareDiagnostics } = await import("./sentry");
 
+// NOTE: `sentry.ts` holds module-level singleton state (`initialized`, the live
+// `enabled` flag, cached options) by design — init must run AT MOST ONCE per
+// process. Since the module is imported once for this whole file, that state
+// persists across tests. We therefore reset only the mocks (not the module
+// singleton) and order tests so the fail-closed-boot / empty-DSN assertions run
+// BEFORE the first enable, then drive the full lifecycle in one test below.
 beforeEach(() => {
-  initMock.mockReset();
+  // mockClear (not mockReset) so initMock keeps its lastInitOptions-capturing
+  // implementation while clearing call history between tests.
+  initMock.mockClear();
   setTagMock.mockReset();
   setClientMock.mockReset();
   writeSettingMock.mockReset();
   sentryClient = undefined;
-  storedConsent = undefined;
   settingChangeCb = null;
 });
 
-describe("initSentryMain", () => {
-  test("does not initialize Sentry when consent is absent", () => {
-    storedConsent = undefined;
+describe("initSentryMain (before any consent)", () => {
+  test("does not register the watcher when the DSN is empty", () => {
+    (globalThis as Record<string, unknown>).__SENTRY_DSN_MACOS__ = "";
+    initSentryMain();
+    expect(initMock).not.toHaveBeenCalled();
+    expect(settingChangeCb).toBeNull();
+    (globalThis as Record<string, unknown>).__SENTRY_DSN_MACOS__ =
+      "https://public@example.test/1";
+  });
+
+  test("starts fail-closed: does not initialize Sentry at boot", () => {
     initSentryMain();
     expect(initMock).not.toHaveBeenCalled();
     // ...but it does register the mid-session watcher.
     expect(settingChangeCb).not.toBeNull();
   });
+});
 
-  test("does not initialize Sentry when consent is explicitly false", () => {
-    storedConsent = false;
+describe("consent lifecycle (one-shot init, beforeSend gate)", () => {
+  test("first enable inits the SDK once with a beforeSend gate; later toggles only flip the flag", () => {
     initSentryMain();
-    expect(initMock).not.toHaveBeenCalled();
-  });
 
-  test("initializes Sentry when consent is stored true", () => {
-    storedConsent = true;
-    initSentryMain();
+    // First enable via the direct apply path (not the unfired change watcher).
+    setShareDiagnostics(true);
+    expect(writeSettingMock).toHaveBeenCalledWith("shareDiagnostics", true);
     expect(initMock).toHaveBeenCalledTimes(1);
     expect(initMock.mock.calls[0][0]).toMatchObject({
       enabled: true,
@@ -96,52 +121,27 @@ describe("initSentryMain", () => {
     });
     // Tags are applied so events carry process/arch/electron/packaged context.
     expect(setTagMock).toHaveBeenCalledWith("process", "main");
-  });
 
-  test("does not initialize when the DSN is empty", () => {
-    (globalThis as Record<string, unknown>).__SENTRY_DSN_MACOS__ = "";
-    storedConsent = true;
-    initSentryMain();
-    expect(initMock).not.toHaveBeenCalled();
-    expect(settingChangeCb).toBeNull();
-    (globalThis as Record<string, unknown>).__SENTRY_DSN_MACOS__ =
-      "https://public@example.test/1";
-  });
-});
+    const beforeSend = lastInitOptions?.beforeSend as
+      | ((event: unknown) => unknown)
+      | undefined;
+    // Enabled now: beforeSend passes events through.
+    const okEvent = { message: "ok" };
+    expect(beforeSend?.(okEvent)).toBe(okEvent);
 
-describe("mid-session toggle watcher", () => {
-  test("flipping the stored value on inits, off closes", () => {
-    initSentryMain();
-
-    settingChangeCb?.(true);
-    expect(initMock).toHaveBeenCalledTimes(1);
-
-    sentryClient = {
-      getOptions: () => ({ enabled: true }),
-      close: () => Promise.resolve(true),
-    };
-    settingChangeCb?.(false);
-    expect(setClientMock).toHaveBeenCalledWith(undefined);
-  });
-
-  test("does not re-init when a client is already enabled", () => {
-    initSentryMain();
-    sentryClient = {
-      getOptions: () => ({ enabled: true }),
-      close: () => Promise.resolve(true),
-    };
-
-    settingChangeCb?.(true);
-    expect(initMock).not.toHaveBeenCalled();
-  });
-});
-
-describe("setShareDiagnostics", () => {
-  test("persists consent so the watcher drives the Sentry lifecycle", () => {
-    setShareDiagnostics(true);
-    expect(writeSettingMock).toHaveBeenCalledWith("shareDiagnostics", true);
-
+    // Disable: no close()/re-init churn; client stays installed, events dropped.
+    const closeMock = mock(() => Promise.resolve(true));
+    sentryClient = { getOptions: () => ({ enabled: true }), close: closeMock };
     setShareDiagnostics(false);
     expect(writeSettingMock).toHaveBeenCalledWith("shareDiagnostics", false);
+    expect(closeMock).not.toHaveBeenCalled();
+    expect(setClientMock).not.toHaveBeenCalled();
+    expect(beforeSend?.({ message: "boom" })).toBeNull();
+
+    // Re-enable: still no second init — only the flag flips back on.
+    settingChangeCb?.(true);
+    expect(initMock).toHaveBeenCalledTimes(1);
+    const okAgain = { message: "ok-again" };
+    expect(beforeSend?.(okAgain)).toBe(okAgain);
   });
 });

--- a/clients/macos/src/main/sentry.ts
+++ b/clients/macos/src/main/sentry.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/node";
 import { app } from "electron";
 
-import { onSettingChange, readSetting, writeSetting } from "./settings";
+import { onSettingChange, writeSetting } from "./settings";
 
 declare const __VELLUM_BUILD_SHA__: string;
 declare const __VELLUM_ENVIRONMENT__: string;
@@ -79,48 +79,43 @@ function tryClose(): void {
   Sentry.getCurrentScope().setClient(undefined);
 }
 
-/**
- * Read consent from electron-store. Strict opt-in: absent or false → OFF.
- */
-function readConsent(): boolean {
-  return readSetting("shareDiagnostics") === true;
+let cachedOptions: Sentry.NodeOptions | null = null;
+
+function applyConsent(enabled: boolean): void {
+  if (!cachedOptions) return;
+  if (enabled) {
+    tryInit(cachedOptions);
+  } else {
+    tryClose();
+  }
 }
 
 /**
- * Initialize Sentry for the Electron main process, gated on the user's
- * Share Diagnostics consent stored in electron-store. The renderer syncs
- * its localStorage `device:share_diagnostics` value to main via the
- * `vellum:diagnostics:setShareDiagnostics` IPC channel.
- *
- * Strict opt-in semantics (matching the renderer's `sentry-control.ts`):
- *   - stored `true`  → Sentry ON  (explicit consent)
- *   - stored `false` → Sentry OFF (explicit opt-out)
- *   - absent         → Sentry OFF (no consent on record yet)
- *
- * Also installs an electron-store watcher so flipping the toggle
- * mid-session immediately enables/disables Sentry without restart.
+ * Prepare main-process Sentry consent gating, starting fail-closed: Sentry is
+ * NOT initialized from the persisted `shareDiagnostics` value, because main
+ * boots before any renderer exists and the persisted value can be a stale
+ * opt-in from a prior signed-in run. The renderer owns the live-session gate
+ * and pushes the effective consent over the
+ * `vellum:diagnostics:setShareDiagnostics` IPC channel; until it does, main
+ * stays silent. An electron-store watcher keeps Sentry in sync with later
+ * mid-session toggles.
  */
 export function initSentryMain(): void {
-  const options = resolveOptions();
-  if (!options) return;
-
-  if (readConsent()) {
-    tryInit(options);
-  }
+  cachedOptions = resolveOptions();
+  if (!cachedOptions) return;
 
   onSettingChange("shareDiagnostics", (newValue) => {
-    if (newValue === true) {
-      tryInit(options);
-    } else {
-      tryClose();
-    }
+    applyConsent(newValue === true);
   });
 }
 
 /**
- * Update the persisted diagnostics consent from the renderer's IPC call.
- * Triggers the `onSettingChange` watcher which handles Sentry lifecycle.
+ * Apply the renderer's effective (session-gated) diagnostics consent: persist
+ * it and enable/disable Sentry immediately. Applied directly rather than via
+ * the change watcher so an unchanged persisted value still enforces the gate
+ * (electron-store's `onDidChange` does not fire when the value is unchanged).
  */
 export function setShareDiagnostics(enabled: boolean): void {
   writeSetting("shareDiagnostics", enabled);
+  applyConsent(enabled);
 }

--- a/clients/macos/src/main/sentry.ts
+++ b/clients/macos/src/main/sentry.ts
@@ -1,15 +1,15 @@
 import * as Sentry from "@sentry/electron/main";
 import { app } from "electron";
 
-import { onSettingChange, readSetting, writeSetting } from "./settings";
+import { onSettingChange, writeSetting } from "./settings";
 
 declare const __VELLUM_BUILD_SHA__: string;
 declare const __VELLUM_ENVIRONMENT__: string;
 declare const __SENTRY_DSN_MACOS__: string;
 
 /**
- * Resolved Sentry init options — cached once so re-init after consent
- * change doesn't need to re-derive them.
+ * Resolved Sentry init options — cached once so the first consented enable
+ * doesn't need to re-derive them.
  *
  * The default `@sentry/electron/main` integrations enable Crashpad minidump
  * capture (`sentryMinidumpIntegration`) and renderer/child process crash
@@ -39,62 +39,67 @@ function applyTags(): void {
   Sentry.setTag("packaged", String(app.isPackaged));
 }
 
-function tryInit(options: Sentry.ElectronMainOptions): void {
-  const existing = Sentry.getClient();
-  if (existing && existing.getOptions().enabled !== false) return;
-  Sentry.init({ ...options, enabled: true });
-  applyTags();
-}
-
-function tryClose(): void {
-  const client = Sentry.getClient();
-  if (!client) return;
-  void client.close(2000);
-  Sentry.getCurrentScope().setClient(undefined);
-}
+let cachedOptions: Sentry.ElectronMainOptions | null = null;
+// Whether the SDK has been initialized this process. `@sentry/electron/main`
+// init() starts Crashpad and installs crash listeners that close() does NOT
+// remove, so an off→on→off churn of init/close would leak stale listeners.
+// We init AT MOST ONCE (lazily, on first consent) and thereafter gate event
+// delivery via the `enabled` flag below rather than tearing the client down.
+let initialized = false;
+// Live consent flag consulted by `beforeSend`: JS events are dropped while
+// false. Native Crashpad minidumps still flush once the SDK is initialized;
+// deeper pre-consent minidump gating is handled by a later PR (PR 10). This
+// PR fixes the stale-listener churn and keeps JS event delivery consent-gated.
+let enabled = false;
 
 /**
- * Read consent from electron-store. Strict opt-in: absent or false → OFF.
+ * Initialize the SDK exactly once, on the first time consent is enabled. After
+ * this, toggling consent only flips the `enabled` flag — the client is never
+ * closed or re-inited, so crash listeners are installed at most once.
  */
-function readConsent(): boolean {
-  return readSetting("shareDiagnostics") === true;
+function ensureInitialized(): void {
+  if (initialized || !cachedOptions) return;
+  Sentry.init({
+    ...cachedOptions,
+    enabled: true,
+    beforeSend: (event) => (enabled ? event : null),
+  });
+  applyTags();
+  initialized = true;
+}
+
+function applyConsent(consented: boolean): void {
+  if (!cachedOptions) return;
+  enabled = consented;
+  if (consented) ensureInitialized();
 }
 
 /**
- * Initialize Sentry for the Electron main process, gated on the user's
- * Share Diagnostics consent stored in electron-store. The renderer syncs an
- * effective diagnostics gate (preference && version-current) to main via the
- * `vellum:diagnostics:setShareDiagnostics` IPC channel.
- *
- * Strict opt-in semantics (matching the renderer's `sentry-control.ts`):
- *   - stored `true`  → Sentry ON  (explicit consent)
- *   - stored `false` → Sentry OFF (explicit opt-out)
- *   - absent         → Sentry OFF (no consent on record yet)
- *
- * Also installs an electron-store watcher so flipping the toggle
- * mid-session immediately enables/disables Sentry without restart.
+ * Prepare main-process Sentry consent gating, starting fail-closed: Sentry is
+ * NOT initialized from the persisted `shareDiagnostics` value, because main
+ * boots before any renderer exists and the persisted value can be a stale
+ * opt-in from a prior signed-in run. The renderer owns the live-session gate
+ * and pushes the effective consent over the
+ * `vellum:diagnostics:setShareDiagnostics` IPC channel; until it does, main
+ * stays silent. An electron-store watcher keeps Sentry in sync with later
+ * mid-session toggles.
  */
 export function initSentryMain(): void {
-  const options = resolveOptions();
-  if (!options) return;
-
-  if (readConsent()) {
-    tryInit(options);
-  }
+  cachedOptions = resolveOptions();
+  if (!cachedOptions) return;
 
   onSettingChange("shareDiagnostics", (newValue) => {
-    if (newValue === true) {
-      tryInit(options);
-    } else {
-      tryClose();
-    }
+    applyConsent(newValue === true);
   });
 }
 
 /**
- * Update the persisted diagnostics consent from the renderer's IPC call.
- * Triggers the `onSettingChange` watcher which handles Sentry lifecycle.
+ * Apply the renderer's effective (session-gated) diagnostics consent: persist
+ * it and apply consent immediately. Applied directly rather than via the change
+ * watcher so an unchanged persisted value still enforces the gate (electron-
+ * store's `onDidChange` does not fire when the value is unchanged).
  */
-export function setShareDiagnostics(enabled: boolean): void {
-  writeSetting("shareDiagnostics", enabled);
+export function setShareDiagnostics(enabledValue: boolean): void {
+  writeSetting("shareDiagnostics", enabledValue);
+  applyConsent(enabledValue);
 }

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
@@ -248,6 +248,7 @@ export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
           url={effectiveUrl}
           filename={attachment.filename}
           mimeType={attachment.mimeType}
+          sizeBytes={attachment.sizeBytes}
         />
       );
     }

--- a/clients/web/src/domains/chat/components/chat-attachments/text-preview.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/text-preview.test.tsx
@@ -1,7 +1,20 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, waitFor } from "@testing-library/react";
 
-import { TextPreviewBody } from "@/domains/chat/components/chat-attachments/text-preview";
+import {
+  MAX_TEXT_PREVIEW_BYTES,
+  TextPreview,
+  TextPreviewBody,
+} from "@/domains/chat/components/chat-attachments/text-preview";
+
+/** Build a base64 `data:` URI the way `toDisplayAttachments` does. */
+function dataUri(mimeType: string, text: string): string {
+  let binary = "";
+  for (const byte of new TextEncoder().encode(text)) {
+    binary += String.fromCharCode(byte);
+  }
+  return `data:${mimeType};base64,${btoa(binary)}`;
+}
 
 afterEach(() => {
   cleanup();
@@ -50,5 +63,35 @@ describe("TextPreviewBody", () => {
     expect(pre?.textContent).toBe(source);
     // Source must not be interpreted as markdown.
     expect(container.querySelector("h1")).toBeNull();
+  });
+});
+
+describe("TextPreview", () => {
+  test("decodes an inline data: URI in-process and renders it", async () => {
+    const { container } = render(
+      <TextPreview
+        url={dataUri("text/markdown", "# Decoded\n\nfrom a data URI")}
+        filename="notes.md"
+        mimeType="text/markdown"
+        sizeBytes={128}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(container.querySelector("h1")?.textContent).toBe("Decoded"),
+    );
+  });
+
+  test("shows the too-large fallback when the known size exceeds the cap", async () => {
+    const { findByText } = render(
+      <TextPreview
+        url="data:text/plain;base64,AAAA"
+        filename="big.txt"
+        mimeType="text/plain"
+        sizeBytes={MAX_TEXT_PREVIEW_BYTES + 1}
+      />,
+    );
+
+    expect(await findByText("File too large to preview inline.")).toBeDefined();
   });
 });

--- a/clients/web/src/domains/chat/components/chat-attachments/text-preview.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/text-preview.tsx
@@ -1,8 +1,9 @@
-import { useQuery } from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
 
 import { FileMarkdown, isMarkdown } from "@/components/file-markdown";
 import { PreviewMessageCard } from "@/domains/chat/components/chat-attachments/preview-message-card";
+import { dataUriToUint8Array } from "@/domains/chat/components/chat-attachments/utils";
 import { captureError } from "@/lib/sentry/capture-error";
 
 /**
@@ -16,12 +17,39 @@ export const MAX_TEXT_PREVIEW_BYTES = 200 * 1024;
  *  outcome shown to the user, not a fault worth reporting to telemetry. */
 class TextTooLargeError extends Error {}
 
-async function loadText(url: string): Promise<string> {
-  const response = await fetch(url);
+/**
+ * Read an attachment's text. By the time the preview renders, `url` is always a
+ * *local* handle, so this never touches the network: inline attachments arrive
+ * as a base64 `data:` URI (the bytes are already in memory — decode them
+ * in-process, like {@link PdfPreview}, rather than round-tripping through
+ * `fetch`), and daemon-backed attachments arrive as a `blob:` object URL the
+ * modal already fetched.
+ */
+async function loadText(
+  url: string,
+  sizeBytes: number,
+  signal: AbortSignal,
+): Promise<string> {
+  // The attachment's size is already known, so gate on it directly rather than
+  // measuring the content — this also skips the read entirely for a file we
+  // already know is too big to preview inline.
+  if (sizeBytes > MAX_TEXT_PREVIEW_BYTES) {
+    throw new TextTooLargeError();
+  }
+
+  if (url.startsWith("data:")) {
+    const bytes = dataUriToUint8Array(url);
+    if (!bytes) throw new Error("Malformed data URI");
+    return new TextDecoder().decode(bytes);
+  }
+
+  const response = await fetch(url, { signal });
   if (!response.ok) {
     throw new Error(`Failed to load file: ${response.status}`);
   }
   const blob = await response.blob();
+  // `sizeBytes` is optional upstream for file-backed attachments, so re-check
+  // the fetched blob's exact size as the authoritative backstop.
   if (blob.size > MAX_TEXT_PREVIEW_BYTES) {
     throw new TextTooLargeError();
   }
@@ -32,7 +60,13 @@ interface TextPreviewProps {
   url: string;
   filename: string;
   mimeType: string;
+  sizeBytes: number;
 }
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "error"; tooLarge: boolean }
+  | { status: "ready"; text: string };
 
 /**
  * Inline preview for a text attachment inside the full-screen preview modal.
@@ -40,34 +74,48 @@ interface TextPreviewProps {
  * renders as monospace source. Content sits on a themed surface so it stays
  * legible on the modal's dark backdrop across light, dark, and velvet themes.
  */
-export function TextPreview({ url, filename, mimeType }: TextPreviewProps) {
-  const { data, isLoading, error } = useQuery({
-    queryKey: ["attachment-text-preview", url],
-    queryFn: async () => {
-      try {
-        return await loadText(url);
-      } catch (err) {
-        if (!(err instanceof TextTooLargeError)) {
+export function TextPreview({
+  url,
+  filename,
+  mimeType,
+  sizeBytes,
+}: TextPreviewProps) {
+  const [state, setState] = useState<LoadState>({ status: "loading" });
+
+  // Read the local URL straight into component state. This is deliberately not
+  // a React Query fetch: the bytes are already in the browser (an inline
+  // `data:` URI, or a `blob:` URL the modal already fetched), so there is no
+  // server state to cache/revalidate — caching it only forced a content-derived
+  // query key that can't be both short and collision-free. Mirrors PdfPreview.
+  useEffect(() => {
+    const controller = new AbortController();
+    setState({ status: "loading" });
+
+    loadText(url, sizeBytes, controller.signal)
+      .then((text) => {
+        if (!controller.signal.aborted) setState({ status: "ready", text });
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return;
+        const tooLarge = err instanceof TextTooLargeError;
+        if (!tooLarge) {
           captureError(err, {
             context: "attachment-text-preview",
             bestEffort: true,
           });
         }
-        throw err;
-      }
-    },
-    // Attachment bytes are immutable for a given URL, so a successful read
-    // never needs revalidating.
-    staleTime: Infinity,
-    retry: false,
-  });
+        setState({ status: "error", tooLarge });
+      });
+
+    return () => controller.abort();
+  }, [url, sizeBytes]);
 
   const handleDownload = async () => {
     const { saveFile } = await import("@/runtime/native-file");
     await saveFile(url, filename);
   };
 
-  if (isLoading) {
+  if (state.status === "loading") {
     return (
       <div className="flex items-center justify-center py-24">
         <Loader2 className="h-8 w-8 animate-spin text-white/70" />
@@ -75,11 +123,11 @@ export function TextPreview({ url, filename, mimeType }: TextPreviewProps) {
     );
   }
 
-  if (error) {
+  if (state.status === "error") {
     return (
       <PreviewMessageCard
         message={
-          error instanceof TextTooLargeError
+          state.tooLarge
             ? "File too large to preview inline."
             : "Failed to load preview."
         }
@@ -87,10 +135,6 @@ export function TextPreview({ url, filename, mimeType }: TextPreviewProps) {
         onDownload={handleDownload}
       />
     );
-  }
-
-  if (data == null) {
-    return null;
   }
 
   return (
@@ -101,7 +145,7 @@ export function TextPreview({ url, filename, mimeType }: TextPreviewProps) {
         color: "var(--content-default)",
       }}
     >
-      <TextPreviewBody text={data} filename={filename} mimeType={mimeType} />
+      <TextPreviewBody text={state.text} filename={filename} mimeType={mimeType} />
     </div>
   );
 }

--- a/clients/web/src/domains/onboarding/onboarding-store.ts
+++ b/clients/web/src/domains/onboarding/onboarding-store.ts
@@ -17,7 +17,6 @@
 
 import { create } from "zustand";
 
-import { syncDiagnosticsToMain } from "@/runtime/diagnostics";
 import { createSelectors } from "@/utils/create-selectors";
 import {
   getLocalBool,
@@ -75,8 +74,9 @@ const useOnboardingStoreBase = create<OnboardingStore>()((set) => ({
   },
   setShareDiagnostics: (value) => {
     set({ shareDiagnostics: value });
+    // Writing the device key fires the `sentry-control.ts` watcher, which
+    // applies the live-session gate and syncs both Sentry clients.
     setLocalBool(KEY_SHARE_DIAGNOSTICS, value);
-    syncDiagnosticsToMain(value);
   },
   setTosAccepted: (value) => {
     set({ tosAccepted: value });

--- a/clients/web/src/domains/onboarding/onboarding-store.ts
+++ b/clients/web/src/domains/onboarding/onboarding-store.ts
@@ -74,6 +74,10 @@ const useOnboardingStoreBase = create<OnboardingStore>()((set) => ({
   },
   setShareDiagnostics: (value) => {
     set({ shareDiagnostics: value });
+    // Writes only the saved preference. The effective reporting gate
+    // (`device:diagnostics_reporting`) — which actually drives the Sentry
+    // clients via the `sentry-control.ts` watcher — is written separately by
+    // the consent chokepoint (`setDiagnosticsReportingGate`).
     setLocalBool(KEY_SHARE_DIAGNOSTICS, value);
   },
   setTosAccepted: (value) => {

--- a/clients/web/src/domains/settings/pages/privacy-page.tsx
+++ b/clients/web/src/domains/settings/pages/privacy-page.tsx
@@ -10,7 +10,10 @@ import { RiskToleranceSettings } from "@/domains/settings/components/risk-tolera
 import { TrustRules } from "@/domains/settings/components/trust-rules/trust-rules";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
-import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
+import {
+  useAuthStore,
+  useHasConfirmedPlatformSession,
+} from "@/stores/auth-store";
 import {
     getDeviceBool,
     getDeviceSetting,
@@ -42,7 +45,13 @@ export function PrivacyPage() {
   // `AccessConsentSetting` exactly.
   const platformGate = usePlatformGate({ platformHostedOnly: true });
   const channelTrustFloors = useAssistantFeatureFlagStore.use.channelTrustFloors();
-  const hasPlatformSession = useHasPlatformSession();
+  // The Share toggles control telemetry (browser Sentry, daemon analytics) that
+  // only runs with a probe-confirmed live platform session, so gate both the
+  // visibility and the consent write on it — matching `sentry-control.ts`. A
+  // believed offline restore (LUM-2412) is not live, so the toggles hide and a
+  // flip can't stamp version-currency offline.
+  const hasPlatformSession = useHasConfirmedPlatformSession();
+  const showShareConsent = hasPlatformSession;
   const userId = useAuthStore.use.user()?.id ?? null;
   const [shareAnalytics, setShareAnalytics] = useState(
     () => getDeviceBool("shareAnalytics", true),
@@ -80,22 +89,26 @@ export function PrivacyPage() {
       <RiskToleranceSettings />
       <DetailCard title="Privacy">
         <div className="space-y-4">
-          <SettingRow
-            label="Share Analytics"
-            helperText="Send anonymous product usage data."
-            checked={shareAnalytics}
-            onChange={handleAnalyticsToggle}
-            variant="toggle-trailing"
-          />
-          <Divider />
-          <SettingRow
-            label="Share Diagnostics"
-            helperText="Send crash reports and performance metrics."
-            checked={shareDiagnostics}
-            onChange={handleDiagnosticsToggle}
-            variant="toggle-trailing"
-          />
-          <Divider />
+          {showShareConsent && (
+            <>
+              <SettingRow
+                label="Share Analytics"
+                helperText="Send anonymous product usage data."
+                checked={shareAnalytics}
+                onChange={handleAnalyticsToggle}
+                variant="toggle-trailing"
+              />
+              <Divider />
+              <SettingRow
+                label="Share Diagnostics"
+                helperText="Send crash reports and performance metrics."
+                checked={shareDiagnostics}
+                onChange={handleDiagnosticsToggle}
+                variant="toggle-trailing"
+              />
+              <Divider />
+            </>
+          )}
           <AccessConsentSetting />
           {/*
             `AccessConsentSetting` returns null when gated (self-hosted

--- a/clients/web/src/lib/consent/consent-refresh.ts
+++ b/clients/web/src/lib/consent/consent-refresh.ts
@@ -30,9 +30,17 @@ let lastRefreshAt = 0;
  * state unchanged.
  */
 export async function refreshDiagnosticsConsent(): Promise<void> {
-  if (!useAuthStore.getState().user) return;
+  // Capture the authenticated user BEFORE the await so we can detect a
+  // logout/account-switch that races the in-flight fetch.
+  const userIdBefore = useAuthStore.getState().user?.id;
+  if (!userIdBefore) return;
   try {
-    const resolved = resolveServerConsent(await fetchConsent());
+    const consent = await fetchConsent();
+    // The user may have logged out or switched accounts while the fetch was in
+    // flight. Applying a stale response would re-enable reporting after logout
+    // or overwrite the next user's setting, so discard it.
+    if (useAuthStore.getState().user?.id !== userIdBefore) return;
+    const resolved = resolveServerConsent(consent);
     applyResolvedDiagnosticsConsent(
       {
         shareDiagnostics: resolved.shareDiagnostics,

--- a/clients/web/src/lib/consent/diagnostics-consent.test.ts
+++ b/clients/web/src/lib/consent/diagnostics-consent.test.ts
@@ -33,10 +33,15 @@ beforeEach(() => {
   syncDiagnosticsToMain.mockClear();
 });
 
-/** Asserts the effective gate was written (device bool + main sync) with `value`. */
+/**
+ * Asserts the effective gate device bool was written with `value`. The
+ * Electron main mirror is NOT synced from here — the `sentry-control` watcher
+ * pushes the session-composed value on this device-setting change — so the
+ * gate writer must never call `syncDiagnosticsToMain` directly.
+ */
 function expectGate(value: boolean): void {
   expect(setDeviceBool).toHaveBeenCalledWith("diagnosticsReporting", value);
-  expect(syncDiagnosticsToMain).toHaveBeenCalledWith(value);
+  expect(syncDiagnosticsToMain).not.toHaveBeenCalled();
 }
 
 describe("applyResolvedDiagnosticsConsent — saved preference", () => {

--- a/clients/web/src/lib/consent/diagnostics-consent.ts
+++ b/clients/web/src/lib/consent/diagnostics-consent.ts
@@ -25,7 +25,6 @@
  */
 
 import { setDeviceBool } from "@/utils/device-settings";
-import { syncDiagnosticsToMain } from "@/runtime/diagnostics";
 
 export interface ResolvedDiagnosticsConsent {
   /** The server's `share_diagnostics` value; `null` when unknown/absent. */
@@ -37,13 +36,15 @@ export interface ResolvedDiagnosticsConsent {
 }
 
 /**
- * Write the effective Sentry reporting gate: the `diagnosticsReporting` device
- * bool AND the main-process diagnostics sync, both with the same effective
- * value. This is the single writer of the gate.
+ * Write the effective Sentry reporting gate (`diagnosticsReporting` device
+ * bool). The Electron main mirror is NOT synced here: the `sentry-control`
+ * watcher reacts to this device-setting change and pushes the
+ * platform-session-composed value (`diagnosticsConsentGranted()`) to main, so a
+ * device gate that is `true` without a confirmed live session never enables the
+ * main client. Syncing the raw gate here would race that composed write.
  */
 export function setDiagnosticsReportingGate(enabled: boolean): void {
   setDeviceBool("diagnosticsReporting", enabled);
-  syncDiagnosticsToMain(enabled);
 }
 
 /**

--- a/clients/web/src/lib/sentry/flavor-capacitor.ts
+++ b/clients/web/src/lib/sentry/flavor-capacitor.ts
@@ -16,10 +16,10 @@ export const capacitorFlavor: SentryFlavor = {
     Capacitor.init({ ...options, enabled: true }, reactInit);
   },
   close() {
-    const client = Capacitor.getClient();
-    if (!client) return;
-    void client.close(2000);
-    Capacitor.getCurrentScope().setClient(undefined);
+    // Use the Capacitor SDK's own close routine, which shuts down BOTH the JS
+    // client and the native sentry-cocoa SDK. Closing only the JS client would
+    // leave native crash reporting running after an opt-out.
+    return Capacitor.close();
   },
   getClientEnabled() {
     const client = Capacitor.getClient();

--- a/clients/web/src/lib/sentry/sentry-control.test.ts
+++ b/clients/web/src/lib/sentry/sentry-control.test.ts
@@ -4,6 +4,10 @@ import type { BrowserOptions } from "@sentry/react";
 
 import type { SentryFlavor } from "@/lib/sentry/flavor";
 
+// ---------------------------------------------------------------------------
+// Flavor seam — SDK access dispatches through selectSentryFlavor()
+// ---------------------------------------------------------------------------
+
 const initMock = mock((_options: BrowserOptions) => {});
 const closeMock = mock(() => {});
 let clientEnabled = false;
@@ -19,96 +23,241 @@ mock.module("@/lib/sentry/flavor", () => ({
   selectSentryFlavor: selectSentryFlavorMock,
 }));
 
-let consent = false;
+// ---------------------------------------------------------------------------
+// Controllable mock state for the composed gate inputs
+// ---------------------------------------------------------------------------
+
+let deviceDiagnostics = false; // device:diagnostics_reporting (effective gate)
+let platformSession = "absent";
+let restoredOffline = false;
+
 const readNames: string[] = [];
 const watchedNames: string[] = [];
-const watchCallbacks: Array<() => void> = [];
-const unwatchMock = mock(() => {});
+let deviceWatchCallback: (() => void) | null = null;
+let authSubscriber:
+  | ((
+      state: { platformSession: string; platformSessionRestoredOffline: boolean },
+      prev: { platformSession: string; platformSessionRestoredOffline: boolean },
+    ) => void)
+  | null = null;
+
+const syncDiagnosticsToMainMock = mock((_enabled: boolean) => {});
 
 mock.module("@/utils/device-settings", () => ({
   getDeviceBool: (name: string, fallback: boolean) => {
     readNames.push(name);
-    return consent ? true : fallback;
+    return deviceDiagnostics ? true : fallback;
   },
-  watchDeviceSetting: (name: string, callback: () => void) => {
+  watchDeviceSetting: (name: string, cb: () => void) => {
     watchedNames.push(name);
-    watchCallbacks.push(callback);
-    return unwatchMock;
+    deviceWatchCallback = cb;
+    return () => {
+      deviceWatchCallback = null;
+    };
   },
 }));
 
-const { syncSentryClient, installSentryControlListeners } = await import(
-  "@/lib/sentry/sentry-control"
-);
+mock.module("@/runtime/diagnostics", () => ({
+  syncDiagnosticsToMain: syncDiagnosticsToMainMock,
+}));
 
-const options: BrowserOptions = { dsn: "https://public@example.com/1" };
+mock.module("@/stores/auth-store", () => ({
+  useAuthStore: {
+    getState: () => ({
+      platformSession,
+      platformSessionRestoredOffline: restoredOffline,
+    }),
+    subscribe: (cb: typeof authSubscriber) => {
+      authSubscriber = cb;
+      return () => {
+        authSubscriber = null;
+      };
+    },
+  },
+}));
+
+const { syncSentryClient, diagnosticsConsentGranted, installSentryControlListeners } =
+  await import("@/lib/sentry/sentry-control");
+
+const OPTIONS: BrowserOptions = { dsn: "https://public@example.test/1" };
 
 beforeEach(() => {
   initMock.mockClear();
   closeMock.mockClear();
   selectSentryFlavorMock.mockClear();
-  unwatchMock.mockClear();
-  watchCallbacks.length = 0;
+  syncDiagnosticsToMainMock.mockReset();
   readNames.length = 0;
   watchedNames.length = 0;
-  consent = false;
+  deviceWatchCallback = null;
+  authSubscriber = null;
+  deviceDiagnostics = false;
+  platformSession = "absent";
+  restoredOffline = false;
   clientEnabled = false;
 });
 
-describe("syncSentryClient", () => {
-  test("dispatches through the selected flavor", () => {
-    consent = true;
-    syncSentryClient(options);
-    expect(selectSentryFlavorMock).toHaveBeenCalled();
-  });
-
-  test("gates off the effective diagnosticsReporting key, not the preference", () => {
-    syncSentryClient(options);
+describe("diagnosticsConsentGranted (composed gate)", () => {
+  test("reads the effective diagnosticsReporting key, not the raw preference", () => {
+    // Use a confirmed-live session so the gate reaches the device-key read
+    // (it short-circuits to false before reading when no session is live).
+    platformSession = "present";
+    restoredOffline = false;
+    diagnosticsConsentGranted();
     expect(readNames).toContain("diagnosticsReporting");
     expect(readNames).not.toContain("shareDiagnostics");
   });
 
+  test("false without a confirmed live platform session even when the gate is on", () => {
+    deviceDiagnostics = true;
+    platformSession = "absent";
+    expect(diagnosticsConsentGranted()).toBe(false);
+  });
+
+  test("false for a believed offline restore even when present + gate on", () => {
+    deviceDiagnostics = true;
+    platformSession = "present";
+    restoredOffline = true;
+    expect(diagnosticsConsentGranted()).toBe(false);
+  });
+
+  test("true only with a confirmed-live session AND the reporting gate on", () => {
+    platformSession = "present";
+    restoredOffline = false;
+    deviceDiagnostics = true;
+    expect(diagnosticsConsentGranted()).toBe(true);
+    deviceDiagnostics = false;
+    expect(diagnosticsConsentGranted()).toBe(false);
+  });
+});
+
+describe("syncSentryClient", () => {
+  test("dispatches through the selected flavor", () => {
+    deviceDiagnostics = true;
+    platformSession = "present";
+    syncSentryClient(OPTIONS);
+    expect(selectSentryFlavorMock).toHaveBeenCalled();
+  });
+
   test("no-ops when dsn is absent (never touches the flavor)", () => {
-    consent = true;
+    deviceDiagnostics = true;
+    platformSession = "present";
     syncSentryClient({});
     expect(initMock).not.toHaveBeenCalled();
     expect(closeMock).not.toHaveBeenCalled();
   });
 
-  test("inits the flavor when consented and no client is enabled", () => {
-    consent = true;
+  test("confirmed-live session + gate on: inits the flavor when no client is enabled", () => {
+    deviceDiagnostics = true;
+    platformSession = "present";
     clientEnabled = false;
-    syncSentryClient(options);
+    syncSentryClient(OPTIONS);
     expect(initMock).toHaveBeenCalledTimes(1);
-    expect(initMock.mock.calls[0]![0]).toBe(options);
+    expect(initMock.mock.calls[0]![0]).toBe(OPTIONS);
     expect(closeMock).not.toHaveBeenCalled();
   });
 
-  test("does not re-init when consented and a client is already enabled", () => {
-    consent = true;
+  test("does not re-init when a client is already enabled", () => {
+    deviceDiagnostics = true;
+    platformSession = "present";
     clientEnabled = true;
-    syncSentryClient(options);
+    syncSentryClient(OPTIONS);
     expect(initMock).not.toHaveBeenCalled();
   });
 
-  test("closes the flavor when consent is absent", () => {
-    consent = false;
-    syncSentryClient(options);
-    expect(closeMock).toHaveBeenCalledTimes(1);
+  test("no live platform session: closes (fail-closed) even when the gate is on", () => {
+    deviceDiagnostics = true;
+    platformSession = "absent";
+    syncSentryClient(OPTIONS);
     expect(initMock).not.toHaveBeenCalled();
+    expect(closeMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("live session + gate off: closes the flavor", () => {
+    deviceDiagnostics = false;
+    platformSession = "present";
+    syncSentryClient(OPTIONS);
+    expect(initMock).not.toHaveBeenCalled();
+    expect(closeMock).toHaveBeenCalledTimes(1);
   });
 });
 
-describe("installSentryControlListeners", () => {
-  test("re-syncs through the flavor when the toggle changes", () => {
-    const cleanup = installSentryControlListeners(options);
-    expect(watchCallbacks).toHaveLength(1);
+describe("installSentryControlListeners drives both Sentry clients", () => {
+  test("watches the diagnosticsReporting key and re-syncs through the flavor", () => {
+    platformSession = "present";
+    const stop = installSentryControlListeners(OPTIONS);
     expect(watchedNames).toEqual(["diagnosticsReporting"]);
 
-    consent = true;
-    watchCallbacks[0]!();
+    deviceDiagnostics = true;
+    deviceWatchCallback?.();
     expect(initMock).toHaveBeenCalledTimes(1);
 
-    expect(cleanup).toBe(unwatchMock);
+    stop();
+  });
+
+  test("device gate change syncs main with the session-gated value", () => {
+    platformSession = "present";
+    deviceDiagnostics = true;
+    const stop = installSentryControlListeners(OPTIONS);
+
+    syncDiagnosticsToMainMock.mockReset();
+    deviceWatchCallback?.();
+    expect(syncDiagnosticsToMainMock).toHaveBeenCalledWith(true);
+
+    // Offline, the same gate value tells main to disable.
+    platformSession = "absent";
+    syncDiagnosticsToMainMock.mockReset();
+    deviceWatchCallback?.();
+    expect(syncDiagnosticsToMainMock).toHaveBeenCalledWith(false);
+
+    stop();
+  });
+
+  test("a platform-session transition re-syncs both clients", () => {
+    deviceDiagnostics = true;
+    platformSession = "absent";
+    const stop = installSentryControlListeners(OPTIONS);
+
+    initMock.mockClear();
+    syncDiagnosticsToMainMock.mockReset();
+    platformSession = "present";
+    authSubscriber?.(
+      { platformSession: "present", platformSessionRestoredOffline: false },
+      { platformSession: "absent", platformSessionRestoredOffline: false },
+    );
+
+    expect(initMock).toHaveBeenCalled();
+    expect(syncDiagnosticsToMainMock).toHaveBeenCalledWith(true);
+
+    stop();
+  });
+
+  test("a restored-offline → confirmed transition (present unchanged) re-syncs", () => {
+    deviceDiagnostics = true;
+    platformSession = "present";
+    restoredOffline = true; // believed offline restore: telemetry off
+    const stop = installSentryControlListeners(OPTIONS);
+
+    initMock.mockClear();
+    syncDiagnosticsToMainMock.mockReset();
+    // A live probe confirms the session: present is unchanged, only the marker flips.
+    restoredOffline = false;
+    authSubscriber?.(
+      { platformSession: "present", platformSessionRestoredOffline: false },
+      { platformSession: "present", platformSessionRestoredOffline: true },
+    );
+
+    expect(initMock).toHaveBeenCalled();
+    expect(syncDiagnosticsToMainMock).toHaveBeenCalledWith(true);
+
+    stop();
+  });
+
+  test("cleanup removes both the device watch and the auth subscription", () => {
+    const stop = installSentryControlListeners(OPTIONS);
+    expect(deviceWatchCallback).not.toBeNull();
+    expect(authSubscriber).not.toBeNull();
+    stop();
+    expect(deviceWatchCallback).toBeNull();
+    expect(authSubscriber).toBeNull();
   });
 });

--- a/clients/web/src/lib/sentry/sentry-control.test.ts
+++ b/clients/web/src/lib/sentry/sentry-control.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Controllable mock state
+// ---------------------------------------------------------------------------
+
+let deviceDiagnostics = false;
+let platformSession = "absent";
+let restoredOffline = false;
+let mockClient:
+  | { getOptions: () => { enabled?: boolean }; close: () => Promise<boolean> }
+  | undefined;
+let deviceWatchCallback: (() => void) | null = null;
+let authSubscriber:
+  | ((
+      state: { platformSession: string; platformSessionRestoredOffline: boolean },
+      prev: { platformSession: string; platformSessionRestoredOffline: boolean },
+    ) => void)
+  | null = null;
+
+const initMock = mock((_opts: Record<string, unknown>) => {});
+const setClientMock = mock((_client: unknown) => {});
+const syncDiagnosticsToMainMock = mock((_enabled: boolean) => {});
+
+mock.module("@sentry/react", () => ({
+  init: initMock,
+  getClient: () => mockClient,
+  getCurrentScope: () => ({ setClient: setClientMock }),
+}));
+
+mock.module("@/utils/device-settings", () => ({
+  getDeviceBool: (_key: string, _dflt: boolean) => deviceDiagnostics,
+  watchDeviceSetting: (_name: string, cb: () => void) => {
+    deviceWatchCallback = cb;
+    return () => {
+      deviceWatchCallback = null;
+    };
+  },
+}));
+
+mock.module("@/runtime/diagnostics", () => ({
+  syncDiagnosticsToMain: syncDiagnosticsToMainMock,
+}));
+
+mock.module("@/stores/auth-store", () => ({
+  useAuthStore: {
+    getState: () => ({
+      platformSession,
+      platformSessionRestoredOffline: restoredOffline,
+    }),
+    subscribe: (cb: typeof authSubscriber) => {
+      authSubscriber = cb;
+      return () => {
+        authSubscriber = null;
+      };
+    },
+  },
+}));
+
+const { syncSentryClient, diagnosticsConsentGranted, installSentryControlListeners } =
+  await import("@/lib/sentry/sentry-control");
+
+const OPTIONS = { dsn: "https://public@example.test/1" };
+
+beforeEach(() => {
+  initMock.mockReset();
+  setClientMock.mockReset();
+  syncDiagnosticsToMainMock.mockReset();
+  mockClient = undefined;
+  deviceDiagnostics = false;
+  platformSession = "absent";
+  restoredOffline = false;
+  deviceWatchCallback = null;
+  authSubscriber = null;
+});
+
+describe("diagnosticsConsentGranted", () => {
+  test("false without a live platform session even when the toggle is on", () => {
+    deviceDiagnostics = true;
+    platformSession = "absent";
+    expect(diagnosticsConsentGranted()).toBe(false);
+  });
+
+  test("false for a believed offline restore even when present + toggle on", () => {
+    deviceDiagnostics = true;
+    platformSession = "present";
+    restoredOffline = true;
+    expect(diagnosticsConsentGranted()).toBe(false);
+  });
+
+  test("true only with a confirmed-live session and the toggle on", () => {
+    platformSession = "present";
+    restoredOffline = false;
+    deviceDiagnostics = true;
+    expect(diagnosticsConsentGranted()).toBe(true);
+    deviceDiagnostics = false;
+    expect(diagnosticsConsentGranted()).toBe(false);
+  });
+});
+
+describe("syncSentryClient consent gate", () => {
+  test("no live platform session: does not init even when the device toggle is on", () => {
+    deviceDiagnostics = true;
+    platformSession = "absent";
+    syncSentryClient(OPTIONS);
+    expect(initMock).not.toHaveBeenCalled();
+  });
+
+  test("confirmed-live session + toggle on: inits the client enabled", () => {
+    deviceDiagnostics = true;
+    platformSession = "present";
+    syncSentryClient(OPTIONS);
+    expect(initMock).toHaveBeenCalledTimes(1);
+    expect(initMock.mock.calls[0][0]).toMatchObject({ enabled: true });
+  });
+
+  test("live session + toggle off: closes a running client", () => {
+    deviceDiagnostics = false;
+    platformSession = "present";
+    const closeMock = mock(() => Promise.resolve(true));
+    mockClient = { getOptions: () => ({ enabled: true }), close: closeMock };
+    syncSentryClient(OPTIONS);
+    expect(initMock).not.toHaveBeenCalled();
+    expect(closeMock).toHaveBeenCalled();
+    expect(setClientMock).toHaveBeenCalledWith(undefined);
+  });
+
+  test("session lost while toggle on: closes the client (fail-closed offline)", () => {
+    deviceDiagnostics = true;
+    platformSession = "absent";
+    const closeMock = mock(() => Promise.resolve(true));
+    mockClient = { getOptions: () => ({ enabled: true }), close: closeMock };
+    syncSentryClient(OPTIONS);
+    expect(initMock).not.toHaveBeenCalled();
+    expect(closeMock).toHaveBeenCalled();
+  });
+});
+
+describe("installSentryControlListeners drives the Electron main process", () => {
+  test("device toggle change syncs main with the session-gated value", () => {
+    platformSession = "present";
+    deviceDiagnostics = true;
+    const stop = installSentryControlListeners(OPTIONS);
+
+    syncDiagnosticsToMainMock.mockReset();
+    deviceWatchCallback?.();
+    expect(syncDiagnosticsToMainMock).toHaveBeenCalledWith(true);
+
+    // Offline, the same toggle value tells main to disable.
+    platformSession = "absent";
+    syncDiagnosticsToMainMock.mockReset();
+    deviceWatchCallback?.();
+    expect(syncDiagnosticsToMainMock).toHaveBeenCalledWith(false);
+
+    stop();
+  });
+
+  test("a platform-session transition re-syncs both clients", () => {
+    deviceDiagnostics = true;
+    platformSession = "absent";
+    const stop = installSentryControlListeners(OPTIONS);
+
+    initMock.mockReset();
+    syncDiagnosticsToMainMock.mockReset();
+    platformSession = "present";
+    authSubscriber?.(
+      { platformSession: "present", platformSessionRestoredOffline: false },
+      { platformSession: "absent", platformSessionRestoredOffline: false },
+    );
+
+    expect(initMock).toHaveBeenCalled();
+    expect(syncDiagnosticsToMainMock).toHaveBeenCalledWith(true);
+
+    stop();
+  });
+
+  test("a restored-offline → confirmed transition (present unchanged) re-syncs", () => {
+    deviceDiagnostics = true;
+    platformSession = "present";
+    restoredOffline = true; // believed offline restore: telemetry off
+    const stop = installSentryControlListeners(OPTIONS);
+
+    initMock.mockReset();
+    syncDiagnosticsToMainMock.mockReset();
+    // A live probe confirms the session: present is unchanged, only the marker flips.
+    restoredOffline = false;
+    authSubscriber?.(
+      { platformSession: "present", platformSessionRestoredOffline: false },
+      { platformSession: "present", platformSessionRestoredOffline: true },
+    );
+
+    expect(initMock).toHaveBeenCalled();
+    expect(syncDiagnosticsToMainMock).toHaveBeenCalledWith(true);
+
+    stop();
+  });
+});

--- a/clients/web/src/lib/sentry/sentry-control.ts
+++ b/clients/web/src/lib/sentry/sentry-control.ts
@@ -2,17 +2,27 @@ import type { BrowserOptions } from "@sentry/react";
 
 import { selectSentryFlavor } from "@/lib/sentry/flavor";
 import { getDeviceBool, watchDeviceSetting } from "@/utils/device-settings";
+import { syncDiagnosticsToMain } from "@/runtime/diagnostics";
+import { useAuthStore } from "@/stores/auth-store";
+import { isConfirmedPlatformSession } from "@/stores/session-status";
 
 /**
- * Gates the browser-side Sentry client on the effective diagnostics-reporting
- * gate (`device:diagnostics_reporting`), matching the macOS app's behavior.
+ * Gates the browser-side Sentry client on BOTH the effective diagnostics-
+ * reporting gate (`device:diagnostics_reporting`) AND a probe-confirmed live
+ * platform session.
  *
- * The gate is the saved Share Diagnostics preference AND a current privacy-
- * consent version, so a stale-version record stops reporting until re-accept
- * without losing the saved opt-in. It is written by the consent-resolution
- * paths (`setDiagnosticsReportingGate`).
+ * The reporting gate is the saved Share Diagnostics preference AND a current
+ * privacy-consent version, so a stale-version record stops reporting until
+ * re-accept without losing the saved opt-in. It is written by the consent-
+ * resolution paths (`setDiagnosticsReportingGate`).
  *
- * Strict opt-in semantics:
+ * Diagnostics are recorded against a platform account, so an offline /
+ * self-hosted client — including a believed offline restore (LUM-2412) that no
+ * live probe has revalidated — stays fail-closed regardless of the device
+ * gate, matching the daemon's consent posture. The same composed gate drives
+ * the browser client and, via `syncDiagnosticsToMain`, the Electron main client.
+ *
+ * Strict opt-in semantics for the reporting gate (when a session is live):
  *   - stored "true"  → Sentry ON  (current consent)
  *   - stored "false" → Sentry OFF (opt-out or stale version)
  *   - absent         → Sentry OFF (no consent on record yet)
@@ -23,7 +33,18 @@ import { getDeviceBool, watchDeviceSetting } from "@/utils/device-settings";
  * Reference: https://docs.sentry.io/platforms/javascript/guides/react/configuration/options/
  */
 
-function readConsent(): boolean {
+/**
+ * The composed diagnostics gate: a probe-confirmed live platform session AND
+ * the effective diagnostics-reporting gate (preference && version-current).
+ */
+export function diagnosticsConsentGranted(): boolean {
+  const { platformSession, platformSessionRestoredOffline } =
+    useAuthStore.getState();
+  if (
+    !isConfirmedPlatformSession(platformSession, platformSessionRestoredOffline)
+  ) {
+    return false;
+  }
   return getDeviceBool("diagnosticsReporting", false);
 }
 
@@ -44,7 +65,7 @@ function tryClose(): void {
  */
 export function syncSentryClient(options: BrowserOptions): void {
   if (!options.dsn) return;
-  if (readConsent()) {
+  if (diagnosticsConsentGranted()) {
     tryInit(options);
   } else {
     tryClose();
@@ -52,17 +73,33 @@ export function syncSentryClient(options: BrowserOptions): void {
 }
 
 /**
- * Install listeners so the Sentry client turns on/off whenever the effective
- * reporting gate changes — covering cross-tab writes (via the native `storage`
- * event) and same-tab writes (via the custom event dispatched by
- * `setLocalSetting`).
+ * Install listeners so both Sentry clients (browser + Electron main) re-apply
+ * the composed gate whenever an input changes: the effective reporting gate
+ * (`device:diagnostics_reporting`, cross-tab via the native `storage` event,
+ * same-tab via the custom event from `setLocalSetting`) or the platform session
+ * transitioning in/out of a confirmed-live state.
  *
  * Returns a cleanup function that removes both listeners.
  */
 export function installSentryControlListeners(
   options: BrowserOptions,
 ): () => void {
-  return watchDeviceSetting("diagnosticsReporting", () => {
+  const sync = () => {
     syncSentryClient(options);
+    syncDiagnosticsToMain(diagnosticsConsentGranted());
+  };
+  const stopDeviceWatch = watchDeviceSetting("diagnosticsReporting", sync);
+  const stopSessionWatch = useAuthStore.subscribe((state, prevState) => {
+    if (
+      state.platformSession !== prevState.platformSession ||
+      state.platformSessionRestoredOffline !==
+        prevState.platformSessionRestoredOffline
+    ) {
+      sync();
+    }
   });
+  return () => {
+    stopDeviceWatch();
+    stopSessionWatch();
+  };
 }

--- a/clients/web/src/lib/sentry/sentry-control.ts
+++ b/clients/web/src/lib/sentry/sentry-control.ts
@@ -1,12 +1,20 @@
 import * as Sentry from "@sentry/react";
 
 import { getDeviceBool, watchDeviceSetting } from "@/utils/device-settings";
+import { syncDiagnosticsToMain } from "@/runtime/diagnostics";
+import { useAuthStore } from "@/stores/auth-store";
+import { isConfirmedPlatformSession } from "@/stores/session-status";
 
 /**
- * Gates the browser-side Sentry client on the user's Share Diagnostics
- * toggle (`device:share_diagnostics`), matching the macOS app's behavior.
+ * Gates Sentry on BOTH the user's Share Diagnostics toggle
+ * (`device:share_diagnostics`) AND a probe-confirmed live platform session.
+ * Diagnostics are recorded against a platform account, so an offline /
+ * self-hosted client — including a believed offline restore (LUM-2412) that no
+ * live probe has revalidated — stays fail-closed regardless of the device
+ * toggle, matching the daemon's consent posture. The same gate drives the
+ * browser client and, via `syncDiagnosticsToMain`, the Electron main client.
  *
- * Strict opt-in semantics:
+ * Strict opt-in semantics for the device toggle (when a session is live):
  *   - stored "true"  → Sentry ON  (explicit consent)
  *   - stored "false" → Sentry OFF (explicit opt-out)
  *   - absent         → Sentry OFF (no consent on record yet)
@@ -14,7 +22,12 @@ import { getDeviceBool, watchDeviceSetting } from "@/utils/device-settings";
  * Reference: https://docs.sentry.io/platforms/javascript/guides/react/configuration/options/
  */
 
-function readConsent(): boolean {
+export function diagnosticsConsentGranted(): boolean {
+  const { platformSession, platformSessionRestoredOffline } =
+    useAuthStore.getState();
+  if (!isConfirmedPlatformSession(platformSession, platformSessionRestoredOffline)) {
+    return false;
+  }
   return getDeviceBool("shareDiagnostics", false);
 }
 
@@ -38,7 +51,7 @@ function tryClose(): void {
  */
 export function syncSentryClient(options: Sentry.BrowserOptions): void {
   if (!options.dsn) return;
-  if (readConsent()) {
+  if (diagnosticsConsentGranted()) {
     tryInit(options);
   } else {
     tryClose();
@@ -46,17 +59,32 @@ export function syncSentryClient(options: Sentry.BrowserOptions): void {
 }
 
 /**
- * Install listeners so the Sentry client turns on/off whenever the user
- * flips the Share Diagnostics toggle — covering cross-tab writes (via the
- * native `storage` event) and same-tab writes (via the custom event
- * dispatched by `setLocalSetting`).
+ * Install listeners so both Sentry clients (browser + Electron main) re-apply
+ * the gate whenever it changes: the user flipping the Share Diagnostics toggle
+ * (cross-tab via the native `storage` event, same-tab via the custom event from
+ * `setLocalSetting`) or the platform session transitioning in/out of "present".
  *
  * Returns a cleanup function that removes both listeners.
  */
 export function installSentryControlListeners(
   options: Sentry.BrowserOptions,
 ): () => void {
-  return watchDeviceSetting("shareDiagnostics", () => {
+  const sync = () => {
     syncSentryClient(options);
+    syncDiagnosticsToMain(diagnosticsConsentGranted());
+  };
+  const stopDeviceWatch = watchDeviceSetting("shareDiagnostics", sync);
+  const stopSessionWatch = useAuthStore.subscribe((state, prevState) => {
+    if (
+      state.platformSession !== prevState.platformSession ||
+      state.platformSessionRestoredOffline !==
+        prevState.platformSessionRestoredOffline
+    ) {
+      sync();
+    }
   });
+  return () => {
+    stopDeviceWatch();
+    stopSessionWatch();
+  };
 }

--- a/clients/web/src/lib/sentry/sentry-init.test.ts
+++ b/clients/web/src/lib/sentry/sentry-init.test.ts
@@ -10,6 +10,7 @@ mock.module("@/lib/sentry/sentry-control", () => ({
     syncedOptions = options;
   },
   installSentryControlListeners: () => () => {},
+  diagnosticsConsentGranted: () => false,
 }));
 mock.module("@/runtime/diagnostics", () => ({ syncDiagnosticsToMain: () => {} }));
 mock.module("@/utils/device-settings", () => ({

--- a/clients/web/src/lib/sentry/sentry-init.ts
+++ b/clients/web/src/lib/sentry/sentry-init.ts
@@ -1,12 +1,12 @@
 import type { BrowserOptions } from "@sentry/react";
 
 import {
+  diagnosticsConsentGranted,
   installSentryControlListeners,
   syncSentryClient,
 } from "@/lib/sentry/sentry-control";
 import { syncDiagnosticsToMain } from "@/runtime/diagnostics";
 import { sanitizeUrl } from "@/lib/sentry/url-sanitize";
-import { getDeviceBool } from "@/utils/device-settings";
 
 /**
  * Browser-side Sentry initialization, gated on the user's Share Diagnostics
@@ -104,13 +104,13 @@ const options: BrowserOptions = {
 /**
  * Bootstrap Sentry consent gating. Must be called after
  * `migrateDeviceSettings()` so the `device:share_diagnostics` key
- * is available when `readConsent()` reads localStorage.
+ * is available when the consent gate reads localStorage.
  *
- * Also syncs the current consent state to the Electron main process
- * (no-op on web/iOS) so the main-process Sentry client matches.
+ * Also syncs the effective (session-gated) consent to the Electron main
+ * process (no-op on web/iOS) so the main-process Sentry client matches.
  */
 export function initSentry(): void {
   syncSentryClient(options);
   installSentryControlListeners(options);
-  syncDiagnosticsToMain(getDeviceBool("shareDiagnostics", false));
+  syncDiagnosticsToMain(diagnosticsConsentGranted());
 }

--- a/clients/web/src/lib/sentry/sentry-init.ts
+++ b/clients/web/src/lib/sentry/sentry-init.ts
@@ -1,13 +1,13 @@
 import type { BrowserOptions } from "@sentry/react";
 
 import {
+  diagnosticsConsentGranted,
   installSentryControlListeners,
   syncSentryClient,
 } from "@/lib/sentry/sentry-control";
 import { syncDiagnosticsToMain } from "@/runtime/diagnostics";
 import { sanitizeUrl } from "@/lib/sentry/url-sanitize";
 import { isNativePlatform } from "@/runtime/native-auth";
-import { getDeviceBool } from "@/utils/device-settings";
 
 /**
  * Resolve the Sentry DSN for the current host. The shared bundle reports to a
@@ -115,15 +115,15 @@ const options: BrowserOptions = {
 /**
  * Bootstrap Sentry consent gating. Must be called after
  * `migrateDeviceSettings()` so the `device:diagnostics_reporting` key
- * is available when `readConsent()` reads localStorage.
+ * is available when the consent gate reads localStorage.
  *
- * Also syncs the effective reporting gate to the Electron main process
- * (no-op on web/iOS) so the main-process Sentry client matches.
+ * Also syncs the effective (session-gated) reporting gate to the Electron main
+ * process (no-op on web/iOS) so the main-process Sentry client matches.
  */
 export function initSentry(): void {
   // Resolve the DSN at init time (post host-detection), not at module load.
   const resolved: BrowserOptions = { ...options, dsn: resolveDsn() };
   syncSentryClient(resolved);
   installSentryControlListeners(resolved);
-  syncDiagnosticsToMain(getDeviceBool("diagnosticsReporting", false));
+  syncDiagnosticsToMain(diagnosticsConsentGranted());
 }

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -490,6 +490,8 @@ describe("auth store onboarding flag reconciliation", () => {
     expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
     expect(useAuthStore.getState().user?.id).toBe("user-1");
     expect(useAuthStore.getState().platformSession).toBe("present");
+    // A live probe confirmed it — not a believed offline restore.
+    expect(useAuthStore.getState().platformSessionRestoredOffline).toBe(false);
   });
 
   test("initSession uses server consent when server has a consent record", async () => {
@@ -1036,6 +1038,8 @@ describe("offline session restore (LUM-2412)", () => {
     // probe runs offline to settle an "unknown" — so the restore settles
     // "present" (believed state); reconnect revalidation corrects it.
     expect(useAuthStore.getState().platformSession).toBe("present");
+    // ...but it is flagged as a believed restore, so telemetry stays fail-closed.
+    expect(useAuthStore.getState().platformSessionRestoredOffline).toBe(true);
   });
 
   test("transport-failed boot (proxy 502) with token + snapshot settles authenticated from cache", async () => {

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -21,6 +21,7 @@ import {
   isSessionSettled,
   isSettledSessionRejection,
   hasLivePlatformSession,
+  isConfirmedPlatformSession,
   type PlatformSessionStatus,
   type SessionStatus,
 } from "@/stores/session-status";
@@ -120,6 +121,10 @@ interface AuthState {
   sessionStatus: SessionStatus;
   user: AuthUser | null;
   platformSession: PlatformSessionStatus;
+  // True while `platformSession: "present"` is a believed offline restore
+  // (LUM-2412) rather than a session a live probe confirmed. Telemetry gates on
+  // a confirmed-live session, so it must not treat the restored state as live.
+  platformSessionRestoredOffline: boolean;
 }
 
 interface AuthActions {
@@ -174,6 +179,8 @@ const authenticatedPlatformUser = (
     sessionStatus: "authenticated",
     user,
     platformSession: "present",
+    // Confirmed by a live probe; `restoreOfflineSession` overrides this to true.
+    platformSessionRestoredOffline: false,
   };
 };
 
@@ -230,7 +237,10 @@ async function restoreOfflineSession(set: AuthSet): Promise<boolean> {
   // Consent/org sync falls back to device-cached keys when the server
   // fetch fails (it will, offline) — same continuity as an online boot.
   await syncUserScopedState(cached.id);
-  set(authenticatedPlatformUser(cached));
+  set({
+    ...authenticatedPlatformUser(cached),
+    platformSessionRestoredOffline: true,
+  });
   return true;
 }
 
@@ -437,7 +447,11 @@ function probePlatformSession(
           }
         }
         if (isStale()) return;
-        set({ platformSession: "present", ...userUpdate });
+        set({
+          platformSession: "present",
+          platformSessionRestoredOffline: false,
+          ...userUpdate,
+        });
       } else if (options.clearOnFailure) {
         set({ platformSession: "absent" });
       }
@@ -520,6 +534,7 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
   sessionStatus: "initializing",
   user: null,
   platformSession: "unknown",
+  platformSessionRestoredOffline: false,
 
   initSession: async () => {
     if (isRemoteGatewayMode()) {
@@ -870,6 +885,17 @@ export const useIsSessionInitializing = (): boolean =>
 
 export const useHasPlatformSession = (): boolean =>
   hasLivePlatformSession(useAuthStore.use.platformSession());
+
+/**
+ * A platform session a live probe confirmed — excludes the believed offline
+ * restore (LUM-2412). Telemetry consent gates on this, not the routing-oriented
+ * {@link useHasPlatformSession}, so it never enables offline.
+ */
+export const useHasConfirmedPlatformSession = (): boolean =>
+  isConfirmedPlatformSession(
+    useAuthStore.use.platformSession(),
+    useAuthStore.use.platformSessionRestoredOffline(),
+  );
 
 /**
  * Subscribe to app-resume signals on the layout-scoped event bus and to

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -21,6 +21,7 @@ import {
   isSessionSettled,
   isSettledSessionRejection,
   hasLivePlatformSession,
+  isConfirmedPlatformSession,
   type PlatformSessionStatus,
   type SessionStatus,
 } from "@/stores/session-status";
@@ -119,6 +120,10 @@ interface AuthState {
   sessionStatus: SessionStatus;
   user: AuthUser | null;
   platformSession: PlatformSessionStatus;
+  // True while `platformSession: "present"` is a believed offline restore
+  // (LUM-2412) rather than a session a live probe confirmed. Telemetry gates on
+  // a confirmed-live session, so it must not treat the restored state as live.
+  platformSessionRestoredOffline: boolean;
 }
 
 interface AuthActions {
@@ -173,6 +178,8 @@ const authenticatedPlatformUser = (
     sessionStatus: "authenticated",
     user,
     platformSession: "present",
+    // Confirmed by a live probe; `restoreOfflineSession` overrides this to true.
+    platformSessionRestoredOffline: false,
   };
 };
 
@@ -229,7 +236,10 @@ async function restoreOfflineSession(set: AuthSet): Promise<boolean> {
   // Consent/org sync falls back to device-cached keys when the server
   // fetch fails (it will, offline) — same continuity as an online boot.
   await syncUserScopedState(cached.id);
-  set(authenticatedPlatformUser(cached));
+  set({
+    ...authenticatedPlatformUser(cached),
+    platformSessionRestoredOffline: true,
+  });
   return true;
 }
 
@@ -427,7 +437,11 @@ function probePlatformSession(
           }
         }
         if (isStale()) return;
-        set({ platformSession: "present", ...userUpdate });
+        set({
+          platformSession: "present",
+          platformSessionRestoredOffline: false,
+          ...userUpdate,
+        });
       } else if (options.clearOnFailure) {
         set({ platformSession: "absent" });
       }
@@ -510,6 +524,7 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
   sessionStatus: "initializing",
   user: null,
   platformSession: "unknown",
+  platformSessionRestoredOffline: false,
 
   initSession: async () => {
     if (isRemoteGatewayMode()) {
@@ -860,6 +875,17 @@ export const useIsSessionInitializing = (): boolean =>
 
 export const useHasPlatformSession = (): boolean =>
   hasLivePlatformSession(useAuthStore.use.platformSession());
+
+/**
+ * A platform session a live probe confirmed — excludes the believed offline
+ * restore (LUM-2412). Telemetry consent gates on this, not the routing-oriented
+ * {@link useHasPlatformSession}, so it never enables offline.
+ */
+export const useHasConfirmedPlatformSession = (): boolean =>
+  isConfirmedPlatformSession(
+    useAuthStore.use.platformSession(),
+    useAuthStore.use.platformSessionRestoredOffline(),
+  );
 
 /**
  * Subscribe to app-resume signals on the layout-scoped event bus and to

--- a/clients/web/src/stores/session-status.ts
+++ b/clients/web/src/stores/session-status.ts
@@ -67,6 +67,17 @@ export const hasLivePlatformSession = (
 ): boolean => status === "present";
 
 /**
+ * A platform session a live probe confirmed — `"present"` AND not a believed
+ * offline restore (LUM-2412). Stricter than {@link hasLivePlatformSession}:
+ * telemetry consent gates on this so it never enables on a restored-offline
+ * launch that no live probe has revalidated.
+ */
+export const isConfirmedPlatformSession = (
+  status: PlatformSessionStatus,
+  restoredOffline: boolean,
+): boolean => status === "present" && !restoredOffline;
+
+/**
  * Statuses where the server itself said "no session": allauth's 401 for
  * an unauthenticated probe, a 403, or 410 Gone (session invalidated).
  */

--- a/clients/web/src/utils/onboarding-cleanup.test.ts
+++ b/clients/web/src/utils/onboarding-cleanup.test.ts
@@ -383,6 +383,17 @@ describe("savePreferenceToggle", () => {
     expect(body.share_diagnostics).toBe(false);
     expect(body.share_diagnostics_accepted_version).toBe(PRIVACY_CONSENT_VERSION);
   });
+
+  test("offline persists the on/off value but skips the currency stamp, ack key, and server patch", () => {
+    savePreferenceToggle("share_analytics", true, { userId: "user-1", hasPlatformSession: false });
+    // The chosen value is still recorded device-locally...
+    expect(storeState.setShareAnalytics).toHaveBeenCalledWith(true);
+    expect(setDeviceBoolMock).toHaveBeenCalledWith("shareAnalytics", true);
+    // ...but no version-currency is stamped without a session to record against.
+    expect(storeState.setAnalyticsConsentCurrent).not.toHaveBeenCalled();
+    expect(localStorage.getItem(analyticsKey("user-1"))).toBeNull();
+    expect(patchConsentMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("clearConsentForUser", () => {

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -243,18 +243,31 @@ export function savePreferenceToggle(
 ): void {
   const store = useOnboardingStore.getState();
   const { userId, hasPlatformSession } = opts;
+  // The on/off value is always device-persisted, but the version-currency ack
+  // ("confirmed under the current terms version") is only earned with a live
+  // platform session to record it against — offline it would stamp a currency
+  // the user never reviewed terms for.
   if (field === "share_analytics") {
     store.setShareAnalytics(value);
     setDeviceBool("shareAnalytics", value);
-    store.setAnalyticsConsentCurrent(true);
-    persistToggleConsent(userId, { analyticsCurrent: true });
+    if (hasPlatformSession) {
+      store.setAnalyticsConsentCurrent(true);
+      persistToggleConsent(userId, { analyticsCurrent: true });
+    }
   } else {
     store.setShareDiagnostics(value);
     setDeviceBool("shareDiagnostics", value);
-    store.setDiagnosticsConsentCurrent(true);
-    // Version is current by construction here, so the gate equals the preference.
-    setDiagnosticsReportingGate(value);
-    persistToggleConsent(userId, { diagnosticsCurrent: true });
+    if (hasPlatformSession) {
+      store.setDiagnosticsConsentCurrent(true);
+      // Version is current here (a live session re-stamps it), so the effective
+      // reporting gate equals the preference.
+      setDiagnosticsReportingGate(value);
+      persistToggleConsent(userId, { diagnosticsCurrent: true });
+    } else {
+      // Offline: no version ack is earned, so the effective gate stays closed
+      // regardless of the toggle value until a live session re-confirms.
+      setDiagnosticsReportingGate(false);
+    }
   }
 
   if (hasPlatformSession) {

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -240,16 +240,24 @@ export function savePreferenceToggle(
 ): void {
   const store = useOnboardingStore.getState();
   const { userId, hasPlatformSession } = opts;
+  // The on/off value is always device-persisted, but the version-currency ack
+  // ("confirmed under the current terms version") is only earned with a live
+  // platform session to record it against — offline it would stamp a currency
+  // the user never reviewed terms for.
   if (field === "share_analytics") {
     store.setShareAnalytics(value);
     setDeviceBool("shareAnalytics", value);
-    store.setAnalyticsConsentCurrent(true);
-    persistToggleConsent(userId, { analyticsCurrent: true });
+    if (hasPlatformSession) {
+      store.setAnalyticsConsentCurrent(true);
+      persistToggleConsent(userId, { analyticsCurrent: true });
+    }
   } else {
     store.setShareDiagnostics(value);
     setDeviceBool("shareDiagnostics", value);
-    store.setDiagnosticsConsentCurrent(true);
-    persistToggleConsent(userId, { diagnosticsCurrent: true });
+    if (hasPlatformSession) {
+      store.setDiagnosticsConsentCurrent(true);
+      persistToggleConsent(userId, { diagnosticsCurrent: true });
+    }
   }
 
   if (hasPlatformSession) {


### PR DESCRIPTION
Integrates merged main PR #35380 onto the feature branch. Composed gate = confirmedPlatformSession && diagnosticsReporting(preference && versionCurrent). Keeps our flavor abstraction, @sentry/electron main (now one-shot init), @sentry/capacitor (now closes native on opt-out), host-aware DSNs, and consent-refresh (now session-re-checked). Also folds in review fixes from #35385 (one-shot Electron init), #35386 (consent-refresh race), #35387 (Capacitor native close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)