### PR TITLE
feat(ios): link SentryCapacitor in the committed SPM package

### DIFF
--- a/clients/ios/App/CapApp-SPM/Package.swift
+++ b/clients/ios/App/CapApp-SPM/Package.swift
@@ -14,14 +14,15 @@ let package = Package(
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.3.4"),
         .package(name: "CapacitorApp", path: "../../../web/node_modules/@capacitor/app"),
         .package(name: "CapacitorBrowser", path: "../../../web/node_modules/@capacitor/browser"),
+        .package(name: "CapacitorFileViewer", path: "../../../web/node_modules/@capacitor/file-viewer"),
         .package(name: "CapacitorFilesystem", path: "../../../web/node_modules/@capacitor/filesystem"),
         .package(name: "CapacitorHaptics", path: "../../../web/node_modules/@capacitor/haptics"),
         .package(name: "CapacitorLocalNotifications", path: "../../../web/node_modules/@capacitor/local-notifications"),
         .package(name: "CapacitorNetwork", path: "../../../web/node_modules/@capacitor/network"),
-        .package(name: "CapacitorPluginSafeArea", path: "../../../web/node_modules/capacitor-plugin-safe-area"),
+        .package(name: "CapacitorPushNotifications", path: "../../../web/node_modules/@capacitor/push-notifications"),
         .package(name: "CapacitorShare", path: "../../../web/node_modules/@capacitor/share"),
-        .package(name: "CapacitorFileViewer", path: "../../../web/node_modules/@capacitor/file-viewer"),
-        .package(name: "CapacitorPushNotifications", path: "../../../web/node_modules/@capacitor/push-notifications")
+        .package(name: "SentryCapacitor", path: "../../../web/node_modules/@sentry/capacitor"),
+        .package(name: "CapacitorPluginSafeArea", path: "../../../web/node_modules/capacitor-plugin-safe-area")
     ],
     targets: [
         .target(
@@ -31,14 +32,15 @@ let package = Package(
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
                 .product(name: "CapacitorApp", package: "CapacitorApp"),
                 .product(name: "CapacitorBrowser", package: "CapacitorBrowser"),
+                .product(name: "CapacitorFileViewer", package: "CapacitorFileViewer"),
                 .product(name: "CapacitorFilesystem", package: "CapacitorFilesystem"),
                 .product(name: "CapacitorHaptics", package: "CapacitorHaptics"),
                 .product(name: "CapacitorLocalNotifications", package: "CapacitorLocalNotifications"),
                 .product(name: "CapacitorNetwork", package: "CapacitorNetwork"),
-                .product(name: "CapacitorPluginSafeArea", package: "CapacitorPluginSafeArea"),
+                .product(name: "CapacitorPushNotifications", package: "CapacitorPushNotifications"),
                 .product(name: "CapacitorShare", package: "CapacitorShare"),
-                .product(name: "CapacitorFileViewer", package: "CapacitorFileViewer"),
-                .product(name: "CapacitorPushNotifications", package: "CapacitorPushNotifications")
+                .product(name: "SentryCapacitor", package: "SentryCapacitor"),
+                .product(name: "CapacitorPluginSafeArea", package: "CapacitorPluginSafeArea")
             ]
         )
     ]


### PR DESCRIPTION
## Summary
- Adds the SentryCapacitor SPM dependency/product to the committed CapApp-SPM/Package.swift so fresh-clone/TestFlight builds link the native @sentry/capacitor plugin
- No Info.plist Sentry auto-init added — native init stays JS/consent-gated
- iOS DSN is delivered via the web SPA build (VITE_SENTRY_DSN_IOS); no env wiring here

Part of plan: sentry-overhaul.md (PR 9 of 12)