### PR TITLE
feat(macos): gate Crashpad minidump uploads on confirmed diagnostics consent

### DIFF
--- a/clients/macos/src/main/sentry.test.ts
+++ b/clients/macos/src/main/sentry.test.ts
@@ -14,7 +14,10 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
  *    once (lazily, on first consent) and thereafter gate JS event delivery via a
  *    `beforeSend` that returns null while disabled — never close()/re-init.
  * Native crash capture rides on the default `@sentry/electron/main`
- * integrations, so init alone configures it.
+ * integrations, so init alone configures it. Native minidumps upload via
+ * core.captureEvent, so they pass through `beforeSend` AND respect
+ * `client.getOptions().enabled`, which we sync to the live consent flag so the
+ * SDK deletes (never uploads) pre-consent minidumps while opted out.
  *
  * `@sentry/electron/main`, `electron`, and `./settings` are mocked so the
  * module runs without an Electron runtime. Each test file runs in its own
@@ -105,9 +108,20 @@ describe("initSentryMain (before any consent)", () => {
   });
 });
 
-describe("consent lifecycle (one-shot init, beforeSend gate)", () => {
-  test("first enable inits the SDK once with a beforeSend gate; later toggles only flip the flag", () => {
+describe("consent lifecycle (one-shot init, beforeSend gate, native gate)", () => {
+  test("first enable inits the SDK once and gates both JS and native events; later toggles only flip the flag and native gate", () => {
     initSentryMain();
+
+    // No native upload path is armed before the first consent: init() (which
+    // starts Crashpad and the minidump uploader) has not run.
+    expect(initMock).not.toHaveBeenCalled();
+
+    // Stand up a client whose options carry a live `enabled` flag, mirroring the
+    // real SDK. The minidump integration reads `getOptions().enabled` at crash
+    // time to decide whether to upload or delete queued minidumps.
+    const clientOptions = { enabled: true };
+    const closeMock = mock(() => Promise.resolve(true));
+    sentryClient = { getOptions: () => clientOptions, close: closeMock };
 
     // First enable via the direct apply path (not the unfired change watcher).
     setShareDiagnostics(true);
@@ -121,27 +135,37 @@ describe("consent lifecycle (one-shot init, beforeSend gate)", () => {
     });
     // Tags are applied so events carry process/arch/electron/packaged context.
     expect(setTagMock).toHaveBeenCalledWith("process", "main");
+    // Native gate armed on: the SDK uploads minidumps.
+    expect(clientOptions.enabled).toBe(true);
 
     const beforeSend = lastInitOptions?.beforeSend as
       | ((event: unknown) => unknown)
       | undefined;
-    // Enabled now: beforeSend passes events through.
+    // Enabled now: beforeSend passes JS events through.
     const okEvent = { message: "ok" };
     expect(beforeSend?.(okEvent)).toBe(okEvent);
+    // ...and minidump-shaped native events (no `type`, level fatal) too.
+    const minidumpEvent = { level: "fatal", platform: "native" };
+    expect(beforeSend?.(minidumpEvent)).toBe(minidumpEvent);
 
-    // Disable: no close()/re-init churn; client stays installed, events dropped.
-    const closeMock = mock(() => Promise.resolve(true));
-    sentryClient = { getOptions: () => ({ enabled: true }), close: closeMock };
+    // Disable: no close()/re-init churn; client stays installed.
     setShareDiagnostics(false);
     expect(writeSettingMock).toHaveBeenCalledWith("shareDiagnostics", false);
     expect(closeMock).not.toHaveBeenCalled();
     expect(setClientMock).not.toHaveBeenCalled();
+    // JS events dropped...
     expect(beforeSend?.({ message: "boom" })).toBeNull();
+    // ...native minidump events dropped at beforeSend too...
+    expect(beforeSend?.({ level: "fatal", platform: "native" })).toBeNull();
+    // ...and the native gate flips off so the SDK deletes (never uploads)
+    // queued/pre-consent minidumps rather than holding them.
+    expect(clientOptions.enabled).toBe(false);
 
-    // Re-enable: still no second init — only the flag flips back on.
+    // Re-enable: still no second init — only the flags flip back on.
     settingChangeCb?.(true);
     expect(initMock).toHaveBeenCalledTimes(1);
     const okAgain = { message: "ok-again" };
     expect(beforeSend?.(okAgain)).toBe(okAgain);
+    expect(clientOptions.enabled).toBe(true);
   });
 });

--- a/clients/macos/src/main/sentry.test.ts
+++ b/clients/macos/src/main/sentry.test.ts
@@ -55,7 +55,29 @@ mock.module("electron", () => ({
   app: {
     isPackaged: false,
     on: mock(() => {}),
+    getPath: (name: string) =>
+      name === "crashDumps" ? "/fake/crash-dumps" : "/fake/user-data",
   },
+}));
+
+// In-memory model of the Crashpad minidump dirs the SDK loader scans, so the
+// purge path can be asserted without touching the real filesystem.
+let minidumpFs: Record<string, string[]> = {};
+const unlinkMock = mock((filePath: string) => {
+  const dir = filePath.slice(0, filePath.lastIndexOf("/"));
+  const file = filePath.slice(filePath.lastIndexOf("/") + 1);
+  if (minidumpFs[dir]) {
+    minidumpFs[dir] = minidumpFs[dir].filter((f) => f !== file);
+  }
+});
+
+mock.module("node:fs", () => ({
+  readdirSync: (dir: string) => {
+    const files = minidumpFs[dir];
+    if (!files) throw new Error("ENOENT");
+    return files;
+  },
+  unlinkSync: unlinkMock,
 }));
 
 let settingChangeCb: ((newValue: boolean | undefined) => void) | null = null;
@@ -86,6 +108,8 @@ beforeEach(() => {
   setTagMock.mockReset();
   setClientMock.mockReset();
   writeSettingMock.mockReset();
+  unlinkMock.mockClear();
+  minidumpFs = {};
   sentryClient = undefined;
   settingChangeCb = null;
 });
@@ -105,6 +129,43 @@ describe("initSentryMain (before any consent)", () => {
     expect(initMock).not.toHaveBeenCalled();
     // ...but it does register the mid-session watcher.
     expect(settingChangeCb).not.toBeNull();
+  });
+});
+
+// Regression for the reviewer's scenario: the first effective consent after a
+// restart is `false`. The SDK was never initialized (fail-closed boot), so
+// there is no client to run the minidump integration's delete-on-disabled
+// startup scan — and `Sentry.init({ enabled: false })` would NOT set that
+// integration up anyway. Dumps captured while opted out must therefore be
+// purged from disk here, so a LATER opt-in's startup scan cannot upload them.
+//
+// Runs BEFORE the lifecycle test below, which permanently sets the module's
+// one-shot `initialized` singleton.
+describe("opted-out boot purges queued minidumps (never-initialized path)", () => {
+  test("first consent=false with no client deletes queued dumps so a later opt-in can't upload them", () => {
+    initSentryMain();
+    expect(initMock).not.toHaveBeenCalled();
+
+    // Crashpad wrote dumps into the loader's scan dirs during the prior
+    // (opted-out) session. No client exists (init never ran).
+    minidumpFs = {
+      "/fake/crash-dumps/completed": ["a.dmp", "metadata"],
+      "/fake/crash-dumps/pending": ["b.dmp"],
+    };
+    sentryClient = undefined;
+
+    // First effective consent after restart is false.
+    setShareDiagnostics(false);
+
+    // Still no init, and the queued .dmp files were deleted (metadata left).
+    expect(initMock).not.toHaveBeenCalled();
+    expect(unlinkMock).toHaveBeenCalledTimes(2);
+    expect(minidumpFs["/fake/crash-dumps/completed"]).toEqual(["metadata"]);
+    expect(minidumpFs["/fake/crash-dumps/pending"]).toEqual([]);
+
+    // A later opt-in's startup scan now finds nothing to upload.
+    expect(minidumpFs["/fake/crash-dumps/completed"]).not.toContain("a.dmp");
+    expect(minidumpFs["/fake/crash-dumps/pending"]).not.toContain("b.dmp");
   });
 });
 

--- a/clients/macos/src/main/sentry.ts
+++ b/clients/macos/src/main/sentry.ts
@@ -14,7 +14,9 @@ declare const __SENTRY_DSN_MACOS__: string;
  * The default `@sentry/electron/main` integrations enable Crashpad minidump
  * capture (`sentryMinidumpIntegration`) and renderer/child process crash
  * reporting (`childProcessIntegration`), so native main/renderer crashes
- * (OOM, segfault) upload real minidumps instead of reason-strings.
+ * (OOM, segfault) upload real minidumps instead of reason-strings. Those
+ * minidumps are uploaded via `core.captureEvent`, so they pass through
+ * `beforeSend` and respect `client.getOptions().enabled` (see syncNativeGate).
  */
 function resolveOptions(): Sentry.ElectronMainOptions | null {
   const dsn =
@@ -47,9 +49,8 @@ let cachedOptions: Sentry.ElectronMainOptions | null = null;
 // delivery via the `enabled` flag below rather than tearing the client down.
 let initialized = false;
 // Live consent flag consulted by `beforeSend`: JS events are dropped while
-// false. Native Crashpad minidumps still flush once the SDK is initialized;
-// deeper pre-consent minidump gating is handled by a later PR (PR 10). This
-// PR fixes the stale-listener churn and keeps JS event delivery consent-gated.
+// false. Native Crashpad minidump events also pass through `beforeSend` (they
+// are captured via core.captureEvent), so this flag gates them too.
 let enabled = false;
 
 /**
@@ -68,10 +69,23 @@ function ensureInitialized(): void {
   initialized = true;
 }
 
+/**
+ * Fail-closed native gate: keep `client.getOptions().enabled` in sync with the
+ * live consent flag. The minidump integration reads this at crash time —
+ * when false it deletes queued minidumps (including pre-consent dumps surfaced
+ * on a later launch) instead of uploading, and the transport short-circuits.
+ * Combined with `beforeSend`, no native minidump leaves the app while opted out.
+ */
+function syncNativeGate(consented: boolean): void {
+  const options = Sentry.getClient()?.getOptions();
+  if (options) options.enabled = consented;
+}
+
 function applyConsent(consented: boolean): void {
   if (!cachedOptions) return;
   enabled = consented;
   if (consented) ensureInitialized();
+  syncNativeGate(consented);
 }
 
 /**

--- a/clients/macos/src/main/sentry.ts
+++ b/clients/macos/src/main/sentry.ts
@@ -1,3 +1,6 @@
+import { readdirSync, unlinkSync } from "node:fs";
+import path from "node:path";
+
 import * as Sentry from "@sentry/electron/main";
 import { app } from "electron";
 
@@ -81,11 +84,63 @@ function syncNativeGate(consented: boolean): void {
   if (options) options.enabled = consented;
 }
 
+/**
+ * Directories the installed `@sentry/electron` minidump loader scans on its
+ * startup sweep (darwin). Mirrors getMinidumpLoader() in
+ * `@sentry/electron/main/integrations/sentry-minidump/minidump-loader.js`:
+ * Crashpad writes completed/pending `.dmp` files under `crashDumps`, and the
+ * loader uploads any it finds (via core.captureEvent) on the next init when
+ * `enabled !== false`.
+ */
+function queuedMinidumpDirs(): string[] {
+  const crashDumps = app.getPath("crashDumps");
+  return [path.join(crashDumps, "completed"), path.join(crashDumps, "pending")];
+}
+
+/**
+ * Fail-closed disk gate for the never-initialized case. When consent is false
+ * and the SDK was never initialized (e.g. the first effective consent after a
+ * restart is false), there is no client to run the minidump integration's
+ * delete-on-disabled startup scan — `Sentry.init({ enabled: false })` does NOT
+ * set up integrations, so the scan never installs. Without this, Crashpad
+ * dumps written during the opted-out session persist on disk and a LATER
+ * opt-in's init would scan and upload them. We delete them ourselves so a
+ * minidump captured while opted out can never be exfiltrated by a later opt-in.
+ */
+function purgeQueuedMinidumps(): void {
+  for (const dir of queuedMinidumpDirs()) {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.endsWith(".dmp")) continue;
+      try {
+        unlinkSync(path.join(dir, entry));
+      } catch {
+        // Best effort: a dump we cannot delete here is still gated by the
+        // native `enabled` flag once a client exists.
+      }
+    }
+  }
+}
+
 function applyConsent(consented: boolean): void {
   if (!cachedOptions) return;
   enabled = consented;
-  if (consented) ensureInitialized();
-  syncNativeGate(consented);
+  if (consented) {
+    ensureInitialized();
+    syncNativeGate(consented);
+    return;
+  }
+  // Opted out. If a client exists, its minidump integration deletes queued
+  // dumps when the native gate is false. If not (never initialized — fail-
+  // closed boot, or first consent after restart is false), no integration
+  // runs, so we purge the queued dumps from disk ourselves.
+  if (Sentry.getClient()) syncNativeGate(consented);
+  else purgeQueuedMinidumps();
 }
 
 /**


### PR DESCRIPTION
## Summary
- Ensures native Crashpad minidumps are not transmitted while diagnostics consent is off, including pre-consent minidumps surfaced on a later launch
- Builds on the one-shot init: Crashpad starts only after first consent; uploads respect the live enabled flag
- Preserves fail-closed boot, live toggle, tags, and JS-event gating

Part of plan: sentry-overhaul.md (PR 10 of 12)