### PR TITLE
feat(ios): fail-closed native gate for Capacitor sentry-cocoa

### DIFF
--- a/clients/web/src/lib/sentry/consent-gate.ts
+++ b/clients/web/src/lib/sentry/consent-gate.ts
@@ -1,0 +1,24 @@
+import { getDeviceBool } from "@/utils/device-settings";
+import { useAuthStore } from "@/stores/auth-store";
+import { isConfirmedPlatformSession } from "@/stores/session-status";
+
+/**
+ * The composed diagnostics gate, shared by `sentry-control.ts` (which decides
+ * init vs close) and `flavor-capacitor.ts` (whose `beforeSend` reads the live
+ * gate). Factored out so the flavor reads the same source without importing
+ * `sentry-control`, which imports the flavor — that would be a cycle.
+ *
+ * Grants only on a probe-confirmed live platform session AND the effective
+ * diagnostics-reporting gate (preference && version-current). See
+ * `sentry-control.ts` for the full rationale.
+ */
+export function diagnosticsConsentGranted(): boolean {
+  const { platformSession, platformSessionRestoredOffline } =
+    useAuthStore.getState();
+  if (
+    !isConfirmedPlatformSession(platformSession, platformSessionRestoredOffline)
+  ) {
+    return false;
+  }
+  return getDeviceBool("diagnosticsReporting", false);
+}

--- a/clients/web/src/lib/sentry/flavor-capacitor.test.ts
+++ b/clients/web/src/lib/sentry/flavor-capacitor.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { BrowserOptions, ErrorEvent } from "@sentry/react";
+
+// ---------------------------------------------------------------------------
+// Mock @sentry/capacitor + the sibling react init the flavor wraps.
+// ---------------------------------------------------------------------------
+
+let lastInitOptions: BrowserOptions | undefined;
+const initMock = mock((options: BrowserOptions) => {
+  lastInitOptions = options;
+});
+const closeMock = mock(() => Promise.resolve());
+let client: { getOptions: () => { enabled?: boolean } } | undefined;
+
+mock.module("@sentry/capacitor", () => ({
+  init: initMock,
+  close: closeMock,
+  getClient: () => client,
+}));
+mock.module("@sentry/react", () => ({ init: mock(() => {}) }));
+
+// Controllable composed gate the flavor's beforeSend reads.
+let consent = false;
+mock.module("@/lib/sentry/consent-gate", () => ({
+  diagnosticsConsentGranted: () => consent,
+}));
+
+const { capacitorFlavor } = await import("@/lib/sentry/flavor-capacitor");
+
+const OPTIONS: BrowserOptions = { dsn: "https://public@example.test/1" };
+const anEvent = (): ErrorEvent =>
+  ({ event_id: "abc", type: undefined }) as ErrorEvent;
+
+beforeEach(() => {
+  initMock.mockClear();
+  closeMock.mockClear();
+  lastInitOptions = undefined;
+  client = undefined;
+  consent = false;
+});
+
+describe("capacitorFlavor.init", () => {
+  test("enables the client and forwards options", () => {
+    capacitorFlavor.init(OPTIONS);
+    expect(initMock).toHaveBeenCalledTimes(1);
+    expect(lastInitOptions?.enabled).toBe(true);
+    expect(lastInitOptions?.dsn).toBe(OPTIONS.dsn);
+  });
+
+  test("beforeSend drops JS-bridged events when consent is off", () => {
+    consent = false;
+    capacitorFlavor.init(OPTIONS);
+    const beforeSend = lastInitOptions?.beforeSend;
+    expect(beforeSend).toBeDefined();
+    expect(beforeSend?.(anEvent(), {})).toBeNull();
+  });
+
+  test("beforeSend keeps events when consent is on", () => {
+    consent = true;
+    capacitorFlavor.init(OPTIONS);
+    const event = anEvent();
+    expect(lastInitOptions?.beforeSend?.(event, {})).toBe(event);
+  });
+
+  test("beforeSend reads the LIVE gate (revocation after init drops events)", () => {
+    consent = true;
+    capacitorFlavor.init(OPTIONS);
+    const beforeSend = lastInitOptions?.beforeSend;
+    consent = false; // user opts out after the client was initialized
+    expect(beforeSend?.(anEvent(), {})).toBeNull();
+  });
+});
+
+describe("capacitorFlavor.close", () => {
+  test("shuts down both JS and native via Capacitor.close", () => {
+    void capacitorFlavor.close();
+    expect(closeMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("capacitorFlavor.getClientEnabled", () => {
+  test("false when no client is installed", () => {
+    client = undefined;
+    expect(capacitorFlavor.getClientEnabled()).toBe(false);
+  });
+
+  test("true when an enabled client is installed", () => {
+    client = { getOptions: () => ({ enabled: true }) };
+    expect(capacitorFlavor.getClientEnabled()).toBe(true);
+  });
+
+  test("false when the installed client is disabled", () => {
+    client = { getOptions: () => ({ enabled: false }) };
+    expect(capacitorFlavor.getClientEnabled()).toBe(false);
+  });
+});

--- a/clients/web/src/lib/sentry/flavor-capacitor.ts
+++ b/clients/web/src/lib/sentry/flavor-capacitor.ts
@@ -2,6 +2,7 @@ import * as Capacitor from "@sentry/capacitor";
 import { init as reactInit } from "@sentry/react";
 
 import type { SentryFlavor } from "@/lib/sentry/flavor";
+import { diagnosticsConsentGranted } from "@/lib/sentry/consent-gate";
 
 /**
  * `SentryFlavor` backed by `@sentry/capacitor`, used inside the iOS WKWebview.
@@ -10,10 +11,42 @@ import type { SentryFlavor } from "@/lib/sentry/flavor";
  * the JS layer routes through the native sentry-cocoa transport. The native
  * bridge dedups events captured on both sides, so webview errors are not
  * double-reported.
+ *
+ * Native fail-closed guarantee (iOS sentry-cocoa)
+ * -----------------------------------------------
+ * sentry-cocoa never auto-starts: `@sentry/capacitor` initializes native only
+ * via `Capacitor.init` → `initNativeSdk` (verified in the SDK source), and the
+ * prior linking PR confirmed there is no Info.plist Sentry block. This flavor
+ * is driven solely through the consent-gated path in `sentry-control.ts`, so
+ * native capture begins ONLY after consent is granted. A crash that occurs
+ * before consent is therefore never captured at all — fail-closed by
+ * construction.
+ *
+ * sentry-cocoa flushes crash envelopes cached from a prior session on its next
+ * native init. Because that init only fires when consent is currently granted,
+ * a cached crash is flushed only if the user remains opted in across launches
+ * (correct). If consent was revoked, `init` never runs, the native SDK never
+ * starts, and the cached envelope is never uploaded. There is no native
+ * cache-purge API in `@sentry/capacitor` 4.1.0 (only `closeNativeSdk`), so this
+ * gated-init contract IS the purge.
+ *
+ * The JS `beforeSend` below gates webview JS errors, which DO round-trip
+ * through it. It is NOT the native gate: on iOS the SDK skips `beforeSend` for
+ * native envelopes captured via `captureEnvelope` (see its SdkInfo
+ * integration). The native gate is consent-gated init + `Capacitor.close()`.
  */
 export const capacitorFlavor: SentryFlavor = {
   init(options) {
-    Capacitor.init({ ...options, enabled: true }, reactInit);
+    Capacitor.init(
+      {
+        ...options,
+        enabled: true,
+        // Defensive gate for JS-bridged webview events; native envelopes
+        // bypass beforeSend, so consent-gated init + close is the native gate.
+        beforeSend: (event) => (diagnosticsConsentGranted() ? event : null),
+      },
+      reactInit,
+    );
   },
   close() {
     // Use the Capacitor SDK's own close routine, which shuts down BOTH the JS

--- a/clients/web/src/lib/sentry/flavor.test.ts
+++ b/clients/web/src/lib/sentry/flavor.test.ts
@@ -7,6 +7,11 @@ mock.module("@/runtime/native-auth", () => ({
   isNativePlatform: () => nativePlatform,
 }));
 mock.module("@/runtime/is-electron", () => ({ isElectron: () => electron }));
+// flavor-capacitor's beforeSend reads the composed gate; stub it so importing
+// the capacitor flavor here does not drag in the auth store's runtime deps.
+mock.module("@/lib/sentry/consent-gate", () => ({
+  diagnosticsConsentGranted: () => false,
+}));
 
 const { selectSentryFlavor } = await import("@/lib/sentry/flavor");
 const { reactFlavor } = await import("@/lib/sentry/flavor-react");

--- a/clients/web/src/lib/sentry/sentry-control.ts
+++ b/clients/web/src/lib/sentry/sentry-control.ts
@@ -1,11 +1,3 @@
-import type { BrowserOptions } from "@sentry/react";
-
-import { selectSentryFlavor } from "@/lib/sentry/flavor";
-import { getDeviceBool, watchDeviceSetting } from "@/utils/device-settings";
-import { syncDiagnosticsToMain } from "@/runtime/diagnostics";
-import { useAuthStore } from "@/stores/auth-store";
-import { isConfirmedPlatformSession } from "@/stores/session-status";
-
 /**
  * Gates the browser-side Sentry client on BOTH the effective diagnostics-
  * reporting gate (`device:diagnostics_reporting`) AND a probe-confirmed live
@@ -28,25 +20,21 @@ import { isConfirmedPlatformSession } from "@/stores/session-status";
  *   - absent         → Sentry OFF (no consent on record yet)
  *
  * SDK access is dispatched through `selectSentryFlavor()` so each surface
- * (web/electron renderer, capacitor) can supply its own implementation.
+ * (web/electron renderer, capacitor) can supply its own implementation. The
+ * composed gate itself lives in `consent-gate.ts` so the capacitor flavor's
+ * native `beforeSend` reads the same source without an import cycle.
  *
  * Reference: https://docs.sentry.io/platforms/javascript/guides/react/configuration/options/
  */
+import type { BrowserOptions } from "@sentry/react";
 
-/**
- * The composed diagnostics gate: a probe-confirmed live platform session AND
- * the effective diagnostics-reporting gate (preference && version-current).
- */
-export function diagnosticsConsentGranted(): boolean {
-  const { platformSession, platformSessionRestoredOffline } =
-    useAuthStore.getState();
-  if (
-    !isConfirmedPlatformSession(platformSession, platformSessionRestoredOffline)
-  ) {
-    return false;
-  }
-  return getDeviceBool("diagnosticsReporting", false);
-}
+import { selectSentryFlavor } from "@/lib/sentry/flavor";
+import { diagnosticsConsentGranted } from "@/lib/sentry/consent-gate";
+import { watchDeviceSetting } from "@/utils/device-settings";
+import { syncDiagnosticsToMain } from "@/runtime/diagnostics";
+import { useAuthStore } from "@/stores/auth-store";
+
+export { diagnosticsConsentGranted };
 
 function tryInit(options: BrowserOptions): void {
   const flavor = selectSentryFlavor();


### PR DESCRIPTION
## Summary
- Ensures native iOS crashes are never uploaded while opted out or before consent (consent-gated native init + beforeSend gate; cached-crash handling per SDK behavior)
- Preserves native shutdown on opt-out (Capacitor.close())
- Gate sourced from the same composed consent as the rest of Sentry control

Part of plan: sentry-overhaul.md (PR 11 of 12)