### PR TITLE
chore: finalize Sentry overhaul — docs, CSP/filter verification, cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,7 +283,7 @@ Error reporting uses Sentry. The daemon/runtime (Node) project's DSN is configur
 
 ### Sentry projects & DSNs
 
-Surfaces map onto Sentry projects as below. The Electron renderer moves from the web project onto the macOS project, sharing the existing `SENTRY_DSN_MACOS` secret with the main process. The per-host runtime DSN selector in the shared clients/web bundle is being wired up incrementally, so today `sentry-init.ts` still initializes every renderer host with `VITE_SENTRY_DSN`. An empty DSN no-ops.
+Surfaces map onto Sentry projects as below. The Electron renderer reports to the macOS project, sharing the `SENTRY_DSN_MACOS` secret with the main process. Per-host flavor + DSN selection in the shared clients/web bundle is live: `flavor.ts` `selectSentryFlavor()` picks the capacitor flavor on native iOS and the react flavor everywhere else (web + Electron renderer); `sentry-init.ts` `resolveDsn()` picks `VITE_SENTRY_DSN_MACOS` (Electron) / `VITE_SENTRY_DSN_IOS` (iOS) / `VITE_SENTRY_DSN` (web). All flavors share one `options` object (ignoreErrors, denyUrls, beforeBreadcrumb URL sanitize, enhanceFetchErrorMessages, attachStacktrace) so PII/noise filtering is uniform. An empty DSN no-ops.
 
 | Surface | Project | DSN source | Delivered via |
 | --- | --- | --- | --- |
@@ -294,6 +294,10 @@ Surfaces map onto Sentry projects as below. The Electron renderer moves from the
 | Assistant daemon | (unchanged) | `SENTRY_DSN_ASSISTANT` | runtime env |
 
 The iOS DSN is baked into the deployed web SPA bundle rather than the iOS build, because the iOS app runs the deployed SPA via `server.url` (see `clients/web/capacitor.config.ts`) and bundles no web assets at `cap sync`.
+
+The Electron renderer uses `@sentry/react` (not `@sentry/electron/renderer`): `@sentry/electron` pins `@sentry/core` 10.50 while `@sentry/capacitor` pins `@sentry/react`/`@sentry/browser` 10.52, and Sentry's current-client carrier is version-specific, so an `@sentry/electron/renderer` client couldn't see `@sentry/react` captures. Renderer native crashes still reach `vellum-assistant-macos` via `@sentry/electron/main` (separate process).
+
+**Version pins**: `@sentry/react`/`@sentry/browser` are pinned to 10.52.0 to satisfy `@sentry/capacitor`'s exact peer; `@sentry/electron` (Electron main process only) is on its own 10.50 line. Bumping any one requires checking the others.
 
 **Sentry CLI**: Use the newer `sentry` CLI (not the legacy `sentry-cli`). Install from `https://cli.sentry.dev/install`. Authenticate with `sentry auth login`.
 


### PR DESCRIPTION
## Summary
- Updates AGENTS.md to the final Sentry architecture (per-host flavor+DSN selection is live; Electron renderer uses @sentry/react due to the @sentry/core version pin; version-pin note)
- Verifies CSP ingest hosts + uniform PII/noise filtering across react/capacitor flavors
- Removes any remaining dead Sentry references

Part of plan: sentry-overhaul.md (PR 12 of 12)