### PR TITLE
Update privacy consent copy and bump privacy consent version

### DIFF
--- a/clients/web/src/components/detail-card.tsx
+++ b/clients/web/src/components/detail-card.tsx
@@ -5,7 +5,7 @@ import { Card, cn } from "@vellumai/design-library";
 export interface DetailCardProps {
   id?: string;
   title?: string;
-  subtitle?: string;
+  subtitle?: ReactNode;
   accessory?: ReactNode;
   compactAccessory?: boolean;
   children?: ReactNode;

--- a/clients/web/src/domains/onboarding/components/consent-controls.tsx
+++ b/clients/web/src/domains/onboarding/components/consent-controls.tsx
@@ -108,7 +108,7 @@ export function PrivacyPreferencesCard({
           {showAnalytics && (
             <SettingRow
               label="Share Analytics"
-              helperText="Send anonymous product usage data."
+              helperText="Send aggregated product usage data"
               checked={shareAnalytics}
               onChange={onShareAnalyticsChange}
             />
@@ -117,7 +117,7 @@ export function PrivacyPreferencesCard({
           {showDiagnostics && (
             <SettingRow
               label="Share Diagnostics"
-              helperText="Send crash reports and performance metrics."
+              helperText="Send crash reports, conversation traces, and session replay data"
               checked={shareDiagnostics}
               onChange={onShareDiagnosticsChange}
             />

--- a/clients/web/src/domains/settings/pages/privacy-page.tsx
+++ b/clients/web/src/domains/settings/pages/privacy-page.tsx
@@ -20,6 +20,7 @@ import {
     setDeviceSetting,
 } from "@/utils/device-settings";
 import { savePreferenceToggle } from "@/utils/onboarding-cleanup";
+import { legalUrl, routes } from "@/utils/routes";
 import { Dropdown } from "@vellumai/design-library/components/dropdown";
 
 const RETENTION_OPTIONS: { value: string; label: string }[] = [
@@ -87,13 +88,31 @@ export function PrivacyPage() {
       <TrustRules />
       {channelTrustFloors && <ChannelPolicyCard />}
       <RiskToleranceSettings />
-      <DetailCard title="Privacy">
+      <DetailCard
+        title="Privacy"
+        subtitle={
+          hasPlatformSession ? (
+            <>
+              View details about what data we collect and how it's used in our{" "}
+              <a
+                href={legalUrl(routes.docs.legal.privacyPolicy)}
+                target="_blank"
+                rel="noreferrer"
+                className="underline"
+              >
+                privacy policy
+              </a>
+              .
+            </>
+          ) : undefined
+        }
+      >
         <div className="space-y-4">
           {showShareConsent && (
             <>
               <SettingRow
                 label="Share Analytics"
-                helperText="Send anonymous product usage data."
+                helperText="Send aggregated product usage data"
                 checked={shareAnalytics}
                 onChange={handleAnalyticsToggle}
                 variant="toggle-trailing"
@@ -101,7 +120,7 @@ export function PrivacyPage() {
               <Divider />
               <SettingRow
                 label="Share Diagnostics"
-                helperText="Send crash reports and performance metrics."
+                helperText="Send crash reports, conversation traces, and session replay data"
                 checked={shareDiagnostics}
                 onChange={handleDiagnosticsToggle}
                 variant="toggle-trailing"

--- a/clients/web/src/utils/onboarding-cleanup.test.ts
+++ b/clients/web/src/utils/onboarding-cleanup.test.ts
@@ -298,6 +298,24 @@ describe("persistToggleConsent + restoreConsentForUser round-trip", () => {
     expect(localStorage.getItem(privacyKey)).toBe("true");
     expect(localStorage.getItem(legacyAiKey)).toBeNull();
   });
+
+  test("migrates legacy unversioned ToS but forces privacy re-review", () => {
+    // A pre-versioning user with only the legacy active keys. ToS is unchanged
+    // so it migrates as current; the unversioned privacy consent predates the
+    // current privacy version, so it must NOT be promoted as current.
+    localStorage.setItem("vellum:onboarding:tosAccepted", "true");
+    localStorage.setItem("vellum:onboarding:aiDataConsent", "true");
+    const privacyKey = `device:consent:privacy:v${PRIVACY_CONSENT_VERSION}:user-1`;
+    const tosKey = `device:consent:tos:v${TOS_CONSENT_VERSION}:user-1`;
+
+    const r = restoreConsentForUser("user-1");
+
+    expect(r.tos).toBe(true);
+    expect(r.privacy).toBe(false);
+    // ToS is promoted; privacy is not stamped current.
+    expect(localStorage.getItem(tosKey)).toBe("true");
+    expect(localStorage.getItem(privacyKey)).toBe("false");
+  });
 });
 
 describe("saveConsent", () => {

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -30,7 +30,7 @@ import { useOnboardingStore } from "@/domains/onboarding/onboarding-store";
 import { patchConsent, type UserConsent } from "@/domains/account/profile";
 
 export const TOS_CONSENT_VERSION = "2026-06-08";
-export const PRIVACY_CONSENT_VERSION = "2026-06-08";
+export const PRIVACY_CONSENT_VERSION = "2026-06-18";
 
 // Version stamp embedded in each field's device-cache key. ToS tracks its own
 // version; the privacy checkbox (privacy policy + AI data sharing) and the two

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -79,12 +79,17 @@ export function restoreConsentForUser(
 
     // One-time migration: users who accepted before the per-user device
     // key change still have consent in the legacy vellum: active keys.
-    // Promote to the new keys so they aren't re-prompted.
+    // Promote ToS so they aren't re-prompted — its version is unchanged, so the
+    // legacy acceptance is still current. The legacy privacy key is unversioned
+    // and predates the current privacy version, so promoting it would stamp
+    // stale consent as current (and let the empty-server fallback backfill it)
+    // without showing the updated privacy checkbox. Force privacy through
+    // re-review instead.
     const legacyTos = getLocalBool("vellum:onboarding:tosAccepted", false);
     const legacyPrivacy = getLocalBool("vellum:onboarding:aiDataConsent", false);
     if (legacyTos || legacyPrivacy) {
-      persistConsentForUser(userId, legacyTos, legacyPrivacy);
-      return { tos: legacyTos, privacy: legacyPrivacy, analyticsCurrent, diagnosticsCurrent };
+      persistConsentForUser(userId, legacyTos, false);
+      return { tos: legacyTos, privacy: false, analyticsCurrent, diagnosticsCurrent };
     }
 
     return { tos: false, privacy: false, analyticsCurrent, diagnosticsCurrent };


### PR DESCRIPTION
## What

Lightweight copy/UI updates to the privacy consent surfaces, plus a privacy consent version bump.

### Changes
- **Reworded the Share toggle helper text** on both the onboarding (`consent-controls.tsx`) and settings (`privacy-page.tsx`) surfaces:
  - Share Analytics: `Send anonymous product usage data.` → `Send aggregated product usage data`
  - Share Diagnostics: `Send crash reports and performance metrics.` → `Send crash reports, conversation traces, and session replay data`
- **Added a privacy-policy link under the settings Privacy header.** Rendered via `DetailCard`'s `subtitle` slot (widened from `string` → `ReactNode` so it can hold the link), so it sits tight under the title. Gated on a **confirmed platform session** (`hasPlatformSession`) — hidden for self-hosted / offline-restore states, matching the existing gate on the Share toggles. Links to `https://vellum.ai/docs/privacy-policy` via the existing `legalUrl`/`routes` helpers.
- **Bumped `PRIVACY_CONSENT_VERSION`** `2026-06-08` → `2026-06-18`.

## Why

Copy refresh to more accurately describe what each consent toggle gates. Because the helper text now describes additional collection (conversation traces, session replay), the privacy version is bumped so existing users re-accept the updated privacy preferences.

## Blast radius of the version bump

`PRIVACY_CONSENT_VERSION` gates four consent fields (`privacy`, `ai_data_sharing`, `share_analytics`, `share_diagnostics`). Bumping it re-prompts every existing user to re-accept their privacy preferences on next load. This is intended.

## Notes / open questions
- **"session replay data"** in the Share Diagnostics copy describes capture that I did not find wired to this consent in the daemon/web today (the toggle currently gates Sentry crash reporting + per-turn conversation traces). Confirm this is intentional forward-looking copy ahead of a replay feature landing.
- This bumps only the **client-facing** `PRIVACY_CONSENT_VERSION`. If the platform tracks a required privacy-policy version server-side that needs to move in lockstep, that lives in `vellum-assistant-platform` and is not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)