### PR TITLE
fix(web): route user-defined app routes (/v1/x/*) to the local gateway in self-hosted mode

### DIFF
--- a/clients/web/src/lib/api-interceptors.test.ts
+++ b/clients/web/src/lib/api-interceptors.test.ts
@@ -275,6 +275,23 @@ describe("api-interceptors / self-hosted rewriting", () => {
     expect(output.headers.get("Authorization")).toBe(`Bearer ${ACTOR_TOKEN}`);
   });
 
+  test("rewrites user-defined route handler (`/x/`) calls to the ingress", async () => {
+    // Sandboxed apps POST to their backend handlers under `/v1/x/*`
+    // through the platform client; in local / self-hosted mode these
+    // must route to the gateway rather than fall through to the
+    // platform proxy.
+    setSelfHostedConnection({ url: INGRESS, token: ACTOR_TOKEN });
+    const userRoutePath = `/v1/assistants/${SELF_HOSTED_ID}/x/us-vs-the-world`;
+    const input = new Request(`https://platform.test${userRoutePath}`, {
+      method: "POST",
+    });
+    const output = await requestInterceptor(input);
+    const outUrl = new URL(output.url);
+    expect(outUrl.origin).toBe(INGRESS);
+    expect(outUrl.pathname).toBe(userRoutePath);
+    expect(output.headers.get("Authorization")).toBe(`Bearer ${ACTOR_TOKEN}`);
+  });
+
   test("prepends the ingress path prefix when the ingress URL has a path", async () => {
     const prefixedIngress = "http://localhost:3000/__gateway/20100";
     setSelfHostedConnection({ url: prefixedIngress, token: ACTOR_TOKEN });

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -81,6 +81,12 @@ const RUNTIME_PROXIED_FIRST_SEGMENTS = new Set<string>([
   // platform client, so it must be forwarded to the gateway in local /
   // self-hosted mode like any other runtime route.
   "events",
+  // User-defined route handlers (`/v1/x/*`). Sandboxed apps reach their
+  // backend handlers through the platform client (the sandbox fetch
+  // proxy in `useSandboxFetchProxy`, gated to `/v1/x/` paths), so these
+  // must be forwarded to the gateway in local / self-hosted mode rather
+  // than falling through to the platform proxy.
+  "x",
 ]);
 
 const ASSISTANT_PATH_RE =


### PR DESCRIPTION
## Summary

- Sandboxed apps reach their backend handlers (`/v1/x/*` user-defined route handlers) through the platform client's sandbox fetch proxy (`useSandboxFetchProxy`), which is gated to `/v1/x/` paths.
- The platform client only rewrites first segments on `RUNTIME_PROXIED_FIRST_SEGMENTS` to the self-hosted/local gateway. `x` was missing, so in local / self-hosted mode an app's save request was never rewritten — it stayed on the platform `/v1/...` path and Vite's dev proxy forwarded it to the dead `:8000` standalone, failing with `ECONNREFUSED`.
- Add `x` to the allowlist (+ a mirror test). Safe and complete: the sandbox proxy regex (`/^\/v1\/x\//`) means apps can only call `/v1/x/*`, and the platform owns no routes under `/x/`. Same class of fix as #35242 (events).

## Original prompt

While running Velissa's local web client in dev mode, saving a value in her "us vs the world" app failed with a Vite `http proxy error … ECONNREFUSED` on `/v1/assistants/<id>/x/us-vs-the-world`. Diagnosis traced it to the `/v1/x/*` user-route segment being absent from the platform client's self-hosted rewrite allowlist — the identical mechanism fixed for the SSE `events` stream in #35242. Add `x` to `RUNTIME_PROXIED_FIRST_SEGMENTS` and mirror the existing events allowlist test.