### PR TITLE
chore(web): self-review cleanup (env comment, device-setting legacy key, re-export hop)

### DIFF
--- a/clients/web/src/env.d.ts
+++ b/clients/web/src/env.d.ts
@@ -16,8 +16,8 @@ interface ImportMetaEnv {
    * DSN-selection contract: the shared clients/web bundle resolves its Sentry
    * DSN per host — web → `VITE_SENTRY_DSN` (vellum-assistant-web), Electron →
    * `VITE_SENTRY_DSN_MACOS` (vellum-assistant-macos), iOS →
-   * `VITE_SENTRY_DSN_IOS` (vellum-assistant-ios). The runtime selector is wired
-   * up incrementally and does not yet consume these.
+   * `VITE_SENTRY_DSN_IOS` (vellum-assistant-ios). The runtime selector
+   * (`resolveDsn` in `sentry-init.ts`) reads these per host.
    */
   readonly VITE_SENTRY_DSN?: string;
   /** Sentry DSN for the Electron renderer (vellum-assistant-macos). See DSN-selection contract above. */

--- a/clients/web/src/lib/sentry/sentry-control.test.ts
+++ b/clients/web/src/lib/sentry/sentry-control.test.ts
@@ -76,8 +76,10 @@ mock.module("@/stores/auth-store", () => ({
   },
 }));
 
-const { syncSentryClient, diagnosticsConsentGranted, installSentryControlListeners } =
-  await import("@/lib/sentry/sentry-control");
+const { syncSentryClient, installSentryControlListeners } = await import(
+  "@/lib/sentry/sentry-control"
+);
+const { diagnosticsConsentGranted } = await import("@/lib/sentry/consent-gate");
 
 const OPTIONS: BrowserOptions = { dsn: "https://public@example.test/1" };
 

--- a/clients/web/src/lib/sentry/sentry-control.ts
+++ b/clients/web/src/lib/sentry/sentry-control.ts
@@ -34,8 +34,6 @@ import { watchDeviceSetting } from "@/utils/device-settings";
 import { syncDiagnosticsToMain } from "@/runtime/diagnostics";
 import { useAuthStore } from "@/stores/auth-store";
 
-export { diagnosticsConsentGranted };
-
 function tryInit(options: BrowserOptions): void {
   const flavor = selectSentryFlavor();
   if (flavor.getClientEnabled()) return;

--- a/clients/web/src/lib/sentry/sentry-init.test.ts
+++ b/clients/web/src/lib/sentry/sentry-init.test.ts
@@ -10,6 +10,8 @@ mock.module("@/lib/sentry/sentry-control", () => ({
     syncedOptions = options;
   },
   installSentryControlListeners: () => () => {},
+}));
+mock.module("@/lib/sentry/consent-gate", () => ({
   diagnosticsConsentGranted: () => false,
 }));
 mock.module("@/runtime/diagnostics", () => ({ syncDiagnosticsToMain: () => {} }));

--- a/clients/web/src/lib/sentry/sentry-init.ts
+++ b/clients/web/src/lib/sentry/sentry-init.ts
@@ -1,7 +1,7 @@
 import type { BrowserOptions } from "@sentry/react";
 
+import { diagnosticsConsentGranted } from "@/lib/sentry/consent-gate";
 import {
-  diagnosticsConsentGranted,
   installSentryControlListeners,
   syncSentryClient,
 } from "@/lib/sentry/sentry-control";

--- a/clients/web/src/utils/device-settings.test.ts
+++ b/clients/web/src/utils/device-settings.test.ts
@@ -70,6 +70,13 @@ describe("getDeviceBool", () => {
     localStorage.setItem("vellum_share_analytics", "false");
     expect(getDeviceBool("shareAnalytics", false)).toBe(true);
   });
+
+  test("never reads a legacy fallback for a legacy-less setting", () => {
+    // diagnosticsReporting was born post-migration: it has no legacy key,
+    // so a stray vellum_diagnostics_reporting value must not leak through.
+    localStorage.setItem("vellum_diagnostics_reporting", "true");
+    expect(getDeviceBool("diagnosticsReporting", false)).toBe(false);
+  });
 });
 
 describe("migrateDeviceSettings", () => {
@@ -134,6 +141,15 @@ describe("migrateDeviceSettings", () => {
 
     expect(localStorage.getItem("device:theme")).toBeNull();
     expect(localStorage.length).toBe(0);
+  });
+
+  test("leaves a legacy-less setting alone (no legacy key to migrate)", () => {
+    localStorage.setItem("vellum_diagnostics_reporting", "true");
+
+    migrateDeviceSettings();
+
+    expect(localStorage.getItem("vellum_diagnostics_reporting")).toBe("true");
+    expect(localStorage.getItem("device:diagnostics_reporting")).toBeNull();
   });
 
   test("preserves legacy key when storage write fails", () => {

--- a/clients/web/src/utils/device-settings.ts
+++ b/clients/web/src/utils/device-settings.ts
@@ -26,6 +26,16 @@ import {
 export const DEVICE_PREFIX = "device:";
 
 /**
+ * One device-scoped setting: its `device:`-prefixed key and, when it predates
+ * the prefix migration, the legacy non-prefixed key it migrated from.
+ */
+interface DeviceSettingEntry {
+  key: string;
+  /** Non-prefixed key migrated from. Absent for settings born post-migration. */
+  legacy?: string;
+}
+
+/**
  * Registry of device-scoped settings. Each entry maps a logical name
  * to its localStorage key and the legacy key it was migrated from.
  */
@@ -37,7 +47,7 @@ const DEVICE_SETTINGS = {
   // current privacy-consent version. Decoupled from `shareDiagnostics` (the
   // saved preference) so a stale-version record stops reporting without losing
   // the user's opt-in. No legacy key — introduced after the migration cutover.
-  diagnosticsReporting: { key: "device:diagnostics_reporting", legacy: "vellum_diagnostics_reporting" },
+  diagnosticsReporting: { key: "device:diagnostics_reporting" },
   biometricEnabled: { key: "device:biometric_enabled", legacy: "vellum_biometric_enabled" },
   llmLogRetention: { key: "device:llm_log_retention", legacy: "vellum_llm_log_retention" },
   timezone: { key: "device:timezone", legacy: "vellum_timezone" },
@@ -45,7 +55,7 @@ const DEVICE_SETTINGS = {
   mediaEmbedDomains: { key: "device:media_embed_domains", legacy: "vellum_media_embed_domains" },
   dockBadgesEnabled: { key: "device:dock_badges_enabled", legacy: "vellum_dock_badges_enabled" },
   lastUserId: { key: "device:last_user_id", legacy: "onboarding.lastUserId" },
-} as const;
+} as const satisfies Record<string, DeviceSettingEntry>;
 
 export type DeviceSettingName = keyof typeof DEVICE_SETTINGS;
 
@@ -54,13 +64,18 @@ export function deviceKey(name: DeviceSettingName): string {
   return DEVICE_SETTINGS[name].key;
 }
 
+/** Read an entry's legacy value, or `null` when it has no legacy key. */
+function readLegacy(entry: DeviceSettingEntry): string | null {
+  return entry.legacy != null ? localStorage.getItem(entry.legacy) : null;
+}
+
 /** Read a device-scoped setting, returning `fallback` when absent or unreadable. */
 export function getDeviceSetting(name: DeviceSettingName, fallback: string): string {
   if (typeof window === "undefined") return fallback;
   const entry = DEVICE_SETTINGS[name];
   try {
     return localStorage.getItem(entry.key)
-      ?? localStorage.getItem(entry.legacy)
+      ?? readLegacy(entry)
       ?? fallback;
   } catch {
     return fallback;
@@ -78,7 +93,7 @@ export function getDeviceBool(name: DeviceSettingName, fallback: boolean): boole
   const entry = DEVICE_SETTINGS[name];
   try {
     const raw = localStorage.getItem(entry.key)
-      ?? localStorage.getItem(entry.legacy);
+      ?? readLegacy(entry);
     if (raw === "true") return true;
     if (raw === "false") return false;
   } catch {
@@ -116,7 +131,8 @@ export function watchDeviceSetting(
 export function migrateDeviceSettings(): void {
   if (typeof window === "undefined") return;
   try {
-    for (const entry of Object.values(DEVICE_SETTINGS)) {
+    for (const entry of Object.values<DeviceSettingEntry>(DEVICE_SETTINGS)) {
+      if (entry.legacy == null) continue;
       const legacyValue = localStorage.getItem(entry.legacy);
       if (legacyValue !== null) {
         // Only write if the new key doesn't already exist — avoids


### PR DESCRIPTION
## Summary
- env.d.ts: present-tense per-host DSN comment (selector is live)
- device-settings: reconcile diagnosticsReporting legacy-key with its comment
- import diagnosticsConsentGranted directly from consent-gate (drop the sentry-control re-export hop)
No consent/gating behavior change.

Part of plan: sentry-overhaul.md (self-review remediation)