### PR TITLE
feat(telemetry): gate traces on flag + share_diagnostics + diagnostics-consent version

### DIFF
--- a/assistant/src/platform/client.test.ts
+++ b/assistant/src/platform/client.test.ts
@@ -189,6 +189,7 @@ describe("VellumPlatformClient", () => {
           JSON.stringify({
             share_analytics: true,
             share_diagnostics: false,
+            share_diagnostics_accepted_version: "2026-06-18",
           }),
           { status: 200 },
         );
@@ -199,6 +200,25 @@ describe("VellumPlatformClient", () => {
       expect(consent).toEqual({
         shareAnalytics: true,
         shareDiagnostics: false,
+        shareDiagnosticsAcceptedVersion: "2026-06-18",
+      });
+    });
+
+    test("defaults shareDiagnosticsAcceptedVersion to '' when the platform omits it (back-compat)", async () => {
+      globalThis.fetch = mock(
+        async () =>
+          new Response(
+            JSON.stringify({ share_analytics: true, share_diagnostics: true }),
+            { status: 200 },
+          ),
+      ) as unknown as typeof globalThis.fetch;
+
+      const client = await VellumPlatformClient.create();
+      const consent = await client!.getOwnerConsent();
+      expect(consent).toEqual({
+        shareAnalytics: true,
+        shareDiagnostics: true,
+        shareDiagnosticsAcceptedVersion: "",
       });
     });
 

--- a/assistant/src/platform/client.test.ts
+++ b/assistant/src/platform/client.test.ts
@@ -189,7 +189,6 @@ describe("VellumPlatformClient", () => {
           JSON.stringify({
             share_analytics: true,
             share_diagnostics: false,
-            diagnostics_trace_collection_enabled: true,
           }),
           { status: 200 },
         );
@@ -200,67 +199,7 @@ describe("VellumPlatformClient", () => {
       expect(consent).toEqual({
         shareAnalytics: true,
         shareDiagnostics: false,
-        diagnosticsTraceCollectionEnabled: true,
       });
-    });
-
-    test("diagnosticsTraceCollectionEnabled is false when the platform omits the field (older deploy)", async () => {
-      // The derived field is added by a later platform deploy. An older
-      // platform that returns only the share_* toggles must still yield a
-      // usable consent object — with trace collection off (fail-closed).
-      globalThis.fetch = mock(
-        async () =>
-          new Response(
-            JSON.stringify({ share_analytics: true, share_diagnostics: true }),
-            { status: 200 },
-          ),
-      ) as unknown as typeof globalThis.fetch;
-
-      const client = await VellumPlatformClient.create();
-      const consent = await client!.getOwnerConsent();
-      expect(consent).toEqual({
-        shareAnalytics: true,
-        shareDiagnostics: true,
-        diagnosticsTraceCollectionEnabled: false,
-      });
-    });
-
-    test("diagnosticsTraceCollectionEnabled is false for an explicit false", async () => {
-      globalThis.fetch = mock(
-        async () =>
-          new Response(
-            JSON.stringify({
-              share_analytics: true,
-              share_diagnostics: true,
-              diagnostics_trace_collection_enabled: false,
-            }),
-            { status: 200 },
-          ),
-      ) as unknown as typeof globalThis.fetch;
-
-      const client = await VellumPlatformClient.create();
-      const consent = await client!.getOwnerConsent();
-      expect(consent?.diagnosticsTraceCollectionEnabled).toBe(false);
-    });
-
-    test("diagnosticsTraceCollectionEnabled is false for a non-boolean value", async () => {
-      // Only an explicit boolean `true` enables trace collection; a truthy
-      // non-boolean (e.g. the string "true") must NOT.
-      globalThis.fetch = mock(
-        async () =>
-          new Response(
-            JSON.stringify({
-              share_analytics: true,
-              share_diagnostics: true,
-              diagnostics_trace_collection_enabled: "true",
-            }),
-            { status: 200 },
-          ),
-      ) as unknown as typeof globalThis.fetch;
-
-      const client = await VellumPlatformClient.create();
-      const consent = await client!.getOwnerConsent();
-      expect(consent?.diagnosticsTraceCollectionEnabled).toBe(false);
     });
 
     test("uses the authenticated Api-Key header", async () => {

--- a/assistant/src/platform/client.ts
+++ b/assistant/src/platform/client.ts
@@ -19,15 +19,6 @@ let _missingPrereqsWarned = false;
 export interface OwnerConsent {
   shareAnalytics: boolean;
   shareDiagnostics: boolean;
-  /**
-   * Server-derived eligibility for diagnostics *trace* collection (full
-   * per-turn transcripts). The platform folds the diagnostics LaunchDarkly
-   * flag, the owner's `share_diagnostics` toggle, and a privacy-policy-version
-   * check into this single boolean — the daemon never evaluates the flag
-   * itself. Fail-closed: `false` unless the platform sends an explicit boolean
-   * `true` (an absent field or a non-boolean value yields `false`).
-   */
-  diagnosticsTraceCollectionEnabled: boolean;
 }
 
 export class VellumPlatformClient {
@@ -151,7 +142,6 @@ export class VellumPlatformClient {
       const body = (await res.json()) as {
         share_analytics?: unknown;
         share_diagnostics?: unknown;
-        diagnostics_trace_collection_enabled?: unknown;
       };
       if (
         typeof body.share_analytics !== "boolean" ||
@@ -164,13 +154,6 @@ export class VellumPlatformClient {
       return {
         shareAnalytics: body.share_analytics,
         shareDiagnostics: body.share_diagnostics,
-        // Fail closed: only an explicit boolean `true` enables trace
-        // collection; an absent field or a non-boolean value yields `false`.
-        // This field is validated independently of the `share_*` checks above,
-        // so a payload that carries the share toggles but omits this field
-        // still yields a usable consent object (with trace collection off).
-        diagnosticsTraceCollectionEnabled:
-          body.diagnostics_trace_collection_enabled === true,
       };
     } catch (err) {
       log.debug({ err }, "owner-consent fetch failed — treating as unknown");

--- a/assistant/src/platform/client.ts
+++ b/assistant/src/platform/client.ts
@@ -19,6 +19,13 @@ let _missingPrereqsWarned = false;
 export interface OwnerConsent {
   shareAnalytics: boolean;
   shareDiagnostics: boolean;
+  /**
+   * Version of the diagnostics-sharing consent the owner accepted
+   * ("YYYY-MM-DD", or "" if never accepted). Composes the per-turn
+   * trace-collection gate: traces are only collected once this is >= the
+   * disclosing version (see telemetry/trace-collection-policy.ts).
+   */
+  shareDiagnosticsAcceptedVersion: string;
 }
 
 export class VellumPlatformClient {
@@ -142,6 +149,7 @@ export class VellumPlatformClient {
       const body = (await res.json()) as {
         share_analytics?: unknown;
         share_diagnostics?: unknown;
+        share_diagnostics_accepted_version?: unknown;
       };
       if (
         typeof body.share_analytics !== "boolean" ||
@@ -154,6 +162,12 @@ export class VellumPlatformClient {
       return {
         shareAnalytics: body.share_analytics,
         shareDiagnostics: body.share_diagnostics,
+        // Back-compat: an older platform that doesn't return this field yields
+        // "" → fails the trace-collection version gate → fail-closed (no trace).
+        shareDiagnosticsAcceptedVersion:
+          typeof body.share_diagnostics_accepted_version === "string"
+            ? body.share_diagnostics_accepted_version
+            : "",
       };
     } catch (err) {
       log.debug({ err }, "owner-consent fetch failed — treating as unknown");

--- a/assistant/src/platform/consent-cache.test.ts
+++ b/assistant/src/platform/consent-cache.test.ts
@@ -48,8 +48,10 @@ mock.module("../util/logger.js", () => ({
 import {
   __setCachedShareAnalyticsForTest,
   __setCachedShareDiagnosticsForTest,
+  __setCachedShareDiagnosticsVersionForTest,
   getCachedShareAnalytics,
   getCachedShareDiagnostics,
+  getCachedShareDiagnosticsVersion,
   refreshConsentCache,
   startConsentRefresh,
   stopConsentRefresh,
@@ -63,6 +65,7 @@ function makeConsent(overrides: Partial<OwnerConsent> = {}): OwnerConsent {
   return {
     shareAnalytics: false,
     shareDiagnostics: false,
+    shareDiagnosticsAcceptedVersion: "",
     ...overrides,
   };
 }
@@ -81,6 +84,7 @@ describe("consent-cache", () => {
     mockLegacyTelemetryOptOut = false;
     __setCachedShareAnalyticsForTest(false);
     __setCachedShareDiagnosticsForTest(false);
+    __setCachedShareDiagnosticsVersionForTest("");
   });
 
   afterEach(async () => {
@@ -213,5 +217,51 @@ describe("consent-cache", () => {
     mockClient = makeClient(makeConsent({ shareDiagnostics: true }), "");
     await refreshConsentCache();
     expect(getCachedShareDiagnostics()).toBe(false);
+  });
+
+  test("caches the accepted diagnostics-consent version from a successful fetch", async () => {
+    mockClient = makeClient(
+      makeConsent({
+        shareDiagnostics: true,
+        shareDiagnosticsAcceptedVersion: "2026-06-18",
+      }),
+    );
+    await refreshConsentCache();
+    expect(getCachedShareDiagnosticsVersion()).toBe("2026-06-18");
+  });
+
+  test("a missing client clears a prior cached diagnostics version", async () => {
+    __setCachedShareDiagnosticsVersionForTest("2026-06-18");
+    mockClient = null;
+    await refreshConsentCache();
+    expect(getCachedShareDiagnosticsVersion()).toBe("");
+  });
+
+  test("a client without a resolvable assistant identity clears the diagnostics version", async () => {
+    __setCachedShareDiagnosticsVersionForTest("2026-06-18");
+    mockClient = makeClient(
+      makeConsent({
+        shareDiagnostics: true,
+        shareDiagnosticsAcceptedVersion: "2026-06-18",
+      }),
+      "",
+    );
+    await refreshConsentCache();
+    expect(getCachedShareDiagnosticsVersion()).toBe("");
+  });
+
+  test("a null fetch keeps the last known diagnostics version", async () => {
+    mockClient = makeClient(
+      makeConsent({
+        shareDiagnostics: true,
+        shareDiagnosticsAcceptedVersion: "2026-06-18",
+      }),
+    );
+    await refreshConsentCache();
+    expect(getCachedShareDiagnosticsVersion()).toBe("2026-06-18");
+
+    mockClient = makeClient(null);
+    await refreshConsentCache();
+    expect(getCachedShareDiagnosticsVersion()).toBe("2026-06-18");
   });
 });

--- a/assistant/src/platform/consent-cache.test.ts
+++ b/assistant/src/platform/consent-cache.test.ts
@@ -46,10 +46,8 @@ mock.module("../util/logger.js", () => ({
 // ---------------------------------------------------------------------------
 
 import {
-  __setCachedDiagnosticsTraceCollectionEnabledForTest,
   __setCachedShareAnalyticsForTest,
   __setCachedShareDiagnosticsForTest,
-  getCachedDiagnosticsTraceCollectionEnabled,
   getCachedShareAnalytics,
   getCachedShareDiagnostics,
   refreshConsentCache,
@@ -58,14 +56,13 @@ import {
 } from "./consent-cache.js";
 
 /**
- * Build a mock owner consent. `diagnosticsTraceCollectionEnabled` defaults to
- * `false` so existing share_analytics-focused cases don't have to spell it out.
+ * Build a mock owner consent. Fields default to `false` so existing
+ * share_analytics-focused cases don't have to spell them out.
  */
 function makeConsent(overrides: Partial<OwnerConsent> = {}): OwnerConsent {
   return {
     shareAnalytics: false,
     shareDiagnostics: false,
-    diagnosticsTraceCollectionEnabled: false,
     ...overrides,
   };
 }
@@ -84,7 +81,6 @@ describe("consent-cache", () => {
     mockLegacyTelemetryOptOut = false;
     __setCachedShareAnalyticsForTest(false);
     __setCachedShareDiagnosticsForTest(false);
-    __setCachedDiagnosticsTraceCollectionEnabledForTest(false);
   });
 
   afterEach(async () => {
@@ -148,94 +144,6 @@ describe("consent-cache", () => {
     mockClient = makeClient(makeConsent({ shareDiagnostics: true }));
     await refreshConsentCache();
     expect(getCachedShareAnalytics()).toBe(false);
-  });
-
-  // -------------------------------------------------------------------------
-  // diagnostics trace-collection consent
-  // -------------------------------------------------------------------------
-
-  test("diagnostics trace collection defaults to false before any refresh", () => {
-    expect(getCachedDiagnosticsTraceCollectionEnabled()).toBe(false);
-  });
-
-  test("becomes true after a fetch reporting diagnosticsTraceCollectionEnabled: true", async () => {
-    mockClient = makeClient(
-      makeConsent({
-        shareAnalytics: true,
-        diagnosticsTraceCollectionEnabled: true,
-      }),
-    );
-    await refreshConsentCache();
-    expect(getCachedDiagnosticsTraceCollectionEnabled()).toBe(true);
-  });
-
-  test("trace collection is independent of share_analytics", async () => {
-    // The owner can have analytics on but trace collection off, or vice
-    // versa — they are separate consent dimensions on the same payload.
-    mockClient = makeClient(
-      makeConsent({
-        shareAnalytics: false,
-        diagnosticsTraceCollectionEnabled: true,
-      }),
-    );
-    await refreshConsentCache();
-    expect(getCachedShareAnalytics()).toBe(false);
-    expect(getCachedDiagnosticsTraceCollectionEnabled()).toBe(true);
-  });
-
-  test("a fetch reporting diagnosticsTraceCollectionEnabled: false turns the trace cache off", async () => {
-    __setCachedDiagnosticsTraceCollectionEnabledForTest(true);
-    mockClient = makeClient(
-      makeConsent({ diagnosticsTraceCollectionEnabled: false }),
-    );
-    await refreshConsentCache();
-    expect(getCachedDiagnosticsTraceCollectionEnabled()).toBe(false);
-  });
-
-  test("a null fetch keeps the last known trace-collection value", async () => {
-    mockClient = makeClient(
-      makeConsent({ diagnosticsTraceCollectionEnabled: true }),
-    );
-    await refreshConsentCache();
-    expect(getCachedDiagnosticsTraceCollectionEnabled()).toBe(true);
-
-    // Transient failure: consent endpoint returns null — keep the opt-in.
-    mockClient = makeClient(null);
-    await refreshConsentCache();
-    expect(getCachedDiagnosticsTraceCollectionEnabled()).toBe(true);
-  });
-
-  test("a missing client flips a prior trace opt-in back to false", async () => {
-    __setCachedDiagnosticsTraceCollectionEnabledForTest(true);
-    mockClient = null;
-    await refreshConsentCache();
-    expect(getCachedDiagnosticsTraceCollectionEnabled()).toBe(false);
-  });
-
-  test("a client without a resolvable assistant identity fails the trace gate closed", async () => {
-    __setCachedDiagnosticsTraceCollectionEnabledForTest(true);
-    mockClient = makeClient(
-      makeConsent({ diagnosticsTraceCollectionEnabled: true }),
-      "",
-    );
-    await refreshConsentCache();
-    expect(getCachedDiagnosticsTraceCollectionEnabled()).toBe(false);
-  });
-
-  test("the legacy analytics opt-out marker does NOT gate the trace accessor", async () => {
-    // The trace accessor answers only "did the owner consent to trace
-    // collection." The flush-level share_analytics gate (which IS subject to
-    // the legacy marker) is what enforces the global telemetry off-switch.
-    mockLegacyTelemetryOptOut = true;
-    mockClient = makeClient(
-      makeConsent({
-        shareAnalytics: true,
-        diagnosticsTraceCollectionEnabled: true,
-      }),
-    );
-    await refreshConsentCache();
-    expect(getCachedShareAnalytics()).toBe(false);
-    expect(getCachedDiagnosticsTraceCollectionEnabled()).toBe(true);
   });
 
   test("startConsentRefresh is idempotent and runs an immediate refresh", async () => {

--- a/assistant/src/platform/consent-cache.ts
+++ b/assistant/src/platform/consent-cache.ts
@@ -1,19 +1,18 @@
 /**
  * In-memory cache of the platform owner's telemetry consent.
  *
- * Three values are cached, all refreshed from the same owner-consent fetch:
+ * Two values are cached, both refreshed from the same owner-consent fetch:
  *  - `share_analytics`: gates usage telemetry collection.
- *  - `share_diagnostics`: gates crash diagnostics (read by Sentry `beforeSend`).
- *  - `diagnostics_trace_collection_enabled`: gates attaching per-turn PII traces
- *    to telemetry. Server-derived (LD flag + `share_diagnostics` +
- *    privacy-policy version, folded by the platform).
+ *  - `share_diagnostics`: gates crash diagnostics (read by Sentry `beforeSend`),
+ *    and composes the per-turn trace-collection gate alongside the
+ *    `trace-collection` feature flag.
  *
  * Hot-path gates (record-time telemetry writes, Sentry `beforeSend`) need a
  * synchronous, I/O-free read, so this module owns the values and refreshes them
  * periodically in the background. Default-off until the first successful fetch:
  * an absent session, a disabled platform, or a transient fetch failure all leave
- * the values untouched (initial `false`), so we never report analytics, send
- * crash diagnostics, or attach a trace without a confirmed opt-in.
+ * the values untouched (initial `false`), so we never report analytics or send
+ * crash diagnostics without a confirmed opt-in.
  */
 
 import { getConfigReadOnly } from "../config/loader.js";
@@ -26,7 +25,6 @@ const REFRESH_INTERVAL_MS = 5 * 60_000; // refresh consent every 5 min
 
 let cachedShareAnalytics = false; // default-off until first success
 let cachedShareDiagnostics = false; // default-off until first success
-let cachedDiagnosticsTraceCollectionEnabled = false; // default-off until first success
 // Fail-closed marker for a workspace that locally opted out of usage data
 // before telemetry moved to platform `share_analytics` consent (migration 106).
 // While set, telemetry stays off regardless of platform consent. Cleared by a
@@ -55,17 +53,6 @@ export function getCachedShareDiagnostics(): boolean {
 }
 
 /**
- * Synchronous hot-path accessor for the owner's diagnostics trace-collection
- * eligibility. Never does I/O; `false` until a successful refresh proves
- * otherwise. Independent of the legacy analytics opt-out marker: the telemetry
- * flush already refuses to send anything when `getCachedShareAnalytics()` is
- * false, so this answers only "did the owner consent to trace collection."
- */
-export function getCachedDiagnosticsTraceCollectionEnabled(): boolean {
-  return cachedDiagnosticsTraceCollectionEnabled;
-}
-
-/**
  * Refresh the cached consent from the platform.
  *
  * No platform session / features disabled (`create()` is null) → default-off.
@@ -81,7 +68,6 @@ export async function refreshConsentCache(): Promise<void> {
   if (!client) {
     setCachedShareAnalytics(false);
     setCachedShareDiagnostics(false);
-    setCachedDiagnosticsTraceCollectionEnabled(false);
     return;
   }
 
@@ -89,7 +75,6 @@ export async function refreshConsentCache(): Promise<void> {
   if (!client.platformAssistantId) {
     setCachedShareAnalytics(false);
     setCachedShareDiagnostics(false);
-    setCachedDiagnosticsTraceCollectionEnabled(false);
     return;
   }
 
@@ -97,9 +82,6 @@ export async function refreshConsentCache(): Promise<void> {
   if (consent) {
     setCachedShareAnalytics(consent.shareAnalytics);
     setCachedShareDiagnostics(consent.shareDiagnostics);
-    setCachedDiagnosticsTraceCollectionEnabled(
-      consent.diagnosticsTraceCollectionEnabled,
-    );
   }
 }
 
@@ -120,16 +102,6 @@ function setCachedShareDiagnostics(value: boolean): void {
       "share_diagnostics consent changed",
     );
     cachedShareDiagnostics = value;
-  }
-}
-
-function setCachedDiagnosticsTraceCollectionEnabled(value: boolean): void {
-  if (value !== cachedDiagnosticsTraceCollectionEnabled) {
-    log.debug(
-      { from: cachedDiagnosticsTraceCollectionEnabled, to: value },
-      "diagnostics_trace_collection_enabled consent changed",
-    );
-    cachedDiagnosticsTraceCollectionEnabled = value;
   }
 }
 
@@ -168,11 +140,4 @@ export function __setCachedShareAnalyticsForTest(value: boolean): void {
 /** Test-only: override the cached diagnostics value without going through a refresh. */
 export function __setCachedShareDiagnosticsForTest(value: boolean): void {
   cachedShareDiagnostics = value;
-}
-
-/** Test-only: override the cached trace-collection value without a refresh. */
-export function __setCachedDiagnosticsTraceCollectionEnabledForTest(
-  value: boolean,
-): void {
-  cachedDiagnosticsTraceCollectionEnabled = value;
 }

--- a/assistant/src/platform/consent-cache.ts
+++ b/assistant/src/platform/consent-cache.ts
@@ -1,11 +1,14 @@
 /**
  * In-memory cache of the platform owner's telemetry consent.
  *
- * Two values are cached, both refreshed from the same owner-consent fetch:
+ * Three values are cached, all refreshed from the same owner-consent fetch:
  *  - `share_analytics`: gates usage telemetry collection.
  *  - `share_diagnostics`: gates crash diagnostics (read by Sentry `beforeSend`),
  *    and composes the per-turn trace-collection gate alongside the
  *    `trace-collection` feature flag.
+ *  - `share_diagnostics_accepted_version`: the consent version the owner
+ *    accepted; the disclosing-version half of the trace-collection gate (see
+ *    telemetry/trace-collection-policy.ts).
  *
  * Hot-path gates (record-time telemetry writes, Sentry `beforeSend`) need a
  * synchronous, I/O-free read, so this module owns the values and refreshes them
@@ -25,6 +28,7 @@ const REFRESH_INTERVAL_MS = 5 * 60_000; // refresh consent every 5 min
 
 let cachedShareAnalytics = false; // default-off until first success
 let cachedShareDiagnostics = false; // default-off until first success
+let cachedShareDiagnosticsVersion = ""; // "" fails the trace disclosure gate
 // Fail-closed marker for a workspace that locally opted out of usage data
 // before telemetry moved to platform `share_analytics` consent (migration 106).
 // While set, telemetry stays off regardless of platform consent. Cleared by a
@@ -53,6 +57,15 @@ export function getCachedShareDiagnostics(): boolean {
 }
 
 /**
+ * Synchronous hot-path accessor for the owner's accepted diagnostics-consent
+ * version ("YYYY-MM-DD", or "" until a successful refresh / if never accepted).
+ * The disclosing-version half of the per-turn trace-collection gate.
+ */
+export function getCachedShareDiagnosticsVersion(): string {
+  return cachedShareDiagnosticsVersion;
+}
+
+/**
  * Refresh the cached consent from the platform.
  *
  * No platform session / features disabled (`create()` is null) → default-off.
@@ -68,6 +81,7 @@ export async function refreshConsentCache(): Promise<void> {
   if (!client) {
     setCachedShareAnalytics(false);
     setCachedShareDiagnostics(false);
+    setCachedShareDiagnosticsVersion("");
     return;
   }
 
@@ -75,6 +89,7 @@ export async function refreshConsentCache(): Promise<void> {
   if (!client.platformAssistantId) {
     setCachedShareAnalytics(false);
     setCachedShareDiagnostics(false);
+    setCachedShareDiagnosticsVersion("");
     return;
   }
 
@@ -82,6 +97,7 @@ export async function refreshConsentCache(): Promise<void> {
   if (consent) {
     setCachedShareAnalytics(consent.shareAnalytics);
     setCachedShareDiagnostics(consent.shareDiagnostics);
+    setCachedShareDiagnosticsVersion(consent.shareDiagnosticsAcceptedVersion);
   }
 }
 
@@ -102,6 +118,16 @@ function setCachedShareDiagnostics(value: boolean): void {
       "share_diagnostics consent changed",
     );
     cachedShareDiagnostics = value;
+  }
+}
+
+function setCachedShareDiagnosticsVersion(value: string): void {
+  if (value !== cachedShareDiagnosticsVersion) {
+    log.debug(
+      { from: cachedShareDiagnosticsVersion, to: value },
+      "share_diagnostics_accepted_version changed",
+    );
+    cachedShareDiagnosticsVersion = value;
   }
 }
 
@@ -140,4 +166,9 @@ export function __setCachedShareAnalyticsForTest(value: boolean): void {
 /** Test-only: override the cached diagnostics value without going through a refresh. */
 export function __setCachedShareDiagnosticsForTest(value: boolean): void {
   cachedShareDiagnostics = value;
+}
+
+/** Test-only: override the cached diagnostics-consent version directly. */
+export function __setCachedShareDiagnosticsVersionForTest(value: string): void {
+  cachedShareDiagnosticsVersion = value;
 }

--- a/assistant/src/telemetry/trace-collection-policy.test.ts
+++ b/assistant/src/telemetry/trace-collection-policy.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isDiagnosticsConsentVersionEligible,
+  TRACE_COLLECTION_MIN_DIAGNOSTICS_CONSENT_VERSION,
+} from "./trace-collection-policy.js";
+
+describe("isDiagnosticsConsentVersionEligible", () => {
+  test("the threshold version itself is eligible (>=, inclusive boundary)", () => {
+    expect(
+      isDiagnosticsConsentVersionEligible(
+        TRACE_COLLECTION_MIN_DIAGNOSTICS_CONSENT_VERSION,
+      ),
+    ).toBe(true);
+  });
+
+  test("a later version is eligible", () => {
+    expect(isDiagnosticsConsentVersionEligible("2999-01-01")).toBe(true);
+  });
+
+  test("an earlier version fails closed", () => {
+    expect(isDiagnosticsConsentVersionEligible("2000-01-01")).toBe(false);
+  });
+
+  test("the empty version (never accepted / unversioned default) fails closed", () => {
+    expect(isDiagnosticsConsentVersionEligible("")).toBe(false);
+  });
+});

--- a/assistant/src/telemetry/trace-collection-policy.ts
+++ b/assistant/src/telemetry/trace-collection-policy.ts
@@ -1,0 +1,30 @@
+/**
+ * Per-turn trace-collection disclosure gate (daemon side).
+ *
+ * A "trace" is the full transcript of one assistant turn. Traces are only
+ * collected from owners who accepted the diagnostics-sharing consent copy that
+ * *discloses* trace collection — identified by its accepted version.
+ *
+ * This mirrors the platform's authoritative ingest gate in
+ * `vellum-assistant-platform`:
+ *   - `django/app/core/trace_collection.py` (`is_trace_collection_enabled`)
+ *   - `config.settings.TRACE_COLLECTION_MIN_DIAGNOSTICS_CONSENT_VERSION`
+ *
+ * The daemon applies the same `share_diagnostics_accepted_version >= threshold`
+ * check the platform does, so traces for ineligible owners never leave the
+ * device. (The platform would drop them anyway, but checking here keeps the PII
+ * local — data minimization.)
+ *
+ * Keep this constant in lockstep with the platform setting. Versions are
+ * "YYYY-MM-DD" strings, so the lexicographic compare is chronological; ""
+ * (never accepted) and older versions fail closed.
+ */
+export const TRACE_COLLECTION_MIN_DIAGNOSTICS_CONSENT_VERSION = "2026-06-18";
+
+/**
+ * True iff `version` (the owner's `share_diagnostics_accepted_version`) is at or
+ * past the disclosing version. Fails closed for "" / older versions.
+ */
+export function isDiagnosticsConsentVersionEligible(version: string): boolean {
+  return version >= TRACE_COLLECTION_MIN_DIAGNOSTICS_CONSENT_VERSION;
+}

--- a/assistant/src/telemetry/types.ts
+++ b/assistant/src/telemetry/types.ts
@@ -196,8 +196,8 @@ export interface TurnTraceToolCall {
  * Full transcript of a single turn — the user message, assistant response
  * message(s), and the tool calls + results that occurred between this user
  * turn and the next real user turn. Attached to the turn telemetry event's
- * `trace` field ONLY when the owner has consented
- * (`diagnostics_trace_collection_enabled` on the owner-consent endpoint).
+ * `trace` field ONLY when trace collection is enabled — the `trace-collection`
+ * feature flag AND the owner's `share_diagnostics` consent must both be true.
  * The platform stores this verbatim as an opaque JSON column, so the daemon
  * owns the shape.
  *
@@ -278,15 +278,15 @@ export interface TurnTelemetryEvent extends TelemetryEventBase {
   client: TurnTelemetryClientInfo | null;
   /**
    * Full per-turn transcript (user message + assistant responses + tool
-   * calls/results). Present ONLY when the assistant owner has consented to
-   * diagnostics trace collection — the daemon reads the derived
-   * `diagnostics_trace_collection_enabled` boolean from the platform's
-   * owner-consent endpoint and attaches the trace fail-closed (absent field,
-   * fetch failure, or `false` → no trace). The platform dual-writes consented
-   * traces into a separate PII table and keeps the trace-free turn row;
-   * downstream consumers that don't read traces ignore this field. Null /
-   * absent when consent is off, unknown, or the serialized trace exceeded the
-   * size cap.
+   * calls/results). Present ONLY when trace collection is enabled — the daemon
+   * composes the gate itself from the `trace-collection` feature flag (delivered
+   * via the assistant-tagged flag sync, evaluated server-side for this
+   * assistant's owner) AND the owner's cached `share_diagnostics` consent, both
+   * of which must be true. Fail-closed: when either is off (or unknown) no trace
+   * is attached. The platform dual-writes consented traces into a separate PII
+   * table and keeps the trace-free turn row; downstream consumers that don't
+   * read traces ignore this field. Null / absent when the gate is off or the
+   * serialized trace exceeded the size cap.
    */
   trace?: TurnTrace | null;
 }

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -93,12 +93,27 @@ mock.module("../version.js", () => ({
 }));
 
 const mockGetCachedShareAnalytics = mock(() => true);
-const mockGetCachedDiagnosticsTraceCollectionEnabled = mock(() => false);
+// Owner's `share_diagnostics` consent — one half of the trace-collection gate.
+const mockGetCachedShareDiagnostics = mock(() => false);
 
 mock.module("../platform/consent-cache.js", () => ({
   getCachedShareAnalytics: mockGetCachedShareAnalytics,
-  getCachedDiagnosticsTraceCollectionEnabled:
-    mockGetCachedDiagnosticsTraceCollectionEnabled,
+  getCachedShareDiagnostics: mockGetCachedShareDiagnostics,
+}));
+
+// The `trace-collection` feature flag — the other half of the trace gate.
+const mockIsAssistantFeatureFlagEnabled = mock(
+  (_key: string, _config: unknown): boolean => true,
+);
+
+mock.module("../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: mockIsAssistantFeatureFlagEnabled,
+}));
+
+// Stub config — the flag checker is mocked, so the contents don't matter; this
+// just keeps `getConfig()` from touching the real loader / filesystem.
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({}),
 }));
 
 interface MockTurnTrace {
@@ -338,10 +353,14 @@ beforeEach(() => {
   // Default consent ON so the happy-path send tests exercise the flush.
   mockGetCachedShareAnalytics.mockReset();
   mockGetCachedShareAnalytics.mockReturnValue(true);
-  // Default trace-collection consent OFF — most tests don't expect a trace;
+  // Default `share_diagnostics` consent OFF — most tests don't expect a trace;
   // the trace-specific tests opt in explicitly.
-  mockGetCachedDiagnosticsTraceCollectionEnabled.mockReset();
-  mockGetCachedDiagnosticsTraceCollectionEnabled.mockReturnValue(false);
+  mockGetCachedShareDiagnostics.mockReset();
+  mockGetCachedShareDiagnostics.mockReturnValue(false);
+  // Default the `trace-collection` flag ON so trace tests can drive eligibility
+  // via the consent knob alone; the flag-gating test flips it explicitly.
+  mockIsAssistantFeatureFlagEnabled.mockReset();
+  mockIsAssistantFeatureFlagEnabled.mockReturnValue(true);
   mockAssembleBoundedTurnTrace.mockReset();
   mockAssembleBoundedTurnTrace.mockImplementation(defaultBoundedTurnTrace);
   mockIsTurnSettled.mockReset();
@@ -1022,7 +1041,8 @@ describe("UsageTelemetryReporter", () => {
   });
 
   // -------------------------------------------------------------------------
-  // Per-turn trace collection (owner-consent gated)
+  // Per-turn trace collection (gated on the trace-collection flag AND
+  // share_diagnostics consent)
   // -------------------------------------------------------------------------
 
   function singleTurnEvent() {
@@ -1040,8 +1060,9 @@ describe("UsageTelemetryReporter", () => {
     ];
   }
 
-  test("attaches the assembled trace to the turn event when trace consent is enabled", async () => {
-    mockGetCachedDiagnosticsTraceCollectionEnabled.mockReturnValue(true);
+  test("attaches the assembled trace when BOTH the trace-collection flag and share_diagnostics are true", async () => {
+    mockIsAssistantFeatureFlagEnabled.mockReturnValue(true);
+    mockGetCachedShareDiagnostics.mockReturnValue(true);
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
     mockQueryUnreportedTurnEvents.mockReturnValue(singleTurnEvent());
     mockFetch.mockImplementation(() =>
@@ -1050,6 +1071,12 @@ describe("UsageTelemetryReporter", () => {
 
     const reporter = new UsageTelemetryReporter();
     await reporter.flush();
+
+    // The gate consults the `trace-collection` flag.
+    expect(mockIsAssistantFeatureFlagEnabled).toHaveBeenCalledWith(
+      "trace-collection",
+      expect.anything(),
+    );
 
     // The assembler is called with the turn's (conversationId, id, createdAt)
     // boundary so the window lines up with the turn event.
@@ -1075,8 +1102,9 @@ describe("UsageTelemetryReporter", () => {
     expect(Array.isArray(turn.trace.tool_calls)).toBe(true);
   });
 
-  test("omits the trace when trace consent is disabled (and still emits the turn event)", async () => {
-    mockGetCachedDiagnosticsTraceCollectionEnabled.mockReturnValue(false);
+  test("omits the trace when share_diagnostics is false even though the flag is on (and still emits the turn event)", async () => {
+    mockIsAssistantFeatureFlagEnabled.mockReturnValue(true);
+    mockGetCachedShareDiagnostics.mockReturnValue(false);
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
     mockQueryUnreportedTurnEvents.mockReturnValue(singleTurnEvent());
     mockFetch.mockImplementation(() =>
@@ -1086,7 +1114,7 @@ describe("UsageTelemetryReporter", () => {
     const reporter = new UsageTelemetryReporter();
     await reporter.flush();
 
-    // Consent off → no assembly at all (no PII touched).
+    // Gate off → no assembly at all (no PII touched).
     expect(mockAssembleBoundedTurnTrace).not.toHaveBeenCalled();
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -1101,8 +1129,32 @@ describe("UsageTelemetryReporter", () => {
     expect("trace" in turn).toBe(false);
   });
 
+  test("omits the trace when the trace-collection flag is off even though share_diagnostics is true", async () => {
+    mockIsAssistantFeatureFlagEnabled.mockReturnValue(false);
+    mockGetCachedShareDiagnostics.mockReturnValue(true);
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    mockQueryUnreportedTurnEvents.mockReturnValue(singleTurnEvent());
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
+    );
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    // Flag off → gate closed → no assembly at all (no PII touched).
+    expect(mockAssembleBoundedTurnTrace).not.toHaveBeenCalled();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    // The single turn event still flushes — just without a trace.
+    expect(body.events.length).toBe(1);
+    expect("trace" in body.events[0]).toBe(false);
+  });
+
   test("omits the trace (key absent) when the assembler returns null (over-cap / failure) but still emits the turn event", async () => {
-    mockGetCachedDiagnosticsTraceCollectionEnabled.mockReturnValue(true);
+    mockGetCachedShareDiagnostics.mockReturnValue(true);
     // Over-cap / assembly-failure path: the bounded assembler returns null.
     mockAssembleBoundedTurnTrace.mockReturnValueOnce(null);
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
@@ -1124,9 +1176,11 @@ describe("UsageTelemetryReporter", () => {
 
   test("no trace is assembled or attached when the whole flush is gated off by share_analytics", async () => {
     // The analytics gate short-circuits the entire flush; trace assembly must
-    // never run (and nothing is sent) even if trace consent is on.
+    // never run (and nothing is sent) even when the trace gate is fully on
+    // (flag + share_diagnostics both true).
     mockGetCachedShareAnalytics.mockReturnValue(false);
-    mockGetCachedDiagnosticsTraceCollectionEnabled.mockReturnValue(true);
+    mockIsAssistantFeatureFlagEnabled.mockReturnValue(true);
+    mockGetCachedShareDiagnostics.mockReturnValue(true);
     mockQueryUnreportedTurnEvents.mockReturnValue(singleTurnEvent());
 
     const reporter = new UsageTelemetryReporter();
@@ -1154,7 +1208,7 @@ describe("UsageTelemetryReporter", () => {
   }
 
   test("a flush during an in-progress turn defers it (no partial trace, watermark held)", async () => {
-    mockGetCachedDiagnosticsTraceCollectionEnabled.mockReturnValue(true);
+    mockGetCachedShareDiagnostics.mockReturnValue(true);
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
     const checkpoints = useStatefulCheckpoints();
     mockQueryUnreportedTurnEvents.mockReturnValue([
@@ -1175,7 +1229,7 @@ describe("UsageTelemetryReporter", () => {
   });
 
   test("a later flush emits the COMPLETE trace once the turn settles", async () => {
-    mockGetCachedDiagnosticsTraceCollectionEnabled.mockReturnValue(true);
+    mockGetCachedShareDiagnostics.mockReturnValue(true);
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
     const checkpoints = useStatefulCheckpoints();
     mockQueryUnreportedTurnEvents.mockReturnValue([
@@ -1237,7 +1291,7 @@ describe("UsageTelemetryReporter", () => {
     // No successor turn exists; `isTurnSettled` returns true purely because the
     // conversation is no longer processing. The trace must still be sent (not
     // deferred forever for lack of a next user turn).
-    mockGetCachedDiagnosticsTraceCollectionEnabled.mockReturnValue(true);
+    mockGetCachedShareDiagnostics.mockReturnValue(true);
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
     mockQueryUnreportedTurnEvents.mockReturnValue([
       turnEvent("evt-final", 1700000060000, "conv-final"),
@@ -1265,7 +1319,7 @@ describe("UsageTelemetryReporter", () => {
     // sorts after a deferred in-flight turn cannot be reported without skipping
     // the deferred one. Both wait; the earlier complete turn (before the
     // barrier) is reported.
-    mockGetCachedDiagnosticsTraceCollectionEnabled.mockReturnValue(true);
+    mockGetCachedShareDiagnostics.mockReturnValue(true);
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
     const checkpoints = useStatefulCheckpoints();
     mockQueryUnreportedTurnEvents.mockReturnValue([
@@ -1306,7 +1360,7 @@ describe("UsageTelemetryReporter", () => {
     // The completeness barrier is trace-eligible-only. With trace collection
     // off, turn telemetry / turn_raw behavior is unchanged: the turn ships
     // immediately and `isTurnSettled` is never consulted.
-    mockGetCachedDiagnosticsTraceCollectionEnabled.mockReturnValue(false);
+    mockGetCachedShareDiagnostics.mockReturnValue(false);
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
     const checkpoints = useStatefulCheckpoints();
     mockQueryUnreportedTurnEvents.mockReturnValue([

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -93,12 +93,18 @@ mock.module("../version.js", () => ({
 }));
 
 const mockGetCachedShareAnalytics = mock(() => true);
-// Owner's `share_diagnostics` consent — one half of the trace-collection gate.
+// Owner's `share_diagnostics` consent — one part of the trace-collection gate.
 const mockGetCachedShareDiagnostics = mock(() => false);
+// Owner's accepted diagnostics-consent version — the disclosing-version part of
+// the trace gate. Default to a far-future (unconditionally eligible) version so
+// the consent/flag cases drive eligibility on those axes; the version-specific
+// cases override it with old/empty values.
+const mockGetCachedShareDiagnosticsVersion = mock(() => "2999-01-01");
 
 mock.module("../platform/consent-cache.js", () => ({
   getCachedShareAnalytics: mockGetCachedShareAnalytics,
   getCachedShareDiagnostics: mockGetCachedShareDiagnostics,
+  getCachedShareDiagnosticsVersion: mockGetCachedShareDiagnosticsVersion,
 }));
 
 // The `trace-collection` feature flag — the other half of the trace gate.
@@ -357,6 +363,10 @@ beforeEach(() => {
   // the trace-specific tests opt in explicitly.
   mockGetCachedShareDiagnostics.mockReset();
   mockGetCachedShareDiagnostics.mockReturnValue(false);
+  // Default the accepted consent version eligible so trace tests drive the gate
+  // via the flag + share_diagnostics knobs; version cases override it.
+  mockGetCachedShareDiagnosticsVersion.mockReset();
+  mockGetCachedShareDiagnosticsVersion.mockReturnValue("2999-01-01");
   // Default the `trace-collection` flag ON so trace tests can drive eligibility
   // via the consent knob alone; the flag-gating test flips it explicitly.
   mockIsAssistantFeatureFlagEnabled.mockReset();
@@ -1060,7 +1070,7 @@ describe("UsageTelemetryReporter", () => {
     ];
   }
 
-  test("attaches the assembled trace when BOTH the trace-collection flag and share_diagnostics are true", async () => {
+  test("attaches the assembled trace when the trace-collection flag, share_diagnostics, and an eligible consent version are all true", async () => {
     mockIsAssistantFeatureFlagEnabled.mockReturnValue(true);
     mockGetCachedShareDiagnostics.mockReturnValue(true);
     mockQueryUnreportedUsageEvents.mockReturnValue([]);
@@ -1127,6 +1137,55 @@ describe("UsageTelemetryReporter", () => {
     expect(turn.type).toBe("turn");
     expect(turn.daemon_event_id).toBe("evt-turn-trace");
     expect("trace" in turn).toBe(false);
+  });
+
+  test("omits the trace when the accepted consent version predates the disclosure threshold (flag + share_diagnostics on)", async () => {
+    mockIsAssistantFeatureFlagEnabled.mockReturnValue(true);
+    mockGetCachedShareDiagnostics.mockReturnValue(true);
+    // Consent recorded under an older version that never disclosed trace
+    // collection → gate closed, mirroring the platform ingest gate.
+    mockGetCachedShareDiagnosticsVersion.mockReturnValue("2000-01-01");
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    mockQueryUnreportedTurnEvents.mockReturnValue(singleTurnEvent());
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
+    );
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    // Version below threshold → no assembly at all (no PII touched).
+    expect(mockAssembleBoundedTurnTrace).not.toHaveBeenCalled();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(body.events.length).toBe(1);
+    expect("trace" in body.events[0]).toBe(false);
+  });
+
+  test("omits the trace when the owner never accepted a versioned consent (empty version)", async () => {
+    mockIsAssistantFeatureFlagEnabled.mockReturnValue(true);
+    mockGetCachedShareDiagnostics.mockReturnValue(true);
+    // Empty version (never accepted / no-row default where share_diagnostics is
+    // true but unversioned) fails closed.
+    mockGetCachedShareDiagnosticsVersion.mockReturnValue("");
+    mockQueryUnreportedUsageEvents.mockReturnValue([]);
+    mockQueryUnreportedTurnEvents.mockReturnValue(singleTurnEvent());
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(new Response('{"accepted":1}', { status: 200 })),
+    );
+
+    const reporter = new UsageTelemetryReporter();
+    await reporter.flush();
+
+    expect(mockAssembleBoundedTurnTrace).not.toHaveBeenCalled();
+    const body = JSON.parse(
+      (mockFetch.mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(body.events.length).toBe(1);
+    expect("trace" in body.events[0]).toBe(false);
   });
 
   test("omits the trace when the trace-collection flag is off even though share_diagnostics is true", async () => {

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -10,7 +10,9 @@
  * flush is skipped and retried next cycle.
  */
 
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
 import { getPlatformOrganizationId, getPlatformUserId } from "../config/env.js";
+import { getConfig } from "../config/loader.js";
 import { queryUnreportedAuthFallbackEvents } from "../memory/auth-fallback-events-store.js";
 import {
   getMemoryCheckpoint,
@@ -28,8 +30,8 @@ import {
 } from "../memory/turn-trace-store.js";
 import { VellumPlatformClient } from "../platform/client.js";
 import {
-  getCachedDiagnosticsTraceCollectionEnabled,
   getCachedShareAnalytics,
+  getCachedShareDiagnostics,
 } from "../platform/consent-cache.js";
 import { arePlatformFeaturesEnabled } from "../platform/feature-gate.js";
 import type { UsageAttributionProfileSource } from "../usage/types.js";
@@ -362,7 +364,15 @@ export class UsageTelemetryReporter {
       //
       // When trace collection is OFF, no turn is deferred and reporting timing
       // is unchanged for everyone else — `turn_raw` behavior is untouched.
-      const traceEligible = getCachedDiagnosticsTraceCollectionEnabled();
+      //
+      // Trace eligibility is composed daemon-side: the `trace-collection`
+      // LaunchDarkly flag (delivered via the assistant-tagged flag sync, already
+      // evaluated server-side for this assistant's owner) AND the owner's cached
+      // `share_diagnostics` consent. This mirrors the platform's owner-based
+      // ingest gate. Fail-closed: both must be true.
+      const traceEligible =
+        isAssistantFeatureFlagEnabled("trace-collection", getConfig()) &&
+        getCachedShareDiagnostics();
       let reportableTurnEvents = turnEvents;
       if (traceEligible && turnEvents.length > 0) {
         let barrier = turnEvents.length;
@@ -465,18 +475,14 @@ export class UsageTelemetryReporter {
           }),
         ),
         ...reportableTurnEvents.map((e): TelemetryEvent => {
-          // Owner-consent gate for per-turn trace collection. `traceEligible`
-          // is the server-derived boolean (LD flag + `share_diagnostics` +
-          // privacy-policy version, folded by the platform into
-          // `diagnostics_trace_collection_enabled`); the daemon never evaluates
-          // the flag itself, and reads it from the same owner-consent cache that
-          // gates analytics (`startConsentRefresh` keeps it fresh). Fail-closed:
-          // when consent is off / unknown the trace is omitted and the
-          // trace-free turn row flushes as before. The `share_analytics` gate
-          // above already passed, so this is an additional, independent gate
-          // specific to trace PII. Every turn reaching here is settled (the
-          // completeness barrier dropped any in-flight turns), so the trace is
-          // never a partial mid-turn snapshot.
+          // Per-turn trace collection gate. `traceEligible` (computed above)
+          // requires both the `trace-collection` flag AND the owner's cached
+          // `share_diagnostics` consent. Fail-closed: when either is off the
+          // trace is omitted and the trace-free turn row flushes as before. The
+          // `share_analytics` gate above already passed, so this is an
+          // additional, independent gate specific to trace PII. Every turn
+          // reaching here is settled (the completeness barrier dropped any
+          // in-flight turns), so the trace is never a partial mid-turn snapshot.
           const trace = traceEligible
             ? assembleBoundedTurnTrace({
                 conversationId: e.conversationId,

--- a/assistant/src/telemetry/usage-telemetry-reporter.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.ts
@@ -32,6 +32,7 @@ import { VellumPlatformClient } from "../platform/client.js";
 import {
   getCachedShareAnalytics,
   getCachedShareDiagnostics,
+  getCachedShareDiagnosticsVersion,
 } from "../platform/consent-cache.js";
 import { arePlatformFeaturesEnabled } from "../platform/feature-gate.js";
 import type { UsageAttributionProfileSource } from "../usage/types.js";
@@ -42,6 +43,7 @@ import {
   type ActivationStepName,
   buildActivationDaemonEventId,
 } from "./activation-funnel.js";
+import { isDiagnosticsConsentVersionEligible } from "./trace-collection-policy.js";
 import type { TelemetryEvent, TurnTelemetryClientInfo } from "./types.js";
 
 const log = getLogger("usage-telemetry");
@@ -365,14 +367,20 @@ export class UsageTelemetryReporter {
       // When trace collection is OFF, no turn is deferred and reporting timing
       // is unchanged for everyone else — `turn_raw` behavior is untouched.
       //
-      // Trace eligibility is composed daemon-side: the `trace-collection`
-      // LaunchDarkly flag (delivered via the assistant-tagged flag sync, already
-      // evaluated server-side for this assistant's owner) AND the owner's cached
-      // `share_diagnostics` consent. This mirrors the platform's owner-based
-      // ingest gate. Fail-closed: both must be true.
+      // Trace eligibility is composed daemon-side to mirror the platform's
+      // authoritative owner-based ingest gate, so traces for ineligible owners
+      // never leave the device. Three parts, fail-closed (all must be true):
+      //   1. the `trace-collection` LaunchDarkly flag (delivered via the
+      //      assistant-tagged flag sync, already evaluated server-side for this
+      //      assistant's owner),
+      //   2. the owner's cached `share_diagnostics` consent, and
+      //   3. the owner's cached `share_diagnostics_accepted_version` being at or
+      //      past the disclosing version — the platform applies the identical
+      //      check, so an old consent never yields a trace here or there.
       const traceEligible =
         isAssistantFeatureFlagEnabled("trace-collection", getConfig()) &&
-        getCachedShareDiagnostics();
+        getCachedShareDiagnostics() &&
+        isDiagnosticsConsentVersionEligible(getCachedShareDiagnosticsVersion());
       let reportableTurnEvents = turnEvents;
       if (traceEligible && turnEvents.length > 0) {
         let barrier = turnEvents.length;
@@ -476,9 +484,10 @@ export class UsageTelemetryReporter {
         ),
         ...reportableTurnEvents.map((e): TelemetryEvent => {
           // Per-turn trace collection gate. `traceEligible` (computed above)
-          // requires both the `trace-collection` flag AND the owner's cached
-          // `share_diagnostics` consent. Fail-closed: when either is off the
-          // trace is omitted and the trace-free turn row flushes as before. The
+          // requires the `trace-collection` flag AND the owner's cached
+          // `share_diagnostics` consent AND an eligible accepted consent
+          // version. Fail-closed: when any is off the trace is omitted and the
+          // trace-free turn row flushes as before. The
           // `share_analytics` gate above already passed, so this is an
           // additional, independent gate specific to trace PII. Every turn
           // reaching here is settled (the completeness barrier dropped any

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -59,6 +59,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "trace-collection",
+      "scope": "assistant",
+      "key": "trace-collection",
+      "label": "Trace Collection",
+      "description": "Gate per-turn conversation trace (user/assistant/tool-call/tool-response) collection. The daemon attaches a trace to its turn telemetry only when this flag AND the owner's share_diagnostics consent are both on. Defaults off (fail-closed) — the live value is delivered from LaunchDarkly.",
+      "defaultEnabled": false
+    },
+    {
       "id": "workspace-tools-watcher",
       "scope": "assistant",
       "key": "workspace-tools-watcher",

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -59,6 +59,14 @@
       "defaultEnabled": false
     },
     {
+      "id": "trace-collection",
+      "scope": "assistant",
+      "key": "trace-collection",
+      "label": "Trace Collection",
+      "description": "Gate per-turn conversation trace (user/assistant/tool-call/tool-response) collection. The daemon attaches a trace to its turn telemetry only when this flag AND the owner's share_diagnostics consent are both on. Defaults off (fail-closed) — the live value is delivered from LaunchDarkly.",
+      "defaultEnabled": false
+    },
+    {
       "id": "workspace-tools-watcher",
       "scope": "assistant",
       "key": "workspace-tools-watcher",


### PR DESCRIPTION
## What

Adds the diagnostics-consent **version** check to the daemon's per-turn trace gate so it mirrors the platform's authoritative ingest gate. A trace is attached only when all three hold (fail-closed):

1. the `trace-collection` flag (synced from the platform, LaunchDarkly-evaluated for the owner),
2. the owner's cached `share_diagnostics`, and
3. the owner's cached `share_diagnostics_accepted_version >= TRACE_COLLECTION_MIN_DIAGNOSTICS_CONSENT_VERSION` (`2026-06-18`, kept in lockstep with the platform setting).

- New `telemetry/trace-collection-policy.ts` holds the threshold + pure eligibility helper.
- `OwnerConsent` / the owner-consent client now carry `shareDiagnosticsAcceptedVersion`; an older platform that omits the field yields `""` → fails closed (back-compat).
- The consent cache tracks the version alongside `share_diagnostics`.

## Why

Closes the device-side leak: an owner with `share_diagnostics=True` under an old/empty consent version (the opt-out default, or a no-row owner) would otherwise transmit a trace the platform then drops — PII leaving the device for nothing. The daemon now never assembles it. `""` and older versions fail closed.

## Pairs with

- Platform: vellum-ai/vellum-assistant-platform#8538 (the authoritative ingest gate keyed on the same `share_diagnostics_accepted_version`).