### PR TITLE
Make legacy 'ai' consent key fail-safe explicit across privacy bumps

### DIFF
--- a/clients/web/src/utils/onboarding-cleanup.test.ts
+++ b/clients/web/src/utils/onboarding-cleanup.test.ts
@@ -285,18 +285,20 @@ describe("persistToggleConsent + restoreConsentForUser round-trip", () => {
     expect(r.diagnosticsCurrent).toBe(false);
   });
 
-  test("migrates the previous version's per-user 'ai' key into 'privacy'", () => {
-    // An existing offline user consented under the old field name.
-    const legacyAiKey = `device:consent:ai:v${PRIVACY_CONSENT_VERSION}:user-1`;
+  test("cleans up the legacy 'ai' key without satisfying the current privacy version", () => {
+    // A user consented under the old field name at the previous privacy version.
+    // The privacy version has since been bumped, so that stale consent must not
+    // be promoted as current — the key is cleaned up and privacy stays un-set.
+    const legacyAiKey = `device:consent:ai:v2026-06-08:user-1`;
     const privacyKey = `device:consent:privacy:v${PRIVACY_CONSENT_VERSION}:user-1`;
     localStorage.setItem(legacyAiKey, "true");
 
     const r = restoreConsentForUser("user-1");
 
-    expect(r.privacy).toBe(true);
-    // The old key is promoted to the new one and removed.
-    expect(localStorage.getItem(privacyKey)).toBe("true");
+    expect(r.privacy).toBe(false);
+    // The stale key is removed and privacy is not stamped current.
     expect(localStorage.getItem(legacyAiKey)).toBeNull();
+    expect(localStorage.getItem(privacyKey)).toBeNull();
   });
 
   test("migrates legacy unversioned ToS but forces privacy re-review", () => {

--- a/clients/web/src/utils/onboarding-cleanup.ts
+++ b/clients/web/src/utils/onboarding-cleanup.ts
@@ -32,6 +32,13 @@ import { patchConsent, type UserConsent } from "@/domains/account/profile";
 export const TOS_CONSENT_VERSION = "2026-06-08";
 export const PRIVACY_CONSENT_VERSION = "2026-06-18";
 
+// The privacy version that the legacy "ai"-named device key was last written
+// under, before that field was folded into "privacy". Frozen as a literal (not
+// PRIVACY_CONSENT_VERSION) so it keeps pointing at the real legacy key after
+// the privacy version is bumped — letting us recognize and clean up that stale
+// key rather than treating it as current consent.
+const LEGACY_AI_PRIVACY_CONSENT_VERSION = "2026-06-08";
+
 // Version stamp embedded in each field's device-cache key. ToS tracks its own
 // version; the privacy checkbox (privacy policy + AI data sharing) and the two
 // share toggles track the privacy version.
@@ -46,12 +53,10 @@ function consentKey(field: keyof typeof CONSENT_KEY_VERSION, userId: string): st
   return `device:consent:${field}:v${CONSENT_KEY_VERSION[field]}:${userId}`;
 }
 
-// The previous release stored this consent under a field named "ai" (now folded
-// into "privacy"). Read at the same version the old key was written under so an
-// existing offline user with only the old key migrates cleanly instead of
-// reading privacy=false and being re-routed through onboarding.
+// The previous release stored privacy consent under a field named "ai" (now
+// folded into "privacy"), written under LEGACY_AI_PRIVACY_CONSENT_VERSION.
 function legacyPrivacyConsentKey(userId: string): string {
-  return `device:consent:ai:v${PRIVACY_CONSENT_VERSION}:${userId}`;
+  return `device:consent:ai:v${LEGACY_AI_PRIVACY_CONSENT_VERSION}:${userId}`;
 }
 
 export function restoreConsentForUser(
@@ -64,14 +69,14 @@ export function restoreConsentForUser(
     const analyticsCurrent = getLocalBool(consentKey("share_analytics", userId), false);
     const diagnosticsCurrent = getLocalBool(consentKey("share_diagnostics", userId), false);
     const tos = getLocalBool(consentKey("tos", userId), false);
-    let privacy = getLocalBool(consentKey("privacy", userId), false);
+    const privacy = getLocalBool(consentKey("privacy", userId), false);
 
-    // Migrate the previous version's "ai"-named key into "privacy" so a renamed-
-    // key user isn't read as un-consented (which the empty-server fallback would
-    // turn into an onboarding re-route).
-    if (!privacy && getLocalBool(legacyPrivacyConsentKey(userId), false)) {
-      privacy = true;
-      setLocalBool(consentKey("privacy", userId), true);
+    // The legacy "ai"-named key was written under the previous privacy version,
+    // so it cannot attest to the current one. Never promote it — that would
+    // stamp stale consent as current. Clean it up if present so it doesn't
+    // linger, and leave privacy un-set so the user re-reviews the updated
+    // privacy checkbox.
+    if (getLocalBool(legacyPrivacyConsentKey(userId), false)) {
       removeLocalSetting(legacyPrivacyConsentKey(userId));
     }
 


### PR DESCRIPTION
## What

Follow-up to #35397. Makes the handling of the legacy `device:consent:ai:*` privacy key **explicitly** fail-safe across a privacy version bump, instead of relying on an accidental no-op.

## Background

`restoreConsentForUser()` has a migration for users who consented under the old `"ai"` field name (since folded into `"privacy"`). Its key lookup interpolated the **current** `PRIVACY_CONSENT_VERSION`:

```ts
`device:consent:ai:v${PRIVACY_CONSENT_VERSION}:${userId}`
```

After #35397 bumped `PRIVACY_CONSENT_VERSION` to `2026-06-18`, that lookup started pointing at `v2026-06-18` — a key that **never existed** (the legacy `ai` key was only ever written under `v2026-06-08`). So the migration silently became a no-op. It happened to fail safe (those users re-review), but only by accident, and the same code path would have *promoted* stale consent if the versions had lined up.

## Change

- Add `LEGACY_AI_PRIVACY_CONSENT_VERSION = "2026-06-08"` — the version the `ai` key was actually written under — and freeze `legacyPrivacyConsentKey()` to it, so the lookup targets the **real** legacy key rather than a vacuous current-version one.
- Explicitly **decline to promote** it: if the legacy `ai` key is present, clean it up and leave `privacy` un-set, so the user re-reviews the bumped privacy checkbox. This mirrors the unversioned-key fix from #35397.
- This also fixes `clearConsentForUser()`, which now removes the legacy key at its real version.
- Updated the migration test to assert the new fail-safe behavior (key cleaned up, `privacy: false`, current privacy key not stamped).

## Tests
- `bun test src/utils/onboarding-cleanup.test.ts` — 27 pass
- `eslint` on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)