### PR TITLE
feat(flags): declare os-beta assistant feature flag in the registry

### DIFF
--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -417,6 +417,14 @@
       "label": "MCP Settings",
       "description": "Show the MCP page in Settings for managing Model Context Protocol server connections: view status, enable/disable, configure, and inspect registered tools per server.",
       "defaultEnabled": false
+    },
+    {
+      "id": "os-beta",
+      "scope": "assistant",
+      "key": "os-beta",
+      "label": "OS Beta",
+      "description": "Enable the OS Beta model profile (GLM 5.2 / Fireworks) in the assistant's model profile selection.",
+      "defaultEnabled": false
     }
   ]
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -417,6 +417,14 @@
       "label": "MCP Settings",
       "description": "Show the MCP page in Settings for managing Model Context Protocol server connections: view status, enable/disable, configure, and inspect registered tools per server.",
       "defaultEnabled": false
+    },
+    {
+      "id": "os-beta",
+      "scope": "assistant",
+      "key": "os-beta",
+      "label": "OS Beta",
+      "description": "Enable the OS Beta model profile (GLM 5.2 / Fireworks) in the assistant's model profile selection.",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Declare the os-beta assistant-scope feature flag (defaultEnabled: false) so the gateway/daemon can read its platform-pushed value instead of failing closed on an undeclared key.

Part of plan: os-beta-managed-profile.md (PR 2 of 5)