### PR TITLE
feat(web): compute topP control visibility per provider/model

### DIFF
--- a/clients/web/src/domains/settings/ai/profile-param-visibility.test.ts
+++ b/clients/web/src/domains/settings/ai/profile-param-visibility.test.ts
@@ -20,9 +20,20 @@ describe("resolveProfileParamVisibility", () => {
     expect(vis.contextWindow).toBe(true);
     expect(vis.effort).toBe(true);
     expect(vis.temperature).toBe(true);
+    expect(vis.topP).toBe(true);
     expect(vis.thinking).toBe(true);
     expect(vis.thinkingLevel).toBe(false);
     expect(vis.verbosity).toBe(false);
+  });
+
+  test("topP is true for anthropic, fireworks, and openrouter, false for gemini", () => {
+    expect(resolveProfileParamVisibility("anthropic", "claude-3-opus-20240229").topP).toBe(true);
+    expect(
+      resolveProfileParamVisibility("fireworks", "accounts/fireworks/models/minimax-m3").topP,
+    ).toBe(true);
+    expect(resolveProfileParamVisibility("openrouter", "anthropic/claude-fable-5").topP).toBe(true);
+    expect(resolveProfileParamVisibility("gemini", "gemini-2.5-flash").topP).toBe(false);
+    expect(VISIBILITY_NONE.topP).toBe(false);
   });
 
   test("anthropic haiku disables effort but supports thinking", () => {
@@ -67,10 +78,12 @@ describe("resolveProfileParamVisibility", () => {
     expect(vis.thinking).toBe(false);
   });
 
-  test("ollama gets only maxTokens and contextWindow", () => {
+  test("ollama gets maxTokens, contextWindow, and topP", () => {
     const vis = resolveProfileParamVisibility("ollama", "llama3");
     expect(vis.maxTokens).toBe(true);
     expect(vis.contextWindow).toBe(true);
+    // ollama is OpenAI-compatible, so it forwards top_p
+    expect(vis.topP).toBe(true);
     expect(vis.effort).toBe(false);
     expect(vis.speed).toBe(false);
     expect(vis.verbosity).toBe(false);

--- a/clients/web/src/domains/settings/ai/profile-param-visibility.test.ts
+++ b/clients/web/src/domains/settings/ai/profile-param-visibility.test.ts
@@ -26,12 +26,15 @@ describe("resolveProfileParamVisibility", () => {
     expect(vis.verbosity).toBe(false);
   });
 
-  test("topP is true for anthropic, fireworks, and openrouter, false for gemini", () => {
+  test("topP is true for anthropic, fireworks, openrouter, and openai-compatible, false for gemini", () => {
     expect(resolveProfileParamVisibility("anthropic", "claude-3-opus-20240229").topP).toBe(true);
     expect(
       resolveProfileParamVisibility("fireworks", "accounts/fireworks/models/minimax-m3").topP,
     ).toBe(true);
     expect(resolveProfileParamVisibility("openrouter", "anthropic/claude-fable-5").topP).toBe(true);
+    // Custom OpenAI-compatible connections route through the OpenAI adapter,
+    // which forwards top_p — so the control must be visible for them too.
+    expect(resolveProfileParamVisibility("openai-compatible", "some-custom-model").topP).toBe(true);
     expect(resolveProfileParamVisibility("gemini", "gemini-2.5-flash").topP).toBe(false);
     expect(VISIBILITY_NONE.topP).toBe(false);
   });

--- a/clients/web/src/domains/settings/ai/profile-param-visibility.ts
+++ b/clients/web/src/domains/settings/ai/profile-param-visibility.ts
@@ -12,6 +12,7 @@ export interface ProfileParamVisibility {
   speed: boolean;
   verbosity: boolean;
   temperature: boolean;
+  topP: boolean;
   thinking: boolean;
   /** Gemini's reasoning-depth knob (`thinking.level`). Distinct from `thinking`
    * (Anthropic/OpenRouter enable + stream toggles) — Gemini uses a level. */
@@ -25,6 +26,7 @@ export const VISIBILITY_NONE: ProfileParamVisibility = {
   speed: false,
   verbosity: false,
   temperature: false,
+  topP: false,
   thinking: false,
   thinkingLevel: false,
 };
@@ -134,6 +136,24 @@ function supportsEffort(provider: string, modelId: string, supportsThinking: boo
   return false;
 }
 
+const TOP_P_OPENAI_COMPAT_PROVIDERS = new Set([
+  "openai",
+  "fireworks",
+  "minimax",
+  "atlascloud",
+  "ollama",
+  "openrouter",
+]);
+
+/**
+ * `topP` is gated to providers whose clients actually forward it: the Anthropic
+ * wire and OpenAI-compatible providers. Gemini is intentionally excluded (it
+ * uses a separate client that doesn't forward top_p yet).
+ */
+function supportsTopP(providerId: string, usesAnthropicWire: boolean): boolean {
+  return usesAnthropicWire || TOP_P_OPENAI_COMPAT_PROVIDERS.has(providerId);
+}
+
 export function resolveProfileParamVisibility(
   provider: string,
   model: string,
@@ -153,6 +173,7 @@ export function resolveProfileParamVisibility(
     speed: providerId === "anthropic" && modelId.includes("opus"),
     verbosity: providerId === "openai" && isOpenAIGPT5Family(modelId),
     temperature: usesAnthropicWire,
+    topP: supportsTopP(providerId, usesAnthropicWire),
     thinking:
       (providerId === "anthropic" || providerId === "openrouter") &&
       supportsThinkingResult &&

--- a/clients/web/src/domains/settings/ai/profile-param-visibility.ts
+++ b/clients/web/src/domains/settings/ai/profile-param-visibility.ts
@@ -138,6 +138,7 @@ function supportsEffort(provider: string, modelId: string, supportsThinking: boo
 
 const TOP_P_OPENAI_COMPAT_PROVIDERS = new Set([
   "openai",
+  "openai-compatible",
   "fireworks",
   "minimax",
   "atlascloud",


### PR DESCRIPTION
## Summary
- Add topP to ProfileParamVisibility + VISIBILITY_NONE
- Gate topP to Anthropic-wire and OpenAI-compatible providers (Gemini excluded)
- Add visibility test coverage

Part of plan: top-p-profiles.md (PR 7 of 9)