### PR TITLE
feat(providers): forward top_p in OpenAIChatCompletionsProvider

### DIFF
--- a/assistant/src/providers/openai/__tests__/chat-completions-provider-reasoning.test.ts
+++ b/assistant/src/providers/openai/__tests__/chat-completions-provider-reasoning.test.ts
@@ -460,6 +460,39 @@ describe("OpenAIChatCompletionsProvider reasoning parsing", () => {
     expect(params.messages[0].content).toBeNull();
   });
 
+  test("forwards config.top_p onto the request body", async () => {
+    const { provider, requests } = stubProvider([
+      {
+        choices: [{ delta: { content: "ok" }, finish_reason: "stop" }],
+        usage: { prompt_tokens: 2, completion_tokens: 1 },
+      },
+    ]);
+
+    await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      { config: { top_p: 0.95 } },
+    );
+
+    const params = requests[0] as { top_p?: number };
+    expect(params.top_p).toBe(0.95);
+  });
+
+  test("omits top_p from the request body when not configured", async () => {
+    const { provider, requests } = stubProvider([
+      {
+        choices: [{ delta: { content: "ok" }, finish_reason: "stop" }],
+        usage: { prompt_tokens: 2, completion_tokens: 1 },
+      },
+    ]);
+
+    await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+    ]);
+
+    const params = requests[0] as { top_p?: number };
+    expect(params.top_p).toBeUndefined();
+  });
+
   test("skips Anthropic-originated thinking blocks (with signatures)", async () => {
     const { provider, requests } = stubProvider(
       [

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -367,6 +367,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
     const logitBias = configObj?.logit_bias as
       | Record<string, number>
       | undefined;
+    const topP = configObj?.top_p as number | undefined;
     const usageAttributionHeaders = configObj?.usageAttributionHeaders as
       | Record<string, string>
       | undefined;
@@ -396,6 +397,12 @@ export class OpenAIChatCompletionsProvider implements Provider {
       // and gated to this provider family upstream in `RetryProvider`.
       if (logitBias) {
         params.logit_bias = logitBias;
+      }
+
+      // `top_p` (nucleus sampling). Forwarded explicitly because this client
+      // builds `params` field-by-field rather than spreading the config object.
+      if (typeof topP === "number") {
+        params.top_p = topP;
       }
 
       // Subclasses (OpenRouter) may already have nested effort under


### PR DESCRIPTION
## Summary
- Explicitly forward config.top_p onto OpenAI chat-completions request params
- Inherited by Fireworks/MiniMax/OpenRouter/AtlasCloud/Ollama subclasses
- Add provider test asserting top_p round-trips

Part of plan: top-p-profiles.md (PR 3 of 9)