### PR TITLE
feat(config): add topP to LLM config schema (base + fragment)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -28639,6 +28639,14 @@ components:
                               maximum: 2
                             - type: "null"
                         - type: "null"
+                    topP:
+                      anyOf:
+                        - anyOf:
+                            - type: number
+                              minimum: 0
+                              maximum: 1
+                            - type: "null"
+                        - type: "null"
                     thinking:
                       anyOf:
                         - type: object
@@ -28876,6 +28884,14 @@ components:
                   maximum: 2
                 - type: "null"
             - type: "null"
+        topP:
+          anyOf:
+            - anyOf:
+                - type: number
+                  minimum: 0
+                  maximum: 1
+                - type: "null"
+            - type: "null"
         thinking:
           anyOf:
             - type: object
@@ -29068,6 +29084,14 @@ components:
                 - type: number
                   minimum: 0
                   maximum: 2
+                - type: "null"
+            - type: "null"
+        topP:
+          anyOf:
+            - anyOf:
+                - type: number
+                  minimum: 0
+                  maximum: 1
                 - type: "null"
             - type: "null"
         thinking:
@@ -29293,6 +29317,12 @@ components:
                       minimum: 0
                       maximum: 2
                     - type: "null"
+                topP:
+                  anyOf:
+                    - type: number
+                      minimum: 0
+                      maximum: 1
+                    - type: "null"
                 thinking:
                   type: object
                   properties:
@@ -29430,6 +29460,12 @@ components:
                           - type: number
                             minimum: 0
                             maximum: 2
+                          - type: "null"
+                      topP:
+                        anyOf:
+                          - type: number
+                            minimum: 0
+                            maximum: 1
                           - type: "null"
                       thinking:
                         type: object
@@ -29597,6 +29633,12 @@ components:
             - type: number
               minimum: 0
               maximum: 2
+            - type: "null"
+        topP:
+          anyOf:
+            - type: number
+              minimum: 0
+              maximum: 1
             - type: "null"
         thinking:
           type: object

--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -219,6 +219,7 @@ describe("AssistantConfigSchema", () => {
       speed: "standard",
       verbosity: "medium",
       temperature: null,
+      topP: null,
       thinking: { enabled: true, streamThinking: true },
       contextWindow: {
         enabled: true,

--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -68,6 +68,7 @@ const defaultLlmConfig: LLMConfig = {
     speed: "standard" as const,
     verbosity: "medium" as const,
     temperature: null,
+    topP: null,
     thinking: { enabled: false, streamThinking: true },
     contextWindow: {
       enabled: true,

--- a/assistant/src/__tests__/llm-resolver.test.ts
+++ b/assistant/src/__tests__/llm-resolver.test.ts
@@ -16,6 +16,7 @@ const fullDefault = {
   speed: "standard" as const,
   verbosity: "medium" as const,
   temperature: null,
+  topP: null,
   thinking: { enabled: true, streamThinking: true },
   contextWindow: {
     enabled: true,
@@ -201,6 +202,26 @@ describe("resolveCallSiteConfig", () => {
     // Profile fields must not appear because mainAgent didn't reference them.
     expect(resolved.speed).toBe("standard");
     expect(resolved.effort).toBe("max");
+  });
+
+  test("topP defaults to null when no profile or override sets it", () => {
+    const llm = LLMSchema.parse({ default: fullDefault });
+    const resolved = resolveCallSiteConfig("mainAgent", llm);
+    expect(resolved.topP).toBeNull();
+  });
+
+  test("profile-level topP resolves onto the merged config", () => {
+    const llm = LLMSchema.parse({
+      default: fullDefault,
+      profiles: {
+        nucleus: { topP: 0.9 },
+      },
+      callSites: {
+        memoryExtraction: { profile: "nucleus" },
+      },
+    });
+    const resolved = resolveCallSiteConfig("memoryExtraction", llm);
+    expect(resolved.topP).toBe(0.9);
   });
 
   test("returns isolated nested objects (not aliased to llm.default)", () => {

--- a/assistant/src/__tests__/llm-schema.test.ts
+++ b/assistant/src/__tests__/llm-schema.test.ts
@@ -78,6 +78,7 @@ describe("LLMSchema", () => {
       speed: "standard",
       verbosity: "medium",
       temperature: null,
+      topP: null,
       thinking: { enabled: true, streamThinking: true },
       contextWindow: {
         enabled: true,

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -128,6 +128,11 @@ const VerbosityEnum = z.enum(["low", "medium", "high"]);
 const ModelSchema = z.string().min(1);
 const MaxTokensSchema = z.number().int().positive();
 const TemperatureSchema = z.number().min(0).max(2).nullable();
+// `top_p` (nucleus sampling). Range 0–1; `null` = "no opinion — let the
+// provider pick its own default" (matches TemperatureSchema's null
+// semantics). `RetryProvider` renames `topP`→`top_p` and only forwards a
+// non-null value, so providers never receive `top_p: null`.
+const TopPSchema = z.number().min(0).max(1).nullable();
 // Named, code-resolved logit-bias preset a profile may opt into. The value is a
 // preset *name*, not an inline token→bias map, so the workspace config stays
 // small. This is profile-identity metadata, not inheritable config: the resolver
@@ -328,6 +333,7 @@ export const LLMConfigBase = z.object({
   speed: SpeedEnum.default("standard"),
   verbosity: VerbosityEnum.default("medium"),
   temperature: TemperatureSchema.default(null),
+  topP: TopPSchema.default(null),
   thinking: ThinkingSchema.default(ThinkingSchema.parse({})),
   contextWindow: ContextWindowSchema.default(ContextWindowSchema.parse({})),
   openrouter: OpenRouterSchema.default(OpenRouterSchema.parse({})),
@@ -363,6 +369,7 @@ export const LLMConfigFragment = z
     speed: SpeedEnum.optional(),
     verbosity: VerbosityEnum.optional(),
     temperature: TemperatureSchema.optional(),
+    topP: TopPSchema.optional(),
     thinking: ThinkingFragmentSchema.optional(),
     contextWindow: ContextWindowDeepPartialSchema.optional(),
     openrouter: OpenRouterDeepPartialSchema.optional(),


### PR DESCRIPTION
## Summary
- Add TopPSchema (0–1, nullable) primitive in schemas/llm.ts
- Add topP to LLMConfigBase (default null) and LLMConfigFragment (optional)
- Add resolver test coverage mirroring temperature

Part of plan: top-p-profiles.md (PR 1 of 9)