### PR TITLE
feat(catalog): add GLM 5.2 (Fireworks) to the model catalog

### DIFF
--- a/assistant/src/__tests__/llm-catalog-parity.test.ts
+++ b/assistant/src/__tests__/llm-catalog-parity.test.ts
@@ -2,7 +2,10 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
-import { PROVIDER_CATALOG } from "../providers/model-catalog.js";
+import {
+  isModelInCatalog,
+  PROVIDER_CATALOG,
+} from "../providers/model-catalog.js";
 import { PLATFORM_PROVIDER_META } from "../providers/platform-proxy/constants.js";
 import { resolvePricing, resolvePricingForUsage } from "../util/pricing.js";
 
@@ -299,6 +302,32 @@ describe("LLM catalog parity: daemon vs client", () => {
       maxOutputTokens: 128000,
       longContextPricingThresholdTokens: 272000,
       longContextMode: "native-model",
+    });
+  });
+
+  test("Fireworks catalog includes GLM 5.2", () => {
+    expect(
+      isModelInCatalog("fireworks", "accounts/fireworks/models/glm-5p2"),
+    ).toBe(true);
+
+    const fireworks = PROVIDER_CATALOG.find(
+      (entry) => entry.id === "fireworks",
+    );
+    expect(
+      fireworks?.models.find(
+        (model) => model.id === "accounts/fireworks/models/glm-5p2",
+      ),
+    ).toMatchObject({
+      displayName: "GLM 5.2",
+      contextWindowTokens: 1040000,
+      maxOutputTokens: 131072,
+      supportsToolUse: true,
+      supportsVision: false,
+      pricing: {
+        inputPer1mTokens: 1.4,
+        outputPer1mTokens: 4.4,
+        cacheReadPer1mTokens: 0.26,
+      },
     });
   });
 

--- a/assistant/src/__tests__/weak-open-model.test.ts
+++ b/assistant/src/__tests__/weak-open-model.test.ts
@@ -10,6 +10,7 @@ describe("isWeakOpenModel", () => {
       "moonshotai/kimi-k2.6",
       "accounts/fireworks/models/kimi-k2p6",
       "deepseek/deepseek-chat",
+      "accounts/fireworks/models/glm-5p2",
     ]) {
       expect(isWeakOpenModel(model)).toBe(true);
     }

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -678,6 +678,23 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         },
       },
       {
+        id: "accounts/fireworks/models/glm-5p2",
+        displayName: "GLM 5.2",
+        // Fireworks serves GLM 5.2 with a 1,040K input window.
+        contextWindowTokens: 1040000,
+        maxOutputTokens: 131072,
+        supportsThinking: true,
+        supportsCaching: true,
+        supportsVision: false,
+        supportsToolUse: true,
+        maxEffort: "max",
+        pricing: {
+          inputPer1mTokens: 1.4,
+          outputPer1mTokens: 4.4,
+          cacheReadPer1mTokens: 0.26,
+        },
+      },
+      {
         id: "accounts/fireworks/models/kimi-k2p5",
         displayName: "Kimi K2.5",
         contextWindowTokens: 256000,

--- a/assistant/src/providers/weak-open-model.ts
+++ b/assistant/src/providers/weak-open-model.ts
@@ -1,6 +1,6 @@
 /**
  * Family-level classification of "weak open models" — open-weight models
- * (Kimi, DeepSeek, MiniMax) that disregard static instructions and have
+ * (Kimi, DeepSeek, MiniMax, GLM) that disregard static instructions and have
  * capability gaps that capable models (Claude, GPT) do not. Used by harness
  * levers that coach or redirect these models without touching capable-model
  * behavior: the task-progress-nudge plugin and the empty-dynamic_page surface
@@ -14,7 +14,7 @@
  * Distinct from exploration-drift's narrower `LOOP_PRONE_MODEL_PATTERN`, which
  * targets specific loop-prone versions rather than the whole capability family.
  */
-export const WEAK_OPEN_MODEL_PATTERN = /kimi|deepseek|minimax/i;
+export const WEAK_OPEN_MODEL_PATTERN = /kimi|deepseek|minimax|glm/i;
 
 /** True when `model` is a weak open model (see {@link WEAK_OPEN_MODEL_PATTERN}). */
 export function isWeakOpenModel(model: string | null | undefined): boolean {

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -232,6 +232,14 @@ export const MODELS_BY_PROVIDER = {
       supportsThinking: true,
     },
     {
+      id: "accounts/fireworks/models/glm-5p2",
+      displayName: "GLM 5.2",
+      contextWindowTokens: 1_040_000,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 131_072,
+      supportsThinking: true,
+    },
+    {
       id: "accounts/fireworks/models/kimi-k2p5",
       displayName: "Kimi K2.5",
       contextWindowTokens: 256_000,

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -586,6 +586,23 @@
           }
         },
         {
+          "id": "accounts/fireworks/models/glm-5p2",
+          "displayName": "GLM 5.2",
+          "contextWindowTokens": 1040000,
+          "maxOutputTokens": 131072,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": false,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 1.4,
+            "outputPer1mTokens": 4.4,
+            "cacheReadPer1mTokens": 0.26
+          }
+        },
+        {
           "id": "accounts/fireworks/models/kimi-k2p5",
           "displayName": "Kimi K2.5",
           "contextWindowTokens": 256000,


### PR DESCRIPTION
## Summary
- Add GLM 5.2 (accounts/fireworks/models/glm-5p2) to the Fireworks model catalog with 1,040K context, 131K max output, tool use, prompt caching, and verified pricing.
- Regenerated meta/llm-provider-catalog.json and mirrored the entry into the web client catalog to keep the parity guards green.

Part of plan: os-beta-managed-profile.md (PR 1 of 5)