### PR TITLE
feat(providers): map resolved topP to wire top_p; drop it under Anthropic thinking

### DIFF
--- a/assistant/src/providers/__tests__/retry-callsite.test.ts
+++ b/assistant/src/providers/__tests__/retry-callsite.test.ts
@@ -425,6 +425,62 @@ describe("RetryProvider — callSite resolution", () => {
     expect(config.temperature).toBe(0.5);
   });
 
+  test("forwards resolved topP to wire `top_p` (non-thinking provider)", async () => {
+    // `topP` (schema, camelCase) renames to `top_p` on the wire, mirroring
+    // `maxTokens`→`max_tokens`. Fireworks has no thinking constraint, so the
+    // value passes straight through.
+    setLlmConfig({
+      default: {
+        provider: "fireworks",
+        model: "fireworks-model",
+        topP: 0.95,
+      },
+      callSites: { mainAgent: {} },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("fireworks", (options) => {
+        seen = options;
+      }),
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    const config = seen?.config as Record<string, unknown>;
+    expect(config.top_p).toBe(0.95);
+  });
+
+  test("does NOT forward top_p when resolved topP is null (schema default)", async () => {
+    setLlmConfig({
+      default: {
+        provider: "fireworks",
+        model: "fireworks-model",
+        // `topP` defaults to null — "let provider pick".
+      },
+      callSites: { mainAgent: {} },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("fireworks", (options) => {
+        seen = options;
+      }),
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    const config = seen?.config as Record<string, unknown>;
+    // Must NOT be set — `top_p: null` would either be a wire error or override
+    // sensible provider defaults, mirroring the `temperature` handling.
+    expect(config.top_p).toBeUndefined();
+    expect("top_p" in config).toBe(false);
+  });
+
   test("strips effort/speed for providers that don't support them (e.g. fireworks)", async () => {
     setLlmConfig({
       default: {
@@ -770,6 +826,126 @@ describe("RetryProvider — thinking/temperature conflict guard", () => {
     const config = seen?.config as Record<string, unknown>;
     expect(config.thinking).toBeUndefined();
     expect(config.temperature).toBe(0.7);
+  });
+});
+
+// ── RetryProvider — Anthropic thinking + top_p conflict guard ───────────────
+//
+// Anthropic rejects *any* `top_p` modification when extended thinking is
+// enabled (same constraint family as `temperature` ≠ 1, but with no
+// "=== 1 is fine" exception). This guard drops the offending `top_p` so the
+// request goes through with Anthropic's default instead of 400ing at the wire.
+
+describe("RetryProvider — thinking/top_p conflict guard", () => {
+  test("drops top_p when thinking is enabled (Anthropic)", async () => {
+    setLlmConfig({
+      default: {
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+        thinking: { enabled: true, streamThinking: true },
+        topP: 0.95,
+      },
+      callSites: { mainAgent: {} },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("anthropic", (options) => {
+        seen = options;
+      }),
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    const config = seen?.config as Record<string, unknown>;
+    expect(config.thinking).toEqual({ type: "adaptive" });
+    expect(config.top_p).toBeUndefined();
+    expect("top_p" in config).toBe(false);
+  });
+
+  test("drops top_p for OpenRouter when fronting an `anthropic/*` model", async () => {
+    setLlmConfig({
+      default: {
+        provider: "openrouter",
+        model: "anthropic/claude-opus-4-7",
+        thinking: { enabled: true, streamThinking: true },
+        topP: 0.9,
+      },
+      callSites: { mainAgent: {} },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("openrouter", (options) => {
+        seen = options;
+      }),
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    const config = seen?.config as Record<string, unknown>;
+    expect(config.model).toBe("anthropic/claude-opus-4-7");
+    expect(config.top_p).toBeUndefined();
+  });
+
+  test("preserves top_p when thinking is enabled on a non-Anthropic provider (fireworks)", async () => {
+    // Fireworks (and other non-Anthropic providers) don't share Anthropic's
+    // top_p-with-thinking constraint — the guard must not over-reach. Note
+    // that fireworks strips `thinking` itself, but `top_p` stays.
+    setLlmConfig({
+      default: {
+        provider: "fireworks",
+        model: "fireworks-model",
+        thinking: { enabled: true, streamThinking: true },
+        topP: 0.95,
+      },
+      callSites: { mainAgent: {} },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("fireworks", (options) => {
+        seen = options;
+      }),
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    const config = seen?.config as Record<string, unknown>;
+    expect(config.top_p).toBe(0.95);
+  });
+
+  test("preserves top_p when thinking is disabled (Anthropic)", async () => {
+    setLlmConfig({
+      default: {
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+        thinking: { enabled: false, streamThinking: false },
+        topP: 0.95,
+      },
+      callSites: { mainAgent: {} },
+    });
+
+    let seen: SendMessageOptions | undefined;
+    const wrapped = new RetryProvider(
+      makeProvider("anthropic", (options) => {
+        seen = options;
+      }),
+    );
+
+    await wrapped.sendMessage(DUMMY_MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    const config = seen?.config as Record<string, unknown>;
+    expect(config.thinking).toEqual({ type: "disabled" });
+    expect(config.top_p).toBe(0.95);
   });
 });
 

--- a/assistant/src/providers/openai/__tests__/responses-provider-top-p.test.ts
+++ b/assistant/src/providers/openai/__tests__/responses-provider-top-p.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+
+import { OpenAIResponsesProvider } from "../responses-provider.js";
+
+interface ResponsesStreamEvent {
+  type: string;
+  response?: { model?: string; status?: string };
+}
+
+function makeStream(
+  events: ResponsesStreamEvent[],
+): AsyncIterable<ResponsesStreamEvent> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const e of events) yield e;
+    },
+  };
+}
+
+/**
+ * Construct a provider with its private `client.responses.create` swapped for a
+ * stub that captures the request params and returns a minimal completed stream
+ * so `sendMessage` resolves cleanly.
+ */
+function stubProvider(): {
+  provider: OpenAIResponsesProvider;
+  requests: Record<string, unknown>[];
+} {
+  const provider = new OpenAIResponsesProvider("test-key", "test-model");
+  const requests: Record<string, unknown>[] = [];
+  (provider as unknown as { client: unknown }).client = {
+    responses: {
+      create: async (params: Record<string, unknown>) => {
+        requests.push(params);
+        return makeStream([
+          {
+            type: "response.completed",
+            response: { model: "test-model", status: "completed" },
+          },
+        ]);
+      },
+    },
+  };
+  return { provider, requests };
+}
+
+describe("OpenAIResponsesProvider top_p forwarding", () => {
+  test("forwards config.top_p onto the Responses request params", async () => {
+    const { provider, requests } = stubProvider();
+
+    await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      { config: { top_p: 0.9 } },
+    );
+
+    const params = requests[0] as { top_p?: number };
+    expect(params.top_p).toBe(0.9);
+  });
+
+  test("omits top_p from the Responses request params when not configured", async () => {
+    const { provider, requests } = stubProvider();
+
+    await provider.sendMessage([
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+    ]);
+
+    const params = requests[0] as { top_p?: number };
+    expect(params.top_p).toBeUndefined();
+  });
+});

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -204,6 +204,7 @@ export class OpenAIResponsesProvider implements Provider {
     const modelOverride = configObj?.model as string | undefined;
     const effort = configObj?.effort as string | undefined;
     const verbosity = configObj?.verbosity as string | undefined;
+    const topP = configObj?.top_p as number | undefined;
     const usageAttributionHeaders = configObj?.usageAttributionHeaders as
       | Record<string, string>
       | undefined;
@@ -241,6 +242,14 @@ export class OpenAIResponsesProvider implements Provider {
         modelSupportsVerbosity(modelOverride ?? this.model)
       ) {
         params.text = { verbosity };
+      }
+
+      // `top_p` (nucleus sampling). Forwarded explicitly because this client
+      // builds `params` field-by-field; the Responses API accepts it as a
+      // top-level param. Mirrors the chat-completions client's forwarding so
+      // OpenAI-profile `topP` is honored on the Responses path too.
+      if (typeof topP === "number") {
+        params.top_p = topP;
       }
 
       if (tools && tools.length > 0) {

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -268,6 +268,16 @@ function normalizeSendMessageOptions(
     ) {
       nextConfig.temperature = resolved.temperature;
     }
+    // `topP` (schema, camelCase) maps to the provider wire field `top_p`.
+    // Defaults to `null` ("no opinion"); only forward an actual number so we
+    // never send `top_p: null`, mirroring the `temperature` handling above.
+    if (
+      nextConfig.top_p === undefined &&
+      resolved.topP !== null &&
+      resolved.topP !== undefined
+    ) {
+      nextConfig.top_p = resolved.topP;
+    }
     if (nextConfig.thinking === undefined && resolved.thinking !== undefined) {
       nextConfig.thinking = resolved.thinking;
     }
@@ -428,12 +438,16 @@ function normalizeSendMessageOptions(
   // - Other providers: not our problem here (e.g. OpenAI reasoning models
   //   strip `temperature` upstream; non-Anthropic OpenRouter reasoning
   //   models don't have this exact constraint).
-  const isThinkingTemperatureConflict = (() => {
+  //
+  // Anthropic applies the same constraint family to `top_p` (see the `top_p`
+  // guard below), so the "thinking is enabled on the Anthropic wire" predicate
+  // is shared between the two guards.
+  const isThinkingEnabledOnAnthropicWire = (() => {
     const model = typeof nextConfig.model === "string" ? nextConfig.model : "";
-    // Claude Fable always reasons in adaptive mode, so the `temperature: 1`
-    // constraint applies even when no explicit `thinking` config is present
-    // (a disabled config was already dropped above). For every other model
-    // the constraint only applies when thinking is actually enabled.
+    // Claude Fable always reasons in adaptive mode, so the constraint applies
+    // even when no explicit `thinking` config is present (a disabled config was
+    // already dropped above). For every other model the constraint only applies
+    // when thinking is actually enabled.
     if (!isAdaptiveThinkingOnlyModel(model)) {
       if (nextConfig.thinking == null) {
         return false;
@@ -442,13 +456,6 @@ function normalizeSendMessageOptions(
         return false;
       }
     }
-    const temp = nextConfig.temperature;
-    if (typeof temp !== "number") {
-      return false;
-    }
-    if (temp === 1) {
-      return false;
-    }
     if (providerName === "anthropic") {
       return true;
     }
@@ -456,6 +463,18 @@ function normalizeSendMessageOptions(
       return model.startsWith("anthropic/");
     }
     return false;
+  })();
+  const isThinkingTemperatureConflict = (() => {
+    if (!isThinkingEnabledOnAnthropicWire) {
+      return false;
+    }
+    const temp = nextConfig.temperature;
+    if (typeof temp !== "number") {
+      return false;
+    }
+    // Unlike `top_p`, `temperature: 1` is explicitly accepted alongside
+    // thinking, so it's the one value that doesn't conflict.
+    return temp !== 1;
   })();
   if (isThinkingTemperatureConflict) {
     log.warn(
@@ -470,6 +489,28 @@ function normalizeSendMessageOptions(
         "need a specific temperature.",
     );
     delete nextConfig.temperature;
+  }
+
+  // Anthropic (and OpenRouter fronting Anthropic) also rejects requests that
+  // combine extended thinking with *any* `top_p` modification. Unlike
+  // `temperature` there is no "=== 1 is fine" exception — when thinking is
+  // enabled the request must not set `top_p` at all. Drop it with a warn log
+  // so the request goes through with Anthropic's default, keeping `thinking`
+  // (the more deliberate, profile-level choice) for the same reasons as the
+  // temperature guard above.
+  if (isThinkingEnabledOnAnthropicWire && nextConfig.top_p !== undefined) {
+    log.warn(
+      {
+        providerName,
+        callSite: config.callSite,
+        droppedTopP: nextConfig.top_p,
+      },
+      "Dropping `top_p` because thinking is enabled — Anthropic does not " +
+        "accept `top_p` modifications when thinking/adaptive mode is on. Set " +
+        "`thinking: { type: 'disabled' }` on the call site if you need a " +
+        "specific top_p.",
+    );
+    delete nextConfig.top_p;
   }
 
   // effort is supported by Anthropic, OpenAI, and OpenAI-compatible providers; strip for others


### PR DESCRIPTION
## Summary
- Forward resolved.topP to wire top_p in RetryProvider (only non-null)
- Drop top_p when thinking is enabled on the Anthropic wire (no top_p+thinking)
- Add retry-callsite tests

Part of plan: top-p-profiles.md (PR 2 of 9)