### PR TITLE
feat(profiles): set Balanced profile top_p to 0.95

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -729,6 +729,7 @@ describe("loadConfig startup behavior", () => {
       "accounts/fireworks/models/minimax-m3",
     );
     expect(raw.llm.profiles.balanced.maxTokens).toBe(32000);
+    expect(raw.llm.profiles.balanced.topP).toBe(0.95);
     expect(raw.llm.profiles.balanced.provider_connection).toBe(
       "fireworks-managed",
     );
@@ -1108,6 +1109,11 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
 
     // Personal profiles keep their bare labels — they're the daily driver.
     expect(config.llm.profiles["custom-balanced"]?.label).toBe("Balanced");
+
+    // top_p is scoped to the managed Balanced profile only; the BYOK
+    // custom-balanced profile must not pick it up.
+    expect(config.llm.profiles.balanced?.topP).toBe(0.95);
+    expect(config.llm.profiles["custom-balanced"]?.topP).toBeUndefined();
   });
 
   test("off-platform hatch initializes managed profile status to 'disabled'", () => {

--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -826,6 +826,48 @@ describe("loadConfig startup behavior", () => {
     );
   });
 
+  test("reseed preserves user-edited topP on managed profiles", () => {
+    // Simulate a user who overrode topP on the managed "balanced" profile via
+    // PUT /v1/config/llm/profiles/balanced { topP: 0.5 }. The override must
+    // survive the reconcile instead of reverting to the template's 0.95.
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: {
+            source: "managed",
+            provider: "anthropic",
+            model: "old-model-from-previous-release",
+            provider_connection: "anthropic-managed",
+            topP: 0.5,
+          },
+        },
+        activeProfile: "balanced",
+      },
+    });
+
+    mergeDefaultConfigAndSeedInferenceProfiles();
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+
+    // The user's topP override is preserved across the reseed (not reverted to
+    // the template default of 0.95).
+    expect(raw.llm.profiles.balanced.topP).toBe(0.5);
+    // Model still refreshes — topP is user-owned, the rest is template-owned.
+    expect(raw.llm.profiles.balanced.model).toBe(
+      "accounts/fireworks/models/minimax-m3",
+    );
+  });
+
+  test("reseed seeds the template topP on a fresh managed balanced profile", () => {
+    // No previous on-disk entry → the balanced profile materializes with the
+    // template's topP default of 0.95.
+    writeConfig({ llm: {} });
+
+    mergeDefaultConfigAndSeedInferenceProfiles();
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+
+    expect(raw.llm.profiles.balanced.topP).toBe(0.95);
+  });
+
   test("off-platform reseed preserves an explicit null label (user cleared it)", () => {
     // Setting label to null is the "clear" intent — must survive too,
     // otherwise the next boot would re-stamp the template's default

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -163,9 +163,10 @@ export type SeedInferenceProfilesOptions = {
  *    `cost-optimized`): reconciled from the code templates on every boot —
  *    on-platform and off-platform alike — so Vellum can push model/config
  *    updates to customers in a release without a workspace migration. The
- *    templates own all profile content; only `label` and `status` are
- *    user-overridable and survive reseeds. Platform overlays
- *    (`preserveProfileNames`) take precedence for the boot they are supplied.
+ *    templates own all profile content; only `label`, `status`,
+ *    `advisorEnabled`, and `topP` are user-overridable and survive reseeds.
+ *    Platform overlays (`preserveProfileNames`) take precedence for the boot
+ *    they are supplied.
  *
  * 2. **User profiles** (`custom-balanced`, `custom-quality-optimized`,
  *    `custom-cost-optimized`): materialized once at hatch time for
@@ -217,13 +218,14 @@ export function seedInferenceProfiles(
   //    its first merge), so on subsequent boots the templates reconcile content
   //    as usual.
   //
-  //    Two user-editable fields survive the reconcile: `label` (display
-  //    rename) and `status` (active/disabled toggle) — the only fields a user
-  //    may override. The PUT route `/v1/config/llm/profiles/:name` lets users
-  //    patch these on managed profiles without duplicating; we honor those
-  //    edits across reseeds or they'd silently revert on every boot. Carry by
-  //    key-presence rather than truthiness so an explicit `null` (user
-  //    cleared the label) survives too.
+  //    A whitelist of user-editable fields survives the reconcile: `label`
+  //    (display rename), `status` (active/disabled toggle), `advisorEnabled`
+  //    (per-profile advisor toggle), and `topP` (sampling override) — the only
+  //    fields a user may override. The PUT route `/v1/config/llm/profiles/:name`
+  //    lets users patch these on managed profiles without duplicating; we honor
+  //    those edits across reseeds or they'd silently revert on every boot. Carry
+  //    by key-presence rather than truthiness so an explicit `null` (user
+  //    cleared the field) survives too.
   //
   //    BYOK seed defaults (off-platform only):
   //      • label: " (Managed)" suffix disambiguates managed profile labels
@@ -284,6 +286,12 @@ export function seedInferenceProfiles(
       if ("advisorEnabled" in previous) {
         next.advisorEnabled = previous.advisorEnabled;
       }
+      // `topP` is user-editable on managed profiles (see the managed-profile
+      // editable allowlist on the PUT route) — preserve a user override across
+      // reseeds, including an explicit `null` clear, or it would silently revert
+      // to the template value on every boot. Carry by key-presence (not
+      // truthiness) so `null` survives too.
+      if ("topP" in previous) next.topP = previous.topP;
     }
     profiles[name] = next as ProfileEntry;
   }

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -51,6 +51,7 @@ const MANAGED_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
     effort: "high",
     thinking: { enabled: true, streamThinking: true },
     contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
+    topP: 0.95,
   },
   "quality-optimized": {
     intent: "quality-optimized",


### PR DESCRIPTION
## Summary
- Set topP: 0.95 on the managed Balanced inference profile template
- custom-balanced and other profiles unchanged
- Assert seeded value in platform-defaults test

Part of plan: top-p-profiles.md (PR 4 of 9)