### PR TITLE
feat(web): add top_p toggle + slider to profile advanced params

### DIFF
--- a/clients/web/src/domains/settings/ai/profile-advanced-params.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-advanced-params.test.tsx
@@ -43,6 +43,10 @@ interface FieldOverrides {
   selectedModel?: typeof MODEL;
   defaultMaxOutputTokens?: number;
   defaultContextWindowMaxInputTokens?: number;
+  topPEnabled?: boolean;
+  onTopPEnabledChange?: (v: boolean) => void;
+  topP?: number;
+  onTopPChange?: (v: number) => void;
 }
 
 function renderParams(overrides: FieldOverrides) {
@@ -72,6 +76,10 @@ function renderParams(overrides: FieldOverrides) {
       onTemperatureEnabledChange={() => {}}
       temperature={1}
       onTemperatureChange={() => {}}
+      topPEnabled={overrides.topPEnabled ?? false}
+      onTopPEnabledChange={overrides.onTopPEnabledChange ?? (() => {})}
+      topP={overrides.topP ?? 1}
+      onTopPChange={overrides.onTopPChange ?? (() => {})}
       thinkingEnabled={false}
       onThinkingEnabledChange={() => {}}
       thinkingStreamThinking={false}
@@ -357,6 +365,10 @@ describe("ProfileAdvancedParams token-budget fields", () => {
         onTemperatureEnabledChange={() => {}}
         temperature={1}
         onTemperatureChange={() => {}}
+        topPEnabled={false}
+        onTopPEnabledChange={() => {}}
+        topP={1}
+        onTopPChange={() => {}}
         thinkingEnabled={false}
         onThinkingEnabledChange={() => {}}
         thinkingStreamThinking={false}
@@ -381,5 +393,90 @@ describe("ProfileAdvancedParams token-budget fields", () => {
 
     // THEN it advances by 1,000 tokens, not a coarse quartile jump
     expect(onContextWindowChange).toHaveBeenLastCalledWith(201000);
+  });
+});
+
+const topPOnly: ProfileParamVisibility = {
+  ...VISIBILITY_NONE,
+  topP: true,
+};
+
+describe("ProfileAdvancedParams Top P control", () => {
+  test("renders the Top P toggle when visibility.topP is true", () => {
+    renderParams({ visibility: topPOnly });
+
+    expect(screen.getByRole("switch", { name: "Top P" })).toBeTruthy();
+  });
+
+  test("does not render the Top P control when visibility.topP is false", () => {
+    renderParams({ visibility: maxTokensOnly });
+
+    expect(screen.queryByRole("switch", { name: "Top P" })).toBeNull();
+  });
+
+  test("toggling Top P invokes onTopPEnabledChange", () => {
+    const onTopPEnabledChange = mock();
+    renderParams({ visibility: topPOnly, onTopPEnabledChange });
+
+    fireEvent.click(screen.getByRole("switch", { name: "Top P" }));
+
+    expect(onTopPEnabledChange).toHaveBeenLastCalledWith(true);
+  });
+
+  test("the slider only renders once Top P is enabled", () => {
+    const { rerender } = renderParams({ visibility: topPOnly });
+
+    expect(screen.queryByRole("slider")).toBeNull();
+
+    rerender(
+      <ProfileAdvancedParams
+        visibility={topPOnly}
+        isReadOnly={false}
+        model="claude-opus-4"
+        selectedModel={MODEL}
+        maxTokens={null}
+        onMaxTokensChange={() => {}}
+        contextWindowMaxInputTokens={null}
+        onContextWindowChange={() => {}}
+        effort="none"
+        onEffortChange={() => {}}
+        speed="standard"
+        onSpeedChange={() => {}}
+        verbosity="low"
+        onVerbosityChange={() => {}}
+        temperatureEnabled={false}
+        onTemperatureEnabledChange={() => {}}
+        temperature={1}
+        onTemperatureChange={() => {}}
+        topPEnabled={true}
+        onTopPEnabledChange={() => {}}
+        topP={0.9}
+        onTopPChange={() => {}}
+        thinkingEnabled={false}
+        onThinkingEnabledChange={() => {}}
+        thinkingStreamThinking={false}
+        onThinkingStreamThinkingChange={() => {}}
+        thinkingLevel="default"
+        onThinkingLevelChange={() => {}}
+      />,
+    );
+    const slider = screen.getByRole("slider");
+    expect(slider.getAttribute("aria-valuemin")).toBe("0");
+    expect(slider.getAttribute("aria-valuemax")).toBe("1");
+    expect(slider.getAttribute("aria-valuenow")).toBe("0.9");
+  });
+
+  test("sliding Top P invokes onTopPChange", () => {
+    const onTopPChange = mock();
+    renderParams({
+      visibility: topPOnly,
+      topPEnabled: true,
+      topP: 0.9,
+      onTopPChange,
+    });
+
+    fireEvent.keyDown(screen.getByRole("slider"), { key: "ArrowRight" });
+
+    expect(onTopPChange).toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/settings/ai/profile-advanced-params.tsx
+++ b/clients/web/src/domains/settings/ai/profile-advanced-params.tsx
@@ -86,6 +86,10 @@ interface ProfileAdvancedParamsProps {
   onTemperatureEnabledChange: (v: boolean) => void;
   temperature: number;
   onTemperatureChange: (v: number) => void;
+  topPEnabled: boolean;
+  onTopPEnabledChange: (v: boolean) => void;
+  topP: number;
+  onTopPChange: (v: number) => void;
   thinkingEnabled: boolean;
   onThinkingEnabledChange: (v: boolean) => void;
   thinkingStreamThinking: boolean;
@@ -259,6 +263,10 @@ export function ProfileAdvancedParams({
   onTemperatureEnabledChange,
   temperature,
   onTemperatureChange,
+  topPEnabled,
+  onTopPEnabledChange,
+  topP,
+  onTopPChange,
   thinkingEnabled,
   onThinkingEnabledChange,
   thinkingStreamThinking,
@@ -381,6 +389,38 @@ export function ProfileAdvancedParams({
                   }
                   min={0}
                   max={2}
+                  step={0.01}
+                  disabled={isReadOnly}
+                  showValue
+                  formatValue={(v) =>
+                    typeof v === "number" ? v.toFixed(2) : String(v)
+                  }
+                />
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Top P */}
+      {visibility.topP && (
+        <div className="space-y-2">
+          <Toggle
+            checked={topPEnabled}
+            onChange={(v) => onTopPEnabledChange(v)}
+            label="Top P"
+            disabled={isReadOnly}
+          />
+          {topPEnabled && (
+            <div className="flex items-center justify-between">
+              <div className="flex-1">
+                <Slider
+                  value={topP}
+                  onValueChange={(v) =>
+                    onTopPChange(typeof v === "number" ? v : v[0])
+                  }
+                  min={0}
+                  max={1}
                   step={0.01}
                   disabled={isReadOnly}
                   showValue

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -214,6 +214,61 @@ function renderCreate(
   );
 }
 
+/** Render the editor in edit mode for an existing profile. */
+function renderEdit(
+  initialValues: Record<string, unknown>,
+  onSave: (name: string, entry: unknown) => Promise<void> = () =>
+    Promise.resolve(),
+) {
+  return render(
+    <Wrapper>
+      <ProfileEditorModal
+        isOpen
+        mode="edit"
+        profileName={(initialValues.name as string) ?? "balanced"}
+        initialValues={initialValues as never}
+        existingNames={[(initialValues.name as string) ?? "balanced"]}
+        connections={[makeConnection("anthropic-personal")]}
+        assistantId={ASSISTANT_ID}
+        onSave={onSave}
+        onCancel={() => {}}
+      />
+    </Wrapper>,
+  );
+}
+
+/** The Top P toggle is a switch labelled (via aria-labelledby) "Top P". */
+function topPSwitch(): HTMLElement {
+  const sw = Array.from(
+    document.querySelectorAll<HTMLElement>('[role="switch"]'),
+  ).find((el) => {
+    const labelId = el.getAttribute("aria-labelledby");
+    const labelEl = labelId ? document.getElementById(labelId) : null;
+    return labelEl?.textContent?.trim() === "Top P";
+  });
+  if (!sw) throw new Error("expected a Top P switch");
+  return sw;
+}
+
+/**
+ * The Top P value slider, or null when absent. Its range is 0..1
+ * (aria-valuemax "1"), which distinguishes it from temperature (0..2) and the
+ * token sliders (large maxes).
+ */
+function findTopPSlider(): HTMLElement | null {
+  return (
+    Array.from(
+      document.querySelectorAll<HTMLElement>('[role="slider"]'),
+    ).find((el) => el.getAttribute("aria-valuemax") === "1") ?? null
+  );
+}
+
+function topPSlider(): HTMLElement {
+  const slider = findTopPSlider();
+  if (!slider) throw new Error("expected a Top P slider (aria-valuemax=1)");
+  return slider;
+}
+
 /** Drive a provider-first create up to a Save-enabled state. */
 function fillCreateForm(): void {
   selectProvider("Anthropic");
@@ -483,5 +538,67 @@ describe("ProfileEditorModal create mode — provider-first", () => {
       expect(resolved).toBe(true);
     });
     expect(toastSuccessCalls).toEqual([]);
+  });
+});
+
+describe("ProfileEditorModal — Top P wiring", () => {
+  // Anthropic opus → visibility.topP is true, so the control renders.
+  const balancedProfile = {
+    name: "balanced",
+    label: "Balanced",
+    provider: "anthropic",
+    model: "claude-opus-4-8",
+    topP: 0.9,
+  };
+
+  test("opens a profile with topP showing the toggle on at that value", () => {
+    renderEdit(balancedProfile);
+
+    expect(topPSwitch().getAttribute("aria-checked")).toBe("true");
+    expect(topPSlider().getAttribute("aria-valuenow")).toBe("0.9");
+  });
+
+  test("a profile without topP shows the toggle off and no slider", () => {
+    renderEdit({ ...balancedProfile, topP: undefined });
+
+    expect(topPSwitch().getAttribute("aria-checked")).toBe("false");
+    expect(findTopPSlider()).toBeNull();
+  });
+
+  test("saving with Top P enabled submits topP as a number", async () => {
+    const saveCalls: { name: string; entry: Record<string, unknown> }[] = [];
+    const onSave = (name: string, entry: unknown) => {
+      saveCalls.push({ name, entry: entry as Record<string, unknown> });
+      return Promise.resolve();
+    };
+
+    renderEdit(balancedProfile, onSave);
+
+    fireEvent.click(getSaveBtn());
+
+    await waitFor(() => {
+      expect(saveCalls.length).toBe(1);
+    });
+    expect(saveCalls[0].entry.topP).toBe(0.9);
+    expect(typeof saveCalls[0].entry.topP).toBe("number");
+  });
+
+  test("disabling Top P in edit mode submits topP: null", async () => {
+    const saveCalls: { name: string; entry: Record<string, unknown> }[] = [];
+    const onSave = (name: string, entry: unknown) => {
+      saveCalls.push({ name, entry: entry as Record<string, unknown> });
+      return Promise.resolve();
+    };
+
+    renderEdit(balancedProfile, onSave);
+
+    // Toggle Top P off, then save — edit mode clears it explicitly with null.
+    fireEvent.click(topPSwitch());
+    fireEvent.click(getSaveBtn());
+
+    await waitFor(() => {
+      expect(saveCalls.length).toBe(1);
+    });
+    expect(saveCalls[0].entry.topP).toBeNull();
   });
 });

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -225,6 +225,14 @@ function ProfileEditorModalInner({
     typeof initialValues?.temperature === "number" ? initialValues.temperature : 0.7,
   );
 
+  // Advanced params — top P
+  const [topPEnabled, setTopPEnabled] = useState<boolean>(
+    typeof initialValues?.topP === "number",
+  );
+  const [topP, setTopP] = useState<number>(
+    typeof initialValues?.topP === "number" ? initialValues.topP : 0.95,
+  );
+
   // Advanced params — thinking
   const [thinkingEnabled, setThinkingEnabled] = useState<boolean>(
     initialValues?.thinking?.enabled ?? false,
@@ -336,6 +344,8 @@ function ProfileEditorModalInner({
     setVerbosity("medium");
     setTemperatureEnabled(false);
     setTemperature(0.7);
+    setTopPEnabled(false);
+    setTopP(0.95);
     setThinkingEnabled(false);
     setThinkingStreamThinking(false);
     setThinkingLevel(THINKING_LEVEL_INHERIT);
@@ -530,6 +540,14 @@ function ProfileEditorModalInner({
         }
         // create mode + toggle off → omit
       }
+      if (visibility.topP) {
+        if (topPEnabled) {
+          entry.topP = topP;
+        } else if (effectiveMode === "edit") {
+          entry.topP = null;
+        }
+        // create mode + toggle off → omit
+      }
       if (visibility.thinking) {
         entry.thinking = {
           enabled: thinkingEnabled,
@@ -674,6 +692,10 @@ function ProfileEditorModalInner({
       onTemperatureEnabledChange={setTemperatureEnabled}
       temperature={temperature}
       onTemperatureChange={setTemperature}
+      topPEnabled={topPEnabled}
+      onTopPEnabledChange={setTopPEnabled}
+      topP={topP}
+      onTopPChange={setTopP}
       thinkingEnabled={thinkingEnabled}
       onThinkingEnabledChange={setThinkingEnabled}
       thinkingStreamThinking={thinkingStreamThinking}


### PR DESCRIPTION
## Summary
- Add Top P toggle + 0–1 slider to ProfileAdvancedParams, gated by visibility.topP
- Mirror the existing Temperature control
- Add component tests

Part of plan: top-p-profiles.md (PR 8 of 9)