### PR TITLE
feat(runtime): allow topP edits on managed profiles

### DIFF
--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -117,7 +117,7 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
       }),
     ).rejects.toThrow(
       'Cannot edit managed profile "quality-optimized" fields [provider, model]. ' +
-        "Only label and status may be edited; duplicate to a custom profile to change other fields.",
+        "Only label, status, and topP may be edited; duplicate to a custom profile to change other fields.",
     );
   });
 
@@ -272,6 +272,59 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
       ?.balanced as Record<string, unknown>;
     expect("label" in profile).toBe(false);
     expect(profile.status).toBe("disabled");
+  });
+
+  test("PUT { topP } on managed profile is accepted and persisted", async () => {
+    savedRaw = null;
+    rawConfig = {
+      llm: {
+        profiles: {
+          balanced: {
+            provider: "anthropic",
+            model: "claude-sonnet",
+            source: "managed",
+          },
+        },
+      },
+    };
+    const result = await replaceRoute.handler({
+      pathParams: { name: "balanced" },
+      body: { topP: 0.9 },
+    });
+    expect(result).toEqual({ ok: true });
+    const profile = (savedRaw as unknown as Record<string, any>)?.llm?.profiles
+      ?.balanced as Record<string, unknown>;
+    // topP override persisted; seed fields preserved.
+    expect(profile.topP).toBe(0.9);
+    expect(profile.provider).toBe("anthropic");
+    expect(profile.model).toBe("claude-sonnet");
+    expect(profile.source).toBe("managed");
+  });
+
+  test("PUT { topP: null } on managed profile clears the override on disk", async () => {
+    savedRaw = null;
+    rawConfig = {
+      llm: {
+        profiles: {
+          balanced: {
+            provider: "anthropic",
+            model: "claude-sonnet",
+            topP: 0.7,
+            source: "managed",
+          },
+        },
+      },
+    };
+    const result = await replaceRoute.handler({
+      pathParams: { name: "balanced" },
+      body: { topP: null },
+    });
+    expect(result).toEqual({ ok: true });
+    const profile = (savedRaw as unknown as Record<string, any>)?.llm?.profiles
+      ?.balanced as Record<string, unknown>;
+    expect("topP" in profile).toBe(false);
+    expect(profile.provider).toBe("anthropic");
+    expect(profile.model).toBe("claude-sonnet");
   });
 
   test("PUT { label: '' } on managed profile still rejected by `.min(1)`", async () => {

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -129,8 +129,15 @@ const INFERENCE_PROFILE_UI_KEYS = new Set([
   "speed",
   "verbosity",
   "temperature",
+  "topP",
   "thinking",
 ]);
+
+// Fields a MANAGED profile may edit. Beyond `label` (display name) and
+// `status` (enabled/disabled), users can tune `topP` — the seed contract
+// owns provider/model/connection, but top_p is a per-profile sampling knob
+// the UI exposes on the managed Balanced profile.
+const MANAGED_PROFILE_EDITABLE_KEYS = new Set(["label", "status", "topP"]);
 
 function asMutablePlainObject(value: unknown): Record<string, unknown> | null {
   if (value == null || typeof value !== "object" || Array.isArray(value)) {
@@ -924,19 +931,20 @@ async function handleReplaceInferenceProfile({
   }
   const isManaged = MANAGED_PROFILE_NAMES.has(name);
   if (isManaged) {
-    // Managed profiles are daemon-seeded — provider, model, advanced params,
-    // and the connection binding all belong to the seed contract and can't
-    // be reshaped by the user. The two fields that ARE user policy (display
-    // label and enabled status) are allowed through so users can rename a
-    // managed profile or temporarily disable it without duplicating it.
+    // Managed profiles are daemon-seeded — provider, model, and the
+    // connection binding all belong to the seed contract and can't be
+    // reshaped by the user. The fields that ARE user policy (display label,
+    // enabled status, and the topP sampling knob) are allowed through so
+    // users can rename a managed profile, temporarily disable it, or tune
+    // top_p without duplicating it.
     const requestedKeys = Object.keys(parsed.data);
     const disallowed = requestedKeys.filter(
-      (k) => k !== "label" && k !== "status",
+      (k) => !MANAGED_PROFILE_EDITABLE_KEYS.has(k),
     );
     if (disallowed.length > 0) {
       throw new BadRequestError(
         `Cannot edit managed profile "${name}" fields [${disallowed.join(", ")}]. ` +
-          `Only label and status may be edited; duplicate to a custom profile to change other fields.`,
+          `Only label, status, and topP may be edited; duplicate to a custom profile to change other fields.`,
       );
     }
   }
@@ -1037,7 +1045,7 @@ async function handleReplaceInferenceProfile({
 }
 
 /**
- * Apply a `{label?, status?}` patch to a managed profile entry, preserving
+ * Apply a `{label?, status?, topP?}` patch to a managed profile entry, preserving
  * every other field already on disk (provider, model, advanced params, etc).
  * Caller is responsible for having already restricted the fragment to the
  * managed-allowed keys.
@@ -1057,19 +1065,16 @@ function patchManagedProfileFields(
 
   const existingProfile = asMutablePlainObject(profiles[name]) ?? {};
   const nextProfile: Record<string, unknown> = { ...existingProfile };
-  // Send `null` to clear; omit to leave untouched.
-  if ("label" in fragment) {
-    if (fragment.label === null) {
-      delete nextProfile.label;
+  // For each managed-editable key: send `null` to clear, a value to set,
+  // omit to leave untouched. Iterating the allowlist keeps persistence in
+  // lock-step with the guard above — a key can't slip through the gate
+  // without also being written.
+  for (const key of MANAGED_PROFILE_EDITABLE_KEYS) {
+    if (!(key in fragment)) continue;
+    if (fragment[key] === null) {
+      delete nextProfile[key];
     } else {
-      nextProfile.label = fragment.label;
-    }
-  }
-  if ("status" in fragment) {
-    if (fragment.status === null) {
-      delete nextProfile.status;
-    } else {
-      nextProfile.status = fragment.status;
+      nextProfile[key] = fragment[key];
     }
   }
   profiles[name] = nextProfile;


### PR DESCRIPTION
## Summary
- Add topP to INFERENCE_PROFILE_UI_KEYS so managed profiles accept top_p edits
- Test managed-profile topP set + null-clear

Part of plan: top-p-profiles.md (PR 5 of 9)