### PR TITLE
feat(web): session replay plumbing — consent-gated, drop-in-ready

### DIFF
--- a/clients/web/src/env.d.ts
+++ b/clients/web/src/env.d.ts
@@ -26,6 +26,12 @@ interface ImportMetaEnv {
   readonly VITE_SENTRY_DSN_IOS?: string;
   /** Sentry environment tag (e.g. "production", "staging"). */
   readonly VITE_SENTRY_ENVIRONMENT?: string;
+  /**
+   * Session-replay app ID. A single ID across all hosts (web / Electron / iOS):
+   * replay records the web DOM, so one project covers every surface and the host
+   * is distinguished by a `surface` trait. Unset → session replay disabled.
+   */
+  readonly VITE_SESSION_REPLAY_APP_ID?: string;
   /** Stripe publishable key for payment forms. Injected by CI/CD pipeline. */
   readonly VITE_STRIPE_PUBLISHABLE_KEY?: string;
   /** App version stamp for diagnostic reporting. */

--- a/clients/web/src/lib/session-replay/session-replay-control.test.ts
+++ b/clients/web/src/lib/session-replay/session-replay-control.test.ts
@@ -1,0 +1,271 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  SessionReplayInitOptions,
+  SessionReplayProvider,
+  SessionReplayTraits,
+} from "@/lib/session-replay/session-replay-provider";
+
+// ---------------------------------------------------------------------------
+// Provider seam — lifecycle dispatches through `provider`; init/stop flip the
+// active flag so the control layer's idempotence guards are exercised.
+// ---------------------------------------------------------------------------
+
+let active = false;
+const initMock = mock((_appId: string, _options: SessionReplayInitOptions) => {
+  active = true;
+});
+const identifyMock = mock((_uid: string, _traits: SessionReplayTraits) => {});
+const stopMock = mock(() => {
+  active = false;
+});
+
+const provider: SessionReplayProvider = {
+  init: initMock,
+  identify: identifyMock,
+  stop: stopMock,
+  isActive: () => active,
+};
+
+mock.module("@/lib/session-replay/session-replay-provider", () => ({ provider }));
+
+// ---------------------------------------------------------------------------
+// Composed gate — reused verbatim from Sentry diagnostics consent.
+// ---------------------------------------------------------------------------
+
+let consentGranted = false;
+mock.module("@/lib/sentry/consent-gate", () => ({
+  diagnosticsConsentGranted: () => consentGranted,
+}));
+
+// ---------------------------------------------------------------------------
+// Device settings + stores
+// ---------------------------------------------------------------------------
+
+const watchedNames: string[] = [];
+let deviceWatchCallback: (() => void) | null = null;
+mock.module("@/utils/device-settings", () => ({
+  watchDeviceSetting: (name: string, cb: () => void) => {
+    watchedNames.push(name);
+    deviceWatchCallback = cb;
+    return () => {
+      deviceWatchCallback = null;
+    };
+  },
+}));
+
+interface MockUser {
+  id?: string | null;
+  email?: string | null;
+  username?: string | null;
+  firstName?: string;
+  lastName?: string;
+  isStaff?: boolean;
+}
+interface MockAuthState {
+  platformSession: string;
+  platformSessionRestoredOffline: boolean;
+  user: MockUser | null;
+}
+
+let user: MockUser | null = null;
+let authSubscriber:
+  | ((state: MockAuthState, prev: MockAuthState) => void)
+  | null = null;
+mock.module("@/stores/auth-store", () => ({
+  useAuthStore: {
+    getState: () => ({ user }),
+    subscribe: (cb: typeof authSubscriber) => {
+      authSubscriber = cb;
+      return () => {
+        authSubscriber = null;
+      };
+    },
+  },
+}));
+
+let orgId: string | null = null;
+mock.module("@/stores/organization-store", () => ({
+  getActiveOrganizationIdForRequests: () => orgId,
+}));
+
+const {
+  sessionReplayConsentGranted,
+  syncSessionReplay,
+  identifySessionReplayUser,
+  installSessionReplayControlListeners,
+} = await import("@/lib/session-replay/session-replay-control");
+
+const CONFIG = {
+  appId: "app-123",
+  surface: "web" as const,
+  environment: "test",
+  release: "1.2.3",
+};
+
+function authState(over: Partial<MockAuthState> = {}): MockAuthState {
+  return {
+    platformSession: "present",
+    platformSessionRestoredOffline: false,
+    user: { id: "u1" },
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  initMock.mockClear();
+  identifyMock.mockClear();
+  stopMock.mockClear();
+  watchedNames.length = 0;
+  deviceWatchCallback = null;
+  authSubscriber = null;
+  active = false;
+  consentGranted = false;
+  user = null;
+  orgId = null;
+});
+
+describe("sessionReplayConsentGranted", () => {
+  test("delegates to the Sentry diagnostics gate", () => {
+    consentGranted = true;
+    expect(sessionReplayConsentGranted()).toBe(true);
+    consentGranted = false;
+    expect(sessionReplayConsentGranted()).toBe(false);
+  });
+});
+
+describe("syncSessionReplay", () => {
+  test("granted + inactive: starts the provider once with surface-tagged options", () => {
+    consentGranted = true;
+    user = { id: "u1" };
+    syncSessionReplay(CONFIG);
+    expect(initMock).toHaveBeenCalledTimes(1);
+    expect(initMock.mock.calls[0]![0]).toBe("app-123");
+    expect(initMock.mock.calls[0]![1]).toEqual({
+      environment: "test",
+      release: "1.2.3",
+      surface: "web",
+    });
+    expect(stopMock).not.toHaveBeenCalled();
+  });
+
+  test("identifies the user on start", () => {
+    consentGranted = true;
+    user = { id: "u1", email: "a@b.co" };
+    syncSessionReplay(CONFIG);
+    expect(identifyMock).toHaveBeenCalledTimes(1);
+    expect(identifyMock.mock.calls[0]![0]).toBe("u1");
+  });
+
+  test("does not re-init when already active", () => {
+    consentGranted = true;
+    active = true;
+    syncSessionReplay(CONFIG);
+    expect(initMock).not.toHaveBeenCalled();
+  });
+
+  test("not granted + active: stops the provider", () => {
+    consentGranted = false;
+    active = true;
+    syncSessionReplay(CONFIG);
+    expect(stopMock).toHaveBeenCalledTimes(1);
+    expect(initMock).not.toHaveBeenCalled();
+  });
+
+  test("not granted + inactive: does not stop", () => {
+    consentGranted = false;
+    active = false;
+    syncSessionReplay(CONFIG);
+    expect(stopMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("identifySessionReplayUser", () => {
+  test("builds traits from the auth + organization stores", () => {
+    active = true;
+    user = {
+      id: "u1",
+      email: "a@b.co",
+      username: "alice",
+      firstName: "Alice",
+      lastName: "Smith",
+      isStaff: true,
+    };
+    orgId = "org-9";
+    identifySessionReplayUser("electron");
+    expect(identifyMock).toHaveBeenCalledWith("u1", {
+      name: "Alice Smith",
+      email: "a@b.co",
+      username: "alice",
+      isStaff: true,
+      organizationId: "org-9",
+      surface: "electron",
+    });
+  });
+
+  test("no-op when no recording is active", () => {
+    active = false;
+    user = { id: "u1" };
+    identifySessionReplayUser("web");
+    expect(identifyMock).not.toHaveBeenCalled();
+  });
+
+  test("no-op when no user is resolved", () => {
+    active = true;
+    user = null;
+    identifySessionReplayUser("web");
+    expect(identifyMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("installSessionReplayControlListeners", () => {
+  test("watches the diagnosticsReporting gate and re-syncs on change", () => {
+    consentGranted = true;
+    const stop = installSessionReplayControlListeners(CONFIG);
+    expect(watchedNames).toEqual(["diagnosticsReporting"]);
+
+    deviceWatchCallback?.();
+    expect(initMock).toHaveBeenCalledTimes(1);
+
+    stop();
+  });
+
+  test("a platform-session transition re-syncs the client", () => {
+    consentGranted = true;
+    const stop = installSessionReplayControlListeners(CONFIG);
+
+    authSubscriber?.(
+      authState({ platformSession: "present" }),
+      authState({ platformSession: "absent" }),
+    );
+    expect(initMock).toHaveBeenCalledTimes(1);
+
+    stop();
+  });
+
+  test("a user change re-identifies without re-syncing the gate", () => {
+    active = true;
+    user = { id: "u2" };
+    const stop = installSessionReplayControlListeners(CONFIG);
+
+    authSubscriber?.(
+      authState({ user: { id: "u2" } }),
+      authState({ user: { id: "u1" } }),
+    );
+    expect(identifyMock).toHaveBeenCalledTimes(1);
+    expect(identifyMock.mock.calls[0]![0]).toBe("u2");
+    expect(initMock).not.toHaveBeenCalled();
+    expect(stopMock).not.toHaveBeenCalled();
+
+    stop();
+  });
+
+  test("cleanup removes both the device watch and the auth subscription", () => {
+    const stop = installSessionReplayControlListeners(CONFIG);
+    expect(deviceWatchCallback).not.toBeNull();
+    expect(authSubscriber).not.toBeNull();
+    stop();
+    expect(deviceWatchCallback).toBeNull();
+    expect(authSubscriber).toBeNull();
+  });
+});

--- a/clients/web/src/lib/session-replay/session-replay-control.test.ts
+++ b/clients/web/src/lib/session-replay/session-replay-control.test.ts
@@ -183,12 +183,12 @@ describe("identifySessionReplayUser", () => {
       firstName: "Alice",
       lastName: "Smith",
     };
-    identifySessionReplayUser("electron");
+    identifySessionReplayUser("macos");
     expect(identifyMock).toHaveBeenCalledWith("u1", {
       name: "Alice Smith",
       email: "user@example.com",
       username: "alice",
-      surface: "electron",
+      surface: "macos",
     });
   });
 

--- a/clients/web/src/lib/session-replay/session-replay-control.test.ts
+++ b/clients/web/src/lib/session-replay/session-replay-control.test.ts
@@ -60,7 +60,6 @@ interface MockUser {
   username?: string | null;
   firstName?: string;
   lastName?: string;
-  isStaff?: boolean;
 }
 interface MockAuthState {
   platformSession: string;
@@ -82,11 +81,6 @@ mock.module("@/stores/auth-store", () => ({
       };
     },
   },
-}));
-
-let orgId: string | null = null;
-mock.module("@/stores/organization-store", () => ({
-  getActiveOrganizationIdForRequests: () => orgId,
 }));
 
 const {
@@ -122,7 +116,6 @@ beforeEach(() => {
   active = false;
   consentGranted = false;
   user = null;
-  orgId = null;
 });
 
 describe("sessionReplayConsentGranted", () => {
@@ -151,7 +144,7 @@ describe("syncSessionReplay", () => {
 
   test("identifies the user on start", () => {
     consentGranted = true;
-    user = { id: "u1", email: "a@b.co" };
+    user = { id: "u1", email: "user@example.com" };
     syncSessionReplay(CONFIG);
     expect(identifyMock).toHaveBeenCalledTimes(1);
     expect(identifyMock.mock.calls[0]![0]).toBe("u1");
@@ -181,24 +174,20 @@ describe("syncSessionReplay", () => {
 });
 
 describe("identifySessionReplayUser", () => {
-  test("builds traits from the auth + organization stores", () => {
+  test("builds traits from the auth store", () => {
     active = true;
     user = {
       id: "u1",
-      email: "a@b.co",
+      email: "user@example.com",
       username: "alice",
       firstName: "Alice",
       lastName: "Smith",
-      isStaff: true,
     };
-    orgId = "org-9";
     identifySessionReplayUser("electron");
     expect(identifyMock).toHaveBeenCalledWith("u1", {
       name: "Alice Smith",
-      email: "a@b.co",
+      email: "user@example.com",
       username: "alice",
-      isStaff: true,
-      organizationId: "org-9",
       surface: "electron",
     });
   });

--- a/clients/web/src/lib/session-replay/session-replay-control.ts
+++ b/clients/web/src/lib/session-replay/session-replay-control.ts
@@ -1,0 +1,121 @@
+/**
+ * Consent-gated lifecycle for session replay, mirroring `sentry-control.ts`.
+ *
+ * Replay records the web DOM, so a single web-layer client covers every surface
+ * (browser, Electron renderer, iOS WKWebview) — there is no native uploader or
+ * per-host client to fan out to. SDK access dispatches through the provider seam
+ * (`session-replay-provider.ts`), a no-op today.
+ *
+ * Fail-closed: the provider is never started until consent is confirmed. On a
+ * mid-session revoke the provider is stopped best-effort; a hard reset takes
+ * effect on the next reload (see the provider's `stop` contract).
+ */
+import { diagnosticsConsentGranted } from "@/lib/sentry/consent-gate";
+import {
+  provider,
+  type SessionReplaySurface,
+  type SessionReplayTraits,
+} from "@/lib/session-replay/session-replay-provider";
+import { getActiveOrganizationIdForRequests } from "@/stores/organization-store";
+import { useAuthStore } from "@/stores/auth-store";
+import { watchDeviceSetting } from "@/utils/device-settings";
+
+export interface SessionReplayConfig {
+  appId: string;
+  surface: SessionReplaySurface;
+  environment: string;
+  release?: string;
+}
+
+/**
+ * Session replay is gated on the SAME composed consent as Sentry diagnostics
+ * (confirmed-live platform session AND the effective reporting gate). This thin
+ * wrapper is the seam: if replay later needs its own consent, only this changes.
+ */
+export function sessionReplayConsentGranted(): boolean {
+  return diagnosticsConsentGranted();
+}
+
+function buildTraits(surface: SessionReplaySurface): SessionReplayTraits {
+  const { user } = useAuthStore.getState();
+  const name = [user?.firstName, user?.lastName].filter(Boolean).join(" ").trim();
+  return {
+    name: name || undefined,
+    email: user?.email ?? undefined,
+    username: user?.username ?? undefined,
+    isStaff: user?.isStaff,
+    organizationId: getActiveOrganizationIdForRequests() ?? undefined,
+    surface,
+  };
+}
+
+/**
+ * Identify the active recording with the authenticated user. No-op when no
+ * recording is active or no user is resolved (`user.id` already falls back to
+ * email/username in the auth store).
+ */
+export function identifySessionReplayUser(surface: SessionReplaySurface): void {
+  if (!provider.isActive()) return;
+  const uid = useAuthStore.getState().user?.id;
+  if (!uid) return;
+  provider.identify(uid, buildTraits(surface));
+}
+
+function tryInit(config: SessionReplayConfig): void {
+  if (provider.isActive()) return;
+  provider.init(config.appId, {
+    environment: config.environment,
+    release: config.release,
+    surface: config.surface,
+  });
+  identifySessionReplayUser(config.surface);
+}
+
+function tryStop(): void {
+  if (!provider.isActive()) return;
+  provider.stop();
+}
+
+/**
+ * Apply the current consent to the replay provider — start when granted and not
+ * running, stop (best-effort) when not. Idempotent when consent matches state.
+ */
+export function syncSessionReplay(config: SessionReplayConfig): void {
+  if (sessionReplayConsentGranted()) {
+    tryInit(config);
+  } else {
+    tryStop();
+  }
+}
+
+/**
+ * Install listeners so the replay client re-applies the gate whenever an input
+ * changes — the effective reporting gate (`device:diagnostics_reporting`) or a
+ * platform-session transition — and re-identifies when the authenticated user
+ * changes. Reuses the same signals Sentry watches, so platform-side revokes
+ * picked up by `consent-refresh.ts` flow through here with no extra wiring.
+ *
+ * Returns a cleanup function that removes both listeners.
+ */
+export function installSessionReplayControlListeners(
+  config: SessionReplayConfig,
+): () => void {
+  const stopDeviceWatch = watchDeviceSetting("diagnosticsReporting", () =>
+    syncSessionReplay(config),
+  );
+  const stopSessionWatch = useAuthStore.subscribe((state, prevState) => {
+    if (
+      state.platformSession !== prevState.platformSession ||
+      state.platformSessionRestoredOffline !==
+        prevState.platformSessionRestoredOffline
+    ) {
+      syncSessionReplay(config);
+    } else if (state.user?.id !== prevState.user?.id) {
+      identifySessionReplayUser(config.surface);
+    }
+  });
+  return () => {
+    stopDeviceWatch();
+    stopSessionWatch();
+  };
+}

--- a/clients/web/src/lib/session-replay/session-replay-control.ts
+++ b/clients/web/src/lib/session-replay/session-replay-control.ts
@@ -16,7 +16,6 @@ import {
   type SessionReplaySurface,
   type SessionReplayTraits,
 } from "@/lib/session-replay/session-replay-provider";
-import { getActiveOrganizationIdForRequests } from "@/stores/organization-store";
 import { useAuthStore } from "@/stores/auth-store";
 import { watchDeviceSetting } from "@/utils/device-settings";
 
@@ -43,8 +42,6 @@ function buildTraits(surface: SessionReplaySurface): SessionReplayTraits {
     name: name || undefined,
     email: user?.email ?? undefined,
     username: user?.username ?? undefined,
-    isStaff: user?.isStaff,
-    organizationId: getActiveOrganizationIdForRequests() ?? undefined,
     surface,
   };
 }

--- a/clients/web/src/lib/session-replay/session-replay-init.ts
+++ b/clients/web/src/lib/session-replay/session-replay-init.ts
@@ -11,7 +11,7 @@ import { isNativePlatform } from "@/runtime/native-auth";
  * runs the web bundle (mirrors `resolveDsn()` in `sentry-init.ts`).
  */
 function sessionReplaySurface(): SessionReplayConfig["surface"] {
-  if (isElectron()) return "electron";
+  if (isElectron()) return "macos";
   if (isNativePlatform()) return "ios";
   return "web";
 }

--- a/clients/web/src/lib/session-replay/session-replay-init.ts
+++ b/clients/web/src/lib/session-replay/session-replay-init.ts
@@ -1,0 +1,36 @@
+import {
+  installSessionReplayControlListeners,
+  syncSessionReplay,
+  type SessionReplayConfig,
+} from "@/lib/session-replay/session-replay-control";
+import { isElectron } from "@/runtime/is-electron";
+import { isNativePlatform } from "@/runtime/native-auth";
+
+/**
+ * Detect the host surface. Electron is checked first since its renderer also
+ * runs the web bundle (mirrors `resolveDsn()` in `sentry-init.ts`).
+ */
+function sessionReplaySurface(): SessionReplayConfig["surface"] {
+  if (isElectron()) return "electron";
+  if (isNativePlatform()) return "ios";
+  return "web";
+}
+
+/**
+ * Bootstrap session-replay consent gating. Must run after
+ * `migrateDeviceSettings()` so the device gate is readable. No-ops when
+ * `VITE_SESSION_REPLAY_APP_ID` is unset (mirrors Sentry's no-DSN no-op), so the
+ * plumbing stays dark until a real provider and the app ID are configured.
+ */
+export function initSessionReplay(): void {
+  const appId = import.meta.env.VITE_SESSION_REPLAY_APP_ID;
+  if (!appId) return;
+  const config: SessionReplayConfig = {
+    appId,
+    surface: sessionReplaySurface(),
+    environment: import.meta.env.VITE_SENTRY_ENVIRONMENT ?? "local",
+    release: import.meta.env.VITE_APP_VERSION,
+  };
+  syncSessionReplay(config);
+  installSessionReplayControlListeners(config);
+}

--- a/clients/web/src/lib/session-replay/session-replay-provider.ts
+++ b/clients/web/src/lib/session-replay/session-replay-provider.ts
@@ -20,8 +20,6 @@ export interface SessionReplayTraits {
   name?: string;
   email?: string;
   username?: string;
-  isStaff?: boolean;
-  organizationId?: string;
   surface: SessionReplaySurface;
 }
 

--- a/clients/web/src/lib/session-replay/session-replay-provider.ts
+++ b/clients/web/src/lib/session-replay/session-replay-provider.ts
@@ -7,7 +7,7 @@
  * provider replaces `noopProvider`.
  */
 
-export type SessionReplaySurface = "web" | "electron" | "ios";
+export type SessionReplaySurface = "web" | "macos" | "ios";
 
 export interface SessionReplayInitOptions {
   environment: string;

--- a/clients/web/src/lib/session-replay/session-replay-provider.ts
+++ b/clients/web/src/lib/session-replay/session-replay-provider.ts
@@ -1,0 +1,75 @@
+/**
+ * Provider seam for session replay. The consent/lifecycle logic in
+ * `session-replay-control.ts` dispatches through this single interface so the
+ * real replay SDK can be dropped in later by swapping `provider` — no caller
+ * changes. The active provider is a no-op today: the plumbing (consent gate,
+ * identify, lifecycle) is wired and tested, but nothing records until a real
+ * provider replaces `noopProvider`.
+ */
+
+export type SessionReplaySurface = "web" | "electron" | "ios";
+
+export interface SessionReplayInitOptions {
+  environment: string;
+  release?: string;
+  surface: SessionReplaySurface;
+}
+
+/** Metadata about the authenticated platform user attached to a recording. */
+export interface SessionReplayTraits {
+  name?: string;
+  email?: string;
+  username?: string;
+  isStaff?: boolean;
+  organizationId?: string;
+  surface: SessionReplaySurface;
+}
+
+export interface SessionReplayProvider {
+  /** Start the SDK. Called once, only after consent is confirmed. */
+  init(appId: string, options: SessionReplayInitOptions): void;
+  /** Associate the active recording with the authenticated platform user. */
+  identify(uid: string, traits: SessionReplayTraits): void;
+  /**
+   * Best-effort stop. Replay SDKs cannot fully un-init mid-page, so a real
+   * provider may keep the page network-silent but only fully reset on reload.
+   */
+  stop(): void;
+  /** Whether a recording is currently active (started and not stopped). */
+  isActive(): boolean;
+}
+
+/**
+ * No-op provider: owns lifecycle state so the control layer stays stateless
+ * (mirroring the Sentry flavor's `getClientEnabled()`), and logs in dev so the
+ * consent gate is observable without an SDK. Swap this one binding to go live.
+ */
+const noopProvider: SessionReplayProvider = (() => {
+  let active = false;
+  return {
+    init(appId, options) {
+      active = true;
+      if (import.meta.env.DEV) {
+        console.debug("[session-replay] init", {
+          appId,
+          surface: options.surface,
+        });
+      }
+    },
+    identify(uid, traits) {
+      if (import.meta.env.DEV) {
+        console.debug("[session-replay] identify", {
+          uid,
+          surface: traits.surface,
+        });
+      }
+    },
+    stop() {
+      active = false;
+      if (import.meta.env.DEV) console.debug("[session-replay] stop");
+    },
+    isActive: () => active,
+  };
+})();
+
+export const provider: SessionReplayProvider = noopProvider;

--- a/clients/web/src/main.tsx
+++ b/clients/web/src/main.tsx
@@ -14,6 +14,7 @@ import { isChunkLoadError } from "@/lib/chunk-errors";
 import { installConsentRefreshListeners } from "@/lib/consent/consent-refresh";
 import { isLocalMode, loadLockfile } from "@/lib/local-mode";
 import { initSentry } from "@/lib/sentry/sentry-init";
+import { initSessionReplay } from "@/lib/session-replay/session-replay-init";
 import { setupAuthListeners, useAuthStore } from "@/stores/auth-store";
 import { setupOrganizationStore } from "@/stores/organization-store";
 import { router } from "./routes";
@@ -28,6 +29,7 @@ async function boot() {
   initInputModality();
   await initSafeAreaBridge();
   initSentry();
+  initSessionReplay();
   installConsentRefreshListeners();
 
   setupOrganizationStore();


### PR DESCRIPTION
## Summary
- Adds `clients/web/src/lib/session-replay/` mirroring the Sentry overhaul: a consent-gated lifecycle + user-identify wiring behind a **no-op provider seam**. Nothing records until a future PR swaps `provider` and sets `VITE_SESSION_REPLAY_APP_ID`.
- Reuses the exact Sentry gate (`diagnosticsConsentGranted` from `consent-gate.ts`) via a one-function seam (`sessionReplayConsentGranted`), and the same device/session signals — so platform-side revokes already flow through with no new refresh wiring. Web-only by design: replay records the DOM, so one client covers web/Electron/iOS (distinguished by a `surface` trait), with no native uploader or per-host project.
- Identify pulls `{ name, email, username, isStaff, organizationId, surface }` from the auth + organization stores; `initSessionReplay()` is wired into `main.tsx boot()` after `initSentry()` and no-ops when the app ID env var is unset.

## Original prompt
After merging the Sentry crash-reporting overhaul (#35402), the next goal is to prepare the same plumbing for session replay (LogRocket), instrumented at the web layer so Electron/macOS and Capacitor/iOS get it for free, and gated under the *same* consent conditions as Sentry. This PR lands only the entrypoints/stubs so a real SDK is a drop-in later — no SDK is added and nothing records yet. Per request, the product name appears nowhere: everything is "session replay".

## Reviewer notes
- Teardown is best-effort by design: replay SDKs can't fully un-init mid-page, so a hard revoke takes full effect on reload (documented on the provider's `stop` contract).
- Follow-ups when the real provider lands (out of scope here): Electron CSP / Capacitor ATS egress allowlist for the replay ingest domains; optionally a distinct session-recording consent (the `sessionReplayConsentGranted` seam is left for it).