### PR TITLE
feat(profiles): reconcile OS Beta profile from the os-beta flag

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -1455,11 +1455,8 @@ describe("OS Beta managed profile template", () => {
     expect((raw.llm.profileOrder as string[]).includes("os-beta")).toBe(false);
   });
 
-  test("MANAGED_PROFILE_NAMES does not yet contain os-beta", () => {
-    // Membership lands with the flag-gated reconciler in a later PR, so the
-    // route layer can't lock a user-owned os-beta profile before a managed
-    // one exists.
-    expect(MANAGED_PROFILE_NAMES.has("os-beta")).toBe(false);
+  test("MANAGED_PROFILE_NAMES contains os-beta", () => {
+    expect(MANAGED_PROFILE_NAMES.has("os-beta")).toBe(true);
   });
 
   test("materializeProfile honors the explicit OS Beta model", () => {

--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -22,10 +22,19 @@ function makeDefaultRawConfig(): Record<string, unknown> {
         "quality-optimized": {
           provider: "anthropic",
           model: "claude-sonnet",
+          source: "managed",
         },
-        balanced: { provider: "anthropic", model: "claude-sonnet" },
-        "cost-optimized": { provider: "anthropic", model: "claude-haiku" },
-        "my-custom": { provider: "openai", model: "gpt-4o" },
+        balanced: {
+          provider: "anthropic",
+          model: "claude-sonnet",
+          source: "managed",
+        },
+        "cost-optimized": {
+          provider: "anthropic",
+          model: "claude-haiku",
+          source: "managed",
+        },
+        "my-custom": { provider: "openai", model: "gpt-4o", source: "user" },
       },
     },
   };
@@ -274,6 +283,50 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
     expect(profile.status).toBe("disabled");
   });
 
+  test("allows edits to a user-owned profile sharing a managed name (os-beta)", async () => {
+    savedRaw = null;
+    rawConfig = {
+      llm: {
+        profiles: {
+          "os-beta": {
+            provider: "anthropic",
+            model: "claude-sonnet",
+            source: "user",
+          },
+        },
+      },
+    };
+    const result = await replaceRoute.handler({
+      pathParams: { name: "os-beta" },
+      body: { provider: "openai", model: "gpt-4o" },
+    });
+    expect(result).toEqual({ ok: true });
+    const profile = (savedRaw as unknown as Record<string, any>)?.llm
+      ?.profiles?.["os-beta"] as Record<string, unknown>;
+    expect(profile.provider).toBe("openai");
+    expect(profile.model).toBe("gpt-4o");
+  });
+
+  test("rejects edits to a managed os-beta profile", async () => {
+    rawConfig = {
+      llm: {
+        profiles: {
+          "os-beta": {
+            provider: "fireworks",
+            model: "accounts/fireworks/models/glm-5p2",
+            source: "managed",
+          },
+        },
+      },
+    };
+    await expect(
+      replaceRoute.handler({
+        pathParams: { name: "os-beta" },
+        body: { provider: "openai", model: "gpt-4o" },
+      }),
+    ).rejects.toThrow(BadRequestError);
+  });
+
   test("PUT { label: '' } on managed profile still rejected by `.min(1)`", async () => {
     // `.nullable()` only widens the type to accept null — empty strings
     // still fail the min-length check, which is correct: an empty string
@@ -373,6 +426,44 @@ describe("PATCH /v1/config — managed profile deletion guard", () => {
       },
     });
     expect(result).toHaveProperty("llm");
+  });
+
+  test("allows deletion of a user-owned profile sharing a managed name (os-beta)", async () => {
+    savedRaw = null;
+    rawConfig = {
+      llm: {
+        profiles: {
+          "os-beta": {
+            provider: "anthropic",
+            model: "claude-sonnet",
+            source: "user",
+          },
+        },
+      },
+    };
+    const result = await patchRoute.handler({
+      body: { llm: { profiles: { "os-beta": null } } },
+    });
+    expect(result).toHaveProperty("llm");
+  });
+
+  test("rejects deletion of a managed os-beta profile", async () => {
+    rawConfig = {
+      llm: {
+        profiles: {
+          "os-beta": {
+            provider: "fireworks",
+            model: "accounts/fireworks/models/glm-5p2",
+            source: "managed",
+          },
+        },
+      },
+    };
+    await expect(
+      patchRoute.handler({
+        body: { llm: { profiles: { "os-beta": null } } },
+      }),
+    ).rejects.toThrow('Cannot delete managed profile "os-beta".');
   });
 
   test("rejects nulling the entire profiles map", async () => {

--- a/assistant/src/config/__tests__/sync-gated-profiles.test.ts
+++ b/assistant/src/config/__tests__/sync-gated-profiles.test.ts
@@ -1,0 +1,210 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+const WORKSPACE_DIR = process.env.VELLUM_WORKSPACE_DIR!;
+const CONFIG_PATH = join(WORKSPACE_DIR, "config.json");
+
+function ensureTestDir(): void {
+  const dirs = [
+    WORKSPACE_DIR,
+    join(WORKSPACE_DIR, "data"),
+    join(WORKSPACE_DIR, "data", "memory"),
+    join(WORKSPACE_DIR, "data", "logs"),
+  ];
+  for (const dir of dirs) {
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  }
+}
+
+function makeLoggerStub(): Record<string, unknown> {
+  const stub: Record<string, unknown> = {};
+  for (const m of [
+    "info",
+    "warn",
+    "error",
+    "debug",
+    "trace",
+    "fatal",
+    "silent",
+    "child",
+  ]) {
+    stub[m] = m === "child" ? () => makeLoggerStub() : () => {};
+  }
+  return stub;
+}
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () => makeLoggerStub(),
+}));
+
+afterAll(() => {
+  mock.restore();
+});
+
+import { setOverridesForTesting } from "../../__tests__/feature-flag-test-helpers.js";
+import { invalidateConfigCache } from "../loader.js";
+import { seedInferenceProfiles } from "../seed-inference-profiles.js";
+import { reconcileFlagGatedProfiles } from "../sync-gated-profiles.js";
+
+type RawConfig = {
+  llm: {
+    profiles: Record<string, Record<string, unknown>>;
+    profileOrder: string[];
+    activeProfile?: string;
+    advisorProfile?: string;
+  };
+};
+
+function writeConfig(obj: unknown): void {
+  writeFileSync(CONFIG_PATH, JSON.stringify(obj, null, 2) + "\n");
+}
+
+function readConfig(): RawConfig {
+  return JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+}
+
+function seedBalancedConfig(): void {
+  writeConfig({ llm: { default: { provider: "anthropic" } } });
+  invalidateConfigCache();
+  seedInferenceProfiles({});
+}
+
+describe("reconcileFlagGatedProfiles", () => {
+  beforeEach(() => {
+    ensureTestDir();
+    if (existsSync(CONFIG_PATH)) rmSync(CONFIG_PATH, { force: true });
+    delete process.env.IS_PLATFORM;
+    setOverridesForTesting({});
+    invalidateConfigCache();
+  });
+
+  afterEach(() => {
+    delete process.env.IS_PLATFORM;
+    setOverridesForTesting({});
+    invalidateConfigCache();
+  });
+
+  test("flag on materializes the managed os-beta profile after balanced", () => {
+    process.env.IS_PLATFORM = "true";
+    seedBalancedConfig();
+    setOverridesForTesting({ "os-beta": true });
+
+    expect(reconcileFlagGatedProfiles()).toBe(true);
+
+    const raw = readConfig();
+    const osBeta = raw.llm.profiles["os-beta"]!;
+    expect(osBeta.model).toBe("accounts/fireworks/models/glm-5p2");
+    expect(osBeta.provider_connection).toBe("fireworks-managed");
+    expect(osBeta.source).toBe("managed");
+    expect(osBeta.label).toBe("OS Beta");
+
+    const order = raw.llm.profileOrder;
+    expect(order.indexOf("os-beta")).toBe(order.indexOf("balanced") + 1);
+  });
+
+  test("flag on is idempotent across repeated runs", () => {
+    process.env.IS_PLATFORM = "true";
+    seedBalancedConfig();
+    setOverridesForTesting({ "os-beta": true });
+
+    expect(reconcileFlagGatedProfiles()).toBe(true);
+    invalidateConfigCache();
+    expect(reconcileFlagGatedProfiles()).toBe(false);
+  });
+
+  test("flag on preserves user overrides on the managed profile", () => {
+    process.env.IS_PLATFORM = "true";
+    seedBalancedConfig();
+    setOverridesForTesting({ "os-beta": true });
+    reconcileFlagGatedProfiles();
+
+    const raw = readConfig();
+    raw.llm.profiles["os-beta"]!.label = "My OS Beta";
+    raw.llm.profiles["os-beta"]!.status = "disabled";
+    raw.llm.profiles["os-beta"]!.advisorEnabled = true;
+    writeConfig(raw);
+    invalidateConfigCache();
+
+    reconcileFlagGatedProfiles();
+
+    const after = readConfig().llm.profiles["os-beta"]!;
+    expect(after.label).toBe("My OS Beta");
+    expect(after.status).toBe("disabled");
+    expect(after.advisorEnabled).toBe(true);
+    expect(after.model).toBe("accounts/fireworks/models/glm-5p2");
+  });
+
+  test("flag off removes a managed os-beta and applies fallbacks", () => {
+    process.env.IS_PLATFORM = "true";
+    seedBalancedConfig();
+    setOverridesForTesting({ "os-beta": true });
+    reconcileFlagGatedProfiles();
+
+    const raw = readConfig();
+    raw.llm.activeProfile = "os-beta";
+    raw.llm.advisorProfile = "os-beta";
+    writeConfig(raw);
+    invalidateConfigCache();
+
+    setOverridesForTesting({ "os-beta": false });
+    expect(reconcileFlagGatedProfiles()).toBe(true);
+
+    const after = readConfig();
+    expect(after.llm.profiles["os-beta"]).toBeUndefined();
+    expect(after.llm.profileOrder.includes("os-beta")).toBe(false);
+    expect(after.llm.activeProfile).toBe("balanced");
+    expect(after.llm.advisorProfile).toBe("quality-optimized");
+  });
+
+  test("flag off with no os-beta present is a no-op", () => {
+    process.env.IS_PLATFORM = "true";
+    seedBalancedConfig();
+    setOverridesForTesting({ "os-beta": false });
+
+    expect(reconcileFlagGatedProfiles()).toBe(false);
+  });
+
+  test("a user-owned os-beta profile is never touched", () => {
+    process.env.IS_PLATFORM = "true";
+    writeConfig({
+      llm: {
+        default: { provider: "anthropic" },
+        profiles: {
+          "os-beta": {
+            source: "user",
+            label: "Mine",
+            provider: "anthropic",
+            model: "claude-x",
+            provider_connection: "anthropic-personal",
+          },
+        },
+        profileOrder: ["os-beta"],
+      },
+    });
+    invalidateConfigCache();
+    const before = readFileSync(CONFIG_PATH, "utf-8");
+
+    setOverridesForTesting({ "os-beta": true });
+    expect(reconcileFlagGatedProfiles()).toBe(false);
+    expect(readFileSync(CONFIG_PATH, "utf-8")).toBe(before);
+
+    setOverridesForTesting({ "os-beta": false });
+    expect(reconcileFlagGatedProfiles()).toBe(false);
+    expect(readFileSync(CONFIG_PATH, "utf-8")).toBe(before);
+  });
+});

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -161,13 +161,13 @@ export const OS_BETA_PROFILE_TEMPLATE: ManagedProfileTemplate = {
 };
 
 // Membership here marks a profile as managed for the route layer, which blocks
-// model/provider edits and deletion. A key only belongs in this set when a
-// managed profile of that name exists to back it. `OS_BETA_PROFILE_KEY` is
-// flag-gated and has no unconditional managed entry, so it stays out — keeping
-// it in would let the route layer lock a user-created `os-beta` profile that
-// has no managed definition behind it.
+// model/provider edits and deletion. `OS_BETA_PROFILE_KEY` is flag-gated: it is
+// materialized by the flag-gated profile reconcile, which refuses to touch a
+// same-named user profile, so the only `os-beta` entry the route layer can lock
+// is one Vellum manages.
 export const MANAGED_PROFILE_NAMES = new Set([
   ...Object.keys(MANAGED_PROFILE_TEMPLATES),
+  OS_BETA_PROFILE_KEY,
   AUTO_PROFILE_KEY,
 ]);
 

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -160,11 +160,12 @@ export const OS_BETA_PROFILE_TEMPLATE: ManagedProfileTemplate = {
   contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
 };
 
-// Membership here marks a profile as managed for the route layer, which blocks
-// model/provider edits and deletion. `OS_BETA_PROFILE_KEY` is flag-gated: it is
+// Membership here marks a name as managed. The route layer applies managed
+// restrictions (blocking model/provider edits and deletion) only to entries
+// whose on-disk `source` is `managed`, so a user-owned profile sharing one of
+// these names is not locked. `OS_BETA_PROFILE_KEY` is flag-gated: it is
 // materialized by the flag-gated profile reconcile, which refuses to touch a
-// same-named user profile, so the only `os-beta` entry the route layer can lock
-// is one Vellum manages.
+// same-named user profile.
 export const MANAGED_PROFILE_NAMES = new Set([
   ...Object.keys(MANAGED_PROFILE_TEMPLATES),
   OS_BETA_PROFILE_KEY,

--- a/assistant/src/config/sync-gated-profiles.ts
+++ b/assistant/src/config/sync-gated-profiles.ts
@@ -1,0 +1,169 @@
+import { getLogger } from "../util/logger.js";
+import { isAssistantFeatureFlagEnabled } from "./assistant-feature-flags.js";
+import {
+  getConfigReadOnly,
+  invalidateConfigCache,
+  loadRawConfig,
+  saveRawConfig,
+} from "./loader.js";
+import type { ProfileEntry } from "./schemas/llm.js";
+import {
+  materializeProfile,
+  OS_BETA_FEATURE_FLAG_KEY,
+  OS_BETA_PROFILE_KEY,
+  OS_BETA_PROFILE_TEMPLATE,
+} from "./seed-inference-profiles.js";
+
+const log = getLogger("sync-gated-profiles");
+
+/**
+ * Reconcile flag-gated managed profiles against the current feature-flag state.
+ *
+ * `seedInferenceProfiles()` runs synchronously at boot before feature flags are
+ * available, so the OS Beta profile (GLM 5.2 / fireworks-managed) is materialized
+ * here once flags have loaded. When the `os-beta` flag is on, the managed profile
+ * is created (ordered right after `balanced`); when it is off, a previously
+ * managed entry is removed with `profileOrder` / `activeProfile` / `advisorProfile`
+ * fallbacks. The reconcile is idempotent and never touches a user-owned profile of
+ * the same name.
+ *
+ * Returns whether the on-disk config changed.
+ */
+export function reconcileFlagGatedProfiles(): boolean {
+  const config = loadRawConfig();
+
+  if (config.llm == null || typeof config.llm !== "object") {
+    config.llm = {};
+  }
+  const llm = config.llm as Record<string, unknown>;
+
+  if (llm.profiles == null || typeof llm.profiles !== "object") {
+    llm.profiles = {};
+  }
+  const profiles = llm.profiles as Record<string, Record<string, unknown>>;
+
+  const profileOrder = Array.isArray(llm.profileOrder)
+    ? (llm.profileOrder as string[])
+    : [];
+  llm.profileOrder = profileOrder;
+
+  // The resolver reads flag state from the gateway-populated override cache and
+  // ignores the config argument; pass the read-only config for signature parity
+  // without mutating disk before the reconcile decision is made.
+  const enabled = isAssistantFeatureFlagEnabled(
+    OS_BETA_FEATURE_FLAG_KEY,
+    getConfigReadOnly(),
+  );
+
+  const isPlatform =
+    process.env.IS_PLATFORM === "true" || process.env.IS_PLATFORM === "1";
+  const isByokMode = !isPlatform;
+
+  const previous = readObject(profiles[OS_BETA_PROFILE_KEY]);
+
+  // Never clobber a user-owned profile that happens to be named `os-beta`. The
+  // entry is ours to manage only when it is absent or already managed; a
+  // user-sourced entry of the same name is left untouched on every path.
+  const isOursToManage = previous == null || previous.source === "managed";
+  if (!isOursToManage) {
+    return false;
+  }
+
+  const changed = enabled
+    ? enableProfile(profiles, profileOrder, previous, isByokMode)
+    : disableProfile(llm, profiles, profileOrder, previous);
+
+  if (changed) {
+    saveRawConfig(config);
+    invalidateConfigCache();
+    log.info(
+      { profile: OS_BETA_PROFILE_KEY, enabled },
+      "Reconciled flag-gated profile",
+    );
+  }
+  return changed;
+}
+
+function enableProfile(
+  profiles: Record<string, Record<string, unknown>>,
+  profileOrder: string[],
+  previous: Record<string, unknown> | null,
+  isByokMode: boolean,
+): boolean {
+  const effectiveTemplate = isByokMode
+    ? {
+        ...OS_BETA_PROFILE_TEMPLATE,
+        label: `${OS_BETA_PROFILE_TEMPLATE.label} (Managed)`,
+      }
+    : OS_BETA_PROFILE_TEMPLATE;
+  const next = materializeProfile(
+    effectiveTemplate,
+    OS_BETA_PROFILE_TEMPLATE.provider,
+    OS_BETA_PROFILE_TEMPLATE.connectionName,
+  ) as Record<string, unknown>;
+
+  if (previous) {
+    // The only fields a user may override on a managed profile. Carry `label`
+    // by key-presence so an explicit null (user cleared it) survives too.
+    if ("label" in previous) next.label = previous.label;
+    if ("status" in previous) next.status = previous.status;
+    if ("advisorEnabled" in previous) {
+      next.advisorEnabled = previous.advisorEnabled;
+    }
+  }
+
+  let changed = false;
+  if (!previous || !deepEqual(previous, next)) {
+    profiles[OS_BETA_PROFILE_KEY] = next as ProfileEntry;
+    changed = true;
+  }
+
+  if (!profileOrder.includes(OS_BETA_PROFILE_KEY)) {
+    const balancedIndex = profileOrder.indexOf("balanced");
+    if (balancedIndex >= 0) {
+      profileOrder.splice(balancedIndex + 1, 0, OS_BETA_PROFILE_KEY);
+    } else {
+      profileOrder.push(OS_BETA_PROFILE_KEY);
+    }
+    changed = true;
+  }
+
+  return changed;
+}
+
+function disableProfile(
+  llm: Record<string, unknown>,
+  profiles: Record<string, Record<string, unknown>>,
+  profileOrder: string[],
+  previous: Record<string, unknown> | null,
+): boolean {
+  if (!previous) return false;
+
+  delete profiles[OS_BETA_PROFILE_KEY];
+
+  const orderIndex = profileOrder.indexOf(OS_BETA_PROFILE_KEY);
+  if (orderIndex >= 0) profileOrder.splice(orderIndex, 1);
+
+  if (llm.activeProfile === OS_BETA_PROFILE_KEY) {
+    llm.activeProfile = "balanced";
+  }
+  if (llm.advisorProfile === OS_BETA_PROFILE_KEY) {
+    if (readObject(profiles["quality-optimized"]) !== null) {
+      llm.advisorProfile = "quality-optimized";
+    } else {
+      delete llm.advisorProfile;
+    }
+  }
+
+  return true;
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -748,8 +748,14 @@ function rejectManagedProfileDeletion(body: Record<string, unknown>): void {
   }
   const profiles = asMutablePlainObject(llm.profiles);
   if (!profiles) return;
+  const existingProfiles = asMutablePlainObject(getConfig().llm.profiles) ?? {};
   for (const name of Object.keys(profiles)) {
-    if (profiles[name] === null && MANAGED_PROFILE_NAMES.has(name)) {
+    if (profiles[name] !== null || !MANAGED_PROFILE_NAMES.has(name)) continue;
+    // Only block deletion when the on-disk entry is Vellum-managed. A
+    // user-owned profile sharing a managed name carries a non-managed `source`
+    // and is freely deletable.
+    const existing = asMutablePlainObject(existingProfiles[name]);
+    if (existing?.source === "managed") {
       throw new BadRequestError(`Cannot delete managed profile "${name}".`);
     }
   }
@@ -922,7 +928,15 @@ async function handleReplaceInferenceProfile({
     const detail = parsed.error.issues.map((issue) => issue.message).join("; ");
     throw new BadRequestError(`Invalid profile fragment: ${detail}`);
   }
-  const isManaged = MANAGED_PROFILE_NAMES.has(name);
+  // A managed name with no existing entry stays protected so users can't
+  // shadow a seeded managed profile. An existing entry carrying a non-managed
+  // `source` is user-owned and remains fully editable.
+  const existingProfile = asMutablePlainObject(
+    getConfig().llm.profiles?.[name],
+  );
+  const isManaged =
+    MANAGED_PROFILE_NAMES.has(name) &&
+    (existingProfile == null || existingProfile.source === "managed");
   if (isManaged) {
     // Managed profiles are daemon-seeded — provider, model, advanced params,
     // and the connection binding all belong to the seed contract and can't


### PR DESCRIPTION
## Summary
- Add reconcileFlagGatedProfiles(): adds the managed OS Beta (GLM 5.2 / fireworks-managed) profile when the os-beta flag is on, removes it when off, with profileOrder/activeProfile/advisorProfile fallbacks. Never clobbers a user-owned os-beta profile. Idempotent.
- Add os-beta to MANAGED_PROFILE_NAMES (deferred from the template PR).

Part of plan: os-beta-managed-profile.md (PR 4 of 5)