### PR TITLE
fix(web): make Action Overrides profile names readable (wider menu + hover tooltip)

### DIFF
--- a/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
+++ b/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
@@ -110,7 +110,9 @@ export function CallSiteOverrideRow({
               value={profileVal}
               onChange={handleProfilePickerChange}
               options={profileOptions}
-              className="w-36"
+              className="w-44"
+              menuMinWidth={280}
+              menuAlign="end"
             />
           )}
           <Toggle

--- a/packages/design-library/src/components/dropdown.test.tsx
+++ b/packages/design-library/src/components/dropdown.test.tsx
@@ -16,6 +16,17 @@ describe("Dropdown", () => {
     expect(html).toContain("Option A");
   });
 
+  test("sets a title on the trigger label so truncated text is recoverable on hover", () => {
+    const longOptions: DropdownOption<"a" | "b">[] = [
+      { value: "a", label: "A very long option label that truncates" },
+      { value: "b", label: "Option B" },
+    ];
+    const html = renderToStaticMarkup(
+      <Dropdown options={longOptions} value="a" onChange={() => {}} aria-label="Test" />,
+    );
+    expect(html).toContain('title="A very long option label that truncates"');
+  });
+
   test("renders placeholder when no value matches", () => {
     const html = renderToStaticMarkup(
       <Dropdown

--- a/packages/design-library/src/components/dropdown.tsx
+++ b/packages/design-library/src/components/dropdown.tsx
@@ -349,7 +349,12 @@ export function Dropdown<T extends string>({
               </span>
             )}
             <span className="flex min-w-0 flex-1 items-center gap-2">
-              <span className="min-w-0 flex-1 truncate">{option.label}</span>
+              <span
+                className="min-w-0 flex-1 truncate"
+                title={option.label || undefined}
+              >
+                {option.label}
+              </span>
               {option.suffix && (
                 <span className="shrink-0">{option.suffix}</span>
               )}
@@ -411,7 +416,10 @@ export function Dropdown<T extends string>({
           </span>
         )}
         <span className="flex min-w-0 flex-1 items-center gap-2">
-          <span className="min-w-0 flex-1 truncate">
+          <span
+            className="min-w-0 flex-1 truncate"
+            title={selectedOption?.label || undefined}
+          >
             {selectedOption?.label ?? placeholder ?? ""}
           </span>
           {selectedOption?.suffix && (


### PR DESCRIPTION
## Summary

- The model-profile picker in Settings → AI → **Action Overrides** clipped long profile names to `openrouter-...` in both the closed trigger and the open menu, so every option read the same and you couldn't tell which profile you were selecting.
- Add a native `title` (hover tooltip) to the shared `Dropdown`'s truncated trigger and menu-item labels, so the full text is recoverable on hover everywhere — matching the existing `title`-on-truncate convention in `side-menu.tsx`.
- Widen the profile picker for that modal: `w-36` → `w-44` trigger, `menuMinWidth={280}` so the open list fits names like `openrouter-fable-5-managed`, and `menuAlign="end"` to anchor the wider menu under the right-aligned control.

## Original prompt

While reviewing the Action Overrides settings panel, the user noticed the model-profile dropdown truncates names so the full profile can't be read — in the screenshot every option in the open menu showed `openrouter-...`. They asked for the dropdown to either be wider or to show a tooltip on hover. This does both, minimally, and the tooltip lives in the shared Dropdown so it benefits every dropdown in the app.