### PR TITLE
ci(web): plumb VITE_SESSION_REPLAY_APP_ID into web/Electron builds

### DIFF
--- a/.github/workflows/deploy-platform-web-spa.yaml
+++ b/.github/workflows/deploy-platform-web-spa.yaml
@@ -64,6 +64,10 @@ jobs:
       #   - VITE_SENTRY_DSN          repo-level variable (same for every env)
       #   - VITE_SENTRY_ENVIRONMENT  per-environment variable (resolves via the
       #                              job's `environment:`)
+      #   - VITE_SESSION_REPLAY_APP_ID  repo-level variable; one ID across all
+      #                              surfaces (web/Electron/iOS). Unset disables
+      #                              session replay. Public, so baking it in is
+      #                              expected.
       #   - VITE_STRIPE_PUBLISHABLE_KEY  per-environment secret; publishable keys
       #                              are public, so embedding them is expected
       #   - VITE_VELAY_HOST          per-environment variable: the live-voice
@@ -91,6 +95,7 @@ jobs:
           # bundle via `server.url`) reports to the vellum-assistant-ios project.
           VITE_SENTRY_DSN_IOS: ${{ secrets.SENTRY_DSN_IOS }}
           VITE_SENTRY_ENVIRONMENT: ${{ vars.VITE_SENTRY_ENVIRONMENT }}
+          VITE_SESSION_REPLAY_APP_ID: ${{ vars.VITE_SESSION_REPLAY_APP_ID }}
           VITE_STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
           VITE_VELAY_HOST: ${{ vars.VITE_VELAY_HOST }}
           VITE_APP_VERSION: ${{ github.sha }}

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1632,6 +1632,7 @@ jobs:
           VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
           VITE_SENTRY_DSN_MACOS: ${{ secrets.SENTRY_DSN_MACOS }}
           VITE_SENTRY_ENVIRONMENT: dev
+          VITE_SESSION_REPLAY_APP_ID: ${{ vars.VITE_SESSION_REPLAY_APP_ID }}
         run: bun run pack --environment dev
 
       - name: Rename DMG for release

--- a/.github/workflows/pr-web.yaml
+++ b/.github/workflows/pr-web.yaml
@@ -160,6 +160,7 @@ jobs:
           # bundle via `server.url`) reports to the vellum-assistant-ios project.
           VITE_SENTRY_DSN_IOS: ${{ secrets.SENTRY_DSN_IOS }}
           VITE_SENTRY_ENVIRONMENT: ${{ vars.VITE_SENTRY_ENVIRONMENT }}
+          VITE_SESSION_REPLAY_APP_ID: ${{ vars.VITE_SESSION_REPLAY_APP_ID }}
           VITE_APP_VERSION: ${{ github.sha }}
         run: bun run build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2045,6 +2045,7 @@ jobs:
           VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
           VITE_SENTRY_DSN_MACOS: ${{ secrets.SENTRY_DSN_MACOS }}
           VITE_SENTRY_ENVIRONMENT: ${{ needs.extract-version.outputs.is_staging == 'true' && 'staging' || 'production' }}
+          VITE_SESSION_REPLAY_APP_ID: ${{ vars.VITE_SESSION_REPLAY_APP_ID }}
         run: bun run pack --environment "${{ needs.extract-version.outputs.is_staging == 'true' && 'staging' || 'production' }}"
 
       - name: Rename DMG for release


### PR DESCRIPTION
## Summary
- Exposes `VITE_SESSION_REPLAY_APP_ID` in the four build/pack `env:` blocks (prod web SPA deploy, PR web preview, Electron release, Electron dev release) so Vite inlines it into the shipped bundle, mirroring how `VITE_SENTRY_DSN` is wired (`${{ vars.* }}` repo variable — the app ID is public/baked into the bundle).
- The session-replay plumbing from #35413 reads `import.meta.env.VITE_SESSION_REPLAY_APP_ID` and no-ops while it is unset; this is the build-side half that lets it light up once a real provider is dropped in.
- One ID for all surfaces — web/Electron/iOS share a single replay project distinguished by a `surface` trait — so no per-host `_MACOS`/`_IOS` variants. The repo-level Actions variable has already been created.

## Original prompt
Following the session-replay plumbing merged in #35413 (consent-gated, no-op provider seam), the next step is the build-side wiring: make `VITE_SESSION_REPLAY_APP_ID` available at build time so the existing code stops no-op'ing once a real SDK lands. The ask was to add the single env line to each of the four web/Electron build steps, matching the existing `VITE_SENTRY_DSN` pattern, without per-host variants. Nothing records yet — going fully live still requires swapping the `noopProvider` and an Electron CSP / Capacitor ATS allowlist for the replay ingest domains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)