### PR TITLE
fix(providers): guard top_p on OpenAI reasoning path; fix managed-field doc drift

### DIFF
--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -163,8 +163,11 @@ export type SeedInferenceProfilesOptions = {
  *    `cost-optimized`): reconciled from the code templates on every boot —
  *    on-platform and off-platform alike — so Vellum can push model/config
  *    updates to customers in a release without a workspace migration. The
- *    templates own all profile content; only `label`, `status`,
- *    `advisorEnabled`, and `topP` are user-overridable and survive reseeds.
+ *    templates own all profile content; `label`, `status`, `advisorEnabled`,
+ *    and `topP` are user overrides that survive reseeds. Of those, only
+ *    `label`, `status`, and `topP` are editable through the managed PUT route
+ *    allowlist; `advisorEnabled` is edited via the generic config path but is
+ *    still preserved here so it survives reboots.
  *    Platform overlays (`preserveProfileNames`) take precedence for the boot
  *    they are supplied.
  *
@@ -221,10 +224,13 @@ export function seedInferenceProfiles(
   //    A whitelist of user-editable fields survives the reconcile: `label`
   //    (display rename), `status` (active/disabled toggle), `advisorEnabled`
   //    (per-profile advisor toggle), and `topP` (sampling override) — the only
-  //    fields a user may override. The PUT route `/v1/config/llm/profiles/:name`
-  //    lets users patch these on managed profiles without duplicating; we honor
-  //    those edits across reseeds or they'd silently revert on every boot. Carry
-  //    by key-presence rather than truthiness so an explicit `null` (user
+  //    fields a user may override. The managed PUT route
+  //    `/v1/config/llm/profiles/:name` lets users patch `label`, `status`, and
+  //    `topP` on managed profiles without duplicating (its editable allowlist,
+  //    `MANAGED_PROFILE_EDITABLE_KEYS`, deliberately excludes `advisorEnabled`,
+  //    which is set through the generic config path). We honor every one of
+  //    these overrides across reseeds or they'd silently revert on every boot.
+  //    Carry by key-presence rather than truthiness so an explicit `null` (user
   //    cleared the field) survives too.
   //
   //    BYOK seed defaults (off-platform only):

--- a/assistant/src/providers/openai/__tests__/responses-provider-top-p.test.ts
+++ b/assistant/src/providers/openai/__tests__/responses-provider-top-p.test.ts
@@ -67,4 +67,20 @@ describe("OpenAIResponsesProvider top_p forwarding", () => {
     const params = requests[0] as { top_p?: number };
     expect(params.top_p).toBeUndefined();
   });
+
+  test("omits top_p on reasoning requests even when configured", async () => {
+    const { provider, requests } = stubProvider();
+
+    // `effort: "high"` maps to a reasoning.effort via EFFORT_TO_REASONING_EFFORT,
+    // so `params.reasoning` is set. Reasoning models reject sampling params, so
+    // top_p must not be forwarded.
+    await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      { config: { top_p: 0.9, effort: "high" } },
+    );
+
+    const params = requests[0] as { top_p?: number; reasoning?: unknown };
+    expect(params.reasoning).toBeDefined();
+    expect(params.top_p).toBeUndefined();
+  });
 });

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -248,7 +248,13 @@ export class OpenAIResponsesProvider implements Provider {
       // builds `params` field-by-field; the Responses API accepts it as a
       // top-level param. Mirrors the chat-completions client's forwarding so
       // OpenAI-profile `topP` is honored on the Responses path too.
-      if (typeof topP === "number") {
+      //
+      // Skip it on reasoning requests: OpenAI reasoning models (o-series,
+      // GPT-5 reasoning) reject sampling params like `top_p`/`temperature`
+      // with HTTP 400 when `reasoning` is active. This mirrors the Anthropic
+      // thinking guard, which drops temperature/top_p when extended thinking
+      // is enabled. (`temperature` is never forwarded on this path at all.)
+      if (typeof topP === "number" && !params.reasoning) {
         params.top_p = topP;
       }
 


### PR DESCRIPTION
## Summary
- Skip forwarding top_p on the OpenAI Responses path when reasoning is active (reasoning models reject sampling params → 400)
- Correct seed-inference-profiles comments: advisorEnabled is preserved across reseed but is NOT in the managed PUT editable allowlist (label/status/topP)

Fixes gaps found during plan review for top-p-profiles.md.