### PR TITLE
fix(web): make topP editable on managed profiles (view mode)

### DIFF
--- a/clients/web/src/domains/settings/ai/profile-advanced-params.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-advanced-params.test.tsx
@@ -36,6 +36,8 @@ const MODEL = {
 
 interface FieldOverrides {
   visibility: ProfileParamVisibility;
+  isReadOnly?: boolean;
+  topPReadOnly?: boolean;
   maxTokens?: number | null;
   contextWindowMaxInputTokens?: number | null;
   onMaxTokensChange?: (v: number | null) => void;
@@ -53,7 +55,8 @@ function renderParams(overrides: FieldOverrides) {
   return render(
     <ProfileAdvancedParams
       visibility={overrides.visibility}
-      isReadOnly={false}
+      isReadOnly={overrides.isReadOnly ?? false}
+      topPReadOnly={overrides.topPReadOnly}
       model="claude-opus-4"
       selectedModel={overrides.selectedModel ?? MODEL}
       defaultMaxOutputTokens={overrides.defaultMaxOutputTokens}
@@ -478,5 +481,42 @@ describe("ProfileAdvancedParams Top P control", () => {
     fireEvent.keyDown(screen.getByRole("slider"), { key: "ArrowRight" });
 
     expect(onTopPChange).toHaveBeenCalled();
+  });
+
+  test("topPReadOnly overrides isReadOnly to keep the Top P control editable", () => {
+    // GIVEN the params locked read-only EXCEPT Top P (managed view mode)
+    const onTopPEnabledChange = mock();
+    renderParams({
+      visibility: topPOnly,
+      isReadOnly: true,
+      topPReadOnly: false,
+      onTopPEnabledChange,
+    });
+
+    // THEN the Top P toggle is enabled despite isReadOnly...
+    const toggle = screen.getByRole("switch", {
+      name: "Top P",
+    }) as HTMLButtonElement;
+    expect(toggle.disabled).toBe(false);
+
+    // ...and toggling it still fires the change handler.
+    fireEvent.click(toggle);
+    expect(onTopPEnabledChange).toHaveBeenLastCalledWith(true);
+  });
+
+  test("falls back to isReadOnly for Top P when topPReadOnly is omitted", () => {
+    // GIVEN read-only params with no topPReadOnly override
+    const onTopPEnabledChange = mock();
+    renderParams({
+      visibility: topPOnly,
+      isReadOnly: true,
+      onTopPEnabledChange,
+    });
+
+    // THEN the Top P toggle inherits the locked read-only state.
+    const toggle = screen.getByRole("switch", {
+      name: "Top P",
+    }) as HTMLButtonElement;
+    expect(toggle.disabled).toBe(true);
   });
 });

--- a/clients/web/src/domains/settings/ai/profile-advanced-params.tsx
+++ b/clients/web/src/domains/settings/ai/profile-advanced-params.tsx
@@ -52,6 +52,13 @@ const DEFAULT_MAX_OUTPUT_TOKENS = 64_000;
 interface ProfileAdvancedParamsProps {
   visibility: ProfileParamVisibility;
   isReadOnly: boolean;
+  /**
+   * Overrides `isReadOnly` for the Top P toggle/slider only. Top P is
+   * user-editable wherever it's visible — including managed-profile view mode,
+   * where the rest of the advanced params stay locked. Defaults to `isReadOnly`
+   * when omitted so callers that don't opt in keep the old behavior.
+   */
+  topPReadOnly?: boolean;
   model: string;
   /** Resolved catalog entry for the selected model (null if not in catalog). */
   selectedModel: {
@@ -245,6 +252,7 @@ function TokenBudgetField({
 export function ProfileAdvancedParams({
   visibility,
   isReadOnly,
+  topPReadOnly,
   model,
   selectedModel,
   defaultMaxOutputTokens,
@@ -293,6 +301,11 @@ export function ProfileAdvancedParams({
     defaultContextWindowMaxInputTokens ?? DEFAULT_CONTEXT_WINDOW_BUDGET_TOKENS,
     contextWindowCeiling,
   );
+
+  // Top P stays editable even when the rest of the params are locked (managed
+  // view mode). Fall back to the shared `isReadOnly` when the caller omits the
+  // override.
+  const topPDisabled = topPReadOnly ?? isReadOnly;
 
   return (
     // space-y-4 matches the modal body's rhythm so each advanced param gets
@@ -409,7 +422,7 @@ export function ProfileAdvancedParams({
             checked={topPEnabled}
             onChange={(v) => onTopPEnabledChange(v)}
             label="Top P"
-            disabled={isReadOnly}
+            disabled={topPDisabled}
           />
           {topPEnabled && (
             <div className="flex items-center justify-between">
@@ -422,7 +435,7 @@ export function ProfileAdvancedParams({
                   min={0}
                   max={1}
                   step={0.01}
-                  disabled={isReadOnly}
+                  disabled={topPDisabled}
                   showValue
                   formatValue={(v) =>
                     typeof v === "number" ? v.toFixed(2) : String(v)

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.test.tsx
@@ -237,6 +237,32 @@ function renderEdit(
   );
 }
 
+/** Render the editor in view mode for a managed (platform-seeded) profile. */
+function renderView(
+  initialValues: Record<string, unknown>,
+  onSave: (
+    name: string,
+    entry: unknown,
+    options?: { mode?: "merge" | "replace" },
+  ) => Promise<void> = () => Promise.resolve(),
+) {
+  return render(
+    <Wrapper>
+      <ProfileEditorModal
+        isOpen
+        mode="view"
+        profileName={(initialValues.name as string) ?? "balanced"}
+        initialValues={initialValues as never}
+        existingNames={[(initialValues.name as string) ?? "balanced"]}
+        connections={[makeConnection("anthropic-personal")]}
+        assistantId={ASSISTANT_ID}
+        onSave={onSave}
+        onCancel={() => {}}
+      />
+    </Wrapper>,
+  );
+}
+
 /** The Top P toggle is a switch labelled (via aria-labelledby) "Top P". */
 function topPSwitch(): HTMLElement {
   const sw = Array.from(
@@ -600,5 +626,73 @@ describe("ProfileEditorModal — Top P wiring", () => {
       expect(saveCalls.length).toBe(1);
     });
     expect(saveCalls[0].entry.topP).toBeNull();
+  });
+
+  describe("managed profile in view mode", () => {
+    // A managed (platform-seeded) Balanced profile. Anthropic opus →
+    // visibility.topP is true, so the Top P control renders even in view mode.
+    const managedProfile = {
+      name: "balanced",
+      label: "Balanced",
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      source: "managed",
+    };
+
+    test("the Top P control is editable even though the modal is read-only", () => {
+      renderView(managedProfile);
+
+      // The Top P toggle stays interactive while the rest of the editor is
+      // locked (provider/model dropdowns are disabled in view mode).
+      expect((topPSwitch() as HTMLButtonElement).disabled).toBe(false);
+    });
+
+    test("enabling Top P arms the otherwise close-only Save button", () => {
+      renderView(managedProfile);
+
+      // View mode opens with Save disabled (no policy fields touched yet).
+      expect(getSaveBtn().disabled).toBe(true);
+
+      // Turning Top P on is a tracked view-mode change → Save unlocks.
+      fireEvent.click(topPSwitch());
+      expect(getSaveBtn().disabled).toBe(false);
+    });
+
+    test("saving sends topP in a merge entry without seed-owned fields", async () => {
+      const saveCalls: {
+        name: string;
+        entry: Record<string, unknown>;
+        options?: { mode?: "merge" | "replace" };
+      }[] = [];
+      const onSave = (
+        name: string,
+        entry: unknown,
+        options?: { mode?: "merge" | "replace" },
+      ) => {
+        saveCalls.push({
+          name,
+          entry: entry as Record<string, unknown>,
+          options,
+        });
+        return Promise.resolve();
+      };
+
+      renderView(managedProfile, onSave);
+
+      // Enable Top P, then save.
+      fireEvent.click(topPSwitch());
+      fireEvent.click(getSaveBtn());
+
+      await waitFor(() => {
+        expect(saveCalls.length).toBe(1);
+      });
+      // The merge entry carries the new topP number...
+      expect(saveCalls[0].entry.topP).toBe(0.95);
+      expect(typeof saveCalls[0].entry.topP).toBe("number");
+      // ...as a deep-merge so seed-owned fields are never sent.
+      expect(saveCalls[0].options?.mode).toBe("merge");
+      expect(saveCalls[0].entry.provider).toBeUndefined();
+      expect(saveCalls[0].entry.model).toBeUndefined();
+    });
   });
 });

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -190,14 +190,6 @@ function ProfileEditorModalInner({
   const [locallyCreatedConnections, setLocallyCreatedConnections] = useState<
     ProviderConnection[]
   >([]);
-  // True when in view mode and the user has touched either of the two
-  // fields that view mode permits editing (label, status). Drives the
-  // view-mode Save button's enabled state and the partial-update save path.
-  const hasViewModeChanges =
-    isReadOnly &&
-    (label !== initialLabel ||
-      status !== initialStatus ||
-      advisorEnabled !== initialAdvisorEnabled);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
 
@@ -225,13 +217,27 @@ function ProfileEditorModalInner({
     typeof initialValues?.temperature === "number" ? initialValues.temperature : 0.7,
   );
 
-  // Advanced params — top P
-  const [topPEnabled, setTopPEnabled] = useState<boolean>(
-    typeof initialValues?.topP === "number",
-  );
-  const [topP, setTopP] = useState<number>(
-    typeof initialValues?.topP === "number" ? initialValues.topP : 0.95,
-  );
+  // Advanced params — top P. Top P is editable in view mode (managed
+  // profiles), so capture its initial enabled flag + value as the baseline
+  // `hasViewModeChanges` compares against — mirroring `initialAdvisorEnabled`.
+  const initialTopPEnabled = typeof initialValues?.topP === "number";
+  const initialTopP =
+    typeof initialValues?.topP === "number" ? initialValues.topP : 0.95;
+  const [topPEnabled, setTopPEnabled] = useState<boolean>(initialTopPEnabled);
+  const [topP, setTopP] = useState<number>(initialTopP);
+
+  // True when in view mode and the user has touched one of the fields that
+  // view mode permits editing (label, status, advisor, Top P). Drives the
+  // view-mode Save button's enabled state and the partial-update save path.
+  // Top P is compared on both the enabled flag and the value so flipping the
+  // toggle or dragging the slider both arm Save.
+  const hasViewModeChanges =
+    isReadOnly &&
+    (label !== initialLabel ||
+      status !== initialStatus ||
+      advisorEnabled !== initialAdvisorEnabled ||
+      topPEnabled !== initialTopPEnabled ||
+      (topPEnabled && topP !== initialTopP));
 
   // Advanced params — thinking
   const [thinkingEnabled, setThinkingEnabled] = useState<boolean>(
@@ -476,6 +482,14 @@ function ProfileEditorModalInner({
           status,
           advisorEnabled,
         };
+        // Top P is the one advanced param managed profiles may override.
+        // Mirror the create/edit build-entry logic: enabled → number,
+        // cleared → null. Only when the selected provider/model surfaces the
+        // control. `mode: "merge"` means sending just this changed subset
+        // leaves the seed-owned fields intact.
+        if (visibility.topP) {
+          entry.topP = topPEnabled ? topP : null;
+        }
         await onSave(keyTrimmed, entry, { mode: "merge" });
       } catch {
         setSaveError("Failed to save profile. Please try again.");
@@ -674,6 +688,9 @@ function ProfileEditorModalInner({
     <ProfileAdvancedParams
       visibility={visibility}
       isReadOnly={isReadOnly}
+      // Top P is user policy on managed profiles too, so it stays editable in
+      // view mode while the other advanced params remain locked by isReadOnly.
+      topPReadOnly={false}
       model={model}
       selectedModel={selectedModel}
       defaultMaxOutputTokens={defaultMaxOutputTokens}


### PR DESCRIPTION
## Summary
Managed profiles open the editor in view mode, which only allowed editing label/status/advisorEnabled — so topP on the managed Balanced profile couldn't be set from the UI despite daemon support. Make the Top P control editable in view mode, track it in hasViewModeChanges, and include it in the view-mode merge save.

Fixes gap found during plan review for top-p-profiles.md.