### PR TITLE
feat(daemon): run OS Beta profile reconcile after flags load and on change

### DIFF
--- a/assistant/src/__tests__/gateway-flag-listener.test.ts
+++ b/assistant/src/__tests__/gateway-flag-listener.test.ts
@@ -61,6 +61,32 @@ mock.module("../tools/registry.js", () => ({
 }));
 
 // ---------------------------------------------------------------------------
+// Track reconcileFlagGatedProfiles calls and let each test control whether it
+// reports a config change, so we can assert the listener broadcasts only when
+// the managed profile set actually changes.
+// ---------------------------------------------------------------------------
+let reconcileCallCount = 0;
+let reconcileReturns = false;
+
+mock.module("../config/sync-gated-profiles.js", () => ({
+  reconcileFlagGatedProfiles: () => {
+    reconcileCallCount++;
+    return reconcileReturns;
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Track publishConfigChanged so we can assert the picker-refresh broadcast.
+// ---------------------------------------------------------------------------
+let configChangedCount = 0;
+
+mock.module("../runtime/sync/resource-sync-events.js", () => ({
+  publishConfigChanged: () => {
+    configChangedCount++;
+  },
+}));
+
+// ---------------------------------------------------------------------------
 // Dynamic imports (after mock.module)
 // ---------------------------------------------------------------------------
 const { startGatewayFlagListener, stopGatewayFlagListener } =
@@ -117,6 +143,9 @@ describe("gateway-flag-listener", () => {
     refreshCallCount = 0;
     syncToolsCallCount = 0;
     publishedTagSets = [];
+    reconcileCallCount = 0;
+    reconcileReturns = false;
+    configChangedCount = 0;
     testServer = createTestServer();
   });
 
@@ -178,6 +207,44 @@ describe("gateway-flag-listener", () => {
       "feature-flags:client",
       "feature-flags:assistant",
     ]);
+  });
+
+  test("reconciles flag-gated profiles and broadcasts config_changed when the profile set changes", async () => {
+    reconcileReturns = true;
+    await new Promise<void>((resolve) => {
+      testServer.server.listen(socketPath, resolve);
+    });
+
+    startGatewayFlagListener();
+    await testServer.waitForClient();
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Connect path reconciles once and, since it reports a change, broadcasts.
+    expect(reconcileCallCount).toBe(1);
+    expect(configChangedCount).toBe(1);
+
+    testServer.emit("feature_flags_changed");
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(reconcileCallCount).toBe(2);
+    expect(configChangedCount).toBe(2);
+  });
+
+  test("reconciles but does not broadcast config_changed when the profile set is unchanged", async () => {
+    reconcileReturns = false;
+    await new Promise<void>((resolve) => {
+      testServer.server.listen(socketPath, resolve);
+    });
+
+    startGatewayFlagListener();
+    await testServer.waitForClient();
+    await new Promise((r) => setTimeout(r, 100));
+
+    testServer.emit("feature_flags_changed");
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(reconcileCallCount).toBeGreaterThanOrEqual(2);
+    expect(configChangedCount).toBe(0);
   });
 
   test("ignores non-flag events", async () => {

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -76,7 +76,10 @@ import {
 import { RuntimeHttpServer } from "../runtime/http-server.js";
 import { recoverInterruptedImport } from "../runtime/migrations/vbundle-streaming-importer.js";
 import { registerSecretsDeps } from "../runtime/routes/secrets-deps.js";
-import { publishConversationListChanged } from "../runtime/sync/resource-sync-events.js";
+import {
+  publishConfigChanged,
+  publishConversationListChanged,
+} from "../runtime/sync/resource-sync-events.js";
 import { recoverStaleSchedules } from "../schedule/schedule-recovery.js";
 import { startScheduler } from "../schedule/scheduler.js";
 import {
@@ -374,11 +377,16 @@ export async function runDaemon(): Promise<void> {
     // the same race). Enable-direction only; chained so it sees the fresh cache.
     // Then reconcile flag-gated managed profiles (OS Beta): `seedInferenceProfiles()`
     // runs synchronously earlier in boot before flags are available, so this lands
-    // the profile on the same boot once the flag cache is populated.
+    // the profile on the same boot once the flag cache is populated. When this
+    // reconcile is the call that mutates config (it raced ahead of the gateway
+    // flag listener), publish the config invalidation so any client that already
+    // fetched `GET /v1/config` refreshes its profile picker.
     void initFeatureFlagOverrides()
       .then(() => syncFlagGatedTools())
       .then(() => {
-        reconcileFlagGatedProfiles();
+        if (reconcileFlagGatedProfiles()) {
+          publishConfigChanged();
+        }
       })
       .catch((err) => log.warn({ err }, "Background feature flag init failed"));
 

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -20,6 +20,7 @@ import {
 import { loadConfig, mergeDefaultWorkspaceConfig } from "../config/loader.js";
 import type { AssistantConfig } from "../config/schema.js";
 import { seedInferenceProfiles } from "../config/seed-inference-profiles.js";
+import { reconcileFlagGatedProfiles } from "../config/sync-gated-profiles.js";
 import type { CesClient } from "../credential-execution/client.js";
 import { createCesClient } from "../credential-execution/client.js";
 import { refreshManagedConnectionCache } from "../credential-execution/managed-catalog.js";
@@ -371,8 +372,14 @@ export async function runDaemon(): Promise<void> {
     // this fetch completes, so without this follow-up sync a flag-enabled
     // assistant would not expose the gated tools until a restart (which can lose
     // the same race). Enable-direction only; chained so it sees the fresh cache.
+    // Then reconcile flag-gated managed profiles (OS Beta): `seedInferenceProfiles()`
+    // runs synchronously earlier in boot before flags are available, so this lands
+    // the profile on the same boot once the flag cache is populated.
     void initFeatureFlagOverrides()
       .then(() => syncFlagGatedTools())
+      .then(() => {
+        reconcileFlagGatedProfiles();
+      })
       .catch((err) => log.warn({ err }, "Background feature flag init failed"));
 
     startGatewayFlagListener();

--- a/assistant/src/ipc/gateway-flag-listener.ts
+++ b/assistant/src/ipc/gateway-flag-listener.ts
@@ -1,7 +1,9 @@
 import { connect, type Socket } from "node:net";
 
 import { refreshOverridesFromGateway } from "../config/assistant-feature-flags.js";
+import { reconcileFlagGatedProfiles } from "../config/sync-gated-profiles.js";
 import { SYNC_TAGS } from "../daemon/message-types/sync.js";
+import { publishConfigChanged } from "../runtime/sync/resource-sync-events.js";
 import { publishSyncInvalidation } from "../runtime/sync/sync-publisher.js";
 import { syncFlagGatedTools } from "../tools/registry.js";
 import { getLogger } from "../util/logger.js";
@@ -19,11 +21,21 @@ const log = getLogger("gateway-flag-listener");
  * they live in a flag-gated bundled skill surfaced via `skill_load` against the
  * live flag cache, so they need no registry sync here. `syncFlagGatedTools` is
  * idempotent and enable-only, so re-running it on every refresh is safe; it also
- * never throws (it logs internally).
+ * never throws (it logs internally). After tools sync, `reconcileFlagGatedProfiles`
+ * adds or removes the flag-gated managed profile (OS Beta); when it reports a
+ * change a `config_changed` broadcast refreshes the profile picker on clients.
  */
 function refreshFlagsAndSyncTools(context: string): void {
   refreshOverridesFromGateway()
     .then(() => syncFlagGatedTools())
+    .then(() => {
+      const changed = reconcileFlagGatedProfiles();
+      if (changed) {
+        // Reuse the config-changed broadcast clients already consume so the
+        // profile picker reflects the added/removed managed profile.
+        publishConfigChanged();
+      }
+    })
     .catch((err) => {
       log.warn(
         { err },


### PR DESCRIPTION
## Summary
- Wire reconcileFlagGatedProfiles() into the daemon post-flag-load startup chain (non-blocking) and the gateway feature_flags_changed listener, broadcasting a config/profiles-changed notification so clients refresh the picker when the OS Beta profile is added/removed.

Part of plan: os-beta-managed-profile.md (PR 5 of 5)