### PR TITLE
feat(web): serve session replay first-party via platform proxy

### DIFF
--- a/clients/macos/electron.vite.config.ts
+++ b/clients/macos/electron.vite.config.ts
@@ -64,6 +64,11 @@ const BUILD_DEFINES = {
       process.env.VELLUM_ENABLE_CHROME_DEVTOOLS === "1",
   ),
   __SENTRY_DSN_MACOS__: JSON.stringify(process.env.SENTRY_DSN_MACOS || ""),
+  // Root hostname (leading dot) shared with the web bundle's
+  // VITE_ROOT_HOSTNAME; baked into the CSP source lists (see src/main/csp.ts).
+  __VELLUM_ROOT_HOSTNAME__: JSON.stringify(
+    process.env.VITE_ROOT_HOSTNAME || ".vellum.ai",
+  ),
 };
 
 export default defineConfig({

--- a/clients/macos/src/main/csp.test.ts
+++ b/clients/macos/src/main/csp.test.ts
@@ -40,6 +40,11 @@ describe("CSP_POLICY", () => {
     expect(scriptSrc).toContain("'unsafe-inline'");
   });
 
+  test("script-src allows the platform origin for the replay recorder script", () => {
+    const scriptSrc = directiveValue("script-src")!;
+    expect(scriptSrc).toContain("https://*.vellum.ai");
+  });
+
   test("object-src is 'none'", () => {
     expect(directiveValue("object-src")).toBe("'none'");
   });

--- a/clients/macos/src/main/csp.ts
+++ b/clients/macos/src/main/csp.ts
@@ -5,6 +5,11 @@ import { session } from "electron";
 // injected bridge/storage scripts are inline. The sandbox attribute is the
 // primary isolation boundary for that content.
 //
+// https://*.vellum.ai in script-src: the session-replay recorder script is
+// served first-party from the platform origin (`/_sr/cdn/...`) and loads as a
+// regular <script>. Ingest is already covered by connect-src and the recorder
+// worker by `worker-src ... blob:`, so this is the only directive that needs it.
+//
 // ws://localhost / ws://127.0.0.1 in connect-src: the self-hosted gateway's
 // WebSocket endpoints (/v1/stt/stream dictation partials, /v1/live-voice).
 // HTTP gateway traffic rides the app:// protocol forward in main and stays
@@ -14,7 +19,7 @@ import { session } from "electron";
 // connections need the planned proxy-through-main follow-up.
 export const CSP_POLICY = [
   "default-src 'self'",
-  "script-src 'self' 'unsafe-inline'",
+  "script-src 'self' 'unsafe-inline' https://*.vellum.ai",
   "style-src 'self' 'unsafe-inline'",
   "connect-src 'self' blob: data: https://*.vellum.ai wss://*.vellum.ai https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://api.elevenlabs.io https://api.deepgram.com ws://localhost:* ws://127.0.0.1:*",
   "img-src 'self' https: data: blob:",

--- a/clients/macos/src/main/csp.ts
+++ b/clients/macos/src/main/csp.ts
@@ -1,11 +1,23 @@
 import { session } from "electron";
 
+// Root hostname (leading dot, e.g. ".vellum.ai") injected at build time via
+// electron-vite `define` from VITE_ROOT_HOSTNAME — the same var the web bundle
+// reads. Falls back to the production default when unset (e.g. under `bun
+// test`, which doesn't run the bundler).
+declare const __VELLUM_ROOT_HOSTNAME__: string;
+const ROOT_HOSTNAME =
+  typeof __VELLUM_ROOT_HOSTNAME__ === "string"
+    ? __VELLUM_ROOT_HOSTNAME__
+    : ".vellum.ai";
+// Wildcard host for CSP source lists, e.g. "*.vellum.ai".
+const WILDCARD_HOST = `*${ROOT_HOSTNAME}`;
+
 // 'unsafe-inline' in script-src: required because sandboxed srcdoc iframes
 // (dynamic-page-surface, app-viewer) inherit the parent CSP and their
 // injected bridge/storage scripts are inline. The sandbox attribute is the
 // primary isolation boundary for that content.
 //
-// https://*.vellum.ai in script-src: the session-replay recorder script is
+// https://${WILDCARD_HOST} in script-src: the session-replay recorder script is
 // served first-party from the platform origin (`/_sr/cdn/...`) and loads as a
 // regular <script>. Ingest is already covered by connect-src and the recorder
 // worker by `worker-src ... blob:`, so this is the only directive that needs it.
@@ -19,9 +31,9 @@ import { session } from "electron";
 // connections need the planned proxy-through-main follow-up.
 export const CSP_POLICY = [
   "default-src 'self'",
-  "script-src 'self' 'unsafe-inline' https://*.vellum.ai",
+  `script-src 'self' 'unsafe-inline' https://${WILDCARD_HOST}`,
   "style-src 'self' 'unsafe-inline'",
-  "connect-src 'self' blob: data: https://*.vellum.ai wss://*.vellum.ai https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://api.elevenlabs.io https://api.deepgram.com ws://localhost:* ws://127.0.0.1:*",
+  `connect-src 'self' blob: data: https://${WILDCARD_HOST} wss://${WILDCARD_HOST} https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://api.elevenlabs.io https://api.deepgram.com ws://localhost:* ws://127.0.0.1:*`,
   "img-src 'self' https: data: blob:",
   "media-src 'self' blob:",
   "worker-src 'self' blob: https://cdn.jsdelivr.net",

--- a/clients/web/bun.lock
+++ b/clients/web/bun.lock
@@ -48,6 +48,7 @@
         "clsx": "2.1.1",
         "jszip": "3.10.1",
         "katex": "0.17.0",
+        "logrocket": "12.1.1",
         "lucide-react": "1.16.0",
         "motion": "12.39.0",
         "pdfjs-dist": "5.7.284",
@@ -1238,6 +1239,8 @@
     "linkifyjs": ["linkifyjs@4.3.3", "", {}, "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "logrocket": ["logrocket@12.1.1", "", {}, "sha512-l7z9ii5nNV6NZ3nzEqbB3xJAqFJC6QdRYDK8DeCC6JKwzuI8nyUezUJAotgMyClrqB6eV/Bo0i/KihQlXSRDKw=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 

--- a/clients/web/package.json
+++ b/clients/web/package.json
@@ -71,6 +71,7 @@
     "clsx": "2.1.1",
     "jszip": "3.10.1",
     "katex": "0.17.0",
+    "logrocket": "12.1.1",
     "lucide-react": "1.16.0",
     "motion": "12.39.0",
     "pdfjs-dist": "5.7.284",

--- a/clients/web/src/env.d.ts
+++ b/clients/web/src/env.d.ts
@@ -32,6 +32,13 @@ interface ImportMetaEnv {
    * is distinguished by a `surface` trait. Unset → session replay disabled.
    */
   readonly VITE_SESSION_REPLAY_APP_ID?: string;
+  /**
+   * Root hostname shared across Vellum subdomains, with a leading dot (e.g.
+   * `.vellum.ai`). Used as the session-replay cookie scope (`rootHostname`).
+   * Defaults to `.vellum.ai` when unset. The Electron main process reads the
+   * same var via `process.env` at build time (see `electron.vite.config.ts`).
+   */
+  readonly VITE_ROOT_HOSTNAME?: string;
   /** Stripe publishable key for payment forms. Injected by CI/CD pipeline. */
   readonly VITE_STRIPE_PUBLISHABLE_KEY?: string;
   /** App version stamp for diagnostic reporting. */

--- a/clients/web/src/env.d.ts
+++ b/clients/web/src/env.d.ts
@@ -59,4 +59,10 @@ interface Window {
   __VELLUM_FLAG_OVERRIDES__?: Record<string, boolean | string>;
   /** Runtime config injected by the shell (Electron preload, CLI, etc.). */
   __VELLUM_CONFIG__?: { disablePlatform?: boolean; mode?: string };
+  /**
+   * SDK-defined override for the session-replay recorder script URL. Set before
+   * the replay SDK inits so it loads the recorder from our first-party proxy
+   * (see `session-replay-provider.ts`).
+   */
+  _lrAsyncScript?: string;
 }

--- a/clients/web/src/lib/session-replay/session-replay-control.test.ts
+++ b/clients/web/src/lib/session-replay/session-replay-control.test.ts
@@ -140,6 +140,8 @@ describe("syncSessionReplay", () => {
       release: "1.2.3",
       surface: "web",
       base: "https://app.example.com",
+      // Live consent gate handed to the SDK (same ref as the exported gate).
+      shouldSendData: sessionReplayConsentGranted,
     });
     expect(stopMock).not.toHaveBeenCalled();
   });

--- a/clients/web/src/lib/session-replay/session-replay-control.test.ts
+++ b/clients/web/src/lib/session-replay/session-replay-control.test.ts
@@ -95,6 +95,7 @@ const CONFIG = {
   surface: "web" as const,
   environment: "test",
   release: "1.2.3",
+  base: "https://app.example.com",
 };
 
 function authState(over: Partial<MockAuthState> = {}): MockAuthState {
@@ -138,6 +139,7 @@ describe("syncSessionReplay", () => {
       environment: "test",
       release: "1.2.3",
       surface: "web",
+      base: "https://app.example.com",
     });
     expect(stopMock).not.toHaveBeenCalled();
   });

--- a/clients/web/src/lib/session-replay/session-replay-control.ts
+++ b/clients/web/src/lib/session-replay/session-replay-control.ts
@@ -67,6 +67,9 @@ function tryInit(config: SessionReplayConfig): void {
     release: config.release,
     surface: config.surface,
     base: config.base,
+    // Live gate the SDK re-checks before every upload — a mid-session revoke
+    // stops ingestion even though the recorder can't be un-init'd.
+    shouldSendData: sessionReplayConsentGranted,
   });
   identifySessionReplayUser(config.surface);
 }

--- a/clients/web/src/lib/session-replay/session-replay-control.ts
+++ b/clients/web/src/lib/session-replay/session-replay-control.ts
@@ -24,6 +24,8 @@ export interface SessionReplayConfig {
   surface: SessionReplaySurface;
   environment: string;
   release?: string;
+  /** Origin fronting the first-party LogRocket proxy. */
+  base: string;
 }
 
 /**
@@ -64,6 +66,7 @@ function tryInit(config: SessionReplayConfig): void {
     environment: config.environment,
     release: config.release,
     surface: config.surface,
+    base: config.base,
   });
   identifySessionReplayUser(config.surface);
 }

--- a/clients/web/src/lib/session-replay/session-replay-control.ts
+++ b/clients/web/src/lib/session-replay/session-replay-control.ts
@@ -24,7 +24,7 @@ export interface SessionReplayConfig {
   surface: SessionReplaySurface;
   environment: string;
   release?: string;
-  /** Origin fronting the first-party LogRocket proxy. */
+  /** Origin fronting the first-party session replay proxy. */
   base: string;
 }
 

--- a/clients/web/src/lib/session-replay/session-replay-init.ts
+++ b/clients/web/src/lib/session-replay/session-replay-init.ts
@@ -1,3 +1,4 @@
+import { getPlatformRuntimeUrl } from "@/lib/local-mode";
 import {
   installSessionReplayControlListeners,
   syncSessionReplay,
@@ -30,6 +31,8 @@ export function initSessionReplay(): void {
     surface: sessionReplaySurface(),
     environment: import.meta.env.VITE_SENTRY_ENVIRONMENT ?? "local",
     release: import.meta.env.VITE_APP_VERSION,
+    // Platform origin per environment + surface; fronts the first-party proxy.
+    base: getPlatformRuntimeUrl(),
   };
   syncSessionReplay(config);
   installSessionReplayControlListeners(config);

--- a/clients/web/src/lib/session-replay/session-replay-provider.test.ts
+++ b/clients/web/src/lib/session-replay/session-replay-provider.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Mock the vendor SDK so we can assert how the provider drives it without
+// loading the real recorder.
+const initMock = mock((_appId: string, _options: Record<string, unknown>) => {});
+const identifyMock = mock(
+  (_uid: string, _traits: Record<string, string>) => {},
+);
+mock.module("logrocket", () => ({
+  default: { init: initMock, identify: identifyMock },
+}));
+
+const { provider } = await import(
+  "@/lib/session-replay/session-replay-provider"
+);
+
+const BASE = "https://app.example.com";
+
+beforeEach(() => {
+  initMock.mockClear();
+  identifyMock.mockClear();
+  delete window._lrAsyncScript;
+  if (provider.isActive()) provider.stop();
+});
+
+describe("replay provider (first-party proxy)", () => {
+  test("init points the recorder script and ingest at our own origin", () => {
+    provider.init("app-123", {
+      environment: "test",
+      release: "1.2.3",
+      surface: "web",
+      base: BASE,
+    });
+
+    // Recorder script served first-party (set before init).
+    expect(window._lrAsyncScript).toBe(`${BASE}/_sr/cdn/logger.min.js`);
+
+    // Ingest server routed through our proxy; no vendor host leaks.
+    expect(initMock).toHaveBeenCalledTimes(1);
+    const [appId, options] = initMock.mock.calls[0]!;
+    expect(appId).toBe("app-123");
+    expect(options.serverURL).toBe(`${BASE}/_sr/ingest/i`);
+    expect(options.release).toBe("1.2.3");
+    expect(provider.isActive()).toBe(true);
+  });
+
+  test("identify forwards only defined traits plus surface", () => {
+    provider.init("app-123", {
+      environment: "test",
+      surface: "macos",
+      base: BASE,
+    });
+    provider.identify("u1", {
+      name: "Alice Smith",
+      email: "alice@example.com",
+      surface: "macos",
+    });
+
+    expect(identifyMock).toHaveBeenCalledWith("u1", {
+      surface: "macos",
+      name: "Alice Smith",
+      email: "alice@example.com",
+    });
+  });
+});

--- a/clients/web/src/lib/session-replay/session-replay-provider.test.ts
+++ b/clients/web/src/lib/session-replay/session-replay-provider.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 // Mock the vendor SDK so we can assert how the provider drives it without
-// loading the real recorder.
+// loading the real recorder. The provider imports it lazily (dynamic import),
+// which mock.module intercepts the same as a static import.
 const initMock = mock((_appId: string, _options: Record<string, unknown>) => {});
 const identifyMock = mock(
   (_uid: string, _traits: Record<string, string>) => {},
@@ -21,15 +22,18 @@ const NETWORK = {
   isEnabled: true,
 };
 
+/** Drain microtasks so the provider's lazy `import("logrocket")` resolves. */
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
 beforeEach(() => {
   initMock.mockClear();
   identifyMock.mockClear();
 });
 
-// The provider is a module singleton with one-shot init, so these tests run as
-// an ordered sequence: the first `init` primes the SDK for the rest.
-describe("replay provider (first-party proxy, singleton lifecycle)", () => {
-  test("init points recorder + ingest at our origin and wires the consent gate", () => {
+// The provider is a module singleton that lazily loads the SDK once, so these
+// tests run as an ordered sequence: the first `init` loads + primes it.
+describe("replay provider (first-party proxy, lazy load)", () => {
+  test("defers the SDK load, then forwards proxied config + queued identify", async () => {
     let consent = true;
     provider.init("app-123", {
       environment: "test",
@@ -40,30 +44,48 @@ describe("replay provider (first-party proxy, singleton lifecycle)", () => {
       network: NETWORK,
     });
 
-    // Recorder script served first-party (set before init).
+    // Recorder URL is set synchronously, pointing at our first-party proxy.
     expect(window._lrAsyncScript).toBe(`${BASE}/_sr/cdn/logger.min.js`);
+    expect(provider.isActive()).toBe(true);
 
-    // Ingest routed through our proxy; no vendor host leaks.
+    // identify before the lazy import resolves must queue, not throw.
+    provider.identify("u1", {
+      name: "Alice Smith",
+      email: "alice@example.com",
+      surface: "web",
+    });
+
+    // Nothing touches the SDK synchronously — the import is deferred so the
+    // recorder never loads at app startup (regression guard for the P1).
+    expect(initMock).not.toHaveBeenCalled();
+    expect(identifyMock).not.toHaveBeenCalled();
+
+    await flush();
+
+    // SDK init forwarded our proxied config.
     expect(initMock).toHaveBeenCalledTimes(1);
     const [appId, options] = initMock.mock.calls[0]!;
     expect(appId).toBe("app-123");
     expect(options.serverURL).toBe(`${BASE}/_sr/ingest/i`);
     expect(options.release).toBe("1.2.3");
-    // Defaults to the apex root hostname when VITE_ROOT_HOSTNAME is unset.
     expect(options.rootHostname).toBe(".vellum.ai");
-    // Network sanitizers are forwarded to the SDK's network config.
     expect(options.network).toBe(NETWORK);
-    expect(provider.isActive()).toBe(true);
 
-    // The SDK re-checks shouldSendData before every upload, so a mid-session
-    // revoke halts ingestion live rather than at next reload.
+    // shouldSendData reflects live consent, re-checked before every upload.
     const shouldSendData = options.shouldSendData as () => boolean;
     expect(shouldSendData()).toBe(true);
     consent = false;
     expect(shouldSendData()).toBe(false);
+
+    // The queued identify flushes once the SDK is loaded.
+    expect(identifyMock).toHaveBeenCalledWith("u1", {
+      surface: "web",
+      name: "Alice Smith",
+      email: "alice@example.com",
+    });
   });
 
-  test("init is one-shot: a revoke→re-grant within a page does not re-init", () => {
+  test("init is one-shot: a revoke→re-grant within a page does not reload", async () => {
     provider.stop();
     expect(provider.isActive()).toBe(false);
 
@@ -74,25 +96,19 @@ describe("replay provider (first-party proxy, singleton lifecycle)", () => {
       shouldSendData: () => true,
       network: NETWORK,
     });
+    await flush();
 
-    // Re-running init must not call the SDK again — the recorder can't be
-    // cleanly re-init'd mid-page; consent gating is what (un)pauses uploads.
+    // Already loaded — must not import/init the SDK again.
     expect(initMock).not.toHaveBeenCalled();
-    // ...but the provider counts as active again so re-identify can fire.
     expect(provider.isActive()).toBe(true);
   });
 
-  test("identify forwards only defined traits plus surface", () => {
-    provider.identify("u1", {
-      name: "Alice Smith",
-      email: "alice@example.com",
-      surface: "macos",
-    });
+  test("identify after load dispatches directly", () => {
+    provider.identify("u2", { username: "bob", surface: "macos" });
 
-    expect(identifyMock).toHaveBeenCalledWith("u1", {
+    expect(identifyMock).toHaveBeenCalledWith("u2", {
       surface: "macos",
-      name: "Alice Smith",
-      email: "alice@example.com",
+      username: "bob",
     });
   });
 });

--- a/clients/web/src/lib/session-replay/session-replay-provider.test.ts
+++ b/clients/web/src/lib/session-replay/session-replay-provider.test.ts
@@ -41,6 +41,8 @@ describe("replay provider (first-party proxy)", () => {
     expect(appId).toBe("app-123");
     expect(options.serverURL).toBe(`${BASE}/_sr/ingest/i`);
     expect(options.release).toBe("1.2.3");
+    // Defaults to the apex root hostname when VITE_ROOT_HOSTNAME is unset.
+    expect(options.rootHostname).toBe(".vellum.ai");
     expect(provider.isActive()).toBe(true);
   });
 

--- a/clients/web/src/lib/session-replay/session-replay-provider.test.ts
+++ b/clients/web/src/lib/session-replay/session-replay-provider.test.ts
@@ -19,23 +19,25 @@ const BASE = "https://app.example.com";
 beforeEach(() => {
   initMock.mockClear();
   identifyMock.mockClear();
-  delete window._lrAsyncScript;
-  if (provider.isActive()) provider.stop();
 });
 
-describe("replay provider (first-party proxy)", () => {
-  test("init points the recorder script and ingest at our own origin", () => {
+// The provider is a module singleton with one-shot init, so these tests run as
+// an ordered sequence: the first `init` primes the SDK for the rest.
+describe("replay provider (first-party proxy, singleton lifecycle)", () => {
+  test("init points recorder + ingest at our origin and wires the consent gate", () => {
+    let consent = true;
     provider.init("app-123", {
       environment: "test",
       release: "1.2.3",
       surface: "web",
       base: BASE,
+      shouldSendData: () => consent,
     });
 
     // Recorder script served first-party (set before init).
     expect(window._lrAsyncScript).toBe(`${BASE}/_sr/cdn/logger.min.js`);
 
-    // Ingest server routed through our proxy; no vendor host leaks.
+    // Ingest routed through our proxy; no vendor host leaks.
     expect(initMock).toHaveBeenCalledTimes(1);
     const [appId, options] = initMock.mock.calls[0]!;
     expect(appId).toBe("app-123");
@@ -44,14 +46,34 @@ describe("replay provider (first-party proxy)", () => {
     // Defaults to the apex root hostname when VITE_ROOT_HOSTNAME is unset.
     expect(options.rootHostname).toBe(".vellum.ai");
     expect(provider.isActive()).toBe(true);
+
+    // The SDK re-checks shouldSendData before every upload, so a mid-session
+    // revoke halts ingestion live rather than at next reload.
+    const shouldSendData = options.shouldSendData as () => boolean;
+    expect(shouldSendData()).toBe(true);
+    consent = false;
+    expect(shouldSendData()).toBe(false);
+  });
+
+  test("init is one-shot: a revoke→re-grant within a page does not re-init", () => {
+    provider.stop();
+    expect(provider.isActive()).toBe(false);
+
+    provider.init("app-123", {
+      environment: "test",
+      surface: "web",
+      base: BASE,
+      shouldSendData: () => true,
+    });
+
+    // Re-running init must not call the SDK again — the recorder can't be
+    // cleanly re-init'd mid-page; consent gating is what (un)pauses uploads.
+    expect(initMock).not.toHaveBeenCalled();
+    // ...but the provider counts as active again so re-identify can fire.
+    expect(provider.isActive()).toBe(true);
   });
 
   test("identify forwards only defined traits plus surface", () => {
-    provider.init("app-123", {
-      environment: "test",
-      surface: "macos",
-      base: BASE,
-    });
     provider.identify("u1", {
       name: "Alice Smith",
       email: "alice@example.com",

--- a/clients/web/src/lib/session-replay/session-replay-provider.ts
+++ b/clients/web/src/lib/session-replay/session-replay-provider.ts
@@ -1,11 +1,13 @@
 /**
  * Provider seam for session replay. The consent/lifecycle logic in
  * `session-replay-control.ts` dispatches through this single interface so the
- * real replay SDK can be dropped in later by swapping `provider` — no caller
- * changes. The active provider is a no-op today: the plumbing (consent gate,
- * identify, lifecycle) is wired and tested, but nothing records until a real
- * provider replaces `noopProvider`.
+ * active SDK can be swapped by changing the `provider` binding — no caller
+ * changes.
  */
+// Session-replay vendor SDK. Referenced only through the neutral `replaySdk`
+// alias below so the vendor name stays out of shipped code and proxied URLs
+// (it's pattern-matched by ad-blockers — the whole reason we proxy first-party).
+import replaySdk from "logrocket";
 
 export type SessionReplaySurface = "web" | "macos" | "ios";
 
@@ -13,6 +15,12 @@ export interface SessionReplayInitOptions {
   environment: string;
   release?: string;
   surface: SessionReplaySurface;
+  /**
+   * Origin fronting the first-party replay proxy (resolved per environment +
+   * surface in `session-replay-init.ts`). The recorder script and ingest
+   * endpoint are served from here via the platform's reverse-proxy rewrites.
+   */
+  base: string;
 }
 
 /** Metadata about the authenticated platform user attached to a recording. */
@@ -38,14 +46,29 @@ export interface SessionReplayProvider {
 }
 
 /**
- * No-op provider: owns lifecycle state so the control layer stays stateless
- * (mirroring the Sentry flavor's `getClientEnabled()`), and logs in dev so the
- * consent gate is observable without an SDK. Swap this one binding to go live.
+ * Active provider. All traffic is first-party: the recorder script
+ * (`window._lrAsyncScript`) and the ingest endpoint (`serverURL`) are served
+ * from our own origin via the platform's reverse-proxy rewrites
+ * (`/_sr/cdn/*` and `/_sr/ingest/*`), so ad-blockers and tracking-protection
+ * don't silently break recordings.
+ *
+ * Owns lifecycle state so the control layer stays stateless (mirroring the
+ * Sentry flavor's `getClientEnabled()`). The SDK cannot be fully un-init'd
+ * mid-page, so `stop` is best-effort — a hard reset only takes effect on the
+ * next reload (per the `stop` contract above).
  */
-const noopProvider: SessionReplayProvider = (() => {
+const replayProvider: SessionReplayProvider = (() => {
   let active = false;
   return {
     init(appId, options) {
+      // Must be set before init so the SDK loads the recorder from our proxy.
+      window._lrAsyncScript = `${options.base}/_sr/cdn/logger.min.js`;
+      replaySdk.init(appId, {
+        serverURL: `${options.base}/_sr/ingest/i`,
+        release: options.release,
+        // Share the recording session across *.vellum.ai subdomains.
+        rootHostname: ".vellum.ai",
+      });
       active = true;
       if (import.meta.env.DEV) {
         console.debug("[session-replay] init", {
@@ -55,6 +78,12 @@ const noopProvider: SessionReplayProvider = (() => {
       }
     },
     identify(uid, traits) {
+      // Traits disallow undefined values, so attach only what's present.
+      const userTraits: Record<string, string> = { surface: traits.surface };
+      if (traits.name) userTraits.name = traits.name;
+      if (traits.email) userTraits.email = traits.email;
+      if (traits.username) userTraits.username = traits.username;
+      replaySdk.identify(uid, userTraits);
       if (import.meta.env.DEV) {
         console.debug("[session-replay] identify", {
           uid,
@@ -70,4 +99,4 @@ const noopProvider: SessionReplayProvider = (() => {
   };
 })();
 
-export const provider: SessionReplayProvider = noopProvider;
+export const provider: SessionReplayProvider = replayProvider;

--- a/clients/web/src/lib/session-replay/session-replay-provider.ts
+++ b/clients/web/src/lib/session-replay/session-replay-provider.ts
@@ -4,16 +4,19 @@
  * active SDK can be swapped by changing the `provider` binding — no caller
  * changes.
  */
-// Session-replay vendor SDK. Referenced only through the neutral `replaySdk`
-// alias below so the vendor name stays out of shipped code and proxied URLs
-// (it's pattern-matched by ad-blockers — the whole reason we proxy first-party).
-import replaySdk from "logrocket";
-
 import type { SessionReplayNetworkConfig } from "@/lib/session-replay/network-sanitize";
+
+// Type-only handle to the vendor SDK. The runtime module is loaded lazily (see
+// `init`) — never statically imported, because the SDK eagerly appends its
+// recorder <script> at module-evaluation time, which would fetch the recorder
+// from the vendor's default CDN at app startup (before consent and bypassing
+// our first-party proxy). The `logrocket` name is otherwise kept out of shipped
+// code so ad-blockers can't pattern-match it.
+type ReplaySdk = typeof import("logrocket");
 
 /** The SDK's `network` option type, derived from the SDK's own init signature. */
 type SdkNetworkOption = NonNullable<
-  Parameters<typeof replaySdk.init>[1]
+  Parameters<ReplaySdk["init"]>[1]
 >["network"];
 
 export type SessionReplaySurface = "web" | "macos" | "ios";
@@ -75,28 +78,47 @@ export interface SessionReplayProvider {
  */
 const replayProvider: SessionReplayProvider = (() => {
   let active = false;
-  // `replaySdk.init` is one-shot — re-running it can't cleanly re-init the
-  // recorder, so a revoke→re-grant within a page must not call it again.
+  // The SDK is loaded once; re-running its `init` can't cleanly re-init the
+  // recorder, so a revoke→re-grant within a page must not load/init it again.
   let started = false;
+  // Resolved SDK once the lazy import completes; until then `identify` calls
+  // queue in `pendingIdentify` (latest wins) and flush on load.
+  let sdk: ReplaySdk | null = null;
+  let pendingIdentify: { uid: string; traits: Record<string, string> } | null =
+    null;
+
   return {
     init(appId, options) {
       if (!started) {
-        // Must be set before init so the SDK loads the recorder from our proxy.
-        window._lrAsyncScript = `${options.base}/_sr/cdn/logger.min.js`;
-        replaySdk.init(appId, {
-          serverURL: `${options.base}/_sr/ingest/i`,
-          release: options.release,
-          // Share the recording session across Vellum subdomains.
-          rootHostname: import.meta.env.VITE_ROOT_HOSTNAME ?? ".vellum.ai",
-          // Live consent gate: evaluated before every upload, so a mid-session
-          // opt-out halts ingestion immediately rather than at next reload.
-          shouldSendData: options.shouldSendData,
-          // SessionReplayNetworkConfig mirrors the SDK's `network` option; the
-          // sanitizers spread-preserve SDK-private fields (e.g. reqId), so this
-          // structural cast across the seam is safe.
-          network: options.network as SdkNetworkOption,
-        });
         started = true;
+        // Set before the SDK module evaluates: its eager loader appends the
+        // recorder <script> reading `window._lrAsyncScript`, so this points it
+        // at our first-party proxy instead of the vendor CDN.
+        window._lrAsyncScript = `${options.base}/_sr/cdn/logger.min.js`;
+        // Lazy import so the eager recorder load happens only here (consent
+        // confirmed), never at app startup. See the `ReplaySdk` type note.
+        void import("logrocket").then((mod) => {
+          // `logrocket` is CJS (`export = `); the interop default holds the SDK.
+          const replaySdk = (mod as { default: ReplaySdk }).default;
+          replaySdk.init(appId, {
+            serverURL: `${options.base}/_sr/ingest/i`,
+            release: options.release,
+            // Share the recording session across Vellum subdomains.
+            rootHostname: import.meta.env.VITE_ROOT_HOSTNAME ?? ".vellum.ai",
+            // Live consent gate: evaluated before every upload, so a mid-session
+            // opt-out halts ingestion immediately rather than at next reload.
+            shouldSendData: options.shouldSendData,
+            // SessionReplayNetworkConfig mirrors the SDK's `network` option; the
+            // sanitizers spread-preserve SDK-private fields (e.g. reqId), so this
+            // structural cast across the seam is safe.
+            network: options.network as SdkNetworkOption,
+          });
+          sdk = replaySdk;
+          if (pendingIdentify) {
+            replaySdk.identify(pendingIdentify.uid, pendingIdentify.traits);
+            pendingIdentify = null;
+          }
+        });
       }
       active = true;
       if (import.meta.env.DEV) {
@@ -112,7 +134,9 @@ const replayProvider: SessionReplayProvider = (() => {
       if (traits.name) userTraits.name = traits.name;
       if (traits.email) userTraits.email = traits.email;
       if (traits.username) userTraits.username = traits.username;
-      replaySdk.identify(uid, userTraits);
+      // Queue until the lazy SDK import resolves, then dispatch directly.
+      if (sdk) sdk.identify(uid, userTraits);
+      else pendingIdentify = { uid, traits: userTraits };
       if (import.meta.env.DEV) {
         console.debug("[session-replay] identify", {
           uid,

--- a/clients/web/src/lib/session-replay/session-replay-provider.ts
+++ b/clients/web/src/lib/session-replay/session-replay-provider.ts
@@ -66,8 +66,8 @@ const replayProvider: SessionReplayProvider = (() => {
       replaySdk.init(appId, {
         serverURL: `${options.base}/_sr/ingest/i`,
         release: options.release,
-        // Share the recording session across *.vellum.ai subdomains.
-        rootHostname: ".vellum.ai",
+        // Share the recording session across Vellum subdomains.
+        rootHostname: import.meta.env.VITE_ROOT_HOSTNAME ?? ".vellum.ai",
       });
       active = true;
       if (import.meta.env.DEV) {

--- a/clients/web/src/lib/session-replay/session-replay-provider.ts
+++ b/clients/web/src/lib/session-replay/session-replay-provider.ts
@@ -21,6 +21,12 @@ export interface SessionReplayInitOptions {
    * endpoint are served from here via the platform's reverse-proxy rewrites.
    */
   base: string;
+  /**
+   * Live consent gate the SDK calls before every upload. The recorder can't be
+   * un-init'd mid-page, so this — not `stop()` — is what halts ingestion the
+   * instant consent is revoked. Returns the current composed consent.
+   */
+  shouldSendData: () => boolean;
 }
 
 /** Metadata about the authenticated platform user attached to a recording. */
@@ -54,21 +60,31 @@ export interface SessionReplayProvider {
  *
  * Owns lifecycle state so the control layer stays stateless (mirroring the
  * Sentry flavor's `getClientEnabled()`). The SDK cannot be fully un-init'd
- * mid-page, so `stop` is best-effort — a hard reset only takes effect on the
- * next reload (per the `stop` contract above).
+ * mid-page, so ingestion is gated live on consent via `shouldSendData` — `stop`
+ * stays best-effort (it flips `active`, halting re-identify) and a hard reset
+ * of the in-memory recorder only takes effect on the next reload.
  */
 const replayProvider: SessionReplayProvider = (() => {
   let active = false;
+  // `replaySdk.init` is one-shot — re-running it can't cleanly re-init the
+  // recorder, so a revoke→re-grant within a page must not call it again.
+  let started = false;
   return {
     init(appId, options) {
-      // Must be set before init so the SDK loads the recorder from our proxy.
-      window._lrAsyncScript = `${options.base}/_sr/cdn/logger.min.js`;
-      replaySdk.init(appId, {
-        serverURL: `${options.base}/_sr/ingest/i`,
-        release: options.release,
-        // Share the recording session across Vellum subdomains.
-        rootHostname: import.meta.env.VITE_ROOT_HOSTNAME ?? ".vellum.ai",
-      });
+      if (!started) {
+        // Must be set before init so the SDK loads the recorder from our proxy.
+        window._lrAsyncScript = `${options.base}/_sr/cdn/logger.min.js`;
+        replaySdk.init(appId, {
+          serverURL: `${options.base}/_sr/ingest/i`,
+          release: options.release,
+          // Share the recording session across Vellum subdomains.
+          rootHostname: import.meta.env.VITE_ROOT_HOSTNAME ?? ".vellum.ai",
+          // Live consent gate: evaluated before every upload, so a mid-session
+          // opt-out halts ingestion immediately rather than at next reload.
+          shouldSendData: options.shouldSendData,
+        });
+        started = true;
+      }
       active = true;
       if (import.meta.env.DEV) {
         console.debug("[session-replay] init", {


### PR DESCRIPTION
## Summary
- Replace the no-op session-replay provider with the real vendor SDK, configured to send all traffic first-party: the recorder script (`window._lrAsyncScript`) and ingest `serverURL` resolve to platform reverse-proxy paths (`/_sr/cdn/...`, `/_sr/ingest/...`) instead of the vendor's hosts. The proxy origin is resolved per environment + surface via the existing `getPlatformRuntimeUrl()` (same-origin for web, injected `platformUrl` for Electron/iOS), so no per-env host switch is needed.
- Use deliberately vendor-neutral proxy paths and identifiers so ad-blockers / tracking-protection can't pattern-match the vendor name and silently break recordings.
- Electron CSP: add `https://*.vellum.ai` to `script-src` so the first-party recorder script can load (ingest is already covered by `connect-src`, the recorder worker by `worker-src ... blob:`). Web and iOS have no app-level CSP.
- Adds the `logrocket` dependency; provider + CSP tests added.

> Companion Next.js reverse-proxy rewrites (`/_sr/cdn`, `/_sr/ingest`) ship in a separate `vellum-assistant-platform` PR — replay stays dark until both land and `VITE_SESSION_REPLAY_APP_ID` is set per environment (handled separately).

## Original prompt
Following up on the merged session-replay plumbing (#35413), wire the provider seam to the real SDK and proxy all replay traffic through our own domain (per the vendor's first-party-proxy guide) so ad-blockers don't break recordings. Because the SPA is served same-origin from each environment's platform (www / staging-assistant / dev-assistant / localhost), the client points at origin-relative proxy paths and the environment is implicit. Additional ask mid-implementation: avoid the vendor's name anywhere we reasonably can (it's exactly what blockers match on). CI/CD env wiring is handled separately.