### PR TITLE
fix(memory): skip retrospectives for scheduled and consolidation sources

### DIFF
--- a/assistant/src/memory/__tests__/memory-retrospective-enqueue.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-enqueue.test.ts
@@ -12,6 +12,8 @@ mock.module("../../util/logger.js", () => ({
 // ---------------------------------------------------------------------------
 
 let sourceTag: string | null = null;
+let convType = "standard";
+let convSource = "user";
 const upsertCalls: Array<{
   payload: { conversationId: string };
   runAfter: number;
@@ -19,6 +21,10 @@ const upsertCalls: Array<{
 
 mock.module("../conversation-crud.js", () => ({
   getConversationSource: (_id: string) => sourceTag,
+  getConversation: (_id: string) => ({
+    conversationType: convType,
+    source: convSource,
+  }),
   reserveMessage: mock(async () => ({ id: "msg-reserve" })),
 }));
 
@@ -40,6 +46,8 @@ import {
 describe("enqueueMemoryRetrospectiveIfEnabled", () => {
   beforeEach(() => {
     sourceTag = null;
+    convType = "standard";
+    convSource = "user";
     upsertCalls.length = 0;
   });
 
@@ -77,6 +85,35 @@ describe("enqueueMemoryRetrospectiveIfEnabled", () => {
       trigger: "interval",
     });
     expect(upsertCalls).toHaveLength(0);
+  });
+
+  test("scheduled conversation — skips enqueue", () => {
+    convType = "scheduled";
+    enqueueMemoryRetrospectiveIfEnabled({
+      conversationId: "c1",
+      trigger: "interval",
+    });
+    expect(upsertCalls).toHaveLength(0);
+  });
+
+  test("memory_v2_consolidation source — skips enqueue", () => {
+    convType = "background";
+    convSource = "memory_v2_consolidation";
+    enqueueMemoryRetrospectiveIfEnabled({
+      conversationId: "c1",
+      trigger: "interval",
+    });
+    expect(upsertCalls).toHaveLength(0);
+  });
+
+  test("heartbeat (background) source — still enqueues", () => {
+    convType = "background";
+    convSource = "heartbeat";
+    enqueueMemoryRetrospectiveIfEnabled({
+      conversationId: "c1",
+      trigger: "interval",
+    });
+    expect(upsertCalls).toHaveLength(1);
   });
 });
 

--- a/assistant/src/memory/memory-retrospective-enqueue.ts
+++ b/assistant/src/memory/memory-retrospective-enqueue.ts
@@ -6,6 +6,8 @@
 //   - Source conversation isn't a memory-retrospective conversation itself
 //     (recursion guard — we never run a retrospective over reflective
 //     musings from the retrospective agent's own writes).
+//   - Source isn't a `scheduled` thread or a memory-consolidation background
+//     (low yield — see `isLowYieldRetrospectiveSource`).
 //
 // All four trigger types funnel through `upsertMemoryRetrospectiveJob` which
 // coalesces rapid enqueues into a single pending row per conversation.
@@ -16,9 +18,10 @@
 import { type TrustClass } from "../runtime/actor-trust-resolver.js";
 import { resolveCapabilities } from "../runtime/capabilities.js";
 import { getLogger } from "../util/logger.js";
-import { getConversationSource } from "./conversation-crud.js";
+import { getConversation, getConversationSource } from "./conversation-crud.js";
 import { isMemoryEnabled, upsertMemoryRetrospectiveJob } from "./jobs-store.js";
 import { isMemoryRetrospectiveSource } from "./memory-retrospective-constants.js";
+import { MEMORY_V2_CONSOLIDATION_SOURCE } from "./v2/constants.js";
 
 const log = getLogger("memory-retrospective-enqueue");
 
@@ -48,6 +51,14 @@ export function enqueueMemoryRetrospectiveIfEnabled(args: {
     return;
   }
 
+  if (isLowYieldRetrospectiveSource(conversationId)) {
+    log.debug(
+      { conversationId, trigger },
+      "Skipping memory-retrospective enqueue: scheduled or consolidation source",
+    );
+    return;
+  }
+
   const runAfter =
     trigger === "compaction" ? Date.now() + COMPACTION_DEBOUNCE_MS : Date.now();
 
@@ -71,6 +82,22 @@ export function isMemoryRetrospectiveConversation(
 ): boolean {
   const source = getConversationSource(conversationId);
   return source !== null && isMemoryRetrospectiveSource(source);
+}
+
+/**
+ * Scheduled task threads (location/health pulses) rarely carry anything worth
+ * remembering, and memory-consolidation conversations already persist their
+ * output to the corpus — a retrospective over either burns an inference pass
+ * for no unique gain (and, for consolidation, re-stores already-captured
+ * content). Heartbeat (`background`) and standard conversations are unaffected.
+ */
+function isLowYieldRetrospectiveSource(conversationId: string): boolean {
+  const conversation = getConversation(conversationId);
+  if (!conversation) return false;
+  return (
+    conversation.conversationType === "scheduled" ||
+    conversation.source === MEMORY_V2_CONSOLIDATION_SOURCE
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- Skip enqueuing memory retrospectives for `scheduled` conversations and `memory_v2_consolidation` backgrounds. Heartbeat (`background`) and standard/user conversations are unaffected.
- Guard added at the single enqueue funnel (`enqueueMemoryRetrospectiveIfEnabled`), next to the existing recursion guard.
- Motivation: on a production instance these two source types accounted for ~66% of retrospective inference spend (Jun 18) for near-zero unique value — `scheduled` threads (location/health pulses) saved nothing 77% of the time, and consolidation retrospectives only re-stored content the consolidation pass had already persisted to the corpus.

## Original prompt
Memory retrospectives spiked to ~$73/day on a production assistant after fork-based retrospectives went live. Investigation showed the spend was dominated by expensive Opus passes over `scheduled` and `memory_v2_consolidation` conversations that yield little or nothing worth remembering. This change scopes retrospective triggering to exclude those two low-yield source types while preserving heartbeat and real user conversations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)