### PR TITLE
fix(prompts): load guardian persona on background/scheduled turns

### DIFF
--- a/assistant/src/__tests__/persona-resolver.test.ts
+++ b/assistant/src/__tests__/persona-resolver.test.ts
@@ -56,12 +56,14 @@ mock.module("../contacts/contact-store.js", () => ({
 
 // Import AFTER mocks so the module under test binds to the stubbed
 // implementations.
+import type { TrustContext } from "../daemon/trust-context.js";
 import {
   ensureGuardianPersonaFile,
   isGuardianPersonaCustomized,
   resolveGuardianPersona,
   resolveGuardianPersonaPath,
   resolveGuardianPersonaStrict,
+  resolveUserSlug,
 } from "../prompts/persona-resolver.js";
 
 // ── Temp workspace scaffold ───────────────────────────────────────
@@ -244,5 +246,41 @@ describe("isGuardianPersonaCustomized", () => {
     );
 
     expect(isGuardianPersonaCustomized(filePath)).toBe(true);
+  });
+});
+
+// ── resolveUserSlug — background/scheduled guardian turns ──────────
+//
+// Background and scheduled turns carry a guardian trust context with no
+// `requesterExternalUserId`. They must resolve the guardian's user file
+// (parity with foreground guardian turns), not fall through to default.
+
+describe("resolveUserSlug (guardian trust, no requester identity)", () => {
+  test("guardian trust context without requesterExternalUserId resolves the guardian user file", () => {
+    mockVellumGuardian = {
+      contact: { userFile: "alice.md" },
+      channel: {},
+    };
+
+    const trustContext = {
+      sourceChannel: "vellum",
+      trustClass: "guardian",
+    } as TrustContext;
+
+    expect(resolveUserSlug(trustContext)).toBe("alice");
+  });
+
+  test("non-guardian trust context without requesterExternalUserId does not borrow the guardian persona", () => {
+    mockVellumGuardian = {
+      contact: { userFile: "alice.md" },
+      channel: {},
+    };
+
+    const trustContext = {
+      sourceChannel: "vellum",
+      trustClass: "trusted_contact",
+    } as TrustContext;
+
+    expect(resolveUserSlug(trustContext)).toBeNull();
   });
 });

--- a/assistant/src/prompts/persona-resolver.ts
+++ b/assistant/src/prompts/persona-resolver.ts
@@ -103,6 +103,16 @@ function resolveUserFilename(
           filename = guardian.contact.userFile ?? "guardian.md";
         }
       }
+    } else if (trustContext.trustClass === "guardian") {
+      // Guardian-trust turn carrying no requester identity — background and
+      // scheduled turns (heartbeat, scheduled pulses) run under the guardian
+      // trust class but have no per-actor address to look up. Resolve the
+      // channel's guardian user file so they load the same persona as a
+      // foreground guardian turn instead of falling back to users/default.md.
+      const guardian = findGuardianForChannel(trustContext.sourceChannel);
+      if (guardian) {
+        filename = guardian.contact.userFile ?? "guardian.md";
+      }
     }
   } catch (err) {
     // Contacts table may be absent — happens during early bootstrap


### PR DESCRIPTION
## Summary
- Background and scheduled turns (heartbeat, scheduled pulses) run under a guardian trust context that carries no `requesterExternalUserId`. `resolveUserFilename` matched no branch for that shape and returned null, so the system prompt fell back to `users/default.md` (the generic "Default User" persona).
- Add a guardian fallback for guardian-trust contexts that lack a requester identity, so these turns resolve the guardian's `users/<slug>.md` — the same persona a foreground guardian turn loads.
- Blast radius is contained to `trustClass === "guardian"`: non-guardian contexts without a requester identity still fall through to default (covered by a regression test).

## Original prompt
While diagnosing memory-retrospective cache misses, background/scheduled turns were found to load the generic Default User persona instead of the guardian's user file, which (besides being wrong on its own) broke prompt-cache prefix parity between a conversation's live turns and its retrospective fork. This change makes background/scheduled guardian turns load the guardian persona like foreground turns do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)