### PR TITLE
fix(memory): add getConversation to jobs-store enqueue-gate test mock

### DIFF
--- a/assistant/src/memory/__tests__/jobs-store-enqueue-gate.test.ts
+++ b/assistant/src/memory/__tests__/jobs-store-enqueue-gate.test.ts
@@ -50,7 +50,10 @@ mock.module("../../config/assistant-feature-flags.js", () => ({
 
 // Stub the conversation-source lookup so the recursion guards in the
 // retrospective and auto-analysis paths fall through to the enqueue.
+// `getConversation` returning null keeps `isLowYieldRetrospectiveSource`
+// false, so the retrospective is enqueued rather than skipped.
 mock.module("../conversation-crud.js", () => ({
+  getConversation: () => null,
   getConversationSource: () => null,
   reserveMessage: mock(async () => ({ id: "msg-reserve" })),
 }));
@@ -112,12 +115,10 @@ mock.module("../db-connection.js", () => ({
 
 // Now load the real modules under test.
 const { isMemoryEnabled } = await import("../jobs-store.js");
-const { enqueueAutoAnalysisIfEnabled } = await import(
-  "../auto-analysis-enqueue.js"
-);
-const { enqueueMemoryRetrospectiveIfEnabled } = await import(
-  "../memory-retrospective-enqueue.js"
-);
+const { enqueueAutoAnalysisIfEnabled } =
+  await import("../auto-analysis-enqueue.js");
+const { enqueueMemoryRetrospectiveIfEnabled } =
+  await import("../memory-retrospective-enqueue.js");
 
 beforeEach(() => {
   dbInserts.length = 0;


### PR DESCRIPTION
## Summary

- The Test job on main went red with `SyntaxError: Export named 'getConversation' not found in module '.../conversation-crud.ts'` in `jobs-store-enqueue-gate.test.ts`.
- Root cause: #35424 added a `getConversation` import to `memory-retrospective-enqueue.ts` (one of the modules the test dynamically imports), but the test's `mock.module('../conversation-crud.js', ...)` only exported `getConversationSource` and `reserveMessage`. Linking the dynamic import against the incomplete mock failed.
- Fix: add `getConversation: () => null` to the mock. Returning null keeps `isLowYieldRetrospectiveSource` false, so the retrospective still falls through to the enqueue — preserving the existing test assertions. All 12 tests pass. (Prettier also rewrapped two pre-existing dynamic-import lines to satisfy the format hook.)

## Original prompt

Fix the specific CI failure in the Test job of run [27807020177](https://github.com/vellum-ai/vellum-assistant/actions/runs/27807020177/job/82288896350) on main, scoped to that one job only. The failure was a deterministic module-link error reproducible in isolation, traced to a companion test mock that wasn't updated alongside #35424's new `getConversation` import.