### PR TITLE
fix(memory): reproduce source background-turn block in retrospective forks

### DIFF
--- a/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
@@ -686,6 +686,40 @@ describe("memoryRetrospectiveJob", () => {
   });
 
   // -------------------------------------------------------------------------
+  // Source background-turn parity (isNonInteractive)
+  // -------------------------------------------------------------------------
+
+  test("background source → wake runs non-interactive (reproduces <background_turn>)", async () => {
+    conversationOverrides["src-conv-1"] = {
+      source: "heartbeat",
+      forkParentMessageId: null,
+      title: "Heartbeat",
+      conversationType: "background",
+    };
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("invoked");
+    expect(wakeCalls).toHaveLength(1);
+    expect(wakeCalls[0]!.opts.isNonInteractive).toBe(true);
+  });
+
+  test("standard source → wake stays interactive (no spurious <background_turn>)", async () => {
+    conversationOverrides["src-conv-1"] = {
+      source: "user",
+      forkParentMessageId: null,
+      title: "Source conversation",
+      conversationType: "standard",
+    };
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("invoked");
+    expect(wakeCalls).toHaveLength(1);
+    expect(wakeCalls[0]!.opts.isNonInteractive).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
   // Source-derived persona override
   // -------------------------------------------------------------------------
 

--- a/assistant/src/memory/memory-retrospective-job.ts
+++ b/assistant/src/memory/memory-retrospective-job.ts
@@ -65,6 +65,7 @@ import {
   getMessagesAfter,
   resolveOverrideProfile,
 } from "./conversation-crud.js";
+import { isBackgroundConversationType } from "./conversation-types.js";
 import {
   enqueueMemoryJob,
   type MemoryJob,
@@ -313,6 +314,14 @@ async function runForkBasedRetrospective(
       // {@link WakeToolContextPin}.
       toolGateMode: "execution" as const,
       toolContextPin,
+      // Reproduce the source's turn block for message-tier cache-prefix
+      // parity: background/scheduled sources ran non-interactive live turns
+      // (which carry `<background_turn>`), so the fork must run non-interactive
+      // too. Standard/user sources ran interactive (no `<background_turn>`), so
+      // the fork stays interactive — preserving their existing byte parity.
+      isNonInteractive: isBackgroundConversationType(
+        sourceConversation.conversationType,
+      ),
       // Profile forcing (model/thinking/effort parity) is a separate concern
       // and stays keyed on `matchConversationProfile` via `matchedProfile`.
       ...(matchedProfile !== undefined

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -197,6 +197,14 @@ export interface WakeOptions {
    */
   suppressWakeSurface?: boolean;
   /**
+   * Run the wake's turn as non-interactive (no client present). Threads to the
+   * agent loop's `isNonInteractive`, which gates the `<non_interactive_context>`
+   * and `<background_turn>` injectors. Fork-based memory retrospectives set this
+   * to the source conversation's background-turn state so the fork reproduces
+   * the source's injected turn block (prompt-cache prefix parity). Default false.
+   */
+  isNonInteractive?: boolean;
+  /**
    * Optional exact tool allowlist for this wake. Used by internal maintenance
    * jobs that need the assistant's judgment but must not execute arbitrary
    * side-effect tools. Enforcement depends on `toolGateMode`: in `"wire"`
@@ -588,6 +596,7 @@ export async function wakeAgentForOpportunity(
       opts.forceOverrideProfile ??
       getConversationOverrideProfile(conversationId);
     const callSite = opts.callSite ?? "mainAgent";
+    const isNonInteractive = opts.isNonInteractive ?? false;
     const config = getConfig();
     const effectiveContextWindow = resolveEffectiveContextWindow({
       llm: config.llm,
@@ -1122,6 +1131,7 @@ export async function wakeAgentForOpportunity(
           trust: wakeTrust,
           overrideProfile,
           forceOverrideProfile,
+          isNonInteractive,
           // The wake's compaction lives in the pre-run gate above
           // (`conversation.maybeCompact()`), never in the loop: the in-loop
           // budget gate and overflow-recovery ladder stay disabled because


### PR DESCRIPTION
## Summary
- Fork-based memory retrospectives over background/scheduled sources ran the fork wake as *interactive*, so the `background-turn` injector stayed silent. The source's live background turn carries a `<background_turn>` block; the fork instead emitted `<turn_context>`, diverging at the first user message and busting message-tier prompt-cache reuse against the source's (warm, 1h-TTL) prefix.
- Thread an `isNonInteractive` option through `wakeAgentForOpportunity` to the agent loop, and set it from the source conversation type: `background`/`scheduled` sources run the fork non-interactive (reproducing `<background_turn>`), while standard/user sources stay interactive — preserving their existing byte-identical parity (and avoiding a spurious `<background_turn>`, since the fork is always created as a `background` conversation).
- Net effect: heartbeat (and other background) retrospectives can read the source's warm cache instead of cold-ingesting the full forked history on Opus.

## Original prompt
While diagnosing expensive memory retrospectives, a byte-diff of a fork's request against its source's live turn showed the fork was missing the `<background_turn>` block the source had (confirmed: source ×1, fork ×0), so the cached prefix never matched. This change makes the retrospective fork reproduce the source turn's injected block by running non-interactive for background sources, restoring prompt-cache prefix parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)