### PR TITLE
fix(profiles): harden OS Beta flag-gated reconcile

### DIFF
--- a/assistant/src/__tests__/gateway-flag-listener.test.ts
+++ b/assistant/src/__tests__/gateway-flag-listener.test.ts
@@ -25,12 +25,14 @@ mock.module("../ipc/socket-path.js", () => ({
 // Track calls to refreshOverridesFromGateway
 // ---------------------------------------------------------------------------
 let refreshCallCount = 0;
+let refreshReturnsLoaded = true;
 
 mock.module("../config/assistant-feature-flags.js", () => ({
   refreshOverridesFromGateway: async () => {
     refreshCallCount++;
+    return refreshReturnsLoaded;
   },
-  initFeatureFlagOverrides: async () => {},
+  initFeatureFlagOverrides: async () => true,
   clearFeatureFlagOverridesCache: () => {},
   isAssistantFeatureFlagEnabled: () => true,
 }));
@@ -141,6 +143,7 @@ describe("gateway-flag-listener", () => {
   beforeEach(() => {
     mkdirSync(testRoot, { recursive: true });
     refreshCallCount = 0;
+    refreshReturnsLoaded = true;
     syncToolsCallCount = 0;
     publishedTagSets = [];
     reconcileCallCount = 0;
@@ -245,6 +248,45 @@ describe("gateway-flag-listener", () => {
 
     expect(reconcileCallCount).toBeGreaterThanOrEqual(2);
     expect(configChangedCount).toBe(0);
+  });
+
+  test("does not reconcile profiles when the refresh reports flags did not load", async () => {
+    reconcileReturns = true;
+    refreshReturnsLoaded = false;
+    await new Promise<void>((resolve) => {
+      testServer.server.listen(socketPath, resolve);
+    });
+
+    startGatewayFlagListener();
+    await testServer.waitForClient();
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Tool sync stays unconditional; the profile reconcile/broadcast are gated.
+    expect(syncToolsCallCount).toBe(1);
+    expect(reconcileCallCount).toBe(0);
+    expect(configChangedCount).toBe(0);
+
+    testServer.emit("feature_flags_changed");
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(syncToolsCallCount).toBe(2);
+    expect(reconcileCallCount).toBe(0);
+    expect(configChangedCount).toBe(0);
+  });
+
+  test("reconciles profiles when the refresh reports flags loaded", async () => {
+    reconcileReturns = true;
+    refreshReturnsLoaded = true;
+    await new Promise<void>((resolve) => {
+      testServer.server.listen(socketPath, resolve);
+    });
+
+    startGatewayFlagListener();
+    await testServer.waitForClient();
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(reconcileCallCount).toBe(1);
+    expect(configChangedCount).toBe(1);
   });
 
   test("ignores non-flag events", async () => {

--- a/assistant/src/config/__tests__/sync-gated-profiles.test.ts
+++ b/assistant/src/config/__tests__/sync-gated-profiles.test.ts
@@ -179,6 +179,39 @@ describe("reconcileFlagGatedProfiles", () => {
     expect(reconcileFlagGatedProfiles()).toBe(false);
   });
 
+  test("flag off scrubs os-beta from user mix arms and preserves the rest", () => {
+    process.env.IS_PLATFORM = "true";
+    seedBalancedConfig();
+    setOverridesForTesting({ "os-beta": true });
+    reconcileFlagGatedProfiles();
+
+    const raw = readConfig();
+    raw.llm.profiles["my-mix"] = {
+      source: "user",
+      label: "My Mix",
+      mix: [
+        { profile: "balanced", weight: 70 },
+        { profile: "os-beta", weight: 30 },
+      ],
+    };
+    raw.llm.profileOrder.push("my-mix");
+    writeConfig(raw);
+    invalidateConfigCache();
+
+    setOverridesForTesting({ "os-beta": false });
+    expect(reconcileFlagGatedProfiles()).toBe(true);
+
+    const after = readConfig();
+    expect(after.llm.profiles["os-beta"]).toBeUndefined();
+    const mix = after.llm.profiles["my-mix"]!;
+    expect(mix.mix).toEqual([{ profile: "balanced", weight: 70 }]);
+    expect(mix.source).toBe("user");
+    expect(mix.label).toBe("My Mix");
+
+    invalidateConfigCache();
+    expect(reconcileFlagGatedProfiles()).toBe(false);
+  });
+
   test("a user-owned os-beta profile is never touched", () => {
     process.env.IS_PLATFORM = "true";
     writeConfig({

--- a/assistant/src/config/assistant-feature-flags.ts
+++ b/assistant/src/config/assistant-feature-flags.ts
@@ -103,7 +103,11 @@ function parseRegistryToDefaults(parsed: unknown): FeatureFlagDefaultsRegistry {
     const entry = flag as Record<string, unknown>;
     if (entry.scope !== "assistant" && entry.scope !== "both") continue;
     if (typeof entry.key !== "string") continue;
-    if (typeof entry.defaultEnabled !== "boolean" && typeof entry.defaultEnabled !== "string") continue;
+    if (
+      typeof entry.defaultEnabled !== "boolean" &&
+      typeof entry.defaultEnabled !== "string"
+    )
+      continue;
 
     result[entry.key as string] = {
       defaultEnabled: entry.defaultEnabled,
@@ -178,6 +182,12 @@ const DEFAULT_INIT_RETRY_BACKOFFS_MS: readonly number[] = [
  * tests preseed flag state via `setOverridesForTesting()` (in
  * `__tests__/feature-flag-test-helpers.ts`) without the gateway IPC call
  * clobbering their setup.
+ *
+ * Resolves `true` when the override cache is populated from the gateway and
+ * `false` when the cache is left unset (exhausted retries / unreachable
+ * gateway). Callers that mutate persisted state from flag values gate that
+ * work on a `true` result so a failed fetch never resolves a flag to its
+ * registry default and drops user state.
  */
 export async function initFeatureFlagOverrides(options?: {
   retryBackoffsMs?: readonly number[];
@@ -188,8 +198,8 @@ export async function initFeatureFlagOverrides(options?: {
    * instead of blocking startup.
    */
   callTimeoutMs?: number;
-}): Promise<void> {
-  if (isCachedFromGateway()) return;
+}): Promise<boolean> {
+  if (isCachedFromGateway()) return true;
 
   const backoffs = options?.retryBackoffsMs ?? DEFAULT_INIT_RETRY_BACKOFFS_MS;
   const callTimeoutMs = options?.callTimeoutMs;
@@ -205,7 +215,7 @@ export async function initFeatureFlagOverrides(options?: {
       // Re-check after the wait: a concurrent caller (e.g. a test using
       // `setOverridesForTesting`) may have populated the cache while we
       // were sleeping. Bail out so we don't clobber their setup.
-      if (isCachedFromGateway()) return;
+      if (isCachedFromGateway()) return true;
     }
 
     const gatewayOverrides = await fetchOverridesFromGateway(callTimeoutMs);
@@ -217,7 +227,7 @@ export async function initFeatureFlagOverrides(options?: {
           "Feature flag overrides loaded from gateway after retry",
         );
       }
-      return;
+      return true;
     }
   }
 
@@ -230,6 +240,7 @@ export async function initFeatureFlagOverrides(options?: {
       "Feature flag overrides empty after all retries; falling back to registry defaults and fail-closed undeclared flags",
     );
   }
+  return false;
 }
 
 /**
@@ -262,10 +273,14 @@ export function clearFeatureFlagOverridesCache(): void {
  * retries (the gateway is known to be up because it just pushed an event).
  * Called by the gateway flag listener when a `feature_flags_changed` event
  * arrives.
+ *
+ * Resolves `true` when the cache was repopulated from the gateway, `false`
+ * when the fetch came back empty/failed — callers gate persisted-state
+ * reconciliation on a `true` result.
  */
-export async function refreshOverridesFromGateway(): Promise<void> {
+export async function refreshOverridesFromGateway(): Promise<boolean> {
   clearFeatureFlagOverridesCache();
-  await initFeatureFlagOverrides({ retryBackoffsMs: [] });
+  return initFeatureFlagOverrides({ retryBackoffsMs: [] });
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -469,7 +469,7 @@ export function materializeProfile(
   };
 }
 
-function readObject(value: unknown): Record<string, unknown> | null {
+export function readObject(value: unknown): Record<string, unknown> | null {
   return value !== null && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : null;

--- a/assistant/src/config/sync-gated-profiles.ts
+++ b/assistant/src/config/sync-gated-profiles.ts
@@ -1,3 +1,5 @@
+import { isDeepStrictEqual } from "node:util";
+
 import { getLogger } from "../util/logger.js";
 import { isAssistantFeatureFlagEnabled } from "./assistant-feature-flags.js";
 import {
@@ -12,6 +14,7 @@ import {
   OS_BETA_FEATURE_FLAG_KEY,
   OS_BETA_PROFILE_KEY,
   OS_BETA_PROFILE_TEMPLATE,
+  readObject,
 } from "./seed-inference-profiles.js";
 
 const log = getLogger("sync-gated-profiles");
@@ -113,7 +116,7 @@ function enableProfile(
   }
 
   let changed = false;
-  if (!previous || !deepEqual(previous, next)) {
+  if (!previous || !isDeepStrictEqual(previous, next)) {
     profiles[OS_BETA_PROFILE_KEY] = next as ProfileEntry;
     changed = true;
   }
@@ -155,15 +158,19 @@ function disableProfile(
     }
   }
 
+  // Removing a flag-gated profile also drops it from any user mix arms so the
+  // config stays loadable — `LLMSchema.superRefine` rejects a mix arm naming a
+  // missing profile.
+  for (const profile of Object.values(profiles)) {
+    if (!Array.isArray(profile.mix)) continue;
+    const arms = profile.mix as Array<Record<string, unknown>>;
+    const kept = arms.filter(
+      (arm) => readObject(arm)?.profile !== OS_BETA_PROFILE_KEY,
+    );
+    if (kept.length !== arms.length) {
+      profile.mix = kept;
+    }
+  }
+
   return true;
-}
-
-function readObject(value: unknown): Record<string, unknown> | null {
-  return value !== null && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
-
-function deepEqual(a: unknown, b: unknown): boolean {
-  return JSON.stringify(a) === JSON.stringify(b);
 }

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -381,10 +381,14 @@ export async function runDaemon(): Promise<void> {
     // reconcile is the call that mutates config (it raced ahead of the gateway
     // flag listener), publish the config invalidation so any client that already
     // fetched `GET /v1/config` refreshes its profile picker.
+    // Profiles are reconciled only when flags actually loaded from the gateway:
+    // a failed fetch leaves the cache unset and resolves `os-beta` to its
+    // registry default `false`, which would remove the user's profile and reset
+    // their selection. Tool sync tolerates the default and stays unconditional.
     void initFeatureFlagOverrides()
-      .then(() => syncFlagGatedTools())
-      .then(() => {
-        if (reconcileFlagGatedProfiles()) {
+      .then(async (loaded) => {
+        await syncFlagGatedTools();
+        if (loaded && reconcileFlagGatedProfiles()) {
           publishConfigChanged();
         }
       })

--- a/assistant/src/ipc/gateway-flag-listener.ts
+++ b/assistant/src/ipc/gateway-flag-listener.ts
@@ -24,13 +24,17 @@ const log = getLogger("gateway-flag-listener");
  * never throws (it logs internally). After tools sync, `reconcileFlagGatedProfiles`
  * adds or removes the flag-gated managed profile (OS Beta); when it reports a
  * change a `config_changed` broadcast refreshes the profile picker on clients.
+ * The profile reconcile runs only when the refresh confirmed flags loaded from
+ * the gateway — a transient IPC failure leaves the cache unset and resolves
+ * `os-beta` to its registry default `false`, which would remove the user's
+ * profile and reset their selection. Tool sync tolerates the default and stays
+ * unconditional.
  */
 function refreshFlagsAndSyncTools(context: string): void {
   refreshOverridesFromGateway()
-    .then(() => syncFlagGatedTools())
-    .then(() => {
-      const changed = reconcileFlagGatedProfiles();
-      if (changed) {
+    .then(async (loaded) => {
+      await syncFlagGatedTools();
+      if (loaded && reconcileFlagGatedProfiles()) {
         // Reuse the config-changed broadcast clients already consume so the
         // profile picker reflects the added/removed managed profile.
         publishConfigChanged();


### PR DESCRIPTION
## Summary
Fixes gaps from plan self-review for os-beta-managed-profile.md:
- Only reconcile the OS Beta profile after a confirmed flag load, so a transient gateway IPC failure no longer removes the profile or resets the user's activeProfile (startup + runtime paths).
- On disable, scrub os-beta from any user mix arms so the config stays loadable (avoids superRefine rejecting a dangling mix reference).
- Dedupe readObject (import from seed-inference-profiles) and replace JSON.stringify deep-equal with node:util isDeepStrictEqual.