### PR TITLE
fix(web): proxy session-replay stats beacon (close last vendor-host leak)

### DIFF
--- a/clients/web/src/env.d.ts
+++ b/clients/web/src/env.d.ts
@@ -72,4 +72,10 @@ interface Window {
    * (see `session-replay-provider.ts`).
    */
   _lrAsyncScript?: string;
+  /**
+   * SDK-defined config object the session-replay recorder reads at boot. We set
+   * `statsURL` on it to route the stats beacon through our first-party proxy —
+   * the data endpoint has an init option but the beacon does not.
+   */
+  __SDKCONFIG__?: { statsURL?: string; serverURL?: string };
 }

--- a/clients/web/src/lib/session-replay/session-replay-provider.test.ts
+++ b/clients/web/src/lib/session-replay/session-replay-provider.test.ts
@@ -71,6 +71,10 @@ describe("replay provider (first-party proxy, lazy load)", () => {
     expect(options.rootHostname).toBe(".vellum.ai");
     expect(options.network).toBe(NETWORK);
 
+    // The stats beacon (no init option) is routed through the proxy via the
+    // SDK config object, so it never POSTs to the vendor host directly.
+    expect(window.__SDKCONFIG__?.statsURL).toBe(`${BASE}/_sr/ingest/s`);
+
     // shouldSendData reflects live consent, re-checked before every upload.
     const shouldSendData = options.shouldSendData as () => boolean;
     expect(shouldSendData()).toBe(true);

--- a/clients/web/src/lib/session-replay/session-replay-provider.ts
+++ b/clients/web/src/lib/session-replay/session-replay-provider.ts
@@ -100,6 +100,15 @@ const replayProvider: SessionReplayProvider = (() => {
         void import("logrocket").then((mod) => {
           // `logrocket` is CJS (`export = `); the interop default holds the SDK.
           const replaySdk = (mod as { default: ReplaySdk }).default;
+          // The SDK splits traffic into a data endpoint (`serverURL`, set via
+          // init below) and a separate stats beacon — which has no init option
+          // and otherwise POSTs to the vendor host directly, bypassing the proxy
+          // (a CSP violation under Electron's `app://` and an ad-blocker target).
+          // Its config object is the only lever, so point the beacon at the proxy
+          // here, after the module's loader has populated the object but before
+          // the async recorder bundle reads it.
+          window.__SDKCONFIG__ = window.__SDKCONFIG__ ?? {};
+          window.__SDKCONFIG__.statsURL = `${options.base}/_sr/ingest/s`;
           replaySdk.init(appId, {
             serverURL: `${options.base}/_sr/ingest/i`,
             release: options.release,


### PR DESCRIPTION
## Summary
- The replay SDK sends session data to `serverURL` (proxied via `init()`) **and** a separate stats beacon to `statsURL` — which has **no `init()` option** and was falling back to the vendor host (`r.logr-in.com/s`), bypassing the first-party proxy.
- That direct beacon is a recurring **CSP violation under Electron** (`connect-src` doesn't list the vendor host), an **ad-blocker target**, and a **vendor-hostname leak** — the exact failure mode the first-party proxy work set out to eliminate.
- Fix: set `window.__SDKCONFIG__.statsURL` to `${base}/_sr/ingest/s` in the lazy-import callback (the SDK's config object is the only lever, since there's no init option). The existing `/_sr/ingest/[...path]` catch-all route already forwards `/s` upstream, so no platform-side change is needed. Session data (`/i`) was already proxied and is unaffected.

## Original prompt
After landing the first-party session-replay proxy (#35422 client / #8543 platform), a holistic pre-release review traced the implementation against the actual `logrocket@12.1.1` loader and the live recorder bundle. Recordings work, but the SDK's stats beacon is a second egress endpoint with no `init()` override, so it was still hitting the vendor host directly. This closes that last gap so all replay traffic — data and stats — stays first-party.