### PR TITLE
OS Beta managed profile (GLM 5.2 / Fireworks), flag-gated

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -1503,11 +1503,8 @@ describe("OS Beta managed profile template", () => {
     expect((raw.llm.profileOrder as string[]).includes("os-beta")).toBe(false);
   });
 
-  test("MANAGED_PROFILE_NAMES does not yet contain os-beta", () => {
-    // Membership lands with the flag-gated reconciler in a later PR, so the
-    // route layer can't lock a user-owned os-beta profile before a managed
-    // one exists.
-    expect(MANAGED_PROFILE_NAMES.has("os-beta")).toBe(false);
+  test("MANAGED_PROFILE_NAMES contains os-beta", () => {
+    expect(MANAGED_PROFILE_NAMES.has("os-beta")).toBe(true);
   });
 
   test("materializeProfile honors the explicit OS Beta model", () => {

--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -75,7 +75,12 @@ import {
   loadConfig,
   mergeDefaultWorkspaceConfig,
 } from "../config/loader.js";
-import { seedInferenceProfiles } from "../config/seed-inference-profiles.js";
+import {
+  MANAGED_PROFILE_NAMES,
+  materializeProfile,
+  OS_BETA_PROFILE_TEMPLATE,
+  seedInferenceProfiles,
+} from "../config/seed-inference-profiles.js";
 import type { DrizzleDb } from "../memory/db-connection.js";
 import { migrateCreateProviderConnections } from "../memory/migrations/243-provider-connections.js";
 import { migrateProviderConnectionStatusLabel } from "../memory/migrations/244-provider-connection-status-label.js";
@@ -1448,5 +1453,77 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
     expect(config.llm.profiles.balanced?.status).toBe("active");
     // Label is still suffixed (Vellum can push label updates).
     expect(config.llm.profiles.balanced?.label).toBe("Balanced (Managed)");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: OS Beta flag-gated managed profile. The template is defined but
+// intentionally NOT part of MANAGED_PROFILE_TEMPLATES, so seedInferenceProfiles
+// must never create it. A later PR reconciles it in/out based on the `os-beta`
+// feature flag.
+// ---------------------------------------------------------------------------
+
+describe("OS Beta managed profile template", () => {
+  beforeEach(() => {
+    ensureTestDir();
+    const resetPaths = [
+      CONFIG_PATH,
+      join(WORKSPACE_DIR, "default-config.json"),
+      join(WORKSPACE_DIR, "hatch-overlay.json"),
+      join(WORKSPACE_DIR, "keys.enc"),
+      join(WORKSPACE_DIR, "data"),
+      join(WORKSPACE_DIR, "data", "memory"),
+    ];
+    for (const path of resetPaths) {
+      if (existsSync(path)) {
+        rmSync(path, { recursive: true, force: true });
+      }
+    }
+    ensureTestDir();
+    setStorePathForTesting(join(WORKSPACE_DIR, "keys.enc"));
+    delete process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
+    delete process.env.IS_PLATFORM;
+    invalidateConfigCache();
+  });
+
+  afterEach(() => {
+    setStorePathForTesting(null);
+    delete process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
+    delete process.env.IS_PLATFORM;
+    invalidateConfigCache();
+  });
+
+  test("seedInferenceProfiles does not create an os-beta profile", () => {
+    writeConfig({ llm: { default: { provider: "anthropic" } } });
+
+    mergeDefaultConfigAndSeedInferenceProfiles();
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+
+    expect(raw.llm.profiles["os-beta"]).toBeUndefined();
+    expect((raw.llm.profileOrder as string[]).includes("os-beta")).toBe(false);
+  });
+
+  test("MANAGED_PROFILE_NAMES does not yet contain os-beta", () => {
+    // Membership lands with the flag-gated reconciler in a later PR, so the
+    // route layer can't lock a user-owned os-beta profile before a managed
+    // one exists.
+    expect(MANAGED_PROFILE_NAMES.has("os-beta")).toBe(false);
+  });
+
+  test("materializeProfile honors the explicit OS Beta model", () => {
+    const entry = materializeProfile(
+      OS_BETA_PROFILE_TEMPLATE,
+      "fireworks",
+      "fireworks-managed",
+    );
+
+    expect(entry.model).toBe("accounts/fireworks/models/glm-5p2");
+    expect(entry.provider_connection).toBe("fireworks-managed");
+    expect(entry.provider).toBe("fireworks");
+    expect(entry.label).toBe("OS Beta");
+    expect(entry.source).toBe("managed");
+    expect(entry.maxTokens).toBe(32000);
+    expect(entry.effort).toBe("high");
+    expect(entry.thinking?.enabled).toBe(true);
   });
 });

--- a/assistant/src/__tests__/gateway-flag-listener.test.ts
+++ b/assistant/src/__tests__/gateway-flag-listener.test.ts
@@ -25,12 +25,14 @@ mock.module("../ipc/socket-path.js", () => ({
 // Track calls to refreshOverridesFromGateway
 // ---------------------------------------------------------------------------
 let refreshCallCount = 0;
+let refreshReturnsLoaded = true;
 
 mock.module("../config/assistant-feature-flags.js", () => ({
   refreshOverridesFromGateway: async () => {
     refreshCallCount++;
+    return refreshReturnsLoaded;
   },
-  initFeatureFlagOverrides: async () => {},
+  initFeatureFlagOverrides: async () => true,
   clearFeatureFlagOverridesCache: () => {},
   isAssistantFeatureFlagEnabled: () => true,
 }));
@@ -141,6 +143,7 @@ describe("gateway-flag-listener", () => {
   beforeEach(() => {
     mkdirSync(testRoot, { recursive: true });
     refreshCallCount = 0;
+    refreshReturnsLoaded = true;
     syncToolsCallCount = 0;
     publishedTagSets = [];
     reconcileCallCount = 0;
@@ -245,6 +248,45 @@ describe("gateway-flag-listener", () => {
 
     expect(reconcileCallCount).toBeGreaterThanOrEqual(2);
     expect(configChangedCount).toBe(0);
+  });
+
+  test("does not reconcile profiles when the refresh reports flags did not load", async () => {
+    reconcileReturns = true;
+    refreshReturnsLoaded = false;
+    await new Promise<void>((resolve) => {
+      testServer.server.listen(socketPath, resolve);
+    });
+
+    startGatewayFlagListener();
+    await testServer.waitForClient();
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Tool sync stays unconditional; the profile reconcile/broadcast are gated.
+    expect(syncToolsCallCount).toBe(1);
+    expect(reconcileCallCount).toBe(0);
+    expect(configChangedCount).toBe(0);
+
+    testServer.emit("feature_flags_changed");
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(syncToolsCallCount).toBe(2);
+    expect(reconcileCallCount).toBe(0);
+    expect(configChangedCount).toBe(0);
+  });
+
+  test("reconciles profiles when the refresh reports flags loaded", async () => {
+    reconcileReturns = true;
+    refreshReturnsLoaded = true;
+    await new Promise<void>((resolve) => {
+      testServer.server.listen(socketPath, resolve);
+    });
+
+    startGatewayFlagListener();
+    await testServer.waitForClient();
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(reconcileCallCount).toBe(1);
+    expect(configChangedCount).toBe(1);
   });
 
   test("ignores non-flag events", async () => {

--- a/assistant/src/__tests__/gateway-flag-listener.test.ts
+++ b/assistant/src/__tests__/gateway-flag-listener.test.ts
@@ -61,6 +61,32 @@ mock.module("../tools/registry.js", () => ({
 }));
 
 // ---------------------------------------------------------------------------
+// Track reconcileFlagGatedProfiles calls and let each test control whether it
+// reports a config change, so we can assert the listener broadcasts only when
+// the managed profile set actually changes.
+// ---------------------------------------------------------------------------
+let reconcileCallCount = 0;
+let reconcileReturns = false;
+
+mock.module("../config/sync-gated-profiles.js", () => ({
+  reconcileFlagGatedProfiles: () => {
+    reconcileCallCount++;
+    return reconcileReturns;
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Track publishConfigChanged so we can assert the picker-refresh broadcast.
+// ---------------------------------------------------------------------------
+let configChangedCount = 0;
+
+mock.module("../runtime/sync/resource-sync-events.js", () => ({
+  publishConfigChanged: () => {
+    configChangedCount++;
+  },
+}));
+
+// ---------------------------------------------------------------------------
 // Dynamic imports (after mock.module)
 // ---------------------------------------------------------------------------
 const { startGatewayFlagListener, stopGatewayFlagListener } =
@@ -117,6 +143,9 @@ describe("gateway-flag-listener", () => {
     refreshCallCount = 0;
     syncToolsCallCount = 0;
     publishedTagSets = [];
+    reconcileCallCount = 0;
+    reconcileReturns = false;
+    configChangedCount = 0;
     testServer = createTestServer();
   });
 
@@ -178,6 +207,44 @@ describe("gateway-flag-listener", () => {
       "feature-flags:client",
       "feature-flags:assistant",
     ]);
+  });
+
+  test("reconciles flag-gated profiles and broadcasts config_changed when the profile set changes", async () => {
+    reconcileReturns = true;
+    await new Promise<void>((resolve) => {
+      testServer.server.listen(socketPath, resolve);
+    });
+
+    startGatewayFlagListener();
+    await testServer.waitForClient();
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Connect path reconciles once and, since it reports a change, broadcasts.
+    expect(reconcileCallCount).toBe(1);
+    expect(configChangedCount).toBe(1);
+
+    testServer.emit("feature_flags_changed");
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(reconcileCallCount).toBe(2);
+    expect(configChangedCount).toBe(2);
+  });
+
+  test("reconciles but does not broadcast config_changed when the profile set is unchanged", async () => {
+    reconcileReturns = false;
+    await new Promise<void>((resolve) => {
+      testServer.server.listen(socketPath, resolve);
+    });
+
+    startGatewayFlagListener();
+    await testServer.waitForClient();
+    await new Promise((r) => setTimeout(r, 100));
+
+    testServer.emit("feature_flags_changed");
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(reconcileCallCount).toBeGreaterThanOrEqual(2);
+    expect(configChangedCount).toBe(0);
   });
 
   test("ignores non-flag events", async () => {

--- a/assistant/src/__tests__/llm-catalog-parity.test.ts
+++ b/assistant/src/__tests__/llm-catalog-parity.test.ts
@@ -2,7 +2,10 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
-import { PROVIDER_CATALOG } from "../providers/model-catalog.js";
+import {
+  isModelInCatalog,
+  PROVIDER_CATALOG,
+} from "../providers/model-catalog.js";
 import { PLATFORM_PROVIDER_META } from "../providers/platform-proxy/constants.js";
 import { resolvePricing, resolvePricingForUsage } from "../util/pricing.js";
 
@@ -299,6 +302,32 @@ describe("LLM catalog parity: daemon vs client", () => {
       maxOutputTokens: 128000,
       longContextPricingThresholdTokens: 272000,
       longContextMode: "native-model",
+    });
+  });
+
+  test("Fireworks catalog includes GLM 5.2", () => {
+    expect(
+      isModelInCatalog("fireworks", "accounts/fireworks/models/glm-5p2"),
+    ).toBe(true);
+
+    const fireworks = PROVIDER_CATALOG.find(
+      (entry) => entry.id === "fireworks",
+    );
+    expect(
+      fireworks?.models.find(
+        (model) => model.id === "accounts/fireworks/models/glm-5p2",
+      ),
+    ).toMatchObject({
+      displayName: "GLM 5.2",
+      contextWindowTokens: 1040000,
+      maxOutputTokens: 131072,
+      supportsToolUse: true,
+      supportsVision: false,
+      pricing: {
+        inputPer1mTokens: 1.4,
+        outputPer1mTokens: 4.4,
+        cacheReadPer1mTokens: 0.26,
+      },
     });
   });
 

--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -22,10 +22,19 @@ function makeDefaultRawConfig(): Record<string, unknown> {
         "quality-optimized": {
           provider: "anthropic",
           model: "claude-sonnet",
+          source: "managed",
         },
-        balanced: { provider: "anthropic", model: "claude-sonnet" },
-        "cost-optimized": { provider: "anthropic", model: "claude-haiku" },
-        "my-custom": { provider: "openai", model: "gpt-4o" },
+        balanced: {
+          provider: "anthropic",
+          model: "claude-sonnet",
+          source: "managed",
+        },
+        "cost-optimized": {
+          provider: "anthropic",
+          model: "claude-haiku",
+          source: "managed",
+        },
+        "my-custom": { provider: "openai", model: "gpt-4o", source: "user" },
       },
     },
   };
@@ -327,6 +336,50 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
     expect(profile.model).toBe("claude-sonnet");
   });
 
+  test("allows edits to a user-owned profile sharing a managed name (os-beta)", async () => {
+    savedRaw = null;
+    rawConfig = {
+      llm: {
+        profiles: {
+          "os-beta": {
+            provider: "anthropic",
+            model: "claude-sonnet",
+            source: "user",
+          },
+        },
+      },
+    };
+    const result = await replaceRoute.handler({
+      pathParams: { name: "os-beta" },
+      body: { provider: "openai", model: "gpt-4o" },
+    });
+    expect(result).toEqual({ ok: true });
+    const profile = (savedRaw as unknown as Record<string, any>)?.llm
+      ?.profiles?.["os-beta"] as Record<string, unknown>;
+    expect(profile.provider).toBe("openai");
+    expect(profile.model).toBe("gpt-4o");
+  });
+
+  test("rejects edits to a managed os-beta profile", async () => {
+    rawConfig = {
+      llm: {
+        profiles: {
+          "os-beta": {
+            provider: "fireworks",
+            model: "accounts/fireworks/models/glm-5p2",
+            source: "managed",
+          },
+        },
+      },
+    };
+    await expect(
+      replaceRoute.handler({
+        pathParams: { name: "os-beta" },
+        body: { provider: "openai", model: "gpt-4o" },
+      }),
+    ).rejects.toThrow(BadRequestError);
+  });
+
   test("PUT { label: '' } on managed profile still rejected by `.min(1)`", async () => {
     // `.nullable()` only widens the type to accept null — empty strings
     // still fail the min-length check, which is correct: an empty string
@@ -426,6 +479,44 @@ describe("PATCH /v1/config — managed profile deletion guard", () => {
       },
     });
     expect(result).toHaveProperty("llm");
+  });
+
+  test("allows deletion of a user-owned profile sharing a managed name (os-beta)", async () => {
+    savedRaw = null;
+    rawConfig = {
+      llm: {
+        profiles: {
+          "os-beta": {
+            provider: "anthropic",
+            model: "claude-sonnet",
+            source: "user",
+          },
+        },
+      },
+    };
+    const result = await patchRoute.handler({
+      body: { llm: { profiles: { "os-beta": null } } },
+    });
+    expect(result).toHaveProperty("llm");
+  });
+
+  test("rejects deletion of a managed os-beta profile", async () => {
+    rawConfig = {
+      llm: {
+        profiles: {
+          "os-beta": {
+            provider: "fireworks",
+            model: "accounts/fireworks/models/glm-5p2",
+            source: "managed",
+          },
+        },
+      },
+    };
+    await expect(
+      patchRoute.handler({
+        body: { llm: { profiles: { "os-beta": null } } },
+      }),
+    ).rejects.toThrow('Cannot delete managed profile "os-beta".');
   });
 
   test("rejects nulling the entire profiles map", async () => {

--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -380,6 +380,21 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
     ).rejects.toThrow(BadRequestError);
   });
 
+  test("rejects PUT to os-beta when no os-beta profile exists, writing no stub", async () => {
+    savedRaw = null;
+    rawConfig = { llm: { profiles: {} } };
+    await expect(
+      replaceRoute.handler({
+        pathParams: { name: "os-beta" },
+        body: { label: "My OS Beta" },
+      }),
+    ).rejects.toThrow("not currently available");
+    expect(savedRaw).toBeNull();
+    expect(
+      (rawConfig as Record<string, any>)?.llm?.profiles?.["os-beta"],
+    ).toBeUndefined();
+  });
+
   test("PUT { label: '' } on managed profile still rejected by `.min(1)`", async () => {
     // `.nullable()` only widens the type to accept null — empty strings
     // still fail the min-length check, which is correct: an empty string

--- a/assistant/src/__tests__/weak-open-model.test.ts
+++ b/assistant/src/__tests__/weak-open-model.test.ts
@@ -10,6 +10,7 @@ describe("isWeakOpenModel", () => {
       "moonshotai/kimi-k2.6",
       "accounts/fireworks/models/kimi-k2p6",
       "deepseek/deepseek-chat",
+      "accounts/fireworks/models/glm-5p2",
     ]) {
       expect(isWeakOpenModel(model)).toBe(true);
     }

--- a/assistant/src/config/__tests__/sync-gated-profiles.test.ts
+++ b/assistant/src/config/__tests__/sync-gated-profiles.test.ts
@@ -58,6 +58,7 @@ afterAll(() => {
 
 import { setOverridesForTesting } from "../../__tests__/feature-flag-test-helpers.js";
 import { invalidateConfigCache } from "../loader.js";
+import { LLMSchema } from "../schemas/llm.js";
 import { seedInferenceProfiles } from "../seed-inference-profiles.js";
 import { reconcileFlagGatedProfiles } from "../sync-gated-profiles.js";
 
@@ -179,7 +180,7 @@ describe("reconcileFlagGatedProfiles", () => {
     expect(reconcileFlagGatedProfiles()).toBe(false);
   });
 
-  test("flag off scrubs os-beta from user mix arms and preserves the rest", () => {
+  test("flag off scrubs os-beta from user mix arms, keeping >= 2-arm mixes", () => {
     process.env.IS_PLATFORM = "true";
     seedBalancedConfig();
     setOverridesForTesting({ "os-beta": true });
@@ -191,6 +192,7 @@ describe("reconcileFlagGatedProfiles", () => {
       label: "My Mix",
       mix: [
         { profile: "balanced", weight: 70 },
+        { profile: "quality-optimized", weight: 20 },
         { profile: "os-beta", weight: 30 },
       ],
     };
@@ -204,12 +206,123 @@ describe("reconcileFlagGatedProfiles", () => {
     const after = readConfig();
     expect(after.llm.profiles["os-beta"]).toBeUndefined();
     const mix = after.llm.profiles["my-mix"]!;
-    expect(mix.mix).toEqual([{ profile: "balanced", weight: 70 }]);
+    expect(mix.mix).toEqual([
+      { profile: "balanced", weight: 70 },
+      { profile: "quality-optimized", weight: 20 },
+    ]);
     expect(mix.source).toBe("user");
     expect(mix.label).toBe("My Mix");
 
     invalidateConfigCache();
     expect(reconcileFlagGatedProfiles()).toBe(false);
+  });
+
+  test("flag off removes a two-arm mix that loses os-beta and repoints refs", () => {
+    process.env.IS_PLATFORM = "true";
+    seedBalancedConfig();
+    setOverridesForTesting({ "os-beta": true });
+    reconcileFlagGatedProfiles();
+
+    const raw = readConfig();
+    raw.llm.profiles["experiment"] = {
+      source: "user",
+      label: "Experiment",
+      mix: [
+        { profile: "balanced", weight: 50 },
+        { profile: "os-beta", weight: 50 },
+      ],
+    };
+    raw.llm.profileOrder.push("experiment");
+    raw.llm.activeProfile = "experiment";
+    raw.llm.advisorProfile = "os-beta";
+    (raw.llm as Record<string, unknown>).callSites = {
+      mainAgent: { profile: "experiment" },
+    };
+    writeConfig(raw);
+    invalidateConfigCache();
+
+    setOverridesForTesting({ "os-beta": false });
+    expect(reconcileFlagGatedProfiles()).toBe(true);
+
+    const after = readConfig();
+    expect(after.llm.profiles["os-beta"]).toBeUndefined();
+    expect(after.llm.profiles["experiment"]).toBeUndefined();
+    expect(after.llm.profileOrder.includes("os-beta")).toBe(false);
+    expect(after.llm.profileOrder.includes("experiment")).toBe(false);
+    expect(after.llm.activeProfile).toBe("balanced");
+    expect(after.llm.advisorProfile).toBe("quality-optimized");
+    expect(
+      (
+        after.llm as unknown as Record<
+          string,
+          Record<string, Record<string, unknown>>
+        >
+      ).callSites.mainAgent.profile,
+    ).toBeUndefined();
+
+    expect(LLMSchema.safeParse(after.llm).success).toBe(true);
+  });
+
+  test("flag off shortens a three-arm mix to two surviving arms", () => {
+    process.env.IS_PLATFORM = "true";
+    seedBalancedConfig();
+    setOverridesForTesting({ "os-beta": true });
+    reconcileFlagGatedProfiles();
+
+    const raw = readConfig();
+    raw.llm.profiles["blend"] = {
+      source: "user",
+      label: "Blend",
+      mix: [
+        { profile: "balanced", weight: 40 },
+        { profile: "os-beta", weight: 30 },
+        { profile: "quality-optimized", weight: 30 },
+      ],
+    };
+    raw.llm.profileOrder.push("blend");
+    writeConfig(raw);
+    invalidateConfigCache();
+
+    setOverridesForTesting({ "os-beta": false });
+    expect(reconcileFlagGatedProfiles()).toBe(true);
+
+    const after = readConfig();
+    expect(after.llm.profiles["os-beta"]).toBeUndefined();
+    expect(after.llm.profiles["blend"]!.mix).toEqual([
+      { profile: "balanced", weight: 40 },
+      { profile: "quality-optimized", weight: 30 },
+    ]);
+
+    expect(LLMSchema.safeParse(after.llm).success).toBe(true);
+  });
+
+  test("flag off clears a call-site profile reference to os-beta", () => {
+    process.env.IS_PLATFORM = "true";
+    seedBalancedConfig();
+    setOverridesForTesting({ "os-beta": true });
+    reconcileFlagGatedProfiles();
+
+    const raw = readConfig();
+    (raw.llm as Record<string, unknown>).callSites = {
+      advisor: { profile: "os-beta", temperature: 0.3 },
+    };
+    writeConfig(raw);
+    invalidateConfigCache();
+
+    setOverridesForTesting({ "os-beta": false });
+    expect(reconcileFlagGatedProfiles()).toBe(true);
+
+    const after = readConfig();
+    const advisor = (
+      after.llm as unknown as Record<
+        string,
+        Record<string, Record<string, unknown>>
+      >
+    ).callSites.advisor;
+    expect(advisor.profile).toBeUndefined();
+    expect(advisor.temperature).toBe(0.3);
+
+    expect(LLMSchema.safeParse(after.llm).success).toBe(true);
   });
 
   test("a user-owned os-beta profile is never touched", () => {

--- a/assistant/src/config/__tests__/sync-gated-profiles.test.ts
+++ b/assistant/src/config/__tests__/sync-gated-profiles.test.ts
@@ -179,6 +179,39 @@ describe("reconcileFlagGatedProfiles", () => {
     expect(reconcileFlagGatedProfiles()).toBe(false);
   });
 
+  test("flag off scrubs os-beta from user mix arms and preserves the rest", () => {
+    process.env.IS_PLATFORM = "true";
+    seedBalancedConfig();
+    setOverridesForTesting({ "os-beta": true });
+    reconcileFlagGatedProfiles();
+
+    const raw = readConfig();
+    raw.llm.profiles["my-mix"] = {
+      source: "user",
+      label: "My Mix",
+      mix: [
+        { profile: "balanced", weight: 70 },
+        { profile: "os-beta", weight: 30 },
+      ],
+    };
+    raw.llm.profileOrder.push("my-mix");
+    writeConfig(raw);
+    invalidateConfigCache();
+
+    setOverridesForTesting({ "os-beta": false });
+    expect(reconcileFlagGatedProfiles()).toBe(true);
+
+    const after = readConfig();
+    expect(after.llm.profiles["os-beta"]).toBeUndefined();
+    const mix = after.llm.profiles["my-mix"]!;
+    expect(mix.mix).toEqual([{ profile: "balanced", weight: 70 }]);
+    expect(mix.source).toBe("user");
+    expect(mix.label).toBe("My Mix");
+
+    invalidateConfigCache();
+    expect(reconcileFlagGatedProfiles()).toBe(false);
+  });
+
   test("a user-owned os-beta profile is never touched", () => {
     process.env.IS_PLATFORM = "true";
     writeConfig({

--- a/assistant/src/config/__tests__/sync-gated-profiles.test.ts
+++ b/assistant/src/config/__tests__/sync-gated-profiles.test.ts
@@ -1,0 +1,210 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+const WORKSPACE_DIR = process.env.VELLUM_WORKSPACE_DIR!;
+const CONFIG_PATH = join(WORKSPACE_DIR, "config.json");
+
+function ensureTestDir(): void {
+  const dirs = [
+    WORKSPACE_DIR,
+    join(WORKSPACE_DIR, "data"),
+    join(WORKSPACE_DIR, "data", "memory"),
+    join(WORKSPACE_DIR, "data", "logs"),
+  ];
+  for (const dir of dirs) {
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  }
+}
+
+function makeLoggerStub(): Record<string, unknown> {
+  const stub: Record<string, unknown> = {};
+  for (const m of [
+    "info",
+    "warn",
+    "error",
+    "debug",
+    "trace",
+    "fatal",
+    "silent",
+    "child",
+  ]) {
+    stub[m] = m === "child" ? () => makeLoggerStub() : () => {};
+  }
+  return stub;
+}
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () => makeLoggerStub(),
+}));
+
+afterAll(() => {
+  mock.restore();
+});
+
+import { setOverridesForTesting } from "../../__tests__/feature-flag-test-helpers.js";
+import { invalidateConfigCache } from "../loader.js";
+import { seedInferenceProfiles } from "../seed-inference-profiles.js";
+import { reconcileFlagGatedProfiles } from "../sync-gated-profiles.js";
+
+type RawConfig = {
+  llm: {
+    profiles: Record<string, Record<string, unknown>>;
+    profileOrder: string[];
+    activeProfile?: string;
+    advisorProfile?: string;
+  };
+};
+
+function writeConfig(obj: unknown): void {
+  writeFileSync(CONFIG_PATH, JSON.stringify(obj, null, 2) + "\n");
+}
+
+function readConfig(): RawConfig {
+  return JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+}
+
+function seedBalancedConfig(): void {
+  writeConfig({ llm: { default: { provider: "anthropic" } } });
+  invalidateConfigCache();
+  seedInferenceProfiles({});
+}
+
+describe("reconcileFlagGatedProfiles", () => {
+  beforeEach(() => {
+    ensureTestDir();
+    if (existsSync(CONFIG_PATH)) rmSync(CONFIG_PATH, { force: true });
+    delete process.env.IS_PLATFORM;
+    setOverridesForTesting({});
+    invalidateConfigCache();
+  });
+
+  afterEach(() => {
+    delete process.env.IS_PLATFORM;
+    setOverridesForTesting({});
+    invalidateConfigCache();
+  });
+
+  test("flag on materializes the managed os-beta profile after balanced", () => {
+    process.env.IS_PLATFORM = "true";
+    seedBalancedConfig();
+    setOverridesForTesting({ "os-beta": true });
+
+    expect(reconcileFlagGatedProfiles()).toBe(true);
+
+    const raw = readConfig();
+    const osBeta = raw.llm.profiles["os-beta"]!;
+    expect(osBeta.model).toBe("accounts/fireworks/models/glm-5p2");
+    expect(osBeta.provider_connection).toBe("fireworks-managed");
+    expect(osBeta.source).toBe("managed");
+    expect(osBeta.label).toBe("OS Beta");
+
+    const order = raw.llm.profileOrder;
+    expect(order.indexOf("os-beta")).toBe(order.indexOf("balanced") + 1);
+  });
+
+  test("flag on is idempotent across repeated runs", () => {
+    process.env.IS_PLATFORM = "true";
+    seedBalancedConfig();
+    setOverridesForTesting({ "os-beta": true });
+
+    expect(reconcileFlagGatedProfiles()).toBe(true);
+    invalidateConfigCache();
+    expect(reconcileFlagGatedProfiles()).toBe(false);
+  });
+
+  test("flag on preserves user overrides on the managed profile", () => {
+    process.env.IS_PLATFORM = "true";
+    seedBalancedConfig();
+    setOverridesForTesting({ "os-beta": true });
+    reconcileFlagGatedProfiles();
+
+    const raw = readConfig();
+    raw.llm.profiles["os-beta"]!.label = "My OS Beta";
+    raw.llm.profiles["os-beta"]!.status = "disabled";
+    raw.llm.profiles["os-beta"]!.advisorEnabled = true;
+    writeConfig(raw);
+    invalidateConfigCache();
+
+    reconcileFlagGatedProfiles();
+
+    const after = readConfig().llm.profiles["os-beta"]!;
+    expect(after.label).toBe("My OS Beta");
+    expect(after.status).toBe("disabled");
+    expect(after.advisorEnabled).toBe(true);
+    expect(after.model).toBe("accounts/fireworks/models/glm-5p2");
+  });
+
+  test("flag off removes a managed os-beta and applies fallbacks", () => {
+    process.env.IS_PLATFORM = "true";
+    seedBalancedConfig();
+    setOverridesForTesting({ "os-beta": true });
+    reconcileFlagGatedProfiles();
+
+    const raw = readConfig();
+    raw.llm.activeProfile = "os-beta";
+    raw.llm.advisorProfile = "os-beta";
+    writeConfig(raw);
+    invalidateConfigCache();
+
+    setOverridesForTesting({ "os-beta": false });
+    expect(reconcileFlagGatedProfiles()).toBe(true);
+
+    const after = readConfig();
+    expect(after.llm.profiles["os-beta"]).toBeUndefined();
+    expect(after.llm.profileOrder.includes("os-beta")).toBe(false);
+    expect(after.llm.activeProfile).toBe("balanced");
+    expect(after.llm.advisorProfile).toBe("quality-optimized");
+  });
+
+  test("flag off with no os-beta present is a no-op", () => {
+    process.env.IS_PLATFORM = "true";
+    seedBalancedConfig();
+    setOverridesForTesting({ "os-beta": false });
+
+    expect(reconcileFlagGatedProfiles()).toBe(false);
+  });
+
+  test("a user-owned os-beta profile is never touched", () => {
+    process.env.IS_PLATFORM = "true";
+    writeConfig({
+      llm: {
+        default: { provider: "anthropic" },
+        profiles: {
+          "os-beta": {
+            source: "user",
+            label: "Mine",
+            provider: "anthropic",
+            model: "claude-x",
+            provider_connection: "anthropic-personal",
+          },
+        },
+        profileOrder: ["os-beta"],
+      },
+    });
+    invalidateConfigCache();
+    const before = readFileSync(CONFIG_PATH, "utf-8");
+
+    setOverridesForTesting({ "os-beta": true });
+    expect(reconcileFlagGatedProfiles()).toBe(false);
+    expect(readFileSync(CONFIG_PATH, "utf-8")).toBe(before);
+
+    setOverridesForTesting({ "os-beta": false });
+    expect(reconcileFlagGatedProfiles()).toBe(false);
+    expect(readFileSync(CONFIG_PATH, "utf-8")).toBe(before);
+  });
+});

--- a/assistant/src/config/__tests__/sync-gated-profiles.test.ts
+++ b/assistant/src/config/__tests__/sync-gated-profiles.test.ts
@@ -118,6 +118,18 @@ describe("reconcileFlagGatedProfiles", () => {
     expect(order.indexOf("os-beta")).toBe(order.indexOf("balanced") + 1);
   });
 
+  test("flag on in BYOK mode seeds the os-beta profile disabled", () => {
+    seedBalancedConfig();
+    setOverridesForTesting({ "os-beta": true });
+
+    expect(reconcileFlagGatedProfiles()).toBe(true);
+
+    const osBeta = readConfig().llm.profiles["os-beta"]!;
+    expect(osBeta.status).toBe("disabled");
+    expect(osBeta.label).toBe("OS Beta (Managed)");
+    expect(osBeta.source).toBe("managed");
+  });
+
   test("flag on is idempotent across repeated runs", () => {
     process.env.IS_PLATFORM = "true";
     seedBalancedConfig();

--- a/assistant/src/config/assistant-feature-flags.ts
+++ b/assistant/src/config/assistant-feature-flags.ts
@@ -103,7 +103,11 @@ function parseRegistryToDefaults(parsed: unknown): FeatureFlagDefaultsRegistry {
     const entry = flag as Record<string, unknown>;
     if (entry.scope !== "assistant" && entry.scope !== "both") continue;
     if (typeof entry.key !== "string") continue;
-    if (typeof entry.defaultEnabled !== "boolean" && typeof entry.defaultEnabled !== "string") continue;
+    if (
+      typeof entry.defaultEnabled !== "boolean" &&
+      typeof entry.defaultEnabled !== "string"
+    )
+      continue;
 
     result[entry.key as string] = {
       defaultEnabled: entry.defaultEnabled,
@@ -178,6 +182,12 @@ const DEFAULT_INIT_RETRY_BACKOFFS_MS: readonly number[] = [
  * tests preseed flag state via `setOverridesForTesting()` (in
  * `__tests__/feature-flag-test-helpers.ts`) without the gateway IPC call
  * clobbering their setup.
+ *
+ * Resolves `true` when the override cache is populated from the gateway and
+ * `false` when the cache is left unset (exhausted retries / unreachable
+ * gateway). Callers that mutate persisted state from flag values gate that
+ * work on a `true` result so a failed fetch never resolves a flag to its
+ * registry default and drops user state.
  */
 export async function initFeatureFlagOverrides(options?: {
   retryBackoffsMs?: readonly number[];
@@ -188,8 +198,8 @@ export async function initFeatureFlagOverrides(options?: {
    * instead of blocking startup.
    */
   callTimeoutMs?: number;
-}): Promise<void> {
-  if (isCachedFromGateway()) return;
+}): Promise<boolean> {
+  if (isCachedFromGateway()) return true;
 
   const backoffs = options?.retryBackoffsMs ?? DEFAULT_INIT_RETRY_BACKOFFS_MS;
   const callTimeoutMs = options?.callTimeoutMs;
@@ -205,7 +215,7 @@ export async function initFeatureFlagOverrides(options?: {
       // Re-check after the wait: a concurrent caller (e.g. a test using
       // `setOverridesForTesting`) may have populated the cache while we
       // were sleeping. Bail out so we don't clobber their setup.
-      if (isCachedFromGateway()) return;
+      if (isCachedFromGateway()) return true;
     }
 
     const gatewayOverrides = await fetchOverridesFromGateway(callTimeoutMs);
@@ -217,7 +227,7 @@ export async function initFeatureFlagOverrides(options?: {
           "Feature flag overrides loaded from gateway after retry",
         );
       }
-      return;
+      return true;
     }
   }
 
@@ -230,6 +240,7 @@ export async function initFeatureFlagOverrides(options?: {
       "Feature flag overrides empty after all retries; falling back to registry defaults and fail-closed undeclared flags",
     );
   }
+  return false;
 }
 
 /**
@@ -262,10 +273,14 @@ export function clearFeatureFlagOverridesCache(): void {
  * retries (the gateway is known to be up because it just pushed an event).
  * Called by the gateway flag listener when a `feature_flags_changed` event
  * arrives.
+ *
+ * Resolves `true` when the cache was repopulated from the gateway, `false`
+ * when the fetch came back empty/failed — callers gate persisted-state
+ * reconciliation on a `true` result.
  */
-export async function refreshOverridesFromGateway(): Promise<void> {
+export async function refreshOverridesFromGateway(): Promise<boolean> {
   clearFeatureFlagOverridesCache();
-  await initFeatureFlagOverrides({ retryBackoffsMs: [] });
+  return initFeatureFlagOverrides({ retryBackoffsMs: [] });
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -484,7 +484,7 @@ export function materializeProfile(
   };
 }
 
-function readObject(value: unknown): Record<string, unknown> | null {
+export function readObject(value: unknown): Record<string, unknown> | null {
   return value !== null && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : null;

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -27,7 +27,10 @@ type ManagedProfileTemplate = Omit<
   ProfileEntry,
   "provider" | "model" | "provider_connection"
 > & {
-  intent: ModelIntent;
+  // Exactly one of `intent` or `model` must be set. `intent` resolves the
+  // model from the catalog at seed time; `model` pins an explicit model id.
+  intent?: ModelIntent;
+  model?: string;
   provider: NonNullable<ProfileEntry["provider"]>;
   connectionName: string;
 };
@@ -136,6 +139,34 @@ const USER_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
  */
 export const AUTO_PROFILE_KEY = "auto";
 
+export const OS_BETA_PROFILE_KEY = "os-beta";
+export const OS_BETA_FEATURE_FLAG_KEY = "os-beta";
+
+/**
+ * Flag-gated managed profile. NOT in MANAGED_PROFILE_TEMPLATES, so the
+ * unconditional boot seed never creates it. Reconciled in/out by
+ * the flag-gated profile reconcile based on the `os-beta` feature flag.
+ * Balanced-parity defaults; GLM 5.2 pinned explicitly via `model`.
+ */
+export const OS_BETA_PROFILE_TEMPLATE: ManagedProfileTemplate = {
+  model: "accounts/fireworks/models/glm-5p2",
+  provider: "fireworks",
+  connectionName: "fireworks-managed",
+  source: "managed",
+  label: "OS Beta",
+  description: "Open-source frontier model (GLM 5.2), in beta",
+  maxTokens: 32000,
+  effort: "high",
+  thinking: { enabled: true, streamThinking: true },
+  contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
+};
+
+// Membership here marks a profile as managed for the route layer, which blocks
+// model/provider edits and deletion. A key only belongs in this set when a
+// managed profile of that name exists to back it. `OS_BETA_PROFILE_KEY` is
+// flag-gated and has no unconditional managed entry, so it stays out — keeping
+// it in would let the route layer lock a user-created `os-beta` profile that
+// has no managed definition behind it.
 export const MANAGED_PROFILE_NAMES = new Set([
   ...Object.keys(MANAGED_PROFILE_TEMPLATES),
   AUTO_PROFILE_KEY,
@@ -433,17 +464,22 @@ export function seedInferenceProfiles(
   saveRawConfig(config);
 }
 
-function materializeProfile(
+export function materializeProfile(
   template: ManagedProfileTemplate,
   provider: NonNullable<ProfileEntry["provider"]>,
   connectionName: string,
 ): ProfileEntry {
-  const { intent, provider: _p, connectionName: _c, ...rest } = template;
+  const { intent, model, provider: _p, connectionName: _c, ...rest } = template;
+  const resolvedModel =
+    model ?? (intent ? resolveModelIntent(provider, intent) : undefined);
+  if (!resolvedModel) {
+    throw new Error("ManagedProfileTemplate requires `intent` or `model`");
+  }
   return {
     ...rest,
     provider,
     provider_connection: connectionName,
-    model: resolveModelIntent(provider, intent),
+    model: resolvedModel,
   };
 }
 

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -161,14 +161,15 @@ export const OS_BETA_PROFILE_TEMPLATE: ManagedProfileTemplate = {
   contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
 };
 
-// Membership here marks a profile as managed for the route layer, which blocks
-// model/provider edits and deletion. A key only belongs in this set when a
-// managed profile of that name exists to back it. `OS_BETA_PROFILE_KEY` is
-// flag-gated and has no unconditional managed entry, so it stays out — keeping
-// it in would let the route layer lock a user-created `os-beta` profile that
-// has no managed definition behind it.
+// Membership here marks a name as managed. The route layer applies managed
+// restrictions (blocking model/provider edits and deletion) only to entries
+// whose on-disk `source` is `managed`, so a user-owned profile sharing one of
+// these names is not locked. `OS_BETA_PROFILE_KEY` is flag-gated: it is
+// materialized by the flag-gated profile reconcile, which refuses to touch a
+// same-named user profile.
 export const MANAGED_PROFILE_NAMES = new Set([
   ...Object.keys(MANAGED_PROFILE_TEMPLATES),
+  OS_BETA_PROFILE_KEY,
   AUTO_PROFILE_KEY,
 ]);
 

--- a/assistant/src/config/sync-gated-profiles.ts
+++ b/assistant/src/config/sync-gated-profiles.ts
@@ -134,6 +134,10 @@ function enableProfile(
   return changed;
 }
 
+// `MixSchema = z.array(MixArmSchema).min(2)` in schemas/llm.ts: mixes require
+// >= 2 arms. A mix that drops below this is invalid and cannot be kept.
+const MIX_MIN_ARMS = 2;
+
 function disableProfile(
   llm: Record<string, unknown>,
   profiles: Record<string, Record<string, unknown>>,
@@ -144,13 +148,42 @@ function disableProfile(
 
   delete profiles[OS_BETA_PROFILE_KEY];
 
-  const orderIndex = profileOrder.indexOf(OS_BETA_PROFILE_KEY);
-  if (orderIndex >= 0) profileOrder.splice(orderIndex, 1);
+  // The removal closure: every name here is absent from `profiles` once the
+  // closure settles, so the written config can never reference one. A mix that
+  // loses arms below the >= 2 minimum is itself invalid, so it joins the set
+  // and the loop runs to a fixpoint to resolve any references that cascade.
+  const removed = new Set<string>([OS_BETA_PROFILE_KEY]);
+  let cascading = true;
+  while (cascading) {
+    cascading = false;
+    for (const [name, profile] of Object.entries(profiles)) {
+      if (removed.has(name)) continue;
+      if (!Array.isArray(profile.mix)) continue;
+      const arms = profile.mix as unknown[];
+      const kept = arms.filter((arm) => {
+        const armProfile = readObject(arm)?.profile;
+        return typeof armProfile !== "string" || !removed.has(armProfile);
+      });
+      if (kept.length === arms.length) continue;
+      if (kept.length >= MIX_MIN_ARMS) {
+        profile.mix = kept;
+      } else {
+        delete profiles[name];
+        removed.add(name);
+      }
+      cascading = true;
+    }
+  }
 
-  if (llm.activeProfile === OS_BETA_PROFILE_KEY) {
+  llm.profileOrder = profileOrder.filter((name) => !removed.has(name));
+
+  if (typeof llm.activeProfile === "string" && removed.has(llm.activeProfile)) {
     llm.activeProfile = "balanced";
   }
-  if (llm.advisorProfile === OS_BETA_PROFILE_KEY) {
+  if (
+    typeof llm.advisorProfile === "string" &&
+    removed.has(llm.advisorProfile)
+  ) {
     if (readObject(profiles["quality-optimized"]) !== null) {
       llm.advisorProfile = "quality-optimized";
     } else {
@@ -158,17 +191,19 @@ function disableProfile(
     }
   }
 
-  // Removing a flag-gated profile also drops it from any user mix arms so the
-  // config stays loadable — `LLMSchema.superRefine` rejects a mix arm naming a
-  // missing profile.
-  for (const profile of Object.values(profiles)) {
-    if (!Array.isArray(profile.mix)) continue;
-    const arms = profile.mix as Array<Record<string, unknown>>;
-    const kept = arms.filter(
-      (arm) => readObject(arm)?.profile !== OS_BETA_PROFILE_KEY,
-    );
-    if (kept.length !== arms.length) {
-      profile.mix = kept;
+  // Clear any call-site `profile` reference to a removed profile; other override
+  // fields on the entry stay intact (an empty override object is valid).
+  const callSites = readObject(llm.callSites);
+  if (callSites) {
+    for (const entry of Object.values(callSites)) {
+      const site = readObject(entry);
+      if (
+        site &&
+        typeof site.profile === "string" &&
+        removed.has(site.profile)
+      ) {
+        delete site.profile;
+      }
     }
   }
 

--- a/assistant/src/config/sync-gated-profiles.ts
+++ b/assistant/src/config/sync-gated-profiles.ts
@@ -1,3 +1,5 @@
+import { isDeepStrictEqual } from "node:util";
+
 import { getLogger } from "../util/logger.js";
 import { isAssistantFeatureFlagEnabled } from "./assistant-feature-flags.js";
 import {
@@ -12,6 +14,7 @@ import {
   OS_BETA_FEATURE_FLAG_KEY,
   OS_BETA_PROFILE_KEY,
   OS_BETA_PROFILE_TEMPLATE,
+  readObject,
 } from "./seed-inference-profiles.js";
 
 const log = getLogger("sync-gated-profiles");
@@ -113,7 +116,7 @@ function enableProfile(
   }
 
   let changed = false;
-  if (!previous || !deepEqual(previous, next)) {
+  if (!previous || !isDeepStrictEqual(previous, next)) {
     profiles[OS_BETA_PROFILE_KEY] = next as ProfileEntry;
     changed = true;
   }
@@ -155,15 +158,19 @@ function disableProfile(
     }
   }
 
+  // Removing a flag-gated profile also drops it from any user mix arms so the
+  // config stays loadable — `LLMSchema.superRefine` rejects a mix arm naming a
+  // missing profile.
+  for (const profile of Object.values(profiles)) {
+    if (!Array.isArray(profile.mix)) continue;
+    const arms = profile.mix as Array<Record<string, unknown>>;
+    const kept = arms.filter(
+      (arm) => readObject(arm)?.profile !== OS_BETA_PROFILE_KEY,
+    );
+    if (kept.length !== arms.length) {
+      profile.mix = kept;
+    }
+  }
+
   return true;
-}
-
-function readObject(value: unknown): Record<string, unknown> | null {
-  return value !== null && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
-
-function deepEqual(a: unknown, b: unknown): boolean {
-  return JSON.stringify(a) === JSON.stringify(b);
 }

--- a/assistant/src/config/sync-gated-profiles.ts
+++ b/assistant/src/config/sync-gated-profiles.ts
@@ -1,0 +1,169 @@
+import { getLogger } from "../util/logger.js";
+import { isAssistantFeatureFlagEnabled } from "./assistant-feature-flags.js";
+import {
+  getConfigReadOnly,
+  invalidateConfigCache,
+  loadRawConfig,
+  saveRawConfig,
+} from "./loader.js";
+import type { ProfileEntry } from "./schemas/llm.js";
+import {
+  materializeProfile,
+  OS_BETA_FEATURE_FLAG_KEY,
+  OS_BETA_PROFILE_KEY,
+  OS_BETA_PROFILE_TEMPLATE,
+} from "./seed-inference-profiles.js";
+
+const log = getLogger("sync-gated-profiles");
+
+/**
+ * Reconcile flag-gated managed profiles against the current feature-flag state.
+ *
+ * `seedInferenceProfiles()` runs synchronously at boot before feature flags are
+ * available, so the OS Beta profile (GLM 5.2 / fireworks-managed) is materialized
+ * here once flags have loaded. When the `os-beta` flag is on, the managed profile
+ * is created (ordered right after `balanced`); when it is off, a previously
+ * managed entry is removed with `profileOrder` / `activeProfile` / `advisorProfile`
+ * fallbacks. The reconcile is idempotent and never touches a user-owned profile of
+ * the same name.
+ *
+ * Returns whether the on-disk config changed.
+ */
+export function reconcileFlagGatedProfiles(): boolean {
+  const config = loadRawConfig();
+
+  if (config.llm == null || typeof config.llm !== "object") {
+    config.llm = {};
+  }
+  const llm = config.llm as Record<string, unknown>;
+
+  if (llm.profiles == null || typeof llm.profiles !== "object") {
+    llm.profiles = {};
+  }
+  const profiles = llm.profiles as Record<string, Record<string, unknown>>;
+
+  const profileOrder = Array.isArray(llm.profileOrder)
+    ? (llm.profileOrder as string[])
+    : [];
+  llm.profileOrder = profileOrder;
+
+  // The resolver reads flag state from the gateway-populated override cache and
+  // ignores the config argument; pass the read-only config for signature parity
+  // without mutating disk before the reconcile decision is made.
+  const enabled = isAssistantFeatureFlagEnabled(
+    OS_BETA_FEATURE_FLAG_KEY,
+    getConfigReadOnly(),
+  );
+
+  const isPlatform =
+    process.env.IS_PLATFORM === "true" || process.env.IS_PLATFORM === "1";
+  const isByokMode = !isPlatform;
+
+  const previous = readObject(profiles[OS_BETA_PROFILE_KEY]);
+
+  // Never clobber a user-owned profile that happens to be named `os-beta`. The
+  // entry is ours to manage only when it is absent or already managed; a
+  // user-sourced entry of the same name is left untouched on every path.
+  const isOursToManage = previous == null || previous.source === "managed";
+  if (!isOursToManage) {
+    return false;
+  }
+
+  const changed = enabled
+    ? enableProfile(profiles, profileOrder, previous, isByokMode)
+    : disableProfile(llm, profiles, profileOrder, previous);
+
+  if (changed) {
+    saveRawConfig(config);
+    invalidateConfigCache();
+    log.info(
+      { profile: OS_BETA_PROFILE_KEY, enabled },
+      "Reconciled flag-gated profile",
+    );
+  }
+  return changed;
+}
+
+function enableProfile(
+  profiles: Record<string, Record<string, unknown>>,
+  profileOrder: string[],
+  previous: Record<string, unknown> | null,
+  isByokMode: boolean,
+): boolean {
+  const effectiveTemplate = isByokMode
+    ? {
+        ...OS_BETA_PROFILE_TEMPLATE,
+        label: `${OS_BETA_PROFILE_TEMPLATE.label} (Managed)`,
+      }
+    : OS_BETA_PROFILE_TEMPLATE;
+  const next = materializeProfile(
+    effectiveTemplate,
+    OS_BETA_PROFILE_TEMPLATE.provider,
+    OS_BETA_PROFILE_TEMPLATE.connectionName,
+  ) as Record<string, unknown>;
+
+  if (previous) {
+    // The only fields a user may override on a managed profile. Carry `label`
+    // by key-presence so an explicit null (user cleared it) survives too.
+    if ("label" in previous) next.label = previous.label;
+    if ("status" in previous) next.status = previous.status;
+    if ("advisorEnabled" in previous) {
+      next.advisorEnabled = previous.advisorEnabled;
+    }
+  }
+
+  let changed = false;
+  if (!previous || !deepEqual(previous, next)) {
+    profiles[OS_BETA_PROFILE_KEY] = next as ProfileEntry;
+    changed = true;
+  }
+
+  if (!profileOrder.includes(OS_BETA_PROFILE_KEY)) {
+    const balancedIndex = profileOrder.indexOf("balanced");
+    if (balancedIndex >= 0) {
+      profileOrder.splice(balancedIndex + 1, 0, OS_BETA_PROFILE_KEY);
+    } else {
+      profileOrder.push(OS_BETA_PROFILE_KEY);
+    }
+    changed = true;
+  }
+
+  return changed;
+}
+
+function disableProfile(
+  llm: Record<string, unknown>,
+  profiles: Record<string, Record<string, unknown>>,
+  profileOrder: string[],
+  previous: Record<string, unknown> | null,
+): boolean {
+  if (!previous) return false;
+
+  delete profiles[OS_BETA_PROFILE_KEY];
+
+  const orderIndex = profileOrder.indexOf(OS_BETA_PROFILE_KEY);
+  if (orderIndex >= 0) profileOrder.splice(orderIndex, 1);
+
+  if (llm.activeProfile === OS_BETA_PROFILE_KEY) {
+    llm.activeProfile = "balanced";
+  }
+  if (llm.advisorProfile === OS_BETA_PROFILE_KEY) {
+    if (readObject(profiles["quality-optimized"]) !== null) {
+      llm.advisorProfile = "quality-optimized";
+    } else {
+      delete llm.advisorProfile;
+    }
+  }
+
+  return true;
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}

--- a/assistant/src/config/sync-gated-profiles.ts
+++ b/assistant/src/config/sync-gated-profiles.ts
@@ -105,6 +105,15 @@ function enableProfile(
     OS_BETA_PROFILE_TEMPLATE.connectionName,
   ) as Record<string, unknown>;
 
+  // BYOK installs seed managed profiles disabled: the platform-auth
+  // `fireworks-managed` connection backing this profile isn't usable until the
+  // user enables it, so a fresh OS Beta entry starts disabled to avoid offering
+  // an unusable route. A user's own status override (preserved below) wins on
+  // later reconciles.
+  if (isByokMode && !previous) {
+    next.status = "disabled";
+  }
+
   if (previous) {
     // The only fields a user may override on a managed profile. Carry `label`
     // by key-presence so an explicit null (user cleared it) survives too.

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -381,10 +381,14 @@ export async function runDaemon(): Promise<void> {
     // reconcile is the call that mutates config (it raced ahead of the gateway
     // flag listener), publish the config invalidation so any client that already
     // fetched `GET /v1/config` refreshes its profile picker.
+    // Profiles are reconciled only when flags actually loaded from the gateway:
+    // a failed fetch leaves the cache unset and resolves `os-beta` to its
+    // registry default `false`, which would remove the user's profile and reset
+    // their selection. Tool sync tolerates the default and stays unconditional.
     void initFeatureFlagOverrides()
-      .then(() => syncFlagGatedTools())
-      .then(() => {
-        if (reconcileFlagGatedProfiles()) {
+      .then(async (loaded) => {
+        await syncFlagGatedTools();
+        if (loaded && reconcileFlagGatedProfiles()) {
           publishConfigChanged();
         }
       })

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -20,6 +20,7 @@ import {
 import { loadConfig, mergeDefaultWorkspaceConfig } from "../config/loader.js";
 import type { AssistantConfig } from "../config/schema.js";
 import { seedInferenceProfiles } from "../config/seed-inference-profiles.js";
+import { reconcileFlagGatedProfiles } from "../config/sync-gated-profiles.js";
 import type { CesClient } from "../credential-execution/client.js";
 import { createCesClient } from "../credential-execution/client.js";
 import { refreshManagedConnectionCache } from "../credential-execution/managed-catalog.js";
@@ -75,7 +76,10 @@ import {
 import { RuntimeHttpServer } from "../runtime/http-server.js";
 import { recoverInterruptedImport } from "../runtime/migrations/vbundle-streaming-importer.js";
 import { registerSecretsDeps } from "../runtime/routes/secrets-deps.js";
-import { publishConversationListChanged } from "../runtime/sync/resource-sync-events.js";
+import {
+  publishConfigChanged,
+  publishConversationListChanged,
+} from "../runtime/sync/resource-sync-events.js";
 import { recoverStaleSchedules } from "../schedule/schedule-recovery.js";
 import { startScheduler } from "../schedule/scheduler.js";
 import {
@@ -371,8 +375,19 @@ export async function runDaemon(): Promise<void> {
     // this fetch completes, so without this follow-up sync a flag-enabled
     // assistant would not expose the gated tools until a restart (which can lose
     // the same race). Enable-direction only; chained so it sees the fresh cache.
+    // Then reconcile flag-gated managed profiles (OS Beta): `seedInferenceProfiles()`
+    // runs synchronously earlier in boot before flags are available, so this lands
+    // the profile on the same boot once the flag cache is populated. When this
+    // reconcile is the call that mutates config (it raced ahead of the gateway
+    // flag listener), publish the config invalidation so any client that already
+    // fetched `GET /v1/config` refreshes its profile picker.
     void initFeatureFlagOverrides()
       .then(() => syncFlagGatedTools())
+      .then(() => {
+        if (reconcileFlagGatedProfiles()) {
+          publishConfigChanged();
+        }
+      })
       .catch((err) => log.warn({ err }, "Background feature flag init failed"));
 
     startGatewayFlagListener();

--- a/assistant/src/ipc/gateway-flag-listener.ts
+++ b/assistant/src/ipc/gateway-flag-listener.ts
@@ -24,13 +24,17 @@ const log = getLogger("gateway-flag-listener");
  * never throws (it logs internally). After tools sync, `reconcileFlagGatedProfiles`
  * adds or removes the flag-gated managed profile (OS Beta); when it reports a
  * change a `config_changed` broadcast refreshes the profile picker on clients.
+ * The profile reconcile runs only when the refresh confirmed flags loaded from
+ * the gateway — a transient IPC failure leaves the cache unset and resolves
+ * `os-beta` to its registry default `false`, which would remove the user's
+ * profile and reset their selection. Tool sync tolerates the default and stays
+ * unconditional.
  */
 function refreshFlagsAndSyncTools(context: string): void {
   refreshOverridesFromGateway()
-    .then(() => syncFlagGatedTools())
-    .then(() => {
-      const changed = reconcileFlagGatedProfiles();
-      if (changed) {
+    .then(async (loaded) => {
+      await syncFlagGatedTools();
+      if (loaded && reconcileFlagGatedProfiles()) {
         // Reuse the config-changed broadcast clients already consume so the
         // profile picker reflects the added/removed managed profile.
         publishConfigChanged();

--- a/assistant/src/ipc/gateway-flag-listener.ts
+++ b/assistant/src/ipc/gateway-flag-listener.ts
@@ -1,7 +1,9 @@
 import { connect, type Socket } from "node:net";
 
 import { refreshOverridesFromGateway } from "../config/assistant-feature-flags.js";
+import { reconcileFlagGatedProfiles } from "../config/sync-gated-profiles.js";
 import { SYNC_TAGS } from "../daemon/message-types/sync.js";
+import { publishConfigChanged } from "../runtime/sync/resource-sync-events.js";
 import { publishSyncInvalidation } from "../runtime/sync/sync-publisher.js";
 import { syncFlagGatedTools } from "../tools/registry.js";
 import { getLogger } from "../util/logger.js";
@@ -19,11 +21,21 @@ const log = getLogger("gateway-flag-listener");
  * they live in a flag-gated bundled skill surfaced via `skill_load` against the
  * live flag cache, so they need no registry sync here. `syncFlagGatedTools` is
  * idempotent and enable-only, so re-running it on every refresh is safe; it also
- * never throws (it logs internally).
+ * never throws (it logs internally). After tools sync, `reconcileFlagGatedProfiles`
+ * adds or removes the flag-gated managed profile (OS Beta); when it reports a
+ * change a `config_changed` broadcast refreshes the profile picker on clients.
  */
 function refreshFlagsAndSyncTools(context: string): void {
   refreshOverridesFromGateway()
     .then(() => syncFlagGatedTools())
+    .then(() => {
+      const changed = reconcileFlagGatedProfiles();
+      if (changed) {
+        // Reuse the config-changed broadcast clients already consume so the
+        // profile picker reflects the added/removed managed profile.
+        publishConfigChanged();
+      }
+    })
     .catch((err) => {
       log.warn(
         { err },

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -678,6 +678,23 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         },
       },
       {
+        id: "accounts/fireworks/models/glm-5p2",
+        displayName: "GLM 5.2",
+        // Fireworks serves GLM 5.2 with a 1,040K input window.
+        contextWindowTokens: 1040000,
+        maxOutputTokens: 131072,
+        supportsThinking: true,
+        supportsCaching: true,
+        supportsVision: false,
+        supportsToolUse: true,
+        maxEffort: "max",
+        pricing: {
+          inputPer1mTokens: 1.4,
+          outputPer1mTokens: 4.4,
+          cacheReadPer1mTokens: 0.26,
+        },
+      },
+      {
         id: "accounts/fireworks/models/kimi-k2p5",
         displayName: "Kimi K2.5",
         contextWindowTokens: 256000,

--- a/assistant/src/providers/weak-open-model.ts
+++ b/assistant/src/providers/weak-open-model.ts
@@ -1,6 +1,6 @@
 /**
  * Family-level classification of "weak open models" — open-weight models
- * (Kimi, DeepSeek, MiniMax) that disregard static instructions and have
+ * (Kimi, DeepSeek, MiniMax, GLM) that disregard static instructions and have
  * capability gaps that capable models (Claude, GPT) do not. Used by harness
  * levers that coach or redirect these models without touching capable-model
  * behavior: the task-progress-nudge plugin and the empty-dynamic_page surface
@@ -14,7 +14,7 @@
  * Distinct from exploration-drift's narrower `LOOP_PRONE_MODEL_PATTERN`, which
  * targets specific loop-prone versions rather than the whole capability family.
  */
-export const WEAK_OPEN_MODEL_PATTERN = /kimi|deepseek|minimax/i;
+export const WEAK_OPEN_MODEL_PATTERN = /kimi|deepseek|minimax|glm/i;
 
 /** True when `model` is a weak open model (see {@link WEAK_OPEN_MODEL_PATTERN}). */
 export function isWeakOpenModel(model: string | null | undefined): boolean {

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -755,8 +755,14 @@ function rejectManagedProfileDeletion(body: Record<string, unknown>): void {
   }
   const profiles = asMutablePlainObject(llm.profiles);
   if (!profiles) return;
+  const existingProfiles = asMutablePlainObject(getConfig().llm.profiles) ?? {};
   for (const name of Object.keys(profiles)) {
-    if (profiles[name] === null && MANAGED_PROFILE_NAMES.has(name)) {
+    if (profiles[name] !== null || !MANAGED_PROFILE_NAMES.has(name)) continue;
+    // Only block deletion when the on-disk entry is Vellum-managed. A
+    // user-owned profile sharing a managed name carries a non-managed `source`
+    // and is freely deletable.
+    const existing = asMutablePlainObject(existingProfiles[name]);
+    if (existing?.source === "managed") {
       throw new BadRequestError(`Cannot delete managed profile "${name}".`);
     }
   }
@@ -929,7 +935,15 @@ async function handleReplaceInferenceProfile({
     const detail = parsed.error.issues.map((issue) => issue.message).join("; ");
     throw new BadRequestError(`Invalid profile fragment: ${detail}`);
   }
-  const isManaged = MANAGED_PROFILE_NAMES.has(name);
+  // A managed name with no existing entry stays protected so users can't
+  // shadow a seeded managed profile. An existing entry carrying a non-managed
+  // `source` is user-owned and remains fully editable.
+  const existingProfile = asMutablePlainObject(
+    getConfig().llm.profiles?.[name],
+  );
+  const isManaged =
+    MANAGED_PROFILE_NAMES.has(name) &&
+    (existingProfile == null || existingProfile.source === "managed");
   if (isManaged) {
     // Managed profiles are daemon-seeded — provider, model, and the
     // connection binding all belong to the seed contract and can't be

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -944,6 +944,15 @@ async function handleReplaceInferenceProfile({
   const isManaged =
     MANAGED_PROFILE_NAMES.has(name) &&
     (existingProfile == null || existingProfile.source === "managed");
+  // A managed profile name with no materialized entry (e.g. a flag-gated profile
+  // whose flag is off) cannot be patched: writing label/status here would persist
+  // a source-less stub that later blocks the real managed profile from being
+  // seeded. Reject rather than create a placeholder.
+  if (MANAGED_PROFILE_NAMES.has(name) && existingProfile == null) {
+    throw new BadRequestError(
+      `Profile "${name}" is not currently available and cannot be edited.`,
+    );
+  }
   if (isManaged) {
     // Managed profiles are daemon-seeded — provider, model, and the
     // connection binding all belong to the seed contract and can't be

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -232,6 +232,14 @@ export const MODELS_BY_PROVIDER = {
       supportsThinking: true,
     },
     {
+      id: "accounts/fireworks/models/glm-5p2",
+      displayName: "GLM 5.2",
+      contextWindowTokens: 1_040_000,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 131_072,
+      supportsThinking: true,
+    },
+    {
       id: "accounts/fireworks/models/kimi-k2p5",
       displayName: "Kimi K2.5",
       contextWindowTokens: 256_000,

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -425,6 +425,14 @@
       "label": "MCP Settings",
       "description": "Show the MCP page in Settings for managing Model Context Protocol server connections: view status, enable/disable, configure, and inspect registered tools per server.",
       "defaultEnabled": false
+    },
+    {
+      "id": "os-beta",
+      "scope": "assistant",
+      "key": "os-beta",
+      "label": "OS Beta",
+      "description": "Enable the OS Beta model profile (GLM 5.2 / Fireworks) in the assistant's model profile selection.",
+      "defaultEnabled": false
     }
   ]
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -425,6 +425,14 @@
       "label": "MCP Settings",
       "description": "Show the MCP page in Settings for managing Model Context Protocol server connections: view status, enable/disable, configure, and inspect registered tools per server.",
       "defaultEnabled": false
+    },
+    {
+      "id": "os-beta",
+      "scope": "assistant",
+      "key": "os-beta",
+      "label": "OS Beta",
+      "description": "Enable the OS Beta model profile (GLM 5.2 / Fireworks) in the assistant's model profile selection.",
+      "defaultEnabled": false
     }
   ]
 }

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -586,6 +586,23 @@
           }
         },
         {
+          "id": "accounts/fireworks/models/glm-5p2",
+          "displayName": "GLM 5.2",
+          "contextWindowTokens": 1040000,
+          "maxOutputTokens": 131072,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": false,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 1.4,
+            "outputPer1mTokens": 4.4,
+            "cacheReadPer1mTokens": 0.26
+          }
+        },
+        {
           "id": "accounts/fireworks/models/kimi-k2p5",
           "displayName": "Kimi K2.5",
           "contextWindowTokens": 256000,


### PR DESCRIPTION
## Summary
Adds a managed **OS Beta** LLM profile (GLM 5.2 via the `fireworks-managed` platform connection, balanced-parity defaults) that appears in a user's profile picker **only when the `os-beta` feature flag is enabled**. Because `seedInferenceProfiles()` runs synchronously at boot before feature flags are available, the profile is reconciled in/out by a post-flag-load hook (`reconcileFlagGatedProfiles()`) — added when the flag is on, removed when off, and re-reconciled on `feature_flags_changed`. No platform-repo changes are required (the flag already exists in platform LaunchDarkly/Terraform, tagged `assistant`).

## Self-review result
PASS — 4-pass self-review found a handful of issues, all fixed in 1 remediation PR (#35428): gate the reconcile on a confirmed flag load (so a transient gateway blip never drops the profile or the user's selection), scrub `os-beta` from user `mix` arms on removal (keeps config loadable), and dedupe helpers. Re-review: PASS, no remaining gaps.

## PRs merged into feature branch
- #35407: feat(catalog): add GLM 5.2 (Fireworks) to the model catalog
- #35403: feat(flags): declare os-beta assistant feature flag in the registry
- #35408: feat(profiles): define OS Beta managed-profile template (not yet seeded)
- #35414: feat(profiles): reconcile OS Beta profile from the os-beta flag (+ route-layer source-based managed gating)
- #35421: feat(daemon): run OS Beta profile reconcile after flags load and on change

### Fix PRs
- #35428: fix(profiles): harden OS Beta flag-gated reconcile (gate on confirmed flag load; scrub mix refs; dedupe helpers)

## Verified model facts (Fireworks GLM 5.2 docs)
`accounts/fireworks/models/glm-5p2` · 1,040K context / 131K output · tool calling ✓ · vision ✗ · prompt caching on (cache-read \$0.26/1M) · \$1.40 in / \$4.40 out per 1M · effort High/Max.

Part of plan: os-beta-managed-profile.md