### PR TITLE
fix(macos): buffer gateway-proxy request bodies so image uploads don't hang

### DIFF
--- a/clients/macos/src/main/gateway-forward.test.ts
+++ b/clients/macos/src/main/gateway-forward.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { planGatewayForward } from "./gateway-forward";
+import {
+  buildGatewayForwardEffect,
+  planGatewayForward,
+} from "./gateway-forward";
 
 const allow =
   (...ports: number[]) =>
@@ -93,5 +96,49 @@ describe("planGatewayForward", () => {
     if (plan.kind !== "forward") throw new Error("expected forward");
     expect(plan.headers.get("authorization")).toBe("Bearer guardian-token");
     expect(plan.headers.get("content-type")).toBe("application/json");
+  });
+});
+
+describe("buildGatewayForwardEffect", () => {
+  test("buffers a body into a finite ArrayBuffer and never streams it", async () => {
+    // A streamed (`duplex: "half"`) request body stalls forever over the
+    // plain-HTTP loopback hop in Chromium's net stack, hanging image/file
+    // uploads. The body must be buffered, and `duplex` must never be set.
+    const plan = planGatewayForward(
+      request("/assistant/__gateway/8080/v1/assistants/x/attachments", {
+        method: "POST",
+      }),
+      allow(8080),
+    );
+    if (plan.kind !== "forward") throw new Error("expected forward");
+
+    const payload = "--boundary\r\nfile bytes\r\n--boundary--";
+    const bodyReq = new Request("http://localhost/ignored", {
+      method: "POST",
+      body: payload,
+    });
+    const { url, init } = await buildGatewayForwardEffect(plan, bodyReq);
+
+    expect(url).toBe("http://127.0.0.1:8080/v1/assistants/x/attachments");
+    expect(init.method).toBe("POST");
+    expect(init.body).toBeInstanceOf(ArrayBuffer);
+    expect(new TextDecoder().decode(init.body)).toBe(payload);
+    expect("duplex" in init).toBe(false);
+  });
+
+  test("sends no body for a bodyless GET", async () => {
+    const plan = planGatewayForward(
+      request("/__gateway/8080/v1/stream"),
+      allow(8080),
+    );
+    if (plan.kind !== "forward") throw new Error("expected forward");
+
+    const { init } = await buildGatewayForwardEffect(
+      plan,
+      new Request("http://localhost/ignored"),
+    );
+
+    expect(init.body).toBeUndefined();
+    expect("duplex" in init).toBe(false);
   });
 });

--- a/clients/macos/src/main/gateway-forward.ts
+++ b/clients/macos/src/main/gateway-forward.ts
@@ -80,3 +80,41 @@ export function planGatewayForward(
     }
   }
 }
+
+export interface GatewayForwardEffect {
+  url: string;
+  init: {
+    method: string;
+    headers: Headers;
+    body?: ArrayBuffer;
+    redirect: "manual";
+  };
+}
+
+/**
+ * Resolve a `forward` plan into the concrete `net.fetch` arguments, buffering
+ * the request body into a finite `ArrayBuffer` rather than streaming it.
+ *
+ * The renderer reaches local gateways over plain-HTTP loopback
+ * (`http://127.0.0.1:<port>`), and Chromium's network stack cannot upload a
+ * streamed (`duplex: "half"`) request body over cleartext HTTP/1.1 — a
+ * non-trivial body (an image or file attachment) stalls indefinitely while
+ * waiting to send, so the upload spins forever. A buffered body carries an
+ * explicit `Content-Length` and uploads normally. The gateway buffers the body
+ * upstream regardless, so nothing on this hop needs request streaming.
+ */
+export async function buildGatewayForwardEffect(
+  plan: Extract<GatewayForwardPlan, { kind: "forward" }>,
+  request: { arrayBuffer: () => Promise<ArrayBuffer> },
+): Promise<GatewayForwardEffect> {
+  const body = plan.hasBody ? await request.arrayBuffer() : undefined;
+  return {
+    url: plan.url,
+    init: {
+      method: plan.method,
+      headers: plan.headers,
+      body,
+      redirect: "manual",
+    },
+  };
+}

--- a/clients/macos/src/main/index.ts
+++ b/clients/macos/src/main/index.ts
@@ -21,7 +21,7 @@ import { getDeviceId } from "./device-id";
 import { handleSync } from "./ipc";
 import { resolveAppProtocolPath } from "./app-protocol";
 import { registerVellumAppProtocol } from "./vellumapp-protocol";
-import { planGatewayForward } from "./gateway-forward";
+import { buildGatewayForwardEffect, planGatewayForward } from "./gateway-forward";
 import {
   fetchForwardPlanWithRetry,
   planPlatformForward,
@@ -280,16 +280,10 @@ const forwardGatewayRequest = async (
       return null;
     case "reject":
       return new Response(plan.message, { status: plan.status });
-    case "forward":
-      return net.fetch(plan.url, {
-        method: plan.method,
-        headers: plan.headers,
-        body: plan.hasBody ? request.body : undefined,
-        // Stream the request body instead of buffering it; required by the
-        // fetch spec whenever a `ReadableStream` body is supplied.
-        ...(plan.hasBody ? { duplex: "half" } : {}),
-        redirect: "manual",
-      });
+    case "forward": {
+      const { url, init } = await buildGatewayForwardEffect(plan, request);
+      return net.fetch(url, init);
+    }
   }
 };
 


### PR DESCRIPTION
## Problem

Pasting (or attaching) an image in the desktop app hangs forever — the attachment chip shows a spinner that never resolves and never errors:

> When I paste an image into the chat with Velissa in the electron app it's stuck uploading forever

## Root cause

The Electron main process proxies renderer requests for `app://…/assistant/__gateway/<port>/…` to the local gateway on **plain-HTTP loopback** (`http://127.0.0.1:<port>`). It forwarded the request body as a streamed `duplex: "half"` `ReadableStream`:

```ts
net.fetch(plan.url, {
  body: plan.hasBody ? request.body : undefined,
  ...(plan.hasBody ? { duplex: "half" } : {}),
  …
});
```

**Chromium's network stack cannot upload a streamed (`duplex: "half"`) request body over cleartext HTTP/1.1.** The renderer-side interceptor already knows this and buffers bodies in local mode (`clients/web/src/lib/api-interceptors.ts` — *"Chrome refuses to send a streaming (duplex: 'half') body without TLS"*), but the **main-process proxy never got the matching fix**.

Small bodies (chat-message JSON) flush in the initial socket buffer and slip through, so only **file/image uploads** — which need real upload streaming — stall. A 1.7 MB PNG is below the 3.5 MB client-side resize threshold, so it's uploaded as-is and hits the streaming path directly.

### Evidence
- The upload **never reaches the gateway or daemon**: today's gateway log has **0** `attachments` entries and the daemon log has **0** `multipart`/`upload` entries while the chip spins → the stall is client-side, before the request completes.
- The request goes through the **daemon SDK client**, which bypasses the `RUNTIME_PROXIED_FIRST_SEGMENTS` allowlist (`skipSegmentAllowlist: true`), so the allowlist is *not* involved.
- `isLocalMode()` is `true` in the packaged macOS build (`VITE_PLATFORM_MODE: "false"`), so the renderer correctly buffers — the surviving streamed hop is **main → gateway**.
- Nothing on the `renderer → app:// → main → gateway` chain has a timeout, and the gateway blocks in `await req.arrayBuffer()` reading a body that never finishes → spins forever rather than erroring (matches the symptom).

## Fix

Buffer the request body into a finite `ArrayBuffer` before forwarding, dropping `duplex: "half"`. This mirrors the renderer-side fix and the gateway's own upstream buffering (`runtime-proxy.ts` already does `await req.arrayBuffer()`), so nothing on this hop needs request streaming. The `net.fetch` arg construction is extracted into a pure `buildGatewayForwardEffect` in `gateway-forward.ts`, covered by a regression test asserting the body is buffered and `duplex` is never set.

**Why it's safe:** request bodies here are finite POST/PUT payloads capped at 50 MB client-side; the gateway buffers them anyway. The streaming **response** (SSE / chunked) is untouched — only the request body changes, and GET/HEAD carry none.

## Testing
- `bunx tsc --noEmit` — clean
- `bun test src/main/gateway-forward.test.ts` — 9 pass (2 new)

## ⚠️ Verification status
Verified by type-check + unit test of the buffered-body contract. **Not yet verified in a packaged app** — that requires a desktop rebuild (this is main-process code; it can't be hot-deployed by a daemon restart like runtime fixes). Confidence in the diagnosis is high (logs prove non-arrival + the cleartext-streaming constraint is documented in our own renderer code + chat-works/image-hangs fits exactly), but a paste test on a build with this change is the final confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)