### PR TITLE
fix(evals): bind free-port probe to IPv4 wildcard

### DIFF
--- a/evals/src/lib/egress/docker-jail.ts
+++ b/evals/src/lib/egress/docker-jail.ts
@@ -89,7 +89,14 @@ export async function findOpenHostPort(): Promise<number> {
     const server = createServer();
     server.unref();
     server.on("error", reject);
-    server.listen(0, () => {
+    // Bind the probe to the IPv4 wildcard explicitly. With no host, the
+    // runtime picks the unspecified address — Bun defaults that to IPv6
+    // `::`, which fails ("Failed to listen at ::") on hosts where IPv6 is
+    // disabled (no `/proc/sys/net/ipv6`), as in container sandboxes. Docker
+    // publishes the resulting port on `0.0.0.0`, so probing the same IPv4
+    // wildcard keeps the free-port check consistent with where the port is
+    // actually bound.
+    server.listen(0, "0.0.0.0", () => {
       const address = server.address();
       if (address === null || typeof address === "string") {
         server.close();


### PR DESCRIPTION
findOpenHostPort() called server.listen(0) with no host. Under Bun the
unspecified address defaults to the IPv6 wildcard ::, which fails with
"Failed to listen at ::" on hosts where IPv6 is disabled (no
/proc/sys/net/ipv6), such as container sandboxes. Docker publishes the
allocated port on 0.0.0.0, so probe the same IPv4 wildcard to keep the
free-port check consistent with where the port is actually bound.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MAw4uch3eXZuNe89Aq7vVB