### PR TITLE
test(credential-security): authorize web-fetch.ts to import secure-keys

### DIFF
--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -237,6 +237,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "tools/credential-execution/make-authenticated-request.ts", // resolves the CES RPC client via getCesClient
       "tools/credential-execution/manage-secure-command-tool.ts", // resolves the CES RPC client via getCesClient
       "tools/executor.ts", // CES approval bridge resolves the CES RPC client via getCesClient
+      "tools/network/web-fetch.ts", // Firecrawl /scrape BYOK fetch provider API key lookup (firecrawl provider key)
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
The Firecrawl /scrape BYOK fetch provider added in #35333 looks up the
firecrawl provider key via getProviderKeyAsync, the same pattern used by
the other authorized provider-key consumers. Add tools/network/web-fetch.ts
to the ALLOWED_IMPORTERS allowlist so the "secure-keys is only imported by
authorized modules" invariant passes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HDjKtDfX23pR6SwSaHgPK8