### PR TITLE
feat(memory): add attached append-only logs database (infra)

### DIFF
--- a/assistant/src/cli/commands/db/status.ts
+++ b/assistant/src/cli/commands/db/status.ts
@@ -28,7 +28,8 @@ import { Database } from "bun:sqlite";
 
 import type { Command } from "commander";
 
-import { getDbPath, getLogsDbPath } from "../../../util/platform.js";
+import { getLogsDbPath } from "../../../util/logs-db-path.js";
+import { getDbPath } from "../../../util/platform.js";
 import { red } from "../../lib/cli-colors.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 import {

--- a/assistant/src/cli/commands/db/status.ts
+++ b/assistant/src/cli/commands/db/status.ts
@@ -28,7 +28,7 @@ import { Database } from "bun:sqlite";
 
 import type { Command } from "commander";
 
-import { getDbPath } from "../../../util/platform.js";
+import { getDbPath, getLogsDbPath } from "../../../util/platform.js";
 import { red } from "../../lib/cli-colors.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 import {
@@ -74,6 +74,14 @@ interface DbFacts {
 interface StatusReport {
   file: FileFacts;
   db: DbFacts | null;
+  /**
+   * The secondary append-only database (`assistant-logs.db`). Omitted from the
+   * report when the file does not exist yet — it is created the first time the
+   * daemon opens (and ATTACHes) the DB, so a fresh install that has never run
+   * the daemon won't have one.
+   */
+  logsFile?: FileFacts;
+  logsDb?: DbFacts | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -242,8 +250,7 @@ function row(label: string, value: string): string {
   return `${label.padEnd(LABEL_WIDTH)}${value}\n`;
 }
 
-function renderHuman(report: StatusReport): string {
-  const { file, db } = report;
+function renderDbBlock(file: FileFacts, db: DbFacts | null): string {
   let out = "";
 
   out += row("Path", file.path);
@@ -297,6 +304,19 @@ function renderHuman(report: StatusReport): string {
         ? formatBytes(t.metric)
         : `${formatCount(t.metric)} rows`;
     out += `  ${t.name.padEnd(nameWidth)}  ${metric}\n`;
+  }
+
+  return out;
+}
+
+function renderHuman(report: StatusReport): string {
+  let out = renderDbBlock(report.file, report.db);
+
+  // The secondary append-only file is only reported once it exists on disk.
+  if (report.logsFile?.exists) {
+    out += "\n";
+    out += "Logs database (append-only tables)\n";
+    out += renderDbBlock(report.logsFile, report.logsDb ?? null);
   }
 
   return out;
@@ -356,7 +376,20 @@ export function registerDbStatus(parent: Command): void {
         process.exit(1);
       }
 
-      const report: StatusReport = { file, db };
+      // Best-effort probe of the secondary append-only DB. It may not exist
+      // yet (fresh install that has never started the daemon), and a probe
+      // failure must never mask the main-DB report.
+      const logsFile = readFileFacts(getLogsDbPath());
+      let logsDb: DbFacts | null = null;
+      if (logsFile.exists) {
+        try {
+          logsDb = readDbFacts(logsFile.path);
+        } catch {
+          logsDb = null;
+        }
+      }
+
+      const report: StatusReport = { file, db, logsFile, logsDb };
       if (shouldOutputJson(this)) {
         writeOutput(this, report);
       } else {

--- a/assistant/src/memory/__tests__/db-logs-attach.test.ts
+++ b/assistant/src/memory/__tests__/db-logs-attach.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for the secondary append-only database file wiring (PR 1).
+ *
+ * What this locks in:
+ *   1. Opening the connection ATTACHes `assistant-logs.db` as the `logs`
+ *      schema and creates the file on disk.
+ *   2. The attached schema runs in WAL mode (its own `-wal`, independent of
+ *      the main DB) — the regression that lets a heavy append-only table
+ *      bloat the *main* WAL is exactly what this split exists to prevent.
+ *   3. A table created in the `logs` schema lives in the separate file, not
+ *      in `main` — proving the physical split rather than just an alias.
+ *   4. `runAsyncSqlite({ dbPath })` targets the given file via the sqlite3
+ *      CLI backend, leaving the main DB untouched.
+ */
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import { removeTestDbFiles } from "../../__tests__/assert-not-live-db.js";
+
+const { getSqlite, LOGS_DB_SCHEMA } = await import("../db-connection.js");
+const { initializeDb } = await import("../db-init.js");
+const { runAsyncSqlite } = await import("../db-async-query.js");
+const { getLogsDbPath } = await import("../../util/platform.js");
+const { findSqlite3 } = await import("../../util/sqlite3-runtime.js");
+
+initializeDb();
+
+const sqlite3Available = findSqlite3() !== undefined;
+
+describe("logs database attachment", () => {
+  test("ATTACHes the logs file as the logs schema and creates it on disk", () => {
+    // Touch the connection so the attach runs.
+    getSqlite();
+    expect(existsSync(getLogsDbPath())).toBe(true);
+
+    const attached = getSqlite()
+      .query<{ name: string; file: string }, []>("PRAGMA database_list")
+      .all();
+    const logsEntry = attached.find((e) => e.name === LOGS_DB_SCHEMA);
+    expect(logsEntry).toBeDefined();
+    expect(logsEntry?.file).toBe(getLogsDbPath());
+  });
+
+  test("the attached schema runs in WAL mode", () => {
+    const mode = getSqlite()
+      .query<
+        { journal_mode: string },
+        []
+      >(`PRAGMA ${LOGS_DB_SCHEMA}.journal_mode`)
+      .get();
+    expect(mode?.journal_mode).toBe("wal");
+  });
+
+  test("a table created in the logs schema lives in the logs file, not main", () => {
+    const sqlite = getSqlite();
+    sqlite.exec(
+      `CREATE TABLE IF NOT EXISTS ${LOGS_DB_SCHEMA}.attach_probe (id INTEGER PRIMARY KEY)`,
+    );
+    try {
+      const inLogs = sqlite
+        .query<
+          { name: string },
+          []
+        >(`SELECT name FROM ${LOGS_DB_SCHEMA}.sqlite_master WHERE name = 'attach_probe'`)
+        .get();
+      expect(inLogs?.name).toBe("attach_probe");
+
+      const inMain = sqlite
+        .query<
+          { name: string },
+          []
+        >(`SELECT name FROM main.sqlite_master WHERE name = 'attach_probe'`)
+        .get();
+      expect(inMain).toBeNull();
+    } finally {
+      sqlite.exec(`DROP TABLE ${LOGS_DB_SCHEMA}.attach_probe`);
+    }
+  });
+
+  test.if(sqlite3Available)(
+    "runAsyncSqlite({ dbPath }) targets the given file, not the main DB",
+    async () => {
+      const targetPath = join(tmpdir(), `vellum-async-dbpath-${Date.now()}.db`);
+      try {
+        const result = await runAsyncSqlite(
+          "CREATE TABLE dbpath_probe (x INTEGER); INSERT INTO dbpath_probe VALUES (42); SELECT changes();",
+          { dbPath: targetPath, forceBackend: "sqlite3-cli" },
+        );
+        expect(result.ok).toBe(true);
+        expect(result.backend).toBe("sqlite3-cli");
+
+        // The target file got the table…
+        const { Database } = await import("bun:sqlite");
+        const probe = new Database(targetPath, { readonly: true });
+        try {
+          const row = probe
+            .query<
+              { name: string },
+              []
+            >("SELECT name FROM sqlite_master WHERE name = 'dbpath_probe'")
+            .get();
+          expect(row?.name).toBe("dbpath_probe");
+        } finally {
+          probe.close();
+        }
+
+        // …and the main DB did not.
+        const inMain = getSqlite()
+          .query<
+            { name: string },
+            []
+          >("SELECT name FROM main.sqlite_master WHERE name = 'dbpath_probe'")
+          .get();
+        expect(inMain).toBeNull();
+      } finally {
+        removeTestDbFiles(targetPath);
+      }
+    },
+  );
+});

--- a/assistant/src/memory/__tests__/db-logs-attach.test.ts
+++ b/assistant/src/memory/__tests__/db-logs-attach.test.ts
@@ -22,7 +22,7 @@ import { removeTestDbFiles } from "../../__tests__/assert-not-live-db.js";
 const { getSqlite, LOGS_DB_SCHEMA } = await import("../db-connection.js");
 const { initializeDb } = await import("../db-init.js");
 const { runAsyncSqlite } = await import("../db-async-query.js");
-const { getLogsDbPath } = await import("../../util/platform.js");
+const { getLogsDbPath } = await import("../../util/logs-db-path.js");
 const { findSqlite3 } = await import("../../util/sqlite3-runtime.js");
 
 initializeDb();

--- a/assistant/src/memory/db-async-query.ts
+++ b/assistant/src/memory/db-async-query.ts
@@ -61,6 +61,19 @@ export interface RunAsyncSqliteOptions {
    * the runtime pick.
    */
   forceBackend?: AsyncSqliteBackend;
+  /**
+   * Database file to run the statement against. Defaults to the main
+   * assistant DB (`getDbPath()`). Pass `getLogsDbPath()` to target the
+   * secondary append-only file directly.
+   *
+   * This only affects the `sqlite3-cli` backend, which opens the given file
+   * as its own `main` database — so a statement like
+   * `DELETE FROM llm_request_logs` runs against the right file with no ATTACH.
+   * The in-process fallback always runs on the daemon connection, which has
+   * the logs DB ATTACHed, so unqualified table names already resolve to the
+   * correct file regardless of this option.
+   */
+  dbPath?: string;
 }
 
 let warnedAboutFallback = false;
@@ -74,7 +87,12 @@ export async function runAsyncSqlite(
     forced === "in-process-blocking" ? undefined : findSqlite3();
 
   if (sqlite3Path && forced !== "in-process-blocking") {
-    return runViaCli(sqlite3Path, sql, options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+    return runViaCli(
+      sqlite3Path,
+      sql,
+      options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      options.dbPath ?? getDbPath(),
+    );
   }
 
   if (!warnedAboutFallback) {
@@ -97,9 +115,9 @@ async function runViaCli(
   sqlite3Path: string,
   sql: string,
   timeoutMs: number,
+  dbPath: string,
 ): Promise<AsyncSqliteResult> {
   const startMs = Date.now();
-  const dbPath = getDbPath();
 
   log.info(
     { sqlite3Path, dbPath, timeoutMs, sqlPreview: sql.slice(0, 80) },

--- a/assistant/src/memory/db-connection.ts
+++ b/assistant/src/memory/db-connection.ts
@@ -5,14 +5,12 @@ import { Database } from "bun:sqlite";
 
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
-import { getLogger } from "../util/logger.js";
-import { ensureDataDir, getDbPath, getLogsDbPath } from "../util/platform.js";
+import { getLogsDbPath } from "../util/logs-db-path.js";
+import { ensureDataDir, getDbPath } from "../util/platform.js";
 import { clearStoredDb, getStoredDb, setStoredDb } from "./db-singleton.js";
 import * as schema from "./schema.js";
 
 export type DrizzleDb = ReturnType<typeof drizzle<typeof schema>>;
-
-const log = getLogger("db-connection");
 
 /**
  * Schema name under which the secondary append-only database file
@@ -37,6 +35,10 @@ export const LOGS_DB_SCHEMA = "logs";
  * file) must not take down the main database. We log and continue in line with
  * the daemon's "never block startup on a subsystem failure" policy; append-only
  * tables are simply unavailable until the next successful open.
+ *
+ * The logger is pulled in lazily (dynamic import) only on the error path. This
+ * file is intentionally kept import-light — see `db-singleton.ts` — so it does
+ * not take a static dependency on the logger (and transitively on pino).
  */
 function attachLogsDb(sqlite: Database): void {
   const logsPath = getLogsDbPath();
@@ -47,9 +49,11 @@ function attachLogsDb(sqlite: Database): void {
     sqlite.exec(`PRAGMA ${LOGS_DB_SCHEMA}.journal_mode=WAL`);
     sqlite.exec(`PRAGMA ${LOGS_DB_SCHEMA}.synchronous=FULL`);
   } catch (err) {
-    log.error(
-      { err, logsPath },
-      "Failed to ATTACH logs database; append-only log tables will be unavailable",
+    void import("../util/logger.js").then(({ getLogger }) =>
+      getLogger("db-connection").error(
+        { err, logsPath },
+        "Failed to ATTACH logs database; append-only log tables will be unavailable",
+      ),
     );
   }
 }

--- a/assistant/src/memory/db-connection.ts
+++ b/assistant/src/memory/db-connection.ts
@@ -5,15 +5,54 @@ import { Database } from "bun:sqlite";
 
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
-import { ensureDataDir, getDbPath } from "../util/platform.js";
-import {
-  clearStoredDb,
-  getStoredDb,
-  setStoredDb,
-} from "./db-singleton.js";
+import { getLogger } from "../util/logger.js";
+import { ensureDataDir, getDbPath, getLogsDbPath } from "../util/platform.js";
+import { clearStoredDb, getStoredDb, setStoredDb } from "./db-singleton.js";
 import * as schema from "./schema.js";
 
 export type DrizzleDb = ReturnType<typeof drizzle<typeof schema>>;
+
+const log = getLogger("db-connection");
+
+/**
+ * Schema name under which the secondary append-only database file
+ * (`assistant-logs.db`) is ATTACHed to the main connection. Tables created in
+ * this schema (e.g. `logs.llm_request_logs`) live in the separate file but are
+ * still queryable — and joinable against main-schema tables — over the single
+ * daemon connection. Because no append-only table exists in the `main` schema,
+ * unqualified references (e.g. `llm_request_logs`) resolve to the attached copy.
+ */
+export const LOGS_DB_SCHEMA = "logs";
+
+/**
+ * ATTACH the append-only logs database to an open connection and apply its
+ * per-database PRAGMAs.
+ *
+ * `journal_mode` and `synchronous` are per-database settings, so they must be
+ * set against the attached schema explicitly — the PRAGMAs run on `main` before
+ * the attach do not carry over. `busy_timeout`, `foreign_keys`, `cache_size`,
+ * and `temp_store` are connection-wide and already configured on the connection.
+ *
+ * Best-effort: a failure here (e.g. a filesystem permission problem on the new
+ * file) must not take down the main database. We log and continue in line with
+ * the daemon's "never block startup on a subsystem failure" policy; append-only
+ * tables are simply unavailable until the next successful open.
+ */
+function attachLogsDb(sqlite: Database): void {
+  const logsPath = getLogsDbPath();
+  try {
+    // Escape single quotes for the SQL string literal (paths can contain them).
+    const escaped = logsPath.replace(/'/g, "''");
+    sqlite.exec(`ATTACH DATABASE '${escaped}' AS ${LOGS_DB_SCHEMA}`);
+    sqlite.exec(`PRAGMA ${LOGS_DB_SCHEMA}.journal_mode=WAL`);
+    sqlite.exec(`PRAGMA ${LOGS_DB_SCHEMA}.synchronous=FULL`);
+  } catch (err) {
+    log.error(
+      { err, logsPath },
+      "Failed to ATTACH logs database; append-only log tables will be unavailable",
+    );
+  }
+}
 
 function canonicalizePathThroughExistingParent(path: string): string {
   const resolvedPath = resolve(path);
@@ -86,6 +125,7 @@ export function getDb(): DrizzleDb {
   sqlite.exec("PRAGMA foreign_keys = ON");
   sqlite.exec("PRAGMA cache_size=-256000");
   sqlite.exec("PRAGMA temp_store=MEMORY");
+  attachLogsDb(sqlite);
   const db = drizzle(sqlite, { schema });
   setStoredDb(db, () => sqlite.close());
   return db;

--- a/assistant/src/util/logs-db-path.ts
+++ b/assistant/src/util/logs-db-path.ts
@@ -1,0 +1,22 @@
+import { join } from "node:path";
+
+import { getDataDir } from "./platform.js";
+
+/**
+ * Path to the secondary SQLite file that houses heavy append-only tables
+ * (LLM request logs, and other log/event tables over time). It lives in the
+ * same `data/db` directory as the main DB and is ATTACHed to the daemon's
+ * connection as the `logs` schema (see `memory/db-connection.ts`). Splitting
+ * these tables into their own file keeps the main DB — and its WAL — small and
+ * lets the two files VACUUM/checkpoint independently.
+ *
+ * Kept in its own leaf module rather than alongside `getDbPath()` in
+ * `platform.ts`: `platform.ts` is imported very early and widely, and adding an
+ * export to it that low-level consumers (e.g. `db-connection.ts`) pull in
+ * across the daemon's large, cyclic import graph trips a Bun link-order bug
+ * ("Export named 'getLogsDbPath' not found"). Isolating it here keeps
+ * `platform.ts`'s module shape stable.
+ */
+export function getLogsDbPath(): string {
+  return join(getDataDir(), "db", "assistant-logs.db");
+}

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -178,18 +178,6 @@ export function getDbPath(): string {
 }
 
 /**
- * Path to the secondary SQLite file that houses heavy append-only tables
- * (LLM request logs, and other log/event tables over time). It lives in the
- * same `data/db` directory as the main DB and is ATTACHed to the daemon's
- * connection as the `logs` schema (see `memory/db-connection.ts`). Splitting
- * these tables into their own file keeps the main DB — and its WAL — small and
- * lets the two files VACUUM/checkpoint independently.
- */
-export function getLogsDbPath(): string {
-  return join(getDataDir(), "db", "assistant-logs.db");
-}
-
-/**
  * Returns the directory where logs live: `<dataDir>/logs/`. Files rotate
  * daily (`assistant-YYYY-MM-DD.log`), so callers ask for the directory and
  * let the logger own the filename.

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -178,6 +178,18 @@ export function getDbPath(): string {
 }
 
 /**
+ * Path to the secondary SQLite file that houses heavy append-only tables
+ * (LLM request logs, and other log/event tables over time). It lives in the
+ * same `data/db` directory as the main DB and is ATTACHed to the daemon's
+ * connection as the `logs` schema (see `memory/db-connection.ts`). Splitting
+ * these tables into their own file keeps the main DB — and its WAL — small and
+ * lets the two files VACUUM/checkpoint independently.
+ */
+export function getLogsDbPath(): string {
+  return join(getDataDir(), "db", "assistant-logs.db");
+}
+
+/**
  * Returns the directory where logs live: `<dataDir>/logs/`. Files rotate
  * daily (`assistant-YYYY-MM-DD.log`), so callers ask for the directory and
  * let the logger own the filename.


### PR DESCRIPTION
Introduce a secondary SQLite file, data/db/assistant-logs.db, ATTACHed to
the daemon's connection as the `logs` schema. This is the foundation for
splitting heavy append-only tables (starting with llm_request_logs in a
follow-up) out of the main DB so the two files grow, VACUUM, and
checkpoint independently — keeping the main DB and its WAL small.

This PR is infrastructure only; no table is moved yet:

- platform: add getLogsDbPath() (sibling of getDbPath() under data/db).
- db-connection: ATTACH the logs file in getDb() and set its per-database
  PRAGMAs (journal_mode=WAL, synchronous=FULL). Best-effort — an attach
  failure logs and continues rather than taking down the main DB.
- db-async-query: runAsyncSqlite now accepts a dbPath so out-of-process
  prune/VACUUM can target the logs file directly (the sqlite3 CLI
  subprocess can't see the daemon's ATTACH); the in-process fallback is
  unaffected since that connection already has the logs DB attached.
- db status: report the secondary file's size/WAL/pragmas when present.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XW2ZBugvdipVAEtFftXjKp