### PR TITLE
fix(migrations): close file descriptors during vbundle export

### DIFF
--- a/assistant/src/runtime/migrations/__tests__/vbundle-builder-fd-leak.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-builder-fd-leak.test.ts
@@ -1,17 +1,13 @@
 /**
- * Regression test for the export-route file-descriptor leak.
+ * Regression test for descriptor hygiene in the vbundle export path.
  *
- * `streamExportVBundle` walks the entire workspace twice — once to hash every
- * file (Pass 1) and once to stream each file into the tar (Pass 2). Both passes
- * previously read through `createReadStream`, whose underlying descriptor was
- * not reliably closed under Bun, so a single export leaked roughly one open
- * descriptor per workspace file. On a long-lived daemon repeated exports drove
- * the process into EMFILE ("too many open files"), failing every subsequent
- * subprocess spawn.
- *
- * Both passes now read through an explicitly-closed `FileHandle`. This test
- * pins that contract: the number of open descriptors held by the process must
- * not grow proportionally to the number of files exported.
+ * `streamExportVBundle` opens every file in the workspace twice — once to hash
+ * it (Pass 1) and once to stream it into the tar (Pass 2). This test pins the
+ * invariant that those reads release their descriptors: the number of open
+ * descriptors held by the process must not grow proportionally to the number
+ * of files exported. Without that guarantee a workspace-sized export exhausts
+ * the daemon's descriptor limit (EMFILE) and every subsequent subprocess spawn
+ * fails.
  *
  * Descriptor counting uses `/proc/self/fd`, which only exists on Linux. The
  * assertion is skipped on platforms without it (e.g. macOS dev machines); CI
@@ -29,6 +25,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
+import { assertNotLiveDb } from "../../../__tests__/assert-not-live-db.js";
 import { streamExportVBundle } from "../vbundle-builder.js";
 import { defaultV1Options } from "./v1-test-helpers.js";
 
@@ -69,7 +66,10 @@ function createPopulatedWorkspace(fileCount: number): {
 
   return {
     dir,
-    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+    cleanup: () => {
+      assertNotLiveDb(dir);
+      rmSync(dir, { recursive: true, force: true });
+    },
   };
 }
 

--- a/assistant/src/runtime/migrations/__tests__/vbundle-builder-fd-leak.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-builder-fd-leak.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Regression test for the export-route file-descriptor leak.
+ *
+ * `streamExportVBundle` walks the entire workspace twice — once to hash every
+ * file (Pass 1) and once to stream each file into the tar (Pass 2). Both passes
+ * previously read through `createReadStream`, whose underlying descriptor was
+ * not reliably closed under Bun, so a single export leaked roughly one open
+ * descriptor per workspace file. On a long-lived daemon repeated exports drove
+ * the process into EMFILE ("too many open files"), failing every subsequent
+ * subprocess spawn.
+ *
+ * Both passes now read through an explicitly-closed `FileHandle`. This test
+ * pins that contract: the number of open descriptors held by the process must
+ * not grow proportionally to the number of files exported.
+ *
+ * Descriptor counting uses `/proc/self/fd`, which only exists on Linux. The
+ * assertion is skipped on platforms without it (e.g. macOS dev machines); CI
+ * runs on Linux, so the regression stays covered there.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import { streamExportVBundle } from "../vbundle-builder.js";
+import { defaultV1Options } from "./v1-test-helpers.js";
+
+const PROC_SELF_FD = "/proc/self/fd";
+const hasProcFd = existsSync(PROC_SELF_FD);
+
+/** Count the descriptors currently open by this process. */
+function openFdCount(): number {
+  return readdirSync(PROC_SELF_FD).length;
+}
+
+/**
+ * Build a workspace with enough distinct files (across nested directories) that
+ * a per-file descriptor leak would be obvious against the assertion bound.
+ */
+function createPopulatedWorkspace(fileCount: number): {
+  dir: string;
+  cleanup: () => void;
+} {
+  const dir = join(
+    tmpdir(),
+    `vbundle-fd-leak-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "config.json"), JSON.stringify({ test: true }));
+  const dbDir = join(dir, "data", "db");
+  mkdirSync(dbDir, { recursive: true });
+  writeFileSync(join(dbDir, "assistant.db"), "fake-db-content");
+
+  // A spread of files under a few nested directories, each with non-trivial
+  // (multi-chunk) content so the read loop iterates more than once.
+  const filler = "x".repeat(200 * 1024);
+  for (let i = 0; i < fileCount; i++) {
+    const sub = join(dir, "data", "files", `dir-${i % 5}`);
+    mkdirSync(sub, { recursive: true });
+    writeFileSync(join(sub, `file-${i}.txt`), `${filler}\n${i}`);
+  }
+
+  return {
+    dir,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+describe("streamExportVBundle — descriptor lifecycle", () => {
+  test.skipIf(!hasProcFd)(
+    "does not leak a file descriptor per exported file",
+    async () => {
+      const fileCount = 60;
+      const workspace = createPopulatedWorkspace(fileCount);
+
+      // Warm-up export: first run can open and cache descriptors that legitimately
+      // persist (loggers, the daemon DB, etc.). Measuring the delta around a
+      // second export isolates per-file leakage from one-time setup.
+      let warmup: Awaited<ReturnType<typeof streamExportVBundle>> | undefined;
+      try {
+        warmup = await streamExportVBundle({
+          workspaceDir: workspace.dir,
+          ...defaultV1Options(),
+        });
+      } finally {
+        await warmup?.cleanup();
+      }
+
+      const before = openFdCount();
+
+      let result: Awaited<ReturnType<typeof streamExportVBundle>> | undefined;
+      try {
+        result = await streamExportVBundle({
+          workspaceDir: workspace.dir,
+          ...defaultV1Options(),
+        });
+        // Manifest covers every file we wrote — proves the walk actually read
+        // them (otherwise a no-op export would trivially leak nothing).
+        expect(result.manifest.contents.length).toBeGreaterThanOrEqual(
+          fileCount,
+        );
+      } finally {
+        await result?.cleanup();
+        workspace.cleanup();
+      }
+
+      const after = openFdCount();
+      const delta = after - before;
+
+      // Each export reads 2×fileCount files (hash pass + tar pass). A per-file
+      // leak would push the delta past `fileCount`. Allow a small constant for
+      // incidental descriptors (temp output file already cleaned up, jitter).
+      expect(delta).toBeLessThan(8);
+    },
+  );
+});

--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -11,7 +11,6 @@
 import { createHash, randomUUID } from "node:crypto";
 import {
   closeSync,
-  createReadStream,
   createWriteStream,
   existsSync,
   lstatSync,
@@ -21,7 +20,7 @@ import {
   readSync,
   realpathSync,
 } from "node:fs";
-import { stat, unlink } from "node:fs/promises";
+import { type FileHandle, open, stat, unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, relative, resolve, sep } from "node:path";
 import { Readable } from "node:stream";
@@ -886,9 +885,10 @@ export function walkDirectoryForMetadata(
 }
 
 /**
- * Compute SHA-256 hex digest of a file by streaming — never buffers the
- * entire file in memory. When `size` is provided, only hashes the first
- * `size` bytes to match what will be archived in the tar entry.
+ * Compute SHA-256 hex digest of a file by reading it in bounded chunks —
+ * never buffers the entire file in memory. When `size` is provided, only
+ * hashes the first `size` bytes to match what will be archived in the tar
+ * entry.
  */
 async function computeFileSha256(
   filePath: string,
@@ -896,11 +896,29 @@ async function computeFileSha256(
 ): Promise<string> {
   const hash = createHash("sha256");
   if (size === 0) return hash.digest("hex");
-  const streamOpts =
-    size !== undefined ? { start: 0, end: size - 1 } : undefined;
-  const stream = createReadStream(filePath, streamOpts);
-  for await (const chunk of stream) {
-    hash.update(chunk);
+
+  // Read through an explicitly-managed FileHandle rather than
+  // `createReadStream` so the descriptor is always released in `finally`.
+  // This pass walks every file in the workspace; relying on stream
+  // auto-close left one descriptor open per file under Bun, which is what
+  // exhausted the daemon's file-descriptor limit (EMFILE) between restarts.
+  // A bounded read loop keeps peak memory flat regardless of file size.
+  const readChunkBytes = 64 * 1024;
+  const handle = await open(filePath, "r");
+  try {
+    const chunk = Buffer.allocUnsafe(readChunkBytes);
+    let position = 0;
+    for (;;) {
+      const remaining = size !== undefined ? size - position : Infinity;
+      if (remaining <= 0) break;
+      const toRead = Math.min(chunk.length, remaining);
+      const { bytesRead } = await handle.read(chunk, 0, toRead, position);
+      if (bytesRead === 0) break;
+      hash.update(chunk.subarray(0, bytesRead));
+      position += bytesRead;
+    }
+  } finally {
+    await handle.close();
   }
   return hash.digest("hex");
 }
@@ -1056,21 +1074,33 @@ async function* generateTarStream(
       // alignment. The WAL checkpoint before export is the primary
       // consistency mechanism for the database.
       let bytesWritten = 0;
-      if (file.size > 0) {
+      if (entrySize > 0) {
+        // Managed FileHandle (not `createReadStream`) so the descriptor is
+        // released in `finally` even when the consumer abandons the generator
+        // mid-file. Each read uses a fresh buffer so a yielded chunk is never
+        // overwritten by the next read before the consumer drains it.
+        let handle: FileHandle | undefined;
         try {
-          const stream = createReadStream(file.diskPath, {
-            start: 0,
-            end: file.size - 1,
-          });
-          for await (const chunk of stream) {
-            const data =
-              chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk);
-            bytesWritten += data.length;
-            yield data;
+          handle = await open(file.diskPath, "r");
+          const readChunkBytes = 64 * 1024;
+          while (bytesWritten < entrySize) {
+            const toRead = Math.min(readChunkBytes, entrySize - bytesWritten);
+            const buf = Buffer.allocUnsafe(toRead);
+            const { bytesRead } = await handle.read(
+              buf,
+              0,
+              toRead,
+              bytesWritten,
+            );
+            if (bytesRead === 0) break;
+            bytesWritten += bytesRead;
+            yield bytesRead === buf.length ? buf : buf.subarray(0, bytesRead);
           }
         } catch {
           // File was deleted or rotated between passes — emit zeros for
           // the full declared size so the tar structure stays valid
+        } finally {
+          if (handle) await handle.close();
         }
       }
 

--- a/assistant/src/runtime/migrations/vbundle-builder.ts
+++ b/assistant/src/runtime/migrations/vbundle-builder.ts
@@ -897,12 +897,11 @@ async function computeFileSha256(
   const hash = createHash("sha256");
   if (size === 0) return hash.digest("hex");
 
-  // Read through an explicitly-managed FileHandle rather than
-  // `createReadStream` so the descriptor is always released in `finally`.
-  // This pass walks every file in the workspace; relying on stream
-  // auto-close left one descriptor open per file under Bun, which is what
-  // exhausted the daemon's file-descriptor limit (EMFILE) between restarts.
-  // A bounded read loop keeps peak memory flat regardless of file size.
+  // Read through an explicitly-managed FileHandle so the descriptor is
+  // always released in `finally`. This pass opens every file in the
+  // workspace, so any per-file descriptor leak here would exhaust the
+  // daemon's file-descriptor limit (EMFILE). A bounded read loop keeps peak
+  // memory flat regardless of file size.
   const readChunkBytes = 64 * 1024;
   const handle = await open(filePath, "r");
   try {
@@ -1075,7 +1074,7 @@ async function* generateTarStream(
       // consistency mechanism for the database.
       let bytesWritten = 0;
       if (entrySize > 0) {
-        // Managed FileHandle (not `createReadStream`) so the descriptor is
+        // Read through an explicitly-managed FileHandle so the descriptor is
         // released in `finally` even when the consumer abandons the generator
         // mid-file. Each read uses a fresh buffer so a yielded chunk is never
         // overwritten by the next read before the consumer drains it.


### PR DESCRIPTION
streamExportVBundle walks the entire workspace twice — Pass 1 hashes
every file, Pass 2 streams each into the tar. Both read through
createReadStream, whose underlying descriptor is not reliably closed
under Bun, so a single export leaked ~1 open fd per workspace file
(observed as ~1458 read-only handles, pos=0, on a live daemon). Repeated
exports drove the daemon into EMFILE, failing every subsequent
subprocess spawn until restart.

Both passes now read through an explicitly-closed FileHandle with a
bounded read loop, so descriptors are released in finally regardless of
Bun's stream auto-close behavior or consumer abandonment. Bundle bytes
and manifest checksums are unchanged (positional reads of the first
`size` bytes preserve the prior semantics).

Adds a regression test asserting the process's open-fd count does not
grow proportionally to the number of exported files (Linux-only;
skipped where /proc/self/fd is absent).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019TY5Jw9LeGexDUZkSB6ysZ