### PR TITLE
fix(web): log dropped-stylesheet diagnostics for session replay (non-prod)

### DIFF
--- a/clients/web/src/lib/session-replay/session-replay-provider.test.ts
+++ b/clients/web/src/lib/session-replay/session-replay-provider.test.ts
@@ -75,6 +75,11 @@ describe("replay provider (first-party proxy, lazy load)", () => {
     // SDK config object, so it never POSTs to the vendor host directly.
     expect(window.__SDKCONFIG__?.statsURL).toBe(`${BASE}/_sr/ingest/s`);
 
+    // Non-prod (here: "test") logs a diagnostic when a stylesheet can't be
+    // recorded, so unstyled replays are traceable from the session console.
+    const dom = options.dom as { shouldLogDroppedStyleDiagnostics?: boolean };
+    expect(dom.shouldLogDroppedStyleDiagnostics).toBe(true);
+
     // shouldSendData reflects live consent, re-checked before every upload.
     const shouldSendData = options.shouldSendData as () => boolean;
     expect(shouldSendData()).toBe(true);

--- a/clients/web/src/lib/session-replay/session-replay-provider.ts
+++ b/clients/web/src/lib/session-replay/session-replay-provider.ts
@@ -121,6 +121,14 @@ const replayProvider: SessionReplayProvider = (() => {
             // sanitizers spread-preserve SDK-private fields (e.g. reqId), so this
             // structural cast across the seam is safe.
             network: options.network as SdkNetworkOption,
+            dom: {
+              // Surfaces a console warning when a stylesheet can't be recorded —
+              // the cause of unstyled replays. The recorder captures console
+              // output, so the diagnostic lands in the session itself. Non-prod
+              // only, to keep production consoles quiet.
+              shouldLogDroppedStyleDiagnostics:
+                options.environment !== "production",
+            },
           });
           sdk = replaySdk;
           if (pendingIdentify) {


### PR DESCRIPTION
## Summary
- Set `dom.shouldLogDroppedStyleDiagnostics` on the session-replay SDK init, gated to non-prod (`environment !== "production"`).
- The SDK logs a console warning whenever a stylesheet change can't be recorded — the root cause of unstyled replays (DOM captured, all CSS missing). Because the recorder captures console output, the diagnostic lands inside the affected session, so we can trace it per-session in the dashboard.
- Long-lived by design: on in dev/staging for ongoing signal, off in prod for a quiet console — nothing to revert.

## Original prompt
We're seeing session-replay recordings where the app renders completely unstyled (full DOM, zero CSS) in some sessions but not others — the first one observed was an iOS/WebKit session loading from the public origin. Investigation ruled out cross-origin CSS and adoptedStyleSheets (it's same-origin external Tailwind `<link>`s on every surface), pointing at the recorder's stylesheet capture intermittently failing (snapshot/parse race, or a referenced-CSS re-fetch failure). Rather than guess at a durable fix, ship the SDK's own diagnostic (`dom.shouldLogDroppedStyleDiagnostics`) gated to non-prod so the next deploy tells us exactly which stylesheet is being dropped and why. `dom.baseHref` was deliberately deferred — it's speculative for the iOS case and risks being reverted.