### PR TITLE
feat(build): optionally trust an egress-proxy CA in image builds

### DIFF
--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -12,6 +12,21 @@ RUN apt-get update && apt-get install -y \
     g++ \
     && rm -rf /var/lib/apt/lists/*
 
+# Optionally trust an egress-proxy CA for this stage's HTTPS package fetches
+# (bun.sh, the npm registry) when building behind a TLS-intercepting proxy
+# such as Claude Code on the web or CI. The CA is supplied as base64 by the
+# build invocation (cli/src/lib/build-extra-ca.ts) and is empty on normal
+# machines, where this whole step is a no-op. Confined to this discarded
+# builder stage, so the shipped runtime image never trusts the proxy CA.
+ARG EGRESS_PROXY_CA_B64=""
+RUN if [ -n "$EGRESS_PROXY_CA_B64" ]; then \
+      command -v update-ca-certificates >/dev/null 2>&1 \
+        || (apt-get update && apt-get install -y --no-install-recommends ca-certificates); \
+      echo "$EGRESS_PROXY_CA_B64" | base64 -d \
+        | awk 'BEGIN{c=0} /-----BEGIN CERTIFICATE-----/{c++} {print > ("/usr/local/share/ca-certificates/egress-proxy-ca-" c ".crt")}'; \
+      update-ca-certificates; \
+    fi
+
 # Install bun (pinned version)
 RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.11"
 ENV PATH="/root/.bun/bin:${PATH}"

--- a/cli/src/lib/build-extra-ca.ts
+++ b/cli/src/lib/build-extra-ca.ts
@@ -1,0 +1,87 @@
+/**
+ * Extra-CA injection for image builds behind a TLS-intercepting egress proxy.
+ *
+ * Some sandboxed environments (Claude Code on the web, certain CI setups)
+ * route all outbound traffic — including a `docker build`'s package fetches
+ * (bun.sh, the npm registry, PyPI) — through a proxy that re-signs TLS with
+ * its own CA. The host trusts that CA, but freshly built images don't, so
+ * every in-build HTTPS fetch fails certificate validation
+ * (`SELF_SIGNED_CERT_IN_CHAIN` / `UnknownIssuer`).
+ *
+ * The proxy CA is public (a certificate, not a key), so the safe fix is to
+ * make the build trust it too. We pass the CA(s) to the Dockerfile as a
+ * base64 build arg (`EGRESS_PROXY_CA_B64`); the Dockerfile injects them into
+ * the *builder* stage's trust store only, so the shipped runtime image is
+ * unchanged. When no such CA is present (a normal dev machine), this returns
+ * nothing and the whole mechanism is a no-op.
+ */
+import { readFileSync, readdirSync } from "fs";
+import { join } from "path";
+
+/** Build-arg name read by every Dockerfile that fetches over HTTPS. */
+export const EGRESS_PROXY_CA_BUILD_ARG = "EGRESS_PROXY_CA_B64";
+
+/**
+ * Directory where Debian-family hosts (and the Claude web sandbox) drop
+ * admin-installed extra CAs. Absent on most dev machines.
+ */
+const EXTRA_CA_DIR = "/usr/local/share/ca-certificates";
+
+/**
+ * Collect extra CA certificate PEMs that image builds should trust, in
+ * priority order:
+ *
+ *  1. `VELLUM_BUILD_EXTRA_CA_FILE` — explicit override (a PEM file path).
+ *  2. Every `*.crt` under {@link EXTRA_CA_DIR} — the host's admin-added CAs,
+ *     which is exactly where an egress proxy CA lands.
+ *
+ * Set `VELLUM_BUILD_NO_EXTRA_CA=1` to force the no-op path (e.g. to build
+ * images that must not trust the local proxy).
+ */
+function collectExtraCaPems(): string[] {
+  if (process.env.VELLUM_BUILD_NO_EXTRA_CA === "1") return [];
+
+  const paths: string[] = [];
+  const override = process.env.VELLUM_BUILD_EXTRA_CA_FILE;
+  if (override) paths.push(override);
+  try {
+    for (const entry of readdirSync(EXTRA_CA_DIR)) {
+      if (entry.endsWith(".crt")) paths.push(join(EXTRA_CA_DIR, entry));
+    }
+  } catch {
+    // EXTRA_CA_DIR doesn't exist — normal on most hosts. No-op.
+  }
+
+  const pems: string[] = [];
+  for (const path of paths) {
+    try {
+      const pem = readFileSync(path, "utf8");
+      if (pem.includes("BEGIN CERTIFICATE")) pems.push(pem.trim());
+    } catch {
+      // Unreadable / missing override path — skip.
+    }
+  }
+  return pems;
+}
+
+/**
+ * Base64 of the concatenated extra-CA PEM bundle, or `undefined` when there
+ * are none. `undefined` means "omit the build arg entirely" so builds on
+ * machines without a proxy CA are byte-for-byte unaffected.
+ */
+export function extraCaBuildArgValue(): string | undefined {
+  const pems = collectExtraCaPems();
+  if (pems.length === 0) return undefined;
+  return Buffer.from(pems.join("\n") + "\n", "utf8").toString("base64");
+}
+
+/**
+ * `--build-arg EGRESS_PROXY_CA_B64=<…>` ready to splice into a `docker build`
+ * argv, or `[]` when there's no extra CA to inject.
+ */
+export function extraCaBuildArgs(): string[] {
+  const value = extraCaBuildArgValue();
+  return value === undefined
+    ? []
+    : ["--build-arg", `${EGRESS_PROXY_CA_BUILD_ARG}=${value}`];
+}

--- a/cli/src/lib/docker.ts
+++ b/cli/src/lib/docker.ts
@@ -19,6 +19,7 @@ import {
   setActiveAssistant,
 } from "./assistant-config";
 import type { AssistantEntry } from "./assistant-config";
+import { extraCaBuildArgs } from "./build-extra-ca";
 import { buildHatchConfigValues, writeInitialConfig } from "./config-utils";
 import { buildServiceRunArgs } from "./statefulset.js";
 import type { Species } from "./constants";
@@ -650,9 +651,12 @@ interface ServiceImageConfig {
 }
 
 async function buildImage(config: ServiceImageConfig): Promise<void> {
+  // Trust a host egress-proxy CA in the builder stage when present (Claude
+  // web / CI sandboxes); a no-op on normal machines. See build-extra-ca.ts.
+  const caArgs = extraCaBuildArgs();
   await exec(
     "docker",
-    ["build", "-f", config.dockerfile, "-t", config.tag, "."],
+    ["build", ...caArgs, "-f", config.dockerfile, "-t", config.tag, "."],
     { cwd: config.context },
   );
 }

--- a/credential-executor/Dockerfile
+++ b/credential-executor/Dockerfile
@@ -9,6 +9,21 @@ RUN apt-get update && apt-get install -y \
     unzip \
     && rm -rf /var/lib/apt/lists/*
 
+# Optionally trust an egress-proxy CA for this stage's HTTPS package fetches
+# (bun.sh, the npm registry) when building behind a TLS-intercepting proxy
+# such as Claude Code on the web or CI. The CA is supplied as base64 by the
+# build invocation (cli/src/lib/build-extra-ca.ts) and is empty on normal
+# machines, where this whole step is a no-op. Confined to this discarded
+# builder stage, so the shipped runtime image never trusts the proxy CA.
+ARG EGRESS_PROXY_CA_B64=""
+RUN if [ -n "$EGRESS_PROXY_CA_B64" ]; then \
+      command -v update-ca-certificates >/dev/null 2>&1 \
+        || (apt-get update && apt-get install -y --no-install-recommends ca-certificates); \
+      echo "$EGRESS_PROXY_CA_B64" | base64 -d \
+        | awk 'BEGIN{c=0} /-----BEGIN CERTIFICATE-----/{c++} {print > ("/usr/local/share/ca-certificates/egress-proxy-ca-" c ".crt")}'; \
+      update-ca-certificates; \
+    fi
+
 # Install bun (pinned version)
 RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.11"
 ENV PATH="/root/.bun/bin:${PATH}"

--- a/evals/src/lib/__tests__/build-extra-ca.test.ts
+++ b/evals/src/lib/__tests__/build-extra-ca.test.ts
@@ -1,0 +1,80 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  EGRESS_PROXY_CA_BUILD_ARG,
+  extraCaBuildArgValue,
+  extraCaBuildArgs,
+} from "../build-extra-ca";
+
+const PEM = [
+  "-----BEGIN CERTIFICATE-----",
+  "MIIBfakecertcontentforunittestonly==",
+  "-----END CERTIFICATE-----",
+].join("\n");
+
+describe("build-extra-ca", () => {
+  const saved = {
+    override: process.env.VELLUM_BUILD_EXTRA_CA_FILE,
+    disable: process.env.VELLUM_BUILD_NO_EXTRA_CA,
+  };
+
+  beforeEach(() => {
+    delete process.env.VELLUM_BUILD_EXTRA_CA_FILE;
+    delete process.env.VELLUM_BUILD_NO_EXTRA_CA;
+  });
+
+  afterEach(() => {
+    if (saved.override === undefined)
+      delete process.env.VELLUM_BUILD_EXTRA_CA_FILE;
+    else process.env.VELLUM_BUILD_EXTRA_CA_FILE = saved.override;
+    if (saved.disable === undefined)
+      delete process.env.VELLUM_BUILD_NO_EXTRA_CA;
+    else process.env.VELLUM_BUILD_NO_EXTRA_CA = saved.disable;
+  });
+
+  test("emits a base64 build-arg for a CA supplied via the override path", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ca-"));
+    const file = join(dir, "proxy.crt");
+    writeFileSync(file, PEM);
+    process.env.VELLUM_BUILD_EXTRA_CA_FILE = file;
+
+    const value = extraCaBuildArgValue();
+    expect(value).toBeDefined();
+    // Round-trips back to the original PEM.
+    expect(Buffer.from(value!, "base64").toString("utf8")).toContain(
+      "BEGIN CERTIFICATE",
+    );
+    expect(extraCaBuildArgs()).toEqual([
+      "--build-arg",
+      `${EGRESS_PROXY_CA_BUILD_ARG}=${value}`,
+    ]);
+  });
+
+  test("is a no-op when the override path is non-existent", () => {
+    process.env.VELLUM_BUILD_EXTRA_CA_FILE = join(
+      tmpdir(),
+      "definitely-not-a-real-ca-file.crt",
+    );
+    // Note: the host scan may still find real CAs, so only assert that a
+    // bad override alone contributes nothing — exercised together with the
+    // kill switch below for a hard no-op guarantee.
+    process.env.VELLUM_BUILD_NO_EXTRA_CA = "1";
+    expect(extraCaBuildArgValue()).toBeUndefined();
+    expect(extraCaBuildArgs()).toEqual([]);
+  });
+
+  test("kill switch forces the no-op path even with a valid CA", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ca-"));
+    const file = join(dir, "proxy.crt");
+    writeFileSync(file, PEM);
+    process.env.VELLUM_BUILD_EXTRA_CA_FILE = file;
+    process.env.VELLUM_BUILD_NO_EXTRA_CA = "1";
+
+    expect(extraCaBuildArgValue()).toBeUndefined();
+    expect(extraCaBuildArgs()).toEqual([]);
+  });
+});

--- a/evals/src/lib/__tests__/hermes-adapter.test.ts
+++ b/evals/src/lib/__tests__/hermes-adapter.test.ts
@@ -34,6 +34,14 @@ import type {
   SpawnedProcess,
 } from "../runtime/command-runner";
 
+// These tests assert the canonical `docker build` argv. The optional
+// egress-proxy CA build-arg (build-extra-ca.ts) is host-dependent — it
+// appears whenever the runner host has admin CAs under
+// /usr/local/share/ca-certificates (e.g. CI / Claude Code on the web) — so
+// force its no-op path here to keep the argv deterministic. The injection
+// itself is covered by build-extra-ca.test.ts.
+process.env.VELLUM_BUILD_NO_EXTRA_CA = "1";
+
 function lines(values: string[]): AsyncIterable<string> {
   return (async function* () {
     for (const value of values) yield value;

--- a/evals/src/lib/adapters/hermes-image/Dockerfile
+++ b/evals/src/lib/adapters/hermes-image/Dockerfile
@@ -19,6 +19,26 @@
 ARG HERMES_BASE
 FROM ${HERMES_BASE}
 
+# Optionally trust an egress-proxy CA for the build's HTTPS package fetch
+# (PyPI, via uv) when building behind a TLS-intercepting proxy such as Claude
+# Code on the web or CI. The CA is supplied as base64 by the build invocation
+# (evals/src/lib/build-extra-ca.ts) and is empty on normal machines, where
+# this whole step is a no-op. Unlike the multi-stage product images this is a
+# single stage, so the CA persists in this eval-only image — acceptable: the
+# image always runs behind the recording jail, never ships. `SSL_CERT_FILE`
+# points uv (which uses its own bundled roots, not the system store) at the
+# jail-augmented system bundle so lazy_deps' `uv pip install` validates.
+ARG EGRESS_PROXY_CA_B64=""
+USER root
+RUN if [ -n "$EGRESS_PROXY_CA_B64" ]; then \
+      command -v update-ca-certificates >/dev/null 2>&1 \
+        || (apt-get update && apt-get install -y --no-install-recommends ca-certificates); \
+      echo "$EGRESS_PROXY_CA_B64" | base64 -d \
+        | awk 'BEGIN{c=0} /-----BEGIN CERTIFICATE-----/{c++} {print > ("/usr/local/share/ca-certificates/egress-proxy-ca-" c ".crt")}'; \
+      update-ca-certificates; \
+    fi
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+
 # Resolve the dep as the unprivileged `hermes` user the gateway runs turns
 # as, so the installed files are owned by the importer (a root-owned venv
 # entry would block hermes-user writes). `HERMES_DISABLE_LAZY_INSTALLS=0`

--- a/evals/src/lib/adapters/hermes.ts
+++ b/evals/src/lib/adapters/hermes.ts
@@ -12,6 +12,7 @@ import type {
   SeededConversationMessage,
   TestSetupCommand,
 } from "../setup-command";
+import { extraCaBuildArgs } from "../build-extra-ca";
 import { runArtifacts } from "../metrics";
 import {
   applyDockerEgressJail,
@@ -554,6 +555,9 @@ export class HermesAgent implements BaseAgent {
           this.derivedImage,
           "--build-arg",
           `HERMES_BASE=${this.baseImage}`,
+          // Trust a host egress-proxy CA when present (Claude web / CI
+          // sandboxes); a no-op on normal machines. See build-extra-ca.ts.
+          ...extraCaBuildArgs(),
           hermesImageDockerfileDir(),
         ],
         {

--- a/evals/src/lib/build-extra-ca.ts
+++ b/evals/src/lib/build-extra-ca.ts
@@ -1,0 +1,78 @@
+/**
+ * Extra-CA injection for image builds behind a TLS-intercepting egress proxy.
+ *
+ * Some sandboxed environments (Claude Code on the web, certain CI setups)
+ * route all outbound traffic — including a `docker build`'s package fetches
+ * (PyPI, the npm registry, bun.sh) — through a proxy that re-signs TLS with
+ * its own CA. The host trusts that CA, but freshly built images don't, so
+ * every in-build HTTPS fetch fails certificate validation
+ * (`UnknownIssuer` / `SELF_SIGNED_CERT_IN_CHAIN`).
+ *
+ * The proxy CA is public (a certificate, not a key), so the safe fix is to
+ * make the build trust it too. We pass the CA(s) to the Dockerfile as a
+ * base64 build arg (`EGRESS_PROXY_CA_B64`) and the Dockerfile injects them
+ * into the image's trust store. When no such CA is present (a normal dev
+ * machine), this returns nothing and the whole mechanism is a no-op.
+ *
+ * Kept as a self-contained copy (mirrors `cli/src/lib/build-extra-ca.ts`) so
+ * the evals workspace stays decoupled from the CLI package.
+ */
+import { readFileSync, readdirSync } from "fs";
+import { join } from "path";
+
+/** Build-arg name read by every Dockerfile that fetches over HTTPS. */
+export const EGRESS_PROXY_CA_BUILD_ARG = "EGRESS_PROXY_CA_B64";
+
+/**
+ * Directory where Debian-family hosts (and the Claude web sandbox) drop
+ * admin-installed extra CAs. Absent on most dev machines.
+ */
+const EXTRA_CA_DIR = "/usr/local/share/ca-certificates";
+
+function collectExtraCaPems(): string[] {
+  if (process.env.VELLUM_BUILD_NO_EXTRA_CA === "1") return [];
+
+  const paths: string[] = [];
+  const override = process.env.VELLUM_BUILD_EXTRA_CA_FILE;
+  if (override) paths.push(override);
+  try {
+    for (const entry of readdirSync(EXTRA_CA_DIR)) {
+      if (entry.endsWith(".crt")) paths.push(join(EXTRA_CA_DIR, entry));
+    }
+  } catch {
+    // EXTRA_CA_DIR doesn't exist — normal on most hosts. No-op.
+  }
+
+  const pems: string[] = [];
+  for (const path of paths) {
+    try {
+      const pem = readFileSync(path, "utf8");
+      if (pem.includes("BEGIN CERTIFICATE")) pems.push(pem.trim());
+    } catch {
+      // Unreadable / missing override path — skip.
+    }
+  }
+  return pems;
+}
+
+/**
+ * Base64 of the concatenated extra-CA PEM bundle, or `undefined` when there
+ * are none — meaning "omit the build arg" so builds on machines without a
+ * proxy CA are byte-for-byte unaffected.
+ */
+export function extraCaBuildArgValue(): string | undefined {
+  const pems = collectExtraCaPems();
+  if (pems.length === 0) return undefined;
+  return Buffer.from(pems.join("\n") + "\n", "utf8").toString("base64");
+}
+
+/**
+ * `--build-arg EGRESS_PROXY_CA_B64=<…>` ready to splice into a `docker build`
+ * argv, or `[]` when there's no extra CA to inject.
+ */
+export function extraCaBuildArgs(): string[] {
+  const value = extraCaBuildArgValue();
+  return value === undefined
+    ? []
+    : ["--build-arg", `${EGRESS_PROXY_CA_BUILD_ARG}=${value}`];
+}

--- a/evals/src/lib/egress/docker-jail.ts
+++ b/evals/src/lib/egress/docker-jail.ts
@@ -89,7 +89,14 @@ export async function findOpenHostPort(): Promise<number> {
     const server = createServer();
     server.unref();
     server.on("error", reject);
-    server.listen(0, () => {
+    // Bind the probe to the IPv4 wildcard explicitly. With no host, the
+    // runtime picks the unspecified address — Bun defaults that to IPv6
+    // `::`, which fails ("Failed to listen at ::") on hosts where IPv6 is
+    // disabled (no `/proc/sys/net/ipv6`), as in container sandboxes. Docker
+    // publishes the resulting port on `0.0.0.0`, so probing the same IPv4
+    // wildcard keeps the free-port check consistent with where the port is
+    // actually bound.
+    server.listen(0, "0.0.0.0", () => {
       const address = server.address();
       if (address === null || typeof address === "string") {
         server.close();

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -17,6 +17,21 @@ COPY packages/service-contracts ./packages/service-contracts
 COPY packages/slack-text ./packages/slack-text
 COPY packages/twilio-client ./packages/twilio-client
 
+# Optionally trust an egress-proxy CA for this stage's HTTPS package fetches
+# (the npm registry) when building behind a TLS-intercepting proxy such as
+# Claude Code on the web or CI. The CA is supplied as base64 by the build
+# invocation (cli/src/lib/build-extra-ca.ts) and is empty on normal machines,
+# where this whole step is a no-op. Confined to this discarded builder stage,
+# so the shipped runtime image never trusts the proxy CA.
+ARG EGRESS_PROXY_CA_B64=""
+RUN if [ -n "$EGRESS_PROXY_CA_B64" ]; then \
+      command -v update-ca-certificates >/dev/null 2>&1 \
+        || (apt-get update && apt-get install -y --no-install-recommends ca-certificates); \
+      echo "$EGRESS_PROXY_CA_B64" | base64 -d \
+        | awk 'BEGIN{c=0} /-----BEGIN CERTIFICATE-----/{c++} {print > ("/usr/local/share/ca-certificates/egress-proxy-ca-" c ".crt")}'; \
+      update-ca-certificates; \
+    fi
+
 # Install deps for shared packages whose source is loaded at runtime.
 RUN cd /app/packages/ces-client && bun install --frozen-lockfile
 RUN cd /app/packages/gateway-client && bun install --frozen-lockfile


### PR DESCRIPTION
## Why

Running the eval harness (and Docker `hatch`) from **Claude Code on the web** fails at image-build time. The managed sandbox routes *all* egress — including a `docker build`'s package fetches — through a TLS-intercepting proxy (Anthropic's "Egress Gateway") that re-signs every HTTPS connection with its own CA. The host trusts that CA, but freshly built images don't, so every in-build fetch fails certificate validation:

- `bun install` / `curl https://bun.sh` → `SELF_SIGNED_CERT_IN_CHAIN`
- `uv pip install` (Hermes) → `invalid peer certificate: UnknownIssuer`

This blocked both `vellum-default` and `hermes-default` from building at all. The widening of the network policy to "full access" doesn't help — the blocker is certificate *trust*, not reachability.

## What

The proxy CA is public (a certificate, not a key), so the fix is to let the builds trust it:

- New `build-extra-ca` helper (in both `cli/` and `evals/`) detects host-installed extra CAs — an explicit `VELLUM_BUILD_EXTRA_CA_FILE` override, else any `*.crt` under `/usr/local/share/ca-certificates` — and passes them to `docker build` as a base64 `EGRESS_PROXY_CA_B64` build arg.
- Each Dockerfile splits the bundle into single-cert files and runs `update-ca-certificates` (bun reads the resulting hashed store; an append-to-bundle approach does **not** work for bun, verified empirically).
- The build invocations (`cli/src/lib/docker.ts` for the product images, `evals` Hermes adapter for the derived image) splice in the arg via `extraCaBuildArgs()`.

## Safe for shipped artifacts

- **Product images** (`assistant` / `gateway` / `credential-executor`): the CA is injected **only in the discarded builder stage**, so the runtime image that ships never trusts the proxy CA.
- **Hermes eval image**: single-stage, so the CA persists — acceptable because it only ever runs behind the recording jail and never ships. `SSL_CERT_FILE` points uv (which uses its own bundled roots) at the augmented system bundle so `lazy_deps`' install validates.
- **No-op on normal machines**: with no extra CA present, the build arg is omitted entirely and builds are byte-for-byte unchanged. `VELLUM_BUILD_NO_EXTRA_CA=1` forces the no-op path.

## Validation

- `bunx tsc --noEmit` clean in `cli/` and `evals/`; `bun test` green (added `build-extra-ca.test.ts`, 29 evals tests pass).
- Full `ai-after-5-deck` run built **and ran both species end-to-end** for the first time from the web sandbox.

⚠️ **The baseline scores from that run are not yet trustworthy** (this PR only fixes the build wall):
- `hermes-default` ended on persistent **502 Bad Gateway** errors — its `pdf-delivered=0.00` is a runtime API failure, not a measurement.
- `vellum-default` ended after turn 1 (0 transcript turns) — minimal engagement.

Those runtime issues are out of scope here and need separate investigation.

## Note

Builds on the now-merged IPv6 free-port fix (#35432), which was the prior blocker on the same branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAw4uch3eXZuNe89Aq7vVB)_