### PR TITLE
fix(macos): use Classic Sentry IPC so lazy consent-gated init survives post-ready

### DIFF
--- a/clients/macos/src/main/sentry.test.ts
+++ b/clients/macos/src/main/sentry.test.ts
@@ -49,6 +49,8 @@ mock.module("@sentry/electron/main", () => ({
   getClient: () => sentryClient,
   getCurrentScope: () => ({ setClient: setClientMock }),
   setTag: setTagMock,
+  // Mirror the real enum so the production import resolves; Classic === 1.
+  IPCMode: { Classic: 1, Protocol: 2, Both: 3 },
 }));
 
 mock.module("electron", () => ({
@@ -193,6 +195,10 @@ describe("consent lifecycle (one-shot init, beforeSend gate, native gate)", () =
       dsn: "https://public@example.test/1",
       tracesSampleRate: 0,
       attachStacktrace: true,
+      // Classic IPC: the default (Both) installs a custom protocol scheme that
+      // throws when init() runs post-`ready` — which lazy first-consent init
+      // always does. Regression guard for VELLUM-ASSISTANT-MACOS-1P5.
+      ipcMode: 1,
     });
     // Tags are applied so events carry process/arch/electron/packaged context.
     expect(setTagMock).toHaveBeenCalledWith("process", "main");

--- a/clients/macos/src/main/sentry.test.ts
+++ b/clients/macos/src/main/sentry.test.ts
@@ -197,7 +197,7 @@ describe("consent lifecycle (one-shot init, beforeSend gate, native gate)", () =
       attachStacktrace: true,
       // Classic IPC: the default (Both) installs a custom protocol scheme that
       // throws when init() runs post-`ready` — which lazy first-consent init
-      // always does. Regression guard for VELLUM-ASSISTANT-MACOS-1P5.
+      // always does.
       ipcMode: 1,
     });
     // Tags are applied so events carry process/arch/electron/packaged context.

--- a/clients/macos/src/main/sentry.ts
+++ b/clients/macos/src/main/sentry.ts
@@ -20,6 +20,12 @@ declare const __SENTRY_DSN_MACOS__: string;
  * (OOM, segfault) upload real minidumps instead of reason-strings. Those
  * minidumps are uploaded via `core.captureEvent`, so they pass through
  * `beforeSend` and respect `client.getOptions().enabled` (see syncNativeGate).
+ *
+ * `ipcMode` is forced to `Classic`: the default (`Both`) installs a custom
+ * protocol scheme via `configureProtocol`, which throws if `init()` runs after
+ * the app `ready` event. We init lazily on first consent (always post-`ready`),
+ * and the protocol channel is unused anyway (no renderer-side Sentry SDK), so
+ * Classic IPC is both required and sufficient.
  */
 function resolveOptions(): Sentry.ElectronMainOptions | null {
   const dsn =
@@ -34,7 +40,14 @@ function resolveOptions(): Sentry.ElectronMainOptions | null {
   const release =
     typeof __VELLUM_BUILD_SHA__ === "string" ? __VELLUM_BUILD_SHA__ : undefined;
 
-  return { dsn, environment, release, tracesSampleRate: 0, attachStacktrace: true };
+  return {
+    dsn,
+    environment,
+    release,
+    tracesSampleRate: 0,
+    attachStacktrace: true,
+    ipcMode: Sentry.IPCMode.Classic,
+  };
 }
 
 function applyTags(): void {


### PR DESCRIPTION
## Summary

- Main-process Sentry inits lazily on first diagnostics consent (always **after** the Electron `ready` event, since the renderer that pushes consent only exists post-ready).
- The default `ipcMode: Both` runs `configureProtocol()`, whose first line throws `"Sentry SDK should be initialized before the Electron app 'ready' event is fired"` when `app.isReady()` — so **every** diagnostics opt-in threw and Sentry never started (Sentry issue VELLUM-ASSISTANT-MACOS-1P5).
- Force `ipcMode: Sentry.IPCMode.Classic`. The protocol IPC channel is unused here (no `@sentry/electron/renderer` init, no preload wiring — main is the only consumer), so Classic is both required and sufficient. Native Crashpad minidump capture is unaffected.
- Added a regression assertion to `sentry.test.ts` that init is called with `ipcMode: Classic`.

## Original prompt

Investigate Sentry issue VELLUM-ASSISTANT-MACOS-1P5 — `Error: Sentry SDK should be initialized before the Electron app 'ready' event is fired`, thrown from `configureProtocol` during `ensureInitialized`/`applyConsent`/`setShareDiagnostics`. Root cause is the conflict between the intentional lazy/fail-closed consent-gated init in `src/main/sentry.ts` and `@sentry/electron`'s default protocol IPC, which requires pre-ready init. Ship the fix (switch to Classic IPC) keeping the lazy-init design intact, with a regression test.