### PR TITLE
feat(compaction): add Gemini countInputTokens via models.countTokens

### DIFF
--- a/assistant/src/__tests__/gemini-count-tokens.test.ts
+++ b/assistant/src/__tests__/gemini-count-tokens.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Coverage for GeminiProvider.countInputTokens — the real Gemini tokenizer via
+ * `models.countTokens`. Mirrors generateContent's composition (contents +
+ * systemInstruction + tool function declarations); throws when the endpoint
+ * returns no `totalTokens` so the daemon falls back to the local estimate.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+let lastCountParams: Record<string, unknown> | undefined;
+let countResult: { totalTokens?: number } = { totalTokens: 1234 };
+
+mock.module("@google/genai", () => ({
+  GoogleGenAI: class {
+    constructor() {}
+    models = {
+      countTokens: async (params: Record<string, unknown>) => {
+        lastCountParams = params;
+        return countResult;
+      },
+    };
+  },
+  ApiError: class extends Error {},
+  ThinkingLevel: {
+    MINIMAL: "MINIMAL",
+    LOW: "LOW",
+    MEDIUM: "MEDIUM",
+    HIGH: "HIGH",
+  },
+}));
+
+import { GeminiProvider } from "../providers/gemini/client.js";
+import type { Message, ToolDefinition } from "../providers/types.js";
+
+const messages: Message[] = [
+  { role: "user", content: [{ type: "text", text: "hello" }] },
+];
+const tools: ToolDefinition[] = [
+  { name: "lookup", description: "d", input_schema: { type: "object" } },
+];
+
+describe("GeminiProvider.countInputTokens", () => {
+  test("returns totalTokens and forwards model + system + tools", async () => {
+    countResult = { totalTokens: 1234 };
+    const provider = new GeminiProvider("key", "gemini-3-flash-preview");
+
+    const count = await provider.countInputTokens(
+      messages,
+      "sys prompt",
+      tools,
+    );
+
+    expect(count).toBe(1234);
+    expect(lastCountParams?.model).toBe("gemini-3-flash-preview");
+    const config = lastCountParams?.config as Record<string, unknown>;
+    expect(config.systemInstruction).toBe("sys prompt");
+    const cfgTools = config.tools as Array<{
+      functionDeclarations: Array<{ name: string }>;
+    }>;
+    expect(cfgTools[0].functionDeclarations[0].name).toBe("lookup");
+    expect(Array.isArray(lastCountParams?.contents)).toBe(true);
+  });
+
+  test("throws when the endpoint returns no totalTokens (caller falls back)", async () => {
+    countResult = {};
+    const provider = new GeminiProvider("key", "gemini-3-flash-preview");
+    await expect(
+      provider.countInputTokens(messages, "sys", undefined),
+    ).rejects.toThrow();
+  });
+});

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -17,6 +17,7 @@ import type {
   Provider,
   ProviderResponse,
   SendMessageOptions,
+  ToolDefinition,
 } from "../types.js";
 import {
   ContextOverflowError,
@@ -516,6 +517,48 @@ export class GeminiProvider implements Provider {
         abortReason ? { cause: error, abortReason } : { cause: error },
       );
     }
+  }
+
+  /**
+   * Exact prompt-token count via Gemini's `models.countTokens` — the real
+   * tokenizer, no generation. Mirrors {@link sendMessage}'s composition
+   * (contents + `systemInstruction` + tool function declarations) so the count
+   * tracks what a real call would send. Throws when the endpoint returns no
+   * `totalTokens`, so the caller falls back to the local estimate.
+   */
+  async countInputTokens(
+    messages: Message[],
+    systemPrompt: string,
+    tools?: ToolDefinition[],
+  ): Promise<number> {
+    const contents = this.toGeminiContents(messages, this.model);
+    const config: genai.CountTokensConfig = {};
+    if (systemPrompt) {
+      config.systemInstruction = systemPrompt.replaceAll(
+        SYSTEM_PROMPT_CACHE_BOUNDARY,
+        "\n\n",
+      );
+    }
+    if (tools && tools.length > 0) {
+      config.tools = [
+        {
+          functionDeclarations: tools.map((t) => ({
+            name: t.name,
+            description: t.description,
+            parametersJsonSchema: t.input_schema,
+          })),
+        },
+      ];
+    }
+    const res = await this.client.models.countTokens({
+      model: this.model,
+      contents,
+      ...(Object.keys(config).length > 0 ? { config } : {}),
+    });
+    if (typeof res.totalTokens !== "number") {
+      throw new Error("Gemini countTokens returned no totalTokens");
+    }
+    return res.totalTokens;
   }
 
   /** Convert neutral messages to Gemini Content[] format. */


### PR DESCRIPTION
## What

Follow-up to #35436 (real tokenizer counts in `/compact` and `/clean`). That PR wired up `Provider.countInputTokens` for Anthropic and left the optional fallback for everyone else. This adds the one other supported provider with a first-party token-count API: **Gemini**, via `models.countTokens`.

The new `GeminiProvider.countInputTokens` mirrors `generateContent`'s composition (contents + `systemInstruction` + tool function declarations), so the count tracks what a real call would send. It throws when the endpoint returns no `totalTokens`, so the daemon's `calculateTokens` falls back to the local estimate.

## Why only Gemini

The remaining supported providers — OpenAI (Responses/ChatCompletions), OpenRouter, Fireworks, MiniMax, AtlasCloud, Ollama — have **no server-side token-count endpoint**. Counting there is local-tokenizer only (tiktoken et al.), which is exactly what `estimatePromptTokens` already provides, so they keep the graceful fallback and omit `countInputTokens`. (Verified: the only `count_tokens` references in the OpenAI SDK are doc-comment links to the tiktoken cookbook, not an endpoint.)

Wrapped providers already forward `countInputTokens` through the chain (added in #35436), so a Gemini connection surfaces the capability with no extra wiring.

## Tests

- `gemini-count-tokens.test.ts` — the `countTokens` path (forwards model + `systemInstruction` + tools) and the missing-`totalTokens` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGSRqvUcr5TRFdreufccwR)_