### PR TITLE
advisor (ui): single Save in Models & Services + fix advisor helper text

### DIFF
--- a/clients/web/src/domains/settings/ai/language-model-card.tsx
+++ b/clients/web/src/domains/settings/ai/language-model-card.tsx
@@ -113,19 +113,21 @@ export function LanguageModelCard() {
   const isProfileDirty = effectiveActiveProfile !== activeProfile;
   const isAdvisorProfileDirty = effectiveAdvisorProfile !== advisorProfile;
 
-  // One save for the whole card — persists both the default and advisor
-  // profile. `null` clears the advisor profile (the PATCH deep-merge deletes
-  // the key); unchanged fields are no-ops.
+  // One save for the whole card. Only the dirty field(s) are sent so we never
+  // re-write a value the user didn't edit (the config PATCH deep-merges every
+  // provided key, so blindly re-sending a stale selector could clobber a change
+  // made elsewhere — e.g. an `/model` switch). `null` clears the advisor profile.
   const handleSave = useCallback(async () => {
     try {
+      const llm: {
+        activeProfile?: string | null;
+        advisorProfile?: string | null;
+      } = {};
+      if (isProfileDirty) llm.activeProfile = effectiveActiveProfile;
+      if (isAdvisorProfileDirty) llm.advisorProfile = effectiveAdvisorProfile;
       await configMutation.mutateAsync({
         path: { assistant_id: assistantId },
-        body: {
-          llm: {
-            activeProfile: effectiveActiveProfile,
-            advisorProfile: effectiveAdvisorProfile,
-          },
-        },
+        body: { llm },
       });
       toast.success("Saved.");
     } catch (error) {
@@ -133,6 +135,8 @@ export function LanguageModelCard() {
       captureError(error, { context: "settings-ai-language-model-save" });
     }
   }, [
+    isProfileDirty,
+    isAdvisorProfileDirty,
     effectiveActiveProfile,
     effectiveAdvisorProfile,
     configMutation,

--- a/clients/web/src/domains/settings/ai/language-model-card.tsx
+++ b/clients/web/src/domains/settings/ai/language-model-card.tsx
@@ -207,8 +207,7 @@ export function LanguageModelCard() {
               as="p"
               className="mt-1 text-(--content-tertiary)"
             >
-              Which profile the advisor consults for a second opinion — your
-              strongest profile by default.
+              Which model your assistant consults for a second opinion
             </Typography>
           </div>
 

--- a/clients/web/src/domains/settings/ai/language-model-card.tsx
+++ b/clients/web/src/domains/settings/ai/language-model-card.tsx
@@ -17,13 +17,17 @@ import { CallSiteOverridesModal } from "@/domains/settings/ai/call-site-override
 import { ManageProfilesModal } from "@/domains/settings/ai/manage-profiles-modal";
 import { ManageProvidersModal } from "@/domains/settings/ai/manage-providers-modal";
 import {
-    AUTO_PROFILE_NAME,
-    gateAutoProfile,
-    profilePickerLabel,
-    visibleProfilesForPicker,
+  AUTO_PROFILE_NAME,
+  gateAutoProfile,
+  profilePickerLabel,
+  visibleProfilesForPicker,
 } from "@/assistant/profile-pickers";
 import { useStickyProfiles } from "@/assistant/use-sticky-profiles";
-import { configGetOptions, configGetSetQueryData, useConfigPatchMutation } from "@/generated/daemon/@tanstack/react-query.gen";
+import {
+  configGetOptions,
+  configGetSetQueryData,
+  useConfigPatchMutation,
+} from "@/generated/daemon/@tanstack/react-query.gen";
 import { useDraftOverride } from "@/domains/settings/ai/use-draft-override";
 import { useQuery } from "@tanstack/react-query";
 
@@ -42,7 +46,10 @@ export function LanguageModelCard() {
   // Retain the last non-empty profile list so a transient empty config payload
   // can't blank the Default Profile dropdown until the next good fetch — managed
   // profiles are always seeded, so an empty map is never a steady state.
-  const { profiles, profileOrder } = useStickyProfiles(config?.llm, assistantId);
+  const { profiles, profileOrder } = useStickyProfiles(
+    config?.llm,
+    assistantId,
+  );
   const orderedProfiles = useMemo(
     () => buildOrderedProfiles(profiles, profileOrder),
     [profiles, profileOrder],
@@ -50,12 +57,18 @@ export function LanguageModelCard() {
 
   const configMutation = useConfigPatchMutation({
     onSuccess: (data) => {
-      configGetSetQueryData(queryClient, { path: { assistant_id: assistantId } }, data);
+      configGetSetQueryData(
+        queryClient,
+        { path: { assistant_id: assistantId } },
+        data,
+      );
     },
   });
 
-  const [effectiveActiveProfile, setDraftActiveProfile] = useDraftOverride(activeProfile);
-  const [effectiveAdvisorProfile, setDraftAdvisorProfile] = useDraftOverride(advisorProfile);
+  const [effectiveActiveProfile, setDraftActiveProfile] =
+    useDraftOverride(activeProfile);
+  const [effectiveAdvisorProfile, setDraftAdvisorProfile] =
+    useDraftOverride(advisorProfile);
 
   // Modal toggles — ephemeral UI state, correct as useState
   const [manageProfilesOpen, setManageProfilesOpen] = useState(false);
@@ -87,39 +100,44 @@ export function LanguageModelCard() {
   );
 
   const overrideCount = Object.entries(callSites).filter(
-    ([id, s]) => id !== "mainAgent" && (s?.profile != null || s?.provider != null || s?.model != null),
+    ([id, s]) =>
+      id !== "mainAgent" &&
+      (s?.profile != null || s?.provider != null || s?.model != null),
   ).length;
   const overrideLabel =
-    overrideCount === 1 ? "1 Override" : overrideCount > 0 ? `${overrideCount} Overrides` : "Overrides";
+    overrideCount === 1
+      ? "1 Override"
+      : overrideCount > 0
+        ? `${overrideCount} Overrides`
+        : "Overrides";
   const isProfileDirty = effectiveActiveProfile !== activeProfile;
   const isAdvisorProfileDirty = effectiveAdvisorProfile !== advisorProfile;
 
-  const handleManagedProfileSave = useCallback(async () => {
+  // One save for the whole card — persists both the default and advisor
+  // profile. `null` clears the advisor profile (the PATCH deep-merge deletes
+  // the key); unchanged fields are no-ops.
+  const handleSave = useCallback(async () => {
     try {
       await configMutation.mutateAsync({
         path: { assistant_id: assistantId },
-        body: { llm: { activeProfile: effectiveActiveProfile } },
+        body: {
+          llm: {
+            activeProfile: effectiveActiveProfile,
+            advisorProfile: effectiveAdvisorProfile,
+          },
+        },
       });
-      toast.success("Profile saved.");
+      toast.success("Saved.");
     } catch (error) {
-      toast.error("Failed to switch profile. Please try again.");
+      toast.error("Failed to save. Please try again.");
       captureError(error, { context: "settings-ai-language-model-save" });
     }
-  }, [effectiveActiveProfile, configMutation, assistantId]);
-
-  const handleAdvisorProfileSave = useCallback(async () => {
-    try {
-      await configMutation.mutateAsync({
-        path: { assistant_id: assistantId },
-        // Empty selection clears the advisor profile (no dedicated advisor).
-        body: { llm: { advisorProfile: effectiveAdvisorProfile ?? "" } },
-      });
-      toast.success("Advisor profile saved.");
-    } catch (error) {
-      toast.error("Failed to switch advisor profile. Please try again.");
-      captureError(error, { context: "settings-ai-advisor-profile-save" });
-    }
-  }, [effectiveAdvisorProfile, configMutation, assistantId]);
+  }, [
+    effectiveActiveProfile,
+    effectiveAdvisorProfile,
+    configMutation,
+    assistantId,
+  ]);
 
   return (
     <>
@@ -146,13 +164,15 @@ export function LanguageModelCard() {
                     : profilePickerLabel(p),
               }))}
             />
-            {queryComplexityRoutingEnabled && effectiveActiveProfile === AUTO_PROFILE_NAME && (
-              <div className="flex items-center gap-2 rounded-lg bg-[var(--surface-warning-subtle)] px-3 py-2">
-                <span className="text-body-small-default text-[var(--content-warning)]">
-                  Auto may use more powerful models when needed, which can increase costs.
-                </span>
-              </div>
-            )}
+            {queryComplexityRoutingEnabled &&
+              effectiveActiveProfile === AUTO_PROFILE_NAME && (
+                <div className="flex items-center gap-2 rounded-lg bg-[var(--surface-warning-subtle)] px-3 py-2">
+                  <span className="text-body-small-default text-[var(--content-warning)]">
+                    Auto may use more powerful models when needed, which can
+                    increase costs.
+                  </span>
+                </div>
+              )}
             {defaultProfilePickerEntries.length === 0 ? (
               <Typography
                 variant="body-small-default"
@@ -187,16 +207,9 @@ export function LanguageModelCard() {
               as="p"
               className="mt-1 text-(--content-tertiary)"
             >
-              Which profile the advisor consults. It won&apos;t be selectable as your chat profile.
+              Which profile the advisor consults for a second opinion — your
+              strongest profile by default.
             </Typography>
-            {isAdvisorProfileDirty && (
-              <div className="mt-2 flex items-center gap-2">
-                <SaveButton onClick={handleAdvisorProfileSave} disabled={configMutation.isPending} />
-                {configMutation.isPending && (
-                  <Loader2 className="h-4 w-4 animate-spin text-[var(--content-disabled)]" />
-                )}
-              </div>
-            )}
           </div>
 
           <div className="flex items-center gap-2">
@@ -223,9 +236,12 @@ export function LanguageModelCard() {
             </Button>
           </div>
 
-          {isProfileDirty && (
+          {(isProfileDirty || isAdvisorProfileDirty) && (
             <div className="flex items-center gap-2">
-              <SaveButton onClick={handleManagedProfileSave} disabled={configMutation.isPending} />
+              <SaveButton
+                onClick={handleSave}
+                disabled={configMutation.isPending}
+              />
               {configMutation.isPending && (
                 <Loader2 className="h-4 w-4 animate-spin text-[var(--content-disabled)]" />
               )}


### PR DESCRIPTION
Follow-up to #35366 (merged). That PR squash-merged everything except this last UI fix, which was committed after the merge to a now-deleted branch — so it never landed. Re-applying it cleanly on top of current `main`.

## What this fixes
The Language Model card (Settings → Models & Services) showed **two Save buttons** when both the Default Profile and Advisor Profile were changed — a separate dirty-gated Save had been added under the advisor dropdown alongside the existing one.

- **Single Save** that persists both the default and advisor profile in one PATCH (unchanged fields are no-ops under the config deep-merge); it appears whenever either dropdown is dirty.
- **Clearing fix:** the save sent `advisorProfile: ""` for an empty selection, which fails the schema's `.min(1)` validation — it now sends `null` (the PATCH convention that deletes/clears the key).
- **Helper text corrected:** dropped the stale "It won't be selectable as your chat profile" line (no longer true since the advisor profile stays selectable; the per-profile toggle handles self-advising). Now: *"Which profile the advisor consults for a second opinion — your strongest profile by default."*

## Verification
`clients/web`: tsc 0 errors, eslint + prettier clean on the changed file. Single-file change (`language-model-card.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)