### PR TITLE
Drop legacy flat fields from ask_question tool

### DIFF
--- a/assistant/src/tools/ask-question/ask-question-tool.test.ts
+++ b/assistant/src/tools/ask-question/ask-question-tool.test.ts
@@ -59,7 +59,9 @@ beforeEach(() => {
   };
 });
 
-const validInput = {
+// A single question used to build batches. The tool only accepts the
+// batched `{ questions: [...] }` shape.
+const singleQ = {
   question: "Which fruit?",
   description: "Pick one to add to the smoothie.",
   options: [
@@ -69,12 +71,7 @@ const validInput = {
   freeTextPlaceholder: "Type a fruit",
 };
 
-const singleQ = {
-  question: validInput.question,
-  description: validInput.description,
-  options: validInput.options,
-  freeTextPlaceholder: validInput.freeTextPlaceholder,
-};
+const validInput = { questions: [singleQ] };
 
 describe("askQuestionTool definition", () => {
   test("exposes the expected schema shape and description language", () => {
@@ -91,7 +88,6 @@ describe("askQuestionTool definition", () => {
     expect(def.description).toContain("remove guessing");
     expect(def.description).toContain("a question is skipped");
     expect(def.description).toContain("every question in the batch is skipped");
-    // Batching language is back now that the prompter handles batches.
     expect(def.description).toContain("Batch related clarifications");
     expect(def.description).toContain("up to 5");
     expect(def.description).toContain("Skip button");
@@ -99,13 +95,23 @@ describe("askQuestionTool definition", () => {
     const schema = def.input_schema as {
       properties: Record<
         string,
-        { type?: string; minItems?: number; maxItems?: number }
+        {
+          type?: string;
+          items?: {
+            properties?: Record<
+              string,
+              { type?: string; minItems?: number; maxItems?: number }
+            >;
+          };
+        }
       >;
       required?: string[];
     };
-    expect(schema.properties.options?.type).toBe("array");
-    expect(schema.properties.options?.minItems).toBe(2);
-    expect(schema.properties.options?.maxItems).toBe(4);
+    const optionsSchema =
+      schema.properties.questions?.items?.properties?.options;
+    expect(optionsSchema?.type).toBe("array");
+    expect(optionsSchema?.minItems).toBe(2);
+    expect(optionsSchema?.maxItems).toBe(4);
   });
 });
 
@@ -132,17 +138,17 @@ describe("AskQuestionTool.execute", () => {
     expect(calls).toHaveLength(1);
     expect(calls[0]?.conversationId).toBe("conv-1");
     expect(calls[0]?.questions).toHaveLength(1);
-    expect(calls[0]?.questions[0]?.question).toBe(validInput.question);
-    expect(calls[0]?.questions[0]?.description).toBe(validInput.description);
-    expect(calls[0]?.questions[0]?.options).toEqual(validInput.options);
+    expect(calls[0]?.questions[0]?.question).toBe(singleQ.question);
+    expect(calls[0]?.questions[0]?.description).toBe(singleQ.description);
+    expect(calls[0]?.questions[0]?.options).toEqual(singleQ.options);
     expect(calls[0]?.questions[0]?.freeTextPlaceholder).toBe(
-      validInput.freeTextPlaceholder,
+      singleQ.freeTextPlaceholder,
     );
     expect(calls[0]?.toolUseId).toBe("tu-1");
 
     expect(result.isError).toBe(false);
     expect(result.content).toBe(
-      `Question "${validInput.question}" → Option: a (Apple)`,
+      `Question "${singleQ.question}" → Option: a (Apple)`,
     );
   });
 
@@ -150,7 +156,7 @@ describe("AskQuestionTool.execute", () => {
     setNextResult(singleCompleted({ decision: "option", optionId: "b" }));
     const result = await askQuestionTool.execute(validInput, makeContext());
     expect(result.content).toBe(
-      `Question "${validInput.question}" → Option: b (Banana)`,
+      `Question "${singleQ.question}" → Option: b (Banana)`,
     );
     expect(result.isError).toBe(false);
   });
@@ -159,7 +165,7 @@ describe("AskQuestionTool.execute", () => {
     setNextResult(singleCompleted({ decision: "option", optionId: "ghost" }));
     const result = await askQuestionTool.execute(validInput, makeContext());
     expect(result.content).toBe(
-      `Question "${validInput.question}" → Option: ghost ((unknown))`,
+      `Question "${singleQ.question}" → Option: ghost ((unknown))`,
     );
     expect(result.isError).toBe(false);
   });
@@ -168,7 +174,7 @@ describe("AskQuestionTool.execute", () => {
     setNextResult(singleCompleted({ decision: "free_text", text: "Cherry" }));
     const result = await askQuestionTool.execute(validInput, makeContext());
     expect(result.content).toBe(
-      `Question "${validInput.question}" → Free text: Cherry`,
+      `Question "${singleQ.question}" → Free text: Cherry`,
     );
     expect(result.isError).toBe(false);
   });
@@ -176,7 +182,7 @@ describe("AskQuestionTool.execute", () => {
   test("formats skipped result", async () => {
     setNextResult(singleCompleted({ decision: "skipped" }));
     const result = await askQuestionTool.execute(validInput, makeContext());
-    expect(result.content).toBe(`Question "${validInput.question}" → Skipped`);
+    expect(result.content).toBe(`Question "${singleQ.question}" → Skipped`);
     expect(result.isError).toBe(false);
   });
 
@@ -200,10 +206,10 @@ describe("AskQuestionTool.execute", () => {
     expect(result.content).toBe("Question aborted");
   });
 
-  test("rejects input with fewer than 2 options", async () => {
+  test("rejects a question with fewer than 2 options", async () => {
     setNextResult(singleCompleted({ decision: "option", optionId: "a" }));
     const result = await askQuestionTool.execute(
-      { ...validInput, options: [{ id: "a", label: "Apple" }] },
+      { questions: [{ ...singleQ, options: [{ id: "a", label: "Apple" }] }] },
       makeContext(),
     );
     expect(result.isError).toBe(true);
@@ -211,17 +217,21 @@ describe("AskQuestionTool.execute", () => {
     expect(calls).toHaveLength(0);
   });
 
-  test("rejects input with more than 4 options", async () => {
+  test("rejects a question with more than 4 options", async () => {
     setNextResult(singleCompleted({ decision: "option", optionId: "a" }));
     const result = await askQuestionTool.execute(
       {
-        ...validInput,
-        options: [
-          { id: "a", label: "A" },
-          { id: "b", label: "B" },
-          { id: "c", label: "C" },
-          { id: "d", label: "D" },
-          { id: "e", label: "E" },
+        questions: [
+          {
+            ...singleQ,
+            options: [
+              { id: "a", label: "A" },
+              { id: "b", label: "B" },
+              { id: "c", label: "C" },
+              { id: "d", label: "D" },
+              { id: "e", label: "E" },
+            ],
+          },
         ],
       },
       makeContext(),
@@ -230,10 +240,10 @@ describe("AskQuestionTool.execute", () => {
     expect(calls).toHaveLength(0);
   });
 
-  test("rejects input with empty question", async () => {
+  test("rejects a question with empty text", async () => {
     setNextResult(singleCompleted({ decision: "option", optionId: "a" }));
     const result = await askQuestionTool.execute(
-      { ...validInput, question: "" },
+      { questions: [{ ...singleQ, question: "" }] },
       makeContext(),
     );
     expect(result.isError).toBe(true);
@@ -254,18 +264,6 @@ describe("AskQuestionTool.execute", () => {
 // ── Batched input ───────────────────────────────────────────────────
 
 describe("AskQuestionTool batched input", () => {
-  test("normalizes legacy flat input into a one-element batch forwarded to the prompter", async () => {
-    setNextResult(singleCompleted({ decision: "option", optionId: "a" }));
-
-    const result = await askQuestionTool.execute(validInput, makeContext());
-
-    expect(calls).toHaveLength(1);
-    expect(calls[0]?.questions).toHaveLength(1);
-    expect(calls[0]?.questions[0]?.question).toBe(validInput.question);
-    expect(calls[0]?.questions[0]?.options).toEqual(validInput.options);
-    expect(result.isError).toBe(false);
-  });
-
   test("accepts a single-element `questions` batch", async () => {
     setNextResult(singleCompleted({ decision: "option", optionId: "a" }));
 
@@ -454,7 +452,7 @@ describe("AskQuestionTool batched input", () => {
     expect(calls).toHaveLength(0);
   });
 
-  test("rejects input missing both `questions` and flat fields", async () => {
+  test("rejects input missing `questions`", async () => {
     setNextResult(singleCompleted({ decision: "option", optionId: "a" }));
 
     const result = await askQuestionTool.execute({}, makeContext());
@@ -464,11 +462,17 @@ describe("AskQuestionTool batched input", () => {
     expect(calls).toHaveLength(0);
   });
 
-  test("rejects legacy `question` without `options`", async () => {
+  test("rejects the dropped flat single-question shape", async () => {
     setNextResult(singleCompleted({ decision: "option", optionId: "a" }));
 
     const result = await askQuestionTool.execute(
-      { question: "Hi?" },
+      {
+        question: "Hi?",
+        options: [
+          { id: "a", label: "A" },
+          { id: "b", label: "B" },
+        ],
+      },
       makeContext(),
     );
 
@@ -479,7 +483,7 @@ describe("AskQuestionTool batched input", () => {
 });
 
 describe("askQuestionTool definition (batched schema)", () => {
-  test("exposes `questions[]` shape, keeps legacy fields, omits per-question id", () => {
+  test("exposes `questions[]` shape, requires it, and drops the flat fields", () => {
     const def = askQuestionTool;
     const schema = def.input_schema as unknown as {
       properties: Record<
@@ -517,8 +521,12 @@ describe("askQuestionTool definition (batched schema)", () => {
 
     expect(questions?.items?.required).toEqual(["question", "options"]);
 
-    // Legacy fields still present.
-    expect(schema.properties.question).toBeDefined();
-    expect(schema.properties.options).toBeDefined();
+    // `questions` is the only top-level input now.
+    expect(schema.required).toEqual(["questions"]);
+    expect(Object.keys(schema.properties)).toEqual(["questions"]);
+
+    // The legacy flat fields are gone.
+    expect(schema.properties.question).toBeUndefined();
+    expect(schema.properties.options).toBeUndefined();
   });
 });

--- a/assistant/src/tools/ask-question/ask-question-tool.ts
+++ b/assistant/src/tools/ask-question/ask-question-tool.ts
@@ -40,35 +40,16 @@ const SingleQuestionSchema = z.object({
 // input with ≥6 entries is rejected with a clear Zod error.
 const MAX_QUESTIONS_PER_BATCH = 5;
 
-// Both the new batched shape (`questions[]`) and the legacy flat shape are
-// accepted. `execute()` normalizes legacy callers into a one-element
-// `questions` array before forwarding to the prompter.
-const InputSchema = z
-  .object({
-    questions: z
-      .array(SingleQuestionSchema)
-      .min(1)
-      .max(MAX_QUESTIONS_PER_BATCH, {
-        message: `At most ${MAX_QUESTIONS_PER_BATCH} questions per batch; split into multiple turns if you need more.`,
-      })
-      .optional(),
-    // Legacy flat fields. Optional so batched callers can omit them; when
-    // present and `questions` is absent, they are normalized into a
-    // one-element batch in `execute()`.
-    question: z.string().min(1).optional(),
-    description: z.string().optional(),
-    options: z.array(OptionSchema).min(2).max(4).optional(),
-    freeTextPlaceholder: z.string().optional(),
-  })
-  .refine(
-    (v) =>
-      v.questions !== undefined ||
-      (v.question !== undefined && v.options !== undefined),
-    {
-      message:
-        "Provide `questions` (preferred) or the legacy flat fields (`question` + `options`).",
-    },
-  );
+// Callers pass a (possibly single-element) batch of questions. `execute()`
+// forwards them straight to the prompter.
+const InputSchema = z.object({
+  questions: z
+    .array(SingleQuestionSchema)
+    .min(1)
+    .max(MAX_QUESTIONS_PER_BATCH, {
+      message: `At most ${MAX_QUESTIONS_PER_BATCH} questions per batch; split into multiple turns if you need more.`,
+    }),
+});
 
 export type SingleQuestion = z.infer<typeof SingleQuestionSchema>;
 export type AskQuestionInput = z.infer<typeof InputSchema>;
@@ -111,8 +92,7 @@ const DESCRIPTION = [
   "context shown beneath the label.",
 ].join("\n");
 
-// Shared option-schema fragment used by both the batched `questions[]`
-// shape and the legacy flat `options` field.
+// Option-schema fragment for the items in `questions[].options`.
 const OPTION_ITEMS_SCHEMA = {
   type: "object",
   properties: {
@@ -150,12 +130,11 @@ export const askQuestionTool = {
   input_schema: {
     type: "object",
     properties: {
-      // ── Recommended shape ─────────────────────────────────────
       questions: {
         type: "array",
         minItems: 1,
         maxItems: MAX_QUESTIONS_PER_BATCH,
-        description: `Recommended shape. 1–${MAX_QUESTIONS_PER_BATCH} clarifying questions to ask in a single turn. Use a batch when several independent ambiguities block progress; ask one at a time when they're sequentially dependent. Past ${MAX_QUESTIONS_PER_BATCH} questions you should be implementing, not asking.`,
+        description: `1–${MAX_QUESTIONS_PER_BATCH} clarifying questions to ask in a single turn. Use a batch when several independent ambiguities block progress; ask one at a time when they're sequentially dependent. Past ${MAX_QUESTIONS_PER_BATCH} questions you should be implementing, not asking.`,
         items: {
           type: "object",
           properties: {
@@ -185,35 +164,8 @@ export const askQuestionTool = {
           required: ["question", "options"],
         },
       },
-      // ── Legacy single-question fields ─────────────────────────
-      // Kept optional so existing prompt caches and any single-question
-      // callers continue to work. New callers should use `questions`.
-      question: {
-        type: "string",
-        description:
-          "Legacy: the single clarifying question. Prefer `questions[]` for new code.",
-      },
-      description: {
-        type: "string",
-        description:
-          "Legacy: optional one-line context shown beneath the question. Prefer `questions[].description`.",
-      },
-      options: {
-        type: "array",
-        minItems: 2,
-        maxItems: 4,
-        description:
-          "Legacy: 2–4 structured options. Prefer `questions[].options`. The UI always appends a free-text fallback slot, so do not include a 'something else' option here.",
-        items: OPTION_ITEMS_SCHEMA,
-      },
-      freeTextPlaceholder: {
-        type: "string",
-        description:
-          "Legacy: optional placeholder text for the free-text fallback input. Prefer `questions[].freeTextPlaceholder`.",
-      },
     },
-    // No top-level `required` — caller must supply either `questions`
-    // or the legacy flat trio (`question` + `options`). Enforced in Zod.
+    required: ["questions"],
   },
 
   async execute(
@@ -228,18 +180,7 @@ export const askQuestionTool = {
       };
     }
 
-    // Normalize legacy flat input into a one-element `questions` batch so
-    // downstream code only has to deal with the batched shape. The refine
-    // above guarantees `question` and `options` are present whenever
-    // `questions` is absent.
-    const questions: SingleQuestion[] = parsed.data.questions ?? [
-      {
-        question: parsed.data.question!,
-        description: parsed.data.description,
-        options: parsed.data.options!,
-        freeTextPlaceholder: parsed.data.freeTextPlaceholder,
-      },
-    ];
+    const questions: SingleQuestion[] = parsed.data.questions;
 
     const prompter = new QuestionPrompter();
     const result = await prompter.prompt({


### PR DESCRIPTION
## Why

The `ask_question` tool definition is one of the heaviest in the core tool catalog (~853 tokens, second only to `ui_show`), and most of that weight lives in `input_schema`. The tool accepted **two** input shapes:

- the batched `questions[]` shape (current), and
- a legacy flat `question` / `description` / `options` / `freeTextPlaceholder` shape, which `execute()` normalized into a one-element batch.

The flat shape roughly **duplicated** the schema surfaced to the model — every field appeared once nested under `questions[].items` and again at the top level — for no functional gain now that callers use the batched shape. Per this service's own conventions, the CLI and daemon ship and upgrade together (no version skew), so there's no flat-param caller left to keep a compat shim alive for.

## What changed

- Removed the legacy flat fields from the Zod `InputSchema` (and dropped the `.refine()` that allowed either shape). `questions` is now required.
- Removed the legacy properties from the wire `input_schema` and added `required: ["questions"]`.
- Simplified `execute()` — the normalization fallback is gone; `questions` is always present.
- Updated comments that referenced the legacy shape.
- Rewrote the tests for the batched-only shape (still covers single/multi-question batches, all formatting paths, validation bounds, and now asserts the flat fields are *absent* and the dropped flat shape is rejected).

## Impact

`ask_question` definition shrinks **~853 → ~640 tokens** (`input_schema` 482 → 269). Format, lint, typecheck, and the 22 tool tests all pass.

> Note: the broader goal was to get under 400 tokens. Removing the legacy fields gets the schema most of the way there; the remaining ~640 is split between the schema (269) and the description (340). Landing under 400 would also need a description trim — happy to do that as a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sq9PBQyxSZWP4L8RsE48zG)_