### PR TITLE
fix(question): rehydrate pending ask_question card on history load

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -16408,6 +16408,48 @@ paths:
                                 required:
                                   - requestId
                                 additionalProperties: false
+                              pendingQuestion:
+                                type: object
+                                properties:
+                                  requestId:
+                                    type: string
+                                  entries:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        id:
+                                          type: string
+                                        question:
+                                          type: string
+                                        description:
+                                          type: string
+                                        options:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              id:
+                                                type: string
+                                              label:
+                                                type: string
+                                              description:
+                                                type: string
+                                            required:
+                                              - id
+                                              - label
+                                            additionalProperties: false
+                                        freeTextPlaceholder:
+                                          type: string
+                                      required:
+                                        - id
+                                        - question
+                                        - options
+                                      additionalProperties: false
+                                required:
+                                  - requestId
+                                  - entries
+                                additionalProperties: false
                             required:
                               - name
                               - input
@@ -16795,6 +16837,48 @@ paths:
                                             type: boolean
                                         required:
                                           - requestId
+                                        additionalProperties: false
+                                      pendingQuestion:
+                                        type: object
+                                        properties:
+                                          requestId:
+                                            type: string
+                                          entries:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                id:
+                                                  type: string
+                                                question:
+                                                  type: string
+                                                description:
+                                                  type: string
+                                                options:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    properties:
+                                                      id:
+                                                        type: string
+                                                      label:
+                                                        type: string
+                                                      description:
+                                                        type: string
+                                                    required:
+                                                      - id
+                                                      - label
+                                                    additionalProperties: false
+                                                freeTextPlaceholder:
+                                                  type: string
+                                              required:
+                                                - id
+                                                - question
+                                                - options
+                                              additionalProperties: false
+                                        required:
+                                          - requestId
+                                          - entries
                                         additionalProperties: false
                                     required:
                                       - name

--- a/assistant/src/api/responses/conversation-message.ts
+++ b/assistant/src/api/responses/conversation-message.ts
@@ -30,6 +30,7 @@ import {
   DirectoryScopeOptionSchema,
   ScopeOptionSchema,
 } from "../events/confirmation-request.js";
+import { QuestionEntrySchema } from "../events/question-request.js";
 import { ToolActivityMetadataSchema } from "../events/tool-result.js";
 
 // ---------------------------------------------------------------------------
@@ -103,6 +104,25 @@ export const PendingToolConfirmationSchema = z.object({
 export type PendingToolConfirmation = z.infer<
   typeof PendingToolConfirmationSchema
 >;
+
+/**
+ * In-flight `ask_question` prompt awaiting a user answer, mirrored onto the
+ * history tool call that raised it so a cold reconnect (or a conversation
+ * reopened after the event-buffer window has elapsed) can restore the inline
+ * question card without replaying the live `question_request` SSE event.
+ *
+ * Stamped at render time from the in-memory `pending-interactions` registry
+ * (the authoritative store of unresolved prompts) — not persisted to the
+ * database, so it appears only while the prompt is genuinely outstanding and
+ * disappears once the interaction resolves. `entries` mirrors the
+ * `question_request` event's `questions[]`, so both paths hydrate the same
+ * client state.
+ */
+export const PendingToolQuestionSchema = z.object({
+  requestId: z.string(),
+  entries: z.array(QuestionEntrySchema),
+});
+export type PendingToolQuestion = z.infer<typeof PendingToolQuestionSchema>;
 
 /**
  * Closed set of confirmation outcomes recorded for a tool call. The daemon
@@ -190,6 +210,12 @@ export const ConversationMessageToolCallSchema = z.object({
    * Guaranteed present for outstanding prompts as of daemon v0.8.8.
    */
   pendingConfirmation: PendingToolConfirmationSchema.optional(),
+  /**
+   * In-flight `ask_question` prompt, present only while the tool call is
+   * awaiting a user answer (read from the `pending-interactions` registry at
+   * render time). Lets a cold reconnect restore the inline question card.
+   */
+  pendingQuestion: PendingToolQuestionSchema.optional(),
 });
 export type ConversationMessageToolCall = z.infer<
   typeof ConversationMessageToolCallSchema

--- a/assistant/src/permissions/question-prompter.test.ts
+++ b/assistant/src/permissions/question-prompter.test.ts
@@ -48,6 +48,8 @@ interface MockInteraction {
     orderedIds: string[];
     optionsById: Record<string, string[]>;
   };
+  toolUseId?: string;
+  questionDetails?: { entries: Array<{ id: string; question: string }> };
 }
 const _piStore = new Map<string, MockInteraction>();
 mock.module("../runtime/pending-interactions.js", () => ({
@@ -203,6 +205,31 @@ describe("QuestionPrompter", () => {
       overall: "completed",
     });
     expect(_piStore.has(req.requestId)).toBe(false);
+  });
+
+  test("persists the full question entries on the interaction for rehydration", async () => {
+    // GIVEN a batched prompt with a tool-use id
+    const { prompter, sent } = makePrompter();
+
+    const promise = prompter.prompt({
+      ...threeQuestionParams,
+      toolUseId: "tool-q",
+    });
+    const req = sent[0] as QuestionRequestEvent;
+
+    // THEN the registered interaction carries the full entries (not just the
+    // id maps in `metadata`) so a history-load render can rehydrate the card
+    const interaction = _piStore.get(req.requestId);
+    expect(interaction?.toolUseId).toBe("tool-q");
+    expect(interaction?.questionDetails?.entries).toHaveLength(3);
+    expect(interaction?.questionDetails?.entries).toEqual(req.questions);
+
+    resolveBatch(req.requestId, [
+      { questionId: "q1", kind: "option", optionId: "a" },
+      { questionId: "q2", kind: "option", optionId: "x" },
+      { questionId: "q3", kind: "skip" },
+    ]);
+    await promise;
   });
 
   test("free-text resolution", async () => {

--- a/assistant/src/permissions/question-prompter.ts
+++ b/assistant/src/permissions/question-prompter.ts
@@ -269,6 +269,10 @@ export class QuestionPrompter {
         timer,
         toolUseId,
         metadata: { orderedIds, optionsById } satisfies QuestionBatchMetadata,
+        // Persist the full entries (not just the id maps in `metadata`) so a
+        // history-load render can stamp this outstanding prompt back onto its
+        // tool call and rehydrate the question card after a reconnect.
+        questionDetails: { entries },
       });
 
       // Populate both shapes on the wire: `questions[]` is the canonical

--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -19,6 +19,7 @@
  */
 
 import type { InteractionResolutionState } from "../api/events/interaction-resolved.js";
+import type { QuestionEntry } from "../api/events/question-request.js";
 import type { UserDecision } from "../permissions/types.js";
 import { getLogger } from "../util/logger.js";
 import { broadcastMessage } from "./assistant-event-hub.js";
@@ -50,6 +51,18 @@ export interface ConfirmationDetails {
   }>;
 }
 
+/**
+ * Full batched question payload carried on a pending `question` interaction, so
+ * a history-load render can stamp the outstanding prompt back onto its tool
+ * call and rehydrate the question card on a cold reconnect. Mirrors the
+ * `question_request` event's `questions[]` — `metadata` only retains the
+ * `orderedIds`/`optionsById` the response route needs to validate submissions,
+ * which is insufficient to reconstruct the card.
+ */
+export interface QuestionDetails {
+  entries: QuestionEntry[];
+}
+
 export interface PendingInteraction {
   /**
    * Owning conversation, when the interaction was raised inside one. Absent
@@ -69,6 +82,8 @@ export interface PendingInteraction {
     | "host_transfer"
     | "acp_confirmation";
   confirmationDetails?: ConfirmationDetails;
+  /** For a pending `question`: the full batched entries, so a history-load render can rehydrate the question card. */
+  questionDetails?: QuestionDetails;
   /** For ACP permissions: resolves directly without a Conversation object. */
   directResolve?: (decision: UserDecision) => void;
   /** When set, the host_bash request should be routed to this specific client. */

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -151,6 +151,10 @@ import {
   collectPendingConfirmations,
   enrichToolCallsWithConfirmation,
 } from "./tool-call-confirmation-enrichment.js";
+import {
+  collectPendingQuestions,
+  enrichToolCallsWithQuestion,
+} from "./tool-call-question-enrichment.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 import { RouteResponse } from "./types.js";
 
@@ -822,6 +826,7 @@ export function handleListMessages({
   const pendingConfirmations = collectPendingConfirmations(
     resolvedConversationId,
   );
+  const pendingQuestions = collectPendingQuestions(resolvedConversationId);
 
   const messages: RuntimeMessagePayload[] = parsed.map((m) => {
     const mergedMessageIds = m.id ? (mergedIdMap.get(m.id) ?? []) : [];
@@ -885,10 +890,13 @@ export function handleListMessages({
       m.id ?? undefined,
     );
 
-    const toolCalls = enrichToolCallsWithConfirmation(rendered.toolCalls, {
-      workspaceDir,
-      pendingConfirmations,
-    });
+    const toolCalls = enrichToolCallsWithQuestion(
+      enrichToolCallsWithConfirmation(rendered.toolCalls, {
+        workspaceDir,
+        pendingConfirmations,
+      }),
+      { pendingQuestions },
+    );
 
     // Strip <no_response/> markers from assistant messages so web/API clients
     // never see the raw sentinel. Only assistant messages produce it; user

--- a/assistant/src/runtime/routes/tool-call-question-enrichment.test.ts
+++ b/assistant/src/runtime/routes/tool-call-question-enrichment.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for render-time enrichment of history tool calls with the in-flight
+ * `ask_question` prompt read from the pending-interactions registry.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+
+import type { QuestionEntry } from "../../api/events/question-request.js";
+import type { ConversationMessageToolCall } from "../../api/responses/conversation-message.js";
+import { clear, register } from "../pending-interactions.js";
+import {
+  collectPendingQuestions,
+  enrichToolCallsWithQuestion,
+} from "./tool-call-question-enrichment.js";
+
+function toolCall(
+  overrides: Partial<ConversationMessageToolCall>,
+): ConversationMessageToolCall {
+  return {
+    name: "ask_question",
+    input: {},
+    ...overrides,
+  };
+}
+
+const ENTRIES: QuestionEntry[] = [
+  {
+    id: "q1",
+    question: "What's the email about?",
+    options: [
+      { id: "a", label: "iOS app is live" },
+      { id: "b", label: "Open source" },
+    ],
+  },
+];
+
+afterEach(() => {
+  clear();
+});
+
+describe("collectPendingQuestions", () => {
+  test("keys question interactions by toolUseId", () => {
+    // GIVEN a question interaction registered for a conversation with a
+    // tool-use id and the full question entries
+    register("req-1", {
+      conversationId: "conv-1",
+      kind: "question",
+      toolUseId: "tool-abc",
+      questionDetails: { entries: ENTRIES },
+    });
+
+    // WHEN we collect the conversation's pending questions
+    const byToolUseId = collectPendingQuestions("conv-1");
+
+    // THEN the interaction is keyed by its tool-use id
+    expect(byToolUseId.size).toBe(1);
+    expect(byToolUseId.get("tool-abc")?.requestId).toBe("req-1");
+    expect(byToolUseId.get("tool-abc")?.entries).toEqual(ENTRIES);
+  });
+
+  test("ignores interactions lacking a toolUseId, details, or the question kind", () => {
+    // GIVEN a question without a toolUseId, a question without details, AND a
+    // non-question interaction in the same conversation
+    register("req-no-tool", {
+      conversationId: "conv-2",
+      kind: "question",
+      questionDetails: { entries: ENTRIES },
+    });
+    register("req-no-details", {
+      conversationId: "conv-2",
+      kind: "question",
+      toolUseId: "tool-no-details",
+    });
+    register("req-confirmation", {
+      conversationId: "conv-2",
+      kind: "confirmation",
+      toolUseId: "tool-xyz",
+      confirmationDetails: {
+        toolName: "file_read",
+        input: {},
+        riskLevel: "low",
+        allowlistOptions: [],
+        scopeOptions: [],
+      },
+    });
+
+    // WHEN we collect the conversation's pending questions
+    const byToolUseId = collectPendingQuestions("conv-2");
+
+    // THEN none is included
+    expect(byToolUseId.size).toBe(0);
+  });
+});
+
+describe("enrichToolCallsWithQuestion", () => {
+  test("stamps the pending question when the registry has a match", () => {
+    // GIVEN a registry entry matching the tool call by id
+    register("req-1", {
+      conversationId: "conv-fixture",
+      kind: "question",
+      toolUseId: "tool-abc",
+      questionDetails: { entries: ENTRIES },
+    });
+    const pendingQuestions = collectPendingQuestions("conv-fixture");
+    const calls = [toolCall({ id: "tool-abc" })];
+
+    // WHEN we enrich it
+    const [enriched] = enrichToolCallsWithQuestion(calls, { pendingQuestions });
+
+    // THEN the outstanding prompt is projected onto the tool call so a cold
+    // reconnect can rehydrate the question card
+    expect(enriched?.pendingQuestion?.requestId).toBe("req-1");
+    expect(enriched?.pendingQuestion?.entries).toEqual(ENTRIES);
+  });
+
+  test("leaves tool calls without a match untouched (same reference)", () => {
+    // GIVEN a tool call with no matching registry entry
+    const original = toolCall({ id: "tool-unmatched" });
+    register("req-other", {
+      conversationId: "conv-fixture",
+      kind: "question",
+      toolUseId: "tool-abc",
+      questionDetails: { entries: ENTRIES },
+    });
+
+    // WHEN we enrich it
+    const [enriched] = enrichToolCallsWithQuestion([original], {
+      pendingQuestions: collectPendingQuestions("conv-fixture"),
+    });
+
+    // THEN the tool call is returned unchanged
+    expect(enriched).toBe(original);
+  });
+
+  test("returns the input array untouched when there are no pending questions", () => {
+    // GIVEN tool calls and an empty registry
+    const calls = [toolCall({ id: "tool-abc" })];
+
+    // WHEN we enrich with an empty lookup
+    const enriched = enrichToolCallsWithQuestion(calls, {
+      pendingQuestions: new Map(),
+    });
+
+    // THEN the original array is returned
+    expect(enriched).toBe(calls);
+  });
+});

--- a/assistant/src/runtime/routes/tool-call-question-enrichment.ts
+++ b/assistant/src/runtime/routes/tool-call-question-enrichment.ts
@@ -1,0 +1,66 @@
+/**
+ * Render-time enrichment of history tool calls with in-flight question context.
+ *
+ * `pendingQuestion` — the outstanding `ask_question` prompt for a tool call
+ * still awaiting a user answer — is read from the in-memory
+ * `pending-interactions` registry (the authoritative store of unresolved
+ * prompts) and stamped onto its tool call so the web/API clients can restore
+ * the same question card on a cold reconnect (or a history reopen after the
+ * live event buffer has aged out) that the live `question_request` SSE stream
+ * would have produced. It appears only while the prompt is genuinely
+ * outstanding. Mirrors the confirmation enrichment in
+ * `tool-call-confirmation-enrichment.ts`.
+ */
+
+import type { QuestionEntry } from "../../api/events/question-request.js";
+import type { ConversationMessageToolCall } from "../../api/responses/conversation-message.js";
+import { getByConversation } from "../pending-interactions.js";
+
+/** A pending question matched to the tool call it prompts for, keyed by `toolUseId`. */
+interface PendingQuestionMatch {
+  requestId: string;
+  entries: QuestionEntry[];
+}
+
+/**
+ * Build the `toolUseId → pending question` lookup for a conversation from the
+ * registry. Only question interactions that carry both a `toolUseId` and
+ * `questionDetails` can be stamped onto a wire tool call.
+ */
+export function collectPendingQuestions(
+  conversationId: string,
+): Map<string, PendingQuestionMatch> {
+  const byToolUseId = new Map<string, PendingQuestionMatch>();
+  for (const interaction of getByConversation(conversationId)) {
+    if (
+      interaction.kind === "question" &&
+      interaction.questionDetails &&
+      interaction.toolUseId
+    ) {
+      byToolUseId.set(interaction.toolUseId, {
+        requestId: interaction.requestId,
+        entries: interaction.questionDetails.entries,
+      });
+    }
+  }
+  return byToolUseId;
+}
+
+/**
+ * Layer any outstanding `pendingQuestion` onto a message's rendered tool calls.
+ * Returns a new array; tool calls without a match are returned unchanged.
+ */
+export function enrichToolCallsWithQuestion(
+  toolCalls: ConversationMessageToolCall[],
+  opts: { pendingQuestions: ReadonlyMap<string, PendingQuestionMatch> },
+): ConversationMessageToolCall[] {
+  if (opts.pendingQuestions.size === 0) return toolCalls;
+  return toolCalls.map((tc) => {
+    const match = tc.id ? opts.pendingQuestions.get(tc.id) : undefined;
+    if (!match) return tc;
+    return {
+      ...tc,
+      pendingQuestion: { requestId: match.requestId, entries: match.entries },
+    };
+  });
+}

--- a/clients/web/src/domains/chat/hooks/use-conversation-history.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history.ts
@@ -21,7 +21,10 @@ import { startTransition, useEffect } from "react";
 
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { reconcileMessagesWithSeq } from "@/domains/chat/utils/reconcile-with-seq";
-import { extractWirePendingConfirmation } from "@/domains/chat/utils/chat";
+import {
+  extractWirePendingConfirmation,
+  extractWirePendingQuestion,
+} from "@/domains/chat/utils/chat";
 import { filterDismissedSurfaces } from "@/domains/chat/utils/dismissed-surfaces-storage";
 import { mapMessageSurfaces } from "@/domains/chat/utils/map-message-surfaces";
 import { recordDiagnostic } from "@/lib/diagnostics";
@@ -234,6 +237,20 @@ export function useConversationHistory({
             wirePendingConfirmation.toolUseId,
           );
         }
+      }
+
+      // Restore an in-flight ask_question prompt the snapshot carries on a tool
+      // call (stamped by the daemon from the pending-interactions registry at
+      // render time). On a cold reconnect — e.g. the live `question_request`
+      // event was broadcast while no SSE client was connected — the prompt
+      // rides the snapshot rather than a replayed event. Skipped when a prompt
+      // is already active so a live in-progress question is never clobbered.
+      const wirePendingQuestion = extractWirePendingQuestion(filteredMessages);
+      if (
+        wirePendingQuestion &&
+        !useInteractionStore.getState().pendingQuestion
+      ) {
+        useInteractionStore.getState().showQuestion(wirePendingQuestion);
       }
     } else {
       recordDiagnostic("history_tq_empty", {

--- a/clients/web/src/domains/chat/utils/chat.test.ts
+++ b/clients/web/src/domains/chat/utils/chat.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   extractWirePendingConfirmation,
+  extractWirePendingQuestion,
   hasAssistantMessage,
   shouldClearFirstMessageGateOnConversationChange,
 } from "@/domains/chat/utils/chat";
@@ -136,6 +137,59 @@ describe("chat utilities", () => {
 
       // WHEN we extract the wire-carried confirmation
       const restored = extractWirePendingConfirmation(messages);
+
+      // THEN there is nothing to restore
+      expect(restored).toBeNull();
+    });
+  });
+
+  describe("extractWirePendingQuestion", () => {
+    test("projects a snapshot-carried question into interaction-store shape", () => {
+      /**
+       * The live `question_request` event can be missed (e.g. broadcast while
+       * no SSE client was connected). On the next history load the daemon
+       * stamps the outstanding prompt onto its tool call; the FE must restore
+       * it to the interaction store so the card finally renders.
+       */
+      // GIVEN a history snapshot whose latest tool call carries a pending question
+      const entries = [
+        {
+          id: "q1",
+          question: "What's the email about?",
+          options: [{ id: "a", label: "iOS app is live" }],
+        },
+      ];
+      const messages = [
+        message("user", "user-1"),
+        assistantWithToolCalls("assistant-1", [
+          {
+            id: "tool-1",
+            name: "ask_question",
+            input: {},
+            pendingQuestion: { requestId: "req-9", entries },
+          },
+        ]),
+      ];
+
+      // WHEN we extract the wire-carried question
+      const restored = extractWirePendingQuestion(messages);
+
+      // THEN the prompt is returned with toolUseId set to the carrying tool call
+      expect(restored?.requestId).toBe("req-9");
+      expect(restored?.entries).toEqual(entries);
+      expect(restored?.toolUseId).toBe("tool-1");
+    });
+
+    test("returns null when no tool call is awaiting an answer", () => {
+      // GIVEN a snapshot whose tool calls carry no pending question
+      const messages = [
+        assistantWithToolCalls("assistant-1", [
+          { id: "tool-1", name: "ask_question", input: {}, result: "answered" },
+        ]),
+      ];
+
+      // WHEN we extract the wire-carried question
+      const restored = extractWirePendingQuestion(messages);
 
       // THEN there is nothing to restore
       expect(restored).toBeNull();

--- a/clients/web/src/domains/chat/utils/chat.ts
+++ b/clients/web/src/domains/chat/utils/chat.ts
@@ -8,6 +8,7 @@ import type {
   AllowlistOption,
   DirectoryScopeOption,
   PendingConfirmationState,
+  PendingQuestionState,
   ScopeOption,
 } from "@/types/interaction-ui-types";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
@@ -317,6 +318,37 @@ export function extractWirePendingConfirmation(
       const tc = msg.toolCalls[ti];
       if (tc?.pendingConfirmation) {
         return { ...tc.pendingConfirmation, toolUseId: tc.id };
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Find the in-flight `ask_question` prompt a history snapshot carries on one
+ * of its tool calls. The daemon stamps `pendingQuestion` from the
+ * pending-interactions registry at render time, so on a cold reconnect (or a
+ * reopen after the live event buffer aged out) the prompt rides the snapshot
+ * rather than a replayed `question_request` event. Returns the prompt
+ * projected into the interaction-store shape — with `toolUseId` set to the
+ * carrying tool call — or null when no tool call is awaiting an answer. Scans
+ * latest-first since the outstanding prompt is on the most recent tool call.
+ * Mirrors {@link extractWirePendingConfirmation}.
+ */
+export function extractWirePendingQuestion(
+  messages: DisplayMessage[],
+): PendingQuestionState | null {
+  for (let mi = messages.length - 1; mi >= 0; mi--) {
+    const msg = messages[mi];
+    if (!msg?.toolCalls?.length) continue;
+    for (let ti = msg.toolCalls.length - 1; ti >= 0; ti--) {
+      const tc = msg.toolCalls[ti];
+      if (tc?.pendingQuestion) {
+        return {
+          requestId: tc.pendingQuestion.requestId,
+          entries: tc.pendingQuestion.entries,
+          toolUseId: tc.id,
+        };
       }
     }
   }


### PR DESCRIPTION
## Problem

A user reported the `ask_question` UI "timed out" and left them staring at a ~2-minute silent hang — **the inline question card never rendered at all.**

Root cause from the feedback logs: the `question_request` SSE event was broadcast during a ~37s window where the web client's SSE connection had cycled (sse-5 ended `14:21:55.933`, event fired `~14:22:07`, sse-6 connected `14:22:32`). `broadcastMessage()` is fire-and-forget to *currently-open* connections only, so the event reached nobody. And **questions were the one interaction type with no rehydration path** — so once the live event was missed, the card could never appear. The blocked tool then sat until the generic 120s tool-execution timeout fired, surfacing as the silent hang.

This is the same class as the 2026-06-18 "Ask a Question not showing inline UI" report (different trigger: there it was wrong-conversation filtering, here a connection-down window). Both reduce to: questions lack the rehydration that confirmations already have.

## Fix

Give questions the **exact** render-time rehydration confirmations use — no new mechanism:

| Confirmation (existing) | Question (added) |
|---|---|
| `prompter` stores full `confirmationDetails` | `question-prompter` now also persists full `entries` (registry previously kept only `orderedIds`/`optionsById`, which can't reconstruct the card) |
| `collectPendingConfirmations` | `collectPendingQuestions` |
| `enrichToolCallsWithConfirmation` stamps `pendingConfirmation` in the conversation-load payload | `enrichToolCallsWithQuestion` stamps `pendingQuestion` |
| `extractWirePendingConfirmation` → `showConfirmation` on history load | `extractWirePendingQuestion` → `showQuestion` (skipped when a live prompt is active) |

The card now restores on the next conversation load / reconnect regardless of how the live event was missed.

## Scope notes

- Uses the source `@vellumai/assistant-api` tool-call schema, **not** the generated daemon SDK — so no OpenAPI regeneration needed.
- This is the load-bearing path (history-snapshot rehydration). A secondary belt — adding `pendingQuestion` to the `GET /v1/pending-interactions` endpoint, which confirmations also populate — is a small follow-up that *does* require OpenAPI regen; left out to keep this diff focused.
- Not addressed here (separate, secondary): the 120s generic tool-execution timeout also kills `ask_question` before its intended 300s human-response window. Worth a follow-up to exempt human-in-the-loop tools, but rehydration is what actually makes the card show up.

## Testing

- `tool-call-question-enrichment.test.ts` (new, mirrors the confirmation enrichment test) — 5 pass
- `question-prompter.test.ts` — added a regression asserting full `entries` are persisted on the interaction
- `chat.test.ts` — added `extractWirePendingQuestion` coverage
- Web typecheck clean; daemon changed files typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)