### PR TITLE
feat(schedules): support creating script-mode schedules via CLI

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -21299,7 +21299,7 @@ paths:
     post:
       operationId: schedules_post
       summary: Create schedule
-      description: Create a new recurring schedule. Currently restricted to mode='execute'.
+      description: Create a new recurring schedule in 'execute', 'script', or 'workflow' mode.
       tags:
         - schedules
       requestBody:
@@ -21320,9 +21320,17 @@ paths:
                   description: Cron or RRULE expression
                 message:
                   type: string
-                  description:
-                    Message body to execute on each fire. Required for execute mode; ignored for workflow mode (which triggers
-                    workflowName/workflowArgs).
+                  description: Message body to execute on each fire. Required for execute mode; ignored for script/workflow modes.
+                script:
+                  anyOf:
+                    - type: string
+                    - type: "null"
+                  description: Shell command run on each fire (no LLM). Required when mode='script'.
+                timeoutMs:
+                  anyOf:
+                    - type: number
+                    - type: "null"
+                  description: Script-mode execution timeout in ms; omitted or null = default.
                 timezone:
                   anyOf:
                     - type: string
@@ -21333,7 +21341,7 @@ paths:
                   description: Whether the schedule starts active (default true)
                 mode:
                   type: string
-                  description: "'execute' (default) or 'workflow' (flag-gated)"
+                  description: "'execute' (default), 'script', or 'workflow' (flag-gated)"
                 workflowName:
                   type: string
                   description: Saved workflow to trigger (required for workflow mode)

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -1231,16 +1231,60 @@ describe("POST /schedules — create", () => {
     expect(job.description).toBe("Description fallback");
   });
 
-  test("rejects modes other than execute/workflow", () => {
+  test("rejects modes other than execute/script/workflow", () => {
+    for (const mode of ["notify", "wake"]) {
+      expect(() =>
+        postCreate({
+          name: "x",
+          description: "Run the thing",
+          expression: "* * * * *",
+          message: "hi",
+          mode,
+        }),
+      ).toThrow("Only 'execute', 'script', and 'workflow' modes are supported");
+    }
+  });
+
+  test("creates a script schedule with a timeout and no message", () => {
+    const result = postCreate({
+      name: "Disk check",
+      description: "Logs disk usage",
+      expression: "*/15 * * * *",
+      mode: "script",
+      script: "  df -h /  ",
+      timeoutMs: 5000,
+    });
+    expect(result.schedules).toHaveLength(1);
+    const job = listSchedules()[0];
+    expect(job.mode).toBe("script");
+    expect(job.script).toBe("df -h /");
+    expect(job.message).toBe("");
+    expect(job.timeoutMs).toBe(5000);
+    expect(job.expression).toBe("*/15 * * * *");
+  });
+
+  test("rejects a script schedule with no script", () => {
     expect(() =>
       postCreate({
         name: "x",
         description: "Run the thing",
         expression: "* * * * *",
-        message: "hi",
-        mode: "notify",
+        mode: "script",
       }),
-    ).toThrow("Only 'execute' and 'workflow' modes are supported");
+    ).toThrow("script is required for script-mode schedules");
+  });
+
+  test("rejects an out-of-range script timeout", () => {
+    expect(() =>
+      postCreate({
+        name: "x",
+        description: "Run the thing",
+        expression: "* * * * *",
+        mode: "script",
+        script: "echo hi",
+        timeoutMs: 1,
+      }),
+    ).toThrow();
   });
 
   test("rejects an unparseable expression", () => {

--- a/assistant/src/cli/commands/__tests__/schedules.test.ts
+++ b/assistant/src/cli/commands/__tests__/schedules.test.ts
@@ -748,6 +748,123 @@ describe("schedules create", () => {
     expect(exitFromIpcResultCalls).toEqual([mockIpcResult]);
     expect(errorLines).toEqual([]);
   });
+
+  test("creates a script schedule with --mode script and --timeout-ms", async () => {
+    mockIpcResult = { ok: true, result: { schedules: [] } };
+
+    const { exitCode } = await runCommand([
+      "schedules",
+      "create",
+      "Disk check",
+      "--mode",
+      "script",
+      "--expression",
+      "*/15 * * * *",
+      "--description",
+      "Logs disk usage",
+      "--script",
+      "df -h /",
+      "--timeout-ms",
+      "5000",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(ipcCalls).toEqual([
+      {
+        method: "createSchedule",
+        params: {
+          body: {
+            name: "Disk check",
+            expression: "*/15 * * * *",
+            description: "Logs disk usage",
+            enabled: true,
+            mode: "script",
+            script: "df -h /",
+            timeoutMs: 5000,
+          },
+        },
+      },
+    ]);
+    expect(logLines).toEqual(["Created schedule: Disk check"]);
+  });
+
+  test("requires --script for script mode", async () => {
+    const { exitCode } = await runCommand([
+      "schedules",
+      "create",
+      "Disk check",
+      "--mode",
+      "script",
+      "--expression",
+      "*/15 * * * *",
+      "--description",
+      "Logs disk usage",
+    ]);
+
+    expect(exitCode).not.toBe(0);
+    expect(ipcCalls).toEqual([]);
+    expect(errorLines).toEqual([
+      "--script is required for script-mode schedules",
+    ]);
+  });
+
+  test("rejects --script without --mode script", async () => {
+    const { exitCode } = await runCommand([
+      "schedules",
+      "create",
+      "Heartbeat",
+      "--expression",
+      "*/30 * * * *",
+      "--description",
+      "Checks service heartbeat",
+      "--message",
+      "run heartbeat",
+      "--script",
+      "df -h /",
+    ]);
+
+    expect(exitCode).not.toBe(0);
+    expect(ipcCalls).toEqual([]);
+  });
+
+  test("requires --message for execute mode", async () => {
+    const { exitCode } = await runCommand([
+      "schedules",
+      "create",
+      "Heartbeat",
+      "--expression",
+      "*/30 * * * *",
+      "--description",
+      "Checks service heartbeat",
+    ]);
+
+    expect(exitCode).not.toBe(0);
+    expect(ipcCalls).toEqual([]);
+    expect(errorLines).toEqual([
+      "--message is required for execute-mode schedules",
+    ]);
+  });
+
+  test("rejects a non-integer --timeout-ms", async () => {
+    const { exitCode } = await runCommand([
+      "schedules",
+      "create",
+      "Disk check",
+      "--mode",
+      "script",
+      "--expression",
+      "*/15 * * * *",
+      "--description",
+      "Logs disk usage",
+      "--script",
+      "df -h /",
+      "--timeout-ms",
+      "abc",
+    ]);
+
+    expect(exitCode).not.toBe(0);
+    expect(ipcCalls).toEqual([]);
+  });
 });
 
 describe("schedules update", () => {

--- a/assistant/src/cli/commands/schedules.ts
+++ b/assistant/src/cli/commands/schedules.ts
@@ -73,9 +73,9 @@ Schedules are recurring or one-shot jobs run by the assistant.
 
 This namespace exposes full CRUD against the assistant's schedule store:
 create, list, get, update, enable/disable, cancel, delete, plus run history
-and manual one-time execution. One documented exception: 'create' is limited
-to 'execute' mode — notify/script/wake schedules are created via the
-in-assistant schedule_create tool, but can be inspected and updated here.
+and manual one-time execution. 'create' supports 'execute' (default) and
+'script' modes; notify/wake schedules are created via the in-assistant
+schedule_create tool, but can be inspected and updated here.
 
 Examples:
   $ assistant schedules list
@@ -416,9 +416,21 @@ Examples:
           "-d, --description <text>",
           "Authored description explaining what the schedule is for",
         )
-        .requiredOption(
+        .option(
+          "--mode <mode>",
+          "Schedule mode: 'execute' (default, sends --message) or 'script' (runs --script, no LLM)",
+        )
+        .option(
           "-m, --message <text>",
-          "Message body sent to the assistant on each fire",
+          "Message body sent to the assistant on each fire (required for execute mode)",
+        )
+        .option(
+          "--script <command>",
+          "Shell command run on each fire (required for script mode; runs with no LLM)",
+        )
+        .option(
+          "--timeout-ms <ms>",
+          "Script-mode execution timeout in milliseconds (integer)",
         )
         .option(
           "-t, --timezone <tz>",
@@ -426,7 +438,7 @@ Examples:
         )
         .option(
           "--profile <name>",
-          "Inference profile (llm.profiles key) the schedule's runs use; defaults to the mainAgent model selection when omitted",
+          "Inference profile (llm.profiles key) the schedule's runs use; defaults to the mainAgent model selection when omitted (execute mode only)",
         )
         .option("--no-enabled", "Create the schedule in a disabled state")
         .option("--json", "Machine-readable compact JSON output")
@@ -436,11 +448,14 @@ Examples:
 Options:
   -e, --expression <expr>   Cron (e.g. '*/30 * * * *') or RRULE expression.
   -d, --description <text>  Authored description explaining what the schedule is for.
-  -m, --message <text>      Message body sent on each fire.
+  --mode <mode>             'execute' (default) or 'script'.
+  -m, --message <text>      Message body sent on each fire (execute mode).
+  --script <command>        Shell command run on each fire (script mode).
+  --timeout-ms <ms>         Script-mode execution timeout in milliseconds.
   -t, --timezone <tz>       IANA timezone applied to the expression.
   --profile <name>          Inference profile (llm.profiles key) the schedule's
-                            runs use. When omitted, runs use the default —
-                            the mainAgent call site's model selection.
+                            runs use (execute mode only). When omitted, runs use
+                            the default — the mainAgent call site's model selection.
   --no-enabled              Create the schedule disabled. Defaults to enabled.
   --json                    Output the updated schedule list as compact JSON.
 
@@ -448,15 +463,21 @@ Arguments:
   <name>   Display name for the schedule.
 
 Behavior:
-  Creates a recurring schedule in 'execute' mode. The IPC endpoint is
-  currently locked to execute mode; notify/script/wake schedules remain
-  reachable only through the in-assistant schedule_create LLM tool.
+  Creates a recurring schedule. In 'execute' mode (default) each fire sends
+  --message to the assistant; in 'script' mode each fire runs --script as a
+  shell command with no LLM. notify/wake schedules remain reachable only
+  through the in-assistant schedule_create LLM tool.
 
 Examples:
   $ assistant schedules create "Heartbeat" \\
       --expression '*/30 * * * *' \\
       --description 'Checks service heartbeat every 30 minutes' \\
       --message 'run heartbeat'
+  $ assistant schedules create "Disk check" \\
+      --mode script \\
+      --expression '*/15 * * * *' \\
+      --description 'Logs disk usage every 15 minutes' \\
+      --script 'df -h / >> /tmp/disk.log'
   $ assistant schedules create "Morning summary" \\
       --expression '0 9 * * MON-FRI' \\
       --description 'Summarizes weekday activity' \\
@@ -474,7 +495,10 @@ Examples:
             opts: {
               expression: string;
               description: string;
-              message: string;
+              mode?: string;
+              message?: string;
+              script?: string;
+              timeoutMs?: string;
               timezone?: string;
               profile?: string;
               enabled: boolean;
@@ -482,27 +506,30 @@ Examples:
             },
             cmd: Command,
           ) => {
-            const scheduleName = name.trim();
-            if (!scheduleName) {
-              const error = "name is required";
+            const fail = (error: string) => {
               if (opts.json) {
                 writeOutput(cmd, { ok: false, error });
               } else {
                 log.error(error);
               }
               process.exitCode = 1;
+            };
+
+            const scheduleName = name.trim();
+            if (!scheduleName) {
+              fail("name is required");
               return;
             }
 
             const description = opts.description.trim();
             if (!description) {
-              const error = "description is required";
-              if (opts.json) {
-                writeOutput(cmd, { ok: false, error });
-              } else {
-                log.error(error);
-              }
-              process.exitCode = 1;
+              fail("description is required");
+              return;
+            }
+
+            const mode = (opts.mode ?? "execute").trim();
+            if (mode !== "execute" && mode !== "script") {
+              fail("--mode must be one of: execute, script");
               return;
             }
 
@@ -510,11 +537,62 @@ Examples:
               name: scheduleName,
               expression: opts.expression,
               description,
-              message: opts.message,
               enabled: opts.enabled,
             };
             if (opts.timezone != null) body.timezone = opts.timezone;
-            if (opts.profile != null) body.inferenceProfile = opts.profile;
+
+            if (mode === "script") {
+              const script = opts.script?.trim();
+              if (!script) {
+                fail("--script is required for script-mode schedules");
+                return;
+              }
+              // Script schedules run no LLM, so a message body and inference
+              // profile have no effect — reject rather than silently ignore.
+              if (opts.message != null) {
+                fail(
+                  "--message is not used by script-mode schedules; pass --script instead",
+                );
+                return;
+              }
+              if (opts.profile != null) {
+                fail(
+                  "--profile is not supported for script-mode schedules (scripts run no LLM)",
+                );
+                return;
+              }
+              body.mode = "script";
+              body.script = script;
+              if (opts.timeoutMs != null) {
+                const parsed = Number(opts.timeoutMs);
+                if (!Number.isInteger(parsed)) {
+                  fail(
+                    `--timeout-ms must be an integer, got "${opts.timeoutMs}"`,
+                  );
+                  return;
+                }
+                body.timeoutMs = parsed;
+              }
+            } else {
+              if (!opts.message) {
+                fail("--message is required for execute-mode schedules");
+                return;
+              }
+              if (opts.script != null) {
+                fail(
+                  "--script is only valid for script-mode schedules; pass --mode script",
+                );
+                return;
+              }
+              if (opts.timeoutMs != null) {
+                fail(
+                  "--timeout-ms is only valid for script-mode schedules; pass --mode script",
+                );
+                return;
+              }
+              body.message = opts.message;
+              if (opts.profile != null) body.inferenceProfile = opts.profile;
+            }
 
             const result = await cliIpcCall<ListSchedulesResponse>(
               "createSchedule",

--- a/assistant/src/runtime/routes/schedule-routes.ts
+++ b/assistant/src/runtime/routes/schedule-routes.ts
@@ -269,11 +269,11 @@ function handleCreateSchedule(body: Record<string, unknown>) {
 
   if (!name) throw new BadRequestError("name is required");
   if (!expression) throw new BadRequestError("expression is required");
-  // Workflow-mode runs trigger a saved workflow by name and ignore `job.message`
-  // entirely (see the workflow branch below), so only require a message for the
-  // execute path. Requiring it for workflow mode would force API/UI callers to
+  // Only execute mode sends a message: workflow mode triggers a saved workflow
+  // by name and script mode runs a shell command (see the branches below), so
+  // both ignore `job.message`. Requiring it for them would force callers to
   // pass an unused dummy string.
-  if (mode !== "workflow" && !message) {
+  if (mode === "execute" && !message) {
     throw new BadRequestError("message is required");
   }
   if (description === "") {
@@ -281,11 +281,13 @@ function handleCreateSchedule(body: Record<string, unknown>) {
   }
 
   // The settings UI only exposes execute mode; `workflow` mode is reachable
-  // here (flag-gated) and via the schedule_create LLM tool. All other modes
-  // remain tool-only.
-  if (mode !== "execute" && mode !== "workflow") {
+  // here (flag-gated). `script` mode (LLM-free shell command) is creatable via
+  // this endpoint and the schedule_create LLM tool. notify/wake remain
+  // tool-only because they need channel/conversation targets this path cannot
+  // set.
+  if (mode !== "execute" && mode !== "workflow" && mode !== "script") {
     throw new BadRequestError(
-      "Only 'execute' and 'workflow' modes are supported by this endpoint",
+      "Only 'execute', 'script', and 'workflow' modes are supported by this endpoint",
     );
   }
 
@@ -321,6 +323,42 @@ function handleCreateSchedule(body: Record<string, unknown>) {
         { id: job.id, name: job.name, workflowName },
         "Workflow schedule created",
       );
+    } catch (err) {
+      if (err instanceof Error) throw new BadRequestError(err.message);
+      throw err;
+    }
+    return handleListSchedules({});
+  }
+
+  if (mode === "script") {
+    const script = typeof body.script === "string" ? body.script.trim() : "";
+    if (!script) {
+      throw new BadRequestError("script is required for script-mode schedules");
+    }
+    let timeoutMs: number | undefined;
+    if (body.timeoutMs != null) {
+      if (typeof body.timeoutMs !== "number") {
+        throw new BadRequestError("timeoutMs must be a number or null");
+      }
+      const timeoutError = validateScriptTimeoutMs(body.timeoutMs);
+      if (timeoutError) throw new BadRequestError(timeoutError);
+      timeoutMs = body.timeoutMs;
+    }
+    try {
+      const job = createSchedule({
+        name,
+        description,
+        // Script mode runs `script`, not an LLM message, so message is unused.
+        message: "",
+        mode: "script",
+        script,
+        enabled,
+        timezone,
+        expression: normalized.expression,
+        syntax: normalized.syntax,
+        timeoutMs,
+      });
+      log.info({ id: job.id, name: job.name }, "Script schedule created");
     } catch (err) {
       if (err instanceof Error) throw new BadRequestError(err.message);
       throw err;
@@ -676,7 +714,7 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Create schedule",
     description:
-      "Create a new recurring schedule. Currently restricted to mode='execute'.",
+      "Create a new recurring schedule in 'execute', 'script', or 'workflow' mode.",
     tags: ["schedules"],
     requestBody: z.object({
       name: z.string().describe("Display name"),
@@ -690,7 +728,21 @@ export const ROUTES: RouteDefinition[] = [
       message: z
         .string()
         .describe(
-          "Message body to execute on each fire. Required for execute mode; ignored for workflow mode (which triggers workflowName/workflowArgs).",
+          "Message body to execute on each fire. Required for execute mode; ignored for script/workflow modes.",
+        )
+        .optional(),
+      script: z
+        .string()
+        .nullable()
+        .describe(
+          "Shell command run on each fire (no LLM). Required when mode='script'.",
+        )
+        .optional(),
+      timeoutMs: z
+        .number()
+        .nullable()
+        .describe(
+          "Script-mode execution timeout in ms; omitted or null = default.",
         )
         .optional(),
       timezone: z
@@ -704,7 +756,7 @@ export const ROUTES: RouteDefinition[] = [
         .optional(),
       mode: z
         .string()
-        .describe("'execute' (default) or 'workflow' (flag-gated)")
+        .describe("'execute' (default), 'script', or 'workflow' (flag-gated)")
         .optional(),
       workflowName: z
         .string()

--- a/gateway/src/risk/command-registry.test.ts
+++ b/gateway/src/risk/command-registry.test.ts
@@ -631,6 +631,23 @@ describe("command-registry", () => {
       expect(modeRule).toBeDefined();
       expect(modeRule!.risk).toBe("high");
     });
+
+    test("assistant schedules create escalates to high for script payloads", () => {
+      const createSpec = getAssistantPath("schedules create");
+      expect(createSpec.argRules).toBeDefined();
+
+      const scriptRule = createSpec.argRules!.find((r) =>
+        r.flags?.includes("--script"),
+      );
+      expect(scriptRule).toBeDefined();
+      expect(scriptRule!.risk).toBe("high");
+
+      const modeRule = createSpec.argRules!.find(
+        (r) => r.flags?.includes("--mode") && r.valuePattern === "^script$",
+      );
+      expect(modeRule).toBeDefined();
+      expect(modeRule!.risk).toBe("high");
+    });
   });
 
   // ── sandboxAutoApprove allowlist guard ───────────────────────────────────

--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -676,4 +676,27 @@ scheduleUpdateNode.argRules = scheduleUpdateArgRules;
 // arg parser pairs `--mode script` / `--script <cmd>` correctly.
 scheduleUpdateNode.argSchema = { valueFlags: ["--mode", "--script"] };
 
+// `schedules create` mirrors `schedules update`: medium-risk as a state
+// mutation, but creating a script-mode schedule persists host shell execution
+// for a later schedule fire — classify those as high like `bash`.
+const scheduleCreateArgRules: ArgRule[] = [
+  {
+    id: "assistant-schedules-create:script",
+    flags: ["--script"],
+    risk: "high",
+    reason:
+      "Persists an arbitrary shell command that the schedule executes on fire",
+  },
+  {
+    id: "assistant-schedules-create:mode-script",
+    flags: ["--mode"],
+    valuePattern: "^script$",
+    risk: "high",
+    reason: "Creates a script-mode schedule (host shell execution on fire)",
+  },
+];
+const scheduleCreateNode = getExistingPath(spec, "schedules create");
+scheduleCreateNode.argRules = scheduleCreateArgRules;
+scheduleCreateNode.argSchema = { valueFlags: ["--mode", "--script"] };
+
 export default spec;


### PR DESCRIPTION
## Summary
- Unlock the `createSchedule` route for `mode='script'` (was locked to execute/workflow): validates a non-empty `script` and optional `timeoutMs`, and `message` is now required only for execute mode.
- Add `--mode`, `--script`, and `--timeout-ms` to `assistant schedules create`, with validation that rejects flag misuse (e.g. `--script` without `--mode script`, `--profile`/`--message` in script mode) instead of silently ignoring it.
- notify/wake schedules stay creatable only via the in-assistant `schedule_create` tool — they need channel/conversation targets the CLI can't set.

## Original prompt
Make script-type Schedules creatable from the CLI. The schedules CLI already had full CRUD, but `create` and its IPC route were mode-locked to execute/workflow, so the LLM-free `script` mode — the cheap deterministic path — could only be created via the in-assistant tool. This PR wires script mode through the create route and the `schedules create` command. Scoped to execute+script on the CLI; workflow and retry-tuning flags stay on `update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
