### PR TITLE
feat(ios): register APNs device tokens so reminder push reaches the iOS app (LUM-1159)

### DIFF
--- a/clients/web/src/hooks/use-push-registration.ts
+++ b/clients/web/src/hooks/use-push-registration.ts
@@ -1,0 +1,33 @@
+/**
+ * Lifecycle hook that registers the Capacitor iOS app for APNs remote push.
+ *
+ * When an assistant becomes active, this acquires an APNs device token and
+ * upserts it to the platform so the daemon's `platform` notification channel
+ * can deliver background notifications (reminders fire while the app is
+ * suspended, where the local-notification path cannot reach the device).
+ *
+ * No-ops off native iOS. Token deletion on logout is handled in
+ * `stores/auth-store.ts` (before the session cookie is cleared), not here —
+ * the assistant-id change on logout races session teardown, so the platform
+ * delete must run while the session is still valid.
+ *
+ * References:
+ * - runtime/push-registration.ts — registration + token upsert
+ * - hooks/use-notification-intent-sync.ts — sibling local-notification path
+ */
+
+import { useEffect } from "react";
+
+import { registerForRemotePush } from "@/runtime/push-registration";
+
+/**
+ * Registers for APNs remote push whenever an assistant is active.
+ *
+ * @param assistantId — current assistant; `null` disables registration
+ */
+export function usePushRegistration(assistantId: string | null): void {
+  useEffect(() => {
+    if (!assistantId) return;
+    void registerForRemotePush(assistantId);
+  }, [assistantId]);
+}

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -26,6 +26,7 @@ import { useAssistantResourceSync } from "@/hooks/use-assistant-resource-sync";
 import { useDocumentEditorSync } from "@/hooks/use-document-editor-sync";
 import { useBookmarksSync } from "@/hooks/use-bookmarks-sync";
 import { useNotificationIntentSync } from "@/hooks/use-notification-intent-sync";
+import { usePushRegistration } from "@/hooks/use-push-registration";
 import { useSoundEffects } from "@/hooks/use-sound-effects";
 import { useOnboardingWindowSize } from "@/hooks/use-onboarding-window-size";
 import { useConversationSync } from "@/hooks/use-conversation-sync";
@@ -122,6 +123,7 @@ export function RootLayout() {
   useConversationSync(assistantId, isAssistantActive);
   useFeatureFlagBusSync(assistantId, isAssistantActive);
   useNotificationIntentSync(assistantId);
+  usePushRegistration(assistantId);
   useSoundEffects(assistantId, isAssistantActive);
   useDocumentEditorSync();
   useBookmarksSync();

--- a/clients/web/src/runtime/push-registration.test.ts
+++ b/clients/web/src/runtime/push-registration.test.ts
@@ -1,0 +1,253 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── platform guards ──────────────────────────────────────────────────────────
+//
+// `native-auth` is mocked rather than loaded because its module-load
+// `registerPlugin("NativeAuth")` would fail against the partial
+// `@capacitor/core` mock (mirrors capacitor-app-state.test.ts).
+
+let isNative = true;
+let platform = "ios";
+mock.module("@/runtime/native-auth", () => ({
+  isNativePlatform: () => isNative,
+}));
+mock.module("@capacitor/core", () => ({
+  Capacitor: {
+    isNativePlatform: () => isNative,
+    getPlatform: () => platform,
+  },
+}));
+
+// ── @capacitor/push-notifications (lazy-imported plugin Proxy) ────────────────
+
+type RegistrationHandler = (token: { value: string }) => void;
+type ErrorHandler = (error: { error: string }) => void;
+
+let registrationHandler: RegistrationHandler | null = null;
+let registrationErrorHandler: ErrorHandler | null = null;
+let permissionState: "granted" | "denied" | "prompt" = "granted";
+
+const addListenerMock = mock(
+  async (event: string, handler: RegistrationHandler | ErrorHandler) => {
+    if (event === "registration") {
+      registrationHandler = handler as RegistrationHandler;
+    } else if (event === "registrationError") {
+      registrationErrorHandler = handler as ErrorHandler;
+    }
+    return { remove: async () => {} };
+  },
+);
+const requestPermissionsMock = mock(async () => ({ receive: permissionState }));
+const registerMock = mock(async () => {});
+
+mock.module("@capacitor/push-notifications", () => ({
+  PushNotifications: {
+    addListener: addListenerMock,
+    requestPermissions: requestPermissionsMock,
+    register: registerMock,
+  },
+}));
+
+// ── @capacitor/app (lazy-imported plugin Proxy) ──────────────────────────────
+
+let bundleId = "ai.vocify-inc.vellum-assistant-ios";
+const getInfoMock = mock(async () => ({
+  id: bundleId,
+  name: "Vellum",
+  build: "1",
+  version: "1.0.0",
+}));
+mock.module("@capacitor/app", () => ({
+  App: { getInfo: getInfoMock },
+}));
+
+// ── generated platform SDK ───────────────────────────────────────────────────
+//
+// Capture call args via typed implementations rather than `.mock.calls` so the
+// assertions stay type-safe (the mock's parameter type drives the captured
+// shape).
+
+interface UpsertArg {
+  path: { assistant_id: string };
+  body: {
+    token: string;
+    platform: string;
+    bundle_id: string;
+    apns_environment: string;
+  };
+  throwOnError: boolean;
+}
+interface DeleteArg {
+  path: { assistant_id: string; token: string };
+  query: { bundle_id: string };
+  throwOnError: boolean;
+}
+
+let lastUpsertArg: UpsertArg | null = null;
+let lastDeleteArg: DeleteArg | null = null;
+let upsertError: unknown = undefined;
+
+const upsertMock = mock(async (arg: UpsertArg) => {
+  lastUpsertArg = arg;
+  return { data: {}, error: upsertError };
+});
+const deleteMock = mock(async (arg: DeleteArg) => {
+  lastDeleteArg = arg;
+  return { data: undefined, error: undefined };
+});
+mock.module("@/generated/api/sdk.gen", () => ({
+  assistantsPushTokensUpsert: upsertMock,
+  assistantsPushTokensDelete: deleteMock,
+}));
+
+// ── Sentry capture-error ─────────────────────────────────────────────────────
+
+const captureErrorMock = mock(() => {});
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: captureErrorMock,
+}));
+
+const {
+  isRemotePushSupported,
+  registerForRemotePush,
+  unregisterFromRemotePush,
+  __resetPushRegistrationStateForTests,
+} = await import("@/runtime/push-registration");
+
+// The `registration` handler fires `upsertToken` fire-and-forget, and its
+// dynamic `import("@capacitor/app")` resolves on the macrotask queue — yield to
+// timers (not just microtasks) so the upsert settles before assertions.
+const flushMicrotasks = async (rounds = 10) => {
+  for (let i = 0; i < rounds; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+};
+
+beforeEach(() => {
+  isNative = true;
+  platform = "ios";
+  permissionState = "granted";
+  bundleId = "ai.vocify-inc.vellum-assistant-ios";
+  registrationHandler = null;
+  registrationErrorHandler = null;
+  lastUpsertArg = null;
+  lastDeleteArg = null;
+  upsertError = undefined;
+  addListenerMock.mockClear();
+  requestPermissionsMock.mockClear();
+  registerMock.mockClear();
+  getInfoMock.mockClear();
+  upsertMock.mockClear();
+  deleteMock.mockClear();
+  captureErrorMock.mockClear();
+  __resetPushRegistrationStateForTests();
+});
+
+describe("isRemotePushSupported", () => {
+  test("true on native iOS", () => {
+    expect(isRemotePushSupported()).toBe(true);
+  });
+
+  test("false off native (desktop browser / Electron)", () => {
+    isNative = false;
+    expect(isRemotePushSupported()).toBe(false);
+  });
+
+  test("false on a non-iOS native platform (e.g. android)", () => {
+    platform = "android";
+    expect(isRemotePushSupported()).toBe(false);
+  });
+});
+
+describe("registerForRemotePush", () => {
+  test("no-ops off native iOS — never touches the plugin or SDK", async () => {
+    isNative = false;
+    await registerForRemotePush("assistant-1");
+    await flushMicrotasks();
+
+    expect(requestPermissionsMock).not.toHaveBeenCalled();
+    expect(registerMock).not.toHaveBeenCalled();
+    expect(upsertMock).not.toHaveBeenCalled();
+  });
+
+  test("requests permission, registers, and upserts the token on registration", async () => {
+    await registerForRemotePush("assistant-1");
+
+    expect(requestPermissionsMock).toHaveBeenCalledTimes(1);
+    expect(registerMock).toHaveBeenCalledTimes(1);
+
+    // Simulate iOS delivering the APNs token.
+    registrationHandler?.({ value: "apns-token-abc" });
+    await flushMicrotasks();
+
+    expect(upsertMock).toHaveBeenCalledTimes(1);
+    expect(lastUpsertArg).toEqual({
+      path: { assistant_id: "assistant-1" },
+      body: {
+        token: "apns-token-abc",
+        platform: "ios",
+        bundle_id: "ai.vocify-inc.vellum-assistant-ios",
+        apns_environment: "production",
+      },
+      throwOnError: false,
+    });
+  });
+
+  test("derives the development APNs environment from a .dev bundle id", async () => {
+    bundleId = "ai.vocify-inc.vellum-assistant-ios.dev";
+    await registerForRemotePush("assistant-1");
+    registrationHandler?.({ value: "apns-token-dev" });
+    await flushMicrotasks();
+
+    expect(lastUpsertArg?.body.apns_environment).toBe("development");
+  });
+
+  test("does not register when notification permission is denied", async () => {
+    permissionState = "denied";
+    await registerForRemotePush("assistant-1");
+    await flushMicrotasks();
+
+    expect(registerMock).not.toHaveBeenCalled();
+    expect(upsertMock).not.toHaveBeenCalled();
+  });
+
+  test("reports an upsert error to Sentry instead of throwing", async () => {
+    upsertError = { detail: "boom" };
+    await registerForRemotePush("assistant-1");
+    registrationHandler?.({ value: "apns-token-abc" });
+    await flushMicrotasks();
+
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("registrationError from APNs is reported, not thrown", async () => {
+    await registerForRemotePush("assistant-1");
+    registrationErrorHandler?.({ error: "APNs failed" });
+    await flushMicrotasks();
+
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    expect(upsertMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("unregisterFromRemotePush", () => {
+  test("deletes the last-registered token with bundle-scoped query", async () => {
+    await registerForRemotePush("assistant-1");
+    registrationHandler?.({ value: "apns-token-abc" });
+    await flushMicrotasks();
+
+    await unregisterFromRemotePush();
+
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+    expect(lastDeleteArg).toEqual({
+      path: { assistant_id: "assistant-1", token: "apns-token-abc" },
+      query: { bundle_id: "ai.vocify-inc.vellum-assistant-ios" },
+      throwOnError: false,
+    });
+  });
+
+  test("no-ops when no token was registered", async () => {
+    await unregisterFromRemotePush();
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/runtime/push-registration.test.ts
+++ b/clients/web/src/runtime/push-registration.test.ts
@@ -86,14 +86,19 @@ interface DeleteArg {
 let lastUpsertArg: UpsertArg | null = null;
 let lastDeleteArg: DeleteArg | null = null;
 let upsertError: unknown = undefined;
+let deleteError: unknown = undefined;
+// When set, the upsert blocks on this gate so a test can interleave logout
+// with an in-flight upsert.
+let upsertGate: Promise<void> | null = null;
 
 const upsertMock = mock(async (arg: UpsertArg) => {
+  if (upsertGate) await upsertGate;
   lastUpsertArg = arg;
   return { data: {}, error: upsertError };
 });
 const deleteMock = mock(async (arg: DeleteArg) => {
   lastDeleteArg = arg;
-  return { data: undefined, error: undefined };
+  return { data: undefined, error: deleteError };
 });
 mock.module("@/generated/api/sdk.gen", () => ({
   assistantsPushTokensUpsert: upsertMock,
@@ -133,6 +138,8 @@ beforeEach(() => {
   lastUpsertArg = null;
   lastDeleteArg = null;
   upsertError = undefined;
+  deleteError = undefined;
+  upsertGate = null;
   addListenerMock.mockClear();
   requestPermissionsMock.mockClear();
   registerMock.mockClear();
@@ -267,6 +274,41 @@ describe("unregisterFromRemotePush", () => {
       query: { bundle_id: "ai.vocify-inc.vellum-assistant-ios" },
       throwOnError: false,
     });
+  });
+
+  test("waits for an in-flight upsert, then deletes the freshly-registered token", async () => {
+    // Block the upsert so we can interleave logout while it is still in flight.
+    let releaseUpsert!: () => void;
+    upsertGate = new Promise<void>((resolve) => {
+      releaseUpsert = resolve;
+    });
+
+    await registerForRemotePush("assistant-1");
+    // iOS delivers the token; the upsert starts but hasn't resolved yet.
+    registrationHandler?.({ value: "race-token" });
+    await Promise.resolve();
+
+    // User logs out mid-upsert. unregister must await the in-flight upsert
+    // rather than concluding there is nothing to delete.
+    const unregisterPromise = unregisterFromRemotePush();
+    releaseUpsert();
+    await unregisterPromise;
+
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+    expect(lastDeleteArg?.path.token).toBe("race-token");
+  });
+
+  test("reports a failed delete to Sentry instead of silently dropping it", async () => {
+    deleteError = { detail: "server error" };
+    await registerForRemotePush("assistant-1");
+    registrationHandler?.({ value: "apns-token-abc" });
+    await flushMicrotasks();
+    captureErrorMock.mockClear();
+
+    await unregisterFromRemotePush();
+
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
   });
 
   test("no-ops when no token was registered", async () => {

--- a/clients/web/src/runtime/push-registration.test.ts
+++ b/clients/web/src/runtime/push-registration.test.ts
@@ -298,6 +298,28 @@ describe("unregisterFromRemotePush", () => {
     expect(lastDeleteArg?.path.token).toBe("race-token");
   });
 
+  test("awaits ALL concurrent in-flight upserts before deleting, not just the latest", async () => {
+    let releaseUpsert!: () => void;
+    upsertGate = new Promise<void>((resolve) => {
+      releaseUpsert = resolve;
+    });
+
+    await registerForRemotePush("assistant-1");
+    // Two overlapping upserts (e.g. manual re-upsert + cached token re-emit).
+    registrationHandler?.({ value: "token-A" });
+    registrationHandler?.({ value: "token-B" });
+    await Promise.resolve();
+
+    const unregisterPromise = unregisterFromRemotePush();
+    releaseUpsert();
+    await unregisterPromise;
+
+    // Both upserts settled before the delete ran — no straggler can
+    // re-register the token after logout.
+    expect(upsertMock).toHaveBeenCalledTimes(2);
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+  });
+
   test("reports a failed delete to Sentry instead of silently dropping it", async () => {
     deleteError = { detail: "server error" };
     await registerForRemotePush("assistant-1");

--- a/clients/web/src/runtime/push-registration.test.ts
+++ b/clients/web/src/runtime/push-registration.test.ts
@@ -246,6 +246,29 @@ describe("unregisterFromRemotePush", () => {
     });
   });
 
+  test("falls back to the persisted token after a process reload (empty module memory)", async () => {
+    // Simulate a prior session that persisted a registration followed by a
+    // reload that wiped module memory — `lastRegistered` is null but the
+    // platform still has the token, so logout must still delete it.
+    localStorage.setItem(
+      "vellum:push_registration",
+      JSON.stringify({
+        token: "persisted-token",
+        bundleId: "ai.vocify-inc.vellum-assistant-ios",
+        assistantId: "assistant-9",
+      }),
+    );
+
+    await unregisterFromRemotePush();
+
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+    expect(lastDeleteArg).toEqual({
+      path: { assistant_id: "assistant-9", token: "persisted-token" },
+      query: { bundle_id: "ai.vocify-inc.vellum-assistant-ios" },
+      throwOnError: false,
+    });
+  });
+
   test("no-ops when no token was registered", async () => {
     await unregisterFromRemotePush();
     expect(deleteMock).not.toHaveBeenCalled();

--- a/clients/web/src/runtime/push-registration.ts
+++ b/clients/web/src/runtime/push-registration.ts
@@ -41,6 +41,7 @@ import {
 import type { ApnsEnvironmentEnum } from "@/generated/api/types.gen";
 import { captureError } from "@/lib/sentry/capture-error";
 import { isNativePlatform } from "@/runtime/native-auth";
+import { createStorageAccessor } from "@/utils/typed-storage";
 
 /**
  * Bundle-id suffix that maps to the development APNs entitlement. The dev Xcode
@@ -59,6 +60,40 @@ interface RegisteredToken {
   bundleId: string;
   assistantId: string;
 }
+
+function parseRegisteredToken(raw: string): RegisteredToken | null {
+  const value = JSON.parse(raw) as Partial<RegisteredToken>;
+  if (
+    typeof value.token === "string" &&
+    typeof value.bundleId === "string" &&
+    typeof value.assistantId === "string"
+  ) {
+    return { token: value.token, bundleId: value.bundleId, assistantId: value.assistantId };
+  }
+  return null;
+}
+
+/**
+ * The last successfully-upserted registration, persisted to user-scoped
+ * storage. Module memory alone is insufficient: the WebView/app process can
+ * reload (dropping `lastRegistered`) before `usePushRegistration` re-runs, and
+ * `/logout` is a standalone route outside `RootLayout` — so logout could fire
+ * with empty module state and skip the platform DELETE, leaving a signed-out
+ * device still receiving remote pushes. The `vellum:` (user) scope is cleared
+ * by the logout storage sweep, and we also remove it explicitly after delete.
+ *
+ * The stored value is a device push-routing registration (APNs destination
+ * token + bundle + assistant), not auth/session material — losing it to XSS
+ * does not grant access to anything, so JS-readable storage is appropriate
+ * here (unlike session tokens, which must stay in HttpOnly cookies).
+ */
+const persistedRegistration = createStorageAccessor<RegisteredToken | null>({
+  key: "vellum:push_registration",
+  scope: "user",
+  parse: parseRegisteredToken,
+  serialize: JSON.stringify,
+  fallback: null,
+});
 
 let listenersRegistered = false;
 let currentAssistantId: string | null = null;
@@ -114,6 +149,7 @@ async function upsertToken(token: string, assistantId: string): Promise<void> {
     }
 
     lastRegistered = { token, bundleId, assistantId };
+    persistedRegistration.save(lastRegistered);
   } catch (err) {
     captureError(err, {
       context: "push_registration_upsert",
@@ -201,8 +237,11 @@ export async function registerForRemotePush(assistantId: string): Promise<void> 
  */
 export async function unregisterFromRemotePush(): Promise<void> {
   currentAssistantId = null;
-  const registered = lastRegistered;
+  // Fall back to persisted storage: a process reload before re-registration
+  // leaves `lastRegistered` null even though a token is still registered.
+  const registered = lastRegistered ?? persistedRegistration.load();
   lastRegistered = null;
+  persistedRegistration.remove();
 
   if (!registered || !isRemotePushSupported()) return;
 
@@ -221,9 +260,10 @@ export async function unregisterFromRemotePush(): Promise<void> {
   }
 }
 
-/** Test-only: reset module state between cases. */
+/** Test-only: reset module + persisted state between cases. */
 export function __resetPushRegistrationStateForTests(): void {
   listenersRegistered = false;
   currentAssistantId = null;
   lastRegistered = null;
+  persistedRegistration.remove();
 }

--- a/clients/web/src/runtime/push-registration.ts
+++ b/clients/web/src/runtime/push-registration.ts
@@ -1,0 +1,229 @@
+/**
+ * APNs remote-push device-token registration for the Capacitor iOS app.
+ *
+ * The daemon's `platform` notification channel POSTs background notifications
+ * (reminders, activity completions, etc.) to the Vellum platform's
+ * `/v1/assistants/{id}/push/dispatch/` endpoint, which fans them out to every
+ * APNs device token registered for the bound user. This module is the missing
+ * client half: it asks iOS for an APNs device token via
+ * `@capacitor/push-notifications`, then upserts that token to the platform so
+ * the daemon has somewhere to deliver.
+ *
+ * Why this matters for reminders specifically: the in-app local-notification
+ * path (`runtime/notifications.ts`) only fires while the JS runtime is alive
+ * (foreground / recently-backgrounded). Scheduled reminders fire while the app
+ * is backgrounded or suspended, so APNs remote push is the only path that can
+ * reach the device. (LUM-1159)
+ *
+ * Lifecycle:
+ *   - {@link registerForRemotePush} — call once an assistant is active. Requests
+ *     notification permission, registers for APNs, and upserts the resulting
+ *     token to the platform. Idempotent and safe to call on every mount.
+ *   - {@link unregisterFromRemotePush} — call from the logout path BEFORE the
+ *     session cookie is cleared (see `stores/auth-store.ts`) so the platform
+ *     delete is authenticated. Removes the token for the bound assistant.
+ *
+ * iOS-only and best-effort: no-ops on Electron, desktop browsers, and Android
+ * (no native Capacitor Android shell ships today); registration/delete failures
+ * are reported to Sentry but never thrown into the app lifecycle.
+ *
+ * Per `docs/CAPACITOR.md`, the `@capacitor/*` plugins are destructured inline
+ * at each call site — never returned through an `async` boundary — because the
+ * plugin Proxy's `.then` trap would hang the awaiting caller forever.
+ */
+
+import { Capacitor } from "@capacitor/core";
+
+import {
+  assistantsPushTokensDelete,
+  assistantsPushTokensUpsert,
+} from "@/generated/api/sdk.gen";
+import type { ApnsEnvironmentEnum } from "@/generated/api/types.gen";
+import { captureError } from "@/lib/sentry/capture-error";
+import { isNativePlatform } from "@/runtime/native-auth";
+
+/**
+ * Bundle-id suffix that maps to the development APNs entitlement. The dev Xcode
+ * config (`clients/ios/App/App/Config/App-Dev.xcconfig`) signs with
+ * `App-Dev.entitlements` (`aps-environment = development`) and ships the `.dev`
+ * bundle id; production and staging both sign with `App.entitlements`
+ * (`aps-environment = production`). APNs rejects a token minted under one
+ * environment if dispatched against the other, so the platform stores the
+ * environment alongside the token and the value must match the running build.
+ */
+const DEV_BUNDLE_SUFFIX = ".dev";
+
+/** Token registration we last upserted, retained so logout can delete it. */
+interface RegisteredToken {
+  token: string;
+  bundleId: string;
+  assistantId: string;
+}
+
+let listenersRegistered = false;
+let currentAssistantId: string | null = null;
+let lastRegistered: RegisteredToken | null = null;
+
+/**
+ * True only on the native Capacitor iOS runtime.
+ *
+ * APNs remote push is a native-only capability: a device token only exists
+ * inside the iOS app process, there is no web/Electron equivalent, and the
+ * daemon's `platform` channel exclusively targets iOS device tokens. This is
+ * not a "present but broken" web API — there is nothing to feature-detect — so
+ * a platform short-circuit is the correct guard. Android is excluded because no
+ * native Capacitor Android shell ships today; revisit this guard if one does.
+ */
+export function isRemotePushSupported(): boolean {
+  return isNativePlatform() && Capacitor.getPlatform() === "ios";
+}
+
+/** Map the running build's bundle id to its APNs entitlement environment. */
+function resolveApnsEnvironment(bundleId: string): ApnsEnvironmentEnum {
+  return bundleId.endsWith(DEV_BUNDLE_SUFFIX) ? "development" : "production";
+}
+
+/**
+ * Upsert a freshly-minted APNs token to the platform for the given assistant.
+ * Best-effort: a non-2xx response or thrown error is reported and swallowed.
+ */
+async function upsertToken(token: string, assistantId: string): Promise<void> {
+  try {
+    // `@capacitor/app` is a plugin Proxy — destructure inline (see CAPACITOR.md).
+    const { App } = await import("@capacitor/app");
+    const { id: bundleId } = await App.getInfo();
+
+    const result = await assistantsPushTokensUpsert({
+      path: { assistant_id: assistantId },
+      body: {
+        token,
+        platform: "ios",
+        bundle_id: bundleId,
+        apns_environment: resolveApnsEnvironment(bundleId),
+      },
+      throwOnError: false,
+    });
+
+    if (result.error) {
+      captureError(result.error, {
+        context: "push_registration_upsert",
+        level: "warning",
+        bestEffort: true,
+      });
+      return;
+    }
+
+    lastRegistered = { token, bundleId, assistantId };
+  } catch (err) {
+    captureError(err, {
+      context: "push_registration_upsert",
+      level: "warning",
+      bestEffort: true,
+    });
+  }
+}
+
+/**
+ * Register the APNs `registration` / `registrationError` listeners exactly
+ * once. The `registration` handler upserts the token under whichever assistant
+ * is current when iOS delivers it (iOS may emit the token asynchronously, and
+ * re-emits the cached token on subsequent `register()` calls).
+ */
+async function ensureListeners(): Promise<void> {
+  if (listenersRegistered) return;
+  listenersRegistered = true;
+  try {
+    const { PushNotifications } = await import("@capacitor/push-notifications");
+    await PushNotifications.addListener("registration", (token) => {
+      const assistantId = currentAssistantId;
+      if (!assistantId) return;
+      void upsertToken(token.value, assistantId);
+    });
+    await PushNotifications.addListener("registrationError", (err) => {
+      captureError(err, {
+        context: "push_registration_apns",
+        level: "warning",
+      });
+    });
+  } catch (err) {
+    // Allow a later call to retry listener registration.
+    listenersRegistered = false;
+    captureError(err, {
+      context: "push_registration_listeners",
+      level: "warning",
+    });
+  }
+}
+
+/**
+ * Request notification permission, register for APNs, and upsert the resulting
+ * device token to the platform for `assistantId`. No-ops off native iOS.
+ *
+ * Safe to call repeatedly (e.g. on every mount or assistant switch): iOS shows
+ * the permission prompt at most once, `register()` re-emits the cached token,
+ * and the listener re-upserts it. The same `UNUserNotificationCenter`
+ * authorization backs the local-notification path, so this does not introduce a
+ * second OS prompt.
+ */
+export async function registerForRemotePush(assistantId: string): Promise<void> {
+  if (!isRemotePushSupported()) return;
+  currentAssistantId = assistantId;
+
+  // If iOS already handed us a token for this device under a different
+  // assistant, re-upsert it now rather than waiting for another registration
+  // event (which only fires again on the next `register()`).
+  if (lastRegistered && lastRegistered.assistantId !== assistantId) {
+    void upsertToken(lastRegistered.token, assistantId);
+  }
+
+  try {
+    // `@capacitor/push-notifications` is a plugin Proxy — destructure inline.
+    const { PushNotifications } = await import("@capacitor/push-notifications");
+    await ensureListeners();
+    const permission = await PushNotifications.requestPermissions();
+    if (permission.receive !== "granted") return;
+    await PushNotifications.register();
+  } catch (err) {
+    captureError(err, {
+      context: "push_registration_register",
+      level: "warning",
+    });
+  }
+}
+
+/**
+ * Delete the last-registered device token from the platform. Call this from the
+ * logout flow BEFORE the session cookie is cleared so the request is
+ * authenticated (the platform delete is keyed on the still-valid session).
+ *
+ * Best-effort and idempotent: no-ops when nothing was registered or off native
+ * iOS, and swallows delete failures.
+ */
+export async function unregisterFromRemotePush(): Promise<void> {
+  currentAssistantId = null;
+  const registered = lastRegistered;
+  lastRegistered = null;
+
+  if (!registered || !isRemotePushSupported()) return;
+
+  try {
+    await assistantsPushTokensDelete({
+      path: { assistant_id: registered.assistantId, token: registered.token },
+      query: { bundle_id: registered.bundleId },
+      throwOnError: false,
+    });
+  } catch (err) {
+    captureError(err, {
+      context: "push_registration_delete",
+      level: "warning",
+      bestEffort: true,
+    });
+  }
+}
+
+/** Test-only: reset module state between cases. */
+export function __resetPushRegistrationStateForTests(): void {
+  listenersRegistered = false;
+  currentAssistantId = null;
+  lastRegistered = null;
+}

--- a/clients/web/src/runtime/push-registration.ts
+++ b/clients/web/src/runtime/push-registration.ts
@@ -98,6 +98,21 @@ const persistedRegistration = createStorageAccessor<RegisteredToken | null>({
 let listenersRegistered = false;
 let currentAssistantId: string | null = null;
 let lastRegistered: RegisteredToken | null = null;
+let pendingUpsert: Promise<void> | null = null;
+
+/**
+ * Track an in-flight upsert so logout can await it before concluding there is
+ * nothing to delete. Without this, a `registration` event whose `upsertToken`
+ * is still mid-POST when logout fires would leave `lastRegistered` unset — the
+ * DELETE would be skipped while the upsert still succeeds, leaving a signed-out
+ * device registered.
+ */
+function trackUpsert(upsert: Promise<void>): void {
+  pendingUpsert = upsert;
+  void upsert.finally(() => {
+    if (pendingUpsert === upsert) pendingUpsert = null;
+  });
+}
 
 /**
  * True only on the native Capacitor iOS runtime.
@@ -173,7 +188,7 @@ async function ensureListeners(): Promise<void> {
     await PushNotifications.addListener("registration", (token) => {
       const assistantId = currentAssistantId;
       if (!assistantId) return;
-      void upsertToken(token.value, assistantId);
+      trackUpsert(upsertToken(token.value, assistantId));
     });
     await PushNotifications.addListener("registrationError", (err) => {
       captureError(err, {
@@ -209,7 +224,7 @@ export async function registerForRemotePush(assistantId: string): Promise<void> 
   // assistant, re-upsert it now rather than waiting for another registration
   // event (which only fires again on the next `register()`).
   if (lastRegistered && lastRegistered.assistantId !== assistantId) {
-    void upsertToken(lastRegistered.token, assistantId);
+    trackUpsert(upsertToken(lastRegistered.token, assistantId));
   }
 
   try {
@@ -233,10 +248,21 @@ export async function registerForRemotePush(assistantId: string): Promise<void> 
  * authenticated (the platform delete is keyed on the still-valid session).
  *
  * Best-effort and idempotent: no-ops when nothing was registered or off native
- * iOS, and swallows delete failures.
+ * iOS, and reports (does not throw) delete failures.
  */
 export async function unregisterFromRemotePush(): Promise<void> {
+  // Stop new registration events from upserting, then wait for any upsert
+  // already in flight so we don't miss a token that is about to be registered
+  // server-side. Logout awaits this function before clearing the session.
   currentAssistantId = null;
+  if (pendingUpsert) {
+    try {
+      await pendingUpsert;
+    } catch {
+      // Upsert failures are already reported inside upsertToken.
+    }
+  }
+
   // Fall back to persisted storage: a process reload before re-registration
   // leaves `lastRegistered` null even though a token is still registered.
   const registered = lastRegistered ?? persistedRegistration.load();
@@ -246,11 +272,25 @@ export async function unregisterFromRemotePush(): Promise<void> {
   if (!registered || !isRemotePushSupported()) return;
 
   try {
-    await assistantsPushTokensDelete({
+    const result = await assistantsPushTokensDelete({
       path: { assistant_id: registered.assistantId, token: registered.token },
       query: { bundle_id: registered.bundleId },
       throwOnError: false,
     });
+    // `throwOnError: false` surfaces 4xx/5xx in `result.error`; a silently
+    // failed delete leaves the token registered, so report it rather than
+    // treating the unregister as complete.
+    if (result.error) {
+      captureError(result.error, {
+        context: "push_registration_delete",
+        level: "warning",
+        bestEffort: true,
+        extra: {
+          assistantId: registered.assistantId,
+          bundleId: registered.bundleId,
+        },
+      });
+    }
   } catch (err) {
     captureError(err, {
       context: "push_registration_delete",
@@ -265,5 +305,6 @@ export function __resetPushRegistrationStateForTests(): void {
   listenersRegistered = false;
   currentAssistantId = null;
   lastRegistered = null;
+  pendingUpsert = null;
   persistedRegistration.remove();
 }

--- a/clients/web/src/runtime/push-registration.ts
+++ b/clients/web/src/runtime/push-registration.ts
@@ -98,19 +98,23 @@ const persistedRegistration = createStorageAccessor<RegisteredToken | null>({
 let listenersRegistered = false;
 let currentAssistantId: string | null = null;
 let lastRegistered: RegisteredToken | null = null;
-let pendingUpsert: Promise<void> | null = null;
+const pendingUpserts = new Set<Promise<void>>();
 
 /**
- * Track an in-flight upsert so logout can await it before concluding there is
- * nothing to delete. Without this, a `registration` event whose `upsertToken`
- * is still mid-POST when logout fires would leave `lastRegistered` unset — the
- * DELETE would be skipped while the upsert still succeeds, leaving a signed-out
- * device registered.
+ * Track every in-flight upsert so logout can await all of them before
+ * concluding there is nothing to delete. Without this, a `registration` event
+ * whose `upsertToken` is still mid-POST when logout fires would leave
+ * `lastRegistered` unset — the DELETE would be skipped while the upsert still
+ * succeeds, leaving a signed-out device registered. A set (not a single
+ * promise) is required because concurrent upserts can overlap — e.g. an
+ * assistant switch starts a manual re-upsert and `register()` re-emits the
+ * cached token — and awaiting only the latest would let an earlier, slower
+ * upsert re-register the token after the delete.
  */
 function trackUpsert(upsert: Promise<void>): void {
-  pendingUpsert = upsert;
+  pendingUpserts.add(upsert);
   void upsert.finally(() => {
-    if (pendingUpsert === upsert) pendingUpsert = null;
+    pendingUpserts.delete(upsert);
   });
 }
 
@@ -255,12 +259,11 @@ export async function unregisterFromRemotePush(): Promise<void> {
   // already in flight so we don't miss a token that is about to be registered
   // server-side. Logout awaits this function before clearing the session.
   currentAssistantId = null;
-  if (pendingUpsert) {
-    try {
-      await pendingUpsert;
-    } catch {
-      // Upsert failures are already reported inside upsertToken.
-    }
+  // Drain in a loop: awaiting a batch can let a concurrent upsert finish and a
+  // straggler get added. New upserts can only originate from a `registration`
+  // event, which now no-ops (currentAssistantId is null), so this terminates.
+  while (pendingUpserts.size > 0) {
+    await Promise.allSettled([...pendingUpserts]);
   }
 
   // Fall back to persisted storage: a process reload before re-registration
@@ -305,6 +308,6 @@ export function __resetPushRegistrationStateForTests(): void {
   listenersRegistered = false;
   currentAssistantId = null;
   lastRegistered = null;
-  pendingUpsert = null;
+  pendingUpserts.clear();
   persistedRegistration.remove();
 }

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -54,6 +54,7 @@ import {
 import { listAssistants } from "@/assistant/api";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { deleteBiometricToken } from "@/runtime/native-biometric";
+import { unregisterFromRemotePush } from "@/runtime/push-registration";
 import { fetchConsent, patchConsent } from "@/domains/account/profile";
 import {
   restoreConsentForUser,
@@ -851,6 +852,10 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
     }
 
     suppressPlatformProbe = true;
+    // Delete the APNs device token from the platform BEFORE clearing the
+    // session — the platform delete is authenticated by the still-valid
+    // session cookie. No-ops off native iOS. Best-effort: never blocks logout.
+    await unregisterFromRemotePush();
     try {
       await allauthLogout();
     } finally {


### PR DESCRIPTION
## Summary

- Add `clients/web/src/runtime/push-registration.ts` + the `usePushRegistration` hook: on the native Capacitor iOS shell, request notification permission, register for APNs via `@capacitor/push-notifications`, and upsert the device token to the platform (`POST /v1/assistants/{id}/push-tokens/`) so the daemon's `platform` notification channel has a token to dispatch to. No-ops off native iOS.
- Wire registration into `root-layout.tsx` (next to the existing local-notification sync) and token deletion into the logout path in `stores/auth-store.ts` — before the session cookie is cleared, so the delete is authenticated (per the platform spec's delete-endpoint contract).
- Derive `apns_environment` from the running build's bundle id (`.dev` → development, prod/staging → production), matching the iOS xcconfig entitlement mapping.

### Why
Reminders fire while the iOS app is backgrounded/suspended, where the in-app local-notification path (`runtime/notifications.ts`) cannot run — APNs remote push is the only delivery path, and the client previously never registered a token (LUM-1159), leaving the platform's token set empty. The daemon/platform side already dispatches correctly; the native plumbing (entitlements, `remote-notification` background mode, AppDelegate token forwarding, the `CapacitorPushNotifications` SPM plugin) and the `@capacitor/push-notifications` dependency were already present. This PR adds only the missing JS glue.

### Testing
- New unit test `push-registration.test.ts` (11 cases): platform guards, permission-denied, token upsert + apns_environment derivation, error reporting, and logout deletion.
- `tsc --noEmit` and eslint clean.

## Original prompt

Diagnosed why iOS push notifications fail for reminders: the daemon's `platform` channel fans notifications out to registered APNs device tokens, but the iOS client never registered one, so background reminders had nowhere to land. The fix was scoped to the client only (LUM-1159): request permission, register for APNs, upsert the token to the platform on login, and delete it on logout — iOS-only, best-effort, without touching the working daemon side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)