### PR TITLE
Route assistant feature-flag writes through the gateway client (fix 404 on local/desktop)

### DIFF
--- a/clients/web/src/domains/settings/components/panels/feature-flags-panel.test.tsx
+++ b/clients/web/src/domains/settings/components/panels/feature-flags-panel.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import * as gatewaySdk from "@/generated/gateway/sdk.gen";
 
 // Regression test for the bug where assistant-scoped flag toggles never
 // persisted: the panel read the active assistant id from the platform
@@ -21,6 +22,15 @@ const getMock = mock((_request: unknown) =>
 
 mock.module("@/generated/api/client.gen", () => ({
   client: { patch: patchMock, get: getMock },
+}));
+
+// Assistant-scoped flag writes route through the gateway client
+// (`assistantFeatureFlagsPatch`), so the toggle's PATCH lands here, not on
+// the platform client above. Spread the real module so the read-query path
+// (`assistantFeatureFlagsGet`, used by the flag-sync hook) keeps working.
+mock.module("@/generated/gateway/sdk.gen", () => ({
+  ...gatewaySdk,
+  assistantFeatureFlagsPatch: patchMock,
 }));
 
 mock.module("@/assistant/use-active-assistant-id", () => ({
@@ -78,7 +88,7 @@ describe("FeatureFlagsPanel", () => {
 
     const request = patchMock.mock.calls[0]?.[0];
     expect(request).toMatchObject({
-      url: "/v1/assistants/assistant-1/feature-flags/voice-mode",
+      path: { assistant_id: "assistant-1", flag_key: "voice-mode" },
       body: { enabled: true },
       throwOnError: false,
     });

--- a/clients/web/src/stores/assistant-feature-flag-store.test.ts
+++ b/clients/web/src/stores/assistant-feature-flag-store.test.ts
@@ -4,8 +4,14 @@ const patchMock = mock((_request: unknown) =>
   Promise.resolve({ response: new Response(null, { status: 204 }) }),
 );
 
-mock.module("@/generated/api/client.gen", () => ({
-  client: { patch: patchMock },
+// Assistant-scoped flag writes MUST go through the gateway client
+// (`assistantFeatureFlagsPatch`), not the platform client. Routing them
+// through the platform client drops them on the runtime-proxy allowlist
+// and 404s for local/self-hosted assistants (non-UUID ids). Mocking the
+// gateway SDK here is the regression guard: if a write ever reverts to
+// the platform client, `patchMock` won't be hit and these tests fail.
+mock.module("@/generated/gateway/sdk.gen", () => ({
+  assistantFeatureFlagsPatch: patchMock,
 }));
 
 const toastErrorMock = mock((_message: string) => {});
@@ -39,7 +45,10 @@ describe("useAssistantFeatureFlagStore", () => {
     expect(store().selfIntroGreeting).toBe(true);
     const request = patchMock.mock.calls[0]?.[0];
     expect(request).toMatchObject({
-      url: "/v1/assistants/assistant-123/feature-flags/self-intro-greeting",
+      path: {
+        assistant_id: "assistant-123",
+        flag_key: "self-intro-greeting",
+      },
       body: { enabled: true },
       throwOnError: false,
     });

--- a/clients/web/src/stores/assistant-feature-flag-store.ts
+++ b/clients/web/src/stores/assistant-feature-flag-store.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 
 import { createSelectors } from "@/utils/create-selectors";
-import { client } from "@/generated/api/client.gen";
+import { assistantFeatureFlagsPatch } from "@/generated/gateway/sdk.gen";
 import {
   ASSISTANT_FLAG_DEFAULTS,
   ASSISTANT_STRING_FLAG_DEFAULTS,
@@ -141,12 +141,11 @@ const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()(
           return;
         }
         pendingFlagRequestIds[key] = requestId;
-        void client
-          .patch({
-            url: `/v1/assistants/${assistantId}/feature-flags/${flagKey}`,
-            body: { enabled: value },
-            throwOnError: false,
-          } as Parameters<typeof client.patch>[0])
+        void assistantFeatureFlagsPatch({
+          path: { assistant_id: assistantId, flag_key: flagKey },
+          body: { enabled: value },
+          throwOnError: false,
+        })
           .then((result) => {
             const response = (result as { response?: Response }).response;
             if (response?.ok) {
@@ -207,12 +206,11 @@ const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()(
           return;
         }
         pendingFlagRequestIds[key] = requestId;
-        void client
-          .patch({
-            url: `/v1/assistants/${assistantId}/feature-flags/${flagKey}`,
-            body: { enabled: value },
-            throwOnError: false,
-          } as Parameters<typeof client.patch>[0])
+        void assistantFeatureFlagsPatch({
+          path: { assistant_id: assistantId, flag_key: flagKey },
+          body: { enabled: value },
+          throwOnError: false,
+        })
           .then((result) => {
             const response = (result as { response?: Response }).response;
             if (response?.ok) {


### PR DESCRIPTION
## Summary
- Assistant-scoped feature-flag **writes** (`setFlag`/`setStringFlag` in `assistant-feature-flag-store.ts`) issued their PATCH through the **platform** client. The platform client's interceptor only forwards an allowlist of `/v1/assistants/{id}/<segment>/...` paths to the assistant's gateway, and `feature-flags` is **not** on that allowlist — so the write was never rewritten to the gateway and leaked to the platform proxy (Django), whose runtime proxy only matches `<uuid:assistant_id>`. For **local/self-hosted** assistants (petname ids like `vellum-grand-wolf-pgg4kz`, not UUIDs) this 404'd.
- Fix: route writes through the generated **gateway** client (`assistantFeatureFlagsPatch`), making them symmetric with the read/sync path (which already uses the gateway client). Removed the now-unused platform `client` import and its `Parameters<...>` cast.
- Impact: this 404 affected **every desktop user with a local assistant on both dev and prod** (and likely web self-hosted) — not a dev-only artifact. Platform/cloud (UUID) assistants were unaffected and stay correct: with no gateway ingress primed, the gateway client falls through to the same relative `/v1/...` → Django→vembda path the platform client used. Remote-gateway mode improves (the write was previously aborted by `platformFeaturesGate`).

## Tests
- Updated `assistant-feature-flag-store.test.ts` and `feature-flags-panel.test.tsx` to mock the gateway SDK and assert the PATCH carries `path: { assistant_id, flag_key }` — this is the regression guard against silently reverting to the platform client. All 63 tests across the touched specs pass; lint clean; the changed files are type-clean.

## Original prompt
While running the desktop (Electron) app locally, opening Settings → Developer issued a PATCH to `/v1/assistants/vellum-grand-wolf-pgg4kz/feature-flags/settings-developer-nav` that returned 404 (the request reached the Vite dev origin and was proxied to Django at :8000, which can't route a non-UUID local assistant id). Investigation traced it to assistant feature-flag writes going through the platform client instead of the gateway client. The ask was to fix the routing so local/self-hosted assistants can persist flag writes, without regressing platform/cloud assistants, and open a PR.