### PR TITLE
fix(oauth): steer weak models straight to the connect surface

### DIFF
--- a/assistant/src/cli/commands/oauth/status.test.ts
+++ b/assistant/src/cli/commands/oauth/status.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { noConnectionsMessage } from "./status.js";
+
+const original = process.env.__RESOLVED_MODEL;
+
+afterEach(() => {
+  if (original === undefined) delete process.env.__RESOLVED_MODEL;
+  else process.env.__RESOLVED_MODEL = original;
+});
+
+describe("noConnectionsMessage", () => {
+  test("capable models get the terse default", () => {
+    process.env.__RESOLVED_MODEL = "claude-opus-4-8";
+    const msg = noConnectionsMessage("google");
+    expect(msg).toBe(
+      "No active connections for google.\n" +
+        "Connect with `assistant oauth connect google`.\n",
+    );
+  });
+
+  test("no resolved model falls back to the terse default", () => {
+    delete process.env.__RESOLVED_MODEL;
+    expect(noConnectionsMessage("google")).toContain(
+      "Connect with `assistant oauth connect google`.",
+    );
+  });
+
+  test("weak open models are steered to the oauth_connect surface", () => {
+    process.env.__RESOLVED_MODEL = "accounts/fireworks/models/minimax-m3";
+    const msg = noConnectionsMessage("google");
+    expect(msg).toContain('surface_type "oauth_connect"');
+    expect(msg).toContain('data.providerKey "google"');
+    expect(msg).not.toContain("assistant oauth connect google");
+  });
+});

--- a/assistant/src/cli/commands/oauth/status.ts
+++ b/assistant/src/cli/commands/oauth/status.ts
@@ -1,7 +1,29 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../../ipc/cli-client.js";
+import { isWeakOpenModel } from "../../../providers/weak-open-model.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
+
+/**
+ * Message shown when a provider has no active connections. Weak open models
+ * loop through redundant discovery commands (channel checks, `oauth providers
+ * get`, loading the OAuth setup skill) before rendering the connect button, so
+ * they get an explicit single next action: render the core `oauth_connect`
+ * surface directly. Capable models keep the terse default.
+ */
+export function noConnectionsMessage(provider: string): string {
+  const base = `No active connections for ${provider}.`;
+  if (isWeakOpenModel(process.env.__RESOLVED_MODEL)) {
+    return (
+      `${base}\nTo let the user connect, render the connect button: call ` +
+      `\`ui_show\` with surface_type "oauth_connect" and ` +
+      `data.providerKey "${provider}". That surface is always available — do ` +
+      `not run further \`oauth\`/\`channels\` commands or load a setup skill ` +
+      `just to display it.\n`
+    );
+  }
+  return `${base}\nConnect with \`assistant oauth connect ${provider}\`.\n`;
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -91,9 +113,7 @@ Examples:
 
           // Text output
           if (connections.length === 0) {
-            process.stdout.write(
-              `No active connections for ${provider}.\nConnect with \`assistant oauth connect ${provider}\`.\n`,
-            );
+            process.stdout.write(noConnectionsMessage(provider));
             return;
           }
 

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -308,6 +308,11 @@ export const shellTool = {
 
     const env = buildSanitizedEnv();
     env.__CONVERSATION_ID = context.conversationId;
+    // Surface the resolving model to assistant CLI commands so they can tailor
+    // remediation guidance for weak open models (see isWeakOpenModel).
+    if (context.attribution?.resolvedModel) {
+      env.__RESOLVED_MODEL = context.attribution.resolvedModel;
+    }
     if (proxyEnv) {
       Object.assign(env, proxyEnv);
     }


### PR DESCRIPTION
## Why

A user reported Gmail login taking ~4 minutes. Log analysis of the conversation showed the main agent (MiniMax M3 on the `balanced` profile) took **8 sequential tool round-trips** to render the connect button when 2 would do. Part of the cause: `assistant oauth status google` returns *"Connect with `assistant oauth connect google`"* when nothing is connected, which steers the model toward a CLI connect path (wrong UX on web/desktop) and never mentions the `oauth_connect` `ui_show` surface — so M3 instead loaded `vellum-oauth-integrations` and ran `oauth providers get` (both wasted) before showing the button.

## What

Gate the "no connections" output on the resolving model:
- **Weak open models** (MiniMax/Kimi/DeepSeek, via `isWeakOpenModel`) get one explicit next action — render `ui_show oauth_connect` with `providerKey`, stop probing.
- **Capable models** keep the terse default, unchanged.

The model is threaded to the CLI via a new `__RESOLVED_MODEL` env var injected by the shell tool alongside the existing `__CONVERSATION_ID`, so the gate reads ground-truth `attribution.resolvedModel` — the same signal used by the empty-`dynamic_page` redirect (#35155) and task-progress nudge.

## Notes
- `__RESOLVED_MODEL` is injected directly after `buildSanitizedEnv()` (like `__CONVERSATION_ID`), so it bypasses the allowlist — no `safe-env.ts` change needed.
- Part of a 3-PR set with the messaging SKILL.md fast-path and the empty-input remediation wording fix.

## Test
`bun test src/cli/commands/oauth/status.test.ts` — 3 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)