### PR TITLE
fix(skills): stop telling models the JSON-string input form is wrong

### DIFF
--- a/assistant/src/__tests__/skill-execute-input.test.ts
+++ b/assistant/src/__tests__/skill-execute-input.test.ts
@@ -103,6 +103,11 @@ describe("augmentSkillExecuteError", () => {
     expect(result.content).toContain("carried no parameters");
     expect(result.content).toContain('"tool": "subagent_spawn"');
     expect(result.content).toContain("inside `input`");
+    // The guidance must not condemn the JSON-encoded-string form: the resolver
+    // accepts it (resolveSkillExecuteInput parses string input), and it is a
+    // shape weak models successfully use. Telling them it is wrong steers them
+    // toward dropping the payload entirely.
+    expect(result.content).not.toContain("JSON-encoded string");
   });
 
   test("leaves errors untouched when parameters were resolved", () => {

--- a/assistant/src/tools/skills/execute.ts
+++ b/assistant/src/tools/skills/execute.ts
@@ -87,8 +87,7 @@ export function augmentSkillExecuteError(
 
   const guidance =
     `\n\nThis skill_execute call carried no parameters for "${toolName}". ` +
-    `Put the tool's parameters inside \`input\` as a JSON object — not as ` +
-    `siblings of \`tool\`, and not as a JSON-encoded string. For example: ` +
+    `Put the tool's parameters inside \`input\`. For example: ` +
     `{"tool": "${toolName}", "input": { /* the tool's parameters */ }, ` +
     `"activity": "..."}. The skill's instructions (from skill_load) list ` +
     `"${toolName}"'s required fields.`;


### PR DESCRIPTION
## Why

In the same ~4-minute Gmail-login incident (#35449), after connecting, MiniMax M3 fell into an empty-input loop: it called `messaging_search` with `input: ""` four times, each time receiving the `augmentSkillExecuteError` remediation, and only recovered intermittently (bad, bad, bad, good, bad, good) — burning ~50s including a 33s inference.

The remediation told the model to put parameters in `input` *"not as a JSON-encoded string."* But `resolveSkillExecuteInput` **explicitly parses and accepts** a JSON-encoded string, and that is the shape M3's *successful* calls actually used. Condemning the form that works is a contradictory signal that can push a confused model toward dropping the payload entirely — the exact loop this guidance is meant to break.

## What

Drop the claims about which forms are rejected and just show the canonical envelope. (Also drop the "not as siblings" clause in the same breath — the resolver rescues siblings too, and the error only fires on a genuinely empty call.) Add a regression assertion that the guidance no longer contains "JSON-encoded string".

## Notes
This is a wording fix only; it does not by itself stop a model that drops `input` entirely. A deterministic loop-break (detect N consecutive empty-input calls and escalate) is the realistic ceiling and is left for a follow-up. Part of a 3-PR set with #35449 and #35450.

## Test
`bun test src/__tests__/skill-execute-input.test.ts` — 11 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)