### PR TITLE
fix(secret-prompt): make cancel resolve the interaction and stop sparse rehydrate from clobbering metadata

### DIFF
--- a/clients/web/src/domains/chat/api/interactions.ts
+++ b/clients/web/src/domains/chat/api/interactions.ts
@@ -117,6 +117,36 @@ export async function submitSecretResponse(
   }
 }
 
+/**
+ * Cancel a pending secret prompt. Posts ONLY `{ requestId }` (no `value`,
+ * no `delivery`) so the daemon resolves the awaiting interaction as cancelled
+ * — the daemon treats an absent `value` as cancellation.
+ */
+export async function submitSecretCancel(
+  assistantId: string,
+  requestId: string,
+): Promise<SubmitSecretResponseResult> {
+  try {
+    const { error, response } = await secretPost({
+      path: { assistant_id: assistantId },
+      body: { requestId },
+      throwOnError: false,
+    });
+    assertHasResponse(response, error, "Failed to cancel secret prompt");
+    if (!response.ok) {
+      const msg = extractErrorMessage(error, response);
+      return { ok: false, status: response.status, error: msg };
+    }
+    return { ok: true };
+  } catch (err) {
+    return {
+      ok: false,
+      status: 500,
+      error: err instanceof Error ? err.message : "Something went wrong.",
+    };
+  }
+}
+
 export async function submitConfirmation(
   assistantId: string,
   requestId: string,

--- a/clients/web/src/domains/chat/interaction-store.test.ts
+++ b/clients/web/src/domains/chat/interaction-store.test.ts
@@ -21,6 +21,43 @@ describe("useInteractionStore", () => {
       expect(s.secretSaved).toBe(false);
     });
 
+    it("showSecret merges sparse rehydrate without erasing rich metadata", () => {
+      // Live SSE event arrives first with full metadata.
+      useInteractionStore.getState().showSecret({
+        requestId: "r1",
+        label: "API Key",
+        description: "Used to call the service",
+        placeholder: "sk-...",
+      });
+      // Sparse rehydrate fires for the same prompt with only the requestId.
+      useInteractionStore.getState().showSecret({ requestId: "r1" });
+      const s = useInteractionStore.getState();
+      expect(s.pendingSecret).toEqual({
+        requestId: "r1",
+        label: "API Key",
+        description: "Used to call the service",
+        placeholder: "sk-...",
+      });
+    });
+
+    it("showSecret replaces fresh when requestId differs", () => {
+      useInteractionStore.getState().showSecret({ requestId: "r1", label: "First" });
+      useInteractionStore.getState().showSecret({ requestId: "r2", label: "Second" });
+      const s = useInteractionStore.getState();
+      expect(s.pendingSecret).toEqual({ requestId: "r2", label: "Second" });
+      expect(s.isSubmittingSecret).toBe(false);
+      expect(s.secretSaved).toBe(false);
+    });
+
+    it("showSecret same-requestId merge preserves submit/saved flags", () => {
+      useInteractionStore.getState().showSecret({ requestId: "r1", label: "API Key" });
+      useInteractionStore.getState().submitSecretStart();
+      useInteractionStore.getState().showSecret({ requestId: "r1" });
+      const s = useInteractionStore.getState();
+      expect(s.isSubmittingSecret).toBe(true);
+      expect(s.pendingSecret?.label).toBe("API Key");
+    });
+
     it("submitSecretStart sets isSubmittingSecret", () => {
       useInteractionStore.getState().showSecret({ requestId: "r1" });
       useInteractionStore.getState().submitSecretStart();

--- a/clients/web/src/domains/chat/interaction-store.ts
+++ b/clients/web/src/domains/chat/interaction-store.ts
@@ -143,8 +143,23 @@ const useInteractionStoreBase = create<InteractionStore>()((set, get) => ({
   ...INITIAL_STATE,
 
   // ----- Secret -----
-  showSecret: (payload) =>
-    set({ pendingSecret: payload, isSubmittingSecret: false, secretSaved: false }),
+  showSecret: (payload) => {
+    const { pendingSecret } = get();
+    // A live `secret_request` SSE event arrives first with full metadata, then
+    // a sparse rehydrate (`{ requestId }`) can fire for the same prompt. Merge
+    // only the defined fields so the sparse rehydrate can't erase rich state.
+    if (pendingSecret && pendingSecret.requestId === payload.requestId) {
+      const defined: Partial<PendingSecretState> = {};
+      for (const key of Object.keys(payload) as (keyof PendingSecretState)[]) {
+        if (payload[key] !== undefined) {
+          (defined[key] as unknown) = payload[key];
+        }
+      }
+      set({ pendingSecret: { ...pendingSecret, ...defined } });
+      return;
+    }
+    set({ pendingSecret: payload, isSubmittingSecret: false, secretSaved: false });
+  },
 
   submitSecretStart: () =>
     set({ isSubmittingSecret: true }),

--- a/clients/web/src/domains/chat/secret-actions.test.ts
+++ b/clients/web/src/domains/chat/secret-actions.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for `handleSecretCancel` — verifies it resolves the pending
+ * interaction on the daemon by posting ONLY `{ requestId }` (no `value`,
+ * no `delivery`), which the daemon treats as cancellation.
+ *
+ * We mock the generated `secretPost` SDK call so we can assert the exact
+ * request body, and mock `turn-coordinator` to keep the test focused.
+ */
+
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+interface CapturedRequest {
+  body: Record<string, unknown>;
+}
+
+const requests: CapturedRequest[] = [];
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  secretPost: async ({ body }: { body: Record<string, unknown> }) => {
+    requests.push({ body });
+    return { error: undefined, response: new Response(null, { status: 200 }) };
+  },
+}));
+
+mock.module("@/domains/chat/turn-coordinator", () => ({
+  endTurn: mock(() => {}),
+}));
+
+import { handleSecretCancel } from "@/domains/chat/secret-actions";
+import { useInteractionStore } from "@/domains/chat/interaction-store";
+import { useStreamStore } from "@/domains/chat/stream-store";
+import { useConversationStore } from "@/stores/conversation-store";
+
+afterEach(() => {
+  requests.length = 0;
+  useInteractionStore.getState().resetAll();
+  useStreamStore.setState({ streamContext: null });
+  useConversationStore.setState({ activeConversationId: null });
+});
+
+describe("handleSecretCancel", () => {
+  it("posts a {requestId}-only cancel with no value or delivery", async () => {
+    useStreamStore.setState({
+      streamContext: { assistantId: "assistant-1", conversationId: "conv-1" },
+    });
+    useInteractionStore.getState().showSecret({ requestId: "req-1", label: "API Key" });
+
+    handleSecretCancel();
+
+    // The cancel POST is fire-and-forget; let the microtask settle.
+    await Promise.resolve();
+
+    expect(requests).toHaveLength(1);
+    const { body } = requests[0]!;
+    expect(body.requestId).toBe("req-1");
+    expect(body).not.toHaveProperty("value");
+    expect(body).not.toHaveProperty("delivery");
+  });
+
+  it("clears the pending secret locally", () => {
+    useStreamStore.setState({
+      streamContext: { assistantId: "assistant-1", conversationId: "conv-1" },
+    });
+    useInteractionStore.getState().showSecret({ requestId: "req-1" });
+
+    handleSecretCancel();
+
+    expect(useInteractionStore.getState().pendingSecret).toBeNull();
+  });
+
+  it("is a no-op POST when there is no pending secret", () => {
+    useStreamStore.setState({
+      streamContext: { assistantId: "assistant-1", conversationId: "conv-1" },
+    });
+
+    handleSecretCancel();
+
+    expect(requests).toHaveLength(0);
+  });
+});

--- a/clients/web/src/domains/chat/secret-actions.ts
+++ b/clients/web/src/domains/chat/secret-actions.ts
@@ -13,7 +13,7 @@ import { useInteractionStore } from "@/domains/chat/interaction-store";
 import { useStreamStore } from "@/domains/chat/stream-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { endTurn } from "@/domains/chat/turn-coordinator";
-import { submitSecretResponse } from "@/domains/chat/api/interactions";
+import { submitSecretCancel, submitSecretResponse } from "@/domains/chat/api/interactions";
 
 /**
  * Submit the user-provided secret value to the daemon.
@@ -65,14 +65,23 @@ export async function handleSecretSubmit(value: string, delivery: string = "stor
 }
 
 /**
- * Cancel the secret prompt — sends an empty "none" delivery to the daemon
- * so the turn can end gracefully, then clears local state.
+ * Cancel the secret prompt — resolves the pending interaction on the daemon
+ * (posting only `{ requestId }` so it's treated as cancellation), then clears
+ * local state so the turn can end gracefully.
  */
 export function handleSecretCancel(): void {
   const ctx = useStreamStore.getState().streamContext;
   const requestId = useInteractionStore.getState().pendingSecret?.requestId;
   if (ctx && requestId) {
-    submitSecretResponse(ctx.assistantId, requestId, "", "none").catch(() => {});
+    submitSecretCancel(ctx.assistantId, requestId)
+      .then((result) => {
+        if (!result.ok) {
+          captureError(new Error(result.error), { context: "cancel_secret" });
+        }
+      })
+      .catch((err) => {
+        captureError(err, { context: "cancel_secret" });
+      });
   }
   useInteractionStore.getState().dismissSecret();
   const convKey = useConversationStore.getState().activeConversationId;


### PR DESCRIPTION
## Problem

The inline "Secure Credential" secret prompt card in the web client had two bugs:

1. **Cancel didn't stick.** `handleSecretCancel()` called `submitSecretResponse(assistantId, requestId, "", "none")`. The daemon's `POST /v1/secret` only accepts `delivery` of `store` / `transient_send` / omitted, and treats an absent `value` as cancellation. So `delivery:"none"` + `value:""` returned 400, the `.catch(()=>{})` swallowed it, and the pending interaction was never resolved — the card then reappeared via rehydration.

2. **Sparse rehydrate clobbered rich state.** `showSecret(payload)` replaced the whole `pendingSecret` object. The live SSE `secret_request` event arrives first with full metadata (service/field/label/description/placeholder); a later rehydration call fires `showSecret({ requestId })` with only the requestId and erased the rich state, so the card rendered a generic "Secret required".

## Fix

- **`api/interactions.ts`** — add `submitSecretCancel(assistantId, requestId)` that posts only `{ requestId }` (no `value`, no `delivery`) via the same `secretPost` SDK call, mirroring `submitSecretResponse`'s shape and `SubmitSecretResponseResult` return type. The daemon resolves the interaction as cancelled.
- **`secret-actions.ts`** — `handleSecretCancel()` now calls `submitSecretCancel`. It remains fire-and-forget (non-blocking) but routes any failure to `captureError` with context `"cancel_secret"` instead of discarding it.
- **`interaction-store.ts`** — `showSecret` merges only the defined (non-`undefined`) fields of an incoming payload into the existing `pendingSecret` when the `requestId` matches, so a sparse `{ requestId }` rehydrate can't erase richer fields. A genuinely new prompt (different `requestId`, or no existing prompt) still sets fresh and resets `isSubmittingSecret`/`secretSaved`; those flags are left untouched on a same-`requestId` merge.

## Tests

- `interaction-store.test.ts`: `showSecret` merges and does not erase `label`/`description`/`placeholder` on `{ requestId }`-only rehydrate; replaces fresh when `requestId` differs; preserves submit/saved flags on same-`requestId` merge.
- `secret-actions.test.ts` (new): `handleSecretCancel` posts a `{ requestId }`-only body (asserts no `value`/`delivery`), clears local state, and is a no-op POST when nothing is pending.

`bunx tsc --noEmit` clean; the two test files pass (33 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)