### PR TITLE
feat(secret-prompt): show reliable credential identity from service/field

### DIFF
--- a/clients/web/src/domains/chat/components/secret-prompt-card.test.tsx
+++ b/clients/web/src/domains/chat/components/secret-prompt-card.test.tsx
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { SecretPromptCard } from "@/domains/chat/components/secret-prompt-card";
+
+function noop() {}
+
+const baseProps = {
+  isSubmitting: false,
+  saved: false,
+  onSave: noop,
+  onSendOnce: noop,
+  onCancel: noop,
+};
+
+describe("SecretPromptCard credential identity line", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("renders a humanized service · field descriptor", () => {
+    render(
+      <SecretPromptCard
+        {...baseProps}
+        secret={{
+          requestId: "req-1",
+          service: "slack_channel",
+          field: "app_token",
+        }}
+      />,
+    );
+
+    expect(screen.queryByText("Slack channel · App token")).not.toBeNull();
+  });
+
+  test("renders only the service when field is absent", () => {
+    render(
+      <SecretPromptCard
+        {...baseProps}
+        secret={{ requestId: "req-2", service: "slack_channel" }}
+      />,
+    );
+
+    expect(screen.queryByText("Slack channel")).not.toBeNull();
+  });
+
+  test("renders no identity line when both service and field are absent", () => {
+    render(
+      <SecretPromptCard
+        {...baseProps}
+        secret={{ requestId: "req-3", label: "API Key" }}
+      />,
+    );
+
+    expect(screen.queryByText("API Key")).not.toBeNull();
+    expect(screen.queryByText("·")).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/components/secret-prompt-card.tsx
+++ b/clients/web/src/domains/chat/components/secret-prompt-card.tsx
@@ -4,10 +4,28 @@ import { type FormEvent, useState } from "react";
 
 import { Card, Input } from "@vellumai/design-library";
 
+/**
+ * Mechanically humanize a structured identifier like `slack_channel` or
+ * `app_token` into "Slack channel" / "App token" — split on underscores and
+ * capitalize the first letter of the first word. Intentionally generic: no
+ * per-service or per-field lookup table. Credential-specific naming is the
+ * model/skill's job, not this shared component's.
+ */
+function humanizeIdentifier(raw: string): string {
+  const words = raw.split("_").filter(Boolean);
+  if (words.length === 0) {
+    return "";
+  }
+  const joined = words.join(" ");
+  return joined.charAt(0).toUpperCase() + joined.slice(1);
+}
+
 export interface SecretPromptCardProps {
   secret: {
     requestId: string;
     label?: string;
+    service?: string;
+    field?: string;
     description?: string;
     placeholder?: string;
     allowOneTimeSend?: boolean;
@@ -35,6 +53,12 @@ export function SecretPromptCard({
   const trimmedValue = value.trim();
   const canSubmit = trimmedValue.length > 0 && !isSubmitting && !saved;
 
+  const credentialIdentity = [secret.service, secret.field]
+    .filter((part): part is string => !!part)
+    .map(humanizeIdentifier)
+    .filter(Boolean)
+    .join(" · ");
+
   const handleSave = (e: FormEvent) => {
     e.preventDefault();
     if (!canSubmit) {
@@ -55,6 +79,11 @@ export function SecretPromptCard({
           <span className="text-body-small-default text-[var(--content-tertiary)]">
             {secret.label || "Secret required"}
           </span>
+          {credentialIdentity && (
+            <span className="text-body-small-default text-[var(--content-tertiary)]">
+              {credentialIdentity}
+            </span>
+          )}
         </div>
       </div>
 

--- a/clients/web/src/domains/chat/types.ts
+++ b/clients/web/src/domains/chat/types.ts
@@ -44,6 +44,8 @@ export interface ChatError {
 export interface PendingSecretState {
   requestId: string;
   label?: string;
+  service?: string;
+  field?: string;
   description?: string;
   placeholder?: string;
   allowOneTimeSend?: boolean;

--- a/clients/web/src/domains/chat/utils/send-message-utils.test.ts
+++ b/clients/web/src/domains/chat/utils/send-message-utils.test.ts
@@ -170,6 +170,8 @@ describe("parsePendingSecretState", () => {
     const raw = {
       requestId: "req-1",
       label: "API Key",
+      service: "slack_channel",
+      field: "app_token",
       description: "Enter your key",
       placeholder: "sk-...",
       allowOneTimeSend: true,
@@ -179,6 +181,16 @@ describe("parsePendingSecretState", () => {
     };
     const result = parsePendingSecretState(raw);
     expect(result).toEqual(raw);
+  });
+
+  it("preserves service and field structured identifiers", () => {
+    const result = parsePendingSecretState({
+      requestId: "req-1",
+      service: "slack_channel",
+      field: "app_token",
+    });
+    expect(result.service).toBe("slack_channel");
+    expect(result.field).toBe("app_token");
   });
 
   it("defaults requestId to empty string when missing", () => {
@@ -195,6 +207,8 @@ describe("parsePendingSecretState", () => {
     expect(result.allowedTools).toBeUndefined();
     expect(result.allowedDomains).toBeUndefined();
     expect(result.purpose).toBeUndefined();
+    expect(result.service).toBeUndefined();
+    expect(result.field).toBeUndefined();
   });
 });
 

--- a/clients/web/src/domains/chat/utils/send-message-utils.ts
+++ b/clients/web/src/domains/chat/utils/send-message-utils.ts
@@ -183,6 +183,8 @@ export function parsePendingSecretState(raw: Record<string, unknown>): PendingSe
   return {
     requestId: typeof raw.requestId === "string" ? raw.requestId : "",
     label: optionalString(raw.label),
+    service: optionalString(raw.service),
+    field: optionalString(raw.field),
     description: optionalString(raw.description),
     placeholder: optionalString(raw.placeholder),
     allowOneTimeSend: optionalBoolean(raw.allowOneTimeSend),

--- a/clients/web/src/domains/chat/utils/stream-handlers/interaction-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/interaction-handlers.ts
@@ -18,6 +18,8 @@ export function handleSecretRequest(
   useInteractionStore.getState().showSecret({
     requestId: event.requestId,
     label: event.label,
+    service: event.service,
+    field: event.field,
     description: event.description,
     placeholder: event.placeholder,
     allowOneTimeSend: event.allowOneTimeSend,

--- a/clients/web/src/types/interaction-ui-types.ts
+++ b/clients/web/src/types/interaction-ui-types.ts
@@ -27,6 +27,8 @@ import type {
 export interface PendingSecretState {
   requestId: string;
   label?: string;
+  service?: string;
+  field?: string;
   description?: string;
   placeholder?: string;
   allowOneTimeSend?: boolean;


### PR DESCRIPTION
## Problem

The inline secret prompt card ("Secure Credential") relied entirely on the model-authored `label`. The wire `secret_request` event **also** carries reliable structured identifiers — `service` (e.g. `"slack_channel"`) and `field` (e.g. `"app_token"`) — but the web client dropped them at every layer (type, live SSE handler, rehydration parser, card props). When `label` was vague or missing, the user couldn't tell which credential was being requested.

## Change

Thread `service`/`field` through:

- **Type** — added `service?`/`field?` to `PendingSecretState` (both the `@/types/interaction-ui-types` and `@/domains/chat/types` copies, which are kept in sync).
- **Live SSE path** — `handleSecretRequest` forwards `event.service`/`event.field` into `showSecret(...)` (the `SecretRequestEvent` schema has both as required fields). This path works **standalone**.
- **Rehydration parse** — `parsePendingSecretState` reads `service`/`field` defensively via the existing `optionalString` helper. This path depends on a companion daemon PR (`asharma53/secret-pending-metadata`) returning `service`/`field` from the pending-interactions GET; reading defensively is harmless before that lands.
- **Card render** — a small muted credential-identity descriptor renders near the header (e.g. `Slack channel · App token`), only when at least one of `service`/`field` is present.

## Generic humanization (no hardcoded lookup)

The descriptor is built with a tiny local pure helper that splits on `_` and capitalizes — `slack_channel` → "Slack channel", `app_token` → "App token". **No per-service / Slack-specific mapping table.** Credential-specific naming stays the model/skill's job; the shared component only does mechanical humanization.

## Tests

- `parsePendingSecretState` — preserves `service`/`field`, returns `undefined` when absent.
- `SecretPromptCard` — renders the humanized identity line for `service: "slack_channel"` + `field: "app_token"`, renders nothing extra when both absent.
- `bunx tsc --noEmit` clean; the two relevant test files pass (22/22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)