### PR TITLE
docs(slack-setup): make credential prompts name the exact Slack token and prefix

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -782,7 +782,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-15T21:08:24.000Z"
+      "updatedAt": "2026-06-19T16:53:05.000Z"
     },
     {
       "id": "start-the-day",
@@ -1024,7 +1024,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-18T01:04:56.000Z"
+      "updatedAt": "2026-06-18T03:26:43.000Z"
     },
     {
       "id": "vellum-oauth-integrations",

--- a/skills/slack-app-setup/SKILL.md
+++ b/skills/slack-app-setup/SKILL.md
@@ -98,8 +98,8 @@ Do both of the following in the **same response** — the instruction text and t
 
    ```bash
    assistant credentials prompt --service slack_channel --field app_token \
-     --label "App-Level Token" --placeholder "xapp-..." \
-     --description "Paste the App-Level Token you just generated"
+     --label "Slack App-Level Token (xapp-...)" --placeholder "xapp-..." \
+     --description "Paste the App-Level Token you just generated. Do not use the Client Secret or Signing Secret."
    ```
 
 ⚠️ CRITICAL — point of action: **Fire the `assistant credentials prompt` command in this same response. Do not wait for the user to say "okay I have it" before firing it.** The secure prompt queues silently; the user fills it when they're ready. Waiting for verbal confirmation leaves the user stuck staring at instructions with no input field.
@@ -120,8 +120,8 @@ Then collect:
 
   ```bash
   assistant credentials prompt --service slack_channel --field bot_token \
-    --label "Bot User OAuth Token" --placeholder "xoxb-..." \
-    --description "From Install App page — the Bot User OAuth Token"
+    --label "Slack Bot User OAuth Token (xoxb-...)" --placeholder "xoxb-..." \
+    --description "Paste the Bot User OAuth Token from the Install App page. Do not use the App-Level Token, Client Secret, or Signing Secret."
   ```
 
 > ✓ Checkpoint: After Step 3, the `app_token` and `bot_token` are both in the credential store and the user has confirmed both prompts came back successful. If either prompt failed, re-run it before moving on.


### PR DESCRIPTION
## Problem

During Slack app setup, the assistant collects credentials through `assistant credentials prompt --service slack_channel`. The labels rendered inside the secure credential widget were technically correct but ambiguous:

- App-Level Token prompt → label `App-Level Token`
- Bot User OAuth Token prompt → label `Bot User OAuth Token`

A user mid-setup is staring at four similarly named Slack secrets — **App-Level Token** (`xapp-`), **Bot User OAuth Token** (`xoxb-`), **Client Secret**, and **Signing Secret**. From the widget alone (which shows only the label/placeholder/description), they could not reliably tell which secret to paste, leading to mis-pasted credentials and a failed connection.

## Fix

Make each Slack credential prompt self-describing inside the widget:

- **Label** now names the exact credential *and* its prefix — `Slack App-Level Token (xapp-...)`, `Slack Bot User OAuth Token (xoxb-...)`.
- **Description** explicitly warns against the wrong tokens (e.g. "Do not use the Client Secret or Signing Secret").
- Placeholders unchanged (already `xapp-...` / `xoxb-...`).

No new `--field` or `--service` values were introduced — the skill's existing `app_token` / `bot_token` fields and `slack_channel` service are preserved. Only the label/placeholder/description copy changed.

## Catalog

`skills/catalog.json` was regenerated via `node scripts/skills/generate-catalog.mjs` so the "Check catalog.json is up to date" CI gate passes. The diff updates the `updatedAt` for `slack-app-setup` (this change) plus a pre-existing `updatedAt` drift for `vellum-memory-v3-migration` that any full regen sweeps in. `node scripts/skills/check-catalog.mjs` exits 0.

## Validation

- `node scripts/skills/lint-skill-spec.mjs` → all 68 SKILL.md files conform.
- `node scripts/skills/check-catalog.mjs` → catalog up to date (exit 0).
- YAML frontmatter intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)