### PR TITLE
feat(secret-prompt): persist and return secret prompt metadata; tolerate legacy cancel

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -19315,9 +19315,37 @@ paths:
                     additionalProperties: {}
                     description: Pending confirmation details or null
                   pendingSecret:
-                    type: object
-                    properties: {}
-                    additionalProperties: {}
+                    anyOf:
+                      - type: object
+                        properties:
+                          requestId:
+                            type: string
+                          service:
+                            type: string
+                          field:
+                            type: string
+                          label:
+                            type: string
+                          description:
+                            type: string
+                          placeholder:
+                            type: string
+                          purpose:
+                            type: string
+                          allowedTools:
+                            type: array
+                            items:
+                              type: string
+                          allowedDomains:
+                            type: array
+                            items:
+                              type: string
+                          allowOneTimeSend:
+                            type: boolean
+                        required:
+                          - requestId
+                        additionalProperties: {}
+                      - type: "null"
                     description: Pending secret request or null
                   interactions:
                     type: array

--- a/assistant/src/__tests__/approval-routes-http.test.ts
+++ b/assistant/src/__tests__/approval-routes-http.test.ts
@@ -689,6 +689,82 @@ describe("standalone approval endpoints — HTTP layer", () => {
       await stopServer();
     });
 
+    test("cancels a secret request when value is omitted", async () => {
+      let secretRequestId: string | undefined;
+      let secretValue: string | undefined;
+
+      const session = makeIdleSession({
+        onSecret: (reqId, val) => {
+          secretRequestId = reqId;
+          secretValue = val;
+        },
+      });
+
+      await startServer(() => session);
+
+      pendingInteractions.register("secret-cancel-1", {
+        conversationId: "conv-1",
+        kind: "secret",
+      });
+
+      const res = await fetch(url("secret"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify({ requestId: "secret-cancel-1" }),
+      });
+      const body = (await res.json()) as { accepted: boolean };
+
+      expect(res.status).toBe(200);
+      expect(body.accepted).toBe(true);
+      expect(secretRequestId).toBe("secret-cancel-1");
+      expect(secretValue).toBeUndefined();
+      expect(pendingInteractions.get("secret-cancel-1")).toBeUndefined();
+
+      await stopServer();
+    });
+
+    test('legacy delivery "none" cancels the request without 400', async () => {
+      let secretRequestId: string | undefined;
+      let secretValue: string | undefined;
+      let secretDelivery: string | undefined;
+
+      const session = makeIdleSession({
+        onSecret: (reqId, val, del) => {
+          secretRequestId = reqId;
+          secretValue = val;
+          secretDelivery = del;
+        },
+      });
+
+      await startServer(() => session);
+
+      pendingInteractions.register("secret-legacy-cancel-1", {
+        conversationId: "conv-1",
+        kind: "secret",
+      });
+
+      const res = await fetch(url("secret"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify({
+          requestId: "secret-legacy-cancel-1",
+          value: "ignored-by-cancel",
+          delivery: "none",
+        }),
+      });
+      const body = (await res.json()) as { accepted: boolean };
+
+      expect(res.status).toBe(200);
+      expect(body.accepted).toBe(true);
+      expect(secretRequestId).toBe("secret-legacy-cancel-1");
+      // delivery "none" normalizes to the cancellation path: value/delivery dropped.
+      expect(secretValue).toBeUndefined();
+      expect(secretDelivery).toBeUndefined();
+      expect(pendingInteractions.get("secret-legacy-cancel-1")).toBeUndefined();
+
+      await stopServer();
+    });
+
     test("rejects a non-secret requestId without consuming it", async () => {
       /**
        * /v1/secret only settles secret prompts. A confirmation (or any other
@@ -785,6 +861,58 @@ describe("standalone approval endpoints — HTTP layer", () => {
       expect(confirmReceived).toHaveLength(1);
       expect(confirmReceived[0].requestId).toBe("auto-req-1");
       expect(confirmReceived[0].decision).toBe("allow");
+
+      await stopServer();
+    });
+  });
+
+  // ── GET /v1/pending-interactions ─────────────────────────────────────
+
+  describe("GET /v1/pending-interactions", () => {
+    test("returns full secret prompt metadata for a registered secret", async () => {
+      const session = makeIdleSession();
+      await startServer(() => session);
+
+      pendingInteractions.register("secret-meta-1", {
+        conversationId: "conv-meta",
+        kind: "secret",
+        secretDetails: {
+          service: "github",
+          field: "token",
+          label: "GitHub Token",
+          description: "Personal access token",
+          placeholder: "ghp_...",
+          purpose: "Push commits",
+          allowedTools: ["git_push"],
+          allowedDomains: ["github.com"],
+          allowOneTimeSend: true,
+        },
+      });
+
+      const res = await fetch(
+        url("pending-interactions?conversationId=conv-meta"),
+        {
+          method: "GET",
+          headers: { ...AUTH_HEADERS },
+        },
+      );
+      const body = (await res.json()) as {
+        pendingSecret: Record<string, unknown> | null;
+      };
+
+      expect(res.status).toBe(200);
+      expect(body.pendingSecret).toEqual({
+        requestId: "secret-meta-1",
+        service: "github",
+        field: "token",
+        label: "GitHub Token",
+        description: "Personal access token",
+        placeholder: "ghp_...",
+        purpose: "Push commits",
+        allowedTools: ["git_push"],
+        allowedDomains: ["github.com"],
+        allowOneTimeSend: true,
+      });
 
       await stopServer();
     });

--- a/assistant/src/__tests__/secret-response-routing.test.ts
+++ b/assistant/src/__tests__/secret-response-routing.test.ts
@@ -106,6 +106,41 @@ describe("secret response routing", () => {
     await promise;
   });
 
+  test("prompt registers public secretDetails without the value", async () => {
+    const promise = prompter.prompt(
+      "github",
+      "token",
+      "GitHub Token",
+      "desc",
+      "placeholder",
+      "session-1",
+      "Push commits",
+      ["git_push"],
+      ["github.com"],
+    );
+    const msg = broadcastedMessages[0] as SecretRequestEvent;
+    const entry = _piStore.get(msg.requestId) as {
+      kind: string;
+      secretDetails?: Record<string, unknown>;
+    };
+    expect(entry.kind).toBe("secret");
+    expect(entry.secretDetails).toMatchObject({
+      service: "github",
+      field: "token",
+      label: "GitHub Token",
+      description: "desc",
+      placeholder: "placeholder",
+      purpose: "Push commits",
+      allowedTools: ["git_push"],
+      allowedDomains: ["github.com"],
+    });
+    // SECURITY: the secret value is never part of the registered metadata.
+    expect(JSON.stringify(entry.secretDetails)).not.toContain("test-value");
+    // Clean up
+    prompter.resolveSecret(msg.requestId, undefined);
+    await promise;
+  });
+
   test("resolveSecret for unknown requestId is a no-op", () => {
     // Should not throw
     prompter.resolveSecret("unknown-id", "value", "store");

--- a/assistant/src/permissions/secret-prompter.ts
+++ b/assistant/src/permissions/secret-prompter.ts
@@ -77,18 +77,32 @@ export class SecretPrompter {
         resolve({ value: null, delivery: "store" });
       }, timeoutMs);
 
+      const config = getConfig();
+
       // Register all lifecycle state in pendingInteractions — same pattern as
       // host proxies and PermissionPrompter. The prompter tracks ownership via ownedIds.
+      // SECURITY: secretDetails carries only the public prompt metadata broadcast
+      // on the secret_request event — never the secret value the user will supply.
       pendingInteractions.register(requestId, {
         conversationId: effectiveConversationId,
         kind: "secret",
+        secretDetails: {
+          service,
+          field,
+          label,
+          description,
+          placeholder,
+          purpose,
+          allowedTools,
+          allowedDomains,
+          allowOneTimeSend: config.secretDetection.allowOneTimeSend,
+        },
         rpcResolve: resolve as (value: unknown) => void,
         rpcReject: reject,
         timer,
       });
       this.ownedIds.add(requestId);
 
-      const config = getConfig();
       const msg: SecretRequestMessage = {
         type: "secret_request",
         requestId,

--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -63,6 +63,24 @@ export interface QuestionDetails {
   entries: QuestionEntry[];
 }
 
+/**
+ * Public prompt metadata for a pending `secret` interaction, retained so a
+ * cold conversation load can rehydrate the secret prompt with its full
+ * descriptive context. SECURITY: never carries the secret value — only the
+ * public fields already broadcast on the `secret_request` event.
+ */
+export interface SecretDetails {
+  service: string;
+  field: string;
+  label: string;
+  description?: string;
+  placeholder?: string;
+  purpose?: string;
+  allowedTools?: string[];
+  allowedDomains?: string[];
+  allowOneTimeSend?: boolean;
+}
+
 export interface PendingInteraction {
   /**
    * Owning conversation, when the interaction was raised inside one. Absent
@@ -84,6 +102,8 @@ export interface PendingInteraction {
   confirmationDetails?: ConfirmationDetails;
   /** For a pending `question`: the full batched entries, so a history-load render can rehydrate the question card. */
   questionDetails?: QuestionDetails;
+  /** For a pending `secret`: the public prompt metadata, so a cold load can rehydrate the secret prompt. */
+  secretDetails?: SecretDetails;
   /** For ACP permissions: resolves directly without a Conversation object. */
   directResolve?: (decision: UserDecision) => void;
   /** When set, the host_bash request should be routed to this specific client. */

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -116,20 +116,34 @@ function handleConfirm({ body }: RouteHandlerArgs) {
  */
 function handleSecret({ body }: RouteHandlerArgs) {
   const requestId = body?.requestId as string | undefined;
-  const value = body?.value as string | undefined;
   const delivery = body?.delivery as string | undefined;
 
   if (!requestId || typeof requestId !== "string") {
     throw new BadRequestError("requestId is required");
   }
 
+  // Legacy compat shim: already-shipped web clients send `delivery: "none"` to
+  // cancel a secret prompt. Normalize it to the cancellation path (value
+  // undefined) so the request settles cleanly rather than 400-ing and stranding
+  // the pending interaction.
+  const isCancel = delivery === "none";
+  const value = isCancel
+    ? undefined
+    : (body?.value as string | undefined);
+
   if (
     delivery !== undefined &&
     delivery !== "store" &&
-    delivery !== "transient_send"
+    delivery !== "transient_send" &&
+    delivery !== "none"
   ) {
     throw new BadRequestError('delivery must be "store" or "transient_send"');
   }
+
+  const effectiveDelivery =
+    isCancel || delivery === undefined
+      ? undefined
+      : (delivery as "store" | "transient_send");
 
   const interaction = pendingInteractions.get(requestId);
   if (!interaction) {
@@ -153,11 +167,7 @@ function handleSecret({ body }: RouteHandlerArgs) {
     ? findConversation(interaction.conversationId)
     : undefined;
   if (conversation?.hasPendingSecret(requestId)) {
-    conversation.handleSecretResponse(
-      requestId,
-      value,
-      delivery as "store" | "transient_send" | undefined,
-    );
+    conversation.handleSecretResponse(requestId, value, effectiveDelivery);
     return { accepted: true };
   }
 
@@ -170,7 +180,7 @@ function handleSecret({ body }: RouteHandlerArgs) {
   );
   (resolved?.rpcResolve as ((r: SecretPromptResult) => void) | undefined)?.({
     value: value ?? null,
-    delivery: (delivery as SecretDelivery) ?? "store",
+    delivery: (effectiveDelivery as SecretDelivery) ?? "store",
   });
   return { accepted: true };
 }
@@ -246,6 +256,15 @@ function handleListPendingInteractions({ queryParams }: RouteHandlerArgs) {
     pendingSecret: secret
       ? {
           requestId: secret.requestId,
+          service: secret.secretDetails?.service,
+          field: secret.secretDetails?.field,
+          label: secret.secretDetails?.label,
+          description: secret.secretDetails?.description,
+          placeholder: secret.secretDetails?.placeholder,
+          purpose: secret.secretDetails?.purpose,
+          allowedTools: secret.secretDetails?.allowedTools,
+          allowedDomains: secret.secretDetails?.allowedDomains,
+          allowOneTimeSend: secret.secretDetails?.allowOneTimeSend,
         }
       : null,
   };
@@ -340,8 +359,20 @@ export const ROUTES: RouteDefinition[] = [
         .describe("Pending confirmation details or null")
         .optional(),
       pendingSecret: z
-        .object({})
+        .object({
+          requestId: z.string(),
+          service: z.string().optional(),
+          field: z.string().optional(),
+          label: z.string().optional(),
+          description: z.string().optional(),
+          placeholder: z.string().optional(),
+          purpose: z.string().optional(),
+          allowedTools: z.array(z.string()).optional(),
+          allowedDomains: z.array(z.string()).optional(),
+          allowOneTimeSend: z.boolean().optional(),
+        })
         .passthrough()
+        .nullable()
         .describe("Pending secret request or null")
         .optional(),
       interactions: z


### PR DESCRIPTION
## Summary

When a tool needs a secret, the daemon broadcasts a `secret_request` SSE event carrying rich metadata (`service`, `field`, `label`, `description`, `placeholder`, `purpose`, `allowedTools`, `allowedDomains`, `allowOneTimeSend`). But the pending-interaction tracker dropped all of it, so on a cold conversation load `GET /v1/pending-interactions` returned only `{ requestId }` and the rehydrated secret prompt rendered generic.

This PR:

- **Persists secret prompt metadata.** Adds a `SecretDetails` interface and an optional `secretDetails` field on `PendingInteraction` (mirrors `ConfirmationDetails`). `SecretPrompter.prompt()` populates it at registration.
- **Returns full metadata from GET.** `handleListPendingInteractions` now returns the full public `pendingSecret` metadata plus `requestId`, and the `pending_interactions` response schema documents the fields.
- **Tolerates legacy cancel.** `POST /v1/secret` with `delivery: "none"` (sent by already-shipped web clients to cancel) is normalized to the cancellation path instead of 400-ing and stranding the pending interaction. Genuinely-invalid delivery values are still rejected.

## SECURITY

Only the public prompt metadata already broadcast on the `secret_request` event is persisted and returned — **never** the secret value the user supplies.

## Tests

- `GET /v1/pending-interactions` returns full `pendingSecret` metadata for a registered secret prompt.
- `POST /v1/secret` with omitted `value` cancels the interaction.
- `POST /v1/secret` with legacy `delivery: "none"` cancels (no 400).
- A non-secret requestId posted to `/v1/secret` is still rejected without consuming the real pending interaction (existing test).
- `prompt()` registers `secretDetails` without the secret value.

`assistant/openapi.yaml` regenerated via `bun run generate:openapi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)