### PR TITLE
fix(document-editor): default document_update to the open document when surface_id is omitted

### DIFF
--- a/assistant/src/__tests__/document-tool-security.test.ts
+++ b/assistant/src/__tests__/document-tool-security.test.ts
@@ -264,12 +264,15 @@ describe("executeDocumentUpdate — input validation", () => {
     seedFixtureDocuments();
   });
 
-  test("returns Invalid input when surface_id is missing", () => {
-    const result = executeDocumentUpdate({}, makeContext());
-    expect(result.isError).toBe(true);
-    const body = parseResult<{ error: string }>(result);
-    expect(body.error).toContain("Invalid input: surface_id is required");
-    expect(body.error).not.toContain("Document not found");
+  test("resolves to the conversation's document when surface_id is omitted", () => {
+    const result = executeDocumentUpdate(
+      { content: "appended chunk" },
+      makeContext({ sendToClient: () => {} }),
+    );
+    expect(result.isError).toBe(false);
+    const body = parseResult<{ surface_id: string; success: boolean }>(result);
+    expect(body.success).toBe(true);
+    expect(body.surface_id).toBe("doc-current");
   });
 
   test("returns Invalid input when content is missing", () => {

--- a/assistant/src/__tests__/document-update-default-surface.test.ts
+++ b/assistant/src/__tests__/document-update-default-surface.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { getDocumentById } from "../documents/document-store.js";
+import { getSqlite } from "../memory/db-connection.js";
+import { executeDocumentUpdate } from "../tools/document/document-tool.js";
+import type { ToolContext, ToolExecutionResult } from "../tools/types.js";
+import { resetDbForTesting } from "./db-test-helpers.js";
+
+function makeContext(overrides: Partial<ToolContext> = {}): ToolContext {
+  return {
+    workingDir: "/tmp/project",
+    conversationId: "conv-current",
+    trustClass: "trusted_contact",
+    executionChannel: "slack",
+    sendToClient: () => {},
+    ...overrides,
+  };
+}
+
+function parseResult<T>(result: ToolExecutionResult): T {
+  return JSON.parse(result.content) as T;
+}
+
+function bootstrapDocumentTables(): void {
+  resetDbForTesting();
+  const raw = getSqlite();
+  raw.exec(/*sql*/ `
+    DROP TABLE IF EXISTS document_conversations;
+    DROP TABLE IF EXISTS documents;
+    DROP TABLE IF EXISTS conversations;
+
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL DEFAULT (strftime('%s','now') * 1000)
+    );
+
+    CREATE TABLE documents (
+      surface_id TEXT PRIMARY KEY,
+      conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+      title TEXT NOT NULL,
+      content TEXT NOT NULL,
+      word_count INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE document_conversations (
+      surface_id TEXT NOT NULL,
+      conversation_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      PRIMARY KEY (surface_id, conversation_id),
+      FOREIGN KEY (surface_id) REFERENCES documents(surface_id) ON DELETE CASCADE
+    );
+  `);
+}
+
+function seedDocument(params: {
+  surfaceId: string;
+  conversationId: string;
+  title: string;
+  content: string;
+  createdAt: number;
+  updatedAt?: number;
+}): void {
+  const raw = getSqlite();
+  raw
+    .query(`INSERT OR IGNORE INTO conversations (id, created_at) VALUES (?, ?)`)
+    .run(params.conversationId, params.createdAt);
+  raw
+    .query(
+      `INSERT INTO documents (surface_id, conversation_id, title, content, word_count, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      params.surfaceId,
+      params.conversationId,
+      params.title,
+      params.content,
+      params.content.split(/\s+/).filter(Boolean).length,
+      params.createdAt,
+      params.updatedAt ?? params.createdAt,
+    );
+  raw
+    .query(
+      `INSERT OR IGNORE INTO document_conversations (surface_id, conversation_id, created_at) VALUES (?, ?, ?)`,
+    )
+    .run(params.surfaceId, params.conversationId, params.createdAt);
+}
+
+describe("executeDocumentUpdate — default surface_id resolution", () => {
+  beforeEach(() => {
+    bootstrapDocumentTables();
+  });
+
+  test("appends to the conversation's only document when surface_id is omitted", () => {
+    const surfaceId = "doc-only";
+    seedDocument({
+      surfaceId,
+      conversationId: "conv-current",
+      title: "Dating in 2026",
+      content: "# Dating in 2026\n\nIntro.",
+      createdAt: Date.now(),
+    });
+
+    const result = executeDocumentUpdate(
+      { content: "## Section two", mode: "append" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    const body = parseResult<{ surface_id: string; success: boolean }>(result);
+    expect(body.success).toBe(true);
+    expect(body.surface_id).toBe(surfaceId);
+    expect(getDocumentById(surfaceId)?.content).toBe(
+      "# Dating in 2026\n\nIntro.\n\n## Section two",
+    );
+  });
+
+  test("targets the most recently updated document when several exist", () => {
+    const now = Date.now();
+    seedDocument({
+      surfaceId: "doc-old",
+      conversationId: "conv-current",
+      title: "Old",
+      content: "old",
+      createdAt: now - 10_000,
+      updatedAt: now - 10_000,
+    });
+    seedDocument({
+      surfaceId: "doc-fresh",
+      conversationId: "conv-current",
+      title: "Fresh",
+      content: "fresh",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const result = executeDocumentUpdate({ content: "more" }, makeContext());
+
+    expect(result.isError).toBe(false);
+    const body = parseResult<{ surface_id: string }>(result);
+    expect(body.surface_id).toBe("doc-fresh");
+    expect(getDocumentById("doc-fresh")?.content).toBe("fresh\n\nmore");
+    expect(getDocumentById("doc-old")?.content).toBe("old");
+  });
+
+  test("an explicit surface_id still wins over the default", () => {
+    const now = Date.now();
+    seedDocument({
+      surfaceId: "doc-target",
+      conversationId: "conv-current",
+      title: "Target",
+      content: "target",
+      createdAt: now - 10_000,
+      updatedAt: now - 10_000,
+    });
+    seedDocument({
+      surfaceId: "doc-fresh",
+      conversationId: "conv-current",
+      title: "Fresh",
+      content: "fresh",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const result = executeDocumentUpdate(
+      { surface_id: "doc-target", content: "hit" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    expect(parseResult<{ surface_id: string }>(result).surface_id).toBe(
+      "doc-target",
+    );
+    expect(getDocumentById("doc-target")?.content).toBe("target\n\nhit");
+    expect(getDocumentById("doc-fresh")?.content).toBe("fresh");
+  });
+
+  test("errors helpfully when the conversation has no document", () => {
+    const result = executeDocumentUpdate(
+      { content: "orphan chunk" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("no document is open");
+    expect(result.content).toContain("document_create");
+  });
+
+  test("still requires content", () => {
+    seedDocument({
+      surfaceId: "doc-only",
+      conversationId: "conv-current",
+      title: "X",
+      content: "x",
+      createdAt: Date.now(),
+    });
+
+    const result = executeDocumentUpdate({ mode: "append" }, makeContext());
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("content is required");
+  });
+});

--- a/assistant/src/config/bundled-skills/document-editor/SKILL.md
+++ b/assistant/src/config/bundled-skills/document-editor/SKILL.md
@@ -33,13 +33,13 @@ Write and edit long-form documents using the built-in rich text editor. Document
 
 This is the default path when the user asks you to write something.
 
-1. **Create the document**: Call `document_create` with a title (inferred from the request). Call the tool immediately, not after conversational preamble. Capture the `surface_id` from the response — every subsequent `document_update` call must reference it.
+1. **Create the document**: Call `document_create` with a title (inferred from the request). Call the tool immediately, not after conversational preamble.
 2. **Write content in Markdown**: Use proper structure (`#` for titles, `##` for sections), **bold**, _italic_, code blocks, tables, lists, blockquotes as appropriate.
-3. **CRITICAL - Stream content in chunks**: Call `document_update` MULTIPLE times, not just once. Break content into logical chunks (paragraphs, sections, or every 200-300 words). Call `document_update` with `mode: "append"` for EACH chunk separately. The user experiences real-time content appearing as you write.
+3. **CRITICAL - Stream content in chunks**: Call `document_update` MULTIPLE times, not just once. Break content into logical chunks (paragraphs, sections, or every 200-300 words). Call `document_update` with `mode: "append"` for EACH chunk separately. When you are streaming into the document you just created, `surface_id` is optional — omit it and pass only `content`, and the update targets that document. The user experiences real-time content appearing as you write.
 
 ### Recovering from a failed update
 
-If a `document_update` call fails with an `Invalid input` error (for example because `surface_id` was missing), do NOT call `document_create` again. The `surface_id` you need is in the tool result of the most recent `document_create` call in this turn. Retry `document_update` with that `surface_id` and the same content. Creating a second document with the same title produces a duplicate for the user.
+If a `document_update` call fails with an `Invalid input` error, do NOT call `document_create` again — that produces a duplicate for the user. The most common cause is a missing `content` field: resend the call with the chunk's Markdown in `content`. You can omit `surface_id` to target the document you are currently writing; pass it explicitly only when editing a different existing document.
 
 ## Editing an existing document
 

--- a/assistant/src/config/bundled-skills/document-editor/TOOLS.json
+++ b/assistant/src/config/bundled-skills/document-editor/TOOLS.json
@@ -50,7 +50,7 @@
         "properties": {
           "surface_id": {
             "type": "string",
-            "description": "The ID of the document surface to update"
+            "description": "The ID of the document surface to update. Optional — when omitted, the most recently updated document in this conversation is used, so streaming successive chunks needs only `content`."
           },
           "content": {
             "type": "string",
@@ -62,7 +62,7 @@
             "description": "Whether to replace all content or append to the end. Defaults to append."
           }
         },
-        "required": ["surface_id", "content"]
+        "required": ["content"]
       },
       "executor": "tools/document-update.ts",
       "execution_target": "host"

--- a/assistant/src/tools/document/document-tool.ts
+++ b/assistant/src/tools/document/document-tool.ts
@@ -269,16 +269,41 @@ export function executeDocumentCreate(
   };
 }
 
+/**
+ * Resolve the target document for an update. An explicit `surface_id` is used
+ * verbatim; when absent, the update targets the conversation's most recently
+ * updated document (`getDocumentsForConversation` orders by `updated_at DESC`),
+ * which is the document being streamed into. This lets a model stream chunks
+ * with only `content` instead of threading the opaque `surface_id` back through
+ * every call — a step weak models routinely drop, leaving the document stuck on
+ * its first chunk.
+ */
+function resolveUpdateSurfaceId(
+  input: Record<string, unknown>,
+  context: ToolContext,
+): ToolExecutionResult | string {
+  if (typeof input.surface_id === "string" && input.surface_id.trim() !== "") {
+    return input.surface_id;
+  }
+  const docs = getDocumentsForConversation(context.conversationId);
+  if (docs.length === 0) {
+    return invalidInput(
+      "surface_id is required: no document is open in this conversation. Call document_create first.",
+    );
+  }
+  return docs[0].surfaceId;
+}
+
 export function executeDocumentUpdate(
   input: Record<string, unknown>,
   context: ToolContext,
 ): ToolExecutionResult {
-  const surfaceIdOrError = validateSurfaceId(input);
-  if (typeof surfaceIdOrError !== "string") return surfaceIdOrError;
-  const surfaceId = surfaceIdOrError;
   if (typeof input.content !== "string") {
     return invalidInput("content is required and must be a string");
   }
+  const surfaceIdOrError = resolveUpdateSurfaceId(input, context);
+  if (typeof surfaceIdOrError !== "string") return surfaceIdOrError;
+  const surfaceId = surfaceIdOrError;
   // Loose `!= null` to match validateInputAgainstSchema, which treats null as
   // "absent" for enum checks — without this, { mode: null } passes the
   // factory validator but rejects here. The `?? "append"` below handles null.


### PR DESCRIPTION
## Why

A MiniMax M3 doc-writer incident (feedback `019ee07b`): the model wrote a full blog post but the document froze after the intro. Wire logs show `document_create` succeeded, then **nine** `document_update` calls each with empty `input` (`input: ""`), every one failing `surface_id is required; content is required`. M3 then gave up and dumped the rest into chat with a fabricated *"the streaming tool keeps failing"* excuse.

Root cause for the friction: `document_update` required **both** `surface_id` and `content`. Streaming successive chunks meant threading the opaque `surface_id` (`doc-5b39ab96…`) from the `document_create` result back through every call. That extra step — copy an opaque id *and* serialize the body — is exactly what weak models drop. The *succeeding* `document_create` call had no prior id to thread; the *failing* updates did.

## What

Make `surface_id` optional on `document_update`:

- When omitted, the update targets the conversation's **most recently updated** document (`getDocumentsForConversation` orders by `updated_at DESC`) — the document being streamed into. A chunk now needs only `content`.
- An explicit `surface_id` still wins (editing a *different* existing document).
- An update with **no** open document returns a clear *"call document_create first"* error instead of a bare schema rejection.

Changes: relax `required` to `["content"]` in `TOOLS.json`, resolve the default in `executeDocumentUpdate`, and update the SKILL.md streaming guidance + schema descriptions so the model is told `surface_id` is optional.

This shrinks the per-chunk payload to the single field the model must actually produce. It does not, on its own, rescue a call where `content` is *also* empty (the captured trace) — that silent-loop case is addressed by a companion change to the loop advisor.

## Test

`bun test src/__tests__/document-update-default-surface.test.ts` — 5 pass (single-doc default, most-recent-of-many, explicit-id-wins, no-doc error, content-still-required). Existing `document-tool-security` / `document-create-dedupe` / `document-find-replace` suites updated and green (40 total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)