### PR TITLE
fix(exploration-drift): escalate empty-input skill_execute loops to the advisor

### DIFF
--- a/assistant/src/__tests__/exploration-drift-empty-input-escalation.test.ts
+++ b/assistant/src/__tests__/exploration-drift-empty-input-escalation.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Tests for the `exploration-drift` plugin's third trigger: empty-input
+ * `skill_execute` loop → advisor escalation.
+ *
+ * The hook lazily imports the advisor gate and consult on the rare escalation
+ * path, so both are mocked here to keep the provider graph out of the test and
+ * to observe how often the consult runs.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let consultCalls = 0;
+let advisorEnabled = true;
+let advisorReply =
+  "Re-issue document_update with content set to the next section.";
+
+mock.module("../plugins/defaults/advisor/advisor-gate.js", () => ({
+  advisorEnabledForProfile: () => advisorEnabled,
+}));
+mock.module("../plugins/defaults/advisor/consult.js", () => ({
+  consultAdvisor: async () => {
+    consultCalls++;
+    return advisorReply;
+  },
+}));
+
+import type { PluginLogger, PostToolUseContext } from "../plugin-api/types.js";
+import postToolUse, {
+  EMPTY_INPUT_ESCALATE_THRESHOLD,
+  resetExplorationDriftStateForTests,
+} from "../plugins/defaults/exploration-drift/hooks/post-tool-use.js";
+import type { Message, ToolResultContent } from "../providers/types.js";
+
+const noopLogger: PluginLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+};
+
+const MINIMAX_MODEL = "accounts/fireworks/models/minimax-m3";
+const GENERIC_MODEL = "claude-test-model";
+const INNER_TOOL = "document_update";
+
+let conversationCounter = 0;
+function freshConversationId(): string {
+  conversationCounter++;
+  return `conv-empty-input-${conversationCounter}`;
+}
+
+/** Assistant turn issuing a single empty-input `skill_execute` call. */
+function emptyCallTurn(id: string, activity: string): Message {
+  return {
+    role: "assistant",
+    content: [
+      {
+        type: "tool_use",
+        id,
+        name: "skill_execute",
+        input: { tool: INNER_TOOL, input: "", activity },
+      },
+    ],
+  };
+}
+
+/** Assistant turn issuing a populated (stringified-JSON) `skill_execute` call. */
+function populatedCallTurn(id: string, activity: string): Message {
+  return {
+    role: "assistant",
+    content: [
+      {
+        type: "tool_use",
+        id,
+        name: "skill_execute",
+        input: {
+          tool: INNER_TOOL,
+          input: '{"content":"a section"}',
+          activity,
+        },
+      },
+    ],
+  };
+}
+
+function erroredResultTurn(toolUseId: string): Message {
+  return {
+    role: "user",
+    content: [
+      {
+        type: "tool_result",
+        tool_use_id: toolUseId,
+        content:
+          'Invalid input for tool "document_update": content is required',
+        is_error: true,
+      },
+    ],
+  };
+}
+
+function currentResult(toolUseId: string, isError = true): ToolResultContent {
+  return {
+    type: "tool_result",
+    tool_use_id: toolUseId,
+    content: isError
+      ? 'Invalid input for tool "document_update": content is required'
+      : "ok",
+    is_error: isError,
+  };
+}
+
+function makeCtx(
+  conversationId: string,
+  toolResponse: ToolResultContent,
+  messages: Message[],
+  model: string = MINIMAX_MODEL,
+): PostToolUseContext {
+  return {
+    conversationId,
+    toolResponse,
+    messages,
+    additionalContext: null,
+    model,
+    maxInputTokens: 10_000,
+    logger: noopLogger,
+  };
+}
+
+/**
+ * History of `priorEmpties` completed empty-input calls (each with a distinct
+ * `activity`, proving the varying field does not defeat detection), then the
+ * current call whose result arrives via `ctx.toolResponse`.
+ */
+function emptyInputHistory(priorEmpties: number): {
+  messages: Message[];
+  currentToolUseId: string;
+} {
+  const messages: Message[] = [];
+  let n = 0;
+  for (; n < priorEmpties; n++) {
+    const id = `se-${n}`;
+    messages.push(emptyCallTurn(id, `streaming chunk ${n}`));
+    messages.push(erroredResultTurn(id));
+  }
+  const currentToolUseId = `se-${n}`;
+  messages.push(emptyCallTurn(currentToolUseId, `streaming chunk ${n}`));
+  return { messages, currentToolUseId };
+}
+
+describe("exploration-drift — empty-input skill_execute escalation", () => {
+  beforeEach(() => {
+    resetExplorationDriftStateForTests();
+    consultCalls = 0;
+    advisorEnabled = true;
+    advisorReply =
+      "Re-issue document_update with content set to the next section.";
+  });
+
+  test("threshold is 2 (escalate on the second empty call)", () => {
+    expect(EMPTY_INPUT_ESCALATE_THRESHOLD).toBe(2);
+  });
+
+  test("stays silent on the first empty call (below threshold)", async () => {
+    const { messages, currentToolUseId } = emptyInputHistory(0);
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResult(currentToolUseId),
+      messages,
+    );
+    await postToolUse(ctx);
+    expect(ctx.additionalContext).toBeNull();
+    expect(consultCalls).toBe(0);
+  });
+
+  test("escalates on the second empty call with advisor guidance", async () => {
+    const { messages, currentToolUseId } = emptyInputHistory(1);
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResult(currentToolUseId),
+      messages,
+    );
+    await postToolUse(ctx);
+    expect(consultCalls).toBe(1);
+    expect(ctx.additionalContext).toContain("advisor model reviewed");
+    expect(ctx.additionalContext).toContain(advisorReply);
+    expect(ctx.additionalContext).toContain("empty parameters 2 times");
+  });
+
+  test("detection survives a varying activity field", async () => {
+    // The two empties carry different `activity` strings; byte-identical
+    // matching would miss them, the resolved-inner-tool match does not.
+    const { messages, currentToolUseId } = emptyInputHistory(1);
+    const firstCall = messages[0].content[0];
+    const currentCall = messages[messages.length - 1].content[0];
+    expect(firstCall.type).toBe("tool_use");
+    expect(currentCall.type).toBe("tool_use");
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResult(currentToolUseId),
+      messages,
+    );
+    await postToolUse(ctx);
+    expect(consultCalls).toBe(1);
+  });
+
+  test("does not fire on non-loop-prone models", async () => {
+    const { messages, currentToolUseId } = emptyInputHistory(1);
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResult(currentToolUseId),
+      messages,
+      GENERIC_MODEL,
+    );
+    await postToolUse(ctx);
+    expect(ctx.additionalContext).toBeNull();
+    expect(consultCalls).toBe(0);
+  });
+
+  test("does not fire when the empty call succeeded (no error)", async () => {
+    const { messages, currentToolUseId } = emptyInputHistory(1);
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResult(currentToolUseId, false),
+      messages,
+    );
+    await postToolUse(ctx);
+    expect(ctx.additionalContext).toBeNull();
+    expect(consultCalls).toBe(0);
+  });
+
+  test("does not count populated (stringified-JSON) calls as empty", async () => {
+    // A prior populated call plus a current populated call — never empty.
+    const messages: Message[] = [
+      populatedCallTurn("se-0", "chunk 0"),
+      erroredResultTurn("se-0"),
+      populatedCallTurn("se-1", "chunk 1"),
+    ];
+    const ctx = makeCtx(freshConversationId(), currentResult("se-1"), messages);
+    await postToolUse(ctx);
+    expect(ctx.additionalContext).toBeNull();
+    expect(consultCalls).toBe(0);
+  });
+
+  test("falls back to a deterministic nudge when the advisor is disabled", async () => {
+    advisorEnabled = false;
+    const { messages, currentToolUseId } = emptyInputHistory(1);
+    const ctx = makeCtx(
+      freshConversationId(),
+      currentResult(currentToolUseId),
+      messages,
+    );
+    await postToolUse(ctx);
+    expect(consultCalls).toBe(0);
+    expect(ctx.additionalContext).toContain("Stop repeating the empty call");
+    expect(ctx.additionalContext).not.toContain("advisor model reviewed");
+  });
+
+  test("escalates at most once per streak", async () => {
+    const conversationId = freshConversationId();
+
+    const first = emptyInputHistory(1);
+    const ctx1 = makeCtx(
+      conversationId,
+      currentResult(first.currentToolUseId),
+      first.messages,
+    );
+    await postToolUse(ctx1);
+    expect(consultCalls).toBe(1);
+    expect(ctx1.additionalContext).not.toBeNull();
+
+    // A third empty call in the same streak must not re-consult.
+    const third = emptyInputHistory(2);
+    const ctx2 = makeCtx(
+      conversationId,
+      currentResult(third.currentToolUseId),
+      third.messages,
+    );
+    await postToolUse(ctx2);
+    expect(consultCalls).toBe(1);
+    expect(ctx2.additionalContext).toBeNull();
+  });
+
+  test("re-escalates after the model recovered and looped again", async () => {
+    const conversationId = freshConversationId();
+
+    const first = emptyInputHistory(1);
+    await postToolUse(
+      makeCtx(
+        conversationId,
+        currentResult(first.currentToolUseId),
+        first.messages,
+      ),
+    );
+    expect(consultCalls).toBe(1);
+
+    // The model sent the user text (turn boundary), then a fresh empty loop
+    // starts. The trailing count resets below threshold, clearing the mark.
+    const recovered: Message[] = [
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Here is the draft." }],
+      },
+    ];
+    await postToolUse(
+      makeCtx(conversationId, currentResult("se-x", true), [
+        ...recovered,
+        emptyCallTurn("se-x", "new chunk"),
+      ]),
+    );
+    expect(consultCalls).toBe(1); // first of the new streak — below threshold
+
+    const again = emptyInputHistory(1);
+    await postToolUse(
+      makeCtx(conversationId, currentResult(again.currentToolUseId), [
+        ...recovered,
+        ...again.messages,
+      ]),
+    );
+    expect(consultCalls).toBe(2);
+  });
+});

--- a/assistant/src/plugins/defaults/exploration-drift/hooks/post-tool-use.ts
+++ b/assistant/src/plugins/defaults/exploration-drift/hooks/post-tool-use.ts
@@ -15,7 +15,7 @@
  * the model decides whether the current run is genuinely an investigation
  * worth delegating.
  *
- * Two triggers, sharing one trailing-run computation:
+ * Three triggers:
  *
  * 1. **Long dig** (all models): an unbroken run of
  *    {@link EXPLORATION_NUDGE_THRESHOLD} exploration calls with no user-facing
@@ -33,6 +33,20 @@
  *    only models prone to this looping; the one legitimate identical-call pattern
  *    (polling an external process's output) is rare inside an unbroken
  *    read-only run and the nudge is advisory anyway.
+ * 3. **Empty-input escalation** (loop-prone models only): the current call is a
+ *    `skill_execute` whose resolved inner input is empty and that errored, for
+ *    the {@link EMPTY_INPUT_ESCALATE_THRESHOLD}-th time in the trailing run
+ *    against the same inner tool. A weak model that emits an empty `input`
+ *    cannot serialize the call's parameters, and the existing remediation text
+ *    has demonstrably failed (it repeated the empty call up to nine times in
+ *    one doc-writer incident). Prose from the same weak model is not the fix,
+ *    so this branch consults a stronger advisor model (Pragun's `consultAdvisor`)
+ *    once per streak and injects its concrete guidance. Unlike triggers 1–2 the
+ *    detection ignores the envelope's `activity` field (which the model varies
+ *    every call, defeating byte-identical matching) and keys on the resolved
+ *    inner tool. The advisor consult is an LLM call, so it is tightly gated:
+ *    loop-prone model, errored empty call, threshold reached, advisor enabled,
+ *    and at most once per streak.
  *
  * The trailing run is derived from conversation history on every call
  * (mirroring the tool-error plugin) so the signal survives mid-run compaction
@@ -109,6 +123,43 @@ const EXPLORATION_TOOL_NAMES: ReadonlySet<string> = new Set([
   "file_list",
 ]);
 
+/** The dispatch wrapper whose empty inner input signals a stuck weak model. */
+const SKILL_EXECUTE_TOOL_NAME = "skill_execute";
+
+/**
+ * Number of consecutive empty-input `skill_execute` calls against the same
+ * inner tool (including the current one) that triggers an advisor escalation
+ * on loop-prone models. Empty input means the model dropped the call's
+ * parameters entirely — a cleaner stuck signal than a byte-identical repeat,
+ * so it fires one step sooner than {@link EXPLORATION_LOOP_REPEAT_THRESHOLD}.
+ */
+export const EMPTY_INPUT_ESCALATE_THRESHOLD = 2;
+
+/**
+ * Notice wrapping the advisor's guidance after an empty-input escalation. The
+ * advice comes from a stronger model that reviewed the conversation; the model
+ * is told to act on it and stop sending empty calls.
+ */
+export function emptyInputEscalationText(
+  innerTool: string,
+  repeatCount: number,
+  advice: string,
+): string {
+  return `<system_notice>You have called ${innerTool} with empty parameters ${repeatCount} times in a row and it keeps failing — the parameters are not reaching the tool. A stronger advisor model reviewed this conversation and provided guidance:\n\n${advice}\n\nAct on it now: re-issue ${innerTool} once with every required field filled in. Do not send another empty call.</system_notice>`;
+}
+
+/**
+ * Deterministic fallback when the advisor is unavailable or returns nothing.
+ * Zero-cost and firm: stop repeating the empty call, fill the parameters, or
+ * tell the user plainly.
+ */
+export function emptyInputNudgeText(
+  innerTool: string,
+  repeatCount: number,
+): string {
+  return `<system_notice>You have called ${innerTool} with empty parameters ${repeatCount} times in a row and it keeps failing — the parameters are not reaching the tool. Stop repeating the empty call. Re-issue ${innerTool} once with every required field filled in (the skill's instructions from skill_load list them). If you cannot produce the parameters, tell the user plainly instead of retrying.</system_notice>`;
+}
+
 /**
  * Streak length at the last nudge (either kind), per conversation. A
  * high-water mark rather than a flag so long-dig nudges stay one full
@@ -119,9 +170,19 @@ const EXPLORATION_TOOL_NAMES: ReadonlySet<string> = new Set([
  */
 const lastNudgedStreakByConversation = new Map<string, number>();
 
+/**
+ * Empty-input streak length at the last escalation, per conversation. The
+ * advisor consult is an LLM call, so it must fire at most once per streak: we
+ * escalate when the streak first reaches the threshold and not again until it
+ * drops back below it (the model recovered or the turn boundary moved). Entries
+ * reset to 0 when the streak falls below the threshold.
+ */
+const lastEscalatedEmptyStreakByConversation = new Map<string, number>();
+
 /** Test-only: clear the per-conversation nudge high-water marks. */
 export function resetExplorationDriftStateForTests(): void {
   lastNudgedStreakByConversation.clear();
+  lastEscalatedEmptyStreakByConversation.clear();
 }
 
 /** A `tool_use` block's invocation: tool name plus its raw input. */
@@ -232,11 +293,170 @@ function currentCallRepeatCount(
   return count;
 }
 
+/** Envelope keys consumed by `skill_execute` itself, never inner-tool params. */
+const SKILL_EXECUTE_ENVELOPE_KEYS: ReadonlySet<string> = new Set([
+  "tool",
+  "input",
+  "activity",
+]);
+
+/**
+ * The inner tool name and emptiness of a `skill_execute` envelope. Mirrors the
+ * emptiness verdict of `resolveSkillExecuteInput` (in `tools/skills/execute.ts`)
+ * without importing it — keeping this lightweight history hook off the tool
+ * registry's module graph. A call counts as non-empty when `input` is a
+ * populated object, a non-empty string (the resolver JSON-parses it), or when
+ * inner parameters are spread as siblings of `tool`/`activity`. Everything else
+ * — including the empty-string `input: ""` shape weak models emit — is empty. A
+ * non-`skill_execute` invocation reports an empty tool name and never matches.
+ */
+function innerSkillExecute(invocation: ToolInvocation): {
+  tool: string;
+  empty: boolean;
+} {
+  const envelope = invocation.input;
+  if (
+    envelope === null ||
+    typeof envelope !== "object" ||
+    Array.isArray(envelope)
+  ) {
+    return { tool: "", empty: true };
+  }
+  const env = envelope as Record<string, unknown>;
+  const tool = typeof env.tool === "string" ? env.tool : "";
+  const raw = env.input;
+  if (raw !== null && typeof raw === "object" && !Array.isArray(raw)) {
+    if (Object.keys(raw as Record<string, unknown>).length > 0) {
+      return { tool, empty: false };
+    }
+  } else if (typeof raw === "string" && raw.trim() !== "") {
+    return { tool, empty: false };
+  }
+  const hasSiblingParams = Object.keys(env).some(
+    (key) => !SKILL_EXECUTE_ENVELOPE_KEYS.has(key),
+  );
+  return { tool, empty: !hasSiblingParams };
+}
+
+/**
+ * Count empty-input `skill_execute` calls against `innerTool` in the trailing
+ * run — the stretch of history since the model last sent the user text or a
+ * real user message arrived. Unlike {@link trailingExplorationRun} this does
+ * not break on intervening non-matching tool results: an empty-input loop is
+ * still a loop even if a stray successful call sits between two empties. The
+ * envelope's `activity` field is ignored (the model varies it every call), so
+ * matching keys only on the resolved inner tool + emptiness.
+ */
+function trailingEmptyInputRepeatCount(
+  messages: ReadonlyArray<Message>,
+  usesById: ReadonlyMap<string, ToolInvocation>,
+  innerTool: string,
+): number {
+  let count = 0;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message.role === "assistant") {
+      const spokeToUser = message.content.some(
+        (block) => block.type === "text" && block.text.trim().length > 0,
+      );
+      if (spokeToUser) break;
+      continue;
+    }
+    if (message.role !== "user") continue;
+    const hasToolResult = message.content.some(
+      (block) => block.type === "tool_result",
+    );
+    if (!hasToolResult) break;
+    for (const block of message.content) {
+      if (block.type !== "tool_result") continue;
+      const use = usesById.get(block.tool_use_id);
+      if (use === undefined || use.name !== SKILL_EXECUTE_TOOL_NAME) continue;
+      const inner = innerSkillExecute(use);
+      if (inner.empty && inner.tool === innerTool) count++;
+    }
+  }
+  return count;
+}
+
+/**
+ * Trigger 3: escalate a weak model stuck issuing empty-input `skill_execute`
+ * calls to a stronger advisor. Returns `true` when it handled the call (so the
+ * caller stops), `false` when this branch does not apply.
+ */
+async function maybeEscalateEmptyInput(
+  ctx: PostToolUseContext,
+  usesById: ReadonlyMap<string, ToolInvocation>,
+  currentUse: ToolInvocation,
+): Promise<boolean> {
+  if (currentUse.name !== SKILL_EXECUTE_TOOL_NAME) return false;
+  // Only models known to drop tool parameters, and only when the call errored —
+  // a rare tool that legitimately takes no parameters succeeds and is skipped.
+  if (!LOOP_PRONE_MODEL_PATTERN.test(ctx.model)) return false;
+  if (ctx.toolResponse.is_error !== true) return false;
+
+  const inner = innerSkillExecute(currentUse);
+  if (!inner.empty || inner.tool === "") return false;
+
+  // The current result is not in history yet — count it explicitly.
+  const repeatCount =
+    trailingEmptyInputRepeatCount(ctx.messages, usesById, inner.tool) + 1;
+
+  const lastEscalated =
+    lastEscalatedEmptyStreakByConversation.get(ctx.conversationId) ?? 0;
+  if (repeatCount < EMPTY_INPUT_ESCALATE_THRESHOLD) {
+    // Streak hasn't reached the threshold (or restarted) — clear any stale mark
+    // so a later loop can escalate again.
+    if (lastEscalated !== 0) {
+      lastEscalatedEmptyStreakByConversation.delete(ctx.conversationId);
+    }
+    return false;
+  }
+  // Escalate at most once per streak.
+  if (lastEscalated >= EMPTY_INPUT_ESCALATE_THRESHOLD) return true;
+  lastEscalatedEmptyStreakByConversation.set(ctx.conversationId, repeatCount);
+
+  // Heavy imports (provider graph, config) stay off the per-tool-result hot
+  // path — pulled in only on the rare escalation.
+  const { advisorEnabledForProfile } =
+    await import("../../advisor/advisor-gate.js");
+  let advice = "";
+  if (advisorEnabledForProfile(null)) {
+    const { consultAdvisor } = await import("../../advisor/consult.js");
+    advice = await consultAdvisor({
+      systemPrompt: null,
+      messages: ctx.messages,
+    });
+  }
+  const escalated = advice.trim().length > 0 && !advice.startsWith("(advisor");
+  const nudgeText = escalated
+    ? emptyInputEscalationText(inner.tool, repeatCount, advice)
+    : emptyInputNudgeText(inner.tool, repeatCount);
+
+  ctx.logger.info(
+    {
+      plugin: "exploration-drift",
+      trigger: "empty-input-escalation",
+      innerTool: inner.tool,
+      repeatCount,
+      escalated,
+    },
+    "Empty-input skill_execute loop — escalating to advisor",
+  );
+  ctx.additionalContext = ctx.additionalContext
+    ? `${ctx.additionalContext}\n${nudgeText}`
+    : nudgeText;
+  return true;
+}
+
 const postToolUse: PluginHookFn<PostToolUseContext> = async (ctx) => {
   const usesById = toolUsesById(ctx.messages);
   const currentUse = usesById.get(ctx.toolResponse.tool_use_id);
-  if (currentUse === undefined || !EXPLORATION_TOOL_NAMES.has(currentUse.name))
-    return;
+  if (currentUse === undefined) return;
+
+  // Trigger 3 handles skill_execute; triggers 1–2 handle exploration tools.
+  if (await maybeEscalateEmptyInput(ctx, usesById, currentUse)) return;
+
+  if (!EXPLORATION_TOOL_NAMES.has(currentUse.name)) return;
 
   // The current result is not in history yet — count it explicitly.
   const run = trailingExplorationRun(ctx.messages, usesById);


### PR DESCRIPTION
## Why

Companion to #35456, from the same MiniMax M3 doc-writer incident (feedback `019ee07b`). Wire logs show M3 issued **nine** `skill_execute` calls with empty inner `input` (`input: ""`), each failing `surface_id is required; content is required`, then gave up and dumped the post into chat with a fabricated *"the streaming tool keeps failing"* excuse.

The existing remediation (`augmentSkillExecuteError`, #35099/#35451) is **prose from the same model that just failed to serialize the payload** — M3 ignored it all nine times. And the existing `exploration-drift` loop detector couldn't catch it: it only watches `bash`/`file_read`/`file_list`, and its byte-identical matching would be defeated anyway by the envelope's `activity` field, which M3 varied every call ("Streaming AI section" → "Testing minimal call").

## What

Add a **third trigger** to the `exploration-drift` post-tool-use hook: an empty-input `skill_execute` loop → **advisor escalation** using Pragun's `consultAdvisor` (the reusable consult-a-stronger-model entry point, #34978/#35308).

- **Detection:** on a loop-prone model, when the current `skill_execute` has an empty resolved inner input *and* errored, count prior empty-input calls in the trailing run against the **same inner tool** (ignoring `activity`). At the threshold (2nd empty), escalate.
- **Action:** consult a stronger advisor model once, inject its concrete guidance via `additionalContext`. The advisor sees the failing loop in the transcript and returns an actionable fix (e.g. "re-issue document_update with content set to …").
- **Gating (it's an LLM call):** loop-prone model only, errored empty call, threshold reached, advisor enabled for the profile, and **at most once per streak** (high-water mark resets when the streak falls below threshold, so a later loop re-escalates). When the advisor is disabled or returns nothing, a zero-cost deterministic nudge is injected instead.
- Emptiness mirrors `resolveSkillExecuteInput`'s verdict **without importing it**, keeping this lightweight history hook off the tool-registry module graph.

This is the safety net under #35456: where #35456 shrinks the per-chunk payload (so blanks are rarer), this guarantees a blank loop no longer burns nine calls and ends in a fabricated success — it gets a stronger model's help or a firm honest nudge.

## Test

`bun test src/__tests__/exploration-drift-empty-input-escalation.test.ts` — 10 pass (below-threshold silence, escalate-at-2, varying-activity survival, model gate, error gate, populated-call exclusion, advisor-disabled fallback, once-per-streak, re-escalate-after-recovery). Existing `exploration-drift-hook.test.ts` triggers 1–2 unaffected (33 total).

## Review focus

The advisor consult runs synchronously inside the post-tool-use hook on the rare escalation path (lazy-imported). Risk: an extra LLM call per stuck streak. Mitigated by the once-per-streak high-water mark and the tight gates above. `consultAdvisor` never throws (soft-fails to a benign string → deterministic-nudge fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)