### PR TITLE
fix(web): buffer self-hosted upload bodies as a Blob to stop >1.5 MB uploads hanging

### DIFF
--- a/clients/web/src/lib/api-interceptors.test.ts
+++ b/clients/web/src/lib/api-interceptors.test.ts
@@ -20,6 +20,7 @@ import {
   describe,
   expect,
   mock,
+  spyOn,
   test,
 } from "bun:test";
 
@@ -1002,5 +1003,80 @@ describe("api-interceptors / localGatewayAuthRecoveryInterceptor", () => {
 
     // THEN only one reload fires
     expect(reloadCalls).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Local-mode body buffering — large uploads must not stall
+// ---------------------------------------------------------------------------
+//
+// Over plain HTTP the body can't stream (Chrome refuses a `duplex: "half"`
+// body without TLS), so it's buffered. It MUST be buffered to a Blob, not an
+// ArrayBuffer: an ArrayBuffer body is streamed to the network process through
+// a fixed-capacity (~1-2 MB) data pipe, so a larger upload stalls forever when
+// the local consumer (a busy dev server) drains the pipe slowly — the symptom
+// being image/file uploads above ~1.5 MB hanging on "Stalled". A Blob is
+// passed by reference (blob handle), so there is no renderer-side data pipe to
+// block on. The preload sets VITE_PLATFORM_MODE=true; these tests clear it so
+// isLocalMode() returns true and the buffering path runs.
+
+describe("api-interceptors / local-mode body buffering", () => {
+  let savedPlatformMode: string | undefined;
+
+  beforeAll(() => {
+    savedPlatformMode = process.env.VITE_PLATFORM_MODE;
+    delete process.env.VITE_PLATFORM_MODE;
+    useOrganizationStore.setState({ currentOrganizationId: TEST_ORG_ID });
+  });
+
+  afterAll(() => {
+    if (savedPlatformMode !== undefined) {
+      process.env.VITE_PLATFORM_MODE = savedPlatformMode;
+    }
+  });
+
+  afterEach(() => {
+    setSelfHostedConnection(null);
+  });
+
+  test("buffers the request body via .blob()", async () => {
+    // .blob() yields a by-reference body; reverting to .arrayBuffer() (which
+    // never calls .blob()) would fail this and reintroduce the >1.5 MB stall.
+    setSelfHostedConnection({ url: INGRESS, token: ACTOR_TOKEN });
+    const blobSpy = spyOn(Request.prototype, "blob");
+    try {
+      const input = new Request(`https://platform.test${RUNTIME_PROXIED_PATH}`, {
+        method: "POST",
+        body: "upload-payload",
+      });
+      await daemonRequestInterceptor(input);
+      expect(blobSpy).toHaveBeenCalled();
+    } finally {
+      blobSpy.mockRestore();
+    }
+  });
+
+  test("the rewritten request carries the buffered body content", async () => {
+    setSelfHostedConnection({ url: INGRESS, token: ACTOR_TOKEN });
+    const input = new Request(`https://platform.test${RUNTIME_PROXIED_PATH}`, {
+      method: "POST",
+      body: "upload-payload",
+    });
+    const output = await daemonRequestInterceptor(input);
+    expect(new URL(output.url).origin).toBe(INGRESS);
+    expect(await output.text()).toBe("upload-payload");
+  });
+
+  test("a bodyless GET is rewritten without buffering", async () => {
+    setSelfHostedConnection({ url: INGRESS, token: ACTOR_TOKEN });
+    const blobSpy = spyOn(Request.prototype, "blob");
+    try {
+      const input = new Request(`https://platform.test${RUNTIME_PROXIED_PATH}`);
+      const output = await daemonRequestInterceptor(input);
+      expect(new URL(output.url).origin).toBe(INGRESS);
+      expect(blobSpy).not.toHaveBeenCalled();
+    } finally {
+      blobSpy.mockRestore();
+    }
   });
 });

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -165,11 +165,16 @@ export async function rewriteForSelfHostedIngress(
 
   // In local mode the gateway proxy runs over plain HTTP, and Chrome
   // refuses to send a streaming (duplex: "half") body without TLS
-  // (ERR_ALPN_NEGOTIATION_FAILED). Buffer the body as an ArrayBuffer so
-  // the Request carries a finite-length payload. Platform self-hosted
-  // uses TLS, so keep the streaming body to avoid buffering large uploads.
+  // (ERR_ALPN_NEGOTIATION_FAILED), so the body must be buffered into a
+  // finite-length payload. Buffer to a Blob rather than an ArrayBuffer:
+  // an ArrayBuffer body is streamed to the network process through a
+  // fixed-capacity (~1-2 MB) data pipe, so a larger upload stalls forever
+  // when the local consumer drains the pipe slowly. A Blob is passed by
+  // reference (blob handle) and read directly, with no renderer-side data
+  // pipe to block on. Platform self-hosted uses TLS, so keep the streaming
+  // body there to avoid buffering large uploads.
   const body = isLocalMode()
-    ? (request.body ? await request.arrayBuffer() : null)
+    ? (request.body ? await request.blob() : null)
     : request.body;
 
   const init: RequestInit = {


### PR DESCRIPTION
## Problem

Pasting/attaching an image larger than **~1.5 MB** in the desktop app (local/self-hosted assistant) hangs forever — the composer's attachment chip spins and never completes, never errors. Smaller images (≲1.4 MB) upload instantly.

## Root cause

In local/self-hosted mode the renderer's request interceptor (`rewriteForSelfHostedIngress`) **buffers** the request body before forwarding to the gateway, because Chrome refuses to send a streaming (`duplex: "half"`) body over plain HTTP. It buffered to an **`ArrayBuffer`**:

```ts
const body = isLocalMode() ? (request.body ? await request.arrayBuffer() : null) : request.body;
```

An `ArrayBuffer` fetch body is streamed to the network process through a **fixed-capacity (~1.5 MB) Mojo data pipe**. Under the capacity, the whole body is written in one shot and the fetch proceeds. **Over** it, the renderer must wait for the consumer to drain the pipe before writing the rest — and when the local consumer is even slightly slow (a dev server busy with other traffic, e.g. a retry storm against an unrelated dead port), that write blocks indefinitely and DevTools shows the request stuck on **"Stalled"** (never sent).

That's exactly the observed signature: a sharp threshold at ~1.5 MB, "Stalled" in the Timing tab, and the request never reaching the gateway.

## Fix

Buffer to a **`Blob`** instead:

```ts
const body = isLocalMode() ? (request.body ? await request.blob() : null) : request.body;
```

A `Blob` body is handed to the network process **by reference** (a blob handle) and read directly from blob storage — there's no renderer-side data pipe to block on. It's still finite with no `duplex` stream, so the original plain-HTTP behavior is preserved for small bodies (chat, etc.) too.

## How it was isolated

Bisected layer by layer against the live app: the backend (gateway + daemon) handles a 1.7 MB multipart upload in ~5 ms; the connection pool is fine (a concurrent identical `fetch` sends while the app's upload stalls); every manual request variation (`fetch(url, init)`, `fetch(Request)`, ArrayBuffer/Blob/FormData, multipart CT, real token) sends fine. Instrumenting the actual call showed the request reaches `globalThis.fetch(request)` looking completely normal (`bodyUsed: false`, `signalAborted: false`, global fetch) yet never returns — and the failure is sharply gated at ~1.5 MB, the data-pipe capacity. Swapping the buffered body to a `Blob` made the same upload complete (`200`) instantly.

## Testing
- `bunx tsc --noEmit` — clean
- `bun test src/lib/api-interceptors.test.ts` — 61 pass (3 new), pinning that the body is buffered via `.blob()` and that a bodyless GET isn't buffered
- **Verified live in the desktop app**: the 1.7 MB image that previously hung now attaches instantly (`POST … 200`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)