### PR TITLE
feat(subagent): default spawned subagents to the invoking agent's inference profile

### DIFF
--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -8,6 +8,7 @@ let mockGetMessages: (
 ) => Array<{ role: string; content: string }> | null = () => null;
 const mockProfiles = {
   balanced: {},
+  "cost-optimized": {},
   disabled: { status: "disabled" },
   "quality-optimized": {},
 };
@@ -470,6 +471,155 @@ describe("Subagent spawn success and failure", () => {
       expect(result.isError).toBe(false);
       expect(capturedConfig).toBeDefined();
       expect(capturedConfig!.overrideProfile).toBe("quality-optimized");
+      expect(capturedConfig!.forceOverrideProfile).toBe(true);
+    } finally {
+      manager.spawn = originalSpawn;
+    }
+  });
+
+  test("spawn inherits the invoking call site's default profile when no override is present", async () => {
+    const manager = getSubagentManager();
+    const originalSpawn = manager.spawn.bind(manager);
+    let capturedConfig: Record<string, unknown> | undefined;
+
+    manager.spawn = async (config: Record<string, unknown>) => {
+      capturedConfig = config;
+      return "inherit-default-id";
+    };
+
+    try {
+      const result = await executeSubagentSpawn(
+        { label: "Inherit default", objective: "Do it" },
+        makeContext("sess-inherit-default", {
+          sendToClient: () => {},
+          invokingCallSite: "mainAgent",
+        }),
+      );
+
+      expect(result.isError).toBe(false);
+      // No explicit profile and no per-turn override → the child matches the
+      // invoking call site's resolved default profile (balanced for mainAgent
+      // in the test config).
+      expect(capturedConfig!.overrideProfile).toBe("balanced");
+      expect(capturedConfig!.forceOverrideProfile).toBeUndefined();
+    } finally {
+      manager.spawn = originalSpawn;
+    }
+  });
+
+  test("spawn inherits a non-main invoker's call-site default profile", async () => {
+    const manager = getSubagentManager();
+    const originalSpawn = manager.spawn.bind(manager);
+    let capturedConfig: Record<string, unknown> | undefined;
+
+    manager.spawn = async (config: Record<string, unknown>) => {
+      capturedConfig = config;
+      return "inherit-heartbeat-id";
+    };
+
+    try {
+      const result = await executeSubagentSpawn(
+        { label: "Heartbeat child", objective: "Do it" },
+        makeContext("sess-inherit-heartbeat", {
+          sendToClient: () => {},
+          invokingCallSite: "heartbeatAgent",
+        }),
+      );
+
+      expect(result.isError).toBe(false);
+      // A subagent spawned from a heartbeat turn matches heartbeatAgent's own
+      // cost-optimized default, not the mainAgent default.
+      expect(capturedConfig!.overrideProfile).toBe("cost-optimized");
+    } finally {
+      manager.spawn = originalSpawn;
+    }
+  });
+
+  test("spawn prefers a per-turn override profile over the invoker default", async () => {
+    const manager = getSubagentManager();
+    const originalSpawn = manager.spawn.bind(manager);
+    let capturedConfig: Record<string, unknown> | undefined;
+
+    manager.spawn = async (config: Record<string, unknown>) => {
+      capturedConfig = config;
+      return "inherit-override-id";
+    };
+
+    try {
+      const result = await executeSubagentSpawn(
+        { label: "Override child", objective: "Do it" },
+        makeContext("sess-inherit-override", {
+          sendToClient: () => {},
+          invokingCallSite: "mainAgent",
+          overrideProfile: "quality-optimized",
+        }),
+      );
+
+      expect(result.isError).toBe(false);
+      // The live per-turn override (per-conversation or tool-routed) wins over
+      // the call-site default, and is forwarded non-forced.
+      expect(capturedConfig!.overrideProfile).toBe("quality-optimized");
+      expect(capturedConfig!.forceOverrideProfile).toBeUndefined();
+    } finally {
+      manager.spawn = originalSpawn;
+    }
+  });
+
+  test("spawn skips the auto profile so the child keeps its own default", async () => {
+    const manager = getSubagentManager();
+    const originalSpawn = manager.spawn.bind(manager);
+    let capturedConfig: Record<string, unknown> | undefined;
+
+    manager.spawn = async (config: Record<string, unknown>) => {
+      capturedConfig = config;
+      return "inherit-auto-id";
+    };
+
+    try {
+      const result = await executeSubagentSpawn(
+        { label: "Auto child", objective: "Do it" },
+        makeContext("sess-inherit-auto", {
+          sendToClient: () => {},
+          invokingCallSite: "mainAgent",
+          // "auto" is metadata-only; forwarding it would collapse the child to
+          // llm.default, so the inherited path drops it and the child keeps its
+          // own subagentSpawn default.
+          overrideProfile: "auto",
+        }),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(capturedConfig!.overrideProfile).toBeUndefined();
+    } finally {
+      manager.spawn = originalSpawn;
+    }
+  });
+
+  test("spawn still forces an explicit inference_profile over the invoker default", async () => {
+    const manager = getSubagentManager();
+    const originalSpawn = manager.spawn.bind(manager);
+    let capturedConfig: Record<string, unknown> | undefined;
+
+    manager.spawn = async (config: Record<string, unknown>) => {
+      capturedConfig = config;
+      return "inherit-explicit-id";
+    };
+
+    try {
+      const result = await executeSubagentSpawn(
+        {
+          label: "Explicit child",
+          objective: "Do it",
+          inference_profile: "cost-optimized",
+        },
+        makeContext("sess-inherit-explicit", {
+          sendToClient: () => {},
+          invokingCallSite: "mainAgent",
+        }),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(capturedConfig!.overrideProfile).toBe("cost-optimized");
       expect(capturedConfig!.forceOverrideProfile).toBe(true);
     } finally {
       manager.spawn = originalSpawn;

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -218,6 +218,7 @@ export function createToolExecutor(
       isPlatformHosted: getIsPlatform(),
       transportInterface: ctx.transportInterface,
       overrideProfile: ctx.currentTurnOverrideProfile,
+      invokingCallSite: ctx.currentCallSite ?? "mainAgent",
       attribution: resolveConversationAttribution(ctx),
       onToolLifecycleEvent: handleToolLifecycleEvent,
       sendToClient: (msg) => {

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -237,10 +237,17 @@ export class SubagentManager {
         config.systemPromptOverride ??
         buildSubagentSystemPrompt({ ...config, id: subagentId }, role);
     }
-    const maxTokens = resolveCallSiteConfig(
-      "subagentSpawn",
-      appConfig.llm,
-    ).maxTokens;
+    // Resolve under the same profile the run will use (forwarded via
+    // `SubagentConfig`) so the constructed conversation's default token cap
+    // matches the inherited profile rather than the static `subagentSpawn`
+    // default. Per-call routing re-resolves the model anyway; this keeps the
+    // initial value consistent.
+    const maxTokens = resolveCallSiteConfig("subagentSpawn", appConfig.llm, {
+      ...(config.overrideProfile
+        ? { overrideProfile: config.overrideProfile }
+        : {}),
+      ...(config.forceOverrideProfile ? { forceOverrideProfile: true } : {}),
+    }).maxTokens;
     const workingDir = getSandboxWorkingDir();
 
     // ── Initialise state ────────────────────────────────────────────

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -1,4 +1,7 @@
 import { validateInferenceProfileKey } from "../../config/inference-profile-validation.js";
+import { resolveDefaultProfileKey } from "../../config/llm-resolver.js";
+import { getConfig } from "../../config/loader.js";
+import { AUTO_PROFILE_KEY } from "../../config/seed-inference-profiles.js";
 import { findConversation } from "../../daemon/conversation-registry.js";
 import { getConversationOverrideProfile } from "../../memory/conversation-crud.js";
 import type { Message } from "../../providers/types.js";
@@ -97,20 +100,41 @@ export async function executeSubagentSpawn(
   // `SubagentManager.spawn` forwards it back into the subagent's
   // `runAgentLoop` call as `options.overrideProfile`.
   //
-  // Prefer an explicit spawn-time profile, then the per-turn
+  // Resolution order: an explicit spawn-time profile, then the per-turn
   // `context.overrideProfile` (populated by `runAgentLoopImpl` from its
-  // resolved `turnOverrideProfile`) over a row read so nested spawns inherit
-  // correctly. The current subagent's own conversation row never has
-  // `inferenceProfile` set — its override arrived via in-memory
-  // `SubagentConfig.overrideProfile` — and even if it were set,
-  // `getConversationOverrideProfile` short-circuits for background
-  // conversations and returns `undefined`. Falling back to the row read
-  // preserves behavior for tool calls that originate outside an agent-loop
-  // turn.
-  const inheritedOverrideProfile =
-    requestedOverrideProfile ??
-    context.overrideProfile ??
-    getConversationOverrideProfile(context.conversationId);
+  // resolved `turnOverrideProfile`, covering per-conversation overrides and
+  // tool-routed switches), then a row read, and finally the resolved DEFAULT
+  // profile of the call site that invoked us. That last fallback is what makes
+  // a subagent match its invoker when the invoking turn ran purely on its
+  // call-site default — the workspace `activeProfile` for `mainAgent`, or the
+  // call site's own catalog default (e.g. `cost-optimized`) for a
+  // heartbeat/background invoker. `resolveDefaultProfileKey` does not reflect a
+  // static `llm.callSites.<callSite>` profile override (only the
+  // activeProfile-for-mainAgent path plus the catalog default), a narrow gap
+  // that only surfaces with no `activeProfile` set and a hand-tuned call-site
+  // profile.
+  //
+  // The fallback is forwarded NON-forced, so an explicit
+  // `llm.callSites.subagentSpawn` profile still wins; an explicit
+  // `inference_profile` argument keeps `forceOverrideProfile` and wins
+  // outright. (The row read short-circuits to `undefined` for the background
+  // subagent conversation and for tool calls outside an agent-loop turn.)
+  let inheritedOverrideProfile = requestedOverrideProfile;
+  if (inheritedOverrideProfile === undefined) {
+    const inheritedCandidate =
+      context.overrideProfile ??
+      getConversationOverrideProfile(context.conversationId) ??
+      resolveDefaultProfileKey(
+        context.invokingCallSite ?? "mainAgent",
+        getConfig().llm,
+      );
+    // Skip the metadata-only "auto" key: forwarding it collapses the child to
+    // `llm.default`, whereas the invoker's own auto base IS the `subagentSpawn`
+    // default — so leaving this undefined keeps the child on that default.
+    if (inheritedCandidate !== AUTO_PROFILE_KEY) {
+      inheritedOverrideProfile = inheritedCandidate;
+    }
+  }
 
   try {
     const subagentId = await manager.spawn(

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -13,6 +13,7 @@ import { RiskLevel } from "@vellumai/skill-host-contracts";
 import { z } from "zod";
 
 import type { InterfaceId } from "../channels/types.js";
+import type { LLMCallSite } from "../config/schemas/llm.js";
 import type { ToolActivityMetadata } from "../daemon/message-types/web-activity.js";
 import type { SecretPromptResult } from "../permissions/secret-prompter.js";
 import type { ContentBlock } from "../providers/types.js";
@@ -363,6 +364,14 @@ export interface ToolContext {
    * `executeSubagentSpawn` in tools/subagent/spawn.ts.
    */
   overrideProfile?: string;
+  /**
+   * The LLM call site of the turn currently executing this tool (`mainAgent`,
+   * `heartbeatAgent`, scheduled work, etc.). `subagent_spawn` reads it to
+   * default a spawned subagent's inference profile to the profile the invoking
+   * turn resolved to, so subagents match whatever agent invoked them rather
+   * than always falling back to the static `subagentSpawn` call-site default.
+   */
+  invokingCallSite?: LLMCallSite;
   /**
    * Canonical principal ID of the actor on whose behalf this tool invocation
    * is running. Sourced from `conversation.trustContext.guardianPrincipalId`.


### PR DESCRIPTION
## Summary
- `subagent_spawn` now defaults a spawned subagent's inference profile to the profile the **invoking turn resolved to** (any call site), instead of the fixed `balanced` `subagentSpawn` default. The invoking call site is exposed on `ToolContext.invokingCallSite`, and `spawn.ts` falls back to `resolveDefaultProfileKey(invokingCallSite, llm)` when there is no per-turn override — so a subagent matches `mainAgent`'s `activeProfile`, or a heartbeat/background invoker's own catalog default (e.g. `cost-optimized`).
- Precedence preserved: an explicit `inference_profile` argument still forces and wins; an explicit `llm.callSites.subagentSpawn` profile still wins (the inherited profile is forwarded **non-forced**); the metadata-only `auto` profile is skipped so the child keeps the `balanced` base. The subagent's constructor `maxTokens` now resolves under the inherited profile for consistency.
- Default users (`activeProfile=balanced`) see no model change; the behavior only diverges when the invoker runs a non-`balanced` profile.

## Original prompt
After tracing how `subagent_spawn` selects its model (it runs under the `subagentSpawn` call site, which defaults to the `balanced` profile), the request was to make subagents default to the same inference profile as the agent that invokes them. We explicitly scoped this to cover **any** invoking agent — foreground chat plus background/heartbeat/scheduled turns — so a subagent mirrors whatever profile its parent turn is running rather than always falling back to `balanced`.