### PR TITLE
fix(advisor): omit the advisor tool from the wire tool list when disabled for the chat profile

### DIFF
--- a/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
@@ -47,6 +47,20 @@ mock.module("../../runtime/assistant-event-hub.js", () => ({
   broadcastMessage: () => {},
 }));
 
+// Control the advisor profile gate to verify the advisor tool is wired to it.
+// The gate's own config semantics (default-on, active-profile fallback) are
+// covered by advisor-gate.test.ts; here we only assert the wiring and the
+// profile argument isToolActiveForContext passes through.
+let advisorGateResult = true;
+const advisorGateProfiles: (string | null)[] = [];
+
+mock.module("../../plugins/defaults/advisor/advisor-gate.js", () => ({
+  advisorEnabledForProfile: (profile: string | null) => {
+    advisorGateProfiles.push(profile);
+    return advisorGateResult;
+  },
+}));
+
 // Dynamic imports after mock.module calls so the stubs take effect
 // before the modules under test are loaded.
 const { HOST_TOOL_NAMES, HOST_TOOL_TO_CAPABILITY, isToolActiveForContext } =
@@ -594,6 +608,36 @@ describe("isToolActiveForContext — ask_question macOS gating", () => {
         }),
       ),
     ).toBe(true);
+  });
+});
+
+describe("isToolActiveForContext — advisor profile gate", () => {
+  beforeEach(() => {
+    advisorGateResult = true;
+    advisorGateProfiles.length = 0;
+  });
+
+  test("advisor is active when the profile enables it", () => {
+    advisorGateResult = true;
+    expect(isToolActiveForContext("advisor", makeCtx())).toBe(true);
+  });
+
+  test("advisor is NOT active when the profile disables it", () => {
+    advisorGateResult = false;
+    expect(isToolActiveForContext("advisor", makeCtx())).toBe(false);
+  });
+
+  test("consults the gate with the per-turn override profile", () => {
+    isToolActiveForContext(
+      "advisor",
+      makeCtx({ currentTurnOverrideProfile: "cost-optimized" }),
+    );
+    expect(advisorGateProfiles).toEqual(["cost-optimized"]);
+  });
+
+  test("consults the gate with null when no per-turn override is set", () => {
+    isToolActiveForContext("advisor", makeCtx());
+    expect(advisorGateProfiles).toEqual([null]);
   });
 });
 

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -17,6 +17,7 @@ import type { LLMCallSite } from "../config/schemas/llm.js";
 import { getBindingByConversation } from "../memory/external-conversation-store.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
+import { advisorEnabledForProfile } from "../plugins/defaults/advisor/advisor-gate.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { registerConversationSender } from "../tools/browser/browser-screencast.js";
@@ -588,6 +589,14 @@ export function isToolActiveForContext(
     } catch {
       return true;
     }
+  }
+  if (name === "advisor") {
+    // Gated per chat-profile (`ProfileEntry.advisorEnabled`): when the resolved
+    // profile disables the advisor, omit the tool from the wire list so the
+    // model never sees a tool it can only no-op on. Resolves the profile the
+    // same way the advisor's execution-time guard does (the per-turn override,
+    // else the active profile).
+    return advisorEnabledForProfile(ctx.currentTurnOverrideProfile ?? null);
   }
   if (UI_SURFACE_TOOL_NAMES.has(name)) {
     if (


### PR DESCRIPTION
## Summary
- When a chat profile sets `advisorEnabled: false`, the `advisor` tool is now omitted from the tool list sent to the LLM, instead of being sent on every turn and only no-opping at execution time.
- Wires the existing `advisorEnabledForProfile` gate into `isToolActiveForContext` (mirroring the existing `remember`/`memory.enabled` gating), resolving the profile via the per-turn override then the active profile — the same resolution the advisor execution-time guard uses.
- Additive filter only: the execution and steering defense-in-depth guards are unchanged, and profiles that do not disable the advisor are unaffected.

## Original prompt
When the advisor setting is turned off for a model profile (`ProfileEntry.advisorEnabled: false`), the `advisor` tool should not be included in the list of tools available when making the LLM call. Previously the tool stayed in the wire tool list even when disabled — the gate was only enforced at execution and steering time — so the model still saw an ~80-word tool description it could only no-op on.