### PR TITLE
fix(subagent): inherit the invoker's resolved profile, respecting call-site overrides

### DIFF
--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -626,6 +626,72 @@ describe("Subagent spawn success and failure", () => {
     }
   });
 
+  test("spawn inherits the invoker's resolved profile from attribution over the catalog default", async () => {
+    const manager = getSubagentManager();
+    const originalSpawn = manager.spawn.bind(manager);
+    let capturedConfig: Record<string, unknown> | undefined;
+
+    manager.spawn = async (config: Record<string, unknown>) => {
+      capturedConfig = config;
+      return "inherit-applied-id";
+    };
+
+    try {
+      const result = await executeSubagentSpawn(
+        { label: "Applied child", objective: "Do it" },
+        makeContext("sess-inherit-applied", {
+          sendToClient: () => {},
+          // The invoker ran under heartbeatAgent but resolved to
+          // quality-optimized via a configured llm.callSites.heartbeatAgent
+          // profile. attribution captures that resolved profile; the catalog
+          // default (cost-optimized) would not.
+          invokingCallSite: "heartbeatAgent",
+          attribution: {
+            appliedProfile: "quality-optimized",
+            resolvedMixArm: null,
+          },
+        }),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(capturedConfig!.overrideProfile).toBe("quality-optimized");
+    } finally {
+      manager.spawn = originalSpawn;
+    }
+  });
+
+  test("spawn pins the invoker's resolved mix arm rather than the mix name", async () => {
+    const manager = getSubagentManager();
+    const originalSpawn = manager.spawn.bind(manager);
+    let capturedConfig: Record<string, unknown> | undefined;
+
+    manager.spawn = async (config: Record<string, unknown>) => {
+      capturedConfig = config;
+      return "inherit-mixarm-id";
+    };
+
+    try {
+      const result = await executeSubagentSpawn(
+        { label: "Mix child", objective: "Do it" },
+        makeContext("sess-inherit-mixarm", {
+          sendToClient: () => {},
+          invokingCallSite: "mainAgent",
+          // The parent turn expanded a mix profile to the "balanced" arm; the
+          // child should pin that arm, not re-expand the mix under its own seed.
+          attribution: {
+            appliedProfile: "balanced-mix",
+            resolvedMixArm: "balanced",
+          },
+        }),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(capturedConfig!.overrideProfile).toBe("balanced");
+    } finally {
+      manager.spawn = originalSpawn;
+    }
+  });
+
   test("spawn returns error for unknown inference_profile", async () => {
     const manager = getSubagentManager();
     const originalSpawn = manager.spawn.bind(manager);

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -92,8 +92,10 @@ export type {
  * agent's). The conversation id is threaded as the mix selection seed so
  * mix-profile arms match what the dispatch path actually ran.
  *
- * Returns `null` on any failure: attribution is telemetry-only and must
- * never break tool execution (or skill loads, which reuse this helper).
+ * Returns `null` on any failure: attribution must never break tool execution
+ * (or skill loads, which reuse this helper). Consumers read it best-effort —
+ * usage telemetry, and `subagent_spawn`, which inherits the resolved
+ * `appliedProfile` so a child defaults to the invoking turn's profile.
  */
 export function resolveConversationAttribution(
   ctx: Pick<

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -96,34 +96,37 @@ export async function executeSubagentSpawn(
 
   // The subagent runs as its own background conversation, so the agent
   // loop's background-skip rule would zero out any inherited profile.
-  // Pass the parent's profile explicitly via `SubagentConfig` so
-  // `SubagentManager.spawn` forwards it back into the subagent's
-  // `runAgentLoop` call as `options.overrideProfile`.
+  // Forward the invoker's profile explicitly via `SubagentConfig` so
+  // `SubagentManager.spawn` passes it into the subagent's `runAgentLoop` as
+  // `options.overrideProfile`.
   //
   // Resolution order: an explicit spawn-time profile, then the per-turn
-  // `context.overrideProfile` (populated by `runAgentLoopImpl` from its
-  // resolved `turnOverrideProfile`, covering per-conversation overrides and
-  // tool-routed switches), then a row read, and finally the resolved DEFAULT
-  // profile of the call site that invoked us. That last fallback is what makes
-  // a subagent match its invoker when the invoking turn ran purely on its
-  // call-site default — the workspace `activeProfile` for `mainAgent`, or the
-  // call site's own catalog default (e.g. `cost-optimized`) for a
-  // heartbeat/background invoker. `resolveDefaultProfileKey` does not reflect a
-  // static `llm.callSites.<callSite>` profile override (only the
-  // activeProfile-for-mainAgent path plus the catalog default), a narrow gap
-  // that only surfaces with no `activeProfile` set and a hand-tuned call-site
-  // profile.
+  // `context.overrideProfile` (per-conversation override or tool-routed
+  // switch), then a row read, then the profile the invoking turn actually
+  // resolved to. `context.attribution` mirrors the full resolver precedence —
+  // including a configured `llm.callSites.<callSite>.profile`, which
+  // `resolveDefaultProfileKey` alone does NOT capture — so the child matches
+  // the profile that ran the parent turn even when it came from a call-site
+  // override. `resolvedMixArm` pins the exact arm a mix profile expanded to
+  // (the child would otherwise re-expand under its own seed). The trailing
+  // `resolveDefaultProfileKey` is a fallback for spawns with no attribution
+  // (e.g. outside an agent-loop turn).
   //
-  // The fallback is forwarded NON-forced, so an explicit
+  // The inherited profile is forwarded NON-forced, so an explicit
   // `llm.callSites.subagentSpawn` profile still wins; an explicit
   // `inference_profile` argument keeps `forceOverrideProfile` and wins
   // outright. (The row read short-circuits to `undefined` for the background
   // subagent conversation and for tool calls outside an agent-loop turn.)
   let inheritedOverrideProfile = requestedOverrideProfile;
   if (inheritedOverrideProfile === undefined) {
+    const invokerResolvedProfile =
+      context.attribution?.resolvedMixArm ??
+      context.attribution?.appliedProfile ??
+      undefined;
     const inheritedCandidate =
       context.overrideProfile ??
       getConversationOverrideProfile(context.conversationId) ??
+      invokerResolvedProfile ??
       resolveDefaultProfileKey(
         context.invokingCallSite ?? "mainAgent",
         getConfig().llm,


### PR DESCRIPTION
## Summary
- Addresses a Codex **P2** on #35459 (already merged): a spawned subagent now inherits the profile the invoking turn **actually resolved to** — read from `ToolContext.attribution.appliedProfile`, which mirrors full resolver precedence including a configured `llm.callSites.<callSite>.profile`. Previously the fallback used `resolveDefaultProfileKey`, which only sees the catalog default (and `activeProfile` for `mainAgent`), so e.g. a `heartbeatAgent` pinned to `quality-optimized` would spawn a `cost-optimized` child.
- Prefers `attribution.resolvedMixArm` over `appliedProfile` so a mix profile pins the exact arm the parent expanded to, rather than re-expanding under the child's own seed. `resolveDefaultProfileKey` is kept as a fallback for spawns with no attribution (e.g. outside an agent-loop turn).
- Tests: adds attribution-based inheritance (configured call-site profile beats the catalog default) and mix-arm pinning. Existing inheritance/precedence/auto-skip cases still cover the no-attribution fallback path.

## Original prompt
Codex left a P2 review on the just-merged #35459 noting that the new subagent profile-inheritance fallback (`resolveDefaultProfileKey`) ignores a configured `llm.callSites.<callSite>.profile`, so a subagent wouldn't always match the profile that actually ran its invoking turn. The request was to address that feedback if correct (it is) in a new PR, since #35459 was already merged.