### PR TITLE
docs(advisor): note the advisor wire-gate is fixed before hook profile routing

### DIFF
--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -597,7 +597,9 @@ export function isToolActiveForContext(
     // profile disables the advisor, omit the tool from the wire list so the
     // model never sees a tool it can only no-op on. Resolves the profile the
     // same way the advisor's execution-time guard does (the per-turn override,
-    // else the active profile).
+    // else the active profile). The wire list is fixed before PRE_MODEL_CALL
+    // hooks run, so a hook that re-routes the profile mid-turn (the model-router
+    // lever on `PreModelCallContext.modelProfile`) is not reflected here.
     return advisorEnabledForProfile(ctx.currentTurnOverrideProfile ?? null);
   }
   if (UI_SURFACE_TOOL_NAMES.has(name)) {


### PR DESCRIPTION
## Summary
- Documents that the advisor wire-gate in `isToolActiveForContext` resolves against the seeded per-turn override / active profile, which is fixed before `PRE_MODEL_CALL` hooks run — so a (currently hypothetical) model-router hook that re-routes `PreModelCallContext.modelProfile` mid-turn is not reflected in the wire tool list.
- Comment-only change addressing a Codex review note on #35461. No behavior change.

## Original prompt
Codex flagged (P2) on #35461 that the advisor wire-gate could use a stale profile when a `pre-model-call` hook re-routes the inference profile after tools are resolved. No shipped hook does this today (the only pre-model-call hook reads the profile for steering and never re-routes), and honoring a post-hook profile in the wire list would require re-resolving tools after `PRE_MODEL_CALL` — out of scope for this gate. The comment documents the seam at the source for whoever introduces a model-router hook.