### PR TITLE
fix(web): route daemon-owned per-assistant resources to the gateway (stop dev 502 storm)

### DIFF
--- a/clients/web/src/lib/api-interceptors.test.ts
+++ b/clients/web/src/lib/api-interceptors.test.ts
@@ -293,6 +293,34 @@ describe("api-interceptors / self-hosted rewriting", () => {
     expect(output.headers.get("Authorization")).toBe(`Bearer ${ACTOR_TOKEN}`);
   });
 
+  test("rewrites daemon/gateway-owned segments reached via the platform client", async () => {
+    // config / permissions / trust-rules / artifacts / contacts /
+    // contact-channels are daemon- or gateway-owned but are called through
+    // the platform client via raw `client.*` requests (e.g. the background
+    // `TimezoneSync` PATCH to `config`). In local / self-hosted mode they
+    // must route to the gateway like conversations rather than fall through
+    // to the dead platform proxy and flood the console with 502s.
+    setSelfHostedConnection({ url: INGRESS, token: ACTOR_TOKEN });
+    for (const segment of [
+      "config",
+      "permissions",
+      "trust-rules",
+      "artifacts",
+      "contacts",
+      "contact-channels",
+    ]) {
+      const path = `/v1/assistants/${SELF_HOSTED_ID}/${segment}/`;
+      const input = new Request(`https://platform.test${path}`, {
+        method: "POST",
+      });
+      const output = await requestInterceptor(input);
+      const outUrl = new URL(output.url);
+      expect(outUrl.origin).toBe(INGRESS);
+      expect(outUrl.pathname).toBe(path);
+      expect(output.headers.get("Authorization")).toBe(`Bearer ${ACTOR_TOKEN}`);
+    }
+  });
+
   test("prepends the ingress path prefix when the ingress URL has a path", async () => {
     const prefixedIngress = "http://localhost:3000/__gateway/20100";
     setSelfHostedConnection({ url: prefixedIngress, token: ACTOR_TOKEN });
@@ -404,6 +432,10 @@ describe("api-interceptors / self-hosted rewriting", () => {
       "domains",
       "email-addresses",
       "oauth",
+      // `/a2a/invites/redeem` is a platform broker (Django) route — it sits
+      // in the same client file as the allowlisted `contacts` /
+      // `contact-channels`, so pin that it is NOT captured by the allowlist.
+      "a2a",
     ]) {
       const input = new Request(
         `https://platform.test/v1/assistants/${SELF_HOSTED_ID}/${segment}/`,

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -87,6 +87,21 @@ const RUNTIME_PROXIED_FIRST_SEGMENTS = new Set<string>([
   // must be forwarded to the gateway in local / self-hosted mode rather
   // than falling through to the platform proxy.
   "x",
+  // Daemon- and gateway-owned per-assistant resources that are reached
+  // through the platform client via raw `client.*` calls (their gateway
+  // SDK functions aren't generated yet) instead of the daemon client.
+  // Like `events`/`x` above they must be forwarded to the gateway in
+  // local / self-hosted mode rather than falling through to the dead
+  // platform proxy — otherwise e.g. the background `TimezoneSync` PATCH to
+  // `config` retries against a nonexistent platform and floods the console
+  // with 502s. `a2a` is deliberately excluded: `/a2a/invites/redeem` is a
+  // platform broker (Django) route that must stay on the platform.
+  "config",
+  "permissions",
+  "trust-rules",
+  "artifacts",
+  "contacts",
+  "contact-channels",
 ]);
 
 const ASSISTANT_PATH_RE =


### PR DESCRIPTION
## Summary
- The background `TimezoneSync` PATCHes `/v1/assistants/{id}/config` through the **platform** client; in local/self-hosted mode `config` wasn't in the rewrite allowlist, so it fell through to the dead platform proxy (`:8000`) → 502, and with `retry: 3` + re-fire on every focus/app.resume it became a continuous 502 flood in the dev console.
- Root-cause sweep: several daemon-/gateway-owned per-assistant resources are reached via the platform client (raw `client.*`, pending gateway codegen) and were missing from `RUNTIME_PROXIED_FIRST_SEGMENTS`. Added the verified daemon/gateway-owned segments — `config`, `permissions`, `trust-rules`, `artifacts`, `contacts`, `contact-channels` — so they forward to the gateway like `conversations`/`events`/`x`.
- Excluded `a2a` (the `/a2a/invites/redeem` platform broker route stays on Django) and `terminal` (already excluded); both pinned in the negative test. Rewriting only triggers when a self-hosted ingress is configured, so platform-hosted behavior is unchanged.

## Original prompt
Follow-up to the image-upload fix (#35458): the dev console showed a continuous flood of `502 (Bad Gateway)` on `PATCH /v1/assistants/<id>/config`, which was also starving the dev server enough to contribute to the upload stall. The ask was to investigate which client issues these requests and route the daemon-owned ones to the local gateway so the console quiets and the pointless retries stop — without breaking genuinely platform-owned routes.

## Verification
- Ownership verified per segment against the daemon/gateway generated SDKs and the gateway route source (`gateway/src/schema.ts`, `auto-approve-thresholds.ts`); `a2a` confirmed platform-owned via the `redeemA2AInvite` "platform broker (Django endpoint)" comment.
- `bunx tsc --noEmit` clean; `bun test src/lib/api-interceptors.test.ts` → 62 pass (new positive test for the routed segments; `a2a` added to the non-rewrite negative test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)