### PR TITLE
fix(subagent): pin the parent's resolved mix arm ahead of raw profile overrides

### DIFF
--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -692,6 +692,41 @@ describe("Subagent spawn success and failure", () => {
     }
   });
 
+  test("spawn pins the resolved mix arm even when the mix was chosen via a per-turn override", async () => {
+    const manager = getSubagentManager();
+    const originalSpawn = manager.spawn.bind(manager);
+    let capturedConfig: Record<string, unknown> | undefined;
+
+    manager.spawn = async (config: Record<string, unknown>) => {
+      capturedConfig = config;
+      return "inherit-mixoverride-id";
+    };
+
+    try {
+      const result = await executeSubagentSpawn(
+        { label: "Mix override child", objective: "Do it" },
+        makeContext("sess-inherit-mixoverride", {
+          sendToClient: () => {},
+          invokingCallSite: "mainAgent",
+          // The per-turn override selected a mix, so overrideProfile holds the
+          // mix NAME; attribution carries the arm the PARENT expanded it to.
+          // The arm must win — forwarding the raw mix name would let the child
+          // re-expand to a different arm under its own seed.
+          overrideProfile: "experiment-mix",
+          attribution: {
+            appliedProfile: "experiment-mix",
+            resolvedMixArm: "quality-optimized",
+          },
+        }),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(capturedConfig!.overrideProfile).toBe("quality-optimized");
+    } finally {
+      manager.spawn = originalSpawn;
+    }
+  });
+
   test("spawn returns error for unknown inference_profile", async () => {
     const manager = getSubagentManager();
     const originalSpawn = manager.spawn.bind(manager);

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -100,17 +100,18 @@ export async function executeSubagentSpawn(
   // `SubagentManager.spawn` passes it into the subagent's `runAgentLoop` as
   // `options.overrideProfile`.
   //
-  // Resolution order: an explicit spawn-time profile, then the per-turn
-  // `context.overrideProfile` (per-conversation override or tool-routed
-  // switch), then a row read, then the profile the invoking turn actually
-  // resolved to. `context.attribution` mirrors the full resolver precedence —
-  // including a configured `llm.callSites.<callSite>.profile`, which
-  // `resolveDefaultProfileKey` alone does NOT capture — so the child matches
-  // the profile that ran the parent turn even when it came from a call-site
-  // override. `resolvedMixArm` pins the exact arm a mix profile expanded to
-  // (the child would otherwise re-expand under its own seed). The trailing
-  // `resolveDefaultProfileKey` is a fallback for spawns with no attribution
-  // (e.g. outside an agent-loop turn).
+  // After an explicit spawn-time profile, the authoritative source is
+  // `context.attribution` — the profile the invoking turn ACTUALLY resolved
+  // to. It already folds in the per-turn override (per-conversation or
+  // tool-routed), the workspace `activeProfile`, and any configured
+  // `llm.callSites.<callSite>.profile`, and `resolvedMixArm` is the exact arm a
+  // mix expanded to under the PARENT's selection seed. Prefer it so the child
+  // runs what the parent ran — in particular, leading with `resolvedMixArm`
+  // (ahead of the raw override below, which holds only the mix NAME) stops the
+  // child from re-expanding the mix under its own seed and drifting to a
+  // different arm. The `context.overrideProfile` / row-read /
+  // `resolveDefaultProfileKey` chain is the fallback for spawns with no
+  // attribution (e.g. tool calls outside an agent-loop turn).
   //
   // The inherited profile is forwarded NON-forced, so an explicit
   // `llm.callSites.subagentSpawn` profile still wins; an explicit
@@ -119,14 +120,11 @@ export async function executeSubagentSpawn(
   // subagent conversation and for tool calls outside an agent-loop turn.)
   let inheritedOverrideProfile = requestedOverrideProfile;
   if (inheritedOverrideProfile === undefined) {
-    const invokerResolvedProfile =
+    const inheritedCandidate =
       context.attribution?.resolvedMixArm ??
       context.attribution?.appliedProfile ??
-      undefined;
-    const inheritedCandidate =
       context.overrideProfile ??
       getConversationOverrideProfile(context.conversationId) ??
-      invokerResolvedProfile ??
       resolveDefaultProfileKey(
         context.invokingCallSite ?? "mainAgent",
         getConfig().llm,


### PR DESCRIPTION
## Summary
- Addresses a Codex **P2** on #35462 (already merged): when the invoking turn's profile is a **mix** selected via a per-conversation or tool-routed override, `context.overrideProfile` holds the mix *name* and previously won ahead of `attribution.resolvedMixArm` in the inheritance chain. The spawned subagent then received the raw mix name (non-forced) and re-expanded it under its **own** selection seed, so it could run a different arm than the parent — breaking the parent's experiment assignment.
- Fix: lead the inheritance chain with `context.attribution` (`resolvedMixArm ?? appliedProfile`) — the profile the invoking turn *actually resolved to*, with the parent's expanded mix arm pinned. The raw `context.overrideProfile` / row-read / `resolveDefaultProfileKey` chain is now strictly the fallback for spawns with no attribution (e.g. outside an agent-loop turn). Since attribution already folds in the per-turn override, `activeProfile`, and call-site profile, this is also a net simplification.
- Adds a regression test: a mix chosen via a per-turn override forwards the parent's resolved arm, not the mix name. Existing inheritance / call-site-profile / auto-skip / fallback cases still pass.

## Original prompt
Codex left a P2 on the just-merged #35462 noting the mix-arm precedence bug: `attribution.resolvedMixArm` sat *after* the raw `context.overrideProfile` in the chain, so a mix selected via an override would be forwarded by name and re-expanded under the child's seed (possibly a different arm than the parent ran). The request was to address it if correct (it is) in a new PR.