### PR TITLE
Cherry-pick fixes into release/v0.10.0

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -16408,6 +16408,48 @@ paths:
                                 required:
                                   - requestId
                                 additionalProperties: false
+                              pendingQuestion:
+                                type: object
+                                properties:
+                                  requestId:
+                                    type: string
+                                  entries:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        id:
+                                          type: string
+                                        question:
+                                          type: string
+                                        description:
+                                          type: string
+                                        options:
+                                          type: array
+                                          items:
+                                            type: object
+                                            properties:
+                                              id:
+                                                type: string
+                                              label:
+                                                type: string
+                                              description:
+                                                type: string
+                                            required:
+                                              - id
+                                              - label
+                                            additionalProperties: false
+                                        freeTextPlaceholder:
+                                          type: string
+                                      required:
+                                        - id
+                                        - question
+                                        - options
+                                      additionalProperties: false
+                                required:
+                                  - requestId
+                                  - entries
+                                additionalProperties: false
                             required:
                               - name
                               - input
@@ -16795,6 +16837,48 @@ paths:
                                             type: boolean
                                         required:
                                           - requestId
+                                        additionalProperties: false
+                                      pendingQuestion:
+                                        type: object
+                                        properties:
+                                          requestId:
+                                            type: string
+                                          entries:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                id:
+                                                  type: string
+                                                question:
+                                                  type: string
+                                                description:
+                                                  type: string
+                                                options:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                    properties:
+                                                      id:
+                                                        type: string
+                                                      label:
+                                                        type: string
+                                                      description:
+                                                        type: string
+                                                    required:
+                                                      - id
+                                                      - label
+                                                    additionalProperties: false
+                                                freeTextPlaceholder:
+                                                  type: string
+                                              required:
+                                                - id
+                                                - question
+                                                - options
+                                              additionalProperties: false
+                                        required:
+                                          - requestId
+                                          - entries
                                         additionalProperties: false
                                     required:
                                       - name

--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -75,7 +75,12 @@ import {
   loadConfig,
   mergeDefaultWorkspaceConfig,
 } from "../config/loader.js";
-import { seedInferenceProfiles } from "../config/seed-inference-profiles.js";
+import {
+  MANAGED_PROFILE_NAMES,
+  materializeProfile,
+  OS_BETA_PROFILE_TEMPLATE,
+  seedInferenceProfiles,
+} from "../config/seed-inference-profiles.js";
 import type { DrizzleDb } from "../memory/db-connection.js";
 import { migrateCreateProviderConnections } from "../memory/migrations/243-provider-connections.js";
 import { migrateProviderConnectionStatusLabel } from "../memory/migrations/244-provider-connection-status-label.js";
@@ -1448,5 +1453,74 @@ describe("seedInferenceProfiles BYOK-mode managed profile labels", () => {
     expect(config.llm.profiles.balanced?.status).toBe("active");
     // Label is still suffixed (Vellum can push label updates).
     expect(config.llm.profiles.balanced?.label).toBe("Balanced (Managed)");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: OS Beta flag-gated managed profile. The template is defined but
+// intentionally NOT part of MANAGED_PROFILE_TEMPLATES, so seedInferenceProfiles
+// must never create it. A later PR reconciles it in/out based on the `os-beta`
+// feature flag.
+// ---------------------------------------------------------------------------
+
+describe("OS Beta managed profile template", () => {
+  beforeEach(() => {
+    ensureTestDir();
+    const resetPaths = [
+      CONFIG_PATH,
+      join(WORKSPACE_DIR, "default-config.json"),
+      join(WORKSPACE_DIR, "hatch-overlay.json"),
+      join(WORKSPACE_DIR, "keys.enc"),
+      join(WORKSPACE_DIR, "data"),
+      join(WORKSPACE_DIR, "data", "memory"),
+    ];
+    for (const path of resetPaths) {
+      if (existsSync(path)) {
+        rmSync(path, { recursive: true, force: true });
+      }
+    }
+    ensureTestDir();
+    setStorePathForTesting(join(WORKSPACE_DIR, "keys.enc"));
+    delete process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
+    delete process.env.IS_PLATFORM;
+    invalidateConfigCache();
+  });
+
+  afterEach(() => {
+    setStorePathForTesting(null);
+    delete process.env.VELLUM_DEFAULT_WORKSPACE_CONFIG_PATH;
+    delete process.env.IS_PLATFORM;
+    invalidateConfigCache();
+  });
+
+  test("seedInferenceProfiles does not create an os-beta profile", () => {
+    writeConfig({ llm: { default: { provider: "anthropic" } } });
+
+    mergeDefaultConfigAndSeedInferenceProfiles();
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+
+    expect(raw.llm.profiles["os-beta"]).toBeUndefined();
+    expect((raw.llm.profileOrder as string[]).includes("os-beta")).toBe(false);
+  });
+
+  test("MANAGED_PROFILE_NAMES contains os-beta", () => {
+    expect(MANAGED_PROFILE_NAMES.has("os-beta")).toBe(true);
+  });
+
+  test("materializeProfile honors the explicit OS Beta model", () => {
+    const entry = materializeProfile(
+      OS_BETA_PROFILE_TEMPLATE,
+      "fireworks",
+      "fireworks-managed",
+    );
+
+    expect(entry.model).toBe("accounts/fireworks/models/glm-5p2");
+    expect(entry.provider_connection).toBe("fireworks-managed");
+    expect(entry.provider).toBe("fireworks");
+    expect(entry.label).toBe("OS Beta");
+    expect(entry.source).toBe("managed");
+    expect(entry.maxTokens).toBe(32000);
+    expect(entry.effort).toBe("high");
+    expect(entry.thinking?.enabled).toBe(true);
   });
 });

--- a/assistant/src/__tests__/gateway-flag-listener.test.ts
+++ b/assistant/src/__tests__/gateway-flag-listener.test.ts
@@ -25,12 +25,14 @@ mock.module("../ipc/socket-path.js", () => ({
 // Track calls to refreshOverridesFromGateway
 // ---------------------------------------------------------------------------
 let refreshCallCount = 0;
+let refreshReturnsLoaded = true;
 
 mock.module("../config/assistant-feature-flags.js", () => ({
   refreshOverridesFromGateway: async () => {
     refreshCallCount++;
+    return refreshReturnsLoaded;
   },
-  initFeatureFlagOverrides: async () => {},
+  initFeatureFlagOverrides: async () => true,
   clearFeatureFlagOverridesCache: () => {},
   isAssistantFeatureFlagEnabled: () => true,
 }));
@@ -57,6 +59,32 @@ let syncToolsCallCount = 0;
 mock.module("../tools/registry.js", () => ({
   syncFlagGatedTools: async () => {
     syncToolsCallCount++;
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Track reconcileFlagGatedProfiles calls and let each test control whether it
+// reports a config change, so we can assert the listener broadcasts only when
+// the managed profile set actually changes.
+// ---------------------------------------------------------------------------
+let reconcileCallCount = 0;
+let reconcileReturns = false;
+
+mock.module("../config/sync-gated-profiles.js", () => ({
+  reconcileFlagGatedProfiles: () => {
+    reconcileCallCount++;
+    return reconcileReturns;
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Track publishConfigChanged so we can assert the picker-refresh broadcast.
+// ---------------------------------------------------------------------------
+let configChangedCount = 0;
+
+mock.module("../runtime/sync/resource-sync-events.js", () => ({
+  publishConfigChanged: () => {
+    configChangedCount++;
   },
 }));
 
@@ -115,8 +143,12 @@ describe("gateway-flag-listener", () => {
   beforeEach(() => {
     mkdirSync(testRoot, { recursive: true });
     refreshCallCount = 0;
+    refreshReturnsLoaded = true;
     syncToolsCallCount = 0;
     publishedTagSets = [];
+    reconcileCallCount = 0;
+    reconcileReturns = false;
+    configChangedCount = 0;
     testServer = createTestServer();
   });
 
@@ -178,6 +210,83 @@ describe("gateway-flag-listener", () => {
       "feature-flags:client",
       "feature-flags:assistant",
     ]);
+  });
+
+  test("reconciles flag-gated profiles and broadcasts config_changed when the profile set changes", async () => {
+    reconcileReturns = true;
+    await new Promise<void>((resolve) => {
+      testServer.server.listen(socketPath, resolve);
+    });
+
+    startGatewayFlagListener();
+    await testServer.waitForClient();
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Connect path reconciles once and, since it reports a change, broadcasts.
+    expect(reconcileCallCount).toBe(1);
+    expect(configChangedCount).toBe(1);
+
+    testServer.emit("feature_flags_changed");
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(reconcileCallCount).toBe(2);
+    expect(configChangedCount).toBe(2);
+  });
+
+  test("reconciles but does not broadcast config_changed when the profile set is unchanged", async () => {
+    reconcileReturns = false;
+    await new Promise<void>((resolve) => {
+      testServer.server.listen(socketPath, resolve);
+    });
+
+    startGatewayFlagListener();
+    await testServer.waitForClient();
+    await new Promise((r) => setTimeout(r, 100));
+
+    testServer.emit("feature_flags_changed");
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(reconcileCallCount).toBeGreaterThanOrEqual(2);
+    expect(configChangedCount).toBe(0);
+  });
+
+  test("does not reconcile profiles when the refresh reports flags did not load", async () => {
+    reconcileReturns = true;
+    refreshReturnsLoaded = false;
+    await new Promise<void>((resolve) => {
+      testServer.server.listen(socketPath, resolve);
+    });
+
+    startGatewayFlagListener();
+    await testServer.waitForClient();
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Tool sync stays unconditional; the profile reconcile/broadcast are gated.
+    expect(syncToolsCallCount).toBe(1);
+    expect(reconcileCallCount).toBe(0);
+    expect(configChangedCount).toBe(0);
+
+    testServer.emit("feature_flags_changed");
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(syncToolsCallCount).toBe(2);
+    expect(reconcileCallCount).toBe(0);
+    expect(configChangedCount).toBe(0);
+  });
+
+  test("reconciles profiles when the refresh reports flags loaded", async () => {
+    reconcileReturns = true;
+    refreshReturnsLoaded = true;
+    await new Promise<void>((resolve) => {
+      testServer.server.listen(socketPath, resolve);
+    });
+
+    startGatewayFlagListener();
+    await testServer.waitForClient();
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(reconcileCallCount).toBe(1);
+    expect(configChangedCount).toBe(1);
   });
 
   test("ignores non-flag events", async () => {

--- a/assistant/src/__tests__/llm-catalog-parity.test.ts
+++ b/assistant/src/__tests__/llm-catalog-parity.test.ts
@@ -2,7 +2,10 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
-import { PROVIDER_CATALOG } from "../providers/model-catalog.js";
+import {
+  isModelInCatalog,
+  PROVIDER_CATALOG,
+} from "../providers/model-catalog.js";
 import { PLATFORM_PROVIDER_META } from "../providers/platform-proxy/constants.js";
 import { resolvePricing, resolvePricingForUsage } from "../util/pricing.js";
 
@@ -299,6 +302,32 @@ describe("LLM catalog parity: daemon vs client", () => {
       maxOutputTokens: 128000,
       longContextPricingThresholdTokens: 272000,
       longContextMode: "native-model",
+    });
+  });
+
+  test("Fireworks catalog includes GLM 5.2", () => {
+    expect(
+      isModelInCatalog("fireworks", "accounts/fireworks/models/glm-5p2"),
+    ).toBe(true);
+
+    const fireworks = PROVIDER_CATALOG.find(
+      (entry) => entry.id === "fireworks",
+    );
+    expect(
+      fireworks?.models.find(
+        (model) => model.id === "accounts/fireworks/models/glm-5p2",
+      ),
+    ).toMatchObject({
+      displayName: "GLM 5.2",
+      contextWindowTokens: 1040000,
+      maxOutputTokens: 131072,
+      supportsToolUse: true,
+      supportsVision: false,
+      pricing: {
+        inputPer1mTokens: 1.4,
+        outputPer1mTokens: 4.4,
+        cacheReadPer1mTokens: 0.26,
+      },
     });
   });
 

--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -22,10 +22,19 @@ function makeDefaultRawConfig(): Record<string, unknown> {
         "quality-optimized": {
           provider: "anthropic",
           model: "claude-sonnet",
+          source: "managed",
         },
-        balanced: { provider: "anthropic", model: "claude-sonnet" },
-        "cost-optimized": { provider: "anthropic", model: "claude-haiku" },
-        "my-custom": { provider: "openai", model: "gpt-4o" },
+        balanced: {
+          provider: "anthropic",
+          model: "claude-sonnet",
+          source: "managed",
+        },
+        "cost-optimized": {
+          provider: "anthropic",
+          model: "claude-haiku",
+          source: "managed",
+        },
+        "my-custom": { provider: "openai", model: "gpt-4o", source: "user" },
       },
     },
   };
@@ -327,6 +336,65 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
     expect(profile.model).toBe("claude-sonnet");
   });
 
+  test("allows edits to a user-owned profile sharing a managed name (os-beta)", async () => {
+    savedRaw = null;
+    rawConfig = {
+      llm: {
+        profiles: {
+          "os-beta": {
+            provider: "anthropic",
+            model: "claude-sonnet",
+            source: "user",
+          },
+        },
+      },
+    };
+    const result = await replaceRoute.handler({
+      pathParams: { name: "os-beta" },
+      body: { provider: "openai", model: "gpt-4o" },
+    });
+    expect(result).toEqual({ ok: true });
+    const profile = (savedRaw as unknown as Record<string, any>)?.llm
+      ?.profiles?.["os-beta"] as Record<string, unknown>;
+    expect(profile.provider).toBe("openai");
+    expect(profile.model).toBe("gpt-4o");
+  });
+
+  test("rejects edits to a managed os-beta profile", async () => {
+    rawConfig = {
+      llm: {
+        profiles: {
+          "os-beta": {
+            provider: "fireworks",
+            model: "accounts/fireworks/models/glm-5p2",
+            source: "managed",
+          },
+        },
+      },
+    };
+    await expect(
+      replaceRoute.handler({
+        pathParams: { name: "os-beta" },
+        body: { provider: "openai", model: "gpt-4o" },
+      }),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  test("rejects PUT to os-beta when no os-beta profile exists, writing no stub", async () => {
+    savedRaw = null;
+    rawConfig = { llm: { profiles: {} } };
+    await expect(
+      replaceRoute.handler({
+        pathParams: { name: "os-beta" },
+        body: { label: "My OS Beta" },
+      }),
+    ).rejects.toThrow("not currently available");
+    expect(savedRaw).toBeNull();
+    expect(
+      (rawConfig as Record<string, any>)?.llm?.profiles?.["os-beta"],
+    ).toBeUndefined();
+  });
+
   test("PUT { label: '' } on managed profile still rejected by `.min(1)`", async () => {
     // `.nullable()` only widens the type to accept null — empty strings
     // still fail the min-length check, which is correct: an empty string
@@ -426,6 +494,44 @@ describe("PATCH /v1/config — managed profile deletion guard", () => {
       },
     });
     expect(result).toHaveProperty("llm");
+  });
+
+  test("allows deletion of a user-owned profile sharing a managed name (os-beta)", async () => {
+    savedRaw = null;
+    rawConfig = {
+      llm: {
+        profiles: {
+          "os-beta": {
+            provider: "anthropic",
+            model: "claude-sonnet",
+            source: "user",
+          },
+        },
+      },
+    };
+    const result = await patchRoute.handler({
+      body: { llm: { profiles: { "os-beta": null } } },
+    });
+    expect(result).toHaveProperty("llm");
+  });
+
+  test("rejects deletion of a managed os-beta profile", async () => {
+    rawConfig = {
+      llm: {
+        profiles: {
+          "os-beta": {
+            provider: "fireworks",
+            model: "accounts/fireworks/models/glm-5p2",
+            source: "managed",
+          },
+        },
+      },
+    };
+    await expect(
+      patchRoute.handler({
+        body: { llm: { profiles: { "os-beta": null } } },
+      }),
+    ).rejects.toThrow('Cannot delete managed profile "os-beta".');
   });
 
   test("rejects nulling the entire profiles map", async () => {

--- a/assistant/src/__tests__/skill-execute-input.test.ts
+++ b/assistant/src/__tests__/skill-execute-input.test.ts
@@ -103,6 +103,11 @@ describe("augmentSkillExecuteError", () => {
     expect(result.content).toContain("carried no parameters");
     expect(result.content).toContain('"tool": "subagent_spawn"');
     expect(result.content).toContain("inside `input`");
+    // The guidance must not condemn the JSON-encoded-string form: the resolver
+    // accepts it (resolveSkillExecuteInput parses string input), and it is a
+    // shape weak models successfully use. Telling them it is wrong steers them
+    // toward dropping the payload entirely.
+    expect(result.content).not.toContain("JSON-encoded string");
   });
 
   test("leaves errors untouched when parameters were resolved", () => {

--- a/assistant/src/__tests__/subagent-tools.test.ts
+++ b/assistant/src/__tests__/subagent-tools.test.ts
@@ -8,6 +8,7 @@ let mockGetMessages: (
 ) => Array<{ role: string; content: string }> | null = () => null;
 const mockProfiles = {
   balanced: {},
+  "cost-optimized": {},
   disabled: { status: "disabled" },
   "quality-optimized": {},
 };
@@ -470,6 +471,155 @@ describe("Subagent spawn success and failure", () => {
       expect(result.isError).toBe(false);
       expect(capturedConfig).toBeDefined();
       expect(capturedConfig!.overrideProfile).toBe("quality-optimized");
+      expect(capturedConfig!.forceOverrideProfile).toBe(true);
+    } finally {
+      manager.spawn = originalSpawn;
+    }
+  });
+
+  test("spawn inherits the invoking call site's default profile when no override is present", async () => {
+    const manager = getSubagentManager();
+    const originalSpawn = manager.spawn.bind(manager);
+    let capturedConfig: Record<string, unknown> | undefined;
+
+    manager.spawn = async (config: Record<string, unknown>) => {
+      capturedConfig = config;
+      return "inherit-default-id";
+    };
+
+    try {
+      const result = await executeSubagentSpawn(
+        { label: "Inherit default", objective: "Do it" },
+        makeContext("sess-inherit-default", {
+          sendToClient: () => {},
+          invokingCallSite: "mainAgent",
+        }),
+      );
+
+      expect(result.isError).toBe(false);
+      // No explicit profile and no per-turn override → the child matches the
+      // invoking call site's resolved default profile (balanced for mainAgent
+      // in the test config).
+      expect(capturedConfig!.overrideProfile).toBe("balanced");
+      expect(capturedConfig!.forceOverrideProfile).toBeUndefined();
+    } finally {
+      manager.spawn = originalSpawn;
+    }
+  });
+
+  test("spawn inherits a non-main invoker's call-site default profile", async () => {
+    const manager = getSubagentManager();
+    const originalSpawn = manager.spawn.bind(manager);
+    let capturedConfig: Record<string, unknown> | undefined;
+
+    manager.spawn = async (config: Record<string, unknown>) => {
+      capturedConfig = config;
+      return "inherit-heartbeat-id";
+    };
+
+    try {
+      const result = await executeSubagentSpawn(
+        { label: "Heartbeat child", objective: "Do it" },
+        makeContext("sess-inherit-heartbeat", {
+          sendToClient: () => {},
+          invokingCallSite: "heartbeatAgent",
+        }),
+      );
+
+      expect(result.isError).toBe(false);
+      // A subagent spawned from a heartbeat turn matches heartbeatAgent's own
+      // cost-optimized default, not the mainAgent default.
+      expect(capturedConfig!.overrideProfile).toBe("cost-optimized");
+    } finally {
+      manager.spawn = originalSpawn;
+    }
+  });
+
+  test("spawn prefers a per-turn override profile over the invoker default", async () => {
+    const manager = getSubagentManager();
+    const originalSpawn = manager.spawn.bind(manager);
+    let capturedConfig: Record<string, unknown> | undefined;
+
+    manager.spawn = async (config: Record<string, unknown>) => {
+      capturedConfig = config;
+      return "inherit-override-id";
+    };
+
+    try {
+      const result = await executeSubagentSpawn(
+        { label: "Override child", objective: "Do it" },
+        makeContext("sess-inherit-override", {
+          sendToClient: () => {},
+          invokingCallSite: "mainAgent",
+          overrideProfile: "quality-optimized",
+        }),
+      );
+
+      expect(result.isError).toBe(false);
+      // The live per-turn override (per-conversation or tool-routed) wins over
+      // the call-site default, and is forwarded non-forced.
+      expect(capturedConfig!.overrideProfile).toBe("quality-optimized");
+      expect(capturedConfig!.forceOverrideProfile).toBeUndefined();
+    } finally {
+      manager.spawn = originalSpawn;
+    }
+  });
+
+  test("spawn skips the auto profile so the child keeps its own default", async () => {
+    const manager = getSubagentManager();
+    const originalSpawn = manager.spawn.bind(manager);
+    let capturedConfig: Record<string, unknown> | undefined;
+
+    manager.spawn = async (config: Record<string, unknown>) => {
+      capturedConfig = config;
+      return "inherit-auto-id";
+    };
+
+    try {
+      const result = await executeSubagentSpawn(
+        { label: "Auto child", objective: "Do it" },
+        makeContext("sess-inherit-auto", {
+          sendToClient: () => {},
+          invokingCallSite: "mainAgent",
+          // "auto" is metadata-only; forwarding it would collapse the child to
+          // llm.default, so the inherited path drops it and the child keeps its
+          // own subagentSpawn default.
+          overrideProfile: "auto",
+        }),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(capturedConfig!.overrideProfile).toBeUndefined();
+    } finally {
+      manager.spawn = originalSpawn;
+    }
+  });
+
+  test("spawn still forces an explicit inference_profile over the invoker default", async () => {
+    const manager = getSubagentManager();
+    const originalSpawn = manager.spawn.bind(manager);
+    let capturedConfig: Record<string, unknown> | undefined;
+
+    manager.spawn = async (config: Record<string, unknown>) => {
+      capturedConfig = config;
+      return "inherit-explicit-id";
+    };
+
+    try {
+      const result = await executeSubagentSpawn(
+        {
+          label: "Explicit child",
+          objective: "Do it",
+          inference_profile: "cost-optimized",
+        },
+        makeContext("sess-inherit-explicit", {
+          sendToClient: () => {},
+          invokingCallSite: "mainAgent",
+        }),
+      );
+
+      expect(result.isError).toBe(false);
+      expect(capturedConfig!.overrideProfile).toBe("cost-optimized");
       expect(capturedConfig!.forceOverrideProfile).toBe(true);
     } finally {
       manager.spawn = originalSpawn;

--- a/assistant/src/__tests__/weak-open-model.test.ts
+++ b/assistant/src/__tests__/weak-open-model.test.ts
@@ -10,6 +10,7 @@ describe("isWeakOpenModel", () => {
       "moonshotai/kimi-k2.6",
       "accounts/fireworks/models/kimi-k2p6",
       "deepseek/deepseek-chat",
+      "accounts/fireworks/models/glm-5p2",
     ]) {
       expect(isWeakOpenModel(model)).toBe(true);
     }

--- a/assistant/src/api/responses/conversation-message.ts
+++ b/assistant/src/api/responses/conversation-message.ts
@@ -30,6 +30,7 @@ import {
   DirectoryScopeOptionSchema,
   ScopeOptionSchema,
 } from "../events/confirmation-request.js";
+import { QuestionEntrySchema } from "../events/question-request.js";
 import { ToolActivityMetadataSchema } from "../events/tool-result.js";
 
 // ---------------------------------------------------------------------------
@@ -103,6 +104,25 @@ export const PendingToolConfirmationSchema = z.object({
 export type PendingToolConfirmation = z.infer<
   typeof PendingToolConfirmationSchema
 >;
+
+/**
+ * In-flight `ask_question` prompt awaiting a user answer, mirrored onto the
+ * history tool call that raised it so a cold reconnect (or a conversation
+ * reopened after the event-buffer window has elapsed) can restore the inline
+ * question card without replaying the live `question_request` SSE event.
+ *
+ * Stamped at render time from the in-memory `pending-interactions` registry
+ * (the authoritative store of unresolved prompts) — not persisted to the
+ * database, so it appears only while the prompt is genuinely outstanding and
+ * disappears once the interaction resolves. `entries` mirrors the
+ * `question_request` event's `questions[]`, so both paths hydrate the same
+ * client state.
+ */
+export const PendingToolQuestionSchema = z.object({
+  requestId: z.string(),
+  entries: z.array(QuestionEntrySchema),
+});
+export type PendingToolQuestion = z.infer<typeof PendingToolQuestionSchema>;
 
 /**
  * Closed set of confirmation outcomes recorded for a tool call. The daemon
@@ -190,6 +210,12 @@ export const ConversationMessageToolCallSchema = z.object({
    * Guaranteed present for outstanding prompts as of daemon v0.8.8.
    */
   pendingConfirmation: PendingToolConfirmationSchema.optional(),
+  /**
+   * In-flight `ask_question` prompt, present only while the tool call is
+   * awaiting a user answer (read from the `pending-interactions` registry at
+   * render time). Lets a cold reconnect restore the inline question card.
+   */
+  pendingQuestion: PendingToolQuestionSchema.optional(),
 });
 export type ConversationMessageToolCall = z.infer<
   typeof ConversationMessageToolCallSchema

--- a/assistant/src/cli/commands/oauth/status.test.ts
+++ b/assistant/src/cli/commands/oauth/status.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { noConnectionsMessage } from "./status.js";
+
+const original = process.env.__RESOLVED_MODEL;
+
+afterEach(() => {
+  if (original === undefined) delete process.env.__RESOLVED_MODEL;
+  else process.env.__RESOLVED_MODEL = original;
+});
+
+describe("noConnectionsMessage", () => {
+  test("capable models get the terse default", () => {
+    process.env.__RESOLVED_MODEL = "claude-opus-4-8";
+    const msg = noConnectionsMessage("google");
+    expect(msg).toBe(
+      "No active connections for google.\n" +
+        "Connect with `assistant oauth connect google`.\n",
+    );
+  });
+
+  test("no resolved model falls back to the terse default", () => {
+    delete process.env.__RESOLVED_MODEL;
+    expect(noConnectionsMessage("google")).toContain(
+      "Connect with `assistant oauth connect google`.",
+    );
+  });
+
+  test("weak open models are steered to the oauth_connect surface", () => {
+    process.env.__RESOLVED_MODEL = "accounts/fireworks/models/minimax-m3";
+    const msg = noConnectionsMessage("google");
+    expect(msg).toContain('surface_type "oauth_connect"');
+    expect(msg).toContain('data.providerKey "google"');
+    expect(msg).not.toContain("assistant oauth connect google");
+  });
+});

--- a/assistant/src/cli/commands/oauth/status.ts
+++ b/assistant/src/cli/commands/oauth/status.ts
@@ -1,7 +1,29 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../../ipc/cli-client.js";
+import { isWeakOpenModel } from "../../../providers/weak-open-model.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
+
+/**
+ * Message shown when a provider has no active connections. Weak open models
+ * loop through redundant discovery commands (channel checks, `oauth providers
+ * get`, loading the OAuth setup skill) before rendering the connect button, so
+ * they get an explicit single next action: render the core `oauth_connect`
+ * surface directly. Capable models keep the terse default.
+ */
+export function noConnectionsMessage(provider: string): string {
+  const base = `No active connections for ${provider}.`;
+  if (isWeakOpenModel(process.env.__RESOLVED_MODEL)) {
+    return (
+      `${base}\nTo let the user connect, render the connect button: call ` +
+      `\`ui_show\` with surface_type "oauth_connect" and ` +
+      `data.providerKey "${provider}". That surface is always available — do ` +
+      `not run further \`oauth\`/\`channels\` commands or load a setup skill ` +
+      `just to display it.\n`
+    );
+  }
+  return `${base}\nConnect with \`assistant oauth connect ${provider}\`.\n`;
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -91,9 +113,7 @@ Examples:
 
           // Text output
           if (connections.length === 0) {
-            process.stdout.write(
-              `No active connections for ${provider}.\nConnect with \`assistant oauth connect ${provider}\`.\n`,
-            );
+            process.stdout.write(noConnectionsMessage(provider));
             return;
           }
 

--- a/assistant/src/config/__tests__/sync-gated-profiles.test.ts
+++ b/assistant/src/config/__tests__/sync-gated-profiles.test.ts
@@ -1,0 +1,368 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+const WORKSPACE_DIR = process.env.VELLUM_WORKSPACE_DIR!;
+const CONFIG_PATH = join(WORKSPACE_DIR, "config.json");
+
+function ensureTestDir(): void {
+  const dirs = [
+    WORKSPACE_DIR,
+    join(WORKSPACE_DIR, "data"),
+    join(WORKSPACE_DIR, "data", "memory"),
+    join(WORKSPACE_DIR, "data", "logs"),
+  ];
+  for (const dir of dirs) {
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  }
+}
+
+function makeLoggerStub(): Record<string, unknown> {
+  const stub: Record<string, unknown> = {};
+  for (const m of [
+    "info",
+    "warn",
+    "error",
+    "debug",
+    "trace",
+    "fatal",
+    "silent",
+    "child",
+  ]) {
+    stub[m] = m === "child" ? () => makeLoggerStub() : () => {};
+  }
+  return stub;
+}
+
+mock.module("../../util/logger.js", () => ({
+  getLogger: () => makeLoggerStub(),
+}));
+
+afterAll(() => {
+  mock.restore();
+});
+
+import { setOverridesForTesting } from "../../__tests__/feature-flag-test-helpers.js";
+import { invalidateConfigCache } from "../loader.js";
+import { LLMSchema } from "../schemas/llm.js";
+import { seedInferenceProfiles } from "../seed-inference-profiles.js";
+import { reconcileFlagGatedProfiles } from "../sync-gated-profiles.js";
+
+type RawConfig = {
+  llm: {
+    profiles: Record<string, Record<string, unknown>>;
+    profileOrder: string[];
+    activeProfile?: string;
+    advisorProfile?: string;
+  };
+};
+
+function writeConfig(obj: unknown): void {
+  writeFileSync(CONFIG_PATH, JSON.stringify(obj, null, 2) + "\n");
+}
+
+function readConfig(): RawConfig {
+  return JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+}
+
+function seedBalancedConfig(): void {
+  writeConfig({ llm: { default: { provider: "anthropic" } } });
+  invalidateConfigCache();
+  seedInferenceProfiles({});
+}
+
+describe("reconcileFlagGatedProfiles", () => {
+  beforeEach(() => {
+    ensureTestDir();
+    if (existsSync(CONFIG_PATH)) rmSync(CONFIG_PATH, { force: true });
+    delete process.env.IS_PLATFORM;
+    setOverridesForTesting({});
+    invalidateConfigCache();
+  });
+
+  afterEach(() => {
+    delete process.env.IS_PLATFORM;
+    setOverridesForTesting({});
+    invalidateConfigCache();
+  });
+
+  test("flag on materializes the managed os-beta profile after balanced", () => {
+    process.env.IS_PLATFORM = "true";
+    seedBalancedConfig();
+    setOverridesForTesting({ "os-beta": true });
+
+    expect(reconcileFlagGatedProfiles()).toBe(true);
+
+    const raw = readConfig();
+    const osBeta = raw.llm.profiles["os-beta"]!;
+    expect(osBeta.model).toBe("accounts/fireworks/models/glm-5p2");
+    expect(osBeta.provider_connection).toBe("fireworks-managed");
+    expect(osBeta.source).toBe("managed");
+    expect(osBeta.label).toBe("OS Beta");
+
+    const order = raw.llm.profileOrder;
+    expect(order.indexOf("os-beta")).toBe(order.indexOf("balanced") + 1);
+  });
+
+  test("flag on in BYOK mode seeds the os-beta profile disabled", () => {
+    seedBalancedConfig();
+    setOverridesForTesting({ "os-beta": true });
+
+    expect(reconcileFlagGatedProfiles()).toBe(true);
+
+    const osBeta = readConfig().llm.profiles["os-beta"]!;
+    expect(osBeta.status).toBe("disabled");
+    expect(osBeta.label).toBe("OS Beta (Managed)");
+    expect(osBeta.source).toBe("managed");
+  });
+
+  test("flag on is idempotent across repeated runs", () => {
+    process.env.IS_PLATFORM = "true";
+    seedBalancedConfig();
+    setOverridesForTesting({ "os-beta": true });
+
+    expect(reconcileFlagGatedProfiles()).toBe(true);
+    invalidateConfigCache();
+    expect(reconcileFlagGatedProfiles()).toBe(false);
+  });
+
+  test("flag on preserves user overrides on the managed profile", () => {
+    process.env.IS_PLATFORM = "true";
+    seedBalancedConfig();
+    setOverridesForTesting({ "os-beta": true });
+    reconcileFlagGatedProfiles();
+
+    const raw = readConfig();
+    raw.llm.profiles["os-beta"]!.label = "My OS Beta";
+    raw.llm.profiles["os-beta"]!.status = "disabled";
+    raw.llm.profiles["os-beta"]!.advisorEnabled = true;
+    writeConfig(raw);
+    invalidateConfigCache();
+
+    reconcileFlagGatedProfiles();
+
+    const after = readConfig().llm.profiles["os-beta"]!;
+    expect(after.label).toBe("My OS Beta");
+    expect(after.status).toBe("disabled");
+    expect(after.advisorEnabled).toBe(true);
+    expect(after.model).toBe("accounts/fireworks/models/glm-5p2");
+  });
+
+  test("flag off removes a managed os-beta and applies fallbacks", () => {
+    process.env.IS_PLATFORM = "true";
+    seedBalancedConfig();
+    setOverridesForTesting({ "os-beta": true });
+    reconcileFlagGatedProfiles();
+
+    const raw = readConfig();
+    raw.llm.activeProfile = "os-beta";
+    raw.llm.advisorProfile = "os-beta";
+    writeConfig(raw);
+    invalidateConfigCache();
+
+    setOverridesForTesting({ "os-beta": false });
+    expect(reconcileFlagGatedProfiles()).toBe(true);
+
+    const after = readConfig();
+    expect(after.llm.profiles["os-beta"]).toBeUndefined();
+    expect(after.llm.profileOrder.includes("os-beta")).toBe(false);
+    expect(after.llm.activeProfile).toBe("balanced");
+    expect(after.llm.advisorProfile).toBe("quality-optimized");
+  });
+
+  test("flag off with no os-beta present is a no-op", () => {
+    process.env.IS_PLATFORM = "true";
+    seedBalancedConfig();
+    setOverridesForTesting({ "os-beta": false });
+
+    expect(reconcileFlagGatedProfiles()).toBe(false);
+  });
+
+  test("flag off scrubs os-beta from user mix arms, keeping >= 2-arm mixes", () => {
+    process.env.IS_PLATFORM = "true";
+    seedBalancedConfig();
+    setOverridesForTesting({ "os-beta": true });
+    reconcileFlagGatedProfiles();
+
+    const raw = readConfig();
+    raw.llm.profiles["my-mix"] = {
+      source: "user",
+      label: "My Mix",
+      mix: [
+        { profile: "balanced", weight: 70 },
+        { profile: "quality-optimized", weight: 20 },
+        { profile: "os-beta", weight: 30 },
+      ],
+    };
+    raw.llm.profileOrder.push("my-mix");
+    writeConfig(raw);
+    invalidateConfigCache();
+
+    setOverridesForTesting({ "os-beta": false });
+    expect(reconcileFlagGatedProfiles()).toBe(true);
+
+    const after = readConfig();
+    expect(after.llm.profiles["os-beta"]).toBeUndefined();
+    const mix = after.llm.profiles["my-mix"]!;
+    expect(mix.mix).toEqual([
+      { profile: "balanced", weight: 70 },
+      { profile: "quality-optimized", weight: 20 },
+    ]);
+    expect(mix.source).toBe("user");
+    expect(mix.label).toBe("My Mix");
+
+    invalidateConfigCache();
+    expect(reconcileFlagGatedProfiles()).toBe(false);
+  });
+
+  test("flag off removes a two-arm mix that loses os-beta and repoints refs", () => {
+    process.env.IS_PLATFORM = "true";
+    seedBalancedConfig();
+    setOverridesForTesting({ "os-beta": true });
+    reconcileFlagGatedProfiles();
+
+    const raw = readConfig();
+    raw.llm.profiles["experiment"] = {
+      source: "user",
+      label: "Experiment",
+      mix: [
+        { profile: "balanced", weight: 50 },
+        { profile: "os-beta", weight: 50 },
+      ],
+    };
+    raw.llm.profileOrder.push("experiment");
+    raw.llm.activeProfile = "experiment";
+    raw.llm.advisorProfile = "os-beta";
+    (raw.llm as Record<string, unknown>).callSites = {
+      mainAgent: { profile: "experiment" },
+    };
+    writeConfig(raw);
+    invalidateConfigCache();
+
+    setOverridesForTesting({ "os-beta": false });
+    expect(reconcileFlagGatedProfiles()).toBe(true);
+
+    const after = readConfig();
+    expect(after.llm.profiles["os-beta"]).toBeUndefined();
+    expect(after.llm.profiles["experiment"]).toBeUndefined();
+    expect(after.llm.profileOrder.includes("os-beta")).toBe(false);
+    expect(after.llm.profileOrder.includes("experiment")).toBe(false);
+    expect(after.llm.activeProfile).toBe("balanced");
+    expect(after.llm.advisorProfile).toBe("quality-optimized");
+    expect(
+      (
+        after.llm as unknown as Record<
+          string,
+          Record<string, Record<string, unknown>>
+        >
+      ).callSites.mainAgent.profile,
+    ).toBeUndefined();
+
+    expect(LLMSchema.safeParse(after.llm).success).toBe(true);
+  });
+
+  test("flag off shortens a three-arm mix to two surviving arms", () => {
+    process.env.IS_PLATFORM = "true";
+    seedBalancedConfig();
+    setOverridesForTesting({ "os-beta": true });
+    reconcileFlagGatedProfiles();
+
+    const raw = readConfig();
+    raw.llm.profiles["blend"] = {
+      source: "user",
+      label: "Blend",
+      mix: [
+        { profile: "balanced", weight: 40 },
+        { profile: "os-beta", weight: 30 },
+        { profile: "quality-optimized", weight: 30 },
+      ],
+    };
+    raw.llm.profileOrder.push("blend");
+    writeConfig(raw);
+    invalidateConfigCache();
+
+    setOverridesForTesting({ "os-beta": false });
+    expect(reconcileFlagGatedProfiles()).toBe(true);
+
+    const after = readConfig();
+    expect(after.llm.profiles["os-beta"]).toBeUndefined();
+    expect(after.llm.profiles["blend"]!.mix).toEqual([
+      { profile: "balanced", weight: 40 },
+      { profile: "quality-optimized", weight: 30 },
+    ]);
+
+    expect(LLMSchema.safeParse(after.llm).success).toBe(true);
+  });
+
+  test("flag off clears a call-site profile reference to os-beta", () => {
+    process.env.IS_PLATFORM = "true";
+    seedBalancedConfig();
+    setOverridesForTesting({ "os-beta": true });
+    reconcileFlagGatedProfiles();
+
+    const raw = readConfig();
+    (raw.llm as Record<string, unknown>).callSites = {
+      advisor: { profile: "os-beta", temperature: 0.3 },
+    };
+    writeConfig(raw);
+    invalidateConfigCache();
+
+    setOverridesForTesting({ "os-beta": false });
+    expect(reconcileFlagGatedProfiles()).toBe(true);
+
+    const after = readConfig();
+    const advisor = (
+      after.llm as unknown as Record<
+        string,
+        Record<string, Record<string, unknown>>
+      >
+    ).callSites.advisor;
+    expect(advisor.profile).toBeUndefined();
+    expect(advisor.temperature).toBe(0.3);
+
+    expect(LLMSchema.safeParse(after.llm).success).toBe(true);
+  });
+
+  test("a user-owned os-beta profile is never touched", () => {
+    process.env.IS_PLATFORM = "true";
+    writeConfig({
+      llm: {
+        default: { provider: "anthropic" },
+        profiles: {
+          "os-beta": {
+            source: "user",
+            label: "Mine",
+            provider: "anthropic",
+            model: "claude-x",
+            provider_connection: "anthropic-personal",
+          },
+        },
+        profileOrder: ["os-beta"],
+      },
+    });
+    invalidateConfigCache();
+    const before = readFileSync(CONFIG_PATH, "utf-8");
+
+    setOverridesForTesting({ "os-beta": true });
+    expect(reconcileFlagGatedProfiles()).toBe(false);
+    expect(readFileSync(CONFIG_PATH, "utf-8")).toBe(before);
+
+    setOverridesForTesting({ "os-beta": false });
+    expect(reconcileFlagGatedProfiles()).toBe(false);
+    expect(readFileSync(CONFIG_PATH, "utf-8")).toBe(before);
+  });
+});

--- a/assistant/src/config/assistant-feature-flags.ts
+++ b/assistant/src/config/assistant-feature-flags.ts
@@ -103,7 +103,11 @@ function parseRegistryToDefaults(parsed: unknown): FeatureFlagDefaultsRegistry {
     const entry = flag as Record<string, unknown>;
     if (entry.scope !== "assistant" && entry.scope !== "both") continue;
     if (typeof entry.key !== "string") continue;
-    if (typeof entry.defaultEnabled !== "boolean" && typeof entry.defaultEnabled !== "string") continue;
+    if (
+      typeof entry.defaultEnabled !== "boolean" &&
+      typeof entry.defaultEnabled !== "string"
+    )
+      continue;
 
     result[entry.key as string] = {
       defaultEnabled: entry.defaultEnabled,
@@ -178,6 +182,12 @@ const DEFAULT_INIT_RETRY_BACKOFFS_MS: readonly number[] = [
  * tests preseed flag state via `setOverridesForTesting()` (in
  * `__tests__/feature-flag-test-helpers.ts`) without the gateway IPC call
  * clobbering their setup.
+ *
+ * Resolves `true` when the override cache is populated from the gateway and
+ * `false` when the cache is left unset (exhausted retries / unreachable
+ * gateway). Callers that mutate persisted state from flag values gate that
+ * work on a `true` result so a failed fetch never resolves a flag to its
+ * registry default and drops user state.
  */
 export async function initFeatureFlagOverrides(options?: {
   retryBackoffsMs?: readonly number[];
@@ -188,8 +198,8 @@ export async function initFeatureFlagOverrides(options?: {
    * instead of blocking startup.
    */
   callTimeoutMs?: number;
-}): Promise<void> {
-  if (isCachedFromGateway()) return;
+}): Promise<boolean> {
+  if (isCachedFromGateway()) return true;
 
   const backoffs = options?.retryBackoffsMs ?? DEFAULT_INIT_RETRY_BACKOFFS_MS;
   const callTimeoutMs = options?.callTimeoutMs;
@@ -205,7 +215,7 @@ export async function initFeatureFlagOverrides(options?: {
       // Re-check after the wait: a concurrent caller (e.g. a test using
       // `setOverridesForTesting`) may have populated the cache while we
       // were sleeping. Bail out so we don't clobber their setup.
-      if (isCachedFromGateway()) return;
+      if (isCachedFromGateway()) return true;
     }
 
     const gatewayOverrides = await fetchOverridesFromGateway(callTimeoutMs);
@@ -217,7 +227,7 @@ export async function initFeatureFlagOverrides(options?: {
           "Feature flag overrides loaded from gateway after retry",
         );
       }
-      return;
+      return true;
     }
   }
 
@@ -230,6 +240,7 @@ export async function initFeatureFlagOverrides(options?: {
       "Feature flag overrides empty after all retries; falling back to registry defaults and fail-closed undeclared flags",
     );
   }
+  return false;
 }
 
 /**
@@ -262,10 +273,14 @@ export function clearFeatureFlagOverridesCache(): void {
  * retries (the gateway is known to be up because it just pushed an event).
  * Called by the gateway flag listener when a `feature_flags_changed` event
  * arrives.
+ *
+ * Resolves `true` when the cache was repopulated from the gateway, `false`
+ * when the fetch came back empty/failed — callers gate persisted-state
+ * reconciliation on a `true` result.
  */
-export async function refreshOverridesFromGateway(): Promise<void> {
+export async function refreshOverridesFromGateway(): Promise<boolean> {
   clearFeatureFlagOverridesCache();
-  await initFeatureFlagOverrides({ retryBackoffsMs: [] });
+  return initFeatureFlagOverrides({ retryBackoffsMs: [] });
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/config/bundled-skills/messaging/SKILL.md
+++ b/assistant/src/config/bundled-skills/messaging/SKILL.md
@@ -28,6 +28,8 @@ When the user mentions "email" - sending, reading, checking, decluttering, draft
 
 Do not offer the assistant's own email as an option unless the user specifically asks. If Gmail and Outlook are not connected, guide them through setup.
 
+Reading, searching, or summarizing the user's inbox is a **messaging task** — use the messaging tools (or the Gmail connection flow below if nothing is connected). Never run `assistant channels` commands for a mailbox request: channels are the assistant's own inbound delivery routes, not the user's mailbox, and inspecting them sends you down the wrong path.
+
 When a platform is connected (auth test succeeds), always use the messaging API tools for that platform. Never fall back to browser automation, shell commands (bash, curl), or any other approach for operations that messaging tools can handle. The messaging tools handle authentication internally - never try to access tokens or call APIs directly. Browser automation is only appropriate for initial credential setup (OAuth consent screens), not for day-to-day messaging operations.
 
 **Exception: Slack.** Slack messaging should use the Slack Web API directly via CLI, not messaging tools. See the **slack** skill for details.
@@ -50,13 +52,13 @@ When the user asks to "connect my email", "set up email", "manage my email", or 
 
 ### Gmail
 
-1. **Try connecting directly first.** Run `assistant oauth status google`. This will show whether or not the user had previously connected their google account. If so, they are ready to go.
-2. **If no connections are found:** Call `skill_load` with `skill: "vellum-oauth-integrations"`. The skill will evaluate whether managed or your-own mode is appropriate and guide the user accordingly.
+1. **Check the connection.** Run `assistant oauth status google`. If a connection exists, the user is ready to go — proceed with their request.
+2. **If no connections are found, render the connect button in one step:** call `ui_show` with `surface_type: "oauth_connect"` and `data.providerKey: "google"`. That surface is always available — do **not** run `assistant channels`, `oauth providers get`, or load `vellum-oauth-integrations` just to display the button, and do **not** fall back to `assistant oauth connect`. Only load `vellum-oauth-integrations` when the managed-vs-your-own-credentials decision genuinely needs handling (e.g. a BYOK setup where the managed connect surface isn't available).
 
 ### Outlook
 
-1. **Try connecting directly first.** Run `assistant oauth status outlook`. This will show whether the user has previously connected their Outlook account.
-2. **If no connections are found:** Call `skill_load` with `skill: "vellum-oauth-integrations"`. The skill will evaluate whether managed or your-own mode is appropriate and guide the user accordingly.
+1. **Check the connection.** Run `assistant oauth status outlook`. If a connection exists, the user is ready to go — proceed with their request.
+2. **If no connections are found, render the connect button in one step:** call `ui_show` with `surface_type: "oauth_connect"` and `data.providerKey: "outlook"`. The same rules as Gmail apply — don't probe further or load a setup skill just to show the button; only load `vellum-oauth-integrations` when a managed-vs-your-own-credentials decision genuinely needs handling.
 
 ### Slack
 

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -27,7 +27,10 @@ type ManagedProfileTemplate = Omit<
   ProfileEntry,
   "provider" | "model" | "provider_connection"
 > & {
-  intent: ModelIntent;
+  // Exactly one of `intent` or `model` must be set. `intent` resolves the
+  // model from the catalog at seed time; `model` pins an explicit model id.
+  intent?: ModelIntent;
+  model?: string;
   provider: NonNullable<ProfileEntry["provider"]>;
   connectionName: string;
 };
@@ -136,8 +139,37 @@ const USER_PROFILE_TEMPLATES: Record<string, ManagedProfileTemplate> = {
  */
 export const AUTO_PROFILE_KEY = "auto";
 
+export const OS_BETA_PROFILE_KEY = "os-beta";
+export const OS_BETA_FEATURE_FLAG_KEY = "os-beta";
+
+/**
+ * Flag-gated managed profile. NOT in MANAGED_PROFILE_TEMPLATES, so the
+ * unconditional boot seed never creates it. Reconciled in/out by
+ * the flag-gated profile reconcile based on the `os-beta` feature flag.
+ * Balanced-parity defaults; GLM 5.2 pinned explicitly via `model`.
+ */
+export const OS_BETA_PROFILE_TEMPLATE: ManagedProfileTemplate = {
+  model: "accounts/fireworks/models/glm-5p2",
+  provider: "fireworks",
+  connectionName: "fireworks-managed",
+  source: "managed",
+  label: "OS Beta",
+  description: "Open-source frontier model (GLM 5.2), in beta",
+  maxTokens: 32000,
+  effort: "high",
+  thinking: { enabled: true, streamThinking: true },
+  contextWindow: { maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS },
+};
+
+// Membership here marks a name as managed. The route layer applies managed
+// restrictions (blocking model/provider edits and deletion) only to entries
+// whose on-disk `source` is `managed`, so a user-owned profile sharing one of
+// these names is not locked. `OS_BETA_PROFILE_KEY` is flag-gated: it is
+// materialized by the flag-gated profile reconcile, which refuses to touch a
+// same-named user profile.
 export const MANAGED_PROFILE_NAMES = new Set([
   ...Object.keys(MANAGED_PROFILE_TEMPLATES),
+  OS_BETA_PROFILE_KEY,
   AUTO_PROFILE_KEY,
 ]);
 
@@ -433,21 +465,26 @@ export function seedInferenceProfiles(
   saveRawConfig(config);
 }
 
-function materializeProfile(
+export function materializeProfile(
   template: ManagedProfileTemplate,
   provider: NonNullable<ProfileEntry["provider"]>,
   connectionName: string,
 ): ProfileEntry {
-  const { intent, provider: _p, connectionName: _c, ...rest } = template;
+  const { intent, model, provider: _p, connectionName: _c, ...rest } = template;
+  const resolvedModel =
+    model ?? (intent ? resolveModelIntent(provider, intent) : undefined);
+  if (!resolvedModel) {
+    throw new Error("ManagedProfileTemplate requires `intent` or `model`");
+  }
   return {
     ...rest,
     provider,
     provider_connection: connectionName,
-    model: resolveModelIntent(provider, intent),
+    model: resolvedModel,
   };
 }
 
-function readObject(value: unknown): Record<string, unknown> | null {
+export function readObject(value: unknown): Record<string, unknown> | null {
   return value !== null && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : null;

--- a/assistant/src/config/sync-gated-profiles.ts
+++ b/assistant/src/config/sync-gated-profiles.ts
@@ -1,0 +1,220 @@
+import { isDeepStrictEqual } from "node:util";
+
+import { getLogger } from "../util/logger.js";
+import { isAssistantFeatureFlagEnabled } from "./assistant-feature-flags.js";
+import {
+  getConfigReadOnly,
+  invalidateConfigCache,
+  loadRawConfig,
+  saveRawConfig,
+} from "./loader.js";
+import type { ProfileEntry } from "./schemas/llm.js";
+import {
+  materializeProfile,
+  OS_BETA_FEATURE_FLAG_KEY,
+  OS_BETA_PROFILE_KEY,
+  OS_BETA_PROFILE_TEMPLATE,
+  readObject,
+} from "./seed-inference-profiles.js";
+
+const log = getLogger("sync-gated-profiles");
+
+/**
+ * Reconcile flag-gated managed profiles against the current feature-flag state.
+ *
+ * `seedInferenceProfiles()` runs synchronously at boot before feature flags are
+ * available, so the OS Beta profile (GLM 5.2 / fireworks-managed) is materialized
+ * here once flags have loaded. When the `os-beta` flag is on, the managed profile
+ * is created (ordered right after `balanced`); when it is off, a previously
+ * managed entry is removed with `profileOrder` / `activeProfile` / `advisorProfile`
+ * fallbacks. The reconcile is idempotent and never touches a user-owned profile of
+ * the same name.
+ *
+ * Returns whether the on-disk config changed.
+ */
+export function reconcileFlagGatedProfiles(): boolean {
+  const config = loadRawConfig();
+
+  if (config.llm == null || typeof config.llm !== "object") {
+    config.llm = {};
+  }
+  const llm = config.llm as Record<string, unknown>;
+
+  if (llm.profiles == null || typeof llm.profiles !== "object") {
+    llm.profiles = {};
+  }
+  const profiles = llm.profiles as Record<string, Record<string, unknown>>;
+
+  const profileOrder = Array.isArray(llm.profileOrder)
+    ? (llm.profileOrder as string[])
+    : [];
+  llm.profileOrder = profileOrder;
+
+  // The resolver reads flag state from the gateway-populated override cache and
+  // ignores the config argument; pass the read-only config for signature parity
+  // without mutating disk before the reconcile decision is made.
+  const enabled = isAssistantFeatureFlagEnabled(
+    OS_BETA_FEATURE_FLAG_KEY,
+    getConfigReadOnly(),
+  );
+
+  const isPlatform =
+    process.env.IS_PLATFORM === "true" || process.env.IS_PLATFORM === "1";
+  const isByokMode = !isPlatform;
+
+  const previous = readObject(profiles[OS_BETA_PROFILE_KEY]);
+
+  // Never clobber a user-owned profile that happens to be named `os-beta`. The
+  // entry is ours to manage only when it is absent or already managed; a
+  // user-sourced entry of the same name is left untouched on every path.
+  const isOursToManage = previous == null || previous.source === "managed";
+  if (!isOursToManage) {
+    return false;
+  }
+
+  const changed = enabled
+    ? enableProfile(profiles, profileOrder, previous, isByokMode)
+    : disableProfile(llm, profiles, profileOrder, previous);
+
+  if (changed) {
+    saveRawConfig(config);
+    invalidateConfigCache();
+    log.info(
+      { profile: OS_BETA_PROFILE_KEY, enabled },
+      "Reconciled flag-gated profile",
+    );
+  }
+  return changed;
+}
+
+function enableProfile(
+  profiles: Record<string, Record<string, unknown>>,
+  profileOrder: string[],
+  previous: Record<string, unknown> | null,
+  isByokMode: boolean,
+): boolean {
+  const effectiveTemplate = isByokMode
+    ? {
+        ...OS_BETA_PROFILE_TEMPLATE,
+        label: `${OS_BETA_PROFILE_TEMPLATE.label} (Managed)`,
+      }
+    : OS_BETA_PROFILE_TEMPLATE;
+  const next = materializeProfile(
+    effectiveTemplate,
+    OS_BETA_PROFILE_TEMPLATE.provider,
+    OS_BETA_PROFILE_TEMPLATE.connectionName,
+  ) as Record<string, unknown>;
+
+  // BYOK installs seed managed profiles disabled: the platform-auth
+  // `fireworks-managed` connection backing this profile isn't usable until the
+  // user enables it, so a fresh OS Beta entry starts disabled to avoid offering
+  // an unusable route. A user's own status override (preserved below) wins on
+  // later reconciles.
+  if (isByokMode && !previous) {
+    next.status = "disabled";
+  }
+
+  if (previous) {
+    // The only fields a user may override on a managed profile. Carry `label`
+    // by key-presence so an explicit null (user cleared it) survives too.
+    if ("label" in previous) next.label = previous.label;
+    if ("status" in previous) next.status = previous.status;
+    if ("advisorEnabled" in previous) {
+      next.advisorEnabled = previous.advisorEnabled;
+    }
+  }
+
+  let changed = false;
+  if (!previous || !isDeepStrictEqual(previous, next)) {
+    profiles[OS_BETA_PROFILE_KEY] = next as ProfileEntry;
+    changed = true;
+  }
+
+  if (!profileOrder.includes(OS_BETA_PROFILE_KEY)) {
+    const balancedIndex = profileOrder.indexOf("balanced");
+    if (balancedIndex >= 0) {
+      profileOrder.splice(balancedIndex + 1, 0, OS_BETA_PROFILE_KEY);
+    } else {
+      profileOrder.push(OS_BETA_PROFILE_KEY);
+    }
+    changed = true;
+  }
+
+  return changed;
+}
+
+// `MixSchema = z.array(MixArmSchema).min(2)` in schemas/llm.ts: mixes require
+// >= 2 arms. A mix that drops below this is invalid and cannot be kept.
+const MIX_MIN_ARMS = 2;
+
+function disableProfile(
+  llm: Record<string, unknown>,
+  profiles: Record<string, Record<string, unknown>>,
+  profileOrder: string[],
+  previous: Record<string, unknown> | null,
+): boolean {
+  if (!previous) return false;
+
+  delete profiles[OS_BETA_PROFILE_KEY];
+
+  // The removal closure: every name here is absent from `profiles` once the
+  // closure settles, so the written config can never reference one. A mix that
+  // loses arms below the >= 2 minimum is itself invalid, so it joins the set
+  // and the loop runs to a fixpoint to resolve any references that cascade.
+  const removed = new Set<string>([OS_BETA_PROFILE_KEY]);
+  let cascading = true;
+  while (cascading) {
+    cascading = false;
+    for (const [name, profile] of Object.entries(profiles)) {
+      if (removed.has(name)) continue;
+      if (!Array.isArray(profile.mix)) continue;
+      const arms = profile.mix as unknown[];
+      const kept = arms.filter((arm) => {
+        const armProfile = readObject(arm)?.profile;
+        return typeof armProfile !== "string" || !removed.has(armProfile);
+      });
+      if (kept.length === arms.length) continue;
+      if (kept.length >= MIX_MIN_ARMS) {
+        profile.mix = kept;
+      } else {
+        delete profiles[name];
+        removed.add(name);
+      }
+      cascading = true;
+    }
+  }
+
+  llm.profileOrder = profileOrder.filter((name) => !removed.has(name));
+
+  if (typeof llm.activeProfile === "string" && removed.has(llm.activeProfile)) {
+    llm.activeProfile = "balanced";
+  }
+  if (
+    typeof llm.advisorProfile === "string" &&
+    removed.has(llm.advisorProfile)
+  ) {
+    if (readObject(profiles["quality-optimized"]) !== null) {
+      llm.advisorProfile = "quality-optimized";
+    } else {
+      delete llm.advisorProfile;
+    }
+  }
+
+  // Clear any call-site `profile` reference to a removed profile; other override
+  // fields on the entry stay intact (an empty override object is valid).
+  const callSites = readObject(llm.callSites);
+  if (callSites) {
+    for (const entry of Object.values(callSites)) {
+      const site = readObject(entry);
+      if (
+        site &&
+        typeof site.profile === "string" &&
+        removed.has(site.profile)
+      ) {
+        delete site.profile;
+      }
+    }
+  }
+
+  return true;
+}

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -218,6 +218,7 @@ export function createToolExecutor(
       isPlatformHosted: getIsPlatform(),
       transportInterface: ctx.transportInterface,
       overrideProfile: ctx.currentTurnOverrideProfile,
+      invokingCallSite: ctx.currentCallSite ?? "mainAgent",
       attribution: resolveConversationAttribution(ctx),
       onToolLifecycleEvent: handleToolLifecycleEvent,
       sendToClient: (msg) => {

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -20,6 +20,7 @@ import {
 import { loadConfig, mergeDefaultWorkspaceConfig } from "../config/loader.js";
 import type { AssistantConfig } from "../config/schema.js";
 import { seedInferenceProfiles } from "../config/seed-inference-profiles.js";
+import { reconcileFlagGatedProfiles } from "../config/sync-gated-profiles.js";
 import type { CesClient } from "../credential-execution/client.js";
 import { createCesClient } from "../credential-execution/client.js";
 import { refreshManagedConnectionCache } from "../credential-execution/managed-catalog.js";
@@ -75,7 +76,10 @@ import {
 import { RuntimeHttpServer } from "../runtime/http-server.js";
 import { recoverInterruptedImport } from "../runtime/migrations/vbundle-streaming-importer.js";
 import { registerSecretsDeps } from "../runtime/routes/secrets-deps.js";
-import { publishConversationListChanged } from "../runtime/sync/resource-sync-events.js";
+import {
+  publishConfigChanged,
+  publishConversationListChanged,
+} from "../runtime/sync/resource-sync-events.js";
 import { recoverStaleSchedules } from "../schedule/schedule-recovery.js";
 import { startScheduler } from "../schedule/scheduler.js";
 import {
@@ -371,8 +375,23 @@ export async function runDaemon(): Promise<void> {
     // this fetch completes, so without this follow-up sync a flag-enabled
     // assistant would not expose the gated tools until a restart (which can lose
     // the same race). Enable-direction only; chained so it sees the fresh cache.
+    // Then reconcile flag-gated managed profiles (OS Beta): `seedInferenceProfiles()`
+    // runs synchronously earlier in boot before flags are available, so this lands
+    // the profile on the same boot once the flag cache is populated. When this
+    // reconcile is the call that mutates config (it raced ahead of the gateway
+    // flag listener), publish the config invalidation so any client that already
+    // fetched `GET /v1/config` refreshes its profile picker.
+    // Profiles are reconciled only when flags actually loaded from the gateway:
+    // a failed fetch leaves the cache unset and resolves `os-beta` to its
+    // registry default `false`, which would remove the user's profile and reset
+    // their selection. Tool sync tolerates the default and stays unconditional.
     void initFeatureFlagOverrides()
-      .then(() => syncFlagGatedTools())
+      .then(async (loaded) => {
+        await syncFlagGatedTools();
+        if (loaded && reconcileFlagGatedProfiles()) {
+          publishConfigChanged();
+        }
+      })
       .catch((err) => log.warn({ err }, "Background feature flag init failed"));
 
     startGatewayFlagListener();

--- a/assistant/src/ipc/gateway-flag-listener.ts
+++ b/assistant/src/ipc/gateway-flag-listener.ts
@@ -1,7 +1,9 @@
 import { connect, type Socket } from "node:net";
 
 import { refreshOverridesFromGateway } from "../config/assistant-feature-flags.js";
+import { reconcileFlagGatedProfiles } from "../config/sync-gated-profiles.js";
 import { SYNC_TAGS } from "../daemon/message-types/sync.js";
+import { publishConfigChanged } from "../runtime/sync/resource-sync-events.js";
 import { publishSyncInvalidation } from "../runtime/sync/sync-publisher.js";
 import { syncFlagGatedTools } from "../tools/registry.js";
 import { getLogger } from "../util/logger.js";
@@ -19,11 +21,25 @@ const log = getLogger("gateway-flag-listener");
  * they live in a flag-gated bundled skill surfaced via `skill_load` against the
  * live flag cache, so they need no registry sync here. `syncFlagGatedTools` is
  * idempotent and enable-only, so re-running it on every refresh is safe; it also
- * never throws (it logs internally).
+ * never throws (it logs internally). After tools sync, `reconcileFlagGatedProfiles`
+ * adds or removes the flag-gated managed profile (OS Beta); when it reports a
+ * change a `config_changed` broadcast refreshes the profile picker on clients.
+ * The profile reconcile runs only when the refresh confirmed flags loaded from
+ * the gateway — a transient IPC failure leaves the cache unset and resolves
+ * `os-beta` to its registry default `false`, which would remove the user's
+ * profile and reset their selection. Tool sync tolerates the default and stays
+ * unconditional.
  */
 function refreshFlagsAndSyncTools(context: string): void {
   refreshOverridesFromGateway()
-    .then(() => syncFlagGatedTools())
+    .then(async (loaded) => {
+      await syncFlagGatedTools();
+      if (loaded && reconcileFlagGatedProfiles()) {
+        // Reuse the config-changed broadcast clients already consume so the
+        // profile picker reflects the added/removed managed profile.
+        publishConfigChanged();
+      }
+    })
     .catch((err) => {
       log.warn(
         { err },

--- a/assistant/src/permissions/question-prompter.test.ts
+++ b/assistant/src/permissions/question-prompter.test.ts
@@ -48,6 +48,8 @@ interface MockInteraction {
     orderedIds: string[];
     optionsById: Record<string, string[]>;
   };
+  toolUseId?: string;
+  questionDetails?: { entries: Array<{ id: string; question: string }> };
 }
 const _piStore = new Map<string, MockInteraction>();
 mock.module("../runtime/pending-interactions.js", () => ({
@@ -203,6 +205,31 @@ describe("QuestionPrompter", () => {
       overall: "completed",
     });
     expect(_piStore.has(req.requestId)).toBe(false);
+  });
+
+  test("persists the full question entries on the interaction for rehydration", async () => {
+    // GIVEN a batched prompt with a tool-use id
+    const { prompter, sent } = makePrompter();
+
+    const promise = prompter.prompt({
+      ...threeQuestionParams,
+      toolUseId: "tool-q",
+    });
+    const req = sent[0] as QuestionRequestEvent;
+
+    // THEN the registered interaction carries the full entries (not just the
+    // id maps in `metadata`) so a history-load render can rehydrate the card
+    const interaction = _piStore.get(req.requestId);
+    expect(interaction?.toolUseId).toBe("tool-q");
+    expect(interaction?.questionDetails?.entries).toHaveLength(3);
+    expect(interaction?.questionDetails?.entries).toEqual(req.questions);
+
+    resolveBatch(req.requestId, [
+      { questionId: "q1", kind: "option", optionId: "a" },
+      { questionId: "q2", kind: "option", optionId: "x" },
+      { questionId: "q3", kind: "skip" },
+    ]);
+    await promise;
   });
 
   test("free-text resolution", async () => {

--- a/assistant/src/permissions/question-prompter.ts
+++ b/assistant/src/permissions/question-prompter.ts
@@ -269,6 +269,10 @@ export class QuestionPrompter {
         timer,
         toolUseId,
         metadata: { orderedIds, optionsById } satisfies QuestionBatchMetadata,
+        // Persist the full entries (not just the id maps in `metadata`) so a
+        // history-load render can stamp this outstanding prompt back onto its
+        // tool call and rehydrate the question card after a reconnect.
+        questionDetails: { entries },
       });
 
       // Populate both shapes on the wire: `questions[]` is the canonical

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -678,6 +678,23 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         },
       },
       {
+        id: "accounts/fireworks/models/glm-5p2",
+        displayName: "GLM 5.2",
+        // Fireworks serves GLM 5.2 with a 1,040K input window.
+        contextWindowTokens: 1040000,
+        maxOutputTokens: 131072,
+        supportsThinking: true,
+        supportsCaching: true,
+        supportsVision: false,
+        supportsToolUse: true,
+        maxEffort: "max",
+        pricing: {
+          inputPer1mTokens: 1.4,
+          outputPer1mTokens: 4.4,
+          cacheReadPer1mTokens: 0.26,
+        },
+      },
+      {
         id: "accounts/fireworks/models/kimi-k2p5",
         displayName: "Kimi K2.5",
         contextWindowTokens: 256000,

--- a/assistant/src/providers/weak-open-model.ts
+++ b/assistant/src/providers/weak-open-model.ts
@@ -1,6 +1,6 @@
 /**
  * Family-level classification of "weak open models" — open-weight models
- * (Kimi, DeepSeek, MiniMax) that disregard static instructions and have
+ * (Kimi, DeepSeek, MiniMax, GLM) that disregard static instructions and have
  * capability gaps that capable models (Claude, GPT) do not. Used by harness
  * levers that coach or redirect these models without touching capable-model
  * behavior: the task-progress-nudge plugin and the empty-dynamic_page surface
@@ -14,7 +14,7 @@
  * Distinct from exploration-drift's narrower `LOOP_PRONE_MODEL_PATTERN`, which
  * targets specific loop-prone versions rather than the whole capability family.
  */
-export const WEAK_OPEN_MODEL_PATTERN = /kimi|deepseek|minimax/i;
+export const WEAK_OPEN_MODEL_PATTERN = /kimi|deepseek|minimax|glm/i;
 
 /** True when `model` is a weak open model (see {@link WEAK_OPEN_MODEL_PATTERN}). */
 export function isWeakOpenModel(model: string | null | undefined): boolean {

--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -19,6 +19,7 @@
  */
 
 import type { InteractionResolutionState } from "../api/events/interaction-resolved.js";
+import type { QuestionEntry } from "../api/events/question-request.js";
 import type { UserDecision } from "../permissions/types.js";
 import { getLogger } from "../util/logger.js";
 import { broadcastMessage } from "./assistant-event-hub.js";
@@ -50,6 +51,18 @@ export interface ConfirmationDetails {
   }>;
 }
 
+/**
+ * Full batched question payload carried on a pending `question` interaction, so
+ * a history-load render can stamp the outstanding prompt back onto its tool
+ * call and rehydrate the question card on a cold reconnect. Mirrors the
+ * `question_request` event's `questions[]` — `metadata` only retains the
+ * `orderedIds`/`optionsById` the response route needs to validate submissions,
+ * which is insufficient to reconstruct the card.
+ */
+export interface QuestionDetails {
+  entries: QuestionEntry[];
+}
+
 export interface PendingInteraction {
   /**
    * Owning conversation, when the interaction was raised inside one. Absent
@@ -69,6 +82,8 @@ export interface PendingInteraction {
     | "host_transfer"
     | "acp_confirmation";
   confirmationDetails?: ConfirmationDetails;
+  /** For a pending `question`: the full batched entries, so a history-load render can rehydrate the question card. */
+  questionDetails?: QuestionDetails;
   /** For ACP permissions: resolves directly without a Conversation object. */
   directResolve?: (decision: UserDecision) => void;
   /** When set, the host_bash request should be routed to this specific client. */

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -755,8 +755,14 @@ function rejectManagedProfileDeletion(body: Record<string, unknown>): void {
   }
   const profiles = asMutablePlainObject(llm.profiles);
   if (!profiles) return;
+  const existingProfiles = asMutablePlainObject(getConfig().llm.profiles) ?? {};
   for (const name of Object.keys(profiles)) {
-    if (profiles[name] === null && MANAGED_PROFILE_NAMES.has(name)) {
+    if (profiles[name] !== null || !MANAGED_PROFILE_NAMES.has(name)) continue;
+    // Only block deletion when the on-disk entry is Vellum-managed. A
+    // user-owned profile sharing a managed name carries a non-managed `source`
+    // and is freely deletable.
+    const existing = asMutablePlainObject(existingProfiles[name]);
+    if (existing?.source === "managed") {
       throw new BadRequestError(`Cannot delete managed profile "${name}".`);
     }
   }
@@ -929,7 +935,24 @@ async function handleReplaceInferenceProfile({
     const detail = parsed.error.issues.map((issue) => issue.message).join("; ");
     throw new BadRequestError(`Invalid profile fragment: ${detail}`);
   }
-  const isManaged = MANAGED_PROFILE_NAMES.has(name);
+  // A managed name with no existing entry stays protected so users can't
+  // shadow a seeded managed profile. An existing entry carrying a non-managed
+  // `source` is user-owned and remains fully editable.
+  const existingProfile = asMutablePlainObject(
+    getConfig().llm.profiles?.[name],
+  );
+  const isManaged =
+    MANAGED_PROFILE_NAMES.has(name) &&
+    (existingProfile == null || existingProfile.source === "managed");
+  // A managed profile name with no materialized entry (e.g. a flag-gated profile
+  // whose flag is off) cannot be patched: writing label/status here would persist
+  // a source-less stub that later blocks the real managed profile from being
+  // seeded. Reject rather than create a placeholder.
+  if (MANAGED_PROFILE_NAMES.has(name) && existingProfile == null) {
+    throw new BadRequestError(
+      `Profile "${name}" is not currently available and cannot be edited.`,
+    );
+  }
   if (isManaged) {
     // Managed profiles are daemon-seeded — provider, model, and the
     // connection binding all belong to the seed contract and can't be

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -151,6 +151,10 @@ import {
   collectPendingConfirmations,
   enrichToolCallsWithConfirmation,
 } from "./tool-call-confirmation-enrichment.js";
+import {
+  collectPendingQuestions,
+  enrichToolCallsWithQuestion,
+} from "./tool-call-question-enrichment.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 import { RouteResponse } from "./types.js";
 
@@ -822,6 +826,7 @@ export function handleListMessages({
   const pendingConfirmations = collectPendingConfirmations(
     resolvedConversationId,
   );
+  const pendingQuestions = collectPendingQuestions(resolvedConversationId);
 
   const messages: RuntimeMessagePayload[] = parsed.map((m) => {
     const mergedMessageIds = m.id ? (mergedIdMap.get(m.id) ?? []) : [];
@@ -885,10 +890,13 @@ export function handleListMessages({
       m.id ?? undefined,
     );
 
-    const toolCalls = enrichToolCallsWithConfirmation(rendered.toolCalls, {
-      workspaceDir,
-      pendingConfirmations,
-    });
+    const toolCalls = enrichToolCallsWithQuestion(
+      enrichToolCallsWithConfirmation(rendered.toolCalls, {
+        workspaceDir,
+        pendingConfirmations,
+      }),
+      { pendingQuestions },
+    );
 
     // Strip <no_response/> markers from assistant messages so web/API clients
     // never see the raw sentinel. Only assistant messages produce it; user

--- a/assistant/src/runtime/routes/tool-call-question-enrichment.test.ts
+++ b/assistant/src/runtime/routes/tool-call-question-enrichment.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for render-time enrichment of history tool calls with the in-flight
+ * `ask_question` prompt read from the pending-interactions registry.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+
+import type { QuestionEntry } from "../../api/events/question-request.js";
+import type { ConversationMessageToolCall } from "../../api/responses/conversation-message.js";
+import { clear, register } from "../pending-interactions.js";
+import {
+  collectPendingQuestions,
+  enrichToolCallsWithQuestion,
+} from "./tool-call-question-enrichment.js";
+
+function toolCall(
+  overrides: Partial<ConversationMessageToolCall>,
+): ConversationMessageToolCall {
+  return {
+    name: "ask_question",
+    input: {},
+    ...overrides,
+  };
+}
+
+const ENTRIES: QuestionEntry[] = [
+  {
+    id: "q1",
+    question: "What's the email about?",
+    options: [
+      { id: "a", label: "iOS app is live" },
+      { id: "b", label: "Open source" },
+    ],
+  },
+];
+
+afterEach(() => {
+  clear();
+});
+
+describe("collectPendingQuestions", () => {
+  test("keys question interactions by toolUseId", () => {
+    // GIVEN a question interaction registered for a conversation with a
+    // tool-use id and the full question entries
+    register("req-1", {
+      conversationId: "conv-1",
+      kind: "question",
+      toolUseId: "tool-abc",
+      questionDetails: { entries: ENTRIES },
+    });
+
+    // WHEN we collect the conversation's pending questions
+    const byToolUseId = collectPendingQuestions("conv-1");
+
+    // THEN the interaction is keyed by its tool-use id
+    expect(byToolUseId.size).toBe(1);
+    expect(byToolUseId.get("tool-abc")?.requestId).toBe("req-1");
+    expect(byToolUseId.get("tool-abc")?.entries).toEqual(ENTRIES);
+  });
+
+  test("ignores interactions lacking a toolUseId, details, or the question kind", () => {
+    // GIVEN a question without a toolUseId, a question without details, AND a
+    // non-question interaction in the same conversation
+    register("req-no-tool", {
+      conversationId: "conv-2",
+      kind: "question",
+      questionDetails: { entries: ENTRIES },
+    });
+    register("req-no-details", {
+      conversationId: "conv-2",
+      kind: "question",
+      toolUseId: "tool-no-details",
+    });
+    register("req-confirmation", {
+      conversationId: "conv-2",
+      kind: "confirmation",
+      toolUseId: "tool-xyz",
+      confirmationDetails: {
+        toolName: "file_read",
+        input: {},
+        riskLevel: "low",
+        allowlistOptions: [],
+        scopeOptions: [],
+      },
+    });
+
+    // WHEN we collect the conversation's pending questions
+    const byToolUseId = collectPendingQuestions("conv-2");
+
+    // THEN none is included
+    expect(byToolUseId.size).toBe(0);
+  });
+});
+
+describe("enrichToolCallsWithQuestion", () => {
+  test("stamps the pending question when the registry has a match", () => {
+    // GIVEN a registry entry matching the tool call by id
+    register("req-1", {
+      conversationId: "conv-fixture",
+      kind: "question",
+      toolUseId: "tool-abc",
+      questionDetails: { entries: ENTRIES },
+    });
+    const pendingQuestions = collectPendingQuestions("conv-fixture");
+    const calls = [toolCall({ id: "tool-abc" })];
+
+    // WHEN we enrich it
+    const [enriched] = enrichToolCallsWithQuestion(calls, { pendingQuestions });
+
+    // THEN the outstanding prompt is projected onto the tool call so a cold
+    // reconnect can rehydrate the question card
+    expect(enriched?.pendingQuestion?.requestId).toBe("req-1");
+    expect(enriched?.pendingQuestion?.entries).toEqual(ENTRIES);
+  });
+
+  test("leaves tool calls without a match untouched (same reference)", () => {
+    // GIVEN a tool call with no matching registry entry
+    const original = toolCall({ id: "tool-unmatched" });
+    register("req-other", {
+      conversationId: "conv-fixture",
+      kind: "question",
+      toolUseId: "tool-abc",
+      questionDetails: { entries: ENTRIES },
+    });
+
+    // WHEN we enrich it
+    const [enriched] = enrichToolCallsWithQuestion([original], {
+      pendingQuestions: collectPendingQuestions("conv-fixture"),
+    });
+
+    // THEN the tool call is returned unchanged
+    expect(enriched).toBe(original);
+  });
+
+  test("returns the input array untouched when there are no pending questions", () => {
+    // GIVEN tool calls and an empty registry
+    const calls = [toolCall({ id: "tool-abc" })];
+
+    // WHEN we enrich with an empty lookup
+    const enriched = enrichToolCallsWithQuestion(calls, {
+      pendingQuestions: new Map(),
+    });
+
+    // THEN the original array is returned
+    expect(enriched).toBe(calls);
+  });
+});

--- a/assistant/src/runtime/routes/tool-call-question-enrichment.ts
+++ b/assistant/src/runtime/routes/tool-call-question-enrichment.ts
@@ -1,0 +1,66 @@
+/**
+ * Render-time enrichment of history tool calls with in-flight question context.
+ *
+ * `pendingQuestion` — the outstanding `ask_question` prompt for a tool call
+ * still awaiting a user answer — is read from the in-memory
+ * `pending-interactions` registry (the authoritative store of unresolved
+ * prompts) and stamped onto its tool call so the web/API clients can restore
+ * the same question card on a cold reconnect (or a history reopen after the
+ * live event buffer has aged out) that the live `question_request` SSE stream
+ * would have produced. It appears only while the prompt is genuinely
+ * outstanding. Mirrors the confirmation enrichment in
+ * `tool-call-confirmation-enrichment.ts`.
+ */
+
+import type { QuestionEntry } from "../../api/events/question-request.js";
+import type { ConversationMessageToolCall } from "../../api/responses/conversation-message.js";
+import { getByConversation } from "../pending-interactions.js";
+
+/** A pending question matched to the tool call it prompts for, keyed by `toolUseId`. */
+interface PendingQuestionMatch {
+  requestId: string;
+  entries: QuestionEntry[];
+}
+
+/**
+ * Build the `toolUseId → pending question` lookup for a conversation from the
+ * registry. Only question interactions that carry both a `toolUseId` and
+ * `questionDetails` can be stamped onto a wire tool call.
+ */
+export function collectPendingQuestions(
+  conversationId: string,
+): Map<string, PendingQuestionMatch> {
+  const byToolUseId = new Map<string, PendingQuestionMatch>();
+  for (const interaction of getByConversation(conversationId)) {
+    if (
+      interaction.kind === "question" &&
+      interaction.questionDetails &&
+      interaction.toolUseId
+    ) {
+      byToolUseId.set(interaction.toolUseId, {
+        requestId: interaction.requestId,
+        entries: interaction.questionDetails.entries,
+      });
+    }
+  }
+  return byToolUseId;
+}
+
+/**
+ * Layer any outstanding `pendingQuestion` onto a message's rendered tool calls.
+ * Returns a new array; tool calls without a match are returned unchanged.
+ */
+export function enrichToolCallsWithQuestion(
+  toolCalls: ConversationMessageToolCall[],
+  opts: { pendingQuestions: ReadonlyMap<string, PendingQuestionMatch> },
+): ConversationMessageToolCall[] {
+  if (opts.pendingQuestions.size === 0) return toolCalls;
+  return toolCalls.map((tc) => {
+    const match = tc.id ? opts.pendingQuestions.get(tc.id) : undefined;
+    if (!match) return tc;
+    return {
+      ...tc,
+      pendingQuestion: { requestId: match.requestId, entries: match.entries },
+    };
+  });
+}

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -237,10 +237,17 @@ export class SubagentManager {
         config.systemPromptOverride ??
         buildSubagentSystemPrompt({ ...config, id: subagentId }, role);
     }
-    const maxTokens = resolveCallSiteConfig(
-      "subagentSpawn",
-      appConfig.llm,
-    ).maxTokens;
+    // Resolve under the same profile the run will use (forwarded via
+    // `SubagentConfig`) so the constructed conversation's default token cap
+    // matches the inherited profile rather than the static `subagentSpawn`
+    // default. Per-call routing re-resolves the model anyway; this keeps the
+    // initial value consistent.
+    const maxTokens = resolveCallSiteConfig("subagentSpawn", appConfig.llm, {
+      ...(config.overrideProfile
+        ? { overrideProfile: config.overrideProfile }
+        : {}),
+      ...(config.forceOverrideProfile ? { forceOverrideProfile: true } : {}),
+    }).maxTokens;
     const workingDir = getSandboxWorkingDir();
 
     // ── Initialise state ────────────────────────────────────────────

--- a/assistant/src/tools/skills/execute.ts
+++ b/assistant/src/tools/skills/execute.ts
@@ -87,8 +87,7 @@ export function augmentSkillExecuteError(
 
   const guidance =
     `\n\nThis skill_execute call carried no parameters for "${toolName}". ` +
-    `Put the tool's parameters inside \`input\` as a JSON object — not as ` +
-    `siblings of \`tool\`, and not as a JSON-encoded string. For example: ` +
+    `Put the tool's parameters inside \`input\`. For example: ` +
     `{"tool": "${toolName}", "input": { /* the tool's parameters */ }, ` +
     `"activity": "..."}. The skill's instructions (from skill_load) list ` +
     `"${toolName}"'s required fields.`;

--- a/assistant/src/tools/subagent/spawn.ts
+++ b/assistant/src/tools/subagent/spawn.ts
@@ -1,4 +1,7 @@
 import { validateInferenceProfileKey } from "../../config/inference-profile-validation.js";
+import { resolveDefaultProfileKey } from "../../config/llm-resolver.js";
+import { getConfig } from "../../config/loader.js";
+import { AUTO_PROFILE_KEY } from "../../config/seed-inference-profiles.js";
 import { findConversation } from "../../daemon/conversation-registry.js";
 import { getConversationOverrideProfile } from "../../memory/conversation-crud.js";
 import type { Message } from "../../providers/types.js";
@@ -97,20 +100,41 @@ export async function executeSubagentSpawn(
   // `SubagentManager.spawn` forwards it back into the subagent's
   // `runAgentLoop` call as `options.overrideProfile`.
   //
-  // Prefer an explicit spawn-time profile, then the per-turn
+  // Resolution order: an explicit spawn-time profile, then the per-turn
   // `context.overrideProfile` (populated by `runAgentLoopImpl` from its
-  // resolved `turnOverrideProfile`) over a row read so nested spawns inherit
-  // correctly. The current subagent's own conversation row never has
-  // `inferenceProfile` set — its override arrived via in-memory
-  // `SubagentConfig.overrideProfile` — and even if it were set,
-  // `getConversationOverrideProfile` short-circuits for background
-  // conversations and returns `undefined`. Falling back to the row read
-  // preserves behavior for tool calls that originate outside an agent-loop
-  // turn.
-  const inheritedOverrideProfile =
-    requestedOverrideProfile ??
-    context.overrideProfile ??
-    getConversationOverrideProfile(context.conversationId);
+  // resolved `turnOverrideProfile`, covering per-conversation overrides and
+  // tool-routed switches), then a row read, and finally the resolved DEFAULT
+  // profile of the call site that invoked us. That last fallback is what makes
+  // a subagent match its invoker when the invoking turn ran purely on its
+  // call-site default — the workspace `activeProfile` for `mainAgent`, or the
+  // call site's own catalog default (e.g. `cost-optimized`) for a
+  // heartbeat/background invoker. `resolveDefaultProfileKey` does not reflect a
+  // static `llm.callSites.<callSite>` profile override (only the
+  // activeProfile-for-mainAgent path plus the catalog default), a narrow gap
+  // that only surfaces with no `activeProfile` set and a hand-tuned call-site
+  // profile.
+  //
+  // The fallback is forwarded NON-forced, so an explicit
+  // `llm.callSites.subagentSpawn` profile still wins; an explicit
+  // `inference_profile` argument keeps `forceOverrideProfile` and wins
+  // outright. (The row read short-circuits to `undefined` for the background
+  // subagent conversation and for tool calls outside an agent-loop turn.)
+  let inheritedOverrideProfile = requestedOverrideProfile;
+  if (inheritedOverrideProfile === undefined) {
+    const inheritedCandidate =
+      context.overrideProfile ??
+      getConversationOverrideProfile(context.conversationId) ??
+      resolveDefaultProfileKey(
+        context.invokingCallSite ?? "mainAgent",
+        getConfig().llm,
+      );
+    // Skip the metadata-only "auto" key: forwarding it collapses the child to
+    // `llm.default`, whereas the invoker's own auto base IS the `subagentSpawn`
+    // default — so leaving this undefined keeps the child on that default.
+    if (inheritedCandidate !== AUTO_PROFILE_KEY) {
+      inheritedOverrideProfile = inheritedCandidate;
+    }
+  }
 
   try {
     const subagentId = await manager.spawn(

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -308,6 +308,11 @@ export const shellTool = {
 
     const env = buildSanitizedEnv();
     env.__CONVERSATION_ID = context.conversationId;
+    // Surface the resolving model to assistant CLI commands so they can tailor
+    // remediation guidance for weak open models (see isWeakOpenModel).
+    if (context.attribution?.resolvedModel) {
+      env.__RESOLVED_MODEL = context.attribution.resolvedModel;
+    }
     if (proxyEnv) {
       Object.assign(env, proxyEnv);
     }

--- a/assistant/src/tools/types.ts
+++ b/assistant/src/tools/types.ts
@@ -13,6 +13,7 @@ import { RiskLevel } from "@vellumai/skill-host-contracts";
 import { z } from "zod";
 
 import type { InterfaceId } from "../channels/types.js";
+import type { LLMCallSite } from "../config/schemas/llm.js";
 import type { ToolActivityMetadata } from "../daemon/message-types/web-activity.js";
 import type { SecretPromptResult } from "../permissions/secret-prompter.js";
 import type { ContentBlock } from "../providers/types.js";
@@ -363,6 +364,14 @@ export interface ToolContext {
    * `executeSubagentSpawn` in tools/subagent/spawn.ts.
    */
   overrideProfile?: string;
+  /**
+   * The LLM call site of the turn currently executing this tool (`mainAgent`,
+   * `heartbeatAgent`, scheduled work, etc.). `subagent_spawn` reads it to
+   * default a spawned subagent's inference profile to the profile the invoking
+   * turn resolved to, so subagents match whatever agent invoked them rather
+   * than always falling back to the static `subagentSpawn` call-site default.
+   */
+  invokingCallSite?: LLMCallSite;
   /**
    * Canonical principal ID of the actor on whose behalf this tool invocation
    * is running. Sourced from `conversation.trustContext.guardianPrincipalId`.

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -232,6 +232,14 @@ export const MODELS_BY_PROVIDER = {
       supportsThinking: true,
     },
     {
+      id: "accounts/fireworks/models/glm-5p2",
+      displayName: "GLM 5.2",
+      contextWindowTokens: 1_040_000,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 131_072,
+      supportsThinking: true,
+    },
+    {
       id: "accounts/fireworks/models/kimi-k2p5",
       displayName: "Kimi K2.5",
       contextWindowTokens: 256_000,

--- a/clients/web/src/domains/chat/hooks/use-conversation-history.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history.ts
@@ -21,7 +21,10 @@ import { startTransition, useEffect } from "react";
 
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { reconcileMessagesWithSeq } from "@/domains/chat/utils/reconcile-with-seq";
-import { extractWirePendingConfirmation } from "@/domains/chat/utils/chat";
+import {
+  extractWirePendingConfirmation,
+  extractWirePendingQuestion,
+} from "@/domains/chat/utils/chat";
 import { filterDismissedSurfaces } from "@/domains/chat/utils/dismissed-surfaces-storage";
 import { mapMessageSurfaces } from "@/domains/chat/utils/map-message-surfaces";
 import { recordDiagnostic } from "@/lib/diagnostics";
@@ -234,6 +237,20 @@ export function useConversationHistory({
             wirePendingConfirmation.toolUseId,
           );
         }
+      }
+
+      // Restore an in-flight ask_question prompt the snapshot carries on a tool
+      // call (stamped by the daemon from the pending-interactions registry at
+      // render time). On a cold reconnect — e.g. the live `question_request`
+      // event was broadcast while no SSE client was connected — the prompt
+      // rides the snapshot rather than a replayed event. Skipped when a prompt
+      // is already active so a live in-progress question is never clobbered.
+      const wirePendingQuestion = extractWirePendingQuestion(filteredMessages);
+      if (
+        wirePendingQuestion &&
+        !useInteractionStore.getState().pendingQuestion
+      ) {
+        useInteractionStore.getState().showQuestion(wirePendingQuestion);
       }
     } else {
       recordDiagnostic("history_tq_empty", {

--- a/clients/web/src/domains/chat/utils/chat.test.ts
+++ b/clients/web/src/domains/chat/utils/chat.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   extractWirePendingConfirmation,
+  extractWirePendingQuestion,
   hasAssistantMessage,
   shouldClearFirstMessageGateOnConversationChange,
 } from "@/domains/chat/utils/chat";
@@ -136,6 +137,59 @@ describe("chat utilities", () => {
 
       // WHEN we extract the wire-carried confirmation
       const restored = extractWirePendingConfirmation(messages);
+
+      // THEN there is nothing to restore
+      expect(restored).toBeNull();
+    });
+  });
+
+  describe("extractWirePendingQuestion", () => {
+    test("projects a snapshot-carried question into interaction-store shape", () => {
+      /**
+       * The live `question_request` event can be missed (e.g. broadcast while
+       * no SSE client was connected). On the next history load the daemon
+       * stamps the outstanding prompt onto its tool call; the FE must restore
+       * it to the interaction store so the card finally renders.
+       */
+      // GIVEN a history snapshot whose latest tool call carries a pending question
+      const entries = [
+        {
+          id: "q1",
+          question: "What's the email about?",
+          options: [{ id: "a", label: "iOS app is live" }],
+        },
+      ];
+      const messages = [
+        message("user", "user-1"),
+        assistantWithToolCalls("assistant-1", [
+          {
+            id: "tool-1",
+            name: "ask_question",
+            input: {},
+            pendingQuestion: { requestId: "req-9", entries },
+          },
+        ]),
+      ];
+
+      // WHEN we extract the wire-carried question
+      const restored = extractWirePendingQuestion(messages);
+
+      // THEN the prompt is returned with toolUseId set to the carrying tool call
+      expect(restored?.requestId).toBe("req-9");
+      expect(restored?.entries).toEqual(entries);
+      expect(restored?.toolUseId).toBe("tool-1");
+    });
+
+    test("returns null when no tool call is awaiting an answer", () => {
+      // GIVEN a snapshot whose tool calls carry no pending question
+      const messages = [
+        assistantWithToolCalls("assistant-1", [
+          { id: "tool-1", name: "ask_question", input: {}, result: "answered" },
+        ]),
+      ];
+
+      // WHEN we extract the wire-carried question
+      const restored = extractWirePendingQuestion(messages);
 
       // THEN there is nothing to restore
       expect(restored).toBeNull();

--- a/clients/web/src/domains/chat/utils/chat.ts
+++ b/clients/web/src/domains/chat/utils/chat.ts
@@ -8,6 +8,7 @@ import type {
   AllowlistOption,
   DirectoryScopeOption,
   PendingConfirmationState,
+  PendingQuestionState,
   ScopeOption,
 } from "@/types/interaction-ui-types";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
@@ -317,6 +318,37 @@ export function extractWirePendingConfirmation(
       const tc = msg.toolCalls[ti];
       if (tc?.pendingConfirmation) {
         return { ...tc.pendingConfirmation, toolUseId: tc.id };
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Find the in-flight `ask_question` prompt a history snapshot carries on one
+ * of its tool calls. The daemon stamps `pendingQuestion` from the
+ * pending-interactions registry at render time, so on a cold reconnect (or a
+ * reopen after the live event buffer aged out) the prompt rides the snapshot
+ * rather than a replayed `question_request` event. Returns the prompt
+ * projected into the interaction-store shape — with `toolUseId` set to the
+ * carrying tool call — or null when no tool call is awaiting an answer. Scans
+ * latest-first since the outstanding prompt is on the most recent tool call.
+ * Mirrors {@link extractWirePendingConfirmation}.
+ */
+export function extractWirePendingQuestion(
+  messages: DisplayMessage[],
+): PendingQuestionState | null {
+  for (let mi = messages.length - 1; mi >= 0; mi--) {
+    const msg = messages[mi];
+    if (!msg?.toolCalls?.length) continue;
+    for (let ti = msg.toolCalls.length - 1; ti >= 0; ti--) {
+      const tc = msg.toolCalls[ti];
+      if (tc?.pendingQuestion) {
+        return {
+          requestId: tc.pendingQuestion.requestId,
+          entries: tc.pendingQuestion.entries,
+          toolUseId: tc.id,
+        };
       }
     }
   }

--- a/clients/web/src/domains/onboarding/pages/hosting-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hosting-screen.tsx
@@ -1,4 +1,4 @@
-import { Cloud, Laptop, Package } from "lucide-react";
+import { Cloud, Laptop } from "lucide-react";
 import { useEffect, useState, type ReactNode } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 
@@ -57,13 +57,6 @@ function useHostingOptions(): HostingOption[] {
       subtitle:
         "Runs directly on your machine. Your data never leaves your computer.",
       icon: <Laptop className={ICON_CLASS} />,
-    },
-    {
-      mode: "docker",
-      label: "Docker",
-      subtitle:
-        "Same privacy as local, but sandboxed using Docker for added isolation.",
-      icon: <Package className={ICON_CLASS} />,
     },
   ];
 }

--- a/clients/web/src/domains/settings/ai/language-model-card.tsx
+++ b/clients/web/src/domains/settings/ai/language-model-card.tsx
@@ -17,13 +17,17 @@ import { CallSiteOverridesModal } from "@/domains/settings/ai/call-site-override
 import { ManageProfilesModal } from "@/domains/settings/ai/manage-profiles-modal";
 import { ManageProvidersModal } from "@/domains/settings/ai/manage-providers-modal";
 import {
-    AUTO_PROFILE_NAME,
-    gateAutoProfile,
-    profilePickerLabel,
-    visibleProfilesForPicker,
+  AUTO_PROFILE_NAME,
+  gateAutoProfile,
+  profilePickerLabel,
+  visibleProfilesForPicker,
 } from "@/assistant/profile-pickers";
 import { useStickyProfiles } from "@/assistant/use-sticky-profiles";
-import { configGetOptions, configGetSetQueryData, useConfigPatchMutation } from "@/generated/daemon/@tanstack/react-query.gen";
+import {
+  configGetOptions,
+  configGetSetQueryData,
+  useConfigPatchMutation,
+} from "@/generated/daemon/@tanstack/react-query.gen";
 import { useDraftOverride } from "@/domains/settings/ai/use-draft-override";
 import { useQuery } from "@tanstack/react-query";
 
@@ -42,7 +46,10 @@ export function LanguageModelCard() {
   // Retain the last non-empty profile list so a transient empty config payload
   // can't blank the Default Profile dropdown until the next good fetch — managed
   // profiles are always seeded, so an empty map is never a steady state.
-  const { profiles, profileOrder } = useStickyProfiles(config?.llm, assistantId);
+  const { profiles, profileOrder } = useStickyProfiles(
+    config?.llm,
+    assistantId,
+  );
   const orderedProfiles = useMemo(
     () => buildOrderedProfiles(profiles, profileOrder),
     [profiles, profileOrder],
@@ -50,12 +57,18 @@ export function LanguageModelCard() {
 
   const configMutation = useConfigPatchMutation({
     onSuccess: (data) => {
-      configGetSetQueryData(queryClient, { path: { assistant_id: assistantId } }, data);
+      configGetSetQueryData(
+        queryClient,
+        { path: { assistant_id: assistantId } },
+        data,
+      );
     },
   });
 
-  const [effectiveActiveProfile, setDraftActiveProfile] = useDraftOverride(activeProfile);
-  const [effectiveAdvisorProfile, setDraftAdvisorProfile] = useDraftOverride(advisorProfile);
+  const [effectiveActiveProfile, setDraftActiveProfile] =
+    useDraftOverride(activeProfile);
+  const [effectiveAdvisorProfile, setDraftAdvisorProfile] =
+    useDraftOverride(advisorProfile);
 
   // Modal toggles — ephemeral UI state, correct as useState
   const [manageProfilesOpen, setManageProfilesOpen] = useState(false);
@@ -87,39 +100,48 @@ export function LanguageModelCard() {
   );
 
   const overrideCount = Object.entries(callSites).filter(
-    ([id, s]) => id !== "mainAgent" && (s?.profile != null || s?.provider != null || s?.model != null),
+    ([id, s]) =>
+      id !== "mainAgent" &&
+      (s?.profile != null || s?.provider != null || s?.model != null),
   ).length;
   const overrideLabel =
-    overrideCount === 1 ? "1 Override" : overrideCount > 0 ? `${overrideCount} Overrides` : "Overrides";
+    overrideCount === 1
+      ? "1 Override"
+      : overrideCount > 0
+        ? `${overrideCount} Overrides`
+        : "Overrides";
   const isProfileDirty = effectiveActiveProfile !== activeProfile;
   const isAdvisorProfileDirty = effectiveAdvisorProfile !== advisorProfile;
 
-  const handleManagedProfileSave = useCallback(async () => {
+  // One save for the whole card. Only the dirty field(s) are sent so we never
+  // re-write a value the user didn't edit (the config PATCH deep-merges every
+  // provided key, so blindly re-sending a stale selector could clobber a change
+  // made elsewhere — e.g. an `/model` switch). `null` clears the advisor profile.
+  const handleSave = useCallback(async () => {
     try {
+      const llm: {
+        activeProfile?: string | null;
+        advisorProfile?: string | null;
+      } = {};
+      if (isProfileDirty) llm.activeProfile = effectiveActiveProfile;
+      if (isAdvisorProfileDirty) llm.advisorProfile = effectiveAdvisorProfile;
       await configMutation.mutateAsync({
         path: { assistant_id: assistantId },
-        body: { llm: { activeProfile: effectiveActiveProfile } },
+        body: { llm },
       });
-      toast.success("Profile saved.");
+      toast.success("Saved.");
     } catch (error) {
-      toast.error("Failed to switch profile. Please try again.");
+      toast.error("Failed to save. Please try again.");
       captureError(error, { context: "settings-ai-language-model-save" });
     }
-  }, [effectiveActiveProfile, configMutation, assistantId]);
-
-  const handleAdvisorProfileSave = useCallback(async () => {
-    try {
-      await configMutation.mutateAsync({
-        path: { assistant_id: assistantId },
-        // Empty selection clears the advisor profile (no dedicated advisor).
-        body: { llm: { advisorProfile: effectiveAdvisorProfile ?? "" } },
-      });
-      toast.success("Advisor profile saved.");
-    } catch (error) {
-      toast.error("Failed to switch advisor profile. Please try again.");
-      captureError(error, { context: "settings-ai-advisor-profile-save" });
-    }
-  }, [effectiveAdvisorProfile, configMutation, assistantId]);
+  }, [
+    isProfileDirty,
+    isAdvisorProfileDirty,
+    effectiveActiveProfile,
+    effectiveAdvisorProfile,
+    configMutation,
+    assistantId,
+  ]);
 
   return (
     <>
@@ -146,13 +168,15 @@ export function LanguageModelCard() {
                     : profilePickerLabel(p),
               }))}
             />
-            {queryComplexityRoutingEnabled && effectiveActiveProfile === AUTO_PROFILE_NAME && (
-              <div className="flex items-center gap-2 rounded-lg bg-[var(--surface-warning-subtle)] px-3 py-2">
-                <span className="text-body-small-default text-[var(--content-warning)]">
-                  Auto may use more powerful models when needed, which can increase costs.
-                </span>
-              </div>
-            )}
+            {queryComplexityRoutingEnabled &&
+              effectiveActiveProfile === AUTO_PROFILE_NAME && (
+                <div className="flex items-center gap-2 rounded-lg bg-[var(--surface-warning-subtle)] px-3 py-2">
+                  <span className="text-body-small-default text-[var(--content-warning)]">
+                    Auto may use more powerful models when needed, which can
+                    increase costs.
+                  </span>
+                </div>
+              )}
             {defaultProfilePickerEntries.length === 0 ? (
               <Typography
                 variant="body-small-default"
@@ -187,16 +211,8 @@ export function LanguageModelCard() {
               as="p"
               className="mt-1 text-(--content-tertiary)"
             >
-              Which profile the advisor consults. It won&apos;t be selectable as your chat profile.
+              Which model your assistant consults for a second opinion
             </Typography>
-            {isAdvisorProfileDirty && (
-              <div className="mt-2 flex items-center gap-2">
-                <SaveButton onClick={handleAdvisorProfileSave} disabled={configMutation.isPending} />
-                {configMutation.isPending && (
-                  <Loader2 className="h-4 w-4 animate-spin text-[var(--content-disabled)]" />
-                )}
-              </div>
-            )}
           </div>
 
           <div className="flex items-center gap-2">
@@ -223,9 +239,12 @@ export function LanguageModelCard() {
             </Button>
           </div>
 
-          {isProfileDirty && (
+          {(isProfileDirty || isAdvisorProfileDirty) && (
             <div className="flex items-center gap-2">
-              <SaveButton onClick={handleManagedProfileSave} disabled={configMutation.isPending} />
+              <SaveButton
+                onClick={handleSave}
+                disabled={configMutation.isPending}
+              />
               {configMutation.isPending && (
                 <Loader2 className="h-4 w-4 animate-spin text-[var(--content-disabled)]" />
               )}

--- a/clients/web/src/hooks/use-push-registration.ts
+++ b/clients/web/src/hooks/use-push-registration.ts
@@ -1,0 +1,33 @@
+/**
+ * Lifecycle hook that registers the Capacitor iOS app for APNs remote push.
+ *
+ * When an assistant becomes active, this acquires an APNs device token and
+ * upserts it to the platform so the daemon's `platform` notification channel
+ * can deliver background notifications (reminders fire while the app is
+ * suspended, where the local-notification path cannot reach the device).
+ *
+ * No-ops off native iOS. Token deletion on logout is handled in
+ * `stores/auth-store.ts` (before the session cookie is cleared), not here —
+ * the assistant-id change on logout races session teardown, so the platform
+ * delete must run while the session is still valid.
+ *
+ * References:
+ * - runtime/push-registration.ts — registration + token upsert
+ * - hooks/use-notification-intent-sync.ts — sibling local-notification path
+ */
+
+import { useEffect } from "react";
+
+import { registerForRemotePush } from "@/runtime/push-registration";
+
+/**
+ * Registers for APNs remote push whenever an assistant is active.
+ *
+ * @param assistantId — current assistant; `null` disables registration
+ */
+export function usePushRegistration(assistantId: string | null): void {
+  useEffect(() => {
+    if (!assistantId) return;
+    void registerForRemotePush(assistantId);
+  }, [assistantId]);
+}

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -425,6 +425,14 @@
       "label": "MCP Settings",
       "description": "Show the MCP page in Settings for managing Model Context Protocol server connections: view status, enable/disable, configure, and inspect registered tools per server.",
       "defaultEnabled": false
+    },
+    {
+      "id": "os-beta",
+      "scope": "assistant",
+      "key": "os-beta",
+      "label": "OS Beta",
+      "description": "Enable the OS Beta model profile (GLM 5.2 / Fireworks) in the assistant's model profile selection.",
+      "defaultEnabled": false
     }
   ]
 }

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -26,6 +26,7 @@ import { useAssistantResourceSync } from "@/hooks/use-assistant-resource-sync";
 import { useDocumentEditorSync } from "@/hooks/use-document-editor-sync";
 import { useBookmarksSync } from "@/hooks/use-bookmarks-sync";
 import { useNotificationIntentSync } from "@/hooks/use-notification-intent-sync";
+import { usePushRegistration } from "@/hooks/use-push-registration";
 import { useSoundEffects } from "@/hooks/use-sound-effects";
 import { useOnboardingWindowSize } from "@/hooks/use-onboarding-window-size";
 import { useConversationSync } from "@/hooks/use-conversation-sync";
@@ -122,6 +123,7 @@ export function RootLayout() {
   useConversationSync(assistantId, isAssistantActive);
   useFeatureFlagBusSync(assistantId, isAssistantActive);
   useNotificationIntentSync(assistantId);
+  usePushRegistration(assistantId);
   useSoundEffects(assistantId, isAssistantActive);
   useDocumentEditorSync();
   useBookmarksSync();

--- a/clients/web/src/runtime/push-registration.test.ts
+++ b/clients/web/src/runtime/push-registration.test.ts
@@ -1,0 +1,340 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── platform guards ──────────────────────────────────────────────────────────
+//
+// `native-auth` is mocked rather than loaded because its module-load
+// `registerPlugin("NativeAuth")` would fail against the partial
+// `@capacitor/core` mock (mirrors capacitor-app-state.test.ts).
+
+let isNative = true;
+let platform = "ios";
+mock.module("@/runtime/native-auth", () => ({
+  isNativePlatform: () => isNative,
+}));
+mock.module("@capacitor/core", () => ({
+  Capacitor: {
+    isNativePlatform: () => isNative,
+    getPlatform: () => platform,
+  },
+}));
+
+// ── @capacitor/push-notifications (lazy-imported plugin Proxy) ────────────────
+
+type RegistrationHandler = (token: { value: string }) => void;
+type ErrorHandler = (error: { error: string }) => void;
+
+let registrationHandler: RegistrationHandler | null = null;
+let registrationErrorHandler: ErrorHandler | null = null;
+let permissionState: "granted" | "denied" | "prompt" = "granted";
+
+const addListenerMock = mock(
+  async (event: string, handler: RegistrationHandler | ErrorHandler) => {
+    if (event === "registration") {
+      registrationHandler = handler as RegistrationHandler;
+    } else if (event === "registrationError") {
+      registrationErrorHandler = handler as ErrorHandler;
+    }
+    return { remove: async () => {} };
+  },
+);
+const requestPermissionsMock = mock(async () => ({ receive: permissionState }));
+const registerMock = mock(async () => {});
+
+mock.module("@capacitor/push-notifications", () => ({
+  PushNotifications: {
+    addListener: addListenerMock,
+    requestPermissions: requestPermissionsMock,
+    register: registerMock,
+  },
+}));
+
+// ── @capacitor/app (lazy-imported plugin Proxy) ──────────────────────────────
+
+let bundleId = "ai.vocify-inc.vellum-assistant-ios";
+const getInfoMock = mock(async () => ({
+  id: bundleId,
+  name: "Vellum",
+  build: "1",
+  version: "1.0.0",
+}));
+mock.module("@capacitor/app", () => ({
+  App: { getInfo: getInfoMock },
+}));
+
+// ── generated platform SDK ───────────────────────────────────────────────────
+//
+// Capture call args via typed implementations rather than `.mock.calls` so the
+// assertions stay type-safe (the mock's parameter type drives the captured
+// shape).
+
+interface UpsertArg {
+  path: { assistant_id: string };
+  body: {
+    token: string;
+    platform: string;
+    bundle_id: string;
+    apns_environment: string;
+  };
+  throwOnError: boolean;
+}
+interface DeleteArg {
+  path: { assistant_id: string; token: string };
+  query: { bundle_id: string };
+  throwOnError: boolean;
+}
+
+let lastUpsertArg: UpsertArg | null = null;
+let lastDeleteArg: DeleteArg | null = null;
+let upsertError: unknown = undefined;
+let deleteError: unknown = undefined;
+// When set, the upsert blocks on this gate so a test can interleave logout
+// with an in-flight upsert.
+let upsertGate: Promise<void> | null = null;
+
+const upsertMock = mock(async (arg: UpsertArg) => {
+  if (upsertGate) await upsertGate;
+  lastUpsertArg = arg;
+  return { data: {}, error: upsertError };
+});
+const deleteMock = mock(async (arg: DeleteArg) => {
+  lastDeleteArg = arg;
+  return { data: undefined, error: deleteError };
+});
+mock.module("@/generated/api/sdk.gen", () => ({
+  assistantsPushTokensUpsert: upsertMock,
+  assistantsPushTokensDelete: deleteMock,
+}));
+
+// ── Sentry capture-error ─────────────────────────────────────────────────────
+
+const captureErrorMock = mock(() => {});
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: captureErrorMock,
+}));
+
+const {
+  isRemotePushSupported,
+  registerForRemotePush,
+  unregisterFromRemotePush,
+  __resetPushRegistrationStateForTests,
+} = await import("@/runtime/push-registration");
+
+// The `registration` handler fires `upsertToken` fire-and-forget, and its
+// dynamic `import("@capacitor/app")` resolves on the macrotask queue — yield to
+// timers (not just microtasks) so the upsert settles before assertions.
+const flushMicrotasks = async (rounds = 10) => {
+  for (let i = 0; i < rounds; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+};
+
+beforeEach(() => {
+  isNative = true;
+  platform = "ios";
+  permissionState = "granted";
+  bundleId = "ai.vocify-inc.vellum-assistant-ios";
+  registrationHandler = null;
+  registrationErrorHandler = null;
+  lastUpsertArg = null;
+  lastDeleteArg = null;
+  upsertError = undefined;
+  deleteError = undefined;
+  upsertGate = null;
+  addListenerMock.mockClear();
+  requestPermissionsMock.mockClear();
+  registerMock.mockClear();
+  getInfoMock.mockClear();
+  upsertMock.mockClear();
+  deleteMock.mockClear();
+  captureErrorMock.mockClear();
+  __resetPushRegistrationStateForTests();
+});
+
+describe("isRemotePushSupported", () => {
+  test("true on native iOS", () => {
+    expect(isRemotePushSupported()).toBe(true);
+  });
+
+  test("false off native (desktop browser / Electron)", () => {
+    isNative = false;
+    expect(isRemotePushSupported()).toBe(false);
+  });
+
+  test("false on a non-iOS native platform (e.g. android)", () => {
+    platform = "android";
+    expect(isRemotePushSupported()).toBe(false);
+  });
+});
+
+describe("registerForRemotePush", () => {
+  test("no-ops off native iOS — never touches the plugin or SDK", async () => {
+    isNative = false;
+    await registerForRemotePush("assistant-1");
+    await flushMicrotasks();
+
+    expect(requestPermissionsMock).not.toHaveBeenCalled();
+    expect(registerMock).not.toHaveBeenCalled();
+    expect(upsertMock).not.toHaveBeenCalled();
+  });
+
+  test("requests permission, registers, and upserts the token on registration", async () => {
+    await registerForRemotePush("assistant-1");
+
+    expect(requestPermissionsMock).toHaveBeenCalledTimes(1);
+    expect(registerMock).toHaveBeenCalledTimes(1);
+
+    // Simulate iOS delivering the APNs token.
+    registrationHandler?.({ value: "apns-token-abc" });
+    await flushMicrotasks();
+
+    expect(upsertMock).toHaveBeenCalledTimes(1);
+    expect(lastUpsertArg).toEqual({
+      path: { assistant_id: "assistant-1" },
+      body: {
+        token: "apns-token-abc",
+        platform: "ios",
+        bundle_id: "ai.vocify-inc.vellum-assistant-ios",
+        apns_environment: "production",
+      },
+      throwOnError: false,
+    });
+  });
+
+  test("derives the development APNs environment from a .dev bundle id", async () => {
+    bundleId = "ai.vocify-inc.vellum-assistant-ios.dev";
+    await registerForRemotePush("assistant-1");
+    registrationHandler?.({ value: "apns-token-dev" });
+    await flushMicrotasks();
+
+    expect(lastUpsertArg?.body.apns_environment).toBe("development");
+  });
+
+  test("does not register when notification permission is denied", async () => {
+    permissionState = "denied";
+    await registerForRemotePush("assistant-1");
+    await flushMicrotasks();
+
+    expect(registerMock).not.toHaveBeenCalled();
+    expect(upsertMock).not.toHaveBeenCalled();
+  });
+
+  test("reports an upsert error to Sentry instead of throwing", async () => {
+    upsertError = { detail: "boom" };
+    await registerForRemotePush("assistant-1");
+    registrationHandler?.({ value: "apns-token-abc" });
+    await flushMicrotasks();
+
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("registrationError from APNs is reported, not thrown", async () => {
+    await registerForRemotePush("assistant-1");
+    registrationErrorHandler?.({ error: "APNs failed" });
+    await flushMicrotasks();
+
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    expect(upsertMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("unregisterFromRemotePush", () => {
+  test("deletes the last-registered token with bundle-scoped query", async () => {
+    await registerForRemotePush("assistant-1");
+    registrationHandler?.({ value: "apns-token-abc" });
+    await flushMicrotasks();
+
+    await unregisterFromRemotePush();
+
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+    expect(lastDeleteArg).toEqual({
+      path: { assistant_id: "assistant-1", token: "apns-token-abc" },
+      query: { bundle_id: "ai.vocify-inc.vellum-assistant-ios" },
+      throwOnError: false,
+    });
+  });
+
+  test("falls back to the persisted token after a process reload (empty module memory)", async () => {
+    // Simulate a prior session that persisted a registration followed by a
+    // reload that wiped module memory — `lastRegistered` is null but the
+    // platform still has the token, so logout must still delete it.
+    localStorage.setItem(
+      "vellum:push_registration",
+      JSON.stringify({
+        token: "persisted-token",
+        bundleId: "ai.vocify-inc.vellum-assistant-ios",
+        assistantId: "assistant-9",
+      }),
+    );
+
+    await unregisterFromRemotePush();
+
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+    expect(lastDeleteArg).toEqual({
+      path: { assistant_id: "assistant-9", token: "persisted-token" },
+      query: { bundle_id: "ai.vocify-inc.vellum-assistant-ios" },
+      throwOnError: false,
+    });
+  });
+
+  test("waits for an in-flight upsert, then deletes the freshly-registered token", async () => {
+    // Block the upsert so we can interleave logout while it is still in flight.
+    let releaseUpsert!: () => void;
+    upsertGate = new Promise<void>((resolve) => {
+      releaseUpsert = resolve;
+    });
+
+    await registerForRemotePush("assistant-1");
+    // iOS delivers the token; the upsert starts but hasn't resolved yet.
+    registrationHandler?.({ value: "race-token" });
+    await Promise.resolve();
+
+    // User logs out mid-upsert. unregister must await the in-flight upsert
+    // rather than concluding there is nothing to delete.
+    const unregisterPromise = unregisterFromRemotePush();
+    releaseUpsert();
+    await unregisterPromise;
+
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+    expect(lastDeleteArg?.path.token).toBe("race-token");
+  });
+
+  test("awaits ALL concurrent in-flight upserts before deleting, not just the latest", async () => {
+    let releaseUpsert!: () => void;
+    upsertGate = new Promise<void>((resolve) => {
+      releaseUpsert = resolve;
+    });
+
+    await registerForRemotePush("assistant-1");
+    // Two overlapping upserts (e.g. manual re-upsert + cached token re-emit).
+    registrationHandler?.({ value: "token-A" });
+    registrationHandler?.({ value: "token-B" });
+    await Promise.resolve();
+
+    const unregisterPromise = unregisterFromRemotePush();
+    releaseUpsert();
+    await unregisterPromise;
+
+    // Both upserts settled before the delete ran — no straggler can
+    // re-register the token after logout.
+    expect(upsertMock).toHaveBeenCalledTimes(2);
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("reports a failed delete to Sentry instead of silently dropping it", async () => {
+    deleteError = { detail: "server error" };
+    await registerForRemotePush("assistant-1");
+    registrationHandler?.({ value: "apns-token-abc" });
+    await flushMicrotasks();
+    captureErrorMock.mockClear();
+
+    await unregisterFromRemotePush();
+
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("no-ops when no token was registered", async () => {
+    await unregisterFromRemotePush();
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/runtime/push-registration.ts
+++ b/clients/web/src/runtime/push-registration.ts
@@ -1,0 +1,313 @@
+/**
+ * APNs remote-push device-token registration for the Capacitor iOS app.
+ *
+ * The daemon's `platform` notification channel POSTs background notifications
+ * (reminders, activity completions, etc.) to the Vellum platform's
+ * `/v1/assistants/{id}/push/dispatch/` endpoint, which fans them out to every
+ * APNs device token registered for the bound user. This module is the missing
+ * client half: it asks iOS for an APNs device token via
+ * `@capacitor/push-notifications`, then upserts that token to the platform so
+ * the daemon has somewhere to deliver.
+ *
+ * Why this matters for reminders specifically: the in-app local-notification
+ * path (`runtime/notifications.ts`) only fires while the JS runtime is alive
+ * (foreground / recently-backgrounded). Scheduled reminders fire while the app
+ * is backgrounded or suspended, so APNs remote push is the only path that can
+ * reach the device. (LUM-1159)
+ *
+ * Lifecycle:
+ *   - {@link registerForRemotePush} — call once an assistant is active. Requests
+ *     notification permission, registers for APNs, and upserts the resulting
+ *     token to the platform. Idempotent and safe to call on every mount.
+ *   - {@link unregisterFromRemotePush} — call from the logout path BEFORE the
+ *     session cookie is cleared (see `stores/auth-store.ts`) so the platform
+ *     delete is authenticated. Removes the token for the bound assistant.
+ *
+ * iOS-only and best-effort: no-ops on Electron, desktop browsers, and Android
+ * (no native Capacitor Android shell ships today); registration/delete failures
+ * are reported to Sentry but never thrown into the app lifecycle.
+ *
+ * Per `docs/CAPACITOR.md`, the `@capacitor/*` plugins are destructured inline
+ * at each call site — never returned through an `async` boundary — because the
+ * plugin Proxy's `.then` trap would hang the awaiting caller forever.
+ */
+
+import { Capacitor } from "@capacitor/core";
+
+import {
+  assistantsPushTokensDelete,
+  assistantsPushTokensUpsert,
+} from "@/generated/api/sdk.gen";
+import type { ApnsEnvironmentEnum } from "@/generated/api/types.gen";
+import { captureError } from "@/lib/sentry/capture-error";
+import { isNativePlatform } from "@/runtime/native-auth";
+import { createStorageAccessor } from "@/utils/typed-storage";
+
+/**
+ * Bundle-id suffix that maps to the development APNs entitlement. The dev Xcode
+ * config (`clients/ios/App/App/Config/App-Dev.xcconfig`) signs with
+ * `App-Dev.entitlements` (`aps-environment = development`) and ships the `.dev`
+ * bundle id; production and staging both sign with `App.entitlements`
+ * (`aps-environment = production`). APNs rejects a token minted under one
+ * environment if dispatched against the other, so the platform stores the
+ * environment alongside the token and the value must match the running build.
+ */
+const DEV_BUNDLE_SUFFIX = ".dev";
+
+/** Token registration we last upserted, retained so logout can delete it. */
+interface RegisteredToken {
+  token: string;
+  bundleId: string;
+  assistantId: string;
+}
+
+function parseRegisteredToken(raw: string): RegisteredToken | null {
+  const value = JSON.parse(raw) as Partial<RegisteredToken>;
+  if (
+    typeof value.token === "string" &&
+    typeof value.bundleId === "string" &&
+    typeof value.assistantId === "string"
+  ) {
+    return { token: value.token, bundleId: value.bundleId, assistantId: value.assistantId };
+  }
+  return null;
+}
+
+/**
+ * The last successfully-upserted registration, persisted to user-scoped
+ * storage. Module memory alone is insufficient: the WebView/app process can
+ * reload (dropping `lastRegistered`) before `usePushRegistration` re-runs, and
+ * `/logout` is a standalone route outside `RootLayout` — so logout could fire
+ * with empty module state and skip the platform DELETE, leaving a signed-out
+ * device still receiving remote pushes. The `vellum:` (user) scope is cleared
+ * by the logout storage sweep, and we also remove it explicitly after delete.
+ *
+ * The stored value is a device push-routing registration (APNs destination
+ * token + bundle + assistant), not auth/session material — losing it to XSS
+ * does not grant access to anything, so JS-readable storage is appropriate
+ * here (unlike session tokens, which must stay in HttpOnly cookies).
+ */
+const persistedRegistration = createStorageAccessor<RegisteredToken | null>({
+  key: "vellum:push_registration",
+  scope: "user",
+  parse: parseRegisteredToken,
+  serialize: JSON.stringify,
+  fallback: null,
+});
+
+let listenersRegistered = false;
+let currentAssistantId: string | null = null;
+let lastRegistered: RegisteredToken | null = null;
+const pendingUpserts = new Set<Promise<void>>();
+
+/**
+ * Track every in-flight upsert so logout can await all of them before
+ * concluding there is nothing to delete. Without this, a `registration` event
+ * whose `upsertToken` is still mid-POST when logout fires would leave
+ * `lastRegistered` unset — the DELETE would be skipped while the upsert still
+ * succeeds, leaving a signed-out device registered. A set (not a single
+ * promise) is required because concurrent upserts can overlap — e.g. an
+ * assistant switch starts a manual re-upsert and `register()` re-emits the
+ * cached token — and awaiting only the latest would let an earlier, slower
+ * upsert re-register the token after the delete.
+ */
+function trackUpsert(upsert: Promise<void>): void {
+  pendingUpserts.add(upsert);
+  void upsert.finally(() => {
+    pendingUpserts.delete(upsert);
+  });
+}
+
+/**
+ * True only on the native Capacitor iOS runtime.
+ *
+ * APNs remote push is a native-only capability: a device token only exists
+ * inside the iOS app process, there is no web/Electron equivalent, and the
+ * daemon's `platform` channel exclusively targets iOS device tokens. This is
+ * not a "present but broken" web API — there is nothing to feature-detect — so
+ * a platform short-circuit is the correct guard. Android is excluded because no
+ * native Capacitor Android shell ships today; revisit this guard if one does.
+ */
+export function isRemotePushSupported(): boolean {
+  return isNativePlatform() && Capacitor.getPlatform() === "ios";
+}
+
+/** Map the running build's bundle id to its APNs entitlement environment. */
+function resolveApnsEnvironment(bundleId: string): ApnsEnvironmentEnum {
+  return bundleId.endsWith(DEV_BUNDLE_SUFFIX) ? "development" : "production";
+}
+
+/**
+ * Upsert a freshly-minted APNs token to the platform for the given assistant.
+ * Best-effort: a non-2xx response or thrown error is reported and swallowed.
+ */
+async function upsertToken(token: string, assistantId: string): Promise<void> {
+  try {
+    // `@capacitor/app` is a plugin Proxy — destructure inline (see CAPACITOR.md).
+    const { App } = await import("@capacitor/app");
+    const { id: bundleId } = await App.getInfo();
+
+    const result = await assistantsPushTokensUpsert({
+      path: { assistant_id: assistantId },
+      body: {
+        token,
+        platform: "ios",
+        bundle_id: bundleId,
+        apns_environment: resolveApnsEnvironment(bundleId),
+      },
+      throwOnError: false,
+    });
+
+    if (result.error) {
+      captureError(result.error, {
+        context: "push_registration_upsert",
+        level: "warning",
+        bestEffort: true,
+      });
+      return;
+    }
+
+    lastRegistered = { token, bundleId, assistantId };
+    persistedRegistration.save(lastRegistered);
+  } catch (err) {
+    captureError(err, {
+      context: "push_registration_upsert",
+      level: "warning",
+      bestEffort: true,
+    });
+  }
+}
+
+/**
+ * Register the APNs `registration` / `registrationError` listeners exactly
+ * once. The `registration` handler upserts the token under whichever assistant
+ * is current when iOS delivers it (iOS may emit the token asynchronously, and
+ * re-emits the cached token on subsequent `register()` calls).
+ */
+async function ensureListeners(): Promise<void> {
+  if (listenersRegistered) return;
+  listenersRegistered = true;
+  try {
+    const { PushNotifications } = await import("@capacitor/push-notifications");
+    await PushNotifications.addListener("registration", (token) => {
+      const assistantId = currentAssistantId;
+      if (!assistantId) return;
+      trackUpsert(upsertToken(token.value, assistantId));
+    });
+    await PushNotifications.addListener("registrationError", (err) => {
+      captureError(err, {
+        context: "push_registration_apns",
+        level: "warning",
+      });
+    });
+  } catch (err) {
+    // Allow a later call to retry listener registration.
+    listenersRegistered = false;
+    captureError(err, {
+      context: "push_registration_listeners",
+      level: "warning",
+    });
+  }
+}
+
+/**
+ * Request notification permission, register for APNs, and upsert the resulting
+ * device token to the platform for `assistantId`. No-ops off native iOS.
+ *
+ * Safe to call repeatedly (e.g. on every mount or assistant switch): iOS shows
+ * the permission prompt at most once, `register()` re-emits the cached token,
+ * and the listener re-upserts it. The same `UNUserNotificationCenter`
+ * authorization backs the local-notification path, so this does not introduce a
+ * second OS prompt.
+ */
+export async function registerForRemotePush(assistantId: string): Promise<void> {
+  if (!isRemotePushSupported()) return;
+  currentAssistantId = assistantId;
+
+  // If iOS already handed us a token for this device under a different
+  // assistant, re-upsert it now rather than waiting for another registration
+  // event (which only fires again on the next `register()`).
+  if (lastRegistered && lastRegistered.assistantId !== assistantId) {
+    trackUpsert(upsertToken(lastRegistered.token, assistantId));
+  }
+
+  try {
+    // `@capacitor/push-notifications` is a plugin Proxy — destructure inline.
+    const { PushNotifications } = await import("@capacitor/push-notifications");
+    await ensureListeners();
+    const permission = await PushNotifications.requestPermissions();
+    if (permission.receive !== "granted") return;
+    await PushNotifications.register();
+  } catch (err) {
+    captureError(err, {
+      context: "push_registration_register",
+      level: "warning",
+    });
+  }
+}
+
+/**
+ * Delete the last-registered device token from the platform. Call this from the
+ * logout flow BEFORE the session cookie is cleared so the request is
+ * authenticated (the platform delete is keyed on the still-valid session).
+ *
+ * Best-effort and idempotent: no-ops when nothing was registered or off native
+ * iOS, and reports (does not throw) delete failures.
+ */
+export async function unregisterFromRemotePush(): Promise<void> {
+  // Stop new registration events from upserting, then wait for any upsert
+  // already in flight so we don't miss a token that is about to be registered
+  // server-side. Logout awaits this function before clearing the session.
+  currentAssistantId = null;
+  // Drain in a loop: awaiting a batch can let a concurrent upsert finish and a
+  // straggler get added. New upserts can only originate from a `registration`
+  // event, which now no-ops (currentAssistantId is null), so this terminates.
+  while (pendingUpserts.size > 0) {
+    await Promise.allSettled([...pendingUpserts]);
+  }
+
+  // Fall back to persisted storage: a process reload before re-registration
+  // leaves `lastRegistered` null even though a token is still registered.
+  const registered = lastRegistered ?? persistedRegistration.load();
+  lastRegistered = null;
+  persistedRegistration.remove();
+
+  if (!registered || !isRemotePushSupported()) return;
+
+  try {
+    const result = await assistantsPushTokensDelete({
+      path: { assistant_id: registered.assistantId, token: registered.token },
+      query: { bundle_id: registered.bundleId },
+      throwOnError: false,
+    });
+    // `throwOnError: false` surfaces 4xx/5xx in `result.error`; a silently
+    // failed delete leaves the token registered, so report it rather than
+    // treating the unregister as complete.
+    if (result.error) {
+      captureError(result.error, {
+        context: "push_registration_delete",
+        level: "warning",
+        bestEffort: true,
+        extra: {
+          assistantId: registered.assistantId,
+          bundleId: registered.bundleId,
+        },
+      });
+    }
+  } catch (err) {
+    captureError(err, {
+      context: "push_registration_delete",
+      level: "warning",
+      bestEffort: true,
+    });
+  }
+}
+
+/** Test-only: reset module + persisted state between cases. */
+export function __resetPushRegistrationStateForTests(): void {
+  listenersRegistered = false;
+  currentAssistantId = null;
+  lastRegistered = null;
+  pendingUpserts.clear();
+  persistedRegistration.remove();
+}

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -54,6 +54,7 @@ import {
 import { listAssistants } from "@/assistant/api";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { deleteBiometricToken } from "@/runtime/native-biometric";
+import { unregisterFromRemotePush } from "@/runtime/push-registration";
 import { fetchConsent, patchConsent } from "@/domains/account/profile";
 import {
   restoreConsentForUser,
@@ -851,6 +852,10 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
     }
 
     suppressPlatformProbe = true;
+    // Delete the APNs device token from the platform BEFORE clearing the
+    // session — the platform delete is authenticated by the still-valid
+    // session cookie. No-ops off native iOS. Best-effort: never blocks logout.
+    await unregisterFromRemotePush();
     try {
       await allauthLogout();
     } finally {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -425,6 +425,14 @@
       "label": "MCP Settings",
       "description": "Show the MCP page in Settings for managing Model Context Protocol server connections: view status, enable/disable, configure, and inspect registered tools per server.",
       "defaultEnabled": false
+    },
+    {
+      "id": "os-beta",
+      "scope": "assistant",
+      "key": "os-beta",
+      "label": "OS Beta",
+      "description": "Enable the OS Beta model profile (GLM 5.2 / Fireworks) in the assistant's model profile selection.",
+      "defaultEnabled": false
     }
   ]
 }

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -586,6 +586,23 @@
           }
         },
         {
+          "id": "accounts/fireworks/models/glm-5p2",
+          "displayName": "GLM 5.2",
+          "contextWindowTokens": 1040000,
+          "maxOutputTokens": 131072,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": false,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 1.4,
+            "outputPer1mTokens": 4.4,
+            "cacheReadPer1mTokens": 0.26
+          }
+        },
+        {
           "id": "accounts/fireworks/models/kimi-k2p5",
           "displayName": "Kimi K2.5",
           "contextWindowTokens": 256000,


### PR DESCRIPTION
Cherry-picks the following commits from `main` into `release/v0.10.0`. All applied cleanly with no conflicts.

| Commit | Summary |
|--------|---------|
| `1a2d0c7` | fix(question): rehydrate pending ask_question card on history load (#35445) |
| `a6aba9a` | fix(oauth): steer weak models straight to the connect surface (#35449) |
| `b5e0124` | docs(messaging): collapse the email connect flow to a single step (#35450) |
| `850b975` | fix(skills): stop telling models the JSON-string input form is wrong (#35451) |
| `3f533cf` | feat(subagent): default spawned subagents to the invoking agent's inference profile (#35459) |
| `7a5174e` | fix(onboarding): remove Docker hosting option (#35460) |
| `bbf9de9` | OS Beta managed profile (GLM 5.2 / Fireworks), flag-gated (#35430) |
| `afabe12` | feat(ios): register APNs device tokens so reminder push reaches the iOS app (LUM-1159) (#35447) |
| `9e90ea1` | advisor (ui): single Save in Models & Services + fix advisor helper text (#35443) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)