### PR TITLE
fix(web): drop unrouted contacts/artifacts segments from the runtime-proxy allowlist

### DIFF
--- a/clients/web/src/lib/api-interceptors.test.ts
+++ b/clients/web/src/lib/api-interceptors.test.ts
@@ -294,21 +294,16 @@ describe("api-interceptors / self-hosted rewriting", () => {
   });
 
   test("rewrites daemon/gateway-owned segments reached via the platform client", async () => {
-    // config / permissions / trust-rules / artifacts / contacts /
-    // contact-channels are daemon- or gateway-owned but are called through
-    // the platform client via raw `client.*` requests (e.g. the background
-    // `TimezoneSync` PATCH to `config`). In local / self-hosted mode they
-    // must route to the gateway like conversations rather than fall through
-    // to the dead platform proxy and flood the console with 502s.
+    // config / permissions / trust-rules are daemon- or gateway-owned and
+    // are called through the platform client via raw `client.*` requests
+    // (e.g. the background `TimezoneSync` PATCH to `config`). In local /
+    // self-hosted mode they must route to the gateway like conversations
+    // rather than fall through to the dead platform proxy and flood the
+    // console with 502s. (contacts / contact-channels / artifacts are NOT
+    // listed — their assistant-scoped routes aren't served by the gateway
+    // or daemon, so forwarding them would only 404.)
     setSelfHostedConnection({ url: INGRESS, token: ACTOR_TOKEN });
-    for (const segment of [
-      "config",
-      "permissions",
-      "trust-rules",
-      "artifacts",
-      "contacts",
-      "contact-channels",
-    ]) {
+    for (const segment of ["config", "permissions", "trust-rules"]) {
       const path = `/v1/assistants/${SELF_HOSTED_ID}/${segment}/`;
       const input = new Request(`https://platform.test${path}`, {
         method: "POST",
@@ -414,9 +409,10 @@ describe("api-interceptors / self-hosted rewriting", () => {
   });
 
   test("does NOT rewrite first segments outside the allowlist", async () => {
-    // The platform client's narrow allowlist ensures platform-owned
-    // routes fall through to Django. Pin the non-rewriting contract
-    // for the routes most likely to get mistakenly captured.
+    // The platform client's narrow allowlist ensures platform-owned routes
+    // (and runtime routes not yet mirrored on the gateway) fall through
+    // rather than being rewritten. Pin the non-rewriting contract for the
+    // routes most likely to get mistakenly captured.
     setSelfHostedConnection({ url: INGRESS, token: ACTOR_TOKEN });
     for (const segment of [
       "activate",
@@ -432,10 +428,16 @@ describe("api-interceptors / self-hosted rewriting", () => {
       "domains",
       "email-addresses",
       "oauth",
-      // `/a2a/invites/redeem` is a platform broker (Django) route — it sits
-      // in the same client file as the allowlisted `contacts` /
-      // `contact-channels`, so pin that it is NOT captured by the allowlist.
+      // `/a2a/invites/redeem` is a platform broker (Django) route.
       "a2a",
+      // contacts / contact-channels / artifacts are daemon/gateway-owned but
+      // their assistant-scoped routes aren't served (the contacts control
+      // plane is registered at flat `/v1/contacts...` paths; there is no
+      // artifacts route), so they must NOT be rewritten — forwarding would
+      // 404 rather than reach a handler.
+      "contacts",
+      "contact-channels",
+      "artifacts",
     ]) {
       const input = new Request(
         `https://platform.test/v1/assistants/${SELF_HOSTED_ID}/${segment}/`,

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -94,14 +94,22 @@ const RUNTIME_PROXIED_FIRST_SEGMENTS = new Set<string>([
   // local / self-hosted mode rather than falling through to the dead
   // platform proxy — otherwise e.g. the background `TimezoneSync` PATCH to
   // `config` retries against a nonexistent platform and floods the console
-  // with 502s. `a2a` is deliberately excluded: `/a2a/invites/redeem` is a
-  // platform broker (Django) route that must stay on the platform.
+  // with 502s. Each is listed only because the gateway (or the daemon it
+  // proxies to) actually serves the assistant-scoped routes the call sites
+  // hit: `config` (daemon GET/PATCH), and `permissions/thresholds` +
+  // `trust-rules` (gateway, all methods).
+  //
+  // Deliberately NOT listed: `contacts`, `contact-channels`, `artifacts`,
+  // and `a2a`. Their assistant-scoped routes aren't served by the gateway
+  // or daemon — the contacts control plane is registered at flat
+  // `/v1/contacts...` paths (only an assistant-scoped contacts DELETE
+  // exists), there is no `artifacts` route, and `/a2a/invites/redeem` is a
+  // platform broker route. Forwarding them would only turn the existing
+  // failure into a 404, so they stay on the platform until the
+  // assistant-scoped routes are mirrored.
   "config",
   "permissions",
   "trust-rules",
-  "artifacts",
-  "contacts",
-  "contact-channels",
 ]);
 
 const ASSISTANT_PATH_RE =


### PR DESCRIPTION
## Summary
- Follow-up to #35465 addressing Codex's P2 review comment. Three of the six segments added to `RUNTIME_PROXIED_FIRST_SEGMENTS` aren't served at the assistant-scoped paths their call sites hit, so forwarding them to the gateway in self-hosted mode would **404** instead of failing at the dead `:8000`:
  - `contacts` — control plane is registered at flat `/v1/contacts...`; only an assistant-scoped `contacts/{id}` DELETE exists, so `upsertContact`'s `POST /contacts/` has no handler.
  - `contact-channels` — verify is flat `/v1/contact-channels/{id}/verify`; the assistant-scoped `POST .../verify/` has no handler.
  - `artifacts` — no `/v1/assistants/{id}/artifacts/{path}` route exists on the gateway or daemon.
- Kept `config` (daemon GET/PATCH — the original `config` 502-storm fix), `permissions/thresholds` and `trust-rules` (gateway serves these assistant-scoped, all methods the call sites use). Verified against the gateway route table (`gateway/src/index.ts`) and the daemon SDK.
- Pinned the three reverted segments (alongside `a2a`) in the non-rewrite negative test so they aren't naively re-added.

## Original prompt
Codex flagged (P2) on #35465 that rewriting assistant-scoped `contacts`/`contact-channels` POSTs to the gateway would 404, because the gateway only registers those control-plane handlers at flat paths. The claim checks out — and the same gap applies to `artifacts` — so this reverts those three from the allowlist while keeping the verified-served `config`/`permissions`/`trust-rules`.

## Verification
- `bunx tsc --noEmit` clean; `bun test src/lib/api-interceptors.test.ts` → 62 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)