### PR TITLE
fix(agent-wake): stamp the wake's resolved call site and override profile for tools

### DIFF
--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -1138,6 +1138,52 @@ describe("wakeAgentForOpportunity", () => {
     expect(conversation.isProcessing()).toBe(false);
   });
 
+  test("stamps the resolved call site and override profile during the run, then restores them", async () => {
+    const conversation = makeWakeConversation({
+      baseline: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      scriptedAssistant: {
+        role: "assistant",
+        content: [{ type: "text", text: "reply" }],
+      },
+    });
+
+    // The conversation is pinned to a profile via its row.
+    mockGetConversationOverrideProfile = () => "quality-optimized";
+
+    // The tool executor reads these fields off the conversation at tool-call
+    // time, so they must reflect the wake's resolved turn while the loop runs.
+    const ctx = conversation as unknown as {
+      currentCallSite?: unknown;
+      currentTurnOverrideProfile?: unknown;
+    };
+    let observedCallSite: unknown;
+    let observedOverrideProfile: unknown;
+    const originalRun = conversation.agentLoop.run;
+    conversation.agentLoop.run = async (options: AgentLoopRunOptions) => {
+      observedCallSite = ctx.currentCallSite;
+      observedOverrideProfile = ctx.currentTurnOverrideProfile;
+      return originalRun(options);
+    };
+
+    await wakeAgentForOpportunity(
+      {
+        conversationId: conversation.conversationId,
+        hint: "x",
+        source: "unit-test",
+        callSite: "heartbeatAgent",
+      },
+      { resolveTarget: async () => conversation },
+    );
+
+    // During the run: the wake's call site and the conversation's pinned profile.
+    expect(observedCallSite).toBe("heartbeatAgent");
+    expect(observedOverrideProfile).toBe("quality-optimized");
+
+    // Restored afterwards so a queued user turn / background read can't inherit them.
+    expect(ctx.currentCallSite).toBeUndefined();
+    expect(ctx.currentTurnOverrideProfile).toBeUndefined();
+  });
+
   test("marks processing false even when the agent loop throws", async () => {
     const conversation = makeWakeConversation({
       conversationId: "conv-err-guard",

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -1114,6 +1114,19 @@ export async function wakeAgentForOpportunity(
         };
       }
 
+      // Wakes bypass `runAgentLoopImpl`, which is what stamps the live turn's
+      // call site and override profile onto the conversation for the tool
+      // executor to read. Without stamping them here, `subagent_spawn` (and
+      // usage attribution) see an unstamped context and resolve children under
+      // workspace defaults instead of the profile this wake actually runs
+      // under — so a wake on a conversation pinned to another profile spawns
+      // children under the wrong one. Restored in the `finally` so a queued
+      // user turn or a later background read never inherits the wake's stamps.
+      const priorCallSite = conversation.currentCallSite;
+      const priorTurnOverrideProfile = conversation.currentTurnOverrideProfile;
+      conversation.currentCallSite = callSite;
+      conversation.currentTurnOverrideProfile = overrideProfile;
+
       let updatedHistory: Message[];
       try {
         ({ history: updatedHistory } = await conversation.agentLoop.run({
@@ -1164,6 +1177,12 @@ export async function wakeAgentForOpportunity(
         // `processing` and drain the queue.
         runError = err instanceof Error ? err : new Error(String(err));
         return { invoked: true, producedToolCalls: false };
+      } finally {
+        // Restore the pre-wake values so a queued user turn or background read
+        // never observes the wake's stamps. (`runAgentLoopImpl` re-stamps both
+        // at the start of the next normal turn regardless.)
+        conversation.currentCallSite = priorCallSite;
+        conversation.currentTurnOverrideProfile = priorTurnOverrideProfile;
       }
 
       // The loop swallows provider rejections into a graceful no-output


### PR DESCRIPTION
## Summary
- Addresses a Codex **P2** on #35466 (already merged). Wakes (scheduled / opportunity / heartbeat) call `conversation.agentLoop.run` directly and **bypass `runAgentLoopImpl`** — which is the code that stamps the live turn's call site + override profile onto the conversation for the tool executor to read. So a wake-spawned `subagent_spawn` (and usage attribution) saw an *unstamped* context: `context.attribution` / `context.overrideProfile` / `context.invokingCallSite` were all override-less, and after the #35466 attribution-first reordering they short-circuited ahead of `getConversationOverrideProfile()` (which still recovered the pinned row). Net effect: a wake on a conversation pinned to another profile spawned children under the workspace default instead.
- Fix: the wake now stamps `conversation.currentCallSite` / `currentTurnOverrideProfile` with the call site + override profile it already resolves, around `agentLoop.run`, and restores them in a `finally`. This makes attribution reliable for wakes, so the existing attribution-first inheritance (incl. mix-arm pinning) resolves correctly. As a side benefit, usage attribution for wake tool-calls is now correct too.
- **Why stamping rather than a spawn.ts precedence tweak:** precedence alone can't resolve the underlying conflict — a normal-turn row-mix needs the resolved *arm* to win, while a wake row-pin needs the *row* to win, and both hinge on whether attribution is trustworthy. Stamping makes attribution trustworthy at the source, so no spawn.ts change is needed.
- Test: a wake on a pinned conversation exposes the resolved call site + pinned profile to the loop during the run, and restores both afterward.

## Original prompt
Codex left a P2 on the merged #35466 noting that the attribution-first inheritance ordering regressed wakes: wakes don't stamp the live-turn fields that attribution reads, so an override-less attribution short-circuited `getConversationOverrideProfile()` (which still recovered the pinned row), spawning children under the wrong profile. The request was to address it if correct (it is) in a new PR.