### PR TITLE
test(migrations): give vbundle fd-leak export test a 30s timeout

### DIFF
--- a/assistant/src/runtime/migrations/__tests__/vbundle-builder-fd-leak.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/vbundle-builder-fd-leak.test.ts
@@ -119,5 +119,8 @@ describe("streamExportVBundle — descriptor lifecycle", () => {
       // incidental descriptors (temp output file already cleaned up, jitter).
       expect(delta).toBeLessThan(8);
     },
+    // Two full exports of a multi-megabyte workspace (hash pass + tar pass each)
+    // do real disk I/O; the default 5s budget is tight under loaded CI runners.
+    30_000,
   );
 });


### PR DESCRIPTION
## Summary
- The `vbundle-builder-fd-leak` regression test (added in #35435) timed out at 5049ms against the 5000ms bun default on a loaded CI runner, failing the main "Test" job.
- The test does heavy real disk I/O — two full vbundle exports of a multi-megabyte workspace (hash pass + tar pass each) — so the default budget is too tight under CI load. This is a flaky timeout (49ms over), not a behavioral regression.
- Add an explicit 30s timeout, matching the convention sibling heavy vbundle tests already use (`vbundle-streaming-importer` uses 60s).

## Original prompt
Fix the specific CI failure in the "Test" job of CI run 27842252705 on main, and only that job. Investigation showed the sole failure was a flaky timeout in the brand-new fd-leak regression test (5049ms vs the 5000ms default), so the fix is scoped to giving that one test a generous, explicit timeout.