### PR TITLE
fix(web): preserve chat composer draft across reloads

### DIFF
--- a/clients/web/src/domains/chat/active-chat-view.tsx
+++ b/clients/web/src/domains/chat/active-chat-view.tsx
@@ -44,6 +44,7 @@ import { useActiveAssistantIsPlatformHosted } from "@/hooks/use-platform-gate";
 import { useComposerStore } from "@/domains/chat/composer-store";
 
 import { useConversationLoader } from "@/domains/chat/hooks/use-conversation-loader";
+import { useDraftPersistence } from "@/domains/chat/hooks/use-draft-persistence";
 import { useOnboardingOrchestrator } from "@/domains/chat/hooks/use-onboarding-orchestrator";
 
 import { useConversationSecondaryActions } from "@/domains/chat/hooks/use-conversation-secondary-actions";
@@ -193,6 +194,10 @@ export function ActiveChatView() {
       useComposerStore.getState().loadAssistantDrafts(assistantId, prevConvId);
     }
   }, [assistantId]);
+
+  // Persist the composer draft across reloads (debounced autosave + unload
+  // flush) and restore it on cold load.
+  useDraftPersistence();
 
   // Keyboard focus: Electron host focus relay + typing auto-focus.
   useComposerKeyboard(inputRef);

--- a/clients/web/src/domains/chat/composer-store.test.ts
+++ b/clients/web/src/domains/chat/composer-store.test.ts
@@ -237,6 +237,65 @@ describe("saveDraft and clearDraft", () => {
 });
 
 // ---------------------------------------------------------------------------
+// restoreDraftIfEmpty — cold-load restore (page reload)
+// ---------------------------------------------------------------------------
+
+describe("restoreDraftIfEmpty", () => {
+  beforeEach(() => {
+    getStore().setInput("");
+    getStore().clearRestoredDraftNotice();
+  });
+
+  test("restores a saved draft into an empty composer and fires the notice", () => {
+    getStore().loadAssistantDrafts("assistant-1");
+    getStore().saveDraft("conv-A", "recovered text");
+    getStore().setInput("");
+
+    getStore().restoreDraftIfEmpty("conv-A");
+
+    expect(getStore().input).toBe("recovered text");
+    expect(getStore().restoredDraftConversationId).toBe("conv-A");
+  });
+
+  test("does not clobber existing composer text (e.g. deep-link prefill)", () => {
+    getStore().loadAssistantDrafts("assistant-1");
+    getStore().saveDraft("conv-A", "saved draft");
+    getStore().setInput("user is mid-sentence");
+
+    getStore().restoreDraftIfEmpty("conv-A");
+
+    expect(getStore().input).toBe("user is mid-sentence");
+    expect(getStore().restoredDraftConversationId).toBeNull();
+  });
+
+  test("no-op when there is no saved draft for the key", () => {
+    getStore().loadAssistantDrafts("assistant-1");
+    getStore().setInput("");
+
+    getStore().restoreDraftIfEmpty("conv-unknown");
+
+    expect(getStore().input).toBe("");
+    expect(getStore().restoredDraftConversationId).toBeNull();
+  });
+
+  test("does not restore a whitespace-only stored draft", () => {
+    // Inject a whitespace-only draft directly into the persisted blob so the
+    // trim guard is exercised (saveDraft itself never stores whitespace).
+    localSettingsStore.set(
+      "vellum:chatDrafts:assistant-1",
+      JSON.stringify({ "conv-A": "   " }),
+    );
+    getStore().loadAssistantDrafts("assistant-1");
+    getStore().setInput("");
+
+    getStore().restoreDraftIfEmpty("conv-A");
+
+    expect(getStore().input).toBe("");
+    expect(getStore().restoredDraftConversationId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Attachment lifecycle basics
 // ---------------------------------------------------------------------------
 

--- a/clients/web/src/domains/chat/composer-store.ts
+++ b/clients/web/src/domains/chat/composer-store.ts
@@ -182,6 +182,13 @@ export interface ComposerActions {
   ) => void;
   /** Clear the restored draft notice. */
   clearRestoredDraftNotice: () => void;
+  /**
+   * Restore the saved draft for `key` into the composer — but only when the
+   * composer is empty, so cold-load restore (page reload) never clobbers text
+   * already present from a deep link or starter prefill. Surfaces the "Draft
+   * restored" notice when it acts.
+   */
+  restoreDraftIfEmpty: (key: string) => void;
 
   // --- Attachment actions ---
   addFiles: (files: FileList | File[], assistantId: string | null) => void;
@@ -294,6 +301,13 @@ const useComposerStoreBase = create<ComposerStore>()((set, get) => ({
 
   clearRestoredDraftNotice: () => {
     set({ restoredDraftConversationId: null });
+  },
+
+  restoreDraftIfEmpty: (key) => {
+    const saved = draftsMap.get(key);
+    if (saved && saved.trim() && !get().input.trim()) {
+      set({ input: saved, restoredDraftConversationId: key });
+    }
   },
 
   // --- Attachment actions ---

--- a/clients/web/src/domains/chat/hooks/use-draft-persistence.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-draft-persistence.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for use-draft-persistence — keeps the composer draft alive across
+ * reloads via debounced autosave, an unload flush, and cold-load restore.
+ */
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+// Observe draft persistence through a local map instead of the real
+// localStorage (happy-dom doesn't persist across tests). Matches the approach
+// in composer-store.test.ts.
+const localSettingsStore = new Map<string, string>();
+mock.module("@/utils/local-settings", () => ({
+  getLocalSetting: (key: string, fallback: string) =>
+    localSettingsStore.get(key) ?? fallback,
+  setLocalSetting: (key: string, value: string) => {
+    localSettingsStore.set(key, value);
+  },
+}));
+mock.module("@/domains/chat/api/messages", () => ({
+  uploadChatAttachment: mock(async () => ({ ok: true, id: "mock-id" })),
+}));
+mock.module(
+  "@/domains/chat/components/chat-attachments/attachment-image-resize",
+  () => ({
+    IMAGE_AUTO_RESIZE_SOURCE_LIMIT_BYTES: 100 * 1024 * 1024,
+    isAutoResizableImage: () => false,
+    prepareImageAttachmentForUpload: async (file: File) => ({
+      status: "unchanged" as const,
+      file,
+    }),
+  }),
+);
+
+const { useComposerStore } = await import("@/domains/chat/composer-store");
+const { useConversationStore } = await import("@/stores/conversation-store");
+const { useDraftPersistence } = await import("./use-draft-persistence");
+
+// Comfortably greater than the hook's AUTOSAVE_DEBOUNCE_MS (300).
+const DEBOUNCE_WAIT_MS = 400;
+
+function setActiveConversation(id: string | null) {
+  act(() => {
+    useConversationStore.setState({ activeConversationId: id });
+  });
+}
+
+function storedDraft(assistantId: string, key: string): string | undefined {
+  const raw = localSettingsStore.get(`vellum:chatDrafts:${assistantId}`);
+  return raw ? (JSON.parse(raw)[key] as string | undefined) : undefined;
+}
+
+beforeEach(() => {
+  localSettingsStore.clear();
+  useComposerStore.getState().fullReset();
+  act(() => {
+    useComposerStore.setState({ input: "", restoredDraftConversationId: null });
+    useConversationStore.setState({ activeConversationId: null });
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  localSettingsStore.clear();
+});
+
+describe("cold-load restore", () => {
+  test("restores the saved draft for the active conversation on mount", () => {
+    useComposerStore.getState().loadAssistantDrafts("assistant-1");
+    useComposerStore.getState().saveDraft("conv-A", "recovered after reload");
+    act(() => useComposerStore.setState({ input: "" }));
+    setActiveConversation("conv-A");
+
+    renderHook(() => useDraftPersistence());
+
+    expect(useComposerStore.getState().input).toBe("recovered after reload");
+    expect(useComposerStore.getState().restoredDraftConversationId).toBe(
+      "conv-A",
+    );
+  });
+
+  test("does not clobber text already in the composer", () => {
+    useComposerStore.getState().loadAssistantDrafts("assistant-1");
+    useComposerStore.getState().saveDraft("conv-A", "saved draft");
+    act(() => useComposerStore.setState({ input: "deep-link prefill" }));
+    setActiveConversation("conv-A");
+
+    renderHook(() => useDraftPersistence());
+
+    expect(useComposerStore.getState().input).toBe("deep-link prefill");
+  });
+});
+
+describe("unload flush", () => {
+  test("pagehide synchronously persists the in-progress draft", () => {
+    useComposerStore.getState().loadAssistantDrafts("assistant-1");
+    setActiveConversation("conv-A");
+    renderHook(() => useDraftPersistence());
+
+    act(() => {
+      useComposerStore.getState().setInput("typed but not yet autosaved");
+    });
+    // Fire pagehide before the debounce window elapses.
+    act(() => {
+      window.dispatchEvent(new Event("pagehide"));
+    });
+
+    expect(storedDraft("assistant-1", "conv-A")).toBe(
+      "typed but not yet autosaved",
+    );
+  });
+});
+
+describe("debounced autosave", () => {
+  test("persists the draft after the debounce window", async () => {
+    useComposerStore.getState().loadAssistantDrafts("assistant-1");
+    setActiveConversation("conv-A");
+    renderHook(() => useDraftPersistence());
+
+    act(() => {
+      useComposerStore.getState().setInput("autosaved text");
+    });
+    // Nothing written yet — the save is debounced.
+    expect(storedDraft("assistant-1", "conv-A")).toBeUndefined();
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, DEBOUNCE_WAIT_MS));
+    });
+
+    expect(storedDraft("assistant-1", "conv-A")).toBe("autosaved text");
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-draft-persistence.ts
+++ b/clients/web/src/domains/chat/hooks/use-draft-persistence.ts
@@ -1,0 +1,96 @@
+/**
+ * use-draft-persistence — keep the chat composer draft alive across reloads.
+ *
+ * The composer's text lives in `composer-store` and is persisted to localStorage
+ * only at discrete moments (conversation switch, assistant switch,
+ * pull-to-refresh, send). A page reload — Vite HMR full reload, Cmd-R, or app
+ * restart — hits none of those, so without this hook the in-progress draft is
+ * lost. This hook closes both ends of that gap:
+ *
+ * - **Debounced autosave** on every input change (survives a crash / force-quit).
+ * - **Synchronous flush** on `pagehide` / `visibilitychange` → hidden — the path
+ *   a reload actually takes. `visibilitychange` also covers iOS/Capacitor, where
+ *   `pagehide` is unreliable.
+ * - **Cold-load restore**: when a conversation first becomes active, restore its
+ *   saved draft into an empty composer.
+ *
+ * Drafts are keyed by `activeConversationId`, which is reload-stable: new chats
+ * carry a `draft-…` id in the URL and the id is re-derived from the URL on load.
+ *
+ * Self-contained — reads both stores directly, so it mounts once with no props.
+ */
+
+import { useEffect, useRef } from "react";
+
+import { useComposerStore } from "@/domains/chat/composer-store";
+import { useConversationStore } from "@/stores/conversation-store";
+
+const AUTOSAVE_DEBOUNCE_MS = 300;
+
+export function useDraftPersistence(): void {
+  // --- Debounced autosave + unload flush -----------------------------------
+  // Registered once; reads the latest state at fire time. Driven by
+  // `store.subscribe` (not a reactive selector) so per-keystroke input changes
+  // never re-render the host component.
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const unsubscribe = useComposerStore.subscribe((state, prev) => {
+      if (state.input === prev.input) return;
+      // Capture key + value at change time so a mid-debounce conversation switch
+      // can't mis-file this draft.
+      const key = useConversationStore.getState().activeConversationId;
+      const value = state.input;
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        // Only write when this conversation is still active — guards the switch
+        // race (never persist conversation B's text under conversation A).
+        if (key && useConversationStore.getState().activeConversationId === key) {
+          useComposerStore.getState().saveDraft(key, value);
+        }
+      }, AUTOSAVE_DEBOUNCE_MS);
+    });
+
+    const flush = () => {
+      if (timer) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+      const key = useConversationStore.getState().activeConversationId;
+      if (key) {
+        // saveDraft deletes the entry when the text is empty, so clearing the
+        // composer then reloading correctly leaves nothing to restore.
+        useComposerStore.getState().saveDraft(key, useComposerStore.getState().input);
+      }
+    };
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "hidden") flush();
+    };
+
+    window.addEventListener("pagehide", flush);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      flush();
+      if (timer) clearTimeout(timer);
+      unsubscribe();
+      window.removeEventListener("pagehide", flush);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, []);
+
+  // --- Cold-load restore ---------------------------------------------------
+  // When a conversation first becomes active (page load / navigation), restore
+  // its saved draft. `restoreDraftIfEmpty` no-ops when the composer already has
+  // text, so this never fights `handleConversationSwitch` (which owns switch-time
+  // restore) and never clobbers a deep-link / starter prefill.
+  const activeConversationId = useConversationStore.use.activeConversationId();
+  const restoredKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!activeConversationId) return;
+    if (restoredKeyRef.current === activeConversationId) return;
+    restoredKeyRef.current = activeConversationId;
+    useComposerStore.getState().restoreDraftIfEmpty(activeConversationId);
+  }, [activeConversationId]);
+}


### PR DESCRIPTION
## Summary
- Persist the chat composer's in-progress text across page reloads (Vite HMR full reload, Cmd-R, app restart) so it's no longer lost. A new `useDraftPersistence` hook adds debounced autosave on keystroke plus a synchronous `pagehide` / `visibilitychange`→hidden flush, both keyed by the reload-stable active conversation id.
- Restore the saved draft on cold load via a new `restoreDraftIfEmpty` composer-store action — it only restores into an *empty* composer, so it never clobbers a deep-link or starter prefill, and it surfaces the existing "Draft restored from your previous session." banner. This closes the gap where the sole restore path (`handleConversationSwitch`) early-returns on first mount (`previousKey === null`).
- Reuses the existing per-conversation `vellum:chatDrafts:<assistantId>` localStorage machinery (`saveDraft`/`restoreDraftIfEmpty`) — no new storage format and no change to the existing switch logic. Adds unit tests for the new store action and the hook (autosave, flush, cold-load restore).

## Original prompt
When the Electron app hot-reloads during development, any text typed into the chat composer is lost. The composer's text lives in a Zustand store and was only persisted to localStorage at discrete moments (conversation/assistant switch, pull-to-refresh, send) — a reload hit none of those, and the one restore path skipped the first-mount case. The ask was to preserve the in-progress draft across reloads and restore it on load, showing the existing "Draft restored" banner.