### PR TITLE
fix(web): preserve resizable side-panel width across hot reloads

### DIFF
--- a/clients/web/src/domains/chat/components/animated-right-drawer.tsx
+++ b/clients/web/src/domains/chat/components/animated-right-drawer.tsx
@@ -111,7 +111,9 @@ export function AnimatedRightDrawer({
   const clamp = useCallback(
     (next: number) => {
       const container = containerRef.current;
-      if (!container) return Math.max(minWidth, next);
+      // Unmeasured container (offsetWidth 0): keep the requested width instead
+      // of collapsing to the minimum on a negative max.
+      if (!container || container.offsetWidth <= 0) return Math.max(minWidth, next);
       const maxWidth = Math.max(
         minWidth,
         container.offsetWidth - minLeftWidth - SEPARATOR_WIDTH_PX,

--- a/packages/design-library/src/components/resizable-panel.tsx
+++ b/packages/design-library/src/components/resizable-panel.tsx
@@ -104,7 +104,9 @@ export function ResizablePanel({
   const clamp = useCallback(
     (width: number) => {
       const container = containerRef.current;
-      if (!container) return width;
+      // Unmeasured container (offsetWidth 0): keep the requested width instead
+      // of collapsing to the minimum on a negative max.
+      if (!container || container.offsetWidth <= 0) return width;
       const maxLeft = container.offsetWidth - minRightWidth;
       return Math.max(minLeftWidth, Math.min(width, maxLeft));
     },


### PR DESCRIPTION
## Summary
- `AnimatedRightDrawer` (the Thought-process / right-hand detail drawer) and the shared `ResizablePanel` lost their dragged width on a Vite/React Fast Refresh hot reload — snapping back to the minimum — while a full Cmd+R reload restored it correctly.
- Root cause: the mount/resize re-clamp effect re-runs on every Fast Refresh; when it fires while the container is mid-layout (`offsetWidth === 0`), `clamp` computes a negative max and collapses the width to the minimum. That path never writes `localStorage`, so the persisted value stays correct (hence Cmd+R works) but the live state collapses.
- Fix: guard `clamp` in both components to keep the requested width when the container is unmeasured (`offsetWidth <= 0`), so width only shrinks against a real measurement.

## Original prompt
While running the Electron app via `bun run dev`, resizing the Thought process panel wider wasn't preserved across hot reloads (it snapped back to the default width), even though the width survived a manual Cmd+R. The task was to find why the resize persisted across a full reload but not a hot reload, and fix it so the dragged width survives both.