### PR TITLE
feat(skills): expose loaded skill tools first-class to weak open models

### DIFF
--- a/assistant/src/__tests__/conversation-skill-tools.test.ts
+++ b/assistant/src/__tests__/conversation-skill-tools.test.ts
@@ -372,7 +372,9 @@ describe("projectSkillTools", () => {
       previouslyActiveSkillIds: sessionState,
     });
 
-    // Tool definitions are no longer sent to the LLM — tools are invoked via skill_execute dispatch.
+    // Tool definitions are not sent to the LLM here — tools are invoked via
+    // skill_execute dispatch; weak-open-model first-class exposure resolves
+    // defs from the registry by name in createResolveToolsCallback.
     expect(result.toolDefinitions).toEqual([]);
     expect(result.allowedToolNames).toEqual(
       new Set(["deploy_run", "deploy_status"]),

--- a/assistant/src/__tests__/first-class-skill-defs.test.ts
+++ b/assistant/src/__tests__/first-class-skill-defs.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for resolveFirstClassSkillDefs: weak open models get loaded skill tools
+ * exposed first-class (resolved from the registry by name), capable models do
+ * not, and the turn allowlist still gates which defs are included.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { resolveFirstClassSkillDefs } from "../daemon/conversation-tool-setup.js";
+import { RiskLevel } from "../permissions/types.js";
+import { registerSkillTools, unregisterSkillTools } from "../tools/registry.js";
+import type { Tool } from "../tools/types.js";
+
+const MINIMAX = "accounts/fireworks/models/minimax-m3";
+const CLAUDE = "claude-opus-4-8";
+
+const SKILL_ID = "first-class-test-skill";
+
+function makeSkillTool(name: string): Tool {
+  return {
+    name,
+    description: `Test tool ${name}`,
+    category: "testing",
+    defaultRiskLevel: RiskLevel.Low,
+    executionTarget: "host",
+    input_schema: {
+      type: "object",
+      properties: { content: { type: "string" } },
+      required: ["content"],
+    },
+    execute: async () => ({ content: "", isError: false }),
+  };
+}
+
+describe("resolveFirstClassSkillDefs", () => {
+  beforeEach(() => {
+    registerSkillTools(SKILL_ID, [
+      makeSkillTool("document_update"),
+      makeSkillTool("document_create"),
+    ]);
+  });
+
+  afterEach(() => {
+    unregisterSkillTools(SKILL_ID);
+  });
+
+  const allowed = new Set(["document_update", "document_create"]);
+  const turnAllowed = new Set([
+    "document_update",
+    "document_create",
+    "skill_execute",
+  ]);
+
+  test("exposes loaded skill tools for a weak open model", () => {
+    const defs = resolveFirstClassSkillDefs(allowed, turnAllowed, MINIMAX);
+    expect(defs.map((d) => d.name).sort()).toEqual([
+      "document_create",
+      "document_update",
+    ]);
+  });
+
+  test("returns nothing for a capable model", () => {
+    const defs = resolveFirstClassSkillDefs(allowed, turnAllowed, CLAUDE);
+    expect(defs).toEqual([]);
+  });
+
+  test("returns nothing when the model is unknown/absent", () => {
+    expect(resolveFirstClassSkillDefs(allowed, turnAllowed, null)).toEqual([]);
+    expect(resolveFirstClassSkillDefs(allowed, turnAllowed, undefined)).toEqual(
+      [],
+    );
+  });
+
+  test("respects the turn allowlist (subagent / exclude gating)", () => {
+    // Only document_update is allowed this turn — document_create is filtered.
+    const restricted = new Set(["document_update", "skill_execute"]);
+    const defs = resolveFirstClassSkillDefs(allowed, restricted, MINIMAX);
+    expect(defs.map((d) => d.name)).toEqual(["document_update"]);
+  });
+
+  test("skips names with no registered tool", () => {
+    const withGhost = new Set([...allowed, "not_registered"]);
+    const turn = new Set([...turnAllowed, "not_registered"]);
+    const defs = resolveFirstClassSkillDefs(withGhost, turn, MINIMAX);
+    expect(defs.map((d) => d.name).sort()).toEqual([
+      "document_create",
+      "document_update",
+    ]);
+  });
+
+  test("each exposed def carries its real scalar schema (single-escape)", () => {
+    const defs = resolveFirstClassSkillDefs(allowed, turnAllowed, MINIMAX);
+    const update = defs.find((d) => d.name === "document_update");
+    expect(update?.input_schema).toMatchObject({
+      properties: { content: { type: "string" } },
+      required: ["content"],
+    });
+  });
+});

--- a/assistant/src/__tests__/skill-tool-factory.test.ts
+++ b/assistant/src/__tests__/skill-tool-factory.test.ts
@@ -255,6 +255,24 @@ describe("createSkillTool — unknown parameter validation", () => {
     expect(result.isError).toBe(false);
   });
 
+  test("strips the harness `activity` field before validation", async () => {
+    const hash = computeSkillVersionHash(tempDir);
+    const tool = createSkillTool(
+      makeEntry({ executor: "echo.ts" }),
+      tempDir,
+      hash,
+    );
+
+    // A first-class skill-tool call may carry `activity` (the harness progress
+    // field). It must not be rejected as an unknown parameter.
+    const result = await tool.execute(
+      { query: "hello", activity: "Doing the thing" },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+  });
+
   test("allows empty input when schema has no required fields", async () => {
     const hash = computeSkillVersionHash(tempDir);
     const tool = createSkillTool(

--- a/assistant/src/daemon/conversation-skill-tools.ts
+++ b/assistant/src/daemon/conversation-skill-tools.ts
@@ -360,7 +360,10 @@ export function projectSkillTools(
     return { toolDefinitions: [], allowedToolNames: new Set() };
   }
 
-  // Tool definitions are no longer sent to the LLM — tools are invoked via skill_execute dispatch.
+  // Tool definitions are not sent to the LLM here — tools are invoked via
+  // skill_execute dispatch (capable models), and the weak-open-model
+  // first-class exposure resolves the registered defs from the registry in
+  // createResolveToolsCallback by name.
   const allToolNames = new Set<string>();
   const successfulEntries = new Map<string, string>();
   // Track skills already unregistered in the version-change branch so the

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -19,6 +19,7 @@ import type { PermissionPrompter } from "../permissions/prompter.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
 import { advisorEnabledForProfile } from "../plugins/defaults/advisor/advisor-gate.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
+import { isWeakOpenModel } from "../providers/weak-open-model.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { registerConversationSender } from "../tools/browser/browser-screencast.js";
 import type { ToolExecutor } from "../tools/executor.js";
@@ -682,6 +683,36 @@ export function isToolActiveForContext(
 }
 
 /**
+ * Resolve the loaded skill tools to expose first-class to weak open models.
+ *
+ * Weak open models (MiniMax, Kimi, DeepSeek, GLM) fail to serialize the nested
+ * `skill_execute` envelope — a large value double-escaped as a JSON string in
+ * `input` — and either drop it or emit it bare. Exposing each loaded skill
+ * tool first-class lets the model fill the tool's own scalar params directly
+ * (single-escape). Capable models keep the envelope-only contract: this returns
+ * `[]` for them, so their wire surface is unchanged.
+ *
+ * Defs are resolved from the registry by name; `skillToolNames` come from the
+ * projection (skill tools only), filtered by `turnAllowed` so subagent
+ * allowlists and the tool exclude list still apply. The generic `skill_execute`
+ * tool remains available as a fallback for both model tiers.
+ */
+export function resolveFirstClassSkillDefs(
+  skillToolNames: Iterable<string>,
+  turnAllowed: ReadonlySet<string>,
+  resolvedModel: string | null | undefined,
+): ToolDefinition[] {
+  if (!isWeakOpenModel(resolvedModel)) return [];
+  const defs: ToolDefinition[] = [];
+  for (const name of skillToolNames) {
+    if (!turnAllowed.has(name)) continue;
+    const tool = getTool(name);
+    if (tool) defs.push(tool);
+  }
+  return defs;
+}
+
+/**
  * Build a resolveTools callback that merges base tool definitions with
  * dynamically projected skill tools on each agent turn. Also updates
  * allowedToolNames so newly-activated skill tools aren't blocked by
@@ -810,7 +841,30 @@ export function createResolveToolsCallback(
     }
 
     ctx.allowedToolNames = turnAllowed;
-    const baseDefs = injectActivityField(allBaseDefs, ACTIVITY_SKIP_SET);
+
+    // Weak open models fail to serialize the nested `skill_execute` envelope
+    // (a large value double-escaped as a JSON string in `input`), so expose the
+    // loaded skill tools first-class — their scalar params are emitted directly
+    // (single-escape). The defs are resolved from the registry by name; the
+    // names are already in `turnAllowed`. The generic `skill_execute` stays
+    // available as a fallback, and capable models keep the envelope-only
+    // contract (this branch is skipped for them).
+    const resolvedModel = resolveConversationAttribution({
+      conversationId: ctx.conversationId ?? "",
+      currentCallSite: ctx.currentCallSite,
+      currentTurnOverrideProfile: ctx.currentTurnOverrideProfile,
+    })?.resolvedModel;
+    const baseDefs = [
+      ...injectActivityField(allBaseDefs, ACTIVITY_SKIP_SET),
+      ...injectActivityField(
+        resolveFirstClassSkillDefs(
+          projection.allowedToolNames,
+          turnAllowed,
+          resolvedModel,
+        ),
+        ACTIVITY_SKIP_SET,
+      ),
+    ];
 
     const config = getConfig();
     if (

--- a/assistant/src/tools/skills/skill-tool-factory.ts
+++ b/assistant/src/tools/skills/skill-tool-factory.ts
@@ -46,7 +46,12 @@ export function createSkillTool(
       context: ToolContext,
     ): Promise<ToolExecutionResult> {
       const schema = entry.input_schema as Record<string, unknown> | undefined;
-      const coercedInput = coerceStringBooleans(input, schema);
+      // `activity` is a harness field (the skill_execute envelope and
+      // first-class skill-tool exposure both surface it for progress display),
+      // never an inner tool parameter. Strip it before validation so a model
+      // that includes it on a direct call isn't rejected for an unknown field.
+      const { activity: _activity, ...rest } = input;
+      const coercedInput = coerceStringBooleans(rest, schema);
       const validation = validateInputAgainstSchema(
         entry.name,
         coercedInput,


### PR DESCRIPTION
## Why

The escape-burden root cause behind the MiniMax doc-writer failures (feedback `019ee07b`, `019ee120`). Token-proven: M3 can serialize a **small** field double-escaped (`input:"{\"content\":\"Test chunk.\"}"` → succeeded) but not a **large** one — for the 1772-char article it either emitted `input:""` or dumped the body as a bare string. The blocker is the nested `skill_execute` envelope: the MiniMax coercion rewrites `input` object→string, so passing `content` means a string-inside-a-string (double escape). #35456/#35457/#35475 reduced the surrounding friction and rescue the bare-string case, but couldn't make M3 produce the double-escaped large payload.

Key evidence this fix is sound: the **single-escaped** form is within M3's reach — it produced the full 1772-char article as a bare single-escaped string (1244 completion tokens). It just had nowhere valid to put it.

## What

For **weak open models only** (`isWeakOpenModel()` — MiniMax/Kimi/DeepSeek/GLM), expose each loaded skill tool **first-class** on the wire, alongside the generic `skill_execute`. The model then calls e.g. `document_update(content: "...")` directly — `content` is a top-level **scalar** param, single-escape, the shape M3 already produces. document-editor tools declare only scalar params, so the object→string coercion leaves them untouched.

- `resolveFirstClassSkillDefs(skillToolNames, turnAllowed, resolvedModel)` resolves the loaded skill tools from the registry by name, gated on the weak-model check and filtered by the turn allowlist (subagent / exclude gating still applies). `createResolveToolsCallback` appends them to the wire list.
- The skill-tool factory strips the harness `activity` field before validation so a first-class call carrying it isn't rejected as an unknown param (the `skill_execute` path already strips envelope keys upstream).
- The names are already in `allowedToolNames`, so the executor accepts direct calls — **no new dispatch plumbing**.

## ⚠️ Review focus — architectural

This **partially reverses the deliberate "tool definitions are no longer sent to the LLM — invoked via skill_execute dispatch" decision** (`conversation-skill-tools.ts:363`) — but **only for weak open models**, and **additively** (skill_execute + the #35475 bare-string rescue remain as fallback). Capable models are provably unchanged: `resolveFirstClassSkillDefs` returns `[]` for them, so their wire surface is identical.

Trade-offs to weigh:
- **Wire tokens** for weak-model conversations grow by the loaded skills' tool defs (e.g. ~10 document-editor tools). These are the cost-optimized models, so more tool tokens is a real cost — bounded by how many skills are loaded.
- **Two ways to call** a skill tool (first-class or via skill_execute) for weak models. Both dispatch through the same executor path; the typed first-class tool should be preferred by the model.
- Gating reads ground-truth `attribution.resolvedModel` (same source as #35155), so per-conversation model overrides are honored.

## Probe / rollout

This is the "probe-gated escape-burden change" discussed on the prior PRs. It ships gated to weak models and additive, so the empirical validation is the next MiniMax dogfood: does a long-article write now land `content` directly? The single-escape evidence (1244-token bare string) is the strong prior that it will.

## Test

`bun test src/__tests__/first-class-skill-defs.test.ts` — 6 pass (weak-model exposes defs, capable returns [], null/undefined model returns [], turn-allowlist gating, ghost-name skip, real scalar schema preserved). Plus `skill-tool-factory` activity-strip test, and existing `conversation-skill-tools` / `subagent-tool-*` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)