### PR TITLE
feat(plugins): install an older reviewed marketplace pin

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -20359,6 +20359,67 @@ paths:
             install-time baseline cannot be reconstructed.
         "503":
           description: The plugin source (GitHub) was temporarily unavailable; the upgrade is retryable.
+  /v1/plugins/{name}/versions:
+    get:
+      operationId: plugins_by_name_versions_get
+      summary: List a plugin's reviewed marketplace pins
+      description:
+        Report the distinct marketplace pins a plugin has been promoted to over time, newest first (the first entry
+        is the current pin), capped at `limit` (default 5). The curated `marketplace.json` stores only the current pin,
+        so this is reconstructed from the manifest's own commit history on the default branch — every entry is therefore
+        a reviewed, known-good revision. Pair with `POST /v1/plugins/install`'s `pin` field to roll a plugin back to an
+        older reviewed version. An unknown name (never in the manifest) returns an empty array, not 404.
+      tags:
+        - plugins
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Maximum number of pins to return (positive integer; default 5).
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    pin:
+                      type: string
+                      description: Plugin commit SHA pinned at this point in marketplace history.
+                    marketplaceCommit:
+                      type: string
+                      description: Marketplace-manifest commit to install this pin from (the newest commit carrying it).
+                    promotedAt:
+                      anyOf:
+                        - type: string
+                        - type: "null"
+                      description: ISO-8601 committer date (UTC) of the marketplace commit that promoted this pin; null when unreadable.
+                    current:
+                      type: boolean
+                      description: True for the pin currently active on the default branch.
+                  required:
+                    - pin
+                    - marketplaceCommit
+                    - promotedAt
+                    - current
+                  additionalProperties: false
+                description:
+                  Distinct marketplace pins a plugin has been promoted to, newest first; the first entry is the current pin.
+                  Empty when the plugin has no resolvable history.
+        "400":
+          description: The plugin name failed sanitization, or `limit` was not a positive integer.
+        "503":
+          description: The marketplace pin history could not be read from GitHub (rate-limited or upstream error); retryable.
   /v1/plugins/install:
     post:
       operationId: plugins_install_post
@@ -20385,6 +20446,13 @@ paths:
                 force:
                   description: Overwrite an existing install in place. Defaults to false.
                   type: boolean
+                pin:
+                  description:
+                    Install a specific reviewed marketplace pin (full commit SHA) instead of the current one. The pin is
+                    validated against the plugin's marketplace pin history (`GET /v1/plugins/:name/versions`) and
+                    installed from the marketplace revision that introduced it; an unreviewed SHA is rejected. Use this
+                    to roll a plugin back to an older reviewed version.
+                  type: string
               required:
                 - name
       responses:

--- a/assistant/src/cli/commands/plugins.ts
+++ b/assistant/src/cli/commands/plugins.ts
@@ -24,12 +24,20 @@ import {
 import {
   DEFAULT_PLUGIN_REF,
   installPlugin,
+  type InstallPluginOptions,
   InvalidPluginNameError,
   PluginAlreadyInstalledError,
   PluginNotFoundError,
 } from "../lib/install-from-github.js";
 import { listInstalledPlugins } from "../lib/list-installed-plugins.js";
 import type { FingerprintComparison } from "../lib/plugin-fingerprint.js";
+import {
+  DEFAULT_PIN_HISTORY_LIMIT,
+  listPinHistory,
+  type PluginPinHistoryEntry,
+  PluginPinHistoryError,
+  resolvePinToMarketplaceCommit,
+} from "../lib/plugin-pin-history.js";
 import { registerCommand } from "../lib/register-command.js";
 import {
   InvalidSearchPatternError,
@@ -65,6 +73,9 @@ Examples:
   $ assistant plugins install example
   $ assistant plugins install example --force
   $ assistant plugins install example --ref my-feature-branch
+  $ assistant plugins versions example
+  $ assistant plugins versions example --json
+  $ assistant plugins install example --pin <sha> --force
   $ assistant plugins list
   $ assistant plugins list --json
   $ assistant plugins inspect example
@@ -90,19 +101,35 @@ Examples:
         .option("--force", "Overwrite an existing install")
         .option(
           "--ref <ref>",
-          `Git ref to fetch from (default: ${DEFAULT_PLUGIN_REF})`,
+          `Marketplace manifest revision to read the pin from (default: ${DEFAULT_PLUGIN_REF})`,
+        )
+        .option(
+          "--pin <sha>",
+          "Install a specific reviewed marketplace pin (full commit SHA); run `plugins versions <name>` to list them",
+        )
+        .option(
+          "--allow-unreviewed",
+          "With --pin, install a SHA that is not in the reviewed marketplace history (advanced; the curated adapter may not match)",
         )
         .action(
-          async (name: string, opts: { force?: boolean; ref?: string }) => {
+          async (
+            name: string,
+            opts: {
+              force?: boolean;
+              ref?: string;
+              pin?: string;
+              allowUnreviewed?: boolean;
+            },
+          ) => {
             try {
-              const result = await installPlugin(
-                {
-                  name,
-                  force: opts.force ?? false,
-                  ref: opts.ref ?? DEFAULT_PLUGIN_REF,
-                },
-                { fetch: globalThis.fetch.bind(globalThis) },
-              );
+              const installOpts = await resolveInstallOptions(name, opts);
+              if (installOpts === null) {
+                process.exitCode = 1;
+                return;
+              }
+              const result = await installPlugin(installOpts, {
+                fetch: globalThis.fetch.bind(globalThis),
+              });
               log.info(
                 {
                   name: result.name,
@@ -131,8 +158,71 @@ Examples:
                 process.exitCode = 1;
                 return;
               }
+              if (
+                err instanceof InvalidPluginNameError ||
+                err instanceof PluginPinHistoryError
+              ) {
+                console.error(err.message);
+                process.exitCode = 1;
+                return;
+              }
               const message = err instanceof Error ? err.message : String(err);
               console.error(`Plugin install failed: ${message}`);
+              process.exitCode = 1;
+            }
+          },
+        );
+
+      plugins
+        .command("versions <name>")
+        .description(
+          "List the recent reviewed marketplace pins for a plugin, newest first. Install an older one with `plugins install <name> --pin <sha>`",
+        )
+        .option("--json", "Emit machine-readable JSON instead of a table")
+        .option(
+          "--limit <n>",
+          `Maximum number of pins to show (default: ${DEFAULT_PIN_HISTORY_LIMIT})`,
+        )
+        .action(
+          async (name: string, opts: { json?: boolean; limit?: string }) => {
+            let limit: number | undefined;
+            if (opts.limit !== undefined) {
+              limit = Number.parseInt(opts.limit, 10);
+              if (!Number.isInteger(limit) || limit < 1) {
+                console.error("--limit must be a positive integer.");
+                process.exitCode = 1;
+                return;
+              }
+            }
+            try {
+              const history = await listPinHistory(
+                name,
+                { fetch: globalThis.fetch.bind(globalThis) },
+                limit !== undefined ? { limit } : {},
+              );
+
+              if (opts.json) {
+                process.stdout.write(JSON.stringify(history, null, 2) + "\n");
+                return;
+              }
+
+              // Logged after the JSON early-return so the logger's stdout
+              // writes never corrupt --json output.
+              log.info({ name, count: history.length }, "plugin versions");
+              for (const line of formatVersions(name, history)) {
+                console.log(line);
+              }
+            } catch (err) {
+              if (
+                err instanceof InvalidPluginNameError ||
+                err instanceof PluginPinHistoryError
+              ) {
+                console.error(err.message);
+                process.exitCode = 1;
+                return;
+              }
+              const message = err instanceof Error ? err.message : String(err);
+              console.error(`Plugin versions failed: ${message}`);
               process.exitCode = 1;
             }
           },
@@ -483,6 +573,109 @@ Examples:
 }
 
 /** Abbreviate a commit SHA for display; passes through non-SHA / null values. */
+/** Full Git commit SHA — 40 hex (SHA-1) or 64 (SHA-256). */
+const FULL_SHA_RE = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
+
+/**
+ * Resolve `plugins install` flags into {@link InstallPluginOptions}, or `null`
+ * when the flag combination is invalid (a message is printed in that case, and
+ * the caller exits non-zero). Network / marketplace failures raised while
+ * resolving a `--pin` propagate to the caller's catch.
+ *
+ * `--pin <sha>` installs a specific reviewed marketplace pin: the SHA is looked
+ * up in the plugin's pin history and installed from the marketplace commit that
+ * introduced it, so the curated adapter stub of that era comes along. With
+ * `--allow-unreviewed` the SHA is materialized directly (adapter from `main`),
+ * bypassing the history check — the advanced escape hatch.
+ */
+async function resolveInstallOptions(
+  name: string,
+  opts: {
+    force?: boolean;
+    ref?: string;
+    pin?: string;
+    allowUnreviewed?: boolean;
+  },
+): Promise<InstallPluginOptions | null> {
+  const force = opts.force ?? false;
+
+  if (!opts.pin) {
+    if (opts.allowUnreviewed) {
+      console.error("--allow-unreviewed only applies together with --pin.");
+      return null;
+    }
+    return { name, force, ref: opts.ref ?? DEFAULT_PLUGIN_REF };
+  }
+
+  const pin = opts.pin.trim();
+  if (!FULL_SHA_RE.test(pin)) {
+    console.error(
+      `--pin must be a full commit SHA (40 or 64 hex chars); got ${JSON.stringify(opts.pin)}.`,
+    );
+    return null;
+  }
+  if (opts.ref) {
+    console.error(
+      "--ref and --pin cannot be combined; --pin already selects the revision.",
+    );
+    return null;
+  }
+
+  if (opts.allowUnreviewed) {
+    // Materialize the exact SHA from the plugin's current-manifest repo,
+    // bypassing the reviewed-history check. The adapter stub still comes from
+    // the default ref, so an adapted plugin may not reproduce faithfully.
+    return { name, force, ref: DEFAULT_PLUGIN_REF, commitOverride: pin };
+  }
+
+  const entry = await resolvePinToMarketplaceCommit(name, pin, {
+    fetch: globalThis.fetch.bind(globalThis),
+  });
+  if (!entry) {
+    console.error(
+      `"${pin}" is not a reviewed marketplace pin for "${name}".\n` +
+        `Run \`assistant plugins versions ${name}\` to see available pins, ` +
+        "or pass --allow-unreviewed to install it anyway.",
+    );
+    return null;
+  }
+  return { name, force, ref: entry.marketplaceCommit };
+}
+
+/**
+ * Render a plugin's marketplace-pin history as a table: the pinned commit (short
+ * SHA), when it was promoted, and a marker for the pin currently active. An
+ * empty history reports that none was found.
+ */
+function formatVersions(
+  name: string,
+  history: readonly PluginPinHistoryEntry[],
+): string[] {
+  if (history.length === 0) {
+    return [`No marketplace pin history found for "${name}".`];
+  }
+  const rows = history.map((entry) => ({
+    pin: shortSha(entry.pin),
+    promoted: formatTimestamp(entry.promotedAt),
+    marker: entry.current ? "(current)" : "",
+  }));
+  const pinW = Math.max(3, ...rows.map((r) => r.pin.length));
+  const promotedW = Math.max(8, ...rows.map((r) => r.promoted.length));
+  const pad = (s: string, w: number) => s + " ".repeat(w - s.length);
+  const lines = [
+    `${pad("PIN", pinW)}  ${pad("PROMOTED", promotedW)}  `.trimEnd(),
+  ];
+  for (const r of rows) {
+    lines.push(
+      `${pad(r.pin, pinW)}  ${pad(r.promoted, promotedW)}  ${r.marker}`.trimEnd(),
+    );
+  }
+  lines.push("");
+  lines.push("Install an older pin with:");
+  lines.push(`  assistant plugins install ${name} --pin <sha> --force`);
+  return lines;
+}
+
 function shortSha(sha: string | null): string {
   return sha ? sha.slice(0, 7) : "—";
 }

--- a/assistant/src/cli/lib/__tests__/install-from-github.test.ts
+++ b/assistant/src/cli/lib/__tests__/install-from-github.test.ts
@@ -32,6 +32,7 @@ import {
   PluginPostinstallError,
   PluginSourceUnavailableError,
   type PostinstallRunner,
+  readInstallMeta,
   sanitizePluginName,
 } from "../install-from-github.js";
 
@@ -290,6 +291,36 @@ describe("installPlugin — install lifecycle", () => {
     expect(existsSync(join(target, "stale.txt"))).toBe(false);
     expect(existsSync(join(target, "package.json"))).toBe(true);
     expect(existsSync(join(target, "README.md"))).toBe(true);
+  });
+
+  test("commitOverride materializes a specific commit, keeping repo from the manifest", async () => {
+    // GIVEN a manifest pinning the current SHA, but an override to an older one
+    const OLD_SHA = "1".repeat(40);
+    const fetch = makeContentsFetch({ tree: {}, manifest: CAVEMAN_MANIFEST });
+    const calls: string[][] = [];
+    const runGit = fakeGitRunner({
+      tree: { "package.json": '{"name":"caveman"}' },
+      commit: OLD_SHA,
+      calls,
+    });
+
+    // WHEN we install with the commit override
+    const result = await installPlugin(
+      { name: "caveman", force: false, ref: "main", commitOverride: OLD_SHA },
+      { fetch, runGit, workspacePluginsDir: pluginsDir },
+    );
+
+    // THEN the clone fetched the override commit, not the manifest's pin
+    expect(calls.find((c) => c[0] === "fetch")?.at(-1)).toBe(OLD_SHA);
+    expect(result.commit).toBe(OLD_SHA);
+    expect(result.ref).toBe(OLD_SHA);
+
+    // AND provenance records the override as the installed ref while still
+    // resolving owner/repo from the manifest entry
+    const meta = readInstallMeta(join(pluginsDir, "caveman"));
+    expect(meta?.source.ref).toBe(OLD_SHA);
+    expect(meta?.source.repo).toBe("caveman");
+    expect(meta?.source.owner).toBe("JuliusBrussee");
   });
 
   test("--force preserves the existing install when the clone fails", async () => {

--- a/assistant/src/cli/lib/__tests__/plugin-pin-history.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-pin-history.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for {@link listPinHistory} and {@link resolvePinToMarketplaceCommit}.
+ *
+ * The marketplace manifest stores only the current pin, so pin history is
+ * reconstructed by walking the manifest's commit history and reading the
+ * plugin's pin at each commit. The fixtures model that timeline with an
+ * in-memory `fetch`: a commits-list endpoint plus a manifest-at-ref endpoint
+ * keyed by commit SHA.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { FetchLike } from "../install-from-github.js";
+import {
+  listPinHistory,
+  resolvePinToMarketplaceCommit,
+} from "../plugin-pin-history.js";
+
+const PIN_A = "a".repeat(40);
+const PIN_B = "b".repeat(40);
+const PIN_C = "c".repeat(40);
+
+// Marketplace-manifest commits, newest → oldest. `C2B` touches the manifest
+// without changing this plugin's pin (a bump for some other plugin), so it must
+// collapse into the same distinct pin as `C3`.
+const C3 = "3".repeat(40);
+const C2B = "d".repeat(40);
+const C2 = "2".repeat(40);
+const C1 = "1".repeat(40);
+
+const COMMIT_DATES: Record<string, string> = {
+  [C3]: "2026-06-10T00:00:00.000Z",
+  [C2B]: "2026-06-08T00:00:00.000Z",
+  [C2]: "2026-06-05T00:00:00.000Z",
+  [C1]: "2026-06-01T00:00:00.000Z",
+};
+
+/** Plugin pin resolved from the manifest at each ref (`main` = current tip). */
+const PIN_BY_REF: Record<string, string> = {
+  main: PIN_C,
+  [C3]: PIN_C,
+  [C2B]: PIN_C,
+  [C2]: PIN_B,
+  [C1]: PIN_A,
+};
+
+function manifest(pin: string): string {
+  return JSON.stringify({
+    name: "vellum",
+    plugins: [
+      {
+        name: "level-up",
+        source: { source: "github", repo: "example-org/level-up", ref: pin },
+      },
+    ],
+  });
+}
+
+/**
+ * Build a `fetch` serving the commits list and the manifest at each ref.
+ * `commits` is the newest-first commit list the API returns.
+ */
+function makeFetch(commits: string[] = [C3, C2B, C2, C1]): FetchLike {
+  return (async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.includes("/commits?")) {
+      const body = commits.map((sha) => ({
+        sha,
+        commit: { committer: { date: COMMIT_DATES[sha] } },
+      }));
+      return new Response(JSON.stringify(body), { status: 200 });
+    }
+    const m = url.match(/contents\/plugins\/marketplace\.json\?ref=([^&]+)/);
+    if (m) {
+      const ref = decodeURIComponent(m[1]!);
+      const pin = PIN_BY_REF[ref];
+      if (!pin) return new Response("not found", { status: 404 });
+      return new Response(manifest(pin), { status: 200 });
+    }
+    return new Response("unexpected url: " + url, { status: 500 });
+  }) as FetchLike;
+}
+
+describe("listPinHistory", () => {
+  test("lists distinct pins newest-first, collapsing unchanged revisions", async () => {
+    // GIVEN a manifest history with three distinct pins (one commit left the
+    // plugin's pin unchanged)
+    const history = await listPinHistory("level-up", { fetch: makeFetch() });
+
+    // THEN one entry per distinct pin, newest first, each tagged with the
+    // newest marketplace commit that carries it
+    expect(history).toEqual([
+      {
+        pin: PIN_C,
+        marketplaceCommit: C3,
+        promotedAt: COMMIT_DATES[C3]!,
+        current: true,
+      },
+      {
+        pin: PIN_B,
+        marketplaceCommit: C2,
+        promotedAt: COMMIT_DATES[C2]!,
+        current: false,
+      },
+      {
+        pin: PIN_A,
+        marketplaceCommit: C1,
+        promotedAt: COMMIT_DATES[C1]!,
+        current: false,
+      },
+    ]);
+  });
+
+  test("honors the limit (newest pins win)", async () => {
+    const history = await listPinHistory(
+      "level-up",
+      { fetch: makeFetch() },
+      { limit: 2 },
+    );
+    expect(history.map((e) => e.pin)).toEqual([PIN_C, PIN_B]);
+  });
+
+  test("returns an empty list for a plugin absent from every revision", async () => {
+    const history = await listPinHistory("ghost", { fetch: makeFetch() });
+    expect(history).toEqual([]);
+  });
+
+  test("returns an empty list when the manifest has no commit history", async () => {
+    const history = await listPinHistory("level-up", {
+      fetch: makeFetch([]),
+    });
+    expect(history).toEqual([]);
+  });
+});
+
+describe("resolvePinToMarketplaceCommit", () => {
+  test("maps a reviewed pin to the marketplace commit that introduced it", async () => {
+    const entry = await resolvePinToMarketplaceCommit("level-up", PIN_B, {
+      fetch: makeFetch(),
+    });
+    expect(entry?.marketplaceCommit).toBe(C2);
+    expect(entry?.pin).toBe(PIN_B);
+  });
+
+  test("is case-insensitive on the pin SHA", async () => {
+    const entry = await resolvePinToMarketplaceCommit(
+      "level-up",
+      PIN_B.toUpperCase(),
+      { fetch: makeFetch() },
+    );
+    expect(entry?.marketplaceCommit).toBe(C2);
+  });
+
+  test("returns null for a pin not in the reviewed history", async () => {
+    const entry = await resolvePinToMarketplaceCommit(
+      "level-up",
+      "f".repeat(40),
+      { fetch: makeFetch() },
+    );
+    expect(entry).toBeNull();
+  });
+});

--- a/assistant/src/cli/lib/install-from-github.ts
+++ b/assistant/src/cli/lib/install-from-github.ts
@@ -112,6 +112,16 @@ export interface InstallPluginOptions {
   readonly force?: boolean;
   /** Git ref (branch, tag, SHA) to fetch from. Defaults to {@link DEFAULT_PLUGIN_REF}. */
   readonly ref?: string;
+  /**
+   * Materialize this exact plugin commit SHA instead of the pin the marketplace
+   * manifest records, while still resolving the plugin's owner/repo/path (and
+   * the curated adapter stub) from the manifest at {@link InstallPluginOptions.ref}.
+   * This is the CLI-only escape hatch for installing an unreviewed revision; the
+   * adapter stub therefore comes from the manifest's `ref`, not the override's
+   * era, so an adapted plugin may not reproduce a historical version faithfully.
+   * Unset for normal installs, which take the reviewed pin from the manifest.
+   */
+  readonly commitOverride?: string;
 }
 
 /** Dependencies injected by the caller. */
@@ -345,7 +355,13 @@ export async function installPlugin(
       "plugins/marketplace.json",
     );
   }
-  const ref = source.ref;
+  // A commit override installs a specific plugin revision while still taking
+  // owner/repo/path (and the adapter stub, via `marketplaceRef`) from the
+  // manifest; otherwise the reviewed pin from the manifest is materialized.
+  const effectiveSource: PluginFetchSource = opts.commitOverride
+    ? { ...source, ref: opts.commitOverride }
+    : source;
+  const ref = effectiveSource.ref;
 
   const pluginsDir = deps.workspacePluginsDir ?? getWorkspacePluginsDir();
   const target = join(pluginsDir, name);
@@ -377,7 +393,12 @@ export async function installPlugin(
   let committedAt: string | null = null;
   try {
     const materialized = await materializePluginTree(
-      { source, name, stubRef: marketplaceRef, destDir: stagingDir },
+      {
+        source: effectiveSource,
+        name,
+        stubRef: marketplaceRef,
+        destDir: stagingDir,
+      },
       deps,
     );
     fileCount = materialized.fileCount;
@@ -390,12 +411,12 @@ export async function installPlugin(
 
   if (fileCount === 0) {
     rmSync(stagingDir, { recursive: true, force: true });
-    throw new PluginNotFoundError(name, ref, sourceLabel(source));
+    throw new PluginNotFoundError(name, ref, sourceLabel(effectiveSource));
   }
 
   finalizeStagedInstall(stagingDir, {
     name,
-    source,
+    source: effectiveSource,
     ref,
     commit,
     committedAt,

--- a/assistant/src/cli/lib/plugin-marketplace.ts
+++ b/assistant/src/cli/lib/plugin-marketplace.ts
@@ -35,6 +35,17 @@ const MARKETPLACE_SOURCE_OWNER = "vellum-ai";
 const MARKETPLACE_SOURCE_REPO = "vellum-assistant";
 const MARKETPLACE_FILE_PATH = "plugins/marketplace.json";
 
+/**
+ * Canonical GitHub coordinates of the marketplace manifest, exported so
+ * sibling readers (e.g. {@link ./plugin-pin-history}) resolve the same
+ * `owner/repo:path` rather than re-declaring it.
+ */
+export const MARKETPLACE_MANIFEST_LOCATION = {
+  owner: MARKETPLACE_SOURCE_OWNER,
+  repo: MARKETPLACE_SOURCE_REPO,
+  path: MARKETPLACE_FILE_PATH,
+} as const;
+
 // ---------------------------------------------------------------------------
 // Manifest schema (subset of the Claude Code marketplace schema)
 // ---------------------------------------------------------------------------

--- a/assistant/src/cli/lib/plugin-pin-history.ts
+++ b/assistant/src/cli/lib/plugin-pin-history.ts
@@ -1,0 +1,257 @@
+/**
+ * Reconstruct the history of marketplace pins for a single plugin.
+ *
+ * The curated `plugins/marketplace.json` manifest (see {@link ./plugin-marketplace})
+ * records only the *current* pin for each plugin — there is no stored version
+ * list. But the manifest is a file in a Git repo, and every time a curator bumps
+ * a plugin's pin, that is a commit to the manifest. So the history of reviewed
+ * pins already exists as the commit history of that one file: this module walks
+ * it (newest → oldest) via the GitHub API and reports the distinct pins a plugin
+ * has been promoted to over time, each tagged with the marketplace commit an
+ * install can reproduce it from.
+ *
+ * Why this is the safe source for "install an older version": every commit on
+ * the default branch was reviewed and merged, so a pin drawn from this history
+ * is a reviewed, known-good revision — unlike an arbitrary caller-supplied ref,
+ * which the install route deliberately refuses. Resolving an older pin to the
+ * marketplace commit that introduced it (rather than the plugin SHA directly)
+ * also means the install reads that era's manifest, so the curated adapter stub
+ * matches the pin and the historical version reproduces coherently.
+ *
+ * Designed for direct programmatic use with an injected `fetch`, mirroring the
+ * sibling plugin libraries.
+ */
+
+import { type FetchLike, sanitizePluginName } from "./install-from-github.js";
+import {
+  fetchMarketplaceEntries,
+  MARKETPLACE_MANIFEST_LOCATION,
+} from "./plugin-marketplace.js";
+
+/** Default number of distinct historical pins surfaced by `plugins versions`. */
+export const DEFAULT_PIN_HISTORY_LIMIT = 5;
+
+/**
+ * Cap on how many manifest-touching commits are inspected in one walk. Bounds
+ * the GitHub API cost: a plugin whose pin changes rarely could otherwise force
+ * a fetch of the manifest at every commit that touched it for *any* plugin.
+ * Well above {@link DEFAULT_PIN_HISTORY_LIMIT} so the default listing is
+ * complete in all but pathological histories.
+ */
+const MAX_MARKETPLACE_COMMITS_SCANNED = 100;
+
+/** A single point in a plugin's marketplace-pin history. */
+export interface PluginPinHistoryEntry {
+  /** Plugin commit SHA pinned at this point in history. */
+  readonly pin: string;
+  /**
+   * Marketplace-manifest commit to install this pin from — the newest commit
+   * that carries it. Installing with this as the marketplace ref reproduces the
+   * pin together with the curated adapter stub of the same era.
+   */
+  readonly marketplaceCommit: string;
+  /**
+   * ISO-8601 committer date (UTC) of {@link PluginPinHistoryEntry.marketplaceCommit},
+   * i.e. when this pin was promoted; `null` when the date could not be read.
+   */
+  readonly promotedAt: string | null;
+  /** True for the pin currently active on the default branch. */
+  readonly current: boolean;
+}
+
+/** Options controlling the pin-history walk. */
+export interface ListPinHistoryOptions {
+  /** Max distinct pins to return (newest first). Defaults to {@link DEFAULT_PIN_HISTORY_LIMIT}. */
+  readonly limit?: number;
+  /** Marketplace branch to read history from. Defaults to `main`. */
+  readonly ref?: string;
+}
+
+/** Dependencies injected by the caller. */
+export interface ListPinHistoryDeps {
+  /** HTTP client. Production callers pass `globalThis.fetch.bind(globalThis)`. */
+  readonly fetch: FetchLike;
+}
+
+/** Shape of a commit entry from the GitHub commits API. */
+interface GitHubCommitListEntry {
+  readonly sha: string;
+  readonly commit: {
+    readonly committer?: { readonly date?: string } | null;
+  } | null;
+}
+
+/** A manifest-touching commit and its committer date. */
+interface ManifestCommit {
+  readonly sha: string;
+  readonly date: string | null;
+}
+
+/** The pin-history walk could not read the marketplace commit list. */
+export class PluginPinHistoryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PluginPinHistoryError";
+  }
+}
+
+/**
+ * List the commits that touched the marketplace manifest on `ref`, newest
+ * first, capped at {@link MAX_MARKETPLACE_COMMITS_SCANNED}. A 404 (the file
+ * never existed at this ref) yields an empty list.
+ */
+async function listManifestCommits(
+  ref: string,
+  fetchFn: FetchLike,
+): Promise<ManifestCommit[]> {
+  const { owner, repo, path } = MARKETPLACE_MANIFEST_LOCATION;
+  const url =
+    `https://api.github.com/repos/${owner}/${repo}/commits` +
+    `?path=${encodeURIComponent(path)}` +
+    `&sha=${encodeURIComponent(ref)}` +
+    `&per_page=${MAX_MARKETPLACE_COMMITS_SCANNED}`;
+
+  const res = await fetchFn(url, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      "User-Agent": "vellum-assistant-cli",
+    },
+  });
+  if (res.status === 404) return [];
+  if (!res.ok) {
+    throw new PluginPinHistoryError(
+      `Marketplace commit history fetch failed for ${path} @ ${ref}: HTTP ${res.status}`,
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = JSON.parse(await res.text());
+  } catch (err) {
+    throw new PluginPinHistoryError(
+      `Marketplace commit history is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (!Array.isArray(body)) {
+    throw new PluginPinHistoryError(
+      "Marketplace commit history response was not an array",
+    );
+  }
+
+  const commits: ManifestCommit[] = [];
+  for (const item of body as GitHubCommitListEntry[]) {
+    if (typeof item?.sha !== "string") continue;
+    const rawDate = item.commit?.committer?.date;
+    commits.push({
+      sha: item.sha,
+      date: typeof rawDate === "string" ? rawDate : null,
+    });
+  }
+  return commits;
+}
+
+/**
+ * Resolve the plugin's pinned SHA in the manifest at a specific marketplace
+ * commit, or `null` when no entry claims the name at that revision.
+ */
+async function pinAtCommit(
+  name: string,
+  marketplaceCommit: string,
+  fetchFn: FetchLike,
+): Promise<string | null> {
+  const entries = await fetchMarketplaceEntries(
+    { fetch: fetchFn },
+    { ref: marketplaceCommit },
+  );
+  return entries.find((e) => e.name === name)?.source.ref ?? null;
+}
+
+/**
+ * Walk a plugin's distinct marketplace pins, newest first. Each pin is yielded
+ * once, tagged with the newest marketplace commit carrying it. Revisions where
+ * the plugin is absent from the manifest are skipped (a gap, not a pin). The
+ * `current` flag is set against the pin live on `ref` today.
+ *
+ * Bounded by {@link MAX_MARKETPLACE_COMMITS_SCANNED} commits scanned.
+ */
+async function* iteratePinHistory(
+  name: string,
+  ref: string,
+  fetchFn: FetchLike,
+): AsyncGenerator<PluginPinHistoryEntry> {
+  const commits = await listManifestCommits(ref, fetchFn);
+  if (commits.length === 0) return;
+
+  // The pin live on the branch today, used to flag the current entry. Reading
+  // it explicitly (rather than assuming the newest commit carries it) stays
+  // correct even if the plugin was just removed from the manifest at the tip.
+  const currentPin = await pinAtCommit(name, ref, fetchFn);
+
+  let lastPin: string | null = null;
+  for (const commit of commits) {
+    const pin = await pinAtCommit(name, commit.sha, fetchFn);
+    if (pin === null) continue;
+    if (pin === lastPin) continue;
+    lastPin = pin;
+    yield {
+      pin,
+      marketplaceCommit: commit.sha,
+      promotedAt: commit.date,
+      current: currentPin !== null && pin === currentPin,
+    };
+  }
+}
+
+/**
+ * List a plugin's distinct marketplace pins, newest first, capped at
+ * `limit` (default {@link DEFAULT_PIN_HISTORY_LIMIT}). The first entry is the
+ * current pin. An empty list means the plugin has no resolvable history at this
+ * ref (never in the manifest, or the manifest does not exist).
+ *
+ * Throws {@link PluginPinHistoryError} when the commit list cannot be read, and
+ * propagates a `MarketplaceFetchError` if a manifest revision fails to parse.
+ */
+export async function listPinHistory(
+  name: string,
+  deps: ListPinHistoryDeps,
+  opts: ListPinHistoryOptions = {},
+): Promise<PluginPinHistoryEntry[]> {
+  const sanitized = sanitizePluginName(name);
+  const ref = opts.ref ?? "main";
+  const limit = opts.limit ?? DEFAULT_PIN_HISTORY_LIMIT;
+
+  const out: PluginPinHistoryEntry[] = [];
+  for await (const entry of iteratePinHistory(sanitized, ref, deps.fetch)) {
+    out.push(entry);
+    if (out.length >= limit) break;
+  }
+  return out;
+}
+
+/**
+ * Resolve a plugin pin (a full commit SHA) to the marketplace commit it should
+ * be installed from, by searching the plugin's pin history. Returns `null` when
+ * the pin is not found in the scanned history — i.e. it is not a reviewed pin
+ * this plugin was ever promoted to (or it predates the scan window).
+ *
+ * Case-insensitive on the SHA, matching the rest of the install pipeline. The
+ * search walks the full scan window, not just the `limit` shown by
+ * {@link listPinHistory}, so a pin older than the default listing still
+ * resolves.
+ */
+export async function resolvePinToMarketplaceCommit(
+  name: string,
+  pin: string,
+  deps: ListPinHistoryDeps,
+  opts: { readonly ref?: string } = {},
+): Promise<PluginPinHistoryEntry | null> {
+  const sanitized = sanitizePluginName(name);
+  const ref = opts.ref ?? "main";
+  const target = pin.trim().toLowerCase();
+  if (target.length === 0) return null;
+
+  for await (const entry of iteratePinHistory(sanitized, ref, deps.fetch)) {
+    if (entry.pin.toLowerCase() === target) return entry;
+  }
+  return null;
+}

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -60,6 +60,11 @@ import {
   PluginDetailsNotFoundError,
   type PluginDetailsOptions,
 } from "../../../cli/lib/plugin-details.js";
+import {
+  DEFAULT_PIN_HISTORY_LIMIT,
+  type PluginPinHistoryEntry,
+  PluginPinHistoryError,
+} from "../../../cli/lib/plugin-pin-history.js";
 import type {
   PluginCatalog,
   PluginSearchMatch,
@@ -202,6 +207,27 @@ mock.module("../../../cli/lib/diff-plugin.js", () => ({
   diffPlugin: diffSpy,
 }));
 
+// Mock the pin-history lib: the GitHub commit-history walk is covered by
+// plugin-pin-history.test.ts; the routes only forward the name, validate a pin
+// against the resolved history, and map errors.
+const listPinHistorySpy = mock(
+  async (..._args: unknown[]): Promise<PluginPinHistoryEntry[]> => {
+    throw new Error("listPinHistorySpy default impl not configured");
+  },
+);
+const resolvePinSpy = mock(
+  async (..._args: unknown[]): Promise<PluginPinHistoryEntry | null> => {
+    throw new Error("resolvePinSpy default impl not configured");
+  },
+);
+
+mock.module("../../../cli/lib/plugin-pin-history.js", () => ({
+  DEFAULT_PIN_HISTORY_LIMIT,
+  PluginPinHistoryError,
+  listPinHistory: listPinHistorySpy,
+  resolvePinToMarketplaceCommit: resolvePinSpy,
+}));
+
 import {
   BadRequestError,
   ConflictError,
@@ -224,6 +250,7 @@ const uninstallHandler = findHandler("plugins_uninstall");
 const getHandler = findHandler("plugins_get");
 const installHandler = findHandler("plugins_install");
 const inspectHandler = findHandler("plugins_inspect");
+const versionsHandler = findHandler("plugins_versions");
 const upgradeHandler = findHandler("plugins_upgrade");
 const diffHandler = findHandler("plugins_diff");
 
@@ -828,6 +855,7 @@ async function invokeInstall(args: RouteHandlerArgs = {}): Promise<{
 describe("POST /v1/plugins/install", () => {
   beforeEach(() => {
     installSpy.mockReset();
+    resolvePinSpy.mockReset();
   });
 
   test("forwards name/force and shapes the result, pinning ref to the default", async () => {
@@ -953,6 +981,121 @@ describe("POST /v1/plugins/install", () => {
     }
     expect(caught).toBeInstanceOf(InternalError);
     expect((caught as Error).message).toContain("ECONNRESET");
+  });
+
+  test("a reviewed pin installs from the marketplace commit that introduced it", async () => {
+    // GIVEN a pin that resolves to a marketplace commit in the reviewed history
+    resolvePinSpy.mockImplementation(async () => ({
+      pin: "a".repeat(40),
+      marketplaceCommit: "f".repeat(40),
+      promotedAt: "2026-06-01T00:00:00.000Z",
+      current: false,
+    }));
+    installSpy.mockImplementation(async (opts) => ({
+      name: opts.name,
+      target: `/workspace/.vellum/plugins/${opts.name}`,
+      fileCount: 7,
+      ref: opts.ref ?? "main",
+      commit: "a".repeat(40),
+      committedAt: null,
+    }));
+
+    const result = await invokeInstall({
+      body: { name: "caveman", pin: "a".repeat(40) },
+    });
+
+    // THEN the install reads the manifest at the resolving marketplace commit,
+    // not the default branch
+    expect(installSpy.mock.calls[0]?.[0]).toEqual({
+      name: "caveman",
+      ref: "f".repeat(40),
+      force: undefined,
+    });
+    expect(result.ref).toBe("f".repeat(40));
+  });
+
+  test("an unreviewed pin is refused as a BadRequest before installing", async () => {
+    resolvePinSpy.mockImplementation(async () => null);
+
+    await expect(
+      invokeInstall({ body: { name: "caveman", pin: "b".repeat(40) } }),
+    ).rejects.toBeInstanceOf(BadRequestError);
+    expect(installSpy).not.toHaveBeenCalled();
+  });
+
+  test("a pin-history read failure surfaces as ServiceUnavailable (503)", async () => {
+    resolvePinSpy.mockImplementation(async () => {
+      throw new PluginPinHistoryError("HTTP 403");
+    });
+
+    await expect(
+      invokeInstall({ body: { name: "caveman", pin: "c".repeat(40) } }),
+    ).rejects.toBeInstanceOf(ServiceUnavailableError);
+    expect(installSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /v1/plugins/:name/versions", () => {
+  beforeEach(() => {
+    listPinHistorySpy.mockReset();
+  });
+
+  test("returns the resolved pin history", async () => {
+    const history: PluginPinHistoryEntry[] = [
+      {
+        pin: "c".repeat(40),
+        marketplaceCommit: "3".repeat(40),
+        promotedAt: "2026-06-10T00:00:00.000Z",
+        current: true,
+      },
+      {
+        pin: "a".repeat(40),
+        marketplaceCommit: "1".repeat(40),
+        promotedAt: "2026-06-01T00:00:00.000Z",
+        current: false,
+      },
+    ];
+    listPinHistorySpy.mockImplementation(async () => history);
+
+    const result = await versionsHandler({ pathParams: { name: "level-up" } });
+    expect(result).toEqual(history);
+  });
+
+  test("forwards a positive limit to the lib", async () => {
+    listPinHistorySpy.mockImplementation(async () => []);
+    await versionsHandler({
+      pathParams: { name: "level-up" },
+      queryParams: { limit: "3" },
+    });
+    expect(listPinHistorySpy.mock.calls[0]?.[2]).toEqual({ limit: 3 });
+  });
+
+  test("rejects a non-positive limit as BadRequest before calling the lib", async () => {
+    await expect(
+      versionsHandler({
+        pathParams: { name: "level-up" },
+        queryParams: { limit: "0" },
+      }),
+    ).rejects.toBeInstanceOf(BadRequestError);
+    expect(listPinHistorySpy).not.toHaveBeenCalled();
+  });
+
+  test("InvalidPluginNameError → BadRequestError (400)", async () => {
+    listPinHistorySpy.mockImplementation(async () => {
+      throw new InvalidPluginNameError("../escape");
+    });
+    await expect(
+      versionsHandler({ pathParams: { name: "../escape" } }),
+    ).rejects.toBeInstanceOf(BadRequestError);
+  });
+
+  test("PluginPinHistoryError → ServiceUnavailableError (503)", async () => {
+    listPinHistorySpy.mockImplementation(async () => {
+      throw new PluginPinHistoryError("HTTP 429");
+    });
+    await expect(
+      versionsHandler({ pathParams: { name: "level-up" } }),
+    ).rejects.toBeInstanceOf(ServiceUnavailableError);
   });
 });
 

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -51,6 +51,12 @@ import {
   PluginDetailsNotFoundError,
 } from "../../cli/lib/plugin-details.js";
 import {
+  DEFAULT_PIN_HISTORY_LIMIT,
+  listPinHistory,
+  PluginPinHistoryError,
+  resolvePinToMarketplaceCommit,
+} from "../../cli/lib/plugin-pin-history.js";
+import {
   assertValidSearchPattern,
   filterPluginCatalog,
   InvalidSearchPatternError,
@@ -73,6 +79,7 @@ import {
   ConflictError,
   InternalError,
   NotFoundError,
+  RouteError,
   ServiceUnavailableError,
 } from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
@@ -236,6 +243,12 @@ const pluginInstallRequestSchema = z.object({
     .boolean()
     .optional()
     .describe("Overwrite an existing install in place. Defaults to false."),
+  pin: z
+    .string()
+    .optional()
+    .describe(
+      "Install a specific reviewed marketplace pin (full commit SHA) instead of the current one. The pin is validated against the plugin's marketplace pin history (`GET /v1/plugins/:name/versions`) and installed from the marketplace revision that introduced it; an unreviewed SHA is rejected. Use this to roll a plugin back to an older reviewed version.",
+    ),
 });
 
 const pluginInstallResponseSchema = z.object({
@@ -249,6 +262,32 @@ const pluginInstallResponseSchema = z.object({
     .describe("Number of files written for the installed plugin."),
   ref: z.string().describe("Git ref the plugin was fetched from."),
 });
+
+const pluginPinHistoryEntrySchema = z.object({
+  pin: z
+    .string()
+    .describe("Plugin commit SHA pinned at this point in marketplace history."),
+  marketplaceCommit: z
+    .string()
+    .describe(
+      "Marketplace-manifest commit to install this pin from (the newest commit carrying it).",
+    ),
+  promotedAt: z
+    .string()
+    .nullable()
+    .describe(
+      "ISO-8601 committer date (UTC) of the marketplace commit that promoted this pin; null when unreadable.",
+    ),
+  current: z
+    .boolean()
+    .describe("True for the pin currently active on the default branch."),
+});
+
+const pluginVersionsResponseSchema = z
+  .array(pluginPinHistoryEntrySchema)
+  .describe(
+    "Distinct marketplace pins a plugin has been promoted to, newest first; the first entry is the current pin. Empty when the plugin has no resolvable history.",
+  );
 
 const fingerprintComparisonSchema = z
   .object({
@@ -771,23 +810,52 @@ async function handleGetPluginDetails({
 // Handler — install
 // ---------------------------------------------------------------------------
 
+/**
+ * Resolve the marketplace ref an install should read from. With no `pin`, that
+ * is the default reviewed branch. With a `pin`, it is the marketplace commit
+ * that introduced that pin — but only when the pin appears in the plugin's
+ * reviewed history; an unreviewed SHA is rejected as a bad request so the route
+ * never installs an unvetted revision.
+ */
+async function resolveInstallMarketplaceRef(
+  name: string,
+  pin: string | undefined,
+): Promise<string> {
+  if (!pin) return DEFAULT_PLUGIN_REF;
+  const entry = await resolvePinToMarketplaceCommit(name, pin, {
+    fetch: globalThis.fetch.bind(globalThis),
+  });
+  if (!entry) {
+    throw new BadRequestError(
+      `"${pin}" is not a reviewed marketplace pin for "${name}". ` +
+        `Use GET /v1/plugins/${name}/versions to list installable pins.`,
+    );
+  }
+  return entry.marketplaceCommit;
+}
+
 async function handleInstallPlugin({ body = {} }: RouteHandlerArgs) {
   const name = typeof body.name === "string" ? body.name : "";
   if (!name) {
     throw new BadRequestError("`name` is required");
   }
   const force = typeof body.force === "boolean" ? body.force : undefined;
+  const pin = typeof body.pin === "string" ? body.pin : undefined;
 
-  // The ref is pinned to the curated `DEFAULT_PLUGIN_REF` rather than taken
-  // from the request: a caller-supplied ref would let any `settings.write`
-  // principal install from an unreviewed revision (a PR branch, fork ref,
-  // ...) whose marketplace manifest could carry attacker code that the loader
-  // then dynamically imports. Installs over HTTP therefore only ever resolve
-  // against the reviewed catalog on the default ref. Operators who need
-  // another ref use the local CLI's `assistant plugins install --ref`.
+  // The marketplace ref is never taken raw from the request: a caller-supplied
+  // ref would let any `settings.write` principal install from an unreviewed
+  // revision (a PR branch, fork ref, ...) whose manifest could carry attacker
+  // code the loader then dynamically imports. Installs over HTTP therefore
+  // resolve only against reviewed history. A `pin` is honored by mapping it —
+  // server-side — to the marketplace commit that introduced it, but only if it
+  // appears in the plugin's reviewed pin history; an unreviewed SHA is refused.
+  // The default install reads the current catalog on `DEFAULT_PLUGIN_REF`.
+  // Operators who need an unreviewed revision use the local CLI's
+  // `assistant plugins install --pin <sha> --allow-unreviewed`.
   try {
+    const marketplaceRef = await resolveInstallMarketplaceRef(name, pin);
     const result = await installPlugin(
-      { name, ref: DEFAULT_PLUGIN_REF, force },
+      { name, ref: marketplaceRef, force },
       { fetch: globalThis.fetch.bind(globalThis) },
     );
     return {
@@ -798,6 +866,11 @@ async function handleInstallPlugin({ body = {} }: RouteHandlerArgs) {
       ref: result.ref,
     };
   } catch (err) {
+    // Pin resolution already maps unreviewed/bad-pin cases to a RouteError;
+    // re-throw those verbatim rather than masking them as a 500.
+    if (err instanceof RouteError) {
+      throw err;
+    }
     if (err instanceof InvalidPluginNameError) {
       throw new BadRequestError(err.message);
     }
@@ -810,6 +883,10 @@ async function handleInstallPlugin({ body = {} }: RouteHandlerArgs) {
     // A rate-limited or otherwise temporarily-down GitHub source is
     // retryable, so surface 503 rather than a misleading 500.
     if (err instanceof PluginSourceUnavailableError) {
+      throw new ServiceUnavailableError(err.message);
+    }
+    // The pin-history read hits GitHub too; treat its failures as retryable.
+    if (err instanceof PluginPinHistoryError) {
       throw new ServiceUnavailableError(err.message);
     }
     throw new InternalError(
@@ -842,6 +919,45 @@ async function handleInspectPlugin({ pathParams = {} }: RouteHandlerArgs) {
     }
     throw new InternalError(
       err instanceof Error ? err.message : "plugin inspect failed",
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Handler — versions (marketplace pin history)
+// ---------------------------------------------------------------------------
+
+async function handlePluginVersions({
+  pathParams = {},
+  queryParams = {},
+}: RouteHandlerArgs) {
+  const rawName = pathParams.name ?? "";
+
+  let limit: number | undefined;
+  if (queryParams.limit !== undefined) {
+    const parsed = Number.parseInt(queryParams.limit, 10);
+    if (!Number.isInteger(parsed) || parsed < 1) {
+      throw new BadRequestError("`limit` must be a positive integer.");
+    }
+    limit = parsed;
+  }
+
+  try {
+    return await listPinHistory(
+      rawName,
+      { fetch: globalThis.fetch.bind(globalThis) },
+      limit !== undefined ? { limit } : {},
+    );
+  } catch (err) {
+    if (err instanceof InvalidPluginNameError) {
+      throw new BadRequestError(err.message);
+    }
+    // The history read hits GitHub; its failures are retryable upstream errors.
+    if (err instanceof PluginPinHistoryError) {
+      throw new ServiceUnavailableError(err.message);
+    }
+    throw new InternalError(
+      err instanceof Error ? err.message : "plugin versions failed",
     );
   }
 }
@@ -1149,6 +1265,46 @@ export const ROUTES: RouteDefinition[] = [
       },
     },
     handler: handleInspectPlugin,
+  },
+  {
+    operationId: "plugins_versions",
+    endpoint: "plugins/:name/versions",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "List a plugin's reviewed marketplace pins",
+    description: `Report the distinct marketplace pins a plugin has been promoted to over time, newest first (the first entry is the current pin), capped at \`limit\` (default ${DEFAULT_PIN_HISTORY_LIMIT}). The curated \`marketplace.json\` stores only the current pin, so this is reconstructed from the manifest's own commit history on the default branch — every entry is therefore a reviewed, known-good revision. Pair with \`POST /v1/plugins/install\`'s \`pin\` field to roll a plugin back to an older reviewed version. An unknown name (never in the manifest) returns an empty array, not 404.`,
+    tags: ["plugins"],
+    pathParams: [
+      {
+        name: "name",
+        type: "string",
+        description:
+          "Install name. Must match the kebab-case name accepted by `assistant plugins install`.",
+      },
+    ],
+    queryParams: [
+      {
+        name: "limit",
+        type: "string",
+        required: false,
+        description: `Maximum number of pins to return (positive integer; default ${DEFAULT_PIN_HISTORY_LIMIT}).`,
+      },
+    ],
+    responseBody: pluginVersionsResponseSchema,
+    additionalResponses: {
+      "400": {
+        description:
+          "The plugin name failed sanitization, or `limit` was not a positive integer.",
+      },
+      "503": {
+        description:
+          "The marketplace pin history could not be read from GitHub (rate-limited or upstream error); retryable.",
+      },
+    },
+    handler: handlePluginVersions,
   },
   {
     operationId: "plugins_diff",


### PR DESCRIPTION
## What & why

You can install a plugin and upgrade it forward, but there was no way to **see** or **roll back to** an older reviewed version. This adds that.

The curated `plugins/marketplace.json` stores only each plugin's *current* pin — there's no stored version list. But the manifest is a versioned file: **every curator pin-bump is a commit to it**, so the history of reviewed pins already exists as that file's git history. We reconstruct it on demand and let a user install a chosen historical pin.

Crucially, an older pin is installed by reading the **marketplace revision that introduced it** (not the plugin SHA directly), so the curated adapter stub of that era comes along and the historical version reproduces coherently.

## Security

Older pins come only from the default branch's manifest history — every one was reviewed and merged. The install route still **never** honors a raw caller-supplied ref (the RCE guard); it accepts a `pin` and validates it against the reconstructed history server-side, rejecting anything unreviewed. Validation-against-history is what makes rollback safe to expose over the API.

## Changes

- **`cli/lib/plugin-pin-history.ts`** (new) — walks the manifest's commit history (newest→oldest, bounded to 100 commits scanned) and reports the distinct pins a plugin has been promoted to, each tagged with the marketplace commit to install it from. `resolvePinToMarketplaceCommit` maps a pin back to that commit.
- **Discovery** — `assistant plugins versions <name>` (CLI, `--json`/`--limit`) + `GET /v1/plugins/:name/versions` list the reviewed pins, newest first, marking the current one.
- **Install** — `assistant plugins install <name> --pin <sha>` installs a chosen reviewed pin. The `plugins_install` route gains an optional `pin` (validated server-side).
- **`--allow-unreviewed`** (CLI only) — escape hatch for a SHA outside the reviewed history, via a new `commitOverride` on `installPlugin`. Caveat documented: its adapter stub comes from `main`, not the matched era.
- **inspect/upgrade unchanged** — a rolled-back install records the older pin in its provenance, so `inspect` already reports `update-available` and `upgrade` re-pins forward. Rollback is round-trippable for free.
- `openapi.yaml` regenerated (one new op `plugins_by_name_versions_get` + the `pin` field).

## Tests

- `plugin-pin-history.test.ts` — distinct-pin dedup, `current` flag, limit, empty history, pin→commit resolution (incl. case-insensitivity & not-found).
- `install-from-github.test.ts` — `commitOverride` materializes the override commit while keeping owner/repo from the manifest.
- `plugins-routes.test.ts` — `versions` handler (history passthrough, limit validation, error mapping) and install `--pin` (reviewed → installs from resolved commit; unreviewed → 400; history-read failure → 503).

Typecheck, lint, and the affected test suites pass.

## Note

This branches off `main` and is independent of #35289 (the registered-surfaces work). It's also adjacent to the in-flight removal of the plugin source watcher — no dependency either way: today the watcher hot-reloads after an install swap; once it's removed, a restart picks up the rolled-back version (install already instructs a restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GA6hBLPYtnrCFfatWLFSWB)_