### PR TITLE
fix(memory): reseed v2 skill/CLI capability pages when managed credential lands

### DIFF
--- a/assistant/src/daemon/memory-v2-startup.test.ts
+++ b/assistant/src/daemon/memory-v2-startup.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for `maybeReseedCapabilitiesAfterManagedCredential` in
+ * `memory-v2-startup.ts`.
+ *
+ * The secrets route calls this when a managed-proxy credential lands, to close
+ * the first-boot race where the daemon's startup capability seed (skills + CLI
+ * commands) runs before the platform provisions the managed embedding
+ * credential — the seed's embed throws and the synthetic capability pages never
+ * reach the page index. The reseed must fire only when v2 memory is enabled AND
+ * the managed-proxy prerequisites are now satisfied, so self-hosted / BYOK
+ * assistants (no managed proxy) are never made to run a doomed embed.
+ *
+ * Dynamic-imported collaborators are mocked at module scope; `bun:test`
+ * isolates `mock.module` per test file.
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { makeMockLogger } from "../__tests__/helpers/mock-logger.js";
+import type { AssistantConfig } from "../config/schema.js";
+
+const proxyState = { prereqs: true };
+const seedSkill = mock(async () => {});
+const seedCli = mock(async () => {});
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () => makeMockLogger(),
+}));
+
+mock.module("../providers/platform-proxy/context.js", () => ({
+  hasManagedProxyPrereqs: async () => proxyState.prereqs,
+}));
+
+mock.module("../memory/v2/skill-store.js", () => ({
+  seedV2SkillEntries: seedSkill,
+}));
+
+mock.module("../memory/v2/cli-command-store.js", () => ({
+  seedV2CliCommandEntries: seedCli,
+}));
+
+const { maybeReseedCapabilitiesAfterManagedCredential } =
+  await import("./memory-v2-startup.js");
+
+function configWithV2(enabled: boolean): AssistantConfig {
+  return { memory: { v2: { enabled } } } as unknown as AssistantConfig;
+}
+
+afterEach(() => {
+  seedSkill.mockClear();
+  seedCli.mockClear();
+  proxyState.prereqs = true;
+});
+
+describe("maybeReseedCapabilitiesAfterManagedCredential", () => {
+  test("reseeds both skill and CLI entries when v2 is enabled and managed-proxy prereqs are satisfied", async () => {
+    proxyState.prereqs = true;
+
+    await maybeReseedCapabilitiesAfterManagedCredential(configWithV2(true));
+
+    expect(seedSkill).toHaveBeenCalledTimes(1);
+    expect(seedCli).toHaveBeenCalledTimes(1);
+  });
+
+  test("no-op when v2 memory is disabled", async () => {
+    await maybeReseedCapabilitiesAfterManagedCredential(configWithV2(false));
+
+    expect(seedSkill).not.toHaveBeenCalled();
+    expect(seedCli).not.toHaveBeenCalled();
+  });
+
+  test("no-op for non-managed assistants (managed-proxy prereqs not satisfied)", async () => {
+    proxyState.prereqs = false;
+
+    await maybeReseedCapabilitiesAfterManagedCredential(configWithV2(true));
+
+    expect(seedSkill).not.toHaveBeenCalled();
+    expect(seedCli).not.toHaveBeenCalled();
+  });
+
+  test("swallows a seed failure and still reseeds the other catalog", async () => {
+    proxyState.prereqs = true;
+    seedSkill.mockImplementationOnce(async () => {
+      throw new Error('Embedding backend "gemini" is not configured');
+    });
+
+    // Must not reject — the helper contains each seed's failure so a doomed
+    // embed never propagates back to the credential-store caller.
+    await maybeReseedCapabilitiesAfterManagedCredential(configWithV2(true));
+
+    expect(seedCli).toHaveBeenCalledTimes(1);
+  });
+});

--- a/assistant/src/daemon/memory-v2-startup.ts
+++ b/assistant/src/daemon/memory-v2-startup.ts
@@ -3,7 +3,8 @@
 // ---------------------------------------------------------------------------
 //
 // Small focused module that holds the gating + dispatch logic for v2-specific
-// startup work invoked from `lifecycle.ts`. Lives in its own file so the unit
+// startup work invoked from `lifecycle.ts` (and, for the post-credential
+// capability reseed, from the secrets route). Lives in its own file so the unit
 // test for the gate does not have to mount the entire lifecycle import graph.
 
 import type { AssistantConfig } from "../config/schema.js";
@@ -46,6 +47,80 @@ export function maybeSeedMemoryV2CliCommands(config: AssistantConfig): void {
   void import("../memory/v2/cli-command-store.js")
     .then(({ seedV2CliCommandEntries }) => seedV2CliCommandEntries())
     .catch((err) => log.warn({ err }, "Failed to seed v2 CLI-command entries"));
+}
+
+/**
+ * Re-seed the v2 skill and CLI-command capability entries once a managed-proxy
+ * credential lands, closing the first-boot race where the daemon's startup seed
+ * runs before the platform has provisioned the managed embedding credential.
+ *
+ * On a brand-new managed assistant the memory worker fires the startup seed
+ * (`maybeSeedMemoryV2Skills` / `maybeSeedMemoryV2CliCommands`) seconds after
+ * boot, but the platform pushes `vellum:assistant_api_key` (the credential the
+ * managed Gemini embedding backend needs) tens of seconds later. The seed's
+ * `embedWithBackend` call throws `EmbeddingBackendUnavailableError` before the
+ * skill/CLI `entries` cache is replaced, so `listSkillEntries()` /
+ * `listCliCommandEntries()` stay empty and the synthetic `skills/<id>` and
+ * `cli-commands/<name>` rows never reach the page index — leaving the v3 needle
+ * finder lane and always-candidate skill pinning with nothing to surface until
+ * the next daemon restart. Re-running the seed when the credential arrives
+ * restores the capability pages without a restart.
+ *
+ * Gated on the managed-proxy prerequisites now being satisfied (both the
+ * platform base URL and the assistant API key present) so a non-managed
+ * credential write — or a partial update that has not yet completed the pair —
+ * does not kick a doomed embed. Idempotent: `seedV2SkillEntries` /
+ * `seedV2CliCommandEntries` atomically replace their caches, so a redundant
+ * reseed (the startup seed already succeeded) is cheap and harmless. The two
+ * catalogs are independent, so they reseed in parallel. Callers invoke this
+ * detached (`void`) — it must not block the credential-store response.
+ */
+export async function maybeReseedCapabilitiesAfterManagedCredential(
+  config: AssistantConfig,
+): Promise<void> {
+  if (!config.memory.v2.enabled) return;
+
+  const { hasManagedProxyPrereqs } =
+    await import("../providers/platform-proxy/context.js");
+  if (!(await hasManagedProxyPrereqs())) return;
+
+  // Skills and CLI commands are independent catalogs sharing the unified
+  // collection — reseed in parallel, each contained so one catalog's embed
+  // failure does not abort the other or reject the detached caller.
+  const catalogs: ReadonlyArray<[label: string, seed: () => Promise<void>]> = [
+    [
+      "skill",
+      async () => {
+        const { seedV2SkillEntries } =
+          await import("../memory/v2/skill-store.js");
+        await seedV2SkillEntries({ throwOnError: true });
+      },
+    ],
+    [
+      "CLI-command",
+      async () => {
+        const { seedV2CliCommandEntries } =
+          await import("../memory/v2/cli-command-store.js");
+        await seedV2CliCommandEntries({ throwOnError: true });
+      },
+    ],
+  ];
+
+  await Promise.all(
+    catalogs.map(async ([label, seed]) => {
+      try {
+        await seed();
+        log.info(
+          `Memory v2 ${label} entries seeded after managed proxy credential update`,
+        );
+      } catch (err) {
+        log.warn(
+          { err },
+          `Failed to seed v2 ${label} entries after managed proxy credential update`,
+        );
+      }
+    }),
+  );
 }
 
 /**

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -22,6 +22,7 @@ import {
   invalidateConfigCache,
 } from "../../config/loader.js";
 import type { CesClient } from "../../credential-execution/client.js";
+import { maybeReseedCapabilitiesAfterManagedCredential } from "../../daemon/memory-v2-startup.js";
 import { setSentryOrganizationId, setSentryUserId } from "../../instrument.js";
 import { clearEmbeddingBackendCache } from "../../memory/embedding-backend.js";
 import { syncManualTokenConnection } from "../../oauth/manual-token-connection.js";
@@ -296,6 +297,10 @@ async function handleAddSecret({ body }: RouteHandlerArgs) {
       }
       if (isManagedProxyCredential(service, field)) {
         await refreshProvidersAfterSecretChange();
+        // Close the first-boot race where the startup capability seed ran before
+        // the managed embedding credential was provisioned, leaving skill/CLI
+        // pages unseeded until restart. Detached — must not block the response.
+        void maybeReseedCapabilitiesAfterManagedCredential(getConfig());
         if (service === "vellum" && field === "assistant_api_key") {
           const generation = ++apiKeyGeneration;
           const deps = getSecretsDeps();


### PR DESCRIPTION
## Summary
- On a brand-new **managed** assistant, the daemon's startup capability seed (`maybeSeedMemoryV2Skills` / `maybeSeedMemoryV2CliCommands`) fires ~5s after boot, but the platform pushes the `vellum:assistant_api_key` credential (required for the managed Gemini embedding backend) ~30s later. The seed's `embedWithBackend` call throws `EmbeddingBackendUnavailableError` **before** the skill/CLI `entries` cache is populated, so the synthetic `skills/<id>` and `cli-commands/<name>` rows never reach the page index — leaving the v3 needle finder lane and always-candidate skill pinning empty until the next daemon restart. It does **not** self-heal: the v3 maintain pass only re-embeds capability rows already in the index.
- Adds `maybeReseedCapabilitiesAfterManagedCredential`, invoked from the secrets route (`POST /v1/secrets`) when a managed-proxy credential (`vellum:assistant_api_key` / `vellum:platform_base_url`) is stored. It re-runs the skill + CLI seeds once the credential lands, restoring the capability pages without a restart.
- **Non-managed assistants are unaffected:** the reseed only runs from the managed-proxy credential branch AND when `hasManagedProxyPrereqs()` is satisfied (both platform base URL and assistant API key present). Self-hosted/BYOK setups (own provider key via the separate `api_key` path) never reach or trigger it. Fire-and-forget so the credential-store HTTP response is not blocked; idempotent (the seed stores atomically replace their caches and dedupe concurrent runs).

## Original prompt
Investigating a "memory isn't being injected" report on a brand-new managed assistant, we traced the empty v3 `<memory>` recall and — more tellingly — the empty `finder` lane to a first-boot ordering race: the embedding-dependent skill/CLI seed runs before the platform provisions the managed embedding credential, so the synthetic capability pages never get registered (and it doesn't self-heal). The fix has the credential-store path reseed the v2 skill and CLI-command entries once the managed-proxy credential arrives, gated on the prerequisites being satisfied, idempotent and fire-and-forget so it never blocks the response or affects non-managed assistants.