### PR TITLE
fix(memory): kick a v3 maintain pass after the managed-credential capability reseed

### DIFF
--- a/assistant/src/daemon/memory-v2-startup.test.ts
+++ b/assistant/src/daemon/memory-v2-startup.test.ts
@@ -8,7 +8,9 @@
  * credential — the seed's embed throws and the synthetic capability pages never
  * reach the page index. The reseed must fire only when v2 memory is enabled AND
  * the managed-proxy prerequisites are now satisfied, so self-hosted / BYOK
- * assistants (no managed proxy) are never made to run a doomed embed.
+ * assistants (no managed proxy) are never made to run a doomed embed. When v3 is
+ * live it then enqueues a `memory_v3_maintain` job so v3 picks up the capability
+ * pages immediately instead of waiting out the 6h maintain backstop.
  *
  * Dynamic-imported collaborators are mocked at module scope; `bun:test`
  * isolates `mock.module` per test file.
@@ -19,8 +21,12 @@ import { makeMockLogger } from "../__tests__/helpers/mock-logger.js";
 import type { AssistantConfig } from "../config/schema.js";
 
 const proxyState = { prereqs: true };
+const v3State = { live: true };
 const seedSkill = mock(async () => {});
 const seedCli = mock(async () => {});
+const enqueueJob = mock(
+  (_type: string, _payload: Record<string, unknown>) => 1,
+);
 
 mock.module("../util/logger.js", () => ({
   getLogger: () => makeMockLogger(),
@@ -28,6 +34,14 @@ mock.module("../util/logger.js", () => ({
 
 mock.module("../providers/platform-proxy/context.js", () => ({
   hasManagedProxyPrereqs: async () => proxyState.prereqs,
+}));
+
+mock.module("../config/memory-v3-gate.js", () => ({
+  isMemoryV3Live: () => v3State.live,
+}));
+
+mock.module("../memory/jobs-store.js", () => ({
+  enqueueMemoryJob: enqueueJob,
 }));
 
 mock.module("../memory/v2/skill-store.js", () => ({
@@ -48,7 +62,9 @@ function configWithV2(enabled: boolean): AssistantConfig {
 afterEach(() => {
   seedSkill.mockClear();
   seedCli.mockClear();
+  enqueueJob.mockClear();
   proxyState.prereqs = true;
+  v3State.live = true;
 });
 
 describe("maybeReseedCapabilitiesAfterManagedCredential", () => {
@@ -61,11 +77,33 @@ describe("maybeReseedCapabilitiesAfterManagedCredential", () => {
     expect(seedCli).toHaveBeenCalledTimes(1);
   });
 
+  test("enqueues a v3 maintain pass after reseeding when v3 is live", async () => {
+    proxyState.prereqs = true;
+    v3State.live = true;
+
+    await maybeReseedCapabilitiesAfterManagedCredential(configWithV2(true));
+
+    expect(enqueueJob).toHaveBeenCalledTimes(1);
+    expect(enqueueJob).toHaveBeenCalledWith("memory_v3_maintain", {});
+  });
+
+  test("reseeds but does not enqueue a v3 maintain pass when v3 is not live", async () => {
+    proxyState.prereqs = true;
+    v3State.live = false;
+
+    await maybeReseedCapabilitiesAfterManagedCredential(configWithV2(true));
+
+    expect(seedSkill).toHaveBeenCalledTimes(1);
+    expect(seedCli).toHaveBeenCalledTimes(1);
+    expect(enqueueJob).not.toHaveBeenCalled();
+  });
+
   test("no-op when v2 memory is disabled", async () => {
     await maybeReseedCapabilitiesAfterManagedCredential(configWithV2(false));
 
     expect(seedSkill).not.toHaveBeenCalled();
     expect(seedCli).not.toHaveBeenCalled();
+    expect(enqueueJob).not.toHaveBeenCalled();
   });
 
   test("no-op for non-managed assistants (managed-proxy prereqs not satisfied)", async () => {
@@ -75,6 +113,7 @@ describe("maybeReseedCapabilitiesAfterManagedCredential", () => {
 
     expect(seedSkill).not.toHaveBeenCalled();
     expect(seedCli).not.toHaveBeenCalled();
+    expect(enqueueJob).not.toHaveBeenCalled();
   });
 
   test("swallows a seed failure and still reseeds the other catalog", async () => {

--- a/assistant/src/daemon/memory-v2-startup.ts
+++ b/assistant/src/daemon/memory-v2-startup.ts
@@ -74,6 +74,15 @@ export function maybeSeedMemoryV2CliCommands(config: AssistantConfig): void {
  * reseed (the startup seed already succeeded) is cheap and harmless. The two
  * catalogs are independent, so they reseed in parallel. Callers invoke this
  * detached (`void`) — it must not block the credential-store response.
+ *
+ * Reseeding alone only repopulates the shared page index — v3 reads its
+ * synthetic capability rows from the v2 stores, but its memoized lanes and its
+ * `memory_v3_sections` dense store refresh only on the v3 maintain pass (6-hour
+ * backstop). So when v3 is live, enqueue a `memory_v3_maintain` job after the
+ * reseed: its capability-reconcile stage embeds the freshly-seeded rows into the
+ * dense store and its lane-invalidation stage forces a rebuild against the now-
+ * populated index, so v3 surfaces the skill/CLI pages within seconds instead of
+ * waiting out the backstop.
  */
 export async function maybeReseedCapabilitiesAfterManagedCredential(
   config: AssistantConfig,
@@ -121,6 +130,21 @@ export async function maybeReseedCapabilitiesAfterManagedCredential(
       }
     }),
   );
+
+  // The stores (and the page index) are now populated; when v3 is live, kick a
+  // maintain pass so it embeds the capability rows into `memory_v3_sections` and
+  // invalidates its lanes immediately rather than waiting out the 6h backstop.
+  const { isMemoryV3Live } = await import("../config/memory-v3-gate.js");
+  if (!isMemoryV3Live(config)) return;
+  try {
+    const { enqueueMemoryJob } = await import("../memory/jobs-store.js");
+    enqueueMemoryJob("memory_v3_maintain", {});
+  } catch (err) {
+    log.warn(
+      { err },
+      "Failed to enqueue memory_v3_maintain after managed proxy credential update",
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Follow-up to #35483. That PR reseeds the v2 skill/CLI stores when a managed-proxy credential lands, which repopulates the shared page index — but v3 reads its synthetic capability rows through memoized lanes (`lanesPromise`) and the `memory_v3_sections` dense store, both of which only refresh on the v3 maintain pass (6-hour backstop). So v3 could lag hours behind the reseed: the needle finder lane + always-candidate pinning wait for the next lane build, and the dense lane waits for the next `reconcileCapabilityRows`.
- When v3 is live, `maybeReseedCapabilitiesAfterManagedCredential` now enqueues a `memory_v3_maintain` job after the reseed completes. Stage 2 (`reconcileCapabilityRows`) embeds the freshly-seeded rows into `memory_v3_sections`, and Stage 5 (`invalidateLanes`) forces a lane rebuild against the now-populated page index — so v3 surfaces the skill/CLI capability pages within seconds instead of waiting out the backstop.
- Gated on `isMemoryV3Live(config)` so v2-only/non-v3 installs don't enqueue a no-op maintain job. Fire-and-forget and wrapped in try/catch so it never blocks or rejects the detached credential-store caller. Idempotent (matches the existing `enqueueMemoryJob("memory_v2_reembed", {})` pattern in the same module).

## Original prompt
Following the first-boot reseed fix (#35483), we noticed that reseeding the v2 stores repopulates the page index but doesn't refresh v3's memoized lanes or its dense store — those only catch up on the 6h v3 maintain backstop, so v3 could lag hours behind. The fix enqueues a `memory_v3_maintain` job right after the reseed (when v3 is live) so v3 reconciles the capability rows into its dense store and rebuilds its lanes immediately — gated, idempotent, and fire-and-forget.