### PR TITLE
fix(test): stub v2 capability reseed in secret-routes managed-proxy test

### DIFF
--- a/assistant/src/__tests__/secret-routes-platform-proxy.test.ts
+++ b/assistant/src/__tests__/secret-routes-platform-proxy.test.ts
@@ -12,7 +12,12 @@ let providerRefreshCalls = 0;
 const PLATFORM_BASE_URL = "https://platform.example.com";
 const ASSISTANT_API_KEY_PATH = credentialKey("vellum", "assistant_api_key");
 const PLATFORM_BASE_URL_PATH = credentialKey("vellum", "platform_base_url");
-const MANAGED_PROVIDERS = ["anthropic", "openai", "gemini", "fireworks"] as const;
+const MANAGED_PROVIDERS = [
+  "anthropic",
+  "openai",
+  "gemini",
+  "fireworks",
+] as const;
 
 let platformBaseUrlOverride: string | undefined;
 
@@ -116,6 +121,13 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
+// `handleAddSecret` fires this detached when a managed-proxy credential lands —
+// a v2-memory side effect outside this suite's provider-registry scope. Stub it
+// to a no-op; its behavior is covered by memory-v2-startup.test.ts.
+mock.module("../daemon/memory-v2-startup.js", () => ({
+  maybeReseedCapabilitiesAfterManagedCredential: async () => {},
+}));
+
 import {
   getProviderRoutingSource,
   initializeProviders,
@@ -199,7 +211,9 @@ describe("secret routes managed proxy registry sync", () => {
   test("provider API key writes notify live-conversation refresh listeners", async () => {
     await addApiKey("fireworks", "fw-key");
 
-    expect(secureKeyStore[credentialKey("fireworks", "api_key")]).toBe("fw-key");
+    expect(secureKeyStore[credentialKey("fireworks", "api_key")]).toBe(
+      "fw-key",
+    );
     expect(providerRefreshCalls).toBe(1);
 
     await deleteApiKey("fireworks");


### PR DESCRIPTION
## Summary
- `secret-routes-platform-proxy.test.ts` began failing on `main` with `TypeError: undefined is not an object (evaluating 'config.memory.v2')` after #35483 wired a detached `maybeReseedCapabilitiesAfterManagedCredential(getConfig())` call into `handleAddSecret`. This suite's `getConfig` mock returns a minimal config with no `memory` block, so the reseed threw on its first line and failed 5 of the 7 tests.
- Stub `../daemon/memory-v2-startup.js` to a no-op in this suite — the reseed is a v2-memory side effect outside the provider-registry scope these tests cover, and its own behavior is already covered by `memory-v2-startup.test.ts`.
- Prettier also normalized two pre-existing lines in the same file (whole-file format check in the pre-commit hook).
- Verified locally: all 7 tests in the file now pass (5 were failing before).

## Original prompt
Fix only the specific failing CI job — the `Test` step of the `CI Main Assistant Checks` run on `main` (run 27845967707), where `secret-routes-platform-proxy.test.ts` broke after the v2 capability-reseed call was added to the secrets route. Keep the fix scoped to that one failing job.