### PR TITLE
feat(feature-flags): register vision-perception flag (default off)

### DIFF
--- a/assistant/src/config/vision-perception-flag.test.ts
+++ b/assistant/src/config/vision-perception-flag.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Tests for the vision-perception feature gate.
+ *
+ * Verifies:
+ * - isVisionPerceptionEnabled defaults to false (registry default).
+ * - It returns true when the flag is enabled via config overrides.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { setOverridesForTesting } from "../__tests__/feature-flag-test-helpers.js";
+import type { AssistantConfig } from "./schema.js";
+import { isVisionPerceptionEnabled } from "./vision-perception-flag.js";
+
+const VISION_PERCEPTION_FLAG = "vision-perception" as const;
+
+beforeEach(() => {
+  setOverridesForTesting({});
+});
+
+afterEach(() => {
+  setOverridesForTesting({});
+});
+
+/** Create a minimal AssistantConfig (flag overrides are set via setOverridesForTesting). */
+function makeConfig(): AssistantConfig {
+  return {} as AssistantConfig;
+}
+
+describe("isVisionPerceptionEnabled", () => {
+  test("returns false by default (no overrides)", () => {
+    expect(isVisionPerceptionEnabled(makeConfig())).toBe(false);
+  });
+
+  test("returns true when the flag is enabled", () => {
+    setOverridesForTesting({ [VISION_PERCEPTION_FLAG]: true });
+    expect(isVisionPerceptionEnabled(makeConfig())).toBe(true);
+  });
+
+  test("returns false when explicitly disabled", () => {
+    setOverridesForTesting({ [VISION_PERCEPTION_FLAG]: false });
+    expect(isVisionPerceptionEnabled(makeConfig())).toBe(false);
+  });
+});

--- a/assistant/src/config/vision-perception-flag.ts
+++ b/assistant/src/config/vision-perception-flag.ts
@@ -1,0 +1,8 @@
+import { isAssistantFeatureFlagEnabled } from "./assistant-feature-flags.js";
+import type { AssistantConfig } from "./schema.js";
+
+const VISION_PERCEPTION_FLAG = "vision-perception" as const;
+
+export function isVisionPerceptionEnabled(config: AssistantConfig): boolean {
+  return isAssistantFeatureFlagEnabled(VISION_PERCEPTION_FLAG, config);
+}

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -433,6 +433,14 @@
       "label": "OS Beta",
       "description": "Enable the OS Beta model profile (GLM 5.2 / Fireworks) in the assistant's model profile selection.",
       "defaultEnabled": false
+    },
+    {
+      "id": "vision-perception",
+      "scope": "assistant",
+      "key": "vision-perception",
+      "label": "Vision Perception",
+      "description": "Qwen3-VL image/video perception tools",
+      "defaultEnabled": false
     }
   ]
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -433,6 +433,14 @@
       "label": "OS Beta",
       "description": "Enable the OS Beta model profile (GLM 5.2 / Fireworks) in the assistant's model profile selection.",
       "defaultEnabled": false
+    },
+    {
+      "id": "vision-perception",
+      "scope": "assistant",
+      "key": "vision-perception",
+      "label": "Vision Perception",
+      "description": "Qwen3-VL image/video perception tools",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Register vision-perception assistant flag (defaultEnabled: false)
- Sync bundled registry copies; add isVisionPerceptionEnabled gate + test

Part of plan: glm-5v-turbo-vlm-tool.md (PR 2 of 8)