### PR TITLE
feat(config): add visionPerception LLM call site

### DIFF
--- a/assistant/src/config/call-site-defaults.test.ts
+++ b/assistant/src/config/call-site-defaults.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+
+import { CALL_SITE_DEFAULTS } from "./call-site-defaults.js";
+import { resolveCallSiteConfig } from "./llm-resolver.js";
+import { LLMCallSiteEnum, LLMSchema } from "./schemas/llm.js";
+
+describe("CALL_SITE_DEFAULTS", () => {
+  test("covers every LLMCallSiteEnum member", () => {
+    const enumMembers = [...LLMCallSiteEnum.options].sort();
+    const defaultKeys = Object.keys(CALL_SITE_DEFAULTS).sort();
+    expect(defaultKeys).toEqual(enumMembers);
+  });
+
+  test("visionPerception pins the vision profile and skips thinking/cache", () => {
+    expect(CALL_SITE_DEFAULTS.visionPerception).toEqual({
+      profile: "vision",
+      effort: "low",
+      thinking: { enabled: false },
+      disableCache: true,
+    });
+  });
+
+  test("resolveCallSiteConfig('visionPerception') returns a config even before the vision profile exists", () => {
+    // Empty config — no `vision` profile defined yet (seeded by a later PR).
+    const llm = LLMSchema.parse({});
+    const resolved = resolveCallSiteConfig("visionPerception", llm);
+
+    // Falls back to the workspace default config; the call-site defaults still
+    // apply on top.
+    expect(resolved).toBeDefined();
+    expect(resolved.effort).toBe("low");
+    expect(resolved.thinking.enabled).toBe(false);
+    expect(resolved.disableCache).toBe(true);
+  });
+});

--- a/assistant/src/config/call-site-defaults.ts
+++ b/assistant/src/config/call-site-defaults.ts
@@ -143,4 +143,12 @@ export const CALL_SITE_DEFAULTS: Record<LLMCallSite, CallSiteDefaultConfig> = {
     effort: "low",
     thinking: { enabled: false },
   },
+  // One-shot multimodal tool call: no reasoning needed and the prompt never
+  // repeats, so skip thinking and prompt caching.
+  visionPerception: {
+    profile: "vision",
+    effort: "low",
+    thinking: { enabled: false },
+    disableCache: true,
+  },
 };

--- a/assistant/src/config/schemas/call-site-catalog.ts
+++ b/assistant/src/config/schemas/call-site-catalog.ts
@@ -321,6 +321,13 @@ const CATALOG_RECORD: CatalogRecord = {
       "Generates contextual conversation-starter suggestions for the Home page.",
     domain: "ui",
   },
+  visionPerception: {
+    id: "visionPerception",
+    displayName: "Vision Perception",
+    description:
+      "Describes and answers questions about images and video frames using a multimodal model.",
+    domain: "skills",
+  },
 };
 
 // Source of truth for call-site display metadata. API responses and usage

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -83,6 +83,7 @@ export const LLMCallSiteEnum = z.enum([
   "homeGreeting",
   "homeSuggestedPrompts",
   "workflowLeaf",
+  "visionPerception",
 ]);
 export type LLMCallSite = z.infer<typeof LLMCallSiteEnum>;
 


### PR DESCRIPTION
## Summary
- Add visionPerception to LLMCallSiteEnum and CALL_SITE_DEFAULTS (profile: vision)

Part of plan: glm-5v-turbo-vlm-tool.md (PR 3 of 8)