### PR TITLE
docs(test): reword visionPerception call-site comment to present-state

### DIFF
--- a/assistant/src/config/call-site-defaults.test.ts
+++ b/assistant/src/config/call-site-defaults.test.ts
@@ -21,7 +21,8 @@ describe("CALL_SITE_DEFAULTS", () => {
   });
 
   test("resolveCallSiteConfig('visionPerception') returns a config even before the vision profile exists", () => {
-    // Empty config — no `vision` profile defined yet (seeded by a later PR).
+    // An empty/default config has no `vision` profile, so resolution falls
+    // back to the workspace default.
     const llm = LLMSchema.parse({});
     const resolved = resolveCallSiteConfig("visionPerception", llm);
 


### PR DESCRIPTION
## Summary
- Address Codex review on #35489: remove PR-stack history from a test comment per the AGENTS.md Code Comments rule (comments describe the present).

Part of plan: glm-5v-turbo-vlm-tool.md (follow-up to PR 3)