### PR TITLE
feat(plugins): vision-perception default plugin (ask/describe)

### DIFF
--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -76,6 +76,9 @@ import toolErrorPostToolUse from "./tool-error/hooks/post-tool-use.js";
 import toolErrorPkg from "./tool-error/package.json" with { type: "json" };
 import toolResultTruncatePostToolUse from "./tool-result-truncate/hooks/post-tool-use.js";
 import toolResultTruncatePkg from "./tool-result-truncate/package.json" with { type: "json" };
+import visionPerceptionPkg from "./vision-perception/package.json" with { type: "json" };
+import vlmAskTool from "./vision-perception/tools/vlm-ask.js";
+import vlmDescribeTool from "./vision-perception/tools/vlm-describe.js";
 
 /**
  * `compaction` — compaction is implemented in `compaction/compact.ts` as
@@ -329,6 +332,28 @@ export const defaultAdvisorPlugin: Plugin = {
 };
 
 /**
+ * `vision-perception` — adds the model-visible `vlm_ask` and `vlm_describe`
+ * tools. The model passes a provided image's attachment id; the plugin resolves
+ * it to an image block and sends it, with the question or a description prompt,
+ * to the `visionPerception` call site (a vision-capable inference profile)
+ * routed through the assistant's own inference. The whole plugin is gated behind
+ * the `vision-perception` feature flag — `bootstrapPlugins` skips it (no tool
+ * contributions) when the flag is off. `finalizeTool` fills each tool's defaults
+ * so it satisfies `Tool`.
+ */
+export const visionPerceptionPlugin: Plugin = {
+  manifest: {
+    name: visionPerceptionPkg.name,
+    version: visionPerceptionPkg.version,
+    requiresFlag: ["vision-perception"],
+  },
+  tools: [
+    finalizeTool(vlmAskTool, "vlm_ask"),
+    finalizeTool(vlmDescribeTool, "vlm_describe"),
+  ],
+};
+
+/**
  * Full set of first-party default plugins. Used by
  * {@link registerDefaultPlugins} to drive the registration loop; the array
  * order is the registration order, which fixes hook-chain order (defaults run
@@ -352,6 +377,7 @@ function getAllDefaultPlugins(): readonly Plugin[] {
     // Registered last so its capture hooks observe the fully-processed turn
     // (memory injections, history repair) that the executor actually sees.
     defaultAdvisorPlugin,
+    visionPerceptionPlugin,
   ];
 }
 

--- a/assistant/src/plugins/defaults/vision-perception/__tests__/vision-tools.test.ts
+++ b/assistant/src/plugins/defaults/vision-perception/__tests__/vision-tools.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { ImageContent, Message } from "../../../../providers/types.js";
+import type { ToolContext } from "../../../../tools/types.js";
+
+// `mock.module` is process-global, so all stubbing for the vision tools lives in
+// this one file. We stub the provider resolution (spreading the real module so
+// `extractAllText` keeps working) and the attachment store (fixture bytes + a
+// configurable row).
+
+let sendMessageArgs: { messages: Message[]; options: unknown } | null = null;
+let responseText = "A red bicycle leans against a brick wall.";
+
+const fakeProvider = {
+  name: "mock-vision-provider",
+  async sendMessage(messages: Message[], options: unknown) {
+    sendMessageArgs = { messages, options };
+    return {
+      content: [{ type: "text", text: responseText }],
+      model: "mock-vision-model",
+      usage: { inputTokens: 1, outputTokens: 1 },
+      stopReason: "end_turn",
+    };
+  },
+};
+
+const realPsm = await import("../../../../providers/provider-send-message.js");
+mock.module("../../../../providers/provider-send-message.js", () => ({
+  ...realPsm,
+  getConfiguredProvider: async () => fakeProvider,
+}));
+
+// A 1x1 PNG — small enough that `optimizeImageForTransport` returns it
+// unchanged, so the bytes flow through to the image block verbatim.
+const PNG_BYTES = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+interface FakeRow {
+  id: string;
+  originalFilename: string;
+  mimeType: string;
+  kind: string;
+}
+
+// The store stub is configurable per-test: `attachmentRows` maps id -> row, and
+// `attachmentBytes` maps id -> bytes. A missing id resolves to null (mirroring
+// the real store's not-found behavior).
+let attachmentRows: Record<string, FakeRow> = {};
+let attachmentBytes: Record<string, Buffer> = {};
+
+mock.module("../../../../memory/attachments-store.js", () => ({
+  getAttachmentById: (id: string) => attachmentRows[id] ?? null,
+  getAttachmentContent: (id: string) => attachmentBytes[id] ?? null,
+}));
+
+const vlmAskTool = (await import("../tools/vlm-ask.js")).default;
+const vlmDescribeTool = (await import("../tools/vlm-describe.js")).default;
+
+const ctx = { conversationId: "c1" } as unknown as ToolContext;
+
+beforeEach(() => {
+  sendMessageArgs = null;
+  responseText = "A red bicycle leans against a brick wall.";
+  attachmentRows = {
+    "att-1": {
+      id: "att-1",
+      originalFilename: "photo.png",
+      mimeType: "image/png",
+      kind: "image",
+    },
+    "att-doc": {
+      id: "att-doc",
+      originalFilename: "notes.pdf",
+      mimeType: "application/pdf",
+      kind: "document",
+    },
+  };
+  attachmentBytes = { "att-1": PNG_BYTES, "att-doc": PNG_BYTES };
+});
+
+describe("vlm_ask tool", () => {
+  test("round-trips an attachment id through the vision model to text", async () => {
+    const result = await vlmAskTool.execute?.(
+      { media_ref: "att-1", question: "What is in this image?" },
+      ctx,
+    );
+
+    expect(result?.isError).toBe(false);
+    expect(result?.content).toBe(responseText);
+  });
+
+  test("sends a single user message containing an ImageContent block", async () => {
+    await vlmAskTool.execute?.(
+      { media_ref: "att-1", question: "What is in this image?" },
+      ctx,
+    );
+
+    const sent = sendMessageArgs?.messages;
+    expect(sent).toHaveLength(1);
+    expect(sent?.[0].role).toBe("user");
+
+    const blocks = sent?.[0].content ?? [];
+    const image = blocks.find((b): b is ImageContent => b.type === "image");
+    expect(image).toBeDefined();
+    expect(image?.source.type).toBe("base64");
+    expect(image?.source.data).toBe(PNG_BYTES.toString("base64"));
+
+    const text = blocks.find((b) => b.type === "text");
+    expect(text).toEqual({ type: "text", text: "What is in this image?" });
+  });
+
+  test("returns isError (no throw) for a missing media_ref", async () => {
+    const result = await vlmAskTool.execute?.(
+      { media_ref: "does-not-exist", question: "?" },
+      ctx,
+    );
+
+    expect(result?.isError).toBe(true);
+    expect(result?.content).toContain("No attachment found");
+    expect(sendMessageArgs).toBeNull();
+  });
+
+  test("returns isError (no throw) for a non-image attachment", async () => {
+    const result = await vlmAskTool.execute?.(
+      { media_ref: "att-doc", question: "?" },
+      ctx,
+    );
+
+    expect(result?.isError).toBe(true);
+    expect(result?.content).toContain("not an image");
+    expect(sendMessageArgs).toBeNull();
+  });
+});
+
+describe("vlm_describe tool", () => {
+  test("returns the model's description as a non-error result", async () => {
+    const result = await vlmDescribeTool.execute?.({ media_ref: "att-1" }, ctx);
+
+    expect(result?.isError).toBe(false);
+    expect(result?.content).toBe(responseText);
+
+    const sent = sendMessageArgs?.messages;
+    const image = sent?.[0].content.find((b) => b.type === "image");
+    expect(image).toBeDefined();
+  });
+
+  test("returns isError (no throw) for a non-image attachment", async () => {
+    const result = await vlmDescribeTool.execute?.(
+      { media_ref: "att-doc" },
+      ctx,
+    );
+
+    expect(result?.isError).toBe(true);
+    expect(result?.content).toContain("not an image");
+  });
+});

--- a/assistant/src/plugins/defaults/vision-perception/package.json
+++ b/assistant/src/plugins/defaults/vision-perception/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "default-vision-perception",
+  "version": "1.0.0",
+  "description": "First-party default plugin that adds vision tools (`vlm_ask`, `vlm_describe`): the model resolves a provided image attachment by id and sends it to a vision-capable inference profile to read it or answer questions about it. Gated behind the `vision-perception` feature flag.",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "engines": {
+    "node": ">=20.12.0"
+  },
+  "peerDependencies": {
+    "@vellumai/plugin-api": "^0.8.0"
+  },
+  "vellumPlugin": {
+    "requiresFlag": [
+      "vision-perception"
+    ]
+  }
+}

--- a/assistant/src/plugins/defaults/vision-perception/src/call-vision-model.ts
+++ b/assistant/src/plugins/defaults/vision-perception/src/call-vision-model.ts
@@ -1,0 +1,60 @@
+/**
+ * Run one vision-perception call.
+ *
+ * Routed entirely through the assistant's own inference: `getConfiguredProvider`
+ * resolves the `visionPerception` call site (flag-gated to a vision-capable
+ * inference profile) to a provider/model/credentials from the configured
+ * profiles — managed-proxy or BYOK, no separate API key. The media reference is
+ * resolved to an `ImageContent` block, paired with the prompt as a single user
+ * `Message`, and sent through `provider.sendMessage`; the returned text blocks
+ * are concatenated into the answer.
+ */
+
+import {
+  extractAllText,
+  getConfiguredProvider,
+} from "../../../../providers/provider-send-message.js";
+import type { Message } from "../../../../providers/types.js";
+import type { ToolContext } from "../../../../tools/types.js";
+import { resolveVisionMedia } from "./media-source.js";
+
+// Dedicated vision call site. Its profile (a vision-capable model) is resolved
+// by the LLM config layer when the `vision-perception` feature flag is on.
+const VISION_CALL_SITE = "visionPerception" as const;
+
+/**
+ * Resolve the media reference, send the image + prompt to the vision call site,
+ * and return the model's text answer. Throws when no vision provider is
+ * configured; media-resolution failures throw {@link VisionMediaError}.
+ */
+export async function callVisionModel(
+  mediaRef: string,
+  prompt: string,
+  ctx: ToolContext,
+): Promise<string> {
+  const media = await resolveVisionMedia(mediaRef);
+
+  const provider = await getConfiguredProvider(VISION_CALL_SITE);
+  if (!provider) {
+    throw new Error("no vision inference provider is configured");
+  }
+
+  const message: Message = {
+    role: "user",
+    content: [media.block, { type: "text", text: prompt }],
+  };
+
+  const response = await provider.sendMessage([message], {
+    systemPrompt: VISION_SYSTEM_PROMPT,
+    config: { callSite: VISION_CALL_SITE },
+    signal: ctx.signal,
+  });
+
+  const answer = extractAllText(response).trim();
+  return answer.length > 0 ? answer : "(vision model returned no text)";
+}
+
+const VISION_SYSTEM_PROMPT =
+  "You are a vision assistant. Examine the provided image carefully and respond " +
+  "to the request precisely. Report only what is actually visible; if something " +
+  "cannot be determined from the image, say so rather than guessing.";

--- a/assistant/src/plugins/defaults/vision-perception/src/media-source.ts
+++ b/assistant/src/plugins/defaults/vision-perception/src/media-source.ts
@@ -1,0 +1,92 @@
+/**
+ * Resolve a vision media reference (an attachment id) into a provider
+ * `ImageContent` block.
+ *
+ * Reads the attachment row and bytes from the assistant's own attachment store,
+ * validates that the reference points to an existing IMAGE (videos and other
+ * kinds are rejected), and runs the bytes through `optimizeImageForTransport`
+ * before building the base64 image block the vision call site sends.
+ *
+ * The attachment store is imported in-tree (relative) rather than from
+ * `@vellumai/plugin-api`, which does not export it.
+ */
+
+import { optimizeImageForTransport } from "../../../../agent/image-optimize.js";
+import {
+  getAttachmentById,
+  getAttachmentContent,
+} from "../../../../memory/attachments-store.js";
+import type { ImageContent } from "../../../../providers/types.js";
+
+/**
+ * Raised when a media reference cannot be resolved to a usable image — the
+ * attachment is missing, has no readable bytes, or is not an image. Tools
+ * convert this into a `{ isError: true }` result rather than throwing.
+ */
+export class VisionMediaError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "VisionMediaError";
+  }
+}
+
+export interface ResolvedVisionMedia {
+  block: ImageContent;
+  mimeType: string;
+  kind: string;
+  filename: string;
+}
+
+/**
+ * Resolve an attachment id to an optimized `ImageContent` block plus its
+ * metadata. Throws {@link VisionMediaError} on a missing / non-image / unreadable
+ * reference.
+ */
+export async function resolveVisionMedia(
+  mediaRef: string,
+): Promise<ResolvedVisionMedia> {
+  const ref = mediaRef?.trim();
+  if (!ref) {
+    throw new VisionMediaError("No media reference was provided.");
+  }
+
+  const row = getAttachmentById(ref);
+  if (!row) {
+    throw new VisionMediaError(`No attachment found for media_ref "${ref}".`);
+  }
+
+  if (row.kind !== "image") {
+    throw new VisionMediaError(
+      `Attachment "${ref}" is a ${row.kind}, not an image. ` +
+        "Only images can be read by the vision tools.",
+    );
+  }
+
+  const bytes = getAttachmentContent(ref);
+  if (!bytes || bytes.length === 0) {
+    throw new VisionMediaError(
+      `Attachment "${ref}" has no readable image content.`,
+    );
+  }
+
+  const optimized = optimizeImageForTransport(
+    bytes.toString("base64"),
+    row.mimeType,
+  );
+
+  const block: ImageContent = {
+    type: "image",
+    source: {
+      type: "base64",
+      media_type: optimized.mediaType,
+      data: optimized.data,
+    },
+  };
+
+  return {
+    block,
+    mimeType: optimized.mediaType,
+    kind: row.kind,
+    filename: row.originalFilename,
+  };
+}

--- a/assistant/src/plugins/defaults/vision-perception/tools/vlm-ask.ts
+++ b/assistant/src/plugins/defaults/vision-perception/tools/vlm-ask.ts
@@ -1,0 +1,54 @@
+/**
+ * The `vlm_ask` tool — reads a provided image and answers a question about it.
+ *
+ * The model passes the image's attachment id as `media_ref` and a `question`;
+ * the plugin resolves the attachment, sends the image plus question to the
+ * vision call site, and returns the model's answer.
+ *
+ * Default export = the tool definition. `defaults/index.ts` finalizes it and
+ * attaches it to the vision-perception plugin's `tools` array, which
+ * `bootstrapPlugins` registers into the model-visible tool catalog.
+ */
+
+import type {
+  ToolContext,
+  ToolDefinition,
+  ToolExecutionResult,
+} from "@vellumai/plugin-api";
+import { RiskLevel } from "@vellumai/plugin-api";
+
+import { callVisionModel } from "../src/call-vision-model.js";
+
+const vlmAskTool: ToolDefinition = {
+  name: "vlm_ask",
+  description:
+    "Use this whenever the user provides an image to read or answer questions about it. " +
+    "Pass the attachment id as media_ref.",
+  input_schema: {
+    type: "object",
+    properties: {
+      media_ref: { type: "string" },
+      question: { type: "string" },
+      region: { type: "array", items: { type: "number" } },
+    },
+    required: ["media_ref", "question"],
+  },
+  // Read-only image inspection; low risk so the call isn't gated behind a prompt.
+  defaultRiskLevel: RiskLevel.Low,
+  async execute(
+    input: Record<string, unknown>,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    try {
+      const mediaRef = String(input.media_ref ?? "");
+      const question = String(input.question ?? "");
+      const content = await callVisionModel(mediaRef, question, ctx);
+      return { content, isError: false };
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      return { content: reason, isError: true };
+    }
+  },
+};
+
+export default vlmAskTool;

--- a/assistant/src/plugins/defaults/vision-perception/tools/vlm-describe.ts
+++ b/assistant/src/plugins/defaults/vision-perception/tools/vlm-describe.ts
@@ -1,0 +1,76 @@
+/**
+ * The `vlm_describe` tool — returns a structured description of a provided
+ * image.
+ *
+ * The model passes the image's attachment id as `media_ref`, optionally
+ * narrowing the description with `focus` and choosing a `detail` level; the
+ * plugin resolves the attachment and sends the image plus a description prompt
+ * to the vision call site.
+ *
+ * Default export = the tool definition. `defaults/index.ts` finalizes it and
+ * attaches it to the vision-perception plugin's `tools` array, which
+ * `bootstrapPlugins` registers into the model-visible tool catalog.
+ */
+
+import type {
+  ToolContext,
+  ToolDefinition,
+  ToolExecutionResult,
+} from "@vellumai/plugin-api";
+import { RiskLevel } from "@vellumai/plugin-api";
+
+import { callVisionModel } from "../src/call-vision-model.js";
+
+const DETAIL_GUIDANCE: Record<string, string> = {
+  brief: "Give a one- to two-sentence summary of the image.",
+  standard:
+    "Give a clear paragraph describing the salient contents of the image.",
+  exhaustive:
+    "Give an exhaustive description covering every notable element, " +
+    "any visible text, layout, colors, and spatial relationships.",
+};
+
+function buildDescribePrompt(focus: string, detail: string): string {
+  const level = DETAIL_GUIDANCE[detail] ?? DETAIL_GUIDANCE.standard;
+  const lens = focus.trim()
+    ? ` Focus your description on: ${focus.trim()}.`
+    : "";
+  return `Describe this image.${lens} ${level}`;
+}
+
+const vlmDescribeTool: ToolDefinition = {
+  name: "vlm_describe",
+  description:
+    "Use to get a structured description of a provided image when you don't yet " +
+    "know what to ask.",
+  input_schema: {
+    type: "object",
+    properties: {
+      media_ref: { type: "string" },
+      focus: { type: "string" },
+      detail: { type: "string", enum: ["brief", "standard", "exhaustive"] },
+    },
+    required: ["media_ref"],
+  },
+  // Read-only image inspection; low risk so the call isn't gated behind a prompt.
+  defaultRiskLevel: RiskLevel.Low,
+  async execute(
+    input: Record<string, unknown>,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    try {
+      const mediaRef = String(input.media_ref ?? "");
+      const focus = typeof input.focus === "string" ? input.focus : "";
+      const detail =
+        typeof input.detail === "string" ? input.detail : "standard";
+      const prompt = buildDescribePrompt(focus, detail);
+      const content = await callVisionModel(mediaRef, prompt, ctx);
+      return { content, isError: false };
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      return { content: reason, isError: true };
+    }
+  },
+};
+
+export default vlmDescribeTool;


### PR DESCRIPTION
## Summary
- First-party default plugin (requiresFlag: vision-perception) exposing vlm_ask + vlm_describe
- Resolves attachment by id, sends image to Qwen 3.7 Plus via the visionPerception call site

Part of plan: glm-5v-turbo-vlm-tool.md (PR 5 of 8)