### PR TITLE
feat(plugins): add vlm_ocr and vlm_detect (grounding)

### DIFF
--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -79,6 +79,8 @@ import toolResultTruncatePkg from "./tool-result-truncate/package.json" with { t
 import visionPerceptionPkg from "./vision-perception/package.json" with { type: "json" };
 import vlmAskTool from "./vision-perception/tools/vlm-ask.js";
 import vlmDescribeTool from "./vision-perception/tools/vlm-describe.js";
+import vlmDetectTool from "./vision-perception/tools/vlm-detect.js";
+import vlmOcrTool from "./vision-perception/tools/vlm-ocr.js";
 
 /**
  * `compaction` — compaction is implemented in `compaction/compact.ts` as
@@ -350,6 +352,8 @@ export const visionPerceptionPlugin: Plugin = {
   tools: [
     finalizeTool(vlmAskTool, "vlm_ask"),
     finalizeTool(vlmDescribeTool, "vlm_describe"),
+    finalizeTool(vlmOcrTool, "vlm_ocr"),
+    finalizeTool(vlmDetectTool, "vlm_detect"),
   ],
 };
 

--- a/assistant/src/plugins/defaults/vision-perception/__tests__/ocr-detect.test.ts
+++ b/assistant/src/plugins/defaults/vision-perception/__tests__/ocr-detect.test.ts
@@ -121,6 +121,27 @@ describe("vlm_ocr tool", () => {
     ]);
   });
 
+  test("drops layout blocks with non-finite coords instead of fabricating a zero box", async () => {
+    // null and empty-string coords must NOT coerce to a 0-size [0,0,0,0] box —
+    // those blocks are dropped; the valid block is still returned.
+    responseText =
+      '```json\n{"full_text": "ABC", "blocks": [' +
+      '{"text": "null-box", "bbox": [null, null, null, null]},' +
+      '{"text": "empty-box", "bbox": ["", "", "", ""]},' +
+      '{"text": "valid", "bbox": [100, 200, 300, 400]}' +
+      "]}\n```";
+    const result = await vlmOcrTool.execute?.(
+      { media_ref: "att-1", layout: true },
+      ctx,
+    );
+
+    expect(result?.isError).toBe(false);
+    const parsed = JSON.parse(result?.content ?? "");
+    expect(parsed.blocks).toEqual([
+      { text: "valid", bbox: [100, 200, 300, 400] },
+    ]);
+  });
+
   test("layout=true with malformed model output degrades to isError (no throw)", async () => {
     responseText = "sorry, I cannot read that image";
     const result = await vlmOcrTool.execute?.(
@@ -169,6 +190,25 @@ describe("vlm_detect tool", () => {
     const parsed = JSON.parse(result?.content ?? "");
     expect(parsed.detections).toEqual([
       { label: "car", bbox: [10, 20, 30, 40], confidence: null },
+    ]);
+  });
+
+  test("drops detections with non-finite coords instead of returning zero boxes", async () => {
+    // Placeholder/uncertain coords (null and empty strings) must NOT coerce to
+    // a [0,0,0,0] box — those detections are dropped, while a valid detection
+    // in the same response is still returned.
+    responseText =
+      '{"detections": [' +
+      '{"label": "ghost", "bbox": [null, null, null, null], "confidence": 0.9},' +
+      '{"label": "blank", "bbox": ["", "", "", ""], "confidence": 0.8},' +
+      '{"label": "dog", "bbox": [500, 600, 700, 800], "confidence": 0.5}' +
+      "]}";
+    const result = await vlmDetectTool.execute?.({ media_ref: "att-1" }, ctx);
+
+    expect(result?.isError).toBe(false);
+    const parsed = JSON.parse(result?.content ?? "");
+    expect(parsed.detections).toEqual([
+      { label: "dog", bbox: [500, 600, 700, 800], confidence: 0.5 },
     ]);
   });
 

--- a/assistant/src/plugins/defaults/vision-perception/__tests__/ocr-detect.test.ts
+++ b/assistant/src/plugins/defaults/vision-perception/__tests__/ocr-detect.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { Message } from "../../../../providers/types.js";
+import type { ToolContext } from "../../../../tools/types.js";
+
+// `mock.module` is process-global, so all stubbing for the grounding tools lives
+// in this one file (the test runner runs each file in its own process). We stub
+// the provider resolution (spreading the real module so `extractAllText` keeps
+// working) and the attachment store (fixture bytes + a configurable row). Each
+// test sets `responseText` to whatever the model should "return".
+
+let responseText = "";
+
+const fakeProvider = {
+  name: "mock-vision-provider",
+  async sendMessage(_messages: Message[], _options: unknown) {
+    return {
+      content: [{ type: "text", text: responseText }],
+      model: "mock-vision-model",
+      usage: { inputTokens: 1, outputTokens: 1 },
+      stopReason: "end_turn",
+    };
+  },
+};
+
+const realPsm = await import("../../../../providers/provider-send-message.js");
+mock.module("../../../../providers/provider-send-message.js", () => ({
+  ...realPsm,
+  getConfiguredProvider: async () => fakeProvider,
+}));
+
+// A 4x2 PNG so `parseImageDimensions` returns a non-trivial size we can assert
+// on. Small enough that `optimizeImageForTransport` leaves the bytes unchanged.
+const PNG_4x2 = (() => {
+  // PNG signature + IHDR(width=4,height=2). That header is all the dimension
+  // parser reads, and the bytes are well under the optimize threshold, so this
+  // truncated file flows through to the image block (and the parser) unchanged.
+  const sig = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  const ihdr = Buffer.alloc(25);
+  ihdr.writeUInt32BE(13, 0); // length
+  ihdr.write("IHDR", 4, "ascii");
+  ihdr.writeUInt32BE(4, 8); // width = 4
+  ihdr.writeUInt32BE(2, 12); // height = 2
+  ihdr[16] = 8; // bit depth
+  ihdr[17] = 6; // color type RGBA
+  // CRC bytes left as zero — the dimension parser never validates the CRC.
+  return Buffer.concat([sig, ihdr]);
+})();
+
+interface FakeRow {
+  id: string;
+  originalFilename: string;
+  mimeType: string;
+  kind: string;
+}
+
+let attachmentRows: Record<string, FakeRow> = {};
+let attachmentBytes: Record<string, Buffer> = {};
+
+mock.module("../../../../memory/attachments-store.js", () => ({
+  getAttachmentById: (id: string) => attachmentRows[id] ?? null,
+  getAttachmentContent: (id: string) => attachmentBytes[id] ?? null,
+}));
+
+const vlmOcrTool = (await import("../tools/vlm-ocr.js")).default;
+const vlmDetectTool = (await import("../tools/vlm-detect.js")).default;
+
+const ctx = { conversationId: "c1" } as unknown as ToolContext;
+
+beforeEach(() => {
+  responseText = "";
+  attachmentRows = {
+    "att-1": {
+      id: "att-1",
+      originalFilename: "photo.png",
+      mimeType: "image/png",
+      kind: "image",
+    },
+    "att-doc": {
+      id: "att-doc",
+      originalFilename: "notes.pdf",
+      mimeType: "application/pdf",
+      kind: "document",
+    },
+  };
+  attachmentBytes = { "att-1": PNG_4x2, "att-doc": PNG_4x2 };
+});
+
+describe("vlm_ocr tool", () => {
+  test("returns the model's text as full_text with the echoed image_size", async () => {
+    responseText = "Hello world\nLine two";
+    const result = await vlmOcrTool.execute?.({ media_ref: "att-1" }, ctx);
+
+    expect(result?.isError).toBe(false);
+    const parsed = JSON.parse(result?.content ?? "");
+    expect(parsed.full_text).toBe("Hello world\nLine two");
+    expect(parsed.image_size).toEqual([4, 2]);
+    expect(parsed.blocks).toBeUndefined();
+  });
+
+  test("parses positioned blocks and normalizes their boxes when layout=true", async () => {
+    // Fractional coords (0..1) should scale up to the 0-1000 contract; an
+    // already-0-1000 box should pass through clamped.
+    responseText =
+      '```json\n{"full_text": "ABC", "blocks": [' +
+      '{"text": "A", "bbox": [0, 0, 0.5, 0.5]},' +
+      '{"text": "BC", "bbox": [100, 200, 300, 400]}' +
+      "]}\n```";
+    const result = await vlmOcrTool.execute?.(
+      { media_ref: "att-1", layout: true },
+      ctx,
+    );
+
+    expect(result?.isError).toBe(false);
+    const parsed = JSON.parse(result?.content ?? "");
+    expect(parsed.full_text).toBe("ABC");
+    expect(parsed.image_size).toEqual([4, 2]);
+    expect(parsed.blocks).toEqual([
+      { text: "A", bbox: [0, 0, 500, 500] },
+      { text: "BC", bbox: [100, 200, 300, 400] },
+    ]);
+  });
+
+  test("layout=true with malformed model output degrades to isError (no throw)", async () => {
+    responseText = "sorry, I cannot read that image";
+    const result = await vlmOcrTool.execute?.(
+      { media_ref: "att-1", layout: true },
+      ctx,
+    );
+
+    expect(result?.isError).toBe(true);
+  });
+
+  test("returns isError (no throw) for a non-image attachment", async () => {
+    responseText = "anything";
+    const result = await vlmOcrTool.execute?.({ media_ref: "att-doc" }, ctx);
+
+    expect(result?.isError).toBe(true);
+    expect(result?.content).toContain("not an image");
+  });
+});
+
+describe("vlm_detect tool", () => {
+  test("parses detections, normalizes boxes to 0-1000, and echoes image_size", async () => {
+    responseText =
+      '{"detections": [' +
+      '{"label": "cat", "bbox": [0.1, 0.2, 0.3, 0.4], "confidence": 0.9},' +
+      '{"label": "dog", "bbox": [500, 600, 700, 800], "confidence": 0.5}' +
+      "]}";
+    const result = await vlmDetectTool.execute?.({ media_ref: "att-1" }, ctx);
+
+    expect(result?.isError).toBe(false);
+    const parsed = JSON.parse(result?.content ?? "");
+    expect(parsed.image_size).toEqual([4, 2]);
+    expect(parsed.detections).toEqual([
+      { label: "cat", bbox: [100, 200, 300, 400], confidence: 0.9 },
+      { label: "dog", bbox: [500, 600, 700, 800], confidence: 0.5 },
+    ]);
+  });
+
+  test("accepts a fenced bare array of detections", async () => {
+    responseText = '```json\n[{"label": "car", "bbox": [10, 20, 30, 40]}]\n```';
+    const result = await vlmDetectTool.execute?.(
+      { media_ref: "att-1", targets: ["car"] },
+      ctx,
+    );
+
+    expect(result?.isError).toBe(false);
+    const parsed = JSON.parse(result?.content ?? "");
+    expect(parsed.detections).toEqual([
+      { label: "car", bbox: [10, 20, 30, 40], confidence: null },
+    ]);
+  });
+
+  test("malformed model output degrades to isError (no throw)", async () => {
+    responseText = "I found a cat near the top-left.";
+    const result = await vlmDetectTool.execute?.({ media_ref: "att-1" }, ctx);
+
+    expect(result?.isError).toBe(true);
+  });
+
+  test("returns isError (no throw) for a missing media_ref", async () => {
+    responseText = '{"detections": []}';
+    const result = await vlmDetectTool.execute?.(
+      { media_ref: "does-not-exist" },
+      ctx,
+    );
+
+    expect(result?.isError).toBe(true);
+    expect(result?.content).toContain("No attachment found");
+  });
+});

--- a/assistant/src/plugins/defaults/vision-perception/src/coordinates.ts
+++ b/assistant/src/plugins/defaults/vision-perception/src/coordinates.ts
@@ -50,18 +50,46 @@ function clampCoord(value: number): number {
 }
 
 /**
+ * Coerce a single raw coordinate to an actual finite number, or `null` when it
+ * isn't one.
+ *
+ * The vision model sometimes emits placeholder/uncertain coordinates like
+ * `null`, `undefined`, or an empty string instead of a number. A bare
+ * `Number(...)` would silently turn those into `0` (e.g. `Number(null) === 0`,
+ * `Number("") === 0`), fabricating a valid-looking zero coordinate. We instead
+ * reject anything that isn't already a finite number or a non-empty string that
+ * parses to one, so the box can be dropped rather than coerced to `[0,0,0,0]`.
+ */
+function toCoord(value: unknown): number | null {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed === "") return null;
+    const n = Number(trimmed);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+/**
  * Normalize a raw 4-tuple box onto the 0–{@link COORD_SCALE} contract.
  *
  * A box whose every coordinate is already within `[0, 1]` is treated as a
  * fractional box and scaled up; otherwise it is assumed to already be on (or
  * near) the 0–1000 scale and is only clamped. Coordinates are reordered so
- * `x0 <= x1` and `y0 <= y1`. Returns `null` when `raw` isn't four finite
- * numbers.
+ * `x0 <= x1` and `y0 <= y1`. Returns `null` when `raw` isn't four actual finite
+ * numbers — placeholder/uncertain coordinates (`null`, `undefined`, empty
+ * strings, NaN/Infinity) are rejected so the detection/block is dropped rather
+ * than fabricated as a zero box.
  */
 export function normalizeBox(raw: unknown): BBox | null {
   if (!Array.isArray(raw) || raw.length !== 4) return null;
-  const nums = raw.map((n) => (typeof n === "number" ? n : Number(n)));
-  if (nums.some((n) => !Number.isFinite(n))) return null;
+  const nums: number[] = [];
+  for (const n of raw) {
+    const coord = toCoord(n);
+    if (coord === null) return null;
+    nums.push(coord);
+  }
 
   const fractional = nums.every((n) => n >= 0 && n <= 1);
   const scaled = fractional ? nums.map((n) => n * COORD_SCALE) : nums;

--- a/assistant/src/plugins/defaults/vision-perception/src/coordinates.ts
+++ b/assistant/src/plugins/defaults/vision-perception/src/coordinates.ts
@@ -1,0 +1,159 @@
+/**
+ * Bounding-box contract for the grounding vision tools (`vlm_ocr`, `vlm_detect`).
+ *
+ * The Qwen vision family emits grounding coordinates on a 0–1000 scale relative
+ * to the image; we normalize everything we surface to that same contract so the
+ * model never has to reason about raw pixel dimensions. Each detection echoes
+ * `image_size: [width, height]` (the real pixel size, parsed from the resolved
+ * image bytes via `parseImageDimensions`) so a caller can map the normalized box
+ * back to pixels when it needs to.
+ *
+ * The model is asked to return JSON; in practice it sometimes wraps that JSON in
+ * a ```json fenced block or prefixes/suffixes prose, so {@link parseModelJson}
+ * is deliberately tolerant of both shapes.
+ */
+
+import { parseImageDimensions } from "../../../../context/image-dimensions.js";
+import { parseJsonSafe } from "../../../../util/json.js";
+import { resolveVisionMedia } from "./media-source.js";
+
+/** The fixed scale the grounding tools normalize boxes onto. */
+export const COORD_SCALE = 1000;
+
+/** A normalized bounding box: `[x0, y0, x1, y1]` on a 0–{@link COORD_SCALE} scale. */
+export type BBox = [number, number, number, number];
+
+/** Image pixel dimensions echoed alongside every grounding result. */
+export type ImageSize = [number, number];
+
+/**
+ * Resolve a media reference's real pixel dimensions, reading the same attachment
+ * bytes the vision call uses. Returns `[0, 0]` when the dimensions can't be
+ * parsed (an unrecognized or truncated format) — callers still get a usable
+ * result, just without a pixel-mapping anchor. Throws only what
+ * `resolveVisionMedia` throws (a missing / non-image reference), which the tools
+ * convert into `{ isError: true }`.
+ */
+export async function resolveImageSize(mediaRef: string): Promise<ImageSize> {
+  const media = await resolveVisionMedia(mediaRef);
+  const dims = parseImageDimensions(media.block.source.data, media.mimeType);
+  return dims ? [dims.width, dims.height] : [0, 0];
+}
+
+/**
+ * Clamp a single coordinate onto the `[0, COORD_SCALE]` range, rounding to an
+ * integer. Non-finite inputs (NaN, Infinity) collapse to 0.
+ */
+function clampCoord(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(COORD_SCALE, Math.max(0, Math.round(value)));
+}
+
+/**
+ * Normalize a raw 4-tuple box onto the 0–{@link COORD_SCALE} contract.
+ *
+ * A box whose every coordinate is already within `[0, 1]` is treated as a
+ * fractional box and scaled up; otherwise it is assumed to already be on (or
+ * near) the 0–1000 scale and is only clamped. Coordinates are reordered so
+ * `x0 <= x1` and `y0 <= y1`. Returns `null` when `raw` isn't four finite
+ * numbers.
+ */
+export function normalizeBox(raw: unknown): BBox | null {
+  if (!Array.isArray(raw) || raw.length !== 4) return null;
+  const nums = raw.map((n) => (typeof n === "number" ? n : Number(n)));
+  if (nums.some((n) => !Number.isFinite(n))) return null;
+
+  const fractional = nums.every((n) => n >= 0 && n <= 1);
+  const scaled = fractional ? nums.map((n) => n * COORD_SCALE) : nums;
+
+  const [a, b, c, d] = scaled.map(clampCoord);
+  return [Math.min(a, c), Math.min(b, d), Math.max(a, c), Math.max(b, d)];
+}
+
+/**
+ * Normalize a list of raw boxes, dropping any that aren't valid 4-tuples.
+ * `imageSize` is accepted for interface symmetry with callers that thread the
+ * echoed size through; normalization itself is size-independent because the
+ * contract is a fixed 0–1000 scale.
+ */
+export function normalizeBoxes(raw: unknown, _imageSize: ImageSize): BBox[] {
+  if (!Array.isArray(raw)) return [];
+  const out: BBox[] = [];
+  for (const candidate of raw) {
+    const box = normalizeBox(candidate);
+    if (box) out.push(box);
+  }
+  return out;
+}
+
+/**
+ * Parse JSON out of a model response that may be a bare JSON value, JSON wrapped
+ * in a ```json (or plain ```) fenced block, or JSON embedded in surrounding
+ * prose. Returns `null` when nothing parses — callers degrade to
+ * `{ isError: true }` rather than throwing.
+ */
+export function parseModelJson(text: string): unknown {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+
+  // 1. Bare JSON.
+  const direct = parseJsonSafe(trimmed);
+  if (direct !== null) return direct;
+
+  // 2. Fenced block: ```json ... ``` or ``` ... ```.
+  const fenced = /```(?:json)?\s*([\s\S]*?)```/i.exec(trimmed);
+  if (fenced?.[1]) {
+    const parsed = parseJsonSafe(fenced[1].trim());
+    if (parsed !== null) return parsed;
+  }
+
+  // 3. First {...} or [...] span embedded in prose.
+  const span = extractJsonSpan(trimmed);
+  if (span) {
+    const parsed = parseJsonSafe(span);
+    if (parsed !== null) return parsed;
+  }
+
+  return null;
+}
+
+/**
+ * Extract the first balanced `{...}` or `[...]` span from `text`, ignoring
+ * braces/brackets that appear inside string literals. Returns `null` when no
+ * candidate opener is found.
+ */
+function extractJsonSpan(text: string): string | null {
+  const objStart = text.indexOf("{");
+  const arrStart = text.indexOf("[");
+  const start =
+    objStart === -1
+      ? arrStart
+      : arrStart === -1
+        ? objStart
+        : Math.min(objStart, arrStart);
+  if (start === -1) return null;
+
+  const open = text[start];
+  const close = open === "{" ? "}" : "]";
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') inString = true;
+    else if (ch === open) depth++;
+    else if (ch === close) {
+      depth--;
+      if (depth === 0) return text.slice(start, i + 1);
+    }
+  }
+
+  return null;
+}

--- a/assistant/src/plugins/defaults/vision-perception/tools/vlm-detect.ts
+++ b/assistant/src/plugins/defaults/vision-perception/tools/vlm-detect.ts
@@ -1,0 +1,136 @@
+/**
+ * The `vlm_detect` tool — locates objects in a provided image, returning each
+ * detection as a normalized bounding box.
+ *
+ * The model passes the image's attachment id as `media_ref` and optionally a
+ * list of `targets` to look for (otherwise all salient objects). The plugin asks
+ * the vision model for detections as JSON, parses that response, normalizes each
+ * box onto the 0–1000 grounding contract, and echoes the image's pixel
+ * `image_size`.
+ *
+ * Default export = the tool definition. `defaults/index.ts` finalizes it and
+ * attaches it to the vision-perception plugin's `tools` array, which
+ * `bootstrapPlugins` registers into the model-visible tool catalog.
+ */
+
+import type {
+  ToolContext,
+  ToolDefinition,
+  ToolExecutionResult,
+} from "@vellumai/plugin-api";
+import { RiskLevel } from "@vellumai/plugin-api";
+
+import { callVisionModel } from "../src/call-vision-model.js";
+import {
+  type BBox,
+  type ImageSize,
+  normalizeBox,
+  parseModelJson,
+  resolveImageSize,
+} from "../src/coordinates.js";
+
+interface Detection {
+  label: string;
+  bbox: BBox;
+  confidence: number | null;
+}
+
+interface DetectResult {
+  detections: Detection[];
+  image_size: ImageSize;
+}
+
+function buildDetectPrompt(targets: string[]): string {
+  const what =
+    targets.length > 0
+      ? `Detect the following objects in this image: ${targets.join(", ")}.`
+      : "Detect all salient objects in this image.";
+  return (
+    `${what} Respond with ONLY a JSON object of the form ` +
+    '{"detections": [{"label": "<object name>", "bbox": [x0, y0, x1, y1], ' +
+    '"confidence": <0..1>}]} where each bbox is the object\'s bounding box on a ' +
+    "0-1000 scale relative to the image. Omit objects you cannot find. Do not " +
+    "include any prose outside the JSON."
+  );
+}
+
+function toConfidence(raw: unknown): number | null {
+  const n = typeof raw === "number" ? raw : Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Parse the model's response into detections. Throws when the response isn't the
+ * expected JSON so the tool can degrade to an error. Accepts either a
+ * `{ detections: [...] }` object or a bare array of detections.
+ */
+function parseDetections(text: string, imageSize: ImageSize): DetectResult {
+  const parsed = parseModelJson(text);
+  let rawList: unknown;
+  if (Array.isArray(parsed)) {
+    rawList = parsed;
+  } else if (parsed && typeof parsed === "object") {
+    rawList = (parsed as Record<string, unknown>).detections;
+  } else {
+    throw new Error("vision model did not return JSON detections");
+  }
+  if (!Array.isArray(rawList)) {
+    throw new Error("vision model did not return a detections array");
+  }
+
+  const detections: Detection[] = [];
+  for (const entry of rawList) {
+    if (!entry || typeof entry !== "object") continue;
+    const obj = entry as Record<string, unknown>;
+    const bbox = normalizeBox(obj.bbox);
+    if (!bbox) continue;
+    detections.push({
+      label: typeof obj.label === "string" ? obj.label : "",
+      bbox,
+      confidence: toConfidence(obj.confidence),
+    });
+  }
+
+  return { detections, image_size: imageSize };
+}
+
+const vlmDetectTool: ToolDefinition = {
+  name: "vlm_detect",
+  description:
+    "Use to locate objects in a provided image and get their bounding boxes. " +
+    "Pass the attachment id as media_ref; optionally pass targets to detect " +
+    "specific objects. Boxes are returned on a 0-1000 scale with the image size.",
+  input_schema: {
+    type: "object",
+    properties: {
+      media_ref: { type: "string" },
+      targets: { type: "array", items: { type: "string" } },
+    },
+    required: ["media_ref"],
+  },
+  // Read-only image inspection; low risk so the call isn't gated behind a prompt.
+  defaultRiskLevel: RiskLevel.Low,
+  async execute(
+    input: Record<string, unknown>,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    try {
+      const mediaRef = String(input.media_ref ?? "");
+      const targets = Array.isArray(input.targets)
+        ? input.targets.filter((t): t is string => typeof t === "string")
+        : [];
+
+      const imageSize = await resolveImageSize(mediaRef);
+      const prompt = buildDetectPrompt(targets);
+      const answer = await callVisionModel(mediaRef, prompt, ctx);
+
+      const result = parseDetections(answer, imageSize);
+      return { content: JSON.stringify(result), isError: false };
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      return { content: reason, isError: true };
+    }
+  },
+};
+
+export default vlmDetectTool;

--- a/assistant/src/plugins/defaults/vision-perception/tools/vlm-ocr.ts
+++ b/assistant/src/plugins/defaults/vision-perception/tools/vlm-ocr.ts
@@ -1,0 +1,133 @@
+/**
+ * The `vlm_ocr` tool — extracts text from a provided image.
+ *
+ * The model passes the image's attachment id as `media_ref`, optionally narrows
+ * to a `region`, and sets `layout` to also recover positioned text blocks. The
+ * plugin asks the vision model to extract the text (returning JSON when `layout`
+ * is on), parses that response, normalizes any block boxes onto the 0–1000
+ * grounding contract, and echoes the image's pixel `image_size`.
+ *
+ * Default export = the tool definition. `defaults/index.ts` finalizes it and
+ * attaches it to the vision-perception plugin's `tools` array, which
+ * `bootstrapPlugins` registers into the model-visible tool catalog.
+ */
+
+import type {
+  ToolContext,
+  ToolDefinition,
+  ToolExecutionResult,
+} from "@vellumai/plugin-api";
+import { RiskLevel } from "@vellumai/plugin-api";
+
+import { callVisionModel } from "../src/call-vision-model.js";
+import {
+  type BBox,
+  type ImageSize,
+  normalizeBox,
+  parseModelJson,
+  resolveImageSize,
+} from "../src/coordinates.js";
+
+interface OcrBlock {
+  text: string;
+  bbox: BBox;
+}
+
+interface OcrResult {
+  full_text: string;
+  blocks?: OcrBlock[];
+  image_size: ImageSize;
+}
+
+function buildOcrPrompt(region: BBox | null, layout: boolean): string {
+  const lens = region
+    ? ` Only read text inside the region [x0,y0,x1,y1]=[${region.join(", ")}] ` +
+      "given on a 0-1000 scale relative to the image."
+    : "";
+  if (layout) {
+    return (
+      `Extract all readable text from this image.${lens} ` +
+      "Respond with ONLY a JSON object of the form " +
+      '{"full_text": "<all text joined in reading order>", ' +
+      '"blocks": [{"text": "<text of this block>", "bbox": [x0, y0, x1, y1]}]} ' +
+      "where each bbox is the block's bounding box on a 0-1000 scale relative " +
+      "to the image. Do not include any prose outside the JSON."
+    );
+  }
+  return (
+    `Extract all readable text from this image.${lens} ` +
+    "Return only the transcribed text, in natural reading order, with no commentary."
+  );
+}
+
+function asBoxOrZero(raw: unknown): BBox {
+  return normalizeBox(raw) ?? [0, 0, 0, 0];
+}
+
+/**
+ * Parse the model's `layout` response into positioned blocks. Throws when the
+ * response isn't the expected JSON object so the tool can degrade to an error.
+ */
+function parseLayout(text: string, imageSize: ImageSize): OcrResult {
+  const parsed = parseModelJson(text);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("vision model did not return a JSON OCR object");
+  }
+  const obj = parsed as Record<string, unknown>;
+  const rawBlocks = Array.isArray(obj.blocks) ? obj.blocks : [];
+  const blocks: OcrBlock[] = rawBlocks
+    .filter((b): b is Record<string, unknown> => !!b && typeof b === "object")
+    .map((b) => ({
+      text: typeof b.text === "string" ? b.text : "",
+      bbox: asBoxOrZero(b.bbox),
+    }));
+  const fullText =
+    typeof obj.full_text === "string"
+      ? obj.full_text
+      : blocks.map((b) => b.text).join("\n");
+  return { full_text: fullText, blocks, image_size: imageSize };
+}
+
+const vlmOcrTool: ToolDefinition = {
+  name: "vlm_ocr",
+  description:
+    "Use to extract (OCR) the text from a provided image. Pass the attachment " +
+    "id as media_ref. Set layout=true to also get the text broken into " +
+    "positioned blocks with bounding boxes.",
+  input_schema: {
+    type: "object",
+    properties: {
+      media_ref: { type: "string" },
+      region: { type: "array", items: { type: "number" } },
+      layout: { type: "boolean" },
+    },
+    required: ["media_ref"],
+  },
+  // Read-only image inspection; low risk so the call isn't gated behind a prompt.
+  defaultRiskLevel: RiskLevel.Low,
+  async execute(
+    input: Record<string, unknown>,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    try {
+      const mediaRef = String(input.media_ref ?? "");
+      const region = normalizeBox(input.region);
+      const layout = input.layout === true;
+
+      const imageSize = await resolveImageSize(mediaRef);
+      const prompt = buildOcrPrompt(region, layout);
+      const answer = await callVisionModel(mediaRef, prompt, ctx);
+
+      const result: OcrResult = layout
+        ? parseLayout(answer, imageSize)
+        : { full_text: answer, image_size: imageSize };
+
+      return { content: JSON.stringify(result), isError: false };
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      return { content: reason, isError: true };
+    }
+  },
+};
+
+export default vlmOcrTool;

--- a/assistant/src/plugins/defaults/vision-perception/tools/vlm-ocr.ts
+++ b/assistant/src/plugins/defaults/vision-perception/tools/vlm-ocr.ts
@@ -60,13 +60,12 @@ function buildOcrPrompt(region: BBox | null, layout: boolean): string {
   );
 }
 
-function asBoxOrZero(raw: unknown): BBox {
-  return normalizeBox(raw) ?? [0, 0, 0, 0];
-}
-
 /**
  * Parse the model's `layout` response into positioned blocks. Throws when the
  * response isn't the expected JSON object so the tool can degrade to an error.
+ * Blocks whose `bbox` isn't four actual finite numbers are dropped rather than
+ * fabricated as a zero box (the model sometimes emits placeholder/uncertain
+ * coordinates like `null` or empty strings).
  */
 function parseLayout(text: string, imageSize: ImageSize): OcrResult {
   const parsed = parseModelJson(text);
@@ -75,12 +74,17 @@ function parseLayout(text: string, imageSize: ImageSize): OcrResult {
   }
   const obj = parsed as Record<string, unknown>;
   const rawBlocks = Array.isArray(obj.blocks) ? obj.blocks : [];
-  const blocks: OcrBlock[] = rawBlocks
-    .filter((b): b is Record<string, unknown> => !!b && typeof b === "object")
-    .map((b) => ({
-      text: typeof b.text === "string" ? b.text : "",
-      bbox: asBoxOrZero(b.bbox),
-    }));
+  const blocks: OcrBlock[] = [];
+  for (const b of rawBlocks) {
+    if (!b || typeof b !== "object") continue;
+    const block = b as Record<string, unknown>;
+    const bbox = normalizeBox(block.bbox);
+    if (!bbox) continue;
+    blocks.push({
+      text: typeof block.text === "string" ? block.text : "",
+      bbox,
+    });
+  }
   const fullText =
     typeof obj.full_text === "string"
       ? obj.full_text


### PR DESCRIPTION
## Summary
- Add vlm_ocr (text/layout) and vlm_detect (0-1000 normalized bboxes + image_size) to the vision-perception plugin

Part of plan: glm-5v-turbo-vlm-tool.md (PR 6 of 8)