### PR TITLE
feat(plugins): activate vision perception only for non-vision backbones

### DIFF
--- a/assistant/src/__tests__/attachments.test.ts
+++ b/assistant/src/__tests__/attachments.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, test } from "bun:test";
 
 import {
   attachmentsToContentBlocks,
+  backfillAttachmentId,
   enrichMessageWithSourcePaths,
 } from "../agent/attachments.js";
 import { createUserMessage } from "../agent/message-types.js";
+import type { FileContent, ImageContent } from "../providers/types.js";
 
 // ---------------------------------------------------------------------------
 // attachmentsToContentBlocks
@@ -142,6 +144,73 @@ describe("createUserMessage with image attachments", () => {
     expect(imageBlock.source.data).toBe(base64);
     expect(imageBlock.source.media_type).toBe("image/jpeg");
     expect(imageBlock.source.type).toBe("base64");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// backfillAttachmentId
+// ---------------------------------------------------------------------------
+
+describe("backfillAttachmentId", () => {
+  test("tags the image block for an inline (id-less) upload", () => {
+    // Inline uploads have no attachment id when the message is built, so the
+    // block starts without `_attachmentId`. The id is minted later and must be
+    // backfilled onto the in-memory block.
+    const msg = createUserMessage("what is this?", [
+      { filename: "photo.jpg", mimeType: "image/jpeg", data: "imgdata" },
+    ]);
+    expect((msg.content[1] as ImageContent)._attachmentId).toBeUndefined();
+
+    backfillAttachmentId(msg, 0, "att-123");
+
+    expect((msg.content[1] as ImageContent)._attachmentId).toBe("att-123");
+  });
+
+  test("maps attachment index to the Nth media block, skipping text", () => {
+    const msg = createUserMessage("compare these", [
+      { filename: "a.jpg", mimeType: "image/jpeg", data: "img1" },
+      { filename: "b.png", mimeType: "image/png", data: "img2" },
+    ]);
+    // content: [text, image, image]
+    backfillAttachmentId(msg, 0, "att-a");
+    backfillAttachmentId(msg, 1, "att-b");
+
+    expect((msg.content[1] as ImageContent)._attachmentId).toBe("att-a");
+    expect((msg.content[2] as ImageContent)._attachmentId).toBe("att-b");
+  });
+
+  test("counts file blocks toward the index alongside images", () => {
+    const msg = createUserMessage("look", [
+      { filename: "doc.pdf", mimeType: "application/pdf", data: "pdfdata" },
+      { filename: "photo.jpg", mimeType: "image/jpeg", data: "imgdata" },
+    ]);
+    // content: [text, file, image]
+    backfillAttachmentId(msg, 1, "att-img");
+
+    expect((msg.content[1] as FileContent)._attachmentId).toBeUndefined();
+    expect((msg.content[2] as ImageContent)._attachmentId).toBe("att-img");
+  });
+
+  test("does not overwrite an id already present on the block", () => {
+    const blocks = attachmentsToContentBlocks([
+      {
+        id: "preexisting",
+        filename: "photo.jpg",
+        mimeType: "image/jpeg",
+        data: "imgdata",
+      },
+    ]);
+    const msg = { role: "user" as const, content: blocks };
+    backfillAttachmentId(msg, 0, "att-new");
+
+    expect((msg.content[0] as ImageContent)._attachmentId).toBe("preexisting");
+  });
+
+  test("is a no-op when the target index has no media block", () => {
+    const msg = createUserMessage("just text", []);
+    expect(() => backfillAttachmentId(msg, 0, "att-x")).not.toThrow();
+    expect(msg.content).toHaveLength(1);
+    expect(msg.content[0].type).toBe("text");
   });
 });
 

--- a/assistant/src/__tests__/inline-upload-media-ref.test.ts
+++ b/assistant/src/__tests__/inline-upload-media-ref.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Codex P2 — "Preserve media refs for inline uploads".
+ *
+ * For an INLINE image upload (data only, no preexisting attachment id), the
+ * LLM message body is built and pushed onto `ctx.messages` before the
+ * attachment row exists — `attachInlineAttachmentToMessage` mints the id later
+ * in the same persist call. Without a backfill, the in-memory image block never
+ * carries `_attachmentId`, so for a non-vision backbone the vision-perception
+ * marker rewrite finds no id and the uploaded image becomes unreachable by the
+ * `vlm_*` tools (no usable `media_ref`).
+ *
+ * This test drives `persistQueuedMessageBody` directly (same entry point as
+ * `dm-persistence.test.ts`) with a stubbed attachments store that mints a
+ * deterministic id, then asserts:
+ *   1. the in-memory image block is backfilled with the minted id, and
+ *   2. `applyVisionPerceptionMarkers` (non-vision backbone) replaces the block
+ *      with a marker whose `media_ref` is that real id.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+mock.module("../util/logger.js", () => ({
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+let nextAttachmentId = 0;
+const inlineAttachCalls: Array<{ messageId: string; position: number }> = [];
+
+mock.module("../memory/conversation-crud.js", () => ({
+  addMessage: async () => ({ id: "persisted-msg" }),
+  getConversation: () => null,
+  provenanceFromTrustContext: () => ({}),
+  setConversationOriginChannelIfUnset: () => {},
+  setConversationOriginInterfaceIfUnset: () => {},
+  extractImageSourcePaths: () => undefined,
+}));
+
+mock.module("../memory/conversation-disk-view.js", () => ({
+  syncMessageToDisk: () => {},
+  updateMetaFile: () => {},
+}));
+
+mock.module("../memory/attachments-store.js", () => ({
+  // No attachment exists yet — this is an inline upload, not a re-link.
+  attachmentExists: () => false,
+  linkAttachmentToMessage: () => {},
+  validateAttachmentUpload: () => ({ ok: true }),
+  AttachmentUploadError: class extends Error {},
+  attachInlineAttachmentToMessage: (messageId: string, position: number) => {
+    inlineAttachCalls.push({ messageId, position });
+    const id = `att-${nextAttachmentId++}`;
+    return {
+      id,
+      originalFilename: "photo.jpg",
+      mimeType: "image/jpeg",
+      sizeBytes: 10,
+      kind: "image",
+      thumbnailBase64: null,
+      createdAt: Date.now(),
+    };
+  },
+}));
+
+import type { MessagingConversationContext } from "../daemon/conversation-messaging.js";
+import { persistQueuedMessageBody } from "../daemon/conversation-messaging.js";
+import type { MessageQueue } from "../daemon/conversation-queue-manager.js";
+import { applyVisionPerceptionMarkers } from "../plugins/defaults/vision-perception/hooks/pre-model-call.js";
+import type { ImageContent, Message } from "../providers/types.js";
+
+function createContext(): MessagingConversationContext & {
+  messages: Message[];
+} {
+  const queueStub = {
+    push: () => true,
+    drain: () => [],
+    size: () => 0,
+  } as unknown as MessageQueue;
+  let processing = false;
+  return {
+    conversationId: "conv-inline-test",
+    messages: [],
+    isProcessing: () => processing,
+    setProcessing: (value: boolean) => {
+      processing = value;
+    },
+    abortController: null,
+    queue: queueStub,
+    getTurnChannelContext: () => null,
+    getTurnInterfaceContext: () => null,
+  } as unknown as MessagingConversationContext & { messages: Message[] };
+}
+
+const PNG_1x1 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+
+describe("Codex P2 — inline upload media_ref", () => {
+  beforeEach(() => {
+    nextAttachmentId = 0;
+    inlineAttachCalls.length = 0;
+  });
+
+  test("backfills the minted attachment id onto the in-memory image block", async () => {
+    const ctx = createContext();
+    await persistQueuedMessageBody(ctx, {
+      content: "what is in this image?",
+      attachments: [
+        // Inline upload: data only, no preexisting `id`.
+        { filename: "photo.jpg", mimeType: "image/jpeg", data: PNG_1x1 },
+      ],
+      requestId: "req-inline",
+    });
+
+    expect(inlineAttachCalls).toHaveLength(1);
+    expect(inlineAttachCalls[0].position).toBe(0);
+
+    // The in-memory message (the one the model loop reads) must now carry the
+    // freshly-minted attachment id on its image block.
+    const message = ctx.messages.at(-1)!;
+    const imageBlock = message.content.find(
+      (b) => b.type === "image",
+    ) as ImageContent;
+    expect(imageBlock).toBeDefined();
+    expect(imageBlock._attachmentId).toBe("att-0");
+  });
+
+  test("non-vision backbone surfaces the real id as the marker media_ref", async () => {
+    const ctx = createContext();
+    await persistQueuedMessageBody(ctx, {
+      content: "describe this",
+      attachments: [
+        { filename: "photo.jpg", mimeType: "image/jpeg", data: PNG_1x1 },
+      ],
+      requestId: "req-inline-marker",
+    });
+
+    // Simulate the outbound sanitization for a non-vision backbone.
+    const rewritten = applyVisionPerceptionMarkers(ctx.messages, false);
+    const userMsg = rewritten.at(-1)!;
+    const marker = userMsg.content.find(
+      (b) => b.type === "text" && b.text.includes('media_ref="att-0"'),
+    ) as { type: "text"; text: string } | undefined;
+
+    // The raw image must be gone (no bytes to a non-vision model) and replaced
+    // by a marker that names the real attachment id as the media_ref the
+    // vlm_* tools can resolve.
+    expect(userMsg.content.some((b) => b.type === "image")).toBe(false);
+    expect(marker).toBeDefined();
+    expect(marker!.text).toContain('id="att-0"');
+    expect(marker!.text).toContain('media_ref="att-0"');
+  });
+});

--- a/assistant/src/agent/attachments.ts
+++ b/assistant/src/agent/attachments.ts
@@ -45,6 +45,40 @@ export function attachmentsToContentBlocks(
 }
 
 /**
+ * Backfill an attachment id onto the in-memory content block for the
+ * `attachmentIndex`-th uploaded attachment.
+ *
+ * Inline (data-only) uploads have no attachment id when the message body is
+ * built — the id is minted later, when the attachment row is created and linked
+ * to the persisted message. Without this backfill the image/file block sent to
+ * the model never carries `_attachmentId`, so downstream consumers (notably the
+ * vision-perception media markers) cannot correlate the block back to a usable
+ * `media_ref`.
+ *
+ * Attachment blocks are appended to `message.content` in attachment order by
+ * {@link attachmentsToContentBlocks}, after any leading text block and before
+ * any trailing source-path annotation, so the `attachmentIndex`-th `image`/
+ * `file` block is the one to tag. Mutates the block in place (the caller holds
+ * the same reference the model loop reads). A no-op if the target block is
+ * missing or already carries an id.
+ */
+export function backfillAttachmentId(
+  message: Message,
+  attachmentIndex: number,
+  attachmentId: string,
+): void {
+  let seen = 0;
+  for (const block of message.content) {
+    if (block.type !== "image" && block.type !== "file") continue;
+    if (seen === attachmentIndex) {
+      if (!block._attachmentId) block._attachmentId = attachmentId;
+      return;
+    }
+    seen++;
+  }
+}
+
+/**
  * Return a copy of the message with text annotations for image source paths.
  * The annotations are appended as a text content block so the LLM knows where
  * the images came from on disk. The caller should persist the ORIGINAL message

--- a/assistant/src/agent/attachments.ts
+++ b/assistant/src/agent/attachments.ts
@@ -26,6 +26,7 @@ export function attachmentsToContentBlocks(
           media_type: mediaType,
           data,
         },
+        ...(attachment.id ? { _attachmentId: attachment.id } : {}),
       } as ContentBlock;
     }
 

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -27,6 +27,10 @@ import type {
 } from "../plugin-api/types.js";
 import { defaultCompact } from "../plugins/defaults/compaction/compact.js";
 import type { ContextWindowResult } from "../plugins/defaults/compaction/window-manager.js";
+import {
+  applyVisionPerceptionMarkers,
+  resolveBackboneSupportsVision,
+} from "../plugins/defaults/vision-perception/hooks/pre-model-call.js";
 import { runHook } from "../plugins/pipeline.js";
 import type { CompactionCircuitEvent } from "../plugins/types.js";
 import { normalizeThinkingConfigForWire } from "../providers/thinking-config.js";
@@ -1346,7 +1350,18 @@ export class AgentLoop {
         // Sanitize the outbound history right before sending: drop accumulated
         // media, collapse old AX-tree snapshots, and convert historical
         // web-search results to text. See {@link preModelCallSanitize}.
-        const providerHistory = preModelCallSanitize(history);
+        // Then, for a backbone that lacks native vision, replace each uploaded
+        // image with a marker naming its attachment id so the model never
+        // receives raw bytes it cannot read and instead reaches for the vlm_*
+        // tools (no-op for vision-capable backbones — feature stays inert).
+        const providerHistory = applyVisionPerceptionMarkers(
+          preModelCallSanitize(history),
+          resolveBackboneSupportsVision({
+            callSite: callSite ?? null,
+            overrideProfile: effectiveOverrideProfile ?? null,
+            selectionSeed: this.conversationId ?? null,
+          }),
+        );
 
         // A `pre-model-call` hook (below) can defer this turn's assistant
         // output; when set, the live text stream is held so an

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -8,6 +8,7 @@
 import { v4 as uuid } from "uuid";
 
 import {
+  backfillAttachmentId,
   enrichMessageWithSourcePaths,
   type MessageAttachmentInput,
 } from "../agent/attachments.js";
@@ -593,7 +594,7 @@ export async function persistQueuedMessageBody(
           );
           continue;
         }
-        attachInlineAttachmentToMessage(
+        const stored = attachInlineAttachmentToMessage(
           persistedUserMessage.id,
           i,
           a.filename,
@@ -601,6 +602,11 @@ export async function persistQueuedMessageBody(
           a.data,
           { sourcePath: a.filePath },
         );
+        // Inline uploads arrive without an attachment id, so the content block
+        // built above (and held by ctx.messages) has no `_attachmentId`. Backfill
+        // the freshly-minted id so the model loop can surface a usable media_ref
+        // (e.g. the vision-perception markers for non-vision backbones).
+        backfillAttachmentId(llmMessage, i, stored.id);
       } catch (err) {
         if (err instanceof AttachmentUploadError) {
           log.warn(

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -18,6 +18,10 @@ import { getBindingByConversation } from "../memory/external-conversation-store.
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
 import { advisorEnabledForProfile } from "../plugins/defaults/advisor/advisor-gate.js";
+import {
+  isVlmToolName,
+  resolveBackboneSupportsVision,
+} from "../plugins/defaults/vision-perception/hooks/pre-model-call.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { registerConversationSender } from "../tools/browser/browser-screencast.js";
@@ -609,6 +613,18 @@ export function isToolActiveForContext(
     // hooks run, so a hook that re-routes the profile mid-turn (the model-router
     // lever on `PreModelCallContext.modelProfile`) is not reflected here.
     return advisorEnabledForProfile(ctx.currentTurnOverrideProfile ?? null);
+  }
+  if (isVlmToolName(name)) {
+    // Vision perception only engages for backbones that lack native vision:
+    // offer the `vlm_*` tools only when the resolved backbone can't see images
+    // itself. A vision-capable model reads uploaded media directly, so the tool
+    // would be dead weight — omit it. Resolves the model the same way dispatch
+    // does (the per-turn override, else the active profile / call-site default).
+    return !resolveBackboneSupportsVision({
+      callSite: ctx.currentCallSite ?? null,
+      overrideProfile: ctx.currentTurnOverrideProfile ?? null,
+      selectionSeed: ctx.conversationId ?? null,
+    });
   }
   if (UI_SURFACE_TOOL_NAMES.has(name)) {
     if (

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -76,6 +76,7 @@ import toolErrorPostToolUse from "./tool-error/hooks/post-tool-use.js";
 import toolErrorPkg from "./tool-error/package.json" with { type: "json" };
 import toolResultTruncatePostToolUse from "./tool-result-truncate/hooks/post-tool-use.js";
 import toolResultTruncatePkg from "./tool-result-truncate/package.json" with { type: "json" };
+import visionPerceptionPreModelCall from "./vision-perception/hooks/pre-model-call.js";
 import visionPerceptionPkg from "./vision-perception/package.json" with { type: "json" };
 import vlmAskTool from "./vision-perception/tools/vlm-ask.js";
 import vlmDescribeTool from "./vision-perception/tools/vlm-describe.js";
@@ -340,12 +341,21 @@ export const defaultAdvisorPlugin: Plugin = {
  * the `vision-perception` feature flag — `bootstrapPlugins` skips it (no tool
  * contributions) when the flag is off. `finalizeTool` fills each tool's defaults
  * so it satisfies `Tool`.
+ *
+ * The feature only engages for backbones that lack native vision: the per-turn
+ * tool gate omits the `vlm_*` tools for vision-capable models, and for non-vision
+ * backbones the outbound request swaps each uploaded image for a marker naming
+ * its attachment id (a usable `media_ref`). The `pre-model-call` hook is the
+ * home for that gating logic (see `hooks/pre-model-call.ts`).
  */
 export const visionPerceptionPlugin: Plugin = {
   manifest: {
     name: visionPerceptionPkg.name,
     version: visionPerceptionPkg.version,
     requiresFlag: ["vision-perception"],
+  },
+  hooks: {
+    "pre-model-call": visionPerceptionPreModelCall,
   },
   tools: [
     finalizeTool(vlmAskTool, "vlm_ask"),

--- a/assistant/src/plugins/defaults/vision-perception/__tests__/pre-model-call.test.ts
+++ b/assistant/src/plugins/defaults/vision-perception/__tests__/pre-model-call.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { ImageContent, Message } from "../../../../providers/types.js";
+
+// The gate resolves the turn's effective provider/model via the LLM resolver and
+// reads `supportsVision` from the real model catalog, behind the
+// `vision-perception` feature flag. We drive all three with controllable mocks.
+let flagEnabled = true;
+let resolvedProviderModel: { provider: string; model: string } = {
+  provider: "anthropic",
+  model: "claude-opus-4-8",
+};
+
+mock.module("../../../../config/loader.js", () => ({
+  getConfig: () => ({ llm: { profiles: {}, default: {} } }),
+}));
+mock.module("../../../../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: () => flagEnabled,
+}));
+mock.module("../../../../config/llm-resolver.js", () => ({
+  resolveCallSiteConfig: () => resolvedProviderModel,
+}));
+
+// Attachment-store lookup supplies the marker's filename. Configurable per test.
+let attachmentFilenames: Record<string, string> = {};
+mock.module("../../../../memory/attachments-store.js", () => ({
+  getAttachmentById: (id: string) =>
+    attachmentFilenames[id]
+      ? { originalFilename: attachmentFilenames[id] }
+      : null,
+}));
+
+const {
+  applyVisionPerceptionMarkers,
+  resolveBackboneSupportsVision,
+  isVlmToolName,
+} = await import("../hooks/pre-model-call.js");
+
+// Vision-capable (anthropic/claude-opus-4-8) and non-vision
+// (fireworks/glm-5p2) catalog entries.
+const VISION_MODEL = { provider: "anthropic", model: "claude-opus-4-8" };
+const NON_VISION_MODEL = {
+  provider: "fireworks",
+  model: "accounts/fireworks/models/glm-5p2",
+};
+
+function imageMessage(attachmentId?: string): Message {
+  const block: ImageContent = {
+    type: "image",
+    source: { type: "base64", media_type: "image/png", data: "AAAA" },
+    ...(attachmentId ? { _attachmentId: attachmentId } : {}),
+  };
+  return { role: "user", content: [{ type: "text", text: "look" }, block] };
+}
+
+const gate = () =>
+  resolveBackboneSupportsVision({
+    callSite: "mainAgent",
+    overrideProfile: null,
+    selectionSeed: "conv-1",
+  });
+
+beforeEach(() => {
+  flagEnabled = true;
+  resolvedProviderModel = { ...VISION_MODEL };
+  attachmentFilenames = { "att-1": "photo.png" };
+});
+
+describe("vision-capable backbone keeps the feature inert", () => {
+  test("vlm_* tools are not offered and media blocks pass through unchanged", () => {
+    resolvedProviderModel = { ...VISION_MODEL };
+
+    // Tool gate: a vision-capable backbone reports supportsVision === true,
+    // which the tool resolver reads as "omit the vlm_* tools".
+    expect(gate()).toBe(true);
+    expect(isVlmToolName("vlm_ask")).toBe(true);
+
+    // Media passes through untouched (same reference, raw image preserved).
+    const messages = [imageMessage("att-1")];
+    const out = applyVisionPerceptionMarkers(messages, gate());
+    expect(out).toBe(messages);
+    expect(out[0].content[1]).toMatchObject({ type: "image" });
+  });
+});
+
+describe("non-vision backbone surfaces a usable media_ref", () => {
+  test("image block becomes a marker whose media_ref is the attachment id; tools stay offered", () => {
+    resolvedProviderModel = { ...NON_VISION_MODEL };
+
+    // Tool gate: a non-vision backbone reports supportsVision === false, which
+    // the tool resolver reads as "offer the vlm_* tools".
+    expect(gate()).toBe(false);
+
+    const out = applyVisionPerceptionMarkers([imageMessage("att-1")], gate());
+    const blocks = out[0].content;
+
+    // The raw image is gone; the model never receives image bytes.
+    expect(blocks.some((b) => b.type === "image")).toBe(false);
+
+    // A text marker replaced it, carrying the attachment id as media_ref
+    // (closes Codex P1: the uploaded image exposes a usable media_ref).
+    const marker = blocks.find(
+      (b) => b.type === "text" && b.text.includes("id="),
+    );
+    expect(marker).toBeDefined();
+    const text = (marker as { text: string }).text;
+    expect(text).toContain('id="att-1"');
+    expect(text).toContain('media_ref="att-1"');
+    expect(text).toContain('file "photo.png"');
+    expect(text).toContain("vlm_ask");
+  });
+});
+
+describe("no media attachments", () => {
+  test("non-vision backbone leaves an attachment-free request unchanged", () => {
+    resolvedProviderModel = { ...NON_VISION_MODEL };
+    const messages: Message[] = [
+      { role: "user", content: [{ type: "text", text: "hello" }] },
+    ];
+    const out = applyVisionPerceptionMarkers(messages, gate());
+    expect(out).toBe(messages);
+  });
+
+  test("an image block without an attachment id is left intact (no usable media_ref)", () => {
+    resolvedProviderModel = { ...NON_VISION_MODEL };
+    const messages = [imageMessage()];
+    const out = applyVisionPerceptionMarkers(messages, gate());
+    expect(out).toBe(messages);
+    expect(out[0].content[1]).toMatchObject({ type: "image" });
+  });
+});
+
+describe("feature flag gating", () => {
+  test("flag off makes a non-vision backbone report inert (supportsVision true)", () => {
+    flagEnabled = false;
+    resolvedProviderModel = { ...NON_VISION_MODEL };
+    expect(gate()).toBe(true);
+
+    // With the gate inert, media passes through and no marker is injected.
+    const messages = [imageMessage("att-1")];
+    expect(applyVisionPerceptionMarkers(messages, gate())).toBe(messages);
+  });
+});

--- a/assistant/src/plugins/defaults/vision-perception/hooks/pre-model-call.ts
+++ b/assistant/src/plugins/defaults/vision-perception/hooks/pre-model-call.ts
@@ -1,0 +1,185 @@
+/**
+ * `pre-model-call` gating for vision perception.
+ *
+ * Vision perception only engages for backbones that lack native image/video
+ * support. The gate is evaluated per turn against the *resolved* model:
+ *
+ * - **Vision-capable backbone:** the feature is fully inert. The `vlm_*` tools
+ *   are removed from the offered tool list (see {@link VLM_TOOL_NAMES}, gated in
+ *   `daemon/conversation-tool-setup.ts`) and media blocks pass through to the
+ *   model unchanged.
+ * - **Non-vision backbone:** an uploaded image must never reach the model as raw
+ *   bytes. Each media block on the outbound request is replaced with a text
+ *   marker that names the attachment id, so the model can read it by calling a
+ *   `vlm_*` tool with `media_ref="<id>"`. The `vlm_*` tools stay offered.
+ *
+ * The runtime `PreModelCallContext` carries neither the outbound message list
+ * nor the offered tools, so the two mutations are driven from the per-turn paths
+ * that do: tool gating in `conversation-tool-setup.ts`, and the media-marker
+ * rewrite in the agent loop's outbound-request sanitization, both keyed on
+ * {@link resolveBackboneSupportsVision}. This module is the single home for the
+ * gating predicate, the marker rendering, and the `vlm_*` tool-name set; the
+ * default export is the registered hook, which self-gates and leaves the request
+ * untouched (its context cannot reach messages or tools today).
+ */
+
+import type { PluginHookFn, PreModelCallContext } from "@vellumai/plugin-api";
+
+import { isAssistantFeatureFlagEnabled } from "../../../../config/assistant-feature-flags.js";
+import { resolveCallSiteConfig } from "../../../../config/llm-resolver.js";
+import { getConfig } from "../../../../config/loader.js";
+import type { LLMCallSite } from "../../../../config/schemas/llm.js";
+import { getAttachmentById } from "../../../../memory/attachments-store.js";
+import { PROVIDER_CATALOG } from "../../../../providers/model-catalog.js";
+import type {
+  ContentBlock,
+  ImageContent,
+  Message,
+} from "../../../../providers/types.js";
+
+/**
+ * Names of the model-visible vision tools the plugin contributes. Kept here so
+ * the offered-tool gate (which omits them for vision-capable backbones) and the
+ * media marker (which names them as the way to inspect an attachment) share one
+ * source of truth, independent of which subset of tools is currently
+ * registered.
+ */
+export const VLM_TOOL_NAMES: ReadonlySet<string> = new Set([
+  "vlm_ask",
+  "vlm_describe",
+  "vlm_ocr",
+  "vlm_detect",
+]);
+
+/** Whether `name` is one of the plugin's vision tools. */
+export function isVlmToolName(name: string): boolean {
+  return VLM_TOOL_NAMES.has(name);
+}
+
+/**
+ * Resolve whether the backbone that will serve a turn natively supports vision.
+ *
+ * Resolves the call site's effective provider/model the same way the dispatch
+ * path does (via {@link resolveCallSiteConfig}) and reads `supportsVision` from
+ * the model catalog. Unknown (provider, model) pairs fail open to `true` —
+ * matching `GET /v1/config`'s per-profile enrichment — so custom or unlisted
+ * models keep native image handling and the feature stays inert for them.
+ *
+ * Returns `true` (feature inert) whenever the `vision-perception` flag is off,
+ * so callers gate uniformly on this one predicate: a vision-capable result means
+ * "leave media intact and don't offer the vlm_* tools".
+ */
+export function resolveBackboneSupportsVision(opts: {
+  callSite: LLMCallSite | null;
+  overrideProfile: string | null;
+  selectionSeed?: string | null;
+}): boolean {
+  try {
+    const config = getConfig();
+    if (!isAssistantFeatureFlagEnabled("vision-perception", config)) {
+      return true;
+    }
+    const { llm } = config;
+    const resolved = resolveCallSiteConfig(opts.callSite ?? "mainAgent", llm, {
+      ...(opts.overrideProfile
+        ? { overrideProfile: opts.overrideProfile }
+        : {}),
+      ...(opts.selectionSeed ? { selectionSeed: opts.selectionSeed } : {}),
+    });
+    const catalogProvider = PROVIDER_CATALOG.find(
+      (p) => p.id === resolved.provider,
+    );
+    const catalogModel = catalogProvider?.models.find(
+      (m) => m.id === resolved.model,
+    );
+    return catalogModel?.supportsVision ?? true;
+  } catch {
+    // Fail open: never let a resolution error strip media from a request.
+    return true;
+  }
+}
+
+/** Human-readable media kind for the marker text. */
+function mediaKind(block: ImageContent): string {
+  return block.source.media_type.startsWith("video/") ? "Video" : "Image";
+}
+
+/** Best-effort original filename for an attachment id; falls back to a generic label. */
+function resolveAttachmentFilename(attachmentId: string): string {
+  try {
+    return getAttachmentById(attachmentId)?.originalFilename ?? "attachment";
+  } catch {
+    return "attachment";
+  }
+}
+
+/**
+ * Render the text marker that replaces a raw media block for a non-vision
+ * backbone. Names the attachment id so the model has a usable `media_ref`.
+ */
+export function renderMediaMarker(
+  attachmentId: string,
+  filename: string,
+  kind: string,
+): string {
+  return (
+    `[${kind} attachment available — id="${attachmentId}", file "${filename}". ` +
+    `You cannot view it directly; call vlm_ask / vlm_describe / vlm_ocr / vlm_detect ` +
+    `with media_ref="${attachmentId}" to inspect it.]`
+  );
+}
+
+/**
+ * Replace raw image blocks with attachment-id markers when the backbone lacks
+ * native vision. Returns the input array unchanged (same reference) when the
+ * backbone is vision-capable or when there is nothing to replace, so a request
+ * that needs no rewrite is not copied.
+ *
+ * Image blocks that carry no `_attachmentId` (e.g. tool-generated images) are
+ * left intact: without an id there is no `media_ref` the model could pass to a
+ * `vlm_*` tool, so dropping them would only lose information.
+ */
+export function applyVisionPerceptionMarkers(
+  messages: Message[],
+  supportsVision: boolean,
+): Message[] {
+  if (supportsVision) return messages;
+
+  const replaceableImage = (block: ContentBlock): block is ImageContent =>
+    block.type === "image" && typeof block._attachmentId === "string";
+
+  const hasReplaceable = messages.some((msg) =>
+    msg.content.some(replaceableImage),
+  );
+  if (!hasReplaceable) return messages;
+
+  return messages.map((msg) => {
+    if (!msg.content.some(replaceableImage)) return msg;
+    return {
+      ...msg,
+      content: msg.content.map((block) => {
+        if (!replaceableImage(block)) return block;
+        const id = block._attachmentId!;
+        return {
+          type: "text" as const,
+          text: renderMediaMarker(
+            id,
+            resolveAttachmentFilename(id),
+            mediaKind(block),
+          ),
+        };
+      }),
+    };
+  });
+}
+
+/**
+ * Registered `pre-model-call` hook. The runtime context exposes only the system
+ * prompt, model-profile routing, and deferred-output flag — not the outbound
+ * messages or offered tools — so the per-turn paths that own those (tool
+ * resolution, outbound sanitization) drive the actual gating. This hook is the
+ * forward-compatible registration point and leaves the request untouched.
+ */
+const preModelCall: PluginHookFn<PreModelCallContext> = async () => {};
+
+export default preModelCall;

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -16,6 +16,16 @@ export interface ImageContent {
     media_type: string;
     data: string;
   };
+  /**
+   * Internal id linking this block to a row in the attachments table.
+   * Set when the image block originates from a persisted user-message
+   * attachment so downstream consumers (vision-perception media markers,
+   * DB joins, inline-chip positioning) can correlate the block back to its
+   * attachment id and surface a usable `media_ref`. Providers reconstruct the
+   * wire image block from `source` alone, so this field is never forwarded to
+   * the model.
+   */
+  _attachmentId?: string;
 }
 
 export interface FileContent {


### PR DESCRIPTION
## Summary
- Per-turn gate: vlm_* tools only offered when the backbone lacks native vision; media passes through for vision-capable models
- pre-model-call hook injects an attachment-id marker for non-vision backbones (closes Codex P1 on #35497)
- Carry _attachmentId on ImageContent (stripped before send) so uploads expose a usable media_ref

Part of plan: glm-5v-turbo-vlm-tool.md (PR 7 of 8)