### PR TITLE
feat(plugins): video perception via keyframe sampling (vlm_video_log)

### DIFF
--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -82,6 +82,7 @@ import vlmAskTool from "./vision-perception/tools/vlm-ask.js";
 import vlmDescribeTool from "./vision-perception/tools/vlm-describe.js";
 import vlmDetectTool from "./vision-perception/tools/vlm-detect.js";
 import vlmOcrTool from "./vision-perception/tools/vlm-ocr.js";
+import vlmVideoLogTool from "./vision-perception/tools/vlm-video-log.js";
 
 /**
  * `compaction` — compaction is implemented in `compaction/compact.ts` as
@@ -364,6 +365,7 @@ export const visionPerceptionPlugin: Plugin = {
     finalizeTool(vlmDescribeTool, "vlm_describe"),
     finalizeTool(vlmOcrTool, "vlm_ocr"),
     finalizeTool(vlmDetectTool, "vlm_detect"),
+    finalizeTool(vlmVideoLogTool, "vlm_video_log"),
   ],
 };
 

--- a/assistant/src/plugins/defaults/vision-perception/__tests__/ocr-detect.test.ts
+++ b/assistant/src/plugins/defaults/vision-perception/__tests__/ocr-detect.test.ts
@@ -60,6 +60,7 @@ let attachmentBytes: Record<string, Buffer> = {};
 mock.module("../../../../memory/attachments-store.js", () => ({
   getAttachmentById: (id: string) => attachmentRows[id] ?? null,
   getAttachmentContent: (id: string) => attachmentBytes[id] ?? null,
+  getFilePathForAttachment: () => null,
 }));
 
 const vlmOcrTool = (await import("../tools/vlm-ocr.js")).default;

--- a/assistant/src/plugins/defaults/vision-perception/__tests__/pre-model-call.test.ts
+++ b/assistant/src/plugins/defaults/vision-perception/__tests__/pre-model-call.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { ImageContent, Message } from "../../../../providers/types.js";
+import type {
+  FileContent,
+  ImageContent,
+  Message,
+} from "../../../../providers/types.js";
 
 // The gate resolves the turn's effective provider/model via the LLM resolver and
 // reads `supportsVision` from the real model catalog, behind the
@@ -21,13 +25,12 @@ mock.module("../../../../config/llm-resolver.js", () => ({
   resolveCallSiteConfig: () => resolvedProviderModel,
 }));
 
-// Attachment-store lookup supplies the marker's filename. Configurable per test.
-let attachmentFilenames: Record<string, string> = {};
+// Attachment-store lookup supplies the marker's filename and (for the video
+// file-block path) the attachment `kind`. Configurable per test.
+let attachmentRows: Record<string, { originalFilename: string; kind: string }> =
+  {};
 mock.module("../../../../memory/attachments-store.js", () => ({
-  getAttachmentById: (id: string) =>
-    attachmentFilenames[id]
-      ? { originalFilename: attachmentFilenames[id] }
-      : null,
+  getAttachmentById: (id: string) => attachmentRows[id] ?? null,
 }));
 
 const {
@@ -53,6 +56,22 @@ function imageMessage(attachmentId?: string): Message {
   return { role: "user", content: [{ type: "text", text: "look" }, block] };
 }
 
+function fileMessage(
+  block: Partial<FileContent> & { type?: "file" } = {},
+): Message {
+  const fileBlock: FileContent = {
+    type: "file",
+    source: {
+      type: "base64",
+      media_type: block.source?.media_type ?? "application/pdf",
+      data: "AAAA",
+      filename: block.source?.filename ?? "doc.pdf",
+    },
+    ...(block._attachmentId ? { _attachmentId: block._attachmentId } : {}),
+  };
+  return { role: "user", content: [{ type: "text", text: "look" }, fileBlock] };
+}
+
 const gate = () =>
   resolveBackboneSupportsVision({
     callSite: "mainAgent",
@@ -63,7 +82,11 @@ const gate = () =>
 beforeEach(() => {
   flagEnabled = true;
   resolvedProviderModel = { ...VISION_MODEL };
-  attachmentFilenames = { "att-1": "photo.png" };
+  attachmentRows = {
+    "att-1": { originalFilename: "photo.png", kind: "image" },
+    "vid-1": { originalFilename: "clip.mp4", kind: "video" },
+    "doc-1": { originalFilename: "report.pdf", kind: "document" },
+  };
 });
 
 describe("vision-capable backbone keeps the feature inert", () => {
@@ -108,6 +131,108 @@ describe("non-vision backbone surfaces a usable media_ref", () => {
     expect(text).toContain('media_ref="att-1"');
     expect(text).toContain('file "photo.png"');
     expect(text).toContain("vlm_ask");
+  });
+});
+
+describe("non-vision backbone surfaces uploaded videos", () => {
+  test("a video file block becomes a marker advertising vlm_video_log", () => {
+    resolvedProviderModel = { ...NON_VISION_MODEL };
+
+    const out = applyVisionPerceptionMarkers(
+      [
+        fileMessage({
+          source: {
+            type: "base64",
+            media_type: "video/mp4",
+            data: "AAAA",
+            filename: "clip.mp4",
+          },
+          _attachmentId: "vid-1",
+        }),
+      ],
+      gate(),
+    );
+    const blocks = out[0].content;
+
+    // The raw file block is gone; the model never receives video bytes.
+    expect(blocks.some((b) => b.type === "file")).toBe(false);
+
+    const marker = blocks.find(
+      (b) => b.type === "text" && b.text.includes("id="),
+    );
+    expect(marker).toBeDefined();
+    const text = (marker as { text: string }).text;
+    expect(text).toContain("Video attachment available");
+    expect(text).toContain('id="vid-1"');
+    expect(text).toContain('media_ref="vid-1"');
+    expect(text).toContain('file "clip.mp4"');
+    expect(text).toContain("vlm_video_log");
+  });
+
+  test("a video file block with a generic mime is detected via attachment kind", () => {
+    resolvedProviderModel = { ...NON_VISION_MODEL };
+
+    const out = applyVisionPerceptionMarkers(
+      [
+        fileMessage({
+          source: {
+            type: "base64",
+            media_type: "application/octet-stream",
+            data: "AAAA",
+            filename: "clip.mov",
+          },
+          _attachmentId: "vid-1",
+        }),
+      ],
+      gate(),
+    );
+    const blocks = out[0].content;
+    expect(blocks.some((b) => b.type === "file")).toBe(false);
+    const marker = blocks.find(
+      (b) => b.type === "text" && b.text.includes("vlm_video_log"),
+    );
+    expect(marker).toBeDefined();
+    expect((marker as { text: string }).text).toContain('media_ref="vid-1"');
+  });
+
+  test("a non-video file block (e.g. a PDF) is left untouched", () => {
+    resolvedProviderModel = { ...NON_VISION_MODEL };
+
+    const messages = [
+      fileMessage({
+        source: {
+          type: "base64",
+          media_type: "application/pdf",
+          data: "AAAA",
+          filename: "report.pdf",
+        },
+        _attachmentId: "doc-1",
+      }),
+    ];
+    const out = applyVisionPerceptionMarkers(messages, gate());
+    // No rewrite was needed, so the same array reference comes back and the file
+    // block survives intact.
+    expect(out).toBe(messages);
+    expect(out[0].content[1]).toMatchObject({ type: "file" });
+  });
+
+  test("a video file block on a vision-capable backbone is left unchanged", () => {
+    resolvedProviderModel = { ...VISION_MODEL };
+
+    const messages = [
+      fileMessage({
+        source: {
+          type: "base64",
+          media_type: "video/mp4",
+          data: "AAAA",
+          filename: "clip.mp4",
+        },
+        _attachmentId: "vid-1",
+      }),
+    ];
+    const out = applyVisionPerceptionMarkers(messages, gate());
+    expect(out).toBe(messages);
+    expect(out[0].content[1]).toMatchObject({ type: "file" });
   });
 });
 

--- a/assistant/src/plugins/defaults/vision-perception/__tests__/video.test.ts
+++ b/assistant/src/plugins/defaults/vision-perception/__tests__/video.test.ts
@@ -17,7 +17,7 @@ const realVideoFrames = await import("../src/video-frames.js");
 type SampledVideo = Awaited<
   ReturnType<typeof realVideoFrames.sampleVideoFrames>
 >;
-const { VideoFramesError } = realVideoFrames;
+const { VideoFramesError, planTimestamps, END_EPSILON_S } = realVideoFrames;
 
 // A 1x1 JPEG-ish payload; frames are pre-built fixtures so no ffmpeg runs.
 const FRAME_DATA = "ZmFrZS1mcmFtZQ==";
@@ -221,5 +221,49 @@ describe("vlm_video_log tool", () => {
     const result = await vlmVideoLogTool.execute?.({ media_ref: "vid-1" }, ctx);
 
     expect(result?.isError).toBe(true);
+  });
+});
+
+describe("planTimestamps avoids seeking to the video's end (EOF)", () => {
+  // Regression for Codex P1: the last sampled timestamp used to equal the
+  // duration, so ffmpeg seeked to EOF and produced no frame, turning ordinary
+  // clips > ~2s into `{ isError: true }` results.
+  test("no sampled timestamp equals the duration for a multi-frame clip", () => {
+    const durationS = 10;
+    const { timestamps } = planTimestamps(durationS, 0, durationS, "keyframes");
+
+    expect(timestamps.length).toBeGreaterThan(1);
+    for (const t of timestamps) {
+      expect(t).toBeLessThan(durationS);
+    }
+    // The final timestamp is pulled back by exactly the EOF epsilon.
+    expect(timestamps[timestamps.length - 1]).toBeCloseTo(
+      durationS - END_EPSILON_S,
+      6,
+    );
+  });
+
+  test("the cap holds for every uniform strategy and an explicit full window", () => {
+    const durationS = 30;
+    for (const strategy of ["uniform_1hz", "uniform_4hz"] as const) {
+      const { timestamps } = planTimestamps(durationS, 0, durationS, strategy);
+      expect(Math.max(...timestamps)).toBeLessThan(durationS);
+      expect(Math.max(...timestamps)).toBeLessThanOrEqual(
+        durationS - END_EPSILON_S,
+      );
+    }
+  });
+
+  test("a single-frame clip still samples a valid, non-negative timestamp", () => {
+    // A very short clip (sub-epsilon) must not yield a negative seek time.
+    const tiny = planTimestamps(0.05, 0, 0.05, "keyframes");
+    expect(tiny.timestamps).toHaveLength(1);
+    expect(tiny.timestamps[0]).toBeGreaterThanOrEqual(0);
+    expect(tiny.timestamps[0]).toBeLessThanOrEqual(0.05);
+
+    // A normal short clip samples near the middle, still below the duration.
+    const short = planTimestamps(1.5, 0, 1.5, "keyframes");
+    expect(short.timestamps).toHaveLength(1);
+    expect(short.timestamps[0]).toBeLessThan(1.5);
   });
 });

--- a/assistant/src/plugins/defaults/vision-perception/__tests__/video.test.ts
+++ b/assistant/src/plugins/defaults/vision-perception/__tests__/video.test.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { ImageContent, Message } from "../../../../providers/types.js";
+import type { ToolContext } from "../../../../tools/types.js";
+
+// `mock.module` is process-global, so all stubbing for vlm_video_log lives in
+// this one file (the test runner runs each file in its own process). We stub:
+//  - frame extraction (`video-frames.js` `sampleVideoFrames`), spreading the
+//    real module so `VideoFramesError` keeps its identity for the `instanceof`
+//    check in `resolveVisionVideo`;
+//  - the attachment store (a configurable video row), so `resolveVisionVideo`
+//    can validate the kind without a real DB;
+//  - the provider resolution (spreading the real module so `extractAllText`
+//    still works).
+
+const realVideoFrames = await import("../src/video-frames.js");
+type SampledVideo = Awaited<
+  ReturnType<typeof realVideoFrames.sampleVideoFrames>
+>;
+const { VideoFramesError } = realVideoFrames;
+
+// A 1x1 JPEG-ish payload; frames are pre-built fixtures so no ffmpeg runs.
+const FRAME_DATA = "ZmFrZS1mcmFtZQ==";
+
+function fixtureFrame(t: number): { t_seconds: number; block: ImageContent } {
+  return {
+    t_seconds: t,
+    block: {
+      type: "image",
+      source: { type: "base64", media_type: "image/jpeg", data: FRAME_DATA },
+    },
+  };
+}
+
+// Per-test control: either a fixture video to return, or an error to throw.
+let sampleResult: SampledVideo | null = null;
+let sampleError: Error | null = null;
+
+mock.module("../src/video-frames.js", () => ({
+  ...realVideoFrames,
+  sampleVideoFrames: async (): Promise<SampledVideo> => {
+    if (sampleError) throw sampleError;
+    return sampleResult!;
+  },
+}));
+
+interface FakeRow {
+  id: string;
+  originalFilename: string;
+  mimeType: string;
+  kind: string;
+}
+
+let attachmentRows: Record<string, FakeRow> = {};
+mock.module("../../../../memory/attachments-store.js", () => ({
+  getAttachmentById: (id: string) => attachmentRows[id] ?? null,
+  getAttachmentContent: () => null,
+  getFilePathForAttachment: () => null,
+}));
+
+let sendMessageArgs: { messages: Message[]; options: unknown } | null = null;
+let responseText = "";
+
+const fakeProvider = {
+  name: "mock-vision-provider",
+  async sendMessage(messages: Message[], options: unknown) {
+    sendMessageArgs = { messages, options };
+    return {
+      content: [{ type: "text", text: responseText }],
+      model: "mock-vision-model",
+      usage: { inputTokens: 1, outputTokens: 1 },
+      stopReason: "end_turn",
+    };
+  },
+};
+
+const realPsm = await import("../../../../providers/provider-send-message.js");
+mock.module("../../../../providers/provider-send-message.js", () => ({
+  ...realPsm,
+  getConfiguredProvider: async () => fakeProvider,
+}));
+
+const vlmVideoLogTool = (await import("../tools/vlm-video-log.js")).default;
+
+const ctx = { conversationId: "c1" } as unknown as ToolContext;
+
+beforeEach(() => {
+  sampleResult = null;
+  sampleError = null;
+  sendMessageArgs = null;
+  responseText = "";
+  attachmentRows = {
+    "vid-1": {
+      id: "vid-1",
+      originalFilename: "clip.mp4",
+      mimeType: "video/mp4",
+      kind: "video",
+    },
+    "img-1": {
+      id: "img-1",
+      originalFilename: "photo.png",
+      mimeType: "image/png",
+      kind: "image",
+    },
+  };
+});
+
+describe("vlm_video_log tool", () => {
+  test("samples keyframes and returns a timestamped event log", async () => {
+    sampleResult = {
+      duration_s: 12,
+      frames: [fixtureFrame(0), fixtureFrame(6), fixtureFrame(12)],
+    };
+    responseText = JSON.stringify({
+      segments: [
+        { t_start: 0, t_end: 6, summary: "intro", events: ["title card"] },
+        { t_start: 6, t_end: 12, summary: "demo", events: ["click", "type"] },
+      ],
+    });
+
+    const result = await vlmVideoLogTool.execute?.({ media_ref: "vid-1" }, ctx);
+
+    expect(result?.isError).toBe(false);
+    const parsed = JSON.parse(result?.content ?? "");
+    expect(parsed.duration_s).toBe(12);
+    expect(parsed.segments).toEqual([
+      { t_start: 0, t_end: 6, summary: "intro", events: ["title card"] },
+      { t_start: 6, t_end: 12, summary: "demo", events: ["click", "type"] },
+    ]);
+    expect(parsed.truncated).toBeUndefined();
+  });
+
+  test("sends each frame as a labeled image block to the vision model", async () => {
+    sampleResult = {
+      duration_s: 4,
+      frames: [fixtureFrame(0), fixtureFrame(4)],
+    };
+    responseText = JSON.stringify({ segments: [] });
+
+    await vlmVideoLogTool.execute?.(
+      { media_ref: "vid-1", query: "what changes?" },
+      ctx,
+    );
+
+    const sent = sendMessageArgs?.messages;
+    expect(sent).toHaveLength(1);
+    const blocks = sent?.[0].content ?? [];
+
+    const images = blocks.filter((b): b is ImageContent => b.type === "image");
+    expect(images).toHaveLength(2);
+    expect(images[0].source.data).toBe(FRAME_DATA);
+
+    const labels = blocks.filter((b) => b.type === "text");
+    expect(labels.some((b) => b.text === "[t=0s]")).toBe(true);
+    expect(labels.some((b) => b.text === "[t=4s]")).toBe(true);
+    // The query is threaded into the trailing prompt block.
+    expect(labels.some((b) => b.text.includes("what changes?"))).toBe(true);
+  });
+
+  test("propagates the truncation descriptor when frames were capped", async () => {
+    sampleResult = {
+      duration_s: 300,
+      frames: [fixtureFrame(0), fixtureFrame(150), fixtureFrame(300)],
+      truncated: {
+        reason: "frame count capped at 32 (sampling asked for 150)",
+        requested: 150,
+        returned: 3,
+        covered_window: [0, 300],
+      },
+    };
+    responseText = JSON.stringify({ segments: [] });
+
+    const result = await vlmVideoLogTool.execute?.({ media_ref: "vid-1" }, ctx);
+
+    expect(result?.isError).toBe(false);
+    const parsed = JSON.parse(result?.content ?? "");
+    expect(parsed.truncated).toEqual({
+      reason: "frame count capped at 32 (sampling asked for 150)",
+      requested: 150,
+      returned: 3,
+      covered_window: [0, 300],
+    });
+  });
+
+  test("ffmpeg unavailable degrades to isError (no throw)", async () => {
+    sampleError = new VideoFramesError(
+      "ffmpeg is not available, so extracting a video frame is not possible in this environment.",
+    );
+
+    const result = await vlmVideoLogTool.execute?.({ media_ref: "vid-1" }, ctx);
+
+    expect(result?.isError).toBe(true);
+    expect(result?.content).toContain("ffmpeg is not available");
+    expect(sendMessageArgs).toBeNull();
+  });
+
+  test("returns isError (no throw) for a non-video attachment", async () => {
+    responseText = JSON.stringify({ segments: [] });
+    const result = await vlmVideoLogTool.execute?.({ media_ref: "img-1" }, ctx);
+
+    expect(result?.isError).toBe(true);
+    expect(result?.content).toContain("not a video");
+    expect(sendMessageArgs).toBeNull();
+  });
+
+  test("returns isError (no throw) for a missing media_ref", async () => {
+    const result = await vlmVideoLogTool.execute?.(
+      { media_ref: "does-not-exist" },
+      ctx,
+    );
+
+    expect(result?.isError).toBe(true);
+    expect(result?.content).toContain("No attachment found");
+    expect(sendMessageArgs).toBeNull();
+  });
+
+  test("malformed model output degrades to isError (no throw)", async () => {
+    sampleResult = { duration_s: 4, frames: [fixtureFrame(0)] };
+    responseText = "sorry, I can't analyze that video";
+
+    const result = await vlmVideoLogTool.execute?.({ media_ref: "vid-1" }, ctx);
+
+    expect(result?.isError).toBe(true);
+  });
+});

--- a/assistant/src/plugins/defaults/vision-perception/__tests__/vision-tools.test.ts
+++ b/assistant/src/plugins/defaults/vision-perception/__tests__/vision-tools.test.ts
@@ -53,6 +53,7 @@ let attachmentBytes: Record<string, Buffer> = {};
 mock.module("../../../../memory/attachments-store.js", () => ({
   getAttachmentById: (id: string) => attachmentRows[id] ?? null,
   getAttachmentContent: (id: string) => attachmentBytes[id] ?? null,
+  getFilePathForAttachment: () => null,
 }));
 
 const vlmAskTool = (await import("../tools/vlm-ask.js")).default;

--- a/assistant/src/plugins/defaults/vision-perception/hooks/pre-model-call.ts
+++ b/assistant/src/plugins/defaults/vision-perception/hooks/pre-model-call.ts
@@ -49,6 +49,7 @@ export const VLM_TOOL_NAMES: ReadonlySet<string> = new Set([
   "vlm_describe",
   "vlm_ocr",
   "vlm_detect",
+  "vlm_video_log",
 ]);
 
 /** Whether `name` is one of the plugin's vision tools. */
@@ -115,17 +116,23 @@ function resolveAttachmentFilename(attachmentId: string): string {
 
 /**
  * Render the text marker that replaces a raw media block for a non-vision
- * backbone. Names the attachment id so the model has a usable `media_ref`.
+ * backbone. Names the attachment id so the model has a usable `media_ref`, and
+ * advertises the right tool for the media kind: `vlm_video_log` for videos, the
+ * image inspection tools otherwise.
  */
 export function renderMediaMarker(
   attachmentId: string,
   filename: string,
   kind: string,
 ): string {
+  const tools =
+    kind === "Video"
+      ? `call vlm_video_log with media_ref="${attachmentId}" to read it`
+      : `call vlm_ask / vlm_describe / vlm_ocr / vlm_detect ` +
+        `with media_ref="${attachmentId}" to inspect it`;
   return (
     `[${kind} attachment available — id="${attachmentId}", file "${filename}". ` +
-    `You cannot view it directly; call vlm_ask / vlm_describe / vlm_ocr / vlm_detect ` +
-    `with media_ref="${attachmentId}" to inspect it.]`
+    `You cannot view it directly; ${tools}.]`
   );
 }
 

--- a/assistant/src/plugins/defaults/vision-perception/hooks/pre-model-call.ts
+++ b/assistant/src/plugins/defaults/vision-perception/hooks/pre-model-call.ts
@@ -33,6 +33,7 @@ import { getAttachmentById } from "../../../../memory/attachments-store.js";
 import { PROVIDER_CATALOG } from "../../../../providers/model-catalog.js";
 import type {
   ContentBlock,
+  FileContent,
   ImageContent,
   Message,
 } from "../../../../providers/types.js";
@@ -105,6 +106,25 @@ function mediaKind(block: ImageContent): string {
   return block.source.media_type.startsWith("video/") ? "Video" : "Image";
 }
 
+/**
+ * Whether a `file` block carries a video the model can't read inline. Inline
+ * uploads of `video/*` reach the model as a {@link FileContent} block (only
+ * `image/*` becomes an {@link ImageContent} — see `agent/attachments.ts`), so a
+ * non-vision backbone needs that block rewritten into a `vlm_video_log` marker
+ * too. Detected by the block's own `media_type` first (no DB hit), falling back
+ * to the attachment row's `kind` for blocks whose declared MIME is generic.
+ */
+function isVideoFileBlock(block: FileContent): boolean {
+  if (block.source.media_type.toLowerCase().startsWith("video/")) return true;
+  const id = block._attachmentId;
+  if (typeof id !== "string") return false;
+  try {
+    return getAttachmentById(id)?.kind === "video";
+  } catch {
+    return false;
+  }
+}
+
 /** Best-effort original filename for an attachment id; falls back to a generic label. */
 function resolveAttachmentFilename(attachmentId: string): string {
   try {
@@ -137,13 +157,23 @@ export function renderMediaMarker(
 }
 
 /**
- * Replace raw image blocks with attachment-id markers when the backbone lacks
+ * Replace raw media blocks with attachment-id markers when the backbone lacks
  * native vision. Returns the input array unchanged (same reference) when the
  * backbone is vision-capable or when there is nothing to replace, so a request
  * that needs no rewrite is not copied.
  *
- * Image blocks that carry no `_attachmentId` (e.g. tool-generated images) are
- * left intact: without an id there is no `media_ref` the model could pass to a
+ * Two block shapes are rewritten:
+ *  - `image` blocks (uploaded images), and
+ *  - `file` blocks that carry a video (uploaded `video/*` files reach the model
+ *    as a generic `file` block — see {@link isVideoFileBlock}). Without this the
+ *    video would arrive as an opaque file placeholder with no `media_ref`, so
+ *    the model could never call `vlm_video_log`.
+ *
+ * Non-video `file` blocks (PDFs, documents, …) are left intact — the backbone
+ * can read their `extracted_text`, and there is no `vlm_*` tool for them.
+ *
+ * Blocks that carry no `_attachmentId` (e.g. tool-generated images) are left
+ * intact: without an id there is no `media_ref` the model could pass to a
  * `vlm_*` tool, so dropping them would only lose information.
  */
 export function applyVisionPerceptionMarkers(
@@ -152,28 +182,30 @@ export function applyVisionPerceptionMarkers(
 ): Message[] {
   if (supportsVision) return messages;
 
-  const replaceableImage = (block: ContentBlock): block is ImageContent =>
-    block.type === "image" && typeof block._attachmentId === "string";
+  const replaceable = (
+    block: ContentBlock,
+  ): block is ImageContent | FileContent => {
+    if (block.type === "image") return typeof block._attachmentId === "string";
+    if (block.type === "file")
+      return typeof block._attachmentId === "string" && isVideoFileBlock(block);
+    return false;
+  };
 
-  const hasReplaceable = messages.some((msg) =>
-    msg.content.some(replaceableImage),
-  );
+  const hasReplaceable = messages.some((msg) => msg.content.some(replaceable));
   if (!hasReplaceable) return messages;
 
   return messages.map((msg) => {
-    if (!msg.content.some(replaceableImage)) return msg;
+    if (!msg.content.some(replaceable)) return msg;
     return {
       ...msg,
       content: msg.content.map((block) => {
-        if (!replaceableImage(block)) return block;
+        if (!replaceable(block)) return block;
         const id = block._attachmentId!;
+        const kind =
+          block.type === "image" ? mediaKind(block) : ("Video" as const);
         return {
           type: "text" as const,
-          text: renderMediaMarker(
-            id,
-            resolveAttachmentFilename(id),
-            mediaKind(block),
-          ),
+          text: renderMediaMarker(id, resolveAttachmentFilename(id), kind),
         };
       }),
     };

--- a/assistant/src/plugins/defaults/vision-perception/src/media-source.ts
+++ b/assistant/src/plugins/defaults/vision-perception/src/media-source.ts
@@ -1,11 +1,11 @@
 /**
- * Resolve a vision media reference (an attachment id) into a provider
- * `ImageContent` block.
+ * Resolve a vision media reference (an attachment id) into provider content.
  *
- * Reads the attachment row and bytes from the assistant's own attachment store,
- * validates that the reference points to an existing IMAGE (videos and other
- * kinds are rejected), and runs the bytes through `optimizeImageForTransport`
- * before building the base64 image block the vision call site sends.
+ * Reads the attachment row and bytes from the assistant's own attachment store.
+ * Images resolve to a single optimized `ImageContent` block via
+ * {@link resolveVisionMedia}; videos resolve to a set of timestamped keyframes
+ * via {@link resolveVisionVideo} (delegating to `video-frames.ts`). Other kinds
+ * are rejected.
  *
  * The attachment store is imported in-tree (relative) rather than from
  * `@vellumai/plugin-api`, which does not export it.
@@ -17,6 +17,12 @@ import {
   getAttachmentContent,
 } from "../../../../memory/attachments-store.js";
 import type { ImageContent } from "../../../../providers/types.js";
+import {
+  type SampledVideo,
+  sampleVideoFrames,
+  type SampleVideoOptions,
+  VideoFramesError,
+} from "./video-frames.js";
 
 /**
  * Raised when a media reference cannot be resolved to a usable image — the
@@ -89,4 +95,43 @@ export async function resolveVisionMedia(
     kind: row.kind,
     filename: row.originalFilename,
   };
+}
+
+/**
+ * Resolve a video attachment id to a set of timestamped keyframes plus its
+ * metadata. Delegates frame extraction to `video-frames.ts`, which relies on
+ * ffmpeg/ffprobe and fails gracefully when those are unavailable. Throws
+ * {@link VisionMediaError} on a missing / non-video reference, and re-raises a
+ * {@link VideoFramesError} as a {@link VisionMediaError} so callers convert
+ * either into a single `{ isError: true }` result.
+ */
+export async function resolveVisionVideo(
+  mediaRef: string,
+  options?: SampleVideoOptions,
+): Promise<{ video: SampledVideo; filename: string }> {
+  const ref = mediaRef?.trim();
+  if (!ref) {
+    throw new VisionMediaError("No media reference was provided.");
+  }
+
+  const row = getAttachmentById(ref);
+  if (!row) {
+    throw new VisionMediaError(`No attachment found for media_ref "${ref}".`);
+  }
+  if (row.kind !== "video") {
+    throw new VisionMediaError(
+      `Attachment "${ref}" is a ${row.kind}, not a video. ` +
+        "Only videos can be read by vlm_video_log.",
+    );
+  }
+
+  try {
+    const video = await sampleVideoFrames(ref, options);
+    return { video, filename: row.originalFilename };
+  } catch (err) {
+    if (err instanceof VideoFramesError) {
+      throw new VisionMediaError(err.message);
+    }
+    throw err;
+  }
 }

--- a/assistant/src/plugins/defaults/vision-perception/src/video-frames.ts
+++ b/assistant/src/plugins/defaults/vision-perception/src/video-frames.ts
@@ -1,0 +1,359 @@
+/**
+ * Sample timestamped keyframes from a video attachment for the vision call site.
+ *
+ * Frames are extracted with `ffmpeg` (duration probed with `ffprobe`) via the
+ * shared {@link spawnWithTimeout} helper, which augments PATH for Homebrew tools
+ * and enforces a timeout. Both binaries may be absent in a given runtime; every
+ * failure path — missing binary, probe failure, extraction failure, an
+ * unreadable attachment — is reported as a typed {@link VideoFramesError} the
+ * calling tool converts into a `{ isError: true }` result. This module never
+ * throws an untyped error and never crashes the daemon.
+ *
+ * The frame count is capped so the resulting request fits the vision call site's
+ * context window (Qwen 3.7 Plus, 262144 tokens). When the cap or the requested
+ * sampling window forces us to drop frames, the result carries a `truncated`
+ * descriptor so the tool can surface the omission rather than silently lying
+ * about coverage.
+ */
+
+import { randomUUID } from "node:crypto";
+import { readFile, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { optimizeImageForTransport } from "../../../../agent/image-optimize.js";
+import {
+  getAttachmentById,
+  getFilePathForAttachment,
+} from "../../../../memory/attachments-store.js";
+import type { ImageContent } from "../../../../providers/types.js";
+import { getLogger } from "../../../../util/logger.js";
+import {
+  FFMPEG_PALETTE_TIMEOUT_MS,
+  FFPROBE_TIMEOUT_MS,
+  spawnWithTimeout,
+} from "../../../../util/spawn.js";
+
+const log = getLogger("vision-perception-video-frames");
+
+/**
+ * Raised when a video cannot be turned into sampled frames — the attachment is
+ * missing or not a video, ffmpeg/ffprobe is unavailable, or extraction failed.
+ * The calling tool converts this into a `{ isError: true }` result rather than
+ * throwing.
+ */
+export class VideoFramesError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "VideoFramesError";
+  }
+}
+
+/** A single sampled frame: its position in the video and the image block. */
+export interface SampledFrame {
+  t_seconds: number;
+  block: ImageContent;
+}
+
+/** Sampling strategies the tool exposes. */
+export type SampleStrategy = "keyframes" | "uniform_1hz" | "uniform_4hz";
+
+/** Why and how the frame set was capped, so the tool never truncates silently. */
+export interface FramesTruncation {
+  reason: string;
+  /** Frames the sampling plan asked for before the cap. */
+  requested: number;
+  /** Frames actually returned. */
+  returned: number;
+  /** Covered time span `[start, end]` in seconds. */
+  covered_window: [number, number];
+}
+
+export interface SampledVideo {
+  duration_s: number;
+  frames: SampledFrame[];
+  truncated?: FramesTruncation;
+}
+
+export interface SampleVideoOptions {
+  /** Sampling strategy. Defaults to `"keyframes"` (uniform over the whole clip). */
+  sample?: SampleStrategy;
+  /** Restrict sampling to `[start, end]` seconds of the clip. */
+  window?: [number, number];
+  /** Cooperative cancellation. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Hard ceiling on frames per request. Each optimized JPEG runs to a few hundred
+ * image tokens for the vision model; capping at 32 keeps the full message
+ * (frames + prompt + response budget) comfortably inside Qwen 3.7 Plus's 262144
+ * token context window with headroom for the model's own output.
+ */
+export const MAX_FRAMES = 32;
+
+/** Per-strategy target sampling rate in frames per second. `null` = keyframe scene cuts. */
+const STRATEGY_FPS: Record<SampleStrategy, number | null> = {
+  keyframes: null,
+  uniform_1hz: 1,
+  uniform_4hz: 4,
+};
+
+/**
+ * Translate a {@link spawnWithTimeout} run into a typed error vocabulary: a
+ * thrown promise (the binary could not be spawned — absent in this environment)
+ * and a non-zero exit both become {@link VideoFramesError}.
+ */
+async function runFfTool(
+  cmd: string[],
+  timeoutMs: number,
+  what: string,
+): Promise<{ stdout: string; stderr: string }> {
+  let result: Awaited<ReturnType<typeof spawnWithTimeout>>;
+  try {
+    result = await spawnWithTimeout(cmd, timeoutMs);
+  } catch {
+    throw new VideoFramesError(
+      `${cmd[0]} is not available, so ${what} is not possible in this environment.`,
+    );
+  }
+  if (result.exitCode !== 0) {
+    throw new VideoFramesError(
+      `${what} failed (exit ${result.exitCode}).` +
+        (result.stderr ? ` ${result.stderr.slice(0, 400)}` : ""),
+    );
+  }
+  return { stdout: result.stdout, stderr: result.stderr };
+}
+
+/** Probe a video's duration in seconds with ffprobe. */
+async function probeDurationSeconds(inputPath: string): Promise<number> {
+  const { stdout } = await runFfTool(
+    [
+      "ffprobe",
+      "-v",
+      "error",
+      "-show_entries",
+      "format=duration",
+      "-of",
+      "default=noprint_wrappers=1:nokey=1",
+      inputPath,
+    ],
+    FFPROBE_TIMEOUT_MS,
+    "reading the video's duration",
+  );
+  const duration = Number.parseFloat(stdout.trim());
+  if (!Number.isFinite(duration) || duration <= 0) {
+    throw new VideoFramesError("Could not determine the video's duration.");
+  }
+  return duration;
+}
+
+/** Extract a single JPEG frame at `tSeconds`, returned as base64 (or throws). */
+async function extractFrameAt(
+  inputPath: string,
+  tSeconds: number,
+): Promise<string> {
+  const outputPath = join(tmpdir(), `vellum-vframe-${randomUUID()}.jpg`);
+  try {
+    await runFfTool(
+      [
+        "ffmpeg",
+        "-y",
+        "-ss",
+        tSeconds.toFixed(3),
+        "-i",
+        inputPath,
+        "-frames:v",
+        "1",
+        "-vf",
+        "scale=720:-2",
+        "-q:v",
+        "5",
+        outputPath,
+      ],
+      FFMPEG_PALETTE_TIMEOUT_MS,
+      `extracting a video frame at ${tSeconds.toFixed(1)}s`,
+    );
+    const bytes = await readFile(outputPath);
+    if (bytes.length === 0) {
+      throw new VideoFramesError(
+        `ffmpeg produced an empty frame at ${tSeconds.toFixed(1)}s.`,
+      );
+    }
+    return bytes.toString("base64");
+  } catch (err) {
+    if (err instanceof VideoFramesError) throw err;
+    throw new VideoFramesError(
+      `Failed to read the extracted frame at ${tSeconds.toFixed(1)}s.`,
+    );
+  } finally {
+    await unlink(outputPath).catch(() => {});
+  }
+}
+
+/**
+ * Compute the timestamps to sample. Uniform strategies sample at their target
+ * rate across the window; the `keyframes` strategy samples uniformly across the
+ * window (a robust, deterministic proxy for scene coverage without a second
+ * decode pass). The list is capped at {@link MAX_FRAMES}; the returned
+ * `requested` reflects the pre-cap count so the caller can report truncation.
+ */
+function planTimestamps(
+  durationS: number,
+  windowStart: number,
+  windowEnd: number,
+  strategy: SampleStrategy,
+): { timestamps: number[]; requested: number } {
+  const span = Math.max(0, windowEnd - windowStart);
+  const fps = STRATEGY_FPS[strategy];
+
+  let requested: number;
+  if (fps === null) {
+    // Uniform keyframe proxy: ~1 frame every 2s, at least 1, never above the cap.
+    requested = Math.max(1, Math.ceil(span / 2));
+  } else {
+    requested = Math.max(1, Math.ceil(span * fps));
+  }
+
+  const count = Math.min(requested, MAX_FRAMES);
+  const timestamps: number[] = [];
+  if (count === 1) {
+    timestamps.push(windowStart + span / 2);
+  } else {
+    const step = span / (count - 1);
+    for (let i = 0; i < count; i++) {
+      timestamps.push(Math.min(durationS, windowStart + i * step));
+    }
+  }
+  return { timestamps, requested };
+}
+
+/** Resolve a video attachment id to a readable on-disk path (or throws). */
+async function materializeVideoPath(mediaRef: string): Promise<{
+  path: string;
+  cleanup: () => Promise<void>;
+}> {
+  const ref = mediaRef.trim();
+  const row = getAttachmentById(ref);
+  if (!row) {
+    throw new VideoFramesError(`No attachment found for media_ref "${ref}".`);
+  }
+
+  const filePath = getFilePathForAttachment(ref);
+  if (filePath) {
+    return { path: filePath, cleanup: async () => {} };
+  }
+
+  // Inline-stored video: spill the base64 to a temp file ffmpeg can read.
+  if (row.dataBase64) {
+    const tmpPath = join(tmpdir(), `vellum-video-${randomUUID()}`);
+    await writeFile(tmpPath, Buffer.from(row.dataBase64, "base64"));
+    return {
+      path: tmpPath,
+      cleanup: async () => unlink(tmpPath).catch(() => {}),
+    };
+  }
+
+  throw new VideoFramesError(
+    `Attachment "${ref}" has no readable video content.`,
+  );
+}
+
+/**
+ * Sample timestamped keyframes from a video attachment. Throws
+ * {@link VideoFramesError} on any failure (missing attachment, ffmpeg
+ * unavailable, extraction failure) — the tool converts it to `{ isError: true }`.
+ */
+export async function sampleVideoFrames(
+  mediaRef: string,
+  options: SampleVideoOptions = {},
+): Promise<SampledVideo> {
+  const { path, cleanup } = await materializeVideoPath(mediaRef);
+  try {
+    const durationS = await probeDurationSeconds(path);
+
+    const strategy = options.sample ?? "keyframes";
+    const rawStart = options.window?.[0];
+    const rawEnd = options.window?.[1];
+    const hasWindow = rawStart !== undefined || rawEnd !== undefined;
+    const windowStart = clampTime(rawStart ?? 0, 0, durationS);
+    const windowEnd = clampTime(rawEnd ?? durationS, windowStart, durationS);
+
+    const { timestamps, requested } = planTimestamps(
+      durationS,
+      windowStart,
+      windowEnd,
+      strategy,
+    );
+
+    const frames: SampledFrame[] = [];
+    for (const t of timestamps) {
+      if (options.signal?.aborted) {
+        throw new VideoFramesError("Video frame sampling was cancelled.");
+      }
+      const base64 = await extractFrameAt(path, t);
+      const optimized = optimizeImageForTransport(base64, "image/jpeg");
+      frames.push({
+        t_seconds: round1(t),
+        block: {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: optimized.mediaType,
+            data: optimized.data,
+          },
+        },
+      });
+    }
+
+    if (frames.length === 0) {
+      throw new VideoFramesError("No frames could be sampled from the video.");
+    }
+
+    const result: SampledVideo = { duration_s: durationS, frames };
+
+    const cappedByMax = requested > frames.length;
+    if (cappedByMax || hasWindow) {
+      const reasons: string[] = [];
+      if (cappedByMax) {
+        reasons.push(
+          `frame count capped at ${MAX_FRAMES} (sampling asked for ${requested})`,
+        );
+      }
+      if (hasWindow) {
+        reasons.push(
+          `sampling restricted to window [${windowStart.toFixed(1)}s, ${windowEnd.toFixed(1)}s] of a ${durationS.toFixed(1)}s clip`,
+        );
+      }
+      result.truncated = {
+        reason: reasons.join("; "),
+        requested,
+        returned: frames.length,
+        covered_window: [round1(windowStart), round1(windowEnd)],
+      };
+    }
+
+    return result;
+  } catch (err) {
+    if (err instanceof VideoFramesError) throw err;
+    log.warn(
+      { error: err instanceof Error ? err.message : String(err) },
+      "video frame sampling failed",
+    );
+    throw new VideoFramesError(
+      "Video frame sampling failed in this environment.",
+    );
+  } finally {
+    await cleanup();
+  }
+}
+
+function clampTime(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(max, Math.max(min, value));
+}
+
+function round1(value: number): number {
+  return Math.round(value * 10) / 10;
+}

--- a/assistant/src/plugins/defaults/vision-perception/src/video-frames.ts
+++ b/assistant/src/plugins/defaults/vision-perception/src/video-frames.ts
@@ -100,6 +100,15 @@ const STRATEGY_FPS: Record<SampleStrategy, number | null> = {
 };
 
 /**
+ * Seconds to pull the final sampled timestamp back from the video's end.
+ * Seeking ffmpeg to exactly the duration (EOF) commonly yields no frame / an
+ * empty file, which would make {@link extractFrameAt} throw and turn an ordinary
+ * clip into a `{ isError: true }` result. Clamping every timestamp to at most
+ * `duration - EPSILON` keeps us on a real frame just before the end.
+ */
+export const END_EPSILON_S = 0.1;
+
+/**
  * Translate a {@link spawnWithTimeout} run into a typed error vocabulary: a
  * thrown promise (the binary could not be spawned — absent in this environment)
  * and a non-zero exit both become {@link VideoFramesError}.
@@ -198,8 +207,12 @@ async function extractFrameAt(
  * window (a robust, deterministic proxy for scene coverage without a second
  * decode pass). The list is capped at {@link MAX_FRAMES}; the returned
  * `requested` reflects the pre-cap count so the caller can report truncation.
+ *
+ * Every timestamp is held strictly below the clip's duration (by
+ * {@link END_EPSILON_S}); see that constant for why seeking to EOF is avoided.
+ * Exported for unit testing of that invariant.
  */
-function planTimestamps(
+export function planTimestamps(
   durationS: number,
   windowStart: number,
   windowEnd: number,
@@ -217,13 +230,20 @@ function planTimestamps(
   }
 
   const count = Math.min(requested, MAX_FRAMES);
+
+  // Never seek to the duration itself: ffmpeg at EOF commonly returns no frame.
+  // Cap every timestamp at `duration - EPSILON`, but keep it non-negative so a
+  // sub-epsilon clip still samples a valid frame near the start.
+  const maxT = Math.max(0, durationS - END_EPSILON_S);
+  const cap = (t: number) => Math.min(maxT, t);
+
   const timestamps: number[] = [];
   if (count === 1) {
-    timestamps.push(windowStart + span / 2);
+    timestamps.push(cap(windowStart + span / 2));
   } else {
     const step = span / (count - 1);
     for (let i = 0; i < count; i++) {
-      timestamps.push(Math.min(durationS, windowStart + i * step));
+      timestamps.push(cap(windowStart + i * step));
     }
   }
   return { timestamps, requested };

--- a/assistant/src/plugins/defaults/vision-perception/tools/vlm-video-log.ts
+++ b/assistant/src/plugins/defaults/vision-perception/tools/vlm-video-log.ts
@@ -1,0 +1,214 @@
+/**
+ * The `vlm_video_log` tool — reads a provided video and returns a timestamped
+ * event log.
+ *
+ * The model passes the video's attachment id as `media_ref`, optionally a
+ * `query` to focus the log, a `sample` strategy, and a `window` to restrict the
+ * span. The plugin samples timestamped keyframes (via `video-frames.ts`, which
+ * relies on ffmpeg and degrades to an error when it is unavailable), sends the
+ * frames plus the query to the `visionPerception` call site, and parses the
+ * model's response into `{ duration_s, segments, truncated? }`. When frames are
+ * capped, `truncated` is populated so coverage is never silently overstated.
+ *
+ * Default export = the tool definition. `defaults/index.ts` finalizes it and
+ * attaches it to the vision-perception plugin's `tools` array, which
+ * `bootstrapPlugins` registers into the model-visible tool catalog.
+ */
+
+import type {
+  ToolContext,
+  ToolDefinition,
+  ToolExecutionResult,
+} from "@vellumai/plugin-api";
+import { RiskLevel } from "@vellumai/plugin-api";
+
+import {
+  extractAllText,
+  getConfiguredProvider,
+} from "../../../../providers/provider-send-message.js";
+import type { Message } from "../../../../providers/types.js";
+import { parseModelJson } from "../src/coordinates.js";
+import { resolveVisionVideo } from "../src/media-source.js";
+import type {
+  FramesTruncation,
+  SampledFrame,
+  SampleStrategy,
+} from "../src/video-frames.js";
+
+const VISION_CALL_SITE = "visionPerception" as const;
+
+const SAMPLE_STRATEGIES: readonly SampleStrategy[] = [
+  "keyframes",
+  "uniform_1hz",
+  "uniform_4hz",
+];
+
+interface VideoSegment {
+  t_start: number;
+  t_end: number;
+  summary: string;
+  events: string[];
+}
+
+interface VideoLog {
+  duration_s: number;
+  segments: VideoSegment[];
+  truncated?: FramesTruncation;
+}
+
+const VIDEO_SYSTEM_PROMPT =
+  "You are a vision assistant analyzing a video. You are given an ordered set of " +
+  "frames sampled from the video, each labeled with its timestamp in seconds. " +
+  "Reason only about what is actually visible across the frames; if something " +
+  "cannot be determined from the frames, say so rather than guessing.";
+
+function buildVideoPrompt(query: string, frameCount: number): string {
+  const focus = query.trim()
+    ? ` Focus the log on: ${query.trim()}.`
+    : " Log everything notable that happens.";
+  return (
+    `You are given ${frameCount} timestamped frames from a video, in order.${focus} ` +
+    "Produce a timestamped event log. Respond with ONLY a JSON object of the form " +
+    '{"segments": [{"t_start": <seconds>, "t_end": <seconds>, ' +
+    '"summary": "<what happens in this span>", "events": ["<discrete event>", ...]}]} ' +
+    "where each segment covers a contiguous span and t_start/t_end are in seconds " +
+    "drawn from the frame timestamps. Do not include any prose outside the JSON."
+  );
+}
+
+/** Build the user message: each frame as `[t=Ns]` text label followed by its image. */
+function buildFrameMessage(frames: SampledFrame[], query: string): Message {
+  const content: Message["content"] = [];
+  for (const frame of frames) {
+    content.push({ type: "text", text: `[t=${frame.t_seconds}s]` });
+    content.push(frame.block);
+  }
+  content.push({ type: "text", text: buildVideoPrompt(query, frames.length) });
+  return { role: "user", content };
+}
+
+function toSeconds(raw: unknown): number {
+  const n = typeof raw === "number" ? raw : Number(raw);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Parse the model's response into segments. Throws when the response isn't the
+ * expected JSON so the tool can degrade to an error. Accepts either a
+ * `{ segments: [...] }` object or a bare array of segments.
+ */
+function parseSegments(text: string): VideoSegment[] {
+  const parsed = parseModelJson(text);
+  let rawList: unknown;
+  if (Array.isArray(parsed)) {
+    rawList = parsed;
+  } else if (parsed && typeof parsed === "object") {
+    rawList = (parsed as Record<string, unknown>).segments;
+  } else {
+    throw new Error("vision model did not return a JSON video log");
+  }
+  if (!Array.isArray(rawList)) {
+    throw new Error("vision model did not return a segments array");
+  }
+
+  const segments: VideoSegment[] = [];
+  for (const entry of rawList) {
+    if (!entry || typeof entry !== "object") continue;
+    const obj = entry as Record<string, unknown>;
+    const events = Array.isArray(obj.events)
+      ? obj.events.filter((e): e is string => typeof e === "string")
+      : [];
+    segments.push({
+      t_start: toSeconds(obj.t_start),
+      t_end: toSeconds(obj.t_end),
+      summary: typeof obj.summary === "string" ? obj.summary : "",
+      events,
+    });
+  }
+  return segments;
+}
+
+function parseWindow(raw: unknown): [number, number] | undefined {
+  if (!Array.isArray(raw) || raw.length !== 2) return undefined;
+  const start = Number(raw[0]);
+  const end = Number(raw[1]);
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return undefined;
+  return [start, end];
+}
+
+const vlmVideoLogTool: ToolDefinition = {
+  name: "vlm_video_log",
+  description:
+    "Use whenever the user provides a video to read or summarize. Pass the " +
+    "attachment id as media_ref. Samples timestamped keyframes and returns a " +
+    "timestamped event log (segments with summaries and discrete events). " +
+    "Optionally pass a query to focus the log, a sample strategy, or a " +
+    "window [start_s, end_s] to restrict the span.",
+  input_schema: {
+    type: "object",
+    properties: {
+      media_ref: { type: "string" },
+      query: { type: "string" },
+      sample: {
+        type: "string",
+        enum: ["keyframes", "uniform_1hz", "uniform_4hz"],
+      },
+      window: {
+        type: "array",
+        items: { type: "number" },
+        minItems: 2,
+        maxItems: 2,
+      },
+    },
+    required: ["media_ref"],
+  },
+  // Read-only video inspection; low risk so the call isn't gated behind a prompt.
+  defaultRiskLevel: RiskLevel.Low,
+  async execute(
+    input: Record<string, unknown>,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> {
+    try {
+      const mediaRef = String(input.media_ref ?? "");
+      const query = typeof input.query === "string" ? input.query : "";
+      const sample =
+        typeof input.sample === "string" &&
+        (SAMPLE_STRATEGIES as readonly string[]).includes(input.sample)
+          ? (input.sample as SampleStrategy)
+          : undefined;
+      const window = parseWindow(input.window);
+
+      const { video } = await resolveVisionVideo(mediaRef, {
+        ...(sample ? { sample } : {}),
+        ...(window ? { window } : {}),
+        ...(ctx.signal ? { signal: ctx.signal } : {}),
+      });
+
+      const provider = await getConfiguredProvider(VISION_CALL_SITE);
+      if (!provider) {
+        throw new Error("no vision inference provider is configured");
+      }
+
+      const message = buildFrameMessage(video.frames, query);
+      const response = await provider.sendMessage([message], {
+        systemPrompt: VIDEO_SYSTEM_PROMPT,
+        config: { callSite: VISION_CALL_SITE },
+        signal: ctx.signal,
+      });
+
+      const segments = parseSegments(extractAllText(response));
+      const result: VideoLog = {
+        duration_s: video.duration_s,
+        segments,
+        ...(video.truncated ? { truncated: video.truncated } : {}),
+      };
+
+      return { content: JSON.stringify(result), isError: false };
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      return { content: reason, isError: true };
+    }
+  },
+};
+
+export default vlmVideoLogTool;


### PR DESCRIPTION
## Summary
- Add vlm_video_log: sample timestamped keyframes from a video attachment and return a timestamped event log via Qwen 3.7 Plus
- Gracefully degrades if ffmpeg/extraction is unavailable; reports truncation explicitly
- Gated like the other vlm_* tools; marker advertises it for video attachments

Part of plan: glm-5v-turbo-vlm-tool.md (PR 8 of 8)