### PR TITLE
refactor(plugins): self-review cleanup (region, dedup, dead code)

### DIFF
--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -162,7 +162,7 @@ export const OS_BETA_PROFILE_TEMPLATE: ManagedProfileTemplate = {
 };
 
 export const VISION_PROFILE_KEY = "vision";
-export const VISION_PERCEPTION_FLAG_KEY = "vision-perception";
+export { VISION_PERCEPTION_FLAG_KEY } from "./vision-perception-flag.js";
 
 /**
  * Flag-gated managed profile backing the `visionPerception` call site. NOT in

--- a/assistant/src/config/vision-perception-flag.ts
+++ b/assistant/src/config/vision-perception-flag.ts
@@ -1,6 +1,8 @@
 import { isAssistantFeatureFlagEnabled } from "./assistant-feature-flags.js";
 import type { AssistantConfig } from "./schema.js";
-import { VISION_PERCEPTION_FLAG_KEY } from "./seed-inference-profiles.js";
+
+/** Single source for the `vision-perception` feature-flag key. */
+export const VISION_PERCEPTION_FLAG_KEY = "vision-perception";
 
 /** Whether the `vision-perception` feature flag is enabled for this config. */
 export function isVisionPerceptionEnabled(config: AssistantConfig): boolean {

--- a/assistant/src/config/vision-perception-flag.ts
+++ b/assistant/src/config/vision-perception-flag.ts
@@ -1,8 +1,8 @@
 import { isAssistantFeatureFlagEnabled } from "./assistant-feature-flags.js";
 import type { AssistantConfig } from "./schema.js";
+import { VISION_PERCEPTION_FLAG_KEY } from "./seed-inference-profiles.js";
 
-const VISION_PERCEPTION_FLAG = "vision-perception" as const;
-
+/** Whether the `vision-perception` feature flag is enabled for this config. */
 export function isVisionPerceptionEnabled(config: AssistantConfig): boolean {
-  return isAssistantFeatureFlagEnabled(VISION_PERCEPTION_FLAG, config);
+  return isAssistantFeatureFlagEnabled(VISION_PERCEPTION_FLAG_KEY, config);
 }

--- a/assistant/src/plugins/defaults/vision-perception/__tests__/vision-tools.test.ts
+++ b/assistant/src/plugins/defaults/vision-perception/__tests__/vision-tools.test.ts
@@ -112,6 +112,36 @@ describe("vlm_ask tool", () => {
     expect(text).toEqual({ type: "text", text: "What is in this image?" });
   });
 
+  test("threads a region into the prompt on the 0-1000 scale", async () => {
+    await vlmAskTool.execute?.(
+      {
+        media_ref: "att-1",
+        question: "What does the sign say?",
+        region: [100, 200, 300, 400],
+      },
+      ctx,
+    );
+
+    const sent = sendMessageArgs?.messages;
+    const text = sent?.[0].content.find((b) => b.type === "text");
+    expect(text?.type).toBe("text");
+    const promptText = text?.type === "text" ? text.text : "";
+    expect(promptText).toContain("What does the sign say?");
+    expect(promptText).toContain("[x0,y0,x1,y1]=[100, 200, 300, 400]");
+    expect(promptText).toContain("0–1000 normalized scale");
+  });
+
+  test("omits the region clause when no region is provided", async () => {
+    await vlmAskTool.execute?.(
+      { media_ref: "att-1", question: "What is in this image?" },
+      ctx,
+    );
+
+    const sent = sendMessageArgs?.messages;
+    const text = sent?.[0].content.find((b) => b.type === "text");
+    expect(text).toEqual({ type: "text", text: "What is in this image?" });
+  });
+
   test("returns isError (no throw) for a missing media_ref", async () => {
     const result = await vlmAskTool.execute?.(
       { media_ref: "does-not-exist", question: "?" },

--- a/assistant/src/plugins/defaults/vision-perception/hooks/pre-model-call.ts
+++ b/assistant/src/plugins/defaults/vision-perception/hooks/pre-model-call.ts
@@ -25,10 +25,10 @@
 
 import type { PluginHookFn, PreModelCallContext } from "@vellumai/plugin-api";
 
-import { isAssistantFeatureFlagEnabled } from "../../../../config/assistant-feature-flags.js";
 import { resolveCallSiteConfig } from "../../../../config/llm-resolver.js";
 import { getConfig } from "../../../../config/loader.js";
 import type { LLMCallSite } from "../../../../config/schemas/llm.js";
+import { isVisionPerceptionEnabled } from "../../../../config/vision-perception-flag.js";
 import { getAttachmentById } from "../../../../memory/attachments-store.js";
 import { PROVIDER_CATALOG } from "../../../../providers/model-catalog.js";
 import type {
@@ -78,7 +78,7 @@ export function resolveBackboneSupportsVision(opts: {
 }): boolean {
   try {
     const config = getConfig();
-    if (!isAssistantFeatureFlagEnabled("vision-perception", config)) {
+    if (!isVisionPerceptionEnabled(config)) {
       return true;
     }
     const { llm } = config;

--- a/assistant/src/plugins/defaults/vision-perception/src/call-vision-model.ts
+++ b/assistant/src/plugins/defaults/vision-perception/src/call-vision-model.ts
@@ -4,23 +4,82 @@
  * Routed entirely through the assistant's own inference: `getConfiguredProvider`
  * resolves the `visionPerception` call site (flag-gated to a vision-capable
  * inference profile) to a provider/model/credentials from the configured
- * profiles — managed-proxy or BYOK, no separate API key. The media reference is
- * resolved to an `ImageContent` block, paired with the prompt as a single user
- * `Message`, and sent through `provider.sendMessage`; the returned text blocks
- * are concatenated into the answer.
+ * profiles — managed-proxy or BYOK, no separate API key. A prebuilt message
+ * content array is paired with a system prompt as a single user `Message` and
+ * sent through `provider.sendMessage`; the returned text blocks are concatenated
+ * into the answer.
+ *
+ * {@link sendVisionMessage} is the single source for the call-site const,
+ * provider resolution, send, and text extraction. {@link callVisionModel} and
+ * {@link callVisionModelWithBlock} are thin helpers over it: the former resolves
+ * a media reference into an image block first; the latter reuses an
+ * already-resolved block so a caller that also needs the image's pixel size
+ * resolves the media only once.
  */
 
 import {
   extractAllText,
   getConfiguredProvider,
 } from "../../../../providers/provider-send-message.js";
-import type { Message } from "../../../../providers/types.js";
+import type { ImageContent, Message } from "../../../../providers/types.js";
 import type { ToolContext } from "../../../../tools/types.js";
 import { resolveVisionMedia } from "./media-source.js";
 
 // Dedicated vision call site. Its profile (a vision-capable model) is resolved
 // by the LLM config layer when the `vision-perception` feature flag is on.
 const VISION_CALL_SITE = "visionPerception" as const;
+
+const VISION_SYSTEM_PROMPT =
+  "You are a vision assistant. Examine the provided image carefully and respond " +
+  "to the request precisely. Report only what is actually visible; if something " +
+  "cannot be determined from the image, say so rather than guessing.";
+
+/**
+ * Send a prebuilt user-message content array to the vision call site and return
+ * the model's text answer. Resolves the provider, sends a single user message,
+ * and concatenates the returned text blocks. Throws when no vision provider is
+ * configured.
+ */
+export async function sendVisionMessage(
+  content: Message["content"],
+  systemPrompt: string,
+  ctx: ToolContext,
+): Promise<string> {
+  const provider = await getConfiguredProvider(VISION_CALL_SITE);
+  if (!provider) {
+    throw new Error("no vision inference provider is configured");
+  }
+
+  const message: Message = { role: "user", content };
+  const response = await provider.sendMessage([message], {
+    systemPrompt,
+    config: { callSite: VISION_CALL_SITE },
+    signal: ctx.signal,
+  });
+
+  return extractAllText(response);
+}
+
+/**
+ * Send an already-resolved image block plus a prompt to the vision call site and
+ * return the model's text answer. Lets a caller that already resolved the media
+ * (e.g. to derive its pixel size) reuse the block instead of resolving twice.
+ * Throws when no vision provider is configured.
+ */
+export async function callVisionModelWithBlock(
+  block: ImageContent,
+  prompt: string,
+  ctx: ToolContext,
+): Promise<string> {
+  const answer = (
+    await sendVisionMessage(
+      [block, { type: "text", text: prompt }],
+      VISION_SYSTEM_PROMPT,
+      ctx,
+    )
+  ).trim();
+  return answer.length > 0 ? answer : "(vision model returned no text)";
+}
 
 /**
  * Resolve the media reference, send the image + prompt to the vision call site,
@@ -33,28 +92,5 @@ export async function callVisionModel(
   ctx: ToolContext,
 ): Promise<string> {
   const media = await resolveVisionMedia(mediaRef);
-
-  const provider = await getConfiguredProvider(VISION_CALL_SITE);
-  if (!provider) {
-    throw new Error("no vision inference provider is configured");
-  }
-
-  const message: Message = {
-    role: "user",
-    content: [media.block, { type: "text", text: prompt }],
-  };
-
-  const response = await provider.sendMessage([message], {
-    systemPrompt: VISION_SYSTEM_PROMPT,
-    config: { callSite: VISION_CALL_SITE },
-    signal: ctx.signal,
-  });
-
-  const answer = extractAllText(response).trim();
-  return answer.length > 0 ? answer : "(vision model returned no text)";
+  return callVisionModelWithBlock(media.block, prompt, ctx);
 }
-
-const VISION_SYSTEM_PROMPT =
-  "You are a vision assistant. Examine the provided image carefully and respond " +
-  "to the request precisely. Report only what is actually visible; if something " +
-  "cannot be determined from the image, say so rather than guessing.";

--- a/assistant/src/plugins/defaults/vision-perception/src/coordinates.ts
+++ b/assistant/src/plugins/defaults/vision-perception/src/coordinates.ts
@@ -14,8 +14,8 @@
  */
 
 import { parseImageDimensions } from "../../../../context/image-dimensions.js";
+import type { ImageContent } from "../../../../providers/types.js";
 import { parseJsonSafe } from "../../../../util/json.js";
-import { resolveVisionMedia } from "./media-source.js";
 
 /** The fixed scale the grounding tools normalize boxes onto. */
 export const COORD_SCALE = 1000;
@@ -27,16 +27,17 @@ export type BBox = [number, number, number, number];
 export type ImageSize = [number, number];
 
 /**
- * Resolve a media reference's real pixel dimensions, reading the same attachment
- * bytes the vision call uses. Returns `[0, 0]` when the dimensions can't be
- * parsed (an unrecognized or truncated format) — callers still get a usable
- * result, just without a pixel-mapping anchor. Throws only what
- * `resolveVisionMedia` throws (a missing / non-image reference), which the tools
- * convert into `{ isError: true }`.
+ * Read an already-resolved image block's real pixel dimensions. Returns
+ * `[0, 0]` when the dimensions can't be parsed (an unrecognized or truncated
+ * format) — callers still get a usable result, just without a pixel-mapping
+ * anchor. Lets the grounding tools resolve the attachment once (for both the
+ * model send and the echoed size) instead of reading the bytes twice.
  */
-export async function resolveImageSize(mediaRef: string): Promise<ImageSize> {
-  const media = await resolveVisionMedia(mediaRef);
-  const dims = parseImageDimensions(media.block.source.data, media.mimeType);
+export function imageSizeFromBlock(
+  block: ImageContent,
+  mimeType: string,
+): ImageSize {
+  const dims = parseImageDimensions(block.source.data, mimeType);
   return dims ? [dims.width, dims.height] : [0, 0];
 }
 
@@ -96,22 +97,6 @@ export function normalizeBox(raw: unknown): BBox | null {
 
   const [a, b, c, d] = scaled.map(clampCoord);
   return [Math.min(a, c), Math.min(b, d), Math.max(a, c), Math.max(b, d)];
-}
-
-/**
- * Normalize a list of raw boxes, dropping any that aren't valid 4-tuples.
- * `imageSize` is accepted for interface symmetry with callers that thread the
- * echoed size through; normalization itself is size-independent because the
- * contract is a fixed 0–1000 scale.
- */
-export function normalizeBoxes(raw: unknown, _imageSize: ImageSize): BBox[] {
-  if (!Array.isArray(raw)) return [];
-  const out: BBox[] = [];
-  for (const candidate of raw) {
-    const box = normalizeBox(candidate);
-    if (box) out.push(box);
-  }
-  return out;
 }
 
 /**

--- a/assistant/src/plugins/defaults/vision-perception/src/image-block.ts
+++ b/assistant/src/plugins/defaults/vision-perception/src/image-block.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared helper for wrapping optimized image bytes into a provider
+ * {@link ImageContent} block.
+ */
+
+import type { ImageContent } from "../../../../providers/types.js";
+
+/**
+ * Wrap an {@link optimizeImageForTransport} result (`{ data, mediaType }`) into
+ * a base64 {@link ImageContent} block. Shared by the image and video-frame
+ * resolvers so the provider block shape has a single source.
+ */
+export function toImageBlock(optimized: {
+  data: string;
+  mediaType: string;
+}): ImageContent {
+  return {
+    type: "image",
+    source: {
+      type: "base64",
+      media_type: optimized.mediaType,
+      data: optimized.data,
+    },
+  };
+}

--- a/assistant/src/plugins/defaults/vision-perception/src/media-source.ts
+++ b/assistant/src/plugins/defaults/vision-perception/src/media-source.ts
@@ -17,6 +17,7 @@ import {
   getAttachmentContent,
 } from "../../../../memory/attachments-store.js";
 import type { ImageContent } from "../../../../providers/types.js";
+import { toImageBlock } from "./image-block.js";
 import {
   type SampledVideo,
   sampleVideoFrames,
@@ -80,17 +81,8 @@ export async function resolveVisionMedia(
     row.mimeType,
   );
 
-  const block: ImageContent = {
-    type: "image",
-    source: {
-      type: "base64",
-      media_type: optimized.mediaType,
-      data: optimized.data,
-    },
-  };
-
   return {
-    block,
+    block: toImageBlock(optimized),
     mimeType: optimized.mediaType,
     kind: row.kind,
     filename: row.originalFilename,

--- a/assistant/src/plugins/defaults/vision-perception/src/video-frames.ts
+++ b/assistant/src/plugins/defaults/vision-perception/src/video-frames.ts
@@ -33,6 +33,7 @@ import {
   FFPROBE_TIMEOUT_MS,
   spawnWithTimeout,
 } from "../../../../util/spawn.js";
+import { toImageBlock } from "./image-block.js";
 
 const log = getLogger("vision-perception-video-frames");
 
@@ -55,8 +56,16 @@ export interface SampledFrame {
   block: ImageContent;
 }
 
-/** Sampling strategies the tool exposes. */
-export type SampleStrategy = "keyframes" | "uniform_1hz" | "uniform_4hz";
+/** Sampling strategies the tool exposes (single source for the type, the tool's
+ * runtime validation list, and its input-schema enum). */
+export const SAMPLE_STRATEGIES = [
+  "keyframes",
+  "uniform_1hz",
+  "uniform_4hz",
+] as const;
+
+/** A sampling strategy the tool exposes. */
+export type SampleStrategy = (typeof SAMPLE_STRATEGIES)[number];
 
 /** Why and how the frame set was capped, so the tool never truncates silently. */
 export interface FramesTruncation {
@@ -316,14 +325,7 @@ export async function sampleVideoFrames(
       const optimized = optimizeImageForTransport(base64, "image/jpeg");
       frames.push({
         t_seconds: round1(t),
-        block: {
-          type: "image",
-          source: {
-            type: "base64",
-            media_type: optimized.mediaType,
-            data: optimized.data,
-          },
-        },
+        block: toImageBlock(optimized),
       });
     }
 

--- a/assistant/src/plugins/defaults/vision-perception/tools/vlm-ask.ts
+++ b/assistant/src/plugins/defaults/vision-perception/tools/vlm-ask.ts
@@ -18,6 +18,20 @@ import type {
 import { RiskLevel } from "@vellumai/plugin-api";
 
 import { callVisionModel } from "../src/call-vision-model.js";
+import { type BBox, normalizeBox } from "../src/coordinates.js";
+
+/**
+ * Build the question prompt, appending a region constraint when the caller
+ * narrows the answer to a sub-rectangle. The region is the normalized
+ * `[x0, y0, x1, y1]` box on the 0–1000 grounding scale the vision tools share.
+ */
+function buildAskPrompt(question: string, region: BBox | null): string {
+  if (!region) return question;
+  return (
+    `${question} Restrict your answer to the region ` +
+    `[x0,y0,x1,y1]=[${region.join(", ")}] on a 0–1000 normalized scale.`
+  );
+}
 
 const vlmAskTool: ToolDefinition = {
   name: "vlm_ask",
@@ -42,7 +56,9 @@ const vlmAskTool: ToolDefinition = {
     try {
       const mediaRef = String(input.media_ref ?? "");
       const question = String(input.question ?? "");
-      const content = await callVisionModel(mediaRef, question, ctx);
+      const region = normalizeBox(input.region);
+      const prompt = buildAskPrompt(question, region);
+      const content = await callVisionModel(mediaRef, prompt, ctx);
       return { content, isError: false };
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);

--- a/assistant/src/plugins/defaults/vision-perception/tools/vlm-detect.ts
+++ b/assistant/src/plugins/defaults/vision-perception/tools/vlm-detect.ts
@@ -20,14 +20,15 @@ import type {
 } from "@vellumai/plugin-api";
 import { RiskLevel } from "@vellumai/plugin-api";
 
-import { callVisionModel } from "../src/call-vision-model.js";
+import { callVisionModelWithBlock } from "../src/call-vision-model.js";
 import {
   type BBox,
   type ImageSize,
+  imageSizeFromBlock,
   normalizeBox,
   parseModelJson,
-  resolveImageSize,
 } from "../src/coordinates.js";
+import { resolveVisionMedia } from "../src/media-source.js";
 
 interface Detection {
   label: string;
@@ -120,9 +121,10 @@ const vlmDetectTool: ToolDefinition = {
         ? input.targets.filter((t): t is string => typeof t === "string")
         : [];
 
-      const imageSize = await resolveImageSize(mediaRef);
+      const media = await resolveVisionMedia(mediaRef);
+      const imageSize = imageSizeFromBlock(media.block, media.mimeType);
       const prompt = buildDetectPrompt(targets);
-      const answer = await callVisionModel(mediaRef, prompt, ctx);
+      const answer = await callVisionModelWithBlock(media.block, prompt, ctx);
 
       const result = parseDetections(answer, imageSize);
       return { content: JSON.stringify(result), isError: false };

--- a/assistant/src/plugins/defaults/vision-perception/tools/vlm-ocr.ts
+++ b/assistant/src/plugins/defaults/vision-perception/tools/vlm-ocr.ts
@@ -19,14 +19,15 @@ import type {
 } from "@vellumai/plugin-api";
 import { RiskLevel } from "@vellumai/plugin-api";
 
-import { callVisionModel } from "../src/call-vision-model.js";
+import { callVisionModelWithBlock } from "../src/call-vision-model.js";
 import {
   type BBox,
   type ImageSize,
+  imageSizeFromBlock,
   normalizeBox,
   parseModelJson,
-  resolveImageSize,
 } from "../src/coordinates.js";
+import { resolveVisionMedia } from "../src/media-source.js";
 
 interface OcrBlock {
   text: string;
@@ -118,9 +119,10 @@ const vlmOcrTool: ToolDefinition = {
       const region = normalizeBox(input.region);
       const layout = input.layout === true;
 
-      const imageSize = await resolveImageSize(mediaRef);
+      const media = await resolveVisionMedia(mediaRef);
+      const imageSize = imageSizeFromBlock(media.block, media.mimeType);
       const prompt = buildOcrPrompt(region, layout);
-      const answer = await callVisionModel(mediaRef, prompt, ctx);
+      const answer = await callVisionModelWithBlock(media.block, prompt, ctx);
 
       const result: OcrResult = layout
         ? parseLayout(answer, imageSize)

--- a/assistant/src/plugins/defaults/vision-perception/tools/vlm-video-log.ts
+++ b/assistant/src/plugins/defaults/vision-perception/tools/vlm-video-log.ts
@@ -22,26 +22,16 @@ import type {
 } from "@vellumai/plugin-api";
 import { RiskLevel } from "@vellumai/plugin-api";
 
-import {
-  extractAllText,
-  getConfiguredProvider,
-} from "../../../../providers/provider-send-message.js";
 import type { Message } from "../../../../providers/types.js";
+import { sendVisionMessage } from "../src/call-vision-model.js";
 import { parseModelJson } from "../src/coordinates.js";
 import { resolveVisionVideo } from "../src/media-source.js";
-import type {
-  FramesTruncation,
-  SampledFrame,
-  SampleStrategy,
+import {
+  type FramesTruncation,
+  SAMPLE_STRATEGIES,
+  type SampledFrame,
+  type SampleStrategy,
 } from "../src/video-frames.js";
-
-const VISION_CALL_SITE = "visionPerception" as const;
-
-const SAMPLE_STRATEGIES: readonly SampleStrategy[] = [
-  "keyframes",
-  "uniform_1hz",
-  "uniform_4hz",
-];
 
 interface VideoSegment {
   t_start: number;
@@ -76,15 +66,18 @@ function buildVideoPrompt(query: string, frameCount: number): string {
   );
 }
 
-/** Build the user message: each frame as `[t=Ns]` text label followed by its image. */
-function buildFrameMessage(frames: SampledFrame[], query: string): Message {
+/** Build the message content: each frame as `[t=Ns]` text label followed by its image. */
+function buildFrameContent(
+  frames: SampledFrame[],
+  query: string,
+): Message["content"] {
   const content: Message["content"] = [];
   for (const frame of frames) {
     content.push({ type: "text", text: `[t=${frame.t_seconds}s]` });
     content.push(frame.block);
   }
   content.push({ type: "text", text: buildVideoPrompt(query, frames.length) });
-  return { role: "user", content };
+  return content;
 }
 
 function toSeconds(raw: unknown): number {
@@ -151,7 +144,7 @@ const vlmVideoLogTool: ToolDefinition = {
       query: { type: "string" },
       sample: {
         type: "string",
-        enum: ["keyframes", "uniform_1hz", "uniform_4hz"],
+        enum: [...SAMPLE_STRATEGIES],
       },
       window: {
         type: "array",
@@ -184,19 +177,10 @@ const vlmVideoLogTool: ToolDefinition = {
         ...(ctx.signal ? { signal: ctx.signal } : {}),
       });
 
-      const provider = await getConfiguredProvider(VISION_CALL_SITE);
-      if (!provider) {
-        throw new Error("no vision inference provider is configured");
-      }
+      const content = buildFrameContent(video.frames, query);
+      const answer = await sendVisionMessage(content, VIDEO_SYSTEM_PROMPT, ctx);
 
-      const message = buildFrameMessage(video.frames, query);
-      const response = await provider.sendMessage([message], {
-        systemPrompt: VIDEO_SYSTEM_PROMPT,
-        config: { callSite: VISION_CALL_SITE },
-        signal: ctx.signal,
-      });
-
-      const segments = parseSegments(extractAllText(response));
+      const segments = parseSegments(answer);
       const result: VideoLog = {
         duration_s: video.duration_s,
         segments,

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -439,7 +439,7 @@
       "scope": "assistant",
       "key": "vision-perception",
       "label": "Vision Perception",
-      "description": "Qwen3-VL image/video perception tools",
+      "description": "Qwen 3.7 Plus image/video perception tools",
       "defaultEnabled": false
     }
   ]

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -439,7 +439,7 @@
       "scope": "assistant",
       "key": "vision-perception",
       "label": "Vision Perception",
-      "description": "Qwen3-VL image/video perception tools",
+      "description": "Qwen 3.7 Plus image/video perception tools",
       "defaultEnabled": false
     }
   ]


### PR DESCRIPTION
## Summary
Self-review remediation for the vision-perception plugin: thread region into vlm_ask; consume/dedup the feature-flag predicate + key; fix flag description to Qwen 3.7 Plus; remove dead normalizeBoxes; extract shared sendVisionMessage; resolve media once in ocr/detect; single-source sampling strategies; add toImageBlock helper.

Part of plan: glm-5v-turbo-vlm-tool.md (self-review cleanup)