### PR TITLE
fix(memory): rehydrate background/channel/non-interactive injection blocks on reload/fork

### DIFF
--- a/assistant/src/__tests__/conversation-lifecycle.test.ts
+++ b/assistant/src/__tests__/conversation-lifecycle.test.ts
@@ -860,6 +860,123 @@ describe("loadFromDb metadata injection rehydration", () => {
     ]);
   });
 
+  test("rehydration order matches live assembly for background-turn / channel-capabilities / non-interactive-context", async () => {
+    // A background/scheduled source's live turns inject three extra blocks that
+    // the metadata persist layer now captures so a reloaded or forked
+    // conversation (memory retrospective) reproduces them byte-for-byte.
+    // Live assembly lands them at:
+    //   - `<background_turn>` — prepend-user-tail injector order 15, between
+    //     `<workspace>` (10) and `<turn_context>` (20).
+    //   - `<channel_capabilities>` — Step-3 prepend, just below `<turn_context>`
+    //     and above the after-memory region.
+    //   - `<non_interactive_context>` — Step-3 APPEND, the very last block.
+    // Expected layout (cf. live `applyRuntimeInjections`):
+    //   [<workspace>, <background_turn>, <turn_context>, <channel_capabilities>,
+    //    <memory>dynamic</memory>, <info>v2static</info>, <memory>v3</memory>,
+    //    <NOW.md>, <system_reminder>, <knowledge_base>, ...original,
+    //    <non_interactive_context>]
+    // Rehydration must reproduce this or a background-source fork busts the
+    // message-tier prefix cache at the first divergent block.
+    mockConversation = defaultConv();
+    mockDbMessages = [
+      {
+        id: "m1",
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "First turn" }]),
+        metadata: JSON.stringify({
+          workspaceBlock: "<workspace>\nworkspace body\n</workspace>",
+          backgroundTurnBlock: "<background_turn>\nbg body\n</background_turn>",
+          turnContextBlock: "<turn_context>\nctx payload\n</turn_context>",
+          channelCapabilitiesBlock:
+            "<channel_capabilities>\nchannel: vellum\n</channel_capabilities>",
+          memoryInjectedBlock: "mem payload",
+          memoryV2StaticBlock:
+            "<info>\n## Essentials\n\nAlice prefers VS Code.\n</info>",
+          memoryV3InjectedBlock:
+            "header line\n\n# memory/concepts/page-a.md\nhead a",
+          nowScratchpadBlock: "<NOW.md>\nnow body\n</NOW.md>",
+          pkbSystemReminderBlock:
+            "<system_reminder>\npkb reminder body\n</system_reminder>",
+          pkbContextBlock: "<knowledge_base>\nkb body\n</knowledge_base>",
+          nonInteractiveContextBlock:
+            "<non_interactive_context>\nno human present\n</non_interactive_context>",
+        }),
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: JSON.stringify([{ type: "text", text: "Reply" }]),
+      },
+      {
+        id: "m3",
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "Tail" }]),
+      },
+    ];
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+    const messages = conversation.getMessages();
+
+    expect(messages).toHaveLength(3);
+    expect(messages[0].content).toEqual([
+      { type: "text", text: "<workspace>\nworkspace body\n</workspace>" },
+      { type: "text", text: "<background_turn>\nbg body\n</background_turn>" },
+      { type: "text", text: "<turn_context>\nctx payload\n</turn_context>" },
+      {
+        type: "text",
+        text: "<channel_capabilities>\nchannel: vellum\n</channel_capabilities>",
+      },
+      { type: "text", text: "<memory>\nmem payload\n</memory>" },
+      {
+        type: "text",
+        text: "<info>\n## Essentials\n\nAlice prefers VS Code.\n</info>",
+      },
+      {
+        type: "text",
+        text: "<memory>\nheader line\n\n# memory/concepts/page-a.md\nhead a\n</memory>",
+      },
+      { type: "text", text: "<NOW.md>\nnow body\n</NOW.md>" },
+      {
+        type: "text",
+        text: "<system_reminder>\npkb reminder body\n</system_reminder>",
+      },
+      { type: "text", text: "<knowledge_base>\nkb body\n</knowledge_base>" },
+      { type: "text", text: "First turn" },
+      {
+        type: "text",
+        text: "<non_interactive_context>\nno human present\n</non_interactive_context>",
+      },
+    ]);
+  });
+
+  test("tail user row skips background-turn / channel-capabilities / non-interactive-context", async () => {
+    // The tail row re-injects these fresh next turn, so rehydration must skip
+    // them on the tail — mirroring `<turn_context>` / `<workspace>`.
+    mockConversation = defaultConv();
+    mockDbMessages = [
+      {
+        id: "m1",
+        role: "user",
+        content: JSON.stringify([{ type: "text", text: "Tail" }]),
+        metadata: JSON.stringify({
+          backgroundTurnBlock: "<background_turn>\nbg body\n</background_turn>",
+          channelCapabilitiesBlock:
+            "<channel_capabilities>\nchannel: vellum\n</channel_capabilities>",
+          nonInteractiveContextBlock:
+            "<non_interactive_context>\nno human present\n</non_interactive_context>",
+        }),
+      },
+    ];
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+    const messages = conversation.getMessages();
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].content).toEqual([{ type: "text", text: "Tail" }]);
+  });
+
   test("untrusted-actor view does not rehydrate memoryV2StaticBlock", async () => {
     mockConversation = defaultConv();
     // Rows with `trusted_contact` / `unknown` provenance survive the

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -88,6 +88,7 @@ import {
   loadSlackActiveThreadFocusBlock,
   loadSlackChronologicalContext,
   loadSlackChronologicalMessages,
+  NON_INTERACTIVE_CONTEXT_BLOCK,
   resolveChannelCapabilities,
   resolveTurnInboundActorContext,
   resolveTurnModelProfileLabel,
@@ -939,6 +940,32 @@ describe("applyRuntimeInjections — injection mode", () => {
     expect(allText).toContain("<NOW.md");
     expect(allText).toContain("<system_reminder>");
     expect(allText).toContain("<knowledge_base>");
+  });
+
+  test("captures background-turn / channel-capabilities / non-interactive-context for metadata persistence", async () => {
+    // These three blocks must be captured into `blocks` so persistInjectionBlocks
+    // writes them to message metadata and loadFromDb rehydrates them on a
+    // reload/fork (background-source memory retrospective cache parity — see the
+    // rehydration-order tests in conversation-lifecycle.test.ts). background-turn
+    // fires only for a background/scheduled live conversation, so register one
+    // under the turn's conversation id.
+    setConversation("injection-mode-conv", {
+      conversationId: "injection-mode-conv",
+      workingDir: "/sandbox",
+      workspaceTopLevelContext: "",
+      workspaceTopLevelDirty: false,
+      surfaceState: new Map(),
+      channelCapabilities,
+      conversationType: "background",
+    } as never);
+
+    const { blocks } = await applyRuntimeInjections(baseMessages, fullOptions);
+
+    expect(blocks.backgroundTurnBlock).toContain("<background_turn>");
+    expect(blocks.channelCapabilitiesBlock).toContain("<channel_capabilities>");
+    expect(blocks.nonInteractiveContextBlock).toBe(
+      NON_INTERACTIVE_CONTEXT_BLOCK,
+    );
   });
 
   test("explicit mode: 'full' behaves the same as default", async () => {

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -681,13 +681,14 @@ export function stripNowScratchpad(messages: Message[]): Message[] {
 }
 
 /**
- * Prepend channel capability context to the last user message so the
- * model knows what the current channel can and cannot do.
+ * Build the `<channel_capabilities>` block text for the given capabilities, or
+ * `null` on the happy path (desktop, full capabilities, no special context)
+ * where no block is injected. Split from {@link injectChannelCapabilityContext}
+ * so callers can capture the exact injected text for metadata persistence.
  */
-export function injectChannelCapabilityContext(
-  message: Message,
+export function buildChannelCapabilityBlock(
   caps: ChannelCapabilities,
-): Message {
+): string | null {
   // Happy path: desktop with full capabilities and no special context — skip injection.
   if (
     caps.dashboardCapable &&
@@ -696,7 +697,7 @@ export function injectChannelCapabilityContext(
     !isGroupChatType(caps.chatType) &&
     caps.clientOS !== "macos"
   ) {
-    return message;
+    return null;
   }
 
   const lines: string[] = ["<channel_capabilities>"];
@@ -769,7 +770,16 @@ export function injectChannelCapabilityContext(
 
   lines.push("</channel_capabilities>");
 
-  const block = lines.join("\n");
+  return lines.join("\n");
+}
+
+/** Prepend the `<channel_capabilities>` block (if any) to a user message. */
+export function injectChannelCapabilityContext(
+  message: Message,
+  caps: ChannelCapabilities,
+): Message {
+  const block = buildChannelCapabilityBlock(caps);
+  if (block === null) return message;
   return {
     ...message,
     content: [{ type: "text", text: block }, ...message.content],
@@ -1513,6 +1523,14 @@ export function loadSlackActiveThreadFocusBlock(
 export type InjectionMode = "full" | "minimal";
 
 /**
+ * The `<non_interactive_context>` block appended on non-interactive turns.
+ * Module-scoped so `applyRuntimeInjections` both injects it and captures the
+ * exact text for metadata persistence from a single source of truth.
+ */
+export const NON_INTERACTIVE_CONTEXT_BLOCK =
+  "<non_interactive_context>\nNon-interactive scheduled task — do not ask for clarification or confirmation. Follow the instructions exactly using your best judgment. If recalled memory contains conflicting notes, prefer the explicit instruction in this message.\n</non_interactive_context>";
+
+/**
  * Per-turn injection bytes captured so `loadFromDb` can rehydrate historical
  * user messages byte-for-byte after a daemon restart or conversation
  * eviction. Persisting the exact injected text onto message metadata keeps
@@ -1527,6 +1545,27 @@ export interface RuntimeInjectionBlocks {
   nowScratchpadBlock?: string;
   pkbContextBlock?: string;
   memoryV2StaticBlock?: string;
+  /**
+   * The `<background_turn>` block the `background-turn` default injector
+   * attached this turn (background/scheduled non-interactive turns only).
+   * Persisted under `metadata.backgroundTurnBlock` so `loadFromDb` rehydrates
+   * it byte-for-byte on reload/fork — without it, a fork of a background
+   * source (memory retrospective) drops the block and breaks message-tier
+   * prefix-cache parity with the source's live turns.
+   */
+  backgroundTurnBlock?: string;
+  /**
+   * The `<channel_capabilities>` block injected this turn (non-default channel
+   * capabilities). Persisted under `metadata.channelCapabilitiesBlock` for the
+   * same reload/fork cache-parity reason as {@link backgroundTurnBlock}.
+   */
+  channelCapabilitiesBlock?: string;
+  /**
+   * The `<non_interactive_context>` block injected this turn (non-interactive
+   * turns only). Persisted under `metadata.nonInteractiveContextBlock` for the
+   * same reload/fork cache-parity reason as {@link backgroundTurnBlock}.
+   */
+  nonInteractiveContextBlock?: string;
   /**
    * UNWRAPPED inner text of the memory-v3 frozen net-new card block the v3
    * injector attached this turn, mirroring v2's unwrapped `memoryInjectedBlock`
@@ -2108,6 +2147,9 @@ export async function applyRuntimeInjections(
   let pkbSystemReminderCaptured: string | undefined;
   let memoryV2StaticCaptured: string | undefined;
   let memoryV3Captured: string | undefined;
+  let backgroundTurnCaptured: string | undefined;
+  let channelCapabilitiesCaptured: string | undefined;
+  let nonInteractiveContextCaptured: string | undefined;
   const initialTail = runMessages[runMessages.length - 1];
   const initialTailIsUser = !!initialTail && initialTail.role === "user";
   if (initialTailIsUser) {
@@ -2130,6 +2172,9 @@ export async function applyRuntimeInjections(
           break;
         case "memory-v2-static":
           memoryV2StaticCaptured = block.text;
+          break;
+        case "background-turn":
+          backgroundTurnCaptured = block.text;
           break;
         case MEMORY_V3_BLOCK_ID: {
           // The v3 frozen card block is persisted UNWRAPPED (the v2
@@ -2260,16 +2305,14 @@ export async function applyRuntimeInjections(
   if (isNonInteractive) {
     const userTail = result[result.length - 1];
     if (userTail && userTail.role === "user") {
+      nonInteractiveContextCaptured = NON_INTERACTIVE_CONTEXT_BLOCK;
       result = [
         ...result.slice(0, -1),
         {
           ...userTail,
           content: [
             ...userTail.content,
-            {
-              type: "text" as const,
-              text: "<non_interactive_context>\nNon-interactive scheduled task — do not ask for clarification or confirmation. Follow the instructions exactly using your best judgment. If recalled memory contains conflicting notes, prefer the explicit instruction in this message.\n</non_interactive_context>",
-            },
+            { type: "text" as const, text: NON_INTERACTIVE_CONTEXT_BLOCK },
           ],
         },
       ];
@@ -2310,10 +2353,21 @@ export async function applyRuntimeInjections(
   if (channelCapabilities) {
     const userTail = result[result.length - 1];
     if (userTail && userTail.role === "user") {
-      result = [
-        ...result.slice(0, -1),
-        injectChannelCapabilityContext(userTail, channelCapabilities),
-      ];
+      const channelCapabilityBlock =
+        buildChannelCapabilityBlock(channelCapabilities);
+      if (channelCapabilityBlock !== null) {
+        channelCapabilitiesCaptured = channelCapabilityBlock;
+        result = [
+          ...result.slice(0, -1),
+          {
+            ...userTail,
+            content: [
+              { type: "text" as const, text: channelCapabilityBlock },
+              ...userTail.content,
+            ],
+          },
+        ];
+      }
     }
   }
 
@@ -2372,6 +2426,9 @@ export async function applyRuntimeInjections(
       pkbContextBlock: pkbContextCaptured,
       memoryV2StaticBlock: memoryV2StaticCaptured,
       memoryV3InjectedBlock: memoryV3Captured,
+      backgroundTurnBlock: backgroundTurnCaptured,
+      channelCapabilitiesBlock: channelCapabilitiesCaptured,
+      nonInteractiveContextBlock: nonInteractiveContextCaptured,
       memoryV3Active,
       injectorChainBlock,
     },

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -976,6 +976,18 @@ export class Conversation {
           const meta = JSON.parse(m.metadata);
           const isTail = index === arr.length - 1;
 
+          // `<non_interactive_context>` is the only rehydrated block that
+          // APPENDS to the tail (live injection appends it in Step 3), so it
+          // must land after the original content. Apply it first — before the
+          // prepends below — so the prepends stack in front of it and it stays
+          // last, matching the live layout.
+          if (!isTail && typeof meta.nonInteractiveContextBlock === "string") {
+            content = [
+              ...content,
+              { type: "text" as const, text: meta.nonInteractiveContextBlock },
+            ];
+          }
+
           // Rehydrate in reverse injection order (innermost block first)
           // so the resulting layout matches `applyRuntimeInjections`'s
           // after-memory-prefix splices in ascending injector order
@@ -1086,9 +1098,30 @@ export class Conversation {
             ];
           }
 
+          // `<channel_capabilities>` lands just below `<turn_context>`: live
+          // injection prepends it (Step 3) before the prepend-user-tail chain
+          // blocks (Step 4), so it must be prepended BEFORE turnContextBlock
+          // here to land one slot deeper than `<turn_context>`.
+          if (!isTail && typeof meta.channelCapabilitiesBlock === "string") {
+            content = [
+              { type: "text" as const, text: meta.channelCapabilitiesBlock },
+              ...content,
+            ];
+          }
+
           if (!isTail && typeof meta.turnContextBlock === "string") {
             content = [
               { type: "text" as const, text: meta.turnContextBlock },
+              ...content,
+            ];
+          }
+
+          // `<background_turn>` lands between `<workspace>` and `<turn_context>`
+          // (injector order 15, between workspace 10 and unified-turn-context
+          // 20), so prepend it AFTER turnContextBlock and BEFORE workspaceBlock.
+          if (!isTail && typeof meta.backgroundTurnBlock === "string") {
+            content = [
+              { type: "text" as const, text: meta.backgroundTurnBlock },
               ...content,
             ];
           }

--- a/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-job.test.ts
@@ -685,39 +685,12 @@ describe("memoryRetrospectiveJob", () => {
     expect(wakeCalls[0]!.opts.toolGateMode).toBe("execution");
   });
 
-  // -------------------------------------------------------------------------
-  // Source background-turn parity (isNonInteractive)
-  // -------------------------------------------------------------------------
-
-  test("background source → wake runs non-interactive (reproduces <background_turn>)", async () => {
-    conversationOverrides["src-conv-1"] = {
-      source: "heartbeat",
-      forkParentMessageId: null,
-      title: "Heartbeat",
-      conversationType: "background",
-    };
-
-    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
-
-    expect(outcome.kind).toBe("invoked");
-    expect(wakeCalls).toHaveLength(1);
-    expect(wakeCalls[0]!.opts.isNonInteractive).toBe(true);
-  });
-
-  test("standard source → wake stays interactive (no spurious <background_turn>)", async () => {
-    conversationOverrides["src-conv-1"] = {
-      source: "user",
-      forkParentMessageId: null,
-      title: "Source conversation",
-      conversationType: "standard",
-    };
-
-    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
-
-    expect(outcome.kind).toBe("invoked");
-    expect(wakeCalls).toHaveLength(1);
-    expect(wakeCalls[0]!.opts.isNonInteractive).toBe(false);
-  });
+  // Source background-turn cache parity is no longer a wake-time concern: the
+  // fork reproduces the source's `<background_turn>` / `<channel_capabilities>`
+  // / `<non_interactive_context>` blocks via metadata rehydration in
+  // `Conversation.loadFromDb` (the wake never re-runs runtime injection). That
+  // round-trip is covered by the byte-parity test in
+  // `conversation-runtime-assembly.test.ts`.
 
   // -------------------------------------------------------------------------
   // Source-derived persona override

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -148,6 +148,13 @@ export const messageMetadataSchema = z
     nowScratchpadBlock: z.string().optional(),
     pkbContextBlock: z.string().optional(),
     memoryV2StaticBlock: z.string().optional(),
+    /** `<background_turn>` block (background/scheduled non-interactive turns),
+     *  rehydrated by `loadFromDb` for reload/fork prefix-cache parity. */
+    backgroundTurnBlock: z.string().optional(),
+    /** `<channel_capabilities>` block, rehydrated for the same reason. */
+    channelCapabilitiesBlock: z.string().optional(),
+    /** `<non_interactive_context>` block, rehydrated for the same reason. */
+    nonInteractiveContextBlock: z.string().optional(),
   })
   .passthrough();
 

--- a/assistant/src/memory/memory-retrospective-job.ts
+++ b/assistant/src/memory/memory-retrospective-job.ts
@@ -65,7 +65,6 @@ import {
   getMessagesAfter,
   resolveOverrideProfile,
 } from "./conversation-crud.js";
-import { isBackgroundConversationType } from "./conversation-types.js";
 import {
   enqueueMemoryJob,
   type MemoryJob,
@@ -314,14 +313,13 @@ async function runForkBasedRetrospective(
       // {@link WakeToolContextPin}.
       toolGateMode: "execution" as const,
       toolContextPin,
-      // Reproduce the source's turn block for message-tier cache-prefix
-      // parity: background/scheduled sources ran non-interactive live turns
-      // (which carry `<background_turn>`), so the fork must run non-interactive
-      // too. Standard/user sources ran interactive (no `<background_turn>`), so
-      // the fork stays interactive — preserving their existing byte parity.
-      isNonInteractive: isBackgroundConversationType(
-        sourceConversation.conversationType,
-      ),
+      // Message-tier cache-prefix parity — reproducing the source's
+      // `<background_turn>` / `<channel_capabilities>` / `<non_interactive_context>`
+      // blocks — is handled by metadata rehydration, not by re-running runtime
+      // injection on the fork: the source's live turns persist those blocks onto
+      // message metadata, the fork copies that metadata, and
+      // `Conversation.loadFromDb` rehydrates them byte-for-byte. The wake never
+      // re-runs the injection pipeline, so it needs no interactivity hint here.
       // Profile forcing (model/thinking/effort parity) is a separate concern
       // and stays keyed on `matchConversationProfile` via `matchedProfile`.
       ...(matchedProfile !== undefined

--- a/assistant/src/plugins/defaults/memory-retrieval/hooks/user-prompt-submit.ts
+++ b/assistant/src/plugins/defaults/memory-retrieval/hooks/user-prompt-submit.ts
@@ -194,6 +194,9 @@ function persistInjectionBlocks(
     !blocks.pkbContextBlock &&
     !blocks.memoryV2StaticBlock &&
     !blocks.memoryV3InjectedBlock &&
+    !blocks.backgroundTurnBlock &&
+    !blocks.channelCapabilitiesBlock &&
+    !blocks.nonInteractiveContextBlock &&
     !removeV2Block
   ) {
     return;
@@ -228,6 +231,17 @@ function persistInjectionBlocks(
     }
     if (blocks.memoryV2StaticBlock) {
       metadataUpdates.memoryV2StaticBlock = blocks.memoryV2StaticBlock;
+    }
+    if (blocks.backgroundTurnBlock) {
+      metadataUpdates.backgroundTurnBlock = blocks.backgroundTurnBlock;
+    }
+    if (blocks.channelCapabilitiesBlock) {
+      metadataUpdates.channelCapabilitiesBlock =
+        blocks.channelCapabilitiesBlock;
+    }
+    if (blocks.nonInteractiveContextBlock) {
+      metadataUpdates.nonInteractiveContextBlock =
+        blocks.nonInteractiveContextBlock;
     }
     updateMessageMetadata(ctx.userMessageId, metadataUpdates);
   } catch (err) {

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -197,14 +197,6 @@ export interface WakeOptions {
    */
   suppressWakeSurface?: boolean;
   /**
-   * Run the wake's turn as non-interactive (no client present). Threads to the
-   * agent loop's `isNonInteractive`, which gates the `<non_interactive_context>`
-   * and `<background_turn>` injectors. Fork-based memory retrospectives set this
-   * to the source conversation's background-turn state so the fork reproduces
-   * the source's injected turn block (prompt-cache prefix parity). Default false.
-   */
-  isNonInteractive?: boolean;
-  /**
    * Optional exact tool allowlist for this wake. Used by internal maintenance
    * jobs that need the assistant's judgment but must not execute arbitrary
    * side-effect tools. Enforcement depends on `toolGateMode`: in `"wire"`
@@ -596,7 +588,6 @@ export async function wakeAgentForOpportunity(
       opts.forceOverrideProfile ??
       getConversationOverrideProfile(conversationId);
     const callSite = opts.callSite ?? "mainAgent";
-    const isNonInteractive = opts.isNonInteractive ?? false;
     const config = getConfig();
     const effectiveContextWindow = resolveEffectiveContextWindow({
       llm: config.llm,
@@ -1144,7 +1135,6 @@ export async function wakeAgentForOpportunity(
           trust: wakeTrust,
           overrideProfile,
           forceOverrideProfile,
-          isNonInteractive,
           // The wake's compaction lives in the pre-run gate above
           // (`conversation.maybeCompact()`), never in the loop: the in-loop
           // budget gate and overflow-recovery ladder stay disabled because


### PR DESCRIPTION
## Summary

- Persist `<background_turn>`, `<channel_capabilities>`, and `<non_interactive_context>` injection blocks to message metadata and rehydrate them in `Conversation.loadFromDb`, mirroring how `<turn_context>` / `<workspace>` already work. A fork of a background/scheduled source (memory retrospective) rebuilds its prompt from copied metadata, not fresh injection — these three blocks were never persisted, so the fork dropped them and broke message-tier prompt-cache parity at the first divergence, re-creating the source's large (byte-identical) `<info>`/`<memory>` prefix on every fork.
- Rehydrate at the byte-exact live order: `[<workspace>, <background_turn>, <turn_context>, <channel_capabilities>, …memory prefix…, …original, <non_interactive_context>]`. `<background_turn>` and `<channel_capabilities>` are needed together so the prefix matches through `<info>`+`<memory>` (the bulk of the bytes); `<memory_spotlight>` stays intentionally ephemeral and caps tail parity after that point.
- Remove #35427's `isNonInteractive` wake plumbing — it threaded only into the wake-disabled in-loop compaction / overflow-recovery paths and never reached the injector gate, so it was a no-op. Parity now comes from rehydration.
- Tests: rehydration order matches live `applyRuntimeInjections` (via real `loadFromDb`); tail rows skip the blocks; `applyRuntimeInjections` captures all three for persistence.

Backwards compatible: additive metadata keys, no migration. Messages persisted before this change simply don't rehydrate the new blocks (no regression); new background turns persist them going forward.

## Original prompt

A memory retrospective fork over a background/scheduled source conversation showed large prompt-cache misses on its first provider call. Tracing the materialized request showed the fork emitting `<turn_context>` where the source's live turn had `<background_turn>`, breaking the cache prefix at the first block and forcing the byte-identical `<info>`/`<memory>` blocks downstream to be re-created. An earlier attempt threaded `isNonInteractive` to the wake, but the fork rebuilds its prompt via metadata rehydration (not fresh injection), so the real fix is to persist these blocks to metadata and rehydrate them byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)