### PR TITLE
test(memory-v2): raise backfill-jobs beforeEach timeout to fix flaky CI

### DIFF
--- a/assistant/src/memory/v2/__tests__/backfill-jobs.test.ts
+++ b/assistant/src/memory/v2/__tests__/backfill-jobs.test.ts
@@ -203,9 +203,8 @@ afterAll(() => {
 });
 
 const { getDb } = await import("../../db-connection.js");
-const { resetDbForTesting } = await import(
-  "../../../__tests__/db-test-helpers.js"
-);
+const { resetDbForTesting } =
+  await import("../../../__tests__/db-test-helpers.js");
 const { initializeDb } = await import("../../db-init.js");
 const { rawExec } = await import("../../raw-query.js");
 const { conversations, memoryJobs, messages } = await import("../../schema.js");
@@ -249,6 +248,10 @@ function makeJob(
   };
 }
 
+// The first `initializeDb()` in a fresh test process builds the migration
+// template by running every step; later calls restore it by file copy. That
+// cold build can exceed bun's default 5s hook timeout under CI load, so give
+// the hook generous headroom.
 beforeEach(() => {
   resetDbForTesting();
   initializeDb();
@@ -282,7 +285,7 @@ beforeEach(() => {
 
   migrationCalls.length = 0;
   migrationOutcome = { type: "ok" };
-});
+}, 30_000);
 
 // ---------------------------------------------------------------------------
 // memoryV2MigrateJob


### PR DESCRIPTION
## Summary
- The first `initializeDb()` in a fresh test process builds the migration template by running every migration step; under CI load that cold build can exceed bun's default 5s `beforeEach` hook timeout, flaking the suite's first test (`memoryV2MigrateJob > invokes runMemoryV2Migration with workspace + database`).
- Give the `beforeEach` hook a 30s timeout so the cold template build has headroom. Later tests restore the template by fast file copy and are unaffected.
- Incidental: `prettier --write` corrected pre-existing format drift on the `resetDbForTesting` import (the touched-file format gate requires it).

## Original prompt
Fix the specific CI issue in the failing "Test" job of run [27854296513](https://github.com/vellum-ai/vellum-assistant/actions/runs/27854296513/job/82438781603) — a flaky `beforeEach`/`afterEach` hook timeout (5780ms) in `src/memory/v2/__tests__/backfill-jobs.test.ts` on a `main` commit unrelated to the test. Scope the fix to that job only.