### PR TITLE
fix(plugins): address Codex P2s — media_ref persistence, video gating, plugin registration

### DIFF
--- a/assistant/src/__tests__/inline-upload-media-ref.test.ts
+++ b/assistant/src/__tests__/inline-upload-media-ref.test.ts
@@ -134,7 +134,10 @@ describe("Codex P2 — inline upload media_ref", () => {
     });
 
     // Simulate the outbound sanitization for a non-vision backbone.
-    const rewritten = applyVisionPerceptionMarkers(ctx.messages, false);
+    const rewritten = applyVisionPerceptionMarkers(ctx.messages, {
+      supportsVision: false,
+      supportsVideo: false,
+    });
     const userMsg = rewritten.at(-1)!;
     const marker = userMsg.content.find(
       (b) => b.type === "text" && b.text.includes('media_ref="att-0"'),

--- a/assistant/src/agent/attachments.test.ts
+++ b/assistant/src/agent/attachments.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for attachment-id rehydration (Codex P2 — inline media_ref must survive
+ * a reload).
+ *
+ * The persisted message JSON never carries `_attachmentId` (it is minted after
+ * persistence and backfilled onto the in-memory block at send time). On a
+ * conversation reload from the DB the in-memory block is reconstructed from JSON
+ * and so loses the id — `rehydrateAttachmentIds` reapplies it from the
+ * message_attachments links so the vision-perception markers can still surface a
+ * usable `media_ref` for a non-vision backbone.
+ *
+ * `mock.module` is process-global, so the attachment-store stub (used only for
+ * the marker filename lookup) lives in this one file.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { FileContent, ImageContent, Message } from "../providers/types.js";
+
+// The marker renderer looks up the attachment's original filename. A missing id
+// resolves to a generic label, matching the real store.
+let attachmentRows: Record<string, { originalFilename: string; kind: string }> =
+  {};
+mock.module("../memory/attachments-store.js", () => ({
+  getAttachmentById: (id: string) => attachmentRows[id] ?? null,
+}));
+
+// Drive marker resolution directly with controllable mocks so the rehydrated
+// block can be threaded through the real marker rewrite without a live config.
+mock.module("../config/loader.js", () => ({
+  getConfig: () => ({ llm: { profiles: {}, default: {} } }),
+}));
+mock.module("../config/assistant-feature-flags.js", () => ({
+  isAssistantFeatureFlagEnabled: () => true,
+}));
+
+const { rehydrateAttachmentIds, backfillAttachmentId } =
+  await import("./attachments.js");
+const { applyVisionPerceptionMarkers } =
+  await import("../plugins/defaults/vision-perception/hooks/pre-model-call.js");
+
+function imageBlock(): ImageContent {
+  return {
+    type: "image",
+    source: { type: "base64", media_type: "image/png", data: "AAAA" },
+  };
+}
+
+function fileBlock(mediaType = "application/pdf"): FileContent {
+  return {
+    type: "file",
+    source: {
+      type: "base64",
+      media_type: mediaType,
+      data: "AAAA",
+      filename: "doc.pdf",
+    },
+  };
+}
+
+beforeEach(() => {
+  attachmentRows = {
+    "att-0": { originalFilename: "photo.png", kind: "image" },
+    "att-1": { originalFilename: "second.png", kind: "image" },
+    "vid-0": { originalFilename: "clip.mp4", kind: "video" },
+  };
+});
+
+describe("rehydrateAttachmentIds", () => {
+  test("maps ordered ids onto image/file blocks, skipping leading text", () => {
+    const message: Message = {
+      role: "user",
+      content: [{ type: "text", text: "look" }, imageBlock(), imageBlock()],
+    };
+    rehydrateAttachmentIds(message, ["att-0", "att-1"]);
+    expect((message.content[1] as ImageContent)._attachmentId).toBe("att-0");
+    expect((message.content[2] as ImageContent)._attachmentId).toBe("att-1");
+  });
+
+  test("uses the same indexing as backfillAttachmentId (n-th media block ← n-th id)", () => {
+    const reloaded: Message = {
+      role: "user",
+      content: [{ type: "text", text: "look" }, imageBlock(), fileBlock()],
+    };
+    const liveBackfilled: Message = {
+      role: "user",
+      content: [{ type: "text", text: "look" }, imageBlock(), fileBlock()],
+    };
+    // Reload path: rehydrate from the ordered id list.
+    rehydrateAttachmentIds(reloaded, ["att-0", "vid-0"]);
+    // Live path: backfill each index individually.
+    backfillAttachmentId(liveBackfilled, 0, "att-0");
+    backfillAttachmentId(liveBackfilled, 1, "vid-0");
+
+    expect((reloaded.content[1] as ImageContent)._attachmentId).toBe(
+      (liveBackfilled.content[1] as ImageContent)._attachmentId,
+    );
+    expect((reloaded.content[2] as FileContent)._attachmentId).toBe(
+      (liveBackfilled.content[2] as FileContent)._attachmentId,
+    );
+  });
+
+  test("never overwrites an id already present on a block", () => {
+    const block = imageBlock();
+    block._attachmentId = "already-set";
+    const message: Message = { role: "user", content: [block] };
+    rehydrateAttachmentIds(message, ["att-0"]);
+    expect(block._attachmentId).toBe("already-set");
+  });
+
+  test("is a no-op for an empty id list", () => {
+    const block = imageBlock();
+    const message: Message = { role: "user", content: [block] };
+    rehydrateAttachmentIds(message, []);
+    expect(block._attachmentId).toBeUndefined();
+  });
+
+  test("ignores extra ids when there are fewer media blocks", () => {
+    const message: Message = { role: "user", content: [imageBlock()] };
+    rehydrateAttachmentIds(message, ["att-0", "att-1", "vid-0"]);
+    expect((message.content[0] as ImageContent)._attachmentId).toBe("att-0");
+  });
+});
+
+describe("reloaded inline upload still yields a media_ref marker", () => {
+  test("a rehydrated image block becomes a marker with the real media_ref on a non-vision backbone", () => {
+    // Simulate a conversation reloaded from the DB: the persisted JSON has no
+    // _attachmentId, but the message_attachments link list does.
+    const reloaded: Message = {
+      role: "user",
+      content: [{ type: "text", text: "what is this?" }, imageBlock()],
+    };
+    rehydrateAttachmentIds(reloaded, ["att-0"]);
+
+    // Non-vision backbone: image is rewritten into an attachment-id marker.
+    const out = applyVisionPerceptionMarkers([reloaded], {
+      supportsVision: false,
+      supportsVideo: false,
+    });
+    const blocks = out[0].content;
+
+    // Raw image gone; marker carries the rehydrated id as a usable media_ref.
+    expect(blocks.some((b) => b.type === "image")).toBe(false);
+    const marker = blocks.find(
+      (b) => b.type === "text" && b.text.includes('media_ref="att-0"'),
+    ) as { type: "text"; text: string } | undefined;
+    expect(marker).toBeDefined();
+    expect(marker!.text).toContain('id="att-0"');
+    expect(marker!.text).toContain('file "photo.png"');
+  });
+
+  test("a rehydrated video file block becomes a vlm_video_log marker", () => {
+    const reloaded: Message = {
+      role: "user",
+      content: [{ type: "text", text: "summarize" }, fileBlock("video/mp4")],
+    };
+    rehydrateAttachmentIds(reloaded, ["vid-0"]);
+
+    const out = applyVisionPerceptionMarkers([reloaded], {
+      supportsVision: false,
+      supportsVideo: false,
+    });
+    const blocks = out[0].content;
+    expect(blocks.some((b) => b.type === "file")).toBe(false);
+    const marker = blocks.find(
+      (b) => b.type === "text" && b.text.includes("vlm_video_log"),
+    ) as { type: "text"; text: string } | undefined;
+    expect(marker).toBeDefined();
+    expect(marker!.text).toContain('media_ref="vid-0"');
+  });
+
+  test("without rehydration a reloaded block has no media_ref (regression guard)", () => {
+    // The pre-fix behavior: a reloaded block with no _attachmentId is left
+    // intact (no usable media_ref), proving the rehydration is load-bearing.
+    const reloaded: Message = {
+      role: "user",
+      content: [{ type: "text", text: "what is this?" }, imageBlock()],
+    };
+    const messages = [reloaded];
+    const out = applyVisionPerceptionMarkers(messages, {
+      supportsVision: false,
+      supportsVideo: false,
+    });
+    // Same reference back — nothing was replaceable without an id, so the raw
+    // image survives with no media_ref (this is what the rehydration fixes).
+    expect(out).toBe(messages);
+    expect(out[0].content.some((b) => b.type === "image")).toBe(true);
+  });
+});

--- a/assistant/src/agent/attachments.test.ts
+++ b/assistant/src/agent/attachments.test.ts
@@ -71,7 +71,10 @@ describe("rehydrateAttachmentIds", () => {
       role: "user",
       content: [{ type: "text", text: "look" }, imageBlock(), imageBlock()],
     };
-    rehydrateAttachmentIds(message, ["att-0", "att-1"]);
+    rehydrateAttachmentIds(message, [
+      { position: 0, attachmentId: "att-0" },
+      { position: 1, attachmentId: "att-1" },
+    ]);
     expect((message.content[1] as ImageContent)._attachmentId).toBe("att-0");
     expect((message.content[2] as ImageContent)._attachmentId).toBe("att-1");
   });
@@ -85,8 +88,11 @@ describe("rehydrateAttachmentIds", () => {
       role: "user",
       content: [{ type: "text", text: "look" }, imageBlock(), fileBlock()],
     };
-    // Reload path: rehydrate from the ordered id list.
-    rehydrateAttachmentIds(reloaded, ["att-0", "vid-0"]);
+    // Reload path: rehydrate from the positioned link list.
+    rehydrateAttachmentIds(reloaded, [
+      { position: 0, attachmentId: "att-0" },
+      { position: 1, attachmentId: "vid-0" },
+    ]);
     // Live path: backfill each index individually.
     backfillAttachmentId(liveBackfilled, 0, "att-0");
     backfillAttachmentId(liveBackfilled, 1, "vid-0");
@@ -99,24 +105,57 @@ describe("rehydrateAttachmentIds", () => {
     );
   });
 
+  test("places ids by stored position when an earlier upload was skipped (sparse)", () => {
+    // Two media blocks persist, but the FIRST attachment was skipped at upload
+    // time (unsupported MIME / no data), so message_attachments only has a row
+    // for the second block, stored at position 1. The reload path must match the
+    // live backfillAttachmentId(message, 1, ...) placement exactly.
+    const reloaded: Message = {
+      role: "user",
+      content: [{ type: "text", text: "look" }, imageBlock(), imageBlock()],
+    };
+    const liveBackfilled: Message = {
+      role: "user",
+      content: [{ type: "text", text: "look" }, imageBlock(), imageBlock()],
+    };
+    // Sparse link list: only position 1 has a row (gap at position 0).
+    rehydrateAttachmentIds(reloaded, [{ position: 1, attachmentId: "att-1" }]);
+    backfillAttachmentId(liveBackfilled, 1, "att-1");
+
+    // The SECOND media block gets the id; the first stays untagged — and the
+    // reload placement is byte-for-byte identical to the live path.
+    expect((reloaded.content[1] as ImageContent)._attachmentId).toBeUndefined();
+    expect((reloaded.content[2] as ImageContent)._attachmentId).toBe("att-1");
+    expect((reloaded.content[1] as ImageContent)._attachmentId).toBe(
+      (liveBackfilled.content[1] as ImageContent)._attachmentId,
+    );
+    expect((reloaded.content[2] as ImageContent)._attachmentId).toBe(
+      (liveBackfilled.content[2] as ImageContent)._attachmentId,
+    );
+  });
+
   test("never overwrites an id already present on a block", () => {
     const block = imageBlock();
     block._attachmentId = "already-set";
     const message: Message = { role: "user", content: [block] };
-    rehydrateAttachmentIds(message, ["att-0"]);
+    rehydrateAttachmentIds(message, [{ position: 0, attachmentId: "att-0" }]);
     expect(block._attachmentId).toBe("already-set");
   });
 
-  test("is a no-op for an empty id list", () => {
+  test("is a no-op for an empty link list", () => {
     const block = imageBlock();
     const message: Message = { role: "user", content: [block] };
     rehydrateAttachmentIds(message, []);
     expect(block._attachmentId).toBeUndefined();
   });
 
-  test("ignores extra ids when there are fewer media blocks", () => {
+  test("ignores positions with no matching media block", () => {
     const message: Message = { role: "user", content: [imageBlock()] };
-    rehydrateAttachmentIds(message, ["att-0", "att-1", "vid-0"]);
+    rehydrateAttachmentIds(message, [
+      { position: 0, attachmentId: "att-0" },
+      { position: 1, attachmentId: "att-1" },
+      { position: 2, attachmentId: "vid-0" },
+    ]);
     expect((message.content[0] as ImageContent)._attachmentId).toBe("att-0");
   });
 });
@@ -129,7 +168,7 @@ describe("reloaded inline upload still yields a media_ref marker", () => {
       role: "user",
       content: [{ type: "text", text: "what is this?" }, imageBlock()],
     };
-    rehydrateAttachmentIds(reloaded, ["att-0"]);
+    rehydrateAttachmentIds(reloaded, [{ position: 0, attachmentId: "att-0" }]);
 
     // Non-vision backbone: image is rewritten into an attachment-id marker.
     const out = applyVisionPerceptionMarkers([reloaded], {
@@ -153,7 +192,7 @@ describe("reloaded inline upload still yields a media_ref marker", () => {
       role: "user",
       content: [{ type: "text", text: "summarize" }, fileBlock("video/mp4")],
     };
-    rehydrateAttachmentIds(reloaded, ["vid-0"]);
+    rehydrateAttachmentIds(reloaded, [{ position: 0, attachmentId: "vid-0" }]);
 
     const out = applyVisionPerceptionMarkers([reloaded], {
       supportsVision: false,

--- a/assistant/src/agent/attachments.ts
+++ b/assistant/src/agent/attachments.ts
@@ -45,6 +45,40 @@ export function attachmentsToContentBlocks(
 }
 
 /**
+ * Tag the `mediaBlockIndex`-th image/file content block of a message with
+ * `attachmentId`, mutating it in place. Returns silently if the target block is
+ * missing or already carries an id (never overwrites an existing id).
+ *
+ * This is the single shared place where an attachment id is mapped to a media
+ * block by ordinal position. Both the live backfill path
+ * ({@link backfillAttachmentId}) and the reload rehydration path
+ * ({@link rehydrateAttachmentIds}) route through it so the two can never drift
+ * in how they index media blocks.
+ *
+ * Attachment blocks are appended to `message.content` in attachment order by
+ * {@link attachmentsToContentBlocks}, after any leading text block and before
+ * any trailing source-path annotation, so the n-th `image`/`file` block always
+ * corresponds to the n-th uploaded attachment (i.e. its `message_attachments`
+ * `position`).
+ */
+function tagMediaBlockAtIndex(
+  message: Message,
+  mediaBlockIndex: number,
+  attachmentId: string,
+): void {
+  if (mediaBlockIndex < 0) return;
+  let seen = 0;
+  for (const block of message.content) {
+    if (block.type !== "image" && block.type !== "file") continue;
+    if (seen === mediaBlockIndex) {
+      if (!block._attachmentId) block._attachmentId = attachmentId;
+      return;
+    }
+    seen++;
+  }
+}
+
+/**
  * Backfill an attachment id onto the in-memory content block for the
  * `attachmentIndex`-th uploaded attachment.
  *
@@ -55,57 +89,58 @@ export function attachmentsToContentBlocks(
  * vision-perception media markers) cannot correlate the block back to a usable
  * `media_ref`.
  *
- * Attachment blocks are appended to `message.content` in attachment order by
- * {@link attachmentsToContentBlocks}, after any leading text block and before
- * any trailing source-path annotation, so the `attachmentIndex`-th `image`/
- * `file` block is the one to tag. Mutates the block in place (the caller holds
- * the same reference the model loop reads). A no-op if the target block is
- * missing or already carries an id.
+ * The live persist loop iterates the uploaded-attachment array by index and
+ * passes that same index here as `attachmentIndex` — which is also the value it
+ * writes to `message_attachments.position`. So `attachmentIndex` is exactly the
+ * media-block ordinal to tag. Mutates the block in place (the caller holds the
+ * same reference the model loop reads). A no-op if the target block is missing
+ * or already carries an id.
  */
 export function backfillAttachmentId(
   message: Message,
   attachmentIndex: number,
   attachmentId: string,
 ): void {
-  let seen = 0;
-  for (const block of message.content) {
-    if (block.type !== "image" && block.type !== "file") continue;
-    if (seen === attachmentIndex) {
-      if (!block._attachmentId) block._attachmentId = attachmentId;
-      return;
-    }
-    seen++;
-  }
+  tagMediaBlockAtIndex(message, attachmentIndex, attachmentId);
+}
+
+/** A linked attachment paired with its stored `message_attachments.position`. */
+export interface PositionedAttachmentId {
+  /** The `message_attachments.position` — the media-block ordinal to tag. */
+  position: number;
+  attachmentId: string;
 }
 
 /**
  * Rehydrate `_attachmentId` onto a message's image/file content blocks from the
- * message's linked attachment ids (ordered by `position`).
+ * message's linked attachments, placing each id at the media-block ordinal that
+ * matches its stored `message_attachments.position`.
  *
  * The persisted message JSON never carries `_attachmentId` — it is minted only
  * after the message row exists and is then backfilled onto the *in-memory*
  * block (see {@link backfillAttachmentId}), so a conversation reloaded from the
- * DB (eviction, restart, fork) loses it. This reapplies the id at load time
- * using the exact same image/file-block indexing {@link backfillAttachmentId}
- * uses (the n-th media block gets the n-th linked attachment id), so the
- * vision-perception markers can still surface a usable `media_ref` on a
- * non-vision backbone after a reload.
+ * DB (eviction, restart, fork) loses it. This reapplies each id at load time at
+ * the exact same media-block index the live path used.
+ *
+ * Critically, this is POSITION-AWARE rather than sequential: at upload time an
+ * attachment can be skipped (unsupported/dangerous MIME, or no data) while its
+ * media block still persists in the message JSON and the live path still
+ * advances the index. So `message_attachments` is sparse — its `position`
+ * values may have gaps. Placing ids by `position` (via the same
+ * {@link tagMediaBlockAtIndex} the live {@link backfillAttachmentId} uses)
+ * keeps the skipped block untagged and assigns each stored id to the block it
+ * actually belongs to, so `media_ref` markers point at the right upload.
  *
  * Mutates blocks in place. Blocks already carrying an id are left untouched, and
- * the id list is consumed in block order — extra ids (e.g. tool-generated media
- * with no persisted block) are ignored.
+ * positions with no matching media block (e.g. tool-generated media with no
+ * persisted block) are ignored.
  */
 export function rehydrateAttachmentIds(
   message: Message,
-  orderedAttachmentIds: readonly string[],
+  positionedAttachmentIds: readonly PositionedAttachmentId[],
 ): void {
-  if (orderedAttachmentIds.length === 0) return;
-  let index = 0;
-  for (const block of message.content) {
-    if (block.type !== "image" && block.type !== "file") continue;
-    if (index >= orderedAttachmentIds.length) return;
-    if (!block._attachmentId) block._attachmentId = orderedAttachmentIds[index];
-    index++;
+  for (const { position, attachmentId } of positionedAttachmentIds) {
+    tagMediaBlockAtIndex(message, position, attachmentId);
   }
 }
 

--- a/assistant/src/agent/attachments.ts
+++ b/assistant/src/agent/attachments.ts
@@ -79,6 +79,37 @@ export function backfillAttachmentId(
 }
 
 /**
+ * Rehydrate `_attachmentId` onto a message's image/file content blocks from the
+ * message's linked attachment ids (ordered by `position`).
+ *
+ * The persisted message JSON never carries `_attachmentId` — it is minted only
+ * after the message row exists and is then backfilled onto the *in-memory*
+ * block (see {@link backfillAttachmentId}), so a conversation reloaded from the
+ * DB (eviction, restart, fork) loses it. This reapplies the id at load time
+ * using the exact same image/file-block indexing {@link backfillAttachmentId}
+ * uses (the n-th media block gets the n-th linked attachment id), so the
+ * vision-perception markers can still surface a usable `media_ref` on a
+ * non-vision backbone after a reload.
+ *
+ * Mutates blocks in place. Blocks already carrying an id are left untouched, and
+ * the id list is consumed in block order — extra ids (e.g. tool-generated media
+ * with no persisted block) are ignored.
+ */
+export function rehydrateAttachmentIds(
+  message: Message,
+  orderedAttachmentIds: readonly string[],
+): void {
+  if (orderedAttachmentIds.length === 0) return;
+  let index = 0;
+  for (const block of message.content) {
+    if (block.type !== "image" && block.type !== "file") continue;
+    if (index >= orderedAttachmentIds.length) return;
+    if (!block._attachmentId) block._attachmentId = orderedAttachmentIds[index];
+    index++;
+  }
+}
+
+/**
  * Return a copy of the message with text annotations for image source paths.
  * The annotations are appended as a text content block so the LLM knows where
  * the images came from on disk. The caller should persist the ORIGINAL message

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -29,6 +29,7 @@ import { defaultCompact } from "../plugins/defaults/compaction/compact.js";
 import type { ContextWindowResult } from "../plugins/defaults/compaction/window-manager.js";
 import {
   applyVisionPerceptionMarkers,
+  resolveBackboneSupportsVideo,
   resolveBackboneSupportsVision,
 } from "../plugins/defaults/vision-perception/hooks/pre-model-call.js";
 import { runHook } from "../plugins/pipeline.js";
@@ -1350,17 +1351,23 @@ export class AgentLoop {
         // Sanitize the outbound history right before sending: drop accumulated
         // media, collapse old AX-tree snapshots, and convert historical
         // web-search results to text. See {@link preModelCallSanitize}.
-        // Then, for a backbone that lacks native vision, replace each uploaded
-        // image with a marker naming its attachment id so the model never
-        // receives raw bytes it cannot read and instead reaches for the vlm_*
-        // tools (no-op for vision-capable backbones — feature stays inert).
+        // Then, per modality, replace each uploaded image/video the backbone
+        // cannot process natively with a marker naming its attachment id, so the
+        // model never receives raw bytes it cannot read and instead reaches for
+        // the vlm_* tools. Image and video gate independently: an image-vision
+        // backbone passes images through but still gets a vlm_video_log marker
+        // for uploaded video (no catalog model reads native video today).
+        const visionMarkerOpts = {
+          callSite: callSite ?? null,
+          overrideProfile: effectiveOverrideProfile ?? null,
+          selectionSeed: this.conversationId ?? null,
+        };
         const providerHistory = applyVisionPerceptionMarkers(
           preModelCallSanitize(history),
-          resolveBackboneSupportsVision({
-            callSite: callSite ?? null,
-            overrideProfile: effectiveOverrideProfile ?? null,
-            selectionSeed: this.conversationId ?? null,
-          }),
+          {
+            supportsVision: resolveBackboneSupportsVision(visionMarkerOpts),
+            supportsVideo: resolveBackboneSupportsVideo(visionMarkerOpts),
+          },
         );
 
         // A `pre-model-call` hook (below) can defer this turn's assistant

--- a/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
@@ -61,6 +61,35 @@ mock.module("../../plugins/defaults/advisor/advisor-gate.js", () => ({
   },
 }));
 
+// ── Vision-perception gate controls (Fix #2 + Fix #3) ──────────────────
+// The vlm_* tool gate reads the `vision-perception` flag and the backbone's
+// per-modality vision capability. Drive both with mutable test state.
+let visionFlagEnabled = true;
+// Backbone native IMAGE vision (`supportsVision`). When true, the image tools
+// are omitted (the backbone can see images itself). Video is never native today.
+let backboneSupportsVision = false;
+
+// Only the flag predicate is stubbed (it ignores its config argument), so the
+// real `getConfig()` runs untouched and other importers of config/loader keep
+// their full exports.
+mock.module("../../config/vision-perception-flag.js", () => ({
+  isVisionPerceptionEnabled: () => visionFlagEnabled,
+  VISION_PERCEPTION_FLAG_KEY: "vision-perception",
+}));
+// Stub only the resolvers; keep the real name predicates (isVlm*ToolName) so the
+// gate's image/video routing is exercised against the actual tool-name sets.
+const realPreModelCall =
+  await import("../../plugins/defaults/vision-perception/hooks/pre-model-call.js");
+mock.module(
+  "../../plugins/defaults/vision-perception/hooks/pre-model-call.js",
+  () => ({
+    ...realPreModelCall,
+    resolveBackboneSupportsVision: () => backboneSupportsVision,
+    // No catalog model is natively video-capable, mirroring production.
+    resolveBackboneSupportsVideo: () => false,
+  }),
+);
+
 // Dynamic imports after mock.module calls so the stubs take effect
 // before the modules under test are loaded.
 const { HOST_TOOL_NAMES, HOST_TOOL_TO_CAPABILITY, isToolActiveForContext } =
@@ -84,6 +113,8 @@ function makeCtx(
 
 beforeEach(() => {
   mockClientCountByCapability.clear();
+  visionFlagEnabled = true;
+  backboneSupportsVision = false;
 });
 
 describe("isToolActiveForContext — Slack task_progress UI exception", () => {
@@ -655,5 +686,67 @@ describe("HOST_TOOL_NAMES derivation", () => {
     // future addition to HOST_TOOL_NAMES without a matching capability entry
     // (or vice versa) would fail.
     expect(HOST_TOOL_NAMES.size).toBe(HOST_TOOL_TO_CAPABILITY.size);
+  });
+});
+
+const IMAGE_TOOLS = ["vlm_ask", "vlm_describe", "vlm_ocr", "vlm_detect"];
+const VIDEO_TOOL = "vlm_video_log";
+
+describe("isToolActiveForContext — vlm_* per-modality gating (Fix #2)", () => {
+  test("non-vision backbone: ALL vlm_* tools are offered (flag on)", () => {
+    backboneSupportsVision = false;
+    const ctx = makeCtx();
+    for (const name of IMAGE_TOOLS) {
+      expect(isToolActiveForContext(name, ctx)).toBe(true);
+    }
+    expect(isToolActiveForContext(VIDEO_TOOL, ctx)).toBe(true);
+  });
+
+  test("image-vision backbone: IMAGE tools hidden, but vlm_video_log STILL offered", () => {
+    // An image-vision model reads images natively (image tools are dead weight)
+    // but cannot process native video, so vlm_video_log must stay available.
+    backboneSupportsVision = true;
+    const ctx = makeCtx();
+    for (const name of IMAGE_TOOLS) {
+      expect(isToolActiveForContext(name, ctx)).toBe(false);
+    }
+    expect(isToolActiveForContext(VIDEO_TOOL, ctx)).toBe(true);
+  });
+});
+
+describe("isToolActiveForContext — vlm_* flag gating (Fix #3)", () => {
+  test("flag off: NO vlm_* tool is offered even on a non-vision backbone", () => {
+    visionFlagEnabled = false;
+    backboneSupportsVision = false;
+    const ctx = makeCtx();
+    for (const name of [...IMAGE_TOOLS, VIDEO_TOOL]) {
+      expect(isToolActiveForContext(name, ctx)).toBe(false);
+    }
+  });
+
+  test("flag on: vlm_* tools are offered (subject to per-modality gating)", () => {
+    visionFlagEnabled = true;
+    backboneSupportsVision = false;
+    const ctx = makeCtx();
+    for (const name of [...IMAGE_TOOLS, VIDEO_TOOL]) {
+      expect(isToolActiveForContext(name, ctx)).toBe(true);
+    }
+  });
+
+  test("flipping the flag at runtime flips tool availability on the next turn (no re-bootstrap)", () => {
+    // The gate reads the flag per call, so a runtime flip is reflected on the
+    // next turn with no plugin re-registration — the plugin is registered
+    // unconditionally and only the per-turn gate moves.
+    backboneSupportsVision = false;
+    const ctx = makeCtx();
+
+    visionFlagEnabled = false;
+    expect(isToolActiveForContext("vlm_ask", ctx)).toBe(false);
+    expect(isToolActiveForContext(VIDEO_TOOL, ctx)).toBe(false);
+
+    // Flag flips on at runtime — same context, next turn.
+    visionFlagEnabled = true;
+    expect(isToolActiveForContext("vlm_ask", ctx)).toBe(true);
+    expect(isToolActiveForContext(VIDEO_TOOL, ctx)).toBe(true);
   });
 });

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -14,12 +14,16 @@ import {
 import { getIsPlatform } from "../config/env-registry.js";
 import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
+import { isVisionPerceptionEnabled } from "../config/vision-perception-flag.js";
 import { getBindingByConversation } from "../memory/external-conversation-store.js";
 import type { PermissionPrompter } from "../permissions/prompter.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
 import { advisorEnabledForProfile } from "../plugins/defaults/advisor/advisor-gate.js";
 import {
+  isVlmImageToolName,
   isVlmToolName,
+  isVlmVideoToolName,
+  resolveBackboneSupportsVideo,
   resolveBackboneSupportsVision,
 } from "../plugins/defaults/vision-perception/hooks/pre-model-call.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
@@ -615,16 +619,42 @@ export function isToolActiveForContext(
     return advisorEnabledForProfile(ctx.currentTurnOverrideProfile ?? null);
   }
   if (isVlmToolName(name)) {
-    // Vision perception only engages for backbones that lack native vision:
-    // offer the `vlm_*` tools only when the resolved backbone can't see images
-    // itself. A vision-capable model reads uploaded media directly, so the tool
-    // would be dead weight — omit it. Resolves the model the same way dispatch
-    // does (the per-turn override, else the active profile / call-site default).
-    return !resolveBackboneSupportsVision({
+    // The plugin now registers unconditionally (its tools are always in the
+    // catalog) so a late/flipped `vision-perception` flag needs no restart —
+    // registration no longer gates the flag, the per-turn gate does. Flag off →
+    // never offer any vlm_* tool. Resolution failure fails closed here (hide
+    // the tool) rather than open, to avoid surfacing dead tools when config is
+    // unreadable.
+    let flagEnabled: boolean;
+    try {
+      flagEnabled = isVisionPerceptionEnabled(getConfig());
+    } catch {
+      flagEnabled = false;
+    }
+    if (!flagEnabled) return false;
+
+    const resolution = {
       callSite: ctx.currentCallSite ?? null,
       overrideProfile: ctx.currentTurnOverrideProfile ?? null,
       selectionSeed: ctx.conversationId ?? null,
-    });
+    };
+
+    // Per-modality gating: vision perception only engages for backbones that
+    // lack native support for that modality. A vision-capable model reads
+    // uploaded images directly, so the IMAGE tools (vlm_ask/describe/ocr/detect)
+    // are dead weight and omitted. But an image-vision model still cannot
+    // process native video, so vlm_video_log stays offered unless the backbone
+    // has native VIDEO support (always false today — no catalog model does).
+    // Resolves the model the same way dispatch does (the per-turn override, else
+    // the active profile / call-site default).
+    if (isVlmImageToolName(name)) {
+      return !resolveBackboneSupportsVision(resolution);
+    }
+    if (isVlmVideoToolName(name)) {
+      return !resolveBackboneSupportsVideo(resolution);
+    }
+    // Defensive: an unclassified vlm_* tool falls back to the image gate.
+    return !resolveBackboneSupportsVision(resolution);
   }
   if (UI_SURFACE_TOOL_NAMES.has(name)) {
     if (

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -15,6 +15,7 @@
  * - conversation-usage.ts        — recordUsage
  */
 
+import { rehydrateAttachmentIds } from "../agent/attachments.js";
 import type { AgentLoopConfig, ResolvedSystemPrompt } from "../agent/loop.js";
 import { AgentLoop } from "../agent/loop.js";
 import type { AssistantActivityStateEvent } from "../api/events/assistant-activity-state.js";
@@ -44,6 +45,7 @@ import {
   ToolProfiler,
 } from "../events/tool-profiling-listener.js";
 import { registerToolTraceListener } from "../events/tool-trace-listener.js";
+import { getLinkedAttachmentIdsForMessage } from "../memory/attachments-store.js";
 import { resolveCanonicalGuardianRequest } from "../memory/canonical-guardian-store.js";
 import {
   getConversation,
@@ -968,6 +970,31 @@ export class Conversation {
       }
 
       content = reinjectImageSourcePaths(content, role, m.metadata);
+
+      // Rehydrate `_attachmentId` onto image/file blocks from the persisted
+      // message_attachments links. The id is minted only after persistence and
+      // backfilled onto the in-memory block at send time, so it is absent from
+      // the stored JSON — without this a reloaded inline upload (eviction,
+      // restart, fork) would have no `media_ref` for the vision-perception
+      // markers to surface on a non-vision backbone. Best-effort: a lookup
+      // failure must never fail the load. Only user messages carry uploaded
+      // attachments; assistant messages skip the DB hit. Runs after the source-
+      // path annotation above (which appends a trailing text block, so it does
+      // not shift the image/file-block indexing) and before any injection-block
+      // prepends below (also text-only).
+      if (role === "user") {
+        try {
+          rehydrateAttachmentIds(
+            { role, content },
+            getLinkedAttachmentIdsForMessage(m.id),
+          );
+        } catch (err) {
+          log.debug(
+            { conversationId: this.conversationId, messageId: m.id, err },
+            "Failed to rehydrate attachment ids on reload (non-fatal)",
+          );
+        }
+      }
 
       // Re-inject persisted injection blocks from metadata so it survives
       // conversation reloads (eviction, restart, fork).

--- a/assistant/src/memory/__tests__/linked-attachment-ids-reload.test.ts
+++ b/assistant/src/memory/__tests__/linked-attachment-ids-reload.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Codex P2 — inline media_ref must survive a reload (DB round-trip).
+ *
+ * For an inline upload the attachment id is minted only after the message row
+ * exists, so it is never written into the persisted message JSON — it is
+ * backfilled onto the in-memory block at send time. On a conversation reload
+ * from the DB the block is rebuilt from JSON and loses the id.
+ *
+ * This test exercises the real persistence + link path
+ * (`attachInlineAttachmentToMessage` → `message_attachments`) and then the
+ * reload-side rehydration (`getLinkedAttachmentIdsForMessage` +
+ * `rehydrateAttachmentIds`), proving that a reloaded inline upload again carries
+ * a usable `_attachmentId` — and therefore still yields a vision-perception
+ * `media_ref` marker for a non-vision backbone.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { rehydrateAttachmentIds } from "../../agent/attachments.js";
+import type { ImageContent, Message } from "../../providers/types.js";
+import {
+  attachInlineAttachmentToMessage,
+  getLinkedAttachmentIdsForMessage,
+} from "../attachments-store.js";
+import { addMessage, createConversation } from "../conversation-crud.js";
+import { getDb } from "../db-connection.js";
+import { initializeDb } from "../db-init.js";
+
+initializeDb();
+
+// 1x1 transparent PNG.
+const PNG_1X1 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+
+function resetTables(): void {
+  const db = getDb();
+  db.run("DELETE FROM message_attachments");
+  db.run("DELETE FROM attachments");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+}
+
+describe("getLinkedAttachmentIdsForMessage + rehydrateAttachmentIds", () => {
+  test("returns linked ids in position order and rehydrates a reloaded block", async () => {
+    resetTables();
+    const conv = createConversation();
+
+    // Persist a user message WITHOUT the attachment id in its content JSON,
+    // mirroring how inline uploads are stored (id is minted afterward).
+    const persisted = await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([
+        { type: "text", text: "two images" },
+        {
+          type: "image",
+          source: { type: "base64", media_type: "image/png", data: PNG_1X1 },
+        },
+        {
+          type: "image",
+          source: { type: "base64", media_type: "image/png", data: PNG_1X1 },
+        },
+      ]),
+      { skipIndexing: true },
+    );
+
+    // Link two inline attachments at positions 0 and 1.
+    const a0 = attachInlineAttachmentToMessage(
+      persisted.id,
+      0,
+      "first.png",
+      "image/png",
+      PNG_1X1,
+    );
+    const a1 = attachInlineAttachmentToMessage(
+      persisted.id,
+      1,
+      "second.png",
+      "image/png",
+      PNG_1X1,
+    );
+
+    // Reload side: the ordered link list comes back position-ordered.
+    const ids = getLinkedAttachmentIdsForMessage(persisted.id);
+    expect(ids).toEqual([a0.id, a1.id]);
+
+    // Simulate the reloaded in-memory message (parsed from JSON, no ids), then
+    // rehydrate.
+    const reloaded: Message = {
+      role: "user",
+      content: [
+        { type: "text", text: "two images" },
+        {
+          type: "image",
+          source: { type: "base64", media_type: "image/png", data: PNG_1X1 },
+        },
+        {
+          type: "image",
+          source: { type: "base64", media_type: "image/png", data: PNG_1X1 },
+        },
+      ],
+    };
+    rehydrateAttachmentIds(reloaded, ids);
+
+    expect((reloaded.content[1] as ImageContent)._attachmentId).toBe(a0.id);
+    expect((reloaded.content[2] as ImageContent)._attachmentId).toBe(a1.id);
+  });
+
+  test("returns an empty list for a message with no linked attachments", async () => {
+    resetTables();
+    const conv = createConversation();
+    const persisted = await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "no attachments" }]),
+      { skipIndexing: true },
+    );
+    expect(getLinkedAttachmentIdsForMessage(persisted.id)).toEqual([]);
+  });
+});

--- a/assistant/src/memory/__tests__/linked-attachment-ids-reload.test.ts
+++ b/assistant/src/memory/__tests__/linked-attachment-ids-reload.test.ts
@@ -79,9 +79,12 @@ describe("getLinkedAttachmentIdsForMessage + rehydrateAttachmentIds", () => {
       PNG_1X1,
     );
 
-    // Reload side: the ordered link list comes back position-ordered.
-    const ids = getLinkedAttachmentIdsForMessage(persisted.id);
-    expect(ids).toEqual([a0.id, a1.id]);
+    // Reload side: the positioned link list comes back position-ordered.
+    const links = getLinkedAttachmentIdsForMessage(persisted.id);
+    expect(links).toEqual([
+      { position: 0, attachmentId: a0.id },
+      { position: 1, attachmentId: a1.id },
+    ]);
 
     // Simulate the reloaded in-memory message (parsed from JSON, no ids), then
     // rehydrate.
@@ -99,9 +102,71 @@ describe("getLinkedAttachmentIdsForMessage + rehydrateAttachmentIds", () => {
         },
       ],
     };
-    rehydrateAttachmentIds(reloaded, ids);
+    rehydrateAttachmentIds(reloaded, links);
 
     expect((reloaded.content[1] as ImageContent)._attachmentId).toBe(a0.id);
+    expect((reloaded.content[2] as ImageContent)._attachmentId).toBe(a1.id);
+  });
+
+  test("sparse: skipped first upload keeps the second id on the SECOND block", async () => {
+    // Reproduces the Codex P2: a message with two media blocks where the FIRST
+    // attachment was skipped at upload time (unsupported/dangerous MIME or no
+    // data) so it has NO message_attachments row, and only the SECOND was
+    // stored — linked at position 1, mirroring the live persist loop which keeps
+    // advancing its index across the skipped upload.
+    resetTables();
+    const conv = createConversation();
+
+    const persisted = await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([
+        { type: "text", text: "two images, first one skipped" },
+        {
+          type: "image",
+          source: { type: "base64", media_type: "image/png", data: PNG_1X1 },
+        },
+        {
+          type: "image",
+          source: { type: "base64", media_type: "image/png", data: PNG_1X1 },
+        },
+      ]),
+      { skipIndexing: true },
+    );
+
+    // Only the SECOND attachment is stored, at position 1 (gap at position 0).
+    const a1 = attachInlineAttachmentToMessage(
+      persisted.id,
+      1,
+      "second.png",
+      "image/png",
+      PNG_1X1,
+    );
+
+    // The link list is sparse: a single entry at position 1, gap preserved.
+    const links = getLinkedAttachmentIdsForMessage(persisted.id);
+    expect(links).toEqual([{ position: 1, attachmentId: a1.id }]);
+
+    const reloaded: Message = {
+      role: "user",
+      content: [
+        { type: "text", text: "two images, first one skipped" },
+        {
+          type: "image",
+          source: { type: "base64", media_type: "image/png", data: PNG_1X1 },
+        },
+        {
+          type: "image",
+          source: { type: "base64", media_type: "image/png", data: PNG_1X1 },
+        },
+      ],
+    };
+    rehydrateAttachmentIds(reloaded, links);
+
+    // The id must land on the SECOND media block (its real upload), and the
+    // first must stay untagged. A compacted id-only list would have wrongly put
+    // a1.id on the first block, so its media_ref would point at the wrong image.
+    expect((reloaded.content[1] as ImageContent)._attachmentId).toBeUndefined();
     expect((reloaded.content[2] as ImageContent)._attachmentId).toBe(a1.id);
   });
 

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -1058,6 +1058,30 @@ export function getAttachmentMetadataForMessage(
 }
 
 /**
+ * Return the attachment ids linked to a message, ordered by `position` — the
+ * same order in which {@link attachmentsToContentBlocks} appended the image/
+ * file content blocks. No file data or metadata is read, so this is cheap
+ * enough to call for every persisted user message on conversation reload.
+ *
+ * Used to rehydrate `_attachmentId` onto image/file content blocks when a
+ * conversation is loaded from the DB: the persisted message JSON never carries
+ * the (later-minted) attachment id, so without this the vision-perception
+ * media markers would have no `media_ref` to surface for an inline upload after
+ * a daemon restart or conversation eviction.
+ */
+export function getLinkedAttachmentIdsForMessage(messageId: string): string[] {
+  const db = getDb();
+  return db
+    .select({ attachmentId: messageAttachments.attachmentId })
+    .from(messageAttachments)
+    .where(eq(messageAttachments.messageId, messageId))
+    .orderBy(messageAttachments.position)
+    .all()
+    .map((link) => link.attachmentId)
+    .filter((id): id is string => id != null);
+}
+
+/**
  * Lightweight existence check — queries only the attachment ID column
  * without reading file contents from disk.
  */

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -1057,11 +1057,32 @@ export function getAttachmentMetadataForMessage(
   return results;
 }
 
+/** A linked attachment paired with its stored `message_attachments.position`. */
+export interface PositionedAttachmentLink {
+  /**
+   * The `message_attachments.position` for this link — the media-block ordinal
+   * the live persist path tagged via `backfillAttachmentId`. Gaps are preserved
+   * (a skipped/unindexed upload leaves no row), so callers must place ids by
+   * this value rather than by sequential index.
+   */
+  position: number;
+  attachmentId: string;
+}
+
 /**
- * Return the attachment ids linked to a message, ordered by `position` — the
- * same order in which {@link attachmentsToContentBlocks} appended the image/
- * file content blocks. No file data or metadata is read, so this is cheap
- * enough to call for every persisted user message on conversation reload.
+ * Return the attachments linked to a message as `{ position, attachmentId }`
+ * pairs, ordered by `position` — where `position` is the media-block ordinal the
+ * live persist path used (see {@link backfillAttachmentId}). No file data or
+ * metadata is read, so this is cheap enough to call for every persisted user
+ * message on conversation reload.
+ *
+ * Gaps are preserved: at upload time an attachment can be skipped (unsupported
+ * MIME, dangerous extension, or empty data) while its media block still persists
+ * in the message JSON, so `message_attachments` is sparse and its `position`
+ * values may not be contiguous. The reload-side rehydration
+ * ({@link rehydrateAttachmentIds}) relies on the exact `position` to tag the
+ * correct media block, identical to the live path — a compacted id-only list
+ * would misalign every block after a skipped upload.
  *
  * Used to rehydrate `_attachmentId` onto image/file content blocks when a
  * conversation is loaded from the DB: the persisted message JSON never carries
@@ -1069,16 +1090,24 @@ export function getAttachmentMetadataForMessage(
  * media markers would have no `media_ref` to surface for an inline upload after
  * a daemon restart or conversation eviction.
  */
-export function getLinkedAttachmentIdsForMessage(messageId: string): string[] {
+export function getLinkedAttachmentIdsForMessage(
+  messageId: string,
+): PositionedAttachmentLink[] {
   const db = getDb();
   return db
-    .select({ attachmentId: messageAttachments.attachmentId })
+    .select({
+      attachmentId: messageAttachments.attachmentId,
+      position: messageAttachments.position,
+    })
     .from(messageAttachments)
     .where(eq(messageAttachments.messageId, messageId))
     .orderBy(messageAttachments.position)
     .all()
-    .map((link) => link.attachmentId)
-    .filter((id): id is string => id != null);
+    .flatMap((link) =>
+      link.attachmentId != null
+        ? [{ position: link.position, attachmentId: link.attachmentId }]
+        : [],
+    );
 }
 
 /**

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -340,22 +340,32 @@ export const defaultAdvisorPlugin: Plugin = {
  * tools. The model passes a provided image's attachment id; the plugin resolves
  * it to an image block and sends it, with the question or a description prompt,
  * to the `visionPerception` call site (a vision-capable inference profile)
- * routed through the assistant's own inference. The whole plugin is gated behind
- * the `vision-perception` feature flag — `bootstrapPlugins` skips it (no tool
- * contributions) when the flag is off. `finalizeTool` fills each tool's defaults
- * so it satisfies `Tool`.
+ * routed through the assistant's own inference. `finalizeTool` fills each tool's
+ * defaults so it satisfies `Tool`.
+ *
+ * Registration is UNCONDITIONAL — the manifest carries no `requiresFlag`, so
+ * `bootstrapPlugins` always registers the `vlm_*` tools into the catalog. This
+ * deliberately decouples registration from the `vision-perception` feature flag:
+ * the flag's gateway overrides load fire-and-forget after startup and a runtime
+ * flip only re-syncs tools/profiles, not default-plugin registration. Gating
+ * registration on the flag would leave the tools absent until a restart whenever
+ * the flag arrived late or flipped on at runtime, while the marker logic + vision
+ * profile activated — so instead the tools are gated DYNAMICALLY per turn.
  *
  * The feature only engages for backbones that lack native vision: the per-turn
- * tool gate omits the `vlm_*` tools for vision-capable models, and for non-vision
- * backbones the outbound request swaps each uploaded image for a marker naming
- * its attachment id (a usable `media_ref`). The `pre-model-call` hook is the
- * home for that gating logic (see `hooks/pre-model-call.ts`).
+ * tool gate (`isToolActiveForContext`) checks `isVisionPerceptionEnabled` AND
+ * per-modality vision capability — flag off → tools never offered (marker inert,
+ * profile handled separately by reconcile); flag on at runtime → the next turn
+ * offers the tools with no restart. For non-vision backbones the outbound request
+ * swaps each uploaded image for a marker naming its attachment id (a usable
+ * `media_ref`); image and video gate independently (an image-vision backbone
+ * still gets a `vlm_video_log` marker for uploaded video). The `pre-model-call`
+ * hook is the home for that gating logic (see `hooks/pre-model-call.ts`).
  */
 export const visionPerceptionPlugin: Plugin = {
   manifest: {
     name: visionPerceptionPkg.name,
     version: visionPerceptionPkg.version,
-    requiresFlag: ["vision-perception"],
   },
   hooks: {
     "pre-model-call": visionPerceptionPreModelCall,

--- a/assistant/src/plugins/defaults/vision-perception/__tests__/pre-model-call.test.ts
+++ b/assistant/src/plugins/defaults/vision-perception/__tests__/pre-model-call.test.ts
@@ -36,6 +36,7 @@ mock.module("../../../../memory/attachments-store.js", () => ({
 const {
   applyVisionPerceptionMarkers,
   resolveBackboneSupportsVision,
+  resolveBackboneSupportsVideo,
   isVlmToolName,
 } = await import("../hooks/pre-model-call.js");
 
@@ -72,12 +73,22 @@ function fileMessage(
   return { role: "user", content: [{ type: "text", text: "look" }, fileBlock] };
 }
 
-const gate = () =>
-  resolveBackboneSupportsVision({
-    callSite: "mainAgent",
-    overrideProfile: null,
-    selectionSeed: "conv-1",
-  });
+const resolutionOpts = {
+  callSite: "mainAgent" as const,
+  overrideProfile: null,
+  selectionSeed: "conv-1",
+};
+
+const gate = () => resolveBackboneSupportsVision(resolutionOpts);
+
+// Per-modality support object for `applyVisionPerceptionMarkers`, resolved the
+// same way the agent loop does (image gate via supportsVision, video gate via
+// supportsVideo — always false today so an image-vision backbone still gets
+// video markers).
+const support = () => ({
+  supportsVision: resolveBackboneSupportsVision(resolutionOpts),
+  supportsVideo: resolveBackboneSupportsVideo(resolutionOpts),
+});
 
 beforeEach(() => {
   flagEnabled = true;
@@ -100,7 +111,7 @@ describe("vision-capable backbone keeps the feature inert", () => {
 
     // Media passes through untouched (same reference, raw image preserved).
     const messages = [imageMessage("att-1")];
-    const out = applyVisionPerceptionMarkers(messages, gate());
+    const out = applyVisionPerceptionMarkers(messages, support());
     expect(out).toBe(messages);
     expect(out[0].content[1]).toMatchObject({ type: "image" });
   });
@@ -114,7 +125,10 @@ describe("non-vision backbone surfaces a usable media_ref", () => {
     // the tool resolver reads as "offer the vlm_* tools".
     expect(gate()).toBe(false);
 
-    const out = applyVisionPerceptionMarkers([imageMessage("att-1")], gate());
+    const out = applyVisionPerceptionMarkers(
+      [imageMessage("att-1")],
+      support(),
+    );
     const blocks = out[0].content;
 
     // The raw image is gone; the model never receives image bytes.
@@ -150,7 +164,7 @@ describe("non-vision backbone surfaces uploaded videos", () => {
           _attachmentId: "vid-1",
         }),
       ],
-      gate(),
+      support(),
     );
     const blocks = out[0].content;
 
@@ -184,7 +198,7 @@ describe("non-vision backbone surfaces uploaded videos", () => {
           _attachmentId: "vid-1",
         }),
       ],
-      gate(),
+      support(),
     );
     const blocks = out[0].content;
     expect(blocks.some((b) => b.type === "file")).toBe(false);
@@ -209,15 +223,21 @@ describe("non-vision backbone surfaces uploaded videos", () => {
         _attachmentId: "doc-1",
       }),
     ];
-    const out = applyVisionPerceptionMarkers(messages, gate());
+    const out = applyVisionPerceptionMarkers(messages, support());
     // No rewrite was needed, so the same array reference comes back and the file
     // block survives intact.
     expect(out).toBe(messages);
     expect(out[0].content[1]).toMatchObject({ type: "file" });
   });
 
-  test("a video file block on a vision-capable backbone is left unchanged", () => {
+  test("an image-vision backbone still gets a vlm_video_log marker for video (Fix #2 per-modality gating)", () => {
+    // An image-vision backbone (supportsVision === true) cannot process native
+    // video, so the video file block must STILL become a vlm_video_log marker
+    // even though images would pass through. resolveBackboneSupportsVideo is
+    // false for every catalog model today.
     resolvedProviderModel = { ...VISION_MODEL };
+    expect(gate()).toBe(true); // image vision native
+    expect(support().supportsVideo).toBe(false); // video not native
 
     const messages = [
       fileMessage({
@@ -230,9 +250,25 @@ describe("non-vision backbone surfaces uploaded videos", () => {
         _attachmentId: "vid-1",
       }),
     ];
-    const out = applyVisionPerceptionMarkers(messages, gate());
+    const out = applyVisionPerceptionMarkers(messages, support());
+
+    // The raw video file block is gone; a vlm_video_log marker replaces it.
+    expect(out[0].content.some((b) => b.type === "file")).toBe(false);
+    const marker = out[0].content.find(
+      (b) => b.type === "text" && b.text.includes("vlm_video_log"),
+    );
+    expect(marker).toBeDefined();
+    expect((marker as { text: string }).text).toContain('media_ref="vid-1"');
+  });
+
+  test("an image-vision backbone passes IMAGE blocks through untouched (Fix #2)", () => {
+    // Images are native for a vision-capable backbone, so an image block is left
+    // intact even though video would be rewritten on the same backbone.
+    resolvedProviderModel = { ...VISION_MODEL };
+    const messages = [imageMessage("att-1")];
+    const out = applyVisionPerceptionMarkers(messages, support());
     expect(out).toBe(messages);
-    expect(out[0].content[1]).toMatchObject({ type: "file" });
+    expect(out[0].content.some((b) => b.type === "image")).toBe(true);
   });
 });
 
@@ -242,14 +278,14 @@ describe("no media attachments", () => {
     const messages: Message[] = [
       { role: "user", content: [{ type: "text", text: "hello" }] },
     ];
-    const out = applyVisionPerceptionMarkers(messages, gate());
+    const out = applyVisionPerceptionMarkers(messages, support());
     expect(out).toBe(messages);
   });
 
   test("an image block without an attachment id is left intact (no usable media_ref)", () => {
     resolvedProviderModel = { ...NON_VISION_MODEL };
     const messages = [imageMessage()];
-    const out = applyVisionPerceptionMarkers(messages, gate());
+    const out = applyVisionPerceptionMarkers(messages, support());
     expect(out).toBe(messages);
     expect(out[0].content[1]).toMatchObject({ type: "image" });
   });
@@ -260,9 +296,21 @@ describe("feature flag gating", () => {
     flagEnabled = false;
     resolvedProviderModel = { ...NON_VISION_MODEL };
     expect(gate()).toBe(true);
+    // Flag off → BOTH modalities report inert, so the video tool/marker path is
+    // also suppressed (not just images).
+    expect(resolveBackboneSupportsVideo(resolutionOpts)).toBe(true);
 
     // With the gate inert, media passes through and no marker is injected.
     const messages = [imageMessage("att-1")];
-    expect(applyVisionPerceptionMarkers(messages, gate())).toBe(messages);
+    expect(applyVisionPerceptionMarkers(messages, support())).toBe(messages);
+  });
+
+  test("flag on keeps video inert (no native-video model) but engages images for a non-vision backbone", () => {
+    flagEnabled = true;
+    resolvedProviderModel = { ...NON_VISION_MODEL };
+    // No catalog model is natively video-capable, so video support is false
+    // whenever the flag is on (the video tool/marker stay active).
+    expect(resolveBackboneSupportsVideo(resolutionOpts)).toBe(false);
+    expect(gate()).toBe(false);
   });
 });

--- a/assistant/src/plugins/defaults/vision-perception/hooks/pre-model-call.ts
+++ b/assistant/src/plugins/defaults/vision-perception/hooks/pre-model-call.ts
@@ -39,18 +39,39 @@ import type {
 } from "../../../../providers/types.js";
 
 /**
- * Names of the model-visible vision tools the plugin contributes. Kept here so
- * the offered-tool gate (which omits them for vision-capable backbones) and the
- * media marker (which names them as the way to inspect an attachment) share one
- * source of truth, independent of which subset of tools is currently
- * registered.
+ * The model-visible IMAGE-inspection tools the plugin contributes. Gated on the
+ * backbone's native *image* vision (`supportsVision`): a backbone that can see
+ * images itself reads uploaded images directly, so these are dead weight and
+ * omitted for it.
  */
-export const VLM_TOOL_NAMES: ReadonlySet<string> = new Set([
+export const VLM_IMAGE_TOOL_NAMES: ReadonlySet<string> = new Set([
   "vlm_ask",
   "vlm_describe",
   "vlm_ocr",
   "vlm_detect",
+]);
+
+/**
+ * The model-visible VIDEO-inspection tool. Gated on native *video* support, not
+ * `supportsVision`: an image-vision backbone still cannot process `video/*`
+ * (the provider serializers render video files as text placeholders, not native
+ * video), so it must keep this tool. No catalog model supports native video
+ * through our pipeline today, so it is offered whenever the feature is active —
+ * see {@link resolveBackboneSupportsVideo}.
+ */
+export const VLM_VIDEO_TOOL_NAMES: ReadonlySet<string> = new Set([
   "vlm_video_log",
+]);
+
+/**
+ * Names of every model-visible vision tool the plugin contributes. Kept here so
+ * the offered-tool gate (which omits them per-modality) and the media marker
+ * (which names them as the way to inspect an attachment) share one source of
+ * truth, independent of which subset of tools is currently registered.
+ */
+export const VLM_TOOL_NAMES: ReadonlySet<string> = new Set([
+  ...VLM_IMAGE_TOOL_NAMES,
+  ...VLM_VIDEO_TOOL_NAMES,
 ]);
 
 /** Whether `name` is one of the plugin's vision tools. */
@@ -58,51 +79,104 @@ export function isVlmToolName(name: string): boolean {
   return VLM_TOOL_NAMES.has(name);
 }
 
-/**
- * Resolve whether the backbone that will serve a turn natively supports vision.
- *
- * Resolves the call site's effective provider/model the same way the dispatch
- * path does (via {@link resolveCallSiteConfig}) and reads `supportsVision` from
- * the model catalog. Unknown (provider, model) pairs fail open to `true` —
- * matching `GET /v1/config`'s per-profile enrichment — so custom or unlisted
- * models keep native image handling and the feature stays inert for them.
- *
- * Returns `true` (feature inert) whenever the `vision-perception` flag is off,
- * so callers gate uniformly on this one predicate: a vision-capable result means
- * "leave media intact and don't offer the vlm_* tools".
- */
-export function resolveBackboneSupportsVision(opts: {
+/** Whether `name` is one of the plugin's IMAGE-inspection tools. */
+export function isVlmImageToolName(name: string): boolean {
+  return VLM_IMAGE_TOOL_NAMES.has(name);
+}
+
+/** Whether `name` is the plugin's VIDEO-inspection tool. */
+export function isVlmVideoToolName(name: string): boolean {
+  return VLM_VIDEO_TOOL_NAMES.has(name);
+}
+
+export interface BackboneResolutionOpts {
   callSite: LLMCallSite | null;
   overrideProfile: string | null;
   selectionSeed?: string | null;
-}): boolean {
+}
+
+/**
+ * Resolve the catalog model entry for the backbone that will serve a turn,
+ * resolving the call site's effective provider/model the same way the dispatch
+ * path does (via {@link resolveCallSiteConfig}). Returns `undefined` for an
+ * unknown (provider, model) pair so each caller can pick its own fail-open
+ * default per capability.
+ */
+function resolveBackboneCatalogModel(opts: BackboneResolutionOpts) {
+  const config = getConfig();
+  const { llm } = config;
+  const resolved = resolveCallSiteConfig(opts.callSite ?? "mainAgent", llm, {
+    ...(opts.overrideProfile ? { overrideProfile: opts.overrideProfile } : {}),
+    ...(opts.selectionSeed ? { selectionSeed: opts.selectionSeed } : {}),
+  });
+  const catalogProvider = PROVIDER_CATALOG.find(
+    (p) => p.id === resolved.provider,
+  );
+  return catalogProvider?.models.find((m) => m.id === resolved.model);
+}
+
+/**
+ * Resolve whether the backbone that will serve a turn natively supports IMAGE
+ * vision, reading `supportsVision` from the model catalog. Unknown (provider,
+ * model) pairs fail open to `true` — matching `GET /v1/config`'s per-profile
+ * enrichment — so custom or unlisted models keep native image handling and the
+ * feature stays inert for them.
+ *
+ * Returns `true` (feature inert) whenever the `vision-perception` flag is off,
+ * so callers gate uniformly on this one predicate: a vision-capable result means
+ * "leave images intact and don't offer the image vlm_* tools".
+ */
+export function resolveBackboneSupportsVision(
+  opts: BackboneResolutionOpts,
+): boolean {
   try {
-    const config = getConfig();
-    if (!isVisionPerceptionEnabled(config)) {
+    if (!isVisionPerceptionEnabled(getConfig())) {
       return true;
     }
-    const { llm } = config;
-    const resolved = resolveCallSiteConfig(opts.callSite ?? "mainAgent", llm, {
-      ...(opts.overrideProfile
-        ? { overrideProfile: opts.overrideProfile }
-        : {}),
-      ...(opts.selectionSeed ? { selectionSeed: opts.selectionSeed } : {}),
-    });
-    const catalogProvider = PROVIDER_CATALOG.find(
-      (p) => p.id === resolved.provider,
-    );
-    const catalogModel = catalogProvider?.models.find(
-      (m) => m.id === resolved.model,
-    );
-    return catalogModel?.supportsVision ?? true;
+    return resolveBackboneCatalogModel(opts)?.supportsVision ?? true;
   } catch {
     // Fail open: never let a resolution error strip media from a request.
     return true;
   }
 }
 
+/**
+ * Resolve whether the backbone that will serve a turn natively supports VIDEO.
+ *
+ * There is no `supportsVideo` capability in the catalog today and no catalog
+ * model can process `video/*` natively through our pipeline (the provider
+ * serializers render video files as text placeholders), so this is always
+ * `false` while the feature is active: `vlm_video_log` and the video marker
+ * stay available even on an image-vision backbone.
+ *
+ * Returns `true` (feature inert) whenever the `vision-perception` flag is off,
+ * mirroring {@link resolveBackboneSupportsVision}.
+ *
+ * If a natively-video-capable model is ever added, give the catalog a
+ * `supportsVideo` field and return it here (fail open to `false` for unknown
+ * models, since native video remains the rare case) so the video tool/marker
+ * become inert for those backbones exactly as the image path does today.
+ */
+export function resolveBackboneSupportsVideo(
+  // Unused today — kept so callers thread the same resolution opts as the image
+  // gate and the extension point (a future `supportsVideo` catalog read) is
+  // already wired. See the doc above.
+  _opts: BackboneResolutionOpts,
+): boolean {
+  try {
+    // Flag off → inert (mirrors the image gate). With the flag on, no catalog
+    // model is natively video-capable, so the video tool/marker stay active.
+    return isVisionPerceptionEnabled(getConfig()) ? false : true;
+  } catch {
+    // A config-read failure leaves the video path active (fail closed toward
+    // "the model can't read video natively"), matching the marker rewrite's
+    // intent that raw video never silently reach a model that can't read it.
+    return false;
+  }
+}
+
 /** Human-readable media kind for the marker text. */
-function mediaKind(block: ImageContent): string {
+function mediaKind(block: ImageContent): "Image" | "Video" {
   return block.source.media_type.startsWith("video/") ? "Video" : "Image";
 }
 
@@ -157,17 +231,34 @@ export function renderMediaMarker(
 }
 
 /**
- * Replace raw media blocks with attachment-id markers when the backbone lacks
- * native vision. Returns the input array unchanged (same reference) when the
- * backbone is vision-capable or when there is nothing to replace, so a request
- * that needs no rewrite is not copied.
+ * Per-modality gating for the marker rewrite. A modality's media is replaced
+ * with an attachment-id marker only when the backbone CANNOT process that
+ * modality natively, so an image-vision backbone (image native, video not) gets
+ * raw images through but a video marker for any uploaded video.
+ */
+export interface VisionPerceptionModalitySupport {
+  /** The backbone natively reads IMAGES (`supportsVision`). */
+  supportsVision: boolean;
+  /** The backbone natively reads VIDEO (always `false` today — see
+   * {@link resolveBackboneSupportsVideo}). */
+  supportsVideo: boolean;
+}
+
+/**
+ * Replace raw media blocks with attachment-id markers, PER MODALITY, when the
+ * backbone lacks native support for that modality. Returns the input array
+ * unchanged (same reference) when nothing needs replacing, so a request that
+ * needs no rewrite is not copied.
  *
- * Two block shapes are rewritten:
- *  - `image` blocks (uploaded images), and
- *  - `file` blocks that carry a video (uploaded `video/*` files reach the model
- *    as a generic `file` block — see {@link isVideoFileBlock}). Without this the
- *    video would arrive as an opaque file placeholder with no `media_ref`, so
- *    the model could never call `vlm_video_log`.
+ * Modalities are gated independently:
+ *  - IMAGE media (an `image` block with an `image/*` media_type) is replaced
+ *    only when `supportsVision` is false.
+ *  - VIDEO media (a `file` block carrying a video — see {@link isVideoFileBlock}
+ *    — or, defensively, an `image` block with a `video/*` media_type) is
+ *    replaced only when `supportsVideo` is false. An image-vision backbone still
+ *    cannot process `video/*` natively (the provider serializers render it as a
+ *    text placeholder), so the video still becomes a `vlm_video_log` marker even
+ *    though images pass through.
  *
  * Non-video `file` blocks (PDFs, documents, …) are left intact — the backbone
  * can read their `extracted_text`, and there is no `vlm_*` tool for them.
@@ -178,31 +269,46 @@ export function renderMediaMarker(
  */
 export function applyVisionPerceptionMarkers(
   messages: Message[],
-  supportsVision: boolean,
+  support: VisionPerceptionModalitySupport,
 ): Message[] {
-  if (supportsVision) return messages;
+  const { supportsVision, supportsVideo } = support;
+  // Both modalities native → feature fully inert, nothing to rewrite.
+  if (supportsVision && supportsVideo) return messages;
 
-  const replaceable = (
-    block: ContentBlock,
-  ): block is ImageContent | FileContent => {
-    if (block.type === "image") return typeof block._attachmentId === "string";
-    if (block.type === "file")
-      return typeof block._attachmentId === "string" && isVideoFileBlock(block);
-    return false;
+  // Classify a block's modality (or null when it is not replaceable media).
+  const modalityOf = (block: ContentBlock): "Image" | "Video" | null => {
+    if (block.type === "image") {
+      if (typeof block._attachmentId !== "string") return null;
+      return mediaKind(block); // "Image" or "Video" (defensive video/* image)
+    }
+    if (block.type === "file") {
+      if (typeof block._attachmentId !== "string") return null;
+      return isVideoFileBlock(block) ? "Video" : null;
+    }
+    return null;
   };
 
-  const hasReplaceable = messages.some((msg) => msg.content.some(replaceable));
+  // A block is replaced only when its modality is NOT natively supported.
+  const replaceableKind = (block: ContentBlock): "Image" | "Video" | null => {
+    const modality = modalityOf(block);
+    if (modality === "Image") return supportsVision ? null : "Image";
+    if (modality === "Video") return supportsVideo ? null : "Video";
+    return null;
+  };
+
+  const hasReplaceable = messages.some((msg) =>
+    msg.content.some((b) => replaceableKind(b) !== null),
+  );
   if (!hasReplaceable) return messages;
 
   return messages.map((msg) => {
-    if (!msg.content.some(replaceable)) return msg;
+    if (!msg.content.some((b) => replaceableKind(b) !== null)) return msg;
     return {
       ...msg,
       content: msg.content.map((block) => {
-        if (!replaceable(block)) return block;
-        const id = block._attachmentId!;
-        const kind =
-          block.type === "image" ? mediaKind(block) : ("Video" as const);
+        const kind = replaceableKind(block);
+        if (kind === null) return block;
+        const id = (block as ImageContent | FileContent)._attachmentId!;
         return {
           type: "text" as const,
           text: renderMediaMarker(id, resolveAttachmentFilename(id), kind),


### PR DESCRIPTION
## Summary
Addresses 3 Codex P2s on the vision-perception feature:
- Inline media_ref now survives daemon restart / conversation reload (persist/rehydrate _attachmentId).
- vlm_video_log stays available for image-only-vision backbones (per-modality gating); image tools still hidden when the backbone has native image vision.
- The default plugin registers unconditionally; tools are gated dynamically per turn on the flag + vision capability, eliminating the flag-load race (no restart needed when the flag flips).

Part of plan: glm-5v-turbo-vlm-tool.md (Codex feedback on feature PR #35508)