### PR TITLE
fix(plugins): scope vision perception to GLM 5.2 (text-only) only

### DIFF
--- a/assistant/src/__tests__/inline-upload-media-ref.test.ts
+++ b/assistant/src/__tests__/inline-upload-media-ref.test.ts
@@ -134,10 +134,7 @@ describe("Codex P2 — inline upload media_ref", () => {
     });
 
     // Simulate the outbound sanitization for a non-vision backbone.
-    const rewritten = applyVisionPerceptionMarkers(ctx.messages, {
-      supportsVision: false,
-      supportsVideo: false,
-    });
+    const rewritten = applyVisionPerceptionMarkers(ctx.messages, false);
     const userMsg = rewritten.at(-1)!;
     const marker = userMsg.content.find(
       (b) => b.type === "text" && b.text.includes('media_ref="att-0"'),

--- a/assistant/src/agent/attachments.test.ts
+++ b/assistant/src/agent/attachments.test.ts
@@ -171,10 +171,7 @@ describe("reloaded inline upload still yields a media_ref marker", () => {
     rehydrateAttachmentIds(reloaded, [{ position: 0, attachmentId: "att-0" }]);
 
     // Non-vision backbone: image is rewritten into an attachment-id marker.
-    const out = applyVisionPerceptionMarkers([reloaded], {
-      supportsVision: false,
-      supportsVideo: false,
-    });
+    const out = applyVisionPerceptionMarkers([reloaded], false);
     const blocks = out[0].content;
 
     // Raw image gone; marker carries the rehydrated id as a usable media_ref.
@@ -194,10 +191,7 @@ describe("reloaded inline upload still yields a media_ref marker", () => {
     };
     rehydrateAttachmentIds(reloaded, [{ position: 0, attachmentId: "vid-0" }]);
 
-    const out = applyVisionPerceptionMarkers([reloaded], {
-      supportsVision: false,
-      supportsVideo: false,
-    });
+    const out = applyVisionPerceptionMarkers([reloaded], false);
     const blocks = out[0].content;
     expect(blocks.some((b) => b.type === "file")).toBe(false);
     const marker = blocks.find(
@@ -215,10 +209,7 @@ describe("reloaded inline upload still yields a media_ref marker", () => {
       content: [{ type: "text", text: "what is this?" }, imageBlock()],
     };
     const messages = [reloaded];
-    const out = applyVisionPerceptionMarkers(messages, {
-      supportsVision: false,
-      supportsVideo: false,
-    });
+    const out = applyVisionPerceptionMarkers(messages, false);
     // Same reference back — nothing was replaceable without an id, so the raw
     // image survives with no media_ref (this is what the rehydration fixes).
     expect(out).toBe(messages);

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -29,7 +29,6 @@ import { defaultCompact } from "../plugins/defaults/compaction/compact.js";
 import type { ContextWindowResult } from "../plugins/defaults/compaction/window-manager.js";
 import {
   applyVisionPerceptionMarkers,
-  resolveBackboneSupportsVideo,
   resolveBackboneSupportsVision,
 } from "../plugins/defaults/vision-perception/hooks/pre-model-call.js";
 import { runHook } from "../plugins/pipeline.js";
@@ -1351,12 +1350,20 @@ export class AgentLoop {
         // Sanitize the outbound history right before sending: drop accumulated
         // media, collapse old AX-tree snapshots, and convert historical
         // web-search results to text. See {@link preModelCallSanitize}.
-        // Then, per modality, replace each uploaded image/video the backbone
-        // cannot process natively with a marker naming its attachment id, so the
-        // model never receives raw bytes it cannot read and instead reaches for
-        // the vlm_* tools. Image and video gate independently: an image-vision
-        // backbone passes images through but still gets a vlm_video_log marker
-        // for uploaded video (no catalog model reads native video today).
+        // Then, on a SINGLE capability gate, replace every uploaded image/video
+        // with a marker naming its attachment id when the backbone cannot see
+        // media natively (`supportsVision === false`), so the model never
+        // receives raw bytes it cannot read and instead reaches for the vlm_*
+        // tools. A vision-capable backbone leaves all media intact (inert).
+        //
+        // TODO(vision-perception): this resolves `supportsVision` from
+        // `effectiveOverrideProfile`, computed BEFORE the pre-model-call hooks
+        // below run. A model-router hook can re-route `ctx.modelProfile`
+        // afterwards, so the marker decision can diverge from the FINAL routed
+        // backbone. Moving this rewrite after the hook chain needs a larger loop
+        // restructure (the rewrite feeds `providerHistory` into the same call the
+        // hooks decorate) — deferred. Same limitation applies to the wire tool
+        // gate in conversation-tool-setup.ts, fixed before the hooks run.
         const visionMarkerOpts = {
           callSite: callSite ?? null,
           overrideProfile: effectiveOverrideProfile ?? null,
@@ -1364,10 +1371,7 @@ export class AgentLoop {
         };
         const providerHistory = applyVisionPerceptionMarkers(
           preModelCallSanitize(history),
-          {
-            supportsVision: resolveBackboneSupportsVision(visionMarkerOpts),
-            supportsVideo: resolveBackboneSupportsVideo(visionMarkerOpts),
-          },
+          resolveBackboneSupportsVision(visionMarkerOpts),
         );
 
         // A `pre-model-call` hook (below) can defer this turn's assistant

--- a/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
@@ -61,13 +61,18 @@ mock.module("../../plugins/defaults/advisor/advisor-gate.js", () => ({
   },
 }));
 
-// ── Vision-perception gate controls (Fix #2 + Fix #3) ──────────────────
-// The vlm_* tool gate reads the `vision-perception` flag and the backbone's
-// per-modality vision capability. Drive both with mutable test state.
+// ── Vision-perception gate controls ────────────────────────────────────
+// The whole feature is a crutch for a text-only backbone, gated on a SINGLE
+// capability (`supportsVision`) plus the `vision-perception` flag plus the BYOK
+// guard (visionPerception resolves to an enabled vision-capable provider). Drive
+// all three with mutable test state.
 let visionFlagEnabled = true;
-// Backbone native IMAGE vision (`supportsVision`). When true, the image tools
-// are omitted (the backbone can see images itself). Video is never native today.
+// Backbone native vision (`supportsVision`). When true, ALL vlm_* tools are
+// omitted (the backbone can see media itself).
 let backboneSupportsVision = false;
+// Whether the visionPerception call site resolves to an enabled vision-capable
+// provider (false in the BYOK-disabled-vision-profile case).
+let visionProviderAvailable = true;
 
 // Only the flag predicate is stubbed (it ignores its config argument), so the
 // real `getConfig()` runs untouched and other importers of config/loader keep
@@ -76,8 +81,8 @@ mock.module("../../config/vision-perception-flag.js", () => ({
   isVisionPerceptionEnabled: () => visionFlagEnabled,
   VISION_PERCEPTION_FLAG_KEY: "vision-perception",
 }));
-// Stub only the resolvers; keep the real name predicates (isVlm*ToolName) so the
-// gate's image/video routing is exercised against the actual tool-name sets.
+// Stub only the resolver; keep the real name predicate (isVlmToolName) so the
+// gate routing is exercised against the actual tool-name set.
 const realPreModelCall =
   await import("../../plugins/defaults/vision-perception/hooks/pre-model-call.js");
 mock.module(
@@ -85,8 +90,14 @@ mock.module(
   () => ({
     ...realPreModelCall,
     resolveBackboneSupportsVision: () => backboneSupportsVision,
-    // No catalog model is natively video-capable, mirroring production.
-    resolveBackboneSupportsVideo: () => false,
+  }),
+);
+// Stub the BYOK availability check (the visionPerception provider resolution).
+mock.module(
+  "../../plugins/defaults/vision-perception/src/vision-capability.js",
+  () => ({
+    isVisionPerceptionProviderAvailable: () => visionProviderAvailable,
+    VISION_CALL_SITE: "visionPerception",
   }),
 );
 
@@ -115,6 +126,7 @@ beforeEach(() => {
   mockClientCountByCapability.clear();
   visionFlagEnabled = true;
   backboneSupportsVision = false;
+  visionProviderAvailable = true;
 });
 
 describe("isToolActiveForContext — Slack task_progress UI exception", () => {
@@ -689,46 +701,49 @@ describe("HOST_TOOL_NAMES derivation", () => {
   });
 });
 
-const IMAGE_TOOLS = ["vlm_ask", "vlm_describe", "vlm_ocr", "vlm_detect"];
-const VIDEO_TOOL = "vlm_video_log";
+const ALL_VLM_TOOLS = [
+  "vlm_ask",
+  "vlm_describe",
+  "vlm_ocr",
+  "vlm_detect",
+  "vlm_video_log",
+];
 
-describe("isToolActiveForContext — vlm_* per-modality gating (Fix #2)", () => {
-  test("non-vision backbone: ALL vlm_* tools are offered (flag on)", () => {
+describe("isToolActiveForContext — vlm_* single capability gate", () => {
+  test("text-only backbone (GLM 5.2): ALL vlm_* tools are offered (flag on, provider available)", () => {
     backboneSupportsVision = false;
     const ctx = makeCtx();
-    for (const name of IMAGE_TOOLS) {
+    for (const name of ALL_VLM_TOOLS) {
       expect(isToolActiveForContext(name, ctx)).toBe(true);
     }
-    expect(isToolActiveForContext(VIDEO_TOOL, ctx)).toBe(true);
   });
 
-  test("image-vision backbone: IMAGE tools hidden, but vlm_video_log STILL offered", () => {
-    // An image-vision model reads images natively (image tools are dead weight)
-    // but cannot process native video, so vlm_video_log must stay available.
+  test("vision-capable backbone: ALL vlm_* tools hidden (incl. vlm_video_log)", () => {
+    // Single gate — a vision-capable backbone is fully inert, so the WHOLE
+    // feature is withheld (reverts the per-modality vlm_video_log carve-out).
     backboneSupportsVision = true;
     const ctx = makeCtx();
-    for (const name of IMAGE_TOOLS) {
+    for (const name of ALL_VLM_TOOLS) {
       expect(isToolActiveForContext(name, ctx)).toBe(false);
     }
-    expect(isToolActiveForContext(VIDEO_TOOL, ctx)).toBe(true);
   });
 });
 
-describe("isToolActiveForContext — vlm_* flag gating (Fix #3)", () => {
-  test("flag off: NO vlm_* tool is offered even on a non-vision backbone", () => {
+describe("isToolActiveForContext — vlm_* flag gating", () => {
+  test("flag off: NO vlm_* tool is offered even on a text-only backbone", () => {
     visionFlagEnabled = false;
     backboneSupportsVision = false;
     const ctx = makeCtx();
-    for (const name of [...IMAGE_TOOLS, VIDEO_TOOL]) {
+    for (const name of ALL_VLM_TOOLS) {
       expect(isToolActiveForContext(name, ctx)).toBe(false);
     }
   });
 
-  test("flag on: vlm_* tools are offered (subject to per-modality gating)", () => {
+  test("flag on: vlm_* tools are offered on a text-only backbone", () => {
     visionFlagEnabled = true;
     backboneSupportsVision = false;
     const ctx = makeCtx();
-    for (const name of [...IMAGE_TOOLS, VIDEO_TOOL]) {
+    for (const name of ALL_VLM_TOOLS) {
       expect(isToolActiveForContext(name, ctx)).toBe(true);
     }
   });
@@ -742,11 +757,35 @@ describe("isToolActiveForContext — vlm_* flag gating (Fix #3)", () => {
 
     visionFlagEnabled = false;
     expect(isToolActiveForContext("vlm_ask", ctx)).toBe(false);
-    expect(isToolActiveForContext(VIDEO_TOOL, ctx)).toBe(false);
+    expect(isToolActiveForContext("vlm_video_log", ctx)).toBe(false);
 
     // Flag flips on at runtime — same context, next turn.
     visionFlagEnabled = true;
     expect(isToolActiveForContext("vlm_ask", ctx)).toBe(true);
-    expect(isToolActiveForContext(VIDEO_TOOL, ctx)).toBe(true);
+    expect(isToolActiveForContext("vlm_video_log", ctx)).toBe(true);
+  });
+});
+
+describe("isToolActiveForContext — vlm_* BYOK provider guard", () => {
+  test("flag on + text-only backbone but visionPerception provider unavailable: NO vlm_* tool offered", () => {
+    // BYOK case: the managed `vision` profile is disabled, so the call site
+    // strips back to a non-vision provider. The tools must not be offered.
+    visionFlagEnabled = true;
+    backboneSupportsVision = false;
+    visionProviderAvailable = false;
+    const ctx = makeCtx();
+    for (const name of ALL_VLM_TOOLS) {
+      expect(isToolActiveForContext(name, ctx)).toBe(false);
+    }
+  });
+
+  test("provider availability only matters on a text-only backbone (vision-capable stays inert regardless)", () => {
+    visionFlagEnabled = true;
+    backboneSupportsVision = true;
+    visionProviderAvailable = true;
+    const ctx = makeCtx();
+    for (const name of ALL_VLM_TOOLS) {
+      expect(isToolActiveForContext(name, ctx)).toBe(false);
+    }
   });
 });

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -20,12 +20,10 @@ import type { PermissionPrompter } from "../permissions/prompter.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
 import { advisorEnabledForProfile } from "../plugins/defaults/advisor/advisor-gate.js";
 import {
-  isVlmImageToolName,
   isVlmToolName,
-  isVlmVideoToolName,
-  resolveBackboneSupportsVideo,
   resolveBackboneSupportsVision,
 } from "../plugins/defaults/vision-perception/hooks/pre-model-call.js";
+import { isVisionPerceptionProviderAvailable } from "../plugins/defaults/vision-perception/src/vision-capability.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { registerConversationSender } from "../tools/browser/browser-screencast.js";
@@ -639,22 +637,20 @@ export function isToolActiveForContext(
       selectionSeed: ctx.conversationId ?? null,
     };
 
-    // Per-modality gating: vision perception only engages for backbones that
-    // lack native support for that modality. A vision-capable model reads
-    // uploaded images directly, so the IMAGE tools (vlm_ask/describe/ocr/detect)
-    // are dead weight and omitted. But an image-vision model still cannot
-    // process native video, so vlm_video_log stays offered unless the backbone
-    // has native VIDEO support (always false today — no catalog model does).
-    // Resolves the model the same way dispatch does (the per-turn override, else
-    // the active profile / call-site default).
-    if (isVlmImageToolName(name)) {
-      return !resolveBackboneSupportsVision(resolution);
-    }
-    if (isVlmVideoToolName(name)) {
-      return !resolveBackboneSupportsVideo(resolution);
-    }
-    // Defensive: an unclassified vlm_* tool falls back to the image gate.
-    return !resolveBackboneSupportsVision(resolution);
+    // Single capability gate: the whole feature is a crutch for a text-only
+    // backbone, so ALL vlm_* tools (vlm_ask/describe/ocr/detect/video_log) are
+    // offered together only when the resolved backbone cannot see media natively
+    // (`supportsVision === false`) — and withheld together for any vision-capable
+    // backbone. Resolves the backbone the same way dispatch does (the per-turn
+    // override, else the active profile / call-site default).
+    if (resolveBackboneSupportsVision(resolution)) return false;
+
+    // BYOK guard: only offer the tools when the visionPerception call site
+    // actually resolves to an enabled, vision-capable provider/model. In BYOK
+    // installs the managed `vision` profile is seeded disabled, so the call site
+    // can strip back to the user's (possibly non-vision) active profile — never
+    // offer a tool that would send image frames to a model that can't read them.
+    return isVisionPerceptionProviderAvailable();
   }
   if (UI_SURFACE_TOOL_NAMES.has(name)) {
     if (

--- a/assistant/src/plugins/defaults/vision-perception/__tests__/ocr-detect.test.ts
+++ b/assistant/src/plugins/defaults/vision-perception/__tests__/ocr-detect.test.ts
@@ -29,6 +29,13 @@ mock.module("../../../../providers/provider-send-message.js", () => ({
   getConfiguredProvider: async () => fakeProvider,
 }));
 
+// The execution guard checks the visionPerception call site resolves to an
+// enabled vision-capable provider. Keep it available for these tests.
+mock.module("../src/vision-capability.js", () => ({
+  isVisionPerceptionProviderAvailable: () => true,
+  VISION_CALL_SITE: "visionPerception",
+}));
+
 // A 4x2 PNG so `parseImageDimensions` returns a non-trivial size we can assert
 // on. Small enough that `optimizeImageForTransport` leaves the bytes unchanged.
 const PNG_4x2 = (() => {

--- a/assistant/src/plugins/defaults/vision-perception/__tests__/pre-model-call.test.ts
+++ b/assistant/src/plugins/defaults/vision-perception/__tests__/pre-model-call.test.ts
@@ -36,12 +36,11 @@ mock.module("../../../../memory/attachments-store.js", () => ({
 const {
   applyVisionPerceptionMarkers,
   resolveBackboneSupportsVision,
-  resolveBackboneSupportsVideo,
   isVlmToolName,
 } = await import("../hooks/pre-model-call.js");
 
-// Vision-capable (anthropic/claude-opus-4-8) and non-vision
-// (fireworks/glm-5p2) catalog entries.
+// Vision-capable (anthropic/claude-opus-4-8) and text-only (fireworks/glm-5p2)
+// catalog entries.
 const VISION_MODEL = { provider: "anthropic", model: "claude-opus-4-8" };
 const NON_VISION_MODEL = {
   provider: "fireworks",
@@ -81,14 +80,9 @@ const resolutionOpts = {
 
 const gate = () => resolveBackboneSupportsVision(resolutionOpts);
 
-// Per-modality support object for `applyVisionPerceptionMarkers`, resolved the
-// same way the agent loop does (image gate via supportsVision, video gate via
-// supportsVideo — always false today so an image-vision backbone still gets
-// video markers).
-const support = () => ({
-  supportsVision: resolveBackboneSupportsVision(resolutionOpts),
-  supportsVideo: resolveBackboneSupportsVideo(resolutionOpts),
-});
+// Single supportsVision decision passed to `applyVisionPerceptionMarkers`,
+// resolved the same way the agent loop does.
+const supportsVision = () => resolveBackboneSupportsVision(resolutionOpts);
 
 beforeEach(() => {
   flagEnabled = true;
@@ -101,41 +95,63 @@ beforeEach(() => {
 });
 
 describe("vision-capable backbone keeps the feature inert", () => {
-  test("vlm_* tools are not offered and media blocks pass through unchanged", () => {
+  test("vlm_* tools are not offered and ALL media blocks pass through unchanged", () => {
     resolvedProviderModel = { ...VISION_MODEL };
 
     // Tool gate: a vision-capable backbone reports supportsVision === true,
-    // which the tool resolver reads as "omit the vlm_* tools".
+    // which the tool resolver reads as "omit all the vlm_* tools".
     expect(gate()).toBe(true);
     expect(isVlmToolName("vlm_ask")).toBe(true);
+    expect(isVlmToolName("vlm_video_log")).toBe(true);
 
-    // Media passes through untouched (same reference, raw image preserved).
+    // Image media passes through untouched (same reference, raw image preserved).
     const messages = [imageMessage("att-1")];
-    const out = applyVisionPerceptionMarkers(messages, support());
+    const out = applyVisionPerceptionMarkers(messages, supportsVision());
     expect(out).toBe(messages);
     expect(out[0].content[1]).toMatchObject({ type: "image" });
   });
+
+  test("video media ALSO passes through unchanged on a vision-capable backbone (single gate)", () => {
+    // Reverts the per-modality video carve-out: a vision-capable backbone is
+    // fully inert, so an uploaded video is NOT rewritten into a marker.
+    resolvedProviderModel = { ...VISION_MODEL };
+    expect(gate()).toBe(true);
+
+    const messages = [
+      fileMessage({
+        source: {
+          type: "base64",
+          media_type: "video/mp4",
+          data: "AAAA",
+          filename: "clip.mp4",
+        },
+        _attachmentId: "vid-1",
+      }),
+    ];
+    const out = applyVisionPerceptionMarkers(messages, supportsVision());
+    expect(out).toBe(messages);
+    expect(out[0].content.some((b) => b.type === "file")).toBe(true);
+  });
 });
 
-describe("non-vision backbone surfaces a usable media_ref", () => {
+describe("text-only backbone surfaces a usable media_ref", () => {
   test("image block becomes a marker whose media_ref is the attachment id; tools stay offered", () => {
     resolvedProviderModel = { ...NON_VISION_MODEL };
 
-    // Tool gate: a non-vision backbone reports supportsVision === false, which
+    // Tool gate: a text-only backbone reports supportsVision === false, which
     // the tool resolver reads as "offer the vlm_* tools".
     expect(gate()).toBe(false);
 
     const out = applyVisionPerceptionMarkers(
       [imageMessage("att-1")],
-      support(),
+      supportsVision(),
     );
     const blocks = out[0].content;
 
     // The raw image is gone; the model never receives image bytes.
     expect(blocks.some((b) => b.type === "image")).toBe(false);
 
-    // A text marker replaced it, carrying the attachment id as media_ref
-    // (closes Codex P1: the uploaded image exposes a usable media_ref).
+    // A text marker replaced it, carrying the attachment id as media_ref.
     const marker = blocks.find(
       (b) => b.type === "text" && b.text.includes("id="),
     );
@@ -146,9 +162,7 @@ describe("non-vision backbone surfaces a usable media_ref", () => {
     expect(text).toContain('file "photo.png"');
     expect(text).toContain("vlm_ask");
   });
-});
 
-describe("non-vision backbone surfaces uploaded videos", () => {
   test("a video file block becomes a marker advertising vlm_video_log", () => {
     resolvedProviderModel = { ...NON_VISION_MODEL };
 
@@ -164,7 +178,7 @@ describe("non-vision backbone surfaces uploaded videos", () => {
           _attachmentId: "vid-1",
         }),
       ],
-      support(),
+      supportsVision(),
     );
     const blocks = out[0].content;
 
@@ -198,7 +212,7 @@ describe("non-vision backbone surfaces uploaded videos", () => {
           _attachmentId: "vid-1",
         }),
       ],
-      support(),
+      supportsVision(),
     );
     const blocks = out[0].content;
     expect(blocks.some((b) => b.type === "file")).toBe(false);
@@ -223,94 +237,49 @@ describe("non-vision backbone surfaces uploaded videos", () => {
         _attachmentId: "doc-1",
       }),
     ];
-    const out = applyVisionPerceptionMarkers(messages, support());
+    const out = applyVisionPerceptionMarkers(messages, supportsVision());
     // No rewrite was needed, so the same array reference comes back and the file
     // block survives intact.
     expect(out).toBe(messages);
     expect(out[0].content[1]).toMatchObject({ type: "file" });
   });
-
-  test("an image-vision backbone still gets a vlm_video_log marker for video (Fix #2 per-modality gating)", () => {
-    // An image-vision backbone (supportsVision === true) cannot process native
-    // video, so the video file block must STILL become a vlm_video_log marker
-    // even though images would pass through. resolveBackboneSupportsVideo is
-    // false for every catalog model today.
-    resolvedProviderModel = { ...VISION_MODEL };
-    expect(gate()).toBe(true); // image vision native
-    expect(support().supportsVideo).toBe(false); // video not native
-
-    const messages = [
-      fileMessage({
-        source: {
-          type: "base64",
-          media_type: "video/mp4",
-          data: "AAAA",
-          filename: "clip.mp4",
-        },
-        _attachmentId: "vid-1",
-      }),
-    ];
-    const out = applyVisionPerceptionMarkers(messages, support());
-
-    // The raw video file block is gone; a vlm_video_log marker replaces it.
-    expect(out[0].content.some((b) => b.type === "file")).toBe(false);
-    const marker = out[0].content.find(
-      (b) => b.type === "text" && b.text.includes("vlm_video_log"),
-    );
-    expect(marker).toBeDefined();
-    expect((marker as { text: string }).text).toContain('media_ref="vid-1"');
-  });
-
-  test("an image-vision backbone passes IMAGE blocks through untouched (Fix #2)", () => {
-    // Images are native for a vision-capable backbone, so an image block is left
-    // intact even though video would be rewritten on the same backbone.
-    resolvedProviderModel = { ...VISION_MODEL };
-    const messages = [imageMessage("att-1")];
-    const out = applyVisionPerceptionMarkers(messages, support());
-    expect(out).toBe(messages);
-    expect(out[0].content.some((b) => b.type === "image")).toBe(true);
-  });
 });
 
 describe("no media attachments", () => {
-  test("non-vision backbone leaves an attachment-free request unchanged", () => {
+  test("text-only backbone leaves an attachment-free request unchanged", () => {
     resolvedProviderModel = { ...NON_VISION_MODEL };
     const messages: Message[] = [
       { role: "user", content: [{ type: "text", text: "hello" }] },
     ];
-    const out = applyVisionPerceptionMarkers(messages, support());
+    const out = applyVisionPerceptionMarkers(messages, supportsVision());
     expect(out).toBe(messages);
   });
 
   test("an image block without an attachment id is left intact (no usable media_ref)", () => {
     resolvedProviderModel = { ...NON_VISION_MODEL };
     const messages = [imageMessage()];
-    const out = applyVisionPerceptionMarkers(messages, support());
+    const out = applyVisionPerceptionMarkers(messages, supportsVision());
     expect(out).toBe(messages);
     expect(out[0].content[1]).toMatchObject({ type: "image" });
   });
 });
 
 describe("feature flag gating", () => {
-  test("flag off makes a non-vision backbone report inert (supportsVision true)", () => {
+  test("flag off makes a text-only backbone report inert (supportsVision true)", () => {
     flagEnabled = false;
     resolvedProviderModel = { ...NON_VISION_MODEL };
     expect(gate()).toBe(true);
-    // Flag off → BOTH modalities report inert, so the video tool/marker path is
-    // also suppressed (not just images).
-    expect(resolveBackboneSupportsVideo(resolutionOpts)).toBe(true);
 
     // With the gate inert, media passes through and no marker is injected.
     const messages = [imageMessage("att-1")];
-    expect(applyVisionPerceptionMarkers(messages, support())).toBe(messages);
+    expect(applyVisionPerceptionMarkers(messages, supportsVision())).toBe(
+      messages,
+    );
   });
 
-  test("flag on keeps video inert (no native-video model) but engages images for a non-vision backbone", () => {
+  test("flag on engages the feature for a text-only backbone", () => {
     flagEnabled = true;
     resolvedProviderModel = { ...NON_VISION_MODEL };
-    // No catalog model is natively video-capable, so video support is false
-    // whenever the flag is on (the video tool/marker stay active).
-    expect(resolveBackboneSupportsVideo(resolutionOpts)).toBe(false);
     expect(gate()).toBe(false);
   });
 });

--- a/assistant/src/plugins/defaults/vision-perception/__tests__/video.test.ts
+++ b/assistant/src/plugins/defaults/vision-perception/__tests__/video.test.ts
@@ -80,6 +80,13 @@ mock.module("../../../../providers/provider-send-message.js", () => ({
   getConfiguredProvider: async () => fakeProvider,
 }));
 
+// The execution guard checks the visionPerception call site resolves to an
+// enabled vision-capable provider. Keep it available for these tests.
+mock.module("../src/vision-capability.js", () => ({
+  isVisionPerceptionProviderAvailable: () => true,
+  VISION_CALL_SITE: "visionPerception",
+}));
+
 const vlmVideoLogTool = (await import("../tools/vlm-video-log.js")).default;
 
 const ctx = { conversationId: "c1" } as unknown as ToolContext;

--- a/assistant/src/plugins/defaults/vision-perception/__tests__/vision-tools.test.ts
+++ b/assistant/src/plugins/defaults/vision-perception/__tests__/vision-tools.test.ts
@@ -30,6 +30,14 @@ mock.module("../../../../providers/provider-send-message.js", () => ({
   getConfiguredProvider: async () => fakeProvider,
 }));
 
+// The execution guard checks the visionPerception call site resolves to an
+// enabled vision-capable provider. Drive it per test (defaults available).
+let visionProviderAvailable = true;
+mock.module("../src/vision-capability.js", () => ({
+  isVisionPerceptionProviderAvailable: () => visionProviderAvailable,
+  VISION_CALL_SITE: "visionPerception",
+}));
+
 // A 1x1 PNG — small enough that `optimizeImageForTransport` returns it
 // unchanged, so the bytes flow through to the image block verbatim.
 const PNG_BYTES = Buffer.from(
@@ -64,6 +72,7 @@ const ctx = { conversationId: "c1" } as unknown as ToolContext;
 beforeEach(() => {
   sendMessageArgs = null;
   responseText = "A red bicycle leans against a brick wall.";
+  visionProviderAvailable = true;
   attachmentRows = {
     "att-1": {
       id: "att-1",
@@ -161,6 +170,21 @@ describe("vlm_ask tool", () => {
 
     expect(result?.isError).toBe(true);
     expect(result?.content).toContain("not an image");
+    expect(sendMessageArgs).toBeNull();
+  });
+
+  test("BYOK guard: returns isError and sends nothing when no vision-capable provider resolves", async () => {
+    // The visionPerception call site does not resolve to an enabled
+    // vision-capable model (BYOK with the managed vision profile disabled), so
+    // the execution guard refuses before any image bytes are sent.
+    visionProviderAvailable = false;
+    const result = await vlmAskTool.execute?.(
+      { media_ref: "att-1", question: "What is in this image?" },
+      ctx,
+    );
+
+    expect(result?.isError).toBe(true);
+    expect(result?.content).toContain("vision perception is unavailable");
     expect(sendMessageArgs).toBeNull();
   });
 });

--- a/assistant/src/plugins/defaults/vision-perception/hooks/pre-model-call.ts
+++ b/assistant/src/plugins/defaults/vision-perception/hooks/pre-model-call.ts
@@ -1,17 +1,21 @@
 /**
  * `pre-model-call` gating for vision perception.
  *
- * Vision perception only engages for backbones that lack native image/video
- * support. The gate is evaluated per turn against the *resolved* model:
+ * This entire feature is a crutch for a text-only backbone (today the only such
+ * catalog model is GLM 5.2, `supportsVision: false`). It engages on a SINGLE
+ * capability gate — the resolved backbone's `supportsVision` — and is fully inert
+ * for every vision-capable model. The gate is evaluated per turn against the
+ * *resolved* model:
  *
- * - **Vision-capable backbone:** the feature is fully inert. The `vlm_*` tools
- *   are removed from the offered tool list (see {@link VLM_TOOL_NAMES}, gated in
- *   `daemon/conversation-tool-setup.ts`) and media blocks pass through to the
- *   model unchanged.
- * - **Non-vision backbone:** an uploaded image must never reach the model as raw
- *   bytes. Each media block on the outbound request is replaced with a text
- *   marker that names the attachment id, so the model can read it by calling a
- *   `vlm_*` tool with `media_ref="<id>"`. The `vlm_*` tools stay offered.
+ * - **Vision-capable backbone (`supportsVision === true`):** the feature is fully
+ *   inert. The `vlm_*` tools are removed from the offered tool list (see
+ *   {@link VLM_TOOL_NAMES}, gated in `daemon/conversation-tool-setup.ts`) and ALL
+ *   media blocks (image and video) pass through to the model unchanged.
+ * - **Text-only backbone (`supportsVision === false`):** an uploaded image/video
+ *   must never reach the model as raw bytes. Each media block on the outbound
+ *   request is replaced with a text marker that names the attachment id, so the
+ *   model can read it by calling a `vlm_*` tool with `media_ref="<id>"`. The
+ *   `vlm_*` tools stay offered.
  *
  * The runtime `PreModelCallContext` carries neither the outbound message list
  * nor the offered tools, so the two mutations are driven from the per-turn paths
@@ -39,54 +43,25 @@ import type {
 } from "../../../../providers/types.js";
 
 /**
- * The model-visible IMAGE-inspection tools the plugin contributes. Gated on the
- * backbone's native *image* vision (`supportsVision`): a backbone that can see
- * images itself reads uploaded images directly, so these are dead weight and
- * omitted for it.
+ * Names of every model-visible vision tool the plugin contributes. Kept here so
+ * the offered-tool gate (which omits them all when the backbone sees natively)
+ * and the media marker (which names them as the way to inspect an attachment)
+ * share one source of truth. ALL of these gate together on the single
+ * `supportsVision` capability — there is no per-modality (image vs video) split:
+ * the feature is offered as a whole for a text-only backbone and withheld as a
+ * whole for a vision-capable one.
  */
-export const VLM_IMAGE_TOOL_NAMES: ReadonlySet<string> = new Set([
+export const VLM_TOOL_NAMES: ReadonlySet<string> = new Set([
   "vlm_ask",
   "vlm_describe",
   "vlm_ocr",
   "vlm_detect",
-]);
-
-/**
- * The model-visible VIDEO-inspection tool. Gated on native *video* support, not
- * `supportsVision`: an image-vision backbone still cannot process `video/*`
- * (the provider serializers render video files as text placeholders, not native
- * video), so it must keep this tool. No catalog model supports native video
- * through our pipeline today, so it is offered whenever the feature is active —
- * see {@link resolveBackboneSupportsVideo}.
- */
-export const VLM_VIDEO_TOOL_NAMES: ReadonlySet<string> = new Set([
   "vlm_video_log",
-]);
-
-/**
- * Names of every model-visible vision tool the plugin contributes. Kept here so
- * the offered-tool gate (which omits them per-modality) and the media marker
- * (which names them as the way to inspect an attachment) share one source of
- * truth, independent of which subset of tools is currently registered.
- */
-export const VLM_TOOL_NAMES: ReadonlySet<string> = new Set([
-  ...VLM_IMAGE_TOOL_NAMES,
-  ...VLM_VIDEO_TOOL_NAMES,
 ]);
 
 /** Whether `name` is one of the plugin's vision tools. */
 export function isVlmToolName(name: string): boolean {
   return VLM_TOOL_NAMES.has(name);
-}
-
-/** Whether `name` is one of the plugin's IMAGE-inspection tools. */
-export function isVlmImageToolName(name: string): boolean {
-  return VLM_IMAGE_TOOL_NAMES.has(name);
-}
-
-/** Whether `name` is the plugin's VIDEO-inspection tool. */
-export function isVlmVideoToolName(name: string): boolean {
-  return VLM_VIDEO_TOOL_NAMES.has(name);
 }
 
 export interface BackboneResolutionOpts {
@@ -116,15 +91,15 @@ function resolveBackboneCatalogModel(opts: BackboneResolutionOpts) {
 }
 
 /**
- * Resolve whether the backbone that will serve a turn natively supports IMAGE
- * vision, reading `supportsVision` from the model catalog. Unknown (provider,
- * model) pairs fail open to `true` — matching `GET /v1/config`'s per-profile
- * enrichment — so custom or unlisted models keep native image handling and the
- * feature stays inert for them.
+ * Resolve whether the backbone that will serve a turn natively supports vision,
+ * reading `supportsVision` from the model catalog. Unknown (provider, model)
+ * pairs fail open to `true` — matching `GET /v1/config`'s per-profile enrichment
+ * — so custom or unlisted models keep native media handling and the feature
+ * stays inert for them.
  *
  * Returns `true` (feature inert) whenever the `vision-perception` flag is off,
  * so callers gate uniformly on this one predicate: a vision-capable result means
- * "leave images intact and don't offer the image vlm_* tools".
+ * "leave media intact and don't offer the vlm_* tools".
  */
 export function resolveBackboneSupportsVision(
   opts: BackboneResolutionOpts,
@@ -140,41 +115,6 @@ export function resolveBackboneSupportsVision(
   }
 }
 
-/**
- * Resolve whether the backbone that will serve a turn natively supports VIDEO.
- *
- * There is no `supportsVideo` capability in the catalog today and no catalog
- * model can process `video/*` natively through our pipeline (the provider
- * serializers render video files as text placeholders), so this is always
- * `false` while the feature is active: `vlm_video_log` and the video marker
- * stay available even on an image-vision backbone.
- *
- * Returns `true` (feature inert) whenever the `vision-perception` flag is off,
- * mirroring {@link resolveBackboneSupportsVision}.
- *
- * If a natively-video-capable model is ever added, give the catalog a
- * `supportsVideo` field and return it here (fail open to `false` for unknown
- * models, since native video remains the rare case) so the video tool/marker
- * become inert for those backbones exactly as the image path does today.
- */
-export function resolveBackboneSupportsVideo(
-  // Unused today — kept so callers thread the same resolution opts as the image
-  // gate and the extension point (a future `supportsVideo` catalog read) is
-  // already wired. See the doc above.
-  _opts: BackboneResolutionOpts,
-): boolean {
-  try {
-    // Flag off → inert (mirrors the image gate). With the flag on, no catalog
-    // model is natively video-capable, so the video tool/marker stay active.
-    return isVisionPerceptionEnabled(getConfig()) ? false : true;
-  } catch {
-    // A config-read failure leaves the video path active (fail closed toward
-    // "the model can't read video natively"), matching the marker rewrite's
-    // intent that raw video never silently reach a model that can't read it.
-    return false;
-  }
-}
-
 /** Human-readable media kind for the marker text. */
 function mediaKind(block: ImageContent): "Image" | "Video" {
   return block.source.media_type.startsWith("video/") ? "Video" : "Image";
@@ -184,7 +124,7 @@ function mediaKind(block: ImageContent): "Image" | "Video" {
  * Whether a `file` block carries a video the model can't read inline. Inline
  * uploads of `video/*` reach the model as a {@link FileContent} block (only
  * `image/*` becomes an {@link ImageContent} — see `agent/attachments.ts`), so a
- * non-vision backbone needs that block rewritten into a `vlm_video_log` marker
+ * text-only backbone needs that block rewritten into a `vlm_video_log` marker
  * too. Detected by the block's own `media_type` first (no DB hit), falling back
  * to the attachment row's `kind` for blocks whose declared MIME is generic.
  */
@@ -209,7 +149,7 @@ function resolveAttachmentFilename(attachmentId: string): string {
 }
 
 /**
- * Render the text marker that replaces a raw media block for a non-vision
+ * Render the text marker that replaces a raw media block for a text-only
  * backbone. Names the attachment id so the model has a usable `media_ref`, and
  * advertises the right tool for the media kind: `vlm_video_log` for videos, the
  * image inspection tools otherwise.
@@ -231,34 +171,15 @@ export function renderMediaMarker(
 }
 
 /**
- * Per-modality gating for the marker rewrite. A modality's media is replaced
- * with an attachment-id marker only when the backbone CANNOT process that
- * modality natively, so an image-vision backbone (image native, video not) gets
- * raw images through but a video marker for any uploaded video.
- */
-export interface VisionPerceptionModalitySupport {
-  /** The backbone natively reads IMAGES (`supportsVision`). */
-  supportsVision: boolean;
-  /** The backbone natively reads VIDEO (always `false` today — see
-   * {@link resolveBackboneSupportsVideo}). */
-  supportsVideo: boolean;
-}
-
-/**
- * Replace raw media blocks with attachment-id markers, PER MODALITY, when the
- * backbone lacks native support for that modality. Returns the input array
- * unchanged (same reference) when nothing needs replacing, so a request that
- * needs no rewrite is not copied.
+ * Replace raw media blocks (images AND videos) with attachment-id markers when
+ * the backbone cannot see media natively. Returns the input array unchanged
+ * (same reference) when nothing needs replacing, so a request that needs no
+ * rewrite is not copied.
  *
- * Modalities are gated independently:
- *  - IMAGE media (an `image` block with an `image/*` media_type) is replaced
- *    only when `supportsVision` is false.
- *  - VIDEO media (a `file` block carrying a video — see {@link isVideoFileBlock}
- *    — or, defensively, an `image` block with a `video/*` media_type) is
- *    replaced only when `supportsVideo` is false. An image-vision backbone still
- *    cannot process `video/*` natively (the provider serializers render it as a
- *    text placeholder), so the video still becomes a `vlm_video_log` marker even
- *    though images pass through.
+ * Single gate: `supportsVision === true` → fully inert, every media block passes
+ * through. `supportsVision === false` → both image media (an `image` block) and
+ * video media (a `file` block carrying a video — see {@link isVideoFileBlock} —
+ * or, defensively, an `image` block with a `video/*` media_type) become markers.
  *
  * Non-video `file` blocks (PDFs, documents, …) are left intact — the backbone
  * can read their `extracted_text`, and there is no `vlm_*` tool for them.
@@ -269,14 +190,14 @@ export interface VisionPerceptionModalitySupport {
  */
 export function applyVisionPerceptionMarkers(
   messages: Message[],
-  support: VisionPerceptionModalitySupport,
+  supportsVision: boolean,
 ): Message[] {
-  const { supportsVision, supportsVideo } = support;
-  // Both modalities native → feature fully inert, nothing to rewrite.
-  if (supportsVision && supportsVideo) return messages;
+  // Vision-capable backbone → feature fully inert, nothing to rewrite.
+  if (supportsVision) return messages;
 
-  // Classify a block's modality (or null when it is not replaceable media).
-  const modalityOf = (block: ContentBlock): "Image" | "Video" | null => {
+  // A block is replaced (with the marker for its media kind) only when it is
+  // replaceable media carrying an attachment id.
+  const replaceableKind = (block: ContentBlock): "Image" | "Video" | null => {
     if (block.type === "image") {
       if (typeof block._attachmentId !== "string") return null;
       return mediaKind(block); // "Image" or "Video" (defensive video/* image)
@@ -285,14 +206,6 @@ export function applyVisionPerceptionMarkers(
       if (typeof block._attachmentId !== "string") return null;
       return isVideoFileBlock(block) ? "Video" : null;
     }
-    return null;
-  };
-
-  // A block is replaced only when its modality is NOT natively supported.
-  const replaceableKind = (block: ContentBlock): "Image" | "Video" | null => {
-    const modality = modalityOf(block);
-    if (modality === "Image") return supportsVision ? null : "Image";
-    if (modality === "Video") return supportsVideo ? null : "Video";
     return null;
   };
 

--- a/assistant/src/plugins/defaults/vision-perception/src/call-vision-model.ts
+++ b/assistant/src/plugins/defaults/vision-perception/src/call-vision-model.ts
@@ -24,10 +24,12 @@ import {
 import type { ImageContent, Message } from "../../../../providers/types.js";
 import type { ToolContext } from "../../../../tools/types.js";
 import { resolveVisionMedia } from "./media-source.js";
+import {
+  isVisionPerceptionProviderAvailable,
+  VISION_CALL_SITE,
+} from "./vision-capability.js";
 
-// Dedicated vision call site. Its profile (a vision-capable model) is resolved
-// by the LLM config layer when the `vision-perception` feature flag is on.
-const VISION_CALL_SITE = "visionPerception" as const;
+export { VISION_CALL_SITE };
 
 const VISION_SYSTEM_PROMPT =
   "You are a vision assistant. Examine the provided image carefully and respond " +
@@ -45,6 +47,19 @@ export async function sendVisionMessage(
   systemPrompt: string,
   ctx: ToolContext,
 ): Promise<string> {
+  // Execution guard (mirrors the tool-offering gate): never send image/video
+  // frames unless the visionPerception call site resolves to an enabled,
+  // vision-capable model. In BYOK installs the managed `vision` profile is seeded
+  // disabled, so the call site can strip back to the user's (possibly non-vision)
+  // active profile — refuse rather than send media a model cannot read. The tool
+  // executors convert this throw into a clear `{ isError: true }` result.
+  if (!isVisionPerceptionProviderAvailable()) {
+    throw new Error(
+      "vision perception is unavailable: the visionPerception profile does not " +
+        "resolve to an enabled vision-capable model",
+    );
+  }
+
   const provider = await getConfiguredProvider(VISION_CALL_SITE);
   if (!provider) {
     throw new Error("no vision inference provider is configured");

--- a/assistant/src/plugins/defaults/vision-perception/src/vision-capability.ts
+++ b/assistant/src/plugins/defaults/vision-perception/src/vision-capability.ts
@@ -1,0 +1,62 @@
+/**
+ * Resolve whether the `visionPerception` call site lands on a usable, vision-capable
+ * inference provider.
+ *
+ * The vision-perception feature routes every `vlm_*` call through the dedicated
+ * `visionPerception` call site (see {@link call-vision-model.ts}). That call site
+ * is *intended* to resolve to the managed `vision` profile (a `supportsVision`
+ * model), but it does not always: in BYOK installs the managed `vision` profile
+ * is seeded `status: "disabled"`, so the call-site resolver strips it back to the
+ * workspace's active/default profile — which may be a NON-vision model. Sending
+ * image frames to a non-vision model is wrong, so both the tool-offering gate and
+ * the execution path must first confirm the call site resolves to an enabled,
+ * vision-capable model.
+ *
+ * This module is the single source of truth for that check. It resolves the
+ * `visionPerception` call site exactly as dispatch does (via
+ * {@link resolveCallSiteConfig}) and looks the resolved `(provider, model)` pair
+ * up in the model catalog, requiring `supportsVision === true`. "Enabled" is
+ * captured structurally: a disabled profile is dropped by the resolver, so the
+ * call site falls back to a different (non-vision) model and the catalog check
+ * fails — there is no separate status flag to read here.
+ */
+
+import { resolveCallSiteConfig } from "../../../../config/llm-resolver.js";
+import { getConfig } from "../../../../config/loader.js";
+import { PROVIDER_CATALOG } from "../../../../providers/model-catalog.js";
+
+/** The dedicated call site every `vlm_*` tool dispatches through. */
+export const VISION_CALL_SITE = "visionPerception" as const;
+
+/**
+ * Resolve the catalog model entry the `visionPerception` call site would
+ * actually dispatch to, or `undefined` when the resolved `(provider, model)` is
+ * not in the catalog. Resolution failures (unreadable config, etc.) also yield
+ * `undefined` so callers fail closed.
+ */
+export function resolveVisionPerceptionCatalogModel() {
+  try {
+    const { llm } = getConfig();
+    const resolved = resolveCallSiteConfig(VISION_CALL_SITE, llm);
+    const catalogProvider = PROVIDER_CATALOG.find(
+      (p) => p.id === resolved.provider,
+    );
+    return catalogProvider?.models.find((m) => m.id === resolved.model);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Whether the `visionPerception` call site resolves to an enabled, vision-capable
+ * provider/model. True only when the resolved `(provider, model)` is a known
+ * catalog model with `supportsVision === true`.
+ *
+ * Fails CLOSED: an unresolvable call site, an unknown model, or a non-vision
+ * model all return `false`, so the `vlm_*` tools are not offered and execution is
+ * refused rather than risk sending image frames to a model that cannot read them
+ * (the BYOK-disabled-vision-profile case — see the module doc).
+ */
+export function isVisionPerceptionProviderAvailable(): boolean {
+  return resolveVisionPerceptionCatalogModel()?.supportsVision === true;
+}


### PR DESCRIPTION
## Summary
Per product intent, the VLM feature is a crutch for the only text-only catalog model (GLM 5.2) and must be inert for every vision-capable model.
- Single capability gate: ALL vlm_* tools (incl. vlm_video_log) offered only when backbone supportsVision === false; reverts the per-modality video carve-out.
- BYOK guard: only offer/execute when visionPerception resolves to an enabled vision-capable provider (don't send images to a user's non-vision model).

Part of plan: glm-5v-turbo-vlm-tool (Codex feedback + GLM-5.2-only scoping)