### PR TITLE
fix(plugins): peer-dep range + remove vestigial requiresFlag/stale docs

### DIFF
--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -352,15 +352,19 @@ export const defaultAdvisorPlugin: Plugin = {
  * the flag arrived late or flipped on at runtime, while the marker logic + vision
  * profile activated — so instead the tools are gated DYNAMICALLY per turn.
  *
- * The feature only engages for backbones that lack native vision: the per-turn
- * tool gate (`isToolActiveForContext`) checks `isVisionPerceptionEnabled` AND
- * per-modality vision capability — flag off → tools never offered (marker inert,
- * profile handled separately by reconcile); flag on at runtime → the next turn
- * offers the tools with no restart. For non-vision backbones the outbound request
- * swaps each uploaded image for a marker naming its attachment id (a usable
- * `media_ref`); image and video gate independently (an image-vision backbone
- * still gets a `vlm_video_log` marker for uploaded video). The `pre-model-call`
- * hook is the home for that gating logic (see `hooks/pre-model-call.ts`).
+ * The feature only engages for a text-only backbone — today GLM 5.2, the sole
+ * catalog model without native vision. The per-turn tool gate
+ * (`isToolActiveForContext`) offers the `vlm_*` tools only when
+ * `isVisionPerceptionEnabled` is true, the resolved backbone has
+ * `supportsVision === false`, AND `visionPerception` resolves to an enabled
+ * vision-capable provider (`isVisionPerceptionProviderAvailable`). Flag off →
+ * tools never offered (marker inert; profile handled separately by reconcile);
+ * flag on at runtime → the next turn offers the tools with no restart. A
+ * vision-capable backbone is left fully inert (all media passes through
+ * untouched); for a text-only backbone the outbound request swaps each uploaded
+ * image and video for a marker naming its attachment id (a usable `media_ref`).
+ * The `pre-model-call` hook is the home for that gating logic (see
+ * `hooks/pre-model-call.ts`).
  */
 export const visionPerceptionPlugin: Plugin = {
   manifest: {

--- a/assistant/src/plugins/defaults/vision-perception/package.json
+++ b/assistant/src/plugins/defaults/vision-perception/package.json
@@ -9,11 +9,6 @@
     "node": ">=20.12.0"
   },
   "peerDependencies": {
-    "@vellumai/plugin-api": "^0.8.0"
-  },
-  "vellumPlugin": {
-    "requiresFlag": [
-      "vision-perception"
-    ]
+    "@vellumai/plugin-api": ">=0.8.0"
   }
 }


### PR DESCRIPTION
## Summary
Small accuracy fixes on the vision-perception plugin:
- Codex P2: change `@vellumai/plugin-api` peerDependency from `^0.8.0` to `>=0.8.0` per the AGENTS.md peer-dependency policy.
- Remove the vestigial `vellumPlugin.requiresFlag` from package.json — the default plugin's runtime manifest (index.ts) is built inline from name+version only and never reads it; registration is intentionally unconditional. Removing it aligns the file with the design and prevents a future footgun.
- Update the index.ts docstring to the single-capability-gate behavior (GLM-5.2-only) after the per-modality revert; the old text still described image/video gating independently.

Part of plan: glm-5v-turbo-vlm-tool (Codex peer-dep + accuracy cleanup)