### PR TITLE
fix(agent): vision gating uses the final routed profile (router-ordering)

### DIFF
--- a/assistant/src/__tests__/loop-vision-routing.test.ts
+++ b/assistant/src/__tests__/loop-vision-routing.test.ts
@@ -1,0 +1,242 @@
+/**
+ * End-to-end: the vision-perception feature's two per-turn gates — offer the
+ * `vlm_*` tools, and strip uploaded media to `media_ref` markers — must key on
+ * the FINAL backbone the `pre-model-call` hook chain resolves, not the
+ * pre-routing profile. A per-turn model-router (a `pre-model-call` hook that
+ * sets `ctx.modelProfile`) can re-route the call after the early profile is
+ * known, so the loop must thread that routed profile into BOTH the tool
+ * resolver and the marker rewrite before the provider receives history + tools.
+ *
+ * Only the provider boundary and the backbone-capability resolution are
+ * stubbed: `resolveBackboneSupportsVision` becomes profile-driven (a "vision"
+ * profile is vision-capable, a "glm-text-only" profile is text-only). The real
+ * `applyVisionPerceptionMarkers`, `isVlmToolName`, and `isToolActiveForContext`
+ * run, so the gates are exercised against the actual rewrite + tool-gate logic.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { AgentLoop } from "../agent/loop.js";
+import type { PreModelCallContext } from "../plugin-api/types.js";
+import { resetPluginRegistryAndRegisterDefaults } from "../plugins/defaults/index.js";
+import { registerPlugin } from "../plugins/registry.js";
+import type {
+  ImageContent,
+  Message,
+  ToolDefinition,
+} from "../providers/types.js";
+import { createMockProvider, textResponse } from "./helpers/mock-provider.js";
+
+// Vision flag on; BYOK provider available — so the only lever left is the
+// resolved backbone's vision capability, which we drive per routed profile.
+mock.module("../config/vision-perception-flag.js", () => ({
+  isVisionPerceptionEnabled: () => true,
+  VISION_PERCEPTION_FLAG_KEY: "vision-perception",
+}));
+mock.module(
+  "../plugins/defaults/vision-perception/src/vision-capability.js",
+  () => ({
+    isVisionPerceptionProviderAvailable: () => true,
+    VISION_CALL_SITE: "visionPerception",
+  }),
+);
+
+// Profile-driven backbone capability: "vision" → vision-capable (feature
+// inert), "glm-text-only" (and null/unknown) → text-only (feature engages).
+// Keep every other export of the module real so the marker rewrite and the
+// vlm_* name predicate run for real.
+const realVisionModule =
+  await import("../plugins/defaults/vision-perception/hooks/pre-model-call.js");
+mock.module(
+  "../plugins/defaults/vision-perception/hooks/pre-model-call.js",
+  () => ({
+    ...realVisionModule,
+    resolveBackboneSupportsVision: (opts: { overrideProfile: string | null }) =>
+      opts.overrideProfile === "vision",
+  }),
+);
+
+const { isToolActiveForContext } =
+  await import("../daemon/conversation-tool-setup.js");
+
+const VLM_ASK: ToolDefinition = {
+  name: "vlm_ask",
+  description: "ask about an image",
+  input_schema: { type: "object", properties: {} },
+};
+const READ_FILE: ToolDefinition = {
+  name: "read_file",
+  description: "read a file",
+  input_schema: { type: "object", properties: {} },
+};
+const ALL_TOOLS = [READ_FILE, VLM_ASK];
+
+function imageUserMessage(): Message {
+  const image: ImageContent = {
+    type: "image",
+    source: { type: "base64", media_type: "image/png", data: "AAAA" },
+    _attachmentId: "att-1",
+  };
+  return {
+    role: "user",
+    content: [{ type: "text", text: "what is in this picture?" }, image],
+  };
+}
+
+/**
+ * A `resolveTools` closure matching how the conversation wires one: it gates
+ * each tool through the real `isToolActiveForContext`, forwarding the routed
+ * profile the loop passes (the third arg) so the vlm_* gate keys on the FINAL
+ * backbone. Records the routed profile it was called with for assertion.
+ */
+function makeResolveTools(recorded: { routedProfile?: string | null }) {
+  return (_history: Message[], routedOverrideProfile?: string | null) => {
+    recorded.routedProfile = routedOverrideProfile;
+    const ctx = {
+      skillProjectionState: new Map<string, string>(),
+      skillProjectionCache: {} as never,
+      coreToolNames: new Set<string>(ALL_TOOLS.map((t) => t.name)),
+      toolsDisabledDepth: 0,
+      conversationId: "vision-routing-itest",
+      currentCallSite: "mainAgent" as const,
+    };
+    return ALL_TOOLS.filter((t) =>
+      isToolActiveForContext(t.name, ctx, routedOverrideProfile),
+    );
+  };
+}
+
+/** Register a `pre-model-call` hook that routes the turn to `profile`. */
+function registerRoutingHook(profile: string | null): void {
+  registerPlugin({
+    manifest: { name: "test-model-router", version: "0.0.0" },
+    hooks: {
+      "pre-model-call": async (ctx: PreModelCallContext) => {
+        ctx.modelProfile = profile;
+      },
+    },
+  });
+}
+
+function imageBlocksOf(messages: Message[]): ImageContent[] {
+  return messages.flatMap((m) =>
+    m.content.filter((b): b is ImageContent => b.type === "image"),
+  );
+}
+
+function markerTextOf(messages: Message[]): string {
+  return messages
+    .flatMap((m) => m.content)
+    .filter((b) => b.type === "text")
+    .map((b) => (b as { text: string }).text)
+    .join("\n");
+}
+
+describe("agent loop — vision gating uses the final routed profile", () => {
+  beforeEach(() => {
+    resetPluginRegistryAndRegisterDefaults();
+  });
+
+  test("router: vision-capable active profile → GLM-5.2 (text-only) — vlm_* offered + image stripped", async () => {
+    // A model-router re-routes a vision-capable active profile to a text-only
+    // backbone AFTER the early profile was resolved. Both gates must engage.
+    registerRoutingHook("glm-text-only");
+    const { provider, calls } = createMockProvider([textResponse("done")]);
+    const recorded: { routedProfile?: string | null } = {};
+
+    const loop = new AgentLoop({
+      provider,
+      systemPrompt: "system",
+      conversationId: "vision-routing-itest",
+      tools: ALL_TOOLS,
+      resolveTools: makeResolveTools(recorded),
+    });
+
+    await loop.run({
+      requestId: "req-1",
+      messages: [imageUserMessage()],
+      onEvent: () => {},
+      callSite: "mainAgent",
+      // Early (pre-routing) profile is the vision-capable one.
+      overrideProfile: "vision",
+      trust: { sourceChannel: "vellum", trustClass: "unknown" },
+    });
+
+    expect(calls).toHaveLength(1);
+    // The loop forwarded the FINAL routed profile to the tool resolver.
+    expect(recorded.routedProfile).toBe("glm-text-only");
+    // Tool gate: vlm_* IS offered for the text-only backbone that runs.
+    const toolNames = (calls[0].tools ?? []).map((t) => t.name);
+    expect(toolNames).toContain("vlm_ask");
+    // Marker rewrite: the raw image is stripped to a media_ref marker.
+    expect(imageBlocksOf(calls[0].messages)).toHaveLength(0);
+    expect(markerTextOf(calls[0].messages)).toContain('media_ref="att-1"');
+  });
+
+  test("router: GLM-5.2 active profile → vision-capable model — vlm_* NOT offered + image passes through", async () => {
+    // The opposite: a text-only active profile re-routed to a vision-capable
+    // backbone. The feature must be fully inert against the model that runs.
+    registerRoutingHook("vision");
+    const { provider, calls } = createMockProvider([textResponse("done")]);
+    const recorded: { routedProfile?: string | null } = {};
+
+    const loop = new AgentLoop({
+      provider,
+      systemPrompt: "system",
+      conversationId: "vision-routing-itest",
+      tools: ALL_TOOLS,
+      resolveTools: makeResolveTools(recorded),
+    });
+
+    await loop.run({
+      requestId: "req-2",
+      messages: [imageUserMessage()],
+      onEvent: () => {},
+      callSite: "mainAgent",
+      // Early (pre-routing) profile is the text-only one.
+      overrideProfile: "glm-text-only",
+      trust: { sourceChannel: "vellum", trustClass: "unknown" },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(recorded.routedProfile).toBe("vision");
+    // Tool gate: vlm_* is withheld for the vision-capable backbone that runs.
+    const toolNames = (calls[0].tools ?? []).map((t) => t.name);
+    expect(toolNames).not.toContain("vlm_ask");
+    expect(toolNames).toContain("read_file");
+    // Marker rewrite: the raw image passes through untouched (no marker).
+    expect(imageBlocksOf(calls[0].messages)).toHaveLength(1);
+    expect(markerTextOf(calls[0].messages)).not.toContain("media_ref");
+  });
+
+  test("no routing hook: fixed GLM-5.2 backbone is unchanged — vlm_* offered + image stripped", async () => {
+    // The common case: no model-router hook. The early profile == the final
+    // profile, so behavior is identical to before the routing fix.
+    const { provider, calls } = createMockProvider([textResponse("done")]);
+    const recorded: { routedProfile?: string | null } = {};
+
+    const loop = new AgentLoop({
+      provider,
+      systemPrompt: "system",
+      conversationId: "vision-routing-itest",
+      tools: ALL_TOOLS,
+      resolveTools: makeResolveTools(recorded),
+    });
+
+    await loop.run({
+      requestId: "req-3",
+      messages: [imageUserMessage()],
+      onEvent: () => {},
+      callSite: "mainAgent",
+      overrideProfile: "glm-text-only",
+      trust: { sourceChannel: "vellum", trustClass: "unknown" },
+    });
+
+    expect(calls).toHaveLength(1);
+    // No hook routed away, so the final profile is the seeded text-only one.
+    expect(recorded.routedProfile).toBe("glm-text-only");
+    const toolNames = (calls[0].tools ?? []).map((t) => t.name);
+    expect(toolNames).toContain("vlm_ask");
+    expect(imageBlocksOf(calls[0].messages)).toHaveLength(0);
+    expect(markerTextOf(calls[0].messages)).toContain('media_ref="att-1"');
+  });
+});

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -626,7 +626,10 @@ export interface AgentLoopConstructorOptions {
   config?: Partial<AgentLoopConfig>;
   tools?: ToolDefinition[];
   toolExecutor?: LoopToolExecutor;
-  resolveTools?: (history: Message[]) => ToolDefinition[];
+  resolveTools?: (
+    history: Message[],
+    routedOverrideProfile?: string | null,
+  ) => ToolDefinition[];
   resolveSystemPrompt?: (history: Message[]) => ResolvedSystemPrompt;
   /**
    * Conversation this loop drives. Scopes the loop-held compaction circuit
@@ -651,7 +654,12 @@ export class AgentLoop {
   private systemPrompt: string;
   private config: AgentLoopConfig;
   private tools: ToolDefinition[];
-  private resolveTools: ((history: Message[]) => ToolDefinition[]) | null;
+  private resolveTools:
+    | ((
+        history: Message[],
+        routedOverrideProfile?: string | null,
+      ) => ToolDefinition[])
+    | null;
   private resolveSystemPrompt:
     | ((history: Message[]) => ResolvedSystemPrompt)
     | null;
@@ -1205,12 +1213,6 @@ export class AgentLoop {
           }
         }
 
-        // Resolve tools for this turn: use the dynamic resolver if provided,
-        // otherwise fall back to the static tool list.
-        const currentTools = this.resolveTools
-          ? this.resolveTools(history)
-          : this.tools;
-
         // Resolve system prompt, per-turn maxTokens, and model
         const resolved = this.resolveSystemPrompt
           ? this.resolveSystemPrompt(history)
@@ -1315,6 +1317,86 @@ export class AgentLoop {
           }
         }
 
+        // A `pre-model-call` hook (below) can defer this turn's assistant
+        // output; when set, the live text stream is held so a
+        // `post-model-call` hook can emit the finalized (transformed) text
+        // instead. Reset per model call. Declared before the hook runs so the
+        // streaming `onEvent` closure (built after) reads the resolved value.
+        let deferAssistantOutput = false;
+
+        // Set once any visible assistant text reaches the client live this
+        // model call. A deferred turn holds the live stream and a turn the
+        // model leaves visibly empty streams nothing, so this stays false for
+        // both — letting the loop surface the finalized text exactly once when
+        // the client would otherwise see nothing.
+        let streamedVisibleText = false;
+
+        // Run the `pre-model-call` hook chain BEFORE resolving the offered
+        // tools and the media-marker rewrite below, so both observe the FINAL
+        // backbone: a model-router hook can re-route this call's inference
+        // profile, and the vision feature's two gates (offer the vlm_* tools;
+        // strip media to `media_ref` markers) must key on the model that
+        // actually runs, not the pre-routing profile. Let plugins edit the
+        // outbound system prompt and opt this call into deferred output
+        // streaming. Runs for every provider call; hooks self-gate on call
+        // site / conversation. Fail-open: a throwing hook leaves the request
+        // unchanged and streaming live.
+        let turnSystemPromptForCall: string | undefined = turnSystemPrompt;
+        try {
+          const preModelCtx: PreModelCallContext = {
+            conversationId: this.conversationId,
+            callSite: callSite ?? null,
+            systemPrompt: turnSystemPrompt ?? null,
+            modelProfile: effectiveOverrideProfile ?? null,
+            deferAssistantOutput: false,
+            logger: rlog,
+          };
+          const finalPreModelCtx = await runHook(
+            HOOKS.PRE_MODEL_CALL,
+            preModelCtx,
+          );
+          turnSystemPromptForCall = finalPreModelCtx.systemPrompt ?? undefined;
+          // Route this call to the hook's chosen inference profile. The
+          // resolver layers `llm.profiles[overrideProfile]` at the top of
+          // precedence for the user-facing call, so a model router can pick
+          // the profile per message; clearing it drops any seeded override.
+          const hookModelProfile = finalPreModelCtx.modelProfile?.trim();
+          if (hookModelProfile) {
+            providerConfig.overrideProfile = hookModelProfile;
+            if (forceOverrideProfile) {
+              providerConfig.forceOverrideProfile = true;
+            }
+          } else {
+            delete providerConfig.overrideProfile;
+            delete providerConfig.forceOverrideProfile;
+          }
+          // The hook owns the policy (it sees `callSite`/conversation and
+          // self-gates); the loop honors whatever it decides.
+          deferAssistantOutput = finalPreModelCtx.deferAssistantOutput;
+        } catch (preModelCallError) {
+          rlog.error(
+            { err: preModelCallError },
+            "pre-model-call hook failed — proceeding with the original request",
+          );
+        }
+
+        // The inference profile this call resolved to AFTER the hook chain —
+        // the hook's choice when it routed, else the call's seeded override.
+        // Both vision gates below (tool offer + marker rewrite) and the tool
+        // resolver key on this so they reflect the backbone that actually
+        // runs. `string | null`: `null` means "no override, use the workspace
+        // active profile" — distinct from `undefined` ("no router decision").
+        const routedOverrideProfile: string | null =
+          (providerConfig.overrideProfile as string | undefined) ?? null;
+
+        // Resolve tools for this turn: use the dynamic resolver if provided,
+        // otherwise fall back to the static tool list. Passing the routed
+        // profile gates the per-turn profile-dependent tools (vlm_*, advisor)
+        // on the FINAL backbone.
+        const currentTools = this.resolveTools
+          ? this.resolveTools(history, routedOverrideProfile)
+          : this.tools;
+
         // Rate-limit consecutive LLM calls to prevent spin when tools return instantly
         const minInterval = this.config.minTurnIntervalMs ?? 0;
         if (minInterval > 0 && lastLlmCallTime > 0) {
@@ -1355,18 +1437,12 @@ export class AgentLoop {
         // media natively (`supportsVision === false`), so the model never
         // receives raw bytes it cannot read and instead reaches for the vlm_*
         // tools. A vision-capable backbone leaves all media intact (inert).
-        //
-        // TODO(vision-perception): this resolves `supportsVision` from
-        // `effectiveOverrideProfile`, computed BEFORE the pre-model-call hooks
-        // below run. A model-router hook can re-route `ctx.modelProfile`
-        // afterwards, so the marker decision can diverge from the FINAL routed
-        // backbone. Moving this rewrite after the hook chain needs a larger loop
-        // restructure (the rewrite feeds `providerHistory` into the same call the
-        // hooks decorate) — deferred. Same limitation applies to the wire tool
-        // gate in conversation-tool-setup.ts, fixed before the hooks run.
+        // Keyed on the routed profile resolved above so the marker decision
+        // matches the FINAL backbone the `pre-model-call` hook chain selected.
+        // Operates on a fresh sanitized COPY — durable history is never mutated.
         const visionMarkerOpts = {
           callSite: callSite ?? null,
-          overrideProfile: effectiveOverrideProfile ?? null,
+          overrideProfile: routedOverrideProfile,
           selectionSeed: this.conversationId ?? null,
         };
         const providerHistory = applyVisionPerceptionMarkers(
@@ -1374,25 +1450,12 @@ export class AgentLoop {
           resolveBackboneSupportsVision(visionMarkerOpts),
         );
 
-        // A `pre-model-call` hook (below) can defer this turn's assistant
-        // output; when set, the live text stream is held so an
-        // `post-model-call` hook can emit the finalized (transformed) text
-        // instead. Reset per model call.
-        let deferAssistantOutput = false;
-
-        // Set once any visible assistant text reaches the client live this
-        // model call. A deferred turn holds the live stream and a turn the
-        // model leaves visibly empty streams nothing, so this stays false for
-        // both — letting the loop surface the finalized text exactly once when
-        // the client would otherwise see nothing.
-        let streamedVisibleText = false;
-
         // The `onEvent` wrapping below applies sensitive-output placeholder
         // substitution to streamed text while forwarding every other event
         // type through unchanged.
         const providerOptions: SendMessageOptions = {
           tools: currentTools.length > 0 ? currentTools : undefined,
-          systemPrompt: turnSystemPrompt,
+          systemPrompt: turnSystemPromptForCall,
           config: providerConfig,
           onEvent: (event) => {
             if (event.type === "text_delta") {
@@ -1455,49 +1518,6 @@ export class AgentLoop {
           },
           signal,
         };
-
-        // Let plugins edit the outbound request and opt this call into deferred
-        // output streaming. Runs for every provider call; hooks self-gate on
-        // call site / conversation. Fail-open: a throwing hook leaves the
-        // request unchanged and streaming live.
-        try {
-          const preModelCtx: PreModelCallContext = {
-            conversationId: this.conversationId,
-            callSite: callSite ?? null,
-            systemPrompt: providerOptions.systemPrompt ?? null,
-            modelProfile: effectiveOverrideProfile ?? null,
-            deferAssistantOutput: false,
-            logger: rlog,
-          };
-          const finalPreModelCtx = await runHook(
-            HOOKS.PRE_MODEL_CALL,
-            preModelCtx,
-          );
-          providerOptions.systemPrompt =
-            finalPreModelCtx.systemPrompt ?? undefined;
-          // Route this call to the hook's chosen inference profile. The
-          // resolver layers `llm.profiles[overrideProfile]` at the top of
-          // precedence for the user-facing call, so a model router can pick
-          // the profile per message; clearing it drops any seeded override.
-          const hookModelProfile = finalPreModelCtx.modelProfile?.trim();
-          if (hookModelProfile) {
-            providerConfig.overrideProfile = hookModelProfile;
-            if (forceOverrideProfile) {
-              providerConfig.forceOverrideProfile = true;
-            }
-          } else {
-            delete providerConfig.overrideProfile;
-            delete providerConfig.forceOverrideProfile;
-          }
-          // The hook owns the policy (it sees `callSite`/conversation and
-          // self-gates); the loop honors whatever it decides.
-          deferAssistantOutput = finalPreModelCtx.deferAssistantOutput;
-        } catch (preModelCallError) {
-          rlog.error(
-            { err: preModelCallError },
-            "pre-model-call hook failed — proceeding with the original request",
-          );
-        }
 
         // Announce the LLM-call boundary so downstream handlers (the
         // daemon's persistence pipeline) can reserve an empty assistant row

--- a/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
@@ -825,7 +825,10 @@ describe("isToolActiveForContext — vlm_* gate keys on the routed profile", () 
     expect(backboneResolutionProfiles).toEqual(["balanced"]);
   });
 
-  test("the advisor gate also keys on the routed profile when one is forwarded", () => {
+  test("the advisor gate is NOT routed — it stays on the per-turn override even when a routed profile is forwarded", () => {
+    // The advisor's steering hook and execution-time guard both key on the
+    // pre-routing profile, so the wire gate must too: routing it would expose a
+    // tool that no-ops on call (or hide one the model was steered toward).
     advisorGateResult = true;
     advisorGateProfiles.length = 0;
     isToolActiveForContext(
@@ -833,6 +836,6 @@ describe("isToolActiveForContext — vlm_* gate keys on the routed profile", () 
       makeCtx({ currentTurnOverrideProfile: "balanced" }),
       "routed-profile",
     );
-    expect(advisorGateProfiles).toEqual(["routed-profile"]);
+    expect(advisorGateProfiles).toEqual(["balanced"]);
   });
 });

--- a/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
@@ -73,6 +73,10 @@ let backboneSupportsVision = false;
 // Whether the visionPerception call site resolves to an enabled vision-capable
 // provider (false in the BYOK-disabled-vision-profile case).
 let visionProviderAvailable = true;
+// Records the `overrideProfile` every `resolveBackboneSupportsVision` call sees,
+// so a test can assert which profile the vlm_* gate resolved the backbone from
+// (the routed profile when the loop forwards one, else the per-turn override).
+const backboneResolutionProfiles: (string | null)[] = [];
 
 // Only the flag predicate is stubbed (it ignores its config argument), so the
 // real `getConfig()` runs untouched and other importers of config/loader keep
@@ -89,7 +93,12 @@ mock.module(
   "../../plugins/defaults/vision-perception/hooks/pre-model-call.js",
   () => ({
     ...realPreModelCall,
-    resolveBackboneSupportsVision: () => backboneSupportsVision,
+    resolveBackboneSupportsVision: (opts: {
+      overrideProfile: string | null;
+    }) => {
+      backboneResolutionProfiles.push(opts.overrideProfile);
+      return backboneSupportsVision;
+    },
   }),
 );
 // Stub the BYOK availability check (the visionPerception provider resolution).
@@ -127,6 +136,7 @@ beforeEach(() => {
   visionFlagEnabled = true;
   backboneSupportsVision = false;
   visionProviderAvailable = true;
+  backboneResolutionProfiles.length = 0;
 });
 
 describe("isToolActiveForContext — Slack task_progress UI exception", () => {
@@ -787,5 +797,42 @@ describe("isToolActiveForContext — vlm_* BYOK provider guard", () => {
     for (const name of ALL_VLM_TOOLS) {
       expect(isToolActiveForContext(name, ctx)).toBe(false);
     }
+  });
+});
+
+describe("isToolActiveForContext — vlm_* gate keys on the routed profile", () => {
+  test("a routed override profile is forwarded to the backbone resolver over the per-turn override", () => {
+    // The loop passes the FINAL post-pre-model-call profile as the third arg.
+    // The vlm_* gate must resolve the backbone from THAT, not the conversation's
+    // pre-routing per-turn override.
+    backboneSupportsVision = false;
+    const ctx = makeCtx({ currentTurnOverrideProfile: "balanced" });
+    isToolActiveForContext("vlm_ask", ctx, "glm-text-only");
+    expect(backboneResolutionProfiles).toEqual(["glm-text-only"]);
+  });
+
+  test("an explicit null routed profile (router resolved no override) wins over the per-turn override", () => {
+    backboneSupportsVision = false;
+    const ctx = makeCtx({ currentTurnOverrideProfile: "vision" });
+    isToolActiveForContext("vlm_ask", ctx, null);
+    expect(backboneResolutionProfiles).toEqual([null]);
+  });
+
+  test("omitting the routed profile falls back to the per-turn override", () => {
+    backboneSupportsVision = false;
+    const ctx = makeCtx({ currentTurnOverrideProfile: "balanced" });
+    isToolActiveForContext("vlm_ask", ctx);
+    expect(backboneResolutionProfiles).toEqual(["balanced"]);
+  });
+
+  test("the advisor gate also keys on the routed profile when one is forwarded", () => {
+    advisorGateResult = true;
+    advisorGateProfiles.length = 0;
+    isToolActiveForContext(
+      "advisor",
+      makeCtx({ currentTurnOverrideProfile: "balanced" }),
+      "routed-profile",
+    );
+    expect(advisorGateProfiles).toEqual(["routed-profile"]);
   });
 });

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -556,11 +556,28 @@ export const SUBAGENT_ONLY_TOOL_NAMES = new Set<string>([
  * current turn. This helper mirrors the filtering applied by
  * `createResolveToolsCallback` — including the subagent allowlist,
  * `toolsDisabledDepth`, and disk-pressure cleanup restrictions.
+ *
+ * `routedOverrideProfile` (when not `undefined`) is the inference profile a
+ * `pre-model-call` model-router resolved for THIS turn, used in place of
+ * `ctx.currentTurnOverrideProfile` for the profile-dependent gates (advisor,
+ * vlm_*) so the offered tool surface reflects the backbone that actually runs
+ * — not the pre-routing profile. `null` means "router resolved no override"
+ * (use the workspace active profile); `undefined` means "no router decision"
+ * (fall back to the per-turn override the conversation carries). The agent
+ * loop passes it after the hook chain resolves; every other caller omits it.
  */
 export function isToolActiveForContext(
   name: string,
   ctx: SkillProjectionContext,
+  routedOverrideProfile?: string | null,
 ): boolean {
+  // Profile the per-turn profile-dependent gates (advisor, vlm_*) resolve the
+  // backbone from. A router decision (even an explicit `null`) wins over the
+  // conversation's per-turn override; absent any decision the override holds.
+  const effectiveOverrideProfile =
+    routedOverrideProfile !== undefined
+      ? routedOverrideProfile
+      : (ctx.currentTurnOverrideProfile ?? null);
   // Execution-gate-mode wakes pin the client-context inputs so the wire tool
   // surface matches the SOURCE conversation's live turns rather than the
   // fork's clientless hydration (see {@link WakeToolContextPin}). When the
@@ -610,11 +627,9 @@ export function isToolActiveForContext(
     // Gated per chat-profile (`ProfileEntry.advisorEnabled`): when the resolved
     // profile disables the advisor, omit the tool from the wire list so the
     // model never sees a tool it can only no-op on. Resolves the profile the
-    // same way the advisor's execution-time guard does (the per-turn override,
-    // else the active profile). The wire list is fixed before PRE_MODEL_CALL
-    // hooks run, so a hook that re-routes the profile mid-turn (the model-router
-    // lever on `PreModelCallContext.modelProfile`) is not reflected here.
-    return advisorEnabledForProfile(ctx.currentTurnOverrideProfile ?? null);
+    // same way the advisor's execution-time guard does — the router's decision
+    // for this turn when present, else the per-turn override / active profile.
+    return advisorEnabledForProfile(effectiveOverrideProfile);
   }
   if (isVlmToolName(name)) {
     // The plugin now registers unconditionally (its tools are always in the
@@ -633,7 +648,7 @@ export function isToolActiveForContext(
 
     const resolution = {
       callSite: ctx.currentCallSite ?? null,
-      overrideProfile: ctx.currentTurnOverrideProfile ?? null,
+      overrideProfile: effectiveOverrideProfile,
       selectionSeed: ctx.conversationId ?? null,
     };
 
@@ -641,8 +656,8 @@ export function isToolActiveForContext(
     // backbone, so ALL vlm_* tools (vlm_ask/describe/ocr/detect/video_log) are
     // offered together only when the resolved backbone cannot see media natively
     // (`supportsVision === false`) — and withheld together for any vision-capable
-    // backbone. Resolves the backbone the same way dispatch does (the per-turn
-    // override, else the active profile / call-site default).
+    // backbone. Resolves the backbone the same way dispatch does (the router's
+    // decision for this turn, else the per-turn override / call-site default).
     if (resolveBackboneSupportsVision(resolution)) return false;
 
     // BYOK guard: only offer the tools when the visionPerception call site
@@ -738,7 +753,12 @@ export function isToolActiveForContext(
 export function createResolveToolsCallback(
   toolDefs: ToolDefinition[],
   ctx: SkillProjectionContext,
-): ((history: Message[]) => ToolDefinition[]) | undefined {
+):
+  | ((
+      history: Message[],
+      routedOverrideProfile?: string | null,
+    ) => ToolDefinition[])
+  | undefined {
   if (toolDefs.length === 0) return undefined;
 
   // Separate the initial tool defs into core (stable) and MCP (dynamic).
@@ -755,7 +775,13 @@ export function createResolveToolsCallback(
     "Conversation tool resolver initialized",
   );
 
-  return (history: Message[]) => {
+  // `routedOverrideProfile`, when supplied by the agent loop after the
+  // `pre-model-call` hook chain runs, is the inference profile a model-router
+  // resolved for this turn. It replaces `ctx.currentTurnOverrideProfile` for
+  // the profile-dependent wire gates (advisor, vlm_*) so the offered tools
+  // reflect the backbone that actually runs. `undefined` (every other caller)
+  // keeps the conversation's per-turn override.
+  return (history: Message[], routedOverrideProfile?: string | null) => {
     // When tools are explicitly disabled (e.g. during pointer generation),
     // return an empty tool list so the LLM never sees tool definitions and
     // keep the allowlist empty so no tool execution can slip through.
@@ -768,7 +794,7 @@ export function createResolveToolsCallback(
     // irrelevant to this turn (e.g. UI tools when no client is connected)
     // are omitted from the definitions sent to the provider.
     const filteredCoreDefs = coreToolDefs.filter((d) =>
-      isToolActiveForContext(d.name, ctx),
+      isToolActiveForContext(d.name, ctx, routedOverrideProfile),
     );
 
     // When the conversation is acting as a subagent, restrict core tools to

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -558,23 +558,30 @@ export const SUBAGENT_ONLY_TOOL_NAMES = new Set<string>([
  * `toolsDisabledDepth`, and disk-pressure cleanup restrictions.
  *
  * `routedOverrideProfile` (when not `undefined`) is the inference profile a
- * `pre-model-call` model-router resolved for THIS turn, used in place of
- * `ctx.currentTurnOverrideProfile` for the profile-dependent gates (advisor,
- * vlm_*) so the offered tool surface reflects the backbone that actually runs
- * — not the pre-routing profile. `null` means "router resolved no override"
- * (use the workspace active profile); `undefined` means "no router decision"
- * (fall back to the per-turn override the conversation carries). The agent
- * loop passes it after the hook chain resolves; every other caller omits it.
+ * `pre-model-call` model-router resolved for THIS turn. It is consulted only by
+ * the vlm_* gate, whose backbone capability is re-resolved per provider call so
+ * the offered vision tools match the model that actually runs — not the
+ * pre-routing profile. `null` means "router resolved no override" (use the
+ * workspace active profile); `undefined` means "no router decision" (fall back
+ * to the per-turn override the conversation carries). The agent loop passes it
+ * after the hook chain resolves; every other caller omits it.
+ *
+ * The advisor gate is intentionally NOT routed: the advisor's steering
+ * (`pre-model-call`) and execution (`ctx.overrideProfile`) paths still key on
+ * the pre-routing per-turn override, so its wire gate must stay on the same
+ * profile to avoid offering a tool that no-ops on call (or steering for a tool
+ * the wire hid). Plumbing the routed profile through those paths is a separate
+ * change.
  */
 export function isToolActiveForContext(
   name: string,
   ctx: SkillProjectionContext,
   routedOverrideProfile?: string | null,
 ): boolean {
-  // Profile the per-turn profile-dependent gates (advisor, vlm_*) resolve the
-  // backbone from. A router decision (even an explicit `null`) wins over the
-  // conversation's per-turn override; absent any decision the override holds.
-  const effectiveOverrideProfile =
+  // Profile the vlm_* gate resolves the backbone from. A router decision (even
+  // an explicit `null`) wins over the conversation's per-turn override; absent
+  // any decision the override holds.
+  const vlmOverrideProfile =
     routedOverrideProfile !== undefined
       ? routedOverrideProfile
       : (ctx.currentTurnOverrideProfile ?? null);
@@ -627,9 +634,11 @@ export function isToolActiveForContext(
     // Gated per chat-profile (`ProfileEntry.advisorEnabled`): when the resolved
     // profile disables the advisor, omit the tool from the wire list so the
     // model never sees a tool it can only no-op on. Resolves the profile the
-    // same way the advisor's execution-time guard does — the router's decision
-    // for this turn when present, else the per-turn override / active profile.
-    return advisorEnabledForProfile(effectiveOverrideProfile);
+    // same way the advisor's execution-time guard and steering hook do — the
+    // per-turn override, else the active profile. Deliberately NOT routed (see
+    // the function doc): the wire gate must match steering + execution, which
+    // both still read the pre-routing profile.
+    return advisorEnabledForProfile(ctx.currentTurnOverrideProfile ?? null);
   }
   if (isVlmToolName(name)) {
     // The plugin now registers unconditionally (its tools are always in the
@@ -648,7 +657,7 @@ export function isToolActiveForContext(
 
     const resolution = {
       callSite: ctx.currentCallSite ?? null,
-      overrideProfile: effectiveOverrideProfile,
+      overrideProfile: vlmOverrideProfile,
       selectionSeed: ctx.conversationId ?? null,
     };
 


### PR DESCRIPTION
## Summary
Vision tool gating + marker rewrite now use the FINAL backbone profile after pre-model-call hooks resolve routing, so a per-turn model-router can't desync the vision decision from the model that actually runs. No behavior change for a fixed GLM-5.2 backbone.

Part of plan: glm-5v-turbo-vlm-tool (Codex router-ordering P2)