### PR TITLE
fix(plugins): conversation-scoped media_ref + gate sync + profileOrder reconcile

### DIFF
--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -29,6 +29,7 @@ import {
   getAttachmentsByIds,
   getAttachmentsForMessage,
   getFilePathForAttachment,
+  isAttachmentInConversation,
   isValidBase64,
   linkAttachmentToMessage,
   MAX_UPLOAD_BYTES,
@@ -464,6 +465,51 @@ describe("linkAttachmentToMessage + getAttachmentsForMessage", () => {
 
     const linked = getAttachmentsForMessage(msg.id);
     expect(linked).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isAttachmentInConversation — cross-conversation access-control check
+// ---------------------------------------------------------------------------
+
+describe("isAttachmentInConversation", () => {
+  beforeEach(resetTables);
+
+  test("returns true for an attachment linked to the given conversation", async () => {
+    const conv = createConversation();
+    const msg = await addMessage(conv.id, "user", "Here is a photo");
+    const stored = uploadAttachment("photo.png", "image/png", "iVBORw0K");
+    const linkedId = linkAttachmentToMessage(msg.id, stored.id, 0);
+
+    expect(isAttachmentInConversation(linkedId, conv.id)).toBe(true);
+  });
+
+  test("returns false for an attachment linked to a DIFFERENT conversation", async () => {
+    // An attachment that belongs to conversation A must not be readable when the
+    // caller is scoped to conversation B — the cross-conversation leak guard.
+    const convA = createConversation();
+    const msgA = await addMessage(convA.id, "user", "A's photo");
+    const stored = uploadAttachment("a.png", "image/png", "iVBORw0K");
+    const linkedId = linkAttachmentToMessage(msgA.id, stored.id, 0);
+
+    const convB = createConversation();
+
+    expect(isAttachmentInConversation(linkedId, convB.id)).toBe(false);
+  });
+
+  test("returns false for a staged (unlinked) attachment", () => {
+    const conv = createConversation();
+    // Uploaded but never linked to a message → not in any conversation.
+    const stored = uploadAttachment("staged.png", "image/png", "iVBORw0K");
+
+    expect(isAttachmentInConversation(stored.id, conv.id)).toBe(false);
+  });
+
+  test("returns false for a nonexistent id or empty inputs", async () => {
+    const conv = createConversation();
+    expect(isAttachmentInConversation("no-such-id", conv.id)).toBe(false);
+    expect(isAttachmentInConversation("", conv.id)).toBe(false);
+    expect(isAttachmentInConversation("some-id", "")).toBe(false);
   });
 });
 

--- a/assistant/src/__tests__/inline-upload-media-ref.test.ts
+++ b/assistant/src/__tests__/inline-upload-media-ref.test.ts
@@ -40,10 +40,25 @@ mock.module("../memory/conversation-disk-view.js", () => ({
   updateMetaFile: () => {},
 }));
 
+// Re-link controls: when `existingAttachmentIds` contains the attachment id,
+// the persist path takes the "already exists" branch and calls
+// `linkAttachmentToMessage`, which returns the conversation-scoped id (possibly
+// cloned to a new id). `linkScopedIds` maps the source id to the scoped id the
+// link returns; absent → returns the source id unchanged.
+let existingAttachmentIds = new Set<string>();
+let linkScopedIds: Record<string, string> = {};
+const linkCalls: Array<{ attachmentId: string; position: number }> = [];
+
 mock.module("../memory/attachments-store.js", () => ({
-  // No attachment exists yet — this is an inline upload, not a re-link.
-  attachmentExists: () => false,
-  linkAttachmentToMessage: () => {},
+  attachmentExists: (id: string) => existingAttachmentIds.has(id),
+  linkAttachmentToMessage: (
+    _messageId: string,
+    attachmentId: string,
+    position: number,
+  ) => {
+    linkCalls.push({ attachmentId, position });
+    return linkScopedIds[attachmentId] ?? attachmentId;
+  },
   validateAttachmentUpload: () => ({ ok: true }),
   AttachmentUploadError: class extends Error {},
   attachInlineAttachmentToMessage: (messageId: string, position: number) => {
@@ -97,6 +112,9 @@ describe("Codex P2 — inline upload media_ref", () => {
   beforeEach(() => {
     nextAttachmentId = 0;
     inlineAttachCalls.length = 0;
+    linkCalls.length = 0;
+    existingAttachmentIds = new Set<string>();
+    linkScopedIds = {};
   });
 
   test("backfills the minted attachment id onto the in-memory image block", async () => {
@@ -147,5 +165,77 @@ describe("Codex P2 — inline upload media_ref", () => {
     expect(marker).toBeDefined();
     expect(marker!.text).toContain('id="att-0"');
     expect(marker!.text).toContain('media_ref="att-0"');
+  });
+
+  test("re-shared attachment: the scoped id replaces the source id on the in-memory block", async () => {
+    // A previously-uploaded attachment ("src-att", existing in the store) is
+    // re-shared into this conversation. Linking scopes it to the conversation
+    // and clones it to a new id ("scoped-att"). The in-memory block — built with
+    // the source id — must be re-tagged to the scoped id so a surfaced media_ref
+    // resolves under the current conversation rather than the original one.
+    existingAttachmentIds = new Set(["src-att"]);
+    linkScopedIds = { "src-att": "scoped-att" };
+
+    const ctx = createContext();
+    await persistQueuedMessageBody(ctx, {
+      content: "look again",
+      attachments: [
+        // Re-link: content lives on disk, so `data` is empty.
+        {
+          id: "src-att",
+          filename: "shared.jpg",
+          mimeType: "image/jpeg",
+          data: "",
+        },
+      ],
+      requestId: "req-relink",
+    });
+
+    // The link was taken via the "already exists" branch.
+    expect(linkCalls).toEqual([{ attachmentId: "src-att", position: 0 }]);
+
+    const imageBlock = ctx.messages
+      .at(-1)!
+      .content.find((b) => b.type === "image") as ImageContent;
+    expect(imageBlock).toBeDefined();
+    // The block now points at the conversation-scoped id, not the source id.
+    expect(imageBlock._attachmentId).toBe("scoped-att");
+
+    // The marker the non-vision backbone surfaces uses the scoped id.
+    const rewritten = applyVisionPerceptionMarkers(ctx.messages, false);
+    const marker = rewritten
+      .at(-1)!
+      .content.find(
+        (b) => b.type === "text" && b.text.includes("media_ref="),
+      ) as { type: "text"; text: string } | undefined;
+    expect(marker).toBeDefined();
+    expect(marker!.text).toContain('media_ref="scoped-att"');
+    expect(marker!.text).not.toContain('media_ref="src-att"');
+  });
+
+  test("re-shared attachment already in this conversation: id is left unchanged", async () => {
+    // When linking returns the same id (the attachment already belongs to this
+    // conversation, no clone), the in-memory block keeps that id.
+    existingAttachmentIds = new Set(["same-att"]);
+    linkScopedIds = {}; // returns the source id unchanged
+
+    const ctx = createContext();
+    await persistQueuedMessageBody(ctx, {
+      content: "again",
+      attachments: [
+        {
+          id: "same-att",
+          filename: "shared.jpg",
+          mimeType: "image/jpeg",
+          data: "",
+        },
+      ],
+      requestId: "req-relink-same",
+    });
+
+    const imageBlock = ctx.messages
+      .at(-1)!
+      .content.find((b) => b.type === "image") as ImageContent;
+    expect(imageBlock._attachmentId).toBe("same-att");
   });
 });

--- a/assistant/src/__tests__/loop-vision-routing.test.ts
+++ b/assistant/src/__tests__/loop-vision-routing.test.ts
@@ -26,8 +26,9 @@ import type {
 } from "../providers/types.js";
 import { createMockProvider, textResponse } from "./helpers/mock-provider.js";
 
-// Vision flag on; BYOK provider available — so the only lever left is the
-// resolved backbone's vision capability, which we drive per routed profile.
+// Vision flag on; BYOK provider availability is a per-test lever (defaults
+// available) so we can exercise the unavailable-provider gate too.
+let visionProviderAvailable = true;
 mock.module("../config/vision-perception-flag.js", () => ({
   isVisionPerceptionEnabled: () => true,
   VISION_PERCEPTION_FLAG_KEY: "vision-perception",
@@ -35,23 +36,30 @@ mock.module("../config/vision-perception-flag.js", () => ({
 mock.module(
   "../plugins/defaults/vision-perception/src/vision-capability.js",
   () => ({
-    isVisionPerceptionProviderAvailable: () => true,
+    isVisionPerceptionProviderAvailable: () => visionProviderAvailable,
     VISION_CALL_SITE: "visionPerception",
   }),
 );
 
 // Profile-driven backbone capability: "vision" → vision-capable (feature
-// inert), "glm-text-only" (and null/unknown) → text-only (feature engages).
-// Keep every other export of the module real so the marker rewrite and the
-// vlm_* name predicate run for real.
+// inert), "glm-text-only" (and null/unknown) → text-only. Both per-turn gates
+// (tool offer + marker rewrite) key on the shared `isVisionPerceptionActiveForTurn`
+// predicate, which we model here as "text-only backbone AND provider available"
+// — exactly the real composition. Keep every other export of the module real so
+// the marker rewrite and the vlm_* name predicate run for real.
 const realVisionModule =
   await import("../plugins/defaults/vision-perception/hooks/pre-model-call.js");
+const resolveBackboneSupportsVision = (opts: {
+  overrideProfile: string | null;
+}) => opts.overrideProfile === "vision";
 mock.module(
   "../plugins/defaults/vision-perception/hooks/pre-model-call.js",
   () => ({
     ...realVisionModule,
-    resolveBackboneSupportsVision: (opts: { overrideProfile: string | null }) =>
-      opts.overrideProfile === "vision",
+    resolveBackboneSupportsVision,
+    isVisionPerceptionActiveForTurn: (opts: {
+      overrideProfile: string | null;
+    }) => !resolveBackboneSupportsVision(opts) && visionProviderAvailable,
   }),
 );
 
@@ -133,6 +141,7 @@ function markerTextOf(messages: Message[]): string {
 
 describe("agent loop — vision gating uses the final routed profile", () => {
   beforeEach(() => {
+    visionProviderAvailable = true;
     resetPluginRegistryAndRegisterDefaults();
   });
 
@@ -238,5 +247,42 @@ describe("agent loop — vision gating uses the final routed profile", () => {
     expect(toolNames).toContain("vlm_ask");
     expect(imageBlocksOf(calls[0].messages)).toHaveLength(0);
     expect(markerTextOf(calls[0].messages)).toContain('media_ref="att-1"');
+  });
+
+  test("text-only backbone but provider UNAVAILABLE — vlm_* NOT offered AND no markers injected", async () => {
+    // BYOK with the managed vision profile disabled: the visionPerception call
+    // site does not resolve to an enabled vision-capable provider, so the tool
+    // offer is withheld. The marker rewrite must gate on the SAME predicate —
+    // otherwise the model would get a marker pointing at a tool it never got.
+    visionProviderAvailable = false;
+    const { provider, calls } = createMockProvider([textResponse("done")]);
+    const recorded: { routedProfile?: string | null } = {};
+
+    const loop = new AgentLoop({
+      provider,
+      systemPrompt: "system",
+      conversationId: "vision-routing-itest",
+      tools: ALL_TOOLS,
+      resolveTools: makeResolveTools(recorded),
+    });
+
+    await loop.run({
+      requestId: "req-4",
+      messages: [imageUserMessage()],
+      onEvent: () => {},
+      callSite: "mainAgent",
+      overrideProfile: "glm-text-only",
+      trust: { sourceChannel: "vellum", trustClass: "unknown" },
+    });
+
+    expect(calls).toHaveLength(1);
+    // Tool gate: vlm_* withheld because no vision-capable provider resolves.
+    const toolNames = (calls[0].tools ?? []).map((t) => t.name);
+    expect(toolNames).not.toContain("vlm_ask");
+    expect(toolNames).toContain("read_file");
+    // Marker rewrite stays in sync: the raw image is left intact (NOT stripped
+    // to a marker that would reference a tool the model was never offered).
+    expect(imageBlocksOf(calls[0].messages)).toHaveLength(1);
+    expect(markerTextOf(calls[0].messages)).not.toContain("media_ref");
   });
 });

--- a/assistant/src/agent/attachments.test.ts
+++ b/assistant/src/agent/attachments.test.ts
@@ -33,7 +33,7 @@ mock.module("../config/assistant-feature-flags.js", () => ({
   isAssistantFeatureFlagEnabled: () => true,
 }));
 
-const { rehydrateAttachmentIds, backfillAttachmentId } =
+const { rehydrateAttachmentIds, backfillAttachmentId, retagAttachmentId } =
   await import("./attachments.js");
 const { applyVisionPerceptionMarkers } =
   await import("../plugins/defaults/vision-perception/hooks/pre-model-call.js");
@@ -157,6 +157,34 @@ describe("rehydrateAttachmentIds", () => {
       { position: 2, attachmentId: "vid-0" },
     ]);
     expect((message.content[0] as ImageContent)._attachmentId).toBe("att-0");
+  });
+});
+
+describe("retagAttachmentId vs backfillAttachmentId", () => {
+  test("retagAttachmentId overwrites an existing id (the conversation-scoped id)", () => {
+    const block = imageBlock();
+    block._attachmentId = "source-id";
+    const message: Message = { role: "user", content: [block] };
+
+    retagAttachmentId(message, 0, "scoped-id");
+    expect(block._attachmentId).toBe("scoped-id");
+  });
+
+  test("backfillAttachmentId leaves an existing id untouched (fills only a gap)", () => {
+    const block = imageBlock();
+    block._attachmentId = "source-id";
+    const message: Message = { role: "user", content: [block] };
+
+    backfillAttachmentId(message, 0, "scoped-id");
+    expect(block._attachmentId).toBe("source-id");
+  });
+
+  test("retagAttachmentId fills a gap when no id is present", () => {
+    const block = imageBlock();
+    const message: Message = { role: "user", content: [block] };
+
+    retagAttachmentId(message, 0, "scoped-id");
+    expect(block._attachmentId).toBe("scoped-id");
   });
 });
 

--- a/assistant/src/agent/attachments.ts
+++ b/assistant/src/agent/attachments.ts
@@ -65,13 +65,16 @@ function tagMediaBlockAtIndex(
   message: Message,
   mediaBlockIndex: number,
   attachmentId: string,
+  options?: { overwrite?: boolean },
 ): void {
   if (mediaBlockIndex < 0) return;
   let seen = 0;
   for (const block of message.content) {
     if (block.type !== "image" && block.type !== "file") continue;
     if (seen === mediaBlockIndex) {
-      if (!block._attachmentId) block._attachmentId = attachmentId;
+      if (options?.overwrite || !block._attachmentId) {
+        block._attachmentId = attachmentId;
+      }
       return;
     }
     seen++;
@@ -102,6 +105,28 @@ export function backfillAttachmentId(
   attachmentId: string,
 ): void {
   tagMediaBlockAtIndex(message, attachmentIndex, attachmentId);
+}
+
+/**
+ * Re-tag the in-memory content block for the `attachmentIndex`-th uploaded
+ * attachment with the conversation-scoped id, overwriting any existing id.
+ *
+ * When a previously-uploaded attachment is re-shared into a new conversation,
+ * linking it clones the row and mints a conversation-scoped id. The content
+ * block still carries the source id, which is not linked to the current
+ * conversation — a `media_ref` derived from it would fail the conversation-scope
+ * check. Overwriting the block with the scoped id keeps the surfaced
+ * `media_ref` resolvable in the current conversation. Unlike
+ * {@link backfillAttachmentId}, this overwrites rather than only filling a gap.
+ */
+export function retagAttachmentId(
+  message: Message,
+  attachmentIndex: number,
+  attachmentId: string,
+): void {
+  tagMediaBlockAtIndex(message, attachmentIndex, attachmentId, {
+    overwrite: true,
+  });
 }
 
 /** A linked attachment paired with its stored `message_attachments.position`. */

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -29,7 +29,7 @@ import { defaultCompact } from "../plugins/defaults/compaction/compact.js";
 import type { ContextWindowResult } from "../plugins/defaults/compaction/window-manager.js";
 import {
   applyVisionPerceptionMarkers,
-  resolveBackboneSupportsVision,
+  isVisionPerceptionActiveForTurn,
 } from "../plugins/defaults/vision-perception/hooks/pre-model-call.js";
 import { runHook } from "../plugins/pipeline.js";
 import type { CompactionCircuitEvent } from "../plugins/types.js";
@@ -1461,14 +1461,18 @@ export class AgentLoop {
         // Sanitize the outbound history right before sending: drop accumulated
         // media, collapse old AX-tree snapshots, and convert historical
         // web-search results to text. See {@link preModelCallSanitize}.
-        // Then, on a SINGLE capability gate, replace every uploaded image/video
-        // with a marker naming its attachment id when the backbone cannot see
-        // media natively (`supportsVision === false`), so the model never
-        // receives raw bytes it cannot read and instead reaches for the vlm_*
-        // tools. A vision-capable backbone leaves all media intact (inert).
-        // Keyed on the routed profile resolved above so the marker decision
-        // matches the FINAL backbone the `pre-model-call` hook chain selected.
-        // Operates on a fresh sanitized COPY — durable history is never mutated.
+        // Then, when vision perception is active for this turn, replace every
+        // uploaded image/video with a marker naming its attachment id, so the
+        // model never receives raw bytes it cannot read and instead reaches for
+        // the vlm_* tools. The activation predicate is shared with the tool gate
+        // ({@link isVisionPerceptionActiveForTurn}): markers are injected only
+        // when the backbone cannot see media natively AND the visionPerception
+        // call site resolves to an enabled vision-capable provider — so an
+        // unavailable provider never strips media and leaves the model with
+        // markers but no tools. Keyed on the routed profile resolved above so
+        // the decision matches the FINAL backbone the `pre-model-call` hook
+        // chain selected. Operates on a fresh sanitized COPY — durable history
+        // is never mutated.
         const visionMarkerOpts = {
           callSite: callSite ?? null,
           overrideProfile: routedOverrideProfile,
@@ -1476,7 +1480,7 @@ export class AgentLoop {
         };
         const providerHistory = applyVisionPerceptionMarkers(
           preModelCallSanitize(history),
-          resolveBackboneSupportsVision(visionMarkerOpts),
+          !isVisionPerceptionActiveForTurn(visionMarkerOpts),
         );
 
         // The `onEvent` wrapping below applies sensitive-output placeholder

--- a/assistant/src/config/__tests__/sync-gated-profiles.test.ts
+++ b/assistant/src/config/__tests__/sync-gated-profiles.test.ts
@@ -422,6 +422,40 @@ describe("reconcileFlagGatedProfiles", () => {
     expect(after.llm.profileOrder.includes("vision")).toBe(false);
   });
 
+  test("both gated profiles present + both flags off → neither name remains in profileOrder", () => {
+    // Regression: the reconcile loop captured `profileOrder` once and reassigned
+    // `llm.profileOrder` to a filtered COPY on each `disableProfile` call, so the
+    // loop kept holding the pre-removal snapshot. With BOTH managed profiles
+    // present and BOTH flags off, the second removal filtered the stale snapshot
+    // and reintroduced the first-deleted name. After the fix, removals filter the
+    // live order in place, so neither name survives.
+    process.env.IS_PLATFORM = "true";
+    seedBalancedConfig();
+    setOverridesForTesting({ "os-beta": true, "vision-perception": true });
+    expect(reconcileFlagGatedProfiles()).toBe(true);
+    invalidateConfigCache();
+
+    // Both managed profiles are materialized and ordered.
+    const seeded = readConfig();
+    expect(seeded.llm.profiles["os-beta"]).toBeDefined();
+    expect(seeded.llm.profiles["vision"]).toBeDefined();
+    expect(seeded.llm.profileOrder.includes("os-beta")).toBe(true);
+    expect(seeded.llm.profileOrder.includes("vision")).toBe(true);
+
+    // Both flags flip off in the same reconcile pass.
+    setOverridesForTesting({ "os-beta": false, "vision-perception": false });
+    expect(reconcileFlagGatedProfiles()).toBe(true);
+
+    const after = readConfig();
+    expect(after.llm.profiles["os-beta"]).toBeUndefined();
+    expect(after.llm.profiles["vision"]).toBeUndefined();
+    // Neither deleted name may linger in the order (the bug reintroduced one).
+    expect(after.llm.profileOrder.includes("os-beta")).toBe(false);
+    expect(after.llm.profileOrder.includes("vision")).toBe(false);
+
+    expect(LLMSchema.safeParse(after.llm).success).toBe(true);
+  });
+
   test("a user-owned vision profile is never touched", () => {
     process.env.IS_PLATFORM = "true";
     writeConfig({

--- a/assistant/src/config/__tests__/sync-gated-profiles.test.ts
+++ b/assistant/src/config/__tests__/sync-gated-profiles.test.ts
@@ -423,12 +423,9 @@ describe("reconcileFlagGatedProfiles", () => {
   });
 
   test("both gated profiles present + both flags off → neither name remains in profileOrder", () => {
-    // Regression: the reconcile loop captured `profileOrder` once and reassigned
-    // `llm.profileOrder` to a filtered COPY on each `disableProfile` call, so the
-    // loop kept holding the pre-removal snapshot. With BOTH managed profiles
-    // present and BOTH flags off, the second removal filtered the stale snapshot
-    // and reintroduced the first-deleted name. After the fix, removals filter the
-    // live order in place, so neither name survives.
+    // Removing both managed gated profiles in a single reconcile pass drops both
+    // names from `profileOrder`: each removal filters the live order, so the
+    // second removal sees the first removal's result and no deleted name lingers.
     process.env.IS_PLATFORM = "true";
     seedBalancedConfig();
     setOverridesForTesting({ "os-beta": true, "vision-perception": true });
@@ -449,7 +446,7 @@ describe("reconcileFlagGatedProfiles", () => {
     const after = readConfig();
     expect(after.llm.profiles["os-beta"]).toBeUndefined();
     expect(after.llm.profiles["vision"]).toBeUndefined();
-    // Neither deleted name may linger in the order (the bug reintroduced one).
+    // Neither removed name may linger in the order.
     expect(after.llm.profileOrder.includes("os-beta")).toBe(false);
     expect(after.llm.profileOrder.includes("vision")).toBe(false);
 

--- a/assistant/src/config/sync-gated-profiles.ts
+++ b/assistant/src/config/sync-gated-profiles.ts
@@ -221,11 +221,10 @@ function disableProfile(
     }
   }
 
-  // Filter in place so `llm.profileOrder` and the caller's `profileOrder`
-  // reference stay the same array across the reconcile loop. Reassigning to a
-  // fresh filtered copy would leave the loop holding the pre-removal snapshot,
-  // so a later removal in the same pass (both gated profiles present, both flags
-  // off) would filter the stale order and reintroduce an already-deleted name.
+  // Filter in place so `llm.profileOrder` and the caller's `profileOrder` are
+  // the same array reference across the reconcile loop: each removal sees the
+  // previous removal's result, so removing both gated profiles in one pass (both
+  // present, both flags off) leaves neither name in the order.
   const survivors = profileOrder.filter((name) => !removed.has(name));
   profileOrder.length = 0;
   profileOrder.push(...survivors);

--- a/assistant/src/config/sync-gated-profiles.ts
+++ b/assistant/src/config/sync-gated-profiles.ts
@@ -221,7 +221,14 @@ function disableProfile(
     }
   }
 
-  llm.profileOrder = profileOrder.filter((name) => !removed.has(name));
+  // Filter in place so `llm.profileOrder` and the caller's `profileOrder`
+  // reference stay the same array across the reconcile loop. Reassigning to a
+  // fresh filtered copy would leave the loop holding the pre-removal snapshot,
+  // so a later removal in the same pass (both gated profiles present, both flags
+  // off) would filter the stale order and reintroduce an already-deleted name.
+  const survivors = profileOrder.filter((name) => !removed.has(name));
+  profileOrder.length = 0;
+  profileOrder.push(...survivors);
 
   if (typeof llm.activeProfile === "string" && removed.has(llm.activeProfile)) {
     llm.activeProfile = "balanced";

--- a/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-tool-setup.test.ts
@@ -85,20 +85,27 @@ mock.module("../../config/vision-perception-flag.js", () => ({
   isVisionPerceptionEnabled: () => visionFlagEnabled,
   VISION_PERCEPTION_FLAG_KEY: "vision-perception",
 }));
-// Stub only the resolver; keep the real name predicate (isVlmToolName) so the
-// gate routing is exercised against the actual tool-name set.
+// Stub the resolver and the shared activation predicate (the tool gate calls the
+// latter directly); keep the real name predicate (isVlmToolName) so the gate
+// routing is exercised against the actual tool-name set. The shared predicate is
+// modeled here exactly as production composes it: text-only backbone (`!supports
+// Vision`) AND the visionPerception provider available.
 const realPreModelCall =
   await import("../../plugins/defaults/vision-perception/hooks/pre-model-call.js");
+const resolveBackboneSupportsVisionStub = (opts: {
+  overrideProfile: string | null;
+}) => {
+  backboneResolutionProfiles.push(opts.overrideProfile);
+  return backboneSupportsVision;
+};
 mock.module(
   "../../plugins/defaults/vision-perception/hooks/pre-model-call.js",
   () => ({
     ...realPreModelCall,
-    resolveBackboneSupportsVision: (opts: {
+    resolveBackboneSupportsVision: resolveBackboneSupportsVisionStub,
+    isVisionPerceptionActiveForTurn: (opts: {
       overrideProfile: string | null;
-    }) => {
-      backboneResolutionProfiles.push(opts.overrideProfile);
-      return backboneSupportsVision;
-    },
+    }) => !resolveBackboneSupportsVisionStub(opts) && visionProviderAvailable,
   }),
 );
 // Stub the BYOK availability check (the visionPerception provider resolution).

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -11,6 +11,7 @@ import {
   backfillAttachmentId,
   enrichMessageWithSourcePaths,
   type MessageAttachmentInput,
+  retagAttachmentId,
 } from "../agent/attachments.js";
 import { createUserMessage } from "../agent/message-types.js";
 import type {
@@ -580,7 +581,19 @@ export async function persistQueuedMessageBody(
         // re-uploading. This handles the case where data is empty because
         // the attachment content lives on disk.
         if (a.id && attachmentExists(a.id)) {
-          linkAttachmentToMessage(persistedUserMessage.id, a.id, i);
+          // Linking scopes the attachment to this conversation, cloning it
+          // (and minting a new id) when the source id belongs to another
+          // conversation. Backfill the scoped id onto the in-memory block so a
+          // media_ref the model surfaces resolves under the current
+          // conversation rather than the original (other-conversation) id.
+          const scopedId = linkAttachmentToMessage(
+            persistedUserMessage.id,
+            a.id,
+            i,
+          );
+          if (scopedId !== a.id) {
+            retagAttachmentId(llmMessage, i, scopedId);
+          }
           continue;
         }
 

--- a/assistant/src/daemon/conversation-tool-setup.ts
+++ b/assistant/src/daemon/conversation-tool-setup.ts
@@ -20,10 +20,9 @@ import type { PermissionPrompter } from "../permissions/prompter.js";
 import type { SecretPrompter } from "../permissions/secret-prompter.js";
 import { advisorEnabledForProfile } from "../plugins/defaults/advisor/advisor-gate.js";
 import {
+  isVisionPerceptionActiveForTurn,
   isVlmToolName,
-  resolveBackboneSupportsVision,
 } from "../plugins/defaults/vision-perception/hooks/pre-model-call.js";
-import { isVisionPerceptionProviderAvailable } from "../plugins/defaults/vision-perception/src/vision-capability.js";
 import type { Message, ToolDefinition } from "../providers/types.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { registerConversationSender } from "../tools/browser/browser-screencast.js";
@@ -661,20 +660,19 @@ export function isToolActiveForContext(
       selectionSeed: ctx.conversationId ?? null,
     };
 
-    // Single capability gate: the whole feature is a crutch for a text-only
-    // backbone, so ALL vlm_* tools (vlm_ask/describe/ocr/detect/video_log) are
-    // offered together only when the resolved backbone cannot see media natively
-    // (`supportsVision === false`) — and withheld together for any vision-capable
-    // backbone. Resolves the backbone the same way dispatch does (the router's
-    // decision for this turn, else the per-turn override / call-site default).
-    if (resolveBackboneSupportsVision(resolution)) return false;
-
-    // BYOK guard: only offer the tools when the visionPerception call site
-    // actually resolves to an enabled, vision-capable provider/model. In BYOK
-    // installs the managed `vision` profile is seeded disabled, so the call site
-    // can strip back to the user's (possibly non-vision) active profile — never
-    // offer a tool that would send image frames to a model that can't read them.
-    return isVisionPerceptionProviderAvailable();
+    // Shared activation predicate (also gates the agent loop's media-marker
+    // rewrite, so the tool offer and the marker injection can never drift): the
+    // whole feature is a crutch for a text-only backbone, so ALL vlm_* tools
+    // (vlm_ask/describe/ocr/detect/video_log) are offered together only when the
+    // resolved backbone cannot see media natively AND the visionPerception call
+    // site resolves to an enabled, vision-capable provider/model. The latter
+    // is the BYOK guard: in BYOK installs the managed `vision` profile is seeded
+    // disabled, so the call site can strip back to the user's (possibly
+    // non-vision) active profile — never offer a tool that would send image
+    // frames to a model that can't read them. Resolves the backbone the same way
+    // dispatch does (the router's decision for this turn, else the per-turn
+    // override / call-site default).
+    return isVisionPerceptionActiveForTurn(resolution);
   }
   if (UI_SURFACE_TOOL_NAMES.has(name)) {
     if (

--- a/assistant/src/memory/attachments-store.ts
+++ b/assistant/src/memory/attachments-store.ts
@@ -1111,6 +1111,35 @@ export function getLinkedAttachmentIdsForMessage(
 }
 
 /**
+ * Whether an attachment is linked to a message in the given conversation.
+ *
+ * Access-control check for callers that resolve a model-supplied attachment id
+ * (e.g. the vision-perception `vlm_*` tools' `media_ref`): an attachment is only
+ * readable from the conversation it belongs to. A crafted id from another
+ * conversation/channel must not resolve to bytes. Uses an indexed `EXISTS`
+ * join so it stays cheap and never reads file contents.
+ *
+ * Returns `false` for an empty/missing id or one with no link to the
+ * conversation, so callers fail closed.
+ */
+export function isAttachmentInConversation(
+  attachmentId: string,
+  conversationId: string,
+): boolean {
+  if (!attachmentId || !conversationId) return false;
+  const row = rawGet<{ linked: number }>(
+    `SELECT 1 AS linked
+     FROM message_attachments ma
+     JOIN messages m ON m.id = ma.message_id
+     WHERE ma.attachment_id = ? AND m.conversation_id = ?
+     LIMIT 1`,
+    attachmentId,
+    conversationId,
+  );
+  return row != null;
+}
+
+/**
  * Lightweight existence check — queries only the attachment ID column
  * without reading file contents from disk.
  */

--- a/assistant/src/plugins/defaults/vision-perception/__tests__/ocr-detect.test.ts
+++ b/assistant/src/plugins/defaults/vision-perception/__tests__/ocr-detect.test.ts
@@ -63,11 +63,16 @@ interface FakeRow {
 
 let attachmentRows: Record<string, FakeRow> = {};
 let attachmentBytes: Record<string, Buffer> = {};
+// Maps attachment id -> the conversation it is linked to. The resolver enforces
+// this access-control scope before reading any bytes.
+let attachmentConversations: Record<string, string> = {};
 
 mock.module("../../../../memory/attachments-store.js", () => ({
   getAttachmentById: (id: string) => attachmentRows[id] ?? null,
   getAttachmentContent: (id: string) => attachmentBytes[id] ?? null,
   getFilePathForAttachment: () => null,
+  isAttachmentInConversation: (id: string, conversationId: string) =>
+    attachmentConversations[id] === conversationId,
 }));
 
 const vlmOcrTool = (await import("../tools/vlm-ocr.js")).default;
@@ -92,6 +97,8 @@ beforeEach(() => {
     },
   };
   attachmentBytes = { "att-1": PNG_4x2, "att-doc": PNG_4x2 };
+  // Both fixtures are linked to the current conversation ("c1") by default.
+  attachmentConversations = { "att-1": "c1", "att-doc": "c1" };
 });
 
 describe("vlm_ocr tool", () => {
@@ -236,5 +243,22 @@ describe("vlm_detect tool", () => {
 
     expect(result?.isError).toBe(true);
     expect(result?.content).toContain("No attachment found");
+  });
+});
+
+describe("conversation isolation (cross-conversation media_ref)", () => {
+  test("vlm_ocr and vlm_detect reject an id linked to a DIFFERENT conversation", async () => {
+    // The attachment row + bytes exist, but the link points at another
+    // conversation. A model that supplies this crafted id must get an error.
+    attachmentConversations = { "att-1": "other-conv" };
+    responseText = '{"detections": []}';
+
+    const ocr = await vlmOcrTool.execute?.({ media_ref: "att-1" }, ctx);
+    expect(ocr?.isError).toBe(true);
+    expect(ocr?.content).toContain("No attachment found");
+
+    const detect = await vlmDetectTool.execute?.({ media_ref: "att-1" }, ctx);
+    expect(detect?.isError).toBe(true);
+    expect(detect?.content).toContain("No attachment found");
   });
 });

--- a/assistant/src/plugins/defaults/vision-perception/__tests__/pre-model-call.test.ts
+++ b/assistant/src/plugins/defaults/vision-perception/__tests__/pre-model-call.test.ts
@@ -33,9 +33,19 @@ mock.module("../../../../memory/attachments-store.js", () => ({
   getAttachmentById: (id: string) => attachmentRows[id] ?? null,
 }));
 
+// Whether the visionPerception call site resolves to an enabled vision-capable
+// provider. The shared `isVisionPerceptionActiveForTurn` predicate folds this in
+// alongside the backbone capability. Configurable per test.
+let visionProviderAvailable = true;
+mock.module("../src/vision-capability.js", () => ({
+  isVisionPerceptionProviderAvailable: () => visionProviderAvailable,
+  VISION_CALL_SITE: "visionPerception",
+}));
+
 const {
   applyVisionPerceptionMarkers,
   resolveBackboneSupportsVision,
+  isVisionPerceptionActiveForTurn,
   isVlmToolName,
 } = await import("../hooks/pre-model-call.js");
 
@@ -86,6 +96,7 @@ const supportsVision = () => resolveBackboneSupportsVision(resolutionOpts);
 
 beforeEach(() => {
   flagEnabled = true;
+  visionProviderAvailable = true;
   resolvedProviderModel = { ...VISION_MODEL };
   attachmentRows = {
     "att-1": { originalFilename: "photo.png", kind: "image" },
@@ -281,5 +292,44 @@ describe("feature flag gating", () => {
     flagEnabled = true;
     resolvedProviderModel = { ...NON_VISION_MODEL };
     expect(gate()).toBe(false);
+  });
+});
+
+// The single predicate both per-turn gates (tool offer + marker rewrite) share,
+// so they can never drift. Active only when the backbone is text-only AND the
+// visionPerception provider is available.
+describe("isVisionPerceptionActiveForTurn (shared gate)", () => {
+  const active = () => isVisionPerceptionActiveForTurn(resolutionOpts);
+
+  test("text-only backbone + provider available → active", () => {
+    resolvedProviderModel = { ...NON_VISION_MODEL };
+    visionProviderAvailable = true;
+    expect(active()).toBe(true);
+  });
+
+  test("text-only backbone + provider UNAVAILABLE → inactive (no markers, no tools)", () => {
+    resolvedProviderModel = { ...NON_VISION_MODEL };
+    visionProviderAvailable = false;
+    expect(active()).toBe(false);
+
+    // The marker rewrite is driven off `!active` as the loop passes it: with the
+    // feature inactive, media is left intact rather than stripped to a marker
+    // pointing at tools the model was never offered.
+    const messages = [imageMessage("att-1")];
+    expect(applyVisionPerceptionMarkers(messages, !active())).toBe(messages);
+    expect(messages[0].content[1]).toMatchObject({ type: "image" });
+  });
+
+  test("vision-capable backbone → inactive regardless of provider availability", () => {
+    resolvedProviderModel = { ...VISION_MODEL };
+    visionProviderAvailable = true;
+    expect(active()).toBe(false);
+  });
+
+  test("flag off → inactive even on a text-only backbone with provider available", () => {
+    flagEnabled = false;
+    resolvedProviderModel = { ...NON_VISION_MODEL };
+    visionProviderAvailable = true;
+    expect(active()).toBe(false);
   });
 });

--- a/assistant/src/plugins/defaults/vision-perception/__tests__/video.test.ts
+++ b/assistant/src/plugins/defaults/vision-perception/__tests__/video.test.ts
@@ -52,10 +52,15 @@ interface FakeRow {
 }
 
 let attachmentRows: Record<string, FakeRow> = {};
+// Maps attachment id -> the conversation it is linked to. The video resolver
+// enforces this access-control scope before sampling any frames.
+let attachmentConversations: Record<string, string> = {};
 mock.module("../../../../memory/attachments-store.js", () => ({
   getAttachmentById: (id: string) => attachmentRows[id] ?? null,
   getAttachmentContent: () => null,
   getFilePathForAttachment: () => null,
+  isAttachmentInConversation: (id: string, conversationId: string) =>
+    attachmentConversations[id] === conversationId,
 }));
 
 let sendMessageArgs: { messages: Message[]; options: unknown } | null = null;
@@ -110,6 +115,8 @@ beforeEach(() => {
       kind: "image",
     },
   };
+  // Both fixtures are linked to the current conversation ("c1") by default.
+  attachmentConversations = { "vid-1": "c1", "img-1": "c1" };
 });
 
 describe("vlm_video_log tool", () => {
@@ -228,6 +235,31 @@ describe("vlm_video_log tool", () => {
     const result = await vlmVideoLogTool.execute?.({ media_ref: "vid-1" }, ctx);
 
     expect(result?.isError).toBe(true);
+  });
+
+  test("resolves a video linked to the current conversation", async () => {
+    sampleResult = { duration_s: 4, frames: [fixtureFrame(0)] };
+    responseText = JSON.stringify({ segments: [] });
+
+    const result = await vlmVideoLogTool.execute?.({ media_ref: "vid-1" }, ctx);
+
+    expect(result?.isError).toBe(false);
+    expect(sendMessageArgs).not.toBeNull();
+  });
+
+  test("rejects a video id linked to a DIFFERENT conversation, sampling no frames", async () => {
+    // The video row exists, but the link points at another conversation. The
+    // resolver must reject before any frames are sampled or sent.
+    attachmentConversations = { "vid-1": "other-conv" };
+    sampleResult = { duration_s: 4, frames: [fixtureFrame(0)] };
+    responseText = JSON.stringify({ segments: [] });
+
+    const result = await vlmVideoLogTool.execute?.({ media_ref: "vid-1" }, ctx);
+
+    expect(result?.isError).toBe(true);
+    expect(result?.content).toContain("No attachment found");
+    // Fail closed: no frames sampled, nothing sent to the vision model.
+    expect(sendMessageArgs).toBeNull();
   });
 });
 

--- a/assistant/src/plugins/defaults/vision-perception/__tests__/vision-tools.test.ts
+++ b/assistant/src/plugins/defaults/vision-perception/__tests__/vision-tools.test.ts
@@ -52,16 +52,21 @@ interface FakeRow {
   kind: string;
 }
 
-// The store stub is configurable per-test: `attachmentRows` maps id -> row, and
-// `attachmentBytes` maps id -> bytes. A missing id resolves to null (mirroring
-// the real store's not-found behavior).
+// The store stub is configurable per-test: `attachmentRows` maps id -> row,
+// `attachmentBytes` maps id -> bytes, and `attachmentConversations` maps id ->
+// the conversation it is linked to (the access-control scope the resolver
+// enforces). A missing id resolves to null (mirroring the real store's
+// not-found behavior).
 let attachmentRows: Record<string, FakeRow> = {};
 let attachmentBytes: Record<string, Buffer> = {};
+let attachmentConversations: Record<string, string> = {};
 
 mock.module("../../../../memory/attachments-store.js", () => ({
   getAttachmentById: (id: string) => attachmentRows[id] ?? null,
   getAttachmentContent: (id: string) => attachmentBytes[id] ?? null,
   getFilePathForAttachment: () => null,
+  isAttachmentInConversation: (id: string, conversationId: string) =>
+    attachmentConversations[id] === conversationId,
 }));
 
 const vlmAskTool = (await import("../tools/vlm-ask.js")).default;
@@ -88,6 +93,9 @@ beforeEach(() => {
     },
   };
   attachmentBytes = { "att-1": PNG_BYTES, "att-doc": PNG_BYTES };
+  // Both fixtures are linked to the current conversation ("c1") by default, so
+  // the access-control check passes; per-test overrides exercise the rejection.
+  attachmentConversations = { "att-1": "c1", "att-doc": "c1" };
 });
 
 describe("vlm_ask tool", () => {
@@ -209,5 +217,48 @@ describe("vlm_describe tool", () => {
 
     expect(result?.isError).toBe(true);
     expect(result?.content).toContain("not an image");
+  });
+});
+
+describe("conversation isolation (cross-conversation media_ref)", () => {
+  test("resolves an attachment linked to the current conversation", async () => {
+    // att-1 belongs to "c1", which is ctx.conversationId — the read proceeds.
+    const result = await vlmAskTool.execute?.(
+      { media_ref: "att-1", question: "What is in this image?" },
+      ctx,
+    );
+
+    expect(result?.isError).toBe(false);
+    expect(sendMessageArgs).not.toBeNull();
+  });
+
+  test("rejects an attachment id linked to a DIFFERENT conversation, reading no bytes", async () => {
+    // The attachment row + bytes exist, but the link points at another
+    // conversation ("other-conv"). A model that supplies this crafted id must
+    // get an error and NO bytes may be read or sent.
+    attachmentConversations = { "att-1": "other-conv" };
+
+    const result = await vlmAskTool.execute?.(
+      { media_ref: "att-1", question: "What is in this image?" },
+      ctx,
+    );
+
+    expect(result?.isError).toBe(true);
+    expect(result?.content).toContain("No attachment found");
+    // Fail closed: the cross-conversation bytes never reach the vision model.
+    expect(sendMessageArgs).toBeNull();
+  });
+
+  test("rejects an unlinked attachment id across all image tools", async () => {
+    attachmentConversations = {};
+    for (const tool of [vlmAskTool, vlmDescribeTool]) {
+      sendMessageArgs = null;
+      const result = await tool.execute?.(
+        { media_ref: "att-1", question: "?" },
+        ctx,
+      );
+      expect(result?.isError).toBe(true);
+      expect(sendMessageArgs).toBeNull();
+    }
   });
 });

--- a/assistant/src/plugins/defaults/vision-perception/hooks/pre-model-call.ts
+++ b/assistant/src/plugins/defaults/vision-perception/hooks/pre-model-call.ts
@@ -41,6 +41,7 @@ import type {
   ImageContent,
   Message,
 } from "../../../../providers/types.js";
+import { isVisionPerceptionProviderAvailable } from "../src/vision-capability.js";
 
 /**
  * Names of every model-visible vision tool the plugin contributes. Kept here so
@@ -113,6 +114,33 @@ export function resolveBackboneSupportsVision(
     // Fail open: never let a resolution error strip media from a request.
     return true;
   }
+}
+
+/**
+ * The single predicate both per-turn vision-perception gates key on: the
+ * `vlm_*` tools are offered, AND uploaded media is rewritten into `media_ref`
+ * markers, only when this returns `true`.
+ *
+ * Two conditions must both hold, so the two gates can never drift:
+ *  1. the resolved backbone cannot see media natively
+ *     (`!resolveBackboneSupportsVision`, which already folds in the
+ *     `vision-perception` flag), and
+ *  2. the `visionPerception` call site resolves to an enabled, vision-capable
+ *     provider ({@link isVisionPerceptionProviderAvailable}).
+ *
+ * When (2) is false (e.g. BYOK with the managed `vision` profile disabled) the
+ * tools are withheld; stripping media here too would otherwise hand the model
+ * markers pointing at tools it was never offered — neither raw media nor a way
+ * to read it. Returns `false` so the request is left for the provider to handle
+ * as it otherwise would.
+ */
+export function isVisionPerceptionActiveForTurn(
+  opts: BackboneResolutionOpts,
+): boolean {
+  return (
+    !resolveBackboneSupportsVision(opts) &&
+    isVisionPerceptionProviderAvailable()
+  );
 }
 
 /** Human-readable media kind for the marker text. */

--- a/assistant/src/plugins/defaults/vision-perception/src/call-vision-model.ts
+++ b/assistant/src/plugins/defaults/vision-perception/src/call-vision-model.ts
@@ -106,6 +106,6 @@ export async function callVisionModel(
   prompt: string,
   ctx: ToolContext,
 ): Promise<string> {
-  const media = await resolveVisionMedia(mediaRef);
+  const media = await resolveVisionMedia(mediaRef, ctx.conversationId);
   return callVisionModelWithBlock(media.block, prompt, ctx);
 }

--- a/assistant/src/plugins/defaults/vision-perception/src/media-source.ts
+++ b/assistant/src/plugins/defaults/vision-perception/src/media-source.ts
@@ -15,6 +15,7 @@ import { optimizeImageForTransport } from "../../../../agent/image-optimize.js";
 import {
   getAttachmentById,
   getAttachmentContent,
+  isAttachmentInConversation,
 } from "../../../../memory/attachments-store.js";
 import type { ImageContent } from "../../../../providers/types.js";
 import { toImageBlock } from "./image-block.js";
@@ -45,17 +46,38 @@ export interface ResolvedVisionMedia {
 }
 
 /**
+ * Reject a model-supplied `media_ref` that is not linked to the current
+ * conversation. `media_ref` is supplied by the model, so a crafted or
+ * previously-seen id from ANOTHER conversation/channel must never resolve to
+ * bytes — that would be a cross-conversation data leak. Fails closed: bytes are
+ * only read once the id is confirmed to belong to {@link conversationId}.
+ */
+function assertMediaRefInConversation(
+  ref: string,
+  conversationId: string,
+): void {
+  if (!isAttachmentInConversation(ref, conversationId)) {
+    throw new VisionMediaError(`No attachment found for media_ref "${ref}".`);
+  }
+}
+
+/**
  * Resolve an attachment id to an optimized `ImageContent` block plus its
- * metadata. Throws {@link VisionMediaError} on a missing / non-image / unreadable
- * reference.
+ * metadata. The `conversationId` (from the tool's `ToolContext`) scopes the
+ * lookup: an id not linked to the current conversation is rejected before any
+ * bytes are read. Throws {@link VisionMediaError} on a missing / non-image /
+ * unreadable / out-of-conversation reference.
  */
 export async function resolveVisionMedia(
   mediaRef: string,
+  conversationId: string,
 ): Promise<ResolvedVisionMedia> {
   const ref = mediaRef?.trim();
   if (!ref) {
     throw new VisionMediaError("No media reference was provided.");
   }
+
+  assertMediaRefInConversation(ref, conversationId);
 
   const row = getAttachmentById(ref);
   if (!row) {
@@ -91,20 +113,26 @@ export async function resolveVisionMedia(
 
 /**
  * Resolve a video attachment id to a set of timestamped keyframes plus its
- * metadata. Delegates frame extraction to `video-frames.ts`, which relies on
- * ffmpeg/ffprobe and fails gracefully when those are unavailable. Throws
- * {@link VisionMediaError} on a missing / non-video reference, and re-raises a
+ * metadata. The `conversationId` (from the tool's `ToolContext`) scopes the
+ * lookup: an id not linked to the current conversation is rejected before any
+ * bytes are read or frames are sampled. Delegates frame extraction to
+ * `video-frames.ts`, which relies on ffmpeg/ffprobe and fails gracefully when
+ * those are unavailable. Throws {@link VisionMediaError} on a missing /
+ * non-video / out-of-conversation reference, and re-raises a
  * {@link VideoFramesError} as a {@link VisionMediaError} so callers convert
  * either into a single `{ isError: true }` result.
  */
 export async function resolveVisionVideo(
   mediaRef: string,
+  conversationId: string,
   options?: SampleVideoOptions,
 ): Promise<{ video: SampledVideo; filename: string }> {
   const ref = mediaRef?.trim();
   if (!ref) {
     throw new VisionMediaError("No media reference was provided.");
   }
+
+  assertMediaRefInConversation(ref, conversationId);
 
   const row = getAttachmentById(ref);
   if (!row) {

--- a/assistant/src/plugins/defaults/vision-perception/tools/vlm-detect.ts
+++ b/assistant/src/plugins/defaults/vision-perception/tools/vlm-detect.ts
@@ -121,7 +121,7 @@ const vlmDetectTool: ToolDefinition = {
         ? input.targets.filter((t): t is string => typeof t === "string")
         : [];
 
-      const media = await resolveVisionMedia(mediaRef);
+      const media = await resolveVisionMedia(mediaRef, ctx.conversationId);
       const imageSize = imageSizeFromBlock(media.block, media.mimeType);
       const prompt = buildDetectPrompt(targets);
       const answer = await callVisionModelWithBlock(media.block, prompt, ctx);

--- a/assistant/src/plugins/defaults/vision-perception/tools/vlm-ocr.ts
+++ b/assistant/src/plugins/defaults/vision-perception/tools/vlm-ocr.ts
@@ -119,7 +119,7 @@ const vlmOcrTool: ToolDefinition = {
       const region = normalizeBox(input.region);
       const layout = input.layout === true;
 
-      const media = await resolveVisionMedia(mediaRef);
+      const media = await resolveVisionMedia(mediaRef, ctx.conversationId);
       const imageSize = imageSizeFromBlock(media.block, media.mimeType);
       const prompt = buildOcrPrompt(region, layout);
       const answer = await callVisionModelWithBlock(media.block, prompt, ctx);

--- a/assistant/src/plugins/defaults/vision-perception/tools/vlm-video-log.ts
+++ b/assistant/src/plugins/defaults/vision-perception/tools/vlm-video-log.ts
@@ -171,7 +171,7 @@ const vlmVideoLogTool: ToolDefinition = {
           : undefined;
       const window = parseWindow(input.window);
 
-      const { video } = await resolveVisionVideo(mediaRef, {
+      const { video } = await resolveVisionVideo(mediaRef, ctx.conversationId, {
         ...(sample ? { sample } : {}),
         ...(window ? { window } : {}),
         ...(ctx.signal ? { signal: ctx.signal } : {}),


### PR DESCRIPTION
## Summary
Addresses 3 Codex findings on the feature PR:
- HIGH: vlm_* media_ref is now scoped to the current conversation (reject attachment ids not linked to ctx.conversationId) — prevents cross-conversation attachment reads.
- MEDIUM: the marker rewrite now gates on isVisionPerceptionProviderAvailable() like the tool offer, so an unavailable vision provider doesn't leave the model with markers but no tools.
- LOW: gated-profile reconcile re-reads profileOrder between removals, so both-flags-off no longer reintroduces a deleted profile name.

Part of plan: glm-5v-turbo-vlm-tool (Codex review on feature PR #35508)