### PR TITLE
feat(config): make background and schedule turn timeouts configurable

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -122,6 +122,8 @@ describe("AssistantConfigSchema", () => {
       permissionTimeoutSec: 300,
       toolExecutionTimeoutSec: 120,
       providerStreamTimeoutSec: 1800,
+      backgroundTurnTimeoutSec: 1800,
+      scheduleTurnTimeoutSec: 1800,
     });
     expect(result.rateLimit).toEqual({
       maxRequestsPerMinute: 0,
@@ -664,6 +666,38 @@ describe("AssistantConfigSchema", () => {
     expect(result.timeouts.shellDefaultTimeoutSec).toBe(30);
     expect(result.timeouts.shellMaxTimeoutSec).toBe(600);
     expect(result.timeouts.permissionTimeoutSec).toBe(300);
+  });
+
+  test("background/schedule turn timeouts default to 1800s when unset", () => {
+    const result = AssistantConfigSchema.parse({
+      timeouts: { shellDefaultTimeoutSec: 30 },
+    });
+    expect(result.timeouts.backgroundTurnTimeoutSec).toBe(1800);
+    expect(result.timeouts.scheduleTurnTimeoutSec).toBe(1800);
+  });
+
+  test("custom background/schedule turn timeouts flow through to resolved config", () => {
+    const result = AssistantConfigSchema.parse({
+      timeouts: {
+        backgroundTurnTimeoutSec: 3600,
+        scheduleTurnTimeoutSec: 10800,
+      },
+    });
+    expect(result.timeouts.backgroundTurnTimeoutSec).toBe(3600);
+    expect(result.timeouts.scheduleTurnTimeoutSec).toBe(10800);
+  });
+
+  test("rejects non-integer and out-of-range turn timeouts", () => {
+    expect(
+      AssistantConfigSchema.safeParse({
+        timeouts: { backgroundTurnTimeoutSec: 12.5 },
+      }).success,
+    ).toBe(false);
+    expect(
+      AssistantConfigSchema.safeParse({
+        timeouts: { scheduleTurnTimeoutSec: 2147484 },
+      }).success,
+    ).toBe(false);
   });
 
   test("accepts zero for non-negative fields", () => {

--- a/assistant/src/config/schemas/timeouts.ts
+++ b/assistant/src/config/schemas/timeouts.ts
@@ -42,6 +42,30 @@ export const TimeoutConfigSchema = z
       .describe(
         "Timeout for waiting on the LLM provider's streaming response (seconds)",
       ),
+    backgroundTurnTimeoutSec: z
+      .number({ error: "timeouts.backgroundTurnTimeoutSec must be a number" })
+      .int("timeouts.backgroundTurnTimeoutSec must be an integer")
+      .positive("timeouts.backgroundTurnTimeoutSec must be a positive integer")
+      .max(
+        2147483,
+        "timeouts.backgroundTurnTimeoutSec must be at most 2147483 (setTimeout-safe limit)",
+      )
+      .default(1800)
+      .describe(
+        "Hard timeout for heartbeat and generic background agent turns (seconds)",
+      ),
+    scheduleTurnTimeoutSec: z
+      .number({ error: "timeouts.scheduleTurnTimeoutSec must be a number" })
+      .int("timeouts.scheduleTurnTimeoutSec must be an integer")
+      .positive("timeouts.scheduleTurnTimeoutSec must be a positive integer")
+      .max(
+        2147483,
+        "timeouts.scheduleTurnTimeoutSec must be at most 2147483 (setTimeout-safe limit)",
+      )
+      .default(1800)
+      .describe(
+        "Hard timeout for deliberately-launched scheduled (talk-mode) agent turns (seconds)",
+      ),
   })
   .describe("Timeout configuration for various operations");
 

--- a/assistant/src/heartbeat/heartbeat-service.ts
+++ b/assistant/src/heartbeat/heartbeat-service.ts
@@ -46,7 +46,6 @@ const DEFAULT_CHECKLIST = `- Check in with yourself. Read NOW.md. Is it still ac
 
 const EARLY_HEARTBEAT_THRESHOLD = 3;
 const REENGAGEMENT_COOLDOWN_MS = 18 * 60 * 60 * 1000; // 18 hours
-const HEARTBEAT_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
 
 // Stripped-comment form of the guardian persona scaffold. Computed
 // once at module load because stripping comment lines is deterministic
@@ -774,8 +773,8 @@ export class HeartbeatService {
     //
     // The runner fires `onConversationCreated` synchronously after
     // bootstrap so the macOS sidebar gets the new conversation
-    // immediately rather than waiting up to HEARTBEAT_TIMEOUT_MS for
-    // the LLM turn to finish. If the model judges the run worth
+    // immediately rather than waiting up to the full background-turn timeout
+    // for the LLM turn to finish. If the model judges the run worth
     // surfacing to the guardian, it calls the `notifications` skill
     // directly — no in-band marker.
     let conversationId: string | undefined;
@@ -789,7 +788,7 @@ export class HeartbeatService {
         trustClass: "guardian",
       },
       callSite: "heartbeatAgent",
-      timeoutMs: HEARTBEAT_TIMEOUT_MS,
+      timeoutMs: getConfig().timeouts.backgroundTurnTimeoutSec * 1000,
       origin: "heartbeat",
       deferNotifications: true,
       onConversationCreated: (newConversationId) => {

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -1,3 +1,4 @@
+import { getConfig } from "../config/loader.js";
 import {
   checkDiskPressureBackgroundGate,
   diskPressureBackgroundSkipLogFields,
@@ -84,14 +85,6 @@ const TICK_INTERVAL_MS = 15_000;
  * ≈ 5 minutes of total retry window.
  */
 const WAKE_MAX_RETRIES = 20;
-
-/**
- * Hard timeout for `talk`-mode scheduled jobs. Schedules can do
- * non-trivial work (research, summarize the day, etc.), so the cap is
- * generous; it exists primarily so a wedged turn cannot block the next
- * scheduler tick indefinitely. Mirrors the heartbeat/filing budgets.
- */
-const SCHEDULE_TALK_TIMEOUT_MS = 30 * 60 * 1000;
 
 /**
  * Apply retry policy on schedule-execution failure. Retries are scheduled by
@@ -718,7 +711,10 @@ export async function runScheduleDueWorkOnce(
         ...(job.inferenceProfile
           ? { overrideProfile: job.inferenceProfile }
           : {}),
-        timeoutMs: SCHEDULE_TALK_TIMEOUT_MS,
+        // Hard timeout for talk-mode scheduled turns: bounds a wedged turn so
+        // it cannot block the next scheduler tick. Configurable via
+        // timeouts.scheduleTurnTimeoutSec (default 1800s).
+        timeoutMs: getConfig().timeouts.scheduleTurnTimeoutSec * 1000,
         origin: "schedule",
         groupId: "system:scheduled",
         conversationType: "scheduled",


### PR DESCRIPTION
## Summary
- Add `timeouts.backgroundTurnTimeoutSec` and `timeouts.scheduleTurnTimeoutSec` to the timeouts config schema, both defaulting to 1800s (30 min) and validated as positive integers with a setTimeout-safe upper bound.
- Derive the heartbeat/generic background-job turn timeout and the schedule talk-mode turn timeout from these config values (seconds × 1000 → ms) instead of the hardcoded `HEARTBEAT_TIMEOUT_MS` / `SCHEDULE_TALK_TIMEOUT_MS` constants. Behavior is unchanged when the values are unset (backwards compatible).
- Add config-schema tests covering defaults (1800s), custom values flowing through to the resolved config, and rejection of non-integer / out-of-range values.

## Original prompt
While scoping what it would take for the assistant to pursue long-horizon background work, we identified the 30-minute background-turn timeout as a hardcoded backstop. The conclusion was to keep a protective 30-minute default but make it configurable, so a deliberately-launched scheduled turn can opt into a longer ceiling without weakening the heartbeat's tighter bound. This PR surfaces both background-turn timeouts in the `timeouts` config section, each defaulting to 30 minutes so existing behavior is preserved.