### PR TITLE
fix(design-library): preserve author-typed numbers in skipped ordered lists

### DIFF
--- a/packages/design-library/src/components/markdown-message.test.tsx
+++ b/packages/design-library/src/components/markdown-message.test.tsx
@@ -52,6 +52,34 @@ describe("MarkdownMessage", () => {
 
     expect(html).toContain("<ol");
     expect(html).not.toContain("start=");
+    // A contiguous list matches the auto-increment, so no item is pinned.
+    expect(html).not.toContain("value=");
+  });
+
+  test("ordered list with a skipped number renders the typed ordinals", () => {
+    // Replying to points 1, 2, 4, 5 (deliberately skipping 3) must not silently
+    // renumber to 1, 2, 3, 4. CommonMark drops the markers, so item 4 is pinned
+    // with <li value="4">; item 5 then follows naturally and needs no pin.
+    const html = renderToStaticMarkup(
+      createElement(MarkdownMessage, {
+        content: "1. a\n2. b\n4. c\n5. d",
+      }),
+    );
+
+    expect(html).toContain('<li value="4"');
+    expect(html).not.toContain('value="3"');
+  });
+
+  test("ordered list that restarts mid-stream pins the lower number", () => {
+    // 1, 2, then a fresh 1 — the restart drops below the running count, so the
+    // third item is pinned back to <li value="1">.
+    const html = renderToStaticMarkup(
+      createElement(MarkdownMessage, {
+        content: "1. a\n2. b\n1. c",
+      }),
+    );
+
+    expect(html).toContain('<li value="1"');
   });
 
   test("tables render with the body-small typography token", () => {

--- a/packages/design-library/src/components/markdown-message.tsx
+++ b/packages/design-library/src/components/markdown-message.tsx
@@ -296,7 +296,10 @@ function buildMarkdownComponents(
 
       <h6 className="mb-1 mt-2 text-body-small-default !font-bold text-[var(--content-secondary)] first:mt-0">{children}</h6>
     ),
-    li: ({ children }) => <li className="mb-0.5">{children}</li>,
+    // `value` is forwarded so a list item whose source ordinal breaks the
+    // running sequence (set by remarkPreserveOrderedListNumbers) renders at its
+    // typed number via the HTML `<li value="N">` attribute.
+    li: ({ children, value }) => <li value={value} className="mb-0.5">{children}</li>,
     a: ({ href, children }) => <LinkComponent href={href}>{children}</LinkComponent>,
     code: ({ className, children, ...props }) => {
       const isBlock = className?.startsWith("language-");
@@ -494,6 +497,60 @@ function hardBreakNewlines(content: string): string {
   return rewriteTextSlices(content, ranges, (slice) => slice.replace(/\n/g, "  \n"));
 }
 
+/** Leading marker of an ordered-list item: up to 3 spaces, digits, then `.`/`)`. */
+const ORDERED_MARKER = /^\s{0,3}(\d{1,9})[.)]/;
+
+/**
+ * remark plugin: render an ordered list with the exact numbers the author typed.
+ *
+ * CommonMark keeps only an ordered list's *first* item number — emitted as the
+ * `<ol start>` — and discards every later marker, so a list written as
+ * `1. / 2. / 4. / 5.` silently renumbers to 1, 2, 3, 4. For each item we recover
+ * the literal ordinal from the source and, wherever it breaks the running
+ * sequence, pin it with `data.hProperties.value` — which react-markdown's
+ * mdast→hast step turns into an HTML `<li value="N">` that overrides the
+ * browser's auto-increment. Items that already match the running count emit no
+ * `value`, so contiguous lists render byte-identically to no plugin at all.
+ */
+function remarkPreserveOrderedListNumbers() {
+  return (tree: unknown, file: { toString(): string }) => {
+    const source = String(file);
+    const visit = (node: {
+      type: string;
+      ordered?: boolean;
+      start?: number | null;
+      position?: { start: { offset?: number } };
+      data?: { hProperties?: Record<string, unknown> };
+      children?: unknown[];
+    }) => {
+      if (node.type === "list" && node.ordered && Array.isArray(node.children)) {
+        let counter = node.start ?? 1;
+        for (const child of node.children) {
+          const item = child as Parameters<typeof visit>[0];
+          const offset = item.position?.start.offset;
+          let literal = counter;
+          if (typeof offset === "number") {
+            const marker = ORDERED_MARKER.exec(source.slice(offset, offset + 16));
+            if (marker) literal = Number(marker[1]);
+          }
+          if (literal !== counter) {
+            item.data ??= {};
+            item.data.hProperties ??= {};
+            item.data.hProperties.value = literal;
+          }
+          counter = literal + 1;
+        }
+      }
+      if (Array.isArray(node.children)) {
+        for (const child of node.children) {
+          visit(child as Parameters<typeof visit>[0]);
+        }
+      }
+    };
+    visit(tree as Parameters<typeof visit>[0]);
+  };
+}
+
 export interface MarkdownMessageProps {
   content: string;
   className?: string;
@@ -524,7 +581,7 @@ export function MarkdownMessage({
   const components = useMemo(() => buildMarkdownComponents(Link), [Link]);
   return (
     <div data-slot="markdown-message" className={cn("text-chat text-[var(--content-default)]", className)}>
-      <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeKatex]} components={components}>
+      <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath, remarkPreserveOrderedListNumbers]} rehypePlugins={[rehypeKatex]} components={components}>
         {processed}
       </ReactMarkdown>
     </div>


### PR DESCRIPTION
## Summary
- Ordered lists that skip a number (e.g. replying to a subset of points: 1, 2, 4, 5) were silently renumbered to 1, 2, 3, 4 on render. Root cause is CommonMark: an ordered list keeps only its *first* item number (emitted as `<ol start>`) and discards every later marker, so the browser auto-increments the rest.
- Add a `remarkPreserveOrderedListNumbers` plugin to the shared design-library `MarkdownMessage`: it recovers each item's literal ordinal from the markdown source and pins any item that breaks the running sequence with an HTML `<li value="N">` (forwarded through the `li` renderer). Contiguous lists emit no `value`, so their output is byte-identical to before.
- Applies to both user-typed messages and assistant replies (one shared renderer). Adds tests covering the skipped-number and mid-stream-restart cases; the existing contiguous-list test now also asserts no stray `value=`.

## Original prompt
In the Electron app, sending the assistant a message that replied to a subset of her points with a gapped markdown ordered list (e.g. 1, 2, 4, 5 — deliberately skipping 3) displayed renumbered as 1, 2, 3, 4, which is confusing. We traced both ends and confirmed the text is stored and sent verbatim (plain textarea, no transformation) — the renumbering is purely a markdown-rendering artifact of CommonMark's ordered-list handling. The ask was to make ordered lists render with the exact numbers the author typed, applied everywhere (user + assistant messages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)