### PR TITLE
fix(heartbeat): add timeouts.backgroundTurnTimeoutSec to test config mocks

### DIFF
--- a/assistant/src/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/__tests__/heartbeat-service.test.ts
@@ -47,6 +47,9 @@ let mockConfig = {
     activeHoursEnd: undefined as number | undefined,
     disposition: "Default disposition text mentioning notifications skill.",
   },
+  timeouts: {
+    backgroundTurnTimeoutSec: 1800,
+  },
 };
 
 mock.module("../config/loader.js", () => ({
@@ -398,6 +401,9 @@ describe("HeartbeatService", () => {
         activeHoursStart: undefined,
         activeHoursEnd: undefined,
         disposition: "Default disposition text mentioning notifications skill.",
+      },
+      timeouts: {
+        backgroundTurnTimeoutSec: 1800,
       },
     };
   });

--- a/assistant/src/heartbeat/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/heartbeat/__tests__/heartbeat-service.test.ts
@@ -88,6 +88,9 @@ const stubConfig: {
     maxDailyRuns: number | null;
     disposition: string;
   };
+  timeouts: {
+    backgroundTurnTimeoutSec: number;
+  };
 } = {
   heartbeat: {
     enabled: true,
@@ -97,6 +100,9 @@ const stubConfig: {
     maxConsecutiveRuns: null,
     maxDailyRuns: null,
     disposition: "Default disposition text.",
+  },
+  timeouts: {
+    backgroundTurnTimeoutSec: 1800,
   },
 };
 mock.module("../../config/loader.js", () => ({


### PR DESCRIPTION
## Summary

- Main CI (`CI Main Assistant Checks` → `Test`) went red after #35514: both `heartbeat-service.test.ts` suites fail with `Expected length: N / Received length: 0`.
- Root cause: #35514 changed `heartbeat-service.ts` to read `getConfig().timeouts.backgroundTurnTimeoutSec * 1000` for the background-turn timeout, but both test files mock `config/loader.js` with stub configs that only define `heartbeat`. The new `.timeouts` read throws (`undefined is not an object`) inside `executeRun`, so every run aborts before `processMessage`/`runBackgroundJob` is invoked and the spies record 0 calls. Verified each file fails in isolation (not a cross-file mock leak).
- Fix: add `timeouts: { backgroundTurnTimeoutSec: 1800 }` to both mocks — `mockConfig` (initializer + `beforeEach` reset) and `stubConfig` (type + value). `1800` is the schema default and equals the old `HEARTBEAT_TIMEOUT_MS = 30*60*1000`, so behavior is unchanged. Mirrors prior fix #33632. Both suites now pass (91/91, including run together to replicate the CI shard).

## Original prompt

Fix the specific failing CI job (`CI Main Assistant Checks` / `Test`, run 27864142486) on `main` — scoped to that job only, not a broader sweep. The job is red because the heartbeat config-timeout change in #35514 didn't update the heartbeat test mocks to include the new `timeouts.backgroundTurnTimeoutSec` field.