### PR TITLE
feat(memory): add attached memory database (infra)

### DIFF
--- a/assistant/src/cli/commands/db/status.ts
+++ b/assistant/src/cli/commands/db/status.ts
@@ -29,6 +29,7 @@ import { Database } from "bun:sqlite";
 import type { Command } from "commander";
 
 import { getLogsDbPath } from "../../../util/logs-db-path.js";
+import { getMemoryDbPath } from "../../../util/memory-db-path.js";
 import { getDbPath } from "../../../util/platform.js";
 import { red } from "../../lib/cli-colors.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
@@ -83,6 +84,14 @@ interface StatusReport {
    */
   logsFile?: FileFacts;
   logsDb?: DbFacts | null;
+  /**
+   * The secondary memory database (`assistant-memory.db`). Like `logsFile`, it
+   * is omitted from the report until the file exists on disk — it is created
+   * the first time the daemon opens (and ATTACHes) the DB, so a fresh install
+   * that has never run the daemon won't have one.
+   */
+  memoryFile?: FileFacts;
+  memoryDb?: DbFacts | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -320,6 +329,13 @@ function renderHuman(report: StatusReport): string {
     out += renderDbBlock(report.logsFile, report.logsDb ?? null);
   }
 
+  // The secondary memory file is likewise only reported once it exists.
+  if (report.memoryFile?.exists) {
+    out += "\n";
+    out += "Memory database (high-churn memory tables)\n";
+    out += renderDbBlock(report.memoryFile, report.memoryDb ?? null);
+  }
+
   return out;
 }
 
@@ -390,7 +406,25 @@ export function registerDbStatus(parent: Command): void {
         }
       }
 
-      const report: StatusReport = { file, db, logsFile, logsDb };
+      // Same best-effort probe for the secondary memory DB.
+      const memoryFile = readFileFacts(getMemoryDbPath());
+      let memoryDb: DbFacts | null = null;
+      if (memoryFile.exists) {
+        try {
+          memoryDb = readDbFacts(memoryFile.path);
+        } catch {
+          memoryDb = null;
+        }
+      }
+
+      const report: StatusReport = {
+        file,
+        db,
+        logsFile,
+        logsDb,
+        memoryFile,
+        memoryDb,
+      };
       if (shouldOutputJson(this)) {
         writeOutput(this, report);
       } else {

--- a/assistant/src/memory/__tests__/db-memory-attach.test.ts
+++ b/assistant/src/memory/__tests__/db-memory-attach.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for the secondary memory database file wiring (infra PR).
+ *
+ * What this locks in:
+ *   1. Opening the connection ATTACHes `assistant-memory.db` as the `memory`
+ *      schema and creates the file on disk.
+ *   2. The attached schema runs in WAL mode (its own `-wal`, independent of
+ *      the main DB) — the regression that lets a high-churn table (the
+ *      `memory_jobs` queue) bloat the *main* WAL is exactly what this split
+ *      exists to prevent.
+ *   3. A table created in the `memory` schema lives in the separate file, not
+ *      in `main` — proving the physical split rather than just an alias.
+ *   4. `runAsyncSqlite({ dbPath })` targets the given file via the sqlite3
+ *      CLI backend, leaving the main DB untouched.
+ */
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import { removeTestDbFiles } from "../../__tests__/assert-not-live-db.js";
+
+const { getSqlite, MEMORY_DB_SCHEMA } = await import("../db-connection.js");
+const { initializeDb } = await import("../db-init.js");
+const { runAsyncSqlite } = await import("../db-async-query.js");
+const { getMemoryDbPath } = await import("../../util/memory-db-path.js");
+const { findSqlite3 } = await import("../../util/sqlite3-runtime.js");
+
+initializeDb();
+
+const sqlite3Available = findSqlite3() !== undefined;
+
+describe("memory database attachment", () => {
+  test("ATTACHes the memory file as the memory schema and creates it on disk", () => {
+    // Touch the connection so the attach runs.
+    getSqlite();
+    expect(existsSync(getMemoryDbPath())).toBe(true);
+
+    const attached = getSqlite()
+      .query<{ name: string; file: string }, []>("PRAGMA database_list")
+      .all();
+    const memoryEntry = attached.find((e) => e.name === MEMORY_DB_SCHEMA);
+    expect(memoryEntry).toBeDefined();
+    expect(memoryEntry?.file).toBe(getMemoryDbPath());
+  });
+
+  test("the attached schema runs in WAL mode", () => {
+    const mode = getSqlite()
+      .query<
+        { journal_mode: string },
+        []
+      >(`PRAGMA ${MEMORY_DB_SCHEMA}.journal_mode`)
+      .get();
+    expect(mode?.journal_mode).toBe("wal");
+  });
+
+  test("a table created in the memory schema lives in the memory file, not main", () => {
+    const sqlite = getSqlite();
+    sqlite.exec(
+      `CREATE TABLE IF NOT EXISTS ${MEMORY_DB_SCHEMA}.attach_probe (id INTEGER PRIMARY KEY)`,
+    );
+    try {
+      const inMemory = sqlite
+        .query<
+          { name: string },
+          []
+        >(`SELECT name FROM ${MEMORY_DB_SCHEMA}.sqlite_master WHERE name = 'attach_probe'`)
+        .get();
+      expect(inMemory?.name).toBe("attach_probe");
+
+      const inMain = sqlite
+        .query<
+          { name: string },
+          []
+        >(`SELECT name FROM main.sqlite_master WHERE name = 'attach_probe'`)
+        .get();
+      expect(inMain).toBeNull();
+    } finally {
+      sqlite.exec(`DROP TABLE ${MEMORY_DB_SCHEMA}.attach_probe`);
+    }
+  });
+
+  test.if(sqlite3Available)(
+    "runAsyncSqlite({ dbPath }) targets the given file, not the main DB",
+    async () => {
+      const targetPath = join(
+        tmpdir(),
+        `vellum-async-memory-dbpath-${Date.now()}.db`,
+      );
+      try {
+        const result = await runAsyncSqlite(
+          "CREATE TABLE dbpath_probe (x INTEGER); INSERT INTO dbpath_probe VALUES (42); SELECT changes();",
+          { dbPath: targetPath, forceBackend: "sqlite3-cli" },
+        );
+        expect(result.ok).toBe(true);
+        expect(result.backend).toBe("sqlite3-cli");
+
+        // The target file got the table…
+        const { Database } = await import("bun:sqlite");
+        const probe = new Database(targetPath, { readonly: true });
+        try {
+          const row = probe
+            .query<
+              { name: string },
+              []
+            >("SELECT name FROM sqlite_master WHERE name = 'dbpath_probe'")
+            .get();
+          expect(row?.name).toBe("dbpath_probe");
+        } finally {
+          probe.close();
+        }
+
+        // …and the main DB did not.
+        const inMain = getSqlite()
+          .query<
+            { name: string },
+            []
+          >("SELECT name FROM main.sqlite_master WHERE name = 'dbpath_probe'")
+          .get();
+        expect(inMain).toBeNull();
+      } finally {
+        removeTestDbFiles(targetPath);
+      }
+    },
+  );
+});

--- a/assistant/src/memory/db-connection.ts
+++ b/assistant/src/memory/db-connection.ts
@@ -6,6 +6,7 @@ import { Database } from "bun:sqlite";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import { getLogsDbPath } from "../util/logs-db-path.js";
+import { getMemoryDbPath } from "../util/memory-db-path.js";
 import { ensureDataDir, getDbPath } from "../util/platform.js";
 import { clearStoredDb, getStoredDb, setStoredDb } from "./db-singleton.js";
 import * as schema from "./schema.js";
@@ -53,6 +54,53 @@ function attachLogsDb(sqlite: Database): void {
       getLogger("db-connection").error(
         { err, logsPath },
         "Failed to ATTACH logs database; append-only log tables will be unavailable",
+      ),
+    );
+  }
+}
+
+/**
+ * Schema name under which the secondary memory database file
+ * (`assistant-memory.db`) is ATTACHed to the main connection. High-churn memory
+ * tables (starting with `memory_jobs`) live in this separate file but remain
+ * queryable — and joinable against main-schema tables — over the single daemon
+ * connection. Because no such table exists in the `main` schema once a table is
+ * relocated, an unqualified reference (e.g. `memory_jobs`) resolves to the
+ * attached copy.
+ */
+export const MEMORY_DB_SCHEMA = "memory";
+
+/**
+ * ATTACH the secondary memory database to an open connection and apply its
+ * per-database PRAGMAs.
+ *
+ * `journal_mode` and `synchronous` are per-database settings, so they must be
+ * set against the attached schema explicitly — the PRAGMAs run on `main` before
+ * the attach do not carry over. `busy_timeout`, `foreign_keys`, `cache_size`,
+ * and `temp_store` are connection-wide and already configured on the connection.
+ *
+ * Best-effort: a failure here (e.g. a filesystem permission problem on the new
+ * file) must not take down the main database. We log and continue in line with
+ * the daemon's "never block startup on a subsystem failure" policy; relocated
+ * memory tables are simply unavailable until the next successful open.
+ *
+ * The logger is pulled in lazily (dynamic import) only on the error path. This
+ * file is intentionally kept import-light — see `db-singleton.ts` — so it does
+ * not take a static dependency on the logger (and transitively on pino).
+ */
+function attachMemoryDb(sqlite: Database): void {
+  const memoryPath = getMemoryDbPath();
+  try {
+    // Escape single quotes for the SQL string literal (paths can contain them).
+    const escaped = memoryPath.replace(/'/g, "''");
+    sqlite.exec(`ATTACH DATABASE '${escaped}' AS ${MEMORY_DB_SCHEMA}`);
+    sqlite.exec(`PRAGMA ${MEMORY_DB_SCHEMA}.journal_mode=WAL`);
+    sqlite.exec(`PRAGMA ${MEMORY_DB_SCHEMA}.synchronous=FULL`);
+  } catch (err) {
+    void import("../util/logger.js").then(({ getLogger }) =>
+      getLogger("db-connection").error(
+        { err, memoryPath },
+        "Failed to ATTACH memory database; relocated memory tables will be unavailable",
       ),
     );
   }
@@ -130,6 +178,7 @@ export function getDb(): DrizzleDb {
   sqlite.exec("PRAGMA cache_size=-256000");
   sqlite.exec("PRAGMA temp_store=MEMORY");
   attachLogsDb(sqlite);
+  attachMemoryDb(sqlite);
   const db = drizzle(sqlite, { schema });
   setStoredDb(db, () => sqlite.close());
   return db;

--- a/assistant/src/util/memory-db-path.ts
+++ b/assistant/src/util/memory-db-path.ts
@@ -1,0 +1,23 @@
+import { join } from "node:path";
+
+import { getDataDir } from "./platform.js";
+
+/**
+ * Path to the secondary SQLite file that houses the high-churn memory
+ * subsystem tables (starting with the `memory_jobs` work queue). It lives in
+ * the same `data/db` directory as the main DB and is ATTACHed to the daemon's
+ * connection as the `memory` schema (see `memory/db-connection.ts`). Splitting
+ * these tables into their own file keeps the main DB — and its WAL — small and
+ * lets the two files VACUUM/checkpoint independently, so a runaway queue can no
+ * longer bloat the main database.
+ *
+ * Kept in its own leaf module rather than alongside `getDbPath()` in
+ * `platform.ts`: `platform.ts` is imported very early and widely, and adding an
+ * export to it that low-level consumers (e.g. `db-connection.ts`) pull in
+ * across the daemon's large, cyclic import graph trips a Bun link-order bug
+ * ("Export named 'getMemoryDbPath' not found"). Isolating it here keeps
+ * `platform.ts`'s module shape stable — same reasoning as `logs-db-path.ts`.
+ */
+export function getMemoryDbPath(): string {
+  return join(getDataDir(), "db", "assistant-memory.db");
+}


### PR DESCRIPTION
## Summary

Introduce a secondary SQLite file, `data/db/assistant-memory.db`, ATTACHed to the daemon's connection as the `memory` schema. This is the foundation for splitting the high-churn `memory_jobs` work queue out of the main DB so the two files grow, VACUUM, and checkpoint **independently** — keeping the main DB and its WAL small.

This mirrors the existing `assistant-logs.db` split and, like it, is **infrastructure only — no table is moved yet.**

### Why

On a production assistant the main `assistant.db` had grown to **22 GB**, of which `memory_jobs` + its two indexes were **~16.6 GB (73%)** — a runaway work queue (millions of terminal `completed`/`failed` rows) co-resident with everything else. Splitting the queue into its own file means a future runaway can only bloat `memory.db`, and that file can be pruned/VACUUMed without touching the main DB's WAL or locks.

`memory_jobs` is a clean candidate for relocation: it has **no foreign keys** (it's keyed on `json_extract(payload, '$.messageId')`), unlike `memory_segments`/`memory_embeddings` which have `FK → conversations(id) ON DELETE CASCADE` and cannot move across the ATTACH boundary (SQLite FKs don't span attached databases).

### Changes

- **`util/memory-db-path.ts`** — new leaf module exporting `getMemoryDbPath()`, sibling of `getLogsDbPath()`. Kept out of `platform.ts` for the same documented Bun link-order reason.
- **`memory/db-connection.ts`** — `export const MEMORY_DB_SCHEMA = "memory"` + `attachMemoryDb()`, called in `getDb()` right after `attachLogsDb()`. Sets per-database PRAGMAs (`journal_mode=WAL`, `synchronous=FULL`). Best-effort: an attach failure logs and continues rather than taking down the main DB (daemon "never block startup on a subsystem failure" policy).
- **`db status`** — probes and reports the memory file's size / WAL / pragmas when present, under a "Memory database (high-churn memory tables)" block. Additive JSON fields (`memoryFile`, `memoryDb`).
- **test** — `db-memory-attach.test.ts` mirrors `db-logs-attach.test.ts`: locks in the ATTACH, the attached schema's independent WAL, the physical split (table lands in the memory file, not `main`), and `runAsyncSqlite({ dbPath })` routing.

The existing `runAsyncSqlite({ dbPath })` plumbing is reused as-is for future out-of-process prune/VACUUM against the memory file — no change needed there.

### Follow-ups (not in this PR)

1. **Relocate `memory_jobs`** into the `memory` schema with a data migration (the actual fix for the 22 GB DB). Audit enqueue call sites in `jobs-store.ts` first: cross-DB writes are **not atomic** when both files are WAL, so any enqueue currently sharing a transaction with a main-DB write needs attention.
2. **Add a `prune_old_memory_jobs` retention job** modeled on `pruneOldTraceEventsJob` in `cleanup.ts` — today nothing ever deletes terminal jobs, which is the root cause of the growth.

### Verification

- `bun test src/memory/__tests__/db-memory-attach.test.ts` — 3 pass, 1 skip (sqlite3-CLI case, no binary on host)
- existing `db-logs-attach.test.ts` + `db status` tests still pass (10 pass, 1 skip) — the added `memory` schema doesn't disturb them
- typecheck + lint + prettier clean (pre-commit/pre-push hooks pass)

> Note: built directly on `main`. The file naming follows the `assistant-logs.db` sibling convention (`assistant-memory.db`) rather than a bare `memory.db` — easy to change if you'd prefer the shorter name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCxgAg2eaYMhocHx7G3CPA)_