### PR TITLE
fix(daemon): survive fs.watch ENOSPC instead of crash-looping the daemon

### DIFF
--- a/assistant/src/__tests__/app-source-watcher.test.ts
+++ b/assistant/src/__tests__/app-source-watcher.test.ts
@@ -3,14 +3,7 @@
  * file changes and triggers debounced recompile + surface refresh.
  */
 
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  mock,
-  test,
-} from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ---------------------------------------------------------------------------
 // Mocks — must be set up before importing the module under test
@@ -19,8 +12,16 @@ import {
 const TEST_APPS_DIR = "/tmp/test-apps";
 const testDirNameMap = new Map<string, string>([["my-app", "app-id-1"]]);
 
-let capturedWatchCallback: ((eventType: string, filename: string | null) => void) | null = null;
-const mockWatcher = { close: mock(() => {}) };
+let capturedWatchCallback:
+  | ((eventType: string, filename: string | null) => void)
+  | null = null;
+let capturedErrorHandler: ((err: unknown) => void) | null = null;
+const mockWatcher = {
+  close: mock(() => {}),
+  on: mock((event: string, handler: (err: unknown) => void) => {
+    if (event === "error") capturedErrorHandler = handler;
+  }),
+};
 const mockExistsSync = mock((p: string): boolean => p === TEST_APPS_DIR);
 const mockWatch = mock(
   (
@@ -68,7 +69,9 @@ describe("AppSourceWatcher", () => {
     watcher = new AppSourceWatcher();
     onChangeSpy = mock(() => {});
     capturedWatchCallback = null;
+    capturedErrorHandler = null;
     mockWatcher.close.mockClear();
+    mockWatcher.on.mockClear();
     // Reset existsSync to default behavior for each test
     mockExistsSync.mockImplementation((p: string) => p === TEST_APPS_DIR);
   });
@@ -181,5 +184,22 @@ describe("AppSourceWatcher", () => {
 
     watcher.ensureStarted();
     expect(mockWatch.mock.calls.length).toBe(callCountAfterStart); // no extra watch call
+  });
+
+  /**
+   * REGRESSION: a recursive watch over a large app tree (node_modules) can
+   * exhaust the inotify watch limit and emit ENOSPC asynchronously as an
+   * 'error' event. Without an 'error' listener that rethrows as an
+   * uncaughtException and crashes the daemon. The watcher must swallow it.
+   */
+  test("attaches an 'error' handler that does not rethrow on async ENOSPC", () => {
+    watcher.start(onChangeSpy);
+
+    expect(capturedErrorHandler).not.toBeNull();
+    const enospc = Object.assign(
+      new Error("ENOSPC: no space left on device, watch"),
+      { code: "ENOSPC", errno: -28, syscall: "watch" },
+    );
+    expect(() => capturedErrorHandler!(enospc)).not.toThrow();
   });
 });

--- a/assistant/src/__tests__/heartbeat-disk-pressure.test.ts
+++ b/assistant/src/__tests__/heartbeat-disk-pressure.test.ts
@@ -26,6 +26,9 @@ mock.module("../config/loader.js", () => ({
       activeHoursStart: undefined,
       activeHoursEnd: undefined,
     },
+    timeouts: {
+      backgroundTurnTimeoutSec: 1800,
+    },
   }),
   loadConfig: () => ({}),
   loadRawConfig: () => ({}),

--- a/assistant/src/__tests__/plugin-source-watcher.test.ts
+++ b/assistant/src/__tests__/plugin-source-watcher.test.ts
@@ -19,7 +19,13 @@ let capturedWatchCallback:
   | ((eventType: string, filename: string | null) => void)
   | null = null;
 let mockWatchShouldThrow = false;
-const mockWatcher = { close: mock(() => {}) };
+let capturedErrorHandler: ((err: unknown) => void) | null = null;
+const mockWatcher = {
+  close: mock(() => {}),
+  on: mock((event: string, handler: (err: unknown) => void) => {
+    if (event === "error") capturedErrorHandler = handler;
+  }),
+};
 
 const mockWatch = mock(
   (
@@ -90,8 +96,10 @@ describe("PluginSourceWatcher", () => {
   beforeEach(() => {
     PluginSourceWatcher.resetForTests();
     capturedWatchCallback = null;
+    capturedErrorHandler = null;
     mockWatchShouldThrow = false;
     mockWatcher.close.mockClear();
+    mockWatcher.on.mockClear();
     mockWatch.mockClear();
     mockRereadirSync.mockClear();
     mockGetRegisteredPlugin.mockClear();
@@ -238,6 +246,30 @@ describe("PluginSourceWatcher", () => {
       mockWatcher,
     );
     expect(capturedWatchCallback).toBe(firstCallback);
+  });
+
+  /**
+   * REGRESSION: a recursive watch over a large plugin tree (node_modules)
+   * can exhaust the inotify watch limit and emit ENOSPC asynchronously as an
+   * 'error' event. An FSWatcher with no 'error' listener rethrows, which
+   * becomes an uncaughtException and crashes the daemon (CrashLoopBackOff).
+   * The watcher must register an 'error' handler that swallows it.
+   */
+  test("attaches an 'error' handler that does not rethrow on async ENOSPC", () => {
+    const watcher = PluginSourceWatcher.getInstance();
+    watcher.start();
+
+    expect(capturedErrorHandler).not.toBeNull();
+    const enospc = Object.assign(
+      new Error("ENOSPC: no space left on device, watch"),
+      {
+        code: "ENOSPC",
+        errno: -28,
+        syscall: "watch",
+      },
+    );
+    // Must not throw — the daemon stays up, the watcher just stops delivering.
+    expect(() => capturedErrorHandler!(enospc)).not.toThrow();
   });
 
   test("singleton instance is shared across calls", () => {

--- a/assistant/src/daemon/app-source-watcher.ts
+++ b/assistant/src/daemon/app-source-watcher.ts
@@ -11,11 +11,9 @@
 
 import { existsSync, type FSWatcher, watch } from "node:fs";
 
-import {
-  getAppsDir,
-  resolveAppIdByDirName,
-} from "../memory/app-store.js";
+import { getAppsDir, resolveAppIdByDirName } from "../memory/app-store.js";
 import { DebouncerMap } from "../util/debounce.js";
+import { attachFsWatcherErrorHandler } from "../util/fs-watcher-error.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("app-source-watcher");
@@ -51,8 +49,10 @@ function resolveAppIdFromRelPath(relPath: string): string | null {
 
   // Skip non-source directories (include bare directory names for fs.watch events)
   if (
-    innerPath === "records" || innerPath.startsWith("records/") ||
-    innerPath === "dist" || innerPath.startsWith("dist/")
+    innerPath === "records" ||
+    innerPath.startsWith("records/") ||
+    innerPath === "dist" ||
+    innerPath.startsWith("dist/")
   ) {
     return null;
   }
@@ -89,7 +89,9 @@ export class AppSourceWatcher {
     try {
       appsDir = getAppsDir();
     } catch {
-      log.warn("Could not resolve apps directory; app source watching disabled");
+      log.warn(
+        "Could not resolve apps directory; app source watching disabled",
+      );
       return;
     }
 
@@ -102,19 +104,30 @@ export class AppSourceWatcher {
     if (!onChange) return;
 
     try {
-      this.watcher = watch(appsDir, { recursive: true }, (_eventType, filename) => {
-        if (!filename) return;
+      this.watcher = watch(
+        appsDir,
+        { recursive: true },
+        (_eventType, filename) => {
+          if (!filename) return;
 
-        const appId = resolveAppIdFromRelPath(filename);
-        if (!appId) return;
+          const appId = resolveAppIdFromRelPath(filename);
+          if (!appId) return;
 
-        this.debouncer.schedule(`app:${appId}`, () => {
-          onChange(appId);
-        });
-      });
+          this.debouncer.schedule(`app:${appId}`, () => {
+            onChange(appId);
+          });
+        },
+      );
+      // Recursive watches over app trees (incl. node_modules) can exhaust the
+      // inotify watch limit and emit ENOSPC asynchronously. Without an 'error'
+      // listener that unhandled emitter error crashes the daemon.
+      attachFsWatcherErrorHandler(this.watcher, log, appsDir);
       log.info("App source watcher started");
     } catch (err) {
-      log.warn({ err }, "Failed to watch apps directory; source watching disabled");
+      log.warn(
+        { err },
+        "Failed to watch apps directory; source watching disabled",
+      );
     }
   }
 

--- a/assistant/src/daemon/plugin-source-watcher.ts
+++ b/assistant/src/daemon/plugin-source-watcher.ts
@@ -39,6 +39,7 @@ import { type FSWatcher, mkdirSync, readdirSync, watch } from "node:fs";
 
 import { getRegisteredPlugin } from "../plugins/registry.js";
 import { DebouncerMap } from "../util/debounce.js";
+import { attachFsWatcherErrorHandler } from "../util/fs-watcher-error.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspacePluginsDir } from "../util/platform.js";
 import { reregisterExternalPlugin } from "./external-plugins-bootstrap.js";
@@ -267,6 +268,10 @@ export class PluginSourceWatcher {
           });
         },
       );
+      // Recursive watches over plugin trees (incl. node_modules) can exhaust
+      // the inotify watch limit and emit ENOSPC asynchronously. Without an
+      // 'error' listener that unhandled emitter error crashes the daemon.
+      attachFsWatcherErrorHandler(this.watcher, log, pluginsDir);
       log.info({ pluginsDir }, "Plugin source watcher started");
     } catch (err) {
       log.warn(

--- a/assistant/src/daemon/workspace-tools-watcher.ts
+++ b/assistant/src/daemon/workspace-tools-watcher.ts
@@ -57,6 +57,7 @@ import {
   loadSingleWorkspaceTool,
 } from "../tools/workspace-tools/loader.js";
 import { DebouncerMap } from "../util/debounce.js";
+import { attachFsWatcherErrorHandler } from "../util/fs-watcher-error.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceToolsDir } from "../util/platform.js";
 
@@ -154,6 +155,9 @@ export class WorkspaceToolsWatcher {
           });
         },
       );
+      // Async FSWatcher errors (e.g. ENOSPC, ENXIO) arrive as an 'error' event;
+      // without a listener they crash the daemon. Degrade to a dead watcher.
+      attachFsWatcherErrorHandler(this.watcher, log, toolsDir);
       log.info({ toolsDir }, "Workspace tools watcher started");
     } catch (err) {
       log.warn(

--- a/assistant/src/util/fs-watcher-error.ts
+++ b/assistant/src/util/fs-watcher-error.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared `'error'`-event handler for `fs.watch()` FSWatchers.
+ *
+ * An `FSWatcher` is an EventEmitter. When the underlying inotify/FSEvents
+ * backend fails *after* the watch was established — e.g. ENOSPC when the
+ * kernel's `fs.inotify.max_user_watches` limit is exhausted while walking a
+ * recursive watch into a large subtree (a plugin's `node_modules`), or ENXIO
+ * when a Unix socket file appears in a watched directory — the failure is
+ * delivered asynchronously as an `'error'` event rather than a synchronous
+ * throw from `watch()`. An emitter with no `'error'` listener rethrows, which
+ * surfaces as an `uncaughtException` and takes the whole daemon down (→
+ * CrashLoopBackOff).
+ *
+ * Attaching this handler degrades the failure to "this watcher stops
+ * delivering events", in line with the daemon startup philosophy: a subsystem
+ * failure must never crash the process.
+ */
+
+import type { FSWatcher } from "node:fs";
+
+import type { Logger } from "pino";
+
+/**
+ * Attach a resilient `'error'` listener so async FSWatcher failures are logged
+ * instead of crashing the process. Pass the owning module's logger and the
+ * watched directory for diagnostic context.
+ */
+export function attachFsWatcherErrorHandler(
+  watcher: FSWatcher,
+  log: Logger,
+  dir: string,
+): void {
+  watcher.on("error", (err) => {
+    log.warn({ err, dir }, "FSWatcher error (non-fatal, continuing)");
+  });
+}


### PR DESCRIPTION
## Why

An assistant was observed in `CrashLoopBackOff`. Every fatal exit traced to the same uncaught error:

```
ENOSPC: no space left on device, watch
'/workspace/plugins/image-fallback/node_modules/tldts-core/.../factory.js'
syscall: "watch", errno: -28
→ [lifecycle] Uncaught exception — initiating shutdown → exit 1
```

The root cause is **inotify watch-limit exhaustion** (the ENOSPC-on-`watch` variant, not the disk-full kind): `PluginSourceWatcher` runs `fs.watch(pluginsDir, { recursive: true })`, which recurses into each plugin's `node_modules` and registers an inotify watch per directory. When the node's `fs.inotify.max_user_watches` is exceeded, the kernel reports ENOSPC.

Crucially, that failure is delivered **asynchronously** as an `'error'` event on the `FSWatcher` (an `EventEmitter`), *not* as a synchronous throw from `watch()`. The watcher's existing `try/catch` only guards the synchronous path, so the emitter has no `'error'` listener — Node/Bun rethrows, it surfaces as an `uncaughtException`, and the lifecycle handler shuts the whole daemon down. Restart, same recursive walk, same ENOSPC → crash loop.

`config-watcher.ts` already defends against exactly this with a local `attachWatcherErrorHandler`. The plugin, app, and workspace-tools watchers did not.

## What

- Add a shared `attachFsWatcherErrorHandler(watcher, log, dir)` util that registers a non-fatal `'error'` listener.
- Wire it into the three unguarded watchers:
  - `plugin-source-watcher.ts` (the actual offender — recursive over `plugins/`)
  - `app-source-watcher.ts` (identical recursive pattern over `apps/`; would crash the daemon the same way)
  - `workspace-tools-watcher.ts` (non-recursive, but still vulnerable to async errors like ENXIO)
- Add regression tests asserting the registered handler swallows an ENOSPC `'error'` event without rethrowing.

This degrades the failure to "this watcher stops delivering events" instead of taking the process down — consistent with the documented daemon startup philosophy that a subsystem failure must never be fatal.

## Scope / follow-ups

This stops the **crash loop**. It does not raise the watch ceiling: the underlying inotify limit is node-level (`fs.inotify.max_user_watches` / `max_user_instances`) and needs a sysctl bump via the node pool / DaemonSet — out of scope for this repo. Separately, the crash-loop state is visible only in the operational-status banner and never lands in **System Events** (the control-plane `crash_loop` state is never bridged to a persisted event); worth a backend follow-up.

## Testing

- `bun test` for all three watcher suites passes, including the new ENOSPC regression tests.
- `prettier`, `eslint`, and `tsc --noEmit` all clean (verified via pre-commit hooks).
- Note: a pre-existing cross-suite flake (`workspace-tools` "flag off" test) reproduces on `main` when run alongside other real-`fs.watch` suites; it passes in isolation and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZjRRQzApLYKNWJHdVAaDh)_