### PR TITLE
fix(workspace): make auto-commit survive a giant git status and ignore plugin node_modules

### DIFF
--- a/assistant/src/__tests__/workspace-git-service.test.ts
+++ b/assistant/src/__tests__/workspace-git-service.test.ts
@@ -69,6 +69,7 @@ describe("WorkspaceGitService", () => {
       expect(content).toContain("*.sock");
       expect(content).toContain("*.pid");
       expect(content).toContain("session-token");
+      expect(content).toContain("plugins/*/node_modules/");
     });
 
     test("sets git identity correctly", async () => {
@@ -400,6 +401,30 @@ describe("WorkspaceGitService", () => {
 
       expect(status.clean).toBe(false);
       expect(status.staged).toContain("file.txt");
+    });
+
+    test("tolerates porcelain output larger than 1 MB without throwing", async () => {
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      // git status --porcelain prints one line per untracked entry. Enough
+      // long-named entries push the output well past Node's 1 MB execFile
+      // maxBuffer; the streamed read must handle it without surfacing
+      // ERR_CHILD_PROCESS_STDIO_MAXBUFFER. Files live in the (tracked) root
+      // so git reports them individually instead of collapsing a dir.
+      const fileCount = 6000;
+      const pad = "a".repeat(200);
+      for (let i = 0; i < fileCount; i++) {
+        writeFileSync(
+          join(testDir, `f${String(i).padStart(6, "0")}-${pad}`),
+          "",
+        );
+      }
+
+      const status = await service.getStatus();
+
+      expect(status.clean).toBe(false);
+      expect(status.untracked.length).toBe(fileCount);
     });
   });
 
@@ -805,7 +830,7 @@ describe("WorkspaceGitService", () => {
         cwd: testDir,
       });
       const gitignoreContent =
-        "# Runtime state - excluded from git tracking\ndata/db/\ndata/qdrant/\nlogs/\n*.log\n*.sock\n*.pid\n*.sqlite\n*.sqlite-journal\n*.sqlite-wal\n*.sqlite-shm\n*.db\n*.db-journal\n*.db-wal\n*.db-shm\nvellum.pid\nsession-token\n";
+        "# Runtime state - excluded from git tracking\ndata/db/\ndata/qdrant/\nplugins/*/node_modules/\nlogs/\n*.log\n*.sock\n*.pid\n*.sqlite\n*.sqlite-journal\n*.sqlite-wal\n*.sqlite-shm\n*.db\n*.db-journal\n*.db-wal\n*.db-shm\nvellum.pid\nsession-token\n";
       writeFileSync(join(testDir, ".gitignore"), gitignoreContent);
       writeFileSync(join(testDir, "file.txt"), "content");
       execFileSync("git", ["add", "-A"], { cwd: testDir });
@@ -905,6 +930,54 @@ describe("WorkspaceGitService", () => {
 
       expect(status.untracked).toContain("config.json");
       expect(status.untracked).toContain("README.md");
+    });
+
+    test("excludes plugin node_modules from computed status", async () => {
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      // Track the plugin dir first so git reports finer-grained untracked
+      // entries — an entirely-untracked dir collapses to a single line and
+      // would hide whether node_modules was filtered.
+      mkdirSync(join(testDir, "plugins", "image-fallback"), {
+        recursive: true,
+      });
+      writeFileSync(
+        join(testDir, "plugins", "image-fallback", "index.js"),
+        "x",
+      );
+      await service.commitChanges("add plugin");
+
+      // Plugin dependencies (ignored) alongside a real source change.
+      mkdirSync(
+        join(testDir, "plugins", "image-fallback", "node_modules", "dep"),
+        { recursive: true },
+      );
+      writeFileSync(
+        join(
+          testDir,
+          "plugins",
+          "image-fallback",
+          "node_modules",
+          "dep",
+          "big.js",
+        ),
+        "module.exports = {}",
+      );
+      writeFileSync(
+        join(testDir, "plugins", "image-fallback", "other.js"),
+        "y",
+      );
+
+      const status = await service.getStatus();
+
+      const allEntries = [
+        ...status.staged,
+        ...status.modified,
+        ...status.untracked,
+      ];
+      expect(allEntries.some((f) => f.includes("node_modules"))).toBe(false);
+      expect(status.untracked).toContain("plugins/image-fallback/other.js");
     });
   });
 
@@ -1099,6 +1172,46 @@ describe("WorkspaceGitService", () => {
         { bypassBreaker: true },
       );
       expect(result.committed).toBe(true);
+    });
+  });
+
+  describe("commitIfDirty status read resilience", () => {
+    test("status read failure does not trip the circuit breaker", async () => {
+      const service = new WorkspaceGitService(testDir);
+      await service.ensureInitialized();
+
+      writeFileSync(join(testDir, "test.txt"), "content");
+
+      // Simulate an oversized/failed `git status` read by making the streamed
+      // status call throw the way Node's maxBuffer overflow would.
+      const proto = Object.getPrototypeOf(service);
+      const originalStreaming = proto.execGitStreaming;
+      proto.execGitStreaming = async function () {
+        const err = new Error(
+          "Git command failed: git status --porcelain\n" +
+            "Error: stdout maxBuffer length exceeded",
+        ) as Error & { code?: string };
+        err.code = "ERR_CHILD_PROCESS_STDIO_MAXBUFFER";
+        throw err;
+      };
+
+      try {
+        const result = await service.commitIfDirty(() => ({
+          message: "should not commit",
+        }));
+        // Degrades to "no commit this tick" rather than throwing.
+        expect(result.committed).toBe(false);
+        // Breaker stays closed so the next cycle still runs.
+        expect(_getConsecutiveFailures(service)).toBe(0);
+      } finally {
+        proto.execGitStreaming = originalStreaming;
+      }
+
+      // Once status recovers, auto-commit proceeds — it was never disabled.
+      const recovered = await service.commitIfDirty(() => ({
+        message: "after status recovery",
+      }));
+      expect(recovered.committed).toBe(true);
     });
   });
 

--- a/assistant/src/__tests__/workspace-heartbeat-service.test.ts
+++ b/assistant/src/__tests__/workspace-heartbeat-service.test.ts
@@ -21,6 +21,7 @@ import type {
   CommitMessageResult,
 } from "../workspace/commit-message-provider.js";
 import {
+  _getConsecutiveFailures,
   _resetGitServiceRegistry,
   WorkspaceGitService,
 } from "../workspace/git-service.js";
@@ -87,6 +88,50 @@ describe("WorkspaceHeartbeatService", () => {
       expect(result.checked).toBe(1);
       expect(result.committed).toBe(0);
       expect(result.skipped).toBe(1);
+    });
+
+    test("continues (does not circuit-break) when a status read fails", async () => {
+      writeFileSync(join(testDir, "dirty.txt"), "content");
+
+      // Force the streamed status read to fail the way a maxBuffer overflow
+      // over a bloated working tree would.
+      const proto = Object.getPrototypeOf(service);
+      const originalStreaming = proto.execGitStreaming;
+      proto.execGitStreaming = async function () {
+        const err = new Error("stdout maxBuffer length exceeded") as Error & {
+          code?: string;
+        };
+        err.code = "ERR_CHILD_PROCESS_STDIO_MAXBUFFER";
+        throw err;
+      };
+
+      try {
+        const heartbeat = new WorkspaceHeartbeatService({
+          ageThresholdMs: 0,
+          fileThreshold: 1,
+          getServices: () => services,
+        });
+
+        const result = await heartbeat.check();
+
+        // The cycle is skipped, not failed — and the breaker stays closed.
+        expect(result.checked).toBe(1);
+        expect(result.failed).toBe(0);
+        expect(result.committed).toBe(0);
+        expect(_getConsecutiveFailures(service)).toBe(0);
+      } finally {
+        proto.execGitStreaming = originalStreaming;
+      }
+
+      // Once status recovers, the still-dirty workspace auto-commits — the
+      // heartbeat was never disabled.
+      const recovered = new WorkspaceHeartbeatService({
+        ageThresholdMs: 0,
+        fileThreshold: 1,
+        getServices: () => services,
+      });
+      const recoveredResult = await recovered.check();
+      expect(recoveredResult.committed).toBe(1);
     });
 
     test("does not commit when changes are below age and file thresholds", async () => {

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -1,4 +1,4 @@
-import { execFile, spawnSync } from "node:child_process";
+import { execFile, spawn, spawnSync } from "node:child_process";
 import {
   chmodSync,
   existsSync,
@@ -62,6 +62,7 @@ function cleanGitEnv(workspaceDir: string): Record<string, string> {
 const WORKSPACE_GITIGNORE_RULES = [
   "data/db/",
   "data/qdrant/",
+  "plugins/*/node_modules/",
   "logs/",
   "*.log",
   "*.sock",
@@ -607,7 +608,25 @@ export class WorkspaceGitService {
           };
         }
 
-        const status = await this.getStatusInternal();
+        // A status read can fail transiently (e.g. an oversized working tree
+        // or a momentary git error). Treat that as "no commit this tick"
+        // rather than a hard failure: returning didRunGit=false leaves the
+        // circuit breaker untouched so auto-commit/heartbeat keeps running
+        // instead of tripping dead until restart.
+        let status: GitStatus;
+        try {
+          status = await this.getStatusInternal();
+        } catch (statusErr) {
+          log.warn(
+            { err: statusErr, workspaceDir: this.workspaceDir },
+            "Skipping commit cycle: git status read failed",
+          );
+          return {
+            committed: false,
+            status: emptyStatus,
+            didRunGit: false as const,
+          };
+        }
         if (status.clean) {
           return { committed: false, status, didRunGit: true as const };
         }
@@ -681,7 +700,9 @@ export class WorkspaceGitService {
    * Internal status implementation (must be called with lock held).
    */
   private async getStatusInternal(): Promise<GitStatus> {
-    const { stdout } = await this.execGit(["status", "--porcelain"]);
+    // Streamed via spawn (not execFile) so an oversized status from a bloated
+    // working tree cannot exceed Node's default 1 MB maxBuffer and fail.
+    const { stdout } = await this.execGitStreaming(["status", "--porcelain"]);
 
     const staged: string[] = [];
     const modified: string[] = [];
@@ -877,33 +898,127 @@ export class WorkspaceGitService {
       });
       return { stdout, stderr };
     } catch (err) {
-      // Enhance error with git command details, preserving properties
-      // needed to distinguish transient failures from corruption.
-      const gitErr = err as Error & {
-        stdout?: string;
-        stderr?: string;
-        code?: string;
-        killed?: boolean;
-        signal?: string;
-      };
-      const isPermissionError =
-        gitErr.code === "EACCES" ||
-        gitErr.stderr?.includes("Permission denied");
-      const prefix = isPermissionError
-        ? "Git permission error"
-        : "Git command failed";
-      const enhanced = new Error(
-        `${prefix}: git ${args.join(" ")}\n` +
-          `Error: ${gitErr.message}\n` +
-          `Stderr: ${gitErr.stderr || ""}`,
-      );
-      // Preserve properties so callers can detect timeouts, permission
-      // errors, and missing-binary failures without parsing the message.
-      (enhanced as ExecError).killed = gitErr.killed;
-      (enhanced as ExecError).signal = gitErr.signal;
-      (enhanced as ExecError).code = gitErr.code;
-      throw enhanced;
+      const gitErr = err as ExecError & { stdout?: string; stderr?: string };
+      throw this.enhanceGitError(args, {
+        message: gitErr.message,
+        stderr: gitErr.stderr,
+        code: gitErr.code,
+        killed: gitErr.killed,
+        signal: gitErr.signal,
+      });
     }
+  }
+
+  /**
+   * Execute a git command, streaming stdout/stderr into buffers via `spawn`.
+   *
+   * Unlike {@link execGit} (which uses `execFile` with Node's 1 MB default
+   * `maxBuffer`), this has no fixed output ceiling — so commands whose output
+   * scales with working-tree size (`git status --porcelain` over a bloated
+   * workspace) cannot fail with `ERR_CHILD_PROCESS_STDIO_MAXBUFFER`. Used for
+   * read paths where output is unbounded; errors are enhanced identically to
+   * {@link execGit} so callers can still distinguish timeouts and permissions.
+   */
+  private execGitStreaming(
+    args: string[],
+    options?: { signal?: AbortSignal },
+  ): Promise<{ stdout: string; stderr: string }> {
+    const config = getConfig();
+    const timeoutMs = config.workspaceGit?.interactiveGitTimeoutMs ?? 10_000;
+    return new Promise((resolve, reject) => {
+      const child = spawn("git", args, {
+        cwd: this.workspaceDir,
+        env: cleanGitEnv(this.workspaceDir),
+        signal: options?.signal,
+      });
+
+      const stdoutChunks: Buffer[] = [];
+      const stderrChunks: Buffer[] = [];
+      let timedOut = false;
+      let settled = false;
+
+      const timer = setTimeout(() => {
+        timedOut = true;
+        child.kill("SIGTERM");
+      }, timeoutMs);
+
+      child.stdout?.on("data", (chunk: Buffer) => stdoutChunks.push(chunk));
+      child.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
+
+      child.on("error", (err: ExecError) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        reject(
+          this.enhanceGitError(args, {
+            message: err.message,
+            stderr: Buffer.concat(stderrChunks).toString("utf-8"),
+            code: err.code,
+            killed: err.killed,
+            signal: err.signal,
+          }),
+        );
+      });
+
+      child.on(
+        "close",
+        (code: number | null, signal: NodeJS.Signals | null) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          const stdout = Buffer.concat(stdoutChunks).toString("utf-8");
+          const stderr = Buffer.concat(stderrChunks).toString("utf-8");
+
+          if (code === 0 && !timedOut) {
+            resolve({ stdout, stderr });
+            return;
+          }
+
+          reject(
+            this.enhanceGitError(args, {
+              message: timedOut
+                ? `git ${args.join(" ")} timed out after ${timeoutMs}ms`
+                : `git ${args.join(" ")} exited with code ${code}`,
+              stderr,
+              code: timedOut ? undefined : (code ?? undefined),
+              killed: timedOut,
+              signal: signal ?? (timedOut ? "SIGTERM" : undefined),
+            }),
+          );
+        },
+      );
+    });
+  }
+
+  /**
+   * Build a descriptive Error for a failed git command, preserving the
+   * properties callers use to distinguish transient failures (timeouts,
+   * permissions, missing binary) from genuine corruption.
+   */
+  private enhanceGitError(
+    args: string[],
+    raw: {
+      message: string;
+      stderr?: string;
+      code?: string | number;
+      killed?: boolean;
+      signal?: string;
+    },
+  ): ExecError {
+    const isPermissionError =
+      raw.code === "EACCES" || raw.stderr?.includes("Permission denied");
+    const prefix = isPermissionError
+      ? "Git permission error"
+      : "Git command failed";
+    const enhanced = new Error(
+      `${prefix}: git ${args.join(" ")}\n` +
+        `Error: ${raw.message}\n` +
+        `Stderr: ${raw.stderr || ""}`,
+    ) as ExecError;
+    enhanced.killed = raw.killed;
+    enhanced.signal = raw.signal;
+    enhanced.code = raw.code;
+    return enhanced;
   }
 
   /**


### PR DESCRIPTION
## Why

Workspace auto-commit/heartbeat was circuit-breaking every ~5 min with:

```
Git command failed: git status --porcelain
Error: stdout maxBuffer length exceeded
code: ERR_CHILD_PROCESS_STDIO_MAXBUFFER
```

Node's `child_process` default `maxBuffer` is 1 MB. `git status --porcelain` over a bloated `/workspace` blows past it, the error propagates out of `commitIfDirty`, trips the circuit breaker, and auto-commit stays dead until the daemon restarts. The bloat source is the same as the prior ENOSPC incident: `plugins/*/node_modules/` (e.g. `image-fallback`) is never ignored, so plugin deps land in the working tree and inflate every status read.

## What

**1. Status read is unbounded and non-fatal** (`assistant/src/workspace/git-service.ts`)
- `getStatusInternal` now streams `git status --porcelain` via a new `execGitStreaming` (`spawn`-based, no fixed `maxBuffer` ceiling) so output size can't regress us again. Error enhancement (timeout/permission/missing-binary detection) is shared with `execGit` via an extracted `enhanceGitError` helper.
- `commitIfDirty` wraps the status read in try/catch: on failure it logs a warning and returns `committed: false` with `didRunGit: false`, leaving the circuit breaker untouched. A transient/oversized status degrades to "no commit this tick," not "auto-commit dead until restart."

**2. Stop the bloat at the source**
- `plugins/*/node_modules/` is added to `WORKSPACE_GITIGNORE_RULES`, the daemon-managed workspace `.gitignore`. It's appended on every init, so it survives workspace re-init.

## Tests
- Oversized (>1 MB) porcelain output is handled without throwing (6000 long-named untracked entries).
- Heartbeat continues (does not circuit-break) when a status read fails, and resumes committing once status recovers.
- `commitIfDirty` status-read failure leaves the breaker closed.
- Plugin `node_modules` paths are excluded from the computed status.

All `workspace-git-service` and `workspace-heartbeat-service` tests pass (80); lint, prettier, generic-examples, and full-project `tsc` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJ1EjiT1FrtxiVwmv4kqRW)_