### PR TITLE
Batch inspector export with a progress modal

### DIFF
--- a/clients/web/src/domains/chat/inspector/components/export-progress-modal.tsx
+++ b/clients/web/src/domains/chat/inspector/components/export-progress-modal.tsx
@@ -1,0 +1,134 @@
+import { AlertCircle, CheckCircle2, Download } from "lucide-react";
+import { type ReactNode } from "react";
+
+import { Button, Modal, ProgressBar } from "@vellumai/design-library";
+
+export type ExportPhase = "running" | "done" | "error";
+
+export interface ExportProgressModalProps {
+  open: boolean;
+  phase: ExportPhase;
+  /** Requests resolved so far. */
+  completed: number;
+  /** Total requests the export will issue. */
+  total: number;
+  /** Error message shown when `phase === "error"`. */
+  error: string | null;
+  onCancel: () => void;
+  onRetry: () => void;
+  onClose: () => void;
+}
+
+/**
+ * Determinate progress UI for the inspector ZIP export. The export fans out
+ * one request per LLM call (in capped batches), which can be thousands of
+ * requests for a long conversation — so we surface a progress bar and a
+ * cancel affordance instead of a bare "Exporting…" spinner.
+ *
+ * Purely presentational: the parent owns the export lifecycle and feeds it
+ * `phase`/`completed`/`total`.
+ */
+export function ExportProgressModal({
+  open,
+  phase,
+  completed,
+  total,
+  error,
+  onCancel,
+  onRetry,
+  onClose,
+}: ExportProgressModalProps): ReactNode {
+  const isRunning = phase === "running";
+  const fraction = total > 0 ? completed / total : 0;
+
+  // While running, the export shouldn't be dismissed out from under itself —
+  // the only exit is the explicit Cancel button.
+  return (
+    <Modal.Root
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && !isRunning) onClose();
+      }}
+    >
+      <Modal.Content
+        size="sm"
+        hideCloseButton={isRunning}
+        dismissOnOverlayClick={!isRunning}
+        onEscapeKeyDown={(event) => {
+          if (isRunning) event.preventDefault();
+        }}
+        onInteractOutside={(event) => {
+          if (isRunning) event.preventDefault();
+        }}
+      >
+        <Modal.Header>
+          <Modal.Title icon={phase === "error" ? AlertCircle : phase === "done" ? CheckCircle2 : Download}>
+            {phase === "error"
+              ? "Export failed"
+              : phase === "done"
+                ? "Export complete"
+                : "Exporting inspector data"}
+          </Modal.Title>
+          <Modal.Description>
+            {phase === "error"
+              ? "Something went wrong while collecting the export."
+              : phase === "done"
+                ? "Your download should have started automatically."
+                : "Collecting provider payloads and normalized context. This can take a moment for long conversations."}
+          </Modal.Description>
+        </Modal.Header>
+        <Modal.Body>
+          {phase === "error" ? (
+            <p
+              className="text-body-medium-default"
+              role="alert"
+              style={{ color: "var(--system-negative-strong)" }}
+            >
+              {error ?? "Failed to export inspector data."}
+            </p>
+          ) : (
+            <div className="flex flex-col gap-2">
+              <ProgressBar
+                value={phase === "done" ? 1 : fraction}
+                aria-label="Export progress"
+              />
+              <div
+                className="flex items-center justify-between text-label-default"
+                style={{ color: "var(--content-secondary)" }}
+              >
+                <span>
+                  {phase === "done"
+                    ? "Done"
+                    : completed >= total && total > 0
+                      ? "Packaging ZIP…"
+                      : `${completed} of ${total} calls`}
+                </span>
+                <span>{Math.round((phase === "done" ? 1 : fraction) * 100)}%</span>
+              </div>
+            </div>
+          )}
+        </Modal.Body>
+        <Modal.Footer>
+          {phase === "running" ? (
+            <Button variant="outlined" onClick={onCancel}>
+              Cancel
+            </Button>
+          ) : phase === "error" ? (
+            <>
+              <Button variant="outlined" onClick={onClose}>
+                Close
+              </Button>
+              <Button variant="primary" onClick={onRetry}>
+                Retry
+              </Button>
+            </>
+          ) : (
+            <Button variant="primary" onClick={onClose}>
+              Done
+            </Button>
+          )}
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal.Root>
+  );
+}

--- a/clients/web/src/domains/chat/inspector/inspect-page.tsx
+++ b/clients/web/src/domains/chat/inspector/inspect-page.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { AlertCircle, ArrowLeft, Download, MessageSquare } from "lucide-react";
-import { useMemo, useState, type ReactNode } from "react";
+import { useMemo, useRef, useState, type ReactNode } from "react";
 import { Link, useNavigate, useParams, useSearchParams } from "react-router";
 
 import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
@@ -12,16 +12,13 @@ import {
 } from "@/domains/chat/inspector/inspector-api";
 import {
     buildInspectorExportFilename,
-    buildInspectorExportZipBlob,
+    buildInspectorExportZipBlobBatched,
 } from "@/domains/chat/inspector/inspector-export";
 import {
     llmCallDetailQueryOptions,
     useLlmCallDetail,
 } from "@/domains/chat/inspector/inspector-detail-api";
-import {
-    llmLogPayloadQueryOptions,
-    type LlmLogPayload,
-} from "@/domains/chat/inspector/inspector-payload-api";
+import { llmLogPayloadQueryOptions } from "@/domains/chat/inspector/inspector-payload-api";
 import { normalizeContentBlocks } from "@/domains/chat/api/messages";
 import {
     supportsLlmContextSummaryView,
@@ -40,6 +37,10 @@ import type {
 import { Button } from "@vellumai/design-library";
 
 import { CallRail } from "./components/call-rail";
+import {
+    ExportProgressModal,
+    type ExportPhase,
+} from "./components/export-progress-modal";
 import { MobileCallSelector } from "./components/mobile-call-selector";
 import { TabBar, type InspectorTab } from "./components/tab-bar";
 import { CompactionTab } from "./components/tabs/compaction-tab";
@@ -243,6 +244,14 @@ interface HeaderProps {
   callCount: number | null;
 }
 
+/** Drives the {@link ExportProgressModal}; `null` means no export in flight. */
+interface ExportRun {
+  phase: ExportPhase;
+  completed: number;
+  total: number;
+  error: string | null;
+}
+
 function Header({
   assistantId,
   conversationId,
@@ -251,8 +260,9 @@ function Header({
   callCount,
 }: HeaderProps): ReactNode {
   const queryClient = useQueryClient();
-  const [isExporting, setIsExporting] = useState(false);
-  const [exportError, setExportError] = useState<string | null>(null);
+  const [exportRun, setExportRun] = useState<ExportRun | null>(null);
+  const exportAbortRef = useRef<AbortController | null>(null);
+  const isExporting = exportRun?.phase === "running";
 
   const { data: scopeMessages } = useConversationMessageList(
     assistantId,
@@ -268,25 +278,40 @@ function Header({
 
   async function handleExport(): Promise<void> {
     if (!assistantId || !context || isExporting) return;
-    setIsExporting(true);
-    setExportError(null);
+
+    const controller = new AbortController();
+    exportAbortRef.current = controller;
+    setExportRun({
+      phase: "running",
+      completed: 0,
+      total: context.logs.length,
+      error: null,
+    });
+
     try {
-      const payloads = await Promise.all(
-        context.logs.map((log): Promise<LlmLogPayload> => {
-          const options = llmLogPayloadQueryOptions(assistantId, log.id);
-          return queryClient.fetchQuery(options);
-        }),
-      );
-      const blob = await buildInspectorExportZipBlob(
-        context,
-        payloads,
-        (logId) =>
+      // Batched fetch (10 in flight) so a long conversation doesn't fire
+      // thousands of simultaneous requests at the daemon. Progress drives
+      // the modal's determinate progress bar.
+      const blob = await buildInspectorExportZipBlobBatched(context, {
+        fetchPayload: (logId) =>
+          queryClient.fetchQuery(
+            llmLogPayloadQueryOptions(assistantId, logId),
+          ),
+        fetchCallSections: (logId) =>
           supportsLlmContextSummaryView()
             ? queryClient.fetchQuery(
                 llmCallDetailQueryOptions(assistantId, logId),
               )
             : Promise.resolve(null),
-      );
+        onProgress: ({ completed, total }) =>
+          setExportRun((prev) =>
+            prev && prev.phase === "running"
+              ? { ...prev, completed, total }
+              : prev,
+          ),
+        signal: controller.signal,
+      });
+      if (controller.signal.aborted) return;
       const { saveFile } = await import("@/runtime/native-file");
       await saveFile(
         blob,
@@ -294,15 +319,29 @@ function Header({
           context.conversationId ?? conversationId,
         ),
       );
+      setExportRun((prev) => (prev ? { ...prev, phase: "done" } : prev));
     } catch (err) {
-      setExportError(
-        err && typeof err === "object" && "message" in err
-          ? String((err as { message: unknown }).message)
-          : "Failed to export inspector data",
-      );
+      if (controller.signal.aborted) return; // user cancelled
+      setExportRun((prev) => ({
+        phase: "error",
+        completed: prev?.completed ?? 0,
+        total: prev?.total ?? 0,
+        error:
+          err && typeof err === "object" && "message" in err
+            ? String((err as { message: unknown }).message)
+            : "Failed to export inspector data",
+      }));
     } finally {
-      setIsExporting(false);
+      if (exportAbortRef.current === controller) {
+        exportAbortRef.current = null;
+      }
     }
+  }
+
+  function handleCancelExport(): void {
+    exportAbortRef.current?.abort();
+    exportAbortRef.current = null;
+    setExportRun(null);
   }
 
   // Mobile-responsive layout:
@@ -352,38 +391,28 @@ function Header({
           >
             {isExporting ? "Exporting…" : "Export ZIP"}
           </Button>
-          <div className="hidden flex-col items-end gap-0.5 md:flex">
-            {callCount != null ? (
-              <span
-                className="text-label-default"
-                style={{ color: "var(--content-secondary)" }}
-              >
-                {callCount === 1 ? "1 LLM call" : `${callCount} LLM calls`}
-              </span>
-            ) : null}
-            {exportError ? (
-              <span
-                className="max-w-72 text-right text-body-small-default"
-                role="alert"
-                style={{ color: "var(--system-negative-strong)" }}
-              >
-                {exportError}
-              </span>
-            ) : null}
-          </div>
+          {callCount != null ? (
+            <span
+              className="hidden text-label-default md:inline"
+              style={{ color: "var(--content-secondary)" }}
+            >
+              {callCount === 1 ? "1 LLM call" : `${callCount} LLM calls`}
+            </span>
+          ) : null}
         </div>
-        {/* Mobile fallback for export errors — the desktop slot above is
-            hidden on narrow viewports so the error needs its own row. */}
-        {exportError ? (
-          <span
-            className="order-4 w-full text-body-small-default md:hidden"
-            role="alert"
-            style={{ color: "var(--system-negative-strong)" }}
-          >
-            {exportError}
-          </span>
-        ) : null}
       </div>
+      {exportRun ? (
+        <ExportProgressModal
+          open
+          phase={exportRun.phase}
+          completed={exportRun.completed}
+          total={exportRun.total}
+          error={exportRun.error}
+          onCancel={handleCancelExport}
+          onRetry={() => void handleExport()}
+          onClose={() => setExportRun(null)}
+        />
+      ) : null}
       <ScopeControls
         assistantId={assistantId}
         conversationId={conversationId}

--- a/clients/web/src/domains/chat/inspector/inspector-export.test.ts
+++ b/clients/web/src/domains/chat/inspector/inspector-export.test.ts
@@ -7,6 +7,9 @@ import {
   buildInspectorExportFilename,
   buildInspectorExportFiles,
   buildInspectorExportZipBlob,
+  buildInspectorExportZipBlobBatched,
+  INSPECTOR_EXPORT_CONCURRENCY,
+  type InspectorExportProgress,
 } from "@/domains/chat/inspector/inspector-export";
 
 function makeContext(): LlmContextResponse {
@@ -181,5 +184,104 @@ describe("inspector export", () => {
         throw new Error("detail fetch failed");
       }),
     ).rejects.toThrow("detail fetch failed");
+  });
+});
+
+function makeManyLogContext(count: number): LlmContextResponse {
+  return {
+    conversationId: "conv",
+    conversationKind: "chat",
+    conversationTotalEstimatedCostUsd: null,
+    memoryRecall: null,
+    memoryV2Activation: null,
+    // Section-less logs so the export hits both the payload and section fetchers.
+    logs: Array.from({ length: count }, (_, index) => ({
+      id: `log/${index}`,
+      createdAt: 1_715_200_000_000 + index,
+      requestPayload: null,
+      responsePayload: null,
+    })),
+  };
+}
+
+function payloadFor(logId: string): LlmLogPayload {
+  return { id: logId, requestPayload: null, responsePayload: null };
+}
+
+describe("inspector export (batched)", () => {
+  test("never exceeds the concurrency cap across both fetch phases", async () => {
+    const context = makeManyLogContext(35);
+    let inFlight = 0;
+    let peak = 0;
+
+    const track = async <T,>(produce: () => T): Promise<T> => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await Promise.resolve();
+      await Promise.resolve();
+      inFlight -= 1;
+      return produce();
+    };
+
+    const blob = await buildInspectorExportZipBlobBatched(context, {
+      fetchPayload: (logId) => track(() => payloadFor(logId)),
+      fetchCallSections: (logId) =>
+        track(() => ({
+          requestSections: [
+            { kind: "message", role: "user", label: "User", text: logId },
+          ],
+          responseSections: [],
+        })),
+    });
+
+    expect(blob.size).toBeGreaterThan(0);
+    expect(peak).toBeLessThanOrEqual(INSPECTOR_EXPORT_CONCURRENCY);
+  });
+
+  test("reports monotonic progress that ends at the total request count", async () => {
+    const context = makeManyLogContext(7);
+    const updates: InspectorExportProgress[] = [];
+
+    await buildInspectorExportZipBlobBatched(context, {
+      fetchPayload: async (logId) => payloadFor(logId),
+      fetchCallSections: async (logId) => ({
+        requestSections: [
+          { kind: "message", role: "user", label: "User", text: logId },
+        ],
+        responseSections: [],
+      }),
+      onProgress: (progress) => updates.push({ ...progress }),
+    });
+
+    // 7 payload fetches + 7 section fetches.
+    const total = 14;
+    expect(updates[0]).toEqual({ completed: 0, total });
+    expect(updates.at(-1)).toEqual({ completed: total, total });
+    for (let i = 1; i < updates.length; i += 1) {
+      expect(updates[i]!.completed).toBeGreaterThanOrEqual(
+        updates[i - 1]!.completed,
+      );
+      expect(updates[i]!.total).toBe(total);
+    }
+  });
+
+  test("stops fetching once the signal aborts", async () => {
+    const context = makeManyLogContext(40);
+    const controller = new AbortController();
+    let fetchCount = 0;
+
+    const promise = buildInspectorExportZipBlobBatched(context, {
+      concurrency: 4,
+      fetchPayload: async (logId) => {
+        fetchCount += 1;
+        if (fetchCount === 6) controller.abort();
+        return payloadFor(logId);
+      },
+      signal: controller.signal,
+    });
+
+    await expect(promise).rejects.toThrow();
+    // A few in-flight workers may finish, but it must not run all 40 logs.
+    expect(fetchCount).toBeLessThan(context.logs.length);
   });
 });

--- a/clients/web/src/domains/chat/inspector/inspector-export.ts
+++ b/clients/web/src/domains/chat/inspector/inspector-export.ts
@@ -141,6 +141,143 @@ export async function buildInspectorExportZipBlob(
   return zip.generateAsync({ type: "blob", mimeType: "application/zip" });
 }
 
+/** Default number of in-flight network requests during an export. */
+export const INSPECTOR_EXPORT_CONCURRENCY = 10;
+
+export interface InspectorExportProgress {
+  /** Network requests that have resolved so far. */
+  completed: number;
+  /** Total network requests the export will issue. */
+  total: number;
+}
+
+export type LlmLogPayloadFetcher = (logId: string) => Promise<LlmLogPayload>;
+
+export interface BuildInspectorExportBatchedOptions {
+  /** Fetches the raw provider request/response payload for one log. */
+  fetchPayload: LlmLogPayloadFetcher;
+  /** Fetches normalized sections for logs that don't carry them inline. */
+  fetchCallSections?: LlmCallSectionsFetcher;
+  /** Maximum concurrent requests. Defaults to {@link INSPECTOR_EXPORT_CONCURRENCY}. */
+  concurrency?: number;
+  /** Invoked after every request resolves so callers can render a progress bar. */
+  onProgress?: (progress: InspectorExportProgress) => void;
+  /** Aborts in-flight batching; the returned promise rejects with the abort reason. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Concurrency-limited variant of {@link buildInspectorExportZipBlob}.
+ *
+ * The original export issued one `Promise.all` over every log for provider
+ * payloads and a second over every log for normalized sections — so a
+ * conversation with N calls fired up to 2·N simultaneous requests (≈2k for a
+ * 1k-call conversation), hammering the daemon. This version pulls both phases
+ * through a fixed-size worker pool (default 10) and reports progress so the UI
+ * can show a determinate progress bar instead of an open-ended spinner.
+ */
+export async function buildInspectorExportZipBlobBatched(
+  context: LlmContextResponse,
+  {
+    fetchPayload,
+    fetchCallSections,
+    concurrency = INSPECTOR_EXPORT_CONCURRENCY,
+    onProgress,
+    signal,
+  }: BuildInspectorExportBatchedOptions,
+): Promise<Blob> {
+  const sectionLessLogs = fetchCallSections
+    ? context.logs.filter(
+        (log) => !log.requestSections && !log.responseSections,
+      )
+    : [];
+
+  const total = context.logs.length + sectionLessLogs.length;
+  let completed = 0;
+  const tick = (): void => {
+    completed += 1;
+    onProgress?.({ completed, total });
+  };
+  onProgress?.({ completed, total });
+
+  // Phase 1 — raw provider payloads, one per log.
+  const payloads = await mapWithConcurrency(
+    context.logs,
+    concurrency,
+    async (log): Promise<LlmLogPayload> => {
+      const payload = await fetchPayload(log.id);
+      tick();
+      return payload;
+    },
+    signal,
+  );
+
+  // Phase 2 — normalized sections, only for logs that lack them inline.
+  const sectionsByLogId = new Map<
+    string,
+    Pick<LLMRequestLogEntry, "requestSections" | "responseSections">
+  >();
+  if (fetchCallSections) {
+    await mapWithConcurrency(
+      sectionLessLogs,
+      concurrency,
+      async (log): Promise<void> => {
+        const detail = await fetchCallSections(log.id);
+        tick();
+        if (detail) sectionsByLogId.set(log.id, detail);
+      },
+      signal,
+    );
+  }
+
+  const hydratedLogs = context.logs.map((log): LLMRequestLogEntry => {
+    const detail = sectionsByLogId.get(log.id);
+    if (!detail) return log;
+    return {
+      ...log,
+      requestSections: detail.requestSections,
+      responseSections: detail.responseSections,
+    };
+  });
+
+  const zip = new JSZip();
+  for (const file of buildInspectorExportFiles(
+    { ...context, logs: hydratedLogs },
+    payloads,
+  )) {
+    zip.file(file.path, file.contents);
+  }
+  return zip.generateAsync({ type: "blob", mimeType: "application/zip" });
+}
+
+/**
+ * Maps `items` through `mapper` with at most `limit` calls in flight at once,
+ * preserving input order in the result. Rejects (and stops scheduling new work)
+ * as soon as the signal aborts or any mapper rejects.
+ */
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  mapper: (item: T, index: number) => Promise<R>,
+  signal?: AbortSignal,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  const workerCount = Math.max(1, Math.min(limit, items.length));
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (true) {
+      signal?.throwIfAborted();
+      const current = nextIndex++;
+      if (current >= items.length) return;
+      results[current] = await mapper(items[current], current);
+    }
+  }
+
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
+}
+
 /**
  * Lists fetched with `view=summary` omit per-log sections, so the
  * export hydrates each call from the per-log context endpoint. Logs


### PR DESCRIPTION
## Why

The LLM Context Inspector's **Export ZIP** button fired one request *per LLM call* up front:

- a `Promise.all` over every log for provider payloads, and
- a second `Promise.all` over every log for normalized sections.

So a long conversation (the report came from one with **1082 calls**) blasted the daemon with up to **~2k simultaneous requests** and left the button stuck in an open-ended `Exporting…` state with no feedback — effectively DDoSing our own assistant.

## What changed

Clicking **Export** now opens a user-friendly modal with a **determinate progress bar**, and both fetch phases are pulled through a fixed-size worker pool — **10 requests in flight at a time** — so we stop hammering the daemon.

- **`buildInspectorExportZipBlobBatched`** (in `inspector-export.ts`): concurrency-capped orchestrator that fetches payloads + sections through a `mapWithConcurrency` worker pool, reports `{ completed, total }` progress, and honors an `AbortSignal`. The original `buildInspectorExportZipBlob` is left intact.
- **`ExportProgressModal`**: presentational modal with the progress bar, a live `N of M calls` / percentage readout, and a `Packaging ZIP…` tail state. Non-dismissible while running (Cancel only); surfaces failures with a **Retry**, and a **Done** state once the download starts.
- **Inspector `Header`**: drives the batched export through the modal, with cancel (abort) and retry wiring. Inline header error text was removed in favor of the modal.

## Tests

- New `inspector-export (batched)` tests: concurrency never exceeds the cap across both phases, progress is monotonic and ends at the total request count, and aborting stops further fetches.
- Full inspector suite green (135 tests), `tsc --noEmit` clean, ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBPC9ZiD5rV8o1GtYfa7h4

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBPC9ZiD5rV8o1GtYfa7h4)_