### PR TITLE
Fix stuck "Assistant is upgrading" banner when an operation fails

### DIFF
--- a/clients/web/src/components/status-banner.test.tsx
+++ b/clients/web/src/components/status-banner.test.tsx
@@ -31,7 +31,14 @@ let assistantStateMock:
   { kind: "active", isLocal: false };
 let requestedOperationalStatusAssistantId: string | null | undefined;
 let operationalStatusQueryMock: {
-  data: { state: string } | null | undefined;
+  data:
+    | {
+        state: string;
+        detail_state?: string;
+        detail?: { reason?: string | null; message?: string | null };
+      }
+    | null
+    | undefined;
   isError: boolean;
   refetch?: () => void;
 } = {
@@ -305,6 +312,61 @@ describe("StatusBanner", () => {
       expect(html).toContain("text-[color:var(--system-info-strong)]");
       expect(html).toContain("animate-spin");
     }
+  });
+
+  test("renders a failed operation as an error instead of a spinner", () => {
+    operationalStatusQueryMock = {
+      data: {
+        state: "upgrading_assistant_version",
+        detail_state: "failed",
+        detail: { reason: "readiness_poll", message: null },
+      },
+      isError: false,
+    };
+
+    const html = renderToStaticMarkup(<StatusBanner />);
+
+    expect(html).toContain("Assistant upgrade failed");
+    expect(html).not.toContain("Assistant is upgrading");
+    expect(html).toContain('data-tone="error"');
+    expect(html).toContain("bg-[var(--system-negative-weak)]");
+    expect(html).toContain("lucide-triangle-alert");
+    expect(html).not.toContain("animate-spin");
+    expect(html).toContain("Go to Doctor");
+  });
+
+  test("surfaces the failure detail message when present", () => {
+    operationalStatusQueryMock = {
+      data: {
+        state: "resizing_machine",
+        detail_state: "failed",
+        detail: { reason: "quota_exceeded", message: "Out of capacity" },
+      },
+      isError: false,
+    };
+
+    const html = renderToStaticMarkup(<StatusBanner />);
+
+    expect(html).toContain("Machine resize failed");
+    expect(html).toContain("Out of capacity");
+    expect(html).toContain('data-tone="error"');
+  });
+
+  test("does not render Doctor action for local assistant failed operations", () => {
+    assistantStateMock = { kind: "active", isLocal: true };
+    operationalStatusQueryMock = {
+      data: {
+        state: "upgrading_assistant_version",
+        detail_state: "failed",
+        detail: { reason: "readiness_poll", message: null },
+      },
+      isError: false,
+    };
+
+    const html = renderToStaticMarkup(<StatusBanner />);
+
+    expect(html).toContain("Assistant upgrade failed");
+    expect(html).not.toContain("Go to Doctor");
   });
 
   test("uses a blue pulsing dot for waking", () => {

--- a/clients/web/src/components/status-banner.tsx
+++ b/clients/web/src/components/status-banner.tsx
@@ -234,6 +234,24 @@ const OPERATIONAL_STATUS_TITLES: Record<AssistantOperationalState, string> = {
   retiring: "Assistant is retiring",
 };
 
+// Titles shown when a transient operation fails. The platform keeps the
+// in-progress `state` (e.g. `upgrading_assistant_version`) but flips
+// `detail_state` to `"failed"`, so we surface a terminal failure message
+// rather than spinning on the operation forever.
+const OPERATIONAL_STATUS_FAILED_TITLES: Partial<
+  Record<AssistantOperationalState, string>
+> = {
+  initializing: "Assistant failed to initialize",
+  provisioning: "Assistant failed to provision",
+  waking: "Assistant failed to wake",
+  restarting: "Assistant restart failed",
+  restoring_backup: "Backup restore failed",
+  upgrading_assistant_version: "Assistant upgrade failed",
+  resizing_machine: "Machine resize failed",
+  resizing_storage: "Storage resize failed",
+  retiring: "Assistant failed to retire",
+};
+
 function maintenanceModeBannerConfig(): BannerConfig {
   return {
     tone: "warning",
@@ -260,6 +278,22 @@ function operationalStatusBannerConfig(
   showDoctorAction: boolean,
 ): BannerConfig | null {
   if (!status || isHealthyOperationalStatus(status)) return null;
+
+  // A transient operation (upgrade, resize, restart, …) can fail while the
+  // reported `state` is still the in-progress operation. The platform signals
+  // this via `detail_state: "failed"`. Surface it as an error so the banner
+  // doesn't spin indefinitely on a dead operation.
+  if (status.detail_state === "failed") {
+    const failedTitle = OPERATIONAL_STATUS_FAILED_TITLES[status.state];
+    if (failedTitle) {
+      return {
+        tone: "error",
+        title: failedTitle,
+        children: status.detail?.message ?? undefined,
+        actions: showDoctorAction ? doctorAction() : undefined,
+      };
+    }
+  }
 
   switch (status.state) {
     case "crash_loop":


### PR DESCRIPTION
## Problem

The status banner gets stuck showing "Assistant is upgrading" (an info-toned spinner) even when the operational-status API is actually reporting a **failed** operation.

This happens because `operationalStatusBannerConfig` switches solely on `status.state`. When a transient operation fails, the platform keeps the in-progress `state` but flips `detail_state` to `"failed"`:

```jsonc
{
  "state": "upgrading_assistant_version",
  "detail_state": "failed",
  "detail": { "reason": "readiness_poll", "message": null }
}
```

Since the banner ignored `detail_state`, the spinner spun indefinitely with no way for the user to tell the operation had died or to take action.

## Fix

Detect `detail_state === "failed"` for transient operation states (upgrade, resize, restart, restore, init, provision, wake, retire) and render a terminal **error** banner instead of the spinner:

- Error tone + triangle-alert icon
- A per-state failure title (e.g. "Assistant upgrade failed", "Machine resize failed")
- The `detail.message` as supporting text when the platform provides one
- The "Go to Doctor" action for platform-hosted assistants (omitted for local assistants, matching existing error-banner behavior)

Healthy/quiet states and non-failed operations are unchanged — the override only fires when `detail_state` is explicitly `"failed"`.

## Tests

Added coverage in `status-banner.test.tsx`:
- failed operation renders an error banner (no spinner, with Doctor action)
- `detail.message` is surfaced when present
- Doctor action is omitted for local assistants on failure

All 38 status-banner tests pass; `tsc --noEmit` and `eslint` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AeuDH357sgLpokrAbbr6oF)_