### PR TITLE
feat(migrations): make the migration runner async

### DIFF
--- a/assistant/scripts/memory-inspect.ts
+++ b/assistant/scripts/memory-inspect.ts
@@ -22,10 +22,13 @@ import {
   queryNodes,
 } from "../src/memory/graph/store.js";
 import type { ScoredNode } from "../src/memory/graph/types.js";
-import { initQdrantClient, resolveQdrantUrl } from "../src/memory/qdrant-client.js";
+import {
+  initQdrantClient,
+  resolveQdrantUrl,
+} from "../src/memory/qdrant-client.js";
 
 // Initialize DB and Qdrant before anything else
-initializeDb();
+await initializeDb();
 const config = getConfig();
 try {
   initQdrantClient({
@@ -83,7 +86,7 @@ async function main() {
   } else if (args.includes("--narrative")) {
     await runNarrative();
   } else if (args.includes("--decay")) {
-    runDecay();
+    await runDecay();
   } else {
     console.log(`Memory Graph Inspector
 
@@ -211,7 +214,8 @@ async function showStats() {
 }
 
 async function showContextLoad() {
-  const { loadContextMemory } = await import("../src/memory/graph/retriever.js");
+  const { loadContextMemory } =
+    await import("../src/memory/graph/retriever.js");
 
   console.log("\n  Simulating context load (conversation start)...\n");
 
@@ -227,7 +231,8 @@ async function showContextLoad() {
   console.log(`  Triggered: ${result.triggeredNodes.length} triggers fired`);
 
   // Show assembled context
-  const { assembleContextBlock } = await import("../src/memory/graph/injection.js");
+  const { assembleContextBlock } =
+    await import("../src/memory/graph/injection.js");
   const block = assembleContextBlock(result.nodes, {
     serendipityNodes: result.serendipityNodes,
   });
@@ -245,7 +250,8 @@ async function showContextLoad() {
 
 async function showQuery(query: string) {
   const { embedWithRetry } = await import("../src/memory/embed.js");
-  const { searchGraphNodes } = await import("../src/memory/graph/graph-search.js");
+  const { searchGraphNodes } =
+    await import("../src/memory/graph/graph-search.js");
   const { getNodesByIds } = await import("../src/memory/graph/store.js");
 
   console.log(`\n  Searching: "${query}"\n`);
@@ -369,7 +375,8 @@ function showNode(nodeId: string) {
 async function showTurn(userMessage: string) {
   const { retrieveForTurn } = await import("../src/memory/graph/retriever.js");
   const { InContextTracker } = await import("../src/memory/graph/injection.js");
-  const { assembleInjectionBlock } = await import("../src/memory/graph/injection.js");
+  const { assembleInjectionBlock } =
+    await import("../src/memory/graph/injection.js");
 
   const tracker = new InContextTracker();
 
@@ -440,7 +447,8 @@ async function runBootstrap() {
 }
 
 async function runJournalBootstrap() {
-  const { bootstrapFromJournal } = await import("../src/memory/graph/bootstrap.js");
+  const { bootstrapFromJournal } =
+    await import("../src/memory/graph/bootstrap.js");
 
   console.log("\n  Extracting from journal files...\n");
   const result = await bootstrapFromJournal();
@@ -450,7 +458,8 @@ async function runJournalBootstrap() {
 }
 
 async function runConsolidate() {
-  const { runConsolidation } = await import("../src/memory/graph/consolidation.js");
+  const { runConsolidation } =
+    await import("../src/memory/graph/consolidation.js");
   console.log("\n  Running consolidation...\n");
   const result = await runConsolidation("default", config);
   console.log(
@@ -469,7 +478,8 @@ async function runConsolidate() {
 }
 
 async function runPatterns() {
-  const { runPatternScan } = await import("../src/memory/graph/pattern-scan.js");
+  const { runPatternScan } =
+    await import("../src/memory/graph/pattern-scan.js");
   console.log("\n  Running pattern scan...\n");
   const result = await runPatternScan("default", config);
   console.log(
@@ -481,7 +491,8 @@ async function runPatterns() {
 }
 
 async function runNarrative() {
-  const { runNarrativeRefinement } = await import("../src/memory/graph/narrative.js");
+  const { runNarrativeRefinement } =
+    await import("../src/memory/graph/narrative.js");
   console.log("\n  Running narrative refinement...\n");
   const result = await runNarrativeRefinement("default", config);
   console.log(
@@ -500,9 +511,8 @@ async function runNarrative() {
   console.log();
 }
 
-function runDecay() {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { runDecayTick } = require("../src/memory/graph/decay.js") as typeof import("../src/memory/graph/decay.js");
+async function runDecay() {
+  const { runDecayTick } = await import("../src/memory/graph/decay.js");
   console.log("\n  Running decay tick...\n");
   const result = runDecayTick("default");
   console.log(`  Nodes processed: ${result.nodesProcessed}`);

--- a/assistant/src/__tests__/db-migration-rollback.test.ts
+++ b/assistant/src/__tests__/db-migration-rollback.test.ts
@@ -1038,7 +1038,7 @@ describe("rollbackMemoryMigration", () => {
     expect(cp1000!.value).toBe("1");
   });
 
-  test("clears forward-step checkpoints so a re-upgrade re-applies a rolled-back registry-backed step", () => {
+  test("clears forward-step checkpoints so a re-upgrade re-applies a rolled-back registry-backed step", async () => {
     /**
      * A registry-backed migration that is also a named forward step is tracked
      * in both the registry checkpoint (via withCrashRecovery) and the runner's
@@ -1083,7 +1083,7 @@ describe("rollbackMemoryMigration", () => {
     });
 
     // AND the step has run once through the runner, recording both checkpoints.
-    runMigrationSteps(db, [migrateTestStepRollback]);
+    await runMigrationSteps(db, [migrateTestStepRollback]);
     expect(hasTable()).toBe(true);
     expect(
       raw
@@ -1098,7 +1098,7 @@ describe("rollbackMemoryMigration", () => {
     expect(hasTable()).toBe(false);
 
     // WHEN the runner executes the forward steps again on a later upgrade.
-    runMigrationSteps(db, [migrateTestStepRollback]);
+    await runMigrationSteps(db, [migrateTestStepRollback]);
 
     // THEN the rolled-back step re-applies instead of being skipped.
     expect(hasTable()).toBe(true);

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -410,7 +410,7 @@ export async function runDaemon(): Promise<void> {
     // remains reachable for health checks and diagnostics.
     let dbReady = false;
     try {
-      initializeDb();
+      await initializeDb();
       dbReady = true;
       log.info("Daemon startup: DB initialized");
     } catch (err) {

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -332,7 +332,7 @@ function saveTemplate(): void {
 
 // ---------------------------------------------------------------------------
 
-export function initializeDb(): void {
+export async function initializeDb(): Promise<void> {
   if (process.env.BUN_TEST === "1" && tryRestoreTemplate()) {
     return;
   }
@@ -595,7 +595,7 @@ export function initializeDb(): void {
   // broken migration doesn't prevent independent later ones from succeeding.
   // The runner creates the checkpoint ledger, recovers crashed migrations, then
   // records each step so an already-migrated database skips it on later boots.
-  const { failed, skipped } = runMigrationSteps(database, migrationSteps);
+  const { failed, skipped } = await runMigrationSteps(database, migrationSteps);
 
   log.debug(
     {

--- a/assistant/src/memory/migrations/__tests__/run-migrations.test.ts
+++ b/assistant/src/memory/migrations/__tests__/run-migrations.test.ts
@@ -19,7 +19,7 @@ function createTestDb() {
 }
 
 describe("runMigrationSteps — checkpointing", () => {
-  test("does not re-execute a step that was already applied on a prior run", () => {
+  test("does not re-execute a step that was already applied on a prior run", async () => {
     /**
      * Booting an already-migrated database must not re-run forward migration
      * steps. With true checkpointing each step's body executes at most once
@@ -43,16 +43,16 @@ describe("runMigrationSteps — checkpointing", () => {
 
     // AND a database that has already been migrated once
     const db = createTestDb();
-    runMigrationSteps(db, steps);
+    await runMigrationSteps(db, steps);
 
     // WHEN the same steps run again against the already-migrated database
-    runMigrationSteps(db, steps);
+    await runMigrationSteps(db, steps);
 
     // THEN no step body executes a second time
     expect(calls).toEqual({ a: 1, b: 1, c: 1 });
   });
 
-  test("records step completions in the shared memory_checkpoints ledger", () => {
+  test("records step completions in the shared memory_checkpoints ledger", async () => {
     /**
      * Step bookkeeping lives in the same memory_checkpoints table the registry
      * uses, under the `step:` namespace — one ledger for all applied state.
@@ -60,7 +60,7 @@ describe("runMigrationSteps — checkpointing", () => {
 
     // GIVEN a single named step
     const db = createTestDb();
-    runMigrationSteps(db, [
+    await runMigrationSteps(db, [
       function dummyMigrationA() {
         // no-op
       },
@@ -75,7 +75,7 @@ describe("runMigrationSteps — checkpointing", () => {
     expect(row?.value).toBe("1");
   });
 
-  test("runs a newly appended step on a later boot while skipping applied ones", () => {
+  test("runs a newly appended step on a later boot while skipping applied ones", async () => {
     /**
      * Checkpointing must not block migrations added in a later release: an
      * already-applied step is skipped, but a brand-new step still runs.
@@ -90,7 +90,7 @@ describe("runMigrationSteps — checkpointing", () => {
       calls.b++;
     };
     const db = createTestDb();
-    runMigrationSteps(db, [stepA, stepB]);
+    await runMigrationSteps(db, [stepA, stepB]);
 
     // AND a third step appended to the list
     const stepC: MigrationStep = function dummyMigrationC() {
@@ -98,13 +98,13 @@ describe("runMigrationSteps — checkpointing", () => {
     };
 
     // WHEN the expanded list runs against the already-migrated database
-    runMigrationSteps(db, [stepA, stepB, stepC]);
+    await runMigrationSteps(db, [stepA, stepB, stepC]);
 
     // THEN only the newly appended step executes
     expect(calls).toEqual({ a: 1, b: 1, c: 1 });
   });
 
-  test("recovers crashed migrations before running steps", () => {
+  test("recovers crashed migrations before running steps", async () => {
     /**
      * runMigrationSteps clears stalled `started`/`rolling_back` checkpoints
      * before the loop so a migration interrupted mid-flight re-runs this boot.
@@ -121,7 +121,7 @@ describe("runMigrationSteps — checkpointing", () => {
     );
 
     // WHEN the runner executes
-    runMigrationSteps(db, [
+    await runMigrationSteps(db, [
       function dummyMigrationA() {
         // no-op
       },
@@ -136,7 +136,7 @@ describe("runMigrationSteps — checkpointing", () => {
     expect(row).toBeNull();
   });
 
-  test("does not checkpoint a failed step so it retries on the next boot", () => {
+  test("does not checkpoint a failed step so it retries on the next boot", async () => {
     /**
      * A step whose body throws is reported in `failed` and left uncheckpointed,
      * so the next boot retries it instead of silently skipping it.
@@ -153,21 +153,21 @@ describe("runMigrationSteps — checkpointing", () => {
       },
     ];
     const db = createTestDb();
-    const first = runMigrationSteps(db, steps);
+    const first = await runMigrationSteps(db, steps);
 
     // AND the first run reports the failure
     expect(first.failed).toEqual(["flakyStep"]);
 
     // WHEN the step runs again on the next boot
-    const second = runMigrationSteps(db, steps);
+    const second = await runMigrationSteps(db, steps);
 
     // THEN it retries, succeeds, and is then checkpointed
     expect(calls.flaky).toBe(2);
     expect(second.failed).toEqual([]);
-    expect(runMigrationSteps(db, steps).skipped).toEqual(["flakyStep"]);
+    expect((await runMigrationSteps(db, steps)).skipped).toEqual(["flakyStep"]);
   });
 
-  test("clearMigrationStepCheckpoints forces every step to re-run", () => {
+  test("clearMigrationStepCheckpoints forces every step to re-run", async () => {
     /**
      * Clearing the step namespace (as rollback does) makes the next run
      * re-execute and re-record all steps.
@@ -181,14 +181,87 @@ describe("runMigrationSteps — checkpointing", () => {
       },
     ];
     const db = createTestDb();
-    runMigrationSteps(db, steps);
+    await runMigrationSteps(db, steps);
     expect(calls.a).toBe(1);
 
     // WHEN the step checkpoints are cleared
     clearMigrationStepCheckpoints(db);
 
     // THEN the next run re-executes the step
-    runMigrationSteps(db, steps);
+    await runMigrationSteps(db, steps);
     expect(calls.a).toBe(2);
+  });
+
+  test("awaits an async step to completion before running or checkpointing the next", async () => {
+    /**
+     * An async step must be fully drained before the runner advances: ordering
+     * is the invariant later migrations rely on (step N+1 may assume N's result
+     * is true), and the step is checkpointed only after its promise resolves so
+     * a crash mid-drain leaves it uncheckpointed and retryable rather than
+     * recorded as done.
+     */
+
+    // GIVEN an async step that records its completion order only after yielding,
+    // followed by a sync step that records when it starts
+    const order: string[] = [];
+    const steps: MigrationStep[] = [
+      async function asyncDrainStep() {
+        await Promise.resolve();
+        order.push("async-done");
+      },
+      function followingStep() {
+        order.push("following-start");
+      },
+    ];
+    const db = createTestDb();
+
+    // WHEN the runner executes both steps
+    const result = await runMigrationSteps(db, steps);
+
+    // THEN the async step finishes before the next step starts
+    expect(order).toEqual(["async-done", "following-start"]);
+
+    // AND both steps are checkpointed, so a later boot skips them
+    expect(result.failed).toEqual([]);
+    expect((await runMigrationSteps(db, steps)).skipped).toEqual([
+      "asyncDrainStep",
+      "followingStep",
+    ]);
+  });
+
+  test("a rejected async step is reported failed and left uncheckpointed", async () => {
+    /**
+     * A step whose promise rejects must be treated exactly like a synchronous
+     * throw: reported in `failed`, not checkpointed, and retried next boot.
+     */
+
+    // GIVEN an async step that rejects on its first run and resolves afterwards
+    const calls = { flaky: 0 };
+    const steps: MigrationStep[] = [
+      async function flakyAsyncStep() {
+        calls.flaky++;
+        await Promise.resolve();
+        if (calls.flaky === 1) {
+          throw new Error("transient async failure");
+        }
+      },
+    ];
+    const db = createTestDb();
+
+    // WHEN it runs and rejects
+    const first = await runMigrationSteps(db, steps);
+
+    // THEN the rejection is reported and the step is not checkpointed
+    expect(first.failed).toEqual(["flakyAsyncStep"]);
+
+    // WHEN it runs again on the next boot
+    const second = await runMigrationSteps(db, steps);
+
+    // THEN it retries, resolves, and is then checkpointed
+    expect(calls.flaky).toBe(2);
+    expect(second.failed).toEqual([]);
+    expect((await runMigrationSteps(db, steps)).skipped).toEqual([
+      "flakyAsyncStep",
+    ]);
   });
 });

--- a/assistant/src/memory/migrations/run-migrations.ts
+++ b/assistant/src/memory/migrations/run-migrations.ts
@@ -7,8 +7,16 @@ const log = getLogger("db-init");
 /**
  * A single forward migration step, identified for checkpointing and logging by
  * its `.name`. Anonymous steps (empty `.name`) cannot be tracked and always run.
+ *
+ * A step may be synchronous or return a promise. The runner awaits an async
+ * step to completion before checkpointing it and moving on, so ordering is
+ * preserved exactly as for sync steps: step N+1 never starts — and is never
+ * skipped via checkpoint — until step N has fully finished. This lets a step
+ * that drains a large backfill in `await`ed batches run without blocking the
+ * thread between batches while still guaranteeing later migrations observe its
+ * completed result.
  */
-export type MigrationStep = (database: DrizzleDb) => void;
+export type MigrationStep = (database: DrizzleDb) => void | Promise<void>;
 
 export interface MigrationRunResult {
   /** Steps whose body threw. */
@@ -103,7 +111,8 @@ export function recoverCrashedMigrations(database: DrizzleDb): string[] {
  * Run the ordered list of forward migration steps against the database, each at
  * most once across boots.
  *
- * A step's name is recorded in `memory_checkpoints` after its body completes; on
+ * A step's name is recorded in `memory_checkpoints` after its body completes —
+ * for an async step, after its returned promise resolves; on
  * later boots an applied step is skipped instead of re-executed. This turns the
  * unconditional ~200-step re-probe — which floors daemon startup at tens of
  * seconds on a fully-migrated database — into a single bookkeeping read.
@@ -121,10 +130,10 @@ export function recoverCrashedMigrations(database: DrizzleDb): string[] {
  * not prevent independent later ones from succeeding; a failed step is not
  * checkpointed and is retried on the next boot.
  */
-export function runMigrationSteps(
+export async function runMigrationSteps(
   database: DrizzleDb,
   steps: MigrationStep[],
-): MigrationRunResult {
+): Promise<MigrationRunResult> {
   const raw = getSqliteFrom(database);
 
   ensureCheckpointsTable(raw);
@@ -158,7 +167,13 @@ export function runMigrationSteps(
 
     try {
       log.debug({ migration: name }, `Starting migration: ${name}`);
-      step(database);
+      // Await only steps that actually return a promise, so a list of purely
+      // synchronous steps runs to completion without yielding the thread — and
+      // an async step is fully drained before it is checkpointed below.
+      const result = step(database);
+      if (result instanceof Promise) {
+        await result;
+      }
       log.debug({ migration: name }, `Migration succeeded: ${name}`);
       if (checkpointable) {
         markApplied.run(`${STEP_CHECKPOINT_PREFIX}${name}`, Date.now());


### PR DESCRIPTION
## Summary

Make the memory-DB migration runner async so a migration step may return a promise. `runMigrationSteps` awaits an async step to completion **before** checkpointing it and advancing to the next step — preserving the ordering invariant later migrations rely on.

This is groundwork only: **no migration is async today.** It unblocks a follow-up where a step drains a large backfill in `await`ed batches without blocking the thread between batches, while still guaranteeing later migrations observe its completed result.

### Why

The runner's core guarantee is that a step is checkpointed *only after its body completes*, and step N+1 doesn't run until N is checkpointed — so "step is in the ledger" means "step is done," which every later migration implicitly leans on.

A tempting alternative for large backfills — keep the step instant and kick off a detached drain loop — quietly breaks that: the runner checkpoints the step as complete while the work is still in flight, so (a) a later migration can run against partial state, and (b) crash recovery stops covering it (a step checkpointed as `'1'` is never re-run). Making the runner async lets a batched drain be `await`ed in-step instead, keeping ordering and crash-safety intact.

### Changes

- **`memory/migrations/run-migrations.ts`** — `MigrationStep` may now return `void | Promise<void>`; `runMigrationSteps` is `async` and awaits a step's returned promise before checkpointing it. It awaits **only** steps that actually return a promise, so today's all-synchronous step list still runs to completion without yielding the thread.
- **`memory/db-init.ts`** — `initializeDb` is now `async` and awaits the runner.
- **`daemon/lifecycle.ts`** — `await initializeDb()` in `runDaemon`.
- **`scripts/memory-inspect.ts`** — top-level `await initializeDb()` (and converted a stray `require()` to `await import()` that a formatter reflow had un-guarded).
- **tests** — `run-migrations.test.ts` and `db-migration-rollback.test.ts` updated to await the runner, plus two new tests for the async path:
  - an async step is fully drained before the next step runs **and** before it is checkpointed;
  - a rejected async step is reported `failed`, left uncheckpointed, and retried next boot — matching the sync-throw behavior.

### Note on unawaited callers

`initializeDb()` has ~150 call sites, nearly all tests that call it synchronously at module top level. They are intentionally left unawaited: with the current all-sync step list the runner never yields, so the DB is fully migrated before control returns (only post-migration logging/template-save defers to a microtask), and `no-floating-promises` is not enabled. **Follow-up caveat:** if an async step is later added to `db-init`'s array, those call sites will need `await` — or the batched drain lives off this runner as a background job, in which case they stay fine.

### Verification

- `bunx tsc --noEmit`, eslint, prettier — clean (pre-commit/pre-push hooks pass)
- `bun test src/memory/migrations/__tests__/run-migrations.test.ts` — 8 pass (incl. 2 new async tests)
- `bun test src/__tests__/db-migration-rollback.test.ts` — 96 pass
- representative unawaited-caller tests (`turn-trace-store`, `db-memory-attach`) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCxgAg2eaYMhocHx7G3CPA)_