### PR TITLE
refactor: migrate secondary databases from ATTACH to dedicated connections

### DIFF
--- a/assistant/src/__tests__/auto-analysis-end-to-end.test.ts
+++ b/assistant/src/__tests__/auto-analysis-end-to-end.test.ts
@@ -132,7 +132,7 @@ mock.module("../runtime/services/analyze-conversation.js", () => ({
 
 import { conversationAnalyzeJob } from "../memory/conversation-analyze-job.js";
 import { createConversation } from "../memory/conversation-crud.js";
-import { getDb } from "../memory/db-connection.js";
+import { getDb, getMemoryDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { indexMessageNow } from "../memory/indexer.js";
 import type { MemoryJob } from "../memory/jobs-store.js";
@@ -157,7 +157,7 @@ function resetTables(): void {
   db.run("DELETE FROM memory_embeddings");
   db.run("DELETE FROM memory_graph_nodes");
   db.run("DELETE FROM memory_segments");
-  db.run("DELETE FROM memory_jobs");
+  getMemoryDb()!.run("DELETE FROM memory_jobs");
   db.run("DELETE FROM messages");
   db.run("DELETE FROM conversations");
 }
@@ -206,8 +206,7 @@ async function indexMessages(
 }
 
 function countJobsOfType(type: string, conversationId?: string): number {
-  const db = getDb();
-  const rows = db
+  const rows = getMemoryDb()!
     .select()
     .from(memoryJobs)
     .where(eq(memoryJobs.type, type))
@@ -234,8 +233,7 @@ function countJobsOfType(type: string, conversationId?: string): number {
 async function drainOneConversationAnalyzeJob(
   conversationId: string,
 ): Promise<boolean> {
-  const db = getDb();
-  const rows = db
+  const rows = getMemoryDb()!
     .select()
     .from(memoryJobs)
     .where(eq(memoryJobs.type, "conversation_analyze"))
@@ -427,8 +425,7 @@ describe("auto-analysis batch trigger uses analysis.batchSize cadence", () => {
 
     // Stronger: any pending analysis job must be debounced (runAfter
     // far in the future), not the immediate batch fire.
-    const db = getDb();
-    const analysisRows = db
+    const analysisRows = getMemoryDb()!
       .select()
       .from(memoryJobs)
       .where(eq(memoryJobs.type, "conversation_analyze"))
@@ -464,8 +461,7 @@ describe("auto-analysis batch trigger uses analysis.batchSize cadence", () => {
     await indexMessages(source.id, 1, 4);
     const after = Date.now();
 
-    const db = getDb();
-    const analysisRows = db
+    const analysisRows = getMemoryDb()!
       .select()
       .from(memoryJobs)
       .where(eq(memoryJobs.type, "conversation_analyze"))
@@ -520,8 +516,7 @@ describe("auto-analysis batch trigger uses analysis.batchSize cadence", () => {
     await indexMessages(source.id, 1, 1);
     const after = Date.now();
 
-    const db = getDb();
-    const graphRows = db
+    const graphRows = getMemoryDb()!
       .select()
       .from(memoryJobs)
       .where(eq(memoryJobs.type, "graph_extract"))

--- a/assistant/src/__tests__/compaction-trail-store.test.ts
+++ b/assistant/src/__tests__/compaction-trail-store.test.ts
@@ -31,7 +31,7 @@ mock.module("../config/loader.js", () => ({
 import { eq } from "drizzle-orm";
 
 import { createConversation } from "../memory/conversation-crud.js";
-import { getDb } from "../memory/db-connection.js";
+import { getDb, getLogsDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import {
   getCompactionLogsBetween,
@@ -44,7 +44,8 @@ initializeDb();
 
 function resetTables(): void {
   const db = getDb();
-  db.delete(llmRequestLogs).run();
+  // llm_request_logs lives in the dedicated logs connection.
+  getLogsDb()!.delete(llmRequestLogs).run();
   db.run("DELETE FROM messages");
   db.run("DELETE FROM conversations");
 }
@@ -72,8 +73,8 @@ function insertLogAt(
   // way `bun:sqlite` does, and a silent no-op there manifests as zero
   // rows in the query under test (the inserted `created_at` keeps its
   // `Date.now()` value and ends up far in the future of the cutoff).
-  const db = getDb();
-  db.update(llmRequestLogs)
+  getLogsDb()!
+    .update(llmRequestLogs)
     .set({ createdAt })
     .where(eq(llmRequestLogs.id, id))
     .run();

--- a/assistant/src/__tests__/conversation-delete-schedule-cleanup.test.ts
+++ b/assistant/src/__tests__/conversation-delete-schedule-cleanup.test.ts
@@ -35,7 +35,11 @@ import {
   createConversation,
   getConversation,
 } from "../memory/conversation-crud.js";
-import { getDb } from "../memory/db-connection.js";
+import {
+  getDb,
+  getLogsSqlite,
+  getMemorySqlite,
+} from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { ROUTES } from "../runtime/routes/conversation-management-routes.js";
 import { createSchedule, getSchedule } from "../schedule/schedule-store.js";
@@ -46,13 +50,9 @@ function getRawDb(): Database {
   return (getDb() as unknown as { $client: Database }).$client;
 }
 
-const deleteRoute = ROUTES.find(
-  (r) => r.operationId === "deleteConversation",
-)!;
+const deleteRoute = ROUTES.find((r) => r.operationId === "deleteConversation")!;
 
-const wipeRoute = ROUTES.find(
-  (r) => r.operationId === "wipeConversation",
-)!;
+const wipeRoute = ROUTES.find((r) => r.operationId === "wipeConversation")!;
 
 describe("DELETE /conversations/:id — schedule cleanup", () => {
   beforeEach(() => {
@@ -62,9 +62,9 @@ describe("DELETE /conversations/:id — schedule cleanup", () => {
     getRawDb().run("DELETE FROM memory_segments");
     getRawDb().run("DELETE FROM memory_summaries");
     getRawDb().run("DELETE FROM memory_embeddings");
-    getRawDb().run("DELETE FROM memory_jobs");
+    getMemorySqlite()!.run("DELETE FROM memory_jobs");
     getRawDb().run("DELETE FROM tool_invocations");
-    getRawDb().run("DELETE FROM llm_request_logs");
+    getLogsSqlite()!.run("DELETE FROM llm_request_logs");
     getRawDb().run("DELETE FROM messages");
     getRawDb().run("DELETE FROM conversations");
   });
@@ -87,7 +87,6 @@ describe("DELETE /conversations/:id — schedule cleanup", () => {
       pathParams: { id: conv.id },
       body: {},
       headers: {},
-
     });
 
     expect(getSchedule(schedule.id)).toBeNull();
@@ -107,7 +106,6 @@ describe("DELETE /conversations/:id — schedule cleanup", () => {
       pathParams: { id: conv.id },
       body: {},
       headers: {},
-
     });
 
     expect(getSchedule(schedule.id)).not.toBeNull();
@@ -143,7 +141,6 @@ describe("DELETE /conversations/:id — schedule cleanup", () => {
       pathParams: { id: conv.id },
       body: {},
       headers: {},
-
     });
 
     expect(getSchedule(schedule.id)).toBeNull();
@@ -173,7 +170,6 @@ describe("DELETE /conversations/:id — schedule cleanup", () => {
       pathParams: { id: conv1.id },
       body: {},
       headers: {},
-
     });
 
     expect(getSchedule(schedule.id)).not.toBeNull();
@@ -204,7 +200,6 @@ describe("DELETE /conversations/:id — schedule cleanup", () => {
       pathParams: { id: convA.id },
       body: {},
       headers: {},
-
     });
 
     expect(getSchedule(scheduleA.id)).toBeNull();
@@ -220,9 +215,9 @@ describe("POST /conversations/:id/wipe — schedule cleanup", () => {
     getRawDb().run("DELETE FROM memory_segments");
     getRawDb().run("DELETE FROM memory_summaries");
     getRawDb().run("DELETE FROM memory_embeddings");
-    getRawDb().run("DELETE FROM memory_jobs");
+    getMemorySqlite()!.run("DELETE FROM memory_jobs");
     getRawDb().run("DELETE FROM tool_invocations");
-    getRawDb().run("DELETE FROM llm_request_logs");
+    getLogsSqlite()!.run("DELETE FROM llm_request_logs");
     getRawDb().run("DELETE FROM messages");
     getRawDb().run("DELETE FROM conversations");
   });
@@ -245,7 +240,6 @@ describe("POST /conversations/:id/wipe — schedule cleanup", () => {
       pathParams: { id: conv.id },
       body: {},
       headers: {},
-
     });
 
     expect(getSchedule(schedule.id)).toBeNull();
@@ -264,7 +258,6 @@ describe("POST /conversations/:id/wipe — schedule cleanup", () => {
       pathParams: { id: conv.id },
       body: {},
       headers: {},
-
     });
 
     expect(getSchedule(schedule.id)).not.toBeNull();

--- a/assistant/src/__tests__/conversation-fork-crud.test.ts
+++ b/assistant/src/__tests__/conversation-fork-crud.test.ts
@@ -37,7 +37,7 @@ import {
   getMessages,
 } from "../memory/conversation-crud.js";
 import { getConversationDirPath } from "../memory/conversation-disk-view.js";
-import { getDb } from "../memory/db-connection.js";
+import { getDb, getLogsDb, getMemoryDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import {
   loadGraphMemoryState,
@@ -80,9 +80,9 @@ function resetTables(): void {
   db.delete(activationState).run();
   db.delete(conversationGraphMemoryState).run();
   db.delete(memoryRetrospectiveState).run();
-  db.delete(llmRequestLogs).run();
+  getLogsDb()!.delete(llmRequestLogs).run();
   db.delete(toolInvocations).run();
-  db.delete(memoryJobs).run();
+  getMemoryDb()!.delete(memoryJobs).run();
   db.run("DELETE FROM memory_v3_ever_injected");
   db.run("DELETE FROM message_attachments");
   db.run("DELETE FROM attachments");
@@ -682,7 +682,8 @@ describe("forkConversation", () => {
 
     const db = getDb();
     const now = Date.now();
-    db.insert(llmRequestLogs)
+    getLogsDb()!
+      .insert(llmRequestLogs)
       .values({
         id: "llm-log-1",
         conversationId: source.id,
@@ -705,7 +706,8 @@ describe("forkConversation", () => {
         createdAt: now,
       })
       .run();
-    db.insert(memoryJobs)
+    getMemoryDb()!
+      .insert(memoryJobs)
       .values({
         id: "memory-job-1",
         type: "delete_qdrant_vectors",
@@ -759,7 +761,7 @@ describe("forkConversation", () => {
     const forkState = getAttentionStateByConversationIds([fork.id]).get(
       fork.id,
     );
-    const forkRequestLogCount = db
+    const forkRequestLogCount = getLogsDb()!
       .select()
       .from(llmRequestLogs)
       .where(eq(llmRequestLogs.conversationId, fork.id))
@@ -774,7 +776,7 @@ describe("forkConversation", () => {
       .from(channelInboundEvents)
       .where(eq(channelInboundEvents.conversationId, fork.id))
       .all().length;
-    const forkQueuedWorkCount = db
+    const forkQueuedWorkCount = getMemoryDb()!
       .select()
       .from(memoryJobs)
       .where(like(memoryJobs.payload, `%${fork.id}%`))

--- a/assistant/src/__tests__/conversation-starter-routes.test.ts
+++ b/assistant/src/__tests__/conversation-starter-routes.test.ts
@@ -14,7 +14,7 @@ mock.module("../prompts/user-reference.js", () => ({
   resolveUserReference: () => "Alice",
 }));
 
-import { getSqlite } from "../memory/db-connection.js";
+import { getMemorySqlite, getSqlite } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import {
   CONVERSATION_STARTERS_STALE_TTL_MS,
@@ -66,7 +66,7 @@ function dispatch(path: string, method = "GET"): unknown | Promise<unknown> {
 function clearTables() {
   getSqlite().run("DELETE FROM conversation_starters");
   getSqlite().run("DELETE FROM memory_graph_nodes");
-  getSqlite().run("DELETE FROM memory_jobs");
+  getMemorySqlite()!.run("DELETE FROM memory_jobs");
   getSqlite().run("DELETE FROM memory_checkpoints");
 }
 
@@ -129,7 +129,7 @@ function setCheckpoint(key: string, value: string, updatedAt = Date.now()) {
 
 function insertStarterJob(scopeId = "default", status = "pending") {
   const now = Date.now();
-  getSqlite().run(
+  getMemorySqlite()!.run(
     `INSERT INTO memory_jobs (
       id, type, payload, status, attempts, deferrals, run_after, last_error,
       started_at, created_at, updated_at
@@ -140,7 +140,7 @@ function insertStarterJob(scopeId = "default", status = "pending") {
 
 function countStarterJobs() {
   return (
-    getSqlite()
+    getMemorySqlite()!
       .prepare(
         `SELECT COUNT(*) AS c FROM memory_jobs WHERE type = 'generate_conversation_starters'`,
       )

--- a/assistant/src/__tests__/conversation-wipe.test.ts
+++ b/assistant/src/__tests__/conversation-wipe.test.ts
@@ -14,7 +14,7 @@ import {
   getMessages,
   wipeConversation,
 } from "../memory/conversation-crud.js";
-import { getDb } from "../memory/db-connection.js";
+import { getDb, getLogsDb, getMemoryDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { enqueueMemoryJob } from "../memory/jobs-store.js";
 
@@ -28,9 +28,10 @@ describe("wipeConversation", () => {
     db.run(`DELETE FROM memory_segments`);
     db.run(`DELETE FROM memory_summaries`);
     db.run(`DELETE FROM memory_embeddings`);
-    db.run(`DELETE FROM memory_jobs`);
+    // memory_jobs / llm_request_logs live in their own dedicated connections.
+    getMemoryDb()!.run(`DELETE FROM memory_jobs`);
     db.run(`DELETE FROM tool_invocations`);
-    db.run(`DELETE FROM llm_request_logs`);
+    getLogsDb()!.run(`DELETE FROM llm_request_logs`);
     db.run(`DELETE FROM messages`);
     db.run(`DELETE FROM conversations`);
   });
@@ -98,9 +99,9 @@ describe("wipeConversation", () => {
       skipIndexing: true,
     });
 
-    // Clear any jobs that might have been created by prior operations
-    const db = getDb();
-    db.run(`DELETE FROM memory_jobs`);
+    // Clear any jobs that might have been created by prior operations.
+    // memory_jobs lives in the dedicated memory connection.
+    getMemoryDb()!.run(`DELETE FROM memory_jobs`);
 
     enqueueMemoryJob("graph_extract", { conversationId: conv.id });
     enqueueMemoryJob("build_conversation_summary", {
@@ -110,7 +111,7 @@ describe("wipeConversation", () => {
     const result = wipeConversation(conv.id);
 
     const raw = (
-      getDb() as unknown as {
+      getMemoryDb() as unknown as {
         $client: import("bun:sqlite").Database;
       }
     ).$client;

--- a/assistant/src/__tests__/db-test-helpers.ts
+++ b/assistant/src/__tests__/db-test-helpers.ts
@@ -1,5 +1,5 @@
 /**
- * Test-only utilities for resetting the assistant DB singleton.
+ * Test-only utilities for resetting the assistant DB singletons.
  *
  * Replaces the removed `resetDb` export from `db-connection.ts`. Lives
  * here (not in the source module) because production modules should not
@@ -7,52 +7,69 @@
  *
  * No source-module imports
  * ------------------------
- * This file has ZERO imports from `src/`. It accesses the DB singleton's
- * state via the shared `globalThis.vellumAssistant.dbSingleton` slot
+ * This file has ZERO imports from `src/`. It accesses the DB singletons'
+ * state via the shared `globalThis.vellumAssistant.dbSingletons` slots
  * that `src/memory/db-singleton.ts` also reads/writes. The slot shape
  * is duplicated here on purpose: keeping this file off the production
  * import graph is what protects the test preload from a broken
  * `node_modules` symlink (DB ghost #3). The two declarations MUST stay
  * in sync — if you change one, change the other.
  *
- * Production code that needs to close + reopen the DB (post-migration,
+ * Production code that needs to close + reopen the DBs (post-migration,
  * post-restore, post-vbundle-import, on shutdown) should use `resetDb()`
  * from `src/memory/db-connection.ts` instead.
  */
 
 // Mirrors `src/memory/db-singleton.ts`. Duplicated by design — see the
 // "No source-module imports" section above.
+type DbSlotKey = "main" | "logs" | "memory";
+
 type DbSlot = {
   db: unknown;
   closer: (() => void) | null;
 };
 
+type DbSlots = Record<DbSlotKey, DbSlot>;
+
 type VellumAssistantNamespace = {
-  dbSingleton?: DbSlot;
+  dbSingletons?: DbSlots;
 };
 
-function dbSlot(): DbSlot {
+function emptySlot(): DbSlot {
+  return { db: null, closer: null };
+}
+
+function dbSlots(): DbSlots {
   const g = globalThis as { vellumAssistant?: VellumAssistantNamespace };
   const ns = (g.vellumAssistant ??= {});
-  return (ns.dbSingleton ??= { db: null, closer: null });
+  return (ns.dbSingletons ??= {
+    main: emptySlot(),
+    logs: emptySlot(),
+    memory: emptySlot(),
+  });
 }
 
 /**
- * Close the active DB connection (if any) and drop the singleton.
+ * Close every active DB connection (main, logs, memory) and drop the
+ * singletons.
  *
- * Used by tests that nuke or replace the DB file mid-run — without this
- * reset, subsequent `getDb()` calls return a handle to the now-gone file.
- * Idempotent: safe to call when no connection has been opened.
+ * Used by tests that nuke or replace a DB file mid-run — without this
+ * reset, subsequent `getDb()`/`getLogsDb()`/`getMemoryDb()` calls return a
+ * handle to the now-gone file. Idempotent: safe to call when no connection
+ * has been opened.
  */
 export function resetDbForTesting(): void {
-  const s = dbSlot();
-  if (s.closer) {
-    try {
-      s.closer();
-    } catch {
-      /* best-effort close */
+  const slots = dbSlots();
+  for (const key of ["main", "logs", "memory"] as const) {
+    const s = slots[key];
+    if (s.closer) {
+      try {
+        s.closer();
+      } catch {
+        /* best-effort close */
+      }
     }
+    s.db = null;
+    s.closer = null;
   }
-  s.db = null;
-  s.closer = null;
 }

--- a/assistant/src/__tests__/jobs-store-qdrant-breaker.test.ts
+++ b/assistant/src/__tests__/jobs-store-qdrant-breaker.test.ts
@@ -15,7 +15,7 @@ mock.module("../config/loader.js", () => ({
 
 import { eq } from "drizzle-orm";
 
-import { getDb } from "../memory/db-connection.js";
+import { getMemoryDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import {
   claimMemoryJobs,
@@ -34,7 +34,7 @@ describe("claimMemoryJobs with Qdrant circuit breaker", () => {
   });
 
   beforeEach(() => {
-    const db = getDb();
+    const db = getMemoryDb()!;
     db.run("DELETE FROM memory_jobs");
     _resetQdrantBreaker();
   });
@@ -149,7 +149,7 @@ describe("claimMemoryJobs with Qdrant circuit breaker", () => {
     expect(embedClaimed).toHaveLength(2);
 
     // Remaining 10 jobs should still be pending.
-    const db = getDb();
+    const db = getMemoryDb()!;
     const pendingRows = db
       .select()
       .from(memoryJobs)

--- a/assistant/src/__tests__/jobs-store-upsert-debounced.test.ts
+++ b/assistant/src/__tests__/jobs-store-upsert-debounced.test.ts
@@ -15,12 +15,9 @@ mock.module("../config/loader.js", () => ({
 
 import { eq } from "drizzle-orm";
 
-import { getDb } from "../memory/db-connection.js";
+import { getMemoryDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
-import {
-  enqueueMemoryJob,
-  upsertDebouncedJob,
-} from "../memory/jobs-store.js";
+import { enqueueMemoryJob, upsertDebouncedJob } from "../memory/jobs-store.js";
 import { memoryJobs } from "../memory/schema.js";
 
 describe("upsertDebouncedJob payload refresh", () => {
@@ -29,7 +26,7 @@ describe("upsertDebouncedJob payload refresh", () => {
   });
 
   beforeEach(() => {
-    const db = getDb();
+    const db = getMemoryDb()!;
     db.run("DELETE FROM memory_jobs");
   });
 
@@ -49,7 +46,7 @@ describe("upsertDebouncedJob payload refresh", () => {
       Date.now(),
     );
 
-    const db = getDb();
+    const db = getMemoryDb()!;
     const rows = db
       .select()
       .from(memoryJobs)
@@ -79,7 +76,7 @@ describe("upsertDebouncedJob payload refresh", () => {
       Date.now(),
     );
 
-    const db = getDb();
+    const db = getMemoryDb()!;
     const rows = db
       .select()
       .from(memoryJobs)
@@ -106,7 +103,7 @@ describe("upsertDebouncedJob payload refresh", () => {
       runAfterNew,
     );
 
-    const db = getDb();
+    const db = getMemoryDb()!;
     const rows = db
       .select()
       .from(memoryJobs)
@@ -124,7 +121,7 @@ describe("upsertDebouncedJob payload refresh", () => {
       Date.now(),
     );
 
-    const db = getDb();
+    const db = getMemoryDb()!;
     const rows = db
       .select()
       .from(memoryJobs)

--- a/assistant/src/__tests__/llm-context-route-provider.test.ts
+++ b/assistant/src/__tests__/llm-context-route-provider.test.ts
@@ -7,7 +7,7 @@ mock.module("../util/logger.js", () => ({
     }),
 }));
 
-import { getDb } from "../memory/db-connection.js";
+import { getLogsDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { llmRequestLogs } from "../memory/schema.js";
 import { ROUTES } from "../runtime/routes/conversation-query-routes.js";
@@ -32,7 +32,7 @@ function dispatchLogPayload(logId: string) {
 }
 
 function clearRequestLogs(): void {
-  getDb().delete(llmRequestLogs).run();
+  getLogsDb()!.delete(llmRequestLogs).run();
 }
 
 function seedRequestLog(overrides: {
@@ -43,7 +43,7 @@ function seedRequestLog(overrides: {
   responsePayload: string;
   createdAt?: number;
 }): void {
-  getDb()
+  getLogsDb()!
     .insert(llmRequestLogs)
     .values({
       id: overrides.id,

--- a/assistant/src/__tests__/llm-request-log-agent-loop-exit-reason.test.ts
+++ b/assistant/src/__tests__/llm-request-log-agent-loop-exit-reason.test.ts
@@ -25,7 +25,7 @@ mock.module("../config/loader.js", () => ({
   }),
 }));
 
-import { getDb } from "../memory/db-connection.js";
+import { getLogsDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import {
   getRequestLogById,
@@ -36,9 +36,9 @@ import { llmRequestLogs } from "../memory/schema.js";
 
 initializeDb();
 
+// llm_request_logs lives in the dedicated logs connection.
 function resetLogs(): void {
-  const db = getDb();
-  db.delete(llmRequestLogs).run();
+  getLogsDb()!.delete(llmRequestLogs).run();
 }
 
 describe("setAgentLoopExitReasonOnLatestLog", () => {
@@ -105,7 +105,11 @@ describe("setAgentLoopExitReasonOnLatestLog", () => {
 
     // Current run lands a new log, then exits.
     Bun.sleepSync(2);
-    const current = recordRequestLog("conv-1", '{"cur_req":1}', '{"cur_res":1}');
+    const current = recordRequestLog(
+      "conv-1",
+      '{"cur_req":1}',
+      '{"cur_res":1}',
+    );
     setAgentLoopExitReasonOnLatestLog("conv-1", "yield_to_user");
 
     expect(getRequestLogById(prev)?.agentLoopExitReason).toBe("no_tool_calls");

--- a/assistant/src/__tests__/llm-request-log-call-site.test.ts
+++ b/assistant/src/__tests__/llm-request-log-call-site.test.ts
@@ -24,7 +24,7 @@ mock.module("../config/loader.js", () => ({
   }),
 }));
 
-import { getDb, getSqliteFrom } from "../memory/db-connection.js";
+import { getLogsDb, getSqliteFrom } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import {
   getRequestLogById,
@@ -35,9 +35,9 @@ import { llmRequestLogs } from "../memory/schema.js";
 
 initializeDb();
 
+// llm_request_logs lives in the dedicated logs connection.
 function resetLogs(): void {
-  const db = getDb();
-  db.delete(llmRequestLogs).run();
+  getLogsDb()!.delete(llmRequestLogs).run();
 }
 
 describe("recordRequestLog call_site stamping", () => {
@@ -100,7 +100,7 @@ describe("recordRequestLog call_site stamping", () => {
 
 describe("migrateLlmRequestLogCallSite", () => {
   test("adds the call_site column when missing", () => {
-    const db = getDb();
+    const db = getLogsDb()!;
     const raw = getSqliteFrom(db);
 
     // Drop the column if present (simulate pre-264 state). SQLite supports
@@ -126,7 +126,7 @@ describe("migrateLlmRequestLogCallSite", () => {
   });
 
   test("is idempotent — second run is a no-op", () => {
-    const db = getDb();
+    const db = getLogsDb()!;
     // First run (column may or may not exist depending on test order; either
     // path is fine for the idempotency contract).
     migrateLlmRequestLogCallSite(db);

--- a/assistant/src/__tests__/llm-request-log-turn-query.test.ts
+++ b/assistant/src/__tests__/llm-request-log-turn-query.test.ts
@@ -25,7 +25,7 @@ import {
   createConversation,
   forkConversation,
 } from "../memory/conversation-crud.js";
-import { getDb } from "../memory/db-connection.js";
+import { getDb, getLogsDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import {
   backfillMessageIdOnLogs,
@@ -37,9 +37,14 @@ import { llmRequestLogs, toolInvocations } from "../memory/schema.js";
 
 initializeDb();
 
+// llm_request_logs lives in the dedicated logs connection.
+function logsDb() {
+  return getLogsDb()!;
+}
+
 function resetTables(): void {
   const db = getDb();
-  db.delete(llmRequestLogs).run();
+  logsDb().delete(llmRequestLogs).run();
   db.delete(toolInvocations).run();
   db.run("DELETE FROM message_attachments");
   db.run("DELETE FROM attachments");
@@ -220,7 +225,8 @@ describe("getRequestLogsByMessageId — turn-aware query", () => {
     );
 
     // Orphaned log 1: message_id points to a deleted message
-    db.insert(llmRequestLogs)
+    logsDb()
+      .insert(llmRequestLogs)
       .values({
         id: "log-orphan-1",
         conversationId: conv.id,
@@ -233,7 +239,8 @@ describe("getRequestLogsByMessageId — turn-aware query", () => {
       .run();
 
     // Orphaned log 2
-    db.insert(llmRequestLogs)
+    logsDb()
+      .insert(llmRequestLogs)
       .values({
         id: "log-orphan-2",
         conversationId: conv.id,
@@ -246,7 +253,8 @@ describe("getRequestLogsByMessageId — turn-aware query", () => {
       .run();
 
     // Surviving log: backfilled to the surviving assistant message
-    db.insert(llmRequestLogs)
+    logsDb()
+      .insert(llmRequestLogs)
       .values({
         id: "log-surviving",
         conversationId: conv.id,
@@ -280,7 +288,8 @@ describe("getRequestLogsByMessageId — turn-aware query", () => {
     );
 
     // Unlinked log: messageId is NULL (backfill hasn't run yet)
-    db.insert(llmRequestLogs)
+    logsDb()
+      .insert(llmRequestLogs)
       .values({
         id: "log-unlinked-1",
         conversationId: conv.id,
@@ -293,7 +302,8 @@ describe("getRequestLogsByMessageId — turn-aware query", () => {
       .run();
 
     // Linked log: already backfilled to the assistant message
-    db.insert(llmRequestLogs)
+    logsDb()
+      .insert(llmRequestLogs)
       .values({
         id: "log-linked-1",
         conversationId: conv.id,
@@ -311,7 +321,7 @@ describe("getRequestLogsByMessageId — turn-aware query", () => {
     expect(logs[1]?.id).toBe("log-linked-1");
 
     // Verify opportunistic backfill ran: the unlinked log should now have a messageId
-    const backfilledLog = db
+    const backfilledLog = logsDb()
       .select({ messageId: llmRequestLogs.messageId })
       .from(llmRequestLogs)
       .where(sql`${llmRequestLogs.id} = 'log-unlinked-1'`)
@@ -332,7 +342,8 @@ describe("getRequestLogsByMessageId — turn-aware query", () => {
     db.run(
       sql`INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('a1-a', ${convA.id}, 'assistant', '"Hi A"', ${T + 10000})`,
     );
-    db.insert(llmRequestLogs)
+    logsDb()
+      .insert(llmRequestLogs)
       .values({
         id: "log-conv-a",
         conversationId: convA.id,
@@ -351,7 +362,8 @@ describe("getRequestLogsByMessageId — turn-aware query", () => {
     db.run(
       sql`INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('a1-b', ${convB.id}, 'assistant', '"Hi B"', ${T + 10000})`,
     );
-    db.insert(llmRequestLogs)
+    logsDb()
+      .insert(llmRequestLogs)
       .values({
         id: "log-conv-b",
         conversationId: convB.id,
@@ -386,7 +398,8 @@ describe("getRequestLogsByMessageId — turn-aware query", () => {
     db.run(
       sql`INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('a1-t', ${conv.id}, 'assistant', '"Answer 1"', ${T + 10000})`,
     );
-    db.insert(llmRequestLogs)
+    logsDb()
+      .insert(llmRequestLogs)
       .values({
         id: "log-turn1-unlinked",
         conversationId: conv.id,
@@ -405,7 +418,8 @@ describe("getRequestLogsByMessageId — turn-aware query", () => {
     db.run(
       sql`INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES ('a2-t', ${conv.id}, 'assistant', '"Answer 2"', ${T + 70000})`,
     );
-    db.insert(llmRequestLogs)
+    logsDb()
+      .insert(llmRequestLogs)
       .values({
         id: "log-turn2-unlinked",
         conversationId: conv.id,

--- a/assistant/src/__tests__/log-export-workspace.test.ts
+++ b/assistant/src/__tests__/log-export-workspace.test.ts
@@ -38,7 +38,7 @@ mock.module("../util/secure-keys.js", () => ({
   getSecureKeyAsync: async () => undefined,
 }));
 
-import { getDb } from "../memory/db-connection.js";
+import { getDb, getLogsDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import {
   conversations,
@@ -552,7 +552,7 @@ describe("POST /v1/export — manifest truncatedSections", () => {
         createdAt: now + i,
       }),
     );
-    db.insert(llmRequestLogs).values(rows).run();
+    getLogsDb()!.insert(llmRequestLogs).values(rows).run();
 
     const manifest = await readManifest({ full: true });
     expect(manifest.truncatedSections).toEqual(["llm-request-logs"]);

--- a/assistant/src/__tests__/memory-jobs-worker-lanes.test.ts
+++ b/assistant/src/__tests__/memory-jobs-worker-lanes.test.ts
@@ -110,7 +110,7 @@ mock.module("../memory/db-maintenance.js", () => ({
   maybeRunDbMaintenance: () => {},
 }));
 
-import { getDb } from "../memory/db-connection.js";
+import { getMemoryDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { enqueueMemoryJob } from "../memory/jobs-store.js";
 import { runMemoryJobsOnce } from "../memory/jobs-worker.js";
@@ -123,7 +123,7 @@ describe("memory jobs worker lane scheduling", () => {
   });
 
   beforeEach(() => {
-    const db = getDb();
+    const db = getMemoryDb()!;
     db.run("DELETE FROM memory_jobs");
     completions.length = 0;
     _resetQdrantBreaker();
@@ -185,7 +185,7 @@ describe("memory jobs worker lane scheduling", () => {
 function countSlowByStatus(
   status: "pending" | "running" | "completed",
 ): number {
-  const db = getDb();
+  const db = getMemoryDb()!;
   return db
     .select()
     .from(memoryJobs)

--- a/assistant/src/__tests__/memory-upsert-concurrency.test.ts
+++ b/assistant/src/__tests__/memory-upsert-concurrency.test.ts
@@ -60,7 +60,7 @@ mock.module("../config/loader.js", () => ({
   invalidateConfigCache: () => {},
 }));
 
-import { getDb } from "../memory/db-connection.js";
+import { getDb, getMemorySqlite } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { indexMessageNow } from "../memory/indexer.js";
 import { conversations, memorySegments, messages } from "../memory/schema.js";
@@ -73,7 +73,7 @@ function resetTables() {
   db.run("DELETE FROM memory_embeddings");
   db.run("DELETE FROM memory_graph_nodes");
   db.run("DELETE FROM memory_segments");
-  db.run("DELETE FROM memory_jobs");
+  getMemorySqlite()!.run("DELETE FROM memory_jobs");
   db.run("DELETE FROM messages");
   db.run("DELETE FROM conversations");
 }
@@ -550,4 +550,3 @@ describe("memory segment job atomicity under repeated indexer invocations", () =
     expect(storedSegments.length).toBe(firstCount);
   });
 });
-

--- a/assistant/src/__tests__/task-memory-cleanup.test.ts
+++ b/assistant/src/__tests__/task-memory-cleanup.test.ts
@@ -40,7 +40,7 @@ mock.module("../config/loader.js", () => ({
   invalidateConfigCache: () => {},
 }));
 
-import { getDb } from "../memory/db-connection.js";
+import { getDb, getMemoryDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { enqueueMemoryJob } from "../memory/jobs-store.js";
 import {
@@ -73,7 +73,8 @@ describe("invalidateAssistantInferredItemsForConversation", () => {
   beforeEach(() => {
     const db = getDb();
     db.run("DELETE FROM memory_graph_nodes");
-    db.run("DELETE FROM memory_jobs");
+    // memory_jobs lives in the dedicated memory connection.
+    getMemoryDb()!.run("DELETE FROM memory_jobs");
     db.run("DELETE FROM messages");
     db.run("DELETE FROM cron_runs");
     db.run("DELETE FROM cron_jobs");
@@ -525,7 +526,8 @@ describe("invalidateAssistantInferredItemsForConversation", () => {
     db.insert(memoryGraphNodes)
       .values({
         id: "item-cross-sched",
-        content: "cross-sourced schedule claim\nClaim from two failed schedules.",
+        content:
+          "cross-sourced schedule claim\nClaim from two failed schedules.",
         type: "semantic",
         created: now + 10,
         lastAccessed: now + 20,
@@ -742,7 +744,8 @@ describe("invalidateAssistantInferredItemsForConversation", () => {
     seedConversations();
     seedMessages();
 
-    const db = getDb();
+    // memory_jobs lives in the dedicated memory connection.
+    const db = getMemoryDb()!;
 
     // Enqueue graph_extract jobs for the target conversation
     enqueueMemoryJob("graph_extract", {

--- a/assistant/src/__tests__/turn-boundary-resolution.test.ts
+++ b/assistant/src/__tests__/turn-boundary-resolution.test.ts
@@ -23,7 +23,7 @@ import {
   createConversation,
   getAssistantMessageIdsInTurn,
 } from "../memory/conversation-crud.js";
-import { getDb } from "../memory/db-connection.js";
+import { getDb, getLogsDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { llmRequestLogs, toolInvocations } from "../memory/schema.js";
 
@@ -31,7 +31,7 @@ initializeDb();
 
 function resetTables(): void {
   const db = getDb();
-  db.delete(llmRequestLogs).run();
+  getLogsDb()!.delete(llmRequestLogs).run();
   db.delete(toolInvocations).run();
   db.run("DELETE FROM message_attachments");
   db.run("DELETE FROM attachments");

--- a/assistant/src/cli/commands/db/__tests__/repair.test.ts
+++ b/assistant/src/cli/commands/db/__tests__/repair.test.ts
@@ -431,20 +431,29 @@ async function initSchema(): Promise<void> {
   // The repair step opens its own bun:sqlite handle but expects the schema
   // to already exist (production-wise, the daemon creates it). Touching the
   // global init triggers schema creation against the env-isolated path.
-  const { initializeDb } = await import("../../../../memory/db-init.js");
-  initializeDb();
-  // Close the singleton so backfill can open its own handle without
-  // collision. WAL allows concurrent handles but cleaner ownership avoids
-  // test cross-talk through the in-process cache.
   const { getDb, getSqliteFrom } =
     await import("../../../../memory/db-connection.js");
   const { clearStoredDb } = await import("../../../../memory/db-singleton.js");
+  // Drop any connections a prior test (or test file) left open against a
+  // now-deleted workspace, so init below opens fresh handles — main and the
+  // dedicated logs/memory connections — at THIS test's workspace.
+  clearStoredDb("main");
+  clearStoredDb("logs");
+  clearStoredDb("memory");
+
+  const { initializeDb } = await import("../../../../memory/db-init.js");
+  initializeDb();
+  // Close the singletons so backfill can open its own handle without
+  // collision. WAL allows concurrent handles but cleaner ownership avoids
+  // test cross-talk through the in-process cache.
   try {
     getSqliteFrom(getDb()).close();
   } catch {
     /* already closed */
   }
-  clearStoredDb();
+  clearStoredDb("main");
+  clearStoredDb("logs");
+  clearStoredDb("memory");
 }
 
 describe("assistant db repair — conversation-backfill step", () => {

--- a/assistant/src/cli/commands/db/status.ts
+++ b/assistant/src/cli/commands/db/status.ts
@@ -77,18 +77,18 @@ interface StatusReport {
   file: FileFacts;
   db: DbFacts | null;
   /**
-   * The secondary append-only database (`assistant-logs.db`). Omitted from the
+   * The dedicated append-only database (`assistant-logs.db`). Omitted from the
    * report when the file does not exist yet — it is created the first time the
-   * daemon opens (and ATTACHes) the DB, so a fresh install that has never run
-   * the daemon won't have one.
+   * daemon opens its connection, so a fresh install that has never run the
+   * daemon won't have one.
    */
   logsFile?: FileFacts;
   logsDb?: DbFacts | null;
   /**
-   * The secondary memory database (`assistant-memory.db`). Like `logsFile`, it
+   * The dedicated memory database (`assistant-memory.db`). Like `logsFile`, it
    * is omitted from the report until the file exists on disk — it is created
-   * the first time the daemon opens (and ATTACHes) the DB, so a fresh install
-   * that has never run the daemon won't have one.
+   * the first time the daemon opens its connection, so a fresh install that has
+   * never run the daemon won't have one.
    */
   memoryFile?: FileFacts;
   memoryDb?: DbFacts | null;
@@ -393,7 +393,7 @@ export function registerDbStatus(parent: Command): void {
         process.exit(1);
       }
 
-      // Best-effort probe of the secondary append-only DB. It may not exist
+      // Best-effort probe of the dedicated append-only DB. It may not exist
       // yet (fresh install that has never started the daemon), and a probe
       // failure must never mask the main-DB report.
       const logsFile = readFileFacts(getLogsDbPath());
@@ -406,7 +406,7 @@ export function registerDbStatus(parent: Command): void {
         }
       }
 
-      // Same best-effort probe for the secondary memory DB.
+      // Same best-effort probe for the dedicated memory DB.
       const memoryFile = readFileFacts(getMemoryDbPath());
       let memoryDb: DbFacts | null = null;
       if (memoryFile.exists) {

--- a/assistant/src/memory/__tests__/db-logs-attach.test.ts
+++ b/assistant/src/memory/__tests__/db-logs-attach.test.ts
@@ -1,14 +1,15 @@
 /**
- * Tests for the secondary append-only database file wiring (PR 1).
+ * Tests for the dedicated logs database connection.
  *
  * What this locks in:
- *   1. Opening the connection ATTACHes `assistant-logs.db` as the `logs`
- *      schema and creates the file on disk.
- *   2. The attached schema runs in WAL mode (its own `-wal`, independent of
- *      the main DB) — the regression that lets a heavy append-only table
- *      bloat the *main* WAL is exactly what this split exists to prevent.
- *   3. A table created in the `logs` schema lives in the separate file, not
- *      in `main` — proving the physical split rather than just an alias.
+ *   1. Opening the logs connection creates `assistant-logs.db` on disk and
+ *      runs it in WAL mode (its own `-wal`, independent of the main DB) — the
+ *      regression that lets a heavy append-only table bloat the *main* WAL is
+ *      exactly what this split exists to prevent.
+ *   2. The main connection no longer ATTACHes the logs file: there is no
+ *      `logs` schema on its `database_list`.
+ *   3. `llm_request_logs` lives in the dedicated logs connection, not in the
+ *      main connection — proving the physical split.
  *   4. `runAsyncSqlite({ dbPath })` targets the given file via the sqlite3
  *      CLI backend, leaving the main DB untouched.
  */
@@ -19,7 +20,7 @@ import { describe, expect, test } from "bun:test";
 
 import { removeTestDbFiles } from "../../__tests__/assert-not-live-db.js";
 
-const { getSqlite, LOGS_DB_SCHEMA } = await import("../db-connection.js");
+const { getSqlite, getLogsSqlite } = await import("../db-connection.js");
 const { initializeDb } = await import("../db-init.js");
 const { runAsyncSqlite } = await import("../db-async-query.js");
 const { getLogsDbPath } = await import("../../util/logs-db-path.js");
@@ -29,54 +30,41 @@ initializeDb();
 
 const sqlite3Available = findSqlite3() !== undefined;
 
-describe("logs database attachment", () => {
-  test("ATTACHes the logs file as the logs schema and creates it on disk", () => {
-    // Touch the connection so the attach runs.
-    getSqlite();
+describe("logs database connection", () => {
+  test("opens the logs file and creates it on disk in WAL mode", () => {
+    const logs = getLogsSqlite();
+    expect(logs).not.toBeNull();
     expect(existsSync(getLogsDbPath())).toBe(true);
 
-    const attached = getSqlite()
-      .query<{ name: string; file: string }, []>("PRAGMA database_list")
-      .all();
-    const logsEntry = attached.find((e) => e.name === LOGS_DB_SCHEMA);
-    expect(logsEntry).toBeDefined();
-    expect(logsEntry?.file).toBe(getLogsDbPath());
-  });
-
-  test("the attached schema runs in WAL mode", () => {
-    const mode = getSqlite()
-      .query<
-        { journal_mode: string },
-        []
-      >(`PRAGMA ${LOGS_DB_SCHEMA}.journal_mode`)
+    const mode = logs!
+      .query<{ journal_mode: string }, []>("PRAGMA journal_mode")
       .get();
     expect(mode?.journal_mode).toBe("wal");
   });
 
-  test("a table created in the logs schema lives in the logs file, not main", () => {
-    const sqlite = getSqlite();
-    sqlite.exec(
-      `CREATE TABLE IF NOT EXISTS ${LOGS_DB_SCHEMA}.attach_probe (id INTEGER PRIMARY KEY)`,
-    );
-    try {
-      const inLogs = sqlite
-        .query<
-          { name: string },
-          []
-        >(`SELECT name FROM ${LOGS_DB_SCHEMA}.sqlite_master WHERE name = 'attach_probe'`)
-        .get();
-      expect(inLogs?.name).toBe("attach_probe");
+  test("the main connection does not attach the logs file", () => {
+    const attached = getSqlite()
+      .query<{ name: string }, []>("PRAGMA database_list")
+      .all();
+    expect(attached.some((e) => e.name === "logs")).toBe(false);
+  });
 
-      const inMain = sqlite
-        .query<
-          { name: string },
-          []
-        >(`SELECT name FROM main.sqlite_master WHERE name = 'attach_probe'`)
-        .get();
-      expect(inMain).toBeNull();
-    } finally {
-      sqlite.exec(`DROP TABLE ${LOGS_DB_SCHEMA}.attach_probe`);
-    }
+  test("llm_request_logs lives in the logs connection, not main", () => {
+    const inLogs = getLogsSqlite()!
+      .query<
+        { name: string },
+        []
+      >(`SELECT name FROM sqlite_master WHERE type='table' AND name='llm_request_logs'`)
+      .get();
+    expect(inLogs?.name).toBe("llm_request_logs");
+
+    const inMain = getSqlite()
+      .query<
+        { name: string },
+        []
+      >(`SELECT name FROM main.sqlite_master WHERE name='llm_request_logs'`)
+      .get();
+    expect(inMain).toBeNull();
   });
 
   test.if(sqlite3Available)(

--- a/assistant/src/memory/__tests__/db-memory-attach.test.ts
+++ b/assistant/src/memory/__tests__/db-memory-attach.test.ts
@@ -1,15 +1,15 @@
 /**
- * Tests for the secondary memory database file wiring (infra PR).
+ * Tests for the dedicated memory database connection.
  *
  * What this locks in:
- *   1. Opening the connection ATTACHes `assistant-memory.db` as the `memory`
- *      schema and creates the file on disk.
- *   2. The attached schema runs in WAL mode (its own `-wal`, independent of
- *      the main DB) — the regression that lets a high-churn table (the
- *      `memory_jobs` queue) bloat the *main* WAL is exactly what this split
- *      exists to prevent.
- *   3. A table created in the `memory` schema lives in the separate file, not
- *      in `main` — proving the physical split rather than just an alias.
+ *   1. Opening the memory connection creates `assistant-memory.db` on disk and
+ *      runs it in WAL mode (its own `-wal`, independent of the main DB) — the
+ *      regression that lets a high-churn table (the `memory_jobs` queue) bloat
+ *      the *main* WAL is exactly what this split exists to prevent.
+ *   2. The main connection no longer ATTACHes the memory file: there is no
+ *      `memory` schema on its `database_list`.
+ *   3. `memory_jobs` lives in the dedicated memory connection, not in the main
+ *      connection — proving the physical split.
  *   4. `runAsyncSqlite({ dbPath })` targets the given file via the sqlite3
  *      CLI backend, leaving the main DB untouched.
  */
@@ -20,7 +20,7 @@ import { describe, expect, test } from "bun:test";
 
 import { removeTestDbFiles } from "../../__tests__/assert-not-live-db.js";
 
-const { getSqlite, MEMORY_DB_SCHEMA } = await import("../db-connection.js");
+const { getSqlite, getMemorySqlite } = await import("../db-connection.js");
 const { initializeDb } = await import("../db-init.js");
 const { runAsyncSqlite } = await import("../db-async-query.js");
 const { getMemoryDbPath } = await import("../../util/memory-db-path.js");
@@ -30,54 +30,41 @@ initializeDb();
 
 const sqlite3Available = findSqlite3() !== undefined;
 
-describe("memory database attachment", () => {
-  test("ATTACHes the memory file as the memory schema and creates it on disk", () => {
-    // Touch the connection so the attach runs.
-    getSqlite();
+describe("memory database connection", () => {
+  test("opens the memory file and creates it on disk in WAL mode", () => {
+    const memory = getMemorySqlite();
+    expect(memory).not.toBeNull();
     expect(existsSync(getMemoryDbPath())).toBe(true);
 
-    const attached = getSqlite()
-      .query<{ name: string; file: string }, []>("PRAGMA database_list")
-      .all();
-    const memoryEntry = attached.find((e) => e.name === MEMORY_DB_SCHEMA);
-    expect(memoryEntry).toBeDefined();
-    expect(memoryEntry?.file).toBe(getMemoryDbPath());
-  });
-
-  test("the attached schema runs in WAL mode", () => {
-    const mode = getSqlite()
-      .query<
-        { journal_mode: string },
-        []
-      >(`PRAGMA ${MEMORY_DB_SCHEMA}.journal_mode`)
+    const mode = memory!
+      .query<{ journal_mode: string }, []>("PRAGMA journal_mode")
       .get();
     expect(mode?.journal_mode).toBe("wal");
   });
 
-  test("a table created in the memory schema lives in the memory file, not main", () => {
-    const sqlite = getSqlite();
-    sqlite.exec(
-      `CREATE TABLE IF NOT EXISTS ${MEMORY_DB_SCHEMA}.attach_probe (id INTEGER PRIMARY KEY)`,
-    );
-    try {
-      const inMemory = sqlite
-        .query<
-          { name: string },
-          []
-        >(`SELECT name FROM ${MEMORY_DB_SCHEMA}.sqlite_master WHERE name = 'attach_probe'`)
-        .get();
-      expect(inMemory?.name).toBe("attach_probe");
+  test("the main connection does not attach the memory file", () => {
+    const attached = getSqlite()
+      .query<{ name: string }, []>("PRAGMA database_list")
+      .all();
+    expect(attached.some((e) => e.name === "memory")).toBe(false);
+  });
 
-      const inMain = sqlite
-        .query<
-          { name: string },
-          []
-        >(`SELECT name FROM main.sqlite_master WHERE name = 'attach_probe'`)
-        .get();
-      expect(inMain).toBeNull();
-    } finally {
-      sqlite.exec(`DROP TABLE ${MEMORY_DB_SCHEMA}.attach_probe`);
-    }
+  test("memory_jobs lives in the memory connection, not main", () => {
+    const inMemory = getMemorySqlite()!
+      .query<
+        { name: string },
+        []
+      >(`SELECT name FROM sqlite_master WHERE type='table' AND name='memory_jobs'`)
+      .get();
+    expect(inMemory?.name).toBe("memory_jobs");
+
+    const inMain = getSqlite()
+      .query<
+        { name: string },
+        []
+      >(`SELECT name FROM main.sqlite_master WHERE name='memory_jobs'`)
+      .get();
+    expect(inMain).toBeNull();
   });
 
   test.if(sqlite3Available)(

--- a/assistant/src/memory/__tests__/jobs-store-enqueue-gate.test.ts
+++ b/assistant/src/memory/__tests__/jobs-store-enqueue-gate.test.ts
@@ -71,6 +71,8 @@ mock.module("../qdrant-circuit-breaker.js", () => ({
 mock.module("../raw-query.js", () => ({
   rawAll: () => [],
   rawChanges: () => 0,
+  rawMemoryAll: () => [],
+  rawMemoryChanges: () => 0,
 }));
 
 // Drizzle-shaped no-op db. Tracks inserts/updates so tests can observe
@@ -111,6 +113,7 @@ function makeStubDb() {
 const stubDb = makeStubDb();
 mock.module("../db-connection.js", () => ({
   getDb: () => stubDb,
+  getMemoryDb: () => stubDb,
 }));
 
 // Now load the real modules under test.

--- a/assistant/src/memory/__tests__/jobs-worker-v2-graph-trigger-embed.test.ts
+++ b/assistant/src/memory/__tests__/jobs-worker-v2-graph-trigger-embed.test.ts
@@ -67,7 +67,7 @@ const tmpWorkspace = mkdtempSync(
 const previousWorkspaceEnv = process.env.VELLUM_WORKSPACE_DIR;
 process.env.VELLUM_WORKSPACE_DIR = tmpWorkspace;
 
-import { getDb } from "../db-connection.js";
+import { getMemoryDb } from "../db-connection.js";
 import { initializeDb } from "../db-init.js";
 import { enqueueMemoryJob } from "../jobs-store.js";
 import { runMemoryJobsOnce } from "../jobs-worker.js";
@@ -89,7 +89,7 @@ describe("graph_trigger_embed under memory v2", () => {
   });
 
   beforeEach(() => {
-    getDb().run("DELETE FROM memory_jobs");
+    getMemoryDb()!.run("DELETE FROM memory_jobs");
     triggerHandlerCalls = 0;
     _resetQdrantBreaker();
   });
@@ -103,7 +103,7 @@ describe("graph_trigger_embed under memory v2", () => {
 
     expect(triggerHandlerCalls).toBe(1);
 
-    const rows = getDb()
+    const rows = getMemoryDb()!
       .select()
       .from(memoryJobs)
       .where(eq(memoryJobs.id, jobId))

--- a/assistant/src/memory/__tests__/jobs-worker-v2-schedule.test.ts
+++ b/assistant/src/memory/__tests__/jobs-worker-v2-schedule.test.ts
@@ -59,7 +59,7 @@ afterAll(() => {
   rmSync(tmpWorkspace, { recursive: true, force: true });
 });
 
-const { getDb } = await import("../db-connection.js");
+const { getMemoryDb } = await import("../db-connection.js");
 const { initializeDb } = await import("../db-init.js");
 const { resetTestTables } = await import("../raw-query.js");
 const { memoryJobs } = await import("../schema.js");
@@ -107,7 +107,7 @@ function removeBuffer(): void {
 }
 
 function countPendingJobs(type: string): number {
-  return getDb()
+  return getMemoryDb()!
     .select()
     .from(memoryJobs)
     .where(eq(memoryJobs.type, type))
@@ -115,7 +115,7 @@ function countPendingJobs(type: string): number {
 }
 
 function consolidationJobPayloads(): Record<string, unknown>[] {
-  return getDb()
+  return getMemoryDb()!
     .select({ payload: memoryJobs.payload })
     .from(memoryJobs)
     .where(eq(memoryJobs.type, "memory_v2_consolidate"))
@@ -130,8 +130,10 @@ initializeDb();
 
 beforeEach(() => {
   // Clear job + checkpoint state so each test starts from zero rows. Other
-  // tables stay intact — the worker only inspects these two.
-  resetTestTables("memory_jobs", "memory_checkpoints");
+  // tables stay intact — the worker only inspects these two. memory_jobs lives
+  // in the dedicated memory connection; memory_checkpoints in main.
+  getMemoryDb()!.run("DELETE FROM memory_jobs");
+  resetTestTables("memory_checkpoints");
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/memory/__tests__/memory-retrospective-startup-cleanup.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-startup-cleanup.test.ts
@@ -40,78 +40,81 @@ function isRetroSource(source: string | null): boolean {
   return source !== null && RETRO_SOURCES.includes(source);
 }
 
-mock.module("../db-connection.js", () => ({
-  getDb: () => ({
-    select: (cols?: Record<string, unknown>) => ({
-      from: (_table: { _: { name: string } } | unknown) => ({
-        where: (..._args: unknown[]) => ({
-          all: () => {
-            // Heuristic: tests only construct two query shapes — the jobs
-            // query and the conversations query. Distinguish by the first
-            // requested column shape.
-            const colKeys = cols ? Object.keys(cols) : [];
-            if (colKeys.includes("conversationId")) {
-              return mockJobs
-                .filter(
-                  (j) =>
-                    j.type === "memory_retrospective" &&
-                    (j.status === "pending" || j.status === "running"),
-                )
-                .map((j) => {
-                  let convId: string | null = null;
-                  try {
-                    const parsed = JSON.parse(j.payload) as {
-                      conversationId?: unknown;
-                    };
-                    if (typeof parsed.conversationId === "string") {
-                      convId = parsed.conversationId;
-                    }
-                  } catch {
-                    // Ignore malformed payload
+const makeFakeDb = () => ({
+  select: (cols?: Record<string, unknown>) => ({
+    from: (_table: { _: { name: string } } | unknown) => ({
+      where: (..._args: unknown[]) => ({
+        all: () => {
+          // Heuristic: tests only construct two query shapes — the jobs
+          // query and the conversations query. Distinguish by the first
+          // requested column shape.
+          const colKeys = cols ? Object.keys(cols) : [];
+          if (colKeys.includes("conversationId")) {
+            return mockJobs
+              .filter(
+                (j) =>
+                  j.type === "memory_retrospective" &&
+                  (j.status === "pending" || j.status === "running"),
+              )
+              .map((j) => {
+                let convId: string | null = null;
+                try {
+                  const parsed = JSON.parse(j.payload) as {
+                    conversationId?: unknown;
+                  };
+                  if (typeof parsed.conversationId === "string") {
+                    convId = parsed.conversationId;
                   }
-                  return { conversationId: convId };
-                });
-            }
-            // The "all retros" query (used to compute the preserved
-            // dedup-baseline per source) requests id + source +
-            // forkParentConversationId + createdAt with only the source +
-            // isNotNull(forkParent) predicate.
-            if (
-              colKeys.includes("forkParentConversationId") &&
-              colKeys.includes("createdAt")
-            ) {
-              return mockConversations
-                .filter((c) => isRetroSource(c.source))
-                .filter((c) => c.fork_parent_conversation_id !== null)
-                .map((c) => ({
-                  id: c.id,
-                  source: c.source,
-                  forkParentConversationId: c.fork_parent_conversation_id,
-                  createdAt: c.created_at,
-                }));
-            }
-            // Otherwise, this is the orphan-candidate query. The production
-            // predicate compares `forkParentConversationId` (the source ID
-            // encoded on the background conversation row) against the set
-            // of source IDs extracted from active jobs.
+                } catch {
+                  // Ignore malformed payload
+                }
+                return { conversationId: convId };
+              });
+          }
+          // The "all retros" query (used to compute the preserved
+          // dedup-baseline per source) requests id + source +
+          // forkParentConversationId + createdAt with only the source +
+          // isNotNull(forkParent) predicate.
+          if (
+            colKeys.includes("forkParentConversationId") &&
+            colKeys.includes("createdAt")
+          ) {
             return mockConversations
               .filter((c) => isRetroSource(c.source))
-              .filter(
-                (c) =>
-                  c.last_message_at !== null &&
-                  c.last_message_at < injectedNowMinusOrphanAgeMs,
-              )
-              .filter(
-                (c) =>
-                  c.fork_parent_conversation_id === null ||
-                  !activeJobSourceConvIds.has(c.fork_parent_conversation_id),
-              )
-              .map((c) => ({ id: c.id }));
-          },
-        }),
+              .filter((c) => c.fork_parent_conversation_id !== null)
+              .map((c) => ({
+                id: c.id,
+                source: c.source,
+                forkParentConversationId: c.fork_parent_conversation_id,
+                createdAt: c.created_at,
+              }));
+          }
+          // Otherwise, this is the orphan-candidate query. The production
+          // predicate compares `forkParentConversationId` (the source ID
+          // encoded on the background conversation row) against the set
+          // of source IDs extracted from active jobs.
+          return mockConversations
+            .filter((c) => isRetroSource(c.source))
+            .filter(
+              (c) =>
+                c.last_message_at !== null &&
+                c.last_message_at < injectedNowMinusOrphanAgeMs,
+            )
+            .filter(
+              (c) =>
+                c.fork_parent_conversation_id === null ||
+                !activeJobSourceConvIds.has(c.fork_parent_conversation_id),
+            )
+            .map((c) => ({ id: c.id }));
+        },
       }),
     }),
   }),
+});
+
+mock.module("../db-connection.js", () => ({
+  getDb: makeFakeDb,
+  getMemoryDb: makeFakeDb,
 }));
 
 let activeJobSourceConvIds = new Set<string>();

--- a/assistant/src/memory/__tests__/table-relocation.test.ts
+++ b/assistant/src/memory/__tests__/table-relocation.test.ts
@@ -6,19 +6,20 @@
  * What this locks in:
  *   1. `stageTableForRelocation` drops an empty source, renames a populated
  *      one aside to `<table>__relocating`, and is idempotent across re-runs.
- *   2. `drainStagedTable` copies the rows worth keeping into the attached
- *      target, purges the rest without copying, applies the spec's per-column
+ *   2. `drainStagedTable` copies the rows worth keeping into the target file,
+ *      purges the rest without copying, applies the spec's per-column
  *      transforms (`running` → `pending`), and drops the staging table — so a
  *      heavy table moves in bounded awaited batches rather than one blocking
  *      shot.
  *
- * sqlite3 may not be on the host here, so the drain runs through the in-process
- * `runAsyncSqlite` fallback — which exercises the same cross-database SQL on the
- * daemon connection (it already has the `memory`/`logs` databases attached).
+ * The drain runs through `runAsyncSqlite`, which targets the memory file
+ * directly (sqlite3 subprocess where available; in-process transient
+ * connection otherwise) — independent of the daemon connection, which no longer
+ * ATTACHes the dedicated files.
  */
 import { describe, expect, test } from "bun:test";
 
-const { getSqlite, MEMORY_DB_SCHEMA } = await import("../db-connection.js");
+const { getSqlite, getMemorySqlite } = await import("../db-connection.js");
 const { initializeDb } = await import("../db-init.js");
 const { drainStagedTable, stageTableForRelocation } =
   await import("../migrations/helpers/relocation.js");
@@ -84,9 +85,10 @@ describe("stageTableForRelocation", () => {
 describe("memory_jobs drain", () => {
   test("copies pending/running rows, purges terminal rows, drops staging", async () => {
     const sqlite = getSqlite();
+    const memory = getMemorySqlite()!;
 
     // Clean slate: empty live queue, fresh populated staging table.
-    sqlite.exec(`DELETE FROM memory_jobs`);
+    memory.exec(`DELETE FROM memory_jobs`);
     sqlite.exec(`DROP TABLE IF EXISTS main."memory_jobs__relocating"`);
     sqlite.exec(
       `CREATE TABLE main."memory_jobs__relocating" (${MEMORY_JOBS_COLUMNS})`,
@@ -112,7 +114,7 @@ describe("memory_jobs drain", () => {
     // Exactly the three keepers landed in the memory database; the terminal
     // rows were purged without being copied, and the in-flight `running` row
     // was reset to `pending` so the worker can re-claim it in its new home.
-    const kept = sqlite
+    const kept = memory
       .query<
         { id: string; status: string },
         []
@@ -123,14 +125,5 @@ describe("memory_jobs drain", () => {
       { id: "seed-keep-2", status: "pending" },
       { id: "seed-keep-3", status: "pending" },
     ]);
-
-    // The keepers physically live in the memory database.
-    const inMemory = getSqlite()
-      .query<
-        { c: number },
-        []
-      >(`SELECT COUNT(*) AS c FROM ${MEMORY_DB_SCHEMA}.memory_jobs WHERE id LIKE 'seed-%'`)
-      .get();
-    expect(inMemory?.c).toBe(3);
   });
 });

--- a/assistant/src/memory/conversation-crud.ts
+++ b/assistant/src/memory/conversation-crud.ts
@@ -37,8 +37,6 @@ import { publishSyncInvalidation } from "../runtime/sync/sync-publisher.js";
 import { UserError } from "../util/errors.js";
 import { safeParseRecord } from "../util/json.js";
 import { getLogger } from "../util/logger.js";
-import { getLogsDbPath } from "../util/logs-db-path.js";
-import { getMemoryDbPath } from "../util/memory-db-path.js";
 import { getConversationsDir } from "../util/platform.js";
 import { createRowMapper } from "../util/row-mapper.js";
 import {
@@ -59,12 +57,23 @@ import {
 import { ensureDisplayOrderMigration } from "./conversation-display-order-migration.js";
 import { ensureGroupMigration } from "./conversation-group-migration.js";
 import { runAsyncSqlite } from "./db-async-query.js";
-import { getDb, getSqliteFrom } from "./db-connection.js";
+import {
+  type DrizzleDb,
+  getDb,
+  getLogsDb,
+  getSqliteFrom,
+} from "./db-connection.js";
 import { forkGraphMemoryState } from "./graph/graph-memory-state-store.js";
 import { indexMessageNow } from "./indexer.js";
 import { MEMORY_RETROSPECTIVE_SOURCES } from "./memory-retrospective-constants.js";
 import { forkRetrospectiveState } from "./memory-retrospective-state.js";
-import { rawExec, rawGet, rawRun } from "./raw-query.js";
+import {
+  rawExec,
+  rawGet,
+  rawLogsRun,
+  rawMemoryRun,
+  rawRun,
+} from "./raw-query.js";
 import {
   channelInboundEvents,
   conversations,
@@ -85,6 +94,19 @@ import {
 import { extractInjectedConceptSlugs } from "./v2/injected-block-slugs.js";
 
 const log = getLogger("conversation-store");
+
+/**
+ * The logs connection (`assistant-logs.db`), where `llm_request_logs` lives.
+ * Throws if the file cannot be opened — the few call sites here that touch
+ * request logs (conversation deletes, turn-window anchoring) have no fallback.
+ */
+function logsDb(): DrizzleDb {
+  const db = getLogsDb();
+  if (!db) {
+    throw new Error("logs database unavailable");
+  }
+  return db;
+}
 
 // ── Message metadata Zod schema ──────────────────────────────────────
 // Validates the JSON stored in messages.metadata. Known fields are typed;
@@ -1189,6 +1211,13 @@ export function deleteConversation(id: string): DeletedMemoryIds {
   const convBeforeDelete = getConversation(id);
   const createdAtForDiskCleanup = convBeforeDelete?.createdAt;
 
+  // llm_request_logs lives in the dedicated logs connection, so it is deleted
+  // there — separately from the main-DB transaction below.
+  logsDb()
+    .delete(llmRequestLogs)
+    .where(eq(llmRequestLogs.conversationId, id))
+    .run();
+
   db.transaction((tx) => {
     // Collect all message IDs for this conversation.
     const messageRows = tx
@@ -1208,9 +1237,6 @@ export function deleteConversation(id: string): DeletedMemoryIds {
       result.segmentIds = linkedSegments.map((r) => r.id);
 
       // Delete non-cascading tables first.
-      tx.delete(llmRequestLogs)
-        .where(eq(llmRequestLogs.conversationId, id))
-        .run();
       tx.delete(toolInvocations)
         .where(eq(toolInvocations.conversationId, id))
         .run();
@@ -1233,9 +1259,6 @@ export function deleteConversation(id: string): DeletedMemoryIds {
       }
     } else {
       // No messages — just clean up non-message tables.
-      tx.delete(llmRequestLogs)
-        .where(eq(llmRequestLogs.conversationId, id))
-        .run();
       tx.delete(toolInvocations)
         .where(eq(toolInvocations.conversationId, id))
         .run();
@@ -2166,13 +2189,12 @@ export async function clearAll(): Promise<{
   await runOrThrow("DELETE FROM memory_segments");
   await runOrThrow("DELETE FROM memory_summaries");
   await runOrThrow("DELETE FROM memory_embeddings");
-  // memory_jobs lives in the attached memory database; point the sqlite3
-  // subprocess at that file (the in-process fallback resolves it via ATTACH).
-  await runOrThrow("DELETE FROM memory_jobs", { dbPath: getMemoryDbPath() });
+  // memory_jobs and llm_request_logs each live in their own dedicated
+  // connection; clear them directly on those connections rather than through a
+  // sqlite3 subprocess.
+  rawMemoryRun("DELETE FROM memory_jobs");
   await runOrThrow("DELETE FROM memory_checkpoints");
-  // llm_request_logs lives in the attached logs database; point the sqlite3
-  // subprocess at that file (the in-process fallback resolves it via ATTACH).
-  await runOrThrow("DELETE FROM llm_request_logs", { dbPath: getLogsDbPath() });
+  rawLogsRun("DELETE FROM llm_request_logs");
   await runOrThrow("DELETE FROM llm_usage_events");
   await runOrThrow("DELETE FROM message_attachments");
   await runOrThrow("DELETE FROM attachments");
@@ -2865,7 +2887,8 @@ export function getTurnTimeBounds(
       : startTime + MAX_TURN_DURATION_MS;
 
   if (hardCeiling > endTime) {
-    const latestLog = db
+    // llm_request_logs lives in the dedicated logs connection.
+    const latestLog = logsDb()
       .select({ createdAt: llmRequestLogs.createdAt })
       .from(llmRequestLogs)
       .where(

--- a/assistant/src/memory/db-async-query.ts
+++ b/assistant/src/memory/db-async-query.ts
@@ -26,6 +26,8 @@
  * ms) should keep using the in-process drizzle / `bun:sqlite` handle
  * directly — the subprocess overhead would dominate.
  */
+import { Database } from "bun:sqlite";
+
 import { getLogger } from "../util/logger.js";
 import { getDbPath } from "../util/platform.js";
 import { findSqlite3 } from "../util/sqlite3-runtime.js";
@@ -63,28 +65,28 @@ export interface RunAsyncSqliteOptions {
   forceBackend?: AsyncSqliteBackend;
   /**
    * Database file to run the statement against. Defaults to the main
-   * assistant DB (`getDbPath()`). Pass `getLogsDbPath()` to target the
-   * secondary append-only file directly.
+   * assistant DB (`getDbPath()`). Pass `getLogsDbPath()` / `getMemoryDbPath()`
+   * to target a dedicated file directly.
    *
-   * This only affects the `sqlite3-cli` backend, which opens the given file
-   * as its own `main` database — so a statement like
-   * `DELETE FROM llm_request_logs` runs against the right file with no ATTACH.
-   * The in-process fallback always runs on the daemon connection, which has
-   * the logs DB ATTACHed, so unqualified table names already resolve to the
-   * correct file regardless of this option.
+   * The `sqlite3-cli` backend opens the given file as its own `main` database —
+   * so a statement like `DELETE FROM llm_request_logs` runs against the right
+   * file. The in-process fallback opens a transient `bun:sqlite` connection to
+   * this file when set (rather than reusing the daemon connection), so the
+   * statement still hits the correct database now that the daemon connection no
+   * longer ATTACHes the logs/memory files.
    */
   dbPath?: string;
   /**
    * Extra databases to `ATTACH` before running `sql`, used for cross-database
-   * statements (e.g. copying rows from `main` into an attached file). Only the
-   * `sqlite3-cli` backend uses this — it opens a fresh connection that has no
-   * attachments, so each entry is emitted as an `ATTACH DATABASE '<path>' AS
-   * <alias>` prefix. The in-process fallback runs on the daemon connection,
-   * which already has the logs/memory databases attached, so it ignores this.
+   * statements (e.g. copying rows from `main` into a dedicated file). Each
+   * entry is emitted as an `ATTACH DATABASE '<path>' AS <alias>` prefix on both
+   * backends: the `sqlite3-cli` backend prefixes the SQL it pipes in, and the
+   * in-process fallback opens a transient connection to `dbPath` and ATTACHes
+   * each entry before running the statement.
    *
-   * Reference tables by their **unqualified** name in `sql`: on both backends a
-   * table that exists in exactly one schema resolves unambiguously, so the
-   * alias chosen here does not have to match the daemon's schema name.
+   * Reference tables by their **unqualified** name in `sql`: a table that
+   * exists in exactly one schema resolves unambiguously, so the alias chosen
+   * here does not have to match any particular schema name.
    */
   attach?: ReadonlyArray<{ path: string; alias: string }>;
 }
@@ -122,7 +124,7 @@ export async function runAsyncSqlite(
         "event loop responsive during VACUUM and other long operations.",
     );
   }
-  return runInProcessBlocking(sql);
+  return runInProcessBlocking(sql, options);
 }
 
 /** For tests: reset the once-only fallback warning. */
@@ -232,10 +234,35 @@ async function runViaCli(
   };
 }
 
-async function runInProcessBlocking(sql: string): Promise<AsyncSqliteResult> {
+async function runInProcessBlocking(
+  sql: string,
+  options: RunAsyncSqliteOptions,
+): Promise<AsyncSqliteResult> {
   const startMs = Date.now();
+
+  // When `dbPath`/`attach` are set the statement targets a dedicated file (or
+  // copies across files), which the daemon connection can no longer reach — it
+  // ATTACHes nothing. Open a transient connection to that file and ATTACH each
+  // extra database so the unqualified table names resolve, mirroring the
+  // sqlite3-cli backend. With neither option set the statement is a plain
+  // main-DB op, so reuse the daemon connection (no extra open).
+  const usesDedicatedFile = options.dbPath !== undefined || !!options.attach;
+  let transient: Database | undefined;
+
   try {
-    const sqlite = getSqlite();
+    let sqlite: Database;
+    if (usesDedicatedFile) {
+      transient = new Database(options.dbPath ?? getDbPath());
+      for (const a of options.attach ?? []) {
+        transient.exec(
+          `ATTACH DATABASE '${a.path.replace(/'/g, "''")}' AS ${a.alias}`,
+        );
+      }
+      sqlite = transient;
+    } else {
+      sqlite = getSqlite();
+    }
+
     sqlite.exec(sql);
     // Synthesize `stdout` to match what the CLI backend would emit
     // when the caller chained `SELECT changes();` at the end of their
@@ -265,5 +292,7 @@ async function runInProcessBlocking(sql: string): Promise<AsyncSqliteResult> {
       error: message,
       elapsedMs: Date.now() - startMs,
     };
+  } finally {
+    transient?.close();
   }
 }

--- a/assistant/src/memory/db-connection.ts
+++ b/assistant/src/memory/db-connection.ts
@@ -13,99 +13,6 @@ import * as schema from "./schema.js";
 
 export type DrizzleDb = ReturnType<typeof drizzle<typeof schema>>;
 
-/**
- * Schema name under which the secondary append-only database file
- * (`assistant-logs.db`) is ATTACHed to the main connection. Tables created in
- * this schema (e.g. `logs.llm_request_logs`) live in the separate file but are
- * still queryable — and joinable against main-schema tables — over the single
- * daemon connection. Because no append-only table exists in the `main` schema,
- * unqualified references (e.g. `llm_request_logs`) resolve to the attached copy.
- */
-export const LOGS_DB_SCHEMA = "logs";
-
-/**
- * ATTACH the append-only logs database to an open connection and apply its
- * per-database PRAGMAs.
- *
- * `journal_mode` and `synchronous` are per-database settings, so they must be
- * set against the attached schema explicitly — the PRAGMAs run on `main` before
- * the attach do not carry over. `busy_timeout`, `foreign_keys`, `cache_size`,
- * and `temp_store` are connection-wide and already configured on the connection.
- *
- * Best-effort: a failure here (e.g. a filesystem permission problem on the new
- * file) must not take down the main database. We log and continue in line with
- * the daemon's "never block startup on a subsystem failure" policy; append-only
- * tables are simply unavailable until the next successful open.
- *
- * The logger is pulled in lazily (dynamic import) only on the error path. This
- * file is intentionally kept import-light — see `db-singleton.ts` — so it does
- * not take a static dependency on the logger (and transitively on pino).
- */
-function attachLogsDb(sqlite: Database): void {
-  const logsPath = getLogsDbPath();
-  try {
-    // Escape single quotes for the SQL string literal (paths can contain them).
-    const escaped = logsPath.replace(/'/g, "''");
-    sqlite.exec(`ATTACH DATABASE '${escaped}' AS ${LOGS_DB_SCHEMA}`);
-    sqlite.exec(`PRAGMA ${LOGS_DB_SCHEMA}.journal_mode=WAL`);
-    sqlite.exec(`PRAGMA ${LOGS_DB_SCHEMA}.synchronous=FULL`);
-  } catch (err) {
-    void import("../util/logger.js").then(({ getLogger }) =>
-      getLogger("db-connection").error(
-        { err, logsPath },
-        "Failed to ATTACH logs database; append-only log tables will be unavailable",
-      ),
-    );
-  }
-}
-
-/**
- * Schema name under which the secondary memory database file
- * (`assistant-memory.db`) is ATTACHed to the main connection. High-churn memory
- * tables (starting with `memory_jobs`) live in this separate file but remain
- * queryable — and joinable against main-schema tables — over the single daemon
- * connection. Because no such table exists in the `main` schema once a table is
- * relocated, an unqualified reference (e.g. `memory_jobs`) resolves to the
- * attached copy.
- */
-export const MEMORY_DB_SCHEMA = "memory";
-
-/**
- * ATTACH the secondary memory database to an open connection and apply its
- * per-database PRAGMAs.
- *
- * `journal_mode` and `synchronous` are per-database settings, so they must be
- * set against the attached schema explicitly — the PRAGMAs run on `main` before
- * the attach do not carry over. `busy_timeout`, `foreign_keys`, `cache_size`,
- * and `temp_store` are connection-wide and already configured on the connection.
- *
- * Best-effort: a failure here (e.g. a filesystem permission problem on the new
- * file) must not take down the main database. We log and continue in line with
- * the daemon's "never block startup on a subsystem failure" policy; relocated
- * memory tables are simply unavailable until the next successful open.
- *
- * The logger is pulled in lazily (dynamic import) only on the error path. This
- * file is intentionally kept import-light — see `db-singleton.ts` — so it does
- * not take a static dependency on the logger (and transitively on pino).
- */
-function attachMemoryDb(sqlite: Database): void {
-  const memoryPath = getMemoryDbPath();
-  try {
-    // Escape single quotes for the SQL string literal (paths can contain them).
-    const escaped = memoryPath.replace(/'/g, "''");
-    sqlite.exec(`ATTACH DATABASE '${escaped}' AS ${MEMORY_DB_SCHEMA}`);
-    sqlite.exec(`PRAGMA ${MEMORY_DB_SCHEMA}.journal_mode=WAL`);
-    sqlite.exec(`PRAGMA ${MEMORY_DB_SCHEMA}.synchronous=FULL`);
-  } catch (err) {
-    void import("../util/logger.js").then(({ getLogger }) =>
-      getLogger("db-connection").error(
-        { err, memoryPath },
-        "Failed to ATTACH memory database; relocated memory tables will be unavailable",
-      ),
-    );
-  }
-}
-
 function canonicalizePathThroughExistingParent(path: string): string {
   const resolvedPath = resolve(path);
   const pendingSegments: string[] = [];
@@ -125,7 +32,12 @@ function canonicalizePathThroughExistingParent(path: string): string {
   }
 }
 
-function assertTestDbIsIsolated(): void {
+/**
+ * Guard against opening a real workspace database during tests. Shared by
+ * every connection opener (main, logs, memory) so a misconfigured test run
+ * cannot write to the real `~/.vellum/workspace` files through any of them.
+ */
+export function assertTestDbIsIsolated(): void {
   if (
     process.env.NODE_ENV !== "test" ||
     process.env.VELLUM_ALLOW_REAL_WORKSPACE_IN_TESTS === "1"
@@ -164,23 +76,30 @@ function assertTestDbIsIsolated(): void {
   }
 }
 
-export function getDb(): DrizzleDb {
-  const existing = getStoredDb<DrizzleDb>();
-  if (existing) return existing;
-
-  assertTestDbIsIsolated();
-  ensureDataDir();
-  const sqlite = new Database(getDbPath());
+/**
+ * Apply the connection-wide PRAGMAs every assistant SQLite connection runs
+ * with. These are per-connection settings, so the dedicated logs/memory
+ * connections set them independently of the main connection.
+ */
+function applyConnectionPragmas(sqlite: Database): void {
   sqlite.exec("PRAGMA journal_mode=WAL");
   sqlite.exec("PRAGMA synchronous=FULL");
   sqlite.exec("PRAGMA busy_timeout=5000");
   sqlite.exec("PRAGMA foreign_keys = ON");
   sqlite.exec("PRAGMA cache_size=-256000");
   sqlite.exec("PRAGMA temp_store=MEMORY");
-  attachLogsDb(sqlite);
-  attachMemoryDb(sqlite);
+}
+
+export function getDb(): DrizzleDb {
+  const existing = getStoredDb<DrizzleDb>("main");
+  if (existing) return existing;
+
+  assertTestDbIsIsolated();
+  ensureDataDir();
+  const sqlite = new Database(getDbPath());
+  applyConnectionPragmas(sqlite);
   const db = drizzle(sqlite, { schema });
-  setStoredDb(db, () => sqlite.close());
+  setStoredDb("main", db, () => sqlite.close());
   return db;
 }
 
@@ -206,14 +125,85 @@ export function getSqliteFrom(drizzleDb: DrizzleDb): Database {
 }
 
 /**
- * Reset the db singleton. Used by production callers that need to close
- * the live connection so the file can be replaced (post-migration,
- * post-restore, post-vbundle-import) and on graceful shutdown.
+ * Open a dedicated bun:sqlite connection to `dbPath`, apply the standard
+ * PRAGMAs, and return its Drizzle instance — caching both in the given
+ * singleton slot. The connection only opens the file and sets PRAGMAs; it
+ * never runs DDL (table/index creation lives in the migrations).
+ *
+ * Fail-soft: on any open error we log and return `null` rather than throwing,
+ * consistent with the daemon's "never block startup on a subsystem failure"
+ * policy. The logger is pulled in lazily (dynamic import) only on the error
+ * path so this file stays import-light. Callers tolerate a `null` result.
+ */
+function openDedicatedDb(
+  key: "logs" | "memory",
+  dbPath: string,
+): DrizzleDb | null {
+  assertTestDbIsIsolated();
+  ensureDataDir();
+  try {
+    const sqlite = new Database(dbPath);
+    applyConnectionPragmas(sqlite);
+    const db = drizzle(sqlite, { schema });
+    setStoredDb(key, db, () => sqlite.close());
+    return db;
+  } catch (err) {
+    void import("../util/logger.js").then(({ getLogger }) =>
+      getLogger("db-connection").error(
+        { err, dbPath, key },
+        "Failed to open dedicated database; its tables will be unavailable",
+      ),
+    );
+    return null;
+  }
+}
+
+/**
+ * The append-only logs database (`assistant-logs.db`), opened lazily as its
+ * own connection. Houses `llm_request_logs`. Returns `null` if the file
+ * cannot be opened (logged; the daemon stays up).
+ */
+export function getLogsDb(): DrizzleDb | null {
+  const existing = getStoredDb<DrizzleDb>("logs");
+  if (existing) return existing;
+  return openDedicatedDb("logs", getLogsDbPath());
+}
+
+/** Underlying bun:sqlite Database for the logs connection, or `null`. */
+export function getLogsSqlite(): Database | null {
+  const db = getLogsDb();
+  return db ? getSqliteFrom(db) : null;
+}
+
+/**
+ * The high-churn memory database (`assistant-memory.db`), opened lazily as
+ * its own connection. Houses `memory_jobs`. Returns `null` if the file
+ * cannot be opened (logged; the daemon stays up).
+ */
+export function getMemoryDb(): DrizzleDb | null {
+  const existing = getStoredDb<DrizzleDb>("memory");
+  if (existing) return existing;
+  return openDedicatedDb("memory", getMemoryDbPath());
+}
+
+/** Underlying bun:sqlite Database for the memory connection, or `null`. */
+export function getMemorySqlite(): Database | null {
+  const db = getMemoryDb();
+  return db ? getSqliteFrom(db) : null;
+}
+
+/**
+ * Reset all DB singletons. Used by production callers that need to close the
+ * live connections so the files can be replaced (post-migration, post-restore,
+ * post-vbundle-import) and on graceful shutdown. Clears the main, logs, and
+ * memory slots together so none lingers open against a swapped-out file.
  *
  * Tests should use `resetDbForTesting()` from
  * `__tests__/db-test-helpers.ts` instead so they don't depend on this
  * module's heavy import chain (`drizzle-orm/bun-sqlite`).
  */
 export function resetDb(): void {
-  clearStoredDb();
+  clearStoredDb("main");
+  clearStoredDb("logs");
+  clearStoredDb("memory");
 }

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -11,10 +11,16 @@ import { dirname, join } from "node:path";
 
 import { getLogger } from "../util/logger.js";
 import { getLogsDbPath } from "../util/logs-db-path.js";
+import { getMemoryDbPath } from "../util/memory-db-path.js";
 import { ensureDataDir, getDbPath } from "../util/platform.js";
 import { backfillAppConversationIds } from "./app-store.js";
 import { runAsyncSqlite } from "./db-async-query.js";
-import { getDb, getSqlite } from "./db-connection.js";
+import {
+  getDb,
+  getLogsSqlite,
+  getMemorySqlite,
+  getSqlite,
+} from "./db-connection.js";
 import { migrateToolCreatedItems } from "./graph/bootstrap.js";
 import { migrateCoreTables } from "./migrations/000-core-tables.js";
 import { migrateJobDeferrals } from "./migrations/001-job-deferrals.js";
@@ -250,8 +256,14 @@ import { migrateWorkflowJournalLeafTokens } from "./migrations/293-workflow-jour
 import { migrateDropExternalUserId } from "./migrations/294-drop-external-user-id.js";
 import { dropApprovalPromptTsTrackerTable } from "./migrations/295-drop-approval-prompt-ts-tracker.js";
 import { migrateRewriteBalancedEconomyProfilePins } from "./migrations/296-rewrite-balanced-economy-profile-pins.js";
-import { migrateMoveLlmRequestLogsToLogsDb } from "./migrations/297-move-llm-request-logs-to-logs-db.js";
-import { migrateMoveMemoryJobsToMemoryDb } from "./migrations/298-move-memory-jobs-to-memory-db.js";
+import {
+  ensureLlmRequestLogsSchema,
+  migrateMoveLlmRequestLogsToLogsDb,
+} from "./migrations/297-move-llm-request-logs-to-logs-db.js";
+import {
+  ensureMemoryJobsSchema,
+  migrateMoveMemoryJobsToMemoryDb,
+} from "./migrations/298-move-memory-jobs-to-memory-db.js";
 import { runMigrationSteps } from "./migrations/run-migrations.js";
 import { validateMigrationState } from "./migrations/validate-migration-state.js";
 
@@ -284,14 +296,23 @@ function getTemplateDbPath(): string {
 }
 
 /**
- * Template path for the attached `logs` database, kept alongside the main
- * template. Both files must be captured/restored together: the migrated state
- * now spans two files (llm_request_logs and its indexes live in `logs`), so
+ * Template path for the dedicated `logs` database, kept alongside the main
+ * template. All three files must be captured/restored together: the migrated
+ * state spans them (llm_request_logs and its indexes live in `logs`), so
  * restoring only the main DB would leave a fresh, empty logs DB with no
  * `llm_request_logs` table.
  */
 function getLogsTemplateDbPath(): string {
   return `${getTemplateDbPath()}.logs`;
+}
+
+/**
+ * Template path for the dedicated `memory` database, kept alongside the main
+ * and logs templates. Captured/restored together with them so the restored
+ * test DB includes `memory_jobs` (created by migration 298 in this file).
+ */
+function getMemoryTemplateDbPath(): string {
+  return `${getTemplateDbPath()}.memory`;
 }
 
 function tryRestoreTemplate(): boolean {
@@ -300,13 +321,17 @@ function tryRestoreTemplate(): boolean {
   // getDb() hasn't run yet, so the data directory may not exist.
   ensureDataDir();
   copyFileSync(templatePath, getDbPath());
-  // Restore the attached logs DB before getDb() opens (and ATTACHes) it, so the
-  // relocated llm_request_logs table is present. Older templates may predate
-  // the split; the hash includes the migration files, so a stale template
-  // without this sibling won't be reused — but guard anyway.
+  // Restore the dedicated logs/memory DBs before their connections open, so the
+  // relocated tables are present. Older templates may predate the split; the
+  // hash includes the migration files, so a stale template without these
+  // siblings won't be reused — but guard anyway.
   const logsTemplate = getLogsTemplateDbPath();
   if (existsSync(logsTemplate)) {
     copyFileSync(logsTemplate, getLogsDbPath());
+  }
+  const memoryTemplate = getMemoryTemplateDbPath();
+  if (existsSync(memoryTemplate)) {
+    copyFileSync(memoryTemplate, getMemoryDbPath());
   }
   // Open the pre-migrated copy — getDb() will set PRAGMAs but skip migrations.
   getDb();
@@ -315,18 +340,22 @@ function tryRestoreTemplate(): boolean {
 
 function saveTemplate(): void {
   try {
-    // Flush each DB's WAL to its main file before copying.
+    // Flush each connection's WAL to its main file before copying.
     getSqlite().exec("PRAGMA wal_checkpoint(TRUNCATE)");
-    getSqlite().exec("PRAGMA logs.wal_checkpoint(TRUNCATE)");
+    getLogsSqlite()?.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+    getMemorySqlite()?.exec("PRAGMA wal_checkpoint(TRUNCATE)");
 
     const mainTmp = `${getTemplateDbPath()}.${process.pid}`;
     copyFileSync(getDbPath(), mainTmp);
     const logsTmp = `${getLogsTemplateDbPath()}.${process.pid}`;
     copyFileSync(getLogsDbPath(), logsTmp);
+    const memoryTmp = `${getMemoryTemplateDbPath()}.${process.pid}`;
+    copyFileSync(getMemoryDbPath(), memoryTmp);
 
     // Atomic renames — safe even with parallel test workers.
     renameSync(mainTmp, getTemplateDbPath());
     renameSync(logsTmp, getLogsTemplateDbPath());
+    renameSync(memoryTmp, getMemoryTemplateDbPath());
   } catch {
     // Best effort — next file will just run migrations normally.
   }
@@ -390,8 +419,26 @@ export async function checkpointWalBeforeOpen(): Promise<void> {
 
 // ---------------------------------------------------------------------------
 
+/**
+ * Create the dedicated logs/memory schemas synchronously. Idempotent
+ * (`CREATE … IF NOT EXISTS`). Runs as part of DB init — never on connection
+ * open — so the tables exist as soon as `initializeDb()` returns, on both the
+ * fresh-migration path and the test template-restore path, and regardless of
+ * whether the caller awaits (the relocation steps 297/298 that also create them
+ * are async). Best-effort: a connection that fails to open leaves its tables
+ * unavailable, matching the daemon's "never block startup on a subsystem
+ * failure" policy.
+ */
+function ensureDedicatedSchemas(): void {
+  const logsRaw = getLogsSqlite();
+  if (logsRaw) ensureLlmRequestLogsSchema(logsRaw);
+  const memoryRaw = getMemorySqlite();
+  if (memoryRaw) ensureMemoryJobsSchema(memoryRaw);
+}
+
 export async function initializeDb(): Promise<void> {
   if (process.env.BUN_TEST === "1" && tryRestoreTemplate()) {
+    ensureDedicatedSchemas();
     return;
   }
 
@@ -666,6 +713,10 @@ export async function initializeDb(): Promise<void> {
   // broken migration doesn't prevent independent later ones from succeeding.
   // The runner creates the checkpoint ledger, recovers crashed migrations, then
   // records each step so an already-migrated database skips it on later boots.
+  // Create the dedicated logs/memory schemas up front, synchronously, before the
+  // (async) relocation steps run — see {@link ensureDedicatedSchemas}.
+  ensureDedicatedSchemas();
+
   const { failed, skipped } = await runMigrationSteps(database, migrationSteps);
 
   log.debug(

--- a/assistant/src/memory/db-singleton.ts
+++ b/assistant/src/memory/db-singleton.ts
@@ -1,15 +1,20 @@
 /**
- * Holds the assistant DB connection singleton and its close callback.
+ * Holds the assistant DB connection singletons and their close callbacks.
  *
- * Lives in its own module (rather than alongside the resolver in
- * `db-connection.ts`) so test code can reset the singleton without
+ * Three connections live here under the same `globalThis.vellumAssistant`
+ * namespace, keyed by slot: the `main` daemon connection, the `logs`
+ * connection (`assistant-logs.db`), and the `memory` connection
+ * (`assistant-memory.db`). Each is opened lazily by `db-connection.ts`.
+ *
+ * Lives in its own module (rather than alongside the resolvers in
+ * `db-connection.ts`) so test code can reset the singletons without
  * importing `db-connection.ts` — which transitively pulls
  * `drizzle-orm/bun-sqlite`. Stdlib-only by design: this file must remain
  * safe to import from the test preload's load-time chain, where a broken
  * `node_modules` symlink has historically tripped the env override
  * (see DB ghost #3, /workspace/journal/2026-05-25-db-ghost-3-recovery.md).
  *
- * State is held on `globalThis.vellumAssistant.dbSingleton` so test
+ * State is held on `globalThis.vellumAssistant.dbSingletons` so test
  * helpers in `__tests__/` can read/write it WITHOUT importing this
  * module — they declare the same slot shape locally and access the
  * globalThis namespace directly. See
@@ -21,50 +26,71 @@
  * parameter on `getStoredDb<DrizzleDb>()`.
  *
  * Consumers:
- *   - `db-connection.ts` (opens/owns the connection)
- *   - production callers that need to close the active connection
+ *   - `db-connection.ts` (opens/owns the connections)
+ *   - production callers that need to close the active connections
  *     (migration routes, vbundle import, backup/restore, daemon shutdown)
  *   - `__tests__/db-test-helpers.ts` (per-test reset, via globalThis)
  */
+
+/** Which connection a slot holds. */
+export type DbSlotKey = "main" | "logs" | "memory";
 
 type DbSlot = {
   db: unknown;
   closer: (() => void) | null;
 };
 
+type DbSlots = Record<DbSlotKey, DbSlot>;
+
 type VellumAssistantNamespace = {
-  dbSingleton?: DbSlot;
+  dbSingletons?: DbSlots;
 };
 
-function slot(): DbSlot {
-  const g = globalThis as { vellumAssistant?: VellumAssistantNamespace };
-  const ns = (g.vellumAssistant ??= {});
-  return (ns.dbSingleton ??= { db: null, closer: null });
+function emptySlot(): DbSlot {
+  return { db: null, closer: null };
 }
 
-/** Read the current singleton, narrowed to `T`. `null` means not yet opened. */
-export function getStoredDb<T>(): T | null {
-  return slot().db as T | null;
+function slots(): DbSlots {
+  const g = globalThis as { vellumAssistant?: VellumAssistantNamespace };
+  const ns = (g.vellumAssistant ??= {});
+  return (ns.dbSingletons ??= {
+    main: emptySlot(),
+    logs: emptySlot(),
+    memory: emptySlot(),
+  });
+}
+
+function slot(key: DbSlotKey): DbSlot {
+  return slots()[key];
+}
+
+/** Read the current singleton for `key`, narrowed to `T`. `null` means not yet opened. */
+export function getStoredDb<T>(key: DbSlotKey): T | null {
+  return slot(key).db as T | null;
 }
 
 /**
  * Store a freshly-opened connection and the closer to run on
- * `clearStoredDb()`. The closer must be self-contained — it is invoked
+ * `clearStoredDb(key)`. The closer must be self-contained — it is invoked
  * inside a try/catch, so partial failures are swallowed (best-effort
  * close on shutdown / restore paths).
  */
-export function setStoredDb<T>(newDb: T, close: () => void): void {
-  const s = slot();
+export function setStoredDb<T>(
+  key: DbSlotKey,
+  newDb: T,
+  close: () => void,
+): void {
+  const s = slot(key);
   s.db = newDb;
   s.closer = close;
 }
 
 /**
- * Close the active connection (if any) via the stored closer, then drop
- * both. Idempotent: safe to call when no connection is stored.
+ * Close the active connection for `key` (if any) via the stored closer,
+ * then drop both. Idempotent: safe to call when no connection is stored.
  */
-export function clearStoredDb(): void {
-  const s = slot();
+export function clearStoredDb(key: DbSlotKey): void {
+  const s = slot(key);
   if (s.closer) {
     try {
       s.closer();

--- a/assistant/src/memory/graph/bootstrap.test.ts
+++ b/assistant/src/memory/graph/bootstrap.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
 
 import { setMemoryCheckpoint } from "../checkpoints.js";
+import { getMemoryDb } from "../db-connection.js";
 import { initializeDb } from "../db-init.js";
 import { rawAll, rawGet, rawRun, resetTestTables } from "../raw-query.js";
 import { migrateToolCreatedItems } from "./bootstrap.js";
@@ -21,7 +22,9 @@ beforeAll(() => {
 
 beforeEach(() => {
   // Clear graph nodes and checkpoints between tests so each test starts clean.
-  resetTestTables("memory_graph_nodes", "memory_checkpoints", "memory_jobs");
+  // memory_jobs lives in the dedicated memory connection; the rest in main.
+  resetTestTables("memory_graph_nodes", "memory_checkpoints");
+  getMemoryDb()!.run("DELETE FROM memory_jobs");
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/memory/graph/store.ts
+++ b/assistant/src/memory/graph/store.ts
@@ -450,7 +450,10 @@ export function getEdgesForNode(
       ? eq(memoryGraphEdges.sourceNodeId, nodeId)
       : direction === "incoming"
         ? eq(memoryGraphEdges.targetNodeId, nodeId)
-        : or(eq(memoryGraphEdges.sourceNodeId, nodeId), eq(memoryGraphEdges.targetNodeId, nodeId));
+        : or(
+            eq(memoryGraphEdges.sourceNodeId, nodeId),
+            eq(memoryGraphEdges.targetNodeId, nodeId),
+          );
 
   // Exclude edges where either endpoint has fidelity='gone' (soft-deleted)
   const condition = and(
@@ -577,12 +580,7 @@ export function getActiveTriggersByType(
       memoryGraphNodes,
       eq(memoryGraphTriggers.nodeId, memoryGraphNodes.id),
     )
-    .where(
-      and(
-        ...conditions,
-        sql`${memoryGraphNodes.fidelity} != 'gone'`,
-      ),
-    )
+    .where(and(...conditions, sql`${memoryGraphNodes.fidelity} != 'gone'`))
     .all();
   return rows.map((r) => rowToTrigger(r.trigger));
 }
@@ -680,19 +678,20 @@ export function applyDiff(
     createdNodeIds: [],
   };
 
+  // Qdrant-cleanup jobs target the dedicated memory connection (`memory_jobs`
+  // lives in its own file), so they can't share this main-DB transaction —
+  // collect the deleted node ids and enqueue them after the transaction commits.
+  const deletedNodeIds: string[] = [];
+
   db.transaction((tx) => {
-    // Soft-delete nodes (set fidelity='gone' and enqueue Qdrant cleanup)
+    // Soft-delete nodes (set fidelity='gone'); the Qdrant cleanup is enqueued
+    // after commit.
     for (const id of diff.deleteNodeIds) {
       tx.update(memoryGraphNodes)
         .set({ fidelity: "gone", lastAccessed: Date.now() })
         .where(eq(memoryGraphNodes.id, id))
         .run();
-      enqueueMemoryJob(
-        "delete_qdrant_vectors",
-        { targetType: "graph_node", targetId: id },
-        Date.now(),
-        tx,
-      );
+      deletedNodeIds.push(id);
       result.nodesDeleted++;
     }
 
@@ -861,6 +860,16 @@ export function applyDiff(
       result.triggersCreated++;
     }
   });
+
+  // Flush Qdrant-cleanup jobs onto the memory connection now the node soft-
+  // deletes have committed — enqueue only on success, mirroring the prior
+  // in-transaction behavior without spanning the two connections.
+  for (const id of deletedNodeIds) {
+    enqueueMemoryJob("delete_qdrant_vectors", {
+      targetType: "graph_node",
+      targetId: id,
+    });
+  }
 
   return result;
 }

--- a/assistant/src/memory/indexer.ts
+++ b/assistant/src/memory/indexer.ts
@@ -95,10 +95,17 @@ export async function indexMessageNow(
       ? candidateMediaMeta
       : [];
 
-  // Wrap all segment inserts and job enqueues in a single transaction so they
-  // either all succeed or all roll back, preventing partial/orphaned state.
+  // Wrap all segment inserts in a single transaction so they either all
+  // succeed or all roll back, preventing partial/orphaned state. The job
+  // enqueues target the dedicated memory connection (`memory_jobs` lives in
+  // its own file), so they can't share this main-DB transaction — collect them
+  // here and flush them after the transaction commits.
   let skippedEmbedJobs = 0;
   let skippedShortSegments = 0;
+  const pendingJobs: Array<{
+    type: "embed_segment" | "embed_attachment";
+    payload: Record<string, unknown>;
+  }> = [];
   db.transaction((tx) => {
     for (const segment of segments) {
       if (segment.text.length < MIN_SEGMENT_CHARS) {
@@ -144,7 +151,7 @@ export async function indexMessageNow(
       if (existing?.contentHash === hash) {
         skippedEmbedJobs++;
       } else if (isMemoryEnabled()) {
-        enqueueMemoryJob("embed_segment", { segmentId }, Date.now(), tx);
+        pendingJobs.push({ type: "embed_segment", payload: { segmentId } });
       }
     }
 
@@ -152,15 +159,20 @@ export async function indexMessageNow(
     // embedding provider supports multimodal (Gemini only).
     if (isMemoryEnabled()) {
       for (const block of mediaBlocks) {
-        enqueueMemoryJob(
-          "embed_attachment",
-          { messageId: input.messageId, blockIndex: block.index },
-          Date.now(),
-          tx,
-        );
+        pendingJobs.push({
+          type: "embed_attachment",
+          payload: { messageId: input.messageId, blockIndex: block.index },
+        });
       }
     }
   });
+
+  // Flush queued jobs onto the memory connection now the segment writes have
+  // committed — enqueue only on success, mirroring the prior in-transaction
+  // behavior without spanning the two connections.
+  for (const job of pendingJobs) {
+    enqueueMemoryJob(job.type, job.payload);
+  }
 
   // ── Batch extraction tracking ──────────────────────────────────────
   // Instead of per-message extraction, track pending unextracted messages

--- a/assistant/src/memory/job-handlers/cleanup.ts
+++ b/assistant/src/memory/job-handlers/cleanup.ts
@@ -4,7 +4,7 @@ import { getLogsDbPath } from "../../util/logs-db-path.js";
 import { runAsyncSqlite } from "../db-async-query.js";
 import { getDb } from "../db-connection.js";
 import { enqueueMemoryJob, type MemoryJob } from "../jobs-store.js";
-import { rawAll, rawRun } from "../raw-query.js";
+import { rawAll, rawLogsRun, rawRun } from "../raw-query.js";
 
 const log = getLogger("memory-jobs-worker");
 
@@ -50,10 +50,10 @@ export async function pruneOldLlmRequestLogsJob(
   // fallback backend in `db-async-query.ts` synthesizes the same shape
   // by capturing `changes()` atomically after `exec()`. Both backends
   // end up on the parser path below.
-  // llm_request_logs lives in the attached logs database. Point the sqlite3
-  // subprocess at that file directly (it can't see the daemon connection's
-  // ATTACH); the in-process fallback runs on the daemon connection, where the
-  // unqualified name already resolves to the attached table.
+  // llm_request_logs lives in the dedicated logs database. Point the prune at
+  // that file directly via `dbPath` — both backends open it as their own
+  // database (the subprocess directly, the in-process fallback via a transient
+  // connection), so the DELETE hits the right file.
   const result = await runAsyncSqlite(
     `DELETE FROM llm_request_logs WHERE rowid IN (SELECT rowid FROM llm_request_logs WHERE created_at < ${cutoffMs} LIMIT ${PRUNE_LOG_BATCH_LIMIT});
 SELECT changes();`,
@@ -209,8 +209,9 @@ export function pruneOldConversationsJob(
       );
       if (still.length === 0) return;
 
-      // Non-cascading tables
-      rawRun(`DELETE FROM llm_request_logs WHERE conversation_id = ?`, id);
+      // Non-cascading tables. llm_request_logs lives in the dedicated logs
+      // connection, so it is deleted there (outside this main-DB transaction).
+      rawLogsRun(`DELETE FROM llm_request_logs WHERE conversation_id = ?`, id);
       rawRun(`DELETE FROM tool_invocations WHERE conversation_id = ?`, id);
       rawRun(`DELETE FROM messages WHERE conversation_id = ?`, id);
       rawRun(`DELETE FROM skill_loaded_events WHERE conversation_id = ?`, id);

--- a/assistant/src/memory/jobs-store.ts
+++ b/assistant/src/memory/jobs-store.ts
@@ -4,7 +4,7 @@ import { v4 as uuid } from "uuid";
 import { getConfig } from "../config/loader.js";
 import { getLogger } from "../util/logger.js";
 import { truncate } from "../util/truncate.js";
-import { getDb } from "./db-connection.js";
+import { type DrizzleDb, getMemoryDb } from "./db-connection.js";
 import {
   isEmbeddingBillingBreakerOpen,
   shouldAllowBillingProbe,
@@ -13,10 +13,22 @@ import {
   isQdrantBreakerOpen,
   shouldAllowQdrantProbe,
 } from "./qdrant-circuit-breaker.js";
-import { rawAll, rawChanges } from "./raw-query.js";
+import { rawMemoryAll, rawMemoryChanges } from "./raw-query.js";
 import { memoryJobs } from "./schema.js";
 
 const log = getLogger("memory-jobs-store");
+
+/**
+ * The memory connection (`assistant-memory.db`), where `memory_jobs` lives.
+ * Throws if the file cannot be opened — the work queue has no fallback.
+ */
+function memoryDb(): DrizzleDb {
+  const db = getMemoryDb();
+  if (!db) {
+    throw new Error("memory database unavailable");
+  }
+  return db;
+}
 
 export type MemoryJobType =
   | "embed_segment"
@@ -115,13 +127,13 @@ export function enqueueMemoryJob(
   type: MemoryJobType,
   payload: Record<string, unknown>,
   runAfter = Date.now(),
-  dbOverride?: Parameters<ReturnType<typeof getDb>["transaction"]>[0] extends (
+  dbOverride?: Parameters<DrizzleDb["transaction"]>[0] extends (
     tx: infer T,
   ) => unknown
     ? T
     : never,
 ): string {
-  const db = dbOverride ?? getDb();
+  const db = dbOverride ?? memoryDb();
   const id = uuid();
   const now = Date.now();
   db.insert(memoryJobs)
@@ -157,13 +169,13 @@ export function upsertDebouncedJob(
   type: MemoryJobType,
   payload: { conversationId: string } & Record<string, unknown>,
   runAfter: number,
-  dbOverride?: Parameters<ReturnType<typeof getDb>["transaction"]>[0] extends (
+  dbOverride?: Parameters<DrizzleDb["transaction"]>[0] extends (
     tx: infer T,
   ) => unknown
     ? T
     : never,
 ): void {
-  const db = dbOverride ?? getDb();
+  const db = dbOverride ?? memoryDb();
   const existing = db
     .select()
     .from(memoryJobs)
@@ -211,13 +223,13 @@ export function upsertAutoAnalysisJob(
     triggerGroup: "immediate" | "debounced";
   },
   runAfter: number,
-  dbOverride?: Parameters<ReturnType<typeof getDb>["transaction"]>[0] extends (
+  dbOverride?: Parameters<DrizzleDb["transaction"]>[0] extends (
     tx: infer T,
   ) => unknown
     ? T
     : never,
 ): void {
-  const db = dbOverride ?? getDb();
+  const db = dbOverride ?? memoryDb();
   // Match rows with the same triggerGroup OR legacy rows without triggerGroup
   // (from older builds that used upsertDebouncedJob before triggerGroup was
   // introduced). Without the IS NULL fallback, the next enqueue would insert
@@ -293,13 +305,13 @@ export function upsertAutoAnalysisJob(
 export function upsertMemoryRetrospectiveJob(
   payload: { conversationId: string },
   runAfter: number = Date.now(),
-  dbOverride?: Parameters<ReturnType<typeof getDb>["transaction"]>[0] extends (
+  dbOverride?: Parameters<DrizzleDb["transaction"]>[0] extends (
     tx: infer T,
   ) => unknown
     ? T
     : never,
 ): void {
-  const db = dbOverride ?? getDb();
+  const db = dbOverride ?? memoryDb();
   const existing = db
     .select()
     .from(memoryJobs)
@@ -331,7 +343,7 @@ export function upsertMemoryRetrospectiveJob(
  * Used to prevent duplicate enqueues for long-running maintenance jobs.
  */
 export function hasActiveJobOfType(type: MemoryJobType): boolean {
-  const db = getDb();
+  const db = memoryDb();
   return (
     db
       .select({ id: memoryJobs.id })
@@ -347,7 +359,7 @@ export function hasActiveJobOfType(type: MemoryJobType): boolean {
 }
 
 export function enqueuePruneOldLlmRequestLogsJob(retentionMs?: number): string {
-  const db = getDb();
+  const db = memoryDb();
   const existing = db
     .select()
     .from(memoryJobs)
@@ -396,7 +408,7 @@ export function enqueuePruneOldLlmRequestLogsJob(retentionMs?: number): string {
 export function enqueuePruneOldConversationsJob(
   retentionDays?: number,
 ): string {
-  const db = getDb();
+  const db = memoryDb();
   const existing = db
     .select()
     .from(memoryJobs)
@@ -443,7 +455,7 @@ export function enqueuePruneOldConversationsJob(
 }
 
 export function enqueuePruneOldTraceEventsJob(retentionDays?: number): string {
-  const db = getDb();
+  const db = memoryDb();
   const existing = db
     .select()
     .from(memoryJobs)
@@ -498,7 +510,7 @@ export interface LaneBudgets {
 export function claimMemoryJobs(limits: LaneBudgets): MemoryJob[] {
   if (limits.slowLlm <= 0 && limits.fast <= 0 && limits.embed <= 0) return [];
 
-  const db = getDb();
+  const db = memoryDb();
   const now = Date.now();
   const pendingFilter = and(
     eq(memoryJobs.status, "pending"),
@@ -584,7 +596,7 @@ export function claimMemoryJobs(limits: LaneBudgets): MemoryJob[] {
       .set({ status: "running", startedAt: now, updatedAt: now })
       .where(and(eq(memoryJobs.id, row.id), eq(memoryJobs.status, "pending")))
       .run();
-    if (rawChanges() === 0) continue;
+    if (rawMemoryChanges() === 0) continue;
     claimed.push(
       parseRow({
         ...row,
@@ -598,7 +610,7 @@ export function claimMemoryJobs(limits: LaneBudgets): MemoryJob[] {
 }
 
 export function completeMemoryJob(id: string): void {
-  const db = getDb();
+  const db = memoryDb();
   db.update(memoryJobs)
     .set({ status: "completed", updatedAt: Date.now(), lastError: null })
     .where(eq(memoryJobs.id, id))
@@ -626,7 +638,7 @@ const DEFER_MAX_DELAY_MS = 5 * 60 * 1000;
  * were exceeded and the job was marked as failed.
  */
 export function deferMemoryJob(id: string): "deferred" | "failed" {
-  const db = getDb();
+  const db = memoryDb();
   const row = db.select().from(memoryJobs).where(eq(memoryJobs.id, id)).get();
   if (!row) return "failed";
 
@@ -683,7 +695,7 @@ export function failMemoryJob(
 ): void {
   const retryDelayMs = options?.retryDelayMs ?? 30_000;
   const maxAttempts = options?.maxAttempts ?? 5;
-  const db = getDb();
+  const db = memoryDb();
   const row = db.select().from(memoryJobs).where(eq(memoryJobs.id, id)).get();
   if (!row) return;
   const attempts = row.attempts + 1;
@@ -713,12 +725,12 @@ export function failMemoryJob(
 }
 
 export function resetRunningJobsToPending(): number {
-  const db = getDb();
+  const db = memoryDb();
   db.update(memoryJobs)
     .set({ status: "pending", updatedAt: Date.now() })
     .where(eq(memoryJobs.status, "running"))
     .run();
-  return rawChanges();
+  return rawMemoryChanges();
 }
 
 /**
@@ -728,7 +740,7 @@ export function resetRunningJobsToPending(): number {
 export function failStalledJobs(timeoutMs: number): number {
   const now = Date.now();
   const cutoff = now - timeoutMs;
-  const stalled = rawAll<{ id: string; type: string }>(
+  const stalled = rawMemoryAll<{ id: string; type: string }>(
     `
     SELECT id, type
     FROM memory_jobs
@@ -740,7 +752,7 @@ export function failStalledJobs(timeoutMs: number): number {
   );
   if (stalled.length === 0) return 0;
 
-  const db = getDb();
+  const db = memoryDb();
   for (const row of stalled) {
     db.update(memoryJobs)
       .set({
@@ -761,7 +773,7 @@ export function failStalledJobs(timeoutMs: number): number {
 }
 
 export function getMemoryJobCounts(): Record<string, number> {
-  const rows = rawAll<{ status: string; c: number }>(`
+  const rows = rawMemoryAll<{ status: string; c: number }>(`
     SELECT status, COUNT(*) AS c
     FROM memory_jobs
     GROUP BY status

--- a/assistant/src/memory/jobs/__tests__/embed-concept-page.test.ts
+++ b/assistant/src/memory/jobs/__tests__/embed-concept-page.test.ts
@@ -142,7 +142,7 @@ afterAll(() => {
 // Imports are deferred to after the env var is set so any internal use of
 // `getWorkspaceDir()` resolves to the tmpdir.
 const { DEFAULT_CONFIG } = await import("../../../config/defaults.js");
-const { getDb } = await import("../../db-connection.js");
+const { getDb, getMemoryDb } = await import("../../db-connection.js");
 const { resetDbForTesting } =
   await import("../../../__tests__/db-test-helpers.js");
 const { initializeDb } = await import("../../db-init.js");
@@ -547,7 +547,7 @@ describe("enqueueEmbedConceptPageJob", () => {
   test("inserted job row carries the right type and slug payload", () => {
     const id = enqueueEmbedConceptPageJob({ slug: "row-check" });
 
-    const row = getDb()
+    const row = getMemoryDb()!
       .select()
       .from(memoryJobs)
       .all()

--- a/assistant/src/memory/jobs/embed-pkb-file.test.ts
+++ b/assistant/src/memory/jobs/embed-pkb-file.test.ts
@@ -33,7 +33,7 @@ mock.module("../../config/loader.js", () => ({
 
 import { DEFAULT_CONFIG } from "../../config/defaults.js";
 import type { AssistantConfig } from "../../config/types.js";
-import { getDb } from "../db-connection.js";
+import { getMemoryDb } from "../db-connection.js";
 import { initializeDb } from "../db-init.js";
 import {
   claimMemoryJobs,
@@ -68,7 +68,7 @@ describe("embedPkbFileJob", () => {
 
   beforeEach(() => {
     indexPkbFileCalls.length = 0;
-    const db = getDb();
+    const db = getMemoryDb()!;
     db.delete(memoryJobs).run();
   });
 
@@ -122,7 +122,7 @@ describe("enqueuePkbIndexJob", () => {
 
   beforeEach(() => {
     indexPkbFileCalls.length = 0;
-    const db = getDb();
+    const db = getMemoryDb()!;
     db.delete(memoryJobs).run();
   });
 

--- a/assistant/src/memory/llm-request-log-store.ts
+++ b/assistant/src/memory/llm-request-log-store.ts
@@ -24,8 +24,22 @@ import {
   getTurnTimeBounds,
   messageMetadataSchema,
 } from "./conversation-crud.js";
-import { getDb } from "./db-connection.js";
+import { type DrizzleDb, getDb, getLogsDb } from "./db-connection.js";
 import { llmRequestLogs, messages } from "./schema.js";
+
+/**
+ * The logs connection (`assistant-logs.db`), where `llm_request_logs` lives.
+ * Throws if the file cannot be opened — the store has no fallback, and a
+ * missing logs DB is a genuine failure for these call sites (insert/read of
+ * request logs). Callers that must not fail on this already wrap in try/catch.
+ */
+function logsDb(): DrizzleDb {
+  const db = getLogsDb();
+  if (!db) {
+    throw new Error("logs database unavailable");
+  }
+  return db;
+}
 
 export type LogRow = {
   id: string;
@@ -111,7 +125,7 @@ export function recordRequestLog(
   provider?: string,
   callSite?: LLMCallSite,
 ): string {
-  const db = getDb();
+  const db = logsDb();
   const id = uuid();
   db.insert(llmRequestLogs)
     .values({
@@ -178,7 +192,7 @@ export function recordSyntheticAgentErrorMessageLog(args: {
   preparedRequest: unknown | null;
   createdAt: number;
 }): string {
-  const db = getDb();
+  const db = logsDb();
   const id = uuid();
   const requestPayload = JSON.stringify({
     syntheticAgentErrorMessage: {
@@ -225,7 +239,7 @@ export function setAgentLoopExitReasonOnLatestLog(
   conversationId: string,
   reason: string,
 ): void {
-  const db = getDb();
+  const db = logsDb();
   const latest = db
     .select({ id: llmRequestLogs.id })
     .from(llmRequestLogs)
@@ -249,7 +263,7 @@ export function backfillMessageIdOnLogs(
   conversationId: string,
   messageId: string,
 ): void {
-  const db = getDb();
+  const db = logsDb();
   db.update(llmRequestLogs)
     .set({ messageId })
     .where(
@@ -272,7 +286,7 @@ export function relinkLlmRequestLogs(
   toMessageId: string,
 ): void {
   if (fromMessageIds.length === 0) return;
-  const db = getDb();
+  const db = logsDb();
   db.update(llmRequestLogs)
     .set({ messageId: toMessageId })
     .where(inArray(llmRequestLogs.messageId, fromMessageIds))
@@ -286,7 +300,7 @@ export function relinkLlmRequestLogs(
  */
 function selectLogsByMessageIds(messageIds: string[]): LogRow[] {
   if (messageIds.length === 0) return [];
-  const db = getDb();
+  const db = logsDb();
   return db
     .select({
       id: llmRequestLogs.id,
@@ -314,7 +328,7 @@ function selectLogsByMessageIds(messageIds: string[]): LogRow[] {
 export function getRequestLogsByConversationId(
   conversationId: string,
 ): LogRow[] {
-  const db = getDb();
+  const db = logsDb();
   return db
     .select({
       id: llmRequestLogs.id,
@@ -346,9 +360,13 @@ function selectOrphanedLogsInRange(
   endTime: number,
 ): LogRow[] {
   if (endTime <= startTime) return [];
-  const db = getDb();
-  // LEFT JOIN messages → filter where message row IS NULL (orphaned).
-  return db
+  // `llm_request_logs` and `messages` live in separate connections now, so the
+  // old LEFT JOIN can't span them. Resolve it in three steps:
+  //   (a) logs conn → candidate rows in [start,end] for the conversation with a
+  //       non-NULL message_id;
+  //   (b) main conn → which of those message_ids still exist in `messages`;
+  //   (c) filter to candidates whose message_id is NOT in the existing set.
+  const candidates = logsDb()
     .select({
       id: llmRequestLogs.id,
       conversationId: llmRequestLogs.conversationId,
@@ -361,18 +379,32 @@ function selectOrphanedLogsInRange(
       callSite: llmRequestLogs.callSite,
     })
     .from(llmRequestLogs)
-    .leftJoin(messages, eq(llmRequestLogs.messageId, messages.id))
     .where(
       and(
         eq(llmRequestLogs.conversationId, conversationId),
         gte(llmRequestLogs.createdAt, startTime),
         lte(llmRequestLogs.createdAt, endTime),
-        sql`${messages.id} IS NULL`,
         sql`${llmRequestLogs.messageId} IS NOT NULL`,
       ),
     )
     .orderBy(llmRequestLogs.createdAt)
     .all();
+  if (candidates.length === 0) return [];
+
+  const candidateMessageIds = [
+    ...new Set(candidates.map((c) => c.messageId as string)),
+  ];
+  const existing = new Set(
+    getDb()
+      .select({ id: messages.id })
+      .from(messages)
+      .where(inArray(messages.id, candidateMessageIds))
+      .all()
+      .map((r) => r.id),
+  );
+
+  // Orphaned = the referenced message no longer exists.
+  return candidates.filter((c) => !existing.has(c.messageId as string));
 }
 
 /**
@@ -389,7 +421,7 @@ function selectUnlinkedLogsInRange(
   endTime: number,
 ): LogRow[] {
   if (endTime <= startTime) return [];
-  const db = getDb();
+  const db = logsDb();
   return db
     .select({
       id: llmRequestLogs.id,
@@ -432,7 +464,7 @@ export function getPreviousNonCompactionCallCreatedAt(
   conversationId: string,
   beforeCreatedAt: number,
 ): number | null {
-  const db = getDb();
+  const db = logsDb();
   const row = db
     .select({ createdAt: llmRequestLogs.createdAt })
     .from(llmRequestLogs)
@@ -480,7 +512,7 @@ export function getCompactionLogsBetween(
   afterCreatedAt: number | null,
   beforeCreatedAt: number,
 ): CompactionAgentLogRow[] {
-  const db = getDb();
+  const db = logsDb();
   const predicates = [
     eq(llmRequestLogs.conversationId, conversationId),
     eq(llmRequestLogs.callSite, "compactionAgent"),
@@ -524,7 +556,7 @@ export function getCompactionLogsBetween(
  * full context window.
  */
 export function getRequestLogMetaById(logId: string): LogMetaRow | null {
-  const db = getDb();
+  const db = logsDb();
   return (
     db
       .select({
@@ -543,7 +575,7 @@ export function getRequestLogMetaById(logId: string): LogMetaRow | null {
 }
 
 export function getRequestLogById(logId: string): LogRow | null {
-  const db = getDb();
+  const db = logsDb();
   return (
     db
       .select({
@@ -609,7 +641,7 @@ export function getRequestLogsByMessageId(messageId: string): LogRow[] {
         // authoritative caller (e.g. watch-notifier).
         if (unlinkedLogs.length > 0 && turnMessageIds.length > 0) {
           try {
-            const db = getDb();
+            const db = logsDb();
             const ids = unlinkedLogs.map((l) => l.id);
             const targetMessageId = turnMessageIds[turnMessageIds.length - 1]!;
             db.update(llmRequestLogs)

--- a/assistant/src/memory/memory-retrospective-startup-cleanup.ts
+++ b/assistant/src/memory/memory-retrospective-startup-cleanup.ts
@@ -54,7 +54,7 @@ import {
 import { getConfig } from "../config/loader.js";
 import { getLogger } from "../util/logger.js";
 import { deleteConversation } from "./conversation-crud.js";
-import { getDb } from "./db-connection.js";
+import { getDb, getMemoryDb } from "./db-connection.js";
 import { MEMORY_RETROSPECTIVE_SOURCES } from "./memory-retrospective-constants.js";
 import { loadRetrospectiveRunMessages } from "./memory-retrospective-fork-boundary.js";
 import { conversations, memoryJobs } from "./schema.js";
@@ -98,6 +98,14 @@ export function sweepOrphanMemoryRetrospectiveConversations(
   const cutoff = now - ORPHAN_AGE_MS;
   const db = getDb();
 
+  // `memory_jobs` lives on the dedicated memory connection. If it is unavailable
+  // we cannot tell which sources have in-flight retrospective jobs, so skip the
+  // sweep rather than risk deleting a conversation whose job is still running.
+  const memoryDb = getMemoryDb();
+  if (!memoryDb) {
+    return { swept: 0 };
+  }
+
   // Job payloads encode the SOURCE conversation id (the conversation being
   // analyzed), not the background-conversation id of the retrospective itself.
   // The background conversation links back to its source via
@@ -105,7 +113,7 @@ export function sweepOrphanMemoryRetrospectiveConversations(
   // memory-retrospective-job.ts). To protect in-flight jobs we therefore
   // compare source-id to source-id by filtering on
   // `conversations.forkParentConversationId`, not `conversations.id`.
-  const activeJobSourceConversationIds = db
+  const activeJobSourceConversationIds = memoryDb
     .select({
       conversationId: sql<string>`json_extract(${memoryJobs.payload}, '$.conversationId')`,
     })

--- a/assistant/src/memory/migrations/297-move-llm-request-logs-to-logs-db.ts
+++ b/assistant/src/memory/migrations/297-move-llm-request-logs-to-logs-db.ts
@@ -1,17 +1,18 @@
+import type { Database } from "bun:sqlite";
+
 import { getLogsDbPath } from "../../util/logs-db-path.js";
 import {
   type DrizzleDb,
+  getLogsSqlite,
   getSqliteFrom,
-  LOGS_DB_SCHEMA,
 } from "../db-connection.js";
 import {
   drainStagedTable,
-  isSchemaAttached,
   type RelocationSpec,
   stageTableForRelocation,
 } from "./helpers/relocation.js";
 
-/** How to drain `llm_request_logs` from `main` into the attached `logs` DB. */
+/** How to drain `llm_request_logs` from `main` into the logs DB. */
 const RELOCATION: RelocationSpec = {
   table: "llm_request_logs",
   targetDbPath: getLogsDbPath,
@@ -28,8 +29,8 @@ const RELOCATION: RelocationSpec = {
   ],
 };
 
-const CREATE_TABLE = (schema: string): string => /*sql*/ `
-  CREATE TABLE IF NOT EXISTS ${schema}.llm_request_logs (
+const CREATE_TABLE = /*sql*/ `
+  CREATE TABLE IF NOT EXISTS llm_request_logs (
     id TEXT PRIMARY KEY,
     conversation_id TEXT NOT NULL,
     message_id TEXT,
@@ -42,68 +43,70 @@ const CREATE_TABLE = (schema: string): string => /*sql*/ `
   )
 `;
 
-/**
- * Create the three indexes in `schema`. The index names are schema-qualified;
- * the table name in `CREATE INDEX` must be unqualified and is resolved within
- * the index's schema — so the table must already resolve to `schema` (i.e. no
- * same-named table shadowing it in `main`) when this runs.
- */
-function createIndexes(raw: ReturnType<typeof getSqliteFrom>, schema: string) {
+/** Create the three indexes on the logs connection's `llm_request_logs`. */
+function createIndexes(raw: Database) {
   raw.exec(
-    `CREATE INDEX IF NOT EXISTS ${schema}.idx_llm_request_logs_message_id ON llm_request_logs(message_id)`,
+    `CREATE INDEX IF NOT EXISTS idx_llm_request_logs_message_id ON llm_request_logs(message_id)`,
   );
   raw.exec(
-    `CREATE INDEX IF NOT EXISTS ${schema}.idx_llm_request_logs_created_at ON llm_request_logs(created_at)`,
+    `CREATE INDEX IF NOT EXISTS idx_llm_request_logs_created_at ON llm_request_logs(created_at)`,
   );
   raw.exec(
-    `CREATE INDEX IF NOT EXISTS ${schema}.idx_llm_request_logs_conv_created ON llm_request_logs(conversation_id, created_at)`,
+    `CREATE INDEX IF NOT EXISTS idx_llm_request_logs_conv_created ON llm_request_logs(conversation_id, created_at)`,
   );
 }
 
 /**
- * Keep `llm_request_logs` housed in the attached append-only `logs` database
+ * Create the `llm_request_logs` table and its indexes on the logs connection.
+ * Idempotent (`IF NOT EXISTS`). Invoked both by this migration and synchronously
+ * by `initializeDb` so the table exists as soon as the DB is initialized — the
+ * dedicated connection itself performs no DDL on open.
+ */
+export function ensureLlmRequestLogsSchema(logsRaw: Database): void {
+  logsRaw.exec(CREATE_TABLE);
+  createIndexes(logsRaw);
+}
+
+/**
+ * House `llm_request_logs` in its own append-only database
  * (`assistant-logs.db`) rather than the main DB. Keeping this heavy table — and
  * the request/response payloads it stores — in its own file stops it from
  * bloating the main DB and its WAL, and lets the two files VACUUM and
- * checkpoint independently. Once it lives only in `logs`, the unqualified name
- * used by the Drizzle store resolves to the attached copy, so query code is
- * unchanged.
+ * checkpoint independently. The Drizzle store reads/writes the table over the
+ * dedicated logs connection (see `getLogsDb()`).
  *
  * The move is incremental: this step does metadata-only work — create the table
- * in `logs`, rename any populated `main.llm_request_logs` aside to
- * `llm_request_logs__relocating` — then drains the staged rows into `logs` in
- * awaited batches (see `helpers/relocation.ts`), keeping the event loop
- * responsive between batches rather than stalling it with a one-shot
- * `INSERT … SELECT` + `DROP` of a multi-GB table.
+ * (and indexes) on the logs connection, rename any populated
+ * `main.llm_request_logs` aside to `llm_request_logs__relocating` — then drains
+ * the staged rows into the logs file in awaited batches (see
+ * `helpers/relocation.ts`), keeping the event loop responsive between batches
+ * rather than stalling it with a one-shot `INSERT … SELECT` + `DROP` of a
+ * multi-GB table.
  *
  * Idempotent and safe to re-run: `stageTableForRelocation` drops a freshly
  * recreated empty shadow, renames a populated table only once, and leaves an
  * in-flight staging table alone; `drainStagedTable` resumes from the remaining
  * rows.
  *
- * Throws (rather than returning) if the `logs` database is not attached, so the
+ * Throws (rather than returning) if the logs database cannot be opened, so the
  * runner records the step as failed instead of applied — leaving it to retry on
- * a later boot once the attach succeeds. The throw is caught per-step by the
- * runner, so startup is not aborted.
+ * a later boot. The throw is caught per-step by the runner, so startup is not
+ * aborted.
  */
 export async function migrateMoveLlmRequestLogsToLogsDb(
   database: DrizzleDb,
 ): Promise<void> {
-  const raw = getSqliteFrom(database);
-
-  if (!isSchemaAttached(raw, LOGS_DB_SCHEMA)) {
+  const logsRaw = getLogsSqlite();
+  if (!logsRaw) {
     throw new Error(
-      "logs database not attached — deferring llm_request_logs relocation",
+      "logs database unavailable — deferring llm_request_logs relocation",
     );
   }
 
-  raw.exec(CREATE_TABLE(LOGS_DB_SCHEMA));
+  ensureLlmRequestLogsSchema(logsRaw);
 
+  const raw = getSqliteFrom(database);
   const needsDrain = stageTableForRelocation(raw, RELOCATION.table);
-
-  // Only now is `main` guaranteed not to shadow the table, so the unqualified
-  // reference in CREATE INDEX resolves to `logs`.
-  createIndexes(raw, LOGS_DB_SCHEMA);
 
   if (needsDrain) await drainStagedTable(raw, RELOCATION);
 }

--- a/assistant/src/memory/migrations/298-move-memory-jobs-to-memory-db.ts
+++ b/assistant/src/memory/migrations/298-move-memory-jobs-to-memory-db.ts
@@ -1,18 +1,19 @@
+import type { Database } from "bun:sqlite";
+
 import { getMemoryDbPath } from "../../util/memory-db-path.js";
 import {
   type DrizzleDb,
+  getMemorySqlite,
   getSqliteFrom,
-  MEMORY_DB_SCHEMA,
 } from "../db-connection.js";
 import {
   drainStagedTable,
-  isSchemaAttached,
   type RelocationSpec,
   stageTableForRelocation,
 } from "./helpers/relocation.js";
 
 /**
- * How to drain `memory_jobs` from `main` into the attached `memory` DB. Only
+ * How to drain `memory_jobs` from `main` into the memory DB. Only
  * `pending`/`running` jobs are worth keeping; the terminal (`completed`/`failed`)
  * rows that make up the bulk of a runaway queue are purged without copying.
  *
@@ -43,8 +44,8 @@ export const MEMORY_JOBS_RELOCATION: RelocationSpec = {
   },
 };
 
-const CREATE_TABLE = (schema: string): string => /*sql*/ `
-  CREATE TABLE IF NOT EXISTS ${schema}.memory_jobs (
+const CREATE_TABLE = /*sql*/ `
+  CREATE TABLE IF NOT EXISTS memory_jobs (
     id TEXT PRIMARY KEY,
     type TEXT NOT NULL,
     payload TEXT NOT NULL,
@@ -60,16 +61,23 @@ const CREATE_TABLE = (schema: string): string => /*sql*/ `
 `;
 
 /**
- * Recreate the two `memory_jobs` indexes in `schema`. As in the table DDL the
- * `CREATE INDEX` table reference is unqualified and resolved within the index's
- * schema, so the source table must no longer shadow it in `main`.
+ * Create the `memory_jobs` table and its indexes on the memory connection.
+ * Idempotent (`IF NOT EXISTS`). Invoked both by this migration and synchronously
+ * by `initializeDb` so the table exists as soon as the DB is initialized — the
+ * dedicated connection itself performs no DDL on open.
  */
-function createIndexes(raw: ReturnType<typeof getSqliteFrom>, schema: string) {
+export function ensureMemoryJobsSchema(memoryRaw: Database): void {
+  memoryRaw.exec(CREATE_TABLE);
+  createIndexes(memoryRaw);
+}
+
+/** Create the two `memory_jobs` indexes on the memory connection. */
+function createIndexes(raw: Database) {
   raw.exec(
-    `CREATE INDEX IF NOT EXISTS ${schema}.idx_memory_jobs_status_run_after ON memory_jobs(status, run_after)`,
+    `CREATE INDEX IF NOT EXISTS idx_memory_jobs_status_run_after ON memory_jobs(status, run_after)`,
   );
   raw.exec(/*sql*/ `
-    CREATE INDEX IF NOT EXISTS ${schema}.idx_memory_jobs_conflict_resolve_dedupe
+    CREATE INDEX IF NOT EXISTS idx_memory_jobs_conflict_resolve_dedupe
     ON memory_jobs(
       type,
       status,
@@ -80,21 +88,23 @@ function createIndexes(raw: ReturnType<typeof getSqliteFrom>, schema: string) {
 }
 
 /**
- * Move the `memory_jobs` work queue into the attached `memory` database
+ * Move the `memory_jobs` work queue into its own database
  * (`assistant-memory.db`). The queue is the heaviest, highest-churn table —
  * left in the main DB a runaway backlog bloats it (and its WAL) to many GB.
  * Splitting it out lets the queue grow, VACUUM, and checkpoint independently.
+ * The jobs store reads/writes the queue over the dedicated memory connection
+ * (see `getMemoryDb()`).
  *
  * Like the `llm_request_logs` move (migration 297) this is incremental: create
- * the table in `memory`, rename any populated `main.memory_jobs` aside to
- * `memory_jobs__relocating`, then drain it in awaited batches (see
- * `helpers/relocation.ts`) per {@link MEMORY_JOBS_RELOCATION}.
+ * the table (and indexes) on the memory connection, rename any populated
+ * `main.memory_jobs` aside to `memory_jobs__relocating`, then drain it in
+ * awaited batches (see `helpers/relocation.ts`) per {@link MEMORY_JOBS_RELOCATION}.
  *
  * Because the drain is awaited as part of this step, the pending/running jobs
  * are in their new home before the memory jobs worker starts later in daemon
  * startup — the worker never observes a transiently empty queue.
  *
- * Throws (rather than returning) if the `memory` database is not attached, so
+ * Throws (rather than returning) if the memory database cannot be opened, so
  * the runner records the step as failed instead of applied and retries it on a
  * later boot — never renaming the source aside without a target to write to,
  * and never marking the relocation done while it has not happened. The throw is
@@ -103,19 +113,17 @@ function createIndexes(raw: ReturnType<typeof getSqliteFrom>, schema: string) {
 export async function migrateMoveMemoryJobsToMemoryDb(
   database: DrizzleDb,
 ): Promise<void> {
-  const raw = getSqliteFrom(database);
-
-  if (!isSchemaAttached(raw, MEMORY_DB_SCHEMA)) {
+  const memoryRaw = getMemorySqlite();
+  if (!memoryRaw) {
     throw new Error(
-      "memory database not attached — deferring memory_jobs relocation",
+      "memory database unavailable — deferring memory_jobs relocation",
     );
   }
 
-  raw.exec(CREATE_TABLE(MEMORY_DB_SCHEMA));
+  ensureMemoryJobsSchema(memoryRaw);
 
+  const raw = getSqliteFrom(database);
   const needsDrain = stageTableForRelocation(raw, MEMORY_JOBS_RELOCATION.table);
-
-  createIndexes(raw, MEMORY_DB_SCHEMA);
 
   if (needsDrain) await drainStagedTable(raw, MEMORY_JOBS_RELOCATION);
 }

--- a/assistant/src/memory/migrations/__tests__/297-move-llm-request-logs.test.ts
+++ b/assistant/src/memory/migrations/__tests__/297-move-llm-request-logs.test.ts
@@ -1,12 +1,13 @@
 /**
- * Tests for migration 297 — keeping `llm_request_logs` in the attached
- * `logs` database.
+ * Tests for migration 297 — housing `llm_request_logs` in the dedicated
+ * `logs` database connection.
  *
  * Covers:
- *   1. End state after a full initializeDb(): the table lives in `logs`, not
- *      `main`, and the Drizzle store round-trips against it.
+ *   1. End state after a full initializeDb(): the table lives in the logs
+ *      connection, not `main`, and the Drizzle store round-trips against it.
  *   2. The relocation itself: rows in a `main.llm_request_logs` are copied into
- *      `logs` and the main-DB copy is dropped, with indexes built in `logs`.
+ *      the logs connection and the main-DB copy is dropped, with indexes built
+ *      in the logs connection.
  *   3. A legacy base-only `main` table (predating the newer columns) is copied
  *      without error, NULL-filling the absent columns.
  *
@@ -15,7 +16,7 @@
  */
 import { describe, expect, test } from "bun:test";
 
-const { getDb, getSqlite, LOGS_DB_SCHEMA } =
+const { getDb, getSqlite, getLogsSqlite } =
   await import("../../db-connection.js");
 const { initializeDb } = await import("../../db-init.js");
 const { migrateMoveLlmRequestLogsToLogsDb } =
@@ -25,30 +26,32 @@ const { recordRequestLog, getRequestLogById } =
 
 initializeDb();
 
-function tableSchemas(name: string): string[] {
-  return getSqlite()
-    .query<{ schema: string }, []>(
-      `SELECT 'main' AS schema FROM main.sqlite_master WHERE type='table' AND name='${name}'
-       UNION ALL
-       SELECT '${LOGS_DB_SCHEMA}' FROM ${LOGS_DB_SCHEMA}.sqlite_master WHERE type='table' AND name='${name}'`,
-    )
-    .all()
-    .map((r) => r.schema);
-}
-
-function stagingExists(table: string): boolean {
+function existsInMain(name: string): boolean {
   return (
     getSqlite()
       .query(
         `SELECT name FROM main.sqlite_master WHERE type='table' AND name = ?`,
       )
-      .get(`${table}__relocating`) != null
+      .get(name) != null
   );
+}
+
+function existsInLogs(name: string): boolean {
+  return (
+    getLogsSqlite()!
+      .query(`SELECT name FROM sqlite_master WHERE type='table' AND name = ?`)
+      .get(name) != null
+  );
+}
+
+function stagingExists(table: string): boolean {
+  return existsInMain(`${table}__relocating`);
 }
 
 describe("migration 297 — llm_request_logs lives in the logs database", () => {
   test("after init, the table is in logs and not in main", () => {
-    expect(tableSchemas("llm_request_logs")).toEqual([LOGS_DB_SCHEMA]);
+    expect(existsInLogs("llm_request_logs")).toBe(true);
+    expect(existsInMain("llm_request_logs")).toBe(false);
   });
 
   test("the store round-trips against the relocated table", () => {
@@ -67,20 +70,21 @@ describe("migration 297 — llm_request_logs lives in the logs database", () => 
     expect(row?.callSite).toBe("mainAgent");
 
     // The written row physically lives in the logs database.
-    const inLogs = getSqlite()
+    const inLogs = getLogsSqlite()!
       .query<
         { c: number },
         [string]
-      >(`SELECT COUNT(*) AS c FROM ${LOGS_DB_SCHEMA}.llm_request_logs WHERE id = ?`)
+      >(`SELECT COUNT(*) AS c FROM llm_request_logs WHERE id = ?`)
       .get(id);
     expect(inLogs?.c).toBe(1);
   });
 
   test("relocates rows from a main-DB table and drops it", async () => {
     const sqlite = getSqlite();
+    const logs = getLogsSqlite()!;
 
     // Simulate a populated pre-relocation main-DB table alongside the logs copy.
-    sqlite.exec(`DROP TABLE IF EXISTS ${LOGS_DB_SCHEMA}.llm_request_logs`);
+    logs.exec(`DROP TABLE IF EXISTS llm_request_logs`);
     sqlite.exec(`DROP TABLE IF EXISTS main.llm_request_logs__relocating`);
     sqlite.exec(`
       CREATE TABLE main.llm_request_logs (
@@ -104,21 +108,22 @@ describe("migration 297 — llm_request_logs lives in the logs database", () => 
     // resolves.
     await migrateMoveLlmRequestLogsToLogsDb(getDb());
 
-    expect(tableSchemas("llm_request_logs")).toEqual([LOGS_DB_SCHEMA]);
+    expect(existsInLogs("llm_request_logs")).toBe(true);
+    expect(existsInMain("llm_request_logs")).toBe(false);
     expect(stagingExists("llm_request_logs")).toBe(false);
-    const moved = sqlite
+    const moved = logs
       .query<
         { conversation_id: string; provider: string },
         []
-      >(`SELECT conversation_id, provider FROM ${LOGS_DB_SCHEMA}.llm_request_logs WHERE id = 'legacy-1'`)
+      >(`SELECT conversation_id, provider FROM llm_request_logs WHERE id = 'legacy-1'`)
       .get();
     expect(moved?.conversation_id).toBe("conv-legacy");
     expect(moved?.provider).toBe("openai");
 
     // Indexes were created in the logs database.
-    const indexes = sqlite
+    const indexes = logs
       .query<{ name: string }, []>(
-        `SELECT name FROM ${LOGS_DB_SCHEMA}.sqlite_master WHERE type='index' AND tbl_name='llm_request_logs'`,
+        `SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='llm_request_logs'`,
       )
       .all()
       .map((r) => r.name);
@@ -129,11 +134,12 @@ describe("migration 297 — llm_request_logs lives in the logs database", () => 
 
   test("copies a legacy base-only table, NULL-filling newer columns", async () => {
     const sqlite = getSqlite();
+    const logs = getLogsSqlite()!;
 
     // A workspace upgrading from a build that predates the
     // message_id/provider/agent_loop_exit_reason/call_site columns: the main
     // table has only the original base columns.
-    sqlite.exec(`DROP TABLE IF EXISTS ${LOGS_DB_SCHEMA}.llm_request_logs`);
+    logs.exec(`DROP TABLE IF EXISTS llm_request_logs`);
     sqlite.exec(`DROP TABLE IF EXISTS main.llm_request_logs__relocating`);
     sqlite.exec(`
       CREATE TABLE main.llm_request_logs (
@@ -151,8 +157,9 @@ describe("migration 297 — llm_request_logs lives in the logs database", () => 
     // Must not throw on the absent columns: the drain NULL-fills them.
     await migrateMoveLlmRequestLogsToLogsDb(getDb());
 
-    expect(tableSchemas("llm_request_logs")).toEqual([LOGS_DB_SCHEMA]);
-    const moved = sqlite
+    expect(existsInLogs("llm_request_logs")).toBe(true);
+    expect(existsInMain("llm_request_logs")).toBe(false);
+    const moved = logs
       .query<
         {
           conversation_id: string;
@@ -162,7 +169,7 @@ describe("migration 297 — llm_request_logs lives in the logs database", () => 
         },
         []
       >(
-        `SELECT conversation_id, message_id, provider, call_site FROM ${LOGS_DB_SCHEMA}.llm_request_logs WHERE id = 'base-1'`,
+        `SELECT conversation_id, message_id, provider, call_site FROM llm_request_logs WHERE id = 'base-1'`,
       )
       .get();
     expect(moved?.conversation_id).toBe("conv-base");

--- a/assistant/src/memory/migrations/helpers/relocation.ts
+++ b/assistant/src/memory/migrations/helpers/relocation.ts
@@ -10,21 +10,21 @@ import {
 const log = getLogger("memory-db");
 
 /**
- * Incremental relocation of a heavy table out of the main DB and into an
- * attached file (`assistant-logs.db` / `assistant-memory.db`).
+ * Incremental relocation of a heavy table out of the main DB and into its
+ * own file (`assistant-logs.db` / `assistant-memory.db`).
  *
  * A one-shot `INSERT … SELECT` + `DROP TABLE` of a multi-GB table on the daemon
  * connection would pin the write lock and block the event loop for minutes.
  * Instead a relocation runs as an async migration step in two parts:
  *
  *   1. {@link stageTableForRelocation} renames the source table in `main` aside
- *      to `<table>__relocating` (instant, metadata-only). Once `main` no longer
- *      has `<table>`, the unqualified name resolves to the attached copy, so
- *      live reads/writes route correctly immediately.
- *   2. {@link drainStagedTable} copies the staged rows into the target in
+ *      to `<table>__relocating` (instant, metadata-only), so live reads/writes
+ *      route to the dedicated connection's copy immediately.
+ *   2. {@link drainStagedTable} copies the staged rows into the target file in
  *      bounded batches and truncates them from the staging table as it goes,
- *      then drops it. Each batch runs off the connection via `runAsyncSqlite`,
- *      so the event loop is free between batches; the migration `await`s it to
+ *      then drops it. Each batch runs through `runAsyncSqlite`, which opens the
+ *      target file directly (the sqlite3 subprocess ATTACHes it), so the work
+ *      is independent of the daemon connection; the migration `await`s it to
  *      completion before checkpointing, so later startup work observes the
  *      finished move.
  *
@@ -65,14 +65,6 @@ export interface RelocationSpec {
    * row; unlisted columns copy as-is (or NULL when absent from the source).
    */
   columnExpr?: Record<string, string>;
-}
-
-/** True if `schema` is currently ATTACHed to the connection. */
-export function isSchemaAttached(raw: Database, schema: string): boolean {
-  const rows = raw
-    .query<{ name: string }, []>("PRAGMA database_list")
-    .all() as Array<{ name: string }>;
-  return rows.some((r) => r.name === schema);
 }
 
 function tableExistsInMain(raw: Database, name: string): boolean {

--- a/assistant/src/memory/raw-query.ts
+++ b/assistant/src/memory/raw-query.ts
@@ -30,9 +30,9 @@
  * filtering, ordering, pagination — use Drizzle.
  */
 
-import type { SQLQueryBindings } from "bun:sqlite";
+import type { Database, SQLQueryBindings } from "bun:sqlite";
 
-import { getSqlite } from "./db-connection.js";
+import { getLogsSqlite, getMemorySqlite, getSqlite } from "./db-connection.js";
 
 type SqlParam = SQLQueryBindings;
 
@@ -80,6 +80,51 @@ export function rawExec(sql: string): void {
  */
 export function rawChanges(): number {
   return (getSqlite().query("SELECT changes() AS c").get() as { c: number }).c;
+}
+
+// ---------------------------------------------------------------------------
+// Typed query helpers for the dedicated memory connection (assistant-memory.db)
+// ---------------------------------------------------------------------------
+
+/** The memory connection, or a thrown error when it cannot be opened. */
+function memorySqlite(): Database {
+  const sqlite = getMemorySqlite();
+  if (!sqlite) throw new Error("memory database unavailable");
+  return sqlite;
+}
+
+/** The logs connection, or a thrown error when it cannot be opened. */
+function logsSqlite(): Database {
+  const sqlite = getLogsSqlite();
+  if (!sqlite) throw new Error("logs database unavailable");
+  return sqlite;
+}
+
+/** {@link rawAll} against the memory connection. */
+export function rawMemoryAll<T>(sql: string, ...params: SqlParam[]): T[] {
+  return memorySqlite()
+    .query(sql)
+    .all(...params) as T[];
+}
+
+/** {@link rawRun} against the memory connection. */
+export function rawMemoryRun(sql: string, ...params: SqlParam[]): number {
+  const sqlite = memorySqlite();
+  sqlite.query(sql).run(...params);
+  return (sqlite.query("SELECT changes() AS c").get() as { c: number }).c;
+}
+
+/** {@link rawChanges} against the memory connection. */
+export function rawMemoryChanges(): number {
+  return (memorySqlite().query("SELECT changes() AS c").get() as { c: number })
+    .c;
+}
+
+/** {@link rawRun} against the logs connection. */
+export function rawLogsRun(sql: string, ...params: SqlParam[]): number {
+  const sqlite = logsSqlite();
+  sqlite.query(sql).run(...params);
+  return (sqlite.query("SELECT changes() AS c").get() as { c: number }).c;
 }
 
 /**

--- a/assistant/src/memory/task-memory-cleanup.ts
+++ b/assistant/src/memory/task-memory-cleanup.ts
@@ -1,7 +1,48 @@
 import { getLogger } from "../util/logger.js";
-import { rawGet, rawRun } from "./raw-query.js";
+import { rawAll, rawGet, rawMemoryRun, rawRun } from "./raw-query.js";
 
 const log = getLogger("task-memory-cleanup");
+
+/**
+ * Max id placeholders per `IN (...)` chunk when cancelling jobs by an id set
+ * resolved on the main connection. SQLite's default bound-variable limit is
+ * well above this, but chunking keeps a pathological conversation (tens of
+ * thousands of messages/segments) from building one giant statement.
+ */
+const ID_CHUNK_SIZE = 500;
+
+/**
+ * Fail every pending/running `memory_jobs` row whose `json_extract(payload,
+ * jsonPath)` matches one of `ids`. `memory_jobs` lives in the dedicated memory
+ * connection while the id sets are resolved on the main connection, so the
+ * cancellation can't be a single cross-DB subquery — bind the ids directly
+ * (chunked) instead. Returns the total rows affected.
+ */
+function cancelJobsByPayloadIds(
+  jsonPath: string,
+  ids: string[],
+  reason: string,
+  now: number,
+): number {
+  if (ids.length === 0) return 0;
+  let affected = 0;
+  for (let i = 0; i < ids.length; i += ID_CHUNK_SIZE) {
+    const chunk = ids.slice(i, i + ID_CHUNK_SIZE);
+    const placeholders = chunk.map(() => "?").join(", ");
+    affected += rawMemoryRun(
+      `UPDATE memory_jobs
+          SET status = 'failed',
+              last_error = ?,
+              updated_at = ?
+        WHERE status IN ('pending', 'running')
+          AND json_extract(payload, '${jsonPath}') IN (${placeholders})`,
+      reason,
+      now,
+      ...chunk,
+    );
+  }
+  return affected;
+}
 
 /**
  * Check whether a conversation belongs to a failed task run or failed
@@ -112,23 +153,19 @@ export function cancelPendingJobsForConversation(
   const now = Date.now();
   let total = 0;
 
+  // The id sets live on the main connection; `memory_jobs` lives on the memory
+  // connection. Resolve each set on main first, then cancel by bound ids on the
+  // memory connection (the conversationId-keyed update needs no main lookup).
+
   // Jobs keyed by messageId: embed_attachment
-  total += rawRun(
-    `UPDATE memory_jobs
-        SET status = 'failed',
-            last_error = ?,
-            updated_at = ?
-      WHERE status IN ('pending', 'running')
-        AND json_extract(payload, '$.messageId') IN (
-          SELECT id FROM messages WHERE conversation_id = ?
-        )`,
-    reason,
-    now,
+  const messageIds = rawAll<{ id: string }>(
+    `SELECT id FROM messages WHERE conversation_id = ?`,
     conversationId,
-  );
+  ).map((r) => r.id);
+  total += cancelJobsByPayloadIds("$.messageId", messageIds, reason, now);
 
   // Jobs keyed by conversationId: graph_extract, build_conversation_summary
-  total += rawRun(
+  total += rawMemoryRun(
     `UPDATE memory_jobs
         SET status = 'failed',
             last_error = ?,
@@ -141,36 +178,20 @@ export function cancelPendingJobsForConversation(
   );
 
   // Jobs keyed by segmentId: embed_segment (segments belong to the conversation)
-  total += rawRun(
-    `UPDATE memory_jobs
-        SET status = 'failed',
-            last_error = ?,
-            updated_at = ?
-      WHERE status IN ('pending', 'running')
-        AND json_extract(payload, '$.segmentId') IN (
-          SELECT id FROM memory_segments WHERE conversation_id = ?
-        )`,
-    reason,
-    now,
+  const segmentIds = rawAll<{ id: string }>(
+    `SELECT id FROM memory_segments WHERE conversation_id = ?`,
     conversationId,
-  );
+  ).map((r) => r.id);
+  total += cancelJobsByPayloadIds("$.segmentId", segmentIds, reason, now);
 
   // Jobs keyed by nodeId: embed_graph_node (nodes sourced from this conversation)
-  total += rawRun(
-    `UPDATE memory_jobs
-        SET status = 'failed',
-            last_error = ?,
-            updated_at = ?
-      WHERE status IN ('pending', 'running')
-        AND json_extract(payload, '$.nodeId') IN (
-          SELECT mgn.id
-            FROM memory_graph_nodes mgn, json_each(mgn.source_conversations) jc
-           WHERE jc.value = ?
-        )`,
-    reason,
-    now,
+  const nodeIds = rawAll<{ id: string }>(
+    `SELECT mgn.id
+       FROM memory_graph_nodes mgn, json_each(mgn.source_conversations) jc
+      WHERE jc.value = ?`,
     conversationId,
-  );
+  ).map((r) => r.id);
+  total += cancelJobsByPayloadIds("$.nodeId", nodeIds, reason, now);
 
   if (total > 0) {
     log.info(
@@ -192,7 +213,7 @@ function cancelPendingExtractionJobsForConversation(
   conversationId: string,
 ): number {
   const now = Date.now();
-  const cancelled = rawRun(
+  const cancelled = rawMemoryRun(
     `UPDATE memory_jobs
         SET status = 'failed',
             last_error = 'conversation_failed',

--- a/assistant/src/memory/v2/__tests__/backfill-jobs.test.ts
+++ b/assistant/src/memory/v2/__tests__/backfill-jobs.test.ts
@@ -202,7 +202,8 @@ afterAll(() => {
   rmSync(tmpWorkspace, { recursive: true, force: true });
 });
 
-const { getDb } = await import("../../db-connection.js");
+const { getDb, getMemoryDb, getMemorySqlite } =
+  await import("../../db-connection.js");
 const { resetDbForTesting } =
   await import("../../../__tests__/db-test-helpers.js");
 const { initializeDb } = await import("../../db-init.js");
@@ -259,14 +260,11 @@ beforeEach(() => {
   // so explicitly truncate every table this suite writes to. Without this,
   // a row written by an earlier test (e.g. an activation_state for
   // `conv-with-state`) leaks into the next test and breaks isolation.
-  for (const table of [
-    "activation_state",
-    "memory_jobs",
-    "messages",
-    "conversations",
-  ]) {
+  for (const table of ["activation_state", "messages", "conversations"]) {
     rawExec(`DELETE FROM ${table}`);
   }
+  // memory_jobs lives in the dedicated memory connection.
+  getMemorySqlite()!.run("DELETE FROM memory_jobs");
   // Reset memory dir so each test starts with a clean concepts/edges set.
   rmSync(join(tmpWorkspace, "memory", "concepts"), {
     recursive: true,
@@ -354,7 +352,7 @@ describe("memoryV2ReembedJob", () => {
     // runs in isolation (or before such tests) the rows do land. Either
     // way, the return value is the canonical contract — the row lookup is
     // belt-and-suspenders.
-    const rows = getDb().select().from(memoryJobs).all();
+    const rows = getMemoryDb()!.select().from(memoryJobs).all();
     if (rows.length > 0) {
       expect(rows).toHaveLength(2);
       const slugs = rows.map((row) => JSON.parse(row.payload).slug);
@@ -388,7 +386,7 @@ describe("memoryV2ReembedJob", () => {
 
     await memoryV2ReembedJob(makeJob("memory_v2_reembed"), TEST_CONFIG);
 
-    const rows = getDb().select().from(memoryJobs).all();
+    const rows = getMemoryDb()!.select().from(memoryJobs).all();
     if (rows.length > 0) {
       const slugs = rows.map((row) => JSON.parse(row.payload).slug);
       for (const reserved of [

--- a/assistant/src/runtime/routes/__tests__/consolidation-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/consolidation-routes.test.ts
@@ -38,10 +38,10 @@ mock.module("../../../util/logger.js", () => ({
 
 import { invalidateConfigCache } from "../../../config/loader.js";
 import { createConversation } from "../../../memory/conversation-crud.js";
-import { getDb } from "../../../memory/db-connection.js";
+import { getDb, getMemorySqlite } from "../../../memory/db-connection.js";
 import { initializeDb } from "../../../memory/db-init.js";
 import { recordUsageEvent } from "../../../memory/llm-usage-store.js";
-import { rawAll, rawRun } from "../../../memory/raw-query.js";
+import { rawRun } from "../../../memory/raw-query.js";
 import { ROUTES } from "../consolidation-routes.js";
 import type { RouteDefinition } from "../types.js";
 
@@ -56,7 +56,7 @@ function resetTables(): void {
   db.run(`DELETE FROM llm_usage_events`);
   db.run(`DELETE FROM messages`);
   db.run(`DELETE FROM conversations`);
-  db.run(`DELETE FROM memory_jobs`);
+  getMemorySqlite()!.run(`DELETE FROM memory_jobs`);
 }
 
 function findHandler(operationId: string): RouteDefinition["handler"] {
@@ -117,16 +117,20 @@ function readMemoryJobRows(): Array<{
   lastError: string | null;
   payload: string;
 }> {
-  return rawAll<{
+  return getMemorySqlite()!
+    .query(
+      `
+    SELECT id, status, last_error AS lastError, payload
+    FROM memory_jobs
+    ORDER BY id
+  `,
+    )
+    .all() as Array<{
     id: string;
     status: string;
     lastError: string | null;
     payload: string;
-  }>(`
-    SELECT id, status, last_error AS lastError, payload
-    FROM memory_jobs
-    ORDER BY id
-  `);
+  }>;
 }
 
 interface RunRecord {

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -57,7 +57,7 @@ mock.module("../../../memory/embedding-backend.js", () => ({
 }));
 
 import type { ConversationCreateType } from "../../../memory/conversation-crud.js";
-import { getDb } from "../../../memory/db-connection.js";
+import { getDb, getLogsDb } from "../../../memory/db-connection.js";
 import { initializeDb } from "../../../memory/db-init.js";
 import {
   backfillMemoryV2ActivationMessageId,
@@ -108,7 +108,7 @@ function dispatchConversationLlmContext(queryParams: Record<string, string>) {
 
 function clearTables(): void {
   const db = getDb();
-  db.delete(llmRequestLogs).run();
+  getLogsDb()!.delete(llmRequestLogs).run();
   db.delete(memoryV2ActivationLogs).run();
   db.delete(messages).run();
   db.delete(conversationKeys).run();
@@ -156,7 +156,7 @@ function seedRequestLog(
   id: string,
   options: { agentLoopExitReason?: string | null } = {},
 ): void {
-  getDb()
+  getLogsDb()!
     .insert(llmRequestLogs)
     .values({
       id,
@@ -176,7 +176,7 @@ function seedRequestLog(
 }
 
 function seedRequestLogWithSections(messageId: string, id: string): void {
-  getDb()
+  getLogsDb()!
     .insert(llmRequestLogs)
     .values({
       id,
@@ -243,7 +243,7 @@ describe("GET /v1/conversations/llm-context", () => {
     seedConversationKey("conv-key", "conv-1");
     seedRequestLog("msg-2", "log-b");
     seedRequestLog("msg-1", "log-a");
-    getDb()
+    getLogsDb()!
       .insert(llmRequestLogs)
       .values({
         id: "log-other",
@@ -630,7 +630,7 @@ describe("GET /v1/messages/:id/llm-context — synthetic call_site projection", 
     // loop was about to send; response = the notice text the user saw),
     // `call_site = "syntheticAgentErrorMessage"`, exit reason stamped at
     // insert time.
-    getDb()
+    getLogsDb()!
       .insert(llmRequestLogs)
       .values({
         id: "log-yield",
@@ -681,7 +681,7 @@ describe("GET /v1/messages/:id/llm-context — synthetic call_site projection", 
       source: "user",
       conversationType: "standard",
     });
-    getDb()
+    getLogsDb()!
       .insert(llmRequestLogs)
       .values({
         id: "log-regular",

--- a/assistant/src/runtime/routes/__tests__/memory-v2-simulate-route.test.ts
+++ b/assistant/src/runtime/routes/__tests__/memory-v2-simulate-route.test.ts
@@ -80,6 +80,10 @@ mock.module("../../../memory/db-connection.js", () => ({
   getDb: () => ({ __stub: true }),
   getSqlite: () => ({ __stub: true }),
   getSqliteFrom: () => ({ __stub: true }),
+  getMemoryDb: () => ({ __stub: true }),
+  getMemorySqlite: () => ({ __stub: true }),
+  getLogsDb: () => ({ __stub: true }),
+  getLogsSqlite: () => ({ __stub: true }),
   resetDb: () => {},
 }));
 

--- a/assistant/src/runtime/routes/acp-routes-list.test.ts
+++ b/assistant/src/runtime/routes/acp-routes-list.test.ts
@@ -46,6 +46,10 @@ mock.module("../../memory/db-connection.js", () => {
     getDb: () => builder,
     getSqlite: () => ({ __stub: true }),
     getSqliteFrom: () => ({ __stub: true }),
+    getMemoryDb: () => builder,
+    getMemorySqlite: () => ({ __stub: true }),
+    getLogsDb: () => builder,
+    getLogsSqlite: () => ({ __stub: true }),
     resetDb: () => {},
   };
 });

--- a/assistant/src/runtime/routes/conversation-starter-routes.ts
+++ b/assistant/src/runtime/routes/conversation-starter-routes.ts
@@ -21,7 +21,7 @@ import {
   buildConversationStarterValidationContext,
   isValidConversationStarterText,
 } from "../../memory/conversation-starter-validation.js";
-import { getDb } from "../../memory/db-connection.js";
+import { getDb, getMemoryDb } from "../../memory/db-connection.js";
 import { enqueueMemoryJob, isMemoryEnabled } from "../../memory/jobs-store.js";
 import { conversationStarters, memoryJobs } from "../../memory/schema.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
@@ -49,12 +49,11 @@ export const CONVERSATION_STARTERS_STALE_TTL_MS = 4 * 60 * 60 * 1000;
  *  when generation repeatedly fails or produces 0 valid starters). */
 const REFRESH_COOLDOWN_MS = 5 * 60 * 1000;
 
-function hasActiveConversationStarterJob(
-  db: ReturnType<typeof getDb>,
-  scopeId: string,
-): boolean {
+function hasActiveConversationStarterJob(scopeId: string): boolean {
+  const memoryDb = getMemoryDb();
+  if (!memoryDb) return false;
   return (
-    db
+    memoryDb
       .select({ id: memoryJobs.id })
       .from(memoryJobs)
       .where(
@@ -200,7 +199,7 @@ function handleListConversationStarters({
       lastGenAt == null ||
       Date.now() - lastGenAt >= CONVERSATION_STARTERS_STALE_TTL_MS;
     const checkpointAhead = lastCount != null && totalActive < lastCount;
-    let hasActiveJob = hasActiveConversationStarterJob(db, scopeId);
+    let hasActiveJob = hasActiveConversationStarterJob(scopeId);
     const lastAttemptAt = parseCheckpointInt(
       getCheckpointValue(checkpointKey(CK_LAST_ATTEMPT_AT, scopeId)),
     );
@@ -232,7 +231,7 @@ function handleListConversationStarters({
     return { starters: [], total: 0, status: "empty" };
   }
 
-  const existing = hasActiveConversationStarterJob(db, scopeId);
+  const existing = hasActiveConversationStarterJob(scopeId);
 
   if (!existing && isMemoryEnabled()) {
     enqueueMemoryJob("generate_conversation_starters", { scopeId });

--- a/assistant/src/runtime/routes/log-export-routes.ts
+++ b/assistant/src/runtime/routes/log-export-routes.ts
@@ -22,7 +22,7 @@ import { join } from "node:path";
 import { and, desc, eq, gte, lte } from "drizzle-orm";
 import { z } from "zod";
 
-import { getDb } from "../../memory/db-connection.js";
+import { getDb, getLogsDb } from "../../memory/db-connection.js";
 import {
   llmRequestLogs,
   llmUsageEvents,
@@ -168,7 +168,7 @@ async function handleExport({
         : [];
 
       const llmLogRows = capRows(
-        db
+        (getLogsDb() ?? db)
           .select()
           .from(llmRequestLogs)
           .where(

--- a/assistant/src/runtime/routes/memory-item-routes.test.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.test.ts
@@ -66,7 +66,11 @@ mock.module("../../memory/qdrant-circuit-breaker.js", () => ({
 
 import { eq } from "drizzle-orm";
 
-import { getDb } from "../../memory/db-connection.js";
+import {
+  getDb,
+  getMemoryDb,
+  getMemorySqlite,
+} from "../../memory/db-connection.js";
 import { initializeDb } from "../../memory/db-init.js";
 import { memoryGraphNodes, memoryJobs } from "../../memory/schema.js";
 import { BadRequestError, ConflictError, NotFoundError } from "./errors.js";
@@ -186,7 +190,7 @@ describe("Memory Item Routes", () => {
     db.run("DELETE FROM memory_graph_triggers");
     db.run("DELETE FROM memory_graph_edges");
     db.run("DELETE FROM memory_graph_nodes");
-    db.run("DELETE FROM memory_jobs");
+    getMemorySqlite()!.run("DELETE FROM memory_jobs");
   });
 
   // =========================================================================
@@ -729,8 +733,7 @@ describe("Memory Item Routes", () => {
       });
 
       // Verify a memory job was enqueued
-      const db = getDb();
-      const jobs = db.select().from(memoryJobs).all();
+      const jobs = getMemoryDb()!.select().from(memoryJobs).all();
       const embedJobs = jobs.filter(
         (j) => j.type === "embed_graph_node" && j.status === "pending",
       );
@@ -835,15 +838,14 @@ describe("Memory Item Routes", () => {
       });
 
       // Clear jobs first
-      getDb().run("DELETE FROM memory_jobs");
+      getMemorySqlite()!.run("DELETE FROM memory_jobs");
 
       await callHandler(route, {
         pathParams: { id: "i1" },
         body: { statement: "new statement" },
       });
 
-      const db = getDb();
-      const jobs = db.select().from(memoryJobs).all();
+      const jobs = getMemoryDb()!.select().from(memoryJobs).all();
       const embedJobs = jobs.filter(
         (j) => j.type === "embed_graph_node" && j.status === "pending",
       );
@@ -897,8 +899,7 @@ describe("Memory Item Routes", () => {
       expect(res.status).toBe(204);
 
       // Verify a delete_qdrant_vectors job was enqueued with graph_node targetType
-      const db = getDb();
-      const jobs = db.select().from(memoryJobs).all();
+      const jobs = getMemoryDb()!.select().from(memoryJobs).all();
       const deleteJobs = jobs.filter(
         (j) => j.type === "delete_qdrant_vectors" && j.status === "pending",
       );

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -24,7 +24,12 @@ import { getPlatformAssistantId } from "../../config/env.js";
 import { invalidateConfigCache } from "../../config/loader.js";
 import { getAssistantName } from "../../daemon/identity-helpers.js";
 import { runAsyncSqlite } from "../../memory/db-async-query.js";
-import { getDb, resetDb } from "../../memory/db-connection.js";
+import {
+  getDb,
+  getLogsSqlite,
+  getMemorySqlite,
+  resetDb,
+} from "../../memory/db-connection.js";
 import { validateMigrationState } from "../../memory/migrations/validate-migration-state.js";
 import { credentialKey } from "../../security/credential-key.js";
 import {
@@ -38,7 +43,6 @@ import {
   upsertCredentialMetadata,
 } from "../../tools/credentials/metadata-store.js";
 import { getLogger } from "../../util/logger.js";
-import { getLogsDbPath } from "../../util/logs-db-path.js";
 import { getWorkspaceDir, getWorkspaceHooksDir } from "../../util/platform.js";
 import { APP_VERSION } from "../../version.js";
 import { DAEMON_INTERNAL_ASSISTANT_ID } from "../assistant-scope.js";
@@ -153,31 +157,42 @@ export async function reconcileVellumMetadataFromCes(warningSink: {
 const log = getLogger("migration-routes");
 
 /**
- * Flush both database files' WALs before an export copies them. The bundle
+ * Flush each database file's WAL before an export copies them. The bundle
  * walker includes `*.db` but skips `*.db-wal`, so committed frames still sitting
  * in a WAL would be missing from the bundle.
  *
- * Dispatched through `runAsyncSqlite` so the flush runs in a sqlite3 subprocess
- * where available — a multi-GB WAL flush would otherwise stall the event loop.
- * The in-process fallback runs on the daemon connection, where one unqualified
- * checkpoint already covers every attached database; the subprocess opens a
- * single file, so we issue a second checkpoint targeting the logs file. FULL
- * (not TRUNCATE) writes committed frames back to the main file, which is all the
- * copy needs.
+ * The main DB is flushed through `runAsyncSqlite` so the (potentially multi-GB)
+ * flush runs in a sqlite3 subprocess where available rather than stalling the
+ * event loop. The dedicated logs/memory connections are checkpointed in-process
+ * on their own handles — they are small and the daemon already holds them open.
+ * FULL (not TRUNCATE) writes committed frames back to the main file, which is
+ * all the copy needs.
  */
 async function checkpointDbsForExport(): Promise<void> {
-  const targets: Array<{ label: string; dbPath?: string }> = [
-    { label: "main" },
-    { label: "logs", dbPath: getLogsDbPath() },
-  ];
-  for (const { label, dbPath } of targets) {
-    const result = await runAsyncSqlite(
-      "PRAGMA wal_checkpoint(FULL)",
-      dbPath ? { dbPath } : undefined,
+  const mainResult = await runAsyncSqlite("PRAGMA wal_checkpoint(FULL)");
+  if (!mainResult.ok) {
+    log.warn(
+      { error: mainResult.error, backend: mainResult.backend, db: "main" },
+      "WAL checkpoint failed — exporting without checkpoint",
     );
-    if (!result.ok) {
+  }
+
+  for (const [label, sqlite] of [
+    ["logs", getLogsSqlite()],
+    ["memory", getMemorySqlite()],
+  ] as const) {
+    if (!sqlite) {
       log.warn(
-        { error: result.error, backend: result.backend, db: label },
+        { db: label },
+        "Dedicated database unavailable — exporting without checkpoint",
+      );
+      continue;
+    }
+    try {
+      sqlite.exec("PRAGMA wal_checkpoint(FULL)");
+    } catch (err) {
+      log.warn(
+        { err, db: label },
         "WAL checkpoint failed — exporting without checkpoint",
       );
     }

--- a/assistant/src/util/logs-db-path.ts
+++ b/assistant/src/util/logs-db-path.ts
@@ -3,12 +3,12 @@ import { join } from "node:path";
 import { getDataDir } from "./platform.js";
 
 /**
- * Path to the secondary SQLite file that houses heavy append-only tables
+ * Path to the dedicated SQLite file that houses heavy append-only tables
  * (LLM request logs, and other log/event tables over time). It lives in the
- * same `data/db` directory as the main DB and is ATTACHed to the daemon's
- * connection as the `logs` schema (see `memory/db-connection.ts`). Splitting
- * these tables into their own file keeps the main DB — and its WAL — small and
- * lets the two files VACUUM/checkpoint independently.
+ * same `data/db` directory as the main DB and is opened on its own connection
+ * (see `getLogsDb()` in `memory/db-connection.ts`). Splitting these tables into
+ * their own file keeps the main DB — and its WAL — small and lets the two files
+ * VACUUM/checkpoint independently.
  *
  * Kept in its own leaf module rather than alongside `getDbPath()` in
  * `platform.ts`: `platform.ts` is imported very early and widely, and adding an

--- a/assistant/src/util/memory-db-path.ts
+++ b/assistant/src/util/memory-db-path.ts
@@ -3,10 +3,10 @@ import { join } from "node:path";
 import { getDataDir } from "./platform.js";
 
 /**
- * Path to the secondary SQLite file that houses the high-churn memory
+ * Path to the dedicated SQLite file that houses the high-churn memory
  * subsystem tables (starting with the `memory_jobs` work queue). It lives in
- * the same `data/db` directory as the main DB and is ATTACHed to the daemon's
- * connection as the `memory` schema (see `memory/db-connection.ts`). Splitting
+ * the same `data/db` directory as the main DB and is opened on its own
+ * connection (see `getMemoryDb()` in `memory/db-connection.ts`). Splitting
  * these tables into their own file keeps the main DB — and its WAL — small and
  * lets the two files VACUUM/checkpoint independently, so a runaway queue can no
  * longer bloat the main database.


### PR DESCRIPTION
## Summary
Replace the `ATTACH DATABASE` pattern for the two secondary SQLite files (`assistant-logs.db` → `llm_request_logs`, `assistant-memory.db` → `memory_jobs`) with dedicated, lazily-opened connections so each file has an independent lifecycle and never gates main DB init.

## Design
- **Dedicated connections in `db-connection.ts`** (no separate "secondary" module): `getLogsDb()`/`getLogsSqlite()` and `getMemoryDb()`/`getMemorySqlite()` live alongside `getDb()`. They only open the file and set PRAGMAs — **no DDL on open**. `assertTestDbIsIsolated()` is exported and applied to the dedicated opens too; `resetDb()` closes all three connections.
- **One singleton module**: all three connections (main/logs/memory) live under the same keyed namespace in `db-singleton.ts` (stdlib-only). No `secondary-db-singleton.ts`.
- **DDL stays part of DB init, not connection open**: `initializeDb()` creates the dedicated schemas synchronously (`ensureDedicatedSchemas`) on both the fresh-migrate and test template-restore paths, so the tables exist as soon as it returns even though the relocation migrations (297/298) that also create them are async. 297/298 keep their idempotent create + batched drain for direct calls and existing-data migration.
- **Cross-DB queries split** (they can no longer span one connection): orphaned-log recovery (logs candidates + main `messages` existence check, filtered in JS) and memory-job cancellation (resolve id sets on main, then `UPDATE memory_jobs` on the memory connection).
- **Consumers repointed**: `llm-request-log-store` → logs connection; `jobs-store`/`jobs-worker`/`task-memory-cleanup`/`conversation-crud` (clearAll + log deletes/select)/`cleanup`/retrospective-startup-cleanup → memory or logs connection as appropriate. Export checkpoint flushes both dedicated connections.
- **Tests**: the test template captures/restores the memory file alongside main and logs; every test that reads/clears these tables now uses the dedicated handle (raw SQL → `get*Sqlite()`, query builder → `get*Db()`).

## Test plan
`tsc`, eslint, prettier clean. Verified the way CI runs — each affected test file in its own process (CI isolates per file): all green, including every test file referencing `memory_jobs`/`llm_request_logs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)