### PR TITLE
fix(inspector): price full input for Anthropic calls (stop double-subtracting cache)

### DIFF
--- a/assistant/src/__tests__/llm-context-route-provider.test.ts
+++ b/assistant/src/__tests__/llm-context-route-provider.test.ts
@@ -250,6 +250,71 @@ describe("GET /v1/messages/:id/llm-context provider preference", () => {
   });
 });
 
+describe("GET /v1/messages/:id/llm-context estimated cost cache accounting", () => {
+  const anthropicRequestPayload = JSON.stringify({
+    model: "claude-opus-4-6",
+    messages: [{ role: "user", content: "Hello there." }],
+  });
+
+  // Anthropic Messages usage reports `input_tokens` net of cache; cache-read is
+  // a separate, additive bucket. 19,091 fresh + 17,096 cache-read on Opus 4.6
+  // ($5/M input, $0.50/M cache-read, $25/M output).
+  const anthropicResponsePayload = JSON.stringify({
+    model: "claude-opus-4-6",
+    stop_reason: "end_turn",
+    content: [{ type: "text", text: "Hello back." }],
+    usage: {
+      input_tokens: 19091,
+      cache_read_input_tokens: 17096,
+      output_tokens: 440,
+    },
+  });
+
+  // 19091*5/1e6 + 17096*0.5/1e6 + 440*25/1e6
+  const expectedCostUsd = 0.115003;
+
+  test("prices full input at full rate for OpenRouter→Anthropic (cache not double-subtracted)", async () => {
+    seedRequestLog({
+      id: "log-cost-openrouter-anthropic",
+      messageId: "msg-cost-openrouter-anthropic",
+      provider: "openrouter",
+      requestPayload: anthropicRequestPayload,
+      responsePayload: anthropicResponsePayload,
+    });
+
+    const body = (await dispatchLlmContext(
+      "msg-cost-openrouter-anthropic",
+    )) as {
+      logs: Array<{ summary?: { estimatedCostUsd?: number | null } }>;
+    };
+
+    const cost = body.logs[0]?.summary?.estimatedCostUsd;
+    expect(cost).toBeCloseTo(expectedCostUsd, 5);
+    // The pre-fix bug subtracted cache-read from the already-net input, pricing
+    // only 1,995 fresh tokens → ~$0.0295. Guard against regressing to that.
+    expect(cost).toBeGreaterThan(0.11);
+  });
+
+  test("prices full input at full rate for native Anthropic", async () => {
+    seedRequestLog({
+      id: "log-cost-anthropic",
+      messageId: "msg-cost-anthropic",
+      provider: "anthropic",
+      requestPayload: anthropicRequestPayload,
+      responsePayload: anthropicResponsePayload,
+    });
+
+    const body = (await dispatchLlmContext("msg-cost-anthropic")) as {
+      logs: Array<{ summary?: { estimatedCostUsd?: number | null } }>;
+    };
+
+    expect(body.logs[0]?.summary?.estimatedCostUsd).toBeCloseTo(
+      expectedCostUsd,
+      5,
+    );
+  });
+});
+
 describe("GET /v1/llm-request-logs/:id/payload", () => {
   test("returns parsed payloads for a valid log", async () => {
     const reqPayload = JSON.stringify({ model: "gpt-4.1", messages: [] });

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -85,7 +85,10 @@ import { PROVIDER_CATALOG } from "../../providers/model-catalog.js";
 import { initializeProviders } from "../../providers/registry.js";
 import { credentialKey } from "../../security/credential-key.js";
 import { validateAllowlistFile } from "../../security/secret-allowlist.js";
-import { resolvePricingForUsage } from "../../util/pricing.js";
+import {
+  resolvePricingForUsage,
+  usesAnthropicPricingRules,
+} from "../../util/pricing.js";
 import { BadRequestError, InternalError, NotFoundError } from "./errors.js";
 import {
   type LlmContextSummary,
@@ -212,10 +215,17 @@ function attachEstimatedCost(summary: LlmContextSummary): LlmContextSummary {
 
   const cacheCreation = summary.cacheCreationInputTokens ?? 0;
   const cacheRead = summary.cacheReadInputTokens ?? 0;
-  const directInputTokens = Math.max(
-    inputTokens - cacheCreation - cacheRead,
-    0,
-  );
+  // `inputTokens` carries provider-shape-dependent cache accounting. Anthropic
+  // Messages responses (native and OpenRouter `anthropic/*`) report `input_tokens`
+  // already net of cache — cache-creation/read are separate, additive buckets —
+  // so the full-rate portion IS `inputTokens`. OpenAI/Gemini report a total
+  // prompt-token count with cached tokens as a subset, so the full-rate portion
+  // is the total minus cache. `usesAnthropicPricingRules` selects the same
+  // response shapes the pricing layer treats as Anthropic (keyed on the stored
+  // transport provider + model), so it also distinguishes the cache accounting.
+  const directInputTokens = usesAnthropicPricingRules(provider, model)
+    ? Math.max(inputTokens, 0)
+    : Math.max(inputTokens - cacheCreation - cacheRead, 0);
 
   const result = resolvePricingForUsage(provider, model, {
     directInputTokens,


### PR DESCRIPTION
## Summary

- The inspector's per-call **Estimated cost** understated Anthropic and OpenRouter→`anthropic/*` calls. `attachEstimatedCost` subtracted cache-creation/read from `inputTokens`, but for Anthropic-shaped responses `inputTokens` (the raw `input_tokens`) already excludes cache — cache is reported in separate, additive buckets — so fresh input was double-subtracted and priced at ~$0. Example: a call with 19,091 fresh + 17,096 cache-read tokens showed **$0.0295** instead of **~$0.115** (~4× under).
- The fix keys the derivation on `usesAnthropicPricingRules(provider, model)`: Anthropic-shaped responses price the full-rate portion as `inputTokens` as-is; OpenAI/Gemini (a total `prompt_tokens` with cached as a subset) keep the existing `total − cache` subtraction. This predicate is robust to the stored transport provider being `openrouter` (which the prior `provider`-string check would have missed).
- Spend accounting is unaffected: the conversation running-total (`recordUsage`) and `llm_usage_events` (`buildPricingUsageFromResponse`) consume the summed `response.usage.inputTokens` and were already correct. This bug was isolated to the inspector's separate re-derivation from the raw stored payload.
- The non-Anthropic branch is byte-identical to before, so OpenAI/Gemini cost and display are unchanged.
- Adds regression tests for the OpenRouter→Anthropic and native-Anthropic cases.

## Original prompt

The user flagged that the LLM inspector's price calculation looked wrong and asked whether input tokens were being omitted from the cost. Two inspector screenshots — notably one showing `Input tokens: 1` alongside `Cache Created 23,207 / Read 17,096` — established that the displayed "Input tokens" is the fresh/uncached count, additive with the separate cache buckets, and that `attachEstimatedCost` was wrongly subtracting cache from it for Anthropic-family calls. The task: fix the per-call estimated-cost derivation so fresh input is billed at the full input rate while cache stays priced at its own discounted rates.