### PR TITLE
test: await initializeDb() in __tests__ (batch 2/4)

### DIFF
--- a/assistant/src/__tests__/inference-profile-session-ipc.test.ts
+++ b/assistant/src/__tests__/inference-profile-session-ipc.test.ts
@@ -43,7 +43,7 @@ import { initializeDb } from "../memory/db-init.js";
 import { ROUTES } from "../runtime/routes/inference-profile-session-routes.js";
 import { resetDbForTesting } from "./db-test-helpers.js";
 
-initializeDb();
+await initializeDb();
 
 const openRoute = ROUTES.find(
   (r) => r.operationId === "inference_profile_open",

--- a/assistant/src/__tests__/injector-chain.test.ts
+++ b/assistant/src/__tests__/injector-chain.test.ts
@@ -84,7 +84,7 @@ import { getWorkspacePromptPath } from "../util/platform.js";
 // `applyRuntimeInjections` self-resolves the Slack active-thread focus block
 // from the persisted message rows, so the schema must exist for Slack-channel
 // turns; with no seeded rows the focus loader resolves to null.
-initializeDb();
+await initializeDb();
 
 // `makeTurnContext` and the workspace registry seed share this id so the
 // `workspace-context` injector resolves the seeded block for the turn.

--- a/assistant/src/__tests__/injector-disk-pressure.test.ts
+++ b/assistant/src/__tests__/injector-disk-pressure.test.ts
@@ -42,7 +42,7 @@ import type { Message } from "../providers/types.js";
 // `applyRuntimeInjections` self-resolves the Slack active-thread focus block
 // from the persisted message rows, so the schema must exist for Slack-channel
 // turns; with no seeded rows the focus loader resolves to null.
-initializeDb();
+await initializeDb();
 
 // `makeContext` and the workspace registry seed share this id so the
 // `workspace-context` injector resolves the seeded block for the turn.

--- a/assistant/src/__tests__/internal-telemetry-routes.test.ts
+++ b/assistant/src/__tests__/internal-telemetry-routes.test.ts
@@ -27,7 +27,7 @@ import { RouteError } from "../runtime/routes/errors.js";
 import { ROUTES } from "../runtime/routes/internal-telemetry-routes.js";
 import type { RouteHandlerArgs } from "../runtime/routes/types.js";
 
-initializeDb();
+await initializeDb();
 
 const route = ROUTES.find(
   (r) => r.operationId === "internal_telemetry_auth_fallback",

--- a/assistant/src/__tests__/invite-redemption-service.test.ts
+++ b/assistant/src/__tests__/invite-redemption-service.test.ts
@@ -26,7 +26,7 @@ import {
 } from "../runtime/invite-redemption-service.js";
 import { hashVoiceCode } from "../util/voice-code.js";
 
-initializeDb();
+await initializeDb();
 
 function resetTables() {
   getSqlite().run("DELETE FROM assistant_ingress_invites");

--- a/assistant/src/__tests__/invite-routes-http.test.ts
+++ b/assistant/src/__tests__/invite-routes-http.test.ts
@@ -116,7 +116,7 @@ async function handleTriggerInviteCall(inviteId: string) {
   }
 }
 
-initializeDb();
+await initializeDb();
 
 /** Create a throwaway contact and return its ID, for use as the invite's contactId. */
 function createTargetContact(displayName = "Test Contact"): string {

--- a/assistant/src/__tests__/jobs-store-qdrant-breaker.test.ts
+++ b/assistant/src/__tests__/jobs-store-qdrant-breaker.test.ts
@@ -29,8 +29,8 @@ import {
 import { memoryJobs } from "../memory/schema.js";
 
 describe("claimMemoryJobs with Qdrant circuit breaker", () => {
-  beforeAll(() => {
-    initializeDb();
+  beforeAll(async () => {
+    await initializeDb();
   });
 
   beforeEach(() => {

--- a/assistant/src/__tests__/jobs-store-upsert-debounced.test.ts
+++ b/assistant/src/__tests__/jobs-store-upsert-debounced.test.ts
@@ -21,8 +21,8 @@ import { enqueueMemoryJob, upsertDebouncedJob } from "../memory/jobs-store.js";
 import { memoryJobs } from "../memory/schema.js";
 
 describe("upsertDebouncedJob payload refresh", () => {
-  beforeAll(() => {
-    initializeDb();
+  beforeAll(async () => {
+    await initializeDb();
   });
 
   beforeEach(() => {

--- a/assistant/src/__tests__/list-messages-attachments.test.ts
+++ b/assistant/src/__tests__/list-messages-attachments.test.ts
@@ -35,7 +35,7 @@ import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { handleListMessages } from "../runtime/routes/conversation-routes.js";
 
-initializeDb();
+await initializeDb();
 
 function resetTables() {
   const db = getDb();

--- a/assistant/src/__tests__/list-messages-client-message-id.test.ts
+++ b/assistant/src/__tests__/list-messages-client-message-id.test.ts
@@ -30,7 +30,7 @@ import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { handleListMessages } from "../runtime/routes/conversation-routes.js";
 
-initializeDb();
+await initializeDb();
 
 function resetTables() {
   const db = getDb();

--- a/assistant/src/__tests__/list-messages-hidden-metadata.test.ts
+++ b/assistant/src/__tests__/list-messages-hidden-metadata.test.ts
@@ -40,7 +40,7 @@ import {
 import { messages } from "../memory/schema.js";
 import { handleListMessages } from "../runtime/routes/conversation-routes.js";
 
-initializeDb();
+await initializeDb();
 
 function resetTables() {
   const db = getDb();

--- a/assistant/src/__tests__/list-messages-page-latest.test.ts
+++ b/assistant/src/__tests__/list-messages-page-latest.test.ts
@@ -49,7 +49,7 @@ import {
 import { handleListMessages } from "../runtime/routes/conversation-routes.js";
 import { BadRequestError } from "../runtime/routes/errors.js";
 
-initializeDb();
+await initializeDb();
 
 function resetTables() {
   const db = getDb();

--- a/assistant/src/__tests__/list-messages-tool-merge.test.ts
+++ b/assistant/src/__tests__/list-messages-tool-merge.test.ts
@@ -30,7 +30,7 @@ import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { handleListMessages } from "../runtime/routes/conversation-routes.js";
 
-initializeDb();
+await initializeDb();
 
 function resetTables() {
   const db = getDb();

--- a/assistant/src/__tests__/llm-context-route-provider.test.ts
+++ b/assistant/src/__tests__/llm-context-route-provider.test.ts
@@ -13,7 +13,7 @@ import { llmRequestLogs } from "../memory/schema.js";
 import { ROUTES } from "../runtime/routes/conversation-query-routes.js";
 import { NotFoundError } from "../runtime/routes/errors.js";
 
-initializeDb();
+await initializeDb();
 
 const llmContextRoute = ROUTES.find(
   (r) => r.method === "GET" && r.endpoint === "messages/:id/llm-context",

--- a/assistant/src/__tests__/llm-request-log-agent-loop-exit-reason.test.ts
+++ b/assistant/src/__tests__/llm-request-log-agent-loop-exit-reason.test.ts
@@ -34,7 +34,7 @@ import {
 } from "../memory/llm-request-log-store.js";
 import { llmRequestLogs } from "../memory/schema.js";
 
-initializeDb();
+await initializeDb();
 
 // llm_request_logs lives in the dedicated logs connection.
 function resetLogs(): void {

--- a/assistant/src/__tests__/llm-request-log-call-site.test.ts
+++ b/assistant/src/__tests__/llm-request-log-call-site.test.ts
@@ -33,7 +33,7 @@ import {
 import { migrateLlmRequestLogCallSite } from "../memory/migrations/264-llm-request-log-call-site.js";
 import { llmRequestLogs } from "../memory/schema.js";
 
-initializeDb();
+await initializeDb();
 
 // llm_request_logs lives in the dedicated logs connection.
 function resetLogs(): void {

--- a/assistant/src/__tests__/llm-request-log-turn-query.test.ts
+++ b/assistant/src/__tests__/llm-request-log-turn-query.test.ts
@@ -35,7 +35,7 @@ import {
 } from "../memory/llm-request-log-store.js";
 import { llmRequestLogs, toolInvocations } from "../memory/schema.js";
 
-initializeDb();
+await initializeDb();
 
 // llm_request_logs lives in the dedicated logs connection.
 function logsDb() {

--- a/assistant/src/__tests__/llm-usage-store.test.ts
+++ b/assistant/src/__tests__/llm-usage-store.test.ts
@@ -21,7 +21,7 @@ import {
 import type { PricingResult, UsageEventInput } from "../usage/types.js";
 
 // Initialize db once before all tests
-initializeDb();
+await initializeDb();
 
 function makeInput(overrides?: Partial<UsageEventInput>): UsageEventInput {
   return {

--- a/assistant/src/__tests__/log-export-routes.test.ts
+++ b/assistant/src/__tests__/log-export-routes.test.ts
@@ -29,7 +29,7 @@ import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { ROUTES } from "../runtime/routes/log-export-routes.js";
 import { getLogsDir } from "../util/platform.js";
 
-initializeDb();
+await initializeDb();
 
 const exportRoute = ROUTES.find((r) => r.endpoint === "export")!;
 

--- a/assistant/src/__tests__/log-export-workspace.test.ts
+++ b/assistant/src/__tests__/log-export-workspace.test.ts
@@ -60,7 +60,7 @@ import {
   SYNTHETIC_OPENAI_PROJECT_KEY,
 } from "./secret-fixtures.js";
 
-initializeDb();
+await initializeDb();
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/assistant/src/__tests__/memory-jobs-worker-lanes.test.ts
+++ b/assistant/src/__tests__/memory-jobs-worker-lanes.test.ts
@@ -118,8 +118,8 @@ import { _resetQdrantBreaker } from "../memory/qdrant-circuit-breaker.js";
 import { memoryJobs } from "../memory/schema.js";
 
 describe("memory jobs worker lane scheduling", () => {
-  beforeAll(() => {
-    initializeDb();
+  beforeAll(async () => {
+    await initializeDb();
   });
 
   beforeEach(() => {

--- a/assistant/src/__tests__/memory-recall-log-store.test.ts
+++ b/assistant/src/__tests__/memory-recall-log-store.test.ts
@@ -28,7 +28,7 @@ import {
 } from "../memory/memory-recall-log-store.js";
 import { memoryRecallLogs } from "../memory/schema.js";
 
-initializeDb();
+await initializeDb();
 
 function resetTables(): void {
   const db = getDb();

--- a/assistant/src/__tests__/memory-upsert-concurrency.test.ts
+++ b/assistant/src/__tests__/memory-upsert-concurrency.test.ts
@@ -66,7 +66,7 @@ import { indexMessageNow } from "../memory/indexer.js";
 import { conversations, memorySegments, messages } from "../memory/schema.js";
 
 // Initialize DB once for the entire file. Each test cleans its own tables.
-initializeDb();
+await initializeDb();
 
 function resetTables() {
   const db = getDb();

--- a/assistant/src/__tests__/messages-after-tiebreaker.test.ts
+++ b/assistant/src/__tests__/messages-after-tiebreaker.test.ts
@@ -14,7 +14,7 @@ import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { conversations, messages } from "../memory/schema.js";
 
-initializeDb();
+await initializeDb();
 
 const CONV_ID = "conv-tiebreaker";
 

--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -71,7 +71,7 @@ import { notifyGuardianOfAccessRequest } from "../runtime/access-request-helper.
 import { handleChannelInbound } from "./helpers/channel-test-adapter.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
 
-initializeDb();
+await initializeDb();
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/assistant/src/__tests__/notification-guardian-path.test.ts
+++ b/assistant/src/__tests__/notification-guardian-path.test.ts
@@ -78,7 +78,7 @@ import { initializeDb } from "../memory/db-init.js";
 import { conversations } from "../memory/schema.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
 
-initializeDb();
+await initializeDb();
 
 function ensureConversation(id: string): void {
   const db = getDb();

--- a/assistant/src/__tests__/notification-schedule-notify-dedup.test.ts
+++ b/assistant/src/__tests__/notification-schedule-notify-dedup.test.ts
@@ -27,7 +27,7 @@ import { createEvent } from "../notifications/events-store.js";
 import type { NotificationSignal } from "../notifications/signal.js";
 import type { NotificationDecision } from "../notifications/types.js";
 
-initializeDb();
+await initializeDb();
 
 beforeEach(() => {
   getDb().delete(notificationEvents).run();

--- a/assistant/src/__tests__/oauth-provider-profiles.test.ts
+++ b/assistant/src/__tests__/oauth-provider-profiles.test.ts
@@ -17,7 +17,7 @@ import { initializeDb } from "../memory/db-init.js";
 import { getProvider } from "../oauth/oauth-store.js";
 import { seedOAuthProviders } from "../oauth/seed-providers.js";
 
-initializeDb();
+await initializeDb();
 seedOAuthProviders();
 
 describe("oauth provider profiles (DB-seeded)", () => {

--- a/assistant/src/__tests__/oauth-provider-visibility.test.ts
+++ b/assistant/src/__tests__/oauth-provider-visibility.test.ts
@@ -29,7 +29,7 @@ import { isProviderVisible } from "../oauth/provider-visibility.js";
 import { resetDbForTesting } from "./db-test-helpers.js";
 import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
 
-initializeDb();
+await initializeDb();
 
 /** Create a minimal AssistantConfig for testing. */
 function makeConfig(): AssistantConfig {

--- a/assistant/src/__tests__/oauth-store.test.ts
+++ b/assistant/src/__tests__/oauth-store.test.ts
@@ -72,7 +72,7 @@ import { seedOAuthProviders } from "../oauth/seed-providers.js";
 import { resetDbForTesting } from "./db-test-helpers.js";
 import { getMockFetchCalls, mockFetch, resetMockFetch } from "./mock-fetch.js";
 
-initializeDb();
+await initializeDb();
 
 /** Seed a minimal provider row for FK satisfaction. */
 function seedTestProvider(provider = "github"): void {

--- a/assistant/src/__tests__/persist-unsendable-image-downscale.test.ts
+++ b/assistant/src/__tests__/persist-unsendable-image-downscale.test.ts
@@ -40,7 +40,7 @@ import { initializeDb } from "../memory/db-init.js";
 import { persistUnsendableImageDowngrades } from "../plugins/defaults/image-recovery/recover.js";
 import type { ContentBlock } from "../providers/types.js";
 
-initializeDb();
+await initializeDb();
 
 function resetTables(): void {
   const db = getDb();

--- a/assistant/src/__tests__/persist-unsendable-image.test.ts
+++ b/assistant/src/__tests__/persist-unsendable-image.test.ts
@@ -27,7 +27,7 @@ import {
 } from "../plugins/defaults/image-recovery/recover.js";
 import type { ContentBlock } from "../providers/types.js";
 
-initializeDb();
+await initializeDb();
 
 function resetTables(): void {
   const db = getDb();

--- a/assistant/src/__tests__/platform-bash-auto-approve.test.ts
+++ b/assistant/src/__tests__/platform-bash-auto-approve.test.ts
@@ -128,7 +128,7 @@ import { PermissionPrompter } from "../permissions/prompter.js";
 import { ToolExecutor } from "../tools/executor.js";
 import type { ToolContext as TC } from "../tools/types.js";
 
-initializeDb();
+await initializeDb();
 
 function makeContext(overrides?: Partial<TC>): TC {
   return {

--- a/assistant/src/__tests__/playbook-execution.test.ts
+++ b/assistant/src/__tests__/playbook-execution.test.ts
@@ -33,7 +33,7 @@ import { compilePlaybooks } from "../playbooks/playbook-compiler.js";
 import { parsePlaybookStatement } from "../playbooks/types.js";
 import type { ToolContext } from "../tools/types.js";
 
-initializeDb();
+await initializeDb();
 
 function getRawDb(): Database {
   return (getDb() as unknown as { $client: Database }).$client;

--- a/assistant/src/__tests__/playbook-tools.test.ts
+++ b/assistant/src/__tests__/playbook-tools.test.ts
@@ -29,7 +29,7 @@ import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import type { ToolContext } from "../tools/types.js";
 
-initializeDb();
+await initializeDb();
 
 function getRawDb(): Database {
   return (getDb() as unknown as { $client: Database }).$client;

--- a/assistant/src/__tests__/provider-usage-tracking.test.ts
+++ b/assistant/src/__tests__/provider-usage-tracking.test.ts
@@ -22,7 +22,7 @@ import { CallSiteConfiguredProvider } from "../providers/provider-send-message.j
 import type { Provider, ProviderResponse } from "../providers/types.js";
 import { UsageTrackingProvider } from "../providers/usage-tracking.js";
 
-initializeDb();
+await initializeDb();
 
 function setLlmConfig(raw: unknown): void {
   mockLlmConfig = LLMSchema.parse(raw) as Record<string, unknown>;

--- a/assistant/src/__tests__/prune-old-conversations-job.test.ts
+++ b/assistant/src/__tests__/prune-old-conversations-job.test.ts
@@ -19,7 +19,7 @@ import {
   toolInvocations,
 } from "../memory/schema.js";
 
-initializeDb();
+await initializeDb();
 
 const STALE_ID = "conv-prune-job-stale";
 const FRESH_ID = "conv-prune-job-fresh";

--- a/assistant/src/__tests__/reaction-persistence.test.ts
+++ b/assistant/src/__tests__/reaction-persistence.test.ts
@@ -63,7 +63,7 @@ import {
 import { handleChannelInbound } from "./helpers/channel-test-adapter.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
 
-initializeDb();
+await initializeDb();
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/assistant/src/__tests__/relay-server.test.ts
+++ b/assistant/src/__tests__/relay-server.test.ts
@@ -161,7 +161,9 @@ mock.module("../runtime/routes/inbound-stages/admission-policy.js", () => ({
       return {
         admitted: false,
         reason:
-          input.memberStatus === "blocked" ? "member_blocked" : "member_revoked",
+          input.memberStatus === "blocked"
+            ? "member_blocked"
+            : "member_revoked",
         shouldChallenge: false,
         effectivePolicy: input.policy,
       };
@@ -317,7 +319,7 @@ import { generateVoiceCode, hashVoiceCode } from "../util/voice-code.js";
 import { resetDbForTesting } from "./db-test-helpers.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
 
-initializeDb();
+await initializeDb();
 
 // Activate the channel-admission-reader stub only while this file's tests run,
 // so the registered (process-global) mock delegates to the real module for

--- a/assistant/src/__tests__/runtime-attachment-metadata.test.ts
+++ b/assistant/src/__tests__/runtime-attachment-metadata.test.ts
@@ -59,7 +59,7 @@ import { RuntimeHttpServer } from "../runtime/http-server.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import { resetDbForTesting } from "./db-test-helpers.js";
 
-initializeDb();
+await initializeDb();
 
 afterAll(() => {
   resetDbForTesting();

--- a/assistant/src/__tests__/runtime-events-sse-bilingual.test.ts
+++ b/assistant/src/__tests__/runtime-events-sse-bilingual.test.ts
@@ -38,13 +38,10 @@ import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { buildAssistantEvent } from "../runtime/assistant-event.js";
 import { AssistantEventHub } from "../runtime/assistant-event-hub.js";
-import {
-  BadRequestError,
-  NotFoundError,
-} from "../runtime/routes/errors.js";
+import { BadRequestError, NotFoundError } from "../runtime/routes/errors.js";
 import { handleSubscribeAssistantEvents } from "../runtime/routes/events-routes.js";
 
-initializeDb();
+await initializeDb();
 
 describe("GET /v1/events — bilingual scope query params", () => {
   beforeEach(() => {
@@ -75,7 +72,9 @@ describe("GET /v1/events — bilingual scope query params", () => {
     expect(new TextDecoder().decode(heartbeat.value)).toBe(": heartbeat\n\n");
 
     // Publish an event scoped to that conversation — should be delivered.
-    await testHub.publish(buildAssistantEvent({ type: "pong" }, conversationId));
+    await testHub.publish(
+      buildAssistantEvent({ type: "pong" }, conversationId),
+    );
 
     const { value, done } = await reader.read();
     ac.abort();
@@ -99,9 +98,8 @@ describe("GET /v1/events — bilingual scope query params", () => {
     // Materialise two distinct conversations: one we'll subscribe to by id,
     // one we'll publish to via the ignored key.
     const { conversationId: idConv } = getOrCreateConversation("sse-id-wins");
-    const { conversationId: keyConv } = getOrCreateConversation(
-      "sse-key-ignored",
-    );
+    const { conversationId: keyConv } =
+      getOrCreateConversation("sse-key-ignored");
     expect(idConv).not.toBe(keyConv);
 
     const ac = new AbortController();

--- a/assistant/src/__tests__/runtime-events-sse-parity.test.ts
+++ b/assistant/src/__tests__/runtime-events-sse-parity.test.ts
@@ -44,7 +44,7 @@ import type { AssistantEvent } from "../runtime/assistant-event.js";
 import { buildAssistantEvent } from "../runtime/assistant-event.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 
-initializeDb();
+await initializeDb();
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/assistant/src/__tests__/runtime-events-sse-reconnect.test.ts
+++ b/assistant/src/__tests__/runtime-events-sse-reconnect.test.ts
@@ -39,7 +39,7 @@ import {
   stampAndBuffer,
 } from "../runtime/assistant-stream-state.js";
 
-initializeDb();
+await initializeDb();
 
 const decoder = new TextDecoder();
 

--- a/assistant/src/__tests__/runtime-events-sse.test.ts
+++ b/assistant/src/__tests__/runtime-events-sse.test.ts
@@ -36,7 +36,7 @@ import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import { mintToken } from "../runtime/auth/token-service.js";
 import { RuntimeHttpServer } from "../runtime/http-server.js";
 
-initializeDb();
+await initializeDb();
 
 const TEST_JWT = mintToken({
   aud: "vellum-daemon",

--- a/assistant/src/__tests__/schedule-retry.test.ts
+++ b/assistant/src/__tests__/schedule-retry.test.ts
@@ -82,7 +82,7 @@ function startScheduler(
   return startSchedulerReal(processMessage, notifyScheduleOneShot, options);
 }
 
-initializeDb();
+await initializeDb();
 
 /** Access the underlying bun:sqlite Database for raw parameterized queries. */
 function getRawDb(): import("bun:sqlite").Database {

--- a/assistant/src/__tests__/schedule-routes-workflow-validation.test.ts
+++ b/assistant/src/__tests__/schedule-routes-workflow-validation.test.ts
@@ -51,7 +51,7 @@ import {
   listSchedules,
 } from "../schedule/schedule-store.js";
 
-initializeDb();
+await initializeDb();
 
 function clearTables(): void {
   const db = getDb();

--- a/assistant/src/__tests__/schedule-routes.test.ts
+++ b/assistant/src/__tests__/schedule-routes.test.ts
@@ -98,7 +98,7 @@ import {
 import { scheduleTask } from "../tasks/task-scheduler.js";
 import { createTask } from "../tasks/task-store.js";
 
-initializeDb();
+await initializeDb();
 
 function clearTables(): void {
   const db = getDb();

--- a/assistant/src/__tests__/schedule-store.test.ts
+++ b/assistant/src/__tests__/schedule-store.test.ts
@@ -40,7 +40,7 @@ import {
   updateSchedule,
 } from "../schedule/schedule-store.js";
 
-initializeDb();
+await initializeDb();
 
 /** Access the underlying bun:sqlite Database for raw parameterized queries. */
 function getRawDb(): import("bun:sqlite").Database {

--- a/assistant/src/__tests__/schedule-tools.test.ts
+++ b/assistant/src/__tests__/schedule-tools.test.ts
@@ -31,7 +31,7 @@ import { executeScheduleUpdate } from "../tools/schedule/update.js";
 import type { Tool, ToolContext } from "../tools/types.js";
 import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
 
-initializeDb();
+await initializeDb();
 
 function getRawDb(): Database {
   return (getDb() as unknown as { $client: Database }).$client;

--- a/assistant/src/__tests__/scheduler-disk-pressure.test.ts
+++ b/assistant/src/__tests__/scheduler-disk-pressure.test.ts
@@ -94,7 +94,7 @@ import { initializeDb } from "../memory/db-init.js";
 import { createSchedule } from "../schedule/schedule-store.js";
 import { runScheduleOnce } from "../schedule/scheduler.js";
 
-initializeDb();
+await initializeDb();
 
 function rawDb(): import("bun:sqlite").Database {
   return (getDb() as unknown as { $client: import("bun:sqlite").Database })

--- a/assistant/src/__tests__/scheduler-recurrence.test.ts
+++ b/assistant/src/__tests__/scheduler-recurrence.test.ts
@@ -60,7 +60,7 @@ import {
 import { startScheduler } from "../schedule/scheduler.js";
 import { createTask } from "../tasks/task-store.js";
 
-initializeDb();
+await initializeDb();
 
 /** Access the underlying bun:sqlite Database for raw parameterized queries. */
 function getRawDb(): import("bun:sqlite").Database {

--- a/assistant/src/__tests__/scheduler-reuse-conversation.test.ts
+++ b/assistant/src/__tests__/scheduler-reuse-conversation.test.ts
@@ -92,7 +92,7 @@ import { initializeDb } from "../memory/db-init.js";
 import { createSchedule, getScheduleRuns } from "../schedule/schedule-store.js";
 import { startScheduler } from "../schedule/scheduler.js";
 
-initializeDb();
+await initializeDb();
 
 /** Access the underlying bun:sqlite Database for raw parameterized queries. */
 function getRawDb(): import("bun:sqlite").Database {

--- a/assistant/src/__tests__/scheduler-wake.test.ts
+++ b/assistant/src/__tests__/scheduler-wake.test.ts
@@ -32,7 +32,7 @@ import { initializeDb } from "../memory/db-init.js";
 import { createSchedule } from "../schedule/schedule-store.js";
 import { startScheduler } from "../schedule/scheduler.js";
 
-initializeDb();
+await initializeDb();
 
 /** Access the underlying bun:sqlite Database for raw parameterized queries. */
 function getRawDb(): import("bun:sqlite").Database {

--- a/assistant/src/__tests__/scoped-approval-grants.test.ts
+++ b/assistant/src/__tests__/scoped-approval-grants.test.ts
@@ -28,7 +28,7 @@ import {
   computeToolApprovalDigest,
 } from "../security/tool-approval-digest.js";
 
-initializeDb();
+await initializeDb();
 
 function clearTables(): void {
   const db = getDb();

--- a/assistant/src/__tests__/scoped-grant-security-matrix.test.ts
+++ b/assistant/src/__tests__/scoped-grant-security-matrix.test.ts
@@ -45,7 +45,7 @@ const { consumeScopedApprovalGrantByToolSignature, createScopedApprovalGrant } =
   _internal;
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
 
-initializeDb();
+await initializeDb();
 
 function clearTables(): void {
   const db = getDb();
@@ -229,7 +229,7 @@ describe("security matrix: concurrent consume (CAS)", () => {
 describe("security matrix: persistence and fail-closed behavior", () => {
   beforeEach(() => clearTables());
 
-  test("grants survive DB re-initialization (simulating daemon restart)", () => {
+  test("grants survive DB re-initialization (simulating daemon restart)", async () => {
     const digest = computeToolApprovalDigest("bash", { cmd: "ls" });
 
     // Create a grant
@@ -242,7 +242,7 @@ describe("security matrix: persistence and fail-closed behavior", () => {
     expect(grant.status).toBe("active");
 
     // Re-initialize the DB (simulates daemon restart — the SQLite file persists)
-    initializeDb();
+    await initializeDb();
 
     // The grant should still be consumable after restart
     const result = consumeScopedApprovalGrantByToolSignature({
@@ -254,7 +254,7 @@ describe("security matrix: persistence and fail-closed behavior", () => {
     expect(result.grant!.id).toBe(grant.id);
   });
 
-  test("consumed grants remain consumed after DB re-initialization", () => {
+  test("consumed grants remain consumed after DB re-initialization", async () => {
     const digest = computeToolApprovalDigest("bash", { cmd: "ls" });
 
     createScopedApprovalGrant(
@@ -273,7 +273,7 @@ describe("security matrix: persistence and fail-closed behavior", () => {
     expect(first.ok).toBe(true);
 
     // Re-initialize the DB (simulates daemon restart)
-    initializeDb();
+    await initializeDb();
 
     // The consumed grant must NOT be consumable again after restart
     const second = consumeScopedApprovalGrantByToolSignature({

--- a/assistant/src/__tests__/send-endpoint-busy.test.ts
+++ b/assistant/src/__tests__/send-endpoint-busy.test.ts
@@ -127,7 +127,7 @@ import { RuntimeHttpServer } from "../runtime/http-server.js";
 import type { ApprovalConversationGenerator } from "../runtime/http-types.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 
-initializeDb();
+await initializeDb();
 
 // ---------------------------------------------------------------------------
 // Conversation helpers

--- a/assistant/src/__tests__/sequence-store.test.ts
+++ b/assistant/src/__tests__/sequence-store.test.ts
@@ -29,7 +29,7 @@ import {
 } from "../sequence/store.js";
 import type { SequenceStep } from "../sequence/types.js";
 
-initializeDb();
+await initializeDb();
 
 function clearTables() {
   const db = getDb();

--- a/assistant/src/__tests__/server-history-render.test.ts
+++ b/assistant/src/__tests__/server-history-render.test.ts
@@ -17,7 +17,7 @@ import {
 import { addMessage, createConversation } from "../memory/conversation-crud.js";
 import { getDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
-initializeDb();
+await initializeDb();
 
 describe("renderHistoryContent", () => {
   test("renders text-only content unchanged", () => {

--- a/assistant/src/__tests__/settings-routes.test.ts
+++ b/assistant/src/__tests__/settings-routes.test.ts
@@ -24,7 +24,7 @@ import { ROUTES } from "../runtime/routes/settings-routes.js";
 import type { RouteHandlerArgs } from "../runtime/routes/types.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
 
-initializeDb();
+await initializeDb();
 
 const testWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR!;
 
@@ -146,23 +146,24 @@ describe("GET /workspace-files/read", () => {
       "utf-8",
     );
 
-    const result = (await handler(
-      makeArgs({ path: "users/alice.md" }),
-    )) as { path: string; content: string };
+    const result = (await handler(makeArgs({ path: "users/alice.md" }))) as {
+      path: string;
+      content: string;
+    };
     expect(result.path).toBe("users/alice.md");
     expect(result.content).toBe(readFileSync(personaPath, "utf-8"));
     expect(result.content).toContain("Preferred name/reference: Alice");
   });
 
   test("rejects path traversal attempts via users/", async () => {
-    expect(() =>
-      handler(makeArgs({ path: "users/../../etc/passwd" })),
-    ).toThrow(BadRequestError);
+    expect(() => handler(makeArgs({ path: "users/../../etc/passwd" }))).toThrow(
+      BadRequestError,
+    );
   });
 
   test("returns 404 for a non-existent users/<slug>.md", async () => {
-    expect(() =>
-      handler(makeArgs({ path: "users/nobody.md" })),
-    ).toThrow(NotFoundError);
+    expect(() => handler(makeArgs({ path: "users/nobody.md" }))).toThrow(
+      NotFoundError,
+    );
   });
 });

--- a/assistant/src/__tests__/slack-inbound-verification.test.ts
+++ b/assistant/src/__tests__/slack-inbound-verification.test.ts
@@ -61,7 +61,7 @@ import { findActiveSession } from "../runtime/channel-verification-service.js";
 import { handleChannelInbound } from "./helpers/channel-test-adapter.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
 
-initializeDb();
+await initializeDb();
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -256,5 +256,4 @@ describe("Slack inbound trusted contact verification", () => {
 
     // No Slack DM was sent
   });
-
 });

--- a/assistant/src/__tests__/slack-reaction-canonical-approval.test.ts
+++ b/assistant/src/__tests__/slack-reaction-canonical-approval.test.ts
@@ -37,7 +37,7 @@ import { initializeDb } from "../memory/db-init.js";
 import { routeGuardianReply } from "../runtime/guardian-reply-router.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 
-initializeDb();
+await initializeDb();
 
 // ---------------------------------------------------------------------------
 // Constants & helpers

--- a/assistant/src/__tests__/task-compiler.test.ts
+++ b/assistant/src/__tests__/task-compiler.test.ts
@@ -30,7 +30,7 @@ import {
 import { renderTemplate } from "../tasks/task-runner.js";
 import { getTask } from "../tasks/task-store.js";
 
-initializeDb();
+await initializeDb();
 
 // ── Helpers ──────────────────────────────────────────────────────────
 

--- a/assistant/src/__tests__/task-management-tools.test.ts
+++ b/assistant/src/__tests__/task-management-tools.test.ts
@@ -57,7 +57,7 @@ import {
   updateWorkItem,
 } from "../work-items/work-item-store.js";
 
-initializeDb();
+await initializeDb();
 
 const ctx: ToolContext = {
   workingDir: "/tmp",

--- a/assistant/src/__tests__/task-memory-cleanup.test.ts
+++ b/assistant/src/__tests__/task-memory-cleanup.test.ts
@@ -66,8 +66,8 @@ describe("invalidateAssistantInferredItemsForConversation", () => {
   const convId = "conv-task-cleanup";
   const otherConvId = "conv-other";
 
-  beforeAll(() => {
-    initializeDb();
+  beforeAll(async () => {
+    await initializeDb();
   });
 
   beforeEach(() => {

--- a/assistant/src/__tests__/task-scheduler.test.ts
+++ b/assistant/src/__tests__/task-scheduler.test.ts
@@ -102,7 +102,7 @@ import {
 import { scheduleTask } from "../tasks/task-scheduler.js";
 import { createTask } from "../tasks/task-store.js";
 
-initializeDb();
+await initializeDb();
 
 /** Access the underlying bun:sqlite Database for raw parameterized queries. */
 function getRawDb(): import("bun:sqlite").Database {

--- a/assistant/src/__tests__/thread-backfill.test.ts
+++ b/assistant/src/__tests__/thread-backfill.test.ts
@@ -124,7 +124,7 @@ import {
   setAdapterProcessMessage,
 } from "./helpers/channel-test-adapter.js";
 
-initializeDb();
+await initializeDb();
 
 // Spy on backfillThreadWindowPage so the stub is scoped to this test file
 // only. Existing tests drive the message array through `backfillThreadMock`;

--- a/assistant/src/__tests__/tool-approval-handler.test.ts
+++ b/assistant/src/__tests__/tool-approval-handler.test.ts
@@ -47,7 +47,7 @@ import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
 import { ToolApprovalHandler } from "../tools/tool-approval-handler.js";
 import type { ToolContext, ToolLifecycleEvent } from "../tools/types.js";
 
-initializeDb();
+await initializeDb();
 
 function clearTables(): void {
   const db = getDb();

--- a/assistant/src/__tests__/tool-grant-request-escalation.test.ts
+++ b/assistant/src/__tests__/tool-grant-request-escalation.test.ts
@@ -112,7 +112,7 @@ import type { ToolContext, ToolLifecycleEvent } from "../tools/types.js";
 /** Short wait config for tests — avoids blocking test suite on the 60s default. */
 const TEST_INLINE_WAIT_CONFIG = { maxWaitMs: 100, intervalMs: 20 };
 
-initializeDb();
+await initializeDb();
 
 function resetTables(): void {
   const db = getDb();
@@ -226,7 +226,6 @@ describe("ToolApprovalHandler / grant-miss escalation", () => {
     });
     expect(requests.length).toBe(0);
   });
-
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
+++ b/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
@@ -177,7 +177,7 @@ import {
 } from "../tools/tool-approval-handler.js";
 import type { ToolContext, ToolLifecycleEvent } from "../tools/types.js";
 
-initializeDb();
+await initializeDb();
 
 function resetTables(): void {
   const db = getDb();

--- a/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
+++ b/assistant/src/__tests__/trusted-contact-lifecycle-notifications.test.ts
@@ -72,7 +72,7 @@ import { createApprovalRequest } from "../memory/guardian-approvals.js";
 import { handleChannelInbound } from "./helpers/channel-test-adapter.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
 
-initializeDb();
+await initializeDb();
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -493,5 +493,4 @@ describe("trusted contact activated notification signal", () => {
     expect(resolver).toBeDefined();
     expect(resolver!.kind).toBe("access_request");
   });
-
 });

--- a/assistant/src/__tests__/trusted-contact-multichannel.test.ts
+++ b/assistant/src/__tests__/trusted-contact-multichannel.test.ts
@@ -83,7 +83,7 @@ import {
 import { handleChannelInbound } from "./helpers/channel-test-adapter.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
 
-initializeDb();
+await initializeDb();
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/assistant/src/__tests__/trusted-contact-verification.test.ts
+++ b/assistant/src/__tests__/trusted-contact-verification.test.ts
@@ -39,7 +39,7 @@ import {
 } from "../runtime/channel-verification-service.js";
 import { createGuardianBinding } from "./helpers/create-guardian-binding.js";
 
-initializeDb();
+await initializeDb();
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/assistant/src/__tests__/turn-boundary-resolution.test.ts
+++ b/assistant/src/__tests__/turn-boundary-resolution.test.ts
@@ -27,7 +27,7 @@ import { getDb, getLogsDb } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
 import { llmRequestLogs, toolInvocations } from "../memory/schema.js";
 
-initializeDb();
+await initializeDb();
 
 function resetTables(): void {
   const db = getDb();

--- a/assistant/src/__tests__/turn-events-store.test.ts
+++ b/assistant/src/__tests__/turn-events-store.test.ts
@@ -20,7 +20,7 @@ import { initializeDb } from "../memory/db-init.js";
 import { messages } from "../memory/schema.js";
 import { queryUnreportedTurnEvents } from "../memory/turn-events-store.js";
 
-initializeDb();
+await initializeDb();
 
 function purge(): void {
   const db = getDb();

--- a/assistant/src/__tests__/twilio-routes.test.ts
+++ b/assistant/src/__tests__/twilio-routes.test.ts
@@ -362,7 +362,7 @@ import {
 import { credentialKey } from "../security/credential-key.js";
 import { resetDbForTesting } from "./db-test-helpers.js";
 
-initializeDb();
+await initializeDb();
 
 // ── Helpers ────────────────────────────────────────────────────────────
 

--- a/assistant/src/__tests__/usage-cache-backfill-migration.test.ts
+++ b/assistant/src/__tests__/usage-cache-backfill-migration.test.ts
@@ -32,7 +32,7 @@ import {
   resolvePricingForUsageWithOverrides,
 } from "../util/pricing.js";
 
-initializeDb();
+await initializeDb();
 
 const CHECKPOINT_KEY = "migration_backfill_usage_cache_accounting_v1";
 

--- a/assistant/src/__tests__/usage-routes.test.ts
+++ b/assistant/src/__tests__/usage-routes.test.ts
@@ -16,7 +16,7 @@ import {
 import { BadRequestError } from "../runtime/routes/errors.js";
 import { ROUTES } from "../runtime/routes/usage-routes.js";
 
-initializeDb();
+await initializeDb();
 
 function clearUsageEvents() {
   getSqlite().run("DELETE FROM cron_runs");

--- a/assistant/src/__tests__/verification-control-plane-policy.test.ts
+++ b/assistant/src/__tests__/verification-control-plane-policy.test.ts
@@ -224,8 +224,8 @@ function makePrompter(): PermissionPrompter {
 
 import { initializeDb } from "../memory/db-init.js";
 
-beforeAll(() => {
-  initializeDb();
+beforeAll(async () => {
+  await initializeDb();
 });
 afterAll(() => {
   mock.restore();

--- a/assistant/src/__tests__/voice-invite-redemption.test.ts
+++ b/assistant/src/__tests__/voice-invite-redemption.test.ts
@@ -19,7 +19,7 @@ import { createInvite, revokeInvite } from "../memory/invite-store.js";
 import { redeemVoiceInviteCode } from "../runtime/invite-redemption-service.js";
 import { generateVoiceCode, hashVoiceCode } from "../util/voice-code.js";
 
-initializeDb();
+await initializeDb();
 
 function resetTables() {
   getSqlite().run("DELETE FROM assistant_ingress_invites");

--- a/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
+++ b/assistant/src/__tests__/voice-scoped-grant-consumer.test.ts
@@ -95,7 +95,7 @@ const { createScopedApprovalGrant } = _internal;
 import type { TrustContext } from "../daemon/trust-context.js";
 import { computeToolApprovalDigest } from "../security/tool-approval-digest.js";
 
-initializeDb();
+await initializeDb();
 
 // ---------------------------------------------------------------------------
 // Mock session that triggers a confirmation_request on processMessage

--- a/assistant/src/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/__tests__/voice-session-bridge.test.ts
@@ -47,7 +47,7 @@ import { initializeDb } from "../memory/db-init.js";
 import { assistantEventHub } from "../runtime/assistant-event-hub.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 
-initializeDb();
+await initializeDb();
 
 /**
  * Build a session that emits multiple events via the onEvent callback,

--- a/assistant/src/__tests__/workspace-migration-009-backfill-conversation-disk-view.test.ts
+++ b/assistant/src/__tests__/workspace-migration-009-backfill-conversation-disk-view.test.ts
@@ -50,7 +50,7 @@ import {
 } from "../memory/schema.js";
 import { backfillConversationDiskViewMigration } from "../workspace/migrations/009-backfill-conversation-disk-view.js";
 
-initializeDb();
+await initializeDb();
 
 function resetTables() {
   const db = getDb();

--- a/assistant/src/__tests__/workspace-migration-013-repair-conversation-disk-view.test.ts
+++ b/assistant/src/__tests__/workspace-migration-013-repair-conversation-disk-view.test.ts
@@ -51,7 +51,7 @@ import {
 } from "../memory/schema.js";
 import { repairConversationDiskViewMigration } from "../workspace/migrations/013-repair-conversation-disk-view.js";
 
-initializeDb();
+await initializeDb();
 
 function resetTables() {
   const db = getDb();

--- a/assistant/src/__tests__/workspace-migration-028-recover-conversations-from-disk-view.test.ts
+++ b/assistant/src/__tests__/workspace-migration-028-recover-conversations-from-disk-view.test.ts
@@ -37,7 +37,7 @@ import { initializeDb } from "../memory/db-init.js";
 import { conversations, messages } from "../memory/schema.js";
 import { recoverConversationsFromDiskViewMigration } from "../workspace/migrations/028-recover-conversations-from-disk-view.js";
 
-initializeDb();
+await initializeDb();
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -60,12 +60,17 @@ function createDiskViewDir(
   messagesJsonl?: string,
 ): string {
   const createdAt =
-    typeof meta.createdAt === "string" ? meta.createdAt : new Date().toISOString();
+    typeof meta.createdAt === "string"
+      ? meta.createdAt
+      : new Date().toISOString();
   const timestamp = createdAt.replace(/:/g, "-");
   const dirName = `${timestamp}_${id}`;
   const dirPath = join(conversationsDir, dirName);
   mkdirSync(dirPath, { recursive: true });
-  writeFileSync(join(dirPath, "meta.json"), JSON.stringify(meta, null, 2) + "\n");
+  writeFileSync(
+    join(dirPath, "meta.json"),
+    JSON.stringify(meta, null, 2) + "\n",
+  );
   if (messagesJsonl !== undefined) {
     writeFileSync(join(dirPath, "messages.jsonl"), messagesJsonl);
   }
@@ -100,7 +105,14 @@ describe("028-recover-conversations-from-disk-view migration", () => {
 
     createDiskViewDir(
       id,
-      { id, title: "Basic Recovery", type: "standard", channel: "desktop", createdAt, updatedAt },
+      {
+        id,
+        title: "Basic Recovery",
+        type: "standard",
+        channel: "desktop",
+        createdAt,
+        updatedAt,
+      },
       userLine + "\n" + assistantLine + "\n",
     );
 
@@ -148,7 +160,13 @@ describe("028-recover-conversations-from-disk-view migration", () => {
 
     createDiskViewDir(
       id,
-      { id, title: "Tool Test", type: "standard", createdAt, updatedAt: createdAt },
+      {
+        id,
+        title: "Tool Test",
+        type: "standard",
+        createdAt,
+        updatedAt: createdAt,
+      },
       toolCallLine + "\n" + toolResultLine + "\n",
     );
 
@@ -188,7 +206,13 @@ describe("028-recover-conversations-from-disk-view migration", () => {
 
     createDiskViewDir(
       id,
-      { id, title: "Mixed Test", type: "standard", createdAt, updatedAt: createdAt },
+      {
+        id,
+        title: "Mixed Test",
+        type: "standard",
+        createdAt,
+        updatedAt: createdAt,
+      },
       mixedLine + "\n",
     );
 
@@ -235,8 +259,18 @@ describe("028-recover-conversations-from-disk-view migration", () => {
     // Create matching disk-view dir with a message
     createDiskViewDir(
       id,
-      { id, title: "Already Here", type: "standard", createdAt, updatedAt: createdAt },
-      JSON.stringify({ role: "user", ts: createdAt, content: "Should not be imported" }) + "\n",
+      {
+        id,
+        title: "Already Here",
+        type: "standard",
+        createdAt,
+        updatedAt: createdAt,
+      },
+      JSON.stringify({
+        role: "user",
+        ts: createdAt,
+        content: "Should not be imported",
+      }) + "\n",
     );
 
     recoverConversationsFromDiskViewMigration.run(workspaceDir);
@@ -256,9 +290,25 @@ describe("028-recover-conversations-from-disk-view migration", () => {
 
     createDiskViewDir(
       id,
-      { id, title: "Idempotency Test", type: "standard", createdAt, updatedAt: createdAt },
-      JSON.stringify({ role: "user", ts: createdAt, content: "First message" }) + "\n" +
-        JSON.stringify({ role: "assistant", ts: "2026-03-18T17:01:00.000Z", content: "Reply" }) + "\n",
+      {
+        id,
+        title: "Idempotency Test",
+        type: "standard",
+        createdAt,
+        updatedAt: createdAt,
+      },
+      JSON.stringify({
+        role: "user",
+        ts: createdAt,
+        content: "First message",
+      }) +
+        "\n" +
+        JSON.stringify({
+          role: "assistant",
+          ts: "2026-03-18T17:01:00.000Z",
+          content: "Reply",
+        }) +
+        "\n",
     );
 
     recoverConversationsFromDiskViewMigration.run(workspaceDir);
@@ -283,10 +333,13 @@ describe("028-recover-conversations-from-disk-view migration", () => {
     const createdAt = "2026-03-18T18:00:00.000Z";
 
     // Create dir with only meta.json — no messages.jsonl
-    createDiskViewDir(
+    createDiskViewDir(id, {
       id,
-      { id, title: "No Messages", type: "standard", createdAt, updatedAt: createdAt },
-    );
+      title: "No Messages",
+      type: "standard",
+      createdAt,
+      updatedAt: createdAt,
+    });
 
     recoverConversationsFromDiskViewMigration.run(workspaceDir);
 
@@ -304,12 +357,22 @@ describe("028-recover-conversations-from-disk-view migration", () => {
     const id = "conv-028-malformed-jsonl";
     const createdAt = "2026-03-18T19:00:00.000Z";
 
-    const validLine = JSON.stringify({ role: "user", ts: createdAt, content: "Valid" });
+    const validLine = JSON.stringify({
+      role: "user",
+      ts: createdAt,
+      content: "Valid",
+    });
     const invalidLine = "{ this is not valid json }}}";
 
     createDiskViewDir(
       id,
-      { id, title: "Malformed JSONL", type: "standard", createdAt, updatedAt: createdAt },
+      {
+        id,
+        title: "Malformed JSONL",
+        type: "standard",
+        createdAt,
+        updatedAt: createdAt,
+      },
       validLine + "\n" + invalidLine + "\n",
     );
 
@@ -368,8 +431,15 @@ describe("028-recover-conversations-from-disk-view migration", () => {
       const ts = new Date(baseTime + i * 60_000).toISOString();
       createDiskViewDir(
         ids[i],
-        { id: ids[i], title: `Multi ${i + 1}`, type: "standard", createdAt: ts, updatedAt: ts },
-        JSON.stringify({ role: "user", ts, content: `Message ${i + 1}` }) + "\n",
+        {
+          id: ids[i],
+          title: `Multi ${i + 1}`,
+          type: "standard",
+          createdAt: ts,
+          updatedAt: ts,
+        },
+        JSON.stringify({ role: "user", ts, content: `Message ${i + 1}` }) +
+          "\n",
       );
     }
 


### PR DESCRIPTION
Converts unawaited `initializeDb()` calls to `await initializeDb()` across 84 test files in `src/__tests__`, making the enclosing scope async where needed (top-level await, `beforeAll` hooks, and `test()` callbacks).

This is part of a 4-PR series cutting tests over to `await initializeDb()` so the synchronous `ensureDedicatedSchemas` hack in `db-init.ts` can be removed in the final PR. This batch is behavior-preserving — the hack is still present, so the tables are still created synchronously; the change only ensures the async initialization is properly awaited. No production code is touched.

Verification: `tsc --noEmit` passes, `eslint` passes, and every changed file passes `bun test` per-file with 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCxgAg2eaYMhocHx7G3CPA)_