### PR TITLE
test: await initializeDb() in non-__tests__ suites (batch 3/4)

### DIFF
--- a/assistant/src/a2a/__tests__/e2e-a2a-channel.test.ts
+++ b/assistant/src/a2a/__tests__/e2e-a2a-channel.test.ts
@@ -68,7 +68,7 @@ import {
   updateState,
 } from "../task-store.js";
 
-initializeDb();
+await initializeDb();
 
 // ---------------------------------------------------------------------------
 // Global fetch intercept

--- a/assistant/src/a2a/__tests__/task-store.test.ts
+++ b/assistant/src/a2a/__tests__/task-store.test.ts
@@ -21,7 +21,7 @@ import {
   updateState,
 } from "../task-store.js";
 
-initializeDb();
+await initializeDb();
 
 function makeRequestMessage(overrides?: Partial<A2AMessage>): A2AMessage {
   return {

--- a/assistant/src/acp/__tests__/session-manager-persistence.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-persistence.test.ts
@@ -28,7 +28,7 @@ import {
   insertHistoryRow,
   readHistoryRow,
 } from "./helpers/acp-history-db.js";
-initializeDb();
+await initializeDb();
 
 /**
  * Builds a manager with a fake session pre-injected and returns the handles

--- a/assistant/src/acp/__tests__/session-manager-resume.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-resume.test.ts
@@ -177,8 +177,11 @@ mock.module("../resolve-agent.js", () => ({
 import { installExecFileStub } from "./helpers/exec-file-stub.js";
 import { installWhichStub } from "./helpers/which-stub.js";
 
-const { execScripts, execFileMock, reset: resetExecStub } =
-  installExecFileStub();
+const {
+  execScripts,
+  execFileMock,
+  reset: resetExecStub,
+} = installExecFileStub();
 const which = installWhichStub();
 /** Fixed resolved `bun` path so install script keys are predictable. */
 const BUN_BIN = "/usr/local/bin/bun";
@@ -200,9 +203,10 @@ const { AcpResumeError, AcpSessionManager, AcpSessionNotFoundError } =
   await import("../session-manager.js");
 // Imported dynamically (after the exec/which stubs above) so auto-install.js
 // binds to the mocked node:child_process, exactly like session-manager.js.
-const { _resetAdapterInstallCacheForTests } = await import("../auto-install.js");
+const { _resetAdapterInstallCacheForTests } =
+  await import("../auto-install.js");
 
-initializeDb();
+await initializeDb();
 
 function countHistoryRows(): number {
   const row = getSqlite()
@@ -400,9 +404,9 @@ describe("AcpSessionManager.resumeFromHistory", () => {
       { sessionId: "proto-old", cwd: "/tmp/proj" },
     ]);
     // The SessionEntry command is the basename (resume hints gate on it).
-    expect(
-      internals(manager).sessions.get("installed-resume-1")!.command,
-    ).toBe("claude-agent-acp");
+    expect(internals(manager).sessions.get("installed-resume-1")!.command).toBe(
+      "claude-agent-acp",
+    );
   });
 
   test("missing adapter on resume: installs via sandboxed bun, then resumes against the real binary", async () => {
@@ -481,7 +485,9 @@ describe("AcpSessionManager.resumeFromHistory", () => {
 
     // prepareAgentEnv ran AFTER resolution, on the resolved real binary, and
     // injected the token at spawn time — the sole point the token is in scope.
-    expect(prepareAgentEnvCommands).toEqual(["/usr/local/bin/claude-agent-acp"]);
+    expect(prepareAgentEnvCommands).toEqual([
+      "/usr/local/bin/claude-agent-acp",
+    ]);
     expect(fake.config.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe("should-not-leak");
   });
 
@@ -498,7 +504,10 @@ describe("AcpSessionManager.resumeFromHistory", () => {
     execScripts.set(BUN_ADD_KEY, { error: new Error("network is down") });
 
     const manager = new AcpSessionManager(4);
-    const promise = manager.resumeFromHistory("resume-install-fail-1", () => {});
+    const promise = manager.resumeFromHistory(
+      "resume-install-fail-1",
+      () => {},
+    );
     await expect(promise).rejects.toThrow(/claude-agent-acp is not on PATH/);
     await expect(promise).rejects.toThrow(
       /auto-install failed: .*network is down/,
@@ -819,8 +828,10 @@ describe("AcpSessionManager.steerOrResume", () => {
 
     const manager = new AcpSessionManager(4);
     const sent: ServerMessage[] = [];
-    const first = manager.steerOrResume("sor-init-1", "first instruction", (msg) =>
-      sent.push(msg),
+    const first = manager.steerOrResume(
+      "sor-init-1",
+      "first instruction",
+      (msg) => sent.push(msg),
     );
 
     // Advance microtasks until the first call's resume has registered its

--- a/assistant/src/acp/__tests__/session-manager-startup.test.ts
+++ b/assistant/src/acp/__tests__/session-manager-startup.test.ts
@@ -17,7 +17,7 @@ mock.module("../../util/logger.js", () => ({
 import { AcpSessionManager } from "../../acp/session-manager.js";
 import { getSqlite } from "../../memory/db-connection.js";
 import { initializeDb } from "../../memory/db-init.js";
-initializeDb();
+await initializeDb();
 
 function clearHistory() {
   getSqlite().run("DELETE FROM acp_session_history");

--- a/assistant/src/background-wake/wake-intent-hooks.test.ts
+++ b/assistant/src/background-wake/wake-intent-hooks.test.ts
@@ -102,7 +102,7 @@ const { getDb } = await import("../memory/db-connection.js");
 const { createSchedule, deleteSchedule, updateSchedule } =
   await import("../schedule/schedule-store.js");
 
-initializeDb();
+await initializeDb();
 
 describe("background wake intent publisher hooks", () => {
   beforeEach(() => {

--- a/assistant/src/cli/commands/db/__tests__/repair.test.ts
+++ b/assistant/src/cli/commands/db/__tests__/repair.test.ts
@@ -442,7 +442,7 @@ async function initSchema(): Promise<void> {
   clearStoredDb("memory");
 
   const { initializeDb } = await import("../../../../memory/db-init.js");
-  initializeDb();
+  await initializeDb();
   // Close the singletons so backfill can open its own handle without
   // collision. WAL allows concurrent handles but cleaner ownership avoids
   // test cross-talk through the in-process cache.

--- a/assistant/src/daemon/handlers/__tests__/config-a2a-accept.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a-accept.test.ts
@@ -30,7 +30,7 @@ import { getSqlite } from "../../../memory/db-connection.js";
 import { initializeDb } from "../../../memory/db-init.js";
 import { acceptA2AInvite, createA2AInvite } from "../config-a2a.js";
 
-initializeDb();
+await initializeDb();
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/assistant/src/daemon/handlers/__tests__/config-a2a-complete.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a-complete.test.ts
@@ -29,7 +29,7 @@ import { initializeDb } from "../../../memory/db-init.js";
 import { findById } from "../../../memory/invite-store.js";
 import { completeA2AInvite, createA2AInvite } from "../config-a2a.js";
 
-initializeDb();
+await initializeDb();
 
 function resetTables(): void {
   const sqlite = getSqlite();

--- a/assistant/src/daemon/handlers/__tests__/config-a2a-invite.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a-invite.test.ts
@@ -26,7 +26,7 @@ import { initializeDb } from "../../../memory/db-init.js";
 import { findById } from "../../../memory/invite-store.js";
 import { createA2AInvite, getA2AConfig } from "../config-a2a.js";
 
-initializeDb();
+await initializeDb();
 
 function resetTables(): void {
   const sqlite = getSqlite();

--- a/assistant/src/daemon/handlers/__tests__/config-a2a-redeem.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a-redeem.test.ts
@@ -28,7 +28,7 @@ import { getSqlite } from "../../../memory/db-connection.js";
 import { initializeDb } from "../../../memory/db-init.js";
 import { getA2AConfig, redeemA2AInvite } from "../config-a2a.js";
 
-initializeDb();
+await initializeDb();
 
 function resetTables(): void {
   const sqlite = getSqlite();

--- a/assistant/src/daemon/handlers/__tests__/config-a2a.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-a2a.test.ts
@@ -24,7 +24,7 @@ import { getSqlite } from "../../../memory/db-connection.js";
 import { initializeDb } from "../../../memory/db-init.js";
 import { clearA2AConfig, getA2AConfig, setA2AConfig } from "../config-a2a.js";
 
-initializeDb();
+await initializeDb();
 
 function resetTables(): void {
   const sqlite = getSqlite();

--- a/assistant/src/documents/document-comments-store.test.ts
+++ b/assistant/src/documents/document-comments-store.test.ts
@@ -18,7 +18,7 @@ import {
   resolveComment,
 } from "./document-comments-store.js";
 
-initializeDb();
+await initializeDb();
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/assistant/src/heartbeat/__tests__/heartbeat-run-store.test.ts
+++ b/assistant/src/heartbeat/__tests__/heartbeat-run-store.test.ts
@@ -25,7 +25,7 @@ import {
   supersedePendingRun,
 } from "../heartbeat-run-store.js";
 
-initializeDb();
+await initializeDb();
 
 describe("heartbeat-run-store", () => {
   beforeEach(() => {

--- a/assistant/src/ipc/__tests__/attachment-ipc.test.ts
+++ b/assistant/src/ipc/__tests__/attachment-ipc.test.ts
@@ -20,7 +20,7 @@ import { cliIpcCall } from "../cli-client.js";
 // DB setup (attachment store needs SQLite)
 // ---------------------------------------------------------------------------
 
-initializeDb();
+await initializeDb();
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/assistant/src/ipc/__tests__/watcher-ipc.test.ts
+++ b/assistant/src/ipc/__tests__/watcher-ipc.test.ts
@@ -19,7 +19,7 @@ import { cliIpcCall } from "../cli-client.js";
 // DB + provider setup
 // ---------------------------------------------------------------------------
 
-initializeDb();
+await initializeDb();
 
 const mockProvider: WatcherProvider = {
   id: "test-provider",
@@ -67,12 +67,14 @@ afterEach(async () => {
 async function createTestWatcher(
   overrides?: Record<string, unknown>,
 ): Promise<Watcher> {
-  const result = await cliIpcCall<Watcher>("watcher_create", { body: {
-    name: "Test Watcher",
-    provider: "test-provider",
-    action_prompt: "Handle events",
-    ...overrides,
-  } });
+  const result = await cliIpcCall<Watcher>("watcher_create", {
+    body: {
+      name: "Test Watcher",
+      provider: "test-provider",
+      action_prompt: "Handle events",
+      ...overrides,
+    },
+  });
   expect(result.ok).toBe(true);
   expect(result.result).toBeDefined();
   createdWatcherIds.push(result.result!.id);
@@ -96,7 +98,9 @@ describe("watcher IPC routes", () => {
     expect(watcher.status).toBe("idle");
 
     // List all
-    const listResult = await cliIpcCall<Watcher[]>("watcher_list", { body: {} });
+    const listResult = await cliIpcCall<Watcher[]>("watcher_list", {
+      body: {},
+    });
     expect(listResult.ok).toBe(true);
     expect(Array.isArray(listResult.result)).toBe(true);
     const found = listResult.result!.find((w) => w.id === watcher.id);
@@ -112,10 +116,12 @@ describe("watcher IPC routes", () => {
     expect(Array.isArray(detailResult.result!.events)).toBe(true);
 
     // Update
-    const updateResult = await cliIpcCall<Watcher>("watcher_update", { body: {
-      watcher_id: watcher.id,
-      name: "Updated Watcher",
-    } });
+    const updateResult = await cliIpcCall<Watcher>("watcher_update", {
+      body: {
+        watcher_id: watcher.id,
+        name: "Updated Watcher",
+      },
+    });
     expect(updateResult.ok).toBe(true);
     expect(updateResult.result!.name).toBe("Updated Watcher");
 
@@ -133,7 +139,9 @@ describe("watcher IPC routes", () => {
     if (idx >= 0) createdWatcherIds.splice(idx, 1);
 
     // Confirm gone
-    const afterDelete = await cliIpcCall<Watcher[]>("watcher_list", { body: {} });
+    const afterDelete = await cliIpcCall<Watcher[]>("watcher_list", {
+      body: {},
+    });
     expect(afterDelete.ok).toBe(true);
     const gone = afterDelete.result!.find((w) => w.id === watcher.id);
     expect(gone).toBeUndefined();
@@ -142,11 +150,13 @@ describe("watcher IPC routes", () => {
   // -- Create: unknown provider -----------------------------------------------
 
   test("watcher/create rejects unknown provider", async () => {
-    const result = await cliIpcCall("watcher_create", { body: {
-      name: "Bad Watcher",
-      provider: "nonexistent",
-      action_prompt: "Do stuff",
-    } });
+    const result = await cliIpcCall("watcher_create", {
+      body: {
+        name: "Bad Watcher",
+        provider: "nonexistent",
+        action_prompt: "Do stuff",
+      },
+    });
     expect(result.ok).toBe(false);
     expect(result.error).toContain('Unknown provider "nonexistent"');
     expect(result.error).toContain("test-provider");
@@ -155,12 +165,14 @@ describe("watcher IPC routes", () => {
   // -- Create: poll interval too low ------------------------------------------
 
   test("watcher/create rejects poll_interval_ms < 15000", async () => {
-    const result = await cliIpcCall("watcher_create", { body: {
-      name: "Fast Watcher",
-      provider: "test-provider",
-      action_prompt: "Handle events",
-      poll_interval_ms: 5000,
-    } });
+    const result = await cliIpcCall("watcher_create", {
+      body: {
+        name: "Fast Watcher",
+        provider: "test-provider",
+        action_prompt: "Handle events",
+        poll_interval_ms: 5000,
+      },
+    });
     expect(result.ok).toBe(false);
     expect(result.error).toBeDefined();
   });
@@ -179,9 +191,11 @@ describe("watcher IPC routes", () => {
 
   test("watcher/update rejects when no update fields provided", async () => {
     const watcher = await createTestWatcher();
-    const result = await cliIpcCall("watcher_update", { body: {
-      watcher_id: watcher.id,
-    } });
+    const result = await cliIpcCall("watcher_update", {
+      body: {
+        watcher_id: watcher.id,
+      },
+    });
     expect(result.ok).toBe(false);
     expect(result.error).toContain("No updates provided");
   });
@@ -189,9 +203,11 @@ describe("watcher IPC routes", () => {
   // -- Delete: non-existent watcher -------------------------------------------
 
   test("watcher/delete returns error for non-existent watcher", async () => {
-    const result = await cliIpcCall("watcher_delete", { body: {
-      watcher_id: "does-not-exist",
-    } });
+    const result = await cliIpcCall("watcher_delete", {
+      body: {
+        watcher_id: "does-not-exist",
+      },
+    });
     expect(result.ok).toBe(false);
     expect(result.error).toContain("Watcher not found");
   });
@@ -211,11 +227,13 @@ describe("watcher IPC routes", () => {
   // -- Underscore aliases -----------------------------------------------------
 
   test("watcher_create alias works identically to watcher/create", async () => {
-    const result = await cliIpcCall<Watcher>("watcher_create", { body: {
-      name: "Alias Watcher",
-      provider: "test-provider",
-      action_prompt: "Handle events",
-    } });
+    const result = await cliIpcCall<Watcher>("watcher_create", {
+      body: {
+        name: "Alias Watcher",
+        provider: "test-provider",
+        action_prompt: "Handle events",
+      },
+    });
     expect(result.ok).toBe(true);
     expect(result.result!.name).toBe("Alias Watcher");
     createdWatcherIds.push(result.result!.id);
@@ -232,10 +250,12 @@ describe("watcher IPC routes", () => {
 
   test("watcher_update alias works identically to watcher/update", async () => {
     const watcher = await createTestWatcher();
-    const result = await cliIpcCall<Watcher>("watcher_update", { body: {
-      watcher_id: watcher.id,
-      name: "Alias Updated",
-    } });
+    const result = await cliIpcCall<Watcher>("watcher_update", {
+      body: {
+        watcher_id: watcher.id,
+        name: "Alias Updated",
+      },
+    });
     expect(result.ok).toBe(true);
     expect(result.result!.name).toBe("Alias Updated");
   });

--- a/assistant/src/live-voice/__tests__/live-voice-archive.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-archive.test.ts
@@ -31,7 +31,7 @@ import {
   linkLiveVoiceUserUtteranceAudioToMessage,
 } from "../live-voice-archive.js";
 
-initializeDb();
+await initializeDb();
 
 function resetTables() {
   const db = getDb();

--- a/assistant/src/memory/__tests__/activation-session-store.test.ts
+++ b/assistant/src/memory/__tests__/activation-session-store.test.ts
@@ -15,7 +15,7 @@ import { getDb } from "../db-connection.js";
 import { initializeDb } from "../db-init.js";
 import { activationSessions } from "../schema.js";
 
-initializeDb();
+await initializeDb();
 
 describe("activation-session-store", () => {
   beforeEach(() => {

--- a/assistant/src/memory/__tests__/auto-analysis-guard.test.ts
+++ b/assistant/src/memory/__tests__/auto-analysis-guard.test.ts
@@ -15,7 +15,7 @@ import {
 import { createConversation } from "../conversation-crud.js";
 import { getDb } from "../db-connection.js";
 import { initializeDb } from "../db-init.js";
-initializeDb();
+await initializeDb();
 
 function resetTables(): void {
   const db = getDb();

--- a/assistant/src/memory/__tests__/conversation-group-migration.test.ts
+++ b/assistant/src/memory/__tests__/conversation-group-migration.test.ts
@@ -10,7 +10,7 @@ mock.module("../../util/logger.js", () => ({
 import { ensureGroupMigration } from "../conversation-group-migration.js";
 import { initializeDb } from "../db-init.js";
 import { rawAll, rawExec, rawGet, rawRun } from "../raw-query.js";
-initializeDb();
+await initializeDb();
 
 // Simulate a legacy install that has the `system:reflections` system group
 // plus a conversation pointing at it. The migration must:

--- a/assistant/src/memory/__tests__/conversation-queries.test.ts
+++ b/assistant/src/memory/__tests__/conversation-queries.test.ts
@@ -25,7 +25,7 @@ import { initializeDb } from "../db-init.js";
 import { rawRun } from "../raw-query.js";
 import { conversations } from "../schema.js";
 
-initializeDb();
+await initializeDb();
 
 function resetTables(): void {
   const db = getDb();

--- a/assistant/src/memory/__tests__/db-async-query.test.ts
+++ b/assistant/src/memory/__tests__/db-async-query.test.ts
@@ -24,7 +24,7 @@ const { runAsyncSqlite, _resetFallbackWarning } =
   await import("../db-async-query.js");
 const { findSqlite3 } = await import("../../util/sqlite3-runtime.js");
 
-initializeDb();
+await initializeDb();
 
 const sqlite3Available = findSqlite3() !== undefined;
 

--- a/assistant/src/memory/__tests__/db-logs-attach.test.ts
+++ b/assistant/src/memory/__tests__/db-logs-attach.test.ts
@@ -26,7 +26,7 @@ const { runAsyncSqlite } = await import("../db-async-query.js");
 const { getLogsDbPath } = await import("../../util/logs-db-path.js");
 const { findSqlite3 } = await import("../../util/sqlite3-runtime.js");
 
-initializeDb();
+await initializeDb();
 
 const sqlite3Available = findSqlite3() !== undefined;
 

--- a/assistant/src/memory/__tests__/db-maintenance.test.ts
+++ b/assistant/src/memory/__tests__/db-maintenance.test.ts
@@ -26,7 +26,7 @@ const { maybeRunDbMaintenance } = await import("../db-maintenance.js");
 const { getLastUserMessageTimestamp } = await import("../conversation-crud.js");
 const { getDbPath } = await import("../../util/platform.js");
 
-initializeDb();
+await initializeDb();
 
 const MAINTENANCE_CHECKPOINT_KEY = "db_maintenance:last_run";
 const QUIET_PERIOD_MS = 3 * 60 * 60 * 1000;

--- a/assistant/src/memory/__tests__/db-memory-attach.test.ts
+++ b/assistant/src/memory/__tests__/db-memory-attach.test.ts
@@ -26,7 +26,7 @@ const { runAsyncSqlite } = await import("../db-async-query.js");
 const { getMemoryDbPath } = await import("../../util/memory-db-path.js");
 const { findSqlite3 } = await import("../../util/sqlite3-runtime.js");
 
-initializeDb();
+await initializeDb();
 
 const sqlite3Available = findSqlite3() !== undefined;
 

--- a/assistant/src/memory/__tests__/find-analysis-conversation.test.ts
+++ b/assistant/src/memory/__tests__/find-analysis-conversation.test.ts
@@ -18,7 +18,7 @@ import { getDb } from "../db-connection.js";
 import { initializeDb } from "../db-init.js";
 import { conversations } from "../schema.js";
 
-initializeDb();
+await initializeDb();
 
 function resetTables(): void {
   const db = getDb();

--- a/assistant/src/memory/__tests__/find-most-recent-retrospective-for.test.ts
+++ b/assistant/src/memory/__tests__/find-most-recent-retrospective-for.test.ts
@@ -18,7 +18,7 @@ import { initializeDb } from "../db-init.js";
 import { MEMORY_RETROSPECTIVE_SOURCE } from "../memory-retrospective-constants.js";
 import { conversations } from "../schema.js";
 
-initializeDb();
+await initializeDb();
 
 function resetTables(): void {
   const db = getDb();

--- a/assistant/src/memory/__tests__/jobs-worker-v2-graph-trigger-embed.test.ts
+++ b/assistant/src/memory/__tests__/jobs-worker-v2-graph-trigger-embed.test.ts
@@ -75,8 +75,8 @@ import { _resetQdrantBreaker } from "../qdrant-circuit-breaker.js";
 import { memoryJobs } from "../schema.js";
 
 describe("graph_trigger_embed under memory v2", () => {
-  beforeAll(() => {
-    initializeDb();
+  beforeAll(async () => {
+    await initializeDb();
   });
 
   afterAll(() => {

--- a/assistant/src/memory/__tests__/jobs-worker-v2-schedule.test.ts
+++ b/assistant/src/memory/__tests__/jobs-worker-v2-schedule.test.ts
@@ -126,7 +126,7 @@ function consolidationJobPayloads(): Record<string, unknown>[] {
 // Initialize the DB once for the file; clear per-test tables in beforeEach
 // rather than tearing down the singleton, which is slow because it re-runs
 // every migration on the next access.
-initializeDb();
+await initializeDb();
 
 beforeEach(() => {
   // Clear job + checkpoint state so each test starts from zero rows. Other

--- a/assistant/src/memory/__tests__/memory-retrospective-state.test.ts
+++ b/assistant/src/memory/__tests__/memory-retrospective-state.test.ts
@@ -33,7 +33,7 @@ import {
 } from "../memory-retrospective-state.js";
 import { memoryRetrospectiveState } from "../schema.js";
 
-initializeDb();
+await initializeDb();
 
 function resetTables(): void {
   const db = getDb();

--- a/assistant/src/memory/__tests__/memory-v2-activation-log-store.test.ts
+++ b/assistant/src/memory/__tests__/memory-v2-activation-log-store.test.ts
@@ -32,7 +32,7 @@ import {
   sampleConfig,
 } from "./fixtures/memory-v2-activation-fixtures.js";
 
-initializeDb();
+await initializeDb();
 
 function resetTables(): void {
   const db = getDb();

--- a/assistant/src/memory/__tests__/memory-v2-concept-frequency.test.ts
+++ b/assistant/src/memory/__tests__/memory-v2-concept-frequency.test.ts
@@ -34,7 +34,7 @@ import { getConceptFrequencySummary } from "../memory-v2-concept-frequency.js";
 import { memoryV2ActivationLogs } from "../schema.js";
 import { sampleConfig } from "./fixtures/memory-v2-activation-fixtures.js";
 
-initializeDb();
+await initializeDb();
 
 const WORKSPACE = "/tmp/memory-v2-concept-frequency-test";
 

--- a/assistant/src/memory/__tests__/onboarding-events-store.test.ts
+++ b/assistant/src/memory/__tests__/onboarding-events-store.test.ts
@@ -22,7 +22,7 @@ import {
 } from "../onboarding-events-store.js";
 import { onboardingEvents } from "../schema.js";
 
-initializeDb();
+await initializeDb();
 
 function resetTable(): void {
   getDb().delete(onboardingEvents).run();

--- a/assistant/src/memory/__tests__/table-relocation.test.ts
+++ b/assistant/src/memory/__tests__/table-relocation.test.ts
@@ -26,7 +26,7 @@ const { drainStagedTable, stageTableForRelocation } =
 const { MEMORY_JOBS_RELOCATION } =
   await import("../migrations/298-move-memory-jobs-to-memory-db.js");
 
-initializeDb();
+await initializeDb();
 
 function existsInMain(name: string): boolean {
   return (

--- a/assistant/src/memory/graph/bootstrap.test.ts
+++ b/assistant/src/memory/graph/bootstrap.test.ts
@@ -16,8 +16,8 @@ const MIGRATE_ITEMS_CHECKPOINT = "graph_bootstrap:migrated_tool_items";
 // Setup
 // ---------------------------------------------------------------------------
 
-beforeAll(() => {
-  initializeDb();
+beforeAll(async () => {
+  await initializeDb();
 });
 
 beforeEach(() => {

--- a/assistant/src/memory/graph/retriever.test.ts
+++ b/assistant/src/memory/graph/retriever.test.ts
@@ -124,18 +124,18 @@ function makeCapabilityNode(content: string, capId: string): NewNode {
 }
 
 describe("loadContextMemory — query/sparse vector surfacing", () => {
-  beforeAll(() => {
-    initializeDb();
+  beforeAll(async () => {
+    await initializeDb();
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     embedShouldThrow = false;
     embedVector = [0.1, 0.2, 0.3];
     embedCallCount = 0;
     embedRouter = null;
     searchRouter = null;
     resetDbForTesting();
-    initializeDb();
+    await initializeDb();
   });
 
   test("returns the dense queryVector when embedding succeeds", async () => {
@@ -180,18 +180,18 @@ describe("loadContextMemory — query/sparse vector surfacing", () => {
 });
 
 describe("retrieveForTurn — query/sparse vector surfacing", () => {
-  beforeAll(() => {
-    initializeDb();
+  beforeAll(async () => {
+    await initializeDb();
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     embedShouldThrow = false;
     embedVector = [0.1, 0.2, 0.3];
     embedCallCount = 0;
     embedRouter = null;
     searchRouter = null;
     resetDbForTesting();
-    initializeDb();
+    await initializeDb();
   });
 
   test("returns the dense queryVector when embedding succeeds", async () => {
@@ -309,8 +309,8 @@ describe("retrieveForTurn — topic-pivot recovery", () => {
     };
   }
 
-  beforeAll(() => {
-    initializeDb();
+  beforeAll(async () => {
+    await initializeDb();
   });
 
   beforeEach(() => {
@@ -458,8 +458,8 @@ describe("loadContextMemory — dual-query capability ranking", () => {
     return [];
   }
 
-  beforeAll(() => {
-    initializeDb();
+  beforeAll(async () => {
+    await initializeDb();
   });
 
   beforeEach(() => {

--- a/assistant/src/memory/graph/store.test.ts
+++ b/assistant/src/memory/graph/store.test.ts
@@ -61,8 +61,8 @@ function makeNewNode(overrides: Partial<NewNode> = {}): NewNode {
   };
 }
 
-beforeAll(() => {
-  initializeDb();
+beforeAll(async () => {
+  await initializeDb();
 });
 
 beforeEach(() => {
@@ -259,12 +259,8 @@ describe("queryNodes", () => {
   });
 
   test("filters by eventDateAfter", () => {
-    createNode(
-      makeNewNode({ content: "Old.", eventDate: 1700000000000 }),
-    );
-    createNode(
-      makeNewNode({ content: "Recent.", eventDate: 1710000000000 }),
-    );
+    createNode(makeNewNode({ content: "Old.", eventDate: 1700000000000 }));
+    createNode(makeNewNode({ content: "Recent.", eventDate: 1710000000000 }));
     createNode(makeNewNode({ content: "None.", eventDate: null }));
 
     const results = queryNodes({ eventDateAfter: 1705000000000 });
@@ -273,12 +269,8 @@ describe("queryNodes", () => {
   });
 
   test("filters by eventDateBefore", () => {
-    createNode(
-      makeNewNode({ content: "Old.", eventDate: 1700000000000 }),
-    );
-    createNode(
-      makeNewNode({ content: "Recent.", eventDate: 1710000000000 }),
-    );
+    createNode(makeNewNode({ content: "Old.", eventDate: 1700000000000 }));
+    createNode(makeNewNode({ content: "Recent.", eventDate: 1710000000000 }));
     createNode(makeNewNode({ content: "None.", eventDate: null }));
 
     const results = queryNodes({ eventDateBefore: 1705000000000 });
@@ -287,15 +279,9 @@ describe("queryNodes", () => {
   });
 
   test("combines eventDateAfter and eventDateBefore for range query", () => {
-    createNode(
-      makeNewNode({ content: "Before.", eventDate: 1690000000000 }),
-    );
-    createNode(
-      makeNewNode({ content: "In range.", eventDate: 1700000000000 }),
-    );
-    createNode(
-      makeNewNode({ content: "After.", eventDate: 1720000000000 }),
-    );
+    createNode(makeNewNode({ content: "Before.", eventDate: 1690000000000 }));
+    createNode(makeNewNode({ content: "In range.", eventDate: 1700000000000 }));
+    createNode(makeNewNode({ content: "After.", eventDate: 1720000000000 }));
 
     const results = queryNodes({
       eventDateAfter: 1695000000000,
@@ -687,7 +673,9 @@ describe("supersedeNode", () => {
 
   test("inherits eventDate from old node when new node has null eventDate", () => {
     const eventDate = 1712534400000; // April 8 2024
-    const old = createNode(makeNewNode({ content: "Dentist April 8.", eventDate }));
+    const old = createNode(
+      makeNewNode({ content: "Dentist April 8.", eventDate }),
+    );
     const newNodeInput = makeNewNode({
       content: "Dentist appointment rescheduled.",
       eventDate: null,
@@ -699,7 +687,9 @@ describe("supersedeNode", () => {
   });
 
   test("uses new node eventDate when both nodes have eventDate", () => {
-    const old = createNode(makeNewNode({ content: "Flight Tuesday.", eventDate: 1712534400000 }));
+    const old = createNode(
+      makeNewNode({ content: "Flight Tuesday.", eventDate: 1712534400000 }),
+    );
     const newEventDate = 1712620800000;
     const newNodeInput = makeNewNode({
       content: "Flight moved to Thursday.",

--- a/assistant/src/memory/job-handlers/embedding.test.ts
+++ b/assistant/src/memory/job-handlers/embedding.test.ts
@@ -61,14 +61,14 @@ const TEST_CONFIG: AssistantConfig = {
 };
 
 describe("embedMediaJob", () => {
-  beforeAll(() => {
-    initializeDb();
+  beforeAll(async () => {
+    await initializeDb();
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     embedAndUpsertCalls.length = 0;
     resetDbForTesting();
-    initializeDb();
+    await initializeDb();
   });
 
   function makeJob(payload: Record<string, unknown>): MemoryJob {

--- a/assistant/src/memory/jobs/__tests__/embed-concept-page.test.ts
+++ b/assistant/src/memory/jobs/__tests__/embed-concept-page.test.ts
@@ -184,11 +184,11 @@ function makeJob(payload: Record<string, unknown>): MemoryJob {
   };
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   resetDbForTesting();
   // The first run pays the full cold-start migration chain; bump the hook
   // timeout above bun's 5s default so the leading test doesn't flake in CI.
-  initializeDb();
+  await initializeDb();
   embedWithBackendCalls.length = 0;
   upsertCalls.length = 0;
   deleteCalls.length = 0;

--- a/assistant/src/memory/jobs/embed-pkb-file.test.ts
+++ b/assistant/src/memory/jobs/embed-pkb-file.test.ts
@@ -62,8 +62,8 @@ function makeJob(payload: Record<string, unknown>): MemoryJob {
 }
 
 describe("embedPkbFileJob", () => {
-  beforeAll(() => {
-    initializeDb();
+  beforeAll(async () => {
+    await initializeDb();
   });
 
   beforeEach(() => {
@@ -116,8 +116,8 @@ describe("embedPkbFileJob", () => {
 });
 
 describe("enqueuePkbIndexJob", () => {
-  beforeAll(() => {
-    initializeDb();
+  beforeAll(async () => {
+    await initializeDb();
   });
 
   beforeEach(() => {

--- a/assistant/src/memory/migrations/__tests__/297-move-llm-request-logs.test.ts
+++ b/assistant/src/memory/migrations/__tests__/297-move-llm-request-logs.test.ts
@@ -24,7 +24,7 @@ const { migrateMoveLlmRequestLogsToLogsDb } =
 const { recordRequestLog, getRequestLogById } =
   await import("../../llm-request-log-store.js");
 
-initializeDb();
+await initializeDb();
 
 function existsInMain(name: string): boolean {
   return (

--- a/assistant/src/memory/skill-loaded-events-store.test.ts
+++ b/assistant/src/memory/skill-loaded-events-store.test.ts
@@ -22,7 +22,7 @@ import {
   recordSkillLoadedEvent,
 } from "./skill-loaded-events-store.js";
 
-initializeDb();
+await initializeDb();
 
 function insertEvent(
   id: string,

--- a/assistant/src/memory/tool-executed-events-store.test.ts
+++ b/assistant/src/memory/tool-executed-events-store.test.ts
@@ -28,7 +28,7 @@ import { initializeDb } from "./db-init.js";
 import { conversations, toolInvocations } from "./schema.js";
 import { queryUnreportedToolExecutedEvents } from "./tool-executed-events-store.js";
 
-initializeDb();
+await initializeDb();
 
 const CONVERSATION_ID = "conv-tool-executed-store-test";
 

--- a/assistant/src/memory/turn-trace-store.test.ts
+++ b/assistant/src/memory/turn-trace-store.test.ts
@@ -39,7 +39,7 @@ import {
   type TurnTraceBoundary,
 } from "./turn-trace-store.js";
 
-initializeDb();
+await initializeDb();
 
 function purge(): void {
   const db = getDb();

--- a/assistant/src/memory/v2/__tests__/backfill-jobs.test.ts
+++ b/assistant/src/memory/v2/__tests__/backfill-jobs.test.ts
@@ -253,9 +253,9 @@ function makeJob(
 // template by running every step; later calls restore it by file copy. That
 // cold build can exceed bun's default 5s hook timeout under CI load, so give
 // the hook generous headroom.
-beforeEach(() => {
+beforeEach(async () => {
   resetDbForTesting();
-  initializeDb();
+  await initializeDb();
   // The shared template-DB caching does not clear WAL state between tests,
   // so explicitly truncate every table this suite writes to. Without this,
   // a row written by an earlier test (e.g. an activation_state for

--- a/assistant/src/memory/v2/__tests__/harness-compare.test.ts
+++ b/assistant/src/memory/v2/__tests__/harness-compare.test.ts
@@ -21,7 +21,7 @@ import {
 import { runComparisonOverHistory } from "../harness/compare.js";
 import type { RetrievalOutput, Retriever } from "../harness/retriever.js";
 
-initializeDb();
+await initializeDb();
 
 // loadNowText reads workspace files; a nonexistent dir yields "".
 const WORKSPACE = "/tmp/harness-compare-nonexistent-workspace";

--- a/assistant/src/memory/v2/__tests__/harness-oracle.test.ts
+++ b/assistant/src/memory/v2/__tests__/harness-oracle.test.ts
@@ -19,7 +19,7 @@ import {
 } from "../../schema.js";
 import { extractOracleTurns } from "../harness/oracle.js";
 
-initializeDb();
+await initializeDb();
 
 const CONFIG_JSON = JSON.stringify({
   d: 0,

--- a/assistant/src/memory/v2/__tests__/harness-replay-input.test.ts
+++ b/assistant/src/memory/v2/__tests__/harness-replay-input.test.ts
@@ -21,7 +21,7 @@ import {
 import type { OracleTurn } from "../harness/oracle.js";
 import { reconstructInput } from "../harness/replay-input.js";
 
-initializeDb();
+await initializeDb();
 
 // loadNowText reads workspace files; a nonexistent dir yields "".
 const WORKSPACE = "/tmp/harness-replay-nonexistent-workspace";

--- a/assistant/src/memory/v2/__tests__/sweep-job.test.ts
+++ b/assistant/src/memory/v2/__tests__/sweep-job.test.ts
@@ -215,9 +215,9 @@ function seedMessages(
   }
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   resetDbForTesting();
-  initializeDb();
+  await initializeDb();
   // Fresh memory dir per test — keeps assertions on file contents independent.
   rmSync(join(tmpWorkspace, "memory"), { recursive: true, force: true });
   mkdirSync(join(tmpWorkspace, "memory"), { recursive: true });

--- a/assistant/src/notifications/__tests__/deterministic-checks.test.ts
+++ b/assistant/src/notifications/__tests__/deterministic-checks.test.ts
@@ -26,7 +26,7 @@ import {
 import type { NotificationSignal } from "../signal.js";
 import type { NotificationDecision } from "../types.js";
 
-initializeDb();
+await initializeDb();
 
 beforeEach(() => {
   getDb().delete(notificationEvents).run();

--- a/assistant/src/runtime/routes/__tests__/acp-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/acp-routes.test.ts
@@ -133,7 +133,7 @@ const { ROUTES } = await import("../acp-routes.js");
 const { _resetAdapterInstallCacheForTests } =
   await import("../../../acp/auto-install.js");
 
-initializeDb();
+await initializeDb();
 
 afterAll(() => {
   which.restore();

--- a/assistant/src/runtime/routes/__tests__/bookmark-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/bookmark-routes.test.ts
@@ -39,7 +39,7 @@ import type { RouteDefinition, RouteHandlerArgs } from "../types.js";
 // DB bootstrap
 // ---------------------------------------------------------------------------
 
-initializeDb();
+await initializeDb();
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/assistant/src/runtime/routes/__tests__/connection-routes-vs-cli-parity.test.ts
+++ b/assistant/src/runtime/routes/__tests__/connection-routes-vs-cli-parity.test.ts
@@ -29,13 +29,16 @@ mock.module("../../../util/logger.js", () => ({
 import { getDb } from "../../../memory/db-connection.js";
 import { initializeDb } from "../../../memory/db-init.js";
 import { providerConnections } from "../../../memory/schema/inference.js";
-import { createConnection, getConnection } from "../../../providers/inference/connections.js";
+import {
+  createConnection,
+  getConnection,
+} from "../../../providers/inference/connections.js";
 import { ROUTES } from "../inference-provider-connection-routes.js";
 import type { RouteDefinition } from "../types.js";
 
 // ── DB bootstrap ──────────────────────────────────────────────────────────────
 
-initializeDb();
+await initializeDb();
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -49,8 +52,14 @@ function clearConnections(): void {
   getDb().delete(providerConnections).run();
 }
 
-function normalizeTimestamps<T extends object>(obj: T): Omit<T, "createdAt" | "updatedAt"> {
-  const { createdAt: _c, updatedAt: _u, ...rest } = obj as T & { createdAt?: unknown; updatedAt?: unknown };
+function normalizeTimestamps<T extends object>(
+  obj: T,
+): Omit<T, "createdAt" | "updatedAt"> {
+  const {
+    createdAt: _c,
+    updatedAt: _u,
+    ...rest
+  } = obj as T & { createdAt?: unknown; updatedAt?: unknown };
   return rest as Omit<T, "createdAt" | "updatedAt">;
 }
 
@@ -79,7 +88,9 @@ describe("CLI vs HTTP route parity", () => {
     clearConnections();
 
     // ── HTTP route path ───────────────────────────────────────────────────────
-    const httpResult = (await findHandler("inference_provider_connections_create")({
+    const httpResult = (await findHandler(
+      "inference_provider_connections_create",
+    )({
       body: {
         name: payload.name,
         provider: payload.provider,
@@ -111,7 +122,11 @@ describe("CLI vs HTTP route parity", () => {
     clearConnections();
 
     await findHandler("inference_provider_connections_create")({
-      body: { name: payload.name, provider: payload.provider, auth: payload.auth },
+      body: {
+        name: payload.name,
+        provider: payload.provider,
+        auth: payload.auth,
+      },
     });
     const httpRow = getConnection(getDb(), payload.name);
 
@@ -133,7 +148,11 @@ describe("CLI vs HTTP route parity", () => {
     clearConnections();
 
     await findHandler("inference_provider_connections_create")({
-      body: { name: payload.name, provider: payload.provider, auth: payload.auth },
+      body: {
+        name: payload.name,
+        provider: payload.provider,
+        auth: payload.auth,
+      },
     });
     const httpRow = getConnection(getDb(), payload.name);
 

--- a/assistant/src/runtime/routes/__tests__/consolidation-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/consolidation-routes.test.ts
@@ -45,7 +45,7 @@ import { rawRun } from "../../../memory/raw-query.js";
 import { ROUTES } from "../consolidation-routes.js";
 import type { RouteDefinition } from "../types.js";
 
-initializeDb();
+await initializeDb();
 
 let workspaceDir: string;
 let origWorkspaceDir: string | undefined;

--- a/assistant/src/runtime/routes/__tests__/conversation-list-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-list-routes.test.ts
@@ -37,7 +37,7 @@ import type { RouteDefinition } from "../types.js";
 // DB bootstrap
 // ---------------------------------------------------------------------------
 
-initializeDb();
+await initializeDb();
 
 function clearConversations(): void {
   getDb().delete(conversations).run();

--- a/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
@@ -39,7 +39,7 @@ import type { RouteDefinition } from "../types.js";
 // DB bootstrap
 // ---------------------------------------------------------------------------
 
-initializeDb();
+await initializeDb();
 
 // ---------------------------------------------------------------------------
 // Config fixture — must expose at least one profile so the handler can

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -84,7 +84,7 @@ const sampleConcepts: MemoryV2ConceptRowRecord[] = sharedSampleConcepts.slice(
   1,
 );
 
-initializeDb();
+await initializeDb();
 
 const llmContextRoute = ROUTES.find(
   (r) => r.method === "GET" && r.endpoint === "messages/:id/llm-context",

--- a/assistant/src/runtime/routes/__tests__/conversation-surface-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-surface-routes.test.ts
@@ -60,7 +60,7 @@ import type { RouteDefinition } from "../types.js";
 // DB bootstrap
 // ---------------------------------------------------------------------------
 
-initializeDb();
+await initializeDb();
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
@@ -40,7 +40,7 @@ import type { RouteDefinition, RouteHandlerArgs } from "../types.js";
 
 // ── DB bootstrap ──────────────────────────────────────────────────────────────
 
-initializeDb();
+await initializeDb();
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -157,7 +157,6 @@ describe("GET inference/provider-connections (list)", () => {
     )) as { connections: unknown[] };
     expect(result.connections).toEqual([]);
   });
-
 });
 
 // ── GET single ────────────────────────────────────────────────────────────────
@@ -186,7 +185,6 @@ describe("GET inference/provider-connections/:name (single)", () => {
       }),
     ).rejects.toBeInstanceOf(NotFoundError);
   });
-
 });
 
 // ── POST create ───────────────────────────────────────────────────────────────

--- a/assistant/src/runtime/routes/__tests__/retrospective-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/retrospective-routes.test.ts
@@ -38,7 +38,7 @@ import { rawRun } from "../../../memory/raw-query.js";
 import { ROUTES } from "../retrospective-routes.js";
 import type { RouteDefinition } from "../types.js";
 
-initializeDb();
+await initializeDb();
 
 let workspaceDir: string;
 let origWorkspaceDir: string | undefined;

--- a/assistant/src/runtime/routes/__tests__/slack-channel-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/slack-channel-routes.test.ts
@@ -39,7 +39,7 @@ import {
 import { ROUTES } from "../slack-channel-routes.js";
 import type { RouteDefinition } from "../types.js";
 
-initializeDb();
+await initializeDb();
 
 interface ResolveResponse {
   channelId: string;

--- a/assistant/src/runtime/routes/acp-routes.test.ts
+++ b/assistant/src/runtime/routes/acp-routes.test.ts
@@ -127,8 +127,7 @@ mock.module("../../tools/credentials/metadata-store.js", () => ({
     const existing = metadataStore.get(key);
     metadataStore.set(key, {
       allowedTools: policy?.allowedTools ?? existing?.allowedTools ?? [],
-      usageDescription:
-        policy?.usageDescription ?? existing?.usageDescription,
+      usageDescription: policy?.usageDescription ?? existing?.usageDescription,
     });
     return {
       credentialId: `cred-${key}`,
@@ -533,8 +532,8 @@ function listRows(): RowSnapshot[] {
 }
 
 describe("DELETE /v1/acp/sessions?status=completed", () => {
-  beforeAll(() => {
-    initializeDb();
+  beforeAll(async () => {
+    await initializeDb();
   });
 
   beforeEach(() => {
@@ -687,8 +686,8 @@ function insertHistoryRow(opts: {
 }
 
 describe("DELETE /v1/acp/sessions/:id", () => {
-  beforeAll(() => {
-    initializeDb();
+  beforeAll(async () => {
+    await initializeDb();
   });
 
   beforeEach(() => {

--- a/assistant/src/runtime/routes/memory-item-routes.test.ts
+++ b/assistant/src/runtime/routes/memory-item-routes.test.ts
@@ -180,8 +180,8 @@ function insertItem(opts: {
 // ---------------------------------------------------------------------------
 
 describe("Memory Item Routes", () => {
-  beforeAll(() => {
-    initializeDb();
+  beforeAll(async () => {
+    await initializeDb();
   });
 
   beforeEach(() => {

--- a/assistant/src/runtime/routes/work-items-routes.test.ts
+++ b/assistant/src/runtime/routes/work-items-routes.test.ts
@@ -25,7 +25,7 @@ import { createWorkItem } from "../../work-items/work-item-store.js";
 import { ForbiddenError } from "./errors.js";
 import { preflightWorkItem, ROUTES } from "./work-items-routes.js";
 
-initializeDb();
+await initializeDb();
 
 describe("empty required_tools snapshot bypass", () => {
   test("falls back to task required tools when snapshot requiredTools is empty", async () => {

--- a/assistant/src/telemetry/usage-telemetry-reporter.test.ts
+++ b/assistant/src/telemetry/usage-telemetry-reporter.test.ts
@@ -241,7 +241,7 @@ import {
 } from "./activation-funnel.js";
 import { UsageTelemetryReporter } from "./usage-telemetry-reporter.js";
 
-initializeDb();
+await initializeDb();
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/assistant/src/tools/document/document-comment-tool.test.ts
+++ b/assistant/src/tools/document/document-comment-tool.test.ts
@@ -20,7 +20,7 @@ import {
   executeCommentResolve,
 } from "./document-comment-tool.js";
 
-initializeDb();
+await initializeDb();
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/assistant/src/workflows/engine-integration.test.ts
+++ b/assistant/src/workflows/engine-integration.test.ts
@@ -186,7 +186,7 @@ import {
 } from "./journal-store.js";
 import { runLeaf } from "./leaf-runner.js";
 
-initializeDb();
+await initializeDb();
 
 // ---------------------------------------------------------------------------
 // Shared fixtures

--- a/assistant/src/workflows/engine.test.ts
+++ b/assistant/src/workflows/engine.test.ts
@@ -24,7 +24,7 @@ import {
 import * as journalStore from "./journal-store.js";
 import type { LeafResult, RunLeafOptions } from "./leaf-runner.js";
 
-initializeDb();
+await initializeDb();
 
 function resetTables(): void {
   getSqlite().exec("DELETE FROM workflow_journal");

--- a/assistant/src/workflows/fanout-load.test.ts
+++ b/assistant/src/workflows/fanout-load.test.ts
@@ -63,7 +63,7 @@ describe.skipIf(!apiKey)(
     test(
       "200-leaf fan-out at default concurrency does not rate-limit-collapse",
       async () => {
-        initializeDb();
+        await initializeDb();
 
         // Non-trivial per-leaf context mirrors the real fan-out shape: each
         // leaf judges a distinct synthetic record, not a one-token prompt.

--- a/assistant/src/workflows/journal-store.test.ts
+++ b/assistant/src/workflows/journal-store.test.ts
@@ -22,7 +22,7 @@ import {
   updateRun,
 } from "./journal-store.js";
 
-initializeDb();
+await initializeDb();
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 

--- a/assistant/src/workflows/leaf-runner.test.ts
+++ b/assistant/src/workflows/leaf-runner.test.ts
@@ -150,7 +150,7 @@ import type { Tool, ToolContext, ToolExecutionResult } from "../tools/types.js";
 import { getWorkspaceDir } from "../util/platform.js";
 import { runLeaf, WorkflowUnknownProfileError } from "./leaf-runner.js";
 
-initializeDb();
+await initializeDb();
 
 const trustContext = {
   sourceChannel: "vellum" as const,


### PR DESCRIPTION
Converts unawaited `initializeDb()` calls to `await initializeDb()` across 71 test files outside `src/__tests__/`, making each enclosing scope async as needed (top-level await, `beforeAll`/`beforeEach` hook callbacks, and already-async helpers).

This is part of a 4-PR series cutting tests over to `await initializeDb()` so the synchronous `ensureDedicatedSchemas` hack in `db-init.ts` can be removed in the final PR. This batch is behavior-preserving — the hack is still present and still creates the tables, so this change only ensures correct async sequencing with no functional difference.

No production code is touched; only `*.test.ts` files. `db-init.ts` / `ensureDedicatedSchemas` are intentionally left unchanged.

Verification: `tsc --noEmit` clean, `prettier --write` applied, `eslint` clean, and every changed file passes per-file (`0 fail`). One file (`workflows/fanout-load.test.ts`) has a pre-existing, environment-gated real-provider test failure that reproduces identically on unmodified `main` and is unrelated to this async change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCxgAg2eaYMhocHx7G3CPA)_