### PR TITLE
refactor(memory): remove the ensureDedicatedSchemas init hack (4/4)

### DIFF
--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -311,22 +311,29 @@ function getMemoryTemplateDbPath(): string {
 
 function tryRestoreTemplate(): boolean {
   const templatePath = getTemplateDbPath();
-  if (!existsSync(templatePath)) return false;
+  const logsTemplate = getLogsTemplateDbPath();
+  const memoryTemplate = getMemoryTemplateDbPath();
+  // Restore only when ALL THREE templates are present. `saveTemplate()` renames
+  // them one at a time, so a parallel test worker can momentarily observe the
+  // main template without its logs/memory siblings. Restoring then would copy
+  // the main DB, leave the dedicated DBs as fresh empty files, and skip
+  // migrations — so the next `llm_request_logs`/`memory_jobs` access would fail
+  // with a missing-table error. Treating a partial set as "not ready" makes such
+  // a worker fall through to a full migrate, which creates every table.
+  if (
+    !existsSync(templatePath) ||
+    !existsSync(logsTemplate) ||
+    !existsSync(memoryTemplate)
+  ) {
+    return false;
+  }
   // getDb() hasn't run yet, so the data directory may not exist.
   ensureDataDir();
   copyFileSync(templatePath, getDbPath());
   // Restore the dedicated logs/memory DBs before their connections open, so the
-  // relocated tables are present. Older templates may predate the split; the
-  // hash includes the migration files, so a stale template without these
-  // siblings won't be reused — but guard anyway.
-  const logsTemplate = getLogsTemplateDbPath();
-  if (existsSync(logsTemplate)) {
-    copyFileSync(logsTemplate, getLogsDbPath());
-  }
-  const memoryTemplate = getMemoryTemplateDbPath();
-  if (existsSync(memoryTemplate)) {
-    copyFileSync(memoryTemplate, getMemoryDbPath());
-  }
+  // relocated tables are present.
+  copyFileSync(logsTemplate, getLogsDbPath());
+  copyFileSync(memoryTemplate, getMemoryDbPath());
   // Open the pre-migrated copy — getDb() will set PRAGMAs but skip migrations.
   getDb();
   return true;

--- a/assistant/src/memory/db-init.ts
+++ b/assistant/src/memory/db-init.ts
@@ -256,14 +256,8 @@ import { migrateWorkflowJournalLeafTokens } from "./migrations/293-workflow-jour
 import { migrateDropExternalUserId } from "./migrations/294-drop-external-user-id.js";
 import { dropApprovalPromptTsTrackerTable } from "./migrations/295-drop-approval-prompt-ts-tracker.js";
 import { migrateRewriteBalancedEconomyProfilePins } from "./migrations/296-rewrite-balanced-economy-profile-pins.js";
-import {
-  ensureLlmRequestLogsSchema,
-  migrateMoveLlmRequestLogsToLogsDb,
-} from "./migrations/297-move-llm-request-logs-to-logs-db.js";
-import {
-  ensureMemoryJobsSchema,
-  migrateMoveMemoryJobsToMemoryDb,
-} from "./migrations/298-move-memory-jobs-to-memory-db.js";
+import { migrateMoveLlmRequestLogsToLogsDb } from "./migrations/297-move-llm-request-logs-to-logs-db.js";
+import { migrateMoveMemoryJobsToMemoryDb } from "./migrations/298-move-memory-jobs-to-memory-db.js";
 import { runMigrationSteps } from "./migrations/run-migrations.js";
 import { validateMigrationState } from "./migrations/validate-migration-state.js";
 
@@ -419,26 +413,8 @@ export async function checkpointWalBeforeOpen(): Promise<void> {
 
 // ---------------------------------------------------------------------------
 
-/**
- * Create the dedicated logs/memory schemas synchronously. Idempotent
- * (`CREATE … IF NOT EXISTS`). Runs as part of DB init — never on connection
- * open — so the tables exist as soon as `initializeDb()` returns, on both the
- * fresh-migration path and the test template-restore path, and regardless of
- * whether the caller awaits (the relocation steps 297/298 that also create them
- * are async). Best-effort: a connection that fails to open leaves its tables
- * unavailable, matching the daemon's "never block startup on a subsystem
- * failure" policy.
- */
-function ensureDedicatedSchemas(): void {
-  const logsRaw = getLogsSqlite();
-  if (logsRaw) ensureLlmRequestLogsSchema(logsRaw);
-  const memoryRaw = getMemorySqlite();
-  if (memoryRaw) ensureMemoryJobsSchema(memoryRaw);
-}
-
 export async function initializeDb(): Promise<void> {
   if (process.env.BUN_TEST === "1" && tryRestoreTemplate()) {
-    ensureDedicatedSchemas();
     return;
   }
 
@@ -713,10 +689,6 @@ export async function initializeDb(): Promise<void> {
   // broken migration doesn't prevent independent later ones from succeeding.
   // The runner creates the checkpoint ledger, recovers crashed migrations, then
   // records each step so an already-migrated database skips it on later boots.
-  // Create the dedicated logs/memory schemas up front, synchronously, before the
-  // (async) relocation steps run — see {@link ensureDedicatedSchemas}.
-  ensureDedicatedSchemas();
-
   const { failed, skipped } = await runMigrationSteps(database, migrationSteps);
 
   log.debug(

--- a/assistant/src/memory/migrations/297-move-llm-request-logs-to-logs-db.ts
+++ b/assistant/src/memory/migrations/297-move-llm-request-logs-to-logs-db.ts
@@ -58,11 +58,10 @@ function createIndexes(raw: Database) {
 
 /**
  * Create the `llm_request_logs` table and its indexes on the logs connection.
- * Idempotent (`IF NOT EXISTS`). Invoked both by this migration and synchronously
- * by `initializeDb` so the table exists as soon as the DB is initialized — the
- * dedicated connection itself performs no DDL on open.
+ * Idempotent (`IF NOT EXISTS`) — the dedicated connection itself performs no DDL
+ * on open, so this migration owns the schema.
  */
-export function ensureLlmRequestLogsSchema(logsRaw: Database): void {
+function ensureLlmRequestLogsSchema(logsRaw: Database): void {
   logsRaw.exec(CREATE_TABLE);
   createIndexes(logsRaw);
 }

--- a/assistant/src/memory/migrations/298-move-memory-jobs-to-memory-db.ts
+++ b/assistant/src/memory/migrations/298-move-memory-jobs-to-memory-db.ts
@@ -62,11 +62,10 @@ const CREATE_TABLE = /*sql*/ `
 
 /**
  * Create the `memory_jobs` table and its indexes on the memory connection.
- * Idempotent (`IF NOT EXISTS`). Invoked both by this migration and synchronously
- * by `initializeDb` so the table exists as soon as the DB is initialized — the
- * dedicated connection itself performs no DDL on open.
+ * Idempotent (`IF NOT EXISTS`) — the dedicated connection itself performs no DDL
+ * on open, so this migration owns the schema.
  */
-export function ensureMemoryJobsSchema(memoryRaw: Database): void {
+function ensureMemoryJobsSchema(memoryRaw: Database): void {
   memoryRaw.exec(CREATE_TABLE);
   createIndexes(memoryRaw);
 }


### PR DESCRIPTION
## What

Removes the synchronous `ensureDedicatedSchemas()` shim from `db-init.ts` (the helper plus its two call sites — the template-restore early-return and the pre-`runMigrationSteps` call), and un-exports the per-migration `ensureLlmRequestLogsSchema` / `ensureMemoryJobsSchema` helpers, which are now only used internally by migrations 297/298.

## Why

When the secondary DBs moved to dedicated connections (#35541), the dedicated tables were created by the **async** relocation migrations (297/298). Most tests call `initializeDb()` without `await`, so a synchronous shim was added to create those tables before unawaited callers reached the stores. PRs #35547, #35548, and #35549 cut every test over to `await initializeDb()`, so the shim is no longer needed:

- Awaited callers get the tables from migrations 297/298.
- The test template-restore path gets them from the restored files (the template is built by a full migrate).

## Verification

- `tsc --noEmit`, `eslint`, `prettier` clean.
- With the shim removed, **all 48 test files that touch `memory_jobs`/`llm_request_logs` pass per-file** (each run in its own process, mirroring CI).

## Note

One test file, `src/__tests__/channel-guardian.test.ts`, still calls `initializeDb()` unawaited. It does **not** touch the dedicated tables (everything it uses comes from synchronous migrations), so it is unaffected by this removal. It was left out of the cutover because committing the one-line `await` triggers the pre-commit formatter to reformat ~576 lines of pre-existing drift, which surfaces non-reserved phone fixtures and trips the `generic-examples` check — an unrelated cleanup best handled on its own. Happy to follow up with that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCxgAg2eaYMhocHx7G3CPA)_