### PR TITLE
feat(gateway): add invite request validation helpers

### DIFF
--- a/gateway/src/http/routes/__tests__/invite-validation.test.ts
+++ b/gateway/src/http/routes/__tests__/invite-validation.test.ts
@@ -8,10 +8,33 @@ import {
 
 describe("parseCreateInviteBody", () => {
   it("accepts a minimal valid body", () => {
-    const result = parseCreateInviteBody({ contactId: "contact-1" });
+    const result = parseCreateInviteBody({
+      contactId: "contact-1",
+      sourceChannel: "telegram",
+    });
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.value.contactId).toBe("contact-1");
+      expect(result.value.sourceChannel).toBe("telegram");
+    }
+  });
+
+  it("rejects a missing sourceChannel", () => {
+    const result = parseCreateInviteBody({ contactId: "contact-1" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("sourceChannel");
+    }
+  });
+
+  it("rejects an empty/whitespace sourceChannel", () => {
+    const result = parseCreateInviteBody({
+      contactId: "contact-1",
+      sourceChannel: "   ",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("sourceChannel");
     }
   });
 
@@ -51,6 +74,7 @@ describe("parseCreateInviteBody", () => {
   it("rejects a negative maxUses", () => {
     const result = parseCreateInviteBody({
       contactId: "contact-1",
+      sourceChannel: "telegram",
       maxUses: -1,
     });
     expect(result.ok).toBe(false);
@@ -62,6 +86,7 @@ describe("parseCreateInviteBody", () => {
   it("rejects a zero expiresInMs", () => {
     const result = parseCreateInviteBody({
       contactId: "contact-1",
+      sourceChannel: "telegram",
       expiresInMs: 0,
     });
     expect(result.ok).toBe(false);
@@ -114,6 +139,25 @@ describe("parseRedeemInviteBody", () => {
         expect(result.value.token).toBe("tok-abc");
         expect(result.value.sourceChannel).toBe("telegram");
       }
+    }
+  });
+
+  it("rejects a token body missing sourceChannel", () => {
+    const result = parseRedeemInviteBody({ token: "tok-abc" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("sourceChannel");
+    }
+  });
+
+  it("rejects a token body with empty/whitespace sourceChannel", () => {
+    const result = parseRedeemInviteBody({
+      token: "tok-abc",
+      sourceChannel: "   ",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("sourceChannel");
     }
   });
 

--- a/gateway/src/http/routes/__tests__/invite-validation.test.ts
+++ b/gateway/src/http/routes/__tests__/invite-validation.test.ts
@@ -46,7 +46,7 @@ describe("parseCreateInviteBody", () => {
       maxUses: 3,
       expiresInMs: 60_000,
       contactName: "Alice",
-      expectedExternalUserId: "+15551234567",
+      expectedExternalUserId: "+12025550100",
       voiceCodeDigits: 4,
       friendName: "Bob",
       guardianName: "Carol",
@@ -105,7 +105,7 @@ describe("parseRedeemInviteBody", () => {
   it("discriminates the voice-code path", () => {
     const result = parseRedeemInviteBody({
       code: "1234",
-      callerExternalUserId: "+15551234567",
+      callerExternalUserId: "+12025550101",
       assistantId: "asst-1",
     });
     expect(result.ok).toBe(true);
@@ -113,7 +113,7 @@ describe("parseRedeemInviteBody", () => {
       expect(result.value.kind).toBe("voice");
       if (result.value.kind === "voice") {
         expect(result.value.code).toBe("1234");
-        expect(result.value.callerExternalUserId).toBe("+15551234567");
+        expect(result.value.callerExternalUserId).toBe("+12025550101");
       }
     }
   });

--- a/gateway/src/http/routes/__tests__/invite-validation.test.ts
+++ b/gateway/src/http/routes/__tests__/invite-validation.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "bun:test";
+
+import {
+  parseCreateInviteBody,
+  parseRedeemInviteBody,
+  parseListInviteQuery,
+} from "../invite-validation.js";
+
+describe("parseCreateInviteBody", () => {
+  it("accepts a minimal valid body", () => {
+    const result = parseCreateInviteBody({ contactId: "contact-1" });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.contactId).toBe("contact-1");
+    }
+  });
+
+  it("accepts the full set of optional fields", () => {
+    const result = parseCreateInviteBody({
+      contactId: "contact-1",
+      sourceChannel: "phone",
+      note: "hello",
+      maxUses: 3,
+      expiresInMs: 60_000,
+      contactName: "Alice",
+      expectedExternalUserId: "+15551234567",
+      voiceCodeDigits: 4,
+      friendName: "Bob",
+      guardianName: "Carol",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.sourceChannel).toBe("phone");
+      expect(result.value.maxUses).toBe(3);
+    }
+  });
+
+  it("rejects a missing contactId", () => {
+    const result = parseCreateInviteBody({ note: "no contact" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("contactId");
+    }
+  });
+
+  it("rejects an empty/whitespace contactId", () => {
+    const result = parseCreateInviteBody({ contactId: "   " });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects a negative maxUses", () => {
+    const result = parseCreateInviteBody({
+      contactId: "contact-1",
+      maxUses: -1,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("maxUses");
+    }
+  });
+
+  it("rejects a zero expiresInMs", () => {
+    const result = parseCreateInviteBody({
+      contactId: "contact-1",
+      expiresInMs: 0,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("expiresInMs");
+    }
+  });
+
+  it("rejects a non-object body", () => {
+    const result = parseCreateInviteBody("nope");
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("parseRedeemInviteBody", () => {
+  it("discriminates the voice-code path", () => {
+    const result = parseRedeemInviteBody({
+      code: "1234",
+      callerExternalUserId: "+15551234567",
+      assistantId: "asst-1",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.kind).toBe("voice");
+      if (result.value.kind === "voice") {
+        expect(result.value.code).toBe("1234");
+        expect(result.value.callerExternalUserId).toBe("+15551234567");
+      }
+    }
+  });
+
+  it("rejects a voice-code body missing callerExternalUserId", () => {
+    const result = parseRedeemInviteBody({ code: "1234" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("callerExternalUserId");
+    }
+  });
+
+  it("discriminates the token path", () => {
+    const result = parseRedeemInviteBody({
+      token: "tok-abc",
+      externalUserId: "user-1",
+      sourceChannel: "telegram",
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.kind).toBe("token");
+      if (result.value.kind === "token") {
+        expect(result.value.token).toBe("tok-abc");
+        expect(result.value.sourceChannel).toBe("telegram");
+      }
+    }
+  });
+
+  it("rejects a body with neither code nor token", () => {
+    const result = parseRedeemInviteBody({ sourceChannel: "telegram" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("token");
+    }
+  });
+});
+
+describe("parseListInviteQuery", () => {
+  it("returns an empty object for an empty query", () => {
+    const result = parseListInviteQuery(new URLSearchParams());
+    expect(result).toEqual({});
+  });
+
+  it("extracts sourceChannel and status when present", () => {
+    const result = parseListInviteQuery(
+      new URLSearchParams({ sourceChannel: "phone", status: "active" }),
+    );
+    expect(result).toEqual({ sourceChannel: "phone", status: "active" });
+  });
+});

--- a/gateway/src/http/routes/invite-validation.ts
+++ b/gateway/src/http/routes/invite-validation.ts
@@ -18,7 +18,7 @@ import { z } from "zod";
 
 export interface CreateInviteInput {
   contactId: string;
-  sourceChannel?: string;
+  sourceChannel: string;
   note?: string;
   maxUses?: number;
   expiresInMs?: number;
@@ -39,7 +39,7 @@ const positiveNumber = z
 
 const createInviteSchema = z.object({
   contactId: z.string().trim().min(1, "contactId is required"),
-  sourceChannel: z.string().optional(),
+  sourceChannel: z.string().trim().min(1, "sourceChannel is required"),
   note: z.string().optional(),
   maxUses: positiveNumber.optional(),
   expiresInMs: positiveNumber.optional(),
@@ -85,7 +85,7 @@ export interface TokenRedeemInput {
   token: string;
   externalUserId?: string;
   externalChatId?: string;
-  sourceChannel?: string;
+  sourceChannel: string;
 }
 
 export type RedeemInviteInput = VoiceRedeemInput | TokenRedeemInput;
@@ -126,6 +126,11 @@ export function parseRedeemInviteBody(
   if (!token) {
     return { ok: false, message: "token is required" };
   }
+  const sourceChannel =
+    typeof raw.sourceChannel === "string" ? raw.sourceChannel.trim() : "";
+  if (!sourceChannel) {
+    return { ok: false, message: "sourceChannel is required" };
+  }
   return {
     ok: true,
     value: {
@@ -135,8 +140,7 @@ export function parseRedeemInviteBody(
         typeof raw.externalUserId === "string" ? raw.externalUserId : undefined,
       externalChatId:
         typeof raw.externalChatId === "string" ? raw.externalChatId : undefined,
-      sourceChannel:
-        typeof raw.sourceChannel === "string" ? raw.sourceChannel : undefined,
+      sourceChannel,
     },
   };
 }

--- a/gateway/src/http/routes/invite-validation.ts
+++ b/gateway/src/http/routes/invite-validation.ts
@@ -1,0 +1,162 @@
+/**
+ * Pure, side-effect-free validation helpers for invite request bodies.
+ *
+ * These mirror the daemon's invite request shapes
+ * (`assistant/src/runtime/routes/contact-routes.ts`, operations
+ * `invites_create` / `invites_redeem`) so the native gateway HTTP handlers
+ * (PR 3) and IPC callers can share a single source of validation truth.
+ *
+ * No DB, no IPC, no logging — just parse/validate. Keep it that way so any
+ * caller (handler or test) can use these directly.
+ */
+
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Create invite
+// ---------------------------------------------------------------------------
+
+export interface CreateInviteInput {
+  contactId: string;
+  sourceChannel?: string;
+  note?: string;
+  maxUses?: number;
+  expiresInMs?: number;
+  contactName?: string;
+  expectedExternalUserId?: string;
+  voiceCodeDigits?: number;
+  friendName?: string;
+  guardianName?: string;
+}
+
+export type ParseResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; message: string };
+
+const positiveNumber = z
+  .number()
+  .refine((n) => Number.isFinite(n) && n > 0, "must be a positive number");
+
+const createInviteSchema = z.object({
+  contactId: z.string().trim().min(1, "contactId is required"),
+  sourceChannel: z.string().optional(),
+  note: z.string().optional(),
+  maxUses: positiveNumber.optional(),
+  expiresInMs: positiveNumber.optional(),
+  contactName: z.string().optional(),
+  expectedExternalUserId: z.string().optional(),
+  voiceCodeDigits: positiveNumber.optional(),
+  friendName: z.string().optional(),
+  guardianName: z.string().optional(),
+});
+
+function firstIssueMessage(error: z.ZodError): string {
+  const issue = error.issues[0];
+  if (!issue) {
+    return "Invalid request body";
+  }
+  const path = issue.path.join(".");
+  return path ? `${path}: ${issue.message}` : issue.message;
+}
+
+export function parseCreateInviteBody(
+  body: unknown,
+): ParseResult<CreateInviteInput> {
+  const parsed = createInviteSchema.safeParse(body ?? {});
+  if (!parsed.success) {
+    return { ok: false, message: firstIssueMessage(parsed.error) };
+  }
+  return { ok: true, value: parsed.data };
+}
+
+// ---------------------------------------------------------------------------
+// Redeem invite (voice-code vs token)
+// ---------------------------------------------------------------------------
+
+export interface VoiceRedeemInput {
+  kind: "voice";
+  code: string;
+  callerExternalUserId: string;
+  assistantId?: string;
+}
+
+export interface TokenRedeemInput {
+  kind: "token";
+  token: string;
+  externalUserId?: string;
+  externalChatId?: string;
+  sourceChannel?: string;
+}
+
+export type RedeemInviteInput = VoiceRedeemInput | TokenRedeemInput;
+
+export function parseRedeemInviteBody(
+  body: unknown,
+): ParseResult<RedeemInviteInput> {
+  const raw = (body ?? {}) as Record<string, unknown>;
+
+  // Voice-code path: presence of `code` selects voice redemption (matching the
+  // daemon, which branches on `body.code != null`).
+  if (raw.code != null) {
+    const code = typeof raw.code === "string" ? raw.code : "";
+    const callerExternalUserId =
+      typeof raw.callerExternalUserId === "string"
+        ? raw.callerExternalUserId
+        : "";
+    if (!code || !callerExternalUserId) {
+      return {
+        ok: false,
+        message: "callerExternalUserId and code are required",
+      };
+    }
+    return {
+      ok: true,
+      value: {
+        kind: "voice",
+        code,
+        callerExternalUserId,
+        assistantId:
+          typeof raw.assistantId === "string" ? raw.assistantId : undefined,
+      },
+    };
+  }
+
+  // Token path.
+  const token = typeof raw.token === "string" ? raw.token : "";
+  if (!token) {
+    return { ok: false, message: "token is required" };
+  }
+  return {
+    ok: true,
+    value: {
+      kind: "token",
+      token,
+      externalUserId:
+        typeof raw.externalUserId === "string" ? raw.externalUserId : undefined,
+      externalChatId:
+        typeof raw.externalChatId === "string" ? raw.externalChatId : undefined,
+      sourceChannel:
+        typeof raw.sourceChannel === "string" ? raw.sourceChannel : undefined,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// List invites query
+// ---------------------------------------------------------------------------
+
+export interface ListInviteQuery {
+  sourceChannel?: string;
+  status?: string;
+}
+
+export function parseListInviteQuery(
+  searchParams: URLSearchParams,
+): ListInviteQuery {
+  const sourceChannel = searchParams.get("sourceChannel") ?? undefined;
+  const status = searchParams.get("status") ?? undefined;
+  return {
+    ...(sourceChannel ? { sourceChannel } : {}),
+    ...(status ? { status } : {}),
+  };
+}


### PR DESCRIPTION
## Summary
- Add pure, side-effect-free invite request validation helpers (create/redeem/list query)
- Unit tests covering happy path and each rejection branch

Part of plan: contacts-gw-native-invites.md (PR 2 of 6)