### PR TITLE
feat(gateway): expose invite CRUD over the gateway IPC server

### DIFF
--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -32,9 +32,53 @@ import {
   parseCreateInviteBody,
   parseListInviteQuery,
   parseRedeemInviteBody,
+  type CreateInviteInput,
+  type ListInviteQuery,
 } from "./invite-validation.js";
 
 const log = getLogger("contacts-control-plane-proxy");
+
+// ---------------------------------------------------------------------------
+// Transport-agnostic invite native errors
+// ---------------------------------------------------------------------------
+
+/**
+ * Error thrown by the transport-agnostic invite native functions to signal a
+ * client-facing failure with a stable code + status. The HTTP handlers map it
+ * to `Response.json`; the gateway IPC routes let it propagate (the IPC server
+ * stringifies thrown errors into the wire `error` field).
+ */
+export class InviteNativeError extends Error {
+  readonly statusCode: number;
+  readonly code: string;
+
+  constructor(message: string, statusCode: number, code: string) {
+    super(message);
+    this.name = "InviteNativeError";
+    this.statusCode = statusCode;
+    this.code = code;
+  }
+}
+
+/** Map an InviteNativeError (or generic error) to the HTTP error Response. */
+function inviteErrorResponse(err: unknown): Response {
+  if (err instanceof InviteNativeError) {
+    return Response.json(
+      { error: { code: err.code, message: err.message } },
+      { status: err.statusCode },
+    );
+  }
+  if (err instanceof IpcHandlerError) {
+    return Response.json(
+      { error: { code: err.code, message: err.message } },
+      { status: err.statusCode },
+    );
+  }
+  return Response.json(
+    { error: { code: "INTERNAL_ERROR", message: "Internal error" } },
+    { status: 500 },
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Validation constants (mirrored from assistant/src/runtime/routes/contact-routes.ts)
@@ -157,11 +201,13 @@ async function listAssistantOnlyInvites(
  * Revoke an invite that exists only in the assistant DB (no gateway row).
  *
  * Flips an active row to revoked, then SELECTs the row to distinguish
- * "absent" (→ 404) from "present but already terminal" (→ success with the
- * row's resulting state). Returns the sanitized invite shape on success.
+ * "absent" (→ throw 404) from "present but already terminal" (→ success with
+ * the row's resulting state). Returns the sanitized invite shape on success.
  * Idempotent: re-revoking an already-terminal invite returns success.
  */
-async function revokeAssistantOnlyInvite(inviteId: string): Promise<Response> {
+async function revokeAssistantOnlyInviteNative(
+  inviteId: string,
+): Promise<{ invite: Record<string, unknown> }> {
   const now = Date.now();
   // Best-effort: flip an ACTIVE row to revoked. A terminal row is untouched.
   try {
@@ -203,14 +249,10 @@ async function revokeAssistantOnlyInvite(inviteId: string): Promise<Response> {
   const row = found[0];
   if (!row) {
     // Absent from BOTH the gateway and the assistant DB.
-    return Response.json(
-      {
-        error: {
-          code: "NOT_FOUND",
-          message: `Invite "${inviteId}" not found`,
-        },
-      },
-      { status: 404 },
+    throw new InviteNativeError(
+      `Invite "${inviteId}" not found`,
+      404,
+      "NOT_FOUND",
     );
   }
 
@@ -229,8 +271,7 @@ async function revokeAssistantOnlyInvite(inviteId: string): Promise<Response> {
     { inviteId, status: row.status },
     "revoke_invite: handled via assistant-only fallback",
   );
-  return Response.json({
-    ok: true,
+  return {
     invite: {
       // No *_hash column is selected, so there's no code hash to strip.
       ...invite,
@@ -239,7 +280,291 @@ async function revokeAssistantOnlyInvite(inviteId: string): Promise<Response> {
       ...(guardianName ? { guardianName } : {}),
       ...(expectedExternalUserId ? { expectedExternalUserId } : {}),
     },
-  });
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Transport-agnostic invite native functions
+//
+// These hold the ONE implementation shared by the gateway HTTP invite handlers
+// and the gateway IPC invite routes (gateway/src/ipc/invite-handlers.ts). They
+// return plain data (never a `Response`) and signal failures by throwing
+// InviteNativeError / IpcHandlerError so each transport can translate the
+// error into its own envelope (HTTP status code vs IPC error string). Behavior
+// here MUST stay identical to the prior inline HTTP handler bodies.
+// ---------------------------------------------------------------------------
+
+/**
+ * List invites (gateway rows + best-effort voice-field join + assistant-only
+ * merge), sanitized (no inviteCodeHash). Throws InviteNativeError(500) when the
+ * gateway read itself fails. The voice-join and assistant-only merge soft-fail.
+ */
+export async function listInvitesNative(
+  query: ListInviteQuery,
+): Promise<{ invites: Array<Record<string, unknown>> }> {
+  let rows;
+  try {
+    rows = new ContactStore().listInvites(query);
+  } catch (err) {
+    log.error({ err }, "list_invites: gateway-native read failed");
+    throw new InviteNativeError(
+      "Failed to list invites",
+      500,
+      "INTERNAL_ERROR",
+    );
+  }
+
+  // Best-effort: join voice UX fields from the assistant DB.
+  const voiceById = new Map<string, Record<string, unknown>>();
+  if (rows.length > 0) {
+    try {
+      const ids = rows.map((r) => r.id);
+      const placeholders = ids.map(() => "?").join(", ");
+      const voiceRows = await assistantDbQuery<{
+        id: string;
+        voiceCodeDigits: number | null;
+        friendName: string | null;
+        guardianName: string | null;
+        expectedExternalUserId: string | null;
+      }>(
+        `SELECT id,
+                voice_code_digits        AS voiceCodeDigits,
+                friend_name              AS friendName,
+                guardian_name            AS guardianName,
+                expected_external_user_id AS expectedExternalUserId
+           FROM assistant_ingress_invites
+          WHERE id IN (${placeholders})`,
+        ids,
+      );
+      for (const v of voiceRows) {
+        voiceById.set(v.id, {
+          ...(v.voiceCodeDigits != null
+            ? { voiceCodeDigits: v.voiceCodeDigits }
+            : {}),
+          ...(v.friendName ? { friendName: v.friendName } : {}),
+          ...(v.guardianName ? { guardianName: v.guardianName } : {}),
+          ...(v.expectedExternalUserId
+            ? { expectedExternalUserId: v.expectedExternalUserId }
+            : {}),
+        });
+      }
+    } catch (err) {
+      log.warn(
+        { err, count: rows.length },
+        "list_invites: assistant DB voice-field join failed; returning gateway rows only",
+      );
+    }
+  }
+
+  const invites: Array<Record<string, unknown>> = rows.map((r) => ({
+    ...sanitizeInviteRow(r),
+    ...(voiceById.get(r.id) ?? {}),
+  }));
+
+  // Belt-and-suspenders for the transitional window: merge in assistant-only
+  // rows (created via the IPC/CLI path with no gateway row), applying the SAME
+  // filters and sanitization. Gateway wins on id (lifecycle truth).
+  try {
+    const gatewayIds = new Set(rows.map((r) => r.id));
+    const assistantOnly = await listAssistantOnlyInvites(query, gatewayIds);
+    for (const inv of assistantOnly) invites.push(inv);
+  } catch (err) {
+    log.warn(
+      { err },
+      "list_invites: assistant-only merge query failed; returning gateway rows only",
+    );
+  }
+
+  log.info({ count: invites.length, ...query }, "list_invites: handled natively");
+  return { invites };
+}
+
+/**
+ * Create an invite: verify the contact exists, relay to the assistant mint
+ * (token/hash + voice fields), then write the canonical gateway lifecycle row.
+ * Returns the assistant's minted one-time payload + rawToken. Throws
+ * InviteNativeError(404) when the contact is unknown, InviteNativeError(500)
+ * when the mint or gateway write fails, and propagates an assistant mint
+ * IpcHandlerError unchanged so its status/code reach the caller.
+ */
+export async function createInviteNative(
+  input: CreateInviteInput,
+): Promise<{ invite: Record<string, unknown>; rawToken?: string }> {
+  const store = new ContactStore();
+
+  // Verify the contact exists in the gateway DB before minting.
+  if (!store.getContact(input.contactId)) {
+    throw new InviteNativeError(
+      `Contact "${input.contactId}" not found`,
+      404,
+      "NOT_FOUND",
+    );
+  }
+
+  // ── Assistant mints (token/hash + voice fields) ──────────────────
+  let mint: {
+    invite: Record<string, unknown>;
+    rawToken?: string;
+    gateway: {
+      id: string;
+      inviteCodeHash: string;
+      sourceChannel: string;
+      contactId: string;
+      note: string | null;
+      maxUses: number;
+      expiresAt: number;
+    };
+  };
+  try {
+    mint = (await ipcCallAssistant("invites_mint", {
+      body: input,
+    } as unknown as Record<string, unknown>)) as typeof mint;
+  } catch (err) {
+    if (err instanceof IpcHandlerError) {
+      // Propagate the assistant's status/code unchanged.
+      throw err;
+    }
+    log.error({ err, contactId: input.contactId }, "create_invite: mint failed");
+    throw new InviteNativeError("Failed to mint invite", 500, "INTERNAL_ERROR");
+  }
+
+  // ── Gateway DB write (source of truth) ───────────────────────────
+  const gw = mint.gateway;
+  let invite;
+  try {
+    invite = store.createInvite({
+      id: gw.id,
+      inviteCodeHash: gw.inviteCodeHash,
+      sourceChannel: gw.sourceChannel,
+      contactId: gw.contactId,
+      note: gw.note,
+      maxUses: gw.maxUses,
+      expiresAt: gw.expiresAt,
+    });
+  } catch (err) {
+    log.error(
+      { err, inviteId: gw?.id, contactId: input.contactId },
+      "create_invite: gateway DB write failed — assistant invite row is now orphaned (stale over lost)",
+    );
+    throw new InviteNativeError(
+      "Failed to record invite",
+      500,
+      "INTERNAL_ERROR",
+    );
+  }
+
+  // Notify connected clients.
+  void ipcCallAssistant("emit_event", {
+    body: { kind: "contacts_changed" },
+  } as unknown as Record<string, unknown>).catch(() => {});
+
+  log.info(
+    { inviteId: invite.id, contactId: input.contactId },
+    "create_invite: handled natively",
+  );
+  // The gateway row is the lifecycle source of truth, but the response must
+  // carry the assistant's minted one-time fields (voiceCode for phone;
+  // inviteCode/guardianInstruction/share/token for non-phone) — returned only
+  // at creation time and never fetchable later.
+  return { invite: mint.invite, rawToken: mint.rawToken };
+}
+
+/**
+ * Revoke an invite: flip the gateway row (source of truth), best-effort mirror
+ * the actual post-revoke status into the assistant DB, and fall back to
+ * revoking the assistant-only row when no gateway row exists. Returns the
+ * sanitized invite. Throws InviteNativeError(404) only when the invite is
+ * absent from BOTH stores, InviteNativeError(500) on unexpected gateway error.
+ */
+export async function revokeInviteNative(
+  inviteId: string,
+): Promise<{ invite: Record<string, unknown> }> {
+  let invite;
+  try {
+    invite = new ContactStore().revokeInvite(inviteId);
+  } catch (err) {
+    log.error({ err, inviteId }, "revoke_invite: gateway-native revoke failed");
+    throw new InviteNativeError(
+      "Failed to revoke invite",
+      500,
+      "INTERNAL_ERROR",
+    );
+  }
+
+  if (!invite) {
+    // No gateway row. Fall back to revoking the assistant-only row; 404 only
+    // when absent from BOTH stores.
+    return await revokeAssistantOnlyInviteNative(inviteId);
+  }
+
+  // Best-effort mirror into the assistant DB — reflect the gateway row's ACTUAL
+  // post-revoke status (revokeInvite only flips ACTIVE rows) so the two stores
+  // stay in sync instead of forcing 'revoked'.
+  try {
+    await assistantDbRun(
+      "UPDATE assistant_ingress_invites SET status=?, updated_at=? WHERE id=?",
+      [invite.status, Date.now(), inviteId],
+    );
+  } catch (err) {
+    log.warn(
+      { err, inviteId },
+      "revoke_invite: assistant DB mirror failed (best-effort)",
+    );
+  }
+
+  void ipcCallAssistant("emit_event", {
+    body: { kind: "contacts_changed" },
+  } as unknown as Record<string, unknown>).catch(() => {});
+
+  log.info({ inviteId }, "revoke_invite: handled natively");
+  return { invite: sanitizeInviteRow(invite) };
+}
+
+/**
+ * Verify the invite exists + is active in the gateway DB (lifecycle source of
+ * truth) then relay the provider-specific outbound call to the assistant.
+ * Returns the provider call sid. Throws InviteNativeError(404) when the invite
+ * is unknown, InviteNativeError(400) when it isn't active, InviteNativeError(500)
+ * on relay failure, and propagates an assistant IpcHandlerError unchanged.
+ */
+export async function triggerInviteCallNative(
+  inviteId: string,
+): Promise<{ callSid: string }> {
+  const invite = new ContactStore().getInviteById(inviteId);
+  if (!invite) {
+    throw new InviteNativeError(
+      `Invite "${inviteId}" not found`,
+      404,
+      "NOT_FOUND",
+    );
+  }
+  if (invite.status !== "active") {
+    throw new InviteNativeError(
+      `Invite "${inviteId}" is not active`,
+      400,
+      "BAD_REQUEST",
+    );
+  }
+
+  try {
+    // `invites_trigger_call` reads the id from pathParams.id (the assistant IPC
+    // server spreads params into RouteHandlerArgs) — send pathParams, not body.
+    const result = (await ipcCallAssistant("invites_trigger_call", {
+      pathParams: { id: inviteId },
+    } as unknown as Record<string, unknown>)) as { callSid: string };
+    log.info({ inviteId, callSid: result.callSid }, "call_invite: handled natively");
+    return { callSid: result.callSid };
+  } catch (err) {
+    if (err instanceof IpcHandlerError) {
+      throw err;
+    }
+    log.error({ err, inviteId }, "call_invite: relay failed");
+    throw new InviteNativeError(
+      "Failed to trigger invite call",
+      500,
+      "INTERNAL_ERROR",
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1077,90 +1402,11 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
     async handleListInvites(req: Request): Promise<Response> {
       const url = new URL(req.url);
       const query = parseListInviteQuery(url.searchParams);
-
       try {
-        const rows = new ContactStore().listInvites(query);
-
-        // Best-effort: join voice UX fields from the assistant DB.
-        const voiceById = new Map<string, Record<string, unknown>>();
-        if (rows.length > 0) {
-          try {
-            const ids = rows.map((r) => r.id);
-            const placeholders = ids.map(() => "?").join(", ");
-            const voiceRows = await assistantDbQuery<{
-              id: string;
-              voiceCodeDigits: number | null;
-              friendName: string | null;
-              guardianName: string | null;
-              expectedExternalUserId: string | null;
-            }>(
-              `SELECT id,
-                      voice_code_digits        AS voiceCodeDigits,
-                      friend_name              AS friendName,
-                      guardian_name            AS guardianName,
-                      expected_external_user_id AS expectedExternalUserId
-                 FROM assistant_ingress_invites
-                WHERE id IN (${placeholders})`,
-              ids,
-            );
-            for (const v of voiceRows) {
-              voiceById.set(v.id, {
-                ...(v.voiceCodeDigits != null
-                  ? { voiceCodeDigits: v.voiceCodeDigits }
-                  : {}),
-                ...(v.friendName ? { friendName: v.friendName } : {}),
-                ...(v.guardianName ? { guardianName: v.guardianName } : {}),
-                ...(v.expectedExternalUserId
-                  ? { expectedExternalUserId: v.expectedExternalUserId }
-                  : {}),
-              });
-            }
-          } catch (err) {
-            log.warn(
-              { err, count: rows.length },
-              "list_invites: assistant DB voice-field join failed; returning gateway rows only",
-            );
-          }
-        }
-
-        const invites: Array<Record<string, unknown>> = rows.map((r) => ({
-          ...sanitizeInviteRow(r),
-          ...(voiceById.get(r.id) ?? {}),
-        }));
-
-        // Belt-and-suspenders for the transitional window: invites created via
-        // the assistant IPC/CLI `invites_create` path write only the assistant
-        // DB (no gateway row), so they're invisible to this list until the
-        // m0007 backfill (one-time) or the CLI create flip. Merge in any
-        // assistant-only rows the gateway hasn't seen, applying the SAME
-        // filters and sanitization. Gateway wins on id (lifecycle truth).
-        try {
-          const gatewayIds = new Set(rows.map((r) => r.id));
-          const assistantOnly = await listAssistantOnlyInvites(
-            query,
-            gatewayIds,
-          );
-          for (const inv of assistantOnly) invites.push(inv);
-        } catch (err) {
-          log.warn(
-            { err },
-            "list_invites: assistant-only merge query failed; returning gateway rows only",
-          );
-        }
-
-        log.info(
-          { count: invites.length, ...query },
-          "list_invites: handled natively",
-        );
+        const { invites } = await listInvitesNative(query);
         return Response.json({ ok: true, invites });
       } catch (err) {
-        log.error({ err }, "list_invites: gateway-native read failed");
-        return Response.json(
-          {
-            error: { code: "INTERNAL_ERROR", message: "Failed to list invites" },
-          },
-          { status: 500 },
-        );
+        return inviteErrorResponse(err);
       }
     },
 
@@ -1191,106 +1437,16 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
           { status: 400 },
         );
       }
-      const input = parsed.value;
-      const store = new ContactStore();
 
-      // Verify the contact exists in the gateway DB before minting.
-      if (!store.getContact(input.contactId)) {
-        return Response.json(
-          {
-            error: {
-              code: "NOT_FOUND",
-              message: `Contact "${input.contactId}" not found`,
-            },
-          },
-          { status: 404 },
-        );
-      }
-
-      // ── Assistant mints (token/hash + voice fields) ──────────────────
-      let mint: {
-        invite: Record<string, unknown>;
-        rawToken?: string;
-        gateway: {
-          id: string;
-          inviteCodeHash: string;
-          sourceChannel: string;
-          contactId: string;
-          note: string | null;
-          maxUses: number;
-          expiresAt: number;
-        };
-      };
       try {
-        mint = (await ipcCallAssistant("invites_mint", {
-          body: input,
-        } as unknown as Record<string, unknown>)) as typeof mint;
-      } catch (err) {
-        if (err instanceof IpcHandlerError) {
-          return Response.json(
-            {
-              error: {
-                code: err.code,
-                message: err.message,
-              },
-            },
-            { status: err.statusCode },
-          );
-        }
-        log.error({ err, contactId: input.contactId }, "create_invite: mint failed");
+        const result = await createInviteNative(parsed.value);
         return Response.json(
-          {
-            error: { code: "INTERNAL_ERROR", message: "Failed to mint invite" },
-          },
-          { status: 500 },
+          { ok: true, invite: result.invite, rawToken: result.rawToken },
+          { status: 201 },
         );
-      }
-
-      // ── Gateway DB write (source of truth) ───────────────────────────
-      const gw = mint.gateway;
-      let invite;
-      try {
-        invite = store.createInvite({
-          id: gw.id,
-          inviteCodeHash: gw.inviteCodeHash,
-          sourceChannel: gw.sourceChannel,
-          contactId: gw.contactId,
-          note: gw.note,
-          maxUses: gw.maxUses,
-          expiresAt: gw.expiresAt,
-        });
       } catch (err) {
-        // The assistant already minted a row; the gateway record is what
-        // gates ACL, so a missing gateway row is a hard failure. No fallback.
-        log.error(
-          { err, inviteId: gw?.id, contactId: input.contactId },
-          "create_invite: gateway DB write failed — assistant invite row is now orphaned (stale over lost)",
-        );
-        return Response.json(
-          {
-            error: { code: "INTERNAL_ERROR", message: "Failed to record invite" },
-          },
-          { status: 500 },
-        );
+        return inviteErrorResponse(err);
       }
-
-      // Notify connected clients.
-      void ipcCallAssistant("emit_event", {
-        body: { kind: "contacts_changed" },
-      } as unknown as Record<string, unknown>).catch(() => {});
-
-      log.info(
-        { inviteId: invite.id, contactId: input.contactId },
-        "create_invite: handled natively",
-      );
-      // The gateway row is the lifecycle source of truth, but the HTTP response
-      // must carry the assistant's minted one-time fields (voiceCode for phone;
-      // inviteCode/guardianInstruction/share/token for non-phone) — these are
-      // returned only at creation time and can never be fetched later.
-      return Response.json(
-        { ok: true, invite: mint.invite, rawToken: mint.rawToken },
-        { status: 201 },
-      );
     },
 
     /**
@@ -1405,60 +1561,11 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
      * assistant. The gateway gates; the assistant places the call.
      */
     async handleCallInvite(_req: Request, inviteId: string): Promise<Response> {
-      const invite = new ContactStore().getInviteById(inviteId);
-      if (!invite) {
-        return Response.json(
-          {
-            error: {
-              code: "NOT_FOUND",
-              message: `Invite "${inviteId}" not found`,
-            },
-          },
-          { status: 404 },
-        );
-      }
-      if (invite.status !== "active") {
-        return Response.json(
-          {
-            error: {
-              code: "BAD_REQUEST",
-              message: `Invite "${inviteId}" is not active`,
-            },
-          },
-          { status: 400 },
-        );
-      }
-
       try {
-        // `invites_trigger_call` is the shared assistant route handler
-        // (handleTriggerInviteCall), which reads the id from pathParams.id. The
-        // assistant IPC server spreads `params` directly into RouteHandlerArgs,
-        // so send it as pathParams — not body.
-        const result = (await ipcCallAssistant("invites_trigger_call", {
-          pathParams: { id: inviteId },
-        } as unknown as Record<string, unknown>)) as { callSid: string };
-        log.info(
-          { inviteId, callSid: result.callSid },
-          "call_invite: handled natively",
-        );
+        const result = await triggerInviteCallNative(inviteId);
         return Response.json({ ok: true, callSid: result.callSid });
       } catch (err) {
-        if (err instanceof IpcHandlerError) {
-          return Response.json(
-            { error: { code: err.code, message: err.message } },
-            { status: err.statusCode },
-          );
-        }
-        log.error({ err, inviteId }, "call_invite: relay failed");
-        return Response.json(
-          {
-            error: {
-              code: "INTERNAL_ERROR",
-              message: "Failed to trigger invite call",
-            },
-          },
-          { status: 500 },
-        );
+        return inviteErrorResponse(err);
       }
     },
 
@@ -1473,49 +1580,10 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
       inviteId: string,
     ): Promise<Response> {
       try {
-        const invite = new ContactStore().revokeInvite(inviteId);
-        if (!invite) {
-          // No gateway row. The invite may still exist assistant-only (created
-          // via the IPC/CLI path before the m0007 backfill or the CLI flip).
-          // Fall back to revoking the assistant row directly so guardians can
-          // still manage it from the gateway surface. 404 only when the invite
-          // is absent from BOTH stores.
-          return await revokeAssistantOnlyInvite(inviteId);
-        }
-
-        // Best-effort mirror into the assistant DB. revokeInvite() only flips an
-        // ACTIVE row to revoked — an already redeemed/expired invite is returned
-        // unchanged. Mirror the gateway row's ACTUAL post-revoke status so the
-        // two lifecycle stores stay in sync instead of forcing 'revoked'.
-        try {
-          await assistantDbRun(
-            "UPDATE assistant_ingress_invites SET status=?, updated_at=? WHERE id=?",
-            [invite.status, Date.now(), inviteId],
-          );
-        } catch (err) {
-          log.warn(
-            { err, inviteId },
-            "revoke_invite: assistant DB mirror failed (best-effort)",
-          );
-        }
-
-        void ipcCallAssistant("emit_event", {
-          body: { kind: "contacts_changed" },
-        } as unknown as Record<string, unknown>).catch(() => {});
-
-        log.info({ inviteId }, "revoke_invite: handled natively");
-        return Response.json({ ok: true, invite: sanitizeInviteRow(invite) });
+        const { invite } = await revokeInviteNative(inviteId);
+        return Response.json({ ok: true, invite });
       } catch (err) {
-        log.error({ err, inviteId }, "revoke_invite: gateway-native revoke failed");
-        return Response.json(
-          {
-            error: {
-              code: "INTERNAL_ERROR",
-              message: "Failed to revoke invite",
-            },
-          },
-          { status: 500 },
-        );
+        return inviteErrorResponse(err);
       }
     },
   };

--- a/gateway/src/ipc/__tests__/invite-ipc-routes.test.ts
+++ b/gateway/src/ipc/__tests__/invite-ipc-routes.test.ts
@@ -118,6 +118,21 @@ describe("invites_list", () => {
     expect(listInvitesNativeMock).toHaveBeenCalledTimes(1);
   });
 
+  test("accepts omitted params (no-filter list) and calls native with {}", async () => {
+    listInvitesNativeMock = mock(async () => ({
+      invites: [{ id: "inv_1" }],
+    }));
+    const r = route("invites_list");
+    // The daemon relay's `ipcCallPersistent("invites_list")` sends no params,
+    // so the server validates `undefined` against the schema before the handler.
+    expect(r.schema?.safeParse(undefined).success).toBe(true);
+
+    const result = await r.handler(undefined);
+    expect(result).toEqual({ invites: [{ id: "inv_1" }] });
+    expect(listInvitesNativeMock).toHaveBeenCalledTimes(1);
+    expect(listInvitesNativeMock.mock.calls[0][0]).toEqual({});
+  });
+
   test("passes sourceChannel + status through to the native function", async () => {
     const r = route("invites_list");
     expect(

--- a/gateway/src/ipc/__tests__/invite-ipc-routes.test.ts
+++ b/gateway/src/ipc/__tests__/invite-ipc-routes.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Tests for the gateway invite CRUD IPC routes (invites_list / invites_create /
+ * invites_revoke / invites_trigger_call).
+ *
+ * Each route is driven directly through its handler. The shared native
+ * functions from the HTTP module are mocked so these tests focus on the IPC
+ * concerns: param validation (bad params throw) and that each route delegates
+ * to its native function with the right params + returns its result shape.
+ *
+ * Behavioral parity of the native functions themselves with the HTTP handlers
+ * is covered by contacts-control-plane-proxy.test.ts (which exercises the same
+ * functions through the HTTP handlers).
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ── Native function mocks (the single shared implementation) ──────────────────
+type ListFn = (query: unknown) => Promise<{
+  invites: Array<Record<string, unknown>>;
+}>;
+let listInvitesNativeMock: ReturnType<typeof mock<ListFn>> = mock(async () => ({
+  invites: [],
+}));
+
+type CreateFn = (input: unknown) => Promise<{
+  invite: Record<string, unknown>;
+  rawToken?: string;
+}>;
+let createInviteNativeMock: ReturnType<typeof mock<CreateFn>> = mock(
+  async () => ({ invite: { id: "inv_1" }, rawToken: "raw" }),
+);
+
+type RevokeFn = (id: string) => Promise<{ invite: Record<string, unknown> }>;
+let revokeInviteNativeMock: ReturnType<typeof mock<RevokeFn>> = mock(
+  async () => ({ invite: { id: "inv_1", status: "revoked" } }),
+);
+
+type TriggerFn = (id: string) => Promise<{ callSid: string }>;
+let triggerInviteCallNativeMock: ReturnType<typeof mock<TriggerFn>> = mock(
+  async () => ({ callSid: "CA123" }),
+);
+
+mock.module("../../http/routes/contacts-control-plane-proxy.js", () => ({
+  listInvitesNative: (...args: Parameters<ListFn>) =>
+    listInvitesNativeMock(...args),
+  createInviteNative: (...args: Parameters<CreateFn>) =>
+    createInviteNativeMock(...args),
+  revokeInviteNative: (...args: Parameters<RevokeFn>) =>
+    revokeInviteNativeMock(...args),
+  triggerInviteCallNative: (...args: Parameters<TriggerFn>) =>
+    triggerInviteCallNativeMock(...args),
+}));
+
+// ContactStore is only touched by the record_invite_redemption route; stub it
+// so importing the module never opens a real DB.
+mock.module("../db/contact-store.js", () => ({
+  ContactStore: class MockContactStore {
+    recordInviteRedemption() {
+      return { updated: true, row: null };
+    }
+  },
+}));
+
+const { inviteRoutes } = await import("../invite-handlers.js");
+
+function route(method: string) {
+  const found = inviteRoutes.find((r) => r.method === method);
+  if (!found) throw new Error(`route not registered: ${method}`);
+  return found;
+}
+
+beforeEach(() => {
+  listInvitesNativeMock = mock(async () => ({ invites: [] }));
+  createInviteNativeMock = mock(async () => ({
+    invite: { id: "inv_1" },
+    rawToken: "raw",
+  }));
+  revokeInviteNativeMock = mock(async () => ({
+    invite: { id: "inv_1", status: "revoked" },
+  }));
+  triggerInviteCallNativeMock = mock(async () => ({ callSid: "CA123" }));
+});
+
+describe("invite CRUD IPC routes registration", () => {
+  test("registers all four CRUD methods alongside record_invite_redemption", () => {
+    const methods = inviteRoutes.map((r) => r.method);
+    expect(methods).toContain("record_invite_redemption");
+    expect(methods).toContain("invites_list");
+    expect(methods).toContain("invites_create");
+    expect(methods).toContain("invites_revoke");
+    expect(methods).toContain("invites_trigger_call");
+    // No redeem IPC method — redemption stays on record_invite_redemption.
+    expect(methods).not.toContain("invites_redeem");
+  });
+
+  test("every CRUD route carries a Zod param schema", () => {
+    for (const m of [
+      "invites_list",
+      "invites_create",
+      "invites_revoke",
+      "invites_trigger_call",
+    ]) {
+      expect(route(m).schema).toBeDefined();
+    }
+  });
+});
+
+describe("invites_list", () => {
+  test("accepts an empty filter and returns { invites }", async () => {
+    listInvitesNativeMock = mock(async () => ({
+      invites: [{ id: "inv_1" }],
+    }));
+    const r = route("invites_list");
+    expect(r.schema?.safeParse({}).success).toBe(true);
+
+    const result = await r.handler({});
+    expect(result).toEqual({ invites: [{ id: "inv_1" }] });
+    expect(listInvitesNativeMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("passes sourceChannel + status through to the native function", async () => {
+    const r = route("invites_list");
+    expect(
+      r.schema?.safeParse({ sourceChannel: "telegram", status: "active" })
+        .success,
+    ).toBe(true);
+    await r.handler({ sourceChannel: "telegram", status: "active" });
+    expect(listInvitesNativeMock.mock.calls[0][0]).toEqual({
+      sourceChannel: "telegram",
+      status: "active",
+    });
+  });
+
+  test("rejects a non-string status param", () => {
+    expect(route("invites_list").schema?.safeParse({ status: 5 }).success).toBe(
+      false,
+    );
+  });
+});
+
+describe("invites_create", () => {
+  test("validates the create body shape", () => {
+    const schema = route("invites_create").schema;
+    expect(
+      schema?.safeParse({ contactId: "ct_1", sourceChannel: "telegram" })
+        .success,
+    ).toBe(true);
+    // contactId required.
+    expect(schema?.safeParse({ sourceChannel: "telegram" }).success).toBe(
+      false,
+    );
+    // sourceChannel required.
+    expect(schema?.safeParse({ contactId: "ct_1" }).success).toBe(false);
+    // maxUses must be positive.
+    expect(
+      schema?.safeParse({
+        contactId: "ct_1",
+        sourceChannel: "telegram",
+        maxUses: -1,
+      }).success,
+    ).toBe(false);
+  });
+
+  test("delegates to createInviteNative and returns the minted payload", async () => {
+    createInviteNativeMock = mock(async () => ({
+      invite: { id: "inv_1", inviteCode: "123456" },
+      rawToken: "raw-token-abc",
+    }));
+    const result = await route("invites_create").handler({
+      contactId: "ct_1",
+      sourceChannel: "telegram",
+      note: "hi",
+    });
+    expect(result).toEqual({
+      invite: { id: "inv_1", inviteCode: "123456" },
+      rawToken: "raw-token-abc",
+    });
+    expect(createInviteNativeMock.mock.calls[0][0]).toMatchObject({
+      contactId: "ct_1",
+      sourceChannel: "telegram",
+      note: "hi",
+    });
+  });
+
+  test("throws on invalid params (no native call)", async () => {
+    await expect(
+      route("invites_create").handler({ sourceChannel: "telegram" }),
+    ).rejects.toThrow();
+    expect(createInviteNativeMock).not.toHaveBeenCalled();
+  });
+
+  test("propagates a native error (e.g. contact not found)", async () => {
+    createInviteNativeMock = mock(async () => {
+      throw new Error('Contact "ct_x" not found');
+    });
+    await expect(
+      route("invites_create").handler({
+        contactId: "ct_x",
+        sourceChannel: "telegram",
+      }),
+    ).rejects.toThrow(/not found/);
+  });
+});
+
+describe("invites_revoke", () => {
+  test("requires a non-empty id", () => {
+    const schema = route("invites_revoke").schema;
+    expect(schema?.safeParse({ id: "inv_1" }).success).toBe(true);
+    expect(schema?.safeParse({ id: "" }).success).toBe(false);
+    expect(schema?.safeParse({}).success).toBe(false);
+  });
+
+  test("delegates to revokeInviteNative and returns the sanitized invite", async () => {
+    revokeInviteNativeMock = mock(async () => ({
+      invite: { id: "inv_9", status: "revoked" },
+    }));
+    const result = await route("invites_revoke").handler({ id: "inv_9" });
+    expect(result).toEqual({ invite: { id: "inv_9", status: "revoked" } });
+    expect(revokeInviteNativeMock.mock.calls[0][0]).toBe("inv_9");
+  });
+
+  test("throws on missing id (no native call)", async () => {
+    await expect(route("invites_revoke").handler({})).rejects.toThrow();
+    expect(revokeInviteNativeMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("invites_trigger_call", () => {
+  test("requires a non-empty id", () => {
+    const schema = route("invites_trigger_call").schema;
+    expect(schema?.safeParse({ id: "inv_1" }).success).toBe(true);
+    expect(schema?.safeParse({}).success).toBe(false);
+  });
+
+  test("delegates to triggerInviteCallNative and returns { callSid }", async () => {
+    triggerInviteCallNativeMock = mock(async () => ({ callSid: "CA999" }));
+    const result = await route("invites_trigger_call").handler({ id: "inv_1" });
+    expect(result).toEqual({ callSid: "CA999" });
+    expect(triggerInviteCallNativeMock.mock.calls[0][0]).toBe("inv_1");
+  });
+
+  test("propagates a native error (e.g. invite not active)", async () => {
+    triggerInviteCallNativeMock = mock(async () => {
+      throw new Error('Invite "inv_1" is not active');
+    });
+    await expect(
+      route("invites_trigger_call").handler({ id: "inv_1" }),
+    ).rejects.toThrow(/not active/);
+  });
+});

--- a/gateway/src/ipc/__tests__/invite-ipc-routes.test.ts
+++ b/gateway/src/ipc/__tests__/invite-ipc-routes.test.ts
@@ -62,6 +62,7 @@ mock.module("../db/contact-store.js", () => ({
 }));
 
 const { inviteRoutes } = await import("../invite-handlers.js");
+const { buildErrorResponse } = await import("../server.js");
 
 function route(method: string) {
   const found = inviteRoutes.find((r) => r.method === method);
@@ -79,6 +80,66 @@ beforeEach(() => {
     invite: { id: "inv_1", status: "revoked" },
   }));
   triggerInviteCallNativeMock = mock(async () => ({ callSid: "CA123" }));
+});
+
+describe("buildErrorResponse — typed-error envelope preservation", () => {
+  // Mirrors InviteNativeError / IpcHandlerError: both carry
+  // `statusCode: number` + `code: string`. The server duck-types these so any
+  // such typed error preserves its status/code over the IPC wire.
+  class TypedError extends Error {
+    readonly statusCode: number;
+    readonly code: string;
+    constructor(message: string, statusCode: number, code: string) {
+      super(message);
+      this.statusCode = statusCode;
+      this.code = code;
+    }
+  }
+
+  test("includes statusCode + errorCode for a typed error (404)", () => {
+    const err = new TypedError("Contact not found", 404, "NOT_FOUND");
+    const res = buildErrorResponse("req-1", err);
+    expect(res).toEqual({
+      id: "req-1",
+      error: String(err),
+      statusCode: 404,
+      errorCode: "NOT_FOUND",
+    });
+  });
+
+  test("includes statusCode + errorCode for a 400 user-error", () => {
+    const err = new TypedError("Invite expired", 400, "INVALID_INVITE");
+    const res = buildErrorResponse("req-2", err);
+    expect(res.statusCode).toBe(400);
+    expect(res.errorCode).toBe("INVALID_INVITE");
+    expect(res.error).toBe(String(err));
+  });
+
+  test("mirrors a structured `details` payload into errorDetails", () => {
+    const err = Object.assign(
+      new TypedError("Conflict", 409, "CONFLICT"),
+      { details: { reason: "already_revoked" } },
+    );
+    const res = buildErrorResponse("req-3", err);
+    expect(res.errorDetails).toEqual({ reason: "already_revoked" });
+  });
+
+  test("plain Error serializes as just { id, error } — no spurious fields", () => {
+    const res = buildErrorResponse("req-4", new Error("boom"));
+    expect(res).toEqual({ id: "req-4", error: "Error: boom" });
+    expect("statusCode" in res).toBe(false);
+    expect("errorCode" in res).toBe(false);
+    expect("errorDetails" in res).toBe(false);
+  });
+
+  test("ignores non-numeric statusCode / non-string code (backward compatible)", () => {
+    const err = Object.assign(new Error("weird"), {
+      statusCode: "503",
+      code: 42,
+    });
+    const res = buildErrorResponse("req-5", err);
+    expect(res).toEqual({ id: "req-5", error: "Error: weird" });
+  });
 });
 
 describe("invite CRUD IPC routes registration", () => {

--- a/gateway/src/ipc/invite-handlers.ts
+++ b/gateway/src/ipc/invite-handlers.ts
@@ -8,11 +8,48 @@
  * authoritative lifecycle gate (no separate check-then-act window). This keeps
  * the gateway invite row authoritative across every runtime redemption path
  * (token + 6-digit channel intercepts, voice relay, HTTP).
+ *
+ * ───────────────────────────────────────────────────────────────────────────
+ * Invite CRUD IPC contract (the daemon CLI relay — see contacts-gw-native-
+ * invites PR 5 — calls these via `ipcCallPersistent`; KEEP STABLE):
+ *
+ *   invites_list
+ *     params : { sourceChannel?: string; status?: string }
+ *     returns: { invites: Array<Record<string, unknown>> }   (sanitized — no
+ *              inviteCodeHash; gateway rows + voice join + assistant-only merge)
+ *
+ *   invites_create
+ *     params : { contactId: string; sourceChannel: string; note?: string;
+ *                maxUses?: number; expiresInMs?: number; contactName?: string;
+ *                expectedExternalUserId?: string; voiceCodeDigits?: number;
+ *                friendName?: string; guardianName?: string }
+ *     returns: { invite: Record<string, unknown>; rawToken?: string }
+ *              (the assistant's one-time minted payload)
+ *
+ *   invites_revoke
+ *     params : { id: string }
+ *     returns: { invite: Record<string, unknown> }            (sanitized)
+ *
+ *   invites_trigger_call
+ *     params : { id: string }
+ *     returns: { callSid: string }
+ *
+ * All four delegate to the SAME native functions the gateway HTTP invite
+ * handlers use (gateway/src/http/routes/contacts-control-plane-proxy.ts), which
+ * throw InviteNativeError / IpcHandlerError on failure. The IPC server
+ * stringifies a thrown error into the wire `error` field.
+ * ───────────────────────────────────────────────────────────────────────────
  */
 
 import { z } from "zod";
 
 import { ContactStore } from "../db/contact-store.js";
+import {
+  createInviteNative,
+  listInvitesNative,
+  revokeInviteNative,
+  triggerInviteCallNative,
+} from "../http/routes/contacts-control-plane-proxy.js";
 import type { IpcRoute } from "./server.js";
 
 let store: ContactStore | null = null;
@@ -28,6 +65,33 @@ const RecordInviteRedemptionParamsSchema = z.object({
   inviteId: z.string().min(1),
   redeemedByExternalUserId: z.string().nullish(),
   redeemedByExternalChatId: z.string().nullish(),
+});
+
+const positiveNumber = z
+  .number()
+  .refine((n) => Number.isFinite(n) && n > 0, "must be a positive number");
+
+const ListInvitesParamsSchema = z.object({
+  sourceChannel: z.string().optional(),
+  status: z.string().optional(),
+});
+
+// Mirrors createInviteSchema in http/routes/invite-validation.ts.
+const CreateInviteParamsSchema = z.object({
+  contactId: z.string().trim().min(1, "contactId is required"),
+  sourceChannel: z.string().trim().min(1, "sourceChannel is required"),
+  note: z.string().optional(),
+  maxUses: positiveNumber.optional(),
+  expiresInMs: positiveNumber.optional(),
+  contactName: z.string().optional(),
+  expectedExternalUserId: z.string().optional(),
+  voiceCodeDigits: positiveNumber.optional(),
+  friendName: z.string().optional(),
+  guardianName: z.string().optional(),
+});
+
+const InviteIdParamsSchema = z.object({
+  id: z.string().min(1),
 });
 
 export const inviteRoutes: IpcRoute[] = [
@@ -52,6 +116,46 @@ export const inviteRoutes: IpcRoute[] = [
         updated: result.updated,
         mirrored: result.row !== null,
       };
+    },
+  },
+  {
+    // Gateway rows (lifecycle truth) + best-effort voice-field join +
+    // assistant-only merge, sanitized (no inviteCodeHash). Shares the HTTP
+    // list native implementation.
+    method: "invites_list",
+    schema: ListInvitesParamsSchema,
+    handler: async (params?: Record<string, unknown>) => {
+      const query = ListInvitesParamsSchema.parse(params ?? {});
+      return await listInvitesNative(query);
+    },
+  },
+  {
+    // Verify contact → relay assistant mint → write canonical gateway row.
+    // Returns the assistant's one-time minted payload + rawToken.
+    method: "invites_create",
+    schema: CreateInviteParamsSchema,
+    handler: async (params?: Record<string, unknown>) => {
+      const input = CreateInviteParamsSchema.parse(params);
+      return await createInviteNative(input);
+    },
+  },
+  {
+    // Flip the gateway row (then mirror to assistant DB), or fall back to the
+    // assistant-only row. Returns the sanitized invite.
+    method: "invites_revoke",
+    schema: InviteIdParamsSchema,
+    handler: async (params?: Record<string, unknown>) => {
+      const { id } = InviteIdParamsSchema.parse(params);
+      return await revokeInviteNative(id);
+    },
+  },
+  {
+    // Gate on active gateway row → relay the outbound call to the assistant.
+    method: "invites_trigger_call",
+    schema: InviteIdParamsSchema,
+    handler: async (params?: Record<string, unknown>) => {
+      const { id } = InviteIdParamsSchema.parse(params);
+      return await triggerInviteCallNative(id);
     },
   },
 ];

--- a/gateway/src/ipc/invite-handlers.ts
+++ b/gateway/src/ipc/invite-handlers.ts
@@ -71,10 +71,18 @@ const positiveNumber = z
   .number()
   .refine((n) => Number.isFinite(n) && n > 0, "must be a positive number");
 
-const ListInvitesParamsSchema = z.object({
-  sourceChannel: z.string().optional(),
-  status: z.string().optional(),
-});
+// The no-filter list is the common case; the daemon relay calls
+// `ipcCallPersistent("invites_list")` with no params (req.params === undefined).
+// The server validates req.params against this schema BEFORE the handler runs,
+// so the schema must accept omitted/undefined params and default them to {}.
+// Field validations stay intact for when params ARE provided.
+const ListInvitesParamsSchema = z.preprocess(
+  (v) => v ?? {},
+  z.object({
+    sourceChannel: z.string().optional(),
+    status: z.string().optional(),
+  }),
+);
 
 // Mirrors createInviteSchema in http/routes/invite-validation.ts.
 const CreateInviteParamsSchema = z.object({

--- a/gateway/src/ipc/invite-handlers.ts
+++ b/gateway/src/ipc/invite-handlers.ts
@@ -10,8 +10,8 @@
  * (token + 6-digit channel intercepts, voice relay, HTTP).
  *
  * ───────────────────────────────────────────────────────────────────────────
- * Invite CRUD IPC contract (the daemon CLI relay — see contacts-gw-native-
- * invites PR 5 — calls these via `ipcCallPersistent`; KEEP STABLE):
+ * Invite CRUD IPC contract (the daemon CLI relay calls these via
+ * `ipcCallPersistent`; KEEP STABLE):
  *
  *   invites_list
  *     params : { sourceChannel?: string; status?: string }

--- a/gateway/src/ipc/server.ts
+++ b/gateway/src/ipc/server.ts
@@ -42,10 +42,28 @@ export type IpcRequest = {
   params?: Record<string, unknown>;
 };
 
+/**
+ * NDJSON IPC response envelope.
+ *
+ * Error responses are ADDITIVE: a thrown error that carries a numeric
+ * `statusCode` and/or a string error code is mirrored into `statusCode`/
+ * `errorCode` (and `errorDetails` when present) ALONGSIDE the existing
+ * `error` string. Errors without those fields serialize exactly as before
+ * (just `{ id, error }`), so consumers reading only `error` keep working.
+ * The PR 5 daemon relay (`PersistentIpcClient.call`) reads `statusCode`/
+ * `errorCode`/`errorDetails` to surface invite user-errors (4xx) instead of
+ * statusless IPC failures.
+ */
 export type IpcResponse = {
   id: string;
   result?: unknown;
   error?: string;
+  /** HTTP-style status code mirrored from a typed error's `statusCode`. */
+  statusCode?: number;
+  /** Machine-readable error code mirrored from a typed error's `code`. */
+  errorCode?: string;
+  /** Structured error payload mirrored from a typed error's `details`. */
+  errorDetails?: unknown;
 };
 
 export type IpcEvent = {
@@ -319,20 +337,14 @@ export class GatewayIpcServer {
           })
           .catch((err) => {
             log.warn({ err, method: req.method }, "IPC handler error");
-            this.sendResponse(socket, {
-              id: req.id,
-              error: String(err),
-            });
+            this.sendResponse(socket, buildErrorResponse(req.id, err));
           });
       } else {
         this.sendResponse(socket, { id: req.id, result });
       }
     } catch (err) {
       log.warn({ err, method: req.method }, "IPC handler error");
-      this.sendResponse(socket, {
-        id: req.id,
-        error: String(err),
-      });
+      this.sendResponse(socket, buildErrorResponse(req.id, err));
     }
   }
 
@@ -349,4 +361,26 @@ export class GatewayIpcServer {
 
 export function getDefaultSocketPath(): string {
   return resolveIpcSocketPath("gateway").path;
+}
+
+/**
+ * Build the IPC error envelope for a thrown handler error.
+ *
+ * Always includes `error: String(err)`. When the error DUCK-TYPES as a
+ * client-facing typed error — a numeric `statusCode` and/or a string `code`
+ * — those are mirrored ADDITIVELY into `statusCode`/`errorCode` (and
+ * `errorDetails` from `details` when present). This covers both
+ * `InviteNativeError` and the assistant `IpcHandlerError` (and any future
+ * typed error) without importing or requiring a specific class. Plain
+ * `Error`s serialize as before: just `{ id, error }`.
+ */
+export function buildErrorResponse(id: string, err: unknown): IpcResponse {
+  const response: IpcResponse = { id, error: String(err) };
+  if (err && typeof err === "object") {
+    const e = err as { statusCode?: unknown; code?: unknown; details?: unknown };
+    if (typeof e.statusCode === "number") response.statusCode = e.statusCode;
+    if (typeof e.code === "string") response.errorCode = e.code;
+    if (e.details !== undefined) response.errorDetails = e.details;
+  }
+  return response;
 }


### PR DESCRIPTION
## Summary
- Add invites_list/create/revoke/trigger_call gateway IPC methods sharing one native implementation with the HTTP handlers
- Enables the daemon CLI invite handlers to relay to the gateway (PR 5)

Part of plan: contacts-gw-native-invites.md (PR 6 of 6)