### PR TITLE
feat(assistant): relay CLI invite IPC handlers to the gateway

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5270,6 +5270,9 @@ paths:
                     properties: {}
                     additionalProperties: {}
                     description: Created invite
+                  rawToken:
+                    description: One-time raw invite token (returned at creation only)
+                    type: string
                 required:
                   - ok
                   - invite

--- a/assistant/src/__tests__/invite-routes-http.test.ts
+++ b/assistant/src/__tests__/invite-routes-http.test.ts
@@ -37,14 +37,14 @@ mock.module("../calls/call-domain.js", () => ({
 import { upsertContact } from "../contacts/contact-store.js";
 import { getSqlite } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
-import { handleRedeemInvite as _handleRedeemInvite } from "../runtime/routes/contact-routes.js";
-import { RouteError } from "../runtime/routes/errors.js";
 import {
   createIngressInvite,
   listIngressInvites,
   revokeIngressInvite,
   triggerInviteCall,
 } from "../runtime/invite-service.js";
+import { handleRedeemInvite as _handleRedeemInvite } from "../runtime/routes/contact-routes.js";
+import { RouteError } from "../runtime/routes/errors.js";
 
 /**
  * The CLI/HTTP create/list/revoke/trigger route handlers now relay to the

--- a/assistant/src/__tests__/invite-routes-http.test.ts
+++ b/assistant/src/__tests__/invite-routes-http.test.ts
@@ -37,58 +37,58 @@ mock.module("../calls/call-domain.js", () => ({
 import { upsertContact } from "../contacts/contact-store.js";
 import { getSqlite } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
-import {
-  handleCreateInvite as _handleCreateInvite,
-  handleListInvites as _handleListInvites,
-  handleRedeemInvite as _handleRedeemInvite,
-  handleRevokeInvite as _handleRevokeInvite,
-  handleTriggerInviteCall as _handleTriggerInviteCall,
-} from "../runtime/routes/contact-routes.js";
+import { handleRedeemInvite as _handleRedeemInvite } from "../runtime/routes/contact-routes.js";
 import { RouteError } from "../runtime/routes/errors.js";
+import {
+  createIngressInvite,
+  listIngressInvites,
+  revokeIngressInvite,
+  triggerInviteCall,
+} from "../runtime/invite-service.js";
 
 /**
- * Compatibility wrappers: translate old handler call signatures into the new
- * RouteHandlerArgs pattern and wrap the result in a Response-like object so
- * existing test assertions (res.status / res.json()) keep working.
+ * The CLI/HTTP create/list/revoke/trigger route handlers now relay to the
+ * gateway (see invite-relay-routes.test.ts). The assistant-native invite logic
+ * those handlers used to call directly — and which the gateway still invokes via
+ * `invites_mint` + its native handlers — is exercised here against the assistant
+ * DB through the `invite-service` functions. Redemption stays daemon-local and is
+ * still driven through the route handler.
  */
 function fakeResponse(body: unknown, status = 200) {
   return { status, json: async () => body };
 }
 
 async function handleCreateInvite(req: Request) {
-  const body = (await req.json()) as Record<string, unknown>;
-  try {
-    const result = await _handleCreateInvite({ body });
-    return fakeResponse(result, 201);
-  } catch (err) {
-    if (err instanceof RouteError)
-      return fakeResponse({ ok: false, error: err.message }, err.statusCode);
-    throw err;
-  }
+  const body = (await req.json()) as Record<string, string | number>;
+  const result = await createIngressInvite({
+    sourceChannel: body.sourceChannel as string | undefined,
+    note: body.note as string | undefined,
+    maxUses: body.maxUses as number | undefined,
+    expiresInMs: body.expiresInMs as number | undefined,
+    contactName: body.contactName as string | undefined,
+    expectedExternalUserId: body.expectedExternalUserId as string | undefined,
+    voiceCodeDigits: body.voiceCodeDigits as number | undefined,
+    friendName: body.friendName as string | undefined,
+    guardianName: body.guardianName as string | undefined,
+    contactId: body.contactId as string,
+  });
+  if (!result.ok) return fakeResponse({ ok: false, error: result.error }, 400);
+  return fakeResponse({ ok: true, invite: result.data }, 201);
 }
 
 function handleListInvites(url: URL) {
-  const queryParams: Record<string, string> = {};
-  for (const [k, v] of url.searchParams.entries()) queryParams[k] = v;
-  try {
-    const result = _handleListInvites({ queryParams });
-    return fakeResponse(result);
-  } catch (err) {
-    if (err instanceof RouteError)
-      return fakeResponse({ ok: false, error: err.message }, err.statusCode);
-    throw err;
-  }
+  const result = listIngressInvites({
+    sourceChannel: url.searchParams.get("sourceChannel") ?? undefined,
+    status: url.searchParams.get("status") ?? undefined,
+  });
+  if (!result.ok) return fakeResponse({ ok: false, error: result.error }, 400);
+  return fakeResponse({ ok: true, invites: result.data });
 }
 
 function handleRevokeInvite(inviteId: string) {
-  try {
-    const result = _handleRevokeInvite({ pathParams: { id: inviteId } });
-    return fakeResponse(result);
-  } catch (err) {
-    if (err instanceof RouteError)
-      return fakeResponse({ ok: false, error: err.message }, err.statusCode);
-    throw err;
-  }
+  const result = revokeIngressInvite(inviteId);
+  if (!result.ok) return fakeResponse({ ok: false, error: result.error }, 404);
+  return fakeResponse({ ok: true, invite: result.data });
 }
 
 async function handleRedeemInvite(req: Request) {
@@ -104,16 +104,9 @@ async function handleRedeemInvite(req: Request) {
 }
 
 async function handleTriggerInviteCall(inviteId: string) {
-  try {
-    const result = await _handleTriggerInviteCall({
-      pathParams: { id: inviteId },
-    });
-    return fakeResponse(result);
-  } catch (err) {
-    if (err instanceof RouteError)
-      return fakeResponse({ ok: false, error: err.message }, err.statusCode);
-    throw err;
-  }
+  const result = await triggerInviteCall(inviteId);
+  if (!result.ok) return fakeResponse({ ok: false, error: result.error }, 400);
+  return fakeResponse({ ok: true, callSid: result.data.callSid });
 }
 
 await initializeDb();

--- a/assistant/src/runtime/routes/__tests__/invite-relay-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/invite-relay-routes.test.ts
@@ -1,11 +1,13 @@
 /**
  * Unit tests for the CLI invite relay routes.
  *
- * The four CLI invite handlers (list/create/revoke/trigger_call) are thin
- * relays to the gateway IPC methods via `ipcCallPersistent`. These tests assert
- * each relays with the correct method + params, returns the parsed gateway
- * response, never writes the assistant invite store directly, and surfaces a
- * relayed IpcCallError with its statusCode. `invites_redeem` stays daemon-local.
+ * Three CLI invite handlers (list/create/revoke) are thin relays to the gateway
+ * IPC methods via `ipcCallPersistent`. These tests assert each relays with the
+ * correct method + params, returns the parsed gateway response, never writes the
+ * assistant invite store directly, and surfaces a relayed IpcCallError with its
+ * statusCode. `invites_redeem` and `invites_trigger_call` stay daemon-local: the
+ * gateway delegates the actual provider call to the daemon-local handler, so
+ * relaying it back would loop gateway→assistant→gateway.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -52,6 +54,18 @@ mock.module("../../../memory/invite-store.js", () => ({
   revokeInvite: inviteStoreCall,
 }));
 
+// `invites_trigger_call` is daemon-local: the handler invokes the local
+// `triggerInviteCall` provider logic directly (never `ipcCallPersistent`).
+let triggerInviteCallResult: unknown = { ok: true, data: { callSid: "CA000" } };
+const triggerInviteCallMock = mock(async (_id: string) => triggerInviteCallResult);
+
+const actualInviteService = await import("../../invite-service.js");
+
+mock.module("../../invite-service.js", () => ({
+  ...actualInviteService,
+  triggerInviteCall: triggerInviteCallMock,
+}));
+
 const {
   handleListInvites,
   handleCreateInvite,
@@ -67,6 +81,8 @@ describe("invite relay routes", () => {
     ipcError = undefined;
     ipcCallPersistentMock.mockClear();
     inviteStoreCall.mockClear();
+    triggerInviteCallResult = { ok: true, data: { callSid: "CA000" } };
+    triggerInviteCallMock.mockClear();
   });
 
   describe("handleListInvites", () => {
@@ -157,16 +173,31 @@ describe("invite relay routes", () => {
     });
   });
 
-  describe("handleTriggerInviteCall", () => {
-    test("relays invites_trigger_call and returns callSid", async () => {
-      ipcResult = { callSid: "CA123" };
+  describe("handleTriggerInviteCall (daemon-local carve-out)", () => {
+    test("invokes the local triggerInviteCall and does NOT relay to the gateway", async () => {
+      triggerInviteCallResult = { ok: true, data: { callSid: "CA123" } };
       const result = await handleTriggerInviteCall({ pathParams: { id: "i7" } });
 
-      expect(ipcCalls).toEqual([
-        { method: "invites_trigger_call", params: { id: "i7" } },
-      ]);
+      expect(triggerInviteCallMock).toHaveBeenCalledTimes(1);
+      expect(triggerInviteCallMock).toHaveBeenCalledWith("i7");
+      // Must NOT relay: relaying invites_trigger_call would loop
+      // gateway→assistant→gateway (the gateway calls THIS to place the call).
+      expect(ipcCalls).toEqual([]);
       expect(result).toEqual({ ok: true, callSid: "CA123" });
-      expect(inviteStoreCall).not.toHaveBeenCalled();
+    });
+
+    test("surfaces a failed provider call as a 400", async () => {
+      triggerInviteCallResult = { ok: false, error: "Invite not eligible" };
+
+      try {
+        await handleTriggerInviteCall({ pathParams: { id: "i7" } });
+        throw new Error("expected handler to throw");
+      } catch (err) {
+        const e = err as { statusCode?: number; message: string };
+        expect(e.message).toBe("Invite not eligible");
+        expect(e.statusCode).toBe(400);
+      }
+      expect(ipcCalls).toEqual([]);
     });
   });
 

--- a/assistant/src/runtime/routes/__tests__/invite-relay-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/invite-relay-routes.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Unit tests for the CLI invite relay routes.
+ *
+ * The four CLI invite handlers (list/create/revoke/trigger_call) are thin
+ * relays to the gateway IPC methods via `ipcCallPersistent`. These tests assert
+ * each relays with the correct method + params, returns the parsed gateway
+ * response, never writes the assistant invite store directly, and surfaces a
+ * relayed IpcCallError with its statusCode. `invites_redeem` stays daemon-local.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
+
+type IpcCall = {
+  method: string;
+  params?: Record<string, unknown>;
+};
+
+let ipcCalls: IpcCall[] = [];
+let ipcResult: unknown = {};
+let ipcError: Error | undefined;
+
+const ipcCallPersistentMock = mock(
+  async (method: string, params?: Record<string, unknown>) => {
+    ipcCalls.push({ method, params });
+    if (ipcError) throw ipcError;
+    return ipcResult;
+  },
+);
+
+const actualGatewayClient = await import("../../../ipc/gateway-client.js");
+
+mock.module("../../../ipc/gateway-client.js", () => ({
+  ...actualGatewayClient,
+  ipcCallPersistent: ipcCallPersistentMock,
+}));
+
+// Guard: fail loudly if any relayed handler still writes the assistant invite
+// store directly. The relayed CLI paths must go through the gateway only, so we
+// spy on the store's write functions and assert they are never invoked.
+const actualInviteStore = await import("../../../memory/invite-store.js");
+
+const inviteStoreCall = mock(() => {
+  throw new Error("invite-store write must not happen on relayed CLI paths");
+});
+
+mock.module("../../../memory/invite-store.js", () => ({
+  ...actualInviteStore,
+  createInvite: inviteStoreCall,
+  listInvites: inviteStoreCall,
+  revokeInvite: inviteStoreCall,
+}));
+
+const {
+  handleListInvites,
+  handleCreateInvite,
+  handleRevokeInvite,
+  handleTriggerInviteCall,
+  ROUTES,
+} = await import("../contact-routes.js");
+
+describe("invite relay routes", () => {
+  beforeEach(() => {
+    ipcCalls = [];
+    ipcResult = {};
+    ipcError = undefined;
+    ipcCallPersistentMock.mockClear();
+    inviteStoreCall.mockClear();
+  });
+
+  describe("handleListInvites", () => {
+    test("relays invites_list with filters from queryParams", async () => {
+      ipcResult = { invites: [{ id: "i1" }] };
+      const result = await handleListInvites({
+        queryParams: { sourceChannel: "telegram", status: "active" },
+      });
+
+      expect(ipcCalls).toEqual([
+        {
+          method: "invites_list",
+          params: { sourceChannel: "telegram", status: "active" },
+        },
+      ]);
+      expect(result).toEqual({ ok: true, invites: [{ id: "i1" }] });
+      expect(inviteStoreCall).not.toHaveBeenCalled();
+    });
+
+    test("omits absent filters", async () => {
+      ipcResult = { invites: [] };
+      await handleListInvites({ queryParams: {} });
+
+      expect(ipcCalls).toEqual([{ method: "invites_list", params: {} }]);
+    });
+  });
+
+  describe("handleCreateInvite", () => {
+    test("relays invites_create with mapped body and returns invite + rawToken", async () => {
+      ipcResult = { invite: { id: "i9", token: "tok-9" }, rawToken: "tok-9" };
+      const result = await handleCreateInvite({
+        body: {
+          contactId: "c1",
+          sourceChannel: "telegram",
+          note: "hi",
+          maxUses: 2,
+        },
+      });
+
+      expect(ipcCalls).toEqual([
+        {
+          method: "invites_create",
+          params: {
+            contactId: "c1",
+            sourceChannel: "telegram",
+            note: "hi",
+            maxUses: 2,
+            expiresInMs: undefined,
+            contactName: undefined,
+            expectedExternalUserId: undefined,
+            voiceCodeDigits: undefined,
+            friendName: undefined,
+            guardianName: undefined,
+          },
+        },
+      ]);
+      expect(result).toEqual({
+        ok: true,
+        invite: { id: "i9", token: "tok-9" },
+        rawToken: "tok-9",
+      });
+      expect(inviteStoreCall).not.toHaveBeenCalled();
+    });
+
+    test("omits rawToken when the gateway returns none", async () => {
+      ipcResult = { invite: { id: "i9" } };
+      const result = await handleCreateInvite({
+        body: { contactId: "c1", sourceChannel: "phone" },
+      });
+
+      expect(result).toEqual({ ok: true, invite: { id: "i9" } });
+    });
+  });
+
+  describe("handleRevokeInvite", () => {
+    test("relays invites_revoke with id from pathParams", async () => {
+      ipcResult = { invite: { id: "i3", status: "revoked" } };
+      const result = await handleRevokeInvite({ pathParams: { id: "i3" } });
+
+      expect(ipcCalls).toEqual([
+        { method: "invites_revoke", params: { id: "i3" } },
+      ]);
+      expect(result).toEqual({
+        ok: true,
+        invite: { id: "i3", status: "revoked" },
+      });
+      expect(inviteStoreCall).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("handleTriggerInviteCall", () => {
+    test("relays invites_trigger_call and returns callSid", async () => {
+      ipcResult = { callSid: "CA123" };
+      const result = await handleTriggerInviteCall({ pathParams: { id: "i7" } });
+
+      expect(ipcCalls).toEqual([
+        { method: "invites_trigger_call", params: { id: "i7" } },
+      ]);
+      expect(result).toEqual({ ok: true, callSid: "CA123" });
+      expect(inviteStoreCall).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("error propagation", () => {
+    test("relayed IpcCallError surfaces with its statusCode/errorCode", async () => {
+      ipcError = new IpcCallError("Invite not found", {
+        statusCode: 404,
+        errorCode: "NOT_FOUND",
+      });
+
+      try {
+        await handleRevokeInvite({ pathParams: { id: "missing" } });
+        throw new Error("expected handler to throw");
+      } catch (err) {
+        const e = err as { statusCode?: number; code?: string; message: string };
+        expect(e.message).toBe("Invite not found");
+        expect(e.statusCode).toBe(404);
+        expect(e.code).toBe("NOT_FOUND");
+      }
+    });
+  });
+
+  describe("invites_redeem carve-out", () => {
+    test("redeem route is registered but NOT relayed to the gateway", () => {
+      const redeemRoute = ROUTES.find((r) => r.operationId === "invites_redeem");
+      expect(redeemRoute).toBeDefined();
+      // The redeem handler is daemon-local; it must not appear in the relayed
+      // operation set above. No gateway IPC call is made by registering it.
+      expect(ipcCalls).toEqual([]);
+    });
+  });
+});

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -221,8 +221,8 @@ function handleGetContact(contactId: string) {
 // ---------------------------------------------------------------------------
 
 // The gateway owns the canonical invite write path. These CLI handlers relay
-// to the gateway IPC methods via `ipcCallPersistent` and no longer touch the
-// assistant DB directly. (Redemption stays daemon-local — see the redeem route.)
+// to the gateway IPC methods via `ipcCallPersistent`; the assistant DB is
+// written only by the gateway. (Redemption stays daemon-local — see the redeem route.)
 
 export async function handleListInvites({ queryParams = {} }: RouteHandlerArgs) {
   try {

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -32,6 +32,7 @@ import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
   redeemIngressInvite,
   redeemVoiceInviteCode,
+  triggerInviteCall,
 } from "../invite-service.js";
 import {
   BadRequestError,
@@ -341,17 +342,18 @@ export async function handleRedeemInvite(args: RouteHandlerArgs) {
   return handleRedeemTokenInvite(args);
 }
 
+// Stays daemon-local by design (like invites_redeem): the gateway's call path
+// validates its row then delegates the actual provider call to THIS handler via
+// ipcCallAssistant("invites_trigger_call"). Relaying back would loop
+// gateway→assistant→gateway. The provider call is a daemon capability.
 export async function handleTriggerInviteCall({
   pathParams = {},
 }: RouteHandlerArgs) {
-  try {
-    const result = (await ipcCallPersistent("invites_trigger_call", {
-      id: pathParams.id,
-    })) as { callSid: string };
-    return { ok: true, callSid: result.callSid };
-  } catch (err) {
-    rethrowGatewayError(err);
+  const result = await triggerInviteCall(pathParams.id);
+  if (!result.ok) {
+    throw new BadRequestError(result.error);
   }
+  return { ok: true, callSid: result.data.callSid };
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -8,6 +8,7 @@
  * they don't shadow more-specific sub-paths like contacts/invites.
  */
 
+import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
 import { z } from "zod";
 
 import {
@@ -25,8 +26,6 @@ import type {
   ContactRole,
   ContactType,
 } from "../../contacts/types.js";
-import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
-
 import { ipcCallPersistent } from "../../ipc/gateway-client.js";
 import { resolveGuardianName } from "../../prompts/user-reference.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -25,18 +25,39 @@ import type {
   ContactRole,
   ContactType,
 } from "../../contacts/types.js";
+import { IpcCallError } from "@vellumai/gateway-client/ipc-client";
+
+import { ipcCallPersistent } from "../../ipc/gateway-client.js";
 import { resolveGuardianName } from "../../prompts/user-reference.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
-  createIngressInvite,
-  listIngressInvites,
   redeemIngressInvite,
   redeemVoiceInviteCode,
-  revokeIngressInvite,
-  triggerInviteCall,
 } from "../invite-service.js";
-import { BadRequestError, ConflictError, NotFoundError } from "./errors.js";
+import {
+  BadRequestError,
+  ConflictError,
+  NotFoundError,
+  RouteError,
+} from "./errors.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+/**
+ * Re-throw a relayed gateway `IpcCallError` as a `RouteError` so the IPC/HTTP
+ * adapters honor its statusCode/errorCode (4xx surfaces as 4xx, not a generic
+ * 500). Non-IpcCallError throws propagate unchanged.
+ */
+function rethrowGatewayError(err: unknown): never {
+  if (err instanceof IpcCallError) {
+    throw new RouteError(
+      err.message,
+      err.errorCode ?? "INTERNAL_ERROR",
+      err.statusCode ?? 500,
+      err.errorDetails,
+    );
+  }
+  throw err;
+}
 
 function withGuardianNameOverride<
   T extends { role: string; displayName: string },
@@ -199,45 +220,57 @@ function handleGetContact(contactId: string) {
 // Invite handlers (transport-agnostic)
 // ---------------------------------------------------------------------------
 
-export function handleListInvites({ queryParams = {} }: RouteHandlerArgs) {
-  const result = listIngressInvites({
-    sourceChannel: queryParams.sourceChannel,
-    status: queryParams.status,
-  });
+// The gateway owns the canonical invite write path. These CLI handlers relay
+// to the gateway IPC methods via `ipcCallPersistent` and no longer touch the
+// assistant DB directly. (Redemption stays daemon-local — see the redeem route.)
 
-  if (!result.ok) {
-    throw new BadRequestError(result.error);
+export async function handleListInvites({ queryParams = {} }: RouteHandlerArgs) {
+  try {
+    const result = (await ipcCallPersistent("invites_list", {
+      ...(queryParams.sourceChannel
+        ? { sourceChannel: queryParams.sourceChannel }
+        : {}),
+      ...(queryParams.status ? { status: queryParams.status } : {}),
+    })) as { invites: Array<Record<string, unknown>> };
+    return { ok: true, invites: result.invites };
+  } catch (err) {
+    rethrowGatewayError(err);
   }
-  return { ok: true, invites: result.data };
 }
 
 export async function handleCreateInvite({ body = {} }: RouteHandlerArgs) {
-  const result = await createIngressInvite({
-    sourceChannel: body.sourceChannel as string | undefined,
-    note: body.note as string | undefined,
-    maxUses: body.maxUses as number | undefined,
-    expiresInMs: body.expiresInMs as number | undefined,
-    contactName: body.contactName as string | undefined,
-    expectedExternalUserId: body.expectedExternalUserId as string | undefined,
-    voiceCodeDigits: body.voiceCodeDigits as number | undefined,
-    friendName: body.friendName as string | undefined,
-    guardianName: body.guardianName as string | undefined,
-    contactId: body.contactId as string,
-  });
-
-  if (!result.ok) {
-    throw new BadRequestError(result.error);
+  try {
+    const result = (await ipcCallPersistent("invites_create", {
+      contactId: body.contactId as string,
+      sourceChannel: body.sourceChannel as string | undefined,
+      note: body.note as string | undefined,
+      maxUses: body.maxUses as number | undefined,
+      expiresInMs: body.expiresInMs as number | undefined,
+      contactName: body.contactName as string | undefined,
+      expectedExternalUserId: body.expectedExternalUserId as string | undefined,
+      voiceCodeDigits: body.voiceCodeDigits as number | undefined,
+      friendName: body.friendName as string | undefined,
+      guardianName: body.guardianName as string | undefined,
+    })) as { invite: Record<string, unknown>; rawToken?: string };
+    return {
+      ok: true,
+      invite: result.invite,
+      ...(result.rawToken ? { rawToken: result.rawToken } : {}),
+    };
+  } catch (err) {
+    rethrowGatewayError(err);
   }
-  return { ok: true, invite: result.data };
 }
 
-export function handleRevokeInvite({ pathParams = {} }: RouteHandlerArgs) {
-  const result = revokeIngressInvite(pathParams.id);
-
-  if (!result.ok) {
-    throw new NotFoundError(result.error);
+export async function handleRevokeInvite({ pathParams = {} }: RouteHandlerArgs) {
+  try {
+    const result = (await ipcCallPersistent("invites_revoke", {
+      id: pathParams.id,
+    })) as { invite: Record<string, unknown> };
+    return { ok: true, invite: result.invite };
+  } catch (err) {
+    rethrowGatewayError(err);
   }
-  return { ok: true, invite: result.data };
 }
 
 /**
@@ -312,11 +345,14 @@ export async function handleRedeemInvite(args: RouteHandlerArgs) {
 export async function handleTriggerInviteCall({
   pathParams = {},
 }: RouteHandlerArgs) {
-  const result = await triggerInviteCall(pathParams.id);
-  if (!result.ok) {
-    throw new BadRequestError(result.error);
+  try {
+    const result = (await ipcCallPersistent("invites_trigger_call", {
+      id: pathParams.id,
+    })) as { callSid: string };
+    return { ok: true, callSid: result.callSid };
+  } catch (err) {
+    rethrowGatewayError(err);
   }
-  return { ok: true, callSid: result.data.callSid };
 }
 
 // ---------------------------------------------------------------------------
@@ -445,6 +481,10 @@ export const ROUTES: RouteDefinition[] = [
     responseBody: z.object({
       ok: z.boolean(),
       invite: z.object({}).passthrough().describe("Created invite"),
+      rawToken: z
+        .string()
+        .optional()
+        .describe("One-time raw invite token (returned at creation only)"),
     }),
     additionalResponses: {
       "400": {
@@ -453,6 +493,9 @@ export const ROUTES: RouteDefinition[] = [
     },
   },
   {
+    // Stays daemon-local by design: redemption is an inbound-channel path (not
+    // a CLI ACL surface), and the assistant redemption service already claims
+    // the gateway row by id via record_invite_redemption — relaying would loop.
     operationId: "invites_redeem",
     endpoint: "contacts/invites/redeem",
     method: "POST",

--- a/gateway/src/ipc/__tests__/invite-ipc-routes.test.ts
+++ b/gateway/src/ipc/__tests__/invite-ipc-routes.test.ts
@@ -1,6 +1,11 @@
 /**
  * Tests for the gateway invite CRUD IPC routes (invites_list / invites_create /
- * invites_revoke / invites_trigger_call).
+ * invites_revoke).
+ *
+ * `invites_trigger_call` is intentionally NOT a gateway IPC route: it stays
+ * daemon-local on the assistant. The gateway HTTP call path validates its row
+ * then delegates the provider call to the assistant via triggerInviteCallNative;
+ * relaying it over IPC would loop gateway→assistant→gateway.
  *
  * Each route is driven directly through its handler. The shared native
  * functions from the HTTP module are mocked so these tests focus on the IPC
@@ -35,11 +40,6 @@ let revokeInviteNativeMock: ReturnType<typeof mock<RevokeFn>> = mock(
   async () => ({ invite: { id: "inv_1", status: "revoked" } }),
 );
 
-type TriggerFn = (id: string) => Promise<{ callSid: string }>;
-let triggerInviteCallNativeMock: ReturnType<typeof mock<TriggerFn>> = mock(
-  async () => ({ callSid: "CA123" }),
-);
-
 mock.module("../../http/routes/contacts-control-plane-proxy.js", () => ({
   listInvitesNative: (...args: Parameters<ListFn>) =>
     listInvitesNativeMock(...args),
@@ -47,8 +47,6 @@ mock.module("../../http/routes/contacts-control-plane-proxy.js", () => ({
     createInviteNativeMock(...args),
   revokeInviteNative: (...args: Parameters<RevokeFn>) =>
     revokeInviteNativeMock(...args),
-  triggerInviteCallNative: (...args: Parameters<TriggerFn>) =>
-    triggerInviteCallNativeMock(...args),
 }));
 
 // ContactStore is only touched by the record_invite_redemption route; stub it
@@ -79,7 +77,6 @@ beforeEach(() => {
   revokeInviteNativeMock = mock(async () => ({
     invite: { id: "inv_1", status: "revoked" },
   }));
-  triggerInviteCallNativeMock = mock(async () => ({ callSid: "CA123" }));
 });
 
 describe("buildErrorResponse — typed-error envelope preservation", () => {
@@ -143,24 +140,22 @@ describe("buildErrorResponse — typed-error envelope preservation", () => {
 });
 
 describe("invite CRUD IPC routes registration", () => {
-  test("registers all four CRUD methods alongside record_invite_redemption", () => {
+  test("registers the three CRUD methods alongside record_invite_redemption", () => {
     const methods = inviteRoutes.map((r) => r.method);
     expect(methods).toContain("record_invite_redemption");
     expect(methods).toContain("invites_list");
     expect(methods).toContain("invites_create");
     expect(methods).toContain("invites_revoke");
-    expect(methods).toContain("invites_trigger_call");
     // No redeem IPC method — redemption stays on record_invite_redemption.
     expect(methods).not.toContain("invites_redeem");
+    // invites_trigger_call stays daemon-local on the assistant; relaying it
+    // here would loop gateway→assistant→gateway.
+    expect(methods).not.toContain("invites_trigger_call");
+    expect(inviteRoutes).toHaveLength(4);
   });
 
   test("every CRUD route carries a Zod param schema", () => {
-    for (const m of [
-      "invites_list",
-      "invites_create",
-      "invites_revoke",
-      "invites_trigger_call",
-    ]) {
+    for (const m of ["invites_list", "invites_create", "invites_revoke"]) {
       expect(route(m).schema).toBeDefined();
     }
   });
@@ -298,29 +293,5 @@ describe("invites_revoke", () => {
   test("throws on missing id (no native call)", async () => {
     await expect(route("invites_revoke").handler({})).rejects.toThrow();
     expect(revokeInviteNativeMock).not.toHaveBeenCalled();
-  });
-});
-
-describe("invites_trigger_call", () => {
-  test("requires a non-empty id", () => {
-    const schema = route("invites_trigger_call").schema;
-    expect(schema?.safeParse({ id: "inv_1" }).success).toBe(true);
-    expect(schema?.safeParse({}).success).toBe(false);
-  });
-
-  test("delegates to triggerInviteCallNative and returns { callSid }", async () => {
-    triggerInviteCallNativeMock = mock(async () => ({ callSid: "CA999" }));
-    const result = await route("invites_trigger_call").handler({ id: "inv_1" });
-    expect(result).toEqual({ callSid: "CA999" });
-    expect(triggerInviteCallNativeMock.mock.calls[0][0]).toBe("inv_1");
-  });
-
-  test("propagates a native error (e.g. invite not active)", async () => {
-    triggerInviteCallNativeMock = mock(async () => {
-      throw new Error('Invite "inv_1" is not active');
-    });
-    await expect(
-      route("invites_trigger_call").handler({ id: "inv_1" }),
-    ).rejects.toThrow(/not active/);
   });
 });

--- a/gateway/src/ipc/__tests__/invite-ipc-routes.test.ts
+++ b/gateway/src/ipc/__tests__/invite-ipc-routes.test.ts
@@ -17,7 +17,7 @@
  * functions through the HTTP handlers).
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ── Native function mocks (the single shared implementation) ──────────────────
 type ListFn = (query: unknown) => Promise<{
@@ -60,7 +60,8 @@ mock.module("../db/contact-store.js", () => ({
 }));
 
 const { inviteRoutes } = await import("../invite-handlers.js");
-const { buildErrorResponse } = await import("../server.js");
+const { buildErrorResponse, buildProtocolErrorResponse, GatewayIpcServer } =
+  await import("../server.js");
 
 function route(method: string) {
   const found = inviteRoutes.find((r) => r.method === method);
@@ -136,6 +137,138 @@ describe("buildErrorResponse — typed-error envelope preservation", () => {
     });
     const res = buildErrorResponse("req-5", err);
     expect(res).toEqual({ id: "req-5", error: "Error: weird" });
+  });
+});
+
+describe("buildProtocolErrorResponse — early-return validation envelope", () => {
+  test("stamps statusCode + errorCode while preserving the error string", () => {
+    const res = buildProtocolErrorResponse(
+      "req-1",
+      "Invalid params: bad",
+      400,
+      "BAD_REQUEST",
+    );
+    expect(res).toEqual({
+      id: "req-1",
+      error: "Invalid params: bad",
+      statusCode: 400,
+      errorCode: "BAD_REQUEST",
+    });
+  });
+
+  test("supports a 404 for unknown methods", () => {
+    const res = buildProtocolErrorResponse(
+      "req-2",
+      "Unknown method: nope",
+      404,
+      "UNKNOWN_METHOD",
+    );
+    expect(res.statusCode).toBe(404);
+    expect(res.errorCode).toBe("UNKNOWN_METHOD");
+  });
+});
+
+describe("GatewayIpcServer — protocol/validation errors carry status codes", () => {
+  // Drive the server through a real Unix-domain-socket round-trip so the
+  // early-return validation paths (Invalid JSON / missing fields / unknown
+  // method / Zod rejection) are exercised exactly as the daemon relay hits
+  // them. The relay maps `statusCode` → RouteError, so these must NOT be 500.
+  let server: InstanceType<typeof GatewayIpcServer>;
+  let socketDir: string;
+  let prevEnv: string | undefined;
+
+  async function rpc(line: string): Promise<Record<string, unknown>> {
+    const { connect } = await import("node:net");
+    return await new Promise((resolve, reject) => {
+      const sock = connect(server.getSocketPath());
+      let buf = "";
+      sock.on("connect", () => sock.write(line + "\n"));
+      sock.on("data", (chunk) => {
+        buf += chunk.toString();
+        const nl = buf.indexOf("\n");
+        if (nl !== -1) {
+          sock.end();
+          resolve(JSON.parse(buf.slice(0, nl)));
+        }
+      });
+      sock.on("error", reject);
+    });
+  }
+
+  beforeEach(async () => {
+    const { mkdtempSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    socketDir = mkdtempSync(join(tmpdir(), "vellum-ipc-test-"));
+    prevEnv = process.env.GATEWAY_IPC_SOCKET_DIR;
+    process.env.GATEWAY_IPC_SOCKET_DIR = socketDir;
+    // Disable the watchdog so the test has a single deterministic listener.
+    server = new GatewayIpcServer(inviteRoutes, { watchdogIntervalMs: 0 });
+    server.start();
+    // Wait for the listener to bind.
+    const { existsSync } = await import("node:fs");
+    for (let i = 0; i < 100 && !existsSync(server.getSocketPath()); i++) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+  });
+
+  afterEach(async () => {
+    server.stop();
+    if (prevEnv === undefined) delete process.env.GATEWAY_IPC_SOCKET_DIR;
+    else process.env.GATEWAY_IPC_SOCKET_DIR = prevEnv;
+    const { rmSync } = await import("node:fs");
+    rmSync(socketDir, { recursive: true, force: true });
+  });
+
+  test("Zod schema rejection → 400 BAD_REQUEST + 'Invalid params'", async () => {
+    // invites_create requires contactId + sourceChannel; omit sourceChannel.
+    const res = await rpc(
+      JSON.stringify({
+        id: "r1",
+        method: "invites_create",
+        params: { contactId: "ct_1" },
+      }),
+    );
+    expect(res.id).toBe("r1");
+    expect(res.statusCode).toBe(400);
+    expect(res.errorCode).toBe("BAD_REQUEST");
+    expect(String(res.error)).toContain("Invalid params");
+    expect(createInviteNativeMock).not.toHaveBeenCalled();
+  });
+
+  test("maxUses: 0 fails the schema → 400, not 500", async () => {
+    const res = await rpc(
+      JSON.stringify({
+        id: "r2",
+        method: "invites_create",
+        params: { contactId: "ct_1", sourceChannel: "telegram", maxUses: 0 },
+      }),
+    );
+    expect(res.statusCode).toBe(400);
+    expect(res.statusCode).not.toBe(500);
+  });
+
+  test("unknown method → 404 UNKNOWN_METHOD", async () => {
+    const res = await rpc(
+      JSON.stringify({ id: "r3", method: "does_not_exist" }),
+    );
+    expect(res.statusCode).toBe(404);
+    expect(res.errorCode).toBe("UNKNOWN_METHOD");
+    expect(String(res.error)).toContain("Unknown method");
+  });
+
+  test("invalid JSON → 400 BAD_REQUEST", async () => {
+    const res = await rpc("{not json");
+    expect(res.statusCode).toBe(400);
+    expect(res.errorCode).toBe("BAD_REQUEST");
+    expect(res.error).toBe("Invalid JSON");
+  });
+
+  test("missing 'id'/'method' → 400 BAD_REQUEST", async () => {
+    const res = await rpc(JSON.stringify({ id: "r5" }));
+    expect(res.statusCode).toBe(400);
+    expect(res.errorCode).toBe("BAD_REQUEST");
+    expect(res.error).toBe("Missing 'id' or 'method' field");
   });
 });
 

--- a/gateway/src/ipc/invite-handlers.ts
+++ b/gateway/src/ipc/invite-handlers.ts
@@ -30,11 +30,12 @@
  *     params : { id: string }
  *     returns: { invite: Record<string, unknown> }            (sanitized)
  *
- *   invites_trigger_call
- *     params : { id: string }
- *     returns: { callSid: string }
+ * (Note: invites_trigger_call is NOT relayed here — it stays daemon-local on the
+ * assistant. The gateway HTTP call path validates its row then delegates the
+ * provider call to the assistant via triggerInviteCallNative; relaying it back
+ * over IPC would loop gateway→assistant→gateway.)
  *
- * All four delegate to the SAME native functions the gateway HTTP invite
+ * All three delegate to the SAME native functions the gateway HTTP invite
  * handlers use (gateway/src/http/routes/contacts-control-plane-proxy.ts), which
  * throw InviteNativeError / IpcHandlerError on failure. The IPC server
  * stringifies a thrown error into the wire `error` field.
@@ -48,7 +49,6 @@ import {
   createInviteNative,
   listInvitesNative,
   revokeInviteNative,
-  triggerInviteCallNative,
 } from "../http/routes/contacts-control-plane-proxy.js";
 import type { IpcRoute } from "./server.js";
 
@@ -155,15 +155,6 @@ export const inviteRoutes: IpcRoute[] = [
     handler: async (params?: Record<string, unknown>) => {
       const { id } = InviteIdParamsSchema.parse(params);
       return await revokeInviteNative(id);
-    },
-  },
-  {
-    // Gate on active gateway row → relay the outbound call to the assistant.
-    method: "invites_trigger_call",
-    schema: InviteIdParamsSchema,
-    handler: async (params?: Record<string, unknown>) => {
-      const { id } = InviteIdParamsSchema.parse(params);
-      return await triggerInviteCallNative(id);
     },
   },
 ];

--- a/gateway/src/ipc/server.ts
+++ b/gateway/src/ipc/server.ts
@@ -276,10 +276,10 @@ export class GatewayIpcServer {
     try {
       req = JSON.parse(line) as IpcRequest;
     } catch {
-      this.sendResponse(socket, {
-        id: "unknown",
-        error: "Invalid JSON",
-      });
+      this.sendResponse(
+        socket,
+        buildProtocolErrorResponse("unknown", "Invalid JSON", 400, "BAD_REQUEST"),
+      );
       return;
     }
 
@@ -297,19 +297,29 @@ export class GatewayIpcServer {
         typeof req.id === "string"
           ? req.id
           : "unknown";
-      this.sendResponse(socket, {
-        id,
-        error: "Missing 'id' or 'method' field",
-      });
+      this.sendResponse(
+        socket,
+        buildProtocolErrorResponse(
+          id,
+          "Missing 'id' or 'method' field",
+          400,
+          "BAD_REQUEST",
+        ),
+      );
       return;
     }
 
     const handler = this.methods.get(req.method);
     if (!handler) {
-      this.sendResponse(socket, {
-        id: req.id,
-        error: `Unknown method: ${req.method}`,
-      });
+      this.sendResponse(
+        socket,
+        buildProtocolErrorResponse(
+          req.id,
+          `Unknown method: ${req.method}`,
+          404,
+          "UNKNOWN_METHOD",
+        ),
+      );
       return;
     }
 
@@ -319,10 +329,15 @@ export class GatewayIpcServer {
     if (schema) {
       const result = schema.safeParse(req.params);
       if (!result.success) {
-        this.sendResponse(socket, {
-          id: req.id,
-          error: `Invalid params: ${result.error.message}`,
-        });
+        this.sendResponse(
+          socket,
+          buildProtocolErrorResponse(
+            req.id,
+            `Invalid params: ${result.error.message}`,
+            400,
+            "BAD_REQUEST",
+          ),
+        );
         return;
       }
       parsedParams = result.data as Record<string, unknown>;
@@ -374,6 +389,25 @@ export function getDefaultSocketPath(): string {
  * typed error) without importing or requiring a specific class. Plain
  * `Error`s serialize as before: just `{ id, error }`.
  */
+/**
+ * Build the IPC error envelope for an early-return PROTOCOL/VALIDATION
+ * failure — one detected before any handler runs (bad JSON, missing
+ * `id`/`method`, unknown method, Zod schema rejection).
+ *
+ * Stamps a `statusCode` + `errorCode` so the daemon relay
+ * (`PersistentIpcClient.call` → `IpcCallError` → `RouteError`) surfaces these
+ * as proper client 4xx instead of defaulting to 500. ADDITIVE: the `error`
+ * string is unchanged, so consumers reading only `error` keep working.
+ */
+export function buildProtocolErrorResponse(
+  id: string,
+  error: string,
+  statusCode: number,
+  errorCode: string,
+): IpcResponse {
+  return { id, error, statusCode, errorCode };
+}
+
 export function buildErrorResponse(id: string, err: unknown): IpcResponse {
   const response: IpcResponse = { id, error: String(err) };
   if (err && typeof err === "object") {


### PR DESCRIPTION
## Summary
- Flip the daemon CLI invites_list/create/revoke/trigger_call handlers to thin relays to the gateway IPC methods via ipcCallPersistent (gateway owns the write path)
- invites_redeem stays daemon-local (inbound-channel path; documented carve-out)
- Daemon no longer writes assistant_ingress_invites directly on the relayed CLI paths

Part of plan: contacts-gw-native-invites.md (PR 5 of 6)