### PR TITLE
refactor(invites): self-review cleanup (schema reuse, dead code, comments)

### DIFF
--- a/assistant/src/__tests__/invite-routes-http.test.ts
+++ b/assistant/src/__tests__/invite-routes-http.test.ts
@@ -37,22 +37,20 @@ mock.module("../calls/call-domain.js", () => ({
 import { upsertContact } from "../contacts/contact-store.js";
 import { getSqlite } from "../memory/db-connection.js";
 import { initializeDb } from "../memory/db-init.js";
+import { revokeInvite } from "../memory/invite-store.js";
 import {
   createIngressInvite,
-  listIngressInvites,
-  revokeIngressInvite,
   triggerInviteCall,
 } from "../runtime/invite-service.js";
 import { handleRedeemInvite as _handleRedeemInvite } from "../runtime/routes/contact-routes.js";
 import { RouteError } from "../runtime/routes/errors.js";
 
 /**
- * The CLI/HTTP create/list/revoke/trigger route handlers now relay to the
- * gateway (see invite-relay-routes.test.ts). The assistant-native invite logic
- * those handlers used to call directly — and which the gateway still invokes via
- * `invites_mint` + its native handlers — is exercised here against the assistant
- * DB through the `invite-service` functions. Redemption stays daemon-local and is
- * still driven through the route handler.
+ * The CLI/HTTP create/list/revoke/trigger route handlers relay to the gateway
+ * (see invite-relay-routes.test.ts). The assistant-native invite logic the
+ * gateway invokes via `invites_mint` + its native handlers is exercised here
+ * against the assistant DB through the `invite-service` functions. Redemption
+ * stays daemon-local and is driven through the route handler.
  */
 function fakeResponse(body: unknown, status = 200) {
   return { status, json: async () => body };
@@ -67,28 +65,12 @@ async function handleCreateInvite(req: Request) {
     expiresInMs: body.expiresInMs as number | undefined,
     contactName: body.contactName as string | undefined,
     expectedExternalUserId: body.expectedExternalUserId as string | undefined,
-    voiceCodeDigits: body.voiceCodeDigits as number | undefined,
     friendName: body.friendName as string | undefined,
     guardianName: body.guardianName as string | undefined,
     contactId: body.contactId as string,
   });
   if (!result.ok) return fakeResponse({ ok: false, error: result.error }, 400);
   return fakeResponse({ ok: true, invite: result.data }, 201);
-}
-
-function handleListInvites(url: URL) {
-  const result = listIngressInvites({
-    sourceChannel: url.searchParams.get("sourceChannel") ?? undefined,
-    status: url.searchParams.get("status") ?? undefined,
-  });
-  if (!result.ok) return fakeResponse({ ok: false, error: result.error }, 400);
-  return fakeResponse({ ok: true, invites: result.data });
-}
-
-function handleRevokeInvite(inviteId: string) {
-  const result = revokeIngressInvite(inviteId);
-  if (!result.ok) return fakeResponse({ ok: false, error: result.error }, 404);
-  return fakeResponse({ ok: true, invite: result.data });
 }
 
 async function handleRedeemInvite(req: Request) {
@@ -203,66 +185,6 @@ describe("ingress invite HTTP routes", () => {
     expect(body.error).toContain("sourceChannel");
   });
 
-  test("GET /v1/contacts/invites — lists invites", async () => {
-    // Create two invites
-    await handleCreateInvite(
-      new Request("http://localhost/v1/contacts/invites", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          sourceChannel: "telegram",
-          contactId: createTargetContact(),
-        }),
-      }),
-    );
-    await handleCreateInvite(
-      new Request("http://localhost/v1/contacts/invites", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          sourceChannel: "telegram",
-          contactId: createTargetContact(),
-        }),
-      }),
-    );
-
-    const url = new URL("http://localhost/v1/contacts/invites");
-    const res = handleListInvites(url);
-    const body = (await res.json()) as Record<string, unknown>;
-
-    expect(res.status).toBe(200);
-    expect(body.ok).toBe(true);
-    expect(Array.isArray(body.invites)).toBe(true);
-    expect((body.invites as unknown[]).length).toBe(2);
-  });
-
-  test("DELETE /v1/contacts/invites/:id — revokes an invite", async () => {
-    const createRes = await handleCreateInvite(
-      new Request("http://localhost/v1/contacts/invites", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          sourceChannel: "telegram",
-          contactId: createTargetContact(),
-        }),
-      }),
-    );
-    const created = (await createRes.json()) as { invite: { id: string } };
-
-    const res = handleRevokeInvite(created.invite.id);
-    const body = (await res.json()) as Record<string, unknown>;
-
-    expect(res.status).toBe(200);
-    expect(body.ok).toBe(true);
-    const invite = body.invite as Record<string, unknown>;
-    expect(invite.status).toBe("revoked");
-  });
-
-  test("DELETE /v1/contacts/invites/:id — not found returns 404", () => {
-    const res = handleRevokeInvite("nonexistent-id");
-    expect(res.status).toBe(404);
-  });
-
   test("POST /v1/contacts/invites/redeem — redeems an invite", async () => {
     // Create an invite first
     const createRes = await handleCreateInvite(
@@ -352,12 +274,9 @@ describe("ingress service shared logic", () => {
     };
     expect(created.invite.status).toBe("active");
 
-    const revokeRes = handleRevokeInvite(created.invite.id);
-    const revoked = (await revokeRes.json()) as {
-      invite: { id: string; status: string };
-    };
-    expect(revoked.invite.status).toBe("revoked");
-    expect(revoked.invite.id).toBe(created.invite.id);
+    const revoked = revokeInvite(created.invite.id);
+    expect(revoked?.status).toBe("revoked");
+    expect(revoked?.id).toBe(created.invite.id);
   });
 });
 
@@ -709,7 +628,7 @@ describe("POST /v1/contacts/invites/:id/call", () => {
     const created = (await createRes.json()) as { invite: { id: string } };
 
     // Revoke the invite
-    handleRevokeInvite(created.invite.id);
+    revokeInvite(created.invite.id);
 
     const res = await handleTriggerInviteCall(created.invite.id);
     const body = (await res.json()) as Record<string, unknown>;

--- a/assistant/src/ipc/routes/invite-ipc-routes.ts
+++ b/assistant/src/ipc/routes/invite-ipc-routes.ts
@@ -35,7 +35,6 @@ export async function handleMintInvite({ body = {} }: RouteHandlerArgs) {
     expiresInMs: body.expiresInMs as number | undefined,
     contactName: body.contactName as string | undefined,
     expectedExternalUserId: body.expectedExternalUserId as string | undefined,
-    voiceCodeDigits: body.voiceCodeDigits as number | undefined,
     friendName: body.friendName as string | undefined,
     guardianName: body.guardianName as string | undefined,
     contactId: body.contactId as string,

--- a/assistant/src/runtime/invite-service.ts
+++ b/assistant/src/runtime/invite-service.ts
@@ -16,10 +16,7 @@ import {
   findByTokenHash,
   hashToken,
   type IngressInvite,
-  type InviteStatus,
-  listInvites,
   markInviteExpired,
-  revokeInvite,
 } from "../memory/invite-store.js";
 import {
   DECLINED_BY_USER_SENTINEL,
@@ -161,7 +158,6 @@ export async function createIngressInvite(params: {
   contactName?: string;
   // Voice invite parameters
   expectedExternalUserId?: string;
-  voiceCodeDigits?: number;
   friendName?: string;
   guardianName?: string;
   contactId: string;
@@ -347,33 +343,6 @@ export async function mintIngressInvite(
       },
     },
   };
-}
-
-export function listIngressInvites(params: {
-  sourceChannel?: string;
-  status?: string;
-}): IngressResult<InviteResponseData[]> {
-  const invites = listInvites({
-    sourceChannel: params.sourceChannel,
-    status: params.status as InviteStatus | undefined,
-  });
-  return {
-    ok: true,
-    data: invites.map((inv) => inviteToResponse(inv)),
-  };
-}
-
-export function revokeIngressInvite(
-  inviteId?: string,
-): IngressResult<InviteResponseData> {
-  if (!inviteId) {
-    return { ok: false, error: "inviteId is required for revoke" };
-  }
-  const revoked = revokeInvite(inviteId);
-  if (!revoked) {
-    return { ok: false, error: "Invite not found or already revoked" };
-  }
-  return { ok: true, data: inviteToResponse(revoked) };
 }
 
 export async function triggerInviteCall(

--- a/assistant/src/runtime/routes/__tests__/invite-relay-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/invite-relay-routes.test.ts
@@ -133,7 +133,6 @@ describe("invite relay routes", () => {
             expiresInMs: undefined,
             contactName: undefined,
             expectedExternalUserId: undefined,
-            voiceCodeDigits: undefined,
             friendName: undefined,
             guardianName: undefined,
           },

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -248,7 +248,6 @@ export async function handleCreateInvite({ body = {} }: RouteHandlerArgs) {
       expiresInMs: body.expiresInMs as number | undefined,
       contactName: body.contactName as string | undefined,
       expectedExternalUserId: body.expectedExternalUserId as string | undefined,
-      voiceCodeDigits: body.voiceCodeDigits as number | undefined,
       friendName: body.friendName as string | undefined,
       guardianName: body.guardianName as string | undefined,
     })) as { invite: Record<string, unknown>; rawToken?: string };

--- a/gateway/src/http/routes/__tests__/invite-validation.test.ts
+++ b/gateway/src/http/routes/__tests__/invite-validation.test.ts
@@ -47,7 +47,6 @@ describe("parseCreateInviteBody", () => {
       expiresInMs: 60_000,
       contactName: "Alice",
       expectedExternalUserId: "+12025550100",
-      voiceCodeDigits: 4,
       friendName: "Bob",
       guardianName: "Carol",
     });

--- a/gateway/src/http/routes/invite-validation.ts
+++ b/gateway/src/http/routes/invite-validation.ts
@@ -3,8 +3,8 @@
  *
  * These mirror the daemon's invite request shapes
  * (`assistant/src/runtime/routes/contact-routes.ts`, operations
- * `invites_create` / `invites_redeem`) so the native gateway HTTP handlers
- * (PR 3) and IPC callers can share a single source of validation truth.
+ * `invites_create` / `invites_redeem`) so the gateway HTTP handlers and IPC
+ * callers share a single source of validation truth.
  *
  * No DB, no IPC, no logging — just parse/validate. Keep it that way so any
  * caller (handler or test) can use these directly.
@@ -24,7 +24,6 @@ export interface CreateInviteInput {
   expiresInMs?: number;
   contactName?: string;
   expectedExternalUserId?: string;
-  voiceCodeDigits?: number;
   friendName?: string;
   guardianName?: string;
 }
@@ -33,11 +32,11 @@ export type ParseResult<T> =
   | { ok: true; value: T }
   | { ok: false; message: string };
 
-const positiveNumber = z
+export const positiveNumber = z
   .number()
   .refine((n) => Number.isFinite(n) && n > 0, "must be a positive number");
 
-const createInviteSchema = z.object({
+export const createInviteSchema = z.object({
   contactId: z.string().trim().min(1, "contactId is required"),
   sourceChannel: z.string().trim().min(1, "sourceChannel is required"),
   note: z.string().optional(),
@@ -45,7 +44,6 @@ const createInviteSchema = z.object({
   expiresInMs: positiveNumber.optional(),
   contactName: z.string().optional(),
   expectedExternalUserId: z.string().optional(),
-  voiceCodeDigits: positiveNumber.optional(),
   friendName: z.string().optional(),
   guardianName: z.string().optional(),
 });
@@ -148,6 +146,13 @@ export function parseRedeemInviteBody(
 // ---------------------------------------------------------------------------
 // List invites query
 // ---------------------------------------------------------------------------
+
+export const listInviteQueryShape = {
+  sourceChannel: z.string().optional(),
+  status: z.string().optional(),
+} as const;
+
+export const listInviteQuerySchema = z.object(listInviteQueryShape);
 
 export interface ListInviteQuery {
   sourceChannel?: string;

--- a/gateway/src/ipc/invite-handlers.ts
+++ b/gateway/src/ipc/invite-handlers.ts
@@ -21,8 +21,8 @@
  *   invites_create
  *     params : { contactId: string; sourceChannel: string; note?: string;
  *                maxUses?: number; expiresInMs?: number; contactName?: string;
- *                expectedExternalUserId?: string; voiceCodeDigits?: number;
- *                friendName?: string; guardianName?: string }
+ *                expectedExternalUserId?: string; friendName?: string;
+ *                guardianName?: string }
  *     returns: { invite: Record<string, unknown>; rawToken?: string }
  *              (the assistant's one-time minted payload)
  *
@@ -50,6 +50,10 @@ import {
   listInvitesNative,
   revokeInviteNative,
 } from "../http/routes/contacts-control-plane-proxy.js";
+import {
+  createInviteSchema,
+  listInviteQueryShape,
+} from "../http/routes/invite-validation.js";
 import type { IpcRoute } from "./server.js";
 
 let store: ContactStore | null = null;
@@ -67,36 +71,20 @@ const RecordInviteRedemptionParamsSchema = z.object({
   redeemedByExternalChatId: z.string().nullish(),
 });
 
-const positiveNumber = z
-  .number()
-  .refine((n) => Number.isFinite(n) && n > 0, "must be a positive number");
-
 // The no-filter list is the common case; the daemon relay calls
 // `ipcCallPersistent("invites_list")` with no params (req.params === undefined).
 // The server validates req.params against this schema BEFORE the handler runs,
 // so the schema must accept omitted/undefined params and default them to {}.
-// Field validations stay intact for when params ARE provided.
+// Field validations stay intact for when params ARE provided. The omitted-params
+// tolerance is the IPC-layer concern; the field shape is shared with the HTTP
+// list-query validator.
 const ListInvitesParamsSchema = z.preprocess(
   (v) => v ?? {},
-  z.object({
-    sourceChannel: z.string().optional(),
-    status: z.string().optional(),
-  }),
+  z.object(listInviteQueryShape),
 );
 
-// Mirrors createInviteSchema in http/routes/invite-validation.ts.
-const CreateInviteParamsSchema = z.object({
-  contactId: z.string().trim().min(1, "contactId is required"),
-  sourceChannel: z.string().trim().min(1, "sourceChannel is required"),
-  note: z.string().optional(),
-  maxUses: positiveNumber.optional(),
-  expiresInMs: positiveNumber.optional(),
-  contactName: z.string().optional(),
-  expectedExternalUserId: z.string().optional(),
-  voiceCodeDigits: positiveNumber.optional(),
-  friendName: z.string().optional(),
-  guardianName: z.string().optional(),
-});
+// The gateway HTTP handlers and IPC callers share a single create-invite schema.
+const CreateInviteParamsSchema = createInviteSchema;
 
 const InviteIdParamsSchema = z.object({
   id: z.string().min(1),

--- a/gateway/src/ipc/server.ts
+++ b/gateway/src/ipc/server.ts
@@ -50,7 +50,7 @@ export type IpcRequest = {
  * `errorCode` (and `errorDetails` when present) ALONGSIDE the existing
  * `error` string. Errors without those fields serialize exactly as before
  * (just `{ id, error }`), so consumers reading only `error` keep working.
- * The PR 5 daemon relay (`PersistentIpcClient.call`) reads `statusCode`/
+ * The daemon relay (`PersistentIpcClient.call`) reads `statusCode`/
  * `errorCode`/`errorDetails` to surface invite user-errors (4xx) instead of
  * statusless IPC failures.
  */


### PR DESCRIPTION
## Summary
   Self-review remediation for the contacts gateway-native invite feature:
   - Share one create/list invite zod schema between gateway HTTP + IPC layers
   - Remove orphaned listIngressInvites/revokeIngressInvite (dead after CLI relay)
   - Drop the dead voiceCodeDigits input param threaded through ~5 layers
   - Reword two PR-history comments to present tense per AGENTS.md

   Part of plan: contacts-gw-native-invites.md (self-review fix)